### PR TITLE
fix(integration): unify isLoggedIn and currentUser auth signals in test helper

### DIFF
--- a/apps/app_user/integration_test/utils/test_app.dart
+++ b/apps/app_user/integration_test/utils/test_app.dart
@@ -16,6 +16,9 @@ Widget createTestApp({
   List<dynamic> additionalOverrides = const [],
   String initialLocation = '/',
 }) {
+  // Unify auth signals: if currentUser is provided, treat as logged in
+  final effectiveLoggedIn = isLoggedIn || currentUser != null;
+
   final testRouter = GoRouter(
     initialLocation: initialLocation,
     routes: $appRoutes,
@@ -31,7 +34,7 @@ Widget createTestApp({
       final isLoggingIn = path == '/login';
 
       // Logged in + trying to access /login → redirect to `from` or home
-      if (isLoggedIn && isLoggingIn) {
+      if (effectiveLoggedIn && isLoggingIn) {
         final from = state.uri.queryParameters['from'];
         if (from != null &&
             from.startsWith('/') &&
@@ -54,7 +57,7 @@ Widget createTestApp({
           protectedPrefixes.any(path.startsWith) || path.endsWith('/apply');
 
       // Not logged in + protected route → /login?from={path}
-      if (!isLoggedIn && isProtected) {
+      if (!effectiveLoggedIn && isProtected) {
         return Uri(
           path: '/login',
           queryParameters: {'from': path},


### PR DESCRIPTION
## Summary
- `createTestApp()`에서 `isLoggedIn`과 `currentUser`가 불일치할 수 있는 문제 수정
- `effectiveLoggedIn = isLoggedIn || currentUser != null`로 통합하여 redirect와 provider가 항상 동기화

From CodeRabbit review on #123.