### PR TITLE
fix(android): set namespace for third-party plugins missing it (AGP 8+)

### DIFF
--- a/apps/app_partner/android/build.gradle.kts
+++ b/apps/app_partner/android/build.gradle.kts
@@ -16,6 +16,24 @@ subprojects {
     project.evaluationDependsOn(":app")
 }
 
+// Fix #406: AGP 8+ requires namespace for all Android library projects.
+// Third-party plugins (e.g. iamport_flutter) may not set it — read from AndroidManifest.xml.
+subprojects {
+    plugins.withId("com.android.library") {
+        val android = extensions.getByType(com.android.build.gradle.LibraryExtension::class.java)
+        if (android.namespace.isNullOrEmpty()) {
+            val manifestFile = file("src/main/AndroidManifest.xml")
+            if (manifestFile.exists()) {
+                val parsedManifest = groovy.xml.XmlParser().parse(manifestFile)
+                val packageName = parsedManifest.attribute("package")?.toString()
+                if (!packageName.isNullOrEmpty()) {
+                    android.namespace = packageName
+                }
+            }
+        }
+    }
+}
+
 tasks.register<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
 }

--- a/apps/app_user/android/build.gradle.kts
+++ b/apps/app_user/android/build.gradle.kts
@@ -16,6 +16,24 @@ subprojects {
     project.evaluationDependsOn(":app")
 }
 
+// Fix #406: AGP 8+ requires namespace for all Android library projects.
+// Third-party plugins (e.g. iamport_flutter) may not set it — read from AndroidManifest.xml.
+subprojects {
+    plugins.withId("com.android.library") {
+        val android = extensions.getByType(com.android.build.gradle.LibraryExtension::class.java)
+        if (android.namespace.isNullOrEmpty()) {
+            val manifestFile = file("src/main/AndroidManifest.xml")
+            if (manifestFile.exists()) {
+                val parsedManifest = groovy.xml.XmlParser().parse(manifestFile)
+                val packageName = parsedManifest.attribute("package")?.toString()
+                if (!packageName.isNullOrEmpty()) {
+                    android.namespace = packageName
+                }
+            }
+        }
+    }
+}
+
 tasks.register<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
 }


### PR DESCRIPTION
## Summary
- `iamport_flutter` 0.10.18의 Android `build.gradle`에 `namespace`가 누락되어 AGP 8+에서 partner 앱 deploy 빌드 실패
- `app_partner`와 `app_user` 모두의 프로젝트 레벨 `build.gradle.kts`에 `subprojects` 블록 추가
- namespace가 없는 서드파티 플러그인에 대해 `AndroidManifest.xml`의 `package` 속성을 자동으로 namespace에 설정

Closes #406

## Test plan
- [ ] `app_partner` Android release 빌드 성공 확인 (CI에서 검증)
- [ ] `app_user` Android 빌드에 영향 없음 확인
- [ ] 기존 namespace가 있는 플러그인에는 영향 없음 (조건문으로 보호)

🤖 Generated with [Claude Code](https://claude.com/claude-code)