### PR TITLE
fix(ci): pass deploy-branch input to flutter deploy action

### DIFF
--- a/.github/actions/deploy-flutter-app/action.yml
+++ b/.github/actions/deploy-flutter-app/action.yml
@@ -17,6 +17,9 @@ inputs:
   dev-domain-alias:
     description: 'Domain alias for dev environment'
     required: true
+  deploy-branch:
+    description: 'Branch name to determine prod vs preview deployment'
+    required: true
 
 outputs:
   accessible-url:
@@ -38,7 +41,7 @@ runs:
         echo "📦 Installing workspace dependencies..."
         (cd ../../ && flutter pub get)
 
-        if [[ "${{ github.ref_name }}" == "main" ]]; then
+        if [[ "${{ inputs.deploy-branch }}" == "main" ]]; then
           TARGET="lib/main.dart"
           SB_URL="$SUPABASE_MAIN_URL"
           SB_KEY="$SUPABASE_MAIN_KEY"
@@ -89,7 +92,7 @@ runs:
 
         cd build/web
 
-        if [[ "${{ github.ref_name }}" == "main" ]]; then
+        if [[ "${{ inputs.deploy-branch }}" == "main" ]]; then
           echo "🚀 Deploying to Production (Main)..."
           npx vercel deploy --prod $COMMON_ARGS
           # Fix #389: output the production alias URL for smoke test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,7 @@ jobs:
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_USER }}
           dev-domain-alias: dev.app.minglit.com
+          deploy-branch: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name }}
         env:
           SUPABASE_DEV_URL: ${{ secrets.SUPABASE_DEV_URL }}
           SUPABASE_DEV_KEY: ${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }}
@@ -107,6 +108,7 @@ jobs:
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID_PARTNER }}
           dev-domain-alias: dev.app.partner.minglit.com
+          deploy-branch: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name }}
         env:
           SUPABASE_DEV_URL: ${{ secrets.SUPABASE_DEV_URL }}
           SUPABASE_DEV_KEY: ${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }}


### PR DESCRIPTION
## Summary

- `workflow_dispatch` with `inputs.branch=main` runs from the `dev` branch, so `github.ref_name` is always `"dev"` inside the flutter deploy action — causing main deployments to use dev Supabase/Google credentials and skip `--prod` flag
- Added `deploy-branch` input to `.github/actions/deploy-flutter-app/action.yml` (same pattern already used by the nextjs action)
- Replaced both `github.ref_name` references in the action with `inputs.deploy-branch`
- Passed `deploy-branch: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name }}` to both `deploy-app_user` and `deploy-app_partner` jobs in `deploy.yml`

## Test plan

- [ ] Trigger `workflow_dispatch` with `branch=main` — verify flutter apps build with `SUPABASE_MAIN_*` credentials and deploy with `--prod`
- [ ] Trigger `workflow_dispatch` with `branch=dev` — verify flutter apps build with `SUPABASE_DEV_*` credentials and deploy as preview
- [ ] Scheduled cron run (targets dev) — verify preview deploy still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)