### PR TITLE
feat(ci): Dependabot auto-merge 워크플로우 추가

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,36 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch/minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge "${{ github.event.pull_request.number }}" --auto --squash --repo "${{ github.repository }}"
+
+      - name: Label major updates for manual review
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" \
+            --add-label "major-update"
+          gh pr comment "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" \
+            --body "⚠️ Major version update — breaking change 가능성이 있어 수동 확인이 필요합니다."


### PR DESCRIPTION
## Summary

Dependabot PR을 자동 처리하는 워크플로우 추가.

- **patch/minor**: CI 통과 시 자동 squash merge
- **major**: `major-update` 라벨 + 수동 확인 요청 코멘트

## Test plan

- [ ] Dependabot patch/minor PR에 auto-merge 활성화 확인
- [ ] Major PR에 라벨 + 코멘트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)