### PR TITLE
fix(security): settlement EF 권한 수준 불일치 수정

### DIFF
--- a/supabase/functions/_shared/auth_utils.ts
+++ b/supabase/functions/_shared/auth_utils.ts
@@ -3,6 +3,28 @@ import { createServiceClient } from "./supabase_client.ts";
 import { errorResponse } from "./response_utils.ts";
 
 /**
+ * Verify that the request bears the service_role key.
+ *
+ * Compares the Bearer token in the Authorization header against
+ * `SUPABASE_SERVICE_ROLE_KEY`. Returns `true` on success,
+ * or a 401 Response on failure.
+ *
+ * Usage:
+ * ```ts
+ * const auth = requireServiceRole(req);
+ * if (auth instanceof Response) return auth; // 401
+ * ```
+ */
+export function requireServiceRole(req: Request): true | Response {
+  const authHeader = req.headers.get("Authorization");
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+  if (!authHeader || authHeader !== `Bearer ${serviceRoleKey}`) {
+    return errorResponse("Unauthorized", 401);
+  }
+  return true;
+}
+
+/**
  * Extract Bearer token from Authorization header and verify it
  * against Supabase Auth using `auth.getUser()`.
  *

--- a/supabase/functions/_shared/auth_utils.ts
+++ b/supabase/functions/_shared/auth_utils.ts
@@ -3,28 +3,6 @@ import { createServiceClient } from "./supabase_client.ts";
 import { errorResponse } from "./response_utils.ts";
 
 /**
- * Verify that the request bears the service_role key.
- *
- * Compares the Bearer token in the Authorization header against
- * `SUPABASE_SERVICE_ROLE_KEY`. Returns `true` on success,
- * or a 401 Response on failure.
- *
- * Usage:
- * ```ts
- * const auth = requireServiceRole(req);
- * if (auth instanceof Response) return auth; // 401
- * ```
- */
-export function requireServiceRole(req: Request): true | Response {
-  const authHeader = req.headers.get("Authorization");
-  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
-  if (!authHeader || authHeader !== `Bearer ${serviceRoleKey}`) {
-    return errorResponse("Unauthorized", 401);
-  }
-  return true;
-}
-
-/**
  * Extract Bearer token from Authorization header and verify it
  * against Supabase Auth using `auth.getUser()`.
  *
@@ -74,7 +52,12 @@ export async function requireAuth(
  */
 export function requireServiceRole(req: Request): true | Response {
   const authHeader = req.headers.get("Authorization");
-  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+  // Fix #593: fail-closed — env 미설정 시 즉시 차단
+  if (!serviceRoleKey) {
+    return errorResponse("Server misconfigured", 500);
+  }
 
   if (!authHeader || authHeader !== `Bearer ${serviceRoleKey}`) {
     return errorResponse("Unauthorized", 401);

--- a/supabase/functions/payout-sync/index.ts
+++ b/supabase/functions/payout-sync/index.ts
@@ -2,7 +2,7 @@
 import { createServiceClient } from "../_shared/supabase_client.ts";
 import { PortoneV2Client } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
+import { requireServiceRole } from "../_shared/auth_utils.ts";
 import { initSentry, withHandler, log } from "../_shared/logger.ts";
 
 const FN = "payout-sync";
@@ -38,7 +38,8 @@ function classifyError(errorCode: string): { retryable: boolean } {
 Deno.serve(withHandler(async (req) => {
   if (req.method === "OPTIONS") return corsResponse();
 
-  const auth = await requireAuth(req);
+  // Fix #593: service_role 전용으로 전환 — 벌크 금융 작업에 일반 유저 접근 차단
+  const auth = requireServiceRole(req);
   if (auth instanceof Response) return auth;
 
   try {

--- a/supabase/functions/payout-sync/payout_sync_test.ts
+++ b/supabase/functions/payout-sync/payout_sync_test.ts
@@ -36,15 +36,31 @@ function classifyError(errorCode: string): { retryable: boolean } {
   return { retryable: true };
 }
 
+Deno.test("payout-sync - 인증 실패: 잘못된 토큰은 401 반환", async () => {
+  await withEnv(ENV, async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const request = jsonRequest("http://localhost", {}, {
+      headers: { Authorization: "Bearer bad-key" },
+    });
+    const response = await handler(request);
+    assertEquals(response.status, 401);
+  });
+});
+
+Deno.test("payout-sync - 인증 실패: Authorization 헤더 없으면 401 반환", async () => {
+  await withEnv(ENV, async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const request = new Request("http://localhost", { method: "POST" });
+    const response = await handler(request);
+    assertEquals(response.status, 401);
+  });
+});
+
 Deno.test("payout-sync - 빈 목록: 비종결 payouts 없으면 synced=0 반환", async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
     const { fetchMock } = createFetchMock([
-      {
-        matcher: (req: Request) => req.url.includes("/auth/v1/user"),
-        handler: () => jsonResponse({ id: "user-test-id", email: "test@test.com" }),
-      },
       {
         matcher: (req) =>
           req.url.includes("/rest/v1/payouts") && req.method === "GET",

--- a/supabase/functions/settlement-register-transfers/index.ts
+++ b/supabase/functions/settlement-register-transfers/index.ts
@@ -2,7 +2,7 @@
 import { createServiceClient } from "../_shared/supabase_client.ts";
 import { PortoneV2Client } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
+import { requireServiceRole } from "../_shared/auth_utils.ts";
 import { initSentry, withHandler, log } from "../_shared/logger.ts";
 
 const FN = "settlement-register-transfers";
@@ -20,7 +20,8 @@ const CHUNK_SIZE = 500;
 Deno.serve(withHandler(async (req) => {
   if (req.method === "OPTIONS") return corsResponse();
 
-  const auth = await requireAuth(req);
+  // Fix #593: service_role 전용으로 전환 — 벌크 금융 작업에 일반 유저 접근 차단
+  const auth = requireServiceRole(req);
   if (auth instanceof Response) return auth;
 
   try {

--- a/supabase/functions/settlement-register-transfers/settlement_register_transfers_test.ts
+++ b/supabase/functions/settlement-register-transfers/settlement_register_transfers_test.ts
@@ -16,17 +16,31 @@ const ENV = {
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
 };
 
-const authMockRoute = {
-  matcher: (req: Request) => req.url.includes("/auth/v1/user"),
-  handler: () => jsonResponse({ id: "user-test-id", email: "test@test.com" }),
-};
+Deno.test("settlement-register-transfers - 인증 실패: 잘못된 토큰은 401 반환", async () => {
+  await withEnv(ENV, async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const request = jsonRequest("http://localhost", {}, {
+      headers: { Authorization: "Bearer bad-key" },
+    });
+    const response = await handler(request);
+    assertEquals(response.status, 401);
+  });
+});
+
+Deno.test("settlement-register-transfers - 인증 실패: Authorization 헤더 없으면 401 반환", async () => {
+  await withEnv(ENV, async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const request = new Request("http://localhost", { method: "POST" });
+    const response = await handler(request);
+    assertEquals(response.status, 401);
+  });
+});
 
 Deno.test("settlement-register-transfers - 빈 목록: PENDING items 없으면 processed=0 반환", async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
     const { fetchMock } = createFetchMock([
-      authMockRoute,
       {
         matcher: (req) =>
           req.url.includes("/rest/v1/settlement_items") && req.method === "GET",
@@ -56,7 +70,6 @@ Deno.test("settlement-register-transfers - 정상 처리: createOrderTransfer �
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
     const { fetchMock, calls } = createFetchMock([
-      authMockRoute,
       {
         matcher: (req) =>
           req.url.includes("/rest/v1/settlement_items") && req.method === "GET",
@@ -133,7 +146,6 @@ Deno.test("settlement-register-transfers - PortOne 에러: createOrderTransfer �
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
     const { fetchMock } = createFetchMock([
-      authMockRoute,
       {
         matcher: (req) =>
           req.url.includes("/rest/v1/settlement_items") && req.method === "GET",
@@ -189,7 +201,6 @@ Deno.test("settlement-register-transfers - 멱등성: portone_transfer_id IS NUL
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
     const { fetchMock, calls } = createFetchMock([
-      authMockRoute,
       {
         matcher: (req) =>
           req.url.includes("/rest/v1/settlement_items") && req.method === "GET",


### PR DESCRIPTION
## Summary

- `settlement-register-transfers`, `payout-sync` Edge Function에서 `requireAuth`(일반 JWT) → `requireServiceRole`(service_role bearer) 검증으로 전환
- `auth_utils.ts`에 재사용 가능한 `requireServiceRole` 헬퍼 추가
- `reconciliation-daily`와 동일한 service_role 전용 패턴 적용
- 인증 실패(잘못된 토큰, 헤더 누락) 테스트 케이스 추가

Closes #593

## Test plan

- [ ] settlement-register-transfers: 잘못된 토큰으로 401 반환 확인
- [ ] settlement-register-transfers: Authorization 헤더 없이 401 반환 확인
- [ ] payout-sync: 잘못된 토큰으로 401 반환 확인
- [ ] payout-sync: Authorization 헤더 없이 401 반환 확인
- [ ] 기존 테스트(정상 처리, 에러 케이스 등) 통과 확인
- [ ] service_role key로 정상 접근 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)