### PR TITLE
fix(ui): remove shake-to-report and trailing chevron icons (#147, #144)

### DIFF
--- a/apps/app_partner/lib/src/features/more/more_page.dart
+++ b/apps/app_partner/lib/src/features/more/more_page.dart
@@ -106,17 +106,16 @@ class MorePage extends ConsumerWidget {
           const Divider(),
 
           // ── 섹션 1: 관리 ──
+          // Fix #144: trailing chevron icons removed for cleaner settings UI
           ListTile(
             leading: const Icon(Icons.verified_user_outlined),
             title: const Text('인증 심사 관리'),
-            trailing: const Icon(Icons.chevron_right),
             onTap: () =>
                 ref.read(moreCoordinatorProvider).pushVerificationManage(),
           ),
           ListTile(
             leading: const Icon(Icons.people_outline),
             title: const Text('멤버 관리'),
-            trailing: const Icon(Icons.chevron_right),
             onTap: () {
               final partner = partnerAsync.value;
               if (partner == null) {
@@ -132,7 +131,6 @@ class MorePage extends ConsumerWidget {
           ListTile(
             leading: const Icon(Icons.notifications_outlined),
             title: const Text('알림 설정'),
-            trailing: const Icon(Icons.chevron_right),
             onTap: () =>
                 ref.read(moreCoordinatorProvider).pushNotificationSettings(),
           ),
@@ -143,13 +141,11 @@ class MorePage extends ConsumerWidget {
           ListTile(
             leading: const Icon(Icons.person_outline),
             title: const Text('계정 관리'),
-            trailing: const Icon(Icons.chevron_right),
             onTap: () => context.showMinglitInfo('준비 중입니다'),
           ),
           ListTile(
             leading: const Icon(Icons.store_outlined),
             title: const Text('파트너 프로필'),
-            trailing: const Icon(Icons.chevron_right),
             onTap: () => context.showMinglitInfo('준비 중입니다'),
           ),
           const Divider(),
@@ -158,7 +154,6 @@ class MorePage extends ConsumerWidget {
           ListTile(
             leading: const Icon(Icons.privacy_tip_outlined),
             title: const Text('개인정보처리방침'),
-            trailing: const Icon(Icons.chevron_right),
             onTap: () {
               final url = ref.read(minglitUrlConfigProvider).privacyUrl;
               unawaited(launchUrl(Uri.parse(url)));
@@ -167,7 +162,6 @@ class MorePage extends ConsumerWidget {
           ListTile(
             leading: const Icon(Icons.description_outlined),
             title: const Text('이용약관'),
-            trailing: const Icon(Icons.chevron_right),
             onTap: () {
               final url = ref.read(minglitUrlConfigProvider).termsUrl;
               unawaited(launchUrl(Uri.parse(url)));

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -55,7 +55,6 @@ dependencies:
   riverpod_annotation: ^3.0.3
   screen_brightness: ^2.1.7
   sentry_flutter: ^9.0.0
-  shake: ^3.0.0
   share_plus: ^12.0.1
   shared_preferences: ^2.5.4
   supabase_flutter: ^2.12.0

--- a/shared/packages/minglit_kit/lib/src/features/theme/theme_settings_tile.dart
+++ b/shared/packages/minglit_kit/lib/src/features/theme/theme_settings_tile.dart
@@ -28,7 +28,6 @@ class ThemeSettingsTile extends ConsumerWidget {
             ? '라이트 모드'
             : '시스템 설정',
       ),
-      trailing: const Icon(Icons.chevron_right),
       onTap: () {
         unawaited(_showThemePicker(context, ref, currentMode));
       },

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
@@ -13,10 +13,9 @@ import 'package:minglit_kit/src/ui/widgets/common/loading_indicator.dart';
 import 'package:minglit_kit/src/utils/environment_info.dart';
 import 'package:minglit_kit/src/utils/layout_dump.dart';
 import 'package:minglit_kit/src/utils/log.dart';
-import 'package:shake/shake.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-/// Wraps [child] with bug reporting UI and shake detection.
+/// Wraps [child] with bug reporting UI.
 class BugReporterWrapper extends StatefulWidget {
   /// Creates a bug reporter wrapper.
   const BugReporterWrapper({
@@ -43,54 +42,13 @@ class BugReporterWrapper extends StatefulWidget {
   State<BugReporterWrapper> createState() => _BugReporterWrapperState();
 }
 
-class _BugReporterWrapperState extends State<BugReporterWrapper>
-    with WidgetsBindingObserver {
-  ShakeDetector? _detector;
+class _BugReporterWrapperState extends State<BugReporterWrapper> {
   bool _isReportOpen = false;
+  bool _isCapturing = false;
   final GlobalKey _boundaryKey = GlobalKey();
   String? _screenshotUrl;
   Map<String, dynamic>? _environmentInfo;
   String? _layoutDumpUrl;
-  DateTime? _lastShakeTime;
-  static const _shakeCooldown = Duration(seconds: 5);
-
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addObserver(this);
-    if (widget.enabled &&
-        !kIsWeb &&
-        (defaultTargetPlatform == TargetPlatform.iOS ||
-            defaultTargetPlatform == TargetPlatform.android)) {
-      _detector = ShakeDetector.autoStart(
-        onPhoneShake: (event) {
-          unawaited(_onShakeDetected());
-        },
-      );
-    }
-  }
-
-  @override
-  void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-    _detector?.stopListening();
-    super.dispose();
-  }
-
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (!widget.enabled) return;
-    switch (state) {
-      case AppLifecycleState.paused:
-      case AppLifecycleState.inactive:
-      case AppLifecycleState.hidden:
-      case AppLifecycleState.detached:
-        // Fix #51: pause shake detection when app is not in foreground
-        _detector?.stopListening();
-      case AppLifecycleState.resumed:
-        _detector?.startListening();
-    }
-  }
 
   /// Returns a [BuildContext] that has a [Navigator] ancestor.
   ///
@@ -127,24 +85,16 @@ class _BugReporterWrapperState extends State<BugReporterWrapper>
     }
   }
 
-  /// Called when shake is detected. Applies cooldown before showing dialog.
-  Future<void> _onShakeDetected() async {
-    // Fix #51: cooldown prevents rapid shake from triggering multiple dialogs
-    if (_lastShakeTime != null &&
-        DateTime.now().difference(_lastShakeTime!) < _shakeCooldown) {
-      return;
-    }
-    _lastShakeTime = DateTime.now();
-    await _showReportDialog();
-  }
-
   Future<void> _showReportDialog() async {
     if (!mounted) return;
     // Fix #51: return early if dialog is already open — do not dismiss+reopen
-    if (_isReportOpen) return;
+    if (_isReportOpen || _isCapturing) return;
     // Capture context BEFORE async gap
     final ctx = _dialogContext;
     if (ctx == null) return;
+
+    // Fix #147: show progress on FAB while capturing screenshot/env info
+    setState(() => _isCapturing = true);
 
     // Capture screenshot AND environment info in parallel BEFORE opening sheet
     final results = await Future.wait([
@@ -152,7 +102,13 @@ class _BugReporterWrapperState extends State<BugReporterWrapper>
       collectEnvironmentInfo(),
       captureLayoutDump(),
     ]);
-    if (!mounted || !ctx.mounted) return;
+
+    if (!mounted) {
+      _isCapturing = false;
+      return;
+    }
+    setState(() => _isCapturing = false);
+    if (!ctx.mounted) return;
 
     final screenshotUrl = results[0] as String?;
     final environment = results[1] as Map<String, dynamic>?;
@@ -384,11 +340,18 @@ class _BugReporterWrapperState extends State<BugReporterWrapper>
             bottom: 16,
             child: Material(
               type: MaterialType.transparency,
+              // Fix #147: show progress indicator while capturing bug report data
               child: FloatingActionButton(
                 mini: true,
-                onPressed: _showReportDialog,
+                onPressed: _isCapturing ? null : _showReportDialog,
                 backgroundColor: MinglitColors.error,
-                child: const Icon(Icons.bug_report),
+                child: _isCapturing
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: MinglitCircularProgressIndicator(),
+                      )
+                    : const Icon(Icons.bug_report),
               ),
             ),
           ),

--- a/shared/packages/minglit_kit/pubspec.yaml
+++ b/shared/packages/minglit_kit/pubspec.yaml
@@ -44,7 +44,6 @@ dependencies:
   # Other dependencies
   riverpod: ^3.0.3
   riverpod_annotation: ^3.0.3
-  shake: ^3.0.0
   shared_preferences: ^2.5.4
   shimmer: ^3.0.0
   sign_in_with_apple: ^7.0.1

--- a/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
+++ b/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
@@ -13,7 +13,7 @@ void main() {
           child: MaterialApp(
             home: Scaffold(
               body: BugReporterWrapper(
-                enabled: false, // Disable to avoid shake detector setup
+                enabled: false, // Disable FAB rendering
                 child: testChild,
               ),
             ),
@@ -121,8 +121,8 @@ void main() {
     });
   });
 
-  group('Deduplication and cooldown', () {
-    testWidgets('registers and removes WidgetsBindingObserver without crash', (
+  group('Lifecycle', () {
+    testWidgets('disposes cleanly without crash', (
       tester,
     ) async {
       await tester.pumpWidget(
@@ -146,7 +146,7 @@ void main() {
           ),
         ),
       );
-      // No crash = observer was properly unregistered
+      // No crash = state was properly cleaned up
     });
 
     testWidgets('renders FAB when enabled', (tester) async {


### PR DESCRIPTION
## Summary

- **Issue #147**: Remove shake-to-report-bug feature. The bug report FAB button exists, so shake detection is no longer needed. Added a progress indicator on the FAB while capturing screenshot/environment info.
- **Issue #144**: Remove trailing chevron_right icons from partner settings (더보기) screen for a cleaner UI.

## Changes

### Bug Reporter (`shared/packages/minglit_kit`)
- Removed `ShakeDetector` and all shake detection code (init, dispose, lifecycle, cooldown)
- Removed `WidgetsBindingObserver` mixin (only used for shake lifecycle)
- Added `_isCapturing` state to show `MinglitCircularProgressIndicator` on FAB during data capture
- Removed `shake: ^3.0.0` dependency from `minglit_kit/pubspec.yaml` and `app_user/pubspec.yaml`
- Updated tests to reflect removed shake functionality

### Partner Settings (`apps/app_partner`)
- Removed `trailing: const Icon(Icons.chevron_right)` from 7 ListTiles in `more_page.dart`
- Removed `trailing: const Icon(Icons.chevron_right)` from `ThemeSettingsTile`

Closes #147, closes #144