### PR TITLE
chore: 디자인 카탈로그 5개 탭 추가 + BottomSheet 문서 보강

### DIFF
--- a/docs/ux/design-system/02-components.md
+++ b/docs/ux/design-system/02-components.md
@@ -166,7 +166,21 @@ Dark Mode 소스: `minglit_theme.dart:228-232`
 
 ---
 
-## 11. Badge / Tag
+## 11. BottomSheet
+
+현재 `BottomSheetThemeData` 및 `BottomSheetTheme` 설정이 별도로 없으며, Flutter 기본 `showModalBottomSheet` 스타일이 적용됩니다.
+
+**사용 패턴**:
+- `showModalBottomSheet`로 호출
+- 내부 패딩: `MinglitSpacing.large` (24px)
+- 닫기 버튼: 전체 너비 `ElevatedButton`
+- drag handle은 Flutter 기본 제공
+
+> 디자인 카탈로그 9번 탭에서 Modal BottomSheet 데모를 확인할 수 있습니다.
+
+---
+
+## 12. Badge / Tag
 
 <!-- TODO: 커스텀 Badge/Tag 컴포넌트 테마 정의 필요. 현재는 Chip 기반으로 사용 중. -->
 
@@ -174,7 +188,7 @@ Dark Mode 소스: `minglit_theme.dart:228-232`
 
 ---
 
-## 12. Toast / Snackbar
+## 13. Toast / Snackbar
 
 <!-- TODO: SnackBarTheme 정의가 minglit_component_theme.dart에 없음. 별도 SnackBar 테마 추가 필요. -->
 

--- a/docs/ux/design-system/02-components.md
+++ b/docs/ux/design-system/02-components.md
@@ -168,13 +168,13 @@ Dark Mode 소스: `minglit_theme.dart:228-232`
 
 ## 11. BottomSheet
 
-현재 `BottomSheetThemeData` 및 `BottomSheetTheme` 설정이 별도로 없으며, Flutter 기본 `showModalBottomSheet` 스타일이 적용됩니다.
+**기본 스타일**: `BottomSheetThemeData` 별도 설정 없음 — Flutter 기본 `showModalBottomSheet` 스타일 적용.
 
-**사용 패턴**:
+**밍릿 권장 패턴**:
 - `showModalBottomSheet`로 호출
 - 내부 패딩: `MinglitSpacing.large` (24px)
 - 닫기/확인 버튼: 용도에 따라 `ElevatedButton` (CTA) 또는 `TextButton` (취소/닫기) 사용
-- drag handle은 Flutter 기본 제공
+- drag handle: Flutter 기본 제공
 
 > 디자인 카탈로그 9번 탭에서 Modal BottomSheet 데모를 확인할 수 있습니다.
 

--- a/docs/ux/design-system/02-components.md
+++ b/docs/ux/design-system/02-components.md
@@ -173,7 +173,7 @@ Dark Mode 소스: `minglit_theme.dart:228-232`
 **사용 패턴**:
 - `showModalBottomSheet`로 호출
 - 내부 패딩: `MinglitSpacing.large` (24px)
-- 닫기 버튼: 전체 너비 `ElevatedButton`
+- 닫기/확인 버튼: 용도에 따라 `ElevatedButton` (CTA) 또는 `TextButton` (취소/닫기) 사용
 - drag handle은 Flutter 기본 제공
 
 > 디자인 카탈로그 9번 탭에서 Modal BottomSheet 데모를 확인할 수 있습니다.

--- a/shared/packages/minglit_kit/lib/src/features/dev/design_catalog_page.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/design_catalog_page.dart
@@ -14,7 +14,7 @@ class DesignCatalogPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-      length: 10,
+      length: 15,
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Design Catalog'),
@@ -32,6 +32,11 @@ class DesignCatalogPage extends StatelessWidget {
               Tab(text: 'Dialogs'),
               Tab(text: 'BottomSheet'),
               Tab(text: 'Badge/Tag'),
+              Tab(text: 'Checkbox'),
+              Tab(text: 'TabBar'),
+              Tab(text: 'Divider'),
+              Tab(text: 'IconSize'),
+              Tab(text: 'Animation'),
             ],
           ),
         ),
@@ -47,6 +52,11 @@ class DesignCatalogPage extends StatelessWidget {
             _DialogsSection(),
             _BottomSheetSection(),
             _BadgeTagSection(),
+            _CheckboxSection(),
+            _TabBarSection(),
+            _DividerSection(),
+            _IconSizeSection(),
+            _AnimationSection(),
           ],
         ),
       ),
@@ -784,6 +794,345 @@ class _BadgeTagSection extends StatelessWidget {
           'in the design system.',
           style: theme.textTheme.bodyMedium?.copyWith(
             color: MinglitColors.textSecondary,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Checkbox Section
+// ---------------------------------------------------------------------------
+
+class _CheckboxSection extends StatefulWidget {
+  const _CheckboxSection();
+
+  @override
+  State<_CheckboxSection> createState() => _CheckboxSectionState();
+}
+
+class _CheckboxSectionState extends State<_CheckboxSection> {
+  bool _checked = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListView(
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      children: [
+        Text('Checkbox States', style: theme.textTheme.titleMedium),
+        const SizedBox(height: MinglitSpacing.small),
+        CheckboxListTile(
+          title: const Text('Selected'),
+          value: _checked,
+          onChanged: (v) => setState(() => _checked = v ?? false),
+        ),
+        CheckboxListTile(
+          title: const Text('Unselected'),
+          value: false,
+          onChanged: (v) {},
+        ),
+        CheckboxListTile(
+          title: const Text('Disabled (selected)'),
+          value: true,
+          onChanged: null,
+        ),
+        CheckboxListTile(
+          title: const Text('Disabled (unselected)'),
+          value: false,
+          onChanged: null,
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// TabBar Section
+// ---------------------------------------------------------------------------
+
+class _TabBarSection extends StatelessWidget {
+  const _TabBarSection();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListView(
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      children: [
+        Text('TabBar (2 tabs)', style: theme.textTheme.titleMedium),
+        const SizedBox(height: MinglitSpacing.small),
+        DefaultTabController(
+          length: 2,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const TabBar(
+                tabs: [
+                  Tab(text: 'Tab A'),
+                  Tab(text: 'Tab B'),
+                ],
+              ),
+              SizedBox(
+                height: 60,
+                child: TabBarView(
+                  children: [
+                    Center(
+                      child: Text(
+                        'Content A',
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                    ),
+                    Center(
+                      child: Text(
+                        'Content B',
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: MinglitSpacing.large),
+        Text('TabBar (3 tabs)', style: theme.textTheme.titleMedium),
+        const SizedBox(height: MinglitSpacing.small),
+        DefaultTabController(
+          length: 3,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const TabBar(
+                tabs: [
+                  Tab(text: 'First'),
+                  Tab(text: 'Second'),
+                  Tab(text: 'Third'),
+                ],
+              ),
+              SizedBox(
+                height: 60,
+                child: TabBarView(
+                  children: [
+                    Center(
+                      child: Text(
+                        'Content 1',
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                    ),
+                    Center(
+                      child: Text(
+                        'Content 2',
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                    ),
+                    Center(
+                      child: Text(
+                        'Content 3',
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Divider Section
+// ---------------------------------------------------------------------------
+
+class _DividerSection extends StatelessWidget {
+  const _DividerSection();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListView(
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      children: [
+        Text('Divider (Light)', style: theme.textTheme.titleMedium),
+        const SizedBox(height: MinglitSpacing.small),
+        const Text('Content above divider'),
+        const Divider(),
+        const Text('Content below divider'),
+        const SizedBox(height: MinglitSpacing.large),
+        Text('Divider (Custom Thickness)', style: theme.textTheme.titleMedium),
+        const SizedBox(height: MinglitSpacing.small),
+        const Divider(thickness: 2),
+        const SizedBox(height: MinglitSpacing.large),
+        Text('Divider (Dark Background)', style: theme.textTheme.titleMedium),
+        const SizedBox(height: MinglitSpacing.small),
+        Container(
+          padding: const EdgeInsets.all(MinglitSpacing.medium),
+          decoration: BoxDecoration(
+            color: MinglitColorsDark.background,
+            borderRadius: BorderRadius.circular(MinglitRadius.card),
+          ),
+          child: Column(
+            children: [
+              Text(
+                'Content above',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: MinglitColorsDark.textPrimary,
+                ),
+              ),
+              Divider(color: MinglitColorsDark.divider),
+              Text(
+                'Content below',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: MinglitColorsDark.textPrimary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// IconSize Section
+// ---------------------------------------------------------------------------
+
+class _IconSizeSection extends StatelessWidget {
+  const _IconSizeSection();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    const sizes = <String, double>{
+      'xsmall (16)': MinglitIconSize.xsmall,
+      'small (20)': MinglitIconSize.small,
+      'medium (24)': MinglitIconSize.medium,
+      'large (28)': MinglitIconSize.large,
+      'xlarge (32)': MinglitIconSize.xlarge,
+    };
+
+    return ListView.builder(
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      itemCount: sizes.length,
+      itemBuilder: (context, index) {
+        final entry = sizes.entries.elementAt(index);
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: MinglitSpacing.small),
+          child: Row(
+            children: [
+              SizedBox(
+                width: 120,
+                child: Text(entry.key, style: theme.textTheme.bodyMedium),
+              ),
+              Icon(Icons.star, size: entry.value),
+              const SizedBox(width: MinglitSpacing.small),
+              Icon(Icons.favorite, size: entry.value),
+              const SizedBox(width: MinglitSpacing.small),
+              Icon(Icons.notifications, size: entry.value),
+              const SizedBox(width: MinglitSpacing.medium),
+              Text(
+                '${entry.value.toInt()}px',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: MinglitColors.textSecondary,
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Animation Section
+// ---------------------------------------------------------------------------
+
+class _AnimationSection extends StatefulWidget {
+  const _AnimationSection();
+
+  @override
+  State<_AnimationSection> createState() => _AnimationSectionState();
+}
+
+class _AnimationSectionState extends State<_AnimationSection> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final targetWidth = _expanded ? 200.0 : 80.0;
+
+    return ListView(
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      children: [
+        Text('Animation Durations', style: theme.textTheme.titleMedium),
+        const SizedBox(height: MinglitSpacing.small),
+        Text(
+          'Tap the button to toggle animated containers.',
+          style: theme.textTheme.bodyMedium,
+        ),
+        const SizedBox(height: MinglitSpacing.medium),
+        ElevatedButton(
+          onPressed: () => setState(() => _expanded = !_expanded),
+          child: Text(_expanded ? 'Collapse' : 'Expand'),
+        ),
+        const SizedBox(height: MinglitSpacing.large),
+        _AnimationRow(
+          label: 'fast (200ms)',
+          duration: MinglitAnimation.fast,
+          targetWidth: targetWidth,
+        ),
+        const SizedBox(height: MinglitSpacing.medium),
+        _AnimationRow(
+          label: 'medium (350ms)',
+          duration: MinglitAnimation.medium,
+          targetWidth: targetWidth,
+        ),
+        const SizedBox(height: MinglitSpacing.medium),
+        _AnimationRow(
+          label: 'slow (500ms)',
+          duration: MinglitAnimation.slow,
+          targetWidth: targetWidth,
+        ),
+      ],
+    );
+  }
+}
+
+class _AnimationRow extends StatelessWidget {
+  const _AnimationRow({
+    required this.label,
+    required this.duration,
+    required this.targetWidth,
+  });
+
+  final String label;
+  final Duration duration;
+  final double targetWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        SizedBox(
+          width: 130,
+          child: Text(label, style: theme.textTheme.bodyMedium),
+        ),
+        AnimatedContainer(
+          duration: duration,
+          curve: Curves.easeInOut,
+          width: targetWidth,
+          height: 40,
+          decoration: BoxDecoration(
+            color: MinglitColors.primary.withAlpha(180),
+            borderRadius: BorderRadius.circular(MinglitRadius.small),
           ),
         ),
       ],

--- a/shared/packages/minglit_kit/lib/src/features/dev/design_catalog_page.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/design_catalog_page.dart
@@ -833,13 +833,13 @@ class _CheckboxSectionState extends State<_CheckboxSection> {
           value: false,
           onChanged: (v) {},
         ),
-        CheckboxListTile(
-          title: const Text('Disabled (selected)'),
+        const CheckboxListTile(
+          title: Text('Disabled (selected)'),
           value: true,
           onChanged: null,
         ),
-        CheckboxListTile(
-          title: const Text('Disabled (unselected)'),
+        const CheckboxListTile(
+          title: Text('Disabled (unselected)'),
           value: false,
           onChanged: null,
         ),
@@ -983,7 +983,7 @@ class _DividerSection extends StatelessWidget {
                   color: MinglitColorsDark.textPrimary,
                 ),
               ),
-              Divider(color: MinglitColorsDark.divider),
+              const Divider(color: MinglitColorsDark.divider),
               Text(
                 'Content below',
                 style: theme.textTheme.bodyMedium?.copyWith(


### PR DESCRIPTION
## Summary

- **Part A**: DesignCatalogPage에 5개 신규 탭 추가 (10탭 → 15탭)
  - Checkbox: 선택/미선택/비활성 상태
  - TabBar: 2탭/3탭 예시
  - Divider: Light/Dark/커스텀 두께
  - IconSize: xsmall~xlarge 5단계 시각 비교
  - Animation: fast/medium/slow AnimatedContainer 데모
- **Part C**: `02-components.md`에 BottomSheet 섹션(§11) 추가, 이후 섹션 번호 조정

Closes #484

## Test plan

- [ ] dev 환경에서 Design Catalog 진입 → 15개 탭 모두 렌더링 확인
- [ ] Checkbox 탭: 선택/미선택 토글, disabled 상태 확인
- [ ] TabBar 탭: 2탭/3탭 전환 동작 확인
- [ ] Divider 탭: Light/Dark 배경 Divider 렌더링 확인
- [ ] IconSize 탭: 5단계 아이콘 크기 비교 확인
- [ ] Animation 탭: Expand/Collapse 버튼으로 3가지 속도 비교 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)