### PR TITLE
fix(edge-fn): github-stats-sync 인증 누락 수정

### DIFF
--- a/supabase/functions/github-stats-sync/index.ts
+++ b/supabase/functions/github-stats-sync/index.ts
@@ -26,8 +26,14 @@ Deno.serve(async (req: Request): Promise<Response> => {
   const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
   const githubToken = Deno.env.get("GITHUB_ACCESS_TOKEN");
 
-  if (!supabaseUrl || !serviceRoleKey) {
-    return errorResponse("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY", 500);
+  // Fix #380: service role key 검증 추가 — verify_jwt=false이므로 자체 인증 필수
+  const authHeader = req.headers.get("Authorization") ?? "";
+  if (!serviceRoleKey || authHeader !== `Bearer ${serviceRoleKey}`) {
+    return errorResponse("Unauthorized", 401);
+  }
+
+  if (!supabaseUrl) {
+    return errorResponse("Missing SUPABASE_URL", 500);
   }
 
   const supabase = createClient(supabaseUrl, serviceRoleKey, {


### PR DESCRIPTION
## Summary
- `github-stats-sync` Edge Function에 service role key 검증 추가
- `verify_jwt=false` 설정에서 자체 인증이 없어 누구나 호출 가능한 보안 취약점 수정
- `reconciliation-daily`, `metrics-alert`와 동일한 `Bearer ${serviceRoleKey}` 검증 패턴 적용

Closes #380

## Test plan
- [ ] CI 통과 확인
- [ ] `Authorization` 헤더 없이 호출 시 401 반환 확인
- [ ] 올바른 service role key로 호출 시 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)