### PR TITLE
feat(verification): partner-review-submission EF 구현 (인증 심사 + 코멘트)

### DIFF
--- a/apps/app_partner/lib/src/features/verification/review/review_verification_screen.dart
+++ b/apps/app_partner/lib/src/features/verification/review/review_verification_screen.dart
@@ -60,17 +60,14 @@ class _ReviewVerificationScreenState
   }) async {
     final loading = ref.read(globalLoadingControllerProvider.notifier)..show();
     try {
+      // Fix #309: review + comment in single EF call
       await ref
           .read(verificationRepositoryProvider)
           .reviewRequest(
             submissionId: id,
             status: status,
+            comment: comment,
           );
-      if (comment != null) {
-        await ref
-            .read(verificationRepositoryProvider)
-            .submitComment(submissionId: id, content: {'text': comment});
-      }
 
       if (!mounted) return;
       context.showMinglitSuccess(

--- a/shared/packages/minglit_kit/lib/src/data/repositories/verification_command_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/verification_command_repository.dart
@@ -295,8 +295,9 @@ mixin _VerificationCommandRepository on _SupabaseVerificationContext {
     Log.d('submitComment called | submissionId: $submissionId');
     try {
       final text = content['text'] as String? ?? '';
-      final efName =
-          isPartner ? 'partner-review-submission' : 'user-submit-verification';
+      final efName = isPartner
+          ? 'partner-review-submission'
+          : 'user-submit-verification';
       final response = await supabaseClient.functions.invoke(
         efName,
         body: {

--- a/shared/packages/minglit_kit/lib/src/data/repositories/verification_command_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/verification_command_repository.dart
@@ -251,23 +251,33 @@ mixin _VerificationCommandRepository on _SupabaseVerificationContext {
     }
   }
 
-  // Fix #301: will be replaced by partner-review-submission EF (#309)
+  // Fix #309: reviewRequest via partner-review-submission EF
   Future<void> reviewRequest({
     required String submissionId,
     required VerificationStatus status,
+    String? comment,
   }) async {
     Log.d(
       'reviewRequest called | submissionId: $submissionId, status: $status',
     );
     try {
-      await supabaseClient
-          .from('verification_submissions')
-          .update({
-            'status': status.name,
-            'reviewed_at': DateTime.now().toIso8601String(),
-            'reviewed_by': supabaseClient.auth.currentUser?.id,
-          })
-          .eq('id', submissionId);
+      final response = await supabaseClient.functions.invoke(
+        'partner-review-submission',
+        body: {
+          'action': 'review',
+          'submission_id': submissionId,
+          'result': status.name,
+          if (comment != null && comment.isNotEmpty) 'comment': comment,
+        },
+      );
+
+      if (response.status != 200) {
+        final respData = response.data;
+        final errorMsg = respData is Map
+            ? (respData['error'] as String?) ?? 'Failed to review submission'
+            : 'Failed to review submission';
+        throw MinglitUserException(errorMsg);
+      }
       Log.d('reviewRequest success');
     } catch (e, st) {
       Log.e('❌ [VerificationRepo] reviewRequest Error', e, st);
@@ -275,16 +285,20 @@ mixin _VerificationCommandRepository on _SupabaseVerificationContext {
     }
   }
 
-  // Fix #301: submitComment via EF (verification_comments table dropped)
+  // Fix #309: submitComment — partner uses partner-review-submission EF,
+  // user uses user-submit-verification EF
   Future<void> submitComment({
     required String submissionId,
     required Map<String, dynamic> content,
+    bool isPartner = false,
   }) async {
     Log.d('submitComment called | submissionId: $submissionId');
     try {
       final text = content['text'] as String? ?? '';
+      final efName =
+          isPartner ? 'partner-review-submission' : 'user-submit-verification';
       final response = await supabaseClient.functions.invoke(
-        'user-submit-verification',
+        efName,
         body: {
           'action': 'comment',
           'submission_id': submissionId,

--- a/shared/packages/minglit_kit/lib/src/data/repositories/verification_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/verification_repository.dart
@@ -92,6 +92,7 @@ abstract class VerificationRepository {
   Future<void> reviewRequest({
     required String submissionId,
     required VerificationStatus status,
+    String? comment,
   });
 
   /// User 특정 상태의 모든 요청 조회 (예: 보완 필요 건만 모아보기)
@@ -108,6 +109,7 @@ abstract class VerificationRepository {
   Future<void> submitComment({
     required String submissionId,
     required Map<String, dynamic> content,
+    bool isPartner = false,
   });
 }
 

--- a/shared/packages/minglit_kit/test/src/data/repositories/verification_command_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/verification_command_repository_test.dart
@@ -291,9 +291,20 @@ void main() {
       });
     });
 
+    // Fix #309: reviewRequest via partner-review-submission EF
     group('reviewRequest', () {
-      test('completes without error', () async {
-        unawaited(mockTable(mockClient, 'verification_submissions'));
+      test('calls partner-review-submission EF with review action', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-review-submission',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true},
+          ),
+        );
 
         await expectLater(
           repository.reviewRequest(
@@ -302,16 +313,79 @@ void main() {
           ),
           completes,
         );
+
+        verify(
+          () => mockFunctions.invoke(
+            'partner-review-submission',
+            body: any(named: 'body'),
+          ),
+        ).called(1);
       });
 
-      test('throws on error', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'verification_submissions',
-            shouldThrow: Exception('DB error'),
+      test('includes comment when provided', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-review-submission',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true},
           ),
         );
+
+        await expectLater(
+          repository.reviewRequest(
+            submissionId: 'sub_1',
+            status: VerificationStatus.rejected,
+            comment: '서류가 흐릿합니다',
+          ),
+          completes,
+        );
+
+        verify(
+          () => mockFunctions.invoke(
+            'partner-review-submission',
+            body: {
+              'action': 'review',
+              'submission_id': 'sub_1',
+              'result': 'rejected',
+              'comment': '서류가 흐릿합니다',
+            },
+          ),
+        ).called(1);
+      });
+
+      test('throws MinglitUserException on error response', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-review-submission',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 403,
+            data: {'error': 'Forbidden: insufficient partner permissions'},
+          ),
+        );
+
+        expect(
+          () => repository.reviewRequest(
+            submissionId: 'sub_1',
+            status: VerificationStatus.approved,
+          ),
+          throwsA(isA<MinglitUserException>()),
+        );
+      });
+
+      test('throws on network error', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-review-submission',
+            body: any(named: 'body'),
+          ),
+        ).thenThrow(Exception('network error'));
 
         await expectLater(
           repository.reviewRequest(

--- a/shared/packages/minglit_kit/test/src/data/repositories/verification_command_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/verification_command_repository_test.dart
@@ -394,5 +394,102 @@ void main() {
         );
       });
     });
+
+    // Fix #309: submitComment isPartner 분기 테스트
+    group('submitComment with isPartner', () {
+      test('calls partner-review-submission EF when isPartner is true',
+          () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-review-submission',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true},
+          ),
+        );
+
+        await expectLater(
+          repository.submitComment(
+            submissionId: 'sub_1',
+            content: {'text': '서류 확인 부탁'},
+            isPartner: true,
+          ),
+          completes,
+        );
+
+        verify(
+          () => mockFunctions.invoke(
+            'partner-review-submission',
+            body: {
+              'action': 'comment',
+              'submission_id': 'sub_1',
+              'text': '서류 확인 부탁',
+            },
+          ),
+        ).called(1);
+      });
+
+      test(
+          'calls user-submit-verification EF when isPartner is false (default)',
+          () async {
+        when(
+          () => mockFunctions.invoke(
+            'user-submit-verification',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true},
+          ),
+        );
+
+        await expectLater(
+          repository.submitComment(
+            submissionId: 'sub_1',
+            content: {'text': '추가 서류 제출합니다'},
+          ),
+          completes,
+        );
+
+        verify(
+          () => mockFunctions.invoke(
+            'user-submit-verification',
+            body: {
+              'action': 'comment',
+              'submission_id': 'sub_1',
+              'text': '추가 서류 제출합니다',
+            },
+          ),
+        ).called(1);
+      });
+
+      test('throws MinglitUserException on error response (partner)',
+          () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-review-submission',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 403,
+            data: {'error': 'Forbidden'},
+          ),
+        );
+
+        expect(
+          () => repository.submitComment(
+            submissionId: 'sub_1',
+            content: {'text': 'test'},
+            isPartner: true,
+          ),
+          throwsA(isA<MinglitUserException>()),
+        );
+      });
+    });
   });
 }

--- a/shared/packages/minglit_kit/test/src/data/repositories/verification_command_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/verification_command_repository_test.dart
@@ -397,78 +397,80 @@ void main() {
 
     // Fix #309: submitComment isPartner 분기 테스트
     group('submitComment with isPartner', () {
-      test('calls partner-review-submission EF when isPartner is true',
-          () async {
-        when(
-          () => mockFunctions.invoke(
-            'partner-review-submission',
-            body: any(named: 'body'),
-          ),
-        ).thenAnswer(
-          (_) async => FunctionResponse(
-            status: 200,
-            data: {'success': true},
-          ),
-        );
+      test(
+        'calls partner-review-submission EF when isPartner is true',
+        () async {
+          when(
+            () => mockFunctions.invoke(
+              'partner-review-submission',
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer(
+            (_) async => FunctionResponse(
+              status: 200,
+              data: {'success': true},
+            ),
+          );
 
-        await expectLater(
-          repository.submitComment(
-            submissionId: 'sub_1',
-            content: {'text': '서류 확인 부탁'},
-            isPartner: true,
-          ),
-          completes,
-        );
+          await expectLater(
+            repository.submitComment(
+              submissionId: 'sub_1',
+              content: {'text': '서류 확인 부탁'},
+              isPartner: true,
+            ),
+            completes,
+          );
 
-        verify(
-          () => mockFunctions.invoke(
-            'partner-review-submission',
-            body: {
-              'action': 'comment',
-              'submission_id': 'sub_1',
-              'text': '서류 확인 부탁',
-            },
-          ),
-        ).called(1);
-      });
+          verify(
+            () => mockFunctions.invoke(
+              'partner-review-submission',
+              body: {
+                'action': 'comment',
+                'submission_id': 'sub_1',
+                'text': '서류 확인 부탁',
+              },
+            ),
+          ).called(1);
+        },
+      );
 
       test(
-          'calls user-submit-verification EF when isPartner is false (default)',
-          () async {
-        when(
-          () => mockFunctions.invoke(
-            'user-submit-verification',
-            body: any(named: 'body'),
-          ),
-        ).thenAnswer(
-          (_) async => FunctionResponse(
-            status: 200,
-            data: {'success': true},
-          ),
-        );
+        'calls user-submit-verification EF when isPartner is false (default)',
+        () async {
+          when(
+            () => mockFunctions.invoke(
+              'user-submit-verification',
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer(
+            (_) async => FunctionResponse(
+              status: 200,
+              data: {'success': true},
+            ),
+          );
 
-        await expectLater(
-          repository.submitComment(
-            submissionId: 'sub_1',
-            content: {'text': '추가 서류 제출합니다'},
-          ),
-          completes,
-        );
+          await expectLater(
+            repository.submitComment(
+              submissionId: 'sub_1',
+              content: {'text': '추가 서류 제출합니다'},
+            ),
+            completes,
+          );
 
-        verify(
-          () => mockFunctions.invoke(
-            'user-submit-verification',
-            body: {
-              'action': 'comment',
-              'submission_id': 'sub_1',
-              'text': '추가 서류 제출합니다',
-            },
-          ),
-        ).called(1);
-      });
+          verify(
+            () => mockFunctions.invoke(
+              'user-submit-verification',
+              body: {
+                'action': 'comment',
+                'submission_id': 'sub_1',
+                'text': '추가 서류 제출합니다',
+              },
+            ),
+          ).called(1);
+        },
+      );
 
-      test('throws MinglitUserException on error response (partner)',
-          () async {
+      test('throws MinglitUserException on error response (partner)', () async {
         when(
           () => mockFunctions.invoke(
             'partner-review-submission',

--- a/shared/packages/minglit_kit/test/src/data/repositories/verification_command_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/verification_command_repository_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async' show unawaited;
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/models/verification.dart';
 import 'package:minglit_kit/src/data/repositories/verification_repository.dart';

--- a/supabase/functions/partner-review-submission/index.ts
+++ b/supabase/functions/partner-review-submission/index.ts
@@ -1,0 +1,211 @@
+// partner-review-submission — Review verification submissions (approve/reject + comment)
+// Issue #309: RLS write strategy 전환
+
+import { createClient } from "@supabase/supabase-js";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
+import { requireAuth } from "../_shared/auth_utils.ts";
+
+const VALID_RESULTS = ["approved", "rejected"];
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") return corsResponse();
+  if (req.method !== "POST") return errorResponse("Method not allowed", 405);
+
+  // 1. Environment check
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !serviceRoleKey) {
+    return errorResponse("Missing server configuration", 500);
+  }
+
+  // 2. Auth
+  const auth = await requireAuth(req);
+  if (auth instanceof Response) return auth;
+  const userId = auth;
+
+  // 3. Parse body
+  let body: Record<string, unknown>;
+  try {
+    const parsed = await req.json();
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return errorResponse("Request body must be a JSON object", 400);
+    }
+    body = parsed as Record<string, unknown>;
+  } catch {
+    return errorResponse("Invalid JSON body", 400);
+  }
+
+  const action = body.action as string | undefined;
+  if (typeof action !== "string" || !action) return errorResponse("Missing action", 400);
+
+  // 4. Supabase client (service role)
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  });
+
+  // ─── review ───
+  if (action === "review") {
+    const submissionId = body.submission_id;
+    if (typeof submissionId !== "string" || !submissionId) {
+      return errorResponse("Missing submission_id", 400);
+    }
+
+    const result = body.result;
+    if (typeof result !== "string" || !VALID_RESULTS.includes(result)) {
+      return errorResponse("Invalid result. Must be 'approved' or 'rejected'", 400);
+    }
+
+    // Fetch submission
+    const { data: submission, error: fetchError } = await supabase
+      .from("verification_submissions")
+      .select("id, partner_id, snapshot_data")
+      .eq("id", submissionId)
+      .maybeSingle();
+
+    if (fetchError) {
+      return errorResponse("Failed to load submission", 500);
+    }
+    if (!submission) {
+      return errorResponse("Submission not found", 404);
+    }
+
+    // Check partner permission
+    const permCheck = await checkPartnerPermission(supabase, submission.partner_id, userId);
+    if (permCheck instanceof Response) return permCheck;
+
+    // Update snapshot_data last entry with review result
+    const snapshotArray = Array.isArray(submission.snapshot_data)
+      ? [...submission.snapshot_data]
+      : [];
+
+    if (snapshotArray.length === 0) {
+      return errorResponse("No submission history found", 400);
+    }
+
+    const now = new Date().toISOString();
+    const lastEntry = { ...snapshotArray[snapshotArray.length - 1] };
+    lastEntry.result = result;
+    lastEntry.reviewed_by = userId;
+    lastEntry.reviewed_at = now;
+
+    // Fix #309: review action에 comment가 있으면 함께 기록
+    const comment = body.comment;
+    if (typeof comment === "string" && comment.trim().length > 0) {
+      const comments = Array.isArray(lastEntry.comments) ? [...lastEntry.comments] : [];
+      comments.push({
+        author: userId,
+        at: now,
+        text: comment.trim(),
+      });
+      lastEntry.comments = comments;
+    }
+
+    snapshotArray[snapshotArray.length - 1] = lastEntry;
+
+    const { error: updateError } = await supabase
+      .from("verification_submissions")
+      .update({
+        status: result,
+        reviewed_at: now,
+        reviewed_by: userId,
+        snapshot_data: snapshotArray,
+      })
+      .eq("id", submissionId);
+
+    if (updateError) {
+      return errorResponse(`Failed to update submission: ${updateError.message}`, 500);
+    }
+
+    return successResponse({ success: true });
+  }
+
+  // ─── comment ───
+  if (action === "comment") {
+    const submissionId = body.submission_id;
+    if (typeof submissionId !== "string" || !submissionId) {
+      return errorResponse("Missing submission_id", 400);
+    }
+
+    const text = body.text;
+    if (typeof text !== "string" || text.trim().length === 0) {
+      return errorResponse("Missing text", 400);
+    }
+
+    // Fetch submission
+    const { data: submission, error: fetchError } = await supabase
+      .from("verification_submissions")
+      .select("id, partner_id, snapshot_data")
+      .eq("id", submissionId)
+      .maybeSingle();
+
+    if (fetchError) {
+      return errorResponse("Failed to load submission", 500);
+    }
+    if (!submission) {
+      return errorResponse("Submission not found", 404);
+    }
+
+    // Check partner permission
+    const permCheck = await checkPartnerPermission(supabase, submission.partner_id, userId);
+    if (permCheck instanceof Response) return permCheck;
+
+    // Append comment to last snapshot entry
+    const snapshotArray = Array.isArray(submission.snapshot_data)
+      ? [...submission.snapshot_data]
+      : [];
+
+    if (snapshotArray.length === 0) {
+      return errorResponse("No submission history found", 400);
+    }
+
+    const lastEntry = { ...snapshotArray[snapshotArray.length - 1] };
+    const comments = Array.isArray(lastEntry.comments) ? [...lastEntry.comments] : [];
+    comments.push({
+      author: userId,
+      at: new Date().toISOString(),
+      text: text.trim(),
+    });
+    lastEntry.comments = comments;
+    snapshotArray[snapshotArray.length - 1] = lastEntry;
+
+    const { error: updateError } = await supabase
+      .from("verification_submissions")
+      .update({ snapshot_data: snapshotArray })
+      .eq("id", submissionId);
+
+    if (updateError) {
+      return errorResponse(`Failed to add comment: ${updateError.message}`, 500);
+    }
+
+    return successResponse({ success: true });
+  }
+
+  return errorResponse(`Unknown action: ${action}`, 400);
+});
+
+// ─── Helper: check partner permission ───
+async function checkPartnerPermission(
+  supabase: ReturnType<typeof createClient>,
+  partnerId: string,
+  userId: string,
+): Promise<void | Response> {
+  const { data: perm, error: permError } = await supabase
+    .from("partner_member_permissions")
+    .select("permissions")
+    .eq("partner_id", partnerId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (permError) {
+    return errorResponse("Failed to verify partner permissions", 500);
+  }
+
+  const hasPermission = (perm?.permissions as string[] | null)?.includes("VERIFY_REVIEW") ?? false;
+  if (!hasPermission) {
+    return errorResponse("Forbidden: insufficient partner permissions", 403);
+  }
+}

--- a/supabase/functions/partner-review-submission/index.ts
+++ b/supabase/functions/partner-review-submission/index.ts
@@ -15,6 +15,15 @@ Deno.serve(async (req: Request): Promise<Response> => {
   if (req.method === "OPTIONS") return corsResponse();
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
+  try {
+    return await handleRequest(req);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return errorResponse(message, 500);
+  }
+});
+
+async function handleRequest(req: Request): Promise<Response> {
   // 1. Environment check
   const supabaseUrl = Deno.env.get("SUPABASE_URL");
   const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
@@ -62,7 +71,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
     // Fetch submission
     const { data: submission, error: fetchError } = await supabase
       .from("verification_submissions")
-      .select("id, partner_id, snapshot_data")
+      .select("id, partner_id, status, snapshot_data")
       .eq("id", submissionId)
       .maybeSingle();
 
@@ -71,6 +80,11 @@ Deno.serve(async (req: Request): Promise<Response> => {
     }
     if (!submission) {
       return errorResponse("Submission not found", 404);
+    }
+
+    // Fix #309: 이미 심사 완료된 submission은 재심사 불가
+    if (submission.status !== "pending") {
+      return errorResponse("Submission is already reviewed", 409);
     }
 
     // Check partner permission
@@ -185,7 +199,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
   }
 
   return errorResponse(`Unknown action: ${action}`, 400);
-});
+}
 
 // ─── Helper: check partner permission ───
 async function checkPartnerPermission(

--- a/supabase/functions/partner-review-submission/partner_review_submission_test.ts
+++ b/supabase/functions/partner-review-submission/partner_review_submission_test.ts
@@ -1,0 +1,636 @@
+import { assertEquals } from "@std/assert";
+import {
+  authenticatedJsonRequest,
+  captureServeHandler,
+  createFetchMock,
+  jsonResponse,
+  readJson,
+  withEnv,
+  withMockedFetch,
+  type FetchRoute,
+} from "../_test_utils/mock_http.ts";
+
+const TEST_USER_ID = "user-partner-reviewer";
+const TEST_PARTNER_ID = "partner-001";
+const TEST_SUBMISSION_ID = "sub-001";
+
+const ENV = {
+  SUPABASE_URL: "http://localhost:54321",
+  SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+};
+
+const SNAPSHOT_DATA = [
+  {
+    submitted_at: "2026-03-20T00:00:00.000Z",
+    data: { school: "MIT" },
+    result: null,
+    reviewed_by: null,
+    reviewed_at: null,
+    comments: [],
+  },
+];
+
+function authRoute(): FetchRoute {
+  return {
+    matcher: "/auth/v1/user",
+    handler: () => jsonResponse({ id: TEST_USER_ID, email: "reviewer@test.com" }),
+  };
+}
+
+function authFailRoute(): FetchRoute {
+  return {
+    matcher: "/auth/v1/user",
+    handler: () => jsonResponse({ error: "invalid" }, { status: 401 }),
+  };
+}
+
+function permRoute(hasPermission = true): FetchRoute {
+  return {
+    matcher: (req) => req.url.includes("partner_member_permissions"),
+    handler: () =>
+      jsonResponse(
+        hasPermission
+          ? { permissions: ["VERIFY_REVIEW", "PARTY_MANAGE"] }
+          : null,
+      ),
+  };
+}
+
+function permErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) => req.url.includes("partner_member_permissions"),
+    handler: () => jsonResponse({ message: "db error" }, { status: 500 }),
+  };
+}
+
+function selectSubmissionRoute(
+  partnerId = TEST_PARTNER_ID,
+  snapshotData = SNAPSHOT_DATA,
+): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/verification_submissions") &&
+      req.url.includes("select=") &&
+      req.method === "GET",
+    handler: () =>
+      jsonResponse({
+        id: TEST_SUBMISSION_ID,
+        partner_id: partnerId,
+        snapshot_data: snapshotData,
+      }),
+  };
+}
+
+function selectSubmissionNotFoundRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/verification_submissions") &&
+      req.url.includes("select=") &&
+      req.method === "GET",
+    handler: () => jsonResponse(null),
+  };
+}
+
+function updateRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/verification_submissions") && req.method === "PATCH",
+    handler: () => new Response(null, { status: 200 }),
+  };
+}
+
+function updateErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/verification_submissions") && req.method === "PATCH",
+    handler: () => jsonResponse({ message: "update error" }, { status: 500 }),
+  };
+}
+
+// ─── CORS preflight ───
+Deno.test({
+  name: "handles OPTIONS preflight request",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          new Request("http://localhost", { method: "OPTIONS" }),
+        );
+        assertEquals(res.status, 200);
+      });
+    });
+  },
+});
+
+// ─── 401: no auth ───
+Deno.test({
+  name: "returns 401 without authorization",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authFailRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = new Request("http://localhost", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action: "review" }),
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 401);
+      });
+    });
+  },
+});
+
+// ─── 400: missing action ───
+Deno.test({
+  name: "returns 400 for missing action",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {}),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing action");
+      });
+    });
+  },
+});
+
+// ─── 400: unknown action ───
+Deno.test({
+  name: "returns 400 for unknown action",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", { action: "unknown" }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Unknown action: unknown");
+      });
+    });
+  },
+});
+
+// ─── REVIEW: approved → status + snapshot_data updated ───
+Deno.test({
+  name: "review: approved updates status and snapshot_data",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    let patchBody: string | null = null;
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectSubmissionRoute(),
+      permRoute(),
+      {
+        matcher: (req) =>
+          req.url.includes("/rest/v1/verification_submissions") && req.method === "PATCH",
+        handler: async (req) => {
+          patchBody = await req.clone().text();
+          return new Response(null, { status: 200 });
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "review",
+            submission_id: TEST_SUBMISSION_ID,
+            result: "approved",
+          }),
+        );
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+
+        // Verify PATCH payload
+        const parsed = JSON.parse(patchBody!);
+        assertEquals(parsed.status, "approved");
+        assertEquals(parsed.reviewed_by, TEST_USER_ID);
+        assertEquals(typeof parsed.reviewed_at, "string");
+
+        // snapshot_data last entry should have result/reviewed_by/reviewed_at
+        const lastEntry = parsed.snapshot_data[0];
+        assertEquals(lastEntry.result, "approved");
+        assertEquals(lastEntry.reviewed_by, TEST_USER_ID);
+        assertEquals(typeof lastEntry.reviewed_at, "string");
+      });
+    });
+  },
+});
+
+// ─── REVIEW: rejected + comment ───
+Deno.test({
+  name: "review: rejected with comment includes comment in snapshot",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    let patchBody: string | null = null;
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectSubmissionRoute(),
+      permRoute(),
+      {
+        matcher: (req) =>
+          req.url.includes("/rest/v1/verification_submissions") && req.method === "PATCH",
+        handler: async (req) => {
+          patchBody = await req.clone().text();
+          return new Response(null, { status: 200 });
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "review",
+            submission_id: TEST_SUBMISSION_ID,
+            result: "rejected",
+            comment: "재학증명서가 흐릿합니다",
+          }),
+        );
+        assertEquals(res.status, 200);
+
+        const parsed = JSON.parse(patchBody!);
+        assertEquals(parsed.status, "rejected");
+        const lastEntry = parsed.snapshot_data[0];
+        assertEquals(lastEntry.result, "rejected");
+        assertEquals(lastEntry.comments.length, 1);
+        assertEquals(lastEntry.comments[0].text, "재학증명서가 흐릿합니다");
+        assertEquals(lastEntry.comments[0].author, TEST_USER_ID);
+      });
+    });
+  },
+});
+
+// ─── REVIEW: reviewed_at, reviewed_by columns updated ───
+Deno.test({
+  name: "review: updates reviewed_at and reviewed_by columns",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    let patchBody: string | null = null;
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectSubmissionRoute(),
+      permRoute(),
+      {
+        matcher: (req) =>
+          req.url.includes("/rest/v1/verification_submissions") && req.method === "PATCH",
+        handler: async (req) => {
+          patchBody = await req.clone().text();
+          return new Response(null, { status: 200 });
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "review",
+            submission_id: TEST_SUBMISSION_ID,
+            result: "approved",
+          }),
+        );
+        assertEquals(res.status, 200);
+
+        const parsed = JSON.parse(patchBody!);
+        assertEquals(parsed.reviewed_by, TEST_USER_ID);
+        assertEquals(typeof parsed.reviewed_at, "string");
+      });
+    });
+  },
+});
+
+// ─── COMMENT: append to snapshot_data ───
+Deno.test({
+  name: "comment: appends comment to last snapshot entry",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    let patchBody: string | null = null;
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectSubmissionRoute(),
+      permRoute(),
+      {
+        matcher: (req) =>
+          req.url.includes("/rest/v1/verification_submissions") && req.method === "PATCH",
+        handler: async (req) => {
+          patchBody = await req.clone().text();
+          return new Response(null, { status: 200 });
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "comment",
+            submission_id: TEST_SUBMISSION_ID,
+            text: "재학증명서가 흐릿합니다. 다시 올려주세요",
+          }),
+        );
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+
+        const parsed = JSON.parse(patchBody!);
+        // Only snapshot_data should be updated for comment action
+        assertEquals(parsed.status, undefined);
+        assertEquals(parsed.reviewed_at, undefined);
+
+        const lastEntry = parsed.snapshot_data[0];
+        assertEquals(lastEntry.comments.length, 1);
+        assertEquals(lastEntry.comments[0].text, "재학증명서가 흐릿합니다. 다시 올려주세요");
+        assertEquals(lastEntry.comments[0].author, TEST_USER_ID);
+      });
+    });
+  },
+});
+
+// ─── REVIEW: other partner's submission → 403 ───
+Deno.test({
+  name: "review: returns 403 for other partner's submission",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectSubmissionRoute("other-partner-id"),
+      permRoute(false),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "review",
+            submission_id: TEST_SUBMISSION_ID,
+            result: "approved",
+          }),
+        );
+        assertEquals(res.status, 403);
+      });
+    });
+  },
+});
+
+// ─── REVIEW: invalid result → 400 ───
+Deno.test({
+  name: "review: returns 400 for invalid result value",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "review",
+            submission_id: TEST_SUBMISSION_ID,
+            result: "maybe",
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Invalid result. Must be 'approved' or 'rejected'");
+      });
+    });
+  },
+});
+
+// ─── REVIEW: nonexistent submission → 404 ───
+Deno.test({
+  name: "review: returns 404 for nonexistent submission",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectSubmissionNotFoundRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "review",
+            submission_id: "nonexistent",
+            result: "approved",
+          }),
+        );
+        assertEquals(res.status, 404);
+        const body = await readJson(res);
+        assertEquals(body.error, "Submission not found");
+      });
+    });
+  },
+});
+
+// ─── COMMENT: nonexistent submission → 404 ───
+Deno.test({
+  name: "comment: returns 404 for nonexistent submission",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectSubmissionNotFoundRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "comment",
+            submission_id: "nonexistent",
+            text: "some comment",
+          }),
+        );
+        assertEquals(res.status, 404);
+        const body = await readJson(res);
+        assertEquals(body.error, "Submission not found");
+      });
+    });
+  },
+});
+
+// ─── REVIEW: missing submission_id → 400 ───
+Deno.test({
+  name: "review: returns 400 for missing submission_id",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "review",
+            result: "approved",
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing submission_id");
+      });
+    });
+  },
+});
+
+// ─── COMMENT: missing text → 400 ───
+Deno.test({
+  name: "comment: returns 400 for missing text",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "comment",
+            submission_id: TEST_SUBMISSION_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing text");
+      });
+    });
+  },
+});
+
+// ─── REVIEW: 500 permission DB error ───
+Deno.test({
+  name: "review: returns 500 when permission query fails",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectSubmissionRoute(),
+      permErrorRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "review",
+            submission_id: TEST_SUBMISSION_ID,
+            result: "approved",
+          }),
+        );
+        assertEquals(res.status, 500);
+        const body = await readJson(res);
+        assertEquals(body.error, "Failed to verify partner permissions");
+      });
+    });
+  },
+});
+
+// ─── REVIEW: 500 update error ───
+Deno.test({
+  name: "review: returns 500 when update fails",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectSubmissionRoute(),
+      permRoute(),
+      updateErrorRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "review",
+            submission_id: TEST_SUBMISSION_ID,
+            result: "approved",
+          }),
+        );
+        assertEquals(res.status, 500);
+      });
+    });
+  },
+});
+
+// ─── COMMENT: 500 update error ───
+Deno.test({
+  name: "comment: returns 500 when update fails",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectSubmissionRoute(),
+      permRoute(),
+      updateErrorRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "comment",
+            submission_id: TEST_SUBMISSION_ID,
+            text: "some comment",
+          }),
+        );
+        assertEquals(res.status, 500);
+      });
+    });
+  },
+});

--- a/supabase/functions/partner-review-submission/partner_review_submission_test.ts
+++ b/supabase/functions/partner-review-submission/partner_review_submission_test.ts
@@ -66,6 +66,7 @@ function permErrorRoute(): FetchRoute {
 function selectSubmissionRoute(
   partnerId = TEST_PARTNER_ID,
   snapshotData = SNAPSHOT_DATA,
+  status = "pending",
 ): FetchRoute {
   return {
     matcher: (req) =>
@@ -76,6 +77,7 @@ function selectSubmissionRoute(
       jsonResponse({
         id: TEST_SUBMISSION_ID,
         partner_id: partnerId,
+        status,
         snapshot_data: snapshotData,
       }),
   };
@@ -630,6 +632,35 @@ Deno.test({
           }),
         );
         assertEquals(res.status, 500);
+      });
+    });
+  },
+});
+
+// ─── REVIEW: already reviewed submission → 409 ───
+Deno.test({
+  name: "review: returns 409 for already reviewed submission",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectSubmissionRoute(TEST_PARTNER_ID, SNAPSHOT_DATA, "approved"),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "review",
+            submission_id: TEST_SUBMISSION_ID,
+            result: "rejected",
+          }),
+        );
+        assertEquals(res.status, 409);
+        const body = await readJson(res);
+        assertEquals(body.error, "Submission is already reviewed");
       });
     });
   },


### PR DESCRIPTION
## Summary

Closes #309

- `partner-review-submission` EF 신규 구현 (review + comment 2개 action)
- Flutter `reviewRequest()` → EF 호출 전환 (직접 DB UPDATE 제거)
- `submitComment()`에 `isPartner` 플래그 추가로 partner/user EF 분기
- Review action에서 comment 포함 가능 → 심사 + 코멘트 원샷 처리

### EF 동작
- **review**: status 업데이트 + snapshot_data 마지막 항목에 result/reviewed_by/reviewed_at 기록 + optional comment
- **comment**: snapshot_data 마지막 항목 comments 배열에 append
- 권한: `VERIFY_REVIEW` (partner_member_permissions)
- DB trigger (`on_submission_status_change`)가 approved/rejected 시 자동으로 partner_verified_users + event_applications 처리

## Test plan

- [x] EF 단위 테스트 17개 전체 통과 (review approved/rejected, comment, 403/400/404/500 케이스)
- [x] Flutter 단위 테스트 16개 전체 통과 (EF 호출 검증, comment 포함 검증, 에러 처리)
- [x] `flutter analyze` 이상 없음 (minglit_kit + app_partner)
- [ ] PR 2에서 RLS UPDATE 정책 제거 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)