### PR TITLE
refactor(app_user): cross-feature import 해소 — coordinator 패턴 전환

### DIFF
--- a/apps/app_user/lib/src/features/event/detail/event_bottom_ticket_bar.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_bottom_ticket_bar.dart
@@ -73,9 +73,16 @@ class _BottomTicketBar extends ConsumerWidget {
     );
   }
 
-  // Fix #539: coordinator 경유로 ticket feature UI 직접 참조 제거
+  // Fix #634: ticket UI를 ticket_coordinator로 위임 — event → ticket cross-feature 격리
   void _showTicketSelection(BuildContext context, WidgetRef ref) {
-    ref.read(eventCoordinatorProvider).showTicketSelection(context, event);
+    final eventCoordinator = ref.read(eventCoordinatorProvider);
+    ref.read(ticketCoordinatorProvider).showTicketSelection(
+      context,
+      event,
+      onTicketSelected: (eventId, ticketId) {
+        eventCoordinator.goToApplicationWizard(eventId, ticketId: ticketId);
+      },
+    );
   }
 
   Widget _buildActionButton(

--- a/apps/app_user/lib/src/features/event/detail/event_bottom_ticket_bar.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_bottom_ticket_bar.dart
@@ -76,13 +76,15 @@ class _BottomTicketBar extends ConsumerWidget {
   // Fix #634: ticket UI를 ticket_coordinator로 위임 — event → ticket cross-feature 격리
   void _showTicketSelection(BuildContext context, WidgetRef ref) {
     final eventCoordinator = ref.read(eventCoordinatorProvider);
-    ref.read(ticketCoordinatorProvider).showTicketSelection(
-      context,
-      event,
-      onTicketSelected: (eventId, ticketId) {
-        eventCoordinator.goToApplicationWizard(eventId, ticketId: ticketId);
-      },
-    );
+    ref
+        .read(ticketCoordinatorProvider)
+        .showTicketSelection(
+          context,
+          event,
+          onTicketSelected: (eventId, ticketId) {
+            eventCoordinator.goToApplicationWizard(eventId, ticketId: ticketId);
+          },
+        );
   }
 
   Widget _buildActionButton(

--- a/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_content.dart
@@ -373,9 +373,10 @@ class _EventDetailContentState extends ConsumerState<_EventDetailContent>
                             activeIcon: Icons.thumb_up,
                             inactiveIcon: Icons.thumb_up_outlined,
                             activeColor: MinglitColors.primary,
+                            // Fix #634: auth_coordinator 직접 참조 → event_coordinator.pushLogin 전환
                             onUnauthenticatedTap: user == null
                                 ? () => ref
-                                      .read(authCoordinatorProvider)
+                                      .read(eventCoordinatorProvider)
                                       .pushLogin()
                                 : null,
                           ),

--- a/apps/app_user/lib/src/features/event/detail/event_detail_page.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_page.dart
@@ -4,8 +4,8 @@ import 'package:app_user/src/features/event/admission/event_admission_controller
 import 'package:app_user/src/features/event/detail/open_in_app_dialog.dart';
 import 'package:app_user/src/features/event/detail/report_bottom_sheet.dart';
 import 'package:app_user/src/features/event/logic/event_coordinator.dart';
-import 'package:app_user/src/features/ticket/logic/ticket_coordinator.dart';
 import 'package:app_user/src/features/event/logic/event_detail_controller.dart';
+import 'package:app_user/src/features/ticket/logic/ticket_coordinator.dart';
 import 'package:app_user/src/utils/share_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/apps/app_user/lib/src/features/event/detail/event_detail_page.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_page.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
-import 'package:app_user/src/features/auth/logic/auth_coordinator.dart';
 import 'package:app_user/src/features/event/admission/event_admission_controller.dart';
 import 'package:app_user/src/features/event/detail/open_in_app_dialog.dart';
 import 'package:app_user/src/features/event/detail/report_bottom_sheet.dart';
 import 'package:app_user/src/features/event/logic/event_coordinator.dart';
+import 'package:app_user/src/features/ticket/logic/ticket_coordinator.dart';
 import 'package:app_user/src/features/event/logic/event_detail_controller.dart';
 import 'package:app_user/src/utils/share_utils.dart';
 import 'package:flutter/material.dart';

--- a/apps/app_user/lib/src/features/event/logic/event_coordinator.dart
+++ b/apps/app_user/lib/src/features/event/logic/event_coordinator.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
 
-import 'package:app_user/src/features/ticket/ui/ticket_selection_sheet.dart';
 import 'package:app_user/src/routing/app_router.dart';
 import 'package:app_user/src/routing/app_routes.dart';
-import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -47,19 +45,8 @@ class EventCoordinator {
     );
   }
 
-  // Fix #539: ticket feature UI import를 coordinator로 이동 — event → ticket cross-feature 격리
-  void showTicketSelection(BuildContext context, Event event) {
-    unawaited(
-      showModalBottomSheet<void>(
-        context: context,
-        isScrollControlled: true,
-        builder: (_) => TicketSelectionSheet(
-          event: event,
-          onTicketSelected: (eventId, ticketId) {
-            goToApplicationWizard(eventId, ticketId: ticketId);
-          },
-        ),
-      ),
-    );
+  // Fix #634: auth_coordinator 직접 참조 → event_coordinator 내부로 login 네비게이션 위임
+  void pushLogin({String? from}) {
+    unawaited(_router.push(LoginRoute(from: from).location));
   }
 }

--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -168,7 +168,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                       return MinglitEventCard(
                         event: event,
                         // Fix #634: event_coordinator 직접 참조 → home_coordinator 전환
-                    onTap: () => homeCoordinator.pushEventDetail(event.id),
+                        onTap: () => homeCoordinator.pushEventDetail(event.id),
                       );
                     },
                   ),

--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
 
-import 'package:app_user/src/features/auth/logic/auth_coordinator.dart';
-import 'package:app_user/src/features/event/logic/event_coordinator.dart';
 import 'package:app_user/src/features/home/logic/home_coordinator.dart';
 import 'package:app_user/src/logic/feed_state_provider.dart';
 import 'package:app_user/src/routing/app_routes.dart';
@@ -46,7 +44,6 @@ class _HomePageState extends ConsumerState<HomePage> {
   Widget build(BuildContext context) {
     final user = ref.watch(currentUserProvider);
     final homeCoordinator = ref.read(homeCoordinatorProvider);
-    final eventCoordinator = ref.read(eventCoordinatorProvider);
     final recommendationState = ref.watch(recommendationFeedProvider);
 
     // Auto-fetch next page when first page is completely filtered out
@@ -126,8 +123,8 @@ class _HomePageState extends ConsumerState<HomePage> {
                     icon: const Icon(Icons.person_outline),
                     // Fix #102: use go (not push) so GoRouter redirect
                     // fires after login
-                    onPressed: () =>
-                        ref.read(authCoordinatorProvider).goToLogin(from: '/'),
+                    // Fix #634: auth_coordinator 직접 참조 → home_coordinator.goToLogin 전환
+                    onPressed: () => homeCoordinator.goToLogin(from: '/'),
                   ),
                 const SizedBox(width: MinglitSpacing.small),
               ],
@@ -170,7 +167,8 @@ class _HomePageState extends ConsumerState<HomePage> {
                       final event = state.events[index];
                       return MinglitEventCard(
                         event: event,
-                        onTap: () => eventCoordinator.pushEventDetail(event.id),
+                        // Fix #634: event_coordinator 직접 참조 → home_coordinator 전환
+                    onTap: () => homeCoordinator.pushEventDetail(event.id),
                       );
                     },
                   ),

--- a/apps/app_user/lib/src/features/home/logic/home_coordinator.dart
+++ b/apps/app_user/lib/src/features/home/logic/home_coordinator.dart
@@ -14,6 +14,11 @@ class HomeCoordinator {
 
   final GoRouter _router;
 
+  // Fix #634: goToLogin을 home_coordinator로 이동 — auth_coordinator 직접 참조 제거
+  void goToLogin({String? from}) {
+    _router.go(LoginRoute(from: from).location);
+  }
+
   void pushNotificationCenter() {
     unawaited(_router.push(const NotificationCenterRoute().location));
   }

--- a/apps/app_user/lib/src/features/partner/detail/partner_detail_page.dart
+++ b/apps/app_user/lib/src/features/partner/detail/partner_detail_page.dart
@@ -1,4 +1,4 @@
-import 'package:app_user/src/features/home/logic/home_coordinator.dart';
+import 'package:app_user/src/features/partner/logic/partner_coordinator.dart';
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -34,8 +34,8 @@ class PartnerDetailPage extends ConsumerWidget {
           if (partner == null) {
             return const Center(child: Text('파트너를 찾을 수 없습니다.'));
           }
-          // Fix #404: Use coordinator instead of direct GoRouter access
-          final coordinator = ref.read(homeCoordinatorProvider);
+          // Fix #634: home_coordinator 직접 참조 → partner_coordinator 전환
+          final coordinator = ref.read(partnerCoordinatorProvider);
           return PartnerDetailView(
             partner: partner,
             onEventTap: (event) => coordinator.pushEventDetail(event.id),

--- a/apps/app_user/lib/src/features/partner/detail/partner_events_page.dart
+++ b/apps/app_user/lib/src/features/partner/detail/partner_events_page.dart
@@ -42,8 +42,9 @@ class PartnerEventsPage extends ConsumerWidget {
               // Fix #634: home_coordinator 직접 참조 → partner_coordinator 전환
               return MinglitEventCard(
                 event: event,
-                onTap: () =>
-                    ref.read(partnerCoordinatorProvider).pushEventDetail(event.id),
+                onTap: () => ref
+                    .read(partnerCoordinatorProvider)
+                    .pushEventDetail(event.id),
               );
             },
           );

--- a/apps/app_user/lib/src/features/partner/detail/partner_events_page.dart
+++ b/apps/app_user/lib/src/features/partner/detail/partner_events_page.dart
@@ -1,4 +1,4 @@
-import 'package:app_user/src/features/home/logic/home_coordinator.dart';
+import 'package:app_user/src/features/partner/logic/partner_coordinator.dart';
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
@@ -39,11 +39,11 @@ class PartnerEventsPage extends ConsumerWidget {
             itemCount: events.length,
             itemBuilder: (context, index) {
               final event = events[index];
-              // Fix #404: Use coordinator instead of direct GoRouter access
+              // Fix #634: home_coordinator 직접 참조 → partner_coordinator 전환
               return MinglitEventCard(
                 event: event,
                 onTap: () =>
-                    ref.read(homeCoordinatorProvider).pushEventDetail(event.id),
+                    ref.read(partnerCoordinatorProvider).pushEventDetail(event.id),
               );
             },
           );

--- a/apps/app_user/lib/src/features/partner/logic/partner_coordinator.dart
+++ b/apps/app_user/lib/src/features/partner/logic/partner_coordinator.dart
@@ -1,0 +1,35 @@
+import 'dart:async';
+
+import 'package:app_user/src/routing/app_router.dart';
+import 'package:app_user/src/routing/app_routes.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+final partnerCoordinatorProvider = Provider<PartnerCoordinator>((ref) {
+  return PartnerCoordinator(ref.read(goRouterProvider));
+});
+
+// Fix #634: partner feature 전용 coordinator — home_coordinator 직접 참조 제거
+class PartnerCoordinator {
+  PartnerCoordinator(this._router);
+
+  final GoRouter _router;
+
+  void pushEventDetail(String eventId) {
+    unawaited(_router.push(EventDetailRoute(eventId: eventId).location));
+  }
+
+  void pushPartnerEvents({
+    required String partnerId,
+    required String partnerName,
+  }) {
+    unawaited(
+      _router.push(
+        PartnerEventsRoute(
+          partnerId: partnerId,
+          partnerName: partnerName,
+        ).location,
+      ),
+    );
+  }
+}

--- a/apps/app_user/lib/src/features/party/logic/party_coordinator.dart
+++ b/apps/app_user/lib/src/features/party/logic/party_coordinator.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+
+import 'package:app_user/src/routing/app_router.dart';
+import 'package:app_user/src/routing/app_routes.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+final partyCoordinatorProvider = Provider<PartyCoordinator>((ref) {
+  return PartyCoordinator(ref.read(goRouterProvider));
+});
+
+// Fix #634: party feature 전용 coordinator — event_coordinator 직접 참조 제거
+class PartyCoordinator {
+  PartyCoordinator(this._router);
+
+  final GoRouter _router;
+
+  void pushEventDetail(String eventId) {
+    unawaited(_router.push(EventDetailRoute(eventId: eventId).location));
+  }
+}

--- a/apps/app_user/lib/src/features/party/party_curation_page.dart
+++ b/apps/app_user/lib/src/features/party/party_curation_page.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:app_user/src/features/event/logic/event_coordinator.dart';
+import 'package:app_user/src/features/party/logic/party_coordinator.dart';
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
@@ -28,7 +28,8 @@ class _PartyCurationPageState extends ConsumerState<PartyCurationPage> {
   @override
   Widget build(BuildContext context) {
     final eventsAsync = ref.watch(eventFeedProvider(type: widget.type));
-    final eventCoordinator = ref.read(eventCoordinatorProvider);
+    // Fix #634: event_coordinator 직접 참조 → party_coordinator 전환
+    final partyCoordinator = ref.read(partyCoordinatorProvider);
 
     return Scaffold(
       appBar: AppBar(title: Text(widget.type.title), centerTitle: true),
@@ -62,7 +63,7 @@ class _PartyCurationPageState extends ConsumerState<PartyCurationPage> {
                 return MinglitEventCard(
                   event: event,
                   onTap: () {
-                    eventCoordinator.pushEventDetail(event.id);
+                    partyCoordinator.pushEventDetail(event.id);
                   },
                 );
               },

--- a/apps/app_user/lib/src/features/search/logic/search_coordinator.dart
+++ b/apps/app_user/lib/src/features/search/logic/search_coordinator.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+
+import 'package:app_user/src/routing/app_router.dart';
+import 'package:app_user/src/routing/app_routes.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+final searchCoordinatorProvider = Provider<SearchCoordinator>((ref) {
+  return SearchCoordinator(ref.read(goRouterProvider));
+});
+
+// Fix #634: search feature 전용 coordinator — event_coordinator 직접 참조 제거
+class SearchCoordinator {
+  SearchCoordinator(this._router);
+
+  final GoRouter _router;
+
+  void pushEventDetail(String eventId) {
+    unawaited(_router.push(EventDetailRoute(eventId: eventId).location));
+  }
+}

--- a/apps/app_user/lib/src/features/search/search_page.dart
+++ b/apps/app_user/lib/src/features/search/search_page.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:app_user/src/features/event/logic/event_coordinator.dart';
+import 'package:app_user/src/features/search/logic/search_coordinator.dart';
 import 'package:app_user/src/logic/feed_state_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -49,7 +49,8 @@ class _SearchPageState extends ConsumerState<SearchPage> {
   Widget build(BuildContext context) {
     final query = ref.watch(searchQueryProvider);
     final searchAsync = ref.watch(searchResultsProvider);
-    final eventCoordinator = ref.read(eventCoordinatorProvider);
+    // Fix #634: event_coordinator 직접 참조 → search_coordinator 전환
+    final searchCoordinator = ref.read(searchCoordinatorProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -123,7 +124,7 @@ class _SearchPageState extends ConsumerState<SearchPage> {
                   final event = events[index];
                   return MinglitEventCard(
                     event: event,
-                    onTap: () => eventCoordinator.pushEventDetail(event.id),
+                    onTap: () => searchCoordinator.pushEventDetail(event.id),
                   );
                 },
               );

--- a/apps/app_user/lib/src/features/ticket/logic/ticket_coordinator.dart
+++ b/apps/app_user/lib/src/features/ticket/logic/ticket_coordinator.dart
@@ -1,8 +1,11 @@
 import 'dart:async';
 
+import 'package:app_user/src/features/ticket/ui/ticket_selection_sheet.dart';
 import 'package:app_user/src/routing/app_router.dart';
 import 'package:app_user/src/routing/app_routes.dart';
+import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:minglit_kit/minglit_kit.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'ticket_coordinator.g.dart';
@@ -19,5 +22,23 @@ class TicketCoordinator {
 
   void pushEventDetail(String eventId) {
     unawaited(_router.push(EventDetailRoute(eventId: eventId).location));
+  }
+
+  // Fix #634: event_coordinator에서 이동 — ticket UI를 ticket feature 내부에서 관리
+  void showTicketSelection(
+    BuildContext context,
+    Event event, {
+    required void Function(String eventId, String? ticketId) onTicketSelected,
+  }) {
+    unawaited(
+      showModalBottomSheet<void>(
+        context: context,
+        isScrollControlled: true,
+        builder: (_) => TicketSelectionSheet(
+          event: event,
+          onTicketSelected: onTicketSelected,
+        ),
+      ),
+    );
   }
 }

--- a/apps/app_user/test/goldens/golden_test_helpers.dart
+++ b/apps/app_user/test/goldens/golden_test_helpers.dart
@@ -2,6 +2,7 @@ import 'package:alchemist/alchemist.dart' show GoldenTestScenario;
 import 'package:app_user/src/features/auth/logic/auth_coordinator.dart';
 import 'package:app_user/src/features/event/logic/event_coordinator.dart';
 import 'package:app_user/src/features/home/logic/home_coordinator.dart';
+import 'package:app_user/src/features/search/logic/search_coordinator.dart';
 import 'package:app_user/src/logic/feed_state_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/date_symbol_data_local.dart';
@@ -64,6 +65,8 @@ class MockHomeCoordinator extends Mock implements HomeCoordinator {}
 class MockEventCoordinator extends Mock implements EventCoordinator {}
 
 class MockAuthCoordinator extends Mock implements AuthCoordinator {}
+
+class MockSearchCoordinator extends Mock implements SearchCoordinator {}
 
 /// No-op ActiveFilters — disables location/eligibility filters in tests.
 class NoFiltersNotifier extends ActiveFilters {

--- a/apps/app_user/test/goldens/home_page_golden_test.dart
+++ b/apps/app_user/test/goldens/home_page_golden_test.dart
@@ -2,8 +2,6 @@
 library;
 
 import 'package:alchemist/alchemist.dart';
-import 'package:app_user/src/features/auth/logic/auth_coordinator.dart';
-import 'package:app_user/src/features/event/logic/event_coordinator.dart';
 import 'package:app_user/src/features/home/home_page.dart';
 import 'package:app_user/src/features/home/logic/home_coordinator.dart';
 import 'package:app_user/src/logic/feed_state_provider.dart';
@@ -21,13 +19,9 @@ void main() {
     bool hasMore = false,
   }) {
     final mockHome = MockHomeCoordinator();
-    final mockEvent = MockEventCoordinator();
-    final mockAuth = MockAuthCoordinator();
 
     return [
       homeCoordinatorProvider.overrideWithValue(mockHome),
-      eventCoordinatorProvider.overrideWithValue(mockEvent),
-      authCoordinatorProvider.overrideWithValue(mockAuth),
       activeFiltersProvider.overrideWith(NoFiltersNotifier.new),
       recommendationFeedProvider.overrideWith(
         () => _FakeRecommendationFeedNotifier(

--- a/apps/app_user/test/goldens/search_page_golden_test.dart
+++ b/apps/app_user/test/goldens/search_page_golden_test.dart
@@ -2,7 +2,7 @@
 library;
 
 import 'package:alchemist/alchemist.dart';
-import 'package:app_user/src/features/event/logic/event_coordinator.dart';
+import 'package:app_user/src/features/search/logic/search_coordinator.dart';
 import 'package:app_user/src/features/search/search_page.dart';
 import 'package:app_user/src/logic/feed_state_provider.dart';
 import 'package:flutter/material.dart';
@@ -36,8 +36,8 @@ void main() {
             child: GoldenPageWrapper(
               page: const SearchPage(),
               overrides: [
-                eventCoordinatorProvider.overrideWithValue(
-                  MockEventCoordinator(),
+                searchCoordinatorProvider.overrideWithValue(
+                  MockSearchCoordinator(),
                 ),
                 searchQueryProvider.overrideWith(_EmptySearchQuery.new),
                 searchResultsProvider.overrideWith((_) async => <Event>[]),
@@ -68,8 +68,8 @@ void main() {
               page: const SearchPage(),
               brightness: Brightness.dark,
               overrides: [
-                eventCoordinatorProvider.overrideWithValue(
-                  MockEventCoordinator(),
+                searchCoordinatorProvider.overrideWithValue(
+                  MockSearchCoordinator(),
                 ),
                 searchQueryProvider.overrideWith(_EmptySearchQuery.new),
                 searchResultsProvider.overrideWith((_) async => <Event>[]),

--- a/apps/app_user/test/src/features/event/logic/event_coordinator_test.dart
+++ b/apps/app_user/test/src/features/event/logic/event_coordinator_test.dart
@@ -84,11 +84,14 @@ void main() {
       ).called(1);
     });
 
+    // Fix #634: from 쿼리 파라미터 값까지 검증
     test('pushLogin with from param includes query param', () {
       coordinator.pushLogin(from: '/events/123');
 
       verify(
-        () => mockRouter.push(any(that: contains('/login'))),
+        () => mockRouter.push(
+          any(that: allOf(contains('/login'), contains('from=%2Fevents%2F123'))),
+        ),
       ).called(1);
     });
   });

--- a/apps/app_user/test/src/features/event/logic/event_coordinator_test.dart
+++ b/apps/app_user/test/src/features/event/logic/event_coordinator_test.dart
@@ -84,17 +84,17 @@ void main() {
       ).called(1);
     });
 
-    // Fix #634: from 쿼리 파라미터 값까지 검증
+    // Fix #634: from query parameter 정확 검증 — contains('/login')만으로는 불충분
     test('pushLogin with from param includes query param', () {
       coordinator.pushLogin(from: '/events/123');
 
-      verify(
-        () => mockRouter.push(
-          any(
-            that: allOf(contains('/login'), contains('from=%2Fevents%2F123')),
-          ),
-        ),
-      ).called(1);
+      final captured = verify(
+        () => mockRouter.push(captureAny()),
+      ).captured.single as String;
+
+      final uri = Uri.parse(captured);
+      expect(uri.path, '/login');
+      expect(uri.queryParameters['from'], '/events/123');
     });
   });
 }

--- a/apps/app_user/test/src/features/event/logic/event_coordinator_test.dart
+++ b/apps/app_user/test/src/features/event/logic/event_coordinator_test.dart
@@ -1,16 +1,10 @@
 import 'package:app_user/src/features/event/logic/event_coordinator.dart';
-import 'package:app_user/src/features/ticket/ui/ticket_selection_sheet.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
 
 class MockGoRouter extends Mock implements GoRouter {}
-
-class MockEventRepository extends Mock implements EventRepository {}
-
-class MockUserRepository extends Mock implements UserRepository {}
 
 void main() {
   late MockGoRouter mockRouter;
@@ -81,115 +75,21 @@ void main() {
       ).called(1);
     });
 
-    group('showTicketSelection', () {
-      late MockEventRepository mockEventRepository;
-      late MockUserRepository mockUserRepository;
+    // Fix #634: pushLogin 테스트 추가
+    test('pushLogin pushes login route', () {
+      coordinator.pushLogin();
 
-      setUp(() {
-        mockEventRepository = MockEventRepository();
-        mockUserRepository = MockUserRepository();
+      verify(
+        () => mockRouter.push('/login'),
+      ).called(1);
+    });
 
-        when(
-          () => mockEventRepository.getTicketBalanceStatus(any()),
-        ).thenAnswer((_) async => <String, bool>{});
-        when(
-          () => mockUserRepository.getUserProfile(any()),
-        ).thenAnswer((_) async => null);
-        when(
-          () => mockUserRepository.getApprovedVerificationIds(any()),
-        ).thenAnswer((_) async => <String>[]);
-      });
+    test('pushLogin with from param includes query param', () {
+      coordinator.pushLogin(from: '/events/123');
 
-      testWidgets('shows TicketSelectionSheet as bottom sheet', (
-        tester,
-      ) async {
-        final now = DateTime(2026, 4);
-        final event = Event(
-          id: 'event-1',
-          partyId: 'party-1',
-          title: 'Test Event',
-          startTime: now,
-          endTime: now.add(const Duration(hours: 2)),
-          createdAt: now,
-          updatedAt: now,
-        );
-
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              eventRepositoryProvider.overrideWithValue(mockEventRepository),
-              currentUserProvider.overrideWith((_) => null),
-              userRepositoryProvider.overrideWithValue(mockUserRepository),
-            ],
-            child: MaterialApp(
-              theme: MinglitTheme.materialTheme,
-              home: Builder(
-                builder: (context) => Scaffold(
-                  body: ElevatedButton(
-                    onPressed: () =>
-                        coordinator.showTicketSelection(context, event),
-                    child: const Text('Show'),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        );
-
-        await tester.tap(find.text('Show'));
-        await tester.pumpAndSettle();
-
-        expect(find.byType(TicketSelectionSheet), findsOneWidget);
-      });
-
-      testWidgets('dismissing bottom sheet does not navigate', (
-        tester,
-      ) async {
-        final now = DateTime(2026, 4);
-        final event = Event(
-          id: 'event-2',
-          partyId: 'party-2',
-          title: 'Test Event 2',
-          startTime: now,
-          endTime: now.add(const Duration(hours: 2)),
-          createdAt: now,
-          updatedAt: now,
-        );
-
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              eventRepositoryProvider.overrideWithValue(mockEventRepository),
-              currentUserProvider.overrideWith((_) => null),
-              userRepositoryProvider.overrideWithValue(mockUserRepository),
-            ],
-            child: MaterialApp(
-              theme: MinglitTheme.materialTheme,
-              home: Builder(
-                builder: (context) => Scaffold(
-                  body: ElevatedButton(
-                    onPressed: () =>
-                        coordinator.showTicketSelection(context, event),
-                    child: const Text('Show'),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        );
-
-        // Open sheet
-        await tester.tap(find.text('Show'));
-        await tester.pumpAndSettle();
-        expect(find.byType(TicketSelectionSheet), findsOneWidget);
-
-        // Dismiss by tapping the barrier
-        await tester.tapAt(Offset.zero);
-        await tester.pumpAndSettle();
-
-        expect(find.byType(TicketSelectionSheet), findsNothing);
-        verifyNever(() => mockRouter.push(any()));
-      });
+      verify(
+        () => mockRouter.push(any(that: contains('/login'))),
+      ).called(1);
     });
   });
 }

--- a/apps/app_user/test/src/features/event/logic/event_coordinator_test.dart
+++ b/apps/app_user/test/src/features/event/logic/event_coordinator_test.dart
@@ -88,9 +88,11 @@ void main() {
     test('pushLogin with from param includes query param', () {
       coordinator.pushLogin(from: '/events/123');
 
-      final captured = verify(
-        () => mockRouter.push(captureAny()),
-      ).captured.single as String;
+      final captured =
+          verify(
+                () => mockRouter.push(captureAny()),
+              ).captured.single
+              as String;
 
       final uri = Uri.parse(captured);
       expect(uri.path, '/login');

--- a/apps/app_user/test/src/features/event/logic/event_coordinator_test.dart
+++ b/apps/app_user/test/src/features/event/logic/event_coordinator_test.dart
@@ -90,7 +90,9 @@ void main() {
 
       verify(
         () => mockRouter.push(
-          any(that: allOf(contains('/login'), contains('from=%2Fevents%2F123'))),
+          any(
+            that: allOf(contains('/login'), contains('from=%2Fevents%2F123')),
+          ),
         ),
       ).called(1);
     });

--- a/apps/app_user/test/src/features/partner/logic/partner_coordinator_test.dart
+++ b/apps/app_user/test/src/features/partner/logic/partner_coordinator_test.dart
@@ -1,0 +1,55 @@
+// Fix #634: PartnerCoordinator unit tests
+import 'package:app_user/src/features/partner/logic/partner_coordinator.dart';
+import 'package:app_user/src/routing/app_router.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../utils/test_utils.dart';
+
+class MockGoRouter extends Mock implements GoRouter {}
+
+void main() {
+  late MockGoRouter mockRouter;
+  late PartnerCoordinator coordinator;
+
+  setUp(() {
+    mockRouter = MockGoRouter();
+    coordinator = PartnerCoordinator(mockRouter);
+
+    when(() => mockRouter.push(any())).thenAnswer((_) async => null);
+  });
+
+  group('PartnerCoordinator', () {
+    test('creates from provider with GoRouter', () {
+      final container = createContainer(
+        overrides: [
+          goRouterProvider.overrideWithValue(mockRouter),
+        ],
+      );
+
+      final result = container.read(partnerCoordinatorProvider);
+
+      expect(result, isA<PartnerCoordinator>());
+    });
+
+    test('pushEventDetail pushes correct route', () {
+      coordinator.pushEventDetail('event-123');
+
+      verify(
+        () => mockRouter.push(any(that: contains('/events/event-123'))),
+      ).called(1);
+    });
+
+    test('pushPartnerEvents pushes correct route', () {
+      coordinator.pushPartnerEvents(
+        partnerId: 'partner-456',
+        partnerName: 'Test Partner',
+      );
+
+      verify(
+        () => mockRouter.push(any(that: contains('partner-456'))),
+      ).called(1);
+    });
+  });
+}

--- a/apps/app_user/test/src/features/partner/logic/partner_coordinator_test.dart
+++ b/apps/app_user/test/src/features/partner/logic/partner_coordinator_test.dart
@@ -1,6 +1,6 @@
-// Fix #634: PartnerCoordinator unit tests
 import 'package:app_user/src/features/partner/logic/partner_coordinator.dart';
 import 'package:app_user/src/routing/app_router.dart';
+import 'package:app_user/src/routing/app_routes.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
@@ -37,7 +37,9 @@ void main() {
       coordinator.pushEventDetail('event-123');
 
       verify(
-        () => mockRouter.push(any(that: contains('/events/event-123'))),
+        () => mockRouter.push(
+          const EventDetailRoute(eventId: 'event-123').location,
+        ),
       ).called(1);
     });
 
@@ -48,7 +50,12 @@ void main() {
       );
 
       verify(
-        () => mockRouter.push(any(that: contains('partner-456'))),
+        () => mockRouter.push(
+          const PartnerEventsRoute(
+            partnerId: 'partner-456',
+            partnerName: 'Test Partner',
+          ).location,
+        ),
       ).called(1);
     });
   });

--- a/apps/app_user/test/src/features/party/logic/party_coordinator_test.dart
+++ b/apps/app_user/test/src/features/party/logic/party_coordinator_test.dart
@@ -1,0 +1,44 @@
+// Fix #634: PartyCoordinator unit tests
+import 'package:app_user/src/features/party/logic/party_coordinator.dart';
+import 'package:app_user/src/routing/app_router.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../utils/test_utils.dart';
+
+class MockGoRouter extends Mock implements GoRouter {}
+
+void main() {
+  late MockGoRouter mockRouter;
+  late PartyCoordinator coordinator;
+
+  setUp(() {
+    mockRouter = MockGoRouter();
+    coordinator = PartyCoordinator(mockRouter);
+
+    when(() => mockRouter.push(any())).thenAnswer((_) async => null);
+  });
+
+  group('PartyCoordinator', () {
+    test('creates from provider with GoRouter', () {
+      final container = createContainer(
+        overrides: [
+          goRouterProvider.overrideWithValue(mockRouter),
+        ],
+      );
+
+      final result = container.read(partyCoordinatorProvider);
+
+      expect(result, isA<PartyCoordinator>());
+    });
+
+    test('pushEventDetail pushes correct route', () {
+      coordinator.pushEventDetail('event-789');
+
+      verify(
+        () => mockRouter.push(any(that: contains('/events/event-789'))),
+      ).called(1);
+    });
+  });
+}

--- a/apps/app_user/test/src/features/party/logic/party_coordinator_test.dart
+++ b/apps/app_user/test/src/features/party/logic/party_coordinator_test.dart
@@ -1,6 +1,6 @@
-// Fix #634: PartyCoordinator unit tests
 import 'package:app_user/src/features/party/logic/party_coordinator.dart';
 import 'package:app_user/src/routing/app_router.dart';
+import 'package:app_user/src/routing/app_routes.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
@@ -34,10 +34,12 @@ void main() {
     });
 
     test('pushEventDetail pushes correct route', () {
-      coordinator.pushEventDetail('event-789');
+      coordinator.pushEventDetail('event-123');
 
       verify(
-        () => mockRouter.push(any(that: contains('/events/event-789'))),
+        () => mockRouter.push(
+          const EventDetailRoute(eventId: 'event-123').location,
+        ),
       ).called(1);
     });
   });

--- a/apps/app_user/test/src/features/search/logic/search_coordinator_test.dart
+++ b/apps/app_user/test/src/features/search/logic/search_coordinator_test.dart
@@ -1,6 +1,6 @@
-// Fix #634: SearchCoordinator unit tests
 import 'package:app_user/src/features/search/logic/search_coordinator.dart';
 import 'package:app_user/src/routing/app_router.dart';
+import 'package:app_user/src/routing/app_routes.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
@@ -34,10 +34,12 @@ void main() {
     });
 
     test('pushEventDetail pushes correct route', () {
-      coordinator.pushEventDetail('event-456');
+      coordinator.pushEventDetail('event-123');
 
       verify(
-        () => mockRouter.push(any(that: contains('/events/event-456'))),
+        () => mockRouter.push(
+          const EventDetailRoute(eventId: 'event-123').location,
+        ),
       ).called(1);
     });
   });

--- a/apps/app_user/test/src/features/search/logic/search_coordinator_test.dart
+++ b/apps/app_user/test/src/features/search/logic/search_coordinator_test.dart
@@ -1,0 +1,44 @@
+// Fix #634: SearchCoordinator unit tests
+import 'package:app_user/src/features/search/logic/search_coordinator.dart';
+import 'package:app_user/src/routing/app_router.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../utils/test_utils.dart';
+
+class MockGoRouter extends Mock implements GoRouter {}
+
+void main() {
+  late MockGoRouter mockRouter;
+  late SearchCoordinator coordinator;
+
+  setUp(() {
+    mockRouter = MockGoRouter();
+    coordinator = SearchCoordinator(mockRouter);
+
+    when(() => mockRouter.push(any())).thenAnswer((_) async => null);
+  });
+
+  group('SearchCoordinator', () {
+    test('creates from provider with GoRouter', () {
+      final container = createContainer(
+        overrides: [
+          goRouterProvider.overrideWithValue(mockRouter),
+        ],
+      );
+
+      final result = container.read(searchCoordinatorProvider);
+
+      expect(result, isA<SearchCoordinator>());
+    });
+
+    test('pushEventDetail pushes correct route', () {
+      coordinator.pushEventDetail('event-456');
+
+      verify(
+        () => mockRouter.push(any(that: contains('/events/event-456'))),
+      ).called(1);
+    });
+  });
+}

--- a/apps/app_user/test/src/features/ticket/logic/ticket_coordinator_test.dart
+++ b/apps/app_user/test/src/features/ticket/logic/ticket_coordinator_test.dart
@@ -1,12 +1,19 @@
 import 'package:app_user/src/features/ticket/logic/ticket_coordinator.dart';
+import 'package:app_user/src/features/ticket/ui/ticket_selection_sheet.dart';
 import 'package:app_user/src/routing/app_router.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../../utils/test_utils.dart';
 
 class MockGoRouter extends Mock implements GoRouter {}
+
+class MockEventRepository extends Mock implements EventRepository {}
+
+class MockUserRepository extends Mock implements UserRepository {}
 
 void main() {
   late MockGoRouter mockRouter;
@@ -33,6 +40,126 @@ void main() {
       TicketCoordinator(mockRouter).pushEventDetail('event_456');
 
       verify(() => mockRouter.push(any(that: contains('event_456')))).called(1);
+    });
+
+    // Fix #634: showTicketSelection 테스트 — event_coordinator에서 이동
+    group('showTicketSelection', () {
+      late MockEventRepository mockEventRepository;
+      late MockUserRepository mockUserRepository;
+
+      setUp(() {
+        mockEventRepository = MockEventRepository();
+        mockUserRepository = MockUserRepository();
+
+        when(
+          () => mockEventRepository.getTicketBalanceStatus(any()),
+        ).thenAnswer((_) async => <String, bool>{});
+        when(
+          () => mockUserRepository.getUserProfile(any()),
+        ).thenAnswer((_) async => null);
+        when(
+          () => mockUserRepository.getApprovedVerificationIds(any()),
+        ).thenAnswer((_) async => <String>[]);
+      });
+
+      testWidgets('shows TicketSelectionSheet as bottom sheet', (
+        tester,
+      ) async {
+        final coordinator = TicketCoordinator(mockRouter);
+        final now = DateTime(2026, 4);
+        final event = Event(
+          id: 'event-1',
+          partyId: 'party-1',
+          title: 'Test Event',
+          startTime: now,
+          endTime: now.add(const Duration(hours: 2)),
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              eventRepositoryProvider.overrideWithValue(mockEventRepository),
+              currentUserProvider.overrideWith((_) => null),
+              userRepositoryProvider.overrideWithValue(mockUserRepository),
+            ],
+            child: MaterialApp(
+              theme: MinglitTheme.materialTheme,
+              home: Builder(
+                builder: (context) => Scaffold(
+                  body: ElevatedButton(
+                    onPressed: () => coordinator.showTicketSelection(
+                      context,
+                      event,
+                      onTicketSelected: (_, _) {},
+                    ),
+                    child: const Text('Show'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Show'));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(TicketSelectionSheet), findsOneWidget);
+      });
+
+      testWidgets('dismissing bottom sheet does not navigate', (
+        tester,
+      ) async {
+        final coordinator = TicketCoordinator(mockRouter);
+        final now = DateTime(2026, 4);
+        final event = Event(
+          id: 'event-2',
+          partyId: 'party-2',
+          title: 'Test Event 2',
+          startTime: now,
+          endTime: now.add(const Duration(hours: 2)),
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              eventRepositoryProvider.overrideWithValue(mockEventRepository),
+              currentUserProvider.overrideWith((_) => null),
+              userRepositoryProvider.overrideWithValue(mockUserRepository),
+            ],
+            child: MaterialApp(
+              theme: MinglitTheme.materialTheme,
+              home: Builder(
+                builder: (context) => Scaffold(
+                  body: ElevatedButton(
+                    onPressed: () => coordinator.showTicketSelection(
+                      context,
+                      event,
+                      onTicketSelected: (_, _) {},
+                    ),
+                    child: const Text('Show'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        // Open sheet
+        await tester.tap(find.text('Show'));
+        await tester.pumpAndSettle();
+        expect(find.byType(TicketSelectionSheet), findsOneWidget);
+
+        // Dismiss by tapping the barrier
+        await tester.tapAt(Offset.zero);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(TicketSelectionSheet), findsNothing);
+        verifyNever(() => mockRouter.push(any()));
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary
- 5개 feature에서 다른 feature의 coordinator/UI를 직접 import하던 **6건의 cross-feature 위반** 해소
- 각 feature에 전용 coordinator를 생성하여 feature 격리 원칙 준수
- 기존 테스트 + 새 테스트 23건 모두 통과, `flutter analyze` 에러 0건

Closes #634

## 변경 사항

| Feature | 변경 전 (cross-feature import) | 변경 후 |
|---------|-------------------------------|---------|
| home | auth_coordinator, event_coordinator | home_coordinator.goToLogin/pushEventDetail |
| search | event_coordinator | **신규** search_coordinator |
| partner | home_coordinator | **신규** partner_coordinator |
| party | event_coordinator | **신규** party_coordinator |
| event | ticket/ui/ticket_selection_sheet | ticket_coordinator.showTicketSelection |
| event_detail | auth_coordinator.pushLogin | event_coordinator.pushLogin |

## 신규 파일
- `search/logic/search_coordinator.dart`
- `partner/logic/partner_coordinator.dart`
- `party/logic/party_coordinator.dart`

## Test plan
- [x] `flutter analyze` 에러 0건 (info 45건은 기존)
- [x] event_coordinator_test — 9건 통과 (pushLogin 2건 추가, showTicketSelection 2건 ticket_coordinator로 이동)
- [x] home_coordinator_test — 10건 통과
- [x] ticket_coordinator_test — 4건 통과 (showTicketSelection 2건 추가)
- [ ] CI `test-flutter-apps` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)