### PR TITLE
fix(ci): add --include-all to supabase db push for feature branch compatibility

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -47,8 +47,8 @@ jobs:
           supabase secrets set SENTRY_DSN=$SENTRY_DSN
           supabase secrets set ENVIRONMENT=development
 
-          # Dev 환경: 새 마이그레이션만 적용 (db reset은 WAL 비대화 유발)
-          supabase db push --password $SUPABASE_DB_PASSWORD
+          # Dev 환경: 새 마이그레이션 적용 (--include-all: feature branch 병렬 작업 시 순서 불일치 허용)
+          supabase db push --password $SUPABASE_DB_PASSWORD --include-all
 
           # Deploy Edge Functions
           supabase functions deploy
@@ -85,7 +85,7 @@ jobs:
           supabase secrets set SENTRY_DSN=$SENTRY_DSN
           supabase secrets set ENVIRONMENT=production
 
-          supabase db push --password $SUPABASE_DB_PASSWORD
+          supabase db push --password $SUPABASE_DB_PASSWORD --include-all
 
           # Deploy Edge Functions
           supabase functions deploy


### PR DESCRIPTION
## Summary
- `supabase db push`에 `--include-all` 플래그 추가 (dev, main 모두)
- feature branch 병렬 작업 시 migration 버전 순서 불일치로 배포 실패하던 문제 해결

## Problem
feature branch A(`20260310_003`)와 B(`20260310_005`)가 순서 달리 머지되면 `supabase db push`가 순서 불일치로 거부 → 최근 4회 연속 배포 실패

## Solution
`--include-all` 플래그로 버전 순서와 무관하게 미적용 migration 모두 적용

Closes #79