### PR TITLE
fix(consent): restore home route in back stack after consent completion

### DIFF
--- a/apps/app_user/lib/src/features/consent/logic/consent_coordinator.dart
+++ b/apps/app_user/lib/src/features/consent/logic/consent_coordinator.dart
@@ -15,7 +15,15 @@ class ConsentCoordinator {
   final GoRouter _router;
 
   void completeSignup({String? from}) {
-    _router.go(_sanitizeReturnLocation(from) ?? '/');
+    final returnTo = _sanitizeReturnLocation(from);
+    if (returnTo == null || returnTo == '/') {
+      _router.go('/');
+    } else {
+      // Fix #970: go('/') first to restore home in the back stack, then push
+      // the return target so back navigation returns to home instead of exiting.
+      _router.go('/');
+      _router.push(returnTo);
+    }
   }
 
   String? _sanitizeReturnLocation(String? from) {

--- a/apps/app_user/test/src/features/consent/logic/consent_coordinator_test.dart
+++ b/apps/app_user/test/src/features/consent/logic/consent_coordinator_test.dart
@@ -7,9 +7,7 @@ class MockGoRouter extends Mock implements GoRouter {}
 
 void main() {
   group('completeSignup', () {
-    test('from이 null이면 홈(/)으로 이동한다', () {
-      _expectNavigatesToHome(from: null);
-    });
+    test('from이 null이면 홈(/)으로 이동한다', _expectNavigatesToHome);
 
     test('from이 유효한 경로면 홈 경유 후 해당 경로로 이동한다', () {
       _expectNavigatesViaHome('/tickets/my', from: '/tickets/my');

--- a/apps/app_user/test/src/features/consent/logic/consent_coordinator_test.dart
+++ b/apps/app_user/test/src/features/consent/logic/consent_coordinator_test.dart
@@ -8,38 +8,54 @@ class MockGoRouter extends Mock implements GoRouter {}
 void main() {
   group('completeSignup', () {
     test('from이 null이면 홈(/)으로 이동한다', () {
-      _expectNavigatesTo('/');
+      _expectNavigatesToHome(from: null);
     });
 
-    test('from이 유효한 경로면 해당 경로로 이동한다', () {
-      _expectNavigatesTo('/tickets/my', from: '/tickets/my');
+    test('from이 유효한 경로면 홈 경유 후 해당 경로로 이동한다', () {
+      _expectNavigatesViaHome('/tickets/my', from: '/tickets/my');
+    });
+
+    test('from이 /my이면 홈 경유 후 /my로 이동한다', () {
+      _expectNavigatesViaHome('/my', from: '/my');
     });
 
     test('from이 /login으로 시작하면 홈(/)으로 이동한다', () {
-      _expectNavigatesTo('/', from: '/login');
+      _expectNavigatesToHome(from: '/login');
     });
 
     test('from이 /signup/consent로 시작하면 홈(/)으로 이동한다', () {
-      _expectNavigatesTo('/', from: '/signup/consent');
+      _expectNavigatesToHome(from: '/signup/consent');
     });
 
     test('from이 빈 문자열이면 홈(/)으로 이동한다', () {
-      _expectNavigatesTo('/', from: '');
+      _expectNavigatesToHome(from: '');
     });
 
     test('from이 //로 시작하면 홈(/)으로 이동한다', () {
-      _expectNavigatesTo('/', from: '//evil.com');
+      _expectNavigatesToHome(from: '//evil.com');
     });
 
     test('from이 /로 시작하지 않으면 홈(/)으로 이동한다', () {
-      _expectNavigatesTo('/', from: 'https://evil.com');
+      _expectNavigatesToHome(from: 'https://evil.com');
     });
   });
 }
 
-void _expectNavigatesTo(String expectedPath, {String? from}) {
+/// Verifies that completeSignup navigates directly to home (go only, no push).
+void _expectNavigatesToHome({String? from}) {
   final mockRouter = MockGoRouter();
   ConsentCoordinator(mockRouter).completeSignup(from: from);
+  verify(() => mockRouter.go('/')).called(1);
+  verifyNever(() => mockRouter.push(any()));
+}
 
-  verify(() => mockRouter.go(expectedPath)).called(1);
+/// Verifies that completeSignup navigates home first, then pushes [expectedPath].
+/// Fix #970: home route must be in the back stack so back key returns to home
+/// instead of exiting the app.
+void _expectNavigatesViaHome(String expectedPath, {required String? from}) {
+  final mockRouter = MockGoRouter();
+  when(() => mockRouter.push(any<String>())).thenAnswer((_) async => null);
+  ConsentCoordinator(mockRouter).completeSignup(from: from);
+  verify(() => mockRouter.go('/')).called(1);
+  verify(() => mockRouter.push(expectedPath)).called(1);
 }


### PR DESCRIPTION
Scheduler: swe

Closes #970

## 문제

동의 완료 후 `completeSignup(from: '/my')`가 `_router.go('/my')`를 호출. `go()`는 네비게이션 스택 전체를 교체하므로 `/my`만 남고 `/`가 스택에 없어진다. 백 키 누르면 앱 종료.

## 원인

```dart
// Before: go('/my') → stack: [/my] → back exits app
_router.go(_sanitizeReturnLocation(from) ?? '/');
```

## 수정

```dart
// After: go('/') + push('/my') → stack: [/, /my] → back returns to home
_router.go('/');
_router.push(returnTo);
```

홈(`/`)을 먼저 이동한 뒤 return target을 push하여 백 스택에 `/`가 항상 존재하도록 보장.

## 테스트 변경

- `consent_coordinator_test.dart`: `_expectNavigatesToHome` / `_expectNavigatesViaHome` 헬퍼로 분리, `/my` 케이스 추가
- 유효한 return path → `go('/') + push(path)` 검증

## 영향 범위

`ConsentCoordinator.completeSignup()` 만 변경. 라우터 가드, 동의 페이지 UI, 다른 플로우 무영향.