### PR TITLE
fix: 에러 삼킴 catch 블록에 Log.e() 로깅 추가 (3건)

### DIFF
--- a/apps/app_partner/lib/src/features/settlement/bank_account_page.dart
+++ b/apps/app_partner/lib/src/features/settlement/bank_account_page.dart
@@ -37,7 +37,7 @@ class _BankAccountPageState extends ConsumerState<BankAccountPage> {
           _isLoading = false;
         });
       }
-    // Fix #459: 계좌 로딩 실패 시 에러 로깅 추가 — 프로덕션 장애 추적 불가 방지
+      // Fix #459: 계좌 로딩 실패 시 에러 로깅 추가 — 프로덕션 장애 추적 불가 방지
     } on Exception catch (e, st) {
       Log.e('[BankAccountPage] _loadAccount failed', e, st);
       if (mounted) setState(() => _isLoading = false);

--- a/apps/app_partner/lib/src/features/settlement/bank_account_page.dart
+++ b/apps/app_partner/lib/src/features/settlement/bank_account_page.dart
@@ -37,7 +37,9 @@ class _BankAccountPageState extends ConsumerState<BankAccountPage> {
           _isLoading = false;
         });
       }
-    } on Exception catch (_) {
+    // Fix #459: 계좌 로딩 실패 시 에러 로깅 추가 — 프로덕션 장애 추적 불가 방지
+    } on Exception catch (e, st) {
+      Log.e('[BankAccountPage] _loadAccount failed', e, st);
       if (mounted) setState(() => _isLoading = false);
     }
   }

--- a/apps/app_user/lib/src/features/event/detail/report_bottom_sheet.dart
+++ b/apps/app_user/lib/src/features/event/detail/report_bottom_sheet.dart
@@ -59,7 +59,9 @@ class _ReportSheetState extends ConsumerState<_ReportSheet> {
           const SnackBar(content: Text('신고가 접수되었습니다')),
         );
       }
-    } on Object catch (_) {
+    // Fix #459: 신고 실패 시 에러 로깅 추가 + catch 범위를 Exception으로 축소
+    } on Exception catch (e, st) {
+      Log.e('[ReportBottomSheet] _submit failed', e, st);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('신고 처리 중 오류가 발생했습니다')),

--- a/apps/app_user/lib/src/features/event/detail/report_bottom_sheet.dart
+++ b/apps/app_user/lib/src/features/event/detail/report_bottom_sheet.dart
@@ -59,7 +59,7 @@ class _ReportSheetState extends ConsumerState<_ReportSheet> {
           const SnackBar(content: Text('신고가 접수되었습니다')),
         );
       }
-    // Fix #459: 신고 실패 시 에러 로깅 추가 + catch 범위를 Exception으로 축소
+      // Fix #459: 신고 실패 시 에러 로깅 추가 + catch 범위를 Exception으로 축소
     } on Exception catch (e, st) {
       Log.e('[ReportBottomSheet] _submit failed', e, st);
       if (mounted) {

--- a/apps/app_user/lib/src/features/ticket/ui/ticket_selection_sheet.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/ticket_selection_sheet.dart
@@ -58,7 +58,7 @@ class _TicketSelectionSheetState extends ConsumerState<TicketSelectionSheet> {
         _isBalanceStatusLoading = false;
       });
       _updateRecommendation();
-    // Fix #459: 잔액 조회 실패 시 에러 로깅 추가 — 프로덕션 장애 추적 불가 방지
+      // Fix #459: 잔액 조회 실패 시 에러 로깅 추가 — 프로덕션 장애 추적 불가 방지
     } on Exception catch (e, st) {
       Log.e('[TicketSelectionSheet] _fetchBalanceStatus failed', e, st);
       if (!mounted) return;

--- a/apps/app_user/lib/src/features/ticket/ui/ticket_selection_sheet.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/ticket_selection_sheet.dart
@@ -58,7 +58,9 @@ class _TicketSelectionSheetState extends ConsumerState<TicketSelectionSheet> {
         _isBalanceStatusLoading = false;
       });
       _updateRecommendation();
-    } on Exception catch (_) {
+    // Fix #459: 잔액 조회 실패 시 에러 로깅 추가 — 프로덕션 장애 추적 불가 방지
+    } on Exception catch (e, st) {
+      Log.e('[TicketSelectionSheet] _fetchBalanceStatus failed', e, st);
       if (!mounted) return;
       setState(() => _isBalanceStatusLoading = false);
       _updateRecommendation();


### PR DESCRIPTION
## Summary
- 정산 계좌 로딩(`bank_account_page.dart`), 티켓 잔액 조회(`ticket_selection_sheet.dart`), 파트너 신고(`report_bottom_sheet.dart`) — 3개 catch 블록에 `Log.e()` 추가
- `report_bottom_sheet.dart`의 `on Object catch`를 `on Exception catch`로 축소
- 프로덕션 장애 발생 시 원인 추적 가능하도록 에러 + 스택트레이스 로깅

Closes #459

## Test plan
- [x] `flutter analyze` 통과 (app_partner, app_user)
- [ ] CI `ci-result` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)