### PR TITLE
feat(design-catalog): P6 빈/에러/로딩 상태 패턴 데모 추가

### DIFF
--- a/shared/packages/minglit_kit/lib/minglit_dev.dart
+++ b/shared/packages/minglit_kit/lib/minglit_dev.dart
@@ -1,3 +1,4 @@
+export 'src/features/dev/catalog_tabs/patterns/data_states_demo.dart';
 export 'src/features/dev/design_catalog_page.dart';
 export 'src/features/dev/dev_config.dart';
 export 'src/features/dev/dev_user_switch_screen.dart';

--- a/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/data_states_demo.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/data_states_demo.dart
@@ -84,11 +84,11 @@ class _DataStatesDemoPageState extends State<DataStatesDemoPage> {
       DemoState.data => const _DataContent(items: _mockItems),
       DemoState.loading => const _LoadingContent(),
       DemoState.error => _ErrorContent(
-          onRetry: () => setState(() => _state = DemoState.data),
-        ),
+        onRetry: () => setState(() => _state = DemoState.data),
+      ),
       DemoState.empty => _EmptyContent(
-          onAdd: () => setState(() => _state = DemoState.data),
-        ),
+        onAdd: () => setState(() => _state = DemoState.data),
+      ),
     };
   }
 }
@@ -144,8 +144,7 @@ class _DataContent extends StatelessWidget {
           margin: EdgeInsets.zero,
           child: ListTile(
             leading: CircleAvatar(
-              backgroundColor:
-                  MinglitColors.primary.withValues(alpha: 0.12),
+              backgroundColor: MinglitColors.primary.withValues(alpha: 0.12),
               child: Text(
                 '${index + 1}',
                 style: theme.textTheme.labelMedium?.copyWith(

--- a/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/data_states_demo.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/data_states_demo.dart
@@ -1,0 +1,378 @@
+// feat #715: P6 빈/에러/로딩 상태 패턴 데모
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/src/theme/minglit_theme.dart';
+import 'package:minglit_kit/src/ui/widgets/common/loading_indicator.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_skeleton.dart';
+
+/// The four demo states for [DataStatesDemoPage].
+enum DemoState {
+  /// Populated data state.
+  data,
+
+  /// Loading state (inline, skeleton, full-screen variants).
+  loading,
+
+  /// Error state with retry affordance.
+  error,
+
+  /// Empty state with CTA.
+  empty,
+}
+
+/// **P6 Data States Demo**
+///
+/// Showcases the three canonical loading variants, the standard empty-state
+/// structure, and the standard error-state structure used across the app.
+///
+/// Use a [SegmentedButton] at the top to toggle between states.
+class DataStatesDemoPage extends StatefulWidget {
+  /// Creates a [DataStatesDemoPage].
+  const DataStatesDemoPage({super.key});
+
+  @override
+  State<DataStatesDemoPage> createState() => _DataStatesDemoPageState();
+}
+
+class _DataStatesDemoPageState extends State<DataStatesDemoPage> {
+  DemoState _state = DemoState.data;
+
+  static const _mockItems = [
+    '서울 한강공원 피크닉',
+    '홍대 카페 모임',
+    '강남 북클럽',
+    '이태원 언어교환',
+    '성수 플리마켓',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('P6 · 데이터 상태 패턴'),
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: MinglitSpacing.medium,
+              vertical: MinglitSpacing.sm,
+            ),
+            child: _StateToggle(
+              current: _state,
+              onChanged: (s) => setState(() => _state = s),
+            ),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: AnimatedSwitcher(
+              duration: MinglitAnimation.fast,
+              child: KeyedSubtree(
+                key: ValueKey(_state),
+                child: _buildBody(theme),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBody(ThemeData theme) {
+    return switch (_state) {
+      DemoState.data => const _DataContent(items: _mockItems),
+      DemoState.loading => const _LoadingContent(),
+      DemoState.error => _ErrorContent(
+          onRetry: () => setState(() => _state = DemoState.data),
+        ),
+      DemoState.empty => _EmptyContent(
+          onAdd: () => setState(() => _state = DemoState.data),
+        ),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// State toggle
+// ---------------------------------------------------------------------------
+
+class _StateToggle extends StatelessWidget {
+  const _StateToggle({required this.current, required this.onChanged});
+
+  final DemoState current;
+  final ValueChanged<DemoState> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return SegmentedButton<DemoState>(
+      segments: const [
+        ButtonSegment(value: DemoState.data, label: Text('데이터')),
+        ButtonSegment(value: DemoState.loading, label: Text('로딩')),
+        ButtonSegment(value: DemoState.error, label: Text('오류')),
+        ButtonSegment(value: DemoState.empty, label: Text('빈 목록')),
+      ],
+      selected: {current},
+      onSelectionChanged: (s) => onChanged(s.first),
+      style: const ButtonStyle(
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        visualDensity: VisualDensity(horizontal: -2),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Data content
+// ---------------------------------------------------------------------------
+
+class _DataContent extends StatelessWidget {
+  const _DataContent({required this.items});
+
+  final List<String> items;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListView.separated(
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      itemCount: items.length,
+      separatorBuilder: (context, index) =>
+          const SizedBox(height: MinglitSpacing.small),
+      itemBuilder: (context, index) {
+        return Card(
+          margin: EdgeInsets.zero,
+          child: ListTile(
+            leading: CircleAvatar(
+              backgroundColor:
+                  MinglitColors.primary.withValues(alpha: 0.12),
+              child: Text(
+                '${index + 1}',
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: MinglitColors.primary,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            title: Text(items[index]),
+            trailing: const Icon(
+              Icons.arrow_forward_ios,
+              size: MinglitIconSize.xsmall,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Loading content (3 variants)
+// ---------------------------------------------------------------------------
+
+class _LoadingContent extends StatelessWidget {
+  const _LoadingContent();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Variant 1 – inline spinner
+          _SectionLabel(label: '① 인라인 스피너', theme: theme),
+          const SizedBox(height: MinglitSpacing.small),
+          const Center(
+            child: MinglitCircularProgressIndicator(
+              color: MinglitColors.primary,
+            ),
+          ),
+          const SizedBox(height: MinglitSpacing.large),
+
+          // Variant 2 – skeleton list
+          _SectionLabel(label: '② 스켈레톤 카드 목록', theme: theme),
+          const SizedBox(height: MinglitSpacing.small),
+          ...List.generate(
+            3,
+            (_) => Padding(
+              padding: const EdgeInsets.only(bottom: MinglitSpacing.small),
+              child: Row(
+                children: [
+                  MinglitSkeleton(
+                    width: 40,
+                    height: 40,
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  const SizedBox(width: MinglitSpacing.small),
+                  const Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        MinglitSkeleton(height: 14),
+                        SizedBox(height: MinglitSpacing.xsmall),
+                        MinglitSkeleton(
+                          width: 120,
+                          height: 12,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: MinglitSpacing.large),
+
+          // Variant 3 – full-screen overlay note
+          _SectionLabel(label: '③ 전체화면 오버레이', theme: theme),
+          const SizedBox(height: MinglitSpacing.small),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(MinglitSpacing.medium),
+            decoration: BoxDecoration(
+              color: MinglitColors.surface,
+              borderRadius: BorderRadius.circular(MinglitRadius.small),
+              border: Border.all(
+                color: MinglitColors.textSecondary.withValues(alpha: 0.2),
+              ),
+            ),
+            child: Text(
+              'MinglitGlobalLoadingOverlay — MaterialApp.builder에서 '
+              'child를 감싸서 사용합니다.\n'
+              '전체화면을 블로킹하는 모달 오버레이입니다.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: MinglitColors.textSecondary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel({required this.label, required this.theme});
+
+  final String label;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      label,
+      style: theme.textTheme.labelLarge?.copyWith(
+        color: MinglitColors.textSecondary,
+        fontWeight: FontWeight.w600,
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+class _EmptyContent extends StatelessWidget {
+  const _EmptyContent({required this.onAdd});
+
+  final VoidCallback onAdd;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(MinglitSpacing.xlarge),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.inbox_outlined,
+              size: MinglitIconSize.xlarge, // 32px — UX review confirmed
+              color: MinglitColors.textSecondary,
+            ),
+            const SizedBox(height: MinglitSpacing.medium),
+            Text(
+              '등록된 항목이 없습니다',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: MinglitColors.textPrimary,
+                fontWeight: FontWeight.w600,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: MinglitSpacing.small),
+            Text(
+              '아직 항목이 없어요. 새 항목을 추가해 보세요.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: MinglitColors.textSecondary,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: MinglitSpacing.large),
+            FilledButton.icon(
+              onPressed: onAdd,
+              icon: const Icon(Icons.add),
+              label: const Text('항목 추가'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error state
+// ---------------------------------------------------------------------------
+
+class _ErrorContent extends StatelessWidget {
+  const _ErrorContent({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(MinglitSpacing.xlarge),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.error_outline,
+              size: MinglitIconSize.xlarge, // 32px — UX review confirmed
+              color: MinglitColors.error,
+            ),
+            const SizedBox(height: MinglitSpacing.medium),
+            Text(
+              '오류가 발생했습니다',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: MinglitColors.textPrimary,
+                fontWeight: FontWeight.w600,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: MinglitSpacing.small),
+            Text(
+              '데이터를 불러오지 못했습니다.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: MinglitColors.textSecondary,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: MinglitSpacing.large),
+            OutlinedButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('다시 시도'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/shared/packages/minglit_kit/test/src/features/dev/catalog_tabs/patterns/data_states_demo_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/dev/catalog_tabs/patterns/data_states_demo_test.dart
@@ -1,0 +1,167 @@
+// Tests for DataStatesDemoPage — P6 data states pattern demo (#715)
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/features/dev/catalog_tabs/patterns/data_states_demo.dart';
+import 'package:minglit_kit/src/theme/minglit_theme.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_skeleton.dart';
+
+Widget _wrap(Widget child) => MaterialApp(home: child);
+
+void main() {
+  group('DemoState enum', () {
+    test('has exactly 4 values', () {
+      expect(DemoState.values.length, 4);
+    });
+
+    test('contains data, loading, error, empty', () {
+      expect(DemoState.values, containsAll([
+        DemoState.data,
+        DemoState.loading,
+        DemoState.error,
+        DemoState.empty,
+      ]));
+    });
+  });
+
+  group('MinglitIconSize.xlarge', () {
+    test('equals 32.0', () {
+      expect(MinglitIconSize.xlarge, 32.0);
+    });
+  });
+
+  group('DataStatesDemoPage — renders without error', () {
+    testWidgets('initial state is data — shows list items', (tester) async {
+      await tester.pumpWidget(_wrap(const DataStatesDemoPage()));
+      await tester.pump();
+
+      // SegmentedButton is present
+      expect(find.byType(SegmentedButton<DemoState>), findsOneWidget);
+
+      // Mock data items are visible
+      expect(find.text('서울 한강공원 피크닉'), findsOneWidget);
+    });
+
+    testWidgets('loading state renders skeleton and spinner', (tester) async {
+      await tester.pumpWidget(_wrap(const DataStatesDemoPage()));
+      await tester.pump();
+
+      // Tap the "로딩" segment; use pump instead of pumpAndSettle because
+      // MinglitSkeleton runs an infinite animation that never settles.
+      await tester.tap(find.text('로딩'));
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(find.byType(MinglitSkeleton), findsWidgets);
+    });
+
+    testWidgets('empty state renders icon, title, description and CTA button',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const DataStatesDemoPage()));
+      await tester.pump();
+
+      await tester.tap(find.text('빈 목록'));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.inbox_outlined), findsOneWidget);
+      expect(find.text('등록된 항목이 없습니다'), findsOneWidget);
+      expect(find.text('아직 항목이 없어요. 새 항목을 추가해 보세요.'), findsOneWidget);
+      expect(find.text('항목 추가'), findsOneWidget);
+    });
+
+    testWidgets('empty state icon is 32px (MinglitIconSize.xlarge)',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const DataStatesDemoPage()));
+      await tester.pump();
+
+      await tester.tap(find.text('빈 목록'));
+      await tester.pumpAndSettle();
+
+      final iconWidget = tester.widget<Icon>(
+        find.byIcon(Icons.inbox_outlined),
+      );
+      expect(iconWidget.size, MinglitIconSize.xlarge);
+      expect(iconWidget.size, 32.0);
+    });
+
+    testWidgets('error state renders icon, title, description and retry button',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const DataStatesDemoPage()));
+      await tester.pump();
+
+      await tester.tap(find.text('오류'));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      expect(find.text('오류가 발생했습니다'), findsOneWidget);
+      expect(find.text('데이터를 불러오지 못했습니다.'), findsOneWidget);
+      expect(find.text('다시 시도'), findsOneWidget);
+    });
+
+    testWidgets('error state icon is 32px (MinglitIconSize.xlarge)',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const DataStatesDemoPage()));
+      await tester.pump();
+
+      await tester.tap(find.text('오류'));
+      await tester.pumpAndSettle();
+
+      final iconWidget = tester.widget<Icon>(
+        find.byIcon(Icons.error_outline),
+      );
+      expect(iconWidget.size, MinglitIconSize.xlarge);
+      expect(iconWidget.size, 32.0);
+    });
+  });
+
+  group('DataStatesDemoPage — state transitions', () {
+    testWidgets('tapping CTA in empty state returns to data state',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const DataStatesDemoPage()));
+      await tester.pump();
+
+      // Go to empty
+      await tester.tap(find.text('빈 목록'));
+      await tester.pumpAndSettle();
+      expect(find.text('항목 추가'), findsOneWidget);
+
+      // Tap CTA
+      await tester.tap(find.text('항목 추가'));
+      await tester.pumpAndSettle();
+
+      // Back to data state — list items visible
+      expect(find.text('서울 한강공원 피크닉'), findsOneWidget);
+    });
+
+    testWidgets('tapping retry in error state returns to data state',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const DataStatesDemoPage()));
+      await tester.pump();
+
+      // Go to error
+      await tester.tap(find.text('오류'));
+      await tester.pumpAndSettle();
+      expect(find.text('다시 시도'), findsOneWidget);
+
+      // Tap retry
+      await tester.tap(find.text('다시 시도'));
+      await tester.pumpAndSettle();
+
+      // Back to data state
+      expect(find.text('서울 한강공원 피크닉'), findsOneWidget);
+    });
+
+    testWidgets('can cycle through all 4 states without error', (tester) async {
+      await tester.pumpWidget(_wrap(const DataStatesDemoPage()));
+      await tester.pump();
+
+      // Tap each state; use pump instead of pumpAndSettle because the
+      // loading state contains an infinite skeleton animation.
+      for (final label in ['로딩', '오류', '빈 목록', '데이터']) {
+        await tester.tap(find.text(label));
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+
+      // Should be back on data state
+      expect(find.text('서울 한강공원 피크닉'), findsOneWidget);
+    });
+  });
+}

--- a/shared/packages/minglit_kit/test/src/features/dev/catalog_tabs/patterns/data_states_demo_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/dev/catalog_tabs/patterns/data_states_demo_test.dart
@@ -14,12 +14,15 @@ void main() {
     });
 
     test('contains data, loading, error, empty', () {
-      expect(DemoState.values, containsAll([
-        DemoState.data,
-        DemoState.loading,
-        DemoState.error,
-        DemoState.empty,
-      ]));
+      expect(
+        DemoState.values,
+        containsAll([
+          DemoState.data,
+          DemoState.loading,
+          DemoState.error,
+          DemoState.empty,
+        ]),
+      );
     });
   });
 
@@ -53,8 +56,9 @@ void main() {
       expect(find.byType(MinglitSkeleton), findsWidgets);
     });
 
-    testWidgets('empty state renders icon, title, description and CTA button',
-        (tester) async {
+    testWidgets('empty state renders icon, title, description and CTA button', (
+      tester,
+    ) async {
       await tester.pumpWidget(_wrap(const DataStatesDemoPage()));
       await tester.pump();
 
@@ -67,8 +71,9 @@ void main() {
       expect(find.text('항목 추가'), findsOneWidget);
     });
 
-    testWidgets('empty state icon is 32px (MinglitIconSize.xlarge)',
-        (tester) async {
+    testWidgets('empty state icon is 32px (MinglitIconSize.xlarge)', (
+      tester,
+    ) async {
       await tester.pumpWidget(_wrap(const DataStatesDemoPage()));
       await tester.pump();
 
@@ -82,22 +87,25 @@ void main() {
       expect(iconWidget.size, 32.0);
     });
 
-    testWidgets('error state renders icon, title, description and retry button',
-        (tester) async {
-      await tester.pumpWidget(_wrap(const DataStatesDemoPage()));
-      await tester.pump();
+    testWidgets(
+      'error state renders icon, title, description and retry button',
+      (tester) async {
+        await tester.pumpWidget(_wrap(const DataStatesDemoPage()));
+        await tester.pump();
 
-      await tester.tap(find.text('오류'));
-      await tester.pumpAndSettle();
+        await tester.tap(find.text('오류'));
+        await tester.pumpAndSettle();
 
-      expect(find.byIcon(Icons.error_outline), findsOneWidget);
-      expect(find.text('오류가 발생했습니다'), findsOneWidget);
-      expect(find.text('데이터를 불러오지 못했습니다.'), findsOneWidget);
-      expect(find.text('다시 시도'), findsOneWidget);
-    });
+        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+        expect(find.text('오류가 발생했습니다'), findsOneWidget);
+        expect(find.text('데이터를 불러오지 못했습니다.'), findsOneWidget);
+        expect(find.text('다시 시도'), findsOneWidget);
+      },
+    );
 
-    testWidgets('error state icon is 32px (MinglitIconSize.xlarge)',
-        (tester) async {
+    testWidgets('error state icon is 32px (MinglitIconSize.xlarge)', (
+      tester,
+    ) async {
       await tester.pumpWidget(_wrap(const DataStatesDemoPage()));
       await tester.pump();
 
@@ -113,8 +121,9 @@ void main() {
   });
 
   group('DataStatesDemoPage — state transitions', () {
-    testWidgets('tapping CTA in empty state returns to data state',
-        (tester) async {
+    testWidgets('tapping CTA in empty state returns to data state', (
+      tester,
+    ) async {
       await tester.pumpWidget(_wrap(const DataStatesDemoPage()));
       await tester.pump();
 
@@ -131,8 +140,9 @@ void main() {
       expect(find.text('서울 한강공원 피크닉'), findsOneWidget);
     });
 
-    testWidgets('tapping retry in error state returns to data state',
-        (tester) async {
+    testWidgets('tapping retry in error state returns to data state', (
+      tester,
+    ) async {
       await tester.pumpWidget(_wrap(const DataStatesDemoPage()));
       await tester.pump();
 


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-2

## Summary

- `DataStatesDemoPage` 위젯 구현 — SegmentedButton으로 data/loading/error/empty 상태 토글
- 3단계 로딩 데모: 인라인 CircularProgressIndicator + MinglitSkeleton + 전체화면 오버레이 안내
- 빈 상태: `Icons.inbox_outlined` (32px) + 제목 + 설명 + CTA 버튼
- 에러 상태: `Icons.error_outline` (32px) + 제목 + 설명 + 다시 시도 버튼
- `minglit_dev.dart` 배럴 파일 export 추가

## Test plan

- [ ] `flutter analyze` — no issues
- [ ] 12개 위젯 테스트 통과 (4 DemoState 렌더링, 아이콘 32px 검증, 상태 전환)
- [ ] 아이콘 크기 `MinglitIconSize.xlarge` (32px) — UX 리뷰 피드백 반영

Closes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)