### PR TITLE
feat(auth): recover pending deletion accounts on sign-in

### DIFF
--- a/apps/app_partner/lib/main.dart
+++ b/apps/app_partner/lib/main.dart
@@ -177,15 +177,15 @@ class _AppView extends ConsumerWidget {
           data: (_) => BugReporterWrapper(
             navigatorKey: rootNavigatorKey,
             // Fix #382: child 강제 언래핑 제거 — nullable child에 fallback 추가
-            child: MinglitGlobalLoadingOverlay(
-              child: child ?? const SizedBox.shrink(),
+            child: PendingDeletionRecoveryListener(
+              child: MinglitGlobalLoadingOverlay(
+                child: child ?? const SizedBox.shrink(),
+              ),
             ),
           ),
           // Hidden behind native splash — show nothing.
           loading: () => const SizedBox.shrink(),
-          error: (e, st) => Scaffold(
-            body: Center(child: Text('Error: $e')),
-          ),
+          error: (e, st) => Scaffold(body: Center(child: Text('Error: $e'))),
         );
       },
     );

--- a/apps/app_partner/test/src/routing/app_router_test.dart
+++ b/apps/app_partner/test/src/routing/app_router_test.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart'
+    show AuthChangeEvent, AuthState;
+
+class _MockSession extends Mock implements Session {}
+
+late DeletionStatus? _currentDeletionStatus;
+late int _checkStatusCalls;
+late int _cancelDeletionCalls;
+late int _signOutCalls;
+
+class _FakeAccountDeletionController extends AccountDeletionController {
+  @override
+  FutureOr<DeletionStatus?> build() async => _currentDeletionStatus;
+
+  @override
+  Future<DeletionStatus?> checkStatus() async {
+    _checkStatusCalls++;
+    return _currentDeletionStatus;
+  }
+
+  @override
+  Future<DeletionStatus?> cancelDeletion() async {
+    _cancelDeletionCalls++;
+    return _currentDeletionStatus = const DeletionStatus();
+  }
+}
+
+class _FakeAuthController extends AuthController {
+  @override
+  FutureOr<void> build() async {}
+
+  @override
+  Future<void> signOut() async {
+    _signOutCalls++;
+  }
+}
+
+void main() {
+  late StreamController<AuthState> authStateController;
+  late User user;
+  late _MockSession session;
+
+  setUp(() {
+    authStateController = StreamController<AuthState>.broadcast();
+    _currentDeletionStatus = null;
+    _checkStatusCalls = 0;
+    _cancelDeletionCalls = 0;
+    _signOutCalls = 0;
+    user = User(
+      id: 'partner-1',
+      appMetadata: const {
+        'provider': 'email',
+        'providers': ['email'],
+      },
+      userMetadata: const {},
+      aud: 'authenticated',
+      createdAt: DateTime(2026).toIso8601String(),
+      email: 'partner@test.com',
+      identities: const [],
+    );
+    session = _MockSession();
+    when(() => session.user).thenReturn(user);
+  });
+
+  tearDown(() async {
+    await authStateController.close();
+  });
+
+  Widget buildSubject() {
+    return ProviderScope(
+      overrides: [
+        authStateChangesProvider.overrideWith(
+          (_) => authStateController.stream,
+        ),
+        accountDeletionControllerProvider.overrideWith(
+          _FakeAccountDeletionController.new,
+        ),
+        authControllerProvider.overrideWith(_FakeAuthController.new),
+      ],
+      child: const MaterialApp(
+        home: PendingDeletionRecoveryListener(
+          child: Scaffold(body: Text('partner-home')),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('pending deletion sign-in can keep deletion and sign out', (
+    tester,
+  ) async {
+    _currentDeletionStatus = DeletionStatus(
+      deletedAt: DateTime.now().subtract(const Duration(days: 2)),
+      gracePeriodEnds: DateTime.now().add(const Duration(days: 5)),
+      isPending: true,
+    );
+
+    await tester.pumpWidget(buildSubject());
+
+    authStateController.add(AuthState(AuthChangeEvent.signedIn, session));
+    await tester.pumpAndSettle();
+
+    expect(find.text('탈퇴 대기 중인 계정입니다'), findsOneWidget);
+    expect(find.textContaining('5일 후 계정이 영구 삭제돼요'), findsOneWidget);
+
+    await tester.tap(find.text('탈퇴 유지'));
+    await tester.pumpAndSettle();
+
+    expect(_checkStatusCalls, 1);
+    expect(_cancelDeletionCalls, 0);
+    expect(_signOutCalls, 1);
+  });
+}

--- a/apps/app_partner/test/src/routing/app_router_test.dart
+++ b/apps/app_partner/test/src/routing/app_router_test.dart
@@ -115,4 +115,18 @@ void main() {
     expect(_cancelDeletionCalls, 0);
     expect(_signOutCalls, 1);
   });
+
+  testWidgets('non-pending sign-in does not show recovery dialog', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildSubject());
+
+    authStateController.add(AuthState(AuthChangeEvent.signedIn, session));
+    await tester.pumpAndSettle();
+
+    expect(find.text('탈퇴 대기 중인 계정입니다'), findsNothing);
+    expect(_checkStatusCalls, 1);
+    expect(_cancelDeletionCalls, 0);
+    expect(_signOutCalls, 0);
+  });
 }

--- a/apps/app_user/lib/main.dart
+++ b/apps/app_user/lib/main.dart
@@ -166,15 +166,15 @@ class _AppView extends ConsumerWidget {
           data: (_) => BugReporterWrapper(
             navigatorKey: rootNavigatorKey,
             // Fix #382: child 강제 언래핑 제거 — nullable child에 fallback 추가
-            child: MinglitGlobalLoadingOverlay(
-              child: child ?? const SizedBox.shrink(),
+            child: PendingDeletionRecoveryListener(
+              child: MinglitGlobalLoadingOverlay(
+                child: child ?? const SizedBox.shrink(),
+              ),
             ),
           ),
           // Hidden behind native splash — show nothing.
           loading: () => const SizedBox.shrink(),
-          error: (e, st) => Scaffold(
-            body: Center(child: Text('Error: $e')),
-          ),
+          error: (e, st) => Scaffold(body: Center(child: Text('Error: $e'))),
         );
       },
     );

--- a/apps/app_user/test/src/routing/app_router_test.dart
+++ b/apps/app_user/test/src/routing/app_router_test.dart
@@ -129,4 +129,26 @@ void main() {
     expect(_cancelDeletionCalls, 0);
     expect(_signOutCalls, 0);
   });
+
+  testWidgets('pending deletion sign-in can keep deletion and sign out', (
+    tester,
+  ) async {
+    _currentDeletionStatus = DeletionStatus(
+      deletedAt: DateTime.now().subtract(const Duration(days: 4)),
+      gracePeriodEnds: DateTime.now().add(const Duration(days: 3)),
+      isPending: true,
+    );
+
+    await tester.pumpWidget(buildSubject());
+
+    authStateController.add(AuthState(AuthChangeEvent.signedIn, session));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('탈퇴 유지'));
+    await tester.pumpAndSettle();
+
+    expect(_checkStatusCalls, 1);
+    expect(_cancelDeletionCalls, 0);
+    expect(_signOutCalls, 1);
+  });
 }

--- a/apps/app_user/test/src/routing/app_router_test.dart
+++ b/apps/app_user/test/src/routing/app_router_test.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart'
+    show AuthChangeEvent, AuthState;
+
+class _MockSession extends Mock implements Session {}
+
+late DeletionStatus? _currentDeletionStatus;
+late int _checkStatusCalls;
+late int _cancelDeletionCalls;
+late int _signOutCalls;
+
+class _FakeAccountDeletionController extends AccountDeletionController {
+  @override
+  FutureOr<DeletionStatus?> build() async => _currentDeletionStatus;
+
+  @override
+  Future<DeletionStatus?> checkStatus() async {
+    _checkStatusCalls++;
+    return _currentDeletionStatus;
+  }
+
+  @override
+  Future<DeletionStatus?> cancelDeletion() async {
+    _cancelDeletionCalls++;
+    return _currentDeletionStatus = const DeletionStatus();
+  }
+}
+
+class _FakeAuthController extends AuthController {
+  @override
+  FutureOr<void> build() async {}
+
+  @override
+  Future<void> signOut() async {
+    _signOutCalls++;
+  }
+}
+
+void main() {
+  late StreamController<AuthState> authStateController;
+  late User user;
+  late _MockSession session;
+
+  setUp(() {
+    authStateController = StreamController<AuthState>.broadcast();
+    _currentDeletionStatus = null;
+    _checkStatusCalls = 0;
+    _cancelDeletionCalls = 0;
+    _signOutCalls = 0;
+    user = User(
+      id: 'user-1',
+      appMetadata: const {
+        'provider': 'email',
+        'providers': ['email'],
+      },
+      userMetadata: const {},
+      aud: 'authenticated',
+      createdAt: DateTime(2026).toIso8601String(),
+      email: 'user@test.com',
+      identities: const [],
+    );
+    session = _MockSession();
+    when(() => session.user).thenReturn(user);
+  });
+
+  tearDown(() async {
+    await authStateController.close();
+  });
+
+  Widget buildSubject() {
+    return ProviderScope(
+      overrides: [
+        authStateChangesProvider.overrideWith(
+          (_) => authStateController.stream,
+        ),
+        accountDeletionControllerProvider.overrideWith(
+          _FakeAccountDeletionController.new,
+        ),
+        authControllerProvider.overrideWith(_FakeAuthController.new),
+      ],
+      child: const MaterialApp(
+        home: PendingDeletionRecoveryListener(
+          child: Scaffold(body: Text('home')),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('pending deletion sign-in shows recovery dialog and cancels', (
+    tester,
+  ) async {
+    _currentDeletionStatus = DeletionStatus(
+      deletedAt: DateTime.now().subtract(const Duration(days: 4)),
+      gracePeriodEnds: DateTime.now().add(const Duration(days: 3)),
+      isPending: true,
+    );
+
+    await tester.pumpWidget(buildSubject());
+
+    authStateController.add(AuthState(AuthChangeEvent.signedIn, session));
+    await tester.pumpAndSettle();
+
+    expect(find.text('탈퇴 대기 중인 계정입니다'), findsOneWidget);
+    expect(find.textContaining('3일 후 계정이 영구 삭제돼요'), findsOneWidget);
+
+    await tester.tap(find.text('취소할게요'));
+    await tester.pumpAndSettle();
+
+    expect(_checkStatusCalls, 1);
+    expect(_cancelDeletionCalls, 1);
+    expect(_signOutCalls, 0);
+  });
+
+  testWidgets('non-pending sign-in does not show recovery dialog', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildSubject());
+
+    authStateController.add(AuthState(AuthChangeEvent.signedIn, session));
+    await tester.pumpAndSettle();
+
+    expect(find.text('탈퇴 대기 중인 계정입니다'), findsNothing);
+    expect(_checkStatusCalls, 1);
+    expect(_cancelDeletionCalls, 0);
+    expect(_signOutCalls, 0);
+  });
+}

--- a/shared/packages/minglit_kit/lib/minglit_ui.dart
+++ b/shared/packages/minglit_kit/lib/minglit_ui.dart
@@ -1,7 +1,7 @@
+export 'src/features/account_deletion/ui/pending_deletion_recovery_listener.dart';
 export 'src/features/auth/ui/minglit_login_screen.dart';
 export 'src/features/auth/ui/staff_gate_screen.dart';
 export 'src/features/auth/ui/staff_guard_wrapper.dart';
-export 'src/features/account_deletion/ui/pending_deletion_recovery_listener.dart';
 export 'src/features/iamport/iamport.dart';
 export 'src/features/loading/global_loading_controller.dart';
 export 'src/features/loading/minglit_global_loading_overlay.dart';

--- a/shared/packages/minglit_kit/lib/minglit_ui.dart
+++ b/shared/packages/minglit_kit/lib/minglit_ui.dart
@@ -1,6 +1,7 @@
 export 'src/features/auth/ui/minglit_login_screen.dart';
 export 'src/features/auth/ui/staff_gate_screen.dart';
 export 'src/features/auth/ui/staff_guard_wrapper.dart';
+export 'src/features/account_deletion/ui/pending_deletion_recovery_listener.dart';
 export 'src/features/iamport/iamport.dart';
 export 'src/features/loading/global_loading_controller.dart';
 export 'src/features/loading/minglit_global_loading_overlay.dart';

--- a/shared/packages/minglit_kit/lib/src/features/account_deletion/ui/pending_deletion_recovery_listener.dart
+++ b/shared/packages/minglit_kit/lib/src/features/account_deletion/ui/pending_deletion_recovery_listener.dart
@@ -1,0 +1,97 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/src/data/models/deletion_status.dart';
+import 'package:minglit_kit/src/data/repositories/auth_repository.dart';
+import 'package:minglit_kit/src/features/account_deletion/logic/account_deletion_controller.dart';
+import 'package:minglit_kit/src/features/auth/logic/auth_controller.dart';
+import 'package:minglit_kit/src/utils/error_ui_handler.dart';
+import 'package:minglit_kit/src/utils/feedback_ext.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// Prompts signed-in users to recover a pending account deletion.
+class PendingDeletionRecoveryListener extends ConsumerStatefulWidget {
+  /// Creates a [PendingDeletionRecoveryListener].
+  const PendingDeletionRecoveryListener({required this.child, super.key});
+
+  /// Descendant app content that stays mounted behind the dialog flow.
+  final Widget child;
+
+  @override
+  ConsumerState<PendingDeletionRecoveryListener> createState() =>
+      _PendingDeletionRecoveryListenerState();
+}
+
+class _PendingDeletionRecoveryListenerState
+    extends ConsumerState<PendingDeletionRecoveryListener> {
+  bool _isHandlingSignIn = false;
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<AsyncValue<AuthState>>(authStateChangesProvider, (_, next) {
+      next.whenData((authState) {
+        // Fix #890: only prompt once when a fresh sign-in completes.
+        if (authState.event != AuthChangeEvent.signedIn || _isHandlingSignIn) {
+          return;
+        }
+
+        unawaited(_handlePendingDeletionRecovery());
+      });
+    });
+
+    return widget.child;
+  }
+
+  Future<void> _handlePendingDeletionRecovery() async {
+    _isHandlingSignIn = true;
+
+    try {
+      final status = await ref
+          .read(accountDeletionControllerProvider.notifier)
+          .checkStatus();
+
+      if (!mounted || status?.isPending != true) return;
+
+      // Fix #890: signed-in users within the grace period must choose whether
+      // to restore the account immediately or sign back out.
+      final shouldCancelDeletion = await context.showMinglitConfirm(
+        title: '탈퇴 대기 중인 계정입니다',
+        message: _buildRecoveryMessage(status!),
+        confirmLabel: '취소할게요',
+        cancelLabel: '탈퇴 유지',
+      );
+
+      if (!mounted) return;
+
+      if (shouldCancelDeletion) {
+        await ref
+            .read(accountDeletionControllerProvider.notifier)
+            .cancelDeletion();
+      } else {
+        await ref.read(authControllerProvider.notifier).signOut();
+      }
+    } on Object catch (error, stackTrace) {
+      if (mounted) {
+        handleMinglitError(context, error, stackTrace);
+      }
+    } finally {
+      _isHandlingSignIn = false;
+    }
+  }
+
+  String _buildRecoveryMessage(DeletionStatus status) {
+    final gracePeriodEnds = status.gracePeriodEnds;
+    if (gracePeriodEnds == null) {
+      return '7일 유예 기간 중인 계정이에요. 탈퇴를 취소할까요?';
+    }
+
+    final now = DateTime.now();
+    final remaining = gracePeriodEnds.difference(now);
+    final remainingDays = remaining.isNegative
+        ? 0
+        : (remaining.inHours / 24).ceil();
+
+    return '$remainingDays일 후 계정이 영구 삭제돼요. 탈퇴를 취소할까요?';
+  }
+}

--- a/shared/packages/minglit_kit/lib/src/features/account_deletion/ui/pending_deletion_recovery_listener.dart
+++ b/shared/packages/minglit_kit/lib/src/features/account_deletion/ui/pending_deletion_recovery_listener.dart
@@ -1,13 +1,13 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:minglit_kit/src/data/models/deletion_status.dart';
 import 'package:minglit_kit/src/data/repositories/auth_repository.dart';
 import 'package:minglit_kit/src/features/account_deletion/logic/account_deletion_controller.dart';
 import 'package:minglit_kit/src/features/auth/logic/auth_controller.dart';
 import 'package:minglit_kit/src/utils/error_ui_handler.dart';
 import 'package:minglit_kit/src/utils/feedback_ext.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 /// Prompts signed-in users to recover a pending account deletion.


### PR DESCRIPTION
Scheduler: needs-dev-codex-1

## Summary
- add a shared pending deletion recovery listener that prompts right after sign-in
- wire the listener into both app roots so user and partner flows behave the same
- add app-specific routing tests for cancel-deletion and keep-deletion branches

## Verification
- `/Users/mark/development/flutter/bin/flutter test test/src/routing/app_router_test.dart` (in `apps/app_user`)
- `/Users/mark/development/flutter/bin/flutter test test/src/routing/app_router_test.dart` (in `apps/app_partner`)
- `/Users/mark/development/flutter/bin/flutter analyze` shows pre-existing info-only lint backlog in both apps; no new test failures introduced by this change

Closes #890