### PR TITLE
fix: resolve TODO/FIXME 2건 — 1-event 테스트 활성화 + env drift CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,45 +12,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # EnvKeyStore ↔ env-manifest.json drift 검사 (항상 실행 — path filter 없음)
-  check-env-keystore-drift:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check env_keystore.dart vs env-manifest.json
-        run: |
-          python3 - <<'PYEOF'
-          import json, re, sys
-
-          with open('shared/packages/minglit_kit/lib/src/config/env_keystore.dart') as f:
-              dart = f.read()
-          # Match String.fromEnvironment('KEY') and String.fromEnvironment(\n  'KEY'
-          keystore_keys = set(re.findall(
-              r"String\.fromEnvironment\s*\([^)]*?'([A-Z_]+)'",
-              dart, re.DOTALL,
-          ))
-
-          with open('env-manifest.json') as f:
-              manifest = json.load(f)
-          flutter = manifest.get('flutter', {})
-          manifest_keys = (
-              set(flutter.get('required', {}).keys()) |
-              set(flutter.get('optional', {}).keys())
-          )
-
-          extra_keystore = sorted(keystore_keys - manifest_keys)
-          extra_manifest = sorted(manifest_keys - keystore_keys)
-
-          if extra_keystore or extra_manifest:
-              print('❌ Drift detected between env_keystore.dart and env-manifest.json (flutter section)')
-              if extra_keystore:
-                  print(f'  Keys in keystore but not manifest: {extra_keystore}')
-              if extra_manifest:
-                  print(f'  Keys in manifest but not keystore: {extra_manifest}')
-              sys.exit(1)
-          print(f'✅ env_keystore.dart and env-manifest.json are in sync ({len(keystore_keys)} keys)')
-          PYEOF
-
   # Migration version 중복 검사 (항상 실행 — path filter 없음)
   check-migration-versions:
     runs-on: ubuntu-latest
@@ -359,7 +320,7 @@ jobs:
         working-directory: supabase
 
   ci-result:
-    needs: [check-env-keystore-drift, check-migration-versions, check-env-manifest-sync, test-flutter-apps, lint-landing-user, lint-landing-partner, test-supabase, test-edge-functions]
+    needs: [check-migration-versions, check-env-manifest-sync, test-flutter-apps, lint-landing-user, lint-landing-partner, test-supabase, test-edge-functions]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # EnvKeyStore ↔ env-manifest.json drift 검사 (항상 실행 — path filter 없음)
+  check-env-keystore-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check env_keystore.dart vs env-manifest.json
+        run: |
+          python3 - <<'PYEOF'
+          import json, re, sys
+
+          with open('shared/packages/minglit_kit/lib/src/config/env_keystore.dart') as f:
+              dart = f.read()
+          # Match String.fromEnvironment('KEY') and String.fromEnvironment(\n  'KEY'
+          keystore_keys = set(re.findall(
+              r"String\.fromEnvironment\s*\([^)]*?'([A-Z_]+)'",
+              dart, re.DOTALL,
+          ))
+
+          with open('env-manifest.json') as f:
+              manifest = json.load(f)
+          flutter = manifest.get('flutter', {})
+          manifest_keys = (
+              set(flutter.get('required', {}).keys()) |
+              set(flutter.get('optional', {}).keys())
+          )
+
+          extra_keystore = sorted(keystore_keys - manifest_keys)
+          extra_manifest = sorted(manifest_keys - keystore_keys)
+
+          if extra_keystore or extra_manifest:
+              print('❌ Drift detected between env_keystore.dart and env-manifest.json (flutter section)')
+              if extra_keystore:
+                  print(f'  Keys in keystore but not manifest: {extra_keystore}')
+              if extra_manifest:
+                  print(f'  Keys in manifest but not keystore: {extra_manifest}')
+              sys.exit(1)
+          print(f'✅ env_keystore.dart and env-manifest.json are in sync ({len(keystore_keys)} keys)')
+          PYEOF
+
   # Migration version 중복 검사 (항상 실행 — path filter 없음)
   check-migration-versions:
     runs-on: ubuntu-latest
@@ -312,7 +351,7 @@ jobs:
         working-directory: supabase
 
   ci-result:
-    needs: [check-migration-versions, test-flutter-apps, lint-landing-user, lint-landing-partner, test-supabase, test-edge-functions]
+    needs: [check-env-keystore-drift, check-migration-versions, test-flutter-apps, lint-landing-user, lint-landing-partner, test-supabase, test-edge-functions]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/apps/app_partner/test/src/features/checkin/checkin_placeholder_page_test.dart
+++ b/apps/app_partner/test/src/features/checkin/checkin_placeholder_page_test.dart
@@ -1,13 +1,88 @@
 import 'dart:async';
 
 import 'package:app_partner/src/features/checkin/checkin_placeholder_page.dart';
+import 'package:app_partner/src/features/checkin/qr_scanner_screen.dart';
 import 'package:app_partner/src/logic/current_partner_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+/// Fake platform implementation for MobileScanner.
+///
+/// Prevents real camera platform channel calls during widget tests. Required
+/// because MobileScannerController initialises asynchronously and its dispose
+/// fires platform calls that outlive the test frame — see Fix #1072.
+class _FakeMobileScannerPlatform extends MobileScannerPlatform {
+  @override
+  Stream<BarcodeCapture?> get barcodesStream => const Stream.empty();
+
+  @override
+  Stream<TorchState> get torchStateStream => const Stream.empty();
+
+  @override
+  Stream<double> get zoomScaleStateStream => const Stream.empty();
+
+  @override
+  Widget buildCameraView() => const SizedBox.shrink();
+
+  @override
+  Future<MobileScannerViewAttributes> start(StartOptions startOptions) async {
+    return const MobileScannerViewAttributes(
+      cameraDirection: CameraFacing.back,
+      currentTorchMode: TorchState.unavailable,
+      size: Size.zero,
+    );
+  }
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<void> pause() async {}
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  Future<void> toggleTorch() async {}
+
+  @override
+  Future<Set<CameraLensType>> getSupportedLenses() async => {};
+
+  @override
+  Future<void> updateScanWindow(Rect? window) async {}
+
+  @override
+  Future<void> resetZoomScale() async {}
+
+  @override
+  Future<void> setZoomScale(double zoomScale) async {}
+
+  @override
+  Future<void> setFocusPoint(Offset position) async {}
+
+  @override
+  Future<BarcodeCapture?> analyzeImage(
+    String path, {
+    List<BarcodeFormat> formats = const <BarcodeFormat>[],
+  }) async =>
+      null;
+}
 
 void main() {
   group('CheckinPlaceholderPage', () {
+    late MobileScannerPlatform _originalPlatform;
+
+    setUp(() {
+      _originalPlatform = MobileScannerPlatform.instance;
+      MobileScannerPlatform.instance = _FakeMobileScannerPlatform();
+    });
+
+    tearDown(() {
+      MobileScannerPlatform.instance = _originalPlatform;
+    });
+
     const testPartner = Partner(
       id: 'partner-1',
       name: 'Test Partner',
@@ -100,16 +175,29 @@ void main() {
       expect(find.byIcon(Icons.qr_code_scanner), findsOneWidget);
     });
 
-    // TODO #1009: 1-event auto-entry test remains disabled.
-    // Blocker: QRScannerScreen uses mobile_scanner (currently unpinned as "any"
-    // in pubspec.yaml), which has async dispose behavior. Flutter's test framework
-    // does not await plugin disposal during teardown, causing flaky test failures.
-    // Note: 0-event and 2+-event tests validate UI states, not 1-event routing.
-    // When re-enabling this test, ensure it verifies auto-routing behavior
-    // (events.length == 1 → direct QRScannerScreen entry).
-    //
-    // Re-enable when mobile_scanner provides synchronous disposal or when a
-    // test shim for camera plugins becomes available.
+    testWidgets('auto-routes to QRScannerScreen when exactly 1 event today', (
+      tester,
+    ) async {
+      // Fix #1097: Previously disabled due to mobile_scanner async dispose
+      // (tracked in #1009). Fix #1072 applied unawaited() to _scannerController
+      // .dispose(); _FakeMobileScannerPlatform stubs out platform calls so the
+      // test runs without a camera and teardown is deterministic.
+      await tester.pumpWidget(
+        buildWidget(
+          overrides: [
+            currentPartnerInfoProvider.overrideWith(
+              (ref) async => testPartner,
+            ),
+            todayEventsProvider.overrideWith(
+              (ref, partnerId) async => [testEvent],
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(QRScannerScreen), findsOneWidget);
+    });
 
     testWidgets('shows event selection when 2+ events today', (
       tester,

--- a/apps/app_partner/test/src/features/checkin/checkin_placeholder_page_test.dart
+++ b/apps/app_partner/test/src/features/checkin/checkin_placeholder_page_test.dart
@@ -66,21 +66,20 @@ class _FakeMobileScannerPlatform extends MobileScannerPlatform {
   Future<BarcodeCapture?> analyzeImage(
     String path, {
     List<BarcodeFormat> formats = const <BarcodeFormat>[],
-  }) async =>
-      null;
+  }) async => null;
 }
 
 void main() {
   group('CheckinPlaceholderPage', () {
-    late MobileScannerPlatform _originalPlatform;
+    late MobileScannerPlatform originalPlatform;
 
     setUp(() {
-      _originalPlatform = MobileScannerPlatform.instance;
+      originalPlatform = MobileScannerPlatform.instance;
       MobileScannerPlatform.instance = _FakeMobileScannerPlatform();
     });
 
     tearDown(() {
-      MobileScannerPlatform.instance = _originalPlatform;
+      MobileScannerPlatform.instance = originalPlatform;
     });
 
     const testPartner = Partner(

--- a/apps/app_partner/test/src/features/checkin/checkin_placeholder_page_test.dart
+++ b/apps/app_partner/test/src/features/checkin/checkin_placeholder_page_test.dart
@@ -13,6 +13,7 @@ import 'package:mobile_scanner/mobile_scanner.dart';
 /// Prevents real camera platform channel calls during widget tests. Required
 /// because MobileScannerController initialises asynchronously and its dispose
 /// fires platform calls that outlive the test frame — see Fix #1072.
+// Fix #1097: widget test에서 MobileScannerPlatform을 스텁해 카메라 채널 호출을 막는다.
 class _FakeMobileScannerPlatform extends MobileScannerPlatform {
   @override
   Stream<BarcodeCapture?> get barcodesStream => const Stream.empty();

--- a/shared/packages/minglit_kit/lib/src/config/env_keystore.dart
+++ b/shared/packages/minglit_kit/lib/src/config/env_keystore.dart
@@ -7,8 +7,8 @@ import 'package:minglit_kit/src/utils/log.dart';
 ///
 /// Each key must be declared as a separate `const String.fromEnvironment()`
 /// because the argument must be a compile-time constant literal.
-// TODO(needs-swe-sonnet-subagents-1): Implement CI audit to detect drift
-// between this file and env-manifest.json.
+/// CI job `check-env-keystore-drift` enforces that this file and
+/// `env-manifest.json` (flutter section) stay in sync.
 class EnvKeyStore {
   EnvKeyStore._();
 


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-2

Closes #1097

## 변경 내용

### 1. 1-event QRScannerScreen 자동 라우팅 테스트 활성화

`checkin_placeholder_page_test.dart`에 `_FakeMobileScannerPlatform` 스텁을 추가해 카메라 플랫폼 채널 호출을 막고, 비활성화되어 있던 1-event 자동 진입 테스트를 재활성화했다.

- Fix #1072에서 `unawaited(_scannerController.dispose())`가 이미 적용됨
- `_FakeMobileScannerPlatform`이 남은 async platform-channel 노이즈를 제거
- `MobileScannerPlatform.instance`를 setUp/tearDown으로 교체 — 다른 테스트에 영향 없음
- 기존 7개 테스트 + 신규 1개 = 총 8개 테스트 전부 통과

### 2. env_keystore.dart ↔ env-manifest.json drift CI 감사

`check-env-keystore-drift` CI 잡을 추가했다 (항상 실행).

- Python regex로 `String.fromEnvironment(...)` 키를 추출 (단일행 + 다중행 모두 지원)
- `env-manifest.json` flutter 섹션과 비교해 drift 발견 시 CI 실패
- `ci-result` needs 목록에 추가 — drift가 있으면 머지 불가
- `env_keystore.dart` TODO 주석을 CI 잡 참조 문서 주석으로 교체

## 검증

```
flutter test test/src/features/checkin/checkin_placeholder_page_test.dart
# 00:13 +8: All tests passed!
```

drift 체크 스크립트도 로컬에서 통과 확인 (11 keys in sync).