### PR TITLE
fix(event-detail): 참여 현황 섹션 좌우 패딩 추가

### DIFF
--- a/apps/app_user/lib/src/features/event/detail/event_entry_conditions_section.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_entry_conditions_section.dart
@@ -20,86 +20,88 @@ class _EntryConditionsSection extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-        Text(
-          '참여 현황',
-          style: theme.textTheme.titleMedium?.copyWith(
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-        const SizedBox(height: MinglitSpacing.medium),
-        if (entryGroups.isEmpty)
           Text(
-            '${event.currentParticipants}명 / ${event.maxParticipants}명',
-            style: theme.textTheme.bodyMedium,
-          )
-        else
-          ListView.separated(
-            shrinkWrap: true,
-            physics: const NeverScrollableScrollPhysics(),
-            itemCount: entryGroups.length,
-            separatorBuilder: (context, index) =>
-                const SizedBox(height: MinglitSpacing.medium),
-            itemBuilder: (context, index) {
-              final group = entryGroups[index];
-              final matchingTickets = (event.tickets ?? [])
-                  .where(
-                    (t) =>
-                        t.targetEntryGroupIds.isNotEmpty &&
-                        t.targetEntryGroupIds.contains(group.id),
-                  )
-                  .toList();
-              final soldCount = matchingTickets.fold<int>(
-                0,
-                (sum, t) => sum + t.soldCount,
-              );
-              final totalQuantity = matchingTickets.fold<int>(
-                0,
-                (sum, t) => sum + t.quantity,
-              );
-              final showGauge = matchingTickets.isNotEmpty;
-              final participantCount = counts[group.id] ?? 0;
-
-              return Stack(
-                children: [
-                  Container(
-                    padding: const EdgeInsets.all(MinglitSpacing.small),
-                    decoration: BoxDecoration(
-                      color: theme.colorScheme.surfaceContainerLowest,
-                      borderRadius: BorderRadius.circular(MinglitRadius.small),
-                      border: Border.all(
-                        color: theme.colorScheme.outlineVariant,
-                      ),
-                    ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        EntryGroupDetail(
-                          group: group.toTemplate(),
-                          showVerificationBadges: false,
-                        ),
-                        const SizedBox(height: MinglitSpacing.xsmall),
-                        Text(
-                          '$participantCount명 참여',
-                          style: theme.textTheme.labelSmall?.copyWith(
-                            color: theme.colorScheme.onSurfaceVariant,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  if (showGauge)
-                    Positioned(
-                      top: MinglitSpacing.small,
-                      right: MinglitSpacing.small,
-                      child: MinglitParticipantGauge(
-                        current: soldCount,
-                        max: totalQuantity,
-                      ),
-                    ),
-                ],
-              );
-            },
+            '참여 현황',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
           ),
+          const SizedBox(height: MinglitSpacing.medium),
+          if (entryGroups.isEmpty)
+            Text(
+              '${event.currentParticipants}명 / ${event.maxParticipants}명',
+              style: theme.textTheme.bodyMedium,
+            )
+          else
+            ListView.separated(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              itemCount: entryGroups.length,
+              separatorBuilder: (context, index) =>
+                  const SizedBox(height: MinglitSpacing.medium),
+              itemBuilder: (context, index) {
+                final group = entryGroups[index];
+                final matchingTickets = (event.tickets ?? [])
+                    .where(
+                      (t) =>
+                          t.targetEntryGroupIds.isNotEmpty &&
+                          t.targetEntryGroupIds.contains(group.id),
+                    )
+                    .toList();
+                final soldCount = matchingTickets.fold<int>(
+                  0,
+                  (sum, t) => sum + t.soldCount,
+                );
+                final totalQuantity = matchingTickets.fold<int>(
+                  0,
+                  (sum, t) => sum + t.quantity,
+                );
+                final showGauge = matchingTickets.isNotEmpty;
+                final participantCount = counts[group.id] ?? 0;
+
+                return Stack(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(MinglitSpacing.small),
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.surfaceContainerLowest,
+                        borderRadius: BorderRadius.circular(
+                          MinglitRadius.small,
+                        ),
+                        border: Border.all(
+                          color: theme.colorScheme.outlineVariant,
+                        ),
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          EntryGroupDetail(
+                            group: group.toTemplate(),
+                            showVerificationBadges: false,
+                          ),
+                          const SizedBox(height: MinglitSpacing.xsmall),
+                          Text(
+                            '$participantCount명 참여',
+                            style: theme.textTheme.labelSmall?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    if (showGauge)
+                      Positioned(
+                        top: MinglitSpacing.small,
+                        right: MinglitSpacing.small,
+                        child: MinglitParticipantGauge(
+                          current: soldCount,
+                          max: totalQuantity,
+                        ),
+                      ),
+                  ],
+                );
+              },
+            ),
         ],
       ),
     );

--- a/apps/app_user/lib/src/features/event/detail/event_entry_conditions_section.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_entry_conditions_section.dart
@@ -14,9 +14,12 @@ class _EntryConditionsSection extends ConsumerWidget {
     );
     final counts = countsAsync.value ?? {};
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
+    // Fix #172: 다른 섹션(Section 4, 5)과 동일하게 좌우 패딩 추가
+    return Padding(
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
         Text(
           '참여 현황',
           style: theme.textTheme.titleMedium?.copyWith(
@@ -97,7 +100,8 @@ class _EntryConditionsSection extends ConsumerWidget {
               );
             },
           ),
-      ],
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- 이벤트 디테일 페이지 Section 3(참여 현황)에 좌우 패딩이 누락되어 카드가 화면 왼쪽 끝에서 시작되는 버그 수정
- Section 4(필요 인증), Section 5(환불 정책)와 동일하게 `Padding(EdgeInsets.all(MinglitSpacing.medium))` 추가

Closes #172

## Test plan
- [ ] 이벤트 디테일 페이지에서 참가 현황 탭 선택 시 좌우 마진 확인
- [ ] entry group이 있는/없는 이벤트 모두 확인
- [ ] 다른 섹션(상세 소개, 필요 인증, 환불 정책)과 마진 일관성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)