### PR TITLE
feat(partner): 온보딩 Welcome 페이지 추가 — 파트너 신청 전 서비스 소개 화면

### DIFF
--- a/apps/app_partner/lib/l10n/app_ko.arb
+++ b/apps/app_partner/lib/l10n/app_ko.arb
@@ -364,5 +364,16 @@
   "partnerApplication_field_profileImage": "프로필 이미지",
   "partnerApplication_button_uploadImage": "이미지 업로드",
   "partnerApplication_button_editApplication": "신청서 수정하기",
-  "partnerApplication_status_title": "입점 신청 현황"
+   "partnerApplication_status_title": "입점 신청 현황",
+
+   "welcome_appbar_title": "파트너 소개",
+   "welcome_page1_title": "밍글릿 파트너가 되어보세요",
+   "welcome_page1_body": "파티를 직접 기획하고 운영하세요. 밍글릿은 파트너님의 비즈니스를 성장시키는 플랫폼입니다.",
+   "welcome_page2_title": "신청 절차 안내",
+   "welcome_page2_body": "기본 정보, 사업자 정보, 연락처 및 정산 정보, 서류(사업자등록증·통장사본) 총 4단계를 완성하면 심사가 시작됩니다.",
+   "welcome_page3_title": "함께 성장해요",
+   "welcome_page3_body": "밍글릿의 검증된 매칭 시스템으로 취향에 맞는 참가자를 만나보세요.",
+   "welcome_page4_title": "파트너 후기",
+   "welcome_page4_body": "\"밍글릿 덕분에 매월 안정적인 파티를 운영하고 있어요. 운영 도구가 특히 편리합니다.\" — 실제 파트너 후기",
+   "welcome_cta_button": "파트너 신청서 작성하기"
 }

--- a/apps/app_partner/lib/src/features/onboarding/partner_welcome_page.dart
+++ b/apps/app_partner/lib/src/features/onboarding/partner_welcome_page.dart
@@ -1,0 +1,207 @@
+import 'dart:async';
+
+import 'package:app_partner/src/features/onboarding/widgets/dot_indicator.dart';
+import 'package:app_partner/src/utils/l10n_ext.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+/// Onboarding welcome page shown to new partners before starting the
+/// application wizard. Displays a 4-page swipeable introduction to the
+/// Minglit partner service.
+class PartnerWelcomePage extends ConsumerStatefulWidget {
+  const PartnerWelcomePage({super.key});
+
+  @override
+  ConsumerState<PartnerWelcomePage> createState() => _PartnerWelcomePageState();
+}
+
+class _PartnerWelcomePageState extends ConsumerState<PartnerWelcomePage> {
+  late final PageController _pageController;
+  int _currentPage = 0;
+  static const int _totalPages = 4;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = PageController();
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  void _onPageChanged(int index) {
+    setState(() => _currentPage = index);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+
+    return Scaffold(
+      appBar: MinglitTheme.simpleAppBar(
+        title: l10n.welcome_appbar_title,
+        showBackButton: false,
+        actions: [
+          PopupMenuButton<String>(
+            icon: const Icon(Icons.more_vert),
+            onSelected: (value) {
+              if (value == 'logout') {
+                _showLogoutDialog(context, ref);
+              }
+            },
+            itemBuilder: (context) => [
+              PopupMenuItem<String>(
+                value: 'logout',
+                child: Text(context.l10n.home_button_logout),
+              ),
+            ],
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: PageView(
+              controller: _pageController,
+              physics: const ClampingScrollPhysics(),
+              onPageChanged: _onPageChanged,
+              children: [
+                _WelcomePage(
+                  icon: Icons.business_center_outlined,
+                  title: l10n.welcome_page1_title,
+                  body: l10n.welcome_page1_body,
+                ),
+                _WelcomePage(
+                  icon: Icons.checklist_outlined,
+                  title: l10n.welcome_page2_title,
+                  body: l10n.welcome_page2_body,
+                ),
+                _WelcomePage(
+                  icon: Icons.celebration_outlined,
+                  title: l10n.welcome_page3_title,
+                  body: l10n.welcome_page3_body,
+                ),
+                _WelcomePage(
+                  icon: Icons.format_quote_outlined,
+                  title: l10n.welcome_page4_title,
+                  body: l10n.welcome_page4_body,
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(bottom: MinglitSpacing.large),
+            child: DotIndicator(
+              currentIndex: _currentPage,
+              totalCount: _totalPages,
+            ),
+          ),
+        ],
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(MinglitSpacing.large),
+          child: ElevatedButton(
+            onPressed: () => context.go('/apply'),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: MinglitColors.primary,
+              foregroundColor: MinglitColors.background,
+              padding: const EdgeInsets.symmetric(
+                vertical: MinglitSpacing.medium,
+              ),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(MinglitRadius.button),
+              ),
+            ),
+            child: Text(l10n.welcome_cta_button),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _showLogoutDialog(BuildContext context, WidgetRef ref) {
+    unawaited(
+      showDialog<void>(
+        context: context,
+        builder: (context) {
+          return AlertDialog(
+            title: Text(context.l10n.home_button_logout),
+            content: const Text(
+              '로그아웃 하시겠습니까?',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: Text(context.l10n.common_button_cancel),
+              ),
+              TextButton(
+                onPressed: () async {
+                  // Fix: dialog를 먼저 닫고 signOut — signOut이 GoRouter redirect를
+                  // 트리거하면 dialog context가 무효화되어 검은화면+freeze 발생
+                  final authRepo = ref.read(authRepositoryProvider);
+                  Navigator.of(context).pop();
+                  await Future<void>.delayed(Duration.zero);
+                  await authRepo.signOut();
+                },
+                child: Text(context.l10n.home_button_logout),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _WelcomePage extends StatelessWidget {
+  const _WelcomePage({
+    required this.icon,
+    required this.title,
+    required this.body,
+  });
+
+  final IconData icon;
+  final String title;
+  final String body;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(MinglitSpacing.xlarge),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const SizedBox(height: MinglitSpacing.xlarge),
+          Icon(
+            icon,
+            size: 80,
+            color: MinglitColors.primary,
+          ),
+          const SizedBox(height: MinglitSpacing.large),
+          Text(
+            title,
+            style: theme.textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: MinglitSpacing.medium),
+          Text(
+            body,
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/app_partner/lib/src/features/onboarding/widgets/dot_indicator.dart
+++ b/apps/app_partner/lib/src/features/onboarding/widgets/dot_indicator.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+class DotIndicator extends StatelessWidget {
+  const DotIndicator({
+    required this.currentIndex,
+    required this.totalCount,
+    super.key,
+  });
+
+  final int currentIndex;
+  final int totalCount;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List.generate(totalCount, (index) {
+        final isActive = index == currentIndex;
+        return Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: MinglitSpacing.xsmall,
+          ),
+          child: AnimatedContainer(
+            duration: MinglitAnimation.medium,
+            width: isActive ? 10.0 : 8.0,
+            height: isActive ? 10.0 : 8.0,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: isActive
+                  ? MinglitColors.primary
+                  : Theme.of(context).colorScheme.outlineVariant,
+            ),
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/apps/app_partner/lib/src/l10n/generated/app_localizations.dart
+++ b/apps/app_partner/lib/src/l10n/generated/app_localizations.dart
@@ -1761,6 +1761,66 @@ abstract class AppLocalizations {
   /// In ko, this message translates to:
   /// **'입점 신청 현황'**
   String get partnerApplication_status_title;
+
+  /// No description provided for @welcome_appbar_title.
+  ///
+  /// In ko, this message translates to:
+  /// **'파트너 소개'**
+  String get welcome_appbar_title;
+
+  /// No description provided for @welcome_page1_title.
+  ///
+  /// In ko, this message translates to:
+  /// **'밍글릿 파트너가 되어보세요'**
+  String get welcome_page1_title;
+
+  /// No description provided for @welcome_page1_body.
+  ///
+  /// In ko, this message translates to:
+  /// **'파티를 직접 기획하고 운영하세요. 밍글릿은 파트너님의 비즈니스를 성장시키는 플랫폼입니다.'**
+  String get welcome_page1_body;
+
+  /// No description provided for @welcome_page2_title.
+  ///
+  /// In ko, this message translates to:
+  /// **'신청 절차 안내'**
+  String get welcome_page2_title;
+
+  /// No description provided for @welcome_page2_body.
+  ///
+  /// In ko, this message translates to:
+  /// **'기본 정보, 사업자 정보, 연락처 및 정산 정보, 서류(사업자등록증·통장사본) 총 4단계를 완성하면 심사가 시작됩니다.'**
+  String get welcome_page2_body;
+
+  /// No description provided for @welcome_page3_title.
+  ///
+  /// In ko, this message translates to:
+  /// **'함께 성장해요'**
+  String get welcome_page3_title;
+
+  /// No description provided for @welcome_page3_body.
+  ///
+  /// In ko, this message translates to:
+  /// **'밍글릿의 검증된 매칭 시스템으로 취향에 맞는 참가자를 만나보세요.'**
+  String get welcome_page3_body;
+
+  /// No description provided for @welcome_page4_title.
+  ///
+  /// In ko, this message translates to:
+  /// **'파트너 후기'**
+  String get welcome_page4_title;
+
+  /// No description provided for @welcome_page4_body.
+  ///
+  /// In ko, this message translates to:
+  /// **'\"밍글릿 덕분에 매월 안정적인 파티를 운영하고 있어요. 운영 도구가 특히 편리합니다.\" — 실제 파트너 후기'**
+  String get welcome_page4_body;
+
+  /// No description provided for @welcome_cta_button.
+  ///
+  /// In ko, this message translates to:
+  /// **'파트너 신청서 작성하기'**
+  String get welcome_cta_button;
 }
 
 class _AppLocalizationsDelegate

--- a/apps/app_partner/lib/src/l10n/generated/app_localizations_ko.dart
+++ b/apps/app_partner/lib/src/l10n/generated/app_localizations_ko.dart
@@ -884,4 +884,37 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get partnerApplication_status_title => '입점 신청 현황';
+
+  @override
+  String get welcome_appbar_title => '파트너 소개';
+
+  @override
+  String get welcome_page1_title => '밍글릿 파트너가 되어보세요';
+
+  @override
+  String get welcome_page1_body =>
+      '파티를 직접 기획하고 운영하세요. 밍글릿은 파트너님의 비즈니스를 성장시키는 플랫폼입니다.';
+
+  @override
+  String get welcome_page2_title => '신청 절차 안내';
+
+  @override
+  String get welcome_page2_body =>
+      '기본 정보, 사업자 정보, 연락처 및 정산 정보, 서류(사업자등록증·통장사본) 총 4단계를 완성하면 심사가 시작됩니다.';
+
+  @override
+  String get welcome_page3_title => '함께 성장해요';
+
+  @override
+  String get welcome_page3_body => '밍글릿의 검증된 매칭 시스템으로 취향에 맞는 참가자를 만나보세요.';
+
+  @override
+  String get welcome_page4_title => '파트너 후기';
+
+  @override
+  String get welcome_page4_body =>
+      '\"밍글릿 덕분에 매월 안정적인 파티를 운영하고 있어요. 운영 도구가 특히 편리합니다.\" — 실제 파트너 후기';
+
+  @override
+  String get welcome_cta_button => '파트너 신청서 작성하기';
 }

--- a/apps/app_partner/lib/src/routing/app_router.dart
+++ b/apps/app_partner/lib/src/routing/app_router.dart
@@ -36,6 +36,7 @@ GoRouter goRouter(Ref ref) {
       final isLoggedIn = ref.read(currentUserProvider) != null;
       final isLoggingIn = state.uri.path == '/login';
       final isApplyPage = state.uri.path.startsWith('/apply');
+      final isWelcomePage = state.uri.path == '/welcome';
 
       // Allow dev pages without authentication
       if (state.uri.path.startsWith('/dev')) return null;
@@ -55,14 +56,28 @@ GoRouter goRouter(Ref ref) {
         final onboarding = ref.read(onboardingStateProvider);
         if (onboarding.hasValue) {
           final onboardingState = onboarding.value!;
-          // Redirect to apply if needs application or has draft
+          // Redirect new applicants to welcome page first
           if (!isApplyPage &&
-              (onboardingState == OnboardingState.needsApplication ||
-                  onboardingState == OnboardingState.draftInProgress)) {
+              !isWelcomePage &&
+              onboardingState == OnboardingState.needsApplication) {
+            return '/welcome';
+          }
+          // Redirect users with draft in progress directly to apply wizard
+          if (!isApplyPage &&
+              !isWelcomePage &&
+              onboardingState == OnboardingState.draftInProgress) {
             return '/apply';
+          }
+          // If on welcome page but no longer needsApplication, redirect away
+          if (isWelcomePage &&
+              onboardingState != OnboardingState.needsApplication) {
+            return onboardingState == OnboardingState.draftInProgress
+                ? '/apply'
+                : '/';
           }
           // Redirect to status if pending/needs_correction
           if (!isApplyPage &&
+              !isWelcomePage &&
               (onboardingState == OnboardingState.pendingReview ||
                   onboardingState == OnboardingState.needsCorrection)) {
             return '/apply/status';

--- a/apps/app_partner/lib/src/routing/app_router.g.dart
+++ b/apps/app_partner/lib/src/routing/app_router.g.dart
@@ -48,4 +48,4 @@ final class GoRouterProvider
   }
 }
 
-String _$goRouterHash() => r'7f33b3cec2c235be7008d832d0d1bf39ce444812';
+String _$goRouterHash() => r'91747ee056d573e2ffe3f4765cc0b9f5ef08533a';

--- a/apps/app_partner/lib/src/routing/app_routes.dart
+++ b/apps/app_partner/lib/src/routing/app_routes.dart
@@ -9,6 +9,7 @@ import 'package:app_partner/src/features/member/partner_member_permission_page.d
 import 'package:app_partner/src/features/more/more_page.dart';
 import 'package:app_partner/src/features/onboarding/partner_apply_page.dart';
 import 'package:app_partner/src/features/onboarding/partner_apply_status_page.dart';
+import 'package:app_partner/src/features/onboarding/partner_welcome_page.dart';
 import 'package:app_partner/src/features/party/create/party_create_wizard_page.dart';
 import 'package:app_partner/src/features/party/detail/party_detail_page.dart';
 import 'package:app_partner/src/features/party/event/create/event_create_page.dart';
@@ -72,6 +73,15 @@ class PartnerApplyStatusRoute extends GoRouteData
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       const PartnerApplyStatusPage();
+}
+
+/// **Partner Welcome Route**: Onboarding page before application wizard.
+@TypedGoRoute<PartnerWelcomeRoute>(path: '/welcome')
+class PartnerWelcomeRoute extends GoRouteData with $PartnerWelcomeRoute {
+  const PartnerWelcomeRoute();
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const PartnerWelcomePage();
 }
 
 /// **Notification Center Route**

--- a/apps/app_partner/lib/src/routing/app_routes.g.dart
+++ b/apps/app_partner/lib/src/routing/app_routes.g.dart
@@ -12,6 +12,7 @@ List<RouteBase> get $appRoutes => [
   $loginRoute,
   $partnerApplyRoute,
   $partnerApplyStatusRoute,
+  $partnerWelcomeRoute,
   $notificationCenterRoute,
   $partnerShellRoute,
 ];
@@ -123,6 +124,32 @@ mixin $PartnerApplyStatusRoute on GoRouteData {
 
   @override
   String get location => GoRouteData.$location('/apply/status');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $partnerWelcomeRoute => GoRouteData.$route(
+  path: '/welcome',
+  factory: $PartnerWelcomeRoute._fromState,
+);
+
+mixin $PartnerWelcomeRoute on GoRouteData {
+  static PartnerWelcomeRoute _fromState(GoRouterState state) =>
+      const PartnerWelcomeRoute();
+
+  @override
+  String get location => GoRouteData.$location('/welcome');
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/apps/app_partner/test/src/features/onboarding/partner_welcome_page_test.dart
+++ b/apps/app_partner/test/src/features/onboarding/partner_welcome_page_test.dart
@@ -1,0 +1,114 @@
+import 'package:app_partner/src/features/onboarding/partner_welcome_page.dart';
+import 'package:app_partner/src/features/onboarding/widgets/dot_indicator.dart';
+import 'package:app_partner/src/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+void main() {
+  Widget buildTestWidget() {
+    return ProviderScope(
+      child: MaterialApp.router(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        routerConfig: GoRouter(
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) => const PartnerWelcomePage(),
+            ),
+            GoRoute(
+              path: '/apply',
+              builder: (context, state) => const Scaffold(
+                body: Center(child: Text('Apply Page')),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  group('PartnerWelcomePage', () {
+    testWidgets('renders PageView', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PageView), findsOneWidget);
+    });
+
+    testWidgets('renders DotIndicator', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DotIndicator), findsOneWidget);
+    });
+
+    testWidgets('CTA button "파트너 신청서 작성하기" is visible', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('파트너 신청서 작성하기'), findsOneWidget);
+    });
+
+    testWidgets('logout PopupMenuButton is present', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PopupMenuButton<String>), findsOneWidget);
+    });
+
+    testWidgets('first page content is visible on initial render', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('밍글릿 파트너가 되어보세요'), findsOneWidget);
+    });
+
+    testWidgets('DotIndicator starts at index 0', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      final dotIndicator = tester.widget<DotIndicator>(
+        find.byType(DotIndicator),
+      );
+      expect(dotIndicator.currentIndex, equals(0));
+      expect(dotIndicator.totalCount, equals(4));
+    });
+
+    testWidgets('swipe left updates dot indicator to index 1', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      // Swipe left to go to page 2
+      await tester.drag(find.byType(PageView), const Offset(-400, 0));
+      await tester.pumpAndSettle();
+
+      final dotIndicator = tester.widget<DotIndicator>(
+        find.byType(DotIndicator),
+      );
+      expect(dotIndicator.currentIndex, equals(1));
+    });
+
+    testWidgets('CTA button navigates to /apply', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('파트너 신청서 작성하기'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Apply Page'), findsOneWidget);
+    });
+
+    testWidgets('ClampingScrollPhysics allows swipe gestures', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      final pageView = tester.widget<PageView>(find.byType(PageView));
+      expect(pageView.physics, isA<ClampingScrollPhysics>());
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- 파트너 신청 위자드(`/apply`) 진입 전 서비스 소개 온보딩 화면(`/welcome`) 추가
- 로그인 후 바로 5단계 신청서가 뜨는 부담스러운 UX를 개선
- 4페이지 스와이프 온보딩 + 하단 CTA "파트너 신청서 작성하기" 버튼으로 자연스러운 전환

## Changes

### New Files
- `partner_welcome_page.dart` — 4페이지 스와이프 온보딩 UI (`ConsumerStatefulWidget` + `PageController`)
- `dot_indicator.dart` — 커스텀 dot indicator 위젯 (`AnimatedContainer` 기반)
- `partner_welcome_page_test.dart` — 9개 widget test

### Modified Files
- `app_ko.arb` — `welcome_*` l10n 키 10개 추가
- `app_routes.dart` — `/welcome` route (`PartnerWelcomeRoute`) 추가
- `app_router.dart` — redirect 로직 변경:
  - `needsApplication` → `/welcome` (기존: `/apply`)
  - `draftInProgress` → `/apply` (기존 유지)
  - `/welcome`에서 CTA 탭 → `/apply` (route guard loop 방지)

## UX Flow

```
로그인
  ↓ (needsApplication)
/welcome — 4페이지 스와이프 소개
  ↓ "파트너 신청서 작성하기" 탭
/apply — 5단계 신청 위자드 (기존)
  ↓
/apply/status — 심사 대기
  ↓
/ — 파트너 홈
```

## Test Results

- `flutter analyze apps/app_partner` → 4 issues (모두 pre-existing, 신규 없음)
- `flutter test apps/app_partner` → **89/89 ALL PASS**
- Debug APK build → ✅ 성공