### PR TITLE
test: 다크모드 골든테스트 variant 추가

### DIFF
--- a/apps/app_partner/test/goldens/closing_soon_events_card_golden_test.dart
+++ b/apps/app_partner/test/goldens/closing_soon_events_card_golden_test.dart
@@ -55,5 +55,33 @@ void main() {
         goldenFileName: 'closing_soon_multiple.png',
       );
     });
+
+    testWidgets('single event (dark)', (tester) async {
+      await expectGolden(
+        tester,
+        widget: ClosingSoonEventsCard(
+          events: [makeEvent('e1', '금요 파티', 1)],
+          onEventTap: (_) {},
+        ),
+        goldenFileName: 'closing_soon_single_dark.png',
+        brightness: Brightness.dark,
+      );
+    });
+
+    testWidgets('multiple events (dark)', (tester) async {
+      await expectGolden(
+        tester,
+        widget: ClosingSoonEventsCard(
+          events: [
+            makeEvent('e1', '금요 파티', 1),
+            makeEvent('e2', '토요 모임', 2),
+            makeEvent('e3', '일요 브런치', 3),
+          ],
+          onEventTap: (_) {},
+        ),
+        goldenFileName: 'closing_soon_multiple_dark.png',
+        brightness: Brightness.dark,
+      );
+    });
   });
 }

--- a/apps/app_partner/test/goldens/closing_soon_events_card_golden_test.dart
+++ b/apps/app_partner/test/goldens/closing_soon_events_card_golden_test.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'package:app_partner/src/features/home/widgets/closing_soon_events_card.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:minglit_kit/minglit_kit.dart';

--- a/apps/app_partner/test/goldens/event_card_golden_test.dart
+++ b/apps/app_partner/test/goldens/event_card_golden_test.dart
@@ -55,5 +55,38 @@ void main() {
         goldenFileName: 'event_card_no_title.png',
       );
     });
+
+    testWidgets('scheduled (dark)', (tester) async {
+      await expectGolden(
+        tester,
+        widget: EventCard(event: baseEvent, onTap: () {}),
+        goldenFileName: 'event_card_scheduled_dark.png',
+        brightness: Brightness.dark,
+      );
+    });
+
+    testWidgets('full capacity (dark)', (tester) async {
+      await expectGolden(
+        tester,
+        widget: EventCard(
+          event: baseEvent.copyWith(currentParticipants: 20),
+          onTap: () {},
+        ),
+        goldenFileName: 'event_card_full_dark.png',
+        brightness: Brightness.dark,
+      );
+    });
+
+    testWidgets('no title (default) (dark)', (tester) async {
+      await expectGolden(
+        tester,
+        widget: EventCard(
+          event: baseEvent.copyWith(title: null),
+          onTap: () {},
+        ),
+        goldenFileName: 'event_card_no_title_dark.png',
+        brightness: Brightness.dark,
+      );
+    });
   });
 }

--- a/apps/app_partner/test/goldens/event_card_golden_test.dart
+++ b/apps/app_partner/test/goldens/event_card_golden_test.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'package:app_partner/src/features/party/event/widgets/event_card.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:minglit_kit/minglit_kit.dart';

--- a/apps/app_partner/test/goldens/home_page_golden_test.dart
+++ b/apps/app_partner/test/goldens/home_page_golden_test.dart
@@ -81,6 +81,70 @@ void main() {
         ],
       );
     });
+
+    testWidgets('empty dashboard (dark)', (tester) async {
+      await expectPageGolden(
+        tester,
+        page: const PartnerHomePage(),
+        goldenFileName: 'goldens/partner_home_page_empty_dark.png',
+        overrides: [
+          currentPartnerInfoProvider.overrideWith(
+            (_) async => const Partner(id: 'p1', name: '테스트 파트너'),
+          ),
+          partnerHomeCoordinatorProvider.overrideWithValue(mockCoordinator),
+          partnerDashboardControllerProvider.overrideWith(
+            _EmptyDashboardController.new,
+          ),
+        ],
+        brightness: Brightness.dark,
+      );
+    });
+
+    testWidgets('with data (dark)', (tester) async {
+      final events = List.generate(
+        2,
+        (i) => Event(
+          id: 'e$i',
+          partyId: 'p1',
+          startTime: baseTime.add(Duration(days: i + 1)),
+          endTime: baseTime.add(Duration(days: i + 1, hours: 2)),
+          createdAt: baseTime,
+          updatedAt: baseTime,
+          title: '이벤트 ${i + 1}',
+          currentParticipants: (i + 1) * 5,
+        ),
+      );
+      final parties = [
+        Party(
+          id: 'party1',
+          partnerId: 'p1',
+          title: '금요 밍글 파티',
+          createdAt: baseTime,
+          updatedAt: baseTime,
+        ),
+      ];
+
+      await expectPageGolden(
+        tester,
+        page: const PartnerHomePage(),
+        goldenFileName: 'goldens/partner_home_page_with_data_dark.png',
+        overrides: [
+          currentPartnerInfoProvider.overrideWith(
+            (_) async => const Partner(id: 'p1', name: '테스트 파트너'),
+          ),
+          partnerHomeCoordinatorProvider.overrideWithValue(mockCoordinator),
+          partnerDashboardControllerProvider.overrideWith(
+            () => _LoadedDashboardController(
+              pendingCount: 3,
+              upcoming: events,
+              closingSoon: [events.first],
+              active: parties,
+            ),
+          ),
+        ],
+        brightness: Brightness.dark,
+      );
+    });
   });
 }
 

--- a/apps/app_partner/test/goldens/home_page_golden_test.dart
+++ b/apps/app_partner/test/goldens/home_page_golden_test.dart
@@ -5,6 +5,7 @@ import 'package:app_partner/src/features/home/partner_dashboard_controller.dart'
 import 'package:app_partner/src/features/home/partner_home_coordinator.dart';
 import 'package:app_partner/src/features/home/partner_home_page.dart';
 import 'package:app_partner/src/logic/current_partner_provider.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:minglit_kit/minglit_kit.dart';

--- a/apps/app_partner/test/goldens/party_list_page_golden_test.dart
+++ b/apps/app_partner/test/goldens/party_list_page_golden_test.dart
@@ -57,5 +57,53 @@ void main() {
         ],
       );
     });
+
+    testWidgets('empty state (dark)', (tester) async {
+      await expectPageGolden(
+        tester,
+        page: const PartyListPage(),
+        goldenFileName: 'goldens/party_list_page_empty_dark.png',
+        overrides: [
+          partyListProvider.overrideWith((_) async => <Party>[]),
+        ],
+        brightness: Brightness.dark,
+      );
+    });
+
+    testWidgets('with parties (dark)', (tester) async {
+      final parties = [
+        Party(
+          id: 'party1',
+          partnerId: 'p1',
+          title: '금요 밍글 파티',
+          createdAt: baseTime,
+          updatedAt: baseTime,
+        ),
+        Party(
+          id: 'party2',
+          partnerId: 'p1',
+          title: '주말 브런치 모임',
+          createdAt: baseTime,
+          updatedAt: baseTime,
+        ),
+        Party(
+          id: 'party3',
+          partnerId: 'p1',
+          title: '평일 네트워킹',
+          createdAt: baseTime,
+          updatedAt: baseTime,
+        ),
+      ];
+
+      await expectPageGolden(
+        tester,
+        page: const PartyListPage(),
+        goldenFileName: 'goldens/party_list_page_with_data_dark.png',
+        overrides: [
+          partyListProvider.overrideWith((_) async => parties),
+        ],
+        brightness: Brightness.dark,
+      );
+    });
   });
 }

--- a/apps/app_partner/test/goldens/party_list_page_golden_test.dart
+++ b/apps/app_partner/test/goldens/party_list_page_golden_test.dart
@@ -3,6 +3,7 @@ library;
 
 import 'package:app_partner/src/features/party/list/party_list_controller.dart';
 import 'package:app_partner/src/features/party/list/party_list_page.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 

--- a/apps/app_partner/test/goldens/settlement_empty_state_golden_test.dart
+++ b/apps/app_partner/test/goldens/settlement_empty_state_golden_test.dart
@@ -41,5 +41,41 @@ void main() {
         goldenFileName: 'settlement_empty_state_action.png',
       );
     });
+
+    testWidgets('default (title only) (dark)', (tester) async {
+      await expectGolden(
+        tester,
+        widget: const SettlementEmptyState(title: '정산 내역이 없습니다'),
+        goldenFileName: 'settlement_empty_state_default_dark.png',
+        brightness: Brightness.dark,
+      );
+    });
+
+    testWidgets('with subtitle (dark)', (tester) async {
+      await expectGolden(
+        tester,
+        widget: const SettlementEmptyState(
+          title: '정산 내역이 없습니다',
+          subtitle: '이벤트를 등록하면 정산 내역이 표시됩니다.',
+        ),
+        goldenFileName: 'settlement_empty_state_subtitle_dark.png',
+        brightness: Brightness.dark,
+      );
+    });
+
+    testWidgets('with action button (dark)', (tester) async {
+      await expectGolden(
+        tester,
+        widget: SettlementEmptyState(
+          title: '이벤트가 없습니다',
+          subtitle: '새 이벤트를 만들어보세요.',
+          icon: Icons.event_outlined,
+          actionLabel: '이벤트 만들기',
+          onAction: () {},
+        ),
+        goldenFileName: 'settlement_empty_state_action_dark.png',
+        brightness: Brightness.dark,
+      );
+    });
   });
 }

--- a/apps/app_partner/test/goldens/upcoming_events_card_golden_test.dart
+++ b/apps/app_partner/test/goldens/upcoming_events_card_golden_test.dart
@@ -51,5 +51,30 @@ void main() {
         goldenFileName: 'upcoming_events_with_data.png',
       );
     });
+
+    testWidgets('empty state (dark)', (tester) async {
+      await expectGolden(
+        tester,
+        widget: UpcomingEventsCard(events: const [], onEventTap: (_) {}),
+        goldenFileName: 'upcoming_events_empty_dark.png',
+        brightness: Brightness.dark,
+      );
+    });
+
+    testWidgets('with events (dark)', (tester) async {
+      await expectGolden(
+        tester,
+        widget: UpcomingEventsCard(
+          events: [
+            makeEvent('e1', '금요 파티', 1),
+            makeEvent('e2', '토요 모임', 2),
+            makeEvent('e3', '일요 브런치', 3),
+          ],
+          onEventTap: (_) {},
+        ),
+        goldenFileName: 'upcoming_events_with_data_dark.png',
+        brightness: Brightness.dark,
+      );
+    });
   });
 }

--- a/apps/app_partner/test/goldens/upcoming_events_card_golden_test.dart
+++ b/apps/app_partner/test/goldens/upcoming_events_card_golden_test.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'package:app_partner/src/features/home/widgets/upcoming_events_card.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:minglit_kit/minglit_kit.dart';

--- a/apps/app_partner/test/utils/golden_test_helpers.dart
+++ b/apps/app_partner/test/utils/golden_test_helpers.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
 
 /// Fixed surface size for golden tests (consistency across environments).
 const goldenSurfaceSize = Size(400, 800);
@@ -8,11 +9,13 @@ const goldenSurfaceSize = Size(400, 800);
 /// then compares against [goldenFileName].
 ///
 /// Use [surfaceSize] to override the default 400x800 canvas.
+/// Use [brightness] to switch between light and dark theme.
 Future<void> expectGolden(
   WidgetTester tester, {
   required Widget widget,
   required String goldenFileName,
   Size surfaceSize = goldenSurfaceSize,
+  Brightness brightness = Brightness.light,
 }) async {
   await tester.binding.setSurfaceSize(surfaceSize);
   addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -20,10 +23,9 @@ Future<void> expectGolden(
   await tester.pumpWidget(
     MaterialApp(
       debugShowCheckedModeBanner: false,
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
+      theme: brightness == Brightness.dark
+          ? MinglitTheme.materialThemeDark
+          : MinglitTheme.materialTheme,
       home: Scaffold(body: Center(child: widget)),
     ),
   );

--- a/apps/app_partner/test/utils/partner_golden_test_helpers.dart
+++ b/apps/app_partner/test/utils/partner_golden_test_helpers.dart
@@ -19,6 +19,7 @@ Future<void> expectPageGolden(
   required String goldenFileName,
   Size surfaceSize = goldenSurfaceSize,
   List<dynamic> overrides = const [],
+  Brightness brightness = Brightness.light,
 }) async {
   await tester.binding.setSurfaceSize(surfaceSize);
   addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -35,7 +36,9 @@ Future<void> expectPageGolden(
       ],
       child: MaterialApp(
         debugShowCheckedModeBanner: false,
-        theme: MinglitTheme.materialTheme,
+        theme: brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
         locale: const Locale('ko'),
         localizationsDelegates: const [
           AppLocalizations.delegate,

--- a/apps/app_user/test/goldens/golden_test_helpers.dart
+++ b/apps/app_user/test/goldens/golden_test_helpers.dart
@@ -23,6 +23,7 @@ Future<void> expectPageGolden(
   Size surfaceSize = goldenSurfaceSize,
   List<dynamic> overrides = const [],
   User? currentUser,
+  Brightness brightness = Brightness.light,
 }) async {
   // Prevent MissingPluginException for SharedPreferences in test environment.
   SharedPreferences.setMockInitialValues({});
@@ -44,7 +45,9 @@ Future<void> expectPageGolden(
       ],
       child: MaterialApp(
         debugShowCheckedModeBanner: false,
-        theme: MinglitTheme.materialTheme,
+        theme: brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
         home: page,
       ),
     ),
@@ -66,6 +69,7 @@ Future<void> expectGolden(
   Size surfaceSize = goldenSurfaceSize,
   List<dynamic> overrides = const [],
   User? currentUser,
+  Brightness brightness = Brightness.light,
 }) async {
   // Prevent MissingPluginException for SharedPreferences in test environment.
   SharedPreferences.setMockInitialValues({});
@@ -86,7 +90,9 @@ Future<void> expectGolden(
       ],
       child: MaterialApp(
         debugShowCheckedModeBanner: false,
-        theme: MinglitTheme.materialTheme,
+        theme: brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
         home: Scaffold(body: Center(child: widget)),
       ),
     ),

--- a/apps/app_user/test/goldens/home_page_golden_test.dart
+++ b/apps/app_user/test/goldens/home_page_golden_test.dart
@@ -6,6 +6,7 @@ import 'package:app_user/src/features/event/logic/event_coordinator.dart';
 import 'package:app_user/src/features/home/home_page.dart';
 import 'package:app_user/src/features/home/logic/home_coordinator.dart';
 import 'package:app_user/src/logic/feed_state_provider.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 

--- a/apps/app_user/test/goldens/home_page_golden_test.dart
+++ b/apps/app_user/test/goldens/home_page_golden_test.dart
@@ -68,6 +68,40 @@ void main() {
         overrides: buildOverrides(events: events),
       );
     });
+
+    testWidgets('empty feed (dark)', (tester) async {
+      await expectPageGolden(
+        tester,
+        page: const HomePage(),
+        goldenFileName: 'goldens/home_page_empty_dark.png',
+        overrides: buildOverrides(),
+        brightness: Brightness.dark,
+      );
+    });
+
+    testWidgets('with events (dark)', (tester) async {
+      final events = List.generate(
+        3,
+        (i) => Event(
+          id: 'e$i',
+          partyId: 'p1',
+          startTime: baseTime.add(Duration(days: i + 1)),
+          endTime: baseTime.add(Duration(days: i + 1, hours: 2)),
+          createdAt: baseTime,
+          updatedAt: baseTime,
+          title: '이벤트 ${i + 1}',
+          currentParticipants: (i + 1) * 5,
+        ),
+      );
+
+      await expectPageGolden(
+        tester,
+        page: const HomePage(),
+        goldenFileName: 'goldens/home_page_with_events_dark.png',
+        overrides: buildOverrides(events: events),
+        brightness: Brightness.dark,
+      );
+    });
   });
 }
 

--- a/apps/app_user/test/goldens/my_page_golden_test.dart
+++ b/apps/app_user/test/goldens/my_page_golden_test.dart
@@ -4,6 +4,7 @@ library;
 import 'dart:async';
 
 import 'package:app_user/src/features/auth/logic/auth_coordinator.dart';
+import 'package:flutter/material.dart';
 import 'package:app_user/src/features/home/logic/home_coordinator.dart';
 import 'package:app_user/src/features/home/my_page.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/apps/app_user/test/goldens/my_page_golden_test.dart
+++ b/apps/app_user/test/goldens/my_page_golden_test.dart
@@ -4,9 +4,9 @@ library;
 import 'dart:async';
 
 import 'package:app_user/src/features/auth/logic/auth_coordinator.dart';
-import 'package:flutter/material.dart';
 import 'package:app_user/src/features/home/logic/home_coordinator.dart';
 import 'package:app_user/src/features/home/my_page.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 

--- a/apps/app_user/test/goldens/my_page_golden_test.dart
+++ b/apps/app_user/test/goldens/my_page_golden_test.dart
@@ -52,6 +52,48 @@ void main() {
         ],
       );
     });
+
+    testWidgets('logged out state (dark)', (tester) async {
+      final mockAuth = MockAuthCoordinator();
+
+      await expectPageGolden(
+        tester,
+        page: const MyPage(),
+        goldenFileName: 'goldens/my_page_logged_out_dark.png',
+        overrides: [
+          authCoordinatorProvider.overrideWithValue(mockAuth),
+        ],
+        brightness: Brightness.dark,
+      );
+    });
+
+    testWidgets('logged in state (dark)', (tester) async {
+      final mockAuth = MockAuthCoordinator();
+      final mockHome = MockHomeCoordinator();
+
+      await expectPageGolden(
+        tester,
+        page: const MyPage(),
+        goldenFileName: 'goldens/my_page_logged_in_dark.png',
+        currentUser: const User(
+          id: 'u1',
+          appMetadata: {},
+          userMetadata: {
+            'full_name': '홍길동',
+            'avatar_url': null,
+          },
+          aud: 'authenticated',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          email: 'test@minglit.com',
+        ),
+        overrides: [
+          authCoordinatorProvider.overrideWithValue(mockAuth),
+          homeCoordinatorProvider.overrideWithValue(mockHome),
+          authControllerProvider.overrideWith(_FakeAuthController.new),
+        ],
+        brightness: Brightness.dark,
+      );
+    });
   });
 }
 

--- a/apps/app_user/test/goldens/search_page_golden_test.dart
+++ b/apps/app_user/test/goldens/search_page_golden_test.dart
@@ -2,9 +2,9 @@
 library;
 
 import 'package:app_user/src/features/event/logic/event_coordinator.dart';
-import 'package:flutter/material.dart';
 import 'package:app_user/src/features/search/search_page.dart';
 import 'package:app_user/src/logic/feed_state_provider.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 

--- a/apps/app_user/test/goldens/search_page_golden_test.dart
+++ b/apps/app_user/test/goldens/search_page_golden_test.dart
@@ -31,5 +31,21 @@ void main() {
         ],
       );
     });
+
+    testWidgets('initial empty state (dark)', (tester) async {
+      final mockEvent = MockEventCoordinator();
+
+      await expectPageGolden(
+        tester,
+        page: const SearchPage(),
+        goldenFileName: 'goldens/search_page_empty_dark.png',
+        overrides: [
+          eventCoordinatorProvider.overrideWithValue(mockEvent),
+          searchQueryProvider.overrideWith(_EmptySearchQuery.new),
+          searchResultsProvider.overrideWith((_) async => <Event>[]),
+        ],
+        brightness: Brightness.dark,
+      );
+    });
   });
 }

--- a/apps/app_user/test/goldens/search_page_golden_test.dart
+++ b/apps/app_user/test/goldens/search_page_golden_test.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'package:app_user/src/features/event/logic/event_coordinator.dart';
+import 'package:flutter/material.dart';
 import 'package:app_user/src/features/search/search_page.dart';
 import 'package:app_user/src/logic/feed_state_provider.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
## Summary

- 골든 테스트 헬퍼 3개(`app_user`, `app_partner` simple/full)에 `Brightness brightness` 파라미터 추가
- `app_partner`의 simple helper를 `ThemeData.fromSeed` → `MinglitTheme` 기반으로 전환하여 디자인 시스템 토큰 검증 가능
- 기존 9개 골든 테스트 파일에 총 16개 다크모드 variant 추가
- `MinglitColorsDark` 토큰이 실제 위젯에서 올바르게 적용되는지 시각적 검증

Closes #466

## Test plan

- [ ] CI `test-flutter-apps` 통과 확인 (app_user, app_partner)
- [ ] Golden test `--update-goldens`로 다크모드 PNG 생성 확인 (CI artifact)
- [ ] 기존 라이트모드 golden test 통과 확인 (regression 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)