### PR TITLE
test: 레이아웃 시스템 위젯 테스트 (MinglitSection, ContentCard, KeyValueRow)

### DIFF
--- a/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_content_card_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_content_card_test.dart
@@ -11,7 +11,7 @@ void main() {
     testWidgets('renders child content', (tester) async {
       await tester.pumpWidget(
         wrap(
-          MinglitContentCard(child: Text('카드 내용')),
+          const MinglitContentCard(child: Text('카드 내용')),
         ),
       );
 
@@ -24,7 +24,7 @@ void main() {
         wrap(
           MinglitContentCard(
             onTap: () => tapped = true,
-            child: Text('탭 가능'),
+            child: const Text('탭 가능'),
           ),
         ),
       );
@@ -38,7 +38,7 @@ void main() {
         wrap(
           MinglitContentCard(
             onTap: () {},
-            child: Text('내용'),
+            child: const Text('내용'),
           ),
         ),
       );
@@ -49,18 +49,19 @@ void main() {
     testWidgets('does not wrap in InkWell when onTap is null', (tester) async {
       await tester.pumpWidget(
         wrap(
-          MinglitContentCard(child: Text('내용')),
+          const MinglitContentCard(child: Text('내용')),
         ),
       );
 
       expect(find.byType(InkWell), findsNothing);
     });
 
-    testWidgets('applies highlighted border when highlighted is true',
-        (tester) async {
+    testWidgets('applies highlighted border when highlighted is true', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         wrap(
-          MinglitContentCard(
+          const MinglitContentCard(
             highlighted: true,
             child: Text('강조'),
           ),

--- a/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_content_card_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_content_card_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+void main() {
+  Widget wrap(Widget child) {
+    return MaterialApp(home: Scaffold(body: child));
+  }
+
+  group('MinglitContentCard', () {
+    testWidgets('renders child content', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          MinglitContentCard(child: Text('카드 내용')),
+        ),
+      );
+
+      expect(find.text('카드 내용'), findsOneWidget);
+    });
+
+    testWidgets('is tappable when onTap is provided', (tester) async {
+      var tapped = false;
+      await tester.pumpWidget(
+        wrap(
+          MinglitContentCard(
+            onTap: () => tapped = true,
+            child: Text('탭 가능'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('탭 가능'));
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('wraps in InkWell when onTap is provided', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          MinglitContentCard(
+            onTap: () {},
+            child: Text('내용'),
+          ),
+        ),
+      );
+
+      expect(find.byType(InkWell), findsOneWidget);
+    });
+
+    testWidgets('does not wrap in InkWell when onTap is null', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          MinglitContentCard(child: Text('내용')),
+        ),
+      );
+
+      expect(find.byType(InkWell), findsNothing);
+    });
+
+    testWidgets('applies highlighted border when highlighted is true',
+        (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          MinglitContentCard(
+            highlighted: true,
+            child: Text('강조'),
+          ),
+        ),
+      );
+
+      final container = tester.widget<Container>(find.byType(Container).first);
+      final decoration = container.decoration! as BoxDecoration;
+      final border = decoration.border! as Border;
+      // Highlighted border should use primary color (not outlineVariant)
+      final theme = Theme.of(tester.element(find.text('강조')));
+      expect(border.top.color, theme.colorScheme.primary);
+    });
+  });
+}

--- a/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_key_value_row_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_key_value_row_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+void main() {
+  Widget wrap(Widget child) {
+    return MaterialApp(home: Scaffold(body: child));
+  }
+
+  group('MinglitKeyValueRow', () {
+    testWidgets('renders label and value', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          MinglitKeyValueRow(label: '이름', value: '홍길동'),
+        ),
+      );
+
+      expect(find.text('이름'), findsOneWidget);
+      expect(find.text('홍길동'), findsOneWidget);
+    });
+
+    testWidgets('applies bold font weight when bold is true', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          MinglitKeyValueRow(label: '총 금액', value: '20,000원', bold: true),
+        ),
+      );
+
+      final valueText = tester.widget<Text>(find.text('20,000원'));
+      expect(valueText.style?.fontWeight, FontWeight.bold);
+    });
+
+    testWidgets('does not apply bold by default', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          MinglitKeyValueRow(label: '항목', value: '값'),
+        ),
+      );
+
+      final valueText = tester.widget<Text>(find.text('값'));
+      expect(valueText.style?.fontWeight, FontWeight.normal);
+    });
+
+    testWidgets('applies custom value color', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          MinglitKeyValueRow(
+            label: '상태',
+            value: '성공',
+            valueColor: Colors.green,
+          ),
+        ),
+      );
+
+      final valueText = tester.widget<Text>(find.text('성공'));
+      expect(valueText.style?.color, Colors.green);
+    });
+
+    testWidgets('renders empty strings without error', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          MinglitKeyValueRow(label: '', value: ''),
+        ),
+      );
+
+      // Should render two empty Text widgets without crashing
+      expect(find.byType(MinglitKeyValueRow), findsOneWidget);
+    });
+  });
+}

--- a/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_key_value_row_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_key_value_row_test.dart
@@ -11,7 +11,7 @@ void main() {
     testWidgets('renders label and value', (tester) async {
       await tester.pumpWidget(
         wrap(
-          MinglitKeyValueRow(label: '이름', value: '홍길동'),
+          const MinglitKeyValueRow(label: '이름', value: '홍길동'),
         ),
       );
 
@@ -22,7 +22,7 @@ void main() {
     testWidgets('applies bold font weight when bold is true', (tester) async {
       await tester.pumpWidget(
         wrap(
-          MinglitKeyValueRow(label: '총 금액', value: '20,000원', bold: true),
+          const MinglitKeyValueRow(label: '총 금액', value: '20,000원', bold: true),
         ),
       );
 
@@ -33,7 +33,7 @@ void main() {
     testWidgets('does not apply bold by default', (tester) async {
       await tester.pumpWidget(
         wrap(
-          MinglitKeyValueRow(label: '항목', value: '값'),
+          const MinglitKeyValueRow(label: '항목', value: '값'),
         ),
       );
 
@@ -44,7 +44,7 @@ void main() {
     testWidgets('applies custom value color', (tester) async {
       await tester.pumpWidget(
         wrap(
-          MinglitKeyValueRow(
+          const MinglitKeyValueRow(
             label: '상태',
             value: '성공',
             valueColor: Colors.green,
@@ -59,7 +59,7 @@ void main() {
     testWidgets('renders empty strings without error', (tester) async {
       await tester.pumpWidget(
         wrap(
-          MinglitKeyValueRow(label: '', value: ''),
+          const MinglitKeyValueRow(label: '', value: ''),
         ),
       );
 

--- a/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_section_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_section_test.dart
@@ -11,7 +11,7 @@ void main() {
     testWidgets('renders title and child', (tester) async {
       await tester.pumpWidget(
         wrap(
-          MinglitSection(
+          const MinglitSection(
             title: '섹션 제목',
             child: Text('섹션 내용'),
           ),
@@ -29,9 +29,9 @@ void main() {
             title: '섹션 제목',
             trailing: TextButton(
               onPressed: () {},
-              child: Text('더보기'),
+              child: const Text('더보기'),
             ),
-            child: Text('내용'),
+            child: const Text('내용'),
           ),
         ),
       );
@@ -42,7 +42,7 @@ void main() {
     testWidgets('does not render trailing when null', (tester) async {
       await tester.pumpWidget(
         wrap(
-          MinglitSection(
+          const MinglitSection(
             title: '섹션 제목',
             child: Text('내용'),
           ),
@@ -55,7 +55,7 @@ void main() {
     testWidgets('applies custom padding', (tester) async {
       await tester.pumpWidget(
         wrap(
-          MinglitSection(
+          const MinglitSection(
             title: '제목',
             padding: EdgeInsets.all(32),
             child: Text('내용'),
@@ -64,10 +64,12 @@ void main() {
       );
 
       final padding = tester.widget<Padding>(
-        find.ancestor(
-          of: find.byType(Column),
-          matching: find.byType(Padding),
-        ).first,
+        find
+            .ancestor(
+              of: find.byType(Column),
+              matching: find.byType(Padding),
+            )
+            .first,
       );
       expect(padding.padding, const EdgeInsets.all(32));
     });

--- a/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_section_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_section_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+void main() {
+  Widget wrap(Widget child) {
+    return MaterialApp(home: Scaffold(body: child));
+  }
+
+  group('MinglitSection', () {
+    testWidgets('renders title and child', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          MinglitSection(
+            title: '섹션 제목',
+            child: Text('섹션 내용'),
+          ),
+        ),
+      );
+
+      expect(find.text('섹션 제목'), findsOneWidget);
+      expect(find.text('섹션 내용'), findsOneWidget);
+    });
+
+    testWidgets('renders trailing widget when provided', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          MinglitSection(
+            title: '섹션 제목',
+            trailing: TextButton(
+              onPressed: () {},
+              child: Text('더보기'),
+            ),
+            child: Text('내용'),
+          ),
+        ),
+      );
+
+      expect(find.text('더보기'), findsOneWidget);
+    });
+
+    testWidgets('does not render trailing when null', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          MinglitSection(
+            title: '섹션 제목',
+            child: Text('내용'),
+          ),
+        ),
+      );
+
+      expect(find.byType(TextButton), findsNothing);
+    });
+
+    testWidgets('applies custom padding', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          MinglitSection(
+            title: '제목',
+            padding: EdgeInsets.all(32),
+            child: Text('내용'),
+          ),
+        ),
+      );
+
+      final padding = tester.widget<Padding>(
+        find.ancestor(
+          of: find.byType(Column),
+          matching: find.byType(Padding),
+        ).first,
+      );
+      expect(padding.padding, const EdgeInsets.all(32));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- `MinglitSection`, `MinglitContentCard`, `MinglitKeyValueRow` 위젯 테스트 14건 신규 작성
- 양 앱에서 재사용되는 공유 레이아웃 위젯의 회귀 방지

Closes #690

## Test plan
- [x] `flutter test test/src/ui/widgets/common/` 14건 전체 통과
- [x] MinglitSection: 제목+자식 렌더링, trailing 위젯, null trailing, 커스텀 패딩
- [x] MinglitContentCard: 자식 렌더링, onTap 핸들러, InkWell 래핑, InkWell 미래핑, highlighted 보더
- [x] MinglitKeyValueRow: 라벨+값 렌더링, bold 적용, 기본 non-bold, 커스텀 색상, 빈 문자열

🤖 Generated with [Claude Code](https://claude.com/claude-code)