### PR TITLE
feat(home): 밍글릿 로고 탭 시 scroll-to-top

### DIFF
--- a/apps/app_partner/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/apps/app_partner/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -18,7 +18,6 @@ import geolocator_apple
 import google_sign_in_ios
 import mobile_scanner
 import package_info_plus
-import path_provider_foundation
 import quill_native_bridge_macos
 import sentry_flutter
 import shared_preferences_foundation
@@ -40,7 +39,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   QuillNativeBridgePlugin.register(with: registry.registrar(forPlugin: "QuillNativeBridgePlugin"))
   SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:app_user/src/features/event/logic/event_coordinator.dart';
 import 'package:app_user/src/features/explore/providers/explore_state_provider.dart';
 import 'package:app_user/src/features/explore/widgets/filter_chip_bar.dart';
@@ -17,6 +19,20 @@ class HomePage extends ConsumerStatefulWidget {
 }
 
 class _HomePageState extends ConsumerState<HomePage> {
+  late ScrollController _scrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     final homeCoordinator = ref.read(homeCoordinatorProvider);
@@ -34,6 +50,7 @@ class _HomePageState extends ConsumerState<HomePage> {
           return false;
         },
         child: CustomScrollView(
+          controller: _scrollController,
           slivers: [
             SliverAppBar(
               floating: true,
@@ -42,7 +59,18 @@ class _HomePageState extends ConsumerState<HomePage> {
               title: Row(
                 children: [
                   const SizedBox(width: MinglitSpacing.medium),
-                  MinglitTheme.appBarLogo(height: 36),
+                  GestureDetector(
+                    onTap: () {
+                      unawaited(
+                        _scrollController.animateTo(
+                          0,
+                          duration: const Duration(milliseconds: 300),
+                          curve: Curves.easeOut,
+                        ),
+                      );
+                    },
+                    child: MinglitTheme.appBarLogo(height: 36),
+                  ),
                 ],
               ),
               actions: [

--- a/apps/app_user/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/apps/app_user/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -18,7 +18,6 @@ import flutter_secure_storage_darwin
 import geolocator_apple
 import google_sign_in_ios
 import package_info_plus
-import path_provider_foundation
 import quill_native_bridge_macos
 import screen_brightness_macos
 import sentry_flutter
@@ -42,7 +41,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   QuillNativeBridgePlugin.register(with: registry.registrar(forPlugin: "QuillNativeBridgePlugin"))
   ScreenBrightnessMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenBrightnessMacosPlugin"))
   SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))


### PR DESCRIPTION
## Summary

홈 상단 밍글릿 로고를 탭하면 리스트 맨 위로 부드럽게 스크롤합니다.

## Changes

- `apps/app_user/lib/src/features/home/home_page.dart`
  - `ScrollController` 추가 (initState 초기화 / dispose 해제)
  - `CustomScrollView`에 controller 연결
  - 로고를 `GestureDetector`로 감싸고 onTap → `animateTo(0, 300ms, easeOut)`
  - `unawaited()` 처리로 lint 경고 제거

## Verification
- `flutter analyze apps/app_user` → info 3건 (기존 파일, 신규 없음)