### PR TITLE
fix(iamport): pass mRedirectUrl to CertificationData for mobile cancel flow

### DIFF
--- a/shared/packages/minglit_iamport_v1/lib/src/implementation/certification_io.dart
+++ b/shared/packages/minglit_iamport_v1/lib/src/implementation/certification_io.dart
@@ -12,6 +12,7 @@ class CertificationServiceImpl implements CertificationService {
     required String merchantUid,
     String? name,
     String? phone,
+    String? mRedirectUrl,
   }) async {
     final completer = Completer<String?>();
 
@@ -24,6 +25,7 @@ class CertificationServiceImpl implements CertificationService {
             merchantUid: merchantUid,
             name: name,
             phone: phone,
+            mRedirectUrl: mRedirectUrl,
           ),
           callback: (Map<String, String> result) {
             if (result['success'] == 'true') {

--- a/shared/packages/minglit_iamport_v1/lib/src/implementation/certification_stub.dart
+++ b/shared/packages/minglit_iamport_v1/lib/src/implementation/certification_stub.dart
@@ -9,6 +9,7 @@ class CertificationServiceImpl implements CertificationService {
     required String merchantUid,
     String? name,
     String? phone,
+    String? mRedirectUrl,
   }) {
     throw UnimplementedError();
   }

--- a/shared/packages/minglit_iamport_v1/lib/src/implementation/certification_web.dart
+++ b/shared/packages/minglit_iamport_v1/lib/src/implementation/certification_web.dart
@@ -14,6 +14,7 @@ class CertificationServiceImpl implements CertificationService {
     required String merchantUid,
     String? name,
     String? phone,
+    String? mRedirectUrl,
   }) async {
     final imp = globalContext['IMP'];
     if (imp == null) throw Exception('Iamport SDK (IMP) not loaded.');

--- a/shared/packages/minglit_iamport_v1/lib/src/service/certification_service.dart
+++ b/shared/packages/minglit_iamport_v1/lib/src/service/certification_service.dart
@@ -10,5 +10,6 @@ abstract class CertificationService {
     required String merchantUid,
     String? name,
     String? phone,
+    String? mRedirectUrl,
   });
 }

--- a/shared/packages/minglit_kit/lib/src/config/iamport_config.dart
+++ b/shared/packages/minglit_kit/lib/src/config/iamport_config.dart
@@ -7,12 +7,15 @@ class IamportConfig {
   /// Creates an [IamportConfig] with a user code.
   const IamportConfig({
     required this.userCode,
+    this.mobileRedirectUrl,
   });
 
   /// PortOne user code used for payment flows.
   final String userCode;
-}
 
+  /// Mobile redirect URL for Iamport certification cancel flow.
+  final String? mobileRedirectUrl;
+}
 /// Provides the current [IamportConfig].
 @Riverpod(keepAlive: true)
 IamportConfig iamportConfig(Ref ref) {
@@ -21,6 +24,12 @@ IamportConfig iamportConfig(Ref ref) {
     'IAMPORT_USER_CODE',
     defaultValue: 'imp10391932',
   );
+  const mobileRedirectScheme = String.fromEnvironment(
+    'MOBILE_REDIRECT_SCHEME',
+  );
 
-  return const IamportConfig(userCode: userCode);
+  return IamportConfig(
+    userCode: userCode,
+    mobileRedirectUrl: mobileRedirectScheme.isEmpty ? null : '$mobileRedirectScheme://iamport',
+  );
 }

--- a/shared/packages/minglit_kit/lib/src/config/iamport_config.dart
+++ b/shared/packages/minglit_kit/lib/src/config/iamport_config.dart
@@ -16,6 +16,7 @@ class IamportConfig {
   /// Mobile redirect URL for Iamport certification cancel flow.
   final String? mobileRedirectUrl;
 }
+
 /// Provides the current [IamportConfig].
 @Riverpod(keepAlive: true)
 IamportConfig iamportConfig(Ref ref) {
@@ -30,6 +31,8 @@ IamportConfig iamportConfig(Ref ref) {
 
   return IamportConfig(
     userCode: userCode,
-    mobileRedirectUrl: mobileRedirectScheme.isEmpty ? null : '$mobileRedirectScheme://iamport',
+    mobileRedirectUrl: mobileRedirectScheme.isEmpty
+        ? null
+        : '$mobileRedirectScheme://iamport',
   );
 }

--- a/shared/packages/minglit_kit/lib/src/features/verification/ui/identity_verification_screen.dart
+++ b/shared/packages/minglit_kit/lib/src/features/verification/ui/identity_verification_screen.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import 'package:minglit_iamport_v1/minglit_iamport_v1.dart';
+import 'package:minglit_kit/src/config/iamport_config.dart';
 import 'package:minglit_kit/src/data/repositories/identity_repository.dart';
 import 'package:minglit_kit/src/theme/minglit_theme.dart';
 import 'package:minglit_kit/src/ui/widgets/common/loading_indicator.dart';
@@ -43,13 +45,14 @@ class _IdentityVerificationScreenState
 
     try {
       final merchantUid = 'IDV_${DateTime.now().millisecondsSinceEpoch}';
-      const userCode = 'imp80716769';
+      final config = ref.read(iamportConfigProvider);
 
       final service = getCertificationService();
       final verificationId = await service.verify(
         context: context,
-        userCode: userCode,
+        userCode: config.userCode,
         merchantUid: merchantUid,
+        mRedirectUrl: config.mobileRedirectUrl,
       );
 
       if (verificationId == null) {


### PR DESCRIPTION
## Summary
- `CertificationService.verify()`에 optional `mRedirectUrl` 파라미터 추가
- `certification_io.dart`에서 `CertificationData`에 전달
- `IamportConfig`에 `mobileRedirectUrl` 필드 추가, 각 앱에서 설정

Closes #23