### PR TITLE
feat: add account deletion cron workers

### DIFF
--- a/supabase/functions/cleanup-blocked-dis/cleanup-blocked-dis_test.ts
+++ b/supabase/functions/cleanup-blocked-dis/cleanup-blocked-dis_test.ts
@@ -1,0 +1,75 @@
+import { assertEquals } from "@std/assert";
+import {
+  captureServeHandler,
+  createFetchMock,
+  jsonResponse,
+  readJson,
+  textRequest,
+  withEnv,
+  withMockedFetch,
+  withNoIntervals,
+} from "../_test_utils/mock_http.ts";
+
+const TEST_OPTS = { sanitizeOps: false, sanitizeResources: false };
+
+const ENV = {
+  SUPABASE_URL: "https://supabase.test",
+  SUPABASE_SERVICE_ROLE_KEY: "service-key",
+};
+
+function serviceRoleRequest() {
+  return textRequest("http://localhost", "{}", {
+    method: "POST",
+    headers: { Authorization: "Bearer service-key" },
+  });
+}
+
+Deno.test("unauthorized request returns 401", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(
+    new URL("./index.ts", import.meta.url),
+  );
+
+  await withEnv(ENV, async () => {
+    await withNoIntervals(async () => {
+      const response = await handler(
+        textRequest("http://localhost", "{}", { method: "POST" }),
+      );
+      const payload = await readJson(response);
+
+      assertEquals(response.status, 401);
+      assertEquals(payload.error, "Unauthorized");
+    });
+  });
+});
+
+Deno.test("expired blocked_dis rows are deleted", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(
+    new URL("./index.ts", import.meta.url),
+  );
+  const { fetchMock, calls } = createFetchMock([{
+    matcher: (req: Request) =>
+      req.url.includes("/rest/v1/blocked_dis") && req.method === "DELETE",
+    handler: () =>
+      jsonResponse([{ di_hash: "expired-1" }, { di_hash: "expired-2" }]),
+  }]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const response = await handler(serviceRoleRequest());
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 200);
+        assertEquals(payload.success, true);
+        assertEquals(payload.deleted_count, 2);
+        assertEquals(
+          calls.some((call) =>
+            call.url.includes("/rest/v1/blocked_dis") &&
+            call.method === "DELETE"
+          ),
+          true,
+        );
+      });
+    });
+  });
+});

--- a/supabase/functions/cleanup-blocked-dis/deno.json
+++ b/supabase/functions/cleanup-blocked-dis/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/cleanup-blocked-dis/index.ts
+++ b/supabase/functions/cleanup-blocked-dis/index.ts
@@ -1,0 +1,74 @@
+import { createServiceClient } from "../_shared/supabase_client.ts";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
+import { initSentry, log, withHandler, withSpan } from "../_shared/logger.ts";
+
+const FN = "cleanup-blocked-dis";
+
+await initSentry();
+
+function requireServiceRole(req: Request): Response | null {
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+  const authHeader = req.headers.get("Authorization") ?? "";
+
+  if (!serviceRoleKey) {
+    return errorResponse("SUPABASE_SERVICE_ROLE_KEY not configured", 500);
+  }
+  if (authHeader !== `Bearer ${serviceRoleKey}`) {
+    return errorResponse("Unauthorized", 401);
+  }
+
+  return null;
+}
+
+Deno.serve(withHandler(async (req) => {
+  if (req.method === "OPTIONS") {
+    return corsResponse();
+  }
+  if (req.method !== "POST") {
+    return errorResponse("Method Not Allowed", 405);
+  }
+
+  const authError = requireServiceRole(req);
+  if (authError) {
+    return authError;
+  }
+
+  const supabase = createServiceClient();
+  const nowIso = new Date().toISOString();
+
+  try {
+    const { data, error } = await withSpan(
+      "db.delete.expired_blocked_dis",
+      "db.delete",
+      () =>
+        supabase
+          .from("blocked_dis")
+          .delete()
+          .lt("blocked_until", nowIso)
+          .select("di_hash"),
+    );
+
+    if (error) {
+      throw new Error(`Failed to cleanup blocked_dis: ${error.message}`);
+    }
+
+    return successResponse({
+      success: true,
+      deleted_count: data?.length ?? 0,
+      executed_at: nowIso,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log({
+      function: FN,
+      level: "error",
+      message: "Unhandled error in cleanup-blocked-dis",
+      metadata: { detail: message },
+    });
+    return errorResponse(message, 500);
+  }
+}));

--- a/supabase/functions/process-pending-deletions/deno.json
+++ b/supabase/functions/process-pending-deletions/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/process-pending-deletions/index.ts
+++ b/supabase/functions/process-pending-deletions/index.ts
@@ -1,0 +1,501 @@
+import { createServiceClient } from "../_shared/supabase_client.ts";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
+import { initSentry, log, withHandler, withSpan } from "../_shared/logger.ts";
+
+const FN = "process-pending-deletions";
+const DELETION_GRACE_DAYS = 7;
+const BLOCKED_DI_DAYS = 30;
+const CONTRACT_RETENTION_YEARS = 5;
+const PAYMENT_RETENTION_YEARS = 5;
+const DISPUTE_RETENTION_YEARS = 3;
+const LOGIN_RETENTION_MONTHS = 3;
+
+type PendingDeletionUser = {
+  id: string;
+  deleted_at: string;
+  di_hash: string | null;
+};
+
+type EventApplicationArchive = {
+  id: string;
+  event_id: string;
+  ticket_id: string;
+  status: string;
+  payment_id: string | null;
+  payment_amount: number | null;
+  refund_amount: number | null;
+  refund_status: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type ReportDetailArchive = {
+  id: string;
+  target_id: string;
+  target_type: string;
+  reason: string;
+  description: string | null;
+  created_at: string;
+};
+
+type ArchivedRecordInsert = {
+  user_id_hash: string;
+  record_type: "contract" | "payment" | "dispute" | "login";
+  record_data: Record<string, unknown>;
+  retention_until: string;
+};
+
+type UserResult = {
+  user_id: string;
+  success: boolean;
+  archived_records: number;
+  blocked_di: boolean;
+  error?: string;
+};
+
+await initSentry();
+
+function requireServiceRole(req: Request): Response | null {
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+  const authHeader = req.headers.get("Authorization") ?? "";
+
+  if (!serviceRoleKey) {
+    return errorResponse("SUPABASE_SERVICE_ROLE_KEY not configured", 500);
+  }
+  if (authHeader !== `Bearer ${serviceRoleKey}`) {
+    return errorResponse("Unauthorized", 401);
+  }
+
+  return null;
+}
+
+function addDays(date: Date, days: number): string {
+  return new Date(date.getTime() + days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function addYears(date: Date, years: number): string {
+  return new Date(
+    Date.UTC(
+      date.getUTCFullYear() + years,
+      date.getUTCMonth(),
+      date.getUTCDate(),
+      date.getUTCHours(),
+      date.getUTCMinutes(),
+      date.getUTCSeconds(),
+      date.getUTCMilliseconds(),
+    ),
+  ).toISOString();
+}
+
+function addMonths(date: Date, months: number): string {
+  return new Date(
+    Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth() + months,
+      date.getUTCDate(),
+      date.getUTCHours(),
+      date.getUTCMinutes(),
+      date.getUTCSeconds(),
+      date.getUTCMilliseconds(),
+    ),
+  ).toISOString();
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const input = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", input);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function loadPendingUsers(
+  cutoffIso: string,
+): Promise<PendingDeletionUser[]> {
+  const supabase = createServiceClient();
+  const { data, error } = await withSpan(
+    "db.query.pending_deletion_users",
+    "db.query",
+    () =>
+      supabase
+        .from("user_profiles")
+        .select("id, deleted_at, di_hash")
+        .not("deleted_at", "is", null)
+        .lte("deleted_at", cutoffIso),
+  );
+
+  if (error) {
+    throw new Error(`Failed to load pending deletions: ${error.message}`);
+  }
+
+  return (data ?? []) as PendingDeletionUser[];
+}
+
+async function loadEventApplications(
+  userId: string,
+): Promise<EventApplicationArchive[]> {
+  const supabase = createServiceClient();
+  const { data, error } = await withSpan(
+    "db.query.event_applications_for_archive",
+    "db.query",
+    () =>
+      supabase
+        .from("event_applications")
+        .select(
+          "id, event_id, ticket_id, status, payment_id, payment_amount, refund_amount, refund_status, created_at, updated_at",
+        )
+        .eq("user_id", userId),
+  );
+
+  if (error) {
+    throw new Error(`Failed to load event applications: ${error.message}`);
+  }
+
+  return (data ?? []) as EventApplicationArchive[];
+}
+
+async function loadReportDetails(
+  userId: string,
+): Promise<ReportDetailArchive[]> {
+  const supabase = createServiceClient();
+  const { data, error } = await withSpan(
+    "db.query.report_details_for_archive",
+    "db.query",
+    () =>
+      supabase
+        .from("report_details")
+        .select("id, target_id, target_type, reason, description, created_at")
+        .eq("user_id", userId),
+  );
+
+  if (error) {
+    throw new Error(`Failed to load report details: ${error.message}`);
+  }
+
+  return (data ?? []) as ReportDetailArchive[];
+}
+
+async function buildArchivedRecords(
+  user: PendingDeletionUser,
+  archivedRunId: string,
+  now: Date,
+): Promise<ArchivedRecordInsert[]> {
+  const userIdHash = await sha256Hex(user.id);
+  const eventApplications = await loadEventApplications(user.id);
+  const reportDetails = await loadReportDetails(user.id);
+  const supabase = createServiceClient();
+  const { data: authUserData, error: authUserError } = await withSpan(
+    "auth.admin.get_user_for_archive",
+    "auth.admin",
+    () => supabase.auth.admin.getUserById(user.id),
+  );
+
+  if (authUserError) {
+    throw new Error(`Failed to load auth user: ${authUserError.message}`);
+  }
+
+  const archivedRecords: ArchivedRecordInsert[] = [];
+  const contractRetention = addYears(now, CONTRACT_RETENTION_YEARS);
+  const paymentRetention = addYears(now, PAYMENT_RETENTION_YEARS);
+  const disputeRetention = addYears(now, DISPUTE_RETENTION_YEARS);
+  const loginRetention = addMonths(now, LOGIN_RETENTION_MONTHS);
+
+  for (const application of eventApplications) {
+    archivedRecords.push({
+      user_id_hash: userIdHash,
+      record_type: "contract",
+      record_data: {
+        archived_run_id: archivedRunId,
+        source_table: "event_applications",
+        application_id: application.id,
+        event_id: application.event_id,
+        ticket_id: application.ticket_id,
+        status: application.status,
+        created_at: application.created_at,
+        updated_at: application.updated_at,
+      },
+      retention_until: contractRetention,
+    });
+
+    if (
+      application.payment_id ||
+      application.payment_amount !== null ||
+      (application.refund_amount ?? 0) > 0
+    ) {
+      archivedRecords.push({
+        user_id_hash: userIdHash,
+        record_type: "payment",
+        record_data: {
+          archived_run_id: archivedRunId,
+          source_table: "event_applications",
+          application_id: application.id,
+          payment_id: application.payment_id,
+          payment_amount: application.payment_amount,
+          refund_amount: application.refund_amount,
+          refund_status: application.refund_status,
+          created_at: application.created_at,
+          updated_at: application.updated_at,
+        },
+        retention_until: paymentRetention,
+      });
+    }
+  }
+
+  for (const reportDetail of reportDetails) {
+    archivedRecords.push({
+      user_id_hash: userIdHash,
+      record_type: "dispute",
+      record_data: {
+        archived_run_id: archivedRunId,
+        source_table: "report_details",
+        report_id: reportDetail.id,
+        target_id: reportDetail.target_id,
+        target_type: reportDetail.target_type,
+        reason: reportDetail.reason,
+        description: reportDetail.description,
+        created_at: reportDetail.created_at,
+      },
+      retention_until: disputeRetention,
+    });
+  }
+
+  archivedRecords.push({
+    user_id_hash: userIdHash,
+    record_type: "login",
+    record_data: {
+      archived_run_id: archivedRunId,
+      source_table: "auth.users",
+      auth_user_id: user.id,
+      created_at: authUserData.user?.created_at ?? null,
+      last_sign_in_at: authUserData.user?.last_sign_in_at ?? null,
+      provider: authUserData.user?.app_metadata?.provider ?? null,
+      providers: authUserData.user?.app_metadata?.providers ?? [],
+      deleted_at: user.deleted_at,
+    },
+    retention_until: loginRetention,
+  });
+
+  return archivedRecords;
+}
+
+async function insertArchivedRecords(
+  records: ArchivedRecordInsert[],
+): Promise<number> {
+  if (records.length === 0) {
+    return 0;
+  }
+
+  const supabase = createServiceClient();
+  const { error } = await withSpan(
+    "db.insert.archived_records",
+    "db.insert",
+    () => supabase.from("archived_records").insert(records),
+  );
+
+  if (error) {
+    throw new Error(`Failed to archive records: ${error.message}`);
+  }
+
+  return records.length;
+}
+
+async function blockedDiExists(diHash: string): Promise<boolean> {
+  const supabase = createServiceClient();
+  const { data, error } = await withSpan(
+    "db.query.blocked_dis_existing",
+    "db.query",
+    () =>
+      supabase
+        .from("blocked_dis")
+        .select("di_hash")
+        .eq("di_hash", diHash)
+        .limit(1),
+  );
+
+  if (error) {
+    throw new Error(`Failed to check blocked_dis: ${error.message}`);
+  }
+
+  return (data?.length ?? 0) > 0;
+}
+
+async function upsertBlockedDi(diHash: string, blockedUntil: string) {
+  const supabase = createServiceClient();
+  const { error } = await withSpan(
+    "db.upsert.blocked_dis",
+    "db.upsert",
+    () =>
+      supabase
+        .from("blocked_dis")
+        .upsert({
+          di_hash: diHash,
+          blocked_until: blockedUntil,
+        }, { onConflict: "di_hash" }),
+  );
+
+  if (error) {
+    throw new Error(`Failed to block di_hash: ${error.message}`);
+  }
+}
+
+async function deleteAuthUser(userId: string) {
+  const supabase = createServiceClient();
+  const { error } = await withSpan(
+    "auth.admin.delete_user",
+    "auth.admin",
+    () => supabase.auth.admin.deleteUser(userId),
+  );
+
+  if (error) {
+    throw new Error(`Failed to delete auth user: ${error.message}`);
+  }
+}
+
+async function rollbackArchivedRecords(
+  userIdHash: string,
+  archivedRunId: string,
+) {
+  const supabase = createServiceClient();
+  const { error } = await withSpan(
+    "db.rollback.archived_records",
+    "db.delete",
+    () =>
+      supabase
+        .from("archived_records")
+        .delete()
+        .eq("user_id_hash", userIdHash)
+        .contains("record_data", { archived_run_id: archivedRunId }),
+  );
+
+  if (error) {
+    log({
+      function: FN,
+      level: "error",
+      message: "Failed to rollback archived records after delete failure",
+      metadata: { userIdHash, archivedRunId, detail: error },
+    });
+  }
+}
+
+async function rollbackBlockedDi(diHash: string) {
+  const supabase = createServiceClient();
+  const { error } = await withSpan(
+    "db.rollback.blocked_dis",
+    "db.delete",
+    () =>
+      supabase
+        .from("blocked_dis")
+        .delete()
+        .eq("di_hash", diHash),
+  );
+
+  if (error) {
+    log({
+      function: FN,
+      level: "error",
+      message: "Failed to rollback blocked_di after delete failure",
+      metadata: { diHash, detail: error },
+    });
+  }
+}
+
+Deno.serve(withHandler(async (req) => {
+  if (req.method === "OPTIONS") {
+    return corsResponse();
+  }
+  if (req.method !== "POST") {
+    return errorResponse("Method Not Allowed", 405);
+  }
+
+  const authError = requireServiceRole(req);
+  if (authError) {
+    return authError;
+  }
+
+  const now = new Date();
+  const cutoffIso = addDays(now, -DELETION_GRACE_DAYS);
+  const blockedUntil = addDays(now, BLOCKED_DI_DAYS);
+  const archivedRunId = crypto.randomUUID();
+
+  try {
+    const users = await loadPendingUsers(cutoffIso);
+    const results: UserResult[] = [];
+    let archivedRecordCount = 0;
+    let blockedCount = 0;
+    let deletedCount = 0;
+
+    for (const user of users) {
+      const userIdHash = await sha256Hex(user.id);
+      let shouldRollbackBlockedDi = false;
+
+      try {
+        if (!user.di_hash) {
+          throw new Error("Missing di_hash for deleted user");
+        }
+
+        const records = await buildArchivedRecords(user, archivedRunId, now);
+        const archivedRecords = await insertArchivedRecords(records);
+        const blockedAlreadyExisted = await blockedDiExists(user.di_hash);
+
+        await upsertBlockedDi(user.di_hash, blockedUntil);
+        shouldRollbackBlockedDi = !blockedAlreadyExisted;
+        await deleteAuthUser(user.id);
+
+        archivedRecordCount += archivedRecords;
+        if (!blockedAlreadyExisted) {
+          blockedCount += 1;
+        }
+        deletedCount += 1;
+        results.push({
+          user_id: user.id,
+          success: true,
+          archived_records: archivedRecords,
+          blocked_di: true,
+        });
+      } catch (error) {
+        if (user.di_hash && shouldRollbackBlockedDi) {
+          await rollbackBlockedDi(user.di_hash);
+        }
+        await rollbackArchivedRecords(userIdHash, archivedRunId);
+
+        const message = error instanceof Error ? error.message : String(error);
+        log({
+          function: FN,
+          level: "error",
+          message: "Failed to process pending deletion user",
+          metadata: { userId: user.id, detail: message },
+        });
+        results.push({
+          user_id: user.id,
+          success: false,
+          archived_records: 0,
+          blocked_di: false,
+          error: message,
+        });
+      }
+    }
+
+    return successResponse({
+      success: true,
+      processed_count: users.length,
+      deleted_count: deletedCount,
+      blocked_count: blockedCount,
+      archived_record_count: archivedRecordCount,
+      failed_count: results.filter((result) => !result.success).length,
+      results,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log({
+      function: FN,
+      level: "error",
+      message: "Unhandled error in process-pending-deletions",
+      metadata: { detail: message },
+    });
+    return errorResponse(message, 500);
+  }
+}));

--- a/supabase/functions/process-pending-deletions/process-pending-deletions_test.ts
+++ b/supabase/functions/process-pending-deletions/process-pending-deletions_test.ts
@@ -1,0 +1,221 @@
+import { assertEquals, assertExists } from "@std/assert";
+import {
+  captureServeHandler,
+  createFetchMock,
+  jsonResponse,
+  readJson,
+  textRequest,
+  withEnv,
+  withMockedFetch,
+  withNoIntervals,
+} from "../_test_utils/mock_http.ts";
+
+const TEST_OPTS = { sanitizeOps: false, sanitizeResources: false };
+
+const ENV = {
+  SUPABASE_URL: "https://supabase.test",
+  SUPABASE_SERVICE_ROLE_KEY: "service-key",
+};
+
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+
+function serviceRoleRequest() {
+  return textRequest("http://localhost", "{}", {
+    method: "POST",
+    headers: { Authorization: "Bearer service-key" },
+  });
+}
+
+function pendingUsersRoute(users: Array<Record<string, unknown>>) {
+  return {
+    matcher: (req: Request) =>
+      req.url.includes("/rest/v1/user_profiles") && req.method === "GET",
+    handler: () => jsonResponse(users),
+  };
+}
+
+const eventApplicationsRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/event_applications") && req.method === "GET",
+  handler: () =>
+    jsonResponse([{
+      id: "app-1",
+      event_id: "event-1",
+      ticket_id: "ticket-1",
+      status: "paid",
+      payment_id: "payment-1",
+      payment_amount: 50000,
+      refund_amount: 0,
+      refund_status: "none",
+      created_at: "2026-03-01T00:00:00Z",
+      updated_at: "2026-03-02T00:00:00Z",
+    }]),
+};
+
+const reportDetailsRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/report_details") && req.method === "GET",
+  handler: () =>
+    jsonResponse([{
+      id: "report-1",
+      target_id: "target-1",
+      target_type: "partner",
+      reason: "refund-delay",
+      description: "환불이 지연되었어요",
+      created_at: "2026-03-05T00:00:00Z",
+    }]),
+};
+
+const authAdminGetUserRoute = {
+  matcher: (req: Request) =>
+    req.url.includes(`/auth/v1/admin/users/${USER_ID}`) && req.method === "GET",
+  handler: () =>
+    jsonResponse({
+      user: {
+        id: USER_ID,
+        created_at: "2026-01-01T00:00:00Z",
+        last_sign_in_at: "2026-03-20T12:00:00Z",
+        app_metadata: {
+          provider: "email",
+          providers: ["email"],
+        },
+      },
+    }),
+};
+
+const blockedDisCheckRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/blocked_dis") && req.method === "GET",
+  handler: () => jsonResponse([]),
+};
+
+const archiveInsertRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/archived_records") && req.method === "POST",
+  handler: () => jsonResponse({}),
+};
+
+const blockedDisUpsertRoute = {
+  matcher: (req: Request) =>
+    req.url.includes("/rest/v1/blocked_dis") && req.method === "POST",
+  handler: () => jsonResponse({}),
+};
+
+const authDeleteRoute = {
+  matcher: (req: Request) =>
+    req.url.includes(`/auth/v1/admin/users/${USER_ID}`) &&
+    req.method === "DELETE",
+  handler: () => jsonResponse({ user: { id: USER_ID } }),
+};
+
+Deno.test("unauthorized request returns 401", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(
+    new URL("./index.ts", import.meta.url),
+  );
+
+  await withEnv(ENV, async () => {
+    await withNoIntervals(async () => {
+      const response = await handler(
+        textRequest("http://localhost", "{}", { method: "POST" }),
+      );
+      const payload = await readJson(response);
+
+      assertEquals(response.status, 401);
+      assertEquals(payload.error, "Unauthorized");
+    });
+  });
+});
+
+Deno.test(
+  "successful run archives records, blocks DI, and deletes auth user",
+  TEST_OPTS,
+  async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock, calls } = createFetchMock([
+      pendingUsersRoute([{
+        id: USER_ID,
+        deleted_at: "2026-03-21T00:00:00Z",
+        di_hash: "di-hash-1",
+      }]),
+      eventApplicationsRoute,
+      reportDetailsRoute,
+      authAdminGetUserRoute,
+      blockedDisCheckRoute,
+      archiveInsertRoute,
+      blockedDisUpsertRoute,
+      authDeleteRoute,
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const response = await handler(serviceRoleRequest());
+          const payload = await readJson(response);
+
+          assertEquals(response.status, 200);
+          assertEquals(payload.success, true);
+          assertEquals(payload.processed_count, 1);
+          assertEquals(payload.deleted_count, 1);
+          assertEquals(payload.blocked_count, 1);
+          assertEquals(payload.failed_count, 0);
+          assertEquals(payload.archived_record_count, 4);
+
+          const archiveCall = calls.find((call) =>
+            call.url.includes("/rest/v1/archived_records") &&
+            call.method === "POST"
+          );
+          assertExists(archiveCall);
+          const archivedBody = JSON.parse(archiveCall!.body ?? "[]");
+          assertEquals(archivedBody.length, 4);
+          assertEquals(
+            archivedBody.some((row: { record_type: string }) =>
+              row.record_type === "login"
+            ),
+            true,
+          );
+
+          const blockedCall = calls.find((call) =>
+            call.url.includes("/rest/v1/blocked_dis") && call.method === "POST"
+          );
+          assertExists(blockedCall);
+          const blockedBody = JSON.parse(blockedCall!.body ?? "{}");
+          assertEquals(blockedBody.di_hash, "di-hash-1");
+
+          assertEquals(
+            calls.some((call) =>
+              call.url.includes(`/auth/v1/admin/users/${USER_ID}`) &&
+              call.method === "DELETE"
+            ),
+            true,
+          );
+        });
+      });
+    });
+  },
+);
+
+Deno.test("no eligible users returns zero summary", TEST_OPTS, async () => {
+  const handler = await captureServeHandler(
+    new URL("./index.ts", import.meta.url),
+  );
+  const { fetchMock, calls } = createFetchMock([
+    pendingUsersRoute([]),
+  ]);
+
+  await withEnv(ENV, async () => {
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const response = await handler(serviceRoleRequest());
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 200);
+        assertEquals(payload.processed_count, 0);
+        assertEquals(payload.deleted_count, 0);
+        assertEquals(payload.failed_count, 0);
+        assertEquals(calls.length, 1);
+      });
+    });
+  });
+});

--- a/supabase/migrations/20260330000006_account_deletion_crons.sql
+++ b/supabase/migrations/20260330000006_account_deletion_crons.sql
@@ -1,0 +1,64 @@
+-- Account deletion cron jobs:
+-- 1. Process soft-deleted users after the 7-day grace period.
+-- 2. Remove expired DI re-signup blocks.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM vault.decrypted_secrets WHERE name = 'service_role_key'
+  ) THEN
+    RAISE WARNING 'vault secret "service_role_key" not found — account deletion cron jobs will fail until it is configured';
+  END IF;
+END $$;
+
+SELECT cron.unschedule(jobid)
+FROM cron.job
+WHERE jobname IN ('process-pending-deletions', 'cleanup-blocked-dis');
+
+-- Process pending deletions: daily 09:00 KST (00:00 UTC)
+SELECT cron.schedule(
+  'process-pending-deletions',
+  '0 0 * * *',
+  $$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret FROM vault.decrypted_secrets
+        WHERE name = 'supabase_url' LIMIT 1
+      ) || '/functions/v1/process-pending-deletions',
+      headers := (
+        jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (
+            SELECT decrypted_secret FROM vault.decrypted_secrets
+            WHERE name = 'service_role_key' LIMIT 1
+          )
+        )
+      ),
+      body := '{}'::jsonb
+    ) AS request_id;
+  $$
+);
+
+-- Cleanup blocked DI rows: daily 10:00 KST (01:00 UTC)
+SELECT cron.schedule(
+  'cleanup-blocked-dis',
+  '0 1 * * *',
+  $$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret FROM vault.decrypted_secrets
+        WHERE name = 'supabase_url' LIMIT 1
+      ) || '/functions/v1/cleanup-blocked-dis',
+      headers := (
+        jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (
+            SELECT decrypted_secret FROM vault.decrypted_secrets
+            WHERE name = 'service_role_key' LIMIT 1
+          )
+        )
+      ),
+      body := '{}'::jsonb
+    ) AS request_id;
+  $$
+);


### PR DESCRIPTION
Scheduler: needs-dev-codex-1

## Summary
- add `process-pending-deletions` edge function to archive legally retained records, block DI hashes, and delete expired soft-deleted users
- add `cleanup-blocked-dis` edge function to purge expired DI blocks
- register both daily cron jobs in a new migration and cover the new functions with Deno tests

## Verification
- `deno test --config supabase/deno.json --allow-all supabase/functions/process-pending-deletions/ supabase/functions/cleanup-blocked-dis/`

Closes #884