### PR TITLE
fix(ci): Daily Backend Simulation integration test 실행 방식 수정

### DIFF
--- a/.github/workflows/daily-backend-simulation.yml
+++ b/.github/workflows/daily-backend-simulation.yml
@@ -71,9 +71,12 @@ jobs:
           profile: pixel_6
           script: |
             cd apps/app_user
-            flutter test integration_test/ \
-              --flavor dev \
-              --dart-define-from-file=../../minglit_env/dev/flutter.env
+            for f in integration_test/*_test.dart; do
+              echo "▶ Running: $f"
+              flutter test "$f" \
+                --flavor dev \
+                --dart-define-from-file=../../minglit_env/dev/flutter.env
+            done
 
   partner-cuj-test:
     needs: seed-and-simulate
@@ -101,9 +104,18 @@ jobs:
           profile: pixel_6
           script: |
             cd apps/app_partner
-            flutter test integration_test/ \
-              --flavor dev \
-              --dart-define-from-file=../../minglit_env/dev/flutter.env
+            shopt -s nullglob
+            files=(integration_test/*_test.dart)
+            if [ ${#files[@]} -eq 0 ]; then
+              echo "⏭ No integration tests found, skipping."
+              exit 0
+            fi
+            for f in "${files[@]}"; do
+              echo "▶ Running: $f"
+              flutter test "$f" \
+                --flavor dev \
+                --dart-define-from-file=../../minglit_env/dev/flutter.env
+            done
 
   notify-failure:
     needs: [seed-and-simulate, client-cuj-test, partner-cuj-test]


### PR DESCRIPTION
## Summary
- `flutter test integration_test/` → 개별 파일 순차 실행으로 전환
- Flutter 3.x에서 integration/unit test 단일 호출 금지 에러 해결
- partner 앱은 integration test 파일 없으므로 graceful skip 처리

Closes #542

## Test plan
- [ ] 다음 daily schedule run (KST 07:00) 또는 workflow_dispatch로 수동 실행하여 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)