### PR TITLE
feat(partner): partner-register EF 구현 (입점 신청 + 서버 사이드 검증)

### DIFF
--- a/shared/packages/minglit_kit/lib/src/data/repositories/partner_application_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/partner_application_repository.dart
@@ -1,10 +1,10 @@
 part of 'partner_repository.dart';
 
 mixin _PartnerApplicationRepository on _SupabasePartnerContext {
+  // Fix #311: submitApplication via EF (서버 사이드 검증)
   /// **Submit Application**
   ///
-  /// Uploads proof files to Storage and inserts a record into
-  /// `partner_applications`.
+  /// Uploads proof files to Storage, saves a draft via EF, then submits.
   /// Uses a transaction-like flow (manual rollback on error) to ensure
   /// data consistency.
   Future<void> submitApplication({
@@ -24,13 +24,45 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
       bizRegPath = await _uploadFile(userId, bizRegistrationFile, 'biz_reg');
       bankbookPath = await _uploadFile(userId, bankbookFile, 'bankbook');
 
-      await supabaseClient.from('partner_applications').insert({
-        'user_id': userId,
-        ...applicationData,
-        'biz_registration_path': bizRegPath,
-        'bankbook_path': bankbookPath,
-        'status': 'pending',
-      });
+      // Fix #311: save_draft via EF → submit via EF
+      final draftResponse = await supabaseClient.functions.invoke(
+        'partner-register',
+        body: {
+          'action': 'save_draft',
+          'data': {
+            ...applicationData,
+            'biz_registration_path': bizRegPath,
+            'bankbook_path': bankbookPath,
+          },
+        },
+      );
+
+      if (draftResponse.status != 200) {
+        final respData = draftResponse.data;
+        final errorMsg = respData is Map
+            ? (respData['error'] as String?) ?? 'Failed to save draft'
+            : 'Failed to save draft';
+        throw MinglitUserException(errorMsg);
+      }
+
+      final draftData = draftResponse.data as Map<String, dynamic>;
+      final applicationId = draftData['application_id'] as String;
+
+      final submitResponse = await supabaseClient.functions.invoke(
+        'partner-register',
+        body: {
+          'action': 'submit',
+          'application_id': applicationId,
+        },
+      );
+
+      if (submitResponse.status != 200) {
+        final respData = submitResponse.data;
+        final errorMsg = respData is Map
+            ? (respData['error'] as String?) ?? 'Failed to submit application'
+            : 'Failed to submit application';
+        throw MinglitUserException(errorMsg);
+      }
 
       Log.i('submitApplication success');
     } on Exception catch (e, stackTrace) {
@@ -170,10 +202,12 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
     }
   }
 
+  // Fix #311: saveDraft via EF (서버 사이드 소유권 검증)
   /// **Save Draft**
   ///
   /// Inserts a new draft if application.id is empty, otherwise updates the
-  /// existing record. Returns the persisted PartnerApplication with its id.
+  /// existing record via EF. Returns the persisted PartnerApplication with
+  /// its id.
   Future<PartnerApplication> saveDraft(PartnerApplication application) async {
     final userId = supabaseClient.auth.currentUser?.id;
     if (userId == null) throw const AuthException('User not authenticated');
@@ -181,22 +215,34 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
     Log.d('saveDraft called | user: $userId, id: ${application.id}');
 
     try {
-      final Map<String, dynamic> data;
-      if (application.id.isEmpty) {
-        data = await supabaseClient
-            .from('partner_applications')
-            .insert({'user_id': userId, ...application.toDbJson()})
-            .select()
-            .single();
-      } else {
-        data = await supabaseClient
-            .from('partner_applications')
-            .update(application.toDbJson())
-            .eq('id', application.id)
-            .select()
-            .single();
+      final response = await supabaseClient.functions.invoke(
+        'partner-register',
+        body: {
+          'action': 'save_draft',
+          if (application.id.isNotEmpty) 'application_id': application.id,
+          'data': application.toDbJson(),
+        },
+      );
+
+      if (response.status != 200) {
+        final respData = response.data;
+        final errorMsg = respData is Map
+            ? (respData['error'] as String?) ?? 'Failed to save draft'
+            : 'Failed to save draft';
+        throw MinglitUserException(errorMsg);
       }
-      final result = PartnerApplication.fromJson(data);
+
+      final data = response.data as Map<String, dynamic>;
+      final applicationId = data['application_id'] as String;
+
+      // Re-fetch the full record since EF only returns the id
+      final fullData = await supabaseClient
+          .from('partner_applications')
+          .select()
+          .eq('id', applicationId)
+          .single();
+
+      final result = PartnerApplication.fromJson(fullData);
       Log.i('saveDraft success | id: ${result.id}');
       return result;
     } catch (e, st) {
@@ -205,9 +251,10 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
     }
   }
 
+  // Fix #311: updateApplication via EF (서버 사이드 상태/소유권 검증)
   /// **Update Application**
   ///
-  /// Updates an existing application by id. The RLS policy enforces that only
+  /// Updates an existing application by id via EF. The EF enforces that only
   /// records in status 'draft' or 'needs_correction' can be updated.
   /// Returns the updated [PartnerApplication].
   Future<PartnerApplication> updateApplication(
@@ -215,13 +262,31 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
   ) async {
     Log.d('updateApplication called | id: ${application.id}');
     try {
-      final data = await supabaseClient
+      final response = await supabaseClient.functions.invoke(
+        'partner-register',
+        body: {
+          'action': 'update',
+          'application_id': application.id,
+          'data': application.toDbJson(),
+        },
+      );
+
+      if (response.status != 200) {
+        final respData = response.data;
+        final errorMsg = respData is Map
+            ? (respData['error'] as String?) ?? 'Failed to update application'
+            : 'Failed to update application';
+        throw MinglitUserException(errorMsg);
+      }
+
+      // Re-fetch the full record
+      final fullData = await supabaseClient
           .from('partner_applications')
-          .update(application.toDbJson())
-          .eq('id', application.id)
           .select()
+          .eq('id', application.id)
           .single();
-      final result = PartnerApplication.fromJson(data);
+
+      final result = PartnerApplication.fromJson(fullData);
       Log.i('updateApplication success | id: ${result.id}');
       return result;
     } catch (e, st) {
@@ -230,22 +295,41 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
     }
   }
 
+  // Fix #311: submitDraft via EF (서버 사이드 필수 필드 + 형식 검증)
   /// **Submit Draft**
   ///
   /// Transitions the application status from 'draft'/'needs_correction' to
-  /// 'pending'. Returns the updated [PartnerApplication].
+  /// 'pending' via EF with server-side validation.
+  /// Returns the updated [PartnerApplication].
   Future<PartnerApplication> submitDraft({
     required String applicationId,
   }) async {
     Log.d('submitDraft called | id: $applicationId');
     try {
-      final data = await supabaseClient
+      final response = await supabaseClient.functions.invoke(
+        'partner-register',
+        body: {
+          'action': 'submit',
+          'application_id': applicationId,
+        },
+      );
+
+      if (response.status != 200) {
+        final respData = response.data;
+        final errorMsg = respData is Map
+            ? (respData['error'] as String?) ?? 'Failed to submit draft'
+            : 'Failed to submit draft';
+        throw MinglitUserException(errorMsg);
+      }
+
+      // Re-fetch the full record
+      final fullData = await supabaseClient
           .from('partner_applications')
-          .update({'status': 'pending'})
-          .eq('id', applicationId)
           .select()
+          .eq('id', applicationId)
           .single();
-      final result = PartnerApplication.fromJson(data);
+
+      final result = PartnerApplication.fromJson(fullData);
       Log.i('submitDraft success | id: ${result.id}');
       return result;
     } catch (e, st) {

--- a/shared/packages/minglit_kit/lib/src/data/repositories/partner_application_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/partner_application_repository.dart
@@ -38,11 +38,7 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
       );
 
       if (draftResponse.status != 200) {
-        final respData = draftResponse.data;
-        final errorMsg = respData is Map
-            ? (respData['error'] as String?) ?? 'Failed to save draft'
-            : 'Failed to save draft';
-        throw MinglitUserException(errorMsg);
+        throw _efError(draftResponse, 'Failed to save draft');
       }
 
       final draftData = draftResponse.data as Map<String, dynamic>;
@@ -57,11 +53,7 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
       );
 
       if (submitResponse.status != 200) {
-        final respData = submitResponse.data;
-        final errorMsg = respData is Map
-            ? (respData['error'] as String?) ?? 'Failed to submit application'
-            : 'Failed to submit application';
-        throw MinglitUserException(errorMsg);
+        throw _efError(submitResponse, 'Failed to submit application');
       }
 
       Log.i('submitApplication success');
@@ -225,11 +217,7 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
       );
 
       if (response.status != 200) {
-        final respData = response.data;
-        final errorMsg = respData is Map
-            ? (respData['error'] as String?) ?? 'Failed to save draft'
-            : 'Failed to save draft';
-        throw MinglitUserException(errorMsg);
+        throw _efError(response, 'Failed to save draft');
       }
 
       final data = response.data as Map<String, dynamic>;
@@ -272,11 +260,7 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
       );
 
       if (response.status != 200) {
-        final respData = response.data;
-        final errorMsg = respData is Map
-            ? (respData['error'] as String?) ?? 'Failed to update application'
-            : 'Failed to update application';
-        throw MinglitUserException(errorMsg);
+        throw _efError(response, 'Failed to update application');
       }
 
       // Re-fetch the full record
@@ -315,11 +299,7 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
       );
 
       if (response.status != 200) {
-        final respData = response.data;
-        final errorMsg = respData is Map
-            ? (respData['error'] as String?) ?? 'Failed to submit draft'
-            : 'Failed to submit draft';
-        throw MinglitUserException(errorMsg);
+        throw _efError(response, 'Failed to submit draft');
       }
 
       // Re-fetch the full record
@@ -392,5 +372,21 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
     if (userId == null) throw const AuthException('User not authenticated');
     Log.d('uploadBankbook called | file: ${file.name}');
     return _uploadFile(userId, file, 'bankbook');
+  }
+
+  // Fix #311: EF 에러 응답에서 details (필드별 검증 에러)를 포함한 예외 생성
+  MinglitUserException _efError(FunctionResponse response, String fallback) {
+    final respData = response.data;
+    if (respData is Map) {
+      final errorMsg = (respData['error'] as String?) ?? fallback;
+      final rawDetails = respData['details'];
+      final details = rawDetails is List
+          ? rawDetails
+              .whereType<Map<String, dynamic>>()
+              .toList()
+          : null;
+      return MinglitUserException(errorMsg, details: details);
+    }
+    return MinglitUserException(fallback);
   }
 }

--- a/shared/packages/minglit_kit/lib/src/data/repositories/partner_application_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/partner_application_repository.dart
@@ -38,6 +38,8 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
       );
 
       if (draftResponse.status != 200) {
+        // Draft 생성 실패 시 업로드 파일 롤백
+        await _cleanupFiles([bizRegPath, bankbookPath]);
         throw _efError(draftResponse, 'Failed to save draft');
       }
 
@@ -53,22 +55,13 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
       );
 
       if (submitResponse.status != 200) {
-        throw _efError(submitResponse, 'Failed to submit application');
+        // Fix #311: submit 실패 시 draft와 파일은 유지 (유저가 수정 후 재제출 가능)
+        throw _efError(submitResponse, '입점 신청에 실패했습니다');
       }
 
       Log.i('submitApplication success');
     } on Exception catch (e, stackTrace) {
       Log.e('❌ [PartnerRepo] Application Failed', e, stackTrace);
-      // Attempt cleanup (Best effort)
-      try {
-        await supabaseClient.storage
-            .from('partner-proofs')
-            .remove(
-              [bizRegPath, bankbookPath].whereType<String>().toList(),
-            );
-      } on Exception catch (_) {
-        // Ignore cleanup errors
-      }
       rethrow;
     }
   }
@@ -374,15 +367,29 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
     return _uploadFile(userId, file, 'bankbook');
   }
 
+  Future<void> _cleanupFiles(List<String?> paths) async {
+    try {
+      await supabaseClient.storage
+          .from('partner-proofs')
+          .remove(paths.whereType<String>().toList());
+    } on Exception catch (_) {
+      // Best effort cleanup
+    }
+  }
+
   // Fix #311: EF 에러 응답에서 details (필드별 검증 에러)를 포함한 예외 생성
   MinglitUserException _efError(FunctionResponse response, String fallback) {
     final respData = response.data;
     if (respData is Map) {
-      final errorMsg = (respData['error'] as String?) ?? fallback;
+      final rawError = (respData['error'] as String?) ?? fallback;
       final rawDetails = respData['details'];
       final details = rawDetails is List
           ? rawDetails.whereType<Map<String, dynamic>>().toList()
           : null;
+      // Fix #311: validation_failed 등 기계적 코드를 사용자 친화적 메시지로 변환
+      final errorMsg = rawError == 'validation_failed'
+          ? '입력 정보를 확인해주세요'
+          : rawError;
       return MinglitUserException(errorMsg, details: details);
     }
     return MinglitUserException(fallback);

--- a/shared/packages/minglit_kit/lib/src/data/repositories/partner_application_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/partner_application_repository.dart
@@ -381,9 +381,7 @@ mixin _PartnerApplicationRepository on _SupabasePartnerContext {
       final errorMsg = (respData['error'] as String?) ?? fallback;
       final rawDetails = respData['details'];
       final details = rawDetails is List
-          ? rawDetails
-              .whereType<Map<String, dynamic>>()
-              .toList()
+          ? rawDetails.whereType<Map<String, dynamic>>().toList()
           : null;
       return MinglitUserException(errorMsg, details: details);
     }

--- a/shared/packages/minglit_kit/lib/src/data/repositories/partner_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/partner_repository.dart
@@ -1,6 +1,7 @@
 import 'package:image_picker/image_picker.dart' show XFile;
 import 'package:minglit_kit/src/data/models/partner.dart';
 import 'package:minglit_kit/src/data/models/partner_application.dart';
+import 'package:minglit_kit/src/utils/exceptions.dart';
 import 'package:minglit_kit/src/utils/log.dart';
 import 'package:path/path.dart' as p;
 import 'package:riverpod_annotation/riverpod_annotation.dart';

--- a/shared/packages/minglit_kit/lib/src/utils/exceptions.dart
+++ b/shared/packages/minglit_kit/lib/src/utils/exceptions.dart
@@ -73,7 +73,13 @@ abstract class MinglitException implements Exception {
 /// The [message] is safe to display to the user directly.
 class MinglitUserException extends MinglitException {
   /// Creates a user-facing exception with a safe [message].
-  const MinglitUserException(super.message);
+  /// Optionally includes field-level [details] for validation errors.
+  const MinglitUserException(super.message, {this.details});
+
+  // Fix #311: 서버 사이드 검증 실패 시 필드별 에러 상세 정보
+  /// Field-level validation error details from the server.
+  /// Each entry contains `field` and `message` keys.
+  final List<Map<String, dynamic>>? details;
 }
 
 /// **Auth Exception**

--- a/shared/packages/minglit_kit/test/src/data/repositories/partner_application_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/partner_application_repository_test.dart
@@ -2,13 +2,16 @@ import 'dart:async' show unawaited;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/models/partner_application.dart';
 import 'package:minglit_kit/src/data/repositories/partner_repository.dart';
+import 'package:minglit_kit/src/utils/exceptions.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../../helpers/mocks.dart';
 import '../../../helpers/supabase_mock_helpers.dart';
 
 void main() {
   late MockSupabaseClient mockClient;
+  late MockFunctionsClient mockFunctions;
   late PartnerRepository repository;
 
   final now = DateTime.now();
@@ -28,6 +31,7 @@ void main() {
   setUp(() {
     mockClient = createMockSupabase(currentUser: mockUser);
     when(() => mockUser.id).thenReturn('user_1');
+    mockFunctions = mockClient.functions as MockFunctionsClient;
     repository = PartnerRepository(supabase: mockClient);
   });
 
@@ -154,6 +158,7 @@ void main() {
       });
     });
 
+    // Fix #311: saveDraft via EF
     group('saveDraft', () {
       test('inserts new draft when id is empty', () async {
         const draftApp = PartnerApplication(
@@ -162,11 +167,24 @@ void main() {
           brandName: 'New Brand',
         );
 
+        when(
+          () => mockFunctions.invoke(
+            'partner-register',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true, 'application_id': 'app_1'},
+          ),
+        );
+
+        // Re-fetch after EF
         unawaited(
           mockTable(
             mockClient,
             'partner_applications',
-            insertReturnData: applicationJson,
+            singleData: applicationJson,
           ),
         );
 
@@ -182,6 +200,19 @@ void main() {
           brandName: 'Existing Brand',
         );
 
+        when(
+          () => mockFunctions.invoke(
+            'partner-register',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true, 'application_id': 'app_1'},
+          ),
+        );
+
+        // Re-fetch after EF
         unawaited(
           mockTable(
             mockClient,
@@ -208,8 +239,33 @@ void main() {
           throwsA(isA<Exception>()),
         );
       });
+
+      test('throws MinglitUserException on EF error', () async {
+        const draftApp = PartnerApplication(
+          id: '',
+          userId: 'user_1',
+        );
+
+        when(
+          () => mockFunctions.invoke(
+            'partner-register',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 403,
+            data: {'error': 'Forbidden: not your application'},
+          ),
+        );
+
+        await expectLater(
+          repository.saveDraft(draftApp),
+          throwsA(isA<MinglitUserException>()),
+        );
+      });
     });
 
+    // Fix #311: updateApplication via EF
     group('updateApplication', () {
       test('returns updated application on success', () async {
         const app = PartnerApplication(
@@ -218,6 +274,19 @@ void main() {
           brandName: 'Updated Brand',
         );
 
+        when(
+          () => mockFunctions.invoke(
+            'partner-register',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true, 'application_id': 'app_1'},
+          ),
+        );
+
+        // Re-fetch after EF
         unawaited(
           mockTable(
             mockClient,
@@ -236,24 +305,43 @@ void main() {
           userId: 'user_1',
         );
 
-        unawaited(
-          mockTable(
-            mockClient,
-            'partner_applications',
-            shouldThrow: Exception('update error'),
+        when(
+          () => mockFunctions.invoke(
+            'partner-register',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 400,
+            data: {'error': 'Application cannot be updated in current status'},
           ),
         );
 
         await expectLater(
           repository.updateApplication(app),
-          throwsA(isA<Exception>()),
+          throwsA(isA<MinglitUserException>()),
         );
       });
     });
 
+    // Fix #311: submitDraft via EF (서버 사이드 검증)
     group('submitDraft', () {
       test('returns submitted application on success', () async {
         final pendingJson = {...applicationJson, 'status': 'pending'};
+
+        when(
+          () => mockFunctions.invoke(
+            'partner-register',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true},
+          ),
+        );
+
+        // Re-fetch after EF
         unawaited(
           mockTable(
             mockClient,
@@ -268,17 +356,21 @@ void main() {
       });
 
       test('throws on error', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'partner_applications',
-            shouldThrow: Exception('submit error'),
+        when(
+          () => mockFunctions.invoke(
+            'partner-register',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 400,
+            data: {'error': 'validation_failed'},
           ),
         );
 
         await expectLater(
           repository.submitDraft(applicationId: 'app_1'),
-          throwsA(isA<Exception>()),
+          throwsA(isA<MinglitUserException>()),
         );
       });
     });

--- a/supabase/functions/_shared/validation_utils.ts
+++ b/supabase/functions/_shared/validation_utils.ts
@@ -1,0 +1,85 @@
+// validation_utils.ts — Shared validation utilities for Edge Functions
+// Issue #311: partner-register EF에서 사용하는 검증 유틸
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+/**
+ * Validates that a string field is non-empty.
+ */
+export function requireNonEmpty(
+  value: unknown,
+  field: string,
+  label: string,
+): ValidationError | null {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return { field, message: `${label}은(는) 필수 항목입니다` };
+  }
+  return null;
+}
+
+/**
+ * Validates biz_type is a valid enum value.
+ */
+const VALID_BIZ_TYPES = ["individual", "corporate"];
+
+export function validateBizType(value: unknown): ValidationError | null {
+  if (typeof value !== "string" || !VALID_BIZ_TYPES.includes(value)) {
+    return { field: "biz_type", message: "사업자 유형이 올바르지 않습니다 (individual/corporate)" };
+  }
+  return null;
+}
+
+/**
+ * Validates Korean business registration number (10-digit + checksum).
+ *
+ * Format: 10 consecutive digits.
+ * Checksum: weighted sum mod 10 algorithm used by NTS.
+ */
+export function validateBizNumber(value: unknown): ValidationError | null {
+  if (typeof value !== "string") {
+    return { field: "biz_number", message: "올바른 사업자번호 형식이 아닙니다" };
+  }
+
+  const digits = value.replace(/-/g, "");
+  if (!/^\d{10}$/.test(digits)) {
+    return { field: "biz_number", message: "올바른 사업자번호 형식이 아닙니다" };
+  }
+
+  // NTS checksum weights
+  const weights = [1, 3, 7, 1, 3, 7, 1, 3, 5];
+  let sum = 0;
+  for (let i = 0; i < 9; i++) {
+    sum += parseInt(digits[i]) * weights[i];
+  }
+  sum += Math.floor((parseInt(digits[8]) * 5) / 10);
+  const checkDigit = (10 - (sum % 10)) % 10;
+
+  if (checkDigit !== parseInt(digits[9])) {
+    return { field: "biz_number", message: "올바른 사업자번호 형식이 아닙니다" };
+  }
+
+  return null;
+}
+
+/**
+ * Validates Korean phone number format: 01X-XXXX-XXXX (digits only).
+ */
+export function validatePhone(value: unknown): ValidationError | null {
+  if (typeof value !== "string" || !/^01[016789]\d{7,8}$/.test(value.replace(/-/g, ""))) {
+    return { field: "contact_phone", message: "올바른 전화번호 형식이 아닙니다" };
+  }
+  return null;
+}
+
+/**
+ * Validates email format (basic RFC 5322 pattern).
+ */
+export function validateEmail(value: unknown): ValidationError | null {
+  if (typeof value !== "string" || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
+    return { field: "contact_email", message: "올바른 이메일 형식이 아닙니다" };
+  }
+  return null;
+}

--- a/supabase/functions/partner-register/deno.json
+++ b/supabase/functions/partner-register/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/partner-register/e2e_test.ts
+++ b/supabase/functions/partner-register/e2e_test.ts
@@ -1,0 +1,866 @@
+import { assertEquals } from "@std/assert";
+import {
+  authenticatedJsonRequest,
+  captureServeHandler,
+  createFetchMock,
+  jsonResponse,
+  readJson,
+  withEnv,
+  withMockedFetch,
+  type FetchRoute,
+} from "../_test_utils/mock_http.ts";
+
+const TEST_USER_ID = "user-applicant-001";
+const OTHER_USER_ID = "user-other-002";
+const TEST_APP_ID = "app-001";
+
+const ENV = {
+  SUPABASE_URL: "http://localhost:54321",
+  SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+};
+
+// Valid complete application data for submit tests
+const VALID_APP = {
+  id: TEST_APP_ID,
+  user_id: TEST_USER_ID,
+  status: "draft",
+  brand_name: "테스트브랜드",
+  biz_type: "individual",
+  biz_name: "테스트사업자",
+  biz_number: "1234567890",
+  representative_name: "홍길동",
+  contact_phone: "01012345678",
+  contact_email: "test@example.com",
+  bank_name: "국민은행",
+  account_number: "12345678901234",
+  account_holder: "홍길동",
+  biz_registration_path: "user-applicant-001/biz_reg_123.pdf",
+  bankbook_path: "user-applicant-001/bankbook_123.pdf",
+};
+
+function authRoute(userId = TEST_USER_ID): FetchRoute {
+  return {
+    matcher: "/auth/v1/user",
+    handler: () => jsonResponse({ id: userId, email: "test@test.com" }),
+  };
+}
+
+function authFailRoute(): FetchRoute {
+  return {
+    matcher: "/auth/v1/user",
+    handler: () => jsonResponse({ error: "invalid" }, { status: 401 }),
+  };
+}
+
+// SELECT route for fetching application
+function selectAppRoute(app: Record<string, unknown> | null = VALID_APP): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/partner_applications") &&
+      req.url.includes("select=") &&
+      req.method === "GET",
+    handler: () => jsonResponse(app),
+  };
+}
+
+// INSERT route for save_draft (new)
+function insertRoute(id = TEST_APP_ID): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/partner_applications") && req.method === "POST",
+    handler: () => jsonResponse({ id }),
+  };
+}
+
+function insertErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/partner_applications") && req.method === "POST",
+    handler: () => jsonResponse({ message: "insert error" }, { status: 500 }),
+  };
+}
+
+// UPDATE (PATCH) route
+function updateRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/partner_applications") && req.method === "PATCH",
+    handler: () => new Response(null, { status: 200 }),
+  };
+}
+
+function updateErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/partner_applications") && req.method === "PATCH",
+    handler: () => jsonResponse({ message: "update error" }, { status: 500 }),
+  };
+}
+
+// Storage list route (for file existence check)
+function storageListRoute(hasFiles = true): FetchRoute {
+  return {
+    matcher: (req) => req.url.includes("/storage/v1/object/list/partner-proofs"),
+    handler: () =>
+      jsonResponse(hasFiles ? [{ name: "file.pdf" }] : []),
+  };
+}
+
+// ─── CORS preflight ───
+Deno.test({
+  name: "handles OPTIONS preflight request",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          new Request("http://localhost", { method: "OPTIONS" }),
+        );
+        assertEquals(res.status, 200);
+      });
+    });
+  },
+});
+
+// ─── 401: no auth ───
+Deno.test({
+  name: "returns 401 without authorization",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authFailRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = new Request("http://localhost", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action: "save_draft" }),
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 401);
+      });
+    });
+  },
+});
+
+// ─── 400: missing action ───
+Deno.test({
+  name: "returns 400 for missing action",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {}),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing action");
+      });
+    });
+  },
+});
+
+// ─── 400: unknown action ───
+Deno.test({
+  name: "returns 400 for unknown action",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", { action: "unknown" }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Unknown action: unknown");
+      });
+    });
+  },
+});
+
+// ═══════════════════════════════════════════
+// save_draft
+// ═══════════════════════════════════════════
+
+// ─── save_draft: new INSERT → returns application_id ───
+Deno.test({
+  name: "save_draft: new insert returns application_id",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      insertRoute("new-app-id"),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "save_draft",
+            data: { brand_name: "테스트", current_step: 1 },
+          }),
+        );
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+        assertEquals(body.application_id, "new-app-id");
+      });
+    });
+  },
+});
+
+// ─── save_draft: existing UPDATE ───
+Deno.test({
+  name: "save_draft: existing update returns application_id",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectAppRoute({ id: TEST_APP_ID, user_id: TEST_USER_ID }),
+      updateRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "save_draft",
+            application_id: TEST_APP_ID,
+            data: { brand_name: "수정된 브랜드", current_step: 2 },
+          }),
+        );
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+        assertEquals(body.application_id, TEST_APP_ID);
+      });
+    });
+  },
+});
+
+// ─── save_draft: current_step saved ───
+Deno.test({
+  name: "save_draft: current_step is persisted",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    let insertBody: string | null = null;
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      {
+        matcher: (req) =>
+          req.url.includes("/rest/v1/partner_applications") && req.method === "POST",
+        handler: async (req) => {
+          insertBody = await req.clone().text();
+          return jsonResponse({ id: "new-id" });
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "save_draft",
+            data: { brand_name: "테스트", current_step: 3 },
+          }),
+        );
+        assertEquals(res.status, 200);
+        const parsed = JSON.parse(insertBody!);
+        assertEquals(parsed.current_step, 3);
+        assertEquals(parsed.status, "draft");
+      });
+    });
+  },
+});
+
+// ─── save_draft: other user's draft → 403 ───
+Deno.test({
+  name: "save_draft: returns 403 for other user's draft",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectAppRoute({ id: TEST_APP_ID, user_id: OTHER_USER_ID }),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "save_draft",
+            application_id: TEST_APP_ID,
+            data: { brand_name: "해킹 시도" },
+          }),
+        );
+        assertEquals(res.status, 403);
+      });
+    });
+  },
+});
+
+// ─── save_draft: insert error → 500 ───
+Deno.test({
+  name: "save_draft: returns 500 when insert fails",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      insertErrorRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "save_draft",
+            data: { brand_name: "테스트" },
+          }),
+        );
+        assertEquals(res.status, 500);
+      });
+    });
+  },
+});
+
+// ═══════════════════════════════════════════
+// submit
+// ═══════════════════════════════════════════
+
+// ─── submit: draft → pending with all fields valid ───
+Deno.test({
+  name: "submit: draft → pending with valid data",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    // Use valid biz_number with correct checksum: 1208100083
+    const validApp = { ...VALID_APP, biz_number: "1208100088" };
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectAppRoute(validApp),
+      storageListRoute(true),
+      updateRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "submit",
+            application_id: TEST_APP_ID,
+          }),
+        );
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+      });
+    });
+  },
+});
+
+// ─── submit: missing required fields → 400 + details ───
+Deno.test({
+  name: "submit: returns 400 with validation details for missing fields",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const incompleteApp = {
+      id: TEST_APP_ID,
+      user_id: TEST_USER_ID,
+      status: "draft",
+      brand_name: "",
+      biz_type: null,
+      biz_name: null,
+      biz_number: null,
+      representative_name: null,
+      contact_phone: null,
+      contact_email: null,
+      bank_name: null,
+      account_number: null,
+      account_holder: null,
+      biz_registration_path: null,
+      bankbook_path: null,
+    };
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectAppRoute(incompleteApp),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "submit",
+            application_id: TEST_APP_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "validation_failed");
+        assertEquals(Array.isArray(body.details), true);
+        // Should have errors for multiple fields
+        const fields = body.details.map((d: { field: string }) => d.field);
+        assertEquals(fields.includes("brand_name"), true);
+        assertEquals(fields.includes("biz_type"), true);
+        assertEquals(fields.includes("biz_number"), true);
+        assertEquals(fields.includes("contact_phone"), true);
+        assertEquals(fields.includes("contact_email"), true);
+      });
+    });
+  },
+});
+
+// ─── submit: biz_number format error → 400 ───
+Deno.test({
+  name: "submit: returns 400 for invalid biz_number format",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const badBizApp = { ...VALID_APP, biz_number: "123" };
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectAppRoute(badBizApp),
+      storageListRoute(true),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "submit",
+            application_id: TEST_APP_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "validation_failed");
+        const bizErr = body.details.find((d: { field: string }) => d.field === "biz_number");
+        assertEquals(bizErr !== undefined, true);
+      });
+    });
+  },
+});
+
+// ─── submit: contact_email format error → 400 ───
+Deno.test({
+  name: "submit: returns 400 for invalid email format",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const badEmailApp = { ...VALID_APP, biz_number: "1208100088", contact_email: "not-an-email" };
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectAppRoute(badEmailApp),
+      storageListRoute(true),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "submit",
+            application_id: TEST_APP_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "validation_failed");
+        const emailErr = body.details.find((d: { field: string }) => d.field === "contact_email");
+        assertEquals(emailErr !== undefined, true);
+      });
+    });
+  },
+});
+
+// ─── submit: biz_registration_path file not found → 400 ───
+Deno.test({
+  name: "submit: returns 400 when storage file not found",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const validApp = { ...VALID_APP, biz_number: "1208100088" };
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectAppRoute(validApp),
+      storageListRoute(false),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "submit",
+            application_id: TEST_APP_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "validation_failed");
+      });
+    });
+  },
+});
+
+// ─── submit: pending → re-submit → 400 ───
+Deno.test({
+  name: "submit: returns 400 when already pending",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const pendingApp = { ...VALID_APP, status: "pending" };
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectAppRoute(pendingApp),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "submit",
+            application_id: TEST_APP_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Application cannot be submitted in current status");
+      });
+    });
+  },
+});
+
+// ─── submit: needs_correction → pending ───
+Deno.test({
+  name: "submit: needs_correction → pending transition success",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const correctionApp = { ...VALID_APP, status: "needs_correction", biz_number: "1208100088" };
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectAppRoute(correctionApp),
+      storageListRoute(true),
+      updateRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "submit",
+            application_id: TEST_APP_ID,
+          }),
+        );
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+      });
+    });
+  },
+});
+
+// ─── submit: missing application_id → 400 ───
+Deno.test({
+  name: "submit: returns 400 for missing application_id",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "submit",
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing application_id");
+      });
+    });
+  },
+});
+
+// ─── submit: other user's application → 403 ───
+Deno.test({
+  name: "submit: returns 403 for other user's application",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const otherApp = { ...VALID_APP, user_id: OTHER_USER_ID };
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectAppRoute(otherApp),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "submit",
+            application_id: TEST_APP_ID,
+          }),
+        );
+        assertEquals(res.status, 403);
+      });
+    });
+  },
+});
+
+// ═══════════════════════════════════════════
+// update
+// ═══════════════════════════════════════════
+
+// ─── update: draft → success ───
+Deno.test({
+  name: "update: draft status allows update",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectAppRoute({ id: TEST_APP_ID, user_id: TEST_USER_ID, status: "draft" }),
+      updateRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            application_id: TEST_APP_ID,
+            data: { brand_name: "수정된 브랜드" },
+          }),
+        );
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+        assertEquals(body.application_id, TEST_APP_ID);
+      });
+    });
+  },
+});
+
+// ─── update: needs_correction → success ───
+Deno.test({
+  name: "update: needs_correction status allows update",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectAppRoute({ id: TEST_APP_ID, user_id: TEST_USER_ID, status: "needs_correction" }),
+      updateRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            application_id: TEST_APP_ID,
+            data: { brand_name: "보정된 브랜드" },
+          }),
+        );
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+      });
+    });
+  },
+});
+
+// ─── update: pending → 400 ───
+Deno.test({
+  name: "update: returns 400 when status is pending",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectAppRoute({ id: TEST_APP_ID, user_id: TEST_USER_ID, status: "pending" }),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            application_id: TEST_APP_ID,
+            data: { brand_name: "수정 시도" },
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Application cannot be updated in current status");
+      });
+    });
+  },
+});
+
+// ─── update: other user → 403 ───
+Deno.test({
+  name: "update: returns 403 for other user's application",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectAppRoute({ id: TEST_APP_ID, user_id: OTHER_USER_ID, status: "draft" }),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            application_id: TEST_APP_ID,
+            data: { brand_name: "해킹" },
+          }),
+        );
+        assertEquals(res.status, 403);
+      });
+    });
+  },
+});
+
+// ─── update: missing application_id → 400 ───
+Deno.test({
+  name: "update: returns 400 for missing application_id",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            data: { brand_name: "테스트" },
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing application_id");
+      });
+    });
+  },
+});
+
+// ─── update: no valid fields → 400 ───
+Deno.test({
+  name: "update: returns 400 when no valid fields in data",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectAppRoute({ id: TEST_APP_ID, user_id: TEST_USER_ID, status: "draft" }),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            application_id: TEST_APP_ID,
+            data: { status: "approved", user_id: "hacker" },
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "No fields to update");
+      });
+    });
+  },
+});
+
+// ─── update: whitelisted fields only — status/user_id ignored ───
+Deno.test({
+  name: "update: only whitelisted fields are sent to DB",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    let patchBody: string | null = null;
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectAppRoute({ id: TEST_APP_ID, user_id: TEST_USER_ID, status: "draft" }),
+      {
+        matcher: (req) =>
+          req.url.includes("/rest/v1/partner_applications") && req.method === "PATCH",
+        handler: async (req) => {
+          patchBody = await req.clone().text();
+          return new Response(null, { status: 200 });
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update",
+            application_id: TEST_APP_ID,
+            data: {
+              brand_name: "정상 수정",
+              status: "approved",
+              user_id: "hacker-id",
+              id: "fake-id",
+            },
+          }),
+        );
+        assertEquals(res.status, 200);
+        const parsed = JSON.parse(patchBody!);
+        assertEquals(parsed.brand_name, "정상 수정");
+        assertEquals(parsed.status, undefined);
+        assertEquals(parsed.user_id, undefined);
+        assertEquals(parsed.id, undefined);
+      });
+    });
+  },
+});

--- a/supabase/functions/partner-register/index.ts
+++ b/supabase/functions/partner-register/index.ts
@@ -97,9 +97,21 @@ async function handleRequest(req: Request): Promise<Response> {
     record.status = "draft";
 
     if (applicationId) {
-      // UPDATE existing draft — verify ownership
-      const ownerCheck = await verifyOwnership(supabase, applicationId, userId);
-      if (ownerCheck instanceof Response) return ownerCheck;
+      // UPDATE existing draft — verify ownership + status guard
+      const { data: app, error: fetchError } = await supabase
+        .from("partner_applications")
+        .select("id, user_id, status")
+        .eq("id", applicationId)
+        .maybeSingle();
+      if (fetchError) return errorResponse("Failed to load application", 500);
+      if (!app) return errorResponse("Application not found", 404);
+      if (app.user_id !== userId) {
+        return errorResponse("Forbidden: not your application", 403);
+      }
+      // Fix #311: pending/approved 신청서는 save_draft로 되돌릴 수 없음
+      if (app.status !== "draft" && app.status !== "needs_correction") {
+        return errorResponse("Application cannot be updated in current status", 400);
+      }
 
       const { error: updateError } = await supabase
         .from("partner_applications")
@@ -200,14 +212,24 @@ async function handleRequest(req: Request): Promise<Response> {
         errors.push({ field, message });
         continue;
       }
-      // Verify file exists in storage
-      const { data: fileData } = await supabase.storage
-        .from("partner-proofs")
-        .list(path.substring(0, path.lastIndexOf("/")), {
-          search: path.substring(path.lastIndexOf("/") + 1),
-        });
+      // Fix #311: 파일 경로가 본인 디렉토리인지 검증
+      if (!path.startsWith(`${userId}/`)) {
+        return errorResponse("Forbidden file path", 403);
+      }
 
-      if (!fileData || fileData.length === 0) {
+      const folder = path.substring(0, path.lastIndexOf("/"));
+      const filename = path.substring(path.lastIndexOf("/") + 1);
+
+      // Verify file exists in storage
+      const { data: fileData, error: fileError } = await supabase.storage
+        .from("partner-proofs")
+        .list(folder, { search: filename });
+
+      if (fileError) {
+        return errorResponse("Failed to verify uploaded files", 500);
+      }
+
+      if (!fileData.some((file) => file.name === filename)) {
         errors.push({ field, message });
       }
     }
@@ -287,25 +309,3 @@ async function handleRequest(req: Request): Promise<Response> {
   return errorResponse(`Unknown action: ${action}`, 400);
 }
 
-// ─── Helper: verify application ownership ───
-async function verifyOwnership(
-  supabase: ReturnType<typeof createClient>,
-  applicationId: string,
-  userId: string,
-): Promise<void | Response> {
-  const { data: app, error } = await supabase
-    .from("partner_applications")
-    .select("id, user_id")
-    .eq("id", applicationId)
-    .maybeSingle();
-
-  if (error) {
-    return errorResponse("Failed to load application", 500);
-  }
-  if (!app) {
-    return errorResponse("Application not found", 404);
-  }
-  if (app.user_id !== userId) {
-    return errorResponse("Forbidden: not your application", 403);
-  }
-}

--- a/supabase/functions/partner-register/index.ts
+++ b/supabase/functions/partner-register/index.ts
@@ -1,0 +1,311 @@
+// partner-register — Partner application (save draft, submit, update)
+// Issue #311: RLS write strategy 전환
+
+import { createClient } from "@supabase/supabase-js";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
+import { requireAuth } from "../_shared/auth_utils.ts";
+import {
+  requireNonEmpty,
+  validateBizNumber,
+  validateBizType,
+  validateEmail,
+  validatePhone,
+  type ValidationError,
+} from "../_shared/validation_utils.ts";
+
+// Fields allowed in save_draft / update actions
+const DRAFT_FIELDS = [
+  "brand_name",
+  "introduction",
+  "address",
+  "contact_phone",
+  "contact_email",
+  "biz_type",
+  "biz_name",
+  "biz_number",
+  "representative_name",
+  "bank_name",
+  "account_number",
+  "account_holder",
+  "tax_email",
+  "biz_registration_path",
+  "bankbook_path",
+  "profile_image_path",
+  "current_step",
+] as const;
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") return corsResponse();
+  if (req.method !== "POST") return errorResponse("Method not allowed", 405);
+
+  try {
+    return await handleRequest(req);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return errorResponse(message, 500);
+  }
+});
+
+async function handleRequest(req: Request): Promise<Response> {
+  // 1. Environment check
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !serviceRoleKey) {
+    return errorResponse("Missing server configuration", 500);
+  }
+
+  // 2. Auth
+  const auth = await requireAuth(req);
+  if (auth instanceof Response) return auth;
+  const userId = auth;
+
+  // 3. Parse body
+  let body: Record<string, unknown>;
+  try {
+    const parsed = await req.json();
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return errorResponse("Request body must be a JSON object", 400);
+    }
+    body = parsed as Record<string, unknown>;
+  } catch {
+    return errorResponse("Invalid JSON body", 400);
+  }
+
+  const action = body.action as string | undefined;
+  if (typeof action !== "string" || !action) return errorResponse("Missing action", 400);
+
+  // 4. Supabase client (service role)
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  });
+
+  // ─── save_draft ───
+  if (action === "save_draft") {
+    const applicationId = body.application_id as string | undefined;
+
+    // Build record — only allow whitelisted fields
+    const record: Record<string, unknown> = {};
+    for (const field of DRAFT_FIELDS) {
+      if (body.data && typeof body.data === "object" && (body.data as Record<string, unknown>)[field] !== undefined) {
+        record[field] = (body.data as Record<string, unknown>)[field];
+      }
+    }
+    record.status = "draft";
+
+    if (applicationId) {
+      // UPDATE existing draft — verify ownership
+      const ownerCheck = await verifyOwnership(supabase, applicationId, userId);
+      if (ownerCheck instanceof Response) return ownerCheck;
+
+      const { error: updateError } = await supabase
+        .from("partner_applications")
+        .update(record)
+        .eq("id", applicationId);
+
+      if (updateError) {
+        return errorResponse(`Failed to update draft: ${updateError.message}`, 500);
+      }
+
+      return successResponse({ success: true, application_id: applicationId });
+    } else {
+      // INSERT new draft
+      record.user_id = userId;
+
+      const { data, error: insertError } = await supabase
+        .from("partner_applications")
+        .insert(record)
+        .select("id")
+        .single();
+
+      if (insertError) {
+        return errorResponse(`Failed to create draft: ${insertError.message}`, 500);
+      }
+
+      return successResponse({ success: true, application_id: data.id });
+    }
+  }
+
+  // ─── submit ───
+  if (action === "submit") {
+    const applicationId = body.application_id;
+    if (typeof applicationId !== "string" || !applicationId) {
+      return errorResponse("Missing application_id", 400);
+    }
+
+    // Fetch application
+    const { data: app, error: fetchError } = await supabase
+      .from("partner_applications")
+      .select("*")
+      .eq("id", applicationId)
+      .maybeSingle();
+
+    if (fetchError) {
+      return errorResponse("Failed to load application", 500);
+    }
+    if (!app) {
+      return errorResponse("Application not found", 404);
+    }
+
+    // Fix #311: 본인 신청서만 제출 가능
+    if (app.user_id !== userId) {
+      return errorResponse("Forbidden: not your application", 403);
+    }
+
+    // Fix #311: draft/needs_correction 상태만 제출 가능
+    if (app.status !== "draft" && app.status !== "needs_correction") {
+      return errorResponse("Application cannot be submitted in current status", 400);
+    }
+
+    // Server-side validation
+    const errors: ValidationError[] = [];
+
+    const nonEmptyChecks: Array<[unknown, string, string]> = [
+      [app.brand_name, "brand_name", "브랜드명"],
+      [app.biz_name, "biz_name", "사업자명"],
+      [app.representative_name, "representative_name", "대표자명"],
+      [app.bank_name, "bank_name", "은행명"],
+      [app.account_number, "account_number", "계좌번호"],
+      [app.account_holder, "account_holder", "예금주"],
+    ];
+
+    for (const [value, field, label] of nonEmptyChecks) {
+      const err = requireNonEmpty(value, field, label);
+      if (err) errors.push(err);
+    }
+
+    const bizTypeErr = validateBizType(app.biz_type);
+    if (bizTypeErr) errors.push(bizTypeErr);
+
+    const bizNumErr = validateBizNumber(app.biz_number);
+    if (bizNumErr) errors.push(bizNumErr);
+
+    const phoneErr = validatePhone(app.contact_phone);
+    if (phoneErr) errors.push(phoneErr);
+
+    const emailErr = validateEmail(app.contact_email);
+    if (emailErr) errors.push(emailErr);
+
+    // Storage file existence checks
+    const fileChecks: Array<[unknown, string, string]> = [
+      [app.biz_registration_path, "biz_registration_path", "사업자등록증 파일이 업로드되지 않았습니다"],
+      [app.bankbook_path, "bankbook_path", "통장사본 파일이 업로드되지 않았습니다"],
+    ];
+
+    for (const [path, field, message] of fileChecks) {
+      if (typeof path !== "string" || path.trim().length === 0) {
+        errors.push({ field, message });
+        continue;
+      }
+      // Verify file exists in storage
+      const { data: fileData } = await supabase.storage
+        .from("partner-proofs")
+        .list(path.substring(0, path.lastIndexOf("/")), {
+          search: path.substring(path.lastIndexOf("/") + 1),
+        });
+
+      if (!fileData || fileData.length === 0) {
+        errors.push({ field, message });
+      }
+    }
+
+    if (errors.length > 0) {
+      return errorResponse("validation_failed", 400, errors);
+    }
+
+    // Transition to pending
+    const { error: updateError } = await supabase
+      .from("partner_applications")
+      .update({ status: "pending" })
+      .eq("id", applicationId);
+
+    if (updateError) {
+      return errorResponse(`Failed to submit application: ${updateError.message}`, 500);
+    }
+
+    return successResponse({ success: true });
+  }
+
+  // ─── update ───
+  if (action === "update") {
+    const applicationId = body.application_id;
+    if (typeof applicationId !== "string" || !applicationId) {
+      return errorResponse("Missing application_id", 400);
+    }
+
+    // Fetch to check ownership and status
+    const { data: app, error: fetchError } = await supabase
+      .from("partner_applications")
+      .select("id, user_id, status")
+      .eq("id", applicationId)
+      .maybeSingle();
+
+    if (fetchError) {
+      return errorResponse("Failed to load application", 500);
+    }
+    if (!app) {
+      return errorResponse("Application not found", 404);
+    }
+
+    // Fix #311: 본인 신청서만 수정 가능
+    if (app.user_id !== userId) {
+      return errorResponse("Forbidden: not your application", 403);
+    }
+
+    // Fix #311: draft/needs_correction 상태만 수정 가능
+    if (app.status !== "draft" && app.status !== "needs_correction") {
+      return errorResponse("Application cannot be updated in current status", 400);
+    }
+
+    // Build update record — only allow whitelisted fields
+    const updates: Record<string, unknown> = {};
+    for (const field of DRAFT_FIELDS) {
+      if (body.data && typeof body.data === "object" && (body.data as Record<string, unknown>)[field] !== undefined) {
+        updates[field] = (body.data as Record<string, unknown>)[field];
+      }
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return errorResponse("No fields to update", 400);
+    }
+
+    const { error: updateError } = await supabase
+      .from("partner_applications")
+      .update(updates)
+      .eq("id", applicationId);
+
+    if (updateError) {
+      return errorResponse(`Failed to update application: ${updateError.message}`, 500);
+    }
+
+    return successResponse({ success: true, application_id: applicationId });
+  }
+
+  return errorResponse(`Unknown action: ${action}`, 400);
+}
+
+// ─── Helper: verify application ownership ───
+async function verifyOwnership(
+  supabase: ReturnType<typeof createClient>,
+  applicationId: string,
+  userId: string,
+): Promise<void | Response> {
+  const { data: app, error } = await supabase
+    .from("partner_applications")
+    .select("id, user_id")
+    .eq("id", applicationId)
+    .maybeSingle();
+
+  if (error) {
+    return errorResponse("Failed to load application", 500);
+  }
+  if (!app) {
+    return errorResponse("Application not found", 404);
+  }
+  if (app.user_id !== userId) {
+    return errorResponse("Forbidden: not your application", 403);
+  }
+}

--- a/supabase/functions/partner-register/index.ts
+++ b/supabase/functions/partner-register/index.ts
@@ -113,10 +113,13 @@ async function handleRequest(req: Request): Promise<Response> {
         return errorResponse("Application cannot be updated in current status", 400);
       }
 
-      const { error: updateError } = await supabase
+      // Fix #311: 상태 조건을 UPDATE WHERE에 포함하여 원자적 검사
+      const { error: updateError, count } = await supabase
         .from("partner_applications")
         .update(record)
-        .eq("id", applicationId);
+        .eq("id", applicationId)
+        .eq("user_id", userId)
+        .in("status", ["draft", "needs_correction"]);
 
       if (updateError) {
         return errorResponse(`Failed to update draft: ${updateError.message}`, 500);
@@ -238,11 +241,13 @@ async function handleRequest(req: Request): Promise<Response> {
       return errorResponse("validation_failed", 400, errors);
     }
 
-    // Transition to pending
+    // Fix #311: 상태 조건을 UPDATE WHERE에 포함하여 원자적 검사
     const { error: updateError } = await supabase
       .from("partner_applications")
       .update({ status: "pending" })
-      .eq("id", applicationId);
+      .eq("id", applicationId)
+      .eq("user_id", userId)
+      .in("status", ["draft", "needs_correction"]);
 
     if (updateError) {
       return errorResponse(`Failed to submit application: ${updateError.message}`, 500);
@@ -294,10 +299,13 @@ async function handleRequest(req: Request): Promise<Response> {
       return errorResponse("No fields to update", 400);
     }
 
+    // Fix #311: 상태 조건을 UPDATE WHERE에 포함하여 원자적 검사
     const { error: updateError } = await supabase
       .from("partner_applications")
       .update(updates)
-      .eq("id", applicationId);
+      .eq("id", applicationId)
+      .eq("user_id", userId)
+      .in("status", ["draft", "needs_correction"]);
 
     if (updateError) {
       return errorResponse(`Failed to update application: ${updateError.message}`, 500);

--- a/supabase/functions/partner-register/partner_register_test.ts
+++ b/supabase/functions/partner-register/partner_register_test.ts
@@ -98,11 +98,18 @@ function updateErrorRoute(): FetchRoute {
 }
 
 // Storage list route (for file existence check)
+// Returns matching file names based on the search query parameter
 function storageListRoute(hasFiles = true): FetchRoute {
   return {
     matcher: (req) => req.url.includes("/storage/v1/object/list/partner-proofs"),
-    handler: () =>
-      jsonResponse(hasFiles ? [{ name: "file.pdf" }] : []),
+    handler: (req) => {
+      if (!hasFiles) return jsonResponse([]);
+      // Extract search param from body or URL to return matching filename
+      const url = new URL(req.url);
+      const prefix = url.pathname.replace("/storage/v1/object/list/partner-proofs/", "");
+      // Return a generic file that matches any search
+      return jsonResponse([{ name: "biz_reg_123.pdf" }, { name: "bankbook_123.pdf" }]);
+    },
   };
 }
 
@@ -235,7 +242,7 @@ Deno.test({
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
-      selectAppRoute({ id: TEST_APP_ID, user_id: TEST_USER_ID }),
+      selectAppRoute({ id: TEST_APP_ID, user_id: TEST_USER_ID, status: "draft" }),
       updateRoute(),
     ]);
 
@@ -304,7 +311,7 @@ Deno.test({
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
-      selectAppRoute({ id: TEST_APP_ID, user_id: OTHER_USER_ID }),
+      selectAppRoute({ id: TEST_APP_ID, user_id: OTHER_USER_ID, status: "draft" }),
     ]);
 
     await withEnv(ENV, async () => {
@@ -317,6 +324,35 @@ Deno.test({
           }),
         );
         assertEquals(res.status, 403);
+      });
+    });
+  },
+});
+
+// ─── save_draft: pending status → 400 ───
+Deno.test({
+  name: "save_draft: returns 400 when application is pending",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectAppRoute({ id: TEST_APP_ID, user_id: TEST_USER_ID, status: "pending" }),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "save_draft",
+            application_id: TEST_APP_ID,
+            data: { brand_name: "되돌리기 시도" },
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Application cannot be updated in current status");
       });
     });
   },

--- a/supabase/functions/partner-register/partner_register_test.ts
+++ b/supabase/functions/partner-register/partner_register_test.ts
@@ -568,6 +568,72 @@ Deno.test({
   },
 });
 
+// ─── submit: other user's file path → 403 ───
+Deno.test({
+  name: "submit: returns 403 for file path with other user's prefix",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const hackedApp = {
+      ...VALID_APP,
+      biz_number: "1208100088",
+      biz_registration_path: "other-user-id/stolen_file.pdf",
+    };
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectAppRoute(hackedApp),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "submit",
+            application_id: TEST_APP_ID,
+          }),
+        );
+        assertEquals(res.status, 403);
+        const body = await readJson(res);
+        assertEquals(body.error, "Forbidden file path");
+      });
+    });
+  },
+});
+
+// ─── submit: storage error → 500 ───
+Deno.test({
+  name: "submit: returns 500 when storage list fails",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const validApp = { ...VALID_APP, biz_number: "1208100088" };
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectAppRoute(validApp),
+      {
+        matcher: (req) => req.url.includes("/storage/v1/object/list/partner-proofs"),
+        handler: () => jsonResponse({ message: "storage error" }, { status: 500 }),
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "submit",
+            application_id: TEST_APP_ID,
+          }),
+        );
+        assertEquals(res.status, 500);
+        const body = await readJson(res);
+        assertEquals(body.error, "Failed to verify uploaded files");
+      });
+    });
+  },
+});
+
 // ─── submit: pending → re-submit → 400 ───
 Deno.test({
   name: "submit: returns 400 when already pending",


### PR DESCRIPTION
## Summary

- `partner-register` Edge Function 신규 구현 (save_draft / submit / update 3개 action)
- `_shared/validation_utils.ts` 검증 유틸 공유 모듈 추가 (사업자번호 체크섬, 전화번호, 이메일 등)
- Flutter `partner_application_repository.dart`의 write 경로를 RLS 직접 쓰기 → EF 호출로 전환
- submit 시 서버 사이드 필수 필드 검증 + 형식 검증 + Storage 파일 존재 확인

Closes #311

## Test plan

- [x] EF e2e 테스트 25개 전부 통과
- [x] Flutter analyze 이슈 없음
- [ ] CI `ci-result` 통과 확인
- [ ] CodeRabbit 리뷰 대응

🤖 Generated with [Claude Code](https://claude.com/claude-code)