### PR TITLE
fix(user): 다크모드 이벤트 디테일 앱바 타이틀 색상 수정 (#140)

### DIFF
--- a/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
@@ -157,10 +157,11 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent>
                 expandedHeight: expandedHeight,
                 pinned: true,
                 title: _showTitle
+                    // Fix #140: onPrimary resolves to black in dark mode — use onSurface to match icon color
                     ? Text(
                         eventTitle,
                         style: theme.textTheme.titleMedium?.copyWith(
-                          color: theme.colorScheme.onPrimary,
+                          color: theme.colorScheme.onSurface,
                           fontWeight: FontWeight.w600,
                         ),
                       )


### PR DESCRIPTION
## Summary
- 다크모드에서 이벤트 디테일 SliverAppBar 타이틀이 검은색으로 표시되는 버그 수정

## Root Cause
`event_detail_content.dart`에서 SliverAppBar 타이틀 색상을 `theme.colorScheme.onPrimary`로 지정. Material 3 dark theme에서 `onPrimary`는 near-black으로 resolve되어 collapse된 앱바에서 타이틀이 보이지 않음.

## Fix
`onPrimary` → `onSurface`로 변경. `onSurface`는 이미 같은 파일에서 아이콘 색상(`iconColor`)에 사용 중이며, light/dark mode 모두에서 올바르게 동작.

Closes #140