### PR TITLE
fix: add error logging to silent catch blocks

### DIFF
--- a/apps/app_partner/lib/src/features/onboarding/widgets/address_search_dialog.dart
+++ b/apps/app_partner/lib/src/features/onboarding/widgets/address_search_dialog.dart
@@ -108,7 +108,9 @@ class _AddressSearchDialogState extends State<AddressSearchDialog> {
         _results = juso.cast<Map<String, dynamic>>();
         _isLoading = false;
       });
-    } on Exception catch (_) {
+    // Fix #544: 에러 삼킴 catch에 로깅 추가
+    } on Exception catch (e, st) {
+      Log.e('❌ [AddressSearchDialog] Address search Error', e, st);
       if (!mounted) return;
       setState(() {
         _isLoading = false;

--- a/apps/app_partner/lib/src/features/onboarding/widgets/address_search_dialog.dart
+++ b/apps/app_partner/lib/src/features/onboarding/widgets/address_search_dialog.dart
@@ -108,7 +108,7 @@ class _AddressSearchDialogState extends State<AddressSearchDialog> {
         _results = juso.cast<Map<String, dynamic>>();
         _isLoading = false;
       });
-    // Fix #544: 에러 삼킴 catch에 로깅 추가
+      // Fix #544: 에러 삼킴 catch에 로깅 추가
     } on Exception catch (e, st) {
       Log.e('❌ [AddressSearchDialog] Address search Error', e, st);
       if (!mounted) return;

--- a/apps/app_user/lib/src/logic/feed_state_provider.dart
+++ b/apps/app_user/lib/src/logic/feed_state_provider.dart
@@ -352,7 +352,7 @@ class RecommendationFeedNotifier extends _$RecommendationFeedNotifier {
       // Discard if a filter change occurred during fetch
       if (updated == null) return;
       state = AsyncData(updated);
-    // Fix #544: 에러 삼킴 catch에 로깅 추가
+      // Fix #544: 에러 삼킴 catch에 로깅 추가
     } on Exception catch (e, st) {
       Log.e('❌ [FeedStateProvider] Load more Error', e, st);
       // On error: restore previous state, preserve existing events

--- a/apps/app_user/lib/src/logic/feed_state_provider.dart
+++ b/apps/app_user/lib/src/logic/feed_state_provider.dart
@@ -352,7 +352,9 @@ class RecommendationFeedNotifier extends _$RecommendationFeedNotifier {
       // Discard if a filter change occurred during fetch
       if (updated == null) return;
       state = AsyncData(updated);
-    } on Exception catch (_) {
+    // Fix #544: 에러 삼킴 catch에 로깅 추가
+    } on Exception catch (e, st) {
+      Log.e('❌ [FeedStateProvider] Load more Error', e, st);
       // On error: restore previous state, preserve existing events
       if (!ref.mounted) return;
       state = AsyncData(current.copyWith(isLoadingMore: false));


### PR DESCRIPTION
## Summary

- `AddressSearchDialog`: `on Exception catch (_)` → `on Exception catch (e, st)` with `Log.e(...)` as first statement in catch block
- `FeedStateProvider`: same pattern applied to the `loadMore` catch block
- Existing behavior is fully preserved; only adds observability

Closes #544