### PR TITLE
fix(ui): prevent bug report dialog stacking on repeated shakes

### DIFF
--- a/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
@@ -37,7 +37,8 @@ class BugReporterWrapper extends StatefulWidget {
 }
 
 class _BugReporterWrapperState extends State<BugReporterWrapper> {
-  ShakeDetector? _detector;
+ShakeDetector? _detector;
+  bool _isDialogShowing = false;
 
   @override
   void initState() {
@@ -68,8 +69,15 @@ class _BugReporterWrapperState extends State<BugReporterWrapper> {
   BuildContext? get _dialogContext =>
       widget.navigatorKey?.currentState?.overlay?.context ?? context;
 
-  Future<void> _showReportDialog() async {
+Future<void> _showReportDialog() async {
     if (!mounted) return;
+    if (_isDialogShowing) {
+      // Dismiss existing dialog before showing a fresh one
+      final ctx = _dialogContext;
+      if (ctx != null && ctx.mounted) {
+        unawaited(Navigator.of(ctx).maybePop());
+      }
+    }
     final ctx = _dialogContext;
     if (ctx == null) return;
 
@@ -77,92 +85,97 @@ class _BugReporterWrapperState extends State<BugReporterWrapper> {
     final descController = TextEditingController();
     var isLoading = false;
 
-    await showDialog<void>(
-      context: ctx,
-      builder: (context) => StatefulBuilder(
-        builder: (context, setState) {
-          return AlertDialog(
-            title: const Text('🐞 Bug Report'),
-            content: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Text('Shake detected! Send logs to developers?'),
-                const SizedBox(height: 16),
-                TextField(
-                  controller: titleController,
-                  decoration: const InputDecoration(
-                    labelText: 'Title (Optional)',
-                    border: OutlineInputBorder(),
-                  ),
-                ),
-                const SizedBox(height: 8),
-                TextField(
-                  controller: descController,
-                  decoration: const InputDecoration(
-                    labelText: 'Description (What happened?)',
-                    border: OutlineInputBorder(),
-                  ),
-                  maxLines: 3,
-                ),
-                if (isLoading) ...[
+    _isDialogShowing = true;
+    try {
+      await showDialog<void>(
+        context: ctx,
+        builder: (context) => StatefulBuilder(
+          builder: (context, setState) {
+            return AlertDialog(
+              title: const Text('🐞 Bug Report'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text('Shake detected! Send logs to developers?'),
                   const SizedBox(height: 16),
-                  const MinglitCircularProgressIndicator(),
+                  TextField(
+                    controller: titleController,
+                    decoration: const InputDecoration(
+                      labelText: 'Title (Optional)',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  TextField(
+                    controller: descController,
+                    decoration: const InputDecoration(
+                      labelText: 'Description (What happened?)',
+                      border: OutlineInputBorder(),
+                    ),
+                    maxLines: 3,
+                  ),
+                  if (isLoading) ...[
+                    const SizedBox(height: 16),
+                    const MinglitCircularProgressIndicator(),
+                  ],
                 ],
-              ],
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.pop(context),
-                child: const Text('Cancel'),
               ),
-              ElevatedButton(
-                onPressed: isLoading
-                    ? null
-                    : () async {
-                        setState(() => isLoading = true);
-                        try {
-                          final logs = Log.export();
-                          final repo = BugReportRepository(
-                            Supabase.instance.client,
-                          );
-                          await repo.reportBug(
-                            title: titleController.text.isEmpty
-                                ? 'User Report'
-                                : titleController.text,
-                            description: descController.text,
-                            logs: logs,
-                          );
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Cancel'),
+                ),
+                ElevatedButton(
+                  onPressed: isLoading
+                      ? null
+                      : () async {
+                          setState(() => isLoading = true);
+                          try {
+                            final logs = Log.export();
+                            final repo = BugReportRepository(
+                              Supabase.instance.client,
+                            );
+                            await repo.reportBug(
+                              title: titleController.text.isEmpty
+                                  ? 'User Report'
+                                  : titleController.text,
+                              description: descController.text,
+                              logs: logs,
+                            );
 
-                          if (!context.mounted) {
-                            return;
+                            if (!context.mounted) {
+                              return;
+                            }
+                            Navigator.pop(context);
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text('Bug reported successfully! 🚀'),
+                                backgroundColor: MinglitColors.success,
+                              ),
+                            );
+                          } on Exception catch (e) {
+                            if (!context.mounted) {
+                              return;
+                            }
+                            setState(() => isLoading = false);
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(
+                                content: Text('Failed to report: $e'),
+                                backgroundColor: MinglitColors.error,
+                              ),
+                            );
                           }
-                          Navigator.pop(context);
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(
-                              content: Text('Bug reported successfully! 🚀'),
-                              backgroundColor: MinglitColors.success,
-                            ),
-                          );
-                        } on Exception catch (e) {
-                          if (!context.mounted) {
-                            return;
-                          }
-                          setState(() => isLoading = false);
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(
-                              content: Text('Failed to report: $e'),
-                              backgroundColor: MinglitColors.error,
-                            ),
-                          );
-                        }
-                      },
-                child: const Text('Send Report'),
-              ),
-            ],
-          );
-        },
-      ),
-    );
+                        },
+                  child: const Text('Send Report'),
+                ),
+              ],
+            );
+          },
+        ),
+      );
+    } finally {
+      _isDialogShowing = false;
+    }
   }
 
   @override

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
@@ -37,7 +37,7 @@ class BugReporterWrapper extends StatefulWidget {
 }
 
 class _BugReporterWrapperState extends State<BugReporterWrapper> {
-ShakeDetector? _detector;
+  ShakeDetector? _detector;
   bool _isDialogShowing = false;
 
   @override
@@ -69,7 +69,7 @@ ShakeDetector? _detector;
   BuildContext? get _dialogContext =>
       widget.navigatorKey?.currentState?.overlay?.context ?? context;
 
-Future<void> _showReportDialog() async {
+  Future<void> _showReportDialog() async {
     if (!mounted) return;
     if (_isDialogShowing) {
       // Dismiss existing dialog before showing a fresh one

--- a/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
+++ b/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/ui/widgets/bug_reporter_wrapper.dart';
+
+void main() {
+  group('BugReporterWrapper Widget Tests', () {
+    testWidgets('renders child widget correctly', (tester) async {
+      const testChild = Text('Test Child Widget');
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: BugReporterWrapper(
+                enabled: false, // Disable to avoid shake detector setup
+                child: testChild,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Test Child Widget'), findsOneWidget);
+    });
+
+    testWidgets('does not render FAB when disabled', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: BugReporterWrapper(
+                enabled: false,
+                child: const Text('Test Content'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // When disabled, no FAB should be rendered
+      expect(find.byType(FloatingActionButton), findsNothing);
+    });
+
+    testWidgets('widget builds without errors', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: BugReporterWrapper(
+                enabled: true,
+                child: const Center(
+                  child: Text('Main Content'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Main Content'), findsOneWidget);
+      expect(find.byType(BugReporterWrapper), findsOneWidget);
+    });
+
+    testWidgets('renders Stack with child and optional FAB', (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: BugReporterWrapper(
+                enabled: false,
+                child: const Text('Stack Child'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Verify the BugReporterWrapper widget is used (which uses Stack internally)
+      expect(find.byType(BugReporterWrapper), findsOneWidget);
+      expect(find.text('Stack Child'), findsOneWidget);
+    });
+
+    testWidgets('accepts navigatorKey parameter', (tester) async {
+      final navigatorKey = GlobalKey<NavigatorState>();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            navigatorKey: navigatorKey,
+            home: Scaffold(
+              body: BugReporterWrapper(
+                enabled: false,
+                navigatorKey: navigatorKey,
+                child: const Text('With Navigator Key'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('With Navigator Key'), findsOneWidget);
+    });
+
+    testWidgets('child widget is always rendered regardless of enabled state', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: BugReporterWrapper(
+                enabled: true,
+                child: const Text('Always Visible'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Always Visible'), findsOneWidget);
+    });
+  });
+}

--- a/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
+++ b/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
@@ -9,7 +9,7 @@ void main() {
       const testChild = Text('Test Child Widget');
 
       await tester.pumpWidget(
-        ProviderScope(
+        const ProviderScope(
           child: MaterialApp(
             home: Scaffold(
               body: BugReporterWrapper(
@@ -26,12 +26,12 @@ void main() {
 
     testWidgets('does not render FAB when disabled', (tester) async {
       await tester.pumpWidget(
-        ProviderScope(
+        const ProviderScope(
           child: MaterialApp(
             home: Scaffold(
               body: BugReporterWrapper(
                 enabled: false,
-                child: const Text('Test Content'),
+                child: Text('Test Content'),
               ),
             ),
           ),
@@ -44,12 +44,11 @@ void main() {
 
     testWidgets('widget builds without errors', (tester) async {
       await tester.pumpWidget(
-        ProviderScope(
+        const ProviderScope(
           child: MaterialApp(
             home: Scaffold(
               body: BugReporterWrapper(
-                enabled: true,
-                child: const Center(
+                child: Center(
                   child: Text('Main Content'),
                 ),
               ),
@@ -64,12 +63,12 @@ void main() {
 
     testWidgets('renders Stack with child and optional FAB', (tester) async {
       await tester.pumpWidget(
-        ProviderScope(
+        const ProviderScope(
           child: MaterialApp(
             home: Scaffold(
               body: BugReporterWrapper(
                 enabled: false,
-                child: const Text('Stack Child'),
+                child: Text('Stack Child'),
               ),
             ),
           ),
@@ -106,12 +105,11 @@ void main() {
       tester,
     ) async {
       await tester.pumpWidget(
-        ProviderScope(
+        const ProviderScope(
           child: MaterialApp(
             home: Scaffold(
               body: BugReporterWrapper(
-                enabled: true,
-                child: const Text('Always Visible'),
+                child: Text('Always Visible'),
               ),
             ),
           ),


### PR DESCRIPTION
## Summary
- `BugReporterWrapper`에 `_isDialogShowing` 가드 추가하여 shake/FAB 반복 시 다이얼로그 중복 방지
- 기존 다이얼로그 dismiss 후 새 다이얼로그 표시

Closes #25