### PR TITLE
fix(home): 대시보드 수평 스크롤 카드 잘림 수정 및 이벤트 자세히 버튼 추가

### DIFF
--- a/apps/app_partner/lib/src/features/home/partner_home_page.dart
+++ b/apps/app_partner/lib/src/features/home/partner_home_page.dart
@@ -102,17 +102,25 @@ class PartnerHomePage extends ConsumerWidget {
               .loadDashboardData(),
           child: SingleChildScrollView(
             physics: const AlwaysScrollableScrollPhysics(),
-            padding: const EdgeInsets.all(MinglitSpacing.medium),
+            padding: const EdgeInsets.symmetric(
+              vertical: MinglitSpacing.medium,
+            ),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 // 1. Pending Applicants
-                PendingApplicantsBadgeCard(
-                  count: state.pendingReviewCount,
-                  onTap: coordinator.pushApplicationList,
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: MinglitSpacing.medium,
+                  ),
+                  child: PendingApplicantsBadgeCard(
+                    count: state.pendingReviewCount,
+                    onTap: coordinator.pushApplicationList,
+                  ),
                 ),
                 const SizedBox(height: MinglitSpacing.large),
 
+                // Fix #422: 수평 스크롤 섹션은 화면 전체 너비 사용
                 // 2. Upcoming Events
                 UpcomingEventsCard(
                   events: state.upcomingEvents,
@@ -122,6 +130,12 @@ class PartnerHomePage extends ConsumerWidget {
                         partyId: event.partyId,
                         eventId: event.id,
                       ).push<void>(context),
+                    );
+                  },
+                  // Fix #422: 이벤트 요약 자세히 버튼 → 파티 목록
+                  onViewAllTap: () {
+                    unawaited(
+                      const PartyListRoute().push<void>(context),
                     );
                   },
                 ),
@@ -145,24 +159,34 @@ class PartnerHomePage extends ConsumerWidget {
                 const SizedBox(height: MinglitSpacing.large),
 
                 // 4. Closing Soon Events
-                ClosingSoonEventsCard(
-                  events: state.closingSoonEvents,
-                  onEventTap: (event) {
-                    unawaited(
-                      EventDetailRoute(
-                        partyId: event.partyId,
-                        eventId: event.id,
-                      ).push<void>(context),
-                    );
-                  },
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: MinglitSpacing.medium,
+                  ),
+                  child: ClosingSoonEventsCard(
+                    events: state.closingSoonEvents,
+                    onEventTap: (event) {
+                      unawaited(
+                        EventDetailRoute(
+                          partyId: event.partyId,
+                          eventId: event.id,
+                        ).push<void>(context),
+                      );
+                    },
+                  ),
                 ),
                 const SizedBox(height: MinglitSpacing.large),
 
                 // 5. Location Guide Banner
-                LocationGuideBanner(
-                  onTap: () {
-                    const LocationGuideRoute().go(context);
-                  },
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: MinglitSpacing.medium,
+                  ),
+                  child: LocationGuideBanner(
+                    onTap: () {
+                      const LocationGuideRoute().go(context);
+                    },
+                  ),
                 ),
 
                 const SizedBox(height: 100), // Bottom padding for FAB/Nav

--- a/apps/app_partner/lib/src/features/home/widgets/active_party_summary_scroll.dart
+++ b/apps/app_partner/lib/src/features/home/widgets/active_party_summary_scroll.dart
@@ -23,8 +23,13 @@ class ActivePartySummaryScroll extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        // Fix #422: 헤더에 가로 패딩 적용 (수평 스크롤은 화면 전체 사용)
         Padding(
-          padding: const EdgeInsets.only(bottom: MinglitSpacing.small),
+          padding: const EdgeInsets.only(
+            left: MinglitSpacing.medium,
+            right: MinglitSpacing.medium,
+            bottom: MinglitSpacing.small,
+          ),
           child: Row(
             children: [
               Icon(
@@ -66,13 +71,18 @@ class ActivePartySummaryScroll extends StatelessWidget {
           ),
         ),
         if (parties.isEmpty)
-          SizedBox(
-            height: 100,
-            child: Center(
-              child: Text(
-                '운영 중인 파티가 없습니다',
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  color: colorScheme.onSurfaceVariant,
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: MinglitSpacing.medium,
+            ),
+            child: SizedBox(
+              height: 100,
+              child: Center(
+                child: Text(
+                  '운영 중인 파티가 없습니다',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
                 ),
               ),
             ),
@@ -82,6 +92,10 @@ class ActivePartySummaryScroll extends StatelessWidget {
             height: 140,
             child: ListView.separated(
               scrollDirection: Axis.horizontal,
+              // Fix #422: 좌우 패딩으로 카드 잘림 방지
+              padding: const EdgeInsets.symmetric(
+                horizontal: MinglitSpacing.medium,
+              ),
               itemCount: parties.length,
               separatorBuilder: (_, _) => const SizedBox(
                 width: MinglitSpacing.small,

--- a/apps/app_partner/lib/src/features/home/widgets/upcoming_events_card.dart
+++ b/apps/app_partner/lib/src/features/home/widgets/upcoming_events_card.dart
@@ -7,11 +7,14 @@ class UpcomingEventsCard extends StatelessWidget {
   const UpcomingEventsCard({
     required this.events,
     required this.onEventTap,
+    // Fix #422: 이벤트 요약 자세히 버튼 콜백
+    this.onViewAllTap,
     super.key,
   });
 
   final List<Event> events;
   final void Function(Event event) onEventTap;
+  final VoidCallback? onViewAllTap;
 
   @override
   Widget build(BuildContext context) {
@@ -21,8 +24,13 @@ class UpcomingEventsCard extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        // Fix #422: 헤더에 가로 패딩 적용 (수평 스크롤은 화면 전체 사용)
         Padding(
-          padding: const EdgeInsets.only(bottom: MinglitSpacing.small),
+          padding: const EdgeInsets.only(
+            left: MinglitSpacing.medium,
+            right: MinglitSpacing.medium,
+            bottom: MinglitSpacing.small,
+          ),
           child: Row(
             children: [
               Icon(
@@ -37,17 +45,45 @@ class UpcomingEventsCard extends StatelessWidget {
                   fontWeight: FontWeight.bold,
                 ),
               ),
+              // Fix #422: 이벤트 요약 자세히 버튼 추가
+              if (onViewAllTap != null) ...[
+                const Spacer(),
+                GestureDetector(
+                  onTap: onViewAllTap,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        '자세히',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                      Icon(
+                        Icons.chevron_right,
+                        size: 16,
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ],
+                  ),
+                ),
+              ],
             ],
           ),
         ),
         if (events.isEmpty)
-          SizedBox(
-            height: 100,
-            child: Center(
-              child: Text(
-                '예정된 이벤트가 없습니다',
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  color: colorScheme.onSurfaceVariant,
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: MinglitSpacing.medium,
+            ),
+            child: SizedBox(
+              height: 100,
+              child: Center(
+                child: Text(
+                  '예정된 이벤트가 없습니다',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
                 ),
               ),
             ),
@@ -57,6 +93,10 @@ class UpcomingEventsCard extends StatelessWidget {
             height: 140,
             child: ListView.separated(
               scrollDirection: Axis.horizontal,
+              // Fix #422: 좌우 패딩으로 카드 잘림 방지
+              padding: const EdgeInsets.symmetric(
+                horizontal: MinglitSpacing.medium,
+              ),
               itemCount: events.take(5).length,
               separatorBuilder: (_, _) => const SizedBox(
                 width: MinglitSpacing.small,


### PR DESCRIPTION
## Summary
- 파트너 앱 대시보드의 수평 스크롤 섹션(파티별 요약, 다가오는 이벤트)이 부모 `SingleChildScrollView`의 전체 패딩으로 인해 우측 카드가 잘리는 문제 수정
- 부모 패딩을 세로만 적용하고, 수평 스크롤 ListView에 자체 가로 패딩 추가하여 화면 가장자리까지 확장
- `UpcomingEventsCard`에 '자세히' 버튼 추가 (`ActivePartySummaryScroll`과 동일 패턴)

Closes #422

## Test plan
- [ ] 파트너 앱 대시보드에서 파티별 요약 카드가 우측에 잘리지 않는지 확인
- [ ] 다가오는 이벤트 카드가 우측에 잘리지 않는지 확인
- [ ] 다가오는 이벤트 섹션에 '자세히' 버튼이 표시되고 탭 시 파티 목록으로 이동하는지 확인
- [ ] 대기 중인 신청, 마감임박, 위치 안내 배너 등 비스크롤 섹션의 가로 패딩이 정상인지 확인
- [ ] 데이터 없는 empty 상태에서 레이아웃이 정상인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)