### PR TITLE
fix(ci): replace gai.conf with /etc/hosts IPv4 override for psql

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -92,8 +92,14 @@ jobs:
           DB_PASSWORD: ${{ steps.env.outputs.DB_PASSWORD }}
           PROJECT_ID: ${{ steps.env.outputs.PROJECT_ID }}
         run: |
-          # Fix #669: GitHub Actions 러너 IPv6 미지원 — IPv4 우선으로 변경
-          sudo sh -c 'echo "precedence ::ffff:0:0/96 100" >> /etc/gai.conf'
+          # Fix #1130: gai.conf IPv4 precedence not effective for psql — /etc/hosts override
+          IPV4=$(dig +short A "db.${PROJECT_ID}.supabase.co" | head -1)
+          if [ -z "$IPV4" ]; then
+            echo "::error::Failed to resolve IPv4 for db.${PROJECT_ID}.supabase.co"
+            exit 1
+          fi
+          echo "${IPV4} db.${PROJECT_ID}.supabase.co" | sudo tee -a /etc/hosts > /dev/null
+          echo "Resolved db.${PROJECT_ID}.supabase.co → ${IPV4}"
 
           REQUIRED=$(jq -r '.vault.required | keys[]' env-manifest.json)
           VAULT_MISSING=""


### PR DESCRIPTION
Scheduler: needs-swe-glm-subagents-1

## Summary

- Replace ineffective `gai.conf` IPv4 precedence approach with `/etc/hosts` override in `Verify vault secrets` step
- Resolve IPv4 via `dig +short A` and inject into `/etc/hosts` so psql connects over IPv4 while preserving SSL cert hostname validation

Closes #1130

## Root Cause

`gai.conf` `precedence` setting is ignored by libpq (PostgreSQL client library). The DNS resolver returns IPv6 address first, and GitHub Actions runners don't support IPv6 connectivity, causing all psql connections to fail with `Network is unreachable`.

## Fix

`/etc/hosts` entries take priority over DNS for all system resolvers including libpq. By resolving the IPv4 address first and adding it to `/etc/hosts`, psql connects via IPv4 while still using the correct hostname for SSL cert validation.

## Test plan

- [ ] Manually trigger `Deploy Supabase Migrations` workflow on this branch
- [ ] Verify `Verify vault secrets` step passes (connects via IPv4)
- [ ] Confirm vault secret check results are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)