### PR TITLE
docs(ux): add partner app UX/UI documentation

### DIFF
--- a/docs/ux/partner-app/design-system.md
+++ b/docs/ux/partner-app/design-system.md
@@ -357,4 +357,12 @@ Material 3 기반 컴포넌트들을 밍릿 스타일로 커스터마이징한 �
 
 ---
 
+## 관련 문서
+
+- [화면 카탈로그](screen-catalog.md) — 전체 화면 목록, 사이트맵, 네비게이션 구조
+- [사용자 플로우](user-flows.md) — 주요 사용자 여정 플로우차트
+- [클라이언트 아키텍처](../../architecture/client.md) — Feature-first 구조, Coordinator 패턴 등 기술 아키텍처
+
+---
+
 *소스 파일 변경 시 이 문서도 함께 업데이트합니다.*

--- a/docs/ux/partner-app/design-system.md
+++ b/docs/ux/partner-app/design-system.md
@@ -1,0 +1,360 @@
+# 파트너 앱 디자인 시스템 (Design System)
+
+이 문서는 밍릿 파트너 앱(`app_partner`)의 일관된 사용자 경험과 시각적 정체성을 유지하기 위한 디자인 시스템 레퍼런스입니다. 모든 UI 컴포넌트는 `minglit_kit` 패키지에 정의된 디자인 토큰과 테마를 기반으로 구축됩니다.
+
+---
+
+## 1. 개요
+
+밍릿 파트너 앱의 디자인 시스템은 파트너(사장님)가 매장·파티·이벤트를 효율적으로 운영할 수 있도록 신뢰감과 사용성을 강조합니다. Material 3 기반 위에 3-Layer 테마 구조를 적용합니다.
+
+- **참조 문서**:
+  - [클라이언트 아키텍처](../../architecture/client.md) — Feature-first 구조, Coordinator 패턴, Repository 패턴
+  - [화면 카탈로그](./screen-catalog.md) — 파트너 앱 전체 화면 목록
+- **소스 경로**: `shared/packages/minglit_kit/lib/src/theme/`
+- **테마 진입점**: `minglit_theme.dart` (part 파일 3개 포함)
+
+### 3-Layer 테마 구조
+
+| Layer | 역할 | 파일 |
+| :--- | :--- | :--- |
+| Layer 1 | 폰트·텍스트 통일 (NotoSansKR) | `minglit_theme.dart` |
+| Layer 2 | Material 컴포넌트 커스터마이징 | `minglit_component_theme.dart` |
+| Layer 3 | 브랜드 상수 (색상·간격·곡률 등) | `minglit_design_tokens.dart` |
+
+---
+
+## 2. 디자인 토큰 (Design Tokens)
+
+디자인 토큰은 UI의 가장 작은 단위로, 색상·간격·곡률·아이콘 크기·애니메이션 지속 시간을 상수로 관리합니다.
+
+**소스**: `shared/packages/minglit_kit/lib/src/theme/minglit_design_tokens.dart:L5-L134`
+
+---
+
+### 2.1 MinglitColors (라이트 모드)
+
+브랜드의 핵심 색상과 UI 상태를 나타내는 컬러 팔레트입니다.
+
+**소스**: `minglit_design_tokens.dart:L5-L41`
+
+| 토큰명 | 값 (Hex) | 용도 |
+| :--- | :--- | :--- |
+| `primary` | `#9900FF` | 브랜드 주색상 (Purple) |
+| `secondary` | `#FF9900` | 보조 색상 Auxiliary 1 (Amber) |
+| `tertiary` | `#48C9B0` | 강조 색상 Toned-down Mint |
+| `background` | `#FFFFFF` | 기본 배경색 |
+| `surface` | `#F9FAFB` | 카드·입력 필드 배경색 (부드러운 회색) |
+| `textPrimary` | `#111827` | 주요 텍스트 (Near-black) |
+| `textSecondary` | `#4B5563` | 보조 텍스트 (Dark gray) |
+| `error` | `#EF4444` | 에러 상태 |
+| `success` | `#22C55E` | 성공 상태 |
+| `warning` | `#F59E0B` | 경고 상태 |
+| `transparent` | `#00000000` | 완전 투명 |
+| `scrim` | `#80000000` | 오버레이 배경 (50% 불투명 검정) |
+
+---
+
+### 2.2 MinglitColorsDark (다크 모드)
+
+다크 모드 대응을 위한 컬러 팔레트입니다. `secondary`, `tertiary`, `error`는 라이트 모드와 동일 값을 공유합니다.
+
+**소스**: `minglit_design_tokens.dart:L43-L59`
+
+| 토큰명 | 값 (Hex) | 비고 |
+| :--- | :--- | :--- |
+| `primary` | `#AA33FF` | 라이트보다 밝게 조정 |
+| `background` | `#0F0F0F` | |
+| `surface` | `#212121` | |
+| `textPrimary` | `#FFFFFF` | |
+| `textSecondary` | `#AAAAAA` | |
+| `divider` | `#3D3D3D` | 다크 모드 전용 구분선 |
+| `secondary` | `#FF9900` | `MinglitColors.secondary`와 동일 |
+| `tertiary` | `#48C9B0` | `MinglitColors.tertiary`와 동일 |
+| `error` | `#EF4444` | `MinglitColors.error`와 동일 |
+
+---
+
+### 2.3 MinglitSpacing (간격)
+
+일관된 레이아웃을 위한 스페이싱 스케일입니다. `double` 타입 상수.
+
+**소스**: `minglit_design_tokens.dart:L62-L89`
+
+| 토큰명 | 값 (px) | 용도 |
+| :--- | :--- | :--- |
+| `zero` | 0 | 간격 없음 |
+| `xxsmall` | 2 | 미세 간격 |
+| `xsmall` | 4 | 요소 내 좁은 간격 |
+| `xsmall2` | 6 | 중간 좁은 간격 |
+| `small` | 8 | 일반적인 좁은 간격 |
+| `sm` | 12 | 요소 간 중간 간격 |
+| `medium` | 16 | 기본 여백 (Standard padding) |
+| `large` | 24 | 섹션 간 간격 |
+| `xlarge` | 32 | 큰 섹션 간 간격 |
+
+---
+
+### 2.4 MinglitRadius (곡률)
+
+컴포넌트의 모서리 둥글기 값입니다. `double` 타입 상수.
+
+**소스**: `minglit_design_tokens.dart:L92-L104`
+
+| 토큰명 | 값 (px) | 용도 |
+| :--- | :--- | :--- |
+| `small` | 8 | 작은 요소 (상태 뱃지, 체크박스 등) |
+| `input` | 12 | 입력 필드 (TextField) |
+| `button` | 16 | 버튼 (ElevatedButton, OutlinedButton) |
+| `card` | 24 | 카드·바텀 시트·이미지 클리핑 |
+
+---
+
+### 2.5 MinglitIconSize (아이콘 크기)
+
+아이콘의 표준 크기 가이드입니다. `double` 타입 상수.
+
+**소스**: `minglit_design_tokens.dart:L107-L122`
+
+| 토큰명 | 값 (px) | 용도 |
+| :--- | :--- | :--- |
+| `xsmall` | 16 | 인라인 텍스트 옆 아이콘 |
+| `small` | 20 | 리스트 아이템 보조 아이콘 |
+| `medium` | 24 | 기본 아이콘 (Material 기본값) |
+| `large` | 28 | 강조 아이콘 |
+| `xlarge` | 32 | 대형 아이콘 (빈 상태 화면 등) |
+
+---
+
+### 2.6 MinglitAnimation (애니메이션)
+
+사용자 인터랙션 피드백을 위한 표준 지속 시간입니다. `Duration` 타입 상수.
+
+**소스**: `minglit_design_tokens.dart:L125-L134`
+
+| 토큰명 | 값 (ms) | 용도 |
+| :--- | :--- | :--- |
+| `fast` | 200 | 간단한 상태 변화 (선택, 토글) |
+| `medium` | 350 | 화면 전환·모달 등장 |
+| `slow` | 500 | 복잡한 레이아웃 변화 |
+
+---
+
+## 3. 유틸리티 클래스 (Design Utils)
+
+토큰을 조합한 재사용 가능한 스타일 프리셋입니다.
+
+**소스**: `shared/packages/minglit_kit/lib/src/theme/minglit_design_utils.dart`
+
+| 클래스 | 주요 메서드 | 설명 |
+| :--- | :--- | :--- |
+| `MinglitShadows` | `cardSelected(Color accentColor)` | 선택된 카드 그림자 — accentColor 10% 불투명, blurRadius 8, offset (0,4) |
+| `MinglitBorders` | `card(ColorScheme, {isSelected})` | 카드 테두리 — 선택 시 `secondary`, 미선택 시 `outlineVariant` |
+| `MinglitDecorations` | `selectableCard(context, {isSelected})` | 선택 가능한 카드 전체 BoxDecoration (색상+곡률+테두리+그림자 통합) |
+| `MinglitTextStyles` | `selectableCardTitle`, `selectableCardSubtitle`, `selectableCardDescription`, `infoText` | 카드 내 텍스트 스타일 프리셋 |
+
+---
+
+## 4. 컴포넌트 테마 (Component Themes)
+
+Material 3 기반 컴포넌트들을 밍릿 스타일로 커스터마이징한 설정값입니다.
+
+**소스**: `shared/packages/minglit_kit/lib/src/theme/minglit_component_theme.dart`
+
+| 컴포넌트 | 주요 설정값 |
+| :--- | :--- |
+| **AppBar** | `elevation: 0`, `centerTitle: true`, `bg: #FFFFFF`, `titleTextStyle: 18px/w600/NotoSansKR` |
+| **ElevatedButton** | `minSize: ∞×56`, `radius: 16`, `bg: primary(#9900FF)`, `fg: white`, `text: 16px/bold`, `elevation: 0` |
+| **OutlinedButton** | `minSize: ∞×56`, `radius: 16`, `border: primary`, `fg: primary`, `text: 16px/bold` |
+| **TextButton** | `fg: primary`, `text: 14px/bold` |
+| **Card** | `elevation: 0`, `radius: 24`, `color: surface(#F9FAFB)`, `margin: zero` |
+| **InputDecoration** | `filled: true`, `fillColor: surface`, `radius: 12`, `border: none`, `focusedBorder: primary 2px`, `contentPadding: 16` |
+| **Chip** | `radius: 100(pill)`, `side: none`, `bg: surface`, `selectedColor: primary`, `labelStyle: 13px` |
+| **Checkbox** | `selectedFill: primary`, `shape: radius 4`, `side: grey 1.5px` |
+| **TabBar** | `labelColor: primary`, `unselectedColor: textSecondary`, `indicatorColor: primary`, `indicatorSize: tab`, `dividerColor: transparent` |
+| **Divider** | `color: #E5E7EB`, `thickness: 1`, `space: 16` |
+
+---
+
+## 5. 위젯 패턴 카탈로그 (Widget Patterns)
+
+파트너 앱에서 반복적으로 사용되는 주요 UI 패턴과 대표 예시입니다.
+
+### 5.1 Card (정보 카드)
+
+데이터 요약이나 목록 항목을 표시할 때 사용합니다. `MinglitRadius.card(24)` + `elevation: 0` 조합이 기본입니다.
+
+- **대표 예시**: `apps/app_partner/lib/src/features/home/widgets/revenue_summary_card.dart`
+  - `Card` + `InkWell` 조합으로 탭 가능한 카드 구현
+  - `colorScheme.surfaceContainerHighest` 배경, `MinglitSpacing.large(24)` 패딩
+- **사용 화면**: 홈 대시보드, 파티 목록, 수익 관리 → [화면 카탈로그](./screen-catalog.md) 참조
+
+### 5.2 Summary (요약 정보)
+
+상세 화면 상단에서 핵심 정보를 브리핑할 때 사용합니다. 이미지 캐러셀 + 상태 뱃지 + 제목 + 설명 구조가 표준입니다.
+
+- **대표 예시**: `apps/app_partner/lib/src/features/party/widgets/party_basic_info_summary.dart`
+  - 상태 뱃지: `active(primary)` / `draft(outline)` / `closed(error)` 색상 분기
+  - 설명 영역: `flutter_quill` 리치 텍스트 뷰어, `collapsible` 옵션 지원
+  - 이미지: `MinglitImageCarousel` + `MinglitRadius.card` 클리핑
+- **사용 화면**: 파티 상세, 이벤트 상세, 위자드 검토 단계
+
+### 5.3 Input (입력 폼)
+
+위자드나 편집 화면에서 정보를 입력받을 때 사용합니다. `InputDecorationTheme`이 전역 적용되므로 별도 스타일 불필요합니다.
+
+- **대표 예시**: `apps/app_partner/lib/src/features/party/widgets/party_location_detail_input.dart`
+- **사용 화면**: 파트너 신청(온보딩), 파티 생성/수정 위자드, 티켓 설정
+
+### 5.4 BottomSheet (하단 시트)
+
+부분 수정이나 옵션 선택 시 사용합니다. `SafeArea` + `Padding(MinglitSpacing.medium)` + `Column(mainAxisSize.min)` 구조가 표준입니다.
+
+- **대표 예시**: `apps/app_partner/lib/src/features/party/widgets/party_status_edit_sheet.dart`
+  - 상태 옵션: `active` / `draft` / `closed` — `ListTile` + 원형 아이콘 컨테이너
+  - 선택 상태: `MinglitColors.primary` 강조 + `Icons.check_circle`
+  - 공개 범위: `SwitchListTile` 추가 섹션
+- **사용 화면**: 파티 상태 변경, 필터 선택
+
+### 5.5 Dialog (다이얼로그)
+
+중요한 확인이나 검색 등 독립적인 작업 시 사용합니다. `minglit_kit`의 `MinglitDialog`를 기반으로 합니다.
+
+- **대표 예시**: `apps/app_partner/lib/src/features/onboarding/widgets/address_search_dialog.dart`
+- **사용 화면**: 주소 검색, 삭제 확인, 권한 설정, 이벤트 신청 심사
+
+### 5.6 List/Scroll (리스트 및 스크롤)
+
+대량의 데이터를 나열할 때 사용합니다. `SliverList` 또는 `ListView.builder` 기반입니다.
+
+- **대표 예시**: `apps/app_partner/lib/src/features/party/event/widgets/event_application_list_view.dart`
+- **사용 화면**: 신청자 명단, 알림 센터, 정산 내역, 파티 목록
+
+### 5.7 Badge/Banner (뱃지 및 배너)
+
+상태 알림이나 가이드를 제공할 때 사용합니다.
+
+- **대표 예시**: `apps/app_partner/lib/src/features/home/widgets/location_guide_banner.dart`
+- **사용 화면**: 홈 대시보드 (미처리 항목 알림, 위치 설정 가이드)
+
+---
+
+## 6. 공유 컴포넌트 목록 (minglit_kit)
+
+`minglit_kit` 패키지에서 `minglit_ui.dart`를 통해 export되는 공용 UI 컴포넌트입니다.
+
+**소스**: `shared/packages/minglit_kit/lib/minglit_ui.dart`
+
+| 컴포넌트명 | 용도 | 파일 경로 |
+| :--- | :--- | :--- |
+| `MinglitLoginScreen` | 공용 로그인 화면 | `src/features/auth/ui/minglit_login_screen.dart` |
+| `StaffGateScreen` | 스태프 게이트 화면 | `src/features/auth/ui/staff_gate_screen.dart` |
+| `StaffGuardWrapper` | 스태프 권한 가드 래퍼 | `src/features/auth/ui/staff_guard_wrapper.dart` |
+| `MinglitGlobalLoadingOverlay` | 전역 로딩 오버레이 | `src/features/loading/minglit_global_loading_overlay.dart` |
+| `NotificationListScreen` | 알림 목록 화면 | `src/features/notification/notification_list_screen.dart` |
+| `NotificationSettingsScreen` | 알림 설정 화면 | `src/features/notification/notification_settings_screen.dart` |
+| `LocationSearchScreen` | 위치 검색 화면 | `src/features/search/ui/location_search_screen.dart` |
+| `MinglitSocialButton` | 소셜 로그인 버튼 | `src/features/social/ui/minglit_social_button.dart` |
+| `IdentityVerificationScreen` | 본인인증 화면 | `src/features/verification/ui/identity_verification_screen.dart` |
+| `MinglitAlert` | 표준 알림 팝업 | `src/ui/widgets/common/minglit_alert.dart` |
+| `MinglitDialog` | 표준 다이얼로그 프레임 | `src/ui/widgets/common/minglit_dialog.dart` |
+| `MinglitChip` | 정보 표시용 칩 | `src/ui/widgets/common/minglit_chip.dart` |
+| `MinglitFilterChip` | 선택/필터용 칩 | `src/ui/widgets/common/minglit_filter_chip.dart` |
+| `MinglitImage` | 네트워크 이미지 (캐싱) | `src/ui/widgets/common/minglit_image.dart` |
+| `MinglitImageCarousel` | 이미지 캐러셀 | `src/ui/widgets/common/minglit_image_carousel.dart` |
+| `MinglitParticipantGauge` | 참가자 게이지 바 | `src/ui/widgets/common/minglit_participant_gauge.dart` |
+| `MinglitSkeleton` | 스켈레톤 로딩 | `src/ui/widgets/common/minglit_skeleton.dart` |
+| `MinglitFilePicker` | 파일 선택기 | `src/ui/widgets/common/minglit_file_picker.dart` |
+| `MinglitAsyncValueWidget` | AsyncValue 상태 처리 래퍼 | `src/ui/widgets/common/minglit_async_value_widget.dart` |
+| `LoadingIndicator` | 공용 로딩 애니메이션 | `src/ui/widgets/common/loading_indicator.dart` |
+| `NumberStepperInput` | 숫자 증감 입력 | `src/ui/widgets/common/number_stepper_input.dart` |
+| `AddActionCard` | 항목 추가 액션 카드 | `src/ui/widgets/common/add_action_card.dart` |
+| `VerificationCard` | 인증 정보 카드 | `src/ui/widgets/common/verification_card.dart` |
+| `VerificationSelectCard` | 인증 선택 카드 | `src/ui/widgets/common/verification_select_card.dart` |
+| `EntryGroupDetail` | 입장 그룹 상세 | `src/ui/widgets/common/entry_group_detail.dart` |
+| `EventCard` | 이벤트 요약 카드 | `src/ui/widgets/party/event_card.dart` |
+| `LocationMapView` | 위치 지도 뷰 | `src/ui/widgets/party/location_map_view.dart` |
+| `PartnerDetailView` | 파트너 상세 뷰 | `src/ui/widgets/partner/partner_detail_view.dart` |
+| `BugReporterWrapper` | 버그 리포트 래퍼 | `src/ui/widgets/bug_reporter_wrapper.dart` |
+
+---
+
+## 7. 앱 전용 위젯 목록 (app_partner)
+
+파트너 앱의 비즈니스 로직에 특화된 전용 위젯들입니다. 피처별로 그룹핑합니다.
+
+**소스 루트**: `apps/app_partner/lib/src/features/`
+
+### Home
+
+| 위젯명 | 용도 | 파일 경로 |
+| :--- | :--- | :--- |
+| `TodayPartyCard` | 오늘의 파티 요약 카드 | `home/widgets/today_party_card.dart` |
+| `RevenueSummaryCard` | 수익 요약 카드 (대시보드) | `home/widgets/revenue_summary_card.dart` |
+| `UpcomingEventsCard` | 다가오는 이벤트 카드 | `home/widgets/upcoming_events_card.dart` |
+| `ClosingSoonEventsCard` | 마감 임박 이벤트 카드 | `home/widgets/closing_soon_events_card.dart` |
+| `PendingApplicantsBadgeCard` | 미처리 신청자 뱃지 카드 | `home/widgets/pending_applicants_badge_card.dart` |
+| `ApprovalWaitingCard` | 승인 대기 카드 | `home/widgets/approval_waiting_card.dart` |
+| `ActivePartySummaryScroll` | 운영 중 파티 가로 스크롤 | `home/widgets/active_party_summary_scroll.dart` |
+| `LocationGuideBanner` | 위치 설정 가이드 배너 | `home/widgets/location_guide_banner.dart` |
+
+### Party
+
+| 위젯명 | 용도 | 파일 경로 |
+| :--- | :--- | :--- |
+| `PartyListItem` | 파티 목록 아이템 | `party/list/widgets/party_list_item.dart` |
+| `PartyBasicInfoSummary` | 파티 기본 정보 요약 (이미지+제목+설명) | `party/widgets/party_basic_info_summary.dart` |
+| `PartyBasicInfoEditScreen` | 파티 기본 정보 편집 화면 | `party/widgets/party_basic_info_edit_screen.dart` |
+| `PartyStatusEditSheet` | 파티 운영 상태 변경 바텀 시트 | `party/widgets/party_status_edit_sheet.dart` |
+| `PartyDescriptionInput` | 파티 설명 입력 (Quill 에디터) | `party/widgets/party_description_input.dart` |
+| `PartyImageEditor` | 파티 이미지 편집 | `party/widgets/party_image_editor.dart` |
+| `PartyLocationInput` | 파티 위치 입력 | `party/widgets/party_location_input.dart` |
+| `PartyLocationDetailInput` | 파티 위치 상세 입력 | `party/widgets/party_location_detail_input.dart` |
+| `PartyLocationSummary` | 파티 위치 요약 | `party/widgets/party_location_summary.dart` |
+| `PartyLocationEditScreen` | 파티 위치 편집 화면 | `party/widgets/party_location_edit_screen.dart` |
+| `PartyCapacityInput` | 파티 정원 입력 | `party/widgets/party_capacity_input.dart` |
+| `PartyCapacitySummary` | 파티 정원 요약 | `party/widgets/party_capacity_summary.dart` |
+| `PartyCapacityContactEditScreen` | 파티 정원·연락처 편집 화면 | `party/widgets/party_capacity_contact_edit_screen.dart` |
+| `PartyContactInput` | 파티 연락처 입력 | `party/widgets/party_contact_input.dart` |
+| `PartyContactSummary` | 파티 연락처 요약 | `party/widgets/party_contact_summary.dart` |
+| `PartyVerificationInput` | 파티 인증 설정 입력 | `party/widgets/party_verification_input.dart` |
+| `PartyEntranceConditionSummary` | 파티 입장 조건 요약 | `party/widgets/party_entrance_condition_summary.dart` |
+| `PartyEventListSummary` | 파티 이벤트 목록 요약 | `party/widgets/party_event_list_summary.dart` |
+
+### Party — Ticket
+
+| 위젯명 | 용도 | 파일 경로 |
+| :--- | :--- | :--- |
+| `PartyTicketTemplateInput` | 파티 티켓 템플릿 입력 | `party/ticket/widgets/party_ticket_template_input.dart` |
+| `PartyTicketsSummary` | 파티 티켓 목록 요약 | `party/ticket/widgets/party_tickets_summary.dart` |
+
+### Party — Event
+
+| 위젯명 | 용도 | 파일 경로 |
+| :--- | :--- | :--- |
+| `EventCard` (파트너 전용) | 파트너 이벤트 카드 | `party/event/widgets/event_card.dart` |
+| `TicketListItem` | 티켓 목록 아이템 | `party/event/widgets/ticket_list_item.dart` |
+| `EventApplicationListView` | 이벤트 신청자 리스트 | `party/event/widgets/event_application_list_view.dart` |
+| `EventApplicationReviewDialog` | 신청자 심사 다이얼로그 | `party/event/widgets/event_application_review_dialog.dart` |
+| `EventBasicInfoSummary` | 이벤트 기본 정보 요약 | `party/event/widgets/event_basic_info_summary.dart` |
+| `EventCapacitySummary` | 이벤트 정원 요약 | `party/event/widgets/event_capacity_summary.dart` |
+| `EventContactSummary` | 이벤트 연락처 요약 | `party/event/widgets/event_contact_summary.dart` |
+| `EventLocationSummary` | 이벤트 위치 요약 | `party/event/widgets/event_location_summary.dart` |
+| `EventEntranceConditionSummary` | 이벤트 입장 조건 요약 | `party/event/widgets/event_entrance_condition_summary.dart` |
+| `EventDateTimeInput` | 이벤트 날짜·시간 입력 | `party/event/widgets/event_date_time_input.dart` |
+
+### Ticket
+
+| 위젯명 | 용도 | 파일 경로 |
+| :--- | :--- | :--- |
+| `TicketForm` | 티켓 생성/편집 폼 | `ticket/widgets/ticket_form.dart` |
+
+### Onboarding
+
+| 위젯명 | 용도 | 파일 경로 |
+| :--- | :--- | :--- |
+| `AddressSearchDialog` | 주소 검색 다이얼로그 | `onboarding/widgets/address_search_dialog.dart` |
+
+---
+
+*소스 파일 변경 시 이 문서도 함께 업데이트합니다.*

--- a/docs/ux/partner-app/screen-catalog.md
+++ b/docs/ux/partner-app/screen-catalog.md
@@ -353,4 +353,9 @@ stateDiagram-v2
   - 위자드로 다시 돌아가기 버튼 (수정용)
 
 ---
-*이 문서는 파트너 앱의 화면 구성을 지속적으로 반영하며, 상세 디자인은 Figma 링크를 참조하십시오.*
+
+## 관련 문서
+
+- [사용자 플로우](user-flows.md) — 각 화면을 연결하는 사용자 여정 플로우차트
+- [디자인 시스템](design-system.md) — 디자인 토큰, 컴포넌트 테마, 위젯 패턴 카탈로그
+- [클라이언트 아키텍처](../../architecture/client.md) — Feature-first 구조, Coordinator 패턴, Repository 패턴 등 기술 아키텍처

--- a/docs/ux/partner-app/screen-catalog.md
+++ b/docs/ux/partner-app/screen-catalog.md
@@ -324,13 +324,37 @@ stateDiagram-v2
   - **EntryGroupEditorScreen**: 입장 그룹(예: 신규 회원, 우수 회원, 남성/여성 전용) 정의 및 편집.
 
 ## 26. [모달] 티켓 및 입장 관리 (Modal: Ticket & Entry)
-- **용도**: 티켓 라이브러리 및 현장 입장 관련 부조 화면.
+- **용도**: 티켓 라이브러리 및 현장 입장 관련 보조 화면.
 - **주요 화면**:
   - **TicketManageScreen**: 파티/이벤트별 전체 티켓 현황 조회.
   - **TicketTemplateManageScreen**: 자주 사용하는 티켓 설정 재사용을 위한 템플릿 관리.
   - **QRScannerScreen**: 티켓 검수용 카메라 스캐너. (체크인 및 일반 QR 인식 중복 기능 포함)
 
-## 27. [온보딩] 파트너 입점 신청 위자드 (Onboarding: Application Wizard)
+## 27. [모달] 위치 검색 (Modal: Location Search)
+- **화면명**: 위치 검색 화면 (LocationSearchScreen)
+- **라우트**: 비라우팅 (Navigator.push)
+- **피처**: `minglit_kit > search`
+- **용도**: 파티/이벤트 생성 시 주소를 검색하고 지도에서 위치를 선택하는 전체 화면 모달.
+- **주요 UI**:
+  - 텍스트 검색 입력
+  - 검색 결과 목록 (주소 자동완성)
+  - 지도 프리뷰 (선택한 위치 표시)
+- **진입**: PartyCreateCoordinator, PartyDetailCoordinator에서 push
+- **이탈**: 위치 선택 후 pop (결과 반환)
+
+## 28. [모달] 인증 심사 (Modal: Review Verification)
+- **화면명**: 인증 심사 화면 (ReviewVerificationScreen)
+- **라우트**: 비라우팅 (Navigator.push)
+- **피처**: `verification > review`
+- **용도**: 유저가 제출한 인증 서류를 파트너가 검토하고 승인/거절/보완요청하는 화면.
+- **주요 UI**:
+  - 유저 제출 서류 이미지 뷰어
+  - 인증 항목별 상태 표시
+  - 승인/거절/보완요청 버튼
+- **진입**: VerificationCoordinator에서 push
+- **이탈**: 심사 완료 후 pop
+
+## 29. [온보딩] 파트너 입점 신청 위자드 (Onboarding: Application Wizard)
 - **화면명**: 파트너 신청 페이지 (PartnerApplyPage)
 - **라우트**: `/apply`
 - **피처**: `onboarding`
@@ -342,7 +366,7 @@ stateDiagram-v2
   4. 증빙 서류 업로드 (사업자 등록증 등)
   5. 입력 정보 최종 확인 및 제출
 
-## 28. [온보딩] 입점 신청 상태 및 보완 (Onboarding: Application Status)
+## 30. [온보딩] 입점 신청 상태 및 보완 (Onboarding: Application Status)
 - **화면명**: 신청 상태 확인 (PartnerApplyStatusPage)
 - **라우트**: `/apply/status`
 - **피처**: `onboarding`

--- a/docs/ux/partner-app/screen-catalog.md
+++ b/docs/ux/partner-app/screen-catalog.md
@@ -1,0 +1,356 @@
+# 파트너 앱 화면 카탈로그 (Screen Catalog)
+
+이 문서는 밍릿 파트너 앱(`app_partner`)의 모든 화면 구조와 네비게이션 경로를 정의한 UX/UI 레퍼런스 가이드입니다. 개발자와 디자이너가 앱의 전체 구조를 파악하고 각 화면의 역할과 연결 관계를 이해하는 데 사용됩니다.
+
+## 1. 개요
+밍릿 파트너 앱은 파트너(매장주)가 자신의 매장(파티)을 등록하고, 이벤트를 운영하며, 정산 및 멤버 권한을 관리하기 위한 도구입니다. 앱은 크게 4개의 하단 탭 내비게이션(Bottom Navigation) 구조를 가지고 있으며, 파트너 입점 신청을 위한 온보딩 프로세스가 포함되어 있습니다.
+
+### 주요 구조
+- **하단 내비게이션**: 홈, 파티관리, 수익관리, 설정의 4탭 구조.
+- **온보딩 게이트**: 인증된 유저의 파트너십 상태에 따라 앱 접근 권한을 제어합니다.
+- **위자드 패턴**: 복잡한 정보 입력이 필요한 파트너 신청 및 파티 생성은 단계별 위자드 방식을 채택합니다.
+
+## 2. 사이트맵 (Sitemap)
+
+파트너 앱의 전체 네비게이션 구조를 나타내는 다이어그램입니다.
+
+```mermaid
+graph TD
+    Root[/Root/] --> Login[로그인 페이지 /login]
+    Root --> Onboarding{온보딩 상태}
+    
+    Onboarding -->|미신청/작성중| Apply[파트너 신청 위자드 /apply]
+    Onboarding -->|심사중/보완필요| ApplyStatus[신청 상태 확인 /apply/status]
+    Onboarding -->|승인완료| MainShell[메인 쉘 /]
+
+    MainShell --> Tab1[홈 탭]
+    MainShell --> Tab2[파티관리 탭]
+    MainShell --> Tab3[수익관리 탭]
+    MainShell --> Tab4[설정 탭]
+
+    subgraph "Home Tab"
+        Tab1 --> Home[파트너 홈]
+        Home --> Notify[알림 센터]
+        Home --> LocGuide[입점 가이드]
+        Home --> AppList[신청 목록 - 어드민]
+        AppList --> AppDetail[신청 상세]
+    end
+
+    subgraph "Party Tab"
+        Tab2 --> PartyList[파티 목록]
+        PartyList --> PartyCreate[파티 생성 위자드]
+        PartyList --> PartyDetail[파티 상세]
+        PartyDetail --> PartyEdit[파티 정보 수정 - 위자드]
+        PartyDetail --> EventCreate[이벤트 생성]
+        PartyDetail --> EventDetail[이벤트 상세]
+        EventDetail --> TicketCreate[티켓 생성]
+        EventDetail --> TicketEdit[티켓 수정]
+    end
+
+    subgraph "Settlement Tab"
+        Tab3 --> Settlement[수익 관리/정산]
+    end
+
+    subgraph "More Tab"
+        Tab4 --> More[더보기/설정]
+        More --> VerifManage[인증 심사 관리]
+        VerifManage --> VerifCreate[인증 템플릿 생성]
+        More --> MemberList[멤버 관리]
+        MemberList --> MemberPerm[멤버 권한 설정]
+    end
+```
+
+## 3. 온보딩 상태 관리 (Onboarding State Management)
+
+사용자의 인증 상태 및 파트너 신청 현황에 따른 화면 전이도입니다.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Loading
+    Loading --> Login: 미인증
+    Loading --> NeedsApplication: 인증 완료
+    
+    state NeedsApplication {
+        [*] --> needsApplication
+        needsApplication --> draftInProgress: 임시 저장
+        draftInProgress --> pendingReview: 제출 완료
+        pendingReview --> needsCorrection: 보완 요청
+        needsCorrection --> pendingReview: 재제출
+        pendingReview --> hasPartner: 승인 완료
+    }
+
+    Login --> NeedsApplication: 로그인 성공
+    needsApplication --> PartnerApply: 진입
+    draftInProgress --> PartnerApply: 이어서 작성
+    pendingReview --> PartnerApplyStatus: 대기중
+    needsCorrection --> PartnerApplyStatus: 수정하기
+    hasPartner --> PartnerHome: 앱 진입
+```
+
+## 4. 파트너 로그인 및 인증 (Partner Login & Auth)
+- **화면명**: 파트너 로그인 (PartnerLoginPage)
+- **라우트**: `/login`
+- **피처**: `auth`
+- **용도**: 파트너 앱 서비스 이용을 위한 로그인 및 인증 관리.
+- **주요 UI**: 
+  - 이메일/비밀번호 입력 폼
+  - 소셜 로그인 (카카오, 구글 등) 버튼
+  - 파트너 회원가입 링크
+- **네비게이션**: 
+  - 진입: 앱 최초 구동 시 미인증 상태일 때
+  - 이탈: 성공 시 온보딩 상태에 따라 `/apply`, `/apply/status` 또는 `/`로 리다이렉트
+
+## 5. 알림 센터 (Notification Center)
+- **화면명**: 알림 리스트 (NotificationListScreen)
+- **라우트**: `/notifications`
+- **피처**: `notification`
+- **용도**: 앱 내 발생하는 각종 알림 내역 확인.
+- **주요 UI**: 
+  - 시간 역순 알림 리스트
+  - 읽지 않은 알림 강조 표시
+  - 알림 유형별 아이콘 (공지, 신청, 정산, 심사)
+- **네비게이션**:
+  - 진입: 홈 화면 또는 상단 앱바의 종 아이콘 클릭
+  - 이탈: 뒤로가기 또는 각 알림 클릭 시 해당 상세 화면으로 이동
+
+## 6. [홈 탭] 파트너 홈 (Home: Dashboard)
+- **화면명**: 파트너 홈 (PartnerHomePage)
+- **라우트**: `/`
+- **피처**: `home`
+- **용도**: 파트너의 운영 현황을 한눈에 보여주는 메인 대시보드.
+- **주요 UI**: 
+  - 오늘의 이벤트 요약 카드
+  - 미처리 항목 (신청 대기자 등) 뱃지
+  - 공지사항 배너
+  - 주요 기능 퀵 메뉴 (이벤트 생성 등)
+- **네비게이션**: Bottom Nav 첫 번째 탭
+
+## 7. [홈 탭] 입점 안내 가이드 (Home: Location Guide)
+- **화면명**: 장소 등록 가이드 (LocationGuidePage)
+- **라우트**: `/guide/location`
+- **피처**: `home`
+- **용도**: 파티(장소) 등록 전 필요한 정보와 운영 정책 안내.
+- **주요 UI**: 
+  - 이미지 및 일러스트가 포함된 단계별 가이드
+  - 준비물 체크리스트
+  - 우수 운영 사례 링크
+- **네비게이션**: 홈 화면의 가이드 배너 또는 링크를 통해 진입
+
+## 8. [홈 탭] 파트너 입점 신청 목록 (Home: Application List - Admin)
+- **화면명**: 입점 신청 목록 (PartnerApplicationListPage)
+- **라우트**: `/applications`
+- **피처**: `admin`
+- **용도**: (시스템 관리자 전용) 신규 파트너들의 입점 신청 내역 관리.
+- **주요 UI**: 
+  - 신청서 리스트
+  - 상태 필터 (전체, 대기, 보완, 반려, 승인)
+  - 신청자명 및 매장명 검색
+- **네비게이션**: 홈 화면의 어드민 섹션에서 진입
+
+## 9. [홈 탭] 파트너 입점 신청 상세 (Home: Application Detail - Admin)
+- **화면명**: 입점 신청 상세 (PartnerApplicationDetailPage)
+- **라우트**: `/applications/:applicationId`
+- **피처**: `admin`
+- **용도**: 특정 파트너의 신청서를 검토하고 승인 여부를 결정.
+- **주요 UI**: 
+  - 사업자 정보 및 증빙 서류 이미지
+  - 매장 위치 및 사진
+  - 심사 결과 입력 폼 (반려 사유 등)
+  - 승인 / 보완요청 / 반려 버튼
+- **네비게이션**: 신청 목록에서 항목 클릭 시 진입
+
+## 10. [파티 탭] 파티 목록 관리 (Party: List Management)
+- **화면명**: 파티 목록 (PartyListPage)
+- **라우트**: `/parties`
+- **피처**: `party`
+- **용도**: 운영 중이거나 준비 중인 모든 파티(매장) 관리.
+- **주요 UI**: 
+  - 파티 카드 (이미지, 제목, 상태)
+  - 활성화/비활성화 토글
+  - 파티 생성 플로팅 버튼 (FAB)
+- **네비게이션**: Bottom Nav 두 번째 탭
+
+## 11. [파티 탭] 파티 생성/편집 위자드 (Party: Create & Edit Wizard)
+- **화면명**: 파티 생성 위자드 (PartyCreateWizardPage)
+- **라우트**: 
+  - 생성: `/parties/create`
+  - 편집: `/parties/:partyId/edit`
+- **피처**: `party`
+- **용도**: **파티 신규 등록 및 기존 파티 정보 수정을 담당하는 통합 위자드.**
+- **주요 특징**: 6단계의 프로세스로 구성되며, 편집 시에는 기존 데이터를 프리필(Pre-fill)함.
+- **단계별 내용**:
+  1. 기본 정보 (이름, 설명, 카테고리)
+  2. 위치 (지도상 좌표, 상세 주소)
+  3. 인원 및 연락처 (정원, 문의 전화)
+  4. 입장 규칙 (연령, 성별, 매칭 여부)
+  5. 티켓 템플릿 (기본 가격 구성)
+  6. 최종 리뷰
+- **네비게이션**: 파티 목록의 '생성' 버튼 또는 파티 상세의 '편집' 메뉴를 통해 진입
+
+## 12. [파티 상세] 이벤트 관리 탭 (Party Detail: Events)
+- **화면명**: 파티 상세 - 이벤트 관리 (PartyEventManagementTab)
+- **소속**: `PartyDetailPage` (1번 탭)
+- **용도**: 해당 파티에서 진행되는 실제 이벤트(회차)들의 일정 관리.
+- **주요 UI**: 
+  - 날짜별 이벤트 리스트
+  - 이벤트 생성 버튼
+  - 각 이벤트의 모집 현황 요약
+
+## 13. [파티 상세] 파티 정보 탭 (Party Detail: Info)
+- **화면명**: 파티 상세 - 정보 조회 (PartyInfoTab)
+- **소속**: `PartyDetailPage` (2번 탭)
+- **용도**: 등록된 파티의 고정적인 기본 정보 확인.
+- **주요 UI**: 
+  - 위치 지도 뷰
+  - 파티 소개 텍스트 및 태그
+  - 시설 정보 및 이용 수칙 리스트
+
+## 14. [파티 상세] 입장 그룹 및 티켓 탭 (Party Rule Management)
+- **화면명**: 파티 상세 - 입장/티켓 관리 (PartyRuleManagementTab)
+- **소속**: `PartyDetailPage` (3번 탭)
+- **용도**: 파티의 기본 입장 그룹과 티켓 판매 규칙 관리.
+- **주요 UI**: 
+  - 설정된 입장 그룹 목록 (남성, 여성 등)
+  - 티켓 템플릿 관리 메뉴
+  - 매칭 설정 요약 정보
+
+## 15. [이벤트] 이벤트 생성 프로세스 (Event: Creation)
+- **화면명**: 이벤트 생성 (EventCreatePage)
+- **라우트**: `/parties/:partyId/events/create`
+- **피처**: `party`
+- **용도**: 특정 파티의 구체적인 일정을 생성.
+- **주요 UI**: 
+  - 날짜 및 시작/종료 시간 선택기
+  - 모집 정원 설정 (파티 기본값 상속/변경)
+  - 해당 회차 공지사항 입력
+- **네비게이션**: 파티 상세 이벤트 관리 탭에서 '이벤트 생성' 클릭 시 진입
+
+## 16. [이벤트] 이벤트 상세 및 운영 (Event: Detail & Operations)
+- **화면명**: 이벤트 상세 (EventDetailPage)
+- **라우트**: `/parties/:partyId/events/:eventId`
+- **피처**: `party`
+- **용도**: 특정 이벤트 회차의 실시간 참가자 관리 및 운영.
+- **주요 UI**: 
+  - 참가 신청자 명단
+  - 체크인/미체크인 현황
+  - 티켓 판매 통계
+  - QR 스캐너 실행 버튼
+- **네비게이션**: 파티 상세 이벤트 리스트에서 항목 클릭 시 진입
+
+## 17. [티켓] 티켓 구성 및 가격 설정 (Ticket: Configuration)
+- **화면명**: 티켓 생성/편집 (TicketCreatePage / TicketEditPage)
+- **라우트**: 
+  - 생성: `/parties/:partyId/events/:eventId/tickets/create`
+  - 편집: `.../tickets/:ticketId/edit`
+- **피처**: `ticket`
+- **용도**: 판매할 티켓의 상세 조건 설정.
+- **주요 UI**: 
+  - 티켓 명칭 및 설명
+  - 가격 및 할인 정보
+  - 판매 수량 제한
+  - 판매 기간 (시작/종료) 설정
+
+## 18. [수익 탭] 정산 및 수익 관리 (Settlement & Revenue)
+- **화면명**: 정산 관리 (SettlementPage)
+- **라우트**: `/settlement`
+- **피처**: `settlement`
+- **용도**: 누적 수익금 조회 및 정산 신청 처리.
+- **상세 사양**: 상세 UI/UX 명세는 [정산 UI/UX 설계서](../../features/partner-settlement/ui-ux-design.md)를 참조하십시오.
+- **주요 UI**: 
+  - 정산 가능 금액 섹션
+  - 월별 수익 리포트 그래프
+  - 정산 계좌 관리 기능
+- **네비게이션**: Bottom Nav 세 번째 탭
+
+## 19. [더보기 탭] 설정 및 프로필 (More: Settings & Profile)
+- **화면명**: 설정 메인 (MorePage)
+- **라우트**: `/more`
+- **피처**: `more`
+- **용도**: 개인 정보 관리 및 각종 부가 기능의 진입점.
+- **주요 UI**: 
+  - 파트너 프로필 정보
+  - 메뉴 리스트 (멤버 관리, 인증 심사, 공지사항 등)
+  - 앱 버전 정보 및 로그아웃 버튼
+- **네비게이션**: Bottom Nav 네 번째 탭
+
+## 20. [더보기 탭] 유저 인증 심사 관리 (More: Verification Management)
+- **화면명**: 인증 심사 관리 (VerificationManagePage)
+- **라우트**: `/more/verifications/manage`
+- **피처**: `verification`
+- **용도**: 유저 신뢰를 위한 인증 시스템(직장, 학력 등)의 활성화 및 상태 관리.
+- **주요 UI**: 
+  - 운영 중인 인증 템플릿 리스트
+  - 심사 대기 건수 표시
+  - 인증 프로세스 통계 요약
+
+## 21. [더보기 탭] 인증 템플릿 생성 (More: Create Verification)
+- **화면명**: 인증 템플릿 생성 (CreateVerificationPage)
+- **라우트**: `/more/verifications/create`
+- **피처**: `verification`
+- **용도**: 새로운 유저 인증 요구사항(예: 특정 자격증, 신분증 인증)을 정의.
+- **주요 UI**: 
+  - 인증 제목 및 설명 입력
+  - 제출 필수 서류 양식 정의
+  - 인증 마크 이미지 업로드
+
+## 22. [더보기 탭] 멤버 및 권한 관리 (More: Member & Permissions)
+- **화면명**: 파트너 멤버 목록 (PartnerMemberListPage)
+- **라우트**: `/more/partners/:partnerId/members`
+- **피처**: `member`
+- **용도**: 파티를 공동 운영하는 직원(매니저, 스태프) 관리.
+- **주요 UI**: 
+  - 멤버 리스트 및 현재 역할 표시
+  - 새로운 멤버 초대 버튼
+  - 멤버별 활동 로그 링크
+
+## 23. [더보기 탭] 멤버 권한 상세 설정 (More: Member Permission Detail)
+- **화면명**: 멤버 권한 설정 (PartnerMemberPermissionPage)
+- **라우트**: `/more/partners/:partnerId/members/:targetUserId/permission`
+- **피처**: `member`
+- **용도**: 특정 멤버에게 부여된 권한(매니저, 스태프 등) 수정.
+- **주요 UI**: 권한 항목 체크박스 리스트 (파티 관리 권한, 이벤트 관리 권한, 정산 조회 권한 등).
+
+## 24. [모달] 파티 정보 부분 수정 (Modal: Quick Edit)
+- **용도**: 전체 위자드 진입 없이 파티의 특정 정보만 빠르게 수정하기 위한 하단 시트 화면들.
+- **주요 화면**:
+  - **PartyBasicInfoEditScreen**: 이름, 설명, 이미지 수정.
+  - **PartyLocationEditScreen**: 장소 좌표 및 주소 텍스트 수정.
+  - **PartyCapacityContactEditScreen**: 정원, 최소 인원, 연락처 정보 수정.
+
+## 25. [모달] 운영 및 매칭 설정 (Modal: Matching & Rules)
+- **용도**: 파티의 입장 로직 및 매칭 조건을 세부적으로 조정.
+- **주요 화면**:
+  - **MatchingSettingsScreen**: 매칭 알고리즘 가중치 및 선호도 설정.
+  - **EntryGroupEditorScreen**: 입장 그룹(예: 신규 회원, 우수 회원, 남성/여성 전용) 정의 및 편집.
+
+## 26. [모달] 티켓 및 입장 관리 (Modal: Ticket & Entry)
+- **용도**: 티켓 라이브러리 및 현장 입장 관련 부조 화면.
+- **주요 화면**:
+  - **TicketManageScreen**: 파티/이벤트별 전체 티켓 현황 조회.
+  - **TicketTemplateManageScreen**: 자주 사용하는 티켓 설정 재사용을 위한 템플릿 관리.
+  - **QRScannerScreen**: 티켓 검수용 카메라 스캐너. (체크인 및 일반 QR 인식 중복 기능 포함)
+
+## 27. [온보딩] 파트너 입점 신청 위자드 (Onboarding: Application Wizard)
+- **화면명**: 파트너 신청 페이지 (PartnerApplyPage)
+- **라우트**: `/apply`
+- **피처**: `onboarding`
+- **용도**: 일반 유저가 파트너 권한을 획득하기 위한 필수 신청 프로세스.
+- **단계**:
+  1. 기본 매장 정보 입력
+  2. 사업자 등록 정보 및 번호 인증
+  3. 연락처 및 정산 수령 계좌 설정
+  4. 증빙 서류 업로드 (사업자 등록증 등)
+  5. 입력 정보 최종 확인 및 제출
+
+## 28. [온보딩] 입점 신청 상태 및 보완 (Onboarding: Application Status)
+- **화면명**: 신청 상태 확인 (PartnerApplyStatusPage)
+- **라우트**: `/apply/status`
+- **피처**: `onboarding`
+- **용도**: 제출된 신청서의 심사 진행 현황 확인 및 보완 요청 대응.
+- **주요 UI**: 
+  - 상태 인디케이터 (심사중, 보완요청, 반려)
+  - 관리자 의견 (보완 사유) 표시 섹션
+  - 위자드로 다시 돌아가기 버튼 (수정용)
+
+---
+*이 문서는 파트너 앱의 화면 구성을 지속적으로 반영하며, 상세 디자인은 Figma 링크를 참조하십시오.*

--- a/docs/ux/partner-app/user-flows.md
+++ b/docs/ux/partner-app/user-flows.md
@@ -345,4 +345,12 @@ flowchart TD
 
 ---
 
+## 관련 문서
+
+- [화면 카탈로그](screen-catalog.md) — 각 화면의 상세 정보, 라우트 경로, UI 요소
+- [디자인 시스템](design-system.md) — 디자인 토큰, 컴포넌트 테마, 위젯 패턴 카탈로그
+- [정산 UI/UX 설계](../../features/partner-settlement/ui-ux-design.md) — 정산 플로우 상세 설계
+
+---
+
 *이 문서는 `app_router.dart`, `partner_apply_controller.dart`, `party_create_wizard_controller.dart`, `event_application_controller.dart`, `checkin_controller.dart` 소스를 기반으로 작성되었습니다.*

--- a/docs/ux/partner-app/user-flows.md
+++ b/docs/ux/partner-app/user-flows.md
@@ -1,174 +1,348 @@
-# 파트너 앱 사용자 여정 (User Flows)
+# 파트너 앱 사용자 여정 플로우 (User Flows)
 
-이 문서는 밍릿 파트너 앱(`app_partner`)의 주요 사용자 여정과 핵심 비즈니스 로직에 따른 화면 전이 흐름을 정의합니다. 모든 화면 명칭과 라우트 경로는 [화면 카탈로그(screen-catalog.md)](screen-catalog.md)를 준수합니다.
-
-## 1. 개요
-파트너 앱은 사용자가 파트너 권한을 획득하는 **온보딩** 단계부터, 자신의 공간을 등록하고 **이벤트를 운영**하며 **수익을 정산**받는 전 과정을 포괄합니다. 각 여정은 복잡한 상태 전이를 포함하며, 특히 인증 게이트를 통해 사용자의 권한 상태에 맞는 최적의 화면을 제공합니다.
+이 문서는 밍릿 파트너 앱(`app_partner`)의 주요 사용자 여정을 플로우차트로 정의한 UX 레퍼런스입니다.
+각 플로우에서 사용하는 화면명과 라우트 경로는 **[화면 카탈로그](./screen-catalog.md)** 를 기준으로 합니다.
 
 ---
 
-## 2. 인증 게이트 및 초기 진입 플로우
-앱 실행 시 사용자의 인증 상태와 파트너 온보딩 완료 여부를 체크하여 적절한 페이지로 리다이렉트합니다.
+## 목차
+
+1. [인증 게이트 플로우](#인증-게이트-플로우)
+2. [Flow 1 — 파트너 온보딩](#flow-1--파트너-온보딩)
+3. [Flow 2 — 파티 생성](#flow-2--파티-생성)
+4. [Flow 3 — 이벤트 생성 및 운영](#flow-3--이벤트-생성-및-운영)
+5. [Flow 4 — 신청 심사](#flow-4--신청-심사)
+6. [Flow 5 — 정산 확인](#flow-5--정산-확인)
+7. [Flow 6 — QR 체크인](#flow-6--qr-체크인)
+8. [공통 예외 경로](#공통-예외-경로)
+
+---
+
+## 인증 게이트 플로우
+
+앱 진입 시 `GoRouter`의 `redirect` 로직이 인증 상태와 온보딩 상태를 순차적으로 검사하여 적절한 화면으로 분기한다.
+분기 기준은 `currentUserProvider`(로그인 여부)와 `onboardingStateProvider`(파트너 신청 상태) 두 가지다.
 
 ```mermaid
-graph TD
-    Start([앱 실행]) --> Loading[로딩 및 상태 확인]
-    Loading --> AuthCheck{로그인 여부}
-    
-    AuthCheck -- No --> Login[파트너 로그인 /login]
-    Login --> LoginSuccess[로그인 성공]
-    LoginSuccess --> Loading
-    
-    AuthCheck -- Yes --> OnboardingCheck{온보딩 상태}
-    
-    OnboardingCheck -- "미신청 (needsApplication)" --> Apply[파트너 신청 위자드 /apply]
-    OnboardingCheck -- "임시저장 (draftInProgress)" --> Apply
-    
-    OnboardingCheck -- "심사중 (pendingReview)" --> ApplyStatus[신청 상태 확인 /apply/status]
-    OnboardingCheck -- "보완필요 (needsCorrection)" --> ApplyStatus
-    
-    OnboardingCheck -- "승인완료 (hasPartner)" --> Main[파트너 홈 /]
-    
-    ApplyStatus -- "수정하기 클릭" --> Apply
-    Apply -- "제출 완료" --> ApplyStatus
-    Main --> BottomNav[하단 내비게이션 활성화]
+flowchart TD
+    A([앱 진입]) --> B{로그인 여부\ncurrentUserProvider}
+    B -- 미인증 --> C[파트너 로그인\n/login]
+    C -- 로그인 성공 --> B
+    B -- 인증됨 --> D{onboardingState\n로드 완료?}
+    D -- 로딩 중 --> E[스플래시/로딩 유지]
+    E --> D
+    D -- 완료 --> F{온보딩 상태\nonboardingStateProvider}
+
+    F -- needsApplication --> G[파트너 신청 위자드\n/apply]
+    F -- draftInProgress --> G
+    F -- pendingReview --> H[신청 상태 확인\n/apply/status]
+    F -- needsCorrection --> H
+    F -- hasPartner --> I[파트너 홈\n/]
+
+    G -- 이미 파트너 상태로 진입 시 --> I
+    H -- 이미 파트너 상태로 진입 시 --> I
+
+    style C fill:#fef3c7
+    style G fill:#dbeafe
+    style H fill:#dbeafe
+    style I fill:#dcfce7
+```
+
+> **참고**: `/dev` 경로는 인증 없이 접근 가능 (개발 전용 DevMap).
+> 로그인 상태에서 `/login` 접근 시 `/`로 즉시 리다이렉트.
+
+---
+
+## Flow 1 — 파트너 온보딩
+
+일반 유저가 파트너 권한을 획득하기까지의 전체 여정.
+신청 위자드(`PartnerApplyPage`)는 5단계로 구성되며, 각 단계 이동 시 임시 저장(draft)이 자동으로 수행된다.
+
+```mermaid
+flowchart TD
+    A([앱 최초 진입\nneedsApplication 상태]) --> B[파트너 로그인\n/login]
+    B -- 회원가입 링크 --> C[회원가입 완료]
+    C --> B
+    B -- 로그인 성공 --> D[파트너 신청 위자드\n/apply]
+
+    D --> S1[Step 1\n기본 매장 정보\n브랜드명·소개·프로필 이미지]
+    S1 -- 유효성 통과 → nextStep + saveDraft --> S2[Step 2\n사업자 등록 정보\n사업자 유형·번호·대표자명]
+    S2 -- 유효성 통과 --> S3[Step 3\n연락처 및 정산 계좌\n전화·이메일·은행·계좌번호·세금계산서 이메일]
+    S3 -- 유효성 통과 --> S4[Step 4\n증빙 서류 업로드\n사업자등록증·통장사본]
+    S4 -- 유효성 통과 --> S5[Step 5\n최종 확인 및 제출]
+
+    S1 -- 유효성 실패 --> S1
+    S2 -- 유효성 실패 --> S2
+    S3 -- 유효성 실패 --> S3
+    S4 -- 유효성 실패 --> S4
+
+    S2 -- 이전 --> S1
+    S3 -- 이전 --> S2
+    S4 -- 이전 --> S3
+    S5 -- 이전 --> S4
+
+    S5 -- 제출 성공 --> W[신청 상태 확인\n/apply/status\npendingReview 상태]
+    S5 -- 제출 실패 --> ERR[에러 토스트 표시]
+    ERR --> S5
+
+    W --> R{관리자 심사 결과}
+    R -- 승인 --> I[파트너 홈\n/\nhasPartner 상태]
+    R -- 보완요청 --> K[신청 상태 확인\n/apply/status\nneedsCorrection + 보완 사유 표시]
+    K -- 수정하기 --> D
+    R -- 반려 --> L[신청 상태 확인\n/apply/status\n반려 사유 표시]
+    L -- 재신청 --> D
+
+    D -- 앱 종료 후 재진입\ndraftInProgress --> D2[임시저장 복원\n이어서 작성]
+    D2 --> S1
+```
+
+### 온보딩 상태 전이 요약
+
+| 상태 | 진입 화면 | 트리거 |
+|------|-----------|--------|
+| `needsApplication` | `/apply` (Step 1) | 최초 진입 |
+| `draftInProgress` | `/apply` (저장된 스텝) | 임시저장 후 재진입 |
+| `pendingReview` | `/apply/status` | 제출 완료 |
+| `needsCorrection` | `/apply/status` | 관리자 보완요청 |
+| `hasPartner` | `/` | 관리자 승인 |
+
+---
+
+## Flow 2 — 파티 생성
+
+파트너가 새로운 파티(매장)를 등록하는 여정.
+위자드는 `PartyCreateStep` enum 기준 6단계로 구성되며, 편집 시에는 기존 데이터가 프리필(`isPrefilled=true`)된다.
+
+```mermaid
+flowchart TD
+    A([파트너 홈\n/]) --> B[파티 목록\n/parties]
+    B -- FAB '파티 생성' 클릭 --> C[파티 생성 위자드\n/parties/create]
+
+    C --> W1[Step 1: basicInfo\n파티명·설명·카테고리·이미지]
+    W1 -- 유효성 통과 --> W2[Step 2: location\n지도 좌표·상세 주소·오시는 길]
+    W2 -- 유효성 통과 --> W3[Step 3: capacityAndContact\n정원·최소인원·연락처·성비균형 허용치]
+    W3 -- 유효성 통과 --> W4[Step 4: entryRules\n입장 그룹 설정\nEntryGroupTemplate 정의]
+    W4 -- 유효성 통과 --> W5[Step 5: tickets\n티켓 템플릿 구성\nTicketTemplate 가격·수량·공개 여부]
+    W5 -- 유효성 통과 --> W6[Step 6: review\n전체 입력 내용 최종 확인]
+
+    W1 -- 유효성 실패 --> W1
+    W2 -- 유효성 실패 --> W2
+    W3 -- 유효성 실패 --> W3
+    W4 -- 유효성 실패 --> W4
+    W5 -- 유효성 실패 --> W5
+
+    W2 -- 이전 --> W1
+    W3 -- 이전 --> W2
+    W4 -- 이전 --> W3
+    W5 -- 이전 --> W4
+    W6 -- 이전 --> W5
+
+    W6 -- 생성 완료 --> D[파티 상세\n/parties/:partyId]
+    W6 -- 생성 실패 --> ERR[에러 토스트]
+    ERR --> W6
+
+    D --> B
+
+    B -- 기존 파티 '편집' 메뉴 --> E[파티 생성 위자드\n/parties/:partyId/edit\nisPrefilled=true]
+    E --> W1
+```
+
+### 파티 생성 위자드 단계 요약
+
+| 스텝 | `PartyCreateStep` | 주요 입력 |
+|------|-------------------|-----------|
+| 1 | `basicInfo` | 파티명, 설명, 카테고리, 이미지 |
+| 2 | `location` | 지도 좌표(`Location`), 상세 주소, 오시는 길 안내 |
+| 3 | `capacityAndContact` | 정원, 최소 인원, 연락처, 성비 균형 허용치(`balanceTolerance`) |
+| 4 | `entryRules` | 입장 그룹(`EntryGroupTemplate`) 정의 |
+| 5 | `tickets` | 티켓 템플릿(`TicketTemplate`), 공개 여부(`visibility`) |
+| 6 | `review` | 전체 내용 최종 확인 후 제출 |
+
+---
+
+## Flow 3 — 이벤트 생성 및 운영
+
+파티 상세에서 특정 일정(이벤트 회차)을 생성하고 운영하는 여정.
+
+```mermaid
+flowchart TD
+    A[파티 상세\n/parties/:partyId] --> B[이벤트 관리 탭\nPartyEventManagementTab]
+    B -- '이벤트 생성' 클릭 --> C[이벤트 생성\n/parties/:partyId/events/create]
+
+    C --> D{날짜·시간·정원 입력\nEventCreatePage}
+    D -- 유효성 실패 --> D
+    D -- 저장 성공 --> E[이벤트 상세\n/parties/:partyId/events/:eventId]
+    D -- 저장 실패 --> ERR1[에러 토스트]
+    ERR1 --> D
+
+    E --> F[참가 신청자 명단 확인]
+    E --> G[체크인 현황 확인]
+    E --> H[티켓 판매 통계 확인]
+    E --> I[티켓 생성\n/parties/:partyId/events/:eventId/tickets/create]
+    E --> J[티켓 수정\n.../tickets/:ticketId/edit]
+    E --> K[QR 스캐너 실행\nQRScannerScreen]
+
+    I --> L{티켓 정보 입력\nTicketCreatePage\n명칭·가격·수량·판매기간}
+    L -- 유효성 실패 --> L
+    L -- 저장 --> E
+
+    J --> M{티켓 정보 수정\nTicketEditPage}
+    M -- 저장 --> E
+
+    K --> N[체크인 플로우\n→ Flow 6 참조]
+    N --> E
 ```
 
 ---
 
-## 3. 여정 1 — 파트너 온보딩 (입점 신청)
-일반 유저가 파트너가 되기 위해 사업자 정보와 증빙 서류를 제출하는 5단계 위자드 프로세스입니다.
+## Flow 4 — 신청 심사
+
+이벤트에 참가 신청한 유저를 개별 심사하는 여정.
+`EventApplicationReviewController`가 `approved` / `rejected` 두 가지 상태를 처리하며,
+인증 제출(`verification_submission`)이 연결된 경우 `verificationRepository`를 통해 처리한다.
 
 ```mermaid
-graph TD
-    A[PartnerApplyPage 진입] --> S1[Step 1: 기본 매장 정보]
-    S1 -- "다음" --> S2[Step 2: 사업자 정보]
-    S2 -- "이전" --> S1
-    S2 -- "다음" --> S3[Step 3: 연락처 및 정산 계좌]
-    S3 -- "이전" --> S2
-    S3 -- "다음" --> S4[Step 4: 증빙 서류 업로드]
-    S4 -- "이전" --> S3
-    S4 -- "다음" --> S5[Step 5: 최종 확인 및 제출]
-    
-    S5 -- "제출" --> Submit{제출 처리}
-    Submit -- "성공" --> Status[PartnerApplyStatusPage 심사중]
-    Submit -- "오류" --> Error[에러 팝업/토스트]
-    Error --> S5
-    
-    Status -- "관리자 보완 요청" --> Correction[상태: 보완 필요]
-    Correction -- "수정하기" --> S1
-    
-    Status -- "관리자 최종 승인" --> Home[PartnerHomePage 진입]
+flowchart TD
+    A[이벤트 상세\n/parties/:partyId/events/:eventId] --> B[참가 신청자 명단\neventApplications 목록]
+    B -- 신청자 항목 클릭 --> C[신청 상세 모달\n신청자 프로필·인증 서류]
+
+    C --> VS{verification_submission\n존재 여부}
+    VS -- 있음 --> VR[verificationRepository.reviewRequest\nVerificationStatus.approved/rejected]
+    VS -- 없음 --> DR[event_applications 직접 업데이트\nstatus + rejection_reason]
+
+    VR --> D{심사 결정}
+    DR --> D
+
+    D -- 승인 --> E[status: approved\n신청자에게 승인 알림 발송]
+    D -- 거절 → 사유 없음 --> F[status: rejected]
+    D -- 거절 → 사유 입력 --> G[status: rejected\nrejection_reason 저장]
+
+    E --> H[명단 갱신\n승인 상태로 표시]
+    F --> H
+    G --> H
+
+    H --> B
+
+    B -- 전체 일괄 승인 --> I[일괄 approved 처리]
+    I --> H
+
+    C -- 심사 중 오류 --> ERR[에러 토스트\n재시도 안내]
+    ERR --> C
 ```
+
+### 심사 결과 상태값
+
+| 결과 | `status` 값 | `rejection_reason` | 비고 |
+|------|-------------|---------------------|------|
+| 승인 | `approved` | — | 신청자 입장 확정, 알림 발송 |
+| 거절 (사유 없음) | `rejected` | `null` | — |
+| 거절 (사유 있음) | `rejected` | 사유 문자열 | 신청자에게 사유 전달 |
 
 ---
 
-## 4. 여정 2 — 파티 생성 (장소 등록)
-파트너가 이벤트를 개최할 기반이 되는 파티(매장) 공간을 등록하는 6단계 위자드입니다.
+## Flow 5 — 정산 확인
+
+정산 탭에서 수익 현황을 확인하는 여정. 상세 UI/UX 명세는
+**[정산 UI/UX 설계서](../../features/partner-settlement/ui-ux-design.md)** 를 참조한다.
 
 ```mermaid
-graph TD
-    List[PartyListPage] --> CreateBtn[파티 생성 버튼 클릭]
-    CreateBtn --> W1[Step 1: 기본 정보 - 이름/설명/이미지]
-    W1 -- "다음" --> W2[Step 2: 위치 - 지도/상세주소]
-    W2 -- "다음" --> W3[Step 3: 인원 및 연락처]
-    W3 -- "다음" --> W4[Step 4: 입장 규칙 - 그룹 설정]
-    W4 -- "다음" --> W5[Step 5: 티켓 템플릿]
-    W5 -- "다음" --> W6[Step 6: 최종 리뷰]
-    
-    W6 -- "생성 완료" --> Detail[PartyDetailPage]
-    
-    Detail -- "정보 수정" --> EditWizard[편집 모드 진입]
-    EditWizard -- "기존 데이터 프리필" --> W1
+flowchart TD
+    A([Bottom Nav\n수익관리 탭]) --> B[정산 관리\n/settlement\nSettlementPage]
+
+    B --> C[정산 가능 금액 섹션]
+    B --> D[월별 수익 리포트 그래프]
+    B --> E[정산 계좌 관리]
+
+    C -- 정산 신청 클릭 --> F{계좌 등록 여부}
+    F -- 미등록 --> G[계좌 등록 안내\n→ 계좌 관리로 이동]
+    G --> E
+    F -- 등록됨 --> H[정산 신청 확인 다이얼로그]
+    H -- 확인 --> I[정산 신청 완료\n처리 중 상태 표시]
+    H -- 취소 --> B
+
+    D -- 월 선택 --> J[해당 월 상세 내역]
+    J -- 뒤로가기 --> B
+
+    E -- 계좌 추가/변경 --> K[계좌 정보 입력 폼]
+    K -- 저장 성공 --> B
+    K -- 저장 실패 --> ERR[에러 토스트]
+    ERR --> K
 ```
+
+> 정산 플로우 상세(수수료 계산, 정산 주기, 세금계산서 등)는 [정산 UI/UX 설계서](../../features/partner-settlement/ui-ux-design.md)에서 관리한다.
 
 ---
 
-## 5. 여정 3 — 이벤트 생성 및 운영
-등록된 파티를 기반으로 실제 모집 일정(이벤트)을 생성하고 관리합니다.
+## Flow 6 — QR 체크인
+
+현장에서 유저의 QR 티켓을 스캔하여 입장을 처리하는 여정.
+`CheckinController`는 `idle → processing → (success | invalid | alreadyCheckedIn | error) → idle` 사이클로 동작하며,
+결과 표시 후 **3초 뒤 자동으로 `idle` 상태로 복귀**한다.
 
 ```mermaid
-graph TD
-    PartyDetail[PartyDetailPage] --> EventTab[이벤트 관리 탭]
-    EventTab --> CreateEv[이벤트 생성 버튼]
-    CreateEv --> EvForm[EventCreatePage: 날짜/시간/정원 설정]
-    EvForm -- "저장" --> PartyDetail
-    
-    PartyDetail --> EvList[이벤트 리스트]
-    EvList -- "클릭" --> EvDetail[EventDetailPage: 운영 대시보드]
-    
-    EvDetail --> Ops{운영 작업}
-    Ops --> Scan[QR 스캐너 실행]
-    Ops --> Manage[참가자 명단 관리]
-    Ops --> Ticket[티켓 설정 변경]
+flowchart TD
+    A([이벤트 상세\n/parties/:partyId/events/:eventId]) --> B[QR 스캐너 버튼 클릭]
+    B --> C[QRScannerScreen\nCheckinResult: idle]
+
+    C -- QR 코드 인식 --> D[CheckinResult: processing\nJSON 파싱 + TicketToken 생성]
+
+    D --> E{서명 검증\nrepo.verifyAndCheckin}
+    E -- 유효한 티켓 --> F[CheckinResult: success\n유저명 표시\n입장 처리 완료]
+    E -- 이미 체크인 --> G[CheckinResult: alreadyCheckedIn\n중복 입장 경고]
+    E -- 서명 불일치 --> H[CheckinResult: invalid\n'유효하지 않은 티켓입니다']
+    E -- JSON 파싱 실패 --> I[CheckinResult: invalid\n'티켓 데이터를 읽을 수 없습니다']
+    E -- 네트워크/기타 오류 --> J[CheckinResult: error\n오류 메시지 표시]
+
+    F -- 3초 후 자동 복귀 --> C
+    G -- 3초 후 자동 복귀 --> C
+    H -- 3초 후 자동 복귀 --> C
+    I -- 3초 후 자동 복귀 --> C
+    J -- 3초 후 자동 복귀 --> C
+
+    C -- 뒤로가기 --> A
 ```
+
+### 체크인 결과 상태 요약
+
+| `CheckinResult` | 표시 내용 | 후속 동작 |
+|-----------------|-----------|-----------|
+| `idle` | 스캐너 대기 화면 | — |
+| `processing` | 로딩 인디케이터 | — |
+| `success` | 유저명 + 성공 메시지 | 3초 후 idle 복귀 |
+| `alreadyCheckedIn` | 중복 입장 경고 | 3초 후 idle 복귀 |
+| `invalid` | 오류 메시지 | 3초 후 idle 복귀 |
+| `error` | 오류 메시지 | 3초 후 idle 복귀 |
 
 ---
 
-## 6. 여정 4 — 신청 심사 (참가 승인)
-유저들이 신청한 이벤트 참가 요청을 검토하고 승인 또는 거절합니다.
+## 공통 예외 경로
 
-```mermaid
-graph TD
-    EvDetail[EventDetailPage] --> AppList[신청자 명단 확인]
-    AppList --> AppItem[개별 신청 상세/프로필]
-    
-    AppItem --> Review{심사 결정}
-    Review -- "승인" --> Approve[상태: 승인됨/티켓 발송]
-    Review -- "거절" --> Reject[거절 사유 입력]
-    Review -- "보완요청" --> NeedsMore[보완 요청 메시지 발송]
-    
-    Approve --> Update[명단 현황 업데이트]
-    Reject --> Update
-    NeedsMore --> Update
-```
+모든 플로우에 공통으로 적용되는 예외 처리 원칙.
+
+| 예외 상황 | 처리 방식 |
+|-----------|-----------|
+| 네트워크 단절 | 스낵바 안내 + 재시도 유도 |
+| 권한 부족 | "권한이 없습니다" 팝업 (멤버 권한 설정에 따라) |
+| 위자드 유효성 실패 | 해당 필드 강조 + 다음 단계 이동 차단 |
+| 세션 만료 | `/login`으로 자동 리다이렉트 |
+| 서버 오류 (5xx) | 에러 토스트 + 재시도 버튼 |
 
 ---
 
-## 7. 여정 5 — 정산 확인 및 관리
-이벤트 운영을 통해 발생한 매출을 확인하고 정산을 관리합니다.
+## 화면 간 연결 관계 요약
 
-```mermaid
-graph TD
-    Tab[SettlementPage: 수익 관리] --> Summary[누적 수익 및 정산 가능 금액 확인]
-    Summary --> History[월별/이벤트별 상세 내역]
-    History --> Detail[정산 상세 리포트]
-    
-    Summary --> Account[정산 계좌 등록/변경]
-    Summary --> Request[정산 신청]
-    
-    subgraph "상세 설계 참조"
-        Ref[../../features/partner-settlement/ui-ux-design.md]
-    end
-    
-    Detail -.-> Ref
-```
+각 플로우에서 등장하는 화면의 전체 목록과 라우트는 **[화면 카탈로그](./screen-catalog.md)** 를 참조한다.
+
+| 플로우 | 진입점 | 핵심 화면 | 종료점 |
+|--------|--------|-----------|--------|
+| 인증 게이트 | 앱 진입 | `파트너 로그인`, `파트너 신청 위자드`, `신청 상태 확인` | `파트너 홈` |
+| 파트너 온보딩 | `파트너 로그인` | `파트너 신청 위자드` (5단계), `신청 상태 확인` | `파트너 홈` |
+| 파티 생성 | `파티 목록` | `파티 생성 위자드` (6단계) | `파티 상세` |
+| 이벤트 생성·운영 | `파티 상세` | `이벤트 생성`, `이벤트 상세`, `티켓 생성/편집` | `이벤트 상세` |
+| 신청 심사 | `이벤트 상세` | 신청 상세 모달 | `이벤트 상세` |
+| 정산 확인 | Bottom Nav 수익관리 탭 | `정산 관리` | `정산 관리` |
+| QR 체크인 | `이벤트 상세` | `QRScannerScreen` | `이벤트 상세` |
 
 ---
 
-## 8. 여정 6 — QR 체크인 플로우
-현장에서 유저의 디지털 티켓을 스캔하여 입장을 확인하는 프로세스입니다.
-
-```mermaid
-graph TD
-    EvDetail[EventDetailPage] --> ScanBtn[QR 스캔 버튼 클릭]
-    ScanBtn --> Scanner[QRScannerScreen 실행]
-    
-    Scanner -- "QR 코드 인식" --> Proc{CheckinController: 검증}
-    
-    Proc -- "성공" --> Success[체크인 완료 표시/이름 확인]
-    Proc -- "이미 체크인됨" --> Already[이미 입장한 유저 경고]
-    Proc -- "유효하지 않음" --> Invalid[위변조 또는 타 이벤트 티켓 에러]
-    Proc -- "네트워크 에러" --> Error[재시도 안내]
-    
-    Success --> Scanner
-    Already --> Scanner
-    Invalid --> Scanner
-```
-
----
-
-## 9. 예외 및 에러 경로
-- **네트워크 단절**: 모든 API 요청 시 오프라인 상태이면 스낵바를 통해 안내하고 재시도를 유도합니다.
-- **권한 부족**: 파트너 멤버 권한 설정에 따라 특정 메뉴(정산, 멤버 관리 등) 접근 시 "권한이 없습니다" 팝업을 노출합니다.
-- **데이터 유효성 실패**: 위자드 단계 이동 시 필수 항목 누락 시 해당 필드를 강조하고 이동을 차단합니다.
+*이 문서는 `app_router.dart`, `partner_apply_controller.dart`, `party_create_wizard_controller.dart`, `event_application_controller.dart`, `checkin_controller.dart` 소스를 기반으로 작성되었습니다.*

--- a/docs/ux/partner-app/user-flows.md
+++ b/docs/ux/partner-app/user-flows.md
@@ -1,0 +1,174 @@
+# 파트너 앱 사용자 여정 (User Flows)
+
+이 문서는 밍릿 파트너 앱(`app_partner`)의 주요 사용자 여정과 핵심 비즈니스 로직에 따른 화면 전이 흐름을 정의합니다. 모든 화면 명칭과 라우트 경로는 [화면 카탈로그(screen-catalog.md)](screen-catalog.md)를 준수합니다.
+
+## 1. 개요
+파트너 앱은 사용자가 파트너 권한을 획득하는 **온보딩** 단계부터, 자신의 공간을 등록하고 **이벤트를 운영**하며 **수익을 정산**받는 전 과정을 포괄합니다. 각 여정은 복잡한 상태 전이를 포함하며, 특히 인증 게이트를 통해 사용자의 권한 상태에 맞는 최적의 화면을 제공합니다.
+
+---
+
+## 2. 인증 게이트 및 초기 진입 플로우
+앱 실행 시 사용자의 인증 상태와 파트너 온보딩 완료 여부를 체크하여 적절한 페이지로 리다이렉트합니다.
+
+```mermaid
+graph TD
+    Start([앱 실행]) --> Loading[로딩 및 상태 확인]
+    Loading --> AuthCheck{로그인 여부}
+    
+    AuthCheck -- No --> Login[파트너 로그인 /login]
+    Login --> LoginSuccess[로그인 성공]
+    LoginSuccess --> Loading
+    
+    AuthCheck -- Yes --> OnboardingCheck{온보딩 상태}
+    
+    OnboardingCheck -- "미신청 (needsApplication)" --> Apply[파트너 신청 위자드 /apply]
+    OnboardingCheck -- "임시저장 (draftInProgress)" --> Apply
+    
+    OnboardingCheck -- "심사중 (pendingReview)" --> ApplyStatus[신청 상태 확인 /apply/status]
+    OnboardingCheck -- "보완필요 (needsCorrection)" --> ApplyStatus
+    
+    OnboardingCheck -- "승인완료 (hasPartner)" --> Main[파트너 홈 /]
+    
+    ApplyStatus -- "수정하기 클릭" --> Apply
+    Apply -- "제출 완료" --> ApplyStatus
+    Main --> BottomNav[하단 내비게이션 활성화]
+```
+
+---
+
+## 3. 여정 1 — 파트너 온보딩 (입점 신청)
+일반 유저가 파트너가 되기 위해 사업자 정보와 증빙 서류를 제출하는 5단계 위자드 프로세스입니다.
+
+```mermaid
+graph TD
+    A[PartnerApplyPage 진입] --> S1[Step 1: 기본 매장 정보]
+    S1 -- "다음" --> S2[Step 2: 사업자 정보]
+    S2 -- "이전" --> S1
+    S2 -- "다음" --> S3[Step 3: 연락처 및 정산 계좌]
+    S3 -- "이전" --> S2
+    S3 -- "다음" --> S4[Step 4: 증빙 서류 업로드]
+    S4 -- "이전" --> S3
+    S4 -- "다음" --> S5[Step 5: 최종 확인 및 제출]
+    
+    S5 -- "제출" --> Submit{제출 처리}
+    Submit -- "성공" --> Status[PartnerApplyStatusPage 심사중]
+    Submit -- "오류" --> Error[에러 팝업/토스트]
+    Error --> S5
+    
+    Status -- "관리자 보완 요청" --> Correction[상태: 보완 필요]
+    Correction -- "수정하기" --> S1
+    
+    Status -- "관리자 최종 승인" --> Home[PartnerHomePage 진입]
+```
+
+---
+
+## 4. 여정 2 — 파티 생성 (장소 등록)
+파트너가 이벤트를 개최할 기반이 되는 파티(매장) 공간을 등록하는 6단계 위자드입니다.
+
+```mermaid
+graph TD
+    List[PartyListPage] --> CreateBtn[파티 생성 버튼 클릭]
+    CreateBtn --> W1[Step 1: 기본 정보 - 이름/설명/이미지]
+    W1 -- "다음" --> W2[Step 2: 위치 - 지도/상세주소]
+    W2 -- "다음" --> W3[Step 3: 인원 및 연락처]
+    W3 -- "다음" --> W4[Step 4: 입장 규칙 - 그룹 설정]
+    W4 -- "다음" --> W5[Step 5: 티켓 템플릿]
+    W5 -- "다음" --> W6[Step 6: 최종 리뷰]
+    
+    W6 -- "생성 완료" --> Detail[PartyDetailPage]
+    
+    Detail -- "정보 수정" --> EditWizard[편집 모드 진입]
+    EditWizard -- "기존 데이터 프리필" --> W1
+```
+
+---
+
+## 5. 여정 3 — 이벤트 생성 및 운영
+등록된 파티를 기반으로 실제 모집 일정(이벤트)을 생성하고 관리합니다.
+
+```mermaid
+graph TD
+    PartyDetail[PartyDetailPage] --> EventTab[이벤트 관리 탭]
+    EventTab --> CreateEv[이벤트 생성 버튼]
+    CreateEv --> EvForm[EventCreatePage: 날짜/시간/정원 설정]
+    EvForm -- "저장" --> PartyDetail
+    
+    PartyDetail --> EvList[이벤트 리스트]
+    EvList -- "클릭" --> EvDetail[EventDetailPage: 운영 대시보드]
+    
+    EvDetail --> Ops{운영 작업}
+    Ops --> Scan[QR 스캐너 실행]
+    Ops --> Manage[참가자 명단 관리]
+    Ops --> Ticket[티켓 설정 변경]
+```
+
+---
+
+## 6. 여정 4 — 신청 심사 (참가 승인)
+유저들이 신청한 이벤트 참가 요청을 검토하고 승인 또는 거절합니다.
+
+```mermaid
+graph TD
+    EvDetail[EventDetailPage] --> AppList[신청자 명단 확인]
+    AppList --> AppItem[개별 신청 상세/프로필]
+    
+    AppItem --> Review{심사 결정}
+    Review -- "승인" --> Approve[상태: 승인됨/티켓 발송]
+    Review -- "거절" --> Reject[거절 사유 입력]
+    Review -- "보완요청" --> NeedsMore[보완 요청 메시지 발송]
+    
+    Approve --> Update[명단 현황 업데이트]
+    Reject --> Update
+    NeedsMore --> Update
+```
+
+---
+
+## 7. 여정 5 — 정산 확인 및 관리
+이벤트 운영을 통해 발생한 매출을 확인하고 정산을 관리합니다.
+
+```mermaid
+graph TD
+    Tab[SettlementPage: 수익 관리] --> Summary[누적 수익 및 정산 가능 금액 확인]
+    Summary --> History[월별/이벤트별 상세 내역]
+    History --> Detail[정산 상세 리포트]
+    
+    Summary --> Account[정산 계좌 등록/변경]
+    Summary --> Request[정산 신청]
+    
+    subgraph "상세 설계 참조"
+        Ref[../../features/partner-settlement/ui-ux-design.md]
+    end
+    
+    Detail -.-> Ref
+```
+
+---
+
+## 8. 여정 6 — QR 체크인 플로우
+현장에서 유저의 디지털 티켓을 스캔하여 입장을 확인하는 프로세스입니다.
+
+```mermaid
+graph TD
+    EvDetail[EventDetailPage] --> ScanBtn[QR 스캔 버튼 클릭]
+    ScanBtn --> Scanner[QRScannerScreen 실행]
+    
+    Scanner -- "QR 코드 인식" --> Proc{CheckinController: 검증}
+    
+    Proc -- "성공" --> Success[체크인 완료 표시/이름 확인]
+    Proc -- "이미 체크인됨" --> Already[이미 입장한 유저 경고]
+    Proc -- "유효하지 않음" --> Invalid[위변조 또는 타 이벤트 티켓 에러]
+    Proc -- "네트워크 에러" --> Error[재시도 안내]
+    
+    Success --> Scanner
+    Already --> Scanner
+    Invalid --> Scanner
+```
+
+---
+
+## 9. 예외 및 에러 경로
+- **네트워크 단절**: 모든 API 요청 시 오프라인 상태이면 스낵바를 통해 안내하고 재시도를 유도합니다.
+- **권한 부족**: 파트너 멤버 권한 설정에 따라 특정 메뉴(정산, 멤버 관리 등) 접근 시 "권한이 없습니다" 팝업을 노출합니다.
+- **데이터 유효성 실패**: 위자드 단계 이동 시 필수 항목 누락 시 해당 필드를 강조하고 이동을 차단합니다.

--- a/docs/ux/partner-app/user-flows.md
+++ b/docs/ux/partner-app/user-flows.md
@@ -20,18 +20,18 @@
 
 ## 인증 게이트 플로우
 
-앱 진입 시 `GoRouter`의 `redirect` 로직이 인증 상태와 온보딩 상태를 순차적으로 검사하여 적절한 화면으로 분기한다.
-분기 기준은 `currentUserProvider`(로그인 여부)와 `onboardingStateProvider`(파트너 신청 상태) 두 가지다.
+앱 진입 시 인증 상태와 온보딩 상태를 순차적으로 검사하여 적절한 화면으로 분기한다.
+분기 기준은 로그인 여부와 파트너 신청 상태 두 가지다.
 
 ```mermaid
 flowchart TD
-    A([앱 진입]) --> B{로그인 여부\ncurrentUserProvider}
+    A([앱 진입]) --> B{로그인 여부}
     B -- 미인증 --> C[파트너 로그인\n/login]
     C -- 로그인 성공 --> B
     B -- 인증됨 --> D{onboardingState\n로드 완료?}
     D -- 로딩 중 --> E[스플래시/로딩 유지]
     E --> D
-    D -- 완료 --> F{온보딩 상태\nonboardingStateProvider}
+    D -- 완료 --> F{온보딩 상태}
 
     F -- needsApplication --> G[파트너 신청 위자드\n/apply]
     F -- draftInProgress --> G
@@ -48,8 +48,7 @@ flowchart TD
     style I fill:#dcfce7
 ```
 
-> **참고**: `/dev` 경로는 인증 없이 접근 가능 (개발 전용 DevMap).
-> 로그인 상태에서 `/login` 접근 시 `/`로 즉시 리다이렉트.
+> **참고**: 로그인 상태에서 `/login` 접근 시 `/`로 즉시 리다이렉트.
 
 ---
 
@@ -198,8 +197,7 @@ flowchart TD
 ## Flow 4 — 신청 심사
 
 이벤트에 참가 신청한 유저를 개별 심사하는 여정.
-`EventApplicationReviewController`가 `approved` / `rejected` 두 가지 상태를 처리하며,
-인증 제출(`verification_submission`)이 연결된 경우 `verificationRepository`를 통해 처리한다.
+승인 또는 거절 두 가지 결과로 처리하며, 인증 제출이 연결된 경우 인증 심사도 함께 진행한다.
 
 ```mermaid
 flowchart TD
@@ -276,8 +274,8 @@ flowchart TD
 ## Flow 6 — QR 체크인
 
 현장에서 유저의 QR 티켓을 스캔하여 입장을 처리하는 여정.
-`CheckinController`는 `idle → processing → (success | invalid | alreadyCheckedIn | error) → idle` 사이클로 동작하며,
-결과 표시 후 **3초 뒤 자동으로 `idle` 상태로 복귀**한다.
+체크인은 `idle → processing → 결과(success/invalid/alreadyCheckedIn/error) → idle` 사이클로 동작하며,
+결과 표시 후 **3초 뒤 자동으로 대기 상태로 복귀**한다.
 
 ```mermaid
 flowchart TD
@@ -286,7 +284,7 @@ flowchart TD
 
     C -- QR 코드 인식 --> D[CheckinResult: processing\nJSON 파싱 + TicketToken 생성]
 
-    D --> E{서명 검증\nrepo.verifyAndCheckin}
+    D --> E{서명 검증}
     E -- 유효한 티켓 --> F[CheckinResult: success\n유저명 표시\n입장 처리 완료]
     E -- 이미 체크인 --> G[CheckinResult: alreadyCheckedIn\n중복 입장 경고]
     E -- 서명 불일치 --> H[CheckinResult: invalid\n'유효하지 않은 티켓입니다']


### PR DESCRIPTION
## Summary
- 파트너앱(app_partner)의 전체 UX/UI 레퍼런스 문서 3종 추가
- 개발자 + 디자이너 대상, 한국어, Mermaid 다이어그램 위주

## Deliverables
- `docs/ux/partner-app/screen-catalog.md` — 30개 화면 카탈로그 + 사이트맵 + 온보딩 상태 다이어그램
- `docs/ux/partner-app/user-flows.md` — 6개 사용자 여정 Mermaid 플로우차트 (인증 게이트, 온보딩, 파티 생성, 이벤트 운영, 신청 심사, QR 체크인)
- `docs/ux/partner-app/design-system.md` — 디자인 토큰 6종 + 컴포넌트 테마 + 위젯 패턴 7종 카탈로그

## Cross-references
- `docs/architecture/client.md` 참조 (기술 아키텍처는 거기에, UX/UI는 여기에)
- `docs/features/partner-settlement/ui-ux-design.md` 참조 (정산 상세는 기존 문서 활용)
- 3개 문서 간 상호 크로스링크 완비