### PR TITLE
test: app_partner settlement/verification 컨트롤러 테스트 추가

### DIFF
--- a/apps/app_partner/test/src/features/settlement/settlement_controller_test.dart
+++ b/apps/app_partner/test/src/features/settlement/settlement_controller_test.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:app_partner/src/features/party/party_providers.dart';
 import 'package:app_partner/src/features/settlement/settlement_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
@@ -7,8 +10,22 @@ import 'package:mocktail/mocktail.dart';
 import '../../../utils/mocks.dart';
 import '../../../utils/test_utils.dart';
 
-Future<void> pump() async {
-  await Future<void>.delayed(const Duration(milliseconds: 50));
+/// Waits until SettlementController.status transitions out of loading.
+Future<void> waitForSettlement(ProviderContainer container) async {
+  final completer = Completer<void>();
+  final sub = container.listen(settlementControllerProvider, (prev, next) {
+    if (next.status is! AsyncLoading && !completer.isCompleted) {
+      completer.complete();
+    }
+  });
+  // Check if already resolved
+  final current = container.read(settlementControllerProvider);
+  if (current.status is! AsyncLoading) {
+    sub.close();
+    return;
+  }
+  await completer.future;
+  sub.close();
 }
 
 void main() {
@@ -98,7 +115,7 @@ void main() {
       expect(state.monthlyRevenue, isEmpty);
 
       // Let the auto-triggered loadSettlementData complete
-      await pump();
+      await waitForSettlement(container);
 
       final resolved = container.read(settlementControllerProvider);
       expect(resolved.status, isA<AsyncData<void>>());
@@ -113,7 +130,7 @@ void main() {
       addTearDown(sub.close);
 
       container.read(settlementControllerProvider);
-      await pump();
+      await waitForSettlement(container);
 
       final state = container.read(settlementControllerProvider);
       expect(state.status, isA<AsyncData<void>>());
@@ -138,7 +155,7 @@ void main() {
         addTearDown(sub.close);
 
         container.read(settlementControllerProvider);
-        await pump();
+        await waitForSettlement(container);
 
         final state = container.read(settlementControllerProvider);
         expect(state.status, isA<AsyncData<void>>());
@@ -157,7 +174,7 @@ void main() {
       addTearDown(sub.close);
 
       container.read(settlementControllerProvider);
-      await pump();
+      await waitForSettlement(container);
 
       final state = container.read(settlementControllerProvider);
       expect(state.status, isA<AsyncError<void>>());
@@ -181,7 +198,7 @@ void main() {
       addTearDown(sub.close);
 
       container.read(settlementControllerProvider);
-      await pump();
+      await waitForSettlement(container);
 
       final state = container.read(settlementControllerProvider);
       expect(state.status, isA<AsyncData<void>>());
@@ -199,7 +216,7 @@ void main() {
       addTearDown(sub.close);
 
       container.read(settlementControllerProvider);
-      await pump();
+      await waitForSettlement(container);
 
       verify(
         () => mockPartnerRepo.getPartnerRevenueStats('partner-1'),

--- a/apps/app_partner/test/src/features/settlement/settlement_controller_test.dart
+++ b/apps/app_partner/test/src/features/settlement/settlement_controller_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:app_partner/src/features/party/party_providers.dart';
 import 'package:app_partner/src/features/settlement/settlement_controller.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';

--- a/apps/app_partner/test/src/features/settlement/settlement_controller_test.dart
+++ b/apps/app_partner/test/src/features/settlement/settlement_controller_test.dart
@@ -1,0 +1,210 @@
+import 'package:app_partner/src/features/party/party_providers.dart';
+import 'package:app_partner/src/features/settlement/settlement_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../utils/mocks.dart';
+import '../../../utils/test_utils.dart';
+
+Future<void> pump() async {
+  await Future<void>.delayed(const Duration(milliseconds: 50));
+}
+
+void main() {
+  late MockPartnerRepository mockPartnerRepo;
+  late Partner fakePartner;
+
+  setUp(() {
+    mockPartnerRepo = MockPartnerRepository();
+    fakePartner = const Partner(id: 'partner-1', name: 'Test Partner');
+  });
+
+  ProviderContainer makeContainer({
+    Partner? partner,
+    bool nullPartner = false,
+    Map<String, dynamic>? revenueStats,
+    List<Map<String, dynamic>>? monthlyRevenue,
+    List<Map<String, dynamic>>? settlements,
+    Exception? error,
+  }) {
+    final resolvedPartner = nullPartner ? null : (partner ?? fakePartner);
+
+    if (error != null) {
+      when(() => mockPartnerRepo.getPartnerRevenueStats(any()))
+          .thenThrow(error);
+    } else {
+      when(() => mockPartnerRepo.getPartnerRevenueStats(any())).thenAnswer(
+        (_) async =>
+            revenueStats ??
+            {'total_sales': 100000, 'total_refunds': 5000, 'net_amount': 95000},
+      );
+      when(() => mockPartnerRepo.getPartnerMonthlyRevenue(any())).thenAnswer(
+        (_) async =>
+            monthlyRevenue ??
+            [
+              {
+                'month': '2026-01-01',
+                'total_sales': 50000,
+                'total_refunds': 2000,
+                'net_amount': 48000,
+              },
+            ],
+      );
+      when(() => mockPartnerRepo.getPartnerSettlements(any())).thenAnswer(
+        (_) async =>
+            settlements ??
+            [
+              {
+                'id': 'settle-1',
+                'event_id': 'evt-1',
+                'event_title': 'Test Event',
+                'event_date': '2026-01-15',
+                'total_sales': 50000,
+                'total_refunds': 2000,
+                'pg_fee': 500,
+                'platform_fee': 1000,
+                'vat': 100,
+                'net_amount': 46400,
+                'status': 'COMPLETED',
+              },
+            ],
+      );
+    }
+
+    return createContainer(
+      overrides: [
+        partnerRepositoryProvider.overrideWithValue(mockPartnerRepo),
+        currentPartnerInfoProvider.overrideWith(
+          (ref) async => resolvedPartner,
+        ),
+      ],
+    );
+  }
+
+  group('SettlementController', () {
+    test('initial state is loading then resolves to data', () async {
+      final container = makeContainer();
+      final sub = container.listen(
+        settlementControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      final state = container.read(settlementControllerProvider);
+      expect(state.status, isA<AsyncLoading<void>>());
+      expect(state.settlements, isEmpty);
+      expect(state.monthlyRevenue, isEmpty);
+
+      // Let the auto-triggered loadSettlementData complete
+      await pump();
+
+      final resolved = container.read(settlementControllerProvider);
+      expect(resolved.status, isA<AsyncData<void>>());
+    });
+
+    test('loadSettlementData success populates all fields', () async {
+      final container = makeContainer();
+      final sub = container.listen(
+        settlementControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      container.read(settlementControllerProvider);
+      await pump();
+
+      final state = container.read(settlementControllerProvider);
+      expect(state.status, isA<AsyncData<void>>());
+      expect(state.revenueSummary.totalSales, 100000);
+      expect(state.revenueSummary.totalRefunds, 5000);
+      expect(state.revenueSummary.netAmount, 95000);
+      expect(state.monthlyRevenue.length, 1);
+      expect(state.monthlyRevenue.first.totalSales, 50000);
+      expect(state.settlements.length, 1);
+      expect(state.settlements.first.id, 'settle-1');
+      expect(state.settlements.first.status, 'completed');
+    });
+
+    test('loadSettlementData with null partner returns early with data status',
+        () async {
+      final container = makeContainer(nullPartner: true);
+      final sub = container.listen(
+        settlementControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      container.read(settlementControllerProvider);
+      await pump();
+
+      final state = container.read(settlementControllerProvider);
+      expect(state.status, isA<AsyncData<void>>());
+      expect(state.settlements, isEmpty);
+      expect(state.monthlyRevenue, isEmpty);
+      verifyNever(() => mockPartnerRepo.getPartnerRevenueStats(any()));
+    });
+
+    test('loadSettlementData error sets error status', () async {
+      final container = makeContainer(error: Exception('network error'));
+      final sub = container.listen(
+        settlementControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      container.read(settlementControllerProvider);
+      await pump();
+
+      final state = container.read(settlementControllerProvider);
+      expect(state.status, isA<AsyncError<void>>());
+      expect(state.settlements, isEmpty);
+    });
+
+    test('loadSettlementData with empty data works', () async {
+      final container = makeContainer(
+        revenueStats: {
+          'total_sales': 0,
+          'total_refunds': 0,
+          'net_amount': 0,
+        },
+        monthlyRevenue: [],
+        settlements: [],
+      );
+      final sub = container.listen(
+        settlementControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      container.read(settlementControllerProvider);
+      await pump();
+
+      final state = container.read(settlementControllerProvider);
+      expect(state.status, isA<AsyncData<void>>());
+      expect(state.revenueSummary.totalSales, 0);
+      expect(state.monthlyRevenue, isEmpty);
+      expect(state.settlements, isEmpty);
+    });
+
+    test('loadSettlementData calls repo with correct partnerId', () async {
+      final container = makeContainer();
+      final sub = container.listen(
+        settlementControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      container.read(settlementControllerProvider);
+      await pump();
+
+      verify(() => mockPartnerRepo.getPartnerRevenueStats('partner-1'))
+          .called(1);
+      verify(() => mockPartnerRepo.getPartnerMonthlyRevenue('partner-1'))
+          .called(1);
+      verify(() => mockPartnerRepo.getPartnerSettlements('partner-1'))
+          .called(1);
+    });
+  });
+}

--- a/apps/app_partner/test/src/features/settlement/settlement_controller_test.dart
+++ b/apps/app_partner/test/src/features/settlement/settlement_controller_test.dart
@@ -1,6 +1,5 @@
 import 'package:app_partner/src/features/party/party_providers.dart';
 import 'package:app_partner/src/features/settlement/settlement_controller.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
@@ -32,8 +31,9 @@ void main() {
     final resolvedPartner = nullPartner ? null : (partner ?? fakePartner);
 
     if (error != null) {
-      when(() => mockPartnerRepo.getPartnerRevenueStats(any()))
-          .thenThrow(error);
+      when(
+        () => mockPartnerRepo.getPartnerRevenueStats(any()),
+      ).thenThrow(error);
     } else {
       when(() => mockPartnerRepo.getPartnerRevenueStats(any())).thenAnswer(
         (_) async =>
@@ -127,24 +127,26 @@ void main() {
       expect(state.settlements.first.status, 'completed');
     });
 
-    test('loadSettlementData with null partner returns early with data status',
-        () async {
-      final container = makeContainer(nullPartner: true);
-      final sub = container.listen(
-        settlementControllerProvider,
-        (_, _) {},
-      );
-      addTearDown(sub.close);
+    test(
+      'loadSettlementData with null partner returns early with data status',
+      () async {
+        final container = makeContainer(nullPartner: true);
+        final sub = container.listen(
+          settlementControllerProvider,
+          (_, _) {},
+        );
+        addTearDown(sub.close);
 
-      container.read(settlementControllerProvider);
-      await pump();
+        container.read(settlementControllerProvider);
+        await pump();
 
-      final state = container.read(settlementControllerProvider);
-      expect(state.status, isA<AsyncData<void>>());
-      expect(state.settlements, isEmpty);
-      expect(state.monthlyRevenue, isEmpty);
-      verifyNever(() => mockPartnerRepo.getPartnerRevenueStats(any()));
-    });
+        final state = container.read(settlementControllerProvider);
+        expect(state.status, isA<AsyncData<void>>());
+        expect(state.settlements, isEmpty);
+        expect(state.monthlyRevenue, isEmpty);
+        verifyNever(() => mockPartnerRepo.getPartnerRevenueStats(any()));
+      },
+    );
 
     test('loadSettlementData error sets error status', () async {
       final container = makeContainer(error: Exception('network error'));
@@ -199,12 +201,15 @@ void main() {
       container.read(settlementControllerProvider);
       await pump();
 
-      verify(() => mockPartnerRepo.getPartnerRevenueStats('partner-1'))
-          .called(1);
-      verify(() => mockPartnerRepo.getPartnerMonthlyRevenue('partner-1'))
-          .called(1);
-      verify(() => mockPartnerRepo.getPartnerSettlements('partner-1'))
-          .called(1);
+      verify(
+        () => mockPartnerRepo.getPartnerRevenueStats('partner-1'),
+      ).called(1);
+      verify(
+        () => mockPartnerRepo.getPartnerMonthlyRevenue('partner-1'),
+      ).called(1);
+      verify(
+        () => mockPartnerRepo.getPartnerSettlements('partner-1'),
+      ).called(1);
     });
   });
 }

--- a/apps/app_partner/test/src/features/verification/create_verification_controller_test.dart
+++ b/apps/app_partner/test/src/features/verification/create_verification_controller_test.dart
@@ -1,5 +1,4 @@
 import 'package:app_partner/src/features/verification/create/create_verification_controller.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
@@ -36,8 +35,7 @@ void main() {
     return createContainer(
       overrides: [
         partnerRepositoryProvider.overrideWithValue(mockPartnerRepo),
-        verificationRepositoryProvider
-            .overrideWithValue(mockVerificationRepo),
+        verificationRepositoryProvider.overrideWithValue(mockVerificationRepo),
       ],
     );
   }
@@ -139,8 +137,9 @@ void main() {
       );
       addTearDown(sub.close);
 
-      final notifier =
-          container.read(createVerificationControllerProvider.notifier);
+      final notifier = container.read(
+        createVerificationControllerProvider.notifier,
+      );
       notifier.addField('text');
       notifier.addField('file');
 
@@ -164,12 +163,15 @@ void main() {
       );
       addTearDown(sub.close);
 
-      final notifier =
-          container.read(createVerificationControllerProvider.notifier);
+      final notifier = container.read(
+        createVerificationControllerProvider.notifier,
+      );
       notifier.addField('text');
 
-      final original =
-          container.read(createVerificationControllerProvider).fields.first;
+      final original = container
+          .read(createVerificationControllerProvider)
+          .fields
+          .first;
       final updated = original.copyWith(label: '회사명');
       notifier.updateField(0, updated);
 
@@ -185,8 +187,9 @@ void main() {
       );
       addTearDown(sub.close);
 
-      final notifier =
-          container.read(createVerificationControllerProvider.notifier);
+      final notifier = container.read(
+        createVerificationControllerProvider.notifier,
+      );
       notifier.addField('text');
       notifier.addField('file');
       notifier.addField('date');
@@ -227,17 +230,19 @@ void main() {
       );
       addTearDown(sub.close);
 
-      when(() => mockVerificationRepo.createVerification(any()))
-          .thenAnswer((_) async => const Verification(
-                id: 'new-v-1',
-                partnerId: 'partner-1',
-                category: VerificationCategory.etc,
-                internalName: 'test',
-                displayName: 'Test',
-              ));
+      when(() => mockVerificationRepo.createVerification(any())).thenAnswer(
+        (_) async => const Verification(
+          id: 'new-v-1',
+          partnerId: 'partner-1',
+          category: VerificationCategory.etc,
+          internalName: 'test',
+          displayName: 'Test',
+        ),
+      );
 
-      final notifier =
-          container.read(createVerificationControllerProvider.notifier);
+      final notifier = container.read(
+        createVerificationControllerProvider.notifier,
+      );
       notifier.updateDisplayName('Test');
       notifier.updateInternalName('test');
       notifier.addField('text');
@@ -259,17 +264,19 @@ void main() {
       when(() => mockPartnerRepo.getMyManagedPartners()).thenAnswer(
         (_) async => [const Partner(id: 'auto-partner', name: 'Auto')],
       );
-      when(() => mockVerificationRepo.createVerification(any()))
-          .thenAnswer((_) async => const Verification(
-                id: 'new-v-1',
-                partnerId: 'auto-partner',
-                category: VerificationCategory.etc,
-                internalName: 'test',
-                displayName: 'Test',
-              ));
+      when(() => mockVerificationRepo.createVerification(any())).thenAnswer(
+        (_) async => const Verification(
+          id: 'new-v-1',
+          partnerId: 'auto-partner',
+          category: VerificationCategory.etc,
+          internalName: 'test',
+          displayName: 'Test',
+        ),
+      );
 
-      final notifier =
-          container.read(createVerificationControllerProvider.notifier);
+      final notifier = container.read(
+        createVerificationControllerProvider.notifier,
+      );
       notifier.addField('text');
 
       final result = await notifier.submit(null);
@@ -278,30 +285,34 @@ void main() {
       verify(() => mockPartnerRepo.getMyManagedPartners()).called(1);
     });
 
-    test('submit with null partnerId and no managed partners returns false',
-        () async {
-      final container = makeContainer();
-      final sub = container.listen(
-        createVerificationControllerProvider,
-        (_, _) {},
-      );
-      addTearDown(sub.close);
+    test(
+      'submit with null partnerId and no managed partners returns false',
+      () async {
+        final container = makeContainer();
+        final sub = container.listen(
+          createVerificationControllerProvider,
+          (_, _) {},
+        );
+        addTearDown(sub.close);
 
-      when(() => mockPartnerRepo.getMyManagedPartners())
-          .thenAnswer((_) async => []);
+        when(
+          () => mockPartnerRepo.getMyManagedPartners(),
+        ).thenAnswer((_) async => []);
 
-      final notifier =
-          container.read(createVerificationControllerProvider.notifier);
-      notifier.addField('text');
+        final notifier = container.read(
+          createVerificationControllerProvider.notifier,
+        );
+        notifier.addField('text');
 
-      final result = await notifier.submit(null);
+        final result = await notifier.submit(null);
 
-      expect(result, isFalse);
-      expect(
-        container.read(createVerificationControllerProvider).error,
-        contains('파트너 정보를 찾을 수 없습니다'),
-      );
-    });
+        expect(result, isFalse);
+        expect(
+          container.read(createVerificationControllerProvider).error,
+          contains('파트너 정보를 찾을 수 없습니다'),
+        );
+      },
+    );
 
     test('submit error sets error message', () async {
       final container = makeContainer();
@@ -311,11 +322,13 @@ void main() {
       );
       addTearDown(sub.close);
 
-      when(() => mockVerificationRepo.createVerification(any()))
-          .thenThrow(Exception('create failed'));
+      when(
+        () => mockVerificationRepo.createVerification(any()),
+      ).thenThrow(Exception('create failed'));
 
-      final notifier =
-          container.read(createVerificationControllerProvider.notifier);
+      final notifier = container.read(
+        createVerificationControllerProvider.notifier,
+      );
       notifier.addField('text');
 
       final result = await notifier.submit('partner-1');

--- a/apps/app_partner/test/src/features/verification/create_verification_controller_test.dart
+++ b/apps/app_partner/test/src/features/verification/create_verification_controller_test.dart
@@ -1,0 +1,330 @@
+import 'package:app_partner/src/features/verification/create/create_verification_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../utils/mocks.dart';
+import '../../../utils/test_utils.dart';
+
+Future<void> pump() async {
+  await Future<void>.delayed(const Duration(milliseconds: 50));
+}
+
+void main() {
+  late MockPartnerRepository mockPartnerRepo;
+  late MockVerificationRepository mockVerificationRepo;
+
+  setUpAll(() {
+    registerFallbackValue(
+      const Verification(
+        id: '',
+        partnerId: '',
+        category: VerificationCategory.etc,
+        internalName: '',
+        displayName: '',
+      ),
+    );
+  });
+
+  setUp(() {
+    mockPartnerRepo = MockPartnerRepository();
+    mockVerificationRepo = MockVerificationRepository();
+  });
+
+  ProviderContainer makeContainer() {
+    return createContainer(
+      overrides: [
+        partnerRepositoryProvider.overrideWithValue(mockPartnerRepo),
+        verificationRepositoryProvider
+            .overrideWithValue(mockVerificationRepo),
+      ],
+    );
+  }
+
+  group('CreateVerificationController', () {
+    test('initial state has empty fields', () {
+      final container = makeContainer();
+      final sub = container.listen(
+        createVerificationControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      final state = container.read(createVerificationControllerProvider);
+      expect(state.displayName, isEmpty);
+      expect(state.internalName, isEmpty);
+      expect(state.description, isEmpty);
+      expect(state.fields, isEmpty);
+      expect(state.error, isNull);
+    });
+
+    test('updateDisplayName updates state', () {
+      final container = makeContainer();
+      final sub = container.listen(
+        createVerificationControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      container
+          .read(createVerificationControllerProvider.notifier)
+          .updateDisplayName('직장 인증');
+
+      expect(
+        container.read(createVerificationControllerProvider).displayName,
+        '직장 인증',
+      );
+    });
+
+    test('updateInternalName updates state', () {
+      final container = makeContainer();
+      final sub = container.listen(
+        createVerificationControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      container
+          .read(createVerificationControllerProvider.notifier)
+          .updateInternalName('career_check');
+
+      expect(
+        container.read(createVerificationControllerProvider).internalName,
+        'career_check',
+      );
+    });
+
+    test('updateDescription updates state', () {
+      final container = makeContainer();
+      final sub = container.listen(
+        createVerificationControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      container
+          .read(createVerificationControllerProvider.notifier)
+          .updateDescription('재직증명서 제출');
+
+      expect(
+        container.read(createVerificationControllerProvider).description,
+        '재직증명서 제출',
+      );
+    });
+
+    test('addField appends a new field', () {
+      final container = makeContainer();
+      final sub = container.listen(
+        createVerificationControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      container
+          .read(createVerificationControllerProvider.notifier)
+          .addField('text');
+
+      final state = container.read(createVerificationControllerProvider);
+      expect(state.fields.length, 1);
+      expect(state.fields.first.type, 'text');
+      expect(state.fields.first.label, isEmpty);
+    });
+
+    test('removeField removes field at index', () {
+      final container = makeContainer();
+      final sub = container.listen(
+        createVerificationControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      final notifier =
+          container.read(createVerificationControllerProvider.notifier);
+      notifier.addField('text');
+      notifier.addField('file');
+
+      expect(
+        container.read(createVerificationControllerProvider).fields.length,
+        2,
+      );
+
+      notifier.removeField(0);
+
+      final state = container.read(createVerificationControllerProvider);
+      expect(state.fields.length, 1);
+      expect(state.fields.first.type, 'file');
+    });
+
+    test('updateField replaces field at index', () {
+      final container = makeContainer();
+      final sub = container.listen(
+        createVerificationControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      final notifier =
+          container.read(createVerificationControllerProvider.notifier);
+      notifier.addField('text');
+
+      final original =
+          container.read(createVerificationControllerProvider).fields.first;
+      final updated = original.copyWith(label: '회사명');
+      notifier.updateField(0, updated);
+
+      final state = container.read(createVerificationControllerProvider);
+      expect(state.fields.first.label, '회사명');
+    });
+
+    test('reorderFields moves field correctly', () {
+      final container = makeContainer();
+      final sub = container.listen(
+        createVerificationControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      final notifier =
+          container.read(createVerificationControllerProvider.notifier);
+      notifier.addField('text');
+      notifier.addField('file');
+      notifier.addField('date');
+
+      // Move item at index 0 to index 2
+      notifier.reorderFields(0, 2);
+
+      final state = container.read(createVerificationControllerProvider);
+      expect(state.fields[0].type, 'file');
+      expect(state.fields[1].type, 'text');
+      expect(state.fields[2].type, 'date');
+    });
+
+    test('submit with empty fields returns false and sets error', () async {
+      final container = makeContainer();
+      final sub = container.listen(
+        createVerificationControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      final result = await container
+          .read(createVerificationControllerProvider.notifier)
+          .submit('partner-1');
+
+      expect(result, isFalse);
+      expect(
+        container.read(createVerificationControllerProvider).error,
+        '적어도 하나의 입력 필드가 필요합니다.',
+      );
+    });
+
+    test('submit success with partnerId returns true', () async {
+      final container = makeContainer();
+      final sub = container.listen(
+        createVerificationControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      when(() => mockVerificationRepo.createVerification(any()))
+          .thenAnswer((_) async => const Verification(
+                id: 'new-v-1',
+                partnerId: 'partner-1',
+                category: VerificationCategory.etc,
+                internalName: 'test',
+                displayName: 'Test',
+              ));
+
+      final notifier =
+          container.read(createVerificationControllerProvider.notifier);
+      notifier.updateDisplayName('Test');
+      notifier.updateInternalName('test');
+      notifier.addField('text');
+
+      final result = await notifier.submit('partner-1');
+
+      expect(result, isTrue);
+      verify(() => mockVerificationRepo.createVerification(any())).called(1);
+    });
+
+    test('submit with null partnerId fetches managed partners', () async {
+      final container = makeContainer();
+      final sub = container.listen(
+        createVerificationControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      when(() => mockPartnerRepo.getMyManagedPartners()).thenAnswer(
+        (_) async => [const Partner(id: 'auto-partner', name: 'Auto')],
+      );
+      when(() => mockVerificationRepo.createVerification(any()))
+          .thenAnswer((_) async => const Verification(
+                id: 'new-v-1',
+                partnerId: 'auto-partner',
+                category: VerificationCategory.etc,
+                internalName: 'test',
+                displayName: 'Test',
+              ));
+
+      final notifier =
+          container.read(createVerificationControllerProvider.notifier);
+      notifier.addField('text');
+
+      final result = await notifier.submit(null);
+
+      expect(result, isTrue);
+      verify(() => mockPartnerRepo.getMyManagedPartners()).called(1);
+    });
+
+    test('submit with null partnerId and no managed partners returns false',
+        () async {
+      final container = makeContainer();
+      final sub = container.listen(
+        createVerificationControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      when(() => mockPartnerRepo.getMyManagedPartners())
+          .thenAnswer((_) async => []);
+
+      final notifier =
+          container.read(createVerificationControllerProvider.notifier);
+      notifier.addField('text');
+
+      final result = await notifier.submit(null);
+
+      expect(result, isFalse);
+      expect(
+        container.read(createVerificationControllerProvider).error,
+        contains('파트너 정보를 찾을 수 없습니다'),
+      );
+    });
+
+    test('submit error sets error message', () async {
+      final container = makeContainer();
+      final sub = container.listen(
+        createVerificationControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      when(() => mockVerificationRepo.createVerification(any()))
+          .thenThrow(Exception('create failed'));
+
+      final notifier =
+          container.read(createVerificationControllerProvider.notifier);
+      notifier.addField('text');
+
+      final result = await notifier.submit('partner-1');
+
+      expect(result, isFalse);
+      expect(
+        container.read(createVerificationControllerProvider).error,
+        isNotNull,
+      );
+    });
+  });
+}

--- a/apps/app_partner/test/src/features/verification/create_verification_controller_test.dart
+++ b/apps/app_partner/test/src/features/verification/create_verification_controller_test.dart
@@ -6,10 +6,6 @@ import 'package:mocktail/mocktail.dart';
 import '../../../utils/mocks.dart';
 import '../../../utils/test_utils.dart';
 
-Future<void> pump() async {
-  await Future<void>.delayed(const Duration(milliseconds: 50));
-}
-
 void main() {
   late MockPartnerRepository mockPartnerRepo;
   late MockVerificationRepository mockVerificationRepo;

--- a/apps/app_partner/test/src/features/verification/verification_manage_controller_test.dart
+++ b/apps/app_partner/test/src/features/verification/verification_manage_controller_test.dart
@@ -1,6 +1,5 @@
 import 'package:app_partner/src/features/party/party_providers.dart';
 import 'package:app_partner/src/features/verification/manage/verification_manage_controller.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';

--- a/apps/app_partner/test/src/features/verification/verification_manage_controller_test.dart
+++ b/apps/app_partner/test/src/features/verification/verification_manage_controller_test.dart
@@ -1,0 +1,270 @@
+import 'package:app_partner/src/features/party/party_providers.dart';
+import 'package:app_partner/src/features/verification/manage/verification_manage_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../utils/mocks.dart';
+import '../../../utils/test_utils.dart';
+
+Future<void> pump() async {
+  await Future<void>.delayed(const Duration(milliseconds: 50));
+}
+
+Verification _makeVerification(String id, {bool isActive = true}) {
+  return Verification(
+    id: id,
+    partnerId: 'partner-1',
+    category: VerificationCategory.etc,
+    internalName: 'test_$id',
+    displayName: 'Test $id',
+    isActive: isActive,
+  );
+}
+
+void main() {
+  late MockVerificationRepository mockVerificationRepo;
+  late Partner fakePartner;
+
+  setUp(() {
+    mockVerificationRepo = MockVerificationRepository();
+    fakePartner = const Partner(id: 'partner-1', name: 'Test Partner');
+  });
+
+  ProviderContainer makeContainer({
+    Partner? partner,
+    bool nullPartner = false,
+    List<Verification>? activeList,
+    List<Verification>? archivedList,
+    Exception? loadError,
+  }) {
+    final resolvedPartner = nullPartner ? null : (partner ?? fakePartner);
+
+    if (loadError != null) {
+      when(
+        () => mockVerificationRepo.getPartnerVerifications(
+          any(),
+          isActive: any(named: 'isActive'),
+        ),
+      ).thenThrow(loadError);
+    } else {
+      // Active list
+      when(
+        () => mockVerificationRepo.getPartnerVerifications(
+          any(),
+          isActive: true,
+        ),
+      ).thenAnswer((_) async => activeList ?? []);
+
+      // Archived list
+      when(
+        () => mockVerificationRepo.getPartnerVerifications(
+          any(),
+          isActive: false,
+        ),
+      ).thenAnswer((_) async => archivedList ?? []);
+    }
+
+    return createContainer(
+      overrides: [
+        verificationRepositoryProvider
+            .overrideWithValue(mockVerificationRepo),
+        currentPartnerInfoProvider.overrideWith(
+          (ref) async => resolvedPartner,
+        ),
+      ],
+    );
+  }
+
+  group('VerificationManageController', () {
+    test('build loads active and archived lists', () async {
+      final active = [_makeVerification('v-1'), _makeVerification('v-2')];
+      final archived = [_makeVerification('v-3', isActive: false)];
+
+      final container = makeContainer(
+        activeList: active,
+        archivedList: archived,
+      );
+      final sub = container.listen(
+        verificationManageControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      // Wait for async build
+      await pump();
+
+      final state =
+          container.read(verificationManageControllerProvider).value!;
+      expect(state.active.length, 2);
+      expect(state.archived.length, 1);
+      expect(state.active.first.id, 'v-1');
+      expect(state.archived.first.id, 'v-3');
+    });
+
+    test('build with null partner returns empty state', () async {
+      final container = makeContainer(nullPartner: true);
+      final sub = container.listen(
+        verificationManageControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      await pump();
+
+      final state =
+          container.read(verificationManageControllerProvider).value!;
+      expect(state.active, isEmpty);
+      expect(state.archived, isEmpty);
+      verifyNever(
+        () => mockVerificationRepo.getPartnerVerifications(any()),
+      );
+    });
+
+    test('build error produces AsyncError', () async {
+      final container =
+          makeContainer(loadError: Exception('network error'));
+      final sub = container.listen(
+        verificationManageControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      await pump();
+
+      final asyncValue =
+          container.read(verificationManageControllerProvider);
+      expect(asyncValue.hasError, isTrue);
+    });
+
+    test('archiveVerification calls deleteVerification and refreshes',
+        () async {
+      final active = [_makeVerification('v-1')];
+      final container = makeContainer(activeList: active);
+      final sub = container.listen(
+        verificationManageControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      await pump();
+
+      when(() => mockVerificationRepo.deleteVerification(any()))
+          .thenAnswer((_) async {});
+
+      // After archive, active list will be empty
+      when(
+        () => mockVerificationRepo.getPartnerVerifications(
+          any(),
+          isActive: true,
+        ),
+      ).thenAnswer((_) async => []);
+      when(
+        () => mockVerificationRepo.getPartnerVerifications(
+          any(),
+          isActive: false,
+        ),
+      ).thenAnswer((_) async => [_makeVerification('v-1', isActive: false)]);
+
+      await container
+          .read(verificationManageControllerProvider.notifier)
+          .archiveVerification('v-1');
+
+      verify(() => mockVerificationRepo.deleteVerification('v-1')).called(1);
+
+      final state =
+          container.read(verificationManageControllerProvider).value!;
+      expect(state.active, isEmpty);
+      expect(state.archived.length, 1);
+    });
+
+    test('archiveVerification error sets AsyncError', () async {
+      final active = [_makeVerification('v-1')];
+      final container = makeContainer(activeList: active);
+      final sub = container.listen(
+        verificationManageControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      await pump();
+
+      when(() => mockVerificationRepo.deleteVerification(any()))
+          .thenThrow(Exception('delete failed'));
+
+      await container
+          .read(verificationManageControllerProvider.notifier)
+          .archiveVerification('v-1');
+
+      final asyncValue =
+          container.read(verificationManageControllerProvider);
+      expect(asyncValue.hasError, isTrue);
+    });
+
+    test('restoreVerification calls restoreVerification and refreshes',
+        () async {
+      final archived = [_makeVerification('v-1', isActive: false)];
+      final container = makeContainer(archivedList: archived);
+      final sub = container.listen(
+        verificationManageControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      await pump();
+
+      when(() => mockVerificationRepo.restoreVerification(any()))
+          .thenAnswer((_) async {});
+
+      // After restore, archived will be empty, active gains the item
+      when(
+        () => mockVerificationRepo.getPartnerVerifications(
+          any(),
+          isActive: true,
+        ),
+      ).thenAnswer((_) async => [_makeVerification('v-1')]);
+      when(
+        () => mockVerificationRepo.getPartnerVerifications(
+          any(),
+          isActive: false,
+        ),
+      ).thenAnswer((_) async => []);
+
+      await container
+          .read(verificationManageControllerProvider.notifier)
+          .restoreVerification('v-1');
+
+      verify(() => mockVerificationRepo.restoreVerification('v-1'))
+          .called(1);
+
+      final state =
+          container.read(verificationManageControllerProvider).value!;
+      expect(state.active.length, 1);
+      expect(state.archived, isEmpty);
+    });
+
+    test('restoreVerification error sets AsyncError', () async {
+      final archived = [_makeVerification('v-1', isActive: false)];
+      final container = makeContainer(archivedList: archived);
+      final sub = container.listen(
+        verificationManageControllerProvider,
+        (_, _) {},
+      );
+      addTearDown(sub.close);
+
+      await pump();
+
+      when(() => mockVerificationRepo.restoreVerification(any()))
+          .thenThrow(Exception('restore failed'));
+
+      await container
+          .read(verificationManageControllerProvider.notifier)
+          .restoreVerification('v-1');
+
+      final asyncValue =
+          container.read(verificationManageControllerProvider);
+      expect(asyncValue.hasError, isTrue);
+    });
+  });
+}

--- a/apps/app_partner/test/src/features/verification/verification_manage_controller_test.dart
+++ b/apps/app_partner/test/src/features/verification/verification_manage_controller_test.dart
@@ -1,5 +1,6 @@
 import 'package:app_partner/src/features/party/party_providers.dart';
 import 'package:app_partner/src/features/verification/manage/verification_manage_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
@@ -7,8 +8,13 @@ import 'package:mocktail/mocktail.dart';
 import '../../../utils/mocks.dart';
 import '../../../utils/test_utils.dart';
 
-Future<void> pump() async {
-  await Future<void>.delayed(const Duration(milliseconds: 50));
+/// Awaits until the VerificationManageController async build completes.
+/// Yields to the event loop to let the mocked async provider chain resolve.
+Future<void> waitForBuild(ProviderContainer container) async {
+  // Double yield: first for currentPartnerInfoProvider.future,
+  // second for the repo calls within Future.wait.
+  await Future<void>(() {});
+  await Future<void>(() {});
 }
 
 Verification _makeVerification(String id, {bool isActive = true}) {
@@ -42,11 +48,14 @@ void main() {
 
     if (loadError != null) {
       when(
+        () => mockVerificationRepo.getPartnerVerifications(any()),
+      ).thenAnswer((_) async => throw loadError);
+      when(
         () => mockVerificationRepo.getPartnerVerifications(
           any(),
           isActive: any(named: 'isActive'),
         ),
-      ).thenThrow(loadError);
+      ).thenAnswer((_) async => throw loadError);
     } else {
       // Active list
       when(
@@ -89,8 +98,7 @@ void main() {
       );
       addTearDown(sub.close);
 
-      // Wait for async build
-      await pump();
+      await waitForBuild(container);
 
       final state = container.read(verificationManageControllerProvider).value!;
       expect(state.active.length, 2);
@@ -107,7 +115,7 @@ void main() {
       );
       addTearDown(sub.close);
 
-      await pump();
+      await waitForBuild(container);
 
       final state = container.read(verificationManageControllerProvider).value!;
       expect(state.active, isEmpty);
@@ -125,7 +133,7 @@ void main() {
       );
       addTearDown(sub.close);
 
-      await pump();
+      await waitForBuild(container);
 
       final asyncValue = container.read(verificationManageControllerProvider);
       expect(asyncValue.hasError, isTrue);
@@ -142,7 +150,7 @@ void main() {
         );
         addTearDown(sub.close);
 
-        await pump();
+        await waitForBuild(container);
 
         when(
           () => mockVerificationRepo.deleteVerification(any()),
@@ -184,7 +192,7 @@ void main() {
       );
       addTearDown(sub.close);
 
-      await pump();
+      await waitForBuild(container);
 
       when(
         () => mockVerificationRepo.deleteVerification(any()),
@@ -209,7 +217,7 @@ void main() {
         );
         addTearDown(sub.close);
 
-        await pump();
+        await waitForBuild(container);
 
         when(
           () => mockVerificationRepo.restoreVerification(any()),
@@ -251,7 +259,7 @@ void main() {
       );
       addTearDown(sub.close);
 
-      await pump();
+      await waitForBuild(container);
 
       when(
         () => mockVerificationRepo.restoreVerification(any()),

--- a/apps/app_partner/test/src/features/verification/verification_manage_controller_test.dart
+++ b/apps/app_partner/test/src/features/verification/verification_manage_controller_test.dart
@@ -1,6 +1,5 @@
 import 'package:app_partner/src/features/party/party_providers.dart';
 import 'package:app_partner/src/features/verification/manage/verification_manage_controller.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
@@ -53,7 +52,6 @@ void main() {
       when(
         () => mockVerificationRepo.getPartnerVerifications(
           any(),
-          isActive: true,
         ),
       ).thenAnswer((_) async => activeList ?? []);
 
@@ -68,8 +66,7 @@ void main() {
 
     return createContainer(
       overrides: [
-        verificationRepositoryProvider
-            .overrideWithValue(mockVerificationRepo),
+        verificationRepositoryProvider.overrideWithValue(mockVerificationRepo),
         currentPartnerInfoProvider.overrideWith(
           (ref) async => resolvedPartner,
         ),
@@ -95,8 +92,7 @@ void main() {
       // Wait for async build
       await pump();
 
-      final state =
-          container.read(verificationManageControllerProvider).value!;
+      final state = container.read(verificationManageControllerProvider).value!;
       expect(state.active.length, 2);
       expect(state.archived.length, 1);
       expect(state.active.first.id, 'v-1');
@@ -113,8 +109,7 @@ void main() {
 
       await pump();
 
-      final state =
-          container.read(verificationManageControllerProvider).value!;
+      final state = container.read(verificationManageControllerProvider).value!;
       expect(state.active, isEmpty);
       expect(state.archived, isEmpty);
       verifyNever(
@@ -123,8 +118,7 @@ void main() {
     });
 
     test('build error produces AsyncError', () async {
-      final container =
-          makeContainer(loadError: Exception('network error'));
+      final container = makeContainer(loadError: Exception('network error'));
       final sub = container.listen(
         verificationManageControllerProvider,
         (_, _) {},
@@ -133,51 +127,53 @@ void main() {
 
       await pump();
 
-      final asyncValue =
-          container.read(verificationManageControllerProvider);
+      final asyncValue = container.read(verificationManageControllerProvider);
       expect(asyncValue.hasError, isTrue);
     });
 
-    test('archiveVerification calls deleteVerification and refreshes',
-        () async {
-      final active = [_makeVerification('v-1')];
-      final container = makeContainer(activeList: active);
-      final sub = container.listen(
-        verificationManageControllerProvider,
-        (_, _) {},
-      );
-      addTearDown(sub.close);
+    test(
+      'archiveVerification calls deleteVerification and refreshes',
+      () async {
+        final active = [_makeVerification('v-1')];
+        final container = makeContainer(activeList: active);
+        final sub = container.listen(
+          verificationManageControllerProvider,
+          (_, _) {},
+        );
+        addTearDown(sub.close);
 
-      await pump();
+        await pump();
 
-      when(() => mockVerificationRepo.deleteVerification(any()))
-          .thenAnswer((_) async {});
+        when(
+          () => mockVerificationRepo.deleteVerification(any()),
+        ).thenAnswer((_) async {});
 
-      // After archive, active list will be empty
-      when(
-        () => mockVerificationRepo.getPartnerVerifications(
-          any(),
-          isActive: true,
-        ),
-      ).thenAnswer((_) async => []);
-      when(
-        () => mockVerificationRepo.getPartnerVerifications(
-          any(),
-          isActive: false,
-        ),
-      ).thenAnswer((_) async => [_makeVerification('v-1', isActive: false)]);
+        // After archive, active list will be empty
+        when(
+          () => mockVerificationRepo.getPartnerVerifications(
+            any(),
+          ),
+        ).thenAnswer((_) async => []);
+        when(
+          () => mockVerificationRepo.getPartnerVerifications(
+            any(),
+            isActive: false,
+          ),
+        ).thenAnswer((_) async => [_makeVerification('v-1', isActive: false)]);
 
-      await container
-          .read(verificationManageControllerProvider.notifier)
-          .archiveVerification('v-1');
+        await container
+            .read(verificationManageControllerProvider.notifier)
+            .archiveVerification('v-1');
 
-      verify(() => mockVerificationRepo.deleteVerification('v-1')).called(1);
+        verify(() => mockVerificationRepo.deleteVerification('v-1')).called(1);
 
-      final state =
-          container.read(verificationManageControllerProvider).value!;
-      expect(state.active, isEmpty);
-      expect(state.archived.length, 1);
-    });
+        final state = container
+            .read(verificationManageControllerProvider)
+            .value!;
+        expect(state.active, isEmpty);
+        expect(state.archived.length, 1);
+      },
+    );
 
     test('archiveVerification error sets AsyncError', () async {
       final active = [_makeVerification('v-1')];
@@ -190,59 +186,61 @@ void main() {
 
       await pump();
 
-      when(() => mockVerificationRepo.deleteVerification(any()))
-          .thenThrow(Exception('delete failed'));
+      when(
+        () => mockVerificationRepo.deleteVerification(any()),
+      ).thenThrow(Exception('delete failed'));
 
       await container
           .read(verificationManageControllerProvider.notifier)
           .archiveVerification('v-1');
 
-      final asyncValue =
-          container.read(verificationManageControllerProvider);
+      final asyncValue = container.read(verificationManageControllerProvider);
       expect(asyncValue.hasError, isTrue);
     });
 
-    test('restoreVerification calls restoreVerification and refreshes',
-        () async {
-      final archived = [_makeVerification('v-1', isActive: false)];
-      final container = makeContainer(archivedList: archived);
-      final sub = container.listen(
-        verificationManageControllerProvider,
-        (_, _) {},
-      );
-      addTearDown(sub.close);
+    test(
+      'restoreVerification calls restoreVerification and refreshes',
+      () async {
+        final archived = [_makeVerification('v-1', isActive: false)];
+        final container = makeContainer(archivedList: archived);
+        final sub = container.listen(
+          verificationManageControllerProvider,
+          (_, _) {},
+        );
+        addTearDown(sub.close);
 
-      await pump();
+        await pump();
 
-      when(() => mockVerificationRepo.restoreVerification(any()))
-          .thenAnswer((_) async {});
+        when(
+          () => mockVerificationRepo.restoreVerification(any()),
+        ).thenAnswer((_) async {});
 
-      // After restore, archived will be empty, active gains the item
-      when(
-        () => mockVerificationRepo.getPartnerVerifications(
-          any(),
-          isActive: true,
-        ),
-      ).thenAnswer((_) async => [_makeVerification('v-1')]);
-      when(
-        () => mockVerificationRepo.getPartnerVerifications(
-          any(),
-          isActive: false,
-        ),
-      ).thenAnswer((_) async => []);
+        // After restore, archived will be empty, active gains the item
+        when(
+          () => mockVerificationRepo.getPartnerVerifications(
+            any(),
+          ),
+        ).thenAnswer((_) async => [_makeVerification('v-1')]);
+        when(
+          () => mockVerificationRepo.getPartnerVerifications(
+            any(),
+            isActive: false,
+          ),
+        ).thenAnswer((_) async => []);
 
-      await container
-          .read(verificationManageControllerProvider.notifier)
-          .restoreVerification('v-1');
+        await container
+            .read(verificationManageControllerProvider.notifier)
+            .restoreVerification('v-1');
 
-      verify(() => mockVerificationRepo.restoreVerification('v-1'))
-          .called(1);
+        verify(() => mockVerificationRepo.restoreVerification('v-1')).called(1);
 
-      final state =
-          container.read(verificationManageControllerProvider).value!;
-      expect(state.active.length, 1);
-      expect(state.archived, isEmpty);
-    });
+        final state = container
+            .read(verificationManageControllerProvider)
+            .value!;
+        expect(state.active.length, 1);
+        expect(state.archived, isEmpty);
+      },
+    );
 
     test('restoreVerification error sets AsyncError', () async {
       final archived = [_makeVerification('v-1', isActive: false)];
@@ -255,15 +253,15 @@ void main() {
 
       await pump();
 
-      when(() => mockVerificationRepo.restoreVerification(any()))
-          .thenThrow(Exception('restore failed'));
+      when(
+        () => mockVerificationRepo.restoreVerification(any()),
+      ).thenThrow(Exception('restore failed'));
 
       await container
           .read(verificationManageControllerProvider.notifier)
           .restoreVerification('v-1');
 
-      final asyncValue =
-          container.read(verificationManageControllerProvider);
+      final asyncValue = container.read(verificationManageControllerProvider);
       expect(asyncValue.hasError, isTrue);
     });
   });


### PR DESCRIPTION
## Summary
- `settlement_controller_test.dart` 추가 (6 tests): happy path, null partner, error, empty data, partnerId 검증
- `verification_manage_controller_test.dart` 추가 (7 tests): build, archive, restore + error cases
- `create_verification_controller_test.dart` 추가 (13 tests): state updates, field CRUD, reorder, submit 시나리오

Closes #216

## Test plan
- [x] `cd apps/app_partner && flutter test` 전체 통과 확인
- [ ] CI `ci-result` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)