### PR TITLE
fix(ci): make .well-known copy conditional in Vercel deploy action

### DIFF
--- a/.github/actions/deploy-flutter-app/action.yml
+++ b/.github/actions/deploy-flutter-app/action.yml
@@ -59,7 +59,9 @@ runs:
       shell: bash
       run: |
         cp ${{ inputs.working-directory }}/vercel.json ${{ inputs.working-directory }}/build/web/vercel.json
-        cp -r ${{ inputs.working-directory }}/web/.well-known ${{ inputs.working-directory }}/build/web/.well-known
+        if [[ -d "${{ inputs.working-directory }}/web/.well-known" ]]; then
+          cp -r ${{ inputs.working-directory }}/web/.well-known ${{ inputs.working-directory }}/build/web/.well-known
+        fi
         if [[ -d "${{ inputs.working-directory }}/api" ]]; then
           mkdir -p ${{ inputs.working-directory }}/build/web/api
           cp -r ${{ inputs.working-directory }}/api/. ${{ inputs.working-directory }}/build/web/api/

--- a/apps/app_user/test/src/features/auth/logic/auth_controller_test.dart
+++ b/apps/app_user/test/src/features/auth/logic/auth_controller_test.dart
@@ -92,13 +92,13 @@ void main() {
       );
 
       final controller = container.read(authControllerProvider.notifier);
-      
+
       // Simulate ref being disposed by invalidating the provider
       container.invalidate(authControllerProvider);
-      
+
       // This should not throw even though ref is disposed
       await controller.signOut();
-      
+
       verify(() => mockAuthRepo.signOut()).called(1);
     });
   });


### PR DESCRIPTION
## Summary
- `.well-known` 디렉토리가 없는 앱(파트너앱)에서 Vercel 배포 시 `cp` 실패하던 문제 수정
- 파트너앱은 딥링크가 불필요하므로 `.well-known` 복사를 조건부(`if [[ -d ... ]]`)로 변경

## Changes
- `.github/actions/deploy-flutter-app/action.yml`: `.well-known` 복사를 디렉토리 존재 여부 체크 후 실행하도록 변경