### PR TITLE
fix(data): handle verification parse errors gracefully in getVerificationsByIds

### DIFF
--- a/shared/packages/minglit_kit/lib/src/data/repositories/verification_query_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/verification_query_repository.dart
@@ -92,13 +92,13 @@ mixin _VerificationQueryRepository on _SupabaseVerificationContext {
   Future<List<Verification>> getVerificationsByIds(List<String> ids) async {
     Log.d('getVerificationsByIds called | ids: $ids');
     if (ids.isEmpty) return [];
+    final result = <Verification>[];
     try {
       final data = await supabaseClient
           .from('verifications')
           .select()
           .inFilter('id', ids);
 
-      final result = <Verification>[];
       for (final e in data as List) {
         try {
           result.add(Verification.fromJson(e as Map<String, dynamic>));
@@ -113,6 +113,13 @@ mixin _VerificationQueryRepository on _SupabaseVerificationContext {
       Log.d('getVerificationsByIds success | count: ${result.length}');
       return result;
     } catch (e, st) {
+      if (e is TypeError || e is FormatException) {
+        Log.w(
+          '⚠️ [VerificationRepo] getVerificationsByIds type/format error,'
+          ' returning partial results: $e',
+        );
+        return result;
+      }
       Log.e('❌ [VerificationRepo] getVerificationsByIds Error', e, st);
       rethrow;
     }

--- a/shared/packages/minglit_kit/test/src/data/repositories/verification_query_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/verification_query_repository_test.dart
@@ -1,0 +1,122 @@
+import 'dart:async' show unawaited;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/data/repositories/verification_repository.dart';
+
+import '../../../helpers/mocks.dart';
+import '../../../helpers/supabase_mock_helpers.dart';
+
+void main() {
+  late MockSupabaseClient mockClient;
+  late SupabaseVerificationRepository repository;
+
+  final now = DateTime.now();
+
+  setUp(() {
+    mockClient = createMockSupabase();
+    repository = SupabaseVerificationRepository(supabase: mockClient);
+  });
+
+  group('VerificationRepository', () {
+    group('getVerificationsByIds', () {
+      test('returns empty list when ids is empty', () async {
+        final result = await repository.getVerificationsByIds([]);
+        expect(result, isEmpty);
+      });
+
+      test('returns parsed Verification list for valid JSON', () async {
+        final verificationJson = {
+          'id': 'ver_1',
+          'category': 'career',
+          'internal_name': 'global_career',
+          'display_name': '직장 인증',
+          'partner_id': null,
+          'description': 'Career verification',
+          'icon_key': 'briefcase',
+          'form_schema': <Map<String, dynamic>>[],
+          'is_active': true,
+          'created_at': now.toIso8601String(),
+        };
+
+        unawaited(
+          mockTable(
+            mockClient,
+            'verifications',
+            selectData: [verificationJson],
+          ),
+        );
+
+        final result = await repository.getVerificationsByIds(['ver_1']);
+
+        expect(result, hasLength(1));
+        expect(result.first.id, 'ver_1');
+        expect(result.first.internalName, 'global_career');
+        expect(result.first.displayName, '직장 인증');
+      });
+
+      test(
+        'returns partial results and logs warning on TypeError (null field)',
+        () async {
+          // Simulate a record with null internal_name that will cause TypeError
+          final validJson = {
+            'id': 'ver_1',
+            'category': 'career',
+            'internal_name': 'global_career',
+            'display_name': '직장 인증',
+            'partner_id': null,
+            'description': 'Career verification',
+            'icon_key': 'briefcase',
+            'form_schema': <Map<String, dynamic>>[],
+            'is_active': true,
+            'created_at': now.toIso8601String(),
+          };
+
+          final invalidJson = {
+            'id': 'ver_2',
+            'category': 'asset',
+            'internal_name': null, // This will cause TypeError in fromJson
+            'display_name': '자산 인증',
+            'partner_id': null,
+            'description': 'Asset verification',
+            'icon_key': 'money',
+            'form_schema': <Map<String, dynamic>>[],
+            'is_active': true,
+            'created_at': now.toIso8601String(),
+          };
+
+          unawaited(
+            mockTable(
+              mockClient,
+              'verifications',
+              selectData: [validJson, invalidJson],
+            ),
+          );
+
+          // Should not throw, should return partial results
+          final result = await repository.getVerificationsByIds([
+            'ver_1',
+            'ver_2',
+          ]);
+
+          // Should have parsed the first valid record
+          expect(result, hasLength(1));
+          expect(result.first.id, 'ver_1');
+        },
+      );
+
+      test('rethrows non-TypeError/FormatException errors', () async {
+        unawaited(
+          mockTable(
+            mockClient,
+            'verifications',
+            shouldThrow: Exception('Network error'),
+          ),
+        );
+
+        expect(
+          () => repository.getVerificationsByIds(['ver_1']),
+          throwsException,
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- `getVerificationsByIds`의 outer catch에서 `TypeError`/`FormatException`은 graceful 처리 (빈 리스트 반환 + warning log)
- 네트워크/인증 에러 등 fatal 에러는 기존대로 rethrow 유지