### PR TITLE
test: 미테스트 보조 Repository 테스트 추가

### DIFF
--- a/shared/packages/minglit_kit/test/src/data/repositories/kakao_location_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/kakao_location_repository_test.dart
@@ -1,0 +1,27 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/data/repositories/kakao_location_repository.dart';
+
+void main() {
+  late KakaoLocationRepository repository;
+
+  setUp(() {
+    repository = KakaoLocationRepository();
+  });
+
+  group('KakaoLocationRepository', () {
+    group('searchKeyword', () {
+      test('returns empty list for empty query', () async {
+        final result = await repository.searchKeyword('');
+        expect(result, isEmpty);
+      });
+
+      test('returns empty list when API key is not defined', () async {
+        // KAKAO_LOCAL_REST_API_KEY is not set in test environment,
+        // so this should return empty list gracefully.
+        final result = await repository.searchKeyword('강남역');
+        expect(result, isEmpty);
+      });
+    });
+  });
+}

--- a/shared/packages/minglit_kit/test/src/data/repositories/kakao_location_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/kakao_location_repository_test.dart
@@ -1,4 +1,3 @@
-import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/repositories/kakao_location_repository.dart';
 

--- a/shared/packages/minglit_kit/test/src/data/repositories/party_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/party_repository_test.dart
@@ -3,6 +3,7 @@ import 'dart:async' show unawaited;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/models/event.dart';
 import 'package:minglit_kit/src/data/models/party.dart';
+import 'package:minglit_kit/src/data/models/party_entry_group.dart';
 import 'package:minglit_kit/src/data/repositories/party_repository.dart';
 
 import '../../../helpers/mocks.dart';
@@ -308,6 +309,79 @@ void main() {
 
         await expectLater(
           repository.updateEventStatus('event_1', 'active'),
+          throwsA(anything),
+        );
+      });
+    });
+
+    group('updateEventMetadata', () {
+      test('completes without error', () async {
+        unawaited(mockTable(mockClient, 'events'));
+
+        await expectLater(
+          repository.updateEventMetadata(
+            'event_1',
+            {'theme': 'dark', 'capacity': 50},
+          ),
+          completes,
+        );
+      });
+
+      test('throws on error', () async {
+        unawaited(
+          mockTable(mockClient, 'events', shouldThrow: Exception('error')),
+        );
+
+        await expectLater(
+          repository.updateEventMetadata('event_1', {'key': 'value'}),
+          throwsA(anything),
+        );
+      });
+    });
+  });
+
+  group('PartyRepository (matching)', () {
+    group('replaceEntryGroupTemplates', () {
+      test('completes with empty templates (delete only)', () async {
+        unawaited(mockTable(mockClient, 'entry_groups'));
+
+        await expectLater(
+          repository.replaceEntryGroupTemplates('party_1', []),
+          completes,
+        );
+      });
+
+      test('completes with templates (delete + insert)', () async {
+        unawaited(mockTable(mockClient, 'entry_groups'));
+
+        final templates = [
+          EntryGroupTemplate(
+            id: 'eg_1',
+            partyId: 'party_1',
+            label: '남성',
+            gender: 'male',
+            birthYearMin: 1990,
+            birthYearMax: 2000,
+          ),
+        ];
+
+        await expectLater(
+          repository.replaceEntryGroupTemplates('party_1', templates),
+          completes,
+        );
+      });
+
+      test('throws on error', () async {
+        unawaited(
+          mockTable(
+            mockClient,
+            'entry_groups',
+            shouldThrow: Exception('error'),
+          ),
+        );
+
+        await expectLater(
+          repository.replaceEntryGroupTemplates('party_1', []),
           throwsA(anything),
         );
       });

--- a/shared/packages/minglit_kit/test/src/data/repositories/party_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/party_repository_test.dart
@@ -355,7 +355,7 @@ void main() {
         unawaited(mockTable(mockClient, 'entry_groups'));
 
         final templates = [
-          EntryGroupTemplate(
+          const EntryGroupTemplate(
             id: 'eg_1',
             partyId: 'party_1',
             label: '남성',

--- a/shared/packages/minglit_kit/test/src/data/repositories/policy_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/policy_repository_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/data/repositories/policy_repository.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../helpers/mocks.dart';
+import '../../../helpers/supabase_mock_helpers.dart';
+
+void main() {
+  late MockSupabaseClient mockClient;
+  late PolicyRepository repository;
+
+  setUp(() {
+    mockClient = createMockSupabase();
+    repository = PolicyRepository(mockClient);
+  });
+
+  group('PolicyRepository', () {
+    group('getRefundPolicy', () {
+      test('returns policy map when found', () async {
+        final policyData = {
+          'key': 'refund',
+          'title': '환불 정책',
+          'content': '결제 후 24시간 이내 환불 가능',
+          'version': 1,
+        };
+
+        when(
+          () => mockClient.rpc<Map<String, dynamic>?>(
+            'get_current_policy',
+            params: any(named: 'params'),
+          ),
+        ).thenAnswer((_) => FakeRpcBuilder(policyData));
+
+        final result = await repository.getRefundPolicy();
+
+        expect(result, isNotNull);
+        expect(result!['key'], 'refund');
+        expect(result['title'], '환불 정책');
+      });
+
+      test('returns null when policy not found', () async {
+        when(
+          () => mockClient.rpc<Map<String, dynamic>?>(
+            'get_current_policy',
+            params: any(named: 'params'),
+          ),
+        ).thenAnswer((_) => FakeRpcBuilder(null));
+
+        final result = await repository.getRefundPolicy();
+
+        expect(result, isNull);
+      });
+
+      test('throws on error', () async {
+        when(
+          () => mockClient.rpc<Map<String, dynamic>?>(
+            'get_current_policy',
+            params: any(named: 'params'),
+          ),
+        ).thenThrow(Exception('RPC error'));
+
+        await expectLater(
+          repository.getRefundPolicy(),
+          throwsA(anything),
+        );
+      });
+    });
+  });
+}

--- a/shared/packages/minglit_kit/test/src/data/repositories/staff_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/staff_repository_test.dart
@@ -56,8 +56,7 @@ void main() {
         expect(result, isNull);
       });
 
-      test('returns user when token valid and email is @minglit.com',
-          () async {
+      test('returns user when token valid and email is @minglit.com', () async {
         SharedPreferences.setMockInitialValues({
           'minglit_staff_proof_token': 'valid_token',
         });
@@ -79,28 +78,30 @@ void main() {
         expect(result!.email, 'admin@minglit.com');
       });
 
-      test('returns null and clears token when email is not @minglit.com',
-          () async {
-        SharedPreferences.setMockInitialValues({
-          'minglit_staff_proof_token': 'valid_token',
-        });
+      test(
+        'returns null and clears token when email is not @minglit.com',
+        () async {
+          SharedPreferences.setMockInitialValues({
+            'minglit_staff_proof_token': 'valid_token',
+          });
 
-        final mockUser = MockUser();
-        when(() => mockUser.email).thenReturn('user@gmail.com');
+          final mockUser = MockUser();
+          when(() => mockUser.email).thenReturn('user@gmail.com');
 
-        final mockResponse = MockUserResponse();
-        when(() => mockResponse.user).thenReturn(mockUser);
+          final mockResponse = MockUserResponse();
+          when(() => mockResponse.user).thenReturn(mockUser);
 
-        when(() => mockAuth.getUser('valid_token')).thenAnswer(
-          (_) async => mockResponse,
-        );
+          when(() => mockAuth.getUser('valid_token')).thenAnswer(
+            (_) async => mockResponse,
+          );
 
-        final result = await repository.verifyStaffStatus();
+          final result = await repository.verifyStaffStatus();
 
-        expect(result, isNull);
-        final prefs = await SharedPreferences.getInstance();
-        expect(prefs.getString('minglit_staff_proof_token'), isNull);
-      });
+          expect(result, isNull);
+          final prefs = await SharedPreferences.getInstance();
+          expect(prefs.getString('minglit_staff_proof_token'), isNull);
+        },
+      );
 
       test('returns null and clears token when verification fails', () async {
         SharedPreferences.setMockInitialValues({

--- a/shared/packages/minglit_kit/test/src/data/repositories/staff_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/staff_repository_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/data/repositories/staff_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../../helpers/mocks.dart';
+import '../../../helpers/supabase_mock_helpers.dart';
+
+class MockUserResponse extends Mock implements UserResponse {}
+
+void main() {
+  late MockSupabaseClient mockClient;
+  late MockGoTrueClient mockAuth;
+  late StaffRepository repository;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    mockClient = createMockSupabase();
+    mockAuth = mockClient.auth as MockGoTrueClient;
+    repository = StaffRepository(
+      supabase: mockClient,
+      redirectUrl: 'https://example.com/callback/',
+    );
+  });
+
+  group('StaffRepository', () {
+    group('saveStaffToken', () {
+      test('saves token to SharedPreferences', () async {
+        await repository.saveStaffToken('test_jwt_token');
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getString('minglit_staff_proof_token'),
+          'test_jwt_token',
+        );
+      });
+    });
+
+    group('clearStaffToken', () {
+      test('removes token from SharedPreferences', () async {
+        SharedPreferences.setMockInitialValues({
+          'minglit_staff_proof_token': 'existing_token',
+        });
+
+        await repository.clearStaffToken();
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getString('minglit_staff_proof_token'), isNull);
+      });
+    });
+
+    group('verifyStaffStatus', () {
+      test('returns null when no token stored', () async {
+        final result = await repository.verifyStaffStatus();
+        expect(result, isNull);
+      });
+
+      test('returns user when token valid and email is @minglit.com',
+          () async {
+        SharedPreferences.setMockInitialValues({
+          'minglit_staff_proof_token': 'valid_token',
+        });
+
+        final mockUser = MockUser();
+        when(() => mockUser.id).thenReturn('staff_1');
+        when(() => mockUser.email).thenReturn('admin@minglit.com');
+
+        final mockResponse = MockUserResponse();
+        when(() => mockResponse.user).thenReturn(mockUser);
+
+        when(() => mockAuth.getUser('valid_token')).thenAnswer(
+          (_) async => mockResponse,
+        );
+
+        final result = await repository.verifyStaffStatus();
+
+        expect(result, isNotNull);
+        expect(result!.email, 'admin@minglit.com');
+      });
+
+      test('returns null and clears token when email is not @minglit.com',
+          () async {
+        SharedPreferences.setMockInitialValues({
+          'minglit_staff_proof_token': 'valid_token',
+        });
+
+        final mockUser = MockUser();
+        when(() => mockUser.email).thenReturn('user@gmail.com');
+
+        final mockResponse = MockUserResponse();
+        when(() => mockResponse.user).thenReturn(mockUser);
+
+        when(() => mockAuth.getUser('valid_token')).thenAnswer(
+          (_) async => mockResponse,
+        );
+
+        final result = await repository.verifyStaffStatus();
+
+        expect(result, isNull);
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getString('minglit_staff_proof_token'), isNull);
+      });
+
+      test('returns null and clears token when verification fails', () async {
+        SharedPreferences.setMockInitialValues({
+          'minglit_staff_proof_token': 'expired_token',
+        });
+
+        when(() => mockAuth.getUser('expired_token')).thenThrow(
+          const AuthException('Token expired'),
+        );
+
+        final result = await repository.verifyStaffStatus();
+
+        expect(result, isNull);
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getString('minglit_staff_proof_token'), isNull);
+      });
+    });
+
+    group('sendMagicLink', () {
+      test('throws AuthException for non-minglit email', () async {
+        await expectLater(
+          repository.sendMagicLink('user@gmail.com'),
+          throwsA(
+            isA<AuthException>().having(
+              (e) => e.message,
+              'message',
+              contains('@minglit.com'),
+            ),
+          ),
+        );
+      });
+
+      test('sends OTP for valid @minglit.com email', () async {
+        when(
+          () => mockAuth.signInWithOtp(
+            email: any(named: 'email'),
+            emailRedirectTo: any(named: 'emailRedirectTo'),
+          ),
+        ).thenAnswer((_) async => AuthResponse());
+
+        await expectLater(
+          repository.sendMagicLink('admin@minglit.com'),
+          completes,
+        );
+
+        verify(
+          () => mockAuth.signInWithOtp(
+            email: 'admin@minglit.com',
+            emailRedirectTo: 'https://example.com/callback',
+          ),
+        ).called(1);
+      });
+
+      test('throws on auth error', () async {
+        when(
+          () => mockAuth.signInWithOtp(
+            email: any(named: 'email'),
+            emailRedirectTo: any(named: 'emailRedirectTo'),
+          ),
+        ).thenThrow(const AuthException('Send failed'));
+
+        await expectLater(
+          repository.sendMagicLink('admin@minglit.com'),
+          throwsA(isA<AuthException>()),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes #214

- `party_repository`: `updateEventMetadata`, `replaceEntryGroupTemplates` 테스트 추가
- `policy_repository`: `getRefundPolicy` RPC 호출 테스트 (성공/null/에러)
- `staff_repository`: `saveStaffToken`, `clearStaffToken`, `verifyStaffStatus`, `sendMagicLink` 테스트 (SharedPreferences + GoTrue 모킹)
- `kakao_location_repository`: `searchKeyword` 빈 쿼리 및 API 키 미설정 케이스 테스트

## Test plan

- [x] `flutter test` 전체 통과 확인 (446+ tests)
- [x] 신규 테스트 파일 3개 + 기존 파일 1개 수정
- [x] CI `ci-result` 통과 대기

🤖 Generated with [Claude Code](https://claude.com/claude-code)