### PR TITLE
test(app_user): cover Event Now Bar fallback integration

### DIFF
--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -69,7 +69,9 @@ class _HomePageState extends ConsumerState<HomePage> {
 
     return Scaffold(
       // Fix #667: keep the persistent now bar above the system inset.
-      bottomSheet: const SafeArea(top: false, child: EventNowBar()),
+      bottomSheet: reservesNowBarSpace
+          ? const SafeArea(top: false, child: EventNowBar())
+          : null,
       // Fix #192: Pull-to-refresh to reload the explore feed from scratch.
       body: RefreshIndicator(
         onRefresh: () =>

--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -46,21 +46,30 @@ class _HomePageState extends ConsumerState<HomePage> {
     final user = ref.watch(currentUserProvider);
     final homeCoordinator = ref.read(homeCoordinatorProvider);
     final recommendationState = ref.watch(recommendationFeedProvider);
+    final todayActiveEventsAsync = ref.watch(todayActiveEventsProvider);
+    final bottomSafeArea = MediaQuery.paddingOf(context).bottom;
+    final reservesNowBarSpace = todayActiveEventsAsync.when(
+      data: (events) => events.isNotEmpty,
+      loading: () => true,
+      error: (_, _) => true,
+    );
+    final bottomContentPadding = reservesNowBarSpace
+        ? EventNowBar.height + bottomSafeArea + MinglitSpacing.medium
+        : MinglitSpacing.xlarge;
 
     // Auto-fetch next page when first page is completely filtered out
     // by client-side eligibility/nearby filter (events empty but hasMore=true).
     ref.listen(recommendationFeedProvider, (_, next) {
       next.whenData((s) {
         if (s.events.isEmpty && s.hasMore && !s.isLoadingMore) {
-          unawaited(
-            ref.read(recommendationFeedProvider.notifier).loadMore(),
-          );
+          unawaited(ref.read(recommendationFeedProvider.notifier).loadMore());
         }
       });
     });
 
     return Scaffold(
-      bottomSheet: const EventNowBar(),
+      // Fix #667: keep the persistent now bar above the system inset.
+      bottomSheet: const SafeArea(top: false, child: EventNowBar()),
       // Fix #192: Pull-to-refresh to reload the explore feed from scratch.
       body: RefreshIndicator(
         onRefresh: () =>
@@ -207,8 +216,10 @@ class _HomePageState extends ConsumerState<HomePage> {
                   child: Center(child: MinglitCircularProgressIndicator()),
                 ),
               ),
-            const SliverPadding(
-              padding: EdgeInsets.only(bottom: MinglitSpacing.xlarge),
+            SliverPadding(
+              // Fix #667: reserve scroll space so the last card is not hidden
+              // behind the fixed EventNowBar.
+              padding: EdgeInsets.only(bottom: bottomContentPadding),
             ),
           ],
         ),

--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:app_user/src/features/home/logic/home_coordinator.dart';
 import 'package:app_user/src/features/home/widgets/event_now_bar.dart';
+import 'package:app_user/src/features/home/widgets/event_now_bar_controller.dart';
 import 'package:app_user/src/logic/feed_state_provider.dart';
 import 'package:app_user/src/routing/app_routes.dart';
 import 'package:app_user/src/widgets/explore_filter_chip_bar.dart';

--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -69,9 +69,13 @@ class _HomePageState extends ConsumerState<HomePage> {
     });
 
     return Scaffold(
-      // Fix #667: keep the persistent now bar above the system inset.
+      // Fix #667: Scaffold.bottomSheet does not preserve the parent bottom
+      // inset here, so pad the bar manually above the home indicator.
       bottomSheet: reservesNowBarSpace
-          ? const SafeArea(top: false, child: EventNowBar())
+          ? Padding(
+              padding: EdgeInsets.only(bottom: bottomSafeArea),
+              child: const EventNowBar(),
+            )
           : null,
       // Fix #192: Pull-to-refresh to reload the explore feed from scratch.
       body: RefreshIndicator(

--- a/apps/app_user/lib/src/features/home/widgets/event_now_bar.dart
+++ b/apps/app_user/lib/src/features/home/widgets/event_now_bar.dart
@@ -14,6 +14,9 @@ class EventNowBar extends ConsumerWidget {
   /// Creates an [EventNowBar].
   const EventNowBar({super.key, this.onTap});
 
+  /// Visible content height excluding bottom safe area padding.
+  static const double height = 56;
+
   /// Callback when the bar is tapped.
   final VoidCallback? onTap;
 
@@ -24,10 +27,7 @@ class EventNowBar extends ConsumerWidget {
     return eventsAsync.when(
       data: (events) {
         if (events.isEmpty) return const SizedBox.shrink();
-        return _EventNowBarContent(
-          activeEvent: events.first,
-          onTap: onTap,
-        );
+        return _EventNowBarContent(activeEvent: events.first, onTap: onTap);
       },
       loading: () => const _EventNowBarLoading(),
       error: (_, _) => _buildOfflineBar(context),
@@ -36,7 +36,7 @@ class EventNowBar extends ConsumerWidget {
 
   Widget _buildOfflineBar(BuildContext context) {
     return Container(
-      height: 56,
+      height: height,
       decoration: _barDecoration(),
       padding: const EdgeInsets.symmetric(
         horizontal: MinglitSpacing.screenEdge,
@@ -44,9 +44,9 @@ class EventNowBar extends ConsumerWidget {
       child: Center(
         child: Text(
           '(오프라인)',
-          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-            color: MinglitColors.textSecondary,
-          ),
+          style: Theme.of(
+            context,
+          ).textTheme.bodySmall?.copyWith(color: MinglitColors.textSecondary),
         ),
       ),
     );
@@ -62,9 +62,7 @@ BoxDecoration _barDecoration() {
       topRight: Radius.circular(MinglitRadius.card),
     ),
     border: Border(
-      top: BorderSide(
-        color: MinglitColors.primary.withValues(alpha: 0.1),
-      ),
+      top: BorderSide(color: MinglitColors.primary.withValues(alpha: 0.1)),
     ),
   );
 }
@@ -74,10 +72,7 @@ BoxDecoration _barDecoration() {
 /// Separated into [ConsumerStatefulWidget] to manage the pulse
 /// [AnimationController] lifecycle for the RESULTS state.
 class _EventNowBarContent extends ConsumerStatefulWidget {
-  const _EventNowBarContent({
-    required this.activeEvent,
-    this.onTap,
-  });
+  const _EventNowBarContent({required this.activeEvent, this.onTap});
 
   final TodayActiveEvent activeEvent;
   final VoidCallback? onTap;
@@ -113,9 +108,7 @@ class _EventNowBarContentState extends ConsumerState<_EventNowBarContent>
 
   @override
   Widget build(BuildContext context) {
-    final stateAsync = ref.watch(
-      eventNowBarStateProvider(widget.activeEvent),
-    );
+    final stateAsync = ref.watch(eventNowBarStateProvider(widget.activeEvent));
 
     return stateAsync.when(
       data: (state) => _buildBar(context, state),
@@ -147,7 +140,7 @@ class _EventNowBarContentState extends ConsumerState<_EventNowBarContent>
             showEventNowBottomSheet(context, ref, widget.activeEvent),
           ),
       child: Container(
-        height: 56,
+        height: EventNowBar.height,
         decoration: _barDecoration(),
         padding: const EdgeInsets.symmetric(
           horizontal: MinglitSpacing.screenEdge,
@@ -219,9 +212,9 @@ class _EventNowBarContentState extends ConsumerState<_EventNowBarContent>
           : '$minutes분 후';
       return Text(
         timeText,
-        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-          color: MinglitColors.textSecondary,
-        ),
+        style: Theme.of(
+          context,
+        ).textTheme.bodySmall?.copyWith(color: MinglitColors.textSecondary),
       );
     }
     return const Icon(

--- a/apps/app_user/lib/src/features/home/widgets/event_now_bar.dart
+++ b/apps/app_user/lib/src/features/home/widgets/event_now_bar.dart
@@ -254,7 +254,7 @@ class _EventNowBarLoading extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const MinglitSkeleton(
-      height: 56,
+      height: EventNowBar.height,
       borderRadius: BorderRadius.only(
         topLeft: Radius.circular(MinglitRadius.card),
         topRight: Radius.circular(MinglitRadius.card),

--- a/apps/app_user/test/src/features/home/home_page_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_test.dart
@@ -264,8 +264,10 @@ void main() {
       final barRect = tester.getRect(find.byType(EventNowBar));
       // Expected: 844 screen height - 34 safe area - 56 bar height = 754.
       const expectedTop = 844 - 34 - EventNowBar.height;
+      // Expected: 844 screen height - 34 safe area = 810.
+      const expectedBottom = 844 - 34;
       expect(barRect.top, closeTo(expectedTop, 0.1));
-      expect(barRect.bottom, closeTo(844, 0.1));
+      expect(barRect.bottom, closeTo(expectedBottom, 0.1));
     });
 
     testWidgets('omits EventNowBar when there are no active events', (

--- a/apps/app_user/test/src/features/home/home_page_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_test.dart
@@ -261,14 +261,11 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      final barContentFinder = find.ancestor(
-        of: find.text('오늘 이벤트'),
-        matching: find.byType(GestureDetector),
-      );
-      // Expected: 844 screen height - 34 bottom safe area = 810.
-      const expectedBottom = 844 - 34;
-      final barBottom = tester.getBottomLeft(barContentFinder).dy;
-      expect(barBottom, closeTo(expectedBottom.toDouble(), 0.1));
+      final barRect = tester.getRect(find.byType(EventNowBar));
+      // Expected: 844 screen height - 34 safe area - 56 bar height = 754.
+      const expectedTop = 844 - 34 - EventNowBar.height;
+      expect(barRect.top, closeTo(expectedTop.toDouble(), 0.1));
+      expect(barRect.bottom, closeTo(844, 0.1));
     });
 
     testWidgets('omits EventNowBar when there are no active events', (

--- a/apps/app_user/test/src/features/home/home_page_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_test.dart
@@ -263,6 +263,28 @@ void main() {
       expect(barBottom, closeTo(810, 0.1));
     });
 
+    testWidgets('omits EventNowBar when there are no active events', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(390, 844));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        createTestWidget(
+          currentUser: mockUser,
+          mediaQueryData: const MediaQueryData(
+            size: Size(390, 844),
+            padding: EdgeInsets.only(bottom: 34),
+          ),
+          overrides: [todayActiveEventsProvider.overrideWith((_) => const [])],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(EventNowBar), findsNothing);
+      expect(find.text('추천 이벤트가 없습니다'), findsOneWidget);
+    });
+
     testWidgets('keeps the last event card above the fixed EventNowBar', (
       tester,
     ) async {

--- a/apps/app_user/test/src/features/home/home_page_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_test.dart
@@ -261,19 +261,18 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      final barContentRect = tester.getRect(
-        find.descendant(
-          of: find.byType(EventNowBar),
-          matching: find.byType(GestureDetector),
-        ),
+      final barContentFinder = find.ancestor(
+        of: find.text('오늘 이벤트'),
+        matching: find.byType(GestureDetector),
       );
-      // SafeArea wraps EventNowBar, so assert the tappable 56px bar content.
       // Expected: 844 screen height - 34 safe area - 56 bar height = 754.
       const expectedTop = 844 - 34 - EventNowBar.height;
-      // Expected: 844 screen height - 34 safe area = 810.
+      // Expected: 844 screen height - 34 bottom safe area = 810.
       const expectedBottom = 844 - 34;
-      expect(barContentRect.top, closeTo(expectedTop, 0.1));
-      expect(barContentRect.bottom, closeTo(expectedBottom, 0.1));
+      final barTop = tester.getTopLeft(barContentFinder).dy;
+      final barBottom = tester.getBottomLeft(barContentFinder).dy;
+      expect(barTop, closeTo(expectedTop.toDouble(), 0.1));
+      expect(barBottom, closeTo(expectedBottom.toDouble(), 0.1));
     });
 
     testWidgets('omits EventNowBar when there are no active events', (

--- a/apps/app_user/test/src/features/home/home_page_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_test.dart
@@ -271,7 +271,7 @@ void main() {
       const expectedBottom = 844 - 34;
       final barTop = tester.getTopLeft(barContentFinder).dy;
       final barBottom = tester.getBottomLeft(barContentFinder).dy;
-      expect(barTop, closeTo(expectedTop.toDouble(), 0.1));
+      expect(barTop, closeTo(expectedTop, 0.1));
       expect(barBottom, closeTo(expectedBottom.toDouble(), 0.1));
     });
 

--- a/apps/app_user/test/src/features/home/home_page_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_test.dart
@@ -1,4 +1,6 @@
 import 'package:app_user/src/features/home/home_page.dart';
+import 'package:app_user/src/features/home/widgets/event_now_bar.dart';
+import 'package:app_user/src/features/home/widgets/event_now_bar_controller.dart';
 import 'package:app_user/src/logic/feed_state_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -276,7 +278,11 @@ void main() {
             size: Size(390, 844),
             padding: EdgeInsets.only(bottom: 34),
           ),
-          overrides: [todayActiveEventsProvider.overrideWith((_) => const [])],
+          overrides: [
+            todayActiveEventsProvider.overrideWith(
+              (_) => const <TodayActiveEvent>[],
+            ),
+          ],
         ),
       );
       await tester.pumpAndSettle();

--- a/apps/app_user/test/src/features/home/home_page_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_test.dart
@@ -261,8 +261,14 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      final barBottom = tester.getBottomLeft(find.byType(EventNowBar)).dy;
-      expect(barBottom, closeTo(810, 0.1));
+      final barContentFinder = find.ancestor(
+        of: find.text('오늘 이벤트'),
+        matching: find.byType(GestureDetector),
+      );
+      // Expected: 844 screen height - 34 bottom safe area = 810.
+      const expectedBottom = 844 - 34;
+      final barBottom = tester.getBottomLeft(barContentFinder).dy;
+      expect(barBottom, closeTo(expectedBottom.toDouble(), 0.1));
     });
 
     testWidgets('omits EventNowBar when there are no active events', (

--- a/apps/app_user/test/src/features/home/home_page_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_test.dart
@@ -264,7 +264,7 @@ void main() {
       final barRect = tester.getRect(find.byType(EventNowBar));
       // Expected: 844 screen height - 34 safe area - 56 bar height = 754.
       const expectedTop = 844 - 34 - EventNowBar.height;
-      expect(barRect.top, closeTo(expectedTop.toDouble(), 0.1));
+      expect(barRect.top, closeTo(expectedTop, 0.1));
       expect(barRect.bottom, closeTo(844, 0.1));
     });
 

--- a/apps/app_user/test/src/features/home/home_page_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_test.dart
@@ -14,9 +14,14 @@ void main() {
   });
 
   late MockEventRepository mockEventRepository;
+  late MockUser mockUser;
 
   setUp(() {
     mockEventRepository = MockEventRepository();
+    mockUser = MockUser();
+    when(() => mockUser.id).thenReturn('user1');
+    when(() => mockUser.email).thenReturn('test@example.com');
+    when(() => mockUser.userMetadata).thenReturn({'full_name': 'Test User'});
 
     // Return empty lists for all feed types by default
     for (final type in EventFeedType.values) {
@@ -35,22 +40,22 @@ void main() {
   Widget createTestWidget({
     User? currentUser,
     List<dynamic> overrides = const [],
+    MediaQueryData? mediaQueryData,
   }) {
+    final page = mediaQueryData == null
+        ? const HomePage()
+        : MediaQuery(data: mediaQueryData, child: const HomePage());
+
     return ProviderScope(
       overrides: [
         eventRepositoryProvider.overrideWithValue(mockEventRepository),
         // Disable active filters to avoid triggering location services
-        activeFiltersProvider.overrideWith(
-          _NoFiltersNotifier.new,
-        ),
+        activeFiltersProvider.overrideWith(_NoFiltersNotifier.new),
         // Default: unauthenticated. Pass currentUser to test logged-in state.
         currentUserProvider.overrideWith((_) => currentUser),
         ...overrides.cast(),
       ],
-      child: MaterialApp(
-        theme: MinglitTheme.materialTheme,
-        home: const HomePage(),
-      ),
+      child: MaterialApp(theme: MinglitTheme.materialTheme, home: page),
     );
   }
 
@@ -58,11 +63,6 @@ void main() {
     testWidgets('renders notification bell icon when logged in', (
       tester,
     ) async {
-      final mockUser = MockUser();
-      when(() => mockUser.id).thenReturn('user1');
-      when(() => mockUser.email).thenReturn('test@example.com');
-      when(() => mockUser.userMetadata).thenReturn({'full_name': 'Test User'});
-
       await tester.pumpWidget(createTestWidget(currentUser: mockUser));
       await tester.pump();
 
@@ -169,9 +169,7 @@ void main() {
       await tester.pumpWidget(
         createTestWidget(
           overrides: [
-            recommendationFeedProvider.overrideWith(
-              _MockErrorNotifier.new,
-            ),
+            recommendationFeedProvider.overrideWith(_MockErrorNotifier.new),
           ],
         ),
       );
@@ -187,9 +185,7 @@ void main() {
       await tester.pumpWidget(
         createTestWidget(
           overrides: [
-            recommendationFeedProvider.overrideWith(
-              _MockNoMoreNotifier.new,
-            ),
+            recommendationFeedProvider.overrideWith(_MockNoMoreNotifier.new),
           ],
         ),
       );
@@ -199,7 +195,161 @@ void main() {
 
       expect(find.byType(MinglitCircularProgressIndicator), findsNothing);
     });
+
+    testWidgets('pins EventNowBar while the feed scrolls', (tester) async {
+      final activeEvent = _makeActiveEvent();
+      final feedEvents = List.generate(12, _makeFeedEvent);
+
+      when(
+        () => mockEventRepository.getEventsByType(
+          type: EventFeedType.newArrivals,
+          latitude: any(named: 'latitude'),
+          longitude: any(named: 'longitude'),
+          limit: any(named: 'limit'),
+          offset: any(named: 'offset'),
+        ),
+      ).thenAnswer((_) async => feedEvents);
+
+      await tester.pumpWidget(
+        createTestWidget(
+          currentUser: mockUser,
+          overrides: [
+            todayActiveEventsProvider.overrideWith((_) => [activeEvent]),
+            eventNowBarStateProvider(activeEvent).overrideWith(
+              () => _FixedNowBarStateNotifier(EventNowBarState.matching),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final barFinder = find.byType(EventNowBar);
+      final before = tester.getTopLeft(barFinder).dy;
+
+      await tester.drag(find.byType(CustomScrollView), const Offset(0, -600));
+      await tester.pumpAndSettle();
+
+      final after = tester.getTopLeft(barFinder).dy;
+      expect(before, after);
+      expect(find.text('오늘 이벤트'), findsOneWidget);
+    });
+
+    testWidgets('positions EventNowBar above the bottom safe area', (
+      tester,
+    ) async {
+      final activeEvent = _makeActiveEvent();
+
+      await tester.binding.setSurfaceSize(const Size(390, 844));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        createTestWidget(
+          currentUser: mockUser,
+          mediaQueryData: const MediaQueryData(
+            size: Size(390, 844),
+            padding: EdgeInsets.only(bottom: 34),
+          ),
+          overrides: [
+            todayActiveEventsProvider.overrideWith((_) => [activeEvent]),
+            eventNowBarStateProvider(activeEvent).overrideWith(
+              () => _FixedNowBarStateNotifier(EventNowBarState.waiting),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final barBottom = tester.getBottomLeft(find.byType(EventNowBar)).dy;
+      expect(barBottom, closeTo(810, 0.1));
+    });
+
+    testWidgets('keeps the last event card above the fixed EventNowBar', (
+      tester,
+    ) async {
+      final activeEvent = _makeActiveEvent();
+      final feedEvents = List.generate(16, _makeFeedEvent);
+      final lastTitle = feedEvents.last.title!;
+
+      when(
+        () => mockEventRepository.getEventsByType(
+          type: EventFeedType.newArrivals,
+          latitude: any(named: 'latitude'),
+          longitude: any(named: 'longitude'),
+          limit: any(named: 'limit'),
+          offset: any(named: 'offset'),
+        ),
+      ).thenAnswer((_) async => feedEvents);
+
+      await tester.binding.setSurfaceSize(const Size(390, 844));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        createTestWidget(
+          currentUser: mockUser,
+          mediaQueryData: const MediaQueryData(
+            size: Size(390, 844),
+            padding: EdgeInsets.only(bottom: 34),
+          ),
+          overrides: [
+            todayActiveEventsProvider.overrideWith((_) => [activeEvent]),
+            eventNowBarStateProvider(activeEvent).overrideWith(
+              () => _FixedNowBarStateNotifier(EventNowBarState.matching),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.scrollUntilVisible(
+        find.text(lastTitle),
+        300,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pumpAndSettle();
+
+      final lastCardBottom = tester.getBottomLeft(find.text(lastTitle)).dy;
+      final nowBarTop = tester.getTopLeft(find.byType(EventNowBar)).dy;
+      expect(lastCardBottom, lessThanOrEqualTo(nowBarTop));
+    });
   });
+}
+
+TodayActiveEvent _makeActiveEvent() {
+  final now = DateTime.now();
+  return TodayActiveEvent(
+    event: Event(
+      id: 'active_event',
+      partyId: 'party_active',
+      title: '오늘 이벤트',
+      startTime: now.add(const Duration(minutes: 40)),
+      endTime: now.add(const Duration(hours: 3)),
+      createdAt: now,
+      updatedAt: now,
+    ),
+    participantStatus: 'ticket_issued',
+  );
+}
+
+Event _makeFeedEvent(int index) {
+  final now = DateTime.now();
+  return Event(
+    id: 'event_$index',
+    partyId: 'party_$index',
+    startTime: now.add(Duration(days: index + 1)),
+    endTime: now.add(Duration(days: index + 1, hours: 2)),
+    createdAt: now,
+    updatedAt: now,
+    title: '추천 이벤트 $index',
+    tickets: [
+      Ticket(
+        id: 'ticket_$index',
+        name: 'General',
+        price: 15000,
+        createdAt: now,
+        updatedAt: now,
+      ),
+    ],
+  );
 }
 
 /// A notifier that starts with no active filters (all disabled),
@@ -240,5 +390,16 @@ class _MockNoMoreNotifier extends RecommendationFeedNotifier {
       serverOffset: 0,
       hasMore: false,
     );
+  }
+}
+
+class _FixedNowBarStateNotifier extends EventNowBarStateNotifier {
+  _FixedNowBarStateNotifier(this.stateValue);
+
+  final EventNowBarState stateValue;
+
+  @override
+  Future<EventNowBarState> build(TodayActiveEvent activeEvent) async {
+    return stateValue;
   }
 }

--- a/apps/app_user/test/src/features/home/home_page_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_test.dart
@@ -261,13 +261,19 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      final barRect = tester.getRect(find.byType(EventNowBar));
+      final barContentRect = tester.getRect(
+        find.descendant(
+          of: find.byType(EventNowBar),
+          matching: find.byType(GestureDetector),
+        ),
+      );
+      // SafeArea wraps EventNowBar, so assert the tappable 56px bar content.
       // Expected: 844 screen height - 34 safe area - 56 bar height = 754.
       const expectedTop = 844 - 34 - EventNowBar.height;
       // Expected: 844 screen height - 34 safe area = 810.
       const expectedBottom = 844 - 34;
-      expect(barRect.top, closeTo(expectedTop, 0.1));
-      expect(barRect.bottom, closeTo(expectedBottom, 0.1));
+      expect(barContentRect.top, closeTo(expectedTop, 0.1));
+      expect(barContentRect.bottom, closeTo(expectedBottom, 0.1));
     });
 
     testWidgets('omits EventNowBar when there are no active events', (

--- a/apps/app_user/test/src/features/home/widgets/event_now_bar_test.dart
+++ b/apps/app_user/test/src/features/home/widgets/event_now_bar_test.dart
@@ -248,7 +248,7 @@ void main() {
           overrides: [
             eventNowBarStateProvider(
               event,
-            ).overrideWith(() => _ThrowingStateNotifier()),
+            ).overrideWith(_ThrowingStateNotifier.new),
           ],
         ),
       );

--- a/apps/app_user/test/src/features/home/widgets/event_now_bar_test.dart
+++ b/apps/app_user/test/src/features/home/widgets/event_now_bar_test.dart
@@ -61,6 +61,7 @@ void main() {
     required List<TodayActiveEvent> activeEvents,
     VoidCallback? onTap,
     bool throwError = false,
+    List<dynamic> overrides = const [],
   }) {
     return ProviderScope(
       overrides: [
@@ -70,6 +71,7 @@ void main() {
           if (throwError) throw Exception('Network error');
           return activeEvents;
         }),
+        ...overrides.cast(),
       ],
       child: MaterialApp(
         theme: MinglitTheme.materialTheme,
@@ -173,10 +175,7 @@ void main() {
       stubMatchingNotAvailable('event_1');
 
       await tester.pumpWidget(
-        createTestWidget(
-          activeEvents: [event],
-          onTap: () => tapped = true,
-        ),
+        createTestWidget(activeEvents: [event], onTap: () => tapped = true),
       );
       await tester.pumpAndSettle();
 
@@ -184,9 +183,7 @@ void main() {
       expect(tapped, isTrue);
     });
 
-    testWidgets('shows skeleton loading while fetching events', (
-      tester,
-    ) async {
+    testWidgets('shows skeleton loading while fetching events', (tester) async {
       // Use a Completer to keep the provider in loading state.
       final completer = Completer<List<TodayActiveEvent>>();
       addTearDown(() {
@@ -196,9 +193,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            todayActiveEventsProvider.overrideWith(
-              (ref) => completer.future,
-            ),
+            todayActiveEventsProvider.overrideWith((ref) => completer.future),
           ],
           child: MaterialApp(
             theme: MinglitTheme.materialTheme,
@@ -241,5 +236,34 @@ void main() {
 
       expect(find.text('종료됨'), findsOneWidget);
     });
+
+    testWidgets('keeps cached event visible when state resolution fails', (
+      tester,
+    ) async {
+      final event = makeActiveEvent();
+
+      await tester.pumpWidget(
+        createTestWidget(
+          activeEvents: [event],
+          overrides: [
+            eventNowBarStateProvider(
+              event,
+            ).overrideWith(() => _ThrowingStateNotifier()),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('강남 밍릿파티'), findsOneWidget);
+      expect(find.text('곧 시작'), findsOneWidget);
+      expect(find.textContaining('후'), findsOneWidget);
+    });
   });
+}
+
+class _ThrowingStateNotifier extends EventNowBarStateNotifier {
+  @override
+  FutureOr<EventNowBarState> build(TodayActiveEvent activeEvent) {
+    throw Exception('state failure');
+  }
 }


### PR DESCRIPTION
Scheduler: needs-dev-codex-1

Closes #667

## Summary
- keep `EventNowBar` above bottom safe area and reserve scroll space in `HomePage`
- add cached-event fallback coverage when now-bar state resolution fails
- add `HomePage` integration tests for fixed bottom placement and bottom overlap prevention

## Verification
- `dart format`
- local `flutter test` not run in this runtime because the `flutter` binary is unavailable; CI should validate