### PR TITLE
feat(app_partner): redesign MorePage with Claude-style settings layout

### DIFF
--- a/apps/app_partner/lib/src/features/more/more_coordinator.dart
+++ b/apps/app_partner/lib/src/features/more/more_coordinator.dart
@@ -1,0 +1,28 @@
+import 'dart:async';
+
+import 'package:app_partner/src/routing/app_router.dart';
+import 'package:app_partner/src/routing/app_routes.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+final moreCoordinatorProvider = Provider<MoreCoordinator>((ref) {
+  return MoreCoordinator(ref.read(goRouterProvider));
+});
+
+class MoreCoordinator {
+  MoreCoordinator(this._router);
+
+  final GoRouter _router;
+
+  void pushNotificationSettings() {
+    unawaited(_router.push(const NotificationSettingsRoute().location));
+  }
+
+  void pushMemberList(String partnerId) {
+    unawaited(_router.push(MemberListRoute(partnerId: partnerId).location));
+  }
+
+  void pushVerificationManage() {
+    unawaited(_router.push(const VerificationManageRoute().location));
+  }
+}

--- a/apps/app_partner/lib/src/features/more/more_page.dart
+++ b/apps/app_partner/lib/src/features/more/more_page.dart
@@ -1,40 +1,212 @@
+import 'dart:async';
+import 'package:app_partner/src/features/more/more_coordinator.dart';
+import 'package:app_partner/src/features/party/party_providers.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:minglit_kit/minglit_kit.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
 
-class MorePage extends StatelessWidget {
+class MorePage extends ConsumerWidget {
   const MorePage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final partnerAsync = ref.watch(currentPartnerInfoProvider);
+    final theme = Theme.of(context);
+
     return Scaffold(
       appBar: MinglitTheme.simpleAppBar(title: '더보기'),
       body: ListView(
         children: [
-          ListTile(
-            leading: const Icon(Icons.person_outline),
-            title: const Text('계정 관리'),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () {},
+          // ── 프로필 헤더 ──
+          partnerAsync.when(
+            loading: () => const Padding(
+              padding: EdgeInsets.all(MinglitSpacing.large),
+              child: CircularProgressIndicator(),
+            ),
+            error: (error, stackTrace) => Padding(
+              padding: const EdgeInsets.all(MinglitSpacing.large),
+              child: Row(
+                children: [
+                  const CircleAvatar(
+                    radius: 32,
+                    child: Icon(Icons.store, size: 32),
+                  ),
+                  const SizedBox(width: MinglitSpacing.medium),
+                  Text(
+                    '파트너 정보를 불러올 수 없습니다',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            data: (partner) {
+              if (partner == null) {
+                return Padding(
+                  padding: const EdgeInsets.all(MinglitSpacing.large),
+                  child: Row(
+                    children: [
+                      const CircleAvatar(
+                        radius: 32,
+                        child: Icon(Icons.store, size: 32),
+                      ),
+                      const SizedBox(width: MinglitSpacing.medium),
+                      Text(
+                        '파트너 정보를 불러올 수 없습니다',
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              }
+              return Padding(
+                padding: const EdgeInsets.all(MinglitSpacing.large),
+                child: Row(
+                  children: [
+                    CircleAvatar(
+                      radius: 32,
+                      backgroundImage: partner.profileImageUrl != null
+                          ? NetworkImage(partner.profileImageUrl!)
+                          : null,
+                      child: partner.profileImageUrl == null
+                          ? const Icon(Icons.store, size: 32)
+                          : null,
+                    ),
+                    const SizedBox(width: MinglitSpacing.medium),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            partner.name,
+                            style: theme.textTheme.titleLarge?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          if (partner.contactEmail != null)
+                            Text(
+                              partner.contactEmail!,
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                color: theme.colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
           ),
+          const Divider(),
+
+          // ── 섹션 1: 관리 ──
           ListTile(
-            leading: const Icon(Icons.store_outlined),
-            title: const Text('파트너 프로필'),
+            leading: const Icon(Icons.verified_user_outlined),
+            title: const Text('인증 심사 관리'),
             trailing: const Icon(Icons.chevron_right),
-            onTap: () {},
-          ),
-          ListTile(
-            leading: const Icon(Icons.notifications_outlined),
-            title: const Text('알림 설정'),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () {},
+            onTap: () =>
+                ref.read(moreCoordinatorProvider).pushVerificationManage(),
           ),
           ListTile(
             leading: const Icon(Icons.people_outline),
             title: const Text('멤버 관리'),
             trailing: const Icon(Icons.chevron_right),
-            onTap: () {},
+            onTap: () {
+              final partner = partnerAsync.value;
+              if (partner == null) {
+                context.showMinglitInfo('파트너 정보를 불러오는 중입니다');
+                return;
+              }
+              ref.read(moreCoordinatorProvider).pushMemberList(partner.id);
+            },
+          ),
+          const Divider(),
+
+          // ── 섹션 2: 설정 ──
+          ListTile(
+            leading: const Icon(Icons.notifications_outlined),
+            title: const Text('알림 설정'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () =>
+                ref.read(moreCoordinatorProvider).pushNotificationSettings(),
           ),
           const ThemeSettingsTile(),
+          const Divider(),
+
+          // ── 섹션 3: 계정 (비활성) ──
+          ListTile(
+            leading: const Icon(Icons.person_outline),
+            title: const Text('계정 관리'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => context.showMinglitInfo('준비 중입니다'),
+          ),
+          ListTile(
+            leading: const Icon(Icons.store_outlined),
+            title: const Text('파트너 프로필'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => context.showMinglitInfo('준비 중입니다'),
+          ),
+          const Divider(),
+
+          // ── 섹션 4: 앱 정보 ──
+          ListTile(
+            leading: const Icon(Icons.privacy_tip_outlined),
+            title: const Text('개인정보처리방침'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              final url = ref.read(minglitUrlConfigProvider).privacyUrl;
+              unawaited(launchUrl(Uri.parse(url)));
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.description_outlined),
+            title: const Text('이용약관'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              final url = ref.read(minglitUrlConfigProvider).termsUrl;
+              unawaited(launchUrl(Uri.parse(url)));
+            },
+          ),
+          FutureBuilder<PackageInfo>(
+            future: PackageInfo.fromPlatform(),
+            builder: (context, snapshot) {
+              final version = snapshot.data?.version ?? '-';
+              return ListTile(
+                leading: const Icon(Icons.info_outline),
+                title: const Text('앱 버전'),
+                trailing: Text(
+                  version,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              );
+            },
+          ),
+          const Divider(),
+
+          // ── 섹션 5: 로그아웃 ──
+          ListTile(
+            leading: const Icon(Icons.logout, color: MinglitColors.error),
+            title: Text(
+              '로그아웃',
+              style: theme.textTheme.bodyMedium!.copyWith(
+                color: MinglitColors.error,
+              ),
+            ),
+            onTap: () async {
+              // GoRouter-first 패턴: '/' 이동 후 signOut — race condition 방지
+              GoRouter.of(context).go('/');
+              await Future<void>.delayed(Duration.zero);
+              await ref.read(authControllerProvider.notifier).signOut();
+            },
+          ),
         ],
       ),
     );

--- a/apps/app_partner/lib/src/routing/app_routes.dart
+++ b/apps/app_partner/lib/src/routing/app_routes.dart
@@ -140,9 +140,7 @@ class NotificationCenterRoute extends GoRouteData
     ),
     // 3. Revenue Management Branch
     TypedStatefulShellBranch<SettlementBranch>(
-      routes: [
-        TypedGoRoute<SettlementRoute>(path: '/settlement'),
-      ],
+      routes: [TypedGoRoute<SettlementRoute>(path: '/settlement')],
     ),
     // 4. Settings & Profile Branch
     TypedStatefulShellBranch<MoreBranch>(
@@ -151,11 +149,10 @@ class NotificationCenterRoute extends GoRouteData
           path: '/more',
           routes: [
             // Settings, Profile, etc.
-            TypedGoRoute<VerificationManageRoute>(
-              path: 'verifications/manage',
-            ),
-            TypedGoRoute<CreateVerificationRoute>(
-              path: 'verifications/create',
+            TypedGoRoute<VerificationManageRoute>(path: 'verifications/manage'),
+            TypedGoRoute<CreateVerificationRoute>(path: 'verifications/create'),
+            TypedGoRoute<NotificationSettingsRoute>(
+              path: 'notification-settings',
             ),
             TypedGoRoute<MemberListRoute>(
               path: 'partners/:partnerId/members',
@@ -367,4 +364,12 @@ class MemberPermissionRoute extends GoRouteData with $MemberPermissionRoute {
         partnerId: partnerId,
         targetUserId: targetUserId,
       );
+}
+
+class NotificationSettingsRoute extends GoRouteData
+    with $NotificationSettingsRoute {
+  const NotificationSettingsRoute();
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const NotificationSettingsScreen();
 }

--- a/apps/app_partner/lib/src/routing/app_routes.g.dart
+++ b/apps/app_partner/lib/src/routing/app_routes.g.dart
@@ -260,6 +260,10 @@ RouteBase get $partnerShellRoute => StatefulShellRouteData.$route(
               factory: $CreateVerificationRoute._fromState,
             ),
             GoRouteData.$route(
+              path: 'notification-settings',
+              factory: $NotificationSettingsRoute._fromState,
+            ),
+            GoRouteData.$route(
               path: 'partners/:partnerId/members',
               factory: $MemberListRoute._fromState,
               routes: [
@@ -671,6 +675,27 @@ mixin $CreateVerificationRoute on GoRouteData {
     '/more/verifications/create',
     queryParams: {if (_self.partnerId != null) 'partner-id': _self.partnerId},
   );
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $NotificationSettingsRoute on GoRouteData {
+  static NotificationSettingsRoute _fromState(GoRouterState state) =>
+      const NotificationSettingsRoute();
+
+  @override
+  String get location => GoRouteData.$location('/more/notification-settings');
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/apps/app_partner/test/src/features/more/more_page_test.dart
+++ b/apps/app_partner/test/src/features/more/more_page_test.dart
@@ -3,7 +3,6 @@ import 'package:app_partner/src/features/more/more_page.dart';
 import 'package:app_partner/src/features/party/party_providers.dart';
 import 'package:app_partner/src/routing/app_router.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
@@ -58,9 +57,9 @@ void main() {
           ),
         ),
         moreCoordinatorProvider.overrideWithValue(mockCoordinator),
-        authControllerProvider.overrideWith(() => MockAuthController()),
+        authControllerProvider.overrideWith(MockAuthController.new),
         minglitUrlConfigProvider.overrideWithValue(
-          MinglitUrlConfig(const MinglitDomains.production()),
+          const MinglitUrlConfig(MinglitDomains.production()),
         ),
         goRouterProvider.overrideWithValue(mockRouter),
       ],

--- a/apps/app_partner/test/src/features/more/more_page_test.dart
+++ b/apps/app_partner/test/src/features/more/more_page_test.dart
@@ -1,0 +1,138 @@
+import 'package:app_partner/src/features/more/more_coordinator.dart';
+import 'package:app_partner/src/features/more/more_page.dart';
+import 'package:app_partner/src/features/party/party_providers.dart';
+import 'package:app_partner/src/routing/app_router.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import '../../../utils/mocks.dart';
+
+// Additional mocks needed for MorePage
+class MockMoreCoordinator extends Mock implements MoreCoordinator {}
+
+class MockAuthController extends _MockAuthControllerBase {}
+
+abstract class _MockAuthControllerBase extends Mock implements AuthController {}
+
+void main() {
+  late MockGoRouter mockRouter;
+  late MockMoreCoordinator mockCoordinator;
+
+  const testPartner = Partner(
+    id: 'test-partner-id',
+    name: 'Test Partner',
+    contactEmail: 'test@partner.com',
+  );
+
+  setUp(() {
+    mockRouter = MockGoRouter();
+    mockCoordinator = MockMoreCoordinator();
+
+    // PackageInfo mock
+    PackageInfo.setMockInitialValues(
+      appName: 'Test App',
+      packageName: 'com.test.app',
+      version: '1.0.0',
+      buildNumber: '1',
+      buildSignature: '',
+    );
+
+    // GoRouter stub — go() is called on logout
+    when(() => mockRouter.go(any())).thenReturn(null);
+  });
+
+  Widget buildSubject({
+    AsyncValue<Partner?> partnerValue = const AsyncValue.data(testPartner),
+  }) {
+    return ProviderScope(
+      overrides: [
+        currentPartnerInfoProvider.overrideWith(
+          (ref) async => partnerValue.when(
+            data: (p) => p,
+            loading: () => throw StateError('loading'),
+            error: (e, _) => throw e,
+          ),
+        ),
+        moreCoordinatorProvider.overrideWithValue(mockCoordinator),
+        authControllerProvider.overrideWith(() => MockAuthController()),
+        minglitUrlConfigProvider.overrideWithValue(
+          MinglitUrlConfig(const MinglitDomains.production()),
+        ),
+        goRouterProvider.overrideWithValue(mockRouter),
+      ],
+      child: const MaterialApp(home: MorePage()),
+    );
+  }
+
+  group('MorePage', () {
+    testWidgets('shows partner name and email when partner data is loaded', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Test Partner'), findsOneWidget);
+      expect(find.text('test@partner.com'), findsOneWidget);
+    });
+
+    testWidgets('shows placeholder when partner is null', (tester) async {
+      await tester.pumpWidget(
+        buildSubject(partnerValue: const AsyncValue.data(null)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('파트너 정보를 불러올 수 없습니다'), findsOneWidget);
+    });
+
+    testWidgets('renders at least 4 Dividers for section separation', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Divider).evaluate().length, greaterThanOrEqualTo(4));
+    });
+
+    testWidgets('shows all required menu items', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.text('인증 심사 관리'), findsOneWidget);
+      expect(find.text('멤버 관리'), findsOneWidget);
+      expect(find.text('알림 설정'), findsOneWidget);
+      expect(find.text('계정 관리'), findsOneWidget);
+      expect(find.text('파트너 프로필'), findsOneWidget);
+      expect(find.text('개인정보처리방침'), findsOneWidget);
+      // Scroll down to reveal items below the fold
+      await tester.scrollUntilVisible(find.text('이용약관'), 100);
+      expect(find.text('이용약관'), findsOneWidget);
+      await tester.scrollUntilVisible(find.text('로그아웃'), 100);
+      expect(find.text('로그아웃'), findsOneWidget);
+    });
+
+    testWidgets('shows toast when tapping disabled menu item', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('계정 관리'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('준비 중입니다'), findsOneWidget);
+    });
+
+    testWidgets('logout text is displayed in error color', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      // Scroll to make logout visible
+      await tester.scrollUntilVisible(find.text('로그아웃'), 100);
+
+      final logoutTextWidget = tester.widget<Text>(find.text('로그아웃'));
+      expect(logoutTextWidget.style?.color, equals(MinglitColors.error));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- 파트너앱 더보기(MorePage)를 Claude 앱 스타일로 리디자인
- 프로필 헤더 + Divider 섹션 구분 + 실제 라우트 연결
- 알림설정 라우트(`/more/notification-settings`) 추가

## Changes

### New Files
- `apps/app_partner/lib/src/features/more/more_coordinator.dart` — 네비게이션 로직 분리 (plain Provider 패턴)
- `apps/app_partner/test/src/features/more/more_page_test.dart` — 위젯 테스트 6개

### Modified Files
- `apps/app_partner/lib/src/features/more/more_page.dart` — Claude 스타일 리디자인
  - `StatelessWidget` → `ConsumerWidget`
  - 파트너 프로필 헤더 (CircleAvatar + 이름 + 이메일, AsyncValue 3-state 처리)
  - 5개 섹션 Divider 구분: 관리 / 설정 / 계정(비활성) / 앱정보 / 로그아웃
  - 인증심사·멤버관리·알림설정 실제 라우트 연결
  - 계정관리·파트너프로필 → '준비 중입니다' 토스트
  - 개인정보처리방침·이용약관 → `launchUrl`
  - 앱 버전 → `PackageInfo.fromPlatform()`
  - 로그아웃 → GoRouter-first 패턴 (race condition 방지)
- `apps/app_partner/lib/src/routing/app_routes.dart` — `NotificationSettingsRoute` 추가
- `apps/app_partner/lib/src/routing/app_routes.g.dart` — codegen 재생성

## Test Results

- `flutter analyze --no-fatal-infos` → No issues (info-level only)
- `flutter test test/src/features/more/more_page_test.dart` → 6/6 PASS
- APK build + ADB install → Success