### PR TITLE
feat(partner): partner-manage-event EF 구현 (이벤트/티켓 CRUD)

### DIFF
--- a/supabase/functions/partner-manage-event/index.ts
+++ b/supabase/functions/partner-manage-event/index.ts
@@ -1,0 +1,543 @@
+// partner-manage-event — Event/ticket/entry-group CRUD for partners
+// Issue #317: RLS write strategy 전환 — 이벤트/티켓 CRUD
+
+import { createClient } from "@supabase/supabase-js";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
+import { requireAuth } from "../_shared/auth_utils.ts";
+
+const VALID_EVENT_STATUSES = ["scheduled", "cancelled", "completed"];
+const VALID_GENDERS = ["male", "female"];
+
+// Fields allowed in event create/update
+const EVENT_FIELDS = [
+  "start_time",
+  "end_time",
+  "max_participants",
+  "min_confirmed_count",
+  "title",
+  "description",
+  "image_urls",
+  "contact_options",
+  "vote_start_at",
+  "vote_end_at",
+] as const;
+
+// Fields allowed in ticket update
+const TICKET_UPDATE_FIELDS = [
+  "price",
+  "quantity",
+  "name",
+  "description",
+  "status",
+  "target_entry_group_ids",
+  "required_verification_ids",
+] as const;
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") return corsResponse();
+  if (req.method !== "POST") return errorResponse("Method not allowed", 405);
+
+  try {
+    return await handleRequest(req);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return errorResponse(message, 500);
+  }
+});
+
+async function handleRequest(req: Request): Promise<Response> {
+  // 1. Environment check
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !serviceRoleKey) {
+    return errorResponse("Missing server configuration", 500);
+  }
+
+  // 2. Auth
+  const auth = await requireAuth(req);
+  if (auth instanceof Response) return auth;
+  const userId = auth;
+
+  // 3. Parse body
+  let body: Record<string, unknown>;
+  try {
+    const parsed = await req.json();
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return errorResponse("Request body must be a JSON object", 400);
+    }
+    body = parsed as Record<string, unknown>;
+  } catch {
+    return errorResponse("Invalid JSON body", 400);
+  }
+
+  const action = body.action as string | undefined;
+  if (typeof action !== "string" || !action) return errorResponse("Missing action", 400);
+
+  // 4. Supabase client (service role)
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { persistSession: false },
+  });
+
+  // ─── create ───
+  if (action === "create") {
+    return handleCreate(supabase, body, userId);
+  }
+
+  // ─── update ───
+  if (action === "update") {
+    return handleUpdate(supabase, body, userId);
+  }
+
+  // ─── update_status ───
+  if (action === "update_status") {
+    return handleUpdateStatus(supabase, body, userId);
+  }
+
+  // ─── update_tickets ───
+  if (action === "update_tickets") {
+    return handleUpdateTickets(supabase, body, userId);
+  }
+
+  return errorResponse(`Unknown action: ${action}`, 400);
+}
+
+// ─── Action Handlers ───
+
+async function handleCreate(
+  supabase: ReturnType<typeof createClient>,
+  body: Record<string, unknown>,
+  userId: string,
+): Promise<Response> {
+  const partyId = body.party_id;
+  if (typeof partyId !== "string" || !partyId) {
+    return errorResponse("Missing party_id", 400);
+  }
+
+  const eventData = body.event;
+  if (typeof eventData !== "object" || eventData === null || Array.isArray(eventData)) {
+    return errorResponse("Missing or invalid event object", 400);
+  }
+  const event = eventData as Record<string, unknown>;
+
+  // Validate required time fields
+  if (typeof event.start_time !== "string" || !event.start_time) {
+    return errorResponse("Missing event start_time", 400);
+  }
+  if (typeof event.end_time !== "string" || !event.end_time) {
+    return errorResponse("Missing event end_time", 400);
+  }
+
+  const startTime = new Date(event.start_time as string);
+  const endTime = new Date(event.end_time as string);
+  if (isNaN(startTime.getTime()) || isNaN(endTime.getTime())) {
+    return errorResponse("Invalid date format for start_time or end_time", 400);
+  }
+  if (startTime >= endTime) {
+    return errorResponse("start_time must be before end_time", 400);
+  }
+  if (startTime <= new Date()) {
+    return errorResponse("start_time must be in the future", 400);
+  }
+
+  // Fetch party to verify ownership
+  const { data: party, error: partyError } = await supabase
+    .from("parties")
+    .select("id, partner_id, location_id")
+    .eq("id", partyId)
+    .maybeSingle();
+
+  if (partyError) return errorResponse("Failed to load party", 500);
+  if (!party) return errorResponse("Party not found", 404);
+
+  // Check partner permission
+  const permCheck = await checkPartnerPermission(supabase, party.partner_id, userId);
+  if (permCheck instanceof Response) return permCheck;
+
+  // ── Pre-validate ticket template references ──
+  const ticketInputs = body.tickets;
+  if (ticketInputs !== undefined) {
+    if (!Array.isArray(ticketInputs)) {
+      return errorResponse("tickets must be an array", 400);
+    }
+    for (let i = 0; i < ticketInputs.length; i++) {
+      const t = ticketInputs[i] as Record<string, unknown>;
+      if (typeof t !== "object" || t === null || Array.isArray(t)) {
+        return errorResponse(`tickets[${i}] must be an object`, 400);
+      }
+      if (typeof t.template_id !== "string" || !t.template_id) {
+        return errorResponse(`tickets[${i}].template_id is required`, 400);
+      }
+      if (typeof t.quantity !== "number" || t.quantity < 0) {
+        return errorResponse(`tickets[${i}].quantity must be a non-negative number`, 400);
+      }
+    }
+  }
+
+  // ── DB writes ──
+
+  // Build event record
+  const eventRecord: Record<string, unknown> = {
+    party_id: partyId,
+    location_id: party.location_id,
+  };
+  for (const field of EVENT_FIELDS) {
+    if (event[field] !== undefined) {
+      eventRecord[field] = event[field];
+    }
+  }
+
+  // Insert event
+  const { data: newEvent, error: eventInsertError } = await supabase
+    .from("events")
+    .insert(eventRecord)
+    .select("id")
+    .single();
+
+  if (eventInsertError) {
+    return errorResponse(`Failed to create event: ${eventInsertError.message}`, 500);
+  }
+
+  const eventId = newEvent.id as string;
+
+  // Copy entry_group_templates → entry_groups
+  const { data: templates, error: tplError } = await supabase
+    .from("entry_group_templates")
+    .select("label, gender, birth_year_min, birth_year_max, required_verification_ids")
+    .eq("party_id", partyId);
+
+  if (tplError) {
+    return errorResponse(`Failed to fetch entry group templates: ${tplError.message}`, 500);
+  }
+
+  if (templates && templates.length > 0) {
+    const entryGroups = templates.map((t: Record<string, unknown>) => ({
+      event_id: eventId,
+      label: t.label ?? null,
+      gender: t.gender ?? null,
+      birth_year_min: t.birth_year_min ?? null,
+      birth_year_max: t.birth_year_max ?? null,
+      required_verification_ids: t.required_verification_ids ?? [],
+    }));
+
+    const { error: egError } = await supabase
+      .from("entry_groups")
+      .insert(entryGroups);
+
+    if (egError) {
+      return errorResponse(`Failed to create entry groups: ${egError.message}`, 500);
+    }
+  }
+
+  // Create tickets from ticket_templates
+  if (Array.isArray(ticketInputs) && ticketInputs.length > 0) {
+    // Fetch referenced ticket templates
+    const templateIds = ticketInputs.map((t: Record<string, unknown>) => t.template_id as string);
+    const { data: ticketTemplates, error: ttError } = await supabase
+      .from("ticket_templates")
+      .select("id, name, description, price, target_entry_group_ids, required_verification_ids")
+      .eq("party_id", partyId)
+      .in("id", templateIds);
+
+    if (ttError) {
+      return errorResponse(`Failed to fetch ticket templates: ${ttError.message}`, 500);
+    }
+
+    const templateMap = new Map(
+      (ticketTemplates ?? []).map((t: Record<string, unknown>) => [t.id, t]),
+    );
+
+    // Verify all template_ids exist
+    for (let i = 0; i < ticketInputs.length; i++) {
+      const input = ticketInputs[i] as Record<string, unknown>;
+      if (!templateMap.has(input.template_id)) {
+        return errorResponse(`tickets[${i}].template_id not found in party templates`, 400);
+      }
+    }
+
+    const tickets = ticketInputs.map((input: Record<string, unknown>) => {
+      const tpl = templateMap.get(input.template_id) as Record<string, unknown>;
+      return {
+        event_id: eventId,
+        name: tpl.name,
+        description: tpl.description ?? null,
+        price: tpl.price ?? 0,
+        quantity: input.quantity,
+        target_entry_group_ids: tpl.target_entry_group_ids ?? [],
+        required_verification_ids: tpl.required_verification_ids ?? [],
+      };
+    });
+
+    const { error: ticketInsertError } = await supabase
+      .from("tickets")
+      .insert(tickets);
+
+    if (ticketInsertError) {
+      return errorResponse(`Failed to create tickets: ${ticketInsertError.message}`, 500);
+    }
+  }
+
+  return successResponse({ success: true, event_id: eventId });
+}
+
+async function handleUpdate(
+  supabase: ReturnType<typeof createClient>,
+  body: Record<string, unknown>,
+  userId: string,
+): Promise<Response> {
+  const eventId = body.event_id;
+  if (typeof eventId !== "string" || !eventId) {
+    return errorResponse("Missing event_id", 400);
+  }
+
+  // Fetch event → party → partner
+  const { data: event, error: fetchError } = await supabase
+    .from("events")
+    .select("id, party_id, parties!inner(partner_id)")
+    .eq("id", eventId)
+    .maybeSingle();
+
+  if (fetchError) return errorResponse("Failed to load event", 500);
+  if (!event) return errorResponse("Event not found", 404);
+
+  const partnerId = (event.parties as Record<string, unknown>).partner_id as string;
+
+  // Check partner permission
+  const permCheck = await checkPartnerPermission(supabase, partnerId, userId);
+  if (permCheck instanceof Response) return permCheck;
+
+  // Build update fields
+  const eventData = body.event;
+  if (typeof eventData !== "object" || eventData === null || Array.isArray(eventData)) {
+    return errorResponse("Missing or invalid event object", 400);
+  }
+  const input = eventData as Record<string, unknown>;
+
+  const updates: Record<string, unknown> = {};
+  for (const field of EVENT_FIELDS) {
+    if (input[field] !== undefined) {
+      updates[field] = input[field];
+    }
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return errorResponse("No fields to update", 400);
+  }
+
+  // Validate time fields if provided
+  if (updates.start_time !== undefined || updates.end_time !== undefined) {
+    const st = updates.start_time ? new Date(updates.start_time as string) : null;
+    const et = updates.end_time ? new Date(updates.end_time as string) : null;
+    if (st && isNaN(st.getTime())) {
+      return errorResponse("Invalid start_time format", 400);
+    }
+    if (et && isNaN(et.getTime())) {
+      return errorResponse("Invalid end_time format", 400);
+    }
+  }
+
+  const { error: updateError } = await supabase
+    .from("events")
+    .update(updates)
+    .eq("id", eventId);
+
+  if (updateError) {
+    return errorResponse(`Failed to update event: ${updateError.message}`, 500);
+  }
+
+  return successResponse({ success: true });
+}
+
+async function handleUpdateStatus(
+  supabase: ReturnType<typeof createClient>,
+  body: Record<string, unknown>,
+  userId: string,
+): Promise<Response> {
+  const eventId = body.event_id;
+  if (typeof eventId !== "string" || !eventId) {
+    return errorResponse("Missing event_id", 400);
+  }
+
+  const status = body.status;
+  if (typeof status !== "string" || !status) {
+    return errorResponse("Missing status", 400);
+  }
+
+  // completed는 시스템 전용 — 파트너가 직접 변경 불가
+  if (status === "completed") {
+    return errorResponse("Cannot set status to completed — system only", 400);
+  }
+
+  if (!VALID_EVENT_STATUSES.includes(status)) {
+    return errorResponse(`Invalid status. Must be one of: ${VALID_EVENT_STATUSES.join(", ")}`, 400);
+  }
+
+  // Fetch event → party → partner
+  const { data: event, error: fetchError } = await supabase
+    .from("events")
+    .select("id, status, party_id, parties!inner(partner_id)")
+    .eq("id", eventId)
+    .maybeSingle();
+
+  if (fetchError) return errorResponse("Failed to load event", 500);
+  if (!event) return errorResponse("Event not found", 404);
+
+  // Only scheduled → cancelled is allowed
+  if (event.status !== "scheduled") {
+    return errorResponse(`Cannot change status from ${event.status} to ${status}`, 400);
+  }
+
+  const partnerId = (event.parties as Record<string, unknown>).partner_id as string;
+
+  // Check partner permission
+  const permCheck = await checkPartnerPermission(supabase, partnerId, userId);
+  if (permCheck instanceof Response) return permCheck;
+
+  const { error: updateError } = await supabase
+    .from("events")
+    .update({ status })
+    .eq("id", eventId);
+
+  if (updateError) {
+    return errorResponse(`Failed to update event status: ${updateError.message}`, 500);
+  }
+
+  return successResponse({ success: true });
+}
+
+async function handleUpdateTickets(
+  supabase: ReturnType<typeof createClient>,
+  body: Record<string, unknown>,
+  userId: string,
+): Promise<Response> {
+  const eventId = body.event_id;
+  if (typeof eventId !== "string" || !eventId) {
+    return errorResponse("Missing event_id", 400);
+  }
+
+  const ticketUpdates = body.tickets;
+  if (!Array.isArray(ticketUpdates) || ticketUpdates.length === 0) {
+    return errorResponse("Missing or empty tickets array", 400);
+  }
+
+  // Validate ticket update inputs
+  for (let i = 0; i < ticketUpdates.length; i++) {
+    const t = ticketUpdates[i] as Record<string, unknown>;
+    if (typeof t !== "object" || t === null || Array.isArray(t)) {
+      return errorResponse(`tickets[${i}] must be an object`, 400);
+    }
+    if (typeof t.ticket_id !== "string" || !t.ticket_id) {
+      return errorResponse(`tickets[${i}].ticket_id is required`, 400);
+    }
+    if (t.price !== undefined && (typeof t.price !== "number" || t.price < 0)) {
+      return errorResponse(`tickets[${i}].price must be >= 0`, 400);
+    }
+    if (t.quantity !== undefined && (typeof t.quantity !== "number" || t.quantity < 0)) {
+      return errorResponse(`tickets[${i}].quantity must be a non-negative number`, 400);
+    }
+  }
+
+  // Fetch event → party → partner
+  const { data: event, error: fetchError } = await supabase
+    .from("events")
+    .select("id, party_id, parties!inner(partner_id)")
+    .eq("id", eventId)
+    .maybeSingle();
+
+  if (fetchError) return errorResponse("Failed to load event", 500);
+  if (!event) return errorResponse("Event not found", 404);
+
+  const partnerId = (event.parties as Record<string, unknown>).partner_id as string;
+
+  // Check partner permission
+  const permCheck = await checkPartnerPermission(supabase, partnerId, userId);
+  if (permCheck instanceof Response) return permCheck;
+
+  // Fetch existing tickets to validate sold_count
+  const ticketIds = ticketUpdates.map((t: Record<string, unknown>) => t.ticket_id as string);
+  const { data: existingTickets, error: ticketFetchError } = await supabase
+    .from("tickets")
+    .select("id, sold_count, event_id")
+    .eq("event_id", eventId)
+    .in("id", ticketIds);
+
+  if (ticketFetchError) {
+    return errorResponse("Failed to fetch tickets", 500);
+  }
+
+  const ticketMap = new Map(
+    (existingTickets ?? []).map((t: Record<string, unknown>) => [t.id, t]),
+  );
+
+  // Validate all ticket_ids exist and belong to this event
+  for (let i = 0; i < ticketUpdates.length; i++) {
+    const input = ticketUpdates[i] as Record<string, unknown>;
+    const existing = ticketMap.get(input.ticket_id);
+    if (!existing) {
+      return errorResponse(`tickets[${i}].ticket_id not found in this event`, 400);
+    }
+    // Validate quantity >= sold_count
+    if (input.quantity !== undefined) {
+      const soldCount = (existing as Record<string, unknown>).sold_count as number;
+      if ((input.quantity as number) < soldCount) {
+        return errorResponse(
+          `tickets[${i}].quantity (${input.quantity}) cannot be less than sold_count (${soldCount})`,
+          400,
+        );
+      }
+    }
+  }
+
+  // Apply updates
+  for (const input of ticketUpdates) {
+    const t = input as Record<string, unknown>;
+    const updates: Record<string, unknown> = {};
+    for (const field of TICKET_UPDATE_FIELDS) {
+      if (t[field] !== undefined) {
+        updates[field] = t[field];
+      }
+    }
+
+    if (Object.keys(updates).length === 0) continue;
+
+    const { error: updateError } = await supabase
+      .from("tickets")
+      .update(updates)
+      .eq("id", t.ticket_id)
+      .eq("event_id", eventId);
+
+    if (updateError) {
+      return errorResponse(`Failed to update ticket: ${updateError.message}`, 500);
+    }
+  }
+
+  return successResponse({ success: true });
+}
+
+// ─── Helpers ───
+
+async function checkPartnerPermission(
+  supabase: ReturnType<typeof createClient>,
+  partnerId: string,
+  userId: string,
+): Promise<void | Response> {
+  const { data: perm, error: permError } = await supabase
+    .from("partner_member_permissions")
+    .select("permissions")
+    .eq("partner_id", partnerId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (permError) {
+    return errorResponse("Failed to verify partner permissions", 500);
+  }
+
+  const permissions = (perm?.permissions as string[] | null) ?? [];
+  const hasPermission = permissions.includes("PARTY_MANAGE") || permissions.includes("EVENT_MANAGE");
+  if (!hasPermission) {
+    return errorResponse("Forbidden: insufficient partner permissions", 403);
+  }
+}

--- a/supabase/functions/partner-manage-event/index.ts
+++ b/supabase/functions/partner-manage-event/index.ts
@@ -337,6 +337,10 @@ async function handleUpdate(
     if (et && isNaN(et.getTime())) {
       return errorResponse("Invalid end_time format", 400);
     }
+    // Fix #317: Cross-validate when both are provided
+    if (st && et && st >= et) {
+      return errorResponse("start_time must be before end_time", 400);
+    }
   }
 
   const { error: updateError } = await supabase

--- a/supabase/functions/partner-manage-event/index.ts
+++ b/supabase/functions/partner-manage-event/index.ts
@@ -27,14 +27,10 @@ const EVENT_FIELDS = [
 ] as const;
 
 // Fields allowed in ticket update
+// Fix #317: 이슈 스펙에 맞게 price/quantity만 허용
 const TICKET_UPDATE_FIELDS = [
   "price",
   "quantity",
-  "name",
-  "description",
-  "status",
-  "target_entry_group_ids",
-  "required_verification_ids",
 ] as const;
 
 Deno.serve(async (req: Request): Promise<Response> => {
@@ -204,14 +200,18 @@ async function handleCreate(
   const eventId = newEvent.id as string;
 
   // Copy entry_group_templates → entry_groups
+  // Fix #317: ID를 포함해서 조회하여 target_entry_group_ids 재매핑에 사용
   const { data: templates, error: tplError } = await supabase
     .from("entry_group_templates")
-    .select("label, gender, birth_year_min, birth_year_max, required_verification_ids")
+    .select("id, label, gender, birth_year_min, birth_year_max, required_verification_ids")
     .eq("party_id", partyId);
 
   if (tplError) {
     return errorResponse(`Failed to fetch entry group templates: ${tplError.message}`, 500);
   }
+
+  // Map: template ID → new entry_group ID (for target_entry_group_ids remapping)
+  const templateToGroupMap = new Map<string, string>();
 
   if (templates && templates.length > 0) {
     const entryGroups = templates.map((t: Record<string, unknown>) => ({
@@ -223,12 +223,23 @@ async function handleCreate(
       required_verification_ids: t.required_verification_ids ?? [],
     }));
 
-    const { error: egError } = await supabase
+    const { data: insertedGroups, error: egError } = await supabase
       .from("entry_groups")
-      .insert(entryGroups);
+      .insert(entryGroups)
+      .select("id");
 
     if (egError) {
       return errorResponse(`Failed to create entry groups: ${egError.message}`, 500);
+    }
+
+    // Build mapping from template ID to new entry_group ID (same order)
+    if (insertedGroups) {
+      for (let i = 0; i < templates.length; i++) {
+        templateToGroupMap.set(
+          templates[i].id as string,
+          (insertedGroups[i] as Record<string, unknown>).id as string,
+        );
+      }
     }
   }
 
@@ -260,13 +271,19 @@ async function handleCreate(
 
     const tickets = ticketInputs.map((input: Record<string, unknown>) => {
       const tpl = templateMap.get(input.template_id) as Record<string, unknown>;
+      // Fix #317: target_entry_group_ids를 새 entry_group ID로 재매핑
+      const originalTargetIds = (tpl.target_entry_group_ids as string[]) ?? [];
+      const remappedTargetIds = originalTargetIds
+        .map((id: string) => templateToGroupMap.get(id))
+        .filter((id): id is string => id !== undefined);
+
       return {
         event_id: eventId,
         name: tpl.name,
         description: tpl.description ?? null,
         price: tpl.price ?? 0,
         quantity: input.quantity,
-        target_entry_group_ids: tpl.target_entry_group_ids ?? [],
+        target_entry_group_ids: remappedTargetIds,
         required_verification_ids: tpl.required_verification_ids ?? [],
       };
     });

--- a/supabase/functions/partner-manage-event/partner_manage_event_test.ts
+++ b/supabase/functions/partner-manage-event/partner_manage_event_test.ts
@@ -1,0 +1,972 @@
+import { assertEquals } from "@std/assert";
+import {
+  authenticatedJsonRequest,
+  captureServeHandler,
+  createFetchMock,
+  jsonRequest,
+  jsonResponse,
+  readJson,
+  withEnv,
+  withMockedFetch,
+  type FetchRoute,
+} from "../_test_utils/mock_http.ts";
+
+const TEST_USER_ID = "user-partner-owner";
+const TEST_PARTNER_ID = "partner-001";
+const TEST_PARTY_ID = "party-001";
+const TEST_EVENT_ID = "event-001";
+const TEST_TICKET_ID_1 = "ticket-001";
+const TEST_TICKET_ID_2 = "ticket-002";
+const TEST_TEMPLATE_ID_1 = "tpl-001";
+const TEST_TEMPLATE_ID_2 = "tpl-002";
+
+const ENV = {
+  SUPABASE_URL: "http://localhost:54321",
+  SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+};
+
+const FUTURE_START = new Date(Date.now() + 86400000).toISOString(); // +1 day
+const FUTURE_END = new Date(Date.now() + 86400000 * 2).toISOString(); // +2 days
+const PAST_TIME = new Date(Date.now() - 86400000).toISOString(); // -1 day
+
+// ─── Route helpers ───
+
+function authRoute(userId = TEST_USER_ID): FetchRoute {
+  return {
+    matcher: "/auth/v1/user",
+    handler: () => jsonResponse({ id: userId, email: "partner@test.com" }),
+  };
+}
+
+function authFailRoute(): FetchRoute {
+  return {
+    matcher: "/auth/v1/user",
+    handler: () => jsonResponse({ error: "invalid" }, { status: 401 }),
+  };
+}
+
+function permRoute(hasPermission = true): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("partner_member_permissions") && req.method === "GET",
+    handler: () =>
+      jsonResponse(
+        hasPermission
+          ? { partner_id: TEST_PARTNER_ID, permissions: ["PARTNER_EDIT", "PARTY_MANAGE"] }
+          : null,
+      ),
+  };
+}
+
+function permNoEventManageRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("partner_member_permissions") && req.method === "GET",
+    handler: () =>
+      jsonResponse({ partner_id: TEST_PARTNER_ID, permissions: ["PARTNER_EDIT"] }),
+  };
+}
+
+// Party routes
+function selectPartyRoute(
+  partnerId = TEST_PARTNER_ID,
+  locationId: string | null = "loc-001",
+): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/parties") &&
+      req.url.includes("select=") &&
+      req.method === "GET",
+    handler: () =>
+      jsonResponse({ id: TEST_PARTY_ID, partner_id: partnerId, location_id: locationId }),
+  };
+}
+
+function selectPartyNotFoundRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/parties") &&
+      req.url.includes("select=") &&
+      req.method === "GET",
+    handler: () => jsonResponse(null),
+  };
+}
+
+// Event routes
+function insertEventRoute(id = TEST_EVENT_ID): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/events") && req.method === "POST",
+    handler: () => jsonResponse({ id }),
+  };
+}
+
+function selectEventRoute(
+  status = "scheduled",
+  partnerId = TEST_PARTNER_ID,
+): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/events") &&
+      req.url.includes("select=") &&
+      req.method === "GET",
+    handler: () =>
+      jsonResponse({
+        id: TEST_EVENT_ID,
+        status,
+        party_id: TEST_PARTY_ID,
+        parties: { partner_id: partnerId },
+      }),
+  };
+}
+
+function selectEventNotFoundRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/events") &&
+      req.url.includes("select=") &&
+      req.method === "GET",
+    handler: () => jsonResponse(null),
+  };
+}
+
+function updateEventRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/events") && req.method === "PATCH",
+    handler: () => new Response(null, { status: 200 }),
+  };
+}
+
+// Entry group templates/groups routes
+function selectEntryGroupTemplatesRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/entry_group_templates") && req.method === "GET",
+    handler: () =>
+      jsonResponse([
+        { label: "남성", gender: "male", birth_year_min: 2000, birth_year_max: 2005, required_verification_ids: [] },
+        { label: "여성", gender: "female", birth_year_min: 2000, birth_year_max: 2005, required_verification_ids: [] },
+      ]),
+  };
+}
+
+function selectEntryGroupTemplatesEmptyRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/entry_group_templates") && req.method === "GET",
+    handler: () => jsonResponse([]),
+  };
+}
+
+function insertEntryGroupsRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/entry_groups") && req.method === "POST",
+    handler: () => jsonResponse([]),
+  };
+}
+
+// Ticket template routes
+function selectTicketTemplatesRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/ticket_templates") && req.method === "GET",
+    handler: () =>
+      jsonResponse([
+        { id: TEST_TEMPLATE_ID_1, name: "남성 티켓", description: null, price: 30000, target_entry_group_ids: [], required_verification_ids: [] },
+        { id: TEST_TEMPLATE_ID_2, name: "여성 티켓", description: null, price: 20000, target_entry_group_ids: [], required_verification_ids: [] },
+      ]),
+  };
+}
+
+function insertTicketsRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/tickets") && req.method === "POST",
+    handler: () => jsonResponse([]),
+  };
+}
+
+// Ticket fetch/update routes for update_tickets
+function selectTicketsRoute(soldCount1 = 0, soldCount2 = 0): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/tickets") &&
+      req.url.includes("select=") &&
+      req.method === "GET",
+    handler: () =>
+      jsonResponse([
+        { id: TEST_TICKET_ID_1, sold_count: soldCount1, event_id: TEST_EVENT_ID },
+        { id: TEST_TICKET_ID_2, sold_count: soldCount2, event_id: TEST_EVENT_ID },
+      ]),
+  };
+}
+
+function updateTicketRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/tickets") && req.method === "PATCH",
+    handler: () => new Response(null, { status: 200 }),
+  };
+}
+
+// ─── Tests ───
+
+Deno.test({
+  name: "OPTIONS returns CORS preflight",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const req = new Request("http://localhost", { method: "OPTIONS" });
+    const res = await handler(req);
+    assertEquals(res.status, 200);
+  },
+});
+
+Deno.test({
+  name: "GET returns 405",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const req = new Request("http://localhost", { method: "GET" });
+    const res = await handler(req);
+    assertEquals(res.status, 405);
+  },
+});
+
+Deno.test({
+  name: "Missing auth returns 401",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authFailRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = jsonRequest("http://localhost", { action: "create" });
+        const res = await handler(req);
+        assertEquals(res.status, 401);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "Invalid JSON body returns 400",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = new Request("http://localhost", {
+          method: "POST",
+          headers: {
+            Authorization: "Bearer test-token",
+            "Content-Type": "application/json",
+          },
+          body: "not json",
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "Missing action returns 400",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {});
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing action");
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "Unknown action returns 400",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", { action: "delete" });
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Unknown action: delete");
+      });
+    });
+  },
+});
+
+// ─── create action ───
+
+Deno.test({
+  name: "create: event + entry_groups + tickets from templates",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectPartyRoute(),
+      permRoute(),
+      insertEventRoute(),
+      selectEntryGroupTemplatesRoute(),
+      insertEntryGroupsRoute(),
+      selectTicketTemplatesRoute(),
+      insertTicketsRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "create",
+          party_id: TEST_PARTY_ID,
+          event: { start_time: FUTURE_START, end_time: FUTURE_END, max_participants: 20 },
+          tickets: [
+            { template_id: TEST_TEMPLATE_ID_1, quantity: 10 },
+            { template_id: TEST_TEMPLATE_ID_2, quantity: 10 },
+          ],
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+        assertEquals(body.event_id, TEST_EVENT_ID);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "create: event with vote_start_at/vote_end_at",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectPartyRoute(),
+      permRoute(),
+      insertEventRoute(),
+      selectEntryGroupTemplatesEmptyRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const voteStart = new Date(Date.now() + 86400000).toISOString();
+        const voteEnd = new Date(Date.now() + 86400000 * 1.5).toISOString();
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "create",
+          party_id: TEST_PARTY_ID,
+          event: {
+            start_time: FUTURE_START,
+            end_time: FUTURE_END,
+            vote_start_at: voteStart,
+            vote_end_at: voteEnd,
+          },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+        assertEquals(body.event_id, TEST_EVENT_ID);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "create: past start_time returns 400",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectPartyRoute(),
+      permRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "create",
+          party_id: TEST_PARTY_ID,
+          event: { start_time: PAST_TIME, end_time: FUTURE_END },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "start_time must be in the future");
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "create: start_time >= end_time returns 400",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "create",
+          party_id: TEST_PARTY_ID,
+          event: { start_time: FUTURE_END, end_time: FUTURE_START },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "start_time must be before end_time");
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "create: missing party_id returns 400",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "create",
+          event: { start_time: FUTURE_START, end_time: FUTURE_END },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing party_id");
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "create: missing event object returns 400",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "create",
+          party_id: TEST_PARTY_ID,
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "create: no partner membership returns 403",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectPartyRoute(),
+      permRoute(false),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "create",
+          party_id: TEST_PARTY_ID,
+          event: { start_time: FUTURE_START, end_time: FUTURE_END },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 403);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "create: no PARTY_MANAGE/EVENT_MANAGE permission returns 403",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectPartyRoute(),
+      permNoEventManageRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "create",
+          party_id: TEST_PARTY_ID,
+          event: { start_time: FUTURE_START, end_time: FUTURE_END },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 403);
+      });
+    });
+  },
+});
+
+// ─── update action ───
+
+Deno.test({
+  name: "update: start_time change",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectEventRoute(),
+      permRoute(),
+      updateEventRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const newStart = new Date(Date.now() + 86400000 * 3).toISOString();
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update",
+          event_id: TEST_EVENT_ID,
+          event: { start_time: newStart },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "update: missing event_id returns 400",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update",
+          event: { start_time: FUTURE_START },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing event_id");
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "update: event not found returns 404",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectEventNotFoundRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update",
+          event_id: "nonexistent",
+          event: { start_time: FUTURE_START },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 404);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "update: other partner's event returns 403",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectEventRoute("scheduled", "other-partner"),
+      permRoute(false),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update",
+          event_id: TEST_EVENT_ID,
+          event: { start_time: FUTURE_START },
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 403);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "update: no fields to update returns 400",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectEventRoute(),
+      permRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update",
+          event_id: TEST_EVENT_ID,
+          event: {},
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "No fields to update");
+      });
+    });
+  },
+});
+
+// ─── update_status action ───
+
+Deno.test({
+  name: "update_status: scheduled → cancelled",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectEventRoute("scheduled"),
+      permRoute(),
+      updateEventRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_status",
+          event_id: TEST_EVENT_ID,
+          status: "cancelled",
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "update_status: completed → 400 (system only)",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_status",
+          event_id: TEST_EVENT_ID,
+          status: "completed",
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Cannot set status to completed — system only");
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "update_status: cancelled event cannot change status",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectEventRoute("cancelled"),
+      permRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_status",
+          event_id: TEST_EVENT_ID,
+          status: "scheduled",
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error.includes("Cannot change status"), true);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "update_status: missing event_id returns 400",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_status",
+          status: "cancelled",
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "update_status: event not found returns 404",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectEventNotFoundRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_status",
+          event_id: "nonexistent",
+          status: "cancelled",
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 404);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "update_status: other partner's event returns 403",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectEventRoute("scheduled", "other-partner"),
+      permRoute(false),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_status",
+          event_id: TEST_EVENT_ID,
+          status: "cancelled",
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 403);
+      });
+    });
+  },
+});
+
+// ─── update_tickets action ───
+
+Deno.test({
+  name: "update_tickets: price change",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectEventRoute(),
+      permRoute(),
+      selectTicketsRoute(),
+      updateTicketRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_tickets",
+          event_id: TEST_EVENT_ID,
+          tickets: [
+            { ticket_id: TEST_TICKET_ID_1, price: 35000 },
+          ],
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "update_tickets: quantity below sold_count returns 400",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectEventRoute(),
+      permRoute(),
+      selectTicketsRoute(5, 0), // ticket 1 has 5 sold
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_tickets",
+          event_id: TEST_EVENT_ID,
+          tickets: [
+            { ticket_id: TEST_TICKET_ID_1, quantity: 3 }, // 3 < 5 sold
+          ],
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error.includes("sold_count"), true);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "update_tickets: missing event_id returns 400",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_tickets",
+          tickets: [{ ticket_id: TEST_TICKET_ID_1, price: 35000 }],
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing event_id");
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "update_tickets: empty tickets array returns 400",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_tickets",
+          event_id: TEST_EVENT_ID,
+          tickets: [],
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 400);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "update_tickets: other partner's event returns 403",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectEventRoute("scheduled", "other-partner"),
+      permRoute(false),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update_tickets",
+          event_id: TEST_EVENT_ID,
+          tickets: [{ ticket_id: TEST_TICKET_ID_1, price: 35000 }],
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 403);
+      });
+    });
+  },
+});

--- a/supabase/functions/partner-manage-event/partner_manage_event_test.ts
+++ b/supabase/functions/partner-manage-event/partner_manage_event_test.ts
@@ -163,7 +163,7 @@ function insertEntryGroupsRoute(): FetchRoute {
   return {
     matcher: (req) =>
       req.url.includes("/rest/v1/entry_groups") && req.method === "POST",
-    handler: () => jsonResponse([]),
+    handler: () => jsonResponse([{ id: "eg-001" }, { id: "eg-002" }]),
   };
 }
 


### PR DESCRIPTION
## Summary

- partner-manage-event Edge Function 구현 (RLS write strategy 전환)
- 4개 action: `create`, `update`, `update_status`, `update_tickets`
- 파티 템플릿 기반 이벤트 생성 (entry_group_templates → entry_groups, ticket_templates → tickets 복사)
- `completed` 상태는 시스템 전용, `scheduled → cancelled`만 파트너 허용
- 티켓 수량 변경 시 sold_count 검증

Closes #317

## Test plan

- [x] EF e2e: create — 이벤트 + entry_groups + tickets 템플릿 기반 생성 (30 tests all passing)
- [x] create: vote_start_at/vote_end_at 설정 확인
- [x] update: start_time 변경 → 반영
- [x] update_status: scheduled → cancelled
- [x] update_status: completed 시도 → 400
- [x] update_tickets: 가격 변경 → 반영
- [x] update_tickets: 판매 수량 미만으로 변경 → 400
- [x] 과거 시간으로 이벤트 생성 → 400
- [x] 다른 파트너 이벤트 수정 → 403
- [x] 인증 없이 → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)