### PR TITLE
fix(event): correct tab-scroll sync offset in event detail page

### DIFF
--- a/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
@@ -69,7 +69,7 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent>
       // maxScrollObstructionExtentBefore — compare directly.
       final revealed = viewport.getOffsetToReveal(
         renderObject,
-        0.0,
+        0,
         rect: Rect.fromLTWH(0, 0, renderObject.paintBounds.width, 0),
       );
       if (_scrollController.offset >= revealed.offset) {
@@ -94,7 +94,7 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent>
     // Use rect to target only the top edge of the section.
     final revealed = viewport.getOffsetToReveal(
       renderObject,
-      0.0,
+      0,
       rect: Rect.fromLTWH(0, 0, renderObject.paintBounds.width, 0),
     );
     final targetOffset = revealed.offset.clamp(

--- a/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
@@ -65,10 +65,14 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent>
       if (renderObject == null || !renderObject.attached) continue;
       final viewport = RenderAbstractViewport.maybeOf(renderObject);
       if (viewport == null) continue;
-      final revealOffset = viewport.getOffsetToReveal(renderObject, 0).offset;
-      // Account for pinned headers (SliverAppBar collapsed + TabBar)
-      const pinnedHeight = kToolbarHeight + kTextTabBarHeight + 1;
-      if (_scrollController.offset >= revealOffset - pinnedHeight) {
+      // getOffsetToReveal already accounts for pinned slivers via
+      // maxScrollObstructionExtentBefore — compare directly.
+      final revealed = viewport.getOffsetToReveal(
+        renderObject,
+        0.0,
+        rect: Rect.fromLTWH(0, 0, renderObject.paintBounds.width, 0),
+      );
+      if (_scrollController.offset >= revealed.offset) {
         activeIndex = i;
       }
     }
@@ -85,9 +89,15 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent>
     final viewport = RenderAbstractViewport.maybeOf(renderObject);
     if (viewport == null) return;
 
-    const pinnedHeight = kToolbarHeight + kTextTabBarHeight + 1;
-    final revealOffset = viewport.getOffsetToReveal(renderObject, 0).offset;
-    final targetOffset = (revealOffset - pinnedHeight).clamp(
+    // getOffsetToReveal already accounts for pinned slivers via
+    // maxScrollObstructionExtentBefore — do NOT subtract pinnedHeight.
+    // Use rect to target only the top edge of the section.
+    final revealed = viewport.getOffsetToReveal(
+      renderObject,
+      0.0,
+      rect: Rect.fromLTWH(0, 0, renderObject.paintBounds.width, 0),
+    );
+    final targetOffset = revealed.offset.clamp(
       0.0,
       _scrollController.position.maxScrollExtent,
     );
@@ -282,8 +292,8 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent>
 
               // Section 1: 기본 정보
               SliverToBoxAdapter(
-                key: _section1Key,
                 child: Padding(
+                  key: _section1Key,
                   padding: const EdgeInsets.all(MinglitSpacing.medium),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -408,8 +418,8 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent>
 
               // Section 2: 상세 소개
               SliverToBoxAdapter(
-                key: _section2Key,
                 child: Padding(
+                  key: _section2Key,
                   padding: const EdgeInsets.all(MinglitSpacing.medium),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -422,20 +432,26 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent>
 
               // Section 3: 참가 현황
               SliverToBoxAdapter(
-                key: _section3Key,
-                child: _ParticipationSection(event: event),
+                child: SizedBox(
+                  key: _section3Key,
+                  child: _ParticipationSection(event: event),
+                ),
               ),
 
               // Section 4: 필요 인증
               SliverToBoxAdapter(
-                key: _section4Key,
-                child: _VerificationSection(event: event),
+                child: SizedBox(
+                  key: _section4Key,
+                  child: _VerificationSection(event: event),
+                ),
               ),
 
               // Section 5: 환불 정책
               SliverToBoxAdapter(
-                key: _section5Key,
-                child: const _RefundPolicySection(),
+                child: SizedBox(
+                  key: _section5Key,
+                  child: const _RefundPolicySection(),
+                ),
               ),
 
               // Bottom padding for last section scrollability


### PR DESCRIPTION
## Summary

이벤트 디테일 화면에서 탭과 스크롤 위치가 맞지 않던 버그 수정.

### Root Cause

1. `getOffsetToReveal`이 이미 pinned sliver의 obstruction(`maxScrollObstructionExtentBefore`)을 내부적으로 차감하는데, 코드에서 `pinnedHeight`를 추가로 빼서 **이중 차감** 발생 → 탭 클릭 시 섹션이 ~150dp 낮게 위치
2. `GlobalKey`가 `SliverToBoxAdapter`(RenderSliver)에 할당되어 있어 `getOffsetToReveal`의 offset 계산이 부정확

### Fix

- `getOffsetToReveal` 반환값을 **그대로 사용** (수동 `pinnedHeight` 차감 제거)
- `GlobalKey`를 `SliverToBoxAdapter` → child `RenderBox` 위젯으로 이동 (정확한 top-edge 타겟팅)
- `rect` 파라미터로 섹션 상단만 타겟팅하여 큰 섹션에서도 정확한 위치 계산

### Testing

- 디바이스에서 이벤트 디테일 화면 테스트 완료
- 탭 클릭 (위→아래, 아래→위 양방향) 정상 동작 확인
- 스크롤 시 탭 자동 전환 정상 동작 확인