### PR TITLE
refactor(ui): BorderRadius + Colors.white 하드코딩 → 디자인 토큰 교체

### DIFF
--- a/apps/app_partner/lib/src/features/account_deletion/ui/deletion_info_page.dart
+++ b/apps/app_partner/lib/src/features/account_deletion/ui/deletion_info_page.dart
@@ -36,7 +36,8 @@ class DeletionInfoPage extends ConsumerWidget {
                       padding: const EdgeInsets.all(MinglitSpacing.medium),
                       decoration: BoxDecoration(
                         color: theme.colorScheme.secondaryContainer,
-                        borderRadius: BorderRadius.circular(16),
+                        // Fix #1195: BorderRadius 하드코딩 → MinglitRadius.card 토큰
+                        borderRadius: BorderRadius.circular(MinglitRadius.card),
                       ),
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
@@ -83,7 +84,7 @@ class DeletionInfoPage extends ConsumerWidget {
                     padding: const EdgeInsets.all(MinglitSpacing.medium),
                     decoration: BoxDecoration(
                       color: MinglitColors.error.withValues(alpha: 0.08),
-                      borderRadius: BorderRadius.circular(16),
+                      borderRadius: BorderRadius.circular(MinglitRadius.card),
                     ),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,

--- a/apps/app_partner/lib/src/features/settlement/settlement_page.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_page.dart
@@ -186,17 +186,18 @@ class _RevenueSummaryCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          // Fix #1195: Colors.white → colorScheme.onPrimary + MinglitOpacity 토큰
           Text(
             '이번 달 총 매출',
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: Colors.white.withValues(alpha: 0.8),
+              color: colorScheme.onPrimary.withValues(alpha: MinglitOpacity.scrimLight),
             ),
           ),
           const SizedBox(height: MinglitSpacing.xsmall),
           Text(
             '₩${fmt.format(totalGross)}',
             style: Theme.of(context).textTheme.displayLarge?.copyWith(
-              color: Colors.white,
+              color: colorScheme.onPrimary,
               fontWeight: FontWeight.w900,
               letterSpacing: -1,
             ),
@@ -208,13 +209,13 @@ class _RevenueSummaryCard extends StatelessWidget {
               Text(
                 '정산 완료',
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Colors.white.withValues(alpha: 0.7),
+                  color: colorScheme.onPrimary.withValues(alpha: MinglitOpacity.scrimLight),
                 ),
               ),
               Text(
                 '₩${fmt.format(totalNet)}',
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Colors.white,
+                  color: colorScheme.onPrimary,
                   fontWeight: FontWeight.w600,
                 ),
               ),
@@ -227,13 +228,13 @@ class _RevenueSummaryCard extends StatelessWidget {
               Text(
                 '정산 대기',
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Colors.white.withValues(alpha: 0.7),
+                  color: colorScheme.onPrimary.withValues(alpha: MinglitOpacity.scrimLight),
                 ),
               ),
               Text(
                 '₩${fmt.format(pendingTotal)}',
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Colors.white,
+                  color: colorScheme.onPrimary,
                   fontWeight: FontWeight.w600,
                 ),
               ),

--- a/apps/app_partner/lib/src/features/settlement/widgets/settlement_shimmer.dart
+++ b/apps/app_partner/lib/src/features/settlement/widgets/settlement_shimmer.dart
@@ -128,7 +128,8 @@ class _ShimmerBox extends StatelessWidget {
       width: width,
       height: height,
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(4),
+        // Fix #1195: BorderRadius 하드코딩 → MinglitRadius.badge 토큰
+        borderRadius: BorderRadius.circular(MinglitRadius.badge),
         gradient: LinearGradient(
           colors: [baseColor, highlightColor, baseColor],
           stops: [

--- a/apps/app_user/lib/src/features/account_deletion/ui/deletion_info_page.dart
+++ b/apps/app_user/lib/src/features/account_deletion/ui/deletion_info_page.dart
@@ -36,7 +36,8 @@ class DeletionInfoPage extends ConsumerWidget {
                       padding: const EdgeInsets.all(MinglitSpacing.medium),
                       decoration: BoxDecoration(
                         color: theme.colorScheme.secondaryContainer,
-                        borderRadius: BorderRadius.circular(16),
+                        // Fix #1195: BorderRadius 하드코딩 → MinglitRadius.card 토큰
+                        borderRadius: BorderRadius.circular(MinglitRadius.card),
                       ),
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
@@ -83,7 +84,7 @@ class DeletionInfoPage extends ConsumerWidget {
                     padding: const EdgeInsets.all(MinglitSpacing.medium),
                     decoration: BoxDecoration(
                       color: MinglitColors.error.withValues(alpha: 0.08),
-                      borderRadius: BorderRadius.circular(16),
+                      borderRadius: BorderRadius.circular(MinglitRadius.card),
                     ),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,

--- a/apps/app_user/lib/src/features/my_tickets/ui/my_ticket_card.dart
+++ b/apps/app_user/lib/src/features/my_tickets/ui/my_ticket_card.dart
@@ -278,7 +278,8 @@ class _DDayChip extends StatelessWidget {
       ),
       decoration: BoxDecoration(
         color: bgColor,
-        borderRadius: BorderRadius.circular(100),
+        // Fix #1195: BorderRadius 하드코딩 → MinglitRadius.chip 토큰
+        borderRadius: BorderRadius.circular(MinglitRadius.chip),
         border: isPast
             ? Border.all(color: theme.colorScheme.outlineVariant)
             : null,


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-2

Closes #1195

## Summary

- `deletion_info_page.dart` (app_user, app_partner): `BorderRadius.circular(16)` → `MinglitRadius.card`
- `my_ticket_card.dart`: `BorderRadius.circular(100)` → `MinglitRadius.chip`
- `settlement_shimmer.dart`: `BorderRadius.circular(4)` → `MinglitRadius.badge`
- `settlement_page.dart`: `Colors.white` → `colorScheme.onPrimary` + `MinglitOpacity.scrimLight`

PR #972에서 누락된 BorderRadius + Colors.white 하드코딩을 디자인 토큰으로 일괄 교체.

## 시각적 동작 변화 없음

| 기존 | 교체 토큰 | 값 동일? |
|------|---------|--------|
| `BorderRadius.circular(16)` | `MinglitRadius.card` | ✅ 16.0 |
| `BorderRadius.circular(100)` | `MinglitRadius.chip` | ✅ 100.0 |
| `BorderRadius.circular(4)` | `MinglitRadius.badge` | ✅ 4.0 |
| `Colors.white` | `colorScheme.onPrimary` | ✅ 흰색 (Material3 라이트) |
| `alpha: 0.8` | `MinglitOpacity.scrimLight` | ✅ 0.8 |
| `alpha: 0.7` | `MinglitOpacity.scrimLight` | ⚠️ 0.8 (대응 토큰 없음, 가장 근접) |