### PR TITLE
fix: strict inference collection literal 경고 해결

### DIFF
--- a/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
@@ -155,7 +155,7 @@ void main() {
 
         notifier.initWithParty(
           party: _makeParty(),
-          templates: [],
+          templates: <TicketTemplate>[],
         );
 
         final state = container.read(
@@ -189,7 +189,7 @@ void main() {
 
         notifier.initWithParty(
           party: _makeParty(entryGroups: entryGroupTemplates),
-          templates: [],
+          templates: <TicketTemplate>[],
         );
 
         final state = container.read(

--- a/apps/app_partner/test/src/features/party/event/detail/event_detail_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/event/detail/event_detail_controller_test.dart
@@ -52,7 +52,7 @@ void main() {
     test('returns empty list when no tickets exist', () async {
       when(
         () => mockTicketRepo.getTicketsByEventId('event_empty'),
-      ).thenAnswer((_) async => []);
+      ).thenAnswer((_) async => <Ticket>[]);
 
       final container = createContainer(
         overrides: [

--- a/apps/app_partner/test/src/features/party/matching/matching_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/matching/matching_controller_test.dart
@@ -86,7 +86,7 @@ void main() {
           matchingControllerProvider.notifier,
         );
 
-        await notifier.updateRules(eventId: 'event_1', rules: []);
+        await notifier.updateRules(eventId: 'event_1', rules: <Map<String, String>>[]);
 
         final state = container.read(matchingControllerProvider);
         expect(state, isA<AsyncError<void>>());
@@ -136,7 +136,7 @@ void main() {
     test('returns empty list when no rules exist', () async {
       when(
         () => mockMatchingRepo.getMatchRules('event_empty'),
-      ).thenAnswer((_) async => []);
+      ).thenAnswer((_) async => <MatchRule>[]);
 
       final container = createContainer(
         overrides: [

--- a/apps/app_partner/test/src/features/party/matching/matching_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/matching/matching_controller_test.dart
@@ -86,7 +86,10 @@ void main() {
           matchingControllerProvider.notifier,
         );
 
-        await notifier.updateRules(eventId: 'event_1', rules: <Map<String, String>>[]);
+        await notifier.updateRules(
+          eventId: 'event_1',
+          rules: <Map<String, String>>[],
+        );
 
         final state = container.read(matchingControllerProvider);
         expect(state, isA<AsyncError<void>>());


### PR DESCRIPTION
## Summary
- `event_create_controller_test.dart`: `templates: []` → `<TicketTemplate>[]` (2곳)
- `event_detail_controller_test.dart`: `async => []` → `async => <Ticket>[]`
- `matching_controller_test.dart`: `rules: []` → `<Map<String, String>>[]`, `async => []` → `async => <MatchRule>[]`

CI의 최신 stable Dart SDK에서 `very_good_analysis`의 `strict-inference` 설정으로 인해 `inference_failure_on_collection_literal` 경고가 발생하여 `flutter analyze --no-fatal-infos`가 실패함.

Closes #244

## Test plan
- [x] `flutter analyze --no-fatal-infos` 통과 확인
- [x] 수정된 3개 테스트 파일 모두 통과 (28건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)