### PR TITLE
feat(ci): add ci-result gate job for branch protection required check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,22 @@ jobs:
         if: always()
         run: supabase stop
 
+  ci-result:
+    needs: [check-migration-versions, test-app-user, test-app-partner, lint-landing-user, lint-landing-partner, test-pgtap, test-backend-integration, test-edge-functions, test-e2e-scenarios]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check CI results
+        run: |
+          results='${{ toJSON(needs.*.result) }}'
+          echo "Job results: $results"
+          if echo "$results" | grep -q '"failure"'; then
+            echo ""
+            echo '${{ toJSON(needs) }}' | jq -r 'to_entries[] | select(.value.result == "failure") | "❌ \(.key)"'
+            exit 1
+          fi
+          echo "✅ CI passed"
+
   notify-failure:
     needs: [check-migration-versions, test-app-user, test-app-partner, lint-landing-user, lint-landing-partner, test-pgtap, test-backend-integration, test-edge-functions, test-e2e-scenarios]
     if: always()


### PR DESCRIPTION
## Summary
- path-filtered CI job을 branch protection required check로 사용하기 위한 gate job 추가
- `ci-result` job이 모든 CI job 결과를 집계하여 하나라도 failure면 실패
- skipped (path 미해당)는 정상 처리
- branch protection에서 `ci-result` 하나만 required로 등록하면 됨

## Post-merge
Settings → Branches → dev rule → Status checks에 `ci-result` 추가