### PR TITLE
fix(ci): DNS resolution fallback for Supabase deploy (#1153)

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -95,10 +95,25 @@ jobs:
           # Fix #1130: gai.conf IPv4 precedence not effective for psql — /etc/hosts override
           # Fix #1153: dig +short A returns empty on some runners — fallback chain
           HOST="db.${PROJECT_ID}.supabase.co"
-          IPV4=$(dig +short A "$HOST" | head -1)
-          : "${IPV4:=$(getent ahostsv4 "$HOST" 2>/dev/null | head -1 | awk '{print $1}')}"
-          : "${IPV4:=$(nslookup -type=A "$HOST" 2>/dev/null | grep 'Address:' | tail -1 | awk '{print $2}')}"
-          : "${IPV4:=$(host -t A "$HOST" 2>/dev/null | awk '/has address/ {print $4; exit}')}"
+          is_valid_ipv4() {
+            [[ $1 =~ ^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])$ ]]
+          }
+          IPV4=""
+          CANDIDATE=$(dig +short A "$HOST" | head -1)
+          is_valid_ipv4 "$CANDIDATE" && IPV4="$CANDIDATE"
+          if [ -z "$IPV4" ]; then
+            CANDIDATE=$(getent ahostsv4 "$HOST" 2>/dev/null | head -1 | awk '{print $1}')
+            is_valid_ipv4 "$CANDIDATE" && IPV4="$CANDIDATE"
+          fi
+          if [ -z "$IPV4" ]; then
+            # Use "^Address: " (space) to exclude the DNS server line "Address:\t8.8.8.8#53" (tab)
+            CANDIDATE=$(nslookup -type=A "$HOST" 2>/dev/null | awk '/^Address: /{print $2}' | tail -1)
+            is_valid_ipv4 "$CANDIDATE" && IPV4="$CANDIDATE"
+          fi
+          if [ -z "$IPV4" ]; then
+            CANDIDATE=$(host -t A "$HOST" 2>/dev/null | awk '/has address/ {print $4; exit}')
+            is_valid_ipv4 "$CANDIDATE" && IPV4="$CANDIDATE"
+          fi
           if [ -z "$IPV4" ]; then
             echo "::error::Failed to resolve IPv4 for ${HOST} (tried dig, getent, nslookup, host)"
             exit 1

--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -93,13 +93,18 @@ jobs:
           PROJECT_ID: ${{ steps.env.outputs.PROJECT_ID }}
         run: |
           # Fix #1130: gai.conf IPv4 precedence not effective for psql — /etc/hosts override
-          IPV4=$(dig +short A "db.${PROJECT_ID}.supabase.co" | head -1)
+          # Fix #1153: dig +short A returns empty on some runners — fallback chain
+          HOST="db.${PROJECT_ID}.supabase.co"
+          IPV4=$(dig +short A "$HOST" | head -1)
+          : "${IPV4:=$(getent ahostsv4 "$HOST" 2>/dev/null | head -1 | awk '{print $1}')}"
+          : "${IPV4:=$(nslookup -type=A "$HOST" 2>/dev/null | grep 'Address:' | tail -1 | awk '{print $2}')}"
+          : "${IPV4:=$(host -t A "$HOST" 2>/dev/null | awk '/has address/ {print $4; exit}')}"
           if [ -z "$IPV4" ]; then
-            echo "::error::Failed to resolve IPv4 for db.${PROJECT_ID}.supabase.co"
+            echo "::error::Failed to resolve IPv4 for ${HOST} (tried dig, getent, nslookup, host)"
             exit 1
           fi
-          echo "${IPV4} db.${PROJECT_ID}.supabase.co" | sudo tee -a /etc/hosts > /dev/null
-          echo "Resolved db.${PROJECT_ID}.supabase.co → ${IPV4}"
+          echo "${IPV4} ${HOST}" | sudo tee -a /etc/hosts > /dev/null
+          echo "Resolved ${HOST} → ${IPV4}"
 
           REQUIRED=$(jq -r '.vault.required | keys[]' env-manifest.json)
           VAULT_MISSING=""


### PR DESCRIPTION
Scheduler: needs-swe-glm-subagents-1

## Summary

- `dig +short A` returns empty on some GitHub Actions Ubuntu 24.04 runners, causing "Verify vault secrets" step to fail with `Failed to resolve IPv4 for db.***.supabase.co`
- Add fallback DNS resolution chain: `dig` → `getent ahostsv4` → `nslookup` → `host` using bash `${VAR:=default}` pattern
- Only the DNS resolution logic changed; vault verification logic untouched

Closes #1153

## Test plan

- [ ] Verify this PR triggers the `Deploy Supabase Migrations` workflow (push to dev with `supabase-deploy.yml` changed)
- [ ] Confirm "Verify vault secrets" step resolves IPv4 successfully via one of the fallback methods
- [ ] Confirm vault secret verification passes after DNS resolution succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)