### PR TITLE
feat: user-manage-notification EF — 알림 읽음/삭제 관리

### DIFF
--- a/supabase/functions/user-manage-notification/index.ts
+++ b/supabase/functions/user-manage-notification/index.ts
@@ -1,0 +1,95 @@
+import { createClient } from "@supabase/supabase-js";
+import { corsResponse, errorResponse, successResponse } from "../_shared/response_utils.ts";
+import { requireAuth } from "../_shared/auth_utils.ts";
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return corsResponse();
+
+  const auth = await requireAuth(req);
+  if (auth instanceof Response) return auth;
+  const userId = auth;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse("Invalid JSON body", 400);
+  }
+
+  const { action, notification_id } = body as {
+    action?: string;
+    notification_id?: string;
+  };
+
+  if (!action) {
+    return errorResponse("Missing required parameter: action", 400);
+  }
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") ?? "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+  );
+
+  if (action === "mark_read") {
+    if (!notification_id) {
+      return errorResponse("Missing required parameter: notification_id", 400);
+    }
+
+    const { data, error } = await supabase
+      .from("user_notifications")
+      .update({ is_read: true })
+      .eq("id", notification_id)
+      .eq("user_id", userId)
+      .select("id")
+      .maybeSingle();
+
+    if (error) {
+      return errorResponse(error.message, 500);
+    }
+    if (!data) {
+      return errorResponse("Notification not found", 404);
+    }
+
+    return successResponse({ success: true });
+  }
+
+  if (action === "mark_all_read") {
+    const { data, error } = await supabase
+      .from("user_notifications")
+      .update({ is_read: true })
+      .eq("user_id", userId)
+      .eq("is_read", false)
+      .select("id");
+
+    if (error) {
+      return errorResponse(error.message, 500);
+    }
+
+    return successResponse({ success: true, count: (data ?? []).length });
+  }
+
+  if (action === "delete") {
+    if (!notification_id) {
+      return errorResponse("Missing required parameter: notification_id", 400);
+    }
+
+    const { data, error } = await supabase
+      .from("user_notifications")
+      .delete()
+      .eq("id", notification_id)
+      .eq("user_id", userId)
+      .select("id")
+      .maybeSingle();
+
+    if (error) {
+      return errorResponse(error.message, 500);
+    }
+    if (!data) {
+      return errorResponse("Notification not found", 404);
+    }
+
+    return successResponse({ success: true });
+  }
+
+  return errorResponse(`Unknown action: ${action}`, 400);
+});

--- a/supabase/functions/user-manage-notification/user_manage_notification_test.ts
+++ b/supabase/functions/user-manage-notification/user_manage_notification_test.ts
@@ -1,0 +1,334 @@
+import { assertEquals } from "@std/assert";
+import {
+  captureServeHandler,
+  createFetchMock,
+  jsonRequest,
+  jsonResponse,
+  readJson,
+  withNoIntervals,
+  withEnv,
+  withMockedFetch,
+} from "../_test_utils/mock_http.ts";
+
+const ENV = {
+  SUPABASE_URL: "https://supabase.test",
+  SUPABASE_SERVICE_ROLE_KEY: "service-key",
+};
+
+const AUTH_HEADER = { Authorization: "Bearer valid-token" };
+
+/** Mock getUser returning user-123 */
+function mockGetUser() {
+  return {
+    matcher: (req: Request) => req.url.includes("/auth/v1/user"),
+    handler: () => jsonResponse({ id: "user-123" }),
+  };
+}
+
+Deno.test({
+  name: "user-manage-notification - mark_read success",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await withEnv(ENV, async () => {
+      const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+      const { fetchMock } = createFetchMock([
+        mockGetUser(),
+        {
+          matcher: (req) =>
+            req.url.includes("/rest/v1/user_notifications") && req.method === "PATCH",
+          handler: () => jsonResponse({ id: "notif-1" }),
+        },
+      ]);
+
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const request = jsonRequest(
+            "http://localhost",
+            { action: "mark_read", notification_id: "notif-1" },
+            { headers: AUTH_HEADER },
+          );
+          const response = await handler(request);
+          const payload = await readJson(response);
+
+          assertEquals(response.status, 200);
+          assertEquals(payload.success, true);
+        });
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "user-manage-notification - mark_read not found returns 404",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await withEnv(ENV, async () => {
+      const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+      const { fetchMock } = createFetchMock([
+        mockGetUser(),
+        {
+          matcher: (req) =>
+            req.url.includes("/rest/v1/user_notifications") && req.method === "PATCH",
+          handler: () => jsonResponse(null),
+        },
+      ]);
+
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const request = jsonRequest(
+            "http://localhost",
+            { action: "mark_read", notification_id: "notif-999" },
+            { headers: AUTH_HEADER },
+          );
+          const response = await handler(request);
+          const payload = await readJson(response);
+
+          assertEquals(response.status, 404);
+          assertEquals(payload.error, "Notification not found");
+        });
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "user-manage-notification - mark_read missing notification_id returns 400",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await withEnv(ENV, async () => {
+      const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+      const { fetchMock } = createFetchMock([mockGetUser()]);
+
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const request = jsonRequest(
+            "http://localhost",
+            { action: "mark_read" },
+            { headers: AUTH_HEADER },
+          );
+          const response = await handler(request);
+          const payload = await readJson(response);
+
+          assertEquals(response.status, 400);
+          assertEquals(payload.error, "Missing required parameter: notification_id");
+        });
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "user-manage-notification - mark_all_read success",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await withEnv(ENV, async () => {
+      const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+      const { fetchMock } = createFetchMock([
+        mockGetUser(),
+        {
+          matcher: (req) =>
+            req.url.includes("/rest/v1/user_notifications") && req.method === "PATCH",
+          handler: () => jsonResponse([{ id: "notif-1" }, { id: "notif-2" }]),
+        },
+      ]);
+
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const request = jsonRequest(
+            "http://localhost",
+            { action: "mark_all_read" },
+            { headers: AUTH_HEADER },
+          );
+          const response = await handler(request);
+          const payload = await readJson(response);
+
+          assertEquals(response.status, 200);
+          assertEquals(payload.success, true);
+          assertEquals(payload.count, 2);
+        });
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "user-manage-notification - mark_all_read nothing to read returns count 0",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await withEnv(ENV, async () => {
+      const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+      const { fetchMock } = createFetchMock([
+        mockGetUser(),
+        {
+          matcher: (req) =>
+            req.url.includes("/rest/v1/user_notifications") && req.method === "PATCH",
+          handler: () => jsonResponse([]),
+        },
+      ]);
+
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const request = jsonRequest(
+            "http://localhost",
+            { action: "mark_all_read" },
+            { headers: AUTH_HEADER },
+          );
+          const response = await handler(request);
+          const payload = await readJson(response);
+
+          assertEquals(response.status, 200);
+          assertEquals(payload.success, true);
+          assertEquals(payload.count, 0);
+        });
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "user-manage-notification - delete success",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await withEnv(ENV, async () => {
+      const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+      const { fetchMock } = createFetchMock([
+        mockGetUser(),
+        {
+          matcher: (req) =>
+            req.url.includes("/rest/v1/user_notifications") && req.method === "DELETE",
+          handler: () => jsonResponse({ id: "notif-1" }),
+        },
+      ]);
+
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const request = jsonRequest(
+            "http://localhost",
+            { action: "delete", notification_id: "notif-1" },
+            { headers: AUTH_HEADER },
+          );
+          const response = await handler(request);
+          const payload = await readJson(response);
+
+          assertEquals(response.status, 200);
+          assertEquals(payload.success, true);
+        });
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "user-manage-notification - delete not found returns 404",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await withEnv(ENV, async () => {
+      const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+      const { fetchMock } = createFetchMock([
+        mockGetUser(),
+        {
+          matcher: (req) =>
+            req.url.includes("/rest/v1/user_notifications") && req.method === "DELETE",
+          handler: () => jsonResponse(null),
+        },
+      ]);
+
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const request = jsonRequest(
+            "http://localhost",
+            { action: "delete", notification_id: "notif-999" },
+            { headers: AUTH_HEADER },
+          );
+          const response = await handler(request);
+          const payload = await readJson(response);
+
+          assertEquals(response.status, 404);
+          assertEquals(payload.error, "Notification not found");
+        });
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "user-manage-notification - no auth returns 401",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await withEnv(ENV, async () => {
+      const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+      const { fetchMock } = createFetchMock([]);
+
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const request = jsonRequest("http://localhost", {
+            action: "mark_read",
+            notification_id: "notif-1",
+          });
+          const response = await handler(request);
+          const payload = await readJson(response);
+
+          assertEquals(response.status, 401);
+          assertEquals(typeof payload.error, "string");
+        });
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "user-manage-notification - unknown action returns 400",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await withEnv(ENV, async () => {
+      const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+      const { fetchMock } = createFetchMock([mockGetUser()]);
+
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const request = jsonRequest(
+            "http://localhost",
+            { action: "invalid_action" },
+            { headers: AUTH_HEADER },
+          );
+          const response = await handler(request);
+          const payload = await readJson(response);
+
+          assertEquals(response.status, 400);
+          assertEquals(payload.error, "Unknown action: invalid_action");
+        });
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "user-manage-notification - OPTIONS returns CORS response",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    await withEnv(ENV, async () => {
+      const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+      const { fetchMock } = createFetchMock([]);
+
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const request = new Request("http://localhost", { method: "OPTIONS" });
+          const response = await handler(request);
+
+          assertEquals(response.status, 200);
+          assertEquals(response.headers.get("Access-Control-Allow-Origin"), "*");
+        });
+      });
+    });
+  },
+});


### PR DESCRIPTION
## Summary
- `user-manage-notification` Edge Function: mark_read, mark_all_read, delete
- 본인 소유 알림만 조작 가능 (user_id 검증)
- Deno 테스트 10개

Closes #295

## Test plan
- [x] Deno 테스트 10개 통과
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)