### PR TITLE
refactor: MinglitChipGroup 합성 위젯 추출 (#477)

### DIFF
--- a/apps/app_partner/lib/src/features/admin/partner_application_list_page.dart
+++ b/apps/app_partner/lib/src/features/admin/partner_application_list_page.dart
@@ -99,7 +99,9 @@ class _PartnerApplicationListPageState
             },
           ),
           const SizedBox(height: MinglitSpacing.small),
+          // Fix #477: Container already has horizontal padding — zero out ChipGroup default padding
           MinglitChipGroup(
+            padding: EdgeInsets.zero,
             children: [
               _buildFilterChip('전체', 'all'),
               _buildFilterChip('대기', 'pending'),

--- a/apps/app_partner/lib/src/features/admin/partner_application_list_page.dart
+++ b/apps/app_partner/lib/src/features/admin/partner_application_list_page.dart
@@ -99,21 +99,14 @@ class _PartnerApplicationListPageState
             },
           ),
           const SizedBox(height: MinglitSpacing.small),
-          SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: Row(
-              children: [
-                _buildFilterChip('전체', 'all'),
-                const SizedBox(width: MinglitSpacing.small),
-                _buildFilterChip('대기', 'pending'),
-                const SizedBox(width: MinglitSpacing.small),
-                _buildFilterChip('승인', 'approved'),
-                const SizedBox(width: MinglitSpacing.small),
-                _buildFilterChip('반려', 'rejected'),
-                const SizedBox(width: MinglitSpacing.small),
-                _buildFilterChip('보완', 'needs_correction'),
-              ],
-            ),
+          MinglitChipGroup(
+            children: [
+              _buildFilterChip('전체', 'all'),
+              _buildFilterChip('대기', 'pending'),
+              _buildFilterChip('승인', 'approved'),
+              _buildFilterChip('반려', 'rejected'),
+              _buildFilterChip('보완', 'needs_correction'),
+            ],
           ),
         ],
       ),

--- a/apps/app_partner/lib/src/features/party/ticket/ui/ticket_manage_screen.dart
+++ b/apps/app_partner/lib/src/features/party/ticket/ui/ticket_manage_screen.dart
@@ -284,8 +284,9 @@ class _TicketEditSheetState extends ConsumerState<_TicketEditSheet> {
           const SizedBox(height: MinglitSpacing.large),
           const Text('판매 상태'),
           const SizedBox(height: MinglitSpacing.small),
-          Wrap(
-            spacing: MinglitSpacing.small,
+          MinglitChipGroup(
+            scrollable: false,
+            padding: EdgeInsets.zero,
             children: [
               _buildStatusChoice('on_sale', '판매중'),
               _buildStatusChoice('sold_out', '매진'),

--- a/apps/app_partner/lib/src/features/settlement/widgets/status_filter_chips.dart
+++ b/apps/app_partner/lib/src/features/settlement/widgets/status_filter_chips.dart
@@ -24,24 +24,15 @@ class StatusFilterChips extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: 40,
-      child: ListView.separated(
-        scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.symmetric(horizontal: MinglitSpacing.medium),
-        itemCount: _statuses.length,
-        separatorBuilder: (context, index) =>
-            const SizedBox(width: MinglitSpacing.small),
-        itemBuilder: (context, i) {
-          final (status, label) = _statuses[i];
-          final isSelected = selectedStatus == status;
-          return ChoiceChip(
+    return MinglitChipGroup(
+      children: [
+        for (final (status, label) in _statuses)
+          ChoiceChip(
             label: Text(label),
-            selected: isSelected,
+            selected: selectedStatus == status,
             onSelected: (_) => onStatusChanged(status),
-          );
-        },
-      ),
+          ),
+      ],
     );
   }
 }

--- a/shared/packages/minglit_kit/lib/minglit_ui.dart
+++ b/shared/packages/minglit_kit/lib/minglit_ui.dart
@@ -26,6 +26,7 @@ export 'src/ui/widgets/common/minglit_bottom_cta.dart';
 export 'src/ui/widgets/common/minglit_bottom_sheet.dart';
 export 'src/ui/widgets/common/minglit_button.dart';
 export 'src/ui/widgets/common/minglit_chip.dart';
+export 'src/ui/widgets/common/minglit_chip_group.dart';
 export 'src/ui/widgets/common/minglit_content_card.dart';
 export 'src/ui/widgets/common/minglit_dialog.dart';
 export 'src/ui/widgets/common/minglit_empty_state.dart';

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_chip_group.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_chip_group.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/src/theme/minglit_theme.dart';
+
+/// 가로 스크롤 또는 줄바꿈 칩 그룹 레이아웃 위젯.
+///
+/// [scrollable]이 true면 `ListView.separated` 기반 가로 스크롤,
+/// false면 `Wrap` 기반 줄바꿈 레이아웃을 사용합니다.
+///
+/// 각 칩 사이 간격과 외부 패딩을 자동으로 적용합니다.
+// Fix #477: 반복되는 필터 칩 그룹 패턴 통합 — MinglitChipGroup 합성 위젯
+class MinglitChipGroup extends StatelessWidget {
+  /// Creates a [MinglitChipGroup].
+  const MinglitChipGroup({
+    required this.children,
+    this.height = 40,
+    this.spacing = MinglitSpacing.small,
+    this.padding = const EdgeInsets.symmetric(
+      horizontal: MinglitSpacing.medium,
+    ),
+    this.scrollable = true,
+    super.key,
+  });
+
+  /// 칩 위젯 목록.
+  final List<Widget> children;
+
+  /// 스크롤 가능 모드일 때 높이. [scrollable]이 false면 무시됩니다.
+  final double height;
+
+  /// 칩 간 간격. [scrollable]이 false일 때 Wrap의 spacing과 runSpacing에 적용됩니다.
+  final double spacing;
+
+  /// 외부 패딩.
+  final EdgeInsets padding;
+
+  /// true: 가로 스크롤 (`ListView.separated`), false: 줄바꿈 (`Wrap`).
+  final bool scrollable;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!scrollable) {
+      return Padding(
+        padding: padding,
+        child: Wrap(
+          spacing: spacing,
+          runSpacing: spacing,
+          children: children,
+        ),
+      );
+    }
+
+    return SizedBox(
+      height: height,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: padding,
+        itemCount: children.length,
+        separatorBuilder: (context, index) => SizedBox(width: spacing),
+        itemBuilder: (_, i) => children[i],
+      ),
+    );
+  }
+}

--- a/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_chip_group_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_chip_group_test.dart
@@ -10,8 +10,9 @@ void main() {
   }
 
   group('MinglitChipGroup', () {
-    testWidgets('scrollable=true renders ListView with correct height',
-        (tester) async {
+    testWidgets('scrollable=true renders ListView with correct height', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         buildApp(
           const MinglitChipGroup(

--- a/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_chip_group_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_chip_group_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_chip_group.dart';
+
+void main() {
+  Widget buildApp(Widget child) {
+    return MaterialApp(
+      home: Scaffold(body: child),
+    );
+  }
+
+  group('MinglitChipGroup', () {
+    testWidgets('scrollable=true renders ListView with correct height',
+        (tester) async {
+      await tester.pumpWidget(
+        buildApp(
+          const MinglitChipGroup(
+            children: [
+              Chip(label: Text('A')),
+              Chip(label: Text('B')),
+            ],
+          ),
+        ),
+      );
+      expect(find.byType(ListView), findsOneWidget);
+      final sizedBox = tester.widget<SizedBox>(
+        find
+            .ancestor(
+              of: find.byType(ListView),
+              matching: find.byType(SizedBox),
+            )
+            .first,
+      );
+      expect(sizedBox.height, 40);
+    });
+
+    testWidgets('scrollable=false renders Wrap', (tester) async {
+      await tester.pumpWidget(
+        buildApp(
+          const MinglitChipGroup(
+            scrollable: false,
+            children: [
+              Chip(label: Text('A')),
+              Chip(label: Text('B')),
+            ],
+          ),
+        ),
+      );
+      expect(find.byType(Wrap), findsOneWidget);
+      expect(find.byType(ListView), findsNothing);
+    });
+
+    testWidgets('empty children renders without crash', (tester) async {
+      await tester.pumpWidget(
+        buildApp(
+          const MinglitChipGroup(children: []),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('children are displayed', (tester) async {
+      await tester.pumpWidget(
+        buildApp(
+          const MinglitChipGroup(
+            children: [
+              Chip(label: Text('Chip 1')),
+              Chip(label: Text('Chip 2')),
+              Chip(label: Text('Chip 3')),
+            ],
+          ),
+        ),
+      );
+      expect(find.text('Chip 1'), findsOneWidget);
+      expect(find.text('Chip 2'), findsOneWidget);
+      expect(find.text('Chip 3'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

## Summary
- MinglitChipGroup 위젯 추가 (scrollable/Wrap 두 모드 지원)
- StatusFilterChips, partner_application_list_page, ticket_manage_screen 마이그레이션
- ExploreFilterChipBar는 VerticalDivider 혼용으로 마이그레이션 제외
- 위젯 테스트 추가 (4개 테스트 케이스)

Closes #477