### PR TITLE
test: iamport 결제 SDK 래퍼 테스트 추가

### DIFF
--- a/shared/packages/minglit_kit/test/src/features/iamport/data/model/iamport_result_model_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/iamport/data/model/iamport_result_model_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/features/iamport/data/model/iamport_result_model.dart';
+
+void main() {
+  group('IamportResultModel', () {
+    group('fromJson', () {
+      test('parses successful certification result', () {
+        final json = <String, dynamic>{
+          'imp_uid': 'imp_123456789',
+          'merchant_uid': 'mid_001',
+          'success': true,
+          'error_msg': null,
+          'pg_provider': 'danal',
+          'pg_type': 'certification',
+        };
+
+        final model = IamportResultModel.fromJson(json);
+
+        expect(model.impUid, 'imp_123456789');
+        expect(model.merchantUid, 'mid_001');
+        expect(model.success, isTrue);
+        expect(model.errorMsg, isNull);
+        expect(model.pgProvider, 'danal');
+        expect(model.pgType, 'certification');
+      });
+
+      test('parses failed certification result', () {
+        final json = <String, dynamic>{
+          'imp_uid': null,
+          'merchant_uid': 'mid_002',
+          'success': false,
+          'error_msg': 'User cancelled',
+          'pg_provider': null,
+          'pg_type': null,
+        };
+
+        final model = IamportResultModel.fromJson(json);
+
+        expect(model.impUid, isNull);
+        expect(model.success, isFalse);
+        expect(model.errorMsg, 'User cancelled');
+      });
+
+      test('defaults success to false when missing', () {
+        final json = <String, dynamic>{
+          'imp_uid': 'imp_999',
+          'merchant_uid': 'mid_003',
+        };
+
+        final model = IamportResultModel.fromJson(json);
+
+        expect(model.success, isFalse);
+      });
+
+      test('handles empty json', () {
+        final json = <String, dynamic>{};
+
+        final model = IamportResultModel.fromJson(json);
+
+        expect(model.impUid, isNull);
+        expect(model.merchantUid, isNull);
+        expect(model.success, isFalse);
+        expect(model.errorMsg, isNull);
+      });
+    });
+
+    group('toJson', () {
+      test('serializes all fields', () {
+        const model = IamportResultModel(
+          impUid: 'imp_abc',
+          merchantUid: 'mid_xyz',
+          success: true,
+          errorMsg: null,
+          pgProvider: 'danal',
+          pgType: 'certification',
+        );
+
+        final json = model.toJson();
+
+        expect(json['imp_uid'], 'imp_abc');
+        expect(json['merchant_uid'], 'mid_xyz');
+        expect(json['success'], isTrue);
+        expect(json['error_msg'], isNull);
+        expect(json['pg_provider'], 'danal');
+        expect(json['pg_type'], 'certification');
+      });
+
+      test('roundtrip fromJson/toJson preserves data', () {
+        const original = IamportResultModel(
+          impUid: 'imp_roundtrip',
+          merchantUid: 'mid_roundtrip',
+          success: true,
+          pgProvider: 'nice',
+          pgType: 'payment',
+        );
+
+        final restored = IamportResultModel.fromJson(original.toJson());
+
+        expect(restored, original);
+      });
+    });
+
+    group('fromMap', () {
+      test('parses string map with success=true', () {
+        final map = <String, String>{
+          'imp_uid': 'imp_map_001',
+          'merchant_uid': 'mid_map_001',
+          'success': 'true',
+          'error_msg': '',
+          'pg_provider': 'danal',
+          'pg_type': 'certification',
+        };
+
+        final model = IamportResultModel.fromMap(map);
+
+        expect(model.impUid, 'imp_map_001');
+        expect(model.merchantUid, 'mid_map_001');
+        expect(model.success, isTrue);
+      });
+
+      test('parses string map with success=True (capitalized)', () {
+        final map = <String, String>{
+          'imp_uid': 'imp_map_002',
+          'merchant_uid': 'mid_map_002',
+          'success': 'True',
+        };
+
+        final model = IamportResultModel.fromMap(map);
+
+        expect(model.success, isTrue);
+      });
+
+      test('parses string map with success=false', () {
+        final map = <String, String>{
+          'imp_uid': '',
+          'merchant_uid': 'mid_map_003',
+          'success': 'false',
+          'error_msg': 'Certification cancelled',
+        };
+
+        final model = IamportResultModel.fromMap(map);
+
+        expect(model.success, isFalse);
+        expect(model.errorMsg, 'Certification cancelled');
+      });
+
+      test('treats missing success key as false', () {
+        final map = <String, String>{
+          'imp_uid': 'imp_map_004',
+          'merchant_uid': 'mid_map_004',
+        };
+
+        final model = IamportResultModel.fromMap(map);
+
+        expect(model.success, isFalse);
+      });
+
+      test('treats arbitrary success value as false', () {
+        final map = <String, String>{
+          'success': 'yes',
+        };
+
+        final model = IamportResultModel.fromMap(map);
+
+        expect(model.success, isFalse);
+      });
+    });
+
+    group('equality', () {
+      test('two models with same values are equal', () {
+        const a = IamportResultModel(
+          impUid: 'imp_eq',
+          merchantUid: 'mid_eq',
+          success: true,
+        );
+        const b = IamportResultModel(
+          impUid: 'imp_eq',
+          merchantUid: 'mid_eq',
+          success: true,
+        );
+
+        expect(a, b);
+        expect(a.hashCode, b.hashCode);
+      });
+
+      test('two models with different values are not equal', () {
+        const a = IamportResultModel(impUid: 'imp_1', success: true);
+        const b = IamportResultModel(impUid: 'imp_2', success: true);
+
+        expect(a, isNot(b));
+      });
+    });
+
+    group('copyWith', () {
+      test('creates modified copy', () {
+        const original = IamportResultModel(
+          impUid: 'imp_copy',
+          success: false,
+          errorMsg: 'timeout',
+        );
+
+        final modified = original.copyWith(success: true, errorMsg: null);
+
+        expect(modified.impUid, 'imp_copy');
+        expect(modified.success, isTrue);
+        expect(modified.errorMsg, isNull);
+      });
+    });
+  });
+}

--- a/shared/packages/minglit_kit/test/src/features/iamport/data/model/iamport_result_model_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/iamport/data/model/iamport_result_model_test.dart
@@ -70,7 +70,6 @@ void main() {
           impUid: 'imp_abc',
           merchantUid: 'mid_xyz',
           success: true,
-          errorMsg: null,
           pgProvider: 'danal',
           pgType: 'certification',
         );
@@ -195,7 +194,6 @@ void main() {
       test('creates modified copy', () {
         const original = IamportResultModel(
           impUid: 'imp_copy',
-          success: false,
           errorMsg: 'timeout',
         );
 

--- a/shared/packages/minglit_kit/test/src/features/iamport/data/repository/iamport_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/iamport/data/repository/iamport_repository_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/features/iamport/data/repository/iamport_repository.dart';
+import 'package:minglit_kit/src/utils/exceptions.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../../../../helpers/mocks.dart';
+import '../../../../../helpers/supabase_mock_helpers.dart';
+
+void main() {
+  group('IamportRepository', () {
+    late MockSupabaseClient mockClient;
+    late MockFunctionsClient mockFunctions;
+    late IamportRepository repository;
+
+    setUp(() {
+      mockClient = createMockSupabase(currentUser: MockUser());
+      mockFunctions = MockFunctionsClient();
+      when(() => mockClient.functions).thenReturn(mockFunctions);
+      repository = IamportRepository(mockClient);
+    });
+
+    group('verifyCertification', () {
+      test('returns response data on success (status 200)', () async {
+        final responseData = <String, dynamic>{
+          'verified': true,
+          'name': '홍길동',
+          'unique_key': 'unique_123',
+        };
+        when(
+          () => mockFunctions.invoke(
+            'identity-verify',
+            body: {'identity_verification_id': 'imp_test_001'},
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(status: 200, data: responseData),
+        );
+
+        final result = await repository.verifyCertification('imp_test_001');
+
+        expect(result['verified'], isTrue);
+        expect(result['name'], '홍길동');
+        expect(result['unique_key'], 'unique_123');
+      });
+
+      test('wraps non-map response in result key', () async {
+        when(
+          () => mockFunctions.invoke(
+            'identity-verify',
+            body: {'identity_verification_id': 'imp_test_002'},
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(status: 200, data: 'ok'),
+        );
+
+        final result = await repository.verifyCertification('imp_test_002');
+
+        expect(result['result'], 'ok');
+      });
+
+      test('throws MinglitUserException on non-200 status', () async {
+        when(
+          () => mockFunctions.invoke(
+            'identity-verify',
+            body: {'identity_verification_id': 'imp_fail_001'},
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(status: 400, data: 'error'),
+        );
+
+        expect(
+          () => repository.verifyCertification('imp_fail_001'),
+          throwsA(isA<MinglitUserException>()),
+        );
+      });
+
+      test('throws MinglitUserException on 500 status', () async {
+        when(
+          () => mockFunctions.invoke(
+            'identity-verify',
+            body: {'identity_verification_id': 'imp_fail_002'},
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(status: 500, data: null),
+        );
+
+        expect(
+          () => repository.verifyCertification('imp_fail_002'),
+          throwsA(isA<MinglitUserException>()),
+        );
+      });
+
+      test('throws MinglitAuthException when user is not logged in', () {
+        final noAuthClient = createMockSupabase();
+        final noAuthRepo = IamportRepository(noAuthClient);
+
+        expect(
+          () => noAuthRepo.verifyCertification('imp_no_auth'),
+          throwsA(isA<MinglitAuthException>()),
+        );
+      });
+
+      test('rethrows unexpected exceptions', () async {
+        when(
+          () => mockFunctions.invoke(
+            'identity-verify',
+            body: {'identity_verification_id': 'imp_crash'},
+          ),
+        ).thenThrow(Exception('network failure'));
+
+        expect(
+          () => repository.verifyCertification('imp_crash'),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
+  });
+}

--- a/shared/packages/minglit_kit/test/src/features/iamport/data/repository/iamport_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/iamport/data/repository/iamport_repository_test.dart
@@ -81,7 +81,7 @@ void main() {
             body: {'identity_verification_id': 'imp_fail_002'},
           ),
         ).thenAnswer(
-          (_) async => FunctionResponse(status: 500, data: null),
+          (_) async => FunctionResponse(status: 500),
         );
 
         expect(

--- a/shared/packages/minglit_kit/test/src/features/iamport/logic/iamport_controller_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/iamport/logic/iamport_controller_test.dart
@@ -1,0 +1,155 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/features/iamport/data/model/iamport_result_model.dart';
+import 'package:minglit_kit/src/features/iamport/data/repository/iamport_repository.dart';
+import 'package:minglit_kit/src/features/iamport/logic/iamport_controller.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../helpers/test_utils.dart';
+
+class MockIamportRepository extends Mock implements IamportRepository {}
+
+void main() {
+  group('IamportController', () {
+    late MockIamportRepository mockRepo;
+
+    setUp(() {
+      mockRepo = MockIamportRepository();
+    });
+
+    ProviderContainer createTestContainer() {
+      return createContainer(
+        overrides: [
+          iamportRepositoryProvider.overrideWithValue(mockRepo),
+        ],
+      );
+    }
+
+    test('initial state is AsyncData(null)', () {
+      final container = createTestContainer();
+
+      final state = container.read(iamportControllerProvider);
+
+      expect(state, isA<AsyncData<IamportResultModel?>>());
+      expect(state.value, isNull);
+    });
+
+    group('onCertificationResult', () {
+      test('verifies and sets success state on successful certification',
+          () async {
+        when(() => mockRepo.verifyCertification('imp_success_001'))
+            .thenAnswer((_) async => <String, dynamic>{'verified': true});
+
+        final container = createTestContainer();
+        final notifier =
+            container.read(iamportControllerProvider.notifier);
+
+        await notifier.onCertificationResult(<String, String>{
+          'imp_uid': 'imp_success_001',
+          'merchant_uid': 'mid_001',
+          'success': 'true',
+        });
+
+        final state = container.read(iamportControllerProvider);
+        expect(state, isA<AsyncData<IamportResultModel?>>());
+        expect(state.value!.success, isTrue);
+        expect(state.value!.impUid, 'imp_success_001');
+        verify(() => mockRepo.verifyCertification('imp_success_001')).called(1);
+      });
+
+      test('sets error state when certification fails from Iamport', () async {
+        final container = createTestContainer();
+        final notifier =
+            container.read(iamportControllerProvider.notifier);
+
+        await notifier.onCertificationResult(<String, String>{
+          'imp_uid': '',
+          'merchant_uid': 'mid_fail',
+          'success': 'false',
+          'error_msg': 'User cancelled authentication',
+        });
+
+        final state = container.read(iamportControllerProvider);
+        expect(state, isA<AsyncError<IamportResultModel?>>());
+        expect(state.error.toString(), 'User cancelled authentication');
+        verifyNever(() => mockRepo.verifyCertification(any()));
+      });
+
+      test('sets error state when success is true but impUid is null',
+          () async {
+        final container = createTestContainer();
+        final notifier =
+            container.read(iamportControllerProvider.notifier);
+
+        await notifier.onCertificationResult(<String, String>{
+          'success': 'false',
+          'error_msg': 'No UID returned',
+        });
+
+        final state = container.read(iamportControllerProvider);
+        expect(state, isA<AsyncError<IamportResultModel?>>());
+      });
+
+      test('sets error state when server verification fails', () async {
+        when(() => mockRepo.verifyCertification('imp_server_fail'))
+            .thenThrow(Exception('server error'));
+
+        final container = createTestContainer();
+        final notifier =
+            container.read(iamportControllerProvider.notifier);
+
+        await notifier.onCertificationResult(<String, String>{
+          'imp_uid': 'imp_server_fail',
+          'merchant_uid': 'mid_003',
+          'success': 'true',
+        });
+
+        final state = container.read(iamportControllerProvider);
+        expect(state, isA<AsyncError<IamportResultModel?>>());
+      });
+
+      test('uses default error message when errorMsg is null', () async {
+        final container = createTestContainer();
+        final notifier =
+            container.read(iamportControllerProvider.notifier);
+
+        await notifier.onCertificationResult(<String, String>{
+          'success': 'false',
+        });
+
+        final state = container.read(iamportControllerProvider);
+        expect(state, isA<AsyncError<IamportResultModel?>>());
+        expect(
+          state.error.toString(),
+          'Unknown certification error',
+        );
+      });
+    });
+
+    group('reset', () {
+      test('resets state to AsyncData(null)', () async {
+        when(() => mockRepo.verifyCertification('imp_reset'))
+            .thenAnswer((_) async => <String, dynamic>{'verified': true});
+
+        final container = createTestContainer();
+        final notifier =
+            container.read(iamportControllerProvider.notifier);
+
+        await notifier.onCertificationResult(<String, String>{
+          'imp_uid': 'imp_reset',
+          'merchant_uid': 'mid_reset',
+          'success': 'true',
+        });
+
+        // Verify state is set before reset
+        expect(container.read(iamportControllerProvider).value, isNotNull);
+
+        notifier.reset();
+
+        final state = container.read(iamportControllerProvider);
+        expect(state, isA<AsyncData<IamportResultModel?>>());
+        expect(state.value, isNull);
+      });
+    });
+  });
+}

--- a/shared/packages/minglit_kit/test/src/features/iamport/logic/iamport_controller_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/iamport/logic/iamport_controller_test.dart
@@ -35,32 +35,35 @@ void main() {
     });
 
     group('onCertificationResult', () {
-      test('verifies and sets success state on successful certification',
-          () async {
-        when(() => mockRepo.verifyCertification('imp_success_001'))
-            .thenAnswer((_) async => <String, dynamic>{'verified': true});
+      test(
+        'verifies and sets success state on successful certification',
+        () async {
+          when(
+            () => mockRepo.verifyCertification('imp_success_001'),
+          ).thenAnswer((_) async => <String, dynamic>{'verified': true});
 
-        final container = createTestContainer();
-        final notifier =
-            container.read(iamportControllerProvider.notifier);
+          final container = createTestContainer();
+          final notifier = container.read(iamportControllerProvider.notifier);
 
-        await notifier.onCertificationResult(<String, String>{
-          'imp_uid': 'imp_success_001',
-          'merchant_uid': 'mid_001',
-          'success': 'true',
-        });
+          await notifier.onCertificationResult(<String, String>{
+            'imp_uid': 'imp_success_001',
+            'merchant_uid': 'mid_001',
+            'success': 'true',
+          });
 
-        final state = container.read(iamportControllerProvider);
-        expect(state, isA<AsyncData<IamportResultModel?>>());
-        expect(state.value!.success, isTrue);
-        expect(state.value!.impUid, 'imp_success_001');
-        verify(() => mockRepo.verifyCertification('imp_success_001')).called(1);
-      });
+          final state = container.read(iamportControllerProvider);
+          expect(state, isA<AsyncData<IamportResultModel?>>());
+          expect(state.value!.success, isTrue);
+          expect(state.value!.impUid, 'imp_success_001');
+          verify(
+            () => mockRepo.verifyCertification('imp_success_001'),
+          ).called(1);
+        },
+      );
 
       test('sets error state when certification fails from Iamport', () async {
         final container = createTestContainer();
-        final notifier =
-            container.read(iamportControllerProvider.notifier);
+        final notifier = container.read(iamportControllerProvider.notifier);
 
         await notifier.onCertificationResult(<String, String>{
           'imp_uid': '',
@@ -75,28 +78,29 @@ void main() {
         verifyNever(() => mockRepo.verifyCertification(any()));
       });
 
-      test('sets error state when success is true but impUid is null',
-          () async {
-        final container = createTestContainer();
-        final notifier =
-            container.read(iamportControllerProvider.notifier);
+      test(
+        'sets error state when success is true but impUid is null',
+        () async {
+          final container = createTestContainer();
+          final notifier = container.read(iamportControllerProvider.notifier);
 
-        await notifier.onCertificationResult(<String, String>{
-          'success': 'false',
-          'error_msg': 'No UID returned',
-        });
+          await notifier.onCertificationResult(<String, String>{
+            'success': 'false',
+            'error_msg': 'No UID returned',
+          });
 
-        final state = container.read(iamportControllerProvider);
-        expect(state, isA<AsyncError<IamportResultModel?>>());
-      });
+          final state = container.read(iamportControllerProvider);
+          expect(state, isA<AsyncError<IamportResultModel?>>());
+        },
+      );
 
       test('sets error state when server verification fails', () async {
-        when(() => mockRepo.verifyCertification('imp_server_fail'))
-            .thenThrow(Exception('server error'));
+        when(
+          () => mockRepo.verifyCertification('imp_server_fail'),
+        ).thenThrow(Exception('server error'));
 
         final container = createTestContainer();
-        final notifier =
-            container.read(iamportControllerProvider.notifier);
+        final notifier = container.read(iamportControllerProvider.notifier);
 
         await notifier.onCertificationResult(<String, String>{
           'imp_uid': 'imp_server_fail',
@@ -110,8 +114,7 @@ void main() {
 
       test('uses default error message when errorMsg is null', () async {
         final container = createTestContainer();
-        final notifier =
-            container.read(iamportControllerProvider.notifier);
+        final notifier = container.read(iamportControllerProvider.notifier);
 
         await notifier.onCertificationResult(<String, String>{
           'success': 'false',
@@ -128,12 +131,12 @@ void main() {
 
     group('reset', () {
       test('resets state to AsyncData(null)', () async {
-        when(() => mockRepo.verifyCertification('imp_reset'))
-            .thenAnswer((_) async => <String, dynamic>{'verified': true});
+        when(
+          () => mockRepo.verifyCertification('imp_reset'),
+        ).thenAnswer((_) async => <String, dynamic>{'verified': true});
 
         final container = createTestContainer();
-        final notifier =
-            container.read(iamportControllerProvider.notifier);
+        final notifier = container.read(iamportControllerProvider.notifier);
 
         await notifier.onCertificationResult(<String, String>{
           'imp_uid': 'imp_reset',

--- a/shared/packages/minglit_kit/test/src/features/iamport/logic/iamport_controller_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/iamport/logic/iamport_controller_test.dart
@@ -85,8 +85,8 @@ void main() {
           final notifier = container.read(iamportControllerProvider.notifier);
 
           await notifier.onCertificationResult(<String, String>{
-            'success': 'false',
-            'error_msg': 'No UID returned',
+            'success': 'true',
+            'merchant_uid': 'mid_no_uid',
           });
 
           final state = container.read(iamportControllerProvider);


### PR DESCRIPTION
## Summary
- iamport 디렉토리 (11 소스, 0 테스트 → 27 테스트) 커버리지 추가
- `IamportResultModel`: fromJson/toJson/fromMap 직렬화, equality, copyWith 테스트
- `IamportRepository`: verifyCertification 성공/실패/인증에러/네트워크에러 테스트
- `IamportController`: 인증 성공/실패/서버검증실패/reset 상태관리 테스트

Closes #212

## Test plan
- [x] `cd shared/packages/minglit_kit && flutter test test/src/features/iamport/` — 27/27 통과
- [ ] CI `test-flutter-apps` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)