### PR TITLE
fix(my-page): 설정 메뉴 그룹별 구분선 추가

### DIFF
--- a/apps/app_user/lib/src/features/home/my_page.dart
+++ b/apps/app_user/lib/src/features/home/my_page.dart
@@ -102,7 +102,7 @@ class MyPage extends ConsumerWidget {
           ),
           const Divider(),
 
-          // 2. Menu Items
+          // 2. Menu Items — 거래
           ListTile(
             leading: const Icon(Icons.receipt_long_outlined),
             title: const Text('구매 내역'),
@@ -115,6 +115,8 @@ class MyPage extends ConsumerWidget {
             trailing: const Icon(Icons.chevron_right),
             onTap: homeCoordinator.pushPurchaseHistory,
           ),
+          // Fix #187: 그룹별 구분선 추가 — 거래 / 앱 설정
+          const Divider(),
           ListTile(
             leading: const Icon(Icons.notifications_outlined),
             title: const Text('알림 설정'),
@@ -122,6 +124,8 @@ class MyPage extends ConsumerWidget {
             onTap: homeCoordinator.pushNotificationSettings,
           ),
           const ThemeSettingsTile(),
+          // Fix #187: 그룹별 구분선 추가 — 앱 설정 / 개인정보·보안
+          const Divider(),
           // Fix #139: Add privacy and permissions menu items
           ListTile(
             leading: const Icon(Icons.lock_outline),


### PR DESCRIPTION
## Summary
- 마이페이지 설정 메뉴에 그룹별 `Divider` 추가
  - **거래** (구매 내역, 내 티켓)
  - **앱 설정** (알림 설정, 테마)
  - **개인정보·보안** (개인정보, 권한 설정, 차단 목록)
  - **로그아웃**

Closes #187

## Test plan
- [ ] 마이페이지 진입 후 4개 그룹 사이에 구분선이 보이는지 확인
- [ ] 다크모드에서도 구분선이 정상 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)