### PR TITLE
fix(explore): invalidate cached location when retrying nearby toggle

### DIFF
--- a/apps/app_user/lib/src/features/explore/widgets/filter_chip_bar.dart
+++ b/apps/app_user/lib/src/features/explore/widgets/filter_chip_bar.dart
@@ -78,7 +78,8 @@ class ExploreFilterChipBar extends ConsumerWidget {
   Future<void> _onNearbyTap(BuildContext context, WidgetRef ref) async {
     final filters = ref.read(activeFiltersProvider);
     if (!filters.nearbyEnabled) {
-      // Check if location is available before enabling
+      // Fix #154: Invalidate cached location to retry GPS acquisition
+      ref.invalidate(userLocationProvider);
       final location = await ref.read(userLocationProvider.future);
       if (location == null) {
         if (context.mounted) {


### PR DESCRIPTION
## Summary
- **Fix #154**: "가까운 거리" 버튼이 반복 토글 후 다시 켜지지 않는 버그 수정
- 위치 타임아웃 후 `userLocationProvider`가 `null`을 캐시하여, 이후 토글 시 GPS 재시도 없이 즉시 실패하던 문제
- `ref.invalidate(userLocationProvider)` 호출로 매번 새로운 GPS 위치 요청을 보장

## Root Cause
`userLocationProvider`는 `@riverpod Future` provider로 한번 resolve되면 결과를 캐시합니다. GPS 타임아웃(10초)으로 `null`이 반환되면, 이후 토글 시도 시 캐시된 `null`을 즉시 반환하여 "위치 권한이 필요합니다" 스낵바만 보여주고 토글이 동작하지 않았습니다.

## Changes
- `filter_chip_bar.dart`: `_onNearbyTap()`에서 nearby 활성화 전 `ref.invalidate(userLocationProvider)` 호출 추가

Closes #154