### PR TITLE
fix(ci): notify-failure 워크플로우 이슈 생성 실패 수정

### DIFF
--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -18,6 +18,10 @@ jobs:
     permissions:
       issues: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .
+          fetch-depth: 1
       - name: Create or comment on issue for CI failure
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `notify-failure.yml`에 `actions/checkout` 추가 — `gh` CLI가 git repo 컨텍스트 없이 실패하던 문제 수정
- daily-e2e 실패 시 GitHub Issue가 생성되지 않던 버그 해결 (최소 5일간 알림 누락)

Closes #221

## Test plan
- [x] YAML 문법 검증 완료
- [ ] 다음 daily-e2e 실행 시 (실패하면) ci-failure 이슈가 정상 생성되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)