### PR TITLE
chore(ci): scope codecov enforcement to minglit_kit only

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,10 +7,19 @@ coverage:
       default:
         target: auto
         threshold: 5%
+        flags:
+          - minglit-kit
     patch:
       default:
-        target: 70%
+        target: 60%
         threshold: 5%
+        flags:
+          - minglit-kit
+      apps:
+        informational: true
+        flags:
+          - app-user
+          - app-partner
 
 comment:
   layout: "condensed_header, diff, flags, condensed_files, condensed_footer"


### PR DESCRIPTION
## Summary

- Codecov project/patch status check를 `minglit-kit` flag에만 enforce하도록 변경
- `app-user`, `app-partner`는 `informational: true`로 전환 (데이터 수집은 유지, PR 블로킹 해제)
- Patch coverage target 70% → 60%로 현실화

## Why

UI 중심의 앱 코드(app_user, app_partner)에 widget test를 붙이는 건 ROI가 낮고, PR마다 codecov/patch가 0%로 실패하는 노이즈만 발생시킴.
공유 비즈니스 로직(minglit_kit)에만 coverage gate를 집중하는 것이 실용적.