### PR TITLE
feat(verification): partner-manage-verification EF 구현 (인증 항목 CRUD)

### DIFF
--- a/shared/packages/minglit_kit/lib/src/data/repositories/verification_command_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/verification_command_repository.dart
@@ -1,34 +1,73 @@
 part of 'verification_repository.dart';
 
 mixin _VerificationCommandRepository on _SupabaseVerificationContext {
+  // Fix #308: createVerification via EF (partner_id 서버 검증)
   Future<Verification> createVerification(Verification verification) async {
     Log.d('createVerification called | name: ${verification.displayName}');
     try {
-      final json = verification.toDbJson();
+      final response = await supabaseClient.functions.invoke(
+        'partner-manage-verification',
+        body: {
+          'action': 'create',
+          'partner_id': verification.partnerId,
+          'category': verification.category.name,
+          'internal_name': verification.internalName,
+          'display_name': verification.displayName,
+          if (verification.description != null)
+            'description': verification.description,
+          if (verification.iconKey != null) 'icon_key': verification.iconKey,
+          'form_schema':
+              verification.formSchema.map((f) => f.toJson()).toList(),
+        },
+      );
 
-      final res = await supabaseClient
-          .from('verifications')
-          .insert(json)
-          .select()
-          .single();
-      final result = Verification.fromJson(res);
-      Log.d('createVerification success | id: ${result.id}');
-      return result;
+      if (response.status != 200) {
+        final respData = response.data;
+        final errorMsg = respData is Map
+            ? (respData['error'] as String?) ??
+                'Failed to create verification'
+            : 'Failed to create verification';
+        throw MinglitUserException(errorMsg);
+      }
+
+      final data = response.data as Map<String, dynamic>;
+      final id = data['id'] as String;
+      Log.d('createVerification success | id: $id');
+      return verification.copyWith(id: id);
     } catch (e, st) {
       Log.e('❌ [VerificationRepo] createVerification Error', e, st);
       rethrow;
     }
   }
 
+  // Fix #308: updateVerification via EF (partner_id 변경 불가, 서버 검증)
   Future<void> updateVerification(Verification verification) async {
     Log.d('updateVerification called | id: ${verification.id}');
     try {
-      final json = verification.toDbJson()..remove('partner_id');
+      final response = await supabaseClient.functions.invoke(
+        'partner-manage-verification',
+        body: {
+          'action': 'update',
+          'verification_id': verification.id,
+          'category': verification.category.name,
+          'internal_name': verification.internalName,
+          'display_name': verification.displayName,
+          'description': verification.description,
+          'icon_key': verification.iconKey,
+          'form_schema':
+              verification.formSchema.map((f) => f.toJson()).toList(),
+          'is_active': verification.isActive,
+        },
+      );
 
-      await supabaseClient
-          .from('verifications')
-          .update(json)
-          .eq('id', verification.id);
+      if (response.status != 200) {
+        final respData = response.data;
+        final errorMsg = respData is Map
+            ? (respData['error'] as String?) ??
+                'Failed to update verification'
+            : 'Failed to update verification';
+        throw MinglitUserException(errorMsg);
+      }
       Log.d('updateVerification success');
     } catch (e, st) {
       Log.e('❌ [VerificationRepo] updateVerification Error', e, st);
@@ -36,13 +75,27 @@ mixin _VerificationCommandRepository on _SupabaseVerificationContext {
     }
   }
 
+  // Fix #308: deleteVerification via EF (soft delete)
   Future<void> deleteVerification(String verificationId) async {
     Log.d('deleteVerification called | verificationId: $verificationId');
     try {
-      await supabaseClient
-          .from('verifications')
-          .update({'is_active': false})
-          .eq('id', verificationId);
+      final response = await supabaseClient.functions.invoke(
+        'partner-manage-verification',
+        body: {
+          'action': 'update',
+          'verification_id': verificationId,
+          'is_active': false,
+        },
+      );
+
+      if (response.status != 200) {
+        final respData = response.data;
+        final errorMsg = respData is Map
+            ? (respData['error'] as String?) ??
+                'Failed to delete verification'
+            : 'Failed to delete verification';
+        throw MinglitUserException(errorMsg);
+      }
       Log.d('deleteVerification success');
     } catch (e, st) {
       Log.e('❌ [VerificationRepo] deleteVerification Error', e, st);
@@ -50,13 +103,27 @@ mixin _VerificationCommandRepository on _SupabaseVerificationContext {
     }
   }
 
+  // Fix #308: restoreVerification via EF (is_active = true)
   Future<void> restoreVerification(String verificationId) async {
     Log.d('restoreVerification called | verificationId: $verificationId');
     try {
-      await supabaseClient
-          .from('verifications')
-          .update({'is_active': true})
-          .eq('id', verificationId);
+      final response = await supabaseClient.functions.invoke(
+        'partner-manage-verification',
+        body: {
+          'action': 'update',
+          'verification_id': verificationId,
+          'is_active': true,
+        },
+      );
+
+      if (response.status != 200) {
+        final respData = response.data;
+        final errorMsg = respData is Map
+            ? (respData['error'] as String?) ??
+                'Failed to restore verification'
+            : 'Failed to restore verification';
+        throw MinglitUserException(errorMsg);
+      }
       Log.d('restoreVerification success');
     } catch (e, st) {
       Log.e('❌ [VerificationRepo] restoreVerification Error', e, st);

--- a/shared/packages/minglit_kit/lib/src/data/repositories/verification_command_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/verification_command_repository.dart
@@ -16,16 +16,16 @@ mixin _VerificationCommandRepository on _SupabaseVerificationContext {
           if (verification.description != null)
             'description': verification.description,
           if (verification.iconKey != null) 'icon_key': verification.iconKey,
-          'form_schema':
-              verification.formSchema.map((f) => f.toJson()).toList(),
+          'form_schema': verification.formSchema
+              .map((f) => f.toJson())
+              .toList(),
         },
       );
 
       if (response.status != 200) {
         final respData = response.data;
         final errorMsg = respData is Map
-            ? (respData['error'] as String?) ??
-                'Failed to create verification'
+            ? (respData['error'] as String?) ?? 'Failed to create verification'
             : 'Failed to create verification';
         throw MinglitUserException(errorMsg);
       }
@@ -54,8 +54,9 @@ mixin _VerificationCommandRepository on _SupabaseVerificationContext {
           'display_name': verification.displayName,
           'description': verification.description,
           'icon_key': verification.iconKey,
-          'form_schema':
-              verification.formSchema.map((f) => f.toJson()).toList(),
+          'form_schema': verification.formSchema
+              .map((f) => f.toJson())
+              .toList(),
           'is_active': verification.isActive,
         },
       );
@@ -63,8 +64,7 @@ mixin _VerificationCommandRepository on _SupabaseVerificationContext {
       if (response.status != 200) {
         final respData = response.data;
         final errorMsg = respData is Map
-            ? (respData['error'] as String?) ??
-                'Failed to update verification'
+            ? (respData['error'] as String?) ?? 'Failed to update verification'
             : 'Failed to update verification';
         throw MinglitUserException(errorMsg);
       }
@@ -91,8 +91,7 @@ mixin _VerificationCommandRepository on _SupabaseVerificationContext {
       if (response.status != 200) {
         final respData = response.data;
         final errorMsg = respData is Map
-            ? (respData['error'] as String?) ??
-                'Failed to delete verification'
+            ? (respData['error'] as String?) ?? 'Failed to delete verification'
             : 'Failed to delete verification';
         throw MinglitUserException(errorMsg);
       }
@@ -119,8 +118,7 @@ mixin _VerificationCommandRepository on _SupabaseVerificationContext {
       if (response.status != 200) {
         final respData = response.data;
         final errorMsg = respData is Map
-            ? (respData['error'] as String?) ??
-                'Failed to restore verification'
+            ? (respData['error'] as String?) ?? 'Failed to restore verification'
             : 'Failed to restore verification';
         throw MinglitUserException(errorMsg);
       }

--- a/shared/packages/minglit_kit/test/src/data/repositories/verification_command_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/verification_command_repository_test.dart
@@ -3,7 +3,9 @@ import 'dart:async' show unawaited;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/models/verification.dart';
 import 'package:minglit_kit/src/data/repositories/verification_repository.dart';
+import 'package:minglit_kit/src/utils/exceptions.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../../helpers/mocks.dart';
 import '../../../helpers/supabase_mock_helpers.dart';
@@ -11,58 +13,85 @@ import '../../../helpers/supabase_mock_helpers.dart';
 void main() {
   late MockSupabaseClient mockClient;
   late MockUser mockUser;
+  late MockFunctionsClient mockFunctions;
   late SupabaseVerificationRepository repository;
 
-  final now = DateTime.now();
-
-  final verificationJson = {
-    'id': 'ver_1',
-    'category': 'career',
-    'internal_name': 'global_career',
-    'display_name': '직장 인증',
-    'partner_id': null,
-    'description': 'Career verification',
-    'icon_key': 'briefcase',
-    'form_schema': <Map<String, dynamic>>[],
-    'is_active': true,
-    'created_at': now.toIso8601String(),
-  };
+  const verification = Verification(
+    id: 'ver_1',
+    category: VerificationCategory.career,
+    internalName: 'global_career',
+    displayName: '직장 인증',
+    partnerId: 'partner_1',
+    description: 'Career verification',
+    iconKey: 'briefcase',
+    formSchema: [],
+    isActive: true,
+  );
 
   setUp(() {
     mockUser = MockUser();
     mockClient = createMockSupabase(currentUser: mockUser);
     when(() => mockUser.id).thenReturn('user_1');
+    mockFunctions = mockClient.functions as MockFunctionsClient;
     repository = SupabaseVerificationRepository(supabase: mockClient);
   });
 
   group('VerificationRepository (command)', () {
+    // Fix #308: createVerification via EF
     group('createVerification', () {
-      test('returns created verification on success', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'verifications',
-            singleData: verificationJson,
+      test('calls partner-manage-verification EF and returns result', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-verification',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true, 'id': 'new-ver-id'},
           ),
         );
 
-        final verification = Verification.fromJson(verificationJson);
         final result = await repository.createVerification(verification);
 
-        expect(result.id, 'ver_1');
+        expect(result.id, 'new-ver-id');
         expect(result.displayName, '직장 인증');
+
+        verify(
+          () => mockFunctions.invoke(
+            'partner-manage-verification',
+            body: any(named: 'body'),
+          ),
+        ).called(1);
       });
 
-      test('throws on error', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'verifications',
-            shouldThrow: Exception('DB error'),
+      test('throws MinglitUserException on error response', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-verification',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 403,
+            data: {'error': 'Forbidden: insufficient partner permissions'},
           ),
         );
 
-        final verification = Verification.fromJson(verificationJson);
+        expect(
+          () => repository.createVerification(verification),
+          throwsA(isA<MinglitUserException>()),
+        );
+      });
+
+      test('throws on network error', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-verification',
+            body: any(named: 'body'),
+          ),
+        ).thenThrow(Exception('network error'));
+
         await expectLater(
           repository.createVerification(verification),
           throwsA(anything),
@@ -70,27 +99,61 @@ void main() {
       });
     });
 
+    // Fix #308: updateVerification via EF
     group('updateVerification', () {
-      test('completes without error', () async {
-        unawaited(mockTable(mockClient, 'verifications'));
+      test('calls partner-manage-verification EF with update action', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-verification',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true},
+          ),
+        );
 
-        final verification = Verification.fromJson(verificationJson);
         await expectLater(
           repository.updateVerification(verification),
           completes,
         );
+
+        verify(
+          () => mockFunctions.invoke(
+            'partner-manage-verification',
+            body: any(named: 'body'),
+          ),
+        ).called(1);
       });
 
-      test('throws on error', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'verifications',
-            shouldThrow: Exception('DB error'),
+      test('throws MinglitUserException on error response', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-verification',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 403,
+            data: {'error': 'Forbidden'},
           ),
         );
 
-        final verification = Verification.fromJson(verificationJson);
+        expect(
+          () => repository.updateVerification(verification),
+          throwsA(isA<MinglitUserException>()),
+        );
+      });
+
+      test('throws on network error', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-verification',
+            body: any(named: 'body'),
+          ),
+        ).thenThrow(Exception('network error'));
+
         await expectLater(
           repository.updateVerification(verification),
           throwsA(anything),
@@ -98,24 +161,64 @@ void main() {
       });
     });
 
+    // Fix #308: deleteVerification via EF (soft delete)
     group('deleteVerification', () {
-      test('completes without error', () async {
-        unawaited(mockTable(mockClient, 'verifications'));
+      test('calls EF with update action and is_active=false', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-verification',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true},
+          ),
+        );
 
         await expectLater(
           repository.deleteVerification('ver_1'),
           completes,
         );
+
+        verify(
+          () => mockFunctions.invoke(
+            'partner-manage-verification',
+            body: {
+              'action': 'update',
+              'verification_id': 'ver_1',
+              'is_active': false,
+            },
+          ),
+        ).called(1);
       });
 
-      test('throws on error', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'verifications',
-            shouldThrow: Exception('DB error'),
+      test('throws MinglitUserException on error response', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-verification',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 404,
+            data: {'error': 'Verification not found'},
           ),
         );
+
+        expect(
+          () => repository.deleteVerification('ver_1'),
+          throwsA(isA<MinglitUserException>()),
+        );
+      });
+
+      test('throws on network error', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-verification',
+            body: any(named: 'body'),
+          ),
+        ).thenThrow(Exception('network error'));
 
         await expectLater(
           repository.deleteVerification('ver_1'),
@@ -124,24 +227,64 @@ void main() {
       });
     });
 
+    // Fix #308: restoreVerification via EF
     group('restoreVerification', () {
-      test('completes without error', () async {
-        unawaited(mockTable(mockClient, 'verifications'));
+      test('calls EF with update action and is_active=true', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-verification',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true},
+          ),
+        );
 
         await expectLater(
           repository.restoreVerification('ver_1'),
           completes,
         );
+
+        verify(
+          () => mockFunctions.invoke(
+            'partner-manage-verification',
+            body: {
+              'action': 'update',
+              'verification_id': 'ver_1',
+              'is_active': true,
+            },
+          ),
+        ).called(1);
       });
 
-      test('throws on error', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'verifications',
-            shouldThrow: Exception('DB error'),
+      test('throws MinglitUserException on error response', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-verification',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 403,
+            data: {'error': 'Forbidden'},
           ),
         );
+
+        expect(
+          () => repository.restoreVerification('ver_1'),
+          throwsA(isA<MinglitUserException>()),
+        );
+      });
+
+      test('throws on network error', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-verification',
+            body: any(named: 'body'),
+          ),
+        ).thenThrow(Exception('network error'));
 
         await expectLater(
           repository.restoreVerification('ver_1'),

--- a/shared/packages/minglit_kit/test/src/data/repositories/verification_command_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/verification_command_repository_test.dart
@@ -24,8 +24,6 @@ void main() {
     partnerId: 'partner_1',
     description: 'Career verification',
     iconKey: 'briefcase',
-    formSchema: [],
-    isActive: true,
   );
 
   setUp(() {

--- a/supabase/functions/partner-manage-verification/deno.json
+++ b/supabase/functions/partner-manage-verification/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/partner-manage-verification/index.ts
+++ b/supabase/functions/partner-manage-verification/index.ts
@@ -1,0 +1,199 @@
+// partner-manage-verification — Manage verification definitions (create, update)
+// Issue #308: RLS write strategy 전환
+
+import { createClient } from "@supabase/supabase-js";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
+import { requireAuth } from "../_shared/auth_utils.ts";
+
+const VALID_CATEGORIES = ["career", "asset", "marriage", "academic", "vehicle", "etc"];
+
+// Fields allowed in create action
+const CREATE_FIELDS = [
+  "category",
+  "internal_name",
+  "display_name",
+  "description",
+  "icon_key",
+  "form_schema",
+] as const;
+
+// Fields allowed in update action (partial update)
+const UPDATE_FIELDS = [
+  "category",
+  "internal_name",
+  "display_name",
+  "description",
+  "icon_key",
+  "form_schema",
+  "is_active",
+] as const;
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") return corsResponse();
+  if (req.method !== "POST") return errorResponse("Method not allowed", 405);
+
+  // 1. Environment check
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !serviceRoleKey) {
+    return errorResponse("Missing server configuration", 500);
+  }
+
+  // 2. Auth
+  const auth = await requireAuth(req);
+  if (auth instanceof Response) return auth;
+  const userId = auth;
+
+  // 3. Parse body
+  let body: Record<string, unknown>;
+  try {
+    const parsed = await req.json();
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return errorResponse("Request body must be a JSON object", 400);
+    }
+    body = parsed as Record<string, unknown>;
+  } catch {
+    return errorResponse("Invalid JSON body", 400);
+  }
+
+  const action = body.action as string | undefined;
+  if (typeof action !== "string" || !action) return errorResponse("Missing action", 400);
+
+  // 4. Supabase client (service role)
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  });
+
+  // ─── create ───
+  if (action === "create") {
+    const partnerId = body.partner_id;
+    if (typeof partnerId !== "string" || !partnerId) {
+      return errorResponse("Missing partner_id", 400);
+    }
+
+    // Validate required fields
+    const category = body.category;
+    if (typeof category !== "string" || !VALID_CATEGORIES.includes(category)) {
+      return errorResponse("Missing or invalid category", 400);
+    }
+
+    const internalName = body.internal_name;
+    if (typeof internalName !== "string" || !internalName) {
+      return errorResponse("Missing internal_name", 400);
+    }
+
+    const displayName = body.display_name;
+    if (typeof displayName !== "string" || !displayName) {
+      return errorResponse("Missing display_name", 400);
+    }
+
+    // Check partner permission
+    const permCheck = await checkPartnerPermission(supabase, partnerId, userId);
+    if (permCheck instanceof Response) return permCheck;
+
+    // Build insert record — only allow whitelisted fields
+    const record: Record<string, unknown> = { partner_id: partnerId };
+    for (const field of CREATE_FIELDS) {
+      if (body[field] !== undefined) {
+        record[field] = body[field];
+      }
+    }
+
+    const { data, error: insertError } = await supabase
+      .from("verifications")
+      .insert(record)
+      .select("id")
+      .single();
+
+    if (insertError) {
+      return errorResponse(`Failed to create verification: ${insertError.message}`, 500);
+    }
+
+    return successResponse({ success: true, id: data.id });
+  }
+
+  // ─── update ───
+  if (action === "update") {
+    const verificationId = body.verification_id;
+    if (typeof verificationId !== "string" || !verificationId) {
+      return errorResponse("Missing verification_id", 400);
+    }
+
+    // Validate category if provided
+    if (body.category !== undefined) {
+      if (typeof body.category !== "string" || !VALID_CATEGORIES.includes(body.category)) {
+        return errorResponse("Invalid category", 400);
+      }
+    }
+
+    // Fetch verification to get partner_id
+    const { data: verification, error: fetchError } = await supabase
+      .from("verifications")
+      .select("id, partner_id")
+      .eq("id", verificationId)
+      .maybeSingle();
+
+    if (fetchError) {
+      return errorResponse("Failed to load verification", 500);
+    }
+    if (!verification) {
+      return errorResponse("Verification not found", 404);
+    }
+
+    // Check partner permission
+    const permCheck = await checkPartnerPermission(supabase, verification.partner_id, userId);
+    if (permCheck instanceof Response) return permCheck;
+
+    // Build update record — only allow whitelisted fields, ignore partner_id
+    const updates: Record<string, unknown> = {};
+    for (const field of UPDATE_FIELDS) {
+      if (body[field] !== undefined) {
+        updates[field] = body[field];
+      }
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return errorResponse("No fields to update", 400);
+    }
+
+    const { error: updateError } = await supabase
+      .from("verifications")
+      .update(updates)
+      .eq("id", verificationId);
+
+    if (updateError) {
+      return errorResponse(`Failed to update verification: ${updateError.message}`, 500);
+    }
+
+    return successResponse({ success: true });
+  }
+
+  return errorResponse(`Unknown action: ${action}`, 400);
+});
+
+// ─── Helper: check partner permission ───
+async function checkPartnerPermission(
+  supabase: ReturnType<typeof createClient>,
+  partnerId: string,
+  userId: string,
+): Promise<void | Response> {
+  const { data: perm, error: permError } = await supabase
+    .from("partner_member_permissions")
+    .select("permissions")
+    .eq("partner_id", partnerId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (permError) {
+    return errorResponse("Failed to verify partner permissions", 500);
+  }
+
+  const hasPermission = (perm?.permissions as string[] | null)?.includes("PARTY_MANAGE") ?? false;
+  if (!hasPermission) {
+    return errorResponse("Forbidden: insufficient partner permissions", 403);
+  }
+}

--- a/supabase/functions/partner-manage-verification/partner_manage_verification_test.ts
+++ b/supabase/functions/partner-manage-verification/partner_manage_verification_test.ts
@@ -1,0 +1,787 @@
+import { assertEquals } from "@std/assert";
+import {
+  authenticatedJsonRequest,
+  captureServeHandler,
+  createFetchMock,
+  jsonResponse,
+  readJson,
+  withEnv,
+  withMockedFetch,
+  type FetchRoute,
+} from "../_test_utils/mock_http.ts";
+
+const TEST_USER_ID = "user-partner-owner";
+const TEST_PARTNER_ID = "partner-001";
+const TEST_VERIFICATION_ID = "ver-001";
+
+const ENV = {
+  SUPABASE_URL: "http://localhost:54321",
+  SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+};
+
+function authRoute(): FetchRoute {
+  return {
+    matcher: "/auth/v1/user",
+    handler: () => jsonResponse({ id: TEST_USER_ID, email: "partner@test.com" }),
+  };
+}
+
+function authFailRoute(): FetchRoute {
+  return {
+    matcher: "/auth/v1/user",
+    handler: () => jsonResponse({ error: "invalid" }, { status: 401 }),
+  };
+}
+
+function permRoute(hasPermission = true): FetchRoute {
+  return {
+    matcher: (req) => req.url.includes("partner_member_permissions"),
+    handler: () =>
+      jsonResponse(
+        hasPermission
+          ? { permissions: ["PARTNER_EDIT", "PARTY_MANAGE", "MEMBER_MANAGE"] }
+          : null,
+      ),
+  };
+}
+
+function permErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) => req.url.includes("partner_member_permissions"),
+    handler: () => jsonResponse({ message: "db error" }, { status: 500 }),
+  };
+}
+
+// Insert route for create action
+function insertRoute(id = TEST_VERIFICATION_ID): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/verifications") && req.method === "POST",
+    handler: () => jsonResponse({ id }),
+  };
+}
+
+function insertErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/verifications") && req.method === "POST",
+    handler: () => jsonResponse({ message: "insert error" }, { status: 500 }),
+  };
+}
+
+// Select route for update action (fetch verification)
+function selectVerificationRoute(
+  partnerId = TEST_PARTNER_ID,
+): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/verifications") &&
+      req.url.includes("select=") &&
+      req.method === "GET",
+    handler: () =>
+      jsonResponse({ id: TEST_VERIFICATION_ID, partner_id: partnerId }),
+  };
+}
+
+function selectVerificationNotFoundRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/verifications") &&
+      req.url.includes("select=") &&
+      req.method === "GET",
+    handler: () => jsonResponse(null),
+  };
+}
+
+// Update (PATCH) route
+function updateRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/verifications") && req.method === "PATCH",
+    handler: () => new Response(null, { status: 200 }),
+  };
+}
+
+function updateErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/verifications") && req.method === "PATCH",
+    handler: () => jsonResponse({ message: "update error" }, { status: 500 }),
+  };
+}
+
+// ─── CORS preflight ───
+Deno.test({
+  name: "handles OPTIONS preflight request",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          new Request("http://localhost", { method: "OPTIONS" }),
+        );
+        assertEquals(res.status, 200);
+      });
+    });
+  },
+});
+
+// ─── 401: no auth ───
+Deno.test({
+  name: "returns 401 without authorization",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authFailRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = new Request("http://localhost", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action: "create" }),
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 401);
+      });
+    });
+  },
+});
+
+// ─── 400: missing action ───
+Deno.test({
+  name: "returns 400 for missing action",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {}),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing action");
+      });
+    });
+  },
+});
+
+// ─── 400: unknown action ───
+Deno.test({
+  name: "returns 400 for unknown action",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", { action: "unknown" }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Unknown action: unknown");
+      });
+    });
+  },
+});
+
+// ─── CREATE: success ───
+Deno.test({
+  name: "create: inserts verification and returns id",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      permRoute(),
+      insertRoute("new-ver-id"),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "create",
+            partner_id: TEST_PARTNER_ID,
+            category: "academic",
+            internal_name: "university_check",
+            display_name: "대학교 재학 인증",
+            description: "재학증명서 또는 학생증 사진",
+            icon_key: "school",
+            form_schema: [{ type: "file", label: "증명서 업로드" }],
+          }),
+        );
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+        assertEquals(body.id, "new-ver-id");
+      });
+    });
+  },
+});
+
+// ─── CREATE: partner_id server-injected — verify POST body ───
+Deno.test({
+  name: "create: sends partner_id in insert payload",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    let insertBody: string | null = null;
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      permRoute(),
+      {
+        matcher: (req) =>
+          req.url.includes("/rest/v1/verifications") && req.method === "POST",
+        handler: async (req) => {
+          insertBody = await req.clone().text();
+          return jsonResponse({ id: "new-ver-id" });
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "create",
+            partner_id: TEST_PARTNER_ID,
+            category: "etc",
+            internal_name: "test",
+            display_name: "테스트",
+          }),
+        );
+        assertEquals(res.status, 200);
+        const parsed = JSON.parse(insertBody!);
+        assertEquals(parsed.partner_id, TEST_PARTNER_ID);
+        assertEquals(parsed.category, "etc");
+        assertEquals(parsed.internal_name, "test");
+      });
+    });
+  },
+});
+
+// ─── CREATE: missing partner_id → 400 ───
+Deno.test({
+  name: "create: returns 400 for missing partner_id",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "create",
+            category: "etc",
+            internal_name: "test",
+            display_name: "테스트",
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing partner_id");
+      });
+    });
+  },
+});
+
+// ─── CREATE: missing required fields → 400 ───
+Deno.test({
+  name: "create: returns 400 for missing category",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "create",
+            partner_id: TEST_PARTNER_ID,
+            internal_name: "test",
+            display_name: "테스트",
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing or invalid category");
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "create: returns 400 for invalid category",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "create",
+            partner_id: TEST_PARTNER_ID,
+            category: "identity",
+            internal_name: "test",
+            display_name: "테스트",
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing or invalid category");
+      });
+    });
+  },
+});
+
+// ─── CREATE: 403 no permission ───
+Deno.test({
+  name: "create: returns 403 when user lacks PARTY_MANAGE permission",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      permRoute(false),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "create",
+            partner_id: TEST_PARTNER_ID,
+            category: "etc",
+            internal_name: "test",
+            display_name: "테스트",
+          }),
+        );
+        assertEquals(res.status, 403);
+      });
+    });
+  },
+});
+
+// ─── CREATE: 500 permission DB error ───
+Deno.test({
+  name: "create: returns 500 when permission query fails",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      permErrorRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "create",
+            partner_id: TEST_PARTNER_ID,
+            category: "etc",
+            internal_name: "test",
+            display_name: "테스트",
+          }),
+        );
+        assertEquals(res.status, 500);
+        const body = await readJson(res);
+        assertEquals(body.error, "Failed to verify partner permissions");
+      });
+    });
+  },
+});
+
+// ─── CREATE: 500 insert error ───
+Deno.test({
+  name: "create: returns 500 when insert fails",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      permRoute(),
+      insertErrorRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "create",
+            partner_id: TEST_PARTNER_ID,
+            category: "etc",
+            internal_name: "test",
+            display_name: "테스트",
+          }),
+        );
+        assertEquals(res.status, 500);
+      });
+    });
+  },
+});
+
+// ─── UPDATE: display_name ───
+Deno.test({
+  name: "update: updates display_name successfully",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectVerificationRoute(),
+      permRoute(),
+      updateRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            verification_id: TEST_VERIFICATION_ID,
+            display_name: "대학교 재학/졸업 인증",
+          }),
+        );
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+      });
+    });
+  },
+});
+
+// ─── UPDATE: is_active=false (soft delete) ───
+Deno.test({
+  name: "update: is_active=false soft deletes",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    let patchBody: string | null = null;
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectVerificationRoute(),
+      permRoute(),
+      {
+        matcher: (req) =>
+          req.url.includes("/rest/v1/verifications") && req.method === "PATCH",
+        handler: async (req) => {
+          patchBody = await req.clone().text();
+          return new Response(null, { status: 200 });
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            verification_id: TEST_VERIFICATION_ID,
+            is_active: false,
+          }),
+        );
+        assertEquals(res.status, 200);
+        const parsed = JSON.parse(patchBody!);
+        assertEquals(parsed.is_active, false);
+      });
+    });
+  },
+});
+
+// ─── UPDATE: is_active=true (restore) ───
+Deno.test({
+  name: "update: is_active=true restores",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    let patchBody: string | null = null;
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectVerificationRoute(),
+      permRoute(),
+      {
+        matcher: (req) =>
+          req.url.includes("/rest/v1/verifications") && req.method === "PATCH",
+        handler: async (req) => {
+          patchBody = await req.clone().text();
+          return new Response(null, { status: 200 });
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            verification_id: TEST_VERIFICATION_ID,
+            is_active: true,
+          }),
+        );
+        assertEquals(res.status, 200);
+        const parsed = JSON.parse(patchBody!);
+        assertEquals(parsed.is_active, true);
+      });
+    });
+  },
+});
+
+// ─── UPDATE: partial — only sent fields updated ───
+Deno.test({
+  name: "update: partial update only sends provided fields",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    let patchBody: string | null = null;
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectVerificationRoute(),
+      permRoute(),
+      {
+        matcher: (req) =>
+          req.url.includes("/rest/v1/verifications") && req.method === "PATCH",
+        handler: async (req) => {
+          patchBody = await req.clone().text();
+          return new Response(null, { status: 200 });
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            verification_id: TEST_VERIFICATION_ID,
+            description: "Updated description only",
+          }),
+        );
+        assertEquals(res.status, 200);
+        const parsed = JSON.parse(patchBody!);
+        assertEquals(parsed.description, "Updated description only");
+        // Should not contain other fields
+        assertEquals(Object.keys(parsed).length, 1);
+      });
+    });
+  },
+});
+
+// ─── UPDATE: other partner's verification → 403 ───
+Deno.test({
+  name: "update: returns 403 for other partner's verification",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectVerificationRoute("other-partner-id"),
+      permRoute(false),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            verification_id: TEST_VERIFICATION_ID,
+            display_name: "Hacked name",
+          }),
+        );
+        assertEquals(res.status, 403);
+      });
+    });
+  },
+});
+
+// ─── UPDATE: partner_id change attempt ignored ───
+Deno.test({
+  name: "update: partner_id in body is ignored (not in update fields)",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    let patchBody: string | null = null;
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectVerificationRoute(),
+      permRoute(),
+      {
+        matcher: (req) =>
+          req.url.includes("/rest/v1/verifications") && req.method === "PATCH",
+        handler: async (req) => {
+          patchBody = await req.clone().text();
+          return new Response(null, { status: 200 });
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            verification_id: TEST_VERIFICATION_ID,
+            partner_id: "evil-partner-id",
+            display_name: "Valid update",
+          }),
+        );
+        assertEquals(res.status, 200);
+        const parsed = JSON.parse(patchBody!);
+        // partner_id should NOT be in the update payload
+        assertEquals(parsed.partner_id, undefined);
+        assertEquals(parsed.display_name, "Valid update");
+      });
+    });
+  },
+});
+
+// ─── UPDATE: missing verification_id → 400 ───
+Deno.test({
+  name: "update: returns 400 for missing verification_id",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            display_name: "Updated",
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing verification_id");
+      });
+    });
+  },
+});
+
+// ─── UPDATE: verification not found → 404 ───
+Deno.test({
+  name: "update: returns 404 when verification not found",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectVerificationNotFoundRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            verification_id: "nonexistent",
+            display_name: "Updated",
+          }),
+        );
+        assertEquals(res.status, 404);
+        const body = await readJson(res);
+        assertEquals(body.error, "Verification not found");
+      });
+    });
+  },
+});
+
+// ─── UPDATE: no fields to update → 400 ───
+Deno.test({
+  name: "update: returns 400 when no valid fields provided",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectVerificationRoute(),
+      permRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            verification_id: TEST_VERIFICATION_ID,
+            // Only non-whitelisted fields
+            partner_id: "evil-id",
+            random_field: "ignored",
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "No fields to update");
+      });
+    });
+  },
+});
+
+// ─── UPDATE: 500 update error ───
+Deno.test({
+  name: "update: returns 500 when update fails",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectVerificationRoute(),
+      permRoute(),
+      updateErrorRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            verification_id: TEST_VERIFICATION_ID,
+            display_name: "Updated",
+          }),
+        );
+        assertEquals(res.status, 500);
+      });
+    });
+  },
+});


### PR DESCRIPTION
## Summary
- `partner-manage-verification` Edge Function 신규 구현 (create/update 액션)
- Flutter `verification_command_repository.dart`의 4개 메서드를 직접 DB write → EF 호출로 전환
  - `createVerification()`, `updateVerification()`, `deleteVerification()`, `restoreVerification()`
- EF e2e 테스트 22개, Flutter 유닛 테스트 14개 전부 통과

Closes #308

## Test plan
- [x] EF 테스트: create → DB 생성, partner_id 서버 주입 확인
- [x] EF 테스트: update display_name → 반영 확인
- [x] EF 테스트: update is_active=false → soft delete 확인
- [x] EF 테스트: update is_active=true → 복원 확인
- [x] EF 테스트: update partial → 전달 안 한 필드 유지
- [x] EF 테스트: 다른 파트너 verification 수정 → 403
- [x] EF 테스트: partner_id 변경 시도 → 무시
- [x] EF 테스트: 인증 없이 → 401
- [x] Flutter 테스트: createVerification EF 호출 + 결과 반환
- [x] Flutter 테스트: deleteVerification/restoreVerification EF 호출 검증
- [x] Flutter 테스트: 에러 응답 시 MinglitUserException throw
- [x] app_partner verification controller 테스트 24개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)