### PR TITLE
feat(matching): user-cast-vote EF + 투표 UI + 매칭 알림/정리 크론잡

### DIFF
--- a/apps/app_user/lib/src/features/event/matching/matching_vote_controller.dart
+++ b/apps/app_user/lib/src/features/event/matching/matching_vote_controller.dart
@@ -19,9 +19,10 @@ class MatchingVoteController extends _$MatchingVoteController {
       final repo = ref.read(matchingRepositoryProvider);
       await repo.castVote(eventId: eventId, candidateId: candidateId);
 
-      // Refresh candidates (to update UI if needed, though mostly static)
-      // and refresh matches to see if a match occurred instantly
+      // Fix #306: 투표 후 투표 상태 + 매칭 결과 갱신
       ref.invalidate(myMatchesProvider(eventId));
+      ref.invalidate(myVotedCandidateIdsProvider(eventId));
+      ref.invalidate(myVoteCountProvider(eventId));
 
       StatsigAnalytics.logEvent(
         MingLitEvent.matchingResult,
@@ -42,4 +43,23 @@ Future<List<UserProfile>> matchCandidates(Ref ref, String eventId) {
 @riverpod
 Future<List<MatchPair>> myMatches(Ref ref, String eventId) {
   return ref.watch(matchingRepositoryProvider).getMyMatches(eventId);
+}
+
+// Fix #306: 잔여 투표 수 표시 + 투표 완료 후보 비활성화
+@riverpod
+Future<int> myVoteCount(Ref ref, String eventId) {
+  return ref.watch(matchingRepositoryProvider).getMyVoteCount(eventId);
+}
+
+@riverpod
+Future<Set<String>> myVotedCandidateIds(Ref ref, String eventId) {
+  return ref.watch(matchingRepositoryProvider).getMyVotedCandidateIds(eventId);
+}
+
+@riverpod
+Future<int> maxVoteCount(Ref ref, String eventId) async {
+  final rules =
+      await ref.watch(matchingRepositoryProvider).getMatchRules(eventId);
+  if (rules.isEmpty) return 1;
+  return rules.map((r) => r.voteCount).reduce((a, b) => a > b ? a : b);
 }

--- a/apps/app_user/lib/src/features/event/matching/matching_vote_controller.dart
+++ b/apps/app_user/lib/src/features/event/matching/matching_vote_controller.dart
@@ -58,8 +58,9 @@ Future<Set<String>> myVotedCandidateIds(Ref ref, String eventId) {
 
 @riverpod
 Future<int> maxVoteCount(Ref ref, String eventId) async {
-  final rules =
-      await ref.watch(matchingRepositoryProvider).getMatchRules(eventId);
+  final rules = await ref
+      .watch(matchingRepositoryProvider)
+      .getMatchRules(eventId);
   if (rules.isEmpty) return 1;
   return rules.map((r) => r.voteCount).reduce((a, b) => a > b ? a : b);
 }

--- a/apps/app_user/lib/src/features/event/matching/matching_vote_controller.g.dart
+++ b/apps/app_user/lib/src/features/event/matching/matching_vote_controller.g.dart
@@ -34,7 +34,7 @@ final class MatchingVoteControllerProvider
 }
 
 String _$matchingVoteControllerHash() =>
-    r'7089846363640118c3ced43940bcfd60a096c8e2';
+    r'5902f89f8b54d6d8a0610ef1b8c2c1cfb5a35c3d';
 
 abstract class _$MatchingVoteController extends $AsyncNotifier<void> {
   FutureOr<void> build();
@@ -205,4 +205,218 @@ final class MyMatchesFamily extends $Family
 
   @override
   String toString() => r'myMatchesProvider';
+}
+
+@ProviderFor(myVoteCount)
+const myVoteCountProvider = MyVoteCountFamily._();
+
+final class MyVoteCountProvider
+    extends $FunctionalProvider<AsyncValue<int>, int, FutureOr<int>>
+    with $FutureModifier<int>, $FutureProvider<int> {
+  const MyVoteCountProvider._({
+    required MyVoteCountFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'myVoteCountProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$myVoteCountHash();
+
+  @override
+  String toString() {
+    return r'myVoteCountProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<int> create(Ref ref) {
+    final argument = this.argument as String;
+    return myVoteCount(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is MyVoteCountProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$myVoteCountHash() => r'c59ff09841424d7727c2428b7b95d69d8d6f8f38';
+
+final class MyVoteCountFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<int>, String> {
+  const MyVoteCountFamily._()
+    : super(
+        retry: null,
+        name: r'myVoteCountProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  MyVoteCountProvider call(String eventId) =>
+      MyVoteCountProvider._(argument: eventId, from: this);
+
+  @override
+  String toString() => r'myVoteCountProvider';
+}
+
+@ProviderFor(myVotedCandidateIds)
+const myVotedCandidateIdsProvider = MyVotedCandidateIdsFamily._();
+
+final class MyVotedCandidateIdsProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<Set<String>>,
+          Set<String>,
+          FutureOr<Set<String>>
+        >
+    with $FutureModifier<Set<String>>, $FutureProvider<Set<String>> {
+  const MyVotedCandidateIdsProvider._({
+    required MyVotedCandidateIdsFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'myVotedCandidateIdsProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$myVotedCandidateIdsHash();
+
+  @override
+  String toString() {
+    return r'myVotedCandidateIdsProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<Set<String>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<Set<String>> create(Ref ref) {
+    final argument = this.argument as String;
+    return myVotedCandidateIds(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is MyVotedCandidateIdsProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$myVotedCandidateIdsHash() =>
+    r'c26471f0b1523dc1f4c56c9d9d6086bcd85a6acb';
+
+final class MyVotedCandidateIdsFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<Set<String>>, String> {
+  const MyVotedCandidateIdsFamily._()
+    : super(
+        retry: null,
+        name: r'myVotedCandidateIdsProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  MyVotedCandidateIdsProvider call(String eventId) =>
+      MyVotedCandidateIdsProvider._(argument: eventId, from: this);
+
+  @override
+  String toString() => r'myVotedCandidateIdsProvider';
+}
+
+@ProviderFor(maxVoteCount)
+const maxVoteCountProvider = MaxVoteCountFamily._();
+
+final class MaxVoteCountProvider
+    extends $FunctionalProvider<AsyncValue<int>, int, FutureOr<int>>
+    with $FutureModifier<int>, $FutureProvider<int> {
+  const MaxVoteCountProvider._({
+    required MaxVoteCountFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'maxVoteCountProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$maxVoteCountHash();
+
+  @override
+  String toString() {
+    return r'maxVoteCountProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<int> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<int> create(Ref ref) {
+    final argument = this.argument as String;
+    return maxVoteCount(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is MaxVoteCountProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$maxVoteCountHash() => r'3e5c192dc6847792a09e6db41136ad42f12ceca3';
+
+final class MaxVoteCountFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<int>, String> {
+  const MaxVoteCountFamily._()
+    : super(
+        retry: null,
+        name: r'maxVoteCountProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  MaxVoteCountProvider call(String eventId) =>
+      MaxVoteCountProvider._(argument: eventId, from: this);
+
+  @override
+  String toString() => r'maxVoteCountProvider';
 }

--- a/apps/app_user/lib/src/features/event/matching/matching_vote_screen.dart
+++ b/apps/app_user/lib/src/features/event/matching/matching_vote_screen.dart
@@ -114,9 +114,7 @@ class MatchingVoteScreen extends ConsumerWidget {
                       ),
                       const SizedBox(width: MinglitSpacing.small),
                       Text(
-                        allUsed
-                            ? '투표 완료!'
-                            : '남은 투표: $remaining/$max',
+                        allUsed ? '투표 완료!' : '남은 투표: $remaining/$max',
                         style: theme.textTheme.bodyMedium?.copyWith(
                           fontWeight: FontWeight.w600,
                           color: allUsed
@@ -139,7 +137,8 @@ class MatchingVoteScreen extends ConsumerWidget {
                   return const Center(child: Text('투표 가능한 상대가 없습니다.'));
                 }
                 final votedIds = votedIdsAsync.valueOrNull ?? {};
-                final allVotesUsed = voteCountAsync.hasValue &&
+                final allVotesUsed =
+                    voteCountAsync.hasValue &&
                     maxVoteAsync.hasValue &&
                     voteCountAsync.value! >= maxVoteAsync.value!;
                 return GridView.builder(
@@ -293,7 +292,8 @@ class MatchingVoteScreen extends ConsumerWidget {
                           ? null
                           : () {
                               unawaited(
-                                  _confirmAndVote(context, ref, candidate));
+                                _confirmAndVote(context, ref, candidate),
+                              );
                             },
                       style: ElevatedButton.styleFrom(
                         backgroundColor: isVoted

--- a/apps/app_user/lib/src/features/event/matching/matching_vote_screen.dart
+++ b/apps/app_user/lib/src/features/event/matching/matching_vote_screen.dart
@@ -14,6 +14,10 @@ class MatchingVoteScreen extends ConsumerWidget {
     final theme = Theme.of(context);
     final candidatesAsync = ref.watch(matchCandidatesProvider(eventId));
     final matchesAsync = ref.watch(myMatchesProvider(eventId));
+    // Fix #306: 잔여 투표 수 + 투표 완료 후보 추적
+    final voteCountAsync = ref.watch(myVoteCountProvider(eventId));
+    final maxVoteAsync = ref.watch(maxVoteCountProvider(eventId));
+    final votedIdsAsync = ref.watch(myVotedCandidateIdsProvider(eventId));
 
     // Listen to vote action state
     ref.listen(matchingVoteControllerProvider, (_, state) {
@@ -86,6 +90,46 @@ class MatchingVoteScreen extends ConsumerWidget {
             },
           ),
 
+          // Fix #306: 잔여 투표 수 표시
+          if (voteCountAsync.hasValue && maxVoteAsync.hasValue)
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: MinglitSpacing.medium,
+                vertical: MinglitSpacing.small,
+              ),
+              child: Builder(
+                builder: (context) {
+                  final used = voteCountAsync.value!;
+                  final max = maxVoteAsync.value!;
+                  final remaining = max - used;
+                  final allUsed = remaining <= 0;
+                  return Row(
+                    children: [
+                      Icon(
+                        allUsed ? Icons.check_circle : Icons.how_to_vote,
+                        size: MinglitIconSize.small,
+                        color: allUsed
+                            ? theme.colorScheme.primary
+                            : theme.colorScheme.onSurfaceVariant,
+                      ),
+                      const SizedBox(width: MinglitSpacing.small),
+                      Text(
+                        allUsed
+                            ? '투표 완료!'
+                            : '남은 투표: $remaining/$max',
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                          color: allUsed
+                              ? theme.colorScheme.primary
+                              : theme.colorScheme.onSurface,
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+
           // 2. Candidates
           Expanded(
             child: MinglitAsyncValueWidget(
@@ -94,6 +138,10 @@ class MatchingVoteScreen extends ConsumerWidget {
                 if (candidates.isEmpty) {
                   return const Center(child: Text('투표 가능한 상대가 없습니다.'));
                 }
+                final votedIds = votedIdsAsync.valueOrNull ?? {};
+                final allVotesUsed = voteCountAsync.hasValue &&
+                    maxVoteAsync.hasValue &&
+                    voteCountAsync.value! >= maxVoteAsync.value!;
                 return GridView.builder(
                   padding: const EdgeInsets.all(MinglitSpacing.medium),
                   gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
@@ -105,7 +153,14 @@ class MatchingVoteScreen extends ConsumerWidget {
                   itemCount: candidates.length,
                   itemBuilder: (context, index) {
                     final candidate = candidates[index];
-                    return _buildCandidateCard(context, ref, candidate);
+                    final isVoted = votedIds.contains(candidate.id);
+                    return _buildCandidateCard(
+                      context,
+                      ref,
+                      candidate,
+                      isVoted: isVoted,
+                      isDisabled: isVoted || allVotesUsed,
+                    );
                   },
                 );
               },
@@ -164,11 +219,14 @@ class MatchingVoteScreen extends ConsumerWidget {
     );
   }
 
+  // Fix #306: isVoted/isDisabled 파라미터 추가
   Widget _buildCandidateCard(
     BuildContext context,
     WidgetRef ref,
-    UserProfile candidate,
-  ) {
+    UserProfile candidate, {
+    bool isVoted = false,
+    bool isDisabled = false,
+  }) {
     final theme = Theme.of(context);
     return Card(
       clipBehavior: Clip.antiAlias,
@@ -185,6 +243,20 @@ class MatchingVoteScreen extends ConsumerWidget {
               ),
             ),
           ),
+          // Fix #306: 투표 완료 체크 오버레이
+          if (isVoted)
+            Positioned.fill(
+              child: ColoredBox(
+                color: theme.colorScheme.primary.withValues(alpha: 0.2),
+                child: Center(
+                  child: Icon(
+                    Icons.check_circle,
+                    size: 48,
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+              ),
+            ),
           // Info Overlay
           Positioned(
             bottom: 0,
@@ -216,17 +288,24 @@ class MatchingVoteScreen extends ConsumerWidget {
                   SizedBox(
                     width: double.infinity,
                     child: ElevatedButton(
-                      onPressed: () {
-                        // Confirm Vote
-                        unawaited(_confirmAndVote(context, ref, candidate));
-                      },
+                      // Fix #306: 투표 완료 또는 투표 수 초과 시 비활성화
+                      onPressed: isDisabled
+                          ? null
+                          : () {
+                              unawaited(
+                                  _confirmAndVote(context, ref, candidate));
+                            },
                       style: ElevatedButton.styleFrom(
-                        backgroundColor: theme.colorScheme.primary,
-                        foregroundColor: theme.colorScheme.onPrimary,
+                        backgroundColor: isVoted
+                            ? theme.colorScheme.surfaceContainerHighest
+                            : theme.colorScheme.primary,
+                        foregroundColor: isVoted
+                            ? theme.colorScheme.onSurfaceVariant
+                            : theme.colorScheme.onPrimary,
                         padding: EdgeInsets.zero,
                         visualDensity: VisualDensity.compact,
                       ),
-                      child: const Text('선택'),
+                      child: Text(isVoted ? '투표 완료' : '선택'),
                     ),
                   ),
                 ],

--- a/apps/app_user/lib/src/features/event/matching/matching_vote_screen.dart
+++ b/apps/app_user/lib/src/features/event/matching/matching_vote_screen.dart
@@ -136,7 +136,9 @@ class MatchingVoteScreen extends ConsumerWidget {
                 if (candidates.isEmpty) {
                   return const Center(child: Text('투표 가능한 상대가 없습니다.'));
                 }
-                final votedIds = votedIdsAsync.valueOrNull ?? {};
+                final votedIds = votedIdsAsync.hasValue
+                    ? votedIdsAsync.value!
+                    : <String>{};
                 final allVotesUsed =
                     voteCountAsync.hasValue &&
                     maxVoteAsync.hasValue &&

--- a/shared/packages/minglit_kit/lib/src/data/repositories/matching_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/matching_repository.dart
@@ -163,11 +163,13 @@ class MatchingRepository {
     if (userId == null) return 0;
 
     try {
-      final data = await _supabase
-          .from('match_votes')
-          .select()
-          .eq('event_id', eventId)
-          .eq('voter_id', userId) as List;
+      final data =
+          await _supabase
+                  .from('match_votes')
+                  .select()
+                  .eq('event_id', eventId)
+                  .eq('voter_id', userId)
+              as List;
       return data.length;
     } catch (e, st) {
       Log.e('❌ [MatchingRepo] getMyVoteCount Error', e, st);
@@ -182,11 +184,13 @@ class MatchingRepository {
     if (userId == null) return {};
 
     try {
-      final data = await _supabase
-          .from('match_votes')
-          .select('candidate_id')
-          .eq('event_id', eventId)
-          .eq('voter_id', userId) as List;
+      final data =
+          await _supabase
+                  .from('match_votes')
+                  .select('candidate_id')
+                  .eq('event_id', eventId)
+                  .eq('voter_id', userId)
+              as List;
       return data
           .map((e) => (e as Map<String, dynamic>)['candidate_id'] as String)
           .toSet();

--- a/shared/packages/minglit_kit/lib/src/data/repositories/matching_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/matching_repository.dart
@@ -85,20 +85,20 @@ class MatchingRepository {
     }
   }
 
-  /// Casts a vote for a candidate.
+  /// Casts a vote for a candidate via user-cast-vote EF.
+  // Fix #306: RLS write → EF 전환 (direct match_votes INSERT → user-cast-vote EF)
   Future<void> castVote({
     required String eventId,
     required String candidateId,
   }) async {
-    final userId = _supabase.auth.currentUser?.id;
-    if (userId == null) throw Exception('User not authenticated');
-
     try {
-      await _supabase.from('match_votes').insert({
-        'event_id': eventId,
-        'voter_id': userId,
-        'candidate_id': candidateId,
-      });
+      await _supabase.functions.invoke(
+        'user-cast-vote',
+        body: {
+          'event_id': eventId,
+          'candidate_id': candidateId,
+        },
+      );
       Log.d('castVote success | candidate: $candidateId');
     } catch (e, st) {
       Log.e('❌ [MatchingRepo] castVote Error', e, st);
@@ -152,6 +152,46 @@ class MatchingRepository {
       return enrichedMatches;
     } catch (e, st) {
       Log.e('❌ [MatchingRepo] getMyMatches Error', e, st);
+      rethrow;
+    }
+  }
+
+  /// Fetches the voter's current vote count for an event.
+  // Fix #306: 잔여 투표 수 표시용
+  Future<int> getMyVoteCount(String eventId) async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) return 0;
+
+    try {
+      final data = await _supabase
+          .from('match_votes')
+          .select()
+          .eq('event_id', eventId)
+          .eq('voter_id', userId) as List;
+      return data.length;
+    } catch (e, st) {
+      Log.e('❌ [MatchingRepo] getMyVoteCount Error', e, st);
+      rethrow;
+    }
+  }
+
+  /// Fetches the voted candidate IDs for the current user in an event.
+  // Fix #306: 투표 완료된 후보 비활성화용
+  Future<Set<String>> getMyVotedCandidateIds(String eventId) async {
+    final userId = _supabase.auth.currentUser?.id;
+    if (userId == null) return {};
+
+    try {
+      final data = await _supabase
+          .from('match_votes')
+          .select('candidate_id')
+          .eq('event_id', eventId)
+          .eq('voter_id', userId) as List;
+      return data
+          .map((e) => (e as Map<String, dynamic>)['candidate_id'] as String)
+          .toSet();
+    } catch (e, st) {
+      Log.e('❌ [MatchingRepo] getMyVotedCandidateIds Error', e, st);
       rethrow;
     }
   }

--- a/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
@@ -163,9 +163,20 @@ void main() {
       });
     });
 
+    // Fix #306: castVote → EF 전환 후 테스트 업데이트
     group('castVote', () {
-      test('completes when user is authenticated', () async {
-        unawaited(mockTable(mockClient, 'match_votes'));
+      test('completes when EF invoke succeeds', () async {
+        when(
+          () => mockFunctions.invoke(
+            'user-cast-vote',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            data: utf8.encode(jsonEncode({'success': true})),
+            status: 200,
+          ),
+        );
 
         await expectLater(
           repository.castVote(
@@ -176,9 +187,13 @@ void main() {
         );
       });
 
-      test('throws when user not authenticated', () async {
-        mockClient = createMockSupabase(); // No user
-        repository = MatchingRepository(supabase: mockClient);
+      test('throws when EF invoke fails', () async {
+        when(
+          () => mockFunctions.invoke(
+            'user-cast-vote',
+            body: any(named: 'body'),
+          ),
+        ).thenThrow(Exception('EF failed'));
 
         expect(
           () => repository.castVote(

--- a/supabase/functions/notification-worker/index.ts
+++ b/supabase/functions/notification-worker/index.ts
@@ -133,6 +133,11 @@ const NOTIFICATION_TEMPLATES: Record<string, (data: Record<string, unknown>) => 
     title: '[지급 실패]',
     body: `정산 지급에 실패했습니다. 계좌 정보를 확인해 주세요.`,
   }),
+  // Fix #306: 매칭 결과 알림
+  match_result: (d) => ({
+    title: '[매칭 결과]',
+    body: `${(d.event_title as string) || '이벤트'}에서 매칭이 성사되었습니다! 결과를 확인해 보세요.`,
+  }),
 };
 
 // --- Helper: Resolve affected user_id for Schema A events ---

--- a/supabase/functions/user-cast-vote/index.ts
+++ b/supabase/functions/user-cast-vote/index.ts
@@ -1,0 +1,158 @@
+// user-cast-vote — Cast a matching vote for a candidate in an event
+// Replaces direct client writes to match_votes (RLS write → EF)
+
+import { createClient } from "@supabase/supabase-js";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
+import { requireAuth } from "../_shared/auth_utils.ts";
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") return corsResponse();
+
+  const auth = await requireAuth(req);
+  if (auth instanceof Response) return auth;
+  const voterId = auth;
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !serviceRoleKey) {
+    return errorResponse("Missing server configuration", 500);
+  }
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  });
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse("Invalid JSON body", 400);
+  }
+
+  const eventId = body.event_id as string | undefined;
+  const candidateId = body.candidate_id as string | undefined;
+
+  if (!eventId) return errorResponse("Missing event_id", 400);
+  if (!candidateId) return errorResponse("Missing candidate_id", 400);
+  if (candidateId === voterId) return errorResponse("자기 자신에게 투표할 수 없습니다", 400);
+
+  // 1. Fetch event with vote period
+  const { data: event, error: eventError } = await supabase
+    .from("events")
+    .select("id, status, vote_start_at, vote_end_at")
+    .eq("id", eventId)
+    .maybeSingle();
+
+  if (eventError) return errorResponse("Failed to load event", 500);
+  if (!event) return errorResponse("Event not found", 404);
+
+  // 2. Vote period validation
+  if (!event.vote_start_at) {
+    return errorResponse("투표 기능이 활성화되지 않았습니다", 400);
+  }
+
+  const now = new Date();
+  if (now < new Date(event.vote_start_at)) {
+    return errorResponse("투표가 아직 시작되지 않았습니다", 400);
+  }
+  if (event.vote_end_at && now > new Date(event.vote_end_at)) {
+    return errorResponse("투표가 마감되었습니다", 400);
+  }
+
+  // 3. Verify voter is checked_in participant
+  const { data: voterParticipant, error: voterError } = await supabase
+    .from("event_participants")
+    .select("status, ticket_id")
+    .eq("event_id", eventId)
+    .eq("user_id", voterId)
+    .maybeSingle();
+
+  if (voterError) return errorResponse("Failed to verify participant", 500);
+  if (!voterParticipant) return errorResponse("이벤트 참가자가 아닙니다", 400);
+  if (voterParticipant.status !== "checked_in") {
+    return errorResponse("체크인 후 투표 가능합니다", 400);
+  }
+
+  // 4. Verify candidate is checked_in participant
+  const { data: candidateParticipant, error: candidateError } = await supabase
+    .from("event_participants")
+    .select("status, ticket_id")
+    .eq("event_id", eventId)
+    .eq("user_id", candidateId)
+    .maybeSingle();
+
+  if (candidateError) return errorResponse("Failed to verify candidate", 500);
+  if (!candidateParticipant) return errorResponse("후보자가 이벤트 참가자가 아닙니다", 400);
+  if (candidateParticipant.status !== "checked_in") {
+    return errorResponse("후보자가 체크인하지 않았습니다", 400);
+  }
+
+  // 5. Fetch voter's group from ticket → target_entry_group_ids
+  const { data: voterTicket } = await supabase
+    .from("tickets")
+    .select("target_entry_group_ids")
+    .eq("id", voterParticipant.ticket_id)
+    .maybeSingle();
+
+  const { data: candidateTicket } = await supabase
+    .from("tickets")
+    .select("target_entry_group_ids")
+    .eq("id", candidateParticipant.ticket_id)
+    .maybeSingle();
+
+  const voterGroupIds: string[] = voterTicket?.target_entry_group_ids ?? [];
+  const candidateGroupIds: string[] = candidateTicket?.target_entry_group_ids ?? [];
+
+  // 6. Check match_rules: voter's group → candidate's group allowed?
+  if (voterGroupIds.length > 0 && candidateGroupIds.length > 0) {
+    const { data: rules } = await supabase
+      .from("match_rules")
+      .select("vote_count")
+      .eq("event_id", eventId)
+      .in("source_group_id", voterGroupIds)
+      .in("target_group_id", candidateGroupIds);
+
+    if (!rules || rules.length === 0) {
+      return errorResponse("매칭 대상이 아닙니다", 400);
+    }
+
+    // 7. Check vote count limit (use max vote_count from applicable rules)
+    const maxVoteCount = Math.max(...rules.map((r: { vote_count: number }) => r.vote_count));
+
+    const { count: currentVotes } = await supabase
+      .from("match_votes")
+      .select("*", { count: "exact", head: true })
+      .eq("event_id", eventId)
+      .eq("voter_id", voterId);
+
+    if (currentVotes !== null && currentVotes >= maxVoteCount) {
+      return errorResponse("투표 수를 초과했습니다", 400);
+    }
+  }
+
+  // 8. Insert vote (DB-level constraints handle duplicates + self-vote)
+  const { error: insertError } = await supabase
+    .from("match_votes")
+    .insert({
+      event_id: eventId,
+      voter_id: voterId,
+      candidate_id: candidateId,
+    });
+
+  if (insertError) {
+    // PK violation = duplicate vote
+    if (insertError.code === "23505") {
+      return errorResponse("이미 투표한 후보입니다", 400);
+    }
+    // CHECK violation = self-vote (should be caught above, but safety net)
+    if (insertError.code === "23514") {
+      return errorResponse("자기 자신에게 투표할 수 없습니다", 400);
+    }
+    return errorResponse(insertError.message, 500);
+  }
+
+  return successResponse({ success: true });
+});

--- a/supabase/functions/user-cast-vote/index.ts
+++ b/supabase/functions/user-cast-vote/index.ts
@@ -39,10 +39,10 @@ Deno.serve(async (req: Request): Promise<Response> => {
   if (!candidateId) return errorResponse("Missing candidate_id", 400);
   if (candidateId === voterId) return errorResponse("자기 자신에게 투표할 수 없습니다", 400);
 
-  // 1. Fetch event with vote period
+  // 1. Fetch event with vote period + end_time fallback
   const { data: event, error: eventError } = await supabase
     .from("events")
-    .select("id, status, vote_start_at, vote_end_at")
+    .select("id, status, vote_start_at, vote_end_at, end_time")
     .eq("id", eventId)
     .maybeSingle();
 
@@ -58,7 +58,9 @@ Deno.serve(async (req: Request): Promise<Response> => {
   if (now < new Date(event.vote_start_at)) {
     return errorResponse("투표가 아직 시작되지 않았습니다", 400);
   }
-  if (event.vote_end_at && now > new Date(event.vote_end_at)) {
+  // Fix #306: vote_end_at이 없으면 end_time을 fallback deadline으로 사용
+  const deadline = event.vote_end_at ?? event.end_time;
+  if (deadline && now > new Date(deadline)) {
     return errorResponse("투표가 마감되었습니다", 400);
   }
 
@@ -90,68 +92,68 @@ Deno.serve(async (req: Request): Promise<Response> => {
     return errorResponse("후보자가 체크인하지 않았습니다", 400);
   }
 
-  // 5. Fetch voter's group from ticket → target_entry_group_ids
-  const { data: voterTicket } = await supabase
+  // 5. Fetch voter's group from ticket → target_entry_group_ids (fail-closed)
+  const { data: voterTicket, error: voterTicketError } = await supabase
     .from("tickets")
     .select("target_entry_group_ids")
     .eq("id", voterParticipant.ticket_id)
     .maybeSingle();
 
-  const { data: candidateTicket } = await supabase
+  if (voterTicketError) return errorResponse("Failed to load voter ticket", 500);
+
+  const { data: candidateTicket, error: candidateTicketError } = await supabase
     .from("tickets")
     .select("target_entry_group_ids")
     .eq("id", candidateParticipant.ticket_id)
     .maybeSingle();
 
+  if (candidateTicketError) return errorResponse("Failed to load candidate ticket", 500);
+
   const voterGroupIds: string[] = voterTicket?.target_entry_group_ids ?? [];
   const candidateGroupIds: string[] = candidateTicket?.target_entry_group_ids ?? [];
 
-  // 6. Check match_rules: voter's group → candidate's group allowed?
-  if (voterGroupIds.length > 0 && candidateGroupIds.length > 0) {
-    const { data: rules } = await supabase
-      .from("match_rules")
-      .select("vote_count")
-      .eq("event_id", eventId)
-      .in("source_group_id", voterGroupIds)
-      .in("target_group_id", candidateGroupIds);
-
-    if (!rules || rules.length === 0) {
-      return errorResponse("매칭 대상이 아닙니다", 400);
-    }
-
-    // 7. Check vote count limit (use max vote_count from applicable rules)
-    const maxVoteCount = Math.max(...rules.map((r: { vote_count: number }) => r.vote_count));
-
-    const { count: currentVotes } = await supabase
-      .from("match_votes")
-      .select("*", { count: "exact", head: true })
-      .eq("event_id", eventId)
-      .eq("voter_id", voterId);
-
-    if (currentVotes !== null && currentVotes >= maxVoteCount) {
-      return errorResponse("투표 수를 초과했습니다", 400);
-    }
+  // Fix #306: 그룹 정보가 없으면 거부 (fail-closed)
+  if (voterGroupIds.length === 0 || candidateGroupIds.length === 0) {
+    return errorResponse("그룹 정보를 확인할 수 없습니다", 400);
   }
 
-  // 8. Insert vote (DB-level constraints handle duplicates + self-vote)
-  const { error: insertError } = await supabase
-    .from("match_votes")
-    .insert({
-      event_id: eventId,
-      voter_id: voterId,
-      candidate_id: candidateId,
-    });
+  // 6. Check match_rules: voter's group → candidate's group allowed?
+  const { data: rules, error: rulesError } = await supabase
+    .from("match_rules")
+    .select("vote_count")
+    .eq("event_id", eventId)
+    .in("source_group_id", voterGroupIds)
+    .in("target_group_id", candidateGroupIds);
 
-  if (insertError) {
-    // PK violation = duplicate vote
-    if (insertError.code === "23505") {
+  if (rulesError) return errorResponse("Failed to load match rules", 500);
+  if (!rules || rules.length === 0) {
+    return errorResponse("매칭 대상이 아닙니다", 400);
+  }
+
+  // 7. Atomic vote count check + insert via RPC (prevents race condition)
+  const maxVoteCount = Math.max(...rules.map((r: { vote_count: number }) => r.vote_count));
+
+  const { data: rpcResult, error: rpcError } = await supabase.rpc("cast_match_vote", {
+    p_event_id: eventId,
+    p_voter_id: voterId,
+    p_candidate_id: candidateId,
+    p_max_vote_count: maxVoteCount,
+  });
+
+  if (rpcError) {
+    if (rpcError.message?.includes("투표 수를 초과했습니다")) {
+      return errorResponse("투표 수를 초과했습니다", 400);
+    }
+    if (rpcError.message?.includes("이미 투표한 후보입니다")) {
       return errorResponse("이미 투표한 후보입니다", 400);
     }
-    // CHECK violation = self-vote (should be caught above, but safety net)
-    if (insertError.code === "23514") {
+    if (rpcError.code === "23505") {
+      return errorResponse("이미 투표한 후보입니다", 400);
+    }
+    if (rpcError.code === "23514") {
       return errorResponse("자기 자신에게 투표할 수 없습니다", 400);
     }
-    return errorResponse(insertError.message, 500);
+    return errorResponse(rpcError.message, 500);
   }
 
   return successResponse({ success: true });

--- a/supabase/functions/user-cast-vote/user_cast_vote_test.ts
+++ b/supabase/functions/user-cast-vote/user_cast_vote_test.ts
@@ -1,0 +1,645 @@
+import { assertEquals } from "@std/assert";
+import {
+  authenticatedJsonRequest,
+  captureServeHandler,
+  createFetchMock,
+  jsonResponse,
+  readJson,
+  withEnv,
+  withMockedFetch,
+  type FetchRoute,
+} from "../_test_utils/mock_http.ts";
+
+const TEST_VOTER_ID = "voter-001";
+const TEST_CANDIDATE_ID = "candidate-001";
+const TEST_EVENT_ID = "event-001";
+const TEST_TICKET_VOTER = "ticket-voter";
+const TEST_TICKET_CANDIDATE = "ticket-candidate";
+const GROUP_MALE = "group-male";
+const GROUP_FEMALE = "group-female";
+
+const ENV = {
+  SUPABASE_URL: "http://localhost:54321",
+  SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+};
+
+function authRoute(): FetchRoute {
+  return {
+    matcher: "/auth/v1/user",
+    handler: () => jsonResponse({ id: TEST_VOTER_ID, email: "voter@test.com" }),
+  };
+}
+
+// Event with vote period active
+function eventRoute(overrides?: {
+  vote_start_at?: string | null;
+  vote_end_at?: string | null;
+  status?: string;
+}): FetchRoute {
+  return {
+    matcher: (req) => req.url.includes("/rest/v1/events") && req.url.includes("select="),
+    handler: () =>
+      jsonResponse({
+        id: TEST_EVENT_ID,
+        status: overrides?.status ?? "ongoing",
+        vote_start_at: overrides?.vote_start_at !== undefined
+          ? overrides.vote_start_at
+          : "2026-01-01T00:00:00Z",
+        vote_end_at: overrides?.vote_end_at !== undefined
+          ? overrides.vote_end_at
+          : "2099-12-31T23:59:59Z",
+      }),
+  };
+}
+
+// Voter participant lookup
+function voterParticipantRoute(overrides?: { status?: string }): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("event_participants") &&
+      req.url.includes(TEST_VOTER_ID) &&
+      !req.url.includes(TEST_CANDIDATE_ID),
+    handler: () =>
+      jsonResponse({
+        status: overrides?.status ?? "checked_in",
+        ticket_id: TEST_TICKET_VOTER,
+      }),
+  };
+}
+
+// Candidate participant lookup
+function candidateParticipantRoute(overrides?: { status?: string }): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("event_participants") &&
+      req.url.includes(TEST_CANDIDATE_ID),
+    handler: () =>
+      jsonResponse({
+        status: overrides?.status ?? "checked_in",
+        ticket_id: TEST_TICKET_CANDIDATE,
+      }),
+  };
+}
+
+// Voter ticket
+function voterTicketRoute(groupIds: string[] = [GROUP_MALE]): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/tickets") && req.url.includes(TEST_TICKET_VOTER),
+    handler: () => jsonResponse({ target_entry_group_ids: groupIds }),
+  };
+}
+
+// Candidate ticket
+function candidateTicketRoute(groupIds: string[] = [GROUP_FEMALE]): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/tickets") && req.url.includes(TEST_TICKET_CANDIDATE),
+    handler: () => jsonResponse({ target_entry_group_ids: groupIds }),
+  };
+}
+
+// Match rules
+function matchRulesRoute(rules: Array<{ vote_count: number }> = [{ vote_count: 3 }]): FetchRoute {
+  return {
+    matcher: (req) => req.url.includes("match_rules"),
+    handler: () => jsonResponse(rules),
+  };
+}
+
+// Current vote count (Supabase count: "exact", head: true → HEAD request)
+function voteCountRoute(count = 0): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("match_votes") &&
+      req.url.includes("select=") &&
+      (req.method === "GET" || req.method === "HEAD"),
+    handler: () =>
+      new Response(null, {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "content-range": `0-${Math.max(0, count - 1)}/${count}`,
+        },
+      }),
+  };
+}
+
+// Insert vote
+function insertVoteRoute(success = true): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("match_votes") && req.method === "POST",
+    handler: () =>
+      success
+        ? jsonResponse({ event_id: TEST_EVENT_ID })
+        : jsonResponse(
+            { message: "duplicate key", code: "23505" },
+            { status: 409 },
+          ),
+  };
+}
+
+// All routes for happy path
+function happyPathRoutes(): FetchRoute[] {
+  return [
+    authRoute(),
+    eventRoute(),
+    voterParticipantRoute(),
+    candidateParticipantRoute(),
+    voterTicketRoute(),
+    candidateTicketRoute(),
+    matchRulesRoute(),
+    voteCountRoute(0),
+    insertVoteRoute(),
+  ];
+}
+
+// ─── CORS preflight ───
+Deno.test({
+  name: "handles OPTIONS preflight request",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          new Request("http://localhost", { method: "OPTIONS" }),
+        );
+        assertEquals(res.status, 200);
+      });
+    });
+  },
+});
+
+// ─── 401: no auth ───
+Deno.test({
+  name: "returns 401 without authorization",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: "/auth/v1/user",
+        handler: () => jsonResponse({ error: "invalid" }, { status: 401 }),
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = new Request("http://localhost", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ event_id: TEST_EVENT_ID, candidate_id: TEST_CANDIDATE_ID }),
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 401);
+      });
+    });
+  },
+});
+
+// ─── 400: missing event_id ───
+Deno.test({
+  name: "returns 400 for missing event_id",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", { candidate_id: TEST_CANDIDATE_ID }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing event_id");
+      });
+    });
+  },
+});
+
+// ─── 400: missing candidate_id ───
+Deno.test({
+  name: "returns 400 for missing candidate_id",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", { event_id: TEST_EVENT_ID }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing candidate_id");
+      });
+    });
+  },
+});
+
+// ─── 400: self vote ───
+Deno.test({
+  name: "returns 400 for self-vote",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            event_id: TEST_EVENT_ID,
+            candidate_id: TEST_VOTER_ID, // self
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "자기 자신에게 투표할 수 없습니다");
+      });
+    });
+  },
+});
+
+// ─── 404: event not found ───
+Deno.test({
+  name: "returns 404 for non-existent event",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      {
+        matcher: (req) => req.url.includes("/rest/v1/events"),
+        handler: () => jsonResponse(null),
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            event_id: "nonexistent",
+            candidate_id: TEST_CANDIDATE_ID,
+          }),
+        );
+        assertEquals(res.status, 404);
+        const body = await readJson(res);
+        assertEquals(body.error, "Event not found");
+      });
+    });
+  },
+});
+
+// ─── 400: vote_start_at is null (voting not enabled) ───
+Deno.test({
+  name: "returns 400 when vote_start_at is null",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute({ vote_start_at: null }),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            event_id: TEST_EVENT_ID,
+            candidate_id: TEST_CANDIDATE_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "투표 기능이 활성화되지 않았습니다");
+      });
+    });
+  },
+});
+
+// ─── 400: vote not yet started ───
+Deno.test({
+  name: "returns 400 when vote has not started yet",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute({ vote_start_at: "2099-12-31T00:00:00Z" }),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            event_id: TEST_EVENT_ID,
+            candidate_id: TEST_CANDIDATE_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "투표가 아직 시작되지 않았습니다");
+      });
+    });
+  },
+});
+
+// ─── 400: vote deadline passed ───
+Deno.test({
+  name: "returns 400 when vote deadline has passed",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute({
+        vote_start_at: "2020-01-01T00:00:00Z",
+        vote_end_at: "2020-12-31T23:59:59Z",
+      }),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            event_id: TEST_EVENT_ID,
+            candidate_id: TEST_CANDIDATE_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "투표가 마감되었습니다");
+      });
+    });
+  },
+});
+
+// ─── 400: voter not participant ───
+Deno.test({
+  name: "returns 400 when voter is not a participant",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute(),
+      {
+        matcher: (req) =>
+          req.url.includes("event_participants") && req.url.includes(TEST_VOTER_ID),
+        handler: () => jsonResponse(null),
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            event_id: TEST_EVENT_ID,
+            candidate_id: TEST_CANDIDATE_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "이벤트 참가자가 아닙니다");
+      });
+    });
+  },
+});
+
+// ─── 400: voter not checked_in (ticket_issued) ───
+Deno.test({
+  name: "returns 400 when voter status is ticket_issued",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute(),
+      voterParticipantRoute({ status: "ticket_issued" }),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            event_id: TEST_EVENT_ID,
+            candidate_id: TEST_CANDIDATE_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "체크인 후 투표 가능합니다");
+      });
+    });
+  },
+});
+
+// ─── 400: voter is no_show ───
+Deno.test({
+  name: "returns 400 when voter status is no_show",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute(),
+      voterParticipantRoute({ status: "no_show" }),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            event_id: TEST_EVENT_ID,
+            candidate_id: TEST_CANDIDATE_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "체크인 후 투표 가능합니다");
+      });
+    });
+  },
+});
+
+// ─── 400: candidate not checked_in ───
+Deno.test({
+  name: "returns 400 when candidate is not checked_in",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute(),
+      voterParticipantRoute(),
+      candidateParticipantRoute({ status: "ticket_issued" }),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            event_id: TEST_EVENT_ID,
+            candidate_id: TEST_CANDIDATE_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "후보자가 체크인하지 않았습니다");
+      });
+    });
+  },
+});
+
+// ─── 400: match_rules에 없는 그룹간 투표 ───
+Deno.test({
+  name: "returns 400 when groups are not in match_rules",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute(),
+      voterParticipantRoute(),
+      candidateParticipantRoute(),
+      voterTicketRoute(),
+      candidateTicketRoute(),
+      matchRulesRoute([]), // no matching rules
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            event_id: TEST_EVENT_ID,
+            candidate_id: TEST_CANDIDATE_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "매칭 대상이 아닙니다");
+      });
+    });
+  },
+});
+
+// ─── 400: vote count exceeded ───
+Deno.test({
+  name: "returns 400 when vote count is exceeded",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute(),
+      voterParticipantRoute(),
+      candidateParticipantRoute(),
+      voterTicketRoute(),
+      candidateTicketRoute(),
+      matchRulesRoute([{ vote_count: 2 }]),
+      voteCountRoute(2), // already used all votes
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            event_id: TEST_EVENT_ID,
+            candidate_id: TEST_CANDIDATE_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "투표 수를 초과했습니다");
+      });
+    });
+  },
+});
+
+// ─── 200: happy path — successful vote ───
+Deno.test({
+  name: "returns 200 for successful vote",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock(happyPathRoutes());
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            event_id: TEST_EVENT_ID,
+            candidate_id: TEST_CANDIDATE_ID,
+          }),
+        );
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+      });
+    });
+  },
+});
+
+// ─── 400: duplicate vote (DB PK violation) ───
+Deno.test({
+  name: "returns 400 for duplicate vote",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const routes = happyPathRoutes().filter(
+      (r) => typeof r.matcher !== "function" || !("" + r.matcher).includes("POST"),
+    );
+    // Replace insert route with duplicate error
+    const routesWithDupError = [
+      ...routes.slice(0, -1), // remove last (insertVoteRoute)
+      {
+        matcher: (req: Request) =>
+          req.url.includes("match_votes") && req.method === "POST",
+        handler: () =>
+          jsonResponse(
+            { message: "duplicate key value violates unique constraint", code: "23505" },
+            { status: 409 },
+          ),
+      } as FetchRoute,
+    ];
+    const { fetchMock } = createFetchMock(routesWithDupError);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            event_id: TEST_EVENT_ID,
+            candidate_id: TEST_CANDIDATE_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "이미 투표한 후보입니다");
+      });
+    });
+  },
+});

--- a/supabase/functions/user-cast-vote/user_cast_vote_test.ts
+++ b/supabase/functions/user-cast-vote/user_cast_vote_test.ts
@@ -34,6 +34,7 @@ function authRoute(): FetchRoute {
 function eventRoute(overrides?: {
   vote_start_at?: string | null;
   vote_end_at?: string | null;
+  end_time?: string | null;
   status?: string;
 }): FetchRoute {
   return {
@@ -48,6 +49,9 @@ function eventRoute(overrides?: {
         vote_end_at: overrides?.vote_end_at !== undefined
           ? overrides.vote_end_at
           : "2099-12-31T23:59:59Z",
+        end_time: overrides?.end_time !== undefined
+          ? overrides.end_time
+          : null,
       }),
   };
 }
@@ -107,35 +111,16 @@ function matchRulesRoute(rules: Array<{ vote_count: number }> = [{ vote_count: 3
   };
 }
 
-// Current vote count (Supabase count: "exact", head: true → HEAD request)
-function voteCountRoute(count = 0): FetchRoute {
+// RPC cast_match_vote
+function rpcCastVoteRoute(success = true, errorMessage?: string): FetchRoute {
   return {
-    matcher: (req) =>
-      req.url.includes("match_votes") &&
-      req.url.includes("select=") &&
-      (req.method === "GET" || req.method === "HEAD"),
-    handler: () =>
-      new Response(null, {
-        status: 200,
-        headers: {
-          "Content-Type": "application/json",
-          "content-range": `0-${Math.max(0, count - 1)}/${count}`,
-        },
-      }),
-  };
-}
-
-// Insert vote
-function insertVoteRoute(success = true): FetchRoute {
-  return {
-    matcher: (req) =>
-      req.url.includes("match_votes") && req.method === "POST",
+    matcher: (req) => req.url.includes("/rest/v1/rpc/cast_match_vote"),
     handler: () =>
       success
-        ? jsonResponse({ event_id: TEST_EVENT_ID })
+        ? jsonResponse(null)
         : jsonResponse(
-            { message: "duplicate key", code: "23505" },
-            { status: 409 },
+            { message: errorMessage ?? "rpc error" },
+            { status: 400 },
           ),
   };
 }
@@ -150,8 +135,7 @@ function happyPathRoutes(): FetchRoute[] {
     voterTicketRoute(),
     candidateTicketRoute(),
     matchRulesRoute(),
-    voteCountRoute(0),
-    insertVoteRoute(),
+    rpcCastVoteRoute(),
   ];
 }
 
@@ -390,6 +374,38 @@ Deno.test({
   },
 });
 
+// ─── 400: end_time fallback when vote_end_at is null ───
+Deno.test({
+  name: "returns 400 when vote_end_at is null but end_time has passed",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute({
+        vote_start_at: "2020-01-01T00:00:00Z",
+        vote_end_at: null,
+        end_time: "2020-12-31T23:59:59Z",
+      }),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            event_id: TEST_EVENT_ID,
+            candidate_id: TEST_CANDIDATE_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "투표가 마감되었습니다");
+      });
+    });
+  },
+});
+
 // ─── 400: voter not participant ───
 Deno.test({
   name: "returns 400 when voter is not a participant",
@@ -511,6 +527,38 @@ Deno.test({
   },
 });
 
+// ─── 400: empty group IDs (fail-closed) ───
+Deno.test({
+  name: "returns 400 when voter has no group IDs",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute(),
+      voterParticipantRoute(),
+      candidateParticipantRoute(),
+      voterTicketRoute([]), // empty groups
+      candidateTicketRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            event_id: TEST_EVENT_ID,
+            candidate_id: TEST_CANDIDATE_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "그룹 정보를 확인할 수 없습니다");
+      });
+    });
+  },
+});
+
 // ─── 400: match_rules에 없는 그룹간 투표 ───
 Deno.test({
   name: "returns 400 when groups are not in match_rules",
@@ -544,7 +592,7 @@ Deno.test({
   },
 });
 
-// ─── 400: vote count exceeded ───
+// ─── 400: vote count exceeded (via RPC) ───
 Deno.test({
   name: "returns 400 when vote count is exceeded",
   sanitizeResources: false,
@@ -559,7 +607,7 @@ Deno.test({
       voterTicketRoute(),
       candidateTicketRoute(),
       matchRulesRoute([{ vote_count: 2 }]),
-      voteCountRoute(2), // already used all votes
+      rpcCastVoteRoute(false, "투표 수를 초과했습니다"),
     ]);
 
     await withEnv(ENV, async () => {
@@ -603,30 +651,23 @@ Deno.test({
   },
 });
 
-// ─── 400: duplicate vote (DB PK violation) ───
+// ─── 400: duplicate vote (via RPC) ───
 Deno.test({
   name: "returns 400 for duplicate vote",
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-    const routes = happyPathRoutes().filter(
-      (r) => typeof r.matcher !== "function" || !("" + r.matcher).includes("POST"),
-    );
-    // Replace insert route with duplicate error
-    const routesWithDupError = [
-      ...routes.slice(0, -1), // remove last (insertVoteRoute)
-      {
-        matcher: (req: Request) =>
-          req.url.includes("match_votes") && req.method === "POST",
-        handler: () =>
-          jsonResponse(
-            { message: "duplicate key value violates unique constraint", code: "23505" },
-            { status: 409 },
-          ),
-      } as FetchRoute,
-    ];
-    const { fetchMock } = createFetchMock(routesWithDupError);
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute(),
+      voterParticipantRoute(),
+      candidateParticipantRoute(),
+      voterTicketRoute(),
+      candidateTicketRoute(),
+      matchRulesRoute(),
+      rpcCastVoteRoute(false, "이미 투표한 후보입니다"),
+    ]);
 
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {

--- a/supabase/migrations/20260322000008_add_match_result_enum.sql
+++ b/supabase/migrations/20260322000008_add_match_result_enum.sql
@@ -1,0 +1,4 @@
+-- Issue #306: event_type_name enum에 match_result 값 추가
+-- ALTER TYPE ADD VALUE는 별도 트랜잭션에서 실행해야 하므로 분리된 migration
+
+ALTER TYPE public.event_type_name ADD VALUE IF NOT EXISTS 'match_result';

--- a/supabase/migrations/20260323000001_match_notification_and_vote_cleanup_cron.sql
+++ b/supabase/migrations/20260323000001_match_notification_and_vote_cleanup_cron.sql
@@ -63,10 +63,9 @@ ALTER TABLE public.match_pairs
   ADD COLUMN notification_sent boolean NOT NULL DEFAULT false;
 
 -- ============================================================
--- 3. event_type_name enum에 match_result 추가 + event_routes 등록
+-- 3. event_routes에 match_result 이벤트 타입 등록
+-- (enum 값은 20260322000008에서 별도 트랜잭션으로 추가됨)
 -- ============================================================
-
-ALTER TYPE public.event_type_name ADD VALUE IF NOT EXISTS 'match_result';
 
 INSERT INTO public.event_routes (event_type, target_queue, is_active) VALUES
   ('match_result', 'q_notifications', true)

--- a/supabase/migrations/20260323000001_match_notification_and_vote_cleanup_cron.sql
+++ b/supabase/migrations/20260323000001_match_notification_and_vote_cleanup_cron.sql
@@ -63,8 +63,10 @@ ALTER TABLE public.match_pairs
   ADD COLUMN notification_sent boolean NOT NULL DEFAULT false;
 
 -- ============================================================
--- 3. event_routes에 match_result 이벤트 타입 추가
+-- 3. event_type_name enum에 match_result 추가 + event_routes 등록
 -- ============================================================
+
+ALTER TYPE public.event_type_name ADD VALUE IF NOT EXISTS 'match_result';
 
 INSERT INTO public.event_routes (event_type, target_queue, is_active) VALUES
   ('match_result', 'q_notifications', true)

--- a/supabase/migrations/20260323000001_match_notification_and_vote_cleanup_cron.sql
+++ b/supabase/migrations/20260323000001_match_notification_and_vote_cleanup_cron.sql
@@ -94,8 +94,8 @@ BEGIN
     FROM public.match_pairs mp
     JOIN public.events e ON e.id = mp.event_id
     WHERE mp.notification_sent = false
-      AND e.vote_end_at IS NOT NULL
-      AND e.vote_end_at < now() - interval '1 day'
+      AND COALESCE(e.vote_end_at, e.end_time) IS NOT NULL
+      AND COALESCE(e.vote_end_at, e.end_time) < now() - interval '1 day'
     FOR UPDATE OF mp SKIP LOCKED
   LOOP
     -- 양쪽 유저에게 알림 발송
@@ -137,8 +137,8 @@ BEGIN
   DELETE FROM public.match_votes
   WHERE event_id IN (
     SELECT id FROM public.events
-    WHERE vote_end_at IS NOT NULL
-      AND vote_end_at < now() - interval '30 days'
+    WHERE COALESCE(vote_end_at, end_time) IS NOT NULL
+      AND COALESCE(vote_end_at, end_time) < now() - interval '30 days'
   );
 
   GET DIAGNOSTICS deleted_count = ROW_COUNT;
@@ -160,7 +160,7 @@ SELECT cron.schedule(
   $$SELECT public.notify_match_results()$$
 );
 
--- 투표 데이터 정리: 매일 03:00 KST (18:00 UTC 전날)
+-- 투표 데이터 정리: 매일 03:00 KST (전날 18:00 UTC)
 SELECT cron.schedule(
   'cleanup-expired-match-votes',
   '0 18 * * *',

--- a/supabase/migrations/20260323000001_match_notification_and_vote_cleanup_cron.sql
+++ b/supabase/migrations/20260323000001_match_notification_and_vote_cleanup_cron.sql
@@ -1,0 +1,112 @@
+-- Issue #306: 매칭 결과 알림 + 투표 데이터 정리 크론잡
+
+SET search_path = public, extensions, pgmq, temp;
+
+-- ============================================================
+-- 1. match_pairs에 알림 발송 여부 플래그 추가
+-- ============================================================
+
+ALTER TABLE public.match_pairs
+  ADD COLUMN notification_sent boolean NOT NULL DEFAULT false;
+
+-- ============================================================
+-- 2. event_routes에 match_result 이벤트 타입 추가
+-- ============================================================
+
+INSERT INTO public.event_routes (event_type, target_queue, is_active) VALUES
+  ('match_result', 'q_notifications', true)
+ON CONFLICT (event_type, target_queue) DO UPDATE SET is_active = EXCLUDED.is_active;
+
+-- ============================================================
+-- 3. 매칭 결과 알림 함수
+-- 이벤트 종료 + 1일 후, 아직 알림 미발송인 match_pairs 처리
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.notify_match_results()
+RETURNS void
+SET search_path = public, extensions, pgmq, temp
+AS $$
+DECLARE
+  pair RECORD;
+BEGIN
+  FOR pair IN
+    SELECT
+      mp.id AS match_pair_id,
+      mp.event_id,
+      mp.user_lower_id,
+      mp.user_higher_id,
+      e.title AS event_title
+    FROM public.match_pairs mp
+    JOIN public.events e ON e.id = mp.event_id
+    WHERE mp.notification_sent = false
+      AND e.vote_end_at IS NOT NULL
+      AND e.vote_end_at < now() - interval '1 day'
+  LOOP
+    -- 양쪽 유저에게 알림 발송
+    PERFORM public.fan_out_event('match_result', jsonb_build_object(
+      'user_id', pair.user_lower_id,
+      'event_id', pair.event_id,
+      'event_title', COALESCE(pair.event_title, '이벤트')
+    ));
+
+    PERFORM public.fan_out_event('match_result', jsonb_build_object(
+      'user_id', pair.user_higher_id,
+      'event_id', pair.event_id,
+      'event_title', COALESCE(pair.event_title, '이벤트')
+    ));
+
+    -- 알림 발송 플래그 설정
+    UPDATE public.match_pairs
+    SET notification_sent = true
+    WHERE id = pair.match_pair_id;
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+REVOKE EXECUTE ON FUNCTION public.notify_match_results() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.notify_match_results() TO service_role;
+
+-- ============================================================
+-- 4. 투표 데이터 정리 함수
+-- 이벤트 완료 + 30일 후 match_votes 삭제 (match_pairs는 영구 보관)
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.cleanup_expired_match_votes()
+RETURNS integer
+SET search_path = public, extensions
+AS $$
+DECLARE
+  deleted_count integer;
+BEGIN
+  DELETE FROM public.match_votes
+  WHERE event_id IN (
+    SELECT id FROM public.events
+    WHERE vote_end_at IS NOT NULL
+      AND vote_end_at < now() - interval '30 days'
+  );
+
+  GET DIAGNOSTICS deleted_count = ROW_COUNT;
+  RETURN deleted_count;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+REVOKE EXECUTE ON FUNCTION public.cleanup_expired_match_votes() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.cleanup_expired_match_votes() TO service_role;
+
+-- ============================================================
+-- 5. pg_cron 등록
+-- ============================================================
+
+-- 매칭 알림: 매일 09:00 KST (00:00 UTC)
+SELECT cron.schedule(
+  'notify-match-results',
+  '0 0 * * *',
+  $$SELECT public.notify_match_results()$$
+);
+
+-- 투표 데이터 정리: 매일 03:00 KST (18:00 UTC 전날)
+SELECT cron.schedule(
+  'cleanup-expired-match-votes',
+  '0 18 * * *',
+  $$SELECT public.cleanup_expired_match_votes()$$
+);

--- a/supabase/migrations/20260323000001_match_notification_and_vote_cleanup_cron.sql
+++ b/supabase/migrations/20260323000001_match_notification_and_vote_cleanup_cron.sql
@@ -1,16 +1,69 @@
--- Issue #306: 매칭 결과 알림 + 투표 데이터 정리 크론잡
+-- Issue #306: 원자적 투표 RPC + 매칭 결과 알림 + 투표 데이터 정리 크론잡
 
 SET search_path = public, extensions, pgmq, temp;
 
 -- ============================================================
--- 1. match_pairs에 알림 발송 여부 플래그 추가
+-- 1. 원자적 투표 RPC (race condition 방지)
+-- advisory lock으로 동일 voter의 동시 투표를 직렬화
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.cast_match_vote(
+  p_event_id uuid,
+  p_voter_id uuid,
+  p_candidate_id uuid,
+  p_max_vote_count integer
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  current_count integer;
+BEGIN
+  -- Advisory lock on voter+event to serialize concurrent votes
+  PERFORM pg_advisory_xact_lock(
+    hashtext(p_event_id::text || ':' || p_voter_id::text)
+  );
+
+  -- Check current vote count
+  SELECT count(*) INTO current_count
+  FROM public.match_votes
+  WHERE event_id = p_event_id AND voter_id = p_voter_id;
+
+  IF current_count >= p_max_vote_count THEN
+    RAISE EXCEPTION '투표 수를 초과했습니다'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  -- Check duplicate vote
+  IF EXISTS (
+    SELECT 1 FROM public.match_votes
+    WHERE event_id = p_event_id
+      AND voter_id = p_voter_id
+      AND candidate_id = p_candidate_id
+  ) THEN
+    RAISE EXCEPTION '이미 투표한 후보입니다'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Insert vote (trigger handles match_pairs creation)
+  INSERT INTO public.match_votes (event_id, voter_id, candidate_id)
+  VALUES (p_event_id, p_voter_id, p_candidate_id);
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.cast_match_vote(uuid, uuid, uuid, integer) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.cast_match_vote(uuid, uuid, uuid, integer) TO service_role;
+
+-- ============================================================
+-- 2. match_pairs에 알림 발송 여부 플래그 추가
 -- ============================================================
 
 ALTER TABLE public.match_pairs
   ADD COLUMN notification_sent boolean NOT NULL DEFAULT false;
 
 -- ============================================================
--- 2. event_routes에 match_result 이벤트 타입 추가
+-- 3. event_routes에 match_result 이벤트 타입 추가
 -- ============================================================
 
 INSERT INTO public.event_routes (event_type, target_queue, is_active) VALUES
@@ -18,7 +71,7 @@ INSERT INTO public.event_routes (event_type, target_queue, is_active) VALUES
 ON CONFLICT (event_type, target_queue) DO UPDATE SET is_active = EXCLUDED.is_active;
 
 -- ============================================================
--- 3. 매칭 결과 알림 함수
+-- 4. 매칭 결과 알림 함수 (FOR UPDATE SKIP LOCKED으로 중복 방지)
 -- 이벤트 종료 + 1일 후, 아직 알림 미발송인 match_pairs 처리
 -- ============================================================
 
@@ -41,6 +94,7 @@ BEGIN
     WHERE mp.notification_sent = false
       AND e.vote_end_at IS NOT NULL
       AND e.vote_end_at < now() - interval '1 day'
+    FOR UPDATE OF mp SKIP LOCKED
   LOOP
     -- 양쪽 유저에게 알림 발송
     PERFORM public.fan_out_event('match_result', jsonb_build_object(
@@ -67,7 +121,7 @@ REVOKE EXECUTE ON FUNCTION public.notify_match_results() FROM PUBLIC, anon, auth
 GRANT EXECUTE ON FUNCTION public.notify_match_results() TO service_role;
 
 -- ============================================================
--- 4. 투표 데이터 정리 함수
+-- 5. 투표 데이터 정리 함수
 -- 이벤트 완료 + 30일 후 match_votes 삭제 (match_pairs는 영구 보관)
 -- ============================================================
 
@@ -94,7 +148,7 @@ REVOKE EXECUTE ON FUNCTION public.cleanup_expired_match_votes() FROM PUBLIC, ano
 GRANT EXECUTE ON FUNCTION public.cleanup_expired_match_votes() TO service_role;
 
 -- ============================================================
--- 5. pg_cron 등록
+-- 6. pg_cron 등록
 -- ============================================================
 
 -- 매칭 알림: 매일 09:00 KST (00:00 UTC)

--- a/supabase/tests/database/14_pipeline_v2_schema_test.sql
+++ b/supabase/tests/database/14_pipeline_v2_schema_test.sql
@@ -1,6 +1,6 @@
 -- Tests for 2-tier queue architecture schema (event_type_name enum, event_routes, produce_event, fan_out_event)
 BEGIN;
-SELECT plan(16);
+SELECT plan(17);
 
 SELECT tests.authenticate_as_service_role();
 
@@ -8,11 +8,11 @@ SELECT tests.authenticate_as_service_role();
 -- PART 1: event_type_name enum validation
 -- ============================================================
 
--- Test 1: event_type_name enum exists and has 12 values
--- (9 original + 3 settlement: settlement_ready, settlement_completed, settlement_failed)
+-- Test 1: event_type_name enum exists and has 13 values
+-- (9 original + 3 settlement + 1 matching: match_result)
 SELECT ok(
-  (SELECT count(*) FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid WHERE pg_type.typname = 'event_type_name') = 12,
-  'event_type_name enum should have 12 values'
+  (SELECT count(*) FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid WHERE pg_type.typname = 'event_type_name') = 13,
+  'event_type_name enum should have 13 values'
 );
 
 -- Test 2-10: individual enum values exist
@@ -86,6 +86,14 @@ SELECT ok(
     WHERE pg_type.typname = 'event_type_name' AND enumlabel = 'event_reminder'
   ),
   'event_type_name should have event_reminder'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_enum JOIN pg_type ON pg_enum.enumtypid = pg_type.oid
+    WHERE pg_type.typname = 'event_type_name' AND enumlabel = 'match_result'
+  ),
+  'event_type_name should have match_result'
 );
 
 -- ============================================================


### PR DESCRIPTION
## Summary

- **user-cast-vote Edge Function**: 체크인 상태, 그룹 매칭 규칙, 투표 수 제한, 투표 기간 검증 후 `match_votes` INSERT. 자기 투표/중복 투표는 DB 제약 조건이 추가 방어
- **Flutter RLS write → EF 전환**: `castVote()` 가 직접 INSERT 대신 `user-cast-vote` EF 호출
- **투표 UI 개선**: 잔여 투표 수 표시 (`남은 투표: 2/3`), 투표 완료 후보 체크 표시 + 비활성화, 전체 투표 완료 시 완료 상태
- **매칭 알림 크론잡**: `vote_end_at` + 1일 후 `match_pairs` 양쪽 유저에게 `match_result` 알림 발송 (매일 09:00 KST)
- **투표 데이터 정리 크론잡**: `vote_end_at` + 30일 후 `match_votes` 삭제, `match_pairs`는 영구 보관 (매일 03:00 KST)
- **EF 단위 테스트 17개**: 인증, 이벤트 검증, 투표 기간, 체크인 상태, 그룹 규칙, 투표 수 제한, 성공, 중복 투표 전부 커버

## Test plan

- [x] EF 단위 테스트 17/17 통과 (`deno test --allow-all functions/user-cast-vote/`)
- [x] Flutter analyze 통과 (info only, no errors/warnings)
- [x] 기존 matching 테스트 8/8 통과
- [ ] CI `ci-result` 통과 확인
- [ ] CodeRabbit 리뷰 대응

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)