### PR TITLE
feat(e2e): add daily CUJ E2E automation testing

### DIFF
--- a/.github/workflows/daily-e2e.yml
+++ b/.github/workflows/daily-e2e.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Install dependencies
         run: flutter pub get
+        working-directory: tests/e2e_automation_tester
 
       - name: Run E2E CUJ Tests
         run: |

--- a/.github/workflows/daily-e2e.yml
+++ b/.github/workflows/daily-e2e.yml
@@ -1,0 +1,52 @@
+name: Daily E2E CUJ Tests
+
+on:
+  schedule:
+    - cron: '0 22 * * *'  # Daily KST 07:00 (UTC 22:00) — runs on default branch (dev)
+  workflow_dispatch:       # Manual trigger
+
+concurrency:
+  group: daily-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Cache pub packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run E2E CUJ Tests
+        run: |
+          flutter test integration_test/ \
+            --reporter expanded \
+            --dart-define=SUPABASE_URL=${{ secrets.SUPABASE_DEV_URL }} \
+            --dart-define=SUPABASE_PUBLISHABLE_KEY=${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }} \
+            --dart-define=SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_DEV_SECRET_KEY }}
+        working-directory: tests/e2e_automation_tester
+
+  notify-failure:
+    needs: [e2e-test]
+    if: always()
+    permissions:
+      issues: write
+    uses: ./.github/workflows/notify-failure.yml
+    with:
+      success: ${{ needs.e2e-test.result == 'success' }}
+      workflow_name: 'Daily E2E CUJ'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ workspace:
   - shared/packages/minglit_lints
   - tests/test_data_seeder
   - tests/backend_integration
+  - tests/e2e_automation_tester
 
 dependency_overrides:
   iamport_webview_flutter: 3.1.0

--- a/tests/e2e_automation_tester/integration_test/cuj/cuj_01_auth_test.dart
+++ b/tests/e2e_automation_tester/integration_test/cuj/cuj_01_auth_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../utils/e2e_auth.dart';
+import '../utils/e2e_helpers.dart';
+
+/// CUJ 01: Authentication — Sign in and verify session + profile.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late SupabaseClient adminClient;
+
+  setUpAll(() async {
+    await initializeE2E();
+    adminClient = createAdminClient();
+  });
+
+  tearDownAll(() async {
+    await signOut();
+  });
+
+  group('CUJ 01: Auth', () {
+    testWidgets('Should sign in and read own profile', (tester) async {
+      // 1. Find test user email
+      final email = await getTestUserEmail(adminClient, gender: 'male');
+
+      // 2. Sign in
+      await signInAsTestUser(email);
+
+      // 3. Verify session exists
+      final currentUser = Supabase.instance.client.auth.currentUser;
+      expect(currentUser, isNotNull, reason: 'Should have an active session');
+      expect(currentUser!.email, equals(email));
+
+      // 4. Read own profile (through authenticated client — RLS applied)
+      final profile = await Supabase.instance.client
+          .from('user_profiles')
+          .select()
+          .eq('id', currentUser.id)
+          .single();
+
+      expect(profile['id'], equals(currentUser.id));
+      expect(profile['username'], isNotNull);
+      expect(profile['gender'], equals('male'));
+    });
+  });
+}

--- a/tests/e2e_automation_tester/integration_test/cuj/cuj_02_browse_test.dart
+++ b/tests/e2e_automation_tester/integration_test/cuj/cuj_02_browse_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../utils/e2e_auth.dart';
+import '../utils/e2e_helpers.dart';
+
+/// CUJ 02: Browse — Explore events and parties.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late SupabaseClient adminClient;
+
+  setUpAll(() async {
+    await initializeE2E();
+    adminClient = createAdminClient();
+  });
+
+  tearDownAll(() async {
+    await signOut();
+  });
+
+  group('CUJ 02: Browse', () {
+    testWidgets('Should browse events and parties', (tester) async {
+      // 1. Sign in
+      final email = await getTestUserEmail(adminClient, gender: 'male');
+      await signInAsTestUser(email);
+
+      final client = Supabase.instance.client;
+
+      // 2. Fetch event feed (scheduled events)
+      final events = await client
+          .from('events')
+          .select('*, party:parties(title, partner:partners(name))')
+          .eq('status', 'scheduled')
+          .order('created_at', ascending: false)
+          .limit(5) as List;
+
+      expect(events, isNotEmpty, reason: 'Dev server should have events');
+
+      // 3. Verify event data structure
+      final firstEvent = events.first as Map<String, dynamic>;
+      expect(firstEvent['id'], isNotNull);
+      expect(firstEvent['title'], isNotNull);
+      expect(firstEvent['status'], equals('scheduled'));
+
+      // 4. Verify party relation
+      final party = firstEvent['party'] as Map<String, dynamic>?;
+      expect(party, isNotNull, reason: 'Event should have a party relation');
+      expect(party!['title'], isNotNull);
+
+      // 5. Verify partner relation (nested)
+      final partner = party['partner'] as Map<String, dynamic>?;
+      expect(partner, isNotNull, reason: 'Party should have a partner');
+      expect(partner!['name'], isNotNull);
+    });
+  });
+}

--- a/tests/e2e_automation_tester/integration_test/cuj/cuj_03_application_test.dart
+++ b/tests/e2e_automation_tester/integration_test/cuj/cuj_03_application_test.dart
@@ -1,0 +1,140 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../utils/e2e_auth.dart';
+import '../utils/e2e_helpers.dart';
+
+/// CUJ 03: Application — Apply to event, get approved, become participant.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late SupabaseClient adminClient;
+  late ScheduledEventContext eventCtx;
+  late String testUserId;
+
+  setUpAll(() async {
+    await initializeE2E();
+    adminClient = createAdminClient();
+
+    eventCtx = await findScheduledEvent(adminClient);
+    final email = await getTestUserEmail(adminClient, gender: 'male');
+    await signInAsTestUser(email);
+    testUserId = Supabase.instance.client.auth.currentUser!.id;
+  });
+
+  tearDownAll(() async {
+    // Best-effort cleanup — don't fail teardown
+    try {
+      await adminClient
+          .from('event_participants')
+          .delete()
+          .eq('user_id', testUserId)
+          .eq('event_id', eventCtx.eventId);
+    } on Object catch (_) {}
+    try {
+      final appId = await _getApplicationId(
+        adminClient,
+        testUserId,
+        eventCtx.eventId,
+      );
+      if (appId != null) {
+        await adminClient
+            .from('verification_submissions')
+            .delete()
+            .eq('application_id', appId);
+        await adminClient.from('event_applications').delete().eq('id', appId);
+      }
+    } on Object catch (_) {}
+    await signOut();
+  });
+
+  group('CUJ 03: Application', () {
+    testWidgets('Should complete full application flow', (tester) async {
+      final client = Supabase.instance.client;
+
+      // 1. Cleanup any existing application (idempotent)
+      try {
+        await adminClient
+            .from('event_participants')
+            .delete()
+            .eq('user_id', testUserId)
+            .eq('event_id', eventCtx.eventId);
+        await adminClient
+            .from('event_applications')
+            .delete()
+            .eq('user_id', testUserId)
+            .eq('event_id', eventCtx.eventId);
+      } on Object catch (_) {}
+
+      // 2. Get verification ID
+      final verificationId = await getCareerVerificationId(adminClient);
+
+      // 3. Apply to event (atomic RPC)
+      final appId = await client.rpc<dynamic>(
+        'apply_event',
+        params: {
+          'p_event_id': eventCtx.eventId,
+          'p_ticket_id': eventCtx.ticketId,
+          'p_user_id': testUserId,
+          'p_payment_id': 'E2E_PAY_${Random().nextInt(99999)}',
+          'p_payment_amount': 1000,
+          'p_verification_data': {
+            'partner_id': eventCtx.partnerId,
+            'verification_id': verificationId,
+            'data': {'company': 'E2E Test Corp', 'position': 'Tester'},
+          },
+        },
+      );
+      expect(appId, isNotNull, reason: 'Application should be created');
+
+      // 4. Verify pending status
+      final app = await client
+          .from('event_applications')
+          .select()
+          .eq('id', appId as Object)
+          .single();
+      expect(app['status'], equals('pending_review'));
+
+      // 5. Admin approves verification
+      await adminClient
+          .from('verification_submissions')
+          .update({'status': 'approved'}).eq('application_id', appId);
+
+      // 6. Wait for DB trigger to process
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+
+      // 7. Verify approved + participant created
+      final updatedApp = await adminClient
+          .from('event_applications')
+          .select()
+          .eq('id', appId)
+          .single();
+      expect(updatedApp['status'], equals('approved'));
+
+      final participant = await adminClient
+          .from('event_participants')
+          .select()
+          .eq('application_id', appId)
+          .maybeSingle();
+      expect(participant, isNotNull, reason: 'Participant should be created');
+      expect(participant!['ticket_code'], isNotNull);
+    });
+  });
+}
+
+Future<String?> _getApplicationId(
+  SupabaseClient admin,
+  String userId,
+  String eventId,
+) async {
+  final res = await admin
+      .from('event_applications')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('event_id', eventId)
+      .maybeSingle();
+  return res?['id'] as String?;
+}

--- a/tests/e2e_automation_tester/integration_test/cuj/cuj_04_matching_test.dart
+++ b/tests/e2e_automation_tester/integration_test/cuj/cuj_04_matching_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../utils/e2e_auth.dart';
+import '../utils/e2e_helpers.dart';
+
+/// CUJ 04: Matching — Cast mutual votes and verify match creation.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late SupabaseClient adminClient;
+  late String maleUserId;
+  late String femaleUserId;
+  late String eventId;
+
+  setUpAll(() async {
+    await initializeE2E();
+    adminClient = createAdminClient();
+
+    // Resolve test users
+    final maleEmail = await getTestUserEmail(adminClient, gender: 'male');
+    final femaleEmail = await getTestUserEmail(adminClient, gender: 'female');
+
+    // Get user IDs via admin
+    await signInAsTestUser(maleEmail);
+    maleUserId = Supabase.instance.client.auth.currentUser!.id;
+    await signOut();
+
+    await signInAsTestUser(femaleEmail);
+    femaleUserId = Supabase.instance.client.auth.currentUser!.id;
+    await signOut();
+
+    // Get a scheduled event
+    final ctx = await findScheduledEvent(adminClient);
+    eventId = ctx.eventId;
+  });
+
+  tearDownAll(() async {
+    // Cleanup votes and matches
+    try {
+      await adminClient
+          .from('match_votes')
+          .delete()
+          .eq('event_id', eventId)
+          .inFilter('voter_id', [maleUserId, femaleUserId]);
+    } on Object catch (_) {}
+    try {
+      await adminClient
+          .from('event_matches')
+          .delete()
+          .eq('event_id', eventId)
+          .or('user_a_id.eq.$maleUserId,user_b_id.eq.$maleUserId');
+    } on Object catch (_) {}
+    await signOut();
+  });
+
+  group('CUJ 04: Matching', () {
+    testWidgets('Should cast mutual votes and verify match data',
+        (tester) async {
+      // 1. Cleanup existing votes (idempotent)
+      try {
+        await adminClient
+            .from('match_votes')
+            .delete()
+            .eq('event_id', eventId)
+            .inFilter('voter_id', [maleUserId, femaleUserId]);
+        await adminClient
+            .from('event_matches')
+            .delete()
+            .eq('event_id', eventId)
+            .or('user_a_id.eq.$maleUserId,user_b_id.eq.$maleUserId');
+      } on Object catch (_) {}
+
+      // 2. Male votes for Female
+      final maleEmail = await getTestUserEmail(adminClient, gender: 'male');
+      await signInAsTestUser(maleEmail);
+      await Supabase.instance.client.from('match_votes').insert({
+        'event_id': eventId,
+        'voter_id': maleUserId,
+        'candidate_id': femaleUserId,
+      });
+      await signOut();
+
+      // 3. Female votes for Male
+      final femaleEmail = await getTestUserEmail(adminClient, gender: 'female');
+      await signInAsTestUser(femaleEmail);
+      await Supabase.instance.client.from('match_votes').insert({
+        'event_id': eventId,
+        'voter_id': femaleUserId,
+        'candidate_id': maleUserId,
+      });
+      await signOut();
+
+      // 4. Wait for match trigger
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+
+      // 5. Verify match exists (use admin to bypass RLS)
+      final matches = await adminClient
+          .from('event_matches')
+          .select()
+          .eq('event_id', eventId)
+          .or(
+            'and(user_a_id.eq.$maleUserId,user_b_id.eq.$femaleUserId),'
+            'and(user_a_id.eq.$femaleUserId,user_b_id.eq.$maleUserId)',
+          ) as List;
+
+      expect(
+        matches,
+        isNotEmpty,
+        reason: 'Mutual votes should create a match',
+      );
+    });
+  });
+}

--- a/tests/e2e_automation_tester/integration_test/cuj/cuj_05_search_test.dart
+++ b/tests/e2e_automation_tester/integration_test/cuj/cuj_05_search_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../utils/e2e_auth.dart';
+import '../utils/e2e_helpers.dart';
+
+/// CUJ 05: Search — PGroonga full-text search for events and parties.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late SupabaseClient adminClient;
+
+  setUpAll(() async {
+    await initializeE2E();
+    adminClient = createAdminClient();
+  });
+
+  tearDownAll(() async {
+    await signOut();
+  });
+
+  group('CUJ 05: Search', () {
+    testWidgets('Should search events via PGroonga RPC', (tester) async {
+      // Sign in (RPC might require auth)
+      final email = await getTestUserEmail(adminClient, gender: 'male');
+      await signInAsTestUser(email);
+
+      final client = Supabase.instance.client;
+
+      // 1. Search events
+      final eventResults = await retry(() async {
+        return await client.rpc<List<dynamic>>(
+          'search_events_pgroonga',
+          params: {'query': '직장인'},
+        );
+      });
+
+      // Events search should return results (seed data has this keyword)
+      // If no results, the test still validates the RPC works without error
+      expect(eventResults, isList);
+      if (eventResults.isNotEmpty) {
+        final first = eventResults.first as Map<String, dynamic>;
+        expect(first.containsKey('id'), isTrue);
+        expect(first.containsKey('title'), isTrue);
+      }
+
+      // 2. Search parties
+      final partyResults = await retry(() async {
+        return await client.rpc<List<dynamic>>(
+          'search_parties_pgroonga',
+          params: {'query': '대학생'},
+        );
+      });
+
+      expect(partyResults, isList);
+      if (partyResults.isNotEmpty) {
+        final first = partyResults.first as Map<String, dynamic>;
+        expect(first.containsKey('id'), isTrue);
+        expect(first.containsKey('title'), isTrue);
+      }
+    });
+  });
+}

--- a/tests/e2e_automation_tester/integration_test/cuj/cuj_06_partner_test.dart
+++ b/tests/e2e_automation_tester/integration_test/cuj/cuj_06_partner_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../utils/e2e_auth.dart';
+import '../utils/e2e_helpers.dart';
+
+/// CUJ 06: Partner — Manage events as a partner owner.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late SupabaseClient adminClient;
+  late ScheduledEventContext eventCtx;
+
+  setUpAll(() async {
+    await initializeE2E();
+    adminClient = createAdminClient();
+    eventCtx = await findScheduledEvent(adminClient);
+  });
+
+  tearDownAll(() async {
+    await signOut();
+  });
+
+  group('CUJ 06: Partner', () {
+    testWidgets('Should access events and applications as partner owner',
+        (tester) async {
+      // 1. Sign in as partner owner
+      final ownerEmail = await getPartnerOwnerEmail(
+        adminClient,
+        ownerId: eventCtx.ownerId,
+      );
+      await signInAsTestUser(ownerEmail);
+
+      final client = Supabase.instance.client;
+
+      // 2. Query partner's events
+      final events = await client
+          .from('events')
+          .select('id, title, status')
+          .eq('party_id', await _getPartyId(adminClient, eventCtx.partnerId))
+          .order('created_at', ascending: false)
+          .limit(5) as List;
+
+      expect(
+        events,
+        isNotEmpty,
+        reason: 'Partner should have at least one event',
+      );
+
+      final firstEvent = events.first as Map<String, dynamic>;
+      expect(firstEvent['id'], isNotNull);
+      expect(firstEvent['title'], isNotNull);
+
+      // 3. Query applications for the event
+      final applications = await client
+          .from('event_applications')
+          .select('id, status, user_id')
+          .eq('event_id', firstEvent['id'] as String) as List;
+
+      // Applications list may be empty, but the query should succeed
+      expect(applications, isList);
+
+      // 4. If applications exist, verify data structure
+      if (applications.isNotEmpty) {
+        final firstApp = applications.first as Map<String, dynamic>;
+        expect(firstApp.containsKey('id'), isTrue);
+        expect(firstApp.containsKey('status'), isTrue);
+        expect(firstApp.containsKey('user_id'), isTrue);
+      }
+    });
+  });
+}
+
+/// Gets a party ID for a given partner.
+Future<String> _getPartyId(
+  SupabaseClient admin,
+  String partnerId,
+) async {
+  final res = await admin
+      .from('parties')
+      .select('id')
+      .eq('partner_id', partnerId)
+      .limit(1)
+      .single();
+  return res['id'] as String;
+}

--- a/tests/e2e_automation_tester/integration_test/utils/e2e_auth.dart
+++ b/tests/e2e_automation_tester/integration_test/utils/e2e_auth.dart
@@ -1,0 +1,95 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'e2e_config.dart';
+
+/// Creates a Supabase admin client that bypasses RLS.
+/// Used for test setup, teardown, and data queries
+/// that require elevated access.
+SupabaseClient createAdminClient() {
+  return SupabaseClient(
+    E2eConfig.supabaseUrl,
+    E2eConfig.serviceRoleKey,
+    headers: {
+      'Authorization': 'Bearer ${E2eConfig.serviceRoleKey}',
+      'apikey': E2eConfig.serviceRoleKey,
+    },
+  );
+}
+
+/// Signs in to the global Supabase instance as a test user.
+/// After this call, `Supabase.instance.client` is authenticated as [email].
+Future<AuthResponse> signInAsTestUser(String email) async {
+  return Supabase.instance.client.auth.signInWithPassword(
+    email: email,
+    password: E2eConfig.testPassword,
+  );
+}
+
+/// Signs out the current user from the global Supabase instance.
+Future<void> signOut() async {
+  await Supabase.instance.client.auth.signOut();
+}
+
+/// Finds a verified seed test user's email by gender.
+///
+/// Queries `user_profiles` for a user matching:
+/// - [gender] ('male' or 'female')
+/// - birth_date = 25 years ago (seed pattern)
+/// - username ending in '_ok' (verified user convention)
+///
+/// Then resolves their auth email via `auth.admin.getUserById`.
+Future<String> getTestUserEmail(
+  SupabaseClient adminClient, {
+  required String gender,
+}) async {
+  final targetBirthYear = DateTime.now().year - 25 + 1;
+
+  final res =
+      await adminClient
+          .from('user_profiles')
+          .select('id')
+          .eq('gender', gender)
+          .eq('birth_date', '$targetBirthYear-01-01')
+          .like('username', '%_ok')
+          .limit(1)
+          .maybeSingle();
+
+  if (res == null) {
+    throw StateError(
+      'No verified $gender test user found. '
+      'Expected user_profiles with gender=$gender, '
+      'birth_date=$targetBirthYear-01-01, username LIKE %_ok. '
+      'Run dev-seed to populate test data.',
+    );
+  }
+
+  final userId = res['id'] as String;
+  final userResponse = await adminClient.auth.admin.getUserById(userId);
+  final email = userResponse.user?.email;
+
+  if (email == null || email.isEmpty) {
+    throw StateError(
+      'Test user $userId has no email in auth.users. '
+      'Seed data may be corrupted.',
+    );
+  }
+
+  return email;
+}
+
+/// Finds a partner owner's email by user ID.
+Future<String> getPartnerOwnerEmail(
+  SupabaseClient adminClient, {
+  required String ownerId,
+}) async {
+  final userResponse = await adminClient.auth.admin.getUserById(ownerId);
+  final email = userResponse.user?.email;
+
+  if (email == null || email.isEmpty) {
+    throw StateError(
+      'Partner owner $ownerId has no email in auth.users.',
+    );
+  }
+
+  return email;
+}

--- a/tests/e2e_automation_tester/integration_test/utils/e2e_config.dart
+++ b/tests/e2e_automation_tester/integration_test/utils/e2e_config.dart
@@ -1,0 +1,37 @@
+/// Environment configuration for E2E tests.
+///
+/// All values are injected via `--dart-define` at test invocation time.
+/// CI uses GH Secrets; local runs use values from `minglit_env/dev/`.
+class E2eConfig {
+  E2eConfig._();
+
+  static const supabaseUrl = String.fromEnvironment('SUPABASE_URL');
+  static const supabasePublishableKey =
+      String.fromEnvironment('SUPABASE_PUBLISHABLE_KEY');
+  static const serviceRoleKey =
+      String.fromEnvironment('SUPABASE_SERVICE_ROLE_KEY');
+
+  /// All seed test users share this password.
+  static const testPassword = 'password1234!';
+
+  /// Validates that all required env vars are present.
+  /// Throws [StateError] if any is missing — fails fast in CI.
+  static void validate() {
+    final missing = <String>[];
+    if (supabaseUrl.isEmpty) missing.add('SUPABASE_URL');
+    if (supabasePublishableKey.isEmpty) {
+      missing.add('SUPABASE_PUBLISHABLE_KEY');
+    }
+    if (serviceRoleKey.isEmpty) missing.add('SUPABASE_SERVICE_ROLE_KEY');
+
+    if (missing.isNotEmpty) {
+      throw StateError(
+        'Missing required --dart-define values: ${missing.join(', ')}\n'
+        'Run with: flutter test integration_test/ '
+        '--dart-define=SUPABASE_URL=... '
+        '--dart-define=SUPABASE_PUBLISHABLE_KEY=... '
+        '--dart-define=SUPABASE_SERVICE_ROLE_KEY=...',
+      );
+    }
+  }
+}

--- a/tests/e2e_automation_tester/integration_test/utils/e2e_helpers.dart
+++ b/tests/e2e_automation_tester/integration_test/utils/e2e_helpers.dart
@@ -1,0 +1,124 @@
+import 'package:integration_test/integration_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'e2e_config.dart';
+
+/// Initializes the E2E test environment.
+///
+/// 1. Binds the integration test framework
+/// 2. Validates env config
+/// 3. Initializes Supabase connection to dev server
+/// 4. Returns a [ProviderContainer] for accessing Riverpod providers
+Future<ProviderContainer> initializeE2E() async {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  E2eConfig.validate();
+
+  await Supabase.initialize(
+    url: E2eConfig.supabaseUrl,
+    anonKey: E2eConfig.supabasePublishableKey,
+  );
+
+  return ProviderContainer();
+}
+
+/// Finds a scheduled event with its ticket, partner, and owner info.
+///
+/// Pattern from: `tests/backend_integration/src/utils/test_helpers.dart`
+Future<ScheduledEventContext> findScheduledEvent(
+  SupabaseClient client,
+) async {
+  final eventRes = await client
+      .from('events')
+      .select('*, tickets(*), party:parties(*, partner:partners(*))')
+      .eq('status', 'scheduled')
+      .limit(1)
+      .maybeSingle();
+
+  if (eventRes == null) {
+    throw StateError('No scheduled events found in dev database.');
+  }
+
+  final eventId = eventRes['id'] as String;
+  final tickets = eventRes['tickets'] as List;
+  if (tickets.isEmpty) {
+    throw StateError('Event $eventId has no tickets.');
+  }
+  final ticketId = (tickets.first as Map<String, dynamic>)['id'] as String;
+
+  final party = eventRes['party'] as Map<String, dynamic>;
+  final partner = party['partner'] as Map<String, dynamic>;
+  final partnerId = partner['id'] as String;
+
+  // Find partner owner
+  final ownerRes = await client
+      .from('partner_member_permissions')
+      .select('user_id')
+      .eq('partner_id', partnerId)
+      .eq('role', 'owner')
+      .single();
+  final ownerId = ownerRes['user_id'] as String;
+
+  return ScheduledEventContext(
+    eventId: eventId,
+    ticketId: ticketId,
+    partnerId: partnerId,
+    ownerId: ownerId,
+  );
+}
+
+/// Context record for a scheduled event.
+class ScheduledEventContext {
+  const ScheduledEventContext({
+    required this.eventId,
+    required this.ticketId,
+    required this.partnerId,
+    required this.ownerId,
+  });
+
+  final String eventId;
+  final String ticketId;
+  final String partnerId;
+  final String ownerId;
+}
+
+/// Retries an async operation with exponential backoff.
+///
+/// Useful for network flakiness mitigation in CI.
+Future<T> retry<T>(
+  Future<T> Function() fn, {
+  int maxAttempts = 3,
+}) async {
+  for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (e) {
+      if (attempt == maxAttempts) rethrow;
+      final delay = Duration(seconds: 1 << (attempt - 1)); // 1s, 2s, 4s
+      Log.w(
+        '⚠️ Attempt $attempt/$maxAttempts failed: $e — '
+        'retrying in ${delay.inSeconds}s...',
+      );
+      await Future<void>.delayed(delay);
+    }
+  }
+  // Unreachable, but Dart needs it.
+  throw StateError('retry: unreachable');
+}
+
+/// Gets a verification ID for test applications.
+Future<String> getCareerVerificationId(SupabaseClient client) async {
+  final res = await client
+      .from('verifications')
+      .select('id')
+      .eq('category', 'career')
+      .limit(1)
+      .maybeSingle();
+
+  if (res == null) {
+    final any =
+        await client.from('verifications').select('id').limit(1).single();
+    return any['id'] as String;
+  }
+  return res['id'] as String;
+}

--- a/tests/e2e_automation_tester/lib/main.dart
+++ b/tests/e2e_automation_tester/lib/main.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const E2eAutomationTesterApp());
+}
+
+class E2eAutomationTesterApp extends StatelessWidget {
+  const E2eAutomationTesterApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: Text(
+            'E2E Automation Tester\n'
+            'Run via: flutter test integration_test/',
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/tests/e2e_automation_tester/pubspec.yaml
+++ b/tests/e2e_automation_tester/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.1.0
 resolution: workspace
 
 environment:
-  sdk: ">=3.7.0 <4.0.0"
+  sdk: ^3.6.0
 
 dependencies:
   flutter:

--- a/tests/e2e_automation_tester/pubspec.yaml
+++ b/tests/e2e_automation_tester/pubspec.yaml
@@ -1,0 +1,23 @@
+name: e2e_automation_tester
+description: Daily CUJ E2E tests against dev Supabase
+publish_to: 'none'
+version: 0.1.0
+resolution: workspace
+
+environment:
+  sdk: ">=3.7.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  minglit_kit:
+    path: ../../shared/packages/minglit_kit
+  supabase_flutter: ^2.8.3
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  integration_test:
+    sdk: flutter
+  test_data_seeder:
+    path: ../test_data_seeder


### PR DESCRIPTION
## Summary
- Daily cron (KST 07:00) GitHub Actions workflow로 6개 Critical User Journey를 remote dev Supabase에 대해 headless Flutter integration test로 실행
- 실패 시 `ci-failure` 라벨 GitHub Issue 자동 생성 (기존 `notify-failure.yml` 재사용)
- `tests/e2e_automation_tester/` — 새 경량 Flutter 앱으로 에뮬레이터 없이 Repository/Provider 레벨 CUJ 테스트

## CUJ Coverage
| # | CUJ | 검증 내용 |
|---|-----|----------|
| 01 | Auth | signInWithPassword → 세션 확인 → 프로필 조회 |
| 02 | Browse | 이벤트 피드 → 상세 → 파티 → 관계 로딩 |
| 03 | Application | apply_event RPC → 승인 → participant 생성 |
| 04 | Matching | 상호 투표 → 매치 생성 확인 |
| 05 | Search | PGroonga RPC (이벤트/파티 검색) |
| 06 | Partner | 파트너 이벤트/신청자 관리 |

## Technical Details
- **인증**: `signInWithPassword` (seed 유저 공통 비밀번호) — JWT secret 불필요
- **Admin 조작**: service role key로 SupabaseClient 직접 생성 (RLS bypass)
- **Secrets**: `SUPABASE_DEV_URL`, `SUPABASE_DEV_PUBLISHABLE_KEY`, `SUPABASE_DEV_SECRET_KEY` (모두 기존 워크플로우에서 사용 중)
- **`--dart-define`**: `String.fromEnvironment()`이 env vars가 아닌 `--dart-define`만 읽으므로 CI에서 직접 주입

## Files
```
tests/e2e_automation_tester/
├── pubspec.yaml
├── lib/main.dart
└── integration_test/
    ├── utils/
    │   ├── e2e_config.dart
    │   ├── e2e_auth.dart
    │   └── e2e_helpers.dart
    └── cuj/
        ├── cuj_01_auth_test.dart
        ├── cuj_02_browse_test.dart
        ├── cuj_03_application_test.dart
        ├── cuj_04_matching_test.dart
        ├── cuj_05_search_test.dart
        └── cuj_06_partner_test.dart
.github/workflows/daily-e2e.yml
```