### PR TITLE
fix(security): tag_usage_monthly RLS auth.role() 통일 (#1190)

### DIFF
--- a/supabase/migrations/20260410000002_tag_monthly_rls_auth_role.sql
+++ b/supabase/migrations/20260410000002_tag_monthly_rls_auth_role.sql
@@ -1,0 +1,10 @@
+-- Fix #1190: tag_usage_monthly RLS 정책 current_setting('role', true) → auth.role() 교체
+-- Issue #1182 Finding #7 (Security Audit #1175): auth.role() 패턴 통일
+-- PR #1188에서 신규 생성된 tag_usage_monthly 테이블이 교체 범위에서 누락됨
+
+DROP POLICY IF EXISTS tag_usage_monthly_service ON tag_usage_monthly;
+
+-- Fix #1190: deprecated current_setting('role', true) → auth.role() 패턴으로 통일
+CREATE POLICY tag_usage_monthly_service ON tag_usage_monthly FOR ALL USING (
+  auth.role() = 'service_role'
+);

--- a/supabase/tests/database/67_tag_monthly_rls_test.sql
+++ b/supabase/tests/database/67_tag_monthly_rls_test.sql
@@ -1,0 +1,72 @@
+BEGIN;
+SELECT no_plan();
+
+-- ============================================================
+-- Issue #1190: tag_usage_monthly RLS auth.role() 검증
+-- Finding #7: current_setting('role', true) → auth.role() 통일
+-- ============================================================
+
+-- 테스트 데이터 세팅
+SELECT tests.create_supabase_user('monthly_user_a', 'monthly_a@test.com');
+
+SELECT tests.authenticate_as_service_role();
+
+WITH t AS (
+  INSERT INTO public.tags (name, is_featured, usage_count)
+  VALUES ('monthly_rls_test_tag', false, 0)
+  RETURNING id
+)
+SELECT set_config('tests.monthly_tag_id', id::text, true) FROM t;
+
+-- ============================================================
+-- authenticated 유저는 tag_usage_monthly에 직접 쓰기 불가
+-- ============================================================
+
+SELECT tests.authenticate_as('monthly_user_a');
+
+SAVEPOINT before_auth_tum_insert;
+SELECT throws_ok(
+  format(
+    $$
+      INSERT INTO public.tag_usage_monthly (tag_id, month, monthly_count)
+      VALUES ('%s', '2024-01-01', 100)
+    $$,
+    current_setting('tests.monthly_tag_id')
+  ),
+  NULL,
+  NULL,
+  'Fix #1190: authenticated user cannot INSERT tag_usage_monthly (auth.role() guard)'
+);
+ROLLBACK TO SAVEPOINT before_auth_tum_insert;
+
+-- ============================================================
+-- service_role은 tag_usage_monthly에 쓰기 가능
+-- ============================================================
+
+SELECT tests.authenticate_as_service_role();
+
+SELECT lives_ok(
+  format(
+    $$
+      INSERT INTO public.tag_usage_monthly (tag_id, month, monthly_count)
+      VALUES ('%s', '2024-01-01', 100)
+      ON CONFLICT (tag_id, month) DO NOTHING
+    $$,
+    current_setting('tests.monthly_tag_id')
+  ),
+  'Fix #1190: service_role can INSERT tag_usage_monthly (auth.role() guard)'
+);
+
+-- ============================================================
+-- authenticated 유저는 tag_usage_monthly 읽기 가능
+-- ============================================================
+
+SELECT tests.authenticate_as('monthly_user_a');
+
+SELECT lives_ok(
+  $$SELECT count(*) FROM public.tag_usage_monthly$$,
+  'Fix #1190: authenticated user can SELECT tag_usage_monthly (read policy)'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-2

Closes #1190

## Summary

PR #1188에서 신규 생성된 `tag_usage_monthly` 테이블의 RLS 정책이 Security Audit #1182 Finding #7의 `auth.role()` 통일 교체 범위에서 누락됨.

## 파일 변경

- `supabase/migrations/20260410000002_tag_monthly_rls_auth_role.sql` — 신규 migration
- `supabase/tests/database/67_tag_monthly_rls_test.sql` — pgTAP 검증

## Test plan

- [ ] test-supabase 통과 (67_tag_monthly_rls_test.sql)
- [ ] authenticated user → INSERT throws error (RLS 차단)
- [ ] service_role → INSERT OK