### PR TITLE
fix(ci): prevent false failure issues on cancelled workflow runs

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -69,10 +69,11 @@ jobs:
 
   notify-failure:
     needs: [auto-format]
-    if: always()
+    # Fix #563: Only notify on actual failure, not on cancelled (from cancel-in-progress)
+    if: ${{ always() && needs.auto-format.result == 'failure' }}
     permissions:
       issues: write
     uses: ./.github/workflows/notify-failure.yml
     with:
-      success: ${{ needs.auto-format.result == 'success' }}
+      success: false
       workflow_name: 'Auto Format'

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -26,10 +26,11 @@ jobs:
 
   notify-failure:
     needs: [gitleaks]
-    if: always()
+    # Fix #563: Only notify on actual failure, not on cancelled (from cancel-in-progress)
+    if: ${{ always() && needs.gitleaks.result == 'failure' }}
     permissions:
       issues: write
     uses: ./.github/workflows/notify-failure.yml
     with:
-      success: ${{ needs.gitleaks.result == 'success' }}
+      success: false
       workflow_name: 'Secret Scan'

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -26,7 +26,7 @@ jobs:
 
   notify-failure:
     needs: [gitleaks]
-    # Fix #563: Only notify on actual failure, not on cancelled (from cancel-in-progress)
+    # Fix #563, #564: Only notify on actual failure, not on cancelled (from cancel-in-progress)
     if: ${{ always() && needs.gitleaks.result == 'failure' }}
     permissions:
       issues: write


### PR DESCRIPTION
## Summary
- auto-format과 secret-scan 워크플로우가 `cancel-in-progress`로 취소된 run을 실패로 오인하여 P0-critical 이슈를 잘못 생성하는 버그 수정
- `notify-failure` job 조건을 `if: always()`에서 `if: always() && needs.X.result == 'failure'`로 변경하여 실제 실패일 때만 알림

Closes #563, closes #564

## Root Cause
`cancel-in-progress: true` 설정으로 인해 동일 PR에서 새 push가 오면 이전 run이 취소됨. `notify-failure` job은 `if: always()`로 항상 실행되고, `cancelled` 상태를 `success`가 아닌 것으로 판단하여 잘못된 이슈를 생성함.

## Test plan
- [ ] CI 통과 확인
- [ ] 동일 PR에 빠르게 push 2회 → 취소된 run에서 이슈가 생성되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)