### PR TITLE
feat(ci): dependency audit + Dependabot 설정 추가

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # Next.js Landing User
+  - package-ecosystem: "npm"
+    directory: "/apps/landing_user"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # Next.js Landing Partner
+  - package-ecosystem: "npm"
+    directory: "/apps/landing_partner"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # Flutter/Dart (pub)
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,8 @@ jobs:
           cache: 'npm'
           cache-dependency-path: ./apps/landing_user/package-lock.json
       - run: npm ci
+      - run: npm audit --audit-level=high
+        continue-on-error: true
       - run: npm run lint
       - run: npm run build
 
@@ -223,6 +225,8 @@ jobs:
           cache: 'npm'
           cache-dependency-path: ./apps/landing_partner/package-lock.json
       - run: npm ci
+      - run: npm audit --audit-level=high
+        continue-on-error: true
       - run: npm run lint
       - run: npm run build
 


### PR DESCRIPTION
## Summary

- CI에 `npm audit --audit-level=high` 추가 (landing_user, landing_partner)
- Dependabot 설정 추가: npm(weekly), GitHub Actions(weekly), Dart pub(monthly)

## Changes

### CI (`ci.yml`)
- `lint-landing-user`, `lint-landing-partner` job에 `npm audit` step 추가
- `continue-on-error: true` — 취약점 발견 시 경고만 (CI 블로킹 안 함)

### Dependabot (`.github/dependabot.yml`)
| Ecosystem | Directory | Schedule | PR Limit |
|-----------|-----------|----------|----------|
| github-actions | `/` | weekly | default |
| npm | `/apps/landing_user` | weekly | 5 |
| npm | `/apps/landing_partner` | weekly | 5 |
| pub (Dart) | `/` | monthly | 5 |

## Test plan

- [x] YAML 문법 확인
- [ ] CI에서 npm audit 실행 확인

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)