### PR TITLE
fix(deps): device_info_plus를 12.4.0 미만으로 고정하여 iOS 빌드 복구

### DIFF
--- a/shared/packages/minglit_kit/pubspec.yaml
+++ b/shared/packages/minglit_kit/pubspec.yaml
@@ -14,7 +14,8 @@ dependencies:
   connectivity_plus: ^6.1.3
   crypto: ^3.0.5
   cryptography: ^2.9.0
-  device_info_plus: ^12.4.0
+  # Fix #1111: device_info_plus 12.4.0 uses isiOSAppOnVision (iOS 16+ SDK) without availability guard — cap below 12.4.0
+  device_info_plus: ">=12.0.0 <12.4.0"
   dio: ^5.9.0
   file_picker: ^10.3.8
   firebase_core: ^4.3.0


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1111

## 문제

`device_info_plus` 12.4.0이 iOS 네이티브 코드에서 `isiOSAppOnVision` 셀렉터를 가용성 가드 없이 호출하여 CI 러너의 iOS SDK에서 ARC Semantic Issue 컴파일 오류 발생.

```
ARC Semantic Issue (Xcode): No visible @interface for 'NSProcessInfo' declares the selector 'isiOSAppOnVision'
```

## 수정

`minglit_kit/pubspec.yaml`에서 `device_info_plus: ^12.4.0` → `">=12.0.0 <12.4.0"` 으로 제약 변경하여 12.3.x 최신 버전을 사용.

## 영향 범위

- `shared/packages/minglit_kit/pubspec.yaml` 1줄 변경
- iOS 빌드 복구 (app_user, app_partner)
- Android / Vercel 영향 없음