### PR TITLE
fix(ci): daily-e2e integration test 실행 명령 수정

### DIFF
--- a/.github/workflows/daily-e2e.yml
+++ b/.github/workflows/daily-e2e.yml
@@ -55,11 +55,11 @@ jobs:
           disable-animations: true
           working-directory: tests/client_cuj_integration
           script: |
-            flutter test integration_test/ \
-              --reporter expanded \
-              --dart-define=SUPABASE_URL=${{ secrets.SUPABASE_DEV_URL }} \
-              --dart-define=SUPABASE_PUBLISHABLE_KEY=${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }} \
-              --dart-define=SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_DEV_SECRET_KEY }}
+            DART_DEFINES="--dart-define=SUPABASE_URL=${{ secrets.SUPABASE_DEV_URL }} --dart-define=SUPABASE_PUBLISHABLE_KEY=${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }} --dart-define=SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_DEV_SECRET_KEY }}"
+            for test_file in integration_test/cuj/*_test.dart; do
+              echo "▶ Running $test_file"
+              flutter test "$test_file" --reporter expanded $DART_DEFINES || exit 1
+            done
 
   notify-failure:
     needs: [client-cuj-test]


### PR DESCRIPTION
## Summary
- `flutter test integration_test/` → 각 CUJ 파일 개별 실행으로 변경
- Flutter가 integration_test 패키지 감지 시 "integration과 unit 혼합 불가" 에러 발생하던 문제 수정
- 5일+ 연속 실패하던 daily-e2e 복구

Closes #221

## Test plan
- [ ] 다음 daily-e2e cron 실행 (KST 07:00) 또는 수동 trigger로 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)