### PR TITLE
test: Edge Function ↔ Flutter Contract 테스트 도입

### DIFF
--- a/shared/packages/minglit_kit/test/contract/contract_test.dart
+++ b/shared/packages/minglit_kit/test/contract/contract_test.dart
@@ -95,14 +95,15 @@ void main() {
     test('payment-cancel success has expected fields', () {
       final json = _loadSample('payment_cancel_success');
       expect(json['success'], true);
-      expect(json['data'], isA<Map>());
+      expect(json['data'], isA<Map<String, dynamic>>());
     });
 
     test('settlement-query settlements has expected fields', () {
       final json = _loadSample('settlement_query_settlements');
       expect(json['success'], true);
-      expect(json['settlements'], isA<List>());
-      final first = (json['settlements'] as List).first as Map;
+      expect(json['settlements'], isA<List<dynamic>>());
+      final settlements = json['settlements'] as List<dynamic>;
+      final first = settlements.first as Map<String, dynamic>;
       expect(first['id'], isA<String>());
       expect(first['partnerId'], isA<String>());
       expect(first['amount'], isA<num>());
@@ -112,8 +113,9 @@ void main() {
     test('settlement-query payouts has expected fields', () {
       final json = _loadSample('settlement_query_payouts');
       expect(json['success'], true);
-      expect(json['payouts'], isA<List>());
-      final first = (json['payouts'] as List).first as Map;
+      expect(json['payouts'], isA<List<dynamic>>());
+      final payouts = json['payouts'] as List<dynamic>;
+      final first = payouts.first as Map<String, dynamic>;
       expect(first['id'], isA<String>());
       expect(first['partnerId'], isA<String>());
       expect(first['amount'], isA<num>());
@@ -128,8 +130,8 @@ void main() {
     test('profile-update success has expected fields', () {
       final json = _loadSample('profile_update_success');
       expect(json['success'], true);
-      expect(json['processed'], isA<Map>());
-      final processed = json['processed'] as Map;
+      expect(json['processed'], isA<Map<String, dynamic>>());
+      final processed = json['processed'] as Map<String, dynamic>;
       expect(processed['user_id'], isA<String>());
       expect(processed['action_type'], isA<String>());
       expect(processed['weight'], isA<num>());

--- a/shared/packages/minglit_kit/test/contract/contract_test.dart
+++ b/shared/packages/minglit_kit/test/contract/contract_test.dart
@@ -57,8 +57,7 @@ void main() {
     test('round-trips through toJson → fromJson', () {
       final json = _loadSample('event_application');
       final model = EventApplication.fromJson(json);
-      final roundTripped =
-          EventApplication.fromJson(model.toJson());
+      final roundTripped = EventApplication.fromJson(model.toJson());
 
       expect(roundTripped.id, model.id);
       expect(roundTripped.eventId, model.eventId);
@@ -85,8 +84,7 @@ void main() {
     test('round-trips through toJson → fromJson', () {
       final json = _loadSample('user_profile');
       final model = UserProfile.fromJson(json);
-      final roundTripped =
-          UserProfile.fromJson(model.toJson());
+      final roundTripped = UserProfile.fromJson(model.toJson());
 
       expect(roundTripped.id, model.id);
       expect(roundTripped.name, model.name);
@@ -116,18 +114,15 @@ void main() {
     test(
       'settlement-query settlements has expected fields',
       () {
-        final json =
-            _loadSample('settlement_query_settlements');
+        final json = _loadSample('settlement_query_settlements');
         expect(json['success'], true);
         expect(
           json['settlements'],
           isA<List<dynamic>>(),
         );
-        final settlements =
-            json['settlements'] as List<dynamic>;
+        final settlements = json['settlements'] as List<dynamic>;
         expect(settlements, isNotEmpty);
-        final first =
-            settlements.first as Map<String, dynamic>;
+        final first = settlements.first as Map<String, dynamic>;
         expect(first['id'], isA<String>());
         expect(first['partnerId'], isA<String>());
         expect(first['amount'], isA<num>());
@@ -138,15 +133,12 @@ void main() {
     test(
       'settlement-query payouts has expected fields',
       () {
-        final json =
-            _loadSample('settlement_query_payouts');
+        final json = _loadSample('settlement_query_payouts');
         expect(json['success'], true);
         expect(json['payouts'], isA<List<dynamic>>());
-        final payouts =
-            json['payouts'] as List<dynamic>;
+        final payouts = json['payouts'] as List<dynamic>;
         expect(payouts, isNotEmpty);
-        final first =
-            payouts.first as Map<String, dynamic>;
+        final first = payouts.first as Map<String, dynamic>;
         expect(first['id'], isA<String>());
         expect(first['partnerId'], isA<String>());
         expect(first['amount'], isA<num>());
@@ -162,15 +154,13 @@ void main() {
     test(
       'profile-update success has expected fields',
       () {
-        final json =
-            _loadSample('profile_update_success');
+        final json = _loadSample('profile_update_success');
         expect(json['success'], true);
         expect(
           json['processed'],
           isA<Map<String, dynamic>>(),
         );
-        final processed =
-            json['processed'] as Map<String, dynamic>;
+        final processed = json['processed'] as Map<String, dynamic>;
         expect(processed['user_id'], isA<String>());
         expect(processed['action_type'], isA<String>());
         expect(processed['weight'], isA<num>());

--- a/shared/packages/minglit_kit/test/contract/contract_test.dart
+++ b/shared/packages/minglit_kit/test/contract/contract_test.dart
@@ -1,0 +1,138 @@
+/// Contract tests: verify that Flutter Freezed models can parse the shared
+/// JSON samples used by Edge Function contract tests.
+///
+/// If an Edge Function changes a field name, the shared sample is updated,
+/// and this test fails — catching the mismatch before runtime.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/data/models/event_application.dart';
+import 'package:minglit_kit/src/data/models/user_profile.dart';
+
+/// Resolve the shared schemas directory relative to the package root.
+String _samplesDir() {
+  // test is run from shared/packages/minglit_kit/
+  final packageRoot = Directory.current.path;
+  return '$packageRoot/../../../shared/schemas/samples';
+}
+
+Map<String, dynamic> _loadSample(String name) {
+  final file = File('${_samplesDir()}/$name.json');
+  if (!file.existsSync()) {
+    fail('Sample file not found: ${file.path}');
+  }
+  return jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+}
+
+void main() {
+  group('Contract: EventApplication model ↔ shared sample', () {
+    test('parses event_application sample without error', () {
+      final json = _loadSample('event_application');
+      final model = EventApplication.fromJson(json);
+
+      expect(model.id, 'app-001');
+      expect(model.eventId, 'evt-001');
+      expect(model.ticketId, 'tkt-001');
+      expect(model.userId, 'user-001');
+      expect(model.status, 'approved');
+      expect(model.paymentId, 'imp_123456789');
+      expect(model.paymentAmount, 15000);
+      expect(model.refundStatus, 'none');
+      expect(model.paidAt, isNotNull);
+    });
+
+    test('round-trips through toJson → fromJson', () {
+      final json = _loadSample('event_application');
+      final model = EventApplication.fromJson(json);
+      final roundTripped = EventApplication.fromJson(model.toJson());
+
+      expect(roundTripped.id, model.id);
+      expect(roundTripped.eventId, model.eventId);
+      expect(roundTripped.paymentId, model.paymentId);
+      expect(roundTripped.paymentAmount, model.paymentAmount);
+      expect(roundTripped.refundStatus, model.refundStatus);
+    });
+  });
+
+  group('Contract: UserProfile model ↔ shared sample', () {
+    test('parses user_profile sample without error', () {
+      final json = _loadSample('user_profile');
+      final model = UserProfile.fromJson(json);
+
+      expect(model.id, 'user-001');
+      expect(model.name, 'Test User');
+      expect(model.username, 'testuser');
+      expect(model.phoneNumber, '01012341234');
+      expect(model.gender, 'female');
+      expect(model.isVerified, true);
+      expect(model.birthDate, isNotNull);
+    });
+
+    test('round-trips through toJson → fromJson', () {
+      final json = _loadSample('user_profile');
+      final model = UserProfile.fromJson(json);
+      final roundTripped = UserProfile.fromJson(model.toJson());
+
+      expect(roundTripped.id, model.id);
+      expect(roundTripped.name, model.name);
+      expect(roundTripped.phoneNumber, model.phoneNumber);
+      expect(roundTripped.gender, model.gender);
+      expect(roundTripped.isVerified, model.isVerified);
+    });
+  });
+
+  group('Contract: Edge Function response shapes', () {
+    test('payment-verify success has expected fields', () {
+      final json = _loadSample('payment_verify_success');
+      expect(json['success'], true);
+      expect(json['imp_uid'], isA<String>());
+      expect((json['imp_uid'] as String).isNotEmpty, true);
+    });
+
+    test('payment-cancel success has expected fields', () {
+      final json = _loadSample('payment_cancel_success');
+      expect(json['success'], true);
+      expect(json['data'], isA<Map>());
+    });
+
+    test('settlement-query settlements has expected fields', () {
+      final json = _loadSample('settlement_query_settlements');
+      expect(json['success'], true);
+      expect(json['settlements'], isA<List>());
+      final first = (json['settlements'] as List).first as Map;
+      expect(first['id'], isA<String>());
+      expect(first['partnerId'], isA<String>());
+      expect(first['amount'], isA<num>());
+      expect(first['currency'], isA<String>());
+    });
+
+    test('settlement-query payouts has expected fields', () {
+      final json = _loadSample('settlement_query_payouts');
+      expect(json['success'], true);
+      expect(json['payouts'], isA<List>());
+      final first = (json['payouts'] as List).first as Map;
+      expect(first['id'], isA<String>());
+      expect(first['partnerId'], isA<String>());
+      expect(first['amount'], isA<num>());
+    });
+
+    test('identity-verify success has expected fields', () {
+      final json = _loadSample('identity_verify_success');
+      expect(json['success'], true);
+      expect(json['user'], isA<String>());
+    });
+
+    test('profile-update success has expected fields', () {
+      final json = _loadSample('profile_update_success');
+      expect(json['success'], true);
+      expect(json['processed'], isA<Map>());
+      final processed = json['processed'] as Map;
+      expect(processed['user_id'], isA<String>());
+      expect(processed['action_type'], isA<String>());
+      expect(processed['weight'], isA<num>());
+    });
+  });
+}

--- a/shared/packages/minglit_kit/test/contract/contract_test.dart
+++ b/shared/packages/minglit_kit/test/contract/contract_test.dart
@@ -13,10 +13,20 @@ import 'package:minglit_kit/src/data/models/event_application.dart';
 import 'package:minglit_kit/src/data/models/user_profile.dart';
 
 /// Resolve the shared schemas directory relative to the package root.
+/// Probes multiple candidate paths so the test works regardless of CWD.
 String _samplesDir() {
-  // test is run from shared/packages/minglit_kit/
-  final packageRoot = Directory.current.path;
-  return '$packageRoot/../../../shared/schemas/samples';
+  final cwd = Directory.current.path;
+  final candidates = <String>[
+    '$cwd/../../../shared/schemas/samples',
+    '$cwd/shared/schemas/samples',
+  ];
+
+  for (final path in candidates) {
+    if (Directory(path).existsSync()) return path;
+  }
+  throw StateError(
+    'shared/schemas/samples not found. cwd=$cwd',
+  );
 }
 
 Map<String, dynamic> _loadSample(String name) {
@@ -47,7 +57,8 @@ void main() {
     test('round-trips through toJson → fromJson', () {
       final json = _loadSample('event_application');
       final model = EventApplication.fromJson(json);
-      final roundTripped = EventApplication.fromJson(model.toJson());
+      final roundTripped =
+          EventApplication.fromJson(model.toJson());
 
       expect(roundTripped.id, model.id);
       expect(roundTripped.eventId, model.eventId);
@@ -74,7 +85,8 @@ void main() {
     test('round-trips through toJson → fromJson', () {
       final json = _loadSample('user_profile');
       final model = UserProfile.fromJson(json);
-      final roundTripped = UserProfile.fromJson(model.toJson());
+      final roundTripped =
+          UserProfile.fromJson(model.toJson());
 
       expect(roundTripped.id, model.id);
       expect(roundTripped.name, model.name);
@@ -89,7 +101,10 @@ void main() {
       final json = _loadSample('payment_verify_success');
       expect(json['success'], true);
       expect(json['imp_uid'], isA<String>());
-      expect((json['imp_uid'] as String).isNotEmpty, true);
+      expect(
+        (json['imp_uid'] as String).isNotEmpty,
+        true,
+      );
     });
 
     test('payment-cancel success has expected fields', () {
@@ -98,28 +113,45 @@ void main() {
       expect(json['data'], isA<Map<String, dynamic>>());
     });
 
-    test('settlement-query settlements has expected fields', () {
-      final json = _loadSample('settlement_query_settlements');
-      expect(json['success'], true);
-      expect(json['settlements'], isA<List<dynamic>>());
-      final settlements = json['settlements'] as List<dynamic>;
-      final first = settlements.first as Map<String, dynamic>;
-      expect(first['id'], isA<String>());
-      expect(first['partnerId'], isA<String>());
-      expect(first['amount'], isA<num>());
-      expect(first['currency'], isA<String>());
-    });
+    test(
+      'settlement-query settlements has expected fields',
+      () {
+        final json =
+            _loadSample('settlement_query_settlements');
+        expect(json['success'], true);
+        expect(
+          json['settlements'],
+          isA<List<dynamic>>(),
+        );
+        final settlements =
+            json['settlements'] as List<dynamic>;
+        expect(settlements, isNotEmpty);
+        final first =
+            settlements.first as Map<String, dynamic>;
+        expect(first['id'], isA<String>());
+        expect(first['partnerId'], isA<String>());
+        expect(first['amount'], isA<num>());
+        expect(first['currency'], isA<String>());
+      },
+    );
 
-    test('settlement-query payouts has expected fields', () {
-      final json = _loadSample('settlement_query_payouts');
-      expect(json['success'], true);
-      expect(json['payouts'], isA<List<dynamic>>());
-      final payouts = json['payouts'] as List<dynamic>;
-      final first = payouts.first as Map<String, dynamic>;
-      expect(first['id'], isA<String>());
-      expect(first['partnerId'], isA<String>());
-      expect(first['amount'], isA<num>());
-    });
+    test(
+      'settlement-query payouts has expected fields',
+      () {
+        final json =
+            _loadSample('settlement_query_payouts');
+        expect(json['success'], true);
+        expect(json['payouts'], isA<List<dynamic>>());
+        final payouts =
+            json['payouts'] as List<dynamic>;
+        expect(payouts, isNotEmpty);
+        final first =
+            payouts.first as Map<String, dynamic>;
+        expect(first['id'], isA<String>());
+        expect(first['partnerId'], isA<String>());
+        expect(first['amount'], isA<num>());
+      },
+    );
 
     test('identity-verify success has expected fields', () {
       final json = _loadSample('identity_verify_success');
@@ -127,14 +159,22 @@ void main() {
       expect(json['user'], isA<String>());
     });
 
-    test('profile-update success has expected fields', () {
-      final json = _loadSample('profile_update_success');
-      expect(json['success'], true);
-      expect(json['processed'], isA<Map<String, dynamic>>());
-      final processed = json['processed'] as Map<String, dynamic>;
-      expect(processed['user_id'], isA<String>());
-      expect(processed['action_type'], isA<String>());
-      expect(processed['weight'], isA<num>());
-    });
+    test(
+      'profile-update success has expected fields',
+      () {
+        final json =
+            _loadSample('profile_update_success');
+        expect(json['success'], true);
+        expect(
+          json['processed'],
+          isA<Map<String, dynamic>>(),
+        );
+        final processed =
+            json['processed'] as Map<String, dynamic>;
+        expect(processed['user_id'], isA<String>());
+        expect(processed['action_type'], isA<String>());
+        expect(processed['weight'], isA<num>());
+      },
+    );
   });
 }

--- a/shared/packages/minglit_kit/test/src/data/repositories/auth_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/auth_repository_test.dart
@@ -56,14 +56,14 @@ void main() {
     });
 
     group('onAuthStateChange', () {
-      test('returns auth state stream from auth client', () {
+      test('returns auth state stream from auth client', () async {
         final controller = StreamController<AuthState>();
         when(
           () => mockAuth.onAuthStateChange,
         ).thenAnswer((_) => controller.stream);
 
         expect(repository.onAuthStateChange, isA<Stream<AuthState>>());
-        controller.close();
+        await controller.close();
       });
     });
 

--- a/shared/packages/minglit_kit/test/src/data/repositories/auth_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/auth_repository_test.dart
@@ -56,14 +56,14 @@ void main() {
     });
 
     group('onAuthStateChange', () {
-      test('returns auth state stream from auth client', () async {
+      test('returns auth state stream from auth client', () {
         final controller = StreamController<AuthState>();
         when(
           () => mockAuth.onAuthStateChange,
         ).thenAnswer((_) => controller.stream);
 
         expect(repository.onAuthStateChange, isA<Stream<AuthState>>());
-        await controller.close();
+        unawaited(controller.close());
       });
     });
 

--- a/shared/packages/minglit_kit/test/src/data/repositories/settlement_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/settlement_repository_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unawaited_futures
+// ignore_for_file: unawaited_futures // test stubs fire-and-forget
 import 'dart:async' show FutureOr;
 
 import 'package:flutter_test/flutter_test.dart';

--- a/shared/packages/minglit_kit/test/src/features/search/logic/location_search_controller_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/search/logic/location_search_controller_test.dart
@@ -89,9 +89,8 @@ void main() {
 
       final notifier = container.read(
         locationSearchControllerProvider.notifier,
-      );
-
-      notifier.onSearchChanged('강남');
+      )
+        ..onSearchChanged('강남');
       await (notifier as _DirectSearchController).lastSearch;
 
       final state = container.read(locationSearchControllerProvider);
@@ -105,9 +104,8 @@ void main() {
 
       final notifier = container.read(
         locationSearchControllerProvider.notifier,
-      );
-
-      notifier.onSearchChanged('');
+      )
+        ..onSearchChanged('');
 
       final state = container.read(locationSearchControllerProvider);
       expect(state.value, isEmpty);
@@ -128,9 +126,8 @@ void main() {
 
       final notifier = container.read(
         locationSearchControllerProvider.notifier,
-      );
-
-      notifier.onSearchChanged('에러');
+      )
+        ..onSearchChanged('에러');
       await (notifier as _DirectSearchController).lastSearch;
 
       final state = container.read(locationSearchControllerProvider);

--- a/shared/packages/minglit_kit/test/src/features/search/logic/location_search_controller_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/search/logic/location_search_controller_test.dart
@@ -101,9 +101,9 @@ void main() {
       final container = createTestContainer();
       await container.read(locationSearchControllerProvider.future);
 
-      final notifier = container.read(
-        locationSearchControllerProvider.notifier,
-      )..onSearchChanged('');
+      container
+          .read(locationSearchControllerProvider.notifier)
+          .onSearchChanged('');
 
       final state = container.read(locationSearchControllerProvider);
       expect(state.value, isEmpty);

--- a/shared/packages/minglit_kit/test/src/features/search/logic/location_search_controller_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/search/logic/location_search_controller_test.dart
@@ -89,8 +89,7 @@ void main() {
 
       final notifier = container.read(
         locationSearchControllerProvider.notifier,
-      )
-        ..onSearchChanged('강남');
+      )..onSearchChanged('강남');
       await (notifier as _DirectSearchController).lastSearch;
 
       final state = container.read(locationSearchControllerProvider);
@@ -104,8 +103,7 @@ void main() {
 
       final notifier = container.read(
         locationSearchControllerProvider.notifier,
-      )
-        ..onSearchChanged('');
+      )..onSearchChanged('');
 
       final state = container.read(locationSearchControllerProvider);
       expect(state.value, isEmpty);
@@ -126,8 +124,7 @@ void main() {
 
       final notifier = container.read(
         locationSearchControllerProvider.notifier,
-      )
-        ..onSearchChanged('에러');
+      )..onSearchChanged('에러');
       await (notifier as _DirectSearchController).lastSearch;
 
       final state = container.read(locationSearchControllerProvider);

--- a/shared/packages/minglit_kit/test/src/features/social/logic/social_interaction_controller_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/social/logic/social_interaction_controller_test.dart
@@ -39,7 +39,7 @@ void main() {
           interactionType: interactionType,
         ).overrideWith(() {
           return _TestSocialInteractionController(
-            initialState,
+            initialState: initialState,
             hasUser: true,
           );
         }),
@@ -165,7 +165,7 @@ void main() {
             interactionType: interactionType,
           ).overrideWith(() {
             return _TestSocialInteractionController(
-              false,
+              initialState: false,
               hasUser: false,
             );
           }),
@@ -203,10 +203,10 @@ void main() {
 
 /// A test controller that bypasses the Supabase.instance dependency.
 class _TestSocialInteractionController extends SocialInteractionController {
-  _TestSocialInteractionController(
-    this._initialState, {
+  _TestSocialInteractionController({
+    required bool initialState,
     required this.hasUser,
-  });
+  }) : _initialState = initialState;
   final bool _initialState;
   final bool hasUser;
 

--- a/shared/schemas/responses/error.json
+++ b/shared/schemas/responses/error.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "error_response",
+  "title": "Standard error response",
+  "type": "object",
+  "required": ["error"],
+  "properties": {
+    "error": { "type": "string", "minLength": 1 },
+    "details": {}
+  },
+  "additionalProperties": false
+}

--- a/shared/schemas/responses/identity_verify.json
+++ b/shared/schemas/responses/identity_verify.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "identity_verify_success_response",
+  "title": "identity-verify success response",
+  "type": "object",
+  "required": ["success", "user"],
+  "properties": {
+    "success": { "type": "boolean", "const": true },
+    "user": { "type": "string", "minLength": 1 }
+  },
+  "additionalProperties": false
+}

--- a/shared/schemas/responses/payment_cancel.json
+++ b/shared/schemas/responses/payment_cancel.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "payment_cancel_success_response",
+  "title": "payment-cancel success response",
+  "type": "object",
+  "required": ["success", "data"],
+  "properties": {
+    "success": { "type": "boolean", "const": true },
+    "data": { "type": "object" }
+  },
+  "additionalProperties": false
+}

--- a/shared/schemas/responses/payment_verify.json
+++ b/shared/schemas/responses/payment_verify.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "payment_verify_success_response",
+  "title": "payment-verify success response",
+  "type": "object",
+  "required": ["success", "imp_uid"],
+  "properties": {
+    "success": { "type": "boolean", "const": true },
+    "imp_uid": { "type": "string", "minLength": 1 },
+    "message": { "type": "string" }
+  },
+  "additionalProperties": false
+}

--- a/shared/schemas/responses/profile_update.json
+++ b/shared/schemas/responses/profile_update.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "profile_update_success_response",
+  "title": "profile-update success response",
+  "type": "object",
+  "required": ["success", "processed"],
+  "properties": {
+    "success": { "type": "boolean", "const": true },
+    "processed": {
+      "type": "object",
+      "required": ["user_id", "action_type", "weight"],
+      "properties": {
+        "user_id": { "type": "string", "minLength": 1 },
+        "action_type": { "type": "string", "enum": ["view", "like", "purchase", "dislike"] },
+        "weight": { "type": "number" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/shared/schemas/responses/settlement_query.json
+++ b/shared/schemas/responses/settlement_query.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "settlement_query_success_response",
+  "title": "settlement-query success response",
+  "type": "object",
+  "required": ["success"],
+  "properties": {
+    "success": { "type": "boolean", "const": true },
+    "settlements": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "partnerId": { "type": "string" },
+          "transferId": { "type": "string" },
+          "amount": { "type": "number" },
+          "currency": { "type": "string" },
+          "settlementDate": { "type": "string" }
+        }
+      }
+    },
+    "payouts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "partnerId": { "type": "string" },
+          "amount": { "type": "number" },
+          "currency": { "type": "string" }
+        }
+      }
+    },
+    "page": { "type": "object" }
+  },
+  "oneOf": [
+    { "required": ["settlements"] },
+    { "required": ["payouts"] }
+  ],
+  "additionalProperties": true
+}

--- a/shared/schemas/responses/settlement_query.json
+++ b/shared/schemas/responses/settlement_query.json
@@ -10,6 +10,7 @@
       "type": "array",
       "items": {
         "type": "object",
+        "required": ["id", "partnerId", "amount", "currency", "settlementDate"],
         "properties": {
           "id": { "type": "string" },
           "partnerId": { "type": "string" },
@@ -24,6 +25,7 @@
       "type": "array",
       "items": {
         "type": "object",
+        "required": ["id", "partnerId", "amount", "currency"],
         "properties": {
           "id": { "type": "string" },
           "partnerId": { "type": "string" },
@@ -32,11 +34,19 @@
         }
       }
     },
-    "page": { "type": "object" }
+    "page": {
+      "type": "object",
+      "required": ["number", "size"],
+      "properties": {
+        "number": { "type": "integer" },
+        "size": { "type": "integer" }
+      },
+      "additionalProperties": false
+    }
   },
   "oneOf": [
     { "required": ["settlements"] },
     { "required": ["payouts"] }
   ],
-  "additionalProperties": true
+  "additionalProperties": false
 }

--- a/shared/schemas/samples/event_application.json
+++ b/shared/schemas/samples/event_application.json
@@ -1,0 +1,14 @@
+{
+  "id": "app-001",
+  "event_id": "evt-001",
+  "ticket_id": "tkt-001",
+  "user_id": "user-001",
+  "status": "approved",
+  "created_at": "2026-03-15T10:00:00.000Z",
+  "updated_at": "2026-03-15T10:05:00.000Z",
+  "payment_id": "imp_123456789",
+  "payment_amount": 15000,
+  "refund_status": "none",
+  "rejection_reason": null,
+  "paid_at": "2026-03-15T10:05:00.000Z"
+}

--- a/shared/schemas/samples/identity_verify_success.json
+++ b/shared/schemas/samples/identity_verify_success.json
@@ -1,0 +1,4 @@
+{
+  "success": true,
+  "user": "user-001"
+}

--- a/shared/schemas/samples/payment_cancel_success.json
+++ b/shared/schemas/samples/payment_cancel_success.json
@@ -1,0 +1,10 @@
+{
+  "success": true,
+  "data": {
+    "imp_uid": "imp_123456789",
+    "merchant_uid": "order-123",
+    "amount": 15000,
+    "cancel_amount": 15000,
+    "status": "cancelled"
+  }
+}

--- a/shared/schemas/samples/payment_verify_success.json
+++ b/shared/schemas/samples/payment_verify_success.json
@@ -1,0 +1,4 @@
+{
+  "success": true,
+  "imp_uid": "imp_123456789"
+}

--- a/shared/schemas/samples/profile_update_success.json
+++ b/shared/schemas/samples/profile_update_success.json
@@ -1,0 +1,8 @@
+{
+  "success": true,
+  "processed": {
+    "user_id": "user-001",
+    "action_type": "like",
+    "weight": 3
+  }
+}

--- a/shared/schemas/samples/settlement_query_payouts.json
+++ b/shared/schemas/samples/settlement_query_payouts.json
@@ -1,0 +1,12 @@
+{
+  "success": true,
+  "payouts": [
+    {
+      "id": "payout_001",
+      "partnerId": "partner-abc",
+      "amount": 95000,
+      "currency": "KRW"
+    }
+  ],
+  "page": { "number": 1, "size": 10 }
+}

--- a/shared/schemas/samples/settlement_query_settlements.json
+++ b/shared/schemas/samples/settlement_query_settlements.json
@@ -1,0 +1,14 @@
+{
+  "success": true,
+  "settlements": [
+    {
+      "id": "stl_001",
+      "partnerId": "partner-abc",
+      "transferId": "xfer-001",
+      "amount": 100000,
+      "currency": "KRW",
+      "settlementDate": "2026-03-20"
+    }
+  ],
+  "page": { "number": 1, "size": 10 }
+}

--- a/shared/schemas/samples/user_profile.json
+++ b/shared/schemas/samples/user_profile.json
@@ -1,0 +1,14 @@
+{
+  "id": "user-001",
+  "name": "Test User",
+  "username": "testuser",
+  "phone_number": "01012341234",
+  "gender": "female",
+  "birth_date": "1990-01-01T00:00:00.000Z",
+  "is_verified": true,
+  "birth_year": 1990,
+  "avatar_url": null,
+  "profile_image_url": null,
+  "created_at": "2026-01-01T00:00:00.000Z",
+  "updated_at": "2026-03-15T10:05:00.000Z"
+}

--- a/supabase/functions/_contract_tests/contract_test.ts
+++ b/supabase/functions/_contract_tests/contract_test.ts
@@ -171,6 +171,113 @@ Deno.test("contract: identity-verify response matches schema", async () => {
   });
 });
 
+Deno.test("contract: payment-cancel response matches schema", async () => {
+  const schema = await loadSchema("payment_cancel");
+
+  const nowMs = Date.now();
+  const eligiblePaidAt = new Date(nowMs - 1 * 60 * 60 * 1000).toISOString();
+  const farFutureEvent = new Date(nowMs + 10 * 24 * 60 * 60 * 1000).toISOString();
+
+  await withEnv(COMMON_ENV, async () => {
+    const handler = await captureServeHandler(
+      new URL("../payment-cancel/index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([
+      authRoute,
+      {
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/event_applications") && req.method === "GET",
+        handler: () =>
+          jsonResponse({
+            paid_at: eligiblePaidAt,
+            event_id: "event-123",
+            refund_status: "none",
+            user_id: "user-123",
+          }),
+      },
+      {
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/events") && req.method === "GET",
+        handler: () => jsonResponse({ start_time: farFutureEvent }),
+      },
+      {
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/rpc/get_current_policy") && req.method === "POST",
+        handler: () => jsonResponse({ grace_period_hours: 2, cutoff_days: 7 }),
+      },
+      {
+        matcher: "https://api.iamport.kr/users/getToken",
+        handler: () => jsonResponse({ code: 0, response: { access_token: "token" } }),
+      },
+      {
+        matcher: "https://api.iamport.kr/payments/cancel",
+        handler: () =>
+          jsonResponse({ code: 0, response: { status: "cancelled", amount: 15000 } }),
+      },
+      {
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/event_applications") && req.method === "PATCH",
+        handler: () => jsonResponse({}),
+      },
+    ]);
+
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          payment_id: "imp_contract_cancel",
+          reason: "contract test",
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const payload = await readJson(res);
+        assertMatchesSchema(payload, schema, "payment-cancel live response");
+      });
+    });
+  });
+});
+
+Deno.test("contract: settlement-query response matches schema", async () => {
+  const schema = await loadSchema("settlement_query");
+
+  await withEnv(COMMON_ENV, async () => {
+    const handler = await captureServeHandler(
+      new URL("../settlement-query/index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([
+      authRoute,
+      {
+        matcher: "https://api.portone.io/platform/partner-settlements",
+        handler: () =>
+          jsonResponse({
+            settlements: [
+              {
+                id: "s1",
+                partnerId: "p1",
+                transferId: "t1",
+                amount: 10000,
+                currency: "KRW",
+                settlementDate: "2026-03-20",
+              },
+            ],
+            page: { number: 0, size: 10 },
+          }),
+      },
+    ]);
+
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          type: "settlements",
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const payload = await readJson(res);
+        assertMatchesSchema(payload, schema, "settlement-query live response");
+      });
+    });
+  });
+});
+
 Deno.test("contract: payment-verify error matches error schema", async () => {
   const schema = await loadSchema("error");
 

--- a/supabase/functions/_contract_tests/contract_test.ts
+++ b/supabase/functions/_contract_tests/contract_test.ts
@@ -1,0 +1,193 @@
+/**
+ * Contract tests: validate Edge Function responses against shared JSON schemas.
+ *
+ * If an Edge Function changes a response field, this test fails — preventing
+ * silent breakage of the Flutter client.
+ */
+import { assertEquals } from "@std/assert";
+import { assertMatchesSchema, validateSchema } from "../_test_utils/schema_validator.ts";
+import {
+  authenticatedJsonRequest,
+  captureServeHandler,
+  createFetchMock,
+  jsonResponse,
+  readJson,
+  withEnv,
+  withMockedFetch,
+  withNoIntervals,
+} from "../_test_utils/mock_http.ts";
+import {
+  authRoute,
+  mockOrder,
+  mockPaidPayment,
+  mockPortoneVerification,
+  mockQueueUpdateMessage,
+} from "../_test_utils/fixtures.ts";
+
+// ── Schema & sample loaders ──────────────────────────────────────────
+
+const schemasDir = new URL("../../../shared/schemas/", import.meta.url);
+
+async function loadSchema(name: string): Promise<Record<string, unknown>> {
+  const path = new URL(`responses/${name}.json`, schemasDir);
+  return JSON.parse(await Deno.readTextFile(path));
+}
+
+async function loadSample(name: string): Promise<unknown> {
+  const path = new URL(`samples/${name}.json`, schemasDir);
+  return JSON.parse(await Deno.readTextFile(path));
+}
+
+// ── Sample files conform to schemas ──────────────────────────────────
+
+Deno.test("contract: sample payment_verify_success matches schema", async () => {
+  const schema = await loadSchema("payment_verify");
+  const sample = await loadSample("payment_verify_success");
+  assertMatchesSchema(sample, schema, "payment_verify_success sample");
+});
+
+Deno.test("contract: sample payment_cancel_success matches schema", async () => {
+  const schema = await loadSchema("payment_cancel");
+  const sample = await loadSample("payment_cancel_success");
+  assertMatchesSchema(sample, schema, "payment_cancel_success sample");
+});
+
+Deno.test("contract: sample settlement_query_settlements matches schema", async () => {
+  const schema = await loadSchema("settlement_query");
+  const sample = await loadSample("settlement_query_settlements");
+  assertMatchesSchema(sample, schema, "settlement_query_settlements sample");
+});
+
+Deno.test("contract: sample settlement_query_payouts matches schema", async () => {
+  const schema = await loadSchema("settlement_query");
+  const sample = await loadSample("settlement_query_payouts");
+  assertMatchesSchema(sample, schema, "settlement_query_payouts sample");
+});
+
+Deno.test("contract: sample profile_update_success matches schema", async () => {
+  const schema = await loadSchema("profile_update");
+  const sample = await loadSample("profile_update_success");
+  assertMatchesSchema(sample, schema, "profile_update_success sample");
+});
+
+Deno.test("contract: sample identity_verify_success matches schema", async () => {
+  const schema = await loadSchema("identity_verify");
+  const sample = await loadSample("identity_verify_success");
+  assertMatchesSchema(sample, schema, "identity_verify_success sample");
+});
+
+// ── Error response schema ────────────────────────────────────────────
+
+Deno.test("contract: error response schema validates standard errors", async () => {
+  const schema = await loadSchema("error");
+  assertMatchesSchema({ error: "Something went wrong" }, schema, "simple error");
+  assertMatchesSchema({ error: "Bad", details: { code: 123 } }, schema, "error with details");
+  const invalid = validateSchema({ message: "wrong shape" }, schema);
+  assertEquals(invalid.length > 0, true, "should reject non-conforming error");
+});
+
+// ── Live Edge Function response validation ───────────────────────────
+
+const COMMON_ENV = {
+  PORTONE_API_KEY: "test-key",
+  PORTONE_API_SECRET: "test-secret",
+  PORTONE_V2_API_KEY: "test-v2-key",
+  SUPABASE_URL: "https://supabase.test",
+  SUPABASE_SERVICE_ROLE_KEY: "service-key",
+};
+
+Deno.test("contract: payment-verify response matches schema", async () => {
+  const schema = await loadSchema("payment_verify");
+
+  await withEnv(COMMON_ENV, async () => {
+    const handler = await captureServeHandler(
+      new URL("../payment-verify/index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([
+      authRoute,
+      {
+        matcher: "https://api.iamport.kr/users/getToken",
+        handler: () => jsonResponse({ code: 0, response: { access_token: "token" } }),
+      },
+      {
+        matcher: "https://api.iamport.kr/payments/imp_contract",
+        handler: () => jsonResponse({ code: 0, response: { ...mockPaidPayment, merchant_uid: "order-contract" } }),
+      },
+      {
+        matcher: (req) => req.url.includes("/rest/v1/event_applications") && req.method === "GET",
+        handler: () => jsonResponse(mockOrder),
+      },
+      {
+        matcher: (req) => req.url.includes("/rest/v1/event_applications") && req.method === "PATCH",
+        handler: () => jsonResponse({}),
+      },
+    ]);
+
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          imp_uid: "imp_contract",
+          merchant_uid: "order-contract",
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const payload = await readJson(res);
+        assertMatchesSchema(payload, schema, "payment-verify live response");
+      });
+    });
+  });
+});
+
+Deno.test("contract: identity-verify response matches schema", async () => {
+  const schema = await loadSchema("identity_verify");
+
+  await withEnv(COMMON_ENV, async () => {
+    const handler = await captureServeHandler(
+      new URL("../identity-verify/index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([
+      authRoute,
+      {
+        matcher: "api.portone.io",
+        handler: () => jsonResponse(mockPortoneVerification),
+      },
+      {
+        matcher: (req) => req.url.includes("/rest/v1/user_profiles") && req.method === "PATCH",
+        handler: () => jsonResponse({}),
+      },
+    ]);
+
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          identity_verification_id: "iv_test_123",
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const payload = await readJson(res);
+        assertMatchesSchema(payload, schema, "identity-verify live response");
+      });
+    });
+  });
+});
+
+Deno.test("contract: payment-verify error matches error schema", async () => {
+  const schema = await loadSchema("error");
+
+  await withEnv(COMMON_ENV, async () => {
+    const handler = await captureServeHandler(
+      new URL("../payment-verify/index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([authRoute]);
+
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const req = authenticatedJsonRequest("http://localhost", {});
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+        const payload = await readJson(res);
+        assertMatchesSchema(payload, schema, "payment-verify error response");
+      });
+    });
+  });
+});

--- a/supabase/functions/_test_utils/schema_validator.ts
+++ b/supabase/functions/_test_utils/schema_validator.ts
@@ -1,0 +1,140 @@
+/**
+ * Lightweight JSON Schema (Draft 2020-12 subset) validator for contract tests.
+ *
+ * Supports: type, required, properties, additionalProperties, const, enum,
+ * minLength, items, oneOf, and nested objects/arrays.
+ */
+
+type Schema = Record<string, unknown>;
+
+interface ValidationError {
+  path: string;
+  message: string;
+}
+
+export function validateSchema(
+  data: unknown,
+  schema: Schema,
+  path = "$",
+): ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  // const
+  if ("const" in schema) {
+    if (data !== schema.const) {
+      errors.push({ path, message: `expected const ${JSON.stringify(schema.const)}, got ${JSON.stringify(data)}` });
+    }
+  }
+
+  // enum
+  if ("enum" in schema && Array.isArray(schema.enum)) {
+    if (!schema.enum.includes(data)) {
+      errors.push({ path, message: `expected one of [${schema.enum.join(", ")}], got ${JSON.stringify(data)}` });
+    }
+  }
+
+  // type
+  if ("type" in schema) {
+    const expectedType = schema.type as string;
+    if (!matchesType(data, expectedType)) {
+      errors.push({ path, message: `expected type "${expectedType}", got ${typeof data}` });
+      return errors; // skip further checks if type doesn't match
+    }
+  }
+
+  // minLength (string)
+  if ("minLength" in schema && typeof data === "string") {
+    if (data.length < (schema.minLength as number)) {
+      errors.push({ path, message: `string length ${data.length} < minLength ${schema.minLength}` });
+    }
+  }
+
+  // object checks
+  if (typeof data === "object" && data !== null && !Array.isArray(data)) {
+    const obj = data as Record<string, unknown>;
+
+    // required
+    if ("required" in schema && Array.isArray(schema.required)) {
+      for (const key of schema.required) {
+        if (!(key in obj)) {
+          errors.push({ path: `${path}.${key}`, message: `missing required property "${key}"` });
+        }
+      }
+    }
+
+    // properties
+    if ("properties" in schema && typeof schema.properties === "object") {
+      const props = schema.properties as Record<string, Schema>;
+      for (const [key, propSchema] of Object.entries(props)) {
+        if (key in obj) {
+          errors.push(...validateSchema(obj[key], propSchema, `${path}.${key}`));
+        }
+      }
+    }
+
+    // additionalProperties
+    if ("additionalProperties" in schema && schema.additionalProperties === false) {
+      const allowedKeys = new Set(
+        Object.keys((schema.properties ?? {}) as Record<string, unknown>),
+      );
+      for (const key of Object.keys(obj)) {
+        if (!allowedKeys.has(key)) {
+          errors.push({ path: `${path}.${key}`, message: `unexpected additional property "${key}"` });
+        }
+      }
+    }
+  }
+
+  // array items
+  if (Array.isArray(data) && "items" in schema && typeof schema.items === "object") {
+    const itemSchema = schema.items as Schema;
+    for (let i = 0; i < data.length; i++) {
+      errors.push(...validateSchema(data[i], itemSchema, `${path}[${i}]`));
+    }
+  }
+
+  // oneOf
+  if ("oneOf" in schema && Array.isArray(schema.oneOf)) {
+    const matchCount = schema.oneOf.filter(
+      (sub: unknown) => validateSchema(data, sub as Schema, path).length === 0,
+    ).length;
+    if (matchCount === 0) {
+      errors.push({ path, message: "does not match any oneOf schema" });
+    }
+  }
+
+  return errors;
+}
+
+function matchesType(data: unknown, expectedType: string): boolean {
+  switch (expectedType) {
+    case "string":
+      return typeof data === "string";
+    case "number":
+    case "integer":
+      return typeof data === "number";
+    case "boolean":
+      return typeof data === "boolean";
+    case "object":
+      return typeof data === "object" && data !== null && !Array.isArray(data);
+    case "array":
+      return Array.isArray(data);
+    case "null":
+      return data === null;
+    default:
+      return true;
+  }
+}
+
+/** Validates data against a schema and throws on failure. */
+export function assertMatchesSchema(
+  data: unknown,
+  schema: Schema,
+  label = "data",
+): void {
+  const errors = validateSchema(data, schema);
+  if (errors.length > 0) {
+    const details = errors.map((e) => `  ${e.path}: ${e.message}`).join("\n");
+    throw new Error(`${label} does not match schema:\n${details}`);
+  }
+}


### PR DESCRIPTION
## Summary
- `shared/schemas/` 에 JSON Schema 정의 (5개 핵심 Edge Function 응답 + 에러 공통) 및 샘플 JSON 생성
- Deno 계약 테스트: Edge Function 응답이 스키마에 맞는지 검증 (10 tests)
- Flutter 계약 테스트: Freezed 모델이 공유 샘플 JSON을 파싱할 수 있는지 검증 (10 tests)
- 한쪽이 응답 필드를 변경하면 양쪽 CI에서 즉시 실패

Closes #219

## 대상 Edge Functions
- `payment-verify` ↔ `EventApplication`
- `payment-cancel` ↔ cancel result
- `settlement-query` ↔ settlement/payout
- `profile-update` ↔ processed result
- `identity-verify` ↔ `UserProfile`

## Test plan
- [x] Deno contract tests 전체 통과 (10/10)
- [x] Flutter contract tests 전체 통과 (10/10)
- [ ] CI `ci-result` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)