### PR TITLE
fix(cuj): enable core library desugaring for CUJ test apps

### DIFF
--- a/tests/client_cuj_integration/android/app/build.gradle.kts
+++ b/tests/client_cuj_integration/android/app/build.gradle.kts
@@ -11,6 +11,8 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
+        // Fix #401: flutter_local_notifications requires core library desugaring
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -41,4 +43,9 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    // Fix #401: required by flutter_local_notifications for Java 8+ API desugaring
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }

--- a/tests/partner_cuj_integration/android/app/build.gradle.kts
+++ b/tests/partner_cuj_integration/android/app/build.gradle.kts
@@ -11,6 +11,8 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
+        // Fix #401: flutter_local_notifications requires core library desugaring
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -41,4 +43,9 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    // Fix #401: required by flutter_local_notifications for Java 8+ API desugaring
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }


### PR DESCRIPTION
## Summary
- Enable `isCoreLibraryDesugaringEnabled` and add `coreLibraryDesugaring` dependency in both `client_cuj_integration` and `partner_cuj_integration` test apps
- Matches existing config in `app_user` and `app_partner` main apps
- Root cause: `flutter_local_notifications` requires Java 8+ API desugaring which was missing in CUJ test apps

Closes #401

## Test plan
- [ ] CI `client-cuj-test` passes (Gradle assembleDebug succeeds)
- [ ] CI `partner-cuj-test` passes (Gradle assembleDebug succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)