### PR TITLE
feat(ci): GitHub Native Release Notes 자동 생성 설정

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,16 @@
+changelog:
+  categories:
+    - title: "🚀 Features"
+      labels: ["enhancement"]
+    - title: "🐛 Bug Fixes"
+      labels: ["bug", "bug-report"]
+    - title: "🏗️ Refactor"
+      labels: ["refactor"]
+    - title: "📝 Documentation"
+      labels: ["documentation"]
+    - title: "🔧 CI/CD"
+      labels: ["ci-failure"]
+    - title: "📦 Dependencies"
+      labels: ["dependencies"]
+    - title: "Other Changes"
+      labels: ["*"]

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -74,6 +74,17 @@ jobs:
           git commit -m "chore: bump version to v${NEW_VERSION} [skip ci]"
           git push origin HEAD:${BRANCH}
 
+      - name: Create GitHub release (main only)
+        if: github.base_ref == 'main'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_VERSION_BUMP }}
+        run: |
+          VERSION="${{ steps.version.outputs.base }}"
+          gh release create "v${VERSION}" \
+            --generate-notes \
+            --target main \
+            --title "v${VERSION}"
+
   notify-failure:
     needs: [bump]
     if: always()


### PR DESCRIPTION
## Summary
- `.github/release.yml` 추가: PR 라벨 기반 changelog 카테고리 설정 (Features, Bug Fixes, Refactor, Documentation, CI/CD, Dependencies, Other Changes)
- `version-bump.yml` 업데이트: main 브랜치 머지 시 `gh release create --generate-notes` 로 GitHub release 자동 생성

## Test plan
- [ ] `.github/release.yml` 형식이 GitHub Docs 스펙과 일치하는지 확인
- [ ] `version-bump.yml` 의 new step이 `github.base_ref == 'main'` 조건으로만 실행되는지 확인
- [ ] 다음 main 브랜치 PR 머지 시 릴리즈 노트가 자동 생성되는지 모니터링

Closes #1007

🤖 Generated with [Claude Code](https://claude.com/claude-code)