### PR TITLE
feat: add user-delete-account edge function

### DIFF
--- a/supabase/functions/user-delete-account/deno.json
+++ b/supabase/functions/user-delete-account/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/user-delete-account/index.ts
+++ b/supabase/functions/user-delete-account/index.ts
@@ -1,0 +1,250 @@
+import { createServiceClient } from "../_shared/supabase_client.ts";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
+import { requireAuth } from "../_shared/auth_utils.ts";
+import { initSentry, log, withHandler, withSpan } from "../_shared/logger.ts";
+
+const FN = "user-delete-account";
+const GRACE_PERIOD_DAYS = 7;
+const ACTIVE_BOOKING_STATUSES = [
+  "pending",
+  "pending_review",
+  "approved",
+  "paid",
+  "payment_pending",
+];
+
+type DeleteAccountRequest = {
+  reason_code?: unknown;
+  reason_text?: unknown;
+};
+
+initSentry();
+
+async function parseRequestBody(
+  req: Request,
+): Promise<DeleteAccountRequest | Response> {
+  const raw = await req.text();
+  if (!raw.trim()) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(raw) as DeleteAccountRequest;
+  } catch {
+    return errorResponse("Invalid JSON body", 400);
+  }
+}
+
+Deno.serve(withHandler(async (req) => {
+  if (req.method === "OPTIONS") return corsResponse();
+  if (req.method !== "POST") return errorResponse("Method Not Allowed", 405);
+
+  const auth = await requireAuth(req);
+  if (auth instanceof Response) return auth;
+  const userId = auth;
+
+  try {
+    const body = await parseRequestBody(req);
+    if (body instanceof Response) return body;
+
+    const reasonCode = typeof body.reason_code === "string"
+      ? body.reason_code.trim()
+      : undefined;
+    const reasonText = typeof body.reason_text === "string"
+      ? body.reason_text.trim()
+      : undefined;
+
+    if (body.reason_code !== undefined && !reasonCode) {
+      return errorResponse("reason_code must be a non-empty string", 400);
+    }
+    if (
+      body.reason_text !== undefined && typeof body.reason_text !== "string"
+    ) {
+      return errorResponse("reason_text must be a string", 400);
+    }
+    if (reasonText && reasonText.length > 200) {
+      return errorResponse("reason_text must be 200 characters or fewer", 400);
+    }
+
+    const supabase = createServiceClient();
+    const now = new Date();
+    const nowIso = now.toISOString();
+    const gracePeriodEnds = new Date(
+      now.getTime() + GRACE_PERIOD_DAYS * 24 * 60 * 60 * 1000,
+    ).toISOString();
+
+    const { data: userProfiles, error: userError } = await withSpan(
+      "db.query.user_profiles",
+      "db.query",
+      () =>
+        supabase
+          .from("user_profiles")
+          .select("deleted_at")
+          .eq("id", userId)
+          .limit(1),
+    );
+
+    if (userError) {
+      log({
+        function: FN,
+        level: "error",
+        message: "Failed to load user profile",
+        metadata: { detail: userError, userId },
+      });
+      return errorResponse("Failed to load user profile", 500);
+    }
+
+    const userProfile = userProfiles?.[0] as
+      | { deleted_at?: string | null }
+      | undefined;
+    if (!userProfile) {
+      return errorResponse("User profile not found", 404);
+    }
+    if (userProfile.deleted_at) {
+      return errorResponse("Account deletion already pending", 409);
+    }
+
+    const { data: activeBookings, error: bookingError } = await withSpan(
+      "db.query.active_bookings",
+      "db.query",
+      () =>
+        supabase
+          .from("event_applications")
+          .select("id, events!inner(start_time, status)")
+          .eq("user_id", userId)
+          .in("status", ACTIVE_BOOKING_STATUSES)
+          .eq("events.status", "scheduled")
+          .gte("events.start_time", nowIso)
+          .limit(1),
+    );
+
+    if (bookingError) {
+      log({
+        function: FN,
+        level: "error",
+        message: "Failed to load active bookings",
+        metadata: { detail: bookingError, userId },
+      });
+      return errorResponse("Failed to verify active bookings", 500);
+    }
+    if ((activeBookings?.length ?? 0) > 0) {
+      return errorResponse(
+        "Active bookings must be cancelled before deleting account",
+        400,
+      );
+    }
+
+    const { data: pendingRefunds, error: refundError } = await withSpan(
+      "db.query.pending_refunds",
+      "db.query",
+      () =>
+        supabase
+          .from("event_applications")
+          .select("id")
+          .eq("user_id", userId)
+          .eq("refund_status", "requested")
+          .limit(1),
+    );
+
+    if (refundError) {
+      log({
+        function: FN,
+        level: "error",
+        message: "Failed to load unsettled refunds",
+        metadata: { detail: refundError, userId },
+      });
+      return errorResponse("Failed to verify unsettled balance", 500);
+    }
+    if ((pendingRefunds?.length ?? 0) > 0) {
+      return errorResponse(
+        "Unsettled balance must be resolved before deleting account",
+        400,
+      );
+    }
+
+    const { error: updateError } = await withSpan(
+      "db.update.user_profiles.deleted_at",
+      "db.update",
+      () =>
+        supabase
+          .from("user_profiles")
+          .update({
+            deleted_at: nowIso,
+            updated_at: nowIso,
+          })
+          .eq("id", userId)
+          .is("deleted_at", null),
+    );
+
+    if (updateError) {
+      log({
+        function: FN,
+        level: "error",
+        message: "Failed to mark account as deleted",
+        metadata: { detail: updateError, userId },
+      });
+      return errorResponse("Failed to delete account", 500);
+    }
+
+    if (reasonCode || reasonText) {
+      const { error: reasonError } = await withSpan(
+        "db.insert.withdrawal_reasons",
+        "db.insert",
+        () =>
+          supabase
+            .from("withdrawal_reasons")
+            .insert({
+              reason_code: reasonCode ?? "other",
+              reason_text: reasonText ?? null,
+            }),
+      );
+
+      if (reasonError) {
+        log({
+          function: FN,
+          level: "error",
+          message: "Failed to save withdrawal reason",
+          metadata: { detail: reasonError, userId },
+        });
+        return errorResponse("Failed to save withdrawal reason", 500);
+      }
+    }
+
+    const { error: tokenDeleteError } = await withSpan(
+      "db.delete.fcm_tokens",
+      "db.delete",
+      () =>
+        supabase
+          .from("fcm_tokens")
+          .delete()
+          .eq("user_id", userId),
+    );
+
+    if (tokenDeleteError) {
+      log({
+        function: FN,
+        level: "error",
+        message: "Failed to delete FCM tokens",
+        metadata: { detail: tokenDeleteError, userId },
+      });
+      return errorResponse("Failed to unsubscribe push notifications", 500);
+    }
+
+    return successResponse({
+      success: true,
+      grace_period_ends: gracePeriodEnds,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log({
+      function: FN,
+      level: "error",
+      message: `Error in ${FN}: ${message}`,
+    });
+    return errorResponse(message, 500);
+  }
+}));

--- a/supabase/functions/user-delete-account/user_delete_account_test.ts
+++ b/supabase/functions/user-delete-account/user_delete_account_test.ts
@@ -1,0 +1,308 @@
+import { assertEquals, assertExists } from "@std/assert";
+import {
+  authenticatedJsonRequest,
+  captureServeHandler,
+  createFetchMock,
+  jsonResponse,
+  readJson,
+  textRequest,
+  withEnv,
+  withMockedFetch,
+  withNoIntervals,
+} from "../_test_utils/mock_http.ts";
+import { authRoute } from "../_test_utils/fixtures.ts";
+
+const TEST_OPTS = { sanitizeOps: false, sanitizeResources: false };
+
+const ENV = {
+  SUPABASE_URL: "https://supabase.test",
+  SUPABASE_SERVICE_ROLE_KEY: "service-key",
+};
+
+function userProfileRoute(overrides?: { deleted_at?: string | null }) {
+  return {
+    matcher: (req: Request) =>
+      req.url.includes("/rest/v1/user_profiles") && req.method === "GET",
+    handler: () =>
+      jsonResponse([{
+        deleted_at: overrides?.deleted_at ?? null,
+      }]),
+  };
+}
+
+function activeBookingsRoute(hasBooking = false) {
+  return {
+    matcher: (req: Request) =>
+      decodeURIComponent(req.url).includes("/rest/v1/event_applications") &&
+      req.method === "GET" &&
+      decodeURIComponent(req.url).includes("events!inner"),
+    handler: () =>
+      jsonResponse(
+        hasBooking
+          ? [{
+            id: "app-123",
+            events: { start_time: "2099-01-01T00:00:00Z", status: "scheduled" },
+          }]
+          : [],
+      ),
+  };
+}
+
+function pendingRefundRoute(hasRefund = false) {
+  return {
+    matcher: (req: Request) =>
+      req.url.includes("/rest/v1/event_applications") &&
+      req.method === "GET" &&
+      req.url.includes("refund_status=eq.requested"),
+    handler: () => jsonResponse(hasRefund ? [{ id: "app-456" }] : []),
+  };
+}
+
+const updateUserProfileRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/user_profiles") && req.method === "PATCH",
+  handler: () => jsonResponse({}),
+};
+
+const insertWithdrawalReasonRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/withdrawal_reasons") && req.method === "POST",
+  handler: () => jsonResponse({}),
+};
+
+const deleteFcmTokensRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/fcm_tokens") && req.method === "DELETE",
+  handler: () => jsonResponse({}),
+};
+
+Deno.test("unauthorized request returns 401", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(
+    new URL("./index.ts", import.meta.url),
+  );
+  const { fetchMock } = createFetchMock([
+    {
+      matcher: "/auth/v1/user",
+      handler: () => jsonResponse({ error: "invalid" }, { status: 401 }),
+    },
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const response = await handler(
+          textRequest("http://localhost", "{}", { method: "POST" }),
+        );
+        assertEquals(response.status, 401);
+      });
+    });
+  });
+});
+
+Deno.test(
+  "successful deletion sets deleted_at, stores anonymous reason, and removes FCM tokens",
+  TEST_OPTS,
+  async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock, calls } = createFetchMock([
+      authRoute,
+      userProfileRoute(),
+      activeBookingsRoute(false),
+      pendingRefundRoute(false),
+      updateUserProfileRoute,
+      insertWithdrawalReasonRoute,
+      deleteFcmTokensRoute,
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const response = await handler(
+            authenticatedJsonRequest("http://localhost", {
+              reason_code: "privacy",
+              reason_text: "더 이상 사용하지 않아요",
+            }),
+          );
+          const payload = await readJson(response);
+
+          assertEquals(response.status, 200);
+          assertEquals(payload.success, true);
+          assertExists(payload.grace_period_ends);
+
+          const patchCall = calls.find(
+            (call) =>
+              call.url.includes("/rest/v1/user_profiles") &&
+              call.method === "PATCH",
+          );
+          assertExists(patchCall);
+          const patchBody = JSON.parse(patchCall.body!);
+          assertEquals(typeof patchBody.deleted_at, "string");
+
+          const reasonCall = calls.find(
+            (call) =>
+              call.url.includes("/rest/v1/withdrawal_reasons") &&
+              call.method === "POST",
+          );
+          assertExists(reasonCall);
+          const reasonBody = JSON.parse(reasonCall.body!);
+          assertEquals(reasonBody.reason_code, "privacy");
+          assertEquals(reasonBody.reason_text, "더 이상 사용하지 않아요");
+          assertEquals("user_id" in reasonBody, false);
+
+          const deleteCall = calls.find(
+            (call) =>
+              call.url.includes("/rest/v1/fcm_tokens") &&
+              call.method === "DELETE",
+          );
+          assertExists(deleteCall);
+        });
+      });
+    });
+  },
+);
+
+Deno.test("active future booking blocks deletion", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(
+    new URL("./index.ts", import.meta.url),
+  );
+  const { fetchMock, calls } = createFetchMock([
+    authRoute,
+    userProfileRoute(),
+    activeBookingsRoute(true),
+    pendingRefundRoute(false),
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const response = await handler(
+          authenticatedJsonRequest("http://localhost", {}),
+        );
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(
+          payload.error,
+          "Active bookings must be cancelled before deleting account",
+        );
+        assertEquals(
+          calls.some((call) =>
+            call.url.includes("/rest/v1/user_profiles") &&
+            call.method === "PATCH"
+          ),
+          false,
+        );
+      });
+    });
+  });
+});
+
+Deno.test(
+  "pending refund blocks deletion as unsettled balance",
+  TEST_OPTS,
+  async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock, calls } = createFetchMock([
+      authRoute,
+      userProfileRoute(),
+      activeBookingsRoute(false),
+      pendingRefundRoute(true),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const response = await handler(
+            authenticatedJsonRequest("http://localhost", {}),
+          );
+          const payload = await readJson(response);
+
+          assertEquals(response.status, 400);
+          assertEquals(
+            payload.error,
+            "Unsettled balance must be resolved before deleting account",
+          );
+          assertEquals(
+            calls.some((call) =>
+              call.url.includes("/rest/v1/user_profiles") &&
+              call.method === "PATCH"
+            ),
+            false,
+          );
+        });
+      });
+    });
+  },
+);
+
+Deno.test("already deleted user returns 409", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(
+    new URL("./index.ts", import.meta.url),
+  );
+  const { fetchMock, calls } = createFetchMock([
+    authRoute,
+    userProfileRoute({ deleted_at: "2026-03-30T00:00:00Z" }),
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const response = await handler(
+          authenticatedJsonRequest("http://localhost", {}),
+        );
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 409);
+        assertEquals(payload.error, "Account deletion already pending");
+        assertEquals(calls.length, 2);
+      });
+    });
+  });
+});
+
+Deno.test(
+  "reason_text without reason_code falls back to other",
+  TEST_OPTS,
+  async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock, calls } = createFetchMock([
+      authRoute,
+      userProfileRoute(),
+      activeBookingsRoute(false),
+      pendingRefundRoute(false),
+      updateUserProfileRoute,
+      insertWithdrawalReasonRoute,
+      deleteFcmTokensRoute,
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const response = await handler(
+            authenticatedJsonRequest("http://localhost", {
+              reason_text: "기타 사유",
+            }),
+          );
+
+          assertEquals(response.status, 200);
+
+          const reasonCall = calls.find(
+            (call) =>
+              call.url.includes("/rest/v1/withdrawal_reasons") &&
+              call.method === "POST",
+          );
+          assertExists(reasonCall);
+          const reasonBody = JSON.parse(reasonCall.body!);
+          assertEquals(reasonBody.reason_code, "other");
+          assertEquals(reasonBody.reason_text, "기타 사유");
+        });
+      });
+    });
+  },
+);


### PR DESCRIPTION
Scheduler: needs-dev-codex-1

## Summary
- add `user-delete-account` Edge Function with auth, soft-delete, anonymous withdrawal reason persistence, and FCM token cleanup
- block deletion when the user has active future bookings or pending refund settlement
- add Deno tests for success, auth failure, blocking conditions, duplicate requests, and anonymous reason fallback

## Testing
- `deno test --allow-all --config supabase/deno.json supabase/functions/user-delete-account/`

Closes #880