### PR TITLE
fix: 코드 품질 감사 런타임 에러 9건 수정 (#270)

### DIFF
--- a/apps/app_partner/lib/main.dart
+++ b/apps/app_partner/lib/main.dart
@@ -67,7 +67,9 @@ Future<void> main() async {
             Sentry.captureException(error, stackTrace: stackTrace),
       ),
     );
-  } on Object catch (_) {
+  } on Object catch (e, st) {
+    // Fix #270: 초기화 에러 로깅 — 에러 삼킴 방지
+    debugPrint('Sentry init failed: $e\n$st');
     startApp();
   }
 }

--- a/apps/app_partner/lib/src/features/member/partner_member_list_page.dart
+++ b/apps/app_partner/lib/src/features/member/partner_member_list_page.dart
@@ -116,7 +116,9 @@ class PartnerMemberListPage extends ConsumerWidget {
         ),
         trailing: const Icon(Icons.settings, size: MinglitIconSize.small),
         onTap: () {
-          final targetUserId = member['user_id'] as String;
+          // Fix #270: dynamic map에서 안전 캐스팅 — null이면 무시
+          final targetUserId = member['user_id'] as String?;
+          if (targetUserId == null) return;
           ref
               .read(memberCoordinatorProvider.notifier)
               .goToMemberPermission(partnerId, targetUserId);

--- a/apps/app_partner/lib/src/features/member/partner_member_permission_page.dart
+++ b/apps/app_partner/lib/src/features/member/partner_member_permission_page.dart
@@ -111,7 +111,8 @@ class _MemberPermissionFormState extends ConsumerState<_MemberPermissionForm> {
   @override
   void initState() {
     super.initState();
-    _selectedRole = widget.memberData['role'] as String;
+    // Fix #270: dynamic map에서 안전 캐스팅 — null이면 기본값 사용
+    _selectedRole = widget.memberData['role'] as String? ?? 'member';
     _currentPermissions = List<String>.from(
       widget.memberData['permissions'] as Iterable<dynamic>? ?? [],
     );
@@ -121,7 +122,16 @@ class _MemberPermissionFormState extends ConsumerState<_MemberPermissionForm> {
     setState(() => _isSaving = true);
     try {
       final repository = ref.read(partnerRepositoryProvider);
-      final userId = widget.memberData['user_id'] as String;
+      // Fix #270: dynamic map에서 안전 캐스팅
+      final userId = widget.memberData['user_id'] as String?;
+      if (userId == null) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('사용자 정보를 확인할 수 없습니다')),
+          );
+        }
+        return;
+      }
 
       await repository.updateMemberRole(
         partnerId: widget.partnerId,

--- a/apps/app_partner/lib/src/features/member/partner_member_permission_page.dart
+++ b/apps/app_partner/lib/src/features/member/partner_member_permission_page.dart
@@ -111,8 +111,10 @@ class _MemberPermissionFormState extends ConsumerState<_MemberPermissionForm> {
   @override
   void initState() {
     super.initState();
-    // Fix #270: dynamic map에서 안전 캐스팅 — null이면 기본값 사용
-    _selectedRole = widget.memberData['role'] as String? ?? 'member';
+    // Fix #270: dynamic map에서 안전 캐스팅 — Dropdown 항목에 없는 값이면 'staff' 사용
+    final rawRole = widget.memberData['role'] as String?;
+    const allowedRoles = {'owner', 'manager', 'staff'};
+    _selectedRole = allowedRoles.contains(rawRole) ? rawRole! : 'staff';
     _currentPermissions = List<String>.from(
       widget.memberData['permissions'] as Iterable<dynamic>? ?? [],
     );

--- a/apps/app_partner/lib/src/features/onboarding/widgets/address_search_dialog.dart
+++ b/apps/app_partner/lib/src/features/onboarding/widgets/address_search_dialog.dart
@@ -60,8 +60,29 @@ class _AddressSearchDialogState extends State<AddressSearchDialog> {
       client.close();
 
       final decoded = jsonDecode(body) as Map<String, dynamic>;
-      final results = decoded['results'] as Map<String, dynamic>;
-      final common = results['common'] as Map<String, dynamic>;
+      // Fix #270: 외부 API 응답 안전 캐스팅 — API 변경 시 TypeError 방지
+      final results = decoded['results'];
+      if (results is! Map<String, dynamic>) {
+        if (mounted) {
+          setState(() {
+            _errorMessage = '주소 검색 응답 형식이 올바르지 않습니다';
+            _results = [];
+            _isLoading = false;
+          });
+        }
+        return;
+      }
+      final common = results['common'];
+      if (common is! Map<String, dynamic>) {
+        if (mounted) {
+          setState(() {
+            _errorMessage = '주소 검색 응답 형식이 올바르지 않습니다';
+            _results = [];
+            _isLoading = false;
+          });
+        }
+        return;
+      }
       final errorCode = common['errorCode'] as String? ?? '';
 
       if (errorCode != '0') {

--- a/apps/app_partner/test/src/features/member/partner_member_permission_page_test.dart
+++ b/apps/app_partner/test/src/features/member/partner_member_permission_page_test.dart
@@ -1,0 +1,135 @@
+import 'package:app_partner/src/features/member/partner_member_permission_page.dart';
+import 'package:app_partner/src/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../utils/mocks.dart';
+
+void main() {
+  late MockPartnerRepository mockRepo;
+
+  setUp(() {
+    mockRepo = MockPartnerRepository();
+  });
+
+  Widget buildTestWidget({
+    required String partnerId,
+    required String targetUserId,
+    required Map<String, dynamic>? memberData,
+  }) {
+    return ProviderScope(
+      overrides: [
+        partnerRepositoryProvider.overrideWithValue(mockRepo),
+        partnerMemberProvider(
+          partnerId: partnerId,
+          targetUserId: targetUserId,
+        ).overrideWith((ref) async => memberData),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: PartnerMemberPermissionPage(
+          partnerId: partnerId,
+          targetUserId: targetUserId,
+        ),
+      ),
+    );
+  }
+
+  group('PartnerMemberPermissionPage — Fix #270 회귀 테스트', () {
+    testWidgets('unknown role "member" defaults to "staff" without crash',
+        (tester) async {
+      final memberData = {
+        'user_id': 'u1',
+        'role': 'member', // Dropdown에 없는 값
+        'permissions': <String>[],
+        'user': {'name': 'Test User', 'email': 'test@test.com'},
+      };
+
+      await tester.pumpWidget(buildTestWidget(
+        partnerId: 'p1',
+        targetUserId: 'u1',
+        memberData: memberData,
+      ));
+      await tester.pump();
+      await tester.pump();
+
+      // Dropdown이 'staff'로 렌더링되어야 함 (member는 허용 목록에 없으므로)
+      expect(find.byType(DropdownButton<String>), findsOneWidget);
+      // No assertion error = success
+    });
+
+    testWidgets('null role defaults to "staff" without crash', (tester) async {
+      final memberData = {
+        'user_id': 'u1',
+        'role': null,
+        'permissions': <String>[],
+        'user': {'name': 'Test User', 'email': 'test@test.com'},
+      };
+
+      await tester.pumpWidget(buildTestWidget(
+        partnerId: 'p1',
+        targetUserId: 'u1',
+        memberData: memberData,
+      ));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.byType(DropdownButton<String>), findsOneWidget);
+    });
+
+    testWidgets('valid role "manager" is used as-is', (tester) async {
+      final memberData = {
+        'user_id': 'u1',
+        'role': 'manager',
+        'permissions': <String>['PARTY_MANAGE'],
+        'user': {'name': 'Test User', 'email': 'test@test.com'},
+      };
+
+      await tester.pumpWidget(buildTestWidget(
+        partnerId: 'p1',
+        targetUserId: 'u1',
+        memberData: memberData,
+      ));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.byType(DropdownButton<String>), findsOneWidget);
+    });
+
+    testWidgets('null user_id aborts save without calling repository',
+        (tester) async {
+      final memberData = {
+        'user_id': null, // null user_id
+        'role': 'staff',
+        'permissions': <String>[],
+        'user': {'name': 'Test User', 'email': 'test@test.com'},
+      };
+
+      await tester.pumpWidget(buildTestWidget(
+        partnerId: 'p1',
+        targetUserId: 'u1',
+        memberData: memberData,
+      ));
+      await tester.pump();
+      await tester.pump();
+
+      // 저장 버튼 탭 — 크래시 없이 처리되어야 함
+      final saveButton = find.byType(ElevatedButton);
+      expect(saveButton, findsOneWidget);
+      await tester.tap(saveButton);
+      await tester.pumpAndSettle();
+
+      // Repository 호출 없음 확인 — null user_id로 DB 호출 시도하지 않아야 함
+      verifyNever(
+        () => mockRepo.updateMemberRole(
+          partnerId: any(named: 'partnerId'),
+          userId: any(named: 'userId'),
+          role: any(named: 'role'),
+        ),
+      );
+    });
+  });
+}

--- a/apps/app_partner/test/src/features/member/partner_member_permission_page_test.dart
+++ b/apps/app_partner/test/src/features/member/partner_member_permission_page_test.dart
@@ -39,8 +39,9 @@ void main() {
   }
 
   group('PartnerMemberPermissionPage — Fix #270 회귀 테스트', () {
-    testWidgets('unknown role "member" defaults to "staff" without crash',
-        (tester) async {
+    testWidgets('unknown role "member" defaults to "staff" without crash', (
+      tester,
+    ) async {
       final memberData = {
         'user_id': 'u1',
         'role': 'member', // Dropdown에 없는 값
@@ -48,11 +49,13 @@ void main() {
         'user': {'name': 'Test User', 'email': 'test@test.com'},
       };
 
-      await tester.pumpWidget(buildTestWidget(
-        partnerId: 'p1',
-        targetUserId: 'u1',
-        memberData: memberData,
-      ));
+      await tester.pumpWidget(
+        buildTestWidget(
+          partnerId: 'p1',
+          targetUserId: 'u1',
+          memberData: memberData,
+        ),
+      );
       await tester.pump();
       await tester.pump();
 
@@ -69,11 +72,13 @@ void main() {
         'user': {'name': 'Test User', 'email': 'test@test.com'},
       };
 
-      await tester.pumpWidget(buildTestWidget(
-        partnerId: 'p1',
-        targetUserId: 'u1',
-        memberData: memberData,
-      ));
+      await tester.pumpWidget(
+        buildTestWidget(
+          partnerId: 'p1',
+          targetUserId: 'u1',
+          memberData: memberData,
+        ),
+      );
       await tester.pump();
       await tester.pump();
 
@@ -88,19 +93,22 @@ void main() {
         'user': {'name': 'Test User', 'email': 'test@test.com'},
       };
 
-      await tester.pumpWidget(buildTestWidget(
-        partnerId: 'p1',
-        targetUserId: 'u1',
-        memberData: memberData,
-      ));
+      await tester.pumpWidget(
+        buildTestWidget(
+          partnerId: 'p1',
+          targetUserId: 'u1',
+          memberData: memberData,
+        ),
+      );
       await tester.pump();
       await tester.pump();
 
       expect(find.byType(DropdownButton<String>), findsOneWidget);
     });
 
-    testWidgets('null user_id aborts save without calling repository',
-        (tester) async {
+    testWidgets('null user_id aborts save without calling repository', (
+      tester,
+    ) async {
       final memberData = {
         'user_id': null, // null user_id
         'role': 'staff',
@@ -108,11 +116,13 @@ void main() {
         'user': {'name': 'Test User', 'email': 'test@test.com'},
       };
 
-      await tester.pumpWidget(buildTestWidget(
-        partnerId: 'p1',
-        targetUserId: 'u1',
-        memberData: memberData,
-      ));
+      await tester.pumpWidget(
+        buildTestWidget(
+          partnerId: 'p1',
+          targetUserId: 'u1',
+          memberData: memberData,
+        ),
+      );
       await tester.pump();
       await tester.pump();
 

--- a/apps/app_user/lib/main.dart
+++ b/apps/app_user/lib/main.dart
@@ -66,7 +66,9 @@ Future<void> main() async {
             Sentry.captureException(error, stackTrace: stackTrace),
       ),
     );
-  } on Object catch (_) {
+  } on Object catch (e, st) {
+    // Fix #270: 초기화 에러 로깅 — 에러 삼킴 방지
+    debugPrint('Sentry init failed: $e\n$st');
     startApp();
   }
 }

--- a/apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart
+++ b/apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart
@@ -267,10 +267,11 @@ class PurchaseHistoryCard extends ConsumerWidget {
       },
       confirmRefund: (calculation) async {
         if (!context.mounted) return false;
+        // Fix #270: paymentAmount가 null일 수 있으므로 안전하게 처리
         final confirmed = await _showRefundConfirmDialog(
           context: context,
           eventName: eventName,
-          paymentAmount: paymentAmount!,
+          paymentAmount: paymentAmount ?? 0,
           calculation: calculation,
         );
         if (!context.mounted) return false;

--- a/apps/app_user/lib/src/features/settings/blocked_partners_page.dart
+++ b/apps/app_user/lib/src/features/settings/blocked_partners_page.dart
@@ -25,8 +25,9 @@ class _BlockedPartnersPageState extends ConsumerState<BlockedPartnersPage> {
     setState(() => _loading = true);
     // Fix #270: 네트워크 실패 시 에러 처리 — 영구 로딩 상태 방지
     try {
-      final data =
-          await ref.read(socialRepositoryProvider).getBlockedPartners();
+      final data = await ref
+          .read(socialRepositoryProvider)
+          .getBlockedPartners();
       if (mounted) {
         setState(() {
           _partners = data;

--- a/apps/app_user/lib/src/features/settings/blocked_partners_page.dart
+++ b/apps/app_user/lib/src/features/settings/blocked_partners_page.dart
@@ -23,12 +23,24 @@ class _BlockedPartnersPageState extends ConsumerState<BlockedPartnersPage> {
 
   Future<void> _load() async {
     setState(() => _loading = true);
-    final data = await ref.read(socialRepositoryProvider).getBlockedPartners();
-    if (mounted) {
-      setState(() {
-        _partners = data;
-        _loading = false;
-      });
+    // Fix #270: 네트워크 실패 시 에러 처리 — 영구 로딩 상태 방지
+    try {
+      final data =
+          await ref.read(socialRepositoryProvider).getBlockedPartners();
+      if (mounted) {
+        setState(() {
+          _partners = data;
+          _loading = false;
+        });
+      }
+    } on Object catch (e) {
+      debugPrint('Failed to load blocked partners: $e');
+      if (mounted) {
+        setState(() => _loading = false);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('차단 목록을 불러오지 못했습니다')),
+        );
+      }
     }
   }
 

--- a/apps/app_user/test/src/features/payment/ui/purchase_history_card_test.dart
+++ b/apps/app_user/test/src/features/payment/ui/purchase_history_card_test.dart
@@ -1,0 +1,85 @@
+import 'package:app_user/src/features/payment/ui/purchase_history_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../utils/mocks.dart';
+
+void main() {
+  setUpAll(() async {
+    await initializeDateFormatting('ko_KR');
+  });
+
+  late MockEventRepository mockEventRepository;
+  late MockUser mockUser;
+
+  setUp(() {
+    mockEventRepository = MockEventRepository();
+    mockUser = MockUser();
+    when(() => mockUser.id).thenReturn('user1');
+  });
+
+  Widget createTestWidget(List<dynamic> overrides) {
+    return ProviderScope(
+      overrides: overrides.cast(),
+      child: const MaterialApp(
+        home: PurchaseHistoryPage(),
+      ),
+    );
+  }
+
+  group('PurchaseHistoryCard — Fix #270 회귀 테스트', () {
+    testWidgets('renders card without crash when paymentAmount is null',
+        (tester) async {
+      final mockHistory = [
+        EventApplication(
+          id: 'app1',
+          eventId: 'event1',
+          ticketId: 'ticket1',
+          userId: 'user1',
+          status: 'paid',
+          createdAt: DateTime(2024),
+          updatedAt: DateTime(2024),
+          paymentAmount: null, // Fix #270: null paymentAmount
+          event: Event(
+            id: 'event1',
+            partyId: 'party1',
+            startTime: DateTime(2024, 1, 10, 19),
+            endTime: DateTime(2024, 1, 10, 21),
+            createdAt: DateTime(2024),
+            updatedAt: DateTime(2024),
+            title: 'Free Event',
+          ),
+          ticket: Ticket(
+            id: 'ticket1',
+            name: 'Free Ticket',
+            createdAt: DateTime(2024),
+            updatedAt: DateTime(2024),
+            price: 0,
+          ),
+        ),
+      ];
+
+      when(
+        () => mockEventRepository.getMyPurchaseHistory('user1'),
+      ).thenAnswer((_) async => mockHistory);
+
+      await tester.pumpWidget(
+        createTestWidget([
+          currentUserProvider.overrideWith((ref) => mockUser),
+          eventRepositoryProvider.overrideWithValue(mockEventRepository),
+        ]),
+      );
+
+      await tester.pump();
+      await tester.pump();
+      await tester.pump();
+
+      // 크래시 없이 렌더링 되어야 함
+      expect(find.text('Free Event'), findsOneWidget);
+      expect(find.text('Free Ticket'), findsOneWidget);
+    });
+  });
+}

--- a/apps/app_user/test/src/features/payment/ui/purchase_history_card_test.dart
+++ b/apps/app_user/test/src/features/payment/ui/purchase_history_card_test.dart
@@ -31,8 +31,9 @@ void main() {
   }
 
   group('PurchaseHistoryCard — Fix #270 회귀 테스트', () {
-    testWidgets('renders card without crash when paymentAmount is null',
-        (tester) async {
+    testWidgets('renders card without crash when paymentAmount is null', (
+      tester,
+    ) async {
       final mockHistory = [
         EventApplication(
           id: 'app1',
@@ -42,7 +43,6 @@ void main() {
           status: 'paid',
           createdAt: DateTime(2024),
           updatedAt: DateTime(2024),
-          paymentAmount: null, // Fix #270: null paymentAmount
           event: Event(
             id: 'event1',
             partyId: 'party1',
@@ -57,7 +57,6 @@ void main() {
             name: 'Free Ticket',
             createdAt: DateTime(2024),
             updatedAt: DateTime(2024),
-            price: 0,
           ),
         ),
       ];

--- a/apps/app_user/test/src/features/settings/blocked_partners_page_test.dart
+++ b/apps/app_user/test/src/features/settings/blocked_partners_page_test.dart
@@ -25,10 +25,12 @@ void main() {
   }
 
   group('BlockedPartnersPage — Fix #270 회귀 테스트', () {
-    testWidgets('network failure shows snackbar and stops loading',
-        (tester) async {
-      when(() => mockSocialRepo.getBlockedPartners())
-          .thenAnswer((_) async => throw Exception('Network error'));
+    testWidgets('network failure shows snackbar and stops loading', (
+      tester,
+    ) async {
+      when(
+        () => mockSocialRepo.getBlockedPartners(),
+      ).thenAnswer((_) async => throw Exception('Network error'));
 
       await tester.pumpWidget(buildTestWidget());
       await tester.pump(); // initState → _load()

--- a/apps/app_user/test/src/features/settings/blocked_partners_page_test.dart
+++ b/apps/app_user/test/src/features/settings/blocked_partners_page_test.dart
@@ -1,0 +1,65 @@
+import 'package:app_user/src/features/settings/blocked_partners_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../utils/mocks.dart';
+
+void main() {
+  late MockSocialRepository mockSocialRepo;
+
+  setUp(() {
+    mockSocialRepo = MockSocialRepository();
+  });
+
+  Widget buildTestWidget() {
+    return ProviderScope(
+      overrides: [
+        socialRepositoryProvider.overrideWithValue(mockSocialRepo),
+      ],
+      child: const MaterialApp(
+        home: BlockedPartnersPage(),
+      ),
+    );
+  }
+
+  group('BlockedPartnersPage — Fix #270 회귀 테스트', () {
+    testWidgets('network failure shows snackbar and stops loading',
+        (tester) async {
+      when(() => mockSocialRepo.getBlockedPartners())
+          .thenAnswer((_) async => throw Exception('Network error'));
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pump(); // initState → _load()
+      await tester.pump(); // Future completes with error
+      await tester.pump(); // SnackBar animation
+
+      // SnackBar 표시 확인
+      expect(find.text('차단 목록을 불러오지 못했습니다'), findsOneWidget);
+
+      // 로딩 인디케이터가 더 이상 표시되지 않아야 함
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    });
+
+    testWidgets('successful load renders partner list', (tester) async {
+      when(() => mockSocialRepo.getBlockedPartners()).thenAnswer(
+        (_) async => [
+          {
+            'id': 'p1',
+            'name': 'Blocked Partner',
+            'profile_image_url': null,
+          },
+        ],
+      );
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pump();
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('Blocked Partner'), findsOneWidget);
+      expect(find.text('차단 해제'), findsOneWidget);
+    });
+  });
+}

--- a/shared/packages/minglit_kit/lib/src/features/iamport/ui/implementation/certification_web.dart
+++ b/shared/packages/minglit_kit/lib/src/features/iamport/ui/implementation/certification_web.dart
@@ -96,7 +96,13 @@ class _MinglitIamportCertificationState
     final state = ref.read(iamportControllerProvider);
 
     if (state.hasValue && state.value != null && state.value!.success) {
-      widget.onSuccess(state.value!.impUid!);
+      // Fix #270: impUid가 null이면 크래시 대신 실패 콜백 호출
+      final impUid = state.value!.impUid;
+      if (impUid != null) {
+        widget.onSuccess(impUid);
+      } else {
+        widget.onFail('인증은 성공했으나 impUid를 받지 못했습니다');
+      }
     } else if (state.hasError) {
       widget.onFail(state.error.toString());
     } else {

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_file_picker.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_file_picker.dart
@@ -141,6 +141,9 @@ class _MinglitFilePickerState extends ConsumerState<MinglitFilePicker> {
       final newUrls = <String>[];
 
       for (final file in files) {
+        // Fix #270: 플랫폼별 bytes/path null 가능 — null이면 건너뛰기
+        if (kIsWeb && file.bytes == null) continue;
+        if (!kIsWeb && file.path == null) continue;
         // Convert PlatformFile to XFile for compatibility
         final xFile = kIsWeb
             ? XFile.fromData(file.bytes!, name: file.name)


### PR DESCRIPTION
## Summary
- 코드 품질 감사에서 발견된 잠재 런타임 에러 10건 중 9건 수정 (statsig_provider.dart는 이미 삭제되어 스킵)
- High 4건: 이중 강제 언래핑 제거 (certification_web, purchase_history_card, minglit_file_picker), 에러 핸들링 추가 (blocked_partners_page)
- Medium 5건: 외부 API 안전 캐스팅, dynamic map hard cast 제거, Sentry 초기화 에러 로깅

Closes #270

## Changes
| # | 심각도 | 파일 | 수정 내용 |
|---|--------|------|-----------|
| 1 | 🔴 High | certification_web.dart | `impUid` null 체크 추가, null이면 onFail 콜백 |
| 2 | 🔴 High | purchase_history_card.dart | `paymentAmount!` → `paymentAmount ?? 0` |
| 3 | 🔴 High | minglit_file_picker.dart | `bytes`/`path` null이면 skip |
| 4 | 🔴 High | blocked_partners_page.dart | `_load()`에 try-catch + 에러 snackbar |
| 5 | 🟠 Medium | address_search_dialog.dart | 외부 API 응답 `is` 체크로 안전 캐스팅 |
| 6-7 | 🟠 Medium | partner_member_permission_page.dart | `as String` → `as String?` + null 처리 |
| 8 | 🟠 Medium | partner_member_list_page.dart | `as String` → `as String?` + null guard |
| 9-10 | 🟠 Medium | main.dart (both apps) | catch 블록에서 에러 로깅 (`debugPrint`) |

## Test plan
- [ ] CI `flutter analyze` + `flutter test` 통과 확인
- [ ] 결제 인증 플로우에서 impUid null 시나리오 크래시 없음 확인
- [ ] 파일 업로드 시 bytes/path null 시나리오 안전 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)