### PR TITLE
fix: create CUJ Flutter env in CI

### DIFF
--- a/.github/scripts/create-dev-flutter-env.sh
+++ b/.github/scripts/create-dev-flutter-env.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${SUPABASE_URL:?SUPABASE_URL is required}"
+: "${SUPABASE_PUBLISHABLE_KEY:?SUPABASE_PUBLISHABLE_KEY is required}"
+
+env_file="minglit_env/dev/flutter.env"
+
+# Fix #1169: CI checkout does not include the private minglit_env submodule, so
+# rebuild the dev Flutter env file from Actions secrets before CUJ tests.
+umask 077
+mkdir -p "$(dirname "$env_file")"
+cat >"$env_file" <<EOF
+SUPABASE_URL=$SUPABASE_URL
+SUPABASE_PUBLISHABLE_KEY=$SUPABASE_PUBLISHABLE_KEY
+ENVIRONMENT=${ENVIRONMENT:-development}
+SENTRY_DSN=${SENTRY_DSN:-}
+STATSIG_CLIENT_KEY=${STATSIG_CLIENT_KEY:-}
+GOOGLE_WEB_CLIENT_ID=${GOOGLE_WEB_CLIENT_ID:-}
+KAKAO_LOCAL_REST_API_KEY=${KAKAO_LOCAL_REST_API_KEY:-}
+KAKAO_MAP_JAVASCRIPT_KEY=${KAKAO_MAP_JAVASCRIPT_KEY:-}
+JUSO_CONFIRM_KEY=${JUSO_CONFIRM_KEY:-}
+IAMPORT_USER_CODE=${IAMPORT_USER_CODE:-}
+MOBILE_REDIRECT_SCHEME=${MOBILE_REDIRECT_SCHEME:-}
+EOF
+
+echo "Created $env_file"

--- a/.github/workflows/daily-backend-simulation.yml
+++ b/.github/workflows/daily-backend-simulation.yml
@@ -58,6 +58,17 @@ jobs:
           flutter-version: '3.x'
           channel: 'stable'
 
+      - name: Create dev Flutter env file
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_DEV_URL }}
+          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }}
+          ENVIRONMENT: development
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN_FLUTTER }}
+          STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
+          GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_DEV_WEB_CLIENT_ID }}
+          KAKAO_LOCAL_REST_API_KEY: ${{ secrets.KAKAO_LOCAL_REST_API_KEY }}
+        run: bash .github/scripts/create-dev-flutter-env.sh
+
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -83,6 +94,17 @@ jobs:
         with:
           flutter-version: '3.x'
           channel: 'stable'
+
+      - name: Create dev Flutter env file
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_DEV_URL }}
+          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }}
+          ENVIRONMENT: development
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN_FLUTTER }}
+          STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
+          GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_DEV_WEB_CLIENT_ID }}
+          KAKAO_LOCAL_REST_API_KEY: ${{ secrets.KAKAO_LOCAL_REST_API_KEY }}
+        run: bash .github/scripts/create-dev-flutter-env.sh
 
       - name: Enable KVM
         run: |


### PR DESCRIPTION
Scheduler: needs-swe-codex-1

Closes #1169

## Summary
- Add a CI helper that rebuilds minglit_env/dev/flutter.env from GitHub Actions secrets.
- Run the helper before client and partner CUJ emulator tests in the daily backend simulation workflow.

## Tests
- bash -n .github/scripts/run-client-cuj.sh .github/scripts/run-partner-cuj.sh .github/scripts/create-dev-flutter-env.sh
- ruby -e 'require "psych"; Psych.load_file(".github/workflows/daily-backend-simulation.yml"); puts "yaml ok"'\n- fake-env run of .github/scripts/create-dev-flutter-env.sh in a temp directory\n- git diff --cached --check\n\n## Notes\n- actionlint is not installed in this worker environment, so YAML validation used Ruby Psych instead.