### PR TITLE
refactor(ci): notify-failure PR 워크플로우 노이즈 이슈 생성 방지

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -77,3 +77,5 @@ jobs:
     with:
       success: false
       workflow_name: 'Auto Format'
+      # Fix #976: PR-triggered workflows should not create P0 noise issues
+      create_issue: false

--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: ''
         description: 'JSON string of job results, e.g. {"build":"success","test":"failure"}'
+      create_issue:
+        type: boolean
+        required: false
+        default: true
+        description: 'Whether to create/comment a GitHub issue on failure. Set false for PR-triggered workflows to avoid noise.'
 
 jobs:
   notify:
@@ -59,6 +64,11 @@ jobs:
 
           if [ "${{ inputs.success }}" = "true" ]; then
             echo "✅ Workflow succeeded, no issue needed."
+            exit 0
+          fi
+
+          if [ "${{ inputs.create_issue }}" = "false" ]; then
+            echo "ℹ️ create_issue=false — skipping issue creation for PR-triggered workflow."
             exit 0
           fi
 

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -34,3 +34,5 @@ jobs:
     with:
       success: false
       workflow_name: 'Secret Scan'
+      # Fix #976: PR-triggered workflows should not create P0 noise issues
+      create_issue: false


### PR DESCRIPTION
Scheduler: swe

Closes #976

## 문제

`auto-format.yml`, `secret-scan.yml` 등 PR-triggered 워크플로우가 실패하면 P0-critical 이슈가 생성되어 노이즈 발생 (#973 사례).

정기 워크플로우(daily-backend-simulation 등) 실패만 이슈로 트래킹해야 한다.

## 수정

`notify-failure.yml`에 `create_issue` boolean 입력 추가 (default: `true`):

```yaml
# notify-failure.yml
create_issue:
  type: boolean
  required: false
  default: true
```

PR-triggered 2개 워크플로우에 `create_issue: false` 전달:
- `auto-format.yml`
- `secret-scan.yml`

기존 9개 정기/배포 워크플로우는 **변경 없이** 기존 동작 유지.