### PR TITLE
fix(ui): show placeholder in image carousel when no images available

### DIFF
--- a/apps/app_user/lib/src/features/event/detail/event_detail_page.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_page.dart
@@ -2,9 +2,9 @@ import 'dart:async';
 
 import 'package:app_user/src/features/event/admission/event_admission_controller.dart';
 import 'package:app_user/src/features/event/detail/open_in_app_dialog.dart';
+import 'package:app_user/src/features/event/detail/report_bottom_sheet.dart';
 import 'package:app_user/src/features/event/logic/event_coordinator.dart';
 import 'package:app_user/src/features/event/logic/event_detail_controller.dart';
-import 'package:app_user/src/features/event/detail/report_bottom_sheet.dart';
 import 'package:app_user/src/utils/share_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -12,14 +12,14 @@ import 'package:flutter_quill/flutter_quill.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
-part 'event_detail_content.dart';
-part 'event_info_tile.dart';
-part 'event_quill_viewer.dart';
-part 'event_entry_conditions_section.dart';
 part 'event_bottom_ticket_bar.dart';
+part 'event_detail_content.dart';
+part 'event_entry_conditions_section.dart';
+part 'event_info_tile.dart';
 part 'event_participation_section.dart';
-part 'event_verification_section.dart';
+part 'event_quill_viewer.dart';
 part 'event_refund_policy_section.dart';
+part 'event_verification_section.dart';
 
 class EventDetailPage extends ConsumerWidget {
   const EventDetailPage({required this.eventId, super.key});

--- a/apps/app_user/lib/src/features/event/detail/report_bottom_sheet.dart
+++ b/apps/app_user/lib/src/features/event/detail/report_bottom_sheet.dart
@@ -26,7 +26,7 @@ class _ReportSheetState extends ConsumerState<_ReportSheet> {
   final _descriptionController = TextEditingController();
   bool _submitting = false;
 
-  static const _reasonLabels = {
+  static const Map<ReportReason, String> _reasonLabels = {
     ReportReason.sexualContent: '선정적인 콘텐츠',
     ReportReason.falseInformation: '허위 또는 과장된 정보',
     ReportReason.noShow: '노쇼 / 이벤트 미진행',

--- a/apps/app_user/lib/src/l10n/generated/app_localizations.dart
+++ b/apps/app_user/lib/src/l10n/generated/app_localizations.dart
@@ -111,6 +111,102 @@ abstract class AppLocalizations {
   /// In ko, this message translates to:
   /// **'일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'**
   String get common_error_system;
+
+  /// No description provided for @reportReasonSexualContent.
+  ///
+  /// In ko, this message translates to:
+  /// **'선정적인 콘텐츠'**
+  String get reportReasonSexualContent;
+
+  /// No description provided for @reportReasonFalseInformation.
+  ///
+  /// In ko, this message translates to:
+  /// **'허위 또는 과장된 정보'**
+  String get reportReasonFalseInformation;
+
+  /// No description provided for @reportReasonNoShow.
+  ///
+  /// In ko, this message translates to:
+  /// **'노쇼 / 이벤트 미진행'**
+  String get reportReasonNoShow;
+
+  /// No description provided for @reportReasonFraud.
+  ///
+  /// In ko, this message translates to:
+  /// **'사기 또는 부당 청구'**
+  String get reportReasonFraud;
+
+  /// No description provided for @reportReasonOther.
+  ///
+  /// In ko, this message translates to:
+  /// **'기타'**
+  String get reportReasonOther;
+
+  /// No description provided for @blockPartnerTitle.
+  ///
+  /// In ko, this message translates to:
+  /// **'차단하기'**
+  String get blockPartnerTitle;
+
+  /// No description provided for @blockPartnerConfirm.
+  ///
+  /// In ko, this message translates to:
+  /// **'이 파트너를 차단하시겠습니까?\n이 파트너의 이벤트가 더 이상 표시되지 않습니다.'**
+  String get blockPartnerConfirm;
+
+  /// No description provided for @blockPartnerSuccess.
+  ///
+  /// In ko, this message translates to:
+  /// **'파트너가 차단되었습니다'**
+  String get blockPartnerSuccess;
+
+  /// No description provided for @reportPartnerTitle.
+  ///
+  /// In ko, this message translates to:
+  /// **'신고하기'**
+  String get reportPartnerTitle;
+
+  /// No description provided for @reportPartnerDescription.
+  ///
+  /// In ko, this message translates to:
+  /// **'신고 이유를 선택해주세요'**
+  String get reportPartnerDescription;
+
+  /// No description provided for @reportSuccess.
+  ///
+  /// In ko, this message translates to:
+  /// **'신고가 접수되었습니다'**
+  String get reportSuccess;
+
+  /// No description provided for @blockedPartnersTitle.
+  ///
+  /// In ko, this message translates to:
+  /// **'차단 목록'**
+  String get blockedPartnersTitle;
+
+  /// No description provided for @unblockPartner.
+  ///
+  /// In ko, this message translates to:
+  /// **'차단 해제'**
+  String get unblockPartner;
+
+  /// No description provided for @unblockPartnerConfirm.
+  ///
+  /// In ko, this message translates to:
+  /// **'이 파트너의 차단을 해제하시겠습니까?'**
+  String get unblockPartnerConfirm;
+
+  /// No description provided for @blockedPartnersEmpty.
+  ///
+  /// In ko, this message translates to:
+  /// **'차단된 파트너가 없습니다'**
+  String get blockedPartnersEmpty;
+
+  /// No description provided for @reportReasonOtherHint.
+  ///
+  /// In ko, this message translates to:
+  /// **'상세 사유를 입력해주세요'**
+  String get reportReasonOtherHint;
 }
 
 class _AppLocalizationsDelegate

--- a/apps/app_user/lib/src/l10n/generated/app_localizations_ko.dart
+++ b/apps/app_user/lib/src/l10n/generated/app_localizations_ko.dart
@@ -16,4 +16,53 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get common_error_system => '일시적인 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+
+  @override
+  String get reportReasonSexualContent => '선정적인 콘텐츠';
+
+  @override
+  String get reportReasonFalseInformation => '허위 또는 과장된 정보';
+
+  @override
+  String get reportReasonNoShow => '노쇼 / 이벤트 미진행';
+
+  @override
+  String get reportReasonFraud => '사기 또는 부당 청구';
+
+  @override
+  String get reportReasonOther => '기타';
+
+  @override
+  String get blockPartnerTitle => '차단하기';
+
+  @override
+  String get blockPartnerConfirm =>
+      '이 파트너를 차단하시겠습니까?\n이 파트너의 이벤트가 더 이상 표시되지 않습니다.';
+
+  @override
+  String get blockPartnerSuccess => '파트너가 차단되었습니다';
+
+  @override
+  String get reportPartnerTitle => '신고하기';
+
+  @override
+  String get reportPartnerDescription => '신고 이유를 선택해주세요';
+
+  @override
+  String get reportSuccess => '신고가 접수되었습니다';
+
+  @override
+  String get blockedPartnersTitle => '차단 목록';
+
+  @override
+  String get unblockPartner => '차단 해제';
+
+  @override
+  String get unblockPartnerConfirm => '이 파트너의 차단을 해제하시겠습니까?';
+
+  @override
+  String get blockedPartnersEmpty => '차단된 파트너가 없습니다';
+
+  @override
+  String get reportReasonOtherHint => '상세 사유를 입력해주세요';
 }

--- a/shared/packages/minglit_kit/lib/src/data/models/report_detail.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/report_detail.dart
@@ -9,7 +9,8 @@ enum ReportReason {
   falseInformation('false_information'),
   noShow('no_show'),
   fraud('fraud'),
-  other('other');
+  other('other')
+  ;
 
   const ReportReason(this.value);
   final String value;
@@ -23,8 +24,8 @@ abstract class ReportDetail with _$ReportDetail {
     @JsonKey(name: 'target_id') required String targetId,
     @JsonKey(name: 'target_type') required SocialTargetType targetType,
     required String reason,
-    String? description,
     @JsonKey(name: 'created_at') required DateTime createdAt,
+    String? description,
   }) = _ReportDetail;
 
   factory ReportDetail.fromJson(Map<String, dynamic> json) =>

--- a/shared/packages/minglit_kit/lib/src/data/repositories/social_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/social_repository.dart
@@ -145,7 +145,7 @@ class SocialRepository {
         'target_id': partnerId,
         'target_type': SocialTargetType.partner.name,
         'reason': reason,
-        if (description != null) 'description': description,
+        'description': ?description,
       });
     } on Object catch (e, st) {
       Log.e('reportPartner Error', e, st);

--- a/shared/packages/minglit_kit/lib/src/features/social/ui/minglit_social_button.dart
+++ b/shared/packages/minglit_kit/lib/src/features/social/ui/minglit_social_button.dart
@@ -119,6 +119,7 @@ class MinglitSocialButton extends ConsumerWidget {
       SocialInteractionType.bookmark =>
         isActive ? Icons.bookmark : Icons.bookmark_border,
       SocialInteractionType.block => Icons.block,
+      SocialInteractionType.report => Icons.flag,
     };
   }
 
@@ -137,6 +138,7 @@ class MinglitSocialButton extends ConsumerWidget {
       SocialInteractionType.subscribe => '구독',
       SocialInteractionType.bookmark => '저장',
       SocialInteractionType.block => '차단',
+      SocialInteractionType.report => '신고',
     };
   }
 }

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_image_carousel.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_image_carousel.dart
@@ -58,11 +58,15 @@ class _MinglitImageCarouselState extends State<MinglitImageCarousel> {
     final theme = Theme.of(context);
     final useFixedHeight = widget.height != null;
 
+    // Fix #74: Show styled placeholder when no images available
     if (widget.imageUrls.isEmpty) {
+      final theme = Theme.of(context);
       final placeholder = Container(
-        width: double.infinity,
-        color: theme.colorScheme.surfaceContainerHighest,
-        child: const Icon(Icons.image_not_supported_outlined, size: 48),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surfaceContainerLow,
+          borderRadius: BorderRadius.circular(MinglitRadius.small),
+        ),
+        child: Icon(Icons.image, color: theme.colorScheme.outline),
       );
       return useFixedHeight
           ? SizedBox(height: widget.height, child: placeholder)

--- a/shared/packages/minglit_kit/test/ui/widgets/common/minglit_image_carousel_test.dart
+++ b/shared/packages/minglit_kit/test/ui/widgets/common/minglit_image_carousel_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_image_carousel.dart';
+
+void main() {
+  group('MinglitImageCarousel Widget Tests', () {
+    testWidgets('renders placeholder when imageUrls is empty', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MinglitImageCarousel(
+              imageUrls: [],
+            ),
+          ),
+        ),
+      );
+
+      // Verify placeholder is rendered
+      expect(find.byIcon(Icons.image), findsOneWidget);
+      // Verify carousel is NOT rendered
+      expect(find.byType(PageView), findsNothing);
+    });
+
+    testWidgets('renders carousel when imageUrls is not empty', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MinglitImageCarousel(
+              imageUrls: ['https://example.com/image1.jpg'],
+            ),
+          ),
+        ),
+      );
+
+      // Verify carousel is rendered
+      expect(find.byType(PageView), findsOneWidget);
+      // Verify placeholder is NOT rendered
+      expect(find.byIcon(Icons.image), findsNothing);
+    });
+
+    testWidgets(
+      'renders placeholder with fixed height when imageUrls is empty',
+      (tester) async {
+        const testHeight = 200.0;
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: MinglitImageCarousel(
+                imageUrls: [],
+                height: testHeight,
+              ),
+            ),
+          ),
+        );
+
+        // Verify placeholder is rendered with SizedBox
+        expect(find.byIcon(Icons.image), findsOneWidget);
+        expect(find.byType(SizedBox), findsWidgets);
+      },
+    );
+
+    testWidgets(
+      'renders placeholder with aspect ratio when imageUrls is empty '
+      'and height is null',
+      (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: MinglitImageCarousel(
+                imageUrls: [],
+              ),
+            ),
+          ),
+        );
+
+        // Verify placeholder is rendered with AspectRatio
+        expect(find.byIcon(Icons.image), findsOneWidget);
+        expect(find.byType(AspectRatio), findsWidgets);
+      },
+    );
+
+    testWidgets('renders indicator when multiple images are provided', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MinglitImageCarousel(
+              imageUrls: [
+                'https://example.com/image1.jpg',
+                'https://example.com/image2.jpg',
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Verify indicator is rendered for multiple images
+      expect(find.text('1 / 2'), findsOneWidget);
+    });
+
+    testWidgets('does not render indicator when only one image is provided', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: MinglitImageCarousel(
+              imageUrls: ['https://example.com/image1.jpg'],
+            ),
+          ),
+        ),
+      );
+
+      // Verify indicator is NOT rendered for single image
+      expect(find.byType(Text), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- `MinglitImageCarousel` now shows a styled placeholder when `imageUrls` is empty (surfaceContainerLow background + centered image icon)
- Fixes blank space in event detail page when party has no images
- Added 6 unit tests for carousel empty/non-empty states
- Fixed pre-existing compilation issue: missing `report` case in `MinglitSocialButton` switch statements

Closes #74