### PR TITLE
fix(ci): scope git add to dart files only in auto-format workflow

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -60,7 +60,7 @@ jobs:
           if [[ -n "$(git status --porcelain)" ]]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add .
+            git add -- '**/*.dart'
             git commit -m "chore: auto-fix and format"
             git push
           else


### PR DESCRIPTION
## Summary
- Replace `git add .` with `git add -- '**/*.dart'` in the auto-format workflow
- Prevents accidentally staging temp files, generated artifacts, or other unintended files after `dart fix --apply` and `dart format` runs
- Uses recursive glob to cover all subdirectories (`shared/packages/minglit_kit`, `apps/app_user`, `apps/app_partner`)

## Test plan
- [ ] Verify auto-format workflow commits only `.dart` files when formatting changes are present
- [ ] Verify no unintended files are staged alongside dart format changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)