### PR TITLE
feat(app_user): add account deletion flow UI

### DIFF
--- a/apps/app_user/lib/src/features/account_deletion/account_deletion_flow.dart
+++ b/apps/app_user/lib/src/features/account_deletion/account_deletion_flow.dart
@@ -1,0 +1,123 @@
+import 'package:minglit_kit/minglit_kit.dart';
+
+class AccountDeletionReasonOption {
+  const AccountDeletionReasonOption({
+    required this.code,
+    required this.title,
+    required this.description,
+  });
+
+  final WithdrawalReasonCode code;
+  final String title;
+  final String description;
+}
+
+const accountDeletionReasonOptions = <AccountDeletionReasonOption>[
+  AccountDeletionReasonOption(
+    code: WithdrawalReasonCode.noLongerUse,
+    title: '더 이상 쓰지 않아요',
+    description: '밍릿이 현재 필요하지 않아요.',
+  ),
+  AccountDeletionReasonOption(
+    code: WithdrawalReasonCode.noDesiredEvents,
+    title: '원하는 이벤트가 없어요',
+    description: '찾고 싶은 분위기나 주제의 이벤트가 부족했어요.',
+  ),
+  AccountDeletionReasonOption(
+    code: WithdrawalReasonCode.usingOtherService,
+    title: '다른 서비스를 이용 중이에요',
+    description: '비슷한 목적의 다른 서비스를 더 자주 사용해요.',
+  ),
+  AccountDeletionReasonOption(
+    code: WithdrawalReasonCode.privacyConcern,
+    title: '개인정보가 걱정돼요',
+    description: '계정과 개인정보 보관이 걱정돼요.',
+  ),
+  AccountDeletionReasonOption(
+    code: WithdrawalReasonCode.poorUsability,
+    title: '앱 사용이 어려워요',
+    description: '원하는 기능을 찾거나 사용하는 과정이 복잡했어요.',
+  ),
+  AccountDeletionReasonOption(
+    code: WithdrawalReasonCode.other,
+    title: '직접 입력할게요',
+    description: '자유롭게 이유를 남길 수 있어요.',
+  ),
+];
+
+WithdrawalReasonCode? parseWithdrawalReasonCode(String? value) {
+  switch (value) {
+    case 'no_longer_use':
+      return WithdrawalReasonCode.noLongerUse;
+    case 'no_desired_events':
+      return WithdrawalReasonCode.noDesiredEvents;
+    case 'using_other_service':
+      return WithdrawalReasonCode.usingOtherService;
+    case 'privacy_concern':
+      return WithdrawalReasonCode.privacyConcern;
+    case 'poor_usability':
+      return WithdrawalReasonCode.poorUsability;
+    case 'other':
+      return WithdrawalReasonCode.other;
+    default:
+      return null;
+  }
+}
+
+String encodeWithdrawalReasonCode(WithdrawalReasonCode code) {
+  switch (code) {
+    case WithdrawalReasonCode.noLongerUse:
+      return 'no_longer_use';
+    case WithdrawalReasonCode.noDesiredEvents:
+      return 'no_desired_events';
+    case WithdrawalReasonCode.usingOtherService:
+      return 'using_other_service';
+    case WithdrawalReasonCode.privacyConcern:
+      return 'privacy_concern';
+    case WithdrawalReasonCode.poorUsability:
+      return 'poor_usability';
+    case WithdrawalReasonCode.other:
+      return 'other';
+  }
+}
+
+String withdrawalReasonLabel(WithdrawalReasonCode code) {
+  return accountDeletionReasonOptions
+      .firstWhere((option) => option.code == code)
+      .title;
+}
+
+WithdrawalReason? buildWithdrawalReason({
+  String? reasonCode,
+  String? reasonText,
+}) {
+  final parsedCode = parseWithdrawalReasonCode(reasonCode);
+  if (parsedCode == null) return null;
+
+  final trimmedReason = reasonText?.trim();
+  return WithdrawalReason(
+    reasonCode: parsedCode,
+    detail: trimmedReason == null || trimmedReason.isEmpty
+        ? null
+        : trimmedReason,
+  );
+}
+
+bool usesPasswordAuth(User user) {
+  final identities = user.identities ?? const [];
+  if (identities.any((identity) => identity.provider == 'email')) {
+    return true;
+  }
+
+  final provider = user.appMetadata['provider'];
+  if (provider == 'email') {
+    return true;
+  }
+
+  final providers = user.appMetadata['providers'];
+  if (providers is List) {
+    return providers.contains('email');
+  }
+
+  return false;
+}

--- a/apps/app_user/lib/src/features/account_deletion/logic/account_deletion_coordinator.dart
+++ b/apps/app_user/lib/src/features/account_deletion/logic/account_deletion_coordinator.dart
@@ -1,0 +1,55 @@
+import 'dart:async';
+
+import 'package:app_user/src/features/account_deletion/account_deletion_flow.dart';
+import 'package:app_user/src/routing/app_router.dart';
+import 'package:app_user/src/routing/app_routes.dart';
+import 'package:go_router/go_router.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'account_deletion_coordinator.g.dart';
+
+@riverpod
+AccountDeletionCoordinator accountDeletionCoordinator(Ref ref) {
+  return AccountDeletionCoordinator(ref.read(goRouterProvider));
+}
+
+class AccountDeletionCoordinator {
+  AccountDeletionCoordinator(this._router);
+
+  final GoRouter _router;
+
+  void start() {
+    unawaited(_router.push(const DeletionReasonRoute().location));
+  }
+
+  void pushInfo({WithdrawalReason? reason}) {
+    unawaited(
+      _router.push(
+        DeletionInfoRoute(
+          reasonCode: reason == null
+              ? null
+              : encodeWithdrawalReasonCode(reason.reasonCode),
+          reasonText: reason?.detail,
+        ).location,
+      ),
+    );
+  }
+
+  void pushVerify({WithdrawalReason? reason}) {
+    unawaited(
+      _router.push(
+        DeletionVerifyRoute(
+          reasonCode: reason == null
+              ? null
+              : encodeWithdrawalReasonCode(reason.reasonCode),
+          reasonText: reason?.detail,
+        ).location,
+      ),
+    );
+  }
+
+  void goComplete() {
+    _router.go(const DeletionCompleteRoute().location);
+  }
+}

--- a/apps/app_user/lib/src/features/account_deletion/logic/account_deletion_coordinator.g.dart
+++ b/apps/app_user/lib/src/features/account_deletion/logic/account_deletion_coordinator.g.dart
@@ -1,0 +1,59 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'account_deletion_coordinator.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(accountDeletionCoordinator)
+const accountDeletionCoordinatorProvider =
+    AccountDeletionCoordinatorProvider._();
+
+final class AccountDeletionCoordinatorProvider
+    extends
+        $FunctionalProvider<
+          AccountDeletionCoordinator,
+          AccountDeletionCoordinator,
+          AccountDeletionCoordinator
+        >
+    with $Provider<AccountDeletionCoordinator> {
+  const AccountDeletionCoordinatorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'accountDeletionCoordinatorProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$accountDeletionCoordinatorHash();
+
+  @$internal
+  @override
+  $ProviderElement<AccountDeletionCoordinator> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  AccountDeletionCoordinator create(Ref ref) {
+    return accountDeletionCoordinator(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AccountDeletionCoordinator value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AccountDeletionCoordinator>(value),
+    );
+  }
+}
+
+String _$accountDeletionCoordinatorHash() =>
+    r'4b9281d677e249a7f622514e89afa4cb3170ce20';

--- a/apps/app_user/lib/src/features/account_deletion/ui/deletion_complete_page.dart
+++ b/apps/app_user/lib/src/features/account_deletion/ui/deletion_complete_page.dart
@@ -1,0 +1,61 @@
+import 'package:app_user/src/features/home/logic/home_coordinator.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+class DeletionCompletePage extends ConsumerWidget {
+  const DeletionCompletePage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('탈퇴 완료')),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(MinglitSpacing.large),
+          child: Column(
+            children: [
+              const Spacer(),
+              Icon(
+                Icons.check_circle_rounded,
+                size: 72,
+                color: theme.colorScheme.primary,
+              ),
+              const SizedBox(height: MinglitSpacing.large),
+              Text(
+                '탈퇴 요청이 완료됐어요',
+                style: theme.textTheme.headlineSmall,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: MinglitSpacing.small),
+              Text(
+                '지금부터 7일 안에 다시 로그인하면 계정을 복구할 수 있어요.',
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const Spacer(),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed: () => _finish(context, ref),
+                  child: const Text('확인'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _finish(BuildContext context, WidgetRef ref) async {
+    ref.read(homeCoordinatorProvider).goToHome();
+    await Future<void>.delayed(Duration.zero);
+    await ref.read(authControllerProvider.notifier).signOut();
+    if (!context.mounted) return;
+    context.showMinglitSuccess('탈퇴 요청이 접수되었어요.');
+  }
+}

--- a/apps/app_user/lib/src/features/account_deletion/ui/deletion_info_page.dart
+++ b/apps/app_user/lib/src/features/account_deletion/ui/deletion_info_page.dart
@@ -1,0 +1,170 @@
+import 'package:app_user/src/features/account_deletion/account_deletion_flow.dart';
+import 'package:app_user/src/features/account_deletion/logic/account_deletion_coordinator.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+class DeletionInfoPage extends ConsumerWidget {
+  const DeletionInfoPage({
+    this.reasonCode,
+    this.reasonText,
+    super.key,
+  });
+
+  final String? reasonCode;
+  final String? reasonText;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final coordinator = ref.read(accountDeletionCoordinatorProvider);
+    final reason = buildWithdrawalReason(
+      reasonCode: reasonCode,
+      reasonText: reasonText,
+    );
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('탈퇴 전 확인')),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.all(MinglitSpacing.large),
+                children: [
+                  if (reason != null) ...[
+                    Container(
+                      padding: const EdgeInsets.all(MinglitSpacing.medium),
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.secondaryContainer,
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '선택한 탈퇴 사유',
+                            style: theme.textTheme.labelLarge?.copyWith(
+                              color: theme.colorScheme.onSecondaryContainer,
+                            ),
+                          ),
+                          const SizedBox(height: MinglitSpacing.xsmall),
+                          Text(
+                            withdrawalReasonLabel(reason.reasonCode),
+                            style: theme.textTheme.titleSmall,
+                          ),
+                          if (reason.detail != null) ...[
+                            const SizedBox(height: MinglitSpacing.xsmall),
+                            Text(reason.detail!),
+                          ],
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: MinglitSpacing.large),
+                  ],
+                  const _InfoSection(
+                    title: '삭제되는 정보',
+                    items: [
+                      '프로필, 관심사, 차단 목록, 알림 설정',
+                      '매칭과 피드 노출을 위한 개인화 데이터',
+                      '활동 기록과 저장된 앱 내 설정',
+                    ],
+                  ),
+                  const SizedBox(height: MinglitSpacing.medium),
+                  const _InfoSection(
+                    title: '법정 보존 정보',
+                    items: [
+                      '전자상거래 관련 결제·계약 기록',
+                      '분쟁 대응을 위한 최소한의 증빙 정보',
+                      '재가입 제한을 위한 식별 해시 정보',
+                    ],
+                  ),
+                  const SizedBox(height: MinglitSpacing.medium),
+                  Container(
+                    padding: const EdgeInsets.all(MinglitSpacing.medium),
+                    decoration: BoxDecoration(
+                      color: MinglitColors.error.withValues(alpha: 0.08),
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          '유예 기간 안내',
+                          style: theme.textTheme.titleSmall?.copyWith(
+                            color: MinglitColors.error,
+                          ),
+                        ),
+                        const SizedBox(height: MinglitSpacing.xsmall),
+                        Text(
+                          '탈퇴 요청 후 7일 동안은 다시 로그인해 계정을 복구할 수 있어요. '
+                          '유예 기간이 지나면 계정이 영구 삭제되고 30일 동안 재가입이 제한될 수 있어요.',
+                          style: theme.textTheme.bodyMedium,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                MinglitSpacing.large,
+                MinglitSpacing.small,
+                MinglitSpacing.large,
+                MinglitSpacing.large,
+              ),
+              child: SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed: () => coordinator.pushVerify(reason: reason),
+                  child: const Text('계속 진행'),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InfoSection extends StatelessWidget {
+  const _InfoSection({
+    required this.title,
+    required this.items,
+  });
+
+  final String title;
+  final List<String> items;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(MinglitSpacing.medium),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: theme.textTheme.titleSmall),
+            const SizedBox(height: MinglitSpacing.small),
+            for (final item in items) ...[
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Padding(
+                    padding: EdgeInsets.only(top: 6),
+                    child: Icon(Icons.circle, size: 8),
+                  ),
+                  const SizedBox(width: MinglitSpacing.small),
+                  Expanded(child: Text(item)),
+                ],
+              ),
+              const SizedBox(height: MinglitSpacing.small),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/app_user/lib/src/features/account_deletion/ui/deletion_reason_page.dart
+++ b/apps/app_user/lib/src/features/account_deletion/ui/deletion_reason_page.dart
@@ -1,0 +1,124 @@
+import 'package:app_user/src/features/account_deletion/account_deletion_flow.dart';
+import 'package:app_user/src/features/account_deletion/logic/account_deletion_coordinator.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+class DeletionReasonPage extends ConsumerStatefulWidget {
+  const DeletionReasonPage({super.key});
+
+  @override
+  ConsumerState<DeletionReasonPage> createState() => _DeletionReasonPageState();
+}
+
+class _DeletionReasonPageState extends ConsumerState<DeletionReasonPage> {
+  final TextEditingController _detailController = TextEditingController();
+  WithdrawalReasonCode? _selectedCode;
+
+  @override
+  void dispose() {
+    _detailController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final coordinator = ref.read(accountDeletionCoordinatorProvider);
+    final selectedReason = _selectedCode == null
+        ? null
+        : WithdrawalReason(
+            reasonCode: _selectedCode!,
+            detail: _selectedCode == WithdrawalReasonCode.other
+                ? _detailController.text
+                : null,
+          );
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('탈퇴 사유')),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.all(MinglitSpacing.large),
+                children: [
+                  Text(
+                    '떠나시는 이유를 알려주시면 더 나은 밍릿을 만드는 데 도움이 돼요.',
+                    style: theme.textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: MinglitSpacing.small),
+                  Text(
+                    '선택하지 않고 계속 진행해도 괜찮아요.',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(height: MinglitSpacing.large),
+                  for (final option in accountDeletionReasonOptions) ...[
+                    Card(
+                      margin: const EdgeInsets.only(
+                        bottom: MinglitSpacing.small,
+                      ),
+                      child: RadioListTile<WithdrawalReasonCode>(
+                        value: option.code,
+                        groupValue: _selectedCode,
+                        onChanged: (value) {
+                          setState(() {
+                            _selectedCode = value;
+                            if (_selectedCode != WithdrawalReasonCode.other) {
+                              _detailController.clear();
+                            }
+                          });
+                        },
+                        title: Text(option.title),
+                        subtitle: Text(option.description),
+                      ),
+                    ),
+                  ],
+                  if (_selectedCode == WithdrawalReasonCode.other) ...[
+                    const SizedBox(height: MinglitSpacing.small),
+                    MinglitTextField(
+                      label: '상세 사유',
+                      controller: _detailController,
+                      hintText: '남겨주고 싶은 내용을 입력해주세요',
+                      maxLines: 4,
+                      inputFormatters: [
+                        LengthLimitingTextInputFormatter(200),
+                      ],
+                      onChanged: (_) => setState(() {}),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                MinglitSpacing.large,
+                MinglitSpacing.small,
+                MinglitSpacing.large,
+                MinglitSpacing.large,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  TextButton(
+                    onPressed: coordinator.pushInfo,
+                    child: const Text('선택하지 않고 계속하기'),
+                  ),
+                  const SizedBox(height: MinglitSpacing.small),
+                  FilledButton(
+                    onPressed: _selectedCode == null
+                        ? null
+                        : () => coordinator.pushInfo(reason: selectedReason),
+                    child: const Text('다음'),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/app_user/lib/src/features/account_deletion/ui/deletion_verify_page.dart
+++ b/apps/app_user/lib/src/features/account_deletion/ui/deletion_verify_page.dart
@@ -1,0 +1,173 @@
+import 'package:app_user/src/features/account_deletion/account_deletion_flow.dart';
+import 'package:app_user/src/features/account_deletion/logic/account_deletion_coordinator.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+class DeletionVerifyPage extends ConsumerStatefulWidget {
+  const DeletionVerifyPage({
+    this.reasonCode,
+    this.reasonText,
+    super.key,
+  });
+
+  final String? reasonCode;
+  final String? reasonText;
+
+  @override
+  ConsumerState<DeletionVerifyPage> createState() => _DeletionVerifyPageState();
+}
+
+class _DeletionVerifyPageState extends ConsumerState<DeletionVerifyPage> {
+  final TextEditingController _passwordController = TextEditingController();
+  String? _passwordErrorText;
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final user = ref.watch(currentUserProvider);
+    final deletionState = ref.watch(accountDeletionControllerProvider);
+    final isLoading = deletionState.isLoading;
+    final reason = buildWithdrawalReason(
+      reasonCode: widget.reasonCode,
+      reasonText: widget.reasonText,
+    );
+
+    if (user == null) {
+      return const Scaffold(body: SizedBox.shrink());
+    }
+
+    final isPasswordUser = usesPasswordAuth(user);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('본인 확인')),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.all(MinglitSpacing.large),
+                children: [
+                  Text(
+                    '회원 탈퇴 전에 본인 확인이 필요해요.',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: MinglitSpacing.small),
+                  Text(
+                    '탈퇴 요청이 접수되면 7일 동안 복구할 수 있어요.',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: MinglitSpacing.large),
+                  if (reason != null)
+                    Card(
+                      child: ListTile(
+                        leading: const Icon(Icons.check_circle_outline),
+                        title: const Text('선택한 탈퇴 사유'),
+                        subtitle: Text(
+                          withdrawalReasonLabel(reason.reasonCode),
+                        ),
+                      ),
+                    ),
+                  if (reason != null)
+                    const SizedBox(height: MinglitSpacing.medium),
+                  if (isPasswordUser)
+                    MinglitTextField(
+                      label: '비밀번호',
+                      controller: _passwordController,
+                      obscureText: true,
+                      errorText: _passwordErrorText,
+                      hintText: '현재 비밀번호를 입력해주세요',
+                      onChanged: (_) {
+                        if (_passwordErrorText != null) {
+                          setState(() {
+                            _passwordErrorText = null;
+                          });
+                        }
+                      },
+                    )
+                  else
+                    Card(
+                      child: Padding(
+                        padding: const EdgeInsets.all(MinglitSpacing.medium),
+                        child: Text(
+                          '소셜 로그인 계정은 다음 단계에서 재인증이 진행돼요.',
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                MinglitSpacing.large,
+                MinglitSpacing.small,
+                MinglitSpacing.large,
+                MinglitSpacing.large,
+              ),
+              child: SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed: isLoading
+                      ? null
+                      : () => _submitDeletion(
+                          context,
+                          isPasswordUser: isPasswordUser,
+                          reason: reason,
+                        ),
+                  child: isLoading
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('탈퇴 요청'),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _submitDeletion(
+    BuildContext context, {
+    required bool isPasswordUser,
+    required WithdrawalReason? reason,
+  }) async {
+    final password = _passwordController.text.trim();
+    if (isPasswordUser && password.isEmpty) {
+      setState(() {
+        _passwordErrorText = '비밀번호를 입력해주세요.';
+      });
+      return;
+    }
+
+    final controller = ref.read(accountDeletionControllerProvider.notifier);
+    try {
+      await controller.reauthenticate(isPasswordUser ? password : null);
+      if (!context.mounted) return;
+
+      final confirmed = await context.showMinglitConfirm(
+        title: '정말 탈퇴할까요?',
+        message: '탈퇴 요청 후 7일 동안은 다시 로그인해 복구할 수 있어요.',
+        confirmLabel: '탈퇴 요청',
+        cancelLabel: '돌아가기',
+      );
+      if (!confirmed || !context.mounted) return;
+
+      await controller.requestDeletion(reason: reason);
+      if (!context.mounted) return;
+
+      ref.read(accountDeletionCoordinatorProvider).goComplete();
+    } on Object catch (error, stackTrace) {
+      if (!context.mounted) return;
+      handleMinglitError(context, error, stackTrace);
+    }
+  }
+}

--- a/apps/app_user/lib/src/features/settings/privacy_page.dart
+++ b/apps/app_user/lib/src/features/settings/privacy_page.dart
@@ -1,39 +1,65 @@
+import 'package:app_user/src/features/account_deletion/logic/account_deletion_coordinator.dart';
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
-/// Fix #139: Placeholder privacy page for future privacy settings.
-class PrivacyPage extends StatelessWidget {
+class PrivacyPage extends ConsumerWidget {
   /// Creates a [PrivacyPage].
   const PrivacyPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
+    final deletionStatus = ref.watch(accountDeletionControllerProvider);
+    final isPending = deletionStatus.value?.isPending ?? false;
+
     return Scaffold(
       appBar: AppBar(title: const Text('개인정보')),
-      body: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              Icons.lock_outline,
-              size: 64,
+      body: ListView(
+        padding: const EdgeInsets.all(MinglitSpacing.large),
+        children: [
+          Icon(
+            Icons.lock_outline,
+            size: 56,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(height: MinglitSpacing.medium),
+          Text(
+            '개인정보 관리',
+            style: theme.textTheme.headlineSmall,
+          ),
+          const SizedBox(height: MinglitSpacing.small),
+          Text(
+            '회원 탈퇴 요청을 진행하면 7일 동안 다시 로그인해 계정을 복구할 수 있어요.',
+            style: theme.textTheme.bodyMedium?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
-            const SizedBox(height: MinglitSpacing.medium),
-            Text(
-              '준비 중입니다',
-              style: theme.textTheme.titleMedium,
-            ),
-            const SizedBox(height: MinglitSpacing.small),
-            Text(
-              '개인정보 관련 설정이 곧 추가될 예정입니다',
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(height: MinglitSpacing.large),
+          Card(
+            child: ListTile(
+              leading: Icon(
+                isPending ? Icons.hourglass_top : Icons.person_remove_outlined,
+                color: MinglitColors.error,
+              ),
+              title: Text(isPending ? '탈퇴 요청 진행 중' : '회원 탈퇴'),
+              subtitle: Text(
+                isPending
+                    ? '유예 기간 안에는 다시 로그인해 계정을 복구할 수 있어요.'
+                    : '탈퇴 사유 선택, 안내 확인, 본인 확인 후 요청할 수 있어요.',
               ),
             ),
-          ],
-        ),
+          ),
+          const SizedBox(height: MinglitSpacing.medium),
+          SizedBox(
+            width: double.infinity,
+            child: TextButton(
+              onPressed: () {
+                ref.read(accountDeletionCoordinatorProvider).start();
+              },
+              child: Text(isPending ? '탈퇴 진행 상태 보기' : '회원 탈퇴 시작하기'),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/apps/app_user/lib/src/routing/app_routes.dart
+++ b/apps/app_user/lib/src/routing/app_routes.dart
@@ -1,3 +1,7 @@
+import 'package:app_user/src/features/account_deletion/ui/deletion_complete_page.dart';
+import 'package:app_user/src/features/account_deletion/ui/deletion_info_page.dart';
+import 'package:app_user/src/features/account_deletion/ui/deletion_reason_page.dart';
+import 'package:app_user/src/features/account_deletion/ui/deletion_verify_page.dart';
 import 'package:app_user/src/features/auth/login_page.dart';
 import 'package:app_user/src/features/auth/ui/auth_callback_page.dart';
 import 'package:app_user/src/features/event/admission/event_application_wizard_page.dart';
@@ -245,6 +249,66 @@ class PrivacyRoute extends GoRouteData with $PrivacyRoute {
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       const PrivacyPage();
+}
+
+/// **Deletion Reason Route**: Account deletion reason selection page.
+/// Path: `/my/privacy/delete/reason`
+@TypedGoRoute<DeletionReasonRoute>(path: '/my/privacy/delete/reason')
+class DeletionReasonRoute extends GoRouteData with $DeletionReasonRoute {
+  const DeletionReasonRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const DeletionReasonPage();
+}
+
+/// **Deletion Info Route**: Account deletion 안내 page.
+/// Path: `/my/privacy/delete/info`
+@TypedGoRoute<DeletionInfoRoute>(path: '/my/privacy/delete/info')
+class DeletionInfoRoute extends GoRouteData with $DeletionInfoRoute {
+  const DeletionInfoRoute({
+    this.reasonCode,
+    this.reasonText,
+  });
+
+  final String? reasonCode;
+  final String? reasonText;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) => DeletionInfoPage(
+    reasonCode: reasonCode,
+    reasonText: reasonText,
+  );
+}
+
+/// **Deletion Verify Route**: Account deletion verification page.
+/// Path: `/my/privacy/delete/verify`
+@TypedGoRoute<DeletionVerifyRoute>(path: '/my/privacy/delete/verify')
+class DeletionVerifyRoute extends GoRouteData with $DeletionVerifyRoute {
+  const DeletionVerifyRoute({
+    this.reasonCode,
+    this.reasonText,
+  });
+
+  final String? reasonCode;
+  final String? reasonText;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) => DeletionVerifyPage(
+    reasonCode: reasonCode,
+    reasonText: reasonText,
+  );
+}
+
+/// **Deletion Complete Route**: Account deletion completion page.
+/// Path: `/my/privacy/delete/complete`
+@TypedGoRoute<DeletionCompleteRoute>(path: '/my/privacy/delete/complete')
+class DeletionCompleteRoute extends GoRouteData with $DeletionCompleteRoute {
+  const DeletionCompleteRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const DeletionCompletePage();
 }
 
 /// **Blocked Partners Route**: Blocked partners list page.

--- a/apps/app_user/lib/src/routing/app_routes.g.dart
+++ b/apps/app_user/lib/src/routing/app_routes.g.dart
@@ -24,6 +24,10 @@ List<RouteBase> get $appRoutes => [
   $searchRoute,
   $myPageRoute,
   $privacyRoute,
+  $deletionReasonRoute,
+  $deletionInfoRoute,
+  $deletionVerifyRoute,
+  $deletionCompleteRoute,
   $blockedPartnersRoute,
 ];
 
@@ -539,6 +543,131 @@ mixin $PrivacyRoute on GoRouteData {
 
   @override
   String get location => GoRouteData.$location('/my/privacy');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $deletionReasonRoute => GoRouteData.$route(
+  path: '/my/privacy/delete/reason',
+  factory: $DeletionReasonRoute._fromState,
+);
+
+mixin $DeletionReasonRoute on GoRouteData {
+  static DeletionReasonRoute _fromState(GoRouterState state) =>
+      const DeletionReasonRoute();
+
+  @override
+  String get location => GoRouteData.$location('/my/privacy/delete/reason');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $deletionInfoRoute => GoRouteData.$route(
+  path: '/my/privacy/delete/info',
+  factory: $DeletionInfoRoute._fromState,
+);
+
+mixin $DeletionInfoRoute on GoRouteData {
+  static DeletionInfoRoute _fromState(GoRouterState state) => DeletionInfoRoute(
+    reasonCode: state.uri.queryParameters['reason-code'],
+    reasonText: state.uri.queryParameters['reason-text'],
+  );
+
+  DeletionInfoRoute get _self => this as DeletionInfoRoute;
+
+  @override
+  String get location => GoRouteData.$location(
+    '/my/privacy/delete/info',
+    queryParams: {
+      if (_self.reasonCode != null) 'reason-code': _self.reasonCode,
+      if (_self.reasonText != null) 'reason-text': _self.reasonText,
+    },
+  );
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $deletionVerifyRoute => GoRouteData.$route(
+  path: '/my/privacy/delete/verify',
+  factory: $DeletionVerifyRoute._fromState,
+);
+
+mixin $DeletionVerifyRoute on GoRouteData {
+  static DeletionVerifyRoute _fromState(GoRouterState state) =>
+      DeletionVerifyRoute(
+        reasonCode: state.uri.queryParameters['reason-code'],
+        reasonText: state.uri.queryParameters['reason-text'],
+      );
+
+  DeletionVerifyRoute get _self => this as DeletionVerifyRoute;
+
+  @override
+  String get location => GoRouteData.$location(
+    '/my/privacy/delete/verify',
+    queryParams: {
+      if (_self.reasonCode != null) 'reason-code': _self.reasonCode,
+      if (_self.reasonText != null) 'reason-text': _self.reasonText,
+    },
+  );
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $deletionCompleteRoute => GoRouteData.$route(
+  path: '/my/privacy/delete/complete',
+  factory: $DeletionCompleteRoute._fromState,
+);
+
+mixin $DeletionCompleteRoute on GoRouteData {
+  static DeletionCompleteRoute _fromState(GoRouterState state) =>
+      const DeletionCompleteRoute();
+
+  @override
+  String get location => GoRouteData.$location('/my/privacy/delete/complete');
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/apps/app_user/test/integration/flow_my_page_test.dart
+++ b/apps/app_user/test/integration/flow_my_page_test.dart
@@ -48,7 +48,7 @@ void main() {
       expect(find.byType(NotificationSettingsScreen), findsOneWidget);
     });
 
-    testWidgets('개인정보 tap → PrivacyPage (Navigator.push)', (tester) async {
+    testWidgets('개인정보 tap → PrivacyPage → 회원 탈퇴 시작', (tester) async {
       setKoreanLocale(tester);
       final user = createMockUserForTest();
       await tester.pumpWidget(
@@ -66,7 +66,13 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(PrivacyPage), findsOneWidget);
-      expect(find.text('준비 중입니다'), findsOneWidget);
+      expect(find.text('개인정보 관리'), findsOneWidget);
+
+      await tester.tap(find.text('회원 탈퇴 시작하기'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('탈퇴 사유'), findsOneWidget);
+      expect(find.text('더 이상 쓰지 않아요'), findsOneWidget);
     });
 
     testWidgets('권한 설정 tap → AppPermissionSettingsScreen (Navigator.push)', (
@@ -248,7 +254,9 @@ void main() {
       setKoreanLocale(tester);
       final user = createMockUserForTest();
       final now = DateTime.now();
-      // canCancel: paid + paymentId + paymentAmount + event.startTime + refundStatus == 'none'
+      // canCancel:
+      // paid + paymentId + paymentAmount + event.startTime +
+      // refundStatus == 'none'
       final refundableApp = _createApplication(
         status: 'paid',
         createdAt: now,

--- a/apps/app_user/test/src/features/account_deletion/ui/deletion_complete_page_test.dart
+++ b/apps/app_user/test/src/features/account_deletion/ui/deletion_complete_page_test.dart
@@ -1,0 +1,21 @@
+import 'package:app_user/src/features/account_deletion/ui/deletion_complete_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+void main() {
+  testWidgets('탈퇴 완료 메시지와 확인 버튼을 렌더링한다', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          theme: MinglitTheme.materialTheme,
+          home: const DeletionCompletePage(),
+        ),
+      ),
+    );
+
+    expect(find.text('탈퇴 요청이 완료됐어요'), findsOneWidget);
+    expect(find.textContaining('7일 안에 다시 로그인하면 계정을 복구'), findsOneWidget);
+    expect(find.text('확인'), findsOneWidget);
+  });
+}

--- a/apps/app_user/test/src/features/account_deletion/ui/deletion_info_page_test.dart
+++ b/apps/app_user/test/src/features/account_deletion/ui/deletion_info_page_test.dart
@@ -1,0 +1,46 @@
+import 'package:app_user/src/features/account_deletion/logic/account_deletion_coordinator.dart';
+import 'package:app_user/src/features/account_deletion/ui/deletion_info_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+void main() {
+  testWidgets('탈퇴 안내 페이지의 핵심 정보가 표시된다', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          accountDeletionCoordinatorProvider.overrideWithValue(
+            _FakeAccountDeletionCoordinator(),
+          ),
+        ],
+        child: MaterialApp(
+          theme: MinglitTheme.materialTheme,
+          home: const DeletionInfoPage(
+            reasonCode: 'privacy_concern',
+            reasonText: '개인정보가 걱정돼요',
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('선택한 탈퇴 사유'), findsOneWidget);
+    expect(find.text('삭제되는 정보'), findsOneWidget);
+    expect(find.text('법정 보존 정보'), findsOneWidget);
+    expect(find.text('계속 진행'), findsOneWidget);
+  });
+}
+
+class _FakeAccountDeletionCoordinator extends AccountDeletionCoordinator {
+  _FakeAccountDeletionCoordinator()
+    : super(
+        GoRouter(
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) => const SizedBox.shrink(),
+            ),
+          ],
+        ),
+      );
+}

--- a/apps/app_user/test/src/features/account_deletion/ui/deletion_reason_page_test.dart
+++ b/apps/app_user/test/src/features/account_deletion/ui/deletion_reason_page_test.dart
@@ -1,0 +1,89 @@
+import 'package:app_user/src/features/account_deletion/logic/account_deletion_coordinator.dart';
+import 'package:app_user/src/features/account_deletion/ui/deletion_reason_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+void main() {
+  testWidgets('6개 탈퇴 사유를 렌더링하고 기타 선택 시 입력 필드를 노출한다', (
+    tester,
+  ) async {
+    final coordinator = _FakeAccountDeletionCoordinator();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          accountDeletionCoordinatorProvider.overrideWithValue(coordinator),
+        ],
+        child: MaterialApp(
+          theme: MinglitTheme.materialTheme,
+          home: const DeletionReasonPage(),
+        ),
+      ),
+    );
+
+    expect(find.text('더 이상 쓰지 않아요'), findsOneWidget);
+    expect(find.text('원하는 이벤트가 없어요'), findsOneWidget);
+    expect(find.text('다른 서비스를 이용 중이에요'), findsOneWidget);
+    expect(find.text('개인정보가 걱정돼요'), findsOneWidget);
+    await tester.scrollUntilVisible(find.text('앱 사용이 어려워요'), 200);
+    expect(find.text('앱 사용이 어려워요'), findsOneWidget);
+    expect(find.text('직접 입력할게요'), findsOneWidget);
+    expect(find.text('상세 사유'), findsNothing);
+
+    await tester.tap(find.text('직접 입력할게요'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('상세 사유'), findsOneWidget);
+  });
+
+  testWidgets('사유 선택 후 다음을 누르면 coordinator로 reason이 전달된다', (
+    tester,
+  ) async {
+    final coordinator = _FakeAccountDeletionCoordinator();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          accountDeletionCoordinatorProvider.overrideWithValue(coordinator),
+        ],
+        child: MaterialApp(
+          theme: MinglitTheme.materialTheme,
+          home: const DeletionReasonPage(),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('개인정보가 걱정돼요'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('다음'));
+    await tester.pumpAndSettle();
+
+    expect(
+      coordinator.lastReason?.reasonCode,
+      WithdrawalReasonCode.privacyConcern,
+    );
+  });
+}
+
+class _FakeAccountDeletionCoordinator extends AccountDeletionCoordinator {
+  _FakeAccountDeletionCoordinator()
+    : super(
+        GoRouter(
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) => const SizedBox.shrink(),
+            ),
+          ],
+        ),
+      );
+
+  WithdrawalReason? lastReason;
+
+  @override
+  void pushInfo({WithdrawalReason? reason}) {
+    lastReason = reason;
+  }
+}

--- a/apps/app_user/test/src/features/account_deletion/ui/deletion_verify_page_test.dart
+++ b/apps/app_user/test/src/features/account_deletion/ui/deletion_verify_page_test.dart
@@ -1,0 +1,51 @@
+import 'package:app_user/src/features/account_deletion/ui/deletion_verify_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+void main() {
+  testWidgets('이메일 로그인 유저에게 비밀번호 입력 필드를 표시한다', (
+    tester,
+  ) async {
+    final user = MockUser();
+    when(() => user.appMetadata).thenReturn(const {'provider': 'email'});
+    when(() => user.identities).thenReturn(const []);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          currentUserProvider.overrideWith((ref) => user),
+          accountRepositoryProvider.overrideWithValue(_FakeAccountRepository()),
+        ],
+        child: MaterialApp(
+          theme: MinglitTheme.materialTheme,
+          home: const DeletionVerifyPage(reasonCode: 'privacy_concern'),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('비밀번호'), findsOneWidget);
+    expect(find.text('탈퇴 요청'), findsOneWidget);
+  });
+}
+
+class MockUser extends Mock implements User {}
+
+class _FakeAccountRepository extends AccountRepository {
+  _FakeAccountRepository() : super(MockSupabaseClient());
+
+  @override
+  Future<DeletionStatus?> getDeletionStatus() async => null;
+
+  @override
+  Future<void> reauthenticate(String? password) async {}
+
+  @override
+  Future<DeletionStatus> deleteAccount(WithdrawalReason? reason) async =>
+      DeletionStatus.fromDeletedAt(DateTime(2026, 3, 31));
+}
+
+class MockSupabaseClient extends Mock implements SupabaseClient {}


### PR DESCRIPTION
Scheduler: needs-dev-codex-1

## Summary
- add app_user account-deletion feature with coordinator and 4-step UI flow
- replace the privacy placeholder with a real account deletion entry point
- add widget tests for each deletion screen and update the my-page integration flow

## Validation
- `cd apps/app_user && ~/development/flutter/bin/flutter test test/src/features/account_deletion/ui test/integration/flow_my_page_test.dart`
- `cd apps/app_user && ~/development/flutter/bin/dart analyze lib/src/features/account_deletion lib/src/features/settings/privacy_page.dart lib/src/routing/app_routes.dart test/src/features/account_deletion/ui test/integration/flow_my_page_test.dart`

## Notes
- targeted analyze is clean except for 2 Flutter deprecation infos on `RadioListTile.groupValue/onChanged`
- analyzer plugin emits an environment-specific build-hook warning in this workspace, but analysis completed

Closes #888
