### PR TITLE
fix(ef): supabase/functions/deno.json 추가 — Deno bare import 해결

### DIFF
--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2"
+  }
+}


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1048

## 변경 내용

`supabase/functions/deno.json`을 추가하여 Deno bare import (`@supabase/supabase-js`) 해결.

Supabase CLI 최신 버전이 `--import-map` flag 지원을 중단했고, `deno.json`이 없어 `recurrence-rules`, `recurrence-cron` EF bundling 실패.

## 수정 파일

- `supabase/functions/deno.json` (신규): `@supabase/supabase-js` → `npm:@supabase/supabase-js@2` import map

## 검증

- 기존 EF regression 없음 (변경 없음)
- `recurrence-rules`, `recurrence-cron` bundling 성공 예상