### PR TITLE
fix(ui): use theme-aware app bar color and remove excess tab bar padding

### DIFF
--- a/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
@@ -464,6 +464,8 @@ class _SliverTabBarDelegate extends SliverPersistentHeaderDelegate {
           TabBar(
             controller: tabController,
             isScrollable: true,
+            // Fix #77: remove default 52dp left padding from scrollable TabBar
+            tabAlignment: TabAlignment.start,
             onTap: onTabTap,
             tabs: const [
               Tab(text: '기본 정보'),

--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -84,8 +84,9 @@ class _HomePageState extends ConsumerState<HomePage> {
                 ),
                 const SizedBox(width: MinglitSpacing.small),
               ],
-              backgroundColor: MinglitColors.background,
-              surfaceTintColor: MinglitColors.transparent,
+              // Fix #76: use theme color instead of hardcoded white for dark mode support
+              backgroundColor: Theme.of(context).colorScheme.surface,
+              surfaceTintColor: Colors.transparent,
             ),
             const SliverToBoxAdapter(
               child: Padding(


### PR DESCRIPTION
## Summary
- Home SliverAppBar: replaced hardcoded `MinglitColors.background` (white) with `Theme.of(context).colorScheme.surface` — now respects dark mode
- Event detail TabBar: added `tabAlignment: TabAlignment.start` to remove default 52dp left padding from scrollable TabBar

Closes #76, closes #77