### PR TITLE
fix(ci): add Android emulator to daily E2E test workflow

### DIFF
--- a/.github/workflows/daily-e2e.yml
+++ b/.github/workflows/daily-e2e.yml
@@ -12,9 +12,14 @@ concurrency:
 jobs:
   client-cuj-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
 
       - uses: subosito/flutter-action@v2
         with:
@@ -33,14 +38,28 @@ jobs:
         run: flutter pub get
         working-directory: tests/client_cuj_integration
 
-      - name: Run CUJ Integration Tests
+      - name: Enable KVM
         run: |
-          flutter test integration_test/ \
-            --reporter expanded \
-            --dart-define=SUPABASE_URL=${{ secrets.SUPABASE_DEV_URL }} \
-            --dart-define=SUPABASE_PUBLISHABLE_KEY=${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }} \
-            --dart-define=SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_DEV_SECRET_KEY }}
-        working-directory: tests/client_cuj_integration
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run CUJ Integration Tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          profile: pixel_6
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          disable-animations: true
+          working-directory: tests/client_cuj_integration
+          script: |
+            flutter test integration_test/ \
+              --reporter expanded \
+              --dart-define=SUPABASE_URL=${{ secrets.SUPABASE_DEV_URL }} \
+              --dart-define=SUPABASE_PUBLISHABLE_KEY=${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }} \
+              --dart-define=SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_DEV_SECRET_KEY }}
 
   notify-failure:
     needs: [client-cuj-test]


### PR DESCRIPTION
## Summary
- **Fix #145**: Daily E2E 테스트가 "No supported devices connected" 에러로 실패하는 문제 수정
- Android 에뮬레이터 설정 추가 (`reactivecircus/android-emulator-runner`)
- Java 17 + KVM 하드웨어 가속 설정 포함

## Root Cause
`flutter test integration_test/`는 `IntegrationTestWidgetsFlutterBinding`을 사용하는 통합 테스트로, 실제 디바이스/에뮬레이터가 필요합니다. 기존 워크플로우에는 Android 에뮬레이터 설정이 없어 `ubuntu-latest` 러너에서 디바이스를 찾지 못했습니다.

## Changes
- `daily-e2e.yml`:
  - `actions/setup-java@v4` (Java 17) 추가
  - KVM 활성화 단계 추가
  - `reactivecircus/android-emulator-runner@v2` (API 34, x86_64) 추가
  - 타임아웃 15분 → 30분 증가 (에뮬레이터 부팅 시간 고려)

Closes #145