### PR TITLE
feat(ef): identity-verify → update_user_identity RPC 전환

### DIFF
--- a/supabase/functions/_contract_tests/contract_test.ts
+++ b/supabase/functions/_contract_tests/contract_test.ts
@@ -152,8 +152,8 @@ Deno.test("contract: identity-verify response matches schema", async () => {
         handler: () => jsonResponse(mockPortoneVerification),
       },
       {
-        matcher: (req) => req.url.includes("/rest/v1/user_profiles") && req.method === "PATCH",
-        handler: () => jsonResponse({}),
+        matcher: (req) => req.url.includes("/rest/v1/rpc/update_user_identity") && req.method === "POST",
+        handler: () => jsonResponse(null),
       },
     ]);
 

--- a/supabase/functions/identity-verify/identity_verify_test.ts
+++ b/supabase/functions/identity-verify/identity_verify_test.ts
@@ -32,8 +32,8 @@ Deno.test("identity-verify - happy path updates profile", async () => {
           handler: () => jsonResponse(mockUser),
         },
         {
-          matcher: (req) => req.url.includes("/rest/v1/user_profiles") && req.method === "PATCH",
-          handler: () => jsonResponse({}),
+          matcher: (req) => req.url.includes("/rest/v1/rpc/update_user_identity") && req.method === "POST",
+          handler: () => jsonResponse(null),
         },
       ]);
 
@@ -144,6 +144,47 @@ Deno.test("identity-verify - unauthorized returns 401", async () => {
 
           assertEquals(response.status, 401);
           assertEquals(payload.error, "Unauthorized");
+        });
+      });
+    },
+  );
+});
+
+// Fix #808: RPC 에러 시 500 반환 확인
+Deno.test("identity-verify - RPC error returns 500", async () => {
+  await withEnv(
+    {
+      PORTONE_V2_API_KEY: "test-key",
+      SUPABASE_URL: "https://supabase.test",
+      SUPABASE_SERVICE_ROLE_KEY: "service-key",
+    },
+    async () => {
+      const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+      const { fetchMock } = createFetchMock([
+        {
+          matcher: "https://api.portone.io/identity-verifications/verify_123",
+          handler: () => jsonResponse(mockPortoneVerification),
+        },
+        {
+          matcher: (req) => req.url.includes("/auth/v1/user"),
+          handler: () => jsonResponse(mockUser),
+        },
+        {
+          matcher: (req) => req.url.includes("/rest/v1/rpc/update_user_identity") && req.method === "POST",
+          handler: () => jsonResponse({ message: "RPC error", code: "42883" }, { status: 400 }),
+        },
+      ]);
+
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const request = authenticatedJsonRequest("http://localhost", {
+            identity_verification_id: "verify_123",
+          });
+          const response = await handler(request);
+          const payload = await readJson(response);
+
+          assertEquals(response.status, 500);
+          assertEquals(payload.error, "Failed to update user profile");
         });
       });
     },

--- a/supabase/functions/identity-verify/index.ts
+++ b/supabase/functions/identity-verify/index.ts
@@ -53,24 +53,20 @@ Deno.serve(withHandler(async (req) => {
       return errorResponse("Verified customer data missing", 500);
     }
 
-    // 3. Supabase DB 업데이트
+    // 3. Supabase DB 업데이트 — Fix #808: update_user_identity RPC로 암호화 저장
     const supabase = createServiceClient();
 
     const gender = typeof customer.gender === "string" ? customer.gender.toLowerCase() : undefined;
 
-    const { error: updateError } = await supabase
-      .from("user_profiles")
-      .update({
-        name: customer.name,
-        birth_date: customer.birthDate,
-        gender,
-        phone_number: customer.phoneNumber,
-        ci: customer.ci,
-        di: customer.di,
-        is_verified: true,
-        updated_at: new Date().toISOString(),
-      })
-      .eq("id", userId);
+    const { error: updateError } = await supabase.rpc("update_user_identity", {
+      p_user_id: userId,
+      p_ci: customer.ci as string,
+      p_di: customer.di as string,
+      p_name: (customer.name as string) ?? null,
+      p_birth_date: (customer.birthDate as string) ?? null,
+      p_gender: gender ?? null,
+      p_phone_number: (customer.phoneNumber as string) ?? null,
+    });
 
     if (updateError) {
       log({ function: FN, level: "error", message: "DB Update Error", metadata: { detail: updateError } });


### PR DESCRIPTION
## Summary
- Edge Function `identity-verify`를 직접 DB insert에서 `update_user_identity` RPC 호출로 전환
- 암호화된 컬럼(`ci_encrypted`, `di_encrypted`)을 사용하는 RPC를 통해 평문 노출 경로 차단
- Contract test mock을 RPC 엔드포인트로 업데이트

Closes #808

## Test plan
- [x] `identity_verify_test.ts` RPC mock 테스트 통과
- [x] `contract_test.ts` mock 업데이트 확인
- [ ] CI (`ci-result`) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)