### PR TITLE
style(minglit_kit): 이벤트 카드 칩 UI 개선 — D-day+참가자 합침, 스퀘어 보더, 타이포 통일

### DIFF
--- a/apps/app_user/lib/src/features/event/detail/event_entry_conditions_section.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_entry_conditions_section.dart
@@ -31,11 +31,13 @@ class _EntryConditionsSection extends StatelessWidget {
                 const SizedBox(height: MinglitSpacing.medium),
             itemBuilder: (context, index) {
               final group = entryGroups[index];
-              final matchingTickets = (event.tickets ?? []).where(
-                (t) =>
-                    t.targetEntryGroupIds.isNotEmpty &&
-                    t.targetEntryGroupIds.contains(group.id),
-              ).toList();
+              final matchingTickets = (event.tickets ?? [])
+                  .where(
+                    (t) =>
+                        t.targetEntryGroupIds.isNotEmpty &&
+                        t.targetEntryGroupIds.contains(group.id),
+                  )
+                  .toList();
               final soldCount = matchingTickets.fold<int>(
                 0,
                 (sum, t) => sum + t.soldCount,

--- a/apps/app_user/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/apps/app_user/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -15,7 +15,6 @@ import flutter_secure_storage_darwin
 import geolocator_apple
 import google_sign_in_ios
 import package_info_plus
-import path_provider_foundation
 import quill_native_bridge_macos
 import screen_brightness_macos
 import sentry_flutter
@@ -36,7 +35,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   QuillNativeBridgePlugin.register(with: registry.registrar(forPlugin: "QuillNativeBridgePlugin"))
   ScreenBrightnessMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenBrightnessMacosPlugin"))
   SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))

--- a/shared/packages/minglit_kit/lib/src/data/repositories/verification_query_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/verification_query_repository.dart
@@ -190,12 +190,14 @@ mixin _VerificationQueryRepository on _SupabaseVerificationContext {
                 orElse: () => null,
               );
 
-          result.add(VerificationRequirementStatus(
-            master: Verification.fromJson(map),
-            userVerification: original,
-            activeSubmission: submission,
-            verifiedResult: verifiedResult,
-          ));
+          result.add(
+            VerificationRequirementStatus(
+              master: Verification.fromJson(map),
+              userVerification: original,
+              activeSubmission: submission,
+              verifiedResult: verifiedResult,
+            ),
+          );
         } on Object catch (parseError) {
           Log.w(
             '⚠️ [VerificationRepo] Skipping invalid'

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_chip.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_chip.dart
@@ -88,7 +88,7 @@ class MinglitChip extends StatelessWidget {
       padding: padding,
       decoration: BoxDecoration(
         color: bgColor,
-        borderRadius: BorderRadius.circular(100),
+        borderRadius: BorderRadius.circular(MinglitRadius.small),
         border: Border.all(
           color: colorScheme.outlineVariant.withValues(alpha: 0.3),
           width: 0.5,
@@ -116,7 +116,7 @@ class MinglitChip extends StatelessWidget {
     if (onTap != null) {
       return InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(100),
+        borderRadius: BorderRadius.circular(MinglitRadius.small),
         child: widget,
       );
     }

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart
@@ -3,7 +3,6 @@ import 'package:intl/intl.dart';
 import 'package:minglit_kit/src/data/models/event.dart';
 import 'package:minglit_kit/src/data/models/partner.dart';
 import 'package:minglit_kit/src/theme/minglit_theme.dart';
-import 'package:minglit_kit/src/ui/widgets/common/minglit_chip.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_image.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_skeleton.dart';
 
@@ -131,23 +130,14 @@ class MinglitEventCard extends StatelessWidget {
                     left: MinglitSpacing.small,
                     child: _PartnerOverlay(partner: partner),
                   ),
-                // D-Day chip + Participant overlay (top-right)
+                // D-Day + Participant overlay (top-right)
                 Positioned(
                   top: MinglitSpacing.small,
                   right: MinglitSpacing.small,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      MinglitChip(
-                        label: dDayLabel,
-                        color: theme.colorScheme.primary,
-                      ),
-                      const SizedBox(width: MinglitSpacing.xsmall),
-                      _ParticipantOverlay(
-                        current: event!.currentParticipants,
-                        max: event!.maxParticipants,
-                      ),
-                    ],
+                  child: _ParticipantDDayOverlay(
+                    current: event!.currentParticipants,
+                    max: event!.maxParticipants,
+                    dDayLabel: dDayLabel,
                   ),
                 ),
               ],
@@ -208,17 +198,24 @@ class MinglitEventCard extends StatelessWidget {
   }
 }
 
-/// Participant count overlay with battery-style indicator.
+/// Participant count overlay with battery-style indicator and D-day label.
 ///
 /// Displays a 3-segment battery gauge based on participation ratio:
 /// - 0–33%: 1 filled segment (orange)
 /// - 34–66%: 2 filled segments (mint)
 /// - 67–100%: 3 filled segments (purple)
-class _ParticipantOverlay extends StatelessWidget {
-  const _ParticipantOverlay({required this.current, required this.max});
+///
+/// Also displays the D-day label (e.g., "오늘", "D-5", "종료").
+class _ParticipantDDayOverlay extends StatelessWidget {
+  const _ParticipantDDayOverlay({
+    required this.current,
+    required this.max,
+    required this.dDayLabel,
+  });
 
   final int current;
   final int max;
+  final String dDayLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -244,7 +241,7 @@ class _ParticipantOverlay extends StatelessWidget {
       ),
       decoration: BoxDecoration(
         color: MinglitColors.textPrimary.withValues(alpha: 0.45),
-        borderRadius: BorderRadius.circular(100),
+        borderRadius: BorderRadius.circular(MinglitRadius.small),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -268,15 +265,27 @@ class _ParticipantOverlay extends StatelessWidget {
             '$current/$max',
             style: Theme.of(context).textTheme.labelSmall?.copyWith(
               color: MinglitColors.background,
-              fontSize: 11,
-              fontWeight: FontWeight.w700,
+              fontSize: 13,
+              fontWeight: FontWeight.w500,
             ),
           ),
-          const SizedBox(width: 2),
-          const Icon(
-            Icons.people_outline,
-            size: 11,
-            color: MinglitColors.background,
+          const SizedBox(width: 4),
+          Text(
+            '·',
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: MinglitColors.background.withValues(alpha: 0.6),
+              fontSize: 13,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(width: 4),
+          Text(
+            dDayLabel,
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: MinglitColors.background,
+              fontSize: 13,
+              fontWeight: FontWeight.w500,
+            ),
           ),
         ],
       ),
@@ -299,7 +308,7 @@ class _PartnerOverlay extends StatelessWidget {
       ),
       decoration: BoxDecoration(
         color: MinglitColors.textPrimary.withValues(alpha: 0.45),
-        borderRadius: BorderRadius.circular(100),
+        borderRadius: BorderRadius.circular(MinglitRadius.small),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -320,13 +329,13 @@ class _PartnerOverlay extends StatelessWidget {
           ),
           const SizedBox(width: 6),
           ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 90),
+            constraints: const BoxConstraints(maxWidth: 130),
             child: Text(
               partner.name,
               style: Theme.of(context).textTheme.labelSmall?.copyWith(
                 color: MinglitColors.background,
-                fontSize: 11,
-                fontWeight: FontWeight.w600,
+                fontSize: 13,
+                fontWeight: FontWeight.w500,
               ),
               maxLines: 1,
               overflow: TextOverflow.ellipsis,


### PR DESCRIPTION
## Summary
- D-day 칩과 참가자 게이지를 하나의 칩으로 합침: `[███ 3/10 · D-7]` 형태
- MinglitChip borderRadius 전역 변경: pill(100) → squarish(8px, MinglitRadius.small)
- 파트너 오버레이 maxWidth 90→130 (한글 13자 수용), 폰트 11/w600→13/w500
- 참가자+D-day 칩 폰트를 MinglitFilterChip medium 스펙으로 통일 (13/w500)
- 피플 아이콘 제거, 가운데점(·) 구분자로 대체

## Changes
| File | What |
|------|------|
| `minglit_chip.dart` | borderRadius circular(100) → MinglitRadius.small (Container + InkWell) |
| `event_card.dart` | _ParticipantOverlay → _ParticipantDDayOverlay 리팩터링, _PartnerOverlay 폰트/너비 수정 |

## Verification
- `flutter analyze`: No issues found
- Playwright 스크린샷: 칩 스퀘어, 합친 칩 정상, 파트너 이름 여유, 콘솔 에러 0