### PR TITLE
fix: resolve UI bugs #141, #142, #143

### DIFF
--- a/apps/app_partner/lib/src/features/party/detail/tabs/party_info_tab.dart
+++ b/apps/app_partner/lib/src/features/party/detail/tabs/party_info_tab.dart
@@ -20,7 +20,9 @@ class PartyInfoTab extends ConsumerWidget {
     final locationAsync = ref.watch(locationDetailProvider(party.locationId));
     final coordinator = ref.read(partyDetailCoordinatorProvider);
 
+    // Fix #142: Add padding to match PartyRuleManagementTab
     return SingleChildScrollView(
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/apps/app_partner/lib/src/ui/shell/partner_scaffold.dart
+++ b/apps/app_partner/lib/src/ui/shell/partner_scaffold.dart
@@ -11,8 +11,19 @@ class PartnerScaffold extends StatelessWidget {
 
   final StatefulNavigationShell navigationShell;
 
+  /// Root paths where bottom nav should be visible.
+  /// Sub-routes (deeper paths) hide the bottom nav.
+  static const _rootPaths = {'/', '/parties', '/settlement', '/more'};
+
   int _calculateSelectedIndex() {
     return navigationShell.currentIndex;
+  }
+
+  // Fix #143: Hide bottom nav on sub-screens so users don't get
+  // confused by navigation when a back button is present.
+  bool _shouldShowBottomNav(BuildContext context) {
+    final uri = GoRouterState.of(context).uri.path;
+    return _rootPaths.contains(uri);
   }
 
   @override
@@ -23,37 +34,40 @@ class PartnerScaffold extends StatelessWidget {
       context: context,
       navigationShell: navigationShell,
     );
+    final showBottomNav = _shouldShowBottomNav(context);
 
     return Scaffold(
       body: navigationShell,
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: _calculateSelectedIndex(),
-        onDestinationSelected: coordinator.onItemTapped,
-        indicatorColor: MinglitColors.transparent,
-        backgroundColor: colorScheme.surface,
-        destinations: const [
-          NavigationDestination(
-            icon: Icon(Icons.home_outlined),
-            selectedIcon: Icon(Icons.home),
-            label: '홈',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.celebration_outlined),
-            selectedIcon: Icon(Icons.celebration),
-            label: '파티관리',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.attach_money_outlined),
-            selectedIcon: Icon(Icons.attach_money),
-            label: '수익관리',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.settings_outlined),
-            selectedIcon: Icon(Icons.settings),
-            label: '설정',
-          ),
-        ],
-      ),
+      bottomNavigationBar: showBottomNav
+          ? NavigationBar(
+              selectedIndex: _calculateSelectedIndex(),
+              onDestinationSelected: coordinator.onItemTapped,
+              indicatorColor: MinglitColors.transparent,
+              backgroundColor: colorScheme.surface,
+              destinations: const [
+                NavigationDestination(
+                  icon: Icon(Icons.home_outlined),
+                  selectedIcon: Icon(Icons.home),
+                  label: '홈',
+                ),
+                NavigationDestination(
+                  icon: Icon(Icons.celebration_outlined),
+                  selectedIcon: Icon(Icons.celebration),
+                  label: '파티관리',
+                ),
+                NavigationDestination(
+                  icon: Icon(Icons.attach_money_outlined),
+                  selectedIcon: Icon(Icons.attach_money),
+                  label: '수익관리',
+                ),
+                NavigationDestination(
+                  icon: Icon(Icons.settings_outlined),
+                  selectedIcon: Icon(Icons.settings),
+                  label: '설정',
+                ),
+              ],
+            )
+          : null,
     );
   }
 }

--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -86,6 +86,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                 ),
               ],
             ),
+            // Fix #141: Equalize action button spacing and padding alignment
             actions: [
               IconButton(
                 icon: const Icon(Icons.search),
@@ -96,22 +97,27 @@ class _HomePageState extends ConsumerState<HomePage> {
                   icon: const Icon(Icons.notifications_outlined),
                   onPressed: homeCoordinator.pushNotificationCenter,
                 ),
-                GestureDetector(
-                  onTap: () => const MyPageRoute().push<void>(context),
-                  child: CircleAvatar(
-                    radius: 14,
-                    backgroundImage: user.userMetadata?['avatar_url'] != null
-                        ? NetworkImage(
-                            user.userMetadata!['avatar_url'] as String,
-                          )
-                        : null,
-                    onBackgroundImageError:
-                        user.userMetadata?['avatar_url'] != null
-                        ? (_, _) {}
-                        : null,
-                    child: user.userMetadata?['avatar_url'] == null
-                        ? const Icon(Icons.person, size: 14)
-                        : null,
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: MinglitSpacing.small,
+                  ),
+                  child: GestureDetector(
+                    onTap: () => const MyPageRoute().push<void>(context),
+                    child: CircleAvatar(
+                      radius: 14,
+                      backgroundImage: user.userMetadata?['avatar_url'] != null
+                          ? NetworkImage(
+                              user.userMetadata!['avatar_url'] as String,
+                            )
+                          : null,
+                      onBackgroundImageError:
+                          user.userMetadata?['avatar_url'] != null
+                          ? (_, _) {}
+                          : null,
+                      child: user.userMetadata?['avatar_url'] == null
+                          ? const Icon(Icons.person, size: 14)
+                          : null,
+                    ),
                   ),
                 ),
               ] else

--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -97,27 +97,24 @@ class _HomePageState extends ConsumerState<HomePage> {
                   icon: const Icon(Icons.notifications_outlined),
                   onPressed: homeCoordinator.pushNotificationCenter,
                 ),
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: MinglitSpacing.small,
-                  ),
-                  child: GestureDetector(
-                    onTap: () => const MyPageRoute().push<void>(context),
-                    child: CircleAvatar(
-                      radius: 14,
-                      backgroundImage: user.userMetadata?['avatar_url'] != null
-                          ? NetworkImage(
-                              user.userMetadata!['avatar_url'] as String,
-                            )
-                          : null,
-                      onBackgroundImageError:
-                          user.userMetadata?['avatar_url'] != null
-                          ? (_, _) {}
-                          : null,
-                      child: user.userMetadata?['avatar_url'] == null
-                          ? const Icon(Icons.person, size: 14)
-                          : null,
-                    ),
+                // Fix #141: Use IconButton for consistent touch target (48x48)
+                // and ripple effect with other app bar actions
+                IconButton(
+                  onPressed: () => const MyPageRoute().push<void>(context),
+                  icon: CircleAvatar(
+                    radius: 14,
+                    backgroundImage: user.userMetadata?['avatar_url'] != null
+                        ? NetworkImage(
+                            user.userMetadata!['avatar_url'] as String,
+                          )
+                        : null,
+                    onBackgroundImageError:
+                        user.userMetadata?['avatar_url'] != null
+                        ? (_, _) {}
+                        : null,
+                    child: user.userMetadata?['avatar_url'] == null
+                        ? const Icon(Icons.person, size: 14)
+                        : null,
                   ),
                 ),
               ] else


### PR DESCRIPTION
## Summary
- **#141**: 메인화면 우측 상단 액션버튼 패딩정렬 — `CircleAvatar`에 `Padding` 래핑하여 `IconButton`과 동일한 간격 확보
- **#142**: 파트너앱 파티 디테일 레이아웃 마진 오류 — `PartyInfoTab`의 `SingleChildScrollView`에 `padding` 추가 (`PartyRuleManagementTab`과 동일하게)
- **#143**: 파트너 앱 세팅화면 바텀네비 표시 오류 — `PartnerScaffold`에서 현재 경로가 루트 탭(`/`, `/parties`, `/settlement`, `/more`)인 경우에만 바텀 네비게이션 표시

Closes #141, closes #142, closes #143