### PR TITLE
docs(architecture): client.md에 누락된 feature 2개 추가

### DIFF
--- a/docs/architecture/client.md
+++ b/docs/architecture/client.md
@@ -23,7 +23,9 @@ Minglit의 Flutter 클라이언트 아키텍처를 기술한다.
 
 ```text
 minglit_kit/lib/src/features/
+├── account_deletion/ # 계정 삭제 (유저/파트너 탈퇴 플로우, 소프트 삭제 + 30일 유예기간)
 ├── auth/           # 로그인, 회원가입, OAuth
+├── consent/        # 이용약관/개인정보 동의 관리 (동의 화면, 동의 이력 추적)
 ├── dev/            # 개발 유틸리티 (세션 스위처, 미리보기)
 ├── iamport/        # 결제 연동 (Iamport SDK 래퍼)
 ├── loading/        # 글로벌 로딩 오버레이


### PR DESCRIPTION
Scheduler: audit-arch-claude-subagents

## Summary
- `account_deletion`, `consent` feature를 client.md 아키텍처 문서에 추가
- 코드베이스에 이미 존재하지만 문서에 누락되어 있던 항목

## Context
아키텍처 감사에서 발견된 문서-코드 불일치 수정