### PR TITLE
fix(ci): add 12 missing Edge Function sections to config.toml

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -569,11 +569,12 @@ verify_jwt = false  # JWT verification handled in function code
 import_map = "./deno.json"
 entrypoint = "./functions/user-manage-notification/index.ts"
 
-# [functions.user-manage-settings]  # PR #318 머지 후 활성화
-# enabled = true
-# verify_jwt = false
-# import_map = "./deno.json"
-# entrypoint = "./functions/user-manage-settings/index.ts"
+# Fix #510: 신규 Edge Function 12개 섹션 추가 — Supabase 배포 실패 방지
+[functions.user-manage-settings]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/user-manage-settings/index.ts"
 
 [functions.user-manage-social]
 enabled = true
@@ -586,3 +587,69 @@ enabled = true
 verify_jwt = false
 import_map = "./deno.json"
 entrypoint = "./functions/metrics-alert/index.ts"
+
+[functions.partner-manage-event]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/partner-manage-event/index.ts"
+
+[functions.partner-manage-match]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/partner-manage-match/index.ts"
+
+[functions.partner-manage-member]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/partner-manage-member/index.ts"
+
+[functions.partner-manage-party]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/partner-manage-party/index.ts"
+
+[functions.partner-manage-settlement]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/partner-manage-settlement/index.ts"
+
+[functions.partner-manage-verification]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/partner-manage-verification/index.ts"
+
+[functions.partner-register]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/partner-register/index.ts"
+
+[functions.partner-review-submission]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/partner-review-submission/index.ts"
+
+[functions.user-cast-vote]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/user-cast-vote/index.ts"
+
+[functions.user-submit-verification]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/user-submit-verification/index.ts"
+
+[functions.user-update-verification]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/user-update-verification/index.ts"


### PR DESCRIPTION
## Summary
- `supabase/config.toml`에 누락된 Edge Function 12개의 `[functions.*]` 섹션 추가
- Supabase CLI가 `deno.json` import map을 찾지 못해 배포 실패하던 문제 해결
- 기존 commented-out `user-manage-settings` 섹션도 활성화

Closes #510

## 변경된 함수 목록
`partner-manage-event`, `partner-manage-match`, `partner-manage-member`, `partner-manage-party`, `partner-manage-settlement`, `partner-manage-verification`, `partner-register`, `partner-review-submission`, `user-cast-vote`, `user-manage-settings`, `user-submit-verification`, `user-update-verification`

## Test plan
- [ ] CI `ci-result` job 통과 확인
- [ ] `supabase functions deploy` 에서 12개 함수 모두 번들링 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)