### PR TITLE
feat(design-catalog): P5 결제 플로우 패턴 데모 추가

### DIFF
--- a/shared/packages/minglit_kit/lib/minglit_dev.dart
+++ b/shared/packages/minglit_kit/lib/minglit_dev.dart
@@ -1,4 +1,5 @@
 export 'src/features/dev/catalog_tabs/patterns/data_states_demo.dart';
+export 'src/features/dev/catalog_tabs/patterns/transaction_flow_demo.dart';
 export 'src/features/dev/design_catalog_page.dart';
 export 'src/features/dev/dev_config.dart';
 export 'src/features/dev/dev_user_switch_screen.dart';

--- a/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/transaction_flow_demo.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/transaction_flow_demo.dart
@@ -1,0 +1,508 @@
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/src/theme/minglit_theme.dart';
+
+/// Payment flow simulation states.
+enum PaymentFlowState {
+  /// Order summary, awaiting user confirmation.
+  confirm,
+
+  /// Payment is being processed.
+  processing,
+
+  /// Payment completed successfully.
+  success,
+
+  /// Payment failed.
+  failure,
+}
+
+/// Refund sub-flow simulation states.
+enum RefundFlowState {
+  /// Cancel request form shown to user.
+  request,
+
+  /// Refund amount is being calculated.
+  calculating,
+
+  /// Refund is being processed.
+  processing,
+
+  /// Refund completed.
+  complete,
+}
+
+/// **TransactionFlowDemoPage**
+///
+/// Design-catalog demo page for P5 결제 플로우 패턴.
+/// Simulates payment and refund sub-flow UI states via [SegmentedButton].
+///
+/// This is a DEMO widget — mock data is inlined and no real payment logic runs.
+class TransactionFlowDemoPage extends StatefulWidget {
+  /// Creates a [TransactionFlowDemoPage].
+  const TransactionFlowDemoPage({super.key});
+
+  @override
+  State<TransactionFlowDemoPage> createState() =>
+      _TransactionFlowDemoPageState();
+}
+
+class _TransactionFlowDemoPageState extends State<TransactionFlowDemoPage> {
+  PaymentFlowState _paymentState = PaymentFlowState.confirm;
+  RefundFlowState _refundState = RefundFlowState.request;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('결제 플로우 패턴 데모')),
+      body: ListView(
+        padding: const EdgeInsets.all(MinglitSpacing.medium),
+        children: [
+          const _SectionHeader(title: '결제 플로우'),
+          const SizedBox(height: MinglitSpacing.small),
+          _PaymentFlowStateSelector(
+            selected: _paymentState,
+            onChanged: (state) => setState(() => _paymentState = state),
+          ),
+          const SizedBox(height: MinglitSpacing.medium),
+          _PaymentFlowStatePanel(state: _paymentState),
+          const SizedBox(height: MinglitSpacing.large),
+          const Divider(),
+          const SizedBox(height: MinglitSpacing.large),
+          const _SectionHeader(title: '환불 플로우'),
+          const SizedBox(height: MinglitSpacing.small),
+          _RefundFlowStateSelector(
+            selected: _refundState,
+            onChanged: (state) => setState(() => _refundState = state),
+          ),
+          const SizedBox(height: MinglitSpacing.medium),
+          _RefundFlowStatePanel(state: _refundState),
+          const SizedBox(height: MinglitSpacing.large),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Section header
+// ---------------------------------------------------------------------------
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      title,
+      style: Theme.of(context).textTheme.titleMedium,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Payment flow widgets
+// ---------------------------------------------------------------------------
+
+class _PaymentFlowStateSelector extends StatelessWidget {
+  const _PaymentFlowStateSelector({
+    required this.selected,
+    required this.onChanged,
+  });
+
+  final PaymentFlowState selected;
+  final ValueChanged<PaymentFlowState> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: SegmentedButton<PaymentFlowState>(
+        segments: const [
+          ButtonSegment(
+            value: PaymentFlowState.confirm,
+            label: Text('확인'),
+          ),
+          ButtonSegment(
+            value: PaymentFlowState.processing,
+            label: Text('처리 중'),
+          ),
+          ButtonSegment(
+            value: PaymentFlowState.success,
+            label: Text('성공'),
+          ),
+          ButtonSegment(
+            value: PaymentFlowState.failure,
+            label: Text('실패'),
+          ),
+        ],
+        selected: {selected},
+        onSelectionChanged: (set) {
+          if (set.isNotEmpty) onChanged(set.first);
+        },
+      ),
+    );
+  }
+}
+
+class _PaymentFlowStatePanel extends StatelessWidget {
+  const _PaymentFlowStatePanel({required this.state});
+
+  final PaymentFlowState state;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (state) {
+      PaymentFlowState.confirm => const _PaymentConfirmPanel(),
+      PaymentFlowState.processing => const _PaymentProcessingPanel(),
+      PaymentFlowState.success => const _PaymentSuccessPanel(),
+      PaymentFlowState.failure => const _PaymentFailurePanel(),
+    };
+  }
+}
+
+class _PaymentConfirmPanel extends StatelessWidget {
+  const _PaymentConfirmPanel();
+
+  @override
+  Widget build(BuildContext context) {
+    return _DemoCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '주문 요약',
+            style: Theme.of(context).textTheme.titleSmall,
+          ),
+          const SizedBox(height: MinglitSpacing.medium),
+          const _OrderSummaryRow(label: '이벤트', value: '밍글릿 봄 파티'),
+          const SizedBox(height: MinglitSpacing.small),
+          const _OrderSummaryRow(label: '티켓 수', value: '2매'),
+          const SizedBox(height: MinglitSpacing.small),
+          const _OrderSummaryRow(label: '결제 금액', value: '₩30,000'),
+          const SizedBox(height: MinglitSpacing.large),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed: () {},
+              child: const Text('결제하기'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PaymentProcessingPanel extends StatelessWidget {
+  const _PaymentProcessingPanel();
+
+  @override
+  Widget build(BuildContext context) {
+    return _DemoCard(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const CircularProgressIndicator(),
+          const SizedBox(height: MinglitSpacing.medium),
+          Text(
+            '결제 처리 중...',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PaymentSuccessPanel extends StatelessWidget {
+  const _PaymentSuccessPanel();
+
+  @override
+  Widget build(BuildContext context) {
+    return _DemoCard(
+      child: Column(
+        children: [
+          const Icon(
+            Icons.check_circle,
+            color: MinglitColors.success,
+            size: MinglitIconSize.xlarge,
+          ),
+          const SizedBox(height: MinglitSpacing.small),
+          Text(
+            '결제 완료',
+            style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  color: MinglitColors.success,
+                ),
+          ),
+          const SizedBox(height: MinglitSpacing.medium),
+          const _OrderSummaryRow(label: '이벤트', value: '밍글릿 봄 파티'),
+          const SizedBox(height: MinglitSpacing.small),
+          const _OrderSummaryRow(label: '티켓 수', value: '2매'),
+          const SizedBox(height: MinglitSpacing.small),
+          const _OrderSummaryRow(label: '결제 금액', value: '₩30,000'),
+          const SizedBox(height: MinglitSpacing.small),
+          const _OrderSummaryRow(label: '주문 번호', value: 'ORD-20260405-001'),
+        ],
+      ),
+    );
+  }
+}
+
+class _PaymentFailurePanel extends StatelessWidget {
+  const _PaymentFailurePanel();
+
+  @override
+  Widget build(BuildContext context) {
+    return _DemoCard(
+      child: Column(
+        children: [
+          const Icon(
+            Icons.cancel,
+            color: MinglitColors.error,
+            size: MinglitIconSize.xlarge,
+          ),
+          const SizedBox(height: MinglitSpacing.small),
+          Text(
+            '결제 실패',
+            style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  color: MinglitColors.error,
+                ),
+          ),
+          const SizedBox(height: MinglitSpacing.small),
+          Text(
+            '결제 처리 중 오류가 발생했습니다.',
+            style: Theme.of(context).textTheme.bodyMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: MinglitSpacing.medium),
+          ElevatedButton(
+            onPressed: () {},
+            child: const Text('다시 시도'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Refund flow widgets
+// ---------------------------------------------------------------------------
+
+class _RefundFlowStateSelector extends StatelessWidget {
+  const _RefundFlowStateSelector({
+    required this.selected,
+    required this.onChanged,
+  });
+
+  final RefundFlowState selected;
+  final ValueChanged<RefundFlowState> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: SegmentedButton<RefundFlowState>(
+        segments: const [
+          ButtonSegment(
+            value: RefundFlowState.request,
+            label: Text('요청'),
+          ),
+          ButtonSegment(
+            value: RefundFlowState.calculating,
+            label: Text('계산 중'),
+          ),
+          ButtonSegment(
+            value: RefundFlowState.processing,
+            label: Text('처리 중'),
+          ),
+          ButtonSegment(
+            value: RefundFlowState.complete,
+            label: Text('완료'),
+          ),
+        ],
+        selected: {selected},
+        onSelectionChanged: (set) {
+          if (set.isNotEmpty) onChanged(set.first);
+        },
+      ),
+    );
+  }
+}
+
+class _RefundFlowStatePanel extends StatelessWidget {
+  const _RefundFlowStatePanel({required this.state});
+
+  final RefundFlowState state;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (state) {
+      RefundFlowState.request => const _RefundRequestPanel(),
+      RefundFlowState.calculating => const _RefundCalculatingPanel(),
+      RefundFlowState.processing => const _RefundProcessingPanel(),
+      RefundFlowState.complete => const _RefundCompletePanel(),
+    };
+  }
+}
+
+class _RefundRequestPanel extends StatelessWidget {
+  const _RefundRequestPanel();
+
+  @override
+  Widget build(BuildContext context) {
+    return _DemoCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '취소 요청',
+            style: Theme.of(context).textTheme.titleSmall,
+          ),
+          const SizedBox(height: MinglitSpacing.medium),
+          const _OrderSummaryRow(label: '이벤트', value: '밍글릿 봄 파티'),
+          const SizedBox(height: MinglitSpacing.small),
+          const _OrderSummaryRow(label: '티켓 번호', value: 'TKT-00123'),
+          const SizedBox(height: MinglitSpacing.small),
+          const _OrderSummaryRow(label: '결제 금액', value: '₩30,000'),
+          const SizedBox(height: MinglitSpacing.large),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed: () {},
+              style: ElevatedButton.styleFrom(
+                backgroundColor: MinglitColors.error,
+                foregroundColor: Colors.white,
+              ),
+              child: const Text('취소 요청'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RefundCalculatingPanel extends StatelessWidget {
+  const _RefundCalculatingPanel();
+
+  @override
+  Widget build(BuildContext context) {
+    return _DemoCard(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const CircularProgressIndicator(),
+          const SizedBox(height: MinglitSpacing.medium),
+          Text(
+            '환불 금액 계산 중',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RefundProcessingPanel extends StatelessWidget {
+  const _RefundProcessingPanel();
+
+  @override
+  Widget build(BuildContext context) {
+    return _DemoCard(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const CircularProgressIndicator(),
+          const SizedBox(height: MinglitSpacing.medium),
+          Text(
+            '환불 처리 중',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RefundCompletePanel extends StatelessWidget {
+  const _RefundCompletePanel();
+
+  @override
+  Widget build(BuildContext context) {
+    return _DemoCard(
+      child: Column(
+        children: [
+          const Icon(
+            Icons.check_circle,
+            color: MinglitColors.success,
+            size: MinglitIconSize.xlarge,
+          ),
+          const SizedBox(height: MinglitSpacing.small),
+          Text(
+            '환불 완료',
+            style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  color: MinglitColors.success,
+                ),
+          ),
+          const SizedBox(height: MinglitSpacing.medium),
+          const _OrderSummaryRow(label: '환불 금액', value: '₩30,000'),
+          const SizedBox(height: MinglitSpacing.small),
+          const _OrderSummaryRow(label: '처리 완료', value: '2026-04-05'),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared helper widgets
+// ---------------------------------------------------------------------------
+
+class _DemoCard extends StatelessWidget {
+  const _DemoCard({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      decoration: BoxDecoration(
+        color: MinglitColors.surface,
+        borderRadius: BorderRadius.circular(MinglitRadius.card),
+      ),
+      child: child,
+    );
+  }
+}
+
+class _OrderSummaryRow extends StatelessWidget {
+  const _OrderSummaryRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          label,
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        Text(
+          value,
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: MinglitColors.textPrimary,
+                fontWeight: FontWeight.w600,
+              ),
+        ),
+      ],
+    );
+  }
+}

--- a/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/transaction_flow_demo.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/patterns/transaction_flow_demo.dart
@@ -233,8 +233,8 @@ class _PaymentSuccessPanel extends StatelessWidget {
           Text(
             '결제 완료',
             style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                  color: MinglitColors.success,
-                ),
+              color: MinglitColors.success,
+            ),
           ),
           const SizedBox(height: MinglitSpacing.medium),
           const _OrderSummaryRow(label: '이벤트', value: '밍글릿 봄 파티'),
@@ -267,8 +267,8 @@ class _PaymentFailurePanel extends StatelessWidget {
           Text(
             '결제 실패',
             style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                  color: MinglitColors.error,
-                ),
+              color: MinglitColors.error,
+            ),
           ),
           const SizedBox(height: MinglitSpacing.small),
           Text(
@@ -444,8 +444,8 @@ class _RefundCompletePanel extends StatelessWidget {
           Text(
             '환불 완료',
             style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                  color: MinglitColors.success,
-                ),
+              color: MinglitColors.success,
+            ),
           ),
           const SizedBox(height: MinglitSpacing.medium),
           const _OrderSummaryRow(label: '환불 금액', value: '₩30,000'),
@@ -498,9 +498,9 @@ class _OrderSummaryRow extends StatelessWidget {
         Text(
           value,
           style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                color: MinglitColors.textPrimary,
-                fontWeight: FontWeight.w600,
-              ),
+            color: MinglitColors.textPrimary,
+            fontWeight: FontWeight.w600,
+          ),
         ),
       ],
     );

--- a/shared/packages/minglit_kit/test/src/features/dev/catalog_tabs/patterns/transaction_flow_demo_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/dev/catalog_tabs/patterns/transaction_flow_demo_test.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/features/dev/catalog_tabs/patterns/transaction_flow_demo.dart';
+
+/// Wraps [widget] in a [MaterialApp] + [Scaffold] for pump.
+Widget _wrap(Widget widget) {
+  return MaterialApp(home: Scaffold(body: widget));
+}
+
+void main() {
+  group('TransactionFlowDemoPage', () {
+    testWidgets('renders without error', (tester) async {
+      await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
+      expect(find.byType(TransactionFlowDemoPage), findsOneWidget);
+    });
+
+    testWidgets('shows payment flow section header', (tester) async {
+      await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
+      expect(find.text('결제 플로우'), findsOneWidget);
+    });
+
+    testWidgets('shows refund flow section header', (tester) async {
+      await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
+      expect(find.text('환불 플로우'), findsOneWidget);
+    });
+
+    testWidgets('shows payment SegmentedButton with four segments',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
+
+      expect(find.text('확인'), findsOneWidget);
+      expect(find.text('처리 중'), findsAtLeastNWidgets(1));
+      expect(find.text('성공'), findsOneWidget);
+      expect(find.text('실패'), findsOneWidget);
+    });
+
+    testWidgets('shows refund SegmentedButton with four segments',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
+
+      expect(find.text('요청'), findsOneWidget);
+      expect(find.text('계산 중'), findsOneWidget);
+      expect(find.text('완료'), findsOneWidget);
+    });
+  });
+
+  group('PaymentFlowState panels', () {
+    testWidgets('confirm state renders order summary and 결제하기 button',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
+      // Default state is confirm.
+      expect(find.text('주문 요약'), findsOneWidget);
+      expect(find.text('결제하기'), findsOneWidget);
+      expect(find.text('밍글릿 봄 파티'), findsAtLeastNWidgets(1));
+    });
+
+    testWidgets('processing state renders CircularProgressIndicator and label',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
+
+      // Tap "처리 중" segment in payment section (first SegmentedButton).
+      final processingSegments = find.text('처리 중');
+      await tester.tap(processingSegments.first);
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsAtLeastNWidgets(1));
+      expect(find.text('결제 처리 중...'), findsOneWidget);
+    });
+
+    testWidgets('success state renders check_circle icon and 결제 완료 text',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
+
+      await tester.tap(find.text('성공'));
+      await tester.pump();
+
+      expect(find.byIcon(Icons.check_circle), findsAtLeastNWidgets(1));
+      expect(find.text('결제 완료'), findsOneWidget);
+    });
+
+    testWidgets('failure state renders cancel icon and 다시 시도 button',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
+
+      await tester.tap(find.text('실패'));
+      await tester.pump();
+
+      expect(find.byIcon(Icons.cancel), findsOneWidget);
+      expect(find.text('결제 실패'), findsOneWidget);
+      expect(find.text('다시 시도'), findsOneWidget);
+    });
+  });
+
+  group('RefundFlowState panels', () {
+    testWidgets('request state renders 취소 요청 button', (tester) async {
+      await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
+      // Default refund state is request.
+      expect(find.text('취소 요청'), findsAtLeastNWidgets(1));
+      expect(find.text('TKT-00123'), findsOneWidget);
+    });
+
+    testWidgets('calculating state renders spinner and label', (tester) async {
+      await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
+
+      await tester.tap(find.text('계산 중'));
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsAtLeastNWidgets(1));
+      expect(find.text('환불 금액 계산 중'), findsOneWidget);
+    });
+
+    testWidgets('processing state renders spinner and label', (tester) async {
+      await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
+
+      // Tap "처리 중" in refund section — it is the second occurrence.
+      final processingSegments = find.text('처리 중');
+      await tester.tap(processingSegments.last);
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsAtLeastNWidgets(1));
+      expect(find.text('환불 처리 중'), findsOneWidget);
+    });
+
+    testWidgets('complete state renders check icon and 환불 완료 text',
+        (tester) async {
+      await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
+
+      // "완료" appears only in the refund SegmentedButton.
+      await tester.tap(find.text('완료'));
+      await tester.pump();
+
+      expect(find.byIcon(Icons.check_circle), findsAtLeastNWidgets(1));
+      expect(find.text('환불 완료'), findsOneWidget);
+      expect(find.text('₩30,000'), findsAtLeastNWidgets(1));
+    });
+  });
+
+  group('State transitions', () {
+    testWidgets(
+        'payment flow cycles through all states without error', (tester) async {
+      await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
+
+      // confirm → processing
+      await tester.tap(find.text('처리 중').first);
+      await tester.pump();
+      expect(find.text('결제 처리 중...'), findsOneWidget);
+
+      // processing → success
+      await tester.tap(find.text('성공'));
+      await tester.pump();
+      expect(find.text('결제 완료'), findsOneWidget);
+
+      // success → failure
+      await tester.tap(find.text('실패'));
+      await tester.pump();
+      expect(find.text('결제 실패'), findsOneWidget);
+
+      // failure → confirm
+      await tester.tap(find.text('확인'));
+      await tester.pump();
+      expect(find.text('주문 요약'), findsOneWidget);
+    });
+
+    testWidgets(
+        'refund flow cycles through all states without error', (tester) async {
+      await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
+
+      // request → calculating
+      await tester.tap(find.text('계산 중'));
+      await tester.pump();
+      expect(find.text('환불 금액 계산 중'), findsOneWidget);
+
+      // calculating → processing
+      await tester.tap(find.text('처리 중').last);
+      await tester.pump();
+      expect(find.text('환불 처리 중'), findsOneWidget);
+
+      // processing → complete
+      await tester.tap(find.text('완료'));
+      await tester.pump();
+      expect(find.text('환불 완료'), findsOneWidget);
+
+      // complete → request
+      await tester.tap(find.text('요청'));
+      await tester.pump();
+      expect(find.text('취소 요청'), findsAtLeastNWidgets(1));
+    });
+  });
+}

--- a/shared/packages/minglit_kit/test/src/features/dev/catalog_tabs/patterns/transaction_flow_demo_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/dev/catalog_tabs/patterns/transaction_flow_demo_test.dart
@@ -24,8 +24,9 @@ void main() {
       expect(find.text('환불 플로우'), findsOneWidget);
     });
 
-    testWidgets('shows payment SegmentedButton with four segments',
-        (tester) async {
+    testWidgets('shows payment SegmentedButton with four segments', (
+      tester,
+    ) async {
       await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
 
       expect(find.text('확인'), findsOneWidget);
@@ -34,8 +35,9 @@ void main() {
       expect(find.text('실패'), findsOneWidget);
     });
 
-    testWidgets('shows refund SegmentedButton with four segments',
-        (tester) async {
+    testWidgets('shows refund SegmentedButton with four segments', (
+      tester,
+    ) async {
       await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
 
       expect(find.text('요청'), findsOneWidget);
@@ -45,8 +47,9 @@ void main() {
   });
 
   group('PaymentFlowState panels', () {
-    testWidgets('confirm state renders order summary and 결제하기 button',
-        (tester) async {
+    testWidgets('confirm state renders order summary and 결제하기 button', (
+      tester,
+    ) async {
       await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
       // Default state is confirm.
       expect(find.text('주문 요약'), findsOneWidget);
@@ -54,21 +57,24 @@ void main() {
       expect(find.text('밍글릿 봄 파티'), findsAtLeastNWidgets(1));
     });
 
-    testWidgets('processing state renders CircularProgressIndicator and label',
-        (tester) async {
-      await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
+    testWidgets(
+      'processing state renders CircularProgressIndicator and label',
+      (tester) async {
+        await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
 
-      // Tap "처리 중" segment in payment section (first SegmentedButton).
-      final processingSegments = find.text('처리 중');
-      await tester.tap(processingSegments.first);
-      await tester.pump();
+        // Tap "처리 중" segment in payment section (first SegmentedButton).
+        final processingSegments = find.text('처리 중');
+        await tester.tap(processingSegments.first);
+        await tester.pump();
 
-      expect(find.byType(CircularProgressIndicator), findsAtLeastNWidgets(1));
-      expect(find.text('결제 처리 중...'), findsOneWidget);
-    });
+        expect(find.byType(CircularProgressIndicator), findsAtLeastNWidgets(1));
+        expect(find.text('결제 처리 중...'), findsOneWidget);
+      },
+    );
 
-    testWidgets('success state renders check_circle icon and 결제 완료 text',
-        (tester) async {
+    testWidgets('success state renders check_circle icon and 결제 완료 text', (
+      tester,
+    ) async {
       await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
 
       await tester.tap(find.text('성공'));
@@ -78,8 +84,9 @@ void main() {
       expect(find.text('결제 완료'), findsOneWidget);
     });
 
-    testWidgets('failure state renders cancel icon and 다시 시도 button',
-        (tester) async {
+    testWidgets('failure state renders cancel icon and 다시 시도 button', (
+      tester,
+    ) async {
       await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
 
       await tester.tap(find.text('실패'));
@@ -121,8 +128,9 @@ void main() {
       expect(find.text('환불 처리 중'), findsOneWidget);
     });
 
-    testWidgets('complete state renders check icon and 환불 완료 text',
-        (tester) async {
+    testWidgets('complete state renders check icon and 환불 완료 text', (
+      tester,
+    ) async {
       await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
 
       // "완료" appears only in the refund SegmentedButton.
@@ -136,8 +144,9 @@ void main() {
   });
 
   group('State transitions', () {
-    testWidgets(
-        'payment flow cycles through all states without error', (tester) async {
+    testWidgets('payment flow cycles through all states without error', (
+      tester,
+    ) async {
       await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
 
       // confirm → processing
@@ -161,8 +170,9 @@ void main() {
       expect(find.text('주문 요약'), findsOneWidget);
     });
 
-    testWidgets(
-        'refund flow cycles through all states without error', (tester) async {
+    testWidgets('refund flow cycles through all states without error', (
+      tester,
+    ) async {
       await tester.pumpWidget(_wrap(const TransactionFlowDemoPage()));
 
       // request → calculating


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-2

## Summary

- `TransactionFlowDemoPage` 위젯 구현 — 결제/환불 플로우 시뮬레이션
- 결제 플로우 (4상태): 확인 → 처리 중 → 성공 / 실패
- 환불 서브플로우 (4상태): 요청 → 계산 중 → 처리 중 → 완료
- 각 플로우별 `SegmentedButton` 상태 토글
- `minglit_dev.dart` 배럴 파일 export 추가

## Test plan

- [ ] `flutter analyze` — no issues
- [ ] 위젯 테스트 (PaymentFlowState 4상태, RefundFlowState 4상태 렌더링)
- [ ] 성공/완료 아이콘 녹색, 실패 아이콘 빨간색 확인

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)