### PR TITLE
fix(explore): 이벤트 피드 페이지네이션 중복/무한로딩 수정

### DIFF
--- a/apps/app_user/lib/src/features/explore/providers/explore_state_provider.dart
+++ b/apps/app_user/lib/src/features/explore/providers/explore_state_provider.dart
@@ -244,6 +244,10 @@ class RecommendationFeedState {
 class RecommendationFeedNotifier extends _$RecommendationFeedNotifier {
   static const int _limit = 10;
 
+  // Fix #193: Cap consecutive page fetches that add zero new visible events
+  // to prevent infinite API hammering when client-side filters reject all items.
+  static const int _maxConsecutiveEmptyPages = 5;
+
   /// Raw events accumulated from server (before client-side filtering).
   /// Reset on every [build] call (i.e., when filters change).
   List<Event> _rawEvents = [];
@@ -253,10 +257,14 @@ class RecommendationFeedNotifier extends _$RecommendationFeedNotifier {
   /// Used to discard stale async results from previous builds.
   int _generation = 0;
 
+  /// Tracks consecutive pages where no new visible events were added.
+  int _consecutiveEmptyPages = 0;
+
   @override
   Future<RecommendationFeedState> build() async {
     // Reset raw accumulation and bump generation on every filter change
     _rawEvents = [];
+    _consecutiveEmptyPages = 0;
     _generation++;
     final capturedGen = _generation;
 
@@ -354,15 +362,31 @@ class RecommendationFeedNotifier extends _$RecommendationFeedNotifier {
     final newUnique = rawPage
         .where((e) => !existingIds.contains(e.id))
         .toList();
+
+    // Fix #193: Track consecutive pages that add zero visible events.
+    // Stop pagination to prevent infinite API calls when all events are
+    // filtered out by eligibility/nearby filters.
+    final prevFilteredCount =
+        ref.read(filteredEventsProvider(events: _rawEvents)).length;
     _rawEvents = [..._rawEvents, ...newUnique];
 
     // Apply client-side filter + sort to full accumulated list
     final filtered = ref.read(filteredEventsProvider(events: _rawEvents));
 
+    if (filtered.length > prevFilteredCount) {
+      _consecutiveEmptyPages = 0;
+    } else {
+      _consecutiveEmptyPages++;
+    }
+
+    final serverHasMore = rawPage.length >= _limit;
+    final hasMore = serverHasMore &&
+        _consecutiveEmptyPages < _maxConsecutiveEmptyPages;
+
     return RecommendationFeedState(
       events: filtered,
       serverOffset: serverOffset + rawPage.length,
-      hasMore: rawPage.length >= _limit,
+      hasMore: hasMore,
     );
   }
 

--- a/apps/app_user/lib/src/features/explore/providers/explore_state_provider.dart
+++ b/apps/app_user/lib/src/features/explore/providers/explore_state_provider.dart
@@ -366,8 +366,9 @@ class RecommendationFeedNotifier extends _$RecommendationFeedNotifier {
     // Fix #193: Track consecutive pages that add zero visible events.
     // Stop pagination to prevent infinite API calls when all events are
     // filtered out by eligibility/nearby filters.
-    final prevFilteredCount =
-        ref.read(filteredEventsProvider(events: _rawEvents)).length;
+    final prevFilteredCount = ref
+        .read(filteredEventsProvider(events: _rawEvents))
+        .length;
     _rawEvents = [..._rawEvents, ...newUnique];
 
     // Apply client-side filter + sort to full accumulated list
@@ -380,8 +381,8 @@ class RecommendationFeedNotifier extends _$RecommendationFeedNotifier {
     }
 
     final serverHasMore = rawPage.length >= _limit;
-    final hasMore = serverHasMore &&
-        _consecutiveEmptyPages < _maxConsecutiveEmptyPages;
+    final hasMore =
+        serverHasMore && _consecutiveEmptyPages < _maxConsecutiveEmptyPages;
 
     return RecommendationFeedState(
       events: filtered,

--- a/apps/app_user/test/src/features/explore/providers/recommendation_feed_notifier_test.dart
+++ b/apps/app_user/test/src/features/explore/providers/recommendation_feed_notifier_test.dart
@@ -267,35 +267,38 @@ void main() {
     });
 
     group('Fix #193: consecutive empty page cap', () {
-      test('hasMore becomes false after 5 pages with no new visible events',
-          () async {
-        // Page 0 returns 10 events that pass filter → visible
-        stubPage(offset: 0, returns: makeEvents(10));
+      test(
+        'hasMore becomes false after 5 pages with no new visible events',
+        () async {
+          // Page 0 returns 10 events that pass filter → visible
+          stubPage(offset: 0, returns: makeEvents(10));
 
-        // Pages 1-5: all return 10 events, but they are duplicates of page 0
-        // (simulating non-deterministic ORDER BY returning same items).
-        for (var i = 1; i <= 5; i++) {
-          stubPage(offset: i * 10, returns: makeEvents(10));
-        }
+          // Pages 1-5: all return 10 events, but they are duplicates of page 0
+          // (simulating non-deterministic ORDER BY returning same items).
+          for (var i = 1; i <= 5; i++) {
+            stubPage(offset: i * 10, returns: makeEvents(10));
+          }
 
-        final container = makeContainer();
-        await container.read(recommendationFeedProvider.future);
+          final container = makeContainer();
+          await container.read(recommendationFeedProvider.future);
 
-        // Load 5 more pages — all add 0 new visible events (all duplicates)
-        for (var i = 0; i < 5; i++) {
-          await container
-              .read(recommendationFeedProvider.notifier)
-              .loadMore();
-        }
+          // Load 5 more pages — all add 0 new visible events (all duplicates)
+          for (var i = 0; i < 5; i++) {
+            await container
+                .read(recommendationFeedProvider.notifier)
+                .loadMore();
+          }
 
-        final state = await container.read(recommendationFeedProvider.future);
-        expect(
-          state.hasMore,
-          isFalse,
-          reason: '5 consecutive pages with no new visible events '
-              'should stop pagination',
-        );
-      });
+          final state = await container.read(recommendationFeedProvider.future);
+          expect(
+            state.hasMore,
+            isFalse,
+            reason:
+                '5 consecutive pages with no new visible events '
+                'should stop pagination',
+          );
+        },
+      );
 
       test('counter resets when new visible events appear', () async {
         stubPage(offset: 0, returns: makeEvents(10));
@@ -315,19 +318,18 @@ void main() {
 
         // Load 3 empty pages
         for (var i = 0; i < 3; i++) {
-          await container
-              .read(recommendationFeedProvider.notifier)
-              .loadMore();
+          await container.read(recommendationFeedProvider.notifier).loadMore();
         }
 
         var state = await container.read(recommendationFeedProvider.future);
-        expect(state.hasMore, isTrue,
-            reason: 'only 3 empty pages, below cap of 5');
+        expect(
+          state.hasMore,
+          isTrue,
+          reason: 'only 3 empty pages, below cap of 5',
+        );
 
         // Page 4 adds new events → counter resets
-        await container
-            .read(recommendationFeedProvider.notifier)
-            .loadMore();
+        await container.read(recommendationFeedProvider.notifier).loadMore();
         state = await container.read(recommendationFeedProvider.future);
         expect(state.hasMore, isTrue);
         expect(state.events, hasLength(20));

--- a/apps/app_user/test/src/features/explore/providers/recommendation_feed_notifier_test.dart
+++ b/apps/app_user/test/src/features/explore/providers/recommendation_feed_notifier_test.dart
@@ -266,6 +266,74 @@ void main() {
       });
     });
 
+    group('Fix #193: consecutive empty page cap', () {
+      test('hasMore becomes false after 5 pages with no new visible events',
+          () async {
+        // Page 0 returns 10 events that pass filter → visible
+        stubPage(offset: 0, returns: makeEvents(10));
+
+        // Pages 1-5: all return 10 events, but they are duplicates of page 0
+        // (simulating non-deterministic ORDER BY returning same items).
+        for (var i = 1; i <= 5; i++) {
+          stubPage(offset: i * 10, returns: makeEvents(10));
+        }
+
+        final container = makeContainer();
+        await container.read(recommendationFeedProvider.future);
+
+        // Load 5 more pages — all add 0 new visible events (all duplicates)
+        for (var i = 0; i < 5; i++) {
+          await container
+              .read(recommendationFeedProvider.notifier)
+              .loadMore();
+        }
+
+        final state = await container.read(recommendationFeedProvider.future);
+        expect(
+          state.hasMore,
+          isFalse,
+          reason: '5 consecutive pages with no new visible events '
+              'should stop pagination',
+        );
+      });
+
+      test('counter resets when new visible events appear', () async {
+        stubPage(offset: 0, returns: makeEvents(10));
+        // Pages 1-3: duplicates (no new visible events)
+        for (var i = 1; i <= 3; i++) {
+          stubPage(offset: i * 10, returns: makeEvents(10));
+        }
+        // Page 4: new unique events → resets counter
+        stubPage(offset: 40, returns: makeEvents(10, startIndex: 10));
+        // Pages 5-7: duplicates again
+        for (var i = 5; i <= 7; i++) {
+          stubPage(offset: i * 10, returns: makeEvents(10));
+        }
+
+        final container = makeContainer();
+        await container.read(recommendationFeedProvider.future);
+
+        // Load 3 empty pages
+        for (var i = 0; i < 3; i++) {
+          await container
+              .read(recommendationFeedProvider.notifier)
+              .loadMore();
+        }
+
+        var state = await container.read(recommendationFeedProvider.future);
+        expect(state.hasMore, isTrue,
+            reason: 'only 3 empty pages, below cap of 5');
+
+        // Page 4 adds new events → counter resets
+        await container
+            .read(recommendationFeedProvider.notifier)
+            .loadMore();
+        state = await container.read(recommendationFeedProvider.future);
+        expect(state.hasMore, isTrue);
+        expect(state.events, hasLength(20));
+      });
+    });
+
     group('Fix #173: eligibility data late arrival re-filters feed', () {
       test('feed re-filters when eligibility data loads after events', () async {
         // Events requiring verification 'v_required' that user does NOT have

--- a/apps/app_user/test/src/features/explore/providers/recommendation_feed_notifier_test.dart
+++ b/apps/app_user/test/src/features/explore/providers/recommendation_feed_notifier_test.dart
@@ -308,10 +308,6 @@ void main() {
         }
         // Page 4: new unique events → resets counter
         stubPage(offset: 40, returns: makeEvents(10, startIndex: 10));
-        // Pages 5-7: duplicates again
-        for (var i = 5; i <= 7; i++) {
-          stubPage(offset: i * 10, returns: makeEvents(10));
-        }
 
         final container = makeContainer();
         await container.read(recommendationFeedProvider.future);

--- a/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_queries.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_queries.dart
@@ -94,6 +94,8 @@ mixin _EventRepositoryQueries on _SupabaseEventContext {
       }
 
       // 4. Sorting Strategy
+      // Fix #193: Add `id` tiebreaker to all ORDER BY for deterministic
+      // offset-based pagination — prevents duplicate/skipped rows across pages.
       switch (type) {
         case EventFeedType.newArrivals:
           // ignore: avoid_dynamic_calls, Reason: Supabase builder chaining
@@ -111,6 +113,8 @@ mixin _EventRepositoryQueries on _SupabaseEventContext {
           // ignore: avoid_dynamic_calls, Reason: Supabase builder chaining
           query = query.order('created_at', ascending: false);
       }
+      // ignore: avoid_dynamic_calls, Reason: Supabase builder chaining
+      query = query.order('id', ascending: true);
 
       final queryLimit =
           blockedPartnerIds != null && blockedPartnerIds.isNotEmpty


### PR DESCRIPTION
Closes #193

## Summary
- `getEventsByType` 쿼리의 ORDER BY에 `id` tiebreaker 추가하여 offset-based pagination의 결정론적 정렬 보장 — 페이지 간 이벤트 중복/누락 방지
- 클라이언트 필터(eligibility/nearby)로 모든 이벤트가 제거될 때 연속 5회 빈 결과 후 `hasMore=false` 설정 — 무한 API 호출 방지
- 페이지네이션 캡 관련 유닛 테스트 2건 추가

## Root Cause
`ORDER BY created_at DESC`만 사용하여 동일 `created_at`을 가진 이벤트들의 순서가 페이지 간 비결정적이었음.
이로 인해 offset 기반 pagination에서 같은 이벤트가 여러 페이지에 반복 반환되고, auto-reload 로직과 결합하여 무한 API 호출 발생.

## Test plan
- [x] `recommendation_feed_notifier_test.dart` 전체 통과 (기존 9건 + 신규 2건 = 11건)
- [ ] dev 환경에서 이벤트 피드 스크롤 시 중복 이벤트 없이 정상 페이지네이션 확인
- [ ] 자격 요건 미충족 이벤트만 있을 때 무한 로딩 없이 종료되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)