### PR TITLE
feat(routing): MyTicketsRoute 등록 + MyPage 네비게이션 연결

### DIFF
--- a/apps/app_user/lib/src/features/home/logic/home_coordinator.dart
+++ b/apps/app_user/lib/src/features/home/logic/home_coordinator.dart
@@ -27,6 +27,11 @@ class HomeCoordinator {
     unawaited(_router.push(const PurchaseHistoryRoute().location));
   }
 
+  // Fix #641: MyTicketsRoute 네비게이션 — "내 티켓" 탭에서 MyTicketsPage로 이동
+  void pushMyTickets() {
+    unawaited(_router.push(const MyTicketsRoute().location));
+  }
+
   void goToPurchaseHistory() {
     _router.go(const PurchaseHistoryRoute().location);
   }

--- a/apps/app_user/lib/src/features/home/my_page.dart
+++ b/apps/app_user/lib/src/features/home/my_page.dart
@@ -110,7 +110,8 @@ class MyPage extends ConsumerWidget {
             leading: const Icon(Icons.confirmation_number_outlined),
             title: const Text('내 티켓'),
             trailing: const Icon(Icons.chevron_right),
-            onTap: homeCoordinator.pushPurchaseHistory,
+            // Fix #641: "내 티켓" → MyTicketsPage로 이동
+            onTap: homeCoordinator.pushMyTickets,
           ),
           // Fix #187: 그룹별 구분선 추가 — 거래 / 앱 설정
           const Divider(),

--- a/apps/app_user/lib/src/routing/app_routes.dart
+++ b/apps/app_user/lib/src/routing/app_routes.dart
@@ -4,6 +4,7 @@ import 'package:app_user/src/features/event/admission/event_application_wizard_p
 import 'package:app_user/src/features/event/detail/event_detail_page.dart';
 import 'package:app_user/src/features/home/home_page.dart';
 import 'package:app_user/src/features/home/my_page.dart';
+import 'package:app_user/src/features/my_tickets/ui/my_tickets_page.dart';
 import 'package:app_user/src/features/partner/detail/partner_detail_page.dart';
 import 'package:app_user/src/features/partner/detail/partner_events_page.dart';
 import 'package:app_user/src/features/party/party_curation_page.dart';
@@ -124,6 +125,17 @@ class EventApplicationRoute extends GoRouteData with $EventApplicationRoute {
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       EventApplicationWizardPage(eventId: eventId, ticketId: ticketId);
+}
+
+/// **My Tickets Route**: User's ticket list page.
+/// Path: `/tickets/my`
+@TypedGoRoute<MyTicketsRoute>(path: '/tickets/my')
+class MyTicketsRoute extends GoRouteData with $MyTicketsRoute {
+  const MyTicketsRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const MyTicketsPage();
 }
 
 /// **Purchase History Route**

--- a/apps/app_user/lib/src/routing/app_routes.g.dart
+++ b/apps/app_user/lib/src/routing/app_routes.g.dart
@@ -15,6 +15,7 @@ List<RouteBase> get $appRoutes => [
   $partnerEventsRoute,
   $certificationRoute,
   $eventApplicationRoute,
+  $myTicketsRoute,
   $purchaseHistoryRoute,
   $notificationCenterRoute,
   $notificationSettingsRoute,
@@ -244,6 +245,32 @@ mixin $EventApplicationRoute on GoRouteData {
     '/events/${Uri.encodeComponent(_self.eventId)}/apply',
     queryParams: {if (_self.ticketId != null) 'ticket-id': _self.ticketId},
   );
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $myTicketsRoute => GoRouteData.$route(
+  path: '/tickets/my',
+  factory: $MyTicketsRoute._fromState,
+);
+
+mixin $MyTicketsRoute on GoRouteData {
+  static MyTicketsRoute _fromState(GoRouterState state) =>
+      const MyTicketsRoute();
+
+  @override
+  String get location => GoRouteData.$location('/tickets/my');
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/apps/app_user/test/src/features/home/logic/home_coordinator_test.dart
+++ b/apps/app_user/test/src/features/home/logic/home_coordinator_test.dart
@@ -93,6 +93,15 @@ void main() {
       ).called(1);
     });
 
+    // Fix #641: pushMyTickets navigates to /tickets/my
+    test('pushMyTickets calls router.push with /tickets/my', () {
+      HomeCoordinator(mockRouter).pushMyTickets();
+
+      verify(
+        () => mockRouter.push(any(that: contains('/tickets/my'))),
+      ).called(1);
+    });
+
     test('pushPartnerEvents calls router.push with partnerId', () {
       HomeCoordinator(mockRouter).pushPartnerEvents(
         partnerId: 'p_1',


### PR DESCRIPTION
## Summary
- `MyTicketsRoute` (`/tickets/my`) GoRouter에 등록
- `HomeCoordinator.pushMyTickets()` 메서드 추가
- MyPage "내 티켓" 탭이 `pushPurchaseHistory`(구매 내역) 대신 `pushMyTickets`(내 티켓)을 호출하도록 수정

Closes #641

## Test plan
- [x] `flutter analyze` 통과 (0 issues)
- [x] `home_coordinator_test.dart` 전체 통과 (11/11)
- [x] 새 테스트: `pushMyTickets calls router.push with /tickets/my`
- [ ] CI (`ci-result`) 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)