### PR TITLE
feat: user-update-verification + user-submit-verification EF 구현 + 스키마 개선

### DIFF
--- a/apps/app_partner/lib/src/features/party/event/detail/event_application_controller.dart
+++ b/apps/app_partner/lib/src/features/party/event/detail/event_application_controller.dart
@@ -40,12 +40,12 @@ class EventApplicationReviewController
 
       if (subData != null) {
         final submissionId = subData['id'] as String;
+        // Fix #301: adminComment removed — will be handled by partner EF (#309)
         await repo.reviewRequest(
           submissionId: submissionId,
           status: status == 'approved'
               ? VerificationStatus.approved
               : VerificationStatus.rejected,
-          adminComment: reason,
         );
       } else {
         // No submission, handle direct application status update

--- a/apps/app_partner/lib/src/features/party/event/widgets/event_application_review_dialog.dart
+++ b/apps/app_partner/lib/src/features/party/event/widgets/event_application_review_dialog.dart
@@ -87,7 +87,7 @@ class _EventApplicationReviewDialogState
               const SizedBox(height: MinglitSpacing.small),
               // Fix #301: snapshot_data is now an array of history entries
               ..._extractLatestData(submission.snapshotData).entries.map((
-                MapEntry<String, dynamic> entry,
+                entry,
               ) {
                 final key = entry.key;
                 final value = entry.value;

--- a/apps/app_partner/lib/src/features/party/event/widgets/event_application_review_dialog.dart
+++ b/apps/app_partner/lib/src/features/party/event/widgets/event_application_review_dialog.dart
@@ -1,6 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
+// Fix #301: Extract latest data from snapshot_data array
+Map<String, dynamic> _extractLatestData(List<dynamic> snapshotData) {
+  if (snapshotData.isEmpty) return <String, dynamic>{};
+  final last = snapshotData.last;
+  if (last is Map<String, dynamic>) {
+    return last['data'] as Map<String, dynamic>? ?? <String, dynamic>{};
+  }
+  return <String, dynamic>{};
+}
+
 class EventApplicationReviewDialog extends StatefulWidget {
   const EventApplicationReviewDialog({
     required this.application,
@@ -75,8 +85,9 @@ class _EventApplicationReviewDialogState
                 ),
               ),
               const SizedBox(height: MinglitSpacing.small),
-              ...submission.snapshotData.entries.map((
-                entry,
+              // Fix #301: snapshot_data is now an array of history entries
+              ..._extractLatestData(submission.snapshotData).entries.map((
+                MapEntry<String, dynamic> entry,
               ) {
                 final key = entry.key;
                 final value = entry.value;

--- a/apps/app_partner/lib/src/features/verification/review/review_verification_screen.dart
+++ b/apps/app_partner/lib/src/features/verification/review/review_verification_screen.dart
@@ -56,7 +56,6 @@ class _ReviewVerificationScreenState
   Future<void> _reviewRequest(
     String id,
     VerificationStatus status, {
-    String? reason,
     String? comment,
   }) async {
     final loading = ref.read(globalLoadingControllerProvider.notifier)..show();
@@ -66,7 +65,6 @@ class _ReviewVerificationScreenState
           .reviewRequest(
             submissionId: id,
             status: status,
-            adminComment: reason,
           );
       if (comment != null) {
         await ref
@@ -128,12 +126,14 @@ class _ReviewVerificationScreenState
         ElevatedButton(
           onPressed: () {
             Navigator.pop(context);
+            // Fix #301: needsCorrection removed — use rejected with comment
             unawaited(
               _reviewRequest(
                 submissionId,
-                VerificationStatus.needsCorrection,
-                reason: reasonController.text,
-                comment: commentController.text,
+                VerificationStatus.rejected,
+                comment: commentController.text.isNotEmpty
+                    ? '${reasonController.text}\n${commentController.text}'
+                    : reasonController.text,
               ),
             );
           },
@@ -205,7 +205,13 @@ class _ReviewVerificationScreenState
   Widget _buildRequestCard(Map<String, dynamic> req) {
     final theme = Theme.of(context);
     final user = req['user'] as Map<String, dynamic>? ?? {};
-    final claim = req['snapshot_data'] as Map<String, dynamic>? ?? {};
+    // Fix #301: snapshot_data is now an array of history entries
+    final snapshotRaw = req['snapshot_data'];
+    final snapshotList = snapshotRaw is List ? snapshotRaw : <dynamic>[];
+    final lastEntry = snapshotList.isNotEmpty
+        ? snapshotList.last as Map<String, dynamic>
+        : <String, dynamic>{};
+    final claim = lastEntry['data'] as Map<String, dynamic>? ?? {};
     final images = claim.values
         .whereType<String>()
         .where((val) => val.contains('/'))

--- a/shared/packages/minglit_kit/lib/src/data/models/event.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/event.freezed.dart
@@ -14,1009 +14,416 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$Event {
-  String get id;
-  @JsonKey(name: 'party_id')
-  String get partyId;
-  @JsonKey(name: 'start_time')
-  DateTime get startTime;
-  @JsonKey(name: 'end_time')
-  DateTime get endTime;
-  @JsonKey(name: 'created_at')
-  DateTime get createdAt;
-  @JsonKey(name: 'updated_at')
-  DateTime get updatedAt;
-  @JsonKey(name: 'location_id')
-  String? get locationId;
-  String? get title;
-  Map<String, dynamic>? get description;
-  @JsonKey(name: 'image_urls')
-  List<String>? get imageUrls;
-  @JsonKey(name: 'contact_options')
-  Map<String, dynamic> get contactOptions;
-  Map<String, dynamic> get metadata;
-  @JsonKey(name: 'min_confirmed_count')
-  int get minConfirmedCount;
-  @JsonKey(name: 'max_participants')
-  int get maxParticipants;
-  @JsonKey(name: 'current_participants')
-  int get currentParticipants;
-  String get status;
-  String? get visibility;
-  @JsonKey(includeToJson: false)
-  Location? get location;
-  @JsonKey(includeToJson: false)
-  Party? get party;
-  @JsonKey(includeToJson: false)
-  List<Ticket>? get tickets;
-  @JsonKey(includeToJson: false)
-  List<EntryGroup>? get entryGroups;
 
-  /// Create a copy of Event
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $EventCopyWith<Event> get copyWith =>
-      _$EventCopyWithImpl<Event>(this as Event, _$identity);
+ String get id;@JsonKey(name: 'party_id') String get partyId;@JsonKey(name: 'start_time') DateTime get startTime;@JsonKey(name: 'end_time') DateTime get endTime;@JsonKey(name: 'created_at') DateTime get createdAt;@JsonKey(name: 'updated_at') DateTime get updatedAt;@JsonKey(name: 'location_id') String? get locationId; String? get title; Map<String, dynamic>? get description;@JsonKey(name: 'image_urls') List<String>? get imageUrls;@JsonKey(name: 'contact_options') Map<String, dynamic> get contactOptions; Map<String, dynamic> get metadata;@JsonKey(name: 'min_confirmed_count') int get minConfirmedCount;@JsonKey(name: 'max_participants') int get maxParticipants;@JsonKey(name: 'current_participants') int get currentParticipants; String get status; String? get visibility;@JsonKey(includeToJson: false) Location? get location;@JsonKey(includeToJson: false) Party? get party;@JsonKey(includeToJson: false) List<Ticket>? get tickets;@JsonKey(includeToJson: false) List<EntryGroup>? get entryGroups;
+/// Create a copy of Event
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EventCopyWith<Event> get copyWith => _$EventCopyWithImpl<Event>(this as Event, _$identity);
 
   /// Serializes this Event to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is Event &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.partyId, partyId) || other.partyId == partyId) &&
-            (identical(other.startTime, startTime) ||
-                other.startTime == startTime) &&
-            (identical(other.endTime, endTime) || other.endTime == endTime) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt) &&
-            (identical(other.locationId, locationId) ||
-                other.locationId == locationId) &&
-            (identical(other.title, title) || other.title == title) &&
-            const DeepCollectionEquality()
-                .equals(other.description, description) &&
-            const DeepCollectionEquality().equals(other.imageUrls, imageUrls) &&
-            const DeepCollectionEquality()
-                .equals(other.contactOptions, contactOptions) &&
-            const DeepCollectionEquality().equals(other.metadata, metadata) &&
-            (identical(other.minConfirmedCount, minConfirmedCount) ||
-                other.minConfirmedCount == minConfirmedCount) &&
-            (identical(other.maxParticipants, maxParticipants) ||
-                other.maxParticipants == maxParticipants) &&
-            (identical(other.currentParticipants, currentParticipants) ||
-                other.currentParticipants == currentParticipants) &&
-            (identical(other.status, status) || other.status == status) &&
-            (identical(other.visibility, visibility) ||
-                other.visibility == visibility) &&
-            (identical(other.location, location) ||
-                other.location == location) &&
-            (identical(other.party, party) || other.party == party) &&
-            const DeepCollectionEquality().equals(other.tickets, tickets) &&
-            const DeepCollectionEquality()
-                .equals(other.entryGroups, entryGroups));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hashAll([
-        runtimeType,
-        id,
-        partyId,
-        startTime,
-        endTime,
-        createdAt,
-        updatedAt,
-        locationId,
-        title,
-        const DeepCollectionEquality().hash(description),
-        const DeepCollectionEquality().hash(imageUrls),
-        const DeepCollectionEquality().hash(contactOptions),
-        const DeepCollectionEquality().hash(metadata),
-        minConfirmedCount,
-        maxParticipants,
-        currentParticipants,
-        status,
-        visibility,
-        location,
-        party,
-        const DeepCollectionEquality().hash(tickets),
-        const DeepCollectionEquality().hash(entryGroups)
-      ]);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Event&&(identical(other.id, id) || other.id == id)&&(identical(other.partyId, partyId) || other.partyId == partyId)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.endTime, endTime) || other.endTime == endTime)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.locationId, locationId) || other.locationId == locationId)&&(identical(other.title, title) || other.title == title)&&const DeepCollectionEquality().equals(other.description, description)&&const DeepCollectionEquality().equals(other.imageUrls, imageUrls)&&const DeepCollectionEquality().equals(other.contactOptions, contactOptions)&&const DeepCollectionEquality().equals(other.metadata, metadata)&&(identical(other.minConfirmedCount, minConfirmedCount) || other.minConfirmedCount == minConfirmedCount)&&(identical(other.maxParticipants, maxParticipants) || other.maxParticipants == maxParticipants)&&(identical(other.currentParticipants, currentParticipants) || other.currentParticipants == currentParticipants)&&(identical(other.status, status) || other.status == status)&&(identical(other.visibility, visibility) || other.visibility == visibility)&&(identical(other.location, location) || other.location == location)&&(identical(other.party, party) || other.party == party)&&const DeepCollectionEquality().equals(other.tickets, tickets)&&const DeepCollectionEquality().equals(other.entryGroups, entryGroups));
+}
 
-  @override
-  String toString() {
-    return 'Event(id: $id, partyId: $partyId, startTime: $startTime, endTime: $endTime, createdAt: $createdAt, updatedAt: $updatedAt, locationId: $locationId, title: $title, description: $description, imageUrls: $imageUrls, contactOptions: $contactOptions, metadata: $metadata, minConfirmedCount: $minConfirmedCount, maxParticipants: $maxParticipants, currentParticipants: $currentParticipants, status: $status, visibility: $visibility, location: $location, party: $party, tickets: $tickets, entryGroups: $entryGroups)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hashAll([runtimeType,id,partyId,startTime,endTime,createdAt,updatedAt,locationId,title,const DeepCollectionEquality().hash(description),const DeepCollectionEquality().hash(imageUrls),const DeepCollectionEquality().hash(contactOptions),const DeepCollectionEquality().hash(metadata),minConfirmedCount,maxParticipants,currentParticipants,status,visibility,location,party,const DeepCollectionEquality().hash(tickets),const DeepCollectionEquality().hash(entryGroups)]);
+
+@override
+String toString() {
+  return 'Event(id: $id, partyId: $partyId, startTime: $startTime, endTime: $endTime, createdAt: $createdAt, updatedAt: $updatedAt, locationId: $locationId, title: $title, description: $description, imageUrls: $imageUrls, contactOptions: $contactOptions, metadata: $metadata, minConfirmedCount: $minConfirmedCount, maxParticipants: $maxParticipants, currentParticipants: $currentParticipants, status: $status, visibility: $visibility, location: $location, party: $party, tickets: $tickets, entryGroups: $entryGroups)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $EventCopyWith<$Res> {
-  factory $EventCopyWith(Event value, $Res Function(Event) _then) =
-      _$EventCopyWithImpl;
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'party_id') String partyId,
-      @JsonKey(name: 'start_time') DateTime startTime,
-      @JsonKey(name: 'end_time') DateTime endTime,
-      @JsonKey(name: 'created_at') DateTime createdAt,
-      @JsonKey(name: 'updated_at') DateTime updatedAt,
-      @JsonKey(name: 'location_id') String? locationId,
-      String? title,
-      Map<String, dynamic>? description,
-      @JsonKey(name: 'image_urls') List<String>? imageUrls,
-      @JsonKey(name: 'contact_options') Map<String, dynamic> contactOptions,
-      Map<String, dynamic> metadata,
-      @JsonKey(name: 'min_confirmed_count') int minConfirmedCount,
-      @JsonKey(name: 'max_participants') int maxParticipants,
-      @JsonKey(name: 'current_participants') int currentParticipants,
-      String status,
-      String? visibility,
-      @JsonKey(includeToJson: false) Location? location,
-      @JsonKey(includeToJson: false) Party? party,
-      @JsonKey(includeToJson: false) List<Ticket>? tickets,
-      @JsonKey(includeToJson: false) List<EntryGroup>? entryGroups});
+abstract mixin class $EventCopyWith<$Res>  {
+  factory $EventCopyWith(Event value, $Res Function(Event) _then) = _$EventCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(name: 'party_id') String partyId,@JsonKey(name: 'start_time') DateTime startTime,@JsonKey(name: 'end_time') DateTime endTime,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'location_id') String? locationId, String? title, Map<String, dynamic>? description,@JsonKey(name: 'image_urls') List<String>? imageUrls,@JsonKey(name: 'contact_options') Map<String, dynamic> contactOptions, Map<String, dynamic> metadata,@JsonKey(name: 'min_confirmed_count') int minConfirmedCount,@JsonKey(name: 'max_participants') int maxParticipants,@JsonKey(name: 'current_participants') int currentParticipants, String status, String? visibility,@JsonKey(includeToJson: false) Location? location,@JsonKey(includeToJson: false) Party? party,@JsonKey(includeToJson: false) List<Ticket>? tickets,@JsonKey(includeToJson: false) List<EntryGroup>? entryGroups
+});
 
-  $LocationCopyWith<$Res>? get location;
-  $PartyCopyWith<$Res>? get party;
+
+$LocationCopyWith<$Res>? get location;$PartyCopyWith<$Res>? get party;
+
 }
-
 /// @nodoc
-class _$EventCopyWithImpl<$Res> implements $EventCopyWith<$Res> {
+class _$EventCopyWithImpl<$Res>
+    implements $EventCopyWith<$Res> {
   _$EventCopyWithImpl(this._self, this._then);
 
   final Event _self;
   final $Res Function(Event) _then;
 
-  /// Create a copy of Event
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? partyId = null,
-    Object? startTime = null,
-    Object? endTime = null,
-    Object? createdAt = null,
-    Object? updatedAt = null,
-    Object? locationId = freezed,
-    Object? title = freezed,
-    Object? description = freezed,
-    Object? imageUrls = freezed,
-    Object? contactOptions = null,
-    Object? metadata = null,
-    Object? minConfirmedCount = null,
-    Object? maxParticipants = null,
-    Object? currentParticipants = null,
-    Object? status = null,
-    Object? visibility = freezed,
-    Object? location = freezed,
-    Object? party = freezed,
-    Object? tickets = freezed,
-    Object? entryGroups = freezed,
-  }) {
-    return _then(_self.copyWith(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      partyId: null == partyId
-          ? _self.partyId
-          : partyId // ignore: cast_nullable_to_non_nullable
-              as String,
-      startTime: null == startTime
-          ? _self.startTime
-          : startTime // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      endTime: null == endTime
-          ? _self.endTime
-          : endTime // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updatedAt: null == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      locationId: freezed == locationId
-          ? _self.locationId
-          : locationId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      title: freezed == title
-          ? _self.title
-          : title // ignore: cast_nullable_to_non_nullable
-              as String?,
-      description: freezed == description
-          ? _self.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>?,
-      imageUrls: freezed == imageUrls
-          ? _self.imageUrls
-          : imageUrls // ignore: cast_nullable_to_non_nullable
-              as List<String>?,
-      contactOptions: null == contactOptions
-          ? _self.contactOptions
-          : contactOptions // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>,
-      metadata: null == metadata
-          ? _self.metadata
-          : metadata // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>,
-      minConfirmedCount: null == minConfirmedCount
-          ? _self.minConfirmedCount
-          : minConfirmedCount // ignore: cast_nullable_to_non_nullable
-              as int,
-      maxParticipants: null == maxParticipants
-          ? _self.maxParticipants
-          : maxParticipants // ignore: cast_nullable_to_non_nullable
-              as int,
-      currentParticipants: null == currentParticipants
-          ? _self.currentParticipants
-          : currentParticipants // ignore: cast_nullable_to_non_nullable
-              as int,
-      status: null == status
-          ? _self.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as String,
-      visibility: freezed == visibility
-          ? _self.visibility
-          : visibility // ignore: cast_nullable_to_non_nullable
-              as String?,
-      location: freezed == location
-          ? _self.location
-          : location // ignore: cast_nullable_to_non_nullable
-              as Location?,
-      party: freezed == party
-          ? _self.party
-          : party // ignore: cast_nullable_to_non_nullable
-              as Party?,
-      tickets: freezed == tickets
-          ? _self.tickets
-          : tickets // ignore: cast_nullable_to_non_nullable
-              as List<Ticket>?,
-      entryGroups: freezed == entryGroups
-          ? _self.entryGroups
-          : entryGroups // ignore: cast_nullable_to_non_nullable
-              as List<EntryGroup>?,
-    ));
-  }
-
-  /// Create a copy of Event
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $LocationCopyWith<$Res>? get location {
-    if (_self.location == null) {
-      return null;
-    }
-
-    return $LocationCopyWith<$Res>(_self.location!, (value) {
-      return _then(_self.copyWith(location: value));
-    });
-  }
-
-  /// Create a copy of Event
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $PartyCopyWith<$Res>? get party {
-    if (_self.party == null) {
-      return null;
-    }
-
-    return $PartyCopyWith<$Res>(_self.party!, (value) {
-      return _then(_self.copyWith(party: value));
-    });
-  }
+/// Create a copy of Event
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? partyId = null,Object? startTime = null,Object? endTime = null,Object? createdAt = null,Object? updatedAt = null,Object? locationId = freezed,Object? title = freezed,Object? description = freezed,Object? imageUrls = freezed,Object? contactOptions = null,Object? metadata = null,Object? minConfirmedCount = null,Object? maxParticipants = null,Object? currentParticipants = null,Object? status = null,Object? visibility = freezed,Object? location = freezed,Object? party = freezed,Object? tickets = freezed,Object? entryGroups = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,startTime: null == startTime ? _self.startTime : startTime // ignore: cast_nullable_to_non_nullable
+as DateTime,endTime: null == endTime ? _self.endTime : endTime // ignore: cast_nullable_to_non_nullable
+as DateTime,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,locationId: freezed == locationId ? _self.locationId : locationId // ignore: cast_nullable_to_non_nullable
+as String?,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,imageUrls: freezed == imageUrls ? _self.imageUrls : imageUrls // ignore: cast_nullable_to_non_nullable
+as List<String>?,contactOptions: null == contactOptions ? _self.contactOptions : contactOptions // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>,metadata: null == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>,minConfirmedCount: null == minConfirmedCount ? _self.minConfirmedCount : minConfirmedCount // ignore: cast_nullable_to_non_nullable
+as int,maxParticipants: null == maxParticipants ? _self.maxParticipants : maxParticipants // ignore: cast_nullable_to_non_nullable
+as int,currentParticipants: null == currentParticipants ? _self.currentParticipants : currentParticipants // ignore: cast_nullable_to_non_nullable
+as int,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,visibility: freezed == visibility ? _self.visibility : visibility // ignore: cast_nullable_to_non_nullable
+as String?,location: freezed == location ? _self.location : location // ignore: cast_nullable_to_non_nullable
+as Location?,party: freezed == party ? _self.party : party // ignore: cast_nullable_to_non_nullable
+as Party?,tickets: freezed == tickets ? _self.tickets : tickets // ignore: cast_nullable_to_non_nullable
+as List<Ticket>?,entryGroups: freezed == entryGroups ? _self.entryGroups : entryGroups // ignore: cast_nullable_to_non_nullable
+as List<EntryGroup>?,
+  ));
 }
+/// Create a copy of Event
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$LocationCopyWith<$Res>? get location {
+    if (_self.location == null) {
+    return null;
+  }
+
+  return $LocationCopyWith<$Res>(_self.location!, (value) {
+    return _then(_self.copyWith(location: value));
+  });
+}/// Create a copy of Event
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$PartyCopyWith<$Res>? get party {
+    if (_self.party == null) {
+    return null;
+  }
+
+  return $PartyCopyWith<$Res>(_self.party!, (value) {
+    return _then(_self.copyWith(party: value));
+  });
+}
+}
+
 
 /// Adds pattern-matching-related methods to [Event].
 extension EventPatterns on Event {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_Event value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Event() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Event value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Event() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_Event value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Event():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Event value)  $default,){
+final _that = this;
+switch (_that) {
+case _Event():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_Event value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Event() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Event value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Event() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'party_id') String partyId,
-            @JsonKey(name: 'start_time') DateTime startTime,
-            @JsonKey(name: 'end_time') DateTime endTime,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'location_id') String? locationId,
-            String? title,
-            Map<String, dynamic>? description,
-            @JsonKey(name: 'image_urls') List<String>? imageUrls,
-            @JsonKey(name: 'contact_options')
-            Map<String, dynamic> contactOptions,
-            Map<String, dynamic> metadata,
-            @JsonKey(name: 'min_confirmed_count') int minConfirmedCount,
-            @JsonKey(name: 'max_participants') int maxParticipants,
-            @JsonKey(name: 'current_participants') int currentParticipants,
-            String status,
-            String? visibility,
-            @JsonKey(includeToJson: false) Location? location,
-            @JsonKey(includeToJson: false) Party? party,
-            @JsonKey(includeToJson: false) List<Ticket>? tickets,
-            @JsonKey(includeToJson: false) List<EntryGroup>? entryGroups)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Event() when $default != null:
-        return $default(
-            _that.id,
-            _that.partyId,
-            _that.startTime,
-            _that.endTime,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.locationId,
-            _that.title,
-            _that.description,
-            _that.imageUrls,
-            _that.contactOptions,
-            _that.metadata,
-            _that.minConfirmedCount,
-            _that.maxParticipants,
-            _that.currentParticipants,
-            _that.status,
-            _that.visibility,
-            _that.location,
-            _that.party,
-            _that.tickets,
-            _that.entryGroups);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'start_time')  DateTime startTime, @JsonKey(name: 'end_time')  DateTime endTime, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'location_id')  String? locationId,  String? title,  Map<String, dynamic>? description, @JsonKey(name: 'image_urls')  List<String>? imageUrls, @JsonKey(name: 'contact_options')  Map<String, dynamic> contactOptions,  Map<String, dynamic> metadata, @JsonKey(name: 'min_confirmed_count')  int minConfirmedCount, @JsonKey(name: 'max_participants')  int maxParticipants, @JsonKey(name: 'current_participants')  int currentParticipants,  String status,  String? visibility, @JsonKey(includeToJson: false)  Location? location, @JsonKey(includeToJson: false)  Party? party, @JsonKey(includeToJson: false)  List<Ticket>? tickets, @JsonKey(includeToJson: false)  List<EntryGroup>? entryGroups)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Event() when $default != null:
+return $default(_that.id,_that.partyId,_that.startTime,_that.endTime,_that.createdAt,_that.updatedAt,_that.locationId,_that.title,_that.description,_that.imageUrls,_that.contactOptions,_that.metadata,_that.minConfirmedCount,_that.maxParticipants,_that.currentParticipants,_that.status,_that.visibility,_that.location,_that.party,_that.tickets,_that.entryGroups);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'party_id') String partyId,
-            @JsonKey(name: 'start_time') DateTime startTime,
-            @JsonKey(name: 'end_time') DateTime endTime,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'location_id') String? locationId,
-            String? title,
-            Map<String, dynamic>? description,
-            @JsonKey(name: 'image_urls') List<String>? imageUrls,
-            @JsonKey(name: 'contact_options')
-            Map<String, dynamic> contactOptions,
-            Map<String, dynamic> metadata,
-            @JsonKey(name: 'min_confirmed_count') int minConfirmedCount,
-            @JsonKey(name: 'max_participants') int maxParticipants,
-            @JsonKey(name: 'current_participants') int currentParticipants,
-            String status,
-            String? visibility,
-            @JsonKey(includeToJson: false) Location? location,
-            @JsonKey(includeToJson: false) Party? party,
-            @JsonKey(includeToJson: false) List<Ticket>? tickets,
-            @JsonKey(includeToJson: false) List<EntryGroup>? entryGroups)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Event():
-        return $default(
-            _that.id,
-            _that.partyId,
-            _that.startTime,
-            _that.endTime,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.locationId,
-            _that.title,
-            _that.description,
-            _that.imageUrls,
-            _that.contactOptions,
-            _that.metadata,
-            _that.minConfirmedCount,
-            _that.maxParticipants,
-            _that.currentParticipants,
-            _that.status,
-            _that.visibility,
-            _that.location,
-            _that.party,
-            _that.tickets,
-            _that.entryGroups);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'start_time')  DateTime startTime, @JsonKey(name: 'end_time')  DateTime endTime, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'location_id')  String? locationId,  String? title,  Map<String, dynamic>? description, @JsonKey(name: 'image_urls')  List<String>? imageUrls, @JsonKey(name: 'contact_options')  Map<String, dynamic> contactOptions,  Map<String, dynamic> metadata, @JsonKey(name: 'min_confirmed_count')  int minConfirmedCount, @JsonKey(name: 'max_participants')  int maxParticipants, @JsonKey(name: 'current_participants')  int currentParticipants,  String status,  String? visibility, @JsonKey(includeToJson: false)  Location? location, @JsonKey(includeToJson: false)  Party? party, @JsonKey(includeToJson: false)  List<Ticket>? tickets, @JsonKey(includeToJson: false)  List<EntryGroup>? entryGroups)  $default,) {final _that = this;
+switch (_that) {
+case _Event():
+return $default(_that.id,_that.partyId,_that.startTime,_that.endTime,_that.createdAt,_that.updatedAt,_that.locationId,_that.title,_that.description,_that.imageUrls,_that.contactOptions,_that.metadata,_that.minConfirmedCount,_that.maxParticipants,_that.currentParticipants,_that.status,_that.visibility,_that.location,_that.party,_that.tickets,_that.entryGroups);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String id,
-            @JsonKey(name: 'party_id') String partyId,
-            @JsonKey(name: 'start_time') DateTime startTime,
-            @JsonKey(name: 'end_time') DateTime endTime,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'location_id') String? locationId,
-            String? title,
-            Map<String, dynamic>? description,
-            @JsonKey(name: 'image_urls') List<String>? imageUrls,
-            @JsonKey(name: 'contact_options')
-            Map<String, dynamic> contactOptions,
-            Map<String, dynamic> metadata,
-            @JsonKey(name: 'min_confirmed_count') int minConfirmedCount,
-            @JsonKey(name: 'max_participants') int maxParticipants,
-            @JsonKey(name: 'current_participants') int currentParticipants,
-            String status,
-            String? visibility,
-            @JsonKey(includeToJson: false) Location? location,
-            @JsonKey(includeToJson: false) Party? party,
-            @JsonKey(includeToJson: false) List<Ticket>? tickets,
-            @JsonKey(includeToJson: false) List<EntryGroup>? entryGroups)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Event() when $default != null:
-        return $default(
-            _that.id,
-            _that.partyId,
-            _that.startTime,
-            _that.endTime,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.locationId,
-            _that.title,
-            _that.description,
-            _that.imageUrls,
-            _that.contactOptions,
-            _that.metadata,
-            _that.minConfirmedCount,
-            _that.maxParticipants,
-            _that.currentParticipants,
-            _that.status,
-            _that.visibility,
-            _that.location,
-            _that.party,
-            _that.tickets,
-            _that.entryGroups);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'party_id')  String partyId, @JsonKey(name: 'start_time')  DateTime startTime, @JsonKey(name: 'end_time')  DateTime endTime, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'location_id')  String? locationId,  String? title,  Map<String, dynamic>? description, @JsonKey(name: 'image_urls')  List<String>? imageUrls, @JsonKey(name: 'contact_options')  Map<String, dynamic> contactOptions,  Map<String, dynamic> metadata, @JsonKey(name: 'min_confirmed_count')  int minConfirmedCount, @JsonKey(name: 'max_participants')  int maxParticipants, @JsonKey(name: 'current_participants')  int currentParticipants,  String status,  String? visibility, @JsonKey(includeToJson: false)  Location? location, @JsonKey(includeToJson: false)  Party? party, @JsonKey(includeToJson: false)  List<Ticket>? tickets, @JsonKey(includeToJson: false)  List<EntryGroup>? entryGroups)?  $default,) {final _that = this;
+switch (_that) {
+case _Event() when $default != null:
+return $default(_that.id,_that.partyId,_that.startTime,_that.endTime,_that.createdAt,_that.updatedAt,_that.locationId,_that.title,_that.description,_that.imageUrls,_that.contactOptions,_that.metadata,_that.minConfirmedCount,_that.maxParticipants,_that.currentParticipants,_that.status,_that.visibility,_that.location,_that.party,_that.tickets,_that.entryGroups);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _Event extends Event {
-  const _Event(
-      {required this.id,
-      @JsonKey(name: 'party_id') required this.partyId,
-      @JsonKey(name: 'start_time') required this.startTime,
-      @JsonKey(name: 'end_time') required this.endTime,
-      @JsonKey(name: 'created_at') required this.createdAt,
-      @JsonKey(name: 'updated_at') required this.updatedAt,
-      @JsonKey(name: 'location_id') this.locationId,
-      this.title,
-      final Map<String, dynamic>? description,
-      @JsonKey(name: 'image_urls') final List<String>? imageUrls,
-      @JsonKey(name: 'contact_options')
-      final Map<String, dynamic> contactOptions = const {},
-      final Map<String, dynamic> metadata = const {},
-      @JsonKey(name: 'min_confirmed_count') this.minConfirmedCount = 0,
-      @JsonKey(name: 'max_participants') this.maxParticipants = 20,
-      @JsonKey(name: 'current_participants') this.currentParticipants = 0,
-      this.status = 'scheduled',
-      this.visibility,
-      @JsonKey(includeToJson: false) this.location,
-      @JsonKey(includeToJson: false) this.party,
-      @JsonKey(includeToJson: false) final List<Ticket>? tickets,
-      @JsonKey(includeToJson: false) final List<EntryGroup>? entryGroups})
-      : _description = description,
-        _imageUrls = imageUrls,
-        _contactOptions = contactOptions,
-        _metadata = metadata,
-        _tickets = tickets,
-        _entryGroups = entryGroups,
-        super._();
+  const _Event({required this.id, @JsonKey(name: 'party_id') required this.partyId, @JsonKey(name: 'start_time') required this.startTime, @JsonKey(name: 'end_time') required this.endTime, @JsonKey(name: 'created_at') required this.createdAt, @JsonKey(name: 'updated_at') required this.updatedAt, @JsonKey(name: 'location_id') this.locationId, this.title, final  Map<String, dynamic>? description, @JsonKey(name: 'image_urls') final  List<String>? imageUrls, @JsonKey(name: 'contact_options') final  Map<String, dynamic> contactOptions = const {}, final  Map<String, dynamic> metadata = const {}, @JsonKey(name: 'min_confirmed_count') this.minConfirmedCount = 0, @JsonKey(name: 'max_participants') this.maxParticipants = 20, @JsonKey(name: 'current_participants') this.currentParticipants = 0, this.status = 'scheduled', this.visibility, @JsonKey(includeToJson: false) this.location, @JsonKey(includeToJson: false) this.party, @JsonKey(includeToJson: false) final  List<Ticket>? tickets, @JsonKey(includeToJson: false) final  List<EntryGroup>? entryGroups}): _description = description,_imageUrls = imageUrls,_contactOptions = contactOptions,_metadata = metadata,_tickets = tickets,_entryGroups = entryGroups,super._();
   factory _Event.fromJson(Map<String, dynamic> json) => _$EventFromJson(json);
 
-  @override
-  final String id;
-  @override
-  @JsonKey(name: 'party_id')
-  final String partyId;
-  @override
-  @JsonKey(name: 'start_time')
-  final DateTime startTime;
-  @override
-  @JsonKey(name: 'end_time')
-  final DateTime endTime;
-  @override
-  @JsonKey(name: 'created_at')
-  final DateTime createdAt;
-  @override
-  @JsonKey(name: 'updated_at')
-  final DateTime updatedAt;
-  @override
-  @JsonKey(name: 'location_id')
-  final String? locationId;
-  @override
-  final String? title;
-  final Map<String, dynamic>? _description;
-  @override
-  Map<String, dynamic>? get description {
-    final value = _description;
-    if (value == null) return null;
-    if (_description is EqualUnmodifiableMapView) return _description;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(value);
-  }
+@override final  String id;
+@override@JsonKey(name: 'party_id') final  String partyId;
+@override@JsonKey(name: 'start_time') final  DateTime startTime;
+@override@JsonKey(name: 'end_time') final  DateTime endTime;
+@override@JsonKey(name: 'created_at') final  DateTime createdAt;
+@override@JsonKey(name: 'updated_at') final  DateTime updatedAt;
+@override@JsonKey(name: 'location_id') final  String? locationId;
+@override final  String? title;
+ final  Map<String, dynamic>? _description;
+@override Map<String, dynamic>? get description {
+  final value = _description;
+  if (value == null) return null;
+  if (_description is EqualUnmodifiableMapView) return _description;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
 
-  final List<String>? _imageUrls;
-  @override
-  @JsonKey(name: 'image_urls')
-  List<String>? get imageUrls {
-    final value = _imageUrls;
-    if (value == null) return null;
-    if (_imageUrls is EqualUnmodifiableListView) return _imageUrls;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
+ final  List<String>? _imageUrls;
+@override@JsonKey(name: 'image_urls') List<String>? get imageUrls {
+  final value = _imageUrls;
+  if (value == null) return null;
+  if (_imageUrls is EqualUnmodifiableListView) return _imageUrls;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
 
-  final Map<String, dynamic> _contactOptions;
-  @override
-  @JsonKey(name: 'contact_options')
-  Map<String, dynamic> get contactOptions {
-    if (_contactOptions is EqualUnmodifiableMapView) return _contactOptions;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(_contactOptions);
-  }
+ final  Map<String, dynamic> _contactOptions;
+@override@JsonKey(name: 'contact_options') Map<String, dynamic> get contactOptions {
+  if (_contactOptions is EqualUnmodifiableMapView) return _contactOptions;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_contactOptions);
+}
 
-  final Map<String, dynamic> _metadata;
-  @override
-  @JsonKey()
-  Map<String, dynamic> get metadata {
-    if (_metadata is EqualUnmodifiableMapView) return _metadata;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(_metadata);
-  }
+ final  Map<String, dynamic> _metadata;
+@override@JsonKey() Map<String, dynamic> get metadata {
+  if (_metadata is EqualUnmodifiableMapView) return _metadata;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_metadata);
+}
 
-  @override
-  @JsonKey(name: 'min_confirmed_count')
-  final int minConfirmedCount;
-  @override
-  @JsonKey(name: 'max_participants')
-  final int maxParticipants;
-  @override
-  @JsonKey(name: 'current_participants')
-  final int currentParticipants;
-  @override
-  @JsonKey()
-  final String status;
-  @override
-  final String? visibility;
-  @override
-  @JsonKey(includeToJson: false)
-  final Location? location;
-  @override
-  @JsonKey(includeToJson: false)
-  final Party? party;
-  final List<Ticket>? _tickets;
-  @override
-  @JsonKey(includeToJson: false)
-  List<Ticket>? get tickets {
-    final value = _tickets;
-    if (value == null) return null;
-    if (_tickets is EqualUnmodifiableListView) return _tickets;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
+@override@JsonKey(name: 'min_confirmed_count') final  int minConfirmedCount;
+@override@JsonKey(name: 'max_participants') final  int maxParticipants;
+@override@JsonKey(name: 'current_participants') final  int currentParticipants;
+@override@JsonKey() final  String status;
+@override final  String? visibility;
+@override@JsonKey(includeToJson: false) final  Location? location;
+@override@JsonKey(includeToJson: false) final  Party? party;
+ final  List<Ticket>? _tickets;
+@override@JsonKey(includeToJson: false) List<Ticket>? get tickets {
+  final value = _tickets;
+  if (value == null) return null;
+  if (_tickets is EqualUnmodifiableListView) return _tickets;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
 
-  final List<EntryGroup>? _entryGroups;
-  @override
-  @JsonKey(includeToJson: false)
-  List<EntryGroup>? get entryGroups {
-    final value = _entryGroups;
-    if (value == null) return null;
-    if (_entryGroups is EqualUnmodifiableListView) return _entryGroups;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
+ final  List<EntryGroup>? _entryGroups;
+@override@JsonKey(includeToJson: false) List<EntryGroup>? get entryGroups {
+  final value = _entryGroups;
+  if (value == null) return null;
+  if (_entryGroups is EqualUnmodifiableListView) return _entryGroups;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
 
-  /// Create a copy of Event
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$EventCopyWith<_Event> get copyWith =>
-      __$EventCopyWithImpl<_Event>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$EventToJson(
-      this,
-    );
-  }
+/// Create a copy of Event
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EventCopyWith<_Event> get copyWith => __$EventCopyWithImpl<_Event>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _Event &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.partyId, partyId) || other.partyId == partyId) &&
-            (identical(other.startTime, startTime) ||
-                other.startTime == startTime) &&
-            (identical(other.endTime, endTime) || other.endTime == endTime) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt) &&
-            (identical(other.locationId, locationId) ||
-                other.locationId == locationId) &&
-            (identical(other.title, title) || other.title == title) &&
-            const DeepCollectionEquality()
-                .equals(other._description, _description) &&
-            const DeepCollectionEquality()
-                .equals(other._imageUrls, _imageUrls) &&
-            const DeepCollectionEquality()
-                .equals(other._contactOptions, _contactOptions) &&
-            const DeepCollectionEquality().equals(other._metadata, _metadata) &&
-            (identical(other.minConfirmedCount, minConfirmedCount) ||
-                other.minConfirmedCount == minConfirmedCount) &&
-            (identical(other.maxParticipants, maxParticipants) ||
-                other.maxParticipants == maxParticipants) &&
-            (identical(other.currentParticipants, currentParticipants) ||
-                other.currentParticipants == currentParticipants) &&
-            (identical(other.status, status) || other.status == status) &&
-            (identical(other.visibility, visibility) ||
-                other.visibility == visibility) &&
-            (identical(other.location, location) ||
-                other.location == location) &&
-            (identical(other.party, party) || other.party == party) &&
-            const DeepCollectionEquality().equals(other._tickets, _tickets) &&
-            const DeepCollectionEquality()
-                .equals(other._entryGroups, _entryGroups));
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$EventToJson(this, );
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hashAll([
-        runtimeType,
-        id,
-        partyId,
-        startTime,
-        endTime,
-        createdAt,
-        updatedAt,
-        locationId,
-        title,
-        const DeepCollectionEquality().hash(_description),
-        const DeepCollectionEquality().hash(_imageUrls),
-        const DeepCollectionEquality().hash(_contactOptions),
-        const DeepCollectionEquality().hash(_metadata),
-        minConfirmedCount,
-        maxParticipants,
-        currentParticipants,
-        status,
-        visibility,
-        location,
-        party,
-        const DeepCollectionEquality().hash(_tickets),
-        const DeepCollectionEquality().hash(_entryGroups)
-      ]);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Event&&(identical(other.id, id) || other.id == id)&&(identical(other.partyId, partyId) || other.partyId == partyId)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.endTime, endTime) || other.endTime == endTime)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.locationId, locationId) || other.locationId == locationId)&&(identical(other.title, title) || other.title == title)&&const DeepCollectionEquality().equals(other._description, _description)&&const DeepCollectionEquality().equals(other._imageUrls, _imageUrls)&&const DeepCollectionEquality().equals(other._contactOptions, _contactOptions)&&const DeepCollectionEquality().equals(other._metadata, _metadata)&&(identical(other.minConfirmedCount, minConfirmedCount) || other.minConfirmedCount == minConfirmedCount)&&(identical(other.maxParticipants, maxParticipants) || other.maxParticipants == maxParticipants)&&(identical(other.currentParticipants, currentParticipants) || other.currentParticipants == currentParticipants)&&(identical(other.status, status) || other.status == status)&&(identical(other.visibility, visibility) || other.visibility == visibility)&&(identical(other.location, location) || other.location == location)&&(identical(other.party, party) || other.party == party)&&const DeepCollectionEquality().equals(other._tickets, _tickets)&&const DeepCollectionEquality().equals(other._entryGroups, _entryGroups));
+}
 
-  @override
-  String toString() {
-    return 'Event(id: $id, partyId: $partyId, startTime: $startTime, endTime: $endTime, createdAt: $createdAt, updatedAt: $updatedAt, locationId: $locationId, title: $title, description: $description, imageUrls: $imageUrls, contactOptions: $contactOptions, metadata: $metadata, minConfirmedCount: $minConfirmedCount, maxParticipants: $maxParticipants, currentParticipants: $currentParticipants, status: $status, visibility: $visibility, location: $location, party: $party, tickets: $tickets, entryGroups: $entryGroups)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hashAll([runtimeType,id,partyId,startTime,endTime,createdAt,updatedAt,locationId,title,const DeepCollectionEquality().hash(_description),const DeepCollectionEquality().hash(_imageUrls),const DeepCollectionEquality().hash(_contactOptions),const DeepCollectionEquality().hash(_metadata),minConfirmedCount,maxParticipants,currentParticipants,status,visibility,location,party,const DeepCollectionEquality().hash(_tickets),const DeepCollectionEquality().hash(_entryGroups)]);
+
+@override
+String toString() {
+  return 'Event(id: $id, partyId: $partyId, startTime: $startTime, endTime: $endTime, createdAt: $createdAt, updatedAt: $updatedAt, locationId: $locationId, title: $title, description: $description, imageUrls: $imageUrls, contactOptions: $contactOptions, metadata: $metadata, minConfirmedCount: $minConfirmedCount, maxParticipants: $maxParticipants, currentParticipants: $currentParticipants, status: $status, visibility: $visibility, location: $location, party: $party, tickets: $tickets, entryGroups: $entryGroups)';
+}
+
+
 }
 
 /// @nodoc
 abstract mixin class _$EventCopyWith<$Res> implements $EventCopyWith<$Res> {
-  factory _$EventCopyWith(_Event value, $Res Function(_Event) _then) =
-      __$EventCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'party_id') String partyId,
-      @JsonKey(name: 'start_time') DateTime startTime,
-      @JsonKey(name: 'end_time') DateTime endTime,
-      @JsonKey(name: 'created_at') DateTime createdAt,
-      @JsonKey(name: 'updated_at') DateTime updatedAt,
-      @JsonKey(name: 'location_id') String? locationId,
-      String? title,
-      Map<String, dynamic>? description,
-      @JsonKey(name: 'image_urls') List<String>? imageUrls,
-      @JsonKey(name: 'contact_options') Map<String, dynamic> contactOptions,
-      Map<String, dynamic> metadata,
-      @JsonKey(name: 'min_confirmed_count') int minConfirmedCount,
-      @JsonKey(name: 'max_participants') int maxParticipants,
-      @JsonKey(name: 'current_participants') int currentParticipants,
-      String status,
-      String? visibility,
-      @JsonKey(includeToJson: false) Location? location,
-      @JsonKey(includeToJson: false) Party? party,
-      @JsonKey(includeToJson: false) List<Ticket>? tickets,
-      @JsonKey(includeToJson: false) List<EntryGroup>? entryGroups});
+  factory _$EventCopyWith(_Event value, $Res Function(_Event) _then) = __$EventCopyWithImpl;
+@override @useResult
+$Res call({
+ String id,@JsonKey(name: 'party_id') String partyId,@JsonKey(name: 'start_time') DateTime startTime,@JsonKey(name: 'end_time') DateTime endTime,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'location_id') String? locationId, String? title, Map<String, dynamic>? description,@JsonKey(name: 'image_urls') List<String>? imageUrls,@JsonKey(name: 'contact_options') Map<String, dynamic> contactOptions, Map<String, dynamic> metadata,@JsonKey(name: 'min_confirmed_count') int minConfirmedCount,@JsonKey(name: 'max_participants') int maxParticipants,@JsonKey(name: 'current_participants') int currentParticipants, String status, String? visibility,@JsonKey(includeToJson: false) Location? location,@JsonKey(includeToJson: false) Party? party,@JsonKey(includeToJson: false) List<Ticket>? tickets,@JsonKey(includeToJson: false) List<EntryGroup>? entryGroups
+});
 
-  @override
-  $LocationCopyWith<$Res>? get location;
-  @override
-  $PartyCopyWith<$Res>? get party;
+
+@override $LocationCopyWith<$Res>? get location;@override $PartyCopyWith<$Res>? get party;
+
 }
-
 /// @nodoc
-class __$EventCopyWithImpl<$Res> implements _$EventCopyWith<$Res> {
+class __$EventCopyWithImpl<$Res>
+    implements _$EventCopyWith<$Res> {
   __$EventCopyWithImpl(this._self, this._then);
 
   final _Event _self;
   final $Res Function(_Event) _then;
 
-  /// Create a copy of Event
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? partyId = null,
-    Object? startTime = null,
-    Object? endTime = null,
-    Object? createdAt = null,
-    Object? updatedAt = null,
-    Object? locationId = freezed,
-    Object? title = freezed,
-    Object? description = freezed,
-    Object? imageUrls = freezed,
-    Object? contactOptions = null,
-    Object? metadata = null,
-    Object? minConfirmedCount = null,
-    Object? maxParticipants = null,
-    Object? currentParticipants = null,
-    Object? status = null,
-    Object? visibility = freezed,
-    Object? location = freezed,
-    Object? party = freezed,
-    Object? tickets = freezed,
-    Object? entryGroups = freezed,
-  }) {
-    return _then(_Event(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      partyId: null == partyId
-          ? _self.partyId
-          : partyId // ignore: cast_nullable_to_non_nullable
-              as String,
-      startTime: null == startTime
-          ? _self.startTime
-          : startTime // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      endTime: null == endTime
-          ? _self.endTime
-          : endTime // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updatedAt: null == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      locationId: freezed == locationId
-          ? _self.locationId
-          : locationId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      title: freezed == title
-          ? _self.title
-          : title // ignore: cast_nullable_to_non_nullable
-              as String?,
-      description: freezed == description
-          ? _self._description
-          : description // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>?,
-      imageUrls: freezed == imageUrls
-          ? _self._imageUrls
-          : imageUrls // ignore: cast_nullable_to_non_nullable
-              as List<String>?,
-      contactOptions: null == contactOptions
-          ? _self._contactOptions
-          : contactOptions // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>,
-      metadata: null == metadata
-          ? _self._metadata
-          : metadata // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>,
-      minConfirmedCount: null == minConfirmedCount
-          ? _self.minConfirmedCount
-          : minConfirmedCount // ignore: cast_nullable_to_non_nullable
-              as int,
-      maxParticipants: null == maxParticipants
-          ? _self.maxParticipants
-          : maxParticipants // ignore: cast_nullable_to_non_nullable
-              as int,
-      currentParticipants: null == currentParticipants
-          ? _self.currentParticipants
-          : currentParticipants // ignore: cast_nullable_to_non_nullable
-              as int,
-      status: null == status
-          ? _self.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as String,
-      visibility: freezed == visibility
-          ? _self.visibility
-          : visibility // ignore: cast_nullable_to_non_nullable
-              as String?,
-      location: freezed == location
-          ? _self.location
-          : location // ignore: cast_nullable_to_non_nullable
-              as Location?,
-      party: freezed == party
-          ? _self.party
-          : party // ignore: cast_nullable_to_non_nullable
-              as Party?,
-      tickets: freezed == tickets
-          ? _self._tickets
-          : tickets // ignore: cast_nullable_to_non_nullable
-              as List<Ticket>?,
-      entryGroups: freezed == entryGroups
-          ? _self._entryGroups
-          : entryGroups // ignore: cast_nullable_to_non_nullable
-              as List<EntryGroup>?,
-    ));
-  }
+/// Create a copy of Event
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? partyId = null,Object? startTime = null,Object? endTime = null,Object? createdAt = null,Object? updatedAt = null,Object? locationId = freezed,Object? title = freezed,Object? description = freezed,Object? imageUrls = freezed,Object? contactOptions = null,Object? metadata = null,Object? minConfirmedCount = null,Object? maxParticipants = null,Object? currentParticipants = null,Object? status = null,Object? visibility = freezed,Object? location = freezed,Object? party = freezed,Object? tickets = freezed,Object? entryGroups = freezed,}) {
+  return _then(_Event(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,startTime: null == startTime ? _self.startTime : startTime // ignore: cast_nullable_to_non_nullable
+as DateTime,endTime: null == endTime ? _self.endTime : endTime // ignore: cast_nullable_to_non_nullable
+as DateTime,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,locationId: freezed == locationId ? _self.locationId : locationId // ignore: cast_nullable_to_non_nullable
+as String?,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self._description : description // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,imageUrls: freezed == imageUrls ? _self._imageUrls : imageUrls // ignore: cast_nullable_to_non_nullable
+as List<String>?,contactOptions: null == contactOptions ? _self._contactOptions : contactOptions // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>,metadata: null == metadata ? _self._metadata : metadata // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>,minConfirmedCount: null == minConfirmedCount ? _self.minConfirmedCount : minConfirmedCount // ignore: cast_nullable_to_non_nullable
+as int,maxParticipants: null == maxParticipants ? _self.maxParticipants : maxParticipants // ignore: cast_nullable_to_non_nullable
+as int,currentParticipants: null == currentParticipants ? _self.currentParticipants : currentParticipants // ignore: cast_nullable_to_non_nullable
+as int,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,visibility: freezed == visibility ? _self.visibility : visibility // ignore: cast_nullable_to_non_nullable
+as String?,location: freezed == location ? _self.location : location // ignore: cast_nullable_to_non_nullable
+as Location?,party: freezed == party ? _self.party : party // ignore: cast_nullable_to_non_nullable
+as Party?,tickets: freezed == tickets ? _self._tickets : tickets // ignore: cast_nullable_to_non_nullable
+as List<Ticket>?,entryGroups: freezed == entryGroups ? _self._entryGroups : entryGroups // ignore: cast_nullable_to_non_nullable
+as List<EntryGroup>?,
+  ));
+}
 
-  /// Create a copy of Event
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $LocationCopyWith<$Res>? get location {
+/// Create a copy of Event
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$LocationCopyWith<$Res>? get location {
     if (_self.location == null) {
-      return null;
-    }
-
-    return $LocationCopyWith<$Res>(_self.location!, (value) {
-      return _then(_self.copyWith(location: value));
-    });
+    return null;
   }
 
-  /// Create a copy of Event
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $PartyCopyWith<$Res>? get party {
+  return $LocationCopyWith<$Res>(_self.location!, (value) {
+    return _then(_self.copyWith(location: value));
+  });
+}/// Create a copy of Event
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$PartyCopyWith<$Res>? get party {
     if (_self.party == null) {
-      return null;
-    }
-
-    return $PartyCopyWith<$Res>(_self.party!, (value) {
-      return _then(_self.copyWith(party: value));
-    });
+    return null;
   }
+
+  return $PartyCopyWith<$Res>(_self.party!, (value) {
+    return _then(_self.copyWith(party: value));
+  });
+}
 }
 
 // dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/event_application.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/event_application.freezed.dart
@@ -14,132 +14,48 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$EventApplication {
-  String get id;
-  @JsonKey(name: 'event_id')
-  String get eventId;
-  @JsonKey(name: 'ticket_id')
-  String get ticketId;
-  @JsonKey(name: 'user_id')
-  String get userId;
-  String get status;
-  @JsonKey(name: 'created_at')
-  DateTime get createdAt;
-  @JsonKey(name: 'updated_at')
-  DateTime get updatedAt;
-  @JsonKey(name: 'payment_id')
-  String? get paymentId;
-  @JsonKey(name: 'payment_amount')
-  int? get paymentAmount;
-  @JsonKey(name: 'refund_status')
-  String get refundStatus;
-  @JsonKey(name: 'rejection_reason')
-  String? get rejectionReason;
-  @JsonKey(name: 'paid_at')
-  DateTime? get paidAt; // Relations (Nullable)
-  UserProfile? get user;
-  VerificationSubmission? get submission;
-  Event? get event;
-  Ticket? get ticket;
 
-  /// Create a copy of EventApplication
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $EventApplicationCopyWith<EventApplication> get copyWith =>
-      _$EventApplicationCopyWithImpl<EventApplication>(
-          this as EventApplication, _$identity);
+ String get id;@JsonKey(name: 'event_id') String get eventId;@JsonKey(name: 'ticket_id') String get ticketId;@JsonKey(name: 'user_id') String get userId; String get status;@JsonKey(name: 'created_at') DateTime get createdAt;@JsonKey(name: 'updated_at') DateTime get updatedAt;@JsonKey(name: 'payment_id') String? get paymentId;@JsonKey(name: 'payment_amount') int? get paymentAmount;@JsonKey(name: 'refund_status') String get refundStatus;@JsonKey(name: 'rejection_reason') String? get rejectionReason;@JsonKey(name: 'paid_at') DateTime? get paidAt;// Relations (Nullable)
+ UserProfile? get user; VerificationSubmission? get submission; Event? get event; Ticket? get ticket;
+/// Create a copy of EventApplication
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EventApplicationCopyWith<EventApplication> get copyWith => _$EventApplicationCopyWithImpl<EventApplication>(this as EventApplication, _$identity);
 
   /// Serializes this EventApplication to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is EventApplication &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.eventId, eventId) || other.eventId == eventId) &&
-            (identical(other.ticketId, ticketId) ||
-                other.ticketId == ticketId) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.status, status) || other.status == status) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt) &&
-            (identical(other.paymentId, paymentId) ||
-                other.paymentId == paymentId) &&
-            (identical(other.paymentAmount, paymentAmount) ||
-                other.paymentAmount == paymentAmount) &&
-            (identical(other.refundStatus, refundStatus) ||
-                other.refundStatus == refundStatus) &&
-            (identical(other.rejectionReason, rejectionReason) ||
-                other.rejectionReason == rejectionReason) &&
-            (identical(other.paidAt, paidAt) || other.paidAt == paidAt) &&
-            (identical(other.user, user) || other.user == user) &&
-            (identical(other.submission, submission) ||
-                other.submission == submission) &&
-            (identical(other.event, event) || other.event == event) &&
-            (identical(other.ticket, ticket) || other.ticket == ticket));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      eventId,
-      ticketId,
-      userId,
-      status,
-      createdAt,
-      updatedAt,
-      paymentId,
-      paymentAmount,
-      refundStatus,
-      rejectionReason,
-      paidAt,
-      user,
-      submission,
-      event,
-      ticket);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EventApplication&&(identical(other.id, id) || other.id == id)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.ticketId, ticketId) || other.ticketId == ticketId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.status, status) || other.status == status)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.paymentId, paymentId) || other.paymentId == paymentId)&&(identical(other.paymentAmount, paymentAmount) || other.paymentAmount == paymentAmount)&&(identical(other.refundStatus, refundStatus) || other.refundStatus == refundStatus)&&(identical(other.rejectionReason, rejectionReason) || other.rejectionReason == rejectionReason)&&(identical(other.paidAt, paidAt) || other.paidAt == paidAt)&&(identical(other.user, user) || other.user == user)&&(identical(other.submission, submission) || other.submission == submission)&&(identical(other.event, event) || other.event == event)&&(identical(other.ticket, ticket) || other.ticket == ticket));
+}
 
-  @override
-  String toString() {
-    return 'EventApplication(id: $id, eventId: $eventId, ticketId: $ticketId, userId: $userId, status: $status, createdAt: $createdAt, updatedAt: $updatedAt, paymentId: $paymentId, paymentAmount: $paymentAmount, refundStatus: $refundStatus, rejectionReason: $rejectionReason, paidAt: $paidAt, user: $user, submission: $submission, event: $event, ticket: $ticket)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,eventId,ticketId,userId,status,createdAt,updatedAt,paymentId,paymentAmount,refundStatus,rejectionReason,paidAt,user,submission,event,ticket);
+
+@override
+String toString() {
+  return 'EventApplication(id: $id, eventId: $eventId, ticketId: $ticketId, userId: $userId, status: $status, createdAt: $createdAt, updatedAt: $updatedAt, paymentId: $paymentId, paymentAmount: $paymentAmount, refundStatus: $refundStatus, rejectionReason: $rejectionReason, paidAt: $paidAt, user: $user, submission: $submission, event: $event, ticket: $ticket)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $EventApplicationCopyWith<$Res> {
-  factory $EventApplicationCopyWith(
-          EventApplication value, $Res Function(EventApplication) _then) =
-      _$EventApplicationCopyWithImpl;
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'event_id') String eventId,
-      @JsonKey(name: 'ticket_id') String ticketId,
-      @JsonKey(name: 'user_id') String userId,
-      String status,
-      @JsonKey(name: 'created_at') DateTime createdAt,
-      @JsonKey(name: 'updated_at') DateTime updatedAt,
-      @JsonKey(name: 'payment_id') String? paymentId,
-      @JsonKey(name: 'payment_amount') int? paymentAmount,
-      @JsonKey(name: 'refund_status') String refundStatus,
-      @JsonKey(name: 'rejection_reason') String? rejectionReason,
-      @JsonKey(name: 'paid_at') DateTime? paidAt,
-      UserProfile? user,
-      VerificationSubmission? submission,
-      Event? event,
-      Ticket? ticket});
+abstract mixin class $EventApplicationCopyWith<$Res>  {
+  factory $EventApplicationCopyWith(EventApplication value, $Res Function(EventApplication) _then) = _$EventApplicationCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(name: 'event_id') String eventId,@JsonKey(name: 'ticket_id') String ticketId,@JsonKey(name: 'user_id') String userId, String status,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'payment_id') String? paymentId,@JsonKey(name: 'payment_amount') int? paymentAmount,@JsonKey(name: 'refund_status') String refundStatus,@JsonKey(name: 'rejection_reason') String? rejectionReason,@JsonKey(name: 'paid_at') DateTime? paidAt, UserProfile? user, VerificationSubmission? submission, Event? event, Ticket? ticket
+});
 
-  $UserProfileCopyWith<$Res>? get user;
-  $VerificationSubmissionCopyWith<$Res>? get submission;
-  $EventCopyWith<$Res>? get event;
-  $TicketCopyWith<$Res>? get ticket;
+
+$UserProfileCopyWith<$Res>? get user;$VerificationSubmissionCopyWith<$Res>? get submission;$EventCopyWith<$Res>? get event;$TicketCopyWith<$Res>? get ticket;
+
 }
-
 /// @nodoc
 class _$EventApplicationCopyWithImpl<$Res>
     implements $EventApplicationCopyWith<$Res> {
@@ -148,585 +64,276 @@ class _$EventApplicationCopyWithImpl<$Res>
   final EventApplication _self;
   final $Res Function(EventApplication) _then;
 
-  /// Create a copy of EventApplication
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? eventId = null,
-    Object? ticketId = null,
-    Object? userId = null,
-    Object? status = null,
-    Object? createdAt = null,
-    Object? updatedAt = null,
-    Object? paymentId = freezed,
-    Object? paymentAmount = freezed,
-    Object? refundStatus = null,
-    Object? rejectionReason = freezed,
-    Object? paidAt = freezed,
-    Object? user = freezed,
-    Object? submission = freezed,
-    Object? event = freezed,
-    Object? ticket = freezed,
-  }) {
-    return _then(_self.copyWith(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      eventId: null == eventId
-          ? _self.eventId
-          : eventId // ignore: cast_nullable_to_non_nullable
-              as String,
-      ticketId: null == ticketId
-          ? _self.ticketId
-          : ticketId // ignore: cast_nullable_to_non_nullable
-              as String,
-      userId: null == userId
-          ? _self.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      status: null == status
-          ? _self.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as String,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updatedAt: null == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      paymentId: freezed == paymentId
-          ? _self.paymentId
-          : paymentId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      paymentAmount: freezed == paymentAmount
-          ? _self.paymentAmount
-          : paymentAmount // ignore: cast_nullable_to_non_nullable
-              as int?,
-      refundStatus: null == refundStatus
-          ? _self.refundStatus
-          : refundStatus // ignore: cast_nullable_to_non_nullable
-              as String,
-      rejectionReason: freezed == rejectionReason
-          ? _self.rejectionReason
-          : rejectionReason // ignore: cast_nullable_to_non_nullable
-              as String?,
-      paidAt: freezed == paidAt
-          ? _self.paidAt
-          : paidAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      user: freezed == user
-          ? _self.user
-          : user // ignore: cast_nullable_to_non_nullable
-              as UserProfile?,
-      submission: freezed == submission
-          ? _self.submission
-          : submission // ignore: cast_nullable_to_non_nullable
-              as VerificationSubmission?,
-      event: freezed == event
-          ? _self.event
-          : event // ignore: cast_nullable_to_non_nullable
-              as Event?,
-      ticket: freezed == ticket
-          ? _self.ticket
-          : ticket // ignore: cast_nullable_to_non_nullable
-              as Ticket?,
-    ));
-  }
-
-  /// Create a copy of EventApplication
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $UserProfileCopyWith<$Res>? get user {
-    if (_self.user == null) {
-      return null;
-    }
-
-    return $UserProfileCopyWith<$Res>(_self.user!, (value) {
-      return _then(_self.copyWith(user: value));
-    });
-  }
-
-  /// Create a copy of EventApplication
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $VerificationSubmissionCopyWith<$Res>? get submission {
-    if (_self.submission == null) {
-      return null;
-    }
-
-    return $VerificationSubmissionCopyWith<$Res>(_self.submission!, (value) {
-      return _then(_self.copyWith(submission: value));
-    });
-  }
-
-  /// Create a copy of EventApplication
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $EventCopyWith<$Res>? get event {
-    if (_self.event == null) {
-      return null;
-    }
-
-    return $EventCopyWith<$Res>(_self.event!, (value) {
-      return _then(_self.copyWith(event: value));
-    });
-  }
-
-  /// Create a copy of EventApplication
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $TicketCopyWith<$Res>? get ticket {
-    if (_self.ticket == null) {
-      return null;
-    }
-
-    return $TicketCopyWith<$Res>(_self.ticket!, (value) {
-      return _then(_self.copyWith(ticket: value));
-    });
-  }
+/// Create a copy of EventApplication
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? eventId = null,Object? ticketId = null,Object? userId = null,Object? status = null,Object? createdAt = null,Object? updatedAt = null,Object? paymentId = freezed,Object? paymentAmount = freezed,Object? refundStatus = null,Object? rejectionReason = freezed,Object? paidAt = freezed,Object? user = freezed,Object? submission = freezed,Object? event = freezed,Object? ticket = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String,ticketId: null == ticketId ? _self.ticketId : ticketId // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,paymentId: freezed == paymentId ? _self.paymentId : paymentId // ignore: cast_nullable_to_non_nullable
+as String?,paymentAmount: freezed == paymentAmount ? _self.paymentAmount : paymentAmount // ignore: cast_nullable_to_non_nullable
+as int?,refundStatus: null == refundStatus ? _self.refundStatus : refundStatus // ignore: cast_nullable_to_non_nullable
+as String,rejectionReason: freezed == rejectionReason ? _self.rejectionReason : rejectionReason // ignore: cast_nullable_to_non_nullable
+as String?,paidAt: freezed == paidAt ? _self.paidAt : paidAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,user: freezed == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as UserProfile?,submission: freezed == submission ? _self.submission : submission // ignore: cast_nullable_to_non_nullable
+as VerificationSubmission?,event: freezed == event ? _self.event : event // ignore: cast_nullable_to_non_nullable
+as Event?,ticket: freezed == ticket ? _self.ticket : ticket // ignore: cast_nullable_to_non_nullable
+as Ticket?,
+  ));
 }
+/// Create a copy of EventApplication
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserProfileCopyWith<$Res>? get user {
+    if (_self.user == null) {
+    return null;
+  }
+
+  return $UserProfileCopyWith<$Res>(_self.user!, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}/// Create a copy of EventApplication
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$VerificationSubmissionCopyWith<$Res>? get submission {
+    if (_self.submission == null) {
+    return null;
+  }
+
+  return $VerificationSubmissionCopyWith<$Res>(_self.submission!, (value) {
+    return _then(_self.copyWith(submission: value));
+  });
+}/// Create a copy of EventApplication
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EventCopyWith<$Res>? get event {
+    if (_self.event == null) {
+    return null;
+  }
+
+  return $EventCopyWith<$Res>(_self.event!, (value) {
+    return _then(_self.copyWith(event: value));
+  });
+}/// Create a copy of EventApplication
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$TicketCopyWith<$Res>? get ticket {
+    if (_self.ticket == null) {
+    return null;
+  }
+
+  return $TicketCopyWith<$Res>(_self.ticket!, (value) {
+    return _then(_self.copyWith(ticket: value));
+  });
+}
+}
+
 
 /// Adds pattern-matching-related methods to [EventApplication].
 extension EventApplicationPatterns on EventApplication {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_EventApplication value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _EventApplication() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EventApplication value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EventApplication() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_EventApplication value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EventApplication():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EventApplication value)  $default,){
+final _that = this;
+switch (_that) {
+case _EventApplication():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_EventApplication value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EventApplication() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EventApplication value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EventApplication() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'event_id') String eventId,
-            @JsonKey(name: 'ticket_id') String ticketId,
-            @JsonKey(name: 'user_id') String userId,
-            String status,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'payment_id') String? paymentId,
-            @JsonKey(name: 'payment_amount') int? paymentAmount,
-            @JsonKey(name: 'refund_status') String refundStatus,
-            @JsonKey(name: 'rejection_reason') String? rejectionReason,
-            @JsonKey(name: 'paid_at') DateTime? paidAt,
-            UserProfile? user,
-            VerificationSubmission? submission,
-            Event? event,
-            Ticket? ticket)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _EventApplication() when $default != null:
-        return $default(
-            _that.id,
-            _that.eventId,
-            _that.ticketId,
-            _that.userId,
-            _that.status,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.paymentId,
-            _that.paymentAmount,
-            _that.refundStatus,
-            _that.rejectionReason,
-            _that.paidAt,
-            _that.user,
-            _that.submission,
-            _that.event,
-            _that.ticket);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'ticket_id')  String ticketId, @JsonKey(name: 'user_id')  String userId,  String status, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'payment_id')  String? paymentId, @JsonKey(name: 'payment_amount')  int? paymentAmount, @JsonKey(name: 'refund_status')  String refundStatus, @JsonKey(name: 'rejection_reason')  String? rejectionReason, @JsonKey(name: 'paid_at')  DateTime? paidAt,  UserProfile? user,  VerificationSubmission? submission,  Event? event,  Ticket? ticket)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EventApplication() when $default != null:
+return $default(_that.id,_that.eventId,_that.ticketId,_that.userId,_that.status,_that.createdAt,_that.updatedAt,_that.paymentId,_that.paymentAmount,_that.refundStatus,_that.rejectionReason,_that.paidAt,_that.user,_that.submission,_that.event,_that.ticket);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'event_id') String eventId,
-            @JsonKey(name: 'ticket_id') String ticketId,
-            @JsonKey(name: 'user_id') String userId,
-            String status,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'payment_id') String? paymentId,
-            @JsonKey(name: 'payment_amount') int? paymentAmount,
-            @JsonKey(name: 'refund_status') String refundStatus,
-            @JsonKey(name: 'rejection_reason') String? rejectionReason,
-            @JsonKey(name: 'paid_at') DateTime? paidAt,
-            UserProfile? user,
-            VerificationSubmission? submission,
-            Event? event,
-            Ticket? ticket)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EventApplication():
-        return $default(
-            _that.id,
-            _that.eventId,
-            _that.ticketId,
-            _that.userId,
-            _that.status,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.paymentId,
-            _that.paymentAmount,
-            _that.refundStatus,
-            _that.rejectionReason,
-            _that.paidAt,
-            _that.user,
-            _that.submission,
-            _that.event,
-            _that.ticket);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'ticket_id')  String ticketId, @JsonKey(name: 'user_id')  String userId,  String status, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'payment_id')  String? paymentId, @JsonKey(name: 'payment_amount')  int? paymentAmount, @JsonKey(name: 'refund_status')  String refundStatus, @JsonKey(name: 'rejection_reason')  String? rejectionReason, @JsonKey(name: 'paid_at')  DateTime? paidAt,  UserProfile? user,  VerificationSubmission? submission,  Event? event,  Ticket? ticket)  $default,) {final _that = this;
+switch (_that) {
+case _EventApplication():
+return $default(_that.id,_that.eventId,_that.ticketId,_that.userId,_that.status,_that.createdAt,_that.updatedAt,_that.paymentId,_that.paymentAmount,_that.refundStatus,_that.rejectionReason,_that.paidAt,_that.user,_that.submission,_that.event,_that.ticket);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String id,
-            @JsonKey(name: 'event_id') String eventId,
-            @JsonKey(name: 'ticket_id') String ticketId,
-            @JsonKey(name: 'user_id') String userId,
-            String status,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'payment_id') String? paymentId,
-            @JsonKey(name: 'payment_amount') int? paymentAmount,
-            @JsonKey(name: 'refund_status') String refundStatus,
-            @JsonKey(name: 'rejection_reason') String? rejectionReason,
-            @JsonKey(name: 'paid_at') DateTime? paidAt,
-            UserProfile? user,
-            VerificationSubmission? submission,
-            Event? event,
-            Ticket? ticket)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EventApplication() when $default != null:
-        return $default(
-            _that.id,
-            _that.eventId,
-            _that.ticketId,
-            _that.userId,
-            _that.status,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.paymentId,
-            _that.paymentAmount,
-            _that.refundStatus,
-            _that.rejectionReason,
-            _that.paidAt,
-            _that.user,
-            _that.submission,
-            _that.event,
-            _that.ticket);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'ticket_id')  String ticketId, @JsonKey(name: 'user_id')  String userId,  String status, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'payment_id')  String? paymentId, @JsonKey(name: 'payment_amount')  int? paymentAmount, @JsonKey(name: 'refund_status')  String refundStatus, @JsonKey(name: 'rejection_reason')  String? rejectionReason, @JsonKey(name: 'paid_at')  DateTime? paidAt,  UserProfile? user,  VerificationSubmission? submission,  Event? event,  Ticket? ticket)?  $default,) {final _that = this;
+switch (_that) {
+case _EventApplication() when $default != null:
+return $default(_that.id,_that.eventId,_that.ticketId,_that.userId,_that.status,_that.createdAt,_that.updatedAt,_that.paymentId,_that.paymentAmount,_that.refundStatus,_that.rejectionReason,_that.paidAt,_that.user,_that.submission,_that.event,_that.ticket);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _EventApplication implements EventApplication {
-  const _EventApplication(
-      {required this.id,
-      @JsonKey(name: 'event_id') required this.eventId,
-      @JsonKey(name: 'ticket_id') required this.ticketId,
-      @JsonKey(name: 'user_id') required this.userId,
-      required this.status,
-      @JsonKey(name: 'created_at') required this.createdAt,
-      @JsonKey(name: 'updated_at') required this.updatedAt,
-      @JsonKey(name: 'payment_id') this.paymentId,
-      @JsonKey(name: 'payment_amount') this.paymentAmount,
-      @JsonKey(name: 'refund_status') this.refundStatus = 'none',
-      @JsonKey(name: 'rejection_reason') this.rejectionReason,
-      @JsonKey(name: 'paid_at') this.paidAt,
-      this.user,
-      this.submission,
-      this.event,
-      this.ticket});
-  factory _EventApplication.fromJson(Map<String, dynamic> json) =>
-      _$EventApplicationFromJson(json);
+  const _EventApplication({required this.id, @JsonKey(name: 'event_id') required this.eventId, @JsonKey(name: 'ticket_id') required this.ticketId, @JsonKey(name: 'user_id') required this.userId, required this.status, @JsonKey(name: 'created_at') required this.createdAt, @JsonKey(name: 'updated_at') required this.updatedAt, @JsonKey(name: 'payment_id') this.paymentId, @JsonKey(name: 'payment_amount') this.paymentAmount, @JsonKey(name: 'refund_status') this.refundStatus = 'none', @JsonKey(name: 'rejection_reason') this.rejectionReason, @JsonKey(name: 'paid_at') this.paidAt, this.user, this.submission, this.event, this.ticket});
+  factory _EventApplication.fromJson(Map<String, dynamic> json) => _$EventApplicationFromJson(json);
 
-  @override
-  final String id;
-  @override
-  @JsonKey(name: 'event_id')
-  final String eventId;
-  @override
-  @JsonKey(name: 'ticket_id')
-  final String ticketId;
-  @override
-  @JsonKey(name: 'user_id')
-  final String userId;
-  @override
-  final String status;
-  @override
-  @JsonKey(name: 'created_at')
-  final DateTime createdAt;
-  @override
-  @JsonKey(name: 'updated_at')
-  final DateTime updatedAt;
-  @override
-  @JsonKey(name: 'payment_id')
-  final String? paymentId;
-  @override
-  @JsonKey(name: 'payment_amount')
-  final int? paymentAmount;
-  @override
-  @JsonKey(name: 'refund_status')
-  final String refundStatus;
-  @override
-  @JsonKey(name: 'rejection_reason')
-  final String? rejectionReason;
-  @override
-  @JsonKey(name: 'paid_at')
-  final DateTime? paidAt;
+@override final  String id;
+@override@JsonKey(name: 'event_id') final  String eventId;
+@override@JsonKey(name: 'ticket_id') final  String ticketId;
+@override@JsonKey(name: 'user_id') final  String userId;
+@override final  String status;
+@override@JsonKey(name: 'created_at') final  DateTime createdAt;
+@override@JsonKey(name: 'updated_at') final  DateTime updatedAt;
+@override@JsonKey(name: 'payment_id') final  String? paymentId;
+@override@JsonKey(name: 'payment_amount') final  int? paymentAmount;
+@override@JsonKey(name: 'refund_status') final  String refundStatus;
+@override@JsonKey(name: 'rejection_reason') final  String? rejectionReason;
+@override@JsonKey(name: 'paid_at') final  DateTime? paidAt;
 // Relations (Nullable)
-  @override
-  final UserProfile? user;
-  @override
-  final VerificationSubmission? submission;
-  @override
-  final Event? event;
-  @override
-  final Ticket? ticket;
+@override final  UserProfile? user;
+@override final  VerificationSubmission? submission;
+@override final  Event? event;
+@override final  Ticket? ticket;
 
-  /// Create a copy of EventApplication
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$EventApplicationCopyWith<_EventApplication> get copyWith =>
-      __$EventApplicationCopyWithImpl<_EventApplication>(this, _$identity);
+/// Create a copy of EventApplication
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EventApplicationCopyWith<_EventApplication> get copyWith => __$EventApplicationCopyWithImpl<_EventApplication>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$EventApplicationToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$EventApplicationToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _EventApplication &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.eventId, eventId) || other.eventId == eventId) &&
-            (identical(other.ticketId, ticketId) ||
-                other.ticketId == ticketId) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.status, status) || other.status == status) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt) &&
-            (identical(other.paymentId, paymentId) ||
-                other.paymentId == paymentId) &&
-            (identical(other.paymentAmount, paymentAmount) ||
-                other.paymentAmount == paymentAmount) &&
-            (identical(other.refundStatus, refundStatus) ||
-                other.refundStatus == refundStatus) &&
-            (identical(other.rejectionReason, rejectionReason) ||
-                other.rejectionReason == rejectionReason) &&
-            (identical(other.paidAt, paidAt) || other.paidAt == paidAt) &&
-            (identical(other.user, user) || other.user == user) &&
-            (identical(other.submission, submission) ||
-                other.submission == submission) &&
-            (identical(other.event, event) || other.event == event) &&
-            (identical(other.ticket, ticket) || other.ticket == ticket));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EventApplication&&(identical(other.id, id) || other.id == id)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.ticketId, ticketId) || other.ticketId == ticketId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.status, status) || other.status == status)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.paymentId, paymentId) || other.paymentId == paymentId)&&(identical(other.paymentAmount, paymentAmount) || other.paymentAmount == paymentAmount)&&(identical(other.refundStatus, refundStatus) || other.refundStatus == refundStatus)&&(identical(other.rejectionReason, rejectionReason) || other.rejectionReason == rejectionReason)&&(identical(other.paidAt, paidAt) || other.paidAt == paidAt)&&(identical(other.user, user) || other.user == user)&&(identical(other.submission, submission) || other.submission == submission)&&(identical(other.event, event) || other.event == event)&&(identical(other.ticket, ticket) || other.ticket == ticket));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      eventId,
-      ticketId,
-      userId,
-      status,
-      createdAt,
-      updatedAt,
-      paymentId,
-      paymentAmount,
-      refundStatus,
-      rejectionReason,
-      paidAt,
-      user,
-      submission,
-      event,
-      ticket);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,eventId,ticketId,userId,status,createdAt,updatedAt,paymentId,paymentAmount,refundStatus,rejectionReason,paidAt,user,submission,event,ticket);
 
-  @override
-  String toString() {
-    return 'EventApplication(id: $id, eventId: $eventId, ticketId: $ticketId, userId: $userId, status: $status, createdAt: $createdAt, updatedAt: $updatedAt, paymentId: $paymentId, paymentAmount: $paymentAmount, refundStatus: $refundStatus, rejectionReason: $rejectionReason, paidAt: $paidAt, user: $user, submission: $submission, event: $event, ticket: $ticket)';
-  }
+@override
+String toString() {
+  return 'EventApplication(id: $id, eventId: $eventId, ticketId: $ticketId, userId: $userId, status: $status, createdAt: $createdAt, updatedAt: $updatedAt, paymentId: $paymentId, paymentAmount: $paymentAmount, refundStatus: $refundStatus, rejectionReason: $rejectionReason, paidAt: $paidAt, user: $user, submission: $submission, event: $event, ticket: $ticket)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$EventApplicationCopyWith<$Res>
-    implements $EventApplicationCopyWith<$Res> {
-  factory _$EventApplicationCopyWith(
-          _EventApplication value, $Res Function(_EventApplication) _then) =
-      __$EventApplicationCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'event_id') String eventId,
-      @JsonKey(name: 'ticket_id') String ticketId,
-      @JsonKey(name: 'user_id') String userId,
-      String status,
-      @JsonKey(name: 'created_at') DateTime createdAt,
-      @JsonKey(name: 'updated_at') DateTime updatedAt,
-      @JsonKey(name: 'payment_id') String? paymentId,
-      @JsonKey(name: 'payment_amount') int? paymentAmount,
-      @JsonKey(name: 'refund_status') String refundStatus,
-      @JsonKey(name: 'rejection_reason') String? rejectionReason,
-      @JsonKey(name: 'paid_at') DateTime? paidAt,
-      UserProfile? user,
-      VerificationSubmission? submission,
-      Event? event,
-      Ticket? ticket});
+abstract mixin class _$EventApplicationCopyWith<$Res> implements $EventApplicationCopyWith<$Res> {
+  factory _$EventApplicationCopyWith(_EventApplication value, $Res Function(_EventApplication) _then) = __$EventApplicationCopyWithImpl;
+@override @useResult
+$Res call({
+ String id,@JsonKey(name: 'event_id') String eventId,@JsonKey(name: 'ticket_id') String ticketId,@JsonKey(name: 'user_id') String userId, String status,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'payment_id') String? paymentId,@JsonKey(name: 'payment_amount') int? paymentAmount,@JsonKey(name: 'refund_status') String refundStatus,@JsonKey(name: 'rejection_reason') String? rejectionReason,@JsonKey(name: 'paid_at') DateTime? paidAt, UserProfile? user, VerificationSubmission? submission, Event? event, Ticket? ticket
+});
 
-  @override
-  $UserProfileCopyWith<$Res>? get user;
-  @override
-  $VerificationSubmissionCopyWith<$Res>? get submission;
-  @override
-  $EventCopyWith<$Res>? get event;
-  @override
-  $TicketCopyWith<$Res>? get ticket;
+
+@override $UserProfileCopyWith<$Res>? get user;@override $VerificationSubmissionCopyWith<$Res>? get submission;@override $EventCopyWith<$Res>? get event;@override $TicketCopyWith<$Res>? get ticket;
+
 }
-
 /// @nodoc
 class __$EventApplicationCopyWithImpl<$Res>
     implements _$EventApplicationCopyWith<$Res> {
@@ -735,151 +342,79 @@ class __$EventApplicationCopyWithImpl<$Res>
   final _EventApplication _self;
   final $Res Function(_EventApplication) _then;
 
-  /// Create a copy of EventApplication
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? eventId = null,
-    Object? ticketId = null,
-    Object? userId = null,
-    Object? status = null,
-    Object? createdAt = null,
-    Object? updatedAt = null,
-    Object? paymentId = freezed,
-    Object? paymentAmount = freezed,
-    Object? refundStatus = null,
-    Object? rejectionReason = freezed,
-    Object? paidAt = freezed,
-    Object? user = freezed,
-    Object? submission = freezed,
-    Object? event = freezed,
-    Object? ticket = freezed,
-  }) {
-    return _then(_EventApplication(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      eventId: null == eventId
-          ? _self.eventId
-          : eventId // ignore: cast_nullable_to_non_nullable
-              as String,
-      ticketId: null == ticketId
-          ? _self.ticketId
-          : ticketId // ignore: cast_nullable_to_non_nullable
-              as String,
-      userId: null == userId
-          ? _self.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      status: null == status
-          ? _self.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as String,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updatedAt: null == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      paymentId: freezed == paymentId
-          ? _self.paymentId
-          : paymentId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      paymentAmount: freezed == paymentAmount
-          ? _self.paymentAmount
-          : paymentAmount // ignore: cast_nullable_to_non_nullable
-              as int?,
-      refundStatus: null == refundStatus
-          ? _self.refundStatus
-          : refundStatus // ignore: cast_nullable_to_non_nullable
-              as String,
-      rejectionReason: freezed == rejectionReason
-          ? _self.rejectionReason
-          : rejectionReason // ignore: cast_nullable_to_non_nullable
-              as String?,
-      paidAt: freezed == paidAt
-          ? _self.paidAt
-          : paidAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      user: freezed == user
-          ? _self.user
-          : user // ignore: cast_nullable_to_non_nullable
-              as UserProfile?,
-      submission: freezed == submission
-          ? _self.submission
-          : submission // ignore: cast_nullable_to_non_nullable
-              as VerificationSubmission?,
-      event: freezed == event
-          ? _self.event
-          : event // ignore: cast_nullable_to_non_nullable
-              as Event?,
-      ticket: freezed == ticket
-          ? _self.ticket
-          : ticket // ignore: cast_nullable_to_non_nullable
-              as Ticket?,
-    ));
-  }
+/// Create a copy of EventApplication
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? eventId = null,Object? ticketId = null,Object? userId = null,Object? status = null,Object? createdAt = null,Object? updatedAt = null,Object? paymentId = freezed,Object? paymentAmount = freezed,Object? refundStatus = null,Object? rejectionReason = freezed,Object? paidAt = freezed,Object? user = freezed,Object? submission = freezed,Object? event = freezed,Object? ticket = freezed,}) {
+  return _then(_EventApplication(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String,ticketId: null == ticketId ? _self.ticketId : ticketId // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,paymentId: freezed == paymentId ? _self.paymentId : paymentId // ignore: cast_nullable_to_non_nullable
+as String?,paymentAmount: freezed == paymentAmount ? _self.paymentAmount : paymentAmount // ignore: cast_nullable_to_non_nullable
+as int?,refundStatus: null == refundStatus ? _self.refundStatus : refundStatus // ignore: cast_nullable_to_non_nullable
+as String,rejectionReason: freezed == rejectionReason ? _self.rejectionReason : rejectionReason // ignore: cast_nullable_to_non_nullable
+as String?,paidAt: freezed == paidAt ? _self.paidAt : paidAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,user: freezed == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
+as UserProfile?,submission: freezed == submission ? _self.submission : submission // ignore: cast_nullable_to_non_nullable
+as VerificationSubmission?,event: freezed == event ? _self.event : event // ignore: cast_nullable_to_non_nullable
+as Event?,ticket: freezed == ticket ? _self.ticket : ticket // ignore: cast_nullable_to_non_nullable
+as Ticket?,
+  ));
+}
 
-  /// Create a copy of EventApplication
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $UserProfileCopyWith<$Res>? get user {
+/// Create a copy of EventApplication
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$UserProfileCopyWith<$Res>? get user {
     if (_self.user == null) {
-      return null;
-    }
-
-    return $UserProfileCopyWith<$Res>(_self.user!, (value) {
-      return _then(_self.copyWith(user: value));
-    });
+    return null;
   }
 
-  /// Create a copy of EventApplication
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $VerificationSubmissionCopyWith<$Res>? get submission {
+  return $UserProfileCopyWith<$Res>(_self.user!, (value) {
+    return _then(_self.copyWith(user: value));
+  });
+}/// Create a copy of EventApplication
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$VerificationSubmissionCopyWith<$Res>? get submission {
     if (_self.submission == null) {
-      return null;
-    }
-
-    return $VerificationSubmissionCopyWith<$Res>(_self.submission!, (value) {
-      return _then(_self.copyWith(submission: value));
-    });
+    return null;
   }
 
-  /// Create a copy of EventApplication
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $EventCopyWith<$Res>? get event {
+  return $VerificationSubmissionCopyWith<$Res>(_self.submission!, (value) {
+    return _then(_self.copyWith(submission: value));
+  });
+}/// Create a copy of EventApplication
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$EventCopyWith<$Res>? get event {
     if (_self.event == null) {
-      return null;
-    }
-
-    return $EventCopyWith<$Res>(_self.event!, (value) {
-      return _then(_self.copyWith(event: value));
-    });
+    return null;
   }
 
-  /// Create a copy of EventApplication
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $TicketCopyWith<$Res>? get ticket {
+  return $EventCopyWith<$Res>(_self.event!, (value) {
+    return _then(_self.copyWith(event: value));
+  });
+}/// Create a copy of EventApplication
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$TicketCopyWith<$Res>? get ticket {
     if (_self.ticket == null) {
-      return null;
-    }
-
-    return $TicketCopyWith<$Res>(_self.ticket!, (value) {
-      return _then(_self.copyWith(ticket: value));
-    });
+    return null;
   }
+
+  return $TicketCopyWith<$Res>(_self.ticket!, (value) {
+    return _then(_self.copyWith(ticket: value));
+  });
+}
 }
 
 // dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/event_participant.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/event_participant.freezed.dart
@@ -14,84 +14,47 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$EventParticipant {
-  String get id;
-  @JsonKey(name: 'event_id')
-  String get eventId;
-  @JsonKey(name: 'ticket_id')
-  String get ticketId;
-  @JsonKey(name: 'user_id')
-  String get userId;
-  @JsonKey(name: 'created_at')
-  DateTime get createdAt;
-  @JsonKey(name: 'updated_at')
-  DateTime get updatedAt;
-  @JsonKey(name: 'application_id')
-  String? get applicationId;
-  String get status;
-  @JsonKey(name: 'ticket_code')
-  String? get ticketCode;
 
-  /// Create a copy of EventParticipant
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $EventParticipantCopyWith<EventParticipant> get copyWith =>
-      _$EventParticipantCopyWithImpl<EventParticipant>(
-          this as EventParticipant, _$identity);
+ String get id;@JsonKey(name: 'event_id') String get eventId;@JsonKey(name: 'ticket_id') String get ticketId;@JsonKey(name: 'user_id') String get userId;@JsonKey(name: 'created_at') DateTime get createdAt;@JsonKey(name: 'updated_at') DateTime get updatedAt;@JsonKey(name: 'application_id') String? get applicationId; String get status;@JsonKey(name: 'ticket_code') String? get ticketCode;
+/// Create a copy of EventParticipant
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EventParticipantCopyWith<EventParticipant> get copyWith => _$EventParticipantCopyWithImpl<EventParticipant>(this as EventParticipant, _$identity);
 
   /// Serializes this EventParticipant to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is EventParticipant &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.eventId, eventId) || other.eventId == eventId) &&
-            (identical(other.ticketId, ticketId) ||
-                other.ticketId == ticketId) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt) &&
-            (identical(other.applicationId, applicationId) ||
-                other.applicationId == applicationId) &&
-            (identical(other.status, status) || other.status == status) &&
-            (identical(other.ticketCode, ticketCode) ||
-                other.ticketCode == ticketCode));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, id, eventId, ticketId, userId,
-      createdAt, updatedAt, applicationId, status, ticketCode);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EventParticipant&&(identical(other.id, id) || other.id == id)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.ticketId, ticketId) || other.ticketId == ticketId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.applicationId, applicationId) || other.applicationId == applicationId)&&(identical(other.status, status) || other.status == status)&&(identical(other.ticketCode, ticketCode) || other.ticketCode == ticketCode));
+}
 
-  @override
-  String toString() {
-    return 'EventParticipant(id: $id, eventId: $eventId, ticketId: $ticketId, userId: $userId, createdAt: $createdAt, updatedAt: $updatedAt, applicationId: $applicationId, status: $status, ticketCode: $ticketCode)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,eventId,ticketId,userId,createdAt,updatedAt,applicationId,status,ticketCode);
+
+@override
+String toString() {
+  return 'EventParticipant(id: $id, eventId: $eventId, ticketId: $ticketId, userId: $userId, createdAt: $createdAt, updatedAt: $updatedAt, applicationId: $applicationId, status: $status, ticketCode: $ticketCode)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $EventParticipantCopyWith<$Res> {
-  factory $EventParticipantCopyWith(
-          EventParticipant value, $Res Function(EventParticipant) _then) =
-      _$EventParticipantCopyWithImpl;
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'event_id') String eventId,
-      @JsonKey(name: 'ticket_id') String ticketId,
-      @JsonKey(name: 'user_id') String userId,
-      @JsonKey(name: 'created_at') DateTime createdAt,
-      @JsonKey(name: 'updated_at') DateTime updatedAt,
-      @JsonKey(name: 'application_id') String? applicationId,
-      String status,
-      @JsonKey(name: 'ticket_code') String? ticketCode});
-}
+abstract mixin class $EventParticipantCopyWith<$Res>  {
+  factory $EventParticipantCopyWith(EventParticipant value, $Res Function(EventParticipant) _then) = _$EventParticipantCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(name: 'event_id') String eventId,@JsonKey(name: 'ticket_id') String ticketId,@JsonKey(name: 'user_id') String userId,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'application_id') String? applicationId, String status,@JsonKey(name: 'ticket_code') String? ticketCode
+});
 
+
+
+
+}
 /// @nodoc
 class _$EventParticipantCopyWithImpl<$Res>
     implements $EventParticipantCopyWith<$Res> {
@@ -100,386 +63,213 @@ class _$EventParticipantCopyWithImpl<$Res>
   final EventParticipant _self;
   final $Res Function(EventParticipant) _then;
 
-  /// Create a copy of EventParticipant
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? eventId = null,
-    Object? ticketId = null,
-    Object? userId = null,
-    Object? createdAt = null,
-    Object? updatedAt = null,
-    Object? applicationId = freezed,
-    Object? status = null,
-    Object? ticketCode = freezed,
-  }) {
-    return _then(_self.copyWith(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      eventId: null == eventId
-          ? _self.eventId
-          : eventId // ignore: cast_nullable_to_non_nullable
-              as String,
-      ticketId: null == ticketId
-          ? _self.ticketId
-          : ticketId // ignore: cast_nullable_to_non_nullable
-              as String,
-      userId: null == userId
-          ? _self.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updatedAt: null == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      applicationId: freezed == applicationId
-          ? _self.applicationId
-          : applicationId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      status: null == status
-          ? _self.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as String,
-      ticketCode: freezed == ticketCode
-          ? _self.ticketCode
-          : ticketCode // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Create a copy of EventParticipant
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? eventId = null,Object? ticketId = null,Object? userId = null,Object? createdAt = null,Object? updatedAt = null,Object? applicationId = freezed,Object? status = null,Object? ticketCode = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String,ticketId: null == ticketId ? _self.ticketId : ticketId // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,applicationId: freezed == applicationId ? _self.applicationId : applicationId // ignore: cast_nullable_to_non_nullable
+as String?,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,ticketCode: freezed == ticketCode ? _self.ticketCode : ticketCode // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [EventParticipant].
 extension EventParticipantPatterns on EventParticipant {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_EventParticipant value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _EventParticipant() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EventParticipant value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EventParticipant() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_EventParticipant value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EventParticipant():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EventParticipant value)  $default,){
+final _that = this;
+switch (_that) {
+case _EventParticipant():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_EventParticipant value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EventParticipant() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EventParticipant value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EventParticipant() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'event_id') String eventId,
-            @JsonKey(name: 'ticket_id') String ticketId,
-            @JsonKey(name: 'user_id') String userId,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'application_id') String? applicationId,
-            String status,
-            @JsonKey(name: 'ticket_code') String? ticketCode)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _EventParticipant() when $default != null:
-        return $default(
-            _that.id,
-            _that.eventId,
-            _that.ticketId,
-            _that.userId,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.applicationId,
-            _that.status,
-            _that.ticketCode);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'ticket_id')  String ticketId, @JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'application_id')  String? applicationId,  String status, @JsonKey(name: 'ticket_code')  String? ticketCode)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EventParticipant() when $default != null:
+return $default(_that.id,_that.eventId,_that.ticketId,_that.userId,_that.createdAt,_that.updatedAt,_that.applicationId,_that.status,_that.ticketCode);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'event_id') String eventId,
-            @JsonKey(name: 'ticket_id') String ticketId,
-            @JsonKey(name: 'user_id') String userId,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'application_id') String? applicationId,
-            String status,
-            @JsonKey(name: 'ticket_code') String? ticketCode)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EventParticipant():
-        return $default(
-            _that.id,
-            _that.eventId,
-            _that.ticketId,
-            _that.userId,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.applicationId,
-            _that.status,
-            _that.ticketCode);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'ticket_id')  String ticketId, @JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'application_id')  String? applicationId,  String status, @JsonKey(name: 'ticket_code')  String? ticketCode)  $default,) {final _that = this;
+switch (_that) {
+case _EventParticipant():
+return $default(_that.id,_that.eventId,_that.ticketId,_that.userId,_that.createdAt,_that.updatedAt,_that.applicationId,_that.status,_that.ticketCode);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String id,
-            @JsonKey(name: 'event_id') String eventId,
-            @JsonKey(name: 'ticket_id') String ticketId,
-            @JsonKey(name: 'user_id') String userId,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'application_id') String? applicationId,
-            String status,
-            @JsonKey(name: 'ticket_code') String? ticketCode)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EventParticipant() when $default != null:
-        return $default(
-            _that.id,
-            _that.eventId,
-            _that.ticketId,
-            _that.userId,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.applicationId,
-            _that.status,
-            _that.ticketCode);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'ticket_id')  String ticketId, @JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'application_id')  String? applicationId,  String status, @JsonKey(name: 'ticket_code')  String? ticketCode)?  $default,) {final _that = this;
+switch (_that) {
+case _EventParticipant() when $default != null:
+return $default(_that.id,_that.eventId,_that.ticketId,_that.userId,_that.createdAt,_that.updatedAt,_that.applicationId,_that.status,_that.ticketCode);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _EventParticipant implements EventParticipant {
-  const _EventParticipant(
-      {required this.id,
-      @JsonKey(name: 'event_id') required this.eventId,
-      @JsonKey(name: 'ticket_id') required this.ticketId,
-      @JsonKey(name: 'user_id') required this.userId,
-      @JsonKey(name: 'created_at') required this.createdAt,
-      @JsonKey(name: 'updated_at') required this.updatedAt,
-      @JsonKey(name: 'application_id') this.applicationId,
-      this.status = 'ticket_issued',
-      @JsonKey(name: 'ticket_code') this.ticketCode});
-  factory _EventParticipant.fromJson(Map<String, dynamic> json) =>
-      _$EventParticipantFromJson(json);
+  const _EventParticipant({required this.id, @JsonKey(name: 'event_id') required this.eventId, @JsonKey(name: 'ticket_id') required this.ticketId, @JsonKey(name: 'user_id') required this.userId, @JsonKey(name: 'created_at') required this.createdAt, @JsonKey(name: 'updated_at') required this.updatedAt, @JsonKey(name: 'application_id') this.applicationId, this.status = 'ticket_issued', @JsonKey(name: 'ticket_code') this.ticketCode});
+  factory _EventParticipant.fromJson(Map<String, dynamic> json) => _$EventParticipantFromJson(json);
 
-  @override
-  final String id;
-  @override
-  @JsonKey(name: 'event_id')
-  final String eventId;
-  @override
-  @JsonKey(name: 'ticket_id')
-  final String ticketId;
-  @override
-  @JsonKey(name: 'user_id')
-  final String userId;
-  @override
-  @JsonKey(name: 'created_at')
-  final DateTime createdAt;
-  @override
-  @JsonKey(name: 'updated_at')
-  final DateTime updatedAt;
-  @override
-  @JsonKey(name: 'application_id')
-  final String? applicationId;
-  @override
-  @JsonKey()
-  final String status;
-  @override
-  @JsonKey(name: 'ticket_code')
-  final String? ticketCode;
+@override final  String id;
+@override@JsonKey(name: 'event_id') final  String eventId;
+@override@JsonKey(name: 'ticket_id') final  String ticketId;
+@override@JsonKey(name: 'user_id') final  String userId;
+@override@JsonKey(name: 'created_at') final  DateTime createdAt;
+@override@JsonKey(name: 'updated_at') final  DateTime updatedAt;
+@override@JsonKey(name: 'application_id') final  String? applicationId;
+@override@JsonKey() final  String status;
+@override@JsonKey(name: 'ticket_code') final  String? ticketCode;
 
-  /// Create a copy of EventParticipant
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$EventParticipantCopyWith<_EventParticipant> get copyWith =>
-      __$EventParticipantCopyWithImpl<_EventParticipant>(this, _$identity);
+/// Create a copy of EventParticipant
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EventParticipantCopyWith<_EventParticipant> get copyWith => __$EventParticipantCopyWithImpl<_EventParticipant>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$EventParticipantToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$EventParticipantToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _EventParticipant &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.eventId, eventId) || other.eventId == eventId) &&
-            (identical(other.ticketId, ticketId) ||
-                other.ticketId == ticketId) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt) &&
-            (identical(other.applicationId, applicationId) ||
-                other.applicationId == applicationId) &&
-            (identical(other.status, status) || other.status == status) &&
-            (identical(other.ticketCode, ticketCode) ||
-                other.ticketCode == ticketCode));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EventParticipant&&(identical(other.id, id) || other.id == id)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.ticketId, ticketId) || other.ticketId == ticketId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.applicationId, applicationId) || other.applicationId == applicationId)&&(identical(other.status, status) || other.status == status)&&(identical(other.ticketCode, ticketCode) || other.ticketCode == ticketCode));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, id, eventId, ticketId, userId,
-      createdAt, updatedAt, applicationId, status, ticketCode);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,eventId,ticketId,userId,createdAt,updatedAt,applicationId,status,ticketCode);
 
-  @override
-  String toString() {
-    return 'EventParticipant(id: $id, eventId: $eventId, ticketId: $ticketId, userId: $userId, createdAt: $createdAt, updatedAt: $updatedAt, applicationId: $applicationId, status: $status, ticketCode: $ticketCode)';
-  }
+@override
+String toString() {
+  return 'EventParticipant(id: $id, eventId: $eventId, ticketId: $ticketId, userId: $userId, createdAt: $createdAt, updatedAt: $updatedAt, applicationId: $applicationId, status: $status, ticketCode: $ticketCode)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$EventParticipantCopyWith<$Res>
-    implements $EventParticipantCopyWith<$Res> {
-  factory _$EventParticipantCopyWith(
-          _EventParticipant value, $Res Function(_EventParticipant) _then) =
-      __$EventParticipantCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'event_id') String eventId,
-      @JsonKey(name: 'ticket_id') String ticketId,
-      @JsonKey(name: 'user_id') String userId,
-      @JsonKey(name: 'created_at') DateTime createdAt,
-      @JsonKey(name: 'updated_at') DateTime updatedAt,
-      @JsonKey(name: 'application_id') String? applicationId,
-      String status,
-      @JsonKey(name: 'ticket_code') String? ticketCode});
-}
+abstract mixin class _$EventParticipantCopyWith<$Res> implements $EventParticipantCopyWith<$Res> {
+  factory _$EventParticipantCopyWith(_EventParticipant value, $Res Function(_EventParticipant) _then) = __$EventParticipantCopyWithImpl;
+@override @useResult
+$Res call({
+ String id,@JsonKey(name: 'event_id') String eventId,@JsonKey(name: 'ticket_id') String ticketId,@JsonKey(name: 'user_id') String userId,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'application_id') String? applicationId, String status,@JsonKey(name: 'ticket_code') String? ticketCode
+});
 
+
+
+
+}
 /// @nodoc
 class __$EventParticipantCopyWithImpl<$Res>
     implements _$EventParticipantCopyWith<$Res> {
@@ -488,60 +278,24 @@ class __$EventParticipantCopyWithImpl<$Res>
   final _EventParticipant _self;
   final $Res Function(_EventParticipant) _then;
 
-  /// Create a copy of EventParticipant
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? eventId = null,
-    Object? ticketId = null,
-    Object? userId = null,
-    Object? createdAt = null,
-    Object? updatedAt = null,
-    Object? applicationId = freezed,
-    Object? status = null,
-    Object? ticketCode = freezed,
-  }) {
-    return _then(_EventParticipant(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      eventId: null == eventId
-          ? _self.eventId
-          : eventId // ignore: cast_nullable_to_non_nullable
-              as String,
-      ticketId: null == ticketId
-          ? _self.ticketId
-          : ticketId // ignore: cast_nullable_to_non_nullable
-              as String,
-      userId: null == userId
-          ? _self.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updatedAt: null == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      applicationId: freezed == applicationId
-          ? _self.applicationId
-          : applicationId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      status: null == status
-          ? _self.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as String,
-      ticketCode: freezed == ticketCode
-          ? _self.ticketCode
-          : ticketCode // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Create a copy of EventParticipant
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? eventId = null,Object? ticketId = null,Object? userId = null,Object? createdAt = null,Object? updatedAt = null,Object? applicationId = freezed,Object? status = null,Object? ticketCode = freezed,}) {
+  return _then(_EventParticipant(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String,ticketId: null == ticketId ? _self.ticketId : ticketId // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,applicationId: freezed == applicationId ? _self.applicationId : applicationId // ignore: cast_nullable_to_non_nullable
+as String?,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,ticketCode: freezed == ticketCode ? _self.ticketCode : ticketCode // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/matching.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/matching.freezed.dart
@@ -14,1277 +14,831 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$MatchRule {
-  String get id;
-  @JsonKey(name: 'event_id')
-  String get eventId;
-  @JsonKey(name: 'source_group_id')
-  String get sourceGroupId;
-  @JsonKey(name: 'target_group_id')
-  String get targetGroupId;
-  @JsonKey(name: 'created_at')
-  DateTime get createdAt;
 
-  /// Create a copy of MatchRule
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $MatchRuleCopyWith<MatchRule> get copyWith =>
-      _$MatchRuleCopyWithImpl<MatchRule>(this as MatchRule, _$identity);
+ String get id;@JsonKey(name: 'event_id') String get eventId;@JsonKey(name: 'source_group_id') String get sourceGroupId;@JsonKey(name: 'target_group_id') String get targetGroupId;@JsonKey(name: 'created_at') DateTime get createdAt;
+/// Create a copy of MatchRule
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MatchRuleCopyWith<MatchRule> get copyWith => _$MatchRuleCopyWithImpl<MatchRule>(this as MatchRule, _$identity);
 
   /// Serializes this MatchRule to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is MatchRule &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.eventId, eventId) || other.eventId == eventId) &&
-            (identical(other.sourceGroupId, sourceGroupId) ||
-                other.sourceGroupId == sourceGroupId) &&
-            (identical(other.targetGroupId, targetGroupId) ||
-                other.targetGroupId == targetGroupId) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, id, eventId, sourceGroupId, targetGroupId, createdAt);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MatchRule&&(identical(other.id, id) || other.id == id)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.sourceGroupId, sourceGroupId) || other.sourceGroupId == sourceGroupId)&&(identical(other.targetGroupId, targetGroupId) || other.targetGroupId == targetGroupId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
 
-  @override
-  String toString() {
-    return 'MatchRule(id: $id, eventId: $eventId, sourceGroupId: $sourceGroupId, targetGroupId: $targetGroupId, createdAt: $createdAt)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,eventId,sourceGroupId,targetGroupId,createdAt);
+
+@override
+String toString() {
+  return 'MatchRule(id: $id, eventId: $eventId, sourceGroupId: $sourceGroupId, targetGroupId: $targetGroupId, createdAt: $createdAt)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $MatchRuleCopyWith<$Res> {
-  factory $MatchRuleCopyWith(MatchRule value, $Res Function(MatchRule) _then) =
-      _$MatchRuleCopyWithImpl;
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'event_id') String eventId,
-      @JsonKey(name: 'source_group_id') String sourceGroupId,
-      @JsonKey(name: 'target_group_id') String targetGroupId,
-      @JsonKey(name: 'created_at') DateTime createdAt});
-}
+abstract mixin class $MatchRuleCopyWith<$Res>  {
+  factory $MatchRuleCopyWith(MatchRule value, $Res Function(MatchRule) _then) = _$MatchRuleCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(name: 'event_id') String eventId,@JsonKey(name: 'source_group_id') String sourceGroupId,@JsonKey(name: 'target_group_id') String targetGroupId,@JsonKey(name: 'created_at') DateTime createdAt
+});
 
+
+
+
+}
 /// @nodoc
-class _$MatchRuleCopyWithImpl<$Res> implements $MatchRuleCopyWith<$Res> {
+class _$MatchRuleCopyWithImpl<$Res>
+    implements $MatchRuleCopyWith<$Res> {
   _$MatchRuleCopyWithImpl(this._self, this._then);
 
   final MatchRule _self;
   final $Res Function(MatchRule) _then;
 
-  /// Create a copy of MatchRule
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? eventId = null,
-    Object? sourceGroupId = null,
-    Object? targetGroupId = null,
-    Object? createdAt = null,
-  }) {
-    return _then(_self.copyWith(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      eventId: null == eventId
-          ? _self.eventId
-          : eventId // ignore: cast_nullable_to_non_nullable
-              as String,
-      sourceGroupId: null == sourceGroupId
-          ? _self.sourceGroupId
-          : sourceGroupId // ignore: cast_nullable_to_non_nullable
-              as String,
-      targetGroupId: null == targetGroupId
-          ? _self.targetGroupId
-          : targetGroupId // ignore: cast_nullable_to_non_nullable
-              as String,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-    ));
-  }
+/// Create a copy of MatchRule
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? eventId = null,Object? sourceGroupId = null,Object? targetGroupId = null,Object? createdAt = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String,sourceGroupId: null == sourceGroupId ? _self.sourceGroupId : sourceGroupId // ignore: cast_nullable_to_non_nullable
+as String,targetGroupId: null == targetGroupId ? _self.targetGroupId : targetGroupId // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [MatchRule].
 extension MatchRulePatterns on MatchRule {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_MatchRule value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _MatchRule() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _MatchRule value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _MatchRule() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_MatchRule value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _MatchRule():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _MatchRule value)  $default,){
+final _that = this;
+switch (_that) {
+case _MatchRule():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_MatchRule value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _MatchRule() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _MatchRule value)?  $default,){
+final _that = this;
+switch (_that) {
+case _MatchRule() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'event_id') String eventId,
-            @JsonKey(name: 'source_group_id') String sourceGroupId,
-            @JsonKey(name: 'target_group_id') String targetGroupId,
-            @JsonKey(name: 'created_at') DateTime createdAt)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _MatchRule() when $default != null:
-        return $default(_that.id, _that.eventId, _that.sourceGroupId,
-            _that.targetGroupId, _that.createdAt);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'source_group_id')  String sourceGroupId, @JsonKey(name: 'target_group_id')  String targetGroupId, @JsonKey(name: 'created_at')  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _MatchRule() when $default != null:
+return $default(_that.id,_that.eventId,_that.sourceGroupId,_that.targetGroupId,_that.createdAt);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'event_id') String eventId,
-            @JsonKey(name: 'source_group_id') String sourceGroupId,
-            @JsonKey(name: 'target_group_id') String targetGroupId,
-            @JsonKey(name: 'created_at') DateTime createdAt)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _MatchRule():
-        return $default(_that.id, _that.eventId, _that.sourceGroupId,
-            _that.targetGroupId, _that.createdAt);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'source_group_id')  String sourceGroupId, @JsonKey(name: 'target_group_id')  String targetGroupId, @JsonKey(name: 'created_at')  DateTime createdAt)  $default,) {final _that = this;
+switch (_that) {
+case _MatchRule():
+return $default(_that.id,_that.eventId,_that.sourceGroupId,_that.targetGroupId,_that.createdAt);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String id,
-            @JsonKey(name: 'event_id') String eventId,
-            @JsonKey(name: 'source_group_id') String sourceGroupId,
-            @JsonKey(name: 'target_group_id') String targetGroupId,
-            @JsonKey(name: 'created_at') DateTime createdAt)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _MatchRule() when $default != null:
-        return $default(_that.id, _that.eventId, _that.sourceGroupId,
-            _that.targetGroupId, _that.createdAt);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'source_group_id')  String sourceGroupId, @JsonKey(name: 'target_group_id')  String targetGroupId, @JsonKey(name: 'created_at')  DateTime createdAt)?  $default,) {final _that = this;
+switch (_that) {
+case _MatchRule() when $default != null:
+return $default(_that.id,_that.eventId,_that.sourceGroupId,_that.targetGroupId,_that.createdAt);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _MatchRule implements MatchRule {
-  const _MatchRule(
-      {required this.id,
-      @JsonKey(name: 'event_id') required this.eventId,
-      @JsonKey(name: 'source_group_id') required this.sourceGroupId,
-      @JsonKey(name: 'target_group_id') required this.targetGroupId,
-      @JsonKey(name: 'created_at') required this.createdAt});
-  factory _MatchRule.fromJson(Map<String, dynamic> json) =>
-      _$MatchRuleFromJson(json);
+  const _MatchRule({required this.id, @JsonKey(name: 'event_id') required this.eventId, @JsonKey(name: 'source_group_id') required this.sourceGroupId, @JsonKey(name: 'target_group_id') required this.targetGroupId, @JsonKey(name: 'created_at') required this.createdAt});
+  factory _MatchRule.fromJson(Map<String, dynamic> json) => _$MatchRuleFromJson(json);
 
-  @override
-  final String id;
-  @override
-  @JsonKey(name: 'event_id')
-  final String eventId;
-  @override
-  @JsonKey(name: 'source_group_id')
-  final String sourceGroupId;
-  @override
-  @JsonKey(name: 'target_group_id')
-  final String targetGroupId;
-  @override
-  @JsonKey(name: 'created_at')
-  final DateTime createdAt;
+@override final  String id;
+@override@JsonKey(name: 'event_id') final  String eventId;
+@override@JsonKey(name: 'source_group_id') final  String sourceGroupId;
+@override@JsonKey(name: 'target_group_id') final  String targetGroupId;
+@override@JsonKey(name: 'created_at') final  DateTime createdAt;
 
-  /// Create a copy of MatchRule
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$MatchRuleCopyWith<_MatchRule> get copyWith =>
-      __$MatchRuleCopyWithImpl<_MatchRule>(this, _$identity);
+/// Create a copy of MatchRule
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$MatchRuleCopyWith<_MatchRule> get copyWith => __$MatchRuleCopyWithImpl<_MatchRule>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$MatchRuleToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$MatchRuleToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _MatchRule &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.eventId, eventId) || other.eventId == eventId) &&
-            (identical(other.sourceGroupId, sourceGroupId) ||
-                other.sourceGroupId == sourceGroupId) &&
-            (identical(other.targetGroupId, targetGroupId) ||
-                other.targetGroupId == targetGroupId) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MatchRule&&(identical(other.id, id) || other.id == id)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.sourceGroupId, sourceGroupId) || other.sourceGroupId == sourceGroupId)&&(identical(other.targetGroupId, targetGroupId) || other.targetGroupId == targetGroupId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, id, eventId, sourceGroupId, targetGroupId, createdAt);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,eventId,sourceGroupId,targetGroupId,createdAt);
 
-  @override
-  String toString() {
-    return 'MatchRule(id: $id, eventId: $eventId, sourceGroupId: $sourceGroupId, targetGroupId: $targetGroupId, createdAt: $createdAt)';
-  }
+@override
+String toString() {
+  return 'MatchRule(id: $id, eventId: $eventId, sourceGroupId: $sourceGroupId, targetGroupId: $targetGroupId, createdAt: $createdAt)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$MatchRuleCopyWith<$Res>
-    implements $MatchRuleCopyWith<$Res> {
-  factory _$MatchRuleCopyWith(
-          _MatchRule value, $Res Function(_MatchRule) _then) =
-      __$MatchRuleCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'event_id') String eventId,
-      @JsonKey(name: 'source_group_id') String sourceGroupId,
-      @JsonKey(name: 'target_group_id') String targetGroupId,
-      @JsonKey(name: 'created_at') DateTime createdAt});
-}
+abstract mixin class _$MatchRuleCopyWith<$Res> implements $MatchRuleCopyWith<$Res> {
+  factory _$MatchRuleCopyWith(_MatchRule value, $Res Function(_MatchRule) _then) = __$MatchRuleCopyWithImpl;
+@override @useResult
+$Res call({
+ String id,@JsonKey(name: 'event_id') String eventId,@JsonKey(name: 'source_group_id') String sourceGroupId,@JsonKey(name: 'target_group_id') String targetGroupId,@JsonKey(name: 'created_at') DateTime createdAt
+});
 
+
+
+
+}
 /// @nodoc
-class __$MatchRuleCopyWithImpl<$Res> implements _$MatchRuleCopyWith<$Res> {
+class __$MatchRuleCopyWithImpl<$Res>
+    implements _$MatchRuleCopyWith<$Res> {
   __$MatchRuleCopyWithImpl(this._self, this._then);
 
   final _MatchRule _self;
   final $Res Function(_MatchRule) _then;
 
-  /// Create a copy of MatchRule
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? eventId = null,
-    Object? sourceGroupId = null,
-    Object? targetGroupId = null,
-    Object? createdAt = null,
-  }) {
-    return _then(_MatchRule(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      eventId: null == eventId
-          ? _self.eventId
-          : eventId // ignore: cast_nullable_to_non_nullable
-              as String,
-      sourceGroupId: null == sourceGroupId
-          ? _self.sourceGroupId
-          : sourceGroupId // ignore: cast_nullable_to_non_nullable
-              as String,
-      targetGroupId: null == targetGroupId
-          ? _self.targetGroupId
-          : targetGroupId // ignore: cast_nullable_to_non_nullable
-              as String,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-    ));
-  }
+/// Create a copy of MatchRule
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? eventId = null,Object? sourceGroupId = null,Object? targetGroupId = null,Object? createdAt = null,}) {
+  return _then(_MatchRule(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String,sourceGroupId: null == sourceGroupId ? _self.sourceGroupId : sourceGroupId // ignore: cast_nullable_to_non_nullable
+as String,targetGroupId: null == targetGroupId ? _self.targetGroupId : targetGroupId // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
 }
+
+
+}
+
 
 /// @nodoc
 mixin _$MatchVote {
-  @JsonKey(name: 'event_id')
-  String get eventId;
-  @JsonKey(name: 'voter_id')
-  String get voterId;
-  @JsonKey(name: 'candidate_id')
-  String get candidateId;
-  @JsonKey(name: 'created_at')
-  DateTime get createdAt;
 
-  /// Create a copy of MatchVote
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $MatchVoteCopyWith<MatchVote> get copyWith =>
-      _$MatchVoteCopyWithImpl<MatchVote>(this as MatchVote, _$identity);
+@JsonKey(name: 'event_id') String get eventId;@JsonKey(name: 'voter_id') String get voterId;@JsonKey(name: 'candidate_id') String get candidateId;@JsonKey(name: 'created_at') DateTime get createdAt;
+/// Create a copy of MatchVote
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MatchVoteCopyWith<MatchVote> get copyWith => _$MatchVoteCopyWithImpl<MatchVote>(this as MatchVote, _$identity);
 
   /// Serializes this MatchVote to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is MatchVote &&
-            (identical(other.eventId, eventId) || other.eventId == eventId) &&
-            (identical(other.voterId, voterId) || other.voterId == voterId) &&
-            (identical(other.candidateId, candidateId) ||
-                other.candidateId == candidateId) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode =>
-      Object.hash(runtimeType, eventId, voterId, candidateId, createdAt);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MatchVote&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.voterId, voterId) || other.voterId == voterId)&&(identical(other.candidateId, candidateId) || other.candidateId == candidateId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
 
-  @override
-  String toString() {
-    return 'MatchVote(eventId: $eventId, voterId: $voterId, candidateId: $candidateId, createdAt: $createdAt)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,eventId,voterId,candidateId,createdAt);
+
+@override
+String toString() {
+  return 'MatchVote(eventId: $eventId, voterId: $voterId, candidateId: $candidateId, createdAt: $createdAt)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $MatchVoteCopyWith<$Res> {
-  factory $MatchVoteCopyWith(MatchVote value, $Res Function(MatchVote) _then) =
-      _$MatchVoteCopyWithImpl;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'event_id') String eventId,
-      @JsonKey(name: 'voter_id') String voterId,
-      @JsonKey(name: 'candidate_id') String candidateId,
-      @JsonKey(name: 'created_at') DateTime createdAt});
-}
+abstract mixin class $MatchVoteCopyWith<$Res>  {
+  factory $MatchVoteCopyWith(MatchVote value, $Res Function(MatchVote) _then) = _$MatchVoteCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'event_id') String eventId,@JsonKey(name: 'voter_id') String voterId,@JsonKey(name: 'candidate_id') String candidateId,@JsonKey(name: 'created_at') DateTime createdAt
+});
 
+
+
+
+}
 /// @nodoc
-class _$MatchVoteCopyWithImpl<$Res> implements $MatchVoteCopyWith<$Res> {
+class _$MatchVoteCopyWithImpl<$Res>
+    implements $MatchVoteCopyWith<$Res> {
   _$MatchVoteCopyWithImpl(this._self, this._then);
 
   final MatchVote _self;
   final $Res Function(MatchVote) _then;
 
-  /// Create a copy of MatchVote
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? eventId = null,
-    Object? voterId = null,
-    Object? candidateId = null,
-    Object? createdAt = null,
-  }) {
-    return _then(_self.copyWith(
-      eventId: null == eventId
-          ? _self.eventId
-          : eventId // ignore: cast_nullable_to_non_nullable
-              as String,
-      voterId: null == voterId
-          ? _self.voterId
-          : voterId // ignore: cast_nullable_to_non_nullable
-              as String,
-      candidateId: null == candidateId
-          ? _self.candidateId
-          : candidateId // ignore: cast_nullable_to_non_nullable
-              as String,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-    ));
-  }
+/// Create a copy of MatchVote
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? eventId = null,Object? voterId = null,Object? candidateId = null,Object? createdAt = null,}) {
+  return _then(_self.copyWith(
+eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String,voterId: null == voterId ? _self.voterId : voterId // ignore: cast_nullable_to_non_nullable
+as String,candidateId: null == candidateId ? _self.candidateId : candidateId // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [MatchVote].
 extension MatchVotePatterns on MatchVote {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_MatchVote value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _MatchVote() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _MatchVote value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _MatchVote() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_MatchVote value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _MatchVote():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _MatchVote value)  $default,){
+final _that = this;
+switch (_that) {
+case _MatchVote():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_MatchVote value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _MatchVote() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _MatchVote value)?  $default,){
+final _that = this;
+switch (_that) {
+case _MatchVote() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            @JsonKey(name: 'event_id') String eventId,
-            @JsonKey(name: 'voter_id') String voterId,
-            @JsonKey(name: 'candidate_id') String candidateId,
-            @JsonKey(name: 'created_at') DateTime createdAt)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _MatchVote() when $default != null:
-        return $default(
-            _that.eventId, _that.voterId, _that.candidateId, _that.createdAt);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'voter_id')  String voterId, @JsonKey(name: 'candidate_id')  String candidateId, @JsonKey(name: 'created_at')  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _MatchVote() when $default != null:
+return $default(_that.eventId,_that.voterId,_that.candidateId,_that.createdAt);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            @JsonKey(name: 'event_id') String eventId,
-            @JsonKey(name: 'voter_id') String voterId,
-            @JsonKey(name: 'candidate_id') String candidateId,
-            @JsonKey(name: 'created_at') DateTime createdAt)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _MatchVote():
-        return $default(
-            _that.eventId, _that.voterId, _that.candidateId, _that.createdAt);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'voter_id')  String voterId, @JsonKey(name: 'candidate_id')  String candidateId, @JsonKey(name: 'created_at')  DateTime createdAt)  $default,) {final _that = this;
+switch (_that) {
+case _MatchVote():
+return $default(_that.eventId,_that.voterId,_that.candidateId,_that.createdAt);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            @JsonKey(name: 'event_id') String eventId,
-            @JsonKey(name: 'voter_id') String voterId,
-            @JsonKey(name: 'candidate_id') String candidateId,
-            @JsonKey(name: 'created_at') DateTime createdAt)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _MatchVote() when $default != null:
-        return $default(
-            _that.eventId, _that.voterId, _that.candidateId, _that.createdAt);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'voter_id')  String voterId, @JsonKey(name: 'candidate_id')  String candidateId, @JsonKey(name: 'created_at')  DateTime createdAt)?  $default,) {final _that = this;
+switch (_that) {
+case _MatchVote() when $default != null:
+return $default(_that.eventId,_that.voterId,_that.candidateId,_that.createdAt);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _MatchVote implements MatchVote {
-  const _MatchVote(
-      {@JsonKey(name: 'event_id') required this.eventId,
-      @JsonKey(name: 'voter_id') required this.voterId,
-      @JsonKey(name: 'candidate_id') required this.candidateId,
-      @JsonKey(name: 'created_at') required this.createdAt});
-  factory _MatchVote.fromJson(Map<String, dynamic> json) =>
-      _$MatchVoteFromJson(json);
+  const _MatchVote({@JsonKey(name: 'event_id') required this.eventId, @JsonKey(name: 'voter_id') required this.voterId, @JsonKey(name: 'candidate_id') required this.candidateId, @JsonKey(name: 'created_at') required this.createdAt});
+  factory _MatchVote.fromJson(Map<String, dynamic> json) => _$MatchVoteFromJson(json);
 
-  @override
-  @JsonKey(name: 'event_id')
-  final String eventId;
-  @override
-  @JsonKey(name: 'voter_id')
-  final String voterId;
-  @override
-  @JsonKey(name: 'candidate_id')
-  final String candidateId;
-  @override
-  @JsonKey(name: 'created_at')
-  final DateTime createdAt;
+@override@JsonKey(name: 'event_id') final  String eventId;
+@override@JsonKey(name: 'voter_id') final  String voterId;
+@override@JsonKey(name: 'candidate_id') final  String candidateId;
+@override@JsonKey(name: 'created_at') final  DateTime createdAt;
 
-  /// Create a copy of MatchVote
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$MatchVoteCopyWith<_MatchVote> get copyWith =>
-      __$MatchVoteCopyWithImpl<_MatchVote>(this, _$identity);
+/// Create a copy of MatchVote
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$MatchVoteCopyWith<_MatchVote> get copyWith => __$MatchVoteCopyWithImpl<_MatchVote>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$MatchVoteToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$MatchVoteToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _MatchVote &&
-            (identical(other.eventId, eventId) || other.eventId == eventId) &&
-            (identical(other.voterId, voterId) || other.voterId == voterId) &&
-            (identical(other.candidateId, candidateId) ||
-                other.candidateId == candidateId) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MatchVote&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.voterId, voterId) || other.voterId == voterId)&&(identical(other.candidateId, candidateId) || other.candidateId == candidateId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode =>
-      Object.hash(runtimeType, eventId, voterId, candidateId, createdAt);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,eventId,voterId,candidateId,createdAt);
 
-  @override
-  String toString() {
-    return 'MatchVote(eventId: $eventId, voterId: $voterId, candidateId: $candidateId, createdAt: $createdAt)';
-  }
+@override
+String toString() {
+  return 'MatchVote(eventId: $eventId, voterId: $voterId, candidateId: $candidateId, createdAt: $createdAt)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$MatchVoteCopyWith<$Res>
-    implements $MatchVoteCopyWith<$Res> {
-  factory _$MatchVoteCopyWith(
-          _MatchVote value, $Res Function(_MatchVote) _then) =
-      __$MatchVoteCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'event_id') String eventId,
-      @JsonKey(name: 'voter_id') String voterId,
-      @JsonKey(name: 'candidate_id') String candidateId,
-      @JsonKey(name: 'created_at') DateTime createdAt});
-}
+abstract mixin class _$MatchVoteCopyWith<$Res> implements $MatchVoteCopyWith<$Res> {
+  factory _$MatchVoteCopyWith(_MatchVote value, $Res Function(_MatchVote) _then) = __$MatchVoteCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'event_id') String eventId,@JsonKey(name: 'voter_id') String voterId,@JsonKey(name: 'candidate_id') String candidateId,@JsonKey(name: 'created_at') DateTime createdAt
+});
 
+
+
+
+}
 /// @nodoc
-class __$MatchVoteCopyWithImpl<$Res> implements _$MatchVoteCopyWith<$Res> {
+class __$MatchVoteCopyWithImpl<$Res>
+    implements _$MatchVoteCopyWith<$Res> {
   __$MatchVoteCopyWithImpl(this._self, this._then);
 
   final _MatchVote _self;
   final $Res Function(_MatchVote) _then;
 
-  /// Create a copy of MatchVote
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? eventId = null,
-    Object? voterId = null,
-    Object? candidateId = null,
-    Object? createdAt = null,
-  }) {
-    return _then(_MatchVote(
-      eventId: null == eventId
-          ? _self.eventId
-          : eventId // ignore: cast_nullable_to_non_nullable
-              as String,
-      voterId: null == voterId
-          ? _self.voterId
-          : voterId // ignore: cast_nullable_to_non_nullable
-              as String,
-      candidateId: null == candidateId
-          ? _self.candidateId
-          : candidateId // ignore: cast_nullable_to_non_nullable
-              as String,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-    ));
-  }
+/// Create a copy of MatchVote
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? eventId = null,Object? voterId = null,Object? candidateId = null,Object? createdAt = null,}) {
+  return _then(_MatchVote(
+eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String,voterId: null == voterId ? _self.voterId : voterId // ignore: cast_nullable_to_non_nullable
+as String,candidateId: null == candidateId ? _self.candidateId : candidateId // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
 }
+
+
+}
+
 
 /// @nodoc
 mixin _$MatchPair {
-  @JsonKey(name: 'match_id')
-  String get matchId;
-  @JsonKey(name: 'event_id')
-  String get eventId;
-  @JsonKey(name: 'partner_id')
-  String get partnerId;
-  @JsonKey(name: 'matched_at')
-  DateTime get matchedAt; // Optional: Partner profile details (if joined)
-  @JsonKey(includeFromJson: false)
-  String? get partnerName;
-  @JsonKey(includeFromJson: false)
-  String? get partnerProfileImage;
-  @JsonKey(includeFromJson: false)
-  String? get partnerContact;
 
-  /// Create a copy of MatchPair
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $MatchPairCopyWith<MatchPair> get copyWith =>
-      _$MatchPairCopyWithImpl<MatchPair>(this as MatchPair, _$identity);
+@JsonKey(name: 'match_id') String get matchId;@JsonKey(name: 'event_id') String get eventId;@JsonKey(name: 'partner_id') String get partnerId;@JsonKey(name: 'matched_at') DateTime get matchedAt;// Optional: Partner profile details (if joined)
+@JsonKey(includeFromJson: false) String? get partnerName;@JsonKey(includeFromJson: false) String? get partnerProfileImage;@JsonKey(includeFromJson: false) String? get partnerContact;
+/// Create a copy of MatchPair
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$MatchPairCopyWith<MatchPair> get copyWith => _$MatchPairCopyWithImpl<MatchPair>(this as MatchPair, _$identity);
 
   /// Serializes this MatchPair to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is MatchPair &&
-            (identical(other.matchId, matchId) || other.matchId == matchId) &&
-            (identical(other.eventId, eventId) || other.eventId == eventId) &&
-            (identical(other.partnerId, partnerId) ||
-                other.partnerId == partnerId) &&
-            (identical(other.matchedAt, matchedAt) ||
-                other.matchedAt == matchedAt) &&
-            (identical(other.partnerName, partnerName) ||
-                other.partnerName == partnerName) &&
-            (identical(other.partnerProfileImage, partnerProfileImage) ||
-                other.partnerProfileImage == partnerProfileImage) &&
-            (identical(other.partnerContact, partnerContact) ||
-                other.partnerContact == partnerContact));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, matchId, eventId, partnerId,
-      matchedAt, partnerName, partnerProfileImage, partnerContact);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MatchPair&&(identical(other.matchId, matchId) || other.matchId == matchId)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.partnerId, partnerId) || other.partnerId == partnerId)&&(identical(other.matchedAt, matchedAt) || other.matchedAt == matchedAt)&&(identical(other.partnerName, partnerName) || other.partnerName == partnerName)&&(identical(other.partnerProfileImage, partnerProfileImage) || other.partnerProfileImage == partnerProfileImage)&&(identical(other.partnerContact, partnerContact) || other.partnerContact == partnerContact));
+}
 
-  @override
-  String toString() {
-    return 'MatchPair(matchId: $matchId, eventId: $eventId, partnerId: $partnerId, matchedAt: $matchedAt, partnerName: $partnerName, partnerProfileImage: $partnerProfileImage, partnerContact: $partnerContact)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,matchId,eventId,partnerId,matchedAt,partnerName,partnerProfileImage,partnerContact);
+
+@override
+String toString() {
+  return 'MatchPair(matchId: $matchId, eventId: $eventId, partnerId: $partnerId, matchedAt: $matchedAt, partnerName: $partnerName, partnerProfileImage: $partnerProfileImage, partnerContact: $partnerContact)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $MatchPairCopyWith<$Res> {
-  factory $MatchPairCopyWith(MatchPair value, $Res Function(MatchPair) _then) =
-      _$MatchPairCopyWithImpl;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'match_id') String matchId,
-      @JsonKey(name: 'event_id') String eventId,
-      @JsonKey(name: 'partner_id') String partnerId,
-      @JsonKey(name: 'matched_at') DateTime matchedAt,
-      @JsonKey(includeFromJson: false) String? partnerName,
-      @JsonKey(includeFromJson: false) String? partnerProfileImage,
-      @JsonKey(includeFromJson: false) String? partnerContact});
-}
+abstract mixin class $MatchPairCopyWith<$Res>  {
+  factory $MatchPairCopyWith(MatchPair value, $Res Function(MatchPair) _then) = _$MatchPairCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'match_id') String matchId,@JsonKey(name: 'event_id') String eventId,@JsonKey(name: 'partner_id') String partnerId,@JsonKey(name: 'matched_at') DateTime matchedAt,@JsonKey(includeFromJson: false) String? partnerName,@JsonKey(includeFromJson: false) String? partnerProfileImage,@JsonKey(includeFromJson: false) String? partnerContact
+});
 
+
+
+
+}
 /// @nodoc
-class _$MatchPairCopyWithImpl<$Res> implements $MatchPairCopyWith<$Res> {
+class _$MatchPairCopyWithImpl<$Res>
+    implements $MatchPairCopyWith<$Res> {
   _$MatchPairCopyWithImpl(this._self, this._then);
 
   final MatchPair _self;
   final $Res Function(MatchPair) _then;
 
-  /// Create a copy of MatchPair
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? matchId = null,
-    Object? eventId = null,
-    Object? partnerId = null,
-    Object? matchedAt = null,
-    Object? partnerName = freezed,
-    Object? partnerProfileImage = freezed,
-    Object? partnerContact = freezed,
-  }) {
-    return _then(_self.copyWith(
-      matchId: null == matchId
-          ? _self.matchId
-          : matchId // ignore: cast_nullable_to_non_nullable
-              as String,
-      eventId: null == eventId
-          ? _self.eventId
-          : eventId // ignore: cast_nullable_to_non_nullable
-              as String,
-      partnerId: null == partnerId
-          ? _self.partnerId
-          : partnerId // ignore: cast_nullable_to_non_nullable
-              as String,
-      matchedAt: null == matchedAt
-          ? _self.matchedAt
-          : matchedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      partnerName: freezed == partnerName
-          ? _self.partnerName
-          : partnerName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      partnerProfileImage: freezed == partnerProfileImage
-          ? _self.partnerProfileImage
-          : partnerProfileImage // ignore: cast_nullable_to_non_nullable
-              as String?,
-      partnerContact: freezed == partnerContact
-          ? _self.partnerContact
-          : partnerContact // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Create a copy of MatchPair
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? matchId = null,Object? eventId = null,Object? partnerId = null,Object? matchedAt = null,Object? partnerName = freezed,Object? partnerProfileImage = freezed,Object? partnerContact = freezed,}) {
+  return _then(_self.copyWith(
+matchId: null == matchId ? _self.matchId : matchId // ignore: cast_nullable_to_non_nullable
+as String,eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String,partnerId: null == partnerId ? _self.partnerId : partnerId // ignore: cast_nullable_to_non_nullable
+as String,matchedAt: null == matchedAt ? _self.matchedAt : matchedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,partnerName: freezed == partnerName ? _self.partnerName : partnerName // ignore: cast_nullable_to_non_nullable
+as String?,partnerProfileImage: freezed == partnerProfileImage ? _self.partnerProfileImage : partnerProfileImage // ignore: cast_nullable_to_non_nullable
+as String?,partnerContact: freezed == partnerContact ? _self.partnerContact : partnerContact // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [MatchPair].
 extension MatchPairPatterns on MatchPair {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_MatchPair value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _MatchPair() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _MatchPair value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _MatchPair() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_MatchPair value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _MatchPair():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _MatchPair value)  $default,){
+final _that = this;
+switch (_that) {
+case _MatchPair():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_MatchPair value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _MatchPair() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _MatchPair value)?  $default,){
+final _that = this;
+switch (_that) {
+case _MatchPair() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            @JsonKey(name: 'match_id') String matchId,
-            @JsonKey(name: 'event_id') String eventId,
-            @JsonKey(name: 'partner_id') String partnerId,
-            @JsonKey(name: 'matched_at') DateTime matchedAt,
-            @JsonKey(includeFromJson: false) String? partnerName,
-            @JsonKey(includeFromJson: false) String? partnerProfileImage,
-            @JsonKey(includeFromJson: false) String? partnerContact)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _MatchPair() when $default != null:
-        return $default(
-            _that.matchId,
-            _that.eventId,
-            _that.partnerId,
-            _that.matchedAt,
-            _that.partnerName,
-            _that.partnerProfileImage,
-            _that.partnerContact);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'match_id')  String matchId, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'partner_id')  String partnerId, @JsonKey(name: 'matched_at')  DateTime matchedAt, @JsonKey(includeFromJson: false)  String? partnerName, @JsonKey(includeFromJson: false)  String? partnerProfileImage, @JsonKey(includeFromJson: false)  String? partnerContact)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _MatchPair() when $default != null:
+return $default(_that.matchId,_that.eventId,_that.partnerId,_that.matchedAt,_that.partnerName,_that.partnerProfileImage,_that.partnerContact);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            @JsonKey(name: 'match_id') String matchId,
-            @JsonKey(name: 'event_id') String eventId,
-            @JsonKey(name: 'partner_id') String partnerId,
-            @JsonKey(name: 'matched_at') DateTime matchedAt,
-            @JsonKey(includeFromJson: false) String? partnerName,
-            @JsonKey(includeFromJson: false) String? partnerProfileImage,
-            @JsonKey(includeFromJson: false) String? partnerContact)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _MatchPair():
-        return $default(
-            _that.matchId,
-            _that.eventId,
-            _that.partnerId,
-            _that.matchedAt,
-            _that.partnerName,
-            _that.partnerProfileImage,
-            _that.partnerContact);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'match_id')  String matchId, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'partner_id')  String partnerId, @JsonKey(name: 'matched_at')  DateTime matchedAt, @JsonKey(includeFromJson: false)  String? partnerName, @JsonKey(includeFromJson: false)  String? partnerProfileImage, @JsonKey(includeFromJson: false)  String? partnerContact)  $default,) {final _that = this;
+switch (_that) {
+case _MatchPair():
+return $default(_that.matchId,_that.eventId,_that.partnerId,_that.matchedAt,_that.partnerName,_that.partnerProfileImage,_that.partnerContact);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            @JsonKey(name: 'match_id') String matchId,
-            @JsonKey(name: 'event_id') String eventId,
-            @JsonKey(name: 'partner_id') String partnerId,
-            @JsonKey(name: 'matched_at') DateTime matchedAt,
-            @JsonKey(includeFromJson: false) String? partnerName,
-            @JsonKey(includeFromJson: false) String? partnerProfileImage,
-            @JsonKey(includeFromJson: false) String? partnerContact)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _MatchPair() when $default != null:
-        return $default(
-            _that.matchId,
-            _that.eventId,
-            _that.partnerId,
-            _that.matchedAt,
-            _that.partnerName,
-            _that.partnerProfileImage,
-            _that.partnerContact);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'match_id')  String matchId, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'partner_id')  String partnerId, @JsonKey(name: 'matched_at')  DateTime matchedAt, @JsonKey(includeFromJson: false)  String? partnerName, @JsonKey(includeFromJson: false)  String? partnerProfileImage, @JsonKey(includeFromJson: false)  String? partnerContact)?  $default,) {final _that = this;
+switch (_that) {
+case _MatchPair() when $default != null:
+return $default(_that.matchId,_that.eventId,_that.partnerId,_that.matchedAt,_that.partnerName,_that.partnerProfileImage,_that.partnerContact);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _MatchPair implements MatchPair {
-  const _MatchPair(
-      {@JsonKey(name: 'match_id') required this.matchId,
-      @JsonKey(name: 'event_id') required this.eventId,
-      @JsonKey(name: 'partner_id') required this.partnerId,
-      @JsonKey(name: 'matched_at') required this.matchedAt,
-      @JsonKey(includeFromJson: false) this.partnerName,
-      @JsonKey(includeFromJson: false) this.partnerProfileImage,
-      @JsonKey(includeFromJson: false) this.partnerContact});
-  factory _MatchPair.fromJson(Map<String, dynamic> json) =>
-      _$MatchPairFromJson(json);
+  const _MatchPair({@JsonKey(name: 'match_id') required this.matchId, @JsonKey(name: 'event_id') required this.eventId, @JsonKey(name: 'partner_id') required this.partnerId, @JsonKey(name: 'matched_at') required this.matchedAt, @JsonKey(includeFromJson: false) this.partnerName, @JsonKey(includeFromJson: false) this.partnerProfileImage, @JsonKey(includeFromJson: false) this.partnerContact});
+  factory _MatchPair.fromJson(Map<String, dynamic> json) => _$MatchPairFromJson(json);
 
-  @override
-  @JsonKey(name: 'match_id')
-  final String matchId;
-  @override
-  @JsonKey(name: 'event_id')
-  final String eventId;
-  @override
-  @JsonKey(name: 'partner_id')
-  final String partnerId;
-  @override
-  @JsonKey(name: 'matched_at')
-  final DateTime matchedAt;
+@override@JsonKey(name: 'match_id') final  String matchId;
+@override@JsonKey(name: 'event_id') final  String eventId;
+@override@JsonKey(name: 'partner_id') final  String partnerId;
+@override@JsonKey(name: 'matched_at') final  DateTime matchedAt;
 // Optional: Partner profile details (if joined)
-  @override
-  @JsonKey(includeFromJson: false)
-  final String? partnerName;
-  @override
-  @JsonKey(includeFromJson: false)
-  final String? partnerProfileImage;
-  @override
-  @JsonKey(includeFromJson: false)
-  final String? partnerContact;
+@override@JsonKey(includeFromJson: false) final  String? partnerName;
+@override@JsonKey(includeFromJson: false) final  String? partnerProfileImage;
+@override@JsonKey(includeFromJson: false) final  String? partnerContact;
 
-  /// Create a copy of MatchPair
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$MatchPairCopyWith<_MatchPair> get copyWith =>
-      __$MatchPairCopyWithImpl<_MatchPair>(this, _$identity);
+/// Create a copy of MatchPair
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$MatchPairCopyWith<_MatchPair> get copyWith => __$MatchPairCopyWithImpl<_MatchPair>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$MatchPairToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$MatchPairToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _MatchPair &&
-            (identical(other.matchId, matchId) || other.matchId == matchId) &&
-            (identical(other.eventId, eventId) || other.eventId == eventId) &&
-            (identical(other.partnerId, partnerId) ||
-                other.partnerId == partnerId) &&
-            (identical(other.matchedAt, matchedAt) ||
-                other.matchedAt == matchedAt) &&
-            (identical(other.partnerName, partnerName) ||
-                other.partnerName == partnerName) &&
-            (identical(other.partnerProfileImage, partnerProfileImage) ||
-                other.partnerProfileImage == partnerProfileImage) &&
-            (identical(other.partnerContact, partnerContact) ||
-                other.partnerContact == partnerContact));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MatchPair&&(identical(other.matchId, matchId) || other.matchId == matchId)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.partnerId, partnerId) || other.partnerId == partnerId)&&(identical(other.matchedAt, matchedAt) || other.matchedAt == matchedAt)&&(identical(other.partnerName, partnerName) || other.partnerName == partnerName)&&(identical(other.partnerProfileImage, partnerProfileImage) || other.partnerProfileImage == partnerProfileImage)&&(identical(other.partnerContact, partnerContact) || other.partnerContact == partnerContact));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, matchId, eventId, partnerId,
-      matchedAt, partnerName, partnerProfileImage, partnerContact);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,matchId,eventId,partnerId,matchedAt,partnerName,partnerProfileImage,partnerContact);
 
-  @override
-  String toString() {
-    return 'MatchPair(matchId: $matchId, eventId: $eventId, partnerId: $partnerId, matchedAt: $matchedAt, partnerName: $partnerName, partnerProfileImage: $partnerProfileImage, partnerContact: $partnerContact)';
-  }
+@override
+String toString() {
+  return 'MatchPair(matchId: $matchId, eventId: $eventId, partnerId: $partnerId, matchedAt: $matchedAt, partnerName: $partnerName, partnerProfileImage: $partnerProfileImage, partnerContact: $partnerContact)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$MatchPairCopyWith<$Res>
-    implements $MatchPairCopyWith<$Res> {
-  factory _$MatchPairCopyWith(
-          _MatchPair value, $Res Function(_MatchPair) _then) =
-      __$MatchPairCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'match_id') String matchId,
-      @JsonKey(name: 'event_id') String eventId,
-      @JsonKey(name: 'partner_id') String partnerId,
-      @JsonKey(name: 'matched_at') DateTime matchedAt,
-      @JsonKey(includeFromJson: false) String? partnerName,
-      @JsonKey(includeFromJson: false) String? partnerProfileImage,
-      @JsonKey(includeFromJson: false) String? partnerContact});
-}
+abstract mixin class _$MatchPairCopyWith<$Res> implements $MatchPairCopyWith<$Res> {
+  factory _$MatchPairCopyWith(_MatchPair value, $Res Function(_MatchPair) _then) = __$MatchPairCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'match_id') String matchId,@JsonKey(name: 'event_id') String eventId,@JsonKey(name: 'partner_id') String partnerId,@JsonKey(name: 'matched_at') DateTime matchedAt,@JsonKey(includeFromJson: false) String? partnerName,@JsonKey(includeFromJson: false) String? partnerProfileImage,@JsonKey(includeFromJson: false) String? partnerContact
+});
 
+
+
+
+}
 /// @nodoc
-class __$MatchPairCopyWithImpl<$Res> implements _$MatchPairCopyWith<$Res> {
+class __$MatchPairCopyWithImpl<$Res>
+    implements _$MatchPairCopyWith<$Res> {
   __$MatchPairCopyWithImpl(this._self, this._then);
 
   final _MatchPair _self;
   final $Res Function(_MatchPair) _then;
 
-  /// Create a copy of MatchPair
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? matchId = null,
-    Object? eventId = null,
-    Object? partnerId = null,
-    Object? matchedAt = null,
-    Object? partnerName = freezed,
-    Object? partnerProfileImage = freezed,
-    Object? partnerContact = freezed,
-  }) {
-    return _then(_MatchPair(
-      matchId: null == matchId
-          ? _self.matchId
-          : matchId // ignore: cast_nullable_to_non_nullable
-              as String,
-      eventId: null == eventId
-          ? _self.eventId
-          : eventId // ignore: cast_nullable_to_non_nullable
-              as String,
-      partnerId: null == partnerId
-          ? _self.partnerId
-          : partnerId // ignore: cast_nullable_to_non_nullable
-              as String,
-      matchedAt: null == matchedAt
-          ? _self.matchedAt
-          : matchedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      partnerName: freezed == partnerName
-          ? _self.partnerName
-          : partnerName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      partnerProfileImage: freezed == partnerProfileImage
-          ? _self.partnerProfileImage
-          : partnerProfileImage // ignore: cast_nullable_to_non_nullable
-              as String?,
-      partnerContact: freezed == partnerContact
-          ? _self.partnerContact
-          : partnerContact // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Create a copy of MatchPair
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? matchId = null,Object? eventId = null,Object? partnerId = null,Object? matchedAt = null,Object? partnerName = freezed,Object? partnerProfileImage = freezed,Object? partnerContact = freezed,}) {
+  return _then(_MatchPair(
+matchId: null == matchId ? _self.matchId : matchId // ignore: cast_nullable_to_non_nullable
+as String,eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String,partnerId: null == partnerId ? _self.partnerId : partnerId // ignore: cast_nullable_to_non_nullable
+as String,matchedAt: null == matchedAt ? _self.matchedAt : matchedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,partnerName: freezed == partnerName ? _self.partnerName : partnerName // ignore: cast_nullable_to_non_nullable
+as String?,partnerProfileImage: freezed == partnerProfileImage ? _self.partnerProfileImage : partnerProfileImage // ignore: cast_nullable_to_non_nullable
+as String?,partnerContact: freezed == partnerContact ? _self.partnerContact : partnerContact // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/partner.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/partner.freezed.dart
@@ -14,601 +14,294 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$Partner {
-  String get id;
-  String get name;
-  String? get introduction;
-  String? get address;
-  @JsonKey(name: 'contact_phone')
-  String? get contactPhone;
-  @JsonKey(name: 'contact_email')
-  String? get contactEmail;
-  @JsonKey(name: 'representative_name')
-  String? get representativeName;
-  @JsonKey(name: 'biz_name')
-  String? get bizName;
-  @JsonKey(name: 'biz_number')
-  String? get bizNumber;
-  @JsonKey(name: 'profile_image_url')
-  String? get profileImageUrl;
-  @JsonKey(name: 'is_active')
-  bool get isActive;
 
-  /// Create a copy of Partner
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $PartnerCopyWith<Partner> get copyWith =>
-      _$PartnerCopyWithImpl<Partner>(this as Partner, _$identity);
+ String get id; String get name; String? get introduction; String? get address;@JsonKey(name: 'contact_phone') String? get contactPhone;@JsonKey(name: 'contact_email') String? get contactEmail;@JsonKey(name: 'representative_name') String? get representativeName;@JsonKey(name: 'biz_name') String? get bizName;@JsonKey(name: 'biz_number') String? get bizNumber;@JsonKey(name: 'profile_image_url') String? get profileImageUrl;@JsonKey(name: 'is_active') bool get isActive;
+/// Create a copy of Partner
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PartnerCopyWith<Partner> get copyWith => _$PartnerCopyWithImpl<Partner>(this as Partner, _$identity);
 
   /// Serializes this Partner to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is Partner &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.introduction, introduction) ||
-                other.introduction == introduction) &&
-            (identical(other.address, address) || other.address == address) &&
-            (identical(other.contactPhone, contactPhone) ||
-                other.contactPhone == contactPhone) &&
-            (identical(other.contactEmail, contactEmail) ||
-                other.contactEmail == contactEmail) &&
-            (identical(other.representativeName, representativeName) ||
-                other.representativeName == representativeName) &&
-            (identical(other.bizName, bizName) || other.bizName == bizName) &&
-            (identical(other.bizNumber, bizNumber) ||
-                other.bizNumber == bizNumber) &&
-            (identical(other.profileImageUrl, profileImageUrl) ||
-                other.profileImageUrl == profileImageUrl) &&
-            (identical(other.isActive, isActive) ||
-                other.isActive == isActive));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      name,
-      introduction,
-      address,
-      contactPhone,
-      contactEmail,
-      representativeName,
-      bizName,
-      bizNumber,
-      profileImageUrl,
-      isActive);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Partner&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.introduction, introduction) || other.introduction == introduction)&&(identical(other.address, address) || other.address == address)&&(identical(other.contactPhone, contactPhone) || other.contactPhone == contactPhone)&&(identical(other.contactEmail, contactEmail) || other.contactEmail == contactEmail)&&(identical(other.representativeName, representativeName) || other.representativeName == representativeName)&&(identical(other.bizName, bizName) || other.bizName == bizName)&&(identical(other.bizNumber, bizNumber) || other.bizNumber == bizNumber)&&(identical(other.profileImageUrl, profileImageUrl) || other.profileImageUrl == profileImageUrl)&&(identical(other.isActive, isActive) || other.isActive == isActive));
+}
 
-  @override
-  String toString() {
-    return 'Partner(id: $id, name: $name, introduction: $introduction, address: $address, contactPhone: $contactPhone, contactEmail: $contactEmail, representativeName: $representativeName, bizName: $bizName, bizNumber: $bizNumber, profileImageUrl: $profileImageUrl, isActive: $isActive)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,introduction,address,contactPhone,contactEmail,representativeName,bizName,bizNumber,profileImageUrl,isActive);
+
+@override
+String toString() {
+  return 'Partner(id: $id, name: $name, introduction: $introduction, address: $address, contactPhone: $contactPhone, contactEmail: $contactEmail, representativeName: $representativeName, bizName: $bizName, bizNumber: $bizNumber, profileImageUrl: $profileImageUrl, isActive: $isActive)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $PartnerCopyWith<$Res> {
-  factory $PartnerCopyWith(Partner value, $Res Function(Partner) _then) =
-      _$PartnerCopyWithImpl;
-  @useResult
-  $Res call(
-      {String id,
-      String name,
-      String? introduction,
-      String? address,
-      @JsonKey(name: 'contact_phone') String? contactPhone,
-      @JsonKey(name: 'contact_email') String? contactEmail,
-      @JsonKey(name: 'representative_name') String? representativeName,
-      @JsonKey(name: 'biz_name') String? bizName,
-      @JsonKey(name: 'biz_number') String? bizNumber,
-      @JsonKey(name: 'profile_image_url') String? profileImageUrl,
-      @JsonKey(name: 'is_active') bool isActive});
-}
+abstract mixin class $PartnerCopyWith<$Res>  {
+  factory $PartnerCopyWith(Partner value, $Res Function(Partner) _then) = _$PartnerCopyWithImpl;
+@useResult
+$Res call({
+ String id, String name, String? introduction, String? address,@JsonKey(name: 'contact_phone') String? contactPhone,@JsonKey(name: 'contact_email') String? contactEmail,@JsonKey(name: 'representative_name') String? representativeName,@JsonKey(name: 'biz_name') String? bizName,@JsonKey(name: 'biz_number') String? bizNumber,@JsonKey(name: 'profile_image_url') String? profileImageUrl,@JsonKey(name: 'is_active') bool isActive
+});
 
+
+
+
+}
 /// @nodoc
-class _$PartnerCopyWithImpl<$Res> implements $PartnerCopyWith<$Res> {
+class _$PartnerCopyWithImpl<$Res>
+    implements $PartnerCopyWith<$Res> {
   _$PartnerCopyWithImpl(this._self, this._then);
 
   final Partner _self;
   final $Res Function(Partner) _then;
 
-  /// Create a copy of Partner
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? name = null,
-    Object? introduction = freezed,
-    Object? address = freezed,
-    Object? contactPhone = freezed,
-    Object? contactEmail = freezed,
-    Object? representativeName = freezed,
-    Object? bizName = freezed,
-    Object? bizNumber = freezed,
-    Object? profileImageUrl = freezed,
-    Object? isActive = null,
-  }) {
-    return _then(_self.copyWith(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      name: null == name
-          ? _self.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      introduction: freezed == introduction
-          ? _self.introduction
-          : introduction // ignore: cast_nullable_to_non_nullable
-              as String?,
-      address: freezed == address
-          ? _self.address
-          : address // ignore: cast_nullable_to_non_nullable
-              as String?,
-      contactPhone: freezed == contactPhone
-          ? _self.contactPhone
-          : contactPhone // ignore: cast_nullable_to_non_nullable
-              as String?,
-      contactEmail: freezed == contactEmail
-          ? _self.contactEmail
-          : contactEmail // ignore: cast_nullable_to_non_nullable
-              as String?,
-      representativeName: freezed == representativeName
-          ? _self.representativeName
-          : representativeName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      bizName: freezed == bizName
-          ? _self.bizName
-          : bizName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      bizNumber: freezed == bizNumber
-          ? _self.bizNumber
-          : bizNumber // ignore: cast_nullable_to_non_nullable
-              as String?,
-      profileImageUrl: freezed == profileImageUrl
-          ? _self.profileImageUrl
-          : profileImageUrl // ignore: cast_nullable_to_non_nullable
-              as String?,
-      isActive: null == isActive
-          ? _self.isActive
-          : isActive // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ));
-  }
+/// Create a copy of Partner
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? introduction = freezed,Object? address = freezed,Object? contactPhone = freezed,Object? contactEmail = freezed,Object? representativeName = freezed,Object? bizName = freezed,Object? bizNumber = freezed,Object? profileImageUrl = freezed,Object? isActive = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,introduction: freezed == introduction ? _self.introduction : introduction // ignore: cast_nullable_to_non_nullable
+as String?,address: freezed == address ? _self.address : address // ignore: cast_nullable_to_non_nullable
+as String?,contactPhone: freezed == contactPhone ? _self.contactPhone : contactPhone // ignore: cast_nullable_to_non_nullable
+as String?,contactEmail: freezed == contactEmail ? _self.contactEmail : contactEmail // ignore: cast_nullable_to_non_nullable
+as String?,representativeName: freezed == representativeName ? _self.representativeName : representativeName // ignore: cast_nullable_to_non_nullable
+as String?,bizName: freezed == bizName ? _self.bizName : bizName // ignore: cast_nullable_to_non_nullable
+as String?,bizNumber: freezed == bizNumber ? _self.bizNumber : bizNumber // ignore: cast_nullable_to_non_nullable
+as String?,profileImageUrl: freezed == profileImageUrl ? _self.profileImageUrl : profileImageUrl // ignore: cast_nullable_to_non_nullable
+as String?,isActive: null == isActive ? _self.isActive : isActive // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [Partner].
 extension PartnerPatterns on Partner {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_Partner value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Partner() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Partner value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Partner() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_Partner value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Partner():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Partner value)  $default,){
+final _that = this;
+switch (_that) {
+case _Partner():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_Partner value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Partner() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Partner value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Partner() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String id,
-            String name,
-            String? introduction,
-            String? address,
-            @JsonKey(name: 'contact_phone') String? contactPhone,
-            @JsonKey(name: 'contact_email') String? contactEmail,
-            @JsonKey(name: 'representative_name') String? representativeName,
-            @JsonKey(name: 'biz_name') String? bizName,
-            @JsonKey(name: 'biz_number') String? bizNumber,
-            @JsonKey(name: 'profile_image_url') String? profileImageUrl,
-            @JsonKey(name: 'is_active') bool isActive)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Partner() when $default != null:
-        return $default(
-            _that.id,
-            _that.name,
-            _that.introduction,
-            _that.address,
-            _that.contactPhone,
-            _that.contactEmail,
-            _that.representativeName,
-            _that.bizName,
-            _that.bizNumber,
-            _that.profileImageUrl,
-            _that.isActive);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  String? introduction,  String? address, @JsonKey(name: 'contact_phone')  String? contactPhone, @JsonKey(name: 'contact_email')  String? contactEmail, @JsonKey(name: 'representative_name')  String? representativeName, @JsonKey(name: 'biz_name')  String? bizName, @JsonKey(name: 'biz_number')  String? bizNumber, @JsonKey(name: 'profile_image_url')  String? profileImageUrl, @JsonKey(name: 'is_active')  bool isActive)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Partner() when $default != null:
+return $default(_that.id,_that.name,_that.introduction,_that.address,_that.contactPhone,_that.contactEmail,_that.representativeName,_that.bizName,_that.bizNumber,_that.profileImageUrl,_that.isActive);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String id,
-            String name,
-            String? introduction,
-            String? address,
-            @JsonKey(name: 'contact_phone') String? contactPhone,
-            @JsonKey(name: 'contact_email') String? contactEmail,
-            @JsonKey(name: 'representative_name') String? representativeName,
-            @JsonKey(name: 'biz_name') String? bizName,
-            @JsonKey(name: 'biz_number') String? bizNumber,
-            @JsonKey(name: 'profile_image_url') String? profileImageUrl,
-            @JsonKey(name: 'is_active') bool isActive)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Partner():
-        return $default(
-            _that.id,
-            _that.name,
-            _that.introduction,
-            _that.address,
-            _that.contactPhone,
-            _that.contactEmail,
-            _that.representativeName,
-            _that.bizName,
-            _that.bizNumber,
-            _that.profileImageUrl,
-            _that.isActive);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  String? introduction,  String? address, @JsonKey(name: 'contact_phone')  String? contactPhone, @JsonKey(name: 'contact_email')  String? contactEmail, @JsonKey(name: 'representative_name')  String? representativeName, @JsonKey(name: 'biz_name')  String? bizName, @JsonKey(name: 'biz_number')  String? bizNumber, @JsonKey(name: 'profile_image_url')  String? profileImageUrl, @JsonKey(name: 'is_active')  bool isActive)  $default,) {final _that = this;
+switch (_that) {
+case _Partner():
+return $default(_that.id,_that.name,_that.introduction,_that.address,_that.contactPhone,_that.contactEmail,_that.representativeName,_that.bizName,_that.bizNumber,_that.profileImageUrl,_that.isActive);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String id,
-            String name,
-            String? introduction,
-            String? address,
-            @JsonKey(name: 'contact_phone') String? contactPhone,
-            @JsonKey(name: 'contact_email') String? contactEmail,
-            @JsonKey(name: 'representative_name') String? representativeName,
-            @JsonKey(name: 'biz_name') String? bizName,
-            @JsonKey(name: 'biz_number') String? bizNumber,
-            @JsonKey(name: 'profile_image_url') String? profileImageUrl,
-            @JsonKey(name: 'is_active') bool isActive)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Partner() when $default != null:
-        return $default(
-            _that.id,
-            _that.name,
-            _that.introduction,
-            _that.address,
-            _that.contactPhone,
-            _that.contactEmail,
-            _that.representativeName,
-            _that.bizName,
-            _that.bizNumber,
-            _that.profileImageUrl,
-            _that.isActive);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  String? introduction,  String? address, @JsonKey(name: 'contact_phone')  String? contactPhone, @JsonKey(name: 'contact_email')  String? contactEmail, @JsonKey(name: 'representative_name')  String? representativeName, @JsonKey(name: 'biz_name')  String? bizName, @JsonKey(name: 'biz_number')  String? bizNumber, @JsonKey(name: 'profile_image_url')  String? profileImageUrl, @JsonKey(name: 'is_active')  bool isActive)?  $default,) {final _that = this;
+switch (_that) {
+case _Partner() when $default != null:
+return $default(_that.id,_that.name,_that.introduction,_that.address,_that.contactPhone,_that.contactEmail,_that.representativeName,_that.bizName,_that.bizNumber,_that.profileImageUrl,_that.isActive);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _Partner implements Partner {
-  const _Partner(
-      {required this.id,
-      required this.name,
-      this.introduction,
-      this.address,
-      @JsonKey(name: 'contact_phone') this.contactPhone,
-      @JsonKey(name: 'contact_email') this.contactEmail,
-      @JsonKey(name: 'representative_name') this.representativeName,
-      @JsonKey(name: 'biz_name') this.bizName,
-      @JsonKey(name: 'biz_number') this.bizNumber,
-      @JsonKey(name: 'profile_image_url') this.profileImageUrl,
-      @JsonKey(name: 'is_active') this.isActive = true});
-  factory _Partner.fromJson(Map<String, dynamic> json) =>
-      _$PartnerFromJson(json);
+  const _Partner({required this.id, required this.name, this.introduction, this.address, @JsonKey(name: 'contact_phone') this.contactPhone, @JsonKey(name: 'contact_email') this.contactEmail, @JsonKey(name: 'representative_name') this.representativeName, @JsonKey(name: 'biz_name') this.bizName, @JsonKey(name: 'biz_number') this.bizNumber, @JsonKey(name: 'profile_image_url') this.profileImageUrl, @JsonKey(name: 'is_active') this.isActive = true});
+  factory _Partner.fromJson(Map<String, dynamic> json) => _$PartnerFromJson(json);
 
-  @override
-  final String id;
-  @override
-  final String name;
-  @override
-  final String? introduction;
-  @override
-  final String? address;
-  @override
-  @JsonKey(name: 'contact_phone')
-  final String? contactPhone;
-  @override
-  @JsonKey(name: 'contact_email')
-  final String? contactEmail;
-  @override
-  @JsonKey(name: 'representative_name')
-  final String? representativeName;
-  @override
-  @JsonKey(name: 'biz_name')
-  final String? bizName;
-  @override
-  @JsonKey(name: 'biz_number')
-  final String? bizNumber;
-  @override
-  @JsonKey(name: 'profile_image_url')
-  final String? profileImageUrl;
-  @override
-  @JsonKey(name: 'is_active')
-  final bool isActive;
+@override final  String id;
+@override final  String name;
+@override final  String? introduction;
+@override final  String? address;
+@override@JsonKey(name: 'contact_phone') final  String? contactPhone;
+@override@JsonKey(name: 'contact_email') final  String? contactEmail;
+@override@JsonKey(name: 'representative_name') final  String? representativeName;
+@override@JsonKey(name: 'biz_name') final  String? bizName;
+@override@JsonKey(name: 'biz_number') final  String? bizNumber;
+@override@JsonKey(name: 'profile_image_url') final  String? profileImageUrl;
+@override@JsonKey(name: 'is_active') final  bool isActive;
 
-  /// Create a copy of Partner
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$PartnerCopyWith<_Partner> get copyWith =>
-      __$PartnerCopyWithImpl<_Partner>(this, _$identity);
+/// Create a copy of Partner
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PartnerCopyWith<_Partner> get copyWith => __$PartnerCopyWithImpl<_Partner>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$PartnerToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$PartnerToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _Partner &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.introduction, introduction) ||
-                other.introduction == introduction) &&
-            (identical(other.address, address) || other.address == address) &&
-            (identical(other.contactPhone, contactPhone) ||
-                other.contactPhone == contactPhone) &&
-            (identical(other.contactEmail, contactEmail) ||
-                other.contactEmail == contactEmail) &&
-            (identical(other.representativeName, representativeName) ||
-                other.representativeName == representativeName) &&
-            (identical(other.bizName, bizName) || other.bizName == bizName) &&
-            (identical(other.bizNumber, bizNumber) ||
-                other.bizNumber == bizNumber) &&
-            (identical(other.profileImageUrl, profileImageUrl) ||
-                other.profileImageUrl == profileImageUrl) &&
-            (identical(other.isActive, isActive) ||
-                other.isActive == isActive));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Partner&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.introduction, introduction) || other.introduction == introduction)&&(identical(other.address, address) || other.address == address)&&(identical(other.contactPhone, contactPhone) || other.contactPhone == contactPhone)&&(identical(other.contactEmail, contactEmail) || other.contactEmail == contactEmail)&&(identical(other.representativeName, representativeName) || other.representativeName == representativeName)&&(identical(other.bizName, bizName) || other.bizName == bizName)&&(identical(other.bizNumber, bizNumber) || other.bizNumber == bizNumber)&&(identical(other.profileImageUrl, profileImageUrl) || other.profileImageUrl == profileImageUrl)&&(identical(other.isActive, isActive) || other.isActive == isActive));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      name,
-      introduction,
-      address,
-      contactPhone,
-      contactEmail,
-      representativeName,
-      bizName,
-      bizNumber,
-      profileImageUrl,
-      isActive);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,introduction,address,contactPhone,contactEmail,representativeName,bizName,bizNumber,profileImageUrl,isActive);
 
-  @override
-  String toString() {
-    return 'Partner(id: $id, name: $name, introduction: $introduction, address: $address, contactPhone: $contactPhone, contactEmail: $contactEmail, representativeName: $representativeName, bizName: $bizName, bizNumber: $bizNumber, profileImageUrl: $profileImageUrl, isActive: $isActive)';
-  }
+@override
+String toString() {
+  return 'Partner(id: $id, name: $name, introduction: $introduction, address: $address, contactPhone: $contactPhone, contactEmail: $contactEmail, representativeName: $representativeName, bizName: $bizName, bizNumber: $bizNumber, profileImageUrl: $profileImageUrl, isActive: $isActive)';
+}
+
+
 }
 
 /// @nodoc
 abstract mixin class _$PartnerCopyWith<$Res> implements $PartnerCopyWith<$Res> {
-  factory _$PartnerCopyWith(_Partner value, $Res Function(_Partner) _then) =
-      __$PartnerCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String id,
-      String name,
-      String? introduction,
-      String? address,
-      @JsonKey(name: 'contact_phone') String? contactPhone,
-      @JsonKey(name: 'contact_email') String? contactEmail,
-      @JsonKey(name: 'representative_name') String? representativeName,
-      @JsonKey(name: 'biz_name') String? bizName,
-      @JsonKey(name: 'biz_number') String? bizNumber,
-      @JsonKey(name: 'profile_image_url') String? profileImageUrl,
-      @JsonKey(name: 'is_active') bool isActive});
-}
+  factory _$PartnerCopyWith(_Partner value, $Res Function(_Partner) _then) = __$PartnerCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String name, String? introduction, String? address,@JsonKey(name: 'contact_phone') String? contactPhone,@JsonKey(name: 'contact_email') String? contactEmail,@JsonKey(name: 'representative_name') String? representativeName,@JsonKey(name: 'biz_name') String? bizName,@JsonKey(name: 'biz_number') String? bizNumber,@JsonKey(name: 'profile_image_url') String? profileImageUrl,@JsonKey(name: 'is_active') bool isActive
+});
 
+
+
+
+}
 /// @nodoc
-class __$PartnerCopyWithImpl<$Res> implements _$PartnerCopyWith<$Res> {
+class __$PartnerCopyWithImpl<$Res>
+    implements _$PartnerCopyWith<$Res> {
   __$PartnerCopyWithImpl(this._self, this._then);
 
   final _Partner _self;
   final $Res Function(_Partner) _then;
 
-  /// Create a copy of Partner
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? name = null,
-    Object? introduction = freezed,
-    Object? address = freezed,
-    Object? contactPhone = freezed,
-    Object? contactEmail = freezed,
-    Object? representativeName = freezed,
-    Object? bizName = freezed,
-    Object? bizNumber = freezed,
-    Object? profileImageUrl = freezed,
-    Object? isActive = null,
-  }) {
-    return _then(_Partner(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      name: null == name
-          ? _self.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      introduction: freezed == introduction
-          ? _self.introduction
-          : introduction // ignore: cast_nullable_to_non_nullable
-              as String?,
-      address: freezed == address
-          ? _self.address
-          : address // ignore: cast_nullable_to_non_nullable
-              as String?,
-      contactPhone: freezed == contactPhone
-          ? _self.contactPhone
-          : contactPhone // ignore: cast_nullable_to_non_nullable
-              as String?,
-      contactEmail: freezed == contactEmail
-          ? _self.contactEmail
-          : contactEmail // ignore: cast_nullable_to_non_nullable
-              as String?,
-      representativeName: freezed == representativeName
-          ? _self.representativeName
-          : representativeName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      bizName: freezed == bizName
-          ? _self.bizName
-          : bizName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      bizNumber: freezed == bizNumber
-          ? _self.bizNumber
-          : bizNumber // ignore: cast_nullable_to_non_nullable
-              as String?,
-      profileImageUrl: freezed == profileImageUrl
-          ? _self.profileImageUrl
-          : profileImageUrl // ignore: cast_nullable_to_non_nullable
-              as String?,
-      isActive: null == isActive
-          ? _self.isActive
-          : isActive // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ));
-  }
+/// Create a copy of Partner
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? introduction = freezed,Object? address = freezed,Object? contactPhone = freezed,Object? contactEmail = freezed,Object? representativeName = freezed,Object? bizName = freezed,Object? bizNumber = freezed,Object? profileImageUrl = freezed,Object? isActive = null,}) {
+  return _then(_Partner(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,introduction: freezed == introduction ? _self.introduction : introduction // ignore: cast_nullable_to_non_nullable
+as String?,address: freezed == address ? _self.address : address // ignore: cast_nullable_to_non_nullable
+as String?,contactPhone: freezed == contactPhone ? _self.contactPhone : contactPhone // ignore: cast_nullable_to_non_nullable
+as String?,contactEmail: freezed == contactEmail ? _self.contactEmail : contactEmail // ignore: cast_nullable_to_non_nullable
+as String?,representativeName: freezed == representativeName ? _self.representativeName : representativeName // ignore: cast_nullable_to_non_nullable
+as String?,bizName: freezed == bizName ? _self.bizName : bizName // ignore: cast_nullable_to_non_nullable
+as String?,bizNumber: freezed == bizNumber ? _self.bizNumber : bizNumber // ignore: cast_nullable_to_non_nullable
+as String?,profileImageUrl: freezed == profileImageUrl ? _self.profileImageUrl : profileImageUrl // ignore: cast_nullable_to_non_nullable
+as String?,isActive: null == isActive ? _self.isActive : isActive // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/partner_application.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/partner_application.freezed.dart
@@ -14,174 +14,47 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$PartnerApplication {
-  String get id;
-  @JsonKey(name: 'user_id')
-  String get userId;
-  String get status;
-  @JsonKey(name: 'contact_phone')
-  String? get contactPhone;
-  @JsonKey(name: 'contact_email')
-  String? get contactEmail;
-  @JsonKey(name: 'brand_name')
-  String? get brandName;
-  String? get introduction;
-  String? get address;
-  @JsonKey(name: 'biz_type')
-  String? get bizType;
-  @JsonKey(name: 'biz_name')
-  String? get bizName;
-  @JsonKey(name: 'biz_number')
-  String? get bizNumber;
-  @JsonKey(name: 'representative_name')
-  String? get representativeName;
-  @JsonKey(name: 'bank_name')
-  String? get bankName;
-  @JsonKey(name: 'account_number')
-  String? get accountNumber;
-  @JsonKey(name: 'account_holder')
-  String? get accountHolder;
-  @JsonKey(name: 'biz_registration_path')
-  String? get bizRegistrationPath;
-  @JsonKey(name: 'bankbook_path')
-  String? get bankbookPath;
-  @JsonKey(name: 'tax_email')
-  String? get taxEmail;
-  @JsonKey(name: 'profile_image_path')
-  String? get profileImagePath;
-  @JsonKey(name: 'current_step')
-  int get currentStep;
-  @JsonKey(name: 'admin_comment')
-  String? get adminComment;
-  @JsonKey(name: 'created_at')
-  String? get createdAt;
-  @JsonKey(name: 'updated_at')
-  String? get updatedAt;
 
-  /// Create a copy of PartnerApplication
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $PartnerApplicationCopyWith<PartnerApplication> get copyWith =>
-      _$PartnerApplicationCopyWithImpl<PartnerApplication>(
-          this as PartnerApplication, _$identity);
+ String get id;@JsonKey(name: 'user_id') String get userId; String get status;@JsonKey(name: 'contact_phone') String? get contactPhone;@JsonKey(name: 'contact_email') String? get contactEmail;@JsonKey(name: 'brand_name') String? get brandName; String? get introduction; String? get address;@JsonKey(name: 'biz_type') String? get bizType;@JsonKey(name: 'biz_name') String? get bizName;@JsonKey(name: 'biz_number') String? get bizNumber;@JsonKey(name: 'representative_name') String? get representativeName;@JsonKey(name: 'bank_name') String? get bankName;@JsonKey(name: 'account_number') String? get accountNumber;@JsonKey(name: 'account_holder') String? get accountHolder;@JsonKey(name: 'biz_registration_path') String? get bizRegistrationPath;@JsonKey(name: 'bankbook_path') String? get bankbookPath;@JsonKey(name: 'tax_email') String? get taxEmail;@JsonKey(name: 'profile_image_path') String? get profileImagePath;@JsonKey(name: 'current_step') int get currentStep;@JsonKey(name: 'admin_comment') String? get adminComment;@JsonKey(name: 'created_at') String? get createdAt;@JsonKey(name: 'updated_at') String? get updatedAt;
+/// Create a copy of PartnerApplication
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PartnerApplicationCopyWith<PartnerApplication> get copyWith => _$PartnerApplicationCopyWithImpl<PartnerApplication>(this as PartnerApplication, _$identity);
 
   /// Serializes this PartnerApplication to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is PartnerApplication &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.status, status) || other.status == status) &&
-            (identical(other.contactPhone, contactPhone) ||
-                other.contactPhone == contactPhone) &&
-            (identical(other.contactEmail, contactEmail) ||
-                other.contactEmail == contactEmail) &&
-            (identical(other.brandName, brandName) ||
-                other.brandName == brandName) &&
-            (identical(other.introduction, introduction) ||
-                other.introduction == introduction) &&
-            (identical(other.address, address) || other.address == address) &&
-            (identical(other.bizType, bizType) || other.bizType == bizType) &&
-            (identical(other.bizName, bizName) || other.bizName == bizName) &&
-            (identical(other.bizNumber, bizNumber) ||
-                other.bizNumber == bizNumber) &&
-            (identical(other.representativeName, representativeName) ||
-                other.representativeName == representativeName) &&
-            (identical(other.bankName, bankName) ||
-                other.bankName == bankName) &&
-            (identical(other.accountNumber, accountNumber) ||
-                other.accountNumber == accountNumber) &&
-            (identical(other.accountHolder, accountHolder) ||
-                other.accountHolder == accountHolder) &&
-            (identical(other.bizRegistrationPath, bizRegistrationPath) ||
-                other.bizRegistrationPath == bizRegistrationPath) &&
-            (identical(other.bankbookPath, bankbookPath) ||
-                other.bankbookPath == bankbookPath) &&
-            (identical(other.taxEmail, taxEmail) ||
-                other.taxEmail == taxEmail) &&
-            (identical(other.profileImagePath, profileImagePath) ||
-                other.profileImagePath == profileImagePath) &&
-            (identical(other.currentStep, currentStep) ||
-                other.currentStep == currentStep) &&
-            (identical(other.adminComment, adminComment) ||
-                other.adminComment == adminComment) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hashAll([
-        runtimeType,
-        id,
-        userId,
-        status,
-        contactPhone,
-        contactEmail,
-        brandName,
-        introduction,
-        address,
-        bizType,
-        bizName,
-        bizNumber,
-        representativeName,
-        bankName,
-        accountNumber,
-        accountHolder,
-        bizRegistrationPath,
-        bankbookPath,
-        taxEmail,
-        profileImagePath,
-        currentStep,
-        adminComment,
-        createdAt,
-        updatedAt
-      ]);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PartnerApplication&&(identical(other.id, id) || other.id == id)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.status, status) || other.status == status)&&(identical(other.contactPhone, contactPhone) || other.contactPhone == contactPhone)&&(identical(other.contactEmail, contactEmail) || other.contactEmail == contactEmail)&&(identical(other.brandName, brandName) || other.brandName == brandName)&&(identical(other.introduction, introduction) || other.introduction == introduction)&&(identical(other.address, address) || other.address == address)&&(identical(other.bizType, bizType) || other.bizType == bizType)&&(identical(other.bizName, bizName) || other.bizName == bizName)&&(identical(other.bizNumber, bizNumber) || other.bizNumber == bizNumber)&&(identical(other.representativeName, representativeName) || other.representativeName == representativeName)&&(identical(other.bankName, bankName) || other.bankName == bankName)&&(identical(other.accountNumber, accountNumber) || other.accountNumber == accountNumber)&&(identical(other.accountHolder, accountHolder) || other.accountHolder == accountHolder)&&(identical(other.bizRegistrationPath, bizRegistrationPath) || other.bizRegistrationPath == bizRegistrationPath)&&(identical(other.bankbookPath, bankbookPath) || other.bankbookPath == bankbookPath)&&(identical(other.taxEmail, taxEmail) || other.taxEmail == taxEmail)&&(identical(other.profileImagePath, profileImagePath) || other.profileImagePath == profileImagePath)&&(identical(other.currentStep, currentStep) || other.currentStep == currentStep)&&(identical(other.adminComment, adminComment) || other.adminComment == adminComment)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+}
 
-  @override
-  String toString() {
-    return 'PartnerApplication(id: $id, userId: $userId, status: $status, contactPhone: $contactPhone, contactEmail: $contactEmail, brandName: $brandName, introduction: $introduction, address: $address, bizType: $bizType, bizName: $bizName, bizNumber: $bizNumber, representativeName: $representativeName, bankName: $bankName, accountNumber: $accountNumber, accountHolder: $accountHolder, bizRegistrationPath: $bizRegistrationPath, bankbookPath: $bankbookPath, taxEmail: $taxEmail, profileImagePath: $profileImagePath, currentStep: $currentStep, adminComment: $adminComment, createdAt: $createdAt, updatedAt: $updatedAt)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hashAll([runtimeType,id,userId,status,contactPhone,contactEmail,brandName,introduction,address,bizType,bizName,bizNumber,representativeName,bankName,accountNumber,accountHolder,bizRegistrationPath,bankbookPath,taxEmail,profileImagePath,currentStep,adminComment,createdAt,updatedAt]);
+
+@override
+String toString() {
+  return 'PartnerApplication(id: $id, userId: $userId, status: $status, contactPhone: $contactPhone, contactEmail: $contactEmail, brandName: $brandName, introduction: $introduction, address: $address, bizType: $bizType, bizName: $bizName, bizNumber: $bizNumber, representativeName: $representativeName, bankName: $bankName, accountNumber: $accountNumber, accountHolder: $accountHolder, bizRegistrationPath: $bizRegistrationPath, bankbookPath: $bankbookPath, taxEmail: $taxEmail, profileImagePath: $profileImagePath, currentStep: $currentStep, adminComment: $adminComment, createdAt: $createdAt, updatedAt: $updatedAt)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $PartnerApplicationCopyWith<$Res> {
-  factory $PartnerApplicationCopyWith(
-          PartnerApplication value, $Res Function(PartnerApplication) _then) =
-      _$PartnerApplicationCopyWithImpl;
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'user_id') String userId,
-      String status,
-      @JsonKey(name: 'contact_phone') String? contactPhone,
-      @JsonKey(name: 'contact_email') String? contactEmail,
-      @JsonKey(name: 'brand_name') String? brandName,
-      String? introduction,
-      String? address,
-      @JsonKey(name: 'biz_type') String? bizType,
-      @JsonKey(name: 'biz_name') String? bizName,
-      @JsonKey(name: 'biz_number') String? bizNumber,
-      @JsonKey(name: 'representative_name') String? representativeName,
-      @JsonKey(name: 'bank_name') String? bankName,
-      @JsonKey(name: 'account_number') String? accountNumber,
-      @JsonKey(name: 'account_holder') String? accountHolder,
-      @JsonKey(name: 'biz_registration_path') String? bizRegistrationPath,
-      @JsonKey(name: 'bankbook_path') String? bankbookPath,
-      @JsonKey(name: 'tax_email') String? taxEmail,
-      @JsonKey(name: 'profile_image_path') String? profileImagePath,
-      @JsonKey(name: 'current_step') int currentStep,
-      @JsonKey(name: 'admin_comment') String? adminComment,
-      @JsonKey(name: 'created_at') String? createdAt,
-      @JsonKey(name: 'updated_at') String? updatedAt});
-}
+abstract mixin class $PartnerApplicationCopyWith<$Res>  {
+  factory $PartnerApplicationCopyWith(PartnerApplication value, $Res Function(PartnerApplication) _then) = _$PartnerApplicationCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(name: 'user_id') String userId, String status,@JsonKey(name: 'contact_phone') String? contactPhone,@JsonKey(name: 'contact_email') String? contactEmail,@JsonKey(name: 'brand_name') String? brandName, String? introduction, String? address,@JsonKey(name: 'biz_type') String? bizType,@JsonKey(name: 'biz_name') String? bizName,@JsonKey(name: 'biz_number') String? bizNumber,@JsonKey(name: 'representative_name') String? representativeName,@JsonKey(name: 'bank_name') String? bankName,@JsonKey(name: 'account_number') String? accountNumber,@JsonKey(name: 'account_holder') String? accountHolder,@JsonKey(name: 'biz_registration_path') String? bizRegistrationPath,@JsonKey(name: 'bankbook_path') String? bankbookPath,@JsonKey(name: 'tax_email') String? taxEmail,@JsonKey(name: 'profile_image_path') String? profileImagePath,@JsonKey(name: 'current_step') int currentStep,@JsonKey(name: 'admin_comment') String? adminComment,@JsonKey(name: 'created_at') String? createdAt,@JsonKey(name: 'updated_at') String? updatedAt
+});
 
+
+
+
+}
 /// @nodoc
 class _$PartnerApplicationCopyWithImpl<$Res>
     implements $PartnerApplicationCopyWith<$Res> {
@@ -190,658 +63,241 @@ class _$PartnerApplicationCopyWithImpl<$Res>
   final PartnerApplication _self;
   final $Res Function(PartnerApplication) _then;
 
-  /// Create a copy of PartnerApplication
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? userId = null,
-    Object? status = null,
-    Object? contactPhone = freezed,
-    Object? contactEmail = freezed,
-    Object? brandName = freezed,
-    Object? introduction = freezed,
-    Object? address = freezed,
-    Object? bizType = freezed,
-    Object? bizName = freezed,
-    Object? bizNumber = freezed,
-    Object? representativeName = freezed,
-    Object? bankName = freezed,
-    Object? accountNumber = freezed,
-    Object? accountHolder = freezed,
-    Object? bizRegistrationPath = freezed,
-    Object? bankbookPath = freezed,
-    Object? taxEmail = freezed,
-    Object? profileImagePath = freezed,
-    Object? currentStep = null,
-    Object? adminComment = freezed,
-    Object? createdAt = freezed,
-    Object? updatedAt = freezed,
-  }) {
-    return _then(_self.copyWith(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      userId: null == userId
-          ? _self.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      status: null == status
-          ? _self.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as String,
-      contactPhone: freezed == contactPhone
-          ? _self.contactPhone
-          : contactPhone // ignore: cast_nullable_to_non_nullable
-              as String?,
-      contactEmail: freezed == contactEmail
-          ? _self.contactEmail
-          : contactEmail // ignore: cast_nullable_to_non_nullable
-              as String?,
-      brandName: freezed == brandName
-          ? _self.brandName
-          : brandName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      introduction: freezed == introduction
-          ? _self.introduction
-          : introduction // ignore: cast_nullable_to_non_nullable
-              as String?,
-      address: freezed == address
-          ? _self.address
-          : address // ignore: cast_nullable_to_non_nullable
-              as String?,
-      bizType: freezed == bizType
-          ? _self.bizType
-          : bizType // ignore: cast_nullable_to_non_nullable
-              as String?,
-      bizName: freezed == bizName
-          ? _self.bizName
-          : bizName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      bizNumber: freezed == bizNumber
-          ? _self.bizNumber
-          : bizNumber // ignore: cast_nullable_to_non_nullable
-              as String?,
-      representativeName: freezed == representativeName
-          ? _self.representativeName
-          : representativeName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      bankName: freezed == bankName
-          ? _self.bankName
-          : bankName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      accountNumber: freezed == accountNumber
-          ? _self.accountNumber
-          : accountNumber // ignore: cast_nullable_to_non_nullable
-              as String?,
-      accountHolder: freezed == accountHolder
-          ? _self.accountHolder
-          : accountHolder // ignore: cast_nullable_to_non_nullable
-              as String?,
-      bizRegistrationPath: freezed == bizRegistrationPath
-          ? _self.bizRegistrationPath
-          : bizRegistrationPath // ignore: cast_nullable_to_non_nullable
-              as String?,
-      bankbookPath: freezed == bankbookPath
-          ? _self.bankbookPath
-          : bankbookPath // ignore: cast_nullable_to_non_nullable
-              as String?,
-      taxEmail: freezed == taxEmail
-          ? _self.taxEmail
-          : taxEmail // ignore: cast_nullable_to_non_nullable
-              as String?,
-      profileImagePath: freezed == profileImagePath
-          ? _self.profileImagePath
-          : profileImagePath // ignore: cast_nullable_to_non_nullable
-              as String?,
-      currentStep: null == currentStep
-          ? _self.currentStep
-          : currentStep // ignore: cast_nullable_to_non_nullable
-              as int,
-      adminComment: freezed == adminComment
-          ? _self.adminComment
-          : adminComment // ignore: cast_nullable_to_non_nullable
-              as String?,
-      createdAt: freezed == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as String?,
-      updatedAt: freezed == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Create a copy of PartnerApplication
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? userId = null,Object? status = null,Object? contactPhone = freezed,Object? contactEmail = freezed,Object? brandName = freezed,Object? introduction = freezed,Object? address = freezed,Object? bizType = freezed,Object? bizName = freezed,Object? bizNumber = freezed,Object? representativeName = freezed,Object? bankName = freezed,Object? accountNumber = freezed,Object? accountHolder = freezed,Object? bizRegistrationPath = freezed,Object? bankbookPath = freezed,Object? taxEmail = freezed,Object? profileImagePath = freezed,Object? currentStep = null,Object? adminComment = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,contactPhone: freezed == contactPhone ? _self.contactPhone : contactPhone // ignore: cast_nullable_to_non_nullable
+as String?,contactEmail: freezed == contactEmail ? _self.contactEmail : contactEmail // ignore: cast_nullable_to_non_nullable
+as String?,brandName: freezed == brandName ? _self.brandName : brandName // ignore: cast_nullable_to_non_nullable
+as String?,introduction: freezed == introduction ? _self.introduction : introduction // ignore: cast_nullable_to_non_nullable
+as String?,address: freezed == address ? _self.address : address // ignore: cast_nullable_to_non_nullable
+as String?,bizType: freezed == bizType ? _self.bizType : bizType // ignore: cast_nullable_to_non_nullable
+as String?,bizName: freezed == bizName ? _self.bizName : bizName // ignore: cast_nullable_to_non_nullable
+as String?,bizNumber: freezed == bizNumber ? _self.bizNumber : bizNumber // ignore: cast_nullable_to_non_nullable
+as String?,representativeName: freezed == representativeName ? _self.representativeName : representativeName // ignore: cast_nullable_to_non_nullable
+as String?,bankName: freezed == bankName ? _self.bankName : bankName // ignore: cast_nullable_to_non_nullable
+as String?,accountNumber: freezed == accountNumber ? _self.accountNumber : accountNumber // ignore: cast_nullable_to_non_nullable
+as String?,accountHolder: freezed == accountHolder ? _self.accountHolder : accountHolder // ignore: cast_nullable_to_non_nullable
+as String?,bizRegistrationPath: freezed == bizRegistrationPath ? _self.bizRegistrationPath : bizRegistrationPath // ignore: cast_nullable_to_non_nullable
+as String?,bankbookPath: freezed == bankbookPath ? _self.bankbookPath : bankbookPath // ignore: cast_nullable_to_non_nullable
+as String?,taxEmail: freezed == taxEmail ? _self.taxEmail : taxEmail // ignore: cast_nullable_to_non_nullable
+as String?,profileImagePath: freezed == profileImagePath ? _self.profileImagePath : profileImagePath // ignore: cast_nullable_to_non_nullable
+as String?,currentStep: null == currentStep ? _self.currentStep : currentStep // ignore: cast_nullable_to_non_nullable
+as int,adminComment: freezed == adminComment ? _self.adminComment : adminComment // ignore: cast_nullable_to_non_nullable
+as String?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as String?,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [PartnerApplication].
 extension PartnerApplicationPatterns on PartnerApplication {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_PartnerApplication value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _PartnerApplication() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _PartnerApplication value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _PartnerApplication() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_PartnerApplication value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _PartnerApplication():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _PartnerApplication value)  $default,){
+final _that = this;
+switch (_that) {
+case _PartnerApplication():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_PartnerApplication value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _PartnerApplication() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _PartnerApplication value)?  $default,){
+final _that = this;
+switch (_that) {
+case _PartnerApplication() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'user_id') String userId,
-            String status,
-            @JsonKey(name: 'contact_phone') String? contactPhone,
-            @JsonKey(name: 'contact_email') String? contactEmail,
-            @JsonKey(name: 'brand_name') String? brandName,
-            String? introduction,
-            String? address,
-            @JsonKey(name: 'biz_type') String? bizType,
-            @JsonKey(name: 'biz_name') String? bizName,
-            @JsonKey(name: 'biz_number') String? bizNumber,
-            @JsonKey(name: 'representative_name') String? representativeName,
-            @JsonKey(name: 'bank_name') String? bankName,
-            @JsonKey(name: 'account_number') String? accountNumber,
-            @JsonKey(name: 'account_holder') String? accountHolder,
-            @JsonKey(name: 'biz_registration_path') String? bizRegistrationPath,
-            @JsonKey(name: 'bankbook_path') String? bankbookPath,
-            @JsonKey(name: 'tax_email') String? taxEmail,
-            @JsonKey(name: 'profile_image_path') String? profileImagePath,
-            @JsonKey(name: 'current_step') int currentStep,
-            @JsonKey(name: 'admin_comment') String? adminComment,
-            @JsonKey(name: 'created_at') String? createdAt,
-            @JsonKey(name: 'updated_at') String? updatedAt)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _PartnerApplication() when $default != null:
-        return $default(
-            _that.id,
-            _that.userId,
-            _that.status,
-            _that.contactPhone,
-            _that.contactEmail,
-            _that.brandName,
-            _that.introduction,
-            _that.address,
-            _that.bizType,
-            _that.bizName,
-            _that.bizNumber,
-            _that.representativeName,
-            _that.bankName,
-            _that.accountNumber,
-            _that.accountHolder,
-            _that.bizRegistrationPath,
-            _that.bankbookPath,
-            _that.taxEmail,
-            _that.profileImagePath,
-            _that.currentStep,
-            _that.adminComment,
-            _that.createdAt,
-            _that.updatedAt);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'user_id')  String userId,  String status, @JsonKey(name: 'contact_phone')  String? contactPhone, @JsonKey(name: 'contact_email')  String? contactEmail, @JsonKey(name: 'brand_name')  String? brandName,  String? introduction,  String? address, @JsonKey(name: 'biz_type')  String? bizType, @JsonKey(name: 'biz_name')  String? bizName, @JsonKey(name: 'biz_number')  String? bizNumber, @JsonKey(name: 'representative_name')  String? representativeName, @JsonKey(name: 'bank_name')  String? bankName, @JsonKey(name: 'account_number')  String? accountNumber, @JsonKey(name: 'account_holder')  String? accountHolder, @JsonKey(name: 'biz_registration_path')  String? bizRegistrationPath, @JsonKey(name: 'bankbook_path')  String? bankbookPath, @JsonKey(name: 'tax_email')  String? taxEmail, @JsonKey(name: 'profile_image_path')  String? profileImagePath, @JsonKey(name: 'current_step')  int currentStep, @JsonKey(name: 'admin_comment')  String? adminComment, @JsonKey(name: 'created_at')  String? createdAt, @JsonKey(name: 'updated_at')  String? updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _PartnerApplication() when $default != null:
+return $default(_that.id,_that.userId,_that.status,_that.contactPhone,_that.contactEmail,_that.brandName,_that.introduction,_that.address,_that.bizType,_that.bizName,_that.bizNumber,_that.representativeName,_that.bankName,_that.accountNumber,_that.accountHolder,_that.bizRegistrationPath,_that.bankbookPath,_that.taxEmail,_that.profileImagePath,_that.currentStep,_that.adminComment,_that.createdAt,_that.updatedAt);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'user_id') String userId,
-            String status,
-            @JsonKey(name: 'contact_phone') String? contactPhone,
-            @JsonKey(name: 'contact_email') String? contactEmail,
-            @JsonKey(name: 'brand_name') String? brandName,
-            String? introduction,
-            String? address,
-            @JsonKey(name: 'biz_type') String? bizType,
-            @JsonKey(name: 'biz_name') String? bizName,
-            @JsonKey(name: 'biz_number') String? bizNumber,
-            @JsonKey(name: 'representative_name') String? representativeName,
-            @JsonKey(name: 'bank_name') String? bankName,
-            @JsonKey(name: 'account_number') String? accountNumber,
-            @JsonKey(name: 'account_holder') String? accountHolder,
-            @JsonKey(name: 'biz_registration_path') String? bizRegistrationPath,
-            @JsonKey(name: 'bankbook_path') String? bankbookPath,
-            @JsonKey(name: 'tax_email') String? taxEmail,
-            @JsonKey(name: 'profile_image_path') String? profileImagePath,
-            @JsonKey(name: 'current_step') int currentStep,
-            @JsonKey(name: 'admin_comment') String? adminComment,
-            @JsonKey(name: 'created_at') String? createdAt,
-            @JsonKey(name: 'updated_at') String? updatedAt)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _PartnerApplication():
-        return $default(
-            _that.id,
-            _that.userId,
-            _that.status,
-            _that.contactPhone,
-            _that.contactEmail,
-            _that.brandName,
-            _that.introduction,
-            _that.address,
-            _that.bizType,
-            _that.bizName,
-            _that.bizNumber,
-            _that.representativeName,
-            _that.bankName,
-            _that.accountNumber,
-            _that.accountHolder,
-            _that.bizRegistrationPath,
-            _that.bankbookPath,
-            _that.taxEmail,
-            _that.profileImagePath,
-            _that.currentStep,
-            _that.adminComment,
-            _that.createdAt,
-            _that.updatedAt);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'user_id')  String userId,  String status, @JsonKey(name: 'contact_phone')  String? contactPhone, @JsonKey(name: 'contact_email')  String? contactEmail, @JsonKey(name: 'brand_name')  String? brandName,  String? introduction,  String? address, @JsonKey(name: 'biz_type')  String? bizType, @JsonKey(name: 'biz_name')  String? bizName, @JsonKey(name: 'biz_number')  String? bizNumber, @JsonKey(name: 'representative_name')  String? representativeName, @JsonKey(name: 'bank_name')  String? bankName, @JsonKey(name: 'account_number')  String? accountNumber, @JsonKey(name: 'account_holder')  String? accountHolder, @JsonKey(name: 'biz_registration_path')  String? bizRegistrationPath, @JsonKey(name: 'bankbook_path')  String? bankbookPath, @JsonKey(name: 'tax_email')  String? taxEmail, @JsonKey(name: 'profile_image_path')  String? profileImagePath, @JsonKey(name: 'current_step')  int currentStep, @JsonKey(name: 'admin_comment')  String? adminComment, @JsonKey(name: 'created_at')  String? createdAt, @JsonKey(name: 'updated_at')  String? updatedAt)  $default,) {final _that = this;
+switch (_that) {
+case _PartnerApplication():
+return $default(_that.id,_that.userId,_that.status,_that.contactPhone,_that.contactEmail,_that.brandName,_that.introduction,_that.address,_that.bizType,_that.bizName,_that.bizNumber,_that.representativeName,_that.bankName,_that.accountNumber,_that.accountHolder,_that.bizRegistrationPath,_that.bankbookPath,_that.taxEmail,_that.profileImagePath,_that.currentStep,_that.adminComment,_that.createdAt,_that.updatedAt);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String id,
-            @JsonKey(name: 'user_id') String userId,
-            String status,
-            @JsonKey(name: 'contact_phone') String? contactPhone,
-            @JsonKey(name: 'contact_email') String? contactEmail,
-            @JsonKey(name: 'brand_name') String? brandName,
-            String? introduction,
-            String? address,
-            @JsonKey(name: 'biz_type') String? bizType,
-            @JsonKey(name: 'biz_name') String? bizName,
-            @JsonKey(name: 'biz_number') String? bizNumber,
-            @JsonKey(name: 'representative_name') String? representativeName,
-            @JsonKey(name: 'bank_name') String? bankName,
-            @JsonKey(name: 'account_number') String? accountNumber,
-            @JsonKey(name: 'account_holder') String? accountHolder,
-            @JsonKey(name: 'biz_registration_path') String? bizRegistrationPath,
-            @JsonKey(name: 'bankbook_path') String? bankbookPath,
-            @JsonKey(name: 'tax_email') String? taxEmail,
-            @JsonKey(name: 'profile_image_path') String? profileImagePath,
-            @JsonKey(name: 'current_step') int currentStep,
-            @JsonKey(name: 'admin_comment') String? adminComment,
-            @JsonKey(name: 'created_at') String? createdAt,
-            @JsonKey(name: 'updated_at') String? updatedAt)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _PartnerApplication() when $default != null:
-        return $default(
-            _that.id,
-            _that.userId,
-            _that.status,
-            _that.contactPhone,
-            _that.contactEmail,
-            _that.brandName,
-            _that.introduction,
-            _that.address,
-            _that.bizType,
-            _that.bizName,
-            _that.bizNumber,
-            _that.representativeName,
-            _that.bankName,
-            _that.accountNumber,
-            _that.accountHolder,
-            _that.bizRegistrationPath,
-            _that.bankbookPath,
-            _that.taxEmail,
-            _that.profileImagePath,
-            _that.currentStep,
-            _that.adminComment,
-            _that.createdAt,
-            _that.updatedAt);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'user_id')  String userId,  String status, @JsonKey(name: 'contact_phone')  String? contactPhone, @JsonKey(name: 'contact_email')  String? contactEmail, @JsonKey(name: 'brand_name')  String? brandName,  String? introduction,  String? address, @JsonKey(name: 'biz_type')  String? bizType, @JsonKey(name: 'biz_name')  String? bizName, @JsonKey(name: 'biz_number')  String? bizNumber, @JsonKey(name: 'representative_name')  String? representativeName, @JsonKey(name: 'bank_name')  String? bankName, @JsonKey(name: 'account_number')  String? accountNumber, @JsonKey(name: 'account_holder')  String? accountHolder, @JsonKey(name: 'biz_registration_path')  String? bizRegistrationPath, @JsonKey(name: 'bankbook_path')  String? bankbookPath, @JsonKey(name: 'tax_email')  String? taxEmail, @JsonKey(name: 'profile_image_path')  String? profileImagePath, @JsonKey(name: 'current_step')  int currentStep, @JsonKey(name: 'admin_comment')  String? adminComment, @JsonKey(name: 'created_at')  String? createdAt, @JsonKey(name: 'updated_at')  String? updatedAt)?  $default,) {final _that = this;
+switch (_that) {
+case _PartnerApplication() when $default != null:
+return $default(_that.id,_that.userId,_that.status,_that.contactPhone,_that.contactEmail,_that.brandName,_that.introduction,_that.address,_that.bizType,_that.bizName,_that.bizNumber,_that.representativeName,_that.bankName,_that.accountNumber,_that.accountHolder,_that.bizRegistrationPath,_that.bankbookPath,_that.taxEmail,_that.profileImagePath,_that.currentStep,_that.adminComment,_that.createdAt,_that.updatedAt);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _PartnerApplication implements PartnerApplication {
-  const _PartnerApplication(
-      {required this.id,
-      @JsonKey(name: 'user_id') required this.userId,
-      this.status = 'draft',
-      @JsonKey(name: 'contact_phone') this.contactPhone,
-      @JsonKey(name: 'contact_email') this.contactEmail,
-      @JsonKey(name: 'brand_name') this.brandName,
-      this.introduction,
-      this.address,
-      @JsonKey(name: 'biz_type') this.bizType,
-      @JsonKey(name: 'biz_name') this.bizName,
-      @JsonKey(name: 'biz_number') this.bizNumber,
-      @JsonKey(name: 'representative_name') this.representativeName,
-      @JsonKey(name: 'bank_name') this.bankName,
-      @JsonKey(name: 'account_number') this.accountNumber,
-      @JsonKey(name: 'account_holder') this.accountHolder,
-      @JsonKey(name: 'biz_registration_path') this.bizRegistrationPath,
-      @JsonKey(name: 'bankbook_path') this.bankbookPath,
-      @JsonKey(name: 'tax_email') this.taxEmail,
-      @JsonKey(name: 'profile_image_path') this.profileImagePath,
-      @JsonKey(name: 'current_step') this.currentStep = 0,
-      @JsonKey(name: 'admin_comment') this.adminComment,
-      @JsonKey(name: 'created_at') this.createdAt,
-      @JsonKey(name: 'updated_at') this.updatedAt});
-  factory _PartnerApplication.fromJson(Map<String, dynamic> json) =>
-      _$PartnerApplicationFromJson(json);
+  const _PartnerApplication({required this.id, @JsonKey(name: 'user_id') required this.userId, this.status = 'draft', @JsonKey(name: 'contact_phone') this.contactPhone, @JsonKey(name: 'contact_email') this.contactEmail, @JsonKey(name: 'brand_name') this.brandName, this.introduction, this.address, @JsonKey(name: 'biz_type') this.bizType, @JsonKey(name: 'biz_name') this.bizName, @JsonKey(name: 'biz_number') this.bizNumber, @JsonKey(name: 'representative_name') this.representativeName, @JsonKey(name: 'bank_name') this.bankName, @JsonKey(name: 'account_number') this.accountNumber, @JsonKey(name: 'account_holder') this.accountHolder, @JsonKey(name: 'biz_registration_path') this.bizRegistrationPath, @JsonKey(name: 'bankbook_path') this.bankbookPath, @JsonKey(name: 'tax_email') this.taxEmail, @JsonKey(name: 'profile_image_path') this.profileImagePath, @JsonKey(name: 'current_step') this.currentStep = 0, @JsonKey(name: 'admin_comment') this.adminComment, @JsonKey(name: 'created_at') this.createdAt, @JsonKey(name: 'updated_at') this.updatedAt});
+  factory _PartnerApplication.fromJson(Map<String, dynamic> json) => _$PartnerApplicationFromJson(json);
 
-  @override
-  final String id;
-  @override
-  @JsonKey(name: 'user_id')
-  final String userId;
-  @override
-  @JsonKey()
-  final String status;
-  @override
-  @JsonKey(name: 'contact_phone')
-  final String? contactPhone;
-  @override
-  @JsonKey(name: 'contact_email')
-  final String? contactEmail;
-  @override
-  @JsonKey(name: 'brand_name')
-  final String? brandName;
-  @override
-  final String? introduction;
-  @override
-  final String? address;
-  @override
-  @JsonKey(name: 'biz_type')
-  final String? bizType;
-  @override
-  @JsonKey(name: 'biz_name')
-  final String? bizName;
-  @override
-  @JsonKey(name: 'biz_number')
-  final String? bizNumber;
-  @override
-  @JsonKey(name: 'representative_name')
-  final String? representativeName;
-  @override
-  @JsonKey(name: 'bank_name')
-  final String? bankName;
-  @override
-  @JsonKey(name: 'account_number')
-  final String? accountNumber;
-  @override
-  @JsonKey(name: 'account_holder')
-  final String? accountHolder;
-  @override
-  @JsonKey(name: 'biz_registration_path')
-  final String? bizRegistrationPath;
-  @override
-  @JsonKey(name: 'bankbook_path')
-  final String? bankbookPath;
-  @override
-  @JsonKey(name: 'tax_email')
-  final String? taxEmail;
-  @override
-  @JsonKey(name: 'profile_image_path')
-  final String? profileImagePath;
-  @override
-  @JsonKey(name: 'current_step')
-  final int currentStep;
-  @override
-  @JsonKey(name: 'admin_comment')
-  final String? adminComment;
-  @override
-  @JsonKey(name: 'created_at')
-  final String? createdAt;
-  @override
-  @JsonKey(name: 'updated_at')
-  final String? updatedAt;
+@override final  String id;
+@override@JsonKey(name: 'user_id') final  String userId;
+@override@JsonKey() final  String status;
+@override@JsonKey(name: 'contact_phone') final  String? contactPhone;
+@override@JsonKey(name: 'contact_email') final  String? contactEmail;
+@override@JsonKey(name: 'brand_name') final  String? brandName;
+@override final  String? introduction;
+@override final  String? address;
+@override@JsonKey(name: 'biz_type') final  String? bizType;
+@override@JsonKey(name: 'biz_name') final  String? bizName;
+@override@JsonKey(name: 'biz_number') final  String? bizNumber;
+@override@JsonKey(name: 'representative_name') final  String? representativeName;
+@override@JsonKey(name: 'bank_name') final  String? bankName;
+@override@JsonKey(name: 'account_number') final  String? accountNumber;
+@override@JsonKey(name: 'account_holder') final  String? accountHolder;
+@override@JsonKey(name: 'biz_registration_path') final  String? bizRegistrationPath;
+@override@JsonKey(name: 'bankbook_path') final  String? bankbookPath;
+@override@JsonKey(name: 'tax_email') final  String? taxEmail;
+@override@JsonKey(name: 'profile_image_path') final  String? profileImagePath;
+@override@JsonKey(name: 'current_step') final  int currentStep;
+@override@JsonKey(name: 'admin_comment') final  String? adminComment;
+@override@JsonKey(name: 'created_at') final  String? createdAt;
+@override@JsonKey(name: 'updated_at') final  String? updatedAt;
 
-  /// Create a copy of PartnerApplication
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$PartnerApplicationCopyWith<_PartnerApplication> get copyWith =>
-      __$PartnerApplicationCopyWithImpl<_PartnerApplication>(this, _$identity);
+/// Create a copy of PartnerApplication
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PartnerApplicationCopyWith<_PartnerApplication> get copyWith => __$PartnerApplicationCopyWithImpl<_PartnerApplication>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$PartnerApplicationToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$PartnerApplicationToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _PartnerApplication &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.status, status) || other.status == status) &&
-            (identical(other.contactPhone, contactPhone) ||
-                other.contactPhone == contactPhone) &&
-            (identical(other.contactEmail, contactEmail) ||
-                other.contactEmail == contactEmail) &&
-            (identical(other.brandName, brandName) ||
-                other.brandName == brandName) &&
-            (identical(other.introduction, introduction) ||
-                other.introduction == introduction) &&
-            (identical(other.address, address) || other.address == address) &&
-            (identical(other.bizType, bizType) || other.bizType == bizType) &&
-            (identical(other.bizName, bizName) || other.bizName == bizName) &&
-            (identical(other.bizNumber, bizNumber) ||
-                other.bizNumber == bizNumber) &&
-            (identical(other.representativeName, representativeName) ||
-                other.representativeName == representativeName) &&
-            (identical(other.bankName, bankName) ||
-                other.bankName == bankName) &&
-            (identical(other.accountNumber, accountNumber) ||
-                other.accountNumber == accountNumber) &&
-            (identical(other.accountHolder, accountHolder) ||
-                other.accountHolder == accountHolder) &&
-            (identical(other.bizRegistrationPath, bizRegistrationPath) ||
-                other.bizRegistrationPath == bizRegistrationPath) &&
-            (identical(other.bankbookPath, bankbookPath) ||
-                other.bankbookPath == bankbookPath) &&
-            (identical(other.taxEmail, taxEmail) ||
-                other.taxEmail == taxEmail) &&
-            (identical(other.profileImagePath, profileImagePath) ||
-                other.profileImagePath == profileImagePath) &&
-            (identical(other.currentStep, currentStep) ||
-                other.currentStep == currentStep) &&
-            (identical(other.adminComment, adminComment) ||
-                other.adminComment == adminComment) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PartnerApplication&&(identical(other.id, id) || other.id == id)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.status, status) || other.status == status)&&(identical(other.contactPhone, contactPhone) || other.contactPhone == contactPhone)&&(identical(other.contactEmail, contactEmail) || other.contactEmail == contactEmail)&&(identical(other.brandName, brandName) || other.brandName == brandName)&&(identical(other.introduction, introduction) || other.introduction == introduction)&&(identical(other.address, address) || other.address == address)&&(identical(other.bizType, bizType) || other.bizType == bizType)&&(identical(other.bizName, bizName) || other.bizName == bizName)&&(identical(other.bizNumber, bizNumber) || other.bizNumber == bizNumber)&&(identical(other.representativeName, representativeName) || other.representativeName == representativeName)&&(identical(other.bankName, bankName) || other.bankName == bankName)&&(identical(other.accountNumber, accountNumber) || other.accountNumber == accountNumber)&&(identical(other.accountHolder, accountHolder) || other.accountHolder == accountHolder)&&(identical(other.bizRegistrationPath, bizRegistrationPath) || other.bizRegistrationPath == bizRegistrationPath)&&(identical(other.bankbookPath, bankbookPath) || other.bankbookPath == bankbookPath)&&(identical(other.taxEmail, taxEmail) || other.taxEmail == taxEmail)&&(identical(other.profileImagePath, profileImagePath) || other.profileImagePath == profileImagePath)&&(identical(other.currentStep, currentStep) || other.currentStep == currentStep)&&(identical(other.adminComment, adminComment) || other.adminComment == adminComment)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hashAll([
-        runtimeType,
-        id,
-        userId,
-        status,
-        contactPhone,
-        contactEmail,
-        brandName,
-        introduction,
-        address,
-        bizType,
-        bizName,
-        bizNumber,
-        representativeName,
-        bankName,
-        accountNumber,
-        accountHolder,
-        bizRegistrationPath,
-        bankbookPath,
-        taxEmail,
-        profileImagePath,
-        currentStep,
-        adminComment,
-        createdAt,
-        updatedAt
-      ]);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hashAll([runtimeType,id,userId,status,contactPhone,contactEmail,brandName,introduction,address,bizType,bizName,bizNumber,representativeName,bankName,accountNumber,accountHolder,bizRegistrationPath,bankbookPath,taxEmail,profileImagePath,currentStep,adminComment,createdAt,updatedAt]);
 
-  @override
-  String toString() {
-    return 'PartnerApplication(id: $id, userId: $userId, status: $status, contactPhone: $contactPhone, contactEmail: $contactEmail, brandName: $brandName, introduction: $introduction, address: $address, bizType: $bizType, bizName: $bizName, bizNumber: $bizNumber, representativeName: $representativeName, bankName: $bankName, accountNumber: $accountNumber, accountHolder: $accountHolder, bizRegistrationPath: $bizRegistrationPath, bankbookPath: $bankbookPath, taxEmail: $taxEmail, profileImagePath: $profileImagePath, currentStep: $currentStep, adminComment: $adminComment, createdAt: $createdAt, updatedAt: $updatedAt)';
-  }
+@override
+String toString() {
+  return 'PartnerApplication(id: $id, userId: $userId, status: $status, contactPhone: $contactPhone, contactEmail: $contactEmail, brandName: $brandName, introduction: $introduction, address: $address, bizType: $bizType, bizName: $bizName, bizNumber: $bizNumber, representativeName: $representativeName, bankName: $bankName, accountNumber: $accountNumber, accountHolder: $accountHolder, bizRegistrationPath: $bizRegistrationPath, bankbookPath: $bankbookPath, taxEmail: $taxEmail, profileImagePath: $profileImagePath, currentStep: $currentStep, adminComment: $adminComment, createdAt: $createdAt, updatedAt: $updatedAt)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$PartnerApplicationCopyWith<$Res>
-    implements $PartnerApplicationCopyWith<$Res> {
-  factory _$PartnerApplicationCopyWith(
-          _PartnerApplication value, $Res Function(_PartnerApplication) _then) =
-      __$PartnerApplicationCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'user_id') String userId,
-      String status,
-      @JsonKey(name: 'contact_phone') String? contactPhone,
-      @JsonKey(name: 'contact_email') String? contactEmail,
-      @JsonKey(name: 'brand_name') String? brandName,
-      String? introduction,
-      String? address,
-      @JsonKey(name: 'biz_type') String? bizType,
-      @JsonKey(name: 'biz_name') String? bizName,
-      @JsonKey(name: 'biz_number') String? bizNumber,
-      @JsonKey(name: 'representative_name') String? representativeName,
-      @JsonKey(name: 'bank_name') String? bankName,
-      @JsonKey(name: 'account_number') String? accountNumber,
-      @JsonKey(name: 'account_holder') String? accountHolder,
-      @JsonKey(name: 'biz_registration_path') String? bizRegistrationPath,
-      @JsonKey(name: 'bankbook_path') String? bankbookPath,
-      @JsonKey(name: 'tax_email') String? taxEmail,
-      @JsonKey(name: 'profile_image_path') String? profileImagePath,
-      @JsonKey(name: 'current_step') int currentStep,
-      @JsonKey(name: 'admin_comment') String? adminComment,
-      @JsonKey(name: 'created_at') String? createdAt,
-      @JsonKey(name: 'updated_at') String? updatedAt});
-}
+abstract mixin class _$PartnerApplicationCopyWith<$Res> implements $PartnerApplicationCopyWith<$Res> {
+  factory _$PartnerApplicationCopyWith(_PartnerApplication value, $Res Function(_PartnerApplication) _then) = __$PartnerApplicationCopyWithImpl;
+@override @useResult
+$Res call({
+ String id,@JsonKey(name: 'user_id') String userId, String status,@JsonKey(name: 'contact_phone') String? contactPhone,@JsonKey(name: 'contact_email') String? contactEmail,@JsonKey(name: 'brand_name') String? brandName, String? introduction, String? address,@JsonKey(name: 'biz_type') String? bizType,@JsonKey(name: 'biz_name') String? bizName,@JsonKey(name: 'biz_number') String? bizNumber,@JsonKey(name: 'representative_name') String? representativeName,@JsonKey(name: 'bank_name') String? bankName,@JsonKey(name: 'account_number') String? accountNumber,@JsonKey(name: 'account_holder') String? accountHolder,@JsonKey(name: 'biz_registration_path') String? bizRegistrationPath,@JsonKey(name: 'bankbook_path') String? bankbookPath,@JsonKey(name: 'tax_email') String? taxEmail,@JsonKey(name: 'profile_image_path') String? profileImagePath,@JsonKey(name: 'current_step') int currentStep,@JsonKey(name: 'admin_comment') String? adminComment,@JsonKey(name: 'created_at') String? createdAt,@JsonKey(name: 'updated_at') String? updatedAt
+});
 
+
+
+
+}
 /// @nodoc
 class __$PartnerApplicationCopyWithImpl<$Res>
     implements _$PartnerApplicationCopyWith<$Res> {
@@ -850,130 +306,38 @@ class __$PartnerApplicationCopyWithImpl<$Res>
   final _PartnerApplication _self;
   final $Res Function(_PartnerApplication) _then;
 
-  /// Create a copy of PartnerApplication
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? userId = null,
-    Object? status = null,
-    Object? contactPhone = freezed,
-    Object? contactEmail = freezed,
-    Object? brandName = freezed,
-    Object? introduction = freezed,
-    Object? address = freezed,
-    Object? bizType = freezed,
-    Object? bizName = freezed,
-    Object? bizNumber = freezed,
-    Object? representativeName = freezed,
-    Object? bankName = freezed,
-    Object? accountNumber = freezed,
-    Object? accountHolder = freezed,
-    Object? bizRegistrationPath = freezed,
-    Object? bankbookPath = freezed,
-    Object? taxEmail = freezed,
-    Object? profileImagePath = freezed,
-    Object? currentStep = null,
-    Object? adminComment = freezed,
-    Object? createdAt = freezed,
-    Object? updatedAt = freezed,
-  }) {
-    return _then(_PartnerApplication(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      userId: null == userId
-          ? _self.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      status: null == status
-          ? _self.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as String,
-      contactPhone: freezed == contactPhone
-          ? _self.contactPhone
-          : contactPhone // ignore: cast_nullable_to_non_nullable
-              as String?,
-      contactEmail: freezed == contactEmail
-          ? _self.contactEmail
-          : contactEmail // ignore: cast_nullable_to_non_nullable
-              as String?,
-      brandName: freezed == brandName
-          ? _self.brandName
-          : brandName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      introduction: freezed == introduction
-          ? _self.introduction
-          : introduction // ignore: cast_nullable_to_non_nullable
-              as String?,
-      address: freezed == address
-          ? _self.address
-          : address // ignore: cast_nullable_to_non_nullable
-              as String?,
-      bizType: freezed == bizType
-          ? _self.bizType
-          : bizType // ignore: cast_nullable_to_non_nullable
-              as String?,
-      bizName: freezed == bizName
-          ? _self.bizName
-          : bizName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      bizNumber: freezed == bizNumber
-          ? _self.bizNumber
-          : bizNumber // ignore: cast_nullable_to_non_nullable
-              as String?,
-      representativeName: freezed == representativeName
-          ? _self.representativeName
-          : representativeName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      bankName: freezed == bankName
-          ? _self.bankName
-          : bankName // ignore: cast_nullable_to_non_nullable
-              as String?,
-      accountNumber: freezed == accountNumber
-          ? _self.accountNumber
-          : accountNumber // ignore: cast_nullable_to_non_nullable
-              as String?,
-      accountHolder: freezed == accountHolder
-          ? _self.accountHolder
-          : accountHolder // ignore: cast_nullable_to_non_nullable
-              as String?,
-      bizRegistrationPath: freezed == bizRegistrationPath
-          ? _self.bizRegistrationPath
-          : bizRegistrationPath // ignore: cast_nullable_to_non_nullable
-              as String?,
-      bankbookPath: freezed == bankbookPath
-          ? _self.bankbookPath
-          : bankbookPath // ignore: cast_nullable_to_non_nullable
-              as String?,
-      taxEmail: freezed == taxEmail
-          ? _self.taxEmail
-          : taxEmail // ignore: cast_nullable_to_non_nullable
-              as String?,
-      profileImagePath: freezed == profileImagePath
-          ? _self.profileImagePath
-          : profileImagePath // ignore: cast_nullable_to_non_nullable
-              as String?,
-      currentStep: null == currentStep
-          ? _self.currentStep
-          : currentStep // ignore: cast_nullable_to_non_nullable
-              as int,
-      adminComment: freezed == adminComment
-          ? _self.adminComment
-          : adminComment // ignore: cast_nullable_to_non_nullable
-              as String?,
-      createdAt: freezed == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as String?,
-      updatedAt: freezed == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Create a copy of PartnerApplication
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? userId = null,Object? status = null,Object? contactPhone = freezed,Object? contactEmail = freezed,Object? brandName = freezed,Object? introduction = freezed,Object? address = freezed,Object? bizType = freezed,Object? bizName = freezed,Object? bizNumber = freezed,Object? representativeName = freezed,Object? bankName = freezed,Object? accountNumber = freezed,Object? accountHolder = freezed,Object? bizRegistrationPath = freezed,Object? bankbookPath = freezed,Object? taxEmail = freezed,Object? profileImagePath = freezed,Object? currentStep = null,Object? adminComment = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,}) {
+  return _then(_PartnerApplication(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,contactPhone: freezed == contactPhone ? _self.contactPhone : contactPhone // ignore: cast_nullable_to_non_nullable
+as String?,contactEmail: freezed == contactEmail ? _self.contactEmail : contactEmail // ignore: cast_nullable_to_non_nullable
+as String?,brandName: freezed == brandName ? _self.brandName : brandName // ignore: cast_nullable_to_non_nullable
+as String?,introduction: freezed == introduction ? _self.introduction : introduction // ignore: cast_nullable_to_non_nullable
+as String?,address: freezed == address ? _self.address : address // ignore: cast_nullable_to_non_nullable
+as String?,bizType: freezed == bizType ? _self.bizType : bizType // ignore: cast_nullable_to_non_nullable
+as String?,bizName: freezed == bizName ? _self.bizName : bizName // ignore: cast_nullable_to_non_nullable
+as String?,bizNumber: freezed == bizNumber ? _self.bizNumber : bizNumber // ignore: cast_nullable_to_non_nullable
+as String?,representativeName: freezed == representativeName ? _self.representativeName : representativeName // ignore: cast_nullable_to_non_nullable
+as String?,bankName: freezed == bankName ? _self.bankName : bankName // ignore: cast_nullable_to_non_nullable
+as String?,accountNumber: freezed == accountNumber ? _self.accountNumber : accountNumber // ignore: cast_nullable_to_non_nullable
+as String?,accountHolder: freezed == accountHolder ? _self.accountHolder : accountHolder // ignore: cast_nullable_to_non_nullable
+as String?,bizRegistrationPath: freezed == bizRegistrationPath ? _self.bizRegistrationPath : bizRegistrationPath // ignore: cast_nullable_to_non_nullable
+as String?,bankbookPath: freezed == bankbookPath ? _self.bankbookPath : bankbookPath // ignore: cast_nullable_to_non_nullable
+as String?,taxEmail: freezed == taxEmail ? _self.taxEmail : taxEmail // ignore: cast_nullable_to_non_nullable
+as String?,profileImagePath: freezed == profileImagePath ? _self.profileImagePath : profileImagePath // ignore: cast_nullable_to_non_nullable
+as String?,currentStep: null == currentStep ? _self.currentStep : currentStep // ignore: cast_nullable_to_non_nullable
+as int,adminComment: freezed == adminComment ? _self.adminComment : adminComment // ignore: cast_nullable_to_non_nullable
+as String?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as String?,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/party.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/party.freezed.dart
@@ -14,1702 +14,726 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$Location {
-  String get id;
-  @JsonKey(name: 'partner_id')
-  String get partnerId;
-  String get name;
-  String get address;
-  @JsonKey(name: 'created_at')
-  DateTime get createdAt;
-  @JsonKey(name: 'updated_at')
-  DateTime get updatedAt;
-  @JsonKey(name: 'address_detail')
-  String? get addressDetail;
-  @JsonKey(name: 'region_1')
-  String? get region1;
-  @JsonKey(name: 'region_2')
-  String? get region2;
-  @JsonKey(name: 'region_3')
-  String? get region3;
-  @JsonKey(name: 'directions_guide')
-  String? get directionsGuide;
-  @JsonKey(name: 'postal_code')
-  String?
-      get postalCode; // GeoJSON Point or lat/lng handled manually if needed.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  dynamic get geoPoint; // UI Convenience fields
-  @JsonKey(name: 'lat')
-  double get latitude;
-  @JsonKey(name: 'lng')
-  double get longitude;
 
-  /// Create a copy of Location
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $LocationCopyWith<Location> get copyWith =>
-      _$LocationCopyWithImpl<Location>(this as Location, _$identity);
+ String get id;@JsonKey(name: 'partner_id') String get partnerId; String get name; String get address;@JsonKey(name: 'created_at') DateTime get createdAt;@JsonKey(name: 'updated_at') DateTime get updatedAt;@JsonKey(name: 'address_detail') String? get addressDetail;@JsonKey(name: 'region_1') String? get region1;@JsonKey(name: 'region_2') String? get region2;@JsonKey(name: 'region_3') String? get region3;@JsonKey(name: 'directions_guide') String? get directionsGuide;@JsonKey(name: 'postal_code') String? get postalCode;// GeoJSON Point or lat/lng handled manually if needed.
+@JsonKey(includeFromJson: false, includeToJson: false) dynamic get geoPoint;// UI Convenience fields
+@JsonKey(name: 'lat') double get latitude;@JsonKey(name: 'lng') double get longitude;
+/// Create a copy of Location
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$LocationCopyWith<Location> get copyWith => _$LocationCopyWithImpl<Location>(this as Location, _$identity);
 
   /// Serializes this Location to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is Location &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.partnerId, partnerId) ||
-                other.partnerId == partnerId) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.address, address) || other.address == address) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt) &&
-            (identical(other.addressDetail, addressDetail) ||
-                other.addressDetail == addressDetail) &&
-            (identical(other.region1, region1) || other.region1 == region1) &&
-            (identical(other.region2, region2) || other.region2 == region2) &&
-            (identical(other.region3, region3) || other.region3 == region3) &&
-            (identical(other.directionsGuide, directionsGuide) ||
-                other.directionsGuide == directionsGuide) &&
-            (identical(other.postalCode, postalCode) ||
-                other.postalCode == postalCode) &&
-            const DeepCollectionEquality().equals(other.geoPoint, geoPoint) &&
-            (identical(other.latitude, latitude) ||
-                other.latitude == latitude) &&
-            (identical(other.longitude, longitude) ||
-                other.longitude == longitude));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      partnerId,
-      name,
-      address,
-      createdAt,
-      updatedAt,
-      addressDetail,
-      region1,
-      region2,
-      region3,
-      directionsGuide,
-      postalCode,
-      const DeepCollectionEquality().hash(geoPoint),
-      latitude,
-      longitude);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Location&&(identical(other.id, id) || other.id == id)&&(identical(other.partnerId, partnerId) || other.partnerId == partnerId)&&(identical(other.name, name) || other.name == name)&&(identical(other.address, address) || other.address == address)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.addressDetail, addressDetail) || other.addressDetail == addressDetail)&&(identical(other.region1, region1) || other.region1 == region1)&&(identical(other.region2, region2) || other.region2 == region2)&&(identical(other.region3, region3) || other.region3 == region3)&&(identical(other.directionsGuide, directionsGuide) || other.directionsGuide == directionsGuide)&&(identical(other.postalCode, postalCode) || other.postalCode == postalCode)&&const DeepCollectionEquality().equals(other.geoPoint, geoPoint)&&(identical(other.latitude, latitude) || other.latitude == latitude)&&(identical(other.longitude, longitude) || other.longitude == longitude));
+}
 
-  @override
-  String toString() {
-    return 'Location(id: $id, partnerId: $partnerId, name: $name, address: $address, createdAt: $createdAt, updatedAt: $updatedAt, addressDetail: $addressDetail, region1: $region1, region2: $region2, region3: $region3, directionsGuide: $directionsGuide, postalCode: $postalCode, geoPoint: $geoPoint, latitude: $latitude, longitude: $longitude)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,partnerId,name,address,createdAt,updatedAt,addressDetail,region1,region2,region3,directionsGuide,postalCode,const DeepCollectionEquality().hash(geoPoint),latitude,longitude);
+
+@override
+String toString() {
+  return 'Location(id: $id, partnerId: $partnerId, name: $name, address: $address, createdAt: $createdAt, updatedAt: $updatedAt, addressDetail: $addressDetail, region1: $region1, region2: $region2, region3: $region3, directionsGuide: $directionsGuide, postalCode: $postalCode, geoPoint: $geoPoint, latitude: $latitude, longitude: $longitude)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $LocationCopyWith<$Res> {
-  factory $LocationCopyWith(Location value, $Res Function(Location) _then) =
-      _$LocationCopyWithImpl;
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'partner_id') String partnerId,
-      String name,
-      String address,
-      @JsonKey(name: 'created_at') DateTime createdAt,
-      @JsonKey(name: 'updated_at') DateTime updatedAt,
-      @JsonKey(name: 'address_detail') String? addressDetail,
-      @JsonKey(name: 'region_1') String? region1,
-      @JsonKey(name: 'region_2') String? region2,
-      @JsonKey(name: 'region_3') String? region3,
-      @JsonKey(name: 'directions_guide') String? directionsGuide,
-      @JsonKey(name: 'postal_code') String? postalCode,
-      @JsonKey(includeFromJson: false, includeToJson: false) dynamic geoPoint,
-      @JsonKey(name: 'lat') double latitude,
-      @JsonKey(name: 'lng') double longitude});
-}
+abstract mixin class $LocationCopyWith<$Res>  {
+  factory $LocationCopyWith(Location value, $Res Function(Location) _then) = _$LocationCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(name: 'partner_id') String partnerId, String name, String address,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'address_detail') String? addressDetail,@JsonKey(name: 'region_1') String? region1,@JsonKey(name: 'region_2') String? region2,@JsonKey(name: 'region_3') String? region3,@JsonKey(name: 'directions_guide') String? directionsGuide,@JsonKey(name: 'postal_code') String? postalCode,@JsonKey(includeFromJson: false, includeToJson: false) dynamic geoPoint,@JsonKey(name: 'lat') double latitude,@JsonKey(name: 'lng') double longitude
+});
 
+
+
+
+}
 /// @nodoc
-class _$LocationCopyWithImpl<$Res> implements $LocationCopyWith<$Res> {
+class _$LocationCopyWithImpl<$Res>
+    implements $LocationCopyWith<$Res> {
   _$LocationCopyWithImpl(this._self, this._then);
 
   final Location _self;
   final $Res Function(Location) _then;
 
-  /// Create a copy of Location
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? partnerId = null,
-    Object? name = null,
-    Object? address = null,
-    Object? createdAt = null,
-    Object? updatedAt = null,
-    Object? addressDetail = freezed,
-    Object? region1 = freezed,
-    Object? region2 = freezed,
-    Object? region3 = freezed,
-    Object? directionsGuide = freezed,
-    Object? postalCode = freezed,
-    Object? geoPoint = freezed,
-    Object? latitude = null,
-    Object? longitude = null,
-  }) {
-    return _then(_self.copyWith(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      partnerId: null == partnerId
-          ? _self.partnerId
-          : partnerId // ignore: cast_nullable_to_non_nullable
-              as String,
-      name: null == name
-          ? _self.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      address: null == address
-          ? _self.address
-          : address // ignore: cast_nullable_to_non_nullable
-              as String,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updatedAt: null == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      addressDetail: freezed == addressDetail
-          ? _self.addressDetail
-          : addressDetail // ignore: cast_nullable_to_non_nullable
-              as String?,
-      region1: freezed == region1
-          ? _self.region1
-          : region1 // ignore: cast_nullable_to_non_nullable
-              as String?,
-      region2: freezed == region2
-          ? _self.region2
-          : region2 // ignore: cast_nullable_to_non_nullable
-              as String?,
-      region3: freezed == region3
-          ? _self.region3
-          : region3 // ignore: cast_nullable_to_non_nullable
-              as String?,
-      directionsGuide: freezed == directionsGuide
-          ? _self.directionsGuide
-          : directionsGuide // ignore: cast_nullable_to_non_nullable
-              as String?,
-      postalCode: freezed == postalCode
-          ? _self.postalCode
-          : postalCode // ignore: cast_nullable_to_non_nullable
-              as String?,
-      geoPoint: freezed == geoPoint
-          ? _self.geoPoint
-          : geoPoint // ignore: cast_nullable_to_non_nullable
-              as dynamic,
-      latitude: null == latitude
-          ? _self.latitude
-          : latitude // ignore: cast_nullable_to_non_nullable
-              as double,
-      longitude: null == longitude
-          ? _self.longitude
-          : longitude // ignore: cast_nullable_to_non_nullable
-              as double,
-    ));
-  }
+/// Create a copy of Location
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? partnerId = null,Object? name = null,Object? address = null,Object? createdAt = null,Object? updatedAt = null,Object? addressDetail = freezed,Object? region1 = freezed,Object? region2 = freezed,Object? region3 = freezed,Object? directionsGuide = freezed,Object? postalCode = freezed,Object? geoPoint = freezed,Object? latitude = null,Object? longitude = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,partnerId: null == partnerId ? _self.partnerId : partnerId // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,address: null == address ? _self.address : address // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,addressDetail: freezed == addressDetail ? _self.addressDetail : addressDetail // ignore: cast_nullable_to_non_nullable
+as String?,region1: freezed == region1 ? _self.region1 : region1 // ignore: cast_nullable_to_non_nullable
+as String?,region2: freezed == region2 ? _self.region2 : region2 // ignore: cast_nullable_to_non_nullable
+as String?,region3: freezed == region3 ? _self.region3 : region3 // ignore: cast_nullable_to_non_nullable
+as String?,directionsGuide: freezed == directionsGuide ? _self.directionsGuide : directionsGuide // ignore: cast_nullable_to_non_nullable
+as String?,postalCode: freezed == postalCode ? _self.postalCode : postalCode // ignore: cast_nullable_to_non_nullable
+as String?,geoPoint: freezed == geoPoint ? _self.geoPoint : geoPoint // ignore: cast_nullable_to_non_nullable
+as dynamic,latitude: null == latitude ? _self.latitude : latitude // ignore: cast_nullable_to_non_nullable
+as double,longitude: null == longitude ? _self.longitude : longitude // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [Location].
 extension LocationPatterns on Location {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_Location value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Location() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Location value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Location() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_Location value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Location():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Location value)  $default,){
+final _that = this;
+switch (_that) {
+case _Location():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_Location value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Location() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Location value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Location() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'partner_id') String partnerId,
-            String name,
-            String address,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'address_detail') String? addressDetail,
-            @JsonKey(name: 'region_1') String? region1,
-            @JsonKey(name: 'region_2') String? region2,
-            @JsonKey(name: 'region_3') String? region3,
-            @JsonKey(name: 'directions_guide') String? directionsGuide,
-            @JsonKey(name: 'postal_code') String? postalCode,
-            @JsonKey(includeFromJson: false, includeToJson: false)
-            dynamic geoPoint,
-            @JsonKey(name: 'lat') double latitude,
-            @JsonKey(name: 'lng') double longitude)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Location() when $default != null:
-        return $default(
-            _that.id,
-            _that.partnerId,
-            _that.name,
-            _that.address,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.addressDetail,
-            _that.region1,
-            _that.region2,
-            _that.region3,
-            _that.directionsGuide,
-            _that.postalCode,
-            _that.geoPoint,
-            _that.latitude,
-            _that.longitude);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'partner_id')  String partnerId,  String name,  String address, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'address_detail')  String? addressDetail, @JsonKey(name: 'region_1')  String? region1, @JsonKey(name: 'region_2')  String? region2, @JsonKey(name: 'region_3')  String? region3, @JsonKey(name: 'directions_guide')  String? directionsGuide, @JsonKey(name: 'postal_code')  String? postalCode, @JsonKey(includeFromJson: false, includeToJson: false)  dynamic geoPoint, @JsonKey(name: 'lat')  double latitude, @JsonKey(name: 'lng')  double longitude)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Location() when $default != null:
+return $default(_that.id,_that.partnerId,_that.name,_that.address,_that.createdAt,_that.updatedAt,_that.addressDetail,_that.region1,_that.region2,_that.region3,_that.directionsGuide,_that.postalCode,_that.geoPoint,_that.latitude,_that.longitude);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'partner_id') String partnerId,
-            String name,
-            String address,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'address_detail') String? addressDetail,
-            @JsonKey(name: 'region_1') String? region1,
-            @JsonKey(name: 'region_2') String? region2,
-            @JsonKey(name: 'region_3') String? region3,
-            @JsonKey(name: 'directions_guide') String? directionsGuide,
-            @JsonKey(name: 'postal_code') String? postalCode,
-            @JsonKey(includeFromJson: false, includeToJson: false)
-            dynamic geoPoint,
-            @JsonKey(name: 'lat') double latitude,
-            @JsonKey(name: 'lng') double longitude)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Location():
-        return $default(
-            _that.id,
-            _that.partnerId,
-            _that.name,
-            _that.address,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.addressDetail,
-            _that.region1,
-            _that.region2,
-            _that.region3,
-            _that.directionsGuide,
-            _that.postalCode,
-            _that.geoPoint,
-            _that.latitude,
-            _that.longitude);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'partner_id')  String partnerId,  String name,  String address, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'address_detail')  String? addressDetail, @JsonKey(name: 'region_1')  String? region1, @JsonKey(name: 'region_2')  String? region2, @JsonKey(name: 'region_3')  String? region3, @JsonKey(name: 'directions_guide')  String? directionsGuide, @JsonKey(name: 'postal_code')  String? postalCode, @JsonKey(includeFromJson: false, includeToJson: false)  dynamic geoPoint, @JsonKey(name: 'lat')  double latitude, @JsonKey(name: 'lng')  double longitude)  $default,) {final _that = this;
+switch (_that) {
+case _Location():
+return $default(_that.id,_that.partnerId,_that.name,_that.address,_that.createdAt,_that.updatedAt,_that.addressDetail,_that.region1,_that.region2,_that.region3,_that.directionsGuide,_that.postalCode,_that.geoPoint,_that.latitude,_that.longitude);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String id,
-            @JsonKey(name: 'partner_id') String partnerId,
-            String name,
-            String address,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'address_detail') String? addressDetail,
-            @JsonKey(name: 'region_1') String? region1,
-            @JsonKey(name: 'region_2') String? region2,
-            @JsonKey(name: 'region_3') String? region3,
-            @JsonKey(name: 'directions_guide') String? directionsGuide,
-            @JsonKey(name: 'postal_code') String? postalCode,
-            @JsonKey(includeFromJson: false, includeToJson: false)
-            dynamic geoPoint,
-            @JsonKey(name: 'lat') double latitude,
-            @JsonKey(name: 'lng') double longitude)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Location() when $default != null:
-        return $default(
-            _that.id,
-            _that.partnerId,
-            _that.name,
-            _that.address,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.addressDetail,
-            _that.region1,
-            _that.region2,
-            _that.region3,
-            _that.directionsGuide,
-            _that.postalCode,
-            _that.geoPoint,
-            _that.latitude,
-            _that.longitude);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'partner_id')  String partnerId,  String name,  String address, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'address_detail')  String? addressDetail, @JsonKey(name: 'region_1')  String? region1, @JsonKey(name: 'region_2')  String? region2, @JsonKey(name: 'region_3')  String? region3, @JsonKey(name: 'directions_guide')  String? directionsGuide, @JsonKey(name: 'postal_code')  String? postalCode, @JsonKey(includeFromJson: false, includeToJson: false)  dynamic geoPoint, @JsonKey(name: 'lat')  double latitude, @JsonKey(name: 'lng')  double longitude)?  $default,) {final _that = this;
+switch (_that) {
+case _Location() when $default != null:
+return $default(_that.id,_that.partnerId,_that.name,_that.address,_that.createdAt,_that.updatedAt,_that.addressDetail,_that.region1,_that.region2,_that.region3,_that.directionsGuide,_that.postalCode,_that.geoPoint,_that.latitude,_that.longitude);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _Location implements Location {
-  const _Location(
-      {required this.id,
-      @JsonKey(name: 'partner_id') required this.partnerId,
-      required this.name,
-      required this.address,
-      @JsonKey(name: 'created_at') required this.createdAt,
-      @JsonKey(name: 'updated_at') required this.updatedAt,
-      @JsonKey(name: 'address_detail') this.addressDetail,
-      @JsonKey(name: 'region_1') this.region1,
-      @JsonKey(name: 'region_2') this.region2,
-      @JsonKey(name: 'region_3') this.region3,
-      @JsonKey(name: 'directions_guide') this.directionsGuide,
-      @JsonKey(name: 'postal_code') this.postalCode,
-      @JsonKey(includeFromJson: false, includeToJson: false) this.geoPoint,
-      @JsonKey(name: 'lat') this.latitude = 0.0,
-      @JsonKey(name: 'lng') this.longitude = 0.0});
-  factory _Location.fromJson(Map<String, dynamic> json) =>
-      _$LocationFromJson(json);
+  const _Location({required this.id, @JsonKey(name: 'partner_id') required this.partnerId, required this.name, required this.address, @JsonKey(name: 'created_at') required this.createdAt, @JsonKey(name: 'updated_at') required this.updatedAt, @JsonKey(name: 'address_detail') this.addressDetail, @JsonKey(name: 'region_1') this.region1, @JsonKey(name: 'region_2') this.region2, @JsonKey(name: 'region_3') this.region3, @JsonKey(name: 'directions_guide') this.directionsGuide, @JsonKey(name: 'postal_code') this.postalCode, @JsonKey(includeFromJson: false, includeToJson: false) this.geoPoint, @JsonKey(name: 'lat') this.latitude = 0.0, @JsonKey(name: 'lng') this.longitude = 0.0});
+  factory _Location.fromJson(Map<String, dynamic> json) => _$LocationFromJson(json);
 
-  @override
-  final String id;
-  @override
-  @JsonKey(name: 'partner_id')
-  final String partnerId;
-  @override
-  final String name;
-  @override
-  final String address;
-  @override
-  @JsonKey(name: 'created_at')
-  final DateTime createdAt;
-  @override
-  @JsonKey(name: 'updated_at')
-  final DateTime updatedAt;
-  @override
-  @JsonKey(name: 'address_detail')
-  final String? addressDetail;
-  @override
-  @JsonKey(name: 'region_1')
-  final String? region1;
-  @override
-  @JsonKey(name: 'region_2')
-  final String? region2;
-  @override
-  @JsonKey(name: 'region_3')
-  final String? region3;
-  @override
-  @JsonKey(name: 'directions_guide')
-  final String? directionsGuide;
-  @override
-  @JsonKey(name: 'postal_code')
-  final String? postalCode;
+@override final  String id;
+@override@JsonKey(name: 'partner_id') final  String partnerId;
+@override final  String name;
+@override final  String address;
+@override@JsonKey(name: 'created_at') final  DateTime createdAt;
+@override@JsonKey(name: 'updated_at') final  DateTime updatedAt;
+@override@JsonKey(name: 'address_detail') final  String? addressDetail;
+@override@JsonKey(name: 'region_1') final  String? region1;
+@override@JsonKey(name: 'region_2') final  String? region2;
+@override@JsonKey(name: 'region_3') final  String? region3;
+@override@JsonKey(name: 'directions_guide') final  String? directionsGuide;
+@override@JsonKey(name: 'postal_code') final  String? postalCode;
 // GeoJSON Point or lat/lng handled manually if needed.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  final dynamic geoPoint;
+@override@JsonKey(includeFromJson: false, includeToJson: false) final  dynamic geoPoint;
 // UI Convenience fields
-  @override
-  @JsonKey(name: 'lat')
-  final double latitude;
-  @override
-  @JsonKey(name: 'lng')
-  final double longitude;
+@override@JsonKey(name: 'lat') final  double latitude;
+@override@JsonKey(name: 'lng') final  double longitude;
 
-  /// Create a copy of Location
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$LocationCopyWith<_Location> get copyWith =>
-      __$LocationCopyWithImpl<_Location>(this, _$identity);
+/// Create a copy of Location
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$LocationCopyWith<_Location> get copyWith => __$LocationCopyWithImpl<_Location>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$LocationToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$LocationToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _Location &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.partnerId, partnerId) ||
-                other.partnerId == partnerId) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.address, address) || other.address == address) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt) &&
-            (identical(other.addressDetail, addressDetail) ||
-                other.addressDetail == addressDetail) &&
-            (identical(other.region1, region1) || other.region1 == region1) &&
-            (identical(other.region2, region2) || other.region2 == region2) &&
-            (identical(other.region3, region3) || other.region3 == region3) &&
-            (identical(other.directionsGuide, directionsGuide) ||
-                other.directionsGuide == directionsGuide) &&
-            (identical(other.postalCode, postalCode) ||
-                other.postalCode == postalCode) &&
-            const DeepCollectionEquality().equals(other.geoPoint, geoPoint) &&
-            (identical(other.latitude, latitude) ||
-                other.latitude == latitude) &&
-            (identical(other.longitude, longitude) ||
-                other.longitude == longitude));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Location&&(identical(other.id, id) || other.id == id)&&(identical(other.partnerId, partnerId) || other.partnerId == partnerId)&&(identical(other.name, name) || other.name == name)&&(identical(other.address, address) || other.address == address)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.addressDetail, addressDetail) || other.addressDetail == addressDetail)&&(identical(other.region1, region1) || other.region1 == region1)&&(identical(other.region2, region2) || other.region2 == region2)&&(identical(other.region3, region3) || other.region3 == region3)&&(identical(other.directionsGuide, directionsGuide) || other.directionsGuide == directionsGuide)&&(identical(other.postalCode, postalCode) || other.postalCode == postalCode)&&const DeepCollectionEquality().equals(other.geoPoint, geoPoint)&&(identical(other.latitude, latitude) || other.latitude == latitude)&&(identical(other.longitude, longitude) || other.longitude == longitude));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      partnerId,
-      name,
-      address,
-      createdAt,
-      updatedAt,
-      addressDetail,
-      region1,
-      region2,
-      region3,
-      directionsGuide,
-      postalCode,
-      const DeepCollectionEquality().hash(geoPoint),
-      latitude,
-      longitude);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,partnerId,name,address,createdAt,updatedAt,addressDetail,region1,region2,region3,directionsGuide,postalCode,const DeepCollectionEquality().hash(geoPoint),latitude,longitude);
 
-  @override
-  String toString() {
-    return 'Location(id: $id, partnerId: $partnerId, name: $name, address: $address, createdAt: $createdAt, updatedAt: $updatedAt, addressDetail: $addressDetail, region1: $region1, region2: $region2, region3: $region3, directionsGuide: $directionsGuide, postalCode: $postalCode, geoPoint: $geoPoint, latitude: $latitude, longitude: $longitude)';
-  }
+@override
+String toString() {
+  return 'Location(id: $id, partnerId: $partnerId, name: $name, address: $address, createdAt: $createdAt, updatedAt: $updatedAt, addressDetail: $addressDetail, region1: $region1, region2: $region2, region3: $region3, directionsGuide: $directionsGuide, postalCode: $postalCode, geoPoint: $geoPoint, latitude: $latitude, longitude: $longitude)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$LocationCopyWith<$Res>
-    implements $LocationCopyWith<$Res> {
-  factory _$LocationCopyWith(_Location value, $Res Function(_Location) _then) =
-      __$LocationCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'partner_id') String partnerId,
-      String name,
-      String address,
-      @JsonKey(name: 'created_at') DateTime createdAt,
-      @JsonKey(name: 'updated_at') DateTime updatedAt,
-      @JsonKey(name: 'address_detail') String? addressDetail,
-      @JsonKey(name: 'region_1') String? region1,
-      @JsonKey(name: 'region_2') String? region2,
-      @JsonKey(name: 'region_3') String? region3,
-      @JsonKey(name: 'directions_guide') String? directionsGuide,
-      @JsonKey(name: 'postal_code') String? postalCode,
-      @JsonKey(includeFromJson: false, includeToJson: false) dynamic geoPoint,
-      @JsonKey(name: 'lat') double latitude,
-      @JsonKey(name: 'lng') double longitude});
-}
+abstract mixin class _$LocationCopyWith<$Res> implements $LocationCopyWith<$Res> {
+  factory _$LocationCopyWith(_Location value, $Res Function(_Location) _then) = __$LocationCopyWithImpl;
+@override @useResult
+$Res call({
+ String id,@JsonKey(name: 'partner_id') String partnerId, String name, String address,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'address_detail') String? addressDetail,@JsonKey(name: 'region_1') String? region1,@JsonKey(name: 'region_2') String? region2,@JsonKey(name: 'region_3') String? region3,@JsonKey(name: 'directions_guide') String? directionsGuide,@JsonKey(name: 'postal_code') String? postalCode,@JsonKey(includeFromJson: false, includeToJson: false) dynamic geoPoint,@JsonKey(name: 'lat') double latitude,@JsonKey(name: 'lng') double longitude
+});
 
+
+
+
+}
 /// @nodoc
-class __$LocationCopyWithImpl<$Res> implements _$LocationCopyWith<$Res> {
+class __$LocationCopyWithImpl<$Res>
+    implements _$LocationCopyWith<$Res> {
   __$LocationCopyWithImpl(this._self, this._then);
 
   final _Location _self;
   final $Res Function(_Location) _then;
 
-  /// Create a copy of Location
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? partnerId = null,
-    Object? name = null,
-    Object? address = null,
-    Object? createdAt = null,
-    Object? updatedAt = null,
-    Object? addressDetail = freezed,
-    Object? region1 = freezed,
-    Object? region2 = freezed,
-    Object? region3 = freezed,
-    Object? directionsGuide = freezed,
-    Object? postalCode = freezed,
-    Object? geoPoint = freezed,
-    Object? latitude = null,
-    Object? longitude = null,
-  }) {
-    return _then(_Location(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      partnerId: null == partnerId
-          ? _self.partnerId
-          : partnerId // ignore: cast_nullable_to_non_nullable
-              as String,
-      name: null == name
-          ? _self.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      address: null == address
-          ? _self.address
-          : address // ignore: cast_nullable_to_non_nullable
-              as String,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updatedAt: null == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      addressDetail: freezed == addressDetail
-          ? _self.addressDetail
-          : addressDetail // ignore: cast_nullable_to_non_nullable
-              as String?,
-      region1: freezed == region1
-          ? _self.region1
-          : region1 // ignore: cast_nullable_to_non_nullable
-              as String?,
-      region2: freezed == region2
-          ? _self.region2
-          : region2 // ignore: cast_nullable_to_non_nullable
-              as String?,
-      region3: freezed == region3
-          ? _self.region3
-          : region3 // ignore: cast_nullable_to_non_nullable
-              as String?,
-      directionsGuide: freezed == directionsGuide
-          ? _self.directionsGuide
-          : directionsGuide // ignore: cast_nullable_to_non_nullable
-              as String?,
-      postalCode: freezed == postalCode
-          ? _self.postalCode
-          : postalCode // ignore: cast_nullable_to_non_nullable
-              as String?,
-      geoPoint: freezed == geoPoint
-          ? _self.geoPoint
-          : geoPoint // ignore: cast_nullable_to_non_nullable
-              as dynamic,
-      latitude: null == latitude
-          ? _self.latitude
-          : latitude // ignore: cast_nullable_to_non_nullable
-              as double,
-      longitude: null == longitude
-          ? _self.longitude
-          : longitude // ignore: cast_nullable_to_non_nullable
-              as double,
-    ));
-  }
+/// Create a copy of Location
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? partnerId = null,Object? name = null,Object? address = null,Object? createdAt = null,Object? updatedAt = null,Object? addressDetail = freezed,Object? region1 = freezed,Object? region2 = freezed,Object? region3 = freezed,Object? directionsGuide = freezed,Object? postalCode = freezed,Object? geoPoint = freezed,Object? latitude = null,Object? longitude = null,}) {
+  return _then(_Location(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,partnerId: null == partnerId ? _self.partnerId : partnerId // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,address: null == address ? _self.address : address // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,addressDetail: freezed == addressDetail ? _self.addressDetail : addressDetail // ignore: cast_nullable_to_non_nullable
+as String?,region1: freezed == region1 ? _self.region1 : region1 // ignore: cast_nullable_to_non_nullable
+as String?,region2: freezed == region2 ? _self.region2 : region2 // ignore: cast_nullable_to_non_nullable
+as String?,region3: freezed == region3 ? _self.region3 : region3 // ignore: cast_nullable_to_non_nullable
+as String?,directionsGuide: freezed == directionsGuide ? _self.directionsGuide : directionsGuide // ignore: cast_nullable_to_non_nullable
+as String?,postalCode: freezed == postalCode ? _self.postalCode : postalCode // ignore: cast_nullable_to_non_nullable
+as String?,geoPoint: freezed == geoPoint ? _self.geoPoint : geoPoint // ignore: cast_nullable_to_non_nullable
+as dynamic,latitude: null == latitude ? _self.latitude : latitude // ignore: cast_nullable_to_non_nullable
+as double,longitude: null == longitude ? _self.longitude : longitude // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
 }
+
+
+}
+
 
 /// @nodoc
 mixin _$Party {
-  String get id;
-  @JsonKey(name: 'partner_id')
-  String get partnerId;
-  String get title;
-  @JsonKey(name: 'created_at')
-  DateTime get createdAt;
-  @JsonKey(name: 'updated_at')
-  DateTime get updatedAt;
-  @JsonKey(name: 'location_id')
-  String? get locationId;
-  @JsonKey(includeToJson: false)
-  Location? get location;
-  Map<String, dynamic>? get description; // Quill Delta JSON
-  @JsonKey(name: 'image_urls')
-  List<String> get imageUrls;
-  @JsonKey(name: 'contact_options')
-  Map<String, dynamic> get contactOptions;
-  Map<String, dynamic> get metadata;
-  @JsonKey(name: 'required_verification_ids')
-  List<String> get requiredVerificationIds;
-  @JsonKey(name: 'min_confirmed_count')
-  int get minConfirmedCount;
-  @JsonKey(name: 'max_participants')
-  int get maxParticipants;
-  String get status;
-  String get visibility;
-  @JsonKey(includeToJson: false)
-  List<TicketTemplate>? get ticketTemplates;
-  @JsonKey(includeToJson: false)
-  Partner? get partner;
-  @JsonKey(name: 'entry_group_templates', includeToJson: false)
-  List<EntryGroupTemplate>? get entryGroups;
 
-  /// Create a copy of Party
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $PartyCopyWith<Party> get copyWith =>
-      _$PartyCopyWithImpl<Party>(this as Party, _$identity);
+ String get id;@JsonKey(name: 'partner_id') String get partnerId; String get title;@JsonKey(name: 'created_at') DateTime get createdAt;@JsonKey(name: 'updated_at') DateTime get updatedAt;@JsonKey(name: 'location_id') String? get locationId;@JsonKey(includeToJson: false) Location? get location; Map<String, dynamic>? get description;// Quill Delta JSON
+@JsonKey(name: 'image_urls') List<String> get imageUrls;@JsonKey(name: 'contact_options') Map<String, dynamic> get contactOptions; Map<String, dynamic> get metadata;@JsonKey(name: 'required_verification_ids') List<String> get requiredVerificationIds;@JsonKey(name: 'min_confirmed_count') int get minConfirmedCount;@JsonKey(name: 'max_participants') int get maxParticipants; String get status; String get visibility;@JsonKey(includeToJson: false) List<TicketTemplate>? get ticketTemplates;@JsonKey(includeToJson: false) Partner? get partner;@JsonKey(name: 'entry_group_templates', includeToJson: false) List<EntryGroupTemplate>? get entryGroups;
+/// Create a copy of Party
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PartyCopyWith<Party> get copyWith => _$PartyCopyWithImpl<Party>(this as Party, _$identity);
 
   /// Serializes this Party to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is Party &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.partnerId, partnerId) ||
-                other.partnerId == partnerId) &&
-            (identical(other.title, title) || other.title == title) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt) &&
-            (identical(other.locationId, locationId) ||
-                other.locationId == locationId) &&
-            (identical(other.location, location) ||
-                other.location == location) &&
-            const DeepCollectionEquality()
-                .equals(other.description, description) &&
-            const DeepCollectionEquality().equals(other.imageUrls, imageUrls) &&
-            const DeepCollectionEquality()
-                .equals(other.contactOptions, contactOptions) &&
-            const DeepCollectionEquality().equals(other.metadata, metadata) &&
-            const DeepCollectionEquality().equals(
-                other.requiredVerificationIds, requiredVerificationIds) &&
-            (identical(other.minConfirmedCount, minConfirmedCount) ||
-                other.minConfirmedCount == minConfirmedCount) &&
-            (identical(other.maxParticipants, maxParticipants) ||
-                other.maxParticipants == maxParticipants) &&
-            (identical(other.status, status) || other.status == status) &&
-            (identical(other.visibility, visibility) ||
-                other.visibility == visibility) &&
-            const DeepCollectionEquality()
-                .equals(other.ticketTemplates, ticketTemplates) &&
-            (identical(other.partner, partner) || other.partner == partner) &&
-            const DeepCollectionEquality()
-                .equals(other.entryGroups, entryGroups));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hashAll([
-        runtimeType,
-        id,
-        partnerId,
-        title,
-        createdAt,
-        updatedAt,
-        locationId,
-        location,
-        const DeepCollectionEquality().hash(description),
-        const DeepCollectionEquality().hash(imageUrls),
-        const DeepCollectionEquality().hash(contactOptions),
-        const DeepCollectionEquality().hash(metadata),
-        const DeepCollectionEquality().hash(requiredVerificationIds),
-        minConfirmedCount,
-        maxParticipants,
-        status,
-        visibility,
-        const DeepCollectionEquality().hash(ticketTemplates),
-        partner,
-        const DeepCollectionEquality().hash(entryGroups)
-      ]);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Party&&(identical(other.id, id) || other.id == id)&&(identical(other.partnerId, partnerId) || other.partnerId == partnerId)&&(identical(other.title, title) || other.title == title)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.locationId, locationId) || other.locationId == locationId)&&(identical(other.location, location) || other.location == location)&&const DeepCollectionEquality().equals(other.description, description)&&const DeepCollectionEquality().equals(other.imageUrls, imageUrls)&&const DeepCollectionEquality().equals(other.contactOptions, contactOptions)&&const DeepCollectionEquality().equals(other.metadata, metadata)&&const DeepCollectionEquality().equals(other.requiredVerificationIds, requiredVerificationIds)&&(identical(other.minConfirmedCount, minConfirmedCount) || other.minConfirmedCount == minConfirmedCount)&&(identical(other.maxParticipants, maxParticipants) || other.maxParticipants == maxParticipants)&&(identical(other.status, status) || other.status == status)&&(identical(other.visibility, visibility) || other.visibility == visibility)&&const DeepCollectionEquality().equals(other.ticketTemplates, ticketTemplates)&&(identical(other.partner, partner) || other.partner == partner)&&const DeepCollectionEquality().equals(other.entryGroups, entryGroups));
+}
 
-  @override
-  String toString() {
-    return 'Party(id: $id, partnerId: $partnerId, title: $title, createdAt: $createdAt, updatedAt: $updatedAt, locationId: $locationId, location: $location, description: $description, imageUrls: $imageUrls, contactOptions: $contactOptions, metadata: $metadata, requiredVerificationIds: $requiredVerificationIds, minConfirmedCount: $minConfirmedCount, maxParticipants: $maxParticipants, status: $status, visibility: $visibility, ticketTemplates: $ticketTemplates, partner: $partner, entryGroups: $entryGroups)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hashAll([runtimeType,id,partnerId,title,createdAt,updatedAt,locationId,location,const DeepCollectionEquality().hash(description),const DeepCollectionEquality().hash(imageUrls),const DeepCollectionEquality().hash(contactOptions),const DeepCollectionEquality().hash(metadata),const DeepCollectionEquality().hash(requiredVerificationIds),minConfirmedCount,maxParticipants,status,visibility,const DeepCollectionEquality().hash(ticketTemplates),partner,const DeepCollectionEquality().hash(entryGroups)]);
+
+@override
+String toString() {
+  return 'Party(id: $id, partnerId: $partnerId, title: $title, createdAt: $createdAt, updatedAt: $updatedAt, locationId: $locationId, location: $location, description: $description, imageUrls: $imageUrls, contactOptions: $contactOptions, metadata: $metadata, requiredVerificationIds: $requiredVerificationIds, minConfirmedCount: $minConfirmedCount, maxParticipants: $maxParticipants, status: $status, visibility: $visibility, ticketTemplates: $ticketTemplates, partner: $partner, entryGroups: $entryGroups)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $PartyCopyWith<$Res> {
-  factory $PartyCopyWith(Party value, $Res Function(Party) _then) =
-      _$PartyCopyWithImpl;
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'partner_id') String partnerId,
-      String title,
-      @JsonKey(name: 'created_at') DateTime createdAt,
-      @JsonKey(name: 'updated_at') DateTime updatedAt,
-      @JsonKey(name: 'location_id') String? locationId,
-      @JsonKey(includeToJson: false) Location? location,
-      Map<String, dynamic>? description,
-      @JsonKey(name: 'image_urls') List<String> imageUrls,
-      @JsonKey(name: 'contact_options') Map<String, dynamic> contactOptions,
-      Map<String, dynamic> metadata,
-      @JsonKey(name: 'required_verification_ids')
-      List<String> requiredVerificationIds,
-      @JsonKey(name: 'min_confirmed_count') int minConfirmedCount,
-      @JsonKey(name: 'max_participants') int maxParticipants,
-      String status,
-      String visibility,
-      @JsonKey(includeToJson: false) List<TicketTemplate>? ticketTemplates,
-      @JsonKey(includeToJson: false) Partner? partner,
-      @JsonKey(name: 'entry_group_templates', includeToJson: false)
-      List<EntryGroupTemplate>? entryGroups});
+abstract mixin class $PartyCopyWith<$Res>  {
+  factory $PartyCopyWith(Party value, $Res Function(Party) _then) = _$PartyCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(name: 'partner_id') String partnerId, String title,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'location_id') String? locationId,@JsonKey(includeToJson: false) Location? location, Map<String, dynamic>? description,@JsonKey(name: 'image_urls') List<String> imageUrls,@JsonKey(name: 'contact_options') Map<String, dynamic> contactOptions, Map<String, dynamic> metadata,@JsonKey(name: 'required_verification_ids') List<String> requiredVerificationIds,@JsonKey(name: 'min_confirmed_count') int minConfirmedCount,@JsonKey(name: 'max_participants') int maxParticipants, String status, String visibility,@JsonKey(includeToJson: false) List<TicketTemplate>? ticketTemplates,@JsonKey(includeToJson: false) Partner? partner,@JsonKey(name: 'entry_group_templates', includeToJson: false) List<EntryGroupTemplate>? entryGroups
+});
 
-  $LocationCopyWith<$Res>? get location;
-  $PartnerCopyWith<$Res>? get partner;
+
+$LocationCopyWith<$Res>? get location;$PartnerCopyWith<$Res>? get partner;
+
 }
-
 /// @nodoc
-class _$PartyCopyWithImpl<$Res> implements $PartyCopyWith<$Res> {
+class _$PartyCopyWithImpl<$Res>
+    implements $PartyCopyWith<$Res> {
   _$PartyCopyWithImpl(this._self, this._then);
 
   final Party _self;
   final $Res Function(Party) _then;
 
-  /// Create a copy of Party
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? partnerId = null,
-    Object? title = null,
-    Object? createdAt = null,
-    Object? updatedAt = null,
-    Object? locationId = freezed,
-    Object? location = freezed,
-    Object? description = freezed,
-    Object? imageUrls = null,
-    Object? contactOptions = null,
-    Object? metadata = null,
-    Object? requiredVerificationIds = null,
-    Object? minConfirmedCount = null,
-    Object? maxParticipants = null,
-    Object? status = null,
-    Object? visibility = null,
-    Object? ticketTemplates = freezed,
-    Object? partner = freezed,
-    Object? entryGroups = freezed,
-  }) {
-    return _then(_self.copyWith(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      partnerId: null == partnerId
-          ? _self.partnerId
-          : partnerId // ignore: cast_nullable_to_non_nullable
-              as String,
-      title: null == title
-          ? _self.title
-          : title // ignore: cast_nullable_to_non_nullable
-              as String,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updatedAt: null == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      locationId: freezed == locationId
-          ? _self.locationId
-          : locationId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      location: freezed == location
-          ? _self.location
-          : location // ignore: cast_nullable_to_non_nullable
-              as Location?,
-      description: freezed == description
-          ? _self.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>?,
-      imageUrls: null == imageUrls
-          ? _self.imageUrls
-          : imageUrls // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      contactOptions: null == contactOptions
-          ? _self.contactOptions
-          : contactOptions // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>,
-      metadata: null == metadata
-          ? _self.metadata
-          : metadata // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>,
-      requiredVerificationIds: null == requiredVerificationIds
-          ? _self.requiredVerificationIds
-          : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      minConfirmedCount: null == minConfirmedCount
-          ? _self.minConfirmedCount
-          : minConfirmedCount // ignore: cast_nullable_to_non_nullable
-              as int,
-      maxParticipants: null == maxParticipants
-          ? _self.maxParticipants
-          : maxParticipants // ignore: cast_nullable_to_non_nullable
-              as int,
-      status: null == status
-          ? _self.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as String,
-      visibility: null == visibility
-          ? _self.visibility
-          : visibility // ignore: cast_nullable_to_non_nullable
-              as String,
-      ticketTemplates: freezed == ticketTemplates
-          ? _self.ticketTemplates
-          : ticketTemplates // ignore: cast_nullable_to_non_nullable
-              as List<TicketTemplate>?,
-      partner: freezed == partner
-          ? _self.partner
-          : partner // ignore: cast_nullable_to_non_nullable
-              as Partner?,
-      entryGroups: freezed == entryGroups
-          ? _self.entryGroups
-          : entryGroups // ignore: cast_nullable_to_non_nullable
-              as List<EntryGroupTemplate>?,
-    ));
-  }
-
-  /// Create a copy of Party
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $LocationCopyWith<$Res>? get location {
-    if (_self.location == null) {
-      return null;
-    }
-
-    return $LocationCopyWith<$Res>(_self.location!, (value) {
-      return _then(_self.copyWith(location: value));
-    });
-  }
-
-  /// Create a copy of Party
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $PartnerCopyWith<$Res>? get partner {
-    if (_self.partner == null) {
-      return null;
-    }
-
-    return $PartnerCopyWith<$Res>(_self.partner!, (value) {
-      return _then(_self.copyWith(partner: value));
-    });
-  }
+/// Create a copy of Party
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? partnerId = null,Object? title = null,Object? createdAt = null,Object? updatedAt = null,Object? locationId = freezed,Object? location = freezed,Object? description = freezed,Object? imageUrls = null,Object? contactOptions = null,Object? metadata = null,Object? requiredVerificationIds = null,Object? minConfirmedCount = null,Object? maxParticipants = null,Object? status = null,Object? visibility = null,Object? ticketTemplates = freezed,Object? partner = freezed,Object? entryGroups = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,partnerId: null == partnerId ? _self.partnerId : partnerId // ignore: cast_nullable_to_non_nullable
+as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,locationId: freezed == locationId ? _self.locationId : locationId // ignore: cast_nullable_to_non_nullable
+as String?,location: freezed == location ? _self.location : location // ignore: cast_nullable_to_non_nullable
+as Location?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,imageUrls: null == imageUrls ? _self.imageUrls : imageUrls // ignore: cast_nullable_to_non_nullable
+as List<String>,contactOptions: null == contactOptions ? _self.contactOptions : contactOptions // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>,metadata: null == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>,requiredVerificationIds: null == requiredVerificationIds ? _self.requiredVerificationIds : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
+as List<String>,minConfirmedCount: null == minConfirmedCount ? _self.minConfirmedCount : minConfirmedCount // ignore: cast_nullable_to_non_nullable
+as int,maxParticipants: null == maxParticipants ? _self.maxParticipants : maxParticipants // ignore: cast_nullable_to_non_nullable
+as int,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,visibility: null == visibility ? _self.visibility : visibility // ignore: cast_nullable_to_non_nullable
+as String,ticketTemplates: freezed == ticketTemplates ? _self.ticketTemplates : ticketTemplates // ignore: cast_nullable_to_non_nullable
+as List<TicketTemplate>?,partner: freezed == partner ? _self.partner : partner // ignore: cast_nullable_to_non_nullable
+as Partner?,entryGroups: freezed == entryGroups ? _self.entryGroups : entryGroups // ignore: cast_nullable_to_non_nullable
+as List<EntryGroupTemplate>?,
+  ));
 }
+/// Create a copy of Party
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$LocationCopyWith<$Res>? get location {
+    if (_self.location == null) {
+    return null;
+  }
+
+  return $LocationCopyWith<$Res>(_self.location!, (value) {
+    return _then(_self.copyWith(location: value));
+  });
+}/// Create a copy of Party
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$PartnerCopyWith<$Res>? get partner {
+    if (_self.partner == null) {
+    return null;
+  }
+
+  return $PartnerCopyWith<$Res>(_self.partner!, (value) {
+    return _then(_self.copyWith(partner: value));
+  });
+}
+}
+
 
 /// Adds pattern-matching-related methods to [Party].
 extension PartyPatterns on Party {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_Party value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Party() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Party value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Party() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_Party value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Party():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Party value)  $default,){
+final _that = this;
+switch (_that) {
+case _Party():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_Party value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Party() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Party value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Party() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'partner_id') String partnerId,
-            String title,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'location_id') String? locationId,
-            @JsonKey(includeToJson: false) Location? location,
-            Map<String, dynamic>? description,
-            @JsonKey(name: 'image_urls') List<String> imageUrls,
-            @JsonKey(name: 'contact_options')
-            Map<String, dynamic> contactOptions,
-            Map<String, dynamic> metadata,
-            @JsonKey(name: 'required_verification_ids')
-            List<String> requiredVerificationIds,
-            @JsonKey(name: 'min_confirmed_count') int minConfirmedCount,
-            @JsonKey(name: 'max_participants') int maxParticipants,
-            String status,
-            String visibility,
-            @JsonKey(includeToJson: false)
-            List<TicketTemplate>? ticketTemplates,
-            @JsonKey(includeToJson: false) Partner? partner,
-            @JsonKey(name: 'entry_group_templates', includeToJson: false)
-            List<EntryGroupTemplate>? entryGroups)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Party() when $default != null:
-        return $default(
-            _that.id,
-            _that.partnerId,
-            _that.title,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.locationId,
-            _that.location,
-            _that.description,
-            _that.imageUrls,
-            _that.contactOptions,
-            _that.metadata,
-            _that.requiredVerificationIds,
-            _that.minConfirmedCount,
-            _that.maxParticipants,
-            _that.status,
-            _that.visibility,
-            _that.ticketTemplates,
-            _that.partner,
-            _that.entryGroups);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'partner_id')  String partnerId,  String title, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'location_id')  String? locationId, @JsonKey(includeToJson: false)  Location? location,  Map<String, dynamic>? description, @JsonKey(name: 'image_urls')  List<String> imageUrls, @JsonKey(name: 'contact_options')  Map<String, dynamic> contactOptions,  Map<String, dynamic> metadata, @JsonKey(name: 'required_verification_ids')  List<String> requiredVerificationIds, @JsonKey(name: 'min_confirmed_count')  int minConfirmedCount, @JsonKey(name: 'max_participants')  int maxParticipants,  String status,  String visibility, @JsonKey(includeToJson: false)  List<TicketTemplate>? ticketTemplates, @JsonKey(includeToJson: false)  Partner? partner, @JsonKey(name: 'entry_group_templates', includeToJson: false)  List<EntryGroupTemplate>? entryGroups)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Party() when $default != null:
+return $default(_that.id,_that.partnerId,_that.title,_that.createdAt,_that.updatedAt,_that.locationId,_that.location,_that.description,_that.imageUrls,_that.contactOptions,_that.metadata,_that.requiredVerificationIds,_that.minConfirmedCount,_that.maxParticipants,_that.status,_that.visibility,_that.ticketTemplates,_that.partner,_that.entryGroups);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'partner_id') String partnerId,
-            String title,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'location_id') String? locationId,
-            @JsonKey(includeToJson: false) Location? location,
-            Map<String, dynamic>? description,
-            @JsonKey(name: 'image_urls') List<String> imageUrls,
-            @JsonKey(name: 'contact_options')
-            Map<String, dynamic> contactOptions,
-            Map<String, dynamic> metadata,
-            @JsonKey(name: 'required_verification_ids')
-            List<String> requiredVerificationIds,
-            @JsonKey(name: 'min_confirmed_count') int minConfirmedCount,
-            @JsonKey(name: 'max_participants') int maxParticipants,
-            String status,
-            String visibility,
-            @JsonKey(includeToJson: false)
-            List<TicketTemplate>? ticketTemplates,
-            @JsonKey(includeToJson: false) Partner? partner,
-            @JsonKey(name: 'entry_group_templates', includeToJson: false)
-            List<EntryGroupTemplate>? entryGroups)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Party():
-        return $default(
-            _that.id,
-            _that.partnerId,
-            _that.title,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.locationId,
-            _that.location,
-            _that.description,
-            _that.imageUrls,
-            _that.contactOptions,
-            _that.metadata,
-            _that.requiredVerificationIds,
-            _that.minConfirmedCount,
-            _that.maxParticipants,
-            _that.status,
-            _that.visibility,
-            _that.ticketTemplates,
-            _that.partner,
-            _that.entryGroups);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'partner_id')  String partnerId,  String title, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'location_id')  String? locationId, @JsonKey(includeToJson: false)  Location? location,  Map<String, dynamic>? description, @JsonKey(name: 'image_urls')  List<String> imageUrls, @JsonKey(name: 'contact_options')  Map<String, dynamic> contactOptions,  Map<String, dynamic> metadata, @JsonKey(name: 'required_verification_ids')  List<String> requiredVerificationIds, @JsonKey(name: 'min_confirmed_count')  int minConfirmedCount, @JsonKey(name: 'max_participants')  int maxParticipants,  String status,  String visibility, @JsonKey(includeToJson: false)  List<TicketTemplate>? ticketTemplates, @JsonKey(includeToJson: false)  Partner? partner, @JsonKey(name: 'entry_group_templates', includeToJson: false)  List<EntryGroupTemplate>? entryGroups)  $default,) {final _that = this;
+switch (_that) {
+case _Party():
+return $default(_that.id,_that.partnerId,_that.title,_that.createdAt,_that.updatedAt,_that.locationId,_that.location,_that.description,_that.imageUrls,_that.contactOptions,_that.metadata,_that.requiredVerificationIds,_that.minConfirmedCount,_that.maxParticipants,_that.status,_that.visibility,_that.ticketTemplates,_that.partner,_that.entryGroups);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String id,
-            @JsonKey(name: 'partner_id') String partnerId,
-            String title,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'location_id') String? locationId,
-            @JsonKey(includeToJson: false) Location? location,
-            Map<String, dynamic>? description,
-            @JsonKey(name: 'image_urls') List<String> imageUrls,
-            @JsonKey(name: 'contact_options')
-            Map<String, dynamic> contactOptions,
-            Map<String, dynamic> metadata,
-            @JsonKey(name: 'required_verification_ids')
-            List<String> requiredVerificationIds,
-            @JsonKey(name: 'min_confirmed_count') int minConfirmedCount,
-            @JsonKey(name: 'max_participants') int maxParticipants,
-            String status,
-            String visibility,
-            @JsonKey(includeToJson: false)
-            List<TicketTemplate>? ticketTemplates,
-            @JsonKey(includeToJson: false) Partner? partner,
-            @JsonKey(name: 'entry_group_templates', includeToJson: false)
-            List<EntryGroupTemplate>? entryGroups)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Party() when $default != null:
-        return $default(
-            _that.id,
-            _that.partnerId,
-            _that.title,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.locationId,
-            _that.location,
-            _that.description,
-            _that.imageUrls,
-            _that.contactOptions,
-            _that.metadata,
-            _that.requiredVerificationIds,
-            _that.minConfirmedCount,
-            _that.maxParticipants,
-            _that.status,
-            _that.visibility,
-            _that.ticketTemplates,
-            _that.partner,
-            _that.entryGroups);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'partner_id')  String partnerId,  String title, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'location_id')  String? locationId, @JsonKey(includeToJson: false)  Location? location,  Map<String, dynamic>? description, @JsonKey(name: 'image_urls')  List<String> imageUrls, @JsonKey(name: 'contact_options')  Map<String, dynamic> contactOptions,  Map<String, dynamic> metadata, @JsonKey(name: 'required_verification_ids')  List<String> requiredVerificationIds, @JsonKey(name: 'min_confirmed_count')  int minConfirmedCount, @JsonKey(name: 'max_participants')  int maxParticipants,  String status,  String visibility, @JsonKey(includeToJson: false)  List<TicketTemplate>? ticketTemplates, @JsonKey(includeToJson: false)  Partner? partner, @JsonKey(name: 'entry_group_templates', includeToJson: false)  List<EntryGroupTemplate>? entryGroups)?  $default,) {final _that = this;
+switch (_that) {
+case _Party() when $default != null:
+return $default(_that.id,_that.partnerId,_that.title,_that.createdAt,_that.updatedAt,_that.locationId,_that.location,_that.description,_that.imageUrls,_that.contactOptions,_that.metadata,_that.requiredVerificationIds,_that.minConfirmedCount,_that.maxParticipants,_that.status,_that.visibility,_that.ticketTemplates,_that.partner,_that.entryGroups);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _Party extends Party {
-  const _Party(
-      {required this.id,
-      @JsonKey(name: 'partner_id') required this.partnerId,
-      required this.title,
-      @JsonKey(name: 'created_at') required this.createdAt,
-      @JsonKey(name: 'updated_at') required this.updatedAt,
-      @JsonKey(name: 'location_id') this.locationId,
-      @JsonKey(includeToJson: false) this.location,
-      final Map<String, dynamic>? description,
-      @JsonKey(name: 'image_urls') final List<String> imageUrls = const [],
-      @JsonKey(name: 'contact_options')
-      final Map<String, dynamic> contactOptions = const {},
-      final Map<String, dynamic> metadata = const {},
-      @JsonKey(name: 'required_verification_ids')
-      final List<String> requiredVerificationIds = const [],
-      @JsonKey(name: 'min_confirmed_count') this.minConfirmedCount = 0,
-      @JsonKey(name: 'max_participants') this.maxParticipants = 20,
-      this.status = 'active',
-      this.visibility = 'public',
-      @JsonKey(includeToJson: false)
-      final List<TicketTemplate>? ticketTemplates,
-      @JsonKey(includeToJson: false) this.partner,
-      @JsonKey(name: 'entry_group_templates', includeToJson: false)
-      final List<EntryGroupTemplate>? entryGroups})
-      : _description = description,
-        _imageUrls = imageUrls,
-        _contactOptions = contactOptions,
-        _metadata = metadata,
-        _requiredVerificationIds = requiredVerificationIds,
-        _ticketTemplates = ticketTemplates,
-        _entryGroups = entryGroups,
-        super._();
+  const _Party({required this.id, @JsonKey(name: 'partner_id') required this.partnerId, required this.title, @JsonKey(name: 'created_at') required this.createdAt, @JsonKey(name: 'updated_at') required this.updatedAt, @JsonKey(name: 'location_id') this.locationId, @JsonKey(includeToJson: false) this.location, final  Map<String, dynamic>? description, @JsonKey(name: 'image_urls') final  List<String> imageUrls = const [], @JsonKey(name: 'contact_options') final  Map<String, dynamic> contactOptions = const {}, final  Map<String, dynamic> metadata = const {}, @JsonKey(name: 'required_verification_ids') final  List<String> requiredVerificationIds = const [], @JsonKey(name: 'min_confirmed_count') this.minConfirmedCount = 0, @JsonKey(name: 'max_participants') this.maxParticipants = 20, this.status = 'active', this.visibility = 'public', @JsonKey(includeToJson: false) final  List<TicketTemplate>? ticketTemplates, @JsonKey(includeToJson: false) this.partner, @JsonKey(name: 'entry_group_templates', includeToJson: false) final  List<EntryGroupTemplate>? entryGroups}): _description = description,_imageUrls = imageUrls,_contactOptions = contactOptions,_metadata = metadata,_requiredVerificationIds = requiredVerificationIds,_ticketTemplates = ticketTemplates,_entryGroups = entryGroups,super._();
   factory _Party.fromJson(Map<String, dynamic> json) => _$PartyFromJson(json);
 
-  @override
-  final String id;
-  @override
-  @JsonKey(name: 'partner_id')
-  final String partnerId;
-  @override
-  final String title;
-  @override
-  @JsonKey(name: 'created_at')
-  final DateTime createdAt;
-  @override
-  @JsonKey(name: 'updated_at')
-  final DateTime updatedAt;
-  @override
-  @JsonKey(name: 'location_id')
-  final String? locationId;
-  @override
-  @JsonKey(includeToJson: false)
-  final Location? location;
-  final Map<String, dynamic>? _description;
-  @override
-  Map<String, dynamic>? get description {
-    final value = _description;
-    if (value == null) return null;
-    if (_description is EqualUnmodifiableMapView) return _description;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(value);
-  }
+@override final  String id;
+@override@JsonKey(name: 'partner_id') final  String partnerId;
+@override final  String title;
+@override@JsonKey(name: 'created_at') final  DateTime createdAt;
+@override@JsonKey(name: 'updated_at') final  DateTime updatedAt;
+@override@JsonKey(name: 'location_id') final  String? locationId;
+@override@JsonKey(includeToJson: false) final  Location? location;
+ final  Map<String, dynamic>? _description;
+@override Map<String, dynamic>? get description {
+  final value = _description;
+  if (value == null) return null;
+  if (_description is EqualUnmodifiableMapView) return _description;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
 
 // Quill Delta JSON
-  final List<String> _imageUrls;
+ final  List<String> _imageUrls;
 // Quill Delta JSON
-  @override
-  @JsonKey(name: 'image_urls')
-  List<String> get imageUrls {
-    if (_imageUrls is EqualUnmodifiableListView) return _imageUrls;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_imageUrls);
-  }
+@override@JsonKey(name: 'image_urls') List<String> get imageUrls {
+  if (_imageUrls is EqualUnmodifiableListView) return _imageUrls;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_imageUrls);
+}
 
-  final Map<String, dynamic> _contactOptions;
-  @override
-  @JsonKey(name: 'contact_options')
-  Map<String, dynamic> get contactOptions {
-    if (_contactOptions is EqualUnmodifiableMapView) return _contactOptions;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(_contactOptions);
-  }
+ final  Map<String, dynamic> _contactOptions;
+@override@JsonKey(name: 'contact_options') Map<String, dynamic> get contactOptions {
+  if (_contactOptions is EqualUnmodifiableMapView) return _contactOptions;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_contactOptions);
+}
 
-  final Map<String, dynamic> _metadata;
-  @override
-  @JsonKey()
-  Map<String, dynamic> get metadata {
-    if (_metadata is EqualUnmodifiableMapView) return _metadata;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(_metadata);
-  }
+ final  Map<String, dynamic> _metadata;
+@override@JsonKey() Map<String, dynamic> get metadata {
+  if (_metadata is EqualUnmodifiableMapView) return _metadata;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_metadata);
+}
 
-  final List<String> _requiredVerificationIds;
-  @override
-  @JsonKey(name: 'required_verification_ids')
-  List<String> get requiredVerificationIds {
-    if (_requiredVerificationIds is EqualUnmodifiableListView)
-      return _requiredVerificationIds;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_requiredVerificationIds);
-  }
+ final  List<String> _requiredVerificationIds;
+@override@JsonKey(name: 'required_verification_ids') List<String> get requiredVerificationIds {
+  if (_requiredVerificationIds is EqualUnmodifiableListView) return _requiredVerificationIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_requiredVerificationIds);
+}
 
-  @override
-  @JsonKey(name: 'min_confirmed_count')
-  final int minConfirmedCount;
-  @override
-  @JsonKey(name: 'max_participants')
-  final int maxParticipants;
-  @override
-  @JsonKey()
-  final String status;
-  @override
-  @JsonKey()
-  final String visibility;
-  final List<TicketTemplate>? _ticketTemplates;
-  @override
-  @JsonKey(includeToJson: false)
-  List<TicketTemplate>? get ticketTemplates {
-    final value = _ticketTemplates;
-    if (value == null) return null;
-    if (_ticketTemplates is EqualUnmodifiableListView) return _ticketTemplates;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
+@override@JsonKey(name: 'min_confirmed_count') final  int minConfirmedCount;
+@override@JsonKey(name: 'max_participants') final  int maxParticipants;
+@override@JsonKey() final  String status;
+@override@JsonKey() final  String visibility;
+ final  List<TicketTemplate>? _ticketTemplates;
+@override@JsonKey(includeToJson: false) List<TicketTemplate>? get ticketTemplates {
+  final value = _ticketTemplates;
+  if (value == null) return null;
+  if (_ticketTemplates is EqualUnmodifiableListView) return _ticketTemplates;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
 
-  @override
-  @JsonKey(includeToJson: false)
-  final Partner? partner;
-  final List<EntryGroupTemplate>? _entryGroups;
-  @override
-  @JsonKey(name: 'entry_group_templates', includeToJson: false)
-  List<EntryGroupTemplate>? get entryGroups {
-    final value = _entryGroups;
-    if (value == null) return null;
-    if (_entryGroups is EqualUnmodifiableListView) return _entryGroups;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
+@override@JsonKey(includeToJson: false) final  Partner? partner;
+ final  List<EntryGroupTemplate>? _entryGroups;
+@override@JsonKey(name: 'entry_group_templates', includeToJson: false) List<EntryGroupTemplate>? get entryGroups {
+  final value = _entryGroups;
+  if (value == null) return null;
+  if (_entryGroups is EqualUnmodifiableListView) return _entryGroups;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
 
-  /// Create a copy of Party
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$PartyCopyWith<_Party> get copyWith =>
-      __$PartyCopyWithImpl<_Party>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$PartyToJson(
-      this,
-    );
-  }
+/// Create a copy of Party
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PartyCopyWith<_Party> get copyWith => __$PartyCopyWithImpl<_Party>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _Party &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.partnerId, partnerId) ||
-                other.partnerId == partnerId) &&
-            (identical(other.title, title) || other.title == title) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt) &&
-            (identical(other.locationId, locationId) ||
-                other.locationId == locationId) &&
-            (identical(other.location, location) ||
-                other.location == location) &&
-            const DeepCollectionEquality()
-                .equals(other._description, _description) &&
-            const DeepCollectionEquality()
-                .equals(other._imageUrls, _imageUrls) &&
-            const DeepCollectionEquality()
-                .equals(other._contactOptions, _contactOptions) &&
-            const DeepCollectionEquality().equals(other._metadata, _metadata) &&
-            const DeepCollectionEquality().equals(
-                other._requiredVerificationIds, _requiredVerificationIds) &&
-            (identical(other.minConfirmedCount, minConfirmedCount) ||
-                other.minConfirmedCount == minConfirmedCount) &&
-            (identical(other.maxParticipants, maxParticipants) ||
-                other.maxParticipants == maxParticipants) &&
-            (identical(other.status, status) || other.status == status) &&
-            (identical(other.visibility, visibility) ||
-                other.visibility == visibility) &&
-            const DeepCollectionEquality()
-                .equals(other._ticketTemplates, _ticketTemplates) &&
-            (identical(other.partner, partner) || other.partner == partner) &&
-            const DeepCollectionEquality()
-                .equals(other._entryGroups, _entryGroups));
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$PartyToJson(this, );
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hashAll([
-        runtimeType,
-        id,
-        partnerId,
-        title,
-        createdAt,
-        updatedAt,
-        locationId,
-        location,
-        const DeepCollectionEquality().hash(_description),
-        const DeepCollectionEquality().hash(_imageUrls),
-        const DeepCollectionEquality().hash(_contactOptions),
-        const DeepCollectionEquality().hash(_metadata),
-        const DeepCollectionEquality().hash(_requiredVerificationIds),
-        minConfirmedCount,
-        maxParticipants,
-        status,
-        visibility,
-        const DeepCollectionEquality().hash(_ticketTemplates),
-        partner,
-        const DeepCollectionEquality().hash(_entryGroups)
-      ]);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Party&&(identical(other.id, id) || other.id == id)&&(identical(other.partnerId, partnerId) || other.partnerId == partnerId)&&(identical(other.title, title) || other.title == title)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.locationId, locationId) || other.locationId == locationId)&&(identical(other.location, location) || other.location == location)&&const DeepCollectionEquality().equals(other._description, _description)&&const DeepCollectionEquality().equals(other._imageUrls, _imageUrls)&&const DeepCollectionEquality().equals(other._contactOptions, _contactOptions)&&const DeepCollectionEquality().equals(other._metadata, _metadata)&&const DeepCollectionEquality().equals(other._requiredVerificationIds, _requiredVerificationIds)&&(identical(other.minConfirmedCount, minConfirmedCount) || other.minConfirmedCount == minConfirmedCount)&&(identical(other.maxParticipants, maxParticipants) || other.maxParticipants == maxParticipants)&&(identical(other.status, status) || other.status == status)&&(identical(other.visibility, visibility) || other.visibility == visibility)&&const DeepCollectionEquality().equals(other._ticketTemplates, _ticketTemplates)&&(identical(other.partner, partner) || other.partner == partner)&&const DeepCollectionEquality().equals(other._entryGroups, _entryGroups));
+}
 
-  @override
-  String toString() {
-    return 'Party(id: $id, partnerId: $partnerId, title: $title, createdAt: $createdAt, updatedAt: $updatedAt, locationId: $locationId, location: $location, description: $description, imageUrls: $imageUrls, contactOptions: $contactOptions, metadata: $metadata, requiredVerificationIds: $requiredVerificationIds, minConfirmedCount: $minConfirmedCount, maxParticipants: $maxParticipants, status: $status, visibility: $visibility, ticketTemplates: $ticketTemplates, partner: $partner, entryGroups: $entryGroups)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hashAll([runtimeType,id,partnerId,title,createdAt,updatedAt,locationId,location,const DeepCollectionEquality().hash(_description),const DeepCollectionEquality().hash(_imageUrls),const DeepCollectionEquality().hash(_contactOptions),const DeepCollectionEquality().hash(_metadata),const DeepCollectionEquality().hash(_requiredVerificationIds),minConfirmedCount,maxParticipants,status,visibility,const DeepCollectionEquality().hash(_ticketTemplates),partner,const DeepCollectionEquality().hash(_entryGroups)]);
+
+@override
+String toString() {
+  return 'Party(id: $id, partnerId: $partnerId, title: $title, createdAt: $createdAt, updatedAt: $updatedAt, locationId: $locationId, location: $location, description: $description, imageUrls: $imageUrls, contactOptions: $contactOptions, metadata: $metadata, requiredVerificationIds: $requiredVerificationIds, minConfirmedCount: $minConfirmedCount, maxParticipants: $maxParticipants, status: $status, visibility: $visibility, ticketTemplates: $ticketTemplates, partner: $partner, entryGroups: $entryGroups)';
+}
+
+
 }
 
 /// @nodoc
 abstract mixin class _$PartyCopyWith<$Res> implements $PartyCopyWith<$Res> {
-  factory _$PartyCopyWith(_Party value, $Res Function(_Party) _then) =
-      __$PartyCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'partner_id') String partnerId,
-      String title,
-      @JsonKey(name: 'created_at') DateTime createdAt,
-      @JsonKey(name: 'updated_at') DateTime updatedAt,
-      @JsonKey(name: 'location_id') String? locationId,
-      @JsonKey(includeToJson: false) Location? location,
-      Map<String, dynamic>? description,
-      @JsonKey(name: 'image_urls') List<String> imageUrls,
-      @JsonKey(name: 'contact_options') Map<String, dynamic> contactOptions,
-      Map<String, dynamic> metadata,
-      @JsonKey(name: 'required_verification_ids')
-      List<String> requiredVerificationIds,
-      @JsonKey(name: 'min_confirmed_count') int minConfirmedCount,
-      @JsonKey(name: 'max_participants') int maxParticipants,
-      String status,
-      String visibility,
-      @JsonKey(includeToJson: false) List<TicketTemplate>? ticketTemplates,
-      @JsonKey(includeToJson: false) Partner? partner,
-      @JsonKey(name: 'entry_group_templates', includeToJson: false)
-      List<EntryGroupTemplate>? entryGroups});
+  factory _$PartyCopyWith(_Party value, $Res Function(_Party) _then) = __$PartyCopyWithImpl;
+@override @useResult
+$Res call({
+ String id,@JsonKey(name: 'partner_id') String partnerId, String title,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'location_id') String? locationId,@JsonKey(includeToJson: false) Location? location, Map<String, dynamic>? description,@JsonKey(name: 'image_urls') List<String> imageUrls,@JsonKey(name: 'contact_options') Map<String, dynamic> contactOptions, Map<String, dynamic> metadata,@JsonKey(name: 'required_verification_ids') List<String> requiredVerificationIds,@JsonKey(name: 'min_confirmed_count') int minConfirmedCount,@JsonKey(name: 'max_participants') int maxParticipants, String status, String visibility,@JsonKey(includeToJson: false) List<TicketTemplate>? ticketTemplates,@JsonKey(includeToJson: false) Partner? partner,@JsonKey(name: 'entry_group_templates', includeToJson: false) List<EntryGroupTemplate>? entryGroups
+});
 
-  @override
-  $LocationCopyWith<$Res>? get location;
-  @override
-  $PartnerCopyWith<$Res>? get partner;
+
+@override $LocationCopyWith<$Res>? get location;@override $PartnerCopyWith<$Res>? get partner;
+
 }
-
 /// @nodoc
-class __$PartyCopyWithImpl<$Res> implements _$PartyCopyWith<$Res> {
+class __$PartyCopyWithImpl<$Res>
+    implements _$PartyCopyWith<$Res> {
   __$PartyCopyWithImpl(this._self, this._then);
 
   final _Party _self;
   final $Res Function(_Party) _then;
 
-  /// Create a copy of Party
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? partnerId = null,
-    Object? title = null,
-    Object? createdAt = null,
-    Object? updatedAt = null,
-    Object? locationId = freezed,
-    Object? location = freezed,
-    Object? description = freezed,
-    Object? imageUrls = null,
-    Object? contactOptions = null,
-    Object? metadata = null,
-    Object? requiredVerificationIds = null,
-    Object? minConfirmedCount = null,
-    Object? maxParticipants = null,
-    Object? status = null,
-    Object? visibility = null,
-    Object? ticketTemplates = freezed,
-    Object? partner = freezed,
-    Object? entryGroups = freezed,
-  }) {
-    return _then(_Party(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      partnerId: null == partnerId
-          ? _self.partnerId
-          : partnerId // ignore: cast_nullable_to_non_nullable
-              as String,
-      title: null == title
-          ? _self.title
-          : title // ignore: cast_nullable_to_non_nullable
-              as String,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updatedAt: null == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      locationId: freezed == locationId
-          ? _self.locationId
-          : locationId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      location: freezed == location
-          ? _self.location
-          : location // ignore: cast_nullable_to_non_nullable
-              as Location?,
-      description: freezed == description
-          ? _self._description
-          : description // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>?,
-      imageUrls: null == imageUrls
-          ? _self._imageUrls
-          : imageUrls // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      contactOptions: null == contactOptions
-          ? _self._contactOptions
-          : contactOptions // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>,
-      metadata: null == metadata
-          ? _self._metadata
-          : metadata // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>,
-      requiredVerificationIds: null == requiredVerificationIds
-          ? _self._requiredVerificationIds
-          : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      minConfirmedCount: null == minConfirmedCount
-          ? _self.minConfirmedCount
-          : minConfirmedCount // ignore: cast_nullable_to_non_nullable
-              as int,
-      maxParticipants: null == maxParticipants
-          ? _self.maxParticipants
-          : maxParticipants // ignore: cast_nullable_to_non_nullable
-              as int,
-      status: null == status
-          ? _self.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as String,
-      visibility: null == visibility
-          ? _self.visibility
-          : visibility // ignore: cast_nullable_to_non_nullable
-              as String,
-      ticketTemplates: freezed == ticketTemplates
-          ? _self._ticketTemplates
-          : ticketTemplates // ignore: cast_nullable_to_non_nullable
-              as List<TicketTemplate>?,
-      partner: freezed == partner
-          ? _self.partner
-          : partner // ignore: cast_nullable_to_non_nullable
-              as Partner?,
-      entryGroups: freezed == entryGroups
-          ? _self._entryGroups
-          : entryGroups // ignore: cast_nullable_to_non_nullable
-              as List<EntryGroupTemplate>?,
-    ));
-  }
+/// Create a copy of Party
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? partnerId = null,Object? title = null,Object? createdAt = null,Object? updatedAt = null,Object? locationId = freezed,Object? location = freezed,Object? description = freezed,Object? imageUrls = null,Object? contactOptions = null,Object? metadata = null,Object? requiredVerificationIds = null,Object? minConfirmedCount = null,Object? maxParticipants = null,Object? status = null,Object? visibility = null,Object? ticketTemplates = freezed,Object? partner = freezed,Object? entryGroups = freezed,}) {
+  return _then(_Party(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,partnerId: null == partnerId ? _self.partnerId : partnerId // ignore: cast_nullable_to_non_nullable
+as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,locationId: freezed == locationId ? _self.locationId : locationId // ignore: cast_nullable_to_non_nullable
+as String?,location: freezed == location ? _self.location : location // ignore: cast_nullable_to_non_nullable
+as Location?,description: freezed == description ? _self._description : description // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,imageUrls: null == imageUrls ? _self._imageUrls : imageUrls // ignore: cast_nullable_to_non_nullable
+as List<String>,contactOptions: null == contactOptions ? _self._contactOptions : contactOptions // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>,metadata: null == metadata ? _self._metadata : metadata // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>,requiredVerificationIds: null == requiredVerificationIds ? _self._requiredVerificationIds : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
+as List<String>,minConfirmedCount: null == minConfirmedCount ? _self.minConfirmedCount : minConfirmedCount // ignore: cast_nullable_to_non_nullable
+as int,maxParticipants: null == maxParticipants ? _self.maxParticipants : maxParticipants // ignore: cast_nullable_to_non_nullable
+as int,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,visibility: null == visibility ? _self.visibility : visibility // ignore: cast_nullable_to_non_nullable
+as String,ticketTemplates: freezed == ticketTemplates ? _self._ticketTemplates : ticketTemplates // ignore: cast_nullable_to_non_nullable
+as List<TicketTemplate>?,partner: freezed == partner ? _self.partner : partner // ignore: cast_nullable_to_non_nullable
+as Partner?,entryGroups: freezed == entryGroups ? _self._entryGroups : entryGroups // ignore: cast_nullable_to_non_nullable
+as List<EntryGroupTemplate>?,
+  ));
+}
 
-  /// Create a copy of Party
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $LocationCopyWith<$Res>? get location {
+/// Create a copy of Party
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$LocationCopyWith<$Res>? get location {
     if (_self.location == null) {
-      return null;
-    }
-
-    return $LocationCopyWith<$Res>(_self.location!, (value) {
-      return _then(_self.copyWith(location: value));
-    });
+    return null;
   }
 
-  /// Create a copy of Party
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $PartnerCopyWith<$Res>? get partner {
+  return $LocationCopyWith<$Res>(_self.location!, (value) {
+    return _then(_self.copyWith(location: value));
+  });
+}/// Create a copy of Party
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$PartnerCopyWith<$Res>? get partner {
     if (_self.partner == null) {
-      return null;
-    }
-
-    return $PartnerCopyWith<$Res>(_self.partner!, (value) {
-      return _then(_self.copyWith(partner: value));
-    });
+    return null;
   }
+
+  return $PartnerCopyWith<$Res>(_self.partner!, (value) {
+    return _then(_self.copyWith(partner: value));
+  });
+}
 }
 
 // dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/party_entry_group.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/party_entry_group.freezed.dart
@@ -14,93 +14,47 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$EntryGroupTemplate {
-  String get id;
-  @JsonKey(name: 'party_id')
-  String get partyId;
-  String? get label;
-  String? get gender;
-  @JsonKey(name: 'birth_year_min')
-  int? get birthYearMin;
-  @JsonKey(name: 'birth_year_max')
-  int? get birthYearMax;
-  @JsonKey(name: 'required_verification_ids')
-  List<String> get requiredVerificationIds;
-  @JsonKey(name: 'created_at')
-  DateTime? get createdAt;
-  @JsonKey(name: 'updated_at')
-  DateTime? get updatedAt;
 
-  /// Create a copy of EntryGroupTemplate
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $EntryGroupTemplateCopyWith<EntryGroupTemplate> get copyWith =>
-      _$EntryGroupTemplateCopyWithImpl<EntryGroupTemplate>(
-          this as EntryGroupTemplate, _$identity);
+ String get id;@JsonKey(name: 'party_id') String get partyId; String? get label; String? get gender;@JsonKey(name: 'birth_year_min') int? get birthYearMin;@JsonKey(name: 'birth_year_max') int? get birthYearMax;@JsonKey(name: 'required_verification_ids') List<String> get requiredVerificationIds;@JsonKey(name: 'created_at') DateTime? get createdAt;@JsonKey(name: 'updated_at') DateTime? get updatedAt;
+/// Create a copy of EntryGroupTemplate
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EntryGroupTemplateCopyWith<EntryGroupTemplate> get copyWith => _$EntryGroupTemplateCopyWithImpl<EntryGroupTemplate>(this as EntryGroupTemplate, _$identity);
 
   /// Serializes this EntryGroupTemplate to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is EntryGroupTemplate &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.partyId, partyId) || other.partyId == partyId) &&
-            (identical(other.label, label) || other.label == label) &&
-            (identical(other.gender, gender) || other.gender == gender) &&
-            (identical(other.birthYearMin, birthYearMin) ||
-                other.birthYearMin == birthYearMin) &&
-            (identical(other.birthYearMax, birthYearMax) ||
-                other.birthYearMax == birthYearMax) &&
-            const DeepCollectionEquality().equals(
-                other.requiredVerificationIds, requiredVerificationIds) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      partyId,
-      label,
-      gender,
-      birthYearMin,
-      birthYearMax,
-      const DeepCollectionEquality().hash(requiredVerificationIds),
-      createdAt,
-      updatedAt);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EntryGroupTemplate&&(identical(other.id, id) || other.id == id)&&(identical(other.partyId, partyId) || other.partyId == partyId)&&(identical(other.label, label) || other.label == label)&&(identical(other.gender, gender) || other.gender == gender)&&(identical(other.birthYearMin, birthYearMin) || other.birthYearMin == birthYearMin)&&(identical(other.birthYearMax, birthYearMax) || other.birthYearMax == birthYearMax)&&const DeepCollectionEquality().equals(other.requiredVerificationIds, requiredVerificationIds)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+}
 
-  @override
-  String toString() {
-    return 'EntryGroupTemplate(id: $id, partyId: $partyId, label: $label, gender: $gender, birthYearMin: $birthYearMin, birthYearMax: $birthYearMax, requiredVerificationIds: $requiredVerificationIds, createdAt: $createdAt, updatedAt: $updatedAt)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,partyId,label,gender,birthYearMin,birthYearMax,const DeepCollectionEquality().hash(requiredVerificationIds),createdAt,updatedAt);
+
+@override
+String toString() {
+  return 'EntryGroupTemplate(id: $id, partyId: $partyId, label: $label, gender: $gender, birthYearMin: $birthYearMin, birthYearMax: $birthYearMax, requiredVerificationIds: $requiredVerificationIds, createdAt: $createdAt, updatedAt: $updatedAt)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $EntryGroupTemplateCopyWith<$Res> {
-  factory $EntryGroupTemplateCopyWith(
-          EntryGroupTemplate value, $Res Function(EntryGroupTemplate) _then) =
-      _$EntryGroupTemplateCopyWithImpl;
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'party_id') String partyId,
-      String? label,
-      String? gender,
-      @JsonKey(name: 'birth_year_min') int? birthYearMin,
-      @JsonKey(name: 'birth_year_max') int? birthYearMax,
-      @JsonKey(name: 'required_verification_ids')
-      List<String> requiredVerificationIds,
-      @JsonKey(name: 'created_at') DateTime? createdAt,
-      @JsonKey(name: 'updated_at') DateTime? updatedAt});
-}
+abstract mixin class $EntryGroupTemplateCopyWith<$Res>  {
+  factory $EntryGroupTemplateCopyWith(EntryGroupTemplate value, $Res Function(EntryGroupTemplate) _then) = _$EntryGroupTemplateCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(name: 'party_id') String partyId, String? label, String? gender,@JsonKey(name: 'birth_year_min') int? birthYearMin,@JsonKey(name: 'birth_year_max') int? birthYearMax,@JsonKey(name: 'required_verification_ids') List<String> requiredVerificationIds,@JsonKey(name: 'created_at') DateTime? createdAt,@JsonKey(name: 'updated_at') DateTime? updatedAt
+});
 
+
+
+
+}
 /// @nodoc
 class _$EntryGroupTemplateCopyWithImpl<$Res>
     implements $EntryGroupTemplateCopyWith<$Res> {
@@ -109,406 +63,219 @@ class _$EntryGroupTemplateCopyWithImpl<$Res>
   final EntryGroupTemplate _self;
   final $Res Function(EntryGroupTemplate) _then;
 
-  /// Create a copy of EntryGroupTemplate
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? partyId = null,
-    Object? label = freezed,
-    Object? gender = freezed,
-    Object? birthYearMin = freezed,
-    Object? birthYearMax = freezed,
-    Object? requiredVerificationIds = null,
-    Object? createdAt = freezed,
-    Object? updatedAt = freezed,
-  }) {
-    return _then(_self.copyWith(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      partyId: null == partyId
-          ? _self.partyId
-          : partyId // ignore: cast_nullable_to_non_nullable
-              as String,
-      label: freezed == label
-          ? _self.label
-          : label // ignore: cast_nullable_to_non_nullable
-              as String?,
-      gender: freezed == gender
-          ? _self.gender
-          : gender // ignore: cast_nullable_to_non_nullable
-              as String?,
-      birthYearMin: freezed == birthYearMin
-          ? _self.birthYearMin
-          : birthYearMin // ignore: cast_nullable_to_non_nullable
-              as int?,
-      birthYearMax: freezed == birthYearMax
-          ? _self.birthYearMax
-          : birthYearMax // ignore: cast_nullable_to_non_nullable
-              as int?,
-      requiredVerificationIds: null == requiredVerificationIds
-          ? _self.requiredVerificationIds
-          : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      createdAt: freezed == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      updatedAt: freezed == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-    ));
-  }
+/// Create a copy of EntryGroupTemplate
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? partyId = null,Object? label = freezed,Object? gender = freezed,Object? birthYearMin = freezed,Object? birthYearMax = freezed,Object? requiredVerificationIds = null,Object? createdAt = freezed,Object? updatedAt = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,label: freezed == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String?,gender: freezed == gender ? _self.gender : gender // ignore: cast_nullable_to_non_nullable
+as String?,birthYearMin: freezed == birthYearMin ? _self.birthYearMin : birthYearMin // ignore: cast_nullable_to_non_nullable
+as int?,birthYearMax: freezed == birthYearMax ? _self.birthYearMax : birthYearMax // ignore: cast_nullable_to_non_nullable
+as int?,requiredVerificationIds: null == requiredVerificationIds ? _self.requiredVerificationIds : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
+as List<String>,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [EntryGroupTemplate].
 extension EntryGroupTemplatePatterns on EntryGroupTemplate {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_EntryGroupTemplate value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _EntryGroupTemplate() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EntryGroupTemplate value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EntryGroupTemplate() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_EntryGroupTemplate value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntryGroupTemplate():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EntryGroupTemplate value)  $default,){
+final _that = this;
+switch (_that) {
+case _EntryGroupTemplate():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_EntryGroupTemplate value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntryGroupTemplate() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EntryGroupTemplate value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EntryGroupTemplate() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'party_id') String partyId,
-            String? label,
-            String? gender,
-            @JsonKey(name: 'birth_year_min') int? birthYearMin,
-            @JsonKey(name: 'birth_year_max') int? birthYearMax,
-            @JsonKey(name: 'required_verification_ids')
-            List<String> requiredVerificationIds,
-            @JsonKey(name: 'created_at') DateTime? createdAt,
-            @JsonKey(name: 'updated_at') DateTime? updatedAt)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _EntryGroupTemplate() when $default != null:
-        return $default(
-            _that.id,
-            _that.partyId,
-            _that.label,
-            _that.gender,
-            _that.birthYearMin,
-            _that.birthYearMax,
-            _that.requiredVerificationIds,
-            _that.createdAt,
-            _that.updatedAt);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'party_id')  String partyId,  String? label,  String? gender, @JsonKey(name: 'birth_year_min')  int? birthYearMin, @JsonKey(name: 'birth_year_max')  int? birthYearMax, @JsonKey(name: 'required_verification_ids')  List<String> requiredVerificationIds, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'updated_at')  DateTime? updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EntryGroupTemplate() when $default != null:
+return $default(_that.id,_that.partyId,_that.label,_that.gender,_that.birthYearMin,_that.birthYearMax,_that.requiredVerificationIds,_that.createdAt,_that.updatedAt);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'party_id') String partyId,
-            String? label,
-            String? gender,
-            @JsonKey(name: 'birth_year_min') int? birthYearMin,
-            @JsonKey(name: 'birth_year_max') int? birthYearMax,
-            @JsonKey(name: 'required_verification_ids')
-            List<String> requiredVerificationIds,
-            @JsonKey(name: 'created_at') DateTime? createdAt,
-            @JsonKey(name: 'updated_at') DateTime? updatedAt)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntryGroupTemplate():
-        return $default(
-            _that.id,
-            _that.partyId,
-            _that.label,
-            _that.gender,
-            _that.birthYearMin,
-            _that.birthYearMax,
-            _that.requiredVerificationIds,
-            _that.createdAt,
-            _that.updatedAt);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'party_id')  String partyId,  String? label,  String? gender, @JsonKey(name: 'birth_year_min')  int? birthYearMin, @JsonKey(name: 'birth_year_max')  int? birthYearMax, @JsonKey(name: 'required_verification_ids')  List<String> requiredVerificationIds, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'updated_at')  DateTime? updatedAt)  $default,) {final _that = this;
+switch (_that) {
+case _EntryGroupTemplate():
+return $default(_that.id,_that.partyId,_that.label,_that.gender,_that.birthYearMin,_that.birthYearMax,_that.requiredVerificationIds,_that.createdAt,_that.updatedAt);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String id,
-            @JsonKey(name: 'party_id') String partyId,
-            String? label,
-            String? gender,
-            @JsonKey(name: 'birth_year_min') int? birthYearMin,
-            @JsonKey(name: 'birth_year_max') int? birthYearMax,
-            @JsonKey(name: 'required_verification_ids')
-            List<String> requiredVerificationIds,
-            @JsonKey(name: 'created_at') DateTime? createdAt,
-            @JsonKey(name: 'updated_at') DateTime? updatedAt)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntryGroupTemplate() when $default != null:
-        return $default(
-            _that.id,
-            _that.partyId,
-            _that.label,
-            _that.gender,
-            _that.birthYearMin,
-            _that.birthYearMax,
-            _that.requiredVerificationIds,
-            _that.createdAt,
-            _that.updatedAt);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'party_id')  String partyId,  String? label,  String? gender, @JsonKey(name: 'birth_year_min')  int? birthYearMin, @JsonKey(name: 'birth_year_max')  int? birthYearMax, @JsonKey(name: 'required_verification_ids')  List<String> requiredVerificationIds, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'updated_at')  DateTime? updatedAt)?  $default,) {final _that = this;
+switch (_that) {
+case _EntryGroupTemplate() when $default != null:
+return $default(_that.id,_that.partyId,_that.label,_that.gender,_that.birthYearMin,_that.birthYearMax,_that.requiredVerificationIds,_that.createdAt,_that.updatedAt);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _EntryGroupTemplate implements EntryGroupTemplate {
-  const _EntryGroupTemplate(
-      {required this.id,
-      @JsonKey(name: 'party_id') required this.partyId,
-      this.label,
-      this.gender,
-      @JsonKey(name: 'birth_year_min') this.birthYearMin,
-      @JsonKey(name: 'birth_year_max') this.birthYearMax,
-      @JsonKey(name: 'required_verification_ids')
-      final List<String> requiredVerificationIds = const [],
-      @JsonKey(name: 'created_at') this.createdAt,
-      @JsonKey(name: 'updated_at') this.updatedAt})
-      : _requiredVerificationIds = requiredVerificationIds;
-  factory _EntryGroupTemplate.fromJson(Map<String, dynamic> json) =>
-      _$EntryGroupTemplateFromJson(json);
+  const _EntryGroupTemplate({required this.id, @JsonKey(name: 'party_id') required this.partyId, this.label, this.gender, @JsonKey(name: 'birth_year_min') this.birthYearMin, @JsonKey(name: 'birth_year_max') this.birthYearMax, @JsonKey(name: 'required_verification_ids') final  List<String> requiredVerificationIds = const [], @JsonKey(name: 'created_at') this.createdAt, @JsonKey(name: 'updated_at') this.updatedAt}): _requiredVerificationIds = requiredVerificationIds;
+  factory _EntryGroupTemplate.fromJson(Map<String, dynamic> json) => _$EntryGroupTemplateFromJson(json);
 
-  @override
-  final String id;
-  @override
-  @JsonKey(name: 'party_id')
-  final String partyId;
-  @override
-  final String? label;
-  @override
-  final String? gender;
-  @override
-  @JsonKey(name: 'birth_year_min')
-  final int? birthYearMin;
-  @override
-  @JsonKey(name: 'birth_year_max')
-  final int? birthYearMax;
-  final List<String> _requiredVerificationIds;
-  @override
-  @JsonKey(name: 'required_verification_ids')
-  List<String> get requiredVerificationIds {
-    if (_requiredVerificationIds is EqualUnmodifiableListView)
-      return _requiredVerificationIds;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_requiredVerificationIds);
-  }
+@override final  String id;
+@override@JsonKey(name: 'party_id') final  String partyId;
+@override final  String? label;
+@override final  String? gender;
+@override@JsonKey(name: 'birth_year_min') final  int? birthYearMin;
+@override@JsonKey(name: 'birth_year_max') final  int? birthYearMax;
+ final  List<String> _requiredVerificationIds;
+@override@JsonKey(name: 'required_verification_ids') List<String> get requiredVerificationIds {
+  if (_requiredVerificationIds is EqualUnmodifiableListView) return _requiredVerificationIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_requiredVerificationIds);
+}
 
-  @override
-  @JsonKey(name: 'created_at')
-  final DateTime? createdAt;
-  @override
-  @JsonKey(name: 'updated_at')
-  final DateTime? updatedAt;
+@override@JsonKey(name: 'created_at') final  DateTime? createdAt;
+@override@JsonKey(name: 'updated_at') final  DateTime? updatedAt;
 
-  /// Create a copy of EntryGroupTemplate
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$EntryGroupTemplateCopyWith<_EntryGroupTemplate> get copyWith =>
-      __$EntryGroupTemplateCopyWithImpl<_EntryGroupTemplate>(this, _$identity);
+/// Create a copy of EntryGroupTemplate
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EntryGroupTemplateCopyWith<_EntryGroupTemplate> get copyWith => __$EntryGroupTemplateCopyWithImpl<_EntryGroupTemplate>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$EntryGroupTemplateToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$EntryGroupTemplateToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _EntryGroupTemplate &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.partyId, partyId) || other.partyId == partyId) &&
-            (identical(other.label, label) || other.label == label) &&
-            (identical(other.gender, gender) || other.gender == gender) &&
-            (identical(other.birthYearMin, birthYearMin) ||
-                other.birthYearMin == birthYearMin) &&
-            (identical(other.birthYearMax, birthYearMax) ||
-                other.birthYearMax == birthYearMax) &&
-            const DeepCollectionEquality().equals(
-                other._requiredVerificationIds, _requiredVerificationIds) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EntryGroupTemplate&&(identical(other.id, id) || other.id == id)&&(identical(other.partyId, partyId) || other.partyId == partyId)&&(identical(other.label, label) || other.label == label)&&(identical(other.gender, gender) || other.gender == gender)&&(identical(other.birthYearMin, birthYearMin) || other.birthYearMin == birthYearMin)&&(identical(other.birthYearMax, birthYearMax) || other.birthYearMax == birthYearMax)&&const DeepCollectionEquality().equals(other._requiredVerificationIds, _requiredVerificationIds)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      partyId,
-      label,
-      gender,
-      birthYearMin,
-      birthYearMax,
-      const DeepCollectionEquality().hash(_requiredVerificationIds),
-      createdAt,
-      updatedAt);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,partyId,label,gender,birthYearMin,birthYearMax,const DeepCollectionEquality().hash(_requiredVerificationIds),createdAt,updatedAt);
 
-  @override
-  String toString() {
-    return 'EntryGroupTemplate(id: $id, partyId: $partyId, label: $label, gender: $gender, birthYearMin: $birthYearMin, birthYearMax: $birthYearMax, requiredVerificationIds: $requiredVerificationIds, createdAt: $createdAt, updatedAt: $updatedAt)';
-  }
+@override
+String toString() {
+  return 'EntryGroupTemplate(id: $id, partyId: $partyId, label: $label, gender: $gender, birthYearMin: $birthYearMin, birthYearMax: $birthYearMax, requiredVerificationIds: $requiredVerificationIds, createdAt: $createdAt, updatedAt: $updatedAt)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$EntryGroupTemplateCopyWith<$Res>
-    implements $EntryGroupTemplateCopyWith<$Res> {
-  factory _$EntryGroupTemplateCopyWith(
-          _EntryGroupTemplate value, $Res Function(_EntryGroupTemplate) _then) =
-      __$EntryGroupTemplateCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'party_id') String partyId,
-      String? label,
-      String? gender,
-      @JsonKey(name: 'birth_year_min') int? birthYearMin,
-      @JsonKey(name: 'birth_year_max') int? birthYearMax,
-      @JsonKey(name: 'required_verification_ids')
-      List<String> requiredVerificationIds,
-      @JsonKey(name: 'created_at') DateTime? createdAt,
-      @JsonKey(name: 'updated_at') DateTime? updatedAt});
-}
+abstract mixin class _$EntryGroupTemplateCopyWith<$Res> implements $EntryGroupTemplateCopyWith<$Res> {
+  factory _$EntryGroupTemplateCopyWith(_EntryGroupTemplate value, $Res Function(_EntryGroupTemplate) _then) = __$EntryGroupTemplateCopyWithImpl;
+@override @useResult
+$Res call({
+ String id,@JsonKey(name: 'party_id') String partyId, String? label, String? gender,@JsonKey(name: 'birth_year_min') int? birthYearMin,@JsonKey(name: 'birth_year_max') int? birthYearMax,@JsonKey(name: 'required_verification_ids') List<String> requiredVerificationIds,@JsonKey(name: 'created_at') DateTime? createdAt,@JsonKey(name: 'updated_at') DateTime? updatedAt
+});
 
+
+
+
+}
 /// @nodoc
 class __$EntryGroupTemplateCopyWithImpl<$Res>
     implements _$EntryGroupTemplateCopyWith<$Res> {
@@ -517,618 +284,317 @@ class __$EntryGroupTemplateCopyWithImpl<$Res>
   final _EntryGroupTemplate _self;
   final $Res Function(_EntryGroupTemplate) _then;
 
-  /// Create a copy of EntryGroupTemplate
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? partyId = null,
-    Object? label = freezed,
-    Object? gender = freezed,
-    Object? birthYearMin = freezed,
-    Object? birthYearMax = freezed,
-    Object? requiredVerificationIds = null,
-    Object? createdAt = freezed,
-    Object? updatedAt = freezed,
-  }) {
-    return _then(_EntryGroupTemplate(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      partyId: null == partyId
-          ? _self.partyId
-          : partyId // ignore: cast_nullable_to_non_nullable
-              as String,
-      label: freezed == label
-          ? _self.label
-          : label // ignore: cast_nullable_to_non_nullable
-              as String?,
-      gender: freezed == gender
-          ? _self.gender
-          : gender // ignore: cast_nullable_to_non_nullable
-              as String?,
-      birthYearMin: freezed == birthYearMin
-          ? _self.birthYearMin
-          : birthYearMin // ignore: cast_nullable_to_non_nullable
-              as int?,
-      birthYearMax: freezed == birthYearMax
-          ? _self.birthYearMax
-          : birthYearMax // ignore: cast_nullable_to_non_nullable
-              as int?,
-      requiredVerificationIds: null == requiredVerificationIds
-          ? _self._requiredVerificationIds
-          : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      createdAt: freezed == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      updatedAt: freezed == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-    ));
-  }
+/// Create a copy of EntryGroupTemplate
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? partyId = null,Object? label = freezed,Object? gender = freezed,Object? birthYearMin = freezed,Object? birthYearMax = freezed,Object? requiredVerificationIds = null,Object? createdAt = freezed,Object? updatedAt = freezed,}) {
+  return _then(_EntryGroupTemplate(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,label: freezed == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String?,gender: freezed == gender ? _self.gender : gender // ignore: cast_nullable_to_non_nullable
+as String?,birthYearMin: freezed == birthYearMin ? _self.birthYearMin : birthYearMin // ignore: cast_nullable_to_non_nullable
+as int?,birthYearMax: freezed == birthYearMax ? _self.birthYearMax : birthYearMax // ignore: cast_nullable_to_non_nullable
+as int?,requiredVerificationIds: null == requiredVerificationIds ? _self._requiredVerificationIds : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
+as List<String>,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
 }
+
+
+}
+
 
 /// @nodoc
 mixin _$EntryGroup {
-  String get id;
-  @JsonKey(name: 'event_id')
-  String get eventId;
-  String? get label;
-  String? get gender;
-  @JsonKey(name: 'birth_year_min')
-  int? get birthYearMin;
-  @JsonKey(name: 'birth_year_max')
-  int? get birthYearMax;
-  @JsonKey(name: 'required_verification_ids')
-  List<String> get requiredVerificationIds;
-  @JsonKey(name: 'created_at')
-  DateTime? get createdAt;
-  @JsonKey(name: 'updated_at')
-  DateTime? get updatedAt;
 
-  /// Create a copy of EntryGroup
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $EntryGroupCopyWith<EntryGroup> get copyWith =>
-      _$EntryGroupCopyWithImpl<EntryGroup>(this as EntryGroup, _$identity);
+ String get id;@JsonKey(name: 'event_id') String get eventId; String? get label; String? get gender;@JsonKey(name: 'birth_year_min') int? get birthYearMin;@JsonKey(name: 'birth_year_max') int? get birthYearMax;@JsonKey(name: 'required_verification_ids') List<String> get requiredVerificationIds;@JsonKey(name: 'created_at') DateTime? get createdAt;@JsonKey(name: 'updated_at') DateTime? get updatedAt;
+/// Create a copy of EntryGroup
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$EntryGroupCopyWith<EntryGroup> get copyWith => _$EntryGroupCopyWithImpl<EntryGroup>(this as EntryGroup, _$identity);
 
   /// Serializes this EntryGroup to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is EntryGroup &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.eventId, eventId) || other.eventId == eventId) &&
-            (identical(other.label, label) || other.label == label) &&
-            (identical(other.gender, gender) || other.gender == gender) &&
-            (identical(other.birthYearMin, birthYearMin) ||
-                other.birthYearMin == birthYearMin) &&
-            (identical(other.birthYearMax, birthYearMax) ||
-                other.birthYearMax == birthYearMax) &&
-            const DeepCollectionEquality().equals(
-                other.requiredVerificationIds, requiredVerificationIds) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      eventId,
-      label,
-      gender,
-      birthYearMin,
-      birthYearMax,
-      const DeepCollectionEquality().hash(requiredVerificationIds),
-      createdAt,
-      updatedAt);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EntryGroup&&(identical(other.id, id) || other.id == id)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.label, label) || other.label == label)&&(identical(other.gender, gender) || other.gender == gender)&&(identical(other.birthYearMin, birthYearMin) || other.birthYearMin == birthYearMin)&&(identical(other.birthYearMax, birthYearMax) || other.birthYearMax == birthYearMax)&&const DeepCollectionEquality().equals(other.requiredVerificationIds, requiredVerificationIds)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+}
 
-  @override
-  String toString() {
-    return 'EntryGroup(id: $id, eventId: $eventId, label: $label, gender: $gender, birthYearMin: $birthYearMin, birthYearMax: $birthYearMax, requiredVerificationIds: $requiredVerificationIds, createdAt: $createdAt, updatedAt: $updatedAt)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,eventId,label,gender,birthYearMin,birthYearMax,const DeepCollectionEquality().hash(requiredVerificationIds),createdAt,updatedAt);
+
+@override
+String toString() {
+  return 'EntryGroup(id: $id, eventId: $eventId, label: $label, gender: $gender, birthYearMin: $birthYearMin, birthYearMax: $birthYearMax, requiredVerificationIds: $requiredVerificationIds, createdAt: $createdAt, updatedAt: $updatedAt)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $EntryGroupCopyWith<$Res> {
-  factory $EntryGroupCopyWith(
-          EntryGroup value, $Res Function(EntryGroup) _then) =
-      _$EntryGroupCopyWithImpl;
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'event_id') String eventId,
-      String? label,
-      String? gender,
-      @JsonKey(name: 'birth_year_min') int? birthYearMin,
-      @JsonKey(name: 'birth_year_max') int? birthYearMax,
-      @JsonKey(name: 'required_verification_ids')
-      List<String> requiredVerificationIds,
-      @JsonKey(name: 'created_at') DateTime? createdAt,
-      @JsonKey(name: 'updated_at') DateTime? updatedAt});
-}
+abstract mixin class $EntryGroupCopyWith<$Res>  {
+  factory $EntryGroupCopyWith(EntryGroup value, $Res Function(EntryGroup) _then) = _$EntryGroupCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(name: 'event_id') String eventId, String? label, String? gender,@JsonKey(name: 'birth_year_min') int? birthYearMin,@JsonKey(name: 'birth_year_max') int? birthYearMax,@JsonKey(name: 'required_verification_ids') List<String> requiredVerificationIds,@JsonKey(name: 'created_at') DateTime? createdAt,@JsonKey(name: 'updated_at') DateTime? updatedAt
+});
 
+
+
+
+}
 /// @nodoc
-class _$EntryGroupCopyWithImpl<$Res> implements $EntryGroupCopyWith<$Res> {
+class _$EntryGroupCopyWithImpl<$Res>
+    implements $EntryGroupCopyWith<$Res> {
   _$EntryGroupCopyWithImpl(this._self, this._then);
 
   final EntryGroup _self;
   final $Res Function(EntryGroup) _then;
 
-  /// Create a copy of EntryGroup
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? eventId = null,
-    Object? label = freezed,
-    Object? gender = freezed,
-    Object? birthYearMin = freezed,
-    Object? birthYearMax = freezed,
-    Object? requiredVerificationIds = null,
-    Object? createdAt = freezed,
-    Object? updatedAt = freezed,
-  }) {
-    return _then(_self.copyWith(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      eventId: null == eventId
-          ? _self.eventId
-          : eventId // ignore: cast_nullable_to_non_nullable
-              as String,
-      label: freezed == label
-          ? _self.label
-          : label // ignore: cast_nullable_to_non_nullable
-              as String?,
-      gender: freezed == gender
-          ? _self.gender
-          : gender // ignore: cast_nullable_to_non_nullable
-              as String?,
-      birthYearMin: freezed == birthYearMin
-          ? _self.birthYearMin
-          : birthYearMin // ignore: cast_nullable_to_non_nullable
-              as int?,
-      birthYearMax: freezed == birthYearMax
-          ? _self.birthYearMax
-          : birthYearMax // ignore: cast_nullable_to_non_nullable
-              as int?,
-      requiredVerificationIds: null == requiredVerificationIds
-          ? _self.requiredVerificationIds
-          : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      createdAt: freezed == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      updatedAt: freezed == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-    ));
-  }
+/// Create a copy of EntryGroup
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? eventId = null,Object? label = freezed,Object? gender = freezed,Object? birthYearMin = freezed,Object? birthYearMax = freezed,Object? requiredVerificationIds = null,Object? createdAt = freezed,Object? updatedAt = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String,label: freezed == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String?,gender: freezed == gender ? _self.gender : gender // ignore: cast_nullable_to_non_nullable
+as String?,birthYearMin: freezed == birthYearMin ? _self.birthYearMin : birthYearMin // ignore: cast_nullable_to_non_nullable
+as int?,birthYearMax: freezed == birthYearMax ? _self.birthYearMax : birthYearMax // ignore: cast_nullable_to_non_nullable
+as int?,requiredVerificationIds: null == requiredVerificationIds ? _self.requiredVerificationIds : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
+as List<String>,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [EntryGroup].
 extension EntryGroupPatterns on EntryGroup {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_EntryGroup value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _EntryGroup() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _EntryGroup value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _EntryGroup() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_EntryGroup value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntryGroup():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _EntryGroup value)  $default,){
+final _that = this;
+switch (_that) {
+case _EntryGroup():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_EntryGroup value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntryGroup() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _EntryGroup value)?  $default,){
+final _that = this;
+switch (_that) {
+case _EntryGroup() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'event_id') String eventId,
-            String? label,
-            String? gender,
-            @JsonKey(name: 'birth_year_min') int? birthYearMin,
-            @JsonKey(name: 'birth_year_max') int? birthYearMax,
-            @JsonKey(name: 'required_verification_ids')
-            List<String> requiredVerificationIds,
-            @JsonKey(name: 'created_at') DateTime? createdAt,
-            @JsonKey(name: 'updated_at') DateTime? updatedAt)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _EntryGroup() when $default != null:
-        return $default(
-            _that.id,
-            _that.eventId,
-            _that.label,
-            _that.gender,
-            _that.birthYearMin,
-            _that.birthYearMax,
-            _that.requiredVerificationIds,
-            _that.createdAt,
-            _that.updatedAt);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'event_id')  String eventId,  String? label,  String? gender, @JsonKey(name: 'birth_year_min')  int? birthYearMin, @JsonKey(name: 'birth_year_max')  int? birthYearMax, @JsonKey(name: 'required_verification_ids')  List<String> requiredVerificationIds, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'updated_at')  DateTime? updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _EntryGroup() when $default != null:
+return $default(_that.id,_that.eventId,_that.label,_that.gender,_that.birthYearMin,_that.birthYearMax,_that.requiredVerificationIds,_that.createdAt,_that.updatedAt);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'event_id') String eventId,
-            String? label,
-            String? gender,
-            @JsonKey(name: 'birth_year_min') int? birthYearMin,
-            @JsonKey(name: 'birth_year_max') int? birthYearMax,
-            @JsonKey(name: 'required_verification_ids')
-            List<String> requiredVerificationIds,
-            @JsonKey(name: 'created_at') DateTime? createdAt,
-            @JsonKey(name: 'updated_at') DateTime? updatedAt)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntryGroup():
-        return $default(
-            _that.id,
-            _that.eventId,
-            _that.label,
-            _that.gender,
-            _that.birthYearMin,
-            _that.birthYearMax,
-            _that.requiredVerificationIds,
-            _that.createdAt,
-            _that.updatedAt);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'event_id')  String eventId,  String? label,  String? gender, @JsonKey(name: 'birth_year_min')  int? birthYearMin, @JsonKey(name: 'birth_year_max')  int? birthYearMax, @JsonKey(name: 'required_verification_ids')  List<String> requiredVerificationIds, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'updated_at')  DateTime? updatedAt)  $default,) {final _that = this;
+switch (_that) {
+case _EntryGroup():
+return $default(_that.id,_that.eventId,_that.label,_that.gender,_that.birthYearMin,_that.birthYearMax,_that.requiredVerificationIds,_that.createdAt,_that.updatedAt);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String id,
-            @JsonKey(name: 'event_id') String eventId,
-            String? label,
-            String? gender,
-            @JsonKey(name: 'birth_year_min') int? birthYearMin,
-            @JsonKey(name: 'birth_year_max') int? birthYearMax,
-            @JsonKey(name: 'required_verification_ids')
-            List<String> requiredVerificationIds,
-            @JsonKey(name: 'created_at') DateTime? createdAt,
-            @JsonKey(name: 'updated_at') DateTime? updatedAt)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _EntryGroup() when $default != null:
-        return $default(
-            _that.id,
-            _that.eventId,
-            _that.label,
-            _that.gender,
-            _that.birthYearMin,
-            _that.birthYearMax,
-            _that.requiredVerificationIds,
-            _that.createdAt,
-            _that.updatedAt);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'event_id')  String eventId,  String? label,  String? gender, @JsonKey(name: 'birth_year_min')  int? birthYearMin, @JsonKey(name: 'birth_year_max')  int? birthYearMax, @JsonKey(name: 'required_verification_ids')  List<String> requiredVerificationIds, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'updated_at')  DateTime? updatedAt)?  $default,) {final _that = this;
+switch (_that) {
+case _EntryGroup() when $default != null:
+return $default(_that.id,_that.eventId,_that.label,_that.gender,_that.birthYearMin,_that.birthYearMax,_that.requiredVerificationIds,_that.createdAt,_that.updatedAt);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _EntryGroup implements EntryGroup {
-  const _EntryGroup(
-      {required this.id,
-      @JsonKey(name: 'event_id') required this.eventId,
-      this.label,
-      this.gender,
-      @JsonKey(name: 'birth_year_min') this.birthYearMin,
-      @JsonKey(name: 'birth_year_max') this.birthYearMax,
-      @JsonKey(name: 'required_verification_ids')
-      final List<String> requiredVerificationIds = const [],
-      @JsonKey(name: 'created_at') this.createdAt,
-      @JsonKey(name: 'updated_at') this.updatedAt})
-      : _requiredVerificationIds = requiredVerificationIds;
-  factory _EntryGroup.fromJson(Map<String, dynamic> json) =>
-      _$EntryGroupFromJson(json);
+  const _EntryGroup({required this.id, @JsonKey(name: 'event_id') required this.eventId, this.label, this.gender, @JsonKey(name: 'birth_year_min') this.birthYearMin, @JsonKey(name: 'birth_year_max') this.birthYearMax, @JsonKey(name: 'required_verification_ids') final  List<String> requiredVerificationIds = const [], @JsonKey(name: 'created_at') this.createdAt, @JsonKey(name: 'updated_at') this.updatedAt}): _requiredVerificationIds = requiredVerificationIds;
+  factory _EntryGroup.fromJson(Map<String, dynamic> json) => _$EntryGroupFromJson(json);
 
-  @override
-  final String id;
-  @override
-  @JsonKey(name: 'event_id')
-  final String eventId;
-  @override
-  final String? label;
-  @override
-  final String? gender;
-  @override
-  @JsonKey(name: 'birth_year_min')
-  final int? birthYearMin;
-  @override
-  @JsonKey(name: 'birth_year_max')
-  final int? birthYearMax;
-  final List<String> _requiredVerificationIds;
-  @override
-  @JsonKey(name: 'required_verification_ids')
-  List<String> get requiredVerificationIds {
-    if (_requiredVerificationIds is EqualUnmodifiableListView)
-      return _requiredVerificationIds;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_requiredVerificationIds);
-  }
+@override final  String id;
+@override@JsonKey(name: 'event_id') final  String eventId;
+@override final  String? label;
+@override final  String? gender;
+@override@JsonKey(name: 'birth_year_min') final  int? birthYearMin;
+@override@JsonKey(name: 'birth_year_max') final  int? birthYearMax;
+ final  List<String> _requiredVerificationIds;
+@override@JsonKey(name: 'required_verification_ids') List<String> get requiredVerificationIds {
+  if (_requiredVerificationIds is EqualUnmodifiableListView) return _requiredVerificationIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_requiredVerificationIds);
+}
 
-  @override
-  @JsonKey(name: 'created_at')
-  final DateTime? createdAt;
-  @override
-  @JsonKey(name: 'updated_at')
-  final DateTime? updatedAt;
+@override@JsonKey(name: 'created_at') final  DateTime? createdAt;
+@override@JsonKey(name: 'updated_at') final  DateTime? updatedAt;
 
-  /// Create a copy of EntryGroup
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$EntryGroupCopyWith<_EntryGroup> get copyWith =>
-      __$EntryGroupCopyWithImpl<_EntryGroup>(this, _$identity);
+/// Create a copy of EntryGroup
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$EntryGroupCopyWith<_EntryGroup> get copyWith => __$EntryGroupCopyWithImpl<_EntryGroup>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$EntryGroupToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$EntryGroupToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _EntryGroup &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.eventId, eventId) || other.eventId == eventId) &&
-            (identical(other.label, label) || other.label == label) &&
-            (identical(other.gender, gender) || other.gender == gender) &&
-            (identical(other.birthYearMin, birthYearMin) ||
-                other.birthYearMin == birthYearMin) &&
-            (identical(other.birthYearMax, birthYearMax) ||
-                other.birthYearMax == birthYearMax) &&
-            const DeepCollectionEquality().equals(
-                other._requiredVerificationIds, _requiredVerificationIds) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _EntryGroup&&(identical(other.id, id) || other.id == id)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.label, label) || other.label == label)&&(identical(other.gender, gender) || other.gender == gender)&&(identical(other.birthYearMin, birthYearMin) || other.birthYearMin == birthYearMin)&&(identical(other.birthYearMax, birthYearMax) || other.birthYearMax == birthYearMax)&&const DeepCollectionEquality().equals(other._requiredVerificationIds, _requiredVerificationIds)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      eventId,
-      label,
-      gender,
-      birthYearMin,
-      birthYearMax,
-      const DeepCollectionEquality().hash(_requiredVerificationIds),
-      createdAt,
-      updatedAt);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,eventId,label,gender,birthYearMin,birthYearMax,const DeepCollectionEquality().hash(_requiredVerificationIds),createdAt,updatedAt);
 
-  @override
-  String toString() {
-    return 'EntryGroup(id: $id, eventId: $eventId, label: $label, gender: $gender, birthYearMin: $birthYearMin, birthYearMax: $birthYearMax, requiredVerificationIds: $requiredVerificationIds, createdAt: $createdAt, updatedAt: $updatedAt)';
-  }
+@override
+String toString() {
+  return 'EntryGroup(id: $id, eventId: $eventId, label: $label, gender: $gender, birthYearMin: $birthYearMin, birthYearMax: $birthYearMax, requiredVerificationIds: $requiredVerificationIds, createdAt: $createdAt, updatedAt: $updatedAt)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$EntryGroupCopyWith<$Res>
-    implements $EntryGroupCopyWith<$Res> {
-  factory _$EntryGroupCopyWith(
-          _EntryGroup value, $Res Function(_EntryGroup) _then) =
-      __$EntryGroupCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'event_id') String eventId,
-      String? label,
-      String? gender,
-      @JsonKey(name: 'birth_year_min') int? birthYearMin,
-      @JsonKey(name: 'birth_year_max') int? birthYearMax,
-      @JsonKey(name: 'required_verification_ids')
-      List<String> requiredVerificationIds,
-      @JsonKey(name: 'created_at') DateTime? createdAt,
-      @JsonKey(name: 'updated_at') DateTime? updatedAt});
-}
+abstract mixin class _$EntryGroupCopyWith<$Res> implements $EntryGroupCopyWith<$Res> {
+  factory _$EntryGroupCopyWith(_EntryGroup value, $Res Function(_EntryGroup) _then) = __$EntryGroupCopyWithImpl;
+@override @useResult
+$Res call({
+ String id,@JsonKey(name: 'event_id') String eventId, String? label, String? gender,@JsonKey(name: 'birth_year_min') int? birthYearMin,@JsonKey(name: 'birth_year_max') int? birthYearMax,@JsonKey(name: 'required_verification_ids') List<String> requiredVerificationIds,@JsonKey(name: 'created_at') DateTime? createdAt,@JsonKey(name: 'updated_at') DateTime? updatedAt
+});
 
+
+
+
+}
 /// @nodoc
-class __$EntryGroupCopyWithImpl<$Res> implements _$EntryGroupCopyWith<$Res> {
+class __$EntryGroupCopyWithImpl<$Res>
+    implements _$EntryGroupCopyWith<$Res> {
   __$EntryGroupCopyWithImpl(this._self, this._then);
 
   final _EntryGroup _self;
   final $Res Function(_EntryGroup) _then;
 
-  /// Create a copy of EntryGroup
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? eventId = null,
-    Object? label = freezed,
-    Object? gender = freezed,
-    Object? birthYearMin = freezed,
-    Object? birthYearMax = freezed,
-    Object? requiredVerificationIds = null,
-    Object? createdAt = freezed,
-    Object? updatedAt = freezed,
-  }) {
-    return _then(_EntryGroup(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      eventId: null == eventId
-          ? _self.eventId
-          : eventId // ignore: cast_nullable_to_non_nullable
-              as String,
-      label: freezed == label
-          ? _self.label
-          : label // ignore: cast_nullable_to_non_nullable
-              as String?,
-      gender: freezed == gender
-          ? _self.gender
-          : gender // ignore: cast_nullable_to_non_nullable
-              as String?,
-      birthYearMin: freezed == birthYearMin
-          ? _self.birthYearMin
-          : birthYearMin // ignore: cast_nullable_to_non_nullable
-              as int?,
-      birthYearMax: freezed == birthYearMax
-          ? _self.birthYearMax
-          : birthYearMax // ignore: cast_nullable_to_non_nullable
-              as int?,
-      requiredVerificationIds: null == requiredVerificationIds
-          ? _self._requiredVerificationIds
-          : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      createdAt: freezed == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      updatedAt: freezed == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-    ));
-  }
+/// Create a copy of EntryGroup
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? eventId = null,Object? label = freezed,Object? gender = freezed,Object? birthYearMin = freezed,Object? birthYearMax = freezed,Object? requiredVerificationIds = null,Object? createdAt = freezed,Object? updatedAt = freezed,}) {
+  return _then(_EntryGroup(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String,label: freezed == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String?,gender: freezed == gender ? _self.gender : gender // ignore: cast_nullable_to_non_nullable
+as String?,birthYearMin: freezed == birthYearMin ? _self.birthYearMin : birthYearMin // ignore: cast_nullable_to_non_nullable
+as int?,birthYearMax: freezed == birthYearMax ? _self.birthYearMax : birthYearMax // ignore: cast_nullable_to_non_nullable
+as int?,requiredVerificationIds: null == requiredVerificationIds ? _self._requiredVerificationIds : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
+as List<String>,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/report_detail.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/report_detail.freezed.dart
@@ -14,432 +14,272 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$ReportDetail {
-  /// Unique identifier.
-  String get id;
 
-  /// ID of the reporting user.
-  @JsonKey(name: 'user_id')
-  String get userId;
-
-  /// ID of the reported target.
-  @JsonKey(name: 'target_id')
-  String get targetId;
-
-  /// Type of the reported target.
-  @JsonKey(name: 'target_type')
-  SocialTargetType get targetType;
-
-  /// Reason category for the report.
-  String get reason;
-
-  /// When the report was created.
-  @JsonKey(name: 'created_at')
-  DateTime get createdAt;
-
-  /// Optional free-text description.
-  String? get description;
-
-  /// Create a copy of ReportDetail
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $ReportDetailCopyWith<ReportDetail> get copyWith =>
-      _$ReportDetailCopyWithImpl<ReportDetail>(
-          this as ReportDetail, _$identity);
+/// Unique identifier.
+ String get id;/// ID of the reporting user.
+@JsonKey(name: 'user_id') String get userId;/// ID of the reported target.
+@JsonKey(name: 'target_id') String get targetId;/// Type of the reported target.
+@JsonKey(name: 'target_type') SocialTargetType get targetType;/// Reason category for the report.
+ String get reason;/// When the report was created.
+@JsonKey(name: 'created_at') DateTime get createdAt;/// Optional free-text description.
+ String? get description;
+/// Create a copy of ReportDetail
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ReportDetailCopyWith<ReportDetail> get copyWith => _$ReportDetailCopyWithImpl<ReportDetail>(this as ReportDetail, _$identity);
 
   /// Serializes this ReportDetail to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is ReportDetail &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.targetId, targetId) ||
-                other.targetId == targetId) &&
-            (identical(other.targetType, targetType) ||
-                other.targetType == targetType) &&
-            (identical(other.reason, reason) || other.reason == reason) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.description, description) ||
-                other.description == description));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, id, userId, targetId, targetType,
-      reason, createdAt, description);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ReportDetail&&(identical(other.id, id) || other.id == id)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.targetId, targetId) || other.targetId == targetId)&&(identical(other.targetType, targetType) || other.targetType == targetType)&&(identical(other.reason, reason) || other.reason == reason)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.description, description) || other.description == description));
+}
 
-  @override
-  String toString() {
-    return 'ReportDetail(id: $id, userId: $userId, targetId: $targetId, targetType: $targetType, reason: $reason, createdAt: $createdAt, description: $description)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,userId,targetId,targetType,reason,createdAt,description);
+
+@override
+String toString() {
+  return 'ReportDetail(id: $id, userId: $userId, targetId: $targetId, targetType: $targetType, reason: $reason, createdAt: $createdAt, description: $description)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $ReportDetailCopyWith<$Res> {
-  factory $ReportDetailCopyWith(
-          ReportDetail value, $Res Function(ReportDetail) _then) =
-      _$ReportDetailCopyWithImpl;
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'user_id') String userId,
-      @JsonKey(name: 'target_id') String targetId,
-      @JsonKey(name: 'target_type') SocialTargetType targetType,
-      String reason,
-      @JsonKey(name: 'created_at') DateTime createdAt,
-      String? description});
-}
+abstract mixin class $ReportDetailCopyWith<$Res>  {
+  factory $ReportDetailCopyWith(ReportDetail value, $Res Function(ReportDetail) _then) = _$ReportDetailCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(name: 'user_id') String userId,@JsonKey(name: 'target_id') String targetId,@JsonKey(name: 'target_type') SocialTargetType targetType, String reason,@JsonKey(name: 'created_at') DateTime createdAt, String? description
+});
 
+
+
+
+}
 /// @nodoc
-class _$ReportDetailCopyWithImpl<$Res> implements $ReportDetailCopyWith<$Res> {
+class _$ReportDetailCopyWithImpl<$Res>
+    implements $ReportDetailCopyWith<$Res> {
   _$ReportDetailCopyWithImpl(this._self, this._then);
 
   final ReportDetail _self;
   final $Res Function(ReportDetail) _then;
 
-  /// Create a copy of ReportDetail
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? userId = null,
-    Object? targetId = null,
-    Object? targetType = null,
-    Object? reason = null,
-    Object? createdAt = null,
-    Object? description = freezed,
-  }) {
-    return _then(_self.copyWith(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      userId: null == userId
-          ? _self.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      targetId: null == targetId
-          ? _self.targetId
-          : targetId // ignore: cast_nullable_to_non_nullable
-              as String,
-      targetType: null == targetType
-          ? _self.targetType
-          : targetType // ignore: cast_nullable_to_non_nullable
-              as SocialTargetType,
-      reason: null == reason
-          ? _self.reason
-          : reason // ignore: cast_nullable_to_non_nullable
-              as String,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      description: freezed == description
-          ? _self.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Create a copy of ReportDetail
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? userId = null,Object? targetId = null,Object? targetType = null,Object? reason = null,Object? createdAt = null,Object? description = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,targetId: null == targetId ? _self.targetId : targetId // ignore: cast_nullable_to_non_nullable
+as String,targetType: null == targetType ? _self.targetType : targetType // ignore: cast_nullable_to_non_nullable
+as SocialTargetType,reason: null == reason ? _self.reason : reason // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [ReportDetail].
 extension ReportDetailPatterns on ReportDetail {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_ReportDetail value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _ReportDetail() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _ReportDetail value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _ReportDetail() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_ReportDetail value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _ReportDetail():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _ReportDetail value)  $default,){
+final _that = this;
+switch (_that) {
+case _ReportDetail():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_ReportDetail value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _ReportDetail() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _ReportDetail value)?  $default,){
+final _that = this;
+switch (_that) {
+case _ReportDetail() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'user_id') String userId,
-            @JsonKey(name: 'target_id') String targetId,
-            @JsonKey(name: 'target_type') SocialTargetType targetType,
-            String reason,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            String? description)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _ReportDetail() when $default != null:
-        return $default(_that.id, _that.userId, _that.targetId,
-            _that.targetType, _that.reason, _that.createdAt, _that.description);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'target_id')  String targetId, @JsonKey(name: 'target_type')  SocialTargetType targetType,  String reason, @JsonKey(name: 'created_at')  DateTime createdAt,  String? description)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _ReportDetail() when $default != null:
+return $default(_that.id,_that.userId,_that.targetId,_that.targetType,_that.reason,_that.createdAt,_that.description);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'user_id') String userId,
-            @JsonKey(name: 'target_id') String targetId,
-            @JsonKey(name: 'target_type') SocialTargetType targetType,
-            String reason,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            String? description)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _ReportDetail():
-        return $default(_that.id, _that.userId, _that.targetId,
-            _that.targetType, _that.reason, _that.createdAt, _that.description);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'target_id')  String targetId, @JsonKey(name: 'target_type')  SocialTargetType targetType,  String reason, @JsonKey(name: 'created_at')  DateTime createdAt,  String? description)  $default,) {final _that = this;
+switch (_that) {
+case _ReportDetail():
+return $default(_that.id,_that.userId,_that.targetId,_that.targetType,_that.reason,_that.createdAt,_that.description);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String id,
-            @JsonKey(name: 'user_id') String userId,
-            @JsonKey(name: 'target_id') String targetId,
-            @JsonKey(name: 'target_type') SocialTargetType targetType,
-            String reason,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            String? description)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _ReportDetail() when $default != null:
-        return $default(_that.id, _that.userId, _that.targetId,
-            _that.targetType, _that.reason, _that.createdAt, _that.description);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'target_id')  String targetId, @JsonKey(name: 'target_type')  SocialTargetType targetType,  String reason, @JsonKey(name: 'created_at')  DateTime createdAt,  String? description)?  $default,) {final _that = this;
+switch (_that) {
+case _ReportDetail() when $default != null:
+return $default(_that.id,_that.userId,_that.targetId,_that.targetType,_that.reason,_that.createdAt,_that.description);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _ReportDetail implements ReportDetail {
-  const _ReportDetail(
-      {required this.id,
-      @JsonKey(name: 'user_id') required this.userId,
-      @JsonKey(name: 'target_id') required this.targetId,
-      @JsonKey(name: 'target_type') required this.targetType,
-      required this.reason,
-      @JsonKey(name: 'created_at') required this.createdAt,
-      this.description});
-  factory _ReportDetail.fromJson(Map<String, dynamic> json) =>
-      _$ReportDetailFromJson(json);
+  const _ReportDetail({required this.id, @JsonKey(name: 'user_id') required this.userId, @JsonKey(name: 'target_id') required this.targetId, @JsonKey(name: 'target_type') required this.targetType, required this.reason, @JsonKey(name: 'created_at') required this.createdAt, this.description});
+  factory _ReportDetail.fromJson(Map<String, dynamic> json) => _$ReportDetailFromJson(json);
 
-  /// Unique identifier.
-  @override
-  final String id;
+/// Unique identifier.
+@override final  String id;
+/// ID of the reporting user.
+@override@JsonKey(name: 'user_id') final  String userId;
+/// ID of the reported target.
+@override@JsonKey(name: 'target_id') final  String targetId;
+/// Type of the reported target.
+@override@JsonKey(name: 'target_type') final  SocialTargetType targetType;
+/// Reason category for the report.
+@override final  String reason;
+/// When the report was created.
+@override@JsonKey(name: 'created_at') final  DateTime createdAt;
+/// Optional free-text description.
+@override final  String? description;
 
-  /// ID of the reporting user.
-  @override
-  @JsonKey(name: 'user_id')
-  final String userId;
+/// Create a copy of ReportDetail
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$ReportDetailCopyWith<_ReportDetail> get copyWith => __$ReportDetailCopyWithImpl<_ReportDetail>(this, _$identity);
 
-  /// ID of the reported target.
-  @override
-  @JsonKey(name: 'target_id')
-  final String targetId;
+@override
+Map<String, dynamic> toJson() {
+  return _$ReportDetailToJson(this, );
+}
 
-  /// Type of the reported target.
-  @override
-  @JsonKey(name: 'target_type')
-  final SocialTargetType targetType;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ReportDetail&&(identical(other.id, id) || other.id == id)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.targetId, targetId) || other.targetId == targetId)&&(identical(other.targetType, targetType) || other.targetType == targetType)&&(identical(other.reason, reason) || other.reason == reason)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.description, description) || other.description == description));
+}
 
-  /// Reason category for the report.
-  @override
-  final String reason;
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,userId,targetId,targetType,reason,createdAt,description);
 
-  /// When the report was created.
-  @override
-  @JsonKey(name: 'created_at')
-  final DateTime createdAt;
+@override
+String toString() {
+  return 'ReportDetail(id: $id, userId: $userId, targetId: $targetId, targetType: $targetType, reason: $reason, createdAt: $createdAt, description: $description)';
+}
 
-  /// Optional free-text description.
-  @override
-  final String? description;
 
-  /// Create a copy of ReportDetail
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$ReportDetailCopyWith<_ReportDetail> get copyWith =>
-      __$ReportDetailCopyWithImpl<_ReportDetail>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$ReportDetailToJson(
-      this,
-    );
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _ReportDetail &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.targetId, targetId) ||
-                other.targetId == targetId) &&
-            (identical(other.targetType, targetType) ||
-                other.targetType == targetType) &&
-            (identical(other.reason, reason) || other.reason == reason) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.description, description) ||
-                other.description == description));
-  }
-
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, id, userId, targetId, targetType,
-      reason, createdAt, description);
-
-  @override
-  String toString() {
-    return 'ReportDetail(id: $id, userId: $userId, targetId: $targetId, targetType: $targetType, reason: $reason, createdAt: $createdAt, description: $description)';
-  }
 }
 
 /// @nodoc
-abstract mixin class _$ReportDetailCopyWith<$Res>
-    implements $ReportDetailCopyWith<$Res> {
-  factory _$ReportDetailCopyWith(
-          _ReportDetail value, $Res Function(_ReportDetail) _then) =
-      __$ReportDetailCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'user_id') String userId,
-      @JsonKey(name: 'target_id') String targetId,
-      @JsonKey(name: 'target_type') SocialTargetType targetType,
-      String reason,
-      @JsonKey(name: 'created_at') DateTime createdAt,
-      String? description});
-}
+abstract mixin class _$ReportDetailCopyWith<$Res> implements $ReportDetailCopyWith<$Res> {
+  factory _$ReportDetailCopyWith(_ReportDetail value, $Res Function(_ReportDetail) _then) = __$ReportDetailCopyWithImpl;
+@override @useResult
+$Res call({
+ String id,@JsonKey(name: 'user_id') String userId,@JsonKey(name: 'target_id') String targetId,@JsonKey(name: 'target_type') SocialTargetType targetType, String reason,@JsonKey(name: 'created_at') DateTime createdAt, String? description
+});
 
+
+
+
+}
 /// @nodoc
 class __$ReportDetailCopyWithImpl<$Res>
     implements _$ReportDetailCopyWith<$Res> {
@@ -448,50 +288,22 @@ class __$ReportDetailCopyWithImpl<$Res>
   final _ReportDetail _self;
   final $Res Function(_ReportDetail) _then;
 
-  /// Create a copy of ReportDetail
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? userId = null,
-    Object? targetId = null,
-    Object? targetType = null,
-    Object? reason = null,
-    Object? createdAt = null,
-    Object? description = freezed,
-  }) {
-    return _then(_ReportDetail(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      userId: null == userId
-          ? _self.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      targetId: null == targetId
-          ? _self.targetId
-          : targetId // ignore: cast_nullable_to_non_nullable
-              as String,
-      targetType: null == targetType
-          ? _self.targetType
-          : targetType // ignore: cast_nullable_to_non_nullable
-              as SocialTargetType,
-      reason: null == reason
-          ? _self.reason
-          : reason // ignore: cast_nullable_to_non_nullable
-              as String,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      description: freezed == description
-          ? _self.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Create a copy of ReportDetail
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? userId = null,Object? targetId = null,Object? targetType = null,Object? reason = null,Object? createdAt = null,Object? description = freezed,}) {
+  return _then(_ReportDetail(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,targetId: null == targetId ? _self.targetId : targetId // ignore: cast_nullable_to_non_nullable
+as String,targetType: null == targetType ? _self.targetType : targetType // ignore: cast_nullable_to_non_nullable
+as SocialTargetType,reason: null == reason ? _self.reason : reason // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/social_interaction.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/social_interaction.freezed.dart
@@ -14,64 +14,47 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$SocialInteraction {
-  String get userId;
-  String get targetId;
-  SocialTargetType get targetType;
-  SocialInteractionType get interactionType;
-  DateTime? get createdAt;
 
-  /// Create a copy of SocialInteraction
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $SocialInteractionCopyWith<SocialInteraction> get copyWith =>
-      _$SocialInteractionCopyWithImpl<SocialInteraction>(
-          this as SocialInteraction, _$identity);
+ String get userId; String get targetId; SocialTargetType get targetType; SocialInteractionType get interactionType; DateTime? get createdAt;
+/// Create a copy of SocialInteraction
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SocialInteractionCopyWith<SocialInteraction> get copyWith => _$SocialInteractionCopyWithImpl<SocialInteraction>(this as SocialInteraction, _$identity);
 
   /// Serializes this SocialInteraction to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is SocialInteraction &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.targetId, targetId) ||
-                other.targetId == targetId) &&
-            (identical(other.targetType, targetType) ||
-                other.targetType == targetType) &&
-            (identical(other.interactionType, interactionType) ||
-                other.interactionType == interactionType) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, userId, targetId, targetType, interactionType, createdAt);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SocialInteraction&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.targetId, targetId) || other.targetId == targetId)&&(identical(other.targetType, targetType) || other.targetType == targetType)&&(identical(other.interactionType, interactionType) || other.interactionType == interactionType)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
 
-  @override
-  String toString() {
-    return 'SocialInteraction(userId: $userId, targetId: $targetId, targetType: $targetType, interactionType: $interactionType, createdAt: $createdAt)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,userId,targetId,targetType,interactionType,createdAt);
+
+@override
+String toString() {
+  return 'SocialInteraction(userId: $userId, targetId: $targetId, targetType: $targetType, interactionType: $interactionType, createdAt: $createdAt)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $SocialInteractionCopyWith<$Res> {
-  factory $SocialInteractionCopyWith(
-          SocialInteraction value, $Res Function(SocialInteraction) _then) =
-      _$SocialInteractionCopyWithImpl;
-  @useResult
-  $Res call(
-      {String userId,
-      String targetId,
-      SocialTargetType targetType,
-      SocialInteractionType interactionType,
-      DateTime? createdAt});
-}
+abstract mixin class $SocialInteractionCopyWith<$Res>  {
+  factory $SocialInteractionCopyWith(SocialInteraction value, $Res Function(SocialInteraction) _then) = _$SocialInteractionCopyWithImpl;
+@useResult
+$Res call({
+ String userId, String targetId, SocialTargetType targetType, SocialInteractionType interactionType, DateTime? createdAt
+});
 
+
+
+
+}
 /// @nodoc
 class _$SocialInteractionCopyWithImpl<$Res>
     implements $SocialInteractionCopyWith<$Res> {
@@ -80,301 +63,205 @@ class _$SocialInteractionCopyWithImpl<$Res>
   final SocialInteraction _self;
   final $Res Function(SocialInteraction) _then;
 
-  /// Create a copy of SocialInteraction
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? userId = null,
-    Object? targetId = null,
-    Object? targetType = null,
-    Object? interactionType = null,
-    Object? createdAt = freezed,
-  }) {
-    return _then(_self.copyWith(
-      userId: null == userId
-          ? _self.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      targetId: null == targetId
-          ? _self.targetId
-          : targetId // ignore: cast_nullable_to_non_nullable
-              as String,
-      targetType: null == targetType
-          ? _self.targetType
-          : targetType // ignore: cast_nullable_to_non_nullable
-              as SocialTargetType,
-      interactionType: null == interactionType
-          ? _self.interactionType
-          : interactionType // ignore: cast_nullable_to_non_nullable
-              as SocialInteractionType,
-      createdAt: freezed == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-    ));
-  }
+/// Create a copy of SocialInteraction
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? userId = null,Object? targetId = null,Object? targetType = null,Object? interactionType = null,Object? createdAt = freezed,}) {
+  return _then(_self.copyWith(
+userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,targetId: null == targetId ? _self.targetId : targetId // ignore: cast_nullable_to_non_nullable
+as String,targetType: null == targetType ? _self.targetType : targetType // ignore: cast_nullable_to_non_nullable
+as SocialTargetType,interactionType: null == interactionType ? _self.interactionType : interactionType // ignore: cast_nullable_to_non_nullable
+as SocialInteractionType,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [SocialInteraction].
 extension SocialInteractionPatterns on SocialInteraction {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_SocialInteraction value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _SocialInteraction() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _SocialInteraction value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _SocialInteraction() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_SocialInteraction value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _SocialInteraction():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _SocialInteraction value)  $default,){
+final _that = this;
+switch (_that) {
+case _SocialInteraction():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_SocialInteraction value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _SocialInteraction() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _SocialInteraction value)?  $default,){
+final _that = this;
+switch (_that) {
+case _SocialInteraction() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String userId,
-            String targetId,
-            SocialTargetType targetType,
-            SocialInteractionType interactionType,
-            DateTime? createdAt)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _SocialInteraction() when $default != null:
-        return $default(_that.userId, _that.targetId, _that.targetType,
-            _that.interactionType, _that.createdAt);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String userId,  String targetId,  SocialTargetType targetType,  SocialInteractionType interactionType,  DateTime? createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _SocialInteraction() when $default != null:
+return $default(_that.userId,_that.targetId,_that.targetType,_that.interactionType,_that.createdAt);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String userId,
-            String targetId,
-            SocialTargetType targetType,
-            SocialInteractionType interactionType,
-            DateTime? createdAt)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _SocialInteraction():
-        return $default(_that.userId, _that.targetId, _that.targetType,
-            _that.interactionType, _that.createdAt);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String userId,  String targetId,  SocialTargetType targetType,  SocialInteractionType interactionType,  DateTime? createdAt)  $default,) {final _that = this;
+switch (_that) {
+case _SocialInteraction():
+return $default(_that.userId,_that.targetId,_that.targetType,_that.interactionType,_that.createdAt);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String userId,
-            String targetId,
-            SocialTargetType targetType,
-            SocialInteractionType interactionType,
-            DateTime? createdAt)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _SocialInteraction() when $default != null:
-        return $default(_that.userId, _that.targetId, _that.targetType,
-            _that.interactionType, _that.createdAt);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String userId,  String targetId,  SocialTargetType targetType,  SocialInteractionType interactionType,  DateTime? createdAt)?  $default,) {final _that = this;
+switch (_that) {
+case _SocialInteraction() when $default != null:
+return $default(_that.userId,_that.targetId,_that.targetType,_that.interactionType,_that.createdAt);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _SocialInteraction implements SocialInteraction {
-  const _SocialInteraction(
-      {required this.userId,
-      required this.targetId,
-      required this.targetType,
-      required this.interactionType,
-      this.createdAt});
-  factory _SocialInteraction.fromJson(Map<String, dynamic> json) =>
-      _$SocialInteractionFromJson(json);
+  const _SocialInteraction({required this.userId, required this.targetId, required this.targetType, required this.interactionType, this.createdAt});
+  factory _SocialInteraction.fromJson(Map<String, dynamic> json) => _$SocialInteractionFromJson(json);
 
-  @override
-  final String userId;
-  @override
-  final String targetId;
-  @override
-  final SocialTargetType targetType;
-  @override
-  final SocialInteractionType interactionType;
-  @override
-  final DateTime? createdAt;
+@override final  String userId;
+@override final  String targetId;
+@override final  SocialTargetType targetType;
+@override final  SocialInteractionType interactionType;
+@override final  DateTime? createdAt;
 
-  /// Create a copy of SocialInteraction
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$SocialInteractionCopyWith<_SocialInteraction> get copyWith =>
-      __$SocialInteractionCopyWithImpl<_SocialInteraction>(this, _$identity);
+/// Create a copy of SocialInteraction
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SocialInteractionCopyWith<_SocialInteraction> get copyWith => __$SocialInteractionCopyWithImpl<_SocialInteraction>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$SocialInteractionToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$SocialInteractionToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _SocialInteraction &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.targetId, targetId) ||
-                other.targetId == targetId) &&
-            (identical(other.targetType, targetType) ||
-                other.targetType == targetType) &&
-            (identical(other.interactionType, interactionType) ||
-                other.interactionType == interactionType) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SocialInteraction&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.targetId, targetId) || other.targetId == targetId)&&(identical(other.targetType, targetType) || other.targetType == targetType)&&(identical(other.interactionType, interactionType) || other.interactionType == interactionType)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, userId, targetId, targetType, interactionType, createdAt);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,userId,targetId,targetType,interactionType,createdAt);
 
-  @override
-  String toString() {
-    return 'SocialInteraction(userId: $userId, targetId: $targetId, targetType: $targetType, interactionType: $interactionType, createdAt: $createdAt)';
-  }
+@override
+String toString() {
+  return 'SocialInteraction(userId: $userId, targetId: $targetId, targetType: $targetType, interactionType: $interactionType, createdAt: $createdAt)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$SocialInteractionCopyWith<$Res>
-    implements $SocialInteractionCopyWith<$Res> {
-  factory _$SocialInteractionCopyWith(
-          _SocialInteraction value, $Res Function(_SocialInteraction) _then) =
-      __$SocialInteractionCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String userId,
-      String targetId,
-      SocialTargetType targetType,
-      SocialInteractionType interactionType,
-      DateTime? createdAt});
-}
+abstract mixin class _$SocialInteractionCopyWith<$Res> implements $SocialInteractionCopyWith<$Res> {
+  factory _$SocialInteractionCopyWith(_SocialInteraction value, $Res Function(_SocialInteraction) _then) = __$SocialInteractionCopyWithImpl;
+@override @useResult
+$Res call({
+ String userId, String targetId, SocialTargetType targetType, SocialInteractionType interactionType, DateTime? createdAt
+});
 
+
+
+
+}
 /// @nodoc
 class __$SocialInteractionCopyWithImpl<$Res>
     implements _$SocialInteractionCopyWith<$Res> {
@@ -383,40 +270,20 @@ class __$SocialInteractionCopyWithImpl<$Res>
   final _SocialInteraction _self;
   final $Res Function(_SocialInteraction) _then;
 
-  /// Create a copy of SocialInteraction
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? userId = null,
-    Object? targetId = null,
-    Object? targetType = null,
-    Object? interactionType = null,
-    Object? createdAt = freezed,
-  }) {
-    return _then(_SocialInteraction(
-      userId: null == userId
-          ? _self.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      targetId: null == targetId
-          ? _self.targetId
-          : targetId // ignore: cast_nullable_to_non_nullable
-              as String,
-      targetType: null == targetType
-          ? _self.targetType
-          : targetType // ignore: cast_nullable_to_non_nullable
-              as SocialTargetType,
-      interactionType: null == interactionType
-          ? _self.interactionType
-          : interactionType // ignore: cast_nullable_to_non_nullable
-              as SocialInteractionType,
-      createdAt: freezed == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-    ));
-  }
+/// Create a copy of SocialInteraction
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? userId = null,Object? targetId = null,Object? targetType = null,Object? interactionType = null,Object? createdAt = freezed,}) {
+  return _then(_SocialInteraction(
+userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,targetId: null == targetId ? _self.targetId : targetId // ignore: cast_nullable_to_non_nullable
+as String,targetType: null == targetType ? _self.targetType : targetType // ignore: cast_nullable_to_non_nullable
+as SocialTargetType,interactionType: null == interactionType ? _self.interactionType : interactionType // ignore: cast_nullable_to_non_nullable
+as SocialInteractionType,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/ticket.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/ticket.freezed.dart
@@ -14,653 +14,309 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$Ticket {
-  String get id;
-  String get name;
-  @JsonKey(name: 'created_at')
-  DateTime get createdAt;
-  @JsonKey(name: 'updated_at')
-  DateTime get updatedAt;
-  @JsonKey(name: 'event_id')
-  String? get eventId;
-  String? get description;
-  int get price;
-  int get quantity;
-  @JsonKey(name: 'sold_count')
-  int get soldCount;
-  @JsonKey(name: 'target_entry_group_ids')
-  List<String> get targetEntryGroupIds;
-  @JsonKey(name: 'required_verification_ids')
-  List<String> get requiredVerificationIds;
-  String get status;
 
-  /// Create a copy of Ticket
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $TicketCopyWith<Ticket> get copyWith =>
-      _$TicketCopyWithImpl<Ticket>(this as Ticket, _$identity);
+ String get id; String get name;@JsonKey(name: 'created_at') DateTime get createdAt;@JsonKey(name: 'updated_at') DateTime get updatedAt;@JsonKey(name: 'event_id') String? get eventId; String? get description; int get price; int get quantity;@JsonKey(name: 'sold_count') int get soldCount;@JsonKey(name: 'target_entry_group_ids') List<String> get targetEntryGroupIds;@JsonKey(name: 'required_verification_ids') List<String> get requiredVerificationIds; String get status;
+/// Create a copy of Ticket
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TicketCopyWith<Ticket> get copyWith => _$TicketCopyWithImpl<Ticket>(this as Ticket, _$identity);
 
   /// Serializes this Ticket to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is Ticket &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt) &&
-            (identical(other.eventId, eventId) || other.eventId == eventId) &&
-            (identical(other.description, description) ||
-                other.description == description) &&
-            (identical(other.price, price) || other.price == price) &&
-            (identical(other.quantity, quantity) ||
-                other.quantity == quantity) &&
-            (identical(other.soldCount, soldCount) ||
-                other.soldCount == soldCount) &&
-            const DeepCollectionEquality()
-                .equals(other.targetEntryGroupIds, targetEntryGroupIds) &&
-            const DeepCollectionEquality().equals(
-                other.requiredVerificationIds, requiredVerificationIds) &&
-            (identical(other.status, status) || other.status == status));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      name,
-      createdAt,
-      updatedAt,
-      eventId,
-      description,
-      price,
-      quantity,
-      soldCount,
-      const DeepCollectionEquality().hash(targetEntryGroupIds),
-      const DeepCollectionEquality().hash(requiredVerificationIds),
-      status);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Ticket&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.description, description) || other.description == description)&&(identical(other.price, price) || other.price == price)&&(identical(other.quantity, quantity) || other.quantity == quantity)&&(identical(other.soldCount, soldCount) || other.soldCount == soldCount)&&const DeepCollectionEquality().equals(other.targetEntryGroupIds, targetEntryGroupIds)&&const DeepCollectionEquality().equals(other.requiredVerificationIds, requiredVerificationIds)&&(identical(other.status, status) || other.status == status));
+}
 
-  @override
-  String toString() {
-    return 'Ticket(id: $id, name: $name, createdAt: $createdAt, updatedAt: $updatedAt, eventId: $eventId, description: $description, price: $price, quantity: $quantity, soldCount: $soldCount, targetEntryGroupIds: $targetEntryGroupIds, requiredVerificationIds: $requiredVerificationIds, status: $status)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,createdAt,updatedAt,eventId,description,price,quantity,soldCount,const DeepCollectionEquality().hash(targetEntryGroupIds),const DeepCollectionEquality().hash(requiredVerificationIds),status);
+
+@override
+String toString() {
+  return 'Ticket(id: $id, name: $name, createdAt: $createdAt, updatedAt: $updatedAt, eventId: $eventId, description: $description, price: $price, quantity: $quantity, soldCount: $soldCount, targetEntryGroupIds: $targetEntryGroupIds, requiredVerificationIds: $requiredVerificationIds, status: $status)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $TicketCopyWith<$Res> {
-  factory $TicketCopyWith(Ticket value, $Res Function(Ticket) _then) =
-      _$TicketCopyWithImpl;
-  @useResult
-  $Res call(
-      {String id,
-      String name,
-      @JsonKey(name: 'created_at') DateTime createdAt,
-      @JsonKey(name: 'updated_at') DateTime updatedAt,
-      @JsonKey(name: 'event_id') String? eventId,
-      String? description,
-      int price,
-      int quantity,
-      @JsonKey(name: 'sold_count') int soldCount,
-      @JsonKey(name: 'target_entry_group_ids') List<String> targetEntryGroupIds,
-      @JsonKey(name: 'required_verification_ids')
-      List<String> requiredVerificationIds,
-      String status});
-}
+abstract mixin class $TicketCopyWith<$Res>  {
+  factory $TicketCopyWith(Ticket value, $Res Function(Ticket) _then) = _$TicketCopyWithImpl;
+@useResult
+$Res call({
+ String id, String name,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'event_id') String? eventId, String? description, int price, int quantity,@JsonKey(name: 'sold_count') int soldCount,@JsonKey(name: 'target_entry_group_ids') List<String> targetEntryGroupIds,@JsonKey(name: 'required_verification_ids') List<String> requiredVerificationIds, String status
+});
 
+
+
+
+}
 /// @nodoc
-class _$TicketCopyWithImpl<$Res> implements $TicketCopyWith<$Res> {
+class _$TicketCopyWithImpl<$Res>
+    implements $TicketCopyWith<$Res> {
   _$TicketCopyWithImpl(this._self, this._then);
 
   final Ticket _self;
   final $Res Function(Ticket) _then;
 
-  /// Create a copy of Ticket
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? name = null,
-    Object? createdAt = null,
-    Object? updatedAt = null,
-    Object? eventId = freezed,
-    Object? description = freezed,
-    Object? price = null,
-    Object? quantity = null,
-    Object? soldCount = null,
-    Object? targetEntryGroupIds = null,
-    Object? requiredVerificationIds = null,
-    Object? status = null,
-  }) {
-    return _then(_self.copyWith(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      name: null == name
-          ? _self.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updatedAt: null == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      eventId: freezed == eventId
-          ? _self.eventId
-          : eventId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      description: freezed == description
-          ? _self.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as String?,
-      price: null == price
-          ? _self.price
-          : price // ignore: cast_nullable_to_non_nullable
-              as int,
-      quantity: null == quantity
-          ? _self.quantity
-          : quantity // ignore: cast_nullable_to_non_nullable
-              as int,
-      soldCount: null == soldCount
-          ? _self.soldCount
-          : soldCount // ignore: cast_nullable_to_non_nullable
-              as int,
-      targetEntryGroupIds: null == targetEntryGroupIds
-          ? _self.targetEntryGroupIds
-          : targetEntryGroupIds // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      requiredVerificationIds: null == requiredVerificationIds
-          ? _self.requiredVerificationIds
-          : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      status: null == status
-          ? _self.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
+/// Create a copy of Ticket
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? createdAt = null,Object? updatedAt = null,Object? eventId = freezed,Object? description = freezed,Object? price = null,Object? quantity = null,Object? soldCount = null,Object? targetEntryGroupIds = null,Object? requiredVerificationIds = null,Object? status = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,eventId: freezed == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,price: null == price ? _self.price : price // ignore: cast_nullable_to_non_nullable
+as int,quantity: null == quantity ? _self.quantity : quantity // ignore: cast_nullable_to_non_nullable
+as int,soldCount: null == soldCount ? _self.soldCount : soldCount // ignore: cast_nullable_to_non_nullable
+as int,targetEntryGroupIds: null == targetEntryGroupIds ? _self.targetEntryGroupIds : targetEntryGroupIds // ignore: cast_nullable_to_non_nullable
+as List<String>,requiredVerificationIds: null == requiredVerificationIds ? _self.requiredVerificationIds : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
+as List<String>,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [Ticket].
 extension TicketPatterns on Ticket {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_Ticket value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Ticket() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Ticket value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Ticket() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_Ticket value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Ticket():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Ticket value)  $default,){
+final _that = this;
+switch (_that) {
+case _Ticket():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_Ticket value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Ticket() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Ticket value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Ticket() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String id,
-            String name,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'event_id') String? eventId,
-            String? description,
-            int price,
-            int quantity,
-            @JsonKey(name: 'sold_count') int soldCount,
-            @JsonKey(name: 'target_entry_group_ids')
-            List<String> targetEntryGroupIds,
-            @JsonKey(name: 'required_verification_ids')
-            List<String> requiredVerificationIds,
-            String status)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Ticket() when $default != null:
-        return $default(
-            _that.id,
-            _that.name,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.eventId,
-            _that.description,
-            _that.price,
-            _that.quantity,
-            _that.soldCount,
-            _that.targetEntryGroupIds,
-            _that.requiredVerificationIds,
-            _that.status);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'event_id')  String? eventId,  String? description,  int price,  int quantity, @JsonKey(name: 'sold_count')  int soldCount, @JsonKey(name: 'target_entry_group_ids')  List<String> targetEntryGroupIds, @JsonKey(name: 'required_verification_ids')  List<String> requiredVerificationIds,  String status)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Ticket() when $default != null:
+return $default(_that.id,_that.name,_that.createdAt,_that.updatedAt,_that.eventId,_that.description,_that.price,_that.quantity,_that.soldCount,_that.targetEntryGroupIds,_that.requiredVerificationIds,_that.status);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String id,
-            String name,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'event_id') String? eventId,
-            String? description,
-            int price,
-            int quantity,
-            @JsonKey(name: 'sold_count') int soldCount,
-            @JsonKey(name: 'target_entry_group_ids')
-            List<String> targetEntryGroupIds,
-            @JsonKey(name: 'required_verification_ids')
-            List<String> requiredVerificationIds,
-            String status)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Ticket():
-        return $default(
-            _that.id,
-            _that.name,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.eventId,
-            _that.description,
-            _that.price,
-            _that.quantity,
-            _that.soldCount,
-            _that.targetEntryGroupIds,
-            _that.requiredVerificationIds,
-            _that.status);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'event_id')  String? eventId,  String? description,  int price,  int quantity, @JsonKey(name: 'sold_count')  int soldCount, @JsonKey(name: 'target_entry_group_ids')  List<String> targetEntryGroupIds, @JsonKey(name: 'required_verification_ids')  List<String> requiredVerificationIds,  String status)  $default,) {final _that = this;
+switch (_that) {
+case _Ticket():
+return $default(_that.id,_that.name,_that.createdAt,_that.updatedAt,_that.eventId,_that.description,_that.price,_that.quantity,_that.soldCount,_that.targetEntryGroupIds,_that.requiredVerificationIds,_that.status);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String id,
-            String name,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'event_id') String? eventId,
-            String? description,
-            int price,
-            int quantity,
-            @JsonKey(name: 'sold_count') int soldCount,
-            @JsonKey(name: 'target_entry_group_ids')
-            List<String> targetEntryGroupIds,
-            @JsonKey(name: 'required_verification_ids')
-            List<String> requiredVerificationIds,
-            String status)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Ticket() when $default != null:
-        return $default(
-            _that.id,
-            _that.name,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.eventId,
-            _that.description,
-            _that.price,
-            _that.quantity,
-            _that.soldCount,
-            _that.targetEntryGroupIds,
-            _that.requiredVerificationIds,
-            _that.status);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'event_id')  String? eventId,  String? description,  int price,  int quantity, @JsonKey(name: 'sold_count')  int soldCount, @JsonKey(name: 'target_entry_group_ids')  List<String> targetEntryGroupIds, @JsonKey(name: 'required_verification_ids')  List<String> requiredVerificationIds,  String status)?  $default,) {final _that = this;
+switch (_that) {
+case _Ticket() when $default != null:
+return $default(_that.id,_that.name,_that.createdAt,_that.updatedAt,_that.eventId,_that.description,_that.price,_that.quantity,_that.soldCount,_that.targetEntryGroupIds,_that.requiredVerificationIds,_that.status);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _Ticket implements Ticket {
-  const _Ticket(
-      {required this.id,
-      required this.name,
-      @JsonKey(name: 'created_at') required this.createdAt,
-      @JsonKey(name: 'updated_at') required this.updatedAt,
-      @JsonKey(name: 'event_id') this.eventId,
-      this.description,
-      this.price = 0,
-      this.quantity = 0,
-      @JsonKey(name: 'sold_count') this.soldCount = 0,
-      @JsonKey(name: 'target_entry_group_ids')
-      final List<String> targetEntryGroupIds = const [],
-      @JsonKey(name: 'required_verification_ids')
-      final List<String> requiredVerificationIds = const [],
-      this.status = 'on_sale'})
-      : _targetEntryGroupIds = targetEntryGroupIds,
-        _requiredVerificationIds = requiredVerificationIds;
+  const _Ticket({required this.id, required this.name, @JsonKey(name: 'created_at') required this.createdAt, @JsonKey(name: 'updated_at') required this.updatedAt, @JsonKey(name: 'event_id') this.eventId, this.description, this.price = 0, this.quantity = 0, @JsonKey(name: 'sold_count') this.soldCount = 0, @JsonKey(name: 'target_entry_group_ids') final  List<String> targetEntryGroupIds = const [], @JsonKey(name: 'required_verification_ids') final  List<String> requiredVerificationIds = const [], this.status = 'on_sale'}): _targetEntryGroupIds = targetEntryGroupIds,_requiredVerificationIds = requiredVerificationIds;
   factory _Ticket.fromJson(Map<String, dynamic> json) => _$TicketFromJson(json);
 
-  @override
-  final String id;
-  @override
-  final String name;
-  @override
-  @JsonKey(name: 'created_at')
-  final DateTime createdAt;
-  @override
-  @JsonKey(name: 'updated_at')
-  final DateTime updatedAt;
-  @override
-  @JsonKey(name: 'event_id')
-  final String? eventId;
-  @override
-  final String? description;
-  @override
-  @JsonKey()
-  final int price;
-  @override
-  @JsonKey()
-  final int quantity;
-  @override
-  @JsonKey(name: 'sold_count')
-  final int soldCount;
-  final List<String> _targetEntryGroupIds;
-  @override
-  @JsonKey(name: 'target_entry_group_ids')
-  List<String> get targetEntryGroupIds {
-    if (_targetEntryGroupIds is EqualUnmodifiableListView)
-      return _targetEntryGroupIds;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_targetEntryGroupIds);
-  }
+@override final  String id;
+@override final  String name;
+@override@JsonKey(name: 'created_at') final  DateTime createdAt;
+@override@JsonKey(name: 'updated_at') final  DateTime updatedAt;
+@override@JsonKey(name: 'event_id') final  String? eventId;
+@override final  String? description;
+@override@JsonKey() final  int price;
+@override@JsonKey() final  int quantity;
+@override@JsonKey(name: 'sold_count') final  int soldCount;
+ final  List<String> _targetEntryGroupIds;
+@override@JsonKey(name: 'target_entry_group_ids') List<String> get targetEntryGroupIds {
+  if (_targetEntryGroupIds is EqualUnmodifiableListView) return _targetEntryGroupIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_targetEntryGroupIds);
+}
 
-  final List<String> _requiredVerificationIds;
-  @override
-  @JsonKey(name: 'required_verification_ids')
-  List<String> get requiredVerificationIds {
-    if (_requiredVerificationIds is EqualUnmodifiableListView)
-      return _requiredVerificationIds;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_requiredVerificationIds);
-  }
+ final  List<String> _requiredVerificationIds;
+@override@JsonKey(name: 'required_verification_ids') List<String> get requiredVerificationIds {
+  if (_requiredVerificationIds is EqualUnmodifiableListView) return _requiredVerificationIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_requiredVerificationIds);
+}
 
-  @override
-  @JsonKey()
-  final String status;
+@override@JsonKey() final  String status;
 
-  /// Create a copy of Ticket
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$TicketCopyWith<_Ticket> get copyWith =>
-      __$TicketCopyWithImpl<_Ticket>(this, _$identity);
+/// Create a copy of Ticket
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$TicketCopyWith<_Ticket> get copyWith => __$TicketCopyWithImpl<_Ticket>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$TicketToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$TicketToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _Ticket &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt) &&
-            (identical(other.eventId, eventId) || other.eventId == eventId) &&
-            (identical(other.description, description) ||
-                other.description == description) &&
-            (identical(other.price, price) || other.price == price) &&
-            (identical(other.quantity, quantity) ||
-                other.quantity == quantity) &&
-            (identical(other.soldCount, soldCount) ||
-                other.soldCount == soldCount) &&
-            const DeepCollectionEquality()
-                .equals(other._targetEntryGroupIds, _targetEntryGroupIds) &&
-            const DeepCollectionEquality().equals(
-                other._requiredVerificationIds, _requiredVerificationIds) &&
-            (identical(other.status, status) || other.status == status));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Ticket&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.description, description) || other.description == description)&&(identical(other.price, price) || other.price == price)&&(identical(other.quantity, quantity) || other.quantity == quantity)&&(identical(other.soldCount, soldCount) || other.soldCount == soldCount)&&const DeepCollectionEquality().equals(other._targetEntryGroupIds, _targetEntryGroupIds)&&const DeepCollectionEquality().equals(other._requiredVerificationIds, _requiredVerificationIds)&&(identical(other.status, status) || other.status == status));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      name,
-      createdAt,
-      updatedAt,
-      eventId,
-      description,
-      price,
-      quantity,
-      soldCount,
-      const DeepCollectionEquality().hash(_targetEntryGroupIds),
-      const DeepCollectionEquality().hash(_requiredVerificationIds),
-      status);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,createdAt,updatedAt,eventId,description,price,quantity,soldCount,const DeepCollectionEquality().hash(_targetEntryGroupIds),const DeepCollectionEquality().hash(_requiredVerificationIds),status);
 
-  @override
-  String toString() {
-    return 'Ticket(id: $id, name: $name, createdAt: $createdAt, updatedAt: $updatedAt, eventId: $eventId, description: $description, price: $price, quantity: $quantity, soldCount: $soldCount, targetEntryGroupIds: $targetEntryGroupIds, requiredVerificationIds: $requiredVerificationIds, status: $status)';
-  }
+@override
+String toString() {
+  return 'Ticket(id: $id, name: $name, createdAt: $createdAt, updatedAt: $updatedAt, eventId: $eventId, description: $description, price: $price, quantity: $quantity, soldCount: $soldCount, targetEntryGroupIds: $targetEntryGroupIds, requiredVerificationIds: $requiredVerificationIds, status: $status)';
+}
+
+
 }
 
 /// @nodoc
 abstract mixin class _$TicketCopyWith<$Res> implements $TicketCopyWith<$Res> {
-  factory _$TicketCopyWith(_Ticket value, $Res Function(_Ticket) _then) =
-      __$TicketCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String id,
-      String name,
-      @JsonKey(name: 'created_at') DateTime createdAt,
-      @JsonKey(name: 'updated_at') DateTime updatedAt,
-      @JsonKey(name: 'event_id') String? eventId,
-      String? description,
-      int price,
-      int quantity,
-      @JsonKey(name: 'sold_count') int soldCount,
-      @JsonKey(name: 'target_entry_group_ids') List<String> targetEntryGroupIds,
-      @JsonKey(name: 'required_verification_ids')
-      List<String> requiredVerificationIds,
-      String status});
-}
+  factory _$TicketCopyWith(_Ticket value, $Res Function(_Ticket) _then) = __$TicketCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String name,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'event_id') String? eventId, String? description, int price, int quantity,@JsonKey(name: 'sold_count') int soldCount,@JsonKey(name: 'target_entry_group_ids') List<String> targetEntryGroupIds,@JsonKey(name: 'required_verification_ids') List<String> requiredVerificationIds, String status
+});
 
+
+
+
+}
 /// @nodoc
-class __$TicketCopyWithImpl<$Res> implements _$TicketCopyWith<$Res> {
+class __$TicketCopyWithImpl<$Res>
+    implements _$TicketCopyWith<$Res> {
   __$TicketCopyWithImpl(this._self, this._then);
 
   final _Ticket _self;
   final $Res Function(_Ticket) _then;
 
-  /// Create a copy of Ticket
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? name = null,
-    Object? createdAt = null,
-    Object? updatedAt = null,
-    Object? eventId = freezed,
-    Object? description = freezed,
-    Object? price = null,
-    Object? quantity = null,
-    Object? soldCount = null,
-    Object? targetEntryGroupIds = null,
-    Object? requiredVerificationIds = null,
-    Object? status = null,
-  }) {
-    return _then(_Ticket(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      name: null == name
-          ? _self.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updatedAt: null == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      eventId: freezed == eventId
-          ? _self.eventId
-          : eventId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      description: freezed == description
-          ? _self.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as String?,
-      price: null == price
-          ? _self.price
-          : price // ignore: cast_nullable_to_non_nullable
-              as int,
-      quantity: null == quantity
-          ? _self.quantity
-          : quantity // ignore: cast_nullable_to_non_nullable
-              as int,
-      soldCount: null == soldCount
-          ? _self.soldCount
-          : soldCount // ignore: cast_nullable_to_non_nullable
-              as int,
-      targetEntryGroupIds: null == targetEntryGroupIds
-          ? _self._targetEntryGroupIds
-          : targetEntryGroupIds // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      requiredVerificationIds: null == requiredVerificationIds
-          ? _self._requiredVerificationIds
-          : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      status: null == status
-          ? _self.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
+/// Create a copy of Ticket
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? createdAt = null,Object? updatedAt = null,Object? eventId = freezed,Object? description = freezed,Object? price = null,Object? quantity = null,Object? soldCount = null,Object? targetEntryGroupIds = null,Object? requiredVerificationIds = null,Object? status = null,}) {
+  return _then(_Ticket(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,eventId: freezed == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,price: null == price ? _self.price : price // ignore: cast_nullable_to_non_nullable
+as int,quantity: null == quantity ? _self.quantity : quantity // ignore: cast_nullable_to_non_nullable
+as int,soldCount: null == soldCount ? _self.soldCount : soldCount // ignore: cast_nullable_to_non_nullable
+as int,targetEntryGroupIds: null == targetEntryGroupIds ? _self._targetEntryGroupIds : targetEntryGroupIds // ignore: cast_nullable_to_non_nullable
+as List<String>,requiredVerificationIds: null == requiredVerificationIds ? _self._requiredVerificationIds : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
+as List<String>,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/ticket_template.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/ticket_template.freezed.dart
@@ -14,97 +14,47 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$TicketTemplate {
-  String get id;
-  @JsonKey(name: 'party_id')
-  String get partyId;
-  String get name;
-  @JsonKey(name: 'created_at')
-  DateTime get createdAt;
-  @JsonKey(name: 'updated_at')
-  DateTime get updatedAt;
-  String? get description;
-  int get price;
-  int get quantity;
-  @JsonKey(name: 'target_entry_group_ids')
-  List<String> get targetEntryGroupIds;
-  @JsonKey(name: 'required_verification_ids')
-  List<String> get requiredVerificationIds;
 
-  /// Create a copy of TicketTemplate
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $TicketTemplateCopyWith<TicketTemplate> get copyWith =>
-      _$TicketTemplateCopyWithImpl<TicketTemplate>(
-          this as TicketTemplate, _$identity);
+ String get id;@JsonKey(name: 'party_id') String get partyId; String get name;@JsonKey(name: 'created_at') DateTime get createdAt;@JsonKey(name: 'updated_at') DateTime get updatedAt; String? get description; int get price; int get quantity;@JsonKey(name: 'target_entry_group_ids') List<String> get targetEntryGroupIds;@JsonKey(name: 'required_verification_ids') List<String> get requiredVerificationIds;
+/// Create a copy of TicketTemplate
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TicketTemplateCopyWith<TicketTemplate> get copyWith => _$TicketTemplateCopyWithImpl<TicketTemplate>(this as TicketTemplate, _$identity);
 
   /// Serializes this TicketTemplate to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is TicketTemplate &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.partyId, partyId) || other.partyId == partyId) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt) &&
-            (identical(other.description, description) ||
-                other.description == description) &&
-            (identical(other.price, price) || other.price == price) &&
-            (identical(other.quantity, quantity) ||
-                other.quantity == quantity) &&
-            const DeepCollectionEquality()
-                .equals(other.targetEntryGroupIds, targetEntryGroupIds) &&
-            const DeepCollectionEquality().equals(
-                other.requiredVerificationIds, requiredVerificationIds));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      partyId,
-      name,
-      createdAt,
-      updatedAt,
-      description,
-      price,
-      quantity,
-      const DeepCollectionEquality().hash(targetEntryGroupIds),
-      const DeepCollectionEquality().hash(requiredVerificationIds));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TicketTemplate&&(identical(other.id, id) || other.id == id)&&(identical(other.partyId, partyId) || other.partyId == partyId)&&(identical(other.name, name) || other.name == name)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.description, description) || other.description == description)&&(identical(other.price, price) || other.price == price)&&(identical(other.quantity, quantity) || other.quantity == quantity)&&const DeepCollectionEquality().equals(other.targetEntryGroupIds, targetEntryGroupIds)&&const DeepCollectionEquality().equals(other.requiredVerificationIds, requiredVerificationIds));
+}
 
-  @override
-  String toString() {
-    return 'TicketTemplate(id: $id, partyId: $partyId, name: $name, createdAt: $createdAt, updatedAt: $updatedAt, description: $description, price: $price, quantity: $quantity, targetEntryGroupIds: $targetEntryGroupIds, requiredVerificationIds: $requiredVerificationIds)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,partyId,name,createdAt,updatedAt,description,price,quantity,const DeepCollectionEquality().hash(targetEntryGroupIds),const DeepCollectionEquality().hash(requiredVerificationIds));
+
+@override
+String toString() {
+  return 'TicketTemplate(id: $id, partyId: $partyId, name: $name, createdAt: $createdAt, updatedAt: $updatedAt, description: $description, price: $price, quantity: $quantity, targetEntryGroupIds: $targetEntryGroupIds, requiredVerificationIds: $requiredVerificationIds)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $TicketTemplateCopyWith<$Res> {
-  factory $TicketTemplateCopyWith(
-          TicketTemplate value, $Res Function(TicketTemplate) _then) =
-      _$TicketTemplateCopyWithImpl;
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'party_id') String partyId,
-      String name,
-      @JsonKey(name: 'created_at') DateTime createdAt,
-      @JsonKey(name: 'updated_at') DateTime updatedAt,
-      String? description,
-      int price,
-      int quantity,
-      @JsonKey(name: 'target_entry_group_ids') List<String> targetEntryGroupIds,
-      @JsonKey(name: 'required_verification_ids')
-      List<String> requiredVerificationIds});
-}
+abstract mixin class $TicketTemplateCopyWith<$Res>  {
+  factory $TicketTemplateCopyWith(TicketTemplate value, $Res Function(TicketTemplate) _then) = _$TicketTemplateCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(name: 'party_id') String partyId, String name,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt, String? description, int price, int quantity,@JsonKey(name: 'target_entry_group_ids') List<String> targetEntryGroupIds,@JsonKey(name: 'required_verification_ids') List<String> requiredVerificationIds
+});
 
+
+
+
+}
 /// @nodoc
 class _$TicketTemplateCopyWithImpl<$Res>
     implements $TicketTemplateCopyWith<$Res> {
@@ -113,436 +63,227 @@ class _$TicketTemplateCopyWithImpl<$Res>
   final TicketTemplate _self;
   final $Res Function(TicketTemplate) _then;
 
-  /// Create a copy of TicketTemplate
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? partyId = null,
-    Object? name = null,
-    Object? createdAt = null,
-    Object? updatedAt = null,
-    Object? description = freezed,
-    Object? price = null,
-    Object? quantity = null,
-    Object? targetEntryGroupIds = null,
-    Object? requiredVerificationIds = null,
-  }) {
-    return _then(_self.copyWith(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      partyId: null == partyId
-          ? _self.partyId
-          : partyId // ignore: cast_nullable_to_non_nullable
-              as String,
-      name: null == name
-          ? _self.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updatedAt: null == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      description: freezed == description
-          ? _self.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as String?,
-      price: null == price
-          ? _self.price
-          : price // ignore: cast_nullable_to_non_nullable
-              as int,
-      quantity: null == quantity
-          ? _self.quantity
-          : quantity // ignore: cast_nullable_to_non_nullable
-              as int,
-      targetEntryGroupIds: null == targetEntryGroupIds
-          ? _self.targetEntryGroupIds
-          : targetEntryGroupIds // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      requiredVerificationIds: null == requiredVerificationIds
-          ? _self.requiredVerificationIds
-          : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-    ));
-  }
+/// Create a copy of TicketTemplate
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? partyId = null,Object? name = null,Object? createdAt = null,Object? updatedAt = null,Object? description = freezed,Object? price = null,Object? quantity = null,Object? targetEntryGroupIds = null,Object? requiredVerificationIds = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,price: null == price ? _self.price : price // ignore: cast_nullable_to_non_nullable
+as int,quantity: null == quantity ? _self.quantity : quantity // ignore: cast_nullable_to_non_nullable
+as int,targetEntryGroupIds: null == targetEntryGroupIds ? _self.targetEntryGroupIds : targetEntryGroupIds // ignore: cast_nullable_to_non_nullable
+as List<String>,requiredVerificationIds: null == requiredVerificationIds ? _self.requiredVerificationIds : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [TicketTemplate].
 extension TicketTemplatePatterns on TicketTemplate {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_TicketTemplate value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _TicketTemplate() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _TicketTemplate value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _TicketTemplate() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_TicketTemplate value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _TicketTemplate():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _TicketTemplate value)  $default,){
+final _that = this;
+switch (_that) {
+case _TicketTemplate():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_TicketTemplate value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _TicketTemplate() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _TicketTemplate value)?  $default,){
+final _that = this;
+switch (_that) {
+case _TicketTemplate() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'party_id') String partyId,
-            String name,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            String? description,
-            int price,
-            int quantity,
-            @JsonKey(name: 'target_entry_group_ids')
-            List<String> targetEntryGroupIds,
-            @JsonKey(name: 'required_verification_ids')
-            List<String> requiredVerificationIds)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _TicketTemplate() when $default != null:
-        return $default(
-            _that.id,
-            _that.partyId,
-            _that.name,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.description,
-            _that.price,
-            _that.quantity,
-            _that.targetEntryGroupIds,
-            _that.requiredVerificationIds);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'party_id')  String partyId,  String name, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt,  String? description,  int price,  int quantity, @JsonKey(name: 'target_entry_group_ids')  List<String> targetEntryGroupIds, @JsonKey(name: 'required_verification_ids')  List<String> requiredVerificationIds)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _TicketTemplate() when $default != null:
+return $default(_that.id,_that.partyId,_that.name,_that.createdAt,_that.updatedAt,_that.description,_that.price,_that.quantity,_that.targetEntryGroupIds,_that.requiredVerificationIds);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'party_id') String partyId,
-            String name,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            String? description,
-            int price,
-            int quantity,
-            @JsonKey(name: 'target_entry_group_ids')
-            List<String> targetEntryGroupIds,
-            @JsonKey(name: 'required_verification_ids')
-            List<String> requiredVerificationIds)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _TicketTemplate():
-        return $default(
-            _that.id,
-            _that.partyId,
-            _that.name,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.description,
-            _that.price,
-            _that.quantity,
-            _that.targetEntryGroupIds,
-            _that.requiredVerificationIds);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'party_id')  String partyId,  String name, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt,  String? description,  int price,  int quantity, @JsonKey(name: 'target_entry_group_ids')  List<String> targetEntryGroupIds, @JsonKey(name: 'required_verification_ids')  List<String> requiredVerificationIds)  $default,) {final _that = this;
+switch (_that) {
+case _TicketTemplate():
+return $default(_that.id,_that.partyId,_that.name,_that.createdAt,_that.updatedAt,_that.description,_that.price,_that.quantity,_that.targetEntryGroupIds,_that.requiredVerificationIds);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String id,
-            @JsonKey(name: 'party_id') String partyId,
-            String name,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            String? description,
-            int price,
-            int quantity,
-            @JsonKey(name: 'target_entry_group_ids')
-            List<String> targetEntryGroupIds,
-            @JsonKey(name: 'required_verification_ids')
-            List<String> requiredVerificationIds)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _TicketTemplate() when $default != null:
-        return $default(
-            _that.id,
-            _that.partyId,
-            _that.name,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.description,
-            _that.price,
-            _that.quantity,
-            _that.targetEntryGroupIds,
-            _that.requiredVerificationIds);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'party_id')  String partyId,  String name, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt,  String? description,  int price,  int quantity, @JsonKey(name: 'target_entry_group_ids')  List<String> targetEntryGroupIds, @JsonKey(name: 'required_verification_ids')  List<String> requiredVerificationIds)?  $default,) {final _that = this;
+switch (_that) {
+case _TicketTemplate() when $default != null:
+return $default(_that.id,_that.partyId,_that.name,_that.createdAt,_that.updatedAt,_that.description,_that.price,_that.quantity,_that.targetEntryGroupIds,_that.requiredVerificationIds);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _TicketTemplate implements TicketTemplate {
-  const _TicketTemplate(
-      {required this.id,
-      @JsonKey(name: 'party_id') required this.partyId,
-      required this.name,
-      @JsonKey(name: 'created_at') required this.createdAt,
-      @JsonKey(name: 'updated_at') required this.updatedAt,
-      this.description,
-      this.price = 0,
-      this.quantity = 0,
-      @JsonKey(name: 'target_entry_group_ids')
-      final List<String> targetEntryGroupIds = const [],
-      @JsonKey(name: 'required_verification_ids')
-      final List<String> requiredVerificationIds = const []})
-      : _targetEntryGroupIds = targetEntryGroupIds,
-        _requiredVerificationIds = requiredVerificationIds;
-  factory _TicketTemplate.fromJson(Map<String, dynamic> json) =>
-      _$TicketTemplateFromJson(json);
+  const _TicketTemplate({required this.id, @JsonKey(name: 'party_id') required this.partyId, required this.name, @JsonKey(name: 'created_at') required this.createdAt, @JsonKey(name: 'updated_at') required this.updatedAt, this.description, this.price = 0, this.quantity = 0, @JsonKey(name: 'target_entry_group_ids') final  List<String> targetEntryGroupIds = const [], @JsonKey(name: 'required_verification_ids') final  List<String> requiredVerificationIds = const []}): _targetEntryGroupIds = targetEntryGroupIds,_requiredVerificationIds = requiredVerificationIds;
+  factory _TicketTemplate.fromJson(Map<String, dynamic> json) => _$TicketTemplateFromJson(json);
 
-  @override
-  final String id;
-  @override
-  @JsonKey(name: 'party_id')
-  final String partyId;
-  @override
-  final String name;
-  @override
-  @JsonKey(name: 'created_at')
-  final DateTime createdAt;
-  @override
-  @JsonKey(name: 'updated_at')
-  final DateTime updatedAt;
-  @override
-  final String? description;
-  @override
-  @JsonKey()
-  final int price;
-  @override
-  @JsonKey()
-  final int quantity;
-  final List<String> _targetEntryGroupIds;
-  @override
-  @JsonKey(name: 'target_entry_group_ids')
-  List<String> get targetEntryGroupIds {
-    if (_targetEntryGroupIds is EqualUnmodifiableListView)
-      return _targetEntryGroupIds;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_targetEntryGroupIds);
-  }
+@override final  String id;
+@override@JsonKey(name: 'party_id') final  String partyId;
+@override final  String name;
+@override@JsonKey(name: 'created_at') final  DateTime createdAt;
+@override@JsonKey(name: 'updated_at') final  DateTime updatedAt;
+@override final  String? description;
+@override@JsonKey() final  int price;
+@override@JsonKey() final  int quantity;
+ final  List<String> _targetEntryGroupIds;
+@override@JsonKey(name: 'target_entry_group_ids') List<String> get targetEntryGroupIds {
+  if (_targetEntryGroupIds is EqualUnmodifiableListView) return _targetEntryGroupIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_targetEntryGroupIds);
+}
 
-  final List<String> _requiredVerificationIds;
-  @override
-  @JsonKey(name: 'required_verification_ids')
-  List<String> get requiredVerificationIds {
-    if (_requiredVerificationIds is EqualUnmodifiableListView)
-      return _requiredVerificationIds;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_requiredVerificationIds);
-  }
+ final  List<String> _requiredVerificationIds;
+@override@JsonKey(name: 'required_verification_ids') List<String> get requiredVerificationIds {
+  if (_requiredVerificationIds is EqualUnmodifiableListView) return _requiredVerificationIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_requiredVerificationIds);
+}
 
-  /// Create a copy of TicketTemplate
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$TicketTemplateCopyWith<_TicketTemplate> get copyWith =>
-      __$TicketTemplateCopyWithImpl<_TicketTemplate>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$TicketTemplateToJson(
-      this,
-    );
-  }
+/// Create a copy of TicketTemplate
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$TicketTemplateCopyWith<_TicketTemplate> get copyWith => __$TicketTemplateCopyWithImpl<_TicketTemplate>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _TicketTemplate &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.partyId, partyId) || other.partyId == partyId) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt) &&
-            (identical(other.description, description) ||
-                other.description == description) &&
-            (identical(other.price, price) || other.price == price) &&
-            (identical(other.quantity, quantity) ||
-                other.quantity == quantity) &&
-            const DeepCollectionEquality()
-                .equals(other._targetEntryGroupIds, _targetEntryGroupIds) &&
-            const DeepCollectionEquality().equals(
-                other._requiredVerificationIds, _requiredVerificationIds));
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$TicketTemplateToJson(this, );
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      partyId,
-      name,
-      createdAt,
-      updatedAt,
-      description,
-      price,
-      quantity,
-      const DeepCollectionEquality().hash(_targetEntryGroupIds),
-      const DeepCollectionEquality().hash(_requiredVerificationIds));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TicketTemplate&&(identical(other.id, id) || other.id == id)&&(identical(other.partyId, partyId) || other.partyId == partyId)&&(identical(other.name, name) || other.name == name)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.description, description) || other.description == description)&&(identical(other.price, price) || other.price == price)&&(identical(other.quantity, quantity) || other.quantity == quantity)&&const DeepCollectionEquality().equals(other._targetEntryGroupIds, _targetEntryGroupIds)&&const DeepCollectionEquality().equals(other._requiredVerificationIds, _requiredVerificationIds));
+}
 
-  @override
-  String toString() {
-    return 'TicketTemplate(id: $id, partyId: $partyId, name: $name, createdAt: $createdAt, updatedAt: $updatedAt, description: $description, price: $price, quantity: $quantity, targetEntryGroupIds: $targetEntryGroupIds, requiredVerificationIds: $requiredVerificationIds)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,partyId,name,createdAt,updatedAt,description,price,quantity,const DeepCollectionEquality().hash(_targetEntryGroupIds),const DeepCollectionEquality().hash(_requiredVerificationIds));
+
+@override
+String toString() {
+  return 'TicketTemplate(id: $id, partyId: $partyId, name: $name, createdAt: $createdAt, updatedAt: $updatedAt, description: $description, price: $price, quantity: $quantity, targetEntryGroupIds: $targetEntryGroupIds, requiredVerificationIds: $requiredVerificationIds)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$TicketTemplateCopyWith<$Res>
-    implements $TicketTemplateCopyWith<$Res> {
-  factory _$TicketTemplateCopyWith(
-          _TicketTemplate value, $Res Function(_TicketTemplate) _then) =
-      __$TicketTemplateCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'party_id') String partyId,
-      String name,
-      @JsonKey(name: 'created_at') DateTime createdAt,
-      @JsonKey(name: 'updated_at') DateTime updatedAt,
-      String? description,
-      int price,
-      int quantity,
-      @JsonKey(name: 'target_entry_group_ids') List<String> targetEntryGroupIds,
-      @JsonKey(name: 'required_verification_ids')
-      List<String> requiredVerificationIds});
-}
+abstract mixin class _$TicketTemplateCopyWith<$Res> implements $TicketTemplateCopyWith<$Res> {
+  factory _$TicketTemplateCopyWith(_TicketTemplate value, $Res Function(_TicketTemplate) _then) = __$TicketTemplateCopyWithImpl;
+@override @useResult
+$Res call({
+ String id,@JsonKey(name: 'party_id') String partyId, String name,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt, String? description, int price, int quantity,@JsonKey(name: 'target_entry_group_ids') List<String> targetEntryGroupIds,@JsonKey(name: 'required_verification_ids') List<String> requiredVerificationIds
+});
 
+
+
+
+}
 /// @nodoc
 class __$TicketTemplateCopyWithImpl<$Res>
     implements _$TicketTemplateCopyWith<$Res> {
@@ -551,65 +292,25 @@ class __$TicketTemplateCopyWithImpl<$Res>
   final _TicketTemplate _self;
   final $Res Function(_TicketTemplate) _then;
 
-  /// Create a copy of TicketTemplate
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? partyId = null,
-    Object? name = null,
-    Object? createdAt = null,
-    Object? updatedAt = null,
-    Object? description = freezed,
-    Object? price = null,
-    Object? quantity = null,
-    Object? targetEntryGroupIds = null,
-    Object? requiredVerificationIds = null,
-  }) {
-    return _then(_TicketTemplate(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      partyId: null == partyId
-          ? _self.partyId
-          : partyId // ignore: cast_nullable_to_non_nullable
-              as String,
-      name: null == name
-          ? _self.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updatedAt: null == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      description: freezed == description
-          ? _self.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as String?,
-      price: null == price
-          ? _self.price
-          : price // ignore: cast_nullable_to_non_nullable
-              as int,
-      quantity: null == quantity
-          ? _self.quantity
-          : quantity // ignore: cast_nullable_to_non_nullable
-              as int,
-      targetEntryGroupIds: null == targetEntryGroupIds
-          ? _self._targetEntryGroupIds
-          : targetEntryGroupIds // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      requiredVerificationIds: null == requiredVerificationIds
-          ? _self._requiredVerificationIds
-          : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-    ));
-  }
+/// Create a copy of TicketTemplate
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? partyId = null,Object? name = null,Object? createdAt = null,Object? updatedAt = null,Object? description = freezed,Object? price = null,Object? quantity = null,Object? targetEntryGroupIds = null,Object? requiredVerificationIds = null,}) {
+  return _then(_TicketTemplate(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,partyId: null == partyId ? _self.partyId : partyId // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,price: null == price ? _self.price : price // ignore: cast_nullable_to_non_nullable
+as int,quantity: null == quantity ? _self.quantity : quantity // ignore: cast_nullable_to_non_nullable
+as int,targetEntryGroupIds: null == targetEntryGroupIds ? _self._targetEntryGroupIds : targetEntryGroupIds // ignore: cast_nullable_to_non_nullable
+as List<String>,requiredVerificationIds: null == requiredVerificationIds ? _self._requiredVerificationIds : requiredVerificationIds // ignore: cast_nullable_to_non_nullable
+as List<String>,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/ticket_token.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/ticket_token.freezed.dart
@@ -14,392 +14,276 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$TicketToken {
-  String get ticketId;
-  String get eventId;
-  String get userId;
-  String get signature;
-  DateTime get expiresAt;
 
-  /// Create a copy of TicketToken
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $TicketTokenCopyWith<TicketToken> get copyWith =>
-      _$TicketTokenCopyWithImpl<TicketToken>(this as TicketToken, _$identity);
+ String get ticketId; String get eventId; String get userId; String get signature; DateTime get expiresAt;
+/// Create a copy of TicketToken
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TicketTokenCopyWith<TicketToken> get copyWith => _$TicketTokenCopyWithImpl<TicketToken>(this as TicketToken, _$identity);
 
   /// Serializes this TicketToken to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is TicketToken &&
-            (identical(other.ticketId, ticketId) ||
-                other.ticketId == ticketId) &&
-            (identical(other.eventId, eventId) || other.eventId == eventId) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.signature, signature) ||
-                other.signature == signature) &&
-            (identical(other.expiresAt, expiresAt) ||
-                other.expiresAt == expiresAt));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode =>
-      Object.hash(runtimeType, ticketId, eventId, userId, signature, expiresAt);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TicketToken&&(identical(other.ticketId, ticketId) || other.ticketId == ticketId)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.signature, signature) || other.signature == signature)&&(identical(other.expiresAt, expiresAt) || other.expiresAt == expiresAt));
+}
 
-  @override
-  String toString() {
-    return 'TicketToken(ticketId: $ticketId, eventId: $eventId, userId: $userId, signature: $signature, expiresAt: $expiresAt)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,ticketId,eventId,userId,signature,expiresAt);
+
+@override
+String toString() {
+  return 'TicketToken(ticketId: $ticketId, eventId: $eventId, userId: $userId, signature: $signature, expiresAt: $expiresAt)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $TicketTokenCopyWith<$Res> {
-  factory $TicketTokenCopyWith(
-          TicketToken value, $Res Function(TicketToken) _then) =
-      _$TicketTokenCopyWithImpl;
-  @useResult
-  $Res call(
-      {String ticketId,
-      String eventId,
-      String userId,
-      String signature,
-      DateTime expiresAt});
-}
+abstract mixin class $TicketTokenCopyWith<$Res>  {
+  factory $TicketTokenCopyWith(TicketToken value, $Res Function(TicketToken) _then) = _$TicketTokenCopyWithImpl;
+@useResult
+$Res call({
+ String ticketId, String eventId, String userId, String signature, DateTime expiresAt
+});
 
+
+
+
+}
 /// @nodoc
-class _$TicketTokenCopyWithImpl<$Res> implements $TicketTokenCopyWith<$Res> {
+class _$TicketTokenCopyWithImpl<$Res>
+    implements $TicketTokenCopyWith<$Res> {
   _$TicketTokenCopyWithImpl(this._self, this._then);
 
   final TicketToken _self;
   final $Res Function(TicketToken) _then;
 
-  /// Create a copy of TicketToken
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? ticketId = null,
-    Object? eventId = null,
-    Object? userId = null,
-    Object? signature = null,
-    Object? expiresAt = null,
-  }) {
-    return _then(_self.copyWith(
-      ticketId: null == ticketId
-          ? _self.ticketId
-          : ticketId // ignore: cast_nullable_to_non_nullable
-              as String,
-      eventId: null == eventId
-          ? _self.eventId
-          : eventId // ignore: cast_nullable_to_non_nullable
-              as String,
-      userId: null == userId
-          ? _self.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      signature: null == signature
-          ? _self.signature
-          : signature // ignore: cast_nullable_to_non_nullable
-              as String,
-      expiresAt: null == expiresAt
-          ? _self.expiresAt
-          : expiresAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-    ));
-  }
+/// Create a copy of TicketToken
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? ticketId = null,Object? eventId = null,Object? userId = null,Object? signature = null,Object? expiresAt = null,}) {
+  return _then(_self.copyWith(
+ticketId: null == ticketId ? _self.ticketId : ticketId // ignore: cast_nullable_to_non_nullable
+as String,eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,signature: null == signature ? _self.signature : signature // ignore: cast_nullable_to_non_nullable
+as String,expiresAt: null == expiresAt ? _self.expiresAt : expiresAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [TicketToken].
 extension TicketTokenPatterns on TicketToken {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_TicketToken value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _TicketToken() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _TicketToken value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _TicketToken() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_TicketToken value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _TicketToken():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _TicketToken value)  $default,){
+final _that = this;
+switch (_that) {
+case _TicketToken():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_TicketToken value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _TicketToken() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _TicketToken value)?  $default,){
+final _that = this;
+switch (_that) {
+case _TicketToken() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(String ticketId, String eventId, String userId,
-            String signature, DateTime expiresAt)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _TicketToken() when $default != null:
-        return $default(_that.ticketId, _that.eventId, _that.userId,
-            _that.signature, _that.expiresAt);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String ticketId,  String eventId,  String userId,  String signature,  DateTime expiresAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _TicketToken() when $default != null:
+return $default(_that.ticketId,_that.eventId,_that.userId,_that.signature,_that.expiresAt);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(String ticketId, String eventId, String userId,
-            String signature, DateTime expiresAt)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _TicketToken():
-        return $default(_that.ticketId, _that.eventId, _that.userId,
-            _that.signature, _that.expiresAt);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String ticketId,  String eventId,  String userId,  String signature,  DateTime expiresAt)  $default,) {final _that = this;
+switch (_that) {
+case _TicketToken():
+return $default(_that.ticketId,_that.eventId,_that.userId,_that.signature,_that.expiresAt);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(String ticketId, String eventId, String userId,
-            String signature, DateTime expiresAt)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _TicketToken() when $default != null:
-        return $default(_that.ticketId, _that.eventId, _that.userId,
-            _that.signature, _that.expiresAt);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String ticketId,  String eventId,  String userId,  String signature,  DateTime expiresAt)?  $default,) {final _that = this;
+switch (_that) {
+case _TicketToken() when $default != null:
+return $default(_that.ticketId,_that.eventId,_that.userId,_that.signature,_that.expiresAt);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _TicketToken implements TicketToken {
-  const _TicketToken(
-      {required this.ticketId,
-      required this.eventId,
-      required this.userId,
-      required this.signature,
-      required this.expiresAt});
-  factory _TicketToken.fromJson(Map<String, dynamic> json) =>
-      _$TicketTokenFromJson(json);
+  const _TicketToken({required this.ticketId, required this.eventId, required this.userId, required this.signature, required this.expiresAt});
+  factory _TicketToken.fromJson(Map<String, dynamic> json) => _$TicketTokenFromJson(json);
 
-  @override
-  final String ticketId;
-  @override
-  final String eventId;
-  @override
-  final String userId;
-  @override
-  final String signature;
-  @override
-  final DateTime expiresAt;
+@override final  String ticketId;
+@override final  String eventId;
+@override final  String userId;
+@override final  String signature;
+@override final  DateTime expiresAt;
 
-  /// Create a copy of TicketToken
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$TicketTokenCopyWith<_TicketToken> get copyWith =>
-      __$TicketTokenCopyWithImpl<_TicketToken>(this, _$identity);
+/// Create a copy of TicketToken
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$TicketTokenCopyWith<_TicketToken> get copyWith => __$TicketTokenCopyWithImpl<_TicketToken>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$TicketTokenToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$TicketTokenToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _TicketToken &&
-            (identical(other.ticketId, ticketId) ||
-                other.ticketId == ticketId) &&
-            (identical(other.eventId, eventId) || other.eventId == eventId) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.signature, signature) ||
-                other.signature == signature) &&
-            (identical(other.expiresAt, expiresAt) ||
-                other.expiresAt == expiresAt));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TicketToken&&(identical(other.ticketId, ticketId) || other.ticketId == ticketId)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.signature, signature) || other.signature == signature)&&(identical(other.expiresAt, expiresAt) || other.expiresAt == expiresAt));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode =>
-      Object.hash(runtimeType, ticketId, eventId, userId, signature, expiresAt);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,ticketId,eventId,userId,signature,expiresAt);
 
-  @override
-  String toString() {
-    return 'TicketToken(ticketId: $ticketId, eventId: $eventId, userId: $userId, signature: $signature, expiresAt: $expiresAt)';
-  }
+@override
+String toString() {
+  return 'TicketToken(ticketId: $ticketId, eventId: $eventId, userId: $userId, signature: $signature, expiresAt: $expiresAt)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$TicketTokenCopyWith<$Res>
-    implements $TicketTokenCopyWith<$Res> {
-  factory _$TicketTokenCopyWith(
-          _TicketToken value, $Res Function(_TicketToken) _then) =
-      __$TicketTokenCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String ticketId,
-      String eventId,
-      String userId,
-      String signature,
-      DateTime expiresAt});
-}
+abstract mixin class _$TicketTokenCopyWith<$Res> implements $TicketTokenCopyWith<$Res> {
+  factory _$TicketTokenCopyWith(_TicketToken value, $Res Function(_TicketToken) _then) = __$TicketTokenCopyWithImpl;
+@override @useResult
+$Res call({
+ String ticketId, String eventId, String userId, String signature, DateTime expiresAt
+});
 
+
+
+
+}
 /// @nodoc
-class __$TicketTokenCopyWithImpl<$Res> implements _$TicketTokenCopyWith<$Res> {
+class __$TicketTokenCopyWithImpl<$Res>
+    implements _$TicketTokenCopyWith<$Res> {
   __$TicketTokenCopyWithImpl(this._self, this._then);
 
   final _TicketToken _self;
   final $Res Function(_TicketToken) _then;
 
-  /// Create a copy of TicketToken
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? ticketId = null,
-    Object? eventId = null,
-    Object? userId = null,
-    Object? signature = null,
-    Object? expiresAt = null,
-  }) {
-    return _then(_TicketToken(
-      ticketId: null == ticketId
-          ? _self.ticketId
-          : ticketId // ignore: cast_nullable_to_non_nullable
-              as String,
-      eventId: null == eventId
-          ? _self.eventId
-          : eventId // ignore: cast_nullable_to_non_nullable
-              as String,
-      userId: null == userId
-          ? _self.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      signature: null == signature
-          ? _self.signature
-          : signature // ignore: cast_nullable_to_non_nullable
-              as String,
-      expiresAt: null == expiresAt
-          ? _self.expiresAt
-          : expiresAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-    ));
-  }
+/// Create a copy of TicketToken
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? ticketId = null,Object? eventId = null,Object? userId = null,Object? signature = null,Object? expiresAt = null,}) {
+  return _then(_TicketToken(
+ticketId: null == ticketId ? _self.ticketId : ticketId // ignore: cast_nullable_to_non_nullable
+as String,eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,signature: null == signature ? _self.signature : signature // ignore: cast_nullable_to_non_nullable
+as String,expiresAt: null == expiresAt ? _self.expiresAt : expiresAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/user_profile.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/user_profile.freezed.dart
@@ -14,636 +14,297 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$UserProfile {
-  String get id;
-  String get name;
-  String get username;
-  @JsonKey(name: 'phone_number')
-  String? get phoneNumber;
-  String? get gender;
-  @JsonKey(name: 'birth_date')
-  DateTime? get birthDate;
-  @JsonKey(name: 'is_verified')
-  bool get isVerified;
-  @JsonKey(name: 'birth_year')
-  int? get birthYear;
-  @JsonKey(name: 'avatar_url')
-  String? get avatarUrl;
-  @JsonKey(name: 'profile_image_url')
-  String? get profileImageUrl;
-  @JsonKey(name: 'created_at')
-  DateTime? get createdAt;
-  @JsonKey(name: 'updated_at')
-  DateTime? get updatedAt;
 
-  /// Create a copy of UserProfile
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $UserProfileCopyWith<UserProfile> get copyWith =>
-      _$UserProfileCopyWithImpl<UserProfile>(this as UserProfile, _$identity);
+ String get id; String get name; String get username;@JsonKey(name: 'phone_number') String? get phoneNumber; String? get gender;@JsonKey(name: 'birth_date') DateTime? get birthDate;@JsonKey(name: 'is_verified') bool get isVerified;@JsonKey(name: 'birth_year') int? get birthYear;@JsonKey(name: 'avatar_url') String? get avatarUrl;@JsonKey(name: 'profile_image_url') String? get profileImageUrl;@JsonKey(name: 'created_at') DateTime? get createdAt;@JsonKey(name: 'updated_at') DateTime? get updatedAt;
+/// Create a copy of UserProfile
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$UserProfileCopyWith<UserProfile> get copyWith => _$UserProfileCopyWithImpl<UserProfile>(this as UserProfile, _$identity);
 
   /// Serializes this UserProfile to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is UserProfile &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.username, username) ||
-                other.username == username) &&
-            (identical(other.phoneNumber, phoneNumber) ||
-                other.phoneNumber == phoneNumber) &&
-            (identical(other.gender, gender) || other.gender == gender) &&
-            (identical(other.birthDate, birthDate) ||
-                other.birthDate == birthDate) &&
-            (identical(other.isVerified, isVerified) ||
-                other.isVerified == isVerified) &&
-            (identical(other.birthYear, birthYear) ||
-                other.birthYear == birthYear) &&
-            (identical(other.avatarUrl, avatarUrl) ||
-                other.avatarUrl == avatarUrl) &&
-            (identical(other.profileImageUrl, profileImageUrl) ||
-                other.profileImageUrl == profileImageUrl) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      name,
-      username,
-      phoneNumber,
-      gender,
-      birthDate,
-      isVerified,
-      birthYear,
-      avatarUrl,
-      profileImageUrl,
-      createdAt,
-      updatedAt);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is UserProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.username, username) || other.username == username)&&(identical(other.phoneNumber, phoneNumber) || other.phoneNumber == phoneNumber)&&(identical(other.gender, gender) || other.gender == gender)&&(identical(other.birthDate, birthDate) || other.birthDate == birthDate)&&(identical(other.isVerified, isVerified) || other.isVerified == isVerified)&&(identical(other.birthYear, birthYear) || other.birthYear == birthYear)&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl)&&(identical(other.profileImageUrl, profileImageUrl) || other.profileImageUrl == profileImageUrl)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+}
 
-  @override
-  String toString() {
-    return 'UserProfile(id: $id, name: $name, username: $username, phoneNumber: $phoneNumber, gender: $gender, birthDate: $birthDate, isVerified: $isVerified, birthYear: $birthYear, avatarUrl: $avatarUrl, profileImageUrl: $profileImageUrl, createdAt: $createdAt, updatedAt: $updatedAt)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,username,phoneNumber,gender,birthDate,isVerified,birthYear,avatarUrl,profileImageUrl,createdAt,updatedAt);
+
+@override
+String toString() {
+  return 'UserProfile(id: $id, name: $name, username: $username, phoneNumber: $phoneNumber, gender: $gender, birthDate: $birthDate, isVerified: $isVerified, birthYear: $birthYear, avatarUrl: $avatarUrl, profileImageUrl: $profileImageUrl, createdAt: $createdAt, updatedAt: $updatedAt)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $UserProfileCopyWith<$Res> {
-  factory $UserProfileCopyWith(
-          UserProfile value, $Res Function(UserProfile) _then) =
-      _$UserProfileCopyWithImpl;
-  @useResult
-  $Res call(
-      {String id,
-      String name,
-      String username,
-      @JsonKey(name: 'phone_number') String? phoneNumber,
-      String? gender,
-      @JsonKey(name: 'birth_date') DateTime? birthDate,
-      @JsonKey(name: 'is_verified') bool isVerified,
-      @JsonKey(name: 'birth_year') int? birthYear,
-      @JsonKey(name: 'avatar_url') String? avatarUrl,
-      @JsonKey(name: 'profile_image_url') String? profileImageUrl,
-      @JsonKey(name: 'created_at') DateTime? createdAt,
-      @JsonKey(name: 'updated_at') DateTime? updatedAt});
-}
+abstract mixin class $UserProfileCopyWith<$Res>  {
+  factory $UserProfileCopyWith(UserProfile value, $Res Function(UserProfile) _then) = _$UserProfileCopyWithImpl;
+@useResult
+$Res call({
+ String id, String name, String username,@JsonKey(name: 'phone_number') String? phoneNumber, String? gender,@JsonKey(name: 'birth_date') DateTime? birthDate,@JsonKey(name: 'is_verified') bool isVerified,@JsonKey(name: 'birth_year') int? birthYear,@JsonKey(name: 'avatar_url') String? avatarUrl,@JsonKey(name: 'profile_image_url') String? profileImageUrl,@JsonKey(name: 'created_at') DateTime? createdAt,@JsonKey(name: 'updated_at') DateTime? updatedAt
+});
 
+
+
+
+}
 /// @nodoc
-class _$UserProfileCopyWithImpl<$Res> implements $UserProfileCopyWith<$Res> {
+class _$UserProfileCopyWithImpl<$Res>
+    implements $UserProfileCopyWith<$Res> {
   _$UserProfileCopyWithImpl(this._self, this._then);
 
   final UserProfile _self;
   final $Res Function(UserProfile) _then;
 
-  /// Create a copy of UserProfile
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? name = null,
-    Object? username = null,
-    Object? phoneNumber = freezed,
-    Object? gender = freezed,
-    Object? birthDate = freezed,
-    Object? isVerified = null,
-    Object? birthYear = freezed,
-    Object? avatarUrl = freezed,
-    Object? profileImageUrl = freezed,
-    Object? createdAt = freezed,
-    Object? updatedAt = freezed,
-  }) {
-    return _then(_self.copyWith(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      name: null == name
-          ? _self.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      username: null == username
-          ? _self.username
-          : username // ignore: cast_nullable_to_non_nullable
-              as String,
-      phoneNumber: freezed == phoneNumber
-          ? _self.phoneNumber
-          : phoneNumber // ignore: cast_nullable_to_non_nullable
-              as String?,
-      gender: freezed == gender
-          ? _self.gender
-          : gender // ignore: cast_nullable_to_non_nullable
-              as String?,
-      birthDate: freezed == birthDate
-          ? _self.birthDate
-          : birthDate // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      isVerified: null == isVerified
-          ? _self.isVerified
-          : isVerified // ignore: cast_nullable_to_non_nullable
-              as bool,
-      birthYear: freezed == birthYear
-          ? _self.birthYear
-          : birthYear // ignore: cast_nullable_to_non_nullable
-              as int?,
-      avatarUrl: freezed == avatarUrl
-          ? _self.avatarUrl
-          : avatarUrl // ignore: cast_nullable_to_non_nullable
-              as String?,
-      profileImageUrl: freezed == profileImageUrl
-          ? _self.profileImageUrl
-          : profileImageUrl // ignore: cast_nullable_to_non_nullable
-              as String?,
-      createdAt: freezed == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      updatedAt: freezed == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-    ));
-  }
+/// Create a copy of UserProfile
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? username = null,Object? phoneNumber = freezed,Object? gender = freezed,Object? birthDate = freezed,Object? isVerified = null,Object? birthYear = freezed,Object? avatarUrl = freezed,Object? profileImageUrl = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,username: null == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
+as String,phoneNumber: freezed == phoneNumber ? _self.phoneNumber : phoneNumber // ignore: cast_nullable_to_non_nullable
+as String?,gender: freezed == gender ? _self.gender : gender // ignore: cast_nullable_to_non_nullable
+as String?,birthDate: freezed == birthDate ? _self.birthDate : birthDate // ignore: cast_nullable_to_non_nullable
+as DateTime?,isVerified: null == isVerified ? _self.isVerified : isVerified // ignore: cast_nullable_to_non_nullable
+as bool,birthYear: freezed == birthYear ? _self.birthYear : birthYear // ignore: cast_nullable_to_non_nullable
+as int?,avatarUrl: freezed == avatarUrl ? _self.avatarUrl : avatarUrl // ignore: cast_nullable_to_non_nullable
+as String?,profileImageUrl: freezed == profileImageUrl ? _self.profileImageUrl : profileImageUrl // ignore: cast_nullable_to_non_nullable
+as String?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [UserProfile].
 extension UserProfilePatterns on UserProfile {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_UserProfile value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _UserProfile() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _UserProfile value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _UserProfile() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_UserProfile value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _UserProfile():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _UserProfile value)  $default,){
+final _that = this;
+switch (_that) {
+case _UserProfile():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_UserProfile value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _UserProfile() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _UserProfile value)?  $default,){
+final _that = this;
+switch (_that) {
+case _UserProfile() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String id,
-            String name,
-            String username,
-            @JsonKey(name: 'phone_number') String? phoneNumber,
-            String? gender,
-            @JsonKey(name: 'birth_date') DateTime? birthDate,
-            @JsonKey(name: 'is_verified') bool isVerified,
-            @JsonKey(name: 'birth_year') int? birthYear,
-            @JsonKey(name: 'avatar_url') String? avatarUrl,
-            @JsonKey(name: 'profile_image_url') String? profileImageUrl,
-            @JsonKey(name: 'created_at') DateTime? createdAt,
-            @JsonKey(name: 'updated_at') DateTime? updatedAt)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _UserProfile() when $default != null:
-        return $default(
-            _that.id,
-            _that.name,
-            _that.username,
-            _that.phoneNumber,
-            _that.gender,
-            _that.birthDate,
-            _that.isVerified,
-            _that.birthYear,
-            _that.avatarUrl,
-            _that.profileImageUrl,
-            _that.createdAt,
-            _that.updatedAt);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  String username, @JsonKey(name: 'phone_number')  String? phoneNumber,  String? gender, @JsonKey(name: 'birth_date')  DateTime? birthDate, @JsonKey(name: 'is_verified')  bool isVerified, @JsonKey(name: 'birth_year')  int? birthYear, @JsonKey(name: 'avatar_url')  String? avatarUrl, @JsonKey(name: 'profile_image_url')  String? profileImageUrl, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'updated_at')  DateTime? updatedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _UserProfile() when $default != null:
+return $default(_that.id,_that.name,_that.username,_that.phoneNumber,_that.gender,_that.birthDate,_that.isVerified,_that.birthYear,_that.avatarUrl,_that.profileImageUrl,_that.createdAt,_that.updatedAt);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String id,
-            String name,
-            String username,
-            @JsonKey(name: 'phone_number') String? phoneNumber,
-            String? gender,
-            @JsonKey(name: 'birth_date') DateTime? birthDate,
-            @JsonKey(name: 'is_verified') bool isVerified,
-            @JsonKey(name: 'birth_year') int? birthYear,
-            @JsonKey(name: 'avatar_url') String? avatarUrl,
-            @JsonKey(name: 'profile_image_url') String? profileImageUrl,
-            @JsonKey(name: 'created_at') DateTime? createdAt,
-            @JsonKey(name: 'updated_at') DateTime? updatedAt)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _UserProfile():
-        return $default(
-            _that.id,
-            _that.name,
-            _that.username,
-            _that.phoneNumber,
-            _that.gender,
-            _that.birthDate,
-            _that.isVerified,
-            _that.birthYear,
-            _that.avatarUrl,
-            _that.profileImageUrl,
-            _that.createdAt,
-            _that.updatedAt);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  String username, @JsonKey(name: 'phone_number')  String? phoneNumber,  String? gender, @JsonKey(name: 'birth_date')  DateTime? birthDate, @JsonKey(name: 'is_verified')  bool isVerified, @JsonKey(name: 'birth_year')  int? birthYear, @JsonKey(name: 'avatar_url')  String? avatarUrl, @JsonKey(name: 'profile_image_url')  String? profileImageUrl, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'updated_at')  DateTime? updatedAt)  $default,) {final _that = this;
+switch (_that) {
+case _UserProfile():
+return $default(_that.id,_that.name,_that.username,_that.phoneNumber,_that.gender,_that.birthDate,_that.isVerified,_that.birthYear,_that.avatarUrl,_that.profileImageUrl,_that.createdAt,_that.updatedAt);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String id,
-            String name,
-            String username,
-            @JsonKey(name: 'phone_number') String? phoneNumber,
-            String? gender,
-            @JsonKey(name: 'birth_date') DateTime? birthDate,
-            @JsonKey(name: 'is_verified') bool isVerified,
-            @JsonKey(name: 'birth_year') int? birthYear,
-            @JsonKey(name: 'avatar_url') String? avatarUrl,
-            @JsonKey(name: 'profile_image_url') String? profileImageUrl,
-            @JsonKey(name: 'created_at') DateTime? createdAt,
-            @JsonKey(name: 'updated_at') DateTime? updatedAt)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _UserProfile() when $default != null:
-        return $default(
-            _that.id,
-            _that.name,
-            _that.username,
-            _that.phoneNumber,
-            _that.gender,
-            _that.birthDate,
-            _that.isVerified,
-            _that.birthYear,
-            _that.avatarUrl,
-            _that.profileImageUrl,
-            _that.createdAt,
-            _that.updatedAt);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  String username, @JsonKey(name: 'phone_number')  String? phoneNumber,  String? gender, @JsonKey(name: 'birth_date')  DateTime? birthDate, @JsonKey(name: 'is_verified')  bool isVerified, @JsonKey(name: 'birth_year')  int? birthYear, @JsonKey(name: 'avatar_url')  String? avatarUrl, @JsonKey(name: 'profile_image_url')  String? profileImageUrl, @JsonKey(name: 'created_at')  DateTime? createdAt, @JsonKey(name: 'updated_at')  DateTime? updatedAt)?  $default,) {final _that = this;
+switch (_that) {
+case _UserProfile() when $default != null:
+return $default(_that.id,_that.name,_that.username,_that.phoneNumber,_that.gender,_that.birthDate,_that.isVerified,_that.birthYear,_that.avatarUrl,_that.profileImageUrl,_that.createdAt,_that.updatedAt);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _UserProfile implements UserProfile {
-  const _UserProfile(
-      {required this.id,
-      required this.name,
-      required this.username,
-      @JsonKey(name: 'phone_number') this.phoneNumber,
-      this.gender,
-      @JsonKey(name: 'birth_date') this.birthDate,
-      @JsonKey(name: 'is_verified') this.isVerified = false,
-      @JsonKey(name: 'birth_year') this.birthYear,
-      @JsonKey(name: 'avatar_url') this.avatarUrl,
-      @JsonKey(name: 'profile_image_url') this.profileImageUrl,
-      @JsonKey(name: 'created_at') this.createdAt,
-      @JsonKey(name: 'updated_at') this.updatedAt});
-  factory _UserProfile.fromJson(Map<String, dynamic> json) =>
-      _$UserProfileFromJson(json);
+  const _UserProfile({required this.id, required this.name, required this.username, @JsonKey(name: 'phone_number') this.phoneNumber, this.gender, @JsonKey(name: 'birth_date') this.birthDate, @JsonKey(name: 'is_verified') this.isVerified = false, @JsonKey(name: 'birth_year') this.birthYear, @JsonKey(name: 'avatar_url') this.avatarUrl, @JsonKey(name: 'profile_image_url') this.profileImageUrl, @JsonKey(name: 'created_at') this.createdAt, @JsonKey(name: 'updated_at') this.updatedAt});
+  factory _UserProfile.fromJson(Map<String, dynamic> json) => _$UserProfileFromJson(json);
 
-  @override
-  final String id;
-  @override
-  final String name;
-  @override
-  final String username;
-  @override
-  @JsonKey(name: 'phone_number')
-  final String? phoneNumber;
-  @override
-  final String? gender;
-  @override
-  @JsonKey(name: 'birth_date')
-  final DateTime? birthDate;
-  @override
-  @JsonKey(name: 'is_verified')
-  final bool isVerified;
-  @override
-  @JsonKey(name: 'birth_year')
-  final int? birthYear;
-  @override
-  @JsonKey(name: 'avatar_url')
-  final String? avatarUrl;
-  @override
-  @JsonKey(name: 'profile_image_url')
-  final String? profileImageUrl;
-  @override
-  @JsonKey(name: 'created_at')
-  final DateTime? createdAt;
-  @override
-  @JsonKey(name: 'updated_at')
-  final DateTime? updatedAt;
+@override final  String id;
+@override final  String name;
+@override final  String username;
+@override@JsonKey(name: 'phone_number') final  String? phoneNumber;
+@override final  String? gender;
+@override@JsonKey(name: 'birth_date') final  DateTime? birthDate;
+@override@JsonKey(name: 'is_verified') final  bool isVerified;
+@override@JsonKey(name: 'birth_year') final  int? birthYear;
+@override@JsonKey(name: 'avatar_url') final  String? avatarUrl;
+@override@JsonKey(name: 'profile_image_url') final  String? profileImageUrl;
+@override@JsonKey(name: 'created_at') final  DateTime? createdAt;
+@override@JsonKey(name: 'updated_at') final  DateTime? updatedAt;
 
-  /// Create a copy of UserProfile
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$UserProfileCopyWith<_UserProfile> get copyWith =>
-      __$UserProfileCopyWithImpl<_UserProfile>(this, _$identity);
+/// Create a copy of UserProfile
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$UserProfileCopyWith<_UserProfile> get copyWith => __$UserProfileCopyWithImpl<_UserProfile>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$UserProfileToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$UserProfileToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _UserProfile &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.username, username) ||
-                other.username == username) &&
-            (identical(other.phoneNumber, phoneNumber) ||
-                other.phoneNumber == phoneNumber) &&
-            (identical(other.gender, gender) || other.gender == gender) &&
-            (identical(other.birthDate, birthDate) ||
-                other.birthDate == birthDate) &&
-            (identical(other.isVerified, isVerified) ||
-                other.isVerified == isVerified) &&
-            (identical(other.birthYear, birthYear) ||
-                other.birthYear == birthYear) &&
-            (identical(other.avatarUrl, avatarUrl) ||
-                other.avatarUrl == avatarUrl) &&
-            (identical(other.profileImageUrl, profileImageUrl) ||
-                other.profileImageUrl == profileImageUrl) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _UserProfile&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.username, username) || other.username == username)&&(identical(other.phoneNumber, phoneNumber) || other.phoneNumber == phoneNumber)&&(identical(other.gender, gender) || other.gender == gender)&&(identical(other.birthDate, birthDate) || other.birthDate == birthDate)&&(identical(other.isVerified, isVerified) || other.isVerified == isVerified)&&(identical(other.birthYear, birthYear) || other.birthYear == birthYear)&&(identical(other.avatarUrl, avatarUrl) || other.avatarUrl == avatarUrl)&&(identical(other.profileImageUrl, profileImageUrl) || other.profileImageUrl == profileImageUrl)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      name,
-      username,
-      phoneNumber,
-      gender,
-      birthDate,
-      isVerified,
-      birthYear,
-      avatarUrl,
-      profileImageUrl,
-      createdAt,
-      updatedAt);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,username,phoneNumber,gender,birthDate,isVerified,birthYear,avatarUrl,profileImageUrl,createdAt,updatedAt);
 
-  @override
-  String toString() {
-    return 'UserProfile(id: $id, name: $name, username: $username, phoneNumber: $phoneNumber, gender: $gender, birthDate: $birthDate, isVerified: $isVerified, birthYear: $birthYear, avatarUrl: $avatarUrl, profileImageUrl: $profileImageUrl, createdAt: $createdAt, updatedAt: $updatedAt)';
-  }
+@override
+String toString() {
+  return 'UserProfile(id: $id, name: $name, username: $username, phoneNumber: $phoneNumber, gender: $gender, birthDate: $birthDate, isVerified: $isVerified, birthYear: $birthYear, avatarUrl: $avatarUrl, profileImageUrl: $profileImageUrl, createdAt: $createdAt, updatedAt: $updatedAt)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$UserProfileCopyWith<$Res>
-    implements $UserProfileCopyWith<$Res> {
-  factory _$UserProfileCopyWith(
-          _UserProfile value, $Res Function(_UserProfile) _then) =
-      __$UserProfileCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String id,
-      String name,
-      String username,
-      @JsonKey(name: 'phone_number') String? phoneNumber,
-      String? gender,
-      @JsonKey(name: 'birth_date') DateTime? birthDate,
-      @JsonKey(name: 'is_verified') bool isVerified,
-      @JsonKey(name: 'birth_year') int? birthYear,
-      @JsonKey(name: 'avatar_url') String? avatarUrl,
-      @JsonKey(name: 'profile_image_url') String? profileImageUrl,
-      @JsonKey(name: 'created_at') DateTime? createdAt,
-      @JsonKey(name: 'updated_at') DateTime? updatedAt});
-}
+abstract mixin class _$UserProfileCopyWith<$Res> implements $UserProfileCopyWith<$Res> {
+  factory _$UserProfileCopyWith(_UserProfile value, $Res Function(_UserProfile) _then) = __$UserProfileCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String name, String username,@JsonKey(name: 'phone_number') String? phoneNumber, String? gender,@JsonKey(name: 'birth_date') DateTime? birthDate,@JsonKey(name: 'is_verified') bool isVerified,@JsonKey(name: 'birth_year') int? birthYear,@JsonKey(name: 'avatar_url') String? avatarUrl,@JsonKey(name: 'profile_image_url') String? profileImageUrl,@JsonKey(name: 'created_at') DateTime? createdAt,@JsonKey(name: 'updated_at') DateTime? updatedAt
+});
 
+
+
+
+}
 /// @nodoc
-class __$UserProfileCopyWithImpl<$Res> implements _$UserProfileCopyWith<$Res> {
+class __$UserProfileCopyWithImpl<$Res>
+    implements _$UserProfileCopyWith<$Res> {
   __$UserProfileCopyWithImpl(this._self, this._then);
 
   final _UserProfile _self;
   final $Res Function(_UserProfile) _then;
 
-  /// Create a copy of UserProfile
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? name = null,
-    Object? username = null,
-    Object? phoneNumber = freezed,
-    Object? gender = freezed,
-    Object? birthDate = freezed,
-    Object? isVerified = null,
-    Object? birthYear = freezed,
-    Object? avatarUrl = freezed,
-    Object? profileImageUrl = freezed,
-    Object? createdAt = freezed,
-    Object? updatedAt = freezed,
-  }) {
-    return _then(_UserProfile(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      name: null == name
-          ? _self.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      username: null == username
-          ? _self.username
-          : username // ignore: cast_nullable_to_non_nullable
-              as String,
-      phoneNumber: freezed == phoneNumber
-          ? _self.phoneNumber
-          : phoneNumber // ignore: cast_nullable_to_non_nullable
-              as String?,
-      gender: freezed == gender
-          ? _self.gender
-          : gender // ignore: cast_nullable_to_non_nullable
-              as String?,
-      birthDate: freezed == birthDate
-          ? _self.birthDate
-          : birthDate // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      isVerified: null == isVerified
-          ? _self.isVerified
-          : isVerified // ignore: cast_nullable_to_non_nullable
-              as bool,
-      birthYear: freezed == birthYear
-          ? _self.birthYear
-          : birthYear // ignore: cast_nullable_to_non_nullable
-              as int?,
-      avatarUrl: freezed == avatarUrl
-          ? _self.avatarUrl
-          : avatarUrl // ignore: cast_nullable_to_non_nullable
-              as String?,
-      profileImageUrl: freezed == profileImageUrl
-          ? _self.profileImageUrl
-          : profileImageUrl // ignore: cast_nullable_to_non_nullable
-              as String?,
-      createdAt: freezed == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      updatedAt: freezed == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-    ));
-  }
+/// Create a copy of UserProfile
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? username = null,Object? phoneNumber = freezed,Object? gender = freezed,Object? birthDate = freezed,Object? isVerified = null,Object? birthYear = freezed,Object? avatarUrl = freezed,Object? profileImageUrl = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,}) {
+  return _then(_UserProfile(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,username: null == username ? _self.username : username // ignore: cast_nullable_to_non_nullable
+as String,phoneNumber: freezed == phoneNumber ? _self.phoneNumber : phoneNumber // ignore: cast_nullable_to_non_nullable
+as String?,gender: freezed == gender ? _self.gender : gender // ignore: cast_nullable_to_non_nullable
+as String?,birthDate: freezed == birthDate ? _self.birthDate : birthDate // ignore: cast_nullable_to_non_nullable
+as DateTime?,isVerified: null == isVerified ? _self.isVerified : isVerified // ignore: cast_nullable_to_non_nullable
+as bool,birthYear: freezed == birthYear ? _self.birthYear : birthYear // ignore: cast_nullable_to_non_nullable
+as int?,avatarUrl: freezed == avatarUrl ? _self.avatarUrl : avatarUrl // ignore: cast_nullable_to_non_nullable
+as String?,profileImageUrl: freezed == profileImageUrl ? _self.profileImageUrl : profileImageUrl // ignore: cast_nullable_to_non_nullable
+as String?,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,updatedAt: freezed == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/user_settings.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/user_settings.freezed.dart
@@ -14,356 +14,252 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$UserSettings {
-  @JsonKey(name: 'user_id')
-  String get userId;
-  @JsonKey(name: 'updated_at')
-  DateTime get updatedAt;
-  @JsonKey(name: 'marketing_consent')
-  bool get marketingConsent;
-  @JsonKey(name: 'service_notification')
-  bool get serviceNotification;
 
-  /// Create a copy of UserSettings
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $UserSettingsCopyWith<UserSettings> get copyWith =>
-      _$UserSettingsCopyWithImpl<UserSettings>(
-          this as UserSettings, _$identity);
+@JsonKey(name: 'user_id') String get userId;@JsonKey(name: 'updated_at') DateTime get updatedAt;@JsonKey(name: 'marketing_consent') bool get marketingConsent;@JsonKey(name: 'service_notification') bool get serviceNotification;
+/// Create a copy of UserSettings
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$UserSettingsCopyWith<UserSettings> get copyWith => _$UserSettingsCopyWithImpl<UserSettings>(this as UserSettings, _$identity);
 
   /// Serializes this UserSettings to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is UserSettings &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt) &&
-            (identical(other.marketingConsent, marketingConsent) ||
-                other.marketingConsent == marketingConsent) &&
-            (identical(other.serviceNotification, serviceNotification) ||
-                other.serviceNotification == serviceNotification));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, userId, updatedAt, marketingConsent, serviceNotification);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is UserSettings&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.marketingConsent, marketingConsent) || other.marketingConsent == marketingConsent)&&(identical(other.serviceNotification, serviceNotification) || other.serviceNotification == serviceNotification));
+}
 
-  @override
-  String toString() {
-    return 'UserSettings(userId: $userId, updatedAt: $updatedAt, marketingConsent: $marketingConsent, serviceNotification: $serviceNotification)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,userId,updatedAt,marketingConsent,serviceNotification);
+
+@override
+String toString() {
+  return 'UserSettings(userId: $userId, updatedAt: $updatedAt, marketingConsent: $marketingConsent, serviceNotification: $serviceNotification)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $UserSettingsCopyWith<$Res> {
-  factory $UserSettingsCopyWith(
-          UserSettings value, $Res Function(UserSettings) _then) =
-      _$UserSettingsCopyWithImpl;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'user_id') String userId,
-      @JsonKey(name: 'updated_at') DateTime updatedAt,
-      @JsonKey(name: 'marketing_consent') bool marketingConsent,
-      @JsonKey(name: 'service_notification') bool serviceNotification});
-}
+abstract mixin class $UserSettingsCopyWith<$Res>  {
+  factory $UserSettingsCopyWith(UserSettings value, $Res Function(UserSettings) _then) = _$UserSettingsCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'user_id') String userId,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'marketing_consent') bool marketingConsent,@JsonKey(name: 'service_notification') bool serviceNotification
+});
 
+
+
+
+}
 /// @nodoc
-class _$UserSettingsCopyWithImpl<$Res> implements $UserSettingsCopyWith<$Res> {
+class _$UserSettingsCopyWithImpl<$Res>
+    implements $UserSettingsCopyWith<$Res> {
   _$UserSettingsCopyWithImpl(this._self, this._then);
 
   final UserSettings _self;
   final $Res Function(UserSettings) _then;
 
-  /// Create a copy of UserSettings
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? userId = null,
-    Object? updatedAt = null,
-    Object? marketingConsent = null,
-    Object? serviceNotification = null,
-  }) {
-    return _then(_self.copyWith(
-      userId: null == userId
-          ? _self.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      updatedAt: null == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      marketingConsent: null == marketingConsent
-          ? _self.marketingConsent
-          : marketingConsent // ignore: cast_nullable_to_non_nullable
-              as bool,
-      serviceNotification: null == serviceNotification
-          ? _self.serviceNotification
-          : serviceNotification // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ));
-  }
+/// Create a copy of UserSettings
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? userId = null,Object? updatedAt = null,Object? marketingConsent = null,Object? serviceNotification = null,}) {
+  return _then(_self.copyWith(
+userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,marketingConsent: null == marketingConsent ? _self.marketingConsent : marketingConsent // ignore: cast_nullable_to_non_nullable
+as bool,serviceNotification: null == serviceNotification ? _self.serviceNotification : serviceNotification // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [UserSettings].
 extension UserSettingsPatterns on UserSettings {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_UserSettings value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _UserSettings() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _UserSettings value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _UserSettings() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_UserSettings value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _UserSettings():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _UserSettings value)  $default,){
+final _that = this;
+switch (_that) {
+case _UserSettings():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_UserSettings value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _UserSettings() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _UserSettings value)?  $default,){
+final _that = this;
+switch (_that) {
+case _UserSettings() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            @JsonKey(name: 'user_id') String userId,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'marketing_consent') bool marketingConsent,
-            @JsonKey(name: 'service_notification') bool serviceNotification)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _UserSettings() when $default != null:
-        return $default(_that.userId, _that.updatedAt, _that.marketingConsent,
-            _that.serviceNotification);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'marketing_consent')  bool marketingConsent, @JsonKey(name: 'service_notification')  bool serviceNotification)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _UserSettings() when $default != null:
+return $default(_that.userId,_that.updatedAt,_that.marketingConsent,_that.serviceNotification);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            @JsonKey(name: 'user_id') String userId,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'marketing_consent') bool marketingConsent,
-            @JsonKey(name: 'service_notification') bool serviceNotification)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _UserSettings():
-        return $default(_that.userId, _that.updatedAt, _that.marketingConsent,
-            _that.serviceNotification);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'marketing_consent')  bool marketingConsent, @JsonKey(name: 'service_notification')  bool serviceNotification)  $default,) {final _that = this;
+switch (_that) {
+case _UserSettings():
+return $default(_that.userId,_that.updatedAt,_that.marketingConsent,_that.serviceNotification);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            @JsonKey(name: 'user_id') String userId,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'marketing_consent') bool marketingConsent,
-            @JsonKey(name: 'service_notification') bool serviceNotification)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _UserSettings() when $default != null:
-        return $default(_that.userId, _that.updatedAt, _that.marketingConsent,
-            _that.serviceNotification);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'marketing_consent')  bool marketingConsent, @JsonKey(name: 'service_notification')  bool serviceNotification)?  $default,) {final _that = this;
+switch (_that) {
+case _UserSettings() when $default != null:
+return $default(_that.userId,_that.updatedAt,_that.marketingConsent,_that.serviceNotification);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _UserSettings implements UserSettings {
-  const _UserSettings(
-      {@JsonKey(name: 'user_id') required this.userId,
-      @JsonKey(name: 'updated_at') required this.updatedAt,
-      @JsonKey(name: 'marketing_consent') this.marketingConsent = false,
-      @JsonKey(name: 'service_notification') this.serviceNotification = true});
-  factory _UserSettings.fromJson(Map<String, dynamic> json) =>
-      _$UserSettingsFromJson(json);
+  const _UserSettings({@JsonKey(name: 'user_id') required this.userId, @JsonKey(name: 'updated_at') required this.updatedAt, @JsonKey(name: 'marketing_consent') this.marketingConsent = false, @JsonKey(name: 'service_notification') this.serviceNotification = true});
+  factory _UserSettings.fromJson(Map<String, dynamic> json) => _$UserSettingsFromJson(json);
 
-  @override
-  @JsonKey(name: 'user_id')
-  final String userId;
-  @override
-  @JsonKey(name: 'updated_at')
-  final DateTime updatedAt;
-  @override
-  @JsonKey(name: 'marketing_consent')
-  final bool marketingConsent;
-  @override
-  @JsonKey(name: 'service_notification')
-  final bool serviceNotification;
+@override@JsonKey(name: 'user_id') final  String userId;
+@override@JsonKey(name: 'updated_at') final  DateTime updatedAt;
+@override@JsonKey(name: 'marketing_consent') final  bool marketingConsent;
+@override@JsonKey(name: 'service_notification') final  bool serviceNotification;
 
-  /// Create a copy of UserSettings
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$UserSettingsCopyWith<_UserSettings> get copyWith =>
-      __$UserSettingsCopyWithImpl<_UserSettings>(this, _$identity);
+/// Create a copy of UserSettings
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$UserSettingsCopyWith<_UserSettings> get copyWith => __$UserSettingsCopyWithImpl<_UserSettings>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$UserSettingsToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$UserSettingsToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _UserSettings &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt) &&
-            (identical(other.marketingConsent, marketingConsent) ||
-                other.marketingConsent == marketingConsent) &&
-            (identical(other.serviceNotification, serviceNotification) ||
-                other.serviceNotification == serviceNotification));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _UserSettings&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.marketingConsent, marketingConsent) || other.marketingConsent == marketingConsent)&&(identical(other.serviceNotification, serviceNotification) || other.serviceNotification == serviceNotification));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, userId, updatedAt, marketingConsent, serviceNotification);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,userId,updatedAt,marketingConsent,serviceNotification);
 
-  @override
-  String toString() {
-    return 'UserSettings(userId: $userId, updatedAt: $updatedAt, marketingConsent: $marketingConsent, serviceNotification: $serviceNotification)';
-  }
+@override
+String toString() {
+  return 'UserSettings(userId: $userId, updatedAt: $updatedAt, marketingConsent: $marketingConsent, serviceNotification: $serviceNotification)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$UserSettingsCopyWith<$Res>
-    implements $UserSettingsCopyWith<$Res> {
-  factory _$UserSettingsCopyWith(
-          _UserSettings value, $Res Function(_UserSettings) _then) =
-      __$UserSettingsCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'user_id') String userId,
-      @JsonKey(name: 'updated_at') DateTime updatedAt,
-      @JsonKey(name: 'marketing_consent') bool marketingConsent,
-      @JsonKey(name: 'service_notification') bool serviceNotification});
-}
+abstract mixin class _$UserSettingsCopyWith<$Res> implements $UserSettingsCopyWith<$Res> {
+  factory _$UserSettingsCopyWith(_UserSettings value, $Res Function(_UserSettings) _then) = __$UserSettingsCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'user_id') String userId,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'marketing_consent') bool marketingConsent,@JsonKey(name: 'service_notification') bool serviceNotification
+});
 
+
+
+
+}
 /// @nodoc
 class __$UserSettingsCopyWithImpl<$Res>
     implements _$UserSettingsCopyWith<$Res> {
@@ -372,35 +268,19 @@ class __$UserSettingsCopyWithImpl<$Res>
   final _UserSettings _self;
   final $Res Function(_UserSettings) _then;
 
-  /// Create a copy of UserSettings
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? userId = null,
-    Object? updatedAt = null,
-    Object? marketingConsent = null,
-    Object? serviceNotification = null,
-  }) {
-    return _then(_UserSettings(
-      userId: null == userId
-          ? _self.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      updatedAt: null == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      marketingConsent: null == marketingConsent
-          ? _self.marketingConsent
-          : marketingConsent // ignore: cast_nullable_to_non_nullable
-              as bool,
-      serviceNotification: null == serviceNotification
-          ? _self.serviceNotification
-          : serviceNotification // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ));
-  }
+/// Create a copy of UserSettings
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? userId = null,Object? updatedAt = null,Object? marketingConsent = null,Object? serviceNotification = null,}) {
+  return _then(_UserSettings(
+userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,marketingConsent: null == marketingConsent ? _self.marketingConsent : marketingConsent // ignore: cast_nullable_to_non_nullable
+as bool,serviceNotification: null == serviceNotification ? _self.serviceNotification : serviceNotification // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/verification.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/verification.dart
@@ -35,13 +35,6 @@ enum VerificationStatus {
 
   /// Submission was rejected.
   rejected,
-
-  /// Submission requires user corrections.
-  @JsonValue('needs_correction')
-  needsCorrection,
-
-  /// Submission was cancelled.
-  cancelled,
 }
 
 /// Represents a single field definition in the dynamic form schema.

--- a/shared/packages/minglit_kit/lib/src/data/models/verification.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/verification.freezed.dart
@@ -14,77 +14,54 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$VerificationFormField {
-  /// Input type: 'text', 'number', 'file', 'date', etc.
-  String get type;
 
-  /// UI Label (e.g., '회사명').
-  String get label;
-
-  /// Unique key for the field (e.g., 'company_name').
-  /// Defaults to empty string when missing from DB data.
-  String get key;
-
-  /// Whether this field is mandatory.
-  bool get required;
-
-  /// Placeholder text for the input.
-  String? get placeholder;
-
-  /// List of options (for select/radio types).
-  List<String>? get options;
-
-  /// Create a copy of VerificationFormField
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $VerificationFormFieldCopyWith<VerificationFormField> get copyWith =>
-      _$VerificationFormFieldCopyWithImpl<VerificationFormField>(
-          this as VerificationFormField, _$identity);
+/// Input type: 'text', 'number', 'file', 'date', etc.
+ String get type;/// UI Label (e.g., '회사명').
+ String get label;/// Unique key for the field (e.g., 'company_name').
+/// Defaults to empty string when missing from DB data.
+ String get key;/// Whether this field is mandatory.
+ bool get required;/// Placeholder text for the input.
+ String? get placeholder;/// List of options (for select/radio types).
+ List<String>? get options;
+/// Create a copy of VerificationFormField
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$VerificationFormFieldCopyWith<VerificationFormField> get copyWith => _$VerificationFormFieldCopyWithImpl<VerificationFormField>(this as VerificationFormField, _$identity);
 
   /// Serializes this VerificationFormField to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is VerificationFormField &&
-            (identical(other.type, type) || other.type == type) &&
-            (identical(other.label, label) || other.label == label) &&
-            (identical(other.key, key) || other.key == key) &&
-            (identical(other.required, required) ||
-                other.required == required) &&
-            (identical(other.placeholder, placeholder) ||
-                other.placeholder == placeholder) &&
-            const DeepCollectionEquality().equals(other.options, options));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, type, label, key, required,
-      placeholder, const DeepCollectionEquality().hash(options));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VerificationFormField&&(identical(other.type, type) || other.type == type)&&(identical(other.label, label) || other.label == label)&&(identical(other.key, key) || other.key == key)&&(identical(other.required, required) || other.required == required)&&(identical(other.placeholder, placeholder) || other.placeholder == placeholder)&&const DeepCollectionEquality().equals(other.options, options));
+}
 
-  @override
-  String toString() {
-    return 'VerificationFormField(type: $type, label: $label, key: $key, required: $required, placeholder: $placeholder, options: $options)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type,label,key,required,placeholder,const DeepCollectionEquality().hash(options));
+
+@override
+String toString() {
+  return 'VerificationFormField(type: $type, label: $label, key: $key, required: $required, placeholder: $placeholder, options: $options)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $VerificationFormFieldCopyWith<$Res> {
-  factory $VerificationFormFieldCopyWith(VerificationFormField value,
-          $Res Function(VerificationFormField) _then) =
-      _$VerificationFormFieldCopyWithImpl;
-  @useResult
-  $Res call(
-      {String type,
-      String label,
-      String key,
-      bool required,
-      String? placeholder,
-      List<String>? options});
-}
+abstract mixin class $VerificationFormFieldCopyWith<$Res>  {
+  factory $VerificationFormFieldCopyWith(VerificationFormField value, $Res Function(VerificationFormField) _then) = _$VerificationFormFieldCopyWithImpl;
+@useResult
+$Res call({
+ String type, String label, String key, bool required, String? placeholder, List<String>? options
+});
 
+
+
+
+}
 /// @nodoc
 class _$VerificationFormFieldCopyWithImpl<$Res>
     implements $VerificationFormFieldCopyWith<$Res> {
@@ -93,322 +70,223 @@ class _$VerificationFormFieldCopyWithImpl<$Res>
   final VerificationFormField _self;
   final $Res Function(VerificationFormField) _then;
 
-  /// Create a copy of VerificationFormField
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? type = null,
-    Object? label = null,
-    Object? key = null,
-    Object? required = null,
-    Object? placeholder = freezed,
-    Object? options = freezed,
-  }) {
-    return _then(_self.copyWith(
-      type: null == type
-          ? _self.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as String,
-      label: null == label
-          ? _self.label
-          : label // ignore: cast_nullable_to_non_nullable
-              as String,
-      key: null == key
-          ? _self.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String,
-      required: null == required
-          ? _self.required
-          : required // ignore: cast_nullable_to_non_nullable
-              as bool,
-      placeholder: freezed == placeholder
-          ? _self.placeholder
-          : placeholder // ignore: cast_nullable_to_non_nullable
-              as String?,
-      options: freezed == options
-          ? _self.options
-          : options // ignore: cast_nullable_to_non_nullable
-              as List<String>?,
-    ));
-  }
+/// Create a copy of VerificationFormField
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? type = null,Object? label = null,Object? key = null,Object? required = null,Object? placeholder = freezed,Object? options = freezed,}) {
+  return _then(_self.copyWith(
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,label: null == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String,key: null == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String,required: null == required ? _self.required : required // ignore: cast_nullable_to_non_nullable
+as bool,placeholder: freezed == placeholder ? _self.placeholder : placeholder // ignore: cast_nullable_to_non_nullable
+as String?,options: freezed == options ? _self.options : options // ignore: cast_nullable_to_non_nullable
+as List<String>?,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [VerificationFormField].
 extension VerificationFormFieldPatterns on VerificationFormField {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_VerificationFormField value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _VerificationFormField() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _VerificationFormField value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _VerificationFormField() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_VerificationFormField value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _VerificationFormField():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _VerificationFormField value)  $default,){
+final _that = this;
+switch (_that) {
+case _VerificationFormField():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_VerificationFormField value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _VerificationFormField() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _VerificationFormField value)?  $default,){
+final _that = this;
+switch (_that) {
+case _VerificationFormField() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(String type, String label, String key, bool required,
-            String? placeholder, List<String>? options)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _VerificationFormField() when $default != null:
-        return $default(_that.type, _that.label, _that.key, _that.required,
-            _that.placeholder, _that.options);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String type,  String label,  String key,  bool required,  String? placeholder,  List<String>? options)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _VerificationFormField() when $default != null:
+return $default(_that.type,_that.label,_that.key,_that.required,_that.placeholder,_that.options);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(String type, String label, String key, bool required,
-            String? placeholder, List<String>? options)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _VerificationFormField():
-        return $default(_that.type, _that.label, _that.key, _that.required,
-            _that.placeholder, _that.options);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String type,  String label,  String key,  bool required,  String? placeholder,  List<String>? options)  $default,) {final _that = this;
+switch (_that) {
+case _VerificationFormField():
+return $default(_that.type,_that.label,_that.key,_that.required,_that.placeholder,_that.options);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(String type, String label, String key, bool required,
-            String? placeholder, List<String>? options)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _VerificationFormField() when $default != null:
-        return $default(_that.type, _that.label, _that.key, _that.required,
-            _that.placeholder, _that.options);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String type,  String label,  String key,  bool required,  String? placeholder,  List<String>? options)?  $default,) {final _that = this;
+switch (_that) {
+case _VerificationFormField() when $default != null:
+return $default(_that.type,_that.label,_that.key,_that.required,_that.placeholder,_that.options);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _VerificationFormField implements VerificationFormField {
-  const _VerificationFormField(
-      {required this.type,
-      required this.label,
-      this.key = '',
-      this.required = true,
-      this.placeholder,
-      final List<String>? options})
-      : _options = options;
-  factory _VerificationFormField.fromJson(Map<String, dynamic> json) =>
-      _$VerificationFormFieldFromJson(json);
+  const _VerificationFormField({required this.type, required this.label, this.key = '', this.required = true, this.placeholder, final  List<String>? options}): _options = options;
+  factory _VerificationFormField.fromJson(Map<String, dynamic> json) => _$VerificationFormFieldFromJson(json);
 
-  /// Input type: 'text', 'number', 'file', 'date', etc.
-  @override
-  final String type;
+/// Input type: 'text', 'number', 'file', 'date', etc.
+@override final  String type;
+/// UI Label (e.g., '회사명').
+@override final  String label;
+/// Unique key for the field (e.g., 'company_name').
+/// Defaults to empty string when missing from DB data.
+@override@JsonKey() final  String key;
+/// Whether this field is mandatory.
+@override@JsonKey() final  bool required;
+/// Placeholder text for the input.
+@override final  String? placeholder;
+/// List of options (for select/radio types).
+ final  List<String>? _options;
+/// List of options (for select/radio types).
+@override List<String>? get options {
+  final value = _options;
+  if (value == null) return null;
+  if (_options is EqualUnmodifiableListView) return _options;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
 
-  /// UI Label (e.g., '회사명').
-  @override
-  final String label;
 
-  /// Unique key for the field (e.g., 'company_name').
-  /// Defaults to empty string when missing from DB data.
-  @override
-  @JsonKey()
-  final String key;
+/// Create a copy of VerificationFormField
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$VerificationFormFieldCopyWith<_VerificationFormField> get copyWith => __$VerificationFormFieldCopyWithImpl<_VerificationFormField>(this, _$identity);
 
-  /// Whether this field is mandatory.
-  @override
-  @JsonKey()
-  final bool required;
+@override
+Map<String, dynamic> toJson() {
+  return _$VerificationFormFieldToJson(this, );
+}
 
-  /// Placeholder text for the input.
-  @override
-  final String? placeholder;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VerificationFormField&&(identical(other.type, type) || other.type == type)&&(identical(other.label, label) || other.label == label)&&(identical(other.key, key) || other.key == key)&&(identical(other.required, required) || other.required == required)&&(identical(other.placeholder, placeholder) || other.placeholder == placeholder)&&const DeepCollectionEquality().equals(other._options, _options));
+}
 
-  /// List of options (for select/radio types).
-  final List<String>? _options;
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type,label,key,required,placeholder,const DeepCollectionEquality().hash(_options));
 
-  /// List of options (for select/radio types).
-  @override
-  List<String>? get options {
-    final value = _options;
-    if (value == null) return null;
-    if (_options is EqualUnmodifiableListView) return _options;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(value);
-  }
+@override
+String toString() {
+  return 'VerificationFormField(type: $type, label: $label, key: $key, required: $required, placeholder: $placeholder, options: $options)';
+}
 
-  /// Create a copy of VerificationFormField
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$VerificationFormFieldCopyWith<_VerificationFormField> get copyWith =>
-      __$VerificationFormFieldCopyWithImpl<_VerificationFormField>(
-          this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$VerificationFormFieldToJson(
-      this,
-    );
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _VerificationFormField &&
-            (identical(other.type, type) || other.type == type) &&
-            (identical(other.label, label) || other.label == label) &&
-            (identical(other.key, key) || other.key == key) &&
-            (identical(other.required, required) ||
-                other.required == required) &&
-            (identical(other.placeholder, placeholder) ||
-                other.placeholder == placeholder) &&
-            const DeepCollectionEquality().equals(other._options, _options));
-  }
-
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, type, label, key, required,
-      placeholder, const DeepCollectionEquality().hash(_options));
-
-  @override
-  String toString() {
-    return 'VerificationFormField(type: $type, label: $label, key: $key, required: $required, placeholder: $placeholder, options: $options)';
-  }
 }
 
 /// @nodoc
-abstract mixin class _$VerificationFormFieldCopyWith<$Res>
-    implements $VerificationFormFieldCopyWith<$Res> {
-  factory _$VerificationFormFieldCopyWith(_VerificationFormField value,
-          $Res Function(_VerificationFormField) _then) =
-      __$VerificationFormFieldCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String type,
-      String label,
-      String key,
-      bool required,
-      String? placeholder,
-      List<String>? options});
-}
+abstract mixin class _$VerificationFormFieldCopyWith<$Res> implements $VerificationFormFieldCopyWith<$Res> {
+  factory _$VerificationFormFieldCopyWith(_VerificationFormField value, $Res Function(_VerificationFormField) _then) = __$VerificationFormFieldCopyWithImpl;
+@override @useResult
+$Res call({
+ String type, String label, String key, bool required, String? placeholder, List<String>? options
+});
 
+
+
+
+}
 /// @nodoc
 class __$VerificationFormFieldCopyWithImpl<$Res>
     implements _$VerificationFormFieldCopyWith<$Res> {
@@ -417,595 +295,305 @@ class __$VerificationFormFieldCopyWithImpl<$Res>
   final _VerificationFormField _self;
   final $Res Function(_VerificationFormField) _then;
 
-  /// Create a copy of VerificationFormField
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? type = null,
-    Object? label = null,
-    Object? key = null,
-    Object? required = null,
-    Object? placeholder = freezed,
-    Object? options = freezed,
-  }) {
-    return _then(_VerificationFormField(
-      type: null == type
-          ? _self.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as String,
-      label: null == label
-          ? _self.label
-          : label // ignore: cast_nullable_to_non_nullable
-              as String,
-      key: null == key
-          ? _self.key
-          : key // ignore: cast_nullable_to_non_nullable
-              as String,
-      required: null == required
-          ? _self.required
-          : required // ignore: cast_nullable_to_non_nullable
-              as bool,
-      placeholder: freezed == placeholder
-          ? _self.placeholder
-          : placeholder // ignore: cast_nullable_to_non_nullable
-              as String?,
-      options: freezed == options
-          ? _self._options
-          : options // ignore: cast_nullable_to_non_nullable
-              as List<String>?,
-    ));
-  }
+/// Create a copy of VerificationFormField
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? type = null,Object? label = null,Object? key = null,Object? required = null,Object? placeholder = freezed,Object? options = freezed,}) {
+  return _then(_VerificationFormField(
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,label: null == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String,key: null == key ? _self.key : key // ignore: cast_nullable_to_non_nullable
+as String,required: null == required ? _self.required : required // ignore: cast_nullable_to_non_nullable
+as bool,placeholder: freezed == placeholder ? _self.placeholder : placeholder // ignore: cast_nullable_to_non_nullable
+as String?,options: freezed == options ? _self._options : options // ignore: cast_nullable_to_non_nullable
+as List<String>?,
+  ));
 }
+
+
+}
+
 
 /// @nodoc
 mixin _$Verification {
-  String get id;
-  VerificationCategory get category;
 
-  /// Internal identifier (e.g., 'global_career').
-  @JsonKey(name: 'internal_name')
-  String get internalName;
-
-  /// Display name shown to users (e.g., '직장 인증').
-  @JsonKey(name: 'display_name')
-  String get displayName;
-
-  /// Partner ID who owns this verification. Null means Global/System verification.
-  @JsonKey(name: 'partner_id')
-  String?
-      get partnerId; // Fix #42: Handle nullable DB fields — description and icon_key can be
+ String get id; VerificationCategory get category;/// Internal identifier (e.g., 'global_career').
+@JsonKey(name: 'internal_name') String get internalName;/// Display name shown to users (e.g., '직장 인증').
+@JsonKey(name: 'display_name') String get displayName;/// Partner ID who owns this verification. Null means Global/System verification.
+@JsonKey(name: 'partner_id') String? get partnerId;// Fix #42: Handle nullable DB fields — description and icon_key can be
 // null in verifications table
-  String? get description;
-
-  /// Icon identifier (e.g., 'briefcase').
-  @JsonKey(name: 'icon_key')
-  String? get iconKey;
-
-  /// Dynamic form definition.
-  @JsonKey(name: 'form_schema')
-  List<VerificationFormField> get formSchema;
-  @JsonKey(name: 'is_active')
-  bool get isActive;
-  @JsonKey(name: 'created_at')
-  DateTime? get createdAt;
-
-  /// Create a copy of Verification
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $VerificationCopyWith<Verification> get copyWith =>
-      _$VerificationCopyWithImpl<Verification>(
-          this as Verification, _$identity);
+ String? get description;/// Icon identifier (e.g., 'briefcase').
+@JsonKey(name: 'icon_key') String? get iconKey;/// Dynamic form definition.
+@JsonKey(name: 'form_schema') List<VerificationFormField> get formSchema;@JsonKey(name: 'is_active') bool get isActive;@JsonKey(name: 'created_at') DateTime? get createdAt;
+/// Create a copy of Verification
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$VerificationCopyWith<Verification> get copyWith => _$VerificationCopyWithImpl<Verification>(this as Verification, _$identity);
 
   /// Serializes this Verification to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is Verification &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.category, category) ||
-                other.category == category) &&
-            (identical(other.internalName, internalName) ||
-                other.internalName == internalName) &&
-            (identical(other.displayName, displayName) ||
-                other.displayName == displayName) &&
-            (identical(other.partnerId, partnerId) ||
-                other.partnerId == partnerId) &&
-            (identical(other.description, description) ||
-                other.description == description) &&
-            (identical(other.iconKey, iconKey) || other.iconKey == iconKey) &&
-            const DeepCollectionEquality()
-                .equals(other.formSchema, formSchema) &&
-            (identical(other.isActive, isActive) ||
-                other.isActive == isActive) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      category,
-      internalName,
-      displayName,
-      partnerId,
-      description,
-      iconKey,
-      const DeepCollectionEquality().hash(formSchema),
-      isActive,
-      createdAt);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Verification&&(identical(other.id, id) || other.id == id)&&(identical(other.category, category) || other.category == category)&&(identical(other.internalName, internalName) || other.internalName == internalName)&&(identical(other.displayName, displayName) || other.displayName == displayName)&&(identical(other.partnerId, partnerId) || other.partnerId == partnerId)&&(identical(other.description, description) || other.description == description)&&(identical(other.iconKey, iconKey) || other.iconKey == iconKey)&&const DeepCollectionEquality().equals(other.formSchema, formSchema)&&(identical(other.isActive, isActive) || other.isActive == isActive)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
 
-  @override
-  String toString() {
-    return 'Verification(id: $id, category: $category, internalName: $internalName, displayName: $displayName, partnerId: $partnerId, description: $description, iconKey: $iconKey, formSchema: $formSchema, isActive: $isActive, createdAt: $createdAt)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,category,internalName,displayName,partnerId,description,iconKey,const DeepCollectionEquality().hash(formSchema),isActive,createdAt);
+
+@override
+String toString() {
+  return 'Verification(id: $id, category: $category, internalName: $internalName, displayName: $displayName, partnerId: $partnerId, description: $description, iconKey: $iconKey, formSchema: $formSchema, isActive: $isActive, createdAt: $createdAt)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $VerificationCopyWith<$Res> {
-  factory $VerificationCopyWith(
-          Verification value, $Res Function(Verification) _then) =
-      _$VerificationCopyWithImpl;
-  @useResult
-  $Res call(
-      {String id,
-      VerificationCategory category,
-      @JsonKey(name: 'internal_name') String internalName,
-      @JsonKey(name: 'display_name') String displayName,
-      @JsonKey(name: 'partner_id') String? partnerId,
-      String? description,
-      @JsonKey(name: 'icon_key') String? iconKey,
-      @JsonKey(name: 'form_schema') List<VerificationFormField> formSchema,
-      @JsonKey(name: 'is_active') bool isActive,
-      @JsonKey(name: 'created_at') DateTime? createdAt});
-}
+abstract mixin class $VerificationCopyWith<$Res>  {
+  factory $VerificationCopyWith(Verification value, $Res Function(Verification) _then) = _$VerificationCopyWithImpl;
+@useResult
+$Res call({
+ String id, VerificationCategory category,@JsonKey(name: 'internal_name') String internalName,@JsonKey(name: 'display_name') String displayName,@JsonKey(name: 'partner_id') String? partnerId, String? description,@JsonKey(name: 'icon_key') String? iconKey,@JsonKey(name: 'form_schema') List<VerificationFormField> formSchema,@JsonKey(name: 'is_active') bool isActive,@JsonKey(name: 'created_at') DateTime? createdAt
+});
 
+
+
+
+}
 /// @nodoc
-class _$VerificationCopyWithImpl<$Res> implements $VerificationCopyWith<$Res> {
+class _$VerificationCopyWithImpl<$Res>
+    implements $VerificationCopyWith<$Res> {
   _$VerificationCopyWithImpl(this._self, this._then);
 
   final Verification _self;
   final $Res Function(Verification) _then;
 
-  /// Create a copy of Verification
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? category = null,
-    Object? internalName = null,
-    Object? displayName = null,
-    Object? partnerId = freezed,
-    Object? description = freezed,
-    Object? iconKey = freezed,
-    Object? formSchema = null,
-    Object? isActive = null,
-    Object? createdAt = freezed,
-  }) {
-    return _then(_self.copyWith(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      category: null == category
-          ? _self.category
-          : category // ignore: cast_nullable_to_non_nullable
-              as VerificationCategory,
-      internalName: null == internalName
-          ? _self.internalName
-          : internalName // ignore: cast_nullable_to_non_nullable
-              as String,
-      displayName: null == displayName
-          ? _self.displayName
-          : displayName // ignore: cast_nullable_to_non_nullable
-              as String,
-      partnerId: freezed == partnerId
-          ? _self.partnerId
-          : partnerId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      description: freezed == description
-          ? _self.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as String?,
-      iconKey: freezed == iconKey
-          ? _self.iconKey
-          : iconKey // ignore: cast_nullable_to_non_nullable
-              as String?,
-      formSchema: null == formSchema
-          ? _self.formSchema
-          : formSchema // ignore: cast_nullable_to_non_nullable
-              as List<VerificationFormField>,
-      isActive: null == isActive
-          ? _self.isActive
-          : isActive // ignore: cast_nullable_to_non_nullable
-              as bool,
-      createdAt: freezed == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-    ));
-  }
+/// Create a copy of Verification
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? category = null,Object? internalName = null,Object? displayName = null,Object? partnerId = freezed,Object? description = freezed,Object? iconKey = freezed,Object? formSchema = null,Object? isActive = null,Object? createdAt = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,category: null == category ? _self.category : category // ignore: cast_nullable_to_non_nullable
+as VerificationCategory,internalName: null == internalName ? _self.internalName : internalName // ignore: cast_nullable_to_non_nullable
+as String,displayName: null == displayName ? _self.displayName : displayName // ignore: cast_nullable_to_non_nullable
+as String,partnerId: freezed == partnerId ? _self.partnerId : partnerId // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,iconKey: freezed == iconKey ? _self.iconKey : iconKey // ignore: cast_nullable_to_non_nullable
+as String?,formSchema: null == formSchema ? _self.formSchema : formSchema // ignore: cast_nullable_to_non_nullable
+as List<VerificationFormField>,isActive: null == isActive ? _self.isActive : isActive // ignore: cast_nullable_to_non_nullable
+as bool,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [Verification].
 extension VerificationPatterns on Verification {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_Verification value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Verification() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Verification value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Verification() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_Verification value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Verification():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Verification value)  $default,){
+final _that = this;
+switch (_that) {
+case _Verification():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_Verification value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Verification() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Verification value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Verification() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String id,
-            VerificationCategory category,
-            @JsonKey(name: 'internal_name') String internalName,
-            @JsonKey(name: 'display_name') String displayName,
-            @JsonKey(name: 'partner_id') String? partnerId,
-            String? description,
-            @JsonKey(name: 'icon_key') String? iconKey,
-            @JsonKey(name: 'form_schema')
-            List<VerificationFormField> formSchema,
-            @JsonKey(name: 'is_active') bool isActive,
-            @JsonKey(name: 'created_at') DateTime? createdAt)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _Verification() when $default != null:
-        return $default(
-            _that.id,
-            _that.category,
-            _that.internalName,
-            _that.displayName,
-            _that.partnerId,
-            _that.description,
-            _that.iconKey,
-            _that.formSchema,
-            _that.isActive,
-            _that.createdAt);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  VerificationCategory category, @JsonKey(name: 'internal_name')  String internalName, @JsonKey(name: 'display_name')  String displayName, @JsonKey(name: 'partner_id')  String? partnerId,  String? description, @JsonKey(name: 'icon_key')  String? iconKey, @JsonKey(name: 'form_schema')  List<VerificationFormField> formSchema, @JsonKey(name: 'is_active')  bool isActive, @JsonKey(name: 'created_at')  DateTime? createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Verification() when $default != null:
+return $default(_that.id,_that.category,_that.internalName,_that.displayName,_that.partnerId,_that.description,_that.iconKey,_that.formSchema,_that.isActive,_that.createdAt);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String id,
-            VerificationCategory category,
-            @JsonKey(name: 'internal_name') String internalName,
-            @JsonKey(name: 'display_name') String displayName,
-            @JsonKey(name: 'partner_id') String? partnerId,
-            String? description,
-            @JsonKey(name: 'icon_key') String? iconKey,
-            @JsonKey(name: 'form_schema')
-            List<VerificationFormField> formSchema,
-            @JsonKey(name: 'is_active') bool isActive,
-            @JsonKey(name: 'created_at') DateTime? createdAt)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Verification():
-        return $default(
-            _that.id,
-            _that.category,
-            _that.internalName,
-            _that.displayName,
-            _that.partnerId,
-            _that.description,
-            _that.iconKey,
-            _that.formSchema,
-            _that.isActive,
-            _that.createdAt);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  VerificationCategory category, @JsonKey(name: 'internal_name')  String internalName, @JsonKey(name: 'display_name')  String displayName, @JsonKey(name: 'partner_id')  String? partnerId,  String? description, @JsonKey(name: 'icon_key')  String? iconKey, @JsonKey(name: 'form_schema')  List<VerificationFormField> formSchema, @JsonKey(name: 'is_active')  bool isActive, @JsonKey(name: 'created_at')  DateTime? createdAt)  $default,) {final _that = this;
+switch (_that) {
+case _Verification():
+return $default(_that.id,_that.category,_that.internalName,_that.displayName,_that.partnerId,_that.description,_that.iconKey,_that.formSchema,_that.isActive,_that.createdAt);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String id,
-            VerificationCategory category,
-            @JsonKey(name: 'internal_name') String internalName,
-            @JsonKey(name: 'display_name') String displayName,
-            @JsonKey(name: 'partner_id') String? partnerId,
-            String? description,
-            @JsonKey(name: 'icon_key') String? iconKey,
-            @JsonKey(name: 'form_schema')
-            List<VerificationFormField> formSchema,
-            @JsonKey(name: 'is_active') bool isActive,
-            @JsonKey(name: 'created_at') DateTime? createdAt)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _Verification() when $default != null:
-        return $default(
-            _that.id,
-            _that.category,
-            _that.internalName,
-            _that.displayName,
-            _that.partnerId,
-            _that.description,
-            _that.iconKey,
-            _that.formSchema,
-            _that.isActive,
-            _that.createdAt);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  VerificationCategory category, @JsonKey(name: 'internal_name')  String internalName, @JsonKey(name: 'display_name')  String displayName, @JsonKey(name: 'partner_id')  String? partnerId,  String? description, @JsonKey(name: 'icon_key')  String? iconKey, @JsonKey(name: 'form_schema')  List<VerificationFormField> formSchema, @JsonKey(name: 'is_active')  bool isActive, @JsonKey(name: 'created_at')  DateTime? createdAt)?  $default,) {final _that = this;
+switch (_that) {
+case _Verification() when $default != null:
+return $default(_that.id,_that.category,_that.internalName,_that.displayName,_that.partnerId,_that.description,_that.iconKey,_that.formSchema,_that.isActive,_that.createdAt);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _Verification implements Verification {
-  const _Verification(
-      {required this.id,
-      required this.category,
-      @JsonKey(name: 'internal_name') required this.internalName,
-      @JsonKey(name: 'display_name') required this.displayName,
-      @JsonKey(name: 'partner_id') this.partnerId,
-      this.description,
-      @JsonKey(name: 'icon_key') this.iconKey,
-      @JsonKey(name: 'form_schema')
-      final List<VerificationFormField> formSchema = const [],
-      @JsonKey(name: 'is_active') this.isActive = true,
-      @JsonKey(name: 'created_at') this.createdAt})
-      : _formSchema = formSchema;
-  factory _Verification.fromJson(Map<String, dynamic> json) =>
-      _$VerificationFromJson(json);
+  const _Verification({required this.id, required this.category, @JsonKey(name: 'internal_name') required this.internalName, @JsonKey(name: 'display_name') required this.displayName, @JsonKey(name: 'partner_id') this.partnerId, this.description, @JsonKey(name: 'icon_key') this.iconKey, @JsonKey(name: 'form_schema') final  List<VerificationFormField> formSchema = const [], @JsonKey(name: 'is_active') this.isActive = true, @JsonKey(name: 'created_at') this.createdAt}): _formSchema = formSchema;
+  factory _Verification.fromJson(Map<String, dynamic> json) => _$VerificationFromJson(json);
 
-  @override
-  final String id;
-  @override
-  final VerificationCategory category;
-
-  /// Internal identifier (e.g., 'global_career').
-  @override
-  @JsonKey(name: 'internal_name')
-  final String internalName;
-
-  /// Display name shown to users (e.g., '직장 인증').
-  @override
-  @JsonKey(name: 'display_name')
-  final String displayName;
-
-  /// Partner ID who owns this verification. Null means Global/System verification.
-  @override
-  @JsonKey(name: 'partner_id')
-  final String? partnerId;
+@override final  String id;
+@override final  VerificationCategory category;
+/// Internal identifier (e.g., 'global_career').
+@override@JsonKey(name: 'internal_name') final  String internalName;
+/// Display name shown to users (e.g., '직장 인증').
+@override@JsonKey(name: 'display_name') final  String displayName;
+/// Partner ID who owns this verification. Null means Global/System verification.
+@override@JsonKey(name: 'partner_id') final  String? partnerId;
 // Fix #42: Handle nullable DB fields — description and icon_key can be
 // null in verifications table
-  @override
-  final String? description;
+@override final  String? description;
+/// Icon identifier (e.g., 'briefcase').
+@override@JsonKey(name: 'icon_key') final  String? iconKey;
+/// Dynamic form definition.
+ final  List<VerificationFormField> _formSchema;
+/// Dynamic form definition.
+@override@JsonKey(name: 'form_schema') List<VerificationFormField> get formSchema {
+  if (_formSchema is EqualUnmodifiableListView) return _formSchema;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_formSchema);
+}
 
-  /// Icon identifier (e.g., 'briefcase').
-  @override
-  @JsonKey(name: 'icon_key')
-  final String? iconKey;
+@override@JsonKey(name: 'is_active') final  bool isActive;
+@override@JsonKey(name: 'created_at') final  DateTime? createdAt;
 
-  /// Dynamic form definition.
-  final List<VerificationFormField> _formSchema;
+/// Create a copy of Verification
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$VerificationCopyWith<_Verification> get copyWith => __$VerificationCopyWithImpl<_Verification>(this, _$identity);
 
-  /// Dynamic form definition.
-  @override
-  @JsonKey(name: 'form_schema')
-  List<VerificationFormField> get formSchema {
-    if (_formSchema is EqualUnmodifiableListView) return _formSchema;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_formSchema);
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$VerificationToJson(this, );
+}
 
-  @override
-  @JsonKey(name: 'is_active')
-  final bool isActive;
-  @override
-  @JsonKey(name: 'created_at')
-  final DateTime? createdAt;
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Verification&&(identical(other.id, id) || other.id == id)&&(identical(other.category, category) || other.category == category)&&(identical(other.internalName, internalName) || other.internalName == internalName)&&(identical(other.displayName, displayName) || other.displayName == displayName)&&(identical(other.partnerId, partnerId) || other.partnerId == partnerId)&&(identical(other.description, description) || other.description == description)&&(identical(other.iconKey, iconKey) || other.iconKey == iconKey)&&const DeepCollectionEquality().equals(other._formSchema, _formSchema)&&(identical(other.isActive, isActive) || other.isActive == isActive)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+}
 
-  /// Create a copy of Verification
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$VerificationCopyWith<_Verification> get copyWith =>
-      __$VerificationCopyWithImpl<_Verification>(this, _$identity);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,category,internalName,displayName,partnerId,description,iconKey,const DeepCollectionEquality().hash(_formSchema),isActive,createdAt);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$VerificationToJson(
-      this,
-    );
-  }
+@override
+String toString() {
+  return 'Verification(id: $id, category: $category, internalName: $internalName, displayName: $displayName, partnerId: $partnerId, description: $description, iconKey: $iconKey, formSchema: $formSchema, isActive: $isActive, createdAt: $createdAt)';
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _Verification &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.category, category) ||
-                other.category == category) &&
-            (identical(other.internalName, internalName) ||
-                other.internalName == internalName) &&
-            (identical(other.displayName, displayName) ||
-                other.displayName == displayName) &&
-            (identical(other.partnerId, partnerId) ||
-                other.partnerId == partnerId) &&
-            (identical(other.description, description) ||
-                other.description == description) &&
-            (identical(other.iconKey, iconKey) || other.iconKey == iconKey) &&
-            const DeepCollectionEquality()
-                .equals(other._formSchema, _formSchema) &&
-            (identical(other.isActive, isActive) ||
-                other.isActive == isActive) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      category,
-      internalName,
-      displayName,
-      partnerId,
-      description,
-      iconKey,
-      const DeepCollectionEquality().hash(_formSchema),
-      isActive,
-      createdAt);
-
-  @override
-  String toString() {
-    return 'Verification(id: $id, category: $category, internalName: $internalName, displayName: $displayName, partnerId: $partnerId, description: $description, iconKey: $iconKey, formSchema: $formSchema, isActive: $isActive, createdAt: $createdAt)';
-  }
 }
 
 /// @nodoc
-abstract mixin class _$VerificationCopyWith<$Res>
-    implements $VerificationCopyWith<$Res> {
-  factory _$VerificationCopyWith(
-          _Verification value, $Res Function(_Verification) _then) =
-      __$VerificationCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String id,
-      VerificationCategory category,
-      @JsonKey(name: 'internal_name') String internalName,
-      @JsonKey(name: 'display_name') String displayName,
-      @JsonKey(name: 'partner_id') String? partnerId,
-      String? description,
-      @JsonKey(name: 'icon_key') String? iconKey,
-      @JsonKey(name: 'form_schema') List<VerificationFormField> formSchema,
-      @JsonKey(name: 'is_active') bool isActive,
-      @JsonKey(name: 'created_at') DateTime? createdAt});
-}
+abstract mixin class _$VerificationCopyWith<$Res> implements $VerificationCopyWith<$Res> {
+  factory _$VerificationCopyWith(_Verification value, $Res Function(_Verification) _then) = __$VerificationCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, VerificationCategory category,@JsonKey(name: 'internal_name') String internalName,@JsonKey(name: 'display_name') String displayName,@JsonKey(name: 'partner_id') String? partnerId, String? description,@JsonKey(name: 'icon_key') String? iconKey,@JsonKey(name: 'form_schema') List<VerificationFormField> formSchema,@JsonKey(name: 'is_active') bool isActive,@JsonKey(name: 'created_at') DateTime? createdAt
+});
 
+
+
+
+}
 /// @nodoc
 class __$VerificationCopyWithImpl<$Res>
     implements _$VerificationCopyWith<$Res> {
@@ -1014,143 +602,74 @@ class __$VerificationCopyWithImpl<$Res>
   final _Verification _self;
   final $Res Function(_Verification) _then;
 
-  /// Create a copy of Verification
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? category = null,
-    Object? internalName = null,
-    Object? displayName = null,
-    Object? partnerId = freezed,
-    Object? description = freezed,
-    Object? iconKey = freezed,
-    Object? formSchema = null,
-    Object? isActive = null,
-    Object? createdAt = freezed,
-  }) {
-    return _then(_Verification(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      category: null == category
-          ? _self.category
-          : category // ignore: cast_nullable_to_non_nullable
-              as VerificationCategory,
-      internalName: null == internalName
-          ? _self.internalName
-          : internalName // ignore: cast_nullable_to_non_nullable
-              as String,
-      displayName: null == displayName
-          ? _self.displayName
-          : displayName // ignore: cast_nullable_to_non_nullable
-              as String,
-      partnerId: freezed == partnerId
-          ? _self.partnerId
-          : partnerId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      description: freezed == description
-          ? _self.description
-          : description // ignore: cast_nullable_to_non_nullable
-              as String?,
-      iconKey: freezed == iconKey
-          ? _self.iconKey
-          : iconKey // ignore: cast_nullable_to_non_nullable
-              as String?,
-      formSchema: null == formSchema
-          ? _self._formSchema
-          : formSchema // ignore: cast_nullable_to_non_nullable
-              as List<VerificationFormField>,
-      isActive: null == isActive
-          ? _self.isActive
-          : isActive // ignore: cast_nullable_to_non_nullable
-              as bool,
-      createdAt: freezed == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-    ));
-  }
+/// Create a copy of Verification
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? category = null,Object? internalName = null,Object? displayName = null,Object? partnerId = freezed,Object? description = freezed,Object? iconKey = freezed,Object? formSchema = null,Object? isActive = null,Object? createdAt = freezed,}) {
+  return _then(_Verification(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,category: null == category ? _self.category : category // ignore: cast_nullable_to_non_nullable
+as VerificationCategory,internalName: null == internalName ? _self.internalName : internalName // ignore: cast_nullable_to_non_nullable
+as String,displayName: null == displayName ? _self.displayName : displayName // ignore: cast_nullable_to_non_nullable
+as String,partnerId: freezed == partnerId ? _self.partnerId : partnerId // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,iconKey: freezed == iconKey ? _self.iconKey : iconKey // ignore: cast_nullable_to_non_nullable
+as String?,formSchema: null == formSchema ? _self._formSchema : formSchema // ignore: cast_nullable_to_non_nullable
+as List<VerificationFormField>,isActive: null == isActive ? _self.isActive : isActive // ignore: cast_nullable_to_non_nullable
+as bool,createdAt: freezed == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
 }
+
+
+}
+
 
 /// @nodoc
 mixin _$VerificationRequirementStatus {
-  Verification get master;
 
-  /// User's original data (내 서랍 데이터)
-  @JsonKey(name: 'user_verification')
-  Map<String, dynamic>? get userVerification;
-
-  /// Active submission to a partner (제출 내역)
-  @JsonKey(name: 'active_submission')
-  VerificationSubmission? get activeSubmission;
-
-  /// Final verified result (출입증)
-  @JsonKey(name: 'verified_result')
-  Map<String, dynamic>? get verifiedResult;
-
-  /// Create a copy of VerificationRequirementStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $VerificationRequirementStatusCopyWith<VerificationRequirementStatus>
-      get copyWith => _$VerificationRequirementStatusCopyWithImpl<
-              VerificationRequirementStatus>(
-          this as VerificationRequirementStatus, _$identity);
+ Verification get master;/// User's original data (내 서랍 데이터)
+@JsonKey(name: 'user_verification') Map<String, dynamic>? get userVerification;/// Active submission to a partner (제출 내역)
+@JsonKey(name: 'active_submission') VerificationSubmission? get activeSubmission;/// Final verified result (출입증)
+@JsonKey(name: 'verified_result') Map<String, dynamic>? get verifiedResult;
+/// Create a copy of VerificationRequirementStatus
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$VerificationRequirementStatusCopyWith<VerificationRequirementStatus> get copyWith => _$VerificationRequirementStatusCopyWithImpl<VerificationRequirementStatus>(this as VerificationRequirementStatus, _$identity);
 
   /// Serializes this VerificationRequirementStatus to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is VerificationRequirementStatus &&
-            (identical(other.master, master) || other.master == master) &&
-            const DeepCollectionEquality()
-                .equals(other.userVerification, userVerification) &&
-            (identical(other.activeSubmission, activeSubmission) ||
-                other.activeSubmission == activeSubmission) &&
-            const DeepCollectionEquality()
-                .equals(other.verifiedResult, verifiedResult));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      master,
-      const DeepCollectionEquality().hash(userVerification),
-      activeSubmission,
-      const DeepCollectionEquality().hash(verifiedResult));
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VerificationRequirementStatus&&(identical(other.master, master) || other.master == master)&&const DeepCollectionEquality().equals(other.userVerification, userVerification)&&(identical(other.activeSubmission, activeSubmission) || other.activeSubmission == activeSubmission)&&const DeepCollectionEquality().equals(other.verifiedResult, verifiedResult));
+}
 
-  @override
-  String toString() {
-    return 'VerificationRequirementStatus(master: $master, userVerification: $userVerification, activeSubmission: $activeSubmission, verifiedResult: $verifiedResult)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,master,const DeepCollectionEquality().hash(userVerification),activeSubmission,const DeepCollectionEquality().hash(verifiedResult));
+
+@override
+String toString() {
+  return 'VerificationRequirementStatus(master: $master, userVerification: $userVerification, activeSubmission: $activeSubmission, verifiedResult: $verifiedResult)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $VerificationRequirementStatusCopyWith<$Res> {
-  factory $VerificationRequirementStatusCopyWith(
-          VerificationRequirementStatus value,
-          $Res Function(VerificationRequirementStatus) _then) =
-      _$VerificationRequirementStatusCopyWithImpl;
-  @useResult
-  $Res call(
-      {Verification master,
-      @JsonKey(name: 'user_verification')
-      Map<String, dynamic>? userVerification,
-      @JsonKey(name: 'active_submission')
-      VerificationSubmission? activeSubmission,
-      @JsonKey(name: 'verified_result') Map<String, dynamic>? verifiedResult});
+abstract mixin class $VerificationRequirementStatusCopyWith<$Res>  {
+  factory $VerificationRequirementStatusCopyWith(VerificationRequirementStatus value, $Res Function(VerificationRequirementStatus) _then) = _$VerificationRequirementStatusCopyWithImpl;
+@useResult
+$Res call({
+ Verification master,@JsonKey(name: 'user_verification') Map<String, dynamic>? userVerification,@JsonKey(name: 'active_submission') VerificationSubmission? activeSubmission,@JsonKey(name: 'verified_result') Map<String, dynamic>? verifiedResult
+});
 
-  $VerificationCopyWith<$Res> get master;
-  $VerificationSubmissionCopyWith<$Res>? get activeSubmission;
+
+$VerificationCopyWith<$Res> get master;$VerificationSubmissionCopyWith<$Res>? get activeSubmission;
+
 }
-
 /// @nodoc
 class _$VerificationRequirementStatusCopyWithImpl<$Res>
     implements $VerificationRequirementStatusCopyWith<$Res> {
@@ -1159,367 +678,245 @@ class _$VerificationRequirementStatusCopyWithImpl<$Res>
   final VerificationRequirementStatus _self;
   final $Res Function(VerificationRequirementStatus) _then;
 
-  /// Create a copy of VerificationRequirementStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? master = null,
-    Object? userVerification = freezed,
-    Object? activeSubmission = freezed,
-    Object? verifiedResult = freezed,
-  }) {
-    return _then(_self.copyWith(
-      master: null == master
-          ? _self.master
-          : master // ignore: cast_nullable_to_non_nullable
-              as Verification,
-      userVerification: freezed == userVerification
-          ? _self.userVerification
-          : userVerification // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>?,
-      activeSubmission: freezed == activeSubmission
-          ? _self.activeSubmission
-          : activeSubmission // ignore: cast_nullable_to_non_nullable
-              as VerificationSubmission?,
-      verifiedResult: freezed == verifiedResult
-          ? _self.verifiedResult
-          : verifiedResult // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>?,
-    ));
-  }
-
-  /// Create a copy of VerificationRequirementStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $VerificationCopyWith<$Res> get master {
-    return $VerificationCopyWith<$Res>(_self.master, (value) {
-      return _then(_self.copyWith(master: value));
-    });
-  }
-
-  /// Create a copy of VerificationRequirementStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $VerificationSubmissionCopyWith<$Res>? get activeSubmission {
+/// Create a copy of VerificationRequirementStatus
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? master = null,Object? userVerification = freezed,Object? activeSubmission = freezed,Object? verifiedResult = freezed,}) {
+  return _then(_self.copyWith(
+master: null == master ? _self.master : master // ignore: cast_nullable_to_non_nullable
+as Verification,userVerification: freezed == userVerification ? _self.userVerification : userVerification // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,activeSubmission: freezed == activeSubmission ? _self.activeSubmission : activeSubmission // ignore: cast_nullable_to_non_nullable
+as VerificationSubmission?,verifiedResult: freezed == verifiedResult ? _self.verifiedResult : verifiedResult // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
+/// Create a copy of VerificationRequirementStatus
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$VerificationCopyWith<$Res> get master {
+  
+  return $VerificationCopyWith<$Res>(_self.master, (value) {
+    return _then(_self.copyWith(master: value));
+  });
+}/// Create a copy of VerificationRequirementStatus
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$VerificationSubmissionCopyWith<$Res>? get activeSubmission {
     if (_self.activeSubmission == null) {
-      return null;
-    }
-
-    return $VerificationSubmissionCopyWith<$Res>(_self.activeSubmission!,
-        (value) {
-      return _then(_self.copyWith(activeSubmission: value));
-    });
+    return null;
   }
+
+  return $VerificationSubmissionCopyWith<$Res>(_self.activeSubmission!, (value) {
+    return _then(_self.copyWith(activeSubmission: value));
+  });
+}
 }
 
+
 /// Adds pattern-matching-related methods to [VerificationRequirementStatus].
-extension VerificationRequirementStatusPatterns
-    on VerificationRequirementStatus {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+extension VerificationRequirementStatusPatterns on VerificationRequirementStatus {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_VerificationRequirementStatus value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _VerificationRequirementStatus() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _VerificationRequirementStatus value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _VerificationRequirementStatus() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_VerificationRequirementStatus value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _VerificationRequirementStatus():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _VerificationRequirementStatus value)  $default,){
+final _that = this;
+switch (_that) {
+case _VerificationRequirementStatus():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_VerificationRequirementStatus value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _VerificationRequirementStatus() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _VerificationRequirementStatus value)?  $default,){
+final _that = this;
+switch (_that) {
+case _VerificationRequirementStatus() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            Verification master,
-            @JsonKey(name: 'user_verification')
-            Map<String, dynamic>? userVerification,
-            @JsonKey(name: 'active_submission')
-            VerificationSubmission? activeSubmission,
-            @JsonKey(name: 'verified_result')
-            Map<String, dynamic>? verifiedResult)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _VerificationRequirementStatus() when $default != null:
-        return $default(_that.master, _that.userVerification,
-            _that.activeSubmission, _that.verifiedResult);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( Verification master, @JsonKey(name: 'user_verification')  Map<String, dynamic>? userVerification, @JsonKey(name: 'active_submission')  VerificationSubmission? activeSubmission, @JsonKey(name: 'verified_result')  Map<String, dynamic>? verifiedResult)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _VerificationRequirementStatus() when $default != null:
+return $default(_that.master,_that.userVerification,_that.activeSubmission,_that.verifiedResult);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            Verification master,
-            @JsonKey(name: 'user_verification')
-            Map<String, dynamic>? userVerification,
-            @JsonKey(name: 'active_submission')
-            VerificationSubmission? activeSubmission,
-            @JsonKey(name: 'verified_result')
-            Map<String, dynamic>? verifiedResult)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _VerificationRequirementStatus():
-        return $default(_that.master, _that.userVerification,
-            _that.activeSubmission, _that.verifiedResult);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( Verification master, @JsonKey(name: 'user_verification')  Map<String, dynamic>? userVerification, @JsonKey(name: 'active_submission')  VerificationSubmission? activeSubmission, @JsonKey(name: 'verified_result')  Map<String, dynamic>? verifiedResult)  $default,) {final _that = this;
+switch (_that) {
+case _VerificationRequirementStatus():
+return $default(_that.master,_that.userVerification,_that.activeSubmission,_that.verifiedResult);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            Verification master,
-            @JsonKey(name: 'user_verification')
-            Map<String, dynamic>? userVerification,
-            @JsonKey(name: 'active_submission')
-            VerificationSubmission? activeSubmission,
-            @JsonKey(name: 'verified_result')
-            Map<String, dynamic>? verifiedResult)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _VerificationRequirementStatus() when $default != null:
-        return $default(_that.master, _that.userVerification,
-            _that.activeSubmission, _that.verifiedResult);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( Verification master, @JsonKey(name: 'user_verification')  Map<String, dynamic>? userVerification, @JsonKey(name: 'active_submission')  VerificationSubmission? activeSubmission, @JsonKey(name: 'verified_result')  Map<String, dynamic>? verifiedResult)?  $default,) {final _that = this;
+switch (_that) {
+case _VerificationRequirementStatus() when $default != null:
+return $default(_that.master,_that.userVerification,_that.activeSubmission,_that.verifiedResult);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _VerificationRequirementStatus extends VerificationRequirementStatus {
-  const _VerificationRequirementStatus(
-      {required this.master,
-      @JsonKey(name: 'user_verification')
-      final Map<String, dynamic>? userVerification,
-      @JsonKey(name: 'active_submission') this.activeSubmission,
-      @JsonKey(name: 'verified_result')
-      final Map<String, dynamic>? verifiedResult})
-      : _userVerification = userVerification,
-        _verifiedResult = verifiedResult,
-        super._();
-  factory _VerificationRequirementStatus.fromJson(Map<String, dynamic> json) =>
-      _$VerificationRequirementStatusFromJson(json);
+  const _VerificationRequirementStatus({required this.master, @JsonKey(name: 'user_verification') final  Map<String, dynamic>? userVerification, @JsonKey(name: 'active_submission') this.activeSubmission, @JsonKey(name: 'verified_result') final  Map<String, dynamic>? verifiedResult}): _userVerification = userVerification,_verifiedResult = verifiedResult,super._();
+  factory _VerificationRequirementStatus.fromJson(Map<String, dynamic> json) => _$VerificationRequirementStatusFromJson(json);
 
-  @override
-  final Verification master;
+@override final  Verification master;
+/// User's original data (내 서랍 데이터)
+ final  Map<String, dynamic>? _userVerification;
+/// User's original data (내 서랍 데이터)
+@override@JsonKey(name: 'user_verification') Map<String, dynamic>? get userVerification {
+  final value = _userVerification;
+  if (value == null) return null;
+  if (_userVerification is EqualUnmodifiableMapView) return _userVerification;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
 
-  /// User's original data (내 서랍 데이터)
-  final Map<String, dynamic>? _userVerification;
+/// Active submission to a partner (제출 내역)
+@override@JsonKey(name: 'active_submission') final  VerificationSubmission? activeSubmission;
+/// Final verified result (출입증)
+ final  Map<String, dynamic>? _verifiedResult;
+/// Final verified result (출입증)
+@override@JsonKey(name: 'verified_result') Map<String, dynamic>? get verifiedResult {
+  final value = _verifiedResult;
+  if (value == null) return null;
+  if (_verifiedResult is EqualUnmodifiableMapView) return _verifiedResult;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
 
-  /// User's original data (내 서랍 데이터)
-  @override
-  @JsonKey(name: 'user_verification')
-  Map<String, dynamic>? get userVerification {
-    final value = _userVerification;
-    if (value == null) return null;
-    if (_userVerification is EqualUnmodifiableMapView) return _userVerification;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(value);
-  }
 
-  /// Active submission to a partner (제출 내역)
-  @override
-  @JsonKey(name: 'active_submission')
-  final VerificationSubmission? activeSubmission;
+/// Create a copy of VerificationRequirementStatus
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$VerificationRequirementStatusCopyWith<_VerificationRequirementStatus> get copyWith => __$VerificationRequirementStatusCopyWithImpl<_VerificationRequirementStatus>(this, _$identity);
 
-  /// Final verified result (출입증)
-  final Map<String, dynamic>? _verifiedResult;
+@override
+Map<String, dynamic> toJson() {
+  return _$VerificationRequirementStatusToJson(this, );
+}
 
-  /// Final verified result (출입증)
-  @override
-  @JsonKey(name: 'verified_result')
-  Map<String, dynamic>? get verifiedResult {
-    final value = _verifiedResult;
-    if (value == null) return null;
-    if (_verifiedResult is EqualUnmodifiableMapView) return _verifiedResult;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(value);
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VerificationRequirementStatus&&(identical(other.master, master) || other.master == master)&&const DeepCollectionEquality().equals(other._userVerification, _userVerification)&&(identical(other.activeSubmission, activeSubmission) || other.activeSubmission == activeSubmission)&&const DeepCollectionEquality().equals(other._verifiedResult, _verifiedResult));
+}
 
-  /// Create a copy of VerificationRequirementStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$VerificationRequirementStatusCopyWith<_VerificationRequirementStatus>
-      get copyWith => __$VerificationRequirementStatusCopyWithImpl<
-          _VerificationRequirementStatus>(this, _$identity);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,master,const DeepCollectionEquality().hash(_userVerification),activeSubmission,const DeepCollectionEquality().hash(_verifiedResult));
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$VerificationRequirementStatusToJson(
-      this,
-    );
-  }
+@override
+String toString() {
+  return 'VerificationRequirementStatus(master: $master, userVerification: $userVerification, activeSubmission: $activeSubmission, verifiedResult: $verifiedResult)';
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _VerificationRequirementStatus &&
-            (identical(other.master, master) || other.master == master) &&
-            const DeepCollectionEquality()
-                .equals(other._userVerification, _userVerification) &&
-            (identical(other.activeSubmission, activeSubmission) ||
-                other.activeSubmission == activeSubmission) &&
-            const DeepCollectionEquality()
-                .equals(other._verifiedResult, _verifiedResult));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      master,
-      const DeepCollectionEquality().hash(_userVerification),
-      activeSubmission,
-      const DeepCollectionEquality().hash(_verifiedResult));
-
-  @override
-  String toString() {
-    return 'VerificationRequirementStatus(master: $master, userVerification: $userVerification, activeSubmission: $activeSubmission, verifiedResult: $verifiedResult)';
-  }
 }
 
 /// @nodoc
-abstract mixin class _$VerificationRequirementStatusCopyWith<$Res>
-    implements $VerificationRequirementStatusCopyWith<$Res> {
-  factory _$VerificationRequirementStatusCopyWith(
-          _VerificationRequirementStatus value,
-          $Res Function(_VerificationRequirementStatus) _then) =
-      __$VerificationRequirementStatusCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {Verification master,
-      @JsonKey(name: 'user_verification')
-      Map<String, dynamic>? userVerification,
-      @JsonKey(name: 'active_submission')
-      VerificationSubmission? activeSubmission,
-      @JsonKey(name: 'verified_result') Map<String, dynamic>? verifiedResult});
+abstract mixin class _$VerificationRequirementStatusCopyWith<$Res> implements $VerificationRequirementStatusCopyWith<$Res> {
+  factory _$VerificationRequirementStatusCopyWith(_VerificationRequirementStatus value, $Res Function(_VerificationRequirementStatus) _then) = __$VerificationRequirementStatusCopyWithImpl;
+@override @useResult
+$Res call({
+ Verification master,@JsonKey(name: 'user_verification') Map<String, dynamic>? userVerification,@JsonKey(name: 'active_submission') VerificationSubmission? activeSubmission,@JsonKey(name: 'verified_result') Map<String, dynamic>? verifiedResult
+});
 
-  @override
-  $VerificationCopyWith<$Res> get master;
-  @override
-  $VerificationSubmissionCopyWith<$Res>? get activeSubmission;
+
+@override $VerificationCopyWith<$Res> get master;@override $VerificationSubmissionCopyWith<$Res>? get activeSubmission;
+
 }
-
 /// @nodoc
 class __$VerificationRequirementStatusCopyWithImpl<$Res>
     implements _$VerificationRequirementStatusCopyWith<$Res> {
@@ -1528,60 +925,40 @@ class __$VerificationRequirementStatusCopyWithImpl<$Res>
   final _VerificationRequirementStatus _self;
   final $Res Function(_VerificationRequirementStatus) _then;
 
-  /// Create a copy of VerificationRequirementStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? master = null,
-    Object? userVerification = freezed,
-    Object? activeSubmission = freezed,
-    Object? verifiedResult = freezed,
-  }) {
-    return _then(_VerificationRequirementStatus(
-      master: null == master
-          ? _self.master
-          : master // ignore: cast_nullable_to_non_nullable
-              as Verification,
-      userVerification: freezed == userVerification
-          ? _self._userVerification
-          : userVerification // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>?,
-      activeSubmission: freezed == activeSubmission
-          ? _self.activeSubmission
-          : activeSubmission // ignore: cast_nullable_to_non_nullable
-              as VerificationSubmission?,
-      verifiedResult: freezed == verifiedResult
-          ? _self._verifiedResult
-          : verifiedResult // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>?,
-    ));
-  }
+/// Create a copy of VerificationRequirementStatus
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? master = null,Object? userVerification = freezed,Object? activeSubmission = freezed,Object? verifiedResult = freezed,}) {
+  return _then(_VerificationRequirementStatus(
+master: null == master ? _self.master : master // ignore: cast_nullable_to_non_nullable
+as Verification,userVerification: freezed == userVerification ? _self._userVerification : userVerification // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,activeSubmission: freezed == activeSubmission ? _self.activeSubmission : activeSubmission // ignore: cast_nullable_to_non_nullable
+as VerificationSubmission?,verifiedResult: freezed == verifiedResult ? _self._verifiedResult : verifiedResult // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,
+  ));
+}
 
-  /// Create a copy of VerificationRequirementStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $VerificationCopyWith<$Res> get master {
-    return $VerificationCopyWith<$Res>(_self.master, (value) {
-      return _then(_self.copyWith(master: value));
-    });
-  }
-
-  /// Create a copy of VerificationRequirementStatus
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $VerificationSubmissionCopyWith<$Res>? get activeSubmission {
+/// Create a copy of VerificationRequirementStatus
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$VerificationCopyWith<$Res> get master {
+  
+  return $VerificationCopyWith<$Res>(_self.master, (value) {
+    return _then(_self.copyWith(master: value));
+  });
+}/// Create a copy of VerificationRequirementStatus
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$VerificationSubmissionCopyWith<$Res>? get activeSubmission {
     if (_self.activeSubmission == null) {
-      return null;
-    }
-
-    return $VerificationSubmissionCopyWith<$Res>(_self.activeSubmission!,
-        (value) {
-      return _then(_self.copyWith(activeSubmission: value));
-    });
+    return null;
   }
+
+  return $VerificationSubmissionCopyWith<$Res>(_self.activeSubmission!, (value) {
+    return _then(_self.copyWith(activeSubmission: value));
+  });
+}
 }
 
 // dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/verification_submission.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/verification_submission.dart
@@ -16,11 +16,10 @@ abstract class VerificationSubmission with _$VerificationSubmission {
     @JsonKey(name: 'user_id') required String userId,
     @JsonKey(name: 'verification_id') required String verificationId,
     required VerificationStatus status,
-    @JsonKey(name: 'snapshot_data') required Map<String, dynamic> snapshotData,
+    @JsonKey(name: 'snapshot_data') required List<dynamic> snapshotData,
     @JsonKey(name: 'created_at') required DateTime createdAt,
     @JsonKey(name: 'updated_at') required DateTime updatedAt,
     @JsonKey(name: 'application_id') String? applicationId,
-    @JsonKey(name: 'admin_comment') String? adminComment,
     @JsonKey(name: 'reviewed_at') DateTime? reviewedAt,
     @JsonKey(name: 'reviewed_by') String? reviewedBy,
   }) = _VerificationSubmission;

--- a/shared/packages/minglit_kit/lib/src/data/models/verification_submission.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/verification_submission.freezed.dart
@@ -14,112 +14,47 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$VerificationSubmission {
-  String get id;
-  @JsonKey(name: 'partner_id')
-  String get partnerId;
-  @JsonKey(name: 'user_id')
-  String get userId;
-  @JsonKey(name: 'verification_id')
-  String get verificationId;
-  VerificationStatus get status;
-  @JsonKey(name: 'snapshot_data')
-  Map<String, dynamic> get snapshotData;
-  @JsonKey(name: 'created_at')
-  DateTime get createdAt;
-  @JsonKey(name: 'updated_at')
-  DateTime get updatedAt;
-  @JsonKey(name: 'application_id')
-  String? get applicationId;
-  @JsonKey(name: 'admin_comment')
-  String? get adminComment;
-  @JsonKey(name: 'reviewed_at')
-  DateTime? get reviewedAt;
-  @JsonKey(name: 'reviewed_by')
-  String? get reviewedBy;
 
-  /// Create a copy of VerificationSubmission
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $VerificationSubmissionCopyWith<VerificationSubmission> get copyWith =>
-      _$VerificationSubmissionCopyWithImpl<VerificationSubmission>(
-          this as VerificationSubmission, _$identity);
+ String get id;@JsonKey(name: 'partner_id') String get partnerId;@JsonKey(name: 'user_id') String get userId;@JsonKey(name: 'verification_id') String get verificationId; VerificationStatus get status;@JsonKey(name: 'snapshot_data') List<dynamic> get snapshotData;@JsonKey(name: 'created_at') DateTime get createdAt;@JsonKey(name: 'updated_at') DateTime get updatedAt;@JsonKey(name: 'application_id') String? get applicationId;@JsonKey(name: 'reviewed_at') DateTime? get reviewedAt;@JsonKey(name: 'reviewed_by') String? get reviewedBy;
+/// Create a copy of VerificationSubmission
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$VerificationSubmissionCopyWith<VerificationSubmission> get copyWith => _$VerificationSubmissionCopyWithImpl<VerificationSubmission>(this as VerificationSubmission, _$identity);
 
   /// Serializes this VerificationSubmission to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is VerificationSubmission &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.partnerId, partnerId) ||
-                other.partnerId == partnerId) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.verificationId, verificationId) ||
-                other.verificationId == verificationId) &&
-            (identical(other.status, status) || other.status == status) &&
-            const DeepCollectionEquality()
-                .equals(other.snapshotData, snapshotData) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt) &&
-            (identical(other.applicationId, applicationId) ||
-                other.applicationId == applicationId) &&
-            (identical(other.adminComment, adminComment) ||
-                other.adminComment == adminComment) &&
-            (identical(other.reviewedAt, reviewedAt) ||
-                other.reviewedAt == reviewedAt) &&
-            (identical(other.reviewedBy, reviewedBy) ||
-                other.reviewedBy == reviewedBy));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      partnerId,
-      userId,
-      verificationId,
-      status,
-      const DeepCollectionEquality().hash(snapshotData),
-      createdAt,
-      updatedAt,
-      applicationId,
-      adminComment,
-      reviewedAt,
-      reviewedBy);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is VerificationSubmission&&(identical(other.id, id) || other.id == id)&&(identical(other.partnerId, partnerId) || other.partnerId == partnerId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.verificationId, verificationId) || other.verificationId == verificationId)&&(identical(other.status, status) || other.status == status)&&const DeepCollectionEquality().equals(other.snapshotData, snapshotData)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.applicationId, applicationId) || other.applicationId == applicationId)&&(identical(other.reviewedAt, reviewedAt) || other.reviewedAt == reviewedAt)&&(identical(other.reviewedBy, reviewedBy) || other.reviewedBy == reviewedBy));
+}
 
-  @override
-  String toString() {
-    return 'VerificationSubmission(id: $id, partnerId: $partnerId, userId: $userId, verificationId: $verificationId, status: $status, snapshotData: $snapshotData, createdAt: $createdAt, updatedAt: $updatedAt, applicationId: $applicationId, adminComment: $adminComment, reviewedAt: $reviewedAt, reviewedBy: $reviewedBy)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,partnerId,userId,verificationId,status,const DeepCollectionEquality().hash(snapshotData),createdAt,updatedAt,applicationId,reviewedAt,reviewedBy);
+
+@override
+String toString() {
+  return 'VerificationSubmission(id: $id, partnerId: $partnerId, userId: $userId, verificationId: $verificationId, status: $status, snapshotData: $snapshotData, createdAt: $createdAt, updatedAt: $updatedAt, applicationId: $applicationId, reviewedAt: $reviewedAt, reviewedBy: $reviewedBy)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $VerificationSubmissionCopyWith<$Res> {
-  factory $VerificationSubmissionCopyWith(VerificationSubmission value,
-          $Res Function(VerificationSubmission) _then) =
-      _$VerificationSubmissionCopyWithImpl;
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'partner_id') String partnerId,
-      @JsonKey(name: 'user_id') String userId,
-      @JsonKey(name: 'verification_id') String verificationId,
-      VerificationStatus status,
-      @JsonKey(name: 'snapshot_data') Map<String, dynamic> snapshotData,
-      @JsonKey(name: 'created_at') DateTime createdAt,
-      @JsonKey(name: 'updated_at') DateTime updatedAt,
-      @JsonKey(name: 'application_id') String? applicationId,
-      @JsonKey(name: 'admin_comment') String? adminComment,
-      @JsonKey(name: 'reviewed_at') DateTime? reviewedAt,
-      @JsonKey(name: 'reviewed_by') String? reviewedBy});
-}
+abstract mixin class $VerificationSubmissionCopyWith<$Res>  {
+  factory $VerificationSubmissionCopyWith(VerificationSubmission value, $Res Function(VerificationSubmission) _then) = _$VerificationSubmissionCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(name: 'partner_id') String partnerId,@JsonKey(name: 'user_id') String userId,@JsonKey(name: 'verification_id') String verificationId, VerificationStatus status,@JsonKey(name: 'snapshot_data') List<dynamic> snapshotData,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'application_id') String? applicationId,@JsonKey(name: 'reviewed_at') DateTime? reviewedAt,@JsonKey(name: 'reviewed_by') String? reviewedBy
+});
 
+
+
+
+}
 /// @nodoc
 class _$VerificationSubmissionCopyWithImpl<$Res>
     implements $VerificationSubmissionCopyWith<$Res> {
@@ -128,461 +63,223 @@ class _$VerificationSubmissionCopyWithImpl<$Res>
   final VerificationSubmission _self;
   final $Res Function(VerificationSubmission) _then;
 
-  /// Create a copy of VerificationSubmission
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? partnerId = null,
-    Object? userId = null,
-    Object? verificationId = null,
-    Object? status = null,
-    Object? snapshotData = null,
-    Object? createdAt = null,
-    Object? updatedAt = null,
-    Object? applicationId = freezed,
-    Object? adminComment = freezed,
-    Object? reviewedAt = freezed,
-    Object? reviewedBy = freezed,
-  }) {
-    return _then(_self.copyWith(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      partnerId: null == partnerId
-          ? _self.partnerId
-          : partnerId // ignore: cast_nullable_to_non_nullable
-              as String,
-      userId: null == userId
-          ? _self.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      verificationId: null == verificationId
-          ? _self.verificationId
-          : verificationId // ignore: cast_nullable_to_non_nullable
-              as String,
-      status: null == status
-          ? _self.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as VerificationStatus,
-      snapshotData: null == snapshotData
-          ? _self.snapshotData
-          : snapshotData // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updatedAt: null == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      applicationId: freezed == applicationId
-          ? _self.applicationId
-          : applicationId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      adminComment: freezed == adminComment
-          ? _self.adminComment
-          : adminComment // ignore: cast_nullable_to_non_nullable
-              as String?,
-      reviewedAt: freezed == reviewedAt
-          ? _self.reviewedAt
-          : reviewedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      reviewedBy: freezed == reviewedBy
-          ? _self.reviewedBy
-          : reviewedBy // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Create a copy of VerificationSubmission
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? partnerId = null,Object? userId = null,Object? verificationId = null,Object? status = null,Object? snapshotData = null,Object? createdAt = null,Object? updatedAt = null,Object? applicationId = freezed,Object? reviewedAt = freezed,Object? reviewedBy = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,partnerId: null == partnerId ? _self.partnerId : partnerId // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,verificationId: null == verificationId ? _self.verificationId : verificationId // ignore: cast_nullable_to_non_nullable
+as String,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as VerificationStatus,snapshotData: null == snapshotData ? _self.snapshotData : snapshotData // ignore: cast_nullable_to_non_nullable
+as List<dynamic>,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,applicationId: freezed == applicationId ? _self.applicationId : applicationId // ignore: cast_nullable_to_non_nullable
+as String?,reviewedAt: freezed == reviewedAt ? _self.reviewedAt : reviewedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,reviewedBy: freezed == reviewedBy ? _self.reviewedBy : reviewedBy // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [VerificationSubmission].
 extension VerificationSubmissionPatterns on VerificationSubmission {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_VerificationSubmission value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _VerificationSubmission() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _VerificationSubmission value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _VerificationSubmission() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_VerificationSubmission value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _VerificationSubmission():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _VerificationSubmission value)  $default,){
+final _that = this;
+switch (_that) {
+case _VerificationSubmission():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_VerificationSubmission value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _VerificationSubmission() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _VerificationSubmission value)?  $default,){
+final _that = this;
+switch (_that) {
+case _VerificationSubmission() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'partner_id') String partnerId,
-            @JsonKey(name: 'user_id') String userId,
-            @JsonKey(name: 'verification_id') String verificationId,
-            VerificationStatus status,
-            @JsonKey(name: 'snapshot_data') Map<String, dynamic> snapshotData,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'application_id') String? applicationId,
-            @JsonKey(name: 'admin_comment') String? adminComment,
-            @JsonKey(name: 'reviewed_at') DateTime? reviewedAt,
-            @JsonKey(name: 'reviewed_by') String? reviewedBy)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _VerificationSubmission() when $default != null:
-        return $default(
-            _that.id,
-            _that.partnerId,
-            _that.userId,
-            _that.verificationId,
-            _that.status,
-            _that.snapshotData,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.applicationId,
-            _that.adminComment,
-            _that.reviewedAt,
-            _that.reviewedBy);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'partner_id')  String partnerId, @JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'verification_id')  String verificationId,  VerificationStatus status, @JsonKey(name: 'snapshot_data')  List<dynamic> snapshotData, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'application_id')  String? applicationId, @JsonKey(name: 'reviewed_at')  DateTime? reviewedAt, @JsonKey(name: 'reviewed_by')  String? reviewedBy)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _VerificationSubmission() when $default != null:
+return $default(_that.id,_that.partnerId,_that.userId,_that.verificationId,_that.status,_that.snapshotData,_that.createdAt,_that.updatedAt,_that.applicationId,_that.reviewedAt,_that.reviewedBy);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            String id,
-            @JsonKey(name: 'partner_id') String partnerId,
-            @JsonKey(name: 'user_id') String userId,
-            @JsonKey(name: 'verification_id') String verificationId,
-            VerificationStatus status,
-            @JsonKey(name: 'snapshot_data') Map<String, dynamic> snapshotData,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'application_id') String? applicationId,
-            @JsonKey(name: 'admin_comment') String? adminComment,
-            @JsonKey(name: 'reviewed_at') DateTime? reviewedAt,
-            @JsonKey(name: 'reviewed_by') String? reviewedBy)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _VerificationSubmission():
-        return $default(
-            _that.id,
-            _that.partnerId,
-            _that.userId,
-            _that.verificationId,
-            _that.status,
-            _that.snapshotData,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.applicationId,
-            _that.adminComment,
-            _that.reviewedAt,
-            _that.reviewedBy);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'partner_id')  String partnerId, @JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'verification_id')  String verificationId,  VerificationStatus status, @JsonKey(name: 'snapshot_data')  List<dynamic> snapshotData, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'application_id')  String? applicationId, @JsonKey(name: 'reviewed_at')  DateTime? reviewedAt, @JsonKey(name: 'reviewed_by')  String? reviewedBy)  $default,) {final _that = this;
+switch (_that) {
+case _VerificationSubmission():
+return $default(_that.id,_that.partnerId,_that.userId,_that.verificationId,_that.status,_that.snapshotData,_that.createdAt,_that.updatedAt,_that.applicationId,_that.reviewedAt,_that.reviewedBy);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            String id,
-            @JsonKey(name: 'partner_id') String partnerId,
-            @JsonKey(name: 'user_id') String userId,
-            @JsonKey(name: 'verification_id') String verificationId,
-            VerificationStatus status,
-            @JsonKey(name: 'snapshot_data') Map<String, dynamic> snapshotData,
-            @JsonKey(name: 'created_at') DateTime createdAt,
-            @JsonKey(name: 'updated_at') DateTime updatedAt,
-            @JsonKey(name: 'application_id') String? applicationId,
-            @JsonKey(name: 'admin_comment') String? adminComment,
-            @JsonKey(name: 'reviewed_at') DateTime? reviewedAt,
-            @JsonKey(name: 'reviewed_by') String? reviewedBy)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _VerificationSubmission() when $default != null:
-        return $default(
-            _that.id,
-            _that.partnerId,
-            _that.userId,
-            _that.verificationId,
-            _that.status,
-            _that.snapshotData,
-            _that.createdAt,
-            _that.updatedAt,
-            _that.applicationId,
-            _that.adminComment,
-            _that.reviewedAt,
-            _that.reviewedBy);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'partner_id')  String partnerId, @JsonKey(name: 'user_id')  String userId, @JsonKey(name: 'verification_id')  String verificationId,  VerificationStatus status, @JsonKey(name: 'snapshot_data')  List<dynamic> snapshotData, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'updated_at')  DateTime updatedAt, @JsonKey(name: 'application_id')  String? applicationId, @JsonKey(name: 'reviewed_at')  DateTime? reviewedAt, @JsonKey(name: 'reviewed_by')  String? reviewedBy)?  $default,) {final _that = this;
+switch (_that) {
+case _VerificationSubmission() when $default != null:
+return $default(_that.id,_that.partnerId,_that.userId,_that.verificationId,_that.status,_that.snapshotData,_that.createdAt,_that.updatedAt,_that.applicationId,_that.reviewedAt,_that.reviewedBy);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _VerificationSubmission implements VerificationSubmission {
-  const _VerificationSubmission(
-      {required this.id,
-      @JsonKey(name: 'partner_id') required this.partnerId,
-      @JsonKey(name: 'user_id') required this.userId,
-      @JsonKey(name: 'verification_id') required this.verificationId,
-      required this.status,
-      @JsonKey(name: 'snapshot_data')
-      required final Map<String, dynamic> snapshotData,
-      @JsonKey(name: 'created_at') required this.createdAt,
-      @JsonKey(name: 'updated_at') required this.updatedAt,
-      @JsonKey(name: 'application_id') this.applicationId,
-      @JsonKey(name: 'admin_comment') this.adminComment,
-      @JsonKey(name: 'reviewed_at') this.reviewedAt,
-      @JsonKey(name: 'reviewed_by') this.reviewedBy})
-      : _snapshotData = snapshotData;
-  factory _VerificationSubmission.fromJson(Map<String, dynamic> json) =>
-      _$VerificationSubmissionFromJson(json);
+  const _VerificationSubmission({required this.id, @JsonKey(name: 'partner_id') required this.partnerId, @JsonKey(name: 'user_id') required this.userId, @JsonKey(name: 'verification_id') required this.verificationId, required this.status, @JsonKey(name: 'snapshot_data') required final  List<dynamic> snapshotData, @JsonKey(name: 'created_at') required this.createdAt, @JsonKey(name: 'updated_at') required this.updatedAt, @JsonKey(name: 'application_id') this.applicationId, @JsonKey(name: 'reviewed_at') this.reviewedAt, @JsonKey(name: 'reviewed_by') this.reviewedBy}): _snapshotData = snapshotData;
+  factory _VerificationSubmission.fromJson(Map<String, dynamic> json) => _$VerificationSubmissionFromJson(json);
 
-  @override
-  final String id;
-  @override
-  @JsonKey(name: 'partner_id')
-  final String partnerId;
-  @override
-  @JsonKey(name: 'user_id')
-  final String userId;
-  @override
-  @JsonKey(name: 'verification_id')
-  final String verificationId;
-  @override
-  final VerificationStatus status;
-  final Map<String, dynamic> _snapshotData;
-  @override
-  @JsonKey(name: 'snapshot_data')
-  Map<String, dynamic> get snapshotData {
-    if (_snapshotData is EqualUnmodifiableMapView) return _snapshotData;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableMapView(_snapshotData);
-  }
+@override final  String id;
+@override@JsonKey(name: 'partner_id') final  String partnerId;
+@override@JsonKey(name: 'user_id') final  String userId;
+@override@JsonKey(name: 'verification_id') final  String verificationId;
+@override final  VerificationStatus status;
+ final  List<dynamic> _snapshotData;
+@override@JsonKey(name: 'snapshot_data') List<dynamic> get snapshotData {
+  if (_snapshotData is EqualUnmodifiableListView) return _snapshotData;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_snapshotData);
+}
 
-  @override
-  @JsonKey(name: 'created_at')
-  final DateTime createdAt;
-  @override
-  @JsonKey(name: 'updated_at')
-  final DateTime updatedAt;
-  @override
-  @JsonKey(name: 'application_id')
-  final String? applicationId;
-  @override
-  @JsonKey(name: 'admin_comment')
-  final String? adminComment;
-  @override
-  @JsonKey(name: 'reviewed_at')
-  final DateTime? reviewedAt;
-  @override
-  @JsonKey(name: 'reviewed_by')
-  final String? reviewedBy;
+@override@JsonKey(name: 'created_at') final  DateTime createdAt;
+@override@JsonKey(name: 'updated_at') final  DateTime updatedAt;
+@override@JsonKey(name: 'application_id') final  String? applicationId;
+@override@JsonKey(name: 'reviewed_at') final  DateTime? reviewedAt;
+@override@JsonKey(name: 'reviewed_by') final  String? reviewedBy;
 
-  /// Create a copy of VerificationSubmission
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$VerificationSubmissionCopyWith<_VerificationSubmission> get copyWith =>
-      __$VerificationSubmissionCopyWithImpl<_VerificationSubmission>(
-          this, _$identity);
+/// Create a copy of VerificationSubmission
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$VerificationSubmissionCopyWith<_VerificationSubmission> get copyWith => __$VerificationSubmissionCopyWithImpl<_VerificationSubmission>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$VerificationSubmissionToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$VerificationSubmissionToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _VerificationSubmission &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.partnerId, partnerId) ||
-                other.partnerId == partnerId) &&
-            (identical(other.userId, userId) || other.userId == userId) &&
-            (identical(other.verificationId, verificationId) ||
-                other.verificationId == verificationId) &&
-            (identical(other.status, status) || other.status == status) &&
-            const DeepCollectionEquality()
-                .equals(other._snapshotData, _snapshotData) &&
-            (identical(other.createdAt, createdAt) ||
-                other.createdAt == createdAt) &&
-            (identical(other.updatedAt, updatedAt) ||
-                other.updatedAt == updatedAt) &&
-            (identical(other.applicationId, applicationId) ||
-                other.applicationId == applicationId) &&
-            (identical(other.adminComment, adminComment) ||
-                other.adminComment == adminComment) &&
-            (identical(other.reviewedAt, reviewedAt) ||
-                other.reviewedAt == reviewedAt) &&
-            (identical(other.reviewedBy, reviewedBy) ||
-                other.reviewedBy == reviewedBy));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _VerificationSubmission&&(identical(other.id, id) || other.id == id)&&(identical(other.partnerId, partnerId) || other.partnerId == partnerId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.verificationId, verificationId) || other.verificationId == verificationId)&&(identical(other.status, status) || other.status == status)&&const DeepCollectionEquality().equals(other._snapshotData, _snapshotData)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.applicationId, applicationId) || other.applicationId == applicationId)&&(identical(other.reviewedAt, reviewedAt) || other.reviewedAt == reviewedAt)&&(identical(other.reviewedBy, reviewedBy) || other.reviewedBy == reviewedBy));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      partnerId,
-      userId,
-      verificationId,
-      status,
-      const DeepCollectionEquality().hash(_snapshotData),
-      createdAt,
-      updatedAt,
-      applicationId,
-      adminComment,
-      reviewedAt,
-      reviewedBy);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,partnerId,userId,verificationId,status,const DeepCollectionEquality().hash(_snapshotData),createdAt,updatedAt,applicationId,reviewedAt,reviewedBy);
 
-  @override
-  String toString() {
-    return 'VerificationSubmission(id: $id, partnerId: $partnerId, userId: $userId, verificationId: $verificationId, status: $status, snapshotData: $snapshotData, createdAt: $createdAt, updatedAt: $updatedAt, applicationId: $applicationId, adminComment: $adminComment, reviewedAt: $reviewedAt, reviewedBy: $reviewedBy)';
-  }
+@override
+String toString() {
+  return 'VerificationSubmission(id: $id, partnerId: $partnerId, userId: $userId, verificationId: $verificationId, status: $status, snapshotData: $snapshotData, createdAt: $createdAt, updatedAt: $updatedAt, applicationId: $applicationId, reviewedAt: $reviewedAt, reviewedBy: $reviewedBy)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$VerificationSubmissionCopyWith<$Res>
-    implements $VerificationSubmissionCopyWith<$Res> {
-  factory _$VerificationSubmissionCopyWith(_VerificationSubmission value,
-          $Res Function(_VerificationSubmission) _then) =
-      __$VerificationSubmissionCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {String id,
-      @JsonKey(name: 'partner_id') String partnerId,
-      @JsonKey(name: 'user_id') String userId,
-      @JsonKey(name: 'verification_id') String verificationId,
-      VerificationStatus status,
-      @JsonKey(name: 'snapshot_data') Map<String, dynamic> snapshotData,
-      @JsonKey(name: 'created_at') DateTime createdAt,
-      @JsonKey(name: 'updated_at') DateTime updatedAt,
-      @JsonKey(name: 'application_id') String? applicationId,
-      @JsonKey(name: 'admin_comment') String? adminComment,
-      @JsonKey(name: 'reviewed_at') DateTime? reviewedAt,
-      @JsonKey(name: 'reviewed_by') String? reviewedBy});
-}
+abstract mixin class _$VerificationSubmissionCopyWith<$Res> implements $VerificationSubmissionCopyWith<$Res> {
+  factory _$VerificationSubmissionCopyWith(_VerificationSubmission value, $Res Function(_VerificationSubmission) _then) = __$VerificationSubmissionCopyWithImpl;
+@override @useResult
+$Res call({
+ String id,@JsonKey(name: 'partner_id') String partnerId,@JsonKey(name: 'user_id') String userId,@JsonKey(name: 'verification_id') String verificationId, VerificationStatus status,@JsonKey(name: 'snapshot_data') List<dynamic> snapshotData,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'updated_at') DateTime updatedAt,@JsonKey(name: 'application_id') String? applicationId,@JsonKey(name: 'reviewed_at') DateTime? reviewedAt,@JsonKey(name: 'reviewed_by') String? reviewedBy
+});
 
+
+
+
+}
 /// @nodoc
 class __$VerificationSubmissionCopyWithImpl<$Res>
     implements _$VerificationSubmissionCopyWith<$Res> {
@@ -591,75 +288,26 @@ class __$VerificationSubmissionCopyWithImpl<$Res>
   final _VerificationSubmission _self;
   final $Res Function(_VerificationSubmission) _then;
 
-  /// Create a copy of VerificationSubmission
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? id = null,
-    Object? partnerId = null,
-    Object? userId = null,
-    Object? verificationId = null,
-    Object? status = null,
-    Object? snapshotData = null,
-    Object? createdAt = null,
-    Object? updatedAt = null,
-    Object? applicationId = freezed,
-    Object? adminComment = freezed,
-    Object? reviewedAt = freezed,
-    Object? reviewedBy = freezed,
-  }) {
-    return _then(_VerificationSubmission(
-      id: null == id
-          ? _self.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      partnerId: null == partnerId
-          ? _self.partnerId
-          : partnerId // ignore: cast_nullable_to_non_nullable
-              as String,
-      userId: null == userId
-          ? _self.userId
-          : userId // ignore: cast_nullable_to_non_nullable
-              as String,
-      verificationId: null == verificationId
-          ? _self.verificationId
-          : verificationId // ignore: cast_nullable_to_non_nullable
-              as String,
-      status: null == status
-          ? _self.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as VerificationStatus,
-      snapshotData: null == snapshotData
-          ? _self._snapshotData
-          : snapshotData // ignore: cast_nullable_to_non_nullable
-              as Map<String, dynamic>,
-      createdAt: null == createdAt
-          ? _self.createdAt
-          : createdAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      updatedAt: null == updatedAt
-          ? _self.updatedAt
-          : updatedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime,
-      applicationId: freezed == applicationId
-          ? _self.applicationId
-          : applicationId // ignore: cast_nullable_to_non_nullable
-              as String?,
-      adminComment: freezed == adminComment
-          ? _self.adminComment
-          : adminComment // ignore: cast_nullable_to_non_nullable
-              as String?,
-      reviewedAt: freezed == reviewedAt
-          ? _self.reviewedAt
-          : reviewedAt // ignore: cast_nullable_to_non_nullable
-              as DateTime?,
-      reviewedBy: freezed == reviewedBy
-          ? _self.reviewedBy
-          : reviewedBy // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Create a copy of VerificationSubmission
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? partnerId = null,Object? userId = null,Object? verificationId = null,Object? status = null,Object? snapshotData = null,Object? createdAt = null,Object? updatedAt = null,Object? applicationId = freezed,Object? reviewedAt = freezed,Object? reviewedBy = freezed,}) {
+  return _then(_VerificationSubmission(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,partnerId: null == partnerId ? _self.partnerId : partnerId // ignore: cast_nullable_to_non_nullable
+as String,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
+as String,verificationId: null == verificationId ? _self.verificationId : verificationId // ignore: cast_nullable_to_non_nullable
+as String,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as VerificationStatus,snapshotData: null == snapshotData ? _self._snapshotData : snapshotData // ignore: cast_nullable_to_non_nullable
+as List<dynamic>,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
+as DateTime,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,applicationId: freezed == applicationId ? _self.applicationId : applicationId // ignore: cast_nullable_to_non_nullable
+as String?,reviewedAt: freezed == reviewedAt ? _self.reviewedAt : reviewedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,reviewedBy: freezed == reviewedBy ? _self.reviewedBy : reviewedBy // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/verification_submission.g.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/verification_submission.g.dart
@@ -14,11 +14,10 @@ _VerificationSubmission _$VerificationSubmissionFromJson(
   userId: json['user_id'] as String,
   verificationId: json['verification_id'] as String,
   status: $enumDecode(_$VerificationStatusEnumMap, json['status']),
-  snapshotData: json['snapshot_data'] as Map<String, dynamic>,
+  snapshotData: json['snapshot_data'] as List<dynamic>,
   createdAt: DateTime.parse(json['created_at'] as String),
   updatedAt: DateTime.parse(json['updated_at'] as String),
   applicationId: json['application_id'] as String?,
-  adminComment: json['admin_comment'] as String?,
   reviewedAt: json['reviewed_at'] == null
       ? null
       : DateTime.parse(json['reviewed_at'] as String),
@@ -37,7 +36,6 @@ Map<String, dynamic> _$VerificationSubmissionToJson(
   'created_at': instance.createdAt.toIso8601String(),
   'updated_at': instance.updatedAt.toIso8601String(),
   'application_id': instance.applicationId,
-  'admin_comment': instance.adminComment,
   'reviewed_at': instance.reviewedAt?.toIso8601String(),
   'reviewed_by': instance.reviewedBy,
 };
@@ -46,6 +44,4 @@ const _$VerificationStatusEnumMap = {
   VerificationStatus.pending: 'pending',
   VerificationStatus.approved: 'approved',
   VerificationStatus.rejected: 'rejected',
-  VerificationStatus.needsCorrection: 'needs_correction',
-  VerificationStatus.cancelled: 'cancelled',
 };

--- a/shared/packages/minglit_kit/lib/src/data/repositories/policy_repository.g.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/policy_repository.g.dart
@@ -8,9 +8,12 @@ part of 'policy_repository.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
+/// Provides a [PolicyRepository] instance.
 
 @ProviderFor(policyRepository)
 const policyRepositoryProvider = PolicyRepositoryProvider._();
+
+/// Provides a [PolicyRepository] instance.
 
 final class PolicyRepositoryProvider
     extends
@@ -20,6 +23,7 @@ final class PolicyRepositoryProvider
           PolicyRepository
         >
     with $Provider<PolicyRepository> {
+  /// Provides a [PolicyRepository] instance.
   const PolicyRepositoryProvider._()
     : super(
         from: null,

--- a/shared/packages/minglit_kit/lib/src/data/repositories/verification_command_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/verification_command_repository.dart
@@ -64,6 +64,78 @@ mixin _VerificationCommandRepository on _SupabaseVerificationContext {
     }
   }
 
+  // Fix #301: Split into EF calls — personal data save + partner submission
+  Future<void> saveUserVerificationData({
+    required String verificationId,
+    required Map<String, dynamic> data,
+  }) async {
+    Log.d(
+      'saveUserVerificationData called | verificationId: $verificationId',
+    );
+    try {
+      final response = await supabaseClient.functions.invoke(
+        'user-update-verification',
+        body: {
+          'verification_id': verificationId,
+          'data': data,
+        },
+      );
+
+      if (response.status != 200) {
+        final respData = response.data;
+        final errorMsg = respData is Map
+            ? (respData['error'] as String?) ?? 'Failed to save verification'
+            : 'Failed to save verification';
+        throw MinglitUserException(errorMsg);
+      }
+      Log.d('saveUserVerificationData success');
+    } catch (e, st) {
+      Log.e('❌ [VerificationRepo] saveUserVerificationData Error', e, st);
+      rethrow;
+    }
+  }
+
+  // Fix #301: Submit verification to partner via EF
+  Future<String> submitVerificationToPartner({
+    required String partnerId,
+    required String verificationId,
+    String? applicationId,
+  }) async {
+    Log.d(
+      'submitVerificationToPartner called | partnerId: $partnerId,'
+      ' verificationId: $verificationId',
+    );
+    try {
+      final response = await supabaseClient.functions.invoke(
+        'user-submit-verification',
+        body: {
+          'action': 'submit',
+          'partner_id': partnerId,
+          'verification_id': verificationId,
+          // ignore: use_null_aware_elements, ?'key': val syntax causes invalid_null_aware_operator
+          if (applicationId != null) 'application_id': applicationId,
+        },
+      );
+
+      if (response.status != 200) {
+        final respData = response.data;
+        final errorMsg = respData is Map
+            ? (respData['error'] as String?) ?? 'Failed to submit verification'
+            : 'Failed to submit verification';
+        throw MinglitUserException(errorMsg);
+      }
+
+      final data = response.data as Map<String, dynamic>;
+      final submissionId = data['submission_id'] as String;
+      Log.d('submitVerificationToPartner success | id: $submissionId');
+      return submissionId;
+    } catch (e, st) {
+      Log.e('❌ [VerificationRepo] submitVerificationToPartner Error', e, st);
+      rethrow;
+    }
+  }
+
+  // Fix #301: Combined save + submit (backward compatible replacement)
   Future<void> submitOrUpdateVerification({
     required String partnerId,
     required String verificationId,
@@ -74,35 +146,17 @@ mixin _VerificationCommandRepository on _SupabaseVerificationContext {
       'submitOrUpdateVerification called | partnerId: $partnerId,'
       ' verificationId: $verificationId',
     );
-    final userId = supabaseClient.auth.currentUser?.id;
-    if (userId == null) throw const AuthException('User not authenticated');
-
     try {
-      await supabaseClient.from('user_verifications').upsert({
-        'user_id': userId,
-        'verification_id': verificationId,
-        'data': claimData,
-        'updated_at': DateTime.now().toIso8601String(),
-      });
-
-      if (existingSubmissionId != null) {
-        await supabaseClient
-            .from('verification_submissions')
-            .update({
-              'status': VerificationStatus.pending.name,
-              'snapshot_data': claimData,
-              'updated_at': DateTime.now().toIso8601String(),
-            })
-            .eq('id', existingSubmissionId);
-      } else {
-        await supabaseClient.from('verification_submissions').insert({
-          'partner_id': partnerId,
-          'user_id': userId,
-          'verification_id': verificationId,
-          'status': VerificationStatus.pending.name,
-          'snapshot_data': claimData,
-        });
-      }
+      // Step 1: Save personal data via EF
+      await saveUserVerificationData(
+        verificationId: verificationId,
+        data: claimData,
+      );
+      // Step 2: Submit to partner via EF
+      await submitVerificationToPartner(
+        partnerId: partnerId,
+        verificationId: verificationId,
+      );
       Log.d('submitOrUpdateVerification success');
     } on Exception catch (e, stackTrace) {
       Log.e('❌ [VerificationRepo] Submission Failed', e, stackTrace);
@@ -120,11 +174,9 @@ mixin _VerificationCommandRepository on _SupabaseVerificationContext {
     );
     try {
       for (final submission in submissions) {
-        await submitOrUpdateVerification(
+        await submitVerificationToPartner(
           partnerId: partnerId,
           verificationId: submission.verificationId,
-          claimData: submission.snapshotData,
-          existingSubmissionId: submission.id,
         );
       }
       Log.d('submitBulkVerifications success');
@@ -134,10 +186,10 @@ mixin _VerificationCommandRepository on _SupabaseVerificationContext {
     }
   }
 
+  // Fix #301: will be replaced by partner-review-submission EF (#309)
   Future<void> reviewRequest({
     required String submissionId,
     required VerificationStatus status,
-    String? adminComment,
   }) async {
     Log.d(
       'reviewRequest called | submissionId: $submissionId, status: $status',
@@ -147,7 +199,6 @@ mixin _VerificationCommandRepository on _SupabaseVerificationContext {
           .from('verification_submissions')
           .update({
             'status': status.name,
-            'admin_comment': adminComment,
             'reviewed_at': DateTime.now().toIso8601String(),
             'reviewed_by': supabaseClient.auth.currentUser?.id,
           })
@@ -159,18 +210,30 @@ mixin _VerificationCommandRepository on _SupabaseVerificationContext {
     }
   }
 
+  // Fix #301: submitComment via EF (verification_comments table dropped)
   Future<void> submitComment({
     required String submissionId,
     required Map<String, dynamic> content,
   }) async {
     Log.d('submitComment called | submissionId: $submissionId');
-    final userId = supabaseClient.auth.currentUser?.id;
     try {
-      await supabaseClient.from('verification_comments').insert({
-        'submission_id': submissionId,
-        'author_id': userId,
-        'content': content,
-      });
+      final text = content['text'] as String? ?? '';
+      final response = await supabaseClient.functions.invoke(
+        'user-submit-verification',
+        body: {
+          'action': 'comment',
+          'submission_id': submissionId,
+          'text': text,
+        },
+      );
+
+      if (response.status != 200) {
+        final respData = response.data;
+        final errorMsg = respData is Map
+            ? (respData['error'] as String?) ?? 'Failed to submit comment'
+            : 'Failed to submit comment';
+        throw MinglitUserException(errorMsg);
+      }
       Log.d('submitComment success');
     } catch (e, st) {
       Log.e('❌ [VerificationRepo] submitComment Error', e, st);

--- a/shared/packages/minglit_kit/lib/src/data/repositories/verification_query_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/verification_query_repository.dart
@@ -267,9 +267,7 @@ mixin _VerificationQueryRepository on _SupabaseVerificationContext {
     if (userId == null) return [];
 
     try {
-      final statusName = status == VerificationStatus.needsCorrection
-          ? 'needs_correction'
-          : status.name;
+      final statusName = status.name;
 
       final data = await supabaseClient
           .from('verification_submissions')
@@ -286,17 +284,41 @@ mixin _VerificationQueryRepository on _SupabaseVerificationContext {
     }
   }
 
+  // Fix #301: Comments now live inside snapshot_data JSON array
   Future<List<Map<String, dynamic>>> getVerificationComments(
     String submissionId,
   ) async {
     Log.d('getVerificationComments called | submissionId: $submissionId');
     try {
       final data = await supabaseClient
-          .from('verification_comments')
-          .select()
-          .eq('submission_id', submissionId)
-          .order('created_at', ascending: true);
-      final result = (data as List<dynamic>).cast<Map<String, dynamic>>();
+          .from('verification_submissions')
+          .select('snapshot_data')
+          .eq('id', submissionId)
+          .maybeSingle();
+
+      if (data == null) return [];
+
+      final snapshotData = data['snapshot_data'];
+      if (snapshotData is! List) return [];
+
+      // Collect all comments from all history entries
+      final result = <Map<String, dynamic>>[];
+      for (final entry in snapshotData) {
+        if (entry is Map<String, dynamic>) {
+          final comments = entry['comments'];
+          if (comments is List) {
+            for (final c in comments) {
+              if (c is Map<String, dynamic>) {
+                result.add({
+                  'author_id': c['author'],
+                  'content': {'text': c['text']},
+                  'created_at': c['at'],
+                });
+              }
+            }
+          }
+        }
+      }
       Log.d('getVerificationComments success | count: ${result.length}');
       return result;
     } catch (e, st) {

--- a/shared/packages/minglit_kit/lib/src/data/repositories/verification_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/verification_repository.dart
@@ -1,5 +1,6 @@
 import 'package:minglit_kit/src/data/models/verification.dart';
 import 'package:minglit_kit/src/data/models/verification_submission.dart';
+import 'package:minglit_kit/src/utils/exceptions.dart';
 import 'package:minglit_kit/src/utils/log.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -91,7 +92,6 @@ abstract class VerificationRepository {
   Future<void> reviewRequest({
     required String submissionId,
     required VerificationStatus status,
-    String? adminComment,
   });
 
   /// User 특정 상태의 모든 요청 조회 (예: 보완 필요 건만 모아보기)

--- a/shared/packages/minglit_kit/lib/src/features/iamport/data/model/iamport_result_model.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/features/iamport/data/model/iamport_result_model.freezed.dart
@@ -14,72 +14,47 @@ T _$identity<T>(T value) => value;
 
 /// @nodoc
 mixin _$IamportResultModel {
-  @JsonKey(name: 'imp_uid')
-  String? get impUid;
-  @JsonKey(name: 'merchant_uid')
-  String? get merchantUid;
-  @JsonKey(name: 'success')
-  bool get success;
-  @JsonKey(name: 'error_msg')
-  String? get errorMsg;
-  @JsonKey(name: 'pg_provider')
-  String? get pgProvider;
-  @JsonKey(name: 'pg_type')
-  String? get pgType;
 
-  /// Create a copy of IamportResultModel
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $IamportResultModelCopyWith<IamportResultModel> get copyWith =>
-      _$IamportResultModelCopyWithImpl<IamportResultModel>(
-          this as IamportResultModel, _$identity);
+@JsonKey(name: 'imp_uid') String? get impUid;@JsonKey(name: 'merchant_uid') String? get merchantUid;@JsonKey(name: 'success') bool get success;@JsonKey(name: 'error_msg') String? get errorMsg;@JsonKey(name: 'pg_provider') String? get pgProvider;@JsonKey(name: 'pg_type') String? get pgType;
+/// Create a copy of IamportResultModel
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$IamportResultModelCopyWith<IamportResultModel> get copyWith => _$IamportResultModelCopyWithImpl<IamportResultModel>(this as IamportResultModel, _$identity);
 
   /// Serializes this IamportResultModel to a JSON map.
   Map<String, dynamic> toJson();
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is IamportResultModel &&
-            (identical(other.impUid, impUid) || other.impUid == impUid) &&
-            (identical(other.merchantUid, merchantUid) ||
-                other.merchantUid == merchantUid) &&
-            (identical(other.success, success) || other.success == success) &&
-            (identical(other.errorMsg, errorMsg) ||
-                other.errorMsg == errorMsg) &&
-            (identical(other.pgProvider, pgProvider) ||
-                other.pgProvider == pgProvider) &&
-            (identical(other.pgType, pgType) || other.pgType == pgType));
-  }
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, impUid, merchantUid, success, errorMsg, pgProvider, pgType);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is IamportResultModel&&(identical(other.impUid, impUid) || other.impUid == impUid)&&(identical(other.merchantUid, merchantUid) || other.merchantUid == merchantUid)&&(identical(other.success, success) || other.success == success)&&(identical(other.errorMsg, errorMsg) || other.errorMsg == errorMsg)&&(identical(other.pgProvider, pgProvider) || other.pgProvider == pgProvider)&&(identical(other.pgType, pgType) || other.pgType == pgType));
+}
 
-  @override
-  String toString() {
-    return 'IamportResultModel(impUid: $impUid, merchantUid: $merchantUid, success: $success, errorMsg: $errorMsg, pgProvider: $pgProvider, pgType: $pgType)';
-  }
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,impUid,merchantUid,success,errorMsg,pgProvider,pgType);
+
+@override
+String toString() {
+  return 'IamportResultModel(impUid: $impUid, merchantUid: $merchantUid, success: $success, errorMsg: $errorMsg, pgProvider: $pgProvider, pgType: $pgType)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $IamportResultModelCopyWith<$Res> {
-  factory $IamportResultModelCopyWith(
-          IamportResultModel value, $Res Function(IamportResultModel) _then) =
-      _$IamportResultModelCopyWithImpl;
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'imp_uid') String? impUid,
-      @JsonKey(name: 'merchant_uid') String? merchantUid,
-      @JsonKey(name: 'success') bool success,
-      @JsonKey(name: 'error_msg') String? errorMsg,
-      @JsonKey(name: 'pg_provider') String? pgProvider,
-      @JsonKey(name: 'pg_type') String? pgType});
-}
+abstract mixin class $IamportResultModelCopyWith<$Res>  {
+  factory $IamportResultModelCopyWith(IamportResultModel value, $Res Function(IamportResultModel) _then) = _$IamportResultModelCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'imp_uid') String? impUid,@JsonKey(name: 'merchant_uid') String? merchantUid,@JsonKey(name: 'success') bool success,@JsonKey(name: 'error_msg') String? errorMsg,@JsonKey(name: 'pg_provider') String? pgProvider,@JsonKey(name: 'pg_type') String? pgType
+});
 
+
+
+
+}
 /// @nodoc
 class _$IamportResultModelCopyWithImpl<$Res>
     implements $IamportResultModelCopyWith<$Res> {
@@ -88,320 +63,207 @@ class _$IamportResultModelCopyWithImpl<$Res>
   final IamportResultModel _self;
   final $Res Function(IamportResultModel) _then;
 
-  /// Create a copy of IamportResultModel
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? impUid = freezed,
-    Object? merchantUid = freezed,
-    Object? success = null,
-    Object? errorMsg = freezed,
-    Object? pgProvider = freezed,
-    Object? pgType = freezed,
-  }) {
-    return _then(_self.copyWith(
-      impUid: freezed == impUid
-          ? _self.impUid
-          : impUid // ignore: cast_nullable_to_non_nullable
-              as String?,
-      merchantUid: freezed == merchantUid
-          ? _self.merchantUid
-          : merchantUid // ignore: cast_nullable_to_non_nullable
-              as String?,
-      success: null == success
-          ? _self.success
-          : success // ignore: cast_nullable_to_non_nullable
-              as bool,
-      errorMsg: freezed == errorMsg
-          ? _self.errorMsg
-          : errorMsg // ignore: cast_nullable_to_non_nullable
-              as String?,
-      pgProvider: freezed == pgProvider
-          ? _self.pgProvider
-          : pgProvider // ignore: cast_nullable_to_non_nullable
-              as String?,
-      pgType: freezed == pgType
-          ? _self.pgType
-          : pgType // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Create a copy of IamportResultModel
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? impUid = freezed,Object? merchantUid = freezed,Object? success = null,Object? errorMsg = freezed,Object? pgProvider = freezed,Object? pgType = freezed,}) {
+  return _then(_self.copyWith(
+impUid: freezed == impUid ? _self.impUid : impUid // ignore: cast_nullable_to_non_nullable
+as String?,merchantUid: freezed == merchantUid ? _self.merchantUid : merchantUid // ignore: cast_nullable_to_non_nullable
+as String?,success: null == success ? _self.success : success // ignore: cast_nullable_to_non_nullable
+as bool,errorMsg: freezed == errorMsg ? _self.errorMsg : errorMsg // ignore: cast_nullable_to_non_nullable
+as String?,pgProvider: freezed == pgProvider ? _self.pgProvider : pgProvider // ignore: cast_nullable_to_non_nullable
+as String?,pgType: freezed == pgType ? _self.pgType : pgType // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [IamportResultModel].
 extension IamportResultModelPatterns on IamportResultModel {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_IamportResultModel value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _IamportResultModel() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _IamportResultModel value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _IamportResultModel() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_IamportResultModel value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _IamportResultModel():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _IamportResultModel value)  $default,){
+final _that = this;
+switch (_that) {
+case _IamportResultModel():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_IamportResultModel value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _IamportResultModel() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _IamportResultModel value)?  $default,){
+final _that = this;
+switch (_that) {
+case _IamportResultModel() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(
-            @JsonKey(name: 'imp_uid') String? impUid,
-            @JsonKey(name: 'merchant_uid') String? merchantUid,
-            @JsonKey(name: 'success') bool success,
-            @JsonKey(name: 'error_msg') String? errorMsg,
-            @JsonKey(name: 'pg_provider') String? pgProvider,
-            @JsonKey(name: 'pg_type') String? pgType)?
-        $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _IamportResultModel() when $default != null:
-        return $default(_that.impUid, _that.merchantUid, _that.success,
-            _that.errorMsg, _that.pgProvider, _that.pgType);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'imp_uid')  String? impUid, @JsonKey(name: 'merchant_uid')  String? merchantUid, @JsonKey(name: 'success')  bool success, @JsonKey(name: 'error_msg')  String? errorMsg, @JsonKey(name: 'pg_provider')  String? pgProvider, @JsonKey(name: 'pg_type')  String? pgType)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _IamportResultModel() when $default != null:
+return $default(_that.impUid,_that.merchantUid,_that.success,_that.errorMsg,_that.pgProvider,_that.pgType);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(
-            @JsonKey(name: 'imp_uid') String? impUid,
-            @JsonKey(name: 'merchant_uid') String? merchantUid,
-            @JsonKey(name: 'success') bool success,
-            @JsonKey(name: 'error_msg') String? errorMsg,
-            @JsonKey(name: 'pg_provider') String? pgProvider,
-            @JsonKey(name: 'pg_type') String? pgType)
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _IamportResultModel():
-        return $default(_that.impUid, _that.merchantUid, _that.success,
-            _that.errorMsg, _that.pgProvider, _that.pgType);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'imp_uid')  String? impUid, @JsonKey(name: 'merchant_uid')  String? merchantUid, @JsonKey(name: 'success')  bool success, @JsonKey(name: 'error_msg')  String? errorMsg, @JsonKey(name: 'pg_provider')  String? pgProvider, @JsonKey(name: 'pg_type')  String? pgType)  $default,) {final _that = this;
+switch (_that) {
+case _IamportResultModel():
+return $default(_that.impUid,_that.merchantUid,_that.success,_that.errorMsg,_that.pgProvider,_that.pgType);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(
-            @JsonKey(name: 'imp_uid') String? impUid,
-            @JsonKey(name: 'merchant_uid') String? merchantUid,
-            @JsonKey(name: 'success') bool success,
-            @JsonKey(name: 'error_msg') String? errorMsg,
-            @JsonKey(name: 'pg_provider') String? pgProvider,
-            @JsonKey(name: 'pg_type') String? pgType)?
-        $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _IamportResultModel() when $default != null:
-        return $default(_that.impUid, _that.merchantUid, _that.success,
-            _that.errorMsg, _that.pgProvider, _that.pgType);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'imp_uid')  String? impUid, @JsonKey(name: 'merchant_uid')  String? merchantUid, @JsonKey(name: 'success')  bool success, @JsonKey(name: 'error_msg')  String? errorMsg, @JsonKey(name: 'pg_provider')  String? pgProvider, @JsonKey(name: 'pg_type')  String? pgType)?  $default,) {final _that = this;
+switch (_that) {
+case _IamportResultModel() when $default != null:
+return $default(_that.impUid,_that.merchantUid,_that.success,_that.errorMsg,_that.pgProvider,_that.pgType);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
 @JsonSerializable()
+
 class _IamportResultModel extends IamportResultModel {
-  const _IamportResultModel(
-      {@JsonKey(name: 'imp_uid') this.impUid,
-      @JsonKey(name: 'merchant_uid') this.merchantUid,
-      @JsonKey(name: 'success') this.success = false,
-      @JsonKey(name: 'error_msg') this.errorMsg,
-      @JsonKey(name: 'pg_provider') this.pgProvider,
-      @JsonKey(name: 'pg_type') this.pgType})
-      : super._();
-  factory _IamportResultModel.fromJson(Map<String, dynamic> json) =>
-      _$IamportResultModelFromJson(json);
+  const _IamportResultModel({@JsonKey(name: 'imp_uid') this.impUid, @JsonKey(name: 'merchant_uid') this.merchantUid, @JsonKey(name: 'success') this.success = false, @JsonKey(name: 'error_msg') this.errorMsg, @JsonKey(name: 'pg_provider') this.pgProvider, @JsonKey(name: 'pg_type') this.pgType}): super._();
+  factory _IamportResultModel.fromJson(Map<String, dynamic> json) => _$IamportResultModelFromJson(json);
 
-  @override
-  @JsonKey(name: 'imp_uid')
-  final String? impUid;
-  @override
-  @JsonKey(name: 'merchant_uid')
-  final String? merchantUid;
-  @override
-  @JsonKey(name: 'success')
-  final bool success;
-  @override
-  @JsonKey(name: 'error_msg')
-  final String? errorMsg;
-  @override
-  @JsonKey(name: 'pg_provider')
-  final String? pgProvider;
-  @override
-  @JsonKey(name: 'pg_type')
-  final String? pgType;
+@override@JsonKey(name: 'imp_uid') final  String? impUid;
+@override@JsonKey(name: 'merchant_uid') final  String? merchantUid;
+@override@JsonKey(name: 'success') final  bool success;
+@override@JsonKey(name: 'error_msg') final  String? errorMsg;
+@override@JsonKey(name: 'pg_provider') final  String? pgProvider;
+@override@JsonKey(name: 'pg_type') final  String? pgType;
 
-  /// Create a copy of IamportResultModel
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$IamportResultModelCopyWith<_IamportResultModel> get copyWith =>
-      __$IamportResultModelCopyWithImpl<_IamportResultModel>(this, _$identity);
+/// Create a copy of IamportResultModel
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$IamportResultModelCopyWith<_IamportResultModel> get copyWith => __$IamportResultModelCopyWithImpl<_IamportResultModel>(this, _$identity);
 
-  @override
-  Map<String, dynamic> toJson() {
-    return _$IamportResultModelToJson(
-      this,
-    );
-  }
+@override
+Map<String, dynamic> toJson() {
+  return _$IamportResultModelToJson(this, );
+}
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _IamportResultModel &&
-            (identical(other.impUid, impUid) || other.impUid == impUid) &&
-            (identical(other.merchantUid, merchantUid) ||
-                other.merchantUid == merchantUid) &&
-            (identical(other.success, success) || other.success == success) &&
-            (identical(other.errorMsg, errorMsg) ||
-                other.errorMsg == errorMsg) &&
-            (identical(other.pgProvider, pgProvider) ||
-                other.pgProvider == pgProvider) &&
-            (identical(other.pgType, pgType) || other.pgType == pgType));
-  }
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _IamportResultModel&&(identical(other.impUid, impUid) || other.impUid == impUid)&&(identical(other.merchantUid, merchantUid) || other.merchantUid == merchantUid)&&(identical(other.success, success) || other.success == success)&&(identical(other.errorMsg, errorMsg) || other.errorMsg == errorMsg)&&(identical(other.pgProvider, pgProvider) || other.pgProvider == pgProvider)&&(identical(other.pgType, pgType) || other.pgType == pgType));
+}
 
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType, impUid, merchantUid, success, errorMsg, pgProvider, pgType);
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,impUid,merchantUid,success,errorMsg,pgProvider,pgType);
 
-  @override
-  String toString() {
-    return 'IamportResultModel(impUid: $impUid, merchantUid: $merchantUid, success: $success, errorMsg: $errorMsg, pgProvider: $pgProvider, pgType: $pgType)';
-  }
+@override
+String toString() {
+  return 'IamportResultModel(impUid: $impUid, merchantUid: $merchantUid, success: $success, errorMsg: $errorMsg, pgProvider: $pgProvider, pgType: $pgType)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$IamportResultModelCopyWith<$Res>
-    implements $IamportResultModelCopyWith<$Res> {
-  factory _$IamportResultModelCopyWith(
-          _IamportResultModel value, $Res Function(_IamportResultModel) _then) =
-      __$IamportResultModelCopyWithImpl;
-  @override
-  @useResult
-  $Res call(
-      {@JsonKey(name: 'imp_uid') String? impUid,
-      @JsonKey(name: 'merchant_uid') String? merchantUid,
-      @JsonKey(name: 'success') bool success,
-      @JsonKey(name: 'error_msg') String? errorMsg,
-      @JsonKey(name: 'pg_provider') String? pgProvider,
-      @JsonKey(name: 'pg_type') String? pgType});
-}
+abstract mixin class _$IamportResultModelCopyWith<$Res> implements $IamportResultModelCopyWith<$Res> {
+  factory _$IamportResultModelCopyWith(_IamportResultModel value, $Res Function(_IamportResultModel) _then) = __$IamportResultModelCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'imp_uid') String? impUid,@JsonKey(name: 'merchant_uid') String? merchantUid,@JsonKey(name: 'success') bool success,@JsonKey(name: 'error_msg') String? errorMsg,@JsonKey(name: 'pg_provider') String? pgProvider,@JsonKey(name: 'pg_type') String? pgType
+});
 
+
+
+
+}
 /// @nodoc
 class __$IamportResultModelCopyWithImpl<$Res>
     implements _$IamportResultModelCopyWith<$Res> {
@@ -410,45 +272,21 @@ class __$IamportResultModelCopyWithImpl<$Res>
   final _IamportResultModel _self;
   final $Res Function(_IamportResultModel) _then;
 
-  /// Create a copy of IamportResultModel
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? impUid = freezed,
-    Object? merchantUid = freezed,
-    Object? success = null,
-    Object? errorMsg = freezed,
-    Object? pgProvider = freezed,
-    Object? pgType = freezed,
-  }) {
-    return _then(_IamportResultModel(
-      impUid: freezed == impUid
-          ? _self.impUid
-          : impUid // ignore: cast_nullable_to_non_nullable
-              as String?,
-      merchantUid: freezed == merchantUid
-          ? _self.merchantUid
-          : merchantUid // ignore: cast_nullable_to_non_nullable
-              as String?,
-      success: null == success
-          ? _self.success
-          : success // ignore: cast_nullable_to_non_nullable
-              as bool,
-      errorMsg: freezed == errorMsg
-          ? _self.errorMsg
-          : errorMsg // ignore: cast_nullable_to_non_nullable
-              as String?,
-      pgProvider: freezed == pgProvider
-          ? _self.pgProvider
-          : pgProvider // ignore: cast_nullable_to_non_nullable
-              as String?,
-      pgType: freezed == pgType
-          ? _self.pgType
-          : pgType // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
+/// Create a copy of IamportResultModel
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? impUid = freezed,Object? merchantUid = freezed,Object? success = null,Object? errorMsg = freezed,Object? pgProvider = freezed,Object? pgType = freezed,}) {
+  return _then(_IamportResultModel(
+impUid: freezed == impUid ? _self.impUid : impUid // ignore: cast_nullable_to_non_nullable
+as String?,merchantUid: freezed == merchantUid ? _self.merchantUid : merchantUid // ignore: cast_nullable_to_non_nullable
+as String?,success: null == success ? _self.success : success // ignore: cast_nullable_to_non_nullable
+as bool,errorMsg: freezed == errorMsg ? _self.errorMsg : errorMsg // ignore: cast_nullable_to_non_nullable
+as String?,pgProvider: freezed == pgProvider ? _self.pgProvider : pgProvider // ignore: cast_nullable_to_non_nullable
+as String?,pgType: freezed == pgType ? _self.pgType : pgType // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/shared/packages/minglit_kit/lib/src/features/loading/global_loading_controller.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/features/loading/global_loading_controller.freezed.dart
@@ -11,52 +11,49 @@ part of 'global_loading_controller.dart';
 
 // dart format off
 T _$identity<T>(T value) => value;
-
 /// @nodoc
 mixin _$GlobalLoadingState {
-  /// Whether the overlay is visible.
-  bool get isVisible;
 
-  /// Optional callback invoked when the user cancels.
-  VoidCallback? get onCancel;
+/// Whether the overlay is visible.
+ bool get isVisible;/// Optional callback invoked when the user cancels.
+ VoidCallback? get onCancel;
+/// Create a copy of GlobalLoadingState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GlobalLoadingStateCopyWith<GlobalLoadingState> get copyWith => _$GlobalLoadingStateCopyWithImpl<GlobalLoadingState>(this as GlobalLoadingState, _$identity);
 
-  /// Create a copy of GlobalLoadingState
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  $GlobalLoadingStateCopyWith<GlobalLoadingState> get copyWith =>
-      _$GlobalLoadingStateCopyWithImpl<GlobalLoadingState>(
-          this as GlobalLoadingState, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is GlobalLoadingState &&
-            (identical(other.isVisible, isVisible) ||
-                other.isVisible == isVisible) &&
-            (identical(other.onCancel, onCancel) ||
-                other.onCancel == onCancel));
-  }
 
-  @override
-  int get hashCode => Object.hash(runtimeType, isVisible, onCancel);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GlobalLoadingState&&(identical(other.isVisible, isVisible) || other.isVisible == isVisible)&&(identical(other.onCancel, onCancel) || other.onCancel == onCancel));
+}
 
-  @override
-  String toString() {
-    return 'GlobalLoadingState(isVisible: $isVisible, onCancel: $onCancel)';
-  }
+
+@override
+int get hashCode => Object.hash(runtimeType,isVisible,onCancel);
+
+@override
+String toString() {
+  return 'GlobalLoadingState(isVisible: $isVisible, onCancel: $onCancel)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class $GlobalLoadingStateCopyWith<$Res> {
-  factory $GlobalLoadingStateCopyWith(
-          GlobalLoadingState value, $Res Function(GlobalLoadingState) _then) =
-      _$GlobalLoadingStateCopyWithImpl;
-  @useResult
-  $Res call({bool isVisible, VoidCallback? onCancel});
-}
+abstract mixin class $GlobalLoadingStateCopyWith<$Res>  {
+  factory $GlobalLoadingStateCopyWith(GlobalLoadingState value, $Res Function(GlobalLoadingState) _then) = _$GlobalLoadingStateCopyWithImpl;
+@useResult
+$Res call({
+ bool isVisible, VoidCallback? onCancel
+});
 
+
+
+
+}
 /// @nodoc
 class _$GlobalLoadingStateCopyWithImpl<$Res>
     implements $GlobalLoadingStateCopyWith<$Res> {
@@ -65,237 +62,198 @@ class _$GlobalLoadingStateCopyWithImpl<$Res>
   final GlobalLoadingState _self;
   final $Res Function(GlobalLoadingState) _then;
 
-  /// Create a copy of GlobalLoadingState
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? isVisible = null,
-    Object? onCancel = freezed,
-  }) {
-    return _then(_self.copyWith(
-      isVisible: null == isVisible
-          ? _self.isVisible
-          : isVisible // ignore: cast_nullable_to_non_nullable
-              as bool,
-      onCancel: freezed == onCancel
-          ? _self.onCancel
-          : onCancel // ignore: cast_nullable_to_non_nullable
-              as VoidCallback?,
-    ));
-  }
+/// Create a copy of GlobalLoadingState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? isVisible = null,Object? onCancel = freezed,}) {
+  return _then(_self.copyWith(
+isVisible: null == isVisible ? _self.isVisible : isVisible // ignore: cast_nullable_to_non_nullable
+as bool,onCancel: freezed == onCancel ? _self.onCancel : onCancel // ignore: cast_nullable_to_non_nullable
+as VoidCallback?,
+  ));
 }
+
+}
+
 
 /// Adds pattern-matching-related methods to [GlobalLoadingState].
 extension GlobalLoadingStatePatterns on GlobalLoadingState {
-  /// A variant of `map` that fallback to returning `orElse`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>(
-    TResult Function(_GlobalLoadingState value)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _GlobalLoadingState() when $default != null:
-        return $default(_that);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GlobalLoadingState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GlobalLoadingState() when $default != null:
+return $default(_that);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// Callbacks receives the raw object, upcasted.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case final Subclass2 value:
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>(
-    TResult Function(_GlobalLoadingState value) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _GlobalLoadingState():
-        return $default(_that);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GlobalLoadingState value)  $default,){
+final _that = this;
+switch (_that) {
+case _GlobalLoadingState():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `map` that fallback to returning `null`.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case final Subclass value:
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>(
-    TResult? Function(_GlobalLoadingState value)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _GlobalLoadingState() when $default != null:
-        return $default(_that);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GlobalLoadingState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GlobalLoadingState() when $default != null:
+return $default(_that);case _:
+  return null;
 
-  /// A variant of `when` that fallback to an `orElse` callback.
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return orElse();
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>(
-    TResult Function(bool isVisible, VoidCallback? onCancel)? $default, {
-    required TResult orElse(),
-  }) {
-    final _that = this;
-    switch (_that) {
-      case _GlobalLoadingState() when $default != null:
-        return $default(_that.isVisible, _that.onCancel);
-      case _:
-        return orElse();
-    }
-  }
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool isVisible,  VoidCallback? onCancel)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GlobalLoadingState() when $default != null:
+return $default(_that.isVisible,_that.onCancel);case _:
+  return orElse();
 
-  /// A `switch`-like method, using callbacks.
-  ///
-  /// As opposed to `map`, this offers destructuring.
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case Subclass2(:final field2):
-  ///     return ...;
-  /// }
-  /// ```
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>(
-    TResult Function(bool isVisible, VoidCallback? onCancel) $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _GlobalLoadingState():
-        return $default(_that.isVisible, _that.onCancel);
-      case _:
-        throw StateError('Unexpected subclass');
-    }
-  }
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool isVisible,  VoidCallback? onCancel)  $default,) {final _that = this;
+switch (_that) {
+case _GlobalLoadingState():
+return $default(_that.isVisible,_that.onCancel);case _:
+  throw StateError('Unexpected subclass');
 
-  /// A variant of `when` that fallback to returning `null`
-  ///
-  /// It is equivalent to doing:
-  /// ```dart
-  /// switch (sealedClass) {
-  ///   case Subclass(:final field):
-  ///     return ...;
-  ///   case _:
-  ///     return null;
-  /// }
-  /// ```
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
 
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>(
-    TResult? Function(bool isVisible, VoidCallback? onCancel)? $default,
-  ) {
-    final _that = this;
-    switch (_that) {
-      case _GlobalLoadingState() when $default != null:
-        return $default(_that.isVisible, _that.onCancel);
-      case _:
-        return null;
-    }
-  }
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool isVisible,  VoidCallback? onCancel)?  $default,) {final _that = this;
+switch (_that) {
+case _GlobalLoadingState() when $default != null:
+return $default(_that.isVisible,_that.onCancel);case _:
+  return null;
+
+}
+}
+
 }
 
 /// @nodoc
+
 
 class _GlobalLoadingState implements GlobalLoadingState {
   const _GlobalLoadingState({this.isVisible = false, this.onCancel});
+  
 
-  /// Whether the overlay is visible.
-  @override
-  @JsonKey()
-  final bool isVisible;
+/// Whether the overlay is visible.
+@override@JsonKey() final  bool isVisible;
+/// Optional callback invoked when the user cancels.
+@override final  VoidCallback? onCancel;
 
-  /// Optional callback invoked when the user cancels.
-  @override
-  final VoidCallback? onCancel;
+/// Create a copy of GlobalLoadingState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GlobalLoadingStateCopyWith<_GlobalLoadingState> get copyWith => __$GlobalLoadingStateCopyWithImpl<_GlobalLoadingState>(this, _$identity);
 
-  /// Create a copy of GlobalLoadingState
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @pragma('vm:prefer-inline')
-  _$GlobalLoadingStateCopyWith<_GlobalLoadingState> get copyWith =>
-      __$GlobalLoadingStateCopyWithImpl<_GlobalLoadingState>(this, _$identity);
 
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _GlobalLoadingState &&
-            (identical(other.isVisible, isVisible) ||
-                other.isVisible == isVisible) &&
-            (identical(other.onCancel, onCancel) ||
-                other.onCancel == onCancel));
-  }
 
-  @override
-  int get hashCode => Object.hash(runtimeType, isVisible, onCancel);
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GlobalLoadingState&&(identical(other.isVisible, isVisible) || other.isVisible == isVisible)&&(identical(other.onCancel, onCancel) || other.onCancel == onCancel));
+}
 
-  @override
-  String toString() {
-    return 'GlobalLoadingState(isVisible: $isVisible, onCancel: $onCancel)';
-  }
+
+@override
+int get hashCode => Object.hash(runtimeType,isVisible,onCancel);
+
+@override
+String toString() {
+  return 'GlobalLoadingState(isVisible: $isVisible, onCancel: $onCancel)';
+}
+
+
 }
 
 /// @nodoc
-abstract mixin class _$GlobalLoadingStateCopyWith<$Res>
-    implements $GlobalLoadingStateCopyWith<$Res> {
-  factory _$GlobalLoadingStateCopyWith(
-          _GlobalLoadingState value, $Res Function(_GlobalLoadingState) _then) =
-      __$GlobalLoadingStateCopyWithImpl;
-  @override
-  @useResult
-  $Res call({bool isVisible, VoidCallback? onCancel});
-}
+abstract mixin class _$GlobalLoadingStateCopyWith<$Res> implements $GlobalLoadingStateCopyWith<$Res> {
+  factory _$GlobalLoadingStateCopyWith(_GlobalLoadingState value, $Res Function(_GlobalLoadingState) _then) = __$GlobalLoadingStateCopyWithImpl;
+@override @useResult
+$Res call({
+ bool isVisible, VoidCallback? onCancel
+});
 
+
+
+
+}
 /// @nodoc
 class __$GlobalLoadingStateCopyWithImpl<$Res>
     implements _$GlobalLoadingStateCopyWith<$Res> {
@@ -304,25 +262,17 @@ class __$GlobalLoadingStateCopyWithImpl<$Res>
   final _GlobalLoadingState _self;
   final $Res Function(_GlobalLoadingState) _then;
 
-  /// Create a copy of GlobalLoadingState
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $Res call({
-    Object? isVisible = null,
-    Object? onCancel = freezed,
-  }) {
-    return _then(_GlobalLoadingState(
-      isVisible: null == isVisible
-          ? _self.isVisible
-          : isVisible // ignore: cast_nullable_to_non_nullable
-              as bool,
-      onCancel: freezed == onCancel
-          ? _self.onCancel
-          : onCancel // ignore: cast_nullable_to_non_nullable
-              as VoidCallback?,
-    ));
-  }
+/// Create a copy of GlobalLoadingState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? isVisible = null,Object? onCancel = freezed,}) {
+  return _then(_GlobalLoadingState(
+isVisible: null == isVisible ? _self.isVisible : isVisible // ignore: cast_nullable_to_non_nullable
+as bool,onCancel: freezed == onCancel ? _self.onCancel : onCancel // ignore: cast_nullable_to_non_nullable
+as VoidCallback?,
+  ));
+}
+
+
 }
 
 // dart format on

--- a/shared/packages/minglit_kit/test/src/data/models/verification_submission_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/models/verification_submission_test.dart
@@ -20,7 +20,7 @@ void main() {
           'result': null,
           'reviewed_by': null,
           'reviewed_at': null,
-          'comments': [],
+          'comments': <dynamic>[],
         },
       ],
       'created_at': now.toIso8601String(),
@@ -38,7 +38,7 @@ void main() {
       expect(sub.userId, 'user_1');
       expect(sub.verificationId, 'verif_1');
       expect(sub.status, VerificationStatus.pending);
-      expect(sub.snapshotData, isA<List>());
+      expect(sub.snapshotData, isA<List<dynamic>>());
       expect(sub.snapshotData.length, 1);
       expect(sub.applicationId, 'app_1');
       expect(sub.reviewedBy, 'admin_1');

--- a/shared/packages/minglit_kit/test/src/data/models/verification_submission_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/models/verification_submission_test.dart
@@ -6,20 +6,26 @@ void main() {
   final now = DateTime(2026, 1, 15, 12);
 
   group('VerificationSubmission', () {
+    // Fix #301: snapshot_data is now an array of history entries
     Map<String, dynamic> submissionJson() => {
       'id': 'sub_1',
       'partner_id': 'partner_1',
       'user_id': 'user_1',
       'verification_id': 'verif_1',
       'status': 'pending',
-      'snapshot_data': {
-        'company': 'Minglit Inc',
-        'position': 'Developer',
-      },
+      'snapshot_data': [
+        {
+          'submitted_at': '2026-03-15',
+          'data': {'company': 'Minglit Inc', 'position': 'Developer'},
+          'result': null,
+          'reviewed_by': null,
+          'reviewed_at': null,
+          'comments': [],
+        },
+      ],
       'created_at': now.toIso8601String(),
       'updated_at': now.toIso8601String(),
       'application_id': 'app_1',
-      'admin_comment': 'Please resubmit',
       'reviewed_at': now.toIso8601String(),
       'reviewed_by': 'admin_1',
     };
@@ -32,9 +38,9 @@ void main() {
       expect(sub.userId, 'user_1');
       expect(sub.verificationId, 'verif_1');
       expect(sub.status, VerificationStatus.pending);
-      expect(sub.snapshotData['company'], 'Minglit Inc');
+      expect(sub.snapshotData, isA<List>());
+      expect(sub.snapshotData.length, 1);
       expect(sub.applicationId, 'app_1');
-      expect(sub.adminComment, 'Please resubmit');
       expect(sub.reviewedBy, 'admin_1');
     });
 
@@ -45,33 +51,26 @@ void main() {
         'user_id': 'u1',
         'verification_id': 'v1',
         'status': 'approved',
-        'snapshot_data': <String, dynamic>{},
+        'snapshot_data': <dynamic>[],
         'created_at': now.toIso8601String(),
         'updated_at': now.toIso8601String(),
       });
 
       expect(sub.status, VerificationStatus.approved);
       expect(sub.applicationId, isNull);
-      expect(sub.adminComment, isNull);
       expect(sub.reviewedAt, isNull);
       expect(sub.reviewedBy, isNull);
     });
 
     test('parses all status values', () {
-      for (final status in [
-        'pending',
-        'approved',
-        'rejected',
-        'needs_correction',
-        'cancelled',
-      ]) {
+      for (final status in ['pending', 'approved', 'rejected']) {
         final sub = VerificationSubmission.fromJson({
           'id': 'sub_1',
           'partner_id': 'p1',
           'user_id': 'u1',
           'verification_id': 'v1',
           'status': status,
-          'snapshot_data': <String, dynamic>{},
+          'snapshot_data': <dynamic>[],
           'created_at': now.toIso8601String(),
           'updated_at': now.toIso8601String(),
         });
@@ -97,11 +96,9 @@ void main() {
       final sub = VerificationSubmission.fromJson(submissionJson());
       final approved = sub.copyWith(
         status: VerificationStatus.approved,
-        adminComment: 'Approved!',
       );
 
       expect(approved.status, VerificationStatus.approved);
-      expect(approved.adminComment, 'Approved!');
       expect(approved.id, 'sub_1');
     });
   });

--- a/shared/packages/minglit_kit/test/src/data/models/verification_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/models/verification_test.dart
@@ -206,7 +206,11 @@ void main() {
         'verification_id': 'v1',
         'status': 'pending',
         'snapshot_data': <dynamic>[
-          {'submitted_at': '2026-03-15', 'data': {'company': 'Test'}, 'comments': <dynamic>[]},
+          {
+            'submitted_at': '2026-03-15',
+            'data': {'company': 'Test'},
+            'comments': <dynamic>[],
+          },
         ],
         'created_at': now.toIso8601String(),
         'updated_at': now.toIso8601String(),

--- a/shared/packages/minglit_kit/test/src/data/models/verification_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/models/verification_test.dart
@@ -205,7 +205,9 @@ void main() {
         'user_id': 'u1',
         'verification_id': 'v1',
         'status': 'pending',
-        'snapshot_data': {'company': 'Test'},
+        'snapshot_data': <dynamic>[
+          {'submitted_at': '2026-03-15', 'data': {'company': 'Test'}, 'comments': <dynamic>[]},
+        ],
         'created_at': now.toIso8601String(),
         'updated_at': now.toIso8601String(),
       });

--- a/shared/packages/minglit_kit/test/src/data/repositories/verification_command_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/verification_command_repository_test.dart
@@ -176,39 +176,6 @@ void main() {
           repository.reviewRequest(
             submissionId: 'sub_1',
             status: VerificationStatus.rejected,
-            adminComment: '부적합',
-          ),
-          throwsA(anything),
-        );
-      });
-    });
-
-    group('submitComment', () {
-      test('completes without error', () async {
-        unawaited(mockTable(mockClient, 'verification_comments'));
-
-        await expectLater(
-          repository.submitComment(
-            submissionId: 'sub_1',
-            content: {'text': '보완 요청'},
-          ),
-          completes,
-        );
-      });
-
-      test('throws on error', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'verification_comments',
-            shouldThrow: Exception('DB error'),
-          ),
-        );
-
-        await expectLater(
-          repository.submitComment(
-            submissionId: 'sub_1',
-            content: {'text': '보완 요청'},
           ),
           throwsA(anything),
         );

--- a/shared/packages/minglit_kit/test/src/data/repositories/verification_query_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/verification_query_repository_test.dart
@@ -272,32 +272,40 @@ void main() {
       });
     });
 
+    // Fix #301: getVerificationComments now reads from snapshot_data JSON
     group('getVerificationComments', () {
-      test('returns list of comments', () async {
-        final commentJson = {
-          'id': 'comment_1',
-          'submission_id': 'sub_1',
-          'content': '수정 필요',
-          'created_at': now.toIso8601String(),
-        };
+      test('returns comments from snapshot_data', () async {
         unawaited(
           mockTable(
             mockClient,
-            'verification_comments',
-            selectData: [commentJson],
+            'verification_submissions',
+            maybeSingleData: {
+              'snapshot_data': [
+                {
+                  'submitted_at': '2026-03-15',
+                  'data': {'university': '서울대'},
+                  'comments': [
+                    {
+                      'author': 'user-1',
+                      'at': '2026-03-16T10:00:00Z',
+                      'text': '다시 올리겠습니다',
+                    },
+                  ],
+                },
+              ],
+            },
           ),
         );
 
         final result = await repository.getVerificationComments('sub_1');
 
         expect(result, hasLength(1));
-        expect(result.first['id'], 'comment_1');
+        expect(result.first['author_id'], 'user-1');
+        expect((result.first['content'] as Map)['text'], '다시 올리겠습니다');
       });
 
-      test('returns empty list when no comments', () async {
-        unawaited(
-          mockTable(mockClient, 'verification_comments', selectData: []),
-        );
+      test('returns empty list when no submission found', () async {
+        unawaited(mockTable(mockClient, 'verification_submissions'));
 
         final result = await repository.getVerificationComments('sub_1');
 
@@ -308,7 +316,7 @@ void main() {
         unawaited(
           mockTable(
             mockClient,
-            'verification_comments',
+            'verification_submissions',
             shouldThrow: Exception('error'),
           ),
         );

--- a/supabase/functions/dev-seed/index.ts
+++ b/supabase/functions/dev-seed/index.ts
@@ -795,7 +795,7 @@ async function seedUserActivity(sb: SupabaseClient): Promise<void> {
     for (let ui = 0; ui < eventUsers.length; ui++) {
       const user = eventUsers[ui]
       const scenario = needsVerification
-        ? (ui === 0 ? 'pending_review_approved' : ui === 1 ? 'pending_review_rejected' : ui === 2 ? 'pending_review_needs_correction' : 'pending_review_pending')
+        ? (ui === 0 ? 'pending_review_approved' : ui === 1 ? 'pending_review_rejected' : 'pending_review_pending')
         : (ui === 0 ? 'approved' : ui === 1 ? 'paid' : ui === 2 ? 'cancelled' : ui === 3 ? 'payment_failed' : 'pending')
 
       const { data: app, error: appErr } = await sb.from('event_applications').insert({
@@ -834,7 +834,7 @@ async function seedUserActivity(sb: SupabaseClient): Promise<void> {
       verification_id: verifId,
       application_id: app.id,
       status: 'pending',
-      snapshot_data: { submitted_at: new Date().toISOString(), data: { note: 'seed data' } },
+      snapshot_data: [{ submitted_at: new Date().toISOString(), data: { note: 'seed data' }, result: null, reviewed_by: null, reviewed_at: null, comments: [] }],
     }).select('id').single()
 
     if (subErr) {
@@ -846,12 +846,10 @@ async function seedUserActivity(sb: SupabaseClient): Promise<void> {
     let targetStatus: string | null = null
     if (app.scenario === 'pending_review_approved') targetStatus = 'approved'
     else if (app.scenario === 'pending_review_rejected') targetStatus = 'rejected'
-    else if (app.scenario === 'pending_review_needs_correction') targetStatus = 'needs_correction'
 
     if (targetStatus) {
       await sb.from('verification_submissions').update({
         status: targetStatus,
-        admin_comment: targetStatus === 'rejected' ? '인증 서류 불충분' : targetStatus === 'needs_correction' ? '추가 서류 필요' : null,
         reviewed_at: new Date().toISOString(),
       }).eq('id', sub.id)
     }

--- a/supabase/functions/user-submit-verification/deno.json
+++ b/supabase/functions/user-submit-verification/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/user-submit-verification/index.ts
+++ b/supabase/functions/user-submit-verification/index.ts
@@ -1,0 +1,241 @@
+import { createClient } from "@supabase/supabase-js";
+import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
+import { requireAuth } from "../_shared/auth_utils.ts";
+import { initSentry, withHandler, withSpan, log } from "../_shared/logger.ts";
+import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
+
+const FN = "user-submit-verification";
+
+initSentry();
+initStatsig();
+
+Deno.serve(withHandler(async (req) => {
+  if (req.method === "OPTIONS") return corsResponse();
+
+  const auth = await requireAuth(req);
+  if (auth instanceof Response) return auth;
+  const userId = auth;
+
+  try {
+    let reqBody: Record<string, unknown>;
+    try {
+      reqBody = await req.json();
+    } catch {
+      return errorResponse("Invalid JSON body", 400);
+    }
+
+    const { action } = reqBody as { action?: string };
+    if (!action) {
+      return errorResponse("Missing required field: action", 400);
+    }
+
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+    );
+
+    switch (action) {
+      case "submit": {
+        const { partner_id, verification_id, application_id } = reqBody as {
+          partner_id?: string;
+          verification_id?: string;
+          application_id?: string;
+        };
+
+        if (!partner_id) {
+          return errorResponse("Missing required field: partner_id", 400);
+        }
+        if (!verification_id) {
+          return errorResponse("Missing required field: verification_id", 400);
+        }
+
+        // 1. Fetch user's verification data (snapshot source)
+        const { data: userVerification, error: uvError } = await withSpan(
+          "db.select.user_verifications", "db.select",
+          () => supabase
+            .from("user_verifications")
+            .select("data")
+            .eq("user_id", userId)
+            .eq("verification_id", verification_id)
+            .maybeSingle(),
+        );
+
+        if (uvError) {
+          log({ function: FN, level: "error", message: "Failed to fetch user verification", metadata: { detail: uvError } });
+          return errorResponse("Failed to fetch user verification data", 500);
+        }
+        if (!userVerification) {
+          return errorResponse("No verification data found. Save your data first.", 400);
+        }
+
+        const now = new Date().toISOString();
+        const snapshotEntry = {
+          submitted_at: now,
+          data: userVerification.data,
+          result: null,
+          reviewed_by: null,
+          reviewed_at: null,
+          comments: [],
+        };
+
+        // 2. Check for existing submission
+        const { data: existing, error: existError } = await withSpan(
+          "db.select.verification_submissions", "db.select",
+          () => supabase
+            .from("verification_submissions")
+            .select("id, snapshot_data")
+            .eq("user_id", userId)
+            .eq("partner_id", partner_id)
+            .eq("verification_id", verification_id)
+            .maybeSingle(),
+        );
+
+        if (existError) {
+          log({ function: FN, level: "error", message: "Failed to check existing submission", metadata: { detail: existError } });
+          return errorResponse("Failed to check existing submission", 500);
+        }
+
+        let submissionId: string;
+
+        if (existing) {
+          // Append to existing snapshot_data array, reset status to pending
+          const snapshotArray = Array.isArray(existing.snapshot_data)
+            ? [...existing.snapshot_data, snapshotEntry]
+            : [snapshotEntry];
+
+          const { error: updateError } = await withSpan(
+            "db.update.verification_submissions", "db.update",
+            () => supabase
+              .from("verification_submissions")
+              .update({
+                snapshot_data: snapshotArray,
+                status: "pending",
+              })
+              .eq("id", existing.id),
+          );
+
+          if (updateError) {
+            log({ function: FN, level: "error", message: "Failed to update submission", metadata: { detail: updateError } });
+            return errorResponse("Failed to update submission", 500);
+          }
+          submissionId = existing.id;
+        } else {
+          // Create new submission
+          const insertData: Record<string, unknown> = {
+            partner_id,
+            user_id: userId,
+            verification_id,
+            status: "pending",
+            snapshot_data: [snapshotEntry],
+          };
+          if (application_id) {
+            insertData.application_id = application_id;
+          }
+
+          const { data: inserted, error: insertError } = await withSpan(
+            "db.insert.verification_submissions", "db.insert",
+            () => supabase
+              .from("verification_submissions")
+              .insert(insertData)
+              .select("id")
+              .single(),
+          );
+
+          if (insertError) {
+            log({ function: FN, level: "error", message: "Failed to create submission", metadata: { detail: insertError } });
+            return errorResponse("Failed to create submission", 500);
+          }
+          submissionId = inserted.id;
+        }
+
+        logStatsigEvent(userId, "verification_submitted", undefined, {
+          partner_id,
+          verification_id,
+          is_resubmit: String(!!existing),
+        }).catch(() => {});
+
+        return successResponse({ success: true, submission_id: submissionId });
+      }
+
+      case "comment": {
+        const { submission_id, text } = reqBody as {
+          submission_id?: string;
+          text?: string;
+        };
+
+        if (!submission_id) {
+          return errorResponse("Missing required field: submission_id", 400);
+        }
+        if (!text || typeof text !== "string" || text.trim().length === 0) {
+          return errorResponse("Missing required field: text", 400);
+        }
+
+        // Fetch submission and verify ownership
+        const { data: submission, error: fetchError } = await withSpan(
+          "db.select.verification_submissions", "db.select",
+          () => supabase
+            .from("verification_submissions")
+            .select("id, user_id, snapshot_data")
+            .eq("id", submission_id)
+            .maybeSingle(),
+        );
+
+        if (fetchError) {
+          log({ function: FN, level: "error", message: "Failed to fetch submission", metadata: { detail: fetchError } });
+          return errorResponse("Failed to fetch submission", 500);
+        }
+        if (!submission) {
+          return errorResponse("Submission not found", 404);
+        }
+        if (submission.user_id !== userId) {
+          return errorResponse("Forbidden: not your submission", 403);
+        }
+
+        // Append comment to the last snapshot entry
+        const snapshotArray = Array.isArray(submission.snapshot_data)
+          ? [...submission.snapshot_data]
+          : [];
+
+        if (snapshotArray.length === 0) {
+          return errorResponse("No submission history found", 400);
+        }
+
+        const lastEntry = { ...snapshotArray[snapshotArray.length - 1] };
+        const comments = Array.isArray(lastEntry.comments) ? [...lastEntry.comments] : [];
+        comments.push({
+          author: userId,
+          at: new Date().toISOString(),
+          text: text.trim(),
+        });
+        lastEntry.comments = comments;
+        snapshotArray[snapshotArray.length - 1] = lastEntry;
+
+        const { error: updateError } = await withSpan(
+          "db.update.verification_submissions", "db.update",
+          () => supabase
+            .from("verification_submissions")
+            .update({ snapshot_data: snapshotArray })
+            .eq("id", submission_id),
+        );
+
+        if (updateError) {
+          log({ function: FN, level: "error", message: "Failed to add comment", metadata: { detail: updateError } });
+          return errorResponse("Failed to add comment", 500);
+        }
+
+        logStatsigEvent(userId, "verification_comment_added", undefined, {
+          submission_id,
+        }).catch(() => {});
+
+        return successResponse({ success: true });
+      }
+
+      default:
+        return errorResponse(`Unknown action: ${action}`, 400);
+    }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    log({ function: FN, level: "error", message: `Error in ${FN}: ${message}` });
+    return errorResponse(message, 500);
+  }
+}));

--- a/supabase/functions/user-submit-verification/index.ts
+++ b/supabase/functions/user-submit-verification/index.ts
@@ -110,6 +110,8 @@ Deno.serve(withHandler(async (req) => {
               .update({
                 snapshot_data: snapshotArray,
                 status: "pending",
+                reviewed_at: null,
+                reviewed_by: null,
               })
               .eq("id", existing.id),
           );

--- a/supabase/functions/user-submit-verification/user_submit_verification_test.ts
+++ b/supabase/functions/user-submit-verification/user_submit_verification_test.ts
@@ -1,0 +1,477 @@
+import { assertEquals } from "@std/assert";
+import {
+  captureServeHandler,
+  createFetchMock,
+  authenticatedJsonRequest,
+  jsonResponse,
+  readJson,
+  textRequest,
+  withEnv,
+  withMockedFetch,
+  withNoIntervals,
+} from "../_test_utils/mock_http.ts";
+import { authRoute } from "../_test_utils/fixtures.ts";
+
+const TEST_OPTS = { sanitizeOps: false, sanitizeResources: false };
+
+const ENV = {
+  SUPABASE_URL: "https://supabase.test",
+  SUPABASE_SERVICE_ROLE_KEY: "service-key",
+};
+
+// --- Route helpers ---
+
+function userVerificationRoute(data: Record<string, unknown> | null) {
+  return {
+    matcher: (req: Request) =>
+      req.url.includes("/rest/v1/user_verifications") && req.method === "GET",
+    handler: () => jsonResponse(data),
+  };
+}
+
+function existingSubmissionRoute(submission: Record<string, unknown> | null) {
+  return {
+    matcher: (req: Request) =>
+      req.url.includes("/rest/v1/verification_submissions") && req.method === "GET",
+    handler: () => jsonResponse(submission),
+  };
+}
+
+const dbInsertSubmissionRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/verification_submissions") && req.method === "POST",
+  handler: () => jsonResponse({ id: "sub-new" }),
+};
+
+const dbUpdateSubmissionRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/verification_submissions") && req.method === "PATCH",
+  handler: () => jsonResponse({}),
+};
+
+// ===== submit action =====
+
+Deno.test("submit — 첫 제출 → submission 생성, snapshot_data 배열 1개 항목", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock, calls } = createFetchMock([
+    authRoute,
+    userVerificationRoute({ data: { university: "서울대" } }),
+    existingSubmissionRoute(null),
+    dbInsertSubmissionRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          action: "submit",
+          partner_id: "partner-1",
+          verification_id: "ver-1",
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 200);
+        assertEquals(payload.success, true);
+        assertEquals(payload.submission_id, "sub-new");
+
+        const insertCall = calls.find(
+          (c) => c.url.includes("/rest/v1/verification_submissions") && c.method === "POST",
+        );
+        assertEquals(!!insertCall, true);
+        const body = JSON.parse(insertCall!.body!);
+        assertEquals(body.user_id, "user-123");
+        assertEquals(body.partner_id, "partner-1");
+        assertEquals(body.verification_id, "ver-1");
+        assertEquals(body.status, "pending");
+        assertEquals(Array.isArray(body.snapshot_data), true);
+        assertEquals(body.snapshot_data.length, 1);
+        assertEquals(body.snapshot_data[0].data.university, "서울대");
+        assertEquals(body.snapshot_data[0].comments.length, 0);
+      });
+    });
+  });
+});
+
+Deno.test("submit — 재제출 → snapshot_data 배열에 append, status = 'pending'", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const existingSnapshot = [
+    {
+      submitted_at: "2026-03-15",
+      data: { university: "서울대" },
+      result: "rejected",
+      reviewed_by: "staff-1",
+      reviewed_at: "2026-03-16",
+      comments: [{ author: "staff-1", at: "2026-03-16", text: "재학증명서 흐림" }],
+    },
+  ];
+
+  const { fetchMock, calls } = createFetchMock([
+    authRoute,
+    userVerificationRoute({ data: { university: "서울대" } }),
+    existingSubmissionRoute({ id: "sub-existing", snapshot_data: existingSnapshot }),
+    dbUpdateSubmissionRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          action: "submit",
+          partner_id: "partner-1",
+          verification_id: "ver-1",
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 200);
+        assertEquals(payload.success, true);
+        assertEquals(payload.submission_id, "sub-existing");
+
+        const updateCall = calls.find(
+          (c) => c.url.includes("/rest/v1/verification_submissions") && c.method === "PATCH",
+        );
+        assertEquals(!!updateCall, true);
+        const body = JSON.parse(updateCall!.body!);
+        assertEquals(body.status, "pending");
+        assertEquals(body.snapshot_data.length, 2);
+        assertEquals(body.snapshot_data[0].result, "rejected");
+        assertEquals(body.snapshot_data[1].data.university, "서울대");
+        assertEquals(body.snapshot_data[1].result, null);
+      });
+    });
+  });
+});
+
+Deno.test("submit — user_verifications에 데이터 없이 제출 → 400", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    userVerificationRoute(null),
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          action: "submit",
+          partner_id: "partner-1",
+          verification_id: "ver-1",
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "No verification data found. Save your data first.");
+      });
+    });
+  });
+});
+
+Deno.test("submit — partner_id 누락 → 400", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([authRoute]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          action: "submit",
+          verification_id: "ver-1",
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "Missing required field: partner_id");
+      });
+    });
+  });
+});
+
+Deno.test("submit — verification_id 누락 → 400", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([authRoute]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          action: "submit",
+          partner_id: "partner-1",
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "Missing required field: verification_id");
+      });
+    });
+  });
+});
+
+Deno.test("submit — 인증 없이 → 401", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    {
+      matcher: (req: Request) => req.url.includes("/auth/v1/user"),
+      handler: () => jsonResponse({ error: "invalid token" }, { status: 401 }),
+    },
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          action: "submit",
+          partner_id: "partner-1",
+          verification_id: "ver-1",
+        });
+        const response = await handler(request);
+
+        assertEquals(response.status, 401);
+      });
+    });
+  });
+});
+
+// ===== comment action =====
+
+Deno.test("comment — 코멘트 추가 → 마지막 항목 comments 배열에 append", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const existingSubmission = {
+    id: "sub-1",
+    user_id: "user-123",
+    snapshot_data: [
+      {
+        submitted_at: "2026-03-15",
+        data: { university: "서울대" },
+        result: "rejected",
+        reviewed_by: "staff-1",
+        reviewed_at: "2026-03-16",
+        comments: [{ author: "staff-1", at: "2026-03-16", text: "서류 흐림" }],
+      },
+    ],
+  };
+
+  const submissionSelectRoute = {
+    matcher: (req: Request) =>
+      req.url.includes("/rest/v1/verification_submissions") && req.method === "GET",
+    handler: () => jsonResponse(existingSubmission),
+  };
+
+  const { fetchMock, calls } = createFetchMock([
+    authRoute,
+    submissionSelectRoute,
+    dbUpdateSubmissionRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          action: "comment",
+          submission_id: "sub-1",
+          text: "다시 올리겠습니다",
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 200);
+        assertEquals(payload.success, true);
+
+        const updateCall = calls.find(
+          (c) => c.url.includes("/rest/v1/verification_submissions") && c.method === "PATCH",
+        );
+        assertEquals(!!updateCall, true);
+        const body = JSON.parse(updateCall!.body!);
+        const lastEntry = body.snapshot_data[0];
+        assertEquals(lastEntry.comments.length, 2);
+        assertEquals(lastEntry.comments[1].author, "user-123");
+        assertEquals(lastEntry.comments[1].text, "다시 올리겠습니다");
+      });
+    });
+  });
+});
+
+Deno.test("comment — 다른 유저 submission에 코멘트 → 403", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const otherUserSubmission = {
+    id: "sub-1",
+    user_id: "other-user-456",
+    snapshot_data: [{ submitted_at: "2026-03-15", data: {}, comments: [] }],
+  };
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    {
+      matcher: (req: Request) =>
+        req.url.includes("/rest/v1/verification_submissions") && req.method === "GET",
+      handler: () => jsonResponse(otherUserSubmission),
+    },
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          action: "comment",
+          submission_id: "sub-1",
+          text: "테스트 코멘트",
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 403);
+        assertEquals(payload.error, "Forbidden: not your submission");
+      });
+    });
+  });
+});
+
+Deno.test("comment — 존재하지 않는 submission → 404", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    {
+      matcher: (req: Request) =>
+        req.url.includes("/rest/v1/verification_submissions") && req.method === "GET",
+      handler: () => jsonResponse(null),
+    },
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          action: "comment",
+          submission_id: "non-existent",
+          text: "테스트",
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 404);
+        assertEquals(payload.error, "Submission not found");
+      });
+    });
+  });
+});
+
+Deno.test("comment — submission_id 누락 → 400", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([authRoute]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          action: "comment",
+          text: "테스트",
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "Missing required field: submission_id");
+      });
+    });
+  });
+});
+
+Deno.test("comment — text 누락 → 400", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([authRoute]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          action: "comment",
+          submission_id: "sub-1",
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "Missing required field: text");
+      });
+    });
+  });
+});
+
+// ===== Common edge cases =====
+
+Deno.test("action 누락 → 400", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([authRoute]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          partner_id: "partner-1",
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "Missing required field: action");
+      });
+    });
+  });
+});
+
+Deno.test("잘못된 action → 400", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([authRoute]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          action: "invalid",
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "Unknown action: invalid");
+      });
+    });
+  });
+});
+
+Deno.test("malformed JSON → 400", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([authRoute]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = textRequest("http://localhost", "{invalid", {
+          headers: { Authorization: "Bearer test-token" },
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "Invalid JSON body");
+      });
+    });
+  });
+});

--- a/supabase/functions/user-update-verification/deno.json
+++ b/supabase/functions/user-update-verification/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/user-update-verification/index.ts
+++ b/supabase/functions/user-update-verification/index.ts
@@ -1,0 +1,94 @@
+import { createClient } from "@supabase/supabase-js";
+import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
+import { requireAuth } from "../_shared/auth_utils.ts";
+import { initSentry, withHandler, withSpan, log } from "../_shared/logger.ts";
+import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
+
+const FN = "user-update-verification";
+
+initSentry();
+initStatsig();
+
+Deno.serve(withHandler(async (req) => {
+  if (req.method === "OPTIONS") return corsResponse();
+
+  const auth = await requireAuth(req);
+  if (auth instanceof Response) return auth;
+  const userId = auth;
+
+  try {
+    let reqBody: Record<string, unknown>;
+    try {
+      reqBody = await req.json();
+    } catch {
+      return errorResponse("Invalid JSON body", 400);
+    }
+
+    const { verification_id, data } = reqBody as {
+      verification_id?: string;
+      data?: Record<string, unknown>;
+    };
+
+    if (!verification_id) {
+      return errorResponse("Missing required field: verification_id", 400);
+    }
+    if (!data || typeof data !== "object") {
+      return errorResponse("Missing required field: data", 400);
+    }
+
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+    );
+
+    // Verify that the verification definition exists
+    const { data: verification, error: verificationError } = await withSpan(
+      "db.select.verifications", "db.select",
+      () => supabase
+        .from("verifications")
+        .select("id")
+        .eq("id", verification_id)
+        .eq("is_active", true)
+        .maybeSingle(),
+    );
+
+    if (verificationError) {
+      log({ function: FN, level: "error", message: "Failed to check verification", metadata: { detail: verificationError } });
+      return errorResponse("Failed to check verification", 500);
+    }
+    if (!verification) {
+      return errorResponse("Verification not found or inactive", 404);
+    }
+
+    // Upsert user_verifications (user_id + verification_id unique constraint)
+    const { error } = await withSpan(
+      "db.upsert.user_verifications", "db.upsert",
+      () => supabase
+        .from("user_verifications")
+        .upsert(
+          {
+            user_id: userId,
+            verification_id,
+            data,
+            updated_at: new Date().toISOString(),
+          },
+          { onConflict: "user_id,verification_id" },
+        ),
+    );
+
+    if (error) {
+      log({ function: FN, level: "error", message: "Failed to upsert user verification", metadata: { detail: error } });
+      return errorResponse("Failed to save verification data", 500);
+    }
+
+    logStatsigEvent(userId, "user_verification_updated", undefined, {
+      verification_id,
+    }).catch(() => {});
+
+    return successResponse({ success: true });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    log({ function: FN, level: "error", message: `Error in ${FN}: ${message}` });
+    return errorResponse(message, 500);
+  }
+}));

--- a/supabase/functions/user-update-verification/user_update_verification_test.ts
+++ b/supabase/functions/user-update-verification/user_update_verification_test.ts
@@ -1,0 +1,239 @@
+import { assertEquals } from "@std/assert";
+import {
+  captureServeHandler,
+  createFetchMock,
+  authenticatedJsonRequest,
+  jsonResponse,
+  readJson,
+  textRequest,
+  withEnv,
+  withMockedFetch,
+  withNoIntervals,
+} from "../_test_utils/mock_http.ts";
+import { authRoute } from "../_test_utils/fixtures.ts";
+
+const TEST_OPTS = { sanitizeOps: false, sanitizeResources: false };
+
+const ENV = {
+  SUPABASE_URL: "https://supabase.test",
+  SUPABASE_SERVICE_ROLE_KEY: "service-key",
+};
+
+// --- Route helpers ---
+
+const verificationExistsRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/verifications") && req.method === "GET",
+  handler: () => jsonResponse({ id: "ver-1" }),
+};
+
+const verificationNotFoundRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/verifications") && req.method === "GET",
+  handler: () => jsonResponse(null),
+};
+
+const dbUpsertRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/user_verifications") && req.method === "POST",
+  handler: () => jsonResponse({}),
+};
+
+const dbUpsertErrorRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/user_verifications") && req.method === "POST",
+  handler: () => jsonResponse({ message: "DB error" }, { status: 400 }),
+};
+
+// ===== 정상 저장 =====
+
+Deno.test("신규 저장 → user_verifications UPSERT 확인", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock, calls } = createFetchMock([
+    authRoute,
+    verificationExistsRoute,
+    dbUpsertRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          verification_id: "ver-1",
+          data: { university: "서울대" },
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 200);
+        assertEquals(payload.success, true);
+
+        const upsertCall = calls.find(
+          (c) => c.url.includes("/rest/v1/user_verifications") && c.method === "POST",
+        );
+        assertEquals(!!upsertCall, true);
+        const body = JSON.parse(upsertCall!.body!);
+        assertEquals(body.user_id, "user-123");
+        assertEquals(body.verification_id, "ver-1");
+        assertEquals(body.data.university, "서울대");
+      });
+    });
+  });
+});
+
+Deno.test("기존 업데이트 → data 갱신 확인", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock, calls } = createFetchMock([
+    authRoute,
+    verificationExistsRoute,
+    dbUpsertRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          verification_id: "ver-1",
+          data: { university: "연세대", gpa: "4.0" },
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 200);
+        assertEquals(payload.success, true);
+
+        const upsertCall = calls.find(
+          (c) => c.url.includes("/rest/v1/user_verifications") && c.method === "POST",
+        );
+        const body = JSON.parse(upsertCall!.body!);
+        assertEquals(body.data.university, "연세대");
+        assertEquals(body.data.gpa, "4.0");
+      });
+    });
+  });
+});
+
+// ===== 인증 없이 → 401 =====
+
+Deno.test("인증 없이 → 401", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    {
+      matcher: (req: Request) => req.url.includes("/auth/v1/user"),
+      handler: () => jsonResponse({ error: "invalid token" }, { status: 401 }),
+    },
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          verification_id: "ver-1",
+          data: { university: "서울대" },
+        });
+        const response = await handler(request);
+
+        assertEquals(response.status, 401);
+      });
+    });
+  });
+});
+
+// ===== verification_id 누락 → 400 =====
+
+Deno.test("verification_id 누락 → 400", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([authRoute]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          data: { university: "서울대" },
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "Missing required field: verification_id");
+      });
+    });
+  });
+});
+
+// ===== data 누락 → 400 =====
+
+Deno.test("data 누락 → 400", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([authRoute]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          verification_id: "ver-1",
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "Missing required field: data");
+      });
+    });
+  });
+});
+
+// ===== 존재하지 않는 verification → 404 =====
+
+Deno.test("존재하지 않는 verification → 404", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    verificationNotFoundRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = authenticatedJsonRequest("http://localhost", {
+          verification_id: "non-existent",
+          data: { university: "서울대" },
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 404);
+        assertEquals(payload.error, "Verification not found or inactive");
+      });
+    });
+  });
+});
+
+// ===== malformed JSON → 400 =====
+
+Deno.test("malformed JSON → 400", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([authRoute]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = textRequest("http://localhost", "{invalid", {
+          headers: { Authorization: "Bearer test-token" },
+        });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "Invalid JSON body");
+      });
+    });
+  });
+});

--- a/supabase/migrations/20260322000006_verification_schema_simplify.sql
+++ b/supabase/migrations/20260322000006_verification_schema_simplify.sql
@@ -1,0 +1,77 @@
+-- Migration: Simplify verification schema for EF transition
+-- Related: #301 (user-update-verification + user-submit-verification)
+--
+-- 1. Reduce verification_status enum: pending, approved, rejected (drop needs_correction, cancelled)
+-- 2. Drop verification_comments table (data migrated into snapshot_data JSON)
+-- 3. Remove admin_comment column from verification_submissions (replaced by JSON comments)
+-- 4. Update trigger to remove needs_correction reference
+
+-- ============================================================
+-- 1. Enum reduction: verification_status → 3 values
+-- ============================================================
+-- PostgreSQL doesn't support DROP VALUE from enum, so we recreate it.
+
+-- 1a. Create new enum
+CREATE TYPE public.verification_status_new AS ENUM ('pending', 'approved', 'rejected');
+
+-- 1b. Alter columns using old enum → text → new enum
+ALTER TABLE public.verification_submissions
+  ALTER COLUMN status DROP DEFAULT,
+  ALTER COLUMN status TYPE public.verification_status_new
+    USING status::text::public.verification_status_new,
+  ALTER COLUMN status SET DEFAULT 'pending'::public.verification_status_new;
+
+-- 1c. Drop old enum and rename
+DROP TYPE public.verification_status;
+ALTER TYPE public.verification_status_new RENAME TO verification_status;
+
+-- ============================================================
+-- 2. Drop verification_comments table + RLS policies
+-- ============================================================
+-- Policies are dropped automatically with the table.
+DROP TABLE IF EXISTS public.verification_comments;
+
+-- Revoke grants (no-op if table already dropped, but explicit for clarity)
+-- REVOKE ALL ON public.verification_comments FROM authenticated;
+
+-- ============================================================
+-- 3. Remove admin_comment column (replaced by snapshot_data JSON comments)
+-- ============================================================
+ALTER TABLE public.verification_submissions DROP COLUMN IF EXISTS admin_comment;
+
+-- ============================================================
+-- 4. Update trigger function: remove needs_correction from IN list
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.trigger_produce_event_verification()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, pgmq, temp
+AS $$
+BEGIN
+  IF TG_OP = 'UPDATE' AND (OLD.status IS DISTINCT FROM NEW.status) THEN
+    IF NEW.status IN ('approved', 'rejected') THEN
+      PERFORM public.produce_event(
+        'verification_result'::public.event_type_name,
+        'verification_submissions',
+        NEW.id,
+        row_to_json(NEW)::jsonb
+      );
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+-- ============================================================
+-- 5. Revoke write grants on user_verifications (writes go through EF now)
+-- ============================================================
+-- Keep SELECT only for authenticated users
+REVOKE INSERT, UPDATE, DELETE ON public.user_verifications FROM authenticated;
+
+-- ============================================================
+-- 6. Update RLS: user_verifications → read-only for clients
+-- ============================================================
+DROP POLICY IF EXISTS "Users can read/write own verifications" ON public.user_verifications;
+CREATE POLICY "Users can read own verifications" ON public.user_verifications
+  FOR SELECT USING (auth.uid() = user_id);

--- a/supabase/migrations/20260322000006_verification_schema_simplify.sql
+++ b/supabase/migrations/20260322000006_verification_schema_simplify.sql
@@ -64,6 +64,50 @@ END;
 $$;
 
 -- ============================================================
+-- 4b. Update handle_verification_approval: remove admin_comment reference
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.handle_verification_approval()
+RETURNS trigger
+SET search_path = public
+AS $$
+BEGIN
+  -- 1. Handling Approval
+  IF (NEW.status = 'approved' AND OLD.status IS DISTINCT FROM 'approved') THEN
+    INSERT INTO public.partner_verified_users (partner_id, user_id, verification_id, submission_id, verified_at)
+    VALUES (NEW.partner_id, NEW.user_id, NEW.verification_id, NEW.id, now())
+    ON CONFLICT (partner_id, user_id, verification_id)
+    DO UPDATE SET submission_id = NEW.id, verified_at = now(), valid_until = NULL;
+
+    IF (NEW.application_id IS NOT NULL) THEN
+      UPDATE public.event_applications
+      SET status = 'approved', updated_at = now()
+      WHERE id = NEW.application_id
+      AND status IN ('pending', 'pending_review');
+    END IF;
+  END IF;
+
+  -- 2. Handling Rejection (admin_comment removed — rejection_reason cleared)
+  IF (NEW.status = 'rejected' AND OLD.status IS DISTINCT FROM 'rejected') THEN
+    IF (NEW.application_id IS NOT NULL) THEN
+      UPDATE public.event_applications
+      SET
+        status = 'rejected',
+        updated_at = now()
+      WHERE id = NEW.application_id;
+    END IF;
+  END IF;
+
+  -- 3. Revoking
+  IF (OLD.status = 'approved' AND NEW.status IS DISTINCT FROM 'approved') THEN
+    DELETE FROM public.partner_verified_users
+    WHERE submission_id = NEW.id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ============================================================
 -- 5. Revoke write grants on user_verifications (writes go through EF now)
 -- ============================================================
 -- Keep SELECT only for authenticated users

--- a/supabase/tests/database/05_commerce_rls_test.sql
+++ b/supabase/tests/database/05_commerce_rls_test.sql
@@ -1,5 +1,5 @@
 BEGIN;
-SELECT plan(8);
+SELECT plan(9);
 
 SELECT tests.create_supabase_user('user_a', 'a@test.com');
 SELECT tests.create_supabase_user('user_b', 'b@test.com');
@@ -104,21 +104,35 @@ SELECT ok(
   'event_participants has display_name column'
 );
 
+-- Fix #301: user_verifications is now read-only for authenticated (writes via EF)
 SELECT tests.authenticate_as('user_a');
-SELECT lives_ok(
-  $$UPDATE public.user_verifications
-      SET data = '{"level":"gold"}'::jsonb
-      WHERE user_id = tests.get_supabase_uid('user_a')
-        AND verification_id = current_setting('tests.verification_a')::uuid$$,
-  'users can update their own verifications'
-);
 SELECT results_eq(
   $$SELECT data->>'level'
     FROM public.user_verifications
     WHERE user_id = tests.get_supabase_uid('user_a')
       AND verification_id = current_setting('tests.verification_a')::uuid$$,
-  $$VALUES ('gold')$$,
-  'verification updates persist'
+  $$VALUES ('bronze')$$,
+  'users can read their own verifications'
+);
+SELECT throws_ok(
+  $$UPDATE public.user_verifications
+      SET data = '{"level":"gold"}'::jsonb
+      WHERE user_id = tests.get_supabase_uid('user_a')
+        AND verification_id = current_setting('tests.verification_a')::uuid$$,
+  '42501',
+  NULL,
+  'users cannot update their own verifications (write via EF only)'
+);
+SELECT throws_ok(
+  $$INSERT INTO public.user_verifications (user_id, verification_id, data)
+    VALUES (
+      tests.get_supabase_uid('user_a'),
+      current_setting('tests.verification_b')::uuid,
+      '{"level":"silver"}'::jsonb
+    )$$,
+  '42501',
+  NULL,
+  'users cannot insert verifications directly (write via EF only)'
 );
 
 SELECT tests.authenticate_as('user_b');
@@ -137,7 +151,7 @@ SELECT throws_ok(
       '{"level":"silver"}'::jsonb
     )$$,
   '42501',
-  'new row violates row-level security policy for table "user_verifications"',
+  NULL,
   'users cannot insert verifications for others'
 );
 

--- a/supabase/tests/database/05_commerce_schema_test.sql
+++ b/supabase/tests/database/05_commerce_schema_test.sql
@@ -1,5 +1,5 @@
 BEGIN;
-SELECT plan(173);
+SELECT plan(152);
 
 -- event_applications
 SELECT has_table('event_applications');
@@ -47,7 +47,7 @@ SELECT has_column('verification_submissions', 'verification_id');
 SELECT has_column('verification_submissions', 'application_id');
 SELECT has_column('verification_submissions', 'status');
 SELECT has_column('verification_submissions', 'snapshot_data');
-SELECT has_column('verification_submissions', 'admin_comment');
+-- Fix #301: admin_comment column dropped
 SELECT has_column('verification_submissions', 'reviewed_at');
 SELECT has_column('verification_submissions', 'reviewed_by');
 SELECT has_column('verification_submissions', 'created_at');
@@ -164,27 +164,7 @@ SELECT col_type_is('event_participants', 'updated_at', 'timestamp with time zone
 SELECT col_has_default('event_participants', 'updated_at');
 SELECT col_not_null('event_participants', 'updated_at');
 
--- verification_comments
-SELECT has_table('verification_comments');
-SELECT has_column('verification_comments', 'id');
-SELECT has_column('verification_comments', 'submission_id');
-SELECT has_column('verification_comments', 'author_id');
-SELECT has_column('verification_comments', 'content');
-SELECT has_column('verification_comments', 'created_at');
-SELECT col_type_is('verification_comments', 'id', 'uuid');
-SELECT col_is_pk('verification_comments', 'id');
-SELECT col_has_default('verification_comments', 'id');
-SELECT col_not_null('verification_comments', 'id');
-SELECT col_type_is('verification_comments', 'submission_id', 'uuid');
-SELECT col_is_fk('verification_comments', 'submission_id');
-SELECT col_not_null('verification_comments', 'submission_id');
-SELECT col_type_is('verification_comments', 'author_id', 'uuid');
-SELECT col_is_fk('verification_comments', 'author_id');
-SELECT col_not_null('verification_comments', 'author_id');
-SELECT col_type_is('verification_comments', 'content', 'jsonb');
-SELECT col_not_null('verification_comments', 'content');
-SELECT col_type_is('verification_comments', 'created_at', 'timestamp with time zone');
-SELECT col_has_default('verification_comments', 'created_at');
+-- Fix #301: verification_comments table dropped (comments now in snapshot_data JSON)
 
 SELECT * FROM finish();
 ROLLBACK;

--- a/supabase/tests/database/06_rls_missing_tables_test.sql
+++ b/supabase/tests/database/06_rls_missing_tables_test.sql
@@ -76,13 +76,7 @@ WITH vs AS (
 )
 SELECT set_config('tests.submission_id', id::text, true) FROM vs;
 
--- user_a (partner owner / reviewer) leaves a verification comment
-INSERT INTO public.verification_comments (submission_id, author_id, content)
-VALUES (
-  current_setting('tests.submission_id')::uuid,
-  tests.get_supabase_uid('user_a'),
-  '{"text": "LGTM"}'::jsonb
-);
+-- Fix #301: verification_comments table dropped — comment data now in snapshot_data JSON
 
 -- ===========================================================================
 -- app_roles TESTS (assertions 1–5)

--- a/supabase/tests/database/06_rls_missing_tables_test.sql
+++ b/supabase/tests/database/06_rls_missing_tables_test.sql
@@ -1,5 +1,5 @@
 BEGIN;
-SELECT plan(28);
+SELECT plan(24);
 
 -- ===========================================================================
 -- SETUP
@@ -264,34 +264,7 @@ SELECT is_empty(
   'non-applicant cannot read others partner_applications'
 );
 
--- ===========================================================================
--- verification_comments TESTS (assertions 25–28)
--- No policies or RLS enabled yet on this table
--- ===========================================================================
-
-SELECT tests.rls_enabled('public', 'verification_comments');
-
-SELECT tests.clear_authentication();
-SELECT is_empty(
-  $$SELECT id FROM public.verification_comments LIMIT 1$$,
-  'anon cannot read verification_comments'
-);
-
-SELECT tests.authenticate_as('user_b');
-SELECT results_eq(
-  $$SELECT count(*)::int FROM public.verification_comments
-    WHERE submission_id = current_setting('tests.submission_id')::uuid$$,
-  $$VALUES (1)$$,
-  'submitter can read comments on own submission'
-);
-
-SELECT tests.authenticate_as('user_a');
-SELECT results_eq(
-  $$SELECT count(*)::int FROM public.verification_comments
-    WHERE author_id = tests.get_supabase_uid('user_a')$$,
-  $$VALUES (1)$$,
-  'comment author can read own verification_comments'
-);
+-- Fix #301: verification_comments table dropped — tests removed
 
 SELECT * FROM finish();
 ROLLBACK;

--- a/supabase/tests/database/09_refund_trigger_test.sql
+++ b/supabase/tests/database/09_refund_trigger_test.sql
@@ -79,9 +79,9 @@ BEGIN
   )
   RETURNING id INTO v_submission_id;
 
+  -- Fix #301: admin_comment column dropped
   UPDATE public.verification_submissions
-  SET status = 'rejected',
-      admin_comment = v_reason
+  SET status = 'rejected'
   WHERE id = v_submission_id;
 
   INSERT INTO refund_results (status, rejection_reason, refund_status)

--- a/supabase/tests/database/09_refund_trigger_test.sql
+++ b/supabase/tests/database/09_refund_trigger_test.sql
@@ -96,10 +96,11 @@ SELECT is(
   'Application status synced to rejected'
 );
 
+-- Fix #301: admin_comment dropped — rejection_reason no longer synced from verification
 SELECT is(
   (SELECT rejection_reason FROM refund_results),
-  'Invalid ID Proof',
-  'Rejection reason synced to application'
+  NULL::text,
+  'Rejection reason is null (admin_comment removed)'
 );
 
 SELECT is(

--- a/supabase/tests/database/12_notification_triggers_test.sql
+++ b/supabase/tests/database/12_notification_triggers_test.sql
@@ -264,25 +264,25 @@ SELECT ok(
 
 DROP TABLE t7_approved;
 
--- Drain and test needs_correction
+-- Drain and test rejected (needs_correction removed in #301)
 CREATE TEMP TABLE _drain7 AS
 SELECT * FROM public.pgmq_read('q_notifications', 60, 1000) AS payload(payload);
 DROP TABLE _drain7;
 
 UPDATE public.verification_submissions
-SET status = 'needs_correction'
+SET status = 'rejected'
 WHERE user_id = (SELECT applicant_user_id FROM trigger_test_setup)
   AND verification_id = (SELECT verification_id FROM trigger_test_setup);
 
-CREATE TEMP TABLE t7_correction AS
+CREATE TEMP TABLE t7_rejection AS
 SELECT * FROM public.pgmq_read('q_notifications', 60, 1000) AS payload(payload);
 
 SELECT ok(
-  (SELECT count(*) > 0 FROM t7_correction WHERE payload->'message'->>'event_type' = 'verification_result'),
-  'T7: needs_correction enqueues verification_result notification'
+  (SELECT count(*) > 0 FROM t7_rejection WHERE payload->'message'->>'event_type' = 'verification_result'),
+  'T7: rejected enqueues verification_result notification'
 );
 
-DROP TABLE t7_correction;
+DROP TABLE t7_rejection;
 
 -- ============================================================
 -- PART 7: T0 — CHECK constraint allows new statuses

--- a/supabase/tests/database/general_trigger_test.sql
+++ b/supabase/tests/database/general_trigger_test.sql
@@ -229,9 +229,9 @@ SELECT ok(
   'Ticket issued on application approval'
 );
 
+-- Fix #301: admin_comment column dropped
 UPDATE public.verification_submissions
-SET status = 'rejected',
-    admin_comment = 'Auto revoke'
+SET status = 'rejected'
 WHERE id = (SELECT submission_id FROM auto_approval_setup);
 
 SELECT ok(


### PR DESCRIPTION
## Summary

- **Migration**: `verification_status` enum 축소 (pending/approved/rejected), `verification_comments` 테이블 DROP, `admin_comment` 컬럼 제거, `user_verifications` RLS read-only 전환
- **EF**: `user-update-verification` (개인 인증 데이터 UPSERT) + `user-submit-verification` (파트너 제출 submit/comment 액션)
- **Flutter**: `submitOrUpdateVerification` → EF 분리 (`saveUserVerificationData` + `submitVerificationToPartner`), `submitComment` → EF 전환, `snapshot_data` 배열 구조 적용
- **Tests**: Deno EF 테스트 21개 + Flutter 테스트 35개 전부 통과

## Test plan

- [x] `user-update-verification` EF 테스트 7개 통과 (신규 저장, 업데이트, 인증 없이 401, 필드 누락 400, 존재하지 않는 verification 404, malformed JSON)
- [x] `user-submit-verification` EF 테스트 14개 통과 (첫 제출, 재제출 append, 데이터 없이 제출 400, 코멘트 추가, 다른 유저 submission 403, 존재하지 않는 submission 404)
- [x] Flutter `VerificationSubmission` 모델 테스트 — snapshot_data 배열 구조 직렬화/역직렬화
- [x] Flutter 커맨드/쿼리 레포지토리 테스트 — EF 전환 후 정상 동작 확인
- [ ] CI `ci-result` 통과 확인

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)