### PR TITLE
test: e2e CUJ 08~10 결제/환불/정산 파이프라인 테스트

### DIFF
--- a/tests/client_cuj_integration/integration_test/cuj/cuj_08_refund_test.dart
+++ b/tests/client_cuj_integration/integration_test/cuj/cuj_08_refund_test.dart
@@ -1,0 +1,141 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../utils/e2e_auth.dart';
+import '../utils/e2e_helpers.dart';
+
+/// CUJ 08: Refund — Cancel payment via Edge Function, verify refund_status.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late SupabaseClient adminClient;
+  late ScheduledEventContext eventCtx;
+  late String testUserId;
+  late String verificationId;
+  late String applicationId;
+  final paymentId = 'E2E_REFUND_${Random().nextInt(99999)}';
+
+  setUpAll(() async {
+    await initializeE2E();
+    adminClient = createAdminClient();
+
+    eventCtx = await findScheduledEvent(adminClient);
+    final email = await getTestUserEmail(adminClient, gender: 'male');
+    await signInAsTestUser(email);
+    testUserId = Supabase.instance.client.auth.currentUser!.id;
+    verificationId = await getCareerVerificationId(adminClient);
+
+    await _cleanup(adminClient, testUserId, eventCtx.eventId);
+
+    // Create a paid application for refund testing
+    applicationId = await Supabase.instance.client.rpc<dynamic>(
+      'apply_event',
+      params: {
+        'p_event_id': eventCtx.eventId,
+        'p_ticket_id': eventCtx.ticketId,
+        'p_user_id': testUserId,
+        'p_payment_id': paymentId,
+        'p_payment_amount': 15000,
+        'p_verification_data': {
+          'partner_id': eventCtx.partnerId,
+          'verification_id': verificationId,
+          'data': {'company': 'E2E Refund Corp', 'position': 'QA'},
+        },
+      },
+    ) as String;
+
+    // Set status to 'paid' and paid_at (admin)
+    await adminClient
+        .from('event_applications')
+        .update({
+          'status': 'paid',
+          'paid_at': DateTime.now().toIso8601String(),
+        })
+        .eq('id', applicationId);
+  });
+
+  tearDownAll(() async {
+    await _cleanup(adminClient, testUserId, eventCtx.eventId);
+    await signOut();
+  });
+
+  group('CUJ 08: Refund', () {
+    testWidgets('paid 상태에서 환불 요청이 성공한다', (tester) async {
+      final client = Supabase.instance.client;
+
+      final response = await client.functions.invoke(
+        'payment-cancel',
+        body: {
+          'payment_id': paymentId,
+          'reason': 'E2E test refund',
+        },
+      );
+
+      expect(response.status, equals(200));
+    });
+
+    testWidgets('환불 후 refund_status가 completed로 변경된다', (tester) async {
+      final app = await retry(() async {
+        final res = await adminClient
+            .from('event_applications')
+            .select('refund_status, refund_amount')
+            .eq('id', applicationId)
+            .single();
+        if (res['refund_status'] != 'completed') {
+          throw Exception('refund not yet completed');
+        }
+        return res;
+      });
+
+      expect(app['refund_status'], equals('completed'));
+    });
+
+    testWidgets('이미 환불된 신청에 중복 환불 요청 시 실패한다', (tester) async {
+      final client = Supabase.instance.client;
+
+      final response = await client.functions.invoke(
+        'payment-cancel',
+        body: {
+          'payment_id': paymentId,
+          'reason': 'Duplicate refund attempt',
+        },
+      );
+
+      // payment-cancel returns 400 for already_refunded
+      expect(response.status, equals(400));
+    });
+  });
+}
+
+Future<void> _cleanup(
+  SupabaseClient admin,
+  String userId,
+  String eventId,
+) async {
+  try {
+    await admin
+        .from('event_participants')
+        .delete()
+        .eq('user_id', userId)
+        .eq('event_id', eventId);
+  } on Object catch (_) {}
+  try {
+    final appRes = await admin
+        .from('event_applications')
+        .select('id')
+        .eq('user_id', userId)
+        .eq('event_id', eventId)
+        .maybeSingle();
+    if (appRes != null) {
+      final appId = appRes['id'] as String;
+      await admin
+          .from('verification_submissions')
+          .delete()
+          .eq('application_id', appId);
+      await admin.from('event_applications').delete().eq('id', appId);
+    }
+  } on Object catch (_) {}
+}

--- a/tests/client_cuj_integration/integration_test/cuj/cuj_09_settlement_creation_test.dart
+++ b/tests/client_cuj_integration/integration_test/cuj/cuj_09_settlement_creation_test.dart
@@ -1,0 +1,149 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../utils/e2e_auth.dart';
+import '../utils/e2e_helpers.dart';
+
+/// CUJ 09: Settlement Creation — Event completion triggers settlement record.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late SupabaseClient adminClient;
+  late ScheduledEventContext eventCtx;
+  late String testUserId;
+  late String verificationId;
+  late String applicationId;
+  final paymentId = 'E2E_SETTLE_${Random().nextInt(99999)}';
+
+  setUpAll(() async {
+    await initializeE2E();
+    adminClient = createAdminClient();
+
+    // Find a fresh scheduled event (not previously completed)
+    eventCtx = await findScheduledEvent(adminClient);
+    final email = await getTestUserEmail(adminClient, gender: 'male');
+    await signInAsTestUser(email);
+    testUserId = Supabase.instance.client.auth.currentUser!.id;
+    verificationId = await getCareerVerificationId(adminClient);
+
+    await _cleanup(adminClient, testUserId, eventCtx.eventId);
+
+    // Create a paid application
+    applicationId = await Supabase.instance.client.rpc<dynamic>(
+      'apply_event',
+      params: {
+        'p_event_id': eventCtx.eventId,
+        'p_ticket_id': eventCtx.ticketId,
+        'p_user_id': testUserId,
+        'p_payment_id': paymentId,
+        'p_payment_amount': 15000,
+        'p_verification_data': {
+          'partner_id': eventCtx.partnerId,
+          'verification_id': verificationId,
+          'data': {'company': 'E2E Settlement Corp', 'position': 'QA'},
+        },
+      },
+    ) as String;
+
+    // Set to paid
+    await adminClient
+        .from('event_applications')
+        .update({
+          'status': 'paid',
+          'paid_at': DateTime.now().toIso8601String(),
+        })
+        .eq('id', applicationId);
+  });
+
+  tearDownAll(() async {
+    // Restore event to scheduled for other tests
+    try {
+      await adminClient
+          .from('events')
+          .update({'status': 'scheduled'})
+          .eq('id', eventCtx.eventId);
+    } on Object catch (_) {}
+    // Delete settlement
+    try {
+      await adminClient
+          .from('settlements')
+          .delete()
+          .eq('event_id', eventCtx.eventId);
+    } on Object catch (_) {}
+    await _cleanup(adminClient, testUserId, eventCtx.eventId);
+    await signOut();
+  });
+
+  group('CUJ 09: Settlement Creation', () {
+    testWidgets('이벤트 완료 시 settlement가 자동 생성된다', (tester) async {
+      // Complete the event (triggers create_settlement_on_event_completion)
+      await adminClient
+          .from('events')
+          .update({'status': 'completed'})
+          .eq('id', eventCtx.eventId);
+
+      // Settlement should be created by trigger
+      final settlement = await retry(() async {
+        final res = await adminClient
+            .from('settlements')
+            .select()
+            .eq('event_id', eventCtx.eventId)
+            .maybeSingle();
+        if (res == null) throw Exception('Settlement not yet created');
+        return res;
+      });
+
+      expect(settlement, isNotNull);
+      expect(settlement['event_id'], equals(eventCtx.eventId));
+      expect(settlement['partner_id'], equals(eventCtx.partnerId));
+      expect(settlement['status'], equals('pending'));
+    });
+
+    testWidgets('settlement의 매출 금액이 올바르다', (tester) async {
+      final settlement = await adminClient
+          .from('settlements')
+          .select()
+          .eq('event_id', eventCtx.eventId)
+          .single();
+
+      // total_sales should include our 15000 payment
+      expect(settlement['total_sales'] as int, greaterThanOrEqualTo(15000));
+      expect(settlement['net_amount'] as int, isA<int>());
+      expect(settlement['pg_fee'] as int, isA<int>());
+      expect(settlement['platform_fee'] as int, isA<int>());
+    });
+  });
+}
+
+Future<void> _cleanup(
+  SupabaseClient admin,
+  String userId,
+  String eventId,
+) async {
+  try {
+    await admin
+        .from('event_participants')
+        .delete()
+        .eq('user_id', userId)
+        .eq('event_id', eventId);
+  } on Object catch (_) {}
+  try {
+    final appRes = await admin
+        .from('event_applications')
+        .select('id')
+        .eq('user_id', userId)
+        .eq('event_id', eventId)
+        .maybeSingle();
+    if (appRes != null) {
+      final appId = appRes['id'] as String;
+      await admin
+          .from('verification_submissions')
+          .delete()
+          .eq('application_id', appId);
+      await admin.from('event_applications').delete().eq('id', appId);
+    }
+  } on Object catch (_) {}
+}

--- a/tests/client_cuj_integration/integration_test/cuj/cuj_10_settlement_state_machine_test.dart
+++ b/tests/client_cuj_integration/integration_test/cuj/cuj_10_settlement_state_machine_test.dart
@@ -1,0 +1,191 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../utils/e2e_auth.dart';
+import '../utils/e2e_helpers.dart';
+
+/// CUJ 10: Settlement State Machine — pending → ready transition via cron/RPC.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late SupabaseClient adminClient;
+  late ScheduledEventContext eventCtx;
+  late String testUserId;
+  late String verificationId;
+  late String applicationId;
+  late String settlementId;
+  final paymentId = 'E2E_SM_${Random().nextInt(99999)}';
+
+  setUpAll(() async {
+    await initializeE2E();
+    adminClient = createAdminClient();
+
+    eventCtx = await findScheduledEvent(adminClient);
+    final email = await getTestUserEmail(adminClient, gender: 'female');
+    await signInAsTestUser(email);
+    testUserId = Supabase.instance.client.auth.currentUser!.id;
+    verificationId = await getCareerVerificationId(adminClient);
+
+    await _cleanup(adminClient, testUserId, eventCtx.eventId);
+
+    // Create paid application
+    applicationId = await Supabase.instance.client.rpc<dynamic>(
+      'apply_event',
+      params: {
+        'p_event_id': eventCtx.eventId,
+        'p_ticket_id': eventCtx.ticketId,
+        'p_user_id': testUserId,
+        'p_payment_id': paymentId,
+        'p_payment_amount': 15000,
+        'p_verification_data': {
+          'partner_id': eventCtx.partnerId,
+          'verification_id': verificationId,
+          'data': {'company': 'E2E StateMachine Corp', 'position': 'QA'},
+        },
+      },
+    ) as String;
+
+    // Set to paid
+    await adminClient
+        .from('event_applications')
+        .update({
+          'status': 'paid',
+          'paid_at': DateTime.now().toIso8601String(),
+        })
+        .eq('id', applicationId);
+
+    // Complete event → trigger creates settlement
+    await adminClient
+        .from('events')
+        .update({'status': 'completed'})
+        .eq('id', eventCtx.eventId);
+
+    // Get settlement ID
+    final settlement = await retry(() async {
+      final res = await adminClient
+          .from('settlements')
+          .select('id')
+          .eq('event_id', eventCtx.eventId)
+          .maybeSingle();
+      if (res == null) throw Exception('Settlement not yet created');
+      return res;
+    });
+    settlementId = settlement['id'] as String;
+  });
+
+  tearDownAll(() async {
+    try {
+      await adminClient
+          .from('events')
+          .update({'status': 'scheduled'})
+          .eq('id', eventCtx.eventId);
+    } on Object catch (_) {}
+    try {
+      await adminClient
+          .from('settlements')
+          .delete()
+          .eq('event_id', eventCtx.eventId);
+    } on Object catch (_) {}
+    await _cleanup(adminClient, testUserId, eventCtx.eventId);
+    await signOut();
+  });
+
+  group('CUJ 10: Settlement State Machine', () {
+    testWidgets('settlement 초기 상태가 pending이다', (tester) async {
+      final settlement = await adminClient
+          .from('settlements')
+          .select('status')
+          .eq('id', settlementId)
+          .single();
+
+      expect(settlement['status'], equals('pending'));
+    });
+
+    testWidgets('update_settlement_ready_status RPC로 ready 전이 가능하다',
+        (tester) async {
+      // Simulate 7-day wait by backdating event_date
+      await adminClient
+          .from('settlements')
+          .update({
+            'event_date': DateTime.now()
+                .subtract(const Duration(days: 8))
+                .toIso8601String(),
+          })
+          .eq('id', settlementId);
+
+      // Call the RPC that cron normally calls
+      await adminClient.rpc<void>('update_settlement_ready_status');
+
+      final settlement = await adminClient
+          .from('settlements')
+          .select('status')
+          .eq('id', settlementId)
+          .single();
+
+      expect(settlement['status'], equals('ready'));
+    });
+
+    testWidgets('ready 상태에서 requested로 전이 가능하다', (tester) async {
+      await adminClient
+          .from('settlements')
+          .update({'status': 'requested'})
+          .eq('id', settlementId);
+
+      final settlement = await adminClient
+          .from('settlements')
+          .select('status')
+          .eq('id', settlementId)
+          .single();
+
+      expect(settlement['status'], equals('requested'));
+    });
+
+    testWidgets('requested에서 completed로 전이 가능하다', (tester) async {
+      await adminClient
+          .from('settlements')
+          .update({'status': 'completed'})
+          .eq('id', settlementId);
+
+      final settlement = await adminClient
+          .from('settlements')
+          .select('status')
+          .eq('id', settlementId)
+          .single();
+
+      expect(settlement['status'], equals('completed'));
+    });
+  });
+}
+
+Future<void> _cleanup(
+  SupabaseClient admin,
+  String userId,
+  String eventId,
+) async {
+  try {
+    await admin
+        .from('event_participants')
+        .delete()
+        .eq('user_id', userId)
+        .eq('event_id', eventId);
+  } on Object catch (_) {}
+  try {
+    final appRes = await admin
+        .from('event_applications')
+        .select('id')
+        .eq('user_id', userId)
+        .eq('event_id', eventId)
+        .maybeSingle();
+    if (appRes != null) {
+      final appId = appRes['id'] as String;
+      await admin
+          .from('verification_submissions')
+          .delete()
+          .eq('application_id', appId);
+      await admin.from('event_applications').delete().eq('id', appId);
+    }
+  } on Object catch (_) {}
+}


### PR DESCRIPTION
## Summary
- **CUJ 08**: 환불 — payment-cancel EF 호출, refund_status 검증, 중복 환불 방지
- **CUJ 09**: 정산 생성 — 이벤트 완료 트리거 → settlement 자동 생성, 금액 검증
- **CUJ 10**: 정산 상태 머신 — pending → ready → requested → completed 전이

Closes #230

## Test plan
- [x] `flutter analyze` 통과 (0 issues)
- [ ] CI 통과 확인
- [ ] dev 환경 daily-e2e에서 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)