### PR TITLE
fix(event): 필요 인증 섹션 UI를 VerificationCard로 개선

### DIFF
--- a/apps/app_user/lib/src/features/event/detail/event_verification_section.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_verification_section.dart
@@ -66,7 +66,8 @@ class _VerificationSection extends ConsumerWidget {
                     )
                     .toList(),
               ),
-              loading: () => const MinglitSkeleton(height: 72, width: double.infinity),
+              loading: () =>
+                  const MinglitSkeleton(height: 72, width: double.infinity),
               error: (e, s) => const SizedBox.shrink(),
             ),
         ],

--- a/apps/app_user/lib/src/features/event/detail/event_verification_section.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_verification_section.dart
@@ -50,12 +50,7 @@ class _VerificationSection extends ConsumerWidget {
                         child: VerificationCard(
                           verification: v,
                           onTap: () {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(
-                                content: Text('구현준비중입니다'),
-                                duration: Duration(seconds: 2),
-                              ),
-                            );
+                            context.showMinglitInfo('구현준비중입니다');
                           },
                           trailing: Icon(
                             Icons.chevron_right,

--- a/apps/app_user/lib/src/features/event/detail/event_verification_section.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_verification_section.dart
@@ -36,21 +36,37 @@ class _VerificationSection extends ConsumerWidget {
               ),
             )
           else
+            // Fix #191: MinglitChip → VerificationCard로 변경하여 다른 UI와 룩앤필 통일
             MinglitAsyncValueWidget(
               value: ref.watch(verificationsByIdsProvider(allIds.join(','))),
-              data: (verifications) => Wrap(
-                spacing: MinglitSpacing.small,
-                runSpacing: MinglitSpacing.small,
+              data: (verifications) => Column(
                 children: verifications
                     .map(
-                      (v) => MinglitChip(
-                        label: v.displayName,
-                        icon: Icons.verified_user_outlined,
+                      (v) => Padding(
+                        padding: const EdgeInsets.only(
+                          bottom: MinglitSpacing.small,
+                        ),
+                        // Fix #191: 클릭 시 상세 화면 이동 (임시 스낵바)
+                        child: VerificationCard(
+                          verification: v,
+                          onTap: () {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                content: Text('구현준비중입니다'),
+                                duration: Duration(seconds: 2),
+                              ),
+                            );
+                          },
+                          trailing: Icon(
+                            Icons.chevron_right,
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
                       ),
                     )
                     .toList(),
               ),
-              loading: () => const MinglitSkeleton(height: 32, width: 80),
+              loading: () => const MinglitSkeleton(height: 72, width: double.infinity),
               error: (e, s) => const SizedBox.shrink(),
             ),
         ],


### PR DESCRIPTION
## Summary
- `MinglitChip` → `VerificationCard`로 변경하여 다른 섹션과 룩앤필 통일
- 카테고리별 아이콘, displayName, description 표시로 정보량 증가
- 카드 클릭 시 "구현준비중입니다" 스낵바 표시 (추후 상세 화면 구현 시 교체)
- chevron_right trailing 아이콘으로 클릭 가능 힌트 제공

Closes #191

## Test plan
- [ ] 이벤트 상세 페이지에서 "필요 인증" 섹션 UI 확인
- [ ] 인증 카드 크기가 다른 UI 요소와 일관되는지 확인
- [ ] 카드 클릭 시 "구현준비중입니다" 스낵바 표시 확인
- [ ] 인증이 없는 이벤트에서 "별도의 인증이 필요하지 않습니다" 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)