### PR TITLE
chore: MinglitOpacity 토큰 클래스 추가 및 인라인 alpha 값 치환

### DIFF
--- a/apps/app_partner/lib/src/features/checkin/qr_scanner_screen.dart
+++ b/apps/app_partner/lib/src/features/checkin/qr_scanner_screen.dart
@@ -31,9 +31,9 @@ class _QRScannerScreenState extends ConsumerState<QRScannerScreen> {
 
     Color? overlayColor;
     if (state.result == CheckinResult.success) {
-      overlayColor = MinglitColors.success.withValues(alpha: 0.8);
+      overlayColor = MinglitColors.success.withValues(alpha: MinglitOpacity.scrimLight);
     } else if (state.result != CheckinResult.idle) {
-      overlayColor = theme.colorScheme.error.withValues(alpha: 0.8);
+      overlayColor = theme.colorScheme.error.withValues(alpha: MinglitOpacity.scrimLight);
     }
 
     return Scaffold(

--- a/apps/app_partner/lib/src/features/checkin/qr_scanner_screen.dart
+++ b/apps/app_partner/lib/src/features/checkin/qr_scanner_screen.dart
@@ -31,9 +31,13 @@ class _QRScannerScreenState extends ConsumerState<QRScannerScreen> {
 
     Color? overlayColor;
     if (state.result == CheckinResult.success) {
-      overlayColor = MinglitColors.success.withValues(alpha: MinglitOpacity.scrimLight);
+      overlayColor = MinglitColors.success.withValues(
+        alpha: MinglitOpacity.scrimLight,
+      );
     } else if (state.result != CheckinResult.idle) {
-      overlayColor = theme.colorScheme.error.withValues(alpha: MinglitOpacity.scrimLight);
+      overlayColor = theme.colorScheme.error.withValues(
+        alpha: MinglitOpacity.scrimLight,
+      );
     }
 
     return Scaffold(

--- a/apps/app_partner/lib/src/features/home/widgets/closing_soon_events_card.dart
+++ b/apps/app_partner/lib/src/features/home/widgets/closing_soon_events_card.dart
@@ -23,7 +23,7 @@ class ClosingSoonEventsCard extends StatelessWidget {
 
     return Card(
       elevation: 0,
-      color: colorScheme.errorContainer.withValues(alpha: 0.3),
+      color: colorScheme.errorContainer.withValues(alpha: MinglitOpacity.muted),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(MinglitRadius.card),
       ),

--- a/apps/app_partner/lib/src/features/party/create/steps/step4_entry_rules.dart
+++ b/apps/app_partner/lib/src/features/party/create/steps/step4_entry_rules.dart
@@ -130,7 +130,7 @@ class Step4EntryRules extends ConsumerWidget {
     return Container(
       padding: const EdgeInsets.all(MinglitSpacing.large),
       decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: MinglitOpacity.muted),
         borderRadius: BorderRadius.circular(MinglitRadius.card),
         border: Border.all(color: theme.colorScheme.outlineVariant),
       ),

--- a/apps/app_partner/lib/src/features/party/create/steps/step4_entry_rules.dart
+++ b/apps/app_partner/lib/src/features/party/create/steps/step4_entry_rules.dart
@@ -130,7 +130,9 @@ class Step4EntryRules extends ConsumerWidget {
     return Container(
       padding: const EdgeInsets.all(MinglitSpacing.large),
       decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: MinglitOpacity.muted),
+        color: theme.colorScheme.surfaceContainerHighest.withValues(
+          alpha: MinglitOpacity.muted,
+        ),
         borderRadius: BorderRadius.circular(MinglitRadius.card),
         border: Border.all(color: theme.colorScheme.outlineVariant),
       ),

--- a/apps/app_partner/lib/src/features/party/create/steps/step6_review.dart
+++ b/apps/app_partner/lib/src/features/party/create/steps/step6_review.dart
@@ -130,7 +130,9 @@ class Step6Review extends ConsumerWidget {
       decoration: BoxDecoration(
         color: colorScheme.errorContainer.withValues(alpha: 0.1),
         borderRadius: BorderRadius.circular(MinglitRadius.card),
-        border: Border.all(color: colorScheme.error.withValues(alpha: MinglitOpacity.muted)),
+        border: Border.all(
+          color: colorScheme.error.withValues(alpha: MinglitOpacity.muted),
+        ),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/apps/app_partner/lib/src/features/party/create/steps/step6_review.dart
+++ b/apps/app_partner/lib/src/features/party/create/steps/step6_review.dart
@@ -130,7 +130,7 @@ class Step6Review extends ConsumerWidget {
       decoration: BoxDecoration(
         color: colorScheme.errorContainer.withValues(alpha: 0.1),
         borderRadius: BorderRadius.circular(MinglitRadius.card),
-        border: Border.all(color: colorScheme.error.withValues(alpha: 0.3)),
+        border: Border.all(color: colorScheme.error.withValues(alpha: MinglitOpacity.muted)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/apps/app_partner/lib/src/features/party/event/create/event_create_page.dart
+++ b/apps/app_partner/lib/src/features/party/event/create/event_create_page.dart
@@ -110,7 +110,9 @@ class _EventCreatePageState extends ConsumerState<EventCreatePage> {
                 color: theme.scaffoldBackgroundColor,
                 boxShadow: [
                   BoxShadow(
-                    color: theme.shadowColor.withValues(alpha: MinglitOpacity.tintFill),
+                    color: theme.shadowColor.withValues(
+                      alpha: MinglitOpacity.tintFill,
+                    ),
                     blurRadius: 10,
                     offset: const Offset(0, -4),
                   ),

--- a/apps/app_partner/lib/src/features/party/event/create/event_create_page.dart
+++ b/apps/app_partner/lib/src/features/party/event/create/event_create_page.dart
@@ -110,7 +110,7 @@ class _EventCreatePageState extends ConsumerState<EventCreatePage> {
                 color: theme.scaffoldBackgroundColor,
                 boxShadow: [
                   BoxShadow(
-                    color: theme.shadowColor.withValues(alpha: 0.05),
+                    color: theme.shadowColor.withValues(alpha: MinglitOpacity.tintFill),
                     blurRadius: 10,
                     offset: const Offset(0, -4),
                   ),

--- a/apps/app_partner/lib/src/features/party/event/widgets/ticket_list_item.dart
+++ b/apps/app_partner/lib/src/features/party/event/widgets/ticket_list_item.dart
@@ -319,7 +319,9 @@ class TicketListView extends StatelessWidget {
       width: double.infinity,
       padding: const EdgeInsets.all(MinglitSpacing.large),
       decoration: BoxDecoration(
-        color: colorScheme.surfaceContainerHighest.withValues(alpha: MinglitOpacity.muted),
+        color: colorScheme.surfaceContainerHighest.withValues(
+          alpha: MinglitOpacity.muted,
+        ),
         borderRadius: BorderRadius.circular(MinglitRadius.card),
       ),
       child: Column(

--- a/apps/app_partner/lib/src/features/party/event/widgets/ticket_list_item.dart
+++ b/apps/app_partner/lib/src/features/party/event/widgets/ticket_list_item.dart
@@ -319,7 +319,7 @@ class TicketListView extends StatelessWidget {
       width: double.infinity,
       padding: const EdgeInsets.all(MinglitSpacing.large),
       decoration: BoxDecoration(
-        color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        color: colorScheme.surfaceContainerHighest.withValues(alpha: MinglitOpacity.muted),
         borderRadius: BorderRadius.circular(MinglitRadius.card),
       ),
       child: Column(

--- a/apps/app_partner/lib/src/features/party/list/widgets/party_list_item.dart
+++ b/apps/app_partner/lib/src/features/party/list/widgets/party_list_item.dart
@@ -176,7 +176,7 @@ class PartyListItem extends StatelessWidget {
       child: Center(
         child: Icon(
           Icons.party_mode,
-          color: theme.colorScheme.surface.withValues(alpha: 0.2),
+          color: theme.colorScheme.surface.withValues(alpha: MinglitOpacity.placeholder),
           size: MinglitIconSize.xlarge * 1.5,
         ),
       ),
@@ -246,7 +246,7 @@ class _InfoChip extends StatelessWidget {
         color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
         borderRadius: BorderRadius.circular(100),
         border: Border.all(
-          color: theme.colorScheme.surface.withValues(alpha: 0.2),
+          color: theme.colorScheme.surface.withValues(alpha: MinglitOpacity.placeholder),
           width: 0.5,
         ),
       ),

--- a/apps/app_partner/lib/src/features/party/list/widgets/party_list_item.dart
+++ b/apps/app_partner/lib/src/features/party/list/widgets/party_list_item.dart
@@ -176,7 +176,9 @@ class PartyListItem extends StatelessWidget {
       child: Center(
         child: Icon(
           Icons.party_mode,
-          color: theme.colorScheme.surface.withValues(alpha: MinglitOpacity.placeholder),
+          color: theme.colorScheme.surface.withValues(
+            alpha: MinglitOpacity.placeholder,
+          ),
           size: MinglitIconSize.xlarge * 1.5,
         ),
       ),
@@ -246,7 +248,9 @@ class _InfoChip extends StatelessWidget {
         color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
         borderRadius: BorderRadius.circular(100),
         border: Border.all(
-          color: theme.colorScheme.surface.withValues(alpha: MinglitOpacity.placeholder),
+          color: theme.colorScheme.surface.withValues(
+            alpha: MinglitOpacity.placeholder,
+          ),
           width: 0.5,
         ),
       ),

--- a/apps/app_partner/lib/src/features/party/ticket/ui/ticket_manage_screen.dart
+++ b/apps/app_partner/lib/src/features/party/ticket/ui/ticket_manage_screen.dart
@@ -156,7 +156,9 @@ class _TicketManageCard extends ConsumerWidget {
       decoration: BoxDecoration(
         color: color.withValues(alpha: 0.1),
         borderRadius: BorderRadius.circular(MinglitRadius.small),
-        border: Border.all(color: color.withValues(alpha: MinglitOpacity.placeholder)),
+        border: Border.all(
+          color: color.withValues(alpha: MinglitOpacity.placeholder),
+        ),
       ),
       child: Text(
         label,

--- a/apps/app_partner/lib/src/features/party/ticket/ui/ticket_manage_screen.dart
+++ b/apps/app_partner/lib/src/features/party/ticket/ui/ticket_manage_screen.dart
@@ -156,7 +156,7 @@ class _TicketManageCard extends ConsumerWidget {
       decoration: BoxDecoration(
         color: color.withValues(alpha: 0.1),
         borderRadius: BorderRadius.circular(MinglitRadius.small),
-        border: Border.all(color: color.withValues(alpha: 0.2)),
+        border: Border.all(color: color.withValues(alpha: MinglitOpacity.placeholder)),
       ),
       child: Text(
         label,

--- a/apps/app_partner/lib/src/features/party/ticket/widgets/party_tickets_summary.dart
+++ b/apps/app_partner/lib/src/features/party/ticket/widgets/party_tickets_summary.dart
@@ -38,7 +38,9 @@ class PartyTicketsSummary extends StatelessWidget {
           color: theme.colorScheme.errorContainer.withValues(alpha: 0.1),
           borderRadius: BorderRadius.circular(MinglitRadius.card),
           border: Border.all(
-            color: theme.colorScheme.error.withValues(alpha: MinglitOpacity.muted),
+            color: theme.colorScheme.error.withValues(
+              alpha: MinglitOpacity.muted,
+            ),
           ),
         ),
         child: Text(

--- a/apps/app_partner/lib/src/features/party/ticket/widgets/party_tickets_summary.dart
+++ b/apps/app_partner/lib/src/features/party/ticket/widgets/party_tickets_summary.dart
@@ -38,7 +38,7 @@ class PartyTicketsSummary extends StatelessWidget {
           color: theme.colorScheme.errorContainer.withValues(alpha: 0.1),
           borderRadius: BorderRadius.circular(MinglitRadius.card),
           border: Border.all(
-            color: theme.colorScheme.error.withValues(alpha: 0.3),
+            color: theme.colorScheme.error.withValues(alpha: MinglitOpacity.muted),
           ),
         ),
         child: Text(

--- a/apps/app_partner/lib/src/features/party/widgets/party_basic_info_summary.dart
+++ b/apps/app_partner/lib/src/features/party/widgets/party_basic_info_summary.dart
@@ -118,7 +118,9 @@ class _PartyBasicInfoSummaryState extends State<PartyBasicInfoSummary> {
                       color: resolvedStatusColor.withValues(alpha: 0.1),
                       borderRadius: BorderRadius.circular(MinglitRadius.small),
                       border: Border.all(
-                        color: resolvedStatusColor.withValues(alpha: MinglitOpacity.muted),
+                        color: resolvedStatusColor.withValues(
+                          alpha: MinglitOpacity.muted,
+                        ),
                       ),
                     ),
                     child: Text(

--- a/apps/app_partner/lib/src/features/party/widgets/party_basic_info_summary.dart
+++ b/apps/app_partner/lib/src/features/party/widgets/party_basic_info_summary.dart
@@ -118,7 +118,7 @@ class _PartyBasicInfoSummaryState extends State<PartyBasicInfoSummary> {
                       color: resolvedStatusColor.withValues(alpha: 0.1),
                       borderRadius: BorderRadius.circular(MinglitRadius.small),
                       border: Border.all(
-                        color: resolvedStatusColor.withValues(alpha: 0.3),
+                        color: resolvedStatusColor.withValues(alpha: MinglitOpacity.muted),
                       ),
                     ),
                     child: Text(

--- a/apps/app_partner/lib/src/features/party/widgets/party_entrance_condition_summary.dart
+++ b/apps/app_partner/lib/src/features/party/widgets/party_entrance_condition_summary.dart
@@ -22,7 +22,9 @@ class PartyEntranceConditionSummary extends ConsumerWidget {
         width: double.infinity,
         padding: const EdgeInsets.all(MinglitSpacing.large),
         decoration: BoxDecoration(
-          color: colorScheme.surfaceContainerHighest.withValues(alpha: MinglitOpacity.muted),
+          color: colorScheme.surfaceContainerHighest.withValues(
+            alpha: MinglitOpacity.muted,
+          ),
           borderRadius: BorderRadius.circular(MinglitRadius.card),
         ),
         child: Column(

--- a/apps/app_partner/lib/src/features/party/widgets/party_entrance_condition_summary.dart
+++ b/apps/app_partner/lib/src/features/party/widgets/party_entrance_condition_summary.dart
@@ -22,7 +22,7 @@ class PartyEntranceConditionSummary extends ConsumerWidget {
         width: double.infinity,
         padding: const EdgeInsets.all(MinglitSpacing.large),
         decoration: BoxDecoration(
-          color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+          color: colorScheme.surfaceContainerHighest.withValues(alpha: MinglitOpacity.muted),
           borderRadius: BorderRadius.circular(MinglitRadius.card),
         ),
         child: Column(

--- a/apps/app_partner/lib/src/features/party/widgets/party_location_detail_input.dart
+++ b/apps/app_partner/lib/src/features/party/widgets/party_location_detail_input.dart
@@ -42,7 +42,9 @@ class PartyLocationDetailInput extends StatelessWidget {
                 : '장소를 먼저 선택해주세요.',
             fillColor: enabled
                 ? null
-                : colorScheme.surfaceContainerHighest.withValues(alpha: MinglitOpacity.muted),
+                : colorScheme.surfaceContainerHighest.withValues(
+                    alpha: MinglitOpacity.muted,
+                  ),
             filled: true,
           ),
           onChanged: onAddressDetailChanged,
@@ -64,7 +66,9 @@ class PartyLocationDetailInput extends StatelessWidget {
                 : '장소를 먼저 선택해주세요.',
             fillColor: enabled
                 ? null
-                : colorScheme.surfaceContainerHighest.withValues(alpha: MinglitOpacity.muted),
+                : colorScheme.surfaceContainerHighest.withValues(
+                    alpha: MinglitOpacity.muted,
+                  ),
             filled: true,
           ),
           maxLines: 3,

--- a/apps/app_partner/lib/src/features/party/widgets/party_location_detail_input.dart
+++ b/apps/app_partner/lib/src/features/party/widgets/party_location_detail_input.dart
@@ -42,7 +42,7 @@ class PartyLocationDetailInput extends StatelessWidget {
                 : '장소를 먼저 선택해주세요.',
             fillColor: enabled
                 ? null
-                : colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+                : colorScheme.surfaceContainerHighest.withValues(alpha: MinglitOpacity.muted),
             filled: true,
           ),
           onChanged: onAddressDetailChanged,
@@ -64,7 +64,7 @@ class PartyLocationDetailInput extends StatelessWidget {
                 : '장소를 먼저 선택해주세요.',
             fillColor: enabled
                 ? null
-                : colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+                : colorScheme.surfaceContainerHighest.withValues(alpha: MinglitOpacity.muted),
             filled: true,
           ),
           maxLines: 3,

--- a/apps/app_partner/lib/src/features/party/widgets/party_location_input.dart
+++ b/apps/app_partner/lib/src/features/party/widgets/party_location_input.dart
@@ -28,7 +28,7 @@ class _PartyLocationInputState extends State<PartyLocationInput> {
         Container(
           height: 200,
           decoration: BoxDecoration(
-            color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+            color: colorScheme.surfaceContainerHighest.withValues(alpha: MinglitOpacity.muted),
             borderRadius: BorderRadius.circular(MinglitRadius.card),
             border: Border.all(
               color: colorScheme.outlineVariant.withValues(alpha: 0.5),

--- a/apps/app_partner/lib/src/features/party/widgets/party_location_input.dart
+++ b/apps/app_partner/lib/src/features/party/widgets/party_location_input.dart
@@ -28,7 +28,9 @@ class _PartyLocationInputState extends State<PartyLocationInput> {
         Container(
           height: 200,
           decoration: BoxDecoration(
-            color: colorScheme.surfaceContainerHighest.withValues(alpha: MinglitOpacity.muted),
+            color: colorScheme.surfaceContainerHighest.withValues(
+              alpha: MinglitOpacity.muted,
+            ),
             borderRadius: BorderRadius.circular(MinglitRadius.card),
             border: Border.all(
               color: colorScheme.outlineVariant.withValues(alpha: 0.5),

--- a/apps/app_partner/lib/src/features/party/widgets/party_verification_input.dart
+++ b/apps/app_partner/lib/src/features/party/widgets/party_verification_input.dart
@@ -107,7 +107,7 @@ class PartyVerificationInput extends StatelessWidget {
                                 '원하는 참가 자격이 없다면 직접 만들어보세요.',
                                 style: theme.textTheme.bodySmall?.copyWith(
                                   color: colorScheme.onSurfaceVariant
-                                      .withValues(alpha: 0.8),
+                                      .withValues(alpha: MinglitOpacity.scrimLight),
                                 ),
                               ),
                             ],

--- a/apps/app_partner/lib/src/features/party/widgets/party_verification_input.dart
+++ b/apps/app_partner/lib/src/features/party/widgets/party_verification_input.dart
@@ -107,7 +107,9 @@ class PartyVerificationInput extends StatelessWidget {
                                 '원하는 참가 자격이 없다면 직접 만들어보세요.',
                                 style: theme.textTheme.bodySmall?.copyWith(
                                   color: colorScheme.onSurfaceVariant
-                                      .withValues(alpha: MinglitOpacity.scrimLight),
+                                      .withValues(
+                                        alpha: MinglitOpacity.scrimLight,
+                                      ),
                                 ),
                               ),
                             ],

--- a/apps/app_partner/lib/src/features/ticket/widgets/ticket_form.dart
+++ b/apps/app_partner/lib/src/features/ticket/widgets/ticket_form.dart
@@ -200,7 +200,7 @@ class _TicketFormState extends State<TicketForm> {
     return Container(
       padding: const EdgeInsets.all(MinglitSpacing.medium),
       decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: MinglitOpacity.muted),
         borderRadius: BorderRadius.circular(MinglitRadius.card),
       ),
       child: Text(context.l10n.ticket_empty_groups),

--- a/apps/app_partner/lib/src/features/ticket/widgets/ticket_form.dart
+++ b/apps/app_partner/lib/src/features/ticket/widgets/ticket_form.dart
@@ -200,7 +200,9 @@ class _TicketFormState extends State<TicketForm> {
     return Container(
       padding: const EdgeInsets.all(MinglitSpacing.medium),
       decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: MinglitOpacity.muted),
+        color: theme.colorScheme.surfaceContainerHighest.withValues(
+          alpha: MinglitOpacity.muted,
+        ),
         borderRadius: BorderRadius.circular(MinglitRadius.card),
       ),
       child: Text(context.l10n.ticket_empty_groups),

--- a/apps/app_partner/lib/src/features/verification/create/create_verification_page.dart
+++ b/apps/app_partner/lib/src/features/verification/create/create_verification_page.dart
@@ -166,7 +166,9 @@ class _CreateVerificationPageState
             padding: const EdgeInsets.all(MinglitSpacing.xlarge),
             alignment: Alignment.center,
             decoration: BoxDecoration(
-              color: colorScheme.surfaceContainerHighest.withValues(alpha: MinglitOpacity.muted),
+              color: colorScheme.surfaceContainerHighest.withValues(
+                alpha: MinglitOpacity.muted,
+              ),
               borderRadius: BorderRadius.circular(MinglitSpacing.small),
               border: Border.all(color: colorScheme.outlineVariant),
             ),

--- a/apps/app_partner/lib/src/features/verification/create/create_verification_page.dart
+++ b/apps/app_partner/lib/src/features/verification/create/create_verification_page.dart
@@ -166,7 +166,7 @@ class _CreateVerificationPageState
             padding: const EdgeInsets.all(MinglitSpacing.xlarge),
             alignment: Alignment.center,
             decoration: BoxDecoration(
-              color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+              color: colorScheme.surfaceContainerHighest.withValues(alpha: MinglitOpacity.muted),
               borderRadius: BorderRadius.circular(MinglitSpacing.small),
               border: Border.all(color: colorScheme.outlineVariant),
             ),

--- a/apps/app_user/lib/src/features/event/detail/event_refund_policy_section.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_refund_policy_section.dart
@@ -111,7 +111,9 @@ class _RefundPolicySection extends ConsumerWidget {
       width: double.infinity,
       padding: const EdgeInsets.all(MinglitSpacing.small),
       decoration: BoxDecoration(
-        color: theme.colorScheme.primaryContainer.withValues(alpha: MinglitOpacity.muted),
+        color: theme.colorScheme.primaryContainer.withValues(
+          alpha: MinglitOpacity.muted,
+        ),
         borderRadius: BorderRadius.circular(MinglitRadius.card),
       ),
       child: Row(
@@ -158,7 +160,9 @@ class _RefundPolicySection extends ConsumerWidget {
       width: double.infinity,
       padding: const EdgeInsets.all(MinglitSpacing.small),
       decoration: BoxDecoration(
-        color: theme.colorScheme.secondaryContainer.withValues(alpha: MinglitOpacity.muted),
+        color: theme.colorScheme.secondaryContainer.withValues(
+          alpha: MinglitOpacity.muted,
+        ),
         borderRadius: BorderRadius.circular(MinglitRadius.card),
       ),
       child: Row(

--- a/apps/app_user/lib/src/features/event/detail/event_refund_policy_section.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_refund_policy_section.dart
@@ -111,7 +111,7 @@ class _RefundPolicySection extends ConsumerWidget {
       width: double.infinity,
       padding: const EdgeInsets.all(MinglitSpacing.small),
       decoration: BoxDecoration(
-        color: theme.colorScheme.primaryContainer.withValues(alpha: 0.3),
+        color: theme.colorScheme.primaryContainer.withValues(alpha: MinglitOpacity.muted),
         borderRadius: BorderRadius.circular(MinglitRadius.card),
       ),
       child: Row(
@@ -158,7 +158,7 @@ class _RefundPolicySection extends ConsumerWidget {
       width: double.infinity,
       padding: const EdgeInsets.all(MinglitSpacing.small),
       decoration: BoxDecoration(
-        color: theme.colorScheme.secondaryContainer.withValues(alpha: 0.3),
+        color: theme.colorScheme.secondaryContainer.withValues(alpha: MinglitOpacity.muted),
         borderRadius: BorderRadius.circular(MinglitRadius.card),
       ),
       child: Row(

--- a/apps/app_user/lib/src/features/event/matching/matching_vote_screen.dart
+++ b/apps/app_user/lib/src/features/event/matching/matching_vote_screen.dart
@@ -248,7 +248,7 @@ class MatchingVoteScreen extends ConsumerWidget {
           if (isVoted)
             Positioned.fill(
               child: ColoredBox(
-                color: theme.colorScheme.primary.withValues(alpha: 0.2),
+                color: theme.colorScheme.primary.withValues(alpha: MinglitOpacity.placeholder),
                 child: Center(
                   child: Icon(
                     Icons.check_circle,

--- a/apps/app_user/lib/src/features/event/matching/matching_vote_screen.dart
+++ b/apps/app_user/lib/src/features/event/matching/matching_vote_screen.dart
@@ -248,7 +248,9 @@ class MatchingVoteScreen extends ConsumerWidget {
           if (isVoted)
             Positioned.fill(
               child: ColoredBox(
-                color: theme.colorScheme.primary.withValues(alpha: MinglitOpacity.placeholder),
+                color: theme.colorScheme.primary.withValues(
+                  alpha: MinglitOpacity.placeholder,
+                ),
                 child: Center(
                   child: Icon(
                     Icons.check_circle,

--- a/apps/app_user/lib/src/features/ticket/ui/ticket_selection_widgets.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/ticket_selection_widgets.dart
@@ -36,7 +36,9 @@ extension _TicketSelectionWidgets on _TicketSelectionSheetState {
                   ),
                   borderRadius: BorderRadius.circular(MinglitRadius.input),
                   color: isSelected
-                      ? theme.colorScheme.primary.withValues(alpha: MinglitOpacity.tintFill)
+                      ? theme.colorScheme.primary.withValues(
+                          alpha: MinglitOpacity.tintFill,
+                        )
                       : theme.colorScheme.surface,
                 ),
                 child: Row(

--- a/apps/app_user/lib/src/features/ticket/ui/ticket_selection_widgets.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/ticket_selection_widgets.dart
@@ -36,7 +36,7 @@ extension _TicketSelectionWidgets on _TicketSelectionSheetState {
                   ),
                   borderRadius: BorderRadius.circular(MinglitRadius.input),
                   color: isSelected
-                      ? theme.colorScheme.primary.withValues(alpha: 0.05)
+                      ? theme.colorScheme.primary.withValues(alpha: MinglitOpacity.tintFill)
                       : theme.colorScheme.surface,
                 ),
                 child: Row(

--- a/shared/packages/minglit_kit/lib/src/features/auth/ui/staff_gate_screen.dart
+++ b/shared/packages/minglit_kit/lib/src/features/auth/ui/staff_gate_screen.dart
@@ -108,8 +108,8 @@ class _StaffGateScreenState extends ConsumerState<StaffGateScreen> {
                     ),
                     decoration: BoxDecoration(
                       color: _message!.contains('발송되었습니다')
-                          ? colorScheme.primaryContainer.withValues(alpha: 0.3)
-                          : colorScheme.errorContainer.withValues(alpha: 0.3),
+                          ? colorScheme.primaryContainer.withValues(alpha: MinglitOpacity.muted)
+                          : colorScheme.errorContainer.withValues(alpha: MinglitOpacity.muted),
                       borderRadius: BorderRadius.circular(MinglitRadius.input),
                     ),
                     child: Text(

--- a/shared/packages/minglit_kit/lib/src/features/auth/ui/staff_gate_screen.dart
+++ b/shared/packages/minglit_kit/lib/src/features/auth/ui/staff_gate_screen.dart
@@ -108,8 +108,12 @@ class _StaffGateScreenState extends ConsumerState<StaffGateScreen> {
                     ),
                     decoration: BoxDecoration(
                       color: _message!.contains('발송되었습니다')
-                          ? colorScheme.primaryContainer.withValues(alpha: MinglitOpacity.muted)
-                          : colorScheme.errorContainer.withValues(alpha: MinglitOpacity.muted),
+                          ? colorScheme.primaryContainer.withValues(
+                              alpha: MinglitOpacity.muted,
+                            )
+                          : colorScheme.errorContainer.withValues(
+                              alpha: MinglitOpacity.muted,
+                            ),
                       borderRadius: BorderRadius.circular(MinglitRadius.input),
                     ),
                     child: Text(

--- a/shared/packages/minglit_kit/lib/src/features/dev/dev_user_switch_screen.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/dev_user_switch_screen.dart
@@ -136,11 +136,11 @@ class _DevUserSwitchScreenState extends ConsumerState<DevUserSwitchScreen> {
 
         final (Color roleColor, String roleLabel) = switch (username) {
           String u when u.startsWith('partner_owner') => (
-            MinglitColors.warning.withValues(alpha: 0.3),
+            MinglitColors.warning.withValues(alpha: MinglitOpacity.muted),
             'Owner',
           ),
           String u when u.startsWith('partner_') => (
-            MinglitColors.primary.withValues(alpha: 0.2),
+            MinglitColors.primary.withValues(alpha: MinglitOpacity.placeholder),
             'Partner',
           ),
           String u when u.startsWith('staff_') => (

--- a/shared/packages/minglit_kit/lib/src/features/dev/widgets/party_detail_view.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/widgets/party_detail_view.dart
@@ -232,7 +232,7 @@ class PartyDetailView extends ConsumerWidget {
         color: theme.colorScheme.surface,
         boxShadow: [
           BoxShadow(
-            color: theme.shadowColor.withValues(alpha: 0.05),
+            color: theme.shadowColor.withValues(alpha: MinglitOpacity.tintFill),
             blurRadius: 10,
             offset: const Offset(0, -5),
           ),

--- a/shared/packages/minglit_kit/lib/src/features/notification/notification_list_screen.dart
+++ b/shared/packages/minglit_kit/lib/src/features/notification/notification_list_screen.dart
@@ -78,7 +78,7 @@ class NotificationListScreen extends ConsumerWidget {
                   child: ListTile(
                     tileColor: isRead
                         ? null
-                        : theme.colorScheme.primary.withValues(alpha: 0.05),
+                        : theme.colorScheme.primary.withValues(alpha: MinglitOpacity.tintFill),
                     title: Text(
                       title,
                       style: theme.textTheme.bodyMedium!.copyWith(

--- a/shared/packages/minglit_kit/lib/src/features/notification/notification_list_screen.dart
+++ b/shared/packages/minglit_kit/lib/src/features/notification/notification_list_screen.dart
@@ -78,7 +78,9 @@ class NotificationListScreen extends ConsumerWidget {
                   child: ListTile(
                     tileColor: isRead
                         ? null
-                        : theme.colorScheme.primary.withValues(alpha: MinglitOpacity.tintFill),
+                        : theme.colorScheme.primary.withValues(
+                            alpha: MinglitOpacity.tintFill,
+                          ),
                     title: Text(
                       title,
                       style: theme.textTheme.bodyMedium!.copyWith(

--- a/shared/packages/minglit_kit/lib/src/theme/minglit_design_tokens.dart
+++ b/shared/packages/minglit_kit/lib/src/theme/minglit_design_tokens.dart
@@ -121,6 +121,24 @@ class MinglitIconSize {
   static const double xlarge = 32;
 }
 
+/// Opacity constants for consistent transparency values.
+class MinglitOpacity {
+  /// 0.05 — very subtle tint fills and divider backgrounds.
+  static const double tintFill = 0.05;
+
+  /// 0.2 — placeholder text and disabled visuals.
+  static const double placeholder = 0.2;
+
+  /// 0.3 — muted/secondary elements and dimmed states.
+  static const double muted = 0.3;
+
+  /// 0.55 — overlay cards and badge backgrounds.
+  static const double overlay = 0.55;
+
+  /// 0.8 — heavy scrims for modals and scanner overlays.
+  static const double scrimLight = 0.8;
+}
+
 /// Animation duration constants.
 class MinglitAnimation {
   /// 200ms fast animation duration.

--- a/shared/packages/minglit_kit/lib/src/theme/minglit_design_utils.dart
+++ b/shared/packages/minglit_kit/lib/src/theme/minglit_design_utils.dart
@@ -33,7 +33,9 @@ class MinglitDecorations {
     final accentColor = colorScheme.secondary;
 
     return BoxDecoration(
-      color: isSelected ? accentColor.withValues(alpha: MinglitOpacity.tintFill) : theme.cardColor,
+      color: isSelected
+          ? accentColor.withValues(alpha: MinglitOpacity.tintFill)
+          : theme.cardColor,
       borderRadius: BorderRadius.circular(MinglitRadius.card),
       border: MinglitBorders.card(colorScheme, isSelected: isSelected),
       boxShadow: isSelected ? MinglitShadows.cardSelected(accentColor) : null,

--- a/shared/packages/minglit_kit/lib/src/theme/minglit_design_utils.dart
+++ b/shared/packages/minglit_kit/lib/src/theme/minglit_design_utils.dart
@@ -33,7 +33,7 @@ class MinglitDecorations {
     final accentColor = colorScheme.secondary;
 
     return BoxDecoration(
-      color: isSelected ? accentColor.withValues(alpha: 0.05) : theme.cardColor,
+      color: isSelected ? accentColor.withValues(alpha: MinglitOpacity.tintFill) : theme.cardColor,
       borderRadius: BorderRadius.circular(MinglitRadius.card),
       border: MinglitBorders.card(colorScheme, isSelected: isSelected),
       boxShadow: isSelected ? MinglitShadows.cardSelected(accentColor) : null,

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_chip.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_chip.dart
@@ -91,7 +91,9 @@ class MinglitChip extends StatelessWidget {
         color: bgColor,
         borderRadius: BorderRadius.circular(MinglitRadius.small),
         border: Border.all(
-          color: colorScheme.outlineVariant.withValues(alpha: MinglitOpacity.muted),
+          color: colorScheme.outlineVariant.withValues(
+            alpha: MinglitOpacity.muted,
+          ),
           width: 0.5,
         ),
       ),

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_chip.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_chip.dart
@@ -91,7 +91,7 @@ class MinglitChip extends StatelessWidget {
         color: bgColor,
         borderRadius: BorderRadius.circular(MinglitRadius.small),
         border: Border.all(
-          color: colorScheme.outlineVariant.withValues(alpha: 0.3),
+          color: colorScheme.outlineVariant.withValues(alpha: MinglitOpacity.muted),
           width: 0.5,
         ),
       ),

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_filter_chip.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_filter_chip.dart
@@ -81,7 +81,7 @@ class MinglitFilterChip extends StatelessWidget {
     // Selected: #0f0f0f bg + #fff text
     final bgColor = isSelected
         ? MinglitColors.textPrimary
-        : MinglitColors.textPrimary.withValues(alpha: 0.05);
+        : MinglitColors.textPrimary.withValues(alpha: MinglitOpacity.tintFill);
 
     final fgColor = isSelected
         ? MinglitColors.background

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/debug/user_session_info.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/debug/user_session_info.dart
@@ -87,7 +87,9 @@ class UserSessionInfo extends ConsumerWidget {
             width: double.infinity,
             padding: const EdgeInsets.all(MinglitSpacing.small),
             decoration: BoxDecoration(
-              color: MinglitColors.textPrimary.withValues(alpha: MinglitOpacity.tintFill),
+              color: MinglitColors.textPrimary.withValues(
+                alpha: MinglitOpacity.tintFill,
+              ),
               borderRadius: BorderRadius.circular(4),
             ),
             // Fix #474: fontSize 11 → labelSmall

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/debug/user_session_info.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/debug/user_session_info.dart
@@ -87,7 +87,7 @@ class UserSessionInfo extends ConsumerWidget {
             width: double.infinity,
             padding: const EdgeInsets.all(MinglitSpacing.small),
             decoration: BoxDecoration(
-              color: MinglitColors.textPrimary.withValues(alpha: 0.05),
+              color: MinglitColors.textPrimary.withValues(alpha: MinglitOpacity.tintFill),
               borderRadius: BorderRadius.circular(4),
             ),
             // Fix #474: fontSize 11 → labelSmall

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart
@@ -234,7 +234,9 @@ class _ParticipantDDayOverlay extends StatelessWidget {
         vertical: MinglitSpacing.xsmall,
       ),
       decoration: BoxDecoration(
-        color: MinglitColors.textPrimary.withValues(alpha: MinglitOpacity.overlay),
+        color: MinglitColors.textPrimary.withValues(
+          alpha: MinglitOpacity.overlay,
+        ),
         borderRadius: BorderRadius.circular(MinglitRadius.small),
       ),
       child: Row(
@@ -255,7 +257,9 @@ class _ParticipantDDayOverlay extends StatelessWidget {
               decoration: BoxDecoration(
                 color: i < filledCount
                     ? segmentColor
-                    : MinglitColors.background.withValues(alpha: MinglitOpacity.placeholder),
+                    : MinglitColors.background.withValues(
+                        alpha: MinglitOpacity.placeholder,
+                      ),
                 borderRadius: BorderRadius.circular(2),
               ),
             ),
@@ -297,7 +301,9 @@ class _PartnerOverlay extends StatelessWidget {
         vertical: MinglitSpacing.xsmall,
       ),
       decoration: BoxDecoration(
-        color: MinglitColors.textPrimary.withValues(alpha: MinglitOpacity.overlay),
+        color: MinglitColors.textPrimary.withValues(
+          alpha: MinglitOpacity.overlay,
+        ),
         borderRadius: BorderRadius.circular(MinglitRadius.small),
       ),
       child: Row(

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart
@@ -215,7 +215,7 @@ class _ParticipantDDayOverlay extends StatelessWidget {
         ? 2
         : 3;
     final segmentColor = switch (filledCount) {
-      0 => MinglitColors.background.withValues(alpha: 0.3),
+      0 => MinglitColors.background.withValues(alpha: MinglitOpacity.muted),
       1 => MinglitColors.secondary,
       2 => MinglitColors.tertiary,
       _ => MinglitColors.primary,
@@ -234,7 +234,7 @@ class _ParticipantDDayOverlay extends StatelessWidget {
         vertical: MinglitSpacing.xsmall,
       ),
       decoration: BoxDecoration(
-        color: MinglitColors.textPrimary.withValues(alpha: 0.55),
+        color: MinglitColors.textPrimary.withValues(alpha: MinglitOpacity.overlay),
         borderRadius: BorderRadius.circular(MinglitRadius.small),
       ),
       child: Row(
@@ -255,7 +255,7 @@ class _ParticipantDDayOverlay extends StatelessWidget {
               decoration: BoxDecoration(
                 color: i < filledCount
                     ? segmentColor
-                    : MinglitColors.background.withValues(alpha: 0.2),
+                    : MinglitColors.background.withValues(alpha: MinglitOpacity.placeholder),
                 borderRadius: BorderRadius.circular(2),
               ),
             ),
@@ -297,7 +297,7 @@ class _PartnerOverlay extends StatelessWidget {
         vertical: MinglitSpacing.xsmall,
       ),
       decoration: BoxDecoration(
-        color: MinglitColors.textPrimary.withValues(alpha: 0.55),
+        color: MinglitColors.textPrimary.withValues(alpha: MinglitOpacity.overlay),
         borderRadius: BorderRadius.circular(MinglitRadius.small),
       ),
       child: Row(

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/party/location_map_view.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/party/location_map_view.dart
@@ -86,7 +86,7 @@ class LocationMapView extends StatelessWidget {
                 borderRadius: BorderRadius.circular(MinglitRadius.card),
                 boxShadow: [
                   BoxShadow(
-                    color: MinglitColors.textPrimary.withValues(alpha: 0.05),
+                    color: MinglitColors.textPrimary.withValues(alpha: MinglitOpacity.tintFill),
                     blurRadius: 10,
                     offset: const Offset(0, 4),
                   ),

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/party/location_map_view.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/party/location_map_view.dart
@@ -86,7 +86,9 @@ class LocationMapView extends StatelessWidget {
                 borderRadius: BorderRadius.circular(MinglitRadius.card),
                 boxShadow: [
                   BoxShadow(
-                    color: MinglitColors.textPrimary.withValues(alpha: MinglitOpacity.tintFill),
+                    color: MinglitColors.textPrimary.withValues(
+                      alpha: MinglitOpacity.tintFill,
+                    ),
                     blurRadius: 10,
                     offset: const Offset(0, 4),
                   ),


### PR DESCRIPTION
## Summary

- `MinglitOpacity` 토큰 클래스를 `minglit_design_tokens.dart`에 추가 (tintFill=0.05, placeholder=0.2, muted=0.3, overlay=0.55, scrimLight=0.8)
- 30개 파일에서 인라인 `withValues(alpha: ...)` 38건을 `MinglitOpacity` 토큰으로 치환

Closes #464

## Test plan

- [ ] `dart analyze` 에러 없음 확인
- [ ] CI `test-flutter-apps` 통과 확인
- [ ] 기존 opacity 동작 변경 없음 (상수 값 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)