### PR TITLE
feat(user): require consent before identity verification

### DIFF
--- a/apps/app_user/test/src/features/consent/identity_verification_consent_sheet_test.dart
+++ b/apps/app_user/test/src/features/consent/identity_verification_consent_sheet_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+void main() {
+  Widget buildSubject({
+    VoidCallback? onCancel,
+    VoidCallback? onAgree,
+  }) {
+    return ProviderScope(
+      child: MaterialApp(
+        theme: MinglitTheme.materialTheme,
+        home: Scaffold(
+          body: IdentityVerificationConsentSheet(
+            onCancel: onCancel ?? () {},
+            onAgree: onAgree ?? () {},
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('IdentityVerificationConsentSheet', () {
+    testWidgets('renders required consent copy', (tester) async {
+      await tester.pumpWidget(buildSubject());
+
+      expect(find.text('본인확인정보 수집·이용 동의'), findsOneWidget);
+      expect(find.text('CI'), findsNothing);
+      expect(find.text('• CI'), findsOneWidget);
+      expect(find.text('• DI'), findsOneWidget);
+      expect(find.text('• 이름'), findsOneWidget);
+      expect(find.text('• 생년월일'), findsOneWidget);
+      expect(find.text('• 성별'), findsOneWidget);
+      expect(find.text('• 휴대폰번호'), findsOneWidget);
+      expect(find.text('본인확인 및 중복가입 방지를 위해 아래 정보를 수집합니다.'), findsOneWidget);
+      expect(find.text('CI/DI는 암호화되어 안전하게 저장됩니다.'), findsOneWidget);
+      expect(find.text('동의하고 인증'), findsOneWidget);
+      expect(find.text('취소'), findsOneWidget);
+    });
+
+    testWidgets('invokes cancel callback when cancel tapped', (tester) async {
+      var cancelled = false;
+
+      await tester.pumpWidget(
+        buildSubject(
+          onCancel: () {
+            cancelled = true;
+          },
+        ),
+      );
+
+      await tester.ensureVisible(find.text('취소'));
+      await tester.tap(find.text('취소'));
+      await tester.pump();
+
+      expect(cancelled, isTrue);
+    });
+
+    testWidgets('invokes agree callback when agree tapped', (tester) async {
+      var agreed = false;
+
+      await tester.pumpWidget(
+        buildSubject(
+          onAgree: () {
+            agreed = true;
+          },
+        ),
+      );
+
+      await tester.ensureVisible(find.text('동의하고 인증'));
+      await tester.tap(find.text('동의하고 인증'));
+      await tester.pump();
+
+      expect(agreed, isTrue);
+    });
+  });
+}

--- a/shared/packages/minglit_kit/lib/minglit_ui.dart
+++ b/shared/packages/minglit_kit/lib/minglit_ui.dart
@@ -10,6 +10,7 @@ export 'src/features/permission/app_permission_settings_screen.dart';
 export 'src/features/search/ui/location_search_screen.dart';
 export 'src/features/social/ui/minglit_social_action_chip.dart';
 export 'src/features/social/ui/minglit_social_button.dart';
+export 'src/features/verification/ui/identity_verification_consent_sheet.dart';
 export 'src/features/verification/ui/identity_verification_screen.dart';
 export 'src/theme/minglit_text_theme_extension.dart';
 export 'src/theme/minglit_theme.dart';

--- a/shared/packages/minglit_kit/lib/src/features/verification/ui/identity_verification_consent_sheet.dart
+++ b/shared/packages/minglit_kit/lib/src/features/verification/ui/identity_verification_consent_sheet.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/src/theme/minglit_theme.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_bottom_sheet.dart';
+
+/// Returns whether the user agreed to collect identity verification data.
+Future<bool> showIdentityVerificationConsentSheet(BuildContext context) async {
+  final result = await showMinglitBottomSheet<bool>(
+    context: context,
+    isScrollControlled: true,
+    child: IdentityVerificationConsentSheet(
+      onCancel: () => Navigator.of(context).pop(false),
+      onAgree: () => Navigator.of(context).pop(true),
+    ),
+  );
+
+  return result ?? false;
+}
+
+/// Consent sheet shown before starting CI/DI identity verification.
+class IdentityVerificationConsentSheet extends StatelessWidget {
+  /// Creates an [IdentityVerificationConsentSheet].
+  const IdentityVerificationConsentSheet({
+    required this.onCancel,
+    required this.onAgree,
+    super.key,
+  });
+
+  /// Invoked when the user dismisses the sheet.
+  final VoidCallback onCancel;
+
+  /// Invoked when the user agrees and wants to continue.
+  final VoidCallback onAgree;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '본인확인정보 수집·이용 동의',
+            style: theme.textTheme.titleLarge,
+          ),
+          const SizedBox(height: MinglitSpacing.small),
+          Text(
+            '본인확인 및 중복가입 방지를 위해 아래 정보를 수집합니다.',
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: MinglitSpacing.large),
+          const _ConsentSection(
+            title: '수집 항목',
+            items: ['CI', 'DI', '이름', '생년월일', '성별', '휴대폰번호'],
+          ),
+          const SizedBox(height: MinglitSpacing.medium),
+          const _ConsentSection(
+            title: '수집 목적',
+            items: ['본인확인 및 실명 인증', '중복가입 방지'],
+          ),
+          const SizedBox(height: MinglitSpacing.medium),
+          const _ConsentSection(
+            title: '보유 기간',
+            items: ['회원 탈퇴 시까지'],
+          ),
+          const SizedBox(height: MinglitSpacing.medium),
+          Text(
+            'CI/DI는 암호화되어 안전하게 저장됩니다.',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: MinglitSpacing.large),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: onAgree,
+              child: const Text('동의하고 인증'),
+            ),
+          ),
+          const SizedBox(height: MinglitSpacing.small),
+          SizedBox(
+            width: double.infinity,
+            child: TextButton(
+              onPressed: onCancel,
+              child: const Text('취소'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ConsentSection extends StatelessWidget {
+  const _ConsentSection({
+    required this.title,
+    required this.items,
+  });
+
+  final String title;
+  final List<String> items;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.4),
+        borderRadius: BorderRadius.circular(MinglitRadius.card),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(MinglitSpacing.medium),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: theme.textTheme.titleSmall,
+            ),
+            const SizedBox(height: MinglitSpacing.xsmall),
+            for (final item in items)
+              Padding(
+                padding: const EdgeInsets.only(bottom: MinglitSpacing.xxsmall),
+                child: Text(
+                  '• $item',
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/shared/packages/minglit_kit/lib/src/features/verification/ui/identity_verification_screen.dart
+++ b/shared/packages/minglit_kit/lib/src/features/verification/ui/identity_verification_screen.dart
@@ -5,7 +5,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:minglit_iamport_v1/minglit_iamport_v1.dart';
 import 'package:minglit_kit/src/config/iamport_config.dart';
+import 'package:minglit_kit/src/data/models/user_consent.dart';
+import 'package:minglit_kit/src/data/repositories/auth_repository.dart';
+import 'package:minglit_kit/src/data/repositories/consent_repository.dart';
+import 'package:minglit_kit/src/features/consent/logic/consent_controller.dart';
 import 'package:minglit_kit/src/features/iamport/data/repository/iamport_repository.dart';
+import 'package:minglit_kit/src/features/verification/ui/identity_verification_consent_sheet.dart';
 import 'package:minglit_kit/src/theme/minglit_theme.dart';
 import 'package:minglit_kit/src/ui/widgets/common/loading_indicator.dart';
 import 'package:minglit_kit/src/utils/error_ui_handler.dart';
@@ -33,46 +38,21 @@ class _IdentityVerificationScreenState
     super.initState();
     // Auto-start verification after first frame
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      unawaited(_startVerification());
+      unawaited(_startVerificationFlow());
     });
   }
 
-  Future<void> _startVerification() async {
+  Future<void> _startVerificationFlow() async {
     setState(() {
       _isLoading = true;
       _errorMessage = null;
     });
 
     try {
-      final merchantUid = 'IDV_${DateTime.now().millisecondsSinceEpoch}';
-      final config = ref.read(iamportConfigProvider);
+      final hasConsent = await _ensureIdentityVerificationConsent();
+      if (!hasConsent) return;
 
-      final service = getCertificationService();
-      final verificationId = await service.verify(
-        context: context,
-        userCode: config.userCode,
-        merchantUid: merchantUid,
-        mRedirectUrl: config.mobileRedirectUrl,
-      );
-
-      if (verificationId == null) {
-        // User cancelled or window blocked
-        setState(() {
-          _errorMessage = '인증이 취소되었거나 창이 열리지 않았습니다.';
-        });
-        return;
-      }
-
-      await ref
-          .read(iamportRepositoryProvider)
-          .verifyCertification(verificationId);
-
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('✅ 본인인증이 성공적으로 완료되었습니다.')),
-        );
-        Navigator.of(context).pop(true);
-      }
+      await _startVerification();
     } on Object catch (e) {
       if (mounted) {
         setState(() => _errorMessage = '인증 중 오류가 발생했습니다.');
@@ -80,6 +60,70 @@ class _IdentityVerificationScreenState
       }
     } finally {
       if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  Future<bool> _ensureIdentityVerificationConsent() async {
+    final user = ref.read(currentUserProvider);
+    if (user == null) {
+      _errorMessage = '로그인이 필요합니다.';
+      return false;
+    }
+
+    final consents = await ref
+        .read(consentRepositoryProvider)
+        .getConsents(
+          user.id,
+        );
+    final hasConsent = consents.any(
+      (consent) => consent.consentKey == ConsentType.identityVerification,
+    );
+    if (hasConsent) return true;
+
+    if (!mounted) return false;
+
+    final agreed = await showIdentityVerificationConsentSheet(context);
+    if (!agreed) {
+      _errorMessage = '본인확인정보 수집·이용 동의 후 인증을 진행할 수 있습니다.';
+      return false;
+    }
+
+    await ref
+        .read(consentControllerProvider.notifier)
+        .toggleConsent(ConsentType.identityVerification, consented: true);
+
+    return true;
+  }
+
+  Future<void> _startVerification() async {
+    final merchantUid = 'IDV_${DateTime.now().millisecondsSinceEpoch}';
+    final config = ref.read(iamportConfigProvider);
+
+    final service = getCertificationService();
+    final verificationId = await service.verify(
+      context: context,
+      userCode: config.userCode,
+      merchantUid: merchantUid,
+      mRedirectUrl: config.mobileRedirectUrl,
+    );
+
+    if (verificationId == null) {
+      // User cancelled or window blocked
+      setState(() {
+        _errorMessage = '인증이 취소되었거나 창이 열리지 않았습니다.';
+      });
+      return;
+    }
+
+    await ref
+        .read(iamportRepositoryProvider)
+        .verifyCertification(verificationId);
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('✅ 본인인증이 성공적으로 완료되었습니다.')),
+      );
+      Navigator.of(context).pop(true);
     }
   }
 
@@ -119,7 +163,7 @@ class _IdentityVerificationScreenState
                   width: double.infinity,
                   height: 52,
                   child: ElevatedButton(
-                    onPressed: _startVerification,
+                    onPressed: _startVerificationFlow,
                     child: const Text('본인인증 다시 시도하기'),
                   ),
                 ),


### PR DESCRIPTION
Scheduler: needs-dev-codex-1

Closes #885

## Summary
- add a reusable CI/DI consent bottom sheet for identity verification
- gate IdentityVerificationScreen so consent is saved before PortOne verification starts
- add widget coverage for the consent sheet interactions and copy

## Verification
- `/Users/mark/development/flutter/bin/flutter test test/src/features/consent/identity_verification_consent_sheet_test.dart`
- `/Users/mark/development/flutter/bin/flutter analyze lib/src/features/verification/ui/identity_verification_consent_sheet.dart lib/src/features/verification/ui/identity_verification_screen.dart lib/minglit_ui.dart`
- `/Users/mark/development/flutter/bin/flutter analyze test/src/features/consent/identity_verification_consent_sheet_test.dart`

## Notes
- full `flutter analyze` for `apps/app_user` still reports pre-existing info-level lint items outside this change set.