### PR TITLE
fix(ci): add domain alias to Next.js preview deploys

### DIFF
--- a/.github/actions/deploy-nextjs-app/action.yml
+++ b/.github/actions/deploy-nextjs-app/action.yml
@@ -36,6 +36,6 @@ runs:
           echo "✅ Deployed to: $DEPLOY_URL"
           if [[ -n "${{ inputs.dev-domain-alias }}" ]]; then
             echo "🔗 Assigning alias: ${{ inputs.dev-domain-alias }}"
-            npx vercel@latest alias set "$DEPLOY_URL" "${{ inputs.dev-domain-alias }}" --token=$VERCEL_TOKEN --scope=$VERCEL_ORG_ID
+            npx --yes vercel@latest alias set "$DEPLOY_URL" "${{ inputs.dev-domain-alias }}" --token=$VERCEL_TOKEN --scope=$VERCEL_ORG_ID
           fi
         fi

--- a/.github/actions/deploy-nextjs-app/action.yml
+++ b/.github/actions/deploy-nextjs-app/action.yml
@@ -10,6 +10,9 @@ inputs:
     required: true
   vercel-project-id:
     required: true
+  dev-domain-alias:
+    description: 'Domain alias for dev/preview deployments'
+    required: false
 
 runs:
   using: "composite"
@@ -25,5 +28,11 @@ runs:
         if [[ "${{ github.ref_name }}" == "main" ]]; then
           npx --yes vercel@latest deploy --prod --token=$VERCEL_TOKEN --yes
         else
-          npx --yes vercel@latest deploy --token=$VERCEL_TOKEN --yes
+          # Fix #372: capture preview URL and assign domain alias so dev.*.minglit.com stays reachable
+          DEPLOY_URL=$(npx --yes vercel@latest deploy --token=$VERCEL_TOKEN --yes)
+          echo "✅ Deployed to: $DEPLOY_URL"
+          if [[ -n "${{ inputs.dev-domain-alias }}" ]]; then
+            echo "🔗 Assigning alias: ${{ inputs.dev-domain-alias }}"
+            npx vercel@latest alias set "$DEPLOY_URL" "${{ inputs.dev-domain-alias }}" --token=$VERCEL_TOKEN --scope=$VERCEL_ORG_ID
+          fi
         fi

--- a/.github/actions/deploy-nextjs-app/action.yml
+++ b/.github/actions/deploy-nextjs-app/action.yml
@@ -13,6 +13,9 @@ inputs:
   dev-domain-alias:
     description: 'Domain alias for dev/preview deployments'
     required: false
+  deploy-branch:
+    description: 'Branch name to determine prod vs preview deployment'
+    required: true
 
 runs:
   using: "composite"
@@ -25,7 +28,7 @@ runs:
         VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
         VERCEL_TOKEN: ${{ inputs.vercel-token }}
       run: |
-        if [[ "${{ github.ref_name }}" == "main" ]]; then
+        if [[ "${{ inputs.deploy-branch }}" == "main" ]]; then
           npx --yes vercel@latest deploy --prod --token=$VERCEL_TOKEN --yes
         else
           # Fix #372: capture preview URL and assign domain alias so dev.*.minglit.com stays reachable

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,7 @@ jobs:
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_LANDING_USER }}
           dev-domain-alias: dev.minglit.com
+          deploy-branch: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name }}
 
   deploy-landing_partner:
     runs-on: ubuntu-latest
@@ -77,6 +78,7 @@ jobs:
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_LANDING_PARTNER }}
           dev-domain-alias: dev.partner.minglit.com
+          deploy-branch: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name }}
 
   deploy-app_partner:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,7 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_LANDING_USER }}
+          dev-domain-alias: dev.minglit.com
 
   deploy-landing_partner:
     runs-on: ubuntu-latest
@@ -75,6 +76,7 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_LANDING_PARTNER }}
+          dev-domain-alias: dev.partner.minglit.com
 
   deploy-app_partner:
     runs-on: ubuntu-latest
@@ -147,7 +149,7 @@ jobs:
             BYPASS="${BYPASS_MAP[$url]}"
             STATUS=$(curl -sL -o /dev/null -w "%{http_code}" \
               -H "x-vercel-protection-bypass: $BYPASS" \
-              --max-time 15 "$url" || echo "000")
+              --max-time 15 "$url") || STATUS="000"
             if [ "$STATUS" = "200" ]; then
               echo "✅ ($STATUS)"
             else


### PR DESCRIPTION
## Summary
- `deploy-nextjs-app` action에 `dev-domain-alias` 입력 추가 — preview 배포 후 custom domain alias를 자동 설정
- `deploy.yml`에서 `landing_user`(`dev.minglit.com`)와 `landing_partner`(`dev.partner.minglit.com`)에 alias 전달
- smoke test의 curl 실패 시 status code 이중 출력 버그 수정 (`000000` → `000`)

## Root Cause
`deploy-nextjs-app`은 preview 배포 시 `vercel deploy`만 실행하고 domain alias를 설정하지 않았음. 매 배포마다 새로운 random preview URL이 생성되면서 `dev.minglit.com`이 만료된 이전 배포를 가리키게 됨. Flutter 앱용 `deploy-flutter-app`에는 이미 alias 단계가 있었으나 Next.js 액션에는 누락.

## Test plan
- [ ] PR 머지 후 Deploy to Vercel 워크플로우가 실행되면 `dev.minglit.com` smoke test 통과 확인
- [ ] `dev.partner.minglit.com`도 정상 응답 확인

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)