### PR TITLE
feat(minglit_kit): MinglitListTile 리스트 항목 위젯 (#625)

### DIFF
--- a/shared/packages/minglit_kit/lib/minglit_ui.dart
+++ b/shared/packages/minglit_kit/lib/minglit_ui.dart
@@ -31,6 +31,7 @@ export 'src/ui/widgets/common/minglit_filter_chip.dart';
 export 'src/ui/widgets/common/minglit_image.dart';
 export 'src/ui/widgets/common/minglit_image_carousel.dart';
 export 'src/ui/widgets/common/minglit_key_value_row.dart';
+export 'src/ui/widgets/common/minglit_list_tile.dart';
 export 'src/ui/widgets/common/minglit_participant_gauge.dart';
 export 'src/ui/widgets/common/minglit_section.dart';
 export 'src/ui/widgets/common/minglit_section_divider.dart';

--- a/shared/packages/minglit_kit/lib/src/features/dev/design_catalog_page.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/design_catalog_page.dart
@@ -4,8 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:minglit_kit/src/theme/minglit_theme.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_content_card.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_key_value_row.dart';
-import 'package:minglit_kit/src/ui/widgets/common/minglit_section.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_list_tile.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_section.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_tag.dart';
 
 /// Dev-only design catalog page displaying all design tokens and components.

--- a/shared/packages/minglit_kit/lib/src/features/dev/design_catalog_page.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/design_catalog_page.dart
@@ -5,6 +5,7 @@ import 'package:minglit_kit/src/theme/minglit_theme.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_content_card.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_key_value_row.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_section.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_list_tile.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_tag.dart';
 
 /// Dev-only design catalog page displaying all design tokens and components.
@@ -1250,6 +1251,35 @@ class _LayoutSection extends StatelessWidget {
               ],
             ),
           ),
+        ),
+
+        const Divider(height: MinglitSpacing.xxlarge),
+
+        // 5. MinglitListTile
+        Text('MinglitListTile', style: titleLarge),
+        const SizedBox(height: MinglitSpacing.medium),
+        const MinglitListTile(title: '기본 타일 (title only)'),
+        const SizedBox(height: MinglitSpacing.small),
+        const MinglitListTile(
+          title: '홍길동',
+          subtitle: '파트너 매니저',
+        ),
+        const SizedBox(height: MinglitSpacing.small),
+        MinglitListTile(
+          title: '아바타 + trailing',
+          subtitle: '네트워크 이미지 예시',
+          avatar: const AssetImage(
+            'packages/minglit_kit/assets/images/minglit_app_bar_logo.png',
+          ),
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {},
+        ),
+        const SizedBox(height: MinglitSpacing.small),
+        const MinglitListTile(
+          title: '비활성 타일',
+          subtitle: 'enabled: false',
+          leading: Icon(Icons.block),
+          enabled: false,
         ),
       ],
     );

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_list_tile.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_list_tile.dart
@@ -78,8 +78,9 @@ class MinglitListTile extends StatelessWidget {
     final subtitleStyle = theme.textTheme.bodyMedium?.copyWith(
       color: enabled
           ? colorScheme.onSurfaceVariant
-          : colorScheme.onSurfaceVariant
-              .withValues(alpha: MinglitOpacity.muted),
+          : colorScheme.onSurfaceVariant.withValues(
+              alpha: MinglitOpacity.muted,
+            ),
     );
 
     return Semantics(

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_list_tile.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_list_tile.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/src/theme/minglit_theme.dart';
+
+/// **Minglit List Tile**
+///
+/// A unified list tile widget for the Minglit design system.
+/// Wraps Material [ListTile] with Minglit design tokens for consistent
+/// spacing, colors, and accessibility across the app.
+///
+/// Supports an optional [avatar] for displaying a [CircleAvatar],
+/// custom [leading] / [trailing] widgets, and disabled state.
+///
+/// {@tool snippet}
+/// ```dart
+/// MinglitListTile(
+///   title: '홍길동',
+///   subtitle: '파트너 매니저',
+///   avatar: NetworkImage('https://example.com/photo.jpg'),
+///   onTap: () => print('tapped'),
+/// )
+/// ```
+/// {@end-tool}
+class MinglitListTile extends StatelessWidget {
+  /// Creates a list tile with a required [title].
+  ///
+  /// When [avatar] is provided, a [CircleAvatar] is shown as the leading
+  /// widget. If both [avatar] and [leading] are provided, [avatar] takes
+  /// precedence.
+  const MinglitListTile({
+    required this.title,
+    this.subtitle,
+    this.leading,
+    this.trailing,
+    this.onTap,
+    this.avatar,
+    this.enabled = true,
+    super.key,
+  });
+
+  /// Primary text displayed in the tile.
+  final String title;
+
+  /// Optional secondary text displayed below [title].
+  final String? subtitle;
+
+  /// Optional widget displayed before the title.
+  /// Ignored when [avatar] is provided.
+  final Widget? leading;
+
+  /// Optional widget displayed after the title.
+  final Widget? trailing;
+
+  /// Called when the tile is tapped.
+  final VoidCallback? onTap;
+
+  /// Optional image for a [CircleAvatar] shown as the leading widget.
+  /// Takes precedence over [leading] when provided.
+  final ImageProvider? avatar;
+
+  /// Whether the tile is interactive. Defaults to `true`.
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    final effectiveLeading = avatar != null
+        ? CircleAvatar(backgroundImage: avatar)
+        : leading;
+
+    final titleStyle = theme.textTheme.bodyLarge?.copyWith(
+      color: enabled
+          ? colorScheme.onSurface
+          : colorScheme.onSurface.withValues(alpha: MinglitOpacity.muted),
+    );
+
+    final subtitleStyle = theme.textTheme.bodyMedium?.copyWith(
+      color: enabled
+          ? colorScheme.onSurfaceVariant
+          : colorScheme.onSurfaceVariant
+              .withValues(alpha: MinglitOpacity.muted),
+    );
+
+    return Semantics(
+      button: onTap != null && enabled,
+      enabled: enabled,
+      child: ListTile(
+        title: Text(title, style: titleStyle),
+        subtitle: subtitle != null
+            ? Text(subtitle!, style: subtitleStyle)
+            : null,
+        leading: effectiveLeading,
+        trailing: trailing,
+        onTap: enabled ? onTap : null,
+        enabled: enabled,
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: MinglitSpacing.medium,
+          vertical: MinglitSpacing.xsmall,
+        ),
+        minVerticalPadding: MinglitSpacing.small,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(MinglitRadius.small),
+        ),
+      ),
+    );
+  }
+}

--- a/shared/packages/minglit_kit/test/ui/widgets/common/minglit_list_tile_test.dart
+++ b/shared/packages/minglit_kit/test/ui/widgets/common/minglit_list_tile_test.dart
@@ -1,0 +1,181 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_list_tile.dart';
+
+/// A minimal 1x1 transparent PNG for testing image providers.
+final _kTransparentImage = Uint8List.fromList(<int>[
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, //
+  0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+  0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41,
+  0x54, 0x78, 0x9c, 0x62, 0x00, 0x00, 0x00, 0x02,
+  0x00, 0x01, 0xe2, 0x21, 0xbc, 0x33, 0x00, 0x00,
+  0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42,
+  0x60, 0x82,
+]);
+
+void main() {
+  Widget wrap(Widget child) {
+    return MaterialApp(
+      home: Scaffold(body: child),
+    );
+  }
+
+  group('MinglitListTile', () {
+    testWidgets('renders title only', (tester) async {
+      await tester.pumpWidget(
+        wrap(const MinglitListTile(title: '기본 타일')),
+      );
+
+      expect(find.text('기본 타일'), findsOneWidget);
+      expect(find.byType(ListTile), findsOneWidget);
+    });
+
+    testWidgets('renders title and subtitle', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const MinglitListTile(
+            title: '홍길동',
+            subtitle: '파트너 매니저',
+          ),
+        ),
+      );
+
+      expect(find.text('홍길동'), findsOneWidget);
+      expect(find.text('파트너 매니저'), findsOneWidget);
+    });
+
+    testWidgets('renders CircleAvatar when avatar is provided',
+        (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          MinglitListTile(
+            title: '아바타 타일',
+            avatar: MemoryImage(_kTransparentImage),
+          ),
+        ),
+      );
+
+      expect(find.byType(CircleAvatar), findsOneWidget);
+    });
+
+    testWidgets('renders trailing widget', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const MinglitListTile(
+            title: '트레일링',
+            trailing: Icon(Icons.chevron_right),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+    });
+
+    testWidgets('calls onTap when tapped', (tester) async {
+      var tapped = false;
+      await tester.pumpWidget(
+        wrap(
+          MinglitListTile(
+            title: '탭 테스트',
+            onTap: () => tapped = true,
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(ListTile));
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('does not call onTap when disabled', (tester) async {
+      var tapped = false;
+      await tester.pumpWidget(
+        wrap(
+          MinglitListTile(
+            title: '비활성',
+            enabled: false,
+            onTap: () => tapped = true,
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(ListTile));
+      expect(tapped, isFalse);
+    });
+
+    testWidgets('has Semantics widget with button and enabled',
+        (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          MinglitListTile(
+            title: '시맨틱 테스트',
+            onTap: () {},
+          ),
+        ),
+      );
+
+      // Verify a Semantics widget with button=true exists in the tree.
+      expect(
+        find.descendant(
+          of: find.byType(MinglitListTile),
+          matching: find.byWidgetPredicate(
+            (w) =>
+                w is Semantics &&
+                w.properties.button == true &&
+                w.properties.enabled == true,
+          ),
+        ),
+        findsWidgets,
+      );
+    });
+
+    testWidgets('disabled tile is not interactive', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const MinglitListTile(
+            title: '비활성 시맨틱',
+            enabled: false,
+          ),
+        ),
+      );
+
+      // When disabled without onTap, ListTile should not be tappable.
+      final listTile = tester.widget<ListTile>(find.byType(ListTile));
+      expect(listTile.enabled, isFalse);
+      expect(listTile.onTap, isNull);
+    });
+
+    testWidgets('avatar takes precedence over leading',
+        (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          MinglitListTile(
+            title: '우선순위 테스트',
+            avatar: MemoryImage(_kTransparentImage),
+            leading: const Icon(Icons.person),
+          ),
+        ),
+      );
+
+      expect(find.byType(CircleAvatar), findsOneWidget);
+      expect(find.byIcon(Icons.person), findsNothing);
+    });
+
+    testWidgets('minimum touch area is at least 48dp', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          MinglitListTile(
+            title: '터치 영역',
+            onTap: () {},
+          ),
+        ),
+      );
+
+      final tileSize = tester.getSize(find.byType(ListTile));
+      expect(tileSize.height, greaterThanOrEqualTo(48));
+    });
+  });
+}

--- a/shared/packages/minglit_kit/test/ui/widgets/common/minglit_list_tile_test.dart
+++ b/shared/packages/minglit_kit/test/ui/widgets/common/minglit_list_tile_test.dart
@@ -48,8 +48,7 @@ void main() {
       expect(find.text('파트너 매니저'), findsOneWidget);
     });
 
-    testWidgets('renders CircleAvatar when avatar is provided',
-        (tester) async {
+    testWidgets('renders CircleAvatar when avatar is provided', (tester) async {
       await tester.pumpWidget(
         wrap(
           MinglitListTile(
@@ -106,8 +105,7 @@ void main() {
       expect(tapped, isFalse);
     });
 
-    testWidgets('has Semantics widget with button and enabled',
-        (tester) async {
+    testWidgets('has Semantics widget with button and enabled', (tester) async {
       await tester.pumpWidget(
         wrap(
           MinglitListTile(
@@ -148,8 +146,7 @@ void main() {
       expect(listTile.onTap, isNull);
     });
 
-    testWidgets('avatar takes precedence over leading',
-        (tester) async {
+    testWidgets('avatar takes precedence over leading', (tester) async {
       await tester.pumpWidget(
         wrap(
           MinglitListTile(


### PR DESCRIPTION
## Summary
- `MinglitListTile` StatelessWidget: Material `ListTile` 래핑 + Minglit 디자인 토큰 강제
- `avatar` (ImageProvider) 제공 시 `CircleAvatar` 자동 생성
- 다크모드 자동 대응 (시맨틱 컬러만 사용)
- 접근성: `Semantics` 래핑, 최소 터치 영역 48dp
- 디자인 카탈로그 `Layout` 탭에 4개 데모 등록
- 위젯 테스트 10건 추가

## Test plan
- [x] `flutter analyze` 통과
- [x] 위젯 테스트 10/10 통과 (기본 렌더링, subtitle, avatar, trailing, onTap, disabled, semantics, 48dp 터치)
- [ ] 카탈로그에서 라이트/다크 모드 확인

Closes #625

🤖 Generated with [Claude Code](https://claude.com/claude-code)