### PR TITLE
feat(animations): Material 3 모션 전환 도입

### DIFF
--- a/apps/app_partner/lib/src/routing/app_routes.dart
+++ b/apps/app_partner/lib/src/routing/app_routes.dart
@@ -260,8 +260,11 @@ class ApplicationDetailRoute extends GoRouteData with $ApplicationDetailRoute {
   const ApplicationDetailRoute({required this.applicationId});
   final String applicationId;
   @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      PartnerApplicationDetailPage(applicationId: applicationId);
+  Page<void> buildPage(BuildContext context, GoRouterState state) =>
+      MinglitPageTransitions.sharedAxisScaled(
+        key: state.pageKey,
+        child: PartnerApplicationDetailPage(applicationId: applicationId),
+      );
 }
 
 class LocationGuideRoute extends GoRouteData with $LocationGuideRoute {
@@ -298,8 +301,11 @@ class PartyDetailRoute extends GoRouteData with $PartyDetailRoute {
   const PartyDetailRoute({required this.partyId});
   final String partyId;
   @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      PartyDetailPage(partyId: partyId);
+  Page<void> buildPage(BuildContext context, GoRouterState state) =>
+      MinglitPageTransitions.sharedAxisScaled(
+        key: state.pageKey,
+        child: PartyDetailPage(partyId: partyId),
+      );
 }
 
 class PartyEditRoute extends GoRouteData with $PartyEditRoute {
@@ -332,8 +338,11 @@ class EventDetailRoute extends GoRouteData with $EventDetailRoute {
   final String partyId;
   final String eventId;
   @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      EventDetailPage(eventId: eventId);
+  Page<void> buildPage(BuildContext context, GoRouterState state) =>
+      MinglitPageTransitions.sharedAxisScaled(
+        key: state.pageKey,
+        child: EventDetailPage(eventId: eventId),
+      );
 }
 
 class TicketCreateRoute extends GoRouteData with $TicketCreateRoute {
@@ -466,10 +475,13 @@ class MemberPermissionRoute extends GoRouteData with $MemberPermissionRoute {
   final String partnerId;
   final String targetUserId;
   @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      PartnerMemberPermissionPage(
-        partnerId: partnerId,
-        targetUserId: targetUserId,
+  Page<void> buildPage(BuildContext context, GoRouterState state) =>
+      MinglitPageTransitions.sharedAxisScaled(
+        key: state.pageKey,
+        child: PartnerMemberPermissionPage(
+          partnerId: partnerId,
+          targetUserId: targetUserId,
+        ),
       );
 }
 

--- a/apps/app_partner/lib/src/routing/app_routes.dart
+++ b/apps/app_partner/lib/src/routing/app_routes.dart
@@ -380,8 +380,11 @@ class SettlementDetailRoute extends GoRouteData with $SettlementDetailRoute {
   const SettlementDetailRoute({required this.id});
   final String id;
   @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      SettlementDetailPage(itemId: id);
+  Page<void> buildPage(BuildContext context, GoRouterState state) =>
+      MinglitPageTransitions.sharedAxisScaled(
+        key: state.pageKey,
+        child: SettlementDetailPage(itemId: id),
+      );
 }
 
 class BankAccountRoute extends GoRouteData with $BankAccountRoute {

--- a/apps/app_partner/lib/src/ui/shell/partner_scaffold.dart
+++ b/apps/app_partner/lib/src/ui/shell/partner_scaffold.dart
@@ -47,10 +47,10 @@ class PartnerScaffold extends StatelessWidget {
       body: PageTransitionSwitcher(
         transitionBuilder: (child, animation, secondaryAnimation) =>
             FadeThroughTransition(
-          animation: animation,
-          secondaryAnimation: secondaryAnimation,
-          child: child,
-        ),
+              animation: animation,
+              secondaryAnimation: secondaryAnimation,
+              child: child,
+            ),
         child: KeyedSubtree(
           key: ValueKey<int>(navigationShell.currentIndex),
           child: navigationShell,

--- a/apps/app_partner/lib/src/ui/shell/partner_scaffold.dart
+++ b/apps/app_partner/lib/src/ui/shell/partner_scaffold.dart
@@ -1,3 +1,4 @@
+import 'package:animations/animations.dart';
 import 'package:app_partner/src/ui/shell/partner_shell_coordinator.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -43,7 +44,18 @@ class PartnerScaffold extends StatelessWidget {
     final showBottomNav = _shouldShowBottomNav(context);
 
     return Scaffold(
-      body: navigationShell,
+      body: PageTransitionSwitcher(
+        transitionBuilder: (child, animation, secondaryAnimation) =>
+            FadeThroughTransition(
+          animation: animation,
+          secondaryAnimation: secondaryAnimation,
+          child: child,
+        ),
+        child: KeyedSubtree(
+          key: ValueKey<int>(navigationShell.currentIndex),
+          child: navigationShell,
+        ),
+      ),
       bottomNavigationBar: showBottomNav
           ? NavigationBar(
               selectedIndex: _calculateSelectedIndex(),

--- a/apps/app_partner/pubspec.yaml
+++ b/apps/app_partner/pubspec.yaml
@@ -29,6 +29,7 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
+  animations: ^2.0.0
   async: ^2.13.0
   collection: ^1.19.1
   cupertino_icons: ^1.0.8

--- a/apps/app_user/lib/src/routing/app_routes.dart
+++ b/apps/app_user/lib/src/routing/app_routes.dart
@@ -86,8 +86,11 @@ class EventDetailRoute extends GoRouteData with $EventDetailRoute {
   final String eventId;
 
   @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      EventDetailPage(eventId: eventId);
+  Page<void> buildPage(BuildContext context, GoRouterState state) =>
+      MinglitPageTransitions.sharedAxisScaled(
+        key: state.pageKey,
+        child: EventDetailPage(eventId: eventId),
+      );
 }
 
 /// **Partner Detail Route**: Detailed information about a specific partner.
@@ -99,8 +102,11 @@ class PartnerDetailRoute extends GoRouteData with $PartnerDetailRoute {
   final String partnerId;
 
   @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      PartnerDetailPage(partnerId: partnerId);
+  Page<void> buildPage(BuildContext context, GoRouterState state) =>
+      MinglitPageTransitions.sharedAxisScaled(
+        key: state.pageKey,
+        child: PartnerDetailPage(partnerId: partnerId),
+      );
 }
 
 /// **Partner Events Route**: Full list of events for a partner.

--- a/shared/packages/minglit_kit/lib/minglit_ui.dart
+++ b/shared/packages/minglit_kit/lib/minglit_ui.dart
@@ -54,4 +54,5 @@ export 'src/ui/widgets/party/location_map_view.dart';
 export 'src/utils/environment_info.dart';
 export 'src/utils/feedback_ext.dart';
 export 'src/utils/layout_dump.dart';
+export 'src/utils/minglit_page_transitions.dart';
 export 'src/utils/splash_screen.dart';

--- a/shared/packages/minglit_kit/lib/src/utils/minglit_page_transitions.dart
+++ b/shared/packages/minglit_kit/lib/src/utils/minglit_page_transitions.dart
@@ -11,32 +11,30 @@ class MinglitPageTransitions {
   static CustomTransitionPage<T> sharedAxisScaled<T>({
     required LocalKey key,
     required Widget child,
-  }) =>
-      CustomTransitionPage<T>(
-        key: key,
-        child: child,
-        transitionsBuilder: (context, animation, secondaryAnimation, child) =>
-            SharedAxisTransition(
+  }) => CustomTransitionPage<T>(
+    key: key,
+    child: child,
+    transitionsBuilder: (context, animation, secondaryAnimation, child) =>
+        SharedAxisTransition(
           animation: animation,
           secondaryAnimation: secondaryAnimation,
           transitionType: SharedAxisTransitionType.scaled,
           child: child,
         ),
-      );
+  );
 
   /// FadeThrough — 동일 계층 전환용
   static CustomTransitionPage<T> fadeThrough<T>({
     required LocalKey key,
     required Widget child,
-  }) =>
-      CustomTransitionPage<T>(
-        key: key,
-        child: child,
-        transitionsBuilder: (context, animation, secondaryAnimation, child) =>
-            FadeThroughTransition(
+  }) => CustomTransitionPage<T>(
+    key: key,
+    child: child,
+    transitionsBuilder: (context, animation, secondaryAnimation, child) =>
+        FadeThroughTransition(
           animation: animation,
           secondaryAnimation: secondaryAnimation,
           child: child,
         ),
-      );
+  );
 }

--- a/shared/packages/minglit_kit/lib/src/utils/minglit_page_transitions.dart
+++ b/shared/packages/minglit_kit/lib/src/utils/minglit_page_transitions.dart
@@ -1,0 +1,42 @@
+import 'package:animations/animations.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// Material 3 모션 전환 헬퍼.
+///
+/// [sharedAxisScaled]: 계층 네비게이션 전환 (Z축 SharedAxis).
+/// [fadeThrough]: 동일 계층 전환 (FadeThrough).
+class MinglitPageTransitions {
+  /// Z축 SharedAxis — 계층 네비게이션용
+  static CustomTransitionPage<T> sharedAxisScaled<T>({
+    required LocalKey key,
+    required Widget child,
+  }) =>
+      CustomTransitionPage<T>(
+        key: key,
+        child: child,
+        transitionsBuilder: (context, animation, secondaryAnimation, child) =>
+            SharedAxisTransition(
+          animation: animation,
+          secondaryAnimation: secondaryAnimation,
+          transitionType: SharedAxisTransitionType.scaled,
+          child: child,
+        ),
+      );
+
+  /// FadeThrough — 동일 계층 전환용
+  static CustomTransitionPage<T> fadeThrough<T>({
+    required LocalKey key,
+    required Widget child,
+  }) =>
+      CustomTransitionPage<T>(
+        key: key,
+        child: child,
+        transitionsBuilder: (context, animation, secondaryAnimation, child) =>
+            FadeThroughTransition(
+          animation: animation,
+          secondaryAnimation: secondaryAnimation,
+          child: child,
+        ),
+      );
+}

--- a/shared/packages/minglit_kit/lib/src/utils/minglit_page_transitions.dart
+++ b/shared/packages/minglit_kit/lib/src/utils/minglit_page_transitions.dart
@@ -5,7 +5,6 @@ import 'package:go_router/go_router.dart';
 /// Material 3 모션 전환 헬퍼.
 ///
 /// [sharedAxisScaled]: 계층 네비게이션 전환 (Z축 SharedAxis).
-/// [fadeThrough]: 동일 계층 전환 (FadeThrough).
 class MinglitPageTransitions {
   /// Z축 SharedAxis — 계층 네비게이션용
   static CustomTransitionPage<T> sharedAxisScaled<T>({
@@ -19,21 +18,6 @@ class MinglitPageTransitions {
           animation: animation,
           secondaryAnimation: secondaryAnimation,
           transitionType: SharedAxisTransitionType.scaled,
-          child: child,
-        ),
-  );
-
-  /// FadeThrough — 동일 계층 전환용
-  static CustomTransitionPage<T> fadeThrough<T>({
-    required LocalKey key,
-    required Widget child,
-  }) => CustomTransitionPage<T>(
-    key: key,
-    child: child,
-    transitionsBuilder: (context, animation, secondaryAnimation, child) =>
-        FadeThroughTransition(
-          animation: animation,
-          secondaryAnimation: secondaryAnimation,
           child: child,
         ),
   );

--- a/shared/packages/minglit_kit/pubspec.yaml
+++ b/shared/packages/minglit_kit/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: ^3.10.4
 
 dependencies:
+  animations: ^2.0.0
   app_settings: ^6.1.1
   async: ^2.13.0
   battery_plus: ^6.0.1


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

## Summary
- animations 패키지 도입 (Material 3 모션 스펙)
- MinglitPageTransitions 헬퍼 유틸리티 추가 (SharedAxisTransition, FadeThroughTransition)
- partner_scaffold.dart: 하단 탭 전환에 FadeThrough 적용
- app_user, app_partner 주요 계층 라우트에 SharedAxis(scaled) 적용

Closes #476