### PR TITLE
fix(cuj): harden CUJ tests against incomplete dev seed data

### DIFF
--- a/tests/client_cuj_integration/integration_test/cuj/cuj_02_browse_test.dart
+++ b/tests/client_cuj_integration/integration_test/cuj/cuj_02_browse_test.dart
@@ -27,20 +27,20 @@ void main() {
     testWidgets('이벤트 피드를 조회할 수 있다', (tester) async {
       final client = Supabase.instance.client;
 
-      // Fix #410: title is nullable in events schema — filter for non-null titles
+      // Fix #410: events.title is usually null — assert party.title instead
       final events = await client
           .from('events')
-          .select('id, title, status')
+          .select('id, status, party:parties(title)')
           .eq('status', 'scheduled')
-          .not('title', 'is', null)
           .order('created_at', ascending: false)
           .limit(5) as List;
 
       expect(events, isNotEmpty, reason: 'Dev server should have events');
 
       final firstEvent = events.first as Map<String, dynamic>;
+      final party = firstEvent['party'] as Map<String, dynamic>?;
       expect(firstEvent['id'], isNotNull);
-      expect(firstEvent['title'], isNotNull);
+      expect(party?['title'], isNotNull);
       expect(firstEvent['status'], equals('scheduled'));
     });
 

--- a/tests/client_cuj_integration/integration_test/cuj/cuj_02_browse_test.dart
+++ b/tests/client_cuj_integration/integration_test/cuj/cuj_02_browse_test.dart
@@ -27,10 +27,12 @@ void main() {
     testWidgets('이벤트 피드를 조회할 수 있다', (tester) async {
       final client = Supabase.instance.client;
 
+      // Fix #410: title is nullable in events schema — filter for non-null titles
       final events = await client
           .from('events')
           .select('id, title, status')
           .eq('status', 'scheduled')
+          .not('title', 'is', null)
           .order('created_at', ascending: false)
           .limit(5) as List;
 

--- a/tests/client_cuj_integration/integration_test/utils/e2e_helpers.dart
+++ b/tests/client_cuj_integration/integration_test/utils/e2e_helpers.dart
@@ -23,11 +23,7 @@ Future<ProviderContainer> initializeE2E() async {
 }
 
 /// Finds a scheduled event with its ticket, partner, and owner info.
-///
-/// Fix #410: queries multiple events and picks the first one whose partner
-/// has an owner in partner_member_permissions (dev data may be incomplete).
-///
-/// Pattern from: `tests/backend_integration/src/utils/test_helpers.dart`
+// Fix #410: iterate candidates to find one with a valid partner owner
 Future<ScheduledEventContext> findScheduledEvent(
   SupabaseClient client,
 ) async {
@@ -35,6 +31,7 @@ Future<ScheduledEventContext> findScheduledEvent(
       .from('events')
       .select('*, tickets(*), party:parties(*, partner:partners(*))')
       .eq('status', 'scheduled')
+      .order('created_at', ascending: false)
       .limit(10) as List;
 
   if (events.isEmpty) {

--- a/tests/client_cuj_integration/integration_test/utils/e2e_helpers.dart
+++ b/tests/client_cuj_integration/integration_test/utils/e2e_helpers.dart
@@ -24,46 +24,56 @@ Future<ProviderContainer> initializeE2E() async {
 
 /// Finds a scheduled event with its ticket, partner, and owner info.
 ///
+/// Fix #410: queries multiple events and picks the first one whose partner
+/// has an owner in partner_member_permissions (dev data may be incomplete).
+///
 /// Pattern from: `tests/backend_integration/src/utils/test_helpers.dart`
 Future<ScheduledEventContext> findScheduledEvent(
   SupabaseClient client,
 ) async {
-  final eventRes = await client
+  final events = await client
       .from('events')
       .select('*, tickets(*), party:parties(*, partner:partners(*))')
       .eq('status', 'scheduled')
-      .limit(1)
-      .maybeSingle();
+      .limit(10) as List;
 
-  if (eventRes == null) {
+  if (events.isEmpty) {
     throw StateError('No scheduled events found in dev database.');
   }
 
-  final eventId = eventRes['id'] as String;
-  final tickets = eventRes['tickets'] as List;
-  if (tickets.isEmpty) {
-    throw StateError('Event $eventId has no tickets.');
+  for (final eventRes in events) {
+    final event = eventRes as Map<String, dynamic>;
+    final eventId = event['id'] as String;
+    final tickets = event['tickets'] as List;
+    if (tickets.isEmpty) continue;
+
+    final party = event['party'] as Map<String, dynamic>?;
+    if (party == null) continue;
+    final partner = party['partner'] as Map<String, dynamic>?;
+    if (partner == null) continue;
+    final partnerId = partner['id'] as String;
+
+    final ownerRes = await client
+        .from('partner_member_permissions')
+        .select('user_id')
+        .eq('partner_id', partnerId)
+        .eq('role', 'owner')
+        .maybeSingle();
+    if (ownerRes == null) continue;
+
+    final ticketId =
+        (tickets.first as Map<String, dynamic>)['id'] as String;
+    return ScheduledEventContext(
+      eventId: eventId,
+      ticketId: ticketId,
+      partnerId: partnerId,
+      ownerId: ownerRes['user_id'] as String,
+    );
   }
-  final ticketId = (tickets.first as Map<String, dynamic>)['id'] as String;
 
-  final party = eventRes['party'] as Map<String, dynamic>;
-  final partner = party['partner'] as Map<String, dynamic>;
-  final partnerId = partner['id'] as String;
-
-  // Find partner owner
-  final ownerRes = await client
-      .from('partner_member_permissions')
-      .select('user_id')
-      .eq('partner_id', partnerId)
-      .eq('role', 'owner')
-      .single();
-  final ownerId = ownerRes['user_id'] as String;
-
-  return ScheduledEventContext(
-    eventId: eventId,
-    ticketId: ticketId,
-    partnerId: partnerId,
-    ownerId: ownerId,
+  throw StateError(
+    'No scheduled event with tickets and a partner owner found '
+    'in dev database.',
   );
 }
 

--- a/tests/partner_cuj_integration/integration_test/utils/e2e_helpers.dart
+++ b/tests/partner_cuj_integration/integration_test/utils/e2e_helpers.dart
@@ -18,9 +18,7 @@ Future<ProviderContainer> initializeE2E() async {
 }
 
 /// Finds a scheduled event with ticket, partner, and owner info.
-///
-/// Fix #410: queries multiple events and picks the first one whose partner
-/// has an owner in partner_member_permissions (dev data may be incomplete).
+// Fix #410: iterate candidates to find one with a valid partner owner
 Future<ScheduledEventContext> findScheduledEvent(
   SupabaseClient client,
 ) async {
@@ -30,6 +28,7 @@ Future<ScheduledEventContext> findScheduledEvent(
         '*, tickets(*), party:parties(*, partner:partners(*))',
       )
       .eq('status', 'scheduled')
+      .order('created_at', ascending: false)
       .limit(10) as List;
 
   if (events.isEmpty) {

--- a/tests/partner_cuj_integration/integration_test/utils/e2e_helpers.dart
+++ b/tests/partner_cuj_integration/integration_test/utils/e2e_helpers.dart
@@ -18,50 +18,60 @@ Future<ProviderContainer> initializeE2E() async {
 }
 
 /// Finds a scheduled event with ticket, partner, and owner info.
+///
+/// Fix #410: queries multiple events and picks the first one whose partner
+/// has an owner in partner_member_permissions (dev data may be incomplete).
 Future<ScheduledEventContext> findScheduledEvent(
   SupabaseClient client,
 ) async {
-  final eventRes = await client
+  final events = await client
       .from('events')
       .select(
         '*, tickets(*), party:parties(*, partner:partners(*))',
       )
       .eq('status', 'scheduled')
-      .limit(1)
-      .maybeSingle();
+      .limit(10) as List;
 
-  if (eventRes == null) {
+  if (events.isEmpty) {
     throw StateError(
       'No scheduled events found in dev database.',
     );
   }
 
-  final eventId = eventRes['id'] as String;
-  final tickets = eventRes['tickets'] as List;
-  if (tickets.isEmpty) {
-    throw StateError('Event $eventId has no tickets.');
+  for (final eventRes in events) {
+    final event = eventRes as Map<String, dynamic>;
+    final eventId = event['id'] as String;
+    final tickets = event['tickets'] as List;
+    if (tickets.isEmpty) continue;
+
+    final party = event['party'] as Map<String, dynamic>?;
+    if (party == null) continue;
+    final partner = party['partner'] as Map<String, dynamic>?;
+    if (partner == null) continue;
+    final partnerId = partner['id'] as String;
+
+    final ownerRes = await client
+        .from('partner_member_permissions')
+        .select('user_id')
+        .eq('partner_id', partnerId)
+        .eq('role', 'owner')
+        .maybeSingle();
+    if (ownerRes == null) continue;
+
+    final ticketId =
+        (tickets.first as Map<String, dynamic>)['id'] as String;
+    return ScheduledEventContext(
+      eventId: eventId,
+      ticketId: ticketId,
+      partnerId: partnerId,
+      partyId: party['id'] as String,
+      ownerId: ownerRes['user_id'] as String,
+    );
   }
-  final ticketId =
-      (tickets.first as Map<String, dynamic>)['id'] as String;
 
-  final party = eventRes['party'] as Map<String, dynamic>;
-  final partner = party['partner'] as Map<String, dynamic>;
-  final partnerId = partner['id'] as String;
-
-  final ownerRes = await client
-      .from('partner_member_permissions')
-      .select('user_id')
-      .eq('partner_id', partnerId)
-      .eq('role', 'owner')
-      .single();
-  final ownerId = ownerRes['user_id'] as String;
-
-  return ScheduledEventContext(
-    eventId: eventId,
-    ticketId: ticketId,
-    partnerId: partnerId,
-    partyId: party['id'] as String,
-    ownerId: ownerId,
+  throw StateError(
+    'No scheduled event with tickets and a partner owner found '
+    'in dev database.',
   );
 }
 


### PR DESCRIPTION
## Summary
- **cuj_02_browse_test**: events.title is nullable in schema — add `.not('title', 'is', null)` filter to avoid asserting non-null on nullable column
- **findScheduledEvent** (both client & partner helpers): iterate up to 10 scheduled events instead of failing on the first event whose partner lacks an owner in `partner_member_permissions`. Uses `.maybeSingle()` + `continue` instead of `.single()` which threw PGRST116

## Root Cause
Dev database seed data degradation — some events have null titles, and some partners lack owner roles in `partner_member_permissions`. The tests were fragile, assuming the first scheduled event would have complete relational data.

## Test plan
- [ ] CI `ci-result` passes (CUJ tests should now find valid events)
- [ ] Verify cuj_02 browse test picks events with non-null titles
- [ ] Verify cuj_08 partner test finds an event with a valid partner owner

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)