### PR TITLE
feat(social): event detail action redesign — dislike + chip buttons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,16 @@ adb -s adb-R3CX803P2ND-8btuuD._adb-tls-connect._tcp install -r build/app/outputs
 - 머지 후 소스 브랜치는 자동 삭제된다 (`delete_branch_on_merge` 활성화).
 - Admin bypass (`--admin`)는 긴급 상황에서만 사용한다.
 
+### PR 머지 확인 및 CI 실패 대응
+
+- PR 생성 후 `gh pr checks <PR번호>`로 CI 상태를 확인한다.
+- CI가 통과하여 auto-merge가 완료되었는지 `gh pr view <PR번호> --json state`로 확인한다.
+- CI 실패 시:
+  1. `gh run view <run_id> --log-failed`로 실패 원인 파악
+  2. 로컬에서 수정 후 같은 브랜치에 push (PR은 유지됨)
+  3. CI 재실행 → 통과 확인 → auto-merge 완료까지 반복
+- PR이 `MERGED` 상태가 될 때까지 케어한다. 생성만 하고 방치하지 않는다.
+
 ## Bug Fix Conventions
 
 ### 진단 프로세스

--- a/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
@@ -386,7 +386,6 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent>
                           MinglitChip(
                             label: '공유하기',
                             icon: Icons.share_outlined,
-                            size: MinglitChipSize.medium,
                             onTap: () => unawaited(
                               ShareUtils.shareEvent(
                                 eventTitle: eventTitle,

--- a/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
@@ -190,33 +190,6 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent>
                 ),
                 leading: BackButton(color: iconColor),
                 actions: [
-                  IconButton(
-                    onPressed: () {
-                      unawaited(
-                        ShareUtils.shareEvent(
-                          eventTitle: eventTitle,
-                          eventId: event.id,
-                          baseUrl: ref.watch(minglitDomainsProvider).userApp,
-                        ),
-                      );
-                    },
-                    icon: Icon(Icons.share_outlined, color: iconColor),
-                    tooltip: '공유하기',
-                  ),
-                  if (user != null)
-                    Padding(
-                      padding: const EdgeInsets.only(
-                        right: MinglitSpacing.small,
-                      ),
-                      child: MinglitSocialButton(
-                        targetId: event.partyId, // Like the party
-                        targetType: SocialTargetType.party,
-                        interactionType: SocialInteractionType.like,
-                        activeColor: iconColor,
-                        inactiveColor: iconColor,
-                        tooltip: '좋아요',
-                      ),
-                    ),
                   if (partner != null && user != null)
                     PopupMenuButton<String>(
                       icon: Icon(Icons.more_vert, color: iconColor),
@@ -374,6 +347,57 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent>
                         icon: Icons.location_on_outlined,
                         title: location?.name ?? '장소 미정',
                         subtitle: location?.address ?? '주소 정보 없음',
+                      ),
+                      const SizedBox(height: MinglitSpacing.medium),
+                      Wrap(
+                        spacing: MinglitSpacing.small,
+                        runSpacing: MinglitSpacing.small,
+                        children: [
+                          MinglitSocialActionChip(
+                            targetId: event.partyId,
+                            targetType: SocialTargetType.party,
+                            interactionType: SocialInteractionType.like,
+                            label: '좋아요',
+                            activeIcon: Icons.thumb_up,
+                            inactiveIcon: Icons.thumb_up_outlined,
+                            activeColor: Theme.of(context).colorScheme.error,
+                            onUnauthenticatedTap: user == null
+                                ? () => ref
+                                      .read(authCoordinatorProvider)
+                                      .pushLogin()
+                                : null,
+                          ),
+                          MinglitSocialActionChip(
+                            targetId: event.partyId,
+                            targetType: SocialTargetType.party,
+                            interactionType: SocialInteractionType.dislike,
+                            label: '싫어요',
+                            activeIcon: Icons.thumb_down,
+                            inactiveIcon: Icons.thumb_down_outlined,
+                            activeColor: Theme.of(
+                              context,
+                            ).colorScheme.onSurfaceVariant,
+                            onUnauthenticatedTap: user == null
+                                ? () => ref
+                                      .read(authCoordinatorProvider)
+                                      .pushLogin()
+                                : null,
+                          ),
+                          MinglitChip(
+                            label: '공유하기',
+                            icon: Icons.share_outlined,
+                            size: MinglitChipSize.medium,
+                            onTap: () => unawaited(
+                              ShareUtils.shareEvent(
+                                eventTitle: eventTitle,
+                                eventId: event.id,
+                                baseUrl: ref
+                                    .watch(minglitDomainsProvider)
+                                    .userApp,
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
                       const Divider(height: MinglitSpacing.xlarge),
                       // Entry Conditions (without verification badges)

--- a/apps/app_user/lib/src/features/event/detail/event_detail_page.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:app_user/src/features/auth/logic/auth_coordinator.dart';
 import 'package:app_user/src/features/event/admission/event_admission_controller.dart';
 import 'package:app_user/src/features/event/detail/open_in_app_dialog.dart';
 import 'package:app_user/src/features/event/detail/report_bottom_sheet.dart';

--- a/shared/packages/minglit_kit/lib/minglit_ui.dart
+++ b/shared/packages/minglit_kit/lib/minglit_ui.dart
@@ -7,6 +7,7 @@ export 'src/features/loading/minglit_global_loading_overlay.dart';
 export 'src/features/notification/notification_list_screen.dart';
 export 'src/features/notification/notification_settings_screen.dart';
 export 'src/features/search/ui/location_search_screen.dart';
+export 'src/features/social/ui/minglit_social_action_chip.dart';
 export 'src/features/social/ui/minglit_social_button.dart';
 export 'src/features/verification/ui/identity_verification_screen.dart';
 export 'src/theme/minglit_theme.dart';

--- a/shared/packages/minglit_kit/lib/src/data/models/social_interaction.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/social_interaction.dart
@@ -34,6 +34,9 @@ enum SocialInteractionType {
 
   /// Indicates a report action.
   report,
+
+  /// Indicates a dislike action.
+  dislike,
 }
 
 /// Represents a user interaction with a social target.

--- a/shared/packages/minglit_kit/lib/src/data/models/social_interaction.g.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/social_interaction.g.dart
@@ -43,4 +43,5 @@ const _$SocialInteractionTypeEnumMap = {
   SocialInteractionType.bookmark: 'bookmark',
   SocialInteractionType.block: 'block',
   SocialInteractionType.report: 'report',
+  SocialInteractionType.dislike: 'dislike',
 };

--- a/shared/packages/minglit_kit/lib/src/data/repositories/social_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/social_repository.dart
@@ -33,6 +33,20 @@ class SocialRepository {
     Log.d('toggleInteraction | type: $interactionType');
 
     try {
+      // 0. Like/dislike mutual exclusivity — remove opposite before toggling
+      if (interactionType == SocialInteractionType.like ||
+          interactionType == SocialInteractionType.dislike) {
+        final opposite = interactionType == SocialInteractionType.like
+            ? SocialInteractionType.dislike
+            : SocialInteractionType.like;
+        await _supabase
+            .from('social_interactions')
+            .delete()
+            .eq('user_id', userId)
+            .eq('target_id', targetId)
+            .eq('interaction_type', opposite.name);
+      }
+
       // 1. Check if interaction already exists
       final existing = await _supabase
           .from('social_interactions')

--- a/shared/packages/minglit_kit/lib/src/features/auth/logic/auth_controller.g.dart
+++ b/shared/packages/minglit_kit/lib/src/features/auth/logic/auth_controller.g.dart
@@ -39,7 +39,7 @@ final class AuthControllerProvider
   AuthController create() => AuthController();
 }
 
-String _$authControllerHash() => r'256785a936d59153b0d6f529e6236f6fd86cfb0f';
+String _$authControllerHash() => r'fb3cf93fc741bd7a184541157529f303fb9ee2c5';
 
 /// Controller for authentication actions (Sign In, Sign Out).
 /// Handles the state of the *request* (loading, error, success).

--- a/shared/packages/minglit_kit/lib/src/features/social/ui/minglit_social_action_chip.dart
+++ b/shared/packages/minglit_kit/lib/src/features/social/ui/minglit_social_action_chip.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:minglit_kit/src/data/models/social_interaction.dart';
+import 'package:minglit_kit/src/features/social/logic/social_interaction_controller.dart';
+import 'package:minglit_kit/src/theme/minglit_theme.dart';
+import 'package:minglit_kit/src/ui/widgets/common/loading_indicator.dart';
+
+/// A chip-style button for social interactions (like/dislike).
+///
+/// Renders as outlined chip when inactive, filled chip when active.
+/// Handles auth guard via [onUnauthenticatedTap].
+class MinglitSocialActionChip extends ConsumerWidget {
+  /// Creates a [MinglitSocialActionChip].
+  const MinglitSocialActionChip({
+    required this.targetId,
+    required this.targetType,
+    required this.interactionType,
+    required this.label,
+    required this.activeIcon,
+    required this.inactiveIcon,
+    this.activeColor,
+    this.onUnauthenticatedTap,
+    super.key,
+  });
+
+  /// The ID of the target entity.
+  final String targetId;
+
+  /// The type of the target.
+  final SocialTargetType targetType;
+
+  /// The type of interaction.
+  final SocialInteractionType interactionType;
+
+  /// Text label displayed on the chip.
+  final String label;
+
+  /// Icon shown when the interaction is active.
+  final IconData activeIcon;
+
+  /// Icon shown when the interaction is inactive.
+  final IconData inactiveIcon;
+
+  /// Background color when active. Defaults to theme error color.
+  final Color? activeColor;
+
+  /// Called when an unauthenticated user taps the chip.
+  final VoidCallback? onUnauthenticatedTap;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncState = ref.watch(
+      socialInteractionControllerProvider(
+        targetId: targetId,
+        targetType: targetType,
+        interactionType: interactionType,
+      ),
+    );
+
+    return asyncState.when(
+      data: (isActive) => _buildChip(context, ref, isActive: isActive),
+      loading: () => _buildChip(context, ref, isLoading: true),
+      error: (_, _) => _buildChip(context, ref),
+    );
+  }
+
+  Widget _buildChip(
+    BuildContext context,
+    WidgetRef ref, {
+    bool isActive = false,
+    bool isLoading = false,
+  }) {
+    final theme = Theme.of(context);
+    final color = activeColor ?? theme.colorScheme.error;
+
+    return Material(
+      color: isActive ? color : Colors.transparent,
+      borderRadius: BorderRadius.circular(MinglitRadius.small),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(MinglitRadius.small),
+        onTap: isLoading
+            ? null
+            : () {
+                if (onUnauthenticatedTap != null) {
+                  onUnauthenticatedTap!();
+                  return;
+                }
+                ref
+                    .read(
+                      socialInteractionControllerProvider(
+                        targetId: targetId,
+                        targetType: targetType,
+                        interactionType: interactionType,
+                      ).notifier,
+                    )
+                    .toggle();
+              },
+        child: Container(
+          padding: const EdgeInsets.symmetric(
+            horizontal: MinglitSpacing.small,
+            vertical: MinglitSpacing.xxsmall,
+          ),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(MinglitRadius.small),
+            border: isActive
+                ? null
+                : Border.all(color: theme.colorScheme.outline),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (isLoading)
+                const SizedBox(
+                  width: 14,
+                  height: 14,
+                  child: MinglitCircularProgressIndicator(strokeWidth: 1.5),
+                )
+              else
+                Icon(
+                  isActive ? activeIcon : inactiveIcon,
+                  size: 14,
+                  color: isActive
+                      ? Colors.white
+                      : theme.colorScheme.onSurfaceVariant,
+                ),
+              const SizedBox(width: MinglitSpacing.xxsmall),
+              Text(
+                label,
+                style: theme.textTheme.labelMedium?.copyWith(
+                  fontSize: 12,
+                  color: isActive
+                      ? Colors.white
+                      : theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/shared/packages/minglit_kit/lib/src/features/social/ui/minglit_social_button.dart
+++ b/shared/packages/minglit_kit/lib/src/features/social/ui/minglit_social_button.dart
@@ -120,6 +120,8 @@ class MinglitSocialButton extends ConsumerWidget {
         isActive ? Icons.bookmark : Icons.bookmark_border,
       SocialInteractionType.block => Icons.block,
       SocialInteractionType.report => Icons.flag,
+      SocialInteractionType.dislike =>
+        isActive ? Icons.thumb_down : Icons.thumb_down_outlined,
     };
   }
 
@@ -128,6 +130,7 @@ class MinglitSocialButton extends ConsumerWidget {
       SocialInteractionType.like => theme.colorScheme.error,
       SocialInteractionType.subscribe => theme.colorScheme.secondary,
       SocialInteractionType.bookmark => theme.colorScheme.primary,
+      SocialInteractionType.dislike => theme.colorScheme.onSurfaceVariant,
       _ => theme.colorScheme.primary,
     };
   }
@@ -139,6 +142,7 @@ class MinglitSocialButton extends ConsumerWidget {
       SocialInteractionType.bookmark => '저장',
       SocialInteractionType.block => '차단',
       SocialInteractionType.report => '신고',
+      SocialInteractionType.dislike => '싫어요',
     };
   }
 }

--- a/shared/packages/minglit_kit/test/src/data/models/social_interaction_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/models/social_interaction_test.dart
@@ -33,7 +33,14 @@ void main() {
     });
 
     test('parses all interaction types', () {
-      for (final type in ['like', 'subscribe', 'bookmark', 'block']) {
+      for (final type in [
+        'like',
+        'subscribe',
+        'bookmark',
+        'block',
+        'report',
+        'dislike',
+      ]) {
         final i = SocialInteraction.fromJson({
           ...interactionJson(),
           'interactionType': type,
@@ -78,7 +85,7 @@ void main() {
 
   group('SocialInteractionType', () {
     test('has all expected values', () {
-      expect(SocialInteractionType.values, hasLength(4));
+      expect(SocialInteractionType.values, hasLength(6));
       expect(
         SocialInteractionType.values,
         contains(SocialInteractionType.like),
@@ -94,6 +101,14 @@ void main() {
       expect(
         SocialInteractionType.values,
         contains(SocialInteractionType.block),
+      );
+      expect(
+        SocialInteractionType.values,
+        contains(SocialInteractionType.report),
+      );
+      expect(
+        SocialInteractionType.values,
+        contains(SocialInteractionType.dislike),
       );
     });
   });

--- a/supabase/migrations/20260315000002_add_dislike_interaction_type.sql
+++ b/supabase/migrations/20260315000002_add_dislike_interaction_type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE public.social_interaction_type ADD VALUE IF NOT EXISTS 'dislike';


### PR DESCRIPTION
## Summary
- DB: `social_interaction_type` enum에 `dislike` 추가
- Dart: `SocialInteractionType.dislike` + `MinglitSocialButton` switch문 업데이트
- `SocialRepository`: like/dislike 상호배타 토글 (반대쪽 자동 해제)
- 새 `MinglitSocialActionChip` 위젯: outlined(비활성)/filled(활성) 칩, 아이콘+라벨
- 이벤트 디테일: 앱바에서 좋아요/공유 제거, 기본정보 탭에 좋아요/싫어요/공유 칩 섹션 추가
- 비로그인 유저: 칩 표시되되 탭 시 로그인 유도
- 기존 stale 테스트 수정 (hasLength 4→6)