### PR TITLE
fix(ci): Seed Dev skipped run에서 notify-failure 차단 (#1184)

### DIFF
--- a/.github/workflows/seed-dev.yml
+++ b/.github/workflows/seed-dev.yml
@@ -77,7 +77,7 @@ jobs:
 
   notify-failure:
     needs: [seed]
-    if: always()
+    if: ${{ always() && needs.seed.result == 'failure' }}
     permissions:
       issues: write
     uses: ./.github/workflows/notify-failure.yml


### PR DESCRIPTION
Scheduler: needs-swe-codex-1

## Summary
- run `notify-failure` only when the `seed` job actually fails
- stop calling the reusable failure notifier on `skipped`, `success`, and `cancelled` seed results
- keep the existing failure issue behavior unchanged for real seeder failures

## Validation
- Ruby YAML parse for `.github/workflows/seed-dev.yml`

Closes #1184
