### PR TITLE
test: app_partner/party 이벤트 관리 컨트롤러 테스트 추가

### DIFF
--- a/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
@@ -348,11 +348,11 @@ void main() {
         final notifier = container.read(
           eventCreateControllerProvider('party-1').notifier,
         );
-        notifier.updateDescription({'ops': []});
+        notifier.updateDescription({'ops': <dynamic>[]});
 
         expect(
           container.read(eventCreateControllerProvider('party-1')).description,
-          {'ops': []},
+          {'ops': <dynamic>[]},
         );
       });
 

--- a/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
@@ -1,6 +1,5 @@
 import 'package:app_partner/src/features/party/detail/party_detail_controller.dart';
 import 'package:app_partner/src/features/party/event/create/event_create_controller.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
@@ -65,22 +64,26 @@ void main() {
   setUp(() {
     mockPartyRepo = MockPartyRepository();
     mockLocationRepo = MockLocationRepository();
-    registerFallbackValue(Event(
-      id: '',
-      partyId: '',
-      startTime: DateTime.now(),
-      endTime: DateTime.now(),
-      createdAt: DateTime.now(),
-      updatedAt: DateTime.now(),
-    ));
-    registerFallbackValue(Location(
-      id: '',
-      partnerId: '',
-      name: '',
-      address: '',
-      createdAt: DateTime.now(),
-      updatedAt: DateTime.now(),
-    ));
+    registerFallbackValue(
+      Event(
+        id: '',
+        partyId: '',
+        startTime: DateTime.now(),
+        endTime: DateTime.now(),
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+      ),
+    );
+    registerFallbackValue(
+      Location(
+        id: '',
+        partnerId: '',
+        name: '',
+        address: '',
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+      ),
+    );
   });
 
   group('EventCreateController', () {
@@ -157,7 +160,6 @@ void main() {
         notifier.initWithParty(
           party: _makeParty(),
           templates: [],
-          location: null,
         );
 
         final state = container.read(
@@ -181,7 +183,7 @@ void main() {
         );
 
         final entryGroupTemplates = [
-          EntryGroupTemplate(
+          const EntryGroupTemplate(
             id: 'eg-1',
             partyId: 'party-1',
             label: 'Male',
@@ -192,7 +194,6 @@ void main() {
         notifier.initWithParty(
           party: _makeParty(entryGroups: entryGroupTemplates),
           templates: [],
-          location: null,
         );
 
         final state = container.read(
@@ -233,8 +234,7 @@ void main() {
         expect(updated.endTime.isAfter(farFuture), isTrue);
       });
 
-      test('updateStartTime does not change end if end is after new start',
-          () {
+      test('updateStartTime does not change end if end is after new start', () {
         final container = createContainer(
           overrides: [
             partyRepositoryProvider.overrideWithValue(mockPartyRepo),
@@ -273,7 +273,7 @@ void main() {
           eventCreateControllerProvider('party-1').notifier,
         );
 
-        final newEnd = DateTime(2030, 1, 1, 23, 0);
+        final newEnd = DateTime(2030, 1, 1, 23);
         notifier.updateEndTime(newEnd);
 
         final state = container.read(
@@ -351,9 +351,7 @@ void main() {
         notifier.updateDescription({'ops': []});
 
         expect(
-          container
-              .read(eventCreateControllerProvider('party-1'))
-              .description,
+          container.read(eventCreateControllerProvider('party-1')).description,
           {'ops': []},
         );
       });
@@ -371,9 +369,7 @@ void main() {
         notifier.updateImageUrl('https://example.com/img.jpg');
 
         expect(
-          container
-              .read(eventCreateControllerProvider('party-1'))
-              .imageUrl,
+          container.read(eventCreateControllerProvider('party-1')).imageUrl,
           'https://example.com/img.jpg',
         );
       });
@@ -473,74 +469,76 @@ void main() {
         notifier.setVisibility('private');
 
         expect(
-          container
-              .read(eventCreateControllerProvider('party-1'))
-              .visibility,
+          container.read(eventCreateControllerProvider('party-1')).visibility,
           'private',
         );
       });
     });
 
     group('submit', () {
-      test('creates event without new location when locationId exists',
-          () async {
-        final party = _makeParty(locationId: 'loc-1');
+      test(
+        'creates event without new location when locationId exists',
+        () async {
+          final party = _makeParty(locationId: 'loc-1');
 
-        when(() => mockPartyRepo.createEvent(any()))
-            .thenAnswer((_) async => Event(
-                  id: 'new-event',
-                  partyId: 'party-1',
-                  startTime: DateTime.now(),
-                  endTime: DateTime.now(),
-                  createdAt: DateTime.now(),
-                  updatedAt: DateTime.now(),
-                ));
-
-        final container = createContainer(
-          overrides: [
-            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
-            locationRepositoryProvider.overrideWithValue(mockLocationRepo),
-            partyDetailProvider('party-1').overrideWith(
-              (ref) async => party,
+          when(() => mockPartyRepo.createEvent(any())).thenAnswer(
+            (_) async => Event(
+              id: 'new-event',
+              partyId: 'party-1',
+              startTime: DateTime.now(),
+              endTime: DateTime.now(),
+              createdAt: DateTime.now(),
+              updatedAt: DateTime.now(),
             ),
-          ],
-        );
+          );
 
-        final notifier = container.read(
-          eventCreateControllerProvider('party-1').notifier,
-        );
+          final container = createContainer(
+            overrides: [
+              partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+              locationRepositoryProvider.overrideWithValue(mockLocationRepo),
+              partyDetailProvider('party-1').overrideWith(
+                (ref) async => party,
+              ),
+            ],
+          );
 
-        // Set locationId (simulating initWithParty)
-        notifier.updateLocation(_makeLocation());
-        notifier.updateTitle('Event Title');
+          final notifier = container.read(
+            eventCreateControllerProvider('party-1').notifier,
+          );
 
-        await notifier.submit();
+          // Set locationId (simulating initWithParty)
+          notifier.updateLocation(_makeLocation());
+          notifier.updateTitle('Event Title');
 
-        final state = container.read(
-          eventCreateControllerProvider('party-1'),
-        );
+          await notifier.submit();
 
-        expect(state.status, isA<AsyncData<void>>());
-        verify(() => mockPartyRepo.createEvent(any())).called(1);
-        verifyNever(() => mockLocationRepo.createLocation(any()));
-      });
+          final state = container.read(
+            eventCreateControllerProvider('party-1'),
+          );
 
-      test('creates location first when selectedLocation has no id',
-          () async {
+          expect(state.status, isA<AsyncData<void>>());
+          verify(() => mockPartyRepo.createEvent(any())).called(1);
+          verifyNever(() => mockLocationRepo.createLocation(any()));
+        },
+      );
+
+      test('creates location first when selectedLocation has no id', () async {
         final party = _makeParty();
         final newLocation = _makeLocation(id: 'new-loc');
 
-        when(() => mockLocationRepo.createLocation(any()))
-            .thenAnswer((_) async => newLocation);
-        when(() => mockPartyRepo.createEvent(any()))
-            .thenAnswer((_) async => Event(
-                  id: 'new-event',
-                  partyId: 'party-1',
-                  startTime: DateTime.now(),
-                  endTime: DateTime.now(),
-                  createdAt: DateTime.now(),
-                  updatedAt: DateTime.now(),
-                ));
+        when(
+          () => mockLocationRepo.createLocation(any()),
+        ).thenAnswer((_) async => newLocation);
+        when(() => mockPartyRepo.createEvent(any())).thenAnswer(
+          (_) async => Event(
+            id: 'new-event',
+            partyId: 'party-1',
+            startTime: DateTime.now(),
+            endTime: DateTime.now(),
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ),
+        );
 
         final container = createContainer(
           overrides: [
@@ -581,8 +579,9 @@ void main() {
       });
 
       test('sets error status on repository failure', () async {
-        when(() => mockPartyRepo.createEvent(any()))
-            .thenThrow(Exception('Create failed'));
+        when(
+          () => mockPartyRepo.createEvent(any()),
+        ).thenThrow(Exception('Create failed'));
 
         final container = createContainer(
           overrides: [

--- a/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
@@ -572,8 +572,9 @@ void main() {
         expect(state.status, isA<AsyncData<void>>());
         verify(() => mockLocationRepo.createLocation(any())).called(1);
 
-        final captured =
-            verify(() => mockPartyRepo.createEvent(captureAny())).captured;
+        final captured = verify(
+          () => mockPartyRepo.createEvent(captureAny()),
+        ).captured;
         expect(captured, hasLength(1));
         final createdEvent = captured.first as Event;
         expect(createdEvent.locationId, 'new-loc');

--- a/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
@@ -7,10 +7,6 @@ import 'package:mocktail/mocktail.dart';
 import '../../../../../utils/mocks.dart';
 import '../../../../../utils/test_utils.dart';
 
-Future<void> pump() async {
-  await Future<void>.delayed(const Duration(milliseconds: 50));
-}
-
 Party _makeParty({
   String id = 'party-1',
   String? locationId,
@@ -575,7 +571,12 @@ void main() {
 
         expect(state.status, isA<AsyncData<void>>());
         verify(() => mockLocationRepo.createLocation(any())).called(1);
-        verify(() => mockPartyRepo.createEvent(any())).called(1);
+
+        final captured =
+            verify(() => mockPartyRepo.createEvent(captureAny())).captured;
+        expect(captured, hasLength(1));
+        final createdEvent = captured.first as Event;
+        expect(createdEvent.locationId, 'new-loc');
       });
 
       test('sets error status on repository failure', () async {
@@ -587,6 +588,9 @@ void main() {
           overrides: [
             partyRepositoryProvider.overrideWithValue(mockPartyRepo),
             locationRepositoryProvider.overrideWithValue(mockLocationRepo),
+            partyDetailProvider('party-1').overrideWith(
+              (ref) async => _makeParty(),
+            ),
           ],
         );
 
@@ -601,6 +605,8 @@ void main() {
         );
 
         expect(state.status, isA<AsyncError<void>>());
+        verify(() => mockPartyRepo.createEvent(any())).called(1);
+        verifyNever(() => mockLocationRepo.createLocation(any()));
       });
     });
   });

--- a/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
@@ -1,0 +1,608 @@
+import 'package:app_partner/src/features/party/detail/party_detail_controller.dart';
+import 'package:app_partner/src/features/party/event/create/event_create_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../../utils/mocks.dart';
+import '../../../../../utils/test_utils.dart';
+
+Future<void> pump() async {
+  await Future<void>.delayed(const Duration(milliseconds: 50));
+}
+
+Party _makeParty({
+  String id = 'party-1',
+  String? locationId,
+  List<EntryGroupTemplate>? entryGroups,
+}) {
+  final now = DateTime.now();
+  return Party(
+    id: id,
+    partnerId: 'partner-1',
+    title: 'Test Party',
+    createdAt: now,
+    updatedAt: now,
+    locationId: locationId,
+    maxParticipants: 30,
+    contactOptions: {'phone': '010-1234-5678'},
+    entryGroups: entryGroups,
+  );
+}
+
+Location _makeLocation({String id = 'loc-1'}) {
+  final now = DateTime.now();
+  return Location(
+    id: id,
+    partnerId: 'partner-1',
+    name: 'Test Venue',
+    address: '서울시 강남구',
+    addressDetail: '3층',
+    directionsGuide: '엘리베이터 이용',
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+TicketTemplate _makeTemplate({String id = 'tmpl-1'}) {
+  final now = DateTime.now();
+  return TicketTemplate(
+    id: id,
+    partyId: 'party-1',
+    name: 'General Ticket',
+    price: 15000,
+    quantity: 50,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+void main() {
+  late MockPartyRepository mockPartyRepo;
+  late MockLocationRepository mockLocationRepo;
+
+  setUp(() {
+    mockPartyRepo = MockPartyRepository();
+    mockLocationRepo = MockLocationRepository();
+    registerFallbackValue(Event(
+      id: '',
+      partyId: '',
+      startTime: DateTime.now(),
+      endTime: DateTime.now(),
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    ));
+    registerFallbackValue(Location(
+      id: '',
+      partnerId: '',
+      name: '',
+      address: '',
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    ));
+  });
+
+  group('EventCreateController', () {
+    group('build', () {
+      test('initializes with default state', () {
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+          ],
+        );
+
+        final state = container.read(
+          eventCreateControllerProvider('party-1'),
+        );
+
+        expect(state.partyId, 'party-1');
+        expect(state.maxParticipants, 20);
+        expect(state.title, '');
+        expect(state.description, isEmpty);
+        expect(state.tickets, isEmpty);
+        expect(state.entryGroups, isEmpty);
+        expect(state.endTime.isAfter(state.startTime), isTrue);
+      });
+    });
+
+    group('initWithParty', () {
+      test('populates state from party template', () {
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+
+        final party = _makeParty(locationId: 'loc-1');
+        final templates = [_makeTemplate()];
+        final location = _makeLocation();
+
+        notifier.initWithParty(
+          party: party,
+          templates: templates,
+          location: location,
+        );
+
+        final state = container.read(
+          eventCreateControllerProvider('party-1'),
+        );
+
+        expect(state.title, 'Test Party');
+        expect(state.maxParticipants, 30);
+        expect(state.contactOptions, {'phone': '010-1234-5678'});
+        expect(state.tickets, hasLength(1));
+        expect(state.tickets.first.name, 'General Ticket');
+        expect(state.locationId, 'loc-1');
+        expect(state.selectedLocation, location);
+        expect(state.addressDetail, '3층');
+        expect(state.directionsGuide, '엘리베이터 이용');
+      });
+
+      test('handles party without location', () {
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+
+        notifier.initWithParty(
+          party: _makeParty(),
+          templates: [],
+          location: null,
+        );
+
+        final state = container.read(
+          eventCreateControllerProvider('party-1'),
+        );
+
+        expect(state.locationId, isNull);
+        expect(state.selectedLocation, isNull);
+        expect(state.tickets, isEmpty);
+      });
+
+      test('maps entry group templates to instances', () {
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+
+        final entryGroupTemplates = [
+          EntryGroupTemplate(
+            id: 'eg-1',
+            partyId: 'party-1',
+            label: 'Male',
+            gender: 'male',
+          ),
+        ];
+
+        notifier.initWithParty(
+          party: _makeParty(entryGroups: entryGroupTemplates),
+          templates: [],
+          location: null,
+        );
+
+        final state = container.read(
+          eventCreateControllerProvider('party-1'),
+        );
+
+        expect(state.entryGroups, hasLength(1));
+        expect(state.entryGroups.first.label, 'Male');
+        expect(state.entryGroups.first.gender, 'male');
+      });
+    });
+
+    group('update methods', () {
+      test('updateStartTime updates start and adjusts end if needed', () {
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+
+        final originalState = container.read(
+          eventCreateControllerProvider('party-1'),
+        );
+
+        // Set start time far in the future (past the current end time)
+        final farFuture = originalState.endTime.add(const Duration(days: 1));
+        notifier.updateStartTime(farFuture);
+
+        final updated = container.read(
+          eventCreateControllerProvider('party-1'),
+        );
+
+        expect(updated.startTime, farFuture);
+        expect(updated.endTime.isAfter(farFuture), isTrue);
+      });
+
+      test('updateStartTime does not change end if end is after new start',
+          () {
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+
+        final originalState = container.read(
+          eventCreateControllerProvider('party-1'),
+        );
+        final originalEnd = originalState.endTime;
+
+        // Set start time before end time
+        final newStart = originalEnd.subtract(const Duration(hours: 5));
+        notifier.updateStartTime(newStart);
+
+        final updated = container.read(
+          eventCreateControllerProvider('party-1'),
+        );
+
+        expect(updated.startTime, newStart);
+        expect(updated.endTime, originalEnd);
+      });
+
+      test('updateEndTime updates end time', () {
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+
+        final newEnd = DateTime(2030, 1, 1, 23, 0);
+        notifier.updateEndTime(newEnd);
+
+        final state = container.read(
+          eventCreateControllerProvider('party-1'),
+        );
+
+        expect(state.endTime, newEnd);
+      });
+
+      test('updateMaxParticipants sets count', () {
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+        notifier.updateMaxParticipants(100);
+
+        final state = container.read(
+          eventCreateControllerProvider('party-1'),
+        );
+
+        expect(state.maxParticipants, 100);
+      });
+
+      test('updateTitle sets title', () {
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+        notifier.updateTitle('New Title');
+
+        expect(
+          container.read(eventCreateControllerProvider('party-1')).title,
+          'New Title',
+        );
+      });
+
+      test('updateTitle with null sets empty string', () {
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+        notifier.updateTitle(null);
+
+        expect(
+          container.read(eventCreateControllerProvider('party-1')).title,
+          '',
+        );
+      });
+
+      test('updateDescription sets description', () {
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+        notifier.updateDescription({'ops': []});
+
+        expect(
+          container
+              .read(eventCreateControllerProvider('party-1'))
+              .description,
+          {'ops': []},
+        );
+      });
+
+      test('updateImageUrl sets imageUrl', () {
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+        notifier.updateImageUrl('https://example.com/img.jpg');
+
+        expect(
+          container
+              .read(eventCreateControllerProvider('party-1'))
+              .imageUrl,
+          'https://example.com/img.jpg',
+        );
+      });
+
+      test('updateContactOptions sets options', () {
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+        notifier.updateContactOptions({'kakao': 'open-chat-link'});
+
+        expect(
+          container
+              .read(eventCreateControllerProvider('party-1'))
+              .contactOptions,
+          {'kakao': 'open-chat-link'},
+        );
+      });
+
+      test('updateLocation sets location and locationId', () {
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+        final location = _makeLocation();
+        notifier.updateLocation(location);
+
+        final state = container.read(
+          eventCreateControllerProvider('party-1'),
+        );
+
+        expect(state.selectedLocation, location);
+        expect(state.locationId, 'loc-1');
+      });
+
+      test('updateLocation with null clears location', () {
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+        notifier.updateLocation(null);
+
+        final state = container.read(
+          eventCreateControllerProvider('party-1'),
+        );
+
+        expect(state.selectedLocation, isNull);
+        expect(state.locationId, isNull);
+      });
+
+      test('updateAddressDetail and updateDirections', () {
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+        notifier.updateAddressDetail('5층 501호');
+        notifier.updateDirections('정문 좌측');
+
+        final state = container.read(
+          eventCreateControllerProvider('party-1'),
+        );
+
+        expect(state.addressDetail, '5층 501호');
+        expect(state.directionsGuide, '정문 좌측');
+      });
+
+      test('setVisibility updates visibility', () {
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+        notifier.setVisibility('private');
+
+        expect(
+          container
+              .read(eventCreateControllerProvider('party-1'))
+              .visibility,
+          'private',
+        );
+      });
+    });
+
+    group('submit', () {
+      test('creates event without new location when locationId exists',
+          () async {
+        final party = _makeParty(locationId: 'loc-1');
+
+        when(() => mockPartyRepo.createEvent(any()))
+            .thenAnswer((_) async => Event(
+                  id: 'new-event',
+                  partyId: 'party-1',
+                  startTime: DateTime.now(),
+                  endTime: DateTime.now(),
+                  createdAt: DateTime.now(),
+                  updatedAt: DateTime.now(),
+                ));
+
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+            locationRepositoryProvider.overrideWithValue(mockLocationRepo),
+            partyDetailProvider('party-1').overrideWith(
+              (ref) async => party,
+            ),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+
+        // Set locationId (simulating initWithParty)
+        notifier.updateLocation(_makeLocation());
+        notifier.updateTitle('Event Title');
+
+        await notifier.submit();
+
+        final state = container.read(
+          eventCreateControllerProvider('party-1'),
+        );
+
+        expect(state.status, isA<AsyncData<void>>());
+        verify(() => mockPartyRepo.createEvent(any())).called(1);
+        verifyNever(() => mockLocationRepo.createLocation(any()));
+      });
+
+      test('creates location first when selectedLocation has no id',
+          () async {
+        final party = _makeParty();
+        final newLocation = _makeLocation(id: 'new-loc');
+
+        when(() => mockLocationRepo.createLocation(any()))
+            .thenAnswer((_) async => newLocation);
+        when(() => mockPartyRepo.createEvent(any()))
+            .thenAnswer((_) async => Event(
+                  id: 'new-event',
+                  partyId: 'party-1',
+                  startTime: DateTime.now(),
+                  endTime: DateTime.now(),
+                  createdAt: DateTime.now(),
+                  updatedAt: DateTime.now(),
+                ));
+
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+            locationRepositoryProvider.overrideWithValue(mockLocationRepo),
+            partyDetailProvider('party-1').overrideWith(
+              (ref) async => party,
+            ),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+
+        // Set selectedLocation but without locationId
+        final locationWithoutId = Location(
+          id: '',
+          partnerId: '',
+          name: 'New Place',
+          address: '서울시 마포구',
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+        );
+        notifier.updateLocation(locationWithoutId);
+        // Clear locationId to simulate a new location
+        notifier.updateLocation(locationWithoutId.copyWith(id: ''));
+
+        await notifier.submit();
+
+        final state = container.read(
+          eventCreateControllerProvider('party-1'),
+        );
+
+        expect(state.status, isA<AsyncData<void>>());
+        verify(() => mockLocationRepo.createLocation(any())).called(1);
+        verify(() => mockPartyRepo.createEvent(any())).called(1);
+      });
+
+      test('sets error status on repository failure', () async {
+        when(() => mockPartyRepo.createEvent(any()))
+            .thenThrow(Exception('Create failed'));
+
+        final container = createContainer(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+            locationRepositoryProvider.overrideWithValue(mockLocationRepo),
+          ],
+        );
+
+        final notifier = container.read(
+          eventCreateControllerProvider('party-1').notifier,
+        );
+
+        await notifier.submit();
+
+        final state = container.read(
+          eventCreateControllerProvider('party-1'),
+        );
+
+        expect(state.status, isA<AsyncError<void>>());
+      });
+    });
+  });
+}

--- a/apps/app_partner/test/src/features/party/event/create/event_create_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/party/event/create/event_create_coordinator_test.dart
@@ -1,0 +1,204 @@
+import 'package:app_partner/src/features/party/event/create/event_create_coordinator.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+Party _makeParty() {
+  final now = DateTime.now();
+  return Party(
+    id: 'party-1',
+    partnerId: 'partner-1',
+    title: 'Test Party',
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+Location _makeLocation() {
+  final now = DateTime.now();
+  return Location(
+    id: 'loc-1',
+    partnerId: 'partner-1',
+    name: 'Test Venue',
+    address: '서울시 강남구',
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+Widget _testApp({
+  required WidgetBuilder builder,
+  required _TrackingObserver observer,
+}) {
+  return ProviderScope(
+    child: MaterialApp(
+      navigatorObservers: [observer],
+      home: Builder(
+        builder: (context) {
+          return Scaffold(body: Builder(builder: builder));
+        },
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('EventCreateCoordinator', () {
+    test('can be constructed with a BuildContext', () {
+      expect(
+        () => EventCreateCoordinator(_FakeBuildContext()),
+        returnsNormally,
+      );
+    });
+
+    testWidgets('openBasicInfoEdit pushes a route', (tester) async {
+      var routePushed = false;
+      final observer = _TrackingObserver(onPush: () => routePushed = true);
+
+      await tester.pumpWidget(
+        _testApp(
+          observer: observer,
+          builder: (context) => ElevatedButton(
+            onPressed: () {
+              EventCreateCoordinator(context).openBasicInfoEdit(
+                party: _makeParty(),
+                onSave: (_, __, ___, ____, _____) {},
+              );
+            },
+            child: const Text('Go'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Go'));
+      await tester.pump();
+
+      expect(routePushed, isTrue);
+      // Consume render errors from the destination screen (not under test)
+      tester.takeException();
+    });
+
+    testWidgets('openCapacityContactEdit pushes a route', (tester) async {
+      var routePushed = false;
+      final observer = _TrackingObserver(onPush: () => routePushed = true);
+
+      await tester.pumpWidget(
+        _testApp(
+          observer: observer,
+          builder: (context) => ElevatedButton(
+            onPressed: () {
+              EventCreateCoordinator(context).openCapacityContactEdit(
+                party: _makeParty(),
+                onSave: (_, __, ___) {},
+              );
+            },
+            child: const Text('Go'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Go'));
+      await tester.pump();
+
+      expect(routePushed, isTrue);
+      tester.takeException();
+    });
+
+    testWidgets('openLocationEdit pushes a route', (tester) async {
+      var routePushed = false;
+      final observer = _TrackingObserver(onPush: () => routePushed = true);
+
+      await tester.pumpWidget(
+        _testApp(
+          observer: observer,
+          builder: (context) => ElevatedButton(
+            onPressed: () {
+              EventCreateCoordinator(context).openLocationEdit(
+                initialLocation: _makeLocation(),
+                initialAddressDetail: '3층',
+                initialDirectionsGuide: '엘리베이터 이용',
+                onSave: (_, __, ___) {},
+              );
+            },
+            child: const Text('Go'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Go'));
+      await tester.pump();
+
+      expect(routePushed, isTrue);
+      tester.takeException();
+    });
+
+    testWidgets('openLocationEdit works with null initial values',
+        (tester) async {
+      var routePushed = false;
+      final observer = _TrackingObserver(onPush: () => routePushed = true);
+
+      await tester.pumpWidget(
+        _testApp(
+          observer: observer,
+          builder: (context) => ElevatedButton(
+            onPressed: () {
+              EventCreateCoordinator(context).openLocationEdit(
+                initialLocation: null,
+                initialAddressDetail: null,
+                initialDirectionsGuide: null,
+                onSave: (_, __, ___) {},
+              );
+            },
+            child: const Text('Go'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Go'));
+      await tester.pump();
+
+      expect(routePushed, isTrue);
+      tester.takeException();
+    });
+
+    testWidgets('openTicketTemplateManage pushes a route', (tester) async {
+      var routePushed = false;
+      final observer = _TrackingObserver(onPush: () => routePushed = true);
+
+      await tester.pumpWidget(
+        _testApp(
+          observer: observer,
+          builder: (context) => ElevatedButton(
+            onPressed: () {
+              EventCreateCoordinator(context)
+                  .openTicketTemplateManage('party-1');
+            },
+            child: const Text('Go'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Go'));
+      await tester.pump();
+
+      expect(routePushed, isTrue);
+      tester.takeException();
+    });
+  });
+}
+
+class _FakeBuildContext extends Fake implements BuildContext {}
+
+class _TrackingObserver extends NavigatorObserver {
+  _TrackingObserver({required this.onPush});
+
+  final VoidCallback onPush;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    if (previousRoute != null) {
+      onPush();
+    }
+  }
+}

--- a/apps/app_partner/test/src/features/party/event/create/event_create_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/party/event/create/event_create_coordinator_test.dart
@@ -1,6 +1,5 @@
 import 'package:app_partner/src/features/party/event/create/event_create_coordinator.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
@@ -63,7 +62,7 @@ void main() {
             onPressed: () {
               EventCreateCoordinator(context).openBasicInfoEdit(
                 party: _makeParty(),
-                onSave: (_, __, ___, ____, _____) {},
+                onSave: (_, _, _, _, _) {},
               );
             },
             child: const Text('Go'),
@@ -90,7 +89,7 @@ void main() {
             onPressed: () {
               EventCreateCoordinator(context).openCapacityContactEdit(
                 party: _makeParty(),
-                onSave: (_, __, ___) {},
+                onSave: (_, _, _) {},
               );
             },
             child: const Text('Go'),
@@ -118,7 +117,7 @@ void main() {
                 initialLocation: _makeLocation(),
                 initialAddressDetail: '3층',
                 initialDirectionsGuide: '엘리베이터 이용',
-                onSave: (_, __, ___) {},
+                onSave: (_, _, _) {},
               );
             },
             child: const Text('Go'),
@@ -133,8 +132,9 @@ void main() {
       tester.takeException();
     });
 
-    testWidgets('openLocationEdit works with null initial values',
-        (tester) async {
+    testWidgets('openLocationEdit works with null initial values', (
+      tester,
+    ) async {
       var routePushed = false;
       final observer = _TrackingObserver(onPush: () => routePushed = true);
 
@@ -147,7 +147,7 @@ void main() {
                 initialLocation: null,
                 initialAddressDetail: null,
                 initialDirectionsGuide: null,
-                onSave: (_, __, ___) {},
+                onSave: (_, _, _) {},
               );
             },
             child: const Text('Go'),
@@ -171,8 +171,9 @@ void main() {
           observer: observer,
           builder: (context) => ElevatedButton(
             onPressed: () {
-              EventCreateCoordinator(context)
-                  .openTicketTemplateManage('party-1');
+              EventCreateCoordinator(
+                context,
+              ).openTicketTemplateManage('party-1');
             },
             child: const Text('Go'),
           ),

--- a/apps/app_partner/test/src/features/party/event/detail/event_detail_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/event/detail/event_detail_controller_test.dart
@@ -1,0 +1,94 @@
+import 'package:app_partner/src/features/party/event/detail/event_detail_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../../utils/mocks.dart';
+import '../../../../../utils/test_utils.dart';
+
+Ticket _makeTicket(String id, {String eventId = 'event_1'}) {
+  final now = DateTime.now();
+  return Ticket(
+    id: id,
+    name: 'Ticket $id',
+    eventId: eventId,
+    price: 10000,
+    quantity: 50,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+void main() {
+  late MockTicketRepository mockTicketRepo;
+
+  setUp(() {
+    mockTicketRepo = MockTicketRepository();
+  });
+
+  group('eventTickets', () {
+    test('returns tickets for given eventId', () async {
+      final tickets = [_makeTicket('t1'), _makeTicket('t2')];
+      when(
+        () => mockTicketRepo.getTicketsByEventId('event_1'),
+      ).thenAnswer((_) async => tickets);
+
+      final container = createContainer(
+        overrides: [
+          ticketRepositoryProvider.overrideWithValue(mockTicketRepo),
+        ],
+      );
+
+      final result = await container.read(
+        eventTicketsProvider('event_1').future,
+      );
+
+      expect(result, hasLength(2));
+      expect(result.first.id, 't1');
+      expect(result.last.id, 't2');
+      verify(() => mockTicketRepo.getTicketsByEventId('event_1')).called(1);
+    });
+
+    test('returns empty list when no tickets exist', () async {
+      when(
+        () => mockTicketRepo.getTicketsByEventId('event_empty'),
+      ).thenAnswer((_) async => []);
+
+      final container = createContainer(
+        overrides: [
+          ticketRepositoryProvider.overrideWithValue(mockTicketRepo),
+        ],
+      );
+
+      final result = await container.read(
+        eventTicketsProvider('event_empty').future,
+      );
+
+      expect(result, isEmpty);
+    });
+
+    test('propagates error when repository throws', () async {
+      when(
+        () => mockTicketRepo.getTicketsByEventId('event_err'),
+      ).thenAnswer((_) async => throw Exception('DB error'));
+
+      final container = createContainer(
+        overrides: [
+          ticketRepositoryProvider.overrideWithValue(mockTicketRepo),
+        ],
+      );
+
+      final sub = container.listen(
+        eventTicketsProvider('event_err'),
+        (_, __) {},
+      );
+      addTearDown(sub.close);
+
+      // Wait for the provider to settle
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final state = container.read(eventTicketsProvider('event_err'));
+      expect(state.hasError, isTrue);
+    });
+  });
+}

--- a/apps/app_partner/test/src/features/party/event/detail/event_detail_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/event/detail/event_detail_controller_test.dart
@@ -80,7 +80,7 @@ void main() {
 
       final sub = container.listen(
         eventTicketsProvider('event_err'),
-        (_, __) {},
+        (_, _) {},
       );
       addTearDown(sub.close);
 

--- a/apps/app_partner/test/src/features/party/matching/matching_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/matching/matching_controller_test.dart
@@ -1,5 +1,4 @@
 import 'package:app_partner/src/features/party/matching/matching_controller.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
@@ -41,7 +40,7 @@ void main() {
         // Listen to controller to initialize
         final sub = container.listen(
           matchingControllerProvider,
-          (_, __) {},
+          (_, _) {},
         );
         addTearDown(sub.close);
         await pump();
@@ -78,7 +77,7 @@ void main() {
 
         final sub = container.listen(
           matchingControllerProvider,
-          (_, __) {},
+          (_, _) {},
         );
         addTearDown(sub.close);
         await pump();
@@ -165,7 +164,7 @@ void main() {
 
       final sub = container.listen(
         eventMatchRulesProvider('event_err'),
-        (_, __) {},
+        (_, _) {},
       );
       addTearDown(sub.close);
 

--- a/apps/app_partner/test/src/features/party/matching/matching_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/matching/matching_controller_test.dart
@@ -1,0 +1,178 @@
+import 'package:app_partner/src/features/party/matching/matching_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../utils/mocks.dart';
+import '../../../../utils/test_utils.dart';
+
+Future<void> pump() async {
+  await Future<void>.delayed(const Duration(milliseconds: 50));
+}
+
+void main() {
+  late MockMatchingRepository mockMatchingRepo;
+
+  setUp(() {
+    mockMatchingRepo = MockMatchingRepository();
+  });
+
+  group('MatchingController', () {
+    group('updateRules', () {
+      test('updates rules successfully', () async {
+        final rules = [
+          {'source_group_id': 'g1', 'target_group_id': 'g2'},
+        ];
+
+        when(
+          () => mockMatchingRepo.updateMatchRules(
+            eventId: 'event_1',
+            rules: rules,
+          ),
+        ).thenAnswer((_) async {});
+
+        final container = createContainer(
+          overrides: [
+            matchingRepositoryProvider.overrideWithValue(mockMatchingRepo),
+          ],
+        );
+
+        // Listen to controller to initialize
+        final sub = container.listen(
+          matchingControllerProvider,
+          (_, __) {},
+        );
+        addTearDown(sub.close);
+        await pump();
+
+        final notifier = container.read(
+          matchingControllerProvider.notifier,
+        );
+
+        await notifier.updateRules(eventId: 'event_1', rules: rules);
+
+        final state = container.read(matchingControllerProvider);
+        expect(state, isA<AsyncData<void>>());
+        verify(
+          () => mockMatchingRepo.updateMatchRules(
+            eventId: 'event_1',
+            rules: rules,
+          ),
+        ).called(1);
+      });
+
+      test('sets error state on failure', () async {
+        when(
+          () => mockMatchingRepo.updateMatchRules(
+            eventId: any(named: 'eventId'),
+            rules: any(named: 'rules'),
+          ),
+        ).thenThrow(Exception('Update failed'));
+
+        final container = createContainer(
+          overrides: [
+            matchingRepositoryProvider.overrideWithValue(mockMatchingRepo),
+          ],
+        );
+
+        final sub = container.listen(
+          matchingControllerProvider,
+          (_, __) {},
+        );
+        addTearDown(sub.close);
+        await pump();
+
+        final notifier = container.read(
+          matchingControllerProvider.notifier,
+        );
+
+        await notifier.updateRules(eventId: 'event_1', rules: []);
+
+        final state = container.read(matchingControllerProvider);
+        expect(state, isA<AsyncError<void>>());
+      });
+    });
+  });
+
+  group('eventMatchRules', () {
+    test('returns match rules for event', () async {
+      final rules = [
+        MatchRule(
+          id: 'rule-1',
+          eventId: 'event_1',
+          sourceGroupId: 'g1',
+          targetGroupId: 'g2',
+          createdAt: DateTime.now(),
+        ),
+        MatchRule(
+          id: 'rule-2',
+          eventId: 'event_1',
+          sourceGroupId: 'g2',
+          targetGroupId: 'g1',
+          createdAt: DateTime.now(),
+        ),
+      ];
+
+      when(
+        () => mockMatchingRepo.getMatchRules('event_1'),
+      ).thenAnswer((_) async => rules);
+
+      final container = createContainer(
+        overrides: [
+          matchingRepositoryProvider.overrideWithValue(mockMatchingRepo),
+        ],
+      );
+
+      final result = await container.read(
+        eventMatchRulesProvider('event_1').future,
+      );
+
+      expect(result, hasLength(2));
+      expect(result.first.sourceGroupId, 'g1');
+      expect(result.last.targetGroupId, 'g1');
+      verify(() => mockMatchingRepo.getMatchRules('event_1')).called(1);
+    });
+
+    test('returns empty list when no rules exist', () async {
+      when(
+        () => mockMatchingRepo.getMatchRules('event_empty'),
+      ).thenAnswer((_) async => []);
+
+      final container = createContainer(
+        overrides: [
+          matchingRepositoryProvider.overrideWithValue(mockMatchingRepo),
+        ],
+      );
+
+      final result = await container.read(
+        eventMatchRulesProvider('event_empty').future,
+      );
+
+      expect(result, isEmpty);
+    });
+
+    test('propagates error when repository throws', () async {
+      when(
+        () => mockMatchingRepo.getMatchRules('event_err'),
+      ).thenAnswer((_) async => throw Exception('DB error'));
+
+      final container = createContainer(
+        overrides: [
+          matchingRepositoryProvider.overrideWithValue(mockMatchingRepo),
+        ],
+      );
+
+      final sub = container.listen(
+        eventMatchRulesProvider('event_err'),
+        (_, __) {},
+      );
+      addTearDown(sub.close);
+
+      await pump();
+
+      final state = container.read(eventMatchRulesProvider('event_err'));
+      expect(state.hasError, isTrue);
+    });
+  });
+}

--- a/apps/app_partner/test/utils/mocks.dart
+++ b/apps/app_partner/test/utils/mocks.dart
@@ -22,3 +22,5 @@ class MockPartyRepository extends Mock implements PartyRepository {}
 class MockTicketRepository extends Mock implements TicketRepository {}
 
 class MockLocationRepository extends Mock implements LocationRepository {}
+
+class MockMatchingRepository extends Mock implements MatchingRepository {}


### PR DESCRIPTION
## Summary
- `event_detail_controller_test.dart`: eventTickets provider happy path, empty, error 테스트 (3건)
- `event_create_controller_test.dart`: build, initWithParty, update methods, submit 테스트 (20건)
- `event_create_coordinator_test.dart`: 5개 navigation 메서드 push 검증 (6건)
- `matching_controller_test.dart`: updateRules, eventMatchRules provider 테스트 (5건)
- `mocks.dart`에 `MockMatchingRepository` 추가

Closes #211

## Test plan
- [x] `cd apps/app_partner && flutter test` 통과 (181 tests)
- [x] 4개 테스트 파일 모두 happy path + error case 포함

🤖 Generated with [Claude Code](https://claude.com/claude-code)