### PR TITLE
fix(ci): iOS deploy heredoc YAML 파싱 에러 수정

### DIFF
--- a/.github/actions/ios-deploy/action.yml
+++ b/.github/actions/ios-deploy/action.yml
@@ -195,12 +195,13 @@ runs:
         fi
 
         # Create xcconfig with correct settings
-        cat > ios/CI.xcconfig << EOF
-CODE_SIGN_STYLE = Manual
-CODE_SIGN_IDENTITY = Apple Distribution
-DEVELOPMENT_TEAM = ${{ inputs.development-team }}
-PROVISIONING_PROFILE_SPECIFIER = $PROFILE_SPECIFIER
-EOF
+        # Fix #901: heredoc content was parsed as YAML keys due to ':'
+        {
+          echo "CODE_SIGN_STYLE = Manual"
+          echo "CODE_SIGN_IDENTITY = Apple Distribution"
+          echo "DEVELOPMENT_TEAM = ${{ inputs.development-team }}"
+          echo "PROVISIONING_PROFILE_SPECIFIER = $PROFILE_SPECIFIER"
+        } > ios/CI.xcconfig
 
         # Include in Release.xcconfig
         echo '#include "../CI.xcconfig"' >> ios/Flutter/Release.xcconfig


### PR DESCRIPTION
Scheduler: needs-dev-claude-1

## Summary
- `.github/actions/ios-deploy/action.yml`의 shell heredoc을 `echo` 방식으로 교체
- heredoc 내 `CODE_SIGN_IDENTITY = Apple Distribution`의 `:`가 YAML 키로 파싱되어 4일간 iOS 배포 실패
- YAML lint 검증 통과 확인

## Test plan
- [ ] CI `ci-result` 통과
- [ ] iOS deploy 워크플로우 YAML 파싱 에러 해소 확인

Closes #901

🤖 Generated with [Claude Code](https://claude.com/claude-code)