### PR TITLE
refactor(ef): auth_utils 마이그레이션 + jose import map + github-stats-sync 테스트

### DIFF
--- a/supabase/deno.json
+++ b/supabase/deno.json
@@ -4,7 +4,8 @@
     "@std/assert": "jsr:@std/assert@1",
     "@std/testing/mock": "jsr:@std/testing@1/mock",
     "@std/testing/time": "jsr:@std/testing@1/time",
-    "https://deno.land/std@0.168.0/http/server.ts": "./functions/_test_utils/std_server_stub.ts"
+    "https://deno.land/std@0.168.0/http/server.ts": "./functions/_test_utils/std_server_stub.ts",
+    "jose": "https://deno.land/x/jose@v4.15.5/index.ts"
   },
   "unstable": ["temporal"]
 }

--- a/supabase/functions/github-stats-sync/deno.json
+++ b/supabase/functions/github-stats-sync/deno.json
@@ -1,5 +1,10 @@
 {
   "imports": {
-    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2",
+    "@std/assert": "jsr:@std/assert@1",
+    "@std/testing/mock": "jsr:@std/testing@1/mock"
+  },
+  "tasks": {
+    "test": "deno test --allow-env --allow-net --allow-read"
   }
 }

--- a/supabase/functions/github-stats-sync/github_stats_sync_test.ts
+++ b/supabase/functions/github-stats-sync/github_stats_sync_test.ts
@@ -1,0 +1,54 @@
+import { assertEquals } from "@std/assert";
+import {
+  captureServeHandler,
+  createFetchMock,
+  jsonRequest,
+  jsonResponse,
+  readJson,
+  withEnv,
+  withMockedFetch,
+} from "../_test_utils/mock_http.ts";
+
+const ENV = {
+  SUPABASE_URL: "https://supabase.test",
+  SUPABASE_SERVICE_ROLE_KEY: "valid-key",
+};
+
+Deno.test("github-stats-sync - unauthorized request returns 401", async () => {
+  await withEnv(ENV, async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const request = jsonRequest("http://localhost", {}, {
+      headers: { Authorization: "Bearer wrong-key" },
+    });
+    const response = await handler(request);
+    assertEquals(response.status, 401);
+  });
+});
+
+Deno.test("github-stats-sync - authorized request is processed", async () => {
+  await withEnv(ENV, async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: (req: Request) => req.url.includes("api.github.com"),
+        handler: () => jsonResponse([]),
+      },
+      {
+        matcher: (req: Request) => req.url.includes("/rest/v1/rpc/upsert_github_daily_stat"),
+        handler: () => jsonResponse(null),
+      },
+    ]);
+
+    await withMockedFetch(fetchMock, async () => {
+      const request = jsonRequest("http://localhost", {}, {
+        headers: { Authorization: "Bearer valid-key" },
+      });
+      const response = await handler(request);
+      const payload = await readJson(response);
+
+      assertEquals(response.status, 200);
+      assertEquals(payload.success, true);
+    });
+  });
+});

--- a/supabase/functions/github-stats-sync/index.ts
+++ b/supabase/functions/github-stats-sync/index.ts
@@ -7,6 +7,7 @@ import {
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
+import { requireServiceRole } from "../_shared/auth_utils.ts";
 
 const REPO = "Mark-Yun/minglit";
 const GITHUB_API = "https://api.github.com";
@@ -22,14 +23,11 @@ interface GitHubItem {
 Deno.serve(async (req: Request): Promise<Response> => {
   if (req.method === "OPTIONS") return corsResponse();
 
-  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
   const githubToken = Deno.env.get("GITHUB_ACCESS_TOKEN");
 
-  // Fix #380: service role key 검증 추가 — verify_jwt=false이므로 자체 인증 필수
-  const authHeader = req.headers.get("Authorization") ?? "";
-  if (!serviceRoleKey || authHeader !== `Bearer ${serviceRoleKey}`) {
-    return errorResponse("Unauthorized", 401);
-  }
+  // Fix #1121: requireServiceRole로 통일 (auth_utils 마이그레이션)
+  const authResult = requireServiceRole(req);
+  if (authResult !== true) return authResult;
 
   const supabase = createServiceClient();
 

--- a/supabase/functions/notification-worker/deno.json
+++ b/supabase/functions/notification-worker/deno.json
@@ -2,7 +2,8 @@
   "imports": {
     "@supabase/supabase-js": "jsr:@supabase/supabase-js@2",
     "@std/assert": "jsr:@std/assert@1",
-    "@std/testing/mock": "jsr:@std/testing@1/mock"
+    "@std/testing/mock": "jsr:@std/testing@1/mock",
+    "jose": "https://deno.land/x/jose@v4.15.5/index.ts"
   },
   "tasks": {
     "test": "deno test --allow-env --allow-net --allow-read"

--- a/supabase/functions/notification-worker/index.ts
+++ b/supabase/functions/notification-worker/index.ts
@@ -3,7 +3,7 @@ import { requireEnv } from '../_shared/env_keystore.ts'
 import { runWorkerLoop } from './loop_worker.ts'
 import { WorkerUtils } from '../_shared/worker_utils.ts'
 import { isoToUnix } from '../_shared/temporal_utils.ts'
-import * as jose from 'https://deno.land/x/jose@v4.14.4/index.ts'
+import * as jose from 'jose'
 import { initSentry, withHandler, log } from '../_shared/logger.ts'
 
 const FN = "notification-worker";


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-2

Closes #1121

## 변경 요약

- **github-stats-sync**: 인라인 service role 체크 → `requireServiceRole()` 교체
- **github-stats-sync**: 기본 contract 테스트 추가 (401/200)
- **notification-worker**: jose URL import → deno.json import map (v4.14.4 → v4.15.5, CVE-2024-28176 해소)

## 상세

### github-stats-sync auth 마이그레이션
- `SUPABASE_SERVICE_ROLE_KEY` 수동 비교 블록을 `_shared/auth_utils.requireServiceRole()` 호출로 교체
- 패턴 Fix #179 참고

### github-stats-sync 테스트
- 인증 없는 요청 → 401 검증
- 올바른 서비스 롤 키로 요청 시 GitHub API + Supabase RPC 모킹 → 200 검증

### notification-worker jose
- `https://deno.land/x/jose@v4.14.4/index.ts` URL import → `deno.json` import map 항목으로 이전
- v4.15.5로 업그레이드 (CVE-2024-28176 해소)