### PR TITLE
refactor(ci): optimize CI/CD workflows — consolidate jobs, add caching, standardize npx

### DIFF
--- a/.github/actions/deploy-nextjs-app/action.yml
+++ b/.github/actions/deploy-nextjs-app/action.yml
@@ -22,9 +22,8 @@ runs:
         VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
         VERCEL_TOKEN: ${{ inputs.vercel-token }}
       run: |
-        npm install --global vercel@latest
         if [[ "${{ github.ref_name }}" == "main" ]]; then
-          vercel deploy --prod --token=$VERCEL_TOKEN --yes
+          npx --yes vercel@latest deploy --prod --token=$VERCEL_TOKEN --yes
         else
-          vercel deploy --token=$VERCEL_TOKEN --yes
+          npx --yes vercel@latest deploy --token=$VERCEL_TOKEN --yes
         fi

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -26,6 +26,14 @@ jobs:
           channel: 'stable'
           cache: true
 
+      - name: Cache pub packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
       - name: Install dependencies
         run: flutter pub get
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,93 +62,72 @@ jobs:
             - 'supabase/**'
             - 'tests/backend_integration/**'
 
-  # App User CI
-  test-app-user:
+  # App CI (User + Partner)
+  test-flutter-apps:
     needs: changes
-    if: ${{ needs.changes.outputs.app_user == 'true' }}
+    if: ${{ needs.changes.outputs.app_user == 'true' || needs.changes.outputs.app_partner == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       checks: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - app: app_user
+            change_key: app_user
+            directory: apps/app_user
+            report_name: 'User App Tests'
+            artifact_name: app-user-coverage
+            coverage_flag: app-user
+          - app: app_partner
+            change_key: app_partner
+            directory: apps/app_partner
+            report_name: 'Partner App Tests'
+            artifact_name: app-partner-coverage
+            coverage_flag: app-partner
     steps:
       - uses: actions/checkout@v4
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
       - uses: subosito/flutter-action@v2
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         with:
           channel: 'stable'
           cache: true
       - name: Install dependencies
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         run: flutter pub get
       - name: Analyze (minglit_kit)
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         run: flutter analyze --no-fatal-infos
         working-directory: shared/packages/minglit_kit
       - name: Analyze
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         run: flutter analyze --no-fatal-infos
-        working-directory: apps/app_user
+        working-directory: ${{ matrix.directory }}
       - name: Test
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         run: flutter test --coverage --file-reporter=json:test-results.json
-        working-directory: apps/app_user
+        working-directory: ${{ matrix.directory }}
       - name: Test Report
         uses: dorny/test-reporter@v1
-        if: success() || failure()
+        if: ${{ (success() || failure()) && needs.changes.outputs[matrix.change_key] == 'true' }}
         with:
-          name: 'User App Tests'
-          path: apps/app_user/test-results.json
+          name: ${{ matrix.report_name }}
+          path: ${{ matrix.directory }}/test-results.json
           reporter: dart-json
           fail-on-error: false
       - uses: actions/upload-artifact@v4
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         with:
-          name: app-user-coverage
-          path: apps/app_user/coverage
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.directory }}/coverage
       - name: Upload coverage
         uses: codecov/codecov-action@v4
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         with:
-          file: apps/app_user/coverage/lcov.info
-          flags: app-user
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-
-  # App Partner CI
-  test-app-partner:
-    needs: changes
-    if: ${{ needs.changes.outputs.app_partner == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      checks: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: 'stable'
-          cache: true
-      - name: Install dependencies
-        run: flutter pub get
-      - name: Analyze (minglit_kit)
-        run: flutter analyze --no-fatal-infos
-        working-directory: shared/packages/minglit_kit
-      - name: Analyze
-        run: flutter analyze --no-fatal-infos
-        working-directory: apps/app_partner
-      - name: Test
-        run: flutter test --coverage --file-reporter=json:test-results.json
-        working-directory: apps/app_partner
-      - name: Test Report
-        uses: dorny/test-reporter@v1
-        if: success() || failure()
-        with:
-          name: 'Partner App Tests'
-          path: apps/app_partner/test-results.json
-          reporter: dart-json
-          fail-on-error: false
-      - uses: actions/upload-artifact@v4
-        with:
-          name: app-partner-coverage
-          path: apps/app_partner/coverage
-      - name: Upload coverage
-        uses: codecov/codecov-action@v4
-        with:
-          file: apps/app_partner/coverage/lcov.info
-          flags: app-partner
+          file: ${{ matrix.directory }}/coverage/lcov.info
+          flags: ${{ matrix.coverage_flag }}
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
@@ -262,7 +241,7 @@ jobs:
         working-directory: supabase
 
   ci-result:
-    needs: [check-migration-versions, test-app-user, test-app-partner, lint-landing-user, lint-landing-partner, test-supabase, test-edge-functions]
+    needs: [check-migration-versions, test-flutter-apps, lint-landing-user, lint-landing-partner, test-supabase, test-edge-functions]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -307,7 +286,7 @@ jobs:
           echo "✅ All checks passed"
 
   notify-failure:
-    needs: [check-migration-versions, test-app-user, test-app-partner, lint-landing-user, lint-landing-partner, test-supabase, test-edge-functions]
+    needs: [check-migration-versions, test-flutter-apps, lint-landing-user, lint-landing-partner, test-supabase, test-edge-functions]
     if: always()
     permissions:
       issues: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,14 @@ jobs:
         with:
           channel: 'stable'
           cache: true
+      - name: Cache pub packages
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
       - name: Install dependencies
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         run: flutter pub get
@@ -188,6 +196,13 @@ jobs:
         run: supabase start
       - name: Test (pgTAP)
         run: supabase test db
+      - name: Cache pub packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
       - name: Install dependencies (integration)
         if: ${{ vars.ENABLE_BACKEND_INTEGRATION == 'true' }}
         run: flutter pub get

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,8 +190,8 @@ jobs:
       - run: npm run lint
       - run: npm run build
 
-  # pgTAP DB 테스트
-  test-pgtap:
+  # Supabase 통합 테스트 (pgTAP + backend-integration + e2e-scenarios)
+  test-supabase:
     needs: changes
     if: ${{ needs.changes.outputs.supabase == 'true' }}
     runs-on: ubuntu-latest
@@ -200,49 +200,49 @@ jobs:
       - uses: supabase/setup-cli@v1
         with:
           version: latest
-      - name: Start Supabase
-        run: supabase start
-      - name: Test (pgTAP)
-        run: supabase test db
-      - name: Stop Supabase
-        if: always()
-        run: supabase stop
-
-  # Dart Backend Integration 테스트
-  test-backend-integration:
-    needs: changes
-    if: ${{ vars.ENABLE_BACKEND_INTEGRATION == 'true' }}  # Requires seeded DB with specific test users — disabled by default
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: supabase/setup-cli@v1
-        with:
-          version: latest
-      - name: Start Supabase
-        run: supabase start
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
           cache: true
+      - name: Start Supabase
+        run: supabase start
+      - name: Test (pgTAP)
+        run: supabase test db
       - name: Install dependencies (integration)
+        if: ${{ vars.ENABLE_BACKEND_INTEGRATION == 'true' }}
         run: flutter pub get
         working-directory: tests/backend_integration
       - name: Test (integration)
+        if: ${{ vars.ENABLE_BACKEND_INTEGRATION == 'true' }}
         run: flutter test src/ --coverage
         working-directory: tests/backend_integration
         env:
           SUPABASE_URL: http://127.0.0.1:54321
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_LOCAL_SERVICE_ROLE_KEY }}
       - name: Format coverage
+        if: ${{ vars.ENABLE_BACKEND_INTEGRATION == 'true' }}
         run: dart run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib
         working-directory: tests/backend_integration
       - uses: codecov/codecov-action@v4
+        if: ${{ vars.ENABLE_BACKEND_INTEGRATION == 'true' }}
         with:
           file: tests/backend_integration/coverage/lcov.info
           flags: backend-integration
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+      - name: Install dependencies (e2e scenarios)
+        if: ${{ vars.ENABLE_E2E_SCENARIOS == 'true' }}
+        run: flutter pub get
+        working-directory: apps/integration_scenario_tester
+      - name: Test (e2e scenarios)
+        if: ${{ vars.ENABLE_E2E_SCENARIOS == 'true' }}
+        run: flutter test integration_test/
+        working-directory: apps/integration_scenario_tester
+        env:
+          SUPABASE_URL: http://127.0.0.1:54321
+          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_LOCAL_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_LOCAL_SERVICE_ROLE_KEY }}
       - name: Stop Supabase
         if: always()
         run: supabase stop
@@ -254,54 +254,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: supabase/setup-cli@v1
-        with:
-          version: latest
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
-      - name: Start Supabase
-        run: supabase start
       - name: Test (edge functions)
         run: deno test --allow-all functions/
         working-directory: supabase
-      - name: Stop Supabase
-        if: always()
-        run: supabase stop
-
-  # E2E 시나리오 테스트
-  test-e2e-scenarios:
-    needs: changes
-    if: ${{ vars.ENABLE_E2E_SCENARIOS == 'true' }}  # Requires device/emulator — disabled by default
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: supabase/setup-cli@v1
-        with:
-          version: latest
-      - name: Start Supabase
-        run: supabase start
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: 'stable'
-          cache: true
-      - name: Install dependencies (e2e scenarios)
-        run: flutter pub get
-        working-directory: apps/integration_scenario_tester
-      - name: Test (e2e scenarios)
-        run: flutter test integration_test/
-        working-directory: apps/integration_scenario_tester
-        env:
-          SUPABASE_URL: http://127.0.0.1:54321
-          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_LOCAL_ANON_KEY }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_LOCAL_SERVICE_ROLE_KEY }}
-      - name: Stop Supabase
-        if: always()
-        run: supabase stop
 
   ci-result:
-    needs: [check-migration-versions, test-app-user, test-app-partner, lint-landing-user, lint-landing-partner, test-pgtap, test-backend-integration, test-edge-functions, test-e2e-scenarios]
+    needs: [check-migration-versions, test-app-user, test-app-partner, lint-landing-user, lint-landing-partner, test-supabase, test-edge-functions]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -346,7 +307,7 @@ jobs:
           echo "✅ All checks passed"
 
   notify-failure:
-    needs: [check-migration-versions, test-app-user, test-app-partner, lint-landing-user, lint-landing-partner, test-pgtap, test-backend-integration, test-edge-functions, test-e2e-scenarios]
+    needs: [check-migration-versions, test-app-user, test-app-partner, lint-landing-user, lint-landing-partner, test-supabase, test-edge-functions]
     if: always()
     permissions:
       issues: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,11 @@ adb -s adb-R3CX803P2ND-8btuuD._adb-tls-connect._tcp install -r build/app/outputs
 ## Branch Protection
 
 - `dev` 브랜치는 direct push 금지. 반드시 feature branch에서 PR을 통해 머지.
-- PR 머지 전 `check-migration-versions` CI 체크 통과 필수 (migration version 중복 검사).
+- Required check: **`ci-result`** — 이 하나의 summary job이 모든 CI + CodeRabbit 리뷰를 게이트한다.
 - Approvals 불필요 (0개). self-merge 가능.
-- Admin은 긴급 시 bypass 가능하지만, 일반 작업은 항상 PR 사용.
+- `required_conversation_resolution` 활성화 — 미해결 코멘트가 있으면 머지 불가.
+- `required_linear_history` 활성화 — squash merge만 허용.
+- `--admin` bypass는 **유저가 명시적으로 요청할 때만** 사용한다. CI나 리뷰 우회 목적 금지.
 
 ## PR Conventions
 
@@ -59,60 +61,69 @@ adb -s adb-R3CX803P2ND-8btuuD._adb-tls-connect._tcp install -r build/app/outputs
   gh pr create --base dev --title "..." --body "..."
   gh pr merge <PR번호> --auto --squash
   ```
-- required check (`check-migration-versions`) 통과 시 자동으로 squash merge 된다.
+- `ci-result` 통과 시 자동으로 squash merge 된다.
 - 머지 후 소스 브랜치는 자동 삭제된다 (`delete_branch_on_merge` 활성화).
-- Admin bypass (`--admin`)는 긴급 상황에서만 사용한다.
+
+### CI 파이프라인
+
+`ci-result`는 아래 모든 항목이 통과해야 success가 된다:
+
+| Job | 조건 | 내용 |
+|-----|------|------|
+| `check-migration-versions` | 항상 | migration version 중복 검사 |
+| `test-app-user` | `apps/app_user/**` 또는 `shared/packages/minglit_kit/**` 변경 시 | Flutter analyze + test |
+| `test-app-partner` | `apps/app_partner/**` 또는 `shared/packages/minglit_kit/**` 변경 시 | Flutter analyze + test |
+| `lint-landing-user` | `apps/landing_user/**` 또는 `shared/web/**` 변경 시 | npm lint + build |
+| `lint-landing-partner` | `apps/landing_partner/**` 또는 `shared/web/**` 변경 시 | npm lint + build |
+| `test-pgtap` | `supabase/**` 또는 `tests/backend_integration/**` 변경 시 | pgTAP DB 테스트 |
+| `test-backend-integration` | 동일 | Dart backend integration 테스트 |
+| `test-edge-functions` | 동일 | Deno edge function 테스트 |
+| `test-e2e-scenarios` | 동일 | E2E 시나리오 테스트 |
+| CodeRabbit 리뷰 | PR only | `ci-result` job 내에서 최대 30분 대기 |
+
+별도 워크플로우 (required check 아님, 참고용):
+- **Auto Format PR**: PR 시 `dart fix --apply` + `dart format` 자동 적용. 포맷 변경이 있으면 자동 커밋.
+- **Secret Scanning**: PR 시 Gitleaks로 시크릿 유출 검사.
 
 ### PR 모니터링 (Background Agent)
 
-PR 생성 직후 **반드시** background monitoring agent를 발사한다. PR이 MERGED 될 때까지 모니터링한다.
+PR 생성 직후 **반드시** background monitoring agent를 발사한다. PR이 MERGED 될 때까지 모니터링한다. 생성만 하고 방치 금지.
 
 ```bash
-# PR 생성 직후 실행할 모니터링 명령 시퀀스
-# Background agent가 60초 간격으로 아래를 반복한다:
+# Background agent가 60초 간격으로 아래를 반복:
 
-# 1. CodeRabbit 리뷰 상태 확인
-gh api repos/{owner}/{repo}/commits/{HEAD_SHA}/statuses --jq '.[] | select(.context=="CodeRabbit") | .state'
+# 1. CI 상태 확인 (ci-result가 CodeRabbit 대기까지 포함)
+gh pr checks <PR번호> --watch --fail-fast
 
-# 2. 리뷰 코멘트 확인 (CodeRabbit이 success 된 후)
+# 2. 리뷰 코멘트 확인
 gh api repos/{owner}/{repo}/pulls/{PR번호}/comments --jq '.[] | {path: .path, body: .body, line: .line}'
 
 # 3. PR 상태 확인
-gh api repos/{owner}/{repo}/pulls/{PR번호} --jq '{state: .state, merged: .merged}'
+gh pr view <PR번호> --json state,mergedAt --jq '{state: .state, merged: .mergedAt}'
 ```
 
 #### 모니터링 결과별 대응
 
 | 상태 | 대응 |
 |------|------|
-| CodeRabbit `pending` | 계속 대기 (60초 후 재확인) |
-| CodeRabbit `success` + 코멘트 없음 | "리뷰 통과" 보고. auto-merge 대기 |
-| CodeRabbit `success` + **코멘트 있음** | 코멘트 내용을 orchestrator에게 보고. orchestrator가 대응 |
-| CI 실패 | 실패 로그(`gh run view --log-failed`)를 orchestrator에게 보고 |
+| `ci-result` 통과 + 코멘트 없음 | "CI 통과" 보고. auto-merge 대기 |
+| `ci-result` 통과 + **코멘트 있음** | 코멘트 내용을 orchestrator에게 보고 |
+| CI 실패 | `gh run view <run_id> --log-failed`로 원인 파악 → orchestrator에게 보고 |
 | PR `MERGED` | "PR 머지 완료" 보고. 모니터링 종료 |
 
 #### 코멘트 대응 규칙
 
-- PR에 달린 코드 리뷰 코멘트는 **전부 resolve** 한다. 미해결 코멘트가 남아있는 상태로 머지하지 않는다.
-- 코멘트에 대한 대응:
-  1. 코드 수정이 필요한 경우: 수정 후 같은 브랜치에 push → 리뷰 코멘트에 수정 내용 답글 → resolve
+- 리뷰 코멘트는 **전부 resolve** 한다 (GitHub 설정에서도 강제됨).
+- 대응 방법:
+  1. 코드 수정 필요: 수정 후 같은 브랜치에 push → 답글 → resolve
   2. 수정 불필요 (의도된 설계): 근거를 답글로 남기고 → resolve
-  3. 논의가 필요한 경우: 답글로 의견 남기고 사용자에게 판단 요청
-- 모든 코멘트가 resolved 된 후 머지를 진행한다.
-
-#### 금지 사항
-
-- `--admin` merge는 **유저가 명시적으로 요청할 때만** 사용한다. CodeRabbit 리뷰를 우회하기 위해 사용 금지.
-- CodeRabbit 리뷰 코멘트를 읽지 않고 머지 금지.
-- PR 생성만 하고 모니터링 agent 없이 방치 금지.
+  3. 논의 필요: 답글로 의견 남기고 사용자에게 판단 요청
 
 ### CI 실패 대응
 
-- CI 실패 시:
-  1. `gh run view <run_id> --log-failed`로 실패 원인 파악
-  2. 로컬에서 수정 후 같은 브랜치에 push (PR은 유지됨)
-  3. CI 재실행 → 통과 확인 → auto-merge 완료까지 반복
-- PR이 `MERGED` 상태가 될 때까지 케어한다. 생성만 하고 방치하지 않는다.
+1. `gh run view <run_id> --log-failed`로 실패 원인 파악
+2. 로컬에서 수정 후 같은 브랜치에 push (PR은 유지됨)
+3. CI 재실행 → 통과 확인 → auto-merge 완료까지 반복
 
 ## Bug Fix Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,14 +71,11 @@ adb -s adb-R3CX803P2ND-8btuuD._adb-tls-connect._tcp install -r build/app/outputs
 | Job | 조건 | 내용 |
 |-----|------|------|
 | `check-migration-versions` | 항상 | migration version 중복 검사 |
-| `test-app-user` | `apps/app_user/**` 또는 `shared/packages/minglit_kit/**` 변경 시 | Flutter analyze + test |
-| `test-app-partner` | `apps/app_partner/**` 또는 `shared/packages/minglit_kit/**` 변경 시 | Flutter analyze + test |
+| `test-flutter-apps` | `apps/app_user/**`, `apps/app_partner/**` 또는 `shared/packages/minglit_kit/**` 변경 시 | Flutter analyze + test (matrix: app_user, app_partner) |
 | `lint-landing-user` | `apps/landing_user/**` 또는 `shared/web/**` 변경 시 | npm lint + build |
 | `lint-landing-partner` | `apps/landing_partner/**` 또는 `shared/web/**` 변경 시 | npm lint + build |
-| `test-pgtap` | `supabase/**` 또는 `tests/backend_integration/**` 변경 시 | pgTAP DB 테스트 |
-| `test-backend-integration` | 동일 | Dart backend integration 테스트 |
+| `test-supabase` | `supabase/**` 또는 `tests/backend_integration/**` 변경 시 | pgTAP + backend integration + e2e 통합 테스트 |
 | `test-edge-functions` | 동일 | Deno edge function 테스트 |
-| `test-e2e-scenarios` | 동일 | E2E 시나리오 테스트 |
 | CodeRabbit 리뷰 | PR only | `ci-result` job 내에서 최대 30분 대기 |
 
 별도 워크플로우 (required check 아님, 참고용):

--- a/apps/integration_scenario_tester/integration_test/scenarios/s01_auth/s01_01_signup_flow_test.dart
+++ b/apps/integration_scenario_tester/integration_test/scenarios/s01_auth/s01_01_signup_flow_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
-import 'package:minglit_kit/src/features/iamport/data/repository/iamport_repository.dart';
 import '../../utils/test_helper.dart';
 
 /// **Scenario S01-01: Full Signup Flow**

--- a/shared/packages/minglit_kit/lib/src/data/models/verification.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/verification.dart
@@ -90,7 +90,8 @@ abstract class Verification with _$Verification {
 
     /// Partner ID who owns this verification. Null means Global/System verification.
     @JsonKey(name: 'partner_id') String? partnerId,
-    // Fix #42: Handle nullable DB fields — description and icon_key can be null in verifications table
+    // Fix #42: Handle nullable DB fields — description and icon_key can be
+    // null in verifications table
     String? description,
 
     /// Icon identifier (e.g., 'briefcase').


### PR DESCRIPTION
## Summary

- **Supabase 테스트 3 job → 1 job 통합**: `test-pgtap`, `test-backend-integration`, `test-e2e-scenarios`를 `test-supabase` 하나로 합침. `supabase start`가 PR당 1회만 실행됨 (~6-9분 절감)
- **Edge function `supabase start` 제거**: `test-edge-functions`는 mocked fetch 기반이라 Docker 불필요. ci.yml 주석에도 명시되어 있었음.
- **Flutter app CI matrix 통합**: `test-app-user` + `test-app-partner` → `test-flutter-apps` (matrix strategy). 변경된 앱만 테스트 실행.
- **pub 패키지 캐시 추가**: `test-flutter-apps`, `test-supabase`, `auto-format` job에 `actions/cache@v4` for `~/.pub-cache` 추가.
- **`deploy-nextjs-app` npx 표준화**: `npm install --global vercel@latest` → `npx --yes vercel@latest` (flutter deploy action과 일관성 맞춤).

## Changed Files

- `.github/workflows/ci.yml`
- `.github/workflows/auto-format.yml`
- `.github/actions/deploy-nextjs-app/action.yml`