### PR TITLE
fix(explore): eligibility 데이터 지연 도착 시 피드 재필터링

### DIFF
--- a/apps/app_user/lib/src/features/explore/providers/explore_state_provider.dart
+++ b/apps/app_user/lib/src/features/explore/providers/explore_state_provider.dart
@@ -267,7 +267,9 @@ class RecommendationFeedNotifier extends _$RecommendationFeedNotifier {
     // asynchronously (without re-fetching from server).
     ref.listen(bulkEligibilityDataProvider, (prev, next) {
       if (next.hasValue && next.value != null) {
-        Log.d('Eligibility data arrived, refiltering ${_rawEvents.length} events');
+        Log.d(
+          'Eligibility data arrived, refiltering ${_rawEvents.length} events',
+        );
       }
       _refilterExistingEvents();
     });

--- a/apps/app_user/lib/src/features/explore/providers/explore_state_provider.dart
+++ b/apps/app_user/lib/src/features/explore/providers/explore_state_provider.dart
@@ -265,7 +265,10 @@ class RecommendationFeedNotifier extends _$RecommendationFeedNotifier {
 
     // Fix #173: Re-filter existing events when eligibility data arrives
     // asynchronously (without re-fetching from server).
-    ref.listen(bulkEligibilityDataProvider, (_, _) {
+    ref.listen(bulkEligibilityDataProvider, (prev, next) {
+      if (next.hasValue && next.value != null) {
+        Log.d('Eligibility data arrived, refiltering ${_rawEvents.length} events');
+      }
       _refilterExistingEvents();
     });
 

--- a/apps/app_user/lib/src/features/explore/providers/explore_state_provider.dart
+++ b/apps/app_user/lib/src/features/explore/providers/explore_state_provider.dart
@@ -263,6 +263,12 @@ class RecommendationFeedNotifier extends _$RecommendationFeedNotifier {
     // Watch filters — triggers rebuild on change, resetting pagination
     final filters = ref.watch(activeFiltersProvider);
 
+    // Fix #173: Re-filter existing events when eligibility data arrives
+    // asynchronously (without re-fetching from server).
+    ref.listen(bulkEligibilityDataProvider, (_, __) {
+      _refilterExistingEvents();
+    });
+
     final result = await _fetchPage(
       filters: filters,
       serverOffset: 0,
@@ -308,6 +314,15 @@ class RecommendationFeedNotifier extends _$RecommendationFeedNotifier {
       if (!ref.mounted) return;
       state = AsyncData(current.copyWith(isLoadingMore: false));
     }
+  }
+
+  // Fix #173: Re-apply client-side filters to already-fetched events when
+  // eligibility data loads after the initial fetch. Preserves pagination state.
+  void _refilterExistingEvents() {
+    final current = state.value;
+    if (current == null || _rawEvents.isEmpty) return;
+    final filtered = ref.read(filteredEventsProvider(events: _rawEvents));
+    state = AsyncData(current.copyWith(events: filtered));
   }
 
   /// Returns null if the result is stale (a newer generation started).

--- a/apps/app_user/lib/src/features/explore/providers/explore_state_provider.dart
+++ b/apps/app_user/lib/src/features/explore/providers/explore_state_provider.dart
@@ -265,7 +265,7 @@ class RecommendationFeedNotifier extends _$RecommendationFeedNotifier {
 
     // Fix #173: Re-filter existing events when eligibility data arrives
     // asynchronously (without re-fetching from server).
-    ref.listen(bulkEligibilityDataProvider, (_, __) {
+    ref.listen(bulkEligibilityDataProvider, (_, _) {
       _refilterExistingEvents();
     });
 

--- a/apps/app_user/test/src/features/explore/providers/recommendation_feed_notifier_test.dart
+++ b/apps/app_user/test/src/features/explore/providers/recommendation_feed_notifier_test.dart
@@ -295,7 +295,6 @@ void main() {
         when(
           () => mockEventRepository.getEventsByType(
             type: EventFeedType.newArrivals,
-            offset: 0,
           ),
         ).thenAnswer((_) async => restrictedEvents);
 
@@ -306,14 +305,14 @@ void main() {
           overrides: [
             eventRepositoryProvider.overrideWithValue(mockEventRepository),
             // Eligibility data controlled by completer (simulates late arrival)
-            bulkEligibilityDataProvider
-                .overrideWith((ref) => eligibilityCompleter.future),
+            bulkEligibilityDataProvider.overrideWith(
+              (ref) => eligibilityCompleter.future,
+            ),
           ],
         );
 
         // Initial load: eligibility data not yet available -> no filtering
-        final state1 =
-            await container.read(recommendationFeedProvider.future);
+        final state1 = await container.read(recommendationFeedProvider.future);
         expect(
           state1.events,
           hasLength(10),
@@ -336,12 +335,12 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);
 
-        final state2 =
-            await container.read(recommendationFeedProvider.future);
+        final state2 = await container.read(recommendationFeedProvider.future);
         expect(
           state2.events,
           hasLength(0),
-          reason: 'user without required verification should see '
+          reason:
+              'user without required verification should see '
               'no events after eligibility data loads',
         );
       });

--- a/apps/app_user/test/src/features/explore/providers/recommendation_feed_notifier_test.dart
+++ b/apps/app_user/test/src/features/explore/providers/recommendation_feed_notifier_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:app_user/src/features/explore/logic/eligibility_filter.dart';
 import 'package:app_user/src/features/explore/providers/explore_state_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -260,6 +263,87 @@ void main() {
         // Existing 10 events preserved after error
         expect(state.events, hasLength(10));
         expect(state.isLoadingMore, isFalse);
+      });
+    });
+
+    group('Fix #173: eligibility data late arrival re-filters feed', () {
+      test('feed re-filters when eligibility data loads after events', () async {
+        // Events requiring verification 'v_required' that user does NOT have
+        final restrictedEvents = List.generate(
+          10,
+          (i) => Event(
+            id: 'e$i',
+            partyId: 'party1',
+            startTime: now.add(const Duration(days: 1)),
+            endTime: now.add(const Duration(days: 1, hours: 2)),
+            createdAt: now,
+            updatedAt: now,
+            tickets: [
+              Ticket(
+                id: 't$i',
+                name: 'Restricted',
+                price: 10000,
+                createdAt: now,
+                updatedAt: now,
+                requiredVerificationIds: ['v_required'],
+              ),
+            ],
+          ),
+        );
+
+        // Stub page with restricted events
+        when(
+          () => mockEventRepository.getEventsByType(
+            type: EventFeedType.newArrivals,
+            offset: 0,
+          ),
+        ).thenAnswer((_) async => restrictedEvents);
+
+        // Completer to control when eligibility data arrives
+        final eligibilityCompleter = Completer<BulkEligibilityData?>();
+
+        final container = createContainer(
+          overrides: [
+            eventRepositoryProvider.overrideWithValue(mockEventRepository),
+            // Eligibility data controlled by completer (simulates late arrival)
+            bulkEligibilityDataProvider
+                .overrideWith((ref) => eligibilityCompleter.future),
+          ],
+        );
+
+        // Initial load: eligibility data not yet available -> no filtering
+        final state1 =
+            await container.read(recommendationFeedProvider.future);
+        expect(
+          state1.events,
+          hasLength(10),
+          reason: 'all events shown before eligibility data arrives',
+        );
+
+        // Eligibility data arrives: verified user without v_required
+        eligibilityCompleter.complete(
+          BulkEligibilityData.fromJson({
+            'user_profile': {
+              'gender': 'male',
+              'birth_year': 1995,
+              'is_verified': true,
+            },
+            'approved_verifications': <dynamic>[],
+          }),
+        );
+
+        // Allow async listener to fire
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        final state2 =
+            await container.read(recommendationFeedProvider.future);
+        expect(
+          state2.events,
+          hasLength(0),
+          reason: 'user without required verification should see '
+              'no events after eligibility data loads',
+        );
       });
     });
   });

--- a/apps/app_user/test/src/features/explore/providers/recommendation_feed_notifier_test.dart
+++ b/apps/app_user/test/src/features/explore/providers/recommendation_feed_notifier_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:app_user/src/features/explore/logic/eligibility_filter.dart';
 import 'package:app_user/src/features/explore/providers/explore_state_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -266,7 +267,8 @@ void main() {
     });
 
     group('Fix #173: eligibility data late arrival re-filters feed', () {
-      test('feed re-filters when eligibility data loads after events', () async {
+      test('feed re-filters when eligibility data loads after events',
+          () async {
         // Events requiring verification 'v_required' that user does NOT have
         final restrictedEvents = List.generate(
           10,

--- a/apps/app_user/test/src/features/explore/providers/recommendation_feed_notifier_test.dart
+++ b/apps/app_user/test/src/features/explore/providers/recommendation_feed_notifier_test.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:app_user/src/features/explore/logic/eligibility_filter.dart';
 import 'package:app_user/src/features/explore/providers/explore_state_provider.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -295,6 +294,7 @@ void main() {
         when(
           () => mockEventRepository.getEventsByType(
             type: EventFeedType.newArrivals,
+            offset: any(named: 'offset'),
           ),
         ).thenAnswer((_) async => restrictedEvents);
 

--- a/apps/app_user/test/src/features/explore/providers/recommendation_feed_notifier_test.dart
+++ b/apps/app_user/test/src/features/explore/providers/recommendation_feed_notifier_test.dart
@@ -267,8 +267,7 @@ void main() {
     });
 
     group('Fix #173: eligibility data late arrival re-filters feed', () {
-      test('feed re-filters when eligibility data loads after events',
-          () async {
+      test('feed re-filters when eligibility data loads after events', () async {
         // Events requiring verification 'v_required' that user does NOT have
         final restrictedEvents = List.generate(
           10,


### PR DESCRIPTION
Closes #173

## Summary
- 메인 페이지에서 "참여 가능" 필터가 적용되지 않는 버그 수정
- `bulkEligibilityData`가 이벤트 목록보다 늦게 로드될 때, 기존 이벤트에 필터가 재적용되지 않던 race condition 해결
- `RecommendationFeedNotifier`에 `ref.listen(bulkEligibilityDataProvider)` 추가하여 eligibility 데이터 도착 시 `_refilterExistingEvents()` 호출

## Test plan
- [x] `recommendation_feed_notifier_test.dart` — eligibility 데이터 지연 도착 시 피드 재필터링 테스트 추가
- [ ] dev 환경에서 "참여 가능" 필터 토글 후 비적격 이벤트가 제외되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)