### PR TITLE
fix(ci): add retry for Vercel alias assignment

### DIFF
--- a/.github/actions/deploy-flutter-app/action.yml
+++ b/.github/actions/deploy-flutter-app/action.yml
@@ -92,7 +92,18 @@ runs:
           DEPLOY_URL=$(npx vercel deploy $COMMON_ARGS)
           echo "✅ Deployed to: $DEPLOY_URL"
           
-          # Assign the custom alias to the deployment
+          # Fix #383: retry alias with backoff — certificate provisioning can fail transiently
           echo "🔗 Assigning alias: ${{ inputs.dev-domain-alias }}"
-          npx vercel alias set "$DEPLOY_URL" "${{ inputs.dev-domain-alias }}" --token=$VERCEL_TOKEN --scope=$VERCEL_ORG_ID
+          for attempt in 1 2 3; do
+            if npx vercel alias set "$DEPLOY_URL" "${{ inputs.dev-domain-alias }}" --token=$VERCEL_TOKEN --scope=$VERCEL_ORG_ID; then
+              echo "✅ Alias assigned successfully"
+              break
+            fi
+            if [[ $attempt -lt 3 ]]; then
+              echo "⚠️ Alias attempt $attempt failed, retrying in $((attempt * 10))s..."
+              sleep $((attempt * 10))
+            else
+              echo "::warning::Alias assignment failed after 3 attempts. Deployment succeeded at: $DEPLOY_URL"
+            fi
+          done
         fi

--- a/.github/actions/deploy-nextjs-app/action.yml
+++ b/.github/actions/deploy-nextjs-app/action.yml
@@ -36,6 +36,18 @@ runs:
           echo "✅ Deployed to: $DEPLOY_URL"
           if [[ -n "${{ inputs.dev-domain-alias }}" ]]; then
             echo "🔗 Assigning alias: ${{ inputs.dev-domain-alias }}"
-            npx --yes vercel@latest alias set "$DEPLOY_URL" "${{ inputs.dev-domain-alias }}" --token=$VERCEL_TOKEN --scope=$VERCEL_ORG_ID
+            # Fix #383: retry alias with backoff — certificate provisioning can fail transiently
+            for attempt in 1 2 3; do
+              if npx --yes vercel@latest alias set "$DEPLOY_URL" "${{ inputs.dev-domain-alias }}" --token=$VERCEL_TOKEN --scope=$VERCEL_ORG_ID; then
+                echo "✅ Alias assigned successfully"
+                break
+              fi
+              if [[ $attempt -lt 3 ]]; then
+                echo "⚠️ Alias attempt $attempt failed, retrying in $((attempt * 10))s..."
+                sleep $((attempt * 10))
+              else
+                echo "::warning::Alias assignment failed after 3 attempts. Deployment succeeded at: $DEPLOY_URL"
+              fi
+            done
           fi
         fi


### PR DESCRIPTION
## Summary
- Vercel `alias set` fails transiently due to certificate provisioning errors ("Error: Response Error"), crashing the entire deploy job even though the deployment itself succeeded
- Added retry logic (3 attempts with exponential backoff: 10s, 20s) for the alias step in both `deploy-nextjs-app` and `deploy-flutter-app` composite actions
- If all retries fail, emits a GitHub Actions warning instead of failing the job

Closes #383

## Test plan
- [ ] Trigger a Vercel deploy workflow and verify alias assignment succeeds
- [ ] Verify that if alias fails, the job still completes with a warning (not a failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)