### PR TITLE
feat: partner-manage-match EF 구현 + vote_count 스키마 추가

### DIFF
--- a/shared/packages/minglit_kit/lib/src/data/models/matching.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/matching.dart
@@ -14,6 +14,8 @@ abstract class MatchRule with _$MatchRule {
     @JsonKey(name: 'source_group_id') required String sourceGroupId,
     @JsonKey(name: 'target_group_id') required String targetGroupId,
     @JsonKey(name: 'created_at') required DateTime createdAt,
+    // Fix #305: 그룹별 투표 수 제한
+    @JsonKey(name: 'vote_count') @Default(1) int voteCount,
   }) = _MatchRule;
 
   /// Creates a [MatchRule] from a JSON map.

--- a/shared/packages/minglit_kit/lib/src/data/models/matching.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/matching.freezed.dart
@@ -15,7 +15,8 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$MatchRule {
 
- String get id;@JsonKey(name: 'event_id') String get eventId;@JsonKey(name: 'source_group_id') String get sourceGroupId;@JsonKey(name: 'target_group_id') String get targetGroupId;@JsonKey(name: 'created_at') DateTime get createdAt;
+ String get id;@JsonKey(name: 'event_id') String get eventId;@JsonKey(name: 'source_group_id') String get sourceGroupId;@JsonKey(name: 'target_group_id') String get targetGroupId;@JsonKey(name: 'created_at') DateTime get createdAt;// Fix #305: 그룹별 투표 수 제한
+@JsonKey(name: 'vote_count') int get voteCount;
 /// Create a copy of MatchRule
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +29,16 @@ $MatchRuleCopyWith<MatchRule> get copyWith => _$MatchRuleCopyWithImpl<MatchRule>
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MatchRule&&(identical(other.id, id) || other.id == id)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.sourceGroupId, sourceGroupId) || other.sourceGroupId == sourceGroupId)&&(identical(other.targetGroupId, targetGroupId) || other.targetGroupId == targetGroupId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MatchRule&&(identical(other.id, id) || other.id == id)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.sourceGroupId, sourceGroupId) || other.sourceGroupId == sourceGroupId)&&(identical(other.targetGroupId, targetGroupId) || other.targetGroupId == targetGroupId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.voteCount, voteCount) || other.voteCount == voteCount));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,eventId,sourceGroupId,targetGroupId,createdAt);
+int get hashCode => Object.hash(runtimeType,id,eventId,sourceGroupId,targetGroupId,createdAt,voteCount);
 
 @override
 String toString() {
-  return 'MatchRule(id: $id, eventId: $eventId, sourceGroupId: $sourceGroupId, targetGroupId: $targetGroupId, createdAt: $createdAt)';
+  return 'MatchRule(id: $id, eventId: $eventId, sourceGroupId: $sourceGroupId, targetGroupId: $targetGroupId, createdAt: $createdAt, voteCount: $voteCount)';
 }
 
 
@@ -48,7 +49,7 @@ abstract mixin class $MatchRuleCopyWith<$Res>  {
   factory $MatchRuleCopyWith(MatchRule value, $Res Function(MatchRule) _then) = _$MatchRuleCopyWithImpl;
 @useResult
 $Res call({
- String id,@JsonKey(name: 'event_id') String eventId,@JsonKey(name: 'source_group_id') String sourceGroupId,@JsonKey(name: 'target_group_id') String targetGroupId,@JsonKey(name: 'created_at') DateTime createdAt
+ String id,@JsonKey(name: 'event_id') String eventId,@JsonKey(name: 'source_group_id') String sourceGroupId,@JsonKey(name: 'target_group_id') String targetGroupId,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'vote_count') int voteCount
 });
 
 
@@ -65,14 +66,15 @@ class _$MatchRuleCopyWithImpl<$Res>
 
 /// Create a copy of MatchRule
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? eventId = null,Object? sourceGroupId = null,Object? targetGroupId = null,Object? createdAt = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? eventId = null,Object? sourceGroupId = null,Object? targetGroupId = null,Object? createdAt = null,Object? voteCount = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
 as String,sourceGroupId: null == sourceGroupId ? _self.sourceGroupId : sourceGroupId // ignore: cast_nullable_to_non_nullable
 as String,targetGroupId: null == targetGroupId ? _self.targetGroupId : targetGroupId // ignore: cast_nullable_to_non_nullable
 as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
-as DateTime,
+as DateTime,voteCount: null == voteCount ? _self.voteCount : voteCount // ignore: cast_nullable_to_non_nullable
+as int,
   ));
 }
 
@@ -157,10 +159,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'source_group_id')  String sourceGroupId, @JsonKey(name: 'target_group_id')  String targetGroupId, @JsonKey(name: 'created_at')  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'source_group_id')  String sourceGroupId, @JsonKey(name: 'target_group_id')  String targetGroupId, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'vote_count')  int voteCount)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _MatchRule() when $default != null:
-return $default(_that.id,_that.eventId,_that.sourceGroupId,_that.targetGroupId,_that.createdAt);case _:
+return $default(_that.id,_that.eventId,_that.sourceGroupId,_that.targetGroupId,_that.createdAt,_that.voteCount);case _:
   return orElse();
 
 }
@@ -178,10 +180,10 @@ return $default(_that.id,_that.eventId,_that.sourceGroupId,_that.targetGroupId,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'source_group_id')  String sourceGroupId, @JsonKey(name: 'target_group_id')  String targetGroupId, @JsonKey(name: 'created_at')  DateTime createdAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'source_group_id')  String sourceGroupId, @JsonKey(name: 'target_group_id')  String targetGroupId, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'vote_count')  int voteCount)  $default,) {final _that = this;
 switch (_that) {
 case _MatchRule():
-return $default(_that.id,_that.eventId,_that.sourceGroupId,_that.targetGroupId,_that.createdAt);case _:
+return $default(_that.id,_that.eventId,_that.sourceGroupId,_that.targetGroupId,_that.createdAt,_that.voteCount);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -198,10 +200,10 @@ return $default(_that.id,_that.eventId,_that.sourceGroupId,_that.targetGroupId,_
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'source_group_id')  String sourceGroupId, @JsonKey(name: 'target_group_id')  String targetGroupId, @JsonKey(name: 'created_at')  DateTime createdAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id, @JsonKey(name: 'event_id')  String eventId, @JsonKey(name: 'source_group_id')  String sourceGroupId, @JsonKey(name: 'target_group_id')  String targetGroupId, @JsonKey(name: 'created_at')  DateTime createdAt, @JsonKey(name: 'vote_count')  int voteCount)?  $default,) {final _that = this;
 switch (_that) {
 case _MatchRule() when $default != null:
-return $default(_that.id,_that.eventId,_that.sourceGroupId,_that.targetGroupId,_that.createdAt);case _:
+return $default(_that.id,_that.eventId,_that.sourceGroupId,_that.targetGroupId,_that.createdAt,_that.voteCount);case _:
   return null;
 
 }
@@ -213,7 +215,7 @@ return $default(_that.id,_that.eventId,_that.sourceGroupId,_that.targetGroupId,_
 @JsonSerializable()
 
 class _MatchRule implements MatchRule {
-  const _MatchRule({required this.id, @JsonKey(name: 'event_id') required this.eventId, @JsonKey(name: 'source_group_id') required this.sourceGroupId, @JsonKey(name: 'target_group_id') required this.targetGroupId, @JsonKey(name: 'created_at') required this.createdAt});
+  const _MatchRule({required this.id, @JsonKey(name: 'event_id') required this.eventId, @JsonKey(name: 'source_group_id') required this.sourceGroupId, @JsonKey(name: 'target_group_id') required this.targetGroupId, @JsonKey(name: 'created_at') required this.createdAt, @JsonKey(name: 'vote_count') this.voteCount = 1});
   factory _MatchRule.fromJson(Map<String, dynamic> json) => _$MatchRuleFromJson(json);
 
 @override final  String id;
@@ -221,6 +223,8 @@ class _MatchRule implements MatchRule {
 @override@JsonKey(name: 'source_group_id') final  String sourceGroupId;
 @override@JsonKey(name: 'target_group_id') final  String targetGroupId;
 @override@JsonKey(name: 'created_at') final  DateTime createdAt;
+// Fix #305: 그룹별 투표 수 제한
+@override@JsonKey(name: 'vote_count') final  int voteCount;
 
 /// Create a copy of MatchRule
 /// with the given fields replaced by the non-null parameter values.
@@ -235,16 +239,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MatchRule&&(identical(other.id, id) || other.id == id)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.sourceGroupId, sourceGroupId) || other.sourceGroupId == sourceGroupId)&&(identical(other.targetGroupId, targetGroupId) || other.targetGroupId == targetGroupId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MatchRule&&(identical(other.id, id) || other.id == id)&&(identical(other.eventId, eventId) || other.eventId == eventId)&&(identical(other.sourceGroupId, sourceGroupId) || other.sourceGroupId == sourceGroupId)&&(identical(other.targetGroupId, targetGroupId) || other.targetGroupId == targetGroupId)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.voteCount, voteCount) || other.voteCount == voteCount));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,eventId,sourceGroupId,targetGroupId,createdAt);
+int get hashCode => Object.hash(runtimeType,id,eventId,sourceGroupId,targetGroupId,createdAt,voteCount);
 
 @override
 String toString() {
-  return 'MatchRule(id: $id, eventId: $eventId, sourceGroupId: $sourceGroupId, targetGroupId: $targetGroupId, createdAt: $createdAt)';
+  return 'MatchRule(id: $id, eventId: $eventId, sourceGroupId: $sourceGroupId, targetGroupId: $targetGroupId, createdAt: $createdAt, voteCount: $voteCount)';
 }
 
 
@@ -255,7 +259,7 @@ abstract mixin class _$MatchRuleCopyWith<$Res> implements $MatchRuleCopyWith<$Re
   factory _$MatchRuleCopyWith(_MatchRule value, $Res Function(_MatchRule) _then) = __$MatchRuleCopyWithImpl;
 @override @useResult
 $Res call({
- String id,@JsonKey(name: 'event_id') String eventId,@JsonKey(name: 'source_group_id') String sourceGroupId,@JsonKey(name: 'target_group_id') String targetGroupId,@JsonKey(name: 'created_at') DateTime createdAt
+ String id,@JsonKey(name: 'event_id') String eventId,@JsonKey(name: 'source_group_id') String sourceGroupId,@JsonKey(name: 'target_group_id') String targetGroupId,@JsonKey(name: 'created_at') DateTime createdAt,@JsonKey(name: 'vote_count') int voteCount
 });
 
 
@@ -272,14 +276,15 @@ class __$MatchRuleCopyWithImpl<$Res>
 
 /// Create a copy of MatchRule
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? eventId = null,Object? sourceGroupId = null,Object? targetGroupId = null,Object? createdAt = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? eventId = null,Object? sourceGroupId = null,Object? targetGroupId = null,Object? createdAt = null,Object? voteCount = null,}) {
   return _then(_MatchRule(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,eventId: null == eventId ? _self.eventId : eventId // ignore: cast_nullable_to_non_nullable
 as String,sourceGroupId: null == sourceGroupId ? _self.sourceGroupId : sourceGroupId // ignore: cast_nullable_to_non_nullable
 as String,targetGroupId: null == targetGroupId ? _self.targetGroupId : targetGroupId // ignore: cast_nullable_to_non_nullable
 as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
-as DateTime,
+as DateTime,voteCount: null == voteCount ? _self.voteCount : voteCount // ignore: cast_nullable_to_non_nullable
+as int,
   ));
 }
 

--- a/shared/packages/minglit_kit/lib/src/data/models/matching.g.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/matching.g.dart
@@ -12,6 +12,7 @@ _MatchRule _$MatchRuleFromJson(Map<String, dynamic> json) => _MatchRule(
   sourceGroupId: json['source_group_id'] as String,
   targetGroupId: json['target_group_id'] as String,
   createdAt: DateTime.parse(json['created_at'] as String),
+  voteCount: (json['vote_count'] as num?)?.toInt() ?? 1,
 );
 
 Map<String, dynamic> _$MatchRuleToJson(_MatchRule instance) =>
@@ -21,6 +22,7 @@ Map<String, dynamic> _$MatchRuleToJson(_MatchRule instance) =>
       'source_group_id': instance.sourceGroupId,
       'target_group_id': instance.targetGroupId,
       'created_at': instance.createdAt.toIso8601String(),
+      'vote_count': instance.voteCount,
     };
 
 _MatchVote _$MatchVoteFromJson(Map<String, dynamic> json) => _MatchVote(

--- a/shared/packages/minglit_kit/lib/src/data/repositories/matching_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/matching_repository.dart
@@ -35,31 +35,52 @@ class MatchingRepository {
     }
   }
 
-  /// Updates matching rules for an event.
+  /// Updates matching rules for an event via partner-manage-match EF.
   /// Replaces all existing rules with the new list.
+  // Fix #305: RLS write → EF 전환 + vote_count 지원
   Future<void> updateMatchRules({
     required String eventId,
-    required List<Map<String, String>> rules,
+    required List<Map<String, dynamic>> rules,
   }) async {
     try {
-      // 1. Delete existing rules
-      await _supabase.from('match_rules').delete().eq('event_id', eventId);
-
-      // 2. Insert new rules
-      if (rules.isNotEmpty) {
-        final records = rules.map((r) {
-          return {
-            'event_id': eventId,
-            'source_group_id': r['source_group_id'],
-            'target_group_id': r['target_group_id'],
-          };
-        }).toList();
-
-        await _supabase.from('match_rules').insert(records);
-      }
+      await _supabase.functions.invoke(
+        'partner-manage-match',
+        body: {
+          'action': 'set_rules',
+          'event_id': eventId,
+          'rules': rules.map((r) {
+            final rule = <String, dynamic>{
+              'source_group_id': r['source_group_id'],
+              'target_group_id': r['target_group_id'],
+            };
+            if (r['vote_count'] != null) {
+              rule['vote_count'] = r['vote_count'];
+            }
+            return rule;
+          }).toList(),
+        },
+      );
       Log.d('updateMatchRules success | count: ${rules.length}');
     } catch (e, st) {
       Log.e('❌ [MatchingRepo] updateMatchRules Error', e, st);
+      rethrow;
+    }
+  }
+
+  /// Clears all matching rules for an event via partner-manage-match EF.
+  // Fix #305: RLS write → EF 전환
+  Future<void> clearMatchRules({required String eventId}) async {
+    try {
+      await _supabase.functions.invoke(
+        'partner-manage-match',
+        body: {
+          'action': 'clear_rules',
+          'event_id': eventId,
+        },
+      );
+      Log.d('clearMatchRules success | eventId: $eventId');
+    } catch (e, st) {
+      Log.e('❌ [MatchingRepo] clearMatchRules Error', e, st);
       rethrow;
     }
   }

--- a/shared/packages/minglit_kit/test/src/data/models/matching_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/models/matching_test.dart
@@ -20,6 +20,13 @@ void main() {
       expect(rule.eventId, 'event_1');
       expect(rule.sourceGroupId, 'group_a');
       expect(rule.targetGroupId, 'group_b');
+      expect(rule.voteCount, 1); // default
+    });
+
+    test('parses vote_count from JSON', () {
+      final json = ruleJson()..['vote_count'] = 3;
+      final rule = MatchRule.fromJson(json);
+      expect(rule.voteCount, 3);
     });
 
     test('serializes to JSON and back', () {

--- a/shared/packages/minglit_kit/test/src/data/models/matching_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/models/matching_test.dart
@@ -29,6 +29,12 @@ void main() {
       expect(rule.voteCount, 3);
     });
 
+    test('serializes vote_count to JSON', () {
+      final rule = MatchRule.fromJson(ruleJson()..['vote_count'] = 3);
+      final json = rule.toJson();
+      expect(json['vote_count'], 3);
+    });
+
     test('serializes to JSON and back', () {
       final original = MatchRule.fromJson(ruleJson());
       final json = original.toJson();

--- a/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
@@ -1,19 +1,25 @@
 import 'dart:async' show unawaited;
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/repositories/matching_repository.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../../helpers/mocks.dart';
 import '../../../helpers/supabase_mock_helpers.dart';
 
 void main() {
   late MockSupabaseClient mockClient;
+  late MockFunctionsClient mockFunctions;
   late MatchingRepository repository;
 
   final mockUser = MockUser();
 
   setUp(() {
     mockClient = createMockSupabase(currentUser: mockUser);
+    mockFunctions = mockClient.functions as MockFunctionsClient;
     when(() => mockUser.id).thenReturn('user_1');
     repository = MatchingRepository(supabase: mockClient);
   });
@@ -53,8 +59,18 @@ void main() {
     });
 
     group('updateMatchRules', () {
-      test('completes without error', () async {
-        unawaited(mockTable(mockClient, 'match_rules'));
+      test('completes without error via EF', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-match',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            data: utf8.encode(jsonEncode({'success': true, 'count': 1})),
+            status: 200,
+          ),
+        );
 
         await expectLater(
           repository.updateMatchRules(
@@ -63,6 +79,7 @@ void main() {
               {
                 'source_group_id': 'group_m',
                 'target_group_id': 'group_f',
+                'vote_count': 3,
               },
             ],
           ),
@@ -70,14 +87,45 @@ void main() {
         );
       });
 
-      test('handles empty rules list', () async {
-        unawaited(mockTable(mockClient, 'match_rules'));
+      test('handles empty rules list via EF', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-match',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            data: utf8.encode(jsonEncode({'success': true, 'count': 0})),
+            status: 200,
+          ),
+        );
 
         await expectLater(
           repository.updateMatchRules(
             eventId: 'event_1',
             rules: [],
           ),
+          completes,
+        );
+      });
+    });
+
+    group('clearMatchRules', () {
+      test('completes without error via EF', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-match',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            data: utf8.encode(jsonEncode({'success': true})),
+            status: 200,
+          ),
+        );
+
+        await expectLater(
+          repository.clearMatchRules(eventId: 'event_1'),
           completes,
         );
       });

--- a/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
@@ -1,6 +1,5 @@
 import 'dart:async' show unawaited;
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/repositories/matching_repository.dart';

--- a/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
@@ -86,6 +86,25 @@ void main() {
         );
       });
 
+      test('propagates EF error when invoke fails', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-match',
+            body: any(named: 'body'),
+          ),
+        ).thenThrow(Exception('EF failed'));
+
+        expect(
+          () => repository.updateMatchRules(
+            eventId: 'event_1',
+            rules: [
+              {'source_group_id': 'g1', 'target_group_id': 'g2'},
+            ],
+          ),
+          throwsA(isA<Exception>()),
+        );
+      });
+
       test('handles empty rules list via EF', () async {
         when(
           () => mockFunctions.invoke(
@@ -110,6 +129,20 @@ void main() {
     });
 
     group('clearMatchRules', () {
+      test('propagates EF error when invoke fails', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-match',
+            body: any(named: 'body'),
+          ),
+        ).thenThrow(Exception('EF failed'));
+
+        expect(
+          () => repository.clearMatchRules(eventId: 'event_1'),
+          throwsA(isA<Exception>()),
+        );
+      });
+
       test('completes without error via EF', () async {
         when(
           () => mockFunctions.invoke(

--- a/supabase/functions/partner-manage-match/deno.json
+++ b/supabase/functions/partner-manage-match/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/partner-manage-match/index.ts
+++ b/supabase/functions/partner-manage-match/index.ts
@@ -18,12 +18,19 @@ interface RuleInput {
 Deno.serve(async (req: Request): Promise<Response> => {
   if (req.method === "OPTIONS") return corsResponse();
 
-  // 1. Auth
+  // 1. Environment check (before auth — requireAuth also reads these)
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !serviceRoleKey) {
+    return errorResponse("Missing server configuration", 500);
+  }
+
+  // 2. Auth
   const auth = await requireAuth(req);
   if (auth instanceof Response) return auth;
   const userId = auth;
 
-  // 2. Parse body
+  // 3. Parse body
   let body: Record<string, unknown>;
   try {
     body = await req.json();
@@ -37,24 +44,22 @@ Deno.serve(async (req: Request): Promise<Response> => {
   const eventId = body.event_id as string | undefined;
   if (!eventId) return errorResponse("Missing event_id", 400);
 
-  // 3. Supabase client (service role)
-  const supabaseUrl = Deno.env.get("SUPABASE_URL");
-  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-  if (!supabaseUrl || !serviceRoleKey) {
-    return errorResponse("Missing server configuration", 500);
-  }
+  // 4. Supabase client (service role)
   const supabase = createClient(supabaseUrl, serviceRoleKey, {
     auth: { persistSession: false },
   });
 
-  // 4. Verify ownership: event → party → partner → has_partner_permission
+  // 5. Verify ownership: event → party → partner
   const { data: event, error: eventError } = await supabase
     .from("events")
     .select("id, status, party:party_id(id, partner_id)")
     .eq("id", eventId)
-    .single();
+    .maybeSingle();
 
-  if (eventError || !event) {
+  if (eventError) {
+    return errorResponse("Failed to load event", 500);
+  }
+  if (!event) {
     return errorResponse("Event not found", 404);
   }
 
@@ -64,12 +69,16 @@ Deno.serve(async (req: Request): Promise<Response> => {
   }
 
   // Check partner permission (service_role bypasses RLS, query directly)
-  const { data: perm } = await supabase
+  const { data: perm, error: permError } = await supabase
     .from("partner_member_permissions")
     .select("permissions")
     .eq("partner_id", party.partner_id)
     .eq("user_id", userId)
     .maybeSingle();
+
+  if (permError) {
+    return errorResponse("Failed to verify partner permissions", 500);
+  }
 
   const hasPermission = (perm?.permissions as string[] | null)?.includes("PARTY_MANAGE") ?? false;
   if (!hasPermission) {
@@ -131,32 +140,20 @@ Deno.serve(async (req: Request): Promise<Response> => {
       }
     }
 
-    // Delete existing rules
-    const { error: deleteError } = await supabase
-      .from("match_rules")
-      .delete()
-      .eq("event_id", eventId);
+    // Atomic replace via RPC (advisory lock + delete + insert in one transaction)
+    const records = rules.map((r) => ({
+      source_group_id: r.source_group_id,
+      target_group_id: r.target_group_id,
+      vote_count: r.vote_count ?? 1,
+    }));
 
-    if (deleteError) {
-      return errorResponse("Failed to clear existing rules", 500);
-    }
+    const { error: replaceError } = await supabase.rpc("replace_match_rules", {
+      p_event_id: eventId,
+      p_rules: records,
+    });
 
-    // Insert new rules
-    if (rules.length > 0) {
-      const records = rules.map((r) => ({
-        event_id: eventId,
-        source_group_id: r.source_group_id,
-        target_group_id: r.target_group_id,
-        vote_count: r.vote_count ?? 1,
-      }));
-
-      const { error: insertError } = await supabase
-        .from("match_rules")
-        .insert(records);
-
-      if (insertError) {
-        return errorResponse(`Failed to insert rules: ${insertError.message}`, 500);
-      }
+    if (replaceError) {
+      return errorResponse(`Failed to replace rules: ${replaceError.message}`, 500);
     }
 
     return successResponse({ success: true, count: rules.length });
@@ -164,12 +161,13 @@ Deno.serve(async (req: Request): Promise<Response> => {
 
   // ─── clear_rules ───
   if (action === "clear_rules") {
-    const { error: deleteError } = await supabase
-      .from("match_rules")
-      .delete()
-      .eq("event_id", eventId);
+    // Reuse RPC with empty rules for atomic clear
+    const { error: clearError } = await supabase.rpc("replace_match_rules", {
+      p_event_id: eventId,
+      p_rules: [],
+    });
 
-    if (deleteError) {
+    if (clearError) {
       return errorResponse("Failed to clear rules", 500);
     }
 

--- a/supabase/functions/partner-manage-match/index.ts
+++ b/supabase/functions/partner-manage-match/index.ts
@@ -1,0 +1,180 @@
+// partner-manage-match — Manage match rules for events (set_rules, clear_rules)
+// Issue #305: RLS write strategy 전환 + vote_count 지원
+
+import { createClient } from "@supabase/supabase-js";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
+import { requireAuth } from "../_shared/auth_utils.ts";
+
+interface RuleInput {
+  source_group_id: string;
+  target_group_id: string;
+  vote_count?: number;
+}
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") return corsResponse();
+
+  // 1. Auth
+  const auth = await requireAuth(req);
+  if (auth instanceof Response) return auth;
+  const userId = auth;
+
+  // 2. Parse body
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse("Invalid JSON body", 400);
+  }
+
+  const action = body.action as string | undefined;
+  if (!action) return errorResponse("Missing action", 400);
+
+  const eventId = body.event_id as string | undefined;
+  if (!eventId) return errorResponse("Missing event_id", 400);
+
+  // 3. Supabase client (service role)
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !serviceRoleKey) {
+    return errorResponse("Missing server configuration", 500);
+  }
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  });
+
+  // 4. Verify ownership: event → party → partner → has_partner_permission
+  const { data: event, error: eventError } = await supabase
+    .from("events")
+    .select("id, status, party:party_id(id, partner_id)")
+    .eq("id", eventId)
+    .single();
+
+  if (eventError || !event) {
+    return errorResponse("Event not found", 404);
+  }
+
+  const party = event.party as { id: string; partner_id: string } | null;
+  if (!party) {
+    return errorResponse("Event has no associated party", 404);
+  }
+
+  // Check partner permission (service_role bypasses RLS, query directly)
+  const { data: perm } = await supabase
+    .from("partner_member_permissions")
+    .select("permissions")
+    .eq("partner_id", party.partner_id)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  const hasPermission = (perm?.permissions as string[] | null)?.includes("PARTY_MANAGE") ?? false;
+  if (!hasPermission) {
+    return errorResponse("Forbidden: insufficient partner permissions", 403);
+  }
+
+  // Check event status — only 'scheduled' events can have rules modified
+  if (event.status !== "scheduled") {
+    return errorResponse(
+      `Cannot modify match rules for event with status '${event.status}'`,
+      400,
+    );
+  }
+
+  // ─── set_rules ───
+  if (action === "set_rules") {
+    const rules = body.rules as RuleInput[] | undefined;
+    if (!Array.isArray(rules)) {
+      return errorResponse("Missing or invalid rules array", 400);
+    }
+
+    // Validate each rule
+    for (const rule of rules) {
+      if (!rule.source_group_id || !rule.target_group_id) {
+        return errorResponse("Each rule must have source_group_id and target_group_id", 400);
+      }
+      if (rule.source_group_id === rule.target_group_id) {
+        return errorResponse("source_group_id and target_group_id must be different", 400);
+      }
+      const voteCount = rule.vote_count ?? 1;
+      if (!Number.isInteger(voteCount) || voteCount < 1) {
+        return errorResponse("vote_count must be a positive integer", 400);
+      }
+    }
+
+    // Validate all group IDs belong to this event
+    if (rules.length > 0) {
+      const allGroupIds = [
+        ...new Set(rules.flatMap((r) => [r.source_group_id, r.target_group_id])),
+      ];
+
+      const { data: groups, error: groupsError } = await supabase
+        .from("entry_groups")
+        .select("id")
+        .eq("event_id", eventId)
+        .in("id", allGroupIds);
+
+      if (groupsError) {
+        return errorResponse("Failed to verify entry groups", 500);
+      }
+
+      const validGroupIds = new Set((groups ?? []).map((g: { id: string }) => g.id));
+      const invalidIds = allGroupIds.filter((id) => !validGroupIds.has(id));
+      if (invalidIds.length > 0) {
+        return errorResponse(
+          `Invalid group IDs for this event: ${invalidIds.join(", ")}`,
+          400,
+        );
+      }
+    }
+
+    // Delete existing rules
+    const { error: deleteError } = await supabase
+      .from("match_rules")
+      .delete()
+      .eq("event_id", eventId);
+
+    if (deleteError) {
+      return errorResponse("Failed to clear existing rules", 500);
+    }
+
+    // Insert new rules
+    if (rules.length > 0) {
+      const records = rules.map((r) => ({
+        event_id: eventId,
+        source_group_id: r.source_group_id,
+        target_group_id: r.target_group_id,
+        vote_count: r.vote_count ?? 1,
+      }));
+
+      const { error: insertError } = await supabase
+        .from("match_rules")
+        .insert(records);
+
+      if (insertError) {
+        return errorResponse(`Failed to insert rules: ${insertError.message}`, 500);
+      }
+    }
+
+    return successResponse({ success: true, count: rules.length });
+  }
+
+  // ─── clear_rules ───
+  if (action === "clear_rules") {
+    const { error: deleteError } = await supabase
+      .from("match_rules")
+      .delete()
+      .eq("event_id", eventId);
+
+    if (deleteError) {
+      return errorResponse("Failed to clear rules", 500);
+    }
+
+    return successResponse({ success: true });
+  }
+
+  return errorResponse(`Unknown action: ${action}`, 400);
+});

--- a/supabase/functions/partner-manage-match/index.ts
+++ b/supabase/functions/partner-manage-match/index.ts
@@ -17,6 +17,7 @@ interface RuleInput {
 
 Deno.serve(async (req: Request): Promise<Response> => {
   if (req.method === "OPTIONS") return corsResponse();
+  if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
   // 1. Environment check (before auth — requireAuth also reads these)
   const supabaseUrl = Deno.env.get("SUPABASE_URL");
@@ -33,16 +34,20 @@ Deno.serve(async (req: Request): Promise<Response> => {
   // 3. Parse body
   let body: Record<string, unknown>;
   try {
-    body = await req.json();
+    const parsed = await req.json();
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return errorResponse("Request body must be a JSON object", 400);
+    }
+    body = parsed as Record<string, unknown>;
   } catch {
     return errorResponse("Invalid JSON body", 400);
   }
 
   const action = body.action as string | undefined;
-  if (!action) return errorResponse("Missing action", 400);
+  if (typeof action !== "string" || !action) return errorResponse("Missing action", 400);
 
-  const eventId = body.event_id as string | undefined;
-  if (!eventId) return errorResponse("Missing event_id", 400);
+  const eventId = body.event_id;
+  if (typeof eventId !== "string" || !eventId) return errorResponse("Missing event_id", 400);
 
   // 4. Supabase client (service role)
   const supabase = createClient(supabaseUrl, serviceRoleKey, {

--- a/supabase/functions/partner-manage-match/partner_manage_match_test.ts
+++ b/supabase/functions/partner-manage-match/partner_manage_match_test.ts
@@ -1,0 +1,564 @@
+import { assertEquals } from "@std/assert";
+import {
+  authenticatedJsonRequest,
+  captureServeHandler,
+  createFetchMock,
+  jsonResponse,
+  readJson,
+  withEnv,
+  withMockedFetch,
+  type FetchRoute,
+} from "../_test_utils/mock_http.ts";
+
+const TEST_USER_ID = "user-partner-owner";
+const TEST_EVENT_ID = "event-001";
+const TEST_PARTY_ID = "party-001";
+const TEST_PARTNER_ID = "partner-001";
+const GROUP_MALE = "group-male";
+const GROUP_FEMALE = "group-female";
+const GROUP_OTHER_EVENT = "group-other-event";
+
+const ENV = {
+  SUPABASE_URL: "http://localhost:54321",
+  SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+};
+
+function authRoute(): FetchRoute {
+  return {
+    matcher: "/auth/v1/user",
+    handler: () => jsonResponse({ id: TEST_USER_ID, email: "partner@test.com" }),
+  };
+}
+
+// Event lookup: returns event with party join
+function eventRoute(overrides?: { status?: string }): FetchRoute {
+  return {
+    matcher: (req) => req.url.includes("/rest/v1/events") && req.url.includes("select="),
+    handler: () =>
+      jsonResponse({
+        id: TEST_EVENT_ID,
+        status: overrides?.status ?? "scheduled",
+        party: { id: TEST_PARTY_ID, partner_id: TEST_PARTNER_ID },
+      }),
+  };
+}
+
+// Permission check: partner_member_permissions
+function permRoute(hasPermission = true): FetchRoute {
+  return {
+    matcher: (req) => req.url.includes("partner_member_permissions"),
+    handler: () =>
+      jsonResponse(
+        hasPermission
+          ? { permissions: ["PARTNER_EDIT", "PARTY_MANAGE", "MEMBER_MANAGE"] }
+          : null,
+      ),
+  };
+}
+
+// Entry groups validation
+function groupsRoute(validIds: string[] = [GROUP_MALE, GROUP_FEMALE]): FetchRoute {
+  return {
+    matcher: (req) => req.url.includes("entry_groups"),
+    handler: () => jsonResponse(validIds.map((id) => ({ id }))),
+  };
+}
+
+// match_rules delete
+function deleteRulesRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("match_rules") && req.method === "DELETE",
+    handler: () => jsonResponse([]),
+  };
+}
+
+// match_rules insert
+function insertRulesRoute(success = true): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("match_rules") && req.method === "POST",
+    handler: () =>
+      success
+        ? jsonResponse([{ id: "rule-1" }], { status: 201 })
+        : jsonResponse({ message: "insert error" }, { status: 400 }),
+  };
+}
+
+// match_rules operations (generic — for tests that don't care about method)
+function rulesRoute(): FetchRoute {
+  return {
+    matcher: (req) => req.url.includes("match_rules"),
+    handler: () => jsonResponse([]),
+  };
+}
+
+// ─── 401: no auth ───
+Deno.test({
+  name: "returns 401 without authorization",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: "/auth/v1/user",
+        handler: () => jsonResponse({ error: "invalid" }, { status: 401 }),
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = new Request("http://localhost", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action: "set_rules", event_id: TEST_EVENT_ID }),
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 401);
+      });
+    });
+  },
+});
+
+// ─── 400: missing action ───
+Deno.test({
+  name: "returns 400 for missing action",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", { event_id: TEST_EVENT_ID }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing action");
+      });
+    });
+  },
+});
+
+// ─── 400: missing event_id ───
+Deno.test({
+  name: "returns 400 for missing event_id",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", { action: "set_rules" }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing event_id");
+      });
+    });
+  },
+});
+
+// ─── 403: no partner permission ───
+Deno.test({
+  name: "returns 403 when user lacks PARTY_MANAGE permission",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute(),
+      permRoute(false),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "set_rules",
+            event_id: TEST_EVENT_ID,
+            rules: [],
+          }),
+        );
+        assertEquals(res.status, 403);
+      });
+    });
+  },
+});
+
+// ─── 400: completed event ───
+Deno.test({
+  name: "returns 400 for completed event",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute({ status: "completed" }),
+      permRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "set_rules",
+            event_id: TEST_EVENT_ID,
+            rules: [],
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Cannot modify match rules for event with status 'completed'");
+      });
+    });
+  },
+});
+
+// ─── set_rules: 2 rules with vote_count ───
+Deno.test({
+  name: "set_rules: inserts 2 rules with vote_count",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute(),
+      permRoute(),
+      groupsRoute(),
+      deleteRulesRoute(),
+      insertRulesRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "set_rules",
+            event_id: TEST_EVENT_ID,
+            rules: [
+              { source_group_id: GROUP_MALE, target_group_id: GROUP_FEMALE, vote_count: 3 },
+              { source_group_id: GROUP_FEMALE, target_group_id: GROUP_MALE, vote_count: 2 },
+            ],
+          }),
+        );
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+        assertEquals(body.count, 2);
+      });
+    });
+  },
+});
+
+// ─── set_rules: empty array clears all rules ───
+Deno.test({
+  name: "set_rules: empty array clears all rules",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute(),
+      permRoute(),
+      deleteRulesRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "set_rules",
+            event_id: TEST_EVENT_ID,
+            rules: [],
+          }),
+        );
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+        assertEquals(body.count, 0);
+      });
+    });
+  },
+});
+
+// ─── set_rules: re-set replaces existing ───
+Deno.test({
+  name: "set_rules: re-set deletes existing then inserts new",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const deleteCalled: boolean[] = [];
+    const insertCalled: boolean[] = [];
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute(),
+      permRoute(),
+      groupsRoute(),
+      {
+        matcher: (req) => req.url.includes("match_rules") && req.method === "DELETE",
+        handler: () => {
+          deleteCalled.push(true);
+          return jsonResponse([]);
+        },
+      },
+      {
+        matcher: (req) => req.url.includes("match_rules") && req.method === "POST",
+        handler: () => {
+          insertCalled.push(true);
+          return jsonResponse([{ id: "new-rule" }], { status: 201 });
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "set_rules",
+            event_id: TEST_EVENT_ID,
+            rules: [
+              { source_group_id: GROUP_MALE, target_group_id: GROUP_FEMALE, vote_count: 1 },
+            ],
+          }),
+        );
+        assertEquals(res.status, 200);
+        assertEquals(deleteCalled.length, 1);
+        assertEquals(insertCalled.length, 1);
+      });
+    });
+  },
+});
+
+// ─── set_rules: invalid group_id → 400 ───
+Deno.test({
+  name: "set_rules: returns 400 for non-existent group_id",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute(),
+      permRoute(),
+      groupsRoute([GROUP_MALE]), // only male group exists
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "set_rules",
+            event_id: TEST_EVENT_ID,
+            rules: [
+              { source_group_id: GROUP_MALE, target_group_id: "nonexistent-group", vote_count: 1 },
+            ],
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error.includes("Invalid group IDs"), true);
+      });
+    });
+  },
+});
+
+// ─── set_rules: source === target → 400 ───
+Deno.test({
+  name: "set_rules: returns 400 when source equals target group",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute(),
+      permRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "set_rules",
+            event_id: TEST_EVENT_ID,
+            rules: [
+              { source_group_id: GROUP_MALE, target_group_id: GROUP_MALE, vote_count: 1 },
+            ],
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "source_group_id and target_group_id must be different");
+      });
+    });
+  },
+});
+
+// ─── set_rules: vote_count = 0 → 400 ───
+Deno.test({
+  name: "set_rules: returns 400 for vote_count = 0",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute(),
+      permRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "set_rules",
+            event_id: TEST_EVENT_ID,
+            rules: [
+              { source_group_id: GROUP_MALE, target_group_id: GROUP_FEMALE, vote_count: 0 },
+            ],
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "vote_count must be a positive integer");
+      });
+    });
+  },
+});
+
+// ─── set_rules: default vote_count = 1 ───
+Deno.test({
+  name: "set_rules: defaults vote_count to 1 when omitted",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    let insertedBody: string | null = null;
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute(),
+      permRoute(),
+      groupsRoute(),
+      deleteRulesRoute(),
+      {
+        matcher: (req) => req.url.includes("match_rules") && req.method === "POST",
+        handler: async (req) => {
+          insertedBody = await req.clone().text();
+          return jsonResponse([{ id: "rule-1" }], { status: 201 });
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "set_rules",
+            event_id: TEST_EVENT_ID,
+            rules: [
+              { source_group_id: GROUP_MALE, target_group_id: GROUP_FEMALE },
+            ],
+          }),
+        );
+        assertEquals(res.status, 200);
+        // Verify vote_count=1 was sent in the insert
+        const parsed = JSON.parse(insertedBody!);
+        assertEquals(Array.isArray(parsed), true);
+        assertEquals(parsed[0].vote_count, 1);
+      });
+    });
+  },
+});
+
+// ─── clear_rules ───
+Deno.test({
+  name: "clear_rules: deletes all rules for event",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute(),
+      permRoute(),
+      deleteRulesRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "clear_rules",
+            event_id: TEST_EVENT_ID,
+          }),
+        );
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+      });
+    });
+  },
+});
+
+// ─── unknown action → 400 ───
+Deno.test({
+  name: "returns 400 for unknown action",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute(),
+      permRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "unknown_action",
+            event_id: TEST_EVENT_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Unknown action: unknown_action");
+      });
+    });
+  },
+});
+
+// ─── CORS preflight ───
+Deno.test({
+  name: "handles OPTIONS preflight request",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          new Request("http://localhost", { method: "OPTIONS" }),
+        );
+        assertEquals(res.status, 200);
+      });
+    });
+  },
+});

--- a/supabase/functions/partner-manage-match/partner_manage_match_test.ts
+++ b/supabase/functions/partner-manage-match/partner_manage_match_test.ts
@@ -16,7 +16,6 @@ const TEST_PARTY_ID = "party-001";
 const TEST_PARTNER_ID = "partner-001";
 const GROUP_MALE = "group-male";
 const GROUP_FEMALE = "group-female";
-const GROUP_OTHER_EVENT = "group-other-event";
 
 const ENV = {
   SUPABASE_URL: "http://localhost:54321",
@@ -64,32 +63,14 @@ function groupsRoute(validIds: string[] = [GROUP_MALE, GROUP_FEMALE]): FetchRout
   };
 }
 
-// match_rules delete
-function deleteRulesRoute(): FetchRoute {
+// RPC replace_match_rules
+function rpcRoute(success = true): FetchRoute {
   return {
-    matcher: (req) =>
-      req.url.includes("match_rules") && req.method === "DELETE",
-    handler: () => jsonResponse([]),
-  };
-}
-
-// match_rules insert
-function insertRulesRoute(success = true): FetchRoute {
-  return {
-    matcher: (req) =>
-      req.url.includes("match_rules") && req.method === "POST",
+    matcher: (req) => req.url.includes("/rest/v1/rpc/replace_match_rules"),
     handler: () =>
       success
-        ? jsonResponse([{ id: "rule-1" }], { status: 201 })
-        : jsonResponse({ message: "insert error" }, { status: 400 }),
-  };
-}
-
-// match_rules operations (generic — for tests that don't care about method)
-function rulesRoute(): FetchRoute {
-  return {
-    matcher: (req) => req.url.includes("match_rules"),
-    handler: () => jsonResponse([]),
+        ? jsonResponse(2)
+        : jsonResponse({ message: "rpc error" }, { status: 400 }),
   };
 }
 
@@ -165,6 +146,38 @@ Deno.test({
   },
 });
 
+// ─── 500: event DB error ───
+Deno.test({
+  name: "returns 500 when event query fails",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      {
+        matcher: (req) => req.url.includes("/rest/v1/events"),
+        handler: () => jsonResponse({ message: "db error" }, { status: 500 }),
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "set_rules",
+            event_id: TEST_EVENT_ID,
+            rules: [],
+          }),
+        );
+        assertEquals(res.status, 500);
+        const body = await readJson(res);
+        assertEquals(body.error, "Failed to load event");
+      });
+    });
+  },
+});
+
 // ─── 403: no partner permission ───
 Deno.test({
   name: "returns 403 when user lacks PARTY_MANAGE permission",
@@ -188,6 +201,39 @@ Deno.test({
           }),
         );
         assertEquals(res.status, 403);
+      });
+    });
+  },
+});
+
+// ─── 500: permission DB error ───
+Deno.test({
+  name: "returns 500 when permission query fails",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute(),
+      {
+        matcher: (req) => req.url.includes("partner_member_permissions"),
+        handler: () => jsonResponse({ message: "db error" }, { status: 500 }),
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "set_rules",
+            event_id: TEST_EVENT_ID,
+            rules: [],
+          }),
+        );
+        assertEquals(res.status, 500);
+        const body = await readJson(res);
+        assertEquals(body.error, "Failed to verify partner permissions");
       });
     });
   },
@@ -223,9 +269,9 @@ Deno.test({
   },
 });
 
-// ─── set_rules: 2 rules with vote_count ───
+// ─── set_rules: 2 rules with vote_count (via RPC) ───
 Deno.test({
-  name: "set_rules: inserts 2 rules with vote_count",
+  name: "set_rules: inserts 2 rules with vote_count via RPC",
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
@@ -235,8 +281,7 @@ Deno.test({
       eventRoute(),
       permRoute(),
       groupsRoute(),
-      deleteRulesRoute(),
-      insertRulesRoute(),
+      rpcRoute(),
     ]);
 
     await withEnv(ENV, async () => {
@@ -262,7 +307,7 @@ Deno.test({
 
 // ─── set_rules: empty array clears all rules ───
 Deno.test({
-  name: "set_rules: empty array clears all rules",
+  name: "set_rules: empty array clears all rules via RPC",
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
@@ -271,7 +316,7 @@ Deno.test({
       authRoute(),
       eventRoute(),
       permRoute(),
-      deleteRulesRoute(),
+      rpcRoute(),
     ]);
 
     await withEnv(ENV, async () => {
@@ -292,15 +337,14 @@ Deno.test({
   },
 });
 
-// ─── set_rules: re-set replaces existing ───
+// ─── set_rules: verifies RPC is called with correct payload ───
 Deno.test({
-  name: "set_rules: re-set deletes existing then inserts new",
+  name: "set_rules: sends correct payload to replace_match_rules RPC",
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-    const deleteCalled: boolean[] = [];
-    const insertCalled: boolean[] = [];
+    let rpcBody: string | null = null;
 
     const { fetchMock } = createFetchMock([
       authRoute(),
@@ -308,17 +352,10 @@ Deno.test({
       permRoute(),
       groupsRoute(),
       {
-        matcher: (req) => req.url.includes("match_rules") && req.method === "DELETE",
-        handler: () => {
-          deleteCalled.push(true);
-          return jsonResponse([]);
-        },
-      },
-      {
-        matcher: (req) => req.url.includes("match_rules") && req.method === "POST",
-        handler: () => {
-          insertCalled.push(true);
-          return jsonResponse([{ id: "new-rule" }], { status: 201 });
+        matcher: (req) => req.url.includes("/rest/v1/rpc/replace_match_rules"),
+        handler: async (req) => {
+          rpcBody = await req.clone().text();
+          return jsonResponse(1);
         },
       },
     ]);
@@ -330,13 +367,16 @@ Deno.test({
             action: "set_rules",
             event_id: TEST_EVENT_ID,
             rules: [
-              { source_group_id: GROUP_MALE, target_group_id: GROUP_FEMALE, vote_count: 1 },
+              { source_group_id: GROUP_MALE, target_group_id: GROUP_FEMALE },
             ],
           }),
         );
         assertEquals(res.status, 200);
-        assertEquals(deleteCalled.length, 1);
-        assertEquals(insertCalled.length, 1);
+        // Verify RPC payload includes vote_count default
+        const parsed = JSON.parse(rpcBody!);
+        assertEquals(parsed.p_event_id, TEST_EVENT_ID);
+        assertEquals(Array.isArray(parsed.p_rules), true);
+        assertEquals(parsed.p_rules[0].vote_count, 1);
       });
     });
   },
@@ -439,54 +479,9 @@ Deno.test({
   },
 });
 
-// ─── set_rules: default vote_count = 1 ───
-Deno.test({
-  name: "set_rules: defaults vote_count to 1 when omitted",
-  sanitizeResources: false,
-  sanitizeOps: false,
-  fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-    let insertedBody: string | null = null;
-
-    const { fetchMock } = createFetchMock([
-      authRoute(),
-      eventRoute(),
-      permRoute(),
-      groupsRoute(),
-      deleteRulesRoute(),
-      {
-        matcher: (req) => req.url.includes("match_rules") && req.method === "POST",
-        handler: async (req) => {
-          insertedBody = await req.clone().text();
-          return jsonResponse([{ id: "rule-1" }], { status: 201 });
-        },
-      },
-    ]);
-
-    await withEnv(ENV, async () => {
-      await withMockedFetch(fetchMock, async () => {
-        const res = await handler(
-          authenticatedJsonRequest("http://localhost", {
-            action: "set_rules",
-            event_id: TEST_EVENT_ID,
-            rules: [
-              { source_group_id: GROUP_MALE, target_group_id: GROUP_FEMALE },
-            ],
-          }),
-        );
-        assertEquals(res.status, 200);
-        // Verify vote_count=1 was sent in the insert
-        const parsed = JSON.parse(insertedBody!);
-        assertEquals(Array.isArray(parsed), true);
-        assertEquals(parsed[0].vote_count, 1);
-      });
-    });
-  },
-});
-
 // ─── clear_rules ───
 Deno.test({
-  name: "clear_rules: deletes all rules for event",
+  name: "clear_rules: clears all rules via RPC",
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
@@ -495,7 +490,7 @@ Deno.test({
       authRoute(),
       eventRoute(),
       permRoute(),
-      deleteRulesRoute(),
+      rpcRoute(),
     ]);
 
     await withEnv(ENV, async () => {

--- a/supabase/migrations/20260322000007_match_rules_vote_count_and_event_vote_period.sql
+++ b/supabase/migrations/20260322000007_match_rules_vote_count_and_event_vote_period.sql
@@ -12,3 +12,35 @@ ALTER TABLE public.match_rules
 ALTER TABLE public.events
   ADD COLUMN vote_start_at timestamptz,
   ADD COLUMN vote_end_at timestamptz;
+
+-- 3. replace_match_rules RPC — 원자적 delete + insert
+CREATE OR REPLACE FUNCTION public.replace_match_rules(
+  p_event_id uuid,
+  p_rules jsonb DEFAULT '[]'::jsonb
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  rule_count integer;
+BEGIN
+  -- Advisory lock on event_id to serialize concurrent calls
+  PERFORM pg_advisory_xact_lock(hashtext(p_event_id::text));
+
+  DELETE FROM public.match_rules WHERE event_id = p_event_id;
+
+  IF jsonb_array_length(p_rules) > 0 THEN
+    INSERT INTO public.match_rules (event_id, source_group_id, target_group_id, vote_count)
+    SELECT
+      p_event_id,
+      (r->>'source_group_id')::uuid,
+      (r->>'target_group_id')::uuid,
+      COALESCE((r->>'vote_count')::integer, 1)
+    FROM jsonb_array_elements(p_rules) AS r;
+  END IF;
+
+  GET DIAGNOSTICS rule_count = ROW_COUNT;
+  RETURN rule_count;
+END;
+$$;

--- a/supabase/migrations/20260322000007_match_rules_vote_count_and_event_vote_period.sql
+++ b/supabase/migrations/20260322000007_match_rules_vote_count_and_event_vote_period.sql
@@ -1,0 +1,14 @@
+-- Issue #305: match_rules에 vote_count 추가 + events에 투표 기간 컬럼 추가
+
+-- 1. match_rules: 그룹별 투표 수 제한
+ALTER TABLE public.match_rules
+  ADD COLUMN vote_count integer NOT NULL DEFAULT 1;
+
+-- vote_count >= 1 제약
+ALTER TABLE public.match_rules
+  ADD CONSTRAINT match_rules_vote_count_positive CHECK (vote_count >= 1);
+
+-- 2. events: 투표 기간 설정
+ALTER TABLE public.events
+  ADD COLUMN vote_start_at timestamptz,
+  ADD COLUMN vote_end_at timestamptz;


### PR DESCRIPTION
## Summary
- **Migration**: `match_rules.vote_count` 컬럼 추가 (DEFAULT 1, CHECK >= 1) + `events.vote_start_at/vote_end_at` 투표 기간 컬럼 추가
- **Edge Function**: `partner-manage-match` — `set_rules` (매칭룰 전체 교체, 권한/상태/그룹 검증 포함) + `clear_rules` (전체 삭제)
- **Flutter**: `matching_repository.dart` → EF 호출로 전환, `MatchRule` 모델에 `voteCount` 필드 추가

Closes #305

## Test plan
- [x] EF e2e 테스트 15개 전부 통과 (인증/권한/상태/그룹검증/vote_count/CORS 등)
- [ ] CI `ci-result` 통과
- [ ] CodeRabbit 리뷰 대응

🤖 Generated with [Claude Code](https://claude.com/claude-code)