### PR TITLE
fix(e2e): CodeRabbit 리뷰 전체 코드 수정 — PR #112 justified 항목 proper fix

### DIFF
--- a/supabase/functions/e2e-test-runner/sim_event.ts
+++ b/supabase/functions/e2e-test-runner/sim_event.ts
@@ -248,7 +248,16 @@ export async function simMatch(
           candidate_id: userA,
         });
         if (voteBErr) {
-          log({ level: "error", phase: "match", step: "insert_vote", message: `Failed to insert vote ${userB}→${userA}: ${voteBErr.message}` });
+          // Rollback: A→B was already inserted — delete it to avoid half-applied state
+          await supabase.from("match_votes")
+            .delete()
+            .eq("event_id", eventId)
+            .eq("voter_id", userA)
+            .eq("candidate_id", userB);
+          log({
+            level: "error", phase: "match", step: "insert_vote",
+            message: `Vote B→A failed, rolled back A→B for pair (${userA}, ${userB}): ${voteBErr.message}`,
+          });
           continue;
         }
 

--- a/supabase/functions/e2e-test-runner/sim_refund.ts
+++ b/supabase/functions/e2e-test-runner/sim_refund.ts
@@ -128,12 +128,18 @@ export async function simRefundRequests(
         .eq("user_id", userId);
 
       if (deleteErr) {
+        // Rollback: participant delete failed — revert application status to avoid cancelled-but-has-participant state
+        await supabase
+          .from("event_applications")
+          .update({ status: "paid", refund_status: null, refund_amount: null })
+          .eq("id", appId);
         log({
-          level: "warn",
+          level: "error",
           phase: "refund",
           step: "delete_participant",
-          message: `Failed to delete participant for app ${appId}: ${deleteErr.message}`,
+          message: `Participant delete failed, reverted application ${appId}: ${deleteErr.message}`,
         });
+        continue;
       }
 
       const assertion = await simAssertRefundProcessed(

--- a/supabase/functions/e2e-test-runner/sim_reporter.ts
+++ b/supabase/functions/e2e-test-runner/sim_reporter.ts
@@ -80,8 +80,14 @@ export async function simUploadLog(
       return null;
     }
 
-    const { data } = supabase.storage.from(BUCKET_NAME).getPublicUrl(path);
-    return data.publicUrl;
+    const { data: signedData, error: signErr } = await supabase.storage
+      .from(BUCKET_NAME)
+      .createSignedUrl(path, 86400);
+    if (signErr) {
+      console.error("[sim_reporter] Signed URL error:", signErr.message);
+      return null;
+    }
+    return signedData?.signedUrl ?? null;
   } catch (err) {
     console.error("[sim_reporter] simUploadLog exception:", err);
     return null;
@@ -120,11 +126,13 @@ export async function simCreateGitHubIssue(
 
     const encoder = new TextEncoder();
     let truncatedLog = logText;
-    while (encoder.encode(truncatedLog).length > MAX_ISSUE_BODY_BYTES) {
-      truncatedLog = truncatedLog.slice(0, -100);
-    }
-    if (truncatedLog.length < logText.length) {
-      truncatedLog += "\n...[truncated]";
+    const logBytes = encoder.encode(logText);
+    if (logBytes.length > MAX_ISSUE_BODY_BYTES) {
+      let safeEnd = MAX_ISSUE_BODY_BYTES;
+      while (safeEnd > 0 && (logBytes[safeEnd] & 0xc0) === 0x80) {
+        safeEnd--;
+      }
+      truncatedLog = new TextDecoder().decode(logBytes.slice(0, safeEnd)) + "\n...[truncated]";
     }
 
     const body = `## E2E Simulation Failure Report

--- a/supabase/functions/e2e-test-runner/sim_reporter_test.ts
+++ b/supabase/functions/e2e-test-runner/sim_reporter_test.ts
@@ -54,8 +54,9 @@ Deno.test("simUploadLog() — returns null gracefully when supabase errors", asy
           error: { message: "Storage unavailable" },
           data: null,
         }),
-        getPublicUrl: (_path: string) => ({
-          data: { publicUrl: "https://example.com/log.log" },
+        createSignedUrl: (_path: string, _expiry: number) => Promise.resolve({
+          data: { signedUrl: "https://example.com/signed/log.log" },
+          error: null,
         }),
       }),
     },

--- a/supabase/functions/e2e-test-runner/sim_settle.ts
+++ b/supabase/functions/e2e-test-runner/sim_settle.ts
@@ -76,8 +76,17 @@ export async function simVerifySettlement(
       const settlementId = (settlement as { id: string; status: string; gross_amount: number }).id;
       const grossAmount = (settlement as { id: string; status: string; gross_amount: number }).gross_amount;
 
-      // 3. Assert fee calculations
-      const amountsAssertion = await simAssertSettlementAmounts(supabase, settlementId, grossAmount);
+      // 3. Assert fee calculations — compute expected gross independently from event_applications
+      //    to avoid self-referential check (passing settlement.gross_amount as its own expected value)
+      const { data: paidAppsData } = await supabase
+        .from("event_applications")
+        .select("payment_amount")
+        .eq("event_id", eventId)
+        .eq("status", "paid");
+      // deno-lint-ignore no-explicit-any
+      const expectedGross = (paidAppsData ?? []).reduce((sum: number, app: any) => sum + (app.payment_amount ?? 0), 0);
+
+      const amountsAssertion = await simAssertSettlementAmounts(supabase, settlementId, expectedGross);
       assertions.push(amountsAssertion);
 
       // 4. Assert checksum
@@ -158,8 +167,10 @@ export async function simTransitionToReady(
         continue;
       }
 
-      // 2. Call update_settlement_ready_status() to transition PENDING → READY
-      const { error: rpcErr } = await supabase.rpc("update_settlement_ready_status");
+      // 2. Call targeted RPC to transition this specific settlement PENDING → READY
+      const { error: rpcErr } = await supabase.rpc("update_single_settlement_ready_status", {
+        p_settlement_id: settlementId,
+      });
 
       if (rpcErr) {
         log({

--- a/supabase/functions/e2e-test-runner/sim_settle_test.ts
+++ b/supabase/functions/e2e-test-runner/sim_settle_test.ts
@@ -49,6 +49,12 @@ Deno.test("simVerifySettlement - passes when settlement exists with PENDING stat
           return { data: null, error: null };
         },
       },
+      event_applications: {
+        select: () => ({
+          data: Array.from({ length: 5 }, () => ({ payment_amount: GROSS / 5 })),
+          error: null,
+        }),
+      },
     },
   });
 
@@ -125,7 +131,7 @@ Deno.test("simTransitionToReady - settlement updated to READY after event_comple
       },
     },
     rpcs: {
-      update_settlement_ready_status: () => {
+      update_single_settlement_ready_status: () => {
         rpcCalled = true;
         return { data: null, error: null };
       },

--- a/supabase/migrations/20260316000002_update_single_settlement_ready_status.sql
+++ b/supabase/migrations/20260316000002_update_single_settlement_ready_status.sql
@@ -1,0 +1,36 @@
+-- Add single-settlement variant of update_settlement_ready_status
+-- Allows targeted PENDING → READY transition for a specific settlement_id
+-- Fixes: test isolation issue where bulk RPC would affect all eligible settlements
+
+CREATE OR REPLACE FUNCTION public.update_single_settlement_ready_status(
+  p_settlement_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  rec RECORD;
+BEGIN
+  FOR rec IN
+    SELECT *
+    FROM settlement_items
+    WHERE id = p_settlement_id
+      AND status = 'PENDING'
+      AND event_completed_at <= now() - interval '14 days'
+    FOR UPDATE
+  LOOP
+    BEGIN
+      PERFORM transition_settlement_status(
+        p_settlement_id := rec.id,
+        p_expected_status := 'PENDING',
+        p_new_status := 'READY',
+        p_version := rec.version
+      );
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'update_single_settlement_ready_status: CAS failed for %, %', rec.id, SQLERRM;
+    END;
+  END LOOP;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.update_single_settlement_ready_status(uuid) TO service_role;

--- a/supabase/migrations/20260316000003_e2e_storage_bucket_private.sql
+++ b/supabase/migrations/20260316000003_e2e_storage_bucket_private.sql
@@ -1,6 +1,13 @@
 -- Make e2e-test-logs bucket private with access restrictions
 -- Fixes: bucket was public=true exposing internal simulation logs externally
 
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM storage.buckets WHERE id = 'e2e-test-logs') THEN
+    RAISE EXCEPTION 'Bucket e2e-test-logs not found — ensure 20260315000012 ran first';
+  END IF;
+END $$;
+
 UPDATE storage.buckets
 SET
   public = false,

--- a/supabase/migrations/20260316000003_e2e_storage_bucket_private.sql
+++ b/supabase/migrations/20260316000003_e2e_storage_bucket_private.sql
@@ -1,0 +1,17 @@
+-- Make e2e-test-logs bucket private with access restrictions
+-- Fixes: bucket was public=true exposing internal simulation logs externally
+
+UPDATE storage.buckets
+SET
+  public = false,
+  allowed_mime_types = ARRAY['text/plain', 'application/json'],
+  file_size_limit = 10485760
+WHERE id = 'e2e-test-logs';
+
+DROP POLICY IF EXISTS "Public read for e2e test logs" ON storage.objects;
+
+CREATE POLICY "Service role write for e2e test logs"
+  ON storage.objects
+  FOR INSERT
+  TO service_role
+  WITH CHECK (bucket_id = 'e2e-test-logs');

--- a/supabase/migrations/20260316000004_e2e_cron_job_vault_url.sql
+++ b/supabase/migrations/20260316000004_e2e_cron_job_vault_url.sql
@@ -1,0 +1,38 @@
+-- Recreate e2e-simulation cron job using vault-stored supabase_url
+-- Fixes: hardcoded project URL breaks if migration runs on a different Supabase project
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM vault.decrypted_secrets WHERE name = 'supabase_url'
+  ) THEN
+    PERFORM vault.create_secret(
+      'https://cnuahgrfzcqkmdyhunuk.supabase.co',
+      'supabase_url',
+      'Supabase project base URL for Edge Function calls'
+    );
+  END IF;
+END $$;
+
+SELECT cron.schedule(
+  'e2e-simulation',
+  '0 * * * *',
+  $$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret FROM vault.decrypted_secrets
+        WHERE name = 'supabase_url' LIMIT 1
+      ) || '/functions/v1/e2e-test-runner',
+      headers := (
+        jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (
+            SELECT decrypted_secret FROM vault.decrypted_secrets
+            WHERE name = 'service_role_key' LIMIT 1
+          )
+        )
+      ),
+      body := '{}'::jsonb
+    ) AS request_id;
+  $$
+);


### PR DESCRIPTION
## Summary

PR #112 CodeRabbit 리뷰에서 'Intentional design'으로 정당화만 했던 6개 항목을 실제 코드로 수정합니다.

## Changes

### 🔴 Critical Fix
- **migration 20260316000004**: 하드코딩된 Edge Function URL → vault `supabase_url` 시크릿 기반으로 변경

### 🟠 Major Fixes
- **sim_event.ts**: 상호 투표에서 B→A 실패 시 A→B rollback 추가 — 부분 상태(orphaned vote) 방지
- **sim_refund.ts**: participant delete 실패 시 application 상태 rollback 추가 — `cancelled-but-has-participant` 불일치 방지
- **sim_settle.ts**: `settlement.gross_amount` 자기참조 검증 → `event_applications`에서 독립 계산
- **sim_settle.ts**: `update_settlement_ready_status()` (전체) → `update_single_settlement_ready_status(id)` (타겟) — 테스트 격리 보장
- **migration 20260316000002**: `update_single_settlement_ready_status(p_settlement_id)` 함수 추가

### 🟡 Minor Fixes
- **migration 20260316000003**: `e2e-test-logs` 버킷 `public=false`로 변경 — 내부 로그 외부 노출 방지
- **sim_reporter.ts**: `getPublicUrl()` → `createSignedUrl(24h)` — private 버킷 접근
- **sim_reporter.ts**: O(n²) 절단 루프 → O(n) UTF-8 바이트 경계 계산으로 개선

## Test
- 79/79 tests pass
- deno lint clean