### PR TITLE
feat(minglit_kit): MinglitButton 통합 버튼 위젯 (#622)

### DIFF
--- a/shared/packages/minglit_kit/lib/minglit_ui.dart
+++ b/shared/packages/minglit_kit/lib/minglit_ui.dart
@@ -21,6 +21,7 @@ export 'src/ui/widgets/common/minglit_alert.dart';
 export 'src/ui/widgets/common/minglit_async_value_widget.dart';
 export 'src/ui/widgets/common/minglit_badge.dart';
 export 'src/ui/widgets/common/minglit_bottom_cta.dart';
+export 'src/ui/widgets/common/minglit_button.dart';
 export 'src/ui/widgets/common/minglit_chip.dart';
 export 'src/ui/widgets/common/minglit_content_card.dart';
 export 'src/ui/widgets/common/minglit_dialog.dart';

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_button.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_button.dart
@@ -1,0 +1,257 @@
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/src/theme/minglit_theme.dart';
+
+/// Button variant for [MinglitButton].
+enum MinglitButtonVariant {
+  /// Filled button with primary background. Use for primary CTA actions.
+  primary,
+
+  /// Outlined button with primary border. Use for secondary actions.
+  secondary,
+
+  /// Text-only button. Use for tertiary or inline actions.
+  text,
+}
+
+/// Button size for [MinglitButton].
+enum MinglitButtonSize {
+  /// Small button (height 36, fontSize 14).
+  small,
+
+  /// Medium button (height 48, fontSize 15).
+  medium,
+
+  /// Large button (height 56, fontSize 16). Default for full-width CTAs.
+  large,
+}
+
+/// **Minglit Button**
+///
+/// A unified button widget that enforces Minglit design tokens
+/// (radius, spacing, typography) across all button variants.
+///
+/// Wraps Material buttons ([ElevatedButton], [OutlinedButton], [TextButton])
+/// with consistent sizing and styling.
+///
+/// {@tool snippet}
+/// ```dart
+/// // Primary CTA
+/// MinglitButton(
+///   label: '참가하기',
+///   onPressed: () => submit(),
+/// )
+///
+/// // Secondary action
+/// MinglitButton.secondary(
+///   label: '취소',
+///   onPressed: () => cancel(),
+/// )
+///
+/// // Text button with icon
+/// MinglitButton.text(
+///   label: '더보기',
+///   icon: Icons.arrow_forward,
+///   onPressed: () => viewMore(),
+/// )
+/// ```
+/// {@end-tool}
+class MinglitButton extends StatelessWidget {
+  /// Creates a primary (filled) button.
+  const MinglitButton({
+    required this.label,
+    this.onPressed,
+    this.icon,
+    this.isLoading = false,
+    this.size = MinglitButtonSize.large,
+    this.expand = true,
+    super.key,
+  }) : variant = MinglitButtonVariant.primary;
+
+  /// Creates a secondary (outlined) button.
+  const MinglitButton.secondary({
+    required this.label,
+    this.onPressed,
+    this.icon,
+    this.isLoading = false,
+    this.size = MinglitButtonSize.large,
+    this.expand = true,
+    super.key,
+  }) : variant = MinglitButtonVariant.secondary;
+
+  /// Creates a text button.
+  const MinglitButton.text({
+    required this.label,
+    this.onPressed,
+    this.icon,
+    this.isLoading = false,
+    this.size = MinglitButtonSize.medium,
+    this.expand = false,
+    super.key,
+  }) : variant = MinglitButtonVariant.text;
+
+  /// Button label text.
+  final String label;
+
+  /// Called when the button is pressed. Null disables the button.
+  final VoidCallback? onPressed;
+
+  /// Optional leading icon.
+  final IconData? icon;
+
+  /// When `true`, shows a loading indicator and disables the button.
+  final bool isLoading;
+
+  /// Button visual variant.
+  final MinglitButtonVariant variant;
+
+  /// Button size controlling height and text size.
+  final MinglitButtonSize size;
+
+  /// When `true`, the button expands to fill available width.
+  /// Defaults to `true` for primary/secondary, `false` for text.
+  final bool expand;
+
+  @override
+  Widget build(BuildContext context) {
+    final child = _buildChild(context);
+
+    final effectiveOnPressed = isLoading ? null : onPressed;
+
+    final Widget button;
+    switch (variant) {
+      case MinglitButtonVariant.primary:
+        button = ElevatedButton(
+          onPressed: effectiveOnPressed,
+          style: _primaryStyle(context),
+          child: child,
+        );
+      case MinglitButtonVariant.secondary:
+        button = OutlinedButton(
+          onPressed: effectiveOnPressed,
+          style: _secondaryStyle(context),
+          child: child,
+        );
+      case MinglitButtonVariant.text:
+        button = TextButton(
+          onPressed: effectiveOnPressed,
+          style: _textStyle(context),
+          child: child,
+        );
+    }
+
+    if (expand) {
+      return SizedBox(width: double.infinity, child: button);
+    }
+    return button;
+  }
+
+  Widget _buildChild(BuildContext context) {
+    final theme = Theme.of(context);
+
+    if (isLoading) {
+      final color = variant == MinglitButtonVariant.primary
+          ? theme.colorScheme.onPrimary
+          : theme.colorScheme.primary;
+      return SizedBox(
+        width: _iconSize,
+        height: _iconSize,
+        child: CircularProgressIndicator(
+          strokeWidth: 2,
+          color: color,
+        ),
+      );
+    }
+
+    if (icon != null) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: _iconSize),
+          const SizedBox(width: MinglitSpacing.small),
+          Text(label),
+        ],
+      );
+    }
+
+    return Text(label);
+  }
+
+  double get _height {
+    switch (size) {
+      case MinglitButtonSize.small:
+        return 36;
+      case MinglitButtonSize.medium:
+        return 48;
+      case MinglitButtonSize.large:
+        return 56;
+    }
+  }
+
+  double get _fontSize {
+    switch (size) {
+      case MinglitButtonSize.small:
+        return 14;
+      case MinglitButtonSize.medium:
+        return 15;
+      case MinglitButtonSize.large:
+        return 16;
+    }
+  }
+
+  double get _iconSize {
+    switch (size) {
+      case MinglitButtonSize.small:
+        return 16;
+      case MinglitButtonSize.medium:
+        return 18;
+      case MinglitButtonSize.large:
+        return 20;
+    }
+  }
+
+  ButtonStyle _primaryStyle(BuildContext context) {
+    return ElevatedButton.styleFrom(
+      backgroundColor: MinglitColors.primary,
+      // ignore: minglit_no_hardcoded_colors -- button theme definition
+      foregroundColor: Colors.white,
+      minimumSize: Size(0, _height),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(MinglitRadius.button),
+      ),
+      elevation: 0,
+      textStyle: TextStyle(
+        // ignore: minglit_no_hardcoded_text_style -- button theme definition
+        fontSize: _fontSize,
+        fontWeight: FontWeight.bold,
+      ),
+    );
+  }
+
+  ButtonStyle _secondaryStyle(BuildContext context) {
+    return OutlinedButton.styleFrom(
+      foregroundColor: MinglitColors.primary,
+      minimumSize: Size(0, _height),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(MinglitRadius.button),
+      ),
+      side: const BorderSide(color: MinglitColors.primary),
+      textStyle: TextStyle(
+        // ignore: minglit_no_hardcoded_text_style -- button theme definition
+        fontSize: _fontSize,
+        fontWeight: FontWeight.bold,
+      ),
+    );
+  }
+
+  ButtonStyle _textStyle(BuildContext context) {
+    return TextButton.styleFrom(
+      foregroundColor: MinglitColors.primary,
+      minimumSize: Size(0, _height),
+      textStyle: TextStyle(
+        // ignore: minglit_no_hardcoded_text_style -- button theme definition
+        fontSize: _fontSize,
+        fontWeight: FontWeight.bold,
+      ),
+    );
+  }
+}

--- a/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_button_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_button_test.dart
@@ -4,88 +4,101 @@ import 'package:minglit_kit/src/ui/widgets/common/minglit_button.dart';
 
 void main() {
   Widget buildApp(Widget child) {
-    return MaterialApp(home: Scaffold(body: Center(child: child)));
+    return MaterialApp(
+      home: Scaffold(body: Center(child: child)),
+    );
   }
 
   group('MinglitButton', () {
     testWidgets('primary renders ElevatedButton', (tester) async {
-      await tester.pumpWidget(buildApp(
-        MinglitButton(label: '참가하기', onPressed: () {}),
-      ));
+      await tester.pumpWidget(
+        buildApp(
+          MinglitButton(label: '참가하기', onPressed: () {}),
+        ),
+      );
 
       expect(find.byType(ElevatedButton), findsOneWidget);
       expect(find.text('참가하기'), findsOneWidget);
     });
 
     testWidgets('secondary renders OutlinedButton', (tester) async {
-      await tester.pumpWidget(buildApp(
-        MinglitButton.secondary(label: '취소', onPressed: () {}),
-      ));
+      await tester.pumpWidget(
+        buildApp(
+          MinglitButton.secondary(label: '취소', onPressed: () {}),
+        ),
+      );
 
       expect(find.byType(OutlinedButton), findsOneWidget);
       expect(find.text('취소'), findsOneWidget);
     });
 
     testWidgets('text renders TextButton', (tester) async {
-      await tester.pumpWidget(buildApp(
-        MinglitButton.text(label: '더보기', onPressed: () {}),
-      ));
+      await tester.pumpWidget(
+        buildApp(
+          MinglitButton.text(label: '더보기', onPressed: () {}),
+        ),
+      );
 
       expect(find.byType(TextButton), findsOneWidget);
       expect(find.text('더보기'), findsOneWidget);
     });
 
     testWidgets('disabled when onPressed is null', (tester) async {
-      await tester.pumpWidget(buildApp(
-        const MinglitButton(label: 'Disabled'),
-      ));
+      await tester.pumpWidget(
+        buildApp(
+          const MinglitButton(label: 'Disabled'),
+        ),
+      );
 
-      final button =
-          tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+      final button = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
       expect(button.onPressed, isNull);
     });
 
     testWidgets('shows loading indicator when isLoading', (tester) async {
-      await tester.pumpWidget(buildApp(
-        MinglitButton(
-          label: '저장',
-          onPressed: () {},
-          isLoading: true,
+      await tester.pumpWidget(
+        buildApp(
+          MinglitButton(
+            label: '저장',
+            onPressed: () {},
+            isLoading: true,
+          ),
         ),
-      ));
+      );
 
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
       // Button should be disabled during loading
-      final button =
-          tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+      final button = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
       expect(button.onPressed, isNull);
     });
 
     testWidgets('shows icon when provided', (tester) async {
-      await tester.pumpWidget(buildApp(
-        MinglitButton(
-          label: '다음',
-          icon: Icons.arrow_forward,
-          onPressed: () {},
+      await tester.pumpWidget(
+        buildApp(
+          MinglitButton(
+            label: '다음',
+            icon: Icons.arrow_forward,
+            onPressed: () {},
+          ),
         ),
-      ));
+      );
 
       expect(find.byIcon(Icons.arrow_forward), findsOneWidget);
       expect(find.text('다음'), findsOneWidget);
     });
 
     testWidgets('expand=true makes button full width', (tester) async {
-      await tester.pumpWidget(buildApp(
-        MinglitButton(label: '전체 너비', onPressed: () {}),
-      ));
+      await tester.pumpWidget(
+        buildApp(
+          MinglitButton(label: '전체 너비', onPressed: () {}),
+        ),
+      );
 
       // Primary defaults to expand=true, wrapped in SizedBox(infinity)
       expect(
         find.ancestor(
           of: find.byType(ElevatedButton),
           matching: find.byWidgetPredicate(
-            (w) =>
-                w is SizedBox && w.width == double.infinity,
+            (w) => w is SizedBox && w.width == double.infinity,
           ),
         ),
         findsOneWidget,
@@ -93,17 +106,18 @@ void main() {
     });
 
     testWidgets('text variant defaults to expand=false', (tester) async {
-      await tester.pumpWidget(buildApp(
-        MinglitButton.text(label: '텍스트', onPressed: () {}),
-      ));
+      await tester.pumpWidget(
+        buildApp(
+          MinglitButton.text(label: '텍스트', onPressed: () {}),
+        ),
+      );
 
       // Text variant defaults to expand=false, no SizedBox wrapper
       expect(
         find.ancestor(
           of: find.byType(TextButton),
           matching: find.byWidgetPredicate(
-            (w) =>
-                w is SizedBox && w.width == double.infinity,
+            (w) => w is SizedBox && w.width == double.infinity,
           ),
         ),
         findsNothing,
@@ -112,25 +126,29 @@ void main() {
 
     testWidgets('calls onPressed when tapped', (tester) async {
       var pressed = false;
-      await tester.pumpWidget(buildApp(
-        MinglitButton(
-          label: '탭 테스트',
-          onPressed: () => pressed = true,
+      await tester.pumpWidget(
+        buildApp(
+          MinglitButton(
+            label: '탭 테스트',
+            onPressed: () => pressed = true,
+          ),
         ),
-      ));
+      );
 
       await tester.tap(find.text('탭 테스트'));
       expect(pressed, isTrue);
     });
 
     testWidgets('small size renders smaller button', (tester) async {
-      await tester.pumpWidget(buildApp(
-        MinglitButton(
-          label: '작은 버튼',
-          size: MinglitButtonSize.small,
-          onPressed: () {},
+      await tester.pumpWidget(
+        buildApp(
+          MinglitButton(
+            label: '작은 버튼',
+            size: MinglitButtonSize.small,
+            onPressed: () {},
+          ),
         ),
-      ));
+      );
 
       expect(find.text('작은 버튼'), findsOneWidget);
     });

--- a/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_button_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_button_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_button.dart';
+
+void main() {
+  Widget buildApp(Widget child) {
+    return MaterialApp(home: Scaffold(body: Center(child: child)));
+  }
+
+  group('MinglitButton', () {
+    testWidgets('primary renders ElevatedButton', (tester) async {
+      await tester.pumpWidget(buildApp(
+        MinglitButton(label: '참가하기', onPressed: () {}),
+      ));
+
+      expect(find.byType(ElevatedButton), findsOneWidget);
+      expect(find.text('참가하기'), findsOneWidget);
+    });
+
+    testWidgets('secondary renders OutlinedButton', (tester) async {
+      await tester.pumpWidget(buildApp(
+        MinglitButton.secondary(label: '취소', onPressed: () {}),
+      ));
+
+      expect(find.byType(OutlinedButton), findsOneWidget);
+      expect(find.text('취소'), findsOneWidget);
+    });
+
+    testWidgets('text renders TextButton', (tester) async {
+      await tester.pumpWidget(buildApp(
+        MinglitButton.text(label: '더보기', onPressed: () {}),
+      ));
+
+      expect(find.byType(TextButton), findsOneWidget);
+      expect(find.text('더보기'), findsOneWidget);
+    });
+
+    testWidgets('disabled when onPressed is null', (tester) async {
+      await tester.pumpWidget(buildApp(
+        const MinglitButton(label: 'Disabled'),
+      ));
+
+      final button =
+          tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+      expect(button.onPressed, isNull);
+    });
+
+    testWidgets('shows loading indicator when isLoading', (tester) async {
+      await tester.pumpWidget(buildApp(
+        MinglitButton(
+          label: '저장',
+          onPressed: () {},
+          isLoading: true,
+        ),
+      ));
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      // Button should be disabled during loading
+      final button =
+          tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+      expect(button.onPressed, isNull);
+    });
+
+    testWidgets('shows icon when provided', (tester) async {
+      await tester.pumpWidget(buildApp(
+        MinglitButton(
+          label: '다음',
+          icon: Icons.arrow_forward,
+          onPressed: () {},
+        ),
+      ));
+
+      expect(find.byIcon(Icons.arrow_forward), findsOneWidget);
+      expect(find.text('다음'), findsOneWidget);
+    });
+
+    testWidgets('expand=true makes button full width', (tester) async {
+      await tester.pumpWidget(buildApp(
+        MinglitButton(label: '전체 너비', onPressed: () {}),
+      ));
+
+      // Primary defaults to expand=true, wrapped in SizedBox(infinity)
+      expect(
+        find.ancestor(
+          of: find.byType(ElevatedButton),
+          matching: find.byWidgetPredicate(
+            (w) =>
+                w is SizedBox && w.width == double.infinity,
+          ),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('text variant defaults to expand=false', (tester) async {
+      await tester.pumpWidget(buildApp(
+        MinglitButton.text(label: '텍스트', onPressed: () {}),
+      ));
+
+      // Text variant defaults to expand=false, no SizedBox wrapper
+      expect(
+        find.ancestor(
+          of: find.byType(TextButton),
+          matching: find.byWidgetPredicate(
+            (w) =>
+                w is SizedBox && w.width == double.infinity,
+          ),
+        ),
+        findsNothing,
+      );
+    });
+
+    testWidgets('calls onPressed when tapped', (tester) async {
+      var pressed = false;
+      await tester.pumpWidget(buildApp(
+        MinglitButton(
+          label: '탭 테스트',
+          onPressed: () => pressed = true,
+        ),
+      ));
+
+      await tester.tap(find.text('탭 테스트'));
+      expect(pressed, isTrue);
+    });
+
+    testWidgets('small size renders smaller button', (tester) async {
+      await tester.pumpWidget(buildApp(
+        MinglitButton(
+          label: '작은 버튼',
+          size: MinglitButtonSize.small,
+          onPressed: () {},
+        ),
+      ));
+
+      expect(find.text('작은 버튼'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- primary/secondary/text 3개 variant + small/medium/large 3개 size 조합의 통합 버튼 위젯
- Material 버튼을 래핑하여 Minglit 디자인 토큰 강제 (radius, spacing, typography)
- isLoading, icon, expand 옵션 지원
- 위젯 테스트 10건 추가

Closes #622

## Test plan
- [x] `flutter analyze` 통과
- [x] 위젯 테스트 10건 전체 통과 (`minglit_button_test.dart`)
- [ ] CI `test-flutter-apps` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)