### PR TITLE
refactor(settlement): Phase 6 — repository/coordinator/controller 분리 + 테스트

### DIFF
--- a/apps/app_partner/lib/src/features/home/widgets/revenue_summary_card.dart
+++ b/apps/app_partner/lib/src/features/home/widgets/revenue_summary_card.dart
@@ -1,5 +1,5 @@
 import 'package:app_partner/src/features/party/party_providers.dart';
-import 'package:app_partner/src/routing/app_routes.dart';
+import 'package:app_partner/src/features/settlement/settlement_coordinator.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -40,7 +40,8 @@ class RevenueSummaryCard extends ConsumerWidget {
         borderRadius: BorderRadius.circular(MinglitRadius.card),
       ),
       child: InkWell(
-        onTap: () => const SettlementRoute().push<void>(context),
+        onTap: () =>
+            ref.read(settlementCoordinatorProvider.notifier).goToSettlement(),
         borderRadius: BorderRadius.circular(MinglitRadius.card),
         child: Padding(
           padding: const EdgeInsets.all(MinglitSpacing.large),

--- a/apps/app_partner/lib/src/features/home/widgets/revenue_summary_card.dart
+++ b/apps/app_partner/lib/src/features/home/widgets/revenue_summary_card.dart
@@ -1,60 +1,37 @@
-import 'dart:async';
-
 import 'package:app_partner/src/features/party/party_providers.dart';
 import 'package:app_partner/src/routing/app_routes.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/minglit_kit.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'revenue_summary_card.g.dart';
+
+/// Loads current month net settlement amount from SettlementRepository.
+@riverpod
+Future<int> currentMonthNet(Ref ref) async {
+  final partner = await ref.read(currentPartnerInfoProvider.future);
+  if (partner == null) return 0;
+  final now = DateTime.now();
+  final repo = ref.read(settlementRepositoryProvider);
+  final data = await repo.getSettlementDashboard(
+    partnerId: partner.id,
+    periodStart: DateTime(now.year, now.month),
+    periodEnd: DateTime(now.year, now.month + 1, 0),
+  );
+  return data['completed_net_total'] as int? ?? 0;
+}
 
 /// Revenue summary card — displays current month net settlement amount.
-/// Loads data from SettlementRepository.getSettlementDashboard().
-class RevenueSummaryCard extends ConsumerStatefulWidget {
+class RevenueSummaryCard extends ConsumerWidget {
   const RevenueSummaryCard({super.key});
 
   @override
-  ConsumerState<RevenueSummaryCard> createState() => _RevenueSummaryCardState();
-}
-
-class _RevenueSummaryCardState extends ConsumerState<RevenueSummaryCard> {
-  int? _currentMonthNet;
-  bool _isLoading = true;
-
-  @override
-  void initState() {
-    super.initState();
-    unawaited(_loadData());
-  }
-
-  Future<void> _loadData() async {
-    try {
-      final partner = await ref.read(currentPartnerInfoProvider.future);
-      if (partner == null) {
-        if (mounted) setState(() => _isLoading = false);
-        return;
-      }
-      final now = DateTime.now();
-      final repo = ref.read(settlementRepositoryProvider);
-      final data = await repo.getSettlementDashboard(
-        partnerId: partner.id,
-        periodStart: DateTime(now.year, now.month),
-        periodEnd: DateTime(now.year, now.month + 1, 0),
-      );
-      if (mounted) {
-        setState(() {
-          _currentMonthNet = data['completed_net_total'] as int? ?? 0;
-          _isLoading = false;
-        });
-      }
-    } on Exception catch (_) {
-      if (mounted) setState(() => _isLoading = false);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final formatter = NumberFormat.currency(locale: 'ko_KR', symbol: '₩');
+    final currentMonthNetAsync = ref.watch(currentMonthNetProvider);
 
     return Card(
       elevation: 0,
@@ -87,8 +64,15 @@ class _RevenueSummaryCardState extends ConsumerState<RevenueSummaryCard> {
                 ],
               ),
               const SizedBox(height: 8),
-              if (_isLoading)
-                SizedBox(
+              currentMonthNetAsync.when(
+                data: (amount) => Text(
+                  formatter.format(amount),
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: colorScheme.primary,
+                  ),
+                ),
+                loading: () => SizedBox(
                   height: 24,
                   width: 24,
                   child: CircularProgressIndicator(
@@ -97,15 +81,15 @@ class _RevenueSummaryCardState extends ConsumerState<RevenueSummaryCard> {
                       colorScheme.primary,
                     ),
                   ),
-                )
-              else
-                Text(
-                  formatter.format(_currentMonthNet ?? 0),
+                ),
+                error: (error, stackTrace) => Text(
+                  formatter.format(0),
                   style: theme.textTheme.headlineSmall?.copyWith(
                     fontWeight: FontWeight.bold,
                     color: colorScheme.primary,
                   ),
                 ),
+              ),
             ],
           ),
         ),

--- a/apps/app_partner/lib/src/features/home/widgets/revenue_summary_card.g.dart
+++ b/apps/app_partner/lib/src/features/home/widgets/revenue_summary_card.g.dart
@@ -1,0 +1,47 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'revenue_summary_card.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Loads current month net settlement amount from SettlementRepository.
+
+@ProviderFor(currentMonthNet)
+const currentMonthNetProvider = CurrentMonthNetProvider._();
+
+/// Loads current month net settlement amount from SettlementRepository.
+
+final class CurrentMonthNetProvider
+    extends $FunctionalProvider<AsyncValue<int>, int, FutureOr<int>>
+    with $FutureModifier<int>, $FutureProvider<int> {
+  /// Loads current month net settlement amount from SettlementRepository.
+  const CurrentMonthNetProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'currentMonthNetProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$currentMonthNetHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<int> create(Ref ref) {
+    return currentMonthNet(ref);
+  }
+}
+
+String _$currentMonthNetHash() => r'c684e86e332e3f63dc7c563172cd5eb8352d8e42';

--- a/apps/app_partner/lib/src/features/settlement/bank_account_page.dart
+++ b/apps/app_partner/lib/src/features/settlement/bank_account_page.dart
@@ -1,10 +1,10 @@
 import 'dart:async' show unawaited;
 
 import 'package:app_partner/src/features/party/party_providers.dart';
+import 'package:app_partner/src/features/settlement/settlement_coordinator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:minglit_kit/minglit_kit.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 
 class BankAccountPage extends ConsumerStatefulWidget {
   const BankAccountPage({super.key});
@@ -30,11 +30,8 @@ class _BankAccountPageState extends ConsumerState<BankAccountPage> {
         if (mounted) setState(() => _isLoading = false);
         return;
       }
-      final data = await Supabase.instance.client
-          .from('partner_settlements')
-          .select('bank_name, account_holder, account_number')
-          .eq('partner_id', partner.id)
-          .maybeSingle();
+      final repo = ref.read(settlementRepositoryProvider);
+      final data = await repo.getBankAccount(partner.id);
       if (mounted) {
         setState(() {
           _accountData = data;
@@ -184,12 +181,13 @@ class _AccountEditFormState extends ConsumerState<AccountEditForm> {
     try {
       final partner = await ref.read(currentPartnerInfoProvider.future);
       if (partner == null) return;
-      await Supabase.instance.client.from('partner_settlements').upsert({
-        'partner_id': partner.id,
-        'bank_name': _bankCtrl.text.trim(),
-        'account_holder': _holderCtrl.text.trim(),
-        'account_number': _numberCtrl.text.trim(),
-      }, onConflict: 'partner_id');
+      final repo = ref.read(settlementRepositoryProvider);
+      await repo.upsertBankAccount(
+        partnerId: partner.id,
+        bankName: _bankCtrl.text.trim(),
+        accountHolder: _holderCtrl.text.trim(),
+        accountNumber: _numberCtrl.text.trim(),
+      );
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('계좌 정보가 저장되었습니다.')),
@@ -272,13 +270,13 @@ class _RetryPayoutButtonState extends ConsumerState<RetryPayoutButton> {
   Future<void> _retry() async {
     setState(() => _isLoading = true);
     try {
-      await Supabase.instance.client.rpc<void>(
-        'request_retry_payout',
-        params: {
-          'p_payout_id': widget.payoutId,
-          'p_partner_id': widget.partnerId,
-        },
-      );
+      await ref
+          .read(settlementCoordinatorProvider.notifier)
+          .retryPayout(
+            context,
+            payoutId: widget.payoutId,
+            partnerId: widget.partnerId,
+          );
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('재지급 요청이 완료되었습니다.')),

--- a/apps/app_partner/lib/src/features/settlement/bank_account_page.dart
+++ b/apps/app_partner/lib/src/features/settlement/bank_account_page.dart
@@ -3,7 +3,6 @@ import 'dart:async' show unawaited;
 import 'package:app_partner/src/features/party/party_providers.dart';
 import 'package:app_partner/src/features/settlement/settlement_coordinator.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
 class BankAccountPage extends ConsumerStatefulWidget {

--- a/apps/app_partner/lib/src/features/settlement/settlement_coordinator.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_coordinator.dart
@@ -1,5 +1,9 @@
+import 'dart:async';
+
 import 'package:app_partner/src/routing/app_router.dart';
 import 'package:app_partner/src/routing/app_routes.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'settlement_coordinator.g.dart';
@@ -11,5 +15,41 @@ class SettlementCoordinator extends _$SettlementCoordinator {
 
   void goToSettlement() {
     ref.read(goRouterProvider).go(const SettlementRoute().location);
+  }
+
+  void goToDetail(String itemId) {
+    unawaited(
+      ref
+          .read(goRouterProvider)
+          .push(SettlementDetailRoute(id: itemId).location),
+    );
+  }
+
+  void goToBankAccount() {
+    unawaited(
+      ref.read(goRouterProvider).push(const BankAccountRoute().location),
+    );
+  }
+
+  Future<void> retryPayout(
+    BuildContext context, {
+    required String payoutId,
+    required String partnerId,
+  }) async {
+    final loading = ref.read(globalLoadingControllerProvider.notifier)..show();
+    try {
+      await ref
+          .read(settlementRepositoryProvider)
+          .retryPayout(payoutId: payoutId, partnerId: partnerId);
+      if (context.mounted) {
+        context.showMinglitSuccess('재지급 요청이 완료되었습니다.');
+      }
+    } on Object catch (e, st) {
+      if (context.mounted) {
+        handleMinglitError(context, e, st);
+      }
+    } finally {
+      loading.hide();
+    }
   }
 }

--- a/apps/app_partner/lib/src/features/settlement/settlement_coordinator.g.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_coordinator.g.dart
@@ -42,7 +42,7 @@ final class SettlementCoordinatorProvider
 }
 
 String _$settlementCoordinatorHash() =>
-    r'90345138923ae890998b40208a23dbd96ea74738';
+    r'05d742aff3585d7a30c37bd17f4aa8e7727f6043';
 
 abstract class _$SettlementCoordinator extends $Notifier<void> {
   void build();

--- a/apps/app_partner/lib/src/features/settlement/settlement_dashboard_controller.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_dashboard_controller.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+import 'package:app_partner/src/features/party/party_providers.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'settlement_dashboard_controller.freezed.dart';
+part 'settlement_dashboard_controller.g.dart';
+
+@freezed
+abstract class SettlementDashboardState with _$SettlementDashboardState {
+  const factory SettlementDashboardState({
+    required DateTime selectedMonth,
+    @Default(AsyncValue<void>.loading()) AsyncValue<void> status,
+    Map<String, dynamic>? dashboardData,
+  }) = _SettlementDashboardState;
+}
+
+@riverpod
+class SettlementDashboardController extends _$SettlementDashboardController {
+  @override
+  SettlementDashboardState build() {
+    final now = DateTime.now();
+    final initialState = SettlementDashboardState(
+      selectedMonth: DateTime(now.year, now.month),
+    );
+    unawaited(Future.microtask(loadDashboard));
+    return initialState;
+  }
+
+  Future<void> loadDashboard() async {
+    state = state.copyWith(status: const AsyncValue.loading());
+    try {
+      final partner = await ref.read(currentPartnerInfoProvider.future);
+      if (partner == null) {
+        state = state.copyWith(status: const AsyncValue.data(null));
+        return;
+      }
+      final repo = ref.read(settlementRepositoryProvider);
+      final month = state.selectedMonth;
+      final data = await repo.getSettlementDashboard(
+        partnerId: partner.id,
+        periodStart: month,
+        periodEnd: DateTime(month.year, month.month + 1, 0, 23, 59, 59, 999),
+      );
+      state = state.copyWith(
+        status: const AsyncValue.data(null),
+        dashboardData: data,
+      );
+    } on Exception catch (e, st) {
+      state = state.copyWith(status: AsyncValue.error(e, st));
+    }
+  }
+
+  void changeMonth(int delta) {
+    final current = state.selectedMonth;
+    state = state.copyWith(
+      selectedMonth: DateTime(current.year, current.month + delta),
+      dashboardData: null,
+    );
+    unawaited(loadDashboard());
+  }
+}

--- a/apps/app_partner/lib/src/features/settlement/settlement_dashboard_controller.freezed.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_dashboard_controller.freezed.dart
@@ -1,0 +1,285 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'settlement_dashboard_controller.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$SettlementDashboardState {
+
+ DateTime get selectedMonth; AsyncValue<void> get status; Map<String, dynamic>? get dashboardData;
+/// Create a copy of SettlementDashboardState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SettlementDashboardStateCopyWith<SettlementDashboardState> get copyWith => _$SettlementDashboardStateCopyWithImpl<SettlementDashboardState>(this as SettlementDashboardState, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SettlementDashboardState&&(identical(other.selectedMonth, selectedMonth) || other.selectedMonth == selectedMonth)&&(identical(other.status, status) || other.status == status)&&const DeepCollectionEquality().equals(other.dashboardData, dashboardData));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,selectedMonth,status,const DeepCollectionEquality().hash(dashboardData));
+
+@override
+String toString() {
+  return 'SettlementDashboardState(selectedMonth: $selectedMonth, status: $status, dashboardData: $dashboardData)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SettlementDashboardStateCopyWith<$Res>  {
+  factory $SettlementDashboardStateCopyWith(SettlementDashboardState value, $Res Function(SettlementDashboardState) _then) = _$SettlementDashboardStateCopyWithImpl;
+@useResult
+$Res call({
+ DateTime selectedMonth, AsyncValue<void> status, Map<String, dynamic>? dashboardData
+});
+
+
+
+
+}
+/// @nodoc
+class _$SettlementDashboardStateCopyWithImpl<$Res>
+    implements $SettlementDashboardStateCopyWith<$Res> {
+  _$SettlementDashboardStateCopyWithImpl(this._self, this._then);
+
+  final SettlementDashboardState _self;
+  final $Res Function(SettlementDashboardState) _then;
+
+/// Create a copy of SettlementDashboardState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? selectedMonth = null,Object? status = null,Object? dashboardData = freezed,}) {
+  return _then(_self.copyWith(
+selectedMonth: null == selectedMonth ? _self.selectedMonth : selectedMonth // ignore: cast_nullable_to_non_nullable
+as DateTime,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as AsyncValue<void>,dashboardData: freezed == dashboardData ? _self.dashboardData : dashboardData // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [SettlementDashboardState].
+extension SettlementDashboardStatePatterns on SettlementDashboardState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SettlementDashboardState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SettlementDashboardState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SettlementDashboardState value)  $default,){
+final _that = this;
+switch (_that) {
+case _SettlementDashboardState():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SettlementDashboardState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SettlementDashboardState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( DateTime selectedMonth,  AsyncValue<void> status,  Map<String, dynamic>? dashboardData)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SettlementDashboardState() when $default != null:
+return $default(_that.selectedMonth,_that.status,_that.dashboardData);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( DateTime selectedMonth,  AsyncValue<void> status,  Map<String, dynamic>? dashboardData)  $default,) {final _that = this;
+switch (_that) {
+case _SettlementDashboardState():
+return $default(_that.selectedMonth,_that.status,_that.dashboardData);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( DateTime selectedMonth,  AsyncValue<void> status,  Map<String, dynamic>? dashboardData)?  $default,) {final _that = this;
+switch (_that) {
+case _SettlementDashboardState() when $default != null:
+return $default(_that.selectedMonth,_that.status,_that.dashboardData);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _SettlementDashboardState implements SettlementDashboardState {
+  const _SettlementDashboardState({required this.selectedMonth, this.status = const AsyncValue<void>.loading(), final  Map<String, dynamic>? dashboardData}): _dashboardData = dashboardData;
+  
+
+@override final  DateTime selectedMonth;
+@override@JsonKey() final  AsyncValue<void> status;
+ final  Map<String, dynamic>? _dashboardData;
+@override Map<String, dynamic>? get dashboardData {
+  final value = _dashboardData;
+  if (value == null) return null;
+  if (_dashboardData is EqualUnmodifiableMapView) return _dashboardData;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
+
+
+/// Create a copy of SettlementDashboardState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SettlementDashboardStateCopyWith<_SettlementDashboardState> get copyWith => __$SettlementDashboardStateCopyWithImpl<_SettlementDashboardState>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SettlementDashboardState&&(identical(other.selectedMonth, selectedMonth) || other.selectedMonth == selectedMonth)&&(identical(other.status, status) || other.status == status)&&const DeepCollectionEquality().equals(other._dashboardData, _dashboardData));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,selectedMonth,status,const DeepCollectionEquality().hash(_dashboardData));
+
+@override
+String toString() {
+  return 'SettlementDashboardState(selectedMonth: $selectedMonth, status: $status, dashboardData: $dashboardData)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SettlementDashboardStateCopyWith<$Res> implements $SettlementDashboardStateCopyWith<$Res> {
+  factory _$SettlementDashboardStateCopyWith(_SettlementDashboardState value, $Res Function(_SettlementDashboardState) _then) = __$SettlementDashboardStateCopyWithImpl;
+@override @useResult
+$Res call({
+ DateTime selectedMonth, AsyncValue<void> status, Map<String, dynamic>? dashboardData
+});
+
+
+
+
+}
+/// @nodoc
+class __$SettlementDashboardStateCopyWithImpl<$Res>
+    implements _$SettlementDashboardStateCopyWith<$Res> {
+  __$SettlementDashboardStateCopyWithImpl(this._self, this._then);
+
+  final _SettlementDashboardState _self;
+  final $Res Function(_SettlementDashboardState) _then;
+
+/// Create a copy of SettlementDashboardState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? selectedMonth = null,Object? status = null,Object? dashboardData = freezed,}) {
+  return _then(_SettlementDashboardState(
+selectedMonth: null == selectedMonth ? _self.selectedMonth : selectedMonth // ignore: cast_nullable_to_non_nullable
+as DateTime,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as AsyncValue<void>,dashboardData: freezed == dashboardData ? _self._dashboardData : dashboardData // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/apps/app_partner/lib/src/features/settlement/settlement_dashboard_controller.g.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_dashboard_controller.g.dart
@@ -1,0 +1,71 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'settlement_dashboard_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(SettlementDashboardController)
+const settlementDashboardControllerProvider =
+    SettlementDashboardControllerProvider._();
+
+final class SettlementDashboardControllerProvider
+    extends
+        $NotifierProvider<
+          SettlementDashboardController,
+          SettlementDashboardState
+        > {
+  const SettlementDashboardControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'settlementDashboardControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$settlementDashboardControllerHash();
+
+  @$internal
+  @override
+  SettlementDashboardController create() => SettlementDashboardController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SettlementDashboardState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SettlementDashboardState>(value),
+    );
+  }
+}
+
+String _$settlementDashboardControllerHash() =>
+    r'3875ecfe7e844ae99318754b7ef9500c025a0f1d';
+
+abstract class _$SettlementDashboardController
+    extends $Notifier<SettlementDashboardState> {
+  SettlementDashboardState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref =
+        this.ref as $Ref<SettlementDashboardState, SettlementDashboardState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<SettlementDashboardState, SettlementDashboardState>,
+              SettlementDashboardState,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/apps/app_partner/lib/src/features/settlement/settlement_detail_page.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_detail_page.dart
@@ -1,12 +1,12 @@
 import 'dart:async' show unawaited;
 
 import 'package:app_partner/src/features/party/party_providers.dart';
+import 'package:app_partner/src/features/settlement/settlement_coordinator.dart';
 import 'package:app_partner/src/features/settlement/widgets/download_bottom_sheet.dart';
 import 'package:app_partner/src/features/settlement/widgets/settlement_status_badge.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/minglit_kit.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 
 class SettlementDetailPage extends ConsumerStatefulWidget {
   const SettlementDetailPage({required this.itemId, super.key});
@@ -55,7 +55,37 @@ class _SettlementDetailPageState extends ConsumerState<SettlementDetailPage> {
       body: _isLoading
           ? const Center(child: CircularProgressIndicator())
           : _error != null
-          ? Center(child: Text('오류: $_error'))
+          ? Center(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      Icons.error_outline,
+                      size: 48,
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      '오류가 발생했습니다',
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      _error!,
+                      style: Theme.of(context).textTheme.bodySmall,
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 16),
+                    FilledButton(
+                      onPressed: _loadDetail,
+                      child: const Text('다시 시도'),
+                    ),
+                  ],
+                ),
+              ),
+            )
           : _detail == null
           ? const Center(child: Text('정산 항목을 찾을 수 없습니다.'))
           : _DetailContent(detail: _detail!),
@@ -281,28 +311,15 @@ class ActionButtons extends ConsumerWidget {
 
   Future<void> _retryPayout(BuildContext context, WidgetRef ref) async {
     if (detail.payoutId == null) return;
-    try {
-      final partner = await ref.read(currentPartnerInfoProvider.future);
-      if (partner == null) return;
-      await Supabase.instance.client.rpc<void>(
-        'request_retry_payout',
-        params: {
-          'p_payout_id': detail.payoutId,
-          'p_partner_id': partner.id,
-        },
-      );
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('재지급 요청이 완료되었습니다.')),
+    final partner = await ref.read(currentPartnerInfoProvider.future);
+    if (partner == null) return;
+    await ref
+        .read(settlementCoordinatorProvider.notifier)
+        .retryPayout(
+          context,
+          payoutId: detail.payoutId!,
+          partnerId: partner.id,
         );
-      }
-    } on Exception catch (e) {
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('오류: $e')),
-        );
-      }
-    }
   }
 
   void _downloadCsv(BuildContext context) {

--- a/apps/app_partner/lib/src/features/settlement/settlement_list_controller.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_list_controller.dart
@@ -45,6 +45,7 @@ class SettlementListController extends _$SettlementListController {
         partnerId: partner.id,
         status: state.selectedStatus,
         offset: state.items.length,
+        limit: _pageSize,
       );
       // Race condition guard: discard stale responses
       if (generation != _currentGeneration) return;

--- a/apps/app_partner/lib/src/features/settlement/settlement_list_controller.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_list_controller.dart
@@ -45,7 +45,6 @@ class SettlementListController extends _$SettlementListController {
         partnerId: partner.id,
         status: state.selectedStatus,
         offset: state.items.length,
-        limit: _pageSize,
       );
       // Race condition guard: discard stale responses
       if (generation != _currentGeneration) return;

--- a/apps/app_partner/lib/src/features/settlement/settlement_list_controller.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_list_controller.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+
+import 'package:app_partner/src/features/party/party_providers.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'settlement_list_controller.freezed.dart';
+part 'settlement_list_controller.g.dart';
+
+@freezed
+abstract class SettlementListState with _$SettlementListState {
+  const factory SettlementListState({
+    @Default([]) List<SettlementItemDetail> items,
+    @Default(null) String? selectedStatus,
+    @Default(false) bool isLoading,
+    @Default(true) bool hasMore,
+    @Default(null) String? error,
+  }) = _SettlementListState;
+}
+
+@riverpod
+class SettlementListController extends _$SettlementListController {
+  static const _pageSize = 20;
+  int _currentGeneration = 0;
+
+  @override
+  SettlementListState build() {
+    unawaited(Future.microtask(loadMore));
+    return const SettlementListState();
+  }
+
+  Future<void> loadMore() async {
+    if (state.isLoading || !state.hasMore) return;
+    final generation = _currentGeneration;
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final partner = await ref.read(currentPartnerInfoProvider.future);
+      if (partner == null) {
+        state = state.copyWith(isLoading: false);
+        return;
+      }
+      final repo = ref.read(settlementRepositoryProvider);
+      final newItems = await repo.getSettlementItems(
+        partnerId: partner.id,
+        status: state.selectedStatus,
+        offset: state.items.length,
+        limit: _pageSize,
+      );
+      // Race condition guard: discard stale responses
+      if (generation != _currentGeneration) return;
+      state = state.copyWith(
+        isLoading: false,
+        items: [...state.items, ...newItems],
+        hasMore: newItems.length == _pageSize,
+      );
+    } on Exception catch (e, st) {
+      if (generation != _currentGeneration) return;
+      Log.e('SettlementListController loadMore error', e, st);
+      state = state.copyWith(isLoading: false, error: e.toString());
+    }
+  }
+
+  void changeStatus(String? status) {
+    _currentGeneration++;
+    state = state.copyWith(
+      selectedStatus: status,
+      items: [],
+      hasMore: true,
+      error: null,
+    );
+    unawaited(loadMore());
+  }
+
+  Future<void> refresh() async {
+    _currentGeneration++;
+    state = state.copyWith(
+      items: [],
+      hasMore: true,
+      error: null,
+    );
+    await loadMore();
+  }
+}

--- a/apps/app_partner/lib/src/features/settlement/settlement_list_controller.freezed.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_list_controller.freezed.dart
@@ -1,0 +1,289 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'settlement_list_controller.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$SettlementListState {
+
+ List<SettlementItemDetail> get items; String? get selectedStatus; bool get isLoading; bool get hasMore; String? get error;
+/// Create a copy of SettlementListState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SettlementListStateCopyWith<SettlementListState> get copyWith => _$SettlementListStateCopyWithImpl<SettlementListState>(this as SettlementListState, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SettlementListState&&const DeepCollectionEquality().equals(other.items, items)&&(identical(other.selectedStatus, selectedStatus) || other.selectedStatus == selectedStatus)&&(identical(other.isLoading, isLoading) || other.isLoading == isLoading)&&(identical(other.hasMore, hasMore) || other.hasMore == hasMore)&&(identical(other.error, error) || other.error == error));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(items),selectedStatus,isLoading,hasMore,error);
+
+@override
+String toString() {
+  return 'SettlementListState(items: $items, selectedStatus: $selectedStatus, isLoading: $isLoading, hasMore: $hasMore, error: $error)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SettlementListStateCopyWith<$Res>  {
+  factory $SettlementListStateCopyWith(SettlementListState value, $Res Function(SettlementListState) _then) = _$SettlementListStateCopyWithImpl;
+@useResult
+$Res call({
+ List<SettlementItemDetail> items, String? selectedStatus, bool isLoading, bool hasMore, String? error
+});
+
+
+
+
+}
+/// @nodoc
+class _$SettlementListStateCopyWithImpl<$Res>
+    implements $SettlementListStateCopyWith<$Res> {
+  _$SettlementListStateCopyWithImpl(this._self, this._then);
+
+  final SettlementListState _self;
+  final $Res Function(SettlementListState) _then;
+
+/// Create a copy of SettlementListState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? items = null,Object? selectedStatus = freezed,Object? isLoading = null,Object? hasMore = null,Object? error = freezed,}) {
+  return _then(_self.copyWith(
+items: null == items ? _self.items : items // ignore: cast_nullable_to_non_nullable
+as List<SettlementItemDetail>,selectedStatus: freezed == selectedStatus ? _self.selectedStatus : selectedStatus // ignore: cast_nullable_to_non_nullable
+as String?,isLoading: null == isLoading ? _self.isLoading : isLoading // ignore: cast_nullable_to_non_nullable
+as bool,hasMore: null == hasMore ? _self.hasMore : hasMore // ignore: cast_nullable_to_non_nullable
+as bool,error: freezed == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [SettlementListState].
+extension SettlementListStatePatterns on SettlementListState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SettlementListState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SettlementListState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SettlementListState value)  $default,){
+final _that = this;
+switch (_that) {
+case _SettlementListState():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SettlementListState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SettlementListState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<SettlementItemDetail> items,  String? selectedStatus,  bool isLoading,  bool hasMore,  String? error)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SettlementListState() when $default != null:
+return $default(_that.items,_that.selectedStatus,_that.isLoading,_that.hasMore,_that.error);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<SettlementItemDetail> items,  String? selectedStatus,  bool isLoading,  bool hasMore,  String? error)  $default,) {final _that = this;
+switch (_that) {
+case _SettlementListState():
+return $default(_that.items,_that.selectedStatus,_that.isLoading,_that.hasMore,_that.error);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<SettlementItemDetail> items,  String? selectedStatus,  bool isLoading,  bool hasMore,  String? error)?  $default,) {final _that = this;
+switch (_that) {
+case _SettlementListState() when $default != null:
+return $default(_that.items,_that.selectedStatus,_that.isLoading,_that.hasMore,_that.error);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _SettlementListState implements SettlementListState {
+  const _SettlementListState({final  List<SettlementItemDetail> items = const [], this.selectedStatus = null, this.isLoading = false, this.hasMore = true, this.error = null}): _items = items;
+  
+
+ final  List<SettlementItemDetail> _items;
+@override@JsonKey() List<SettlementItemDetail> get items {
+  if (_items is EqualUnmodifiableListView) return _items;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_items);
+}
+
+@override@JsonKey() final  String? selectedStatus;
+@override@JsonKey() final  bool isLoading;
+@override@JsonKey() final  bool hasMore;
+@override@JsonKey() final  String? error;
+
+/// Create a copy of SettlementListState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SettlementListStateCopyWith<_SettlementListState> get copyWith => __$SettlementListStateCopyWithImpl<_SettlementListState>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SettlementListState&&const DeepCollectionEquality().equals(other._items, _items)&&(identical(other.selectedStatus, selectedStatus) || other.selectedStatus == selectedStatus)&&(identical(other.isLoading, isLoading) || other.isLoading == isLoading)&&(identical(other.hasMore, hasMore) || other.hasMore == hasMore)&&(identical(other.error, error) || other.error == error));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_items),selectedStatus,isLoading,hasMore,error);
+
+@override
+String toString() {
+  return 'SettlementListState(items: $items, selectedStatus: $selectedStatus, isLoading: $isLoading, hasMore: $hasMore, error: $error)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SettlementListStateCopyWith<$Res> implements $SettlementListStateCopyWith<$Res> {
+  factory _$SettlementListStateCopyWith(_SettlementListState value, $Res Function(_SettlementListState) _then) = __$SettlementListStateCopyWithImpl;
+@override @useResult
+$Res call({
+ List<SettlementItemDetail> items, String? selectedStatus, bool isLoading, bool hasMore, String? error
+});
+
+
+
+
+}
+/// @nodoc
+class __$SettlementListStateCopyWithImpl<$Res>
+    implements _$SettlementListStateCopyWith<$Res> {
+  __$SettlementListStateCopyWithImpl(this._self, this._then);
+
+  final _SettlementListState _self;
+  final $Res Function(_SettlementListState) _then;
+
+/// Create a copy of SettlementListState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? items = null,Object? selectedStatus = freezed,Object? isLoading = null,Object? hasMore = null,Object? error = freezed,}) {
+  return _then(_SettlementListState(
+items: null == items ? _self._items : items // ignore: cast_nullable_to_non_nullable
+as List<SettlementItemDetail>,selectedStatus: freezed == selectedStatus ? _self.selectedStatus : selectedStatus // ignore: cast_nullable_to_non_nullable
+as String?,isLoading: null == isLoading ? _self.isLoading : isLoading // ignore: cast_nullable_to_non_nullable
+as bool,hasMore: null == hasMore ? _self.hasMore : hasMore // ignore: cast_nullable_to_non_nullable
+as bool,error: freezed == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/apps/app_partner/lib/src/features/settlement/settlement_list_controller.g.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_list_controller.g.dart
@@ -1,0 +1,65 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'settlement_list_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(SettlementListController)
+const settlementListControllerProvider = SettlementListControllerProvider._();
+
+final class SettlementListControllerProvider
+    extends $NotifierProvider<SettlementListController, SettlementListState> {
+  const SettlementListControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'settlementListControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$settlementListControllerHash();
+
+  @$internal
+  @override
+  SettlementListController create() => SettlementListController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SettlementListState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SettlementListState>(value),
+    );
+  }
+}
+
+String _$settlementListControllerHash() =>
+    r'c22b8bd1ef474c1faa59aa6e7362abfc4be6e096';
+
+abstract class _$SettlementListController
+    extends $Notifier<SettlementListState> {
+  SettlementListState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref as $Ref<SettlementListState, SettlementListState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<SettlementListState, SettlementListState>,
+              SettlementListState,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/apps/app_partner/lib/src/features/settlement/settlement_page.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async' show unawaited;
 
 import 'package:app_partner/src/features/party/party_providers.dart';
+import 'package:app_partner/src/features/settlement/settlement_dashboard_controller.dart';
 import 'package:app_partner/src/features/settlement/widgets/settlement_card.dart';
 import 'package:app_partner/src/features/settlement/widgets/settlement_empty_state.dart';
 import 'package:app_partner/src/features/settlement/widgets/status_filter_chips.dart';
@@ -56,72 +57,17 @@ class _SettlementPageState extends ConsumerState<SettlementPage>
   }
 }
 
-class _DashboardTab extends ConsumerStatefulWidget {
+class _DashboardTab extends ConsumerWidget {
   const _DashboardTab();
 
   @override
-  ConsumerState<_DashboardTab> createState() => _DashboardTabState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final dashState = ref.watch(settlementDashboardControllerProvider);
 
-class _DashboardTabState extends ConsumerState<_DashboardTab> {
-  DateTime _selectedMonth = DateTime(DateTime.now().year, DateTime.now().month);
-  Map<String, dynamic>? _dashboardData;
-  bool _isLoading = true;
-
-  @override
-  void initState() {
-    super.initState();
-    unawaited(_loadDashboard());
-  }
-
-  Future<void> _loadDashboard() async {
-    setState(() => _isLoading = true);
-    try {
-      final repo = ref.read(settlementRepositoryProvider);
-      final partner = await ref.read(currentPartnerInfoProvider.future);
-      if (partner == null) {
-        if (mounted) setState(() => _isLoading = false);
-        return;
-      }
-      final data = await repo.getSettlementDashboard(
-        partnerId: partner.id,
-        periodStart: _selectedMonth,
-        periodEnd: DateTime(
-          _selectedMonth.year,
-          _selectedMonth.month + 1,
-          0,
-          23,
-          59,
-          59,
-          999,
-        ),
-      );
-      if (mounted) {
-        setState(() {
-          _dashboardData = data;
-          _isLoading = false;
-        });
-      }
-    } on Exception catch (_) {
-      if (mounted) setState(() => _isLoading = false);
-    }
-  }
-
-  void _onMonthChanged(int delta) {
-    setState(() {
-      _selectedMonth = DateTime(
-        _selectedMonth.year,
-        _selectedMonth.month + delta,
-      );
-      _dashboardData = null;
-    });
-    unawaited(_loadDashboard());
-  }
-
-  @override
-  Widget build(BuildContext context) {
     return RefreshIndicator(
-      onRefresh: _loadDashboard,
+      onRefresh: () => ref
+          .read(settlementDashboardControllerProvider.notifier)
+          .loadDashboard(),
       child: SingleChildScrollView(
         physics: const AlwaysScrollableScrollPhysics(),
         padding: const EdgeInsets.all(16),
@@ -129,17 +75,46 @@ class _DashboardTabState extends ConsumerState<_DashboardTab> {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             _PeriodSelector(
-              selectedMonth: _selectedMonth,
-              onChanged: _onMonthChanged,
+              selectedMonth: dashState.selectedMonth,
+              onChanged: (delta) => ref
+                  .read(settlementDashboardControllerProvider.notifier)
+                  .changeMonth(delta),
             ),
             const SizedBox(height: 16),
-            if (_isLoading)
-              const Center(child: CircularProgressIndicator())
-            else ...[
-              _RevenueSummaryCard(data: _dashboardData),
-              const SizedBox(height: 16),
-              _StatusSummaryGrid(data: _dashboardData),
-            ],
+            ...dashState.status.when(
+              data: (_) => [
+                _RevenueSummaryCard(data: dashState.dashboardData),
+                const SizedBox(height: 16),
+                _StatusSummaryGrid(data: dashState.dashboardData),
+              ],
+              loading: () => [const Center(child: CircularProgressIndicator())],
+              error: (error, _) => [
+                Center(
+                  child: Column(
+                    children: [
+                      Text(
+                        '오류가 발생했습니다',
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        error.toString(),
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                      const SizedBox(height: 16),
+                      FilledButton(
+                        onPressed: () => ref
+                            .read(
+                              settlementDashboardControllerProvider.notifier,
+                            )
+                            .loadDashboard(),
+                        child: const Text('다시 시도'),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
           ],
         ),
       ),

--- a/apps/app_partner/lib/src/features/settlement/settlement_page.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_page.dart
@@ -1,11 +1,9 @@
-import 'dart:async' show unawaited;
-
-import 'package:app_partner/src/features/party/party_providers.dart';
+import 'package:app_partner/src/features/settlement/settlement_coordinator.dart';
 import 'package:app_partner/src/features/settlement/settlement_dashboard_controller.dart';
+import 'package:app_partner/src/features/settlement/settlement_list_controller.dart';
 import 'package:app_partner/src/features/settlement/widgets/settlement_card.dart';
 import 'package:app_partner/src/features/settlement/widgets/settlement_empty_state.dart';
 import 'package:app_partner/src/features/settlement/widgets/status_filter_chips.dart';
-import 'package:app_partner/src/routing/app_routes.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -306,7 +304,7 @@ class _MonthHeader extends _ListItem {
 
 class _CardItem extends _ListItem {
   const _CardItem(this.data);
-  final Map<String, dynamic> data;
+  final SettlementItemDetail data;
 }
 
 class _ListTab extends ConsumerStatefulWidget {
@@ -318,17 +316,11 @@ class _ListTab extends ConsumerStatefulWidget {
 
 class _ListTabState extends ConsumerState<_ListTab> {
   final _scrollController = ScrollController();
-  String? _selectedStatus;
-  final _items = <Map<String, dynamic>>[];
-  bool _isLoading = false;
-  bool _hasMore = true;
-  static const _pageSize = 20;
 
   @override
   void initState() {
     super.initState();
     _scrollController.addListener(_onScroll);
-    unawaited(_loadMore());
   }
 
   @override
@@ -340,62 +332,19 @@ class _ListTabState extends ConsumerState<_ListTab> {
   void _onScroll() {
     if (_scrollController.position.pixels >=
         _scrollController.position.maxScrollExtent - 200) {
-      unawaited(_loadMore());
+      ref.read(settlementListControllerProvider.notifier).loadMore();
     }
   }
 
-  Future<void> _loadMore() async {
-    if (_isLoading || !_hasMore) return;
-    setState(() => _isLoading = true);
-    try {
-      final repo = ref.read(settlementRepositoryProvider);
-      final partner = await ref.read(currentPartnerInfoProvider.future);
-      final partnerId = partner?.id;
-      if (partnerId == null) {
-        if (mounted) setState(() => _isLoading = false);
-        return;
-      }
-      final newItems = await repo.getSettlementItems(
-        partnerId: partnerId,
-        status: _selectedStatus,
-        offset: _items.length,
-      );
-      if (mounted) {
-        setState(() {
-          _items.addAll(
-            newItems.map((e) => e.toJson()).toList(),
-          );
-          _hasMore = newItems.length == _pageSize;
-        });
-      }
-    } on Exception catch (e, st) {
-      Log.e('ListTab _loadMore error', e, st);
-    } finally {
-      if (mounted) setState(() => _isLoading = false);
-    }
-  }
-
-  void _onStatusChanged(String? status) {
-    setState(() {
-      _selectedStatus = status;
-      _items.clear();
-      _hasMore = true;
-    });
-    unawaited(_loadMore());
-  }
-
-  List<_ListItem> _buildViewList() {
+  List<_ListItem> _buildViewList(List<SettlementItemDetail> items) {
     final result = <_ListItem>[];
     String? lastMonth;
-    for (final item in _items) {
-      final raw = item['created_at'] as String?;
-      final dt = raw != null ? DateTime.tryParse(raw) : null;
-      if (dt != null) {
-        final label = '${dt.year}년 ${dt.month}월';
-        if (label != lastMonth) {
-          result.add(_MonthHeader(label));
-          lastMonth = label;
-        }
+    for (final item in items) {
+      final dt = item.createdAt;
+      final label = '${dt.year}년 ${dt.month}월';
+      if (label != lastMonth) {
+        result.add(_MonthHeader(label));
+        lastMonth = label;
       }
       result.add(_CardItem(item));
     }
@@ -404,35 +353,38 @@ class _ListTabState extends ConsumerState<_ListTab> {
 
   @override
   Widget build(BuildContext context) {
+    final listState = ref.watch(settlementListControllerProvider);
+
     return Column(
       children: [
         const SizedBox(height: 8),
         StatusFilterChips(
-          selectedStatus: _selectedStatus,
-          onStatusChanged: _onStatusChanged,
+          selectedStatus: listState.selectedStatus,
+          onStatusChanged: (status) => ref
+              .read(settlementListControllerProvider.notifier)
+              .changeStatus(status),
         ),
         const SizedBox(height: 8),
         Expanded(
-          child: _items.isEmpty && !_isLoading
+          child: listState.items.isEmpty && !listState.isLoading
               ? SettlementEmptyState(
                   title: '정산 항목이 없습니다',
-                  subtitle: _selectedStatus != null ? '다른 상태를 선택해 보세요.' : null,
+                  subtitle: listState.selectedStatus != null
+                      ? '다른 상태를 선택해 보세요.'
+                      : null,
                 )
               : RefreshIndicator(
-                  onRefresh: () async {
-                    setState(() {
-                      _items.clear();
-                      _hasMore = true;
-                    });
-                    await _loadMore();
-                  },
+                  onRefresh: () => ref
+                      .read(settlementListControllerProvider.notifier)
+                      .refresh(),
                   child: Builder(
                     builder: (context) {
-                      final viewList = _buildViewList();
+                      final viewList = _buildViewList(listState.items);
                       return ListView.builder(
                         controller: _scrollController,
                         physics: const AlwaysScrollableScrollPhysics(),
-                        itemCount: viewList.length + (_isLoading ? 1 : 0),
+                        itemCount:
+                            viewList.length + (listState.isLoading ? 1 : 0),
                         itemBuilder: (context, i) {
                           if (i >= viewList.length) {
                             return const Padding(
@@ -451,13 +403,12 @@ class _ListTabState extends ConsumerState<_ListTab> {
                               mainAxisSize: MainAxisSize.min,
                               children: [
                                 SettlementCard(
-                                  item: data,
-                                  onTap: () {
-                                    final id = data['id'] as String?;
-                                    if (id != null) {
-                                      SettlementDetailRoute(id: id).go(context);
-                                    }
-                                  },
+                                  item: data.toJson(),
+                                  onTap: () => ref
+                                      .read(
+                                        settlementCoordinatorProvider.notifier,
+                                      )
+                                      .goToDetail(data.id),
                                 ),
                                 const Divider(height: 1),
                               ],

--- a/apps/app_partner/lib/src/features/settlement/settlement_page.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_page.dart
@@ -3,6 +3,7 @@ import 'package:app_partner/src/features/settlement/settlement_dashboard_control
 import 'package:app_partner/src/features/settlement/settlement_list_controller.dart';
 import 'package:app_partner/src/features/settlement/widgets/settlement_card.dart';
 import 'package:app_partner/src/features/settlement/widgets/settlement_empty_state.dart';
+import 'package:app_partner/src/features/settlement/widgets/settlement_status_badge.dart';
 import 'package:app_partner/src/features/settlement/widgets/status_filter_chips.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -68,7 +69,7 @@ class _DashboardTab extends ConsumerWidget {
           .loadDashboard(),
       child: SingleChildScrollView(
         physics: const AlwaysScrollableScrollPhysics(),
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(MinglitSpacing.medium),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
@@ -78,11 +79,11 @@ class _DashboardTab extends ConsumerWidget {
                   .read(settlementDashboardControllerProvider.notifier)
                   .changeMonth(delta),
             ),
-            const SizedBox(height: 16),
+            const SizedBox(height: MinglitSpacing.medium),
             ...dashState.status.when(
               data: (_) => [
                 _RevenueSummaryCard(data: dashState.dashboardData),
-                const SizedBox(height: 16),
+                const SizedBox(height: MinglitSpacing.medium),
                 _StatusSummaryGrid(data: dashState.dashboardData),
               ],
               loading: () => [const Center(child: CircularProgressIndicator())],
@@ -94,12 +95,12 @@ class _DashboardTab extends ConsumerWidget {
                         '오류가 발생했습니다',
                         style: Theme.of(context).textTheme.bodyMedium,
                       ),
-                      const SizedBox(height: 8),
+                      const SizedBox(height: MinglitSpacing.small),
                       Text(
                         error.toString(),
                         style: Theme.of(context).textTheme.bodySmall,
                       ),
-                      const SizedBox(height: 16),
+                      const SizedBox(height: MinglitSpacing.medium),
                       FilledButton(
                         onPressed: () => ref
                             .read(
@@ -163,12 +164,12 @@ class _RevenueSummaryCard extends StatelessWidget {
 
     return Card(
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(MinglitSpacing.medium),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text('매출 요약', style: Theme.of(context).textTheme.titleSmall),
-            const SizedBox(height: 12),
+            const SizedBox(height: MinglitSpacing.sm),
             _DashRow('총 매출', '₩${fmt.format(totalGross)}'),
             _DashRow('총 수수료', '-₩${fmt.format(totalFees)}'),
             const Divider(),
@@ -195,7 +196,7 @@ class _DashRow extends StatelessWidget {
           ).textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold)
         : Theme.of(context).textTheme.bodyMedium;
     return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4),
+      padding: const EdgeInsets.symmetric(vertical: MinglitSpacing.xsmall),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
@@ -212,38 +213,43 @@ class _StatusSummaryGrid extends StatelessWidget {
 
   final Map<String, dynamic>? data;
 
-  static const _statuses = [
-    ('PENDING', '대기', Color(0xFF616161)),
-    ('READY', '확정', Color(0xFF1565C0)),
-    ('PROCESSING', '지급중', Color(0xFF283593)),
-    ('COMPLETED', '완료', Color(0xFF1B5E20)),
-    ('FAILED', '실패', Color(0xFFB71C1C)),
-    ('HOLD', '보류', Color(0xFFE65100)),
-    ('CANCELED', '취소', Color(0xFF9E9E9E)),
+  static final List<(String, String, SettlementStatus)> _statuses = [
+    ('PENDING', '대기', SettlementStatus.pending),
+    ('READY', '확정', SettlementStatus.ready),
+    ('PROCESSING', '지급중', SettlementStatus.processing),
+    ('COMPLETED', '완료', SettlementStatus.completed),
+    ('FAILED', '실패', SettlementStatus.failed),
+    ('HOLD', '보류', SettlementStatus.hold),
+    ('CANCELED', '취소', SettlementStatus.canceled),
   ];
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     final counts = data?['status_counts'] as Map<String, dynamic>? ?? {};
     return Card(
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(MinglitSpacing.medium),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text('상태별 현황', style: Theme.of(context).textTheme.titleSmall),
-            const SizedBox(height: 12),
+            const SizedBox(height: MinglitSpacing.sm),
             GridView.count(
               crossAxisCount: 4,
               shrinkWrap: true,
               physics: const NeverScrollableScrollPhysics(),
-              mainAxisSpacing: 8,
-              crossAxisSpacing: 8,
+              mainAxisSpacing: MinglitSpacing.small,
+              crossAxisSpacing: MinglitSpacing.small,
               childAspectRatio: 1.2,
               children: _statuses.map((s) {
-                final (status, label, color) = s;
+                final (status, label, statusEnum) = s;
                 final count = counts[status] as int? ?? 0;
-                return _StatusCell(label: label, count: count, color: color);
+                return _StatusCell(
+                  label: label,
+                  count: count,
+                  color: statusEnum.textColor(colorScheme),
+                );
               }).toList(),
             ),
           ],
@@ -269,7 +275,7 @@ class _StatusCell extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         color: color.withValues(alpha: 0.1),
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: BorderRadius.circular(MinglitRadius.small),
       ),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -357,14 +363,14 @@ class _ListTabState extends ConsumerState<_ListTab> {
 
     return Column(
       children: [
-        const SizedBox(height: 8),
+        const SizedBox(height: MinglitSpacing.small),
         StatusFilterChips(
           selectedStatus: listState.selectedStatus,
           onStatusChanged: (status) => ref
               .read(settlementListControllerProvider.notifier)
               .changeStatus(status),
         ),
-        const SizedBox(height: 8),
+        const SizedBox(height: MinglitSpacing.small),
         Expanded(
           child: listState.items.isEmpty && !listState.isLoading
               ? SettlementEmptyState(
@@ -388,7 +394,7 @@ class _ListTabState extends ConsumerState<_ListTab> {
                         itemBuilder: (context, i) {
                           if (i >= viewList.length) {
                             return const Padding(
-                              padding: EdgeInsets.all(16),
+                              padding: EdgeInsets.all(MinglitSpacing.medium),
                               child: Center(
                                 child: CircularProgressIndicator(),
                               ),
@@ -432,7 +438,12 @@ class _MonthHeaderWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+      padding: const EdgeInsets.fromLTRB(
+        MinglitSpacing.medium,
+        MinglitSpacing.medium,
+        MinglitSpacing.medium,
+        MinglitSpacing.xsmall,
+      ),
       child: Text(
         label,
         style: Theme.of(context).textTheme.labelMedium?.copyWith(

--- a/apps/app_partner/lib/src/features/settlement/widgets/settlement_status_badge.dart
+++ b/apps/app_partner/lib/src/features/settlement/widgets/settlement_status_badge.dart
@@ -7,7 +7,8 @@ enum SettlementStatus {
   processing,
   completed,
   failed,
-  canceled
+  canceled,
+  unknown
   ;
 
   static SettlementStatus fromString(String value) {
@@ -19,7 +20,7 @@ enum SettlementStatus {
       'COMPLETED' => SettlementStatus.completed,
       'FAILED' => SettlementStatus.failed,
       'CANCELED' => SettlementStatus.canceled,
-      _ => SettlementStatus.pending,
+      _ => SettlementStatus.unknown,
     };
   }
 
@@ -31,26 +32,29 @@ enum SettlementStatus {
     SettlementStatus.completed => '지급 완료',
     SettlementStatus.failed => '지급 실패',
     SettlementStatus.canceled => '취소',
+    SettlementStatus.unknown => '알 수 없음',
   };
 
-  Color get backgroundColor => switch (this) {
-    SettlementStatus.pending => const Color(0xFFE0E0E0),
-    SettlementStatus.hold => const Color(0xFFFFF3E0),
-    SettlementStatus.ready => const Color(0xFFE3F2FD),
-    SettlementStatus.processing => const Color(0xFFE8EAF6),
-    SettlementStatus.completed => const Color(0xFFE8F5E9),
-    SettlementStatus.failed => const Color(0xFFFFEBEE),
-    SettlementStatus.canceled => const Color(0xFFF5F5F5),
+  Color backgroundColor(ColorScheme colorScheme) => switch (this) {
+    SettlementStatus.pending => colorScheme.surfaceContainerHighest,
+    SettlementStatus.hold => colorScheme.errorContainer,
+    SettlementStatus.ready => colorScheme.primaryContainer,
+    SettlementStatus.processing => colorScheme.secondaryContainer,
+    SettlementStatus.completed => colorScheme.tertiaryContainer,
+    SettlementStatus.failed => colorScheme.errorContainer,
+    SettlementStatus.canceled => colorScheme.surfaceContainerLow,
+    SettlementStatus.unknown => colorScheme.surfaceContainerHighest,
   };
 
-  Color get textColor => switch (this) {
-    SettlementStatus.pending => const Color(0xFF616161),
-    SettlementStatus.hold => const Color(0xFFE65100),
-    SettlementStatus.ready => const Color(0xFF1565C0),
-    SettlementStatus.processing => const Color(0xFF283593),
-    SettlementStatus.completed => const Color(0xFF1B5E20),
-    SettlementStatus.failed => const Color(0xFFB71C1C),
-    SettlementStatus.canceled => const Color(0xFF9E9E9E),
+  Color textColor(ColorScheme colorScheme) => switch (this) {
+    SettlementStatus.pending => colorScheme.onSurfaceVariant,
+    SettlementStatus.hold => colorScheme.error,
+    SettlementStatus.ready => colorScheme.primary,
+    SettlementStatus.processing => colorScheme.secondary,
+    SettlementStatus.completed => colorScheme.tertiary,
+    SettlementStatus.failed => colorScheme.error,
+    SettlementStatus.canceled => colorScheme.outline,
+    SettlementStatus.unknown => colorScheme.onSurfaceVariant,
   };
 }
 
@@ -66,14 +70,17 @@ class SettlementStatusBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     final isStrikethrough = status == SettlementStatus.canceled;
+    final bgColor = status.backgroundColor(colorScheme);
+    final textCol = status.textColor(colorScheme);
     return Container(
       padding: EdgeInsets.symmetric(
         horizontal: compact ? 8 : 12,
         vertical: compact ? 2 : 4,
       ),
       decoration: BoxDecoration(
-        color: status.backgroundColor,
+        color: bgColor,
         borderRadius: BorderRadius.circular(4),
       ),
       child: Text(
@@ -81,9 +88,9 @@ class SettlementStatusBadge extends StatelessWidget {
         style: TextStyle(
           fontSize: compact ? 11 : 13,
           fontWeight: FontWeight.w600,
-          color: status.textColor,
+          color: textCol,
           decoration: isStrikethrough ? TextDecoration.lineThrough : null,
-          decorationColor: isStrikethrough ? status.textColor : null,
+          decorationColor: isStrikethrough ? textCol : null,
         ),
       ),
     );

--- a/apps/app_partner/lib/src/features/settlement/widgets/status_filter_chips.dart
+++ b/apps/app_partner/lib/src/features/settlement/widgets/status_filter_chips.dart
@@ -28,10 +28,10 @@ class StatusFilterChips extends StatelessWidget {
       height: 40,
       child: ListView.separated(
         scrollDirection: Axis.horizontal,
-        padding: EdgeInsets.symmetric(horizontal: MinglitSpacing.medium),
+        padding: const EdgeInsets.symmetric(horizontal: MinglitSpacing.medium),
         itemCount: _statuses.length,
         separatorBuilder: (context, index) =>
-            SizedBox(width: MinglitSpacing.small),
+            const SizedBox(width: MinglitSpacing.small),
         itemBuilder: (context, i) {
           final (status, label) = _statuses[i];
           final isSelected = selectedStatus == status;

--- a/apps/app_partner/lib/src/features/settlement/widgets/status_filter_chips.dart
+++ b/apps/app_partner/lib/src/features/settlement/widgets/status_filter_chips.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
 
 class StatusFilterChips extends StatelessWidget {
   const StatusFilterChips({
@@ -27,9 +28,10 @@ class StatusFilterChips extends StatelessWidget {
       height: 40,
       child: ListView.separated(
         scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.symmetric(horizontal: 16),
+        padding: EdgeInsets.symmetric(horizontal: MinglitSpacing.medium),
         itemCount: _statuses.length,
-        separatorBuilder: (context, index) => const SizedBox(width: 8),
+        separatorBuilder: (context, index) =>
+            SizedBox(width: MinglitSpacing.small),
         itemBuilder: (context, i) {
           final (status, label) = _statuses[i];
           final isSelected = selectedStatus == status;

--- a/apps/app_partner/test/src/features/settlement/settlement_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/settlement/settlement_coordinator_test.dart
@@ -1,6 +1,5 @@
 import 'package:app_partner/src/features/settlement/settlement_coordinator.dart';
 import 'package:app_partner/src/routing/app_router.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -9,11 +8,9 @@ import '../../../utils/test_utils.dart';
 
 void main() {
   late MockGoRouter mockRouter;
-  late MockSettlementRepository mockSettlementRepository;
 
   setUp(() {
     mockRouter = MockGoRouter();
-    mockSettlementRepository = MockSettlementRepository();
     when(() => mockRouter.go(any())).thenReturn(null);
     when(() => mockRouter.push(any())).thenAnswer((_) => Future.value());
   });
@@ -75,13 +72,4 @@ void main() {
     // Unit testing this method would require mocking the entire Material framework.
     // Consider testing retryPayout in integration tests or widget tests instead.
   });
-}
-
-// Mock BuildContext for testing retryPayout
-class _MockBuildContext extends Mock implements BuildContext {
-  @override
-  bool get mounted => true;
-
-  @override
-  Widget get widget => const SizedBox();
 }

--- a/apps/app_partner/test/src/features/settlement/settlement_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/settlement/settlement_coordinator_test.dart
@@ -1,6 +1,8 @@
 import 'package:app_partner/src/features/settlement/settlement_coordinator.dart';
 import 'package:app_partner/src/routing/app_router.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../utils/mocks.dart';
@@ -8,10 +10,13 @@ import '../../../utils/test_utils.dart';
 
 void main() {
   late MockGoRouter mockRouter;
+  late MockSettlementRepository mockSettlementRepository;
 
   setUp(() {
     mockRouter = MockGoRouter();
+    mockSettlementRepository = MockSettlementRepository();
     when(() => mockRouter.go(any())).thenReturn(null);
+    when(() => mockRouter.push(any())).thenAnswer((_) => Future.value(null));
   });
 
   group('SettlementCoordinator', () {
@@ -39,5 +44,45 @@ void main() {
 
       verify(() => mockRouter.go(any())).called(1);
     });
+
+    test('goToDetail calls router.push with settlement detail route', () {
+      final container = createContainer(
+        overrides: [
+          goRouterProvider.overrideWithValue(mockRouter),
+        ],
+      );
+
+      container
+          .read(settlementCoordinatorProvider.notifier)
+          .goToDetail('test-item-id');
+
+      verify(() => mockRouter.push(any())).called(1);
+    });
+
+    test('goToBankAccount calls router.push with bank account route', () {
+      final container = createContainer(
+        overrides: [
+          goRouterProvider.overrideWithValue(mockRouter),
+        ],
+      );
+
+      container.read(settlementCoordinatorProvider.notifier).goToBankAccount();
+
+      verify(() => mockRouter.push(any())).called(1);
+    });
+
+    // Note: retryPayout testing requires widget test context because it calls
+    // context.showMinglitSuccess() and handleMinglitError() which need Material context.
+    // Unit testing this method would require mocking the entire Material framework.
+    // Consider testing retryPayout in integration tests or widget tests instead.
   });
+}
+
+// Mock BuildContext for testing retryPayout
+class _MockBuildContext extends Mock implements BuildContext {
+  @override
+  bool get mounted => true;
+
+  @override
+  Widget get widget => const SizedBox();
 }

--- a/apps/app_partner/test/src/features/settlement/settlement_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/settlement/settlement_coordinator_test.dart
@@ -2,7 +2,6 @@ import 'package:app_partner/src/features/settlement/settlement_coordinator.dart'
 import 'package:app_partner/src/routing/app_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../utils/mocks.dart';
@@ -16,7 +15,7 @@ void main() {
     mockRouter = MockGoRouter();
     mockSettlementRepository = MockSettlementRepository();
     when(() => mockRouter.go(any())).thenReturn(null);
-    when(() => mockRouter.push(any())).thenAnswer((_) => Future.value(null));
+    when(() => mockRouter.push(any())).thenAnswer((_) => Future.value());
   });
 
   group('SettlementCoordinator', () {

--- a/apps/app_partner/test/src/features/settlement/settlement_dashboard_controller_test.dart
+++ b/apps/app_partner/test/src/features/settlement/settlement_dashboard_controller_test.dart
@@ -1,0 +1,211 @@
+import 'package:app_partner/src/features/party/party_providers.dart';
+import 'package:app_partner/src/features/settlement/settlement_dashboard_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../utils/mocks.dart';
+import '../../../utils/test_utils.dart';
+
+/// Waits for all pending microtasks and async operations to complete.
+Future<void> pump() async {
+  await Future<void>.delayed(const Duration(milliseconds: 50));
+}
+
+void main() {
+  late MockSettlementRepository mockRepo;
+  late Partner fakePartner;
+
+  setUp(() {
+    mockRepo = MockSettlementRepository();
+    fakePartner = const Partner(id: 'partner-1', name: 'Test Partner');
+  });
+
+  ProviderContainer makeContainer({
+    Partner? partner,
+    bool nullPartner = false,
+    Map<String, dynamic>? dashboardData,
+    Exception? dashboardError,
+  }) {
+    final resolvedPartner = nullPartner ? null : (partner ?? fakePartner);
+
+    if (dashboardError != null) {
+      when(
+        () => mockRepo.getSettlementDashboard(
+          partnerId: any(named: 'partnerId'),
+          periodStart: any(named: 'periodStart'),
+          periodEnd: any(named: 'periodEnd'),
+        ),
+      ).thenThrow(dashboardError);
+    } else {
+      when(
+        () => mockRepo.getSettlementDashboard(
+          partnerId: any(named: 'partnerId'),
+          periodStart: any(named: 'periodStart'),
+          periodEnd: any(named: 'periodEnd'),
+        ),
+      ).thenAnswer((_) async => dashboardData ?? {'total_items': 0});
+    }
+
+    return createContainer(
+      overrides: [
+        settlementRepositoryProvider.overrideWithValue(mockRepo),
+        currentPartnerInfoProvider.overrideWith(
+          (ref) async => resolvedPartner,
+        ),
+      ],
+    );
+  }
+
+  group('SettlementDashboardController', () {
+    test('initial state has current month as selectedMonth', () async {
+      final container = makeContainer();
+      // Listen to keep provider alive during async microtask
+      final sub = container.listen(
+        settlementDashboardControllerProvider,
+        (_, __) {},
+      );
+      addTearDown(sub.close);
+
+      final state = container.read(settlementDashboardControllerProvider);
+      final now = DateTime.now();
+      expect(state.selectedMonth.year, now.year);
+      expect(state.selectedMonth.month, now.month);
+      expect(state.selectedMonth.day, 1);
+
+      await pump();
+    });
+
+    test('initial state has loading status', () async {
+      final container = makeContainer();
+      final sub = container.listen(
+        settlementDashboardControllerProvider,
+        (_, __) {},
+      );
+      addTearDown(sub.close);
+
+      final state = container.read(settlementDashboardControllerProvider);
+      expect(state.status, isA<AsyncLoading>());
+
+      await pump();
+    });
+
+    test('loadDashboard success populates dashboardData', () async {
+      final data = {
+        'status_counts': {'COMPLETED': 3},
+        'completed_net_total': 90000,
+        'total_items': 3,
+      };
+      final container = makeContainer(dashboardData: data);
+      final sub = container.listen(
+        settlementDashboardControllerProvider,
+        (_, __) {},
+      );
+      addTearDown(sub.close);
+
+      // Trigger build
+      container.read(settlementDashboardControllerProvider);
+
+      // Wait for microtask + async to complete
+      await pump();
+
+      final state = container.read(settlementDashboardControllerProvider);
+      expect(state.status, isA<AsyncData>());
+      expect(state.dashboardData, equals(data));
+    });
+
+    test('loadDashboard error sets error status', () async {
+      final error = Exception('network error');
+      final container = makeContainer(dashboardError: error);
+      final sub = container.listen(
+        settlementDashboardControllerProvider,
+        (_, __) {},
+      );
+      addTearDown(sub.close);
+
+      container.read(settlementDashboardControllerProvider);
+      await pump();
+
+      final state = container.read(settlementDashboardControllerProvider);
+      expect(state.status, isA<AsyncError>());
+      expect(state.dashboardData, isNull);
+    });
+
+    test(
+      'loadDashboard with null partner sets data status without loading',
+      () async {
+        final container = makeContainer(nullPartner: true);
+        final sub = container.listen(
+          settlementDashboardControllerProvider,
+          (_, __) {},
+        );
+        addTearDown(sub.close);
+
+        container.read(settlementDashboardControllerProvider);
+        await pump();
+
+        final state = container.read(settlementDashboardControllerProvider);
+        expect(state.status, isA<AsyncData>());
+        expect(state.dashboardData, isNull);
+      },
+    );
+
+    test('changeMonth updates selectedMonth and reloads', () async {
+      final container = makeContainer();
+      final sub = container.listen(
+        settlementDashboardControllerProvider,
+        (_, __) {},
+      );
+      addTearDown(sub.close);
+
+      container.read(settlementDashboardControllerProvider);
+      await pump();
+
+      final now = DateTime.now();
+      final expectedMonth = DateTime(now.year, now.month + 1);
+
+      container
+          .read(settlementDashboardControllerProvider.notifier)
+          .changeMonth(1);
+
+      final stateAfterChange = container.read(
+        settlementDashboardControllerProvider,
+      );
+      expect(stateAfterChange.selectedMonth, equals(expectedMonth));
+      expect(stateAfterChange.dashboardData, isNull);
+
+      // Wait for reload
+      await pump();
+
+      final stateAfterReload = container.read(
+        settlementDashboardControllerProvider,
+      );
+      expect(stateAfterReload.status, isA<AsyncData>());
+    });
+
+    test('changeMonth with negative delta goes to previous month', () async {
+      final container = makeContainer();
+      final sub = container.listen(
+        settlementDashboardControllerProvider,
+        (_, __) {},
+      );
+      addTearDown(sub.close);
+
+      container.read(settlementDashboardControllerProvider);
+      await pump();
+
+      final now = DateTime.now();
+      final expectedMonth = DateTime(now.year, now.month - 1);
+
+      container
+          .read(settlementDashboardControllerProvider.notifier)
+          .changeMonth(-1);
+
+      final state = container.read(settlementDashboardControllerProvider);
+      expect(state.selectedMonth, equals(expectedMonth));
+
+      await pump();
+    });
+  });
+}

--- a/apps/app_partner/test/src/features/settlement/settlement_dashboard_controller_test.dart
+++ b/apps/app_partner/test/src/features/settlement/settlement_dashboard_controller_test.dart
@@ -1,6 +1,5 @@
 import 'package:app_partner/src/features/party/party_providers.dart';
 import 'package:app_partner/src/features/settlement/settlement_dashboard_controller.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
@@ -64,7 +63,7 @@ void main() {
       // Listen to keep provider alive during async microtask
       final sub = container.listen(
         settlementDashboardControllerProvider,
-        (_, __) {},
+        (_, _) {},
       );
       addTearDown(sub.close);
 
@@ -81,7 +80,7 @@ void main() {
       final container = makeContainer();
       final sub = container.listen(
         settlementDashboardControllerProvider,
-        (_, __) {},
+        (_, _) {},
       );
       addTearDown(sub.close);
 
@@ -100,7 +99,7 @@ void main() {
       final container = makeContainer(dashboardData: data);
       final sub = container.listen(
         settlementDashboardControllerProvider,
-        (_, __) {},
+        (_, _) {},
       );
       addTearDown(sub.close);
 
@@ -120,7 +119,7 @@ void main() {
       final container = makeContainer(dashboardError: error);
       final sub = container.listen(
         settlementDashboardControllerProvider,
-        (_, __) {},
+        (_, _) {},
       );
       addTearDown(sub.close);
 
@@ -138,7 +137,7 @@ void main() {
         final container = makeContainer(nullPartner: true);
         final sub = container.listen(
           settlementDashboardControllerProvider,
-          (_, __) {},
+          (_, _) {},
         );
         addTearDown(sub.close);
 
@@ -155,7 +154,7 @@ void main() {
       final container = makeContainer();
       final sub = container.listen(
         settlementDashboardControllerProvider,
-        (_, __) {},
+        (_, _) {},
       );
       addTearDown(sub.close);
 
@@ -188,7 +187,7 @@ void main() {
       final container = makeContainer();
       final sub = container.listen(
         settlementDashboardControllerProvider,
-        (_, __) {},
+        (_, _) {},
       );
       addTearDown(sub.close);
 

--- a/apps/app_partner/test/src/features/settlement/settlement_dashboard_controller_test.dart
+++ b/apps/app_partner/test/src/features/settlement/settlement_dashboard_controller_test.dart
@@ -85,7 +85,7 @@ void main() {
       addTearDown(sub.close);
 
       final state = container.read(settlementDashboardControllerProvider);
-      expect(state.status, isA<AsyncLoading>());
+      expect(state.status, isA<AsyncLoading<void>>());
 
       await pump();
     });
@@ -110,7 +110,7 @@ void main() {
       await pump();
 
       final state = container.read(settlementDashboardControllerProvider);
-      expect(state.status, isA<AsyncData>());
+      expect(state.status, isA<AsyncData<void>>());
       expect(state.dashboardData, equals(data));
     });
 
@@ -127,7 +127,7 @@ void main() {
       await pump();
 
       final state = container.read(settlementDashboardControllerProvider);
-      expect(state.status, isA<AsyncError>());
+      expect(state.status, isA<AsyncError<void>>());
       expect(state.dashboardData, isNull);
     });
 
@@ -145,7 +145,7 @@ void main() {
         await pump();
 
         final state = container.read(settlementDashboardControllerProvider);
-        expect(state.status, isA<AsyncData>());
+        expect(state.status, isA<AsyncData<void>>());
         expect(state.dashboardData, isNull);
       },
     );
@@ -180,7 +180,7 @@ void main() {
       final stateAfterReload = container.read(
         settlementDashboardControllerProvider,
       );
-      expect(stateAfterReload.status, isA<AsyncData>());
+      expect(stateAfterReload.status, isA<AsyncData<void>>());
     });
 
     test('changeMonth with negative delta goes to previous month', () async {

--- a/apps/app_partner/test/src/features/settlement/settlement_list_controller_test.dart
+++ b/apps/app_partner/test/src/features/settlement/settlement_list_controller_test.dart
@@ -1,6 +1,5 @@
 import 'package:app_partner/src/features/party/party_providers.dart';
 import 'package:app_partner/src/features/settlement/settlement_list_controller.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
@@ -86,7 +85,7 @@ void main() {
       final container = makeContainer();
       final sub = container.listen(
         settlementListControllerProvider,
-        (_, __) {},
+        (_, _) {},
       );
       addTearDown(sub.close);
 
@@ -104,7 +103,7 @@ void main() {
       final container = makeContainer(items: items);
       final sub = container.listen(
         settlementListControllerProvider,
-        (_, __) {},
+        (_, _) {},
       );
       addTearDown(sub.close);
 
@@ -125,7 +124,7 @@ void main() {
         final container = makeContainer(items: items);
         final sub = container.listen(
           settlementListControllerProvider,
-          (_, __) {},
+          (_, _) {},
         );
         addTearDown(sub.close);
 
@@ -142,7 +141,7 @@ void main() {
       final container = makeContainer(loadError: error);
       final sub = container.listen(
         settlementListControllerProvider,
-        (_, __) {},
+        (_, _) {},
       );
       addTearDown(sub.close);
 
@@ -159,7 +158,7 @@ void main() {
       final container = makeContainer(nullPartner: true);
       final sub = container.listen(
         settlementListControllerProvider,
-        (_, __) {},
+        (_, _) {},
       );
       addTearDown(sub.close);
 
@@ -177,7 +176,7 @@ void main() {
       final container = makeContainer(items: items);
       final sub = container.listen(
         settlementListControllerProvider,
-        (_, __) {},
+        (_, _) {},
       );
       addTearDown(sub.close);
 
@@ -212,7 +211,7 @@ void main() {
       final container = makeContainer();
       final sub = container.listen(
         settlementListControllerProvider,
-        (_, __) {},
+        (_, _) {},
       );
       addTearDown(sub.close);
 
@@ -238,7 +237,7 @@ void main() {
       final container = makeContainer(items: items);
       final sub = container.listen(
         settlementListControllerProvider,
-        (_, __) {},
+        (_, _) {},
       );
       addTearDown(sub.close);
 

--- a/apps/app_partner/test/src/features/settlement/settlement_list_controller_test.dart
+++ b/apps/app_partner/test/src/features/settlement/settlement_list_controller_test.dart
@@ -1,0 +1,261 @@
+import 'package:app_partner/src/features/party/party_providers.dart';
+import 'package:app_partner/src/features/settlement/settlement_list_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../utils/mocks.dart';
+import '../../../utils/test_utils.dart';
+
+/// Waits for all pending microtasks and async operations to complete.
+Future<void> pump() async {
+  await Future<void>.delayed(const Duration(milliseconds: 50));
+}
+
+SettlementItemDetail _makeItem(String id) {
+  final now = DateTime.now();
+  return SettlementItemDetail(
+    id: id,
+    partnerId: 'partner-1',
+    status: 'PENDING',
+    grossAmount: 10000,
+    platformFeeAmount: 500,
+    pgFeeAmount: 200,
+    vatAmount: 100,
+    netAmount: 9200,
+    currency: 'KRW',
+    createdAt: now,
+    updatedAt: now,
+    retryable: false,
+    retryCount: 0,
+    histories: [],
+    adjustments: [],
+  );
+}
+
+void main() {
+  late MockSettlementRepository mockRepo;
+  late Partner fakePartner;
+
+  setUp(() {
+    mockRepo = MockSettlementRepository();
+    fakePartner = const Partner(id: 'partner-1', name: 'Test Partner');
+  });
+
+  ProviderContainer makeContainer({
+    Partner? partner,
+    bool nullPartner = false,
+    List<SettlementItemDetail>? items,
+    Exception? loadError,
+  }) {
+    final resolvedPartner = nullPartner ? null : (partner ?? fakePartner);
+
+    if (loadError != null) {
+      when(
+        () => mockRepo.getSettlementItems(
+          partnerId: any(named: 'partnerId'),
+          status: any(named: 'status'),
+          offset: any(named: 'offset'),
+          limit: any(named: 'limit'),
+        ),
+      ).thenThrow(loadError);
+    } else {
+      when(
+        () => mockRepo.getSettlementItems(
+          partnerId: any(named: 'partnerId'),
+          status: any(named: 'status'),
+          offset: any(named: 'offset'),
+          limit: any(named: 'limit'),
+        ),
+      ).thenAnswer((_) async => items ?? []);
+    }
+
+    return createContainer(
+      overrides: [
+        settlementRepositoryProvider.overrideWithValue(mockRepo),
+        currentPartnerInfoProvider.overrideWith(
+          (ref) async => resolvedPartner,
+        ),
+      ],
+    );
+  }
+
+  group('SettlementListController', () {
+    test('initial state has empty items and isLoading false', () async {
+      final container = makeContainer();
+      final sub = container.listen(
+        settlementListControllerProvider,
+        (_, __) {},
+      );
+      addTearDown(sub.close);
+
+      final state = container.read(settlementListControllerProvider);
+      expect(state.items, isEmpty);
+      expect(state.isLoading, isFalse);
+      expect(state.selectedStatus, isNull);
+      expect(state.hasMore, isTrue);
+
+      await pump();
+    });
+
+    test('loadMore success adds items to state', () async {
+      final items = [_makeItem('item-1'), _makeItem('item-2')];
+      final container = makeContainer(items: items);
+      final sub = container.listen(
+        settlementListControllerProvider,
+        (_, __) {},
+      );
+      addTearDown(sub.close);
+
+      container.read(settlementListControllerProvider);
+      await pump();
+
+      final state = container.read(settlementListControllerProvider);
+      expect(state.items.length, 2);
+      expect(state.items.first.id, 'item-1');
+      expect(state.isLoading, isFalse);
+      expect(state.error, isNull);
+    });
+
+    test(
+      'loadMore with fewer than pageSize items sets hasMore to false',
+      () async {
+        final items = List.generate(5, (i) => _makeItem('item-$i'));
+        final container = makeContainer(items: items);
+        final sub = container.listen(
+          settlementListControllerProvider,
+          (_, __) {},
+        );
+        addTearDown(sub.close);
+
+        container.read(settlementListControllerProvider);
+        await pump();
+
+        final state = container.read(settlementListControllerProvider);
+        expect(state.hasMore, isFalse);
+      },
+    );
+
+    test('loadMore error sets error field', () async {
+      final error = Exception('fetch failed');
+      final container = makeContainer(loadError: error);
+      final sub = container.listen(
+        settlementListControllerProvider,
+        (_, __) {},
+      );
+      addTearDown(sub.close);
+
+      container.read(settlementListControllerProvider);
+      await pump();
+
+      final state = container.read(settlementListControllerProvider);
+      expect(state.error, isNotNull);
+      expect(state.isLoading, isFalse);
+      expect(state.items, isEmpty);
+    });
+
+    test('loadMore with null partner stops loading without error', () async {
+      final container = makeContainer(nullPartner: true);
+      final sub = container.listen(
+        settlementListControllerProvider,
+        (_, __) {},
+      );
+      addTearDown(sub.close);
+
+      container.read(settlementListControllerProvider);
+      await pump();
+
+      final state = container.read(settlementListControllerProvider);
+      expect(state.isLoading, isFalse);
+      expect(state.error, isNull);
+      expect(state.items, isEmpty);
+    });
+
+    test('changeStatus resets items and changes filter', () async {
+      final items = [_makeItem('item-1')];
+      final container = makeContainer(items: items);
+      final sub = container.listen(
+        settlementListControllerProvider,
+        (_, __) {},
+      );
+      addTearDown(sub.close);
+
+      // Initial load
+      container.read(settlementListControllerProvider);
+      await pump();
+
+      expect(
+        container.read(settlementListControllerProvider).items.length,
+        1,
+      );
+
+      // Change status — should reset items
+      container
+          .read(settlementListControllerProvider.notifier)
+          .changeStatus('COMPLETED');
+
+      final stateAfterChange = container.read(settlementListControllerProvider);
+      expect(stateAfterChange.selectedStatus, 'COMPLETED');
+      expect(stateAfterChange.items, isEmpty);
+      expect(stateAfterChange.hasMore, isTrue);
+      expect(stateAfterChange.error, isNull);
+
+      // Wait for reload
+      await pump();
+
+      final stateAfterReload = container.read(settlementListControllerProvider);
+      expect(stateAfterReload.isLoading, isFalse);
+    });
+
+    test('changeStatus to null clears filter', () async {
+      final container = makeContainer();
+      final sub = container.listen(
+        settlementListControllerProvider,
+        (_, __) {},
+      );
+      addTearDown(sub.close);
+
+      container.read(settlementListControllerProvider);
+      await pump();
+
+      container
+          .read(settlementListControllerProvider.notifier)
+          .changeStatus('PENDING');
+      await pump();
+
+      container
+          .read(settlementListControllerProvider.notifier)
+          .changeStatus(null);
+      await pump();
+
+      final state = container.read(settlementListControllerProvider);
+      expect(state.selectedStatus, isNull);
+    });
+
+    test('refresh resets items and reloads', () async {
+      final items = [_makeItem('item-1'), _makeItem('item-2')];
+      final container = makeContainer(items: items);
+      final sub = container.listen(
+        settlementListControllerProvider,
+        (_, __) {},
+      );
+      addTearDown(sub.close);
+
+      container.read(settlementListControllerProvider);
+      await pump();
+
+      expect(
+        container.read(settlementListControllerProvider).items.length,
+        2,
+      );
+
+      await container.read(settlementListControllerProvider.notifier).refresh();
+
+      final state = container.read(settlementListControllerProvider);
+      expect(state.items.length, 2);
+      expect(state.isLoading, isFalse);
+      expect(state.error, isNull);
+    });
+  });
+}

--- a/apps/app_partner/test/utils/mocks.dart
+++ b/apps/app_partner/test/utils/mocks.dart
@@ -14,3 +14,5 @@ class MockVerificationRepository extends Mock
     implements VerificationRepository {}
 
 class MockUserRepository extends Mock implements UserRepository {}
+
+class MockSettlementRepository extends Mock implements SettlementRepository {}

--- a/shared/packages/minglit_kit/lib/src/data/repositories/settlement_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/settlement_repository.dart
@@ -230,4 +230,108 @@ class SettlementRepository {
       rethrow;
     }
   }
+
+  /// Fetches bank account info for a partner.
+  ///
+  /// Returns null if the partner settlement record is not found.
+  Future<Map<String, dynamic>?> getBankAccount(String partnerId) async {
+    Log.d('getBankAccount called | partnerId: $partnerId');
+    try {
+      final data = await _supabase
+          .from('partner_settlements')
+          .select('bank_name, account_holder, account_number')
+          .eq('partner_id', partnerId)
+          .maybeSingle();
+
+      if (data == null) {
+        Log.d('getBankAccount | not found: $partnerId');
+        return null;
+      }
+
+      Log.d('getBankAccount success | bankName: ${data['bank_name']}');
+      return data;
+    } catch (e, st) {
+      Log.e('❌ [SettlementRepo] getBankAccount Error', e, st);
+      rethrow;
+    }
+  }
+
+  /// Upserts bank account info for a partner.
+  ///
+  /// Creates or updates the bank account record in partner_settlements table.
+  Future<void> upsertBankAccount({
+    required String partnerId,
+    required String bankName,
+    required String accountHolder,
+    required String accountNumber,
+  }) async {
+    Log.d(
+      'upsertBankAccount called | partnerId: $partnerId, bankName: $bankName',
+    );
+    try {
+      await _supabase.from('partner_settlements').upsert({
+        'partner_id': partnerId,
+        'bank_name': bankName,
+        'account_holder': accountHolder,
+        'account_number': accountNumber,
+      }, onConflict: 'partner_id');
+
+      Log.d('upsertBankAccount success | partnerId: $partnerId');
+    } catch (e, st) {
+      Log.e('❌ [SettlementRepo] upsertBankAccount Error', e, st);
+      rethrow;
+    }
+  }
+
+  /// Fetches full partner settlement info for display.
+  ///
+  /// Returns null if the partner settlement record is not found.
+  Future<Map<String, dynamic>?> getPartnerSettlementInfo(
+    String partnerId,
+  ) async {
+    Log.d('getPartnerSettlementInfo called | partnerId: $partnerId');
+    try {
+      final data = await _supabase
+          .from('partner_settlements')
+          .select()
+          .eq('partner_id', partnerId)
+          .maybeSingle();
+
+      if (data == null) {
+        Log.d('getPartnerSettlementInfo | not found: $partnerId');
+        return null;
+      }
+
+      Log.d('getPartnerSettlementInfo success | partnerId: $partnerId');
+      return data;
+    } catch (e, st) {
+      Log.e('❌ [SettlementRepo] getPartnerSettlementInfo Error', e, st);
+      rethrow;
+    }
+  }
+
+  /// Requests a retry payout via RPC.
+  ///
+  /// Calls the request_retry_payout RPC function to retry a failed payout.
+  Future<Map<String, dynamic>> retryPayout({
+    required String payoutId,
+    required String partnerId,
+  }) async {
+    Log.d('retryPayout called | payoutId: $payoutId, partnerId: $partnerId');
+    try {
+      final result = await _supabase.rpc<Map<String, dynamic>>(
+        'request_retry_payout',
+        params: {
+          'p_payout_id': payoutId,
+          'p_partner_id': partnerId,
+        },
+      );
+
+      Log.d('retryPayout success | payoutId: $payoutId');
+      return result;
+    } catch (e, st) {
+      Log.e('❌ [SettlementRepo] retryPayout Error', e, st);
+      rethrow;
+    }
+  }
 }

--- a/shared/packages/minglit_kit/test/src/data/repositories/settlement_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/settlement_repository_test.dart
@@ -133,7 +133,7 @@ void main() {
       });
 
       test('returns null when item not found', () async {
-        mockTable(mockClient, 'settlement_items', maybeSingleData: null);
+        mockTable(mockClient, 'settlement_items');
         // Other tables won't be queried when item is null.
 
         final result = await repository.getSettlementItemDetail('nonexistent');
@@ -276,7 +276,7 @@ void main() {
       });
 
       test('returns null when event not found', () async {
-        mockTable(mockClient, 'events', maybeSingleData: null);
+        mockTable(mockClient, 'events');
 
         final result = await repository.getEventInfo('nonexistent');
 
@@ -321,7 +321,7 @@ void main() {
       });
 
       test('returns null when not found', () async {
-        mockTable(mockClient, 'partner_settlements', maybeSingleData: null);
+        mockTable(mockClient, 'partner_settlements');
 
         final result = await repository.getBankAccount('partner_1');
 
@@ -405,7 +405,7 @@ void main() {
       });
 
       test('returns null when not found', () async {
-        mockTable(mockClient, 'partner_settlements', maybeSingleData: null);
+        mockTable(mockClient, 'partner_settlements');
 
         final result = await repository.getPartnerSettlementInfo('partner_1');
 

--- a/shared/packages/minglit_kit/test/src/data/repositories/settlement_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/settlement_repository_test.dart
@@ -1,0 +1,469 @@
+import 'dart:async' show FutureOr;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/data/models/settlement_item_detail.dart';
+import 'package:minglit_kit/src/data/repositories/settlement_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../../helpers/mocks.dart';
+import '../../../helpers/supabase_mock_helpers.dart';
+
+/// Fake RPC result builder that resolves to [_data] when awaited.
+class _FakeRpcResult<T> extends Fake implements PostgrestFilterBuilder<T> {
+  _FakeRpcResult(this._data);
+  final T _data;
+
+  @override
+  Future<U> then<U>(
+    FutureOr<U> Function(T) onValue, {
+    Function? onError,
+  }) {
+    return Future<T>.value(_data).then(onValue, onError: onError);
+  }
+}
+
+/// Minimal valid settlement item JSON for use in tests.
+Map<String, dynamic> _settlementItemJson({String id = 'item_1'}) => {
+  'id': id,
+  'partner_id': 'partner_1',
+  'event_id': null,
+  'status': 'PENDING',
+  'gross_amount': 10000,
+  'platform_fee_amount': 500,
+  'pg_fee_amount': 200,
+  'vat_amount': 50,
+  'net_amount': 9250,
+  'currency': 'KRW',
+  'hold_reason_code': null,
+  'hold_reason_detail': null,
+  'failure_reason_code': null,
+  'failure_message': null,
+  'settlement_period_start': null,
+  'settlement_period_end': null,
+  'processing_started_at': null,
+  'processing_ended_at': null,
+  'created_at': '2026-01-01T00:00:00.000Z',
+  'updated_at': '2026-01-01T00:00:00.000Z',
+  'payout_id': null,
+  'retryable': false,
+  'retry_count': 0,
+};
+
+void main() {
+  late MockSupabaseClient mockClient;
+  late SettlementRepository repository;
+
+  setUp(() {
+    mockClient = createMockSupabase();
+    repository = SettlementRepository(supabase: mockClient);
+  });
+
+  group('SettlementRepository', () {
+    // -------------------------------------------------------------------------
+    // getSettlementItems
+    // -------------------------------------------------------------------------
+    group('getSettlementItems', () {
+      test('returns list of SettlementItemDetail', () async {
+        mockTable(
+          mockClient,
+          'settlement_items',
+          selectData: [_settlementItemJson()],
+        );
+
+        final result = await repository.getSettlementItems(
+          partnerId: 'partner_1',
+        );
+
+        expect(result, hasLength(1));
+        expect(result.first, isA<SettlementItemDetail>());
+        expect(result.first.id, 'item_1');
+        expect(result.first.partnerId, 'partner_1');
+      });
+
+      test('returns empty list when no items', () async {
+        mockTable(mockClient, 'settlement_items', selectData: []);
+
+        final result = await repository.getSettlementItems(
+          partnerId: 'partner_1',
+        );
+
+        expect(result, isEmpty);
+      });
+
+      test('throws on db error', () async {
+        mockTable(
+          mockClient,
+          'settlement_items',
+          shouldThrow: Exception('db error'),
+        );
+
+        await expectLater(
+          repository.getSettlementItems(partnerId: 'partner_1'),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // getSettlementItemDetail
+    // -------------------------------------------------------------------------
+    group('getSettlementItemDetail', () {
+      test('returns SettlementItemDetail with nested data', () async {
+        final itemJson = _settlementItemJson();
+
+        // settlement_items → maybeSingle returns the item
+        mockTable(
+          mockClient,
+          'settlement_items',
+          maybeSingleData: itemJson,
+        );
+        // payouts → not queried because payout_id is null in itemJson
+        // settlement_histories → returns empty list
+        mockTable(mockClient, 'settlement_histories', selectData: []);
+        // adjustment_items → returns empty list
+        mockTable(mockClient, 'adjustment_items', selectData: []);
+
+        final result = await repository.getSettlementItemDetail('item_1');
+
+        expect(result, isNotNull);
+        expect(result!.id, 'item_1');
+        expect(result.histories, isEmpty);
+        expect(result.adjustments, isEmpty);
+      });
+
+      test('returns null when item not found', () async {
+        mockTable(mockClient, 'settlement_items', maybeSingleData: null);
+        // Other tables won't be queried when item is null.
+
+        final result = await repository.getSettlementItemDetail('nonexistent');
+
+        expect(result, isNull);
+      });
+
+      test('throws on db error', () async {
+        mockTable(
+          mockClient,
+          'settlement_items',
+          shouldThrow: Exception('db error'),
+        );
+
+        await expectLater(
+          repository.getSettlementItemDetail('item_1'),
+          throwsA(isA<Exception>()),
+        );
+      });
+
+      test('fetches payout info when payout_id is present', () async {
+        final itemJsonWithPayout = {
+          ..._settlementItemJson(),
+          'payout_id': 'payout_1',
+        };
+        final payoutJson = {
+          'id': 'payout_1',
+          'status': 'COMPLETED',
+          'scheduled_at': null,
+          'total_net_amount': 9250,
+          'bank_account_snapshot': null,
+        };
+
+        mockTable(
+          mockClient,
+          'settlement_items',
+          maybeSingleData: itemJsonWithPayout,
+        );
+        mockTable(
+          mockClient,
+          'payouts',
+          maybeSingleData: payoutJson,
+        );
+        mockTable(mockClient, 'settlement_histories', selectData: []);
+        mockTable(mockClient, 'adjustment_items', selectData: []);
+
+        final result = await repository.getSettlementItemDetail('item_1');
+
+        expect(result, isNotNull);
+        expect(result!.payoutId, 'payout_1');
+        expect(result.payoutInfo, isNotNull);
+        expect(result.payoutInfo!.id, 'payout_1');
+        expect(result.payoutInfo!.status, 'COMPLETED');
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // getSettlementDashboard
+    // -------------------------------------------------------------------------
+    group('getSettlementDashboard', () {
+      test('returns aggregated dashboard data', () async {
+        mockTable(
+          mockClient,
+          'settlement_items',
+          selectData: [
+            {
+              'status': 'COMPLETED',
+              'net_amount': 9000,
+              'gross_amount': 10000,
+            },
+            {
+              'status': 'COMPLETED',
+              'net_amount': 8000,
+              'gross_amount': 9000,
+            },
+            {
+              'status': 'PENDING',
+              'net_amount': 5000,
+              'gross_amount': 6000,
+            },
+          ],
+        );
+
+        final result = await repository.getSettlementDashboard(
+          partnerId: 'partner_1',
+        );
+
+        expect(result['total_items'], 3);
+        final statusCounts = result['status_counts'] as Map<String, int>;
+        expect(statusCounts['COMPLETED'], 2);
+        expect(statusCounts['PENDING'], 1);
+        expect(result['completed_net_total'], 17000);
+        expect(result['completed_gross_total'], 19000);
+      });
+
+      test('returns zeros when no items', () async {
+        mockTable(mockClient, 'settlement_items', selectData: []);
+
+        final result = await repository.getSettlementDashboard(
+          partnerId: 'partner_1',
+        );
+
+        expect(result['total_items'], 0);
+        expect(result['completed_net_total'], 0);
+        expect(result['completed_gross_total'], 0);
+      });
+
+      test('throws on db error', () async {
+        mockTable(
+          mockClient,
+          'settlement_items',
+          shouldThrow: Exception('db error'),
+        );
+
+        await expectLater(
+          repository.getSettlementDashboard(partnerId: 'partner_1'),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // getEventInfo
+    // -------------------------------------------------------------------------
+    group('getEventInfo', () {
+      test('returns event info map', () async {
+        final eventJson = {
+          'id': 'event_1',
+          'title': '테스트 이벤트',
+          'date': '2026-03-01',
+          'parties': {'name': '테스트 파티'},
+        };
+        mockTable(mockClient, 'events', maybeSingleData: eventJson);
+
+        final result = await repository.getEventInfo('event_1');
+
+        expect(result, isNotNull);
+        expect(result!['id'], 'event_1');
+        expect(result['title'], '테스트 이벤트');
+      });
+
+      test('returns null when event not found', () async {
+        mockTable(mockClient, 'events', maybeSingleData: null);
+
+        final result = await repository.getEventInfo('nonexistent');
+
+        expect(result, isNull);
+      });
+
+      test('throws on db error', () async {
+        mockTable(
+          mockClient,
+          'events',
+          shouldThrow: Exception('db error'),
+        );
+
+        await expectLater(
+          repository.getEventInfo('event_1'),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // getBankAccount
+    // -------------------------------------------------------------------------
+    group('getBankAccount', () {
+      test('returns bank account map', () async {
+        final bankJson = {
+          'bank_name': '국민은행',
+          'account_holder': '홍길동',
+          'account_number': '123-456-789',
+        };
+        mockTable(
+          mockClient,
+          'partner_settlements',
+          maybeSingleData: bankJson,
+        );
+
+        final result = await repository.getBankAccount('partner_1');
+
+        expect(result, isNotNull);
+        expect(result!['bank_name'], '국민은행');
+        expect(result['account_holder'], '홍길동');
+      });
+
+      test('returns null when not found', () async {
+        mockTable(mockClient, 'partner_settlements', maybeSingleData: null);
+
+        final result = await repository.getBankAccount('partner_1');
+
+        expect(result, isNull);
+      });
+
+      test('throws on db error', () async {
+        mockTable(
+          mockClient,
+          'partner_settlements',
+          shouldThrow: Exception('db error'),
+        );
+
+        await expectLater(
+          repository.getBankAccount('partner_1'),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // upsertBankAccount
+    // -------------------------------------------------------------------------
+    group('upsertBankAccount', () {
+      test('completes without error', () async {
+        mockTable(mockClient, 'partner_settlements');
+
+        await expectLater(
+          repository.upsertBankAccount(
+            partnerId: 'partner_1',
+            bankName: '국민은행',
+            accountHolder: '홍길동',
+            accountNumber: '123-456-789',
+          ),
+          completes,
+        );
+      });
+
+      test('throws on db error', () async {
+        mockTable(
+          mockClient,
+          'partner_settlements',
+          shouldThrow: Exception('upsert failed'),
+        );
+
+        await expectLater(
+          repository.upsertBankAccount(
+            partnerId: 'partner_1',
+            bankName: '국민은행',
+            accountHolder: '홍길동',
+            accountNumber: '123-456-789',
+          ),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // getPartnerSettlementInfo
+    // -------------------------------------------------------------------------
+    group('getPartnerSettlementInfo', () {
+      test('returns partner settlement info map', () async {
+        final infoJson = {
+          'partner_id': 'partner_1',
+          'bank_name': '신한은행',
+          'account_holder': '김철수',
+          'account_number': '987-654-321',
+          'created_at': '2026-01-01T00:00:00.000Z',
+        };
+        mockTable(
+          mockClient,
+          'partner_settlements',
+          maybeSingleData: infoJson,
+        );
+
+        final result = await repository.getPartnerSettlementInfo('partner_1');
+
+        expect(result, isNotNull);
+        expect(result!['partner_id'], 'partner_1');
+        expect(result['bank_name'], '신한은행');
+      });
+
+      test('returns null when not found', () async {
+        mockTable(mockClient, 'partner_settlements', maybeSingleData: null);
+
+        final result = await repository.getPartnerSettlementInfo('partner_1');
+
+        expect(result, isNull);
+      });
+
+      test('throws on db error', () async {
+        mockTable(
+          mockClient,
+          'partner_settlements',
+          shouldThrow: Exception('db error'),
+        );
+
+        await expectLater(
+          repository.getPartnerSettlementInfo('partner_1'),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
+
+    // -------------------------------------------------------------------------
+    // retryPayout
+    // -------------------------------------------------------------------------
+    group('retryPayout', () {
+      test('returns result map on success', () async {
+        when(
+          () => mockClient.rpc<Map<String, dynamic>>(
+            'request_retry_payout',
+            params: any(named: 'params'),
+          ),
+        ).thenAnswer(
+          (_) => _FakeRpcResult<Map<String, dynamic>>({'status': 'ok'}),
+        );
+
+        final result = await repository.retryPayout(
+          payoutId: 'payout_1',
+          partnerId: 'partner_1',
+        );
+
+        expect(result['status'], 'ok');
+      });
+
+      test('throws on rpc error', () async {
+        when(
+          () => mockClient.rpc<Map<String, dynamic>>(
+            'request_retry_payout',
+            params: any(named: 'params'),
+          ),
+        ).thenThrow(Exception('rpc error'));
+
+        await expectLater(
+          repository.retryPayout(
+            payoutId: 'payout_1',
+            partnerId: 'partner_1',
+          ),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Settlement 기능의 Phase 6 리팩토링. Direct Supabase 호출을 Repository/Coordinator 패턴으로 전환하고, setState를 Riverpod AsyncValue로 마이그레이션.

### 변경 사항

**Wave 1 — Foundation (Repository + Coordinator)**
- `SettlementRepository`: getBankAccount, upsertBankAccount, getPartnerSettlementInfo, retryPayout 4개 메서드 추가
- `SettlementCoordinator`: goToDetail, goToBankAccount, retryPayout 3개 메서드 추가
- Repository 23개 + Coordinator 4개 단위 테스트

**Wave 2 — Controllers**
- `SettlementDashboardController`: 대시보드 상태 관리 (Freezed + Riverpod)
- `SettlementListController`: 목록 상태 관리 + generation token 기반 race condition 수정
- `currentMonthNetProvider`: RevenueSummaryCard 데이터 로딩 FutureProvider 분리
- `bank_account_page.dart`: Direct Supabase → Repository/Coordinator 전환 (Supabase.instance 0건)
- Controller 15개 단위 테스트

**Wave 3 — UI Migration**
- `settlement_page.dart`: _DashboardTab + _ListTab setState 전량 제거 → AsyncValue
- `settlement_detail_page.dart`: Coordinator 전환 + 구조화된 에러 UI
- `revenue_summary_card.dart`: ConsumerStatefulWidget → ConsumerWidget + Coordinator 네비게이션
- `settlement_status_badge.dart`: Color(0x...) → colorScheme + unknown enum 추가
- `status_filter_chips.dart`: 하드코딩 spacing → MinglitSpacing 토큰
- `settlement_page.dart`: 전체 하드코딩 색상/spacing → design tokens

### 검증
- ✅ `flutter analyze --no-fatal-infos` 통과 (minglit_kit + app_partner)
- ✅ 42개 단위 테스트 전량 통과
- ✅ settlement_page.dart setState 0건
- ✅ bank_account_page.dart / settlement_detail_page.dart Supabase.instance 0건
- ✅ settlement_status_badge.dart / settlement_page.dart Color(0x...) 0건