### PR TITLE
fix(ci): psql vault 검증 IPv6 연결 실패 — IPv4 강제

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -92,6 +92,9 @@ jobs:
           DB_PASSWORD: ${{ steps.env.outputs.DB_PASSWORD }}
           PROJECT_ID: ${{ steps.env.outputs.PROJECT_ID }}
         run: |
+          # Fix #669: GitHub Actions 러너 IPv6 미지원 — IPv4 우선으로 변경
+          sudo sh -c 'echo "precedence ::ffff:0:0/96 100" >> /etc/gai.conf'
+
           REQUIRED=$(jq -r '.vault.required | keys[]' env-manifest.json)
           VAULT_MISSING=""
           for key in $REQUIRED; do


### PR DESCRIPTION
## Summary
- Supabase migration 배포 후 vault 검증 단계에서 `psql`이 IPv6로 연결 시도 → `Network is unreachable` 에러로 5회 연속 실패
- `/etc/gai.conf`에 IPv4 우선 설정 추가하여 DNS 해석 시 IPv4 주소를 선택하도록 변경

Closes #669

## Test plan
- [ ] `Deploy Supabase Migrations` 워크플로우 수동 실행하여 vault 검증 단계 통과 확인
- [ ] dev 브랜치 머지 후 자동 배포 시 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)