### PR TITLE
fix(landing): env-manifest.json lazy require 전환으로 Vercel 배포 복구

### DIFF
--- a/apps/landing_partner/lib/env.ts
+++ b/apps/landing_partner/lib/env.ts
@@ -1,11 +1,12 @@
-import manifest from "../../../env-manifest.json";
-
 /**
  * Validate that all required build-time env vars for landing_partner are present.
  *
  * Call from `next.config.ts` so missing variables fail the build early.
  */
 export function validateBuildEnv(): void {
+  // Fix #447: lazy require to avoid module resolution failure on Vercel
+  // where the monorepo root is outside the build directory
+  const manifest = require("../../../env-manifest.json");
   const section = manifest.nextjs.landing_partner;
   const required = Object.keys(section.required);
   const missing = required.filter((k) => !process.env[k]);

--- a/apps/landing_partner/lib/env.ts
+++ b/apps/landing_partner/lib/env.ts
@@ -6,6 +6,7 @@
 export function validateBuildEnv(): void {
   // Fix #447: lazy require to avoid module resolution failure on Vercel
   // where the monorepo root is outside the build directory
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const manifest = require("../../../env-manifest.json");
   const section = manifest.nextjs.landing_partner;
   const required = Object.keys(section.required);

--- a/apps/landing_user/lib/env.ts
+++ b/apps/landing_user/lib/env.ts
@@ -1,11 +1,12 @@
-import manifest from "../../../env-manifest.json";
-
 /**
  * Validate that all required build-time env vars for landing_user are present.
  *
  * Call from `next.config.ts` so missing variables fail the build early.
  */
 export function validateBuildEnv(): void {
+  // Fix #447: lazy require to avoid module resolution failure on Vercel
+  // where the monorepo root is outside the build directory
+  const manifest = require("../../../env-manifest.json");
   const section = manifest.nextjs.landing_user;
   const required = Object.keys(section.required);
   const missing = required.filter((k) => !process.env[k]);

--- a/apps/landing_user/lib/env.ts
+++ b/apps/landing_user/lib/env.ts
@@ -6,6 +6,7 @@
 export function validateBuildEnv(): void {
   // Fix #447: lazy require to avoid module resolution failure on Vercel
   // where the monorepo root is outside the build directory
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const manifest = require("../../../env-manifest.json");
   const section = manifest.nextjs.landing_user;
   const required = Object.keys(section.required);


### PR DESCRIPTION
## Summary
- `landing_partner` / `landing_user`의 `lib/env.ts`에서 top-level `import`로 `env-manifest.json`을 참조하던 것을 `validateBuildEnv()` 내부의 lazy `require()`로 전환
- Vercel 빌드 환경에서 모노레포 root가 접근 불가한 문제 해결 (Root Directory가 `apps/landing_*`로 설정)
- `validateBuildEnv()`는 `!CI` 조건에서만 호출되므로, Vercel 환경에서는 require가 실행되지 않음

Closes #447

## Test plan
- [ ] CI lint + build 통과 확인
- [ ] Vercel deploy 워크플로우 수동 실행하여 배포 성공 확인
- [ ] 로컬에서 `npm run build` 시 env validation 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)