### PR TITLE
test(my_tickets): P1/P2 테스트 보강

### DIFF
--- a/apps/app_user/test/src/features/my_tickets/ui/my_tickets_page_test.dart
+++ b/apps/app_user/test/src/features/my_tickets/ui/my_tickets_page_test.dart
@@ -410,7 +410,7 @@ void main() {
       clearInteractions(navigatorObserver);
 
       await tester.tap(find.text('입장 QR'));
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       // Verify Navigator.push was called exactly once (route to TicketQRScreen)
       verify(() => navigatorObserver.didPush(any(), any())).called(1);

--- a/apps/app_user/test/src/features/my_tickets/ui/my_tickets_page_test.dart
+++ b/apps/app_user/test/src/features/my_tickets/ui/my_tickets_page_test.dart
@@ -237,8 +237,9 @@ void main() {
     });
 
     // Fix #642: P2 — banner not shown when no todayEvent
-    testWidgets('does not render today banner when no today event',
-        (tester) async {
+    testWidgets('does not render today banner when no today event', (
+      tester,
+    ) async {
       final upcoming = makeApplication(
         id: '1',
         status: 'paid',
@@ -285,7 +286,7 @@ void main() {
       );
       expect(opacityWidget.opacity, 0.55);
     });
-  });  // end MyTicketsPage group
+  }); // end MyTicketsPage group
 
   group('MyTicketCard', () {
     testWidgets('shows D-Day chip for today event', (tester) async {

--- a/apps/app_user/test/src/features/my_tickets/ui/my_tickets_page_test.dart
+++ b/apps/app_user/test/src/features/my_tickets/ui/my_tickets_page_test.dart
@@ -406,13 +406,14 @@ void main() {
         ),
       );
 
-      await tester.tap(find.text('입장 QR'));
-      await tester.pump();
+      // Fix #642: 초기 route push 이력 제거 — 탭 이후 push만 검증
+      clearInteractions(navigatorObserver);
 
-      // Verify Navigator.push was called (route to TicketQRScreen)
-      verify(() => navigatorObserver.didPush(any(), any())).called(
-        greaterThanOrEqualTo(1),
-      );
+      await tester.tap(find.text('입장 QR'));
+      await tester.pumpAndSettle();
+
+      // Verify Navigator.push was called exactly once (route to TicketQRScreen)
+      verify(() => navigatorObserver.didPush(any(), any())).called(1);
     });
 
     testWidgets('shows location name', (tester) async {

--- a/apps/app_user/test/src/features/my_tickets/ui/my_tickets_page_test.dart
+++ b/apps/app_user/test/src/features/my_tickets/ui/my_tickets_page_test.dart
@@ -11,9 +11,14 @@ import '../../../../utils/mocks.dart';
 
 class MockHomeCoordinator extends Mock implements HomeCoordinator {}
 
+class MockNavigatorObserver extends Mock implements NavigatorObserver {}
+
+class FakeRoute extends Fake implements Route<dynamic> {}
+
 void main() {
   setUpAll(() async {
     await initializeDateFormatting('ko_KR');
+    registerFallbackValue(FakeRoute());
   });
 
   late MockEventRepository mockEventRepository;
@@ -187,7 +192,7 @@ void main() {
       expect(find.text('종료된 이벤트'), findsOneWidget);
       // Past cards should show "종료" chip, not QR button
       expect(find.text('종료'), findsOneWidget);
-      // No QR button in past cards (only banner might have one, but no today event)
+      // No QR button in past cards
       expect(find.text('입장 QR'), findsNothing);
     });
 
@@ -230,7 +235,57 @@ void main() {
         () => mockHomeCoordinator.pushEventDetail('event_1'),
       ).called(1);
     });
-  });
+
+    // Fix #642: P2 — banner not shown when no todayEvent
+    testWidgets('does not render today banner when no today event',
+        (tester) async {
+      final upcoming = makeApplication(
+        id: '1',
+        status: 'paid',
+        startTime: DateTime.now().add(const Duration(days: 5)),
+        eventTitle: '5일 뒤 이벤트',
+      );
+
+      when(
+        () => mockEventRepository.getMyTickets('user1'),
+      ).thenAnswer((_) async => [upcoming]);
+
+      await tester.pumpWidget(createTestWidget());
+      await pumpAndSettle(tester);
+
+      // Section header should appear, but no banner
+      expect(find.text('다가오는 이벤트'), findsOneWidget);
+      // Banner has "입장 QR" text — only card QR buttons should show
+      // No "오늘" text in banner format
+      expect(find.text('오늘'), findsNothing);
+    });
+
+    // Fix #642: P2 — past card has reduced opacity
+    testWidgets('past cards have reduced opacity', (tester) async {
+      final past = makeApplication(
+        id: '1',
+        status: 'paid',
+        startTime: DateTime.now().subtract(const Duration(days: 3)),
+        eventTitle: '지난 이벤트',
+      );
+
+      when(
+        () => mockEventRepository.getMyTickets('user1'),
+      ).thenAnswer((_) async => [past]);
+
+      await tester.pumpWidget(createTestWidget());
+      await pumpAndSettle(tester);
+
+      // MyTicketCard wraps content in Opacity(opacity: 0.55) for past
+      final opacityWidget = tester.widget<Opacity>(
+        find.descendant(
+          of: find.byType(MyTicketCard),
+          matching: find.byType(Opacity),
+        ),
+      );
+      expect(opacityWidget.opacity, 0.55);
+    });
+  });  // end MyTicketsPage group
 
   group('MyTicketCard', () {
     testWidgets('shows D-Day chip for today event', (tester) async {
@@ -324,6 +379,39 @@ void main() {
       );
 
       expect(find.text('결제완료'), findsOneWidget);
+    });
+
+    // Fix #642: P1 — QR button tap navigates to TicketQRScreen
+    testWidgets('QR button tap pushes TicketQRScreen', (tester) async {
+      final app = makeApplication(
+        id: '1',
+        status: 'paid',
+        startTime: DateTime.now().add(const Duration(days: 3)),
+        eventTitle: 'QR 테스트 이벤트',
+      );
+
+      final navigatorObserver = MockNavigatorObserver();
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            navigatorObservers: [navigatorObserver],
+            home: Scaffold(
+              body: MyTicketCard(
+                application: app,
+                isPast: false,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('입장 QR'));
+      await tester.pump();
+
+      // Verify Navigator.push was called (route to TicketQRScreen)
+      verify(() => navigatorObserver.didPush(any(), any())).called(
+        greaterThanOrEqualTo(1),
+      );
     });
 
     testWidgets('shows location name', (tester) async {


### PR DESCRIPTION
## Summary
- P1: MyTicketCard QR 버튼 탭 → TicketQRScreen 네비게이션 검증 추가
- P2: todayEvent 없을 때 배너 미표시 테스트 추가
- P2: 과거 카드 Opacity 0.55 검증 테스트 추가

기존 20건 + 3건 신규 = 위젯 23건 전체 통과.

Closes #642

## Test plan
- [x] `flutter test test/src/features/my_tickets/` 전체 pass (23 widget + 8 controller)
- [x] `flutter analyze` pass (0 issues)
- [x] 기존 테스트 회귀 없음
- [ ] CI (`ci-result`) 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)