### PR TITLE
fix(ci): ci-failure 이슈에 P0-critical 라벨 추가

### DIFF
--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -47,5 +47,5 @@ jobs:
             gh issue comment "$EXISTING" --repo "$REPO" --body "$BODY"
           else
             echo "🆕 Creating new issue..."
-            gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY" --label "ci-failure"
+            gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY" --label "ci-failure" --label "P0-critical"
           fi


### PR DESCRIPTION
## Summary

배치/배포 CI 실패 시 생성되는 이슈에 `P0-critical` 라벨을 자동 추가하여 우선순위 관리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)