### PR TITLE
fix(nav): consent 완료 후 back 버튼으로 앱 종료되는 버그 수정

### DIFF
--- a/apps/app_user/lib/src/features/consent/logic/consent_coordinator.dart
+++ b/apps/app_user/lib/src/features/consent/logic/consent_coordinator.dart
@@ -15,7 +15,17 @@ class ConsentCoordinator {
   final GoRouter _router;
 
   void completeSignup({String? from}) {
-    _router.go(_sanitizeReturnLocation(from) ?? '/');
+    final destination = _sanitizeReturnLocation(from);
+    if (destination == null || destination == '/') {
+      _router.go('/');
+    } else {
+      // Fix #970: go(destination) replaces the entire navigation stack because
+      // destination routes (e.g. /my) are top-level and have no implicit parent.
+      // Navigate to home first to anchor the back stack, then push the
+      // destination on top so the user can press back to return home.
+      _router.go('/');
+      _router.push(destination);
+    }
   }
 
   String? _sanitizeReturnLocation(String? from) {

--- a/apps/app_user/test/integration/consent_redirect_test.dart
+++ b/apps/app_user/test/integration/consent_redirect_test.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 
 import 'package:app_user/src/features/auth/login_page.dart';
+import 'package:app_user/src/features/consent/logic/consent_coordinator.dart';
 import 'package:app_user/src/features/consent/ui/signup_consent_page.dart';
+import 'package:app_user/src/features/home/home_page.dart';
 import 'package:app_user/src/features/home/my_page.dart';
 import 'package:app_user/src/logic/feed_state_provider.dart';
 import 'package:app_user/src/routing/app_router.dart';
@@ -156,6 +158,49 @@ void main() {
 
       expect(find.byType(MyPage), findsOneWidget);
       expect(find.byType(SignupConsentPage), findsNothing);
+    });
+
+    // Fix #970: consent 완료 후 /my에서 back 버튼으로 앱이 종료되던 버그 재발 방지.
+    // completeSignup()이 go(/)→push(destination) 패턴을 써야 back stack이 보존된다.
+    testWidgets('동의 완료 후 /my에서 back 버튼을 누르면 앱 종료 대신 홈(/)으로 이동한다', (
+      tester,
+    ) async {
+      setKoreanLocale(tester);
+      when(
+        () => mockConsentRepository.hasRequiredConsents(),
+      ).thenAnswer((_) async => true);
+
+      await pumpRouterApp(
+        tester,
+        currentUser: user,
+        initialLocation: '/',
+        consentRepository: mockConsentRepository,
+      );
+
+      expect(find.byType(HomePage), findsOneWidget);
+
+      // ConsentCoordinator가 completeSignup(from: '/my')를 호출하는 상황을 재현:
+      // go('/')로 홈을 스택 바닥에 anchor한 뒤 push('/my')로 목적지로 이동한다.
+      final context = tester.element(find.byType(_RouterTestApp));
+      final router = ProviderScope.containerOf(context).read(goRouterProvider);
+      ConsentCoordinator(router).completeSignup(from: '/my');
+
+      await tester.pumpAndSettle();
+
+      // /my에 도착했는지 확인
+      expect(find.byType(MyPage), findsOneWidget);
+      expect(find.byType(HomePage), findsNothing);
+
+      // Fix #970: back stack에 /가 있으므로 canPop()이 true여야 한다.
+      // (이전 버그: go('/my')가 전체 스택을 교체해서 canPop() == false → 앱 종료)
+      expect(router.canPop(), isTrue);
+
+      // 실제로 pop해서 홈으로 돌아오는지 확인
+      router.pop();
+      await tester.pumpAndSettle();
+
+      expect(find.byType(HomePage), findsOneWidget);
+      expect(find.byType(MyPage), findsNothing);
     });
   });
 }

--- a/apps/app_user/test/src/features/consent/logic/consent_coordinator_test.dart
+++ b/apps/app_user/test/src/features/consent/logic/consent_coordinator_test.dart
@@ -16,7 +16,7 @@ void main() {
 
   group('completeSignup — 홈으로 이동 (push 없음)', () {
     test('from이 null이면 홈(/)으로 go한다', () {
-      ConsentCoordinator(mockRouter).completeSignup(from: null);
+      ConsentCoordinator(mockRouter).completeSignup();
 
       verify(() => mockRouter.go('/')).called(1);
       verifyNever(() => mockRouter.push(any()));

--- a/apps/app_user/test/src/features/consent/logic/consent_coordinator_test.dart
+++ b/apps/app_user/test/src/features/consent/logic/consent_coordinator_test.dart
@@ -6,40 +6,94 @@ import 'package:mocktail/mocktail.dart';
 class MockGoRouter extends Mock implements GoRouter {}
 
 void main() {
-  group('completeSignup', () {
-    test('from이 null이면 홈(/)으로 이동한다', () {
-      _expectNavigatesTo('/');
+  late MockGoRouter mockRouter;
+
+  setUp(() {
+    mockRouter = MockGoRouter();
+    when(() => mockRouter.go(any())).thenReturn(null);
+    when(() => mockRouter.push(any())).thenAnswer((_) async => null);
+  });
+
+  group('completeSignup — 홈으로 이동 (push 없음)', () {
+    test('from이 null이면 홈(/)으로 go한다', () {
+      ConsentCoordinator(mockRouter).completeSignup(from: null);
+
+      verify(() => mockRouter.go('/')).called(1);
+      verifyNever(() => mockRouter.push(any()));
     });
 
-    test('from이 유효한 경로면 해당 경로로 이동한다', () {
-      _expectNavigatesTo('/tickets/my', from: '/tickets/my');
+    test('from이 빈 문자열이면 홈(/)으로 go한다', () {
+      ConsentCoordinator(mockRouter).completeSignup(from: '');
+
+      verify(() => mockRouter.go('/')).called(1);
+      verifyNever(() => mockRouter.push(any()));
     });
 
-    test('from이 /login으로 시작하면 홈(/)으로 이동한다', () {
-      _expectNavigatesTo('/', from: '/login');
+    test('from이 /이면 홈(/)으로 go한다', () {
+      ConsentCoordinator(mockRouter).completeSignup(from: '/');
+
+      verify(() => mockRouter.go('/')).called(1);
+      verifyNever(() => mockRouter.push(any()));
     });
 
-    test('from이 /signup/consent로 시작하면 홈(/)으로 이동한다', () {
-      _expectNavigatesTo('/', from: '/signup/consent');
+    test('from이 /login으로 시작하면 홈(/)으로 go한다', () {
+      ConsentCoordinator(mockRouter).completeSignup(from: '/login');
+
+      verify(() => mockRouter.go('/')).called(1);
+      verifyNever(() => mockRouter.push(any()));
     });
 
-    test('from이 빈 문자열이면 홈(/)으로 이동한다', () {
-      _expectNavigatesTo('/', from: '');
+    test('from이 /signup/consent로 시작하면 홈(/)으로 go한다', () {
+      ConsentCoordinator(mockRouter).completeSignup(from: '/signup/consent');
+
+      verify(() => mockRouter.go('/')).called(1);
+      verifyNever(() => mockRouter.push(any()));
     });
 
-    test('from이 //로 시작하면 홈(/)으로 이동한다', () {
-      _expectNavigatesTo('/', from: '//evil.com');
+    test('from이 //로 시작하면 홈(/)으로 go한다', () {
+      ConsentCoordinator(mockRouter).completeSignup(from: '//evil.com');
+
+      verify(() => mockRouter.go('/')).called(1);
+      verifyNever(() => mockRouter.push(any()));
     });
 
-    test('from이 /로 시작하지 않으면 홈(/)으로 이동한다', () {
-      _expectNavigatesTo('/', from: 'https://evil.com');
+    test('from이 /로 시작하지 않으면 홈(/)으로 go한다', () {
+      ConsentCoordinator(mockRouter).completeSignup(from: 'https://evil.com');
+
+      verify(() => mockRouter.go('/')).called(1);
+      verifyNever(() => mockRouter.push(any()));
     });
   });
-}
 
-void _expectNavigatesTo(String expectedPath, {String? from}) {
-  final mockRouter = MockGoRouter();
-  ConsentCoordinator(mockRouter).completeSignup(from: from);
+  group('completeSignup — 목적지로 이동 (back stack 보존)', () {
+    // Fix #970: go(destination)은 전체 스택을 교체하므로
+    // 먼저 go('/')로 홈을 스택에 anchor한 뒤 push(destination)으로 이동한다.
 
-  verify(() => mockRouter.go(expectedPath)).called(1);
+    test('from이 /my이면 go(/)한 뒤 push(/my)한다', () {
+      ConsentCoordinator(mockRouter).completeSignup(from: '/my');
+
+      verifyInOrder([
+        () => mockRouter.go('/'),
+        () => mockRouter.push('/my'),
+      ]);
+    });
+
+    test('from이 /tickets/my이면 go(/)한 뒤 push(/tickets/my)한다', () {
+      ConsentCoordinator(mockRouter).completeSignup(from: '/tickets/my');
+
+      verifyInOrder([
+        () => mockRouter.go('/'),
+        () => mockRouter.push('/tickets/my'),
+      ]);
+    });
+
+    test('from이 /purchase-history이면 go(/)한 뒤 push(/purchase-history)한다', () {
+      ConsentCoordinator(mockRouter).completeSignup(from: '/purchase-history');
+
+      verifyInOrder([
+        () => mockRouter.go('/'),
+        () => mockRouter.push('/purchase-history'),
+      ]);
+    });
+  });
 }


### PR DESCRIPTION
Scheduler: swe

Closes #965, closes #970

## 문제

로그인 후 `/my`(마이페이지) 접근 시 약관 미동의로 `/signup/consent`로 리다이렉트, 동의 완료 후 go_router의 `go('/my')`가 전체 스택을 교체하여 `/my`만 남음 → back 버튼으로 앱 종료.

**네비게이션 로그 (버그 재현):**
```
PUSH: /signup/consent (from /) | args: {from: /my}
PUSH: /my (from /signup/consent)
REMOVE: /signup/consent
REMOVE: /          ← 루트까지 제거됨 (버그)
```

## 원인

`/my`는 `GoRoute(path: '/my')`로 top-level 라우트로 정의되어 있어, `go('/my')` 호출 시 암묵적 부모가 없어 go_router가 스택을 `[/my]`로 재구성한다.

## 수정

`consent_coordinator.dart`의 `completeSignup()`에서 목적지로 직접 `go()` 대신 `go('/') + push(destination)` 패턴으로 변경:

```dart
// Before
_router.go(destination ?? '/');

// After — Fix #970
if (destination == null || destination == '/') {
  _router.go('/');
} else {
  _router.go('/');       // 홈을 스택 바닥에 anchor
  _router.push(destination); // 목적지를 push
}
```

**수정 후 스택:**
```
PUSH: /        (go('/'))
PUSH: /my      (push('/my'))
// 결과: [/, /my] → back 버튼으로 홈으로 이동
```

## 테스트

- `consent_coordinator_test.dart`: 10개 유닛 테스트 (홈 이동 7개 + back stack 보존 3개)
- `consent_redirect_test.dart`: 새 통합 테스트 추가 — `completeSignup(from: '/my')` 후 `router.canPop() == true` + `pop()` 시 `HomePage` 표시 확인