### PR TITLE
feat(backend-simulator): verify phase GitHub issue + Axiom 디버깅

### DIFF
--- a/supabase/functions/_shared/axiom_logger.ts
+++ b/supabase/functions/_shared/axiom_logger.ts
@@ -113,6 +113,10 @@ export function extractFunctionName(req: Request): string {
   }
 }
 
+export function debugStatus(): { enabled: boolean; token: string; dataset: string; environment: string; bufferSize: number } {
+  return { enabled: _enabled, token: _token ? `${_token.slice(0, 8)}...` : "(empty)", dataset: _dataset, environment: _environment, bufferSize: _buffer.length };
+}
+
 export function isEnabled(): boolean {
   return _enabled;
 }

--- a/supabase/functions/_shared/axiom_logger.ts
+++ b/supabase/functions/_shared/axiom_logger.ts
@@ -113,8 +113,8 @@ export function extractFunctionName(req: Request): string {
   }
 }
 
-export function debugStatus(): { enabled: boolean; token: string; dataset: string; environment: string; bufferSize: number } {
-  return { enabled: _enabled, token: _token ? `${_token.slice(0, 8)}...` : "(empty)", dataset: _dataset, environment: _environment, bufferSize: _buffer.length };
+export function debugStatus(): { enabled: boolean; tokenConfigured: boolean; dataset: string; environment: string; bufferSize: number } {
+  return { enabled: _enabled, tokenConfigured: _token.length > 0, dataset: _dataset, environment: _environment, bufferSize: _buffer.length };
 }
 
 export function isEnabled(): boolean {

--- a/supabase/functions/backend-simulator/e2e_test.ts
+++ b/supabase/functions/backend-simulator/e2e_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertExists, assertMatch } from "@std/assert";
+import { assertEquals, assertExists, assertMatch, assertStringIncludes } from "@std/assert";
 import {
   captureServeHandler,
   createFetchMock,
@@ -346,6 +346,7 @@ Deno.test({
         ENVIRONMENT: "development",
         SUPABASE_URL: "http://localhost:54321",
         SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+        GITHUB_ACCESS_TOKEN: "test-github-token",
       },
       async () => {
         await withMockedFetch(fetchMock, async () => {
@@ -359,6 +360,12 @@ Deno.test({
           assertEquals(typeof body.summary.passed, "number");
           assertEquals(typeof body.summary.failed, "number");
           assertEquals(Array.isArray(body.summary.assertion_results), true);
+
+          // When assertions fail, github_issue_url should be present
+          if (body.summary.failed > 0) {
+            assertExists(body.github_issue_url);
+            assertStringIncludes(body.github_issue_url, "github.com");
+          }
         });
       },
     );

--- a/supabase/functions/backend-simulator/index.ts
+++ b/supabase/functions/backend-simulator/index.ts
@@ -287,10 +287,24 @@ Deno.serve(async (req: Request): Promise<Response> => {
       assertion_results: settleResult.assertions,
     };
 
+    // Create GitHub issue on assertion failure
+    let githubIssueUrl: string | null = null;
+    if (summary.failed > 0) {
+      const logText = collector.formatAsText();
+      const logUrl = await simUploadLog(supabase, runId, logText);
+      githubIssueUrl = await simCreateGitHubIssue(
+        summary,
+        logUrl,
+        runId,
+        logText,
+      );
+    }
+
     return successResponse({
       success: summary.failed === 0,
       run_id: runId,
       summary,
+      github_issue_url: githubIssueUrl,
       _axiom_debug: debugStatus(),
     });
   }

--- a/supabase/functions/backend-simulator/index.ts
+++ b/supabase/functions/backend-simulator/index.ts
@@ -6,7 +6,7 @@ import {
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { log, flush } from "../_shared/axiom_logger.ts";
+import { log, flush, debugStatus } from "../_shared/axiom_logger.ts";
 import {
   SimLogCollector,
   simCreateGitHubIssue,
@@ -291,6 +291,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
       success: summary.failed === 0,
       run_id: runId,
       summary,
+      _axiom_debug: debugStatus(),
     });
   }
 

--- a/supabase/functions/backend-simulator/sim_reporter.ts
+++ b/supabase/functions/backend-simulator/sim_reporter.ts
@@ -135,13 +135,24 @@ export async function simCreateGitHubIssue(
       truncatedLog = new TextDecoder().decode(logBytes.slice(0, safeEnd)) + "\n...[truncated]";
     }
 
+    const axiomDataset = Deno.env.get("AXIOM_DATASET") ?? "edge-functions";
     const body = `## E2E Simulation Failure Report
 
-**Run ID**: ${runId}
+**Run ID**: \`${runId}\`
 **Failed Checks**: ${summary.failed}/${summary.total_checks}
+**Environment**: ${Deno.env.get("ENVIRONMENT") ?? "unknown"}
 
 ## Failed Assertions
 ${assertionLines || "_No assertion details available_"}
+
+## Axiom 디버깅
+Edge Function 로그는 Axiom에서 확인할 수 있습니다.
+
+\`\`\`
+axiom query "['${axiomDataset}'] | where metadata.runId == '${runId}'"
+\`\`\`
+
+또는 Axiom 대시보드에서 dataset \`${axiomDataset}\`를 선택하고 \`metadata.runId == '${runId}'\`로 필터링하세요.
 
 ## Log Details
 ${logSection}

--- a/supabase/functions/backend-simulator/sim_reporter_test.ts
+++ b/supabase/functions/backend-simulator/sim_reporter_test.ts
@@ -116,6 +116,9 @@ Deno.test("simCreateGitHubIssue() — mock fetch, title contains [E2E-SIM], labe
     assertExists(result);
     assertStringIncludes(result!, "github.com");
     assertStringIncludes(capturedBody.title as string, "[E2E-SIM]");
+    assertStringIncludes(capturedBody.body as string, "Axiom");
+    assertStringIncludes(capturedBody.body as string, "axiom query");
+    assertStringIncludes(capturedBody.body as string, "run-abc-123");
     assertEquals(
       (capturedBody.labels as string[]).includes("e2e-simulation"),
       true,


### PR DESCRIPTION
## Summary
- verify phase에서 assertion 실패 시 로그 업로드 + GitHub 이슈 자동 생성
- 이슈 body에 Axiom CLI 쿼리 및 대시보드 필터 안내 포함
- 기존 `simCreateGitHubIssue` 재사용, verify phase 전용 리포팅 경로 추가

## Changes
- `index.ts`: verify phase에 이슈 생성 로직 추가
- `sim_reporter.ts`: 이슈 포맷에 Axiom 디버깅 섹션 추가
- `sim_reporter_test.ts`: Axiom 내용 포함 검증
- `e2e_test.ts`: verify phase 실패 시 `github_issue_url` 반환 검증

## Test plan
- [x] `deno test` 10/10 passed (sim_reporter_test + e2e_test)
- [ ] CI 통과 확인
- [ ] dev 머지 후 `phase=verify` 호출하여 이슈 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)