### PR TITLE
refactor: my_tickets → ticket cross-feature import 해소

### DIFF
--- a/apps/app_user/lib/src/features/home/logic/home_coordinator.dart
+++ b/apps/app_user/lib/src/features/home/logic/home_coordinator.dart
@@ -53,6 +53,12 @@ class HomeCoordinator {
     unawaited(_router.push(const BlockedPartnersRoute().location));
   }
 
+  // Fix #852: Navigate to ticket QR via coordinator
+  // — removes cross-feature import
+  void pushTicketQR(String ticketId) {
+    unawaited(_router.push(TicketQRRoute(ticketId: ticketId).location));
+  }
+
   void pushEventDetail(String eventId) {
     unawaited(_router.push(EventDetailRoute(eventId: eventId).location));
   }

--- a/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.g.dart
+++ b/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.g.dart
@@ -265,7 +265,7 @@ final class EventRealtimeProvider
   }
 }
 
-String _$eventRealtimeHash() => r'f3f208f3d4c41e56fc1a2745040e5c63f6794d76';
+String _$eventRealtimeHash() => r'071f128393c0f22c32ba5b47c1df32d438346598';
 
 /// Subscribes to Supabase Realtime changes on `event_participants` for a
 /// given [eventId]. When a change is received, [todayActiveEventsProvider]

--- a/apps/app_user/lib/src/features/my_tickets/ui/my_ticket_card.dart
+++ b/apps/app_user/lib/src/features/my_tickets/ui/my_ticket_card.dart
@@ -1,7 +1,4 @@
-import 'dart:async';
-
 import 'package:app_user/src/common/widgets/status_badge.dart';
-import 'package:app_user/src/features/ticket/ui/ticket_qr_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -13,6 +10,8 @@ class MyTicketCard extends StatelessWidget {
     required this.application,
     required this.isPast,
     this.onTap,
+    // Fix #852: onQRTap callback — replaces direct TicketQRScreen import
+    this.onQRTap,
     @visibleForTesting this.currentTime,
     super.key,
   });
@@ -20,6 +19,9 @@ class MyTicketCard extends StatelessWidget {
   final EventApplication application;
   final bool isPast;
   final VoidCallback? onTap;
+
+  /// Callback for the QR button tap.
+  final VoidCallback? onQRTap;
 
   /// Override current time for D-day calculation (testing only).
   final DateTime? currentTime;
@@ -197,17 +199,7 @@ class MyTicketCard extends StatelessWidget {
         // QR button (only for upcoming events)
         if (!isPast)
           TextButton.icon(
-            onPressed: () {
-              unawaited(
-                Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (_) => TicketQRScreen(
-                      ticketId: application.ticketId,
-                    ),
-                  ),
-                ),
-              );
-            },
+            onPressed: onQRTap,
             icon: const Icon(Icons.qr_code_2, size: 18),
             label: const Text('입장 QR'),
             style: TextButton.styleFrom(

--- a/apps/app_user/lib/src/features/my_tickets/ui/my_tickets_page.dart
+++ b/apps/app_user/lib/src/features/my_tickets/ui/my_tickets_page.dart
@@ -1,9 +1,6 @@
-import 'dart:async';
-
 import 'package:app_user/src/features/home/logic/home_coordinator.dart';
 import 'package:app_user/src/features/my_tickets/logic/my_tickets_controller.dart';
 import 'package:app_user/src/features/my_tickets/ui/my_ticket_card.dart';
-import 'package:app_user/src/features/ticket/ui/ticket_qr_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -34,7 +31,10 @@ class MyTicketsPage extends ConsumerWidget {
             children: [
               // Today event banner
               if (state.todayEvent != null)
-                _TodayBanner(application: state.todayEvent!),
+                _TodayBanner(
+                  application: state.todayEvent!,
+                  onQRTap: () => _onQRTap(ref, state.todayEvent!.ticketId),
+                ),
 
               // Upcoming section
               if (state.upcoming.isNotEmpty) ...[
@@ -44,6 +44,7 @@ class MyTicketsPage extends ConsumerWidget {
                     application: app,
                     isPast: false,
                     onTap: () => _onCardTap(ref, app),
+                    onQRTap: () => _onQRTap(ref, app.ticketId),
                   ),
                 ),
               ],
@@ -70,6 +71,12 @@ class MyTicketsPage extends ConsumerWidget {
 
   void _onCardTap(WidgetRef ref, EventApplication application) {
     ref.read(homeCoordinatorProvider).pushEventDetail(application.eventId);
+  }
+
+  // Fix #852: Navigate to ticket QR via coordinator
+  // — removes cross-feature import
+  void _onQRTap(WidgetRef ref, String ticketId) {
+    ref.read(homeCoordinatorProvider).pushTicketQR(ticketId);
   }
 }
 
@@ -138,9 +145,12 @@ class _EmptyState extends StatelessWidget {
 
 /// Today event banner shown at the top when there's an event starting today.
 class _TodayBanner extends StatelessWidget {
-  const _TodayBanner({required this.application});
+  const _TodayBanner({required this.application, required this.onQRTap});
 
   final EventApplication application;
+
+  // Fix #852: QR navigation callback — replaces direct TicketQRScreen import
+  final VoidCallback onQRTap;
 
   @override
   Widget build(BuildContext context) {
@@ -212,17 +222,7 @@ class _TodayBanner extends StatelessWidget {
 
             // QR button
             TextButton(
-              onPressed: () {
-                unawaited(
-                  Navigator.of(context).push(
-                    MaterialPageRoute<void>(
-                      builder: (_) => TicketQRScreen(
-                        ticketId: application.ticketId,
-                      ),
-                    ),
-                  ),
-                );
-              },
+              onPressed: onQRTap,
               style: TextButton.styleFrom(
                 foregroundColor: theme.colorScheme.onPrimary,
                 backgroundColor: theme.colorScheme.primary,

--- a/apps/app_user/lib/src/routing/app_routes.dart
+++ b/apps/app_user/lib/src/routing/app_routes.dart
@@ -12,6 +12,7 @@ import 'package:app_user/src/features/payment/ui/purchase_history_page.dart';
 import 'package:app_user/src/features/search/search_page.dart';
 import 'package:app_user/src/features/settings/blocked_partners_page.dart';
 import 'package:app_user/src/features/settings/privacy_page.dart';
+import 'package:app_user/src/features/ticket/ui/ticket_qr_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:minglit_kit/minglit_dev.dart';
@@ -136,6 +137,19 @@ class MyTicketsRoute extends GoRouteData with $MyTicketsRoute {
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       const MyTicketsPage();
+}
+
+/// **Ticket QR Route**: QR code screen for a specific ticket.
+/// Path: `/tickets/:ticketId/qr`
+@TypedGoRoute<TicketQRRoute>(path: '/tickets/:ticketId/qr')
+class TicketQRRoute extends GoRouteData with $TicketQRRoute {
+  const TicketQRRoute({required this.ticketId});
+
+  final String ticketId;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      TicketQRScreen(ticketId: ticketId);
 }
 
 /// **Purchase History Route**

--- a/apps/app_user/lib/src/routing/app_routes.g.dart
+++ b/apps/app_user/lib/src/routing/app_routes.g.dart
@@ -16,6 +16,7 @@ List<RouteBase> get $appRoutes => [
   $certificationRoute,
   $eventApplicationRoute,
   $myTicketsRoute,
+  $ticketQRRoute,
   $purchaseHistoryRoute,
   $notificationCenterRoute,
   $notificationSettingsRoute,
@@ -271,6 +272,36 @@ mixin $MyTicketsRoute on GoRouteData {
 
   @override
   String get location => GoRouteData.$location('/tickets/my');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $ticketQRRoute => GoRouteData.$route(
+  path: '/tickets/:ticketId/qr',
+  factory: $TicketQRRoute._fromState,
+);
+
+mixin $TicketQRRoute on GoRouteData {
+  static TicketQRRoute _fromState(GoRouterState state) =>
+      TicketQRRoute(ticketId: state.pathParameters['ticketId']!);
+
+  TicketQRRoute get _self => this as TicketQRRoute;
+
+  @override
+  String get location => GoRouteData.$location(
+    '/tickets/${Uri.encodeComponent(_self.ticketId)}/qr',
+  );
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/apps/app_user/test/src/features/my_tickets/ui/my_tickets_page_test.dart
+++ b/apps/app_user/test/src/features/my_tickets/ui/my_tickets_page_test.dart
@@ -11,14 +11,9 @@ import '../../../../utils/mocks.dart';
 
 class MockHomeCoordinator extends Mock implements HomeCoordinator {}
 
-class MockNavigatorObserver extends Mock implements NavigatorObserver {}
-
-class FakeRoute extends Fake implements Route<dynamic> {}
-
 void main() {
   setUpAll(() async {
     await initializeDateFormatting('ko_KR');
-    registerFallbackValue(FakeRoute());
   });
 
   late MockEventRepository mockEventRepository;
@@ -236,6 +231,27 @@ void main() {
       ).called(1);
     });
 
+    testWidgets('tapping QR button calls pushTicketQR', (tester) async {
+      final upcoming = makeApplication(
+        id: '1',
+        status: 'paid',
+        startTime: DateTime.now().add(const Duration(days: 3)),
+        eventTitle: 'QR 라우팅 테스트',
+      );
+
+      when(
+        () => mockEventRepository.getMyTickets('user1'),
+      ).thenAnswer((_) async => [upcoming]);
+
+      await tester.pumpWidget(createTestWidget());
+      await pumpAndSettle(tester);
+
+      await tester.tap(find.text('입장 QR'));
+      await tester.pump();
+
+      verify(() => mockHomeCoordinator.pushTicketQR('ticket_1')).called(1);
+    });
+
     // Fix #642: P2 — banner not shown when no todayEvent
     testWidgets('does not render today banner when no today event', (
       tester,
@@ -382,8 +398,7 @@ void main() {
       expect(find.text('결제완료'), findsOneWidget);
     });
 
-    // Fix #642: P1 — QR button tap navigates to TicketQRScreen
-    testWidgets('QR button tap pushes TicketQRScreen', (tester) async {
+    testWidgets('QR button tap calls onQRTap callback', (tester) async {
       final app = makeApplication(
         id: '1',
         status: 'paid',
@@ -391,29 +406,25 @@ void main() {
         eventTitle: 'QR 테스트 이벤트',
       );
 
-      final navigatorObserver = MockNavigatorObserver();
+      var didTapQr = false;
       await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            navigatorObservers: [navigatorObserver],
-            home: Scaffold(
-              body: MyTicketCard(
-                application: app,
-                isPast: false,
-              ),
+        MaterialApp(
+          home: Scaffold(
+            body: MyTicketCard(
+              application: app,
+              isPast: false,
+              onQRTap: () {
+                didTapQr = true;
+              },
             ),
           ),
         ),
       );
 
-      // Fix #642: 초기 route push 이력 제거 — 탭 이후 push만 검증
-      clearInteractions(navigatorObserver);
-
       await tester.tap(find.text('입장 QR'));
       await tester.pump();
 
-      // Verify Navigator.push was called exactly once (route to TicketQRScreen)
-      verify(() => navigatorObserver.didPush(any(), any())).called(1);
+      expect(didTapQr, isTrue);
     });
 
     testWidgets('shows location name', (tester) async {


### PR DESCRIPTION
Scheduler: needs-dev-glm-1

Closes #852

## Summary
- Remove direct `TicketQRScreen` import from `my_tickets` feature (cross-feature violation)
- Add `TicketQRRoute` to GoRouter with `/tickets/:ticketId/qr` path
- Add `pushTicketQR` method to `HomeCoordinator` following existing coordinator pattern
- Pass `onQRTap` callback through `MyTicketCard` and `_TodayBanner` instead of direct navigation

## Changes
| File | Change |
|------|--------|
| `my_ticket_card.dart` | Remove `ticket_qr_screen` import, add `onQRTap` callback |
| `my_tickets_page.dart` | Remove import, add `_onQRTap` via coordinator, wire `onQRTap` to `_TodayBanner` |
| `home_coordinator.dart` | Add `pushTicketQR` method |
| `app_routes.dart` | Add `TicketQRRoute` TypedGoRoute |
| `app_routes.g.dart` | Generated code for new route |

## Verification
- `flutter analyze` passes (0 errors)
- Cross-feature import count: 0 (was 2)
- Coordinator pattern consistent with existing `pushEventDetail`, `pushBlockedPartners`

Constraint: Feature isolation — my_tickets must not import ticket UI
Confidence: high
Scope-risk: narrow