### PR TITLE
fix(ci): refresh dev-seed before Daily CUJ tests

### DIFF
--- a/.github/workflows/daily-e2e.yml
+++ b/.github/workflows/daily-e2e.yml
@@ -10,7 +10,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Fix #428: refresh seed data before tests so scheduled events exist
+  refresh-seed-data:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Refresh dev seed data
+        run: |
+          curl -sf -X POST \
+            "${{ secrets.SUPABASE_DEV_URL }}/functions/v1/dev-seed" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_DEV_SECRET_KEY }}" \
+            -H "Content-Type: application/json"
+
   client-cuj-test:
+    needs: refresh-seed-data
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -65,6 +78,7 @@ jobs:
             done
 
   partner-cuj-test:
+    needs: refresh-seed-data
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Summary
- Daily CUJ tests (`client-cuj-test`, `partner-cuj-test`) both failed with `Bad state: No scheduled event with tickets and a partner owner found in dev database`
- Root cause: `dev-seed` creates events dated 3–10 days out, but the workflow never re-seeds — events expire and no `scheduled` events remain
- Added a shared `refresh-seed-data` job that calls `dev-seed` Edge Function before both test jobs, ensuring fresh test data

## Test plan
- [ ] Manually trigger Daily CUJ workflow after merge and verify both jobs pass
- [ ] Verify `refresh-seed-data` job completes before test jobs start

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)