### PR TITLE
feat(supabase): add policies table with get_current_policy RPC

### DIFF
--- a/supabase/migrations/20260316000006_policies_table.sql
+++ b/supabase/migrations/20260316000006_policies_table.sql
@@ -18,7 +18,6 @@ CREATE TABLE public.policies (
   CONSTRAINT policies_key_effective_date_unique UNIQUE(key, effective_date)
 );
 
-CREATE INDEX idx_policies_key_effective ON public.policies(key, effective_date DESC);
 
 -- ============================================================
 -- 2. RLS
@@ -50,7 +49,7 @@ CREATE OR REPLACE FUNCTION public.get_current_policy(
 RETURNS jsonb
 LANGUAGE sql
 STABLE
-SECURITY DEFINER
+SECURITY INVOKER
 SET search_path = public
 AS $$
   SELECT value FROM public.policies

--- a/supabase/migrations/20260316000006_policies_table.sql
+++ b/supabase/migrations/20260316000006_policies_table.sql
@@ -1,0 +1,84 @@
+-- ============================================================
+-- policies — Admin-managed policy store
+-- Stores versioned, time-effective policies in JSONB format.
+-- Clients read via get_current_policy() RPC.
+-- ============================================================
+
+-- ============================================================
+-- 1. policies table
+-- ============================================================
+CREATE TABLE public.policies (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  key text NOT NULL,
+  value jsonb NOT NULL DEFAULT '{}',
+  version integer NOT NULL DEFAULT 1,
+  effective_date timestamptz NOT NULL DEFAULT now(),
+  description text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT policies_key_effective_date_unique UNIQUE(key, effective_date)
+);
+
+CREATE INDEX idx_policies_key_effective ON public.policies(key, effective_date DESC);
+
+-- ============================================================
+-- 2. RLS
+-- ============================================================
+ALTER TABLE public.policies ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "authenticated_read_policies" ON public.policies
+  FOR SELECT USING (auth.uid() IS NOT NULL);
+
+CREATE POLICY "service_role_all_policies" ON public.policies
+  FOR ALL USING (auth.role() = 'service_role');
+
+-- ============================================================
+-- 3. GRANT
+-- ============================================================
+GRANT SELECT ON public.policies TO authenticated;
+GRANT ALL ON public.policies TO service_role;
+
+-- ============================================================
+-- 4. get_current_policy() RPC
+-- Returns the currently effective policy JSONB for a given key.
+-- Uses p_at parameter for testability (default: now()).
+-- Returns NULL if no policy found for given key/time.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_current_policy(
+  p_key text,
+  p_at timestamptz DEFAULT now()
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT value FROM public.policies
+  WHERE key = p_key
+    AND effective_date <= p_at
+  ORDER BY effective_date DESC, version DESC
+  LIMIT 1;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_current_policy(text, timestamptz) FROM public;
+GRANT EXECUTE ON FUNCTION public.get_current_policy(text, timestamptz) TO authenticated, service_role;
+
+-- ============================================================
+-- 5. Seed — Default refund policy (source of truth: RefundCalculator)
+-- tiers sorted by min_days_before DESC (most days first)
+-- ============================================================
+INSERT INTO public.policies (key, value, version, effective_date, description)
+VALUES (
+  'refund',
+  '{
+    "tiers": [
+      {"min_days_before": 7, "refund_percentage": 100},
+      {"min_days_before": 3, "refund_percentage": 80},
+      {"min_days_before": 1, "refund_percentage": 50},
+      {"min_days_before": 0, "refund_percentage": 0}
+    ]
+  }'::jsonb,
+  1,
+  '2026-01-01T00:00:00Z'::timestamptz,
+  'Default refund policy — 4 tier: 7+ days=100%, 3-7 days=80%, 1-3 days=50%, <1 day=0%'
+);

--- a/supabase/tests/database/52_policies_test.sql
+++ b/supabase/tests/database/52_policies_test.sql
@@ -13,7 +13,7 @@ SELECT col_type_is('public', 'policies', 'version', 'integer', 'policies.version
 SELECT col_type_is('public', 'policies', 'effective_date', 'timestamp with time zone', 'policies.effective_date is timestamptz');
 SELECT col_type_is('public', 'policies', 'description', 'text', 'policies.description is text');
 SELECT col_type_is('public', 'policies', 'created_at', 'timestamp with time zone', 'policies.created_at is timestamptz');
-SELECT has_index('public', 'policies', 'idx_policies_key_effective', 'idx_policies_key_effective index exists');
+SELECT has_index('public', 'policies', 'policies_key_effective_date_unique', 'UNIQUE(key, effective_date) index exists');
 SELECT tests.rls_enabled('public', 'policies');
 
 -- ============================================================

--- a/supabase/tests/database/52_policies_test.sql
+++ b/supabase/tests/database/52_policies_test.sql
@@ -1,0 +1,150 @@
+BEGIN;
+SELECT no_plan();
+
+-- ============================================================
+-- 1. Schema — table existence + columns + index + RLS
+-- ============================================================
+SELECT has_table('public', 'policies', 'policies table exists');
+SELECT col_is_pk('public', 'policies', 'id', 'policies.id is primary key');
+SELECT col_type_is('public', 'policies', 'id', 'uuid', 'policies.id is uuid');
+SELECT col_type_is('public', 'policies', 'key', 'text', 'policies.key is text');
+SELECT col_type_is('public', 'policies', 'value', 'jsonb', 'policies.value is jsonb');
+SELECT col_type_is('public', 'policies', 'version', 'integer', 'policies.version is integer');
+SELECT col_type_is('public', 'policies', 'effective_date', 'timestamp with time zone', 'policies.effective_date is timestamptz');
+SELECT col_type_is('public', 'policies', 'description', 'text', 'policies.description is text');
+SELECT col_type_is('public', 'policies', 'created_at', 'timestamp with time zone', 'policies.created_at is timestamptz');
+SELECT has_index('public', 'policies', 'idx_policies_key_effective', 'idx_policies_key_effective index exists');
+SELECT tests.rls_enabled('public', 'policies');
+
+-- ============================================================
+-- 2. Function existence
+-- ============================================================
+SELECT has_function('public', 'get_current_policy', 'get_current_policy function exists');
+
+-- ============================================================
+-- 3. RLS — anon (no auth): cannot read policies
+-- ============================================================
+SELECT tests.clear_authentication();
+
+SELECT is_empty(
+  $$SELECT * FROM public.policies$$,
+  'anon cannot SELECT policies'
+);
+
+-- ============================================================
+-- 4. RLS — authenticated: can SELECT, cannot write
+-- ============================================================
+SELECT tests.create_supabase_user('policy_test_user', 'policy_test@test.com');
+SELECT tests.authenticate_as('policy_test_user');
+
+SELECT results_eq(
+  $$SELECT count(*)::int FROM public.policies WHERE key = 'refund'$$,
+  $$VALUES (1)$$,
+  'authenticated user can SELECT policies (sees seed data)'
+);
+
+SAVEPOINT before_blocked_insert;
+SELECT throws_ok(
+  $$INSERT INTO public.policies (key, value, version, effective_date)
+    VALUES ('test_key', '{"test": true}'::jsonb, 1, now())$$,
+  NULL,
+  'authenticated user cannot INSERT policies'
+);
+ROLLBACK TO SAVEPOINT before_blocked_insert;
+
+SELECT is_empty(
+  $$UPDATE public.policies SET description = 'hacked' WHERE key = 'refund' RETURNING id$$,
+  'authenticated user cannot UPDATE policies'
+);
+
+SELECT is_empty(
+  $$DELETE FROM public.policies WHERE key = 'refund' RETURNING id$$,
+  'authenticated user cannot DELETE policies'
+);
+
+-- ============================================================
+-- 5. RLS — service_role: full access
+-- ============================================================
+SELECT tests.authenticate_as_service_role();
+
+SELECT lives_ok(
+  $$INSERT INTO public.policies (key, value, version, effective_date, description)
+    VALUES ('test_policy', '{"tiers": []}'::jsonb, 1, '2026-06-01T00:00:00Z'::timestamptz, 'test')$$,
+  'service_role can INSERT policies'
+);
+
+SELECT results_eq(
+  $$SELECT count(*)::int FROM public.policies WHERE key = 'test_policy'$$,
+  $$VALUES (1)$$,
+  'service_role can SELECT inserted row'
+);
+
+SELECT lives_ok(
+  $$DELETE FROM public.policies WHERE key = 'test_policy'$$,
+  'service_role can DELETE policies'
+);
+
+-- ============================================================
+-- 6. RPC — get_current_policy() behavior
+-- ============================================================
+
+-- Happy path: returns refund policy JSONB
+SELECT isnt(
+  public.get_current_policy('refund', '2026-03-16T00:00:00Z'::timestamptz),
+  NULL,
+  'get_current_policy returns non-null for existing key'
+);
+
+SELECT results_eq(
+  $$SELECT jsonb_array_length(public.get_current_policy('refund', '2026-03-16T00:00:00Z'::timestamptz) -> 'tiers')$$,
+  $$VALUES (4)$$,
+  'refund policy has 4 tiers'
+);
+
+-- NULL for nonexistent key
+SELECT is(
+  public.get_current_policy('nonexistent_key', '2026-03-16T00:00:00Z'::timestamptz),
+  NULL,
+  'get_current_policy returns NULL for nonexistent key'
+);
+
+-- p_at before effective_date: seed is effective 2026-01-01, so 2025-12-31 should return NULL
+SELECT is(
+  public.get_current_policy('refund', '2025-12-31T23:59:59Z'::timestamptz),
+  NULL,
+  'get_current_policy returns NULL when p_at is before effective_date'
+);
+
+-- p_at exactly at effective_date: should return the policy
+SELECT isnt(
+  public.get_current_policy('refund', '2026-01-01T00:00:00Z'::timestamptz),
+  NULL,
+  'get_current_policy returns policy when p_at equals effective_date'
+);
+
+-- Multiple versions: newer effective_date wins
+SELECT tests.authenticate_as_service_role();
+
+INSERT INTO public.policies (key, value, version, effective_date, description)
+VALUES (
+  'refund',
+  '{"tiers": [{"min_days_before": 7, "refund_percentage": 100}, {"min_days_before": 0, "refund_percentage": 0}]}'::jsonb,
+  2,
+  '2026-02-01T00:00:00Z'::timestamptz,
+  'Updated refund policy v2 — 2 tier for testing'
+);
+
+SELECT results_eq(
+  $$SELECT jsonb_array_length(public.get_current_policy('refund', '2026-03-16T00:00:00Z'::timestamptz) -> 'tiers')$$,
+  $$VALUES (2)$$,
+  'newer effective_date policy (v2, 2 tiers) is returned over older (v1, 4 tiers)'
+);
+
+SELECT results_eq(
+  $$SELECT jsonb_array_length(public.get_current_policy('refund', '2026-01-15T00:00:00Z'::timestamptz) -> 'tiers')$$,
+  $$VALUES (4)$$,
+  'older effective_date policy (v1, 4 tiers) returned when p_at is before v2 effective_date'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/52_policies_test.sql
+++ b/supabase/tests/database/52_policies_test.sql
@@ -80,6 +80,13 @@ SELECT results_eq(
 );
 
 SELECT lives_ok(
+  $$UPDATE public.policies
+      SET description = 'updated by service_role'
+    WHERE key = 'test_policy'$$,
+  'service_role can UPDATE policies'
+);
+
+SELECT lives_ok(
   $$DELETE FROM public.policies WHERE key = 'test_policy'$$,
   'service_role can DELETE policies'
 );


### PR DESCRIPTION
## Summary

- Admin이 관리하는 \`policies\` 테이블 추가 — JSONB 포맷으로 유연한 정책 관리
- \`get_current_policy(key, at)\` RPC — \`effective_date <= at\` 중 최신 버전 정책 자동 반환
- 환불정책 초기 seed 데이터 (4 tier: 100/80/50/0%)
- pgTAP 테스트 27개 — schema, RLS, RPC 기능 전체 검증

## Changes

### \`supabase/migrations/20260316000006_policies_table.sql\`
- \`policies\` 테이블: id, key, value(jsonb), version, effective_date, description, created_at
- \`UNIQUE(key, effective_date)\` 제약으로 모호성 제거
- RLS: authenticated SELECT, service_role ALL
- \`get_current_policy(p_key text, p_at timestamptz DEFAULT now())\` RPC — SECURITY DEFINER
- 환불정책 seed: 7일+ 100%, 3-7일 80%, 1-3일 50%, 당일 0%

### \`supabase/tests/database/52_policies_test.sql\`
- Schema tests: 테이블/컬럼/인덱스/RLS enabled
- RLS tests: anon 차단, authenticated SELECT 허용, 쓰기 차단, service_role 전체 허용
- RPC tests: happy path, NULL for unknown key, effective_date 필터링, 다중 버전 정렬