### PR TITLE
feat(db): CI/DI 암호화 마이그레이션 — pgcrypto + Vault

### DIFF
--- a/supabase/migrations/20260330000001_ci_di_encryption.sql
+++ b/supabase/migrations/20260330000001_ci_di_encryption.sql
@@ -1,0 +1,186 @@
+-- Fix #807: CI/DI 암호화 저장 (개인정보보호법 제29조)
+-- Phase 1: pgcrypto + Vault 하이브리드 암호화
+-- - 새 암호화 컬럼 추가 (ci_encrypted, di_encrypted, di_hash)
+-- - update_user_identity / get_user_ci_di RPC 생성
+-- - 기존 평문 데이터 배치 암호화
+-- - protect_user_profile_fields 트리거 업데이트
+-- 주의: 기존 ci, di 컬럼은 이 단계에서 제거하지 않음 (Phase 3에서 제거)
+
+SET search_path TO public, extensions;
+
+-- ============================================================
+-- 1. Ensure pgcrypto extension
+-- ============================================================
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- ============================================================
+-- 2. Add encrypted columns
+-- ============================================================
+ALTER TABLE public.user_profiles
+  ADD COLUMN IF NOT EXISTS ci_encrypted bytea,
+  ADD COLUMN IF NOT EXISTS di_encrypted bytea,
+  ADD COLUMN IF NOT EXISTS di_hash text;
+
+-- ============================================================
+-- 3. Vault encryption key
+-- ============================================================
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM vault.decrypted_secrets WHERE name = 'pii_encryption_key'
+  ) THEN
+    PERFORM vault.create_secret(
+      encode(gen_random_bytes(32), 'hex'),
+      'pii_encryption_key',
+      'Symmetric key for CI/DI PII encryption (pgp_sym_encrypt)'
+    );
+    RAISE NOTICE 'vault: pii_encryption_key created with random key';
+  ELSE
+    RAISE NOTICE 'vault: pii_encryption_key already exists';
+  END IF;
+END $$;
+
+-- ============================================================
+-- 4. update_user_identity RPC (encrypt + store)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.update_user_identity(
+  p_user_id uuid,
+  p_ci text,
+  p_di text,
+  p_name text DEFAULT NULL,
+  p_birth_date date DEFAULT NULL,
+  p_gender public.gender DEFAULT NULL,
+  p_phone_number text DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_key text;
+BEGIN
+  -- Retrieve encryption key from vault
+  SELECT decrypted_secret INTO v_key
+  FROM vault.decrypted_secrets
+  WHERE name = 'pii_encryption_key'
+  LIMIT 1;
+
+  IF v_key IS NULL THEN
+    RAISE EXCEPTION 'pii_encryption_key not found in vault';
+  END IF;
+
+  UPDATE public.user_profiles SET
+    ci_encrypted = pgp_sym_encrypt(p_ci, v_key),
+    di_encrypted = pgp_sym_encrypt(p_di, v_key),
+    di_hash = encode(digest(p_di, 'sha256'), 'hex'),
+    name = COALESCE(p_name, name),
+    birth_date = COALESCE(p_birth_date, birth_date),
+    gender = COALESCE(p_gender, gender),
+    phone_number = COALESCE(p_phone_number, phone_number),
+    is_verified = true
+  WHERE id = p_user_id;
+END;
+$$;
+
+-- Only service_role can call this RPC
+REVOKE ALL ON FUNCTION public.update_user_identity(uuid, text, text, text, date, public.gender, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.update_user_identity(uuid, text, text, text, date, public.gender, text) FROM authenticated;
+REVOKE ALL ON FUNCTION public.update_user_identity(uuid, text, text, text, date, public.gender, text) FROM anon;
+
+-- ============================================================
+-- 5. get_user_ci_di RPC (decrypt + return)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_user_ci_di(p_user_id uuid)
+RETURNS TABLE(ci text, di text)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_key text;
+BEGIN
+  SELECT decrypted_secret INTO v_key
+  FROM vault.decrypted_secrets
+  WHERE name = 'pii_encryption_key'
+  LIMIT 1;
+
+  IF v_key IS NULL THEN
+    RAISE EXCEPTION 'pii_encryption_key not found in vault';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    pgp_sym_decrypt(up.ci_encrypted, v_key) AS ci,
+    pgp_sym_decrypt(up.di_encrypted, v_key) AS di
+  FROM public.user_profiles up
+  WHERE up.id = p_user_id
+    AND up.ci_encrypted IS NOT NULL;
+END;
+$$;
+
+-- Only service_role can call this RPC
+REVOKE ALL ON FUNCTION public.get_user_ci_di(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_user_ci_di(uuid) FROM authenticated;
+REVOKE ALL ON FUNCTION public.get_user_ci_di(uuid) FROM anon;
+
+-- ============================================================
+-- 6. Batch encrypt existing plaintext data
+-- ============================================================
+DO $$
+DECLARE
+  v_key text;
+  v_count integer;
+BEGIN
+  SELECT decrypted_secret INTO v_key
+  FROM vault.decrypted_secrets
+  WHERE name = 'pii_encryption_key'
+  LIMIT 1;
+
+  IF v_key IS NULL THEN
+    RAISE EXCEPTION 'pii_encryption_key not found in vault';
+  END IF;
+
+  UPDATE public.user_profiles SET
+    ci_encrypted = pgp_sym_encrypt(ci, v_key),
+    di_encrypted = pgp_sym_encrypt(di, v_key),
+    di_hash = encode(digest(di, 'sha256'), 'hex')
+  WHERE ci IS NOT NULL AND ci_encrypted IS NULL;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RAISE NOTICE 'Batch encrypted % existing rows', v_count;
+END $$;
+
+-- ============================================================
+-- 7. di_hash UNIQUE constraint
+-- ============================================================
+ALTER TABLE public.user_profiles
+  ADD CONSTRAINT user_profiles_di_hash_unique UNIQUE (di_hash);
+
+-- ============================================================
+-- 8. Update protect_user_profile_fields trigger
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.protect_user_profile_fields()
+RETURNS trigger
+SET search_path = public
+AS $$
+BEGIN
+  -- Fix #807: protect verification status from direct update by non-admin users
+  IF (NEW.is_verified IS DISTINCT FROM OLD.is_verified) THEN
+    IF (auth.role() = 'authenticated' AND NOT public.is_super_admin()) THEN
+      RAISE EXCEPTION 'You cannot update verification status directly. (Access Denied)';
+    END IF;
+  END IF;
+
+  -- Fix #807: protect encrypted PII columns from direct update by non-service-role
+  IF (NEW.ci_encrypted IS DISTINCT FROM OLD.ci_encrypted)
+     OR (NEW.di_encrypted IS DISTINCT FROM OLD.di_encrypted)
+     OR (NEW.di_hash IS DISTINCT FROM OLD.di_hash) THEN
+    IF (auth.role() = 'authenticated' AND NOT public.is_super_admin()) THEN
+      RAISE EXCEPTION 'Encrypted identity fields can only be updated via update_user_identity RPC. (Access Denied)';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/supabase/tests/database/55_ci_di_encryption_test.sql
+++ b/supabase/tests/database/55_ci_di_encryption_test.sql
@@ -1,0 +1,101 @@
+-- Fix #807: CI/DI 암호화 마이그레이션 테스트
+BEGIN;
+SELECT plan(16);
+
+-- ============================================================
+-- 1. Schema: encrypted columns exist
+-- ============================================================
+SELECT has_column('user_profiles', 'ci_encrypted',
+  'user_profiles should have ci_encrypted column');
+SELECT col_type_is('user_profiles', 'ci_encrypted', 'bytea',
+  'ci_encrypted should be bytea');
+
+SELECT has_column('user_profiles', 'di_encrypted',
+  'user_profiles should have di_encrypted column');
+SELECT col_type_is('user_profiles', 'di_encrypted', 'bytea',
+  'di_encrypted should be bytea');
+
+SELECT has_column('user_profiles', 'di_hash',
+  'user_profiles should have di_hash column');
+SELECT col_type_is('user_profiles', 'di_hash', 'text',
+  'di_hash should be text');
+
+-- ============================================================
+-- 2. di_hash UNIQUE constraint
+-- ============================================================
+SELECT has_index('user_profiles', 'user_profiles_di_hash_unique',
+  'di_hash should have unique constraint');
+
+-- ============================================================
+-- 3. RPC functions exist
+-- ============================================================
+SELECT has_function('update_user_identity',
+  'update_user_identity RPC should exist');
+SELECT has_function('get_user_ci_di',
+  'get_user_ci_di RPC should exist');
+
+-- ============================================================
+-- 4. RPC functions are SECURITY DEFINER
+-- ============================================================
+SELECT function_security_type_is('update_user_identity',
+  ARRAY['uuid', 'text', 'text', 'text', 'date', 'gender', 'text'],
+  'definer',
+  'update_user_identity should be SECURITY DEFINER');
+SELECT function_security_type_is('get_user_ci_di',
+  ARRAY['uuid'],
+  'definer',
+  'get_user_ci_di should be SECURITY DEFINER');
+
+-- ============================================================
+-- 5. Encrypt/decrypt round-trip via RPC
+-- ============================================================
+
+-- Create a test user in auth.users first
+INSERT INTO auth.users (id, email) VALUES
+  ('a0000000-0000-0000-0000-000000000807', 'test-807@test.com');
+-- handle_new_user trigger auto-creates user_profiles row
+
+-- Call update_user_identity to encrypt
+SELECT lives_ok($$
+  SELECT public.update_user_identity(
+    'a0000000-0000-0000-0000-000000000807'::uuid,
+    'test_ci_value_807',
+    'test_di_value_807',
+    'Test User 807',
+    '1990-01-01'::date,
+    'male'::gender,
+    '010-0000-0807'
+  )
+$$, 'update_user_identity should succeed for test user');
+
+-- Verify encrypted columns are NOT NULL
+SELECT isnt(
+  (SELECT ci_encrypted FROM public.user_profiles WHERE id = 'a0000000-0000-0000-0000-000000000807'),
+  NULL::bytea,
+  'ci_encrypted should be populated after update_user_identity');
+
+SELECT isnt(
+  (SELECT di_hash FROM public.user_profiles WHERE id = 'a0000000-0000-0000-0000-000000000807'),
+  NULL::text,
+  'di_hash should be populated after update_user_identity');
+
+-- Verify decrypt round-trip via get_user_ci_di
+SELECT results_eq($$
+  SELECT ci, di FROM public.get_user_ci_di('a0000000-0000-0000-0000-000000000807'::uuid)
+$$, $$
+  VALUES ('test_ci_value_807'::text, 'test_di_value_807'::text)
+$$, 'get_user_ci_di should return decrypted values matching originals');
+
+-- Verify di_hash is deterministic SHA-256
+SELECT is(
+  (SELECT di_hash FROM public.user_profiles WHERE id = 'a0000000-0000-0000-0000-000000000807'),
+  encode(digest('test_di_value_807', 'sha256'), 'hex'),
+  'di_hash should be SHA-256 hex of the DI value');
+
+-- ============================================================
+-- Cleanup
+-- ============================================================
+DELETE FROM auth.users WHERE id = 'a0000000-0000-0000-0000-000000000807';
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/55_ci_di_encryption_test.sql
+++ b/supabase/tests/database/55_ci_di_encryption_test.sql
@@ -37,13 +37,19 @@ SELECT has_function('get_user_ci_di',
 -- ============================================================
 -- 4. RPC functions are SECURITY DEFINER
 -- ============================================================
-SELECT function_security_type_is('update_user_identity',
-  ARRAY['uuid', 'text', 'text', 'text', 'date', 'gender', 'text'],
-  'definer',
+SELECT is(
+  (SELECT p.prosecdef FROM pg_proc p
+   JOIN pg_namespace n ON p.pronamespace = n.oid
+   WHERE n.nspname = 'public' AND p.proname = 'update_user_identity'
+   LIMIT 1),
+  true,
   'update_user_identity should be SECURITY DEFINER');
-SELECT function_security_type_is('get_user_ci_di',
-  ARRAY['uuid'],
-  'definer',
+SELECT is(
+  (SELECT p.prosecdef FROM pg_proc p
+   JOIN pg_namespace n ON p.pronamespace = n.oid
+   WHERE n.nspname = 'public' AND p.proname = 'get_user_ci_di'
+   LIMIT 1),
+  true,
   'get_user_ci_di should be SECURITY DEFINER');
 
 -- ============================================================


### PR DESCRIPTION
## Summary
- 개인정보보호법 제29조에 따라 `user_profiles` 테이블의 CI/DI를 pgcrypto(`pgp_sym_encrypt`) + Vault 하이브리드로 암호화 저장
- `ci_encrypted`, `di_encrypted` (bytea) + `di_hash` (text, UNIQUE) 컬럼 추가
- `update_user_identity` / `get_user_ci_di` RPC 생성 (SECURITY DEFINER, service_role 전용)
- 기존 평문 데이터 배치 암호화 + `protect_user_profile_fields` 트리거 업데이트

Closes #807

## 피처 파이프라인 히스토리
| 단계 | 이슈 | PR | 산출물 |
|------|------|-----|--------|
| 아키텍처 결정 | #759 | - | pgcrypto + Vault 하이브리드 |
| Phase 1: DB 마이그레이션 | #807 | 현재 PR | migration + pgTAP test |
| Phase 2: EF 전환 | #808 | - | 후속 |

## Test plan
- [ ] `check-migration-versions` CI 통과 (migration version 중복 없음)
- [ ] `test-supabase` CI 통과 (pgTAP 16건: 스키마, RPC 존재, SECURITY DEFINER, 라운드트립 암복호화, di_hash 결정성)
- [ ] `anon` role에서 `ci_encrypted`, `di_encrypted` 접근 불가 (RLS + REVOKE)
- [ ] `di_hash` UNIQUE 제약으로 중복 DI 차단

🤖 Generated with [Claude Code](https://claude.com/claude-code)