### PR TITLE
fix(explore): 홈 피드에 pull-to-refresh 추가

### DIFF
--- a/apps/app_user/lib/src/features/explore/providers/explore_state_provider.dart
+++ b/apps/app_user/lib/src/features/explore/providers/explore_state_provider.dart
@@ -298,6 +298,13 @@ class RecommendationFeedNotifier extends _$RecommendationFeedNotifier {
         );
   }
 
+  /// Resets pagination and re-fetches from page 0.
+  // Fix #192: Pull-to-refresh support for the explore feed.
+  Future<void> refresh() async {
+    ref.invalidateSelf();
+    await future;
+  }
+
   /// Loads the next page of events.
   ///
   /// No-op if already loading or no more pages available.

--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -107,8 +107,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                     onPressed: () => const MyPageRoute().push<void>(context),
                     icon: CircleAvatar(
                       radius: 14,
-                      backgroundImage:
-                          user.userMetadata?['avatar_url'] != null
+                      backgroundImage: user.userMetadata?['avatar_url'] != null
                           ? NetworkImage(
                               user.userMetadata!['avatar_url'] as String,
                             )
@@ -171,8 +170,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                       final event = state.events[index];
                       return MinglitEventCard(
                         event: event,
-                        onTap: () =>
-                            eventCoordinator.pushEventDetail(event.id),
+                        onTap: () => eventCoordinator.pushEventDetail(event.id),
                       );
                     },
                   ),

--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -179,8 +179,22 @@ class _HomePageState extends ConsumerState<HomePage> {
               loading: () => const SliverFillRemaining(
                 child: Center(child: MinglitCircularProgressIndicator()),
               ),
-              error: (_, _) => const SliverFillRemaining(
-                child: SizedBox.shrink(),
+              // Fix #192: 피드 로드 실패 시 에러 메시지와 재시도 버튼 표시
+              error: (_, _) => SliverFillRemaining(
+                child: Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Text('피드를 불러오지 못했습니다'),
+                      const SizedBox(height: MinglitSpacing.small),
+                      TextButton(
+                        onPressed: () =>
+                            ref.invalidate(recommendationFeedProvider),
+                        child: const Text('다시 시도'),
+                      ),
+                    ],
+                  ),
+                ),
               ),
             ),
             if (recommendationState.value?.isLoadingMore ?? false)

--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -62,137 +62,144 @@ class _HomePageState extends ConsumerState<HomePage> {
     });
 
     return Scaffold(
-      body: CustomScrollView(
-        controller: _scrollController,
-        slivers: [
-          SliverAppBar(
-            floating: true,
-            snap: true,
-            titleSpacing: 0,
-            title: Row(
-              children: [
-                const SizedBox(width: MinglitSpacing.medium),
-                GestureDetector(
-                  onTap: () {
-                    unawaited(
-                      _scrollController.animateTo(
-                        0,
-                        duration: const Duration(milliseconds: 300),
-                        curve: Curves.easeOut,
-                      ),
-                    );
-                  },
-                  child: MinglitTheme.appBarLogo(height: 36),
-                ),
-              ],
-            ),
-            // Fix #141: Equalize action button spacing and padding alignment
-            actions: [
-              IconButton(
-                icon: const Icon(Icons.search),
-                onPressed: () => const SearchRoute().push<void>(context),
-              ),
-              if (user != null) ...[
-                IconButton(
-                  icon: const Icon(Icons.notifications_outlined),
-                  onPressed: homeCoordinator.pushNotificationCenter,
-                ),
-                // Fix #141: Use IconButton for consistent touch target (48x48)
-                // and ripple effect with other app bar actions
-                IconButton(
-                  onPressed: () => const MyPageRoute().push<void>(context),
-                  icon: CircleAvatar(
-                    radius: 14,
-                    backgroundImage: user.userMetadata?['avatar_url'] != null
-                        ? NetworkImage(
-                            user.userMetadata!['avatar_url'] as String,
-                          )
-                        : null,
-                    onBackgroundImageError:
-                        user.userMetadata?['avatar_url'] != null
-                        ? (_, _) {}
-                        : null,
-                    child: user.userMetadata?['avatar_url'] == null
-                        ? const Icon(Icons.person, size: 14)
-                        : null,
+      // Fix #192: Pull-to-refresh to reload the explore feed from scratch.
+      body: RefreshIndicator(
+        onRefresh: () =>
+            ref.read(recommendationFeedProvider.notifier).refresh(),
+        child: CustomScrollView(
+          controller: _scrollController,
+          slivers: [
+            SliverAppBar(
+              floating: true,
+              snap: true,
+              titleSpacing: 0,
+              title: Row(
+                children: [
+                  const SizedBox(width: MinglitSpacing.medium),
+                  GestureDetector(
+                    onTap: () {
+                      unawaited(
+                        _scrollController.animateTo(
+                          0,
+                          duration: const Duration(milliseconds: 300),
+                          curve: Curves.easeOut,
+                        ),
+                      );
+                    },
+                    child: MinglitTheme.appBarLogo(height: 36),
                   ),
-                ),
-              ] else
+                ],
+              ),
+              // Fix #141: Equalize action button spacing and padding alignment
+              actions: [
                 IconButton(
-                  icon: const Icon(Icons.person_outline),
-                  // Fix #102: use go (not push) so GoRouter redirect
-                  // fires after login
-                  onPressed: () =>
-                      ref.read(authCoordinatorProvider).goToLogin(from: '/'),
+                  icon: const Icon(Icons.search),
+                  onPressed: () => const SearchRoute().push<void>(context),
                 ),
-              const SizedBox(width: MinglitSpacing.small),
-            ],
-            // Fix #76: use theme color instead of
-            // hardcoded white for dark mode support
-            backgroundColor: Theme.of(context).colorScheme.surface,
-            surfaceTintColor: MinglitColors.transparent,
-          ),
-          const SliverToBoxAdapter(
-            child: Padding(
-              padding: EdgeInsets.only(top: MinglitSpacing.small),
-              child: ExploreFilterChipBar(),
+                if (user != null) ...[
+                  IconButton(
+                    icon: const Icon(Icons.notifications_outlined),
+                    onPressed: homeCoordinator.pushNotificationCenter,
+                  ),
+                  // Fix #141: Use IconButton for consistent touch target (48x48)
+                  // and ripple effect with other app bar actions
+                  IconButton(
+                    onPressed: () => const MyPageRoute().push<void>(context),
+                    icon: CircleAvatar(
+                      radius: 14,
+                      backgroundImage:
+                          user.userMetadata?['avatar_url'] != null
+                          ? NetworkImage(
+                              user.userMetadata!['avatar_url'] as String,
+                            )
+                          : null,
+                      onBackgroundImageError:
+                          user.userMetadata?['avatar_url'] != null
+                          ? (_, _) {}
+                          : null,
+                      child: user.userMetadata?['avatar_url'] == null
+                          ? const Icon(Icons.person, size: 14)
+                          : null,
+                    ),
+                  ),
+                ] else
+                  IconButton(
+                    icon: const Icon(Icons.person_outline),
+                    // Fix #102: use go (not push) so GoRouter redirect
+                    // fires after login
+                    onPressed: () =>
+                        ref.read(authCoordinatorProvider).goToLogin(from: '/'),
+                  ),
+                const SizedBox(width: MinglitSpacing.small),
+              ],
+              // Fix #76: use theme color instead of
+              // hardcoded white for dark mode support
+              backgroundColor: Theme.of(context).colorScheme.surface,
+              surfaceTintColor: MinglitColors.transparent,
             ),
-          ),
-          // ignore: use_minglit_async_value_widget, returns Sliver which is incompatible with Widget-based MinglitAsyncValueWidget
-          recommendationState.when(
-            data: (state) {
-              if (state.events.isEmpty && !state.hasMore) {
-                return const SliverFillRemaining(
-                  child: Center(child: Text('추천 이벤트가 없습니다')),
-                );
-              }
-              // First page fully filtered client-side: show loading while
-              // auto-fetch (triggered by ref.listen above) loads next page.
-              if (state.events.isEmpty) {
-                return const SliverFillRemaining(
-                  child: Center(child: MinglitCircularProgressIndicator()),
-                );
-              }
-              return SliverPadding(
-                padding: const EdgeInsets.only(
-                  top: MinglitSpacing.small,
-                  bottom: MinglitSpacing.medium,
-                ),
-                sliver: SliverList.separated(
-                  itemCount: state.events.length,
-                  separatorBuilder: (_, _) =>
-                      const SizedBox(height: MinglitSpacing.small),
-                  itemBuilder: (context, index) {
-                    final event = state.events[index];
-                    return MinglitEventCard(
-                      event: event,
-                      onTap: () => eventCoordinator.pushEventDetail(event.id),
-                    );
-                  },
-                ),
-              );
-            },
-            loading: () => const SliverFillRemaining(
-              child: Center(child: MinglitCircularProgressIndicator()),
-            ),
-            error: (_, _) => const SliverFillRemaining(
-              child: SizedBox.shrink(),
-            ),
-          ),
-          if (recommendationState.value?.isLoadingMore ?? false)
             const SliverToBoxAdapter(
               child: Padding(
-                padding: EdgeInsets.only(
-                  top: MinglitSpacing.medium,
-                  bottom: MinglitSpacing.medium,
-                ),
-                child: Center(child: MinglitCircularProgressIndicator()),
+                padding: EdgeInsets.only(top: MinglitSpacing.small),
+                child: ExploreFilterChipBar(),
               ),
             ),
-          const SliverPadding(
-            padding: EdgeInsets.only(bottom: MinglitSpacing.xlarge),
-          ),
-        ],
+            // ignore: use_minglit_async_value_widget, returns Sliver which is incompatible with Widget-based MinglitAsyncValueWidget
+            recommendationState.when(
+              data: (state) {
+                if (state.events.isEmpty && !state.hasMore) {
+                  return const SliverFillRemaining(
+                    child: Center(child: Text('추천 이벤트가 없습니다')),
+                  );
+                }
+                // First page fully filtered client-side: show loading while
+                // auto-fetch (triggered by ref.listen above) loads next page.
+                if (state.events.isEmpty) {
+                  return const SliverFillRemaining(
+                    child: Center(child: MinglitCircularProgressIndicator()),
+                  );
+                }
+                return SliverPadding(
+                  padding: const EdgeInsets.only(
+                    top: MinglitSpacing.small,
+                    bottom: MinglitSpacing.medium,
+                  ),
+                  sliver: SliverList.separated(
+                    itemCount: state.events.length,
+                    separatorBuilder: (_, _) =>
+                        const SizedBox(height: MinglitSpacing.small),
+                    itemBuilder: (context, index) {
+                      final event = state.events[index];
+                      return MinglitEventCard(
+                        event: event,
+                        onTap: () =>
+                            eventCoordinator.pushEventDetail(event.id),
+                      );
+                    },
+                  ),
+                );
+              },
+              loading: () => const SliverFillRemaining(
+                child: Center(child: MinglitCircularProgressIndicator()),
+              ),
+              error: (_, _) => const SliverFillRemaining(
+                child: SizedBox.shrink(),
+              ),
+            ),
+            if (recommendationState.value?.isLoadingMore ?? false)
+              const SliverToBoxAdapter(
+                child: Padding(
+                  padding: EdgeInsets.only(
+                    top: MinglitSpacing.medium,
+                    bottom: MinglitSpacing.medium,
+                  ),
+                  child: Center(child: MinglitCircularProgressIndicator()),
+                ),
+              ),
+            const SliverPadding(
+              padding: EdgeInsets.only(bottom: MinglitSpacing.xlarge),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/apps/app_user/test/src/features/home/home_page_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_test.dart
@@ -163,6 +163,24 @@ void main() {
       expect(find.byType(RefreshIndicator), findsOneWidget);
     });
 
+    testWidgets('shows error message with retry button on feed load failure', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        createTestWidget(
+          overrides: [
+            recommendationFeedProvider.overrideWith(
+              _MockErrorNotifier.new,
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('피드를 불러오지 못했습니다'), findsOneWidget);
+      expect(find.text('다시 시도'), findsOneWidget);
+    });
+
     testWidgets('does not show loading indicator when hasMore is false', (
       tester,
     ) async {
@@ -202,6 +220,14 @@ class _MockLoadingMoreNotifier extends RecommendationFeedNotifier {
       hasMore: true,
       isLoadingMore: true,
     );
+  }
+}
+
+/// A notifier that throws an error to test the error state UI.
+class _MockErrorNotifier extends RecommendationFeedNotifier {
+  @override
+  Future<RecommendationFeedState> build() async {
+    throw Exception('Feed load failed');
   }
 }
 

--- a/apps/app_user/test/src/features/home/home_page_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_test.dart
@@ -175,7 +175,7 @@ void main() {
           ],
         ),
       );
-      await tester.pump();
+      await tester.pumpAndSettle();
 
       expect(find.text('피드를 불러오지 못했습니다'), findsOneWidget);
       expect(find.text('다시 시도'), findsOneWidget);

--- a/apps/app_user/test/src/features/home/home_page_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_test.dart
@@ -154,6 +154,15 @@ void main() {
       expect(find.byType(MinglitCircularProgressIndicator), findsOneWidget);
     });
 
+    testWidgets('wraps content in RefreshIndicator for pull-to-refresh', (
+      tester,
+    ) async {
+      await tester.pumpWidget(createTestWidget());
+      await tester.pump();
+
+      expect(find.byType(RefreshIndicator), findsOneWidget);
+    });
+
     testWidgets('does not show loading indicator when hasMore is false', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary
- 홈(탐색) 화면의 `CustomScrollView`를 `RefreshIndicator`로 감싸 pull-to-refresh 지원
- `RecommendationFeedNotifier.refresh()` 메서드 추가: `invalidateSelf()`로 페이지네이션 초기화 후 재로드
- RefreshIndicator 존재 확인 테스트 추가

Closes #192

## Test plan
- [ ] 홈 화면에서 아래로 당겨 새로고침 동작 확인
- [ ] 새로고침 후 피드가 처음부터 다시 로드되는지 확인
- [ ] 필터 적용 상태에서 새로고침 시 필터 유지 확인
- [ ] 기존 무한 스크롤 페이지네이션 정상 동작 확인
- [ ] `flutter test test/src/features/home/` 전체 통과 확인 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)