### PR TITLE
fix(location): 가까운 거리 필터 탭 시 10초 UI 프리즈 수정

### DIFF
--- a/apps/app_user/lib/src/widgets/explore_filter_chip_bar.dart
+++ b/apps/app_user/lib/src/widgets/explore_filter_chip_bar.dart
@@ -75,19 +75,29 @@ class ExploreFilterChipBar extends ConsumerWidget {
     );
   }
 
+  // Fix #419: Check permission first (instant) instead of blocking UI
+  // for up to 10s on GPS timeout. Toggle filter immediately — the list
+  // auto-updates via Riverpod when location becomes available.
   Future<void> _onNearbyTap(BuildContext context, WidgetRef ref) async {
     final filters = ref.read(activeFiltersProvider);
     if (!filters.nearbyEnabled) {
-      // Fix #154: Invalidate cached location to retry GPS acquisition
-      ref.invalidate(userLocationProvider);
-      final location = await ref.read(userLocationProvider.future);
-      if (location == null) {
-        if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('위치 권한이 필요합니다')),
-          );
+      final locationService = LocationService();
+      final hasPermission = await locationService.hasPermission();
+      if (!hasPermission) {
+        // Fix #154: Invalidate cached location to trigger permission request
+        ref.invalidate(userLocationProvider);
+        final location = await ref.read(userLocationProvider.future);
+        if (location == null) {
+          if (context.mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('위치 권한이 필요합니다')),
+            );
+          }
+          return;
         }
-        return;
+      } else {
+        // Permission granted — refresh location in background, don't block UI.
+        ref.invalidate(userLocationProvider);
       }
     }
     ref.read(activeFiltersProvider.notifier).toggleNearby();

--- a/shared/packages/minglit_kit/lib/src/services/location_service.dart
+++ b/shared/packages/minglit_kit/lib/src/services/location_service.dart
@@ -15,7 +15,19 @@ class LocationResult {
 
 /// Service for retrieving the device's current GPS position.
 class LocationService {
+  /// Returns true if location permission is granted (whileInUse or always).
+  ///
+  /// Does NOT request permission — only checks current status.
+  Future<bool> hasPermission() async {
+    final permission = await Geolocator.checkPermission();
+    return permission == LocationPermission.whileInUse ||
+        permission == LocationPermission.always;
+  }
+
   /// Returns the current position, or null if unavailable or permission denied.
+  ///
+  /// // Fix #419: Try getLastKnownPosition first for instant results,
+  /// then fall back to getCurrentPosition with timeout.
   Future<LocationResult?> getCurrentPosition() async {
     try {
       final serviceEnabled = await Geolocator.isLocationServiceEnabled();
@@ -36,6 +48,16 @@ class LocationService {
       if (permission == LocationPermission.deniedForever) {
         Log.d('[LocationService] Permission denied forever');
         return null;
+      }
+
+      // Fix #419: Try last known position first (instant, no GPS wait).
+      final lastKnown = await Geolocator.getLastKnownPosition();
+      if (lastKnown != null) {
+        Log.d('[LocationService] Using last known position');
+        return LocationResult(
+          latitude: lastKnown.latitude,
+          longitude: lastKnown.longitude,
+        );
       }
 
       final position = await Geolocator.getCurrentPosition(

--- a/shared/packages/minglit_kit/test/services/location_service_test.dart
+++ b/shared/packages/minglit_kit/test/services/location_service_test.dart
@@ -28,6 +28,9 @@ void main() {
           () => mockGeolocator.checkPermission(),
         ).thenAnswer((_) async => LocationPermission.whileInUse);
         when(
+          () => mockGeolocator.getLastKnownPosition(),
+        ).thenAnswer((_) async => null);
+        when(
           () => mockGeolocator.getCurrentPosition(
             locationSettings: any(named: 'locationSettings'),
           ),
@@ -108,6 +111,9 @@ void main() {
         () => mockGeolocator.requestPermission(),
       ).thenAnswer((_) async => LocationPermission.whileInUse);
       when(
+        () => mockGeolocator.getLastKnownPosition(),
+      ).thenAnswer((_) async => null);
+      when(
         () => mockGeolocator.getCurrentPosition(
           locationSettings: any(named: 'locationSettings'),
         ),
@@ -132,6 +138,126 @@ void main() {
       expect(result, isNotNull);
       expect(result!.latitude, 37.5665);
       verify(() => mockGeolocator.requestPermission()).called(1);
+    });
+
+    // Fix #419: Test getLastKnownPosition fast path
+    test('returns last known position without calling getCurrentPosition',
+        () async {
+      when(
+        () => mockGeolocator.isLocationServiceEnabled(),
+      ).thenAnswer((_) async => true);
+      when(
+        () => mockGeolocator.checkPermission(),
+      ).thenAnswer((_) async => LocationPermission.whileInUse);
+      when(
+        () => mockGeolocator.getLastKnownPosition(),
+      ).thenAnswer(
+        (_) async => Position(
+          latitude: 37.4979,
+          longitude: 127.0276,
+          timestamp: DateTime.now(),
+          accuracy: 10,
+          altitude: 0,
+          altitudeAccuracy: 0,
+          heading: 0,
+          headingAccuracy: 0,
+          speed: 0,
+          speedAccuracy: 0,
+        ),
+      );
+
+      final service = LocationService();
+      final result = await service.getCurrentPosition();
+
+      expect(result, isNotNull);
+      expect(result!.latitude, 37.4979);
+      expect(result.longitude, 127.0276);
+      verifyNever(
+        () => mockGeolocator.getCurrentPosition(
+          locationSettings: any(named: 'locationSettings'),
+        ),
+      );
+    });
+
+    // Fix #419: Test fallback to getCurrentPosition when no last known
+    test('falls back to getCurrentPosition when no last known position',
+        () async {
+      when(
+        () => mockGeolocator.isLocationServiceEnabled(),
+      ).thenAnswer((_) async => true);
+      when(
+        () => mockGeolocator.checkPermission(),
+      ).thenAnswer((_) async => LocationPermission.whileInUse);
+      when(
+        () => mockGeolocator.getLastKnownPosition(),
+      ).thenAnswer((_) async => null);
+      when(
+        () => mockGeolocator.getCurrentPosition(
+          locationSettings: any(named: 'locationSettings'),
+        ),
+      ).thenAnswer(
+        (_) async => Position(
+          latitude: 37.5665,
+          longitude: 126.9780,
+          timestamp: DateTime.now(),
+          accuracy: 10,
+          altitude: 0,
+          altitudeAccuracy: 0,
+          heading: 0,
+          headingAccuracy: 0,
+          speed: 0,
+          speedAccuracy: 0,
+        ),
+      );
+
+      final service = LocationService();
+      final result = await service.getCurrentPosition();
+
+      expect(result, isNotNull);
+      expect(result!.latitude, 37.5665);
+      verify(
+        () => mockGeolocator.getCurrentPosition(
+          locationSettings: any(named: 'locationSettings'),
+        ),
+      ).called(1);
+    });
+  });
+
+  group('LocationService.hasPermission', () {
+    test('returns true when permission is whileInUse', () async {
+      when(
+        () => mockGeolocator.checkPermission(),
+      ).thenAnswer((_) async => LocationPermission.whileInUse);
+
+      final service = LocationService();
+      expect(await service.hasPermission(), isTrue);
+    });
+
+    test('returns true when permission is always', () async {
+      when(
+        () => mockGeolocator.checkPermission(),
+      ).thenAnswer((_) async => LocationPermission.always);
+
+      final service = LocationService();
+      expect(await service.hasPermission(), isTrue);
+    });
+
+    test('returns false when permission is denied', () async {
+      when(
+        () => mockGeolocator.checkPermission(),
+      ).thenAnswer((_) async => LocationPermission.denied);
+
+      final service = LocationService();
+      expect(await service.hasPermission(), isFalse);
+    });
+
+    test('returns false when permission is deniedForever', () async {
+      when(
+        () => mockGeolocator.checkPermission(),
+      ).thenAnswer((_) async => LocationPermission.deniedForever);
+
+      final service = LocationService();
+      expect(await service.hasPermission(), isFalse);
     });
   });
 }

--- a/shared/packages/minglit_kit/test/services/location_service_test.dart
+++ b/shared/packages/minglit_kit/test/services/location_service_test.dart
@@ -141,86 +141,90 @@ void main() {
     });
 
     // Fix #419: Test getLastKnownPosition fast path
-    test('returns last known position without calling getCurrentPosition',
-        () async {
-      when(
-        () => mockGeolocator.isLocationServiceEnabled(),
-      ).thenAnswer((_) async => true);
-      when(
-        () => mockGeolocator.checkPermission(),
-      ).thenAnswer((_) async => LocationPermission.whileInUse);
-      when(
-        () => mockGeolocator.getLastKnownPosition(),
-      ).thenAnswer(
-        (_) async => Position(
-          latitude: 37.4979,
-          longitude: 127.0276,
-          timestamp: DateTime.now(),
-          accuracy: 10,
-          altitude: 0,
-          altitudeAccuracy: 0,
-          heading: 0,
-          headingAccuracy: 0,
-          speed: 0,
-          speedAccuracy: 0,
-        ),
-      );
+    test(
+      'returns last known position without calling getCurrentPosition',
+      () async {
+        when(
+          () => mockGeolocator.isLocationServiceEnabled(),
+        ).thenAnswer((_) async => true);
+        when(
+          () => mockGeolocator.checkPermission(),
+        ).thenAnswer((_) async => LocationPermission.whileInUse);
+        when(
+          () => mockGeolocator.getLastKnownPosition(),
+        ).thenAnswer(
+          (_) async => Position(
+            latitude: 37.4979,
+            longitude: 127.0276,
+            timestamp: DateTime.now(),
+            accuracy: 10,
+            altitude: 0,
+            altitudeAccuracy: 0,
+            heading: 0,
+            headingAccuracy: 0,
+            speed: 0,
+            speedAccuracy: 0,
+          ),
+        );
 
-      final service = LocationService();
-      final result = await service.getCurrentPosition();
+        final service = LocationService();
+        final result = await service.getCurrentPosition();
 
-      expect(result, isNotNull);
-      expect(result!.latitude, 37.4979);
-      expect(result.longitude, 127.0276);
-      verifyNever(
-        () => mockGeolocator.getCurrentPosition(
-          locationSettings: any(named: 'locationSettings'),
-        ),
-      );
-    });
+        expect(result, isNotNull);
+        expect(result!.latitude, 37.4979);
+        expect(result.longitude, 127.0276);
+        verifyNever(
+          () => mockGeolocator.getCurrentPosition(
+            locationSettings: any(named: 'locationSettings'),
+          ),
+        );
+      },
+    );
 
     // Fix #419: Test fallback to getCurrentPosition when no last known
-    test('falls back to getCurrentPosition when no last known position',
-        () async {
-      when(
-        () => mockGeolocator.isLocationServiceEnabled(),
-      ).thenAnswer((_) async => true);
-      when(
-        () => mockGeolocator.checkPermission(),
-      ).thenAnswer((_) async => LocationPermission.whileInUse);
-      when(
-        () => mockGeolocator.getLastKnownPosition(),
-      ).thenAnswer((_) async => null);
-      when(
-        () => mockGeolocator.getCurrentPosition(
-          locationSettings: any(named: 'locationSettings'),
-        ),
-      ).thenAnswer(
-        (_) async => Position(
-          latitude: 37.5665,
-          longitude: 126.9780,
-          timestamp: DateTime.now(),
-          accuracy: 10,
-          altitude: 0,
-          altitudeAccuracy: 0,
-          heading: 0,
-          headingAccuracy: 0,
-          speed: 0,
-          speedAccuracy: 0,
-        ),
-      );
+    test(
+      'falls back to getCurrentPosition when no last known position',
+      () async {
+        when(
+          () => mockGeolocator.isLocationServiceEnabled(),
+        ).thenAnswer((_) async => true);
+        when(
+          () => mockGeolocator.checkPermission(),
+        ).thenAnswer((_) async => LocationPermission.whileInUse);
+        when(
+          () => mockGeolocator.getLastKnownPosition(),
+        ).thenAnswer((_) async => null);
+        when(
+          () => mockGeolocator.getCurrentPosition(
+            locationSettings: any(named: 'locationSettings'),
+          ),
+        ).thenAnswer(
+          (_) async => Position(
+            latitude: 37.5665,
+            longitude: 126.9780,
+            timestamp: DateTime.now(),
+            accuracy: 10,
+            altitude: 0,
+            altitudeAccuracy: 0,
+            heading: 0,
+            headingAccuracy: 0,
+            speed: 0,
+            speedAccuracy: 0,
+          ),
+        );
 
-      final service = LocationService();
-      final result = await service.getCurrentPosition();
+        final service = LocationService();
+        final result = await service.getCurrentPosition();
 
-      expect(result, isNotNull);
-      expect(result!.latitude, 37.5665);
-      verify(
-        () => mockGeolocator.getCurrentPosition(
-          locationSettings: any(named: 'locationSettings'),
-        ),
-      ).called(1);
-    });
+        expect(result, isNotNull);
+        expect(result!.latitude, 37.5665);
+        verify(
+          () => mockGeolocator.getCurrentPosition(
+            locationSettings: any(named: 'locationSettings'),
+          ),
+        ).called(1);
+      },
+    );
   });
 
   group('LocationService.hasPermission', () {


### PR DESCRIPTION
## Summary
- **Root cause**: "가까운 거리" 필터 탭 시 `getCurrentPosition()`의 10초 타임아웃 동안 UI가 블로킹됨. 위치 권한은 이미 허용된 상태에서 GPS 타임아웃 발생 시 잘못된 에러 메시지("위치 권한이 필요합니다") 표시.
- **Fix**: 권한 상태를 먼저 확인(instant)하고, 이미 허용된 경우 필터를 즉시 토글 후 위치를 백그라운드에서 갱신. Riverpod 반응성으로 리스트가 자동 업데이트됨.
- **Fast path**: `getLastKnownPosition()`을 먼저 시도하여 캐시된 위치가 있으면 GPS 대기 없이 즉시 반환.

Closes #419

## Test plan
- [x] `LocationService` 유닛 테스트 11개 통과 (기존 5 + 신규 6)
- [x] `flutter analyze` 이슈 없음
- [ ] 위치 권한 허용 상태에서 "가까운 거리" 탭 → 즉시 토글, 래그 없음 확인
- [ ] 위치 권한 미허용 상태에서 "가까운 거리" 탭 → 권한 요청 다이얼로그 표시 확인
- [ ] 권한 거부 시 "위치 권한이 필요합니다" 스낵바 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)