### PR TITLE
fix(ci): version-bump 기존 브랜치 충돌 방지

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -77,8 +77,26 @@ jobs:
           BRANCH="${{ github.base_ref }}"
           BUMP_BRANCH="chore/version-bump-v${NEW_VERSION}"
 
+          # Fix #350: skip if a bump PR already exists for this version
+          EXISTING_PR=$(gh pr list \
+            --base "$BRANCH" \
+            --head "$BUMP_BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number' \
+            --repo "${{ github.repository }}" 2>/dev/null || true)
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Version bump PR #${EXISTING_PR} already exists for v${NEW_VERSION}. Skipping."
+            exit 0
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Fix #350: delete stale remote branch from previous failed runs
+          git push origin --delete "$BUMP_BRANCH" 2>/dev/null || true
+
           git checkout -b "$BUMP_BRANCH"
           git add -A
           git commit -m "chore: bump version to v${NEW_VERSION}"


### PR DESCRIPTION
## Summary
- Version Bump 워크플로우가 이전 실패 run에서 남은 stale 브랜치로 인해 매번 push 실패하던 문제 수정
- push 전 기존 remote 브랜치 삭제 + 동일 버전 PR이 이미 열려있으면 skip

Closes #350

## Test plan
- [ ] Version Bump 워크플로우가 stale 브랜치 존재 시에도 정상 동작하는지 확인
- [ ] 이미 열린 bump PR이 있을 때 중복 생성하지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)