### PR TITLE
feat: 신청관리 탭 (이벤트별 그루핑 + 인라인 승인/거절)

### DIFF
--- a/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
+++ b/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
@@ -85,7 +85,7 @@ class _EventApplicationManagePageState
 /// Provider to fetch applications grouped by event for a partner.
 final FutureProviderFamily<
   Map<Event, List<EventApplication>>,
-  ({String partnerId, List<dynamic> statusFilter})
+  ({String partnerId, List<String> statusFilter})
 >
 eventApplicationsGroupedProvider = FutureProvider.family
     .autoDispose<

--- a/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
+++ b/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
@@ -1,11 +1,10 @@
 import 'dart:async';
 
+import 'package:app_partner/src/logic/current_partner_provider.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/minglit_kit.dart';
-
-import 'package:app_partner/src/logic/current_partner_provider.dart';
+import 'package:riverpod/src/providers/future_provider.dart';
 
 /// Event application management page — grouped by event with inline approve/reject.
 class EventApplicationManagePage extends ConsumerStatefulWidget {
@@ -84,31 +83,38 @@ class _EventApplicationManagePageState
 }
 
 /// Provider to fetch applications grouped by event for a partner.
-final eventApplicationsGroupedProvider = FutureProvider.family
-    .autoDispose<Map<Event, List<EventApplication>>, ({String partnerId, List<String> statusFilter})>(
-  (ref, params) async {
-    final eventRepo = ref.read(eventRepositoryProvider);
+final FutureProviderFamily<
+  Map<Event, List<EventApplication>>,
+  ({String partnerId, List<dynamic> statusFilter})
+>
+eventApplicationsGroupedProvider = FutureProvider.family
+    .autoDispose<
+      Map<Event, List<EventApplication>>,
+      ({String partnerId, List<String> statusFilter})
+    >(
+      (ref, params) async {
+        final eventRepo = ref.read(eventRepositoryProvider);
 
-    // Get all upcoming events for this partner
-    final events = await eventRepo.getUpcomingEvents(params.partnerId);
-    // Also get recent past events (last 7 days)
-    final allEvents = [...events];
+        // Get all upcoming events for this partner
+        final events = await eventRepo.getUpcomingEvents(params.partnerId);
+        // Also get recent past events (last 7 days)
+        final allEvents = [...events];
 
-    final grouped = <Event, List<EventApplication>>{};
+        final grouped = <Event, List<EventApplication>>{};
 
-    for (final event in allEvents) {
-      final apps = await eventRepo.getApplicationsByEventId(event.id);
-      final filtered = apps
-          .where((a) => params.statusFilter.contains(a.status))
-          .toList();
-      if (filtered.isNotEmpty) {
-        grouped[event] = filtered;
-      }
-    }
+        for (final event in allEvents) {
+          final apps = await eventRepo.getApplicationsByEventId(event.id);
+          final filtered = apps
+              .where((a) => params.statusFilter.contains(a.status))
+              .toList();
+          if (filtered.isNotEmpty) {
+            grouped[event] = filtered;
+          }
+        }
 
-    return grouped;
-  },
-);
+        return grouped;
+      },
+    );
 
 class _ApplicationTab extends ConsumerWidget {
   const _ApplicationTab({
@@ -170,8 +176,10 @@ class _ApplicationTab extends ConsumerWidget {
         }
 
         final entries = grouped.entries.toList();
-        final totalPending = grouped.values
-            .fold<int>(0, (sum, apps) => sum + apps.length);
+        final totalPending = grouped.values.fold<int>(
+          0,
+          (sum, apps) => sum + apps.length,
+        );
 
         return Column(
           children: [
@@ -195,7 +203,8 @@ class _ApplicationTab extends ConsumerWidget {
                       applications: apps,
                       showActions: showActions,
                       onApprove: (appId) => _approve(ref, context, appId),
-                      onReject: (appId) => _showRejectDialog(ref, context, appId),
+                      onReject: (appId) =>
+                          _showRejectDialog(ref, context, appId),
                     );
                   },
                 ),
@@ -221,7 +230,11 @@ class _ApplicationTab extends ConsumerWidget {
     );
   }
 
-  Future<void> _approve(WidgetRef ref, BuildContext context, String appId) async {
+  Future<void> _approve(
+    WidgetRef ref,
+    BuildContext context,
+    String appId,
+  ) async {
     try {
       final client = ref.read(supabaseClientProvider);
       await client.functions.invoke(
@@ -377,7 +390,9 @@ class _EventGroupSection extends StatelessWidget {
             horizontal: MinglitSpacing.medium,
             vertical: MinglitSpacing.sm,
           ),
-          color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+          color: theme.colorScheme.surfaceContainerHighest.withValues(
+            alpha: 0.3,
+          ),
           child: Row(
             children: [
               Expanded(
@@ -446,8 +461,8 @@ class _ApplicationItem extends StatelessWidget {
     };
 
     final subtitle = [
-      if (age != null) '${age}세',
-      if (genderText != null) genderText,
+      if (age != null) '$age세',
+      ?genderText,
       timeAgo,
     ].join(' · ');
 
@@ -496,7 +511,7 @@ class _ApplicationItem extends StatelessWidget {
           // Actions or status
           if (showActions) ...[
             IconButton(
-              icon: Icon(
+              icon: const Icon(
                 Icons.close,
                 color: MinglitColors.error,
                 size: MinglitIconSize.small,

--- a/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
+++ b/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
@@ -1,0 +1,575 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import 'package:app_partner/src/logic/current_partner_provider.dart';
+
+/// Event application management page — grouped by event with inline approve/reject.
+class EventApplicationManagePage extends ConsumerStatefulWidget {
+  const EventApplicationManagePage({super.key});
+
+  @override
+  ConsumerState<EventApplicationManagePage> createState() =>
+      _EventApplicationManagePageState();
+}
+
+class _EventApplicationManagePageState
+    extends ConsumerState<EventApplicationManagePage>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 3, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final partnerAsync = ref.watch(currentPartnerInfoProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('신청관리'),
+        centerTitle: true,
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: '대기중'),
+            Tab(text: '승인됨'),
+            Tab(text: '거절됨'),
+          ],
+        ),
+      ),
+      body: partnerAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('오류: $e')),
+        data: (partner) {
+          if (partner == null) {
+            return const Center(child: Text('파트너 정보를 불러올 수 없습니다'));
+          }
+          return TabBarView(
+            controller: _tabController,
+            children: [
+              _ApplicationTab(
+                partnerId: partner.id,
+                statusFilter: const ['pending', 'pending_review'],
+                showActions: true,
+              ),
+              _ApplicationTab(
+                partnerId: partner.id,
+                statusFilter: const ['approved', 'paid'],
+                showActions: false,
+              ),
+              _ApplicationTab(
+                partnerId: partner.id,
+                statusFilter: const ['rejected'],
+                showActions: false,
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// Provider to fetch applications grouped by event for a partner.
+final eventApplicationsGroupedProvider = FutureProvider.family
+    .autoDispose<Map<Event, List<EventApplication>>, ({String partnerId, List<String> statusFilter})>(
+  (ref, params) async {
+    final eventRepo = ref.read(eventRepositoryProvider);
+
+    // Get all upcoming events for this partner
+    final events = await eventRepo.getUpcomingEvents(params.partnerId);
+    // Also get recent past events (last 7 days)
+    final allEvents = [...events];
+
+    final grouped = <Event, List<EventApplication>>{};
+
+    for (final event in allEvents) {
+      final apps = await eventRepo.getApplicationsByEventId(event.id);
+      final filtered = apps
+          .where((a) => params.statusFilter.contains(a.status))
+          .toList();
+      if (filtered.isNotEmpty) {
+        grouped[event] = filtered;
+      }
+    }
+
+    return grouped;
+  },
+);
+
+class _ApplicationTab extends ConsumerWidget {
+  const _ApplicationTab({
+    required this.partnerId,
+    required this.statusFilter,
+    required this.showActions,
+  });
+
+  final String partnerId;
+  final List<String> statusFilter;
+  final bool showActions;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final groupedAsync = ref.watch(
+      eventApplicationsGroupedProvider(
+        (partnerId: partnerId, statusFilter: statusFilter),
+      ),
+    );
+
+    return groupedAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('신청 목록을 불러올 수 없습니다'),
+            const SizedBox(height: MinglitSpacing.small),
+            FilledButton(
+              onPressed: () => ref.invalidate(
+                eventApplicationsGroupedProvider(
+                  (partnerId: partnerId, statusFilter: statusFilter),
+                ),
+              ),
+              child: const Text('다시 시도'),
+            ),
+          ],
+        ),
+      ),
+      data: (grouped) {
+        if (grouped.isEmpty) {
+          return Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  Icons.assignment_outlined,
+                  size: MinglitIconSize.xlarge * 2,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(height: MinglitSpacing.medium),
+                Text(
+                  showActions ? '대기 중인 신청이 없습니다' : '해당 신청이 없습니다',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ],
+            ),
+          );
+        }
+
+        final entries = grouped.entries.toList();
+        final totalPending = grouped.values
+            .fold<int>(0, (sum, apps) => sum + apps.length);
+
+        return Column(
+          children: [
+            Expanded(
+              child: RefreshIndicator(
+                onRefresh: () async {
+                  ref.invalidate(
+                    eventApplicationsGroupedProvider(
+                      (partnerId: partnerId, statusFilter: statusFilter),
+                    ),
+                  );
+                },
+                child: ListView.builder(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  itemCount: entries.length,
+                  itemBuilder: (context, index) {
+                    final event = entries[index].key;
+                    final apps = entries[index].value;
+                    return _EventGroupSection(
+                      event: event,
+                      applications: apps,
+                      showActions: showActions,
+                      onApprove: (appId) => _approve(ref, context, appId),
+                      onReject: (appId) => _showRejectDialog(ref, context, appId),
+                    );
+                  },
+                ),
+              ),
+            ),
+            // Bulk approve button (only for pending tab)
+            if (showActions && totalPending > 0)
+              SafeArea(
+                child: Padding(
+                  padding: const EdgeInsets.all(MinglitSpacing.medium),
+                  child: SizedBox(
+                    width: double.infinity,
+                    child: FilledButton(
+                      onPressed: () => _bulkApprove(ref, context, grouped),
+                      child: Text('전체 승인 ($totalPending건)'),
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _approve(WidgetRef ref, BuildContext context, String appId) async {
+    try {
+      final client = ref.read(supabaseClientProvider);
+      await client.functions.invoke(
+        'partner-approve-application',
+        body: {'action': 'approve', 'application_id': appId},
+      );
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('승인되었습니다')),
+        );
+        ref.invalidate(eventApplicationsGroupedProvider);
+      }
+    } on Exception catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('승인 실패: $e')),
+        );
+      }
+    }
+  }
+
+  Future<void> _showRejectDialog(
+    WidgetRef ref,
+    BuildContext context,
+    String appId,
+  ) async {
+    final reasonController = TextEditingController();
+    final reason = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('신청 거절'),
+        content: TextField(
+          controller: reasonController,
+          decoration: const InputDecoration(
+            hintText: '거절 사유를 입력하세요',
+          ),
+          maxLines: 3,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('취소'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, reasonController.text),
+            child: const Text('거절'),
+          ),
+        ],
+      ),
+    );
+    reasonController.dispose();
+
+    if (reason == null || reason.trim().isEmpty) return;
+
+    try {
+      final client = ref.read(supabaseClientProvider);
+      await client.functions.invoke(
+        'partner-reject-application',
+        body: {'application_id': appId, 'reason': reason.trim()},
+      );
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('거절되었습니다')),
+        );
+        ref.invalidate(eventApplicationsGroupedProvider);
+      }
+    } on Exception catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('거절 실패: $e')),
+        );
+      }
+    }
+  }
+
+  Future<void> _bulkApprove(
+    WidgetRef ref,
+    BuildContext context,
+    Map<Event, List<EventApplication>> grouped,
+  ) async {
+    final total = grouped.values.fold<int>(0, (s, apps) => s + apps.length);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('전체 승인'),
+        content: Text('대기 중인 $total건을 모두 승인하시겠습니까?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('취소'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('전체 승인'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    try {
+      final client = ref.read(supabaseClientProvider);
+      for (final event in grouped.keys) {
+        await client.functions.invoke(
+          'partner-approve-application',
+          body: {'action': 'bulk_approve', 'event_id': event.id},
+        );
+      }
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('$total건 승인 완료')),
+        );
+        ref.invalidate(eventApplicationsGroupedProvider);
+      }
+    } on Exception catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('일괄 승인 실패: $e')),
+        );
+      }
+    }
+  }
+}
+
+class _EventGroupSection extends StatelessWidget {
+  const _EventGroupSection({
+    required this.event,
+    required this.applications,
+    required this.showActions,
+    required this.onApprove,
+    required this.onReject,
+  });
+
+  final Event event;
+  final List<EventApplication> applications;
+  final bool showActions;
+  final void Function(String appId) onApprove;
+  final void Function(String appId) onReject;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dateFmt = DateFormat('M/d (E)', 'ko');
+    final timeFmt = DateFormat('HH:mm');
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Event header
+        Container(
+          padding: const EdgeInsets.symmetric(
+            horizontal: MinglitSpacing.medium,
+            vertical: MinglitSpacing.sm,
+          ),
+          color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '${event.title ?? ''} · ${dateFmt.format(event.startTime)} ${timeFmt.format(event.startTime)}',
+                      style: theme.textTheme.labelLarge?.copyWith(
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                    Text(
+                      '${applications.length}건 · ${event.currentParticipants}/${event.maxParticipants}명',
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+        // Application items
+        ...applications.map(
+          (app) => _ApplicationItem(
+            application: app,
+            showActions: showActions,
+            onApprove: () => onApprove(app.id),
+            onReject: () => onReject(app.id),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ApplicationItem extends StatelessWidget {
+  const _ApplicationItem({
+    required this.application,
+    required this.showActions,
+    required this.onApprove,
+    required this.onReject,
+  });
+
+  final EventApplication application;
+  final bool showActions;
+  final VoidCallback onApprove;
+  final VoidCallback onReject;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final user = application.user;
+    final name = user?.name ?? '이름 없음';
+    final gender = user?.gender;
+    final birthYear = user?.birthYear;
+    final age = birthYear != null ? DateTime.now().year - birthYear : null;
+    final timeAgo = _formatTimeAgo(application.createdAt);
+
+    final genderText = switch (gender) {
+      'male' => '남',
+      'female' => '여',
+      _ => null,
+    };
+
+    final subtitle = [
+      if (age != null) '${age}세',
+      if (genderText != null) genderText,
+      timeAgo,
+    ].join(' · ');
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: MinglitSpacing.medium,
+        vertical: MinglitSpacing.sm,
+      ),
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: BorderSide(
+            color: theme.dividerColor.withValues(alpha: 0.3),
+          ),
+        ),
+      ),
+      child: Row(
+        children: [
+          // Avatar
+          CircleAvatar(
+            radius: 20,
+            backgroundColor: theme.colorScheme.primary.withValues(alpha: 0.1),
+            child: Text(
+              name.isNotEmpty ? name[0] : '?',
+              style: theme.textTheme.titleSmall?.copyWith(
+                color: theme.colorScheme.primary,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+          const SizedBox(width: MinglitSpacing.sm),
+          // Info
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  name,
+                  style: theme.textTheme.labelLarge?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                Text(subtitle, style: theme.textTheme.labelSmall),
+              ],
+            ),
+          ),
+          // Actions or status
+          if (showActions) ...[
+            IconButton(
+              icon: Icon(
+                Icons.close,
+                color: MinglitColors.error,
+                size: MinglitIconSize.small,
+              ),
+              onPressed: onReject,
+              tooltip: '거절',
+              style: IconButton.styleFrom(
+                shape: CircleBorder(
+                  side: BorderSide(
+                    color: theme.dividerColor,
+                  ),
+                ),
+                minimumSize: const Size(36, 36),
+              ),
+            ),
+            const SizedBox(width: MinglitSpacing.xsmall),
+            IconButton(
+              icon: const Icon(
+                Icons.check,
+                color: Colors.white,
+                size: MinglitIconSize.small,
+              ),
+              onPressed: onApprove,
+              tooltip: '승인',
+              style: IconButton.styleFrom(
+                backgroundColor: theme.colorScheme.primary,
+                minimumSize: const Size(36, 36),
+              ),
+            ),
+          ] else
+            _StatusBadge(status: application.status),
+        ],
+      ),
+    );
+  }
+
+  static String _formatTimeAgo(DateTime dt) {
+    final diff = DateTime.now().difference(dt);
+    if (diff.inMinutes < 60) return '${diff.inMinutes}분 전';
+    if (diff.inHours < 24) return '${diff.inHours}시간 전';
+    return '${diff.inDays}일 전';
+  }
+}
+
+class _StatusBadge extends StatelessWidget {
+  const _StatusBadge({required this.status});
+  final String status;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final (label, color) = switch (status) {
+      'approved' || 'paid' => ('승인', MinglitColors.success),
+      'rejected' => ('거절', MinglitColors.error),
+      _ => ('대기', theme.colorScheme.primary),
+    };
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: MinglitSpacing.small,
+        vertical: MinglitSpacing.xsmall,
+      ),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(MinglitRadius.small),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: color,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+}

--- a/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
+++ b/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
@@ -4,6 +4,7 @@ import 'package:app_partner/src/logic/current_partner_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/minglit_kit.dart';
+import 'package:riverpod/src/providers/future_provider.dart';
 
 /// Event application management page — grouped by event with inline approve/reject.
 class EventApplicationManagePage extends ConsumerStatefulWidget {
@@ -82,7 +83,11 @@ class _EventApplicationManagePageState
 }
 
 /// Provider to fetch applications grouped by event for a partner.
-final eventApplicationsGroupedProvider = FutureProvider.family
+final FutureProviderFamily<
+  Map<Event, List<EventApplication>>,
+  ({String partnerId, List<dynamic> statusFilter})
+>
+eventApplicationsGroupedProvider = FutureProvider.family
     .autoDispose<
       Map<Event, List<EventApplication>>,
       ({String partnerId, List<String> statusFilter})

--- a/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
+++ b/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
@@ -97,12 +97,10 @@ eventApplicationsGroupedProvider = FutureProvider.family
 
         // Get all upcoming events for this partner
         final events = await eventRepo.getUpcomingEvents(params.partnerId);
-        // Also get recent past events (last 7 days)
-        final allEvents = [...events];
 
         final grouped = <Event, List<EventApplication>>{};
 
-        for (final event in allEvents) {
+        for (final event in events) {
           final apps = await eventRepo.getApplicationsByEventId(event.id);
           final filtered = apps
               .where((a) => params.statusFilter.contains(a.status))
@@ -336,26 +334,33 @@ class _ApplicationTab extends ConsumerWidget {
 
     if (confirmed != true) return;
 
-    try {
-      final client = ref.read(supabaseClientProvider);
-      for (final event in grouped.keys) {
+    final client = ref.read(supabaseClientProvider);
+    final failures = <String>[];
+    for (final event in grouped.keys) {
+      try {
         await client.functions.invoke(
           'partner-approve-application',
           body: {'action': 'bulk_approve', 'event_id': event.id},
         );
+      } on Exception catch (e) {
+        failures.add('${event.title}: $e');
       }
-      if (context.mounted) {
+    }
+    if (context.mounted) {
+      if (failures.isEmpty) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('$total건 승인 완료')),
         );
-        ref.invalidate(eventApplicationsGroupedProvider);
-      }
-    } on Exception catch (e) {
-      if (context.mounted) {
+      } else {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('일괄 승인 실패: $e')),
+          SnackBar(
+            content: Text(
+              '일부 승인 실패 (${failures.length}건): ${failures.first}',
+            ),
+          ),
         );
       }
+      ref.invalidate(eventApplicationsGroupedProvider);
     }
   }
 }

--- a/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
+++ b/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
@@ -529,9 +529,9 @@ class _ApplicationItem extends StatelessWidget {
             ),
             const SizedBox(width: MinglitSpacing.xsmall),
             IconButton(
-              icon: const Icon(
+              icon: Icon(
                 Icons.check,
-                color: Colors.white,
+                color: theme.colorScheme.onPrimary,
                 size: MinglitIconSize.small,
               ),
               onPressed: onApprove,

--- a/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
+++ b/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
@@ -4,7 +4,6 @@ import 'package:app_partner/src/logic/current_partner_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/minglit_kit.dart';
-import 'package:riverpod/src/providers/future_provider.dart';
 
 /// Event application management page — grouped by event with inline approve/reject.
 class EventApplicationManagePage extends ConsumerStatefulWidget {
@@ -83,11 +82,7 @@ class _EventApplicationManagePageState
 }
 
 /// Provider to fetch applications grouped by event for a partner.
-final FutureProviderFamily<
-  Map<Event, List<EventApplication>>,
-  ({String partnerId, List<dynamic> statusFilter})
->
-eventApplicationsGroupedProvider = FutureProvider.family
+final eventApplicationsGroupedProvider = FutureProvider.family
     .autoDispose<
       Map<Event, List<EventApplication>>,
       ({String partnerId, List<String> statusFilter})

--- a/apps/app_partner/lib/src/routing/app_routes.dart
+++ b/apps/app_partner/lib/src/routing/app_routes.dart
@@ -1,5 +1,6 @@
 import 'package:app_partner/src/features/admin/partner_application_detail_page.dart';
 import 'package:app_partner/src/features/admin/partner_application_list_page.dart';
+import 'package:app_partner/src/features/application/event_application_manage_page.dart';
 import 'package:app_partner/src/features/auth/partner_login_page.dart';
 import 'package:app_partner/src/features/checkin/checkin_placeholder_page.dart';
 import 'package:app_partner/src/features/home/guide/location_guide_page.dart';
@@ -239,7 +240,7 @@ class ApplicationListRoute extends GoRouteData with $ApplicationListRoute {
   const ApplicationListRoute();
   @override
   Widget build(BuildContext context, GoRouterState state) =>
-      const PartnerApplicationListPage();
+      const EventApplicationManagePage();
 }
 
 class ApplicationDetailRoute extends GoRouteData with $ApplicationDetailRoute {

--- a/apps/app_partner/lib/src/routing/app_routes.dart
+++ b/apps/app_partner/lib/src/routing/app_routes.dart
@@ -1,5 +1,4 @@
 import 'package:app_partner/src/features/admin/partner_application_detail_page.dart';
-import 'package:app_partner/src/features/admin/partner_application_list_page.dart';
 import 'package:app_partner/src/features/application/event_application_manage_page.dart';
 import 'package:app_partner/src/features/auth/partner_login_page.dart';
 import 'package:app_partner/src/features/checkin/checkin_placeholder_page.dart';


### PR DESCRIPTION
## Summary
- 신청관리 바텀탭을 이벤트 신청 관리 화면으로 교체
- 탭바: 대기중 / 승인됨 / 거절됨
- 이벤트별 그루핑 (이벤트 헤더에 이름·날짜·건수·인원)
- 인라인 승인/거절 버튼 (상세 진입 없이)
- 전체 승인 버튼 (하단 고정)
- `partner-approve-application` / `partner-reject-application` EF 호출
- 거절 시 사유 입력 다이얼로그

Closes #522

## Test plan
- [ ] 신청관리 탭 → 이벤트별 그루핑된 목록 표시
- [ ] 승인 버튼 → EF 호출 → 대기중에서 사라지고 승인됨으로 이동
- [ ] 거절 버튼 → 사유 입력 → EF 호출 → 거절됨으로 이동
- [ ] 전체 승인 → 확인 다이얼로그 → 일괄 처리
- [ ] 빈 상태 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)