### PR TITLE
refactor: event ↔ ticket 순환 참조 및 event → payment → event 근접 순환 해소

### DIFF
--- a/apps/app_user/lib/src/features/event/admission/event_admission_controller.dart
+++ b/apps/app_user/lib/src/features/event/admission/event_admission_controller.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:app_user/src/features/auth/logic/auth_coordinator.dart';
-import 'package:app_user/src/features/ticket/ui/ticket_selection_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -9,7 +8,6 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'event_admission_controller.g.dart';
 part 'admission_action_handler.dart';
-part 'ticket_recommendation_util.dart';
 part 'event_admission_state.dart';
 
 @riverpod
@@ -88,10 +86,12 @@ class EventAdmissionController extends _$EventAdmissionController {
     );
   }
 
+  // Fix #453: showTicketSelection 콜백으로 ticket feature 직접 참조 제거 — 순환 참조 해소
   /// Handles user action based on current admission state.
   Future<void> handleAction({
     required BuildContext context,
     required AdmissionState state,
+    required VoidCallback showTicketSelection,
   }) async {
     switch (state.status) {
       case EventAdmissionStatus.guest:
@@ -110,32 +110,16 @@ class EventAdmissionController extends _$EventAdmissionController {
         }
         return;
       case EventAdmissionStatus.qualificationRequired:
-        await showModalBottomSheet<void>(
-          context: context,
-          isScrollControlled: true,
-          builder: (_) => TicketSelectionSheet(event: event),
-        );
+        showTicketSelection();
         ref.invalidate(eventAdmissionControllerProvider(event));
         return;
       case EventAdmissionStatus.notEligible:
         return;
       case EventAdmissionStatus.eligible:
-        unawaited(
-          showModalBottomSheet<void>(
-            context: context,
-            isScrollControlled: true,
-            builder: (_) => TicketSelectionSheet(event: event),
-          ),
-        );
+        showTicketSelection();
         return;
       case EventAdmissionStatus.pendingPayment:
-        unawaited(
-          showModalBottomSheet<void>(
-            context: context,
-            isScrollControlled: true,
-            builder: (_) => TicketSelectionSheet(event: event),
-          ),
-        );
+        showTicketSelection();
         return;
       case EventAdmissionStatus.applied:
         handleMinglitError(
@@ -167,13 +151,7 @@ class EventAdmissionController extends _$EventAdmissionController {
                 .cancelOrder(eventId: event.id);
             ref.invalidate(eventAdmissionControllerProvider(event));
             if (context.mounted) {
-              unawaited(
-                showModalBottomSheet<void>(
-                  context: context,
-                  isScrollControlled: true,
-                  builder: (_) => TicketSelectionSheet(event: event),
-                ),
-              );
+              showTicketSelection();
             }
           } finally {
             loading.hide();

--- a/apps/app_user/lib/src/features/event/admission/event_application_wizard_page.dart
+++ b/apps/app_user/lib/src/features/event/admission/event_application_wizard_page.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 
 import 'package:app_user/src/features/event/admission/event_application_controller.dart';
+import 'package:app_user/src/features/event/logic/event_coordinator.dart';
 import 'package:app_user/src/features/event/logic/event_detail_controller.dart';
+import 'package:app_user/src/features/home/logic/home_coordinator.dart';
 import 'package:app_user/src/features/payment/ui/payment_success_screen.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
@@ -88,12 +90,18 @@ class _WizardBodyState extends ConsumerState<_WizardBody> {
         if (next.status == EventApplicationStatus.success) {
           final ticket = next.selectedTicket;
           if (ticket == null) return;
+          // Fix #453: 콜백으로 coordinator 의존을 wizard 페이지가 소유 — payment → event 순환 제거
           unawaited(
             Navigator.of(context).pushReplacement(
               MaterialPageRoute<void>(
                 builder: (_) => PaymentSuccessScreen(
-                  eventId: widget.event.id,
+                  event: widget.event,
                   ticketId: ticket.id,
+                  onViewTickets: () =>
+                      ref.read(homeCoordinatorProvider).goToPurchaseHistory(),
+                  onBackToEvent: () => ref
+                      .read(eventCoordinatorProvider)
+                      .goToEventDetail(widget.event.id),
                 ),
               ),
             ),

--- a/apps/app_user/lib/src/features/event/detail/event_bottom_ticket_bar.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_bottom_ticket_bar.dart
@@ -102,11 +102,11 @@ class _BottomTicketBar extends ConsumerWidget {
     final config = controller.buttonConfig(state);
     final onPressed = config.enabled
         ? () => controller.handleAction(
-              context: context,
-              state: state,
-              // Fix #453: ticket feature 직접 참조를 콜백으로 위임
-              showTicketSelection: () => _showTicketSelection(context, ref),
-            )
+            context: context,
+            state: state,
+            // Fix #453: ticket feature 직접 참조를 콜백으로 위임
+            showTicketSelection: () => _showTicketSelection(context, ref),
+          )
         : null;
     Color? backgroundColor;
     switch (config.style) {

--- a/apps/app_user/lib/src/features/event/detail/event_bottom_ticket_bar.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_bottom_ticket_bar.dart
@@ -73,6 +73,23 @@ class _BottomTicketBar extends ConsumerWidget {
     );
   }
 
+  void _showTicketSelection(BuildContext context, WidgetRef ref) {
+    unawaited(
+      showModalBottomSheet<void>(
+        context: context,
+        isScrollControlled: true,
+        builder: (_) => TicketSelectionSheet(
+          event: event,
+          onTicketSelected: (eventId, ticketId) {
+            ref
+                .read(eventCoordinatorProvider)
+                .goToApplicationWizard(eventId, ticketId: ticketId);
+          },
+        ),
+      ),
+    );
+  }
+
   Widget _buildActionButton(
     BuildContext context,
     WidgetRef ref,
@@ -84,7 +101,12 @@ class _BottomTicketBar extends ConsumerWidget {
     );
     final config = controller.buttonConfig(state);
     final onPressed = config.enabled
-        ? () => controller.handleAction(context: context, state: state)
+        ? () => controller.handleAction(
+              context: context,
+              state: state,
+              // Fix #453: ticket feature 직접 참조를 콜백으로 위임
+              showTicketSelection: () => _showTicketSelection(context, ref),
+            )
         : null;
     Color? backgroundColor;
     switch (config.style) {

--- a/apps/app_user/lib/src/features/event/detail/event_detail_page.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_page.dart
@@ -6,6 +6,7 @@ import 'package:app_user/src/features/event/detail/open_in_app_dialog.dart';
 import 'package:app_user/src/features/event/detail/report_bottom_sheet.dart';
 import 'package:app_user/src/features/event/logic/event_coordinator.dart';
 import 'package:app_user/src/features/event/logic/event_detail_controller.dart';
+import 'package:app_user/src/features/ticket/ui/ticket_selection_sheet.dart';
 import 'package:app_user/src/utils/share_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/apps/app_user/lib/src/features/payment/ui/payment_success_screen.dart
+++ b/apps/app_user/lib/src/features/payment/ui/payment_success_screen.dart
@@ -1,153 +1,145 @@
-import 'package:app_user/src/features/event/logic/event_coordinator.dart';
-import 'package:app_user/src/features/event/logic/event_detail_controller.dart';
-import 'package:app_user/src/features/home/logic/home_coordinator.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
-class PaymentSuccessScreen extends ConsumerWidget {
+// Fix #453: event/home coordinator 직접 참조 제거 — 콜백으로 전환하여 순환 참조 해소
+class PaymentSuccessScreen extends StatelessWidget {
   const PaymentSuccessScreen({
-    required this.eventId,
+    required this.event,
     required this.ticketId,
+    required this.onViewTickets,
+    required this.onBackToEvent,
     super.key,
   });
 
-  final String eventId;
+  final Event event;
   final String ticketId;
+  final VoidCallback onViewTickets;
+  final VoidCallback onBackToEvent;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final eventAsync = ref.watch(eventDetailControllerProvider(eventId));
-    final eventCoordinator = ref.read(eventCoordinatorProvider);
-    final homeCoordinator = ref.read(homeCoordinatorProvider);
+
+    final ticket = _findTicket();
+    final formatter = NumberFormat('#,###');
+    final dateLabel = DateFormat(
+      'M월 d일 (E) HH:mm',
+      'ko_KR',
+    ).format(event.startTime);
+    final location = event.location ?? event.party?.location;
 
     return Scaffold(
       appBar: AppBar(
         title: const Text('결제 완료'),
         leading: const CloseButton(),
       ),
-      body: MinglitAsyncValueWidget(
-        value: eventAsync,
-        data: (event) {
-          final ticket = _findTicket(event);
-          final formatter = NumberFormat('#,###');
-          final dateLabel = DateFormat(
-            'M월 d일 (E) HH:mm',
-            'ko_KR',
-          ).format(event.startTime);
-          final location = event.location ?? event.party?.location;
-
-          return SingleChildScrollView(
-            padding: const EdgeInsets.all(MinglitSpacing.large),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Container(
-                  padding: const EdgeInsets.all(MinglitSpacing.large),
-                  decoration: BoxDecoration(
-                    color: theme.colorScheme.primaryContainer,
-                    borderRadius: BorderRadius.circular(MinglitRadius.card),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(MinglitSpacing.large),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              padding: const EdgeInsets.all(MinglitSpacing.large),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.primaryContainer,
+                borderRadius: BorderRadius.circular(MinglitRadius.card),
+              ),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.check_circle,
+                    color: theme.colorScheme.primary,
+                    size: 36,
                   ),
-                  child: Row(
-                    children: [
-                      Icon(
-                        Icons.check_circle,
-                        color: theme.colorScheme.primary,
-                        size: 36,
-                      ),
-                      const SizedBox(width: MinglitSpacing.medium),
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              '결제가 완료되었습니다! ',
-                              style: theme.textTheme.titleMedium?.copyWith(
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                            const SizedBox(height: MinglitSpacing.xxsmall),
-                            Text(
-                              '내 티켓에서 확인하실 수 있어요.',
-                              style: theme.textTheme.bodySmall,
-                            ),
-                          ],
+                  const SizedBox(width: MinglitSpacing.medium),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          '결제가 완료되었습니다! ',
+                          style: theme.textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
-                      ),
-                    ],
+                        const SizedBox(height: MinglitSpacing.xxsmall),
+                        Text(
+                          '내 티켓에서 확인하실 수 있어요.',
+                          style: theme.textTheme.bodySmall,
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-                const SizedBox(height: MinglitSpacing.xlarge),
-                Text(
-                  '티켓 요약',
-                  style: theme.textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                const SizedBox(height: MinglitSpacing.medium),
-                Container(
-                  padding: const EdgeInsets.all(MinglitSpacing.medium),
-                  decoration: BoxDecoration(
-                    color: theme.colorScheme.surface,
-                    borderRadius: BorderRadius.circular(MinglitRadius.card),
-                    border: Border.all(color: theme.colorScheme.outlineVariant),
-                  ),
-                  child: Column(
-                    children: [
-                      _SummaryRow(
-                        label: '이벤트',
-                        value: event.title ?? '이벤트 정보 없음',
-                      ),
-                      _SummaryRow(
-                        label: '일시',
-                        value: dateLabel,
-                      ),
-                      _SummaryRow(
-                        label: '장소',
-                        value: location?.name ?? '장소 정보 없음',
-                      ),
-                      _SummaryRow(
-                        label: '티켓',
-                        value: ticket?.name ?? '티켓 정보 없음',
-                      ),
-                      _SummaryRow(
-                        label: '결제 금액',
-                        value: ticket == null
-                            ? '-'
-                            : '${formatter.format(ticket.price)}원',
-                        isLast: true,
-                      ),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: MinglitSpacing.xlarge),
-                SizedBox(
-                  width: double.infinity,
-                  child: ElevatedButton(
-                    onPressed: homeCoordinator.goToPurchaseHistory,
-                    child: const Text('내 티켓 보기'),
-                  ),
-                ),
-                const SizedBox(height: MinglitSpacing.small),
-                SizedBox(
-                  width: double.infinity,
-                  child: OutlinedButton(
-                    onPressed: () {
-                      eventCoordinator.goToEventDetail(eventId);
-                    },
-                    child: const Text('이벤트로 돌아가기'),
-                  ),
-                ),
-              ],
+                ],
+              ),
             ),
-          );
-        },
+            const SizedBox(height: MinglitSpacing.xlarge),
+            Text(
+              '티켓 요약',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: MinglitSpacing.medium),
+            Container(
+              padding: const EdgeInsets.all(MinglitSpacing.medium),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surface,
+                borderRadius: BorderRadius.circular(MinglitRadius.card),
+                border: Border.all(color: theme.colorScheme.outlineVariant),
+              ),
+              child: Column(
+                children: [
+                  _SummaryRow(
+                    label: '이벤트',
+                    value: event.title ?? '이벤트 정보 없음',
+                  ),
+                  _SummaryRow(
+                    label: '일시',
+                    value: dateLabel,
+                  ),
+                  _SummaryRow(
+                    label: '장소',
+                    value: location?.name ?? '장소 정보 없음',
+                  ),
+                  _SummaryRow(
+                    label: '티켓',
+                    value: ticket?.name ?? '티켓 정보 없음',
+                  ),
+                  _SummaryRow(
+                    label: '결제 금액',
+                    value: ticket == null
+                        ? '-'
+                        : '${formatter.format(ticket.price)}원',
+                    isLast: true,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: MinglitSpacing.xlarge),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: onViewTickets,
+                child: const Text('내 티켓 보기'),
+              ),
+            ),
+            const SizedBox(height: MinglitSpacing.small),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton(
+                onPressed: onBackToEvent,
+                child: const Text('이벤트로 돌아가기'),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
 
-  Ticket? _findTicket(Event event) {
+  Ticket? _findTicket() {
     final tickets = event.tickets ?? [];
     for (final ticket in tickets) {
       if (ticket.id == ticketId) {

--- a/apps/app_user/lib/src/features/ticket/logic/ticket_recommendation_util.dart
+++ b/apps/app_user/lib/src/features/ticket/logic/ticket_recommendation_util.dart
@@ -1,4 +1,4 @@
-part of 'event_admission_controller.dart';
+import 'package:minglit_kit/minglit_kit.dart';
 
 class TicketRecommendationResult {
   const TicketRecommendationResult({

--- a/apps/app_user/lib/src/features/ticket/ui/ticket_selection_sheet.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/ticket_selection_sheet.dart
@@ -1,17 +1,22 @@
 import 'dart:async';
 
-import 'package:app_user/src/features/event/admission/event_admission_controller.dart';
-import 'package:app_user/src/features/event/logic/event_coordinator.dart';
+import 'package:app_user/src/features/ticket/logic/ticket_recommendation_util.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
 part 'ticket_selection_widgets.dart';
 
+// Fix #453: onTicketSelected 콜백으로 event feature 의존 제거 — 순환 참조 해소
 class TicketSelectionSheet extends ConsumerStatefulWidget {
-  const TicketSelectionSheet({required this.event, super.key});
+  const TicketSelectionSheet({
+    required this.event,
+    required this.onTicketSelected,
+    super.key,
+  });
 
   final Event event;
+  final void Function(String eventId, String? ticketId) onTicketSelected;
 
   @override
   ConsumerState<TicketSelectionSheet> createState() =>
@@ -120,13 +125,8 @@ class _TicketSelectionSheetState extends ConsumerState<TicketSelectionSheet> {
     // Close sheet first
     Navigator.pop(context);
 
-    // Navigate to Application Wizard via Coordinator
-    ref
-        .read(eventCoordinatorProvider)
-        .goToApplicationWizard(
-          widget.event.id,
-          ticketId: _selectedTicketId,
-        );
+    // Fix #453: 콜백으로 네비게이션 위임 — event feature 직접 참조 제거
+    widget.onTicketSelected(widget.event.id, _selectedTicketId);
   }
 
   @override

--- a/apps/app_user/lib/src/logic/eligibility_filter.dart
+++ b/apps/app_user/lib/src/logic/eligibility_filter.dart
@@ -1,4 +1,4 @@
-import 'package:app_user/src/features/event/admission/event_admission_controller.dart';
+import 'package:app_user/src/features/ticket/logic/ticket_recommendation_util.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
 /// Parsed user eligibility data from `get_bulk_eligibility_data` RPC.

--- a/apps/app_user/test/src/features/event/admission/ticket_recommendation_util_test.dart
+++ b/apps/app_user/test/src/features/event/admission/ticket_recommendation_util_test.dart
@@ -1,4 +1,4 @@
-import 'package:app_user/src/features/event/admission/event_admission_controller.dart';
+import 'package:app_user/src/features/ticket/logic/ticket_recommendation_util.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 


### PR DESCRIPTION
## Summary

Closes #453

- **event ↔ ticket 순환 해소**: `TicketRecommendationUtil`을 `ticket/logic/`로 추출하고, `EventAdmissionController` ↔ `TicketSelectionSheet` 간 직접 참조를 콜백 패턴으로 전환
- **event → payment → event 순환 해소**: `PaymentSuccessScreen`에서 `EventCoordinator`/`EventDetailController`/`HomeCoordinator` import 제거. `Event` 객체와 네비게이션 콜백을 파라미터로 전달
- `PaymentSuccessScreen`을 `ConsumerWidget` → `StatelessWidget`으로 전환 (Riverpod 의존 불필요)

## 변경된 import 구조

| 파일 | Before | After |
|------|--------|-------|
| `ticket_selection_sheet.dart` | `event/admission/`, `event/logic/` | `ticket/logic/` (자체 feature만) |
| `event_admission_controller.dart` | `ticket/ui/` | 없음 (콜백 사용) |
| `payment_success_screen.dart` | `event/logic/`, `home/logic/` | 없음 (콜백 + Event 파라미터) |

## Test plan

- [x] `flutter analyze` — 에러/경고 없음 (기존 info만 존재)
- [x] `ticket_recommendation_util_test.dart` — 10개 전체 통과
- [x] `flow_admission_status_test.dart` — 전체 통과 (eligible 탭 → TicketSelectionSheet 포함)
- [x] `flow_ticket_application_test.dart` — 전체 통과
- [ ] CI `ci-result` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)