### PR TITLE
feat(settlement): Phase 1 — DB schema foundation (5 tables + data migration + Flutter)

### DIFF
--- a/apps/app_partner/lib/src/features/settlement/settlement_list_section.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_list_section.dart
@@ -91,14 +91,14 @@ class _SettlementCard extends StatelessWidget {
             value: formatter.format(settlement.totalRefunds),
           ),
           _FeeRow(
-            label: 'PG 수수료 (3.5%)',
+            label: 'PG 수수료',
             value: formatter.format(settlement.pgFee),
           ),
           _FeeRow(
-            label: '플랫폼 수수료 (5%)',
+            label: '플랫폼 수수료',
             value: formatter.format(settlement.platformFee),
           ),
-          _FeeRow(label: '부가세 (10%)', value: formatter.format(settlement.vat)),
+          _FeeRow(label: '부가세', value: formatter.format(settlement.vat)),
           const Divider(height: MinglitSpacing.large),
           _FeeRow(
             label: '정산 예정액',
@@ -184,28 +184,40 @@ class _StatusBadge extends StatelessWidget {
   }
 
   String _statusLabel(String status) {
-    switch (status) {
-      case 'ready':
-        return '정산 가능';
-      case 'requested':
-        return '정산 신청됨';
-      case 'completed':
+    switch (status.toUpperCase()) {
+      case 'READY':
+        return '정산 확정';
+      case 'PROCESSING':
+        return '처리중';
+      case 'COMPLETED':
         return '정산 완료';
-      case 'pending':
+      case 'HOLD':
+        return '보류';
+      case 'CANCELED':
+        return '취소됨';
+      case 'FAILED':
+        return '실패';
+      case 'PENDING':
       default:
         return '정산 대기';
     }
   }
 
   Color _statusColor(String status, ColorScheme scheme) {
-    switch (status) {
-      case 'ready':
+    switch (status.toUpperCase()) {
+      case 'READY':
         return scheme.primary;
-      case 'requested':
+      case 'PROCESSING':
         return scheme.tertiary;
-      case 'completed':
+      case 'COMPLETED':
         return scheme.secondary;
-      case 'pending':
+      case 'HOLD':
+        return const Color(0xFFFF9800);
+      case 'CANCELED':
+        return scheme.error;
+      case 'FAILED':
+        return scheme.error;
+      case 'PENDING':
       default:
         return scheme.onSurfaceVariant;
     }

--- a/apps/app_partner/lib/src/features/settlement/settlement_models.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_models.dart
@@ -73,7 +73,8 @@ class PartnerSettlement {
       platformFee: _toInt(json['platform_fee']),
       vat: _toInt(json['vat']),
       netAmount: _toInt(json['net_amount']),
-      status: json['status'] as String? ?? 'pending',
+      // Normalize UPPERCASE statuses to lowercase for backward compatibility
+      status: (json['status'] as String? ?? 'pending').toLowerCase(),
     );
   }
 
@@ -90,6 +91,111 @@ class PartnerSettlement {
   final String status;
 }
 
+/// Represents a single settlement item from the `settlement_items` table.
+/// Uses UPPERCASE status values natively (see [SettlementItemStatus]).
+class SettlementItem {
+  const SettlementItem({
+    required this.id,
+    required this.partnerId,
+    required this.settlementPeriodStart,
+    required this.settlementPeriodEnd,
+    required this.currency,
+    required this.sourceType,
+    required this.sourceId,
+    required this.status,
+    required this.grossAmount,
+    required this.platformFeeRate,
+    required this.platformFeeAmount,
+    required this.pgFeeRate,
+    required this.pgFeeAmount,
+    required this.vatRate,
+    required this.vatAmount,
+    required this.netAmount,
+    required this.retryable,
+    required this.retryCount,
+    required this.calcChecksum,
+    required this.version,
+    required this.createdAt,
+    required this.updatedAt,
+    this.holdReasonCode,
+    this.holdReasonDetail,
+    this.failureReasonCode,
+    this.failureMessage,
+    this.nextRetryAt,
+    this.payoutId,
+    this.eventCompletedAt,
+  });
+
+  factory SettlementItem.fromJson(Map<String, dynamic> json) {
+    return SettlementItem(
+      id: json['id'] as String? ?? '',
+      partnerId: json['partner_id'] as String? ?? '',
+      settlementPeriodStart: _toDate(json['settlement_period_start']),
+      settlementPeriodEnd: _toDate(json['settlement_period_end']),
+      currency: json['currency'] as String? ?? 'KRW',
+      sourceType: json['source_type'] as String? ?? '',
+      sourceId: json['source_id'] as String? ?? '',
+      status: json['status'] as String? ?? 'PENDING',
+      grossAmount: _toInt(json['gross_amount']),
+      platformFeeRate: _toDouble(json['platform_fee_rate']),
+      platformFeeAmount: _toInt(json['platform_fee_amount']),
+      pgFeeRate: _toDouble(json['pg_fee_rate']),
+      pgFeeAmount: _toInt(json['pg_fee_amount']),
+      vatRate: _toDouble(json['vat_rate']),
+      vatAmount: _toInt(json['vat_amount']),
+      netAmount: _toInt(json['net_amount']),
+      holdReasonCode: json['hold_reason_code'] as String?,
+      holdReasonDetail: json['hold_reason_detail'] as String?,
+      failureReasonCode: json['failure_reason_code'] as String?,
+      failureMessage: json['failure_message'] as String?,
+      retryable: json['retryable'] as bool? ?? false,
+      retryCount: _toInt(json['retry_count']),
+      nextRetryAt: json['next_retry_at'] != null
+          ? _toDateTime(json['next_retry_at'])
+          : null,
+      payoutId: json['payout_id'] as String?,
+      calcChecksum: json['calc_checksum'] as String? ?? '',
+      version: _toInt(json['version']),
+      eventCompletedAt: json['event_completed_at'] != null
+          ? _toDateTime(json['event_completed_at'])
+          : null,
+      createdAt: _toDateTime(json['created_at']),
+      updatedAt: _toDateTime(json['updated_at']),
+    );
+  }
+
+  final String id;
+  final String partnerId;
+  final DateTime settlementPeriodStart;
+  final DateTime settlementPeriodEnd;
+  final String currency;
+  final String sourceType;
+  final String sourceId;
+  // 'PENDING','HOLD','CANCELED','READY','PROCESSING','COMPLETED','FAILED'
+  final String status;
+  final int grossAmount;
+  final double platformFeeRate;
+  final int platformFeeAmount;
+  final double pgFeeRate;
+  final int pgFeeAmount;
+  final double vatRate;
+  final int vatAmount;
+  final int netAmount;
+  final String? holdReasonCode;
+  final String? holdReasonDetail;
+  final String? failureReasonCode;
+  final String? failureMessage;
+  final bool retryable;
+  final int retryCount;
+  final DateTime? nextRetryAt;
+  final String? payoutId;
+  final String calcChecksum;
+  final int version;
+  final DateTime? eventCompletedAt;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+}
+
 int _toInt(dynamic value) {
   if (value is int) return value;
   if (value is num) return value.round();
@@ -97,8 +203,32 @@ int _toInt(dynamic value) {
   return 0;
 }
 
+double _toDouble(dynamic value) {
+  if (value is double) return value;
+  if (value is num) return value.toDouble();
+  if (value is String) return double.tryParse(value) ?? 0;
+  return 0;
+}
+
 DateTime _toDateTime(dynamic value) {
   if (value is DateTime) return value;
   if (value is String) return DateTime.tryParse(value) ?? DateTime.now();
   return DateTime.now();
+}
+
+DateTime _toDate(dynamic value) {
+  if (value is DateTime) return value;
+  if (value is String) return DateTime.tryParse(value) ?? DateTime.now();
+  return DateTime.now();
+}
+
+/// Status constants for [SettlementItem].
+abstract class SettlementItemStatus {
+  static const pending = 'PENDING';
+  static const hold = 'HOLD';
+  static const canceled = 'CANCELED';
+  static const ready = 'READY';
+  static const processing = 'PROCESSING';
+  static const completed = 'COMPLETED';
+  static const failed = 'FAILED';
 }

--- a/docs/ux/partner-app/screen-catalog.md
+++ b/docs/ux/partner-app/screen-catalog.md
@@ -324,37 +324,13 @@ stateDiagram-v2
   - **EntryGroupEditorScreen**: 입장 그룹(예: 신규 회원, 우수 회원, 남성/여성 전용) 정의 및 편집.
 
 ## 26. [모달] 티켓 및 입장 관리 (Modal: Ticket & Entry)
-- **용도**: 티켓 라이브러리 및 현장 입장 관련 보조 화면.
+- **용도**: 티켓 라이브러리 및 현장 입장 관련 부조 화면.
 - **주요 화면**:
   - **TicketManageScreen**: 파티/이벤트별 전체 티켓 현황 조회.
   - **TicketTemplateManageScreen**: 자주 사용하는 티켓 설정 재사용을 위한 템플릿 관리.
   - **QRScannerScreen**: 티켓 검수용 카메라 스캐너. (체크인 및 일반 QR 인식 중복 기능 포함)
 
-## 27. [모달] 위치 검색 (Modal: Location Search)
-- **화면명**: 위치 검색 화면 (LocationSearchScreen)
-- **라우트**: 비라우팅 (Navigator.push)
-- **피처**: `minglit_kit > search`
-- **용도**: 파티/이벤트 생성 시 주소를 검색하고 지도에서 위치를 선택하는 전체 화면 모달.
-- **주요 UI**:
-  - 텍스트 검색 입력
-  - 검색 결과 목록 (주소 자동완성)
-  - 지도 프리뷰 (선택한 위치 표시)
-- **진입**: PartyCreateCoordinator, PartyDetailCoordinator에서 push
-- **이탈**: 위치 선택 후 pop (결과 반환)
-
-## 28. [모달] 인증 심사 (Modal: Review Verification)
-- **화면명**: 인증 심사 화면 (ReviewVerificationScreen)
-- **라우트**: 비라우팅 (Navigator.push)
-- **피처**: `verification > review`
-- **용도**: 유저가 제출한 인증 서류를 파트너가 검토하고 승인/거절/보완요청하는 화면.
-- **주요 UI**:
-  - 유저 제출 서류 이미지 뷰어
-  - 인증 항목별 상태 표시
-  - 승인/거절/보완요청 버튼
-- **진입**: VerificationCoordinator에서 push
-- **이탈**: 심사 완료 후 pop
-
-## 29. [온보딩] 파트너 입점 신청 위자드 (Onboarding: Application Wizard)
+## 27. [온보딩] 파트너 입점 신청 위자드 (Onboarding: Application Wizard)
 - **화면명**: 파트너 신청 페이지 (PartnerApplyPage)
 - **라우트**: `/apply`
 - **피처**: `onboarding`
@@ -366,7 +342,7 @@ stateDiagram-v2
   4. 증빙 서류 업로드 (사업자 등록증 등)
   5. 입력 정보 최종 확인 및 제출
 
-## 30. [온보딩] 입점 신청 상태 및 보완 (Onboarding: Application Status)
+## 28. [온보딩] 입점 신청 상태 및 보완 (Onboarding: Application Status)
 - **화면명**: 신청 상태 확인 (PartnerApplyStatusPage)
 - **라우트**: `/apply/status`
 - **피처**: `onboarding`
@@ -377,9 +353,4 @@ stateDiagram-v2
   - 위자드로 다시 돌아가기 버튼 (수정용)
 
 ---
-
-## 관련 문서
-
-- [사용자 플로우](user-flows.md) — 각 화면을 연결하는 사용자 여정 플로우차트
-- [디자인 시스템](design-system.md) — 디자인 토큰, 컴포넌트 테마, 위젯 패턴 카탈로그
-- [클라이언트 아키텍처](../../architecture/client.md) — Feature-first 구조, Coordinator 패턴, Repository 패턴 등 기술 아키텍처
+*이 문서는 파트너 앱의 화면 구성을 지속적으로 반영하며, 상세 디자인은 Figma 링크를 참조하십시오.*

--- a/shared/packages/minglit_kit/lib/src/data/repositories/partner_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/partner_repository.dart
@@ -204,7 +204,7 @@ abstract class _SupabasePartnerContextBase implements _SupabasePartnerContext {
     }
   }
 
-  /// Fetches settlement records for a partner.
+  /// Fetches settlement records for a partner from settlement_items table.
   Future<List<Map<String, dynamic>>> getPartnerSettlements(
     String partnerId,
   ) async {
@@ -212,10 +212,10 @@ abstract class _SupabasePartnerContextBase implements _SupabasePartnerContext {
     try {
       final data =
           await supabaseClient
-                  .from('settlements')
+                  .from('settlement_items')
                   .select()
                   .eq('partner_id', partnerId)
-                  .order('event_date', ascending: false)
+                  .order('settlement_period_start', ascending: false)
               as List;
       return data.map((entry) {
         return entry as Map<String, dynamic>;

--- a/shared/packages/minglit_kit/test/src/data/repositories/partner_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/partner_repository_test.dart
@@ -205,16 +205,17 @@ void main() {
     });
 
     group('getPartnerSettlements', () {
-      test('returns settlement records', () async {
+      test('returns settlement records from settlement_items', () async {
         unawaited(
           mockTable(
             mockClient,
-            'settlements',
+            'settlement_items',
             selectData: [
               {
                 'partner_id': 'partner_1',
-                'event_date': '2026-02-15',
-                'amount': 150000,
+                'settlement_period_start': '2026-02-01',
+                'gross_amount': 150000,
+                'status': 'COMPLETED',
               },
             ],
           ),
@@ -223,7 +224,8 @@ void main() {
         final result = await repository.getPartnerSettlements('partner_1');
 
         expect(result, hasLength(1));
-        expect(result.first['amount'], 150000);
+        expect(result.first['gross_amount'], 150000);
+        expect(result.first['status'], 'COMPLETED');
       });
     });
   });

--- a/supabase/migrations/20260314000001_settlement_phase1_schema.sql
+++ b/supabase/migrations/20260314000001_settlement_phase1_schema.sql
@@ -1,0 +1,339 @@
+-- Settlement Phase 1: DB Schema Foundation
+-- Adds 5 new settlement tables alongside existing `settlements` table (parallel coexistence).
+-- DOES NOT drop or modify the existing `settlements` table, triggers, or cron jobs.
+-- Business logic (state machine, CAS, audit triggers) comes in Phase 2.
+
+-- ============================================================
+-- 1. settlement_items (정산 원장 — core ledger)
+-- Created first WITHOUT payout FK (payouts table doesn't exist yet).
+-- FK to payouts added via ALTER TABLE after payouts is created.
+-- ============================================================
+
+create table if not exists public.settlement_items (
+  id uuid primary key default gen_random_uuid(),
+
+  partner_id uuid not null
+    references public.partners(id) on delete restrict,  -- RESTRICT not CASCADE: protect financial data
+  settlement_period_start date not null,
+  settlement_period_end   date not null,
+
+  currency char(3) not null default 'KRW',
+
+  source_type text not null,
+  source_id   text not null,
+
+  status text not null check (status in
+    ('PENDING','HOLD','CANCELED','READY','PROCESSING','COMPLETED','FAILED')
+  ),
+
+  gross_amount        bigint not null check (gross_amount >= 0),
+  platform_fee_rate   decimal(5,2) not null check (platform_fee_rate >= 0 and platform_fee_rate <= 100),
+  platform_fee_amount bigint not null check (platform_fee_amount >= 0),
+
+  pg_fee_rate         decimal(5,2) not null check (pg_fee_rate >= 0 and pg_fee_rate <= 100),
+  pg_fee_amount       bigint not null check (pg_fee_amount >= 0),
+
+  vat_rate            decimal(5,2) not null check (vat_rate >= 0 and vat_rate <= 100),
+  vat_amount          bigint not null check (vat_amount >= 0),
+
+  net_amount          bigint not null check (net_amount >= 0),
+
+  hold_reason_code    text,
+  hold_reason_detail  text,
+  failure_reason_code text,
+  failure_message     text,
+
+  retryable boolean not null default false,
+  retry_count int not null default 0 check (retry_count >= 0),
+  next_retry_at timestamptz,
+
+  processing_started_at timestamptz,
+  processing_ended_at   timestamptz,
+
+  payout_id uuid,  -- FK added below after payouts table is created
+
+  calc_checksum char(64) not null,
+  version int not null default 1 check (version >= 1),
+
+  event_completed_at timestamptz,
+
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  constraint uq_settlement_items_source unique (partner_id, source_type, source_id),
+  constraint ck_settlement_items_period check (settlement_period_start <= settlement_period_end),
+  constraint ck_settlement_items_hold_reason check (
+    (status <> 'HOLD') or (hold_reason_code is not null)
+  )
+);
+
+create index if not exists idx_settlement_items_partner_period
+  on public.settlement_items(partner_id, settlement_period_start, settlement_period_end);
+
+create index if not exists idx_settlement_items_status
+  on public.settlement_items(status);
+
+create index if not exists idx_settlement_items_payout
+  on public.settlement_items(payout_id);
+
+create index if not exists idx_settlement_items_source
+  on public.settlement_items(source_type, source_id);
+
+-- moddatetime trigger (matching codebase pattern from settlements table)
+create trigger handle_updated_at before update on public.settlement_items
+  for each row execute procedure moddatetime(updated_at);
+
+-- ============================================================
+-- 2. payouts (파트너별 지급 묶음)
+-- ============================================================
+
+create table if not exists public.payouts (
+  id uuid primary key default gen_random_uuid(),
+  partner_id uuid not null
+    references public.partners(id) on delete restrict,
+
+  payout_period_start date not null,
+  payout_period_end   date not null,
+  currency char(3) not null default 'KRW',
+
+  status text not null check (status in ('CREATED','READY','PROCESSING','COMPLETED','FAILED','CANCELED')),
+
+  scheduled_at timestamptz not null,
+  processing_started_at timestamptz,
+  processing_ended_at   timestamptz,
+
+  item_count int not null default 0 check (item_count >= 0),
+
+  total_gross_amount        bigint not null check (total_gross_amount >= 0),
+  total_platform_fee_amount bigint not null check (total_platform_fee_amount >= 0),
+  total_pg_fee_amount       bigint not null check (total_pg_fee_amount >= 0),
+  total_vat_amount          bigint not null check (total_vat_amount >= 0),
+  total_net_amount          bigint not null check (total_net_amount >= 0),
+
+  bank_account_snapshot jsonb not null default '{}'::jsonb,
+
+  payout_request_idempotency_key text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  constraint ck_payouts_period check (payout_period_start <= payout_period_end)
+);
+
+create unique index if not exists uq_payouts_partner_period
+  on public.payouts(partner_id, payout_period_start, payout_period_end);
+
+create index if not exists idx_payouts_status_scheduled
+  on public.payouts(status, scheduled_at);
+
+-- REQ-5.3.05: idempotency key uniqueness per partner
+create unique index if not exists uq_payouts_partner_idempotency
+  on public.payouts(partner_id, payout_request_idempotency_key)
+  where payout_request_idempotency_key is not null;
+
+-- moddatetime trigger
+create trigger handle_updated_at before update on public.payouts
+  for each row execute procedure moddatetime(updated_at);
+
+-- ============================================================
+-- 3. Add payout FK to settlement_items (now that payouts exists)
+-- ============================================================
+
+alter table public.settlement_items
+  add constraint fk_settlement_items_payout
+    foreign key (payout_id) references public.payouts(id);
+
+-- ============================================================
+-- 4. settlement_histories (감사 로그 — append-only)
+-- NO moddatetime trigger (append-only: no updates allowed)
+-- ============================================================
+
+create table if not exists public.settlement_histories (
+  id uuid primary key default gen_random_uuid(),
+  settlement_item_id uuid not null,
+
+  event_at timestamptz not null default now(),
+  event_type text not null,
+  actor_type text not null check (actor_type in ('SYSTEM','JOB','ADMIN','PARTNER')),
+  actor_id text not null,
+
+  from_status text not null,
+  to_status   text not null,
+
+  idempotency_key text,
+  details jsonb not null default '{}'::jsonb,
+
+  constraint fk_settlement_histories_item
+    foreign key (settlement_item_id) references public.settlement_items(id)
+);
+
+create index if not exists idx_settlement_histories_item_eventat
+  on public.settlement_histories(settlement_item_id, event_at);
+
+create index if not exists idx_settlement_histories_event_type
+  on public.settlement_histories(event_type);
+
+-- REQ-5.2.06: prevent duplicate idempotency keys per item+event_type
+create unique index if not exists uq_settlement_histories_idempotency
+  on public.settlement_histories(settlement_item_id, event_type, idempotency_key)
+  where idempotency_key is not null;
+
+-- REQ-5.2.07: audit query index on actor
+create index if not exists idx_settlement_histories_actor
+  on public.settlement_histories(actor_type, actor_id);
+
+-- ============================================================
+-- 5. payout_transfers (송금 시도 + 멱등성 키)
+-- ============================================================
+
+create table if not exists public.payout_transfers (
+  id uuid primary key default gen_random_uuid(),
+  payout_id uuid not null,
+
+  provider text not null,
+  idempotency_key text not null,
+
+  attempt_no int not null check (attempt_no >= 1),
+  status text not null check (status in ('CREATED','REQUESTED','SUCCEEDED','FAILED')),
+
+  amount bigint not null check (amount >= 0),
+  currency char(3) not null default 'KRW',
+
+  provider_transfer_id text,
+  requested_at timestamptz,
+  responded_at timestamptz,
+
+  response_code text,
+  response_message text,
+
+  error_class text,
+  retryable boolean not null default false,
+  next_retry_at timestamptz,
+
+  request_payload  jsonb not null default '{}'::jsonb,
+  response_payload jsonb not null default '{}'::jsonb,
+
+  created_at timestamptz not null default now(),
+
+  constraint fk_payout_transfers_payout
+    foreign key (payout_id) references public.payouts(id),
+  constraint uq_payout_transfers_idem unique (provider, idempotency_key)
+);
+
+create index if not exists idx_payout_transfers_payout
+  on public.payout_transfers(payout_id);
+
+create index if not exists idx_payout_transfers_status_retry
+  on public.payout_transfers(status, next_retry_at);
+
+-- ============================================================
+-- 6. adjustment_items (사후 차감/조정 — 원장 불변 원칙)
+-- ============================================================
+
+create table if not exists public.adjustment_items (
+  id uuid primary key default gen_random_uuid(),
+  partner_id uuid not null
+    references public.partners(id) on delete restrict,
+
+  adjustment_type text not null check (adjustment_type in
+    ('REFUND','CHARGEBACK','MANUAL_DEDUCT','MANUAL_ADD','FEE_CORRECTION','TAX_CORRECTION')
+  ),
+
+  amount_signed bigint not null check (amount_signed <> 0),
+  currency char(3) not null default 'KRW',
+
+  reason_code text not null,
+  reason_detail text,
+
+  related_settlement_item_id uuid,
+  related_payout_id uuid,
+  source_type text,
+  source_id text,
+
+  evidence_url text,
+  status text not null check (status in ('CREATED','APPLIED','CANCELED')),
+
+  created_by_actor_type text not null check (created_by_actor_type in ('SYSTEM','ADMIN')),
+  created_by_actor_id text not null,
+
+  created_at timestamptz not null default now(),
+
+  constraint fk_adjustment_related_item
+    foreign key (related_settlement_item_id) references public.settlement_items(id),
+  constraint fk_adjustment_related_payout
+    foreign key (related_payout_id) references public.payouts(id)
+);
+
+create index if not exists idx_adjustment_partner_created
+  on public.adjustment_items(partner_id, created_at);
+
+create index if not exists idx_adjustment_related
+  on public.adjustment_items(related_settlement_item_id, related_payout_id);
+
+-- REQ-5.3.25: prevent duplicate adjustments for same source
+create unique index if not exists uq_adjustment_source
+  on public.adjustment_items(partner_id, adjustment_type, source_type, source_id)
+  where source_type is not null and source_id is not null;
+
+-- ============================================================
+-- 7. RLS (Row Level Security)
+-- Pattern: is_super_admin() OR has_partner_permission(partner_id, 'SETTLEMENT_VIEW')
+-- ============================================================
+
+-- settlement_items
+alter table public.settlement_items enable row level security;
+
+create policy "Partner can read own settlement_items"
+  on public.settlement_items for select
+  using (
+    public.is_super_admin()
+    or public.has_partner_permission(partner_id, 'SETTLEMENT_VIEW')
+  );
+
+-- payouts
+alter table public.payouts enable row level security;
+
+create policy "Partner can read own payouts"
+  on public.payouts for select
+  using (
+    public.is_super_admin()
+    or public.has_partner_permission(partner_id, 'SETTLEMENT_VIEW')
+  );
+
+-- adjustment_items
+alter table public.adjustment_items enable row level security;
+
+create policy "Partner can read own adjustment_items"
+  on public.adjustment_items for select
+  using (
+    public.is_super_admin()
+    or public.has_partner_permission(partner_id, 'SETTLEMENT_VIEW')
+  );
+
+-- settlement_histories: SELECT via settlement_item subquery, INSERT for service role only
+-- No UPDATE/DELETE policies: append-only enforced at DB level
+alter table public.settlement_histories enable row level security;
+
+create policy "Partner can read related settlement_histories"
+  on public.settlement_histories for select
+  using (
+    public.is_super_admin()
+    or exists (
+      select 1 from public.settlement_items si
+      where si.id = settlement_item_id
+        and public.has_partner_permission(si.partner_id, 'SETTLEMENT_VIEW')
+    )
+  );
+
+-- payout_transfers: SELECT via payout subquery
+alter table public.payout_transfers enable row level security;
+
+create policy "Partner can read related payout_transfers"
+  on public.payout_transfers for select
+  using (
+    public.is_super_admin()
+    or exists (
+      select 1 from public.payouts p
+      where p.id = payout_id
+        and public.has_partner_permission(p.partner_id, 'SETTLEMENT_VIEW')
+    )
+  );

--- a/supabase/migrations/20260314000002_settlement_phase1_data_migration.sql
+++ b/supabase/migrations/20260314000002_settlement_phase1_data_migration.sql
@@ -1,0 +1,136 @@
+-- Settlement Phase 1: Data Migration + Compatibility Views
+-- Copies existing settlements data into settlement_items (parallel coexistence).
+-- Recreates partner_revenue_stats and partner_monthly_revenue views to use settlement_items.
+-- Old settlements table and its data are preserved (NOT deleted).
+
+-- ============================================================
+-- Data Migration: settlements → settlement_items
+-- ============================================================
+-- Column mapping:
+--   source_type = 'EVENT', source_id = event_id::text
+--   status: lowercase→UPPERCASE mapping
+--   amounts: INTEGER→BIGINT cast
+--   rates: hardcoded (3.5%, 5%, 10%) — Phase 2 adds configurable rates
+--   calc_checksum: SHA-256 of canonical string per SRS REQ-7.03
+--   settlement_period_start/end: from events.end_time or fallback to event_date
+
+insert into public.settlement_items (
+  id,
+  partner_id,
+  settlement_period_start,
+  settlement_period_end,
+  currency,
+  source_type,
+  source_id,
+  status,
+  gross_amount,
+  platform_fee_rate,
+  platform_fee_amount,
+  pg_fee_rate,
+  pg_fee_amount,
+  vat_rate,
+  vat_amount,
+  net_amount,
+  retryable,
+  retry_count,
+  calc_checksum,
+  version,
+  event_completed_at,
+  created_at,
+  updated_at
+)
+select
+  gen_random_uuid()                          as id,
+  s.partner_id,
+  coalesce(e.end_time::date, s.event_date::date) as settlement_period_start,
+  coalesce(e.end_time::date, s.event_date::date) as settlement_period_end,
+  'KRW'                                      as currency,
+  'EVENT'                                    as source_type,
+  s.event_id::text                           as source_id,
+  case s.status
+    when 'pending'   then 'PENDING'
+    when 'ready'     then 'READY'
+    when 'requested' then 'PROCESSING'
+    when 'completed' then 'COMPLETED'
+    else 'PENDING'
+  end                                        as status,
+  s.total_sales::bigint                      as gross_amount,
+  5.00::decimal(5,2)                         as platform_fee_rate,
+  s.platform_fee::bigint                     as platform_fee_amount,
+  3.50::decimal(5,2)                         as pg_fee_rate,
+  s.pg_fee::bigint                           as pg_fee_amount,
+  10.00::decimal(5,2)                        as vat_rate,
+  s.vat::bigint                              as vat_amount,
+  s.net_amount::bigint                       as net_amount,
+  false                                      as retryable,
+  0                                          as retry_count,
+  encode(
+    digest(
+      s.partner_id::text || '|' ||
+      coalesce(e.end_time::date, s.event_date::date)::text || '|' ||
+      coalesce(e.end_time::date, s.event_date::date)::text || '|' ||
+      'KRW' || '|' ||
+      s.total_sales::text || '|' ||
+      '5.00' || '|' ||
+      '3.50' || '|' ||
+      '10.00' || '|' ||
+      s.platform_fee::text || '|' ||
+      s.pg_fee::text || '|' ||
+      s.vat::text || '|' ||
+      s.net_amount::text || '|' ||
+      'v1',
+      'sha256'
+    ),
+    'hex'
+  )                                          as calc_checksum,
+  1                                          as version,
+  e.end_time                                 as event_completed_at,
+  s.created_at,
+  s.updated_at
+from public.settlements s
+left join public.events e on e.id = s.event_id;
+
+-- ============================================================
+-- Verify migration row count (assertion in migration)
+-- ============================================================
+do $$
+declare
+  v_settlements_count int;
+  v_items_count int;
+begin
+  select count(*) into v_settlements_count from public.settlements;
+  select count(*) into v_items_count from public.settlement_items where source_type = 'EVENT';
+
+  if v_settlements_count <> v_items_count then
+    raise exception 'Data migration row count mismatch: settlements=%, settlement_items=%',
+      v_settlements_count, v_items_count;
+  end if;
+end;
+$$;
+
+-- ============================================================
+-- Compatibility Views: recreate to read from settlement_items
+-- Maps settlement_items columns → legacy column names
+-- ============================================================
+
+drop view if exists public.partner_revenue_stats;
+create view public.partner_revenue_stats as
+select
+  partner_id,
+  coalesce(sum(gross_amount), 0)::bigint as total_sales,
+  0::bigint                               as total_refunds,
+  coalesce(sum(net_amount), 0)::bigint   as net_amount
+from public.settlement_items
+group by partner_id;
+
+drop view if exists public.partner_monthly_revenue;
+create view public.partner_monthly_revenue as
+select
+  partner_id,
+  date_trunc('month', settlement_period_start)::date as month,
+  coalesce(sum(gross_amount), 0)::bigint              as total_sales,
+  0::bigint                                            as total_refunds,
+  coalesce(sum(net_amount), 0)::bigint                as net_amount
+from public.settlement_items
+group by partner_id, date_trunc('month', settlement_period_start)
+order by month;

--- a/supabase/tests/database/33_settlement_phase1_schema_test.sql
+++ b/supabase/tests/database/33_settlement_phase1_schema_test.sql
@@ -1,0 +1,170 @@
+BEGIN;
+SELECT no_plan();
+
+-- ============================================================
+-- settlement_items
+-- ============================================================
+SELECT has_table('public', 'settlement_items', 'settlement_items table exists');
+
+-- Required columns
+SELECT has_column('settlement_items', 'id');
+SELECT has_column('settlement_items', 'partner_id');
+SELECT has_column('settlement_items', 'settlement_period_start');
+SELECT has_column('settlement_items', 'settlement_period_end');
+SELECT has_column('settlement_items', 'currency');
+SELECT has_column('settlement_items', 'source_type');
+SELECT has_column('settlement_items', 'source_id');
+SELECT has_column('settlement_items', 'status');
+SELECT has_column('settlement_items', 'gross_amount');
+SELECT has_column('settlement_items', 'platform_fee_rate');
+SELECT has_column('settlement_items', 'platform_fee_amount');
+SELECT has_column('settlement_items', 'pg_fee_rate');
+SELECT has_column('settlement_items', 'pg_fee_amount');
+SELECT has_column('settlement_items', 'vat_rate');
+SELECT has_column('settlement_items', 'vat_amount');
+SELECT has_column('settlement_items', 'net_amount');
+SELECT has_column('settlement_items', 'hold_reason_code');
+SELECT has_column('settlement_items', 'failure_reason_code');
+SELECT has_column('settlement_items', 'retryable');
+SELECT has_column('settlement_items', 'retry_count');
+SELECT has_column('settlement_items', 'payout_id');
+SELECT has_column('settlement_items', 'calc_checksum');
+SELECT has_column('settlement_items', 'version');
+SELECT has_column('settlement_items', 'event_completed_at');
+SELECT has_column('settlement_items', 'created_at');
+SELECT has_column('settlement_items', 'updated_at');
+
+-- PK
+SELECT col_is_pk('settlement_items', 'id');
+
+-- CHECK constraints
+SELECT col_has_check('settlement_items', 'status');
+SELECT col_has_check('settlement_items', 'gross_amount');
+SELECT col_has_check('settlement_items', 'platform_fee_rate');
+SELECT col_has_check('settlement_items', 'retry_count');
+SELECT col_has_check('settlement_items', 'version');
+
+-- Indexes
+SELECT has_index('settlement_items', 'idx_settlement_items_partner_period');
+SELECT has_index('settlement_items', 'idx_settlement_items_status');
+SELECT has_index('settlement_items', 'idx_settlement_items_payout');
+SELECT has_index('settlement_items', 'idx_settlement_items_source');
+SELECT has_index('settlement_items', 'uq_settlement_items_source');
+
+-- RLS policy exists
+SELECT results_eq(
+  $$SELECT count(*)::int FROM pg_policies WHERE tablename='settlement_items' AND policyname='Partner can read own settlement_items'$$,
+  $$VALUES (1)$$,
+  'settlement_items has Partner can read own settlement_items policy'
+);
+
+-- ============================================================
+-- settlement_histories
+-- ============================================================
+SELECT has_table('public', 'settlement_histories', 'settlement_histories table exists');
+
+SELECT has_column('settlement_histories', 'id');
+SELECT has_column('settlement_histories', 'settlement_item_id');
+SELECT has_column('settlement_histories', 'event_at');
+SELECT has_column('settlement_histories', 'event_type');
+SELECT has_column('settlement_histories', 'actor_type');
+SELECT has_column('settlement_histories', 'actor_id');
+SELECT has_column('settlement_histories', 'from_status');
+SELECT has_column('settlement_histories', 'to_status');
+SELECT has_column('settlement_histories', 'idempotency_key');
+SELECT has_column('settlement_histories', 'details');
+
+SELECT col_is_pk('settlement_histories', 'id');
+SELECT col_is_fk('settlement_histories', 'settlement_item_id');
+SELECT col_has_check('settlement_histories', 'actor_type');
+
+SELECT has_index('settlement_histories', 'idx_settlement_histories_item_eventat');
+SELECT has_index('settlement_histories', 'idx_settlement_histories_event_type');
+SELECT has_index('settlement_histories', 'idx_settlement_histories_actor');
+SELECT has_index('settlement_histories', 'uq_settlement_histories_idempotency');
+
+SELECT results_eq(
+  $$SELECT count(*)::int FROM pg_policies WHERE tablename='settlement_histories' AND policyname='Partner can read related settlement_histories'$$,
+  $$VALUES (1)$$,
+  'settlement_histories has read policy'
+);
+
+-- ============================================================
+-- payouts
+-- ============================================================
+SELECT has_table('public', 'payouts', 'payouts table exists');
+
+SELECT has_column('payouts', 'id');
+SELECT has_column('payouts', 'partner_id');
+SELECT has_column('payouts', 'status');
+SELECT has_column('payouts', 'scheduled_at');
+SELECT has_column('payouts', 'total_net_amount');
+SELECT has_column('payouts', 'bank_account_snapshot');
+SELECT has_column('payouts', 'payout_request_idempotency_key');
+SELECT has_column('payouts', 'updated_at');
+
+SELECT col_is_pk('payouts', 'id');
+SELECT col_has_check('payouts', 'status');
+SELECT col_has_check('payouts', 'total_net_amount');
+
+SELECT has_index('payouts', 'uq_payouts_partner_period');
+SELECT has_index('payouts', 'idx_payouts_status_scheduled');
+
+SELECT results_eq(
+  $$SELECT count(*)::int FROM pg_policies WHERE tablename='payouts' AND policyname='Partner can read own payouts'$$,
+  $$VALUES (1)$$,
+  'payouts has Partner can read own payouts policy'
+);
+
+-- ============================================================
+-- payout_transfers
+-- ============================================================
+SELECT has_table('public', 'payout_transfers', 'payout_transfers table exists');
+
+SELECT has_column('payout_transfers', 'id');
+SELECT has_column('payout_transfers', 'payout_id');
+SELECT has_column('payout_transfers', 'idempotency_key');
+SELECT has_column('payout_transfers', 'status');
+SELECT has_column('payout_transfers', 'amount');
+
+SELECT col_is_pk('payout_transfers', 'id');
+SELECT col_is_fk('payout_transfers', 'payout_id');
+SELECT col_has_check('payout_transfers', 'status');
+
+SELECT has_index('payout_transfers', 'idx_payout_transfers_payout');
+SELECT has_index('payout_transfers', 'idx_payout_transfers_status_retry');
+SELECT has_index('payout_transfers', 'uq_payout_transfers_idem');
+
+SELECT results_eq(
+  $$SELECT count(*)::int FROM pg_policies WHERE tablename='payout_transfers' AND policyname='Partner can read related payout_transfers'$$,
+  $$VALUES (1)$$,
+  'payout_transfers has read policy'
+);
+
+-- ============================================================
+-- adjustment_items
+-- ============================================================
+SELECT has_table('public', 'adjustment_items', 'adjustment_items table exists');
+
+SELECT has_column('adjustment_items', 'id');
+SELECT has_column('adjustment_items', 'partner_id');
+SELECT has_column('adjustment_items', 'adjustment_type');
+SELECT has_column('adjustment_items', 'amount_signed');
+SELECT has_column('adjustment_items', 'status');
+
+SELECT col_is_pk('adjustment_items', 'id');
+SELECT col_has_check('adjustment_items', 'adjustment_type');
+SELECT col_has_check('adjustment_items', 'amount_signed');
+
+SELECT has_index('adjustment_items', 'idx_adjustment_partner_created');
+SELECT has_index('adjustment_items', 'idx_adjustment_related');
+
+SELECT results_eq(
+  $$SELECT count(*)::int FROM pg_policies WHERE tablename='adjustment_items' AND policyname='Partner can read own adjustment_items'$$,
+  $$VALUES (1)$$,
+  'adjustment_items has Partner can read own adjustment_items policy'
+);
+
+SELECT * FROM finish();
+ROLLBACK;
+


### PR DESCRIPTION
## Summary

정산 시스템 Phase 1 — DB 스키마 기초 작업. 기존 `settlements` 테이블과 병행 공존하며 새 5개 테이블을 추가한다.

## Changes

### DB (Supabase)
- **Migration 1** (`20260314000001`): 5개 신규 테이블 생성
  - `settlement_items` — 정산 원장 (7단계 상태, BIGINT 금액, DECIMAL 요율, SHA-256 체크섬)
  - `payouts` — 파트너별 지급 묶음 (계좌 스냅샷, 멱등키)
  - `settlement_histories` — 감사로그 (append-only, UPDATE/DELETE 권한 미부여)
  - `payout_transfers` — 송금 시도 (멱등키 UNIQUE 제약)
  - `adjustment_items` — 사후 차감/조정 (원장 불변 원칙)
  - 모든 테이블: RLS 활성화, CHECK/FK/UNIQUE 제약, 인덱스
- **Migration 2** (`20260314000002`): 데이터 마이그레이션 + 호환 뷰
  - `settlements` → `settlement_items` 데이터 복사 (SHA-256 체크섬 계산 포함)
  - `partner_revenue_stats`, `partner_monthly_revenue` 뷰 재생성 (settlement_items 기반)
- **pgTAP 테스트** (`33_settlement_phase1_schema_test.sql`): 5개 테이블 스키마 검증

### Flutter
- `settlement_models.dart`: `SettlementItem` 클래스 추가 (28개 필드, UPPERCASE 상태), `SettlementItemStatus` 상수, `PartnerSettlement.fromJson` 대소문자 정규화
- `partner_repository.dart`: `getPartnerSettlements()` → `settlement_items` 쿼리로 전환
- `settlement_list_section.dart`: 하드코딩 수수료율 제거, `_StatusBadge` 7개 상태 지원

## Guardrails (Phase 1 범위 준수)
- 기존 `settlements` 테이블/트리거/크론 **유지** (병행 공존)
- 상태 전이 함수(CAS), 자동 감사로그 트리거 **미구현** (Phase 2)
- Edge Functions **미수정**
- `partner_settlements` 테이블 **미수정**

## Test Results
- `supabase db reset`: ✅ zero errors
- `33_settlement_phase1_schema_test.sql`: ✅ all assertions pass
- `flutter analyze` (app_partner, minglit_kit): ✅ No issues found
- `partner_repository_test.dart`: ✅ 13/13 pass