### PR TITLE
feat(minglit_kit): MinglitBottomSheet 바텀시트 위젯

### DIFF
--- a/shared/packages/minglit_kit/lib/minglit_ui.dart
+++ b/shared/packages/minglit_kit/lib/minglit_ui.dart
@@ -21,6 +21,7 @@ export 'src/ui/widgets/common/minglit_alert.dart';
 export 'src/ui/widgets/common/minglit_async_value_widget.dart';
 export 'src/ui/widgets/common/minglit_badge.dart';
 export 'src/ui/widgets/common/minglit_bottom_cta.dart';
+export 'src/ui/widgets/common/minglit_bottom_sheet.dart';
 export 'src/ui/widgets/common/minglit_chip.dart';
 export 'src/ui/widgets/common/minglit_content_card.dart';
 export 'src/ui/widgets/common/minglit_dialog.dart';

--- a/shared/packages/minglit_kit/lib/src/features/dev/design_catalog_page.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/design_catalog_page.dart
@@ -5,6 +5,7 @@ import 'package:minglit_kit/src/theme/minglit_theme.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_content_card.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_key_value_row.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_section.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_bottom_sheet.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_tag.dart';
 
 /// Dev-only design catalog page displaying all design tokens and components.
@@ -688,50 +689,91 @@ class _BottomSheetSection extends StatelessWidget {
     return ListView(
       padding: const EdgeInsets.all(MinglitSpacing.medium),
       children: [
-        Text('BottomSheet', style: theme.textTheme.titleMedium),
+        Text('MinglitBottomSheet', style: theme.textTheme.titleLarge),
+        const SizedBox(height: MinglitSpacing.medium),
+        Text('With Title', style: theme.textTheme.titleMedium),
         const SizedBox(height: MinglitSpacing.small),
         Text(
-          'Tap the button below to preview a modal BottomSheet.',
+          'showMinglitBottomSheet으로 통일된 바텀시트를 표시합니다.',
           style: theme.textTheme.bodyMedium,
         ),
         const SizedBox(height: MinglitSpacing.medium),
         ElevatedButton(
           onPressed: () {
             unawaited(
-              showModalBottomSheet<void>(
+              showMinglitBottomSheet<void>(
                 context: context,
-                builder: (ctx) => Padding(
-                  padding: const EdgeInsets.all(MinglitSpacing.large),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        'Example BottomSheet',
-                        style: theme.textTheme.titleLarge,
+                title: '옵션 선택',
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '바텀시트 내용입니다. 핸들과 제목이 자동으로 포함됩니다.',
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                    const SizedBox(height: MinglitSpacing.large),
+                    SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton(
+                        onPressed: () => Navigator.pop(context),
+                        child: const Text('닫기'),
                       ),
-                      const SizedBox(height: MinglitSpacing.medium),
-                      Text(
-                        'This is an example modal bottom sheet '
-                        'using the current theme.',
-                        style: theme.textTheme.bodyMedium,
-                      ),
-                      const SizedBox(height: MinglitSpacing.large),
-                      SizedBox(
-                        width: double.infinity,
-                        child: ElevatedButton(
-                          onPressed: () => Navigator.pop(ctx),
-                          child: const Text('Close'),
-                        ),
-                      ),
-                      const SizedBox(height: MinglitSpacing.medium),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
               ),
             );
           },
-          child: const Text('Show BottomSheet'),
+          child: const Text('Show with Title'),
+        ),
+        const SizedBox(height: MinglitSpacing.large),
+        Text('Without Title', style: theme.textTheme.titleMedium),
+        const SizedBox(height: MinglitSpacing.small),
+        ElevatedButton(
+          onPressed: () {
+            unawaited(
+              showMinglitBottomSheet<void>(
+                context: context,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      '제목 없이 핸들과 콘텐츠만 표시됩니다.',
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                    const SizedBox(height: MinglitSpacing.medium),
+                  ],
+                ),
+              ),
+            );
+          },
+          child: const Text('Show without Title'),
+        ),
+        const SizedBox(height: MinglitSpacing.large),
+        Text('No Handle', style: theme.textTheme.titleMedium),
+        const SizedBox(height: MinglitSpacing.small),
+        ElevatedButton(
+          onPressed: () {
+            unawaited(
+              showMinglitBottomSheet<void>(
+                context: context,
+                title: '핸들 없음',
+                showHandle: false,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      '드래그 핸들 없이 제목과 콘텐츠만 표시됩니다.',
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                    const SizedBox(height: MinglitSpacing.medium),
+                  ],
+                ),
+              ),
+            );
+          },
+          child: const Text('Show without Handle'),
         ),
       ],
     );

--- a/shared/packages/minglit_kit/lib/src/features/dev/design_catalog_page.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/design_catalog_page.dart
@@ -2,10 +2,10 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/src/theme/minglit_theme.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_bottom_sheet.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_content_card.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_key_value_row.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_section.dart';
-import 'package:minglit_kit/src/ui/widgets/common/minglit_bottom_sheet.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_tag.dart';
 
 /// Dev-only design catalog page displaying all design tokens and components.

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_bottom_sheet.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_bottom_sheet.dart
@@ -77,7 +77,8 @@ class MinglitBottomSheet extends StatelessWidget {
           ],
           Flexible(
             child: Padding(
-              padding: padding ??
+              padding:
+                  padding ??
                   const EdgeInsets.only(
                     left: MinglitSpacing.screenEdge,
                     right: MinglitSpacing.screenEdge,

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_bottom_sheet.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_bottom_sheet.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/src/theme/minglit_theme.dart';
+
+/// **Minglit Bottom Sheet**
+///
+/// A themed bottom sheet content widget for the Minglit design system.
+/// Provides a consistent structure with optional drag handle, title header,
+/// and content padding using Minglit design tokens.
+///
+/// Use [showMinglitBottomSheet] to display this as a modal bottom sheet.
+///
+/// {@tool snippet}
+/// ```dart
+/// showMinglitBottomSheet(
+///   context: context,
+///   title: '옵션 선택',
+///   child: Column(
+///     children: [
+///       ListTile(title: Text('옵션 1')),
+///       ListTile(title: Text('옵션 2')),
+///     ],
+///   ),
+/// );
+/// ```
+/// {@end-tool}
+class MinglitBottomSheet extends StatelessWidget {
+  /// Creates a bottom sheet content widget with optional [title] and [child].
+  const MinglitBottomSheet({
+    required this.child,
+    this.title,
+    this.showHandle = true,
+    this.padding,
+    super.key,
+  });
+
+  /// The main content of the bottom sheet.
+  final Widget child;
+
+  /// Optional title displayed below the handle.
+  final String? title;
+
+  /// Whether to show the drag handle at the top.
+  final bool showHandle;
+
+  /// Custom padding for the content.
+  /// Defaults to horizontal screenEdge + vertical medium.
+  final EdgeInsets? padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (showHandle) ...[
+            const SizedBox(height: MinglitSpacing.small),
+            _DragHandle(color: colorScheme.onSurfaceVariant),
+            const SizedBox(height: MinglitSpacing.small),
+          ],
+          if (title != null) ...[
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: MinglitSpacing.screenEdge,
+              ),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  title!,
+                  style: theme.textTheme.titleLarge,
+                ),
+              ),
+            ),
+            const SizedBox(height: MinglitSpacing.sm),
+          ],
+          Flexible(
+            child: Padding(
+              padding: padding ??
+                  const EdgeInsets.only(
+                    left: MinglitSpacing.screenEdge,
+                    right: MinglitSpacing.screenEdge,
+                    bottom: MinglitSpacing.medium,
+                  ),
+              child: child,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DragHandle extends StatelessWidget {
+  const _DragHandle({required this.color});
+
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: MinglitOpacity.muted),
+          borderRadius: BorderRadius.circular(MinglitRadius.chip),
+        ),
+        child: const SizedBox(width: 32, height: 4),
+      ),
+    );
+  }
+}
+
+/// Shows a Minglit-styled modal bottom sheet.
+///
+/// Wraps [showModalBottomSheet] with consistent Minglit design tokens
+/// (border radius, background color, handle, title).
+Future<T?> showMinglitBottomSheet<T>({
+  required BuildContext context,
+  required Widget child,
+  String? title,
+  bool showHandle = true,
+  EdgeInsets? padding,
+  bool isScrollControlled = false,
+  BoxConstraints? constraints,
+}) {
+  return showModalBottomSheet<T>(
+    context: context,
+    isScrollControlled: isScrollControlled,
+    constraints: constraints,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(
+        top: Radius.circular(MinglitRadius.card),
+      ),
+    ),
+    builder: (ctx) => MinglitBottomSheet(
+      title: title,
+      showHandle: showHandle,
+      padding: padding,
+      child: child,
+    ),
+  );
+}

--- a/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_bottom_sheet_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_bottom_sheet_test.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_bottom_sheet.dart';
+
+void main() {
+  Widget wrap(Widget child) {
+    return MaterialApp(
+      home: Scaffold(body: child),
+    );
+  }
+
+  group('MinglitBottomSheet', () {
+    testWidgets('renders child widget', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const MinglitBottomSheet(
+            child: Text('Content'),
+          ),
+        ),
+      );
+
+      expect(find.text('Content'), findsOneWidget);
+    });
+
+    testWidgets('shows drag handle by default', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const MinglitBottomSheet(
+            child: Text('Content'),
+          ),
+        ),
+      );
+
+      // Handle is a DecoratedBox with SizedBox(width: 32, height: 4)
+      final sizedBoxes = tester.widgetList<SizedBox>(find.byType(SizedBox));
+      final handleBox = sizedBoxes.where(
+        (sb) => sb.width == 32 && sb.height == 4,
+      );
+      expect(handleBox, isNotEmpty);
+    });
+
+    testWidgets('hides drag handle when showHandle is false', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const MinglitBottomSheet(
+            showHandle: false,
+            child: Text('Content'),
+          ),
+        ),
+      );
+
+      final sizedBoxes = tester.widgetList<SizedBox>(find.byType(SizedBox));
+      final handleBox = sizedBoxes.where(
+        (sb) => sb.width == 32 && sb.height == 4,
+      );
+      expect(handleBox, isEmpty);
+    });
+
+    testWidgets('displays title when provided', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const MinglitBottomSheet(
+            title: '옵션 선택',
+            child: Text('Content'),
+          ),
+        ),
+      );
+
+      expect(find.text('옵션 선택'), findsOneWidget);
+    });
+
+    testWidgets('does not display title when null', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const MinglitBottomSheet(
+            child: Text('Content'),
+          ),
+        ),
+      );
+
+      // Only the child text should be present
+      expect(find.text('Content'), findsOneWidget);
+      // No title text
+      expect(find.byType(MinglitBottomSheet), findsOneWidget);
+    });
+
+    testWidgets('applies custom padding', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const MinglitBottomSheet(
+            padding: EdgeInsets.all(32),
+            child: Text('Padded'),
+          ),
+        ),
+      );
+
+      expect(find.text('Padded'), findsOneWidget);
+    });
+
+    testWidgets('renders with title and handle together', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const MinglitBottomSheet(
+            title: '제목',
+            child: Text('내용'),
+          ),
+        ),
+      );
+
+      expect(find.text('제목'), findsOneWidget);
+      expect(find.text('내용'), findsOneWidget);
+
+      // Handle should be present
+      final sizedBoxes = tester.widgetList<SizedBox>(find.byType(SizedBox));
+      final handleBox = sizedBoxes.where(
+        (sb) => sb.width == 32 && sb.height == 4,
+      );
+      expect(handleBox, isNotEmpty);
+    });
+  });
+
+  group('showMinglitBottomSheet', () {
+    testWidgets('opens a modal bottom sheet', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () {
+                  showMinglitBottomSheet<void>(
+                    context: context,
+                    title: '테스트',
+                    child: const Text('바텀시트 내용'),
+                  );
+                },
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('테스트'), findsOneWidget);
+      expect(find.text('바텀시트 내용'), findsOneWidget);
+    });
+
+    testWidgets('can be dismissed', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () {
+                  showMinglitBottomSheet<void>(
+                    context: context,
+                    child: const Text('Dismissible'),
+                  );
+                },
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Dismissible'), findsOneWidget);
+
+      // Tap the scrim to dismiss
+      await tester.tapAt(const Offset(0, 0));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Dismissible'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- `MinglitBottomSheet` StatelessWidget 추가 (핸들 + 제목 + 콘텐츠 구조)
- `showMinglitBottomSheet()` 헬퍼 함수로 showModalBottomSheet 래핑
- 카탈로그 BottomSheet 탭을 3가지 변형 데모로 교체 (with title, without title, no handle)
- 위젯 테스트 9건 추가

Closes #624

## Test plan
- [x] `flutter analyze` — no issues
- [x] 위젯 테스트 9/9 통과 (렌더링, handle show/hide, title, padding, modal open/dismiss)
- [ ] CI `test-flutter-apps` 통과 확인
- [ ] 카탈로그 BottomSheet 탭에서 라이트/다크 모드 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)