### PR TITLE
feat(ef): identity-verify → update_user_identity RPC 전환 (#808)

### DIFF
--- a/supabase/functions/_contract_tests/contract_test.ts
+++ b/supabase/functions/_contract_tests/contract_test.ts
@@ -152,8 +152,8 @@ Deno.test("contract: identity-verify response matches schema", async () => {
         handler: () => jsonResponse(mockPortoneVerification),
       },
       {
-        matcher: (req) => req.url.includes("/rest/v1/user_profiles") && req.method === "PATCH",
-        handler: () => jsonResponse({}),
+        matcher: (req) => req.url.includes("/rest/v1/rpc/update_user_identity") && req.method === "POST",
+        handler: () => jsonResponse(null),
       },
     ]);
 

--- a/supabase/functions/identity-verify/identity_verify_test.ts
+++ b/supabase/functions/identity-verify/identity_verify_test.ts
@@ -32,8 +32,8 @@ Deno.test("identity-verify - happy path updates profile", async () => {
           handler: () => jsonResponse(mockUser),
         },
         {
-          matcher: (req) => req.url.includes("/rest/v1/user_profiles") && req.method === "PATCH",
-          handler: () => jsonResponse({}),
+          matcher: (req) => req.url.includes("/rest/v1/rpc/update_user_identity") && req.method === "POST",
+          handler: () => jsonResponse(null),
         },
       ]);
 
@@ -144,6 +144,48 @@ Deno.test("identity-verify - unauthorized returns 401", async () => {
 
           assertEquals(response.status, 401);
           assertEquals(payload.error, "Unauthorized");
+        });
+      });
+    },
+  );
+});
+
+Deno.test("identity-verify - RPC failure returns 500", async () => {
+  await withEnv(
+    {
+      PORTONE_V2_API_KEY: "test-key",
+      SUPABASE_URL: "https://supabase.test",
+      SUPABASE_SERVICE_ROLE_KEY: "service-key",
+    },
+    async () => {
+      const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+      const { fetchMock } = createFetchMock([
+        {
+          matcher: "https://api.portone.io/identity-verifications/verify_123",
+          handler: () => jsonResponse(mockPortoneVerification),
+        },
+        {
+          matcher: (req) => req.url.includes("/auth/v1/user"),
+          handler: () => jsonResponse(mockUser),
+        },
+        {
+          matcher: (req) => req.url.includes("/rest/v1/rpc/update_user_identity"),
+          handler: () => jsonResponse({ message: "pii_encryption_key not found" }, { status: 400 }),
+        },
+      ]);
+
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const request = jsonRequest(
+            "http://localhost",
+            { identity_verification_id: "verify_123" },
+            { headers: { Authorization: "Bearer test-token" } },
+          );
+          const response = await handler(request);
+          const payload = await readJson(response);
+
+          assertEquals(response.status, 500);
+          assertEquals(payload.error, "Failed to update user profile");
         });
       });
     },

--- a/supabase/functions/identity-verify/index.ts
+++ b/supabase/functions/identity-verify/index.ts
@@ -58,19 +58,17 @@ Deno.serve(withHandler(async (req) => {
 
     const gender = typeof customer.gender === "string" ? customer.gender.toLowerCase() : undefined;
 
-    const { error: updateError } = await supabase
-      .from("user_profiles")
-      .update({
-        name: customer.name,
-        birth_date: customer.birthDate,
-        gender,
-        phone_number: customer.phoneNumber,
-        ci: customer.ci,
-        di: customer.di,
-        is_verified: true,
-        updated_at: new Date().toISOString(),
-      })
-      .eq("id", userId);
+    // Fix #808: identity-verify → update_user_identity RPC 전환
+    // 평문 CI/DI 대신 암호화 RPC를 호출하여 ci_encrypted, di_encrypted, di_hash에 저장
+    const { error: updateError } = await supabase.rpc('update_user_identity', {
+      p_user_id: userId,
+      p_ci: customer.ci as string,
+      p_di: customer.di as string,
+      p_name: customer.name as string,
+      p_birth_date: customer.birthDate as string,
+      p_gender: gender,
+      p_phone_number: customer.phoneNumber as string,
+    });
 
     if (updateError) {
       log({ function: FN, level: "error", message: "DB Update Error", metadata: { detail: updateError } });

--- a/supabase/migrations/20260330000002_update_user_identity_updated_at.sql
+++ b/supabase/migrations/20260330000002_update_user_identity_updated_at.sql
@@ -1,0 +1,41 @@
+-- Fix #808: update_user_identity RPC에 updated_at 추가
+-- EF에서 별도 UPDATE 없이 RPC 하나로 모든 필드를 처리하기 위함
+CREATE OR REPLACE FUNCTION public.update_user_identity(
+  p_user_id uuid,
+  p_ci text,
+  p_di text,
+  p_name text DEFAULT NULL,
+  p_birth_date date DEFAULT NULL,
+  p_gender public.gender DEFAULT NULL,
+  p_phone_number text DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_key text;
+BEGIN
+  SELECT decrypted_secret INTO v_key
+  FROM vault.decrypted_secrets
+  WHERE name = 'pii_encryption_key'
+  LIMIT 1;
+
+  IF v_key IS NULL THEN
+    RAISE EXCEPTION 'pii_encryption_key not found in vault';
+  END IF;
+
+  UPDATE public.user_profiles SET
+    ci_encrypted = pgp_sym_encrypt(p_ci, v_key),
+    di_encrypted = pgp_sym_encrypt(p_di, v_key),
+    di_hash = encode(digest(p_di, 'sha256'), 'hex'),
+    name = COALESCE(p_name, name),
+    birth_date = COALESCE(p_birth_date, birth_date),
+    gender = COALESCE(p_gender, gender),
+    phone_number = COALESCE(p_phone_number, phone_number),
+    is_verified = true,
+    updated_at = now()
+  WHERE id = p_user_id;
+END;
+$$;


### PR DESCRIPTION
## Summary
- `identity-verify` Edge Function에서 직접 DB 업데이트하던 로직을 `update_user_identity` RPC 호출로 전환
- contract test mock을 RPC 엔드포인트에 맞게 업데이트
- `update_user_identity` RPC에 `updated_at` 타임스탬프 추가

Closes #808

## 피처 파이프라인 히스토리
| 단계 | 이슈 | PR | 산출물 |
|------|------|-----|--------|
| 아키텍처 결정 | #759 | - | pgcrypto + Vault 하이브리드 |
| Phase 1: DB 마이그레이션 | #807 | #812 | migration + pgTAP test |
| Phase 2: EF 전환 | #808 | 현재 PR | EF → RPC 전환 |

## Test plan
- [ ] `update_user_identity` RPC contract test 통과
- [ ] Edge Function identity-verify가 RPC를 통해 정상 동작
- [ ] `flutter analyze` 통과
- [ ] CI `test-edge-functions` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)