### PR TITLE
fix(ci): add missing deno.json to 7 Edge Functions to unblock deploy

### DIFF
--- a/supabase/functions/_contract_tests/deno.json
+++ b/supabase/functions/_contract_tests/deno.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "@std/assert": "jsr:@std/assert@1",
+    "@std/testing/mock": "jsr:@std/testing@1/mock",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/health/deno.json
+++ b/supabase/functions/health/deno.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "@std/assert": "jsr:@std/assert@1",
+    "@std/testing/mock": "jsr:@std/testing@1/mock",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/partner-manage-event/deno.json
+++ b/supabase/functions/partner-manage-event/deno.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "@std/assert": "jsr:@std/assert@1",
+    "@std/testing/mock": "jsr:@std/testing@1/mock",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/partner-manage-party/deno.json
+++ b/supabase/functions/partner-manage-party/deno.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "@std/assert": "jsr:@std/assert@1",
+    "@std/testing/mock": "jsr:@std/testing@1/mock",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/partner-review-submission/deno.json
+++ b/supabase/functions/partner-review-submission/deno.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "@std/assert": "jsr:@std/assert@1",
+    "@std/testing/mock": "jsr:@std/testing@1/mock",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/settlement-query/deno.json
+++ b/supabase/functions/settlement-query/deno.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "@std/assert": "jsr:@std/assert@1",
+    "@std/testing/mock": "jsr:@std/testing@1/mock",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/user-cast-vote/deno.json
+++ b/supabase/functions/user-cast-vote/deno.json
@@ -1,0 +1,7 @@
+{
+  "imports": {
+    "@std/assert": "jsr:@std/assert@1",
+    "@std/testing/mock": "jsr:@std/testing@1/mock",
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  }
+}


### PR DESCRIPTION
## Summary

- 7 Edge Functions were missing per-function `deno.json` with `@supabase/supabase-js` import mapping
- Supabase CLI no longer supports `--import-map` flag, so each function needs its own `deno.json`
- This blocked **all** EF deployments, including the refund timeout fix from PR #511
- Adds `deno.json` to: `partner-manage-party`, `partner-manage-event`, `partner-review-submission`, `user-cast-vote`, `settlement-query`, `health`, `_contract_tests`

Closes #513

## Root Cause

The `Hourly User Activity Simulation` workflow fails with `exit code 28` (curl timeout) on the `refund` phase. The refund timeout fix (PR #511, `Promise.allSettled` parallelization) was merged but never deployed because `supabase functions deploy` has been failing since the Supabase CLI stopped supporting `--import-map` flag.

Deploy error:
```
Relative import path "@supabase/supabase-js" not prefixed with / or ./ or ../
  at file:///.../supabase/functions/_shared/supabase_client.ts:1:51
```

## Test plan

- [ ] `supabase functions deploy` succeeds in CI (Deploy Supabase Migrations workflow)
- [ ] Hourly User Activity Simulation passes after deploy
- [ ] `deno test` passes for affected functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)