### PR TITLE
refactor: MatchingVoteScreen → MatchingVoteContent 위젯 추출

### DIFF
--- a/apps/app_user/lib/src/features/event/matching/matching_vote_screen.dart
+++ b/apps/app_user/lib/src/features/event/matching/matching_vote_screen.dart
@@ -4,8 +4,24 @@ import 'package:app_user/src/features/event/matching/matching_vote_controller.da
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
+/// Full-screen matching vote page with Scaffold + AppBar.
 class MatchingVoteScreen extends ConsumerWidget {
   const MatchingVoteScreen({required this.eventId, super.key});
+
+  final String eventId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: MinglitTheme.simpleAppBar(title: '매칭 투표'),
+      body: MatchingVoteContent(eventId: eventId),
+    );
+  }
+}
+
+/// Scaffold-free matching vote UI — embeddable in bottom sheets or other hosts.
+class MatchingVoteContent extends ConsumerWidget {
+  const MatchingVoteContent({required this.eventId, super.key});
 
   final String eventId;
 
@@ -34,141 +50,138 @@ class MatchingVoteScreen extends ConsumerWidget {
       }
     });
 
-    return Scaffold(
-      appBar: MinglitTheme.simpleAppBar(title: '매칭 투표'),
-      body: Column(
-        children: [
-          // 1. Matches (Success)
-          MinglitAsyncValueWidget(
-            value: matchesAsync,
-            data: (matches) {
-              if (matches.isEmpty) return const SizedBox.shrink();
-              return ColoredBox(
-                color: theme.colorScheme.secondaryContainer.withValues(
-                  alpha: 0.2,
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.all(MinglitSpacing.medium),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        children: [
-                          Icon(
-                            Icons.favorite,
-                            color: theme.colorScheme.error,
-                            size: MinglitIconSize.small,
-                          ),
-                          const SizedBox(width: MinglitSpacing.small),
-                          Text(
-                            '매칭 성공! (${matches.length}명)',
-                            style: theme.textTheme.titleSmall?.copyWith(
-                              fontWeight: FontWeight.bold,
-                              color: theme.colorScheme.error,
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: MinglitSpacing.small),
-                      SizedBox(
-                        height: 80,
-                        child: ListView.separated(
-                          scrollDirection: Axis.horizontal,
-                          itemCount: matches.length,
-                          separatorBuilder: (context, index) =>
-                              const SizedBox(width: MinglitSpacing.medium),
-                          itemBuilder: (context, index) {
-                            final match = matches[index];
-                            return _buildMatchCard(context, match);
-                          },
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              );
-            },
-          ),
-
-          // Fix #306: 잔여 투표 수 표시
-          if (voteCountAsync.hasValue && maxVoteAsync.hasValue)
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: MinglitSpacing.medium,
-                vertical: MinglitSpacing.small,
+    return Column(
+      children: [
+        // 1. Matches (Success)
+        MinglitAsyncValueWidget(
+          value: matchesAsync,
+          data: (matches) {
+            if (matches.isEmpty) return const SizedBox.shrink();
+            return ColoredBox(
+              color: theme.colorScheme.secondaryContainer.withValues(
+                alpha: 0.2,
               ),
-              child: Builder(
-                builder: (context) {
-                  final used = voteCountAsync.value!;
-                  final max = maxVoteAsync.value!;
-                  final remaining = max - used;
-                  final allUsed = remaining <= 0;
-                  return Row(
-                    children: [
-                      Icon(
-                        allUsed ? Icons.check_circle : Icons.how_to_vote,
-                        size: MinglitIconSize.small,
+              child: Padding(
+                padding: const EdgeInsets.all(MinglitSpacing.medium),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Icon(
+                          Icons.favorite,
+                          color: theme.colorScheme.error,
+                          size: MinglitIconSize.small,
+                        ),
+                        const SizedBox(width: MinglitSpacing.small),
+                        Text(
+                          '매칭 성공! (${matches.length}명)',
+                          style: theme.textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            color: theme.colorScheme.error,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: MinglitSpacing.small),
+                    SizedBox(
+                      height: 80,
+                      child: ListView.separated(
+                        scrollDirection: Axis.horizontal,
+                        itemCount: matches.length,
+                        separatorBuilder: (context, index) =>
+                            const SizedBox(width: MinglitSpacing.medium),
+                        itemBuilder: (context, index) {
+                          final match = matches[index];
+                          return _buildMatchCard(context, match);
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+
+        // Fix #306: 잔여 투표 수 표시
+        if (voteCountAsync.hasValue && maxVoteAsync.hasValue)
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: MinglitSpacing.medium,
+              vertical: MinglitSpacing.small,
+            ),
+            child: Builder(
+              builder: (context) {
+                final used = voteCountAsync.value!;
+                final max = maxVoteAsync.value!;
+                final remaining = max - used;
+                final allUsed = remaining <= 0;
+                return Row(
+                  children: [
+                    Icon(
+                      allUsed ? Icons.check_circle : Icons.how_to_vote,
+                      size: MinglitIconSize.small,
+                      color: allUsed
+                          ? theme.colorScheme.primary
+                          : theme.colorScheme.onSurfaceVariant,
+                    ),
+                    const SizedBox(width: MinglitSpacing.small),
+                    Text(
+                      allUsed ? '투표 완료!' : '남은 투표: $remaining/$max',
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
                         color: allUsed
                             ? theme.colorScheme.primary
-                            : theme.colorScheme.onSurfaceVariant,
+                            : theme.colorScheme.onSurface,
                       ),
-                      const SizedBox(width: MinglitSpacing.small),
-                      Text(
-                        allUsed ? '투표 완료!' : '남은 투표: $remaining/$max',
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          fontWeight: FontWeight.w600,
-                          color: allUsed
-                              ? theme.colorScheme.primary
-                              : theme.colorScheme.onSurface,
-                        ),
-                      ),
-                    ],
-                  );
-                },
-              ),
-            ),
-
-          // 2. Candidates
-          Expanded(
-            child: MinglitAsyncValueWidget(
-              value: candidatesAsync,
-              data: (candidates) {
-                if (candidates.isEmpty) {
-                  return const Center(child: Text('투표 가능한 상대가 없습니다.'));
-                }
-                final votedIds = votedIdsAsync.hasValue
-                    ? votedIdsAsync.value!
-                    : <String>{};
-                final allVotesUsed =
-                    voteCountAsync.hasValue &&
-                    maxVoteAsync.hasValue &&
-                    voteCountAsync.value! >= maxVoteAsync.value!;
-                return GridView.builder(
-                  padding: const EdgeInsets.all(MinglitSpacing.medium),
-                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 2,
-                    childAspectRatio: 0.8,
-                    mainAxisSpacing: MinglitSpacing.medium,
-                    crossAxisSpacing: MinglitSpacing.medium,
-                  ),
-                  itemCount: candidates.length,
-                  itemBuilder: (context, index) {
-                    final candidate = candidates[index];
-                    final isVoted = votedIds.contains(candidate.id);
-                    return _buildCandidateCard(
-                      context,
-                      ref,
-                      candidate,
-                      isVoted: isVoted,
-                      isDisabled: isVoted || allVotesUsed,
-                    );
-                  },
+                    ),
+                  ],
                 );
               },
             ),
           ),
-        ],
-      ),
+
+        // 2. Candidates
+        Expanded(
+          child: MinglitAsyncValueWidget(
+            value: candidatesAsync,
+            data: (candidates) {
+              if (candidates.isEmpty) {
+                return const Center(child: Text('투표 가능한 상대가 없습니다.'));
+              }
+              final votedIds = votedIdsAsync.hasValue
+                  ? votedIdsAsync.value!
+                  : <String>{};
+              final allVotesUsed =
+                  voteCountAsync.hasValue &&
+                  maxVoteAsync.hasValue &&
+                  voteCountAsync.value! >= maxVoteAsync.value!;
+              return GridView.builder(
+                padding: const EdgeInsets.all(MinglitSpacing.medium),
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 2,
+                  childAspectRatio: 0.8,
+                  mainAxisSpacing: MinglitSpacing.medium,
+                  crossAxisSpacing: MinglitSpacing.medium,
+                ),
+                itemCount: candidates.length,
+                itemBuilder: (context, index) {
+                  final candidate = candidates[index];
+                  final isVoted = votedIds.contains(candidate.id);
+                  return _buildCandidateCard(
+                    context,
+                    ref,
+                    candidate,
+                    isVoted: isVoted,
+                    isDisabled: isVoted || allVotesUsed,
+                  );
+                },
+              );
+            },
+          ),
+        ),
+      ],
     );
   }
 

--- a/apps/app_user/test/src/features/event/matching/matching_vote_content_test.dart
+++ b/apps/app_user/test/src/features/event/matching/matching_vote_content_test.dart
@@ -1,0 +1,185 @@
+import 'package:app_user/src/features/event/matching/matching_vote_controller.dart';
+import 'package:app_user/src/features/event/matching/matching_vote_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../utils/mocks.dart';
+
+void main() {
+  late MockMatchingRepository mockMatchingRepo;
+
+  setUp(() {
+    mockMatchingRepo = MockMatchingRepository();
+  });
+
+  Widget createTestWidget({
+    String eventId = 'event_1',
+    List<dynamic> overrides = const [],
+  }) {
+    return ProviderScope(
+      overrides: [
+        matchingRepositoryProvider.overrideWithValue(mockMatchingRepo),
+        ...overrides,
+      ].cast(),
+      child: MaterialApp(
+        home: Scaffold(
+          body: MatchingVoteContent(eventId: eventId),
+        ),
+      ),
+    );
+  }
+
+  void stubDefaultProviders({
+    List<UserProfile> candidates = const [],
+    List<MatchPair> matches = const [],
+    int voteCount = 0,
+    int maxVotes = 3,
+    Set<String> votedIds = const {},
+  }) {
+    when(() => mockMatchingRepo.getMatchingCandidates('event_1'))
+        .thenAnswer((_) async => candidates);
+    when(() => mockMatchingRepo.getMyMatches('event_1'))
+        .thenAnswer((_) async => matches);
+    when(() => mockMatchingRepo.getMyVoteCount('event_1'))
+        .thenAnswer((_) async => voteCount);
+    when(() => mockMatchingRepo.getMyVotedCandidateIds('event_1'))
+        .thenAnswer((_) async => votedIds);
+    when(() => mockMatchingRepo.getMatchRules('event_1'))
+        .thenAnswer((_) async => [
+              MatchRule(
+                id: 'rule_1',
+                eventId: 'event_1',
+                sourceGroupId: 'g_1',
+                targetGroupId: 'g_2',
+                voteCount: maxVotes,
+                createdAt: DateTime(2024),
+              ),
+            ]);
+  }
+
+  group('MatchingVoteContent', () {
+    testWidgets('renders without Scaffold — embeddable in any host',
+        (tester) async {
+      stubDefaultProviders();
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      // MatchingVoteContent itself does not contain a Scaffold
+      // The test wraps it in one, so exactly 1 Scaffold should exist
+      expect(find.byType(Scaffold), findsOneWidget);
+      expect(find.byType(MatchingVoteContent), findsOneWidget);
+    });
+
+    testWidgets('shows empty state when no candidates', (tester) async {
+      stubDefaultProviders();
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('투표 가능한 상대가 없습니다.'), findsOneWidget);
+    });
+
+    testWidgets('renders candidate cards with vote buttons', (tester) async {
+      stubDefaultProviders(
+        candidates: [
+          const UserProfile(
+            id: 'c_1',
+            name: '홍길동',
+            username: 'hong',
+          ),
+          const UserProfile(
+            id: 'c_2',
+            name: '김철수',
+            username: 'kim',
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('홍길동'), findsOneWidget);
+      expect(find.text('김철수'), findsOneWidget);
+      expect(find.text('선택'), findsNWidgets(2));
+    });
+
+    testWidgets('shows remaining vote count', (tester) async {
+      stubDefaultProviders(
+        candidates: [
+          const UserProfile(id: 'c_1', name: '홍길동', username: 'hong'),
+        ],
+        voteCount: 1,
+        maxVotes: 3,
+      );
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('남은 투표: 2/3'), findsOneWidget);
+    });
+
+    testWidgets('shows vote complete when all votes used', (tester) async {
+      stubDefaultProviders(
+        candidates: [
+          const UserProfile(id: 'c_1', name: '홍길동', username: 'hong'),
+        ],
+        voteCount: 3,
+        maxVotes: 3,
+        votedIds: {'c_1'},
+      );
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('투표 완료!'), findsOneWidget);
+      // Candidate button should show '투표 완료' instead of '선택'
+      expect(find.text('투표 완료'), findsOneWidget);
+    });
+
+    testWidgets('shows match section when matches exist', (tester) async {
+      stubDefaultProviders(
+        candidates: [
+          const UserProfile(id: 'c_1', name: '홍길동', username: 'hong'),
+        ],
+        matches: [
+          MatchPair(
+            matchId: 'm_1',
+            eventId: 'event_1',
+            partnerId: 'p_1',
+            matchedAt: DateTime(2024),
+            partnerName: '이영희',
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('매칭 성공! (1명)'), findsOneWidget);
+      expect(find.text('이영희'), findsOneWidget);
+    });
+
+    testWidgets('MatchingVoteScreen wraps content with Scaffold and AppBar',
+        (tester) async {
+      stubDefaultProviders();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            matchingRepositoryProvider.overrideWithValue(mockMatchingRepo),
+          ].cast(),
+          child: const MaterialApp(
+            home: MatchingVoteScreen(eventId: 'event_1'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('매칭 투표'), findsOneWidget);
+      expect(find.byType(MatchingVoteContent), findsOneWidget);
+    });
+  });
+}

--- a/apps/app_user/test/src/features/event/matching/matching_vote_content_test.dart
+++ b/apps/app_user/test/src/features/event/matching/matching_vote_content_test.dart
@@ -1,4 +1,3 @@
-import 'package:app_user/src/features/event/matching/matching_vote_controller.dart';
 import 'package:app_user/src/features/event/matching/matching_vote_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -38,30 +37,36 @@ void main() {
     int maxVotes = 3,
     Set<String> votedIds = const {},
   }) {
-    when(() => mockMatchingRepo.getMatchingCandidates('event_1'))
-        .thenAnswer((_) async => candidates);
-    when(() => mockMatchingRepo.getMyMatches('event_1'))
-        .thenAnswer((_) async => matches);
-    when(() => mockMatchingRepo.getMyVoteCount('event_1'))
-        .thenAnswer((_) async => voteCount);
-    when(() => mockMatchingRepo.getMyVotedCandidateIds('event_1'))
-        .thenAnswer((_) async => votedIds);
-    when(() => mockMatchingRepo.getMatchRules('event_1'))
-        .thenAnswer((_) async => [
-              MatchRule(
-                id: 'rule_1',
-                eventId: 'event_1',
-                sourceGroupId: 'g_1',
-                targetGroupId: 'g_2',
-                voteCount: maxVotes,
-                createdAt: DateTime(2024),
-              ),
-            ]);
+    when(
+      () => mockMatchingRepo.getMatchingCandidates('event_1'),
+    ).thenAnswer((_) async => candidates);
+    when(
+      () => mockMatchingRepo.getMyMatches('event_1'),
+    ).thenAnswer((_) async => matches);
+    when(
+      () => mockMatchingRepo.getMyVoteCount('event_1'),
+    ).thenAnswer((_) async => voteCount);
+    when(
+      () => mockMatchingRepo.getMyVotedCandidateIds('event_1'),
+    ).thenAnswer((_) async => votedIds);
+    when(() => mockMatchingRepo.getMatchRules('event_1')).thenAnswer(
+      (_) async => [
+        MatchRule(
+          id: 'rule_1',
+          eventId: 'event_1',
+          sourceGroupId: 'g_1',
+          targetGroupId: 'g_2',
+          voteCount: maxVotes,
+          createdAt: DateTime(2024),
+        ),
+      ],
+    );
   }
 
   group('MatchingVoteContent', () {
-    testWidgets('renders without Scaffold — embeddable in any host',
-        (tester) async {
+    testWidgets('renders without Scaffold — embeddable in any host', (
+      tester,
+    ) async {
       stubDefaultProviders();
 
       await tester.pumpWidget(createTestWidget());
@@ -112,7 +117,6 @@ void main() {
           const UserProfile(id: 'c_1', name: '홍길동', username: 'hong'),
         ],
         voteCount: 1,
-        maxVotes: 3,
       );
 
       await tester.pumpWidget(createTestWidget());
@@ -127,7 +131,6 @@ void main() {
           const UserProfile(id: 'c_1', name: '홍길동', username: 'hong'),
         ],
         voteCount: 3,
-        maxVotes: 3,
         votedIds: {'c_1'},
       );
 
@@ -162,8 +165,9 @@ void main() {
       expect(find.text('이영희'), findsOneWidget);
     });
 
-    testWidgets('MatchingVoteScreen wraps content with Scaffold and AppBar',
-        (tester) async {
+    testWidgets('MatchingVoteScreen wraps content with Scaffold and AppBar', (
+      tester,
+    ) async {
       stubDefaultProviders();
 
       await tester.pumpWidget(


### PR DESCRIPTION
## Summary
- `MatchingVoteScreen`의 Scaffold body를 `MatchingVoteContent` ConsumerWidget으로 추출
- `MatchingVoteScreen`은 `Scaffold(body: MatchingVoteContent)` 형태로 위임 — 기존 동작 유지
- `MatchingVoteContent`는 Scaffold 없이 독립 렌더링 가능 — 바텀시트 임베드 준비 완료

Closes #658

## Test plan
- [x] `flutter analyze` 통과
- [x] 기존 `matching_vote_controller_test.dart` 8건 통과 (회귀 없음)
- [x] `matching_vote_content_test.dart` 위젯 테스트 7건 추가:
  - Scaffold 없이 독립 렌더링 검증
  - 빈 상태 (후보 없음) 렌더링
  - 후보 카드 + 투표 버튼 렌더링
  - 잔여 투표 수 표시
  - 투표 완료 상태
  - 매칭 성공 섹션
  - MatchingVoteScreen이 MatchingVoteContent를 Scaffold로 래핑

🤖 Generated with [Claude Code](https://claude.com/claude-code)