### PR TITLE
ci: EF deno.json 누락 탐지 + iOS SDK 호환성 주석

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,24 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
+      - name: Validate deno.json presence
+        run: |
+          missing=()
+          for dir in functions/*/; do
+            name=$(basename "$dir")
+            if [[ "$name" != _* ]] && [ ! -f "${dir}deno.json" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "❌ deno.json missing in the following Edge Functions:"
+            for ef in "${missing[@]}"; do
+              echo "  - $ef"
+            done
+            exit 1
+          fi
+          echo "✅ All Edge Functions have deno.json"
+        working-directory: supabase
       - name: Test (edge functions)
         run: deno test --allow-all functions/
         working-directory: supabase

--- a/apps/app_partner/pubspec.yaml
+++ b/apps/app_partner/pubspec.yaml
@@ -43,22 +43,22 @@ dependencies:
   flutter_riverpod: ^3.0.3
   freezed_annotation: ^3.1.0
   go_router: ^17.0.0
-  google_sign_in: 7.2.0
-  image_picker: ^1.2.1
+  google_sign_in: 7.2.0  # iOS: GoogleService-Info.plist required
+  image_picker: ^1.2.1  # iOS: camera/photo permissions
   intl: ^0.20.2
   kakao_map_plugin: ^0.4.0
   minglit_kit:
     path: ../../shared/packages/minglit_kit
-  mobile_scanner: any
-  package_info_plus: ^9.0.1
+  mobile_scanner: any  # iOS: camera permission
+  package_info_plus: ^9.0.1  # iOS: CFBundleVersion (Info.plist)
   path: any
   riverpod: ^3.0.3
   riverpod_annotation: ^3.0.3
-  sentry_flutter: ^9.0.0
-  share_plus: ^12.0.1
+  sentry_flutter: ^9.0.0  # iOS: native crash reporting
+  share_plus: ^12.0.1  # iOS: share sheet
   shared_preferences: ^2.5.4
   supabase_flutter: ^2.12.0
-  url_launcher: ^6.3.2
+  url_launcher: ^6.3.2  # iOS: LSApplicationQueriesSchemes (Info.plist)
   uuid: ^4.5.2
   web: ^1.1.1
 

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -30,7 +30,7 @@ environment:
 # versions available, run `flutter pub outdated`.
 dependencies:
   cupertino_icons: ^1.0.8
-  file_picker: ^10.3.8
+  file_picker: ^10.3.8  # iOS: native file picker
   firebase_core: ^4.3.0
   flutter:
     sdk: flutter
@@ -39,10 +39,10 @@ dependencies:
   flutter_native_splash: ^2.4.3
   flutter_quill: ^11.5.0
   flutter_riverpod: ^3.0.3
-  flutter_secure_storage: ^10.0.0
+  flutter_secure_storage: ^10.0.0  # iOS: Keychain
   freezed_annotation: ^3.1.0
   go_router: ^17.0.0
-  google_sign_in: 7.2.0
+  google_sign_in: 7.2.0  # iOS: GoogleService-Info.plist required
   http: ^1.6.0
   intl: ^0.20.2
   kakao_map_plugin: ^0.4.0
@@ -52,12 +52,12 @@ dependencies:
   qr_flutter: ^4.1.0
   riverpod: ^3.0.3
   riverpod_annotation: ^3.0.3
-  screen_brightness: ^2.1.7
-  sentry_flutter: ^9.0.0
-  share_plus: ^12.0.1
+  screen_brightness: ^2.1.7  # iOS: UIScreen brightness API
+  sentry_flutter: ^9.0.0  # iOS: native crash reporting
+  share_plus: ^12.0.1  # iOS: share sheet
   shared_preferences: ^2.5.4
   supabase_flutter: ^2.12.0
-  url_launcher: ^6.3.2
+  url_launcher: ^6.3.2  # iOS: LSApplicationQueriesSchemes (Info.plist)
 
 dev_dependencies:
   alchemist: ^0.14.0

--- a/supabase/functions/recurrence-rules/deno.json
+++ b/supabase/functions/recurrence-rules/deno.json
@@ -1,0 +1,10 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2",
+    "@std/assert": "jsr:@std/assert@1",
+    "@std/testing/mock": "jsr:@std/testing@1/mock"
+  },
+  "tasks": {
+    "test": "deno test --allow-env --allow-net"
+  }
+}


### PR DESCRIPTION
Scheduler: needs-arch-claude-team-1

## Summary
- `test-edge-functions` CI job에 deno.json 누락 검증 step 추가 (PR 단계에서 사전 탐지)
- `recurrence-rules` EF에 누락된 `deno.json` 추가
- `app_user`, `app_partner` pubspec.yaml에 iOS native plugin 호환성 주석 표준화

## Background
QA 감사(#1114)에서 식별된 반복 CI 실패 패턴 2건에 대한 사전 방지:
1. EF deno.json 누락 → 배포 실패 (#897, #1048)
2. iOS SDK 비호환 패키지 → 빌드 실패 (#1083, #1081, #1111)

## Test plan
- [ ] CI `ci-result` 통과 확인
- [ ] `test-edge-functions` job에서 deno.json validation step 실행 확인
- [ ] pubspec.yaml 변경이 Flutter 테스트에 영향 없음 확인

Closes #1124

🤖 Generated with [Claude Code](https://claude.com/claude-code)