### PR TITLE
feat(event): improve event detail page UI

### DIFF
--- a/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
@@ -173,10 +173,7 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent>
                             gradient: LinearGradient(
                               begin: Alignment.topCenter,
                               end: Alignment.bottomCenter,
-                              colors: [
-                                Colors.black45,
-                                Colors.transparent,
-                              ],
+                              colors: [Colors.black45, Colors.transparent],
                             ),
                           ),
                         ),
@@ -196,10 +193,7 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent>
                         ),
                       );
                     },
-                    icon: Icon(
-                      Icons.share_outlined,
-                      color: iconColor,
-                    ),
+                    icon: Icon(Icons.share_outlined, color: iconColor),
                     tooltip: '공유하기',
                   ),
                   if (user != null)
@@ -323,13 +317,6 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent>
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        '상세 소개',
-                        style: theme.textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      const SizedBox(height: MinglitSpacing.medium),
                       _QuillViewer(description: party?.description ?? {}),
                     ],
                   ),
@@ -495,10 +482,7 @@ class _EventDetailContentSkeleton extends StatelessWidget {
             background: Stack(
               fit: StackFit.expand,
               children: [
-                MinglitSkeleton(
-                  width: double.infinity,
-                  height: expandedHeight,
-                ),
+                MinglitSkeleton(width: double.infinity, height: expandedHeight),
                 Positioned(
                   top: 0,
                   left: 0,
@@ -509,10 +493,7 @@ class _EventDetailContentSkeleton extends StatelessWidget {
                       gradient: LinearGradient(
                         begin: Alignment.topCenter,
                         end: Alignment.bottomCenter,
-                        colors: [
-                          Colors.black26,
-                          Colors.transparent,
-                        ],
+                        colors: [Colors.black26, Colors.transparent],
                       ),
                     ),
                   ),

--- a/apps/app_user/lib/src/features/event/detail/event_entry_conditions_section.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_entry_conditions_section.dart
@@ -1,27 +1,34 @@
 part of 'event_detail_page.dart';
 
-class _EntryConditionsSection extends StatelessWidget {
+class _EntryConditionsSection extends ConsumerWidget {
   const _EntryConditionsSection({required this.event});
 
   final Event event;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final entryGroups = event.entryGroups ?? [];
+    final countsAsync = ref.watch(
+      entryGroupParticipantCountsProvider(event.id),
+    );
+    final counts = countsAsync.value ?? {};
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          '참여 자격',
+          '참여 현황',
           style: theme.textTheme.titleMedium?.copyWith(
             fontWeight: FontWeight.bold,
           ),
         ),
         const SizedBox(height: MinglitSpacing.medium),
         if (entryGroups.isEmpty)
-          const Text('별도의 참여 제한이 없습니다.')
+          Text(
+            '${event.currentParticipants}명 / ${event.maxParticipants}명',
+            style: theme.textTheme.bodyMedium,
+          )
         else
           ListView.separated(
             shrinkWrap: true,
@@ -47,6 +54,7 @@ class _EntryConditionsSection extends StatelessWidget {
                 (sum, t) => sum + t.quantity,
               );
               final showGauge = matchingTickets.isNotEmpty;
+              final participantCount = counts[group.id] ?? 0;
 
               return Stack(
                 children: [
@@ -59,9 +67,21 @@ class _EntryConditionsSection extends StatelessWidget {
                         color: theme.colorScheme.outlineVariant,
                       ),
                     ),
-                    child: EntryGroupDetail(
-                      group: group.toTemplate(),
-                      showVerificationBadges: false,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        EntryGroupDetail(
+                          group: group.toTemplate(),
+                          showVerificationBadges: false,
+                        ),
+                        const SizedBox(height: MinglitSpacing.xsmall),
+                        Text(
+                          '$participantCount명 참여',
+                          style: theme.textTheme.labelSmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
                     ),
                   ),
                   if (showGauge)

--- a/apps/app_user/lib/src/features/event/logic/event_detail_controller.dart
+++ b/apps/app_user/lib/src/features/event/logic/event_detail_controller.dart
@@ -11,3 +11,17 @@ class EventDetailController extends _$EventDetailController {
     return repository.getEventById(eventId);
   }
 }
+
+@riverpod
+Future<Map<String, int>> entryGroupParticipantCounts(
+  Ref ref,
+  String eventId,
+) async {
+  final repo = ref.read(eventRepositoryProvider);
+  final list = await repo.getEntryGroupParticipantCounts(eventId);
+  return {
+    for (final item in list)
+      item['entry_group_id'] as String: (item['participant_count'] as num)
+          .toInt(),
+  };
+}

--- a/apps/app_user/lib/src/features/event/logic/event_detail_controller.g.dart
+++ b/apps/app_user/lib/src/features/event/logic/event_detail_controller.g.dart
@@ -99,3 +99,81 @@ abstract class _$EventDetailController extends $AsyncNotifier<Event> {
     element.handleValue(ref, created);
   }
 }
+
+@ProviderFor(entryGroupParticipantCounts)
+const entryGroupParticipantCountsProvider =
+    EntryGroupParticipantCountsFamily._();
+
+final class EntryGroupParticipantCountsProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<Map<String, int>>,
+          Map<String, int>,
+          FutureOr<Map<String, int>>
+        >
+    with $FutureModifier<Map<String, int>>, $FutureProvider<Map<String, int>> {
+  const EntryGroupParticipantCountsProvider._({
+    required EntryGroupParticipantCountsFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'entryGroupParticipantCountsProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$entryGroupParticipantCountsHash();
+
+  @override
+  String toString() {
+    return r'entryGroupParticipantCountsProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<Map<String, int>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<Map<String, int>> create(Ref ref) {
+    final argument = this.argument as String;
+    return entryGroupParticipantCounts(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is EntryGroupParticipantCountsProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$entryGroupParticipantCountsHash() =>
+    r'7e9fe0ef2132acff2158b9d80790afcf731dbaf9';
+
+final class EntryGroupParticipantCountsFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<Map<String, int>>, String> {
+  const EntryGroupParticipantCountsFamily._()
+    : super(
+        retry: null,
+        name: r'entryGroupParticipantCountsProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  EntryGroupParticipantCountsProvider call(String eventId) =>
+      EntryGroupParticipantCountsProvider._(argument: eventId, from: this);
+
+  @override
+  String toString() => r'entryGroupParticipantCountsProvider';
+}

--- a/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_queries.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_queries.dart
@@ -205,6 +205,24 @@ mixin _EventRepositoryQueries on _SupabaseEventContext {
     return app != null && app.status != 'rejected' && app.status != 'cancelled';
   }
 
+  /// Fetches entry group participant counts for a specific event.
+  Future<List<Map<String, dynamic>>> getEntryGroupParticipantCounts(
+    String eventId,
+  ) async {
+    try {
+      final data =
+          await supabaseClient.rpc(
+                'get_entry_group_participant_counts',
+                params: {'p_event_id': eventId},
+              )
+              as List<dynamic>;
+      return data.cast<Map<String, dynamic>>();
+    } on Exception catch (e, st) {
+      Log.e('getEntryGroupParticipantCounts Error', e, st);
+      rethrow;
+    }
+  }
+
   /// Fetches the current user's purchase history.
   Future<List<EventApplication>> getMyPurchaseHistory(String userId) async {
     Log.d('getMyPurchaseHistory called | userId: $userId');
@@ -266,9 +284,7 @@ mixin _EventRepositoryQueries on _SupabaseEventContext {
           .map((item) => item as Map<String, dynamic>)
           .toList();
 
-      Log.d(
-        'getPersonalizedRecommendations success | count: ${result.length}',
-      );
+      Log.d('getPersonalizedRecommendations success | count: ${result.length}');
       return result;
     } catch (e, st) {
       Log.e('❌ [EventRepo] getPersonalizedRecommendations Error', e, st);

--- a/supabase/migrations/20260310000003_add_entry_group_participant_counts.sql
+++ b/supabase/migrations/20260310000003_add_entry_group_participant_counts.sql
@@ -1,0 +1,31 @@
+-- ============================================================
+-- RPC: get_entry_group_participant_counts
+-- 이벤트의 각 입장 그룹별 참여자 수를 반환
+-- ============================================================
+create or replace function public.get_entry_group_participant_counts(
+  p_event_id uuid
+)
+returns table (
+  entry_group_id uuid,
+  label text,
+  participant_count bigint
+)
+language sql
+security invoker
+stable
+as $$
+  select
+    eg.id as entry_group_id,
+    eg.label,
+    count(distinct ep.id) as participant_count
+  from public.entry_groups eg
+  left join public.tickets t
+    on eg.id = any(t.target_entry_group_ids)
+    and t.event_id = p_event_id
+  left join public.event_participants ep
+    on ep.ticket_id = t.id
+    and ep.event_id = p_event_id
+  where eg.event_id = p_event_id
+  group by eg.id, eg.label
+  order by eg.created_at;
+$$;


### PR DESCRIPTION
## Summary
- Remove "상세 소개" title from event detail page (description section)
- Add "참여 현황" section with per-entry-group participant counts via new Supabase RPC
- New migration: `get_entry_group_participant_counts` RPC function
- Add `getEntryGroupParticipantCounts` to EventRepository + Riverpod provider

Note: T1 (icon mint color) and T5 (partner detail route/navigation) were already on `dev`.