### PR TITLE
ci: switch dev mobile builds from push-per-merge to daily cron

### DIFF
--- a/.github/workflows/android-deploy-partner.yml
+++ b/.github/workflows/android-deploy-partner.yml
@@ -2,11 +2,13 @@ name: Android Build & Deploy (Partner)
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: ["main"]
     paths:
       - "apps/app_partner/**"
       - "shared/packages/minglit_kit/**"
       - "pubspec.yaml"
+  schedule:
+    - cron: '0 10 * * *'  # Daily dev build (KST 19:00) — runs on default branch (dev)
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/android-deploy.yml
+++ b/.github/workflows/android-deploy.yml
@@ -2,11 +2,13 @@ name: Android Build & Deploy (User)
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: ["main"]
     paths:
       - "apps/app_user/**"
       - "shared/packages/minglit_kit/**"
       - "pubspec.yaml"
+  schedule:
+    - cron: '0 10 * * *'  # Daily dev build (KST 19:00) — runs on default branch (dev)
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ios-deploy-partner.yml
+++ b/.github/workflows/ios-deploy-partner.yml
@@ -2,11 +2,13 @@ name: iOS Partner App Deploy
 
 on:
   push:
-    branches: ["dev", "main"]
+    branches: ["main"]
     paths:
       - "apps/app_partner/**"
       - "shared/packages/minglit_kit/**"
       - "pubspec.yaml"
+  schedule:
+    - cron: '0 10 * * *'  # Daily dev build (KST 19:00) — runs on default branch (dev)
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ios-deploy-user.yml
+++ b/.github/workflows/ios-deploy-user.yml
@@ -2,11 +2,13 @@ name: iOS User App Deploy
 
 on:
   push:
-    branches: ["dev", "main"]
+    branches: ["main"]
     paths:
       - "apps/app_user/**"
       - "shared/packages/minglit_kit/**"
       - "pubspec.yaml"
+  schedule:
+    - cron: '0 10 * * *'  # Daily dev build (KST 19:00) — runs on default branch (dev)
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

- `push` to `main` → 즉시 빌드 (변경 없음)
- `push` to `dev` → 빌드 트리거 **제거** (매 머지마다 빌드하던 것 중단)
- `schedule: cron: '0 10 * * *'` → 매일 KST 19시 dev 빌드 (일괄 배치)
- `workflow_dispatch:` → 수동 트리거 유지

## Changed Files
- `.github/workflows/android-deploy.yml`
- `.github/workflows/android-deploy-partner.yml`
- `.github/workflows/ios-deploy-user.yml`
- `.github/workflows/ios-deploy-partner.yml`

## Why

현재: dev 머지마다 4개 앱 동시 빌드 → 월 ~2,900분 (active day에 최대 8회 트리거)
변경: 하루 1회 cron → 월 ~840분 예상 (**~70% 절감**)

## Notes

- `schedule:` 트리거는 default branch(dev)에서 실행 → `github.ref = refs/heads/dev` → dev 빌드 경로 정상 동작
- `paths:` 필터는 schedule에 적용 안 되나 1일 1회 × 28분이라 수용
- dispatcher pattern 불필요 (default branch = dev)