### PR TITLE
fix(ci): supabase db execute → psql 직접 연결로 대체

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install PostgreSQL client
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq postgresql-client
+
       - uses: supabase/setup-cli@v1
         with:
           version: latest
@@ -59,35 +62,27 @@ jobs:
           fi
           supabase secrets set ENVIRONMENT=development
 
-          # Ensure vault has publishable_key for pg_cron → Edge Function auth
+          # Vault: inject publishable_key via psql (supabase db execute removed in recent CLI)
           if [ -z "$SUPABASE_PUBLISHABLE_KEY" ]; then
             echo "::error::SUPABASE_PUBLISHABLE_KEY is not set. Vault injection failed."
             exit 1
           fi
-          supabase db execute <<EOSQL
-          DO \$\$
-          DECLARE
-            v_publishable_secret_id uuid;
-          BEGIN
-            SELECT id INTO v_publishable_secret_id
-            FROM vault.decrypted_secrets
-            WHERE name = 'publishable_key'
-            LIMIT 1;
-
-            IF v_publishable_secret_id IS NULL THEN
-              PERFORM vault.create_secret('${SUPABASE_PUBLISHABLE_KEY}', 'publishable_key', 'Publishable key for EF cron calls');
-              RAISE NOTICE 'vault: publishable_key created';
-            ELSE
-              PERFORM vault.update_secret(
-                v_publishable_secret_id,
-                '${SUPABASE_PUBLISHABLE_KEY}',
-                'publishable_key',
-                'Publishable key for EF cron calls'
-              );
-              RAISE NOTICE 'vault: publishable_key updated';
-            END IF;
-          END \$\$;
-          EOSQL
+          PGPASSWORD="$SUPABASE_DB_PASSWORD" psql \
+            "postgresql://postgres:${SUPABASE_DB_PASSWORD}@db.${SUPABASE_PROJECT_ID}.supabase.co:5432/postgres" \
+            -c "
+            DO \$\$
+            DECLARE v_id uuid;
+            BEGIN
+              SELECT id INTO v_id FROM vault.decrypted_secrets WHERE name = 'publishable_key' LIMIT 1;
+              IF v_id IS NULL THEN
+                PERFORM vault.create_secret('${SUPABASE_PUBLISHABLE_KEY}', 'publishable_key', 'Publishable key for EF cron calls');
+                RAISE NOTICE 'vault: publishable_key created';
+              ELSE
+                PERFORM vault.update_secret(v_id, '${SUPABASE_PUBLISHABLE_KEY}', 'publishable_key', 'Publishable key for EF cron calls');
+                RAISE NOTICE 'vault: publishable_key updated';
+              END IF;
+            END \$\$;
+            "
 
           supabase db push --password $SUPABASE_DB_PASSWORD --include-all
 
@@ -124,35 +119,27 @@ jobs:
           fi
           supabase secrets set ENVIRONMENT=production
 
-          # Ensure vault has publishable_key for pg_cron → Edge Function auth
+          # Vault: inject publishable_key via psql (supabase db execute removed in recent CLI)
           if [ -z "$SUPABASE_PUBLISHABLE_KEY" ]; then
             echo "::error::SUPABASE_PUBLISHABLE_KEY is not set. Vault injection failed."
             exit 1
           fi
-          supabase db execute <<EOSQL
-          DO \$\$
-          DECLARE
-            v_publishable_secret_id uuid;
-          BEGIN
-            SELECT id INTO v_publishable_secret_id
-            FROM vault.decrypted_secrets
-            WHERE name = 'publishable_key'
-            LIMIT 1;
-
-            IF v_publishable_secret_id IS NULL THEN
-              PERFORM vault.create_secret('${SUPABASE_PUBLISHABLE_KEY}', 'publishable_key', 'Publishable key for EF cron calls');
-              RAISE NOTICE 'vault: publishable_key created';
-            ELSE
-              PERFORM vault.update_secret(
-                v_publishable_secret_id,
-                '${SUPABASE_PUBLISHABLE_KEY}',
-                'publishable_key',
-                'Publishable key for EF cron calls'
-              );
-              RAISE NOTICE 'vault: publishable_key updated';
-            END IF;
-          END \$\$;
-          EOSQL
+          PGPASSWORD="$SUPABASE_DB_PASSWORD" psql \
+            "postgresql://postgres:${SUPABASE_DB_PASSWORD}@db.${SUPABASE_PROJECT_ID}.supabase.co:5432/postgres" \
+            -c "
+            DO \$\$
+            DECLARE v_id uuid;
+            BEGIN
+              SELECT id INTO v_id FROM vault.decrypted_secrets WHERE name = 'publishable_key' LIMIT 1;
+              IF v_id IS NULL THEN
+                PERFORM vault.create_secret('${SUPABASE_PUBLISHABLE_KEY}', 'publishable_key', 'Publishable key for EF cron calls');
+                RAISE NOTICE 'vault: publishable_key created';
+              ELSE
+                PERFORM vault.update_secret(v_id, '${SUPABASE_PUBLISHABLE_KEY}', 'publishable_key', 'Publishable key for EF cron calls');
+                RAISE NOTICE 'vault: publishable_key updated';
+              END IF;
+            END \$\$;
+            "
 
           supabase db push --password $SUPABASE_DB_PASSWORD --include-all
 
@@ -173,13 +160,11 @@ jobs:
           fi
 
       - name: Verify migration count
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: |
           EXPECTED=$(ls supabase/migrations/*.sql | wc -l | tr -d ' ')
-          APPLIED=$(supabase db execute \
-            --sql "SELECT count(*)::text FROM supabase_migrations.schema_migrations;" \
-            | grep -oE '[0-9]+' | head -1)
+          APPLIED=$(PGPASSWORD="${{ steps.env.outputs.DB_PASSWORD }}" psql \
+            "postgresql://postgres:${{ steps.env.outputs.DB_PASSWORD }}@db.${{ steps.env.outputs.PROJECT_ID }}.supabase.co:5432/postgres" \
+            -t -A -c "SELECT count(*)::text FROM supabase_migrations.schema_migrations;")
           echo "Expected: $EXPECTED, Applied: $APPLIED"
           if [ "$EXPECTED" != "$APPLIED" ]; then
             echo "::error::Migration count mismatch! Expected $EXPECTED, applied $APPLIED"
@@ -188,24 +173,22 @@ jobs:
           echo "✅ Migration count matches: $APPLIED"
 
       - name: Verify critical DB objects
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: |
-          supabase db execute \
-            --sql "$(cat scripts/verify-db-objects.sql)"
+          PGPASSWORD="${{ steps.env.outputs.DB_PASSWORD }}" psql \
+            "postgresql://postgres:${{ steps.env.outputs.DB_PASSWORD }}@db.${{ steps.env.outputs.PROJECT_ID }}.supabase.co:5432/postgres" \
+            -f scripts/verify-db-objects.sql
 
       # --- DB state snapshot ---
       - name: Generate DB state report
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: |
           ENV="${{ steps.env.outputs.ENV }}"
           REPORT_FILE="docs/snapshots/${ENV}-db-state.md"
           mkdir -p docs/snapshots
           echo "# ${ENV} DB State — $(date -u '+%Y-%m-%d %H:%M UTC')" > "$REPORT_FILE"
           echo "" >> "$REPORT_FILE"
-          supabase db execute \
-            --sql "$(cat scripts/db-snapshot.sql)" >> "$REPORT_FILE"
+          PGPASSWORD="${{ steps.env.outputs.DB_PASSWORD }}" psql \
+            "postgresql://postgres:${{ steps.env.outputs.DB_PASSWORD }}@db.${{ steps.env.outputs.PROJECT_ID }}.supabase.co:5432/postgres" \
+            -f scripts/db-snapshot.sql >> "$REPORT_FILE"
 
       - name: Commit DB state report
         run: |


### PR DESCRIPTION
## Summary
- 최신 Supabase CLI에서 `db execute` 명령 제거로 deploy 실패 (#344) 수정
- vault injection + post-deploy 검증 3곳: `supabase db execute` → `psql` 직접 연결
- CI 러너에 `postgresql-client` 설치 step 추가
- 로컬 테스트 완료 (vault injection, migration count, verify-db-objects, db-snapshot)

Closes #344

## Test plan
- [x] 로컬 psql vault injection 성공
- [x] 로컬 migration count 검증 (56/56)
- [x] 로컬 verify-db-objects 통과
- [x] 로컬 db-snapshot 출력 확인
- [x] YAML lint 통과
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)