### PR TITLE
feat(minglit_kit): add account deletion shared layer

### DIFF
--- a/shared/packages/minglit_kit/lib/minglit_data.dart
+++ b/shared/packages/minglit_kit/lib/minglit_data.dart
@@ -5,6 +5,7 @@ export 'package:supabase_flutter/supabase_flutter.dart'
 // Config
 export 'src/config/iamport_config.dart';
 // Models
+export 'src/data/models/deletion_status.dart';
 export 'src/data/models/event.dart';
 export 'src/data/models/event_application.dart';
 export 'src/data/models/event_feed_type.dart';
@@ -27,7 +28,9 @@ export 'src/data/models/user_profile.dart';
 export 'src/data/models/user_settings.dart';
 export 'src/data/models/verification.dart';
 export 'src/data/models/verification_submission.dart';
+export 'src/data/models/withdrawal_reason.dart';
 // Repositories
+export 'src/data/repositories/account_repository.dart';
 export 'src/data/repositories/auth_repository.dart';
 export 'src/data/repositories/bug_report_repository.dart';
 export 'src/data/repositories/checkin_repository.dart';

--- a/shared/packages/minglit_kit/lib/minglit_logic.dart
+++ b/shared/packages/minglit_kit/lib/minglit_logic.dart
@@ -3,6 +3,7 @@ export 'package:flutter_riverpod/flutter_riverpod.dart';
 
 // Providers
 
+export 'src/features/account_deletion/logic/account_deletion_controller.dart';
 export 'src/features/auth/logic/auth_controller.dart';
 export 'src/features/consent/logic/consent_controller.dart';
 export 'src/features/notification/logic/notification_settings_controller.dart';

--- a/shared/packages/minglit_kit/lib/src/data/models/deletion_status.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/deletion_status.dart
@@ -1,0 +1,30 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'deletion_status.freezed.dart';
+part 'deletion_status.g.dart';
+
+const _gracePeriod = Duration(days: 7);
+
+/// The current account deletion state for the signed-in user.
+@freezed
+abstract class DeletionStatus with _$DeletionStatus {
+  /// Creates a [DeletionStatus].
+  const factory DeletionStatus({
+    @JsonKey(name: 'deleted_at') DateTime? deletedAt,
+    @JsonKey(name: 'grace_period_ends') DateTime? gracePeriodEnds,
+    @Default(false) bool isPending,
+  }) = _DeletionStatus;
+
+  /// Creates a [DeletionStatus] from JSON.
+  factory DeletionStatus.fromJson(Map<String, dynamic> json) =>
+      _$DeletionStatusFromJson(json);
+
+  /// Creates a pending/non-pending status from the `deleted_at` column.
+  factory DeletionStatus.fromDeletedAt(DateTime? deletedAt) {
+    return DeletionStatus(
+      deletedAt: deletedAt,
+      gracePeriodEnds: deletedAt?.add(_gracePeriod),
+      isPending: deletedAt != null,
+    );
+  }
+}

--- a/shared/packages/minglit_kit/lib/src/data/models/deletion_status.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/deletion_status.freezed.dart
@@ -1,0 +1,283 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'deletion_status.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$DeletionStatus {
+
+@JsonKey(name: 'deleted_at') DateTime? get deletedAt;@JsonKey(name: 'grace_period_ends') DateTime? get gracePeriodEnds; bool get isPending;
+/// Create a copy of DeletionStatus
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$DeletionStatusCopyWith<DeletionStatus> get copyWith => _$DeletionStatusCopyWithImpl<DeletionStatus>(this as DeletionStatus, _$identity);
+
+  /// Serializes this DeletionStatus to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DeletionStatus&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.gracePeriodEnds, gracePeriodEnds) || other.gracePeriodEnds == gracePeriodEnds)&&(identical(other.isPending, isPending) || other.isPending == isPending));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,deletedAt,gracePeriodEnds,isPending);
+
+@override
+String toString() {
+  return 'DeletionStatus(deletedAt: $deletedAt, gracePeriodEnds: $gracePeriodEnds, isPending: $isPending)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $DeletionStatusCopyWith<$Res>  {
+  factory $DeletionStatusCopyWith(DeletionStatus value, $Res Function(DeletionStatus) _then) = _$DeletionStatusCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'deleted_at') DateTime? deletedAt,@JsonKey(name: 'grace_period_ends') DateTime? gracePeriodEnds, bool isPending
+});
+
+
+
+
+}
+/// @nodoc
+class _$DeletionStatusCopyWithImpl<$Res>
+    implements $DeletionStatusCopyWith<$Res> {
+  _$DeletionStatusCopyWithImpl(this._self, this._then);
+
+  final DeletionStatus _self;
+  final $Res Function(DeletionStatus) _then;
+
+/// Create a copy of DeletionStatus
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? deletedAt = freezed,Object? gracePeriodEnds = freezed,Object? isPending = null,}) {
+  return _then(_self.copyWith(
+deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,gracePeriodEnds: freezed == gracePeriodEnds ? _self.gracePeriodEnds : gracePeriodEnds // ignore: cast_nullable_to_non_nullable
+as DateTime?,isPending: null == isPending ? _self.isPending : isPending // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [DeletionStatus].
+extension DeletionStatusPatterns on DeletionStatus {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _DeletionStatus value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _DeletionStatus() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _DeletionStatus value)  $default,){
+final _that = this;
+switch (_that) {
+case _DeletionStatus():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _DeletionStatus value)?  $default,){
+final _that = this;
+switch (_that) {
+case _DeletionStatus() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'deleted_at')  DateTime? deletedAt, @JsonKey(name: 'grace_period_ends')  DateTime? gracePeriodEnds,  bool isPending)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _DeletionStatus() when $default != null:
+return $default(_that.deletedAt,_that.gracePeriodEnds,_that.isPending);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'deleted_at')  DateTime? deletedAt, @JsonKey(name: 'grace_period_ends')  DateTime? gracePeriodEnds,  bool isPending)  $default,) {final _that = this;
+switch (_that) {
+case _DeletionStatus():
+return $default(_that.deletedAt,_that.gracePeriodEnds,_that.isPending);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'deleted_at')  DateTime? deletedAt, @JsonKey(name: 'grace_period_ends')  DateTime? gracePeriodEnds,  bool isPending)?  $default,) {final _that = this;
+switch (_that) {
+case _DeletionStatus() when $default != null:
+return $default(_that.deletedAt,_that.gracePeriodEnds,_that.isPending);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _DeletionStatus implements DeletionStatus {
+  const _DeletionStatus({@JsonKey(name: 'deleted_at') this.deletedAt, @JsonKey(name: 'grace_period_ends') this.gracePeriodEnds, this.isPending = false});
+  factory _DeletionStatus.fromJson(Map<String, dynamic> json) => _$DeletionStatusFromJson(json);
+
+@override@JsonKey(name: 'deleted_at') final  DateTime? deletedAt;
+@override@JsonKey(name: 'grace_period_ends') final  DateTime? gracePeriodEnds;
+@override@JsonKey() final  bool isPending;
+
+/// Create a copy of DeletionStatus
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$DeletionStatusCopyWith<_DeletionStatus> get copyWith => __$DeletionStatusCopyWithImpl<_DeletionStatus>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$DeletionStatusToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _DeletionStatus&&(identical(other.deletedAt, deletedAt) || other.deletedAt == deletedAt)&&(identical(other.gracePeriodEnds, gracePeriodEnds) || other.gracePeriodEnds == gracePeriodEnds)&&(identical(other.isPending, isPending) || other.isPending == isPending));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,deletedAt,gracePeriodEnds,isPending);
+
+@override
+String toString() {
+  return 'DeletionStatus(deletedAt: $deletedAt, gracePeriodEnds: $gracePeriodEnds, isPending: $isPending)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$DeletionStatusCopyWith<$Res> implements $DeletionStatusCopyWith<$Res> {
+  factory _$DeletionStatusCopyWith(_DeletionStatus value, $Res Function(_DeletionStatus) _then) = __$DeletionStatusCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'deleted_at') DateTime? deletedAt,@JsonKey(name: 'grace_period_ends') DateTime? gracePeriodEnds, bool isPending
+});
+
+
+
+
+}
+/// @nodoc
+class __$DeletionStatusCopyWithImpl<$Res>
+    implements _$DeletionStatusCopyWith<$Res> {
+  __$DeletionStatusCopyWithImpl(this._self, this._then);
+
+  final _DeletionStatus _self;
+  final $Res Function(_DeletionStatus) _then;
+
+/// Create a copy of DeletionStatus
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? deletedAt = freezed,Object? gracePeriodEnds = freezed,Object? isPending = null,}) {
+  return _then(_DeletionStatus(
+deletedAt: freezed == deletedAt ? _self.deletedAt : deletedAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,gracePeriodEnds: freezed == gracePeriodEnds ? _self.gracePeriodEnds : gracePeriodEnds // ignore: cast_nullable_to_non_nullable
+as DateTime?,isPending: null == isPending ? _self.isPending : isPending // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/deletion_status.g.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/deletion_status.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'deletion_status.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_DeletionStatus _$DeletionStatusFromJson(Map<String, dynamic> json) =>
+    _DeletionStatus(
+      deletedAt: json['deleted_at'] == null
+          ? null
+          : DateTime.parse(json['deleted_at'] as String),
+      gracePeriodEnds: json['grace_period_ends'] == null
+          ? null
+          : DateTime.parse(json['grace_period_ends'] as String),
+      isPending: json['isPending'] as bool? ?? false,
+    );
+
+Map<String, dynamic> _$DeletionStatusToJson(_DeletionStatus instance) =>
+    <String, dynamic>{
+      'deleted_at': instance.deletedAt?.toIso8601String(),
+      'grace_period_ends': instance.gracePeriodEnds?.toIso8601String(),
+      'isPending': instance.isPending,
+    };

--- a/shared/packages/minglit_kit/lib/src/data/models/withdrawal_reason.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/withdrawal_reason.dart
@@ -1,0 +1,45 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'withdrawal_reason.freezed.dart';
+part 'withdrawal_reason.g.dart';
+
+/// Anonymous reason codes stored for account deletion analytics.
+enum WithdrawalReasonCode {
+  /// The user no longer needs Minglit.
+  @JsonValue('no_longer_use')
+  noLongerUse,
+
+  /// The user could not find desired events.
+  @JsonValue('no_desired_events')
+  noDesiredEvents,
+
+  /// The user is using another service instead.
+  @JsonValue('using_other_service')
+  usingOtherService,
+
+  /// The user is concerned about privacy.
+  @JsonValue('privacy_concern')
+  privacyConcern,
+
+  /// The user found the app difficult to use.
+  @JsonValue('poor_usability')
+  poorUsability,
+
+  /// A custom free-text reason.
+  @JsonValue('other')
+  other,
+}
+
+/// Optional anonymous withdrawal reason payload.
+@freezed
+abstract class WithdrawalReason with _$WithdrawalReason {
+  /// Creates a [WithdrawalReason].
+  const factory WithdrawalReason({
+    @JsonKey(name: 'reason_code') required WithdrawalReasonCode reasonCode,
+    @JsonKey(name: 'reason_text') String? detail,
+  }) = _WithdrawalReason;
+
+  /// Creates a [WithdrawalReason] from JSON.
+  factory WithdrawalReason.fromJson(Map<String, dynamic> json) =>
+      _$WithdrawalReasonFromJson(json);
+}

--- a/shared/packages/minglit_kit/lib/src/data/models/withdrawal_reason.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/withdrawal_reason.freezed.dart
@@ -1,0 +1,280 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'withdrawal_reason.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$WithdrawalReason {
+
+@JsonKey(name: 'reason_code') WithdrawalReasonCode get reasonCode;@JsonKey(name: 'reason_text') String? get detail;
+/// Create a copy of WithdrawalReason
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$WithdrawalReasonCopyWith<WithdrawalReason> get copyWith => _$WithdrawalReasonCopyWithImpl<WithdrawalReason>(this as WithdrawalReason, _$identity);
+
+  /// Serializes this WithdrawalReason to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is WithdrawalReason&&(identical(other.reasonCode, reasonCode) || other.reasonCode == reasonCode)&&(identical(other.detail, detail) || other.detail == detail));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,reasonCode,detail);
+
+@override
+String toString() {
+  return 'WithdrawalReason(reasonCode: $reasonCode, detail: $detail)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $WithdrawalReasonCopyWith<$Res>  {
+  factory $WithdrawalReasonCopyWith(WithdrawalReason value, $Res Function(WithdrawalReason) _then) = _$WithdrawalReasonCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: 'reason_code') WithdrawalReasonCode reasonCode,@JsonKey(name: 'reason_text') String? detail
+});
+
+
+
+
+}
+/// @nodoc
+class _$WithdrawalReasonCopyWithImpl<$Res>
+    implements $WithdrawalReasonCopyWith<$Res> {
+  _$WithdrawalReasonCopyWithImpl(this._self, this._then);
+
+  final WithdrawalReason _self;
+  final $Res Function(WithdrawalReason) _then;
+
+/// Create a copy of WithdrawalReason
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? reasonCode = null,Object? detail = freezed,}) {
+  return _then(_self.copyWith(
+reasonCode: null == reasonCode ? _self.reasonCode : reasonCode // ignore: cast_nullable_to_non_nullable
+as WithdrawalReasonCode,detail: freezed == detail ? _self.detail : detail // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [WithdrawalReason].
+extension WithdrawalReasonPatterns on WithdrawalReason {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _WithdrawalReason value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _WithdrawalReason() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _WithdrawalReason value)  $default,){
+final _that = this;
+switch (_that) {
+case _WithdrawalReason():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _WithdrawalReason value)?  $default,){
+final _that = this;
+switch (_that) {
+case _WithdrawalReason() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'reason_code')  WithdrawalReasonCode reasonCode, @JsonKey(name: 'reason_text')  String? detail)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _WithdrawalReason() when $default != null:
+return $default(_that.reasonCode,_that.detail);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'reason_code')  WithdrawalReasonCode reasonCode, @JsonKey(name: 'reason_text')  String? detail)  $default,) {final _that = this;
+switch (_that) {
+case _WithdrawalReason():
+return $default(_that.reasonCode,_that.detail);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'reason_code')  WithdrawalReasonCode reasonCode, @JsonKey(name: 'reason_text')  String? detail)?  $default,) {final _that = this;
+switch (_that) {
+case _WithdrawalReason() when $default != null:
+return $default(_that.reasonCode,_that.detail);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _WithdrawalReason implements WithdrawalReason {
+  const _WithdrawalReason({@JsonKey(name: 'reason_code') required this.reasonCode, @JsonKey(name: 'reason_text') this.detail});
+  factory _WithdrawalReason.fromJson(Map<String, dynamic> json) => _$WithdrawalReasonFromJson(json);
+
+@override@JsonKey(name: 'reason_code') final  WithdrawalReasonCode reasonCode;
+@override@JsonKey(name: 'reason_text') final  String? detail;
+
+/// Create a copy of WithdrawalReason
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$WithdrawalReasonCopyWith<_WithdrawalReason> get copyWith => __$WithdrawalReasonCopyWithImpl<_WithdrawalReason>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$WithdrawalReasonToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _WithdrawalReason&&(identical(other.reasonCode, reasonCode) || other.reasonCode == reasonCode)&&(identical(other.detail, detail) || other.detail == detail));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,reasonCode,detail);
+
+@override
+String toString() {
+  return 'WithdrawalReason(reasonCode: $reasonCode, detail: $detail)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$WithdrawalReasonCopyWith<$Res> implements $WithdrawalReasonCopyWith<$Res> {
+  factory _$WithdrawalReasonCopyWith(_WithdrawalReason value, $Res Function(_WithdrawalReason) _then) = __$WithdrawalReasonCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: 'reason_code') WithdrawalReasonCode reasonCode,@JsonKey(name: 'reason_text') String? detail
+});
+
+
+
+
+}
+/// @nodoc
+class __$WithdrawalReasonCopyWithImpl<$Res>
+    implements _$WithdrawalReasonCopyWith<$Res> {
+  __$WithdrawalReasonCopyWithImpl(this._self, this._then);
+
+  final _WithdrawalReason _self;
+  final $Res Function(_WithdrawalReason) _then;
+
+/// Create a copy of WithdrawalReason
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? reasonCode = null,Object? detail = freezed,}) {
+  return _then(_WithdrawalReason(
+reasonCode: null == reasonCode ? _self.reasonCode : reasonCode // ignore: cast_nullable_to_non_nullable
+as WithdrawalReasonCode,detail: freezed == detail ? _self.detail : detail // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/shared/packages/minglit_kit/lib/src/data/models/withdrawal_reason.g.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/withdrawal_reason.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'withdrawal_reason.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_WithdrawalReason _$WithdrawalReasonFromJson(Map<String, dynamic> json) =>
+    _WithdrawalReason(
+      reasonCode: $enumDecode(
+        _$WithdrawalReasonCodeEnumMap,
+        json['reason_code'],
+      ),
+      detail: json['reason_text'] as String?,
+    );
+
+Map<String, dynamic> _$WithdrawalReasonToJson(_WithdrawalReason instance) =>
+    <String, dynamic>{
+      'reason_code': _$WithdrawalReasonCodeEnumMap[instance.reasonCode]!,
+      'reason_text': instance.detail,
+    };
+
+const _$WithdrawalReasonCodeEnumMap = {
+  WithdrawalReasonCode.noLongerUse: 'no_longer_use',
+  WithdrawalReasonCode.noDesiredEvents: 'no_desired_events',
+  WithdrawalReasonCode.usingOtherService: 'using_other_service',
+  WithdrawalReasonCode.privacyConcern: 'privacy_concern',
+  WithdrawalReasonCode.poorUsability: 'poor_usability',
+  WithdrawalReasonCode.other: 'other',
+};

--- a/shared/packages/minglit_kit/lib/src/data/repositories/account_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/account_repository.dart
@@ -1,0 +1,159 @@
+import 'package:minglit_kit/src/data/models/deletion_status.dart';
+import 'package:minglit_kit/src/data/models/withdrawal_reason.dart';
+import 'package:minglit_kit/src/utils/exceptions.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+part 'account_repository.g.dart';
+
+const _deletionGracePeriod = Duration(days: 7);
+
+/// Provides the [AccountRepository].
+@Riverpod(keepAlive: true)
+AccountRepository accountRepository(Ref ref) {
+  return AccountRepository(Supabase.instance.client);
+}
+
+/// Shared repository for account deletion and restoration flows.
+class AccountRepository {
+  /// Creates an [AccountRepository] with the given Supabase client.
+  const AccountRepository(this._supabase);
+
+  final SupabaseClient _supabase;
+
+  /// Requests account deletion and returns the pending deletion status.
+  Future<DeletionStatus> deleteAccount(WithdrawalReason? reason) async {
+    try {
+      final response = await _supabase.functions.invoke(
+        'user-delete-account',
+        body: {
+          if (reason != null) ...reason.toJson(),
+        },
+      );
+
+      if (response.status != 200) {
+        throw _efError(response, '탈퇴 요청에 실패했습니다.');
+      }
+
+      final data = _decodeMap(response.data);
+      final gracePeriodEnds = _parseDateTime(data['grace_period_ends']);
+      return DeletionStatus(
+        deletedAt: gracePeriodEnds?.subtract(_deletionGracePeriod),
+        gracePeriodEnds: gracePeriodEnds,
+        isPending: true,
+      );
+    } on Object catch (error, stackTrace) {
+      throw MinglitException.from(error, stackTrace);
+    }
+  }
+
+  /// Cancels a pending deletion request.
+  Future<void> cancelDeletion() async {
+    try {
+      final response = await _supabase.functions.invoke('user-cancel-deletion');
+      if (response.status != 200) {
+        throw _efError(response, '탈퇴 취소에 실패했습니다.');
+      }
+    } on Object catch (error, stackTrace) {
+      throw MinglitException.from(error, stackTrace);
+    }
+  }
+
+  /// Fetches the current signed-in user's deletion status.
+  Future<DeletionStatus?> getDeletionStatus() async {
+    final user = _supabase.auth.currentUser;
+    if (user == null) {
+      throw const MinglitAuthException('로그인이 필요합니다.');
+    }
+
+    try {
+      final data = await _supabase
+          .from('user_profiles')
+          .select('deleted_at')
+          .eq('id', user.id)
+          .maybeSingle();
+
+      if (data == null) return null;
+
+      final deletedAt = _parseDateTime(data['deleted_at']);
+      return DeletionStatus.fromDeletedAt(deletedAt);
+    } on Object catch (error, stackTrace) {
+      throw MinglitException.from(error, stackTrace);
+    }
+  }
+
+  /// Performs a reauthentication step before deletion.
+  ///
+  /// Email users must pass [password]. Social users trigger Supabase
+  /// reauthentication which continues in the provider-specific flow.
+  Future<void> reauthenticate(String? password) async {
+    final user = _supabase.auth.currentUser;
+    if (user == null) {
+      throw const MinglitAuthException('로그인이 필요합니다.');
+    }
+
+    try {
+      if (_usesPasswordAuth(user)) {
+        final email = user.email;
+        if (email == null || email.isEmpty) {
+          throw const MinglitAuthException('이메일 계정을 확인할 수 없습니다.');
+        }
+        if (password == null || password.isEmpty) {
+          throw const MinglitUserException('비밀번호를 입력해주세요.');
+        }
+
+        await _supabase.auth.signInWithPassword(
+          email: email,
+          password: password,
+        );
+        return;
+      }
+
+      await _supabase.auth.reauthenticate();
+    } on Object catch (error, stackTrace) {
+      throw MinglitException.from(error, stackTrace);
+    }
+  }
+
+  bool _usesPasswordAuth(User user) {
+    final identities = user.identities ?? const [];
+    if (identities.any((identity) => identity.provider == 'email')) {
+      return true;
+    }
+
+    final provider = user.appMetadata['provider'];
+    if (provider == 'email') {
+      return true;
+    }
+
+    final providers = user.appMetadata['providers'];
+    if (providers is List) {
+      return providers.contains('email');
+    }
+
+    return false;
+  }
+
+  MinglitUserException _efError(FunctionResponse response, String fallback) {
+    final data = response.data;
+    if (data is Map) {
+      final message = (data['error'] as String?) ?? fallback;
+      return MinglitUserException(message);
+    }
+    if (data is String && data.isNotEmpty) {
+      return MinglitUserException(data);
+    }
+    return MinglitUserException(fallback);
+  }
+
+  Map<String, dynamic> _decodeMap(dynamic value) {
+    if (value is Map<String, dynamic>) return value;
+    if (value is Map) return value.cast<String, dynamic>();
+    return const <String, dynamic>{};
+  }
+
+  DateTime? _parseDateTime(dynamic value) {
+    if (value is! String || value.isEmpty) return null;
+    return DateTime.tryParse(value);
+  }
+}

--- a/shared/packages/minglit_kit/lib/src/data/repositories/account_repository.g.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/account_repository.g.dart
@@ -1,0 +1,61 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'account_repository.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Provides the [AccountRepository].
+
+@ProviderFor(accountRepository)
+const accountRepositoryProvider = AccountRepositoryProvider._();
+
+/// Provides the [AccountRepository].
+
+final class AccountRepositoryProvider
+    extends
+        $FunctionalProvider<
+          AccountRepository,
+          AccountRepository,
+          AccountRepository
+        >
+    with $Provider<AccountRepository> {
+  /// Provides the [AccountRepository].
+  const AccountRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'accountRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$accountRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<AccountRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  AccountRepository create(Ref ref) {
+    return accountRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AccountRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AccountRepository>(value),
+    );
+  }
+}
+
+String _$accountRepositoryHash() => r'b9faf2b36039a169b145d691fd9c3e2c50037ad9';

--- a/shared/packages/minglit_kit/lib/src/features/account_deletion/logic/account_deletion_controller.dart
+++ b/shared/packages/minglit_kit/lib/src/features/account_deletion/logic/account_deletion_controller.dart
@@ -1,0 +1,85 @@
+import 'package:minglit_kit/src/data/models/deletion_status.dart';
+import 'package:minglit_kit/src/data/models/withdrawal_reason.dart';
+import 'package:minglit_kit/src/data/repositories/account_repository.dart';
+import 'package:minglit_kit/src/data/repositories/auth_repository.dart';
+import 'package:minglit_kit/src/utils/exceptions.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'account_deletion_controller.g.dart';
+
+/// Manages shared account deletion state for the signed-in user.
+@riverpod
+class AccountDeletionController extends _$AccountDeletionController {
+  @override
+  FutureOr<DeletionStatus?> build() async {
+    final user = ref.watch(currentUserProvider);
+    if (user == null) return null;
+
+    final repository = ref.watch(accountRepositoryProvider);
+    return repository.getDeletionStatus();
+  }
+
+  /// Reloads the deletion status from the backend.
+  Future<DeletionStatus?> checkStatus() async {
+    if (state.isLoading) return state.value;
+
+    state = const AsyncLoading();
+    try {
+      final nextStatus = await ref
+          .read(accountRepositoryProvider)
+          .getDeletionStatus();
+      state = AsyncData(nextStatus);
+      return nextStatus;
+    } on Object catch (error, stackTrace) {
+      state = AsyncError(MinglitException.from(error, stackTrace), stackTrace);
+      return state.value;
+    }
+  }
+
+  /// Requests account deletion with an optional anonymous [reason].
+  Future<DeletionStatus?> requestDeletion({WithdrawalReason? reason}) async {
+    if (state.isLoading) return state.value;
+
+    state = const AsyncLoading();
+    try {
+      final nextStatus = await ref
+          .read(accountRepositoryProvider)
+          .deleteAccount(reason);
+      state = AsyncData(nextStatus);
+      return nextStatus;
+    } on Object catch (error, stackTrace) {
+      state = AsyncError(MinglitException.from(error, stackTrace), stackTrace);
+      return state.value;
+    }
+  }
+
+  /// Cancels a pending deletion and reloads the latest status.
+  Future<DeletionStatus?> cancelDeletion() async {
+    if (state.isLoading) return state.value;
+
+    state = const AsyncLoading();
+    final repository = ref.read(accountRepositoryProvider);
+    try {
+      await repository.cancelDeletion();
+      final nextStatus = await repository.getDeletionStatus();
+      state = AsyncData(nextStatus);
+      return nextStatus;
+    } on Object catch (error, stackTrace) {
+      state = AsyncError(MinglitException.from(error, stackTrace), stackTrace);
+      return state.value;
+    }
+  }
+
+  /// Reauthenticates the signed-in user before destructive actions.
+  Future<void> reauthenticate(String? password) async {
+    final previous = state;
+    try {
+      await ref.read(accountRepositoryProvider).reauthenticate(password);
+    } on Object catch (error, stackTrace) {
+      state = AsyncError(MinglitException.from(error, stackTrace), stackTrace);
+      rethrow;
+    }
+
+    state = previous;
+  }
+}

--- a/shared/packages/minglit_kit/lib/src/features/account_deletion/logic/account_deletion_controller.g.dart
+++ b/shared/packages/minglit_kit/lib/src/features/account_deletion/logic/account_deletion_controller.g.dart
@@ -1,0 +1,62 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'account_deletion_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Manages shared account deletion state for the signed-in user.
+
+@ProviderFor(AccountDeletionController)
+const accountDeletionControllerProvider = AccountDeletionControllerProvider._();
+
+/// Manages shared account deletion state for the signed-in user.
+final class AccountDeletionControllerProvider
+    extends $AsyncNotifierProvider<AccountDeletionController, DeletionStatus?> {
+  /// Manages shared account deletion state for the signed-in user.
+  const AccountDeletionControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'accountDeletionControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$accountDeletionControllerHash();
+
+  @$internal
+  @override
+  AccountDeletionController create() => AccountDeletionController();
+}
+
+String _$accountDeletionControllerHash() =>
+    r'fdf6a9f4c856711d3c833f34cca0e7b205980d8d';
+
+/// Manages shared account deletion state for the signed-in user.
+
+abstract class _$AccountDeletionController
+    extends $AsyncNotifier<DeletionStatus?> {
+  FutureOr<DeletionStatus?> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref as $Ref<AsyncValue<DeletionStatus?>, DeletionStatus?>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<DeletionStatus?>, DeletionStatus?>,
+              AsyncValue<DeletionStatus?>,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/shared/packages/minglit_kit/test/src/data/repositories/account_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/account_repository_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/data/models/withdrawal_reason.dart';
+import 'package:minglit_kit/src/data/repositories/account_repository.dart';
+import 'package:minglit_kit/src/utils/exceptions.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../../helpers/mocks.dart';
+import '../../../helpers/supabase_mock_helpers.dart';
+
+void main() {
+  late MockSupabaseClient mockClient;
+  late MockGoTrueClient mockAuth;
+  late MockFunctionsClient mockFunctions;
+  late MockUser mockUser;
+  late AccountRepository repository;
+
+  setUp(() {
+    mockUser = MockUser();
+    mockClient = createMockSupabase(currentUser: mockUser);
+    mockAuth = mockClient.auth as MockGoTrueClient;
+    mockFunctions = mockClient.functions as MockFunctionsClient;
+    repository = AccountRepository(mockClient);
+
+    when(() => mockUser.id).thenReturn('user_1');
+    when(() => mockUser.email).thenReturn('user@example.com');
+    when(() => mockUser.identities).thenReturn(const []);
+    when(() => mockUser.appMetadata).thenReturn(const {});
+  });
+
+  group('AccountRepository', () {
+    group('deleteAccount', () {
+      test('sends anonymous reason and returns pending status', () async {
+        when(
+          () => mockFunctions.invoke(
+            'user-delete-account',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {
+              'success': true,
+              'grace_period_ends': '2026-04-06T00:00:00Z',
+            },
+          ),
+        );
+
+        final result = await repository.deleteAccount(
+          const WithdrawalReason(
+            reasonCode: WithdrawalReasonCode.privacyConcern,
+            detail: 'privacy',
+          ),
+        );
+
+        final captured = verify(
+          () => mockFunctions.invoke(
+            'user-delete-account',
+            body: captureAny(named: 'body'),
+          ),
+        ).captured.single as Map<String, dynamic>;
+
+        expect(captured['reason_code'], 'privacy_concern');
+        expect(captured['reason_text'], 'privacy');
+        expect(result.isPending, true);
+        expect(result.gracePeriodEnds, DateTime.parse('2026-04-06T00:00:00Z'));
+      });
+
+      test('omits reason fields when no reason was selected', () async {
+        when(
+          () => mockFunctions.invoke(
+            'user-delete-account',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true, 'grace_period_ends': '2026-04-06T00:00:00Z'},
+          ),
+        );
+
+        await repository.deleteAccount(null);
+
+        final captured = verify(
+          () => mockFunctions.invoke(
+            'user-delete-account',
+            body: captureAny(named: 'body'),
+          ),
+        ).captured.single as Map<String, dynamic>;
+
+        expect(captured, isEmpty);
+      });
+
+      test('throws MinglitUserException on EF error', () async {
+        when(
+          () => mockFunctions.invoke(
+            'user-delete-account',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 409,
+            data: {'error': 'Account deletion already pending'},
+          ),
+        );
+
+        await expectLater(
+          () => repository.deleteAccount(null),
+          throwsA(
+            isA<MinglitUserException>().having(
+              (e) => e.message,
+              'message',
+              'Account deletion already pending',
+            ),
+          ),
+        );
+      });
+    });
+
+    group('cancelDeletion', () {
+      test('calls the cancel edge function', () async {
+        when(
+          () => mockFunctions.invoke('user-cancel-deletion'),
+        ).thenAnswer((_) async => FunctionResponse(status: 200, data: {'success': true}));
+
+        await repository.cancelDeletion();
+
+        verify(() => mockFunctions.invoke('user-cancel-deletion')).called(1);
+      });
+    });
+
+    group('getDeletionStatus', () {
+      test('returns pending status when deleted_at exists', () async {
+        mockTable(
+          mockClient,
+          'user_profiles',
+          maybeSingleData: {'deleted_at': '2026-03-30T00:00:00Z'},
+        );
+
+        final result = await repository.getDeletionStatus();
+
+        expect(result, isNotNull);
+        expect(result!.isPending, true);
+        expect(result.deletedAt, DateTime.parse('2026-03-30T00:00:00Z'));
+        expect(result.gracePeriodEnds, DateTime.parse('2026-04-06T00:00:00Z'));
+      });
+
+      test('returns non-pending status when deleted_at is null', () async {
+        mockTable(
+          mockClient,
+          'user_profiles',
+          maybeSingleData: {'deleted_at': null},
+        );
+
+        final result = await repository.getDeletionStatus();
+
+        expect(result, isNotNull);
+        expect(result!.isPending, false);
+        expect(result.deletedAt, isNull);
+        expect(result.gracePeriodEnds, isNull);
+      });
+    });
+
+    group('reauthenticate', () {
+      test('uses password sign-in for email users', () async {
+        when(() => mockUser.appMetadata).thenReturn(const {'provider': 'email'});
+        when(
+          () => mockAuth.signInWithPassword(
+            email: any(named: 'email'),
+            password: any(named: 'password'),
+          ),
+        ).thenAnswer((_) async => AuthResponse());
+
+        await repository.reauthenticate('pw-1234');
+
+        verify(
+          () => mockAuth.signInWithPassword(
+            email: 'user@example.com',
+            password: 'pw-1234',
+          ),
+        ).called(1);
+        verifyNever(() => mockAuth.reauthenticate());
+      });
+
+      test('throws when email user password is missing', () async {
+        when(() => mockUser.appMetadata).thenReturn(const {'provider': 'email'});
+
+        await expectLater(
+          () => repository.reauthenticate(null),
+          throwsA(isA<MinglitUserException>()),
+        );
+      });
+
+      test('uses Supabase reauthenticate for social users', () async {
+        when(() => mockUser.appMetadata).thenReturn(const {'provider': 'google'});
+        when(() => mockAuth.reauthenticate()).thenAnswer((_) async {});
+
+        await repository.reauthenticate(null);
+
+        verify(() => mockAuth.reauthenticate()).called(1);
+        verifyNever(
+          () => mockAuth.signInWithPassword(
+            email: any(named: 'email'),
+            password: any(named: 'password'),
+          ),
+        );
+      });
+    });
+  });
+}

--- a/shared/packages/minglit_kit/test/src/data/repositories/account_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/account_repository_test.dart
@@ -53,12 +53,14 @@ void main() {
           ),
         );
 
-        final captured = verify(
-          () => mockFunctions.invoke(
-            'user-delete-account',
-            body: captureAny(named: 'body'),
-          ),
-        ).captured.single as Map<String, dynamic>;
+        final captured =
+            verify(
+                  () => mockFunctions.invoke(
+                    'user-delete-account',
+                    body: captureAny(named: 'body'),
+                  ),
+                ).captured.single
+                as Map<String, dynamic>;
 
         expect(captured['reason_code'], 'privacy_concern');
         expect(captured['reason_text'], 'privacy');
@@ -75,18 +77,23 @@ void main() {
         ).thenAnswer(
           (_) async => FunctionResponse(
             status: 200,
-            data: {'success': true, 'grace_period_ends': '2026-04-06T00:00:00Z'},
+            data: {
+              'success': true,
+              'grace_period_ends': '2026-04-06T00:00:00Z',
+            },
           ),
         );
 
         await repository.deleteAccount(null);
 
-        final captured = verify(
-          () => mockFunctions.invoke(
-            'user-delete-account',
-            body: captureAny(named: 'body'),
-          ),
-        ).captured.single as Map<String, dynamic>;
+        final captured =
+            verify(
+                  () => mockFunctions.invoke(
+                    'user-delete-account',
+                    body: captureAny(named: 'body'),
+                  ),
+                ).captured.single
+                as Map<String, dynamic>;
 
         expect(captured, isEmpty);
       });
@@ -121,7 +128,9 @@ void main() {
       test('calls the cancel edge function', () async {
         when(
           () => mockFunctions.invoke('user-cancel-deletion'),
-        ).thenAnswer((_) async => FunctionResponse(status: 200, data: {'success': true}));
+        ).thenAnswer(
+          (_) async => FunctionResponse(status: 200, data: {'success': true}),
+        );
 
         await repository.cancelDeletion();
 
@@ -163,7 +172,9 @@ void main() {
 
     group('reauthenticate', () {
       test('uses password sign-in for email users', () async {
-        when(() => mockUser.appMetadata).thenReturn(const {'provider': 'email'});
+        when(
+          () => mockUser.appMetadata,
+        ).thenReturn(const {'provider': 'email'});
         when(
           () => mockAuth.signInWithPassword(
             email: any(named: 'email'),
@@ -183,7 +194,9 @@ void main() {
       });
 
       test('throws when email user password is missing', () async {
-        when(() => mockUser.appMetadata).thenReturn(const {'provider': 'email'});
+        when(
+          () => mockUser.appMetadata,
+        ).thenReturn(const {'provider': 'email'});
 
         await expectLater(
           () => repository.reauthenticate(null),
@@ -192,7 +205,9 @@ void main() {
       });
 
       test('uses Supabase reauthenticate for social users', () async {
-        when(() => mockUser.appMetadata).thenReturn(const {'provider': 'google'});
+        when(
+          () => mockUser.appMetadata,
+        ).thenReturn(const {'provider': 'google'});
         when(() => mockAuth.reauthenticate()).thenAnswer((_) async {});
 
         await repository.reauthenticate(null);

--- a/shared/packages/minglit_kit/test/src/features/account_deletion/logic/account_deletion_controller_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/account_deletion/logic/account_deletion_controller_test.dart
@@ -1,0 +1,178 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/data/models/deletion_status.dart';
+import 'package:minglit_kit/src/data/models/withdrawal_reason.dart';
+import 'package:minglit_kit/src/data/repositories/account_repository.dart';
+import 'package:minglit_kit/src/data/repositories/auth_repository.dart';
+import 'package:minglit_kit/src/features/account_deletion/logic/account_deletion_controller.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../../../helpers/test_utils.dart';
+
+class MockAccountRepository extends Mock implements AccountRepository {}
+
+class MockUser extends Mock implements User {}
+
+void main() {
+  late MockAccountRepository mockRepository;
+  late MockUser mockUser;
+
+  const pendingStatus = DeletionStatus(isPending: true);
+  const activeStatus = DeletionStatus();
+
+  setUp(() {
+    mockRepository = MockAccountRepository();
+    mockUser = MockUser();
+    when(() => mockUser.id).thenReturn('user_1');
+  });
+
+  ProviderContainer createTestContainer({User? user}) {
+    return createContainer(
+      overrides: [
+        accountRepositoryProvider.overrideWithValue(mockRepository),
+        currentUserProvider.overrideWithValue(user),
+      ],
+    );
+  }
+
+  group('AccountDeletionController', () {
+    test('returns null when user is not logged in', () async {
+      final container = createTestContainer();
+
+      final result = await container.read(
+        accountDeletionControllerProvider.future,
+      );
+
+      expect(result, isNull);
+    });
+
+    test('loads current deletion status from repository', () async {
+      when(
+        () => mockRepository.getDeletionStatus(),
+      ).thenAnswer((_) async => activeStatus);
+
+      final container = createTestContainer(user: mockUser);
+
+      final result = await container.read(
+        accountDeletionControllerProvider.future,
+      );
+
+      expect(result, activeStatus);
+      verify(() => mockRepository.getDeletionStatus()).called(1);
+    });
+
+    test('requestDeletion updates state with pending status', () async {
+      when(
+        () => mockRepository.getDeletionStatus(),
+      ).thenAnswer((_) async => activeStatus);
+      when(
+        () => mockRepository.deleteAccount(any()),
+      ).thenAnswer((_) async => pendingStatus);
+
+      final container = createTestContainer(user: mockUser);
+      await container.read(accountDeletionControllerProvider.future);
+
+      await container
+          .read(accountDeletionControllerProvider.notifier)
+          .requestDeletion(
+            reason: const WithdrawalReason(
+              reasonCode: WithdrawalReasonCode.noLongerUse,
+            ),
+          );
+
+      expect(
+        container.read(accountDeletionControllerProvider).value,
+        pendingStatus,
+      );
+      verify(() => mockRepository.deleteAccount(any())).called(1);
+    });
+
+    test('requestDeletion stores AsyncError on failure', () async {
+      when(
+        () => mockRepository.getDeletionStatus(),
+      ).thenAnswer((_) async => activeStatus);
+      when(
+        () => mockRepository.deleteAccount(any()),
+      ).thenThrow(const AuthException('boom'));
+
+      final container = createTestContainer(user: mockUser);
+      await container.read(accountDeletionControllerProvider.future);
+
+      await container
+          .read(accountDeletionControllerProvider.notifier)
+          .requestDeletion();
+
+      expect(
+        container.read(accountDeletionControllerProvider),
+        isA<AsyncError<DeletionStatus?>>(),
+      );
+    });
+
+    test('cancelDeletion reloads status after success', () async {
+      var callCount = 0;
+      when(() => mockRepository.getDeletionStatus()).thenAnswer((_) async {
+        callCount += 1;
+        return callCount == 1 ? pendingStatus : activeStatus;
+      });
+      when(() => mockRepository.cancelDeletion()).thenAnswer((_) async {});
+
+      final container = createTestContainer(user: mockUser);
+      await container.read(accountDeletionControllerProvider.future);
+
+      await container
+          .read(accountDeletionControllerProvider.notifier)
+          .cancelDeletion();
+
+      expect(
+        container.read(accountDeletionControllerProvider).value,
+        activeStatus,
+      );
+      verify(() => mockRepository.cancelDeletion()).called(1);
+      expect(callCount, 2);
+    });
+
+    test('reauthenticate keeps previous state on success', () async {
+      when(
+        () => mockRepository.getDeletionStatus(),
+      ).thenAnswer((_) async => activeStatus);
+      when(() => mockRepository.reauthenticate('pw')).thenAnswer((_) async {});
+
+      final container = createTestContainer(user: mockUser);
+      await container.read(accountDeletionControllerProvider.future);
+
+      await container
+          .read(accountDeletionControllerProvider.notifier)
+          .reauthenticate('pw');
+
+      expect(
+        container.read(accountDeletionControllerProvider).value,
+        activeStatus,
+      );
+    });
+
+    test('reauthenticate stores AsyncError on failure', () async {
+      when(
+        () => mockRepository.getDeletionStatus(),
+      ).thenAnswer((_) async => activeStatus);
+      when(
+        () => mockRepository.reauthenticate('pw'),
+      ).thenThrow(const AuthException('invalid'));
+
+      final container = createTestContainer(user: mockUser);
+      await container.read(accountDeletionControllerProvider.future);
+
+      await expectLater(
+        () => container
+            .read(accountDeletionControllerProvider.notifier)
+            .reauthenticate('pw'),
+        throwsA(isA<AuthException>()),
+      );
+
+      expect(
+        container.read(accountDeletionControllerProvider),
+        isA<AsyncError<DeletionStatus?>>(),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Scheduler: needs-dev-codex-1

Closes #887

## Summary
- add shared account deletion models for status and anonymous withdrawal reasons
- add AccountRepository and AccountDeletionController for delete, cancel, status, and reauth flows
- export the new shared layer and add repository/controller tests

## Verification
- `/Users/mark/development/flutter/bin/flutter test test/src/data/repositories/account_repository_test.dart test/src/features/account_deletion/logic/account_deletion_controller_test.dart`
- `/Users/mark/development/flutter/bin/flutter analyze --no-fatal-infos`
