### PR TITLE
feat(event-card): 이미지 오버레이 레이아웃, 참여자 수 + progress bar, 스켈레톤 추가

### DIFF
--- a/apps/app_partner/lib/main.dart
+++ b/apps/app_partner/lib/main.dart
@@ -1,18 +1,19 @@
 import 'dart:async';
 
-import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:app_partner/firebase_options.dart';
 import 'package:app_partner/src/l10n/generated/app_localizations.dart';
 import 'package:app_partner/src/routing/app_router.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:kakao_map_plugin/kakao_map_plugin.dart' as kakao;
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' show Supabase;
+
 part 'main.g.dart';
 
 Future<void> main() async {

--- a/apps/app_partner/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/apps/app_partner/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -15,7 +15,6 @@ import geolocator_apple
 import google_sign_in_ios
 import mobile_scanner
 import package_info_plus
-import path_provider_foundation
 import quill_native_bridge_macos
 import sentry_flutter
 import shared_preferences_foundation
@@ -34,7 +33,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   QuillNativeBridgePlugin.register(with: registry.registrar(forPlugin: "QuillNativeBridgePlugin"))
   SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/apps/app_user/lib/main.dart
+++ b/apps/app_user/lib/main.dart
@@ -1,17 +1,18 @@
 import 'dart:async';
 
-import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:app_user/firebase_options.dart';
 import 'package:app_user/src/l10n/generated/app_localizations.dart';
 import 'package:app_user/src/routing/app_router.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' show Supabase;
+
 part 'main.g.dart';
 
 Future<void> main() async {

--- a/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
@@ -45,6 +45,7 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent> {
     final location = event.location ?? party?.location;
     final partnerProfileImageUrl = partner?.profileImageUrl;
     final eventTitle = party?.title ?? event.title ?? '제목 없음';
+    final user = ref.watch(currentUserProvider);
 
     // Date Format
     final dateLabel = DateFormat(
@@ -95,18 +96,20 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent> {
                 ),
                 tooltip: '공유하기',
               ),
-              Padding(
+              if (user != null)
+                Padding(
                 padding: const EdgeInsets.only(right: MinglitSpacing.small),
-                child: MinglitSocialButton(
-                  targetId: event.partyId, // Like the party
-                  targetType: SocialTargetType.party,
-                  interactionType: SocialInteractionType.like,
-                  activeColor: theme.colorScheme.onPrimary,
-                  inactiveColor: theme.colorScheme.onPrimary.withValues(
-                    alpha: 0.7,
+                  child: MinglitSocialButton(
+                    targetId: event.partyId, // Like the party
+                    targetType: SocialTargetType.party,
+                    interactionType: SocialInteractionType.like,
+                    activeColor: theme.colorScheme.onPrimary,
+                    inactiveColor: theme.colorScheme.onPrimary.withValues(
+                      alpha: 0.7,
+                    ),
+                    tooltip: '좋아요',
                   ),
                 ),
-              ),
             ],
             backgroundColor: theme.colorScheme.primary,
           ),

--- a/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
@@ -14,7 +14,7 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent> {
   final _scrollController = ScrollController();
   bool _showTitle = false;
 
-  static const _collapseThreshold = 300.0 - kToolbarHeight;
+  static const double _collapseThreshold = 300.0 - kToolbarHeight;
 
   @override
   void initState() {
@@ -98,7 +98,7 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent> {
               ),
               if (user != null)
                 Padding(
-                padding: const EdgeInsets.only(right: MinglitSpacing.small),
+                  padding: const EdgeInsets.only(right: MinglitSpacing.small),
                   child: MinglitSocialButton(
                     targetId: event.partyId, // Like the party
                     targetType: SocialTargetType.party,

--- a/apps/app_user/lib/src/features/explore/providers/explore_state_provider.dart
+++ b/apps/app_user/lib/src/features/explore/providers/explore_state_provider.dart
@@ -64,9 +64,9 @@ class SearchQuery extends _$SearchQuery {
 class ActiveFilters extends _$ActiveFilters {
   @override
   ExploreFilters build() => const ExploreFilters(
-        eligibilityEnabled: true,
-        nearbyEnabled: true,
-      );
+    eligibilityEnabled: true,
+    nearbyEnabled: true,
+  );
 
   // Riverpod notifier method — cannot use setter syntax with code generation.
   // ignore: use_setters_to_change_properties

--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -3,83 +3,103 @@ import 'package:app_user/src/features/explore/providers/explore_state_provider.d
 import 'package:app_user/src/features/explore/widgets/filter_chip_bar.dart';
 import 'package:app_user/src/features/home/logic/home_coordinator.dart';
 import 'package:app_user/src/routing/app_routes.dart';
+import 'package:app_user/src/ui/shell/nav_visibility_provider.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
 /// Home page — explore recommendation content merged into home.
-class HomePage extends ConsumerWidget {
+class HomePage extends ConsumerStatefulWidget {
   const HomePage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends ConsumerState<HomePage> {
+  @override
+  Widget build(BuildContext context) {
     final homeCoordinator = ref.read(homeCoordinatorProvider);
     final eventCoordinator = ref.read(eventCoordinatorProvider);
     final recommendationAsync = ref.watch(recommendationEventsProvider);
 
     return Scaffold(
-      body: CustomScrollView(
-        slivers: [
-          SliverAppBar(
-            floating: true,
-            snap: true,
-            titleSpacing: 0,
-            title: Row(
-              children: [
-                const SizedBox(width: MinglitSpacing.medium),
-                MinglitTheme.appBarLogo(height: 36),
-              ],
-            ),
-            actions: [
-              IconButton(
-                icon: const Icon(Icons.search),
-                onPressed: () => const SearchRoute().push<void>(context),
+      body: NotificationListener<UserScrollNotification>(
+        onNotification: (notification) {
+          if (notification.direction == ScrollDirection.forward) {
+            ref.read(navVisibilityProvider.notifier).show();
+          } else if (notification.direction == ScrollDirection.reverse) {
+            ref.read(navVisibilityProvider.notifier).hide();
+          }
+          return false;
+        },
+        child: CustomScrollView(
+          slivers: [
+            SliverAppBar(
+              floating: true,
+              snap: true,
+              titleSpacing: 0,
+              title: Row(
+                children: [
+                  const SizedBox(width: MinglitSpacing.medium),
+                  MinglitTheme.appBarLogo(height: 36),
+                ],
               ),
-              IconButton(
-                icon: const Icon(Icons.notifications_outlined),
-                onPressed: homeCoordinator.pushNotificationCenter,
-              ),
-              const SizedBox(width: MinglitSpacing.small),
-            ],
-            backgroundColor: MinglitColors.background,
-            surfaceTintColor: Colors.transparent,
-          ),
-          const SliverToBoxAdapter(
-            child: Padding(
-              padding: EdgeInsets.only(top: MinglitSpacing.small),
-              child: ExploreFilterChipBar(),
-            ),
-          ),
-          recommendationAsync.when(
-            data: (events) {
-              if (events.isEmpty) {
-                return const SliverFillRemaining(
-                  child: Center(child: Text('추천 이벤트가 없습니다')),
-                );
-              }
-              return SliverPadding(
-                padding: const EdgeInsets.all(MinglitSpacing.medium),
-                sliver: SliverList.separated(
-                  itemCount: events.length,
-                  separatorBuilder: (_, _) =>
-                      const SizedBox(height: MinglitSpacing.small),
-                  itemBuilder: (context, index) {
-                    final event = events[index];
-                    return MinglitEventCard(
-                      event: event,
-                      onTap: () => eventCoordinator.pushEventDetail(event.id),
-                    );
-                  },
+              actions: [
+                IconButton(
+                  icon: const Icon(Icons.search),
+                  onPressed: () => const SearchRoute().push<void>(context),
                 ),
-              );
-            },
-            loading: () => const SliverFillRemaining(
-              child: Center(child: CircularProgressIndicator()),
+                IconButton(
+                  icon: const Icon(Icons.notifications_outlined),
+                  onPressed: homeCoordinator.pushNotificationCenter,
+                ),
+                const SizedBox(width: MinglitSpacing.small),
+              ],
+              backgroundColor: MinglitColors.background,
+              surfaceTintColor: Colors.transparent,
             ),
-            error: (_, _) => const SliverFillRemaining(
-              child: SizedBox.shrink(),
+            const SliverToBoxAdapter(
+              child: Padding(
+                padding: EdgeInsets.only(top: MinglitSpacing.small),
+                child: ExploreFilterChipBar(),
+              ),
             ),
-          ),
-        ],
+            recommendationAsync.when(
+              data: (events) {
+                if (events.isEmpty) {
+                  return const SliverFillRemaining(
+                    child: Center(child: Text('추천 이벤트가 없습니다')),
+                  );
+                }
+                return SliverPadding(
+                  padding: const EdgeInsets.all(MinglitSpacing.medium),
+                  sliver: SliverList.separated(
+                    itemCount: events.length,
+                    separatorBuilder: (_, _) =>
+                        const SizedBox(height: MinglitSpacing.small),
+                    itemBuilder: (context, index) {
+                      final event = events[index];
+                      return MinglitEventCard(
+                        event: event,
+                      onTap: () => eventCoordinator.pushEventDetail(event.id),
+                      );
+                    },
+                  ),
+                );
+              },
+              loading: () => const SliverFillRemaining(
+                child: Center(child: CircularProgressIndicator()),
+              ),
+              error: (_, _) => const SliverFillRemaining(
+                child: SizedBox.shrink(),
+              ),
+            ),
+            const SliverPadding(
+              padding: EdgeInsets.only(bottom: 80),
+            ),
+          ],
+      ),
       ),
     );
   }

--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -82,7 +82,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                       final event = events[index];
                       return MinglitEventCard(
                         event: event,
-                      onTap: () => eventCoordinator.pushEventDetail(event.id),
+                        onTap: () => eventCoordinator.pushEventDetail(event.id),
                       );
                     },
                   ),
@@ -99,7 +99,7 @@ class _HomePageState extends ConsumerState<HomePage> {
               padding: EdgeInsets.only(bottom: 80),
             ),
           ],
-      ),
+        ),
       ),
     );
   }

--- a/apps/app_user/lib/src/features/home/my_page.dart
+++ b/apps/app_user/lib/src/features/home/my_page.dart
@@ -39,9 +39,7 @@ class MyPage extends ConsumerWidget {
               const SizedBox(height: MinglitSpacing.xlarge),
               FilledButton(
                 onPressed: () {
-                  ref
-                      .read(authCoordinatorProvider)
-                      .pushLogin(from: '/my');
+                  ref.read(authCoordinatorProvider).pushLogin(from: '/my');
                 },
                 child: const Text('로그인'),
               ),
@@ -52,8 +50,7 @@ class MyPage extends ConsumerWidget {
     }
 
     final avatarUrl = user.userMetadata?['avatar_url'] as String?;
-    final displayName =
-        user.userMetadata?['full_name'] as String? ?? '유저';
+    final displayName = user.userMetadata?['full_name'] as String? ?? '유저';
     final homeCoordinator = ref.read(homeCoordinatorProvider);
 
     return Scaffold(
@@ -69,8 +66,9 @@ class MyPage extends ConsumerWidget {
               children: [
                 CircleAvatar(
                   radius: 32,
-                  backgroundImage:
-                      avatarUrl != null ? NetworkImage(avatarUrl) : null,
+                  backgroundImage: avatarUrl != null
+                      ? NetworkImage(avatarUrl)
+                      : null,
                   child: avatarUrl == null
                       ? const Icon(Icons.person, size: 32)
                       : null,

--- a/apps/app_user/lib/src/routing/app_routes.dart
+++ b/apps/app_user/lib/src/routing/app_routes.dart
@@ -217,8 +217,7 @@ class SearchRoute extends GoRouteData with $SearchRoute {
   const SearchRoute();
 
   @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      const SearchPage();
+  Widget build(BuildContext context, GoRouterState state) => const SearchPage();
 }
 
 /// **My Page Route**

--- a/apps/app_user/lib/src/ui/shell/nav_visibility_provider.dart
+++ b/apps/app_user/lib/src/ui/shell/nav_visibility_provider.dart
@@ -1,0 +1,22 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'nav_visibility_provider.g.dart';
+
+/// Controls bottom navigation bar visibility.
+///
+/// `false` = hidden (initial state on app launch).
+/// `true` = visible (shown on upward scroll in home tab).
+///
+/// Only the home tab (index == 0) drives this provider via scroll events.
+/// The my-page tab always shows the nav bar regardless of this value.
+@riverpod
+class NavVisibility extends _$NavVisibility {
+  @override
+  bool build() => false;
+
+  /// Show the bottom navigation bar.
+  void show() => state = true;
+
+  /// Hide the bottom navigation bar.
+  void hide() => state = false;
+}

--- a/apps/app_user/lib/src/ui/shell/nav_visibility_provider.g.dart
+++ b/apps/app_user/lib/src/ui/shell/nav_visibility_provider.g.dart
@@ -1,0 +1,92 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'nav_visibility_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Controls bottom navigation bar visibility.
+///
+/// [false] = hidden (initial state on app launch).
+/// [true]  = visible (shown on upward scroll in home tab).
+///
+/// Only the home tab (index == 0) drives this provider via scroll events.
+/// The my-page tab always shows the nav bar regardless of this value.
+
+@ProviderFor(NavVisibility)
+const navVisibilityProvider = NavVisibilityProvider._();
+
+/// Controls bottom navigation bar visibility.
+///
+/// [false] = hidden (initial state on app launch).
+/// [true]  = visible (shown on upward scroll in home tab).
+///
+/// Only the home tab (index == 0) drives this provider via scroll events.
+/// The my-page tab always shows the nav bar regardless of this value.
+final class NavVisibilityProvider
+    extends $NotifierProvider<NavVisibility, bool> {
+  /// Controls bottom navigation bar visibility.
+  ///
+  /// [false] = hidden (initial state on app launch).
+  /// [true]  = visible (shown on upward scroll in home tab).
+  ///
+  /// Only the home tab (index == 0) drives this provider via scroll events.
+  /// The my-page tab always shows the nav bar regardless of this value.
+  const NavVisibilityProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'navVisibilityProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$navVisibilityHash();
+
+  @$internal
+  @override
+  NavVisibility create() => NavVisibility();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+}
+
+String _$navVisibilityHash() => r'a9c4612d1c3dd086b17880f8bed5f5389961c0c1';
+
+/// Controls bottom navigation bar visibility.
+///
+/// [false] = hidden (initial state on app launch).
+/// [true]  = visible (shown on upward scroll in home tab).
+///
+/// Only the home tab (index == 0) drives this provider via scroll events.
+/// The my-page tab always shows the nav bar regardless of this value.
+
+abstract class _$NavVisibility extends $Notifier<bool> {
+  bool build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref as $Ref<bool, bool>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<bool, bool>,
+              bool,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/apps/app_user/lib/src/ui/shell/nav_visibility_provider.g.dart
+++ b/apps/app_user/lib/src/ui/shell/nav_visibility_provider.g.dart
@@ -10,8 +10,8 @@ part of 'nav_visibility_provider.dart';
 // ignore_for_file: type=lint, type=warning
 /// Controls bottom navigation bar visibility.
 ///
-/// [false] = hidden (initial state on app launch).
-/// [true]  = visible (shown on upward scroll in home tab).
+/// `false` = hidden (initial state on app launch).
+/// `true` = visible (shown on upward scroll in home tab).
 ///
 /// Only the home tab (index == 0) drives this provider via scroll events.
 /// The my-page tab always shows the nav bar regardless of this value.
@@ -21,8 +21,8 @@ const navVisibilityProvider = NavVisibilityProvider._();
 
 /// Controls bottom navigation bar visibility.
 ///
-/// [false] = hidden (initial state on app launch).
-/// [true]  = visible (shown on upward scroll in home tab).
+/// `false` = hidden (initial state on app launch).
+/// `true` = visible (shown on upward scroll in home tab).
 ///
 /// Only the home tab (index == 0) drives this provider via scroll events.
 /// The my-page tab always shows the nav bar regardless of this value.
@@ -30,8 +30,8 @@ final class NavVisibilityProvider
     extends $NotifierProvider<NavVisibility, bool> {
   /// Controls bottom navigation bar visibility.
   ///
-  /// [false] = hidden (initial state on app launch).
-  /// [true]  = visible (shown on upward scroll in home tab).
+  /// `false` = hidden (initial state on app launch).
+  /// `true` = visible (shown on upward scroll in home tab).
   ///
   /// Only the home tab (index == 0) drives this provider via scroll events.
   /// The my-page tab always shows the nav bar regardless of this value.
@@ -66,8 +66,8 @@ String _$navVisibilityHash() => r'a9c4612d1c3dd086b17880f8bed5f5389961c0c1';
 
 /// Controls bottom navigation bar visibility.
 ///
-/// [false] = hidden (initial state on app launch).
-/// [true]  = visible (shown on upward scroll in home tab).
+/// `false` = hidden (initial state on app launch).
+/// `true` = visible (shown on upward scroll in home tab).
 ///
 /// Only the home tab (index == 0) drives this provider via scroll events.
 /// The my-page tab always shows the nav bar regardless of this value.

--- a/apps/app_user/lib/src/ui/shell/user_scaffold.dart
+++ b/apps/app_user/lib/src/ui/shell/user_scaffold.dart
@@ -22,8 +22,7 @@ class UserScaffold extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final colorScheme = Theme.of(context).colorScheme;
     final currentIndex = navigationShell.currentIndex;
-    final isVisible =
-        currentIndex != 0 || ref.watch(navVisibilityProvider);
+    final isVisible = currentIndex != 0 || ref.watch(navVisibilityProvider);
 
     return Scaffold(
       body: Stack(

--- a/apps/app_user/lib/src/ui/shell/user_scaffold.dart
+++ b/apps/app_user/lib/src/ui/shell/user_scaffold.dart
@@ -1,10 +1,12 @@
+import 'package:app_user/src/ui/shell/nav_visibility_provider.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 /// Shell scaffold with bottom navigation for the User app.
 ///
 /// 2 tabs: 홈 / 마이
-class UserScaffold extends StatelessWidget {
+class UserScaffold extends ConsumerWidget {
   const UserScaffold({required this.navigationShell, super.key});
 
   final StatefulNavigationShell navigationShell;
@@ -17,26 +19,46 @@ class UserScaffold extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final colorScheme = Theme.of(context).colorScheme;
+    final currentIndex = navigationShell.currentIndex;
+    final isVisible =
+        currentIndex != 0 || ref.watch(navVisibilityProvider);
 
     return Scaffold(
-      body: navigationShell,
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: navigationShell.currentIndex,
-        onDestinationSelected: _goBranch,
-        indicatorColor: Colors.transparent,
-        backgroundColor: colorScheme.surface,
-        destinations: const [
-          NavigationDestination(
-            icon: Icon(Icons.home_outlined),
-            selectedIcon: Icon(Icons.home),
-            label: '홈',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.person_outline),
-            selectedIcon: Icon(Icons.person),
-            label: '마이',
+      body: Stack(
+        children: [
+          navigationShell,
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            child: AnimatedSlide(
+              offset: isVisible ? Offset.zero : const Offset(0, 1),
+              duration: const Duration(milliseconds: 200),
+              curve: Curves.easeInOut,
+              child: SafeArea(
+                top: false,
+                child: NavigationBar(
+                  selectedIndex: currentIndex,
+                  onDestinationSelected: _goBranch,
+                  indicatorColor: Colors.transparent,
+                  backgroundColor: colorScheme.surface,
+                  destinations: const [
+                    NavigationDestination(
+                      icon: Icon(Icons.home_outlined),
+                      selectedIcon: Icon(Icons.home),
+                      label: '홈',
+                    ),
+                    NavigationDestination(
+                      icon: Icon(Icons.person_outline),
+                      selectedIcon: Icon(Icons.person),
+                      label: '마이',
+                    ),
+                  ],
+                ),
+              ),
+            ),
           ),
         ],
       ),

--- a/apps/app_user/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/apps/app_user/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -15,7 +15,6 @@ import flutter_secure_storage_darwin
 import geolocator_apple
 import google_sign_in_ios
 import package_info_plus
-import path_provider_foundation
 import quill_native_bridge_macos
 import screen_brightness_macos
 import sentry_flutter
@@ -36,7 +35,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   QuillNativeBridgePlugin.register(with: registry.registrar(forPlugin: "QuillNativeBridgePlugin"))
   ScreenBrightnessMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenBrightnessMacosPlugin"))
   SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))

--- a/shared/packages/minglit_kit/lib/src/features/social/ui/minglit_social_button.dart
+++ b/shared/packages/minglit_kit/lib/src/features/social/ui/minglit_social_button.dart
@@ -16,6 +16,7 @@ class MinglitSocialButton extends ConsumerWidget {
     this.activeColor,
     this.inactiveColor,
     this.iconSize = MinglitIconSize.medium,
+    this.tooltip,
     super.key,
   });
 
@@ -36,6 +37,9 @@ class MinglitSocialButton extends ConsumerWidget {
 
   /// Size of the interaction icon.
   final double iconSize;
+
+  /// Tooltip text shown on long press. Defaults to interaction type label.
+  final String? tooltip;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -65,8 +69,8 @@ class MinglitSocialButton extends ConsumerWidget {
         ? (activeColor ?? _getDefaultActiveColor(theme))
         : (inactiveColor ?? theme.colorScheme.onSurfaceVariant);
 
-    return InkWell(
-      onTap: () => ref
+    return IconButton(
+      onPressed: () => ref
           .read(
             socialInteractionControllerProvider(
               targetId: targetId,
@@ -75,15 +79,14 @@ class MinglitSocialButton extends ConsumerWidget {
             ).notifier,
           )
           .toggle(),
-      borderRadius: BorderRadius.circular(MinglitRadius.small),
-      child: Padding(
-        padding: const EdgeInsets.all(MinglitSpacing.xxsmall),
-        child: Icon(
-          _getIcon(isActive),
-          color: color,
-          size: iconSize,
-        ),
+      icon: Icon(
+        _getIcon(isActive),
+        color: color,
+        size: iconSize,
       ),
+      tooltip: tooltip ?? _getDefaultTooltip(),
+      constraints: const BoxConstraints(),
+      padding: const EdgeInsets.all(MinglitSpacing.xxsmall),
     );
   }
 
@@ -125,6 +128,15 @@ class MinglitSocialButton extends ConsumerWidget {
       SocialInteractionType.subscribe => theme.colorScheme.secondary,
       SocialInteractionType.bookmark => theme.colorScheme.primary,
       _ => theme.colorScheme.primary,
+    };
+  }
+
+  String _getDefaultTooltip() {
+    return switch (interactionType) {
+      SocialInteractionType.like => '좋아요',
+      SocialInteractionType.subscribe => '구독',
+      SocialInteractionType.bookmark => '저장',
+      SocialInteractionType.block => '차단',
     };
   }
 }

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/src/data/models/event.dart';
 import 'package:minglit_kit/src/theme/minglit_theme.dart';
+import 'package:minglit_kit/src/ui/widgets/common/loading_indicator.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_chip.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_image.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_skeleton.dart';
 
 /// **Minglit Event Card**
 ///
@@ -173,6 +175,46 @@ class MinglitEventCard extends StatelessWidget {
                     ],
                   ),
                   const SizedBox(height: MinglitSpacing.small),
+
+                  // Participation Progress
+                  if (event.maxParticipants == 0 &&
+                      event.currentParticipants == 0) ...[
+                    const MinglitSkeleton(height: 8, width: double.infinity),
+                    const SizedBox(height: MinglitSpacing.small),
+                  ] else if (event.maxParticipants > 0) ...[
+                    Row(
+                      children: [
+                        Expanded(
+                          child: ClipRRect(
+                            borderRadius: BorderRadius.circular(
+                              MinglitRadius.small / 2,
+                            ),
+                            child: MinglitLinearProgressIndicator(
+                              value:
+                                  (event.currentParticipants /
+                                          event.maxParticipants)
+                                      .clamp(0.0, 1.0),
+                              color:
+                                  event.currentParticipants >=
+                                      event.maxParticipants
+                                  ? theme.colorScheme.error
+                                  : MinglitColors.tertiary,
+                              backgroundColor:
+                                  theme.colorScheme.surfaceContainerHighest,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          '${event.currentParticipants}/${event.maxParticipants}',
+                          style: theme.textTheme.labelSmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: MinglitSpacing.small),
+                  ],
 
                   // Price
                   Text(

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/src/data/models/event.dart';
+import 'package:minglit_kit/src/data/models/partner.dart';
 import 'package:minglit_kit/src/theme/minglit_theme.dart';
-import 'package:minglit_kit/src/ui/widgets/common/loading_indicator.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_chip.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_image.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_skeleton.dart';
@@ -17,10 +17,18 @@ class MinglitEventCard extends StatelessWidget {
     super.key,
     this.onTap,
     this.width = 240,
-  });
+  }) : _isLoading = false;
+
+  /// Named constructor for loading skeleton state.
+  const MinglitEventCard.loading({
+    super.key,
+    this.event,
+    this.onTap,
+    this.width = 240,
+  }) : _isLoading = true;
 
   /// Event data to render.
-  final Event event;
+  final Event? event;
 
   /// Optional tap handler for the card.
   final VoidCallback? onTap;
@@ -28,15 +36,22 @@ class MinglitEventCard extends StatelessWidget {
   /// Fixed width of the card.
   final double width;
 
+  /// Internal flag for loading state.
+  final bool _isLoading;
+
   @override
   Widget build(BuildContext context) {
+    if (_isLoading || event == null) {
+      return _EventCardSkeleton(width: width);
+    }
+
     final theme = Theme.of(context);
-    final party = event.party;
-    final location = event.location ?? party?.location;
+    final party = event!.party;
+    final location = event!.location ?? party?.location;
 
     // Calculate D-Day
     final now = DateTime.now();
-    final difference = event.startTime.difference(now).inDays;
+    final difference = event!.startTime.difference(now).inDays;
     final dDayLabel = difference == 0
         ? '오늘'
         : difference > 0
@@ -47,16 +62,18 @@ class MinglitEventCard extends StatelessWidget {
     final dateLabel = DateFormat(
       'M월 d일 (E) HH:mm',
       'ko_KR',
-    ).format(event.startTime);
+    ).format(event!.startTime);
 
     // Get Lowest Price
-    final lowestPrice = event.tickets?.fold<int?>(
+    final lowestPrice = event!.tickets?.fold<int?>(
       null,
       (min, t) => min == null || t.price < min ? t.price : min,
     );
-    final priceLabel = lowestPrice != null
-        ? '${NumberFormat('#,###').format(lowestPrice)}원~'
-        : '가격 미정';
+    final priceLabel = lowestPrice == null
+        ? '가격 미정'
+        : lowestPrice == 0
+        ? '무료'
+        : '${NumberFormat('#,###').format(lowestPrice)}원~';
 
     final partner = party?.partner;
 
@@ -80,9 +97,10 @@ class MinglitEventCard extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: [
-            // Event Image with D-Day Badge
+            // Image with overlays
             Stack(
               children: [
+                // Image
                 AspectRatio(
                   aspectRatio: 16 / 9,
                   child: MinglitImage(
@@ -90,6 +108,23 @@ class MinglitEventCard extends StatelessWidget {
                     fit: BoxFit.cover,
                   ),
                 ),
+                // Gradient fade at bottom
+                Positioned.fill(
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          Colors.transparent,
+                          Colors.black.withValues(alpha: 0.45),
+                        ],
+                        stops: const [0.45, 1.0],
+                      ),
+                    ),
+                  ),
+                ),
+                // D-Day chip (top-left)
                 Positioned(
                   top: MinglitSpacing.small,
                   left: MinglitSpacing.small,
@@ -98,70 +133,51 @@ class MinglitEventCard extends StatelessWidget {
                     color: theme.colorScheme.primary,
                   ),
                 ),
+                // Participant overlay (top-right)
+                Positioned(
+                  top: MinglitSpacing.small,
+                  right: MinglitSpacing.small,
+                  child: _ParticipantOverlay(
+                    current: event!.currentParticipants,
+                    max: event!.maxParticipants,
+                  ),
+                ),
+                // Partner overlay (bottom-left) - only if partner exists
+                if (partner != null)
+                  Positioned(
+                    bottom: MinglitSpacing.small,
+                    left: MinglitSpacing.small,
+                    child: _PartnerOverlay(partner: partner),
+                  ),
               ],
             ),
 
+            // Content area
             Padding(
               padding: const EdgeInsets.all(MinglitSpacing.medium),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  // Partner Info
-                  if (partner != null) ...[
-                    Row(
-                      children: [
-                        CircleAvatar(
-                          radius: 10,
-                          backgroundImage: partner.profileImageUrl != null
-                              ? NetworkImage(partner.profileImageUrl!)
-                              : null,
-                          backgroundColor:
-                              theme.colorScheme.surfaceContainerHighest,
-                          child: partner.profileImageUrl == null
-                              ? Icon(
-                                  Icons.store,
-                                  size: 12,
-                                  color: theme.colorScheme.onSurfaceVariant,
-                                )
-                              : null,
-                        ),
-                        const SizedBox(width: 6),
-                        Expanded(
-                          child: Text(
-                            partner.name,
-                            style: theme.textTheme.labelSmall?.copyWith(
-                              color: theme.colorScheme.onSurfaceVariant,
-                              fontWeight: FontWeight.w600,
-                            ),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: MinglitSpacing.small),
-                  ],
-
                   // Title
                   Text(
-                    party?.title ?? event.title ?? '제목 없음',
+                    party?.title ?? event!.title ?? '제목 없음',
                     style: theme.textTheme.titleMedium?.copyWith(
                       fontWeight: FontWeight.bold,
                     ),
-                    maxLines: 2,
+                    maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
-                  const SizedBox(height: MinglitSpacing.small),
+                  const SizedBox(height: MinglitSpacing.xsmall),
 
                   // Location & Date Row
                   Row(
                     children: [
                       Icon(
                         Icons.location_on_outlined,
-                        size: 14,
+                        size: 13,
                         color: theme.colorScheme.primary,
                       ),
-                      const SizedBox(width: 4),
+                      const SizedBox(width: 3),
                       Expanded(
                         child: Text(
                           '${location?.name ?? "장소 미정"} · $dateLabel',
@@ -172,63 +188,170 @@ class MinglitEventCard extends StatelessWidget {
                           overflow: TextOverflow.ellipsis,
                         ),
                       ),
+                      Text(
+                        priceLabel,
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          color: theme.colorScheme.secondary,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
                     ],
-                  ),
-                  const SizedBox(height: MinglitSpacing.small),
-
-                  // Participation Progress
-                  if (event.maxParticipants == 0 &&
-                      event.currentParticipants == 0) ...[
-                    const MinglitSkeleton(height: 8, width: double.infinity),
-                    const SizedBox(height: MinglitSpacing.small),
-                  ] else if (event.maxParticipants > 0) ...[
-                    Row(
-                      children: [
-                        Expanded(
-                          child: ClipRRect(
-                            borderRadius: BorderRadius.circular(
-                              MinglitRadius.small / 2,
-                            ),
-                            child: MinglitLinearProgressIndicator(
-                              value:
-                                  (event.currentParticipants /
-                                          event.maxParticipants)
-                                      .clamp(0.0, 1.0),
-                              color:
-                                  event.currentParticipants >=
-                                      event.maxParticipants
-                                  ? theme.colorScheme.error
-                                  : MinglitColors.tertiary,
-                              backgroundColor:
-                                  theme.colorScheme.surfaceContainerHighest,
-                            ),
-                          ),
-                        ),
-                        const SizedBox(width: 8),
-                        Text(
-                          '${event.currentParticipants}/${event.maxParticipants}',
-                          style: theme.textTheme.labelSmall?.copyWith(
-                            color: theme.colorScheme.onSurfaceVariant,
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: MinglitSpacing.small),
-                  ],
-
-                  // Price
-                  Text(
-                    priceLabel,
-                    style: theme.textTheme.titleSmall?.copyWith(
-                      color: theme.colorScheme.secondary,
-                      fontWeight: FontWeight.bold,
-                    ),
                   ),
                 ],
               ),
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+/// Participant count overlay with progress bar.
+class _ParticipantOverlay extends StatelessWidget {
+  const _ParticipantOverlay({required this.current, required this.max});
+
+  final int current;
+  final int max;
+
+  @override
+  Widget build(BuildContext context) {
+    final ratio = max > 0 ? (current / max).clamp(0.0, 1.0) : 0.0;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.45),
+        borderRadius: BorderRadius.circular(100),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: 40,
+            child: LinearProgressIndicator(
+              // ignore: use_minglit_progress_indicator -- LinearProgressIndicator used for participant progress display
+              value: ratio,
+              color: MinglitColors.tertiary,
+              backgroundColor: Colors.white.withValues(alpha: 0.3),
+              borderRadius: BorderRadius.circular(2),
+              minHeight: 4,
+            ),
+          ),
+          const SizedBox(width: 6),
+          const Icon(Icons.people_outline, size: 11, color: Colors.white),
+          const SizedBox(width: 2),
+          Text(
+            '$current/$max',
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Partner info overlay with avatar and name.
+class _PartnerOverlay extends StatelessWidget {
+  const _PartnerOverlay({required this.partner});
+
+  final Partner partner;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.45),
+        borderRadius: BorderRadius.circular(100),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          CircleAvatar(
+            radius: 10,
+            backgroundImage: partner.profileImageUrl != null
+                ? NetworkImage(partner.profileImageUrl!)
+                : null,
+            backgroundColor: Colors.white24,
+            child: partner.profileImageUrl == null
+                ? const Icon(Icons.store, size: 12, color: Colors.white)
+                : null,
+          ),
+          const SizedBox(width: 6),
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 90),
+            child: Text(
+              partner.name,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 11,
+                fontWeight: FontWeight.w600,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Skeleton loader for event card.
+class _EventCardSkeleton extends StatelessWidget {
+  const _EventCardSkeleton({required this.width});
+
+  final double width;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      width: width,
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        borderRadius: BorderRadius.circular(MinglitRadius.card),
+        boxShadow: [
+          BoxShadow(
+            color: MinglitColors.textPrimary.withValues(alpha: 0.05),
+            blurRadius: 10,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const AspectRatio(
+            aspectRatio: 16 / 9,
+            child: MinglitSkeleton(borderRadius: BorderRadius.zero),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(MinglitSpacing.medium),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                MinglitSkeleton(width: width * 0.8, height: 16),
+                const SizedBox(height: MinglitSpacing.xsmall),
+                Row(
+                  children: [
+                    MinglitSkeleton(width: width * 0.5, height: 12),
+                    const Spacer(),
+                    MinglitSkeleton(width: width * 0.2, height: 12),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary

- 홈 이벤트 카드를 이미지 오버레이 중심 레이아웃으로 전면 리디자인
- 참여자 수 표시 (`[███░░░] 👥 4/14`) + 민트색 progress bar를 이미지 우상단 오버레이로 배치
- 파트너 아바타 + 이름을 이미지 좌하단 오버레이로 이동하여 콘텐츠 영역 슬림화

## Changes

### 레이아웃 변경

```
[Before]                          [After]
┌─────────────────┐               ┌──────────────────────────┐
│  Hero 이미지     │               │  Hero 이미지              │
│  [D-Day]        │               │  [D-Day]    [███░] 👥4/14│
└─────────────────┘               │  [🏪 파트너이름]          │
  Partner + 이름                   └──────────────────────────┘
  이벤트 제목 (2줄)                  이벤트 제목 (1줄)
  📍 장소 · 날짜                    📍 장소 · 날짜     3,000원~
  3,000원~
```

### 세부 사항

- **이미지 우상단**: 반투명 pill에 `LinearProgressIndicator` + `👥 N/M` 인원수 (민트색 단일)
- **이미지 좌하단**: 반투명 pill에 파트너 아바타 + 이름 (`partner != null` 시만 표시)
- **이미지 하단**: 검정 그라디언트 페이드로 오버레이 텍스트 가독성 확보
- **콘텐츠 영역**: 타이틀(maxLines:1) + `[📍장소·날짜 | 가격]` 단일 행으로 슬림화
- **가격 로직**: `price == 0` → "무료" 표시 추가
- **방어 로직**: `maxParticipants == 0` → `ratio = 0.0` (division by zero 방지)
- **스켈레톤**: `MinglitEventCard.loading()` named constructor 추가

### 새로 추가된 private 위젯

- `_ParticipantOverlay` — 참여자 수 + progress bar 오버레이
- `_PartnerOverlay` — 파트너 정보 오버레이
- `_EventCardSkeleton` — 로딩 스켈레톤

## Verification

- ✅ `flutter analyze shared/packages/minglit_kit` → No issues found
- ✅ `flutter test shared/packages/minglit_kit` → 253 tests passed
- ✅ `flutter analyze apps/app_user` → MinglitEventCard 관련 에러 0건
- ✅ 기존 call site (`MinglitEventCard(event:, onTap:)`) 변경 없이 동작

## Files Changed

- `shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart` (226 insertions, 103 deletions)