### PR TITLE
refactor(payment): StatusBadge 공유 위젯 추출

### DIFF
--- a/apps/app_user/lib/src/common/widgets/status_badge.dart
+++ b/apps/app_user/lib/src/common/widgets/status_badge.dart
@@ -1,7 +1,10 @@
-part of 'purchase_history_page.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
 
-class _StatusBadge extends StatelessWidget {
-  const _StatusBadge({required this.status});
+// Fix #638: StatusBadge를 공유 위젯으로 추출
+// purchase_history 전용 private 위젯에서 공통 위젯으로 승격
+class StatusBadge extends StatelessWidget {
+  const StatusBadge({required this.status, super.key});
 
   final String status;
 

--- a/apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart
+++ b/apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart
@@ -59,7 +59,7 @@ class PurchaseHistoryCard extends ConsumerWidget {
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
               ),
-              _StatusBadge(status: application.status),
+              StatusBadge(status: application.status),
             ],
           ),
           const SizedBox(height: MinglitSpacing.medium),

--- a/apps/app_user/lib/src/features/payment/ui/purchase_history_page.dart
+++ b/apps/app_user/lib/src/features/payment/ui/purchase_history_page.dart
@@ -1,3 +1,4 @@
+import 'package:app_user/src/common/widgets/status_badge.dart';
 import 'package:app_user/src/features/payment/logic/purchase_history_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -6,7 +7,6 @@ import 'package:url_launcher/url_launcher.dart';
 
 part 'purchase_history_card.dart';
 part 'purchase_history_refund_row.dart';
-part 'purchase_history_status_badge.dart';
 
 class PurchaseHistoryPage extends ConsumerWidget {
   const PurchaseHistoryPage({super.key});

--- a/apps/app_user/test/src/common/widgets/status_badge_test.dart
+++ b/apps/app_user/test/src/common/widgets/status_badge_test.dart
@@ -1,0 +1,50 @@
+import 'package:app_user/src/common/widgets/status_badge.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Widget createTestWidget(String status) {
+    return MaterialApp(
+      home: Scaffold(
+        body: StatusBadge(status: status),
+      ),
+    );
+  }
+
+  group('StatusBadge', () {
+    testWidgets('displays 결제대기 for pending status', (tester) async {
+      await tester.pumpWidget(createTestWidget('pending'));
+      expect(find.text('결제대기'), findsOneWidget);
+    });
+
+    testWidgets('displays 심사중 for pending_review status', (tester) async {
+      await tester.pumpWidget(createTestWidget('pending_review'));
+      expect(find.text('심사중'), findsOneWidget);
+    });
+
+    testWidgets('displays 승인됨 for approved status', (tester) async {
+      await tester.pumpWidget(createTestWidget('approved'));
+      expect(find.text('승인됨'), findsOneWidget);
+    });
+
+    testWidgets('displays 결제완료 for paid status', (tester) async {
+      await tester.pumpWidget(createTestWidget('paid'));
+      expect(find.text('결제완료'), findsOneWidget);
+    });
+
+    testWidgets('displays 반려됨 for rejected status', (tester) async {
+      await tester.pumpWidget(createTestWidget('rejected'));
+      expect(find.text('반려됨'), findsOneWidget);
+    });
+
+    testWidgets('displays 취소됨 for cancelled status', (tester) async {
+      await tester.pumpWidget(createTestWidget('cancelled'));
+      expect(find.text('취소됨'), findsOneWidget);
+    });
+
+    testWidgets('displays 알수없음 for unknown status', (tester) async {
+      await tester.pumpWidget(createTestWidget('unknown_status'));
+      expect(find.text('알수없음'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- `_StatusBadge`를 `purchase_history_status_badge.dart` (private part)에서 `common/widgets/status_badge.dart` (public shared widget)으로 이동
- `purchase_history_page.dart`에서 `part` 지시문 → `import`로 전환
- `StatusBadge` 위젯 테스트 7건 추가 (전체 상태 매핑 검증)

Closes #638

## Test plan
- [x] `flutter analyze` 통과 (새 에러/경고 없음)
- [x] `StatusBadge` 위젯 테스트 7건 전체 pass
- [ ] 기존 `purchase_history_screen_test.dart`, `purchase_history_card_test.dart` CI에서 pass 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)