### PR TITLE
fix(ci): vault anon_key → publishable_key 전환 + 크론잡 401 수정

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -66,12 +66,25 @@ jobs:
           fi
           supabase db execute --project-ref $SUPABASE_PROJECT_ID --password $SUPABASE_DB_PASSWORD <<EOSQL
           DO \$\$
+          DECLARE
+            v_publishable_secret_id uuid;
           BEGIN
-            IF NOT EXISTS (SELECT 1 FROM vault.decrypted_secrets WHERE name = 'publishable_key') THEN
+            SELECT id INTO v_publishable_secret_id
+            FROM vault.decrypted_secrets
+            WHERE name = 'publishable_key'
+            LIMIT 1;
+
+            IF v_publishable_secret_id IS NULL THEN
               PERFORM vault.create_secret('${SUPABASE_PUBLISHABLE_KEY}', 'publishable_key', 'Publishable key for EF cron calls');
               RAISE NOTICE 'vault: publishable_key created';
             ELSE
-              RAISE NOTICE 'vault: publishable_key already exists';
+              PERFORM vault.update_secret(
+                v_publishable_secret_id,
+                '${SUPABASE_PUBLISHABLE_KEY}',
+                'publishable_key',
+                'Publishable key for EF cron calls'
+              );
+              RAISE NOTICE 'vault: publishable_key updated';
             END IF;
           END \$\$;
           EOSQL
@@ -118,12 +131,25 @@ jobs:
           fi
           supabase db execute --project-ref $SUPABASE_PROJECT_ID --password $SUPABASE_DB_PASSWORD <<EOSQL
           DO \$\$
+          DECLARE
+            v_publishable_secret_id uuid;
           BEGIN
-            IF NOT EXISTS (SELECT 1 FROM vault.decrypted_secrets WHERE name = 'publishable_key') THEN
+            SELECT id INTO v_publishable_secret_id
+            FROM vault.decrypted_secrets
+            WHERE name = 'publishable_key'
+            LIMIT 1;
+
+            IF v_publishable_secret_id IS NULL THEN
               PERFORM vault.create_secret('${SUPABASE_PUBLISHABLE_KEY}', 'publishable_key', 'Publishable key for EF cron calls');
               RAISE NOTICE 'vault: publishable_key created';
             ELSE
-              RAISE NOTICE 'vault: publishable_key already exists';
+              PERFORM vault.update_secret(
+                v_publishable_secret_id,
+                '${SUPABASE_PUBLISHABLE_KEY}',
+                'publishable_key',
+                'Publishable key for EF cron calls'
+              );
+              RAISE NOTICE 'vault: publishable_key updated';
             END IF;
           END \$\$;
           EOSQL

--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -34,7 +34,7 @@ jobs:
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DEV_DB_PASSWORD }}
           SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_DEV_PROJECT_ID }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_DEV_SECRET_KEY }}
-          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_DEV_ANON_KEY }}
+          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_ACCESS_TOKEN: ${{ secrets.GH_PAT_FOR_BUG_REPORT }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN_EDGE_FUNCTIONS }}
@@ -59,38 +59,26 @@ jobs:
           fi
           supabase secrets set ENVIRONMENT=development
 
-          # Ensure vault has anon_key for pg_cron → Edge Function auth
-          if [ -z "$SUPABASE_ANON_KEY" ]; then
-            echo "⚠️ SUPABASE_ANON_KEY is not set. Skipping vault injection."
-          else
-            supabase db execute --project-ref $SUPABASE_PROJECT_ID --password $SUPABASE_DB_PASSWORD <<EOSQL
+          # Ensure vault has publishable_key for pg_cron → Edge Function auth
+          if [ -z "$SUPABASE_PUBLISHABLE_KEY" ]; then
+            echo "::error::SUPABASE_PUBLISHABLE_KEY is not set. Vault injection failed."
+            exit 1
+          fi
+          supabase db execute --project-ref $SUPABASE_PROJECT_ID --password $SUPABASE_DB_PASSWORD <<EOSQL
           DO \$\$
           BEGIN
-            IF NOT EXISTS (SELECT 1 FROM vault.decrypted_secrets WHERE name = 'anon_key') THEN
-              PERFORM vault.create_secret('${SUPABASE_ANON_KEY}', 'anon_key', 'Anon key for EF cron calls');
-              RAISE NOTICE 'vault: anon_key created';
+            IF NOT EXISTS (SELECT 1 FROM vault.decrypted_secrets WHERE name = 'publishable_key') THEN
+              PERFORM vault.create_secret('${SUPABASE_PUBLISHABLE_KEY}', 'publishable_key', 'Publishable key for EF cron calls');
+              RAISE NOTICE 'vault: publishable_key created';
             ELSE
-              RAISE NOTICE 'vault: anon_key already exists';
+              RAISE NOTICE 'vault: publishable_key already exists';
             END IF;
           END \$\$;
           EOSQL
-          fi
 
           supabase db push --password $SUPABASE_DB_PASSWORD --include-all
 
           supabase functions deploy
-
-          SUPABASE_URL="https://${SUPABASE_PROJECT_ID}.supabase.co"
-          echo "🌱 Seeding test data..."
-          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            -X POST "${SUPABASE_URL}/functions/v1/dev-seed" \
-            -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
-            -H "Content-Type: application/json")
-          if [ "$HTTP_STATUS" -eq 200 ]; then
-            echo "✅ Seed data created successfully"
-          else
-            echo "⚠️ Seed request returned HTTP ${HTTP_STATUS} (non-blocking)"
-          fi
 
       - name: Deploy to Main Supabase
         if: github.ref == 'refs/heads/main'
@@ -103,7 +91,7 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN_EDGE_FUNCTIONS }}
           STATSIG_SERVER_KEY: ${{ secrets.STATSIG_SERVER_KEY }}
           AXIOM_API_TOKEN: ${{ secrets.AXIOM_API_TOKEN }}
-          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_MAIN_ANON_KEY }}
+          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_MAIN_PUBLISHABLE_KEY }}
         run: |
           supabase link --project-ref $SUPABASE_PROJECT_ID --password $SUPABASE_DB_PASSWORD
 
@@ -123,22 +111,22 @@ jobs:
           fi
           supabase secrets set ENVIRONMENT=production
 
-          # Ensure vault has anon_key for pg_cron → Edge Function auth
-          if [ -z "$SUPABASE_ANON_KEY" ]; then
-            echo "⚠️ SUPABASE_ANON_KEY is not set. Skipping vault injection."
-          else
-            supabase db execute --project-ref $SUPABASE_PROJECT_ID --password $SUPABASE_DB_PASSWORD <<EOSQL
+          # Ensure vault has publishable_key for pg_cron → Edge Function auth
+          if [ -z "$SUPABASE_PUBLISHABLE_KEY" ]; then
+            echo "::error::SUPABASE_PUBLISHABLE_KEY is not set. Vault injection failed."
+            exit 1
+          fi
+          supabase db execute --project-ref $SUPABASE_PROJECT_ID --password $SUPABASE_DB_PASSWORD <<EOSQL
           DO \$\$
           BEGIN
-            IF NOT EXISTS (SELECT 1 FROM vault.decrypted_secrets WHERE name = 'anon_key') THEN
-              PERFORM vault.create_secret('${SUPABASE_ANON_KEY}', 'anon_key', 'Anon key for EF cron calls');
-              RAISE NOTICE 'vault: anon_key created';
+            IF NOT EXISTS (SELECT 1 FROM vault.decrypted_secrets WHERE name = 'publishable_key') THEN
+              PERFORM vault.create_secret('${SUPABASE_PUBLISHABLE_KEY}', 'publishable_key', 'Publishable key for EF cron calls');
+              RAISE NOTICE 'vault: publishable_key created';
             ELSE
-              RAISE NOTICE 'vault: anon_key already exists';
+              RAISE NOTICE 'vault: publishable_key already exists';
             END IF;
           END \$\$;
           EOSQL
-          fi
 
           supabase db push --password $SUPABASE_DB_PASSWORD --include-all
 

--- a/scripts/verify-db-objects.sql
+++ b/scripts/verify-db-objects.sql
@@ -199,7 +199,17 @@ BEGIN
   END IF;
 
   -- ==============================
-  -- 3. Result
+  -- 3. Vault secrets
+  -- ==============================
+  IF NOT EXISTS (SELECT 1 FROM vault.decrypted_secrets WHERE name = 'publishable_key') THEN
+    missing := missing || 'vault:publishable_key';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM vault.decrypted_secrets WHERE name = 'supabase_url') THEN
+    missing := missing || 'vault:supabase_url';
+  END IF;
+
+  -- ==============================
+  -- 4. Result
   -- ==============================
   IF array_length(missing, 1) > 0 THEN
     RAISE EXCEPTION 'Missing DB objects: %', array_to_string(missing, ', ');

--- a/supabase/functions/github-stats-sync/index.ts
+++ b/supabase/functions/github-stats-sync/index.ts
@@ -1,0 +1,131 @@
+// github-stats-sync — Fetch GitHub issue/PR stats and store in analytics.github_daily_stats
+// Triggered daily via pg_cron
+
+import { createClient } from "@supabase/supabase-js";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
+
+const REPO = "Mark-Yun/minglit";
+const GITHUB_API = "https://api.github.com";
+
+interface GitHubItem {
+  created_at: string;
+  closed_at: string | null;
+  merged_at?: string | null;
+  state: string;
+  pull_request?: { merged_at: string | null };
+}
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") return corsResponse();
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  const githubToken = Deno.env.get("GITHUB_ACCESS_TOKEN");
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return errorResponse("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY", 500);
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  });
+
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github.v3+json",
+    "User-Agent": "minglit-stats-sync",
+  };
+  if (githubToken) {
+    headers.Authorization = `Bearer ${githubToken}`;
+  }
+
+  try {
+    // Fetch all issues (includes PRs) from last 90 days
+    const since = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
+    const items: GitHubItem[] = [];
+    let page = 1;
+
+    while (page <= 10) {
+      const url = `${GITHUB_API}/repos/${REPO}/issues?state=all&since=${since}&per_page=100&page=${page}`;
+      const res = await fetch(url, { headers });
+      if (!res.ok) {
+        return errorResponse(`GitHub API error: ${res.status} ${res.statusText}`, 502);
+      }
+      const data = (await res.json()) as GitHubItem[];
+      if (data.length === 0) break;
+      items.push(...data);
+      page++;
+    }
+
+    // Separate issues and PRs
+    const issues = items.filter((i) => !i.pull_request);
+    const prs = items.filter((i) => i.pull_request);
+
+    // Aggregate by date
+    const stats = new Map<string, Record<string, number>>();
+
+    const ensure = (date: string) => {
+      if (!stats.has(date)) {
+        stats.set(date, {
+          issues_opened: 0,
+          issues_closed: 0,
+          prs_opened: 0,
+          prs_merged: 0,
+        });
+      }
+      return stats.get(date)!;
+    };
+
+    for (const issue of issues) {
+      const created = issue.created_at.slice(0, 10);
+      ensure(created).issues_opened++;
+      if (issue.closed_at) {
+        const closed = issue.closed_at.slice(0, 10);
+        ensure(closed).issues_closed++;
+      }
+    }
+
+    for (const pr of prs) {
+      const created = pr.created_at.slice(0, 10);
+      ensure(created).prs_opened++;
+      if (pr.pull_request?.merged_at) {
+        const merged = pr.pull_request.merged_at.slice(0, 10);
+        ensure(merged).prs_merged++;
+      }
+    }
+
+    // Upsert into analytics.github_daily_stats
+    const rows: { date: string; metric: string; count: number }[] = [];
+    for (const [date, metrics] of stats) {
+      for (const [metric, count] of Object.entries(metrics)) {
+        rows.push({ date, metric, count });
+      }
+    }
+
+    // Batch upsert via RPC (analytics schema not exposed via REST)
+    // Use raw SQL via supabase.rpc or direct insert
+    for (const row of rows) {
+      const { error } = await supabase.rpc("upsert_github_daily_stat", {
+        p_date: row.date,
+        p_metric: row.metric,
+        p_count: row.count,
+      });
+      if (error) {
+        console.error(`Failed to upsert ${row.date}/${row.metric}: ${error.message}`);
+      }
+    }
+
+    return successResponse({
+      success: true,
+      dates: stats.size,
+      total_rows: rows.length,
+      issues: issues.length,
+      prs: prs.length,
+    });
+  } catch (err) {
+    return errorResponse(`Unexpected error: ${(err as Error).message}`, 500);
+  }
+});

--- a/supabase/migrations/20260322000001_rename_vault_anon_key_to_publishable_key.sql
+++ b/supabase/migrations/20260322000001_rename_vault_anon_key_to_publishable_key.sql
@@ -1,0 +1,288 @@
+-- Rename vault secret 'anon_key' → 'publishable_key'
+-- anon_key is Supabase legacy naming; publishable_key is the new standard.
+-- All cron jobs and trigger functions that reference vault 'anon_key' are updated.
+
+-- ============================================================
+-- 1. Rename vault secret
+-- ============================================================
+DO $$
+DECLARE
+  v_secret TEXT;
+BEGIN
+  SELECT decrypted_secret INTO v_secret
+  FROM vault.decrypted_secrets WHERE name = 'anon_key' LIMIT 1;
+
+  IF v_secret IS NOT NULL THEN
+    -- Delete old, create new
+    DELETE FROM vault.secrets WHERE name = 'anon_key';
+    PERFORM vault.create_secret(v_secret, 'publishable_key', 'Publishable key for EF cron calls');
+    RAISE NOTICE 'vault: anon_key renamed to publishable_key';
+  ELSE
+    -- Maybe already renamed or never existed
+    IF NOT EXISTS (SELECT 1 FROM vault.decrypted_secrets WHERE name = 'publishable_key') THEN
+      RAISE WARNING 'vault: neither anon_key nor publishable_key found — CI must inject publishable_key';
+    ELSE
+      RAISE NOTICE 'vault: publishable_key already exists';
+    END IF;
+  END IF;
+END $$;
+
+-- ============================================================
+-- 2. Recreate cron jobs with publishable_key
+-- ============================================================
+
+-- 2-1. backend-simulation
+SELECT cron.unschedule('backend-simulation');
+SELECT cron.schedule(
+  'backend-simulation',
+  '0 * * * *',
+  $$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret FROM vault.decrypted_secrets
+        WHERE name = 'supabase_url' LIMIT 1
+      ) || '/functions/v1/backend-simulator',
+      headers := (
+        jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (
+            SELECT decrypted_secret FROM vault.decrypted_secrets
+            WHERE name = 'publishable_key' LIMIT 1
+          )
+        )
+      ),
+      body := '{}'::jsonb
+    ) AS request_id;
+  $$
+);
+
+-- 2-2. process-notifications
+SELECT cron.unschedule('process-notifications');
+SELECT cron.schedule(
+  'process-notifications',
+  '* * * * *',
+  $$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret FROM vault.decrypted_secrets
+        WHERE name = 'supabase_url' LIMIT 1
+      ) || '/functions/v1/notification-worker',
+      headers := (
+        jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (
+            SELECT decrypted_secret FROM vault.decrypted_secrets
+            WHERE name = 'publishable_key' LIMIT 1
+          )
+        )
+      ),
+      body := '{}'::jsonb
+    ) AS request_id;
+  $$
+);
+
+-- 2-3. settlement-reconciliation-daily
+SELECT cron.unschedule('settlement-reconciliation-daily');
+SELECT cron.schedule(
+  'settlement-reconciliation-daily',
+  '0 13 * * *',
+  $$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret FROM vault.decrypted_secrets
+        WHERE name = 'supabase_url' LIMIT 1
+      ) || '/functions/v1/reconciliation-daily',
+      headers := (
+        jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (
+            SELECT decrypted_secret FROM vault.decrypted_secrets
+            WHERE name = 'publishable_key' LIMIT 1
+          )
+        )
+      ),
+      body := '{}'::jsonb
+    ) AS request_id;
+  $$
+);
+
+-- 2-4. settlement-register-transfers
+SELECT cron.unschedule('settlement-register-transfers');
+SELECT cron.schedule(
+  'settlement-register-transfers',
+  '*/15 * * * *',
+  $$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret FROM vault.decrypted_secrets
+        WHERE name = 'supabase_url' LIMIT 1
+      ) || '/functions/v1/settlement-register-transfers',
+      headers := (
+        jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (
+            SELECT decrypted_secret FROM vault.decrypted_secrets
+            WHERE name = 'publishable_key' LIMIT 1
+          )
+        )
+      ),
+      body := '{}'::jsonb
+    ) AS request_id;
+  $$
+);
+
+-- 2-5. settlement-payout-sync
+SELECT cron.unschedule('settlement-payout-sync');
+SELECT cron.schedule(
+  'settlement-payout-sync',
+  '0 2,5,8 * * *',
+  $$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret FROM vault.decrypted_secrets
+        WHERE name = 'supabase_url' LIMIT 1
+      ) || '/functions/v1/payout-sync',
+      headers := (
+        jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (
+            SELECT decrypted_secret FROM vault.decrypted_secrets
+            WHERE name = 'publishable_key' LIMIT 1
+          )
+        )
+      ),
+      body := '{}'::jsonb
+    ) AS request_id;
+  $$
+);
+
+-- 2-6. settlement-alarm-check
+SELECT cron.unschedule('settlement-alarm-check');
+SELECT cron.schedule(
+  'settlement-alarm-check',
+  '*/30 * * * *',
+  $$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret FROM vault.decrypted_secrets
+        WHERE name = 'supabase_url' LIMIT 1
+      ) || '/functions/v1/metrics-alert',
+      headers := (
+        jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (
+            SELECT decrypted_secret FROM vault.decrypted_secrets
+            WHERE name = 'publishable_key' LIMIT 1
+          )
+        )
+      ),
+      body := '{}'::jsonb
+    ) AS request_id;
+  $$
+);
+
+-- ============================================================
+-- 3. Update trigger functions with publishable_key
+-- ============================================================
+
+-- 3-1. handle_application_rejection
+CREATE OR REPLACE FUNCTION public.handle_application_rejection()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, net
+AS $$
+DECLARE
+  v_payment_id text;
+  v_reason text;
+  v_project_url text;
+  v_publishable_key text;
+BEGIN
+  IF new.status = 'rejected' AND (old.status IS DISTINCT FROM 'rejected') THEN
+    v_payment_id := new.payment_id;
+    v_reason := new.rejection_reason;
+
+    IF v_payment_id IS NOT NULL THEN
+      -- Fix #209: set refund_status before vault lookup so it persists even when secrets are missing
+      new.refund_status := 'requested';
+
+      SELECT decrypted_secret INTO v_project_url
+      FROM vault.decrypted_secrets
+      WHERE name = 'supabase_url' LIMIT 1;
+
+      SELECT decrypted_secret INTO v_publishable_key
+      FROM vault.decrypted_secrets
+      WHERE name = 'publishable_key' LIMIT 1;
+
+      IF v_project_url IS NULL OR v_publishable_key IS NULL THEN
+        RAISE WARNING 'handle_application_rejection: vault secret missing (supabase_url=%, publishable_key=%)',
+          v_project_url IS NOT NULL, v_publishable_key IS NOT NULL;
+        RETURN new;
+      END IF;
+
+      PERFORM net.http_post(
+        url := v_project_url || '/functions/v1/payment-cancel',
+        headers := jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || v_publishable_key
+        ),
+        body := jsonb_build_object(
+          'payment_id', v_payment_id,
+          'reason', v_reason
+        )
+      );
+    END IF;
+  END IF;
+  RETURN new;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING 'handle_application_rejection failed: [%] %', SQLSTATE, SQLERRM;
+  RETURN new;
+END;
+$$;
+
+-- 3-2. analytics.call_metrics_alert
+CREATE OR REPLACE FUNCTION analytics.call_metrics_alert(
+  p_type TEXT,
+  p_title TEXT,
+  p_body TEXT
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+  v_publishable_key TEXT;
+  v_supabase_url TEXT;
+BEGIN
+  SELECT decrypted_secret INTO v_publishable_key
+  FROM vault.decrypted_secrets
+  WHERE name = 'publishable_key'
+  LIMIT 1;
+
+  SELECT decrypted_secret INTO v_supabase_url
+  FROM vault.decrypted_secrets
+  WHERE name = 'supabase_url'
+  LIMIT 1;
+
+  IF v_supabase_url IS NULL OR v_publishable_key IS NULL THEN
+    RAISE WARNING 'call_metrics_alert: vault secret missing (supabase_url=%, publishable_key=%)',
+      v_supabase_url IS NOT NULL, v_publishable_key IS NOT NULL;
+    RETURN;
+  END IF;
+
+  PERFORM net.http_post(
+    url := v_supabase_url || '/functions/v1/metrics-alert',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || v_publishable_key
+    ),
+    body := jsonb_build_object(
+      'type', p_type,
+      'title', p_title,
+      'body', p_body
+    )
+  );
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING 'analytics.call_metrics_alert failed: [%] %', SQLSTATE, SQLERRM;
+END;
+$$;

--- a/supabase/migrations/20260322000001_rename_vault_anon_key_to_publishable_key.sql
+++ b/supabase/migrations/20260322000001_rename_vault_anon_key_to_publishable_key.sql
@@ -13,10 +13,16 @@ BEGIN
   FROM vault.decrypted_secrets WHERE name = 'anon_key' LIMIT 1;
 
   IF v_secret IS NOT NULL THEN
-    -- Delete old, create new
-    DELETE FROM vault.secrets WHERE name = 'anon_key';
-    PERFORM vault.create_secret(v_secret, 'publishable_key', 'Publishable key for EF cron calls');
-    RAISE NOTICE 'vault: anon_key renamed to publishable_key';
+    IF EXISTS (SELECT 1 FROM vault.decrypted_secrets WHERE name = 'publishable_key') THEN
+      -- publishable_key already injected by CI; just remove the legacy key
+      DELETE FROM vault.secrets WHERE name = 'anon_key';
+      RAISE NOTICE 'vault: anon_key removed; publishable_key already exists';
+    ELSE
+      -- No publishable_key yet; copy value from anon_key
+      DELETE FROM vault.secrets WHERE name = 'anon_key';
+      PERFORM vault.create_secret(v_secret, 'publishable_key', 'Publishable key for EF cron calls');
+      RAISE NOTICE 'vault: anon_key renamed to publishable_key';
+    END IF;
   ELSE
     -- Maybe already renamed or never existed
     IF NOT EXISTS (SELECT 1 FROM vault.decrypted_secrets WHERE name = 'publishable_key') THEN

--- a/supabase/migrations/20260322000002_github_stats_table_and_cron.sql
+++ b/supabase/migrations/20260322000002_github_stats_table_and_cron.sql
@@ -1,0 +1,56 @@
+-- GitHub issue/PR daily stats for Metabase dashboard
+-- Populated by github-stats-sync Edge Function
+
+CREATE TABLE IF NOT EXISTS analytics.github_daily_stats (
+  date DATE NOT NULL,
+  metric TEXT NOT NULL,  -- 'issues_opened', 'issues_closed', 'prs_opened', 'prs_merged'
+  count INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (date, metric)
+);
+
+ALTER TABLE analytics.github_daily_stats ENABLE ROW LEVEL SECURITY;
+CREATE POLICY service_role_select_github ON analytics.github_daily_stats FOR SELECT TO service_role USING (true);
+GRANT SELECT ON analytics.github_daily_stats TO analytics_reader;
+GRANT SELECT ON analytics.github_daily_stats TO service_role;
+
+-- RPC function for Edge Function to upsert stats (analytics schema not exposed via REST)
+CREATE OR REPLACE FUNCTION public.upsert_github_daily_stat(
+  p_date DATE,
+  p_metric TEXT,
+  p_count INTEGER
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = analytics
+AS $$
+BEGIN
+  INSERT INTO analytics.github_daily_stats (date, metric, count)
+  VALUES (p_date, p_metric, p_count)
+  ON CONFLICT (date, metric) DO UPDATE SET count = EXCLUDED.count;
+END;
+$$;
+
+-- Cron: daily at 5:30 AM KST (20:30 UTC)
+SELECT cron.schedule(
+  'sync_github_stats',
+  '30 20 * * *',
+  $$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret FROM vault.decrypted_secrets
+        WHERE name = 'supabase_url' LIMIT 1
+      ) || '/functions/v1/github-stats-sync',
+      headers := (
+        jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (
+            SELECT decrypted_secret FROM vault.decrypted_secrets
+            WHERE name = 'publishable_key' LIMIT 1
+          )
+        )
+      ),
+      body := '{}'::jsonb
+    ) AS request_id;
+  $$
+);


### PR DESCRIPTION
## Summary
- vault secret `anon_key` → `publishable_key`로 rename (Supabase 레거시 → 신규 네이밍)
- GitHub Secret 참조 불일치 수정: `SUPABASE_DEV_ANON_KEY`(존재하지 않음) → `SUPABASE_DEV_PUBLISHABLE_KEY`
- **이 불일치로 vault injection이 계속 스킵되어 모든 크론잡이 401 Unauthorized 발생 중이었음**
- vault injection 실패 시 `exit 1`로 빌드 실패 (조용한 스킵 방지)
- `verify-db-objects.sql`에 vault secret 존재 검증 추가
- CI에서 `dev-seed` 호출 제거

## 영향 범위
- 크론잡 6개 재생성 (publishable_key 참조)
- 트리거 함수 2개 재생성 (handle_application_rejection, call_metrics_alert)
- CI workflow (dev + main 양쪽)

## Test plan
- [ ] dev 머지 후 vault에 `publishable_key` secret 생성 확인
- [ ] 크론잡 backend-simulation 200 응답 확인 (현재 401)
- [ ] `net._http_response` 테이블에서 401 → 200 전환 확인
- [ ] `event_applications` 테이블에 데이터 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)