### PR TITLE
refactor(edge-functions): unified logging with logger.ts

### DIFF
--- a/supabase/functions/_shared/logger.ts
+++ b/supabase/functions/_shared/logger.ts
@@ -1,12 +1,25 @@
 /**
- * Sentry error tracking + Axiom structured logging for Edge Functions.
+ * Unified observability for Edge Functions.
  *
- * Supports both `serve()` (old) and `Deno.serve()` (new) patterns.
+ * - Axiom: structured logging (all levels)
+ * - Sentry: error tracking + performance spans
+ *
+ * Usage:
+ * ```ts
+ * import { initSentry, withHandler, log, withSpan } from "../_shared/logger.ts";
+ * await initSentry();
+ * Deno.serve(withHandler(async (req) => {
+ *   log({ function: "my-fn", level: "info", message: "doing work" });
+ *   const data = await withSpan("db.query", "db", () => supabase.from("t").select("*"));
+ *   return successResponse(data);
+ * }));
+ * ```
+ *
  * Gracefully no-ops when SENTRY_DSN / AXIOM_API_TOKEN is not set.
  */
 
 import { log as axiomLog, flush as axiomFlush, extractFunctionName } from "./axiom_logger.ts";
-export { log, flush } from "./axiom_logger.ts";
+export { log, flush, isEnabled, debugStatus } from "./axiom_logger.ts";
 
 let _initialized = false;
 let _enabled = false;
@@ -20,7 +33,7 @@ let _Sentry: {
 } | null = null;
 
 /**
- * Initialize Sentry. Call once at module top-level, before serve().
+ * Initialize Sentry. Call once at module top-level, before Deno.serve().
  * No-ops if SENTRY_DSN env var is missing or empty.
  */
 export async function initSentry(dsn?: string): Promise<void> {
@@ -44,22 +57,20 @@ export async function initSentry(dsn?: string): Promise<void> {
     _Sentry = Sentry;
     _enabled = true;
   } catch (e) {
-    console.warn("[sentry_utils] Failed to initialize Sentry:", e);
+    console.warn("[logger] Failed to initialize Sentry:", e);
     _enabled = false;
   }
 }
 
 /**
- * Wrapper for old `serve()` pattern.
+ * Request handler wrapper. Provides:
+ * - Axiom structured logging (invoked/completed/error)
+ * - Sentry error capture
+ * - Axiom flush on completion
  *
- * Usage:
- * ```ts
- * import { initSentry, withSentry } from "../_shared/sentry_utils.ts";
- * initSentry();
- * serve(withSentry(async (req) => { ... }));
- * ```
+ * Works with both `Deno.serve()` and legacy `serve()`.
  */
-export function withSentry(
+export function withHandler(
   handler: (req: Request) => Response | Promise<Response>,
 ): (req: Request) => Promise<Response> {
   return async (req: Request): Promise<Response> => {
@@ -82,51 +93,14 @@ export function withSentry(
   };
 }
 
-/**
- * Wrapper for new `Deno.serve()` pattern.
- *
- * Usage:
- * ```ts
- * import { initSentry, withSentryHandler } from "../_shared/sentry_utils.ts";
- * await initSentry();
- * Deno.serve(withSentryHandler(async (req) => { ... }));
- * ```
- */
-export function withSentryHandler(
-  handler: (req: Request) => Response | Promise<Response>,
-): (req: Request) => Promise<Response> {
-  return async (req: Request): Promise<Response> => {
-    const fn = extractFunctionName(req);
-    axiomLog({ function: fn, level: "info", message: "invoked", metadata: { method: req.method } });
-    try {
-      const res = await handler(req);
-      axiomLog({ function: fn, level: "info", message: "completed", metadata: { status: res.status } });
-      return res;
-    } catch (error) {
-      axiomLog({ function: fn, level: "error", message: error instanceof Error ? error.message : String(error) });
-      if (_enabled && _Sentry) {
-        _Sentry.captureException(error);
-        await _Sentry.flush(2000);
-      }
-      throw error;
-    } finally {
-      await axiomFlush();
-    }
-  };
-}
+/** @deprecated Use `withHandler` instead. */
+export const withSentry = withHandler;
+/** @deprecated Use `withHandler` instead. */
+export const withSentryHandler = withHandler;
 
 /**
  * Wrap an async operation in a Sentry performance span.
  * No-ops if Sentry is not initialized.
- *
- * Usage:
- * ```ts
- * const result = await withSpan(
- *   'db.query.users',
- *   'db.query',
- *   () => supabase.from('users').select('*')
- * );
- * ```
  */
 export async function withSpan<T>(
   name: string,

--- a/supabase/functions/_shared/statsig_utils.ts
+++ b/supabase/functions/_shared/statsig_utils.ts
@@ -3,7 +3,7 @@
  * Uses REST API directly (no SDK) for Deno compatibility.
  * Gracefully no-ops when STATSIG_SERVER_KEY is not set.
  *
- * Pattern follows sentry_utils.ts.
+ * Pattern follows logger.ts.
  */
 
 let _enabled = false;

--- a/supabase/functions/bug-report/index.ts
+++ b/supabase/functions/bug-report/index.ts
@@ -1,13 +1,15 @@
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withSentry } from "../_shared/sentry_utils.ts";
+import { initSentry, withHandler, log } from "../_shared/logger.ts";
+
+const FN = "bug-report";
 
 const GITHUB_TOKEN = Deno.env.get("GITHUB_ACCESS_TOKEN");
 const GITHUB_REPO = "Mark-Yun/minglit";
 
 initSentry();
 
-Deno.serve(withSentry(async (req) => {
+Deno.serve(withHandler(async (req) => {
   if (req.method === "OPTIONS") return corsResponse();
 
   // Verify JWT (ES256-compatible, via Auth server)
@@ -103,7 +105,7 @@ ${screenshotSection}${environmentSection}${layoutDumpSection}`;
 
     if (!response.ok) {
       const errorText = await response.text();
-      console.error("GitHub API Error:", errorText);
+      log({ function: FN, level: "error", message: "GitHub API Error", metadata: { detail: errorText } });
       throw new Error(`GitHub API Error: ${response.status}`);
     }
 
@@ -113,7 +115,7 @@ ${screenshotSection}${environmentSection}${layoutDumpSection}`;
 
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error("Internal Error:", message);
+    log({ function: FN, level: "error", message: "Internal Error", metadata: { detail: message } });
     return errorResponse(message, 500);
   }
 }));

--- a/supabase/functions/health/index.ts
+++ b/supabase/functions/health/index.ts
@@ -1,4 +1,7 @@
 import { successResponse, errorResponse } from "../_shared/response_utils.ts";
+import { initSentry, withHandler } from "../_shared/logger.ts";
+
+initSentry();
 
 interface CheckResult {
   status: "up" | "down";
@@ -108,7 +111,7 @@ async function checkStorage(): Promise<CheckResult> {
   }
 }
 
-Deno.serve(async (req) => {
+Deno.serve(withHandler(async (req) => {
   if (req.method !== "GET") {
     return errorResponse("Method not allowed", 405);
   }
@@ -138,4 +141,4 @@ Deno.serve(async (req) => {
     return successResponse(body as unknown as Record<string, unknown>, 200);
   }
   return errorResponse("unhealthy", 503, body);
-});
+}));

--- a/supabase/functions/identity-verify/index.ts
+++ b/supabase/functions/identity-verify/index.ts
@@ -2,7 +2,9 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { PortoneV2Client } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withSentry } from "../_shared/sentry_utils.ts";
+import { initSentry, withHandler, log } from "../_shared/logger.ts";
+
+const FN = "identity-verify";
 
 const PORTONE_API_KEY = Deno.env.get("PORTONE_V2_API_KEY");
 
@@ -12,7 +14,7 @@ if (!PORTONE_API_KEY) {
 
 initSentry();
 
-Deno.serve(withSentry(async (req) => {
+Deno.serve(withHandler(async (req) => {
   if (req.method === "OPTIONS") return corsResponse();
 
   const auth = await requireAuth(req);
@@ -32,7 +34,7 @@ Deno.serve(withSentry(async (req) => {
       verification = await portone.getIdentityVerification(identity_verification_id);
     } catch (fetchError) {
       const msg = fetchError instanceof Error ? fetchError.message : String(fetchError);
-      console.error("Portone V2 API Error:", msg);
+      log({ function: FN, level: "error", message: "Portone V2 API Error", metadata: { detail: msg } });
       return errorResponse("Failed to fetch verification info", 502, msg);
     }
 
@@ -68,7 +70,7 @@ Deno.serve(withSentry(async (req) => {
       .eq("id", userId);
 
     if (updateError) {
-      console.error("DB Update Error:", updateError);
+      log({ function: FN, level: "error", message: "DB Update Error", metadata: { detail: updateError } });
       return errorResponse("Failed to update user profile", 500);
     }
 
@@ -76,7 +78,7 @@ Deno.serve(withSentry(async (req) => {
 
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    console.error("Error in verify-identity:", message);
+    log({ function: FN, level: "error", message: "Error in verify-identity", metadata: { detail: message } });
     return errorResponse(message, 500);
   }
 }));

--- a/supabase/functions/metrics-alert/index.ts
+++ b/supabase/functions/metrics-alert/index.ts
@@ -1,5 +1,5 @@
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
-import { initSentry, withSentry } from "../_shared/sentry_utils.ts";
+import { initSentry, withHandler } from "../_shared/logger.ts";
 
 const GITHUB_TOKEN = Deno.env.get("GITHUB_ACCESS_TOKEN");
 const GITHUB_REPO = "Mark-Yun/minglit";
@@ -13,7 +13,7 @@ export const ALERT_LABELS: Record<string, string[]> = {
 
 initSentry();
 
-Deno.serve(withSentry(async (req) => {
+Deno.serve(withHandler(async (req) => {
   if (req.method === "OPTIONS") return corsResponse();
 
   const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");

--- a/supabase/functions/notification-worker/index.ts
+++ b/supabase/functions/notification-worker/index.ts
@@ -2,8 +2,9 @@ import { createClient } from '@supabase/supabase-js'
 import { runWorkerLoop } from './loop_worker.ts'
 import { WorkerUtils } from '../_shared/worker_utils.ts'
 import * as jose from 'https://deno.land/x/jose@v4.14.4/index.ts'
-import { initSentry, withSentryHandler } from '../_shared/sentry_utils.ts'
+import { initSentry, withHandler, log } from '../_shared/logger.ts'
 
+const FN = "notification-worker";
 
 // --- Helper: Google OAuth2 Access Token ---
 async function getAccessToken(serviceAccountJson: string) {
@@ -35,7 +36,7 @@ async function getAccessToken(serviceAccountJson: string) {
     const data = await response.json();
     return { token: data.access_token, projectId: serviceAccount.project_id };
   } catch (e) {
-    console.error('Failed to get Access Token:', e);
+    log({ function: FN, level: "error", message: "Failed to get Access Token", metadata: { error: e } });
     throw e;
   }
 }
@@ -43,7 +44,7 @@ async function getAccessToken(serviceAccountJson: string) {
 // --- Helper: Send FCM ---
 async function sendFCM(accessToken: string, projectId: string, fcmToken: string, title: string, body: string, data?: any) {
   const url = `https://fcm.googleapis.com/v1/projects/${projectId}/messages:send`;
-  
+
   const payload = {
     message: {
       token: fcmToken,
@@ -66,7 +67,7 @@ async function sendFCM(accessToken: string, projectId: string, fcmToken: string,
 
   if (!res.ok) {
     const errText = await res.text();
-    console.error(`FCM Send Error [${fcmToken}]:`, errText);
+    log({ function: FN, level: "error", message: `FCM Send Error [${fcmToken}]`, metadata: { detail: errText } });
     // If error is 'UNREGISTERED' (token invalid), return specific status to delete it
     if (errText.includes('UNREGISTERED') || errText.includes('INVALID_ARGUMENT')) {
         return 'INVALID';
@@ -155,7 +156,7 @@ async function getAffectedUserId(supabase: any, eventType: string, data: Record<
       .eq('id', data.settlement_item_id)
       .single();
     if (itemError) {
-      console.error('Failed to fetch settlement item:', itemError.message);
+      log({ function: FN, level: "error", message: `Failed to fetch settlement item: ${itemError.message}` });
       return null;
     }
     if (!item?.partner_id) return null;
@@ -167,7 +168,7 @@ async function getAffectedUserId(supabase: any, eventType: string, data: Record<
       .eq('role', 'owner')
       .single();
     if (permError) {
-      console.error('Failed to fetch partner owner:', permError.message);
+      log({ function: FN, level: "error", message: `Failed to fetch partner owner: ${permError.message}` });
       return null;
     }
     return perm?.user_id || null;
@@ -192,11 +193,11 @@ async function sendToAllParticipants(
     .eq('status', 'approved');
 
   if (!applications || applications.length === 0) {
-    console.log(`[fan-out] No approved participants for event ${eventId}`);
+    log({ function: FN, level: "info", message: `[fan-out] No approved participants for event ${eventId}` });
     return;
   }
 
-  console.log(`[fan-out] Sending to ${applications.length} participants for event ${eventId}`);
+  log({ function: FN, level: "info", message: `[fan-out] Sending to ${applications.length} participants for event ${eventId}` });
 
   for (const app of applications) {
     const { data: tokens } = await supabase
@@ -209,7 +210,7 @@ async function sendToAllParticipants(
         const status = await sendFCM(accessToken, projectId, t.token, title, body);
         if (status === 'INVALID') {
           await supabase.from('fcm_tokens').delete().eq('token', t.token);
-          console.log(`Deleted invalid token: ${t.token}`);
+          log({ function: FN, level: "info", message: `Deleted invalid token: ${t.token}` });
         }
       }
     }
@@ -226,12 +227,12 @@ async function sendToAllParticipants(
 
 initSentry();
 
-Deno.serve(withSentryHandler(async (_req) => {
+Deno.serve(withHandler(async (_req) => {
   try {
     const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? ''
     const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
     const firebaseServiceAccount = Deno.env.get('FIREBASE_SERVICE_ACCOUNT') ?? ''
-    
+
     if (!supabaseUrl || !supabaseKey || !firebaseServiceAccount) {
         throw new Error("Missing environment variables (SUPABASE_URL, KEY, or FIREBASE_SERVICE_ACCOUNT)");
     }
@@ -239,7 +240,7 @@ Deno.serve(withSentryHandler(async (_req) => {
     const supabase = createClient(supabaseUrl, supabaseKey)
     const utils = new WorkerUtils(supabase, 'q_notifications')
 
-    console.log("Notification Worker v2 Started");
+    log({ function: FN, level: "info", message: "Notification Worker v2 Started" });
 
     await runWorkerLoop({ maxDurationMs: 55000, intervalMs: 5000 }, async () => {
       // Use pgmq_read instead of pop for safer retry handling
@@ -250,12 +251,12 @@ Deno.serve(withSentryHandler(async (_req) => {
       });
 
       if (error) {
-        console.error('PGMQ Read Error:', error);
+        log({ function: FN, level: "error", message: "PGMQ Read Error", metadata: { detail: error } });
         return false;
       }
 
       if (!msgs || (Array.isArray(msgs) && msgs.length === 0)) {
-        return false; 
+        return false;
       }
 
       const msg = Array.isArray(msgs) ? msgs[0] : msgs;
@@ -275,7 +276,7 @@ Deno.serve(withSentryHandler(async (_req) => {
 
       // 2. Idempotency Check
       if (await utils.isProcessed(traceId)) {
-        console.log(`[${traceId}] Already processed. Skipping.`);
+        log({ function: FN, level: "info", message: `[${traceId}] Already processed. Skipping.` });
         await supabase.rpc('pgmq_delete', { queue_name: 'q_notifications', msg_id: msg.msg_id });
         return true;
       }
@@ -295,8 +296,8 @@ Deno.serve(withSentryHandler(async (_req) => {
       }
 
       // 4. Actual Processing
-      console.log(`[Notification] Processing ${isSchemaA ? 'Schema A' : 'Schema B'} event (ID: ${traceId})`);
-      
+      log({ function: FN, level: "info", message: `[Notification] Processing ${isSchemaA ? 'Schema A' : 'Schema B'} event (ID: ${traceId})` });
+
       try {
         let userId: string | null;
         let title: string;
@@ -311,7 +312,7 @@ Deno.serve(withSentryHandler(async (_req) => {
 
           const template = NOTIFICATION_TEMPLATES[eventType];
           if (!template) {
-            console.warn(`[${traceId}] Unknown event_type: ${eventType}. Skipping.`);
+            log({ function: FN, level: "warn", message: `[${traceId}] Unknown event_type: ${eventType}. Skipping.` });
             await supabase.rpc('pgmq_delete', { queue_name: 'q_notifications', msg_id: msg.msg_id });
             return true;
           }
@@ -347,7 +348,7 @@ Deno.serve(withSentryHandler(async (_req) => {
         }
 
         if (!userId) {
-          console.warn(`[${traceId}] No userId resolved. Skipping.`);
+          log({ function: FN, level: "warn", message: `[${traceId}] No userId resolved. Skipping.` });
           await supabase.rpc('pgmq_delete', { queue_name: 'q_notifications', msg_id: msg.msg_id });
           return true;
         }
@@ -360,9 +361,9 @@ Deno.serve(withSentryHandler(async (_req) => {
             .from('fcm_tokens')
             .select('token')
             .eq('user_id', userId);
-        
+
         if (tokenError) {
-            console.error('DB Error fetching tokens:', tokenError);
+            log({ function: FN, level: "error", message: "DB Error fetching tokens", metadata: { detail: tokenError } });
             throw tokenError;
         }
 
@@ -376,9 +377,9 @@ Deno.serve(withSentryHandler(async (_req) => {
                     }
                   : payload.data;
                 const status = await sendFCM(
-                    accessToken, 
-                    projectId, 
-                    t.token, 
+                    accessToken,
+                    projectId,
+                    t.token,
                     title,
                     body,
                     fcmData
@@ -387,14 +388,14 @@ Deno.serve(withSentryHandler(async (_req) => {
                 if (status === 'INVALID') {
                     // Clean up invalid token
                     await supabase.from('fcm_tokens').delete().eq('token', t.token);
-                    console.log(`Deleted invalid token: ${t.token}`);
+                    log({ function: FN, level: "info", message: `Deleted invalid token: ${t.token}` });
                 }
             });
 
             await Promise.all(sendPromises);
-            console.log(`Sent notifications to ${tokens.length} devices.`);
+            log({ function: FN, level: "info", message: `Sent notifications to ${tokens.length} devices.` });
         } else {
-            console.log(`No FCM tokens found for user ${userId}. Skipping push.`);
+            log({ function: FN, level: "info", message: `No FCM tokens found for user ${userId}. Skipping push.` });
         }
 
         // D. Save to Notification History (DB)
@@ -409,7 +410,7 @@ Deno.serve(withSentryHandler(async (_req) => {
 
       } catch (procError) {
           const msg_ = procError instanceof Error ? procError.message : String(procError);
-          console.error(`[${traceId}] Processing Failed: ${msg_}`);
+          log({ function: FN, level: "error", message: `[${traceId}] Processing Failed: ${msg_}` });
           // DLQ Policy: On processing error, message is NOT deleted from queue.
           // PGMQ visibility timeout (30s) will make it available for retry.
           // After 5 retries (read_ct > 5), the DLQ check above moves it to dead_letter_queue.
@@ -424,7 +425,7 @@ Deno.serve(withSentryHandler(async (_req) => {
         msg_id: msg.msg_id
       });
 
-      return true; 
+      return true;
     });
 
     return new Response(JSON.stringify({ status: "done" }), {
@@ -433,9 +434,9 @@ Deno.serve(withSentryHandler(async (_req) => {
 
   } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : String(err);
-    console.error("Worker Error:", errorMessage);
-    return new Response(JSON.stringify({ error: errorMessage }), { 
-      status: 500, 
+    log({ function: FN, level: "error", message: `Worker Error: ${errorMessage}` });
+    return new Response(JSON.stringify({ error: errorMessage }), {
+      status: 500,
       headers: { "Content-Type": "application/json" }
     })
   }

--- a/supabase/functions/partner-sync/index.ts
+++ b/supabase/functions/partner-sync/index.ts
@@ -2,7 +2,9 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { PortoneV2Client } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withSentry } from "../_shared/sentry_utils.ts";
+import { initSentry, withHandler, log } from "../_shared/logger.ts";
+
+const FN = "partner-sync";
 
 const PORTONE_V2_API_KEY = Deno.env.get("PORTONE_V2_API_KEY");
 
@@ -12,7 +14,7 @@ if (!PORTONE_V2_API_KEY) {
 
 initSentry();
 
-Deno.serve(withSentry(async (req) => {
+Deno.serve(withHandler(async (req) => {
   if (req.method === "OPTIONS") return corsResponse();
 
   const auth = await requireAuth(req);
@@ -58,7 +60,7 @@ Deno.serve(withSentry(async (req) => {
       });
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
-      console.error("PortOne createPartner error:", message);
+      log({ function: FN, level: "error", message: "PortOne createPartner error", metadata: { detail: message } });
       return errorResponse("Failed to create PortOne partner", 502);
     }
 
@@ -68,7 +70,7 @@ Deno.serve(withSentry(async (req) => {
       .eq("id", partner_id);
 
     if (updateError) {
-      console.error("DB Update Error:", updateError);
+      log({ function: FN, level: "error", message: "DB Update Error", metadata: { detail: updateError } });
       return errorResponse("Failed to save portone_partner_id", 500);
     }
 
@@ -76,7 +78,7 @@ Deno.serve(withSentry(async (req) => {
 
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    console.error("Error in partner-sync:", message);
+    log({ function: FN, level: "error", message: "Error in partner-sync", metadata: { detail: message } });
     return errorResponse(message, 500);
   }
 }));

--- a/supabase/functions/payment-cancel/index.ts
+++ b/supabase/functions/payment-cancel/index.ts
@@ -2,11 +2,13 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { IamportClient } from "../_shared/iamport_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withSentry } from "../_shared/sentry_utils.ts";
+import { initSentry, withHandler, log } from "../_shared/logger.ts";
+
+const FN = "payment-cancel";
 
 initSentry();
 
-Deno.serve(withSentry(async (req) => {
+Deno.serve(withHandler(async (req) => {
   if (req.method === "OPTIONS") return corsResponse();
 
   const auth = await requireAuth(req);
@@ -71,12 +73,12 @@ Deno.serve(withSentry(async (req) => {
 
     // Fix #133: 이벤트/정책 조회 실패 시 적격성 검사를 건너뛰지 않고 명시적으로 에러 반환
     if (eventResult.error || !eventResult.data) {
-      console.error("Failed to fetch event:", eventResult.error);
+      log({ function: FN, level: "error", message: "Failed to fetch event", metadata: { detail: eventResult.error } });
       return errorResponse("Failed to verify refund eligibility", 500);
     }
 
     if (policyResult.error || !policyResult.data) {
-      console.error("Failed to fetch policy:", policyResult.error);
+      log({ function: FN, level: "error", message: "Failed to fetch policy", metadata: { detail: policyResult.error } });
       return errorResponse("Failed to verify refund eligibility", 500);
     }
 
@@ -110,7 +112,7 @@ Deno.serve(withSentry(async (req) => {
     const impSecret = Deno.env.get("PORTONE_API_SECRET");
 
     if (!impKey || !impSecret) {
-      console.error("Missing Portone credentials");
+      log({ function: FN, level: "error", message: "Missing Portone credentials" });
       return errorResponse("Server configuration error", 500);
     }
 
@@ -126,7 +128,7 @@ Deno.serve(withSentry(async (req) => {
       );
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
-      console.error("Failed to cancel payment:", message);
+      log({ function: FN, level: "error", message: `Failed to cancel payment: ${message}` });
       if (message.startsWith("Failed to get token") || message.startsWith("Iamport Error")) {
         return errorResponse("Payment provider error", 502);
       }
@@ -148,7 +150,7 @@ Deno.serve(withSentry(async (req) => {
       .eq("payment_id", payment_id);
 
     if (dbError) {
-      console.error("DB Update Error:", dbError);
+      log({ function: FN, level: "error", message: "DB Update Error", metadata: { detail: dbError } });
       // Non-fatal: payment was cancelled, just log the DB error
     }
 
@@ -157,7 +159,7 @@ Deno.serve(withSentry(async (req) => {
 
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    console.error("Error in payment-cancel:", message);
+    log({ function: FN, level: "error", message: `Error in payment-cancel: ${message}` });
     return errorResponse(message, 500);
   }
 }));

--- a/supabase/functions/payment-verify/index.ts
+++ b/supabase/functions/payment-verify/index.ts
@@ -2,7 +2,9 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { IamportClient } from "../_shared/iamport_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withSentry, withSpan } from "../_shared/sentry_utils.ts";
+import { initSentry, withHandler, withSpan, log } from "../_shared/logger.ts";
+
+const FN = "payment-verify";
 import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
 
 const IMP_KEY = Deno.env.get("PORTONE_API_KEY");
@@ -15,7 +17,7 @@ if (!IMP_KEY || !IMP_SECRET) {
 initSentry();
 initStatsig();
 
-Deno.serve(withSentry(async (req) => {
+Deno.serve(withHandler(async (req) => {
   if (req.method === "OPTIONS") return corsResponse();
 
   const auth = await requireAuth(req);
@@ -72,7 +74,7 @@ Deno.serve(withSentry(async (req) => {
     if (payment.amount !== order.payment_amount) {
       client.cancelPayment(imp_uid, "결제 금액 위변조로 자동 취소").catch((e: unknown) => {
         const msg = e instanceof Error ? e.message : String(e);
-        console.error("Cancel on mismatch failed:", msg);
+        log({ function: FN, level: "error", message: "Cancel on mismatch failed", metadata: { detail: msg } });
       });
       logStatsigEvent(auth, 'payment_failed', undefined, { reason: 'amount_mismatch', imp_uid }).catch(() => {});
       return errorResponse("Amount mismatch", 400, {
@@ -101,7 +103,7 @@ Deno.serve(withSentry(async (req) => {
     );
 
     if (updateError) {
-      console.error("DB Update Error:", updateError);
+      log({ function: FN, level: "error", message: "DB Update Error", metadata: { detail: updateError } });
       logStatsigEvent(auth, 'payment_failed', undefined, { reason: 'db_update_error', imp_uid }).catch(() => {});
       return errorResponse("Failed to update order status", 500);
     }
@@ -112,7 +114,7 @@ Deno.serve(withSentry(async (req) => {
 
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error("Error in payment-verify:", message);
+    log({ function: FN, level: "error", message: "Error in payment-verify", metadata: { detail: message } });
     return errorResponse(message, 500);
   }
 }));

--- a/supabase/functions/payment-webhook/index.ts
+++ b/supabase/functions/payment-webhook/index.ts
@@ -2,11 +2,12 @@
 // 현재: IP whitelist만 사용 (ALLOWED_IPS)
 // 추가 필요: 포트원 V1 webhook signature 검증 또는 HMAC 검증
 // 참고: V1은 HMAC 미지원이므로 IP whitelist가 1차 보안. 추가 보안 레이어 검토 필요.
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { IamportClient } from "../_shared/iamport_client.ts";
-import { initSentry, withSentry } from "../_shared/sentry_utils.ts";
+import { initSentry, withHandler, log } from "../_shared/logger.ts";
 import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
+
+const FN = "payment-webhook";
 
 const IMP_KEY = Deno.env.get("PORTONE_API_KEY");
 const IMP_SECRET = Deno.env.get("PORTONE_API_SECRET");
@@ -21,22 +22,22 @@ const ALLOWED_IPS = ["52.78.100.19", "52.78.48.223", "52.78.17.128", "127.0.0.1"
 initSentry();
 initStatsig();
 
-serve(withSentry(async (req) => {
+Deno.serve(withHandler(async (req) => {
   try {
     const rawBody = await req.text();
-    
+
     // 1. IP Validation (Primary Security Layer for V1 — V1 has no HMAC signing)
     const forwardedFor = req.headers.get("x-forwarded-for");
     const clientIp = forwardedFor ? forwardedFor.split(",")[0].trim() : "";
-    
+
     if (clientIp && !ALLOWED_IPS.includes(clientIp)) {
-      console.warn(`Blocked Webhook Request from unauthorized IP: ${clientIp}`);
+      log({ function: FN, level: "warn", message: `Blocked Webhook Request from unauthorized IP: ${clientIp}` });
       return new Response("Unauthorized IP", { status: 403 });
     }
 
     const body = JSON.parse(rawBody);
     const { imp_uid, merchant_uid, status } = body;
-    console.log(`Webhook V1 received: ${imp_uid} (${status})`);
+    log({ function: FN, level: "info", message: `Webhook V1 received: ${imp_uid} (${status})` });
 
     if (!imp_uid || !merchant_uid) {
       return new Response("Missing parameters", { status: 400 });
@@ -48,8 +49,8 @@ serve(withSentry(async (req) => {
 
     // 3. Consistency Check
     if (payment.merchant_uid !== merchant_uid) {
-       console.error("Merchant UID mismatch:", payment.merchant_uid, merchant_uid);
-       return new Response("Merchant UID mismatch", { status: 400 });
+      log({ function: FN, level: "error", message: "Merchant UID mismatch", metadata: { received: merchant_uid, actual: payment.merchant_uid } });
+      return new Response("Merchant UID mismatch", { status: 400 });
     }
 
     // 4. Update DB (idempotent)
@@ -82,7 +83,7 @@ serve(withSentry(async (req) => {
      const paidAtIso = payment.paid_at && payment.paid_at > 0
        ? new Date(payment.paid_at * 1000).toISOString()
        : null;
-     
+
      const updatePayload: Record<string, unknown> = {
        status: dbStatus,
        payment_id: imp_uid,
@@ -98,11 +99,11 @@ serve(withSentry(async (req) => {
       .eq("id", merchant_uid);
 
     if (error) {
-      console.error("DB Update Error:", error);
+      log({ function: FN, level: "error", message: "DB Update Error", metadata: { detail: error } });
       return new Response("DB Error", { status: 500 });
     }
 
-    console.log(`Updated order ${merchant_uid} to status ${dbStatus}`);
+    log({ function: FN, level: "info", message: `Updated order ${merchant_uid} to status ${dbStatus}` });
 
     if (payment.status === "failed") {
       logStatsigEvent(merchant_uid, 'payment_failed', undefined, { reason: 'payment_failed', imp_uid, merchant_uid }).catch(() => {});
@@ -144,7 +145,7 @@ serve(withSentry(async (req) => {
 
   } catch (e) {
     const errorMessage = e instanceof Error ? e.message : String(e);
-    console.error("Webhook Error:", errorMessage);
+    log({ function: FN, level: "error", message: `Webhook Error: ${errorMessage}` });
     return new Response(errorMessage, { status: 500 });
   }
 }));

--- a/supabase/functions/payout-sync/index.ts
+++ b/supabase/functions/payout-sync/index.ts
@@ -2,7 +2,9 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { PortoneV2Client } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withSentry } from "../_shared/sentry_utils.ts";
+import { initSentry, withHandler, log } from "../_shared/logger.ts";
+
+const FN = "payout-sync";
 
 const PORTONE_V2_API_KEY = Deno.env.get("PORTONE_V2_API_KEY");
 
@@ -32,7 +34,7 @@ function classifyError(errorCode: string): { retryable: boolean } {
   return { retryable: true };
 }
 
-Deno.serve(withSentry(async (req) => {
+Deno.serve(withHandler(async (req) => {
   if (req.method === "OPTIONS") return corsResponse();
 
   const auth = await requireAuth(req);
@@ -50,7 +52,7 @@ Deno.serve(withSentry(async (req) => {
       .in("status", ["CREATED", "READY", "PROCESSING"]);
 
     if (payoutFetchError) {
-      console.error("Failed to fetch active payouts:", payoutFetchError.message);
+      log({ function: FN, level: "error", message: `Failed to fetch active payouts: ${payoutFetchError.message}` });
       return errorResponse("Failed to fetch payouts", 500);
     }
 
@@ -70,7 +72,7 @@ Deno.serve(withSentry(async (req) => {
           .single();
 
         if (partnerError || !partner?.portone_partner_id) {
-          console.error(`Partner not found for payout ${payout.id}`);
+          log({ function: FN, level: "error", message: `Partner not found for payout ${payout.id}` });
           continue;
         }
 
@@ -80,7 +82,7 @@ Deno.serve(withSentry(async (req) => {
           portonePayouts = result.payouts ?? [];
         } catch (e) {
           const message = e instanceof Error ? e.message : String(e);
-          console.error(`getPayouts failed for payout ${payout.id}:`, message);
+          log({ function: FN, level: "error", message: `getPayouts failed for payout ${payout.id}: ${message}` });
           continue;
         }
 
@@ -197,14 +199,14 @@ Deno.serve(withSentry(async (req) => {
         }
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e);
-        console.error(`Error syncing payout ${payout.id}:`, message);
+        log({ function: FN, level: "error", message: `Error syncing payout ${payout.id}: ${message}` });
       }
     }
 
     return successResponse({ synced });
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    console.error("Error in payout-sync:", message);
+    log({ function: FN, level: "error", message: `Error in payout-sync: ${message}` });
     return errorResponse(message, 500);
   }
 }));

--- a/supabase/functions/profile-update/index.ts
+++ b/supabase/functions/profile-update/index.ts
@@ -3,7 +3,9 @@
 // queue is removed or renamed.
 import { createClient } from '@supabase/supabase-js'
 import { HybridCalculator } from './calculator.ts'
-import { initSentry, withSentryHandler } from '../_shared/sentry_utils.ts'
+import { initSentry, withHandler, log } from '../_shared/logger.ts'
+
+const FN = "profile-update";
 
 const WEIGHTS: Record<string, number> = {
   view: 1,
@@ -16,7 +18,7 @@ const calculator = new HybridCalculator({ decayRate: 0.05 });
 
 initSentry();
 
-Deno.serve(withSentryHandler(async (_req) => {
+Deno.serve(withHandler(async (_req) => {
   try {
     const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? ''
     const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
@@ -27,7 +29,7 @@ Deno.serve(withSentryHandler(async (_req) => {
     });
 
     if (qError) {
-        console.error('PGMQ Pop Error:', qError);
+        log({ function: FN, level: "error", message: "PGMQ Pop Error", metadata: { detail: qError } });
         throw qError;
     }
     
@@ -42,7 +44,7 @@ Deno.serve(withSentryHandler(async (_req) => {
     const { user_id, party_id, action_type } = msg.message;
     const weight = WEIGHTS[action_type] ?? 0;
 
-    console.log(`Processing action: ${action_type} (w:${weight}) for user ${user_id}`);
+    log({ function: FN, level: "info", message: `Processing action: ${action_type} (w:${weight}) for user ${user_id}` });
 
     const [userRes, partyRes] = await Promise.all([
       supabase.from('user_embeddings').select('embedding').eq('user_id', user_id).maybeSingle(),
@@ -50,7 +52,7 @@ Deno.serve(withSentryHandler(async (_req) => {
     ]);
 
     if (partyRes.error || !partyRes.data) {
-        console.warn(`Party embedding not found for ${party_id}. Skipping.`);
+        log({ function: FN, level: "warn", message: `Party embedding not found for ${party_id}. Skipping.` });
         return new Response(JSON.stringify({ error: "Party embedding missing" }), { status: 404 });
     }
 
@@ -76,7 +78,7 @@ Deno.serve(withSentryHandler(async (_req) => {
 
   } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : String(err);
-    console.error('Error:', errorMessage);
+    log({ function: FN, level: "error", message: "Error", metadata: { detail: errorMessage } });
     return new Response(JSON.stringify({ error: errorMessage }), { 
       status: 500,
       headers: { "Content-Type": "application/json" }

--- a/supabase/functions/reconciliation-daily/index.ts
+++ b/supabase/functions/reconciliation-daily/index.ts
@@ -1,5 +1,8 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { PortoneV2Client, PortoneSettlement } from "../_shared/portone_client.ts";
+import { initSentry, withHandler } from "../_shared/logger.ts";
+
+initSentry();
 
 const PORTONE_V2_API_KEY = Deno.env.get("PORTONE_V2_API_KEY") ?? "";
 
@@ -81,7 +84,7 @@ function computeSourceHash(ledgerData: unknown[], portoneData: unknown[]): strin
   return Math.abs(hash).toString(16);
 }
 
-Deno.serve(async (req) => {
+Deno.serve(withHandler(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: CORS_HEADERS });
   }
@@ -303,4 +306,4 @@ Deno.serve(async (req) => {
       { status: 500, headers: { ...CORS_HEADERS, "Content-Type": "application/json" } },
     );
   }
-});
+}));

--- a/supabase/functions/settlement-query/index.ts
+++ b/supabase/functions/settlement-query/index.ts
@@ -1,7 +1,9 @@
 import { PortoneV2Client } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withSentry } from "../_shared/sentry_utils.ts";
+import { initSentry, withHandler, log } from "../_shared/logger.ts";
+
+const FN = "settlement-query";
 
 const PORTONE_V2_API_KEY = Deno.env.get("PORTONE_V2_API_KEY");
 
@@ -11,7 +13,7 @@ if (!PORTONE_V2_API_KEY) {
 
 initSentry();
 
-Deno.serve(withSentry(async (req) => {
+Deno.serve(withHandler(async (req) => {
   if (req.method === "OPTIONS") return corsResponse();
 
   const auth = await requireAuth(req);
@@ -46,7 +48,7 @@ Deno.serve(withSentry(async (req) => {
         });
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e);
-        console.error("PortOne getPartnerSettlements error:", message);
+        log({ function: FN, level: "error", message: "PortOne getPartnerSettlements error", metadata: { detail: message } });
         return errorResponse("Failed to fetch settlements", 502);
       }
       return successResponse({ success: true, ...result });
@@ -59,14 +61,14 @@ Deno.serve(withSentry(async (req) => {
       });
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
-      console.error("PortOne getPayouts error:", message);
+      log({ function: FN, level: "error", message: "PortOne getPayouts error", metadata: { detail: message } });
       return errorResponse("Failed to fetch payouts", 502);
     }
     return successResponse({ success: true, ...result });
 
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    console.error("Error in settlement-query:", message);
+    log({ function: FN, level: "error", message: "Error in settlement-query", metadata: { detail: message } });
     return errorResponse(message, 500);
   }
 }));

--- a/supabase/functions/settlement-register-transfers/index.ts
+++ b/supabase/functions/settlement-register-transfers/index.ts
@@ -2,7 +2,9 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { PortoneV2Client } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withSentry } from "../_shared/sentry_utils.ts";
+import { initSentry, withHandler, log } from "../_shared/logger.ts";
+
+const FN = "settlement-register-transfers";
 
 const PORTONE_V2_API_KEY = Deno.env.get("PORTONE_V2_API_KEY");
 
@@ -14,7 +16,7 @@ initSentry();
 
 const CHUNK_SIZE = 500;
 
-Deno.serve(withSentry(async (req) => {
+Deno.serve(withHandler(async (req) => {
   if (req.method === "OPTIONS") return corsResponse();
 
   const auth = await requireAuth(req);
@@ -33,7 +35,7 @@ Deno.serve(withSentry(async (req) => {
       .is("portone_transfer_id", null);
 
     if (fetchError) {
-      console.error("Failed to fetch pending settlement items:", fetchError.message);
+      log({ function: FN, level: "error", message: `Failed to fetch pending settlement items: ${fetchError.message}` });
       return errorResponse("Failed to fetch pending items", 500);
     }
 
@@ -57,7 +59,7 @@ Deno.serve(withSentry(async (req) => {
             .single();
 
           if (partnerError || !partner?.portone_partner_id) {
-            console.error(`Partner not found or not synced for item ${item.id}`);
+            log({ function: FN, level: "error", message: `Partner not found or not synced for item ${item.id}` });
             failed++;
             continue;
           }
@@ -70,7 +72,7 @@ Deno.serve(withSentry(async (req) => {
             .in("payment_status", ["paid", "approved"]);
 
           if (appError || !applications || applications.length === 0) {
-            console.error(`No paid applications found for item ${item.id}`);
+            log({ function: FN, level: "error", message: `No paid applications found for item ${item.id}` });
             failed++;
             continue;
           }
@@ -95,7 +97,7 @@ Deno.serve(withSentry(async (req) => {
               }
             } catch (e) {
               const message = e instanceof Error ? e.message : String(e);
-              console.error(`createOrderTransfer failed for item ${item.id}, app ${app.id}:`, message);
+              log({ function: FN, level: "error", message: `createOrderTransfer failed for item ${item.id}, app ${app.id}: ${message}` });
             }
           }
 
@@ -106,7 +108,7 @@ Deno.serve(withSentry(async (req) => {
           }
         } catch (e) {
           const message = e instanceof Error ? e.message : String(e);
-          console.error(`Error processing item ${item.id}:`, message);
+          log({ function: FN, level: "error", message: `Error processing item ${item.id}: ${message}` });
           failed++;
         }
       }
@@ -119,7 +121,7 @@ Deno.serve(withSentry(async (req) => {
     });
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    console.error("Error in settlement-register-transfers:", message);
+    log({ function: FN, level: "error", message: `Error in settlement-register-transfers: ${message}` });
     return errorResponse(message, 500);
   }
 }));

--- a/supabase/functions/settlement-transfer/index.ts
+++ b/supabase/functions/settlement-transfer/index.ts
@@ -2,7 +2,9 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { PortoneV2Client } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withSentry } from "../_shared/sentry_utils.ts";
+import { initSentry, withHandler, log } from "../_shared/logger.ts";
+
+const FN = "settlement-transfer";
 
 const PORTONE_V2_API_KEY = Deno.env.get("PORTONE_V2_API_KEY");
 
@@ -12,7 +14,7 @@ if (!PORTONE_V2_API_KEY) {
 
 initSentry();
 
-Deno.serve(withSentry(async (req) => {
+Deno.serve(withHandler(async (req) => {
   if (req.method === "OPTIONS") return corsResponse();
 
   const auth = await requireAuth(req);
@@ -70,7 +72,7 @@ Deno.serve(withSentry(async (req) => {
       transfer = await portone.createOrderTransfer(transferBody as Parameters<typeof portone.createOrderTransfer>[0]);
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
-      console.error("PortOne createOrderTransfer error:", message);
+      log({ function: FN, level: "error", message: "PortOne createOrderTransfer error", metadata: { detail: message } });
       return errorResponse("Failed to create order transfer", 502);
     }
 
@@ -78,7 +80,7 @@ Deno.serve(withSentry(async (req) => {
 
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    console.error("Error in settlement-transfer:", message);
+    log({ function: FN, level: "error", message: "Error in settlement-transfer", metadata: { detail: message } });
     return errorResponse(message, 500);
   }
 }));

--- a/supabase/functions/vector-worker/index.ts
+++ b/supabase/functions/vector-worker/index.ts
@@ -3,7 +3,9 @@ import { OpenAIService } from './openai_service.ts'
 import { serializeParty } from './party_serializer.ts'
 import { HybridCalculator } from './calculator.ts'
 import { WorkerUtils } from '../_shared/worker_utils.ts'
-import { initSentry, withSentryHandler } from '../_shared/sentry_utils.ts'
+import { initSentry, withHandler, log } from '../_shared/logger.ts'
+
+const FN = "vector-worker";
 
 const WEIGHTS: Record<string, number> = {
   view: 0.1,
@@ -16,8 +18,8 @@ const calculator = new HybridCalculator({ decayRate: 0.05 });
 
 initSentry();
 
-Deno.serve(withSentryHandler(async (req) => {
-  console.log("🚀 [Vector Worker] Triggered! Checking environment and auth...");
+Deno.serve(withHandler(async (req) => {
+  log({ function: FN, level: "info", message: "Vector Worker Triggered! Checking environment and auth..." });
   try {
     const payload = await req.json().catch(() => ({}));
     const batchSize = payload.batch_size ?? 50;
@@ -48,18 +50,18 @@ Deno.serve(withSentryHandler(async (req) => {
     });
 
     if (readError) {
-        console.error('PGMQ Read Error:', readError);
+        log({ function: FN, level: "error", message: "PGMQ Read Error", metadata: { detail: readError } });
         throw readError;
     }
-    
+
     if (!messages || (Array.isArray(messages) && messages.length === 0)) {
-      return new Response(JSON.stringify({ processed: 0 }), { 
+      return new Response(JSON.stringify({ processed: 0 }), {
         headers: { "Content-Type": "application/json" }
       });
     }
 
     const msgArray = Array.isArray(messages) ? messages : [messages];
-    console.log(`Processing v2 batch of ${msgArray.length} messages`);
+    log({ function: FN, level: "info", message: `Processing v2 batch of ${msgArray.length} messages` });
 
     // deno-lint-ignore no-explicit-any
     const partyTasks: any[] = [];
@@ -79,7 +81,7 @@ Deno.serve(withSentryHandler(async (req) => {
 
       // B. Idempotency Check
       if (await utils.isProcessed(traceId)) {
-        console.log(`[${traceId}] Already processed. Skipping.`);
+        log({ function: FN, level: "info", message: `[${traceId}] Already processed. Skipping.` });
         processedMsgIds.push(msg.msg_id);
         continue;
       }
@@ -105,31 +107,31 @@ Deno.serve(withSentryHandler(async (req) => {
         // Separate public and private parties
         const publicPartyTasks = partyTasks.filter(t => t.record.visibility !== 'private');
         const privatePartyTasks = partyTasks.filter(t => t.record.visibility === 'private');
-        
+
         // Handle private parties - skip embedding, delete existing
         for (const t of privatePartyTasks) {
-          console.log(`Skipping private party: ${t.record.id}`);
+          log({ function: FN, level: "info", message: `Skipping private party: ${t.record.id}` });
           await supabase.from('party_embeddings').delete().eq('party_id', t.record.id);
           await utils.markProcessed(t.traceId);
           processedMsgIds.push(t.msgId);
         }
-        
+
         // Process only public parties
         if (publicPartyTasks.length > 0) {
           const texts = publicPartyTasks.map(t => serializeParty(t.record));
-          console.log(`Requesting ${texts.length} embeddings from OpenAI...`);
+          log({ function: FN, level: "info", message: `Requesting ${texts.length} embeddings from OpenAI...` });
           const embeddings = await openAi.generateEmbeddings(texts);
-          console.log(`Received ${embeddings.length} embeddings.`);
-          
+          log({ function: FN, level: "info", message: `Received ${embeddings.length} embeddings.` });
+
           await supabase.from('debug_logs').insert({
             message: 'OpenAI Result Check',
-            payload: { 
-              textCount: texts.length, 
+            payload: {
+              textCount: texts.length,
               embeddingCount: embeddings.length,
               sample: embeddings.length > 0 ? Array.from(embeddings[0]).slice(0, 5) : null
             }
           });
-          
+
           for (let i = 0; i < publicPartyTasks.length; i++) {
             const t = publicPartyTasks[i];
             const item = {
@@ -137,19 +139,19 @@ Deno.serve(withSentryHandler(async (req) => {
               embedding: embeddings[i],
               updated_at: new Date().toISOString()
             };
-            
+
             const { error: upsertError } = await supabase.from('party_embeddings').upsert(item);
             if (upsertError) {
-              console.error(`Upsert Error for party ${t.record.id}:`, JSON.stringify(upsertError));
+              log({ function: FN, level: "error", message: `Upsert Error for party ${t.record.id}`, metadata: { detail: JSON.stringify(upsertError) } });
             } else {
-              console.log(`Successfully saved embedding for party ${t.record.id}`);
+              log({ function: FN, level: "info", message: `Successfully saved embedding for party ${t.record.id}` });
               await utils.markProcessed(t.traceId);
               processedMsgIds.push(t.msgId);
             }
           }
         }
       } catch (e) {
-        console.error('Party Vectorization Error:', e);
+        log({ function: FN, level: "error", message: "Party Vectorization Error", metadata: { error: e } });
       }
     }
 
@@ -167,34 +169,34 @@ Deno.serve(withSentryHandler(async (req) => {
         if (partyRes.data && partyRes.data.embedding) {
           const oldVector = userRes.data?.embedding ?? new Array(1536).fill(0);
           const newVector = calculator.calculate(oldVector, partyRes.data.embedding, weight);
-          
+
           const { error } = await supabase.from('user_embeddings').upsert({
             user_id,
             embedding: newVector,
             updated_at: new Date().toISOString()
           });
           if (error) throw error;
-          
+
           await utils.markProcessed(task.traceId);
           processedMsgIds.push(task.msgId);
         } else {
-          console.warn(`Skipping interaction: Party ${party_id} embedding not found.`);
+          log({ function: FN, level: "warn", message: `Skipping interaction: Party ${party_id} embedding not found.` });
           processedMsgIds.push(task.msgId);
         }
       } catch (e) {
-        console.error(`Interaction Error:`, e);
+        log({ function: FN, level: "error", message: "Interaction Error", metadata: { error: e } });
       }
     }
 
     // 4. Delete processed messages from queue individually for reliability
     if (processedMsgIds.length > 0) {
-      console.log(`Deleting ${processedMsgIds.length} messages from queue...`);
+      log({ function: FN, level: "info", message: `Deleting ${processedMsgIds.length} messages from queue...` });
       for (const msgId of processedMsgIds) {
         const { error: delError } = await supabase.rpc('pgmq_delete', {
           queue_name: 'q_vectors',
           msg_id: msgId
         });
-        if (delError) console.error(`PGMQ Delete Error for ${msgId}:`, delError);
+        if (delError) log({ function: FN, level: "error", message: `PGMQ Delete Error for ${msgId}`, metadata: { detail: delError } });
       }
     }
 
@@ -204,8 +206,8 @@ Deno.serve(withSentryHandler(async (req) => {
 
   } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : String(err);
-    console.error('Vector Worker Error:', errorMessage);
-    return new Response(JSON.stringify({ error: errorMessage }), { 
+    log({ function: FN, level: "error", message: `Vector Worker Error: ${errorMessage}` });
+    return new Response(JSON.stringify({ error: errorMessage }), {
       status: 500,
       headers: { "Content-Type": "application/json" }
     });


### PR DESCRIPTION
## Summary
- `sentry_utils.ts` → `logger.ts` 리네이밍 (Sentry+Axiom+래퍼 통합 역할 반영)
- `withSentry`/`withSentryHandler` → `withHandler` 단일 함수로 통합 (deprecated alias 유지)
- `health`, `reconciliation-daily`에 `withHandler` 래퍼 추가 (구조화 로깅 적용)
- `payment-webhook`: 레거시 `serve()` → `Deno.serve()` 마이그레이션
- 14개 함수의 raw `console.*` → 구조화 `log()` 교체

## Motivation
- 20개 Edge Function 중 패턴이 4가지로 분산 → 단일 `withHandler` 패턴으로 통일
- raw console 로그가 Axiom에 수집되지 않음 → 구조화 로거로 교체하여 전체 가시성 확보
- `sentry_utils.ts` 이름이 실제 역할(Sentry+Axiom+핸들러 래퍼)을 반영하지 못함

## Test plan
- [x] `deno test --allow-all` 215 passed, 0 failed
- [ ] CI 통과 확인
- [ ] dev 배포 후 Axiom 대시보드에서 health, reconciliation-daily 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)