### PR TITLE
feat(block-report): add partner block/report system

### DIFF
--- a/apps/app_user/lib/l10n/app_ko.arb
+++ b/apps/app_user/lib/l10n/app_ko.arb
@@ -2,5 +2,21 @@
   "@@locale": "ko",
   "common_button_confirm": "확인",
   "common_button_cancel": "취소",
-  "common_error_system": "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
+  "common_error_system": "일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+  "reportReasonSexualContent": "선정적인 콘텐츠",
+  "reportReasonFalseInformation": "허위 또는 과장된 정보",
+  "reportReasonNoShow": "노쇼 / 이벤트 미진행",
+  "reportReasonFraud": "사기 또는 부당 청구",
+  "reportReasonOther": "기타",
+  "blockPartnerTitle": "차단하기",
+  "blockPartnerConfirm": "이 파트너를 차단하시겠습니까?\n이 파트너의 이벤트가 더 이상 표시되지 않습니다.",
+  "blockPartnerSuccess": "파트너가 차단되었습니다",
+  "reportPartnerTitle": "신고하기",
+  "reportPartnerDescription": "신고 이유를 선택해주세요",
+  "reportSuccess": "신고가 접수되었습니다",
+  "blockedPartnersTitle": "차단 목록",
+  "unblockPartner": "차단 해제",
+  "unblockPartnerConfirm": "이 파트너의 차단을 해제하시겠습니까?",
+  "blockedPartnersEmpty": "차단된 파트너가 없습니다",
+  "reportReasonOtherHint": "상세 사유를 입력해주세요"
 }

--- a/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
@@ -210,6 +210,73 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent>
                         tooltip: '좋아요',
                       ),
                     ),
+                  if (partner != null && user != null)
+                    PopupMenuButton<String>(
+                      icon: Icon(Icons.more_vert, color: iconColor),
+                      onSelected: (value) async {
+                        switch (value) {
+                          case 'block':
+                            final confirmed = await showDialog<bool>(
+                              context: context,
+                              builder: (ctx) => AlertDialog(
+                                title: const Text('차단하기'),
+                                content: const Text(
+                                  '이 파트너를 차단하시겠습니까?\n'
+                                  '이 파트너의 이벤트가 더 이상 표시되지 않습니다.',
+                                ),
+                                actions: [
+                                  TextButton(
+                                    onPressed: () => Navigator.pop(ctx, false),
+                                    child: const Text('취소'),
+                                  ),
+                                  TextButton(
+                                    onPressed: () => Navigator.pop(ctx, true),
+                                    child: const Text('차단'),
+                                  ),
+                                ],
+                              ),
+                            );
+                            if (confirmed == true && context.mounted) {
+                              await ref
+                                  .read(socialRepositoryProvider)
+                                  .blockPartner(partner.id);
+                              if (context.mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text('파트너가 차단되었습니다'),
+                                  ),
+                                );
+                              }
+                            }
+                          case 'report':
+                            if (context.mounted) {
+                              await showReportBottomSheet(
+                                context,
+                                ref,
+                                partner.id,
+                              );
+                            }
+                        }
+                      },
+                      itemBuilder: (_) => [
+                        const PopupMenuItem(
+                          value: 'block',
+                          child: ListTile(
+                            leading: Icon(Icons.block),
+                            title: Text('차단하기'),
+                            contentPadding: EdgeInsets.zero,
+                          ),
+                        ),
+                        const PopupMenuItem(
+                          value: 'report',
+                          child: ListTile(
+                            leading: Icon(Icons.flag),
+                            title: Text('신고하기'),
+                            contentPadding: EdgeInsets.zero,
+                          ),
+                        ),
+                      ],
+                    ),
                 ],
                 backgroundColor: theme.colorScheme.primary,
                 foregroundColor: Colors.white,

--- a/apps/app_user/lib/src/features/event/detail/event_detail_page.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_page.dart
@@ -4,6 +4,7 @@ import 'package:app_user/src/features/event/admission/event_admission_controller
 import 'package:app_user/src/features/event/detail/open_in_app_dialog.dart';
 import 'package:app_user/src/features/event/logic/event_coordinator.dart';
 import 'package:app_user/src/features/event/logic/event_detail_controller.dart';
+import 'package:app_user/src/features/event/detail/report_bottom_sheet.dart';
 import 'package:app_user/src/utils/share_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/apps/app_user/lib/src/features/event/detail/report_bottom_sheet.dart
+++ b/apps/app_user/lib/src/features/event/detail/report_bottom_sheet.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+Future<void> showReportBottomSheet(
+  BuildContext context,
+  WidgetRef ref,
+  String partnerId,
+) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    builder: (_) => _ReportSheet(partnerId: partnerId),
+  );
+}
+
+class _ReportSheet extends ConsumerStatefulWidget {
+  const _ReportSheet({required this.partnerId});
+  final String partnerId;
+
+  @override
+  ConsumerState<_ReportSheet> createState() => _ReportSheetState();
+}
+
+class _ReportSheetState extends ConsumerState<_ReportSheet> {
+  ReportReason? _selectedReason;
+  final _descriptionController = TextEditingController();
+  bool _submitting = false;
+
+  static const _reasonLabels = {
+    ReportReason.sexualContent: '선정적인 콘텐츠',
+    ReportReason.falseInformation: '허위 또는 과장된 정보',
+    ReportReason.noShow: '노쇼 / 이벤트 미진행',
+    ReportReason.fraud: '사기 또는 부당 청구',
+    ReportReason.other: '기타',
+  };
+
+  @override
+  void dispose() {
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (_selectedReason == null || _submitting) return;
+    setState(() => _submitting = true);
+    try {
+      await ref
+          .read(socialRepositoryProvider)
+          .reportPartner(
+            partnerId: widget.partnerId,
+            reason: _selectedReason!.value,
+            description: _selectedReason == ReportReason.other
+                ? _descriptionController.text.trim()
+                : null,
+          );
+      if (mounted) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('신고가 접수되었습니다')),
+        );
+      }
+    } on Object catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('신고 처리 중 오류가 발생했습니다')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _submitting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.viewInsetsOf(context).bottom,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const SizedBox(height: MinglitSpacing.medium),
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: MinglitSpacing.medium,
+            ),
+            child: Text(
+              '신고하기',
+              style: theme.textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          const SizedBox(height: MinglitSpacing.xsmall),
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: MinglitSpacing.medium,
+            ),
+            child: Text(
+              '신고 이유를 선택해주세요',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          const SizedBox(height: MinglitSpacing.small),
+          for (final reason in ReportReason.values)
+            RadioListTile<ReportReason>(
+              title: Text(_reasonLabels[reason] ?? reason.name),
+              value: reason,
+              groupValue: _selectedReason,
+              onChanged: (v) => setState(() => _selectedReason = v),
+            ),
+          if (_selectedReason == ReportReason.other)
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: MinglitSpacing.medium,
+              ),
+              child: TextField(
+                controller: _descriptionController,
+                decoration: const InputDecoration(
+                  hintText: '상세 사유를 입력해주세요',
+                  border: OutlineInputBorder(),
+                ),
+                maxLines: 3,
+              ),
+            ),
+          Padding(
+            padding: const EdgeInsets.all(MinglitSpacing.medium),
+            child: FilledButton(
+              onPressed: _selectedReason != null && !_submitting
+                  ? _submit
+                  : null,
+              child: _submitting
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('신고하기'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/app_user/lib/src/features/home/my_page.dart
+++ b/apps/app_user/lib/src/features/home/my_page.dart
@@ -1,5 +1,6 @@
 import 'package:app_user/src/features/auth/logic/auth_coordinator.dart';
 import 'package:app_user/src/features/home/logic/home_coordinator.dart';
+import 'package:app_user/src/features/settings/blocked_partners_page.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -119,6 +120,17 @@ class MyPage extends ConsumerWidget {
             onTap: homeCoordinator.pushNotificationSettings,
           ),
           const ThemeSettingsTile(),
+          ListTile(
+            leading: const Icon(Icons.block),
+            title: const Text('차단 목록'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute<void>(
+                builder: (_) => const BlockedPartnersPage(),
+              ),
+            ),
+          ),
           const Divider(),
           ListTile(
             leading: const Icon(Icons.logout, color: MinglitColors.error),

--- a/apps/app_user/lib/src/features/settings/blocked_partners_page.dart
+++ b/apps/app_user/lib/src/features/settings/blocked_partners_page.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+class BlockedPartnersPage extends ConsumerStatefulWidget {
+  const BlockedPartnersPage({super.key});
+
+  @override
+  ConsumerState<BlockedPartnersPage> createState() =>
+      _BlockedPartnersPageState();
+}
+
+class _BlockedPartnersPageState extends ConsumerState<BlockedPartnersPage> {
+  List<Map<String, dynamic>>? _partners;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    final data = await ref.read(socialRepositoryProvider).getBlockedPartners();
+    if (mounted) {
+      setState(() {
+        _partners = data;
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _unblock(String partnerId) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('차단 해제'),
+        content: const Text('이 파트너의 차단을 해제하시겠습니까?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('취소'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('해제'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    await ref.read(socialRepositoryProvider).unblockPartner(partnerId);
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('차단이 해제되었습니다')),
+      );
+      _load();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(title: const Text('차단 목록')),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _partners == null || _partners!.isEmpty
+          ? Center(
+              child: Text(
+                '차단된 파트너가 없습니다',
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            )
+          : ListView.builder(
+              itemCount: _partners!.length,
+              itemBuilder: (context, index) {
+                final p = _partners![index];
+                final id = p['id'] as String;
+                final name = p['name'] as String? ?? '';
+                final imageUrl = p['profile_image_url'] as String?;
+                return ListTile(
+                  leading: CircleAvatar(
+                    backgroundImage: imageUrl != null
+                        ? NetworkImage(imageUrl)
+                        : null,
+                    child: imageUrl == null ? const Icon(Icons.store) : null,
+                  ),
+                  title: Text(name),
+                  trailing: TextButton(
+                    onPressed: () => _unblock(id),
+                    child: const Text('차단 해제'),
+                  ),
+                );
+              },
+            ),
+    );
+  }
+}

--- a/shared/packages/minglit_kit/lib/minglit_data.dart
+++ b/shared/packages/minglit_kit/lib/minglit_data.dart
@@ -16,6 +16,7 @@ export 'src/data/models/partner.dart';
 export 'src/data/models/partner_application.dart';
 export 'src/data/models/party.dart';
 export 'src/data/models/party_entry_group.dart';
+export 'src/data/models/report_detail.dart';
 export 'src/data/models/social_interaction.dart';
 export 'src/data/models/ticket.dart';
 export 'src/data/models/ticket_template.dart';

--- a/shared/packages/minglit_kit/lib/src/data/models/report_detail.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/report_detail.dart
@@ -1,0 +1,32 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:minglit_kit/src/data/models/social_interaction.dart';
+
+part 'report_detail.freezed.dart';
+part 'report_detail.g.dart';
+
+enum ReportReason {
+  sexualContent('sexual_content'),
+  falseInformation('false_information'),
+  noShow('no_show'),
+  fraud('fraud'),
+  other('other');
+
+  const ReportReason(this.value);
+  final String value;
+}
+
+@freezed
+abstract class ReportDetail with _$ReportDetail {
+  const factory ReportDetail({
+    required String id,
+    @JsonKey(name: 'user_id') required String userId,
+    @JsonKey(name: 'target_id') required String targetId,
+    @JsonKey(name: 'target_type') required SocialTargetType targetType,
+    required String reason,
+    String? description,
+    @JsonKey(name: 'created_at') required DateTime createdAt,
+  }) = _ReportDetail;
+
+  factory ReportDetail.fromJson(Map<String, dynamic> json) =>
+      _$ReportDetailFromJson(json);
+}

--- a/shared/packages/minglit_kit/lib/src/data/models/report_detail.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/report_detail.freezed.dart
@@ -1,0 +1,295 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'report_detail.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$ReportDetail {
+
+ String get id;@JsonKey(name: 'user_id') String get userId;@JsonKey(name: 'target_id') String get targetId;@JsonKey(name: 'target_type') SocialTargetType get targetType; String get reason; String? get description;@JsonKey(name: 'created_at') DateTime get createdAt;
+/// Create a copy of ReportDetail
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ReportDetailCopyWith<ReportDetail> get copyWith => _$ReportDetailCopyWithImpl<ReportDetail>(this as ReportDetail, _$identity);
+
+  /// Serializes this ReportDetail to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ReportDetail&&(identical(other.id, id) || other.id == id)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.targetId, targetId) || other.targetId == targetId)&&(identical(other.targetType, targetType) || other.targetType == targetType)&&(identical(other.reason, reason) || other.reason == reason)&&(identical(other.description, description) || other.description == description)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,userId,targetId,targetType,reason,description,createdAt);
+
+@override
+String toString() {
+  return 'ReportDetail(id: $id, userId: $userId, targetId: $targetId, targetType: $targetType, reason: $reason, description: $description, createdAt: $createdAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ReportDetailCopyWith<$Res>  {
+  factory $ReportDetailCopyWith(ReportDetail value, $Res Function(ReportDetail) _then) = _$ReportDetailCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(name: 'user_id') String userId,@JsonKey(name: 'target_id') String targetId,@JsonKey(name: 'target_type') SocialTargetType targetType, String reason, String? description,@JsonKey(name: 'created_at') DateTime createdAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$ReportDetailCopyWithImpl<$Res>
+    implements $ReportDetailCopyWith<$Res> {
+  _$ReportDetailCopyWithImpl(this._self, this._then);
+
+  final ReportDetail _self;
+  final $Res Function(ReportDetail) _then;
+
+/// Create a copy of ReportDetail
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? userId = null,Object? targetId = null,Object? targetType = null,Object? reason = null,Object? description = freezed,Object? createdAt = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,targetId: null == targetId ? _self.targetId : targetId // ignore: cast_nullable_to_non_nullable
+as String,targetType: null == targetType ? _self.targetType : targetType // ignore: cast_nullable_to_non_nullable
+as SocialTargetType,reason: null == reason ? _self.reason : reason // ignore: cast_nullable_to_non_nullable
+as String,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [ReportDetail].
+extension ReportDetailPatterns on ReportDetail {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ReportDetail value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ReportDetail() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ReportDetail value)  $default,){
+final _that = this;
+switch (_that) {
+case _ReportDetail():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ReportDetail value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ReportDetail() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'target_id')  String targetId, @JsonKey(name: 'target_type')  SocialTargetType targetType,  String reason,  String? description, @JsonKey(name: 'created_at')  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ReportDetail() when $default != null:
+return $default(_that.id,_that.userId,_that.targetId,_that.targetType,_that.reason,_that.description,_that.createdAt);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'target_id')  String targetId, @JsonKey(name: 'target_type')  SocialTargetType targetType,  String reason,  String? description, @JsonKey(name: 'created_at')  DateTime createdAt)  $default,) {final _that = this;
+switch (_that) {
+case _ReportDetail():
+return $default(_that.id,_that.userId,_that.targetId,_that.targetType,_that.reason,_that.description,_that.createdAt);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'target_id')  String targetId, @JsonKey(name: 'target_type')  SocialTargetType targetType,  String reason,  String? description, @JsonKey(name: 'created_at')  DateTime createdAt)?  $default,) {final _that = this;
+switch (_that) {
+case _ReportDetail() when $default != null:
+return $default(_that.id,_that.userId,_that.targetId,_that.targetType,_that.reason,_that.description,_that.createdAt);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _ReportDetail implements ReportDetail {
+  const _ReportDetail({required this.id, @JsonKey(name: 'user_id') required this.userId, @JsonKey(name: 'target_id') required this.targetId, @JsonKey(name: 'target_type') required this.targetType, required this.reason, this.description, @JsonKey(name: 'created_at') required this.createdAt});
+  factory _ReportDetail.fromJson(Map<String, dynamic> json) => _$ReportDetailFromJson(json);
+
+@override final  String id;
+@override@JsonKey(name: 'user_id') final  String userId;
+@override@JsonKey(name: 'target_id') final  String targetId;
+@override@JsonKey(name: 'target_type') final  SocialTargetType targetType;
+@override final  String reason;
+@override final  String? description;
+@override@JsonKey(name: 'created_at') final  DateTime createdAt;
+
+/// Create a copy of ReportDetail
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ReportDetailCopyWith<_ReportDetail> get copyWith => __$ReportDetailCopyWithImpl<_ReportDetail>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ReportDetailToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ReportDetail&&(identical(other.id, id) || other.id == id)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.targetId, targetId) || other.targetId == targetId)&&(identical(other.targetType, targetType) || other.targetType == targetType)&&(identical(other.reason, reason) || other.reason == reason)&&(identical(other.description, description) || other.description == description)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,userId,targetId,targetType,reason,description,createdAt);
+
+@override
+String toString() {
+  return 'ReportDetail(id: $id, userId: $userId, targetId: $targetId, targetType: $targetType, reason: $reason, description: $description, createdAt: $createdAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$ReportDetailCopyWith<$Res> implements $ReportDetailCopyWith<$Res> {
+  factory _$ReportDetailCopyWith(_ReportDetail value, $Res Function(_ReportDetail) _then) = __$ReportDetailCopyWithImpl;
+@override @useResult
+$Res call({
+ String id,@JsonKey(name: 'user_id') String userId,@JsonKey(name: 'target_id') String targetId,@JsonKey(name: 'target_type') SocialTargetType targetType, String reason, String? description,@JsonKey(name: 'created_at') DateTime createdAt
+});
+
+
+
+
+}
+/// @nodoc
+class __$ReportDetailCopyWithImpl<$Res>
+    implements _$ReportDetailCopyWith<$Res> {
+  __$ReportDetailCopyWithImpl(this._self, this._then);
+
+  final _ReportDetail _self;
+  final $Res Function(_ReportDetail) _then;
+
+/// Create a copy of ReportDetail
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? userId = null,Object? targetId = null,Object? targetType = null,Object? reason = null,Object? description = freezed,Object? createdAt = null,}) {
+  return _then(_ReportDetail(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,targetId: null == targetId ? _self.targetId : targetId // ignore: cast_nullable_to_non_nullable
+as String,targetType: null == targetType ? _self.targetType : targetType // ignore: cast_nullable_to_non_nullable
+as SocialTargetType,reason: null == reason ? _self.reason : reason // ignore: cast_nullable_to_non_nullable
+as String,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/report_detail.g.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/report_detail.g.dart
@@ -1,0 +1,36 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'report_detail.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_ReportDetail _$ReportDetailFromJson(Map<String, dynamic> json) =>
+    _ReportDetail(
+      id: json['id'] as String,
+      userId: json['user_id'] as String,
+      targetId: json['target_id'] as String,
+      targetType: $enumDecode(_$SocialTargetTypeEnumMap, json['target_type']),
+      reason: json['reason'] as String,
+      description: json['description'] as String?,
+      createdAt: DateTime.parse(json['created_at'] as String),
+    );
+
+Map<String, dynamic> _$ReportDetailToJson(_ReportDetail instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'user_id': instance.userId,
+      'target_id': instance.targetId,
+      'target_type': _$SocialTargetTypeEnumMap[instance.targetType]!,
+      'reason': instance.reason,
+      'description': instance.description,
+      'created_at': instance.createdAt.toIso8601String(),
+    };
+
+const _$SocialTargetTypeEnumMap = {
+  SocialTargetType.party: 'party',
+  SocialTargetType.partner: 'partner',
+  SocialTargetType.review: 'review',
+  SocialTargetType.comment: 'comment',
+};

--- a/shared/packages/minglit_kit/lib/src/data/models/social_interaction.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/social_interaction.dart
@@ -31,6 +31,9 @@ enum SocialInteractionType {
 
   /// Indicates a block action.
   block,
+
+  /// Indicates a report action.
+  report,
 }
 
 /// Represents a user interaction with a social target.

--- a/shared/packages/minglit_kit/lib/src/data/models/social_interaction.g.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/social_interaction.g.dart
@@ -42,4 +42,5 @@ const _$SocialInteractionTypeEnumMap = {
   SocialInteractionType.subscribe: 'subscribe',
   SocialInteractionType.bookmark: 'bookmark',
   SocialInteractionType.block: 'block',
+  SocialInteractionType.report: 'report',
 };

--- a/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_queries.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_queries.dart
@@ -58,6 +58,7 @@ mixin _EventRepositoryQueries on _SupabaseEventContext {
     double? latitude,
     double? longitude,
     int limit = 10,
+    Set<String>? blockedPartnerIds,
   }) async {
     Log.d('getEventsByType called | type: $type');
     try {
@@ -108,11 +109,24 @@ mixin _EventRepositoryQueries on _SupabaseEventContext {
           query = query.order('created_at', ascending: false);
       }
 
+      final queryLimit =
+          blockedPartnerIds != null && blockedPartnerIds.isNotEmpty
+          ? (limit * 2).clamp(limit, 30)
+          : limit;
       final data =
-          await (query as PostgrestTransformBuilder).limit(limit) as List;
-      final result = data.map((json) {
+          await (query as PostgrestTransformBuilder).limit(queryLimit) as List;
+      var result = data.map((json) {
         return Event.fromJson(json as Map<String, dynamic>);
       }).toList();
+
+      if (blockedPartnerIds != null && blockedPartnerIds.isNotEmpty) {
+        result = result
+            .where(
+              (e) => !blockedPartnerIds.contains(e.party?.partner?.id),
+            )
+            .take(limit)
+            .toList();
+      }
 
       Log.d('getEventsByType success | count: ${result.length}');
       return result;

--- a/shared/packages/minglit_kit/lib/src/data/repositories/social_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/social_repository.dart
@@ -93,6 +93,98 @@ class SocialRepository {
     }
   }
 
+  Future<void> blockPartner(String partnerId) async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) throw Exception('User not authenticated');
+    try {
+      await _supabase.from('social_interactions').upsert({
+        'user_id': userId,
+        'target_id': partnerId,
+        'target_type': SocialTargetType.partner.name,
+        'interaction_type': SocialInteractionType.block.name,
+      });
+    } on Object catch (e, st) {
+      Log.e('blockPartner Error', e, st);
+      rethrow;
+    }
+  }
+
+  Future<void> unblockPartner(String partnerId) async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) throw Exception('User not authenticated');
+    try {
+      await _supabase
+          .from('social_interactions')
+          .delete()
+          .eq('user_id', userId)
+          .eq('target_id', partnerId)
+          .eq('interaction_type', SocialInteractionType.block.name);
+    } on Object catch (e, st) {
+      Log.e('unblockPartner Error', e, st);
+      rethrow;
+    }
+  }
+
+  Future<void> reportPartner({
+    required String partnerId,
+    required String reason,
+    String? description,
+  }) async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) throw Exception('User not authenticated');
+    try {
+      await blockPartner(partnerId);
+      await _supabase.from('social_interactions').upsert({
+        'user_id': userId,
+        'target_id': partnerId,
+        'target_type': SocialTargetType.partner.name,
+        'interaction_type': SocialInteractionType.report.name,
+      });
+      await _supabase.from('report_details').insert({
+        'user_id': userId,
+        'target_id': partnerId,
+        'target_type': SocialTargetType.partner.name,
+        'reason': reason,
+        if (description != null) 'description': description,
+      });
+    } on Object catch (e, st) {
+      Log.e('reportPartner Error', e, st);
+      rethrow;
+    }
+  }
+
+  Future<List<String>> getBlockedPartnerIds() async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) return [];
+    try {
+      final data = await _supabase
+          .from('social_interactions')
+          .select('target_id')
+          .eq('user_id', userId)
+          .eq('target_type', SocialTargetType.partner.name)
+          .eq('interaction_type', SocialInteractionType.block.name);
+      return data.map<String>((row) => row['target_id'] as String).toList();
+    } on Object catch (e, st) {
+      Log.e('getBlockedPartnerIds Error', e, st);
+      return [];
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> getBlockedPartners() async {
+    final ids = await getBlockedPartnerIds();
+    if (ids.isEmpty) return [];
+    try {
+      final data = await _supabase
+          .from('partners')
+          .select('id, name, profile_image_url')
+          .inFilter('id', ids);
+      return data.cast<Map<String, dynamic>>();
+    } on Object catch (e, st) {
+      Log.e('getBlockedPartners Error', e, st);
+      return [];
+    }
+  }
+
   /// Gets the total count of a specific interaction type for a target.
   Future<int> getInteractionCount({
     required String targetId,

--- a/supabase/migrations/20260310000003_add_block_report_system.sql
+++ b/supabase/migrations/20260310000003_add_block_report_system.sql
@@ -1,0 +1,205 @@
+ALTER TYPE public.social_interaction_type ADD VALUE IF NOT EXISTS 'report';
+
+-- ============================================================
+-- report_details table
+-- ============================================================
+
+CREATE TABLE public.report_details (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  target_id uuid NOT NULL,
+  target_type public.social_target_type NOT NULL,
+  reason text NOT NULL,
+  description text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.report_details ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can insert own reports" ON public.report_details FOR INSERT TO authenticated WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can view own reports" ON public.report_details FOR SELECT TO authenticated USING (auth.uid() = user_id);
+GRANT SELECT, INSERT ON public.report_details TO authenticated;
+
+-- ============================================================
+-- search_events_pgroonga: add block filter
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.search_events_pgroonga(query text)
+RETURNS SETOF public.events
+LANGUAGE sql STABLE SECURITY INVOKER AS $$
+  SELECT e.* FROM public.events e
+  JOIN public.parties p ON e.party_id = p.id
+  WHERE query <> ''
+    AND p.title &@~ query
+    AND e.status = 'scheduled'
+    AND e.start_time >= now()
+    AND NOT EXISTS (SELECT 1 FROM public.social_interactions si WHERE si.user_id = auth.uid() AND si.target_id = p.partner_id AND si.interaction_type = 'block')
+  ORDER BY e.start_time ASC
+  LIMIT 20;
+$$;
+
+-- ============================================================
+-- search_parties_pgroonga: add block filter
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.search_parties_pgroonga(query text)
+RETURNS SETOF public.parties
+LANGUAGE sql STABLE SECURITY INVOKER AS $$
+  SELECT p.* FROM public.parties p
+  WHERE query <> ''
+    AND p.title &@~ query
+    AND NOT EXISTS (SELECT 1 FROM public.social_interactions si WHERE si.user_id = auth.uid() AND si.target_id = p.partner_id AND si.interaction_type = 'block')
+  LIMIT 20;
+$$;
+
+-- ============================================================
+-- get_personalized_recommendations: add block filter
+-- ============================================================
+
+create or replace function public.get_personalized_recommendations(
+  p_user_id uuid,
+  p_limit int default 10
+)
+returns table (
+  event_id uuid,
+  event_title text,
+  event_description jsonb,
+  event_image_urls text[],
+  event_start_time timestamptz,
+  event_end_time timestamptz,
+  event_status text,
+  event_max_participants int,
+  event_current_participants int,
+  party_id uuid,
+  party_title text,
+  party_image_urls text[],
+  location_id uuid,
+  location_name text,
+  location_address text,
+  location_lat double precision,
+  location_lng double precision,
+  similarity_score double precision
+)
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+declare
+  v_user_embedding extensions.vector(1536);
+begin
+  select ue.embedding into v_user_embedding
+  from public.user_embeddings ue
+  where ue.user_id = p_user_id;
+
+  if v_user_embedding is null then
+    return;
+  end if;
+
+  return query
+  select
+    e.id as event_id,
+    e.title as event_title,
+    e.description as event_description,
+    coalesce(e.image_urls, p.image_urls) as event_image_urls,
+    e.start_time as event_start_time,
+    e.end_time as event_end_time,
+    e.status as event_status,
+    e.max_participants as event_max_participants,
+    e.current_participants as event_current_participants,
+    p.id as party_id,
+    p.title as party_title,
+    p.image_urls as party_image_urls,
+    l.id as location_id,
+    l.name as location_name,
+    l.address as location_address,
+    st_y(l.geo_point::geometry) as location_lat,
+    st_x(l.geo_point::geometry) as location_lng,
+    1 - (pe.embedding <=> v_user_embedding) as similarity_score
+  from public.party_embeddings pe
+  join public.parties p on p.id = pe.party_id
+  join public.events e on e.party_id = p.id
+  left join public.locations l on l.id = coalesce(e.location_id, p.location_id)
+  where e.status = 'scheduled'
+    and e.start_time >= now()
+    and pe.embedding is not null
+    and not exists (select 1 from public.social_interactions si where si.user_id = p_user_id and si.target_id = p.partner_id and si.interaction_type = 'block')
+  order by pe.embedding <=> v_user_embedding asc
+  limit p_limit;
+end;
+$$;
+
+comment on function public.get_personalized_recommendations is
+  'Returns personalized event recommendations based on pgvector cosine similarity between user and party embeddings';
+
+-- ============================================================
+-- get_events_within_radius: add p_user_id + block filter
+-- ============================================================
+
+create or replace function public.get_events_within_radius(
+  p_lat double precision,
+  p_lng double precision,
+  p_radius_meters int default 5000,
+  p_limit int default 20,
+  p_user_id uuid default null
+)
+returns table (
+  event_id uuid,
+  event_title text,
+  event_description jsonb,
+  event_image_urls text[],
+  event_start_time timestamptz,
+  event_end_time timestamptz,
+  event_status text,
+  event_max_participants int,
+  event_current_participants int,
+  party_id uuid,
+  party_title text,
+  party_image_urls text[],
+  location_id uuid,
+  location_name text,
+  location_address text,
+  location_lat double precision,
+  location_lng double precision,
+  distance_meters double precision
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_point geography;
+begin
+  v_point := st_makepoint(p_lng, p_lat)::geography;
+
+  return query
+  select
+    e.id as event_id,
+    e.title as event_title,
+    e.description as event_description,
+    coalesce(e.image_urls, p.image_urls) as event_image_urls,
+    e.start_time as event_start_time,
+    e.end_time as event_end_time,
+    e.status as event_status,
+    e.max_participants as event_max_participants,
+    e.current_participants as event_current_participants,
+    p.id as party_id,
+    p.title as party_title,
+    p.image_urls as party_image_urls,
+    l.id as location_id,
+    l.name as location_name,
+    l.address as location_address,
+    st_y(l.geo_point::geometry) as location_lat,
+    st_x(l.geo_point::geometry) as location_lng,
+    st_distance(l.geo_point, v_point) as distance_meters
+  from public.events e
+  join public.parties p on p.id = e.party_id
+  join public.locations l on l.id = coalesce(e.location_id, p.location_id)
+  where e.status = 'scheduled'
+    and e.start_time >= now()
+    and l.geo_point is not null
+    and st_dwithin(l.geo_point, v_point, p_radius_meters)
+    and (p_user_id is null or not exists (select 1 from public.social_interactions si where si.user_id = p_user_id and si.target_id = p.partner_id and si.interaction_type = 'block'))
+  order by st_distance(l.geo_point, v_point) asc
+  limit p_limit;
+end;
+$$;


### PR DESCRIPTION
## Summary
- DB migration: `report` enum value + `report_details` table + block filters on 4 RPCs (search_events_pgroonga, search_parties_pgroonga, get_personalized_recommendations, get_events_within_radius)
- Flutter models: `SocialInteractionType.report`, `ReportDetail` Freezed model, `ReportReason` enum
- Repository: `blockPartner`, `unblockPartner`, `reportPartner`, `getBlockedPartnerIds`, `getBlockedPartners`
- Feed filtering: `getEventsByType` post-processing filter for blocked partners
- UI: ⋮ overflow menu on event detail page (차단하기 + 신고하기)
- UI: Report reason bottom sheet with 5 options + "기타" text input
- UI: Blocked partners management page (설정 > 차단 목록)
- l10n: Korean strings for all block/report UI

Skipped per user request: pgTAP tests, Flutter unit tests, integration QA, final verification.