### PR TITLE
feat(test): add integration test infrastructure with party browse flow

### DIFF
--- a/apps/app_user/integration_test/party_browse_test.dart
+++ b/apps/app_user/integration_test/party_browse_test.dart
@@ -1,0 +1,121 @@
+import 'package:app_user/main.dart';
+import 'package:app_user/src/routing/app_router.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' show Supabase;
+
+// ---------------------------------------------------------------------------
+// Test Helper (inline to avoid cross-file import issues in integration_test)
+// ---------------------------------------------------------------------------
+
+const _supabaseUrl = 'http://127.0.0.1:54321';
+const _supabaseAnonKey = 'sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH';
+
+bool _servicesInitialized = false;
+
+Future<void> _initServices() async {
+  if (_servicesInitialized) return;
+  await initializeDateFormatting('ko_KR');
+  await Supabase.initialize(url: _supabaseUrl, anonKey: _supabaseAnonKey);
+  _servicesInitialized = true;
+}
+
+Future<Widget> _createApp() async {
+  await _initServices();
+  return ProviderScope(
+    overrides: [
+      authConfigProvider.overrideWithValue(
+        const AuthConfig(
+          webClientId: '',
+          defaultRedirectUrl: 'http://localhost:3000',
+        ),
+      ),
+      notificationDeepLinkHandlerProvider.overrideWith((ref) {
+        final router = ref.read(goRouterProvider);
+        return router.go;
+      }),
+    ],
+    child: const MinglitApp(),
+  );
+}
+
+Future<void> pumpApp(
+  WidgetTester tester, {
+  Duration settleTimeout = const Duration(seconds: 10),
+}) async {
+  final app = await _createApp();
+  await tester.pumpWidget(app);
+  await tester.pumpAndSettle(settleTimeout);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Party Browse Flow', () {
+    testWidgets('App launches without errors', (tester) async {
+      await pumpApp(tester);
+
+      // App should load without showing error screen
+      expect(find.textContaining('Error:'), findsNothing);
+      expect(find.byType(MaterialApp), findsOneWidget);
+    });
+
+    testWidgets('Curation screen shows events or empty state', (
+      tester,
+    ) async {
+      await pumpApp(tester);
+
+      // Navigate to curation (new arrivals)
+      final context = tester.element(find.byType(MaterialApp).first);
+      GoRouter.of(context).go('/curation');
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      // Either events are loaded or empty state is shown
+      final eventCards = find.byType(MinglitEventCard);
+
+      if (eventCards.evaluate().isEmpty) {
+        // No seeded data — verify empty state
+        expect(find.text('현재 표시할 파티가 없습니다.'), findsOneWidget);
+      } else {
+        // Events exist — verify at least one card rendered
+        expect(eventCards, findsWidgets);
+      }
+    });
+
+    testWidgets('Tapping event card opens detail screen', (tester) async {
+      await pumpApp(tester);
+
+      // Navigate to curation
+      final context = tester.element(find.byType(MaterialApp).first);
+      GoRouter.of(context).go('/curation');
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      final eventCards = find.byType(MinglitEventCard);
+
+      // Skip if no seeded data available
+      if (eventCards.evaluate().isEmpty) return;
+
+      // Tap first event card
+      await tester.tap(eventCards.first);
+      await tester.pumpAndSettle(const Duration(seconds: 5));
+
+      // Verify we're on the detail screen
+      expect(find.text('상세 소개'), findsOneWidget);
+      expect(find.text('참여 자격'), findsOneWidget);
+
+      // Bottom ticket bar should be visible
+      expect(find.text('최저가'), findsOneWidget);
+
+      // For unauthenticated users, button should say "로그인하고 신청하기"
+      expect(find.text('로그인하고 신청하기'), findsOneWidget);
+    });
+  });
+}

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -62,6 +62,8 @@ dev_dependencies:
   flutter_lints: ^5.0.0
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   freezed: ^3.2.3
   go_router_builder: ^4.1.3
   integration_test:

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -62,8 +62,6 @@ dev_dependencies:
   flutter_lints: ^5.0.0
   flutter_test:
     sdk: flutter
-  integration_test:
-    sdk: flutter
   freezed: ^3.2.3
   go_router_builder: ^4.1.3
   integration_test:

--- a/apps/app_user/test_driver/integration_test.dart
+++ b/apps/app_user/test_driver/integration_test.dart
@@ -1,0 +1,3 @@
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();


### PR DESCRIPTION
## Summary
- Integration test 인프라 구축 (`integration_test` SDK, test driver)
- 파티 탐색 플로우 E2E 테스트 3개 케이스 추가
  - 앱 정상 실행 검증
  - 큐레이션 화면 이벤트 목록 / 빈 상태 확인
  - 이벤트 카드 탭 → 상세 화면 진입 검증 (상세 소개, 참여 자격, 로그인 유도)

## How to run
```bash
supabase start
cd apps/app_user
flutter test integration_test/party_browse_test.dart -d chrome
```

## Notes
- 로컬 Supabase (127.0.0.1:54321) 연결 기반
- 시드 데이터 유무에 따라 빈 상태 / 이벤트 목록 양쪽 검증
- `flutter analyze integration_test/ test_driver/` → No issues found