### PR TITLE
fix(ci): auto-update에서 UNKNOWN 상태 PR도 브랜치 업데이트

### DIFF
--- a/.github/workflows/auto-update-branches.yml
+++ b/.github/workflows/auto-update-branches.yml
@@ -26,8 +26,8 @@ jobs:
           gh pr list --repo "$REPO" --base dev --state open --json number,autoMergeRequest \
             --jq '.[] | select(.autoMergeRequest != null) | .number' | while read -r PR_NUM; do
             MERGE_STATE=$(gh pr view "$PR_NUM" --repo "$REPO" --json mergeStateStatus --jq '.mergeStateStatus')
-            if [ "$MERGE_STATE" = "BEHIND" ]; then
-              echo "PR #$PR_NUM is BEHIND — updating branch..."
+            if [ "$MERGE_STATE" = "BEHIND" ] || [ "$MERGE_STATE" = "UNKNOWN" ]; then
+              echo "PR #$PR_NUM is $MERGE_STATE — updating branch..."
               gh api "repos/$REPO/pulls/$PR_NUM/update-branch" --method PUT || true
             else
               echo "PR #$PR_NUM is $MERGE_STATE — skipping"


### PR DESCRIPTION
## Summary
- `mergeStateStatus: UNKNOWN` PR이 auto-update 대상에서 제외되던 버그 수정
- dependabot PR(#937, #784)이 BEHIND/UNKNOWN 상태로 방치되던 원인

## Test plan
- [ ] 머지 후 다음 dev push 시 UNKNOWN 상태 PR이 업데이트되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)