### PR TITLE
fix(partner): Kakao Map 미표시 및 멤버 목록 조회 오류 수정 (#108)

### DIFF
--- a/shared/packages/minglit_kit/lib/src/ui/widgets/party/location_map_view.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/party/location_map_view.dart
@@ -4,7 +4,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:minglit_kit/src/data/models/party.dart';
 import 'package:minglit_kit/src/theme/minglit_theme.dart';
-import 'package:minglit_kit/src/ui/widgets/map/location_map.dart';
+// Fix #108: Use conditional import so mobile gets KakaoMap, web gets JS SDK
+import 'package:minglit_kit/src/ui/widgets/map/location_map.dart'
+    if (dart.library.html) 'package:minglit_kit/src/ui/widgets/map/location_map_web.dart'
+    if (dart.library.io) 'package:minglit_kit/src/ui/widgets/map/location_map_mobile.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 /// **Location Map View**

--- a/supabase/migrations/20260316000007_fix_get_partner_members_ambiguous_column.sql
+++ b/supabase/migrations/20260316000007_fix_get_partner_members_ambiguous_column.sql
@@ -1,0 +1,32 @@
+-- Fix #108: Disambiguate partner_id/user_id in get_partner_members_with_user
+--
+-- The RETURNS TABLE clause declares partner_id and user_id as output columns,
+-- which creates PL/pgSQL variables that clash with the unqualified column
+-- references in the EXISTS subquery. Adding table alias resolves the ambiguity.
+
+CREATE OR REPLACE FUNCTION public.get_partner_members_with_user(p_partner_id uuid)
+RETURNS TABLE(
+  user_id uuid, partner_id uuid, role text, permissions text[],
+  joined_at timestamptz, user_name text, user_profile_image text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF public.has_partner_permission(p_partner_id, 'MEMBER_MANAGE')
+     OR EXISTS (
+       SELECT 1 FROM public.partner_member_permissions pcheck
+       WHERE pcheck.partner_id = p_partner_id AND pcheck.user_id = auth.uid()
+     )
+  THEN
+    RETURN QUERY
+      SELECT pmp.user_id, pmp.partner_id, pmp.role, pmp.permissions,
+             pmp.joined_at, up.name, up.profile_image_url
+      FROM public.partner_member_permissions pmp
+      LEFT JOIN public.user_profiles up ON up.id = pmp.user_id
+      WHERE pmp.partner_id = p_partner_id
+      ORDER BY pmp.joined_at;
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Summary

- **Kakao Map SDK 미표시**: `LocationMapView`에서 conditional import 없이 fallback `location_map.dart`를 직접 import하여 모바일에서 항상 "Map not supported on this platform" 플레이스홀더가 표시되던 문제 수정
- **멤버 목록 조회 실패**: `get_partner_members_with_user` RPC의 EXISTS 서브쿼리에서 `RETURNS TABLE` 출력 변수(`partner_id`, `user_id`)와 테이블 컬럼 간 참조 모호성(PostgreSQL 42702) 해결

## Changes

### 1. Conditional Import 추가 (`location_map_view.dart`)
`minglit_ui.dart`의 export와 동일한 conditional import 패턴 적용:
- `dart.library.io` → `location_map_mobile.dart` (KakaoMap plugin)
- `dart.library.html` → `location_map_web.dart` (JS SDK)
- fallback → `location_map.dart` (placeholder)

### 2. SQL Migration (`20260316000007`)
EXISTS 서브쿼리의 `partner_member_permissions` 테이블에 `pcheck` alias를 추가하여 PL/pgSQL 변수와 테이블 컬럼 간 모호성 해소.

## Testing
- `flutter analyze` (app_partner): No issues found
- `flutter test` (app_partner): 89/89 passed
- `flutter test` (minglit_kit): 402/403 passed (1 pre-existing failure in ticket_repository_test)

Closes #108