### PR TITLE
feat(pattern-catalog): P1 상세 페이지 패턴 데모 추가

### DIFF
--- a/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/catalog_tabs.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/catalog_tabs.dart
@@ -1,3 +1,6 @@
+export 'pattern_list_section.dart';
+export 'patterns/detail_page_demo.dart';
+export 'patterns/mock_data.dart';
 export 'tokens/animation_section.dart';
 export 'tokens/colors_section.dart';
 export 'tokens/icon_size_section.dart';
@@ -12,6 +15,3 @@ export 'widgets/inputs_section.dart';
 export 'widgets/layout_section.dart';
 export 'widgets/loading_section.dart';
 export 'widgets/overlay_section.dart';
-export 'pattern_list_section.dart';
-export 'patterns/detail_page_demo.dart';
-export 'patterns/mock_data.dart';

--- a/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/catalog_tabs.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/catalog_tabs.dart
@@ -12,3 +12,6 @@ export 'widgets/inputs_section.dart';
 export 'widgets/layout_section.dart';
 export 'widgets/loading_section.dart';
 export 'widgets/overlay_section.dart';
+export 'pattern_list_section.dart';
+export 'patterns/detail_page_demo.dart';
+export 'patterns/mock_data.dart';

--- a/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/pattern_list_section.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/pattern_list_section.dart
@@ -31,14 +31,14 @@ class PatternListSection extends StatelessWidget {
         const SizedBox(height: MinglitSpacing.large),
         Text('상태 패턴', style: theme.textTheme.titleMedium),
         const SizedBox(height: MinglitSpacing.small),
-        _PatternTile(
+        const _PatternTile(
           title: 'P6 — 빈/에러/로딩 상태',
           subtitle: '3단계 로딩 + 빈/에러 표준 구조',
           icon: Icons.hourglass_empty_outlined,
           onTap: null, // feat/715 — 준비 중
           disabled: true,
         ),
-        _PatternTile(
+        const _PatternTile(
           title: 'P7 — Async 래퍼',
           subtitle: 'MinglitAsyncValueWidget 사용법',
           icon: Icons.sync_outlined,
@@ -48,7 +48,7 @@ class PatternListSection extends StatelessWidget {
         const SizedBox(height: MinglitSpacing.large),
         Text('데이터 표시 패턴', style: theme.textTheme.titleMedium),
         const SizedBox(height: MinglitSpacing.small),
-        _PatternTile(
+        const _PatternTile(
           title: 'P4 — 카드 레이아웃',
           subtitle: '5가지 카드 변형 프리뷰',
           icon: Icons.grid_view_outlined,
@@ -58,7 +58,7 @@ class PatternListSection extends StatelessWidget {
         const SizedBox(height: MinglitSpacing.large),
         Text('트랜잭션 패턴', style: theme.textTheme.titleMedium),
         const SizedBox(height: MinglitSpacing.small),
-        _PatternTile(
+        const _PatternTile(
           title: 'P5 — 결제 플로우',
           subtitle: '결제/환불 상태 시뮬레이션',
           icon: Icons.payment_outlined,

--- a/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/pattern_list_section.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/pattern_list_section.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/src/features/dev/catalog_tabs/patterns/detail_page_demo.dart';
+import 'package:minglit_kit/src/theme/minglit_theme.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_content_card.dart';
+
+/// Pattern catalog listing section.
+///
+/// Displays all available pattern demos grouped by category.
+/// Each item navigates to its corresponding full-screen demo.
+class PatternListSection extends StatelessWidget {
+  /// Creates a [PatternListSection].
+  const PatternListSection({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListView(
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      children: [
+        Text('페이지 패턴', style: theme.textTheme.titleMedium),
+        const SizedBox(height: MinglitSpacing.small),
+        _PatternTile(
+          title: 'P1 — 상세 페이지',
+          subtitle: 'Hero + TabBar + CTA 구조',
+          icon: Icons.article_outlined,
+          onTap: () => Navigator.push(
+            context,
+            MaterialPageRoute<void>(builder: (_) => const DetailPageDemo()),
+          ),
+        ),
+        const SizedBox(height: MinglitSpacing.large),
+        Text('상태 패턴', style: theme.textTheme.titleMedium),
+        const SizedBox(height: MinglitSpacing.small),
+        _PatternTile(
+          title: 'P6 — 빈/에러/로딩 상태',
+          subtitle: '3단계 로딩 + 빈/에러 표준 구조',
+          icon: Icons.hourglass_empty_outlined,
+          onTap: null, // feat/715 — 준비 중
+          disabled: true,
+        ),
+        _PatternTile(
+          title: 'P7 — Async 래퍼',
+          subtitle: 'MinglitAsyncValueWidget 사용법',
+          icon: Icons.sync_outlined,
+          onTap: null, // feat/716 — 준비 중
+          disabled: true,
+        ),
+        const SizedBox(height: MinglitSpacing.large),
+        Text('데이터 표시 패턴', style: theme.textTheme.titleMedium),
+        const SizedBox(height: MinglitSpacing.small),
+        _PatternTile(
+          title: 'P4 — 카드 레이아웃',
+          subtitle: '5가지 카드 변형 프리뷰',
+          icon: Icons.grid_view_outlined,
+          onTap: null, // feat/714 — 준비 중
+          disabled: true,
+        ),
+        const SizedBox(height: MinglitSpacing.large),
+        Text('트랜잭션 패턴', style: theme.textTheme.titleMedium),
+        const SizedBox(height: MinglitSpacing.small),
+        _PatternTile(
+          title: 'P5 — 결제 플로우',
+          subtitle: '결제/환불 상태 시뮬레이션',
+          icon: Icons.payment_outlined,
+          onTap: null, // feat/717 — 준비 중
+          disabled: true,
+        ),
+      ],
+    );
+  }
+}
+
+class _PatternTile extends StatelessWidget {
+  const _PatternTile({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    required this.onTap,
+    this.disabled = false,
+  });
+
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final VoidCallback? onTap;
+  final bool disabled;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: MinglitSpacing.small),
+      child: MinglitContentCard(
+        child: ListTile(
+          leading: Icon(
+            icon,
+            color: disabled
+                ? theme.colorScheme.onSurface.withValues(alpha: 0.38)
+                : MinglitColors.primary,
+          ),
+          title: Text(
+            title,
+            style: theme.textTheme.titleSmall?.copyWith(
+              color: disabled
+                  ? theme.colorScheme.onSurface.withValues(alpha: 0.38)
+                  : null,
+            ),
+          ),
+          subtitle: Text(subtitle),
+          trailing: disabled
+              ? Chip(
+                  label: const Text('준비 중'),
+                  labelStyle: theme.textTheme.labelSmall,
+                  padding: EdgeInsets.zero,
+                )
+              : const Icon(Icons.chevron_right),
+          onTap: onTap,
+        ),
+      ),
+    );
+  }
+}

--- a/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/pattern_list_section.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/pattern_list_section.dart
@@ -95,14 +95,14 @@ class _PatternTile extends StatelessWidget {
           leading: Icon(
             icon,
             color: disabled
-                ? theme.colorScheme.onSurface.withValues(alpha: 0.38)
+                ? theme.colorScheme.onSurface.withOpacity(0.38)
                 : MinglitColors.primary,
           ),
           title: Text(
             title,
             style: theme.textTheme.titleSmall?.copyWith(
               color: disabled
-                  ? theme.colorScheme.onSurface.withValues(alpha: 0.38)
+                  ? theme.colorScheme.onSurface.withOpacity(0.38)
                   : null,
             ),
           ),

--- a/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/detail_page_demo.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/detail_page_demo.dart
@@ -1,0 +1,418 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/src/features/dev/catalog_tabs/patterns/mock_data.dart';
+import 'package:minglit_kit/src/theme/minglit_theme.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_content_card.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_empty_state.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_error_state.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_section.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_skeleton.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_tag.dart';
+
+/// Demo states for pattern preview.
+enum DemoState { data, loading, error, empty }
+
+/// P1 — Detail Page Pattern Demo.
+///
+/// Demonstrates Hero + TabBar + CTA structure with a full-screen push.
+/// Includes [DemoState] toggle (data / loading / error / empty).
+///
+/// Launch via [Navigator.push]:
+/// ```dart
+/// Navigator.push(context, MaterialPageRoute(builder: (_) => const DetailPageDemo()));
+/// ```
+class DetailPageDemo extends StatefulWidget {
+  /// Creates a [DetailPageDemo].
+  const DetailPageDemo({super.key});
+
+  @override
+  State<DetailPageDemo> createState() => _DetailPageDemoState();
+}
+
+class _DetailPageDemoState extends State<DetailPageDemo>
+    with SingleTickerProviderStateMixin {
+  DemoState _state = DemoState.data;
+  late final TabController _tabController;
+
+  static const _tabs = ['개요', '참여자', '일정'];
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: _tabs.length, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      body: Column(
+        children: [
+          // State toggle
+          SafeArea(
+            bottom: false,
+            child: Padding(
+              padding: const EdgeInsets.all(MinglitSpacing.medium),
+              child: SegmentedButton<DemoState>(
+                segments: const [
+                  ButtonSegment(value: DemoState.data, label: Text('Data')),
+                  ButtonSegment(
+                    value: DemoState.loading,
+                    label: Text('Loading'),
+                  ),
+                  ButtonSegment(value: DemoState.error, label: Text('Error')),
+                  ButtonSegment(value: DemoState.empty, label: Text('Empty')),
+                ],
+                selected: {_state},
+                onSelectionChanged: (s) => setState(() => _state = s.first),
+              ),
+            ),
+          ),
+          // Preview area
+          Expanded(child: _buildPreview(theme)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPreview(ThemeData theme) {
+    return switch (_state) {
+      DemoState.loading => _DetailPageLoading(tabController: _tabController),
+      DemoState.error => _DetailPageError(
+        onRetry: () => setState(() => _state = DemoState.data),
+      ),
+      DemoState.empty => _DetailPageEmpty(),
+      DemoState.data => _DetailPageData(
+        event: mockEvents.first,
+        tabController: _tabController,
+        tabs: _tabs,
+        onAction: () {
+          unawaited(
+            showDialog<void>(
+              context: context,
+              builder: (_) => AlertDialog(
+                title: const Text('참여 신청'),
+                content: const Text('이벤트에 참여 신청하시겠습니까?'),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: const Text('취소'),
+                  ),
+                  ElevatedButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: const Text('신청'),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Data state
+// ---------------------------------------------------------------------------
+
+class _DetailPageData extends StatelessWidget {
+  const _DetailPageData({
+    required this.event,
+    required this.tabController,
+    required this.tabs,
+    required this.onAction,
+  });
+
+  final MockEventData event;
+  final TabController tabController;
+  final List<String> tabs;
+  final VoidCallback onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Stack(
+      children: [
+        NestedScrollView(
+          headerSliverBuilder: (context, _) => [
+            SliverAppBar(
+              expandedHeight: 200,
+              pinned: true,
+              leading: IconButton(
+                icon: const Icon(Icons.arrow_back),
+                onPressed: () => Navigator.of(context).pop(),
+              ),
+              flexibleSpace: FlexibleSpaceBar(
+                title: Text(
+                  event.title,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: Colors.white,
+                  ),
+                ),
+                background: Container(
+                  color: MinglitColors.primary,
+                  child: Center(
+                    child: Icon(
+                      Icons.event,
+                      size: 64,
+                      color: Colors.white.withValues(alpha: 0.5),
+                    ),
+                  ),
+                ),
+              ),
+              bottom: TabBar(
+                controller: tabController,
+                tabs: tabs.map((t) => Tab(text: t)).toList(),
+              ),
+            ),
+          ],
+          body: TabBarView(
+            controller: tabController,
+            children: [
+              _OverviewTab(event: event),
+              _ParticipantsTab(count: event.currentParticipants),
+              _ScheduleTab(),
+            ],
+          ),
+        ),
+        // CTA
+        Positioned(
+          bottom: 0,
+          left: 0,
+          right: 0,
+          child: _CtaBar(
+            label: '참여 신청 (${event.currentParticipants}/${event.maxParticipants})',
+            onTap: onAction,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _OverviewTab extends StatelessWidget {
+  const _OverviewTab({required this.event});
+
+  final MockEventData event;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(
+        MinglitSpacing.medium,
+        MinglitSpacing.medium,
+        MinglitSpacing.medium,
+        MinglitSpacing.xlarge * 2,
+      ),
+      children: [
+        MinglitTag(label: event.categoryLabel, color: MinglitColors.primary),
+        const SizedBox(height: MinglitSpacing.small),
+        Text(event.subtitle, style: theme.textTheme.bodyLarge),
+        const SizedBox(height: MinglitSpacing.medium),
+        MinglitContentCard(
+          child: Column(
+            children: [
+              _InfoRow(icon: Icons.calendar_today, text: event.dateLabel),
+              const SizedBox(height: MinglitSpacing.small),
+              _InfoRow(icon: Icons.location_on, text: event.locationLabel),
+              const SizedBox(height: MinglitSpacing.small),
+              _InfoRow(icon: Icons.person, text: '주최: ${event.hostName}'),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Icon(icon, size: MinglitIconSize.small),
+        const SizedBox(width: MinglitSpacing.small),
+        Expanded(child: Text(text, style: Theme.of(context).textTheme.bodyMedium)),
+      ],
+    );
+  }
+}
+
+class _ParticipantsTab extends StatelessWidget {
+  const _ParticipantsTab({required this.count});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListView.separated(
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      itemCount: count,
+      separatorBuilder: (_, __) => const Divider(),
+      itemBuilder: (context, i) => ListTile(
+        leading: CircleAvatar(child: Text('${i + 1}')),
+        title: Text('참여자 ${i + 1}', style: theme.textTheme.bodyMedium),
+        subtitle: Text('승인됨', style: theme.textTheme.bodySmall),
+      ),
+    );
+  }
+}
+
+class _ScheduleTab extends StatelessWidget {
+  const _ScheduleTab();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListView.builder(
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      itemCount: mockSectionItems.length,
+      itemBuilder: (context, i) => MinglitSection(
+        title: mockSectionItems[i],
+        child: Text(
+          '${mockSectionItems[i]} 상세 내용이 여기에 표시됩니다.',
+          style: theme.textTheme.bodyMedium,
+        ),
+      ),
+    );
+  }
+}
+
+class _CtaBar extends StatelessWidget {
+  const _CtaBar({required this.label, required this.onTap});
+
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(
+        MinglitSpacing.medium,
+        MinglitSpacing.small,
+        MinglitSpacing.medium,
+        MinglitSpacing.large,
+      ),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.08),
+            blurRadius: 8,
+            offset: const Offset(0, -2),
+          ),
+        ],
+      ),
+      child: SizedBox(
+        width: double.infinity,
+        child: ElevatedButton(
+          onPressed: onTap,
+          child: Text(label),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Loading state
+// ---------------------------------------------------------------------------
+
+class _DetailPageLoading extends StatelessWidget {
+  const _DetailPageLoading({required this.tabController});
+
+  final TabController tabController;
+
+  @override
+  Widget build(BuildContext context) {
+    return NestedScrollView(
+      headerSliverBuilder: (context, _) => [
+        SliverAppBar(
+          expandedHeight: 200,
+          pinned: true,
+          flexibleSpace: FlexibleSpaceBar(
+            background: MinglitSkeleton(
+              width: double.infinity,
+              height: double.infinity,
+              borderRadius: BorderRadius.zero,
+            ),
+          ),
+          bottom: TabBar(
+            controller: tabController,
+            tabs: const [Tab(text: '개요'), Tab(text: '참여자'), Tab(text: '일정')],
+          ),
+        ),
+      ],
+      body: ListView(
+        padding: const EdgeInsets.all(MinglitSpacing.medium),
+        children: [
+          const MinglitSkeleton(width: 80, height: 24),
+          const SizedBox(height: MinglitSpacing.small),
+          const MinglitSkeleton(width: double.infinity, height: 20),
+          const SizedBox(height: MinglitSpacing.xsmall),
+          const MinglitSkeleton(width: 200, height: 20),
+          const SizedBox(height: MinglitSpacing.medium),
+          MinglitSkeleton(
+            width: double.infinity,
+            height: 100,
+            borderRadius: BorderRadius.circular(MinglitRadius.card),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error state
+// ---------------------------------------------------------------------------
+
+class _DetailPageError extends StatelessWidget {
+  const _DetailPageError({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: MinglitErrorState(
+        title: '이벤트 정보를 불러올 수 없습니다',
+        subtitle: '잠시 후 다시 시도해주세요',
+        onRetry: onRetry,
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+class _DetailPageEmpty extends StatelessWidget {
+  const _DetailPageEmpty();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: MinglitEmptyState(
+        title: '표시할 이벤트가 없습니다',
+        subtitle: '새로운 이벤트를 찾아보세요',
+      ),
+    );
+  }
+}

--- a/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/detail_page_demo.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/detail_page_demo.dart
@@ -88,7 +88,7 @@ class _DetailPageDemoState extends State<DetailPageDemo>
       DemoState.error => _DetailPageError(
         onRetry: () => setState(() => _state = DemoState.data),
       ),
-      DemoState.empty => _DetailPageEmpty(),
+      DemoState.empty => const _DetailPageEmpty(),
       DemoState.data => _DetailPageData(
         event: mockEvents.first,
         tabController: _tabController,
@@ -157,7 +157,7 @@ class _DetailPageData extends StatelessWidget {
                     color: Colors.white,
                   ),
                 ),
-                background: Container(
+                background: ColoredBox(
                   color: MinglitColors.primary,
                   child: Center(
                     child: Icon(
@@ -179,7 +179,7 @@ class _DetailPageData extends StatelessWidget {
             children: [
               _OverviewTab(event: event),
               _ParticipantsTab(count: event.currentParticipants),
-              _ScheduleTab(),
+              const _ScheduleTab(),
             ],
           ),
         ),
@@ -189,7 +189,8 @@ class _DetailPageData extends StatelessWidget {
           left: 0,
           right: 0,
           child: _CtaBar(
-            label: '참여 신청 (${event.currentParticipants}/${event.maxParticipants})',
+            label:
+                '참여 신청 (${event.currentParticipants}/${event.maxParticipants})',
             onTap: onAction,
           ),
         ),
@@ -246,7 +247,9 @@ class _InfoRow extends StatelessWidget {
       children: [
         Icon(icon, size: MinglitIconSize.small),
         const SizedBox(width: MinglitSpacing.small),
-        Expanded(child: Text(text, style: Theme.of(context).textTheme.bodyMedium)),
+        Expanded(
+          child: Text(text, style: Theme.of(context).textTheme.bodyMedium),
+        ),
       ],
     );
   }
@@ -263,7 +266,7 @@ class _ParticipantsTab extends StatelessWidget {
     return ListView.separated(
       padding: const EdgeInsets.all(MinglitSpacing.medium),
       itemCount: count,
-      separatorBuilder: (_, __) => const Divider(),
+      separatorBuilder: (_, _) => const Divider(),
       itemBuilder: (context, i) => ListTile(
         leading: CircleAvatar(child: Text('${i + 1}')),
         title: Text('참여자 ${i + 1}', style: theme.textTheme.bodyMedium),
@@ -345,7 +348,7 @@ class _DetailPageLoading extends StatelessWidget {
         SliverAppBar(
           expandedHeight: 200,
           pinned: true,
-          flexibleSpace: FlexibleSpaceBar(
+          flexibleSpace: const FlexibleSpaceBar(
             background: MinglitSkeleton(
               width: double.infinity,
               height: double.infinity,
@@ -354,7 +357,11 @@ class _DetailPageLoading extends StatelessWidget {
           ),
           bottom: TabBar(
             controller: tabController,
-            tabs: const [Tab(text: '개요'), Tab(text: '참여자'), Tab(text: '일정')],
+            tabs: const [
+              Tab(text: '개요'),
+              Tab(text: '참여자'),
+              Tab(text: '일정'),
+            ],
           ),
         ),
       ],

--- a/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/detail_page_demo.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/detail_page_demo.dart
@@ -154,7 +154,7 @@ class _DetailPageData extends StatelessWidget {
                 title: Text(
                   event.title,
                   style: theme.textTheme.titleMedium?.copyWith(
-                    color: Colors.white,
+                    color: theme.colorScheme.onPrimary,
                   ),
                 ),
                 background: ColoredBox(
@@ -163,7 +163,7 @@ class _DetailPageData extends StatelessWidget {
                     child: Icon(
                       Icons.event,
                       size: 64,
-                      color: Colors.white.withValues(alpha: 0.5),
+                      color: theme.colorScheme.onPrimary.withOpacity(0.5),
                     ),
                   ),
                 ),
@@ -264,7 +264,12 @@ class _ParticipantsTab extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return ListView.separated(
-      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      padding: const EdgeInsets.fromLTRB(
+        MinglitSpacing.medium,
+        MinglitSpacing.medium,
+        MinglitSpacing.medium,
+        MinglitSpacing.xlarge * 2,
+      ),
       itemCount: count,
       separatorBuilder: (_, _) => const Divider(),
       itemBuilder: (context, i) => ListTile(
@@ -283,7 +288,12 @@ class _ScheduleTab extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return ListView.builder(
-      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      padding: const EdgeInsets.fromLTRB(
+        MinglitSpacing.medium,
+        MinglitSpacing.medium,
+        MinglitSpacing.medium,
+        MinglitSpacing.xlarge * 2,
+      ),
       itemCount: mockSectionItems.length,
       itemBuilder: (context, i) => MinglitSection(
         title: mockSectionItems[i],
@@ -315,7 +325,7 @@ class _CtaBar extends StatelessWidget {
         color: Theme.of(context).colorScheme.surface,
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withValues(alpha: 0.08),
+            color: Colors.black.withOpacity(0.08),
             blurRadius: 8,
             offset: const Offset(0, -2),
           ),

--- a/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/mock_data.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/mock_data.dart
@@ -1,6 +1,5 @@
 // Mock data for design pattern catalog demos.
 // Uses plain Dart types; no real Repository or model imports.
-library;
 
 /// A mock event card data structure for demos.
 class MockEventData {

--- a/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/mock_data.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/mock_data.dart
@@ -1,0 +1,58 @@
+// Mock data for design pattern catalog demos.
+// Uses plain Dart types; no real Repository or model imports.
+library;
+
+/// A mock event card data structure for demos.
+class MockEventData {
+  const MockEventData({
+    required this.title,
+    required this.subtitle,
+    required this.dateLabel,
+    required this.locationLabel,
+    required this.currentParticipants,
+    required this.maxParticipants,
+    required this.hostName,
+    required this.categoryLabel,
+  });
+
+  final String title;
+  final String subtitle;
+  final String dateLabel;
+  final String locationLabel;
+  final int currentParticipants;
+  final int maxParticipants;
+  final String hostName;
+  final String categoryLabel;
+}
+
+/// Sample events for pattern demos.
+const mockEvents = [
+  MockEventData(
+    title: '재즈 이브닝 in 성수',
+    subtitle: '재즈 음악을 사랑하는 분들을 위한 소셜 이벤트',
+    dateLabel: '4월 15일 (화) 오후 7시',
+    locationLabel: '성수 라이브 클럽, 서울',
+    currentParticipants: 12,
+    maxParticipants: 20,
+    hostName: '밍글릿 팀',
+    categoryLabel: '음악',
+  ),
+  MockEventData(
+    title: '브런치 네트워킹',
+    subtitle: '스타트업 종사자를 위한 캐주얼 모임',
+    dateLabel: '4월 20일 (일) 오전 11시',
+    locationLabel: '강남 카페 라떼, 서울',
+    currentParticipants: 8,
+    maxParticipants: 15,
+    hostName: '스타트업 커뮤니티',
+    categoryLabel: '네트워킹',
+  ),
+];
+
+const mockSectionItems = [
+  '이벤트 개요',
+  '참여자 소개',
+  '진행 일정',
+  '준비물 안내',
+  '위치 및 교통',
+];

--- a/shared/packages/minglit_kit/lib/src/features/dev/design_catalog_page.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/design_catalog_page.dart
@@ -3,9 +3,10 @@ import 'package:minglit_kit/src/features/dev/catalog_tabs/catalog_tabs.dart';
 
 /// Dev-only design catalog page displaying all design tokens and components.
 ///
-/// Organized into two sections:
+/// Organized into three sections:
 /// - **Tokens** (6 tabs): design foundation values
 /// - **Widgets** (8 tabs): reusable Minglit components
+/// - **Patterns** (1 tab): composited design patterns
 ///
 /// Shared between user and partner apps. Only accessible when
 /// `ENVIRONMENT` is `development` or `local`.
@@ -16,8 +17,8 @@ class DesignCatalogPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-      // Fix #621: 16탭 → 14탭 (토큰 6 + 위젯 8) 재구성
-      length: 14,
+      // Fix #621: 16탭 → 14탭 (토큰 6 + 위젯 8) 재구성; #713: +1 패턴 탭
+      length: 15,
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Design Catalog'),
@@ -41,6 +42,8 @@ class DesignCatalogPage extends StatelessWidget {
               Tab(text: 'Overlay'),
               Tab(text: 'Data'),
               Tab(text: 'Loading'),
+              // Patterns (1)
+              Tab(text: 'Patterns'),
             ],
           ),
         ),
@@ -62,6 +65,8 @@ class DesignCatalogPage extends StatelessWidget {
             OverlaySection(),
             DataSection(),
             LoadingSection(),
+            // Patterns (1)
+            PatternListSection(),
           ],
         ),
       ),

--- a/shared/packages/minglit_kit/test/src/features/dev/catalog_tabs/patterns/detail_page_demo_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/dev/catalog_tabs/patterns/detail_page_demo_test.dart
@@ -59,9 +59,9 @@ void main() {
       await tester.tap(find.text('다시 시도'));
       await tester.pump();
 
-      // Should show event title again (data state)
-      // SegmentedButton should still be present
-      expect(find.text('Data'), findsOneWidget);
+      // Should show event content again (data state)
+      expect(find.text('재즈 이브닝 in 성수'), findsOneWidget);
+      expect(find.byType(SegmentedButton<DemoState>), findsOneWidget);
     });
   });
 }

--- a/shared/packages/minglit_kit/test/src/features/dev/catalog_tabs/patterns/detail_page_demo_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/dev/catalog_tabs/patterns/detail_page_demo_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/features/dev/catalog_tabs/patterns/detail_page_demo.dart';
+
+void main() {
+  group('DetailPageDemo', () {
+    Widget buildSubject() => const MaterialApp(home: DetailPageDemo());
+
+    testWidgets('data state shows event content', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+
+      // SegmentedButton present
+      expect(find.text('Data'), findsOneWidget);
+      expect(find.text('Loading'), findsOneWidget);
+      expect(find.text('Error'), findsOneWidget);
+      expect(find.text('Empty'), findsOneWidget);
+    });
+
+    testWidgets('switches to loading state', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+
+      await tester.tap(find.text('Loading'));
+      await tester.pump();
+
+      // In loading state skeletons are shown (no event title text)
+      expect(find.text('재즈 이브닝 in 성수'), findsNothing);
+    });
+
+    testWidgets('switches to error state', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+
+      await tester.tap(find.text('Error'));
+      await tester.pump();
+
+      expect(find.text('이벤트 정보를 불러올 수 없습니다'), findsOneWidget);
+    });
+
+    testWidgets('switches to empty state', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+
+      await tester.tap(find.text('Empty'));
+      await tester.pump();
+
+      expect(find.text('표시할 이벤트가 없습니다'), findsOneWidget);
+    });
+
+    testWidgets('error state retry returns to data', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+
+      await tester.tap(find.text('Error'));
+      await tester.pump();
+
+      // Tap retry button
+      await tester.tap(find.text('다시 시도'));
+      await tester.pump();
+
+      // Should show event title again (data state)
+      // SegmentedButton should still be present
+      expect(find.text('Data'), findsOneWidget);
+    });
+  });
+}

--- a/shared/packages/minglit_kit/test/src/features/dev/design_catalog_page_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/dev/design_catalog_page_test.dart
@@ -22,17 +22,17 @@ void main() {
     await tester.pump(const Duration(milliseconds: 300));
   }
 
-  // Tab indices: Tokens(0-5), Widgets(6-13)
+  // Tab indices: Tokens(0-5), Widgets(6-13), Patterns(14)
   // 0:Colors, 1:Typography, 2:Spacing, 3:Radius, 4:IconSize, 5:Animation
   // 6:Layout, 7:Buttons, 8:Inputs, 9:Cards, 10:Feedback, 11:Overlay,
-  // 12:Data, 13:Loading
+  // 12:Data, 13:Loading, 14:Patterns
 
   group('DesignCatalogPage tab structure', () {
-    testWidgets('has 14 tabs total', (tester) async {
+    testWidgets('has 15 tabs total', (tester) async {
       await tester.pumpWidget(buildApp());
 
       final tabBar = tester.widget<TabBar>(find.byType(TabBar));
-      expect(tabBar.tabs.length, 14);
+      expect(tabBar.tabs.length, 15);
     });
 
     testWidgets('tab labels match spec order', (tester) async {
@@ -47,6 +47,8 @@ void main() {
         // Widgets (8)
         'Layout', 'Buttons', 'Inputs', 'Cards',
         'Feedback', 'Overlay', 'Data', 'Loading',
+        // Patterns (1)
+        'Patterns',
       ]);
     });
 


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #713

## 변경 내용

P1 상세 페이지 패턴 데모 구현 + Patterns 탭 추가.

### 신규 파일
- `catalog_tabs/patterns/mock_data.dart` — 데모용 Mock 데이터 (외부 의존 없음)
- `catalog_tabs/patterns/detail_page_demo.dart` — P1 데모
  - `DemoState` enum (data/loading/error/empty) 상태 토글
  - `NestedScrollView` + `SliverAppBar` + `TabBar` (개요/참여자/일정)
  - CTA bar (Positioned bottom overlay)
  - Navigator.push로 전체화면 전환 (카탈로그 TabBar 충돌 방지)
- `catalog_tabs/pattern_list_section.dart` — Patterns 탭 목록
  - P1 활성 / P4, P5, P6, P7 "준비 중" placeholder

### 수정 파일
- `design_catalog_page.dart`: Patterns 탭 추가 (14 → 15탭)
- `catalog_tabs.dart`: 신규 파일 exports 추가

### 테스트
- `test/src/features/dev/catalog_tabs/patterns/detail_page_demo_test.dart`
  - 4가지 DemoState 전환 검증
  - error → retry → data 복귀 검증