### PR TITLE
feat(edge): add user-cancel-deletion function

### DIFF
--- a/supabase/functions/user-cancel-deletion/deno.json
+++ b/supabase/functions/user-cancel-deletion/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/user-cancel-deletion/index.ts
+++ b/supabase/functions/user-cancel-deletion/index.ts
@@ -1,0 +1,94 @@
+import { createServiceClient } from "../_shared/supabase_client.ts";
+import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
+import { requireAuth } from "../_shared/auth_utils.ts";
+import { initSentry, withHandler, withSpan, log } from "../_shared/logger.ts";
+
+const FN = "user-cancel-deletion";
+const DELETION_GRACE_PERIOD_MS = 7 * 24 * 60 * 60 * 1000;
+
+initSentry();
+
+Deno.serve(withHandler(async (req) => {
+  if (req.method === "OPTIONS") return corsResponse();
+  if (req.method !== "POST") return errorResponse("Method not allowed", 405);
+
+  const auth = await requireAuth(req);
+  if (auth instanceof Response) return auth;
+  const userId = auth;
+
+  try {
+    const supabase = createServiceClient();
+
+    const { data: profile, error: profileError } = await withSpan(
+      "db.query.user_profiles",
+      "db.query",
+      async () =>
+        await supabase
+          .from("user_profiles")
+          .select("deleted_at")
+          .eq("id", userId)
+          .single(),
+    );
+
+    if (profileError || !profile) {
+      log({
+        function: FN,
+        level: "error",
+        message: "Failed to fetch user profile",
+        metadata: { detail: profileError, userId },
+      });
+      return errorResponse("User profile not found", 404);
+    }
+
+    if (!profile.deleted_at) {
+      return errorResponse("탈퇴 진행 중인 계정이 아닙니다", 404);
+    }
+
+    const deletedAtMs = Date.parse(profile.deleted_at);
+    if (Number.isNaN(deletedAtMs)) {
+      log({
+        function: FN,
+        level: "error",
+        message: "Invalid deleted_at timestamp",
+        metadata: { deleted_at: profile.deleted_at, userId },
+      });
+      return errorResponse("Invalid deletion state", 500);
+    }
+
+    if (Date.now() - deletedAtMs >= DELETION_GRACE_PERIOD_MS) {
+      return errorResponse("탈퇴 유예 기간이 만료되었습니다", 400);
+    }
+
+    const { error: updateError } = await withSpan(
+      "db.update.user_profiles.restore",
+      "db.update",
+      async () =>
+        await supabase
+          .from("user_profiles")
+          .update({
+            deleted_at: null,
+          })
+          .eq("id", userId),
+    );
+
+    if (updateError) {
+      log({
+        function: FN,
+        level: "error",
+        message: "Failed to restore deleted account",
+        metadata: { detail: updateError, userId },
+      });
+      return errorResponse("Failed to cancel account deletion", 500);
+    }
+
+    return successResponse({ success: true });
+  } catch (error) {
+    log({
+      function: FN,
+      level: "error",
+      message: "Unhandled error in user-cancel-deletion",
+      metadata: { detail: error instanceof Error ? error.message : String(error), userId },
+    });
+    return errorResponse("Internal server error", 500);
+  }
+}));

--- a/supabase/functions/user-cancel-deletion/user-cancel-deletion_test.ts
+++ b/supabase/functions/user-cancel-deletion/user-cancel-deletion_test.ts
@@ -1,0 +1,128 @@
+import { assertEquals } from "@std/assert";
+import {
+  captureServeHandler,
+  authenticatedJsonRequest,
+  createFetchMock,
+  jsonResponse,
+  readJson,
+  withEnv,
+  withMockedFetch,
+  withNoIntervals,
+} from "../_test_utils/mock_http.ts";
+import { authRoute } from "../_test_utils/fixtures.ts";
+
+const TEST_OPTS = { sanitizeOps: false, sanitizeResources: false };
+
+const ENV = {
+  SUPABASE_URL: "https://supabase.test",
+  SUPABASE_SERVICE_ROLE_KEY: "service-key",
+};
+
+function profileRoute(deletedAt: string | null) {
+  return {
+    matcher: (req: Request) =>
+      req.url.includes("/rest/v1/user_profiles") && req.method === "GET",
+    handler: () => jsonResponse({ deleted_at: deletedAt }),
+  };
+}
+
+const restoreRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/user_profiles") && req.method === "PATCH",
+  handler: () => jsonResponse({}),
+};
+
+Deno.test("인증 없는 요청 → 401", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const response = await handler(new Request("http://localhost", { method: "POST" }));
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 401);
+        assertEquals(payload.error, "Missing or invalid Authorization header");
+      });
+    });
+  });
+});
+
+Deno.test("유예 기간 중 취소 → deleted_at 복구", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+  const deletedAt = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+
+  const { fetchMock, calls } = createFetchMock([
+    authRoute,
+    profileRoute(deletedAt),
+    restoreRoute,
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const response = await handler(authenticatedJsonRequest("http://localhost", {}));
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 200);
+        assertEquals(payload.success, true);
+
+        const restoreCall = calls.find(
+          (call) => call.url.includes("/rest/v1/user_profiles") && call.method === "PATCH",
+        );
+        assertEquals(restoreCall !== undefined, true);
+        assertEquals(JSON.parse(restoreCall!.body ?? "{}").deleted_at, null);
+      });
+    });
+  });
+});
+
+Deno.test("deleted_at 이 null인 유저 → 404", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const { fetchMock } = createFetchMock([
+    authRoute,
+    profileRoute(null),
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const response = await handler(authenticatedJsonRequest("http://localhost", {}));
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 404);
+        assertEquals(payload.error, "탈퇴 진행 중인 계정이 아닙니다");
+      });
+    });
+  });
+});
+
+Deno.test("유예 기간 초과 → 400", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+  const deletedAt = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+
+  const { fetchMock, calls } = createFetchMock([
+    authRoute,
+    profileRoute(deletedAt),
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const response = await handler(authenticatedJsonRequest("http://localhost", {}));
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "탈퇴 유예 기간이 만료되었습니다");
+
+        const restoreCall = calls.find(
+          (call) => call.url.includes("/rest/v1/user_profiles") && call.method === "PATCH",
+        );
+        assertEquals(restoreCall, undefined);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Scheduler: needs-dev-codex-1

## Summary
- add `user-cancel-deletion` Edge Function guarded by `requireAuth`
- restore `user_profiles.deleted_at` only within the 7-day grace period
- add Deno tests for unauthorized, restore success, no pending deletion, and grace-period expiry

## Verification
- `deno check --config supabase/deno.json supabase/functions/user-cancel-deletion/index.ts supabase/functions/user-cancel-deletion/user-cancel-deletion_test.ts`
- `deno test --allow-all --config supabase/deno.json supabase/functions/user-cancel-deletion/user-cancel-deletion_test.ts`

Closes #882
