### PR TITLE
fix(supabase): ticket balance status allowed 필드 boolean 타입 보장

### DIFF
--- a/supabase/migrations/20260321000001_fix_ticket_balance_bool_cast.sql
+++ b/supabase/migrations/20260321000001_fix_ticket_balance_bool_cast.sql
@@ -1,0 +1,35 @@
+-- Fix #189: get_event_ticket_balance_status에서 allowed 필드가 string으로 반환되는 버그 수정
+-- 원인: ->> 연산자가 jsonb boolean을 text로 변환 → Dart 클라이언트에서 bool 캐스팅 실패
+-- 수정: allowed 필드에 -> 연산자 사용하여 jsonb boolean 타입 유지
+
+create or replace function public.get_event_ticket_balance_status(
+  p_event_id uuid
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_result jsonb := '[]'::jsonb;
+  v_ticket record;
+  v_check_result jsonb;
+begin
+  for v_ticket in
+    select id, name from public.tickets where event_id = p_event_id
+  loop
+    v_check_result := public.check_party_balance(p_event_id, v_ticket.id);
+    -- Fix #189: -> 연산자로 boolean 타입 유지 (->>'allowed'는 text로 변환됨)
+    v_result := v_result || jsonb_build_array(
+      jsonb_build_object(
+        'ticket_id', v_ticket.id,
+        'ticket_name', v_ticket.name,
+        'allowed', v_check_result->'allowed',
+        'reason', v_check_result->>'reason'
+      )
+    );
+  end loop;
+
+  return v_result;
+end;
+$$;

--- a/supabase/tests/database/42_ticket_balance_status_type_test.sql
+++ b/supabase/tests/database/42_ticket_balance_status_type_test.sql
@@ -1,0 +1,65 @@
+-- Fix #189: get_event_ticket_balance_status의 allowed 필드가 boolean으로 반환되는지 회귀 테스트
+BEGIN;
+SELECT plan(2);
+
+SELECT tests.authenticate_as_service_role();
+
+-- ============================================================
+-- Test 1: allowed 필드가 boolean 타입인지 확인 (string이 아닌)
+-- ============================================================
+
+CREATE TEMP TABLE balance_status_type_results (
+  allowed_is_boolean boolean,
+  allowed_value boolean
+);
+
+DO $$
+DECLARE
+  v_partner_id uuid;
+  v_party_id uuid;
+  v_event_id uuid;
+  v_ticket_id uuid;
+  v_result jsonb;
+  v_first_item jsonb;
+BEGIN
+  INSERT INTO public.partners (name)
+  VALUES ('Balance Type Test Partner')
+  RETURNING id INTO v_partner_id;
+
+  INSERT INTO public.parties (partner_id, title, min_confirmed_count, max_participants, balance_config)
+  VALUES (v_partner_id, 'Party Type Test', 0, 10, null)
+  RETURNING id INTO v_party_id;
+
+  INSERT INTO public.events (party_id, start_time, end_time, min_confirmed_count, max_participants)
+  VALUES (v_party_id, now() + interval '1 day', now() + interval '1 day 2 hours', 0, 10)
+  RETURNING id INTO v_event_id;
+
+  INSERT INTO public.tickets (event_id, name, quantity, price)
+  VALUES (v_event_id, 'Ticket Type Test', 10, 1000)
+  RETURNING id INTO v_ticket_id;
+
+  v_result := public.get_event_ticket_balance_status(v_event_id);
+  v_first_item := v_result->0;
+
+  -- jsonb_typeof returns 'boolean' for true/false, 'string' for "true"/"false"
+  INSERT INTO balance_status_type_results (allowed_is_boolean, allowed_value)
+  VALUES (
+    jsonb_typeof(v_first_item->'allowed') = 'boolean',
+    (v_first_item->>'allowed')::boolean
+  );
+END $$;
+
+SELECT is(
+  (SELECT allowed_is_boolean FROM balance_status_type_results),
+  true,
+  'get_event_ticket_balance_status: allowed 필드는 boolean 타입이어야 함 (string 아님)'
+);
+
+SELECT is(
+  (SELECT allowed_value FROM balance_status_type_results),
+  true,
+  'get_event_ticket_balance_status: balance_config null → allowed: true'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary
- `get_event_ticket_balance_status` SQL 함수에서 `allowed` 필드가 string(`"true"`)으로 반환되어 Dart 클라이언트에서 `type 'String' is not a subtype of type 'bool?'` 에러 발생
- PostgreSQL `->>` 연산자를 `->` 로 변경하여 jsonb boolean 타입 유지
- 회귀 테스트 추가: `allowed` 필드가 boolean 타입인지 검증

## Root Cause
`check_party_balance()`는 `jsonb_build_object('allowed', true, ...)` 형태로 boolean을 반환하지만, `get_event_ticket_balance_status()`에서 `->>` 연산자로 추출하면서 text로 변환됨.

## Fix
```sql
-- Before (bug): ->> converts boolean to text
'allowed', v_check_result->>'allowed',

-- After (fix): -> preserves jsonb boolean type  
'allowed', v_check_result->'allowed',
```

Closes #189

## Test plan
- [ ] `42_ticket_balance_status_type_test.sql` pgTAP 테스트 통과 확인
- [ ] 이벤트 신청 시 추천티켓이 정상 표시되는지 확인
- [ ] CI `ci-result` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)