### PR TITLE
fix(payment): 구매내역 날짜를 paidAt(실제 결제일)으로 표시

### DIFF
--- a/apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart
+++ b/apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart
@@ -50,7 +50,8 @@ class PurchaseHistoryCard extends ConsumerWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text(
-                DateFormat('yyyy.MM.dd').format(application.createdAt),
+                // Fix #579: 구매일은 paidAt(실제 결제일)을 표시, 없으면 createdAt 폴백
+                DateFormat('yyyy.MM.dd').format(application.paidAt ?? application.createdAt),
                 style: theme.textTheme.labelMedium?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),

--- a/apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart
+++ b/apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart
@@ -51,9 +51,10 @@ class PurchaseHistoryCard extends ConsumerWidget {
             children: [
               Text(
                 // Fix #579: 구매일은 paidAt(실제 결제일)을 표시, 없으면 createdAt 폴백
-                DateFormat(
-                  'yyyy.MM.dd',
-                ).format(application.paidAt ?? application.createdAt),
+                // UTC → 로컬 변환 후 포맷 (KST 등에서 날짜 하루 차이 방지)
+                DateFormat('yyyy.MM.dd').format(
+                  (application.paidAt ?? application.createdAt).toLocal(),
+                ),
                 style: theme.textTheme.labelMedium?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),

--- a/apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart
+++ b/apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart
@@ -51,7 +51,9 @@ class PurchaseHistoryCard extends ConsumerWidget {
             children: [
               Text(
                 // Fix #579: 구매일은 paidAt(실제 결제일)을 표시, 없으면 createdAt 폴백
-                DateFormat('yyyy.MM.dd').format(application.paidAt ?? application.createdAt),
+                DateFormat(
+                  'yyyy.MM.dd',
+                ).format(application.paidAt ?? application.createdAt),
                 style: theme.textTheme.labelMedium?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),

--- a/apps/app_user/test/src/features/payment/ui/purchase_history_card_test.dart
+++ b/apps/app_user/test/src/features/payment/ui/purchase_history_card_test.dart
@@ -81,4 +81,108 @@ void main() {
       expect(find.text('Free Ticket'), findsOneWidget);
     });
   });
+
+  group('PurchaseHistoryCard — Fix #579 구매일 표시 회귀 테스트', () {
+    testWidgets('displays paidAt date when available', (tester) async {
+      final paidDate = DateTime(2026, 3, 15);
+      final createdDate = DateTime(2026, 3, 10);
+
+      final mockHistory = [
+        EventApplication(
+          id: 'app1',
+          eventId: 'event1',
+          ticketId: 'ticket1',
+          userId: 'user1',
+          status: 'paid',
+          createdAt: createdDate,
+          updatedAt: createdDate,
+          paidAt: paidDate,
+          event: Event(
+            id: 'event1',
+            partyId: 'party1',
+            startTime: DateTime(2026, 4, 1, 19),
+            endTime: DateTime(2026, 4, 1, 21),
+            createdAt: createdDate,
+            updatedAt: createdDate,
+            title: 'Paid Event',
+          ),
+          ticket: Ticket(
+            id: 'ticket1',
+            name: 'Standard Ticket',
+            createdAt: createdDate,
+            updatedAt: createdDate,
+          ),
+        ),
+      ];
+
+      when(
+        () => mockEventRepository.getMyPurchaseHistory('user1'),
+      ).thenAnswer((_) async => mockHistory);
+
+      await tester.pumpWidget(
+        createTestWidget([
+          currentUserProvider.overrideWith((ref) => mockUser),
+          eventRepositoryProvider.overrideWithValue(mockEventRepository),
+        ]),
+      );
+
+      await tester.pump();
+      await tester.pump();
+      await tester.pump();
+
+      // paidAt 날짜(2026.03.15)가 표시되어야 함
+      expect(find.text('2026.03.15'), findsOneWidget);
+      // createdAt 날짜(2026.03.10)는 표시되지 않아야 함
+      expect(find.text('2026.03.10'), findsNothing);
+    });
+
+    testWidgets('falls back to createdAt when paidAt is null', (tester) async {
+      final createdDate = DateTime(2026, 3, 10);
+
+      final mockHistory = [
+        EventApplication(
+          id: 'app2',
+          eventId: 'event2',
+          ticketId: 'ticket2',
+          userId: 'user1',
+          status: 'paid',
+          createdAt: createdDate,
+          updatedAt: createdDate,
+          event: Event(
+            id: 'event2',
+            partyId: 'party2',
+            startTime: DateTime(2026, 4, 5, 19),
+            endTime: DateTime(2026, 4, 5, 21),
+            createdAt: createdDate,
+            updatedAt: createdDate,
+            title: 'Free Event',
+          ),
+          ticket: Ticket(
+            id: 'ticket2',
+            name: 'Free Ticket',
+            createdAt: createdDate,
+            updatedAt: createdDate,
+          ),
+        ),
+      ];
+
+      when(
+        () => mockEventRepository.getMyPurchaseHistory('user1'),
+      ).thenAnswer((_) async => mockHistory);
+
+      await tester.pumpWidget(
+        createTestWidget([
+          currentUserProvider.overrideWith((ref) => mockUser),
+          eventRepositoryProvider.overrideWithValue(mockEventRepository),
+        ]),
+      );
+
+      await tester.pump();
+      await tester.pump();
+      await tester.pump();
+
+      // paidAt가 null이면 createdAt(2026.03.10)이 표시되어야 함
+      expect(find.text('2026.03.10'), findsOneWidget);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- 구매내역 카드에서 `createdAt`(신청 생성일) 대신 `paidAt`(실제 결제 완료일)을 표시하도록 수정
- `paidAt`가 null인 경우(무료 이벤트 등) `createdAt`으로 폴백
- 회귀 테스트 2건 추가 (paidAt 있을 때 / null일 때)

Closes #579

## Test plan
- [x] `paidAt` 있을 때 해당 날짜 표시 확인
- [x] `paidAt` null일 때 `createdAt` 폴백 확인
- [x] 기존 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)