### PR TITLE
fix(security): event-matching 인가 우회 차단

### DIFF
--- a/supabase/functions/_shared/auth_utils.ts
+++ b/supabase/functions/_shared/auth_utils.ts
@@ -34,3 +34,29 @@ export async function requireAuth(
 
   return data.user.id;
 }
+
+/**
+ * Verify that the request carries a Bearer token matching the
+ * `SUPABASE_SERVICE_ROLE_KEY` environment variable.
+ *
+ * Use this for system-only Edge Functions that must not be callable
+ * by regular authenticated users.
+ *
+ * Returns `true` when the token matches, or a 401 Response on failure.
+ *
+ * Usage:
+ * ```ts
+ * const auth = requireServiceRole(req);
+ * if (auth instanceof Response) return auth; // 401
+ * ```
+ */
+export function requireServiceRole(req: Request): true | Response {
+  const authHeader = req.headers.get("Authorization");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+
+  if (!authHeader || authHeader !== `Bearer ${serviceRoleKey}`) {
+    return errorResponse("Unauthorized", 401);
+  }
+
+  return true;
+}

--- a/supabase/functions/event-matching/event_matching_test.ts
+++ b/supabase/functions/event-matching/event_matching_test.ts
@@ -1,8 +1,8 @@
 import { assertEquals } from "@std/assert";
 import {
-  authenticatedJsonRequest,
   captureServeHandler,
   createFetchMock,
+  jsonRequest,
   jsonResponse,
   readJson,
   withEnv,
@@ -16,6 +16,49 @@ const ENV = {
 
 const BASE_URL = "http://localhost";
 
+/** Helper: create a POST request with service_role bearer token */
+function serviceRoleJsonRequest(url: string, body: unknown): Request {
+  return jsonRequest(url, body, {
+    headers: { Authorization: "Bearer test-service-key" },
+  });
+}
+
+// ── Auth tests (Fix #592) ──────────────────────────────────────────
+
+Deno.test({
+  name: "event-matching - returns 401 for regular user JWT",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+    await withEnv(ENV, async () => {
+      const request = jsonRequest(BASE_URL, { event_id: "evt-1" }, {
+        headers: { Authorization: "Bearer regular-user-jwt" },
+      });
+      const response = await handler(request);
+      assertEquals(response.status, 401);
+    });
+  },
+});
+
+Deno.test({
+  name: "event-matching - returns 401 when Authorization header is missing",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+    await withEnv(ENV, async () => {
+      const request = new Request(BASE_URL, { method: "POST" });
+      const response = await handler(request);
+      assertEquals(response.status, 401);
+    });
+  },
+});
+
+// ── Functional tests ────────────────────────────────────────────────
+
 Deno.test({
   name: "event-matching - creates match pairs from two groups",
   sanitizeResources: false,
@@ -28,10 +71,6 @@ Deno.test({
     ];
 
     const { fetchMock } = createFetchMock([
-      {
-        matcher: "/auth/v1/user",
-        handler: () => jsonResponse({ id: "admin-1", email: "admin@test.com" }),
-      },
       // existing pairs check — empty
       {
         matcher: (req) => req.url.includes("/rest/v1/match_pairs") && req.method === "GET",
@@ -65,7 +104,7 @@ Deno.test({
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
         const response = await handler(
-          authenticatedJsonRequest(BASE_URL, { event_id: "evt-1" }),
+          serviceRoleJsonRequest(BASE_URL, { event_id: "evt-1" }),
         );
         assertEquals(response.status, 200);
 
@@ -93,10 +132,6 @@ Deno.test({
 
     const { fetchMock, calls } = createFetchMock([
       {
-        matcher: "/auth/v1/user",
-        handler: () => jsonResponse({ id: "admin-1", email: "admin@test.com" }),
-      },
-      {
         matcher: (req) =>
           req.url.includes("/rest/v1/match_pairs") && req.method === "GET",
         handler: () => jsonResponse(existingPairs),
@@ -106,7 +141,7 @@ Deno.test({
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
         const response = await handler(
-          authenticatedJsonRequest(BASE_URL, { event_id: "evt-1" }),
+          serviceRoleJsonRequest(BASE_URL, { event_id: "evt-1" }),
         );
         assertEquals(response.status, 200);
 
@@ -132,23 +167,14 @@ Deno.test({
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
-    const { fetchMock } = createFetchMock([
-      {
-        matcher: "/auth/v1/user",
-        handler: () => jsonResponse({ id: "admin-1", email: "admin@test.com" }),
-      },
-    ]);
-
     await withEnv(ENV, async () => {
-      await withMockedFetch(fetchMock, async () => {
-        const response = await handler(
-          authenticatedJsonRequest(BASE_URL, {}),
-        );
-        assertEquals(response.status, 400);
+      const response = await handler(
+        serviceRoleJsonRequest(BASE_URL, {}),
+      );
+      assertEquals(response.status, 400);
 
-        const body = await readJson(response);
-        assertEquals(body.error, "Missing required parameter: event_id");
-      });
+      const body = await readJson(response);
+      assertEquals(body.error, "Missing required parameter: event_id");
     });
   },
 });
@@ -162,10 +188,6 @@ Deno.test({
 
     const { fetchMock } = createFetchMock([
       {
-        matcher: "/auth/v1/user",
-        handler: () => jsonResponse({ id: "admin-1", email: "admin@test.com" }),
-      },
-      {
         matcher: (req) => req.url.includes("/rest/v1/match_pairs") && req.method === "GET",
         handler: () => jsonResponse([]),
       },
@@ -178,7 +200,7 @@ Deno.test({
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
         const response = await handler(
-          authenticatedJsonRequest(BASE_URL, { event_id: "evt-1" }),
+          serviceRoleJsonRequest(BASE_URL, { event_id: "evt-1" }),
         );
         assertEquals(response.status, 400);
 
@@ -197,10 +219,6 @@ Deno.test({
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
     const { fetchMock } = createFetchMock([
-      {
-        matcher: "/auth/v1/user",
-        handler: () => jsonResponse({ id: "admin-1", email: "admin@test.com" }),
-      },
       {
         matcher: (req) => req.url.includes("/rest/v1/match_pairs") && req.method === "GET",
         handler: () => jsonResponse([]),
@@ -226,7 +244,7 @@ Deno.test({
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
         const response = await handler(
-          authenticatedJsonRequest(BASE_URL, { event_id: "evt-1" }),
+          serviceRoleJsonRequest(BASE_URL, { event_id: "evt-1" }),
         );
         assertEquals(response.status, 400);
 
@@ -246,10 +264,6 @@ Deno.test({
 
     // user-z from group A, user-a from group B → lower=user-a, higher=user-z
     const { fetchMock, calls } = createFetchMock([
-      {
-        matcher: "/auth/v1/user",
-        handler: () => jsonResponse({ id: "admin-1", email: "admin@test.com" }),
-      },
       {
         matcher: (req) => req.url.includes("/rest/v1/match_pairs") && req.method === "GET",
         handler: () => jsonResponse([]),
@@ -272,7 +286,7 @@ Deno.test({
       },
       {
         matcher: (req) => req.url.includes("/rest/v1/match_pairs") && req.method === "POST",
-        handler: (req) =>
+        handler: () =>
           jsonResponse(
             [{ id: "mp-1", user_lower_id: "user-a", user_higher_id: "user-z" }],
             { status: 201 },
@@ -283,7 +297,7 @@ Deno.test({
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
         const response = await handler(
-          authenticatedJsonRequest(BASE_URL, { event_id: "evt-1" }),
+          serviceRoleJsonRequest(BASE_URL, { event_id: "evt-1" }),
         );
         assertEquals(response.status, 200);
 

--- a/supabase/functions/event-matching/index.ts
+++ b/supabase/functions/event-matching/index.ts
@@ -2,7 +2,8 @@
 
 import { createServiceClient } from "../_shared/supabase_client.ts";
 import { corsResponse, errorResponse, successResponse } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
+// Fix #592: requireAuth(일반 JWT) → requireServiceRole로 전환하여 인가 우회 차단
+import { requireServiceRole } from "../_shared/auth_utils.ts";
 import { initSentry, withHandler, log } from "../_shared/logger.ts";
 
 const FN = "event-matching";
@@ -12,7 +13,8 @@ initSentry();
 Deno.serve(withHandler(async (req) => {
   if (req.method === "OPTIONS") return corsResponse();
 
-  const auth = await requireAuth(req);
+  // Fix #592: service_role 전용 — 일반 유저 JWT로 호출 불가
+  const auth = requireServiceRole(req);
   if (auth instanceof Response) return auth;
 
   let reqBody: Record<string, unknown>;
@@ -29,11 +31,6 @@ Deno.serve(withHandler(async (req) => {
   }
 
   const supabase = createServiceClient();
-
-  // Only service_role or admin can trigger matching — verify caller has elevated access
-  // (requireAuth already validated JWT; for admin check, service_role callers pass a service_role JWT)
-  // For backend-simulator calls with service_role token, auth will be the service_role user id.
-  // This is acceptable since event-matching is an admin-only operation.
 
   // Check idempotency: if match_pairs already exist for this event, return existing
   const { data: existingPairs, error: existingErr } = await supabase
@@ -122,7 +119,7 @@ Deno.serve(withHandler(async (req) => {
 
   const resultPairs = (insertedPairs ?? []) as Array<{ id: string; user_lower_id: string; user_higher_id: string }>;
 
-  log({ function: FN, level: "info", message: "Match pairs created", metadata: { event_id, match_count: resultPairs.length, triggered_by: auth } });
+  log({ function: FN, level: "info", message: "Match pairs created", metadata: { event_id, match_count: resultPairs.length } });
 
   return successResponse({
     success: true,


### PR DESCRIPTION
## Summary

- `event-matching` Edge Function의 인증을 `requireAuth`(일반 유저 JWT 허용)에서 `requireServiceRole`(service_role 전용)로 전환
- `auth_utils.ts`에 재사용 가능한 `requireServiceRole` 헬퍼 추가
- 기존 테스트를 service_role 인증 패턴으로 업데이트하고, 일반 JWT/미인증 요청에 대한 401 테스트 케이스 추가

Closes #592

## Test plan

- [x] 일반 유저 JWT로 호출 시 401 반환 확인 (테스트 추가)
- [x] Authorization 헤더 없이 호출 시 401 반환 확인 (테스트 추가)
- [x] service_role 토큰으로 호출 시 기존 기능 정상 동작 확인 (기존 테스트 업데이트)
- [ ] CI `test-edge-functions` job 통과 확인