### PR TITLE
fix(ui): remove purple background bleed from event detail SliverAppBar

### DIFF
--- a/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
@@ -80,7 +80,7 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent> {
                     ? Text(
                         eventTitle,
                         style: theme.textTheme.titleMedium?.copyWith(
-                          color: theme.colorScheme.onPrimary,
+                          color: _showTitle ? theme.colorScheme.onSurface : theme.colorScheme.onPrimary,
                           fontWeight: FontWeight.w600,
                         ),
                       )
@@ -88,12 +88,35 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent> {
                 centerTitle: false,
                 flexibleSpace: FlexibleSpaceBar(
                   collapseMode: CollapseMode.pin,
-                  background: MinglitImageCarousel(
-                    imageUrls: party?.imageUrls ?? [],
-                    height: expandedHeight,
+                  background: Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      MinglitImageCarousel(
+                        imageUrls: party?.imageUrls ?? [],
+                        height: expandedHeight,
+                      ),
+                      Positioned(
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        height: topPadding + kToolbarHeight + 16,
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            gradient: LinearGradient(
+                              begin: Alignment.topCenter,
+                              end: Alignment.bottomCenter,
+                              colors: [
+                                Colors.black45,
+                                Colors.transparent,
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
                 ),
-                leading: BackButton(color: theme.colorScheme.onPrimary),
+                leading: BackButton(color: _showTitle ? theme.colorScheme.onSurface : Colors.white),
                 actions: [
                   IconButton(
                     onPressed: () {
@@ -107,7 +130,7 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent> {
                     },
                     icon: Icon(
                       Icons.share_outlined,
-                      color: theme.colorScheme.onPrimary,
+                      color: _showTitle ? theme.colorScheme.onSurface : Colors.white,
                     ),
                     tooltip: '공유하기',
                   ),
@@ -120,13 +143,13 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent> {
                         targetId: event.partyId, // Like the party
                         targetType: SocialTargetType.party,
                         interactionType: SocialInteractionType.like,
-                        activeColor: theme.colorScheme.onPrimary,
-                        inactiveColor: theme.colorScheme.onPrimary,
+                        activeColor: _showTitle ? theme.colorScheme.onSurface : Colors.white,
+                        inactiveColor: _showTitle ? theme.colorScheme.onSurface : Colors.white,
                         tooltip: '좋아요',
                       ),
                     ),
                 ],
-                backgroundColor: theme.colorScheme.primary,
+                backgroundColor: theme.scaffoldBackgroundColor,
               ),
 
               // 2. Main Info
@@ -257,17 +280,39 @@ class _EventDetailContentSkeleton extends StatelessWidget {
         SliverAppBar(
           expandedHeight: expandedHeight,
           pinned: true,
-          leading: BackButton(color: theme.colorScheme.onPrimary),
-          backgroundColor: theme.colorScheme.primary,
+          leading: const BackButton(),
+          backgroundColor: theme.scaffoldBackgroundColor,
           flexibleSpace: FlexibleSpaceBar(
             collapseMode: CollapseMode.pin,
-            background: MinglitSkeleton(
-              width: double.infinity,
-              height: expandedHeight,
+            background: Stack(
+              fit: StackFit.expand,
+              children: [
+                MinglitSkeleton(
+                  width: double.infinity,
+                  height: expandedHeight,
+                ),
+                Positioned(
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  height: topPadding + kToolbarHeight + 16,
+                  child: const DecoratedBox(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          Colors.black26,
+                          Colors.transparent,
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
         ),
-
         // 2. Main Info
         SliverToBoxAdapter(
           child: Padding(

--- a/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
@@ -54,6 +54,8 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent> {
     final partnerProfileImageUrl = partner?.profileImageUrl;
     final eventTitle = party?.title ?? event.title ?? '제목 없음';
     final user = ref.watch(currentUserProvider);
+    final iconColor =
+        _showTitle ? theme.colorScheme.onSurface : Colors.white;
 
     // Date Format
     final dateLabel = DateFormat(
@@ -80,7 +82,7 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent> {
                     ? Text(
                         eventTitle,
                         style: theme.textTheme.titleMedium?.copyWith(
-                          color: _showTitle ? theme.colorScheme.onSurface : theme.colorScheme.onPrimary,
+                          color: theme.colorScheme.onSurface,
                           fontWeight: FontWeight.w600,
                         ),
                       )
@@ -100,7 +102,7 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent> {
                         left: 0,
                         right: 0,
                         height: topPadding + kToolbarHeight + 16,
-                        child: DecoratedBox(
+                        child: const DecoratedBox(
                           decoration: BoxDecoration(
                             gradient: LinearGradient(
                               begin: Alignment.topCenter,
@@ -116,7 +118,7 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent> {
                     ],
                   ),
                 ),
-                leading: BackButton(color: _showTitle ? theme.colorScheme.onSurface : Colors.white),
+                leading: BackButton(color: iconColor),
                 actions: [
                   IconButton(
                     onPressed: () {
@@ -130,7 +132,7 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent> {
                     },
                     icon: Icon(
                       Icons.share_outlined,
-                      color: _showTitle ? theme.colorScheme.onSurface : Colors.white,
+                      color: iconColor,
                     ),
                     tooltip: '공유하기',
                   ),
@@ -143,8 +145,8 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent> {
                         targetId: event.partyId, // Like the party
                         targetType: SocialTargetType.party,
                         interactionType: SocialInteractionType.like,
-                        activeColor: _showTitle ? theme.colorScheme.onSurface : Colors.white,
-                        inactiveColor: _showTitle ? theme.colorScheme.onSurface : Colors.white,
+                        activeColor: iconColor,
+                        inactiveColor: iconColor,
                         tooltip: '좋아요',
                       ),
                     ),


### PR DESCRIPTION
## Summary

- Remove purple `backgroundColor` from `SliverAppBar` in event detail page (both main content and skeleton)
- Add gradient scrim overlay on hero image for icon visibility
- Dynamically switch icon/text colors based on collapsed state

## Fixes

Closes #43
Closes #44
Closes #45

## Changes

**File**: `apps/app_user/lib/src/features/event/detail/event_detail_content.dart`

- `backgroundColor: theme.colorScheme.primary` → `backgroundColor: theme.scaffoldBackgroundColor` on both SliverAppBars
- Added `iconColor` variable: white when expanded (image visible), dark when collapsed
- Added gradient scrim (`Colors.black45 → Colors.transparent`) in `FlexibleSpaceBar.background` as a `Stack` overlay
- Applied to both `_EventDetailContent` and `_EventDetailContentSkeleton`