### PR TITLE
test(e2e): Tier 3 CUJ 16–20 RLS/권한/라이프사이클/체크인

### DIFF
--- a/tests/client_cuj_integration/integration_test/cuj/cuj_16_rls_isolation_test.dart
+++ b/tests/client_cuj_integration/integration_test/cuj/cuj_16_rls_isolation_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../utils/e2e_auth.dart';
+import '../utils/e2e_helpers.dart';
+
+/// CUJ 16: RLS Isolation — Verify cross-user data access is blocked.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late SupabaseClient adminClient;
+  late String userBId;
+
+  setUpAll(() async {
+    await initializeE2E();
+    adminClient = createAdminClient();
+
+    // Get two distinct test users (male and female)
+    final emailA = await getTestUserEmail(adminClient, gender: 'male');
+    await signInAsTestUser(emailA);
+    await signOut();
+
+    final emailB = await getTestUserEmail(adminClient, gender: 'female');
+    await signInAsTestUser(emailB);
+    userBId = Supabase.instance.client.auth.currentUser!.id;
+    await signOut();
+
+    // Sign in as user A for the tests
+    await signInAsTestUser(emailA);
+  });
+
+  tearDownAll(() async {
+    await signOut();
+  });
+
+  group('CUJ 16: RLS Isolation', () {
+    testWidgets('유저 A는 유저 B의 event_applications를 조회할 수 없다', (tester) async {
+      final client = Supabase.instance.client;
+
+      // User A queries user B's applications — RLS should return empty
+      final apps = await client
+          .from('event_applications')
+          .select()
+          .eq('user_id', userBId);
+
+      expect(
+        apps,
+        isEmpty,
+        reason: "User A should not see User B's applications",
+      );
+    });
+
+    testWidgets('유저 A는 유저 B의 user_profiles를 수정할 수 없다', (tester) async {
+      final client = Supabase.instance.client;
+
+      // Attempt to update user B's profile — RLS should block
+      try {
+        await client
+            .from('user_profiles')
+            .update({'bio': 'RLS bypass attempt'}).eq('id', userBId);
+
+        // If no error, verify the update didn't actually take effect
+        final profile = await adminClient
+            .from('user_profiles')
+            .select('bio')
+            .eq('id', userBId)
+            .single();
+        expect(
+          profile['bio'],
+          isNot(equals('RLS bypass attempt')),
+          reason: "User A should not be able to modify User B's profile",
+        );
+      } on PostgrestException catch (e) {
+        // RLS violation — expected behavior
+        expect(e.code, isNotNull);
+      }
+    });
+
+    testWidgets('유저 A는 유저 B의 프로필을 직접 조회할 수 없다', (tester) async {
+      final client = Supabase.instance.client;
+
+      // RLS policy: "Users can read own profile" — self-only
+      final profiles =
+          await client.from('user_profiles').select().eq('id', userBId);
+
+      expect(
+        profiles,
+        isEmpty,
+        reason: "User A should not see User B's profile (self-only RLS)",
+      );
+    });
+
+    testWidgets('인증되지 않은 요청은 보호된 테이블에 접근할 수 없다', (tester) async {
+      // Sign out to become unauthenticated
+      await signOut();
+
+      final client = Supabase.instance.client;
+
+      try {
+        final result = await client.from('event_applications').select();
+        // Anon should get empty or error
+        expect(
+          result,
+          isEmpty,
+          reason:
+              'Unauthenticated request should not access event_applications',
+        );
+      } on PostgrestException catch (e) {
+        // Permission denied — expected
+        expect(e.code, isNotNull);
+      }
+
+      // Re-authenticate for subsequent tests/teardown
+      final emailA = await getTestUserEmail(adminClient, gender: 'male');
+      await signInAsTestUser(emailA);
+    });
+  });
+}

--- a/tests/client_cuj_integration/integration_test/cuj/cuj_17_partner_permission_test.dart
+++ b/tests/client_cuj_integration/integration_test/cuj/cuj_17_partner_permission_test.dart
@@ -1,0 +1,178 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../utils/e2e_auth.dart';
+import '../utils/e2e_helpers.dart';
+
+/// CUJ 17: Partner Permission Branching
+/// — owner can view settlements, manager cannot,
+/// staff can only view submissions.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late SupabaseClient adminClient;
+  late ScheduledEventContext eventCtx;
+  late String ownerEmail;
+  late String managerUserId;
+  late String managerEmail;
+  late String staffUserId;
+  late String staffEmail;
+
+  setUpAll(() async {
+    await initializeE2E();
+    adminClient = createAdminClient();
+    eventCtx = await findScheduledEvent(adminClient);
+
+    ownerEmail = await getPartnerOwnerEmail(
+      adminClient,
+      ownerId: eventCtx.ownerId,
+    );
+
+    // Use male test user as temporary manager
+    managerEmail = await getTestUserEmail(adminClient, gender: 'male');
+    await signInAsTestUser(managerEmail);
+    managerUserId = Supabase.instance.client.auth.currentUser!.id;
+    await signOut();
+
+    // Use female test user as temporary staff
+    staffEmail = await getTestUserEmail(adminClient, gender: 'female');
+    await signInAsTestUser(staffEmail);
+    staffUserId = Supabase.instance.client.auth.currentUser!.id;
+    await signOut();
+
+    // Add manager and staff roles (cleanup first)
+    await _cleanupRoles(adminClient, eventCtx.partnerId, managerUserId);
+    await _cleanupRoles(adminClient, eventCtx.partnerId, staffUserId);
+
+    await adminClient.from('partner_member_permissions').insert({
+      'partner_id': eventCtx.partnerId,
+      'user_id': managerUserId,
+      'role': 'manager',
+    });
+
+    await adminClient.from('partner_member_permissions').insert({
+      'partner_id': eventCtx.partnerId,
+      'user_id': staffUserId,
+      'role': 'staff',
+    });
+
+    // Ensure a settlement exists for this partner (create via completed event)
+    await _ensureSettlementExists(adminClient, eventCtx);
+  });
+
+  tearDownAll(() async {
+    // Remove temporary role assignments
+    await _cleanupRoles(adminClient, eventCtx.partnerId, managerUserId);
+    await _cleanupRoles(adminClient, eventCtx.partnerId, staffUserId);
+    await signOut();
+  });
+
+  group('CUJ 17: Partner Permission Branching', () {
+    testWidgets('owner는 settlement을 조회할 수 있다', (tester) async {
+      await signInAsTestUser(ownerEmail);
+      final client = Supabase.instance.client;
+
+      final settlements = await client
+          .from('settlements')
+          .select()
+          .eq('partner_id', eventCtx.partnerId);
+
+      expect(
+        settlements,
+        isNotEmpty,
+        reason: 'Owner (SETTLEMENT_VIEW) should see settlements',
+      );
+
+      await signOut();
+    });
+
+    testWidgets('manager는 settlement을 조회할 수 없다 (RLS 차단)', (tester) async {
+      await signInAsTestUser(managerEmail);
+      final client = Supabase.instance.client;
+
+      // Manager lacks SETTLEMENT_VIEW permission
+      final settlements = await client
+          .from('settlements')
+          .select()
+          .eq('partner_id', eventCtx.partnerId);
+
+      expect(
+        settlements,
+        isEmpty,
+        reason: 'Manager (no SETTLEMENT_VIEW) should not see settlements',
+      );
+
+      await signOut();
+    });
+
+    testWidgets('staff는 verification_submissions만 접근 가능하다', (tester) async {
+      await signInAsTestUser(staffEmail);
+      final client = Supabase.instance.client;
+
+      // Staff has VERIFY_LIST_VIEW — can see submissions for their partner
+      final submissions = await client
+          .from('verification_submissions')
+          .select()
+          .eq('partner_id', eventCtx.partnerId);
+
+      // Staff should be able to query (may be empty if no submissions exist,
+      // but the query itself should not fail)
+      expect(submissions, isA<List<dynamic>>());
+
+      // Staff should NOT see settlements
+      final settlements = await client
+          .from('settlements')
+          .select()
+          .eq('partner_id', eventCtx.partnerId);
+
+      expect(
+        settlements,
+        isEmpty,
+        reason: 'Staff (no SETTLEMENT_VIEW) should not see settlements',
+      );
+
+      await signOut();
+    });
+  });
+}
+
+/// Ensures at least one settlement exists for the partner.
+Future<void> _ensureSettlementExists(
+  SupabaseClient admin,
+  ScheduledEventContext ctx,
+) async {
+  final existing = await admin
+      .from('settlements')
+      .select('id')
+      .eq('partner_id', ctx.partnerId)
+      .maybeSingle();
+
+  if (existing != null) return;
+
+  // Create a minimal settlement record for testing
+  await admin.from('settlements').insert({
+    'event_id': ctx.eventId,
+    'partner_id': ctx.partnerId,
+    'status': 'pending',
+    'total_sales': 0,
+    'total_refunds': 0,
+    'pg_fee': 0,
+    'platform_fee': 0,
+    'net_amount': 0,
+  });
+}
+
+Future<void> _cleanupRoles(
+  SupabaseClient admin,
+  String partnerId,
+  String userId,
+) async {
+  try {
+    await admin
+        .from('partner_member_permissions')
+        .delete()
+        .eq('partner_id', partnerId)
+        .eq('user_id', userId);
+  } on Object catch (_) {}
+}

--- a/tests/client_cuj_integration/integration_test/cuj/cuj_18_event_lifecycle_test.dart
+++ b/tests/client_cuj_integration/integration_test/cuj/cuj_18_event_lifecycle_test.dart
@@ -1,0 +1,146 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../utils/e2e_auth.dart';
+import '../utils/e2e_helpers.dart';
+
+/// CUJ 18: Event Lifecycle
+/// — scheduled → completed transition, apply to completed event fails,
+///   settlement auto-creation on completion.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late SupabaseClient adminClient;
+  late ScheduledEventContext eventCtx;
+  late String testUserId;
+  late String testEmail;
+  late String verificationId;
+
+  setUpAll(() async {
+    await initializeE2E();
+    adminClient = createAdminClient();
+    eventCtx = await findScheduledEvent(adminClient);
+
+    testEmail = await getTestUserEmail(adminClient, gender: 'male');
+    await signInAsTestUser(testEmail);
+    testUserId = Supabase.instance.client.auth.currentUser!.id;
+    verificationId = await getCareerVerificationId(adminClient);
+
+    // Cleanup any prior state
+    await _cleanup(adminClient, testUserId, eventCtx.eventId);
+  });
+
+  tearDownAll(() async {
+    // Restore event to scheduled for other tests
+    try {
+      await adminClient
+          .from('events')
+          .update({'status': 'scheduled'}).eq('id', eventCtx.eventId);
+    } on Object catch (_) {}
+    // Delete settlement created by this test
+    try {
+      await adminClient
+          .from('settlements')
+          .delete()
+          .eq('event_id', eventCtx.eventId);
+    } on Object catch (_) {}
+    await _cleanup(adminClient, testUserId, eventCtx.eventId);
+    await signOut();
+  });
+
+  group('CUJ 18: Event Lifecycle', () {
+    testWidgets('admin이 이벤트를 scheduled → completed로 변경할 수 있다', (tester) async {
+      await adminClient
+          .from('events')
+          .update({'status': 'completed'}).eq('id', eventCtx.eventId);
+
+      final event = await adminClient
+          .from('events')
+          .select('status')
+          .eq('id', eventCtx.eventId)
+          .single();
+
+      expect(event['status'], equals('completed'));
+    });
+
+    testWidgets('completed 이벤트에 apply_event 시도 시 에러가 발생한다', (tester) async {
+      final client = Supabase.instance.client;
+
+      try {
+        await client.rpc<dynamic>(
+          'apply_event',
+          params: {
+            'p_event_id': eventCtx.eventId,
+            'p_ticket_id': eventCtx.ticketId,
+            'p_user_id': testUserId,
+            'p_payment_id': 'E2E_LIFE_${Random().nextInt(99999)}',
+            'p_payment_amount': 1000,
+            'p_verification_data': {
+              'partner_id': eventCtx.partnerId,
+              'verification_id': verificationId,
+              'data': {'company': 'Lifecycle Test', 'position': 'Tester'},
+            },
+          },
+        );
+        // If no error thrown, the application should not have been created
+        // (balance check or other guard should prevent it)
+        fail('apply_event should fail for completed event');
+      } on PostgrestException catch (e) {
+        // Expected: balance check or event status guard rejects
+        expect(e.message, isNotEmpty);
+      }
+    });
+
+    testWidgets('completed 이벤트에 settlement이 자동 생성된다', (tester) async {
+      // Settlement should have been auto-created by the trigger
+      // when we set status to 'completed' in the first test
+      final settlement = await retry(() async {
+        final res = await adminClient
+            .from('settlements')
+            .select()
+            .eq('event_id', eventCtx.eventId)
+            .maybeSingle();
+        if (res == null) throw Exception('Settlement not yet created');
+        return res;
+      });
+
+      expect(settlement, isNotNull);
+      expect(settlement['event_id'], equals(eventCtx.eventId));
+      expect(settlement['partner_id'], equals(eventCtx.partnerId));
+      expect(settlement['status'], equals('pending'));
+    });
+  });
+}
+
+Future<void> _cleanup(
+  SupabaseClient admin,
+  String userId,
+  String eventId,
+) async {
+  try {
+    await admin
+        .from('event_participants')
+        .delete()
+        .eq('user_id', userId)
+        .eq('event_id', eventId);
+  } on Object catch (_) {}
+  try {
+    final appRes = await admin
+        .from('event_applications')
+        .select('id')
+        .eq('user_id', userId)
+        .eq('event_id', eventId)
+        .maybeSingle();
+    if (appRes != null) {
+      final appId = appRes['id'] as String;
+      await admin
+          .from('verification_submissions')
+          .delete()
+          .eq('application_id', appId);
+      await admin.from('event_applications').delete().eq('id', appId);
+    }
+  } on Object catch (_) {}
+}

--- a/tests/client_cuj_integration/integration_test/cuj/cuj_19_duplicate_application_test.dart
+++ b/tests/client_cuj_integration/integration_test/cuj/cuj_19_duplicate_application_test.dart
@@ -1,0 +1,163 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../utils/e2e_auth.dart';
+import '../utils/e2e_helpers.dart';
+
+/// CUJ 19: Duplicate Application Prevention
+/// — Same user applying to same event twice should fail with a clear error.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late SupabaseClient adminClient;
+  late ScheduledEventContext eventCtx;
+  late String testUserId;
+  late String verificationId;
+  String? firstApplicationId;
+
+  setUpAll(() async {
+    await initializeE2E();
+    adminClient = createAdminClient();
+    eventCtx = await findScheduledEvent(adminClient);
+
+    final email = await getTestUserEmail(adminClient, gender: 'male');
+    await signInAsTestUser(email);
+    testUserId = Supabase.instance.client.auth.currentUser!.id;
+    verificationId = await getCareerVerificationId(adminClient);
+
+    await _cleanup(adminClient, testUserId, eventCtx.eventId);
+  });
+
+  tearDownAll(() async {
+    await _cleanup(adminClient, testUserId, eventCtx.eventId);
+    await signOut();
+  });
+
+  group('CUJ 19: Duplicate Application Prevention', () {
+    testWidgets('첫 번째 신청은 성공한다', (tester) async {
+      final client = Supabase.instance.client;
+
+      final appId = await client.rpc<dynamic>(
+        'apply_event',
+        params: {
+          'p_event_id': eventCtx.eventId,
+          'p_ticket_id': eventCtx.ticketId,
+          'p_user_id': testUserId,
+          'p_payment_id': 'E2E_DUP1_${Random().nextInt(99999)}',
+          'p_payment_amount': 1000,
+          'p_verification_data': {
+            'partner_id': eventCtx.partnerId,
+            'verification_id': verificationId,
+            'data': {'company': 'Dup Test Corp', 'position': 'Tester'},
+          },
+        },
+      );
+
+      expect(appId, isNotNull, reason: 'First application should succeed');
+      firstApplicationId = appId as String;
+    });
+
+    testWidgets('동일 유저가 동일 이벤트에 2회 신청하면 에러가 발생한다', (tester) async {
+      expect(
+        firstApplicationId,
+        isNotNull,
+        reason: 'Previous test must create first application',
+      );
+
+      final client = Supabase.instance.client;
+
+      try {
+        await client.rpc<dynamic>(
+          'apply_event',
+          params: {
+            'p_event_id': eventCtx.eventId,
+            'p_ticket_id': eventCtx.ticketId,
+            'p_user_id': testUserId,
+            'p_payment_id': 'E2E_DUP2_${Random().nextInt(99999)}',
+            'p_payment_amount': 1000,
+            'p_verification_data': {
+              'partner_id': eventCtx.partnerId,
+              'verification_id': verificationId,
+              'data': {'company': 'Dup Test Corp', 'position': 'Tester'},
+            },
+          },
+        );
+        fail('Second application should fail due to unique constraint');
+      } on PostgrestException catch (e) {
+        // unique(event_id, user_id) violation — code 23505
+        expect(
+          e.message,
+          isNotEmpty,
+          reason: 'Error message should indicate duplicate',
+        );
+      }
+    });
+
+    testWidgets('에러 메시지가 PostgrestException 구조를 갖는다', (tester) async {
+      expect(
+        firstApplicationId,
+        isNotNull,
+        reason: 'Previous test must create first application',
+      );
+
+      final client = Supabase.instance.client;
+
+      PostgrestException? caughtError;
+      try {
+        await client.rpc<dynamic>(
+          'apply_event',
+          params: {
+            'p_event_id': eventCtx.eventId,
+            'p_ticket_id': eventCtx.ticketId,
+            'p_user_id': testUserId,
+            'p_payment_id': 'E2E_DUP3_${Random().nextInt(99999)}',
+            'p_payment_amount': 1000,
+          },
+        );
+      } on PostgrestException catch (e) {
+        caughtError = e;
+      }
+
+      expect(
+        caughtError,
+        isNotNull,
+        reason: 'Duplicate application should throw PostgrestException',
+      );
+      expect(caughtError!.code, isNotNull);
+      expect(caughtError.message, isNotEmpty);
+    });
+  });
+}
+
+Future<void> _cleanup(
+  SupabaseClient admin,
+  String userId,
+  String eventId,
+) async {
+  try {
+    await admin
+        .from('event_participants')
+        .delete()
+        .eq('user_id', userId)
+        .eq('event_id', eventId);
+  } on Object catch (_) {}
+  try {
+    final appRes = await admin
+        .from('event_applications')
+        .select('id')
+        .eq('user_id', userId)
+        .eq('event_id', eventId)
+        .maybeSingle();
+    if (appRes != null) {
+      final appId = appRes['id'] as String;
+      await admin
+          .from('verification_submissions')
+          .delete()
+          .eq('application_id', appId);
+      await admin.from('event_applications').delete().eq('id', appId);
+    }
+  } on Object catch (_) {}
+}

--- a/tests/client_cuj_integration/integration_test/cuj/cuj_20_checkin_flow_test.dart
+++ b/tests/client_cuj_integration/integration_test/cuj/cuj_20_checkin_flow_test.dart
@@ -1,0 +1,191 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../utils/e2e_auth.dart';
+import '../utils/e2e_helpers.dart';
+
+/// CUJ 20: Check-in Flow
+/// — approved participant gets ticket, checks in via Edge Function,
+///   re-check-in returns 409 conflict.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late SupabaseClient adminClient;
+  late ScheduledEventContext eventCtx;
+  late String testUserId;
+  late String testEmail;
+  late String verificationId;
+  String? applicationId;
+  String? participantId;
+
+  setUpAll(() async {
+    await initializeE2E();
+    adminClient = createAdminClient();
+    eventCtx = await findScheduledEvent(adminClient);
+
+    testEmail = await getTestUserEmail(adminClient, gender: 'male');
+    await signInAsTestUser(testEmail);
+    testUserId = Supabase.instance.client.auth.currentUser!.id;
+    verificationId = await getCareerVerificationId(adminClient);
+
+    await _cleanup(adminClient, testUserId, eventCtx.eventId);
+
+    // Create application, approve, and get participant with ticket
+    applicationId = await Supabase.instance.client.rpc<dynamic>(
+      'apply_event',
+      params: {
+        'p_event_id': eventCtx.eventId,
+        'p_ticket_id': eventCtx.ticketId,
+        'p_user_id': testUserId,
+        'p_payment_id': 'E2E_CHK_${Random().nextInt(99999)}',
+        'p_payment_amount': 1000,
+        'p_verification_data': {
+          'partner_id': eventCtx.partnerId,
+          'verification_id': verificationId,
+          'data': {
+            'company': 'Checkin Test Corp',
+            'position': 'QA',
+          },
+        },
+      },
+    ) as String;
+
+    // Approve verification → triggers approved + participant creation
+    await adminClient
+        .from('verification_submissions')
+        .update({'status': 'approved'}).eq('application_id', applicationId!);
+
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+
+    // Set application to paid (required for participant ticket_issued)
+    await adminClient.from('event_applications').update({
+      'status': 'paid',
+      'paid_at': DateTime.now().toIso8601String(),
+    }).eq('id', applicationId!);
+
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+
+    // Get participant record
+    final participant = await retry(() async {
+      final res = await adminClient
+          .from('event_participants')
+          .select()
+          .eq('application_id', applicationId!)
+          .maybeSingle();
+      if (res == null) throw Exception('Participant not yet created');
+      return res;
+    });
+    participantId = participant['id'] as String;
+
+    // Ensure participant is in ticket_issued status
+    await adminClient
+        .from('event_participants')
+        .update({'status': 'ticket_issued'}).eq('id', participantId!);
+  });
+
+  tearDownAll(() async {
+    await _cleanup(adminClient, testUserId, eventCtx.eventId);
+    await signOut();
+  });
+
+  group('CUJ 20: Check-in Flow', () {
+    testWidgets('approved participant의 ticket_code를 조회할 수 있다', (tester) async {
+      final participant = await adminClient
+          .from('event_participants')
+          .select('ticket_code, status')
+          .eq('id', participantId!)
+          .single();
+
+      expect(
+        participant['ticket_code'],
+        isNotNull,
+        reason: 'Approved participant should have a ticket_code',
+      );
+      expect(participant['status'], equals('ticket_issued'));
+    });
+
+    testWidgets('체크인 처리 후 checked_in 상태로 변경된다', (tester) async {
+      final client = Supabase.instance.client;
+
+      final response = await client.functions.invoke(
+        'event-checkin',
+        body: {
+          'event_id': eventCtx.eventId,
+          'participant_id': participantId,
+        },
+      );
+
+      expect(
+        response.status,
+        equals(200),
+        reason: 'Check-in should succeed: ${response.data}',
+      );
+
+      final body = response.data is String
+          ? jsonDecode(response.data as String) as Map<String, dynamic>
+          : response.data as Map<String, dynamic>;
+      expect(body['success'], isTrue);
+      expect(body['status'], equals('checked_in'));
+
+      // Verify in DB
+      final participant = await adminClient
+          .from('event_participants')
+          .select('status')
+          .eq('id', participantId!)
+          .single();
+      expect(participant['status'], equals('checked_in'));
+    });
+
+    testWidgets('이미 체크인한 참가자 재체크인 시도 시 409 에러가 발생한다', (tester) async {
+      final client = Supabase.instance.client;
+
+      final response = await client.functions.invoke(
+        'event-checkin',
+        body: {
+          'event_id': eventCtx.eventId,
+          'participant_id': participantId,
+        },
+      );
+
+      expect(
+        response.status,
+        equals(409),
+        reason: 'Re-check-in should return 409 Conflict',
+      );
+    });
+  });
+}
+
+Future<void> _cleanup(
+  SupabaseClient admin,
+  String userId,
+  String eventId,
+) async {
+  try {
+    await admin
+        .from('event_participants')
+        .delete()
+        .eq('user_id', userId)
+        .eq('event_id', eventId);
+  } on Object catch (_) {}
+  try {
+    final appRes = await admin
+        .from('event_applications')
+        .select('id')
+        .eq('user_id', userId)
+        .eq('event_id', eventId)
+        .maybeSingle();
+    if (appRes != null) {
+      final appId = appRes['id'] as String;
+      await admin
+          .from('verification_submissions')
+          .delete()
+          .eq('application_id', appId);
+      await admin.from('event_applications').delete().eq('id', appId);
+    }
+  } on Object catch (_) {}
+}


### PR DESCRIPTION
## Summary
- CUJ 16: RLS 격리 — 유저 간 데이터 접근 차단 검증
- CUJ 17: 파트너 권한 분기 — owner/manager/staff 역할별 settlement 접근 제어
- CUJ 18: 이벤트 라이프사이클 — scheduled→completed 전환, apply 차단, settlement 자동 생성
- CUJ 19: 중복 신청 방지 — unique(event_id, user_id) 제약 조건 검증
- CUJ 20: 체크인 플로우 — ticket_issued→checked_in Edge Function 호출, 재체크인 409

Closes #232

## Test plan
- [ ] daily-e2e CI에서 CUJ 16–20 자동 실행 확인
- [ ] dev-seed 데이터가 존재하는 환경에서 각 테스트 통과 확인
- [ ] CUJ 17: 테스트 유저가 이미 해당 파트너의 멤버가 아닌지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)