### PR TITLE
fix(partner): 파트너 대시보드 UI 개선 (#185)

### DIFF
--- a/apps/app_partner/lib/src/features/home/partner_home_page.dart
+++ b/apps/app_partner/lib/src/features/home/partner_home_page.dart
@@ -135,6 +135,12 @@ class PartnerHomePage extends ConsumerWidget {
                       PartyDetailRoute(partyId: party.id).push<void>(context),
                     );
                   },
+                  // Fix #185: 파티 전체 보기 화면으로 이동
+                  onViewAllTap: () {
+                    unawaited(
+                      const PartyListRoute().push<void>(context),
+                    );
+                  },
                 ),
                 const SizedBox(height: MinglitSpacing.large),
 

--- a/apps/app_partner/lib/src/features/home/widgets/active_party_summary_scroll.dart
+++ b/apps/app_partner/lib/src/features/home/widgets/active_party_summary_scroll.dart
@@ -6,11 +6,14 @@ class ActivePartySummaryScroll extends StatelessWidget {
   const ActivePartySummaryScroll({
     required this.parties,
     required this.onPartyTap,
+    this.onViewAllTap,
     super.key,
   });
 
   final List<Party> parties;
   final void Function(Party party) onPartyTap;
+  // Fix #185: 파티 전체 보기 버튼 콜백
+  final VoidCallback? onViewAllTap;
 
   @override
   Widget build(BuildContext context) {
@@ -36,6 +39,29 @@ class ActivePartySummaryScroll extends StatelessWidget {
                   fontWeight: FontWeight.bold,
                 ),
               ),
+              // Fix #185: 파티 전체 보기 버튼
+              if (onViewAllTap != null) ...[
+                const Spacer(),
+                GestureDetector(
+                  onTap: onViewAllTap,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        '자세히',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                      Icon(
+                        Icons.chevron_right,
+                        size: 16,
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ],
+                  ),
+                ),
+              ],
             ],
           ),
         ),

--- a/apps/app_partner/lib/src/features/home/widgets/upcoming_events_card.dart
+++ b/apps/app_partner/lib/src/features/home/widgets/upcoming_events_card.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
-/// Shows upcoming events (next 7 days) - max 5 items.
+/// Shows upcoming events (next 7 days) as horizontal scrolling cards.
 class UpcomingEventsCard extends StatelessWidget {
   const UpcomingEventsCard({
     required this.events,
@@ -17,102 +17,140 @@ class UpcomingEventsCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(bottom: MinglitSpacing.small),
+          child: Row(
+            children: [
+              Icon(
+                Icons.calendar_today,
+                size: 18,
+                color: colorScheme.primary,
+              ),
+              const SizedBox(width: 8),
+              Text(
+                '다가오는 이벤트',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+        ),
+        if (events.isEmpty)
+          SizedBox(
+            height: 100,
+            child: Center(
+              child: Text(
+                '예정된 이벤트가 없습니다',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          )
+        else
+          SizedBox(
+            height: 140,
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              itemCount: events.take(5).length,
+              separatorBuilder: (_, _) => const SizedBox(
+                width: MinglitSpacing.small,
+              ),
+              itemBuilder: (context, index) {
+                final event = events[index];
+                return _EventCard(
+                  event: event,
+                  onTap: () => onEventTap(event),
+                );
+              },
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _EventCard extends StatelessWidget {
+  const _EventCard({
+    required this.event,
+    required this.onTap,
+  });
+
+  final Event event;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
     final dateFormat = DateFormat('M/d (E)', 'ko_KR');
 
-    return Card(
-      elevation: 0,
-      color: colorScheme.surfaceContainerHighest,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(MinglitRadius.card),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(MinglitSpacing.large),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
+    return SizedBox(
+      width: 160,
+      child: Card(
+        elevation: 0,
+        color: colorScheme.surfaceContainerHighest,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(MinglitRadius.card),
+        ),
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(MinglitRadius.card),
+          child: Padding(
+            padding: const EdgeInsets.all(MinglitSpacing.medium),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Icon(
-                  Icons.calendar_today,
-                  size: 18,
-                  color: colorScheme.primary,
-                ),
-                const SizedBox(width: 8),
                 Text(
-                  '다가오는 이벤트',
+                  event.title ?? '이벤트',
                   style: theme.textTheme.titleSmall?.copyWith(
-                    fontWeight: FontWeight.bold,
+                    fontWeight: FontWeight.w600,
                   ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(
+                          Icons.schedule,
+                          size: 14,
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                        const SizedBox(width: 4),
+                        Text(
+                          dateFormat.format(event.startTime),
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+                    // Fix #185: 파티명 표시
+                    if (event.party?.title != null) ...[
+                      const SizedBox(height: 2),
+                      Text(
+                        event.party!.title,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ],
                 ),
               ],
             ),
-            const SizedBox(height: MinglitSpacing.medium),
-            if (events.isEmpty)
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                  vertical: MinglitSpacing.medium,
-                ),
-                child: Center(
-                  child: Text(
-                    '예정된 이벤트가 없습니다',
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                ),
-              )
-            else
-              ...events
-                  .take(5)
-                  .map(
-                    (event) => InkWell(
-                      onTap: () => onEventTap(event),
-                      borderRadius: BorderRadius.circular(8),
-                      child: Padding(
-                        padding: const EdgeInsets.symmetric(
-                          vertical: MinglitSpacing.small,
-                        ),
-                        child: Row(
-                          children: [
-                            Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    event.title ?? '이벤트',
-                                    style: theme.textTheme.bodyMedium?.copyWith(
-                                      fontWeight: FontWeight.w600,
-                                    ),
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis,
-                                  ),
-                                  const SizedBox(height: 2),
-                                  Text(
-                                    // Fix #180: 강제 언래핑 제거 — null-safe 접근
-                                    dateFormat.format(event.startTime) +
-                                        (event.party?.title != null
-                                            ? ' \u00b7 ${event.party?.title}'
-                                            : ''),
-                                    style: theme.textTheme.bodySmall?.copyWith(
-                                      color: colorScheme.onSurfaceVariant,
-                                    ),
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis,
-                                  ),
-                                ],
-                              ),
-                            ),
-                            Icon(
-                              Icons.chevron_right,
-                              size: 20,
-                              color: colorScheme.onSurfaceVariant,
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                  ),
-          ],
+          ),
         ),
       ),
     );

--- a/apps/app_partner/test/src/features/home/widgets/upcoming_events_card_test.dart
+++ b/apps/app_partner/test/src/features/home/widgets/upcoming_events_card_test.dart
@@ -152,7 +152,7 @@ void main() {
       expect(find.text('예정된 이벤트가 없습니다'), findsNothing);
     });
 
-    testWidgets('shows chevron_right icon for each event', (tester) async {
+    testWidgets('shows schedule icon for each event card', (tester) async {
       final now = DateTime.now();
       final events = [
         Event(
@@ -181,7 +181,8 @@ void main() {
           ),
         ),
       );
-      expect(find.byIcon(Icons.chevron_right), findsNWidgets(2));
+      // Fix #185: 카드 레이아웃 변경으로 chevron_right → schedule 아이콘
+      expect(find.byIcon(Icons.schedule), findsNWidgets(2));
     });
   });
 }


### PR DESCRIPTION
## Summary
- 다가오는 이벤트 섹션을 세로 리스트에서 가로 스크롤 카드 레이아웃으로 변경 (파티별 요약과 동일한 스타일)
- 파티별 요약 섹션 헤더에 '자세히' 버튼 추가 → 파티 전체 보기 화면(`PartyListRoute`)으로 이동

## Test plan
- [ ] 파트너 앱 대시보드에서 다가오는 이벤트가 가로 스크롤 카드로 표시되는지 확인
- [ ] 이벤트 카드에 제목, 날짜, 파티명이 정상 표시되는지 확인
- [ ] 이벤트 카드 탭 시 이벤트 상세 화면으로 이동하는지 확인
- [ ] 파티별 요약 옆 '자세히' 버튼 탭 시 파티 전체 보기 화면으로 이동하는지 확인
- [ ] 이벤트/파티가 없을 때 빈 상태 메시지가 정상 표시되는지 확인

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)