### PR TITLE
feat(design-catalog): P7 Async 래퍼 패턴 데모 추가

### DIFF
--- a/shared/packages/minglit_kit/lib/minglit_dev.dart
+++ b/shared/packages/minglit_kit/lib/minglit_dev.dart
@@ -1,3 +1,4 @@
+export 'src/features/dev/catalog_tabs/patterns/async_wrapper_demo.dart';
 export 'src/features/dev/catalog_tabs/patterns/data_states_demo.dart';
 export 'src/features/dev/design_catalog_page.dart';
 export 'src/features/dev/dev_config.dart';

--- a/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/async_wrapper_demo.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/async_wrapper_demo.dart
@@ -52,9 +52,9 @@ class _AsyncWrapperDemoPageState extends State<AsyncWrapperDemoPage> {
     return switch (_selectedState) {
       AsyncDemoState.loading => const AsyncValue.loading(),
       AsyncDemoState.error => AsyncValue.error(
-          Exception('데이터를 불러오지 못했습니다.'),
-          StackTrace.empty,
-        ),
+        Exception('데이터를 불러오지 못했습니다.'),
+        StackTrace.empty,
+      ),
       AsyncDemoState.data => const AsyncValue.data(_mockItems),
     };
   }
@@ -299,8 +299,7 @@ class _DataList extends StatelessWidget {
               height: 40,
               decoration: BoxDecoration(
                 color: theme.colorScheme.primaryContainer,
-                borderRadius:
-                    BorderRadius.circular(MinglitRadius.small),
+                borderRadius: BorderRadius.circular(MinglitRadius.small),
               ),
               child: Icon(
                 Icons.article_outlined,
@@ -362,9 +361,9 @@ class _SectionHeader extends StatelessWidget {
         Text(
           label,
           style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                fontWeight: FontWeight.bold,
-                color: color,
-              ),
+            fontWeight: FontWeight.bold,
+            color: color,
+          ),
         ),
       ],
     );
@@ -423,7 +422,8 @@ class _DoSection extends StatelessWidget {
         ),
         const SizedBox(height: MinglitSpacing.small),
         const _CodeSnippet(
-          code: 'MinglitAsyncValueWidget<List<Item>>(\n'
+          code:
+              'MinglitAsyncValueWidget<List<Item>>(\n'
               '  value: ref.watch(itemsProvider),\n'
               '  data: (items) => ItemList(items: items),\n'
               '  // loading/error는 기본 UI가 자동 처리됩니다.\n'
@@ -458,7 +458,8 @@ class _DontSection extends StatelessWidget {
         ),
         const SizedBox(height: MinglitSpacing.small),
         const _CodeSnippet(
-          code: '// ❌ 피하세요\n'
+          code:
+              '// ❌ 피하세요\n'
               'bool _isLoading = false;\n'
               'String? _error;\n'
               'List<Item>? _items;\n\n'

--- a/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/async_wrapper_demo.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/async_wrapper_demo.dart
@@ -1,0 +1,479 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:minglit_kit/src/theme/minglit_theme.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_async_value_widget.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_skeleton.dart';
+
+/// Demo states for the async wrapper interactive demo.
+enum AsyncDemoState {
+  /// Shows shimmer/skeleton loading UI.
+  loading,
+
+  /// Shows error widget with retry button.
+  error,
+
+  /// Shows data list.
+  data,
+}
+
+/// Mock data item for the data-state demo list.
+class _MockItem {
+  const _MockItem({required this.title, required this.subtitle});
+
+  final String title;
+  final String subtitle;
+}
+
+const _mockItems = [
+  _MockItem(title: '첫 번째 항목', subtitle: '상세 설명 텍스트입니다.'),
+  _MockItem(title: '두 번째 항목', subtitle: '다양한 상태를 시연합니다.'),
+  _MockItem(title: '세 번째 항목', subtitle: 'AsyncValue를 사용하세요.'),
+];
+
+/// **P7 Async 래퍼 패턴 데모**
+///
+/// [MinglitAsyncValueWidget]을 사용해 [AsyncValue]의 세 가지 상태
+/// (loading / error / data)를 처리하는 패턴을 보여줍니다.
+///
+/// 상단의 [SegmentedButton]으로 상태를 전환하고,
+/// 하단의 Do / Don't 섹션에서 올바른 사용법과 지양할 패턴을 확인할 수 있습니다.
+class AsyncWrapperDemoPage extends StatefulWidget {
+  /// Creates the async wrapper pattern demo page.
+  const AsyncWrapperDemoPage({super.key});
+
+  @override
+  State<AsyncWrapperDemoPage> createState() => _AsyncWrapperDemoPageState();
+}
+
+class _AsyncWrapperDemoPageState extends State<AsyncWrapperDemoPage> {
+  AsyncDemoState _selectedState = AsyncDemoState.data;
+
+  AsyncValue<List<_MockItem>> get _asyncValue {
+    return switch (_selectedState) {
+      AsyncDemoState.loading => const AsyncValue.loading(),
+      AsyncDemoState.error => AsyncValue.error(
+          Exception('데이터를 불러오지 못했습니다.'),
+          StackTrace.empty,
+        ),
+      AsyncDemoState.data => const AsyncValue.data(_mockItems),
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(title: const Text('P7 Async 래퍼 패턴')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(MinglitSpacing.medium),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _StateToggle(
+              selected: _selectedState,
+              onChanged: (state) => setState(() => _selectedState = state),
+            ),
+            const SizedBox(height: MinglitSpacing.medium),
+            _DemoPreview(asyncValue: _asyncValue),
+            const SizedBox(height: MinglitSpacing.large),
+            _DoSection(theme: theme),
+            const SizedBox(height: MinglitSpacing.medium),
+            _DontSection(theme: theme),
+            const SizedBox(height: MinglitSpacing.large),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// State Toggle
+// ---------------------------------------------------------------------------
+
+class _StateToggle extends StatelessWidget {
+  const _StateToggle({required this.selected, required this.onChanged});
+
+  final AsyncDemoState selected;
+  final ValueChanged<AsyncDemoState> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SegmentedButton<AsyncDemoState>(
+        segments: const [
+          ButtonSegment(
+            value: AsyncDemoState.loading,
+            label: Text('loading'),
+            icon: Icon(Icons.hourglass_empty),
+          ),
+          ButtonSegment(
+            value: AsyncDemoState.error,
+            label: Text('error'),
+            icon: Icon(Icons.error_outline),
+          ),
+          ButtonSegment(
+            value: AsyncDemoState.data,
+            label: Text('data'),
+            icon: Icon(Icons.check_circle_outline),
+          ),
+        ],
+        selected: {selected},
+        onSelectionChanged: (set) {
+          if (set.isNotEmpty) onChanged(set.first);
+        },
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Demo Preview
+// ---------------------------------------------------------------------------
+
+class _DemoPreview extends StatelessWidget {
+  const _DemoPreview({required this.asyncValue});
+
+  final AsyncValue<List<_MockItem>> asyncValue;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      constraints: const BoxConstraints(minHeight: 200),
+      decoration: BoxDecoration(
+        color: MinglitColors.surface,
+        borderRadius: BorderRadius.circular(MinglitRadius.card),
+        border: Border.all(
+          color: theme.colorScheme.outlineVariant,
+        ),
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(MinglitRadius.card),
+        child: MinglitAsyncValueWidget<List<_MockItem>>(
+          value: asyncValue,
+          loading: _buildSkeleton,
+          error: (err, _) => _ErrorView(onRetry: () {}),
+          data: (items) => _DataList(items: items),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSkeleton() => const _SkeletonList();
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton List
+// ---------------------------------------------------------------------------
+
+class _SkeletonList extends StatelessWidget {
+  const _SkeletonList();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      child: Column(
+        children: List.generate(3, (i) => _SkeletonRow(key: ValueKey(i))),
+      ),
+    );
+  }
+}
+
+class _SkeletonRow extends StatelessWidget {
+  const _SkeletonRow({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: MinglitSpacing.small),
+      child: Row(
+        children: [
+          const MinglitSkeleton(
+            width: 40,
+            height: 40,
+            borderRadius: BorderRadius.all(
+              Radius.circular(MinglitRadius.small),
+            ),
+          ),
+          const SizedBox(width: MinglitSpacing.medium),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                MinglitSkeleton(
+                  width: double.infinity,
+                  height: 14,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                const SizedBox(height: MinglitSpacing.xsmall),
+                MinglitSkeleton(
+                  width: 140,
+                  height: 12,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error View
+// ---------------------------------------------------------------------------
+
+class _ErrorView extends StatelessWidget {
+  const _ErrorView({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.all(MinglitSpacing.large),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(
+            Icons.error_outline,
+            color: MinglitColors.error,
+            size: MinglitIconSize.xlarge,
+          ),
+          const SizedBox(height: MinglitSpacing.medium),
+          Text(
+            '오류가 발생했습니다.',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: MinglitColors.textPrimary,
+            ),
+          ),
+          const SizedBox(height: MinglitSpacing.small),
+          Text(
+            '데이터를 불러오지 못했습니다.',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: MinglitColors.textSecondary,
+            ),
+          ),
+          const SizedBox(height: MinglitSpacing.medium),
+          TextButton.icon(
+            onPressed: onRetry,
+            icon: const Icon(Icons.refresh),
+            label: const Text('다시 시도'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Data List
+// ---------------------------------------------------------------------------
+
+class _DataList extends StatelessWidget {
+  const _DataList({required this.items});
+
+  final List<_MockItem> items;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListView.separated(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      itemCount: items.length,
+      separatorBuilder: (context, index) =>
+          const SizedBox(height: MinglitSpacing.small),
+      itemBuilder: (context, index) {
+        final item = items[index];
+        return Row(
+          children: [
+            Container(
+              width: 40,
+              height: 40,
+              decoration: BoxDecoration(
+                color: theme.colorScheme.primaryContainer,
+                borderRadius:
+                    BorderRadius.circular(MinglitRadius.small),
+              ),
+              child: Icon(
+                Icons.article_outlined,
+                size: MinglitIconSize.small,
+                color: theme.colorScheme.onPrimaryContainer,
+              ),
+            ),
+            const SizedBox(width: MinglitSpacing.medium),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    item.title,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: MinglitColors.textPrimary,
+                    ),
+                  ),
+                  Text(
+                    item.subtitle,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: MinglitColors.textSecondary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Do / Don't sections
+// ---------------------------------------------------------------------------
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.label, required this.color});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Container(
+          width: 4,
+          height: 18,
+          decoration: BoxDecoration(
+            color: color,
+            borderRadius: BorderRadius.circular(2),
+          ),
+        ),
+        const SizedBox(width: MinglitSpacing.small),
+        Text(
+          label,
+          style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: color,
+              ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CodeSnippet extends StatelessWidget {
+  const _CodeSnippet({required this.code});
+
+  final String code;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      decoration: BoxDecoration(
+        // ignore: minglit_no_hardcoded_colors -- code snippet background is intentionally dark
+        color: const Color(0xFF1E1E1E),
+        borderRadius: BorderRadius.circular(MinglitRadius.small),
+      ),
+      child: Text(
+        code,
+        style: const TextStyle(
+          fontFamily: 'monospace',
+          fontSize: 12,
+          // ignore: minglit_no_hardcoded_colors -- code text is intentionally light-on-dark
+          color: Color(0xFFD4D4D4),
+          height: 1.6,
+        ),
+      ),
+    );
+  }
+}
+
+class _DoSection extends StatelessWidget {
+  const _DoSection({required this.theme});
+
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const _SectionHeader(
+          label: 'Do — MinglitAsyncValueWidget 사용',
+          color: MinglitColors.success,
+        ),
+        const SizedBox(height: MinglitSpacing.small),
+        Text(
+          'AsyncValue 상태를 한 곳에서 처리하고, 로딩/에러 UI를 일관되게 유지합니다.',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: MinglitColors.textSecondary,
+          ),
+        ),
+        const SizedBox(height: MinglitSpacing.small),
+        const _CodeSnippet(
+          code: 'MinglitAsyncValueWidget<List<Item>>(\n'
+              '  value: ref.watch(itemsProvider),\n'
+              '  data: (items) => ItemList(items: items),\n'
+              '  // loading/error는 기본 UI가 자동 처리됩니다.\n'
+              ')',
+        ),
+      ],
+    );
+  }
+}
+
+class _DontSection extends StatelessWidget {
+  const _DontSection({required this.theme});
+
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const _SectionHeader(
+          label: "Don't — 수동 setState + _isLoading",
+          color: MinglitColors.error,
+        ),
+        const SizedBox(height: MinglitSpacing.small),
+        Text(
+          '로딩/에러 상태를 직접 관리하면 중복 코드가 늘어나고 '
+          '일관성을 유지하기 어렵습니다.',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: MinglitColors.textSecondary,
+          ),
+        ),
+        const SizedBox(height: MinglitSpacing.small),
+        const _CodeSnippet(
+          code: '// ❌ 피하세요\n'
+              'bool _isLoading = false;\n'
+              'String? _error;\n'
+              'List<Item>? _items;\n\n'
+              'Future<void> _load() async {\n'
+              '  setState(() => _isLoading = true);\n'
+              '  try {\n'
+              '    _items = await repo.fetchItems();\n'
+              '  } catch (e) {\n'
+              '    _error = e.toString();\n'
+              '  } finally {\n'
+              '    setState(() => _isLoading = false);\n'
+              '  }\n'
+              '}',
+        ),
+      ],
+    );
+  }
+}

--- a/shared/packages/minglit_kit/test/src/features/dev/catalog_tabs/patterns/async_wrapper_demo_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/dev/catalog_tabs/patterns/async_wrapper_demo_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/features/dev/catalog_tabs/patterns/async_wrapper_demo.dart';
+
+void main() {
+  Widget buildApp() {
+    return const MaterialApp(
+      home: AsyncWrapperDemoPage(),
+    );
+  }
+
+  group('AsyncWrapperDemoPage', () {
+    testWidgets('renders without error in default data state', (tester) async {
+      await tester.pumpWidget(buildApp());
+      // Allow skeleton animation frames to settle
+      await tester.pump();
+
+      expect(find.byType(AsyncWrapperDemoPage), findsOneWidget);
+      expect(find.byType(SegmentedButton<AsyncDemoState>), findsOneWidget);
+    });
+
+    testWidgets('shows data list items when data state is selected', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildApp());
+      await tester.pump();
+
+      // Default state is data — mock items should be visible
+      expect(find.text('첫 번째 항목'), findsOneWidget);
+      expect(find.text('두 번째 항목'), findsOneWidget);
+      expect(find.text('세 번째 항목'), findsOneWidget);
+    });
+
+    testWidgets('shows skeleton when loading state is selected', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildApp());
+      await tester.pump();
+
+      // Tap the loading segment
+      await tester.tap(find.text('loading'));
+      await tester.pump();
+
+      // Skeleton rows should appear — mock items should NOT be visible
+      expect(find.text('첫 번째 항목'), findsNothing);
+    });
+
+    testWidgets('shows error widget when error state is selected', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildApp());
+      await tester.pump();
+
+      // Tap the error segment
+      await tester.tap(find.text('error'));
+      await tester.pump();
+
+      expect(find.text('오류가 발생했습니다.'), findsOneWidget);
+      expect(find.text('다시 시도'), findsOneWidget);
+    });
+
+    testWidgets('can transition between all three states', (tester) async {
+      await tester.pumpWidget(buildApp());
+      await tester.pump();
+
+      // data → loading
+      await tester.tap(find.text('loading'));
+      await tester.pump();
+      expect(find.text('첫 번째 항목'), findsNothing);
+
+      // loading → error
+      await tester.tap(find.text('error'));
+      await tester.pump();
+      expect(find.text('오류가 발생했습니다.'), findsOneWidget);
+
+      // error → data
+      await tester.tap(find.text('data'));
+      await tester.pump();
+      expect(find.text('첫 번째 항목'), findsOneWidget);
+    });
+
+    testWidgets("shows Do / Don't sections", (tester) async {
+      await tester.pumpWidget(buildApp());
+      await tester.pump();
+
+      expect(
+        find.text('Do — MinglitAsyncValueWidget 사용'),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining("Don't"),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('retry button in error view is tappable without crash', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildApp());
+      await tester.pump();
+
+      await tester.tap(find.text('error'));
+      await tester.pump();
+
+      expect(find.text('다시 시도'), findsOneWidget);
+      await tester.tap(find.text('다시 시도'));
+      await tester.pump();
+      // No exception should be thrown
+    });
+  });
+}


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-2

## Summary

- `AsyncWrapperDemoPage` 위젯 구현 — SegmentedButton으로 loading/error/data 상태 토글
- loading: `MinglitSkeleton` shimmer 목록 표시
- error: 에러 아이콘 + 설명 + 다시 시도 버튼
- data: 3개 mock 항목 목록
- Do/Don't 섹션: `MinglitAsyncValueWidget` 올바른 사용법 vs 수동 `setState + _isLoading` 패턴
- `minglit_dev.dart` 배럴 파일 export 추가

## Test plan

- [ ] `flutter analyze` — no issues
- [ ] 위젯 테스트 (3가지 AsyncDemoState 렌더링, 상태 전환)
- [ ] Do/Don't 섹션 코드 스니펫 표시 확인

Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)