### PR TITLE
feat(ci): Allure 리포트 개선 — 커버리지 표시 + 자동 라벨링

### DIFF
--- a/.github/workflows/allure-report.yml
+++ b/.github/workflows/allure-report.yml
@@ -20,6 +20,7 @@ jobs:
           ref: gh-pages
           path: gh-pages-content
 
+      # ── Download Allure Results ──
       - name: Download Allure Results (app_user)
         uses: dawidd6/action-download-artifact@v9
         with:
@@ -47,6 +48,35 @@ jobs:
           if_no_artifact_found: warn
         continue-on-error: true
 
+      # ── Download Coverage Artifacts ──
+      - name: Download Coverage (app_user)
+        uses: dawidd6/action-download-artifact@v9
+        with:
+          workflow: ci.yml
+          name: app-user-coverage
+          path: coverage/app_user/
+          if_no_artifact_found: warn
+        continue-on-error: true
+
+      - name: Download Coverage (app_partner)
+        uses: dawidd6/action-download-artifact@v9
+        with:
+          workflow: ci.yml
+          name: app-partner-coverage
+          path: coverage/app_partner/
+          if_no_artifact_found: warn
+        continue-on-error: true
+
+      - name: Download Coverage (minglit_kit)
+        uses: dawidd6/action-download-artifact@v9
+        with:
+          workflow: ci.yml
+          name: minglit-kit-coverage
+          path: coverage/minglit_kit/
+          if_no_artifact_found: warn
+        continue-on-error: true
+
+      # ── Copy previous history for trend tracking ──
       - name: Copy previous history for trend tracking
         run: |
           if [ -d "gh-pages-content/history" ]; then
@@ -56,6 +86,101 @@ jobs:
             echo "No previous history found — first run"
           fi
 
+      # ── Generate Allure metadata files ──
+      - name: Generate Allure metadata
+        run: |
+          mkdir -p allure-results
+
+          # categories.json — failure type classification
+          cat > allure-results/categories.json <<'CATEOF'
+          [
+            {"name": "Test Defects", "matchedStatuses": ["failed"]},
+            {"name": "Infrastructure Issues", "matchedStatuses": ["broken"]},
+            {"name": "Skipped / Disabled", "matchedStatuses": ["skipped"]}
+          ]
+          CATEOF
+
+          # executor.json — CI link
+          cat > allure-results/executor.json <<EXEOF
+          {
+            "name": "GitHub Actions",
+            "type": "github",
+            "buildName": "Daily Report #${GITHUB_RUN_NUMBER}",
+            "buildUrl": "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}",
+            "reportUrl": "https://mark-yun.github.io/minglit/"
+          }
+          EXEOF
+
+          # environment.properties — build info + coverage
+          cat > allure-results/environment.properties <<ENVEOF
+          Report.Date=$(date -u +%Y-%m-%d)
+          Flutter.Channel=stable
+          Repository=${GITHUB_REPOSITORY}
+          Branch=dev
+          ENVEOF
+
+          # Parse coverage from lcov.info and append to environment.properties
+          calc_coverage() {
+            local lcov_file="$1"
+            if [ -f "$lcov_file" ]; then
+              awk -F: '/^LF:/{total+=$2} /^LH:/{hit+=$2} END{if(total>0) printf "%.1f%%", hit/total*100; else print "N/A"}' "$lcov_file"
+            else
+              echo "N/A"
+            fi
+          }
+
+          calc_feature_coverage() {
+            local lcov_file="$1"
+            local project="$2"
+            if [ ! -f "$lcov_file" ]; then return; fi
+
+            # Extract unique feature names from SF: lines (features/<name>/)
+            grep '^SF:' "$lcov_file" | sed -n 's|.*features/\([^/]*\)/.*|\1|p' | sort -u | while read -r feature; do
+              if [ -n "$feature" ]; then
+                # Filter lcov data for this feature and compute coverage
+                local cov
+                cov=$(awk -v feat="features/${feature}/" -F: '
+                  /^SF:/ { match_feat = index($0, feat) > 0 }
+                  match_feat && /^LF:/ { total += $2 }
+                  match_feat && /^LH:/ { hit += $2 }
+                  END { if(total>0) printf "%.1f%%", hit/total*100; else print "N/A" }
+                ' "$lcov_file")
+                echo "Coverage.${project}.${feature}=${cov}" >> allure-results/environment.properties
+              fi
+            done
+          }
+
+          # Project-level coverage
+          TOTAL_LF=0
+          TOTAL_LH=0
+          for proj in app_user app_partner minglit_kit; do
+            lcov="coverage/${proj}/lcov.info"
+            cov=$(calc_coverage "$lcov")
+            echo "Coverage.${proj}=${cov}" >> allure-results/environment.properties
+
+            if [ -f "$lcov" ]; then
+              lf=$(awk -F: '/^LF:/{s+=$2} END{print s+0}' "$lcov")
+              lh=$(awk -F: '/^LH:/{s+=$2} END{print s+0}' "$lcov")
+              TOTAL_LF=$((TOTAL_LF + lf))
+              TOTAL_LH=$((TOTAL_LH + lh))
+            fi
+
+            # Per-feature coverage
+            calc_feature_coverage "$lcov" "$proj"
+          done
+
+          if [ "$TOTAL_LF" -gt 0 ]; then
+            total_pct=$(awk "BEGIN{printf \"%.1f%%\", ${TOTAL_LH}/${TOTAL_LF}*100}")
+          else
+            total_pct="N/A"
+          fi
+          # Prepend total to top of coverage section
+          sed -i "/^Coverage\./i Coverage.Total=${total_pct}" allure-results/environment.properties
+
+          echo "📊 Environment properties:"
+          cat allure-results/environment.properties
+
+      # ── Generate and Deploy ──
       - name: Generate Allure Report
         run: npx allure-commandline generate allure-results/ -o allure-report/ --clean
         continue-on-error: true

--- a/apps/app_partner/test/reporter.dart
+++ b/apps/app_partner/test/reporter.dart
@@ -1,6 +1,7 @@
-import 'package:allure_report/allure_report.dart';
 import 'package:test_reporter/test_reporter.dart';
 
+import 'utils/auto_label_allure_reporter.dart';
+
 TestReporter create() {
-  return AllureReporter();
+  return AutoLabelAllureReporter();
 }

--- a/apps/app_partner/test/utils/auto_label_allure_reporter.dart
+++ b/apps/app_partner/test/utils/auto_label_allure_reporter.dart
@@ -1,0 +1,34 @@
+import 'package:allure_report/allure_report.dart';
+import 'package:allure_report/src/test_report.dart';
+
+/// AllureReporter that auto-derives epic/feature labels from test file paths.
+///
+/// Uses the convention `features/<feature>/<layer>/` to extract:
+/// - epic: feature name (e.g. auth, event, payment)
+/// - feature: layer name (e.g. logic, ui, data)
+class AutoLabelAllureReporter extends AllureReporter {
+  static final _featureRegex = RegExp(r'features/(\w+)');
+  static final _layerRegex = RegExp(r'features/\w+/(\w+)');
+
+  @override
+  Future<void> onReportCreated(TestReport report) async {
+    final test = report.start?.test;
+    if (test == null) return super.onReportCreated(report);
+
+    final suitePath = suites[test.suiteID]?.path ?? '';
+
+    final featureMatch = _featureRegex.firstMatch(suitePath);
+    if (featureMatch != null) {
+      extraLabels.putIfAbsent(test.id, () => {})['epic'] =
+          featureMatch.group(1)!;
+    }
+
+    final layerMatch = _layerRegex.firstMatch(suitePath);
+    if (layerMatch != null) {
+      extraLabels.putIfAbsent(test.id, () => {})['feature'] =
+          layerMatch.group(1)!;
+    }
+
+    return super.onReportCreated(report);
+  }
+}

--- a/apps/app_partner/test/utils/auto_label_allure_reporter.dart
+++ b/apps/app_partner/test/utils/auto_label_allure_reporter.dart
@@ -19,14 +19,16 @@ class AutoLabelAllureReporter extends AllureReporter {
 
     final featureMatch = _featureRegex.firstMatch(suitePath);
     if (featureMatch != null) {
-      extraLabels.putIfAbsent(test.id, () => {})['epic'] =
-          featureMatch.group(1)!;
+      extraLabels.putIfAbsent(test.id, () => {})['epic'] = featureMatch.group(
+        1,
+      )!;
     }
 
     final layerMatch = _layerRegex.firstMatch(suitePath);
     if (layerMatch != null) {
-      extraLabels.putIfAbsent(test.id, () => {})['feature'] =
-          layerMatch.group(1)!;
+      extraLabels.putIfAbsent(test.id, () => {})['feature'] = layerMatch.group(
+        1,
+      )!;
     }
 
     return super.onReportCreated(report);

--- a/apps/app_user/test/reporter.dart
+++ b/apps/app_user/test/reporter.dart
@@ -1,6 +1,7 @@
-import 'package:allure_report/allure_report.dart';
 import 'package:test_reporter/test_reporter.dart';
 
+import 'utils/auto_label_allure_reporter.dart';
+
 TestReporter create() {
-  return AllureReporter();
+  return AutoLabelAllureReporter();
 }

--- a/apps/app_user/test/utils/auto_label_allure_reporter.dart
+++ b/apps/app_user/test/utils/auto_label_allure_reporter.dart
@@ -1,0 +1,34 @@
+import 'package:allure_report/allure_report.dart';
+import 'package:allure_report/src/test_report.dart';
+
+/// AllureReporter that auto-derives epic/feature labels from test file paths.
+///
+/// Uses the convention `features/<feature>/<layer>/` to extract:
+/// - epic: feature name (e.g. auth, event, payment)
+/// - feature: layer name (e.g. logic, ui, data)
+class AutoLabelAllureReporter extends AllureReporter {
+  static final _featureRegex = RegExp(r'features/(\w+)');
+  static final _layerRegex = RegExp(r'features/\w+/(\w+)');
+
+  @override
+  Future<void> onReportCreated(TestReport report) async {
+    final test = report.start?.test;
+    if (test == null) return super.onReportCreated(report);
+
+    final suitePath = suites[test.suiteID]?.path ?? '';
+
+    final featureMatch = _featureRegex.firstMatch(suitePath);
+    if (featureMatch != null) {
+      extraLabels.putIfAbsent(test.id, () => {})['epic'] =
+          featureMatch.group(1)!;
+    }
+
+    final layerMatch = _layerRegex.firstMatch(suitePath);
+    if (layerMatch != null) {
+      extraLabels.putIfAbsent(test.id, () => {})['feature'] =
+          layerMatch.group(1)!;
+    }
+
+    return super.onReportCreated(report);
+  }
+}

--- a/apps/app_user/test/utils/auto_label_allure_reporter.dart
+++ b/apps/app_user/test/utils/auto_label_allure_reporter.dart
@@ -19,14 +19,16 @@ class AutoLabelAllureReporter extends AllureReporter {
 
     final featureMatch = _featureRegex.firstMatch(suitePath);
     if (featureMatch != null) {
-      extraLabels.putIfAbsent(test.id, () => {})['epic'] =
-          featureMatch.group(1)!;
+      extraLabels.putIfAbsent(test.id, () => {})['epic'] = featureMatch.group(
+        1,
+      )!;
     }
 
     final layerMatch = _layerRegex.firstMatch(suitePath);
     if (layerMatch != null) {
-      extraLabels.putIfAbsent(test.id, () => {})['feature'] =
-          layerMatch.group(1)!;
+      extraLabels.putIfAbsent(test.id, () => {})['feature'] = layerMatch.group(
+        1,
+      )!;
     }
 
     return super.onReportCreated(report);

--- a/shared/packages/minglit_kit/test/reporter.dart
+++ b/shared/packages/minglit_kit/test/reporter.dart
@@ -1,6 +1,7 @@
-import 'package:allure_report/allure_report.dart';
 import 'package:test_reporter/test_reporter.dart';
 
+import 'utils/auto_label_allure_reporter.dart';
+
 TestReporter create() {
-  return AllureReporter();
+  return AutoLabelAllureReporter();
 }

--- a/shared/packages/minglit_kit/test/utils/auto_label_allure_reporter.dart
+++ b/shared/packages/minglit_kit/test/utils/auto_label_allure_reporter.dart
@@ -1,0 +1,36 @@
+import 'package:allure_report/allure_report.dart';
+import 'package:allure_report/src/test_report.dart';
+
+/// AllureReporter that auto-derives epic/feature labels from test file paths.
+///
+/// Uses the convention `features/<feature>/<layer>/` to extract:
+/// - epic: feature name (e.g. auth, event, payment)
+/// - feature: layer name (e.g. logic, ui, data)
+///
+/// Zero test file changes required.
+class AutoLabelAllureReporter extends AllureReporter {
+  static final _featureRegex = RegExp(r'features/(\w+)');
+  static final _layerRegex = RegExp(r'features/\w+/(\w+)');
+
+  @override
+  Future<void> onReportCreated(TestReport report) async {
+    final test = report.start?.test;
+    if (test == null) return super.onReportCreated(report);
+
+    final suitePath = suites[test.suiteID]?.path ?? '';
+
+    final featureMatch = _featureRegex.firstMatch(suitePath);
+    if (featureMatch != null) {
+      extraLabels.putIfAbsent(test.id, () => {})['epic'] =
+          featureMatch.group(1)!;
+    }
+
+    final layerMatch = _layerRegex.firstMatch(suitePath);
+    if (layerMatch != null) {
+      extraLabels.putIfAbsent(test.id, () => {})['feature'] =
+          layerMatch.group(1)!;
+    }
+
+    return super.onReportCreated(report);
+  }
+}

--- a/shared/packages/minglit_kit/test/utils/auto_label_allure_reporter.dart
+++ b/shared/packages/minglit_kit/test/utils/auto_label_allure_reporter.dart
@@ -21,14 +21,16 @@ class AutoLabelAllureReporter extends AllureReporter {
 
     final featureMatch = _featureRegex.firstMatch(suitePath);
     if (featureMatch != null) {
-      extraLabels.putIfAbsent(test.id, () => {})['epic'] =
-          featureMatch.group(1)!;
+      extraLabels.putIfAbsent(test.id, () => {})['epic'] = featureMatch.group(
+        1,
+      )!;
     }
 
     final layerMatch = _layerRegex.firstMatch(suitePath);
     if (layerMatch != null) {
-      extraLabels.putIfAbsent(test.id, () => {})['feature'] =
-          layerMatch.group(1)!;
+      extraLabels.putIfAbsent(test.id, () => {})['feature'] = layerMatch.group(
+        1,
+      )!;
     }
 
     return super.onReportCreated(report);


### PR DESCRIPTION
## Summary
- Allure Overview에 프로젝트별/피쳐별 코드 커버리지 표시 (lcov.info 파싱)
- 테스트 자동 라벨링 — `features/<name>/<layer>/` 경로에서 Epic/Feature 추출
- 메타데이터 추가: categories.json (실패 유형 분류), executor.json (CI 링크), environment.properties (빌드 정보)

### Allure Overview에 표시되는 정보
```
Coverage.Total=75.2%
Coverage.app_user=72.3%
Coverage.minglit_kit=85.4%
Coverage.minglit_kit.auth=88.0%
...
```

### Behaviors 탭 그룹핑 (자동)
- Epic: `auth`, `event`, `payment`, `iamport` 등 (features 폴더명)
- Feature: `logic`, `ui`, `data` 등 (레이어명)
- 테스트 파일 변경 0개 — AllureReporter 상속으로 구현

## Test plan
- [x] minglit_kit 로컬 테스트 실행 → allure-results에 epic/feature 라벨 확인 (74/599)
- [ ] CI 통과 확인
- [ ] 머지 후 `workflow_dispatch`로 allure-report 수동 트리거
- [ ] https://mark-yun.github.io/minglit/ 에서 커버리지 + Behaviors 탭 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)