### PR TITLE
docs: architecture 문서 최신화 (2026-03-29)

### DIFF
--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -91,7 +91,7 @@ Minglit의 Supabase 기반 백엔드 인프라를 기술한다.
 | `social_interactions` | 소셜 상호작용 | user_id, target_id, target_type, interaction_type (like/subscribe/bookmark/block) |
 | `match_rules` | 매칭 규칙 | event_id, source_group_id, target_group_id, vote_count |
 | `match_votes` | 매칭 투표 | event_id, voter_id, candidate_id |
-| `match_pairs` | 매칭 결과 | event_id, user_lower_id, user_higher_id, matched_at |
+| `match_pairs` | 매칭 결과 | event_id, user_lower_id, user_higher_id, matched_at, notification_sent |
 | `minglit_files` | 파일 메타데이터 | storage_object_id, bucket_id, file_path, owner_id |
 | `file_access_grants` | 파일 접근 권한 | file_id, viewer_id, expires_at |
 | `settlements` | 정산 (레거시) | partner_id, event_id, total_sales, net_amount, status — [상세](./payment-pipeline.md) |
@@ -388,6 +388,7 @@ protect_user_profile_fields() → trigger
 | `get_entry_group_participant_counts()` | 입장 그룹별 참가자 수 조회 | SECURITY DEFINER |
 | `search_events_pgroonga()` | 이벤트 전문 검색 | SECURITY INVOKER |
 | `search_parties_pgroonga()` | 파티 전문 검색 | SECURITY INVOKER |
+| `cast_match_vote()` | 매칭 투표 (advisory lock 기반 원자적 투표 + 상호 매칭 감지) | SECURITY DEFINER |
 | `replace_match_rules()` | 매칭 규칙 원자적 교체 (delete + insert) | SECURITY DEFINER |
 | `get_ticket_public_key()` | 티켓 QR 서명 검증용 Ed25519 공개키 조회 | SECURITY DEFINER |
 | `notify_match_results()` | 매칭 결과 알림 발송 (크론 호출) | SECURITY DEFINER |

--- a/docs/architecture/global-event-pipeline.md
+++ b/docs/architecture/global-event-pipeline.md
@@ -46,7 +46,7 @@ The diagram below illustrates the flow of an event from the database trigger to 
 
 ## 3. Event Types
 
-Minglit tracks nine primary event types. Each type has a specific producer and target queues.
+Minglit tracks ten primary event types. Each type has a specific producer and target queues.
 
 | Event Type | Producer (Trigger/Cron) | Target Queues | Description |
 | :--- | :--- | :--- | :--- |
@@ -59,6 +59,7 @@ Minglit tracks nine primary event types. Each type has a specific producer and t
 | `new_application` | `event_applications` INSERT | `q_notifications` | Notifies partners about a new applicant for their event. |
 | `verification_result` | `verification_submissions` UPDATE | `q_notifications` | Communicates the outcome of a user's ID verification. |
 | `event_reminder` | `send_event_reminders()` cron | `q_notifications` | Sent to participants one hour before an event starts. |
+| `match_result` | `notify_match_results()` cron | `q_notifications` | Notifies matched users of their match result after the event. |
 
 ## 4. Event Routes
 
@@ -77,8 +78,9 @@ The `event_routes` table governs how events move from the global queue to specia
 | `new_application` | ✅ | — |
 | `verification_result` | ✅ | — |
 | `event_reminder` | ✅ | — |
+| `match_result` | ✅ | — |
 
-Total: 11 active routes (q_notifications: 9, q_vectors: 2)
+Total: 12 active routes (q_notifications: 10, q_vectors: 2)
 
 ## 5. Payload Schema
 
@@ -123,6 +125,7 @@ While some legacy triggers still hold text, the system is moving toward a templa
 | `new_application` | `[신규 신청] {title}` | `새로운 이벤트 참가 신청이 도착했습니다.` |
 | `verification_result` | `[인증 승인] {display_name}` | `인증이 승인되었습니다.` |
 | `event_reminder` | `[리마인더] {title}` | `이벤트가 1시간 후 시작됩니다.` |
+| `match_result` | `[매칭 결과]` | `{event_title}에서 매칭이 성사되었습니다! 결과를 확인해 보세요.` |
 
 ## 8. Error Handling
 


### PR DESCRIPTION
## Summary
- **backend.md**: `match_pairs.notification_sent` 컬럼, `cast_match_vote()` RPC 추가
- **global-event-pipeline.md**: `match_result` 이벤트 타입 추가 (10번째), Route Matrix·알림 템플릿 반영

## 근거
- `20260323000001_match_notification_and_vote_cleanup_cron.sql` 마이그레이션 반영
- `notification-worker` 실제 코드의 match_result 템플릿 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)