### PR TITLE
fix(ci): version-bump CalVer 통합 + dev/main 양쪽 트리거

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -3,10 +3,10 @@ name: Version Bump
 on:
   pull_request:
     types: [closed]
-    branches: [main]
+    branches: [dev, main]
 
 concurrency:
-  group: version-bump
+  group: version-bump-${{ github.base_ref }}
   cancel-in-progress: false
 
 permissions:
@@ -20,76 +20,68 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.base_ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check PR labels for version bump type
-        id: bump-type
-        run: |
-          LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
 
-          if echo "$LABELS" | grep -q '"major"'; then
-            echo "type=major" >> $GITHUB_OUTPUT
-          elif echo "$LABELS" | grep -q '"minor"'; then
-            echo "type=minor" >> $GITHUB_OUTPUT
-          elif echo "$LABELS" | grep -q '"patch"'; then
-            echo "type=patch" >> $GITHUB_OUTPUT
-          else
-            echo "type=skip" >> $GITHUB_OUTPUT
-            echo "No version bump label found (patch/minor/major). Skipping."
-          fi
-
-      - name: Bump version
-        if: steps.bump-type.outputs.type != 'skip'
+      - name: Calculate next CalVer version
         id: version
         run: |
-          CURRENT=$(grep "^version:" apps/app_user/pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
+          BRANCH="${{ github.base_ref }}"
+          CURRENT=$(grep "^version:" apps/app_user/pubspec.yaml | sed 's/version: //' | sed 's/+.*//' | sed 's/-dev$//')
           echo "current=$CURRENT"
 
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
-          BUMP_TYPE="${{ steps.bump-type.outputs.type }}"
+          IFS='.' read -r CUR_YY CUR_MM CUR_PR <<< "$CURRENT"
 
-          case "$BUMP_TYPE" in
-            major)
-              MAJOR=$((MAJOR + 1))
-              MINOR=0
-              PATCH=0
-              ;;
-            minor)
-              MINOR=$((MINOR + 1))
-              PATCH=0
-              ;;
-            patch)
-              PATCH=$((PATCH + 1))
-              ;;
-          esac
+          # Current year/month (2-digit)
+          NOW_YY=$(date -u +%y)
+          NOW_MM=$(date -u +%m)
 
-          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
-          echo "new=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "Bumping $CURRENT → $NEW_VERSION ($BUMP_TYPE)"
+          if [ "$CUR_YY" = "$NOW_YY" ] && [ "$CUR_MM" = "$NOW_MM" ]; then
+            # Same month → increment PR#
+            NEXT_PR=$(( 10#$CUR_PR + 1 ))
+          else
+            # New month → reset PR# to 1
+            NEXT_PR=1
+          fi
 
-      - name: Update pubspec.yaml files
-        if: steps.bump-type.outputs.type != 'skip'
-        run: |
-          NEW_VERSION="${{ steps.version.outputs.new }}"
-          sed -i "s/^version: .*/version: ${NEW_VERSION}+1/" apps/app_user/pubspec.yaml
-          sed -i "s/^version: .*/version: ${NEW_VERSION}+1/" apps/app_partner/pubspec.yaml
+          BASE="${NOW_YY}.${NOW_MM}.${NEXT_PR}"
 
-          echo "Updated app_user:"
-          grep "^version:" apps/app_user/pubspec.yaml
-          echo "Updated app_partner:"
-          grep "^version:" apps/app_partner/pubspec.yaml
+          if [ "$BRANCH" = "dev" ]; then
+            NEW_VERSION="${BASE}-dev"
+          else
+            NEW_VERSION="${BASE}"
+          fi
+
+          echo "new=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+          echo "Bumping $CURRENT → $NEW_VERSION"
+
+      - name: Run bump-version.sh
+        run: bash scripts/bump-version.sh "${{ steps.version.outputs.new }}"
 
       - name: Commit and tag
-        if: steps.bump-type.outputs.type != 'skip'
         run: |
           NEW_VERSION="${{ steps.version.outputs.new }}"
+          BASE="${{ steps.version.outputs.base }}"
+          BRANCH="${{ github.base_ref }}"
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add apps/app_user/pubspec.yaml apps/app_partner/pubspec.yaml
-          git commit -m "chore: bump version to v${NEW_VERSION}"
-          git tag "v${NEW_VERSION}"
-          git push origin main --follow-tags
+          git add -A
+          git commit -m "chore: bump version to v${NEW_VERSION} [skip ci]"
+
+          if [ "$BRANCH" = "main" ]; then
+            git tag "v${BASE}"
+            git push origin main --follow-tags
+          else
+            git push origin dev
+          fi
 
   notify-failure:
     needs: [bump]


### PR DESCRIPTION
## Summary

version-bump.yml을 CalVer 컨벤션에 맞게 재작성하고 bump-version.sh와 통합.

## Before vs After

| | Before | After |
|---|--------|-------|
| 트리거 | main 머지만 | **dev + main** 머지 |
| 버전 로직 | semver (patch/minor/major 라벨) | **CalVer 자동** (같은 월 PR#+1, 새 월 리셋) |
| 업데이트 대상 | app_user, app_partner (2개) | **8개 파일** (bump-version.sh) |
| versionCode | 하드코딩 `+1` | **YYMM*10000+PR#** 자동 계산 |
| dev 버전 | 없음 | `26.03.2-dev` |
| main 버전 | `26.03.2` + tag | `26.03.2` + `v26.03.2` tag |

## 동작 예시

```
dev 머지 #1: 26.03.1-dev → 26.03.2-dev (8개 파일 일괄)
dev 머지 #2: 26.03.2-dev → 26.03.3-dev
4월 첫 머지: 26.03.3-dev → 26.04.1-dev (리셋)
main 릴리즈: 26.04.1
```

## Test plan

- [x] bump-version.sh 단독 실행 검증 (기존 테스트)
- [ ] dev 머지 시 버전 자동 증가 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)