### PR TITLE
docs(agents): PR 케어 섹션 범용화

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,14 +161,33 @@ gh pr view <PR번호> --json state,mergedAt --jq '{state: .state, merged: .merge
 
 | 상태 | 대응 |
 |------|------|
-| `ci-result` 통과 + 코멘트 없음 | "CI 통과" 보고. auto-merge 대기 |
-| `ci-result` 통과 + **코멘트 있음** | 코멘트 내용을 orchestrator에게 보고 |
-| CI 실패 | `gh run view <run_id> --log-failed`로 원인 파악 → orchestrator에게 보고 |
-| PR `MERGED` | "PR 머지 완료" 보고. 모니터링 종료 |
+| `ci-result` 통과 + 코멘트 없음 | auto-merge 대기 |
+| `ci-result` 통과 + **코멘트 있음** | 코멘트 대응 (아래 규칙 참고) |
+| CI 실패 | 실패 원인 파악 → 수정 (아래 규칙 참고) |
+| PR `MERGED` | 모니터링 종료 |
+| `mergeStateStatus: BEHIND` | 브랜치 업데이트 필요 (아래 규칙 참고) |
+
+#### 브랜치 업데이트 (BEHIND 상태)
+
+PR의 브랜치가 base(dev) 대비 뒤처지면 auto-merge가 진행되지 않는다. 반드시 업데이트한다:
+
+```bash
+# 방법 1: GitHub API로 업데이트 (권장 — 로컬 체크아웃 불필요)
+gh api repos/{owner}/{repo}/pulls/{PR번호}/update-branch --method PUT
+
+# 방법 2: 로컬에서 업데이트
+git checkout <브랜치>
+git merge origin/dev
+git push
+```
+
+- `mergeStateStatus`가 `BEHIND`이면 **즉시** 브랜치를 업데이트한다.
+- 업데이트 후 CI가 다시 돌아가고, 통과하면 auto-merge가 진행된다.
+- 충돌(conflict)이 발생하면 로컬에서 수동 해결 후 push.
 
 #### 코멘트 대응 규칙
 
-- 리뷰 코멘트는 **전부 resolve** 한다 (GitHub 설정에서도 강제됨).
+- 리뷰 코멘트는 **전부 resolve** 한다 (GitHub 설정에서도 강제됨 — unresolved 코멘트가 있으면 머지 불가).
 - 대응 방법:
   1. 코드 수정 필요: 수정 후 같은 브랜치에 push → 답글 → resolve
   2. 수정 불필요 (의도된 설계): 근거를 답글로 남기고 → resolve
@@ -177,8 +196,9 @@ gh pr view <PR번호> --json state,mergedAt --jq '{state: .state, merged: .merge
 ### CI 실패 대응
 
 1. `gh run view <run_id> --log-failed`로 실패 원인 파악
-2. 로컬에서 수정 후 같은 브랜치에 push (PR은 유지됨)
-3. CI 재실행 → 통과 확인 → auto-merge 완료까지 반복
+2. **ci-result만 실패** + 나머지 전부 pass → CodeRabbit 타임아웃일 가능성. `gh run rerun <run_id> --failed`로 재실행 (최대 3회).
+3. 실제 test/build 실패 → 로컬에서 수정 후 같은 브랜치에 push (PR은 유지됨)
+4. CI 재실행 → 통과 확인 → auto-merge 완료까지 반복
 
 ## Deploy Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,21 +140,20 @@ adb -s adb-R3CX803P2ND-8btuuD._adb-tls-connect._tcp install -r build/app/outputs
 - **Auto Format PR**: PR 시 `dart fix --apply` + `dart format` 자동 적용. 포맷 변경이 있으면 자동 커밋.
 - **Secret Scanning**: PR 시 Gitleaks로 시크릿 유출 검사.
 
-### PR 모니터링 (Background Agent)
+### PR 케어 (생성 → 머지 완료까지)
 
-PR 생성 직후 **반드시** background monitoring agent를 발사한다. PR이 MERGED 될 때까지 모니터링한다. 생성만 하고 방치 금지.
+PR을 생성하면 **MERGED 될 때까지 케어한다**. 생성만 하고 방치 금지.
+CI 확인, 리뷰 코멘트 대응, 브랜치 업데이트를 모두 포함한다.
 
 ```bash
-# Background agent가 60초 간격으로 아래를 반복:
-
 # 1. CI 상태 확인 (ci-result가 CodeRabbit 대기까지 포함)
-gh pr checks <PR번호> --watch --fail-fast
+gh pr checks <PR번호>
 
 # 2. 리뷰 코멘트 확인
 gh api repos/{owner}/{repo}/pulls/{PR번호}/comments --jq '.[] | {path: .path, body: .body, line: .line}'
 
-# 3. PR 상태 확인
-gh pr view <PR번호> --json state,mergedAt --jq '{state: .state, merged: .mergedAt}'
+# 3. PR 상태 확인 (머지 여부, 브랜치 상태)
+gh pr view <PR번호> --json state,mergedAt,mergeStateStatus --jq '{state: .state, merged: .mergedAt, mergeState: .mergeStateStatus}'
 ```
 
 #### 모니터링 결과별 대응

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,7 @@ gh api repos/{owner}/{repo}/pulls/{PR번호}/update-branch --method PUT
 
 # 방법 2: 로컬에서 업데이트
 git checkout <브랜치>
+git fetch origin
 git merge origin/dev
 git push
 ```


### PR DESCRIPTION
## Summary
- PR 모니터링 섹션을 "Background Agent" 전용에서 범용적인 "PR 케어" 규칙으로 변경
- 어떤 에이전트든 (orchestrator, AI worker, 수동) PR 생성 후 머지까지 케어하는 규칙 적용
- `mergeStateStatus` 확인 명령어 추가

#161 후속