### PR TITLE
feat(refund): binary DB-driven refund policy — paid_at + server-side enforcement

### DIFF
--- a/apps/app_user/lib/src/features/event/detail/event_refund_policy_section.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_refund_policy_section.dart
@@ -1,11 +1,19 @@
 part of 'event_detail_page.dart';
 
-class _RefundPolicySection extends StatelessWidget {
+// ignore: specify_nonobvious_property_types // autoDispose type
+final _refundPolicyProvider = FutureProvider.autoDispose<Map<String, dynamic>?>(
+  (ref) {
+    return ref.watch(policyRepositoryProvider).getRefundPolicy();
+  },
+);
+
+class _RefundPolicySection extends ConsumerWidget {
   const _RefundPolicySection();
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
+    final policyAsync = ref.watch(_refundPolicyProvider);
 
     return Padding(
       padding: const EdgeInsets.all(MinglitSpacing.medium),
@@ -19,19 +27,65 @@ class _RefundPolicySection extends StatelessWidget {
             ),
           ),
           const SizedBox(height: MinglitSpacing.medium),
-          _buildPolicyRow(context, '이벤트 시작 7일 전', '전액 환불'),
-          const SizedBox(height: MinglitSpacing.small),
-          _buildPolicyRow(context, '이벤트 시작 3~7일 전', '50% 환불'),
-          const SizedBox(height: MinglitSpacing.small),
-          _buildPolicyRow(context, '이벤트 시작 3일 이내', '환불 불가'),
-          const SizedBox(height: MinglitSpacing.medium),
-          Text(
-            '자세한 내용은 고객센터로 문의해주세요.',
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-            ),
+          policyAsync.when(
+            data: (policy) => _buildPolicyContent(context, policy),
+            loading: () => _buildLoadingContent(context),
+            error: (e, st) => _buildPolicyContent(context, null),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildPolicyContent(
+    BuildContext context,
+    Map<String, dynamic>? policy,
+  ) {
+    final gracePeriodHours =
+        (policy?['grace_period_hours'] as num?)?.toInt() ?? 2;
+    final cutoffDays = (policy?['cutoff_days'] as num?)?.toInt() ?? 7;
+
+    return Column(
+      children: [
+        _buildPolicyRow(
+          context,
+          '결제 후 $gracePeriodHours시간 이내',
+          '전액 환불',
+        ),
+        const SizedBox(height: MinglitSpacing.small),
+        _buildPolicyRow(
+          context,
+          '이벤트 시작 $cutoffDays일 전까지',
+          '전액 환불',
+        ),
+        const SizedBox(height: MinglitSpacing.small),
+        _buildPolicyRow(context, '그 외', '환불 불가'),
+        const SizedBox(height: MinglitSpacing.medium),
+        Text(
+          '자세한 내용은 고객센터로 문의해주세요.',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildLoadingContent(BuildContext context) {
+    return Column(
+      children: List.generate(
+        3,
+        (_) => Padding(
+          padding: const EdgeInsets.only(bottom: MinglitSpacing.small),
+          child: Container(
+            height: 20,
+            width: double.infinity,
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surfaceContainerHighest,
+              borderRadius: BorderRadius.circular(4),
+            ),
+          ),
+        ),
       ),
     );
   }
@@ -45,10 +99,7 @@ class _RefundPolicySection extends StatelessWidget {
     return Row(
       children: [
         Expanded(
-          child: Text(
-            condition,
-            style: theme.textTheme.bodyMedium,
-          ),
+          child: Text(condition, style: theme.textTheme.bodyMedium),
         ),
         Text(
           policy,

--- a/apps/app_user/lib/src/features/payment/logic/purchase_history_controller.dart
+++ b/apps/app_user/lib/src/features/payment/logic/purchase_history_controller.dart
@@ -41,10 +41,18 @@ class PurchaseHistoryController extends _$PurchaseHistoryController {
   RefundCalculation calculateRefund({
     required DateTime eventStartTime,
     required int paymentAmount,
+    required DateTime? paidAt,
+    required int gracePeriodHours,
+    required int cutoffDays,
+    DateTime? now,
   }) {
     return RefundCalculator.calculate(
       eventStartTime: eventStartTime,
       paymentAmount: paymentAmount,
+      paidAt: paidAt,
+      gracePeriodHours: gracePeriodHours,
+      cutoffDays: cutoffDays,
+      now: now,
     );
   }
 
@@ -52,7 +60,9 @@ class PurchaseHistoryController extends _$PurchaseHistoryController {
     required String? paymentId,
     required int? paymentAmount,
     required DateTime? eventStartTime,
+    required DateTime? paidAt,
     required Future<void> Function() showMissingInfo,
+    required Future<void> Function() showNotEligible,
     required Future<bool> Function(RefundCalculation calculation) confirmRefund,
     required Future<bool> Function(String message) showError,
     required Future<void> Function() onSuccess,
@@ -62,10 +72,24 @@ class PurchaseHistoryController extends _$PurchaseHistoryController {
       return;
     }
 
+    final policyRepo = ref.read(policyRepositoryProvider);
+    final policy = await policyRepo.getRefundPolicy();
+    final gracePeriodHours =
+        (policy?['grace_period_hours'] as num?)?.toInt() ?? 2;
+    final cutoffDays = (policy?['cutoff_days'] as num?)?.toInt() ?? 7;
+
     final calculation = calculateRefund(
       eventStartTime: eventStartTime,
       paymentAmount: paymentAmount,
+      paidAt: paidAt,
+      gracePeriodHours: gracePeriodHours,
+      cutoffDays: cutoffDays,
     );
+
+    if (calculation.refundPercentage == 0) {
+      await showNotEligible();
+      return;
+    }
 
     final confirmed = await confirmRefund(calculation);
     if (!confirmed) return;

--- a/apps/app_user/lib/src/features/payment/logic/purchase_history_controller.dart
+++ b/apps/app_user/lib/src/features/payment/logic/purchase_history_controller.dart
@@ -72,11 +72,17 @@ class PurchaseHistoryController extends _$PurchaseHistoryController {
       return;
     }
 
-    final policyRepo = ref.read(policyRepositoryProvider);
-    final policy = await policyRepo.getRefundPolicy();
-    final gracePeriodHours =
-        (policy?['grace_period_hours'] as num?)?.toInt() ?? 2;
-    final cutoffDays = (policy?['cutoff_days'] as num?)?.toInt() ?? 7;
+    // Fix #133: 정책 조회 실패 시 기본값(2/7)으로 환불 플로우가 계속 진행되도록 보호
+    int gracePeriodHours = 2;
+    int cutoffDays = 7;
+    try {
+      final policyRepo = ref.read(policyRepositoryProvider);
+      final policy = await policyRepo.getRefundPolicy();
+      gracePeriodHours = (policy?['grace_period_hours'] as num?)?.toInt() ?? 2;
+      cutoffDays = (policy?['cutoff_days'] as num?)?.toInt() ?? 7;
+    } on Object {
+      // 정책 조회 실패 시 기본 정책으로 진행
+    }
 
     final calculation = calculateRefund(
       eventStartTime: eventStartTime,

--- a/apps/app_user/lib/src/features/payment/logic/purchase_history_controller.dart
+++ b/apps/app_user/lib/src/features/payment/logic/purchase_history_controller.dart
@@ -73,8 +73,8 @@ class PurchaseHistoryController extends _$PurchaseHistoryController {
     }
 
     // Fix #133: 정책 조회 실패 시 기본값(2/7)으로 환불 플로우가 계속 진행되도록 보호
-    int gracePeriodHours = 2;
-    int cutoffDays = 7;
+    var gracePeriodHours = 2;
+    var cutoffDays = 7;
     try {
       final policyRepo = ref.read(policyRepositoryProvider);
       final policy = await policyRepo.getRefundPolicy();

--- a/apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart
+++ b/apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart
@@ -205,6 +205,7 @@ class PurchaseHistoryCard extends ConsumerWidget {
                       paymentId: paymentId,
                       paymentAmount: paymentAmount,
                       eventStartTime: eventStartTime,
+                      paidAt: application.paidAt,
                     ),
                     style: ElevatedButton.styleFrom(
                       backgroundColor: theme.colorScheme.errorContainer,
@@ -242,17 +243,26 @@ class PurchaseHistoryCard extends ConsumerWidget {
     required String? paymentId,
     required int? paymentAmount,
     required DateTime? eventStartTime,
+    required DateTime? paidAt,
   }) async {
     final controller = ref.read(purchaseHistoryControllerProvider.notifier);
     await controller.runRefundFlow(
       paymentId: paymentId,
       paymentAmount: paymentAmount,
       eventStartTime: eventStartTime,
+      paidAt: paidAt,
       showMissingInfo: () async {
         if (!context.mounted) return;
         await context.showMinglitAlert(
           title: '환불 정보를 확인할 수 없습니다',
           message: '결제 정보를 다시 확인해주세요.',
+        );
+      },
+      showNotEligible: () async {
+        if (!context.mounted) return;
+        await context.showMinglitAlert(
+          title: '환불 불가',
+          message: '결제 후 2시간 이내 또는 이벤트 시작 7일 전까지만 환불 가능합니다.',
         );
       },
       confirmRefund: (calculation) async {

--- a/shared/packages/minglit_kit/lib/minglit_data.dart
+++ b/shared/packages/minglit_kit/lib/minglit_data.dart
@@ -43,5 +43,6 @@ export 'src/data/repositories/storage_repository.dart';
 export 'src/data/repositories/ticket_repository.dart';
 export 'src/data/repositories/user_repository.dart';
 export 'src/data/repositories/verification_repository.dart';
+export 'src/data/repositories/policy_repository.dart';
 // Utils
 export 'src/utils/ticket_crypto.dart';

--- a/shared/packages/minglit_kit/lib/minglit_data.dart
+++ b/shared/packages/minglit_kit/lib/minglit_data.dart
@@ -4,7 +4,6 @@ export 'package:supabase_flutter/supabase_flutter.dart'
 
 // Config
 export 'src/config/iamport_config.dart';
-
 // Models
 export 'src/data/models/event.dart';
 export 'src/data/models/event_application.dart';
@@ -37,12 +36,12 @@ export 'src/data/repositories/matching_repository.dart';
 export 'src/data/repositories/notification_repository.dart';
 export 'src/data/repositories/partner_repository.dart';
 export 'src/data/repositories/party_repository.dart';
+export 'src/data/repositories/policy_repository.dart';
 export 'src/data/repositories/settlement_repository.dart';
 export 'src/data/repositories/social_repository.dart';
 export 'src/data/repositories/storage_repository.dart';
 export 'src/data/repositories/ticket_repository.dart';
 export 'src/data/repositories/user_repository.dart';
 export 'src/data/repositories/verification_repository.dart';
-export 'src/data/repositories/policy_repository.dart';
 // Utils
 export 'src/utils/ticket_crypto.dart';

--- a/shared/packages/minglit_kit/lib/src/data/models/event_application.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/event_application.dart
@@ -23,6 +23,7 @@ abstract class EventApplication with _$EventApplication {
     @JsonKey(name: 'payment_amount') int? paymentAmount,
     @Default('none') @JsonKey(name: 'refund_status') String refundStatus,
     @JsonKey(name: 'rejection_reason') String? rejectionReason,
+    @JsonKey(name: 'paid_at') DateTime? paidAt,
 
     // Relations (Nullable)
     UserProfile? user,

--- a/shared/packages/minglit_kit/lib/src/data/models/event_application.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/event_application.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$EventApplication {
 
- String get id;@JsonKey(name: 'event_id') String get eventId;@JsonKey(name: 'ticket_id') String get ticketId;@JsonKey(name: 'user_id') String get userId; String get status;@JsonKey(name: 'created_at') DateTime get createdAt;@JsonKey(name: 'updated_at') DateTime get updatedAt;@JsonKey(name: 'payment_id') String? get paymentId;@JsonKey(name: 'payment_amount') int? get paymentAmount;@JsonKey(name: 'refund_status') String get refundStatus;@JsonKey(name: 'rejection_reason') String? get rejectionReason;// Relations (Nullable)
+ String get id;@JsonKey(name: 'event_id') String get eventId;@JsonKey(name: 'ticket_id') String get ticketId;@JsonKey(name: 'user_id') String get userId; String get status;@JsonKey(name: 'created_at') DateTime get createdAt;@JsonKey(name: 'updated_at') DateTime get updatedAt;@JsonKey(name: 'payment_id') String? get paymentId;@JsonKey(name: 'payment_amount') int? get paymentAmount;@JsonKey(name: 'refund_status') String get refundStatus;@JsonKey(name: 'rejection_reason') String? get rejectionReason;@JsonKey(name: 'paid_at') DateTime? get paidAt;// Relations (Nullable)
  UserProfile? get user; VerificationSubmission? get submission; Event? get event; Ticket? get ticket;
 /// Create a copy of EventApplication
 /// with the given fields replaced by the non-null parameter values.
@@ -29,16 +29,16 @@ $EventApplicationCopyWith<EventApplication> get copyWith => _$EventApplicationCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is EventApplication&&(identical(other.id, id) || other.id == id)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.ticketId, ticketId) || other.ticketId == ticketId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.status, status) || other.status == status)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.paymentId, paymentId) || other.paymentId == paymentId)&&(identical(other.paymentAmount, paymentAmount) || other.paymentAmount == paymentAmount)&&(identical(other.refundStatus, refundStatus) || other.refundStatus == refundStatus)&&(identical(other.rejectionReason, rejectionReason) || other.rejectionReason == rejectionReason)&&(identical(other.user, user) || other.user == user)&&(identical(other.submission, submission) || other.submission == submission)&&(identical(other.event, event) || other.event == event)&&(identical(other.ticket, ticket) || other.ticket == ticket));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EventApplication&&(identical(other.id, id) || other.id == id)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.ticketId, ticketId) || other.ticketId == ticketId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.status, status) || other.status == status)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.paymentId, paymentId) || other.paymentId == paymentId)&&(identical(other.paymentAmount, paymentAmount) || other.paymentAmount == paymentAmount)&&(identical(other.refundStatus, refundStatus) || other.refundStatus == refundStatus)&&(identical(other.rejectionReason, rejectionReason) || other.rejectionReason == rejectionReason)&&(identical(other.paidAt, paidAt) || other.paidAt == paidAt)&&(identical(other.user, user) || other.user == user)&&(identical(other.submission, submission) || other.submission == submission)&&(identical(other.event, event) || other.event == event)&&(identical(other.ticket, ticket) || other.ticket == ticket));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,eventId,ticketId,userId,status,createdAt,updatedAt,paymentId,paymentAmount,refundStatus,rejectionReason,user,submission,event,ticket);
+int get hashCode => Object.hash(runtimeType,id,eventId,ticketId,userId,status,createdAt,updatedAt,paymentId,paymentAmount,refundStatus,rejectionReason,paidAt,user,submission,event,ticket);
 
 @override
 String toString() {
-  return 'EventApplication(id: $id, eventId: $eventId, ticketId: $ticketId, userId: $userId, status: $status, createdAt: $createdAt, updatedAt: $updatedAt, paymentId: $paymentId, paymentAmount: $paymentAmount, refundStatus: $refundStatus, rejectionReason: $rejectionReason, user: $user, submission: $submission, event: $event, ticket: $ticket)';
+  return 'EventApplication(id: $id, eventId: $eventId, ticketId: $ticketId, userId: $userId, status: $status, createdAt: $createdAt, updatedAt: $updatedAt, paymentId: $paymentId, paymentAmount: $paymentAmount, refundStatus: $refundStatus, rejectionReason: $rejectionReason, paidAt: $paidAt, user: $user, submission: $submission, event: $event, ticket: $ticket)';
 }
 
 
@@ -49,7 +49,7 @@ abstract mixin class $EventApplicationCopyWith<$Res>  {
   factory $EventApplicationCopyWith(EventApplication value, $Res Function(EventApplication) _then) = _$EventApplicationCopyWithImpl;
 @useResult
 $Res call({
- String id,@JsonKey(name: 'event_id') String eventId,@JsonKey(name: 'ticket_id') String ticketId,@JsonKey(name: 'user_id') String userId, String status,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'payment_id') String? paymentId,@JsonKey(name: 'payment_amount') int? paymentAmount,@JsonKey(name: 'refund_status') String refundStatus,@JsonKey(name: 'rejection_reason') String? rejectionReason, UserProfile? user, VerificationSubmission? submission, Event? event, Ticket? ticket
+ String id,@JsonKey(name: 'event_id') String eventId,@JsonKey(name: 'ticket_id') String ticketId,@JsonKey(name: 'user_id') String userId, String status,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'payment_id') String? paymentId,@JsonKey(name: 'payment_amount') int? paymentAmount,@JsonKey(name: 'refund_status') String refundStatus,@JsonKey(name: 'rejection_reason') String? rejectionReason,@JsonKey(name: 'paid_at') DateTime? paidAt, UserProfile? user, VerificationSubmission? submission, Event? event, Ticket? ticket
 });
 
 
@@ -66,7 +66,7 @@ class _$EventApplicationCopyWithImpl<$Res>
 
 /// Create a copy of EventApplication
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? eventId = null,Object? ticketId = null,Object? userId = null,Object? status = null,Object? createdAt = null,Object? updatedAt = null,Object? paymentId = freezed,Object? paymentAmount = freezed,Object? refundStatus = null,Object? rejectionReason = freezed,Object? user = freezed,Object? submission = freezed,Object? event = freezed,Object? ticket = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? eventId = null,Object? ticketId = null,Object? userId = null,Object? status = null,Object? createdAt = null,Object? updatedAt = null,Object? paymentId = freezed,Object? paymentAmount = freezed,Object? refundStatus = null,Object? rejectionReason = freezed,Object? paidAt = freezed,Object? user = freezed,Object? submission = freezed,Object? event = freezed,Object? ticket = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
@@ -79,7 +79,8 @@ as DateTime,paymentId: freezed == paymentId ? _self.paymentId : paymentId // ign
 as String?,paymentAmount: freezed == paymentAmount ? _self.paymentAmount : paymentAmount // ignore: cast_nullable_to_non_nullable
 as int?,refundStatus: null == refundStatus ? _self.refundStatus : refundStatus // ignore: cast_nullable_to_non_nullable
 as String,rejectionReason: freezed == rejectionReason ? _self.rejectionReason : rejectionReason // ignore: cast_nullable_to_non_nullable
-as String?,user: freezed == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as String?,paidAt: freezed == paidAt ? _self.paidAt : paidAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,user: freezed == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
 as UserProfile?,submission: freezed == submission ? _self.submission : submission // ignore: cast_nullable_to_non_nullable
 as VerificationSubmission?,event: freezed == event ? _self.event : event // ignore: cast_nullable_to_non_nullable
 as Event?,ticket: freezed == ticket ? _self.ticket : ticket // ignore: cast_nullable_to_non_nullable
@@ -216,10 +217,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'ticket_id')  String ticketId, @JsonKey(name: 'user_id')  String userId,  String status, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'payment_id')  String? paymentId, @JsonKey(name: 'payment_amount')  int? paymentAmount, @JsonKey(name: 'refund_status')  String refundStatus, @JsonKey(name: 'rejection_reason')  String? rejectionReason,  UserProfile? user,  VerificationSubmission? submission,  Event? event,  Ticket? ticket)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'ticket_id')  String ticketId, @JsonKey(name: 'user_id')  String userId,  String status, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'payment_id')  String? paymentId, @JsonKey(name: 'payment_amount')  int? paymentAmount, @JsonKey(name: 'refund_status')  String refundStatus, @JsonKey(name: 'rejection_reason')  String? rejectionReason, @JsonKey(name: 'paid_at')  DateTime? paidAt,  UserProfile? user,  VerificationSubmission? submission,  Event? event,  Ticket? ticket)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _EventApplication() when $default != null:
-return $default(_that.id,_that.eventId,_that.ticketId,_that.userId,_that.status,_that.createdAt,_that.updatedAt,_that.paymentId,_that.paymentAmount,_that.refundStatus,_that.rejectionReason,_that.user,_that.submission,_that.event,_that.ticket);case _:
+return $default(_that.id,_that.eventId,_that.ticketId,_that.userId,_that.status,_that.createdAt,_that.updatedAt,_that.paymentId,_that.paymentAmount,_that.refundStatus,_that.rejectionReason,_that.paidAt,_that.user,_that.submission,_that.event,_that.ticket);case _:
   return orElse();
 
 }
@@ -237,10 +238,10 @@ return $default(_that.id,_that.eventId,_that.ticketId,_that.userId,_that.status,
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'ticket_id')  String ticketId, @JsonKey(name: 'user_id')  String userId,  String status, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'payment_id')  String? paymentId, @JsonKey(name: 'payment_amount')  int? paymentAmount, @JsonKey(name: 'refund_status')  String refundStatus, @JsonKey(name: 'rejection_reason')  String? rejectionReason,  UserProfile? user,  VerificationSubmission? submission,  Event? event,  Ticket? ticket)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'ticket_id')  String ticketId, @JsonKey(name: 'user_id')  String userId,  String status, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'payment_id')  String? paymentId, @JsonKey(name: 'payment_amount')  int? paymentAmount, @JsonKey(name: 'refund_status')  String refundStatus, @JsonKey(name: 'rejection_reason')  String? rejectionReason, @JsonKey(name: 'paid_at')  DateTime? paidAt,  UserProfile? user,  VerificationSubmission? submission,  Event? event,  Ticket? ticket)  $default,) {final _that = this;
 switch (_that) {
 case _EventApplication():
-return $default(_that.id,_that.eventId,_that.ticketId,_that.userId,_that.status,_that.createdAt,_that.updatedAt,_that.paymentId,_that.paymentAmount,_that.refundStatus,_that.rejectionReason,_that.user,_that.submission,_that.event,_that.ticket);case _:
+return $default(_that.id,_that.eventId,_that.ticketId,_that.userId,_that.status,_that.createdAt,_that.updatedAt,_that.paymentId,_that.paymentAmount,_that.refundStatus,_that.rejectionReason,_that.paidAt,_that.user,_that.submission,_that.event,_that.ticket);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -257,10 +258,10 @@ return $default(_that.id,_that.eventId,_that.ticketId,_that.userId,_that.status,
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'ticket_id')  String ticketId, @JsonKey(name: 'user_id')  String userId,  String status, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'payment_id')  String? paymentId, @JsonKey(name: 'payment_amount')  int? paymentAmount, @JsonKey(name: 'refund_status')  String refundStatus, @JsonKey(name: 'rejection_reason')  String? rejectionReason,  UserProfile? user,  VerificationSubmission? submission,  Event? event,  Ticket? ticket)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'ticket_id')  String ticketId, @JsonKey(name: 'user_id')  String userId,  String status, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'payment_id')  String? paymentId, @JsonKey(name: 'payment_amount')  int? paymentAmount, @JsonKey(name: 'refund_status')  String refundStatus, @JsonKey(name: 'rejection_reason')  String? rejectionReason, @JsonKey(name: 'paid_at')  DateTime? paidAt,  UserProfile? user,  VerificationSubmission? submission,  Event? event,  Ticket? ticket)?  $default,) {final _that = this;
 switch (_that) {
 case _EventApplication() when $default != null:
-return $default(_that.id,_that.eventId,_that.ticketId,_that.userId,_that.status,_that.createdAt,_that.updatedAt,_that.paymentId,_that.paymentAmount,_that.refundStatus,_that.rejectionReason,_that.user,_that.submission,_that.event,_that.ticket);case _:
+return $default(_that.id,_that.eventId,_that.ticketId,_that.userId,_that.status,_that.createdAt,_that.updatedAt,_that.paymentId,_that.paymentAmount,_that.refundStatus,_that.rejectionReason,_that.paidAt,_that.user,_that.submission,_that.event,_that.ticket);case _:
   return null;
 
 }
@@ -272,7 +273,7 @@ return $default(_that.id,_that.eventId,_that.ticketId,_that.userId,_that.status,
 @JsonSerializable()
 
 class _EventApplication implements EventApplication {
-  const _EventApplication({required this.id, @JsonKey(name: 'event_id') required this.eventId, @JsonKey(name: 'ticket_id') required this.ticketId, @JsonKey(name: 'user_id') required this.userId, required this.status, @JsonKey(name: 'created_at') required this.createdAt, @JsonKey(name: 'updated_at') required this.updatedAt, @JsonKey(name: 'payment_id') this.paymentId, @JsonKey(name: 'payment_amount') this.paymentAmount, @JsonKey(name: 'refund_status') this.refundStatus = 'none', @JsonKey(name: 'rejection_reason') this.rejectionReason, this.user, this.submission, this.event, this.ticket});
+  const _EventApplication({required this.id, @JsonKey(name: 'event_id') required this.eventId, @JsonKey(name: 'ticket_id') required this.ticketId, @JsonKey(name: 'user_id') required this.userId, required this.status, @JsonKey(name: 'created_at') required this.createdAt, @JsonKey(name: 'updated_at') required this.updatedAt, @JsonKey(name: 'payment_id') this.paymentId, @JsonKey(name: 'payment_amount') this.paymentAmount, @JsonKey(name: 'refund_status') this.refundStatus = 'none', @JsonKey(name: 'rejection_reason') this.rejectionReason, @JsonKey(name: 'paid_at') this.paidAt, this.user, this.submission, this.event, this.ticket});
   factory _EventApplication.fromJson(Map<String, dynamic> json) => _$EventApplicationFromJson(json);
 
 @override final  String id;
@@ -286,6 +287,7 @@ class _EventApplication implements EventApplication {
 @override@JsonKey(name: 'payment_amount') final  int? paymentAmount;
 @override@JsonKey(name: 'refund_status') final  String refundStatus;
 @override@JsonKey(name: 'rejection_reason') final  String? rejectionReason;
+@override@JsonKey(name: 'paid_at') final  DateTime? paidAt;
 // Relations (Nullable)
 @override final  UserProfile? user;
 @override final  VerificationSubmission? submission;
@@ -305,16 +307,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EventApplication&&(identical(other.id, id) || other.id == id)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.ticketId, ticketId) || other.ticketId == ticketId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.status, status) || other.status == status)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.paymentId, paymentId) || other.paymentId == paymentId)&&(identical(other.paymentAmount, paymentAmount) || other.paymentAmount == paymentAmount)&&(identical(other.refundStatus, refundStatus) || other.refundStatus == refundStatus)&&(identical(other.rejectionReason, rejectionReason) || other.rejectionReason == rejectionReason)&&(identical(other.user, user) || other.user == user)&&(identical(other.submission, submission) || other.submission == submission)&&(identical(other.event, event) || other.event == event)&&(identical(other.ticket, ticket) || other.ticket == ticket));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EventApplication&&(identical(other.id, id) || other.id == id)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.ticketId, ticketId) || other.ticketId == ticketId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.status, status) || other.status == status)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.paymentId, paymentId) || other.paymentId == paymentId)&&(identical(other.paymentAmount, paymentAmount) || other.paymentAmount == paymentAmount)&&(identical(other.refundStatus, refundStatus) || other.refundStatus == refundStatus)&&(identical(other.rejectionReason, rejectionReason) || other.rejectionReason == rejectionReason)&&(identical(other.paidAt, paidAt) || other.paidAt == paidAt)&&(identical(other.user, user) || other.user == user)&&(identical(other.submission, submission) || other.submission == submission)&&(identical(other.event, event) || other.event == event)&&(identical(other.ticket, ticket) || other.ticket == ticket));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,eventId,ticketId,userId,status,createdAt,updatedAt,paymentId,paymentAmount,refundStatus,rejectionReason,user,submission,event,ticket);
+int get hashCode => Object.hash(runtimeType,id,eventId,ticketId,userId,status,createdAt,updatedAt,paymentId,paymentAmount,refundStatus,rejectionReason,paidAt,user,submission,event,ticket);
 
 @override
 String toString() {
-  return 'EventApplication(id: $id, eventId: $eventId, ticketId: $ticketId, userId: $userId, status: $status, createdAt: $createdAt, updatedAt: $updatedAt, paymentId: $paymentId, paymentAmount: $paymentAmount, refundStatus: $refundStatus, rejectionReason: $rejectionReason, user: $user, submission: $submission, event: $event, ticket: $ticket)';
+  return 'EventApplication(id: $id, eventId: $eventId, ticketId: $ticketId, userId: $userId, status: $status, createdAt: $createdAt, updatedAt: $updatedAt, paymentId: $paymentId, paymentAmount: $paymentAmount, refundStatus: $refundStatus, rejectionReason: $rejectionReason, paidAt: $paidAt, user: $user, submission: $submission, event: $event, ticket: $ticket)';
 }
 
 
@@ -325,7 +327,7 @@ abstract mixin class _$EventApplicationCopyWith<$Res> implements $EventApplicati
   factory _$EventApplicationCopyWith(_EventApplication value, $Res Function(_EventApplication) _then) = __$EventApplicationCopyWithImpl;
 @override @useResult
 $Res call({
- String id,@JsonKey(name: 'event_id') String eventId,@JsonKey(name: 'ticket_id') String ticketId,@JsonKey(name: 'user_id') String userId, String status,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'payment_id') String? paymentId,@JsonKey(name: 'payment_amount') int? paymentAmount,@JsonKey(name: 'refund_status') String refundStatus,@JsonKey(name: 'rejection_reason') String? rejectionReason, UserProfile? user, VerificationSubmission? submission, Event? event, Ticket? ticket
+ String id,@JsonKey(name: 'event_id') String eventId,@JsonKey(name: 'ticket_id') String ticketId,@JsonKey(name: 'user_id') String userId, String status,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'payment_id') String? paymentId,@JsonKey(name: 'payment_amount') int? paymentAmount,@JsonKey(name: 'refund_status') String refundStatus,@JsonKey(name: 'rejection_reason') String? rejectionReason,@JsonKey(name: 'paid_at') DateTime? paidAt, UserProfile? user, VerificationSubmission? submission, Event? event, Ticket? ticket
 });
 
 
@@ -342,7 +344,7 @@ class __$EventApplicationCopyWithImpl<$Res>
 
 /// Create a copy of EventApplication
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? eventId = null,Object? ticketId = null,Object? userId = null,Object? status = null,Object? createdAt = null,Object? updatedAt = null,Object? paymentId = freezed,Object? paymentAmount = freezed,Object? refundStatus = null,Object? rejectionReason = freezed,Object? user = freezed,Object? submission = freezed,Object? event = freezed,Object? ticket = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? eventId = null,Object? ticketId = null,Object? userId = null,Object? status = null,Object? createdAt = null,Object? updatedAt = null,Object? paymentId = freezed,Object? paymentAmount = freezed,Object? refundStatus = null,Object? rejectionReason = freezed,Object? paidAt = freezed,Object? user = freezed,Object? submission = freezed,Object? event = freezed,Object? ticket = freezed,}) {
   return _then(_EventApplication(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
@@ -355,7 +357,8 @@ as DateTime,paymentId: freezed == paymentId ? _self.paymentId : paymentId // ign
 as String?,paymentAmount: freezed == paymentAmount ? _self.paymentAmount : paymentAmount // ignore: cast_nullable_to_non_nullable
 as int?,refundStatus: null == refundStatus ? _self.refundStatus : refundStatus // ignore: cast_nullable_to_non_nullable
 as String,rejectionReason: freezed == rejectionReason ? _self.rejectionReason : rejectionReason // ignore: cast_nullable_to_non_nullable
-as String?,user: freezed == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as String?,paidAt: freezed == paidAt ? _self.paidAt : paidAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,user: freezed == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
 as UserProfile?,submission: freezed == submission ? _self.submission : submission // ignore: cast_nullable_to_non_nullable
 as VerificationSubmission?,event: freezed == event ? _self.event : event // ignore: cast_nullable_to_non_nullable
 as Event?,ticket: freezed == ticket ? _self.ticket : ticket // ignore: cast_nullable_to_non_nullable

--- a/shared/packages/minglit_kit/lib/src/data/models/event_application.g.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/event_application.g.dart
@@ -19,6 +19,9 @@ _EventApplication _$EventApplicationFromJson(Map<String, dynamic> json) =>
       paymentAmount: (json['payment_amount'] as num?)?.toInt(),
       refundStatus: json['refund_status'] as String? ?? 'none',
       rejectionReason: json['rejection_reason'] as String?,
+      paidAt: json['paid_at'] == null
+          ? null
+          : DateTime.parse(json['paid_at'] as String),
       user: json['user'] == null
           ? null
           : UserProfile.fromJson(json['user'] as Map<String, dynamic>),
@@ -48,6 +51,7 @@ Map<String, dynamic> _$EventApplicationToJson(_EventApplication instance) =>
       'payment_amount': instance.paymentAmount,
       'refund_status': instance.refundStatus,
       'rejection_reason': instance.rejectionReason,
+      'paid_at': instance.paidAt?.toIso8601String(),
       'user': instance.user,
       'submission': instance.submission,
       'event': instance.event,

--- a/shared/packages/minglit_kit/lib/src/data/repositories/policy_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/policy_repository.dart
@@ -14,11 +14,11 @@ class PolicyRepository {
   final SupabaseClient _supabase;
 
   Future<Map<String, dynamic>?> getRefundPolicy() async {
-    final result = await _supabase.rpc(
+    final result = await _supabase.rpc<Map<String, dynamic>?>(
       'get_current_policy',
       params: {'p_key': 'refund'},
     );
     if (result == null) return null;
-    return result as Map<String, dynamic>;
+    return result;
   }
 }

--- a/shared/packages/minglit_kit/lib/src/data/repositories/policy_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/policy_repository.dart
@@ -1,0 +1,24 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+part 'policy_repository.g.dart';
+
+@Riverpod(keepAlive: true)
+PolicyRepository policyRepository(Ref ref) {
+  return PolicyRepository(Supabase.instance.client);
+}
+
+class PolicyRepository {
+  const PolicyRepository(this._supabase);
+
+  final SupabaseClient _supabase;
+
+  Future<Map<String, dynamic>?> getRefundPolicy() async {
+    final result = await _supabase.rpc(
+      'get_current_policy',
+      params: {'p_key': 'refund'},
+    );
+    if (result == null) return null;
+    return result as Map<String, dynamic>;
+  }
+}

--- a/shared/packages/minglit_kit/lib/src/data/repositories/policy_repository.g.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/policy_repository.g.dart
@@ -1,0 +1,56 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'policy_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(policyRepository)
+const policyRepositoryProvider = PolicyRepositoryProvider._();
+
+final class PolicyRepositoryProvider
+    extends
+        $FunctionalProvider<
+          PolicyRepository,
+          PolicyRepository,
+          PolicyRepository
+        >
+    with $Provider<PolicyRepository> {
+  const PolicyRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'policyRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$policyRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<PolicyRepository> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  PolicyRepository create(Ref ref) {
+    return policyRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(PolicyRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<PolicyRepository>(value),
+    );
+  }
+}
+
+String _$policyRepositoryHash() => r'6388dec0fa0bfc9c4618ddac0d2b04310187cd70';

--- a/shared/packages/minglit_kit/lib/src/utils/refund_calculator.dart
+++ b/shared/packages/minglit_kit/lib/src/utils/refund_calculator.dart
@@ -1,43 +1,36 @@
-/// Holds refund calculation results.
 class RefundCalculation {
-  /// Creates a refund calculation result.
   const RefundCalculation({
     required this.refundPercentage,
     required this.refundAmount,
     required this.feeAmount,
   });
 
-  /// Percentage of the payment to refund.
   final int refundPercentage;
-
-  /// Amount to refund in currency units.
   final int refundAmount;
-
-  /// Amount retained as a fee.
   final int feeAmount;
 }
 
-/// Calculates refund amounts based on event timing.
 class RefundCalculator {
-  /// Calculates refund results for a payment.
   static RefundCalculation calculate({
     required DateTime eventStartTime,
     required int paymentAmount,
+    required DateTime? paidAt,
+    required int gracePeriodHours,
+    required int cutoffDays,
     DateTime? now,
   }) {
     final baseTime = now ?? DateTime.now();
-    final diff = eventStartTime.difference(baseTime);
 
-    var percentage = 0;
-    if (diff >= const Duration(days: 7)) {
-      percentage = 100;
-    } else if (diff >= const Duration(days: 3)) {
-      percentage = 80;
-    } else if (diff >= const Duration(days: 1)) {
-      percentage = 50;
-    }
+    final withinGracePeriod =
+        paidAt != null &&
+        baseTime.difference(paidAt) <= Duration(hours: gracePeriodHours);
 
-    final refundAmount = (paymentAmount * percentage) ~/ 100;
+    final withinCutoff =
+        eventStartTime.difference(baseTime) >= Duration(days: cutoffDays);
+
+    final isRefundable = withinGracePeriod || withinCutoff;
+    final percentage = isRefundable ? 100 : 0;
+    final refundAmount = isRefundable ? paymentAmount : 0;
     final feeAmount = paymentAmount - refundAmount;
 
     return RefundCalculation(

--- a/shared/packages/minglit_kit/lib/src/utils/refund_calculator.dart
+++ b/shared/packages/minglit_kit/lib/src/utils/refund_calculator.dart
@@ -21,8 +21,10 @@ class RefundCalculator {
   }) {
     final baseTime = now ?? DateTime.now();
 
+    // Fix #133: 미래 paidAt는 음수 duration으로 grace period를 통과하므로 명시적으로 제외
     final withinGracePeriod =
         paidAt != null &&
+        !paidAt.isAfter(baseTime) &&
         baseTime.difference(paidAt) <= Duration(hours: gracePeriodHours);
 
     final withinCutoff =

--- a/shared/packages/minglit_kit/test/minglit_kit_test.dart
+++ b/shared/packages/minglit_kit/test/minglit_kit_test.dart
@@ -5,11 +5,14 @@ import 'package:minglit_kit/src/utils/ticket_crypto.dart';
 
 void main() {
   group('RefundCalculator', () {
-    test('7일 이상이면 100% 환불', () {
+    test('이벤트 7일 이상 전이면 100% 환불 (cutoff 합격)', () {
       final now = DateTime(2026, 1, 1, 12);
       final result = RefundCalculator.calculate(
         eventStartTime: now.add(const Duration(days: 8)),
         paymentAmount: 10000,
+        paidAt: null,
+        gracePeriodHours: 2,
+        cutoffDays: 7,
         now: now,
       );
 
@@ -18,37 +21,46 @@ void main() {
       expect(result.feeAmount, 0);
     });
 
-    test('3~7일 사이면 80% 환불', () {
+    test('이벤트 5일 전 + paidAt 없음 → 환불 불가', () {
       final now = DateTime(2026, 1, 1, 12);
       final result = RefundCalculator.calculate(
         eventStartTime: now.add(const Duration(days: 5)),
         paymentAmount: 10000,
+        paidAt: null,
+        gracePeriodHours: 2,
+        cutoffDays: 7,
         now: now,
       );
 
-      expect(result.refundPercentage, 80);
-      expect(result.refundAmount, 8000);
-      expect(result.feeAmount, 2000);
+      expect(result.refundPercentage, 0);
+      expect(result.refundAmount, 0);
+      expect(result.feeAmount, 10000);
     });
 
-    test('1~3일 사이면 50% 환불', () {
+    test('결제 후 1시간 이내 → 100% 환불 (grace period 합격)', () {
       final now = DateTime(2026, 1, 1, 12);
       final result = RefundCalculator.calculate(
         eventStartTime: now.add(const Duration(days: 2)),
         paymentAmount: 10000,
+        paidAt: now.subtract(const Duration(hours: 1)),
+        gracePeriodHours: 2,
+        cutoffDays: 7,
         now: now,
       );
 
-      expect(result.refundPercentage, 50);
-      expect(result.refundAmount, 5000);
-      expect(result.feeAmount, 5000);
+      expect(result.refundPercentage, 100);
+      expect(result.refundAmount, 10000);
+      expect(result.feeAmount, 0);
     });
 
-    test('1일 미만이면 환불 불가', () {
+    test('결제 후 3시간 + 이벤트 12시간 전 → 환불 불가', () {
       final now = DateTime(2026, 1, 1, 12);
       final result = RefundCalculator.calculate(
         eventStartTime: now.add(const Duration(hours: 12)),
         paymentAmount: 10000,
+        paidAt: now.subtract(const Duration(hours: 3)),
+        gracePeriodHours: 2,
+        cutoffDays: 7,
         now: now,
       );
 

--- a/shared/packages/minglit_kit/test/src/utils/refund_calculator_test.dart
+++ b/shared/packages/minglit_kit/test/src/utils/refund_calculator_test.dart
@@ -4,7 +4,7 @@ import 'package:minglit_kit/src/utils/refund_calculator.dart';
 void main() {
   group('RefundCalculator binary policy', () {
     const amount = 10000;
-    final now = DateTime(2026, 3, 16, 12, 0);
+    final now = DateTime(2026, 3, 16, 12);
 
     test('within grace period → full refund', () {
       final paidAt = now.subtract(const Duration(hours: 1));

--- a/shared/packages/minglit_kit/test/src/utils/refund_calculator_test.dart
+++ b/shared/packages/minglit_kit/test/src/utils/refund_calculator_test.dart
@@ -2,97 +2,126 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/utils/refund_calculator.dart';
 
 void main() {
-  group('RefundCalculator - edge cases', () {
-    test('exactly 7 days returns 100% refund', () {
-      final now = DateTime(2026, 1, 1, 12);
+  group('RefundCalculator binary policy', () {
+    const amount = 10000;
+    final now = DateTime(2026, 3, 16, 12, 0);
+
+    test('within grace period → full refund', () {
+      final paidAt = now.subtract(const Duration(hours: 1));
+      final eventStart = now.add(const Duration(days: 3));
       final result = RefundCalculator.calculate(
-        eventStartTime: now.add(const Duration(days: 7)),
-        paymentAmount: 10000,
+        eventStartTime: eventStart,
+        paymentAmount: amount,
+        paidAt: paidAt,
+        gracePeriodHours: 2,
+        cutoffDays: 7,
         now: now,
       );
-
       expect(result.refundPercentage, 100);
-      expect(result.refundAmount, 10000);
+      expect(result.refundAmount, amount);
       expect(result.feeAmount, 0);
     });
 
-    test('exactly 3 days returns 80% refund', () {
-      final now = DateTime(2026, 1, 1, 12);
+    test('within cutoff days → full refund', () {
+      final paidAt = now.subtract(const Duration(hours: 5));
+      final eventStart = now.add(const Duration(days: 10));
       final result = RefundCalculator.calculate(
-        eventStartTime: now.add(const Duration(days: 3)),
-        paymentAmount: 10000,
+        eventStartTime: eventStart,
+        paymentAmount: amount,
+        paidAt: paidAt,
+        gracePeriodHours: 2,
+        cutoffDays: 7,
         now: now,
       );
-
-      expect(result.refundPercentage, 80);
-      expect(result.refundAmount, 8000);
-      expect(result.feeAmount, 2000);
+      expect(result.refundPercentage, 100);
+      expect(result.refundAmount, amount);
+      expect(result.feeAmount, 0);
     });
 
-    test('exactly 1 day returns 50% refund', () {
-      final now = DateTime(2026, 1, 1, 12);
+    test('both conditions fail → no refund', () {
+      final paidAt = now.subtract(const Duration(hours: 5));
+      final eventStart = now.add(const Duration(days: 3));
       final result = RefundCalculator.calculate(
-        eventStartTime: now.add(const Duration(days: 1)),
-        paymentAmount: 10000,
+        eventStartTime: eventStart,
+        paymentAmount: amount,
+        paidAt: paidAt,
+        gracePeriodHours: 2,
+        cutoffDays: 7,
         now: now,
       );
-
-      expect(result.refundPercentage, 50);
-      expect(result.refundAmount, 5000);
-      expect(result.feeAmount, 5000);
-    });
-
-    test('event already started returns 0% refund', () {
-      final now = DateTime(2026, 1, 1, 12);
-      final result = RefundCalculator.calculate(
-        eventStartTime: now.subtract(const Duration(hours: 1)),
-        paymentAmount: 10000,
-        now: now,
-      );
-
       expect(result.refundPercentage, 0);
       expect(result.refundAmount, 0);
-      expect(result.feeAmount, 10000);
+      expect(result.feeAmount, amount);
+    });
+
+    test('paidAt null + within cutoff → full refund', () {
+      final eventStart = now.add(const Duration(days: 10));
+      final result = RefundCalculator.calculate(
+        eventStartTime: eventStart,
+        paymentAmount: amount,
+        paidAt: null,
+        gracePeriodHours: 2,
+        cutoffDays: 7,
+        now: now,
+      );
+      expect(result.refundPercentage, 100);
+      expect(result.refundAmount, amount);
+    });
+
+    test('paidAt null + outside cutoff → no refund', () {
+      final eventStart = now.add(const Duration(days: 3));
+      final result = RefundCalculator.calculate(
+        eventStartTime: eventStart,
+        paymentAmount: amount,
+        paidAt: null,
+        gracePeriodHours: 2,
+        cutoffDays: 7,
+        now: now,
+      );
+      expect(result.refundPercentage, 0);
+      expect(result.refundAmount, 0);
+    });
+
+    test('exactly at grace period boundary → full refund', () {
+      final paidAt = now.subtract(const Duration(hours: 2));
+      final eventStart = now.add(const Duration(days: 3));
+      final result = RefundCalculator.calculate(
+        eventStartTime: eventStart,
+        paymentAmount: amount,
+        paidAt: paidAt,
+        gracePeriodHours: 2,
+        cutoffDays: 7,
+        now: now,
+      );
+      expect(result.refundPercentage, 100);
+    });
+
+    test('exactly at cutoff boundary → full refund', () {
+      final paidAt = now.subtract(const Duration(hours: 5));
+      final eventStart = now.add(const Duration(days: 7));
+      final result = RefundCalculator.calculate(
+        eventStartTime: eventStart,
+        paymentAmount: amount,
+        paidAt: paidAt,
+        gracePeriodHours: 2,
+        cutoffDays: 7,
+        now: now,
+      );
+      expect(result.refundPercentage, 100);
     });
 
     test('zero payment amount returns zero amounts', () {
-      final now = DateTime(2026, 1, 1, 12);
+      final eventStart = now.add(const Duration(days: 10));
       final result = RefundCalculator.calculate(
-        eventStartTime: now.add(const Duration(days: 10)),
+        eventStartTime: eventStart,
         paymentAmount: 0,
+        paidAt: null,
+        gracePeriodHours: 2,
+        cutoffDays: 7,
         now: now,
       );
-
       expect(result.refundAmount, 0);
       expect(result.feeAmount, 0);
-    });
-
-    test('large payment amount calculates correctly', () {
-      final now = DateTime(2026, 1, 1, 12);
-      final result = RefundCalculator.calculate(
-        eventStartTime: now.add(const Duration(days: 5)),
-        paymentAmount: 1000000,
-        now: now,
-      );
-
-      expect(result.refundPercentage, 80);
-      expect(result.refundAmount, 800000);
-      expect(result.feeAmount, 200000);
-    });
-
-    test('23 hours 59 minutes returns 0% refund', () {
-      final now = DateTime(2026, 1, 1, 12);
-      final result = RefundCalculator.calculate(
-        eventStartTime: now.add(
-          const Duration(hours: 23, minutes: 59),
-        ),
-        paymentAmount: 10000,
-        now: now,
-      );
-
-      expect(result.refundPercentage, 0);
-      expect(result.refundAmount, 0);
-      expect(result.feeAmount, 10000);
     });
   });
 }

--- a/supabase/functions/e2e-test-runner/sim_assertions.ts
+++ b/supabase/functions/e2e-test-runner/sim_assertions.ts
@@ -163,6 +163,7 @@ export async function simAssertVerificationApproved(
 // Phase 4 — 환불 검증
 // ─────────────────────────────────────────────────────────
 
+// Fix #133: 환불 시뮬레이션 로직을 binary DB-driven 정책(100%/0%)으로 정렬
 export function simCalcRefund(
   startTime: Date,
   paymentAmount: number,
@@ -176,19 +177,10 @@ export function simCalcRefund(
     paidAt.getTime() <= now.getTime() &&
     now.getTime() - paidAt.getTime() <= gracePeriodHours * 60 * 60 * 1000;
 
-  const daysUntilEvent = (startTime.getTime() - now.getTime()) / (24 * 60 * 60 * 1000);
+  const withinCutoff =
+    startTime.getTime() - now.getTime() >= cutoffDays * 24 * 60 * 60 * 1000;
 
-  let percentage: number;
-  if (withinGracePeriod || daysUntilEvent >= cutoffDays) {
-    percentage = 100;
-  } else if (daysUntilEvent >= 3) {
-    percentage = 80;
-  } else if (daysUntilEvent >= 1) {
-    percentage = 50;
-  } else {
-    percentage = 0;
-  }
-
+  const percentage = withinGracePeriod || withinCutoff ? 100 : 0;
   const refundAmount = Math.floor((paymentAmount * percentage) / 100);
   const feeAmount = paymentAmount - refundAmount;
   return { refund_percentage: percentage, refund_amount: refundAmount, fee_amount: feeAmount };

--- a/supabase/functions/e2e-test-runner/sim_assertions.ts
+++ b/supabase/functions/e2e-test-runner/sim_assertions.ts
@@ -166,10 +166,10 @@ export async function simAssertVerificationApproved(
 export function simCalcRefund(
   startTime: Date,
   paymentAmount: number,
+  now: Date = new Date(),
   paidAt: Date | null = null,
   gracePeriodHours: number = 2,
   cutoffDays: number = 7,
-  now: Date = new Date(),
 ): SimRefundCalc {
   const withinGracePeriod =
     paidAt !== null &&

--- a/supabase/functions/e2e-test-runner/sim_assertions.ts
+++ b/supabase/functions/e2e-test-runner/sim_assertions.ts
@@ -173,12 +173,22 @@ export function simCalcRefund(
 ): SimRefundCalc {
   const withinGracePeriod =
     paidAt !== null &&
+    paidAt.getTime() <= now.getTime() &&
     now.getTime() - paidAt.getTime() <= gracePeriodHours * 60 * 60 * 1000;
 
-  const withinCutoff =
-    startTime.getTime() - now.getTime() >= cutoffDays * 24 * 60 * 60 * 1000;
+  const daysUntilEvent = (startTime.getTime() - now.getTime()) / (24 * 60 * 60 * 1000);
 
-  const percentage = withinGracePeriod || withinCutoff ? 100 : 0;
+  let percentage: number;
+  if (withinGracePeriod || daysUntilEvent >= cutoffDays) {
+    percentage = 100;
+  } else if (daysUntilEvent >= 3) {
+    percentage = 80;
+  } else if (daysUntilEvent >= 1) {
+    percentage = 50;
+  } else {
+    percentage = 0;
+  }
+
   const refundAmount = Math.floor((paymentAmount * percentage) / 100);
   const feeAmount = paymentAmount - refundAmount;
   return { refund_percentage: percentage, refund_amount: refundAmount, fee_amount: feeAmount };

--- a/supabase/functions/e2e-test-runner/sim_assertions.ts
+++ b/supabase/functions/e2e-test-runner/sim_assertions.ts
@@ -166,17 +166,19 @@ export async function simAssertVerificationApproved(
 export function simCalcRefund(
   startTime: Date,
   paymentAmount: number,
+  paidAt: Date | null = null,
+  gracePeriodHours: number = 2,
+  cutoffDays: number = 7,
   now: Date = new Date(),
 ): SimRefundCalc {
-  const diffMs = startTime.getTime() - now.getTime();
-  const diffDays = diffMs / (1000 * 60 * 60 * 24);
+  const withinGracePeriod =
+    paidAt !== null &&
+    now.getTime() - paidAt.getTime() <= gracePeriodHours * 60 * 60 * 1000;
 
-  let percentage = 0;
-  if (diffDays >= 7) percentage = 100;
-  else if (diffDays >= 3) percentage = 80;
-  else if (diffDays >= 1) percentage = 50;
-  // else 0 (< 1 day)
+  const withinCutoff =
+    startTime.getTime() - now.getTime() >= cutoffDays * 24 * 60 * 60 * 1000;
 
+  const percentage = withinGracePeriod || withinCutoff ? 100 : 0;
   const refundAmount = Math.floor((paymentAmount * percentage) / 100);
   const feeAmount = paymentAmount - refundAmount;
   return { refund_percentage: percentage, refund_amount: refundAmount, fee_amount: feeAmount };

--- a/supabase/functions/e2e-test-runner/sim_assertions_test.ts
+++ b/supabase/functions/e2e-test-runner/sim_assertions_test.ts
@@ -23,7 +23,7 @@ import {
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 // ─────────────────────────────────────────────────────────
-// simCalcRefund — 4 tiers
+// simCalcRefund — binary policy (100% or 0%)
 // ─────────────────────────────────────────────────────────
 
 Deno.test("simCalcRefund - 7d+ returns 100%", () => {
@@ -44,40 +44,40 @@ Deno.test("simCalcRefund - exactly 7d returns 100%", () => {
   assertEquals(result.fee_amount, 0);
 });
 
-Deno.test("simCalcRefund - 3-7d returns 80%", () => {
+Deno.test("simCalcRefund - 3-7d returns 0% (binary policy)", () => {
   const now = new Date();
   const startTime = new Date(now.getTime() + 5 * 24 * 60 * 60 * 1000);
   const result = simCalcRefund(startTime, 10000, now);
-  assertEquals(result.refund_percentage, 80);
-  assertEquals(result.refund_amount, 8000);
-  assertEquals(result.fee_amount, 2000);
+  assertEquals(result.refund_percentage, 0);
+  assertEquals(result.refund_amount, 0);
+  assertEquals(result.fee_amount, 10000);
 });
 
-Deno.test("simCalcRefund - exactly 3d returns 80%", () => {
+Deno.test("simCalcRefund - exactly 3d returns 0% (binary policy)", () => {
   const now = new Date();
   const startTime = new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000);
   const result = simCalcRefund(startTime, 10000, now);
-  assertEquals(result.refund_percentage, 80);
-  assertEquals(result.refund_amount, 8000);
-  assertEquals(result.fee_amount, 2000);
+  assertEquals(result.refund_percentage, 0);
+  assertEquals(result.refund_amount, 0);
+  assertEquals(result.fee_amount, 10000);
 });
 
-Deno.test("simCalcRefund - 1-3d returns 50%", () => {
+Deno.test("simCalcRefund - 1-3d returns 0% (binary policy)", () => {
   const now = new Date();
   const startTime = new Date(now.getTime() + 2 * 24 * 60 * 60 * 1000);
   const result = simCalcRefund(startTime, 10000, now);
-  assertEquals(result.refund_percentage, 50);
-  assertEquals(result.refund_amount, 5000);
-  assertEquals(result.fee_amount, 5000);
+  assertEquals(result.refund_percentage, 0);
+  assertEquals(result.refund_amount, 0);
+  assertEquals(result.fee_amount, 10000);
 });
 
-Deno.test("simCalcRefund - exactly 1d returns 50%", () => {
+Deno.test("simCalcRefund - exactly 1d returns 0% (binary policy)", () => {
   const now = new Date();
   const startTime = new Date(now.getTime() + 1 * 24 * 60 * 60 * 1000);
   const result = simCalcRefund(startTime, 10000, now);
-  assertEquals(result.refund_percentage, 50);
-  assertEquals(result.refund_amount, 5000);
-  assertEquals(result.fee_amount, 5000);
+  assertEquals(result.refund_percentage, 0);
+  assertEquals(result.refund_amount, 0);
+  assertEquals(result.fee_amount, 10000);
 });
 
 Deno.test("simCalcRefund - <1d returns 0%", () => {
@@ -89,12 +89,12 @@ Deno.test("simCalcRefund - <1d returns 0%", () => {
   assertEquals(result.fee_amount, 10000);
 });
 
-Deno.test("simCalcRefund - floor math (odd amount)", () => {
+Deno.test("simCalcRefund - floor math (100% case)", () => {
   const now = new Date();
-  const startTime = new Date(now.getTime() + 5 * 24 * 60 * 60 * 1000); // 80%
-  const result = simCalcRefund(startTime, 10001, now); // 10001 * 80 / 100 = 8000.8 → floor = 8000
-  assertEquals(result.refund_amount, 8000);
-  assertEquals(result.fee_amount, 10001 - 8000);
+  const startTime = new Date(now.getTime() + 8 * 24 * 60 * 60 * 1000);
+  const result = simCalcRefund(startTime, 10001, now);
+  assertEquals(result.refund_amount, 10001);
+  assertEquals(result.fee_amount, 0);
 });
 
 // ─────────────────────────────────────────────────────────

--- a/supabase/functions/e2e-test-runner/sim_refund.ts
+++ b/supabase/functions/e2e-test-runner/sim_refund.ts
@@ -99,7 +99,7 @@ export async function simRefundRequests(
       const ev = eventData as any;
       const startTime = new Date(ev.start_time);
 
-      const refundCalc = simCalcRefund(startTime, paymentAmount, new Date());
+       const refundCalc = simCalcRefund(startTime, paymentAmount, null, 2, 7, new Date());
 
       const refundStatus = refundCalc.refund_percentage > 0 ? "completed" : "failed";
       const { error: updateErr } = await supabase

--- a/supabase/functions/e2e-test-runner/sim_refund.ts
+++ b/supabase/functions/e2e-test-runner/sim_refund.ts
@@ -99,7 +99,7 @@ export async function simRefundRequests(
       const ev = eventData as any;
       const startTime = new Date(ev.start_time);
 
-       const refundCalc = simCalcRefund(startTime, paymentAmount, null, 2, 7, new Date());
+      const refundCalc = simCalcRefund(startTime, paymentAmount, new Date(), null, 2, 7);
 
       const refundStatus = refundCalc.refund_percentage > 0 ? "completed" : "failed";
       const { error: updateErr } = await supabase

--- a/supabase/functions/e2e-test-runner/sim_refund_test.ts
+++ b/supabase/functions/e2e-test-runner/sim_refund_test.ts
@@ -123,13 +123,13 @@ Deno.test("simRefundRequests - 100% refund (event +30 days) → refund_amount ==
   assertEquals(deletedParticipants.length, 1);
 });
 
-Deno.test("simRefundRequests - 80% refund (event +5 days) → floor calculation correct", async () => {
+Deno.test("simRefundRequests - 0% refund (event +5 days, binary policy) → refund_amount=0", async () => {
   const paymentAmount = 10000;
   const startTime = daysFromNow(5);
   const expectedCalc = simCalcRefund(new Date(startTime), paymentAmount, new Date());
 
-  assertEquals(expectedCalc.refund_percentage, 80);
-  assertEquals(expectedCalc.refund_amount, Math.floor(paymentAmount * 80 / 100));
+  assertEquals(expectedCalc.refund_percentage, 0);
+  assertEquals(expectedCalc.refund_amount, 0);
 
   const appStates: Record<string, { status: string; refund_status: string; refund_amount: number }> = {};
 
@@ -192,18 +192,18 @@ Deno.test("simRefundRequests - 80% refund (event +5 days) → floor calculation 
     1.0,
   );
 
-  assertEquals(result.refundedApplicationIds.length, 1);
-  assertEquals(appStates["app-80pct"].refund_status, "completed");
-  assertEquals(appStates["app-80pct"].refund_amount, Math.floor(paymentAmount * 80 / 100));
+  assertEquals(result.refundedApplicationIds.length, 0);
+  assertEquals(appStates["app-80pct"].refund_status, "failed");
+  assertEquals(appStates["app-80pct"].refund_amount, 0);
 });
 
-Deno.test("simRefundRequests - 50% refund (event +2 days) → floor calculation correct", async () => {
+Deno.test("simRefundRequests - 0% refund (event +2 days, binary policy) → refund_amount=0", async () => {
   const paymentAmount = 9999;
   const startTime = daysFromNow(2);
   const expectedCalc = simCalcRefund(new Date(startTime), paymentAmount, new Date());
 
-  assertEquals(expectedCalc.refund_percentage, 50);
-  assertEquals(expectedCalc.refund_amount, Math.floor(paymentAmount * 50 / 100));
+  assertEquals(expectedCalc.refund_percentage, 0);
+  assertEquals(expectedCalc.refund_amount, 0);
 
   const appStates: Record<string, { status: string; refund_status: string; refund_amount: number }> = {};
 
@@ -268,8 +268,8 @@ Deno.test("simRefundRequests - 50% refund (event +2 days) → floor calculation 
 
   assertEquals(result.assertions.length, 1);
   assertEquals(appStates["app-50pct"].status, "cancelled");
-  assertEquals(appStates["app-50pct"].refund_status, "completed");
-  assertEquals(appStates["app-50pct"].refund_amount, Math.floor(paymentAmount * 50 / 100));
+  assertEquals(appStates["app-50pct"].refund_status, "failed");
+  assertEquals(appStates["app-50pct"].refund_amount, 0);
 });
 
 Deno.test("simRefundRequests - 0% refund (+12 hours) → refund_amount=0, status='failed'", async () => {

--- a/supabase/functions/payment-cancel/index.ts
+++ b/supabase/functions/payment-cancel/index.ts
@@ -64,7 +64,18 @@ Deno.serve(withSentry(async (req) => {
       supabase.rpc("get_current_policy", { p_key: "refund" }),
     ]);
 
-    if (eventResult.data && policyResult.data) {
+    // Fix #133: 이벤트/정책 조회 실패 시 적격성 검사를 건너뛰지 않고 명시적으로 에러 반환
+    if (eventResult.error || !eventResult.data) {
+      console.error("Failed to fetch event:", eventResult.error);
+      return errorResponse("Failed to verify refund eligibility", 500);
+    }
+
+    if (policyResult.error || !policyResult.data) {
+      console.error("Failed to fetch policy:", policyResult.error);
+      return errorResponse("Failed to verify refund eligibility", 500);
+    }
+
+    {
       const policy = policyResult.data as Record<string, number>;
       const gracePeriodHours = policy.grace_period_hours ?? 2;
       const cutoffDays = policy.cutoff_days ?? 7;

--- a/supabase/functions/payment-cancel/index.ts
+++ b/supabase/functions/payment-cancel/index.ts
@@ -39,12 +39,17 @@ Deno.serve(withSentry(async (req) => {
     // 1.5a Fetch application for eligibility check
     const { data: application, error: appError } = await supabase
       .from("event_applications")
-      .select("paid_at, event_id, refund_status")
+      .select("paid_at, event_id, refund_status, user_id")
       .eq("payment_id", payment_id)
       .single();
 
     if (appError || !application) {
       return errorResponse("Application not found", 404);
+    }
+
+    // Fix #133: 호출자가 신청자 본인인지 검증 — service role은 RLS를 우회하므로 명시적 확인 필요
+    if (application.user_id !== auth) {
+      return errorResponse("Forbidden", 403);
     }
 
     // 1.5b Prevent double refund

--- a/supabase/functions/payment-cancel/index.ts
+++ b/supabase/functions/payment-cancel/index.ts
@@ -30,6 +30,63 @@ Deno.serve(withSentry(async (req) => {
       return errorResponse("Missing payment_id", 400);
     }
 
+    // 1.5 Init Supabase (reused throughout)
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+    );
+
+    // 1.5a Fetch application for eligibility check
+    const { data: application, error: appError } = await supabase
+      .from("event_applications")
+      .select("paid_at, event_id, refund_status")
+      .eq("payment_id", payment_id)
+      .single();
+
+    if (appError || !application) {
+      return errorResponse("Application not found", 404);
+    }
+
+    // 1.5b Prevent double refund
+    if (application.refund_status !== "none") {
+      return errorResponse("already_refunded", 400, {
+        reason: "Refund already processed",
+      });
+    }
+
+    // 1.5c Verify refund eligibility against policy
+    const [eventResult, policyResult] = await Promise.all([
+      supabase
+        .from("events")
+        .select("start_time")
+        .eq("id", application.event_id)
+        .single(),
+      supabase.rpc("get_current_policy", { p_key: "refund" }),
+    ]);
+
+    if (eventResult.data && policyResult.data) {
+      const policy = policyResult.data as Record<string, number>;
+      const gracePeriodHours = policy.grace_period_hours ?? 2;
+      const cutoffDays = policy.cutoff_days ?? 7;
+      const now = new Date();
+      const paidAt = application.paid_at ? new Date(application.paid_at) : null;
+      const eventStart = new Date(eventResult.data.start_time);
+
+      const withinGracePeriod =
+        paidAt !== null &&
+        now.getTime() - paidAt.getTime() <=
+          gracePeriodHours * 60 * 60 * 1000;
+      const withinCutoff =
+        eventStart.getTime() - now.getTime() >=
+          cutoffDays * 24 * 60 * 60 * 1000;
+
+      if (!withinGracePeriod && !withinCutoff) {
+        return errorResponse("refund_not_eligible", 400, {
+          reason: "Refund window has expired",
+        });
+      }
+    }
+
     // 2. Init IamportClient
     const impKey = Deno.env.get("PORTONE_API_KEY");
     const impSecret = Deno.env.get("PORTONE_API_SECRET");
@@ -60,10 +117,6 @@ Deno.serve(withSentry(async (req) => {
 
     // 4. Update DB: refund_status + refund_amount
     const refundAmount = amount ?? (cancelResponse.amount as number | undefined);
-    const supabase = createClient(
-      Deno.env.get("SUPABASE_URL") ?? "",
-      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
-    );
     const updatePayload: Record<string, unknown> = {
       refund_status: "completed",
       updated_at: new Date().toISOString(),

--- a/supabase/functions/payment-cancel/index.ts
+++ b/supabase/functions/payment-cancel/index.ts
@@ -83,8 +83,10 @@ Deno.serve(withSentry(async (req) => {
       const paidAt = application.paid_at ? new Date(application.paid_at) : null;
       const eventStart = new Date(eventResult.data.start_time);
 
+      // Fix #133: 미래 paid_at은 음수 duration으로 grace period를 통과하므로 명시적으로 제외
       const withinGracePeriod =
         paidAt !== null &&
+        paidAt.getTime() <= now.getTime() &&
         now.getTime() - paidAt.getTime() <=
           gracePeriodHours * 60 * 60 * 1000;
       const withinCutoff =

--- a/supabase/functions/payment-cancel/payment_cancel_test.ts
+++ b/supabase/functions/payment-cancel/payment_cancel_test.ts
@@ -19,23 +19,68 @@ const ENV = {
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
 };
 
-Deno.test("payment-cancel - happy path cancels payment and updates DB", async () => {
+const nowMs = Date.now();
+const eligiblePaidAt = new Date(nowMs - 1 * 60 * 60 * 1000).toISOString(); // 1시간 전
+const ineligiblePaidAt = new Date(nowMs - 3 * 60 * 60 * 1000).toISOString(); // 3시간 전
+const farFutureEvent = new Date(nowMs + 10 * 24 * 60 * 60 * 1000).toISOString(); // 10일 후
+const nearFutureEvent = new Date(nowMs + 3 * 24 * 60 * 60 * 1000).toISOString(); // 3일 후
+
+function appRoute(overrides?: { paid_at?: string | null; refund_status?: string }) {
+  return {
+    matcher: (req: Request) =>
+      req.url.includes("/rest/v1/event_applications") && req.method === "GET",
+    handler: () =>
+      jsonResponse({
+        paid_at: overrides?.paid_at !== undefined ? overrides.paid_at : eligiblePaidAt,
+        event_id: "event-123",
+        refund_status: overrides?.refund_status ?? "none",
+      }),
+  };
+}
+
+function eventRoute(start_time?: string) {
+  return {
+    matcher: (req: Request) =>
+      req.url.includes("/rest/v1/events") && req.method === "GET",
+    handler: () => jsonResponse({ start_time: start_time ?? farFutureEvent }),
+  };
+}
+
+function policyRoute() {
+  return {
+    matcher: (req: Request) =>
+      req.url.includes("/rest/v1/rpc/get_current_policy") && req.method === "POST",
+    handler: () => jsonResponse({ grace_period_hours: 2, cutoff_days: 7 }),
+  };
+}
+
+const portoneTokenRoute = {
+  matcher: "https://api.iamport.kr/users/getToken",
+  handler: () => jsonResponse({ code: 0, response: { access_token: "token" } }),
+};
+
+const portoneCancelRoute = {
+  matcher: "https://api.iamport.kr/payments/cancel",
+  handler: () => jsonResponse({ code: 0, response: { status: "cancelled", amount: 15000 } }),
+};
+
+const dbUpdateRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/event_applications") && req.method === "PATCH",
+  handler: () => jsonResponse({}),
+};
+
+Deno.test("payment-cancel - eligible (within grace period) → 200", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock, calls } = createFetchMock([
     authRoute,
-    {
-      matcher: "https://api.iamport.kr/users/getToken",
-      handler: () => jsonResponse({ code: 0, response: { access_token: "token" } }),
-    },
-    {
-      matcher: "https://api.iamport.kr/payments/cancel",
-      handler: () => jsonResponse({ code: 0, response: { status: "cancelled", amount: 15000 } }),
-    },
-    {
-      matcher: (req) => req.url.includes("/rest/v1/event_applications") && req.method === "PATCH",
-      handler: () => jsonResponse({}),
-    },
+    appRoute({ paid_at: eligiblePaidAt }), // 1시간 전 결제
+    eventRoute(nearFutureEvent),             // 3일 후 이벤트 (cutoff 불합격)
+    policyRoute(),
+    portoneTokenRoute,
+    portoneCancelRoute,
+    dbUpdateRoute,
   ]);
 
   await withEnv(ENV, async () => {
@@ -52,9 +97,122 @@ Deno.test("payment-cancel - happy path cancels payment and updates DB", async ()
         assertEquals(response.status, 200);
         assertEquals(payload.success, true);
 
-        const dbCall = calls.find((c) => c.url.includes("/rest/v1/event_applications") && c.method === "PATCH");
+        const dbCall = calls.find(
+          (c) => c.url.includes("/rest/v1/event_applications") && c.method === "PATCH",
+        );
         const dbBody = JSON.parse(dbCall!.body!);
         assertEquals(dbBody.refund_status, "completed");
+      });
+    });
+  });
+});
+
+Deno.test("payment-cancel - ineligible (3h after payment, 3 days before event) → 400", async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    appRoute({ paid_at: ineligiblePaidAt }), // 3시간 전 결제 (grace 불합격)
+    eventRoute(nearFutureEvent),              // 3일 후 이벤트 (cutoff 불합격)
+    policyRoute(),
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          payment_id: "imp_123",
+        });
+
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "refund_not_eligible");
+      });
+    });
+  });
+});
+
+Deno.test("payment-cancel - already refunded → 400", async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    appRoute({ refund_status: "completed" }),
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          payment_id: "imp_123",
+        });
+
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "already_refunded");
+      });
+    });
+  });
+});
+
+Deno.test("payment-cancel - application not found → 404", async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    {
+      matcher: (req: Request) =>
+        req.url.includes("/rest/v1/event_applications") && req.method === "GET",
+      handler: () => jsonResponse({ error: { message: "not found" } }, { status: 406 }),
+    },
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          payment_id: "imp_unknown",
+        });
+
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 404);
+        assertEquals(payload.error, "Application not found");
+      });
+    });
+  });
+});
+
+Deno.test("payment-cancel - paidAt null + within cutoff → eligible → 200", async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    appRoute({ paid_at: null }),     // paid_at 없음 → grace 불합격
+    eventRoute(farFutureEvent),      // 10일 후 이벤트 → cutoff 합격
+    policyRoute(),
+    portoneTokenRoute,
+    portoneCancelRoute,
+    dbUpdateRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          payment_id: "imp_123",
+        });
+
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 200);
+        assertEquals(payload.success, true);
       });
     });
   });
@@ -83,6 +241,9 @@ Deno.test("payment-cancel - token failure returns 502", async () => {
 
   const { fetchMock } = createFetchMock([
     authRoute,
+    appRoute(),
+    eventRoute(),
+    policyRoute(),
     {
       matcher: "https://api.iamport.kr/users/getToken",
       handler: () => jsonResponse({ code: 1, message: "bad key" }),
@@ -126,18 +287,15 @@ Deno.test("payment-cancel - partial refund passes amount and checksum to iamport
 
   const { fetchMock, calls } = createFetchMock([
     authRoute,
-    {
-      matcher: "https://api.iamport.kr/users/getToken",
-      handler: () => jsonResponse({ code: 0, response: { access_token: "token" } }),
-    },
+    appRoute(),
+    eventRoute(),
+    policyRoute(),
+    portoneTokenRoute,
     {
       matcher: "https://api.iamport.kr/payments/cancel",
       handler: () => jsonResponse({ code: 0, response: { status: "cancelled", amount: 5000 } }),
     },
-    {
-      matcher: (req) => req.url.includes("/rest/v1/event_applications") && req.method === "PATCH",
-      handler: () => jsonResponse({}),
-    },
+    dbUpdateRoute,
   ]);
 
   await withEnv(ENV, async () => {
@@ -172,16 +330,17 @@ Deno.test("payment-cancel - DB error is non-fatal, still returns 200", async () 
 
   const { fetchMock } = createFetchMock([
     authRoute,
-    {
-      matcher: "https://api.iamport.kr/users/getToken",
-      handler: () => jsonResponse({ code: 0, response: { access_token: "token" } }),
-    },
+    appRoute(),
+    eventRoute(),
+    policyRoute(),
+    portoneTokenRoute,
     {
       matcher: "https://api.iamport.kr/payments/cancel",
       handler: () => jsonResponse({ code: 0, response: { status: "cancelled" } }),
     },
     {
-      matcher: (req) => req.url.includes("/rest/v1/event_applications") && req.method === "PATCH",
+      matcher: (req: Request) =>
+        req.url.includes("/rest/v1/event_applications") && req.method === "PATCH",
       handler: () => jsonResponse({ error: { message: "DB error" } }, { status: 500 }),
     },
   ]);

--- a/supabase/functions/payment-cancel/payment_cancel_test.ts
+++ b/supabase/functions/payment-cancel/payment_cancel_test.ts
@@ -25,7 +25,7 @@ const ineligiblePaidAt = new Date(nowMs - 3 * 60 * 60 * 1000).toISOString(); // 
 const farFutureEvent = new Date(nowMs + 10 * 24 * 60 * 60 * 1000).toISOString(); // 10일 후
 const nearFutureEvent = new Date(nowMs + 3 * 24 * 60 * 60 * 1000).toISOString(); // 3일 후
 
-function appRoute(overrides?: { paid_at?: string | null; refund_status?: string }) {
+function appRoute(overrides?: { paid_at?: string | null; refund_status?: string; user_id?: string }) {
   return {
     matcher: (req: Request) =>
       req.url.includes("/rest/v1/event_applications") && req.method === "GET",
@@ -34,6 +34,7 @@ function appRoute(overrides?: { paid_at?: string | null; refund_status?: string 
         paid_at: overrides?.paid_at !== undefined ? overrides.paid_at : eligiblePaidAt,
         event_id: "event-123",
         refund_status: overrides?.refund_status ?? "none",
+        user_id: overrides?.user_id ?? "user-123",
       }),
   };
 }
@@ -320,6 +321,31 @@ Deno.test("payment-cancel - partial refund passes amount and checksum to iamport
         const dbBody = JSON.parse(dbCall!.body!);
         assertEquals(dbBody.refund_status, "completed");
         assertEquals(dbBody.refund_amount, 5000);
+      });
+    });
+  });
+});
+
+Deno.test("payment-cancel - different user's payment → 403", async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    appRoute({ user_id: "other-user-456" }),
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          payment_id: "imp_123",
+        });
+
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 403);
+        assertEquals(payload.error, "Forbidden");
       });
     });
   });

--- a/supabase/functions/payment-verify/index.ts
+++ b/supabase/functions/payment-verify/index.ts
@@ -73,20 +73,26 @@ Deno.serve(withSentry(async (req) => {
       });
     }
 
-    // 4. Supabase DB 업데이트 (티켓 발권 및 신청 상태 변경)
-    // ... rest of the logic ...
-    
-    // Note: We used service role key so auth check via header is optional but good practice if we want to link user.
-    // But since we have merchant_uid which is unique, we can just update.
-    
-    const { error: updateError } = await supabase
-      .from("event_applications")
-      .update({
-        status: "approved",
-        payment_id: imp_uid,
-        updated_at: new Date().toISOString(),
-      })
-      .eq("id", merchant_uid);
+     // 4. Supabase DB 업데이트 (티켓 발권 및 신청 상태 변경)
+     // ... rest of the logic ...
+     
+     // Note: We used service role key so auth check via header is optional but good practice if we want to link user.
+     // But since we have merchant_uid which is unique, we can just update.
+     
+     // payment.paid_at is Unix seconds from Portone V1 API
+     const paidAtIso = payment.paid_at && payment.paid_at > 0
+       ? new Date(payment.paid_at * 1000).toISOString()
+       : new Date().toISOString();
+     
+     const { error: updateError } = await supabase
+       .from("event_applications")
+       .update({
+         status: "approved",
+         payment_id: imp_uid,
+         paid_at: paidAtIso,
+         updated_at: new Date().toISOString(),
+       })
+       .eq("id", merchant_uid);
 
     if (updateError) {
       console.error("DB Update Error:", updateError);

--- a/supabase/functions/payment-webhook/index.ts
+++ b/supabase/functions/payment-webhook/index.ts
@@ -75,15 +75,20 @@ serve(withSentry(async (req) => {
         dbStatus = `unknown_${payment.status}`;
     }
 
-    // Update event_applications table
-    const updatePayload: Record<string, unknown> = {
-      status: dbStatus,
-      payment_id: imp_uid,
-      updated_at: new Date().toISOString(),
-    };
-    if (payment.status === "cancelled") {
-      updatePayload.refund_status = "completed";
-    }
+     // Update event_applications table
+     const paidAtIso = payment.paid_at && payment.paid_at > 0
+       ? new Date(payment.paid_at * 1000).toISOString()
+       : new Date().toISOString();
+     
+     const updatePayload: Record<string, unknown> = {
+       status: dbStatus,
+       payment_id: imp_uid,
+       updated_at: new Date().toISOString(),
+       ...(payment.status === "paid" ? { paid_at: paidAtIso } : {}),
+     };
+     if (payment.status === "cancelled") {
+       updatePayload.refund_status = "completed";
+     }
     const { error } = await supabase
       .from("event_applications")
       .update(updatePayload)

--- a/supabase/functions/payment-webhook/index.ts
+++ b/supabase/functions/payment-webhook/index.ts
@@ -76,15 +76,16 @@ serve(withSentry(async (req) => {
     }
 
      // Update event_applications table
+     // Fix #133: paid_at 없을 때 now로 폴백하면 재시도마다 paid_at이 밀려 멱등성 깨짐 — 실제 결제 시각이 있을 때만 업데이트
      const paidAtIso = payment.paid_at && payment.paid_at > 0
        ? new Date(payment.paid_at * 1000).toISOString()
-       : new Date().toISOString();
+       : null;
      
      const updatePayload: Record<string, unknown> = {
        status: dbStatus,
        payment_id: imp_uid,
        updated_at: new Date().toISOString(),
-       ...(payment.status === "paid" ? { paid_at: paidAtIso } : {}),
+       ...(payment.status === "paid" && paidAtIso ? { paid_at: paidAtIso } : {}),
      };
      if (payment.status === "cancelled") {
        updatePayload.refund_status = "completed";

--- a/supabase/migrations/20260317000001_refund_policy_binary.sql
+++ b/supabase/migrations/20260317000001_refund_policy_binary.sql
@@ -1,0 +1,11 @@
+ALTER TABLE public.event_applications
+  ADD COLUMN IF NOT EXISTS paid_at timestamptz;
+
+INSERT INTO public.policies (key, value, version, effective_date, description)
+VALUES (
+  'refund',
+  '{"grace_period_hours": 2, "cutoff_days": 7}'::jsonb,
+  2,
+  '2026-03-01T00:00:00Z'::timestamptz,
+  'Binary refund: full refund within 2h of payment OR 7+ days before event'
+);

--- a/supabase/tests/database/52_policies_test.sql
+++ b/supabase/tests/database/52_policies_test.sql
@@ -39,8 +39,8 @@ SELECT tests.authenticate_as('policy_test_user');
 
 SELECT results_eq(
   $$SELECT count(*)::int FROM public.policies WHERE key = 'refund'$$,
-  $$VALUES (1)$$,
-  'authenticated user can SELECT policies (sees seed data)'
+  $$VALUES (2)$$,
+  'authenticated user can SELECT policies (sees both refund seed rows)'
 );
 
 SAVEPOINT before_blocked_insert;
@@ -102,10 +102,20 @@ SELECT isnt(
   'get_current_policy returns non-null for existing key'
 );
 
-SELECT results_eq(
-  $$SELECT jsonb_array_length(public.get_current_policy('refund', '2026-03-16T00:00:00Z'::timestamptz) -> 'tiers')$$,
-  $$VALUES (4)$$,
-  'refund policy has 4 tiers'
+SELECT is(
+  (public.get_current_policy('refund', '2026-03-16T00:00:00Z'::timestamptz) ->> 'grace_period_hours')::int,
+  2,
+  'current refund policy (binary) has grace_period_hours=2'
+);
+SELECT is(
+  (public.get_current_policy('refund', '2026-03-16T00:00:00Z'::timestamptz) ->> 'cutoff_days')::int,
+  7,
+  'current refund policy (binary) has cutoff_days=7'
+);
+SELECT is(
+  jsonb_array_length(public.get_current_policy('refund', '2026-01-15T00:00:00Z'::timestamptz) -> 'tiers'),
+  4,
+  'old 4-tier policy returned for timestamps before 2026-03-01'
 );
 
 -- NULL for nonexistent key
@@ -142,9 +152,9 @@ VALUES (
 );
 
 SELECT results_eq(
-  $$SELECT jsonb_array_length(public.get_current_policy('refund', '2026-03-16T00:00:00Z'::timestamptz) -> 'tiers')$$,
+  $$SELECT jsonb_array_length(public.get_current_policy('refund', '2026-02-15T00:00:00Z'::timestamptz) -> 'tiers')$$,
   $$VALUES (2)$$,
-  'newer effective_date policy (v2, 2 tiers) is returned over older (v1, 4 tiers)'
+  'test v2 (effective 2026-02-01, 2 tiers) is returned at 2026-02-15'
 );
 
 SELECT results_eq(
@@ -152,6 +162,9 @@ SELECT results_eq(
   $$VALUES (4)$$,
   'older effective_date policy (v1, 4 tiers) returned when p_at is before v2 effective_date'
 );
+
+SELECT has_column('public', 'event_applications', 'paid_at', 'event_applications has paid_at column');
+SELECT col_type_is('public', 'event_applications', 'paid_at', 'timestamp with time zone', 'paid_at is timestamptz');
 
 SELECT * FROM finish();
 ROLLBACK;


### PR DESCRIPTION
## Summary

- 하드코딩된 4-tier 환불정책을 DB 기반 binary 정책으로 전환
- `{"grace_period_hours": 2, "cutoff_days": 7}` — 숫자 2개로 정책 완전 표현
- 서버사이드 검증으로 클라이언트 시간 조작 방지

## Changes

### Backend
- `supabase/migrations/20260317000001_refund_policy_binary.sql` — `paid_at` 컬럼 + binary seed
- `supabase/tests/database/52_policies_test.sql` — 새 seed 구조 검증 추가

### Edge Functions
- `payment-verify/index.ts` — Portone `paid_at` (Unix→ISO) 저장
- `payment-webhook/index.ts` — 동일
- `payment-cancel/index.ts` — 서버사이드 환불 자격 검증 (policy 기반 거부)
- `payment-cancel/payment_cancel_test.ts` — 10개 테스트 (eligible/ineligible/duplicate/not-found)

### Flutter (minglit_kit)
- `refund_calculator.dart` — binary 로직 (100% or 0%), `paidAt` + `gracePeriodHours` + `cutoffDays` 파라미터
- `event_application.dart` — `paidAt` 필드 추가
- `policy_repository.dart` — `get_current_policy('refund')` RPC 래퍼

### Flutter (app_user)
- `purchase_history_controller.dart` — PolicyRepository fetch + binary 환불 자격 체크
- `purchase_history_card.dart` — `paidAt` 전달 + 환불 불가 다이얼로그
- `event_refund_policy_section.dart` — 하드코딩 제거, DB 기반 동적 UI

### E2E
- `sim_assertions.ts` — `simCalcRefund()` binary 로직으로 교체