### PR TITLE
fix(consent): 구분선 위치를 required 프로퍼티 기반으로 변경

### DIFF
--- a/apps/app_user/lib/src/features/consent/ui/signup_consent_page.dart
+++ b/apps/app_user/lib/src/features/consent/ui/signup_consent_page.dart
@@ -102,8 +102,8 @@ class _SignupConsentPageState extends ConsumerState<SignupConsentPage> {
                     Card(
                       child: Column(
                         children: [
-                          for (final definition
-                              in _consentDefinitions.values) ...[
+                          for (final (index, definition)
+                              in _consentDefinitions.values.indexed) ...[
                             _ConsentItemTile(
                               definition: definition,
                               selected: _selectedConsents.contains(
@@ -118,9 +118,14 @@ class _SignupConsentPageState extends ConsumerState<SignupConsentPage> {
                                       content: definition.detail!,
                                     ),
                             ),
-                            // Fix #966: 필수/선택 구분선 (필수 마지막 항목 다음)
-                            if (definition.type ==
-                                ConsentType.requiredTypes.last)
+                            // Fix #966: 필수/선택 구분선 — 현재 항목이 필수이고
+                            // 다음 항목이 선택이거나 마지막일 때 표시.
+                            // requiredTypes.last에 의존하지 않으므로 항목 추가 시에도 안전.
+                            if (definition.required &&
+                                (index == _consentDefinitions.length - 1 ||
+                                    !_consentDefinitions.values
+                                        .elementAt(index + 1)
+                                        .required))
                               const Divider(
                                 height: 1,
                                 indent: MinglitSpacing.medium,


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

## 문제

PR #1039 코드 리뷰에서 [P2] 지적: `signup_consent_page.dart`의 구분선이 `ConsentType.requiredTypes.last`에 의존 — `_consentDefinitions` 맵 순서와 `requiredTypes` 리스트가 동기화되지 않으면 구분선이 잘못된 위치에 렌더링될 수 있음.

## 수정

- `requiredTypes.last` 비교 → `definition.required` + 다음 항목 경계 판단으로 교체
- 향후 필수 항목 추가 시 두 곳을 동기화할 필요 없이 자동으로 올바른 위치에 구분선 표시

## 관련

- PR #1039 코드 리뷰 (needs-review-sonnet-1 [P2] 지적)