### PR TITLE
feat(ci): auto-merge PR 브랜치 자동 업데이트

### DIFF
--- a/.github/workflows/auto-update-branches.yml
+++ b/.github/workflows/auto-update-branches.yml
@@ -1,0 +1,31 @@
+name: Auto-update PR branches
+
+on:
+  push:
+    branches: [dev]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update auto-merge PRs that are behind
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+          echo "Checking open PRs with auto-merge enabled..."
+
+          gh pr list --repo "$REPO" --base dev --state open --json number,autoMergeRequest \
+            --jq '.[] | select(.autoMergeRequest != null) | .number' | while read -r PR_NUM; do
+            MERGE_STATE=$(gh pr view "$PR_NUM" --repo "$REPO" --json mergeStateStatus --jq '.mergeStateStatus')
+            if [ "$MERGE_STATE" = "BEHIND" ]; then
+              echo "PR #$PR_NUM is BEHIND — updating branch..."
+              gh api "repos/$REPO/pulls/$PR_NUM/update-branch" --method PUT || true
+            else
+              echo "PR #$PR_NUM is $MERGE_STATE — skipping"
+            fi
+          done

--- a/.github/workflows/auto-update-branches.yml
+++ b/.github/workflows/auto-update-branches.yml
@@ -8,6 +8,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-branches:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

dev에 push될 때 auto-merge가 활성화된 PR 중 BEHIND 상태인 브랜치를 자동으로 업데이트.

## 동작

1. dev에 push 발생
2. auto-merge가 켜진 open PR 목록 조회
3. BEHIND 상태인 PR → `update-branch` API 호출
4. 브랜치 업데이트 → CI 재실행 → auto-merge 진행

## Context

Dependabot PR이 20개+ 동시에 올라오면 하나 머지할 때마다 나머지가 BEHIND가 됨.
이 워크플로우가 자동으로 업데이트해줘서 수동 개입 없이 순차 머지 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)