### PR TITLE
ci(supabase): add migration dry-run validation step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,11 @@ jobs:
           cache: true
       - name: Start Supabase
         run: supabase start
+      - name: Validate migrations (dry-run)
+        run: |
+          echo "🔄 Resetting DB and re-applying all migrations from scratch..."
+          supabase db reset
+          echo "✅ All migrations applied successfully"
       - name: Test (pgTAP)
         run: supabase test db
       - name: Stop Supabase


### PR DESCRIPTION
## Summary
- `test-supabase` job에 `supabase db reset` 단계를 추가하여 모든 migration이 처음부터 깨끗하게 적용되는지 PR 단계에서 사전 검증
- 기존 `supabase start` → `supabase test db` 사이에 dry-run 삽입
- Migration SQL 문법 오류, 의존성 누락 등을 머지 전에 차단

Closes #234

## Test plan
- [ ] `supabase/**` 변경이 포함된 PR에서 `test-supabase` job이 `Validate migrations (dry-run)` 단계를 실행하는지 확인
- [ ] 의도적으로 깨진 migration SQL을 넣었을 때 해당 단계에서 CI가 실패하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)