### PR TITLE
fix(simulator): add query LIMIT to standalone phase queries to prevent timeout

### DIFF
--- a/supabase/functions/backend-simulator/index.ts
+++ b/supabase/functions/backend-simulator/index.ts
@@ -133,7 +133,8 @@ Deno.serve(async (req: Request): Promise<Response> => {
     const { data: pendingApps, error: fetchErr } = await supabase
       .from("event_applications")
       .select("id")
-      .eq("status", "pending_review");
+      .eq("status", "pending_review")
+      .limit(50);
 
     if (fetchErr) {
       return errorResponse(`Failed to fetch pending applications: ${fetchErr.message}`, 500);
@@ -161,7 +162,8 @@ Deno.serve(async (req: Request): Promise<Response> => {
     const { data: paidApps, error: fetchErr } = await supabase
       .from("event_applications")
       .select("id")
-      .eq("status", "paid");
+      .eq("status", "paid")
+      .limit(50);
 
     if (fetchErr) {
       return errorResponse(`Failed to fetch paid applications: ${fetchErr.message}`, 500);
@@ -191,7 +193,8 @@ Deno.serve(async (req: Request): Promise<Response> => {
     const { data: scheduledEvents, error: fetchErr } = await supabase
       .from("events")
       .select("id")
-      .eq("status", "scheduled");
+      .eq("status", "scheduled")
+      .limit(50);
 
     if (fetchErr) {
       return errorResponse(`Failed to fetch events: ${fetchErr.message}`, 500);
@@ -233,7 +236,8 @@ Deno.serve(async (req: Request): Promise<Response> => {
     const { data: completedEvents, error: fetchErr } = await supabase
       .from("events")
       .select("id")
-      .eq("status", "completed");
+      .eq("status", "completed")
+      .limit(50);
 
     if (fetchErr) {
       return errorResponse(`Failed to fetch completed events: ${fetchErr.message}`, 500);
@@ -273,7 +277,8 @@ Deno.serve(async (req: Request): Promise<Response> => {
     const { data: completedEvents } = await supabase
       .from("events")
       .select("id")
-      .eq("status", "completed");
+      .eq("status", "completed")
+      .limit(50);
 
     const completedEventIds = (
       (completedEvents ?? []) as Array<{ id: string }>


### PR DESCRIPTION
## Summary
- Add `.limit(50)` to 5 unbounded queries in the phase routing section of `backend-simulator/index.ts`
- Queries for `pending_review`/`paid` applications and `scheduled`/`completed` events had no LIMIT, causing timeouts when large amounts of accumulated pg_cron data exist
- Prevents Edge Function from exceeding the 150s wall clock limit during hourly workflow calls

## Test plan
- [ ] Verify Edge Function responds within timeout for `approve`, `refund`, `run`, `settle`, `verify` phases
- [ ] Confirm each phase processes up to 50 rows per invocation (consistent with simulator batch behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)