### PR TITLE
chore: dependabot PR 그룹화 설정

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      ci-actions:
+        patterns:
+          - "*"
 
   # Next.js Landing User
   - package-ecosystem: "npm"
@@ -12,6 +16,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      landing-user-deps:
+        patterns:
+          - "*"
 
   # Next.js Landing Partner
   - package-ecosystem: "npm"
@@ -19,6 +27,10 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      landing-partner-deps:
+        patterns:
+          - "*"
 
   # Flutter/Dart (pub)
   - package-ecosystem: "pub"
@@ -26,3 +38,7 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
+    groups:
+      flutter-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- dependabot.yml에 그룹화 설정 추가
- 개별 PR 20개 → 카테고리별 1개로 묶어 CI 병목 해소
  - `ci-actions`: GitHub Actions 전체
  - `landing-user-deps`: landing_user npm 전체
  - `landing-partner-deps`: landing_partner npm 전체
  - `flutter-deps`: Flutter/Dart pub 전체

## Test plan
- [ ] 머지 후 기존 dependabot PR 20건 일괄 close
- [ ] 다음 dependabot 스케줄에서 그룹 PR 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)