### PR TITLE
feat(ef): identity-verify → update_user_identity RPC 전환

### DIFF
--- a/supabase/functions/_contract_tests/contract_test.ts
+++ b/supabase/functions/_contract_tests/contract_test.ts
@@ -152,8 +152,8 @@ Deno.test("contract: identity-verify response matches schema", async () => {
         handler: () => jsonResponse(mockPortoneVerification),
       },
       {
-        matcher: (req) => req.url.includes("/rest/v1/user_profiles") && req.method === "PATCH",
-        handler: () => jsonResponse({}),
+        matcher: (req) => req.url.includes("/rest/v1/rpc/update_user_identity") && req.method === "POST",
+        handler: () => jsonResponse(null),
       },
     ]);
 

--- a/supabase/functions/identity-verify/identity_verify_test.ts
+++ b/supabase/functions/identity-verify/identity_verify_test.ts
@@ -32,8 +32,8 @@ Deno.test("identity-verify - happy path updates profile", async () => {
           handler: () => jsonResponse(mockUser),
         },
         {
-          matcher: (req) => req.url.includes("/rest/v1/user_profiles") && req.method === "PATCH",
-          handler: () => jsonResponse({}),
+          matcher: (req) => req.url.includes("/rest/v1/rpc/update_user_identity") && req.method === "POST",
+          handler: () => jsonResponse(null),
         },
       ]);
 
@@ -144,6 +144,47 @@ Deno.test("identity-verify - unauthorized returns 401", async () => {
 
           assertEquals(response.status, 401);
           assertEquals(payload.error, "Unauthorized");
+        });
+      });
+    },
+  );
+});
+
+// Fix #808: RPC 에러 시 500 반환 확인
+Deno.test("identity-verify - RPC error returns 500", async () => {
+  await withEnv(
+    {
+      PORTONE_V2_API_KEY: "test-key",
+      SUPABASE_URL: "https://supabase.test",
+      SUPABASE_SERVICE_ROLE_KEY: "service-key",
+    },
+    async () => {
+      const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+      const { fetchMock } = createFetchMock([
+        {
+          matcher: "https://api.portone.io/identity-verifications/verify_123",
+          handler: () => jsonResponse(mockPortoneVerification),
+        },
+        {
+          matcher: (req) => req.url.includes("/auth/v1/user"),
+          handler: () => jsonResponse(mockUser),
+        },
+        {
+          matcher: (req) => req.url.includes("/rest/v1/rpc/update_user_identity") && req.method === "POST",
+          handler: () => jsonResponse({ message: "RPC error", code: "42883" }, { status: 400 }),
+        },
+      ]);
+
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const request = authenticatedJsonRequest("http://localhost", {
+            identity_verification_id: "verify_123",
+          });
+          const response = await handler(request);
+          const payload = await readJson(response);
+
+          assertEquals(response.status, 500);
+          assertEquals(payload.error, "Failed to update user profile");
         });
       });
     },

--- a/supabase/functions/identity-verify/index.ts
+++ b/supabase/functions/identity-verify/index.ts
@@ -53,24 +53,20 @@ Deno.serve(withHandler(async (req) => {
       return errorResponse("Verified customer data missing", 500);
     }
 
-    // 3. Supabase DB 업데이트
+    // 3. Supabase DB 업데이트 — Fix #808: update_user_identity RPC로 암호화 저장
     const supabase = createServiceClient();
 
     const gender = typeof customer.gender === "string" ? customer.gender.toLowerCase() : undefined;
 
-    const { error: updateError } = await supabase
-      .from("user_profiles")
-      .update({
-        name: customer.name,
-        birth_date: customer.birthDate,
-        gender,
-        phone_number: customer.phoneNumber,
-        ci: customer.ci,
-        di: customer.di,
-        is_verified: true,
-        updated_at: new Date().toISOString(),
-      })
-      .eq("id", userId);
+    const { error: updateError } = await supabase.rpc("update_user_identity", {
+      p_user_id: userId,
+      p_ci: customer.ci as string,
+      p_di: customer.di as string,
+      p_name: (customer.name as string) ?? null,
+      p_birth_date: (customer.birthDate as string) ?? null,
+      p_gender: gender ?? null,
+      p_phone_number: (customer.phoneNumber as string) ?? null,
+    });
 
     if (updateError) {
       log({ function: FN, level: "error", message: "DB Update Error", metadata: { detail: updateError } });


### PR DESCRIPTION
## Summary
- `identity-verify` Edge Function이 `user_profiles` 테이블에 직접 ci/di 평문 기록하던 방식을 `update_user_identity` RPC 호출로 전환
- 본인인증 완료 시 CI/DI가 pgcrypto로 암호화 저장됨 (Phase 1 #807에서 생성한 RPC 활용)
- 기존 테스트 mock을 PATCH → RPC POST로 업데이트 + RPC 에러 케이스 테스트 추가

Closes #808

## 피처 파이프라인 히스토리
| 단계 | 이슈 | PR | 산출물 |
|------|------|-----|--------|
| 아키텍처 결정 | #759 | - | pgcrypto + Vault 하이브리드 |
| Phase 1: DB 마이그레이션 | #807 | #812 (merged) | migration + pgTAP test |
| Phase 2: EF 전환 | #808 | 현재 PR | identity-verify EF 수정 |

## Test plan
- [ ] `test-edge-functions` CI 통과 (identity-verify 6개 테스트: happy path + RPC error + missing id + API error + unauthorized + malformed JSON)
- [ ] 본인인증 후 `ci_encrypted`, `di_encrypted`에 값이 저장되고, `ci`, `di` 컬럼이 업데이트되지 않음 확인
- [ ] `di_hash`로 중복 본인인증 차단 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)