### PR TITLE
chore(storage): .list() → listV2 커서 기반 페이지네이션 전환

### DIFF
--- a/supabase/functions/dev-seed/index.ts
+++ b/supabase/functions/dev-seed/index.ts
@@ -542,8 +542,9 @@ async function uploadSeedImages(supabase: SupabaseClient): Promise<string[]> {
   const urls: string[] = []
 
   // Check if images already exist in storage (uploaded externally or by a previous run)
-  const { data: existing } = await supabase.storage.from('party-assets').list('seed-images', { limit: 10 })
-  const existingNames = new Set((existing ?? []).map((f: { name: string }) => f.name))
+  // Use listV2 (cursor-based pagination) over deprecated list() — see #445
+  const { data: existing } = await supabase.storage.from('party-assets').listV2({ prefix: 'seed-images/', limit: 10 })
+  const existingNames = new Set((existing?.objects ?? []).map((f: { name: string }) => f.name.replace('seed-images/', '')))
 
   // If all images already exist, just return their public URLs
   const allExist = imageFiles.every(f => existingNames.has(f))


### PR DESCRIPTION
## Summary
- `dev-seed/index.ts`의 Storage `.list()` 호출을 `.listV2()` 커서 기반 페이지네이션으로 전환
- SDK 버전 확인: `@supabase/supabase-js@2.99.2` → `@supabase/storage-js@2.99.2` (listV2 지원 확인)
- `data.objects` 배열에서 파일명 추출, `prefix` 필터로 `seed-images/` 경로 지정

Closes #445

## Test plan
- [ ] `deno check` 통과
- [ ] dev-seed 함수 정적 분석 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)