### PR TITLE
fix(ci): remove backslash continuation in android-emulator-runner script

### DIFF
--- a/.github/workflows/daily-backend-simulation.yml
+++ b/.github/workflows/daily-backend-simulation.yml
@@ -75,9 +75,7 @@ jobs:
             for f in integration_test/*_test.dart; do
               [ -f "$f" ] || { echo "⏭ No integration tests found, skipping."; break; }
               echo "▶ Running: $f"
-              flutter test "$f" \
-                --flavor dev \
-                --dart-define-from-file=../../minglit_env/dev/flutter.env
+              flutter test "$f" --flavor dev --dart-define-from-file=../../minglit_env/dev/flutter.env
             done
 
   partner-cuj-test:
@@ -111,9 +109,7 @@ jobs:
               [ -f "$f" ] || break
               found=1
               echo "▶ Running: $f"
-              flutter test "$f" \
-                --flavor dev \
-                --dart-define-from-file=../../minglit_env/dev/flutter.env
+              flutter test "$f" --flavor dev --dart-define-from-file=../../minglit_env/dev/flutter.env
             done
             [ "$found" -eq 0 ] && echo "⏭ No integration tests found, skipping."
 


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

## 문제

`android-emulator-runner@v2`의 `script:` 블록에서 `\` (backslash line continuation)가 포함된 multi-line `flutter test` 명령이 파싱 실패.

러너가 각 줄을 별도 `/usr/bin/sh -c`로 실행하면서 `for...do`와 `done`이 분리됨:
```
/usr/bin/sh -c for f in integration_test/*_test.dart; do
/usr/bin/sh: 1: Syntax error: end of file unexpected (expecting "done")
```

동일 실패 반복: #542, #703, #831, #916, #1063, #1105

## 수정

`client-cuj-test` 및 `partner-cuj-test` 양쪽의 `flutter test` 명령에서 backslash continuation을 제거하고 단일 라인으로 변경.

## 검증

- `.github/workflows/daily-backend-simulation.yml` 변경사항만 포함 (CI 파이프라인 변경이므로 unit test 없음)
- `workflow_dispatch`로 수동 실행하여 확인 가능

Closes #1105