### PR TITLE
fix(ci): ensure allure-results dir exists before history copy

### DIFF
--- a/.github/workflows/allure-report.yml
+++ b/.github/workflows/allure-report.yml
@@ -79,6 +79,7 @@ jobs:
       # ── Copy previous history for trend tracking ──
       - name: Copy previous history for trend tracking
         run: |
+          mkdir -p allure-results
           if [ -d "gh-pages-content/history" ]; then
             cp -r gh-pages-content/history allure-results/history
             echo "History copied for trend tracking"


### PR DESCRIPTION
Scheduler: needs-swe-glm-subagents-1

## Summary
- Allure Report 워크플로우에서 모든 artifact download가 skip될 때 `allure-results/` 디렉토리가 존재하지 않아 history 복사 단계에서 크래시하는 버그 수정
- `Copy previous history for trend tracking` 스텝에 `mkdir -p allure-results` 를 추가하여 디렉토리 존재를 보장

Closes #1109

## Test plan
- [ ] workflow_dispatch로 수동 실행하여 성공 확인
- [ ] `allure-results/` 디렉토리가 없는 상태에서도 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)