### PR TITLE
feat(home): EventNowMultiStack 멀티 이벤트 스택 위젯

### DIFF
--- a/apps/app_user/lib/src/features/home/widgets/event_now_multi_stack.dart
+++ b/apps/app_user/lib/src/features/home/widgets/event_now_multi_stack.dart
@@ -1,0 +1,423 @@
+import 'package:app_user/src/features/home/widgets/event_now_bar_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+/// Sorts [TodayActiveEvent] items by state priority, then by start time.
+///
+/// Priority groups (highest first):
+///   1. Active — CHECK_IN_READY, CHECKED_IN, MATCHING, RESULTS
+///   2. Waiting — WAITING
+///   3. Ended — ENDED
+///
+/// Within the same priority group, events are sorted by [Event.startTime]
+/// ascending (earlier events first).
+List<TodayActiveEvent> sortActiveEvents(
+  List<TodayActiveEvent> events,
+  Map<String, EventNowBarState> stateMap,
+) {
+  return [...events]..sort((a, b) {
+    final priorityA = _statePriority(stateMap[a.event.id]);
+    final priorityB = _statePriority(stateMap[b.event.id]);
+
+    if (priorityA != priorityB) return priorityA.compareTo(priorityB);
+    return a.event.startTime.compareTo(b.event.startTime);
+  });
+}
+
+/// Lower number = higher priority.
+int _statePriority(EventNowBarState? state) {
+  return switch (state) {
+    EventNowBarState.checkInReady => 0,
+    EventNowBarState.checkedIn => 0,
+    EventNowBarState.matching => 0,
+    EventNowBarState.results => 0,
+    EventNowBarState.waiting => 1,
+    EventNowBarState.ended => 2,
+    null => 1, // Unknown → treat as waiting.
+  };
+}
+
+/// Wraps the event now bar with multi-event support.
+///
+/// When one event exists, displays the bar without additional chrome.
+/// When two or more events exist, adds a count badge and dropdown icon.
+/// Tapping the dropdown opens a bottom sheet for event selection.
+class EventNowMultiStack extends ConsumerStatefulWidget {
+  /// Creates an [EventNowMultiStack].
+  const EventNowMultiStack({
+    required this.events,
+    super.key,
+    this.onEventTap,
+  });
+
+  /// All today's active events.
+  final List<TodayActiveEvent> events;
+
+  /// Called when the user taps on an event (bar or bottom sheet selection).
+  final void Function(TodayActiveEvent event)? onEventTap;
+
+  @override
+  ConsumerState<EventNowMultiStack> createState() =>
+      _EventNowMultiStackState();
+}
+
+class _EventNowMultiStackState extends ConsumerState<EventNowMultiStack> {
+  int _selectedIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.events.isEmpty) return const SizedBox.shrink();
+
+    // Collect resolved states for sorting.
+    final stateMap = <String, EventNowBarState>{};
+    for (final active in widget.events) {
+      ref
+          .watch(eventNowBarStateProvider(active))
+          .whenData((s) => stateMap[active.event.id] = s);
+    }
+
+    final sorted = sortActiveEvents(widget.events, stateMap);
+    final clampedIndex = _selectedIndex.clamp(0, sorted.length - 1);
+    final current = sorted[clampedIndex];
+    final hasMultiple = sorted.length > 1;
+
+    return _EventNowMultiBar(
+      activeEvent: current,
+      eventCount: sorted.length,
+      showDropdown: hasMultiple,
+      onTap: () => widget.onEventTap?.call(current),
+      onDropdownTap: hasMultiple
+          ? () => _showEventListSheet(context, sorted, stateMap)
+          : null,
+    );
+  }
+
+  Future<void> _showEventListSheet(
+    BuildContext context,
+    List<TodayActiveEvent> sorted,
+    Map<String, EventNowBarState> stateMap,
+  ) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(MinglitRadius.card),
+        ),
+      ),
+      builder: (_) => _EventListSheet(
+        events: sorted,
+        stateMap: stateMap,
+        selectedIndex: _selectedIndex.clamp(0, sorted.length - 1),
+        onSelect: (index) {
+          setState(() => _selectedIndex = index);
+          Navigator.of(context).pop();
+          final selected = sorted[index];
+          widget.onEventTap?.call(selected);
+        },
+      ),
+    );
+  }
+}
+
+/// The mini-bar that shows the current event, with optional count badge
+/// and dropdown icon for multi-event scenarios.
+class _EventNowMultiBar extends ConsumerWidget {
+  const _EventNowMultiBar({
+    required this.activeEvent,
+    required this.eventCount,
+    required this.showDropdown,
+    this.onTap,
+    this.onDropdownTap,
+  });
+
+  final TodayActiveEvent activeEvent;
+  final int eventCount;
+  final bool showDropdown;
+  final VoidCallback? onTap;
+  final VoidCallback? onDropdownTap;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final stateAsync = ref.watch(eventNowBarStateProvider(activeEvent));
+    final state = stateAsync.when(
+      data: (s) => s,
+      loading: () => EventNowBarState.waiting,
+      error: (_, _) => EventNowBarState.waiting,
+    );
+    final event = activeEvent.event;
+    final theme = Theme.of(context);
+    final dotColor = _dotColor(state);
+    final statusLabel = _statusText(state);
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        height: 56,
+        decoration: BoxDecoration(
+          color: MinglitColors.surface,
+          borderRadius: const BorderRadius.only(
+            topLeft: Radius.circular(MinglitRadius.card),
+            topRight: Radius.circular(MinglitRadius.card),
+          ),
+          border: Border(
+            top: BorderSide(
+              color: MinglitColors.primary.withValues(alpha: 0.1),
+            ),
+          ),
+        ),
+        padding: const EdgeInsets.symmetric(
+          horizontal: MinglitSpacing.screenEdge,
+        ),
+        child: Row(
+          children: [
+            // Status dot
+            Container(
+              width: 8,
+              height: 8,
+              decoration: BoxDecoration(
+                color: dotColor,
+                shape: BoxShape.circle,
+              ),
+            ),
+            const SizedBox(width: MinglitSpacing.sm),
+            // Event title
+            Flexible(
+              child: Text(
+                event.title ?? '이벤트',
+                style: theme.textTheme.bodyMedium,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            const Spacer(),
+            // Status text
+            Text(
+              statusLabel,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: MinglitColors.textSecondary,
+              ),
+            ),
+            // Count badge + dropdown (multi-event only)
+            if (showDropdown) ...[
+              const SizedBox(width: MinglitSpacing.small),
+              _CountBadge(count: eventCount),
+              GestureDetector(
+                onTap: onDropdownTap,
+                behavior: HitTestBehavior.opaque,
+                child: const Padding(
+                  padding: EdgeInsets.all(MinglitSpacing.xsmall),
+                  child: Icon(
+                    Icons.expand_more,
+                    color: MinglitColors.textSecondary,
+                    size: MinglitIconSize.small,
+                  ),
+                ),
+              ),
+            ],
+            if (!showDropdown) ...[
+              const SizedBox(width: MinglitSpacing.small),
+              const Icon(
+                Icons.chevron_right,
+                color: MinglitColors.textSecondary,
+                size: MinglitIconSize.small,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Small circular badge showing the number of active events.
+class _CountBadge extends StatelessWidget {
+  const _CountBadge({required this.count});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: MinglitSpacing.xsmall + 2,
+        vertical: 1,
+      ),
+      decoration: BoxDecoration(
+        color: MinglitColors.primary,
+        borderRadius: BorderRadius.circular(MinglitRadius.chip),
+      ),
+      child: Text(
+        '$count',
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: Colors.white,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+}
+
+/// Bottom sheet listing all active events for selection.
+class _EventListSheet extends StatelessWidget {
+  const _EventListSheet({
+    required this.events,
+    required this.stateMap,
+    required this.selectedIndex,
+    required this.onSelect,
+  });
+
+  final List<TodayActiveEvent> events;
+  final Map<String, EventNowBarState> stateMap;
+  final int selectedIndex;
+  final void Function(int index) onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Drag handle
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: MinglitSpacing.small),
+            child: Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: MinglitColors.textSecondary.withValues(alpha: 0.3),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: MinglitSpacing.screenEdge,
+            ),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                '진행 중인 이벤트',
+                style: theme.textTheme.titleSmall,
+              ),
+            ),
+          ),
+          const SizedBox(height: MinglitSpacing.small),
+          ...List.generate(events.length, (i) {
+            final active = events[i];
+            final event = active.event;
+            final state = stateMap[event.id];
+            final isSelected = i == selectedIndex;
+
+            return _EventListTile(
+              title: event.title ?? '이벤트',
+              statusLabel: _statusText(state ?? EventNowBarState.waiting),
+              dotColor: _dotColor(state ?? EventNowBarState.waiting),
+              isSelected: isSelected,
+              onTap: () => onSelect(i),
+            );
+          }),
+          const SizedBox(height: MinglitSpacing.medium),
+        ],
+      ),
+    );
+  }
+}
+
+/// A single row in the event selection bottom sheet.
+class _EventListTile extends StatelessWidget {
+  const _EventListTile({
+    required this.title,
+    required this.statusLabel,
+    required this.dotColor,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final String title;
+  final String statusLabel;
+  final Color dotColor;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: MinglitSpacing.screenEdge,
+          vertical: MinglitSpacing.sm,
+        ),
+        color: isSelected
+            ? MinglitColors.primary.withValues(alpha: 0.05)
+            : null,
+        child: Row(
+          children: [
+            Container(
+              width: 8,
+              height: 8,
+              decoration: BoxDecoration(
+                color: dotColor,
+                shape: BoxShape.circle,
+              ),
+            ),
+            const SizedBox(width: MinglitSpacing.sm),
+            Expanded(
+              child: Text(
+                title,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontWeight: isSelected ? FontWeight.w600 : null,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            Text(
+              statusLabel,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: MinglitColors.textSecondary,
+              ),
+            ),
+            if (isSelected) ...[
+              const SizedBox(width: MinglitSpacing.small),
+              const Icon(
+                Icons.check,
+                color: MinglitColors.primary,
+                size: MinglitIconSize.xsmall,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// --- Shared helpers (duplicated from EventNowBar to avoid
+// exposing privates) ---
+
+Color _dotColor(EventNowBarState state) {
+  return switch (state) {
+    EventNowBarState.waiting => MinglitColors.textSecondary,
+    EventNowBarState.checkInReady => MinglitColors.primary,
+    EventNowBarState.checkedIn => MinglitColors.success,
+    EventNowBarState.matching => MinglitColors.secondary,
+    EventNowBarState.results => MinglitColors.primary,
+    EventNowBarState.ended => MinglitColors.textSecondary,
+  };
+}
+
+String _statusText(EventNowBarState state) {
+  return switch (state) {
+    EventNowBarState.waiting => '곧 시작',
+    EventNowBarState.checkInReady => '체크인하세요',
+    EventNowBarState.checkedIn => '체크인 완료',
+    EventNowBarState.matching => '매칭 진행 중',
+    EventNowBarState.results => '결과 확인',
+    EventNowBarState.ended => '종료됨',
+  };
+}

--- a/apps/app_user/lib/src/features/home/widgets/event_now_multi_stack.dart
+++ b/apps/app_user/lib/src/features/home/widgets/event_now_multi_stack.dart
@@ -57,8 +57,7 @@ class EventNowMultiStack extends ConsumerStatefulWidget {
   final void Function(TodayActiveEvent event)? onEventTap;
 
   @override
-  ConsumerState<EventNowMultiStack> createState() =>
-      _EventNowMultiStackState();
+  ConsumerState<EventNowMultiStack> createState() => _EventNowMultiStackState();
 }
 
 class _EventNowMultiStackState extends ConsumerState<EventNowMultiStack> {

--- a/apps/app_user/test/src/features/home/widgets/event_now_multi_stack_test.dart
+++ b/apps/app_user/test/src/features/home/widgets/event_now_multi_stack_test.dart
@@ -1,0 +1,347 @@
+import 'package:app_user/src/features/home/widgets/event_now_bar_controller.dart';
+import 'package:app_user/src/features/home/widgets/event_now_multi_stack.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../utils/mocks.dart';
+import '../../../../utils/test_utils.dart';
+
+void main() {
+  late MockMatchingRepository mockMatchingRepo;
+
+  setUp(() {
+    mockMatchingRepo = MockMatchingRepository();
+  });
+
+  /// Helper to create a [TodayActiveEvent] with sensible defaults.
+  TodayActiveEvent makeActiveEvent({
+    String id = 'event_1',
+    String? title,
+    String status = 'scheduled',
+    String participantStatus = 'ticket_issued',
+    DateTime? startTime,
+    DateTime? endTime,
+  }) {
+    final now = DateTime.now();
+    return TodayActiveEvent(
+      event: Event(
+        id: id,
+        partyId: 'party_1',
+        startTime: startTime ?? now.subtract(const Duration(hours: 1)),
+        endTime: endTime ?? now.add(const Duration(hours: 2)),
+        createdAt: now,
+        updatedAt: now,
+        status: status,
+        title: title ?? '이벤트 $id',
+      ),
+      participantStatus: participantStatus,
+    );
+  }
+
+  // ──────────────────────────────────────────────────
+  // Sorting logic unit tests (5건)
+  // ──────────────────────────────────────────────────
+  group('sortActiveEvents — 정렬 로직', () {
+    test('진행 중 이벤트가 대기 이벤트보다 우선', () {
+      final waiting = makeActiveEvent(id: 'waiting');
+      final checkIn = makeActiveEvent(id: 'checkin');
+
+      final stateMap = {
+        'waiting': EventNowBarState.waiting,
+        'checkin': EventNowBarState.checkInReady,
+      };
+
+      final sorted = sortActiveEvents([waiting, checkIn], stateMap);
+
+      expect(sorted.first.event.id, 'checkin');
+      expect(sorted.last.event.id, 'waiting');
+    });
+
+    test('종료 이벤트가 스택 하단에 위치', () {
+      final ended = makeActiveEvent(id: 'ended');
+      final waiting = makeActiveEvent(id: 'waiting');
+      final active = makeActiveEvent(id: 'active');
+
+      final stateMap = {
+        'ended': EventNowBarState.ended,
+        'waiting': EventNowBarState.waiting,
+        'active': EventNowBarState.matching,
+      };
+
+      final sorted = sortActiveEvents([ended, waiting, active], stateMap);
+
+      expect(sorted[0].event.id, 'active');
+      expect(sorted[1].event.id, 'waiting');
+      expect(sorted[2].event.id, 'ended');
+    });
+
+    test('같은 우선순위 내 시작 시간 빠른 순 정렬', () {
+      final now = DateTime.now();
+      final early = makeActiveEvent(
+        id: 'early',
+        startTime: now.subtract(const Duration(hours: 2)),
+      );
+      final late_ = makeActiveEvent(
+        id: 'late',
+        startTime: now.subtract(const Duration(minutes: 30)),
+      );
+
+      final stateMap = {
+        'early': EventNowBarState.checkedIn,
+        'late': EventNowBarState.matching,
+      };
+
+      final sorted = sortActiveEvents([late_, early], stateMap);
+
+      // Both are active priority (0), so sort by start time.
+      expect(sorted[0].event.id, 'early');
+      expect(sorted[1].event.id, 'late');
+    });
+
+    test('4가지 상태 혼합 정렬: RESULTS > CHECKED_IN > WAITING > ENDED', () {
+      final results = makeActiveEvent(
+        id: 'results',
+        startTime: DateTime.now().subtract(const Duration(hours: 3)),
+      );
+      final checkedIn = makeActiveEvent(
+        id: 'checkedin',
+        startTime: DateTime.now().subtract(const Duration(hours: 1)),
+      );
+      final waiting = makeActiveEvent(
+        id: 'waiting',
+        startTime: DateTime.now().add(const Duration(hours: 1)),
+      );
+      final ended = makeActiveEvent(
+        id: 'ended',
+        startTime: DateTime.now().subtract(const Duration(hours: 5)),
+      );
+
+      final stateMap = {
+        'results': EventNowBarState.results,
+        'checkedin': EventNowBarState.checkedIn,
+        'waiting': EventNowBarState.waiting,
+        'ended': EventNowBarState.ended,
+      };
+
+      final sorted = sortActiveEvents(
+        [ended, waiting, checkedIn, results],
+        stateMap,
+      );
+
+      // Active group (results, checkedin) sorted by startTime,
+      // then waiting, then ended.
+      expect(sorted[0].event.id, 'results');
+      expect(sorted[1].event.id, 'checkedin');
+      expect(sorted[2].event.id, 'waiting');
+      expect(sorted[3].event.id, 'ended');
+    });
+
+    test('stateMap에 없는 이벤트는 WAITING 그룹으로 분류', () {
+      final known = makeActiveEvent(
+        id: 'known',
+        startTime: DateTime.now().subtract(const Duration(hours: 1)),
+      );
+      final unknown = makeActiveEvent(
+        id: 'unknown',
+        startTime: DateTime.now().add(const Duration(hours: 1)),
+      );
+
+      final stateMap = {
+        'known': EventNowBarState.matching,
+        // 'unknown' is not in the map.
+      };
+
+      final sorted = sortActiveEvents([unknown, known], stateMap);
+
+      // known (active priority 0) comes before unknown (waiting priority 1).
+      expect(sorted[0].event.id, 'known');
+      expect(sorted[1].event.id, 'unknown');
+    });
+  });
+
+  // ──────────────────────────────────────────────────
+  // Widget tests (5건)
+  // ──────────────────────────────────────────────────
+  group('EventNowMultiStack — 위젯', () {
+    /// Sets up mocks so that eventNowBarStateProvider resolves to the given state.
+    ProviderContainer makeContainer({
+      required List<String> eventIds,
+      Map<String, List<UserProfile>>? candidatesMap,
+      Map<String, List<MatchPair>>? matchesMap,
+    }) {
+      final overrides = <dynamic>[
+        matchingRepositoryProvider.overrideWith((ref) => mockMatchingRepo),
+      ];
+
+      for (final id in eventIds) {
+        final candidates = candidatesMap?[id] ?? <UserProfile>[];
+        when(
+          () => mockMatchingRepo.getMatchingCandidates(id),
+        ).thenAnswer((_) async => candidates);
+
+        final matches = matchesMap?[id] ?? <MatchPair>[];
+        when(
+          () => mockMatchingRepo.getMyMatches(id),
+        ).thenAnswer((_) async => matches);
+      }
+
+      return createContainer(overrides: overrides);
+    }
+
+    Widget buildTestWidget({
+      required List<TodayActiveEvent> events,
+      required ProviderContainer container,
+      void Function(TodayActiveEvent)? onEventTap,
+    }) {
+      return UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: Scaffold(
+            body: EventNowMultiStack(
+              events: events,
+              onEventTap: onEventTap,
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('이벤트 0건일 때 SizedBox.shrink 렌더링', (tester) async {
+      final container = makeContainer(eventIds: []);
+
+      await tester.pumpWidget(
+        buildTestWidget(events: [], container: container),
+      );
+
+      // SizedBox.shrink has zero size.
+      expect(find.byType(EventNowMultiStack), findsOneWidget);
+      final size = tester.getSize(find.byType(EventNowMultiStack));
+      expect(size, Size.zero);
+    });
+
+    testWidgets('이벤트 1건일 때 카운트 배지 없이 바만 표시', (tester) async {
+      final event = makeActiveEvent(
+        id: 'solo',
+        title: '솔로 이벤트',
+        startTime: DateTime.now().add(const Duration(hours: 2)),
+        endTime: DateTime.now().add(const Duration(hours: 5)),
+      );
+
+      final container = makeContainer(eventIds: ['solo']);
+
+      await tester.pumpWidget(
+        buildTestWidget(events: [event], container: container),
+      );
+      await tester.pumpAndSettle();
+
+      // Title is shown.
+      expect(find.text('솔로 이벤트'), findsOneWidget);
+      // No expand_more icon (single event).
+      expect(find.byIcon(Icons.expand_more), findsNothing);
+      // Chevron right is shown (single event trailing).
+      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+    });
+
+    testWidgets('이벤트 2건일 때 카운트 배지 + 드롭다운 아이콘 표시', (tester) async {
+      final event1 = makeActiveEvent(
+        id: 'e1',
+        title: '첫 번째',
+        startTime: DateTime.now().add(const Duration(hours: 1)),
+        endTime: DateTime.now().add(const Duration(hours: 4)),
+      );
+      final event2 = makeActiveEvent(
+        id: 'e2',
+        title: '두 번째',
+        startTime: DateTime.now().add(const Duration(hours: 2)),
+        endTime: DateTime.now().add(const Duration(hours: 5)),
+      );
+
+      final container = makeContainer(eventIds: ['e1', 'e2']);
+
+      await tester.pumpWidget(
+        buildTestWidget(events: [event1, event2], container: container),
+      );
+      await tester.pumpAndSettle();
+
+      // Count badge showing "2".
+      expect(find.text('2'), findsOneWidget);
+      // Dropdown icon is shown.
+      expect(find.byIcon(Icons.expand_more), findsOneWidget);
+      // No chevron right in multi mode.
+      expect(find.byIcon(Icons.chevron_right), findsNothing);
+    });
+
+    testWidgets('드롭다운 탭 시 이벤트 목록 바텀시트 표시', (tester) async {
+      final event1 = makeActiveEvent(
+        id: 'e1',
+        title: '첫 번째 이벤트',
+        startTime: DateTime.now().add(const Duration(hours: 1)),
+        endTime: DateTime.now().add(const Duration(hours: 4)),
+      );
+      final event2 = makeActiveEvent(
+        id: 'e2',
+        title: '두 번째 이벤트',
+        startTime: DateTime.now().add(const Duration(hours: 2)),
+        endTime: DateTime.now().add(const Duration(hours: 5)),
+      );
+
+      final container = makeContainer(eventIds: ['e1', 'e2']);
+
+      await tester.pumpWidget(
+        buildTestWidget(events: [event1, event2], container: container),
+      );
+      await tester.pumpAndSettle();
+
+      // Tap the dropdown icon.
+      await tester.tap(find.byIcon(Icons.expand_more));
+      await tester.pumpAndSettle();
+
+      // Bottom sheet header is shown.
+      expect(find.text('진행 중인 이벤트'), findsOneWidget);
+      // Both event titles appear in the sheet.
+      expect(find.text('첫 번째 이벤트'), findsWidgets);
+      expect(find.text('두 번째 이벤트'), findsOneWidget);
+    });
+
+    testWidgets('바텀시트에서 이벤트 선택 시 onEventTap 콜백 호출', (tester) async {
+      final event1 = makeActiveEvent(
+        id: 'e1',
+        title: '이벤트 A',
+        startTime: DateTime.now().add(const Duration(hours: 1)),
+        endTime: DateTime.now().add(const Duration(hours: 4)),
+      );
+      final event2 = makeActiveEvent(
+        id: 'e2',
+        title: '이벤트 B',
+        startTime: DateTime.now().add(const Duration(hours: 2)),
+        endTime: DateTime.now().add(const Duration(hours: 5)),
+      );
+
+      final container = makeContainer(eventIds: ['e1', 'e2']);
+      TodayActiveEvent? tappedEvent;
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          events: [event1, event2],
+          container: container,
+          onEventTap: (e) => tappedEvent = e,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Open the dropdown.
+      await tester.tap(find.byIcon(Icons.expand_more));
+      await tester.pumpAndSettle();
+
+      // Tap '이벤트 B' in the bottom sheet.
+      await tester.tap(find.text('이벤트 B'));
+      await tester.pumpAndSettle();
+
+      expect(tappedEvent, isNotNull);
+      expect(tappedEvent!.event.id, 'e2');
+    });
+  });
+}

--- a/apps/app_user/test/src/features/home/widgets/event_now_multi_stack_test.dart
+++ b/apps/app_user/test/src/features/home/widgets/event_now_multi_stack_test.dart
@@ -1,7 +1,6 @@
 import 'package:app_user/src/features/home/widgets/event_now_bar_controller.dart';
 import 'package:app_user/src/features/home/widgets/event_now_multi_stack.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';


### PR DESCRIPTION
## Summary

- 멀티 이벤트 참여 시 우선순위 정렬 + 드롭다운 이벤트 전환 UI 구현
- 정렬 로직: 진행 중(CHECK_IN~RESULTS) > 대기(WAITING) > 종료(ENDED), 같은 그룹 내 시작 시간 순
- 이벤트 1건 → 바만 표시, 2건+ → 카운트 배지 + 드롭다운 아이콘 → 이벤트 목록 바텀시트
- 종료된 이벤트는 스택 하단 유지 (리뷰 작성용)

Closes #666

## 피처 파이프라인 히스토리
| 단계 | 이슈 | PR | 산출물 |
|------|------|-----|--------|
| 에픽 | #657 | - | Event Now Bar |
| 미니바 구현 | #662 | #773 | EventNowBar 위젯 |
| 바텀시트 Phase 1~2 | #663 | #799 | EventNowBottomSheet |
| **멀티 이벤트 스택** | **#666** | **현재** | **EventNowMultiStack** |

## Test plan
- [x] `flutter analyze` — no issues
- [x] 정렬 유닛 테스트 5건 통과
  - 진행 중 > 대기 우선순위
  - 종료 이벤트 하단 배치
  - 같은 그룹 내 시작 시간 순
  - 4가지 상태 혼합 정렬
  - stateMap 미등록 이벤트 → WAITING 그룹
- [x] 위젯 테스트 5건 통과
  - 0건 → SizedBox.shrink
  - 1건 → 카운트 배지 없음
  - 2건 → 카운트 배지 + 드롭다운 아이콘
  - 드롭다운 탭 → 바텀시트 표시
  - 바텀시트 선택 → onEventTap 콜백

🤖 Generated with [Claude Code](https://claude.com/claude-code)