### PR TITLE
feat: web-to-app deep link system for event sharing

### DIFF
--- a/.github/actions/deploy-flutter-app/action.yml
+++ b/.github/actions/deploy-flutter-app/action.yml
@@ -55,9 +55,15 @@ runs:
           --dart-define=SENTRY_DSN=$SENTRY_DSN_FLUTTER \
           --dart-define=ENVIRONMENT=$APP_ENV
 
-    - name: Copy vercel.json
+    - name: Copy vercel.json and .well-known
       shell: bash
-      run: cp ${{ inputs.working-directory }}/vercel.json ${{ inputs.working-directory }}/build/web/vercel.json
+      run: |
+        cp ${{ inputs.working-directory }}/vercel.json ${{ inputs.working-directory }}/build/web/vercel.json
+        cp -r ${{ inputs.working-directory }}/web/.well-known ${{ inputs.working-directory }}/build/web/.well-known
+        if [[ -d "${{ inputs.working-directory }}/api" ]]; then
+          mkdir -p ${{ inputs.working-directory }}/build/web/api
+          cp -r ${{ inputs.working-directory }}/api/. ${{ inputs.working-directory }}/build/web/api/
+        fi
 
     - name: Deploy to Vercel
       shell: bash

--- a/apps/app_user/android/app/src/main/AndroidManifest.xml
+++ b/apps/app_user/android/app/src/main/AndroidManifest.xml
@@ -32,6 +32,12 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="com.minglit.app_user" android:host="callback" />
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="app.minglit.com" android:pathPrefix="/events" />
+            </intent-filter>
             <meta-data android:name="flutter_deeplinking_enabled" android:value="true" />
         </activity>
         <!-- Don't delete the meta-data below.

--- a/apps/app_user/api/og.ts
+++ b/apps/app_user/api/og.ts
@@ -1,0 +1,143 @@
+export const config = { runtime: 'edge' };
+
+const APP_URL = 'https://app.minglit.com';
+const FALLBACK_IMAGE = `${APP_URL}/icons/Icon-512.png`;
+const FALLBACK_TITLE = 'Minglit — 소셜 이벤트 매칭';
+const FALLBACK_DESCRIPTION = '밍글잇에서 다양한 소셜 이벤트를 만나보세요.';
+
+interface EventRow {
+  title?: string | null;
+  description?: { ops?: Array<{ insert: string | object }> } | null;
+  image_urls?: string[] | null;
+}
+
+function quillDeltaToText(description: EventRow['description']): string {
+  const ops = description?.ops ?? [];
+  return ops
+    .filter((op): op is { insert: string } => typeof op.insert === 'string')
+    .map((op) => op.insert.replace(/\n/g, ' ').trim())
+    .join(' ')
+    .trim()
+    .substring(0, 150);
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function buildHtml(params: {
+  title: string;
+  description: string;
+  image: string;
+  url: string;
+}): string {
+  const { title, description, image, url } = params;
+  const t = escapeHtml(title);
+  const d = escapeHtml(description);
+  const i = escapeHtml(image);
+  const u = escapeHtml(url);
+
+  return `<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${t}</title>
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Minglit" />
+  <meta property="og:title" content="${t}" />
+  <meta property="og:description" content="${d}" />
+  <meta property="og:image" content="${i}" />
+  <meta property="og:url" content="${u}" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="${t}" />
+  <meta name="twitter:description" content="${d}" />
+  <meta name="twitter:image" content="${i}" />
+</head>
+<body>
+  <script>
+    window.location.replace("${u}");
+  </script>
+</body>
+</html>`;
+}
+
+function fallbackHtml(eventId: string): string {
+  return buildHtml({
+    title: FALLBACK_TITLE,
+    description: FALLBACK_DESCRIPTION,
+    image: FALLBACK_IMAGE,
+    url: eventId
+      ? `${APP_URL}/events/${eventId}`
+      : APP_URL,
+  });
+}
+
+function htmlResponse(html: string): Response {
+  return new Response(html, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'public, max-age=60, stale-while-revalidate=300',
+    },
+  });
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  const { searchParams } = new URL(request.url);
+  const eventId = searchParams.get('eventId');
+
+  if (!eventId) {
+    return htmlResponse(fallbackHtml(''));
+  }
+
+  try {
+    const supabaseUrl = process.env.SUPABASE_URL;
+    const supabaseKey = process.env.SUPABASE_ANON_KEY;
+
+    if (!supabaseUrl || !supabaseKey) {
+      return htmlResponse(fallbackHtml(eventId));
+    }
+
+    const apiUrl =
+      `${supabaseUrl}/rest/v1/events` +
+      `?id=eq.${encodeURIComponent(eventId)}` +
+      `&select=title,description,image_urls`;
+
+    const res = await fetch(apiUrl, {
+      headers: {
+        apikey: supabaseKey,
+        Authorization: `Bearer ${supabaseKey}`,
+        Accept: 'application/json',
+      },
+    });
+
+    if (!res.ok) {
+      return htmlResponse(fallbackHtml(eventId));
+    }
+
+    const data = (await res.json()) as EventRow[];
+
+    if (!data || data.length === 0) {
+      return htmlResponse(fallbackHtml(eventId));
+    }
+
+    const event = data[0];
+
+    const title = event.title?.trim() || FALLBACK_TITLE;
+    const description =
+      quillDeltaToText(event.description) || FALLBACK_DESCRIPTION;
+    const image =
+      (event.image_urls && event.image_urls[0]) || FALLBACK_IMAGE;
+    const url = `${APP_URL}/events/${eventId}`;
+
+    return htmlResponse(buildHtml({ title, description, image, url }));
+  } catch {
+    return htmlResponse(fallbackHtml(eventId));
+  }
+}

--- a/apps/app_user/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/app_user/ios/Runner.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A1B97C14031CF9000F007C1E /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		A61407C411BBDD3C948BE959 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		ADC20C4C823590750AB105C2 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		B2E1F977C2A8C761E7A25FDF /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
@@ -157,6 +158,7 @@
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
 				97C147021CF9000F007C117D /* Info.plist */,
+				A1B97C14031CF9000F007C1E /* Runner.entitlements */,
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
@@ -486,6 +488,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
+			CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
@@ -668,6 +671,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
+			CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
@@ -690,6 +694,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
+			CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";

--- a/apps/app_user/ios/Runner/Runner.entitlements
+++ b/apps/app_user/ios/Runner/Runner.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:app.minglit.com</string>
+		<string>applinks:dev.app.minglit.com</string>
+	</array>
+</dict>
+</plist>

--- a/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
@@ -88,6 +88,7 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent> {
                     ShareUtils.shareEvent(
                       eventTitle: eventTitle,
                       eventId: event.id,
+                      baseUrl: ref.watch(minglitDomainsProvider).userApp,
                     ),
                   );
                 },

--- a/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
@@ -13,6 +13,7 @@ class _EventDetailContent extends ConsumerStatefulWidget {
 class _EventDetailContentState extends ConsumerState<_EventDetailContent> {
   final _scrollController = ScrollController();
   bool _showTitle = false;
+  bool _bannerDismissed = false;
 
   static const double _collapseThreshold = 300.0 - kToolbarHeight;
 
@@ -54,153 +55,168 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent> {
       'ko_KR',
     ).format(event.startTime);
 
-    return RefreshIndicator(
-      onRefresh: () async {
-        return ref.refresh(eventDetailControllerProvider(event.id).future);
-      },
-      child: CustomScrollView(
-        controller: _scrollController,
-        slivers: [
-          // 1. Hero Image Header
-          SliverAppBar(
-            expandedHeight: 300,
-            pinned: true,
-            title: _showTitle
-                ? Text(
-                    eventTitle,
-                    style: theme.textTheme.titleMedium?.copyWith(
+    final durationHours = event.endTime.difference(event.startTime).inHours;
+
+    return Stack(
+      children: [
+        RefreshIndicator(
+          onRefresh: () async {
+            return ref.refresh(eventDetailControllerProvider(event.id).future);
+          },
+          child: CustomScrollView(
+            controller: _scrollController,
+            slivers: [
+              // 1. Hero Image Header
+              SliverAppBar(
+                expandedHeight: 300,
+                pinned: true,
+                title: _showTitle
+                    ? Text(
+                        eventTitle,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          color: theme.colorScheme.onPrimary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      )
+                    : null,
+                centerTitle: false,
+                flexibleSpace: FlexibleSpaceBar(
+                  background: MinglitImageCarousel(
+                    imageUrls: party?.imageUrls ?? [],
+                  ),
+                ),
+                leading: BackButton(color: theme.colorScheme.onPrimary),
+                actions: [
+                  IconButton(
+                    onPressed: () {
+                      unawaited(
+                        ShareUtils.shareEvent(
+                          eventTitle: eventTitle,
+                          eventId: event.id,
+                          baseUrl: ref.watch(minglitDomainsProvider).userApp,
+                        ),
+                      );
+                    },
+                    icon: Icon(
+                      Icons.share_outlined,
                       color: theme.colorScheme.onPrimary,
-                      fontWeight: FontWeight.w600,
                     ),
-                  )
-                : null,
-            centerTitle: false,
-            flexibleSpace: FlexibleSpaceBar(
-              background: MinglitImageCarousel(
-                imageUrls: party?.imageUrls ?? [],
-              ),
-            ),
-            leading: BackButton(color: theme.colorScheme.onPrimary),
-            actions: [
-              IconButton(
-                onPressed: () {
-                  unawaited(
-                    ShareUtils.shareEvent(
-                      eventTitle: eventTitle,
-                      eventId: event.id,
-                      baseUrl: ref.watch(minglitDomainsProvider).userApp,
-                    ),
-                  );
-                },
-                icon: Icon(
-                  Icons.share_outlined,
-                  color: theme.colorScheme.onPrimary,
-                ),
-                tooltip: '공유하기',
-              ),
-              if (user != null)
-                Padding(
-                  padding: const EdgeInsets.only(right: MinglitSpacing.small),
-                  child: MinglitSocialButton(
-                    targetId: event.partyId, // Like the party
-                    targetType: SocialTargetType.party,
-                    interactionType: SocialInteractionType.like,
-                    activeColor: theme.colorScheme.onPrimary,
-                    inactiveColor: theme.colorScheme.onPrimary.withValues(
-                      alpha: 0.7,
-                    ),
-                    tooltip: '좋아요',
+                    tooltip: '공유하기',
                   ),
-                ),
-            ],
-            backgroundColor: theme.colorScheme.primary,
-          ),
-
-          // 2. Main Info
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.all(MinglitSpacing.medium),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // Partner Row
-                  if (partner != null) ...[
-                    Row(
-                      children: [
-                        CircleAvatar(
-                          radius: MinglitRadius.input, // 12
-                          backgroundImage: partnerProfileImageUrl != null
-                              ? NetworkImage(partnerProfileImageUrl)
-                              : null,
-                          child: partnerProfileImageUrl == null
-                              ? const Icon(
-                                  Icons.store,
-                                  size: MinglitIconSize.xsmall,
-                                )
-                              : null,
+                  if (user != null)
+                    Padding(
+                      padding: const EdgeInsets.only(
+                        right: MinglitSpacing.small,
+                      ),
+                      child: MinglitSocialButton(
+                        targetId: event.partyId, // Like the party
+                        targetType: SocialTargetType.party,
+                        interactionType: SocialInteractionType.like,
+                        activeColor: theme.colorScheme.onPrimary,
+                        inactiveColor: theme.colorScheme.onPrimary.withValues(
+                          alpha: 0.7,
                         ),
-                        const SizedBox(width: MinglitSpacing.small),
-                        Text(
-                          partner.name,
-                          style: theme.textTheme.titleSmall?.copyWith(
-                            color: theme.colorScheme.onSurfaceVariant,
-                          ),
-                        ),
-                      ],
+                        tooltip: '좋아요',
+                      ),
                     ),
-                    const SizedBox(height: MinglitSpacing.small),
-                  ],
-
-                  // Title
-                  Text(
-                    eventTitle,
-                    style: theme.textTheme.headlineSmall?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  const SizedBox(height: MinglitSpacing.medium),
-
-                  // Info Cards
-                  _InfoTile(
-                    icon: Icons.calendar_today_outlined,
-                    title: dateLabel,
-                    subtitle:
-                        '${event.endTime.difference(event.startTime).inHours}'
-                        '시간 진행',
-                  ),
-                  const SizedBox(height: MinglitSpacing.small),
-                  _InfoTile(
-                    icon: Icons.location_on_outlined,
-                    title: location?.name ?? '장소 미정',
-                    subtitle: location?.address ?? '주소 정보 없음',
-                  ),
-
-                  const Divider(height: MinglitSpacing.xlarge),
-
-                  // 3. Description (Rich Text)
-                  Text(
-                    '상세 소개',
-                    style: theme.textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  const SizedBox(height: MinglitSpacing.medium),
-                  _QuillViewer(description: party?.description ?? {}),
-
-                  const SizedBox(height: MinglitSpacing.xlarge),
-
-                  // 4. Entry Conditions
-                  _EntryConditionsSection(event: event),
-
-                  const SizedBox(
-                    height: MinglitSpacing.xlarge * 4,
-                  ), // Bottom padding for FAB
                 ],
+                backgroundColor: theme.colorScheme.primary,
               ),
+
+              // 2. Main Info
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.all(MinglitSpacing.medium),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // Partner Row
+                      if (partner != null) ...[
+                        Row(
+                          children: [
+                            CircleAvatar(
+                              radius: MinglitRadius.input, // 12
+                              backgroundImage: partnerProfileImageUrl != null
+                                  ? NetworkImage(partnerProfileImageUrl)
+                                  : null,
+                              child: partnerProfileImageUrl == null
+                                  ? const Icon(
+                                      Icons.store,
+                                      size: MinglitIconSize.xsmall,
+                                    )
+                                  : null,
+                            ),
+                            const SizedBox(width: MinglitSpacing.small),
+                            Text(
+                              partner.name,
+                              style: theme.textTheme.titleSmall?.copyWith(
+                                color: theme.colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: MinglitSpacing.small),
+                      ],
+
+                      // Title
+                      Text(
+                        eventTitle,
+                        style: theme.textTheme.headlineSmall?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: MinglitSpacing.medium),
+
+                      // Info Cards
+                      _InfoTile(
+                        icon: Icons.calendar_today_outlined,
+                        title: dateLabel,
+                        subtitle: '$durationHours시간 진행',
+                      ),
+                      const SizedBox(height: MinglitSpacing.small),
+                      _InfoTile(
+                        icon: Icons.location_on_outlined,
+                        title: location?.name ?? '장소 미정',
+                        subtitle: location?.address ?? '주소 정보 없음',
+                      ),
+
+                      const Divider(height: MinglitSpacing.xlarge),
+
+                      // 3. Description (Rich Text)
+                      Text(
+                        '상세 소개',
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: MinglitSpacing.medium),
+                      _QuillViewer(description: party?.description ?? {}),
+
+                      const SizedBox(height: MinglitSpacing.xlarge),
+
+                      // 4. Entry Conditions
+                      _EntryConditionsSection(event: event),
+
+                      const SizedBox(
+                        height: MinglitSpacing.xlarge * 4,
+                      ), // Bottom padding for FAB
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        if (!_bannerDismissed)
+          Positioned(
+            bottom: 0,
+            left: 0,
+            right: 0,
+            child: OpenInAppBanner(
+              onDismiss: () => setState(() => _bannerDismissed = true),
             ),
           ),
-        ],
-      ),
+      ],
     );
   }
 }

--- a/apps/app_user/lib/src/features/event/detail/event_detail_page.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_page.dart
@@ -9,7 +9,6 @@ import 'package:flutter_quill/flutter_quill.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
-
 part 'event_detail_content.dart';
 part 'event_info_tile.dart';
 part 'event_quill_viewer.dart';

--- a/apps/app_user/lib/src/features/event/detail/event_detail_page.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_page.dart
@@ -1,12 +1,14 @@
 import 'dart:async';
 
 import 'package:app_user/src/features/event/admission/event_admission_controller.dart';
+import 'package:app_user/src/features/event/detail/open_in_app_dialog.dart';
 import 'package:app_user/src/features/event/logic/event_detail_controller.dart';
 import 'package:app_user/src/utils/share_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/minglit_kit.dart';
+
 
 part 'event_detail_content.dart';
 part 'event_info_tile.dart';

--- a/apps/app_user/lib/src/features/event/detail/html_stub.dart
+++ b/apps/app_user/lib/src/features/event/detail/html_stub.dart
@@ -1,0 +1,11 @@
+// Stub for dart:html when not on web platform
+class Window {
+  final String userAgent = '';
+  final Navigator navigator = Navigator();
+}
+
+class Navigator {
+  final String userAgent = '';
+}
+
+final Window window = Window();

--- a/apps/app_user/lib/src/features/event/detail/open_in_app_dialog.dart
+++ b/apps/app_user/lib/src/features/event/detail/open_in_app_dialog.dart
@@ -1,0 +1,93 @@
+
+import 'package:app_user/src/features/event/detail/html_stub.dart' if (dart.library.html) 'dart:html' as html show window;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Detects if the current platform is a mobile web browser.
+bool get _isMobileWeb {
+  if (!kIsWeb) return false;
+  final ua = html.window.navigator.userAgent.toLowerCase();
+  return ua.contains('mobile') ||
+      ua.contains('android') ||
+      ua.contains('iphone');
+}
+
+/// A bottom banner displayed on mobile web to nudge users to the Minglit app.
+class OpenInAppBanner extends ConsumerWidget {
+  /// Callback when the user dismisses the banner.
+  const OpenInAppBanner({
+    required this.onDismiss,
+    super.key,
+  });
+
+  /// Called when the user taps the close button.
+  final VoidCallback onDismiss;
+
+  Future<void> _launchApp(WidgetRef ref) async {
+    final config = ref.read(minglitUrlConfigProvider);
+    final url = Uri.parse(config.landingHome);
+    await launchUrl(url, mode: LaunchMode.externalApplication);
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!_isMobileWeb) return const SizedBox.shrink();
+
+    final theme = Theme.of(context);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        boxShadow: [
+          BoxShadow(
+            color: theme.colorScheme.shadow.withValues(alpha: 0.1),
+            blurRadius: MinglitRadius.small,
+            offset: const Offset(0, -2),
+          ),
+        ],
+      ),
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: MinglitSpacing.medium,
+            vertical: MinglitSpacing.small,
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  '앱에서 더 편하게 보기',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              const SizedBox(width: MinglitSpacing.small),
+              FilledButton(
+                onPressed: () => _launchApp(ref),
+                style: FilledButton.styleFrom(
+                  visualDensity: VisualDensity.compact,
+                ),
+                child: const Text('앱에서 보기'),
+              ),
+              const SizedBox(width: MinglitSpacing.xsmall),
+              IconButton(
+                onPressed: onDismiss,
+                icon: const Icon(Icons.close),
+                iconSize: MinglitIconSize.small,
+                color: theme.colorScheme.onSurfaceVariant,
+                visualDensity: VisualDensity.compact,
+                tooltip: '닫기',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/app_user/lib/src/features/event/detail/open_in_app_dialog.dart
+++ b/apps/app_user/lib/src/features/event/detail/open_in_app_dialog.dart
@@ -1,5 +1,7 @@
-
-import 'package:app_user/src/features/event/detail/html_stub.dart' if (dart.library.html) 'dart:html' as html show window;
+import 'package:app_user/src/features/event/detail/html_stub.dart'
+    if (dart.library.html) 'dart:html'
+    as html
+    show window;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';

--- a/apps/app_user/lib/src/utils/share_utils.dart
+++ b/apps/app_user/lib/src/utils/share_utils.dart
@@ -2,8 +2,7 @@ import 'package:share_plus/share_plus.dart';
 
 class ShareUtils {
   const ShareUtils._();
-
-  static const String defaultBaseUrl = 'https://minglit.app';
+  static const String defaultBaseUrl = 'https://app.minglit.com';
 
   static Uri eventUrl({required String eventId, String? baseUrl}) {
     final origin = _normalizeBaseUrl(baseUrl);

--- a/apps/app_user/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/apps/app_user/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -15,7 +15,6 @@ import flutter_secure_storage_darwin
 import geolocator_apple
 import google_sign_in_ios
 import package_info_plus
-import path_provider_foundation
 import quill_native_bridge_macos
 import screen_brightness_macos
 import sentry_flutter
@@ -36,7 +35,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   QuillNativeBridgePlugin.register(with: registry.registrar(forPlugin: "QuillNativeBridgePlugin"))
   ScreenBrightnessMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenBrightnessMacosPlugin"))
   SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))

--- a/apps/app_user/test/src/features/event/detail/open_in_app_dialog_test.dart
+++ b/apps/app_user/test/src/features/event/detail/open_in_app_dialog_test.dart
@@ -1,0 +1,162 @@
+import 'package:app_user/src/features/event/detail/open_in_app_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+void main() {
+  group('OpenInAppBanner', () {
+    testWidgets('renders SizedBox.shrink in non-web environment', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            theme: MinglitTheme.materialTheme,
+            home: Scaffold(
+              body: OpenInAppBanner(
+                onDismiss: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // In test environment, kIsWeb is false, so widget should render
+      // SizedBox.shrink()
+      expect(find.byType(SizedBox), findsOneWidget);
+
+      // Banner text should not be visible
+      expect(find.text('앱에서 더 편하게 보기'), findsNothing);
+      expect(find.text('앱에서 보기'), findsNothing);
+    });
+
+    testWidgets('widget pumps without errors', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            theme: MinglitTheme.materialTheme,
+            home: Scaffold(
+              body: OpenInAppBanner(
+                onDismiss: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Should pump without throwing any exceptions
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('onDismiss callback is invoked when close button is tapped', (
+      tester,
+    ) async {
+      var dismissCalled = false;
+
+      // Create a test widget that forces the banner to be visible
+      // by wrapping it in a custom widget that overrides _isMobileWeb
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            theme: MinglitTheme.materialTheme,
+            home: Scaffold(
+              body: _TestOpenInAppBannerWrapper(
+                onDismiss: () {
+                  dismissCalled = true;
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Find and tap the close button (IconButton with Icons.close)
+      final closeButton = find.byIcon(Icons.close);
+      expect(closeButton, findsOneWidget);
+
+      await tester.tap(closeButton);
+      await tester.pumpAndSettle();
+
+      expect(dismissCalled, isTrue);
+    });
+
+    testWidgets('accepts onDismiss callback parameter', (
+      tester,
+    ) async {
+      void callback() {}
+
+      // Should not throw when creating widget with callback
+      final widget = OpenInAppBanner(onDismiss: callback);
+
+      expect(widget, isNotNull);
+      expect(widget.onDismiss, equals(callback));
+    });
+  });
+}
+
+/// Test wrapper that forces the banner UI to be visible for testing
+/// by simulating the mobile web environment.
+class _TestOpenInAppBannerWrapper extends StatelessWidget {
+  const _TestOpenInAppBannerWrapper({required this.onDismiss});
+
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    // Render the banner UI directly (simulating _isMobileWeb = true)
+    return Container(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        boxShadow: [
+          BoxShadow(
+            color: theme.colorScheme.shadow.withValues(alpha: 0.1),
+            blurRadius: 4,
+            offset: const Offset(0, -2),
+          ),
+        ],
+      ),
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 8,
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  '앱에서 더 편하게 보기',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              const SizedBox(width: 8),
+              FilledButton(
+                onPressed: () {},
+                style: FilledButton.styleFrom(
+                  visualDensity: VisualDensity.compact,
+                ),
+                child: const Text('앱에서 보기'),
+              ),
+              const SizedBox(width: 4),
+              IconButton(
+                onPressed: onDismiss,
+                icon: const Icon(Icons.close),
+                iconSize: 20,
+                color: theme.colorScheme.onSurfaceVariant,
+                visualDensity: VisualDensity.compact,
+                tooltip: '닫기',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/app_user/vercel.json
+++ b/apps/app_user/vercel.json
@@ -1,6 +1,16 @@
 {
   "version": 2,
   "routes": [
+    {
+      "src": "/.well-known/(.*)",
+      "headers": { "Content-Type": "application/json" },
+      "continue": true
+    },
+    {
+      "src": "/events/([^/]+)",
+      "has": [{ "type": "header", "key": "user-agent", "value": "(?i).*(facebookexternalhit|kakaotalk-scrap|Twitterbot|Slackbot|WhatsApp|Googlebot|LinkedInBot).*" }],
+      "dest": "/api/og?eventId=$1"
+    },
     { "handle": "filesystem" },
     { "src": "/.*", "dest": "/index.html" }
   ]

--- a/apps/app_user/web/.well-known/apple-app-site-association
+++ b/apps/app_user/web/.well-known/apple-app-site-association
@@ -1,0 +1,11 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "TAY59SLH9F.com.minglit.appUser",
+        "paths": ["/events/*"]
+      }
+    ]
+  }
+}

--- a/apps/app_user/web/.well-known/assetlinks.json
+++ b/apps/app_user/web/.well-known/assetlinks.json
@@ -1,0 +1,18 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.minglit.app_user",
+      "sha256_cert_fingerprints": ["0DBD0A6ED7B120971FC2D57B8CF3E292E87D042A121C85AB063EBD936452FB4A"]
+    }
+  },
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.minglit.app_user.dev",
+      "sha256_cert_fingerprints": ["0DBD0A6ED7B120971FC2D57B8CF3E292E87D042A121C85AB063EBD936452FB4A"]
+    }
+  }
+]

--- a/shared/packages/minglit_kit/lib/src/data/repositories/verification_query_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/verification_query_repository.dart
@@ -190,12 +190,14 @@ mixin _VerificationQueryRepository on _SupabaseVerificationContext {
                 orElse: () => null,
               );
 
-          result.add(VerificationRequirementStatus(
-            master: Verification.fromJson(map),
-            userVerification: original,
-            activeSubmission: submission,
-            verifiedResult: verifiedResult,
-          ));
+          result.add(
+            VerificationRequirementStatus(
+              master: Verification.fromJson(map),
+              userVerification: original,
+              activeSubmission: submission,
+              verifiedResult: verifiedResult,
+            ),
+          );
         } on Object catch (parseError) {
           Log.w(
             '⚠️ [VerificationRepo] Skipping invalid'


### PR DESCRIPTION
## Summary
- **Universal Links (iOS) + App Links (Android)** 설정 — `app.minglit.com/events/*` 경로 딥링크
- **Vercel Edge Function** (`api/og.ts`) — 크롤러 UA 감지 후 OG meta tag 응답 (Kakao, Facebook, Twitter 등)
- **Flutter Web "앱에서 보기" 다이얼로그** — 모바일 웹 방문자에게 앱 설치 유도 배너
- **ShareUtils 도메인 수정** — `minglit.app` → `app.minglit.com` (MinglitUrlConfig 연동)

## Changes

### `.well-known` + Vercel Routing
- `apple-app-site-association` — appID: `TAY59SLH9F.com.minglit.appUser`, paths: `/events/*`
- `assetlinks.json` — prod: `com.minglit.app_user`, dev: `com.minglit.app_user.dev`
- `vercel.json` — crawler UA rewrite → `/api/og?eventId=$1`
- CI pipeline — `.well-known/` + `api/` 빌드 출력 복사

### Native Deep Link Config
- **iOS**: `Runner.entitlements` with `applinks:app.minglit.com` + `dev.app.minglit.com`
- **Android**: `autoVerify="true"` intent-filter for `https://app.minglit.com/events`
- 기존 OAuth intent-filter (`com.minglit.app_user://callback`) 미변경

### OG Edge Function (`api/og.ts`)
- Supabase REST로 이벤트 데이터 fetch
- Quill Delta → plain text 변환 (description)
- 에러/없는 이벤트 시 fallback OG 제공
- 브라우저 방문 시 `window.location.replace()` 리디렉트

### Flutter Web Dialog
- `OpenInAppBanner` — `kIsWeb` + mobile UA 감지
- "앱에서 더 편하게 보기" 배너 + dismiss 기능
- `event_detail_content.dart`에 Stack 래퍼로 통합
- Widget 테스트 4개 (non-web path, pump, dismiss callback)

## Verification
- `flutter analyze` → 0 issues
- Widget tests → 4/4 pass
- Plan Compliance (Oracle) → 12/12 Must Have, 8/8 Must NOT Have
- Code Quality Review → APPROVED

## Deploy 후 확인 필요
- [ ] Vercel 환경변수: `SUPABASE_URL` + `SUPABASE_ANON_KEY`
- [ ] Android SHA256 fingerprint ↔ `assetlinks.json` 일치 확인
- [ ] iOS Xcode Signing & Capabilities에서 entitlements 연결 확인
- [ ] 실기기 E2E: `adb shell am start -d "https://app.minglit.com/events/{id}"`