### PR TITLE
feat(event-card): 참여자 인디케이터를 3칸 배터리 게이지로 변경

### DIFF
--- a/shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart
@@ -225,10 +225,10 @@ class _ParticipantOverlay extends StatelessWidget {
     final filledCount = ratio <= 0
         ? 0
         : ratio <= 0.33
-            ? 1
-            : ratio <= 0.66
-                ? 2
-                : 3;
+        ? 1
+        : ratio <= 0.66
+        ? 2
+        : 3;
     final segmentColor = switch (filledCount) {
       0 => Colors.white.withValues(alpha: 0.3),
       1 => MinglitColors.secondary,

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart
@@ -207,7 +207,12 @@ class MinglitEventCard extends StatelessWidget {
   }
 }
 
-/// Participant count overlay with progress bar.
+/// Participant count overlay with battery-style indicator.
+///
+/// Displays a 3-segment battery gauge based on participation ratio:
+/// - 0–33%: 1 filled segment (orange)
+/// - 34–66%: 2 filled segments (mint)
+/// - 67–100%: 3 filled segments (purple)
 class _ParticipantOverlay extends StatelessWidget {
   const _ParticipantOverlay({required this.current, required this.max});
 
@@ -217,6 +222,19 @@ class _ParticipantOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ratio = max > 0 ? (current / max).clamp(0.0, 1.0) : 0.0;
+    final filledCount = ratio <= 0
+        ? 0
+        : ratio <= 0.33
+            ? 1
+            : ratio <= 0.66
+                ? 2
+                : 3;
+    final segmentColor = switch (filledCount) {
+      0 => Colors.white.withValues(alpha: 0.3),
+      1 => MinglitColors.secondary,
+      2 => MinglitColors.tertiary,
+      _ => MinglitColors.primary,
+    };
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
@@ -227,20 +245,21 @@ class _ParticipantOverlay extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          SizedBox(
-            width: 40,
-            child: LinearProgressIndicator(
-              // ignore: use_minglit_progress_indicator -- LinearProgressIndicator used for participant progress display
-              value: ratio,
-              color: MinglitColors.tertiary,
-              backgroundColor: Colors.white.withValues(alpha: 0.3),
-              borderRadius: BorderRadius.circular(2),
-              minHeight: 4,
+          // 3-segment battery gauge
+          for (var i = 0; i < 3; i++) ...[
+            if (i > 0) const SizedBox(width: 2),
+            Container(
+              width: 10,
+              height: 8,
+              decoration: BoxDecoration(
+                color: i < filledCount
+                    ? segmentColor
+                    : Colors.white.withValues(alpha: 0.2),
+                borderRadius: BorderRadius.circular(2),
+              ),
             ),
-          ),
+          ],
           const SizedBox(width: 6),
-          const Icon(Icons.people_outline, size: 11, color: Colors.white),
-          const SizedBox(width: 2),
           Text(
             '$current/$max',
             style: const TextStyle(
@@ -249,6 +268,8 @@ class _ParticipantOverlay extends StatelessWidget {
               fontWeight: FontWeight.w700,
             ),
           ),
+          const SizedBox(width: 2),
+          const Icon(Icons.people_outline, size: 11, color: Colors.white),
         ],
       ),
     );


### PR DESCRIPTION
## Summary

- 이벤트 카드 참여자 오버레이의 `LinearProgressIndicator`를 3칸 배터리 스타일 게이지로 교체
- 참여율 구간별 브랜드 컬러 적용: 오렌지(~33%) → 민트(~66%) → 보라(67%~)

## Changes

### Before → After

```
[████░░░░] 👥 4/14        →        [■][■][□] 4/14 👥
(LinearProgressIndicator)           (3-segment battery gauge)
```

### 색상 로직

| 구간 | 칸 수 | 색상 |
|---|---|---|
| 0~33% | `[■][□][□]` | 🟠 오렌지 (`MinglitColors.secondary`) |
| 34~66% | `[■][■][□]` | 🟢 민트 (`MinglitColors.tertiary`) |
| 67~100% | `[■][■][■]` | 🟣 보라 (`MinglitColors.primary`) |
| 0명 | `[□][□][□]` | ⬜ 반투명 white |

### 구현 세부

- 3개의 `Container` 위젯으로 세그먼트 구성 (각 10x8px, borderRadius: 2)
- 채워진 세그먼트: 구간별 브랜드 컬러 / 빈 세그먼트: `white.withValues(alpha: 0.2)`
- 기존 반투명 pill chip 스타일 유지
- 레이아웃 순서: `[배터리] [인원수] [아이콘]`

## Verification

- ✅ `flutter analyze event_card.dart` → No issues found
- ✅ `flutter test minglit_kit` → 253 tests passed
- ✅ 단일 파일 수정 (`event_card.dart`)

## Files Changed

- `shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart` (+34, -13)