### PR TITLE
fix(arch): resolve doc-code mismatches and repository pattern violations

### DIFF
--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -41,7 +41,7 @@ Minglit의 Supabase 기반 백엔드 인프라를 기술한다.
 
 ### 2.1 Table Inventory
 
-총 **50개 테이블(analytics 스키마 5개 포함)** + **4개 뷰** + **3개 PGMQ 큐 테이블**.
+총 **54개 테이블(analytics 스키마 5개 포함)** + **4개 뷰** + **4개 PGMQ 인프라 테이블**.
 
 #### Core (사용자/파트너)
 
@@ -228,6 +228,7 @@ Supabase Edge Functions는 Deno 런타임 기반이며, `supabase/functions/` �
 | `partner-manage-match` | Partner | 매칭 룰 관리 (set_rules, clear_rules) |
 | `partner-manage-party` | Partner | 파티/장소/템플릿 CRUD (RLS write → EF 전환) |
 | `partner-manage-member` | Partner | 파트너 멤버 관리 (초대, 권한 변경, 제거) |
+| `partner-manage-settlement` | Partner | 파트너 정산 계좌 관리 (등록/수정) |
 | `partner-manage-verification` | Partner | 인증 양식 정의 생성/수정 |
 | `partner-register` | Partner | 파트너 입점 신청 (임시저장, 제출, 수정) |
 | `partner-review-submission` | Partner | 인증 제출물 심사 (승인/거절 + 코멘트) |

--- a/docs/architecture/client.md
+++ b/docs/architecture/client.md
@@ -35,6 +35,39 @@ minglit_kit/lib/src/features/
 └── verification/   # 본인인증 (Identity Verification) — Iamport V2 기반 실명 인증 화면
 ```
 
+#### app_user Features
+
+```text
+apps/app_user/lib/src/features/
+├── auth/           # 로그인/인증 플로우
+├── event/          # 이벤트 상세, 신청, 입장
+├── home/           # 홈 피드, 마이페이지
+├── partner/        # 파트너 상세 페이지
+├── party/          # 파티 목록/상세
+├── payment/        # 결제 플로우, 결제 완료
+├── search/         # 이벤트/파티 검색
+├── settings/       # 앱 설정
+└── ticket/         # 티켓 선택/관리
+```
+
+#### app_partner Features
+
+```text
+apps/app_partner/lib/src/features/
+├── admin/          # 관리자 기능
+├── auth/           # 파트너 로그인/인증
+├── checkin/        # 이벤트 체크인 관리
+├── home/           # 파트너 대시보드
+├── member/         # 멤버 관리 (초대, 권한)
+├── more/           # 더보기 메뉴
+├── onboarding/     # 파트너 온보딩
+├── party/          # 파티/이벤트 관리
+├── qr/             # QR 스캐너
+├── settlement/     # 정산 관리
+├── ticket/         # 티켓 관리
+└── verification/   # 인증 심사
+```
+
 ### 2.1.1 Shared Packages
 
 `shared/packages/` 디렉토리에는 모노레포 전체에서 공유되는 패키지가 위치합니다.

--- a/shared/packages/minglit_kit/lib/src/features/auth/ui/staff_guard_wrapper.dart
+++ b/shared/packages/minglit_kit/lib/src/features/auth/ui/staff_guard_wrapper.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:minglit_kit/src/features/auth/logic/staff_guard_provider.dart';
 import 'package:minglit_kit/src/features/auth/ui/staff_gate_screen.dart';
+import 'package:minglit_kit/src/logic/providers/supabase_provider.dart';
 import 'package:minglit_kit/src/theme/minglit_theme.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_async_value_widget.dart';
 import 'package:minglit_kit/src/utils/platform_utils.dart';
@@ -30,8 +31,9 @@ class _StaffGuardWrapperState extends ConsumerState<StaffGuardWrapper> {
   @override
   void initState() {
     super.initState();
-    // Listen to auth changes to catch Magic Link login completion
-    _authSubscription = Supabase.instance.client.auth.onAuthStateChange.listen(
+    // Fix #412: Riverpod Provider를 통해 Supabase 클라이언트 주입
+    final client = ref.read(supabaseClientProvider);
+    _authSubscription = client.auth.onAuthStateChange.listen(
       (data) {
         unawaited(_handleAuthChange(data));
       },

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
@@ -5,18 +5,19 @@ import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:minglit_kit/src/data/repositories/bug_report_repository.dart';
 import 'package:minglit_kit/src/data/repositories/storage_repository.dart';
+import 'package:minglit_kit/src/logic/providers/supabase_provider.dart';
 import 'package:minglit_kit/src/theme/minglit_theme.dart';
 import 'package:minglit_kit/src/ui/widgets/common/loading_indicator.dart';
-
 import 'package:minglit_kit/src/utils/environment_info.dart';
 import 'package:minglit_kit/src/utils/layout_dump.dart';
 import 'package:minglit_kit/src/utils/log.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 
 /// Wraps [child] with bug reporting UI.
-class BugReporterWrapper extends StatefulWidget {
+// Fix #412: ConsumerStatefulWidget 전환 — Supabase 직접 접근 제거, Riverpod Provider 주입
+class BugReporterWrapper extends ConsumerStatefulWidget {
   /// Creates a bug reporter wrapper.
   const BugReporterWrapper({
     required this.child,
@@ -39,10 +40,10 @@ class BugReporterWrapper extends StatefulWidget {
   final bool enabled;
 
   @override
-  State<BugReporterWrapper> createState() => _BugReporterWrapperState();
+  ConsumerState<BugReporterWrapper> createState() => _BugReporterWrapperState();
 }
 
-class _BugReporterWrapperState extends State<BugReporterWrapper> {
+class _BugReporterWrapperState extends ConsumerState<BugReporterWrapper> {
   bool _isReportOpen = false;
   bool _isCapturing = false;
   final GlobalKey _boundaryKey = GlobalKey();
@@ -73,7 +74,7 @@ class _BugReporterWrapperState extends State<BugReporterWrapper> {
       final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
       if (byteData == null) return null;
       final bytes = byteData.buffer.asUint8List();
-      final url = await StorageRepository().uploadBytes(
+      final url = await ref.read(storageRepositoryProvider).uploadBytes(
         bytes: bytes,
         bucket: 'bug-report-attachments',
         pathPrefix: 'screenshots',
@@ -118,7 +119,7 @@ class _BugReporterWrapperState extends State<BugReporterWrapper> {
     String? layoutDumpUrl;
     if (layoutDump != null) {
       try {
-        layoutDumpUrl = await StorageRepository().uploadBytes(
+        layoutDumpUrl = await ref.read(storageRepositoryProvider).uploadBytes(
           bytes: Uint8List.fromList(utf8.encode(layoutDump)),
           bucket: 'bug-report-attachments',
           pathPrefix: 'layout-dumps',
@@ -265,8 +266,11 @@ class _BugReporterWrapperState extends State<BugReporterWrapper> {
                                     setSheetState(() => isLoading = true);
                                     try {
                                       final logs = Log.export();
+                                      // Fix #412: Provider 주입
                                       final repo = BugReportRepository(
-                                        Supabase.instance.client,
+                                        ref.read(
+                                          supabaseClientProvider,
+                                        ),
                                       );
                                       await repo.reportBug(
                                         title: titleController.text.isEmpty

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
@@ -74,11 +74,13 @@ class _BugReporterWrapperState extends ConsumerState<BugReporterWrapper> {
       final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
       if (byteData == null) return null;
       final bytes = byteData.buffer.asUint8List();
-      final url = await ref.read(storageRepositoryProvider).uploadBytes(
-        bytes: bytes,
-        bucket: 'bug-report-attachments',
-        pathPrefix: 'screenshots',
-      );
+      final url = await ref
+          .read(storageRepositoryProvider)
+          .uploadBytes(
+            bytes: bytes,
+            bucket: 'bug-report-attachments',
+            pathPrefix: 'screenshots',
+          );
       return url;
     } on Exception catch (e) {
       Log.e('Screenshot capture failed (best-effort)', e);
@@ -119,13 +121,15 @@ class _BugReporterWrapperState extends ConsumerState<BugReporterWrapper> {
     String? layoutDumpUrl;
     if (layoutDump != null) {
       try {
-        layoutDumpUrl = await ref.read(storageRepositoryProvider).uploadBytes(
-          bytes: Uint8List.fromList(utf8.encode(layoutDump)),
-          bucket: 'bug-report-attachments',
-          pathPrefix: 'layout-dumps',
-          contentType: 'text/plain',
-          extension: '.txt',
-        );
+        layoutDumpUrl = await ref
+            .read(storageRepositoryProvider)
+            .uploadBytes(
+              bytes: Uint8List.fromList(utf8.encode(layoutDump)),
+              bucket: 'bug-report-attachments',
+              pathPrefix: 'layout-dumps',
+              contentType: 'text/plain',
+              extension: '.txt',
+            );
       } on Object catch (e) {
         Log.e('Layout dump upload failed (best-effort)', e);
       }

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
@@ -74,6 +74,7 @@ class _BugReporterWrapperState extends ConsumerState<BugReporterWrapper> {
       final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
       if (byteData == null) return null;
       final bytes = byteData.buffer.asUint8List();
+      // Fix #412: StorageRepository 직접 생성 → Provider 주입
       final url = await ref
           .read(storageRepositoryProvider)
           .uploadBytes(
@@ -121,6 +122,7 @@ class _BugReporterWrapperState extends ConsumerState<BugReporterWrapper> {
     String? layoutDumpUrl;
     if (layoutDump != null) {
       try {
+        // Fix #412: StorageRepository 직접 생성 → Provider 주입
         layoutDumpUrl = await ref
             .read(storageRepositoryProvider)
             .uploadBytes(


### PR DESCRIPTION
## Summary

- **backend.md**: 테이블 수 50→54 수정 (settlement v2 4개 테이블 추가 반영), `partner-manage-settlement` Edge Function 누락 추가
- **client.md**: `app_user` (9개), `app_partner` (12개) feature 디렉토리 목록 추가
- **bug_reporter_wrapper.dart**: `StatefulWidget` → `ConsumerStatefulWidget` 전환, `Supabase.instance.client` 직접 접근을 `supabaseClientProvider`로 교체, `StorageRepository()` 직접 생성을 `storageRepositoryProvider`로 교체
- **staff_guard_wrapper.dart**: `Supabase.instance.client.auth.onAuthStateChange` 직접 접근을 `supabaseClientProvider`로 교체

Closes #412

## Test plan

- [ ] `flutter analyze` 통과 확인 (로컬에서 0 issues 확인 완료)
- [ ] bug_reporter_wrapper: 버그 리포트 FAB 동작 확인 (스크린샷 캡처 → 전송)
- [ ] staff_guard_wrapper: 웹 배포 시 staff guard 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)