### PR TITLE
fix(db): exclude soft-deleted users from participant and match reads

### DIFF
--- a/supabase/migrations/20260331000001_rls_exclude_deleted_users.sql
+++ b/supabase/migrations/20260331000001_rls_exclude_deleted_users.sql
@@ -1,5 +1,7 @@
+-- Fix #891: soft-deleted user visibility를 participant/match read 경로에서 제외
 set search_path to public, extensions;
 
+-- Fix #891: soft-deleted user profile의 공개 가시성 판별 헬퍼 추가
 create or replace function public.is_visible_user_profile(p_user_id uuid)
 returns boolean
 language sql
@@ -14,7 +16,11 @@ as $$
   );
 $$;
 
+revoke all on function public.is_visible_user_profile(uuid) from public;
+grant execute on function public.is_visible_user_profile(uuid) to authenticated, service_role;
+
 drop policy if exists "Authenticated users can read all participants" on public.event_participants;
+-- Fix #891: soft-deleted participant는 본인만 조회 가능하고 타 유저에게는 숨김
 create policy "Authenticated users can read visible participants" on public.event_participants
   for select
   using (
@@ -25,6 +31,7 @@ create policy "Authenticated users can read visible participants" on public.even
     )
   );
 
+-- Fix #891: 매칭 뷰에서 soft-deleted 상대 유저를 제외
 create or replace view public.my_matches_view as
 select
   mp.id as match_id,
@@ -40,6 +47,7 @@ join public.user_profiles matched_user
 where (mp.user_lower_id = auth.uid() or mp.user_higher_id = auth.uid())
   and matched_user.deleted_at is null;
 
+-- Fix #891: 연락처 RPC가 soft-deleted 매칭 유저 정보를 반환하지 않도록 제한
 create or replace function public.get_matched_user_contact(target_user_id uuid, target_event_id uuid)
 returns text
 as $$
@@ -66,6 +74,10 @@ begin
 end;
 $$ language plpgsql security definer;
 
+revoke all on function public.get_matched_user_contact(uuid, uuid) from public;
+grant execute on function public.get_matched_user_contact(uuid, uuid) to authenticated, service_role;
+
+-- Fix #891: 프로필 RPC가 soft-deleted 매칭 유저 정보를 반환하지 않도록 제한
 create or replace function public.get_matched_user_info(
   p_target_user_id uuid,
   p_target_event_id uuid
@@ -92,3 +104,6 @@ begin
   end if;
 end;
 $$;
+
+revoke all on function public.get_matched_user_info(uuid, uuid) from public;
+grant execute on function public.get_matched_user_info(uuid, uuid) to authenticated, service_role;

--- a/supabase/migrations/20260331000001_rls_exclude_deleted_users.sql
+++ b/supabase/migrations/20260331000001_rls_exclude_deleted_users.sql
@@ -1,0 +1,94 @@
+set search_path to public, extensions;
+
+create or replace function public.is_visible_user_profile(p_user_id uuid)
+returns boolean
+language sql
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.user_profiles up
+    where up.id = p_user_id
+      and up.deleted_at is null
+  );
+$$;
+
+drop policy if exists "Authenticated users can read all participants" on public.event_participants;
+create policy "Authenticated users can read visible participants" on public.event_participants
+  for select
+  using (
+    auth.role() = 'authenticated'
+    and (
+      auth.uid() = user_id
+      or public.is_visible_user_profile(user_id)
+    )
+  );
+
+create or replace view public.my_matches_view as
+select
+  mp.id as match_id,
+  mp.event_id,
+  mp.matched_at,
+  matched_user.id as partner_id
+from public.match_pairs mp
+join public.user_profiles matched_user
+  on matched_user.id = case
+    when mp.user_lower_id = auth.uid() then mp.user_higher_id
+    else mp.user_lower_id
+  end
+where (mp.user_lower_id = auth.uid() or mp.user_higher_id = auth.uid())
+  and matched_user.deleted_at is null;
+
+create or replace function public.get_matched_user_contact(target_user_id uuid, target_event_id uuid)
+returns text
+as $$
+declare
+  contact_info text;
+begin
+  if exists (
+    select 1 from public.match_pairs
+    where event_id = target_event_id
+      and (
+        (user_lower_id = auth.uid() and user_higher_id = target_user_id) or
+        (user_lower_id = target_user_id and user_higher_id = auth.uid())
+      )
+  ) then
+    select phone_number into contact_info
+    from public.user_profiles
+    where id = target_user_id
+      and deleted_at is null;
+
+    return contact_info;
+  else
+    return null;
+  end if;
+end;
+$$ language plpgsql security definer;
+
+create or replace function public.get_matched_user_info(
+  p_target_user_id uuid,
+  p_target_event_id uuid
+)
+returns table(user_name text, profile_image_url text, phone_number text)
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if exists (
+    select 1 from public.match_pairs
+    where event_id = p_target_event_id
+      and (
+        (user_lower_id = auth.uid() and user_higher_id = p_target_user_id) or
+        (user_lower_id = p_target_user_id and user_higher_id = auth.uid())
+      )
+  ) then
+    return query
+      select up.name, up.profile_image_url, up.phone_number
+      from public.user_profiles up
+      where up.id = p_target_user_id
+        and up.deleted_at is null;
+  end if;
+end;
+$$;

--- a/supabase/tests/database/58_account_deletion_visibility_rls_test.sql
+++ b/supabase/tests/database/58_account_deletion_visibility_rls_test.sql
@@ -1,0 +1,109 @@
+BEGIN;
+SELECT plan(6);
+
+SELECT tests.create_supabase_user('deleted_user', 'deleted@test.com');
+SELECT tests.create_supabase_user('viewer_user', 'viewer@test.com');
+
+SELECT tests.authenticate_as_service_role();
+
+UPDATE public.user_profiles
+SET
+  name = 'Deleted User',
+  phone_number = '010-1111-1111',
+  deleted_at = now()
+WHERE id = tests.get_supabase_uid('deleted_user');
+
+UPDATE public.user_profiles
+SET name = 'Viewer User'
+WHERE id = tests.get_supabase_uid('viewer_user');
+
+WITH partner AS (
+  INSERT INTO public.partners (name)
+  VALUES ('Deleted Visibility Partner')
+  RETURNING id
+),
+party AS (
+  INSERT INTO public.parties (partner_id, title, status)
+  SELECT id, 'Deleted Visibility Party', 'active'
+  FROM partner
+  RETURNING id
+),
+event_row AS (
+  INSERT INTO public.events (party_id, title, start_time, end_time, status)
+  SELECT id, 'Deleted Visibility Event', now() + interval '1 day', now() + interval '1 day' + interval '2 hours', 'scheduled'
+  FROM party
+  RETURNING id
+),
+ticket_row AS (
+  INSERT INTO public.tickets (event_id, name, price, quantity, status)
+  SELECT id, 'Deleted Visibility Ticket', 1000, 10, 'on_sale'
+  FROM event_row
+  RETURNING id
+),
+participant_row AS (
+  INSERT INTO public.event_participants (event_id, ticket_id, user_id, status, ticket_code, display_name)
+  SELECT event_row.id, ticket_row.id, tests.get_supabase_uid('deleted_user'), 'ticket_issued', 'DELETED-TICKET', 'Deleted User'
+  FROM event_row, ticket_row
+  RETURNING id, event_id
+),
+match_pair AS (
+  INSERT INTO public.match_pairs (event_id, user_lower_id, user_higher_id)
+  SELECT
+    participant_row.event_id,
+    least(tests.get_supabase_uid('deleted_user'), tests.get_supabase_uid('viewer_user')),
+    greatest(tests.get_supabase_uid('deleted_user'), tests.get_supabase_uid('viewer_user'))
+  FROM participant_row
+  RETURNING event_id
+)
+SELECT
+  set_config('tests.participant_id', participant_row.id::text, true),
+  set_config('tests.event_id', participant_row.event_id::text, true)
+FROM participant_row;
+
+SELECT tests.authenticate_as('deleted_user');
+SELECT set_config('request.jwt.claims', (current_setting('request.jwt.claims', true)::jsonb || '{"role":"authenticated"}')::text, true);
+
+SELECT results_eq(
+  $$SELECT count(*)::int FROM public.user_profiles WHERE id = tests.get_supabase_uid('deleted_user')$$,
+  $$VALUES (1)$$,
+  'soft-deleted user can still read own profile during grace period'
+);
+
+SELECT results_eq(
+  $$SELECT count(*)::int FROM public.event_participants WHERE id = current_setting('tests.participant_id')::uuid$$,
+  $$VALUES (1)$$,
+  'soft-deleted user can still read own participant row'
+);
+
+SELECT tests.authenticate_as('viewer_user');
+SELECT set_config('request.jwt.claims', (current_setting('request.jwt.claims', true)::jsonb || '{"role":"authenticated"}')::text, true);
+
+SELECT is_empty(
+  $$SELECT id FROM public.event_participants WHERE id = current_setting('tests.participant_id')::uuid$$,
+  'other users cannot read soft-deleted participant rows'
+);
+
+SELECT is_empty(
+  $$SELECT partner_id FROM public.my_matches_view WHERE partner_id = tests.get_supabase_uid('deleted_user')$$,
+  'my_matches_view excludes soft-deleted matched users'
+);
+
+SELECT is_empty(
+  $$SELECT * FROM public.get_matched_user_info(
+      tests.get_supabase_uid('deleted_user'),
+      current_setting('tests.event_id')::uuid
+    )$$,
+  'get_matched_user_info hides soft-deleted matched users'
+);
+
+SELECT results_eq(
+  $$SELECT public.get_matched_user_contact(
+      tests.get_supabase_uid('deleted_user'),
+      current_setting('tests.event_id')::uuid
+    ) is null$$,
+  $$VALUES (true)$$,
+  'get_matched_user_contact returns null for soft-deleted matched users'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/58_account_deletion_visibility_rls_test.sql
+++ b/supabase/tests/database/58_account_deletion_visibility_rls_test.sql
@@ -1,5 +1,5 @@
 BEGIN;
-SELECT plan(6);
+SELECT plan(7);
 
 SELECT tests.create_supabase_user('deleted_user', 'deleted@test.com');
 SELECT tests.create_supabase_user('viewer_user', 'viewer@test.com');
@@ -46,6 +46,12 @@ participant_row AS (
   FROM event_row, ticket_row
   RETURNING id, event_id
 ),
+visible_participant_row AS (
+  INSERT INTO public.event_participants (event_id, ticket_id, user_id, status, ticket_code, display_name)
+  SELECT event_row.id, ticket_row.id, tests.get_supabase_uid('viewer_user'), 'ticket_issued', 'VISIBLE-TICKET', 'Viewer User'
+  FROM event_row, ticket_row
+  RETURNING id
+),
 match_pair AS (
   INSERT INTO public.match_pairs (event_id, user_lower_id, user_higher_id)
   SELECT
@@ -57,8 +63,10 @@ match_pair AS (
 )
 SELECT
   set_config('tests.participant_id', participant_row.id::text, true),
+  set_config('tests.visible_participant_id', visible_participant_row.id::text, true),
   set_config('tests.event_id', participant_row.event_id::text, true)
-FROM participant_row;
+FROM participant_row
+CROSS JOIN visible_participant_row;
 
 SELECT tests.authenticate_as('deleted_user');
 SELECT set_config('request.jwt.claims', (current_setting('request.jwt.claims', true)::jsonb || '{"role":"authenticated"}')::text, true);
@@ -77,6 +85,12 @@ SELECT results_eq(
 
 SELECT tests.authenticate_as('viewer_user');
 SELECT set_config('request.jwt.claims', (current_setting('request.jwt.claims', true)::jsonb || '{"role":"authenticated"}')::text, true);
+
+SELECT results_eq(
+  $$SELECT count(*)::int FROM public.event_participants WHERE id = current_setting('tests.visible_participant_id')::uuid$$,
+  $$VALUES (1)$$,
+  'visible participant rows remain readable cross-user'
+);
 
 SELECT is_empty(
   $$SELECT id FROM public.event_participants WHERE id = current_setting('tests.participant_id')::uuid$$,


### PR DESCRIPTION
Scheduler: needs-dev-codex-1

Closes #891

## Summary
- add a dedicated RLS migration to hide soft-deleted users from participant list reads for other users
- exclude soft-deleted matched users from `my_matches_view` and matched-user contact/info RPCs
- add pgTAP coverage for grace-period self access and cross-user visibility blocking

## Verification
- `supabase db reset --local --no-seed`
- `docker exec` + `psql` with `supabase/tests/database/00_setup.sql`
- `docker exec` + `psql` for `supabase/tests/database/58_account_deletion_visibility_rls_test.sql`
- `docker exec` + `psql` for `supabase/tests/database/24_rls_hardening_test.sql`
- `docker exec` + `psql` for `supabase/tests/database/05_commerce_rls_test.sql`