### PR TITLE
feat(settlement): Phase 2 — State machine, calculation functions, trigger cutover

### DIFF
--- a/supabase/migrations/20260315000001_settlement_phase2_state_machine.sql
+++ b/supabase/migrations/20260315000001_settlement_phase2_state_machine.sql
@@ -1,0 +1,478 @@
+-- Settlement Phase 2: State Machine & Ledger Logic
+-- Builds business logic on top of Phase 1 tables.
+-- Full cutover: trigger writes to settlement_items (not settlements).
+-- Old settlements table preserved as read-only archive (no DROP).
+
+-- ============================================================
+-- 0. Prerequisites
+-- ============================================================
+create extension if not exists pgcrypto;
+
+-- ============================================================
+-- Task 3: Remove net_amount >= 0 CHECK constraint
+-- Allows negative net_amount (e.g., when refunds exceed gross)
+-- ============================================================
+alter table public.settlement_items
+  drop constraint if exists settlement_items_net_amount_check;
+
+-- ============================================================
+-- Task 1a: calculate_settlement_amounts()
+-- REQ-7.01: floor-based fee calculation (not round)
+-- ============================================================
+create or replace function public.calculate_settlement_amounts(
+  p_gross              bigint,
+  p_platform_fee_rate  decimal(5,2),
+  p_pg_fee_rate        decimal(5,2),
+  p_vat_rate           decimal(5,2),
+  out out_platform_fee_amount bigint,
+  out out_pg_fee_amount       bigint,
+  out out_vat_amount          bigint,
+  out out_net_amount          bigint
+)
+returns record
+language plpgsql
+immutable
+security definer
+set search_path = public
+as $$
+begin
+  out_platform_fee_amount := floor(p_gross * p_platform_fee_rate / 100)::bigint;
+  out_pg_fee_amount       := floor(p_gross * p_pg_fee_rate / 100)::bigint;
+  out_vat_amount          := floor((out_platform_fee_amount + out_pg_fee_amount) * p_vat_rate / 100)::bigint;
+  out_net_amount          := p_gross - out_platform_fee_amount - out_pg_fee_amount - out_vat_amount;
+end;
+$$;
+
+-- ============================================================
+-- Task 1b: calculate_settlement_checksum()
+-- REQ-7.03: SHA-256 of canonical string
+-- Format: "{partner_id}|{period_start}|{period_end}|{currency}|{gross}|
+--          {platform_fee_rate}|{pg_fee_rate}|{vat_rate}|
+--          {platform_fee_amount}|{pg_fee_amount}|{vat_amount}|{net_amount}|v1"
+-- ============================================================
+create or replace function public.calculate_settlement_checksum(
+  p_partner_id            uuid,
+  p_period_start          date,
+  p_period_end            date,
+  p_currency              char(3),
+  p_gross                 bigint,
+  p_platform_fee_rate     decimal(5,2),
+  p_pg_fee_rate           decimal(5,2),
+  p_vat_rate              decimal(5,2),
+  p_platform_fee_amount   bigint,
+  p_pg_fee_amount         bigint,
+  p_vat_amount            bigint,
+  p_net_amount            bigint
+)
+returns char(64)
+language plpgsql
+immutable
+security definer
+set search_path = public
+as $$
+declare
+  v_canonical text;
+begin
+  v_canonical :=
+    p_partner_id::text || '|' ||
+    p_period_start::text || '|' ||
+    p_period_end::text || '|' ||
+    p_currency || '|' ||
+    p_gross::text || '|' ||
+    p_platform_fee_rate::text || '|' ||
+    p_pg_fee_rate::text || '|' ||
+    p_vat_rate::text || '|' ||
+    p_platform_fee_amount::text || '|' ||
+    p_pg_fee_amount::text || '|' ||
+    p_vat_amount::text || '|' ||
+    p_net_amount::text || '|' ||
+    'v1';
+  return encode(extensions.digest(v_canonical, 'sha256'), 'hex');
+end;
+$$;
+
+-- ============================================================
+-- Task 2: transition_settlement_status()
+-- REQ-3.2.15: CAS-based state transition with audit logging
+-- Allowed transitions (13):
+--   PENDING  → READY, HOLD, CANCELED
+--   HOLD     → READY, CANCELED
+--   READY    → PROCESSING, HOLD, CANCELED
+--   PROCESSING → COMPLETED, FAILED
+--   FAILED   → READY, HOLD, CANCELED
+-- COMPLETED and CANCELED are terminal — no transitions allowed
+-- ============================================================
+create or replace function public.transition_settlement_status(
+  p_item_id              uuid,
+  p_expected_version     int,
+  p_new_status           text,
+  p_actor_type           text,
+  p_actor_id             text,
+  p_event_type           text,
+  p_hold_reason_code     text    default null,
+  p_hold_reason_detail   text    default null,
+  p_failure_reason_code  text    default null,
+  p_failure_message      text    default null,
+  p_details              jsonb   default '{}',
+  p_idempotency_key      text    default null
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_current_status  text;
+  v_current_version int;
+  v_rows_updated    int;
+  v_allowed_targets text[];
+begin
+  -- Lock and read current state
+  select status, version
+  into   v_current_status, v_current_version
+  from   public.settlement_items
+  where  id = p_item_id
+  for    update;
+
+  if not found then
+    raise exception 'settlement_item not found: %', p_item_id;
+  end if;
+
+  -- Reject any transition from terminal states (REQ-3.2.16)
+  if v_current_status in ('COMPLETED', 'CANCELED') then
+    raise exception
+      'Cannot transition from terminal state % to % for item %',
+      v_current_status, p_new_status, p_item_id;
+  end if;
+
+  -- Validate transition against allowed matrix
+  v_allowed_targets := case v_current_status
+    when 'PENDING'    then array['READY','HOLD','CANCELED']
+    when 'HOLD'       then array['READY','CANCELED']
+    when 'READY'      then array['PROCESSING','HOLD','CANCELED']
+    when 'PROCESSING' then array['COMPLETED','FAILED']
+    when 'FAILED'     then array['READY','HOLD','CANCELED']
+    else array[]::text[]
+  end;
+
+  if not (p_new_status = any(v_allowed_targets)) then
+    raise exception
+      'Invalid transition: % → % is not allowed for item %',
+      v_current_status, p_new_status, p_item_id;
+  end if;
+
+  -- Guard: HOLD requires hold_reason_code (REQ-3.2.23)
+  if p_new_status = 'HOLD' and p_hold_reason_code is null then
+    raise exception 'hold_reason_code is required when transitioning to HOLD';
+  end if;
+
+  -- Guard: FAILED requires failure_reason_code (REQ-3.2.18)
+  if p_new_status = 'FAILED' and p_failure_reason_code is null then
+    raise exception 'failure_reason_code is required when transitioning to FAILED';
+  end if;
+
+  -- CAS update (REQ-3.2.15)
+  update public.settlement_items
+  set
+    status               = p_new_status,
+    version              = version + 1,
+    hold_reason_code     = case when p_new_status = 'HOLD'   then p_hold_reason_code    else hold_reason_code end,
+    hold_reason_detail   = case when p_new_status = 'HOLD'   then p_hold_reason_detail  else hold_reason_detail end,
+    failure_reason_code  = case when p_new_status = 'FAILED' then p_failure_reason_code else failure_reason_code end,
+    failure_message      = case when p_new_status = 'FAILED' then p_failure_message     else failure_message end,
+    processing_started_at = case when p_new_status = 'PROCESSING' then now() else processing_started_at end,
+    processing_ended_at   = case when p_new_status in ('COMPLETED','FAILED') then now() else processing_ended_at end,
+    updated_at           = now()
+  where id      = p_item_id
+    and version = p_expected_version
+    and status  = v_current_status;
+
+  get diagnostics v_rows_updated = row_count;
+
+  if v_rows_updated = 0 then
+    raise exception
+      'CAS failure: version mismatch or concurrent modification for item %. Expected version: %',
+      p_item_id, p_expected_version;
+  end if;
+
+  -- Append-only audit log (REQ-3.2.10)
+  insert into public.settlement_histories (
+    settlement_item_id,
+    event_type,
+    actor_type,
+    actor_id,
+    from_status,
+    to_status,
+    details,
+    idempotency_key
+  ) values (
+    p_item_id,
+    p_event_type,
+    p_actor_type,
+    p_actor_id,
+    v_current_status,
+    p_new_status,
+    coalesce(p_details, '{}'),
+    p_idempotency_key
+  );
+
+  return true;
+end;
+$$;
+
+-- ============================================================
+-- Task 4: Modify create_settlement_on_event_completion()
+-- Full cutover: writes to settlement_items (not settlements)
+-- Uses calculate_settlement_amounts() (floor) and checksum
+-- ============================================================
+create or replace function public.create_settlement_on_event_completion()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_partner_id            uuid;
+  v_event_date            date;
+  v_total_sales           bigint := 0;
+  v_platform_fee_rate     decimal(5,2) := 5.00;
+  v_pg_fee_rate           decimal(5,2) := 3.50;
+  v_vat_rate              decimal(5,2) := 10.00;
+  v_platform_fee_amount   bigint;
+  v_pg_fee_amount         bigint;
+  v_vat_amount            bigint;
+  v_net_amount            bigint;
+  v_checksum              char(64);
+  v_amounts               record;
+begin
+  if (new.status = 'completed' and old.status is distinct from 'completed') then
+
+    -- Get partner_id from parties
+    select p.partner_id
+    into   v_partner_id
+    from   public.parties p
+    where  p.id = new.party_id;
+
+    -- Settlement period = event end date
+    v_event_date := coalesce(new.end_time, now())::date;
+
+    -- Aggregate total sales from event_applications (gross, before refunds)
+    select coalesce(
+      sum(case when ea.status in ('paid', 'approved') then ea.payment_amount else 0 end),
+      0
+    )
+    into v_total_sales
+    from public.event_applications ea
+    where ea.event_id = new.id;
+
+    -- Calculate amounts using floor() (REQ-4.1.3, REQ-7.01)
+    select * into v_amounts
+    from public.calculate_settlement_amounts(
+      v_total_sales::bigint,
+      v_platform_fee_rate,
+      v_pg_fee_rate,
+      v_vat_rate
+    );
+
+    v_platform_fee_amount := v_amounts.out_platform_fee_amount;
+    v_pg_fee_amount       := v_amounts.out_pg_fee_amount;
+    v_vat_amount          := v_amounts.out_vat_amount;
+    v_net_amount          := v_amounts.out_net_amount;
+
+    -- Calculate SHA-256 checksum (REQ-7.03)
+    v_checksum := public.calculate_settlement_checksum(
+      v_partner_id,
+      v_event_date,
+      v_event_date,
+      'KRW',
+      v_total_sales::bigint,
+      v_platform_fee_rate,
+      v_pg_fee_rate,
+      v_vat_rate,
+      v_platform_fee_amount,
+      v_pg_fee_amount,
+      v_vat_amount,
+      v_net_amount
+    );
+
+    -- Full cutover: insert into settlement_items (not settlements)
+    insert into public.settlement_items (
+      partner_id,
+      settlement_period_start,
+      settlement_period_end,
+      currency,
+      source_type,
+      source_id,
+      status,
+      gross_amount,
+      platform_fee_rate,
+      platform_fee_amount,
+      pg_fee_rate,
+      pg_fee_amount,
+      vat_rate,
+      vat_amount,
+      net_amount,
+      calc_checksum,
+      event_completed_at
+    )
+    values (
+      v_partner_id,
+      v_event_date,
+      v_event_date,
+      'KRW',
+      'EVENT',
+      new.id::text,
+      'PENDING',
+      v_total_sales::bigint,
+      v_platform_fee_rate,
+      v_platform_fee_amount,
+      v_pg_fee_rate,
+      v_pg_fee_amount,
+      v_vat_rate,
+      v_vat_amount,
+      v_net_amount,
+      v_checksum,
+      new.end_time
+    )
+    on conflict on constraint uq_settlement_items_source do update
+    set
+      gross_amount          = excluded.gross_amount,
+      platform_fee_rate     = excluded.platform_fee_rate,
+      platform_fee_amount   = excluded.platform_fee_amount,
+      pg_fee_rate           = excluded.pg_fee_rate,
+      pg_fee_amount         = excluded.pg_fee_amount,
+      vat_rate              = excluded.vat_rate,
+      vat_amount            = excluded.vat_amount,
+      net_amount            = excluded.net_amount,
+      calc_checksum         = excluded.calc_checksum,
+      event_completed_at    = excluded.event_completed_at,
+      updated_at            = now();
+
+  end if;
+  return new;
+end;
+$$;
+
+-- ============================================================
+-- Task 5a: Replace update_settlement_ready_status()
+-- 14-day hold (was 7-day), uses transition_settlement_status()
+-- Includes checksum re-validation before READY transition
+-- ============================================================
+create or replace function public.update_settlement_ready_status()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_item          record;
+  v_expected_cs   char(64);
+begin
+  for v_item in
+    select id, version, partner_id, settlement_period_start, settlement_period_end,
+           currency, gross_amount, platform_fee_rate, pg_fee_rate, vat_rate,
+           platform_fee_amount, pg_fee_amount, vat_amount, net_amount, calc_checksum
+    from   public.settlement_items
+    where  status = 'PENDING'
+    and    event_completed_at <= now() - interval '14 days'
+  loop
+    -- Re-validate checksum before transitioning to READY (REQ-7.03)
+    v_expected_cs := public.calculate_settlement_checksum(
+      v_item.partner_id,
+      v_item.settlement_period_start,
+      v_item.settlement_period_end,
+      v_item.currency,
+      v_item.gross_amount,
+      v_item.platform_fee_rate,
+      v_item.pg_fee_rate,
+      v_item.vat_rate,
+      v_item.platform_fee_amount,
+      v_item.pg_fee_amount,
+      v_item.vat_amount,
+      v_item.net_amount
+    );
+
+    if v_item.calc_checksum = v_expected_cs then
+      -- Checksum valid → transition to READY
+      perform public.transition_settlement_status(
+        v_item.id,
+        v_item.version,
+        'READY',
+        'SYSTEM',
+        'settlement_cron_job',
+        'calc_succeeded',
+        null, null, null, null,
+        '{"source": "update_settlement_ready_status"}',
+        null
+      );
+    else
+      -- Checksum mismatch → FAILED (REQ-7.03)
+      perform public.transition_settlement_status(
+        v_item.id,
+        v_item.version,
+        'FAILED',
+        'SYSTEM',
+        'settlement_cron_job',
+        'payout_failed',
+        null, null,
+        'CHECKSUM_MISMATCH',
+        'Checksum validation failed during ready transition',
+        '{"expected": "' || v_expected_cs || '", "actual": "' || v_item.calc_checksum || '"}',
+        null
+      );
+    end if;
+
+  end loop;
+end;
+$$;
+
+-- Update cron: same name replaces existing job, 14-day logic applied
+select cron.schedule(
+  'settlement-status-transition',
+  '0 3 * * *',
+  $$select public.update_settlement_ready_status();$$
+);
+
+-- ============================================================
+-- Task 6: Stuck processing check (REQ-3.2.13)
+-- PROCESSING > 2h → auto FAILED
+-- No-op until Phase 3 creates PROCESSING items
+-- ============================================================
+create or replace function public.check_stuck_processing_settlements()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_item record;
+begin
+  for v_item in
+    select id, version
+    from   public.settlement_items
+    where  status = 'PROCESSING'
+    and    processing_started_at < now() - interval '2 hours'
+  loop
+    perform public.transition_settlement_status(
+      v_item.id,
+      v_item.version,
+      'FAILED',
+      'SYSTEM',
+      'stuck_check_job',
+      'payout_failed',
+      null, null,
+      'TIMEOUT_STUCK_PROCESSING',
+      'Processing exceeded 2 hour limit',
+      '{"source": "check_stuck_processing_settlements"}',
+      null
+    );
+  end loop;
+end;
+$$;
+
+-- Cron: every 30 minutes
+select cron.schedule(
+  'settlement-stuck-processing-check',
+  '*/30 * * * *',
+  $$select public.check_stuck_processing_settlements();$$
+);

--- a/supabase/migrations/20260315000001_settlement_phase2_state_machine.sql
+++ b/supabase/migrations/20260315000001_settlement_phase2_state_machine.sql
@@ -401,24 +401,24 @@ begin
         'SYSTEM',
         'settlement_cron_job',
         'calc_succeeded',
-        null, null, null, null,
-        '{"source": "update_settlement_ready_status"}',
-        null
+        null::text, null::text, null::text, null::text,
+        '{"source": "update_settlement_ready_status"}'::jsonb,
+        null::text
       );
     else
-      -- Checksum mismatch → FAILED (REQ-7.03)
+      -- Checksum mismatch → HOLD for manual review (PENDING→FAILED not in allowed matrix)
       perform public.transition_settlement_status(
         v_item.id,
         v_item.version,
-        'FAILED',
+        'HOLD',
         'SYSTEM',
         'settlement_cron_job',
-        'payout_failed',
-        null, null,
-        'CHECKSUM_MISMATCH',
-        'Checksum validation failed during ready transition',
-        '{"expected": "' || v_expected_cs || '", "actual": "' || v_item.calc_checksum || '"}',
-        null
+        'hold_applied',
+        'CHECKSUM_MISMATCH'::text,
+        'Checksum validation failed during ready transition'::text,
+        null::text, null::text,
+        ('{"expected": "' || v_expected_cs || '", "actual": "' || v_item.calc_checksum || '"}')::jsonb,
+        null::text
       );
     end if;
 
@@ -460,11 +460,11 @@ begin
       'SYSTEM',
       'stuck_check_job',
       'payout_failed',
-      null, null,
+      null::text, null::text,
       'TIMEOUT_STUCK_PROCESSING',
       'Processing exceeded 2 hour limit',
-      '{"source": "check_stuck_processing_settlements"}',
-      null
+      '{"source": "check_stuck_processing_settlements"}'::jsonb,
+      null::text
     );
   end loop;
 end;

--- a/supabase/tests/database/34_settlement_state_machine_test.sql
+++ b/supabase/tests/database/34_settlement_state_machine_test.sql
@@ -1,0 +1,321 @@
+BEGIN;
+SELECT no_plan();
+
+SELECT tests.authenticate_as_service_role();
+
+CREATE TEMP TABLE transition_results (
+  item_id uuid,
+  result  boolean,
+  err_msg text
+);
+
+-- ============================================================
+-- 1. Function existence
+-- ============================================================
+SELECT has_function('public', 'calculate_settlement_amounts',
+  'calculate_settlement_amounts function exists');
+
+SELECT has_function('public', 'calculate_settlement_checksum',
+  'calculate_settlement_checksum function exists');
+
+SELECT has_function('public', 'transition_settlement_status',
+  'transition_settlement_status function exists');
+
+-- ============================================================
+-- 2. calculate_settlement_amounts — floor() correctness
+-- ============================================================
+SELECT results_eq(
+  $$SELECT out_platform_fee_amount, out_pg_fee_amount, out_vat_amount, out_net_amount
+    FROM calculate_settlement_amounts(100000, 5.00, 3.50, 10.00)$$,
+  $$VALUES (5000::bigint, 3500::bigint, 850::bigint, 90650::bigint)$$,
+  'basic fee calculation: platform=5000, pg=3500, vat=850, net=90650'
+);
+
+SELECT results_eq(
+  $$SELECT out_platform_fee_amount, out_pg_fee_amount, out_vat_amount, out_net_amount
+    FROM calculate_settlement_amounts(142857, 5.00, 3.50, 10.00)$$,
+  $$VALUES (7142::bigint, 4999::bigint, 1214::bigint, 129502::bigint)$$,
+  'floor() applied: 142857*5%=7142.85 floors to 7142'
+);
+
+SELECT results_eq(
+  $$SELECT out_platform_fee_amount, out_pg_fee_amount, out_vat_amount, out_net_amount
+    FROM calculate_settlement_amounts(0, 5.00, 3.50, 10.00)$$,
+  $$VALUES (0::bigint, 0::bigint, 0::bigint, 0::bigint)$$,
+  'zero gross amount produces all-zero fees'
+);
+
+SELECT results_eq(
+  $$SELECT out_platform_fee_amount, out_pg_fee_amount, out_vat_amount, out_net_amount
+    FROM calculate_settlement_amounts(1000000, 5.00, 3.50, 10.00)$$,
+  $$VALUES (50000::bigint, 35000::bigint, 8500::bigint, 906500::bigint)$$,
+  'large amount (1M) calculation correct'
+);
+
+-- ============================================================
+-- 3. calculate_settlement_checksum — format and consistency
+-- ============================================================
+SELECT results_eq(
+  $$SELECT length(calculate_settlement_checksum(
+    'aaaaaaaa-0000-0000-0000-000000000001'::uuid,
+    '2026-01-01'::date, '2026-01-31'::date,
+    'KRW', 100000, 5.00, 3.50, 10.00, 5000, 3500, 850, 90650
+  ))$$,
+  $$VALUES (64)$$,
+  'checksum returns 64-char hex string (SHA-256)'
+);
+
+SELECT results_eq(
+  $$SELECT
+    calculate_settlement_checksum(
+      'aaaaaaaa-0000-0000-0000-000000000001'::uuid,
+      '2026-01-01'::date, '2026-01-31'::date,
+      'KRW', 100000, 5.00, 3.50, 10.00, 5000, 3500, 850, 90650
+    ) = calculate_settlement_checksum(
+      'aaaaaaaa-0000-0000-0000-000000000001'::uuid,
+      '2026-01-01'::date, '2026-01-31'::date,
+      'KRW', 100000, 5.00, 3.50, 10.00, 5000, 3500, 850, 90650
+    )$$,
+  $$VALUES (true)$$,
+  'same inputs produce identical checksum (deterministic)'
+);
+
+SELECT results_eq(
+  $$SELECT
+    calculate_settlement_checksum(
+      'aaaaaaaa-0000-0000-0000-000000000001'::uuid,
+      '2026-01-01'::date, '2026-01-31'::date,
+      'KRW', 100000, 5.00, 3.50, 10.00, 5000, 3500, 850, 90650
+    ) <> calculate_settlement_checksum(
+      'aaaaaaaa-0000-0000-0000-000000000002'::uuid,
+      '2026-01-01'::date, '2026-01-31'::date,
+      'KRW', 100000, 5.00, 3.50, 10.00, 5000, 3500, 850, 90650
+    )$$,
+  $$VALUES (true)$$,
+  'different partner_id produces different checksum'
+);
+
+-- ============================================================
+-- 4. transition_settlement_status — state machine correctness
+-- ============================================================
+DO $$
+DECLARE
+  v_partner_id uuid;
+  v_item_id    uuid;
+  v_cs         char(64);
+BEGIN
+  INSERT INTO public.partners (name) VALUES ('Test Partner Phase2') RETURNING id INTO v_partner_id;
+
+  v_cs := repeat('a', 64);
+
+  INSERT INTO public.settlement_items (
+    partner_id, settlement_period_start, settlement_period_end,
+    currency, source_type, source_id, status,
+    gross_amount, platform_fee_rate, platform_fee_amount,
+    pg_fee_rate, pg_fee_amount, vat_rate, vat_amount, net_amount, calc_checksum
+  ) VALUES (
+    v_partner_id, '2026-01-01', '2026-01-31',
+    'KRW', 'TEST', 'phase2-test-001', 'PENDING',
+    100000, 5.00, 5000, 3.50, 3500, 10.00, 850, 90650, v_cs
+  ) RETURNING id INTO v_item_id;
+
+  INSERT INTO transition_results (item_id, result, err_msg)
+  VALUES (v_item_id, null, 'item_created');
+
+  UPDATE transition_results SET item_id = v_item_id WHERE err_msg = 'item_created';
+END;
+$$;
+
+SELECT results_eq(
+  $$SELECT transition_settlement_status(
+    (SELECT item_id FROM transition_results LIMIT 1),
+    1, 'READY', 'SYSTEM', 'cron', 'calc_succeeded'
+  )$$,
+  $$VALUES (true)$$,
+  'PENDING → READY transition succeeds'
+);
+
+SELECT results_eq(
+  $$SELECT status, version FROM settlement_items
+    WHERE id = (SELECT item_id FROM transition_results LIMIT 1)$$,
+  $$VALUES ('READY'::text, 2)$$,
+  'after PENDING→READY: status=READY, version=2'
+);
+
+SELECT results_eq(
+  $$SELECT count(*)::int FROM settlement_histories
+    WHERE settlement_item_id = (SELECT item_id FROM transition_results LIMIT 1)$$,
+  $$VALUES (1)$$,
+  'settlement_histories auto-populated on transition'
+);
+
+SELECT results_eq(
+  $$SELECT from_status, to_status, actor_type FROM settlement_histories
+    WHERE settlement_item_id = (SELECT item_id FROM transition_results LIMIT 1)$$,
+  $$VALUES ('PENDING'::text, 'READY'::text, 'SYSTEM'::text)$$,
+  'history record contains correct from/to status and actor'
+);
+
+SELECT results_eq(
+  $$SELECT transition_settlement_status(
+    (SELECT item_id FROM transition_results LIMIT 1),
+    2, 'HOLD', 'ADMIN', 'admin1', 'hold_applied',
+    'MANUAL_REVIEW', 'Requires manual review', null, null
+  )$$,
+  $$VALUES (true)$$,
+  'READY → HOLD transition succeeds with reason_code'
+);
+
+SELECT results_eq(
+  $$SELECT transition_settlement_status(
+    (SELECT item_id FROM transition_results LIMIT 1),
+    3, 'READY', 'ADMIN', 'admin1', 'hold_released'
+  )$$,
+  $$VALUES (true)$$,
+  'HOLD → READY transition succeeds'
+);
+
+SELECT results_eq(
+  $$SELECT transition_settlement_status(
+    (SELECT item_id FROM transition_results LIMIT 1),
+    4, 'CANCELED', 'ADMIN', 'admin1', 'canceled'
+  )$$,
+  $$VALUES (true)$$,
+  'READY → CANCELED transition succeeds'
+);
+
+SELECT throws_ok(
+  $$SELECT transition_settlement_status(
+    (SELECT item_id FROM transition_results LIMIT 1),
+    5, 'READY', 'ADMIN', 'admin1', 'hold_released'
+  )$$,
+  'P0001',
+  null,
+  'CANCELED is terminal: transition_settlement_status raises exception'
+);
+
+-- ============================================================
+-- 5. Invalid transitions — deny by default
+-- ============================================================
+DO $$
+DECLARE
+  v_partner_id uuid;
+  v_item2_id   uuid;
+BEGIN
+  SELECT id INTO v_partner_id FROM public.partners WHERE name = 'Test Partner Phase2';
+
+  INSERT INTO public.settlement_items (
+    partner_id, settlement_period_start, settlement_period_end,
+    currency, source_type, source_id, status,
+    gross_amount, platform_fee_rate, platform_fee_amount,
+    pg_fee_rate, pg_fee_amount, vat_rate, vat_amount, net_amount, calc_checksum
+  ) VALUES (
+    v_partner_id, '2026-02-01', '2026-02-28',
+    'KRW', 'TEST', 'phase2-test-002', 'PENDING',
+    50000, 5.00, 2500, 3.50, 1750, 10.00, 425, 45325, repeat('b', 64)
+  ) RETURNING id INTO v_item2_id;
+
+  INSERT INTO transition_results (item_id, err_msg) VALUES (v_item2_id, 'item2');
+END;
+$$;
+
+SELECT throws_ok(
+  $$SELECT transition_settlement_status(
+    (SELECT item_id FROM transition_results WHERE err_msg='item2'),
+    1, 'COMPLETED', 'SYSTEM', 'job', 'payout_succeeded'
+  )$$,
+  'P0001',
+  null,
+  'PENDING→COMPLETED is invalid: raises exception'
+);
+
+-- PENDING→FAILED is invalid (matrix check fires first)
+-- Test failure_reason_code guard via PROCESSING item:
+DO $$
+DECLARE
+  v_partner_id uuid;
+  v_processing_id uuid;
+BEGIN
+  SELECT id INTO v_partner_id FROM public.partners WHERE name = 'Test Partner Phase2';
+  INSERT INTO public.settlement_items (
+    partner_id, settlement_period_start, settlement_period_end,
+    currency, source_type, source_id, status,
+    gross_amount, platform_fee_rate, platform_fee_amount,
+    pg_fee_rate, pg_fee_amount, vat_rate, vat_amount, net_amount,
+    calc_checksum, processing_started_at
+  ) VALUES (
+    v_partner_id, '2026-05-01', '2026-05-31',
+    'KRW', 'TEST', 'phase2-processing-001', 'PROCESSING',
+    60000, 5.00, 3000, 3.50, 2100, 10.00, 510, 54390,
+    repeat('e', 64), now()
+  ) RETURNING id INTO v_processing_id;
+  INSERT INTO transition_results (item_id, err_msg) VALUES (v_processing_id, 'processing_item');
+END;
+$$;
+
+SELECT throws_ok(
+  $$SELECT transition_settlement_status(
+    (SELECT item_id FROM transition_results WHERE err_msg='processing_item'),
+    1, 'FAILED', 'SYSTEM', 'job', 'payout_failed'
+  )$$,
+  'failure_reason_code is required when transitioning to FAILED'
+);
+
+SELECT throws_ok(
+  $$SELECT transition_settlement_status(
+    (SELECT item_id FROM transition_results WHERE err_msg='item2'),
+    1, 'HOLD', 'ADMIN', 'admin1', 'hold_applied'
+  )$$,
+  'hold_reason_code is required when transitioning to HOLD'
+);
+
+SELECT throws_ok(
+  $$SELECT transition_settlement_status(
+    (SELECT item_id FROM transition_results WHERE err_msg='item2'),
+    999, 'READY', 'SYSTEM', 'cron', 'calc_succeeded'
+  )$$,
+  'P0001',
+  null,
+  'CAS failure: wrong version raises exception'
+);
+
+SELECT throws_ok(
+  $$SELECT transition_settlement_status(
+    '00000000-dead-beef-dead-000000000000'::uuid,
+    1, 'READY', 'SYSTEM', 'cron', 'calc_succeeded'
+  )$$,
+  'P0001',
+  null,
+  'non-existent item raises exception'
+);
+
+-- ============================================================
+-- 6. Negative net_amount is allowed (CHECK removed)
+-- ============================================================
+DO $$
+DECLARE
+  v_partner_id uuid;
+BEGIN
+  SELECT id INTO v_partner_id FROM public.partners WHERE name = 'Test Partner Phase2';
+
+  INSERT INTO public.settlement_items (
+    partner_id, settlement_period_start, settlement_period_end,
+    currency, source_type, source_id, status,
+    gross_amount, platform_fee_rate, platform_fee_amount,
+    pg_fee_rate, pg_fee_amount, vat_rate, vat_amount, net_amount, calc_checksum
+  ) VALUES (
+    v_partner_id, '2026-03-01', '2026-03-31',
+    'KRW', 'TEST', 'phase2-test-neg', 'PENDING',
+    1000, 5.00, 50, 3.50, 35, 10.00, 8, -9000, repeat('c', 64)
+  );
+END;
+$$;
+
+SELECT results_eq(
+  $$SELECT net_amount FROM settlement_items WHERE source_id = 'phase2-test-neg'$$,
+  $$VALUES (-9000::bigint)$$,
+  'negative net_amount is allowed (CHECK constraint removed)'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/35_settlement_trigger_cron_test.sql
+++ b/supabase/tests/database/35_settlement_trigger_cron_test.sql
@@ -1,0 +1,302 @@
+BEGIN;
+SELECT no_plan();
+
+SELECT tests.authenticate_as_service_role();
+
+CREATE TEMP TABLE trigger_results (key text, val text);
+
+-- ============================================================
+-- 1. Trigger cutover: event completion → settlement_items
+-- ============================================================
+DO $$
+DECLARE
+  v_partner_id uuid;
+  v_party_id   uuid;
+  v_event_id   uuid;
+  v_ticket_id  uuid;
+  v_user_id    uuid;
+BEGIN
+  v_user_id := tests.create_supabase_user('trigger_test_user');
+  INSERT INTO public.partners (name) VALUES ('Trigger Test Partner') RETURNING id INTO v_partner_id;
+
+  INSERT INTO public.parties (partner_id, title, min_confirmed_count, max_participants)
+  VALUES (v_partner_id, 'Trigger Test Party', 0, 10)
+  RETURNING id INTO v_party_id;
+
+  INSERT INTO public.events (party_id, start_time, end_time, min_confirmed_count, max_participants)
+  VALUES (v_party_id,
+    now() - interval '2 days',
+    now() - interval '1 day',
+    0, 10)
+  RETURNING id INTO v_event_id;
+
+  INSERT INTO public.tickets (event_id, name, quantity, price)
+  VALUES (v_event_id, 'Trigger Test Ticket', 10, 50000)
+  RETURNING id INTO v_ticket_id;
+
+  INSERT INTO public.event_applications (
+    event_id, ticket_id, user_id, status, payment_id, payment_amount
+  ) VALUES (
+    v_event_id, v_ticket_id, v_user_id, 'paid', 'pay_trigger_001', 50000
+  );
+
+  INSERT INTO trigger_results (key, val) VALUES
+    ('event_id', v_event_id::text),
+    ('partner_id', v_partner_id::text);
+
+  UPDATE public.events SET status = 'completed' WHERE id = v_event_id;
+END;
+$$;
+
+SELECT results_eq(
+  $$SELECT count(*)::int FROM settlement_items
+    WHERE source_id = (SELECT val FROM trigger_results WHERE key='event_id')
+      AND source_type = 'EVENT'$$,
+  $$VALUES (1)$$,
+  'event completion creates 1 settlement_items record'
+);
+
+SELECT results_eq(
+  $$SELECT status FROM settlement_items
+    WHERE source_id = (SELECT val FROM trigger_results WHERE key='event_id')$$,
+  $$VALUES ('PENDING'::text)$$,
+  'new settlement_item starts in PENDING status'
+);
+
+SELECT results_eq(
+  $$SELECT gross_amount FROM settlement_items
+    WHERE source_id = (SELECT val FROM trigger_results WHERE key='event_id')$$,
+  $$VALUES (50000::bigint)$$,
+  'gross_amount = total paid sales (50000)'
+);
+
+SELECT results_eq(
+  $$SELECT platform_fee_amount FROM settlement_items
+    WHERE source_id = (SELECT val FROM trigger_results WHERE key='event_id')$$,
+  $$VALUES (2500::bigint)$$,
+  'platform_fee = floor(50000 * 5%) = 2500'
+);
+
+SELECT results_eq(
+  $$SELECT count(*)::int FROM settlements
+    WHERE event_id = (SELECT val FROM trigger_results WHERE key='event_id')::uuid$$,
+  $$VALUES (0)$$,
+  'old settlements table NOT written (full cutover)'
+);
+
+SELECT results_eq(
+  $$SELECT length(calc_checksum) FROM settlement_items
+    WHERE source_id = (SELECT val FROM trigger_results WHERE key='event_id')$$,
+  $$VALUES (64)$$,
+  'calc_checksum is a valid 64-char SHA-256 hex'
+);
+
+-- ============================================================
+-- 2. Cron: 14-day hold transition PENDING → READY
+-- ============================================================
+DO $$
+DECLARE
+  v_partner_id uuid;
+  v_item_id    uuid;
+  v_cs         char(64);
+  v_amounts    record;
+BEGIN
+  SELECT id INTO v_partner_id FROM public.partners WHERE name = 'Trigger Test Partner';
+
+  SELECT * INTO v_amounts FROM calculate_settlement_amounts(80000, 5.00, 3.50, 10.00);
+
+  v_cs := calculate_settlement_checksum(
+    v_partner_id,
+    '2026-01-01'::date, '2026-01-31'::date,
+    'KRW', 80000, 5.00, 3.50, 10.00,
+    v_amounts.out_platform_fee_amount,
+    v_amounts.out_pg_fee_amount,
+    v_amounts.out_vat_amount,
+    v_amounts.out_net_amount
+  );
+
+  INSERT INTO public.settlement_items (
+    partner_id, settlement_period_start, settlement_period_end,
+    currency, source_type, source_id, status,
+    gross_amount, platform_fee_rate, platform_fee_amount,
+    pg_fee_rate, pg_fee_amount, vat_rate, vat_amount, net_amount,
+    calc_checksum, event_completed_at
+  ) VALUES (
+    v_partner_id, '2026-01-01', '2026-01-31',
+    'KRW', 'TEST', 'cron-test-14d', 'PENDING',
+    80000, 5.00, v_amounts.out_platform_fee_amount,
+    3.50, v_amounts.out_pg_fee_amount, 10.00, v_amounts.out_vat_amount, v_amounts.out_net_amount,
+    v_cs,
+    now() - interval '15 days'
+  ) RETURNING id INTO v_item_id;
+
+  INSERT INTO trigger_results (key, val) VALUES ('cron_item_id', v_item_id::text);
+END;
+$$;
+
+SELECT is(
+  (SELECT status FROM settlement_items WHERE source_id = 'cron-test-14d'),
+  'PENDING',
+  'before cron: status is PENDING'
+);
+
+SELECT lives_ok(
+  $$SELECT update_settlement_ready_status()$$,
+  'update_settlement_ready_status() executes without error'
+);
+
+SELECT results_eq(
+  $$SELECT status FROM settlement_items WHERE source_id = 'cron-test-14d'$$,
+  $$VALUES ('READY'::text)$$,
+  '15-day old item transitions to READY after cron'
+);
+
+SELECT results_eq(
+  $$SELECT count(*)::int FROM settlement_histories
+    WHERE settlement_item_id = (SELECT val FROM trigger_results WHERE key='cron_item_id')::uuid
+    AND event_type = 'calc_succeeded'$$,
+  $$VALUES (1)$$,
+  'cron transition recorded in settlement_histories'
+);
+
+-- ============================================================
+-- 3. Cron: 13-day item does NOT transition
+-- ============================================================
+DO $$
+DECLARE
+  v_partner_id uuid;
+  v_amounts    record;
+  v_cs         char(64);
+BEGIN
+  SELECT id INTO v_partner_id FROM public.partners WHERE name = 'Trigger Test Partner';
+  SELECT * INTO v_amounts FROM calculate_settlement_amounts(30000, 5.00, 3.50, 10.00);
+
+  v_cs := calculate_settlement_checksum(
+    v_partner_id, '2026-02-01'::date, '2026-02-28'::date,
+    'KRW', 30000, 5.00, 3.50, 10.00,
+    v_amounts.out_platform_fee_amount,
+    v_amounts.out_pg_fee_amount,
+    v_amounts.out_vat_amount,
+    v_amounts.out_net_amount
+  );
+
+  INSERT INTO public.settlement_items (
+    partner_id, settlement_period_start, settlement_period_end,
+    currency, source_type, source_id, status,
+    gross_amount, platform_fee_rate, platform_fee_amount,
+    pg_fee_rate, pg_fee_amount, vat_rate, vat_amount, net_amount,
+    calc_checksum, event_completed_at
+  ) VALUES (
+    v_partner_id, '2026-02-01', '2026-02-28',
+    'KRW', 'TEST', 'cron-test-13d', 'PENDING',
+    30000, 5.00, v_amounts.out_platform_fee_amount,
+    3.50, v_amounts.out_pg_fee_amount, 10.00, v_amounts.out_vat_amount, v_amounts.out_net_amount,
+    v_cs,
+    now() - interval '13 days'
+  );
+END;
+$$;
+
+SELECT lives_ok(
+  $$SELECT update_settlement_ready_status()$$,
+  'cron runs without error'
+);
+
+SELECT results_eq(
+  $$SELECT status FROM settlement_items WHERE source_id = 'cron-test-13d'$$,
+  $$VALUES ('PENDING'::text)$$,
+  '13-day old item stays PENDING (14-day threshold not met)'
+);
+
+-- ============================================================
+-- 4. Cron: checksum mismatch → FAILED
+-- ============================================================
+DO $$
+DECLARE
+  v_partner_id uuid;
+  v_amounts    record;
+BEGIN
+  SELECT id INTO v_partner_id FROM public.partners WHERE name = 'Trigger Test Partner';
+  SELECT * INTO v_amounts FROM calculate_settlement_amounts(20000, 5.00, 3.50, 10.00);
+
+  INSERT INTO public.settlement_items (
+    partner_id, settlement_period_start, settlement_period_end,
+    currency, source_type, source_id, status,
+    gross_amount, platform_fee_rate, platform_fee_amount,
+    pg_fee_rate, pg_fee_amount, vat_rate, vat_amount, net_amount,
+    calc_checksum, event_completed_at
+  ) VALUES (
+    v_partner_id, '2026-03-01', '2026-03-31',
+    'KRW', 'TEST', 'cron-test-tampered', 'PENDING',
+    20000, 5.00, v_amounts.out_platform_fee_amount,
+    3.50, v_amounts.out_pg_fee_amount, 10.00, v_amounts.out_vat_amount, v_amounts.out_net_amount,
+    repeat('f', 64),
+    now() - interval '20 days'
+  );
+END;
+$$;
+
+SELECT lives_ok(
+  $$SELECT update_settlement_ready_status()$$,
+  'cron handles checksum mismatch gracefully'
+);
+
+SELECT results_eq(
+  $$SELECT status FROM settlement_items WHERE source_id = 'cron-test-tampered'$$,
+  $$VALUES ('HOLD'::text)$$,
+  'tampered checksum results in HOLD status for manual review'
+);
+
+SELECT results_eq(
+  $$SELECT hold_reason_code FROM settlement_items WHERE source_id = 'cron-test-tampered'$$,
+  $$VALUES ('CHECKSUM_MISMATCH'::text)$$,
+  'hold_reason_code = CHECKSUM_MISMATCH for tampered item'
+);
+
+-- ============================================================
+-- 5. Stuck processing check: PROCESSING > 2h → FAILED
+-- ============================================================
+DO $$
+DECLARE
+  v_partner_id uuid;
+  v_item_id    uuid;
+BEGIN
+  SELECT id INTO v_partner_id FROM public.partners WHERE name = 'Trigger Test Partner';
+
+  INSERT INTO public.settlement_items (
+    partner_id, settlement_period_start, settlement_period_end,
+    currency, source_type, source_id, status,
+    gross_amount, platform_fee_rate, platform_fee_amount,
+    pg_fee_rate, pg_fee_amount, vat_rate, vat_amount, net_amount,
+    calc_checksum, processing_started_at
+  ) VALUES (
+    v_partner_id, '2026-04-01', '2026-04-30',
+    'KRW', 'TEST', 'stuck-processing-001', 'PROCESSING',
+    10000, 5.00, 500, 3.50, 350, 10.00, 85, 9065,
+    repeat('d', 64),
+    now() - interval '3 hours'
+  ) RETURNING id INTO v_item_id;
+
+  INSERT INTO trigger_results (key, val) VALUES ('stuck_item_id', v_item_id::text);
+END;
+$$;
+
+SELECT lives_ok(
+  $$SELECT check_stuck_processing_settlements()$$,
+  'check_stuck_processing_settlements() runs without error'
+);
+
+SELECT results_eq(
+  $$SELECT status FROM settlement_items WHERE source_id = 'stuck-processing-001'$$,
+  $$VALUES ('FAILED'::text)$$,
+  'PROCESSING item older than 2h transitions to FAILED'
+);
+
+SELECT results_eq(
+  $$SELECT failure_reason_code FROM settlement_items WHERE source_id = 'stuck-processing-001'$$,
+  $$VALUES ('TIMEOUT_STUCK_PROCESSING'::text)$$,
+  'failure_reason_code = TIMEOUT_STUCK_PROCESSING'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary

정산 시스템 Phase 2 — Phase 1 테이블 위에 비즈니스 로직 구축. 순수 SQL migration.

**Depends on**: PR #88 (Phase 1 schema)

## Changes

### 신규 함수 (3개)
- **`calculate_settlement_amounts()`**: floor() 기반 수수료 산출 (REQ-7.01). platform_fee, pg_fee, vat, net_amount 4개 OUT 파라미터
- **`calculate_settlement_checksum()`**: SHA-256 canonical string (REQ-7.03). 12개 입력 → 64자 hex
- **`transition_settlement_status()`**: CAS 기반 13개 허용 상태 전이 (REQ-3.2.15). 버전 증가 + settlement_histories 자동 기록. HOLD→hold_reason_code 필수, FAILED→failure_reason_code 필수

### 트리거 Full Cutover
- `create_settlement_on_event_completion()` 재정의: `settlements` → `settlement_items`에 INSERT
- `calculate_settlement_amounts()` + `calculate_settlement_checksum()` 호출
- ON CONFLICT: `uq_settlement_items_source`

### 크론잡 업데이트
- `update_settlement_ready_status()`: 7일 → **14일** 보류, `transition_settlement_status()` 호출, 체크섬 재검증 (불일치 시 HOLD)
- `check_stuck_processing_settlements()`: PROCESSING > 2h → FAILED (Phase 3 대비, 현재 no-op)

### 스키마 변경
- `settlement_items.net_amount` CHECK (>= 0) 제거 — 음수 허용

### pgTAP 테스트
- `34_settlement_state_machine_test.sql`: 24 assertions — 상태 전이 매트릭스, CAS, floor() 계산, 체크섬
- `35_settlement_trigger_cron_test.sql`: 트리거 cutover, 14일 크론, 체크섬 불일치→HOLD, stuck processing

## Guardrails
- 기존 `settlements` 테이블 무수정 (read-only 아카이브)
- Dart/Edge Function 변경 없음 (순수 SQL)
- Phase 3+ 로직 없음 (payout, retry, DLQ)

## Test Results
- `supabase db reset`: ✅ zero errors
- `supabase test db`: ✅ 34, 35 both ok (28_visibility pre-existing fail)