### PR TITLE
fix(e2e): partner_verified_users id 컬럼 참조 오류 수정

### DIFF
--- a/supabase/functions/backend-simulator/sim_assertions.ts
+++ b/supabase/functions/backend-simulator/sim_assertions.ts
@@ -143,9 +143,10 @@ export async function simAssertVerificationApproved(
       return fail("verification_approved", "approved", actualStatus, `submission status is '${actualStatus}'`);
     }
     // Also check that partner_verified_users row was created by the trigger
+    // Fix #181: partner_verified_users has composite PK (partner_id, user_id, verification_id), no 'id' column
     const { data: pvuData, error: pvuErr } = await supabase
       .from("partner_verified_users")
-      .select("id")
+      .select("submission_id")
       .eq("partner_id", data.partner_id)
       .eq("user_id", data.user_id)
       .eq("verification_id", data.verification_id)

--- a/supabase/functions/backend-simulator/sim_assertions_test.ts
+++ b/supabase/functions/backend-simulator/sim_assertions_test.ts
@@ -254,7 +254,7 @@ Deno.test("simAssertVerificationApproved - passes when approved + pvu exists", a
         }),
       },
       partner_verified_users: {
-        select: () => ({ data: { id: "pvu-1" }, error: null }),
+        select: () => ({ data: { submission_id: "pvu-1" }, error: null }),
       },
     },
   });


### PR DESCRIPTION
## Summary
- `partner_verified_users` 테이블은 composite PK로 `id` 컬럼이 없음
- `sim_assertions.ts`에서 `.select("id")` → `.select("submission_id")`로 변경
- 테스트 mock 데이터도 동일하게 수정

## Root Cause
E2E 시뮬레이션의 `simAssertVerificationApproved` 함수가 `partner_verified_users` 테이블에서 존재하지 않는 `id` 컬럼을 조회하여 70건 전체 실패.

## Test plan
- [ ] `test-edge-functions` CI 통과 확인
- [ ] E2E 시뮬레이션 재실행 시 `verification_approved` assertion 통과 확인

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)