### PR TITLE
refactor(ci): unify Dev/Main deploy steps in supabase-deploy

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -36,22 +36,24 @@ jobs:
             echo "PROJECT_ID=${{ secrets.SUPABASE_DEV_PROJECT_ID }}" >> "$GITHUB_OUTPUT"
             echo "DB_PASSWORD=${{ secrets.SUPABASE_DEV_DB_PASSWORD }}" >> "$GITHUB_OUTPUT"
             echo "PUBLISHABLE_KEY=${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }}" >> "$GITHUB_OUTPUT"
+            echo "SERVICE_ROLE_KEY=${{ secrets.SUPABASE_DEV_SECRET_KEY }}" >> "$GITHUB_OUTPUT"
             echo "ENVIRONMENT_VALUE=development" >> "$GITHUB_OUTPUT"
           else
             echo "ENV=main" >> "$GITHUB_OUTPUT"
             echo "PROJECT_ID=${{ secrets.SUPABASE_MAIN_PROJECT_ID }}" >> "$GITHUB_OUTPUT"
             echo "DB_PASSWORD=${{ secrets.SUPABASE_MAIN_DB_PASSWORD }}" >> "$GITHUB_OUTPUT"
             echo "PUBLISHABLE_KEY=${{ secrets.SUPABASE_MAIN_PUBLISHABLE_KEY }}" >> "$GITHUB_OUTPUT"
+            echo "SERVICE_ROLE_KEY=${{ secrets.SUPABASE_MAIN_SECRET_KEY }}" >> "$GITHUB_OUTPUT"
             echo "ENVIRONMENT_VALUE=production" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Deploy to Dev Supabase
-        if: github.ref == 'refs/heads/dev'
+      # Fix #470: Dev/Main 배포 로직 통합 — 중복 제거 + Main에 누락된 SERVICE_ROLE_KEY 추가
+      - name: Deploy to Supabase
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DEV_DB_PASSWORD }}
-          SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_DEV_PROJECT_ID }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_DEV_SECRET_KEY }}
+          SUPABASE_DB_PASSWORD: ${{ steps.env.outputs.DB_PASSWORD }}
+          SUPABASE_PROJECT_ID: ${{ steps.env.outputs.PROJECT_ID }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ steps.env.outputs.SERVICE_ROLE_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_ACCESS_TOKEN: ${{ secrets.GH_PAT_FOR_BUG_REPORT }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN_EDGE_FUNCTIONS }}
@@ -74,41 +76,7 @@ jobs:
           else
             supabase secrets set STATSIG_SERVER_KEY=$STATSIG_SERVER_KEY
           fi
-          supabase secrets set ENVIRONMENT=development
-
-          supabase db push --password $SUPABASE_DB_PASSWORD --include-all
-
-          supabase functions deploy
-
-      - name: Deploy to Main Supabase
-        if: github.ref == 'refs/heads/main'
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_MAIN_DB_PASSWORD }}
-          SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_MAIN_PROJECT_ID }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GITHUB_ACCESS_TOKEN: ${{ secrets.GH_PAT_FOR_BUG_REPORT }}
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN_EDGE_FUNCTIONS }}
-          STATSIG_SERVER_KEY: ${{ secrets.STATSIG_SERVER_KEY }}
-          AXIOM_API_TOKEN: ${{ secrets.AXIOM_API_TOKEN }}
-        run: |
-          supabase link --project-ref $SUPABASE_PROJECT_ID --password $SUPABASE_DB_PASSWORD
-
-          supabase secrets set OPENAI_API_KEY=$OPENAI_API_KEY
-          supabase secrets set GITHUB_ACCESS_TOKEN=$GITHUB_ACCESS_TOKEN
-          supabase secrets set SENTRY_DSN=$SENTRY_DSN
-          if [ -z "$AXIOM_API_TOKEN" ]; then
-            echo "AXIOM_API_TOKEN is not set. Skipping."
-          else
-            supabase secrets set AXIOM_API_TOKEN=$AXIOM_API_TOKEN
-            supabase secrets set AXIOM_DATASET=edge-functions
-          fi
-          if [ -z "$STATSIG_SERVER_KEY" ]; then
-            echo "STATSIG_SERVER_KEY is not set. Skipping."
-          else
-            supabase secrets set STATSIG_SERVER_KEY=$STATSIG_SERVER_KEY
-          fi
-          supabase secrets set ENVIRONMENT=production
+          supabase secrets set ENVIRONMENT=${{ steps.env.outputs.ENVIRONMENT_VALUE }}
 
           supabase db push --password $SUPABASE_DB_PASSWORD --include-all
 


### PR DESCRIPTION
## Summary
- Merge duplicate "Deploy to Dev Supabase" and "Deploy to Main Supabase" steps into a single unified "Deploy to Supabase" step using `steps.env.outputs.*`
- Add `SERVICE_ROLE_KEY` to the "Set environment variables" step (Dev: `SUPABASE_DEV_SECRET_KEY`, Main: `SUPABASE_MAIN_SECRET_KEY`)
- Fix missing `SUPABASE_SERVICE_ROLE_KEY` for Main deploys that was causing deployment issues

Closes #470

## Changes
- `.github/workflows/supabase-deploy.yml`: -40 lines, +8 lines (net -32 lines of duplication removed)

## Test plan
- [ ] Trigger workflow_dispatch on dev branch — verify deploy succeeds
- [ ] Verify Main branch deploy picks up `SUPABASE_MAIN_SECRET_KEY` correctly
- [ ] Post-deploy verification steps (vault secrets, EF env vars) remain unchanged and functional