### PR TITLE
fix(vercel): disable auto-deploy and switch to cron (every 2h) + manual dispatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,9 +23,11 @@ concurrency:
 jobs:
   deploy-app_user:
     runs-on: ubuntu-latest
-    environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
+    environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' && 'production' || 'preview' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name }}
       - name: Deploy User App
         uses: ./.github/actions/deploy-flutter-app
         with:
@@ -45,9 +47,11 @@ jobs:
 
   deploy-landing_user:
     runs-on: ubuntu-latest
-    environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
+    environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' && 'production' || 'preview' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name }}
       - name: Deploy User Landing
         uses: ./.github/actions/deploy-nextjs-app
         with:
@@ -58,9 +62,11 @@ jobs:
 
   deploy-landing_partner:
     runs-on: ubuntu-latest
-    environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
+    environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' && 'production' || 'preview' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name }}
       - name: Deploy Partner Landing
         uses: ./.github/actions/deploy-nextjs-app
         with:
@@ -71,9 +77,11 @@ jobs:
 
   deploy-app_partner:
     runs-on: ubuntu-latest
-    environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
+    environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' && 'production' || 'preview' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name }}
       - name: Deploy Partner App
         uses: ./.github/actions/deploy-flutter-app
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ on:
           - main
 
 concurrency:
-  group: vercel-${{ github.ref }}
+  group: vercel-${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,46 +3,25 @@ name: Deploy to Vercel
 # NOTE: Consider adding status badges to README.
 
 on:
-  push:
-    branches: [ "main", "dev" ]
+  schedule:
+    - cron: '0 */2 * * *'   # Every 2 hours (UTC), targets dev branch
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to deploy (dev or main)'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - main
 
 concurrency:
   group: vercel-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # 변경 사항 감지
-  changes:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      app_user: ${{ steps.filter.outputs.app_user }}
-      app_partner: ${{ steps.filter.outputs.app_partner }}
-      landing_user: ${{ steps.filter.outputs.landing_user }}
-      landing_partner: ${{ steps.filter.outputs.landing_partner }}
-    steps:
-    - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
-      id: filter
-      with:
-        filters: |
-          app_user:
-            - 'apps/app_user/**'
-            - 'shared/packages/minglit_kit/**'
-          app_partner:
-            - 'apps/app_partner/**'
-            - 'shared/packages/minglit_kit/**'
-          landing_user:
-            - 'apps/landing_user/**'
-            - 'shared/web/**'
-          landing_partner:
-            - 'apps/landing_partner/**'
-            - 'shared/web/**'
-
   deploy-app_user:
-    needs: changes
-    if: ${{ needs.changes.outputs.app_user == 'true' }}
     runs-on: ubuntu-latest
     environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
     steps:
@@ -65,8 +44,6 @@ jobs:
           SENTRY_DSN_FLUTTER: ${{ secrets.SENTRY_DSN_FLUTTER }}
 
   deploy-landing_user:
-    needs: changes
-    if: ${{ needs.changes.outputs.landing_user == 'true' }}
     runs-on: ubuntu-latest
     environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
     steps:
@@ -80,8 +57,6 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_LANDING_USER }}
 
   deploy-landing_partner:
-    needs: changes
-    if: ${{ needs.changes.outputs.landing_partner == 'true' }}
     runs-on: ubuntu-latest
     environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
     steps:
@@ -95,8 +70,6 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_LANDING_PARTNER }}
 
   deploy-app_partner:
-    needs: changes
-    if: ${{ needs.changes.outputs.app_partner == 'true' }}
     runs-on: ubuntu-latest
     environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
     steps:
@@ -119,7 +92,7 @@ jobs:
           SENTRY_DSN_FLUTTER: ${{ secrets.SENTRY_DSN_FLUTTER }}
 
   notify-failure:
-    needs: [changes, deploy-app_user, deploy-landing_user, deploy-landing_partner, deploy-app_partner]
+    needs: [deploy-app_user, deploy-landing_user, deploy-landing_partner, deploy-app_partner]
     if: always()
     permissions:
       issues: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,13 @@ gh pr view <PR번호> --json state,mergedAt --jq '{state: .state, merged: .merge
 2. 로컬에서 수정 후 같은 브랜치에 push (PR은 유지됨)
 3. CI 재실행 → 통과 확인 → auto-merge 완료까지 반복
 
+## Deploy Conventions
+
+- Vercel 배포는 cron (2시간마다) + 수동(`workflow_dispatch`)으로 실행된다.
+- PR/push 시 Vercel auto-deploy는 `ignoreCommand`로 차단되어 있다.
+- 즉시 배포가 필요하면: GitHub Actions → Deploy to Vercel → Run workflow → branch 선택 → 실행.
+- 4개 앱(app_user, app_partner, landing_user, landing_partner) 모두 매 cron마다 deploy된다.
+
 ## Bug Fix Conventions
 
 ### 진단 프로세스

--- a/apps/app_partner/vercel.json
+++ b/apps/app_partner/vercel.json
@@ -3,5 +3,6 @@
   "routes": [
     { "handle": "filesystem" },
     { "src": "/.*", "dest": "/index.html" }
-  ]
+  ],
+  "ignoreCommand": "exit 0"
 }

--- a/apps/app_user/vercel.json
+++ b/apps/app_user/vercel.json
@@ -13,5 +13,6 @@
     },
     { "handle": "filesystem" },
     { "src": "/.*", "dest": "/index.html" }
-  ]
+  ],
+  "ignoreCommand": "exit 0"
 }

--- a/apps/landing_partner/package.json
+++ b/apps/landing_partner/package.json
@@ -13,6 +13,9 @@
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },
+  "optionalDependencies": {
+    "lightningcss-linux-x64-gnu": "1.30.2"
+  },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",

--- a/apps/landing_partner/package.json
+++ b/apps/landing_partner/package.json
@@ -14,7 +14,8 @@
     "react-dom": "19.2.3"
   },
   "optionalDependencies": {
-    "lightningcss-linux-x64-gnu": "1.30.2"
+    "lightningcss-linux-x64-gnu": "1.30.2",
+    "@tailwindcss/oxide-linux-x64-gnu": "4.1.18"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/apps/landing_partner/vercel.json
+++ b/apps/landing_partner/vercel.json
@@ -1,5 +1,6 @@
 {
   "buildCommand": "npm run build",
   "installCommand": "npm install",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "ignoreCommand": "exit 0"
 }

--- a/apps/landing_user/package.json
+++ b/apps/landing_user/package.json
@@ -15,7 +15,8 @@
     "react-dom": "19.2.3"
   },
   "optionalDependencies": {
-    "lightningcss-linux-x64-gnu": "1.30.2"
+    "lightningcss-linux-x64-gnu": "1.30.2",
+    "@tailwindcss/oxide-linux-x64-gnu": "4.1.18"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/apps/landing_user/package.json
+++ b/apps/landing_user/package.json
@@ -14,6 +14,9 @@
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },
+  "optionalDependencies": {
+    "lightningcss-linux-x64-gnu": "1.30.2"
+  },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",

--- a/apps/landing_user/vercel.json
+++ b/apps/landing_user/vercel.json
@@ -1,5 +1,6 @@
 {
   "buildCommand": "npm run build",
   "installCommand": "npm install",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "ignoreCommand": "exit 0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "typescript": "^5"
       },
       "optionalDependencies": {
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
         "lightningcss-linux-x64-gnu": "1.30.2"
       }
     },
@@ -4535,6 +4536,7 @@
         "typescript": "^5"
       },
       "optionalDependencies": {
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
         "lightningcss-linux-x64-gnu": "1.30.2"
       }
     },
@@ -9017,6 +9019,22 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz",
+      "integrity": "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/cross-spawn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,9 @@
         "eslint-config-next": "16.1.1",
         "tailwindcss": "^4",
         "typescript": "^5"
+      },
+      "optionalDependencies": {
+        "lightningcss-linux-x64-gnu": "1.30.2"
       }
     },
     "apps/landing_partner/node_modules/@alloc/quick-lru": {
@@ -4530,6 +4533,9 @@
         "eslint-config-next": "16.1.1",
         "tailwindcss": "^4",
         "typescript": "^5"
+      },
+      "optionalDependencies": {
+        "lightningcss-linux-x64-gnu": "1.30.2"
       }
     },
     "apps/landing_user/node_modules/@alloc/quick-lru": {
@@ -9081,6 +9087,26 @@
     "node_modules/landing_user": {
       "resolved": "apps/landing_user",
       "link": true
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
+      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/lucide-react": {
       "version": "0.562.0",


### PR DESCRIPTION
## Summary

- **문제**: Vercel GitHub App이 모든 PR/push에 4개 프로젝트 auto-deploy를 시도해 Hobby 한도(100/일) rate limit 위험
- **해결**: \`ignoreCommand: exit 0\`으로 auto-deploy 차단, deploy.yml을 push → cron(2시간) + workflow_dispatch로 전환

## Changes

### \`apps/*/vercel.json\` (4개)
- \`"ignoreCommand": "exit 0"\` 추가 — Vercel GitHub App auto-build 차단
- 기존 설정(routes, buildCommand, framework) 유지

### \`.github/workflows/deploy.yml\`
- \`on.push\` 트리거 제거
- \`on.schedule: cron '0 */2 * * *'\` 추가 (매 2시간, UTC, dev 브랜치)
- \`on.workflow_dispatch\` 추가 (branch: dev/main 선택)
- \`changes\` job 제거, 모든 deploy job이 항상 실행

### \`AGENTS.md\`
- \`## Deploy Conventions\` 섹션 추가 — 즉시 배포 방법 안내