### PR TITLE
feat(my-tickets): MyTicketsController + Provider 생성

### DIFF
--- a/apps/app_user/lib/src/features/my_tickets/logic/my_tickets_controller.dart
+++ b/apps/app_user/lib/src/features/my_tickets/logic/my_tickets_controller.dart
@@ -1,0 +1,96 @@
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'my_tickets_controller.g.dart';
+
+class MyTicketsState {
+  const MyTicketsState({
+    required this.upcoming,
+    required this.past,
+    required this.todayEvent,
+  });
+
+  final List<EventApplication> upcoming;
+  final List<EventApplication> past;
+  final EventApplication? todayEvent;
+}
+
+@riverpod
+class MyTicketsController extends _$MyTicketsController {
+  @override
+  FutureOr<MyTicketsState> build() async {
+    final user = ref.watch(currentUserProvider);
+    if (user == null) {
+      return const MyTicketsState(
+        upcoming: [],
+        past: [],
+        todayEvent: null,
+      );
+    }
+
+    final repository = ref.watch(eventRepositoryProvider);
+    final tickets = await repository.getMyTickets(user.id);
+    return _categorize(tickets);
+  }
+
+  MyTicketsState _categorize(List<EventApplication> tickets) {
+    final now = DateTime.now();
+    final todayStart = DateTime(now.year, now.month, now.day);
+    final todayEnd = todayStart.add(const Duration(days: 1));
+
+    final upcoming = <EventApplication>[];
+    final past = <EventApplication>[];
+    EventApplication? todayEvent;
+
+    for (final ticket in tickets) {
+      final startTime = ticket.event?.startTime;
+      if (startTime == null) {
+        past.add(ticket);
+        continue;
+      }
+
+      if (startTime.isAfter(now)) {
+        upcoming.add(ticket);
+
+        // 오늘 시작하는 이벤트 중 가장 임박한 것
+        if (!startTime.isBefore(todayStart) && startTime.isBefore(todayEnd)) {
+          if (todayEvent == null ||
+              startTime.isBefore(todayEvent.event!.startTime)) {
+            todayEvent = ticket;
+          }
+        }
+      } else {
+        past.add(ticket);
+
+        // 오늘 시작했지만 이미 시작 시간이 지난 경우도 todayEvent 후보
+        if (!startTime.isBefore(todayStart) && startTime.isBefore(todayEnd)) {
+          if (todayEvent == null ||
+              startTime.isAfter(todayEvent.event!.startTime)) {
+            todayEvent = ticket;
+          }
+        }
+      }
+    }
+
+    // upcoming: 가까운 순 (ASC)
+    upcoming.sort(
+      (a, b) => a.event!.startTime.compareTo(b.event!.startTime),
+    );
+
+    // past: 최근 종료 순 (DESC)
+    past.sort((a, b) {
+      final aTime = a.event?.startTime;
+      final bTime = b.event?.startTime;
+      if (aTime == null && bTime == null) return 0;
+      if (aTime == null) return 1;
+      if (bTime == null) return -1;
+      return bTime.compareTo(aTime);
+    });
+
+    return MyTicketsState(
+      upcoming: upcoming,
+      past: past,
+      todayEvent: todayEvent,
+    );
+  }
+}

--- a/apps/app_user/lib/src/features/my_tickets/logic/my_tickets_controller.g.dart
+++ b/apps/app_user/lib/src/features/my_tickets/logic/my_tickets_controller.g.dart
@@ -1,0 +1,56 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'my_tickets_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(MyTicketsController)
+const myTicketsControllerProvider = MyTicketsControllerProvider._();
+
+final class MyTicketsControllerProvider
+    extends $AsyncNotifierProvider<MyTicketsController, MyTicketsState> {
+  const MyTicketsControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'myTicketsControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$myTicketsControllerHash();
+
+  @$internal
+  @override
+  MyTicketsController create() => MyTicketsController();
+}
+
+String _$myTicketsControllerHash() =>
+    r'b4d487d7e52af0b7e5a9e2a875ca243564f39938';
+
+abstract class _$MyTicketsController extends $AsyncNotifier<MyTicketsState> {
+  FutureOr<MyTicketsState> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref as $Ref<AsyncValue<MyTicketsState>, MyTicketsState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<MyTicketsState>, MyTicketsState>,
+              AsyncValue<MyTicketsState>,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/apps/app_user/test/src/features/my_tickets/logic/my_tickets_controller_test.dart
+++ b/apps/app_user/test/src/features/my_tickets/logic/my_tickets_controller_test.dart
@@ -1,0 +1,260 @@
+import 'package:app_user/src/features/my_tickets/logic/my_tickets_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../utils/mocks.dart';
+
+EventApplication _makeTicket({
+  required String id,
+  required DateTime startTime,
+  String status = 'paid',
+}) {
+  return EventApplication(
+    id: id,
+    eventId: 'event_$id',
+    ticketId: 'ticket_$id',
+    userId: 'user_1',
+    status: status,
+    createdAt: DateTime(2026),
+    updatedAt: DateTime(2026),
+    event: Event(
+      id: 'event_$id',
+      partyId: 'party_1',
+      startTime: startTime,
+      endTime: startTime.add(const Duration(hours: 2)),
+      createdAt: DateTime(2026),
+      updatedAt: DateTime(2026),
+    ),
+  );
+}
+
+void main() {
+  late MockEventRepository mockEventRepository;
+  late MockUser mockUser;
+
+  setUp(() {
+    mockEventRepository = MockEventRepository();
+    mockUser = MockUser();
+    when(() => mockUser.id).thenReturn('user_1');
+  });
+
+  ProviderContainer createContainer({bool loggedIn = true}) {
+    return ProviderContainer(
+      overrides: [
+        currentUserProvider.overrideWith(
+          (ref) => loggedIn ? mockUser : null,
+        ),
+        eventRepositoryProvider.overrideWithValue(mockEventRepository),
+      ],
+    );
+  }
+
+  group('MyTicketsController', () {
+    test('returns empty state when user is not logged in', () async {
+      final container = createContainer(loggedIn: false);
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        myTicketsControllerProvider.future,
+      );
+
+      expect(result.upcoming, isEmpty);
+      expect(result.past, isEmpty);
+      expect(result.todayEvent, isNull);
+    });
+
+    test('separates upcoming and past tickets by startTime', () async {
+      final now = DateTime.now();
+      final upcoming1 = _makeTicket(
+        id: 'a',
+        startTime: now.add(const Duration(days: 3)),
+      );
+      final upcoming2 = _makeTicket(
+        id: 'b',
+        startTime: now.add(const Duration(days: 1)),
+      );
+      final past1 = _makeTicket(
+        id: 'c',
+        startTime: now.subtract(const Duration(days: 1)),
+      );
+      final past2 = _makeTicket(
+        id: 'd',
+        startTime: now.subtract(const Duration(days: 5)),
+      );
+
+      when(
+        () => mockEventRepository.getMyTickets('user_1'),
+      ).thenAnswer((_) async => [upcoming1, upcoming2, past1, past2]);
+
+      final container = createContainer();
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        myTicketsControllerProvider.future,
+      );
+
+      expect(result.upcoming, hasLength(2));
+      expect(result.past, hasLength(2));
+    });
+
+    test('sorts upcoming ASC (closest first)', () async {
+      final now = DateTime.now();
+      final far = _makeTicket(
+        id: 'far',
+        startTime: now.add(const Duration(days: 10)),
+      );
+      final close = _makeTicket(
+        id: 'close',
+        startTime: now.add(const Duration(days: 1)),
+      );
+      final mid = _makeTicket(
+        id: 'mid',
+        startTime: now.add(const Duration(days: 5)),
+      );
+
+      when(
+        () => mockEventRepository.getMyTickets('user_1'),
+      ).thenAnswer((_) async => [far, close, mid]);
+
+      final container = createContainer();
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        myTicketsControllerProvider.future,
+      );
+
+      expect(result.upcoming[0].id, 'close');
+      expect(result.upcoming[1].id, 'mid');
+      expect(result.upcoming[2].id, 'far');
+    });
+
+    test('sorts past DESC (most recent first)', () async {
+      final now = DateTime.now();
+      final recent = _makeTicket(
+        id: 'recent',
+        startTime: now.subtract(const Duration(days: 1)),
+      );
+      final old = _makeTicket(
+        id: 'old',
+        startTime: now.subtract(const Duration(days: 10)),
+      );
+      final mid = _makeTicket(
+        id: 'mid',
+        startTime: now.subtract(const Duration(days: 5)),
+      );
+
+      when(
+        () => mockEventRepository.getMyTickets('user_1'),
+      ).thenAnswer((_) async => [recent, old, mid]);
+
+      final container = createContainer();
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        myTicketsControllerProvider.future,
+      );
+
+      expect(result.past[0].id, 'recent');
+      expect(result.past[1].id, 'mid');
+      expect(result.past[2].id, 'old');
+    });
+
+    test('detects todayEvent as most imminent event today', () async {
+      final now = DateTime.now();
+      final todayStart = DateTime(now.year, now.month, now.day);
+
+      final earlier = _makeTicket(
+        id: 'early',
+        startTime: todayStart.add(
+          const Duration(hours: 23, minutes: 50),
+        ),
+      );
+      final later = _makeTicket(
+        id: 'late',
+        startTime: todayStart.add(
+          const Duration(hours: 23, minutes: 55),
+        ),
+      );
+
+      when(
+        () => mockEventRepository.getMyTickets('user_1'),
+      ).thenAnswer((_) async => [later, earlier]);
+
+      final container = createContainer();
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        myTicketsControllerProvider.future,
+      );
+
+      expect(result.todayEvent, isNotNull);
+      expect(result.todayEvent!.id, 'early');
+    });
+
+    test('todayEvent is null when no events today', () async {
+      final now = DateTime.now();
+      final tomorrow = _makeTicket(
+        id: 'tomorrow',
+        startTime: now.add(const Duration(days: 2)),
+      );
+
+      when(
+        () => mockEventRepository.getMyTickets('user_1'),
+      ).thenAnswer((_) async => [tomorrow]);
+
+      final container = createContainer();
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        myTicketsControllerProvider.future,
+      );
+
+      expect(result.todayEvent, isNull);
+    });
+
+    test('handles empty ticket list', () async {
+      when(
+        () => mockEventRepository.getMyTickets('user_1'),
+      ).thenAnswer((_) async => []);
+
+      final container = createContainer();
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        myTicketsControllerProvider.future,
+      );
+
+      expect(result.upcoming, isEmpty);
+      expect(result.past, isEmpty);
+      expect(result.todayEvent, isNull);
+    });
+
+    test('tickets without event go to past', () async {
+      final noEvent = EventApplication(
+        id: 'no_event',
+        eventId: 'event_1',
+        ticketId: 'ticket_1',
+        userId: 'user_1',
+        status: 'paid',
+        createdAt: DateTime(2026),
+        updatedAt: DateTime(2026),
+      );
+
+      when(
+        () => mockEventRepository.getMyTickets('user_1'),
+      ).thenAnswer((_) async => [noEvent]);
+
+      final container = createContainer();
+      addTearDown(container.dispose);
+
+      final result = await container.read(
+        myTicketsControllerProvider.future,
+      );
+
+      expect(result.upcoming, isEmpty);
+      expect(result.past, hasLength(1));
+      expect(result.past[0].id, 'no_event');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- `MyTicketsController` (Riverpod AsyncNotifier): `getMyTickets()`로 active 티켓을 가져와 upcoming/past 분리 + 정렬
- `MyTicketsState`: upcoming (ASC), past (DESC), todayEvent (오늘 가장 임박한 이벤트)
- 8개 유닛 테스트: 빈 상태, 분리, 정렬, todayEvent 감지/null, 이벤트 없는 티켓 처리

Closes #639

## Test plan
- [x] `flutter analyze` 통과
- [x] 유닛 테스트 8/8 통과
  - 미로그인 시 빈 상태
  - upcoming/past 분리
  - upcoming ASC 정렬
  - past DESC 정렬
  - todayEvent 감지
  - todayEvent null (오늘 이벤트 없을 때)
  - 빈 티켓 리스트
  - event 없는 티켓 → past 분류

🤖 Generated with [Claude Code](https://claude.com/claude-code)