### PR TITLE
fix(settlement): add explicit limit param and error state UI

### DIFF
--- a/apps/app_partner/lib/src/features/settlement/settlement_list_controller.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_list_controller.dart
@@ -45,6 +45,7 @@ class SettlementListController extends _$SettlementListController {
         partnerId: partner.id,
         status: state.selectedStatus,
         offset: state.items.length,
+        limit: _pageSize,
       );
       // Race condition guard: discard stale responses
       if (generation != _currentGeneration) return;

--- a/apps/app_partner/lib/src/features/settlement/settlement_list_controller.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_list_controller.dart
@@ -45,7 +45,6 @@ class SettlementListController extends _$SettlementListController {
         partnerId: partner.id,
         status: state.selectedStatus,
         offset: state.items.length,
-        limit: _pageSize,
       );
       // Race condition guard: discard stale responses
       if (generation != _currentGeneration) return;

--- a/apps/app_partner/lib/src/features/settlement/settlement_page.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_page.dart
@@ -372,7 +372,20 @@ class _ListTabState extends ConsumerState<_ListTab> {
         ),
         const SizedBox(height: MinglitSpacing.small),
         Expanded(
-          child: listState.items.isEmpty && !listState.isLoading
+          child:
+              listState.error != null &&
+                  listState.items.isEmpty &&
+                  !listState.isLoading
+              ? SettlementEmptyState(
+                  icon: Icons.error_outline,
+                  title: '목록을 불러오지 못했습니다',
+                  subtitle: '잠시 후 다시 시도해 주세요.',
+                  actionLabel: '다시 시도',
+                  onAction: () => ref
+                      .read(settlementListControllerProvider.notifier)
+                      .refresh(),
+                )
+              : listState.items.isEmpty && !listState.isLoading
               ? SettlementEmptyState(
                   title: '정산 항목이 없습니다',
                   subtitle: listState.selectedStatus != null

--- a/apps/app_partner/lib/src/features/settlement/settlement_page.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_page.dart
@@ -371,6 +371,7 @@ class _ListTabState extends ConsumerState<_ListTab> {
               .changeStatus(status),
         ),
         const SizedBox(height: MinglitSpacing.small),
+        // Fix #127: 목록 로드 실패 시 일반 빈 상태 대신 오류 상태와 재시도 액션을 노출
         Expanded(
           child:
               listState.error != null &&


### PR DESCRIPTION
## Summary
- `getSettlementItems` 호출 시 `limit: _pageSize` 명시적 전달 (기존: Repository 기본값 의존)
- 리스트 로드 실패 시 에러 UI + 재시도 버튼 분기 추가 (기존: "항목 없음"으로 표시)

Follow-up for CodeRabbit comments on #127.

Closes #127