### PR TITLE
fix: resolve code quality audit high-severity findings

### DIFF
--- a/apps/app_partner/lib/main.dart
+++ b/apps/app_partner/lib/main.dart
@@ -174,7 +174,10 @@ class _AppView extends ConsumerWidget {
           value: startupState,
           data: (_) => BugReporterWrapper(
             navigatorKey: rootNavigatorKey,
-            child: MinglitGlobalLoadingOverlay(child: child!),
+            // Fix #382: child 강제 언래핑 제거 — nullable child에 fallback 추가
+            child: MinglitGlobalLoadingOverlay(
+              child: child ?? const SizedBox.shrink(),
+            ),
           ),
           // Hidden behind native splash — show nothing.
           loading: () => const SizedBox.shrink(),

--- a/apps/app_partner/lib/src/features/checkin/qr_scanner_screen.dart
+++ b/apps/app_partner/lib/src/features/checkin/qr_scanner_screen.dart
@@ -57,11 +57,13 @@ class _QRScannerScreenState extends ConsumerState<QRScannerScreen> {
             onDetect: (capture) {
               final barcodes = capture.barcodes;
               for (final barcode in barcodes) {
-                if (barcode.rawValue != null) {
+                // Fix #382: 강제 언래핑 제거 — local variable로 null 안전성 확보
+                final rawValue = barcode.rawValue;
+                if (rawValue != null) {
                   unawaited(
                     ref
                         .read(checkinControllerProvider.notifier)
-                        .processQR(barcode.rawValue!),
+                        .processQR(rawValue),
                   );
                 }
               }

--- a/apps/app_partner/lib/src/features/onboarding/partner_apply_draft.dart
+++ b/apps/app_partner/lib/src/features/onboarding/partner_apply_draft.dart
@@ -70,8 +70,10 @@ mixin _PartnerApplyDraft on _$PartnerApplyController {
   Future<void> uploadProfileImage(XFile file) async {
     try {
       final repo = ref.read(partnerRepositoryProvider);
-      if (state.profileImagePath != null) {
-        await repo.deleteUploadedFile(state.profileImagePath!);
+      // Fix #382: 강제 언래핑 제거 — local variable로 null 안전성 확보
+      final oldPath = state.profileImagePath;
+      if (oldPath != null) {
+        await repo.deleteUploadedFile(oldPath);
       }
       final path = await repo.uploadProfileImage(file);
       state = state.copyWith(profileImagePath: path, profileImageFile: file);
@@ -84,8 +86,10 @@ mixin _PartnerApplyDraft on _$PartnerApplyController {
   Future<void> uploadBizRegistration(XFile file) async {
     try {
       final repo = ref.read(partnerRepositoryProvider);
-      if (state.bizRegistrationPath != null) {
-        await repo.deleteUploadedFile(state.bizRegistrationPath!);
+      // Fix #382: 강제 언래핑 제거 — local variable로 null 안전성 확보
+      final oldBizPath = state.bizRegistrationPath;
+      if (oldBizPath != null) {
+        await repo.deleteUploadedFile(oldBizPath);
       }
       final path = await repo.uploadBizRegistration(file);
       state = state.copyWith(
@@ -101,8 +105,10 @@ mixin _PartnerApplyDraft on _$PartnerApplyController {
   Future<void> uploadBankbook(XFile file) async {
     try {
       final repo = ref.read(partnerRepositoryProvider);
-      if (state.bankbookPath != null) {
-        await repo.deleteUploadedFile(state.bankbookPath!);
+      // Fix #382: 강제 언래핑 제거 — local variable로 null 안전성 확보
+      final oldBankbookPath = state.bankbookPath;
+      if (oldBankbookPath != null) {
+        await repo.deleteUploadedFile(oldBankbookPath);
       }
       final path = await repo.uploadBankbook(file);
       state = state.copyWith(bankbookPath: path, bankbookFile: file);

--- a/apps/app_partner/lib/src/features/verification/review/review_verification_screen.dart
+++ b/apps/app_partner/lib/src/features/verification/review/review_verification_screen.dart
@@ -339,10 +339,11 @@ class _CommentsView extends ConsumerWidget {
             child: FutureBuilder<List<Map<String, dynamic>>>(
               future: repository.getVerificationComments(submissionId),
               builder: (context, snapshot) {
-                if (!snapshot.hasData) {
+                // Fix #382: snapshot.data null 안전성 확보 — hasData가 true여도 data가 null일 수 있음
+                final comments = snapshot.data;
+                if (comments == null) {
                   return const MinglitCircularProgressIndicator();
                 }
-                final comments = snapshot.data!;
                 return ListView.builder(
                   itemCount: comments.length,
                   itemBuilder: (context, i) {

--- a/apps/app_user/lib/main.dart
+++ b/apps/app_user/lib/main.dart
@@ -163,7 +163,10 @@ class _AppView extends ConsumerWidget {
           value: startupState,
           data: (_) => BugReporterWrapper(
             navigatorKey: rootNavigatorKey,
-            child: MinglitGlobalLoadingOverlay(child: child!),
+            // Fix #382: child 강제 언래핑 제거 — nullable child에 fallback 추가
+            child: MinglitGlobalLoadingOverlay(
+              child: child ?? const SizedBox.shrink(),
+            ),
           ),
           // Hidden behind native splash — show nothing.
           loading: () => const SizedBox.shrink(),

--- a/apps/app_user/lib/src/features/ticket/ui/widgets/ticket_qr_viewer.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/widgets/ticket_qr_viewer.dart
@@ -52,10 +52,12 @@ class _TicketQRViewerState extends State<TicketQRViewer>
   }
 
   Future<void> _restoreBrightness() async {
-    if (_originalBrightness != null) {
+    // Fix #382: 강제 언래핑 제거 — local variable로 null 안전성 확보
+    final brightness = _originalBrightness;
+    if (brightness != null) {
       try {
         await ScreenBrightness().setApplicationScreenBrightness(
-          _originalBrightness!,
+          brightness,
         );
       } on Object catch (e) {
         Log.e('Failed to restore screen brightness', e);

--- a/shared/packages/minglit_kit/lib/src/features/iamport/logic/iamport_controller.dart
+++ b/shared/packages/minglit_kit/lib/src/features/iamport/logic/iamport_controller.dart
@@ -38,11 +38,13 @@ class IamportController extends _$IamportController {
     try {
       final model = IamportResultModel.fromMap(result);
 
-      if (model.success && model.impUid != null) {
+      // Fix #382: 강제 언래핑 제거 — local variable로 null 안전성 확보
+      final impUid = model.impUid;
+      if (model.success && impUid != null) {
         // 1. Server-side Verification
         await ref
             .read(iamportRepositoryProvider)
-            .verifyCertification(model.impUid!);
+            .verifyCertification(impUid);
 
         // 2. If successful, update state
         state = AsyncData(model);

--- a/shared/packages/minglit_kit/lib/src/features/iamport/logic/iamport_controller.dart
+++ b/shared/packages/minglit_kit/lib/src/features/iamport/logic/iamport_controller.dart
@@ -42,9 +42,7 @@ class IamportController extends _$IamportController {
       final impUid = model.impUid;
       if (model.success && impUid != null) {
         // 1. Server-side Verification
-        await ref
-            .read(iamportRepositoryProvider)
-            .verifyCertification(impUid);
+        await ref.read(iamportRepositoryProvider).verifyCertification(impUid);
 
         // 2. If successful, update state
         state = AsyncData(model);

--- a/shared/packages/minglit_kit/lib/src/logic/providers/statsig_provider.dart
+++ b/shared/packages/minglit_kit/lib/src/logic/providers/statsig_provider.dart
@@ -89,8 +89,8 @@ class StatsigAnalytics {
     if (!_initialized) return;
     try {
       await Statsig.updateUser(StatsigUser(userId: userId));
-      // Fix #382: 에러 삼킴 방지 — debug 로그 추가
     } on Object catch (e) {
+      // Fix #382: 에러 삼킴 방지 — debug 로그 추가
       Log.d('Statsig updateUser failed: $e');
     }
   }
@@ -104,8 +104,8 @@ class StatsigAnalytics {
     if (!_initialized) return;
     try {
       Statsig.logEvent(eventName, doubleValue: value, metadata: metadata);
-      // Fix #382: 에러 삼킴 방지 — debug 로그 추가
     } on Object catch (e) {
+      // Fix #382: 에러 삼킴 방지 — debug 로그 추가
       Log.d('Statsig logEvent failed: $e');
     }
   }
@@ -115,7 +115,9 @@ class StatsigAnalytics {
     if (!_initialized) return false;
     try {
       return Statsig.checkGate(gateName);
-    } on Object catch (_) {
+    } on Object catch (e) {
+      // Fix #382: 에러 삼킴 방지 — debug 로그 추가
+      Log.d('Statsig checkGate failed: $e');
       return false;
     }
   }
@@ -126,8 +128,8 @@ class StatsigAnalytics {
     try {
       await Statsig.shutdown();
       _initialized = false;
-      // Fix #382: 에러 삼킴 방지 — debug 로그 추가
     } on Object catch (e) {
+      // Fix #382: 에러 삼킴 방지 — debug 로그 추가
       Log.d('Statsig shutdown failed: $e');
     }
   }

--- a/shared/packages/minglit_kit/lib/src/logic/providers/statsig_provider.dart
+++ b/shared/packages/minglit_kit/lib/src/logic/providers/statsig_provider.dart
@@ -4,6 +4,7 @@
 /// No-ops gracefully when STATSIG_CLIENT_KEY is empty or 'FILL_THIS'.
 library;
 
+import 'package:minglit_kit/src/utils/log.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:statsig/statsig.dart';
 import 'package:uuid/uuid.dart';
@@ -54,8 +55,9 @@ class StatsigAnalytics {
     }
     try {
       await _initializeInternal(clientKey, userId: userId, tier: tier);
-    } on Object catch (_) {
-      // Graceful degradation — never crash on analytics
+    } on Object catch (e) {
+      // Fix #382: Graceful degradation — never crash on analytics, but log for debuggability
+      Log.d('Statsig initialize failed: $e');
     }
   }
 
@@ -87,7 +89,10 @@ class StatsigAnalytics {
     if (!_initialized) return;
     try {
       await Statsig.updateUser(StatsigUser(userId: userId));
-    } on Object catch (_) {}
+      // Fix #382: 에러 삼킴 방지 — debug 로그 추가
+    } on Object catch (e) {
+      Log.d('Statsig updateUser failed: $e');
+    }
   }
 
   /// Log an analytics event. Use [MingLitEvent] constants.
@@ -99,7 +104,10 @@ class StatsigAnalytics {
     if (!_initialized) return;
     try {
       Statsig.logEvent(eventName, doubleValue: value, metadata: metadata);
-    } on Object catch (_) {}
+      // Fix #382: 에러 삼킴 방지 — debug 로그 추가
+    } on Object catch (e) {
+      Log.d('Statsig logEvent failed: $e');
+    }
   }
 
   /// Evaluate a feature gate. Returns false if not initialized.
@@ -118,6 +126,9 @@ class StatsigAnalytics {
     try {
       await Statsig.shutdown();
       _initialized = false;
-    } on Object catch (_) {}
+      // Fix #382: 에러 삼킴 방지 — debug 로그 추가
+    } on Object catch (e) {
+      Log.d('Statsig shutdown failed: $e');
+    }
   }
 }

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_file_picker.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_file_picker.dart
@@ -144,15 +144,17 @@ class _MinglitFilePickerState extends ConsumerState<MinglitFilePicker> {
 
       for (final file in files) {
         // Fix #270: 플랫폼별 bytes/path null 가능 — null이면 건너뛰기
-        if (kIsWeb && file.bytes == null) continue;
-        if (!kIsWeb && file.path == null) continue;
-        // Convert PlatformFile to XFile for compatibility
-        // Fix #382: 강제 언래핑 제거 — local variable로 null 안전성 확보
-        final bytes = file.bytes;
-        final path = file.path;
-        final xFile = kIsWeb
-            ? XFile.fromData(bytes!, name: file.name)
-            : XFile(path!);
+        // Fix #382: 강제 언래핑 제거 — local variable + type promotion으로 null 안전성 확보
+        final XFile xFile;
+        if (kIsWeb) {
+          final bytes = file.bytes;
+          if (bytes == null) continue;
+          xFile = XFile.fromData(bytes, name: file.name);
+        } else {
+          final path = file.path;
+          if (path == null) continue;
+          xFile = XFile(path);
+        }
         final url = await repo.uploadFile(
           file: xFile,
           bucket: bucket,

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_file_picker.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_file_picker.dart
@@ -129,12 +129,14 @@ class _MinglitFilePickerState extends ConsumerState<MinglitFilePicker> {
     });
     widget.onFilesSelected(_selectedFiles);
 
-    if (widget.autoUpload && widget.uploadBucket != null) {
-      await _uploadFiles(newFiles);
+    // Fix #382: uploadBucket을 local variable로 캡처하여 _uploadFiles 내 강제 언래핑 방지
+    final bucket = widget.uploadBucket;
+    if (widget.autoUpload && bucket != null) {
+      await _uploadFiles(newFiles, bucket);
     }
   }
 
-  Future<void> _uploadFiles(List<PlatformFile> files) async {
+  Future<void> _uploadFiles(List<PlatformFile> files, String bucket) async {
     setState(() => _isUploading = true);
     try {
       final repo = ref.read(storageRepositoryProvider);
@@ -145,12 +147,15 @@ class _MinglitFilePickerState extends ConsumerState<MinglitFilePicker> {
         if (kIsWeb && file.bytes == null) continue;
         if (!kIsWeb && file.path == null) continue;
         // Convert PlatformFile to XFile for compatibility
+        // Fix #382: 강제 언래핑 제거 — local variable로 null 안전성 확보
+        final bytes = file.bytes;
+        final path = file.path;
         final xFile = kIsWeb
-            ? XFile.fromData(file.bytes!, name: file.name)
-            : XFile(file.path!);
+            ? XFile.fromData(bytes!, name: file.name)
+            : XFile(path!);
         final url = await repo.uploadFile(
           file: xFile,
-          bucket: widget.uploadBucket!,
+          bucket: bucket,
           pathPrefix: widget.uploadPathPrefix,
         );
         newUrls.add(url);

--- a/shared/packages/minglit_kit/lib/src/utils/riverpod_ext.dart
+++ b/shared/packages/minglit_kit/lib/src/utils/riverpod_ext.dart
@@ -26,8 +26,10 @@ extension AsyncValueMinglitX<T> on AsyncValue<T> {
   /// });
   /// ```
   void showMinglitError(BuildContext context) {
-    if (!isLoading && hasError) {
-      handleMinglitError(context, error!, stackTrace);
+    // Fix #382: 강제 언래핑 제거 — local variable로 null 안전성 확보
+    final err = error;
+    if (!isLoading && hasError && err != null) {
+      handleMinglitError(context, err, stackTrace);
     }
   }
 }


### PR DESCRIPTION
## Summary

- **강제 언래핑(!) 제거**: 9개 파일에서 nullable 값을 local variable로 캡처한 후 null-check하도록 수정하여 잠재적 런타임 크래시 방지
- **빈 catch 블록에 로깅 추가**: `StatsigAnalytics`의 4개 빈 catch 블록에 `Log.d()` 추가하여 에러 삼킴 방지 및 디버깅 가능성 확보
- **FutureBuilder snapshot.data null 안전성**: `review_verification_screen.dart`에서 `snapshot.data!` 대신 `snapshot.data`로 변경 후 null 체크
- **MaterialApp builder child fallback**: `app_user/main.dart`, `app_partner/main.dart`에서 `child!` → `child ?? const SizedBox.shrink()`

Closes #382

## Test plan

- [ ] `flutter analyze` 통과 확인 (CI)
- [ ] app_user, app_partner 빌드 성공 확인 (CI)
- [ ] 기존 테스트 통과 확인 (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)