### PR TITLE
refactor(app_partner): Coordinator 패턴 위반 수정 — UI 직접 Route 호출 제거

### DIFF
--- a/apps/app_partner/lib/src/features/home/partner_home_coordinator.dart
+++ b/apps/app_partner/lib/src/features/home/partner_home_coordinator.dart
@@ -35,4 +35,8 @@ class PartnerHomeCoordinator {
   void goToCheckin() {
     _router.go(const CheckinRoute().location);
   }
+
+  void pushEventCreate(String partyId) {
+    unawaited(_router.push(EventCreateRoute(partyId: partyId).location));
+  }
 }

--- a/apps/app_partner/lib/src/features/home/partner_home_coordinator.dart
+++ b/apps/app_partner/lib/src/features/home/partner_home_coordinator.dart
@@ -26,4 +26,13 @@ class PartnerHomeCoordinator {
   void goToSettlement() {
     _router.go(const SettlementRoute().location);
   }
+
+  // Fix #845: ApplicationList/Checkin 탭 전환을 coordinator를 통해 위임
+  void goToApplicationList() {
+    _router.go(const ApplicationListRoute().location);
+  }
+
+  void goToCheckin() {
+    _router.go(const CheckinRoute().location);
+  }
 }

--- a/apps/app_partner/lib/src/features/home/partner_home_page.dart
+++ b/apps/app_partner/lib/src/features/home/partner_home_page.dart
@@ -256,11 +256,7 @@ class PartnerHomePage extends ConsumerWidget {
             coordinator.goToCheckin();
           case EventPhase.ended:
             // "다음 회차 만들기" → 이벤트 생성 (pre-fill은 #520에서 구현)
-            unawaited(
-              EventCreateRoute(
-                partyId: primaryEvent.partyId,
-              ).push<void>(context),
-            );
+            coordinator.pushEventCreate(primaryEvent.partyId);
         }
       },
       onSecondaryAction1: () {

--- a/apps/app_partner/lib/src/features/home/partner_home_page.dart
+++ b/apps/app_partner/lib/src/features/home/partner_home_page.dart
@@ -146,10 +146,7 @@ class PartnerHomePage extends ConsumerWidget {
                     TodoSummaryChips(
                       pendingApplications: state.pendingReviewCount,
                       upcomingEvents: state.upcomingEvents.length,
-                      onPendingTap: () {
-                        // Fix #845: coordinator를 통해 탭 전환 위임
-                        coordinator.goToApplicationList();
-                      },
+                      onPendingTap: coordinator.goToApplicationList,
                       onUpcomingTap: () {
                         unawaited(
                           const PartyListRoute().push<void>(context),

--- a/apps/app_partner/lib/src/features/home/partner_home_page.dart
+++ b/apps/app_partner/lib/src/features/home/partner_home_page.dart
@@ -147,7 +147,8 @@ class PartnerHomePage extends ConsumerWidget {
                       pendingApplications: state.pendingReviewCount,
                       upcomingEvents: state.upcomingEvents.length,
                       onPendingTap: () {
-                        const ApplicationListRoute().go(context);
+                        // Fix #845: coordinator를 통해 탭 전환 위임
+                        coordinator.goToApplicationList();
                       },
                       onUpcomingTap: () {
                         unawaited(
@@ -248,12 +249,14 @@ class PartnerHomePage extends ConsumerWidget {
     return EventActionCard(
       event: primaryEvent,
       onMainAction: () {
+        // Fix #845: coordinator를 통해 탭 전환 위임
+        final coordinator = ref.read(partnerHomeCoordinatorProvider);
         switch (phase) {
           case EventPhase.recruiting:
-            const ApplicationListRoute().go(context);
+            coordinator.goToApplicationList();
           case EventPhase.preparing:
           case EventPhase.live:
-            const CheckinRoute().go(context);
+            coordinator.goToCheckin();
           case EventPhase.ended:
             // "다음 회차 만들기" → 이벤트 생성 (pre-fill은 #520에서 구현)
             unawaited(

--- a/apps/app_partner/lib/src/features/onboarding/partner_apply_status_page.dart
+++ b/apps/app_partner/lib/src/features/onboarding/partner_apply_status_page.dart
@@ -63,7 +63,7 @@ class PartnerApplyStatusPage extends ConsumerWidget {
           _buildStatusMessage(context, onboardingState, application, l10n),
           const SizedBox(height: MinglitSpacing.xlarge),
           if (onboardingState == OnboardingState.needsCorrection) ...[
-            _buildEditButton(context, ref, l10n),
+            _buildEditButton(ref, l10n),
             const SizedBox(height: MinglitSpacing.medium),
           ],
           _buildLogoutButton(context, ref, l10n),
@@ -138,11 +138,7 @@ class PartnerApplyStatusPage extends ConsumerWidget {
     );
   }
 
-  Widget _buildEditButton(
-    BuildContext context,
-    WidgetRef ref,
-    AppLocalizations l10n,
-  ) {
+  Widget _buildEditButton(WidgetRef ref, AppLocalizations l10n) {
     return FilledButton(
       // Fix #845: coordinator를 통해 네비게이션 위임
       onPressed: () => ref.read(onboardingCoordinatorProvider).goToApply(),

--- a/apps/app_partner/lib/src/features/onboarding/partner_apply_status_page.dart
+++ b/apps/app_partner/lib/src/features/onboarding/partner_apply_status_page.dart
@@ -1,6 +1,6 @@
+import 'package:app_partner/src/features/onboarding/onboarding_coordinator.dart';
 import 'package:app_partner/src/l10n/generated/app_localizations.dart';
 import 'package:app_partner/src/logic/onboarding_state_provider.dart';
-import 'package:app_partner/src/routing/app_routes.dart';
 import 'package:app_partner/src/utils/l10n_ext.dart';
 import 'package:flutter/material.dart';
 
@@ -63,7 +63,7 @@ class PartnerApplyStatusPage extends ConsumerWidget {
           _buildStatusMessage(context, onboardingState, application, l10n),
           const SizedBox(height: MinglitSpacing.xlarge),
           if (onboardingState == OnboardingState.needsCorrection) ...[
-            _buildEditButton(context, l10n),
+            _buildEditButton(context, ref, l10n),
             const SizedBox(height: MinglitSpacing.medium),
           ],
           _buildLogoutButton(context, ref, l10n),
@@ -138,9 +138,14 @@ class PartnerApplyStatusPage extends ConsumerWidget {
     );
   }
 
-  Widget _buildEditButton(BuildContext context, AppLocalizations l10n) {
+  Widget _buildEditButton(
+    BuildContext context,
+    WidgetRef ref,
+    AppLocalizations l10n,
+  ) {
     return FilledButton(
-      onPressed: () => const PartnerApplyRoute().go(context),
+      // Fix #845: coordinator를 통해 네비게이션 위임
+      onPressed: () => ref.read(onboardingCoordinatorProvider).goToApply(),
       child: Text(l10n.partnerApplication_button_editApplication),
     );
   }


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #845

## 변경 내용

UI에서 GoRouter Route를 직접 호출하는 패턴을 Coordinator 위임으로 수정.

### 수정 파일
- `partner_home_coordinator.dart`: `goToApplicationList()`, `goToCheckin()` 메서드 추가
- `partner_home_page.dart`: `ApplicationListRoute().go()`, `CheckinRoute().go()` → coordinator 위임
- `partner_apply_status_page.dart`: `PartnerApplyRoute().go()` → `OnboardingCoordinator.goToApply()` 위임, 불필요한 `app_routes` import 제거

## 출처
- Audit 리포트 #772 (audit-arch)