### PR TITLE
fix(ci): PR 워크플로우에서 notify-failure 제거

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -66,13 +66,3 @@ jobs:
           else
             echo "No formatting changes needed"
           fi
-
-  notify-failure:
-    needs: [auto-format]
-    if: always()
-    permissions:
-      issues: write
-    uses: ./.github/workflows/notify-failure.yml
-    with:
-      success: ${{ needs.auto-format.result == 'success' }}
-      workflow_name: 'Auto Format'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,13 +307,3 @@ jobs:
 
           echo ""
           echo "✅ All checks passed"
-
-  notify-failure:
-    needs: [check-migration-versions, test-flutter-apps, lint-landing-user, lint-landing-partner, test-supabase, test-edge-functions]
-    if: always()
-    permissions:
-      issues: write
-    uses: ./.github/workflows/notify-failure.yml
-    with:
-      success: ${{ !contains(needs.*.result, 'failure') }}
-      workflow_name: 'CI'

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -23,13 +23,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml
-
-  notify-failure:
-    needs: [gitleaks]
-    if: always()
-    permissions:
-      issues: write
-    uses: ./.github/workflows/notify-failure.yml
-    with:
-      success: ${{ needs.gitleaks.result == 'success' }}
-      workflow_name: 'Secret Scan'


### PR DESCRIPTION
## Summary

- PR 트리거 워크플로우(ci, secret-scan, auto-format)에서 notify-failure job 제거
- PR CI 실패는 PR 자체에서 확인 가능하므로 이슈 생성 불필요
- 배치/배포 워크플로우(daily-e2e, deploy, supabase-deploy 등)는 유지

## Test plan

- [x] ci.yml에서 notify-failure 제거 확인
- [x] secret-scan.yml에서 notify-failure 제거 확인
- [x] auto-format.yml에서 notify-failure 제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)