### PR TITLE
fix(deps): connectivity_plus ^7.1.0 → ^6.1.3 iOS 빌드 실패 수정

### DIFF
--- a/shared/packages/minglit_kit/pubspec.yaml
+++ b/shared/packages/minglit_kit/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   app_settings: ^7.0.0
   async: ^2.13.0
   battery_plus: ^7.0.0
-  connectivity_plus: ^7.1.0
+  connectivity_plus: ^6.1.3
   crypto: ^3.0.5
   cryptography: ^2.9.0
   device_info_plus: ^12.4.0


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

## 요약
- `connectivity_plus ^7.1.0`이 iOS 18.4+ 전용 API(`NWPath.isUltraConstrained`)를 사용하여 CI 빌드 실패
- `^6.1.3`으로 다운그레이드하여 기존 Xcode 버전과 호환성 복원

## 원인
- `connectivity_plus` v7.1.0의 `PathMonitorConnectivityProvider.swift:28`이 `NWPath.isUltraConstrained` 사용
- 이 API는 iOS 18.4 SDK (Xcode 16.4+)에서만 지원
- CI 러너(macos-latest)의 Xcode가 16.4 미만

Closes #1083
Closes #1081
Closes #1082