### PR TITLE
fix(ci): supabase db execute에서 deprecated --project-ref 제거

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -64,7 +64,7 @@ jobs:
             echo "::error::SUPABASE_PUBLISHABLE_KEY is not set. Vault injection failed."
             exit 1
           fi
-          supabase db execute --project-ref $SUPABASE_PROJECT_ID --password $SUPABASE_DB_PASSWORD <<EOSQL
+          supabase db execute <<EOSQL
           DO \$\$
           DECLARE
             v_publishable_secret_id uuid;
@@ -129,7 +129,7 @@ jobs:
             echo "::error::SUPABASE_PUBLISHABLE_KEY is not set. Vault injection failed."
             exit 1
           fi
-          supabase db execute --project-ref $SUPABASE_PROJECT_ID --password $SUPABASE_DB_PASSWORD <<EOSQL
+          supabase db execute <<EOSQL
           DO \$\$
           DECLARE
             v_publishable_secret_id uuid;
@@ -178,8 +178,6 @@ jobs:
         run: |
           EXPECTED=$(ls supabase/migrations/*.sql | wc -l | tr -d ' ')
           APPLIED=$(supabase db execute \
-            --project-ref ${{ steps.env.outputs.PROJECT_ID }} \
-            --password ${{ steps.env.outputs.DB_PASSWORD }} \
             --sql "SELECT count(*)::text FROM supabase_migrations.schema_migrations;" \
             | grep -oE '[0-9]+' | head -1)
           echo "Expected: $EXPECTED, Applied: $APPLIED"
@@ -194,8 +192,6 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: |
           supabase db execute \
-            --project-ref ${{ steps.env.outputs.PROJECT_ID }} \
-            --password ${{ steps.env.outputs.DB_PASSWORD }} \
             --sql "$(cat scripts/verify-db-objects.sql)"
 
       # --- DB state snapshot ---
@@ -209,8 +205,6 @@ jobs:
           echo "# ${ENV} DB State — $(date -u '+%Y-%m-%d %H:%M UTC')" > "$REPORT_FILE"
           echo "" >> "$REPORT_FILE"
           supabase db execute \
-            --project-ref ${{ steps.env.outputs.PROJECT_ID }} \
-            --password ${{ steps.env.outputs.DB_PASSWORD }} \
             --sql "$(cat scripts/db-snapshot.sql)" >> "$REPORT_FILE"
 
       - name: Commit DB state report


### PR DESCRIPTION
## Summary

Supabase CLI 최신 버전에서 `db execute`의 `--project-ref` 플래그가 제거되어 supabase-deploy 워크플로우가 5회 연속 실패 중.

## Root Cause

`supabase link --project-ref`로 프로젝트를 연결한 후에는 `db execute`에 별도 `--project-ref`/`--password` 플래그 불필요. CLI 업데이트로 해당 플래그가 `unknown flag` 에러 발생.

## Changes

- `supabase db execute`에서 `--project-ref` 및 `--password` 제거 (5곳)
- `supabase link --project-ref`는 유지 (정상 동작)

## Test plan

- [ ] 머지 후 다음 supabase-deploy cron에서 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)