### PR TITLE
feat(minglit_kit): MinglitListTile 리스트 항목 위젯

### DIFF
--- a/shared/packages/minglit_kit/lib/minglit_ui.dart
+++ b/shared/packages/minglit_kit/lib/minglit_ui.dart
@@ -31,6 +31,7 @@ export 'src/ui/widgets/common/minglit_filter_chip.dart';
 export 'src/ui/widgets/common/minglit_image.dart';
 export 'src/ui/widgets/common/minglit_image_carousel.dart';
 export 'src/ui/widgets/common/minglit_key_value_row.dart';
+export 'src/ui/widgets/common/minglit_list_tile.dart';
 export 'src/ui/widgets/common/minglit_participant_gauge.dart';
 export 'src/ui/widgets/common/minglit_section.dart';
 export 'src/ui/widgets/common/minglit_section_divider.dart';

--- a/shared/packages/minglit_kit/lib/src/features/dev/design_catalog_page.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/design_catalog_page.dart
@@ -1222,7 +1222,36 @@ class _LayoutSection extends StatelessWidget {
 
         const Divider(height: MinglitSpacing.xxlarge),
 
-        // 4. 조합 예시
+        // 4. MinglitListTile
+        Text('MinglitListTile', style: titleLarge),
+        const SizedBox(height: MinglitSpacing.medium),
+        MinglitListTile(
+          title: '홍길동',
+          subtitle: '서울특별시 강남구',
+          leading: const CircleAvatar(child: Icon(Icons.person)),
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {},
+        ),
+        const SizedBox(height: MinglitSpacing.small),
+        const MinglitListTile(
+          title: '아이콘 리딩',
+          subtitle: '아이콘을 leading에 배치',
+          leading: CircleAvatar(
+            radius: 20,
+            child: Icon(Icons.event, size: MinglitIconSize.medium),
+          ),
+        ),
+        const SizedBox(height: MinglitSpacing.small),
+        const MinglitListTile(
+          title: '비활성 타일',
+          subtitle: 'enabled: false',
+          leading: CircleAvatar(child: Icon(Icons.block)),
+          enabled: false,
+        ),
+
+        const Divider(height: MinglitSpacing.xxlarge),
+
+        // 5. 조합 예시
         Text('조합 예시', style: titleLarge),
         const SizedBox(height: MinglitSpacing.medium),
         MinglitSection(

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_list_tile.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_list_tile.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/src/theme/minglit_theme.dart';
+
+/// **Minglit List Tile**
+///
+/// 리스트 항목 위젯으로 아바타/아이콘 + 제목/부제 + trailing 구조를 제공합니다.
+/// Material [ListTile]을 래핑하여 Minglit 디자인 토큰을 강제합니다.
+///
+/// {@tool snippet}
+/// ```dart
+/// MinglitListTile(
+///   title: '홍길동',
+///   subtitle: '서울특별시',
+///   leading: CircleAvatar(child: Icon(Icons.person)),
+///   trailing: Icon(Icons.chevron_right),
+///   onTap: () {},
+/// )
+/// ```
+/// {@end-tool}
+class MinglitListTile extends StatelessWidget {
+  /// Creates a list tile with Minglit design tokens.
+  const MinglitListTile({
+    required this.title,
+    this.subtitle,
+    this.leading,
+    this.trailing,
+    this.onTap,
+    this.enabled = true,
+    super.key,
+  });
+
+  /// Primary text displayed in the tile.
+  final String title;
+
+  /// Optional secondary text below the title.
+  final String? subtitle;
+
+  /// Optional leading widget (avatar, icon, etc.).
+  final Widget? leading;
+
+  /// Optional trailing widget (icon, badge, etc.).
+  final Widget? trailing;
+
+  /// Optional tap handler.
+  final VoidCallback? onTap;
+
+  /// Whether the tile is interactive. Defaults to true.
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Material(
+      color: Colors.transparent,
+      child: ListTile(
+        leading: leading,
+        title: Text(
+          title,
+          style: theme.textTheme.titleMedium?.copyWith(
+            color: enabled
+                ? colorScheme.onSurface
+                : colorScheme.onSurface.withValues(
+                    alpha: MinglitOpacity.muted,
+                  ),
+          ),
+        ),
+        subtitle: subtitle != null
+            ? Text(
+                subtitle!,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: enabled
+                      ? colorScheme.onSurfaceVariant
+                      : colorScheme.onSurfaceVariant.withValues(
+                          alpha: MinglitOpacity.muted,
+                        ),
+                ),
+              )
+            : null,
+        trailing: trailing,
+        onTap: enabled ? onTap : null,
+        enabled: enabled,
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: MinglitSpacing.medium,
+          vertical: MinglitSpacing.xsmall,
+        ),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(MinglitRadius.small),
+        ),
+        minVerticalPadding: MinglitSpacing.small,
+      ),
+    );
+  }
+}

--- a/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_list_tile_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_list_tile_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_list_tile.dart';
+
+void main() {
+  Widget wrap(Widget child) {
+    return MaterialApp(
+      home: Scaffold(body: child),
+    );
+  }
+
+  group('MinglitListTile', () {
+    testWidgets('renders title', (tester) async {
+      await tester.pumpWidget(
+        wrap(const MinglitListTile(title: '홍길동')),
+      );
+
+      expect(find.text('홍길동'), findsOneWidget);
+      expect(find.byType(ListTile), findsOneWidget);
+    });
+
+    testWidgets('renders subtitle when provided', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const MinglitListTile(
+            title: '홍길동',
+            subtitle: '서울특별시',
+          ),
+        ),
+      );
+
+      expect(find.text('홍길동'), findsOneWidget);
+      expect(find.text('서울특별시'), findsOneWidget);
+    });
+
+    testWidgets('does not render subtitle when null', (tester) async {
+      await tester.pumpWidget(
+        wrap(const MinglitListTile(title: '제목만')),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.subtitle, isNull);
+    });
+
+    testWidgets('renders leading widget', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const MinglitListTile(
+            title: '아바타',
+            leading: CircleAvatar(child: Icon(Icons.person)),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.person), findsOneWidget);
+      expect(find.byType(CircleAvatar), findsOneWidget);
+    });
+
+    testWidgets('renders trailing widget', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const MinglitListTile(
+            title: '화살표',
+            trailing: Icon(Icons.chevron_right),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+    });
+
+    testWidgets('onTap is called when tapped', (tester) async {
+      var tapped = false;
+      await tester.pumpWidget(
+        wrap(
+          MinglitListTile(
+            title: '탭 가능',
+            onTap: () => tapped = true,
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(ListTile));
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('onTap is not called when disabled', (tester) async {
+      var tapped = false;
+      await tester.pumpWidget(
+        wrap(
+          MinglitListTile(
+            title: '비활성',
+            onTap: () => tapped = true,
+            enabled: false,
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(ListTile));
+      expect(tapped, isFalse);
+    });
+
+    testWidgets('enabled is true by default', (tester) async {
+      await tester.pumpWidget(
+        wrap(const MinglitListTile(title: '기본')),
+      );
+
+      final widget = tester.widget<MinglitListTile>(
+        find.byType(MinglitListTile),
+      );
+      expect(widget.enabled, isTrue);
+    });
+
+    testWidgets('uses rounded shape', (tester) async {
+      await tester.pumpWidget(
+        wrap(const MinglitListTile(title: '모양')),
+      );
+
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.shape, isA<RoundedRectangleBorder>());
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Material `ListTile` 래핑, Minglit 디자인 토큰 강제 리스트 항목 위젯
- `title`, `subtitle`, `leading`, `trailing`, `onTap`, `enabled` 파라미터 지원
- 디자인 카탈로그 Layout 탭에 3가지 데모 등록 (기본, 아이콘, 비활성)
- 위젯 테스트 9건 추가

Closes #625

## Test plan
- [x] `flutter analyze` 통과
- [x] 위젯 테스트 9건 전체 pass
- [ ] CI `ci-result` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)