### PR TITLE
fix: 강제 언래핑(!) null crash 4건 수정

### DIFF
--- a/apps/app_partner/lib/src/features/home/widgets/upcoming_events_card.dart
+++ b/apps/app_partner/lib/src/features/home/widgets/upcoming_events_card.dart
@@ -91,7 +91,7 @@ class UpcomingEventsCard extends StatelessWidget {
                                     // Fix #180: 강제 언래핑 제거 — null-safe 접근
                                     dateFormat.format(event.startTime) +
                                         (event.party?.title != null
-                                            ? ' \u00b7 ${event.party!.title}'
+                                            ? ' \u00b7 ${event.party?.title}'
                                             : ''),
                                     style: theme.textTheme.bodySmall?.copyWith(
                                       color: colorScheme.onSurfaceVariant,

--- a/apps/app_partner/lib/src/features/home/widgets/upcoming_events_card.dart
+++ b/apps/app_partner/lib/src/features/home/widgets/upcoming_events_card.dart
@@ -88,8 +88,9 @@ class UpcomingEventsCard extends StatelessWidget {
                                   ),
                                   const SizedBox(height: 2),
                                   Text(
+                                    // Fix #180: 강제 언래핑 제거 — null-safe 접근
                                     dateFormat.format(event.startTime) +
-                                        (event.party != null
+                                        (event.party?.title != null
                                             ? ' \u00b7 ${event.party!.title}'
                                             : ''),
                                     style: theme.textTheme.bodySmall?.copyWith(

--- a/apps/app_partner/lib/src/features/onboarding/partner_apply_status_page.dart
+++ b/apps/app_partner/lib/src/features/onboarding/partner_apply_status_page.dart
@@ -117,8 +117,9 @@ class PartnerApplyStatusPage extends ConsumerWidget {
                     ),
                   ),
                   const SizedBox(height: MinglitSpacing.small),
+                  // Fix #180: 이중 강제 언래핑 제거 — null-safe 접근으로 crash 방지
                   Text(
-                    application!.adminComment!,
+                    application?.adminComment ?? '',
                     style: theme.textTheme.bodyMedium,
                   ),
                 ],

--- a/apps/app_partner/lib/src/features/party/list/widgets/party_list_item.dart
+++ b/apps/app_partner/lib/src/features/party/list/widgets/party_list_item.dart
@@ -110,10 +110,11 @@ class PartyListItem extends StatelessWidget {
                           runSpacing: MinglitSpacing.xxsmall,
                           children: [
                             // Location Chip
+                            // Fix #180: 강제 언래핑 제거 — null-safe 접근
                             if (party.location != null)
                               _InfoChip(
                                 icon: Icons.location_on,
-                                label: party.location!.name,
+                                label: party.location?.name ?? '',
                               )
                             else
                               _InfoChip(

--- a/apps/app_user/lib/src/features/ticket/ui/ticket_selection_widgets.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/ticket_selection_widgets.dart
@@ -178,11 +178,13 @@ extension _TicketSelectionWidgets on _TicketSelectionSheetState {
     );
   }
 
+  // Fix #180: tickets null 및 firstWhere 매치 실패 시 crash 방지
   String calculateTotal() {
     if (_selectedTicketId == null) return '0원';
-    final ticket = widget.event.tickets!.firstWhere(
-      (t) => t.id == _selectedTicketId,
-    );
+    final tickets = widget.event.tickets;
+    if (tickets == null) return '0원';
+    final ticket = tickets.where((t) => t.id == _selectedTicketId).firstOrNull;
+    if (ticket == null) return '0원';
     return '${NumberFormat('#,###').format(ticket.price * _quantity)}원';
   }
 


### PR DESCRIPTION
## Summary
- 코드 품질 감사(#180)에서 발견된 High 심각도 강제 언래핑(!) null crash 4건 수정
- `application!.adminComment!`, `tickets!.firstWhere(...)`, `party.location!.name`, `event.party!.title` → null-safe 패턴으로 변경

## Changes
| 파일 | 수정 내용 |
|------|-----------|
| `partner_apply_status_page.dart` | `application!.adminComment!` → `application?.adminComment ?? ''` |
| `ticket_selection_widgets.dart` | `tickets!.firstWhere(...)` → null 체크 + `firstOrNull` 사용 |
| `party_list_item.dart` | `party.location!.name` → `party.location?.name ?? ''` |
| `upcoming_events_card.dart` | `event.party != null` → `event.party?.title != null` 안전 체크 |

## Test plan
- [ ] `flutter analyze` 통과 확인 (CI)
- [ ] 기존 테스트 통과 확인 (CI)

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)