### PR TITLE
refactor: remove orphaned TODO comments referencing closed issues

### DIFF
--- a/apps/app_partner/lib/src/features/home/partner_home_page.dart
+++ b/apps/app_partner/lib/src/features/home/partner_home_page.dart
@@ -16,9 +16,6 @@ class PartnerHomePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // TODO(#519): partnerDashboardControllerProvider loads all sections in a
-    // single async call. Consider splitting into per-section providers for
-    // independent loading states (e.g. events, stats, applications).
     final state = ref.watch(partnerDashboardControllerProvider);
     final partner = ref.watch(currentPartnerInfoProvider).value;
     final unreadCount = ref
@@ -167,9 +164,7 @@ class PartnerHomePage extends ConsumerWidget {
                     // 4. Weekly Stats
                     const _SectionHeader(title: '이번 주 성과'),
                     const SizedBox(height: MinglitSpacing.small),
-                    // TODO(#519): wire real weekly stats APIs — values
-                    // below are placeholders and should NOT be used for
-                    // KPI reporting until the backend endpoint is ready.
+                    // Note: weekly stats values below are placeholders — not yet backed by a real API.
                     WeeklyStatsRow(
                       totalRevenue: null,
                       totalApplications: state.pendingReviewCount,

--- a/apps/app_user/lib/src/features/home/widgets/event_now_bottom_sheet.dart
+++ b/apps/app_user/lib/src/features/home/widgets/event_now_bottom_sheet.dart
@@ -623,7 +623,6 @@ class _EndedContent extends StatelessWidget {
             width: double.infinity,
             child: ElevatedButton.icon(
               onPressed: () {
-                // TODO(mark): Navigate to review screen (#665)
                 Navigator.of(context).pop();
               },
               icon: const Icon(Icons.rate_review_outlined),

--- a/apps/app_user/lib/src/logic/feed_state_provider.dart
+++ b/apps/app_user/lib/src/logic/feed_state_provider.dart
@@ -441,8 +441,8 @@ class RecommendationFeedNotifier extends _$RecommendationFeedNotifier {
 /// - closingSoon → closingSoon
 /// - nearestDate → nearest
 ///
-// TODO(mark): Phase 2 (#614) — migrate to [recommendationEventsFromEf] once
-// the user-event-feed EF is validated in production.
+// TODO: migrate to [recommendationEventsFromEf] once the user-event-feed EF
+// is validated in production.
 @riverpod
 Future<List<Event>> recommendationEvents(Ref ref) async {
   final filters = ref.watch(activeFiltersProvider);
@@ -475,8 +475,8 @@ Future<List<Event>> recommendationEvents(Ref ref) async {
 /// and cursor pagination are handled by the DB function, so no
 /// client-side post-processing is needed.
 ///
-// TODO(mark): Phase 2 (#614) — wire this into the explore UI behind a feature
-// flag, then remove the legacy [recommendationEvents] path.
+// TODO: wire this into the explore UI behind a feature flag, then remove the
+// legacy [recommendationEvents] path.
 @riverpod
 Future<Map<String, dynamic>> recommendationEventsFromEf(Ref ref) async {
   final filters = ref.watch(activeFiltersProvider);


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-2

## Summary

닫힌 이슈를 참조하는 orphaned TODO 5건 정리:

- `feed_state_provider.dart` (L444, L478): `#614` 이슈 번호 제거, 기능 의도(EF 마이그레이션) 주석은 유지
- `event_now_bottom_sheet.dart` (L626): 리뷰 화면 TODO 삭제 (`#665` closed, 미구현으로 결론)
- `partner_home_page.dart` (L19): provider 분리 제안 TODO 삭제 (`#519` closed)
- `partner_home_page.dart` (L170): weekly stats 경고 주석 단순화 (이슈 번호 제거, 경고 내용 유지)

Closes #1008

## Test plan

- [ ] `flutter analyze` 0 errors (app_user, app_partner)
- [ ] 기존 테스트 통과 확인