### PR TITLE
feat: user-cancel-order EF 구현 — 결제전취소/무료취소/유료환불 통합

### DIFF
--- a/apps/app_user/lib/src/features/event/admission/event_admission_controller.dart
+++ b/apps/app_user/lib/src/features/event/admission/event_admission_controller.dart
@@ -161,12 +161,10 @@ class EventAdmissionController extends _$EventAdmissionController {
           final loading = ref.read(globalLoadingControllerProvider.notifier)
             ..show();
           try {
+            // Fix #299: deleteApplication → cancelOrder EF 전환
             await ref
                 .read(eventRepositoryProvider)
-                .deleteApplication(
-                  eventId: event.id,
-                  userId: user.id,
-                );
+                .cancelOrder(eventId: event.id);
             ref.invalidate(eventAdmissionControllerProvider(event));
             if (context.mounted) {
               unawaited(

--- a/apps/app_user/lib/src/features/payment/logic/purchase_history_controller.dart
+++ b/apps/app_user/lib/src/features/payment/logic/purchase_history_controller.dart
@@ -56,7 +56,9 @@ class PurchaseHistoryController extends _$PurchaseHistoryController {
     );
   }
 
+  // Fix #299: eventId 기반으로 전환 — user-cancel-order EF가 서버에서 검증
   Future<void> runRefundFlow({
+    required String eventId,
     required String? paymentId,
     required int? paymentAmount,
     required DateTime? eventStartTime,
@@ -101,16 +103,15 @@ class PurchaseHistoryController extends _$PurchaseHistoryController {
     if (!confirmed) return;
 
     await _requestRefund(
-      paymentId: paymentId,
-      calculation: calculation,
+      eventId: eventId,
       showError: showError,
       onSuccess: onSuccess,
     );
   }
 
+  // Fix #299: cancelPayment → cancelOrder EF 전환
   Future<void> _requestRefund({
-    required String paymentId,
-    required RefundCalculation calculation,
+    required String eventId,
     required Future<bool> Function(String message) showError,
     required Future<void> Function() onSuccess,
   }) async {
@@ -118,9 +119,8 @@ class PurchaseHistoryController extends _$PurchaseHistoryController {
     try {
       await ref
           .read(eventRepositoryProvider)
-          .cancelPayment(
-            paymentId: paymentId,
-            refundAmount: calculation.refundAmount,
+          .cancelOrder(
+            eventId: eventId,
             reason: '사용자 예매 취소',
           );
 
@@ -134,8 +134,7 @@ class PurchaseHistoryController extends _$PurchaseHistoryController {
       final retry = await showError(message);
       if (retry) {
         await _requestRefund(
-          paymentId: paymentId,
-          calculation: calculation,
+          eventId: eventId,
           showError: showError,
           onSuccess: onSuccess,
         );

--- a/apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart
+++ b/apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart
@@ -202,6 +202,7 @@ class PurchaseHistoryCard extends ConsumerWidget {
                       context: context,
                       ref: ref,
                       eventName: eventName,
+                      eventId: application.eventId,
                       paymentId: paymentId,
                       paymentAmount: paymentAmount,
                       eventStartTime: eventStartTime,
@@ -236,10 +237,12 @@ class PurchaseHistoryCard extends ConsumerWidget {
     return null;
   }
 
+  // Fix #299: eventId 추가 — user-cancel-order EF 전환
   Future<void> _onCancelPressed({
     required BuildContext context,
     required WidgetRef ref,
     required String eventName,
+    required String eventId,
     required String? paymentId,
     required int? paymentAmount,
     required DateTime? eventStartTime,
@@ -247,6 +250,7 @@ class PurchaseHistoryCard extends ConsumerWidget {
   }) async {
     final controller = ref.read(purchaseHistoryControllerProvider.notifier);
     await controller.runRefundFlow(
+      eventId: eventId,
       paymentId: paymentId,
       paymentAmount: paymentAmount,
       eventStartTime: eventStartTime,

--- a/apps/app_user/test/integration/flow_admission_status_test.dart
+++ b/apps/app_user/test/integration/flow_admission_status_test.dart
@@ -33,13 +33,22 @@ void main() {
     when(
       () => mockUserRepo.getApprovedVerificationIds(any()),
     ).thenAnswer((_) async => <String>[]);
-    // Stub deleteApplication for rejected → re-apply flow
+    // Stub deleteApplication for rejected → re-apply flow (deprecated, kept for compatibility)
     when(
       () => mockEventRepo.deleteApplication(
         eventId: any(named: 'eventId'),
         userId: any(named: 'userId'),
       ),
     ).thenAnswer((_) async {});
+    // Fix #299: cancelOrder EF stub for rejected → re-apply flow
+    when(
+      () => mockEventRepo.cancelOrder(
+        eventId: any(named: 'eventId'),
+        reason: any(named: 'reason'),
+      ),
+    ).thenAnswer(
+      (_) async => const CancelOrderResult(type: 'cancelled'),
+    );
   });
 
   final testEvent = Event(

--- a/shared/packages/minglit_kit/lib/src/data/repositories/event_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/event_repository.dart
@@ -39,6 +39,17 @@ class CreateOrderResult {
   final String ticketName;
 }
 
+/// Fix #299: Result from user-cancel-order Edge Function.
+class CancelOrderResult {
+  const CancelOrderResult({required this.type, this.refundAmount});
+
+  /// 'cancelled' (결제 전/무료) or 'refunded' (유료 환불)
+  final String type;
+
+  /// 환불 금액 (type == 'refunded'일 때만)
+  final int? refundAmount;
+}
+
 abstract class _SupabaseEventContext {
   SupabaseClient get supabaseClient;
 }

--- a/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_commands.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_commands.dart
@@ -34,7 +34,7 @@ mixin _EventRepositoryCommands
         'user-cancel-order',
         body: {
           'event_id': eventId,
-          if (reason != null) 'reason': reason,
+          'reason': ?reason,
         },
       );
 

--- a/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_commands.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_commands.dart
@@ -3,6 +3,7 @@ part of 'event_repository.dart';
 mixin _EventRepositoryCommands
     on _SupabaseEventContext, _EventRepositoryQueries {
   /// Deletes an application record.
+  @Deprecated('Use cancelOrder() instead — #299 user-cancel-order EF 전환')
   Future<void> deleteApplication({
     required String eventId,
     required String userId,
@@ -17,6 +18,45 @@ mixin _EventRepositoryCommands
       Log.i('✅ [EventRepo] Application deleted.');
     } catch (e, st) {
       Log.e('❌ [EventRepo] deleteApplication Error', e, st);
+      rethrow;
+    }
+  }
+
+  /// Fix #299: 주문 취소/환불을 user-cancel-order EF로 통합 호출.
+  /// 결제 전 취소, 무료 이벤트 취소, 유료 이벤트 환불을 모두 처리한다.
+  Future<CancelOrderResult> cancelOrder({
+    required String eventId,
+    String? reason,
+  }) async {
+    Log.d('cancelOrder called | event: $eventId');
+    try {
+      final response = await supabaseClient.functions.invoke(
+        'user-cancel-order',
+        body: {
+          'event_id': eventId,
+          if (reason != null) 'reason': reason,
+        },
+      );
+
+      if (response.status != 200) {
+        final data = response.data;
+        final errorMsg = data is Map
+            ? (data['error'] as String?) ?? '취소 요청에 실패했습니다.'
+            : '취소 요청에 실패했습니다.';
+        throw MinglitUserException(errorMsg);
+      }
+
+      final data = response.data as Map<String, dynamic>;
+      final type = data['type'] as String;
+      int? refundAmount;
+      if (type == 'refunded') {
+        final refundData = data['data'] as Map<String, dynamic>?;
+        refundAmount = refundData?['refund_amount'] as int?;
+      }
+
+      return CancelOrderResult(type: type, refundAmount: refundAmount);
+    } catch (e, st) {
+      Log.e('❌ [EventRepo] cancelOrder Error', e, st);
       rethrow;
     }
   }

--- a/shared/packages/minglit_kit/test/src/data/repositories/event_repository_commands_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/event_repository_commands_test.dart
@@ -174,6 +174,112 @@ void main() {
       });
     });
 
+    group('cancelOrder', () {
+      test('returns cancelled result on pre-payment cancel', () async {
+        when(
+          () => mockFunctions.invoke(
+            'user-cancel-order',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true, 'type': 'cancelled'},
+          ),
+        );
+
+        final result = await repository.cancelOrder(eventId: 'event_1');
+
+        expect(result.type, 'cancelled');
+        expect(result.refundAmount, isNull);
+      });
+
+      test('returns refunded result with amount', () async {
+        when(
+          () => mockFunctions.invoke(
+            'user-cancel-order',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {
+              'success': true,
+              'type': 'refunded',
+              'data': {'refund_amount': 30000},
+            },
+          ),
+        );
+
+        final result = await repository.cancelOrder(
+          eventId: 'event_1',
+          reason: '일정 변경',
+        );
+
+        expect(result.type, 'refunded');
+        expect(result.refundAmount, 30000);
+      });
+
+      test('passes reason when provided', () async {
+        when(
+          () => mockFunctions.invoke(
+            'user-cancel-order',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true, 'type': 'cancelled'},
+          ),
+        );
+
+        await repository.cancelOrder(
+          eventId: 'event_1',
+          reason: '일정 변경',
+        );
+
+        verify(
+          () => mockFunctions.invoke(
+            'user-cancel-order',
+            body: {'event_id': 'event_1', 'reason': '일정 변경'},
+          ),
+        ).called(1);
+      });
+
+      test('throws MinglitUserException on error response', () async {
+        when(
+          () => mockFunctions.invoke(
+            'user-cancel-order',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 400,
+            data: {'error': '이미 취소/거절된 신청입니다'},
+          ),
+        );
+
+        expect(
+          () => repository.cancelOrder(eventId: 'event_1'),
+          throwsA(isA<MinglitUserException>()),
+        );
+      });
+
+      test('throws on network error', () async {
+        when(
+          () => mockFunctions.invoke(
+            'user-cancel-order',
+            body: any(named: 'body'),
+          ),
+        ).thenThrow(Exception('network error'));
+
+        await expectLater(
+          repository.cancelOrder(eventId: 'event_1'),
+          throwsA(anything),
+        );
+      });
+    });
+
     group('applyEvent', () {
       test('calls apply_event RPC and returns application ID', () async {
         when(

--- a/supabase/functions/_shared/refund_utils.ts
+++ b/supabase/functions/_shared/refund_utils.ts
@@ -1,0 +1,107 @@
+import { IamportClient } from "./iamport_client.ts";
+import { log } from "./logger.ts";
+
+/**
+ * Shared refund utilities for user-cancel-order and payment-cancel.
+ *
+ * Extracted per #299 to avoid duplicating eligibility logic and PortOne calls.
+ */
+
+export interface RefundEligibilityParams {
+  paidAt: string | null;
+  eventStartTime: string;
+  gracePeriodHours: number;
+  cutoffDays: number;
+  now?: Date;
+}
+
+export interface RefundEligibilityResult {
+  eligible: boolean;
+  reason?: string;
+}
+
+/**
+ * Verify whether a refund is eligible based on grace period and cutoff policy.
+ *
+ * Eligible if EITHER:
+ * - Within grace period (paidAt is past and within gracePeriodHours), OR
+ * - Within cutoff (event starts >= cutoffDays from now)
+ */
+export function verifyRefundEligibility(
+  params: RefundEligibilityParams,
+): RefundEligibilityResult {
+  const now = params.now ?? new Date();
+  const paidAt = params.paidAt ? new Date(params.paidAt) : null;
+  const eventStart = new Date(params.eventStartTime);
+
+  // Fix #133: 미래 paid_at은 음수 duration으로 grace period를 통과하므로 명시적으로 제외
+  const withinGracePeriod =
+    paidAt !== null &&
+    paidAt.getTime() <= now.getTime() &&
+    now.getTime() - paidAt.getTime() <=
+      params.gracePeriodHours * 60 * 60 * 1000;
+
+  const withinCutoff =
+    eventStart.getTime() - now.getTime() >=
+      params.cutoffDays * 24 * 60 * 60 * 1000;
+
+  if (!withinGracePeriod && !withinCutoff) {
+    return { eligible: false, reason: "Refund window has expired" };
+  }
+
+  return { eligible: true };
+}
+
+export interface ExecuteRefundParams {
+  paymentId: string;
+  reason: string;
+  amount?: number;
+  checksum?: number;
+  fnName: string;
+}
+
+/**
+ * Execute a refund via PortOne (Iamport) API.
+ *
+ * Returns the cancel response on success, or throws on failure.
+ */
+export async function executeRefund(
+  params: ExecuteRefundParams,
+): Promise<Record<string, unknown>> {
+  const impKey = Deno.env.get("PORTONE_API_KEY");
+  const impSecret = Deno.env.get("PORTONE_API_SECRET");
+
+  if (!impKey || !impSecret) {
+    log({ function: params.fnName, level: "error", message: "Missing Portone credentials" });
+    throw new RefundError("Server configuration error", 500);
+  }
+
+  const client = new IamportClient(impKey, impSecret);
+  try {
+    return await client.cancelPayment(
+      params.paymentId,
+      params.reason,
+      params.amount,
+      params.checksum,
+    );
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    log({ function: params.fnName, level: "error", message: `Failed to cancel payment: ${message}` });
+    if (message.startsWith("Failed to get token") || message.startsWith("Iamport Error")) {
+      throw new RefundError("Payment provider error", 502);
+    }
+    throw new RefundError(message, 400);
+  }
+}
+
+/**
+ * Typed error for refund operations, carrying an HTTP status code.
+ */
+export class RefundError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "RefundError";
+    this.status = status;
+  }
+}

--- a/supabase/functions/payment-cancel/index.ts
+++ b/supabase/functions/payment-cancel/index.ts
@@ -1,9 +1,10 @@
 // Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
 import { createClient } from "@supabase/supabase-js";
-import { IamportClient } from "../_shared/iamport_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
 import { initSentry, withHandler, log } from "../_shared/logger.ts";
+// Fix #299: 환불 로직을 shared 모듈로 추출 — user-cancel-order와 공유
+import { verifyRefundEligibility, executeRefund, RefundError } from "../_shared/refund_utils.ts";
 
 const FN = "payment-cancel";
 
@@ -83,57 +84,41 @@ Deno.serve(withHandler(async (req) => {
       return errorResponse("Failed to verify refund eligibility", 500);
     }
 
+    // Fix #299: 환불 적격성 검증을 shared 모듈로 위임
     {
       const policy = policyResult.data as Record<string, number>;
       const gracePeriodHours = policy.grace_period_hours ?? 2;
       const cutoffDays = policy.cutoff_days ?? 7;
-      const now = new Date();
-      const paidAt = application.paid_at ? new Date(application.paid_at) : null;
-      const eventStart = new Date(eventResult.data.start_time);
 
-      // Fix #133: 미래 paid_at은 음수 duration으로 grace period를 통과하므로 명시적으로 제외
-      const withinGracePeriod =
-        paidAt !== null &&
-        paidAt.getTime() <= now.getTime() &&
-        now.getTime() - paidAt.getTime() <=
-          gracePeriodHours * 60 * 60 * 1000;
-      const withinCutoff =
-        eventStart.getTime() - now.getTime() >=
-          cutoffDays * 24 * 60 * 60 * 1000;
+      const eligibility = verifyRefundEligibility({
+        paidAt: application.paid_at as string | null,
+        eventStartTime: eventResult.data.start_time,
+        gracePeriodHours,
+        cutoffDays,
+      });
 
-      if (!withinGracePeriod && !withinCutoff) {
+      if (!eligibility.eligible) {
         return errorResponse("refund_not_eligible", 400, {
-          reason: "Refund window has expired",
+          reason: eligibility.reason,
         });
       }
     }
 
-    // 2. Init IamportClient
-    const impKey = Deno.env.get("PORTONE_API_KEY");
-    const impSecret = Deno.env.get("PORTONE_API_SECRET");
-
-    if (!impKey || !impSecret) {
-      log({ function: FN, level: "error", message: "Missing Portone credentials" });
-      return errorResponse("Server configuration error", 500);
-    }
-
-    // 3. Cancel Payment via IamportClient
-    const client = new IamportClient(impKey, impSecret);
+    // Fix #299: PortOne 환불 실행을 shared 모듈로 위임
     let cancelResponse: Record<string, unknown>;
     try {
-      cancelResponse = await client.cancelPayment(
-        payment_id,
-        reason || "심사 반려로 인한 자동 환불",
+      cancelResponse = await executeRefund({
+        paymentId: payment_id,
+        reason: reason || "심사 반려로 인한 자동 환불",
         amount,
         checksum,
-      );
+        fnName: FN,
+      });
     } catch (e) {
-      const message = e instanceof Error ? e.message : String(e);
-      log({ function: FN, level: "error", message: `Failed to cancel payment: ${message}` });
-      if (message.startsWith("Failed to get token") || message.startsWith("Iamport Error")) {
-        return errorResponse("Payment provider error", 502);
+      if (e instanceof RefundError) {
+        return errorResponse(e.message, e.status);
       }
-      return errorResponse(message, 400);
+      throw e;
     }
 
     // 4. Update DB: refund_status + refund_amount

--- a/supabase/functions/user-cancel-order/index.ts
+++ b/supabase/functions/user-cancel-order/index.ts
@@ -1,0 +1,236 @@
+import { createClient } from "@supabase/supabase-js";
+import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
+import { requireAuth } from "../_shared/auth_utils.ts";
+import { initSentry, withHandler, withSpan, log } from "../_shared/logger.ts";
+import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
+import { verifyRefundEligibility, executeRefund, RefundError } from "../_shared/refund_utils.ts";
+
+const FN = "user-cancel-order";
+
+initSentry();
+initStatsig();
+
+Deno.serve(withHandler(async (req) => {
+  if (req.method === "OPTIONS") return corsResponse();
+
+  const auth = await requireAuth(req);
+  if (auth instanceof Response) return auth;
+  const userId = auth;
+
+  try {
+    // 1. Parse Request
+    let reqBody: Record<string, unknown>;
+    try {
+      reqBody = await req.json();
+    } catch {
+      return errorResponse("Invalid JSON body", 400);
+    }
+
+    const { event_id, reason } = reqBody as {
+      event_id?: string;
+      reason?: string;
+    };
+
+    if (!event_id) {
+      return errorResponse("Missing required field: event_id", 400);
+    }
+
+    // 2. Init Supabase (service role for cross-table operations)
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+    );
+
+    // 3. Fetch application by (event_id, user_id)
+    const { data: application, error: appError } = await withSpan(
+      "db.query.event_applications", "db.query",
+      () => supabase
+        .from("event_applications")
+        .select("id, status, payment_id, payment_amount, paid_at, refund_status, event_id, user_id")
+        .eq("event_id", event_id)
+        .eq("user_id", userId)
+        .single(),
+    );
+
+    if (appError || !application) {
+      return errorResponse("해당 이벤트에 신청 내역이 없습니다", 404);
+    }
+
+    // 4. Status validation
+    const { status } = application;
+    if (status === "cancelled" || status === "rejected") {
+      return errorResponse("이미 취소/거절된 신청입니다", 400);
+    }
+
+    // 5. Branch: pre-payment vs post-payment
+    const isPaid = status === "paid" || status === "pending_review" || status === "approved";
+    const isPrePayment = status === "pending" || status === "payment_failed";
+
+    if (isPrePayment) {
+      // Pre-payment cancellation: delete verification_submissions + delete application
+      await withSpan(
+        "db.delete.verification_submissions", "db.delete",
+        () => supabase
+          .from("verification_submissions")
+          .delete()
+          .eq("application_id", application.id)
+          .eq("status", "pending"),
+      );
+
+      await withSpan(
+        "db.delete.event_applications", "db.delete",
+        () => supabase
+          .from("event_applications")
+          .delete()
+          .eq("id", application.id),
+      );
+
+      logStatsigEvent(userId, "order_cancelled", undefined, {
+        event_id,
+        type: "pre_payment",
+        previous_status: status,
+      }).catch(() => {});
+
+      return successResponse({ success: true, type: "cancelled" });
+    }
+
+    if (isPaid) {
+      const paymentAmount = application.payment_amount as number | null;
+
+      // Free event (payment_amount = 0 or null): just update status
+      if (!paymentAmount || paymentAmount === 0) {
+        const { error: updateError } = await withSpan(
+          "db.update.event_applications.cancel", "db.update",
+          () => supabase
+            .from("event_applications")
+            .update({
+              status: "cancelled",
+              updated_at: new Date().toISOString(),
+            })
+            .eq("id", application.id),
+        );
+
+        if (updateError) {
+          log({ function: FN, level: "error", message: "DB Update Error (free cancel)", metadata: { detail: updateError } });
+        }
+
+        logStatsigEvent(userId, "order_cancelled", undefined, {
+          event_id,
+          type: "free_cancelled",
+          previous_status: status,
+        }).catch(() => {});
+
+        return successResponse({ success: true, type: "cancelled" });
+      }
+
+      // Paid event: check refund eligibility
+      if (application.refund_status !== "none") {
+        return errorResponse("already_refunded", 400, {
+          reason: "Refund already processed",
+        });
+      }
+
+      // Fetch event + refund policy
+      const [eventResult, policyResult] = await Promise.all([
+        withSpan("db.query.events", "db.query", () =>
+          supabase
+            .from("events")
+            .select("start_time")
+            .eq("id", event_id)
+            .single(),
+        ),
+        withSpan("db.rpc.get_current_policy", "db.rpc", () =>
+          supabase.rpc("get_current_policy", { p_key: "refund" }),
+        ),
+      ]);
+
+      if (eventResult.error || !eventResult.data) {
+        log({ function: FN, level: "error", message: "Failed to fetch event", metadata: { detail: eventResult.error } });
+        return errorResponse("Failed to verify refund eligibility", 500);
+      }
+
+      if (policyResult.error || !policyResult.data) {
+        log({ function: FN, level: "error", message: "Failed to fetch policy", metadata: { detail: policyResult.error } });
+        return errorResponse("Failed to verify refund eligibility", 500);
+      }
+
+      const policy = policyResult.data as Record<string, number>;
+      const gracePeriodHours = policy.grace_period_hours ?? 2;
+      const cutoffDays = policy.cutoff_days ?? 7;
+
+      const eligibility = verifyRefundEligibility({
+        paidAt: application.paid_at as string | null,
+        eventStartTime: eventResult.data.start_time,
+        gracePeriodHours,
+        cutoffDays,
+      });
+
+      if (!eligibility.eligible) {
+        return errorResponse("refund_not_eligible", 400, {
+          reason: eligibility.reason,
+        });
+      }
+
+      // Execute refund via PortOne
+      let cancelResponse: Record<string, unknown>;
+      try {
+        cancelResponse = await executeRefund({
+          paymentId: application.payment_id as string,
+          reason: reason || "사용자 예매 취소",
+          amount: paymentAmount,
+          checksum: paymentAmount,
+          fnName: FN,
+        });
+      } catch (e) {
+        if (e instanceof RefundError) {
+          return errorResponse(e.message, e.status);
+        }
+        throw e;
+      }
+
+      // Update DB: refund_status + refund_amount
+      const refundAmount = paymentAmount ?? (cancelResponse.amount as number | undefined);
+      const updatePayload: Record<string, unknown> = {
+        refund_status: "completed",
+        updated_at: new Date().toISOString(),
+      };
+      if (refundAmount !== undefined) {
+        updatePayload.refund_amount = refundAmount;
+      }
+
+      const { error: dbError } = await withSpan(
+        "db.update.event_applications.refund", "db.update",
+        () => supabase
+          .from("event_applications")
+          .update(updatePayload)
+          .eq("id", application.id),
+      );
+
+      if (dbError) {
+        log({ function: FN, level: "error", message: "DB Update Error", metadata: { detail: dbError } });
+        // Non-fatal: payment was already refunded
+      }
+
+      logStatsigEvent(userId, "order_cancelled", refundAmount, {
+        event_id,
+        type: "refunded",
+        previous_status: status,
+      }).catch(() => {});
+
+      return successResponse({
+        success: true,
+        type: "refunded",
+        data: { refund_amount: refundAmount },
+      });
+    }
+
+    // Unhandled status
+    log({ function: FN, level: "error", message: `Unhandled status: ${status}`, metadata: { application_id: application.id } });
+    return errorResponse("지원하지 않는 신청 상태입니다", 400);
+
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    log({ function: FN, level: "error", message: `Error in user-cancel-order: ${message}` });
+    return errorResponse(message, 500);
+  }
+}));

--- a/supabase/functions/user-cancel-order/user_cancel_order_test.ts
+++ b/supabase/functions/user-cancel-order/user_cancel_order_test.ts
@@ -1,0 +1,659 @@
+import { assertEquals } from "@std/assert";
+import {
+  captureServeHandler,
+  createFetchMock,
+  authenticatedJsonRequest,
+  jsonResponse,
+  readJson,
+  textRequest,
+  withEnv,
+  withMockedFetch,
+  withNoIntervals,
+} from "../_test_utils/mock_http.ts";
+import { authRoute } from "../_test_utils/fixtures.ts";
+
+const TEST_OPTS = { sanitizeOps: false, sanitizeResources: false };
+
+const ENV = {
+  PORTONE_API_KEY: "test-key",
+  PORTONE_API_SECRET: "test-secret",
+  SUPABASE_URL: "https://supabase.test",
+  SUPABASE_SERVICE_ROLE_KEY: "service-key",
+};
+
+const nowMs = Date.now();
+const eligiblePaidAt = new Date(nowMs - 1 * 60 * 60 * 1000).toISOString(); // 1시간 전
+const ineligiblePaidAt = new Date(nowMs - 3 * 60 * 60 * 1000).toISOString(); // 3시간 전
+const farFutureEvent = new Date(nowMs + 10 * 24 * 60 * 60 * 1000).toISOString(); // 10일 후
+const nearFutureEvent = new Date(nowMs + 3 * 24 * 60 * 60 * 1000).toISOString(); // 3일 후
+
+// --- Route helpers ---
+
+function appRoute(overrides?: {
+  status?: string;
+  payment_id?: string | null;
+  payment_amount?: number | null;
+  paid_at?: string | null;
+  refund_status?: string;
+  user_id?: string;
+}) {
+  return {
+    matcher: (req: Request) =>
+      req.url.includes("/rest/v1/event_applications") && req.method === "GET",
+    handler: () =>
+      jsonResponse({
+        id: "app-123",
+        status: overrides?.status ?? "pending",
+        payment_id: overrides?.payment_id ?? "imp_123",
+        payment_amount: overrides?.payment_amount !== undefined ? overrides.payment_amount : 30000,
+        paid_at: overrides?.paid_at !== undefined ? overrides.paid_at : null,
+        refund_status: overrides?.refund_status ?? "none",
+        event_id: "event-123",
+        user_id: overrides?.user_id ?? "user-123",
+      }),
+  };
+}
+
+function eventRoute(start_time?: string) {
+  return {
+    matcher: (req: Request) =>
+      req.url.includes("/rest/v1/events") && req.method === "GET",
+    handler: () => jsonResponse({ start_time: start_time ?? farFutureEvent }),
+  };
+}
+
+function policyRoute() {
+  return {
+    matcher: (req: Request) =>
+      req.url.includes("/rest/v1/rpc/get_current_policy") && req.method === "POST",
+    handler: () => jsonResponse({ grace_period_hours: 2, cutoff_days: 7 }),
+  };
+}
+
+const portoneTokenRoute = {
+  matcher: "https://api.iamport.kr/users/getToken",
+  handler: () => jsonResponse({ code: 0, response: { access_token: "token" } }),
+};
+
+const portoneCancelRoute = {
+  matcher: "https://api.iamport.kr/payments/cancel",
+  handler: () => jsonResponse({ code: 0, response: { status: "cancelled", amount: 30000 } }),
+};
+
+const dbUpdateRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/event_applications") && req.method === "PATCH",
+  handler: () => jsonResponse({}),
+};
+
+const dbDeleteAppRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/event_applications") && req.method === "DELETE",
+  handler: () => jsonResponse({}),
+};
+
+const dbDeleteVerificationRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/verification_submissions") && req.method === "DELETE",
+  handler: () => jsonResponse({}),
+};
+
+const appNotFoundRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/event_applications") && req.method === "GET",
+  handler: () => jsonResponse({ error: { message: "not found" } }, { status: 406 }),
+};
+
+// ===== Pre-payment cancellation tests =====
+
+Deno.test("pending 신청 → 취소 → event_applications 삭제", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock, calls } = createFetchMock([
+    authRoute,
+    appRoute({ status: "pending" }),
+    dbDeleteVerificationRoute,
+    dbDeleteAppRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", { event_id: "event-123" });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 200);
+        assertEquals(payload.success, true);
+        assertEquals(payload.type, "cancelled");
+
+        // Verify deletion calls were made
+        const deleteVerification = calls.find(
+          (c) => c.url.includes("/rest/v1/verification_submissions") && c.method === "DELETE",
+        );
+        assertEquals(!!deleteVerification, true);
+
+        const deleteApp = calls.find(
+          (c) => c.url.includes("/rest/v1/event_applications") && c.method === "DELETE",
+        );
+        assertEquals(!!deleteApp, true);
+      });
+    });
+  });
+});
+
+Deno.test("pending + verification_submissions → 함께 삭제", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock, calls } = createFetchMock([
+    authRoute,
+    appRoute({ status: "pending" }),
+    dbDeleteVerificationRoute,
+    dbDeleteAppRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", { event_id: "event-123" });
+        const response = await handler(request);
+
+        assertEquals(response.status, 200);
+
+        const deleteVerification = calls.find(
+          (c) => c.url.includes("/rest/v1/verification_submissions") && c.method === "DELETE",
+        );
+        assertEquals(!!deleteVerification, true, "verification_submissions should be deleted");
+      });
+    });
+  });
+});
+
+Deno.test("payment_failed → 취소 → 삭제", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    appRoute({ status: "payment_failed" }),
+    dbDeleteVerificationRoute,
+    dbDeleteAppRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", { event_id: "event-123" });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 200);
+        assertEquals(payload.success, true);
+        assertEquals(payload.type, "cancelled");
+      });
+    });
+  });
+});
+
+// ===== Free event cancellation =====
+
+Deno.test("무료 이벤트 (payment_amount = 0) → 취소 → status = 'cancelled'", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock, calls } = createFetchMock([
+    authRoute,
+    appRoute({ status: "paid", payment_amount: 0, paid_at: eligiblePaidAt }),
+    dbUpdateRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", { event_id: "event-123" });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 200);
+        assertEquals(payload.success, true);
+        assertEquals(payload.type, "cancelled");
+
+        const dbCall = calls.find(
+          (c) => c.url.includes("/rest/v1/event_applications") && c.method === "PATCH",
+        );
+        const dbBody = JSON.parse(dbCall!.body!);
+        assertEquals(dbBody.status, "cancelled");
+      });
+    });
+  });
+});
+
+Deno.test("무료 이벤트 (payment_amount = null) → 취소", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    appRoute({ status: "paid", payment_amount: null, paid_at: eligiblePaidAt }),
+    dbUpdateRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", { event_id: "event-123" });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 200);
+        assertEquals(payload.type, "cancelled");
+      });
+    });
+  });
+});
+
+Deno.test("이미 cancelled → 400", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    appRoute({ status: "cancelled" }),
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", { event_id: "event-123" });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "이미 취소/거절된 신청입니다");
+      });
+    });
+  });
+});
+
+// ===== Paid event refund tests =====
+
+Deno.test("paid → grace period 내 → 환불 성공 + refund_status = 'completed'", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock, calls } = createFetchMock([
+    authRoute,
+    appRoute({ status: "paid", paid_at: eligiblePaidAt, payment_amount: 30000 }),
+    eventRoute(nearFutureEvent),
+    policyRoute(),
+    portoneTokenRoute,
+    portoneCancelRoute,
+    dbUpdateRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", { event_id: "event-123" });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 200);
+        assertEquals(payload.success, true);
+        assertEquals(payload.type, "refunded");
+        assertEquals(payload.data.refund_amount, 30000);
+
+        const dbCall = calls.find(
+          (c) => c.url.includes("/rest/v1/event_applications") && c.method === "PATCH",
+        );
+        const dbBody = JSON.parse(dbCall!.body!);
+        assertEquals(dbBody.refund_status, "completed");
+        assertEquals(dbBody.refund_amount, 30000);
+      });
+    });
+  });
+});
+
+Deno.test("paid → grace period 초과 + cutoff 내 → 환불 성공", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    appRoute({ status: "paid", paid_at: ineligiblePaidAt, payment_amount: 30000 }),
+    eventRoute(farFutureEvent), // 10일 후 → cutoff 합격
+    policyRoute(),
+    portoneTokenRoute,
+    portoneCancelRoute,
+    dbUpdateRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", { event_id: "event-123" });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 200);
+        assertEquals(payload.success, true);
+        assertEquals(payload.type, "refunded");
+      });
+    });
+  });
+});
+
+Deno.test("paid → grace period 초과 + cutoff 초과 → 400 (refund_not_eligible)", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    appRoute({ status: "paid", paid_at: ineligiblePaidAt, payment_amount: 30000 }),
+    eventRoute(nearFutureEvent), // 3일 후 → cutoff 불합격
+    policyRoute(),
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", { event_id: "event-123" });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "refund_not_eligible");
+      });
+    });
+  });
+});
+
+Deno.test("이미 환불됨 (refund_status != 'none') → 400 (already_refunded)", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    appRoute({ status: "paid", refund_status: "completed", payment_amount: 30000 }),
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", { event_id: "event-123" });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "already_refunded");
+      });
+    });
+  });
+});
+
+Deno.test("pending_review → 환불 정상 처리", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    appRoute({ status: "pending_review", paid_at: eligiblePaidAt, payment_amount: 30000 }),
+    eventRoute(nearFutureEvent),
+    policyRoute(),
+    portoneTokenRoute,
+    portoneCancelRoute,
+    dbUpdateRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", { event_id: "event-123" });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 200);
+        assertEquals(payload.type, "refunded");
+      });
+    });
+  });
+});
+
+Deno.test("approved → 환불 정상 처리", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    appRoute({ status: "approved", paid_at: eligiblePaidAt, payment_amount: 30000 }),
+    eventRoute(nearFutureEvent),
+    policyRoute(),
+    portoneTokenRoute,
+    portoneCancelRoute,
+    dbUpdateRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", { event_id: "event-123" });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 200);
+        assertEquals(payload.type, "refunded");
+      });
+    });
+  });
+});
+
+Deno.test("reason 포함 → 정상 처리", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock, calls } = createFetchMock([
+    authRoute,
+    appRoute({ status: "paid", paid_at: eligiblePaidAt, payment_amount: 30000 }),
+    eventRoute(nearFutureEvent),
+    policyRoute(),
+    portoneTokenRoute,
+    portoneCancelRoute,
+    dbUpdateRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          event_id: "event-123",
+          reason: "일정 변경",
+        });
+        const response = await handler(request);
+
+        assertEquals(response.status, 200);
+
+        // Verify reason was passed to PortOne
+        const cancelCall = calls.find((c) => c.url.includes("/payments/cancel"));
+        const cancelBody = JSON.parse(cancelCall!.body!);
+        assertEquals(cancelBody.reason, "일정 변경");
+      });
+    });
+  });
+});
+
+// ===== Auth & Edge cases =====
+
+Deno.test("존재하지 않는 event_id → 404", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    appNotFoundRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", { event_id: "nonexistent" });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 404);
+        assertEquals(payload.error, "해당 이벤트에 신청 내역이 없습니다");
+      });
+    });
+  });
+});
+
+Deno.test("인증 없이 → 401", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    {
+      matcher: (req: Request) => req.url.includes("/auth/v1/user"),
+      handler: () => jsonResponse({ error: "invalid token" }, { status: 401 }),
+    },
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", { event_id: "event-123" });
+        const response = await handler(request);
+
+        assertEquals(response.status, 401);
+      });
+    });
+  });
+});
+
+Deno.test("rejected 상태 → 400", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    appRoute({ status: "rejected" }),
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", { event_id: "event-123" });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "이미 취소/거절된 신청입니다");
+      });
+    });
+  });
+});
+
+Deno.test("신청 없는 event_id → 404", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    appNotFoundRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", { event_id: "event-no-app" });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 404);
+        assertEquals(payload.error, "해당 이벤트에 신청 내역이 없습니다");
+      });
+    });
+  });
+});
+
+Deno.test("missing event_id → 400", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+  const { fetchMock } = createFetchMock([authRoute]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", { reason: "test" });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "Missing required field: event_id");
+      });
+    });
+  });
+});
+
+Deno.test("malformed JSON → 400", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+  const { fetchMock } = createFetchMock([authRoute]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = textRequest("http://localhost", "{invalid-json", {
+          headers: { Authorization: "Bearer test-token" },
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "Invalid JSON body");
+      });
+    });
+  });
+});
+
+Deno.test("token failure → 502", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    appRoute({ status: "paid", paid_at: eligiblePaidAt, payment_amount: 30000 }),
+    eventRoute(nearFutureEvent),
+    policyRoute(),
+    {
+      matcher: "https://api.iamport.kr/users/getToken",
+      handler: () => jsonResponse({ code: 1, message: "bad key" }),
+    },
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", { event_id: "event-123" });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 502);
+        assertEquals(payload.error, "Payment provider error");
+      });
+    });
+  });
+});
+
+Deno.test("DB error is non-fatal for refund → 200", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    appRoute({ status: "paid", paid_at: eligiblePaidAt, payment_amount: 30000 }),
+    eventRoute(nearFutureEvent),
+    policyRoute(),
+    portoneTokenRoute,
+    portoneCancelRoute,
+    {
+      matcher: (req: Request) =>
+        req.url.includes("/rest/v1/event_applications") && req.method === "PATCH",
+      handler: () => jsonResponse({ error: { message: "DB error" } }, { status: 500 }),
+    },
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", { event_id: "event-123" });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 200);
+        assertEquals(payload.success, true);
+        assertEquals(payload.type, "refunded");
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #299 (Phase 1: EF 생성 + Flutter 전환, RLS 유지)

- **`user-cancel-order` EF 신규 생성**: 유저 주도 주문 취소/환불을 하나의 엔드포인트로 통합
  - `pending`/`payment_failed` → verification_submissions + event_applications 삭제
  - `paid`/`pending_review`/`approved` (무료) → status = `cancelled`
  - `paid`/`pending_review`/`approved` (유료) → 환불 정책 검증 + PortOne 환불 + refund_status 업데이트
  - `cancelled`/`rejected` → 400 에러
- **`refund_utils.ts` 공유 모듈**: 환불 적격성 검증(`verifyRefundEligibility`) + PortOne 호출(`executeRefund`)을 `payment-cancel`과 공유
- **`payment-cancel` 리팩토링**: 인라인 환불 로직 → `refund_utils` 사용 (동작 변경 없음)
- **Flutter 전환**:
  - `deleteApplication()` → `cancelOrder()` (admission controller)
  - `cancelPayment()` → `cancelOrder()` (purchase history controller)
  - `CancelOrderResult` 모델 추가

## Test plan

- [x] user-cancel-order EF e2e 테스트 21개 통과
  - 결제 전 취소 (pending, payment_failed, verification 삭제)
  - 무료 이벤트 취소 (payment_amount = 0/null)
  - 유료 환불 (grace period, cutoff, 적격성 검증)
  - 이미 취소/환불된 케이스, 인증 오류, 404 등
- [x] Flutter cancelOrder 유닛 테스트 5개 통과
- [x] Flutter admission integration 테스트 13개 통과
- [x] payment-cancel 기존 동작 보존 (pre-existing interval sanitization 이슈는 별도)
- [ ] CI `ci-result` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)