### PR TITLE
refactor(partner): Supabase 직접 접근 → Repository 분리

### DIFF
--- a/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
+++ b/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
@@ -228,17 +228,15 @@ class _ApplicationTab extends ConsumerWidget {
     );
   }
 
+  // Fix #653: Supabase 직접 접근 → EventRepository 분리
   Future<void> _approve(
     WidgetRef ref,
     BuildContext context,
     String appId,
   ) async {
     try {
-      final client = ref.read(supabaseClientProvider);
-      await client.functions.invoke(
-        'partner-approve-application',
-        body: {'action': 'approve', 'application_id': appId},
-      );
+      final eventRepo = ref.read(eventRepositoryProvider);
+      await eventRepo.approveApplication(applicationId: appId);
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('승인되었습니다')),
@@ -287,11 +285,12 @@ class _ApplicationTab extends ConsumerWidget {
 
     if (reason == null || reason.trim().isEmpty) return;
 
+    // Fix #653: Supabase 직접 접근 → EventRepository 분리
     try {
-      final client = ref.read(supabaseClientProvider);
-      await client.functions.invoke(
-        'partner-reject-application',
-        body: {'application_id': appId, 'reason': reason.trim()},
+      final eventRepo = ref.read(eventRepositoryProvider);
+      await eventRepo.rejectApplication(
+        applicationId: appId,
+        reason: reason.trim(),
       );
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -334,14 +333,12 @@ class _ApplicationTab extends ConsumerWidget {
 
     if (confirmed != true) return;
 
-    final client = ref.read(supabaseClientProvider);
+    // Fix #653: Supabase 직접 접근 → EventRepository 분리
+    final eventRepo = ref.read(eventRepositoryProvider);
     final failures = <String>[];
     for (final event in grouped.keys) {
       try {
-        await client.functions.invoke(
-          'partner-approve-application',
-          body: {'action': 'bulk_approve', 'event_id': event.id},
-        );
+        await eventRepo.bulkApproveApplications(eventId: event.id);
       } on Exception catch (e) {
         failures.add('${event.title}: $e');
       }

--- a/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_commands.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_commands.dart
@@ -266,4 +266,52 @@ mixin _EventRepositoryCommands
       rethrow;
     }
   }
+
+  /// Fix #653: Approves a single event application via Edge Function.
+  Future<void> approveApplication({required String applicationId}) async {
+    Log.d('approveApplication called | applicationId: $applicationId');
+    try {
+      await supabaseClient.functions.invoke(
+        'partner-approve-application',
+        body: {'action': 'approve', 'application_id': applicationId},
+      );
+      Log.i('✅ [EventRepo] Application approved: $applicationId');
+    } catch (e, st) {
+      Log.e('❌ [EventRepo] approveApplication Error', e, st);
+      rethrow;
+    }
+  }
+
+  /// Fix #653: Rejects a single event application via Edge Function.
+  Future<void> rejectApplication({
+    required String applicationId,
+    required String reason,
+  }) async {
+    Log.d('rejectApplication called | applicationId: $applicationId');
+    try {
+      await supabaseClient.functions.invoke(
+        'partner-reject-application',
+        body: {'application_id': applicationId, 'reason': reason},
+      );
+      Log.i('✅ [EventRepo] Application rejected: $applicationId');
+    } catch (e, st) {
+      Log.e('❌ [EventRepo] rejectApplication Error', e, st);
+      rethrow;
+    }
+  }
+
+  /// Fix #653: Bulk-approves all pending applications for a given event.
+  Future<void> bulkApproveApplications({required String eventId}) async {
+    Log.d('bulkApproveApplications called | eventId: $eventId');
+    try {
+      await supabaseClient.functions.invoke(
+        'partner-approve-application',
+        body: {'action': 'bulk_approve', 'event_id': eventId},
+      );
+      Log.i('✅ [EventRepo] Bulk approve completed for event: $eventId');
+    } catch (e, st) {
+      Log.e('❌ [EventRepo] bulkApproveApplications Error', e, st);
+      rethrow;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- `event_application_manage_page.dart`에서 `supabaseClientProvider`를 직접 호출하던 3개 메서드를 `EventRepository`로 이동
  - `_approve()` → `EventRepository.approveApplication()`
  - `_showRejectDialog()` → `EventRepository.rejectApplication()`
  - `_bulkApprove()` → `EventRepository.bulkApproveApplications()`
- UI 레이어에서 Supabase 직접 접근을 제거하여 Repository 패턴 준수

## Test plan
- [ ] `flutter analyze` 통과 확인 (info-level 기존 이슈만 존재)
- [ ] 신청관리 페이지에서 승인/거절/전체승인 기능 정상 동작 확인

Closes #653