### PR TITLE
fix(event): 환불 정책 UI 날짜 인지성 개선

### DIFF
--- a/apps/app_user/lib/src/features/event/detail/event_refund_policy_section.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_refund_policy_section.dart
@@ -22,16 +22,16 @@ class _RefundPolicySection extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          // Fix #190: 인포버튼을 타이틀 바로 옆에 배치
           Row(
             children: [
-              Expanded(
-                child: Text(
-                  '환불 정책',
-                  style: theme.textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
+              Text(
+                '환불 정책',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
                 ),
               ),
+              const SizedBox(width: MinglitSpacing.xxsmall),
               IconButton(
                 icon: Icon(
                   Icons.info_outline,
@@ -69,7 +69,9 @@ class _RefundPolicySection extends ConsumerWidget {
     final now = DateTime.now();
     // Fix #138: "~까지 환불 가능" 문구와 일치하도록 경계값 포함 비교
     final isRefundable = !now.isAfter(cutoffDate);
-    final dateFormat = DateFormat('M월 d일 HH시', 'ko_KR');
+    // Fix #190: 요일 추가, D-day 표시로 날짜 인지성 개선
+    final dateFormat = DateFormat('M월 d일 (E) HH시', 'ko_KR');
+    final daysLeft = cutoffDate.difference(now).inDays;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -96,18 +98,41 @@ class _RefundPolicySection extends ConsumerWidget {
                     : theme.colorScheme.error,
               ),
               const SizedBox(width: MinglitSpacing.small),
+              // Fix #190: 날짜만 강조하여 빠른 인지 지원
               Expanded(
-                child: Text(
-                  isRefundable
-                      ? '지금 결제 시 ${dateFormat.format(cutoffDate)}까지 환불 가능'
-                      : '환불 가능 기간이 지났습니다',
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    fontWeight: FontWeight.w600,
-                    color: isRefundable
-                        ? theme.colorScheme.primary
-                        : theme.colorScheme.error,
-                  ),
-                ),
+                child: isRefundable
+                    ? Text.rich(
+                        TextSpan(
+                          style: theme.textTheme.bodyMedium,
+                          children: [
+                            TextSpan(
+                              text: dateFormat.format(cutoffDate),
+                              style: TextStyle(
+                                fontWeight: FontWeight.bold,
+                                color: theme.colorScheme.primary,
+                              ),
+                            ),
+                            const TextSpan(text: '까지 환불 가능'),
+                            if (daysLeft >= 0)
+                              TextSpan(
+                                text: daysLeft == 0
+                                    ? ' (오늘)'
+                                    : ' ($daysLeft일 후)',
+                                style: TextStyle(
+                                  fontWeight: FontWeight.w600,
+                                  color: theme.colorScheme.primary,
+                                ),
+                              ),
+                          ],
+                        ),
+                      )
+                    : Text(
+                        '환불 가능 기간이 지났습니다',
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                          color: theme.colorScheme.error,
+                        ),
+                      ),
               ),
             ],
           ),

--- a/apps/app_user/lib/src/features/event/detail/event_refund_policy_section.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_refund_policy_section.dart
@@ -72,9 +72,11 @@ class _RefundPolicySection extends ConsumerWidget {
     // Fix #190: 요일 추가, D-day 표시로 날짜 인지성 개선
     final dateFormat = DateFormat('M월 d일 (E) HH시', 'ko_KR');
     // Fix #190: 캘린더 일수 기반 계산 — 시간 무관하게 날짜 단위로 비교
-    final daysLeft = DateTime(cutoffDate.year, cutoffDate.month, cutoffDate.day)
-        .difference(DateTime(now.year, now.month, now.day))
-        .inDays;
+    final daysLeft = DateTime(
+      cutoffDate.year,
+      cutoffDate.month,
+      cutoffDate.day,
+    ).difference(DateTime(now.year, now.month, now.day)).inDays;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/apps/app_user/lib/src/features/event/detail/event_refund_policy_section.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_refund_policy_section.dart
@@ -71,7 +71,10 @@ class _RefundPolicySection extends ConsumerWidget {
     final isRefundable = !now.isAfter(cutoffDate);
     // Fix #190: 요일 추가, D-day 표시로 날짜 인지성 개선
     final dateFormat = DateFormat('M월 d일 (E) HH시', 'ko_KR');
-    final daysLeft = cutoffDate.difference(now).inDays;
+    // Fix #190: 캘린더 일수 기반 계산 — 시간 무관하게 날짜 단위로 비교
+    final daysLeft = DateTime(cutoffDate.year, cutoffDate.month, cutoffDate.day)
+        .difference(DateTime(now.year, now.month, now.day))
+        .inDays;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
## Summary
Closes #190

- 날짜에 **요일** 추가: `3월 23일 19시` → `3월 23일 (일) 19시`
- **D-day 표시** 추가: `(2일 후)` — 남은 일수를 직관적으로 표시
- **날짜만 강조**: 전체 텍스트가 bold/primary였던 것을 날짜 부분만 bold로 분리하여 가독성 향상
- **인포버튼 위치 변경**: 우측 끝 → "환불 정책" 타이틀 바로 옆

### Before
> ✅ **지금 결제 시 3월 23일 19시까지 환불 가능** (전체 강조)

### After
> ✅ **3월 23일 (일) 19시**까지 환불 가능 **(2일 후)** (날짜+D-day만 강조)

## Test plan
- [ ] 이벤트 상세에서 환불 정책 섹션의 날짜에 요일이 표시되는지 확인
- [ ] D-day(N일 후) 텍스트가 정확한지 확인
- [ ] 인포버튼이 "환불 정책" 바로 옆에 위치하는지 확인
- [ ] 환불 기간 만료 시 "환불 가능 기간이 지났습니다" 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)