### PR TITLE
fix(ci): daily CUJ script for-loop syntax error

### DIFF
--- a/.github/workflows/daily-e2e.yml
+++ b/.github/workflows/daily-e2e.yml
@@ -55,10 +55,7 @@ jobs:
           disable-animations: true
           working-directory: tests/client_cuj_integration
           script: |
-            # Fix #259: android-emulator-runner executes each line as separate sh -c call,
-            # so the for-loop must be a single line to avoid "expecting done" syntax error
-            DART_DEFINES="--dart-define=SUPABASE_URL=${{ secrets.SUPABASE_DEV_URL }} --dart-define=SUPABASE_PUBLISHABLE_KEY=${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }} --dart-define=SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_DEV_SECRET_KEY }}"
-            for test_file in integration_test/cuj/*_test.dart; do echo "▶ Running $test_file" && flutter test "$test_file" --reporter expanded $DART_DEFINES || exit 1; done
+            for test_file in integration_test/cuj/*_test.dart; do echo "▶ Running $test_file" && flutter test "$test_file" --reporter expanded --dart-define=SUPABASE_URL=${{ secrets.SUPABASE_DEV_URL }} --dart-define=SUPABASE_PUBLISHABLE_KEY=${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }} --dart-define=SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_DEV_SECRET_KEY }} || exit 1; done
 
   notify-failure:
     needs: [client-cuj-test]

--- a/.github/workflows/daily-e2e.yml
+++ b/.github/workflows/daily-e2e.yml
@@ -55,11 +55,10 @@ jobs:
           disable-animations: true
           working-directory: tests/client_cuj_integration
           script: |
+            # Fix #259: android-emulator-runner executes each line as separate sh -c call,
+            # so the for-loop must be a single line to avoid "expecting done" syntax error
             DART_DEFINES="--dart-define=SUPABASE_URL=${{ secrets.SUPABASE_DEV_URL }} --dart-define=SUPABASE_PUBLISHABLE_KEY=${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }} --dart-define=SUPABASE_SERVICE_ROLE_KEY=${{ secrets.SUPABASE_DEV_SECRET_KEY }}"
-            for test_file in integration_test/cuj/*_test.dart; do
-              echo "▶ Running $test_file"
-              flutter test "$test_file" --reporter expanded $DART_DEFINES || exit 1
-            done
+            for test_file in integration_test/cuj/*_test.dart; do echo "▶ Running $test_file" && flutter test "$test_file" --reporter expanded $DART_DEFINES || exit 1; done
 
   notify-failure:
     needs: [client-cuj-test]


### PR DESCRIPTION
## Summary
- `android-emulator-runner` action이 `script:` 블록의 각 줄을 별도 `sh -c`로 실행하여 for 루프가 깨지는 문제 수정
- for-loop을 단일 라인으로 변경하여 정상 실행되도록 함

Closes #259

## Test plan
- [ ] Daily CUJ workflow를 수동 실행(`workflow_dispatch`)하여 for-loop이 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)