### PR TITLE
fix(event-detail): improve user action buttons

### DIFF
--- a/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
@@ -364,6 +364,7 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent>
                         spacing: MinglitSpacing.small,
                         runSpacing: MinglitSpacing.small,
                         children: [
+                          // Fix #136: Remove dislike button, change like active color to brand primary
                           MinglitSocialActionChip(
                             targetId: event.partyId,
                             targetType: SocialTargetType.party,
@@ -371,32 +372,18 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent>
                             label: '좋아요',
                             activeIcon: Icons.thumb_up,
                             inactiveIcon: Icons.thumb_up_outlined,
-                            activeColor: Theme.of(context).colorScheme.error,
+                            activeColor: MinglitColors.primary,
                             onUnauthenticatedTap: user == null
                                 ? () => ref
                                       .read(authCoordinatorProvider)
                                       .pushLogin()
                                 : null,
                           ),
-                          MinglitSocialActionChip(
-                            targetId: event.partyId,
-                            targetType: SocialTargetType.party,
-                            interactionType: SocialInteractionType.dislike,
-                            label: '싫어요',
-                            activeIcon: Icons.thumb_down,
-                            inactiveIcon: Icons.thumb_down_outlined,
-                            activeColor: Theme.of(
-                              context,
-                            ).colorScheme.onSurfaceVariant,
-                            onUnauthenticatedTap: user == null
-                                ? () => ref
-                                      .read(authCoordinatorProvider)
-                                      .pushLogin()
-                                : null,
-                          ),
+                          // Fix #136: Use large size to match social action chip updates
                           MinglitChip(
                             label: '공유하기',
                             icon: Icons.share_outlined,
+                            size: MinglitChipSize.large,
                             onTap: () => unawaited(
                               ShareUtils.shareEvent(
                                 eventTitle: eventTitle,

--- a/shared/packages/minglit_kit/lib/src/features/social/ui/minglit_social_action_chip.dart
+++ b/shared/packages/minglit_kit/lib/src/features/social/ui/minglit_social_action_chip.dart
@@ -95,10 +95,11 @@ class MinglitSocialActionChip extends ConsumerWidget {
                     )
                     .toggle();
               },
+        // Fix #136: Increase padding, font size, icon size and add vertical separator
         child: Container(
           padding: const EdgeInsets.symmetric(
-            horizontal: MinglitSpacing.small,
-            vertical: MinglitSpacing.xxsmall,
+            horizontal: MinglitSpacing.sm,
+            vertical: MinglitSpacing.xsmall2,
           ),
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(MinglitRadius.small),
@@ -111,23 +112,31 @@ class MinglitSocialActionChip extends ConsumerWidget {
             children: [
               if (isLoading)
                 const SizedBox(
-                  width: 14,
-                  height: 14,
+                  width: 16,
+                  height: 16,
                   child: MinglitCircularProgressIndicator(strokeWidth: 1.5),
                 )
               else
                 Icon(
                   isActive ? activeIcon : inactiveIcon,
-                  size: 14,
+                  size: 16,
                   color: isActive
                       ? Colors.white
                       : theme.colorScheme.onSurfaceVariant,
                 ),
-              const SizedBox(width: MinglitSpacing.xxsmall),
+              const SizedBox(width: 4),
+              Container(
+                width: 1,
+                height: 14,
+                color: isActive
+                    ? Colors.white.withValues(alpha: 0.4)
+                    : theme.colorScheme.outlineVariant,
+              ),
+              const SizedBox(width: 4),
               Text(
                 label,
                 style: theme.textTheme.labelMedium?.copyWith(
-                  fontSize: 12,
+                  fontSize: 14,
                   color: isActive
                       ? Colors.white
                       : theme.colorScheme.onSurfaceVariant,

--- a/shared/packages/minglit_kit/lib/src/features/social/ui/minglit_social_action_chip.dart
+++ b/shared/packages/minglit_kit/lib/src/features/social/ui/minglit_social_action_chip.dart
@@ -121,7 +121,7 @@ class MinglitSocialActionChip extends ConsumerWidget {
                   isActive ? activeIcon : inactiveIcon,
                   size: 16,
                   color: isActive
-                      ? Colors.white
+                      ? MinglitColors.background
                       : theme.colorScheme.onSurfaceVariant,
                 ),
               const SizedBox(width: 4),
@@ -129,7 +129,7 @@ class MinglitSocialActionChip extends ConsumerWidget {
                 width: 1,
                 height: 14,
                 color: isActive
-                    ? Colors.white.withValues(alpha: 0.4)
+                    ? MinglitColors.background.withValues(alpha: 0.4)
                     : theme.colorScheme.outlineVariant,
               ),
               const SizedBox(width: 4),
@@ -138,7 +138,7 @@ class MinglitSocialActionChip extends ConsumerWidget {
                 style: theme.textTheme.labelMedium?.copyWith(
                   fontSize: 14,
                   color: isActive
-                      ? Colors.white
+                      ? MinglitColors.background
                       : theme.colorScheme.onSurfaceVariant,
                 ),
               ),

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_chip.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_chip.dart
@@ -97,9 +97,20 @@ class MinglitChip extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
+          // Fix #136: Add vertical separator between icon and text for medium/large sizes
           if (icon != null) ...[
             Icon(icon, size: iconSize, color: textColor),
-            const SizedBox(width: MinglitSpacing.xxsmall),
+            if (size == MinglitChipSize.small)
+              const SizedBox(width: MinglitSpacing.xxsmall)
+            else ...[
+              const SizedBox(width: 4),
+              Container(
+                width: 1,
+                height: iconSize - 2,
+                color: colorScheme.outlineVariant,
+              ),
+              const SizedBox(width: 4),
+            ],
           ],
           Text(
             label,


### PR DESCRIPTION
## Summary
- **싫어요 버튼 제거**: 이벤트 디테일의 dislike 칩 완전 제거
- **좋아요 브랜드 컬러 적용**: `colorScheme.error` (빨강) → `MinglitColors.primary` (보라)
- **아이콘-텍스트 세로 구분선 추가**: MinglitSocialActionChip, MinglitChip (medium/large) 모두 적용
- **칩 크기 개선**: padding/icon/font 크기 증가로 더 풍성한 시각적 존재감

## Changes
| File | Description |
|------|-------------|
| `event_detail_content.dart` | dislike 칩 제거, like activeColor → primary, share → large |
| `minglit_social_action_chip.dart` | padding/icon/font 증가, 아이콘-텍스트 사이 vertical divider |
| `minglit_chip.dart` | medium/large 사이즈에 아이콘-텍스트 vertical divider 추가 |

## Verification
- `flutter analyze` — 0 errors, 0 warnings
- `flutter test` in `apps/app_user` — 147/147 passed

Closes #136