### PR TITLE
fix(minglit_kit): remove broken ticket filter from event feed

### DIFF
--- a/shared/packages/minglit_kit/lib/src/logic/providers/event_feed_provider.dart
+++ b/shared/packages/minglit_kit/lib/src/logic/providers/event_feed_provider.dart
@@ -59,20 +59,15 @@ Future<List<Event>> eventFeed(
     ).future,
   );
 
-  // 2. Watch User Profile (for filtering)
+  // 2. Watch User Profile (triggers re-computation on profile change)
+  // ignore: unused_local_variable — kept as extension point for future filtering
   final currentUser = ref.watch(currentUserProfileProvider).value;
 
   // 3. Apply Filtering Logic
-  if (currentUser != null) {
-    return events.where((event) {
-      final tickets = event.tickets ?? [];
-      // Example logic: if tickets exist, show event.
-      // Adjust this logic as per business requirements.
-      if (tickets.isEmpty) return false;
-      return true;
-    }).toList();
-  }
-
+  // Fix #778: Removed broken ticket filter that hid events without tickets
+  // for logged-in users. Free events and new events may not have ticket
+  // configurations. This provider remains as a business-logic extension point
+  // for future user-specific filtering (e.g., personalization, visibility).
   return events;
 }
 

--- a/shared/packages/minglit_kit/test/src/logic/providers/event_feed_provider_test.dart
+++ b/shared/packages/minglit_kit/test/src/logic/providers/event_feed_provider_test.dart
@@ -1,8 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/models/event.dart';
 import 'package:minglit_kit/src/data/models/event_feed_type.dart';
+import 'package:minglit_kit/src/data/models/ticket.dart';
+import 'package:minglit_kit/src/data/models/user_profile.dart';
 import 'package:minglit_kit/src/data/repositories/event_repository.dart';
 import 'package:minglit_kit/src/logic/providers/event_feed_provider.dart';
+import 'package:minglit_kit/src/logic/providers/user_profile_provider.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/test_utils.dart';
@@ -10,6 +13,33 @@ import '../../../helpers/test_utils.dart';
 class MockEventRepository extends Mock implements EventRepository {}
 
 class MockEvent extends Mock implements Event {}
+
+/// Helper to create a real Event for ticket-related tests.
+Event _createEvent({
+  String id = 'event-1',
+  List<Ticket>? tickets,
+}) {
+  final now = DateTime.now();
+  return Event(
+    id: id,
+    partyId: 'party-1',
+    startTime: now.add(const Duration(days: 1)),
+    endTime: now.add(const Duration(days: 1, hours: 2)),
+    createdAt: now,
+    updatedAt: now,
+    tickets: tickets,
+  );
+}
+
+Ticket _createTicket({String id = 'ticket-1', String name = 'General'}) {
+  final now = DateTime.now();
+  return Ticket(
+    id: id,
+    name: name,
+    createdAt: now,
+    updatedAt: now,
+  );
+}
 
 void main() {
   setUpAll(() {
@@ -94,6 +124,205 @@ void main() {
         ),
         throwsA(anything),
       );
+    });
+  });
+
+  // Fix #778: Regression tests — eventFeed must return all events regardless
+  // of ticket configuration. The previous implementation filtered out events
+  // without tickets for logged-in users.
+  group('eventFeedProvider — ticket filter regression (#778)', () {
+    late MockEventRepository mockRepo;
+
+    setUp(() {
+      mockRepo = MockEventRepository();
+    });
+
+    test('returns events with empty tickets when user is logged in', () async {
+      final event = _createEvent(tickets: []);
+
+      when(
+        () => mockRepo.getEventsByType(
+          type: any(named: 'type'),
+          latitude: any(named: 'latitude'),
+          longitude: any(named: 'longitude'),
+          limit: any(named: 'limit'),
+          blockedPartnerIds: any(named: 'blockedPartnerIds'),
+          offset: any(named: 'offset'),
+        ),
+      ).thenAnswer((_) async => [event]);
+
+      final container = createContainer(
+        overrides: [
+          eventRepositoryProvider.overrideWith((ref) => mockRepo),
+          currentUserProfileProvider.overrideWith(
+            (ref) async => UserProfile(
+              id: 'user-1',
+              name: 'Test User',
+              username: 'testuser',
+            ),
+          ),
+        ],
+      );
+
+      final result = await container.read(
+        eventFeedProvider(type: EventFeedType.newArrivals).future,
+      );
+
+      expect(result, hasLength(1));
+      expect(result.first.id, 'event-1');
+    });
+
+    test('returns events with null tickets when user is logged in', () async {
+      final event = _createEvent(tickets: null);
+
+      when(
+        () => mockRepo.getEventsByType(
+          type: any(named: 'type'),
+          latitude: any(named: 'latitude'),
+          longitude: any(named: 'longitude'),
+          limit: any(named: 'limit'),
+          blockedPartnerIds: any(named: 'blockedPartnerIds'),
+          offset: any(named: 'offset'),
+        ),
+      ).thenAnswer((_) async => [event]);
+
+      final container = createContainer(
+        overrides: [
+          eventRepositoryProvider.overrideWith((ref) => mockRepo),
+          currentUserProfileProvider.overrideWith(
+            (ref) async => UserProfile(
+              id: 'user-1',
+              name: 'Test User',
+              username: 'testuser',
+            ),
+          ),
+        ],
+      );
+
+      final result = await container.read(
+        eventFeedProvider(type: EventFeedType.newArrivals).future,
+      );
+
+      expect(result, hasLength(1));
+      expect(result.first.tickets, isNull);
+    });
+
+    test('returns events with tickets when user is logged in', () async {
+      final event = _createEvent(
+        tickets: [_createTicket()],
+      );
+
+      when(
+        () => mockRepo.getEventsByType(
+          type: any(named: 'type'),
+          latitude: any(named: 'latitude'),
+          longitude: any(named: 'longitude'),
+          limit: any(named: 'limit'),
+          blockedPartnerIds: any(named: 'blockedPartnerIds'),
+          offset: any(named: 'offset'),
+        ),
+      ).thenAnswer((_) async => [event]);
+
+      final container = createContainer(
+        overrides: [
+          eventRepositoryProvider.overrideWith((ref) => mockRepo),
+          currentUserProfileProvider.overrideWith(
+            (ref) async => UserProfile(
+              id: 'user-1',
+              name: 'Test User',
+              username: 'testuser',
+            ),
+          ),
+        ],
+      );
+
+      final result = await container.read(
+        eventFeedProvider(type: EventFeedType.newArrivals).future,
+      );
+
+      expect(result, hasLength(1));
+      expect(result.first.tickets, hasLength(1));
+    });
+
+    test('returns mixed events (with and without tickets) for logged-in user',
+        () async {
+      final eventWithTickets = _createEvent(
+        id: 'event-with-tickets',
+        tickets: [_createTicket()],
+      );
+      final eventWithoutTickets = _createEvent(
+        id: 'event-without-tickets',
+        tickets: [],
+      );
+      final eventNullTickets = _createEvent(
+        id: 'event-null-tickets',
+        tickets: null,
+      );
+
+      when(
+        () => mockRepo.getEventsByType(
+          type: any(named: 'type'),
+          latitude: any(named: 'latitude'),
+          longitude: any(named: 'longitude'),
+          limit: any(named: 'limit'),
+          blockedPartnerIds: any(named: 'blockedPartnerIds'),
+          offset: any(named: 'offset'),
+        ),
+      ).thenAnswer(
+        (_) async => [
+          eventWithTickets,
+          eventWithoutTickets,
+          eventNullTickets,
+        ],
+      );
+
+      final container = createContainer(
+        overrides: [
+          eventRepositoryProvider.overrideWith((ref) => mockRepo),
+          currentUserProfileProvider.overrideWith(
+            (ref) async => UserProfile(
+              id: 'user-1',
+              name: 'Test User',
+              username: 'testuser',
+            ),
+          ),
+        ],
+      );
+
+      final result = await container.read(
+        eventFeedProvider(type: EventFeedType.newArrivals).future,
+      );
+
+      expect(result, hasLength(3), reason: 'All events should be returned '
+          'regardless of ticket configuration');
+    });
+
+    test('returns events when user is not logged in', () async {
+      final event = _createEvent(tickets: []);
+
+      when(
+        () => mockRepo.getEventsByType(
+          type: any(named: 'type'),
+          latitude: any(named: 'latitude'),
+          longitude: any(named: 'longitude'),
+          limit: any(named: 'limit'),
+          blockedPartnerIds: any(named: 'blockedPartnerIds'),
+          offset: any(named: 'offset'),
+        ),
+      ).thenAnswer((_) async => [event]);
+
+      final container = createContainer(
+        overrides: [
+          eventRepositoryProvider.overrideWith((ref) => mockRepo),
+          currentUserProfileProvider.overrideWith((ref) async => null),
+        ],
+      );
+
+      final result = await container.read(
+        eventFeedProvider(type: EventFeedType.newArrivals).future,
+      );
+
+      expect(result, hasLength(1));
     });
   });
 

--- a/shared/packages/minglit_kit/test/src/logic/providers/event_feed_provider_test.dart
+++ b/shared/packages/minglit_kit/test/src/logic/providers/event_feed_provider_test.dart
@@ -155,7 +155,7 @@ void main() {
         overrides: [
           eventRepositoryProvider.overrideWith((ref) => mockRepo),
           currentUserProfileProvider.overrideWith(
-            (ref) async => UserProfile(
+            (ref) async => const UserProfile(
               id: 'user-1',
               name: 'Test User',
               username: 'testuser',
@@ -173,7 +173,7 @@ void main() {
     });
 
     test('returns events with null tickets when user is logged in', () async {
-      final event = _createEvent(tickets: null);
+      final event = _createEvent();
 
       when(
         () => mockRepo.getEventsByType(
@@ -190,7 +190,7 @@ void main() {
         overrides: [
           eventRepositoryProvider.overrideWith((ref) => mockRepo),
           currentUserProfileProvider.overrideWith(
-            (ref) async => UserProfile(
+            (ref) async => const UserProfile(
               id: 'user-1',
               name: 'Test User',
               username: 'testuser',
@@ -227,7 +227,7 @@ void main() {
         overrides: [
           eventRepositoryProvider.overrideWith((ref) => mockRepo),
           currentUserProfileProvider.overrideWith(
-            (ref) async => UserProfile(
+            (ref) async => const UserProfile(
               id: 'user-1',
               name: 'Test User',
               username: 'testuser',
@@ -244,58 +244,64 @@ void main() {
       expect(result.first.tickets, hasLength(1));
     });
 
-    test('returns mixed events (with and without tickets) for logged-in user',
-        () async {
-      final eventWithTickets = _createEvent(
-        id: 'event-with-tickets',
-        tickets: [_createTicket()],
-      );
-      final eventWithoutTickets = _createEvent(
-        id: 'event-without-tickets',
-        tickets: [],
-      );
-      final eventNullTickets = _createEvent(
-        id: 'event-null-tickets',
-        tickets: null,
-      );
+    test(
+      'returns mixed events (with and without tickets) for logged-in user',
+      () async {
+        final eventWithTickets = _createEvent(
+          id: 'event-with-tickets',
+          tickets: [_createTicket()],
+        );
+        final eventWithoutTickets = _createEvent(
+          id: 'event-without-tickets',
+          tickets: [],
+        );
+        final eventNullTickets = _createEvent(
+          id: 'event-null-tickets',
+        );
 
-      when(
-        () => mockRepo.getEventsByType(
-          type: any(named: 'type'),
-          latitude: any(named: 'latitude'),
-          longitude: any(named: 'longitude'),
-          limit: any(named: 'limit'),
-          blockedPartnerIds: any(named: 'blockedPartnerIds'),
-          offset: any(named: 'offset'),
-        ),
-      ).thenAnswer(
-        (_) async => [
-          eventWithTickets,
-          eventWithoutTickets,
-          eventNullTickets,
-        ],
-      );
-
-      final container = createContainer(
-        overrides: [
-          eventRepositoryProvider.overrideWith((ref) => mockRepo),
-          currentUserProfileProvider.overrideWith(
-            (ref) async => UserProfile(
-              id: 'user-1',
-              name: 'Test User',
-              username: 'testuser',
-            ),
+        when(
+          () => mockRepo.getEventsByType(
+            type: any(named: 'type'),
+            latitude: any(named: 'latitude'),
+            longitude: any(named: 'longitude'),
+            limit: any(named: 'limit'),
+            blockedPartnerIds: any(named: 'blockedPartnerIds'),
+            offset: any(named: 'offset'),
           ),
-        ],
-      );
+        ).thenAnswer(
+          (_) async => [
+            eventWithTickets,
+            eventWithoutTickets,
+            eventNullTickets,
+          ],
+        );
 
-      final result = await container.read(
-        eventFeedProvider(type: EventFeedType.newArrivals).future,
-      );
+        final container = createContainer(
+          overrides: [
+            eventRepositoryProvider.overrideWith((ref) => mockRepo),
+            currentUserProfileProvider.overrideWith(
+              (ref) async => const UserProfile(
+                id: 'user-1',
+                name: 'Test User',
+                username: 'testuser',
+              ),
+            ),
+          ],
+        );
 
-      expect(result, hasLength(3), reason: 'All events should be returned '
-          'regardless of ticket configuration');
-    });
+        final result = await container.read(
+          eventFeedProvider(type: EventFeedType.newArrivals).future,
+        );
+
+        expect(
+          result,
+          hasLength(3),
+          reason:
+              'All events should be returned '
+              'regardless of ticket configuration',
+        );
+      },
+    );
 
     test('returns events when user is not logged in', () async {
       final event = _createEvent(tickets: []);


### PR DESCRIPTION
## Summary
- Remove broken ticket filter in `eventFeed` provider that filtered out all events without tickets for logged-in users
- Free events and newly created events without ticket configurations were hidden, causing "추천 이벤트가 없습니다"
- Add 5 regression tests covering empty tickets, null tickets, mixed events, and logged-out user scenarios

Closes #778

## Test plan
- [x] `flutter analyze` passes with no issues
- [x] All 9 tests pass (3 existing + 5 new regression tests + 1 existing detail test)
- [ ] Verify on dev environment that logged-in users can see events without ticket configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)