### PR TITLE
fix(checkin): 서버 공개키로 티켓 검증 — 임시 키페어 생성 제거

### DIFF
--- a/apps/app_partner/lib/src/features/checkin/checkin_controller.dart
+++ b/apps/app_partner/lib/src/features/checkin/checkin_controller.dart
@@ -57,11 +57,11 @@ class CheckinController extends _$CheckinController {
       // 2. Verify with Repository
       final repo = ref.read(checkinRepositoryProvider);
 
-      // TODO(Checkin): Get actual public key from server
+      // Fix #458: 서버 공개키를 fetch하여 검증 — 임시 키페어 생성 제거
+      final serverPublicKey = await repo.fetchServerPublicKey();
       final success = await repo.verifyAndCheckin(
         token: token,
-        serverPublicKey: await (await TicketCrypto().generateKeyPair())
-            .extractPublicKey(),
+        serverPublicKey: serverPublicKey,
       );
 
       if (success) {

--- a/apps/app_partner/lib/src/features/checkin/checkin_controller.g.dart
+++ b/apps/app_partner/lib/src/features/checkin/checkin_controller.g.dart
@@ -41,7 +41,7 @@ final class CheckinControllerProvider
   }
 }
 
-String _$checkinControllerHash() => r'd2cd4b654a93e22ba461114d0cbe399e40de6089';
+String _$checkinControllerHash() => r'1f2eb82b25de3cdf059caa84845ec090b4f5220e';
 
 abstract class _$CheckinController extends $Notifier<CheckinState> {
   CheckinState build();

--- a/shared/packages/minglit_kit/lib/src/data/repositories/checkin_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/checkin_repository.dart
@@ -27,8 +27,8 @@ class CheckinRepository {
   CheckinRepository({
     required TicketCrypto crypto,
     required SupabaseClient supabase,
-  })  : _crypto = crypto,
-        _supabase = supabase;
+  }) : _crypto = crypto,
+       _supabase = supabase;
 
   final TicketCrypto _crypto;
   final SupabaseClient _supabase;

--- a/shared/packages/minglit_kit/lib/src/data/repositories/checkin_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/checkin_repository.dart
@@ -1,14 +1,20 @@
+import 'dart:convert';
+
 import 'package:cryptography/cryptography.dart';
 import 'package:minglit_kit/src/data/models/ticket_token.dart';
 import 'package:minglit_kit/src/utils/ticket_crypto.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 part 'checkin_repository.g.dart';
 
 /// Provides the [CheckinRepository].
 @riverpod
 CheckinRepository checkinRepository(Ref ref) {
-  return CheckinRepository(TicketCrypto());
+  return CheckinRepository(
+    crypto: TicketCrypto(),
+    supabase: Supabase.instance.client,
+  );
 }
 
 /// **Check-in Repository**
@@ -18,8 +24,28 @@ CheckinRepository checkinRepository(Ref ref) {
 /// a repository interface for consistent client-side access.
 class CheckinRepository {
   /// Creates a [CheckinRepository] with ticket crypto helpers.
-  CheckinRepository(this._crypto);
+  CheckinRepository({
+    required TicketCrypto crypto,
+    required SupabaseClient supabase,
+  })  : _crypto = crypto,
+        _supabase = supabase;
+
   final TicketCrypto _crypto;
+  final SupabaseClient _supabase;
+
+  /// Cached server public key to avoid repeated network calls.
+  SimplePublicKey? _cachedPublicKey;
+
+  /// Fetches the server's Ed25519 public key for ticket verification.
+  /// Caches the result after the first successful fetch.
+  Future<SimplePublicKey> fetchServerPublicKey() async {
+    if (_cachedPublicKey != null) return _cachedPublicKey!;
+
+    final result = await _supabase.rpc('get_ticket_public_key') as String;
+    final keyBytes = base64Url.decode(result);
+    _cachedPublicKey = SimplePublicKey(keyBytes, type: KeyPairType.ed25519);
+    return _cachedPublicKey!;
+  }
 
   /// Mints a signed [TicketToken] for a given participant record.
   /// This simulates an Edge Function call.
@@ -67,8 +93,7 @@ class CheckinRepository {
     if (token.expiresAt.isBefore(DateTime.now())) return false;
 
     // 4. Update DB (Simulated)
-    // TODO(Checkin): Update verification logic when real server integration
-    // is ready.
+    // TODO(Checkin): Call server-side check-in endpoint when ready.
     return true;
   }
 }

--- a/shared/packages/minglit_kit/lib/src/data/repositories/checkin_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/checkin_repository.dart
@@ -41,8 +41,14 @@ class CheckinRepository {
   Future<SimplePublicKey> fetchServerPublicKey() async {
     if (_cachedPublicKey != null) return _cachedPublicKey!;
 
-    final result = await _supabase.rpc<String>('get_ticket_public_key');
-    final keyBytes = base64Url.decode(result);
+    final result =
+        await _supabase.rpc<String?>('get_ticket_public_key');
+    if (result == null || result.isEmpty) {
+      throw StateError('Server public key not configured');
+    }
+    // Support both standard base64 and base64url
+    final normalized = result.replaceAll('+', '-').replaceAll('/', '_');
+    final keyBytes = base64Url.decode(base64Url.normalize(normalized));
     _cachedPublicKey = SimplePublicKey(keyBytes, type: KeyPairType.ed25519);
     return _cachedPublicKey!;
   }

--- a/shared/packages/minglit_kit/lib/src/data/repositories/checkin_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/checkin_repository.dart
@@ -41,8 +41,7 @@ class CheckinRepository {
   Future<SimplePublicKey> fetchServerPublicKey() async {
     if (_cachedPublicKey != null) return _cachedPublicKey!;
 
-    final result =
-        await _supabase.rpc<String>('get_ticket_public_key');
+    final result = await _supabase.rpc<String>('get_ticket_public_key');
     final keyBytes = base64Url.decode(result);
     _cachedPublicKey = SimplePublicKey(keyBytes, type: KeyPairType.ed25519);
     return _cachedPublicKey!;

--- a/shared/packages/minglit_kit/lib/src/data/repositories/checkin_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/checkin_repository.dart
@@ -41,7 +41,8 @@ class CheckinRepository {
   Future<SimplePublicKey> fetchServerPublicKey() async {
     if (_cachedPublicKey != null) return _cachedPublicKey!;
 
-    final result = await _supabase.rpc('get_ticket_public_key') as String;
+    final result =
+        await _supabase.rpc<String>('get_ticket_public_key');
     final keyBytes = base64Url.decode(result);
     _cachedPublicKey = SimplePublicKey(keyBytes, type: KeyPairType.ed25519);
     return _cachedPublicKey!;

--- a/shared/packages/minglit_kit/lib/src/data/repositories/checkin_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/checkin_repository.dart
@@ -41,8 +41,7 @@ class CheckinRepository {
   Future<SimplePublicKey> fetchServerPublicKey() async {
     if (_cachedPublicKey != null) return _cachedPublicKey!;
 
-    final result =
-        await _supabase.rpc<String?>('get_ticket_public_key');
+    final result = await _supabase.rpc<String?>('get_ticket_public_key');
     if (result == null || result.isEmpty) {
       throw StateError('Server public key not configured');
     }

--- a/shared/packages/minglit_kit/lib/src/data/repositories/checkin_repository.g.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/checkin_repository.g.dart
@@ -58,4 +58,4 @@ final class CheckinRepositoryProvider
   }
 }
 
-String _$checkinRepositoryHash() => r'6eb7d58a311c46355492205d40aa8c025d8fd97c';
+String _$checkinRepositoryHash() => r'd499621964bafe7b78eb26f4e65a59d0fc5f87cc';

--- a/shared/packages/minglit_kit/test/src/data/repositories/checkin_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/checkin_repository_test.dart
@@ -2,6 +2,11 @@ import 'package:cryptography/cryptography.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/repositories/checkin_repository.dart';
 import 'package:minglit_kit/src/utils/ticket_crypto.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// Minimal [SupabaseClient] for unit tests that don't hit the network.
+SupabaseClient _stubSupabase() =>
+    SupabaseClient('https://stub.supabase.co', 'stub-anon-key');
 
 void main() {
   late CheckinRepository repository;
@@ -16,7 +21,10 @@ void main() {
   });
 
   setUp(() {
-    repository = CheckinRepository(crypto);
+    repository = CheckinRepository(
+      crypto: crypto,
+      supabase: _stubSupabase(),
+    );
   });
 
   group('CheckinRepository', () {

--- a/supabase/migrations/20260327000002_ticket_signing_public_key.sql
+++ b/supabase/migrations/20260327000002_ticket_signing_public_key.sql
@@ -1,0 +1,30 @@
+-- Adds ticket signing public key to system_settings and exposes it via RPC.
+-- The corresponding private key must be stored in Supabase Vault
+-- and used by the ticket-minting Edge Function.
+
+-- 1. Insert ticket signing public key placeholder
+-- Replace the placeholder value with the actual Base64-encoded Ed25519 public key
+-- after generating the key pair for the ticket-minting Edge Function.
+insert into public.system_settings (key, value, description)
+values (
+  'ticket_signing_public_key',
+  '"FILL_THIS_WITH_BASE64_ED25519_PUBLIC_KEY"'::jsonb,
+  'Ed25519 public key (Base64) for ticket QR signature verification'
+)
+on conflict (key) do nothing;
+
+-- 2. RPC function to serve the public key to authenticated users
+create or replace function public.get_ticket_public_key()
+returns text
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select value #>> '{}'
+  from public.system_settings
+  where key = 'ticket_signing_public_key';
+$$;
+
+-- Grant execute to authenticated users (partners need it for check-in)
+grant execute on function public.get_ticket_public_key() to authenticated;


### PR DESCRIPTION
## Summary
- 체크인 시 `generateKeyPair()`로 새 키를 만들어 자기 자신의 서명을 검증하던 placeholder 코드를 서버 공개키 fetch 로직으로 교체
- `system_settings`에 `ticket_signing_public_key` 항목 + `get_ticket_public_key()` RPC 함수 추가
- `CheckinRepository`에 `fetchServerPublicKey()` 메서드 추가 (캐싱 포함)

## 운영팀 필수 조치
⚠️ migration의 `FILL_THIS_WITH_BASE64_ED25519_PUBLIC_KEY` 플레이스홀더를 **실제 Base64 Ed25519 공개키**로 교체해야 합니다. 대응하는 private key는 Supabase Vault에 저장하여 티켓 서명 Edge Function에서 사용.

## Test plan
- [x] `checkin_repository_test.dart` 5/5 통과
- [ ] `flutter analyze` 통과 확인
- [ ] `supabase test` (migration + RPC) 통과 확인

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)