### PR TITLE
feat(user): replace PrivacyPage placeholder with consent management UI

### DIFF
--- a/apps/app_user/lib/src/features/settings/privacy_page.dart
+++ b/apps/app_user/lib/src/features/settings/privacy_page.dart
@@ -40,8 +40,7 @@ class _PrivacyPageState extends ConsumerState<PrivacyPage> {
     return Scaffold(
       appBar: AppBar(title: const Text('개인정보')),
       body: consentState.when(
-        loading: () =>
-            const Center(child: MinglitCircularProgressIndicator()),
+        loading: () => const Center(child: MinglitCircularProgressIndicator()),
         error: (e, st) => Center(
           child: Padding(
             padding: const EdgeInsets.all(MinglitSpacing.large),
@@ -88,14 +87,13 @@ class _PrivacyPageState extends ConsumerState<PrivacyPage> {
                 title: '본인인증 정보',
                 statusText:
                     (consentMap[ConsentType.identityVerification] ?? false)
-                        ? '동의됨'
-                        : '미동의',
-                onTap:
-                    (consentMap[ConsentType.identityVerification] ?? false)
-                        ? () => showConsentDetailSheet(
-                          context,
-                          content: _identityVerificationContent,
-                        )
+                    ? '동의됨'
+                    : '미동의',
+                onTap: (consentMap[ConsentType.identityVerification] ?? false)
+                    ? () => showConsentDetailSheet(
+                        context,
+                        content: _identityVerificationContent,
+                      )
                     : null,
               ),
 
@@ -189,8 +187,8 @@ class _SectionHeader extends StatelessWidget {
       child: Text(
         title,
         style: Theme.of(context).textTheme.titleSmall?.copyWith(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
-            ),
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
       ),
     );
   }

--- a/apps/app_user/lib/src/features/settings/privacy_page.dart
+++ b/apps/app_user/lib/src/features/settings/privacy_page.dart
@@ -1,66 +1,357 @@
+import 'dart:async';
+
 import 'package:app_user/src/features/account_deletion/logic/account_deletion_coordinator.dart';
+import 'package:app_user/src/features/consent/ui/consent_detail_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
-class PrivacyPage extends ConsumerWidget {
+/// Privacy settings page showing consent status, terms, and account
+/// management.
+class PrivacyPage extends ConsumerStatefulWidget {
   /// Creates a [PrivacyPage].
   const PrivacyPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
+  ConsumerState<PrivacyPage> createState() => _PrivacyPageState();
+}
+
+class _PrivacyPageState extends ConsumerState<PrivacyPage> {
+  @override
+  Widget build(BuildContext context) {
+    final consentState = ref.watch(consentControllerProvider);
     final deletionStatus = ref.watch(accountDeletionControllerProvider);
     final isPending = deletionStatus.value?.isPending ?? false;
 
+    ref.listen(consentControllerProvider, (prev, next) {
+      if (next.hasError && (prev?.hasValue ?? false)) {
+        // Fix #886: toggle 실패 시 원상복구 + 스낵바
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('동의 변경에 실패했습니다. 다시 시도해주세요.')),
+        );
+        // Invalidate to reload from server, which reverts the UI
+        unawaited(
+          Future.microtask(() {
+            if (mounted) ref.invalidate(consentControllerProvider);
+          }),
+        );
+      }
+    });
+
     return Scaffold(
       appBar: AppBar(title: const Text('개인정보')),
-      body: ListView(
-        padding: const EdgeInsets.all(MinglitSpacing.large),
-        children: [
-          Icon(
-            Icons.lock_outline,
-            size: 56,
-            color: theme.colorScheme.onSurfaceVariant,
-          ),
-          const SizedBox(height: MinglitSpacing.medium),
-          Text(
-            '개인정보 관리',
-            style: theme.textTheme.headlineSmall,
-          ),
-          const SizedBox(height: MinglitSpacing.small),
-          Text(
-            '회원 탈퇴 요청을 진행하면 7일 동안 다시 로그인해 계정을 복구할 수 있어요.',
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
+      body: consentState.when(
+        loading: () =>
+            const Center(child: MinglitCircularProgressIndicator()),
+        error: (e, st) => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(MinglitSpacing.large),
+            child: Text(
+              '동의 정보를 불러올 수 없습니다.',
+              style: Theme.of(context).textTheme.bodyLarge,
             ),
           ),
-          const SizedBox(height: MinglitSpacing.large),
-          Card(
-            child: ListTile(
-              leading: Icon(
-                isPending ? Icons.hourglass_top : Icons.person_remove_outlined,
-                color: MinglitColors.error,
+        ),
+        data: (consents) {
+          final consentMap = <ConsentType, bool>{
+            for (final c in consents) c.consentKey: c.consented,
+          };
+
+          return ListView(
+            children: [
+              // — 동의 현황 —
+              const _SectionHeader(title: '동의 현황'),
+              _ReadOnlyConsentTile(
+                title: '서비스 이용약관',
+                onTap: () => showConsentDetailSheet(
+                  context,
+                  content: _termsOfServiceContent,
+                ),
               ),
-              title: Text(isPending ? '탈퇴 요청 진행 중' : '회원 탈퇴'),
-              subtitle: Text(
-                isPending
-                    ? '유예 기간 안에는 다시 로그인해 계정을 복구할 수 있어요.'
-                    : '탈퇴 사유 선택, 안내 확인, 본인 확인 후 요청할 수 있어요.',
+              _ReadOnlyConsentTile(
+                title: '개인정보 수집·이용',
+                onTap: () => showConsentDetailSheet(
+                  context,
+                  content: _privacyCollectionContent,
+                ),
               ),
+              SwitchListTile(
+                title: const Text('제3자 제공 동의'),
+                value: consentMap[ConsentType.thirdPartyProvision] ?? false,
+                onChanged: (v) => _toggle(ConsentType.thirdPartyProvision, v),
+              ),
+              SwitchListTile(
+                title: const Text('마케팅 정보 수신'),
+                value: consentMap[ConsentType.marketingConsent] ?? false,
+                onChanged: (v) => _toggle(ConsentType.marketingConsent, v),
+              ),
+              _ReadOnlyConsentTile(
+                title: '본인인증 정보',
+                statusText:
+                    (consentMap[ConsentType.identityVerification] ?? false)
+                        ? '동의됨'
+                        : '미동의',
+                onTap:
+                    (consentMap[ConsentType.identityVerification] ?? false)
+                        ? () => showConsentDetailSheet(
+                          context,
+                          content: _identityVerificationContent,
+                        )
+                    : null,
+              ),
+
+              const Divider(height: 1),
+
+              // — 약관 보기 —
+              const _SectionHeader(title: '약관 보기'),
+              ListTile(
+                title: const Text('서비스 이용약관'),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () => showConsentDetailSheet(
+                  context,
+                  content: _termsOfServiceContent,
+                ),
+              ),
+              ListTile(
+                title: const Text('개인정보처리방침'),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () => showConsentDetailSheet(
+                  context,
+                  content: _privacyPolicyContent,
+                ),
+              ),
+
+              const Divider(height: 1),
+
+              // — 계정 —
+              const _SectionHeader(title: '계정'),
+              Card(
+                margin: const EdgeInsets.symmetric(
+                  horizontal: MinglitSpacing.screenEdge,
+                ),
+                child: ListTile(
+                  leading: Icon(
+                    isPending
+                        ? Icons.hourglass_top
+                        : Icons.person_remove_outlined,
+                    color: MinglitColors.error,
+                  ),
+                  title: Text(isPending ? '탈퇴 요청 진행 중' : '회원 탈퇴'),
+                  subtitle: Text(
+                    isPending
+                        ? '유예 기간 안에는 다시 로그인해 계정을 복구할 수 있어요.'
+                        : '탈퇴 사유 선택, 안내 확인, 본인 확인 후 요청할 수 있어요.',
+                  ),
+                ),
+              ),
+              const SizedBox(height: MinglitSpacing.medium),
+              SizedBox(
+                width: double.infinity,
+                child: TextButton(
+                  onPressed: () {
+                    ref.read(accountDeletionCoordinatorProvider).start();
+                  },
+                  child: Text(isPending ? '탈퇴 진행 상태 보기' : '회원 탈퇴 시작하기'),
+                ),
+              ),
+              const SizedBox(height: MinglitSpacing.large),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _toggle(ConsentType type, bool value) async {
+    await ref
+        .read(consentControllerProvider.notifier)
+        .toggleConsent(type, consented: value);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Section header
+// ---------------------------------------------------------------------------
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        MinglitSpacing.screenEdge,
+        MinglitSpacing.large,
+        MinglitSpacing.screenEdge,
+        MinglitSpacing.small,
+      ),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
             ),
-          ),
-          const SizedBox(height: MinglitSpacing.medium),
-          SizedBox(
-            width: double.infinity,
-            child: TextButton(
-              onPressed: () {
-                ref.read(accountDeletionCoordinatorProvider).start();
-              },
-              child: Text(isPending ? '탈퇴 진행 상태 보기' : '회원 탈퇴 시작하기'),
-            ),
-          ),
-        ],
       ),
     );
   }
 }
+
+// ---------------------------------------------------------------------------
+// Read-only consent tile (required consents + identity verification)
+// ---------------------------------------------------------------------------
+
+class _ReadOnlyConsentTile extends StatelessWidget {
+  const _ReadOnlyConsentTile({
+    required this.title,
+    this.statusText = '동의됨',
+    this.onTap,
+  });
+
+  final String title;
+  final String statusText;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListTile(
+      title: Text(title),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            statusText,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          if (onTap != null)
+            Icon(
+              Icons.chevron_right,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+        ],
+      ),
+      onTap: onTap,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Consent detail content (static data for bottom sheets)
+// ---------------------------------------------------------------------------
+
+const _termsOfServiceContent = ConsentDetailContent(
+  title: '서비스 이용약관',
+  summary: '서비스 이용을 위해 필요한 기본 권리와 의무를 안내합니다.',
+  sections: [
+    ConsentDetailSection(
+      title: '주요 내용',
+      items: [
+        '회원은 정확한 정보를 제공하고 안전하게 계정을 관리해야 합니다.',
+        '서비스 운영 정책과 커뮤니티 가이드를 위반하면 이용이 제한될 수 있습니다.',
+        '결제, 환불, 이벤트 신청 등 세부 정책은 개별 안내와 함께 적용됩니다.',
+      ],
+    ),
+    ConsentDetailSection(
+      title: '이용자 보호',
+      items: [
+        '법령과 약관에 따라 개인정보와 거래 정보를 보호합니다.',
+        '문의와 분쟁은 고객 지원 채널을 통해 접수하고 순차적으로 처리합니다.',
+      ],
+    ),
+  ],
+);
+
+const _privacyCollectionContent = ConsentDetailContent(
+  title: '개인정보 수집·이용 동의',
+  summary: '수집 항목과 이용 목적, 보관 기간을 안내합니다.',
+  sections: [
+    ConsentDetailSection(
+      title: '수집 항목',
+      items: [
+        '이름, 이메일, 프로필 사진',
+        '관심 태그, 이용 기록, 기기 정보',
+      ],
+    ),
+    ConsentDetailSection(
+      title: '이용 목적',
+      items: [
+        '회원 식별과 계정 관리',
+        '이벤트 추천과 서비스 품질 개선',
+        '고객 문의 대응과 공지 전달',
+      ],
+    ),
+    ConsentDetailSection(
+      title: '보관 기간',
+      items: [
+        '회원 탈퇴 시까지 보관합니다.',
+        '법령상 보관 의무가 있는 정보는 관련 기간 동안 별도 보관합니다.',
+      ],
+    ),
+  ],
+);
+
+const _identityVerificationContent = ConsentDetailContent(
+  title: '본인인증(CI/DI) 수집 동의',
+  summary: '본인 확인 서비스를 통해 연계정보(CI)와 중복가입확인정보(DI)를 수집합니다.',
+  sections: [
+    ConsentDetailSection(
+      title: '수집 항목',
+      items: [
+        '연계정보(CI): 본인 확인을 위한 고유 식별값',
+        '중복가입확인정보(DI): 동일 서비스 중복 가입 방지',
+      ],
+    ),
+    ConsentDetailSection(
+      title: '이용 목적',
+      items: [
+        '회원 본인 여부 확인',
+        '중복 계정 생성 방지',
+      ],
+    ),
+    ConsentDetailSection(
+      title: '보관 기간',
+      items: [
+        '회원 탈퇴 시까지 보관하며, 탈퇴 후 즉시 파기합니다.',
+      ],
+    ),
+  ],
+);
+
+const _privacyPolicyContent = ConsentDetailContent(
+  title: '개인정보처리방침',
+  summary: '밍릿의 개인정보 처리 방침을 안내합니다.',
+  sections: [
+    ConsentDetailSection(
+      title: '수집하는 개인정보',
+      items: [
+        '회원가입: 이름, 이메일, 프로필 사진',
+        '본인인증: 이름, 생년월일, 성별, 휴대폰 번호, CI/DI',
+        '서비스 이용: 관심 태그, 이벤트 참여 기록, 기기 정보',
+      ],
+    ),
+    ConsentDetailSection(
+      title: '개인정보 이용 목적',
+      items: [
+        '회원 관리 및 서비스 제공',
+        '이벤트 매칭 및 추천',
+        '고객 문의 대응',
+      ],
+    ),
+    ConsentDetailSection(
+      title: '개인정보 보관 기간',
+      items: [
+        '회원 탈퇴 시까지 보관합니다.',
+        '관련 법령에 따라 일정 기간 보관이 필요한 경우 해당 기간 동안 보관합니다.',
+      ],
+    ),
+    ConsentDetailSection(
+      title: '동의 철회',
+      items: [
+        '선택 항목은 설정 > 개인정보에서 언제든 철회할 수 있습니다.',
+        '필수 항목은 회원 탈퇴로만 철회할 수 있습니다.',
+      ],
+    ),
+  ],
+);

--- a/apps/app_user/test/integration/flow_my_page_test.dart
+++ b/apps/app_user/test/integration/flow_my_page_test.dart
@@ -56,6 +56,14 @@ void main() {
           isLoggedIn: true,
           currentUser: user,
           initialLocation: '/my',
+          additionalOverrides: [
+            consentControllerProvider.overrideWith(
+              _MockConsentController.new,
+            ),
+            accountDeletionControllerProvider.overrideWith(
+              _MockAccountDeletionController.new,
+            ),
+          ],
         ),
       );
       await tester.pump();
@@ -66,7 +74,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(PrivacyPage), findsOneWidget);
-      expect(find.text('개인정보 관리'), findsOneWidget);
+      expect(find.text('개인정보'), findsOneWidget);
 
       await tester.tap(find.text('회원 탈퇴 시작하기'));
       await tester.pumpAndSettle();
@@ -425,6 +433,52 @@ class _MockNotificationSettingsWithData extends NotificationSettingsController {
 class _MockNotificationSettingsNull extends NotificationSettingsController {
   @override
   FutureOr<UserSettings?> build() async => null;
+}
+
+/// ConsentController — returns mock consent data for PrivacyPage
+class _MockConsentController extends ConsentController {
+  @override
+  FutureOr<List<UserConsent>> build() async => [
+        UserConsent(
+          id: 'c1',
+          userId: 'test-user-id',
+          consentKey: ConsentType.termsOfService,
+          consented: true,
+          consentedAt: DateTime.now(),
+          createdAt: DateTime.now(),
+        ),
+        UserConsent(
+          id: 'c2',
+          userId: 'test-user-id',
+          consentKey: ConsentType.privacyCollection,
+          consented: true,
+          consentedAt: DateTime.now(),
+          createdAt: DateTime.now(),
+        ),
+        UserConsent(
+          id: 'c3',
+          userId: 'test-user-id',
+          consentKey: ConsentType.thirdPartyProvision,
+          consented: false,
+          consentedAt: DateTime.now(),
+          createdAt: DateTime.now(),
+        ),
+        UserConsent(
+          id: 'c4',
+          userId: 'test-user-id',
+          consentKey: ConsentType.marketingConsent,
+          consented: false,
+          consentedAt: DateTime.now(),
+          createdAt: DateTime.now(),
+        ),
+      ];
+}
+
+/// AccountDeletionController — returns non-pending status
+class _MockAccountDeletionController extends AccountDeletionController {
+  @override
+  FutureOr<DeletionStatus?> build() async =>
+      const DeletionStatus(isPending: false);
 }
 
 /// Fake SocialRepository for BlockedPartnersPage (returns empty list)

--- a/apps/app_user/test/integration/flow_my_page_test.dart
+++ b/apps/app_user/test/integration/flow_my_page_test.dart
@@ -76,6 +76,10 @@ void main() {
       expect(find.byType(PrivacyPage), findsOneWidget);
       expect(find.text('개인정보'), findsOneWidget);
 
+      // Fix #886: PrivacyPage has consent management sections above the
+      // account deletion button. The button is below the viewport in the
+      // ListView, so we must scroll to it before tapping.
+      await tester.scrollUntilVisible(find.text('회원 탈퇴 시작하기'), 100);
       await tester.tap(find.text('회원 탈퇴 시작하기'));
       await tester.pumpAndSettle();
 

--- a/apps/app_user/test/integration/flow_my_page_test.dart
+++ b/apps/app_user/test/integration/flow_my_page_test.dart
@@ -439,46 +439,45 @@ class _MockNotificationSettingsNull extends NotificationSettingsController {
 class _MockConsentController extends ConsentController {
   @override
   FutureOr<List<UserConsent>> build() async => [
-        UserConsent(
-          id: 'c1',
-          userId: 'test-user-id',
-          consentKey: ConsentType.termsOfService,
-          consented: true,
-          consentedAt: DateTime.now(),
-          createdAt: DateTime.now(),
-        ),
-        UserConsent(
-          id: 'c2',
-          userId: 'test-user-id',
-          consentKey: ConsentType.privacyCollection,
-          consented: true,
-          consentedAt: DateTime.now(),
-          createdAt: DateTime.now(),
-        ),
-        UserConsent(
-          id: 'c3',
-          userId: 'test-user-id',
-          consentKey: ConsentType.thirdPartyProvision,
-          consented: false,
-          consentedAt: DateTime.now(),
-          createdAt: DateTime.now(),
-        ),
-        UserConsent(
-          id: 'c4',
-          userId: 'test-user-id',
-          consentKey: ConsentType.marketingConsent,
-          consented: false,
-          consentedAt: DateTime.now(),
-          createdAt: DateTime.now(),
-        ),
-      ];
+    UserConsent(
+      id: 'c1',
+      userId: 'test-user-id',
+      consentKey: ConsentType.termsOfService,
+      consented: true,
+      consentedAt: DateTime.now(),
+      createdAt: DateTime.now(),
+    ),
+    UserConsent(
+      id: 'c2',
+      userId: 'test-user-id',
+      consentKey: ConsentType.privacyCollection,
+      consented: true,
+      consentedAt: DateTime.now(),
+      createdAt: DateTime.now(),
+    ),
+    UserConsent(
+      id: 'c3',
+      userId: 'test-user-id',
+      consentKey: ConsentType.thirdPartyProvision,
+      consented: false,
+      consentedAt: DateTime.now(),
+      createdAt: DateTime.now(),
+    ),
+    UserConsent(
+      id: 'c4',
+      userId: 'test-user-id',
+      consentKey: ConsentType.marketingConsent,
+      consented: false,
+      consentedAt: DateTime.now(),
+      createdAt: DateTime.now(),
+    ),
+  ];
 }
 
 /// AccountDeletionController — returns non-pending status
 class _MockAccountDeletionController extends AccountDeletionController {
   @override
-  FutureOr<DeletionStatus?> build() async =>
-      const DeletionStatus(isPending: false);
+  FutureOr<DeletionStatus?> build() async => const DeletionStatus();
 }
 
 /// Fake SocialRepository for BlockedPartnersPage (returns empty list)

--- a/apps/app_user/test/src/features/settings/privacy_page_test.dart
+++ b/apps/app_user/test/src/features/settings/privacy_page_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:app_user/src/features/account_deletion/logic/account_deletion_coordinator.dart';
 import 'package:app_user/src/features/settings/privacy_page.dart';
 import 'package:flutter/material.dart';
@@ -99,6 +101,37 @@ void main() {
 
     await tester.pumpAndSettle();
   }
+
+  testWidgets('로딩 중일 때 인디케이터가 표시된다', (tester) async {
+    final completer = Completer<List<UserConsent>>();
+    when(
+      () => mockRepository.getConsents('user_1'),
+    ).thenAnswer((_) => completer.future);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          consentRepositoryProvider.overrideWithValue(mockRepository),
+          currentUserProvider.overrideWithValue(mockUser),
+          accountRepositoryProvider.overrideWithValue(mockAccountRepo),
+          accountDeletionCoordinatorProvider.overrideWithValue(
+            MockAccountDeletionCoordinator(),
+          ),
+        ],
+        child: MaterialApp(
+          theme: MinglitTheme.materialTheme,
+          home: const PrivacyPage(),
+        ),
+      ),
+    );
+
+    await tester.pump(); // One frame to show loading
+    expect(find.byType(MinglitCircularProgressIndicator), findsOneWidget);
+
+    // Complete the future so the test tears down cleanly.
+    completer.complete(testConsents);
+    await tester.pumpAndSettle();
+  });
 
   testWidgets('로딩 인디케이터가 표시된 후 동의 현황이 보인다', (tester) async {
     await pumpPage(tester);

--- a/apps/app_user/test/src/features/settings/privacy_page_test.dart
+++ b/apps/app_user/test/src/features/settings/privacy_page_test.dart
@@ -152,8 +152,7 @@ void main() {
     expect(thirdPartyWidget.value, isFalse);
   });
 
-  testWidgets('마케팅 토글 시 ConsentController.toggleConsent를 호출한다',
-      (tester) async {
+  testWidgets('마케팅 토글 시 ConsentController.toggleConsent를 호출한다', (tester) async {
     await pumpPage(tester);
 
     // Toggle marketing OFF (currently ON)

--- a/apps/app_user/test/src/features/settings/privacy_page_test.dart
+++ b/apps/app_user/test/src/features/settings/privacy_page_test.dart
@@ -2,7 +2,6 @@ import 'package:app_user/src/features/account_deletion/logic/account_deletion_co
 import 'package:app_user/src/features/settings/privacy_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:go_router/go_router.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -179,9 +178,7 @@ void main() {
 
     // Scroll to 약관 보기 section
     await tester.scrollUntilVisible(find.text('개인정보처리방침'), 200);
-    // Tap 서비스 이용약관 in the 약관 보기 section (second occurrence)
-    final tosTiles = find.text('서비스 이용약관');
-    // There are multiple — tap the one in 약관 보기 (with chevron)
+    // Tap 서비스 이용약관 in the 약관 보기 section (with chevron)
     await tester.tap(find.widgetWithText(ListTile, '서비스 이용약관').last);
     await tester.pumpAndSettle();
 

--- a/apps/app_user/test/src/features/settings/privacy_page_test.dart
+++ b/apps/app_user/test/src/features/settings/privacy_page_test.dart
@@ -1,0 +1,224 @@
+import 'package:app_user/src/features/account_deletion/logic/account_deletion_coordinator.dart';
+import 'package:app_user/src/features/settings/privacy_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockConsentRepository extends Mock implements ConsentRepository {}
+
+class MockAccountRepository extends Mock implements AccountRepository {}
+
+class MockUser extends Mock implements User {}
+
+class MockAccountDeletionCoordinator extends Mock
+    implements AccountDeletionCoordinator {}
+
+void main() {
+  late MockConsentRepository mockRepository;
+  late MockAccountRepository mockAccountRepo;
+  late MockUser mockUser;
+
+  final testConsents = [
+    UserConsent(
+      id: '1',
+      userId: 'user_1',
+      consentKey: ConsentType.termsOfService,
+      consented: true,
+      consentedAt: DateTime(2026),
+      createdAt: DateTime(2026),
+    ),
+    UserConsent(
+      id: '2',
+      userId: 'user_1',
+      consentKey: ConsentType.privacyCollection,
+      consented: true,
+      consentedAt: DateTime(2026),
+      createdAt: DateTime(2026),
+    ),
+    UserConsent(
+      id: '3',
+      userId: 'user_1',
+      consentKey: ConsentType.thirdPartyProvision,
+      consented: false,
+      consentedAt: DateTime(2026),
+      createdAt: DateTime(2026),
+    ),
+    UserConsent(
+      id: '4',
+      userId: 'user_1',
+      consentKey: ConsentType.marketingConsent,
+      consented: true,
+      consentedAt: DateTime(2026),
+      createdAt: DateTime(2026),
+    ),
+    UserConsent(
+      id: '5',
+      userId: 'user_1',
+      consentKey: ConsentType.identityVerification,
+      consented: true,
+      consentedAt: DateTime(2026),
+      createdAt: DateTime(2026),
+    ),
+  ];
+
+  setUp(() {
+    mockRepository = MockConsentRepository();
+    mockAccountRepo = MockAccountRepository();
+    mockUser = MockUser();
+
+    when(() => mockUser.id).thenReturn('user_1');
+    when(
+      () => mockRepository.getConsents('user_1'),
+    ).thenAnswer((_) async => testConsents);
+    when(
+      () => mockRepository.saveConsents('user_1', any()),
+    ).thenAnswer((_) async {});
+    when(
+      () => mockAccountRepo.getDeletionStatus(),
+    ).thenAnswer((_) async => null);
+  });
+
+  Future<void> pumpPage(WidgetTester tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          consentRepositoryProvider.overrideWithValue(mockRepository),
+          currentUserProvider.overrideWithValue(mockUser),
+          accountRepositoryProvider.overrideWithValue(mockAccountRepo),
+          accountDeletionCoordinatorProvider.overrideWithValue(
+            MockAccountDeletionCoordinator(),
+          ),
+        ],
+        child: MaterialApp(
+          theme: MinglitTheme.materialTheme,
+          home: const PrivacyPage(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('로딩 인디케이터가 표시된 후 동의 현황이 보인다', (tester) async {
+    await pumpPage(tester);
+
+    expect(find.text('동의 현황'), findsOneWidget);
+    // "서비스 이용약관" appears in both 동의 현황 and 약관 보기 sections
+    expect(find.text('서비스 이용약관'), findsAtLeast(1));
+    expect(find.text('개인정보 수집·이용'), findsOneWidget);
+    expect(find.text('제3자 제공 동의'), findsOneWidget);
+    expect(find.text('마케팅 정보 수신'), findsOneWidget);
+    expect(find.text('본인인증 정보'), findsOneWidget);
+  });
+
+  testWidgets('필수 동의 항목은 읽기 전용 "동의됨"으로 표시된다', (tester) async {
+    await pumpPage(tester);
+
+    // 서비스 이용약관 and 개인정보 수집·이용 are read-only
+    expect(find.text('동의됨'), findsAtLeast(2));
+  });
+
+  testWidgets('본인인증이 동의된 경우 "동의됨"으로 표시된다', (tester) async {
+    await pumpPage(tester);
+
+    // identityVerification is consented in testConsents
+    expect(find.text('본인인증 정보'), findsOneWidget);
+    expect(find.text('동의됨'), findsAtLeast(3));
+  });
+
+  testWidgets('선택 동의 항목이 SwitchListTile로 표시된다', (tester) async {
+    await pumpPage(tester);
+
+    // 마케팅 정보 수신 switch should be ON (consented: true)
+    final marketingSwitch = tester.widgetList<SwitchListTile>(
+      find.byType(SwitchListTile),
+    );
+    expect(marketingSwitch.length, 2); // thirdParty + marketing
+
+    // 마케팅 is ON
+    final marketingTile = find.widgetWithText(SwitchListTile, '마케팅 정보 수신');
+    expect(marketingTile, findsOneWidget);
+    final marketingWidget = tester.widget<SwitchListTile>(marketingTile);
+    expect(marketingWidget.value, isTrue);
+
+    // 제3자 is OFF
+    final thirdPartyTile = find.widgetWithText(
+      SwitchListTile,
+      '제3자 제공 동의',
+    );
+    expect(thirdPartyTile, findsOneWidget);
+    final thirdPartyWidget = tester.widget<SwitchListTile>(thirdPartyTile);
+    expect(thirdPartyWidget.value, isFalse);
+  });
+
+  testWidgets('마케팅 토글 시 ConsentController.toggleConsent를 호출한다',
+      (tester) async {
+    await pumpPage(tester);
+
+    // Toggle marketing OFF (currently ON)
+    await tester.tap(find.widgetWithText(SwitchListTile, '마케팅 정보 수신'));
+    await tester.pumpAndSettle();
+
+    verify(
+      () => mockRepository.saveConsents('user_1', any()),
+    ).called(greaterThanOrEqualTo(1));
+  });
+
+  testWidgets('약관 보기 섹션이 표시된다', (tester) async {
+    await pumpPage(tester);
+
+    expect(find.text('약관 보기'), findsOneWidget);
+    // 서비스 이용약관 appears in both 동의 현황 and 약관 보기 sections
+    expect(find.text('개인정보처리방침'), findsOneWidget);
+  });
+
+  testWidgets('약관 보기에서 서비스 이용약관 탭 시 바텀시트가 열린다', (tester) async {
+    await pumpPage(tester);
+
+    // Scroll to 약관 보기 section
+    await tester.scrollUntilVisible(find.text('개인정보처리방침'), 200);
+    // Tap 서비스 이용약관 in the 약관 보기 section (second occurrence)
+    final tosTiles = find.text('서비스 이용약관');
+    // There are multiple — tap the one in 약관 보기 (with chevron)
+    await tester.tap(find.widgetWithText(ListTile, '서비스 이용약관').last);
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('서비스 이용을 위해 필요한 기본 권리와 의무를 안내합니다.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('개인정보처리방침 탭 시 바텀시트가 열린다', (tester) async {
+    await pumpPage(tester);
+
+    await tester.scrollUntilVisible(find.text('개인정보처리방침'), 200);
+    await tester.tap(find.text('개인정보처리방침'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('밍릿의 개인정보 처리 방침을 안내합니다.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('계정 섹션에 회원 탈퇴가 표시된다', (tester) async {
+    await pumpPage(tester);
+
+    await tester.scrollUntilVisible(find.text('회원 탈퇴'), 200);
+    expect(find.text('회원 탈퇴'), findsOneWidget);
+    expect(find.text('회원 탈퇴 시작하기'), findsOneWidget);
+  });
+
+  testWidgets('동의 정보 로드 실패 시 에러 메시지가 표시된다', (tester) async {
+    when(
+      () => mockRepository.getConsents('user_1'),
+    ).thenAnswer((_) async => throw Exception('network error'));
+
+    await pumpPage(tester);
+
+    expect(find.text('동의 정보를 불러올 수 없습니다.'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Scheduler: needs-dev-glm-1

## Summary

- Replace PrivacyPage placeholder with full consent management UI
- Show consent status: required consents (read-only), optional consents (SwitchListTile toggle)
- Add terms viewing section with ConsentDetailSheet bottom sheets
- Preserve account deletion section with deletion status awareness
- Handle toggle errors with snackbar + auto-revert via provider invalidation

Closes #886

## Test plan

- [x] `flutter analyze` passes (no new warnings)
- [x] 10/10 widget tests pass (`privacy_page_test.dart`)
- [ ] Manual: 설정 > 개인정보 → 동의 현황 표시 → 마케팅 토글 동작
- [ ] Manual: 약관 보기 → 서비스 이용약관/개인정보처리방침 바텀시트

🤖 Generated with [Claude Code](https://claude.com/claude-code)