### PR TITLE
fix(auth): bypass StaffGuard on mobile platforms

### DIFF
--- a/shared/packages/minglit_kit/lib/src/features/auth/ui/staff_guard_wrapper.dart
+++ b/shared/packages/minglit_kit/lib/src/features/auth/ui/staff_guard_wrapper.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:minglit_kit/src/features/auth/logic/staff_guard_provider.dart';
@@ -53,8 +54,9 @@ class _StaffGuardWrapperState extends ConsumerState<StaffGuardWrapper> {
 
   @override
   Widget build(BuildContext context) {
-    // Automatically bypass for local development
-    if (isLocalhost) {
+    // Staff guard only applies to web deployments.
+    // Mobile apps are not publicly distributed, so no protection needed.
+    if (!kIsWeb || isLocalhost) {
       return widget.child;
     }
 


### PR DESCRIPTION
## Summary
- Skip StaffGuard when `!kIsWeb` — mobile apps are not publicly distributed, so staff protection is only needed for web deployments
- Keeps localhost bypass for web development

## Changes
- `staff_guard_wrapper.dart`: Add `!kIsWeb` check before `isLocalhost`