### PR TITLE
fix: 아키텍처 감사 항목 수정 — 문서 동기화 + import 통일

### DIFF
--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -96,8 +96,8 @@ Minglit의 Supabase 기반 백엔드 인프라를 기술한다.
 | `file_access_grants` | 파일 접근 권한 | file_id, viewer_id, expires_at |
 | `settlements` | 정산 (레거시) | partner_id, event_id, total_sales, net_amount, status — [상세](./payment-pipeline.md) |
 | `report_details` | 신고 상세 정보 | social_interaction_id, target_type, reason, description |
-| `system_settings` | 시스템 설정 키-값 | key (PK), value jsonb, description |
-| `policies` | 약관/정책 버전 관리 | key, value jsonb, version, effective_date |
+| `system_settings` | 시스템 설정 키-값 | key (PK), value jsonb, description, updated_at, updated_by |
+| `policies` | 약관/정책 버전 관리 | id (PK uuid), key, value jsonb, version, effective_date, description, created_at |
 
 #### Settlement v2 (정산 파이프라인 v2)
 
@@ -227,9 +227,9 @@ Supabase Edge Functions는 Deno 런타임 기반이며, `supabase/functions/` �
 |--------|-----|---------|
 | `portone_client.ts` | 209 | Portone V2 API 클라이언트 (결제 검증, 취소) |
 | `iamport_client.ts` | 63 | Iamport V1 레거시 API 래퍼 |
-| `logger.ts` | — | 구조화 로깅 (Axiom 연동, Sentry 래퍼) |
-| `axiom_logger.ts` | — | Axiom 로그 전송 클라이언트 |
-| `statsig_utils.ts` | — | Statsig 피처 플래그 / 이벤트 로깅 |
+| `logger.ts` | 124 | 구조화 로깅 (Axiom 연동, Sentry 래퍼) |
+| `axiom_logger.ts` | 130 | Axiom 로그 전송 클라이언트 |
+| `statsig_utils.ts` | 115 | Statsig 피처 플래그 / 이벤트 로깅 |
 | `worker_utils.ts` | 58 | PGMQ 워커 유틸 (중복 체크, DLQ, 지연 로깅) |
 | `auth_utils.ts` | 38 | 인증 유틸 (`requireAuth` — Bearer 토큰 → `auth.getUser()`) |
 | `response_utils.ts` | 33 | HTTP 응답 헬퍼 (CORS, JSON/에러 응답) |

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -41,7 +41,7 @@ Minglit의 Supabase 기반 백엔드 인프라를 기술한다.
 
 ### 2.1 Table Inventory
 
-총 **44개 테이블** + **4개 뷰** + **3개 PGMQ 큐 테이블** + **4개 analytics 테이블**.
+총 **44개 테이블(analytics 스키마 4개 포함)** + **4개 뷰** + **3개 PGMQ 큐 테이블**.
 
 #### Core (사용자/파트너)
 
@@ -409,13 +409,15 @@ User B ──vote──> User A
 
 ## 10. Error Handling & Monitoring
 
-### Sentry Integration
+### Logging & Monitoring
 
-`sentry_utils.ts`가 Edge Function 에러 트래킹을 담당한다:
+`logger.ts`가 Edge Function의 구조화 로깅과 에러 트래킹을 담당한다:
 
-- `initSentry()` — SENTRY_DSN 환경변수가 있을 때만 초기화 (없으면 no-op)
-- `withSentry()` — `serve()` 패턴용 래퍼
-- `withSentryHandler()` — `Deno.serve()` 패턴용 래퍼
+- `initSentry()` — Sentry 초기화 (SENTRY_DSN 환경변수가 있을 때만, 없으면 no-op)
+- `withHandler()` — `Deno.serve()` 래퍼 (Sentry + 구조화 로깅)
+- `log` — 구조화 로깅 객체 (`log.info()`, `log.error()` 등)
+- `axiom_logger.ts` — Axiom으로 로그 전송
+- `statsig_utils.ts` — Statsig 피처 플래그 및 이벤트 로깅 (`initStatsig()`, `logStatsigEvent()`)
 - 환경 구분: `ENVIRONMENT` 환경변수 (local/dev/prod)
 - `tracesSampleRate`: 0.2 (20%)
 

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -41,7 +41,7 @@ Minglit의 Supabase 기반 백엔드 인프라를 기술한다.
 
 ### 2.1 Table Inventory
 
-총 **29개 테이블** + **4개 뷰** + **3개 PGMQ 큐 테이블**.
+총 **44개 테이블** + **4개 뷰** + **3개 PGMQ 큐 테이블** + **4개 analytics 테이블**.
 
 #### Core (사용자/파트너)
 
@@ -94,8 +94,33 @@ Minglit의 Supabase 기반 백엔드 인프라를 기술한다.
 | `match_pairs` | 매칭 결과 | event_id, user_lower_id, user_higher_id, matched_at |
 | `minglit_files` | 파일 메타데이터 | storage_object_id, bucket_id, file_path, owner_id |
 | `file_access_grants` | 파일 접근 권한 | file_id, viewer_id, expires_at |
-| `settlements` | 정산 | partner_id, event_id, total_sales, net_amount, status — [상세](./payment-pipeline.md) |
+| `settlements` | 정산 (레거시) | partner_id, event_id, total_sales, net_amount, status — [상세](./payment-pipeline.md) |
 | `report_details` | 신고 상세 정보 | social_interaction_id, target_type, reason, description |
+| `system_settings` | 시스템 설정 키-값 | key (PK), value jsonb, description |
+| `policies` | 약관/정책 버전 관리 | key, value jsonb, version, effective_date |
+
+#### Settlement v2 (정산 파이프라인 v2)
+
+| Table | Purpose | Key Columns |
+|-------|---------|-------------|
+| `settlement_items` | 정산 항목 (v2) | partner_id, source_type, source_id, status, gross_amount, net_amount, version |
+| `settlement_histories` | 정산 상태 변경 이력 | settlement_item_id, event_type, actor_type, from_status, to_status |
+| `payouts` | 지급 건 | partner_id, payout_period_start/end, status, total_net_amount |
+| `payout_transfers` | 지급 이체 시도 | payout_id, provider, status, amount, attempt_no, idempotency_key |
+| `adjustment_items` | 조정 항목 (환불/차감/보정) | partner_id, adjustment_type, amount_signed, status |
+| `business_calendar` | 영업일 달력 | date (PK), is_business_day, reason |
+| `reconciliation_runs` | 일일 대사 실행 | run_date, run_type, status, matched_count, mismatched_count |
+| `reconciliation_results` | 대사 불일치 결과 | run_id, settlement_item_id, mismatch_type, severity |
+| `settlement_alarm_results` | 정산 모니터링 알람 | alarm_type, severity, message, metric_value, threshold |
+
+#### Analytics (분석)
+
+| Table | Schema | Purpose | Key Columns |
+|-------|--------|---------|-------------|
+| `daily_active_users` | analytics | 일별 활성 사용자 | date, app, count |
+| `daily_events` | analytics | 일별 이벤트 집계 | date, event_name, count |
+| `daily_revenue` | analytics | 일별 매출 집계 | date, gross, net, refunds |
+| `funnel_daily` | analytics | 일별 퍼널 전환율 | date, step, count, conversion_rate |
 
 #### PGMQ Infrastructure
 
@@ -189,6 +214,12 @@ Supabase Edge Functions는 Deno 런타임 기반이며, `supabase/functions/` �
 | `health` | System | 시스템 헬스 체크 |
 | `dev-seed` | Dev | 테스트 데이터 시딩 (dev only) |
 | `dev-session-switch` | Dev | 테스트 유저 전환 (dev only) |
+| `backend-simulator` | Dev | 백엔드 시뮬레이터 (dev only) |
+| `dev-mock-portone` | Dev | Portone 목업 서버 (dev only) |
+| `metrics-alert` | Monitoring | 정산 메트릭 알람 발송 |
+| `payout-sync` | Payment | 지급 상태 동기화 |
+| `reconciliation-daily` | Payment | 일일 대사 (PG ↔ DB 불일치 검출) |
+| `settlement-register-transfers` | Payment | 정산 이체 등록 |
 
 ### 3.2 Shared Modules (`_shared/`)
 
@@ -196,7 +227,9 @@ Supabase Edge Functions는 Deno 런타임 기반이며, `supabase/functions/` �
 |--------|-----|---------|
 | `portone_client.ts` | 209 | Portone V2 API 클라이언트 (결제 검증, 취소) |
 | `iamport_client.ts` | 63 | Iamport V1 레거시 API 래퍼 |
-| `sentry_utils.ts` | 105 | Sentry 에러 트래킹 (`withSentry`, `withSentryHandler`) |
+| `logger.ts` | — | 구조화 로깅 (Axiom 연동, Sentry 래퍼) |
+| `axiom_logger.ts` | — | Axiom 로그 전송 클라이언트 |
+| `statsig_utils.ts` | — | Statsig 피처 플래그 / 이벤트 로깅 |
 | `worker_utils.ts` | 58 | PGMQ 워커 유틸 (중복 체크, DLQ, 지연 로깅) |
 | `auth_utils.ts` | 38 | 인증 유틸 (`requireAuth` — Bearer 토큰 → `auth.getUser()`) |
 | `response_utils.ts` | 33 | HTTP 응답 헬퍼 (CORS, JSON/에러 응답) |

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -41,7 +41,7 @@ Minglit의 Supabase 기반 백엔드 인프라를 기술한다.
 
 ### 2.1 Table Inventory
 
-총 **44개 테이블(analytics 스키마 4개 포함)** + **4개 뷰** + **3개 PGMQ 큐 테이블**.
+총 **49개 테이블(analytics 스키마 4개 포함)** + **4개 뷰** + **3개 PGMQ 큐 테이블**.
 
 #### Core (사용자/파트너)
 

--- a/docs/architecture/client.md
+++ b/docs/architecture/client.md
@@ -30,7 +30,8 @@ minglit_kit/lib/src/features/
 ├── notification/   # 푸시 알림, FCM, 알림 목록/설정
 ├── search/         # 전문 검색 (PGroonga)
 ├── social/         # 소셜 기능 (좋아요, 구독, 차단)
-└── theme/          # 테마 모드 컨트롤러 (라이트/다크/시스템)
+├── theme/          # 테마 모드 컨트롤러 (라이트/다크/시스템)
+└── verification/   # 인증 UI 컴포넌트 (인증 제출/심사 관련)
 ```
 
 ### 2.2 Coordinator Pattern (Navigation)

--- a/supabase/functions/_shared/auth_utils.ts
+++ b/supabase/functions/_shared/auth_utils.ts
@@ -1,3 +1,4 @@
+// Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
 import { createClient } from "@supabase/supabase-js";
 import { errorResponse } from "./response_utils.ts";
 

--- a/supabase/functions/_shared/auth_utils.ts
+++ b/supabase/functions/_shared/auth_utils.ts
@@ -1,4 +1,4 @@
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "@supabase/supabase-js";
 import { errorResponse } from "./response_utils.ts";
 
 /**

--- a/supabase/functions/identity-verify/index.ts
+++ b/supabase/functions/identity-verify/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "@supabase/supabase-js";
 import { PortoneV2Client } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";

--- a/supabase/functions/identity-verify/index.ts
+++ b/supabase/functions/identity-verify/index.ts
@@ -1,3 +1,4 @@
+// Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
 import { createClient } from "@supabase/supabase-js";
 import { PortoneV2Client } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";

--- a/supabase/functions/partner-sync/index.ts
+++ b/supabase/functions/partner-sync/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "@supabase/supabase-js";
 import { PortoneV2Client } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";

--- a/supabase/functions/partner-sync/index.ts
+++ b/supabase/functions/partner-sync/index.ts
@@ -1,3 +1,4 @@
+// Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
 import { createClient } from "@supabase/supabase-js";
 import { PortoneV2Client } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";

--- a/supabase/functions/payment-cancel/index.ts
+++ b/supabase/functions/payment-cancel/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "@supabase/supabase-js";
 import { IamportClient } from "../_shared/iamport_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";

--- a/supabase/functions/payment-cancel/index.ts
+++ b/supabase/functions/payment-cancel/index.ts
@@ -1,3 +1,4 @@
+// Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
 import { createClient } from "@supabase/supabase-js";
 import { IamportClient } from "../_shared/iamport_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";

--- a/supabase/functions/payment-verify/index.ts
+++ b/supabase/functions/payment-verify/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "@supabase/supabase-js";
 import { IamportClient } from "../_shared/iamport_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";

--- a/supabase/functions/payment-verify/index.ts
+++ b/supabase/functions/payment-verify/index.ts
@@ -1,3 +1,4 @@
+// Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
 import { createClient } from "@supabase/supabase-js";
 import { IamportClient } from "../_shared/iamport_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";

--- a/supabase/functions/payment-webhook/index.ts
+++ b/supabase/functions/payment-webhook/index.ts
@@ -2,7 +2,7 @@
 // 현재: IP whitelist만 사용 (ALLOWED_IPS)
 // 추가 필요: 포트원 V1 webhook signature 검증 또는 HMAC 검증
 // 참고: V1은 HMAC 미지원이므로 IP whitelist가 1차 보안. 추가 보안 레이어 검토 필요.
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "@supabase/supabase-js";
 import { IamportClient } from "../_shared/iamport_client.ts";
 import { initSentry, withHandler, log } from "../_shared/logger.ts";
 import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";

--- a/supabase/functions/payment-webhook/index.ts
+++ b/supabase/functions/payment-webhook/index.ts
@@ -2,6 +2,7 @@
 // 현재: IP whitelist만 사용 (ALLOWED_IPS)
 // 추가 필요: 포트원 V1 webhook signature 검증 또는 HMAC 검증
 // 참고: V1은 HMAC 미지원이므로 IP whitelist가 1차 보안. 추가 보안 레이어 검토 필요.
+// Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
 import { createClient } from "@supabase/supabase-js";
 import { IamportClient } from "../_shared/iamport_client.ts";
 import { initSentry, withHandler, log } from "../_shared/logger.ts";

--- a/supabase/functions/payout-sync/index.ts
+++ b/supabase/functions/payout-sync/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "@supabase/supabase-js";
 import { PortoneV2Client } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";

--- a/supabase/functions/payout-sync/index.ts
+++ b/supabase/functions/payout-sync/index.ts
@@ -1,3 +1,4 @@
+// Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
 import { createClient } from "@supabase/supabase-js";
 import { PortoneV2Client } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";

--- a/supabase/functions/reconciliation-daily/index.ts
+++ b/supabase/functions/reconciliation-daily/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "@supabase/supabase-js";
 import { PortoneV2Client, PortoneSettlement } from "../_shared/portone_client.ts";
 import { initSentry, withHandler } from "../_shared/logger.ts";
 

--- a/supabase/functions/reconciliation-daily/index.ts
+++ b/supabase/functions/reconciliation-daily/index.ts
@@ -1,3 +1,4 @@
+// Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
 import { createClient } from "@supabase/supabase-js";
 import { PortoneV2Client, PortoneSettlement } from "../_shared/portone_client.ts";
 import { initSentry, withHandler } from "../_shared/logger.ts";

--- a/supabase/functions/settlement-register-transfers/index.ts
+++ b/supabase/functions/settlement-register-transfers/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "@supabase/supabase-js";
 import { PortoneV2Client } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";

--- a/supabase/functions/settlement-register-transfers/index.ts
+++ b/supabase/functions/settlement-register-transfers/index.ts
@@ -1,3 +1,4 @@
+// Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
 import { createClient } from "@supabase/supabase-js";
 import { PortoneV2Client } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";

--- a/supabase/functions/settlement-transfer/index.ts
+++ b/supabase/functions/settlement-transfer/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "@supabase/supabase-js";
 import { PortoneV2Client } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";

--- a/supabase/functions/settlement-transfer/index.ts
+++ b/supabase/functions/settlement-transfer/index.ts
@@ -1,3 +1,4 @@
+// Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
 import { createClient } from "@supabase/supabase-js";
 import { PortoneV2Client } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";


### PR DESCRIPTION
## Summary

Closes #179

- **backend.md**: 누락된 테이블 15개(settlement v2 9개, analytics 4개, policies, system_settings), Edge Function 6개, shared 모듈 3개(logger, axiom_logger, statsig_utils) 추가
- **client.md**: `verification` 피처 누락 추가
- **Edge Functions**: `esm.sh` 직접 URL import를 `deno.json` import map 기반 `@supabase/supabase-js`로 통일 (10개 파일)

### 감사 항목 처리 현황

| # | 항목 | 상태 |
|---|------|------|
| 6 | createClient 보일러플레이트 중복 | ⏳ 후속 PR |
| 7 | import 경로 불일치 (`esm.sh` 혼용) | ✅ 이 PR |
| 8 | 미등록 테이블 (backend.md) | ✅ 이 PR |
| 9 | 미등록 Edge Function (backend.md) | ✅ 이 PR |
| 10 | 미등록 피처 (client.md) | ✅ 이 PR |
| 1-5 | Feature 격리 위반 (cross-feature import) | ⏳ 후속 PR |

## Test plan

- [ ] CI `test-edge-functions` 통과 확인 (import 경로 변경이 deno.json import map으로 정상 해소되는지)
- [ ] 문서 내용 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)