### PR TITLE
feat(home): remove bottom nav, add auth-aware app bar actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,16 @@ adb -s adb-R3CX803P2ND-8btuuD._adb-tls-connect._tcp install -r build/app/outputs
 - 머지 후 소스 브랜치는 자동 삭제된다 (`delete_branch_on_merge` 활성화).
 - Admin bypass (`--admin`)는 긴급 상황에서만 사용한다.
 
+### PR 코드 리뷰 대응
+
+- PR에 달린 코드 리뷰 코멘트는 **전부 resolve** 한다. 미해결 코멘트가 남아있는 상태로 머지하지 않는다.
+- 리뷰 코멘트 확인: `gh api repos/{owner}/{repo}/pulls/{PR번호}/comments`
+- 코멘트에 대한 대응:
+  1. 코드 수정이 필요한 경우: 수정 후 같은 브랜치에 push → 리뷰 코멘트에 수정 내용 답글 → resolve
+  2. 수정 불필요 (의도된 설계): 근거를 답글로 남기고 → resolve
+  3. 논의가 필요한 경우: 답글로 의견 남기고 사용자에게 판단 요청
+- 모든 코멘트가 resolved 된 후 머지를 진행한다.
+
 ### PR 머지 확인 및 CI 실패 대응
 
 - PR 생성 후 `gh pr checks <PR번호>`로 CI 상태를 확인한다.

--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -95,8 +95,9 @@ class _HomePageState extends ConsumerState<HomePage> {
               ] else
                 IconButton(
                   icon: const Icon(Icons.person_outline),
+                  // Fix #102: use go (not push) so GoRouter redirect fires after login
                   onPressed: () =>
-                      ref.read(authCoordinatorProvider).pushLogin(from: '/'),
+                      ref.read(authCoordinatorProvider).goToLogin(from: '/'),
                 ),
               const SizedBox(width: MinglitSpacing.small),
             ],


### PR DESCRIPTION
## Summary
- 유저앱 바텀 네비게이션 바(홈/마이 2탭) 완전 제거
- 홈 SliverAppBar에 인증 상태별 액션 아이콘 배치
  - 로그인: 검색 + 알림 + 프로필 아바타(→ /my push)
  - 비로그인: 검색 + person 아이콘(→ 로그인 화면)
- StatefulShellRoute → TypedGoRoute 승격, /my는 push 라우트로 전환
- AGENTS.md에 PR 코드리뷰 resolve 가이드라인 추가

## Bug Fix
- **Closes #102** — 비로그인 상태에서 person 아이콘 → 로그인 후 로그인 화면에 머무르는 버그 수정
  - Root cause: `pushLogin()`의 `push()`는 GoRouter redirect가 스택 위에서 작동하지 않음
  - Fix: `goToLogin(from: '/')`으로 변경하여 로그인 성공 시 홈으로 정상 리다이렉트

## Changed Files
| File | Change |
|------|--------|
| `user_scaffold.dart` | 삭제 (바텀바 셸) |
| `nav_visibility_provider.dart` + `.g.dart` | 삭제 |
| `user_scaffold_test.dart` | 삭제 (stale) |
| `app_routes.dart` + `.g.dart` | ShellRoute → TypedGoRoute |
| `home_page.dart` | NotificationListener 제거 + 인증 상태별 앱바 액션 |
| `home_page_app_bar_test.dart` | 새 테스트 (11개) |
| `home_page_test.dart` + `widget_test.dart` | currentUserProvider override 추가 |
| `AGENTS.md` | PR 코드리뷰 가이드라인 추가 |

## Verification
- `flutter analyze`: No issues found ✅
- `flutter test`: 110/110 ALL PASSED ✅
- APK build + device install: 성공 ✅