### PR TITLE
fix(ci): extract android-emulator-runner scripts to bash files (#1128)

### DIFF
--- a/.github/scripts/run-client-cuj.sh
+++ b/.github/scripts/run-client-cuj.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd apps/app_user
+for f in integration_test/*_test.dart; do
+  [ -f "$f" ] || { echo "⏭ No integration tests found, skipping."; break; }
+  echo "▶ Running: $f"
+  flutter test "$f" --flavor dev --dart-define-from-file=../../minglit_env/dev/flutter.env
+done

--- a/.github/scripts/run-partner-cuj.sh
+++ b/.github/scripts/run-partner-cuj.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd apps/app_partner
+found=0
+for f in integration_test/*_test.dart; do
+  [ -f "$f" ] || break
+  found=1
+  echo "▶ Running: $f"
+  flutter test "$f" --flavor dev --dart-define-from-file=../../minglit_env/dev/flutter.env
+done
+[ "$found" -eq 0 ] && echo "⏭ No integration tests found, skipping."

--- a/.github/workflows/daily-backend-simulation.yml
+++ b/.github/workflows/daily-backend-simulation.yml
@@ -70,13 +70,7 @@ jobs:
           api-level: 33
           arch: x86_64
           profile: pixel_6
-          script: |
-            cd apps/app_user
-            for f in integration_test/*_test.dart; do
-              [ -f "$f" ] || { echo "⏭ No integration tests found, skipping."; break; }
-              echo "▶ Running: $f"
-              flutter test "$f" --flavor dev --dart-define-from-file=../../minglit_env/dev/flutter.env
-            done
+          script: bash .github/scripts/run-client-cuj.sh
 
   partner-cuj-test:
     needs: seed-and-simulate
@@ -102,16 +96,7 @@ jobs:
           api-level: 33
           arch: x86_64
           profile: pixel_6
-          script: |
-            cd apps/app_partner
-            found=0
-            for f in integration_test/*_test.dart; do
-              [ -f "$f" ] || break
-              found=1
-              echo "▶ Running: $f"
-              flutter test "$f" --flavor dev --dart-define-from-file=../../minglit_env/dev/flutter.env
-            done
-            [ "$found" -eq 0 ] && echo "⏭ No integration tests found, skipping."
+          script: bash .github/scripts/run-partner-cuj.sh
 
   notify-failure:
     needs: [seed-and-simulate, client-cuj-test, partner-cuj-test]


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1128

## 문제

`android-emulator-runner@v2`의 `script:` 파라미터가 YAML multi-line 블록을 `sh -c`에 줄 단위로 전달하여, `for...done` 루프가 첫 줄만 실행되고 문법 오류 발생:

```
[command]/usr/bin/sh -c for f in integration_test/*_test.dart; do
/usr/bin/sh: 1: Syntax error: end of file unexpected (expecting "done")
```

## 해결

multi-line 스크립트를 `.github/scripts/` 디렉토리의 별도 bash 파일로 추출하고, `script:` 파라미터를 단일 라인 호출로 변경.

## 변경 사항

- `.github/scripts/run-client-cuj.sh` 신규 추가
- `.github/scripts/run-partner-cuj.sh` 신규 추가
- `.github/workflows/daily-backend-simulation.yml` — script: 블록을 bash 파일 호출로 교체

## 테스트 계획

- [ ] `daily-backend-simulation.yml` CI 재실행으로 두 CUJ 테스트 job 통과 확인
- [ ] `workflow_dispatch`로 수동 트리거 후 확인