### PR TITLE
feat(supabase): add partner-manage-member EF

### DIFF
--- a/shared/packages/minglit_kit/lib/src/data/repositories/partner_member_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/partner_member_repository.dart
@@ -37,7 +37,7 @@ mixin _PartnerMemberRepository on _SupabasePartnerContext {
     }
   }
 
-  /// Updates a member's role.
+  // Fix #313: updateMemberRole via EF (MEMBER_MANAGE 권한 서버 검증)
   Future<void> updateMemberRole({
     required String partnerId,
     required String userId,
@@ -48,12 +48,23 @@ mixin _PartnerMemberRepository on _SupabasePartnerContext {
       ' role: $role',
     );
     try {
-      await supabaseClient
-          .from('partner_member_permissions')
-          .update({'role': role})
-          .match(
-            {'partner_id': partnerId, 'user_id': userId},
-          );
+      final response = await supabaseClient.functions.invoke(
+        'partner-manage-member',
+        body: {
+          'action': 'update_role',
+          'partner_id': partnerId,
+          'user_id': userId,
+          'role': role,
+        },
+      );
+
+      if (response.status != 200) {
+        final respData = response.data;
+        final errorMsg = respData is Map
+            ? (respData['error'] as String?) ?? 'Failed to update member role'
+            : 'Failed to update member role';
+        throw MinglitUserException(errorMsg);
+      }
       Log.d('updateMemberRole success');
     } catch (e, st) {
       Log.e('❌ [PartnerRepo] updateMemberRole Error', e, st);
@@ -61,7 +72,7 @@ mixin _PartnerMemberRepository on _SupabasePartnerContext {
     }
   }
 
-  /// Updates a member's specific permissions.
+  // Fix #313: updateMemberPermissions via EF (MEMBER_MANAGE 권한 서버 검증)
   Future<void> updateMemberPermissions({
     required String partnerId,
     required String userId,
@@ -72,12 +83,24 @@ mixin _PartnerMemberRepository on _SupabasePartnerContext {
       ' perms: $permissions',
     );
     try {
-      await supabaseClient
-          .from('partner_member_permissions')
-          .update({'permissions': permissions})
-          .match(
-            {'partner_id': partnerId, 'user_id': userId},
-          );
+      final response = await supabaseClient.functions.invoke(
+        'partner-manage-member',
+        body: {
+          'action': 'update_permissions',
+          'partner_id': partnerId,
+          'user_id': userId,
+          'permissions': permissions,
+        },
+      );
+
+      if (response.status != 200) {
+        final respData = response.data;
+        final errorMsg = respData is Map
+            ? (respData['error'] as String?) ??
+                'Failed to update member permissions'
+            : 'Failed to update member permissions';
+        throw MinglitUserException(errorMsg);
+      }
       Log.d('updateMemberPermissions success');
     } catch (e, st) {
       Log.e('❌ [PartnerRepo] updateMemberPermissions Error', e, st);

--- a/shared/packages/minglit_kit/lib/src/data/repositories/partner_member_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/partner_member_repository.dart
@@ -97,7 +97,7 @@ mixin _PartnerMemberRepository on _SupabasePartnerContext {
         final respData = response.data;
         final errorMsg = respData is Map
             ? (respData['error'] as String?) ??
-                'Failed to update member permissions'
+                  'Failed to update member permissions'
             : 'Failed to update member permissions';
         throw MinglitUserException(errorMsg);
       }

--- a/shared/packages/minglit_kit/test/src/data/repositories/partner_member_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/partner_member_repository_test.dart
@@ -168,38 +168,40 @@ void main() {
     });
 
     group('updateMemberPermissions', () {
-      test('calls partner-manage-member EF with update_permissions action',
-          () async {
-        when(
-          () => mockFunctions.invoke(
-            'partner-manage-member',
-            body: any(named: 'body'),
-          ),
-        ).thenAnswer(
-          (_) async => FunctionResponse(status: 200, data: {'success': true}),
-        );
+      test(
+        'calls partner-manage-member EF with update_permissions action',
+        () async {
+          when(
+            () => mockFunctions.invoke(
+              'partner-manage-member',
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer(
+            (_) async => FunctionResponse(status: 200, data: {'success': true}),
+          );
 
-        await expectLater(
-          repository.updateMemberPermissions(
-            partnerId: 'partner_1',
-            userId: 'user_1',
-            permissions: ['PARTY_MANAGE', 'COMMENT_MANAGE'],
-          ),
-          completes,
-        );
+          await expectLater(
+            repository.updateMemberPermissions(
+              partnerId: 'partner_1',
+              userId: 'user_1',
+              permissions: ['PARTY_MANAGE', 'COMMENT_MANAGE'],
+            ),
+            completes,
+          );
 
-        verify(
-          () => mockFunctions.invoke(
-            'partner-manage-member',
-            body: {
-              'action': 'update_permissions',
-              'partner_id': 'partner_1',
-              'user_id': 'user_1',
-              'permissions': ['PARTY_MANAGE', 'COMMENT_MANAGE'],
-            },
-          ),
-        ).called(1);
-      });
+          verify(
+            () => mockFunctions.invoke(
+              'partner-manage-member',
+              body: {
+                'action': 'update_permissions',
+                'partner_id': 'partner_1',
+                'user_id': 'user_1',
+                'permissions': ['PARTY_MANAGE', 'COMMENT_MANAGE'],
+              },
+            ),
+          ).called(1);
+        },
+      );
 
       test('throws MinglitUserException on non-200 response', () async {
         when(

--- a/shared/packages/minglit_kit/test/src/data/repositories/partner_member_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/partner_member_repository_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async' show FutureOr, unawaited;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/repositories/partner_repository.dart';
+import 'package:minglit_kit/src/utils/exceptions.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -23,6 +24,7 @@ class _FakeRpcResult extends Fake implements PostgrestFilterBuilder<dynamic> {
 void main() {
   late MockSupabaseClient mockClient;
   late PartnerRepository repository;
+  late MockFunctionsClient mockFunctions;
 
   final now = DateTime.now();
   final mockUser = MockUser();
@@ -40,6 +42,7 @@ void main() {
   setUp(() {
     mockClient = createMockSupabase(currentUser: mockUser);
     when(() => mockUser.id).thenReturn('user_1');
+    mockFunctions = mockClient.functions as MockFunctionsClient;
     repository = PartnerRepository(supabase: mockClient);
   });
 
@@ -90,8 +93,50 @@ void main() {
     });
 
     group('updateMemberRole', () {
-      test('completes without error', () async {
-        unawaited(mockTable(mockClient, 'partner_member_permissions'));
+      test('calls partner-manage-member EF with update_role action', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-member',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(status: 200, data: {'success': true}),
+        );
+
+        await expectLater(
+          repository.updateMemberRole(
+            partnerId: 'partner_1',
+            userId: 'user_1',
+            role: 'manager',
+          ),
+          completes,
+        );
+
+        verify(
+          () => mockFunctions.invoke(
+            'partner-manage-member',
+            body: {
+              'action': 'update_role',
+              'partner_id': 'partner_1',
+              'user_id': 'user_1',
+              'role': 'manager',
+            },
+          ),
+        ).called(1);
+      });
+
+      test('throws MinglitUserException on non-200 response', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-member',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 403,
+            data: {'error': 'Forbidden: insufficient partner permissions'},
+          ),
+        );
 
         await expectLater(
           repository.updateMemberRole(
@@ -99,18 +144,17 @@ void main() {
             userId: 'user_1',
             role: 'owner',
           ),
-          completes,
+          throwsA(isA<MinglitUserException>()),
         );
       });
 
-      test('throws on db error', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'partner_member_permissions',
-            shouldThrow: Exception('db error'),
+      test('throws on network error', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-member',
+            body: any(named: 'body'),
           ),
-        );
+        ).thenThrow(Exception('network error'));
 
         await expectLater(
           repository.updateMemberRole(
@@ -124,25 +168,49 @@ void main() {
     });
 
     group('updateMemberPermissions', () {
-      test('completes without error', () async {
-        unawaited(mockTable(mockClient, 'partner_member_permissions'));
+      test('calls partner-manage-member EF with update_permissions action',
+          () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-member',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(status: 200, data: {'success': true}),
+        );
 
         await expectLater(
           repository.updateMemberPermissions(
             partnerId: 'partner_1',
             userId: 'user_1',
-            permissions: ['view', 'edit'],
+            permissions: ['PARTY_MANAGE', 'COMMENT_MANAGE'],
           ),
           completes,
         );
+
+        verify(
+          () => mockFunctions.invoke(
+            'partner-manage-member',
+            body: {
+              'action': 'update_permissions',
+              'partner_id': 'partner_1',
+              'user_id': 'user_1',
+              'permissions': ['PARTY_MANAGE', 'COMMENT_MANAGE'],
+            },
+          ),
+        ).called(1);
       });
 
-      test('throws on db error', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'partner_member_permissions',
-            shouldThrow: Exception('permissions update failed'),
+      test('throws MinglitUserException on non-200 response', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-member',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 400,
+            data: {'error': 'Invalid permission: HACK'},
           ),
         );
 
@@ -150,7 +218,25 @@ void main() {
           repository.updateMemberPermissions(
             partnerId: 'partner_1',
             userId: 'user_1',
-            permissions: ['view'],
+            permissions: ['HACK'],
+          ),
+          throwsA(isA<MinglitUserException>()),
+        );
+      });
+
+      test('throws on network error', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-member',
+            body: any(named: 'body'),
+          ),
+        ).thenThrow(Exception('network error'));
+
+        await expectLater(
+          repository.updateMemberPermissions(
+            partnerId: 'partner_1',
+            userId: 'user_1',
+            permissions: ['PARTY_MANAGE'],
           ),
           throwsA(isA<Exception>()),
         );

--- a/shared/packages/minglit_kit/test/src/data/repositories/partner_member_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/partner_member_repository_test.dart
@@ -1,4 +1,4 @@
-import 'dart:async' show FutureOr, unawaited;
+import 'dart:async' show FutureOr;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/repositories/partner_repository.dart';
 import 'package:minglit_kit/src/utils/exceptions.dart';

--- a/supabase/functions/partner-manage-member/deno.json
+++ b/supabase/functions/partner-manage-member/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/partner-manage-member/index.ts
+++ b/supabase/functions/partner-manage-member/index.ts
@@ -145,7 +145,7 @@ async function checkPartnerPermission(
 ): Promise<void | Response> {
   const { data: perm, error: permError } = await supabase
     .from("partner_member_permissions")
-    .select("permissions")
+    .select("role, permissions")
     .eq("partner_id", partnerId)
     .eq("user_id", userId)
     .maybeSingle();
@@ -154,8 +154,9 @@ async function checkPartnerPermission(
     return errorResponse("Failed to verify partner permissions", 500);
   }
 
-  // Fix #313: MEMBER_MANAGE 권한 확인
-  const hasPermission = (perm?.permissions as string[] | null)?.includes("MEMBER_MANAGE") ?? false;
+  // Fix #313: owner role 또는 MEMBER_MANAGE 권한 확인 (defense-in-depth)
+  const hasPermission = perm?.role === "owner" ||
+    ((perm?.permissions as string[] | null)?.includes("MEMBER_MANAGE") ?? false);
   if (!hasPermission) {
     return errorResponse("Forbidden: insufficient partner permissions", 403);
   }

--- a/supabase/functions/partner-manage-member/index.ts
+++ b/supabase/functions/partner-manage-member/index.ts
@@ -1,0 +1,162 @@
+// partner-manage-member — Manage partner member roles and permissions
+// Issue #313: RLS write strategy 전환
+
+import { createServiceClient } from "../_shared/supabase_client.ts";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
+import { requireAuth } from "../_shared/auth_utils.ts";
+
+// Fix #313: role 화이트리스트 — partner_role enum과 일치
+const VALID_ROLES = ["owner", "manager", "staff"] as const;
+
+// Fix #313: permissions 화이트리스트 — sync_partner_member_permissions 트리거와 일치
+const VALID_PERMISSIONS = [
+  "PARTNER_EDIT",
+  "SETTLEMENT_VIEW",
+  "SETTLEMENT_EDIT",
+  "MEMBER_MANAGE",
+  "PARTY_MANAGE",
+  "VERIFY_LIST_VIEW",
+  "USER_DATA_VIEW",
+  "VERIFY_REVIEW",
+  "COMMENT_MANAGE",
+] as const;
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") return corsResponse();
+  if (req.method !== "POST") return errorResponse("Method not allowed", 405);
+
+  try {
+    // 1. Auth
+    const auth = await requireAuth(req);
+    if (auth instanceof Response) return auth;
+    const userId = auth;
+
+    // 2. Parse body
+    let body: Record<string, unknown>;
+    try {
+      const parsed = await req.json();
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        return errorResponse("Request body must be a JSON object", 400);
+      }
+      body = parsed as Record<string, unknown>;
+    } catch {
+      return errorResponse("Invalid JSON body", 400);
+    }
+
+    const action = body.action as string | undefined;
+    if (typeof action !== "string" || !action) return errorResponse("Missing action", 400);
+
+    // 3. Supabase client (service role)
+    const supabase = createServiceClient();
+
+    // ─── update_role ───
+    if (action === "update_role") {
+      const partnerId = typeof body.partner_id === "string" ? body.partner_id.trim() : "";
+      if (!partnerId) return errorResponse("Missing partner_id", 400);
+
+      const targetUserId = typeof body.user_id === "string" ? body.user_id.trim() : "";
+      if (!targetUserId) return errorResponse("Missing user_id", 400);
+
+      const role = typeof body.role === "string" ? body.role.trim() : "";
+      if (!role) return errorResponse("Missing role", 400);
+
+      // Fix #313: role 화이트리스트 검증
+      if (!VALID_ROLES.includes(role as typeof VALID_ROLES[number])) {
+        return errorResponse(`Invalid role: ${role}`, 400);
+      }
+
+      // Fix #313: 자기 자신 role 변경 방지
+      if (targetUserId === userId) {
+        return errorResponse("Cannot change own role", 400);
+      }
+
+      // Check MEMBER_MANAGE permission
+      const permCheck = await checkPartnerPermission(supabase, partnerId, userId);
+      if (permCheck instanceof Response) return permCheck;
+
+      const { error: updateError } = await supabase
+        .from("partner_member_permissions")
+        .update({ role })
+        .eq("partner_id", partnerId)
+        .eq("user_id", targetUserId);
+
+      if (updateError) {
+        return errorResponse(`Failed to update role: ${updateError.message}`, 500);
+      }
+
+      return successResponse({ success: true });
+    }
+
+    // ─── update_permissions ───
+    if (action === "update_permissions") {
+      const partnerId = typeof body.partner_id === "string" ? body.partner_id.trim() : "";
+      if (!partnerId) return errorResponse("Missing partner_id", 400);
+
+      const targetUserId = typeof body.user_id === "string" ? body.user_id.trim() : "";
+      if (!targetUserId) return errorResponse("Missing user_id", 400);
+
+      if (!Array.isArray(body.permissions)) {
+        return errorResponse("Missing permissions", 400);
+      }
+
+      const permissions = body.permissions as unknown[];
+
+      // Fix #313: permissions 화이트리스트 검증
+      for (const perm of permissions) {
+        if (typeof perm !== "string" || !VALID_PERMISSIONS.includes(perm as typeof VALID_PERMISSIONS[number])) {
+          return errorResponse(`Invalid permission: ${perm}`, 400);
+        }
+      }
+
+      // Check MEMBER_MANAGE permission
+      const permCheck = await checkPartnerPermission(supabase, partnerId, userId);
+      if (permCheck instanceof Response) return permCheck;
+
+      const { error: updateError } = await supabase
+        .from("partner_member_permissions")
+        .update({ permissions })
+        .eq("partner_id", partnerId)
+        .eq("user_id", targetUserId);
+
+      if (updateError) {
+        return errorResponse(`Failed to update permissions: ${updateError.message}`, 500);
+      }
+
+      return successResponse({ success: true });
+    }
+
+    return errorResponse(`Unknown action: ${action}`, 400);
+  } catch (error) {
+    console.error("partner-manage-member failed", error);
+    return errorResponse("Internal server error", 500);
+  }
+});
+
+// ─── Helper: check partner MEMBER_MANAGE permission ───
+async function checkPartnerPermission(
+  supabase: SupabaseClient,
+  partnerId: string,
+  userId: string,
+): Promise<void | Response> {
+  const { data: perm, error: permError } = await supabase
+    .from("partner_member_permissions")
+    .select("permissions")
+    .eq("partner_id", partnerId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (permError) {
+    return errorResponse("Failed to verify partner permissions", 500);
+  }
+
+  // Fix #313: MEMBER_MANAGE 권한 확인
+  const hasPermission = (perm?.permissions as string[] | null)?.includes("MEMBER_MANAGE") ?? false;
+  if (!hasPermission) {
+    return errorResponse("Forbidden: insufficient partner permissions", 403);
+  }
+}

--- a/supabase/functions/partner-manage-member/partner_manage_member_test.ts
+++ b/supabase/functions/partner-manage-member/partner_manage_member_test.ts
@@ -39,7 +39,7 @@ function permRoute(hasPermission = true): FetchRoute {
     handler: () =>
       jsonResponse(
         hasPermission
-          ? { permissions: ["PARTNER_EDIT", "MEMBER_MANAGE"] }
+          ? { role: "owner", permissions: ["PARTNER_EDIT", "MEMBER_MANAGE"] }
           : null,
       ),
   };

--- a/supabase/functions/partner-manage-member/partner_manage_member_test.ts
+++ b/supabase/functions/partner-manage-member/partner_manage_member_test.ts
@@ -1,0 +1,681 @@
+import { assertEquals } from "@std/assert";
+import {
+  authenticatedJsonRequest,
+  captureServeHandler,
+  createFetchMock,
+  jsonResponse,
+  readJson,
+  withEnv,
+  withMockedFetch,
+  type FetchRoute,
+} from "../_test_utils/mock_http.ts";
+
+const TEST_USER_ID = "user-partner-owner";
+const TEST_TARGET_USER_ID = "user-target-member";
+const TEST_PARTNER_ID = "partner-001";
+
+const ENV = {
+  SUPABASE_URL: "http://localhost:54321",
+  SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+};
+
+function authRoute(): FetchRoute {
+  return {
+    matcher: "/auth/v1/user",
+    handler: () => jsonResponse({ id: TEST_USER_ID, email: "partner@test.com" }),
+  };
+}
+
+function authFailRoute(): FetchRoute {
+  return {
+    matcher: "/auth/v1/user",
+    handler: () => jsonResponse({ error: "invalid" }, { status: 401 }),
+  };
+}
+
+function permRoute(hasPermission = true): FetchRoute {
+  return {
+    matcher: (req) => req.url.includes("partner_member_permissions") && req.url.includes("select"),
+    handler: () =>
+      jsonResponse(
+        hasPermission
+          ? { permissions: ["PARTNER_EDIT", "MEMBER_MANAGE"] }
+          : null,
+      ),
+  };
+}
+
+function permErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) => req.url.includes("partner_member_permissions") && req.url.includes("select"),
+    handler: () => jsonResponse({ message: "db error" }, { status: 500 }),
+  };
+}
+
+function updateRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/partner_member_permissions") && req.method === "PATCH",
+    handler: () => new Response(null, { status: 200 }),
+  };
+}
+
+function updateErrorRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/partner_member_permissions") && req.method === "PATCH",
+    handler: () => jsonResponse({ message: "update error" }, { status: 500 }),
+  };
+}
+
+// ─── CORS preflight ───
+Deno.test({
+  name: "handles OPTIONS preflight request",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          new Request("http://localhost", { method: "OPTIONS" }),
+        );
+        assertEquals(res.status, 200);
+      });
+    });
+  },
+});
+
+// ─── 401: no auth ───
+Deno.test({
+  name: "returns 401 without authorization",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authFailRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = new Request("http://localhost", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action: "update_role" }),
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 401);
+      });
+    });
+  },
+});
+
+// ─── 400: missing action ───
+Deno.test({
+  name: "returns 400 for missing action",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {}),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing action");
+      });
+    });
+  },
+});
+
+// ─── 400: unknown action ───
+Deno.test({
+  name: "returns 400 for unknown action",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", { action: "unknown" }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Unknown action: unknown");
+      });
+    });
+  },
+});
+
+// ─── update_role: success ───
+Deno.test({
+  name: "update_role: updates role successfully",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      permRoute(),
+      updateRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update_role",
+            partner_id: TEST_PARTNER_ID,
+            user_id: TEST_TARGET_USER_ID,
+            role: "manager",
+          }),
+        );
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+      });
+    });
+  },
+});
+
+// ─── update_role: verify payload sent to DB ───
+Deno.test({
+  name: "update_role: sends correct payload to DB",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    let updateBody: string | null = null;
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      permRoute(),
+      {
+        matcher: (req) =>
+          req.url.includes("/rest/v1/partner_member_permissions") && req.method === "PATCH",
+        handler: async (req) => {
+          updateBody = await req.clone().text();
+          return new Response(null, { status: 200 });
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update_role",
+            partner_id: TEST_PARTNER_ID,
+            user_id: TEST_TARGET_USER_ID,
+            role: "manager",
+          }),
+        );
+        assertEquals(res.status, 200);
+        const parsed = JSON.parse(updateBody!);
+        assertEquals(parsed.role, "manager");
+        assertEquals(Object.keys(parsed).length, 1);
+      });
+    });
+  },
+});
+
+// ─── update_role: missing partner_id → 400 ───
+Deno.test({
+  name: "update_role: returns 400 for missing partner_id",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update_role",
+            user_id: TEST_TARGET_USER_ID,
+            role: "manager",
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing partner_id");
+      });
+    });
+  },
+});
+
+// ─── update_role: missing user_id → 400 ───
+Deno.test({
+  name: "update_role: returns 400 for missing user_id",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update_role",
+            partner_id: TEST_PARTNER_ID,
+            role: "manager",
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing user_id");
+      });
+    });
+  },
+});
+
+// ─── update_role: missing role → 400 ───
+Deno.test({
+  name: "update_role: returns 400 for missing role",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update_role",
+            partner_id: TEST_PARTNER_ID,
+            user_id: TEST_TARGET_USER_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing role");
+      });
+    });
+  },
+});
+
+// ─── update_role: invalid role → 400 ───
+Deno.test({
+  name: "update_role: returns 400 for invalid role",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update_role",
+            partner_id: TEST_PARTNER_ID,
+            user_id: TEST_TARGET_USER_ID,
+            role: "superadmin",
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Invalid role: superadmin");
+      });
+    });
+  },
+});
+
+// ─── update_role: self role change → 400 ───
+Deno.test({
+  name: "update_role: returns 400 when changing own role",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update_role",
+            partner_id: TEST_PARTNER_ID,
+            user_id: TEST_USER_ID,
+            role: "staff",
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Cannot change own role");
+      });
+    });
+  },
+});
+
+// ─── update_role: 403 no permission ───
+Deno.test({
+  name: "update_role: returns 403 when user lacks MEMBER_MANAGE permission",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      permRoute(false),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update_role",
+            partner_id: TEST_PARTNER_ID,
+            user_id: TEST_TARGET_USER_ID,
+            role: "manager",
+          }),
+        );
+        assertEquals(res.status, 403);
+      });
+    });
+  },
+});
+
+// ─── update_role: 500 permission DB error ───
+Deno.test({
+  name: "update_role: returns 500 when permission query fails",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      permErrorRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update_role",
+            partner_id: TEST_PARTNER_ID,
+            user_id: TEST_TARGET_USER_ID,
+            role: "manager",
+          }),
+        );
+        assertEquals(res.status, 500);
+        const body = await readJson(res);
+        assertEquals(body.error, "Failed to verify partner permissions");
+      });
+    });
+  },
+});
+
+// ─── update_role: 500 update error ───
+Deno.test({
+  name: "update_role: returns 500 when update fails",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      permRoute(),
+      updateErrorRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update_role",
+            partner_id: TEST_PARTNER_ID,
+            user_id: TEST_TARGET_USER_ID,
+            role: "manager",
+          }),
+        );
+        assertEquals(res.status, 500);
+      });
+    });
+  },
+});
+
+// ─── update_permissions: success ───
+Deno.test({
+  name: "update_permissions: updates permissions successfully",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      permRoute(),
+      updateRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update_permissions",
+            partner_id: TEST_PARTNER_ID,
+            user_id: TEST_TARGET_USER_ID,
+            permissions: ["PARTY_MANAGE", "COMMENT_MANAGE"],
+          }),
+        );
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+      });
+    });
+  },
+});
+
+// ─── update_permissions: verify payload sent to DB ───
+Deno.test({
+  name: "update_permissions: sends correct payload to DB",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    let updateBody: string | null = null;
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      permRoute(),
+      {
+        matcher: (req) =>
+          req.url.includes("/rest/v1/partner_member_permissions") && req.method === "PATCH",
+        handler: async (req) => {
+          updateBody = await req.clone().text();
+          return new Response(null, { status: 200 });
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update_permissions",
+            partner_id: TEST_PARTNER_ID,
+            user_id: TEST_TARGET_USER_ID,
+            permissions: ["PARTY_MANAGE", "COMMENT_MANAGE"],
+          }),
+        );
+        assertEquals(res.status, 200);
+        const parsed = JSON.parse(updateBody!);
+        assertEquals(parsed.permissions, ["PARTY_MANAGE", "COMMENT_MANAGE"]);
+        assertEquals(Object.keys(parsed).length, 1);
+      });
+    });
+  },
+});
+
+// ─── update_permissions: missing partner_id → 400 ───
+Deno.test({
+  name: "update_permissions: returns 400 for missing partner_id",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update_permissions",
+            user_id: TEST_TARGET_USER_ID,
+            permissions: ["PARTY_MANAGE"],
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing partner_id");
+      });
+    });
+  },
+});
+
+// ─── update_permissions: missing user_id → 400 ───
+Deno.test({
+  name: "update_permissions: returns 400 for missing user_id",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update_permissions",
+            partner_id: TEST_PARTNER_ID,
+            permissions: ["PARTY_MANAGE"],
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing user_id");
+      });
+    });
+  },
+});
+
+// ─── update_permissions: missing permissions → 400 ───
+Deno.test({
+  name: "update_permissions: returns 400 for missing permissions",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update_permissions",
+            partner_id: TEST_PARTNER_ID,
+            user_id: TEST_TARGET_USER_ID,
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Missing permissions");
+      });
+    });
+  },
+});
+
+// ─── update_permissions: invalid permission → 400 ───
+Deno.test({
+  name: "update_permissions: returns 400 for invalid permission",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([authRoute()]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update_permissions",
+            partner_id: TEST_PARTNER_ID,
+            user_id: TEST_TARGET_USER_ID,
+            permissions: ["PARTY_MANAGE", "HACK_SYSTEM"],
+          }),
+        );
+        assertEquals(res.status, 400);
+        const body = await readJson(res);
+        assertEquals(body.error, "Invalid permission: HACK_SYSTEM");
+      });
+    });
+  },
+});
+
+// ─── update_permissions: 403 no permission ───
+Deno.test({
+  name: "update_permissions: returns 403 when user lacks MEMBER_MANAGE permission",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      permRoute(false),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update_permissions",
+            partner_id: TEST_PARTNER_ID,
+            user_id: TEST_TARGET_USER_ID,
+            permissions: ["PARTY_MANAGE"],
+          }),
+        );
+        assertEquals(res.status, 403);
+      });
+    });
+  },
+});
+
+// ─── update_permissions: 500 update error ───
+Deno.test({
+  name: "update_permissions: returns 500 when update fails",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      permRoute(),
+      updateErrorRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const res = await handler(
+          authenticatedJsonRequest("http://localhost", {
+            action: "update_permissions",
+            partner_id: TEST_PARTNER_ID,
+            user_id: TEST_TARGET_USER_ID,
+            permissions: ["PARTY_MANAGE"],
+          }),
+        );
+        assertEquals(res.status, 500);
+      });
+    });
+  },
+});


### PR DESCRIPTION
## Summary

Closes #313

- `partner-manage-member` Edge Function 구현 (update_role, update_permissions 액션)
- MEMBER_MANAGE 권한 서버 검증, role/permissions 화이트리스트, 자기 자신 role 변경 방지
- Flutter 클라이언트 직접 DB 호출 → EF 호출로 전환 (partner_member_repository.dart)
- Deno 테스트 22개 + Flutter 테스트 9개 통과

## Test plan

- [x] Deno EF 테스트 22개 통과 (CORS, 401, 400, 403, 500, 200 시나리오)
- [x] Flutter 단위 테스트 9개 통과 (EF 호출 검증, 에러 핸들링)
- [ ] CI `ci-result` 통과 확인
- [ ] RLS write policy drop은 후속 PR에서 처리

🤖 Generated with [Claude Code](https://claude.com/claude-code)