### PR TITLE
fix(minglit_kit): 좋아요 버튼 토글 시 크기 변동 방지

### DIFF
--- a/shared/packages/minglit_kit/lib/src/features/social/ui/minglit_social_action_chip.dart
+++ b/shared/packages/minglit_kit/lib/src/features/social/ui/minglit_social_action_chip.dart
@@ -107,9 +107,11 @@ class MinglitSocialActionChip extends ConsumerWidget {
           ),
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(MinglitRadius.small),
-            // Fix #174: 항상 border 유지 — active 시 transparent로 변경하여 크기 변동 방지
+            // Fix #174: 항상 border 유지 — active 시 alpha 0으로 변경하여 크기 변동 방지
             border: Border.all(
-              color: isActive ? Colors.transparent : theme.colorScheme.outline,
+              color: theme.colorScheme.outline.withValues(
+                alpha: isActive ? 0 : 1,
+              ),
             ),
           ),
           child: Row(

--- a/shared/packages/minglit_kit/lib/src/features/social/ui/minglit_social_action_chip.dart
+++ b/shared/packages/minglit_kit/lib/src/features/social/ui/minglit_social_action_chip.dart
@@ -107,9 +107,10 @@ class MinglitSocialActionChip extends ConsumerWidget {
           ),
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(MinglitRadius.small),
-            border: isActive
-                ? null
-                : Border.all(color: theme.colorScheme.outline),
+            // Fix #174: 항상 border 유지 — active 시 transparent로 변경하여 크기 변동 방지
+            border: Border.all(
+              color: isActive ? Colors.transparent : theme.colorScheme.outline,
+            ),
           ),
           child: Row(
             mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
## Summary
- `MinglitSocialActionChip`에서 active 상태일 때 `border: null`이 되면서 Container 크기가 ~2px 줄어드는 문제 수정
- 항상 `Border.all`을 유지하되 active 시 `Colors.transparent`로 변경하여 레이아웃 안정성 확보

Closes #174

## Test plan
- [ ] 이벤트 디테일 페이지에서 좋아요 버튼 반복 클릭 시 크기 변동 없는지 확인
- [ ] 공유하기 버튼과 같은 라인에서 밀리지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)