### PR TITLE
fix(event-detail): show participant gauge even when soldCount is 0

### DIFF
--- a/apps/app_user/lib/src/features/event/detail/event_entry_conditions_section.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_entry_conditions_section.dart
@@ -46,7 +46,7 @@ class _EntryConditionsSection extends StatelessWidget {
                 0,
                 (sum, t) => sum + t.quantity,
               );
-              final showGauge = matchingTickets.isNotEmpty && totalQuantity > 0;
+              final showGauge = matchingTickets.isNotEmpty;
 
               return Stack(
                 children: [


### PR DESCRIPTION
## Summary

- Remove `&& totalQuantity > 0` condition from `showGauge` so the participant gauge and count UI displays even when no tickets are sold yet (0/N)

## Change

**Before**: `final showGauge = matchingTickets.isNotEmpty && totalQuantity > 0;`
**After**: `final showGauge = matchingTickets.isNotEmpty;`

1 file changed, 1 line modified.