### PR TITLE
fix: lint warnings 수정 — deprecated calls, type args, unawaited futures

### DIFF
--- a/apps/app_user/lib/src/features/event/matching/matching_vote_controller.dart
+++ b/apps/app_user/lib/src/features/event/matching/matching_vote_controller.dart
@@ -20,9 +20,10 @@ class MatchingVoteController extends _$MatchingVoteController {
       await repo.castVote(eventId: eventId, candidateId: candidateId);
 
       // Fix #306: 투표 후 투표 상태 + 매칭 결과 갱신
-      ref.invalidate(myMatchesProvider(eventId));
-      ref.invalidate(myVotedCandidateIdsProvider(eventId));
-      ref.invalidate(myVoteCountProvider(eventId));
+      ref
+        ..invalidate(myMatchesProvider(eventId))
+        ..invalidate(myVotedCandidateIdsProvider(eventId))
+        ..invalidate(myVoteCountProvider(eventId));
 
       StatsigAnalytics.logEvent(
         MingLitEvent.matchingResult,

--- a/apps/app_user/test/integration/flow_admission_status_test.dart
+++ b/apps/app_user/test/integration/flow_admission_status_test.dart
@@ -33,13 +33,6 @@ void main() {
     when(
       () => mockUserRepo.getApprovedVerificationIds(any()),
     ).thenAnswer((_) async => <String>[]);
-    // Stub deleteApplication for rejected → re-apply flow (deprecated, kept for compatibility)
-    when(
-      () => mockEventRepo.deleteApplication(
-        eventId: any(named: 'eventId'),
-        userId: any(named: 'userId'),
-      ),
-    ).thenAnswer((_) async {});
     // Fix #299: cancelOrder EF stub for rejected → re-apply flow
     when(
       () => mockEventRepo.cancelOrder(

--- a/shared/packages/minglit_kit/lib/src/data/repositories/event_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/event_repository.dart
@@ -26,6 +26,7 @@ class EventRepository extends _SupabaseEventContextBase
 
 /// Result from user-create-order Edge Function.
 class CreateOrderResult {
+  /// Creates a [CreateOrderResult] with the given order details.
   const CreateOrderResult({
     required this.applicationId,
     required this.amount,
@@ -33,9 +34,16 @@ class CreateOrderResult {
     required this.ticketName,
   });
 
+  /// The created application ID (used as merchant_uid for payment).
   final String applicationId;
+
+  /// The server-determined amount for the order in KRW.
   final int amount;
+
+  /// Whether payment processing is required (false for free tickets).
   final bool requiresPayment;
+
+  /// The name of the selected ticket.
   final String ticketName;
 }
 

--- a/shared/packages/minglit_kit/test/src/data/repositories/event_repository_commands_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/event_repository_commands_test.dart
@@ -37,33 +37,36 @@ void main() {
   });
 
   group('EventRepository Commands', () {
-    group('deleteApplication', () {
+    group('cancelOrder', () {
       test('completes without error', () async {
-        unawaited(mockTable(mockClient, 'event_applications'));
+        when(
+          () => mockFunctions.invoke(
+            'user-cancel-order',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true, 'type': 'cancelled'},
+          ),
+        );
 
         await expectLater(
-          repository.deleteApplication(
-            eventId: 'event_1',
-            userId: 'user_1',
-          ),
+          repository.cancelOrder(eventId: 'event_1'),
           completes,
         );
       });
 
       test('throws on error', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'event_applications',
-            shouldThrow: Exception('delete error'),
+        when(
+          () => mockFunctions.invoke(
+            'user-cancel-order',
+            body: any(named: 'body'),
           ),
-        );
+        ).thenThrow(Exception('cancel error'));
 
         await expectLater(
-          repository.deleteApplication(
-            eventId: 'event_1',
-            userId: 'user_1',
-          ),
+          repository.cancelOrder(eventId: 'event_1'),
           throwsA(anything),
         );
       });

--- a/shared/packages/minglit_kit/test/src/data/repositories/event_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/event_repository_test.dart
@@ -166,33 +166,36 @@ void main() {
       });
     });
 
-    group('deleteApplication', () {
+    group('cancelOrder', () {
       test('completes without error', () async {
-        unawaited(mockTable(mockClient, 'event_applications'));
+        when(
+          () => mockFunctions.invoke(
+            'user-cancel-order',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true, 'type': 'cancelled'},
+          ),
+        );
 
         await expectLater(
-          repository.deleteApplication(
-            eventId: 'event_1',
-            userId: 'user_1',
-          ),
+          repository.cancelOrder(eventId: 'event_1'),
           completes,
         );
       });
 
       test('throws on error', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'event_applications',
-            shouldThrow: Exception('delete error'),
+        when(
+          () => mockFunctions.invoke(
+            'user-cancel-order',
+            body: any(named: 'body'),
           ),
-        );
+        ).thenThrow(Exception('cancel error'));
 
         await expectLater(
-          repository.deleteApplication(
-            eventId: 'event_1',
-            userId: 'user_1',
-          ),
+          repository.cancelOrder(eventId: 'event_1'),
           throwsA(anything),
         );
       });

--- a/shared/packages/minglit_kit/test/src/data/repositories/notification_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/notification_repository_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async' show unawaited;
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/shared/packages/minglit_kit/test/src/data/repositories/notification_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/notification_repository_test.dart
@@ -125,10 +125,12 @@ void main() {
           'created_at': now.toIso8601String(),
         };
 
-        mockTable(
-          mockClient,
-          'user_notifications',
-          selectData: [notificationJson],
+        unawaited(
+          mockTable(
+            mockClient,
+            'user_notifications',
+            selectData: [notificationJson],
+          ),
         );
 
         final result = await repository.getNotifications();
@@ -139,7 +141,9 @@ void main() {
       });
 
       test('supports pagination', () async {
-        mockTable(mockClient, 'user_notifications', selectData: []);
+        unawaited(
+          mockTable(mockClient, 'user_notifications', selectData: []),
+        );
 
         final result = await repository.getNotifications(limit: 10, offset: 20);
         expect(result, isEmpty);
@@ -148,7 +152,7 @@ void main() {
 
     group('markAsRead', () {
       test('completes without error', () async {
-        mockTable(mockClient, 'user_notifications');
+        unawaited(mockTable(mockClient, 'user_notifications'));
 
         await expectLater(
           repository.markAsRead('notif_1'),
@@ -159,7 +163,7 @@ void main() {
 
     group('markAllAsRead', () {
       test('completes without error', () async {
-        mockTable(mockClient, 'user_notifications');
+        unawaited(mockTable(mockClient, 'user_notifications'));
 
         await expectLater(
           repository.markAllAsRead('user_1'),
@@ -170,7 +174,7 @@ void main() {
 
     group('deleteNotification', () {
       test('completes without error', () async {
-        mockTable(mockClient, 'user_notifications');
+        unawaited(mockTable(mockClient, 'user_notifications'));
 
         await expectLater(
           repository.deleteNotification('notif_1'),
@@ -188,10 +192,12 @@ void main() {
           'updated_at': now.toIso8601String(),
         };
 
-        mockTable(
-          mockClient,
-          'user_settings',
-          maybeSingleData: settingsJson,
+        unawaited(
+          mockTable(
+            mockClient,
+            'user_settings',
+            maybeSingleData: settingsJson,
+          ),
         );
 
         final result = await repository.getSettings('user_1');
@@ -200,7 +206,7 @@ void main() {
       });
 
       test('returns null when not found', () async {
-        mockTable(mockClient, 'user_settings');
+        unawaited(mockTable(mockClient, 'user_settings'));
 
         final result = await repository.getSettings('user_unknown');
         expect(result, isNull);

--- a/tests/client_cuj_integration/integration_test/cuj/cuj_12_recommendation_test.dart
+++ b/tests/client_cuj_integration/integration_test/cuj/cuj_12_recommendation_test.dart
@@ -30,28 +30,28 @@ void main() {
         (tester) async {
       final client = Supabase.instance.client;
 
-      final result = await client.rpc(
+      final result = await client.rpc<List<dynamic>>(
         'get_personalized_recommendations',
         params: {
           'p_user_id': testUserId,
           'p_limit': 10,
         },
-      ) as List;
+      );
 
       // 임베딩이 없을 경우 빈 리스트도 유효한 결과다
-      expect(result, isA<List>(), reason: 'RPC 결과는 리스트여야 한다');
+      expect(result, isA<List<dynamic>>(), reason: 'RPC 결과는 리스트여야 한다');
     });
 
     testWidgets('추천 결과 데이터 구조가 올바르다', (tester) async {
       final client = Supabase.instance.client;
 
-      final result = await client.rpc(
+      final result = await client.rpc<List<dynamic>>(
         'get_personalized_recommendations',
         params: {
           'p_user_id': testUserId,
           'p_limit': 10,
         },
-      ) as List;
+      );
 
       if (result.isEmpty) {
         // 임베딩 데이터가 없으면 빈 결과는 정상이므로 스킵

--- a/tests/client_cuj_integration/integration_test/cuj/cuj_13_geo_search_test.dart
+++ b/tests/client_cuj_integration/integration_test/cuj/cuj_13_geo_search_test.dart
@@ -29,7 +29,7 @@ void main() {
       final client = Supabase.instance.client;
 
       // Seoul coordinates
-      final result = await client.rpc(
+      final result = await client.rpc<List<dynamic>>(
         'get_events_within_radius',
         params: {
           'p_lat': 37.5665,
@@ -40,13 +40,13 @@ void main() {
       );
 
       expect(result, isNotNull);
-      expect(result, isA<List>());
+      expect(result, isA<List<dynamic>>());
     });
 
     testWidgets('검색 결과에 distance 필드가 포함된다', (tester) async {
       final client = Supabase.instance.client;
 
-      final result = await client.rpc(
+      final result = await client.rpc<List<dynamic>>(
         'get_events_within_radius',
         params: {
           'p_lat': 37.5665,
@@ -54,21 +54,27 @@ void main() {
           'p_radius_meters': 50000.0,
           'p_limit': 20,
         },
-      ) as List;
+      );
 
       if (result.isNotEmpty) {
         for (final item in result) {
           final row = item as Map<String, dynamic>;
-          expect(row.containsKey('id'), isTrue,
-              reason: 'Each result must have an id field');
+          expect(
+            row.containsKey('id'),
+            isTrue,
+            reason: 'Each result must have an id field',
+          );
           // Verify at least one distance-related field is present
           final hasDistanceField =
               row.containsKey('distance') ||
               row.containsKey('distance_meters') ||
               row.containsKey('dist_meters');
-          expect(hasDistanceField, isTrue,
-              reason:
-                  'Each result must have a distance-related field (distance, distance_meters, or dist_meters)');
+          expect(
+            hasDistanceField,
+            isTrue,
+            reason:
+                'Each result must have a distance-related field (distance, distance_meters, or dist_meters)',
+          );
         }
       }
     });
@@ -77,7 +83,7 @@ void main() {
       final client = Supabase.instance.client;
 
       // Seoul search — may return results
-      final seoulResult = await client.rpc(
+      final seoulResult = await client.rpc<List<dynamic>>(
         'get_events_within_radius',
         params: {
           'p_lat': 37.5665,
@@ -85,10 +91,10 @@ void main() {
           'p_radius_meters': 50000.0,
           'p_limit': 20,
         },
-      ) as List;
+      );
 
       // Remote coordinates (Gulf of Guinea, far from Seoul)
-      final remoteResult = await client.rpc(
+      final remoteResult = await client.rpc<List<dynamic>>(
         'get_events_within_radius',
         params: {
           'p_lat': 0.0,
@@ -96,11 +102,14 @@ void main() {
           'p_radius_meters': 50000.0,
           'p_limit': 20,
         },
-      ) as List;
+      );
 
-      expect(remoteResult.length, lessThanOrEqualTo(seoulResult.length),
-          reason:
-              'Remote coordinates should return fewer or equal results than Seoul');
+      expect(
+        remoteResult.length,
+        lessThanOrEqualTo(seoulResult.length),
+        reason:
+            'Remote coordinates should return fewer or equal results than Seoul',
+      );
     });
   });
 }

--- a/tests/client_cuj_integration/integration_test/cuj/cuj_14_profile_update_test.dart
+++ b/tests/client_cuj_integration/integration_test/cuj/cuj_14_profile_update_test.dart
@@ -91,8 +91,11 @@ void main() {
           .eq('id', testUserId)
           .single();
 
-      expect(profile['bio'], equals(originalBio),
-          reason: '프로필 bio가 원래 값으로 복원되어야 한다');
+      expect(
+        profile['bio'],
+        equals(originalBio),
+        reason: '프로필 bio가 원래 값으로 복원되어야 한다',
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
- deprecated `deleteApplication` → `cancelOrder` 전환 (테스트 3개 파일)
- CUJ 테스트 `rpc<dynamic>()` 타입 인자 추가
- `unawaited()` 감싸기 (notification_repository_test, search_page)
- `CreateOrderResult` doc comments 추가
- cascade_invocations, lines_longer_than_80_chars, require_trailing_commas 수정

## Test plan
- [x] `flutter analyze --no-fatal-infos` — 대상 파일 경고 0건
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)