### PR TITLE
refactor(ui): BorderRadius + Colors.white 하드코딩 → 디자인 토큰 교체

### DIFF
--- a/apps/app_partner/lib/src/features/account_deletion/ui/deletion_info_page.dart
+++ b/apps/app_partner/lib/src/features/account_deletion/ui/deletion_info_page.dart
@@ -36,7 +36,7 @@ class DeletionInfoPage extends ConsumerWidget {
                       padding: const EdgeInsets.all(MinglitSpacing.medium),
                       decoration: BoxDecoration(
                         color: theme.colorScheme.secondaryContainer,
-                        borderRadius: BorderRadius.circular(16),
+                        borderRadius: BorderRadius.circular(MinglitRadius.card),
                       ),
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
@@ -83,7 +83,7 @@ class DeletionInfoPage extends ConsumerWidget {
                     padding: const EdgeInsets.all(MinglitSpacing.medium),
                     decoration: BoxDecoration(
                       color: MinglitColors.error.withValues(alpha: 0.08),
-                      borderRadius: BorderRadius.circular(16),
+                      borderRadius: BorderRadius.circular(MinglitRadius.card),
                     ),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,

--- a/apps/app_partner/lib/src/features/settlement/settlement_page.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_page.dart
@@ -189,14 +189,14 @@ class _RevenueSummaryCard extends StatelessWidget {
           Text(
             '이번 달 총 매출',
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: Colors.white.withValues(alpha: 0.8),
+              color: colorScheme.onPrimary.withValues(alpha: MinglitOpacity.scrimLight),
             ),
           ),
           const SizedBox(height: MinglitSpacing.xsmall),
           Text(
             '₩${fmt.format(totalGross)}',
             style: Theme.of(context).textTheme.displayLarge?.copyWith(
-              color: Colors.white,
+              color: colorScheme.onPrimary,
               fontWeight: FontWeight.w900,
               letterSpacing: -1,
             ),
@@ -208,13 +208,13 @@ class _RevenueSummaryCard extends StatelessWidget {
               Text(
                 '정산 완료',
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Colors.white.withValues(alpha: 0.7),
+                  color: colorScheme.onPrimary.withValues(alpha: 0.7),
                 ),
               ),
               Text(
                 '₩${fmt.format(totalNet)}',
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Colors.white,
+                  color: colorScheme.onPrimary,
                   fontWeight: FontWeight.w600,
                 ),
               ),
@@ -227,13 +227,13 @@ class _RevenueSummaryCard extends StatelessWidget {
               Text(
                 '정산 대기',
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Colors.white.withValues(alpha: 0.7),
+                  color: colorScheme.onPrimary.withValues(alpha: 0.7),
                 ),
               ),
               Text(
                 '₩${fmt.format(pendingTotal)}',
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Colors.white,
+                  color: colorScheme.onPrimary,
                   fontWeight: FontWeight.w600,
                 ),
               ),

--- a/apps/app_partner/lib/src/features/settlement/settlement_page.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_page.dart
@@ -189,7 +189,9 @@ class _RevenueSummaryCard extends StatelessWidget {
           Text(
             '이번 달 총 매출',
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: colorScheme.onPrimary.withValues(alpha: MinglitOpacity.scrimLight),
+              color: colorScheme.onPrimary.withValues(
+                alpha: MinglitOpacity.scrimLight,
+              ),
             ),
           ),
           const SizedBox(height: MinglitSpacing.xsmall),

--- a/apps/app_partner/lib/src/features/settlement/widgets/settlement_shimmer.dart
+++ b/apps/app_partner/lib/src/features/settlement/widgets/settlement_shimmer.dart
@@ -128,7 +128,7 @@ class _ShimmerBox extends StatelessWidget {
       width: width,
       height: height,
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(4),
+        borderRadius: BorderRadius.circular(MinglitRadius.badge),
         gradient: LinearGradient(
           colors: [baseColor, highlightColor, baseColor],
           stops: [

--- a/apps/app_user/lib/src/features/account_deletion/ui/deletion_info_page.dart
+++ b/apps/app_user/lib/src/features/account_deletion/ui/deletion_info_page.dart
@@ -36,7 +36,7 @@ class DeletionInfoPage extends ConsumerWidget {
                       padding: const EdgeInsets.all(MinglitSpacing.medium),
                       decoration: BoxDecoration(
                         color: theme.colorScheme.secondaryContainer,
-                        borderRadius: BorderRadius.circular(16),
+                        borderRadius: BorderRadius.circular(MinglitRadius.card),
                       ),
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
@@ -83,7 +83,7 @@ class DeletionInfoPage extends ConsumerWidget {
                     padding: const EdgeInsets.all(MinglitSpacing.medium),
                     decoration: BoxDecoration(
                       color: MinglitColors.error.withValues(alpha: 0.08),
-                      borderRadius: BorderRadius.circular(16),
+                      borderRadius: BorderRadius.circular(MinglitRadius.card),
                     ),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,

--- a/apps/app_user/lib/src/features/my_tickets/ui/my_ticket_card.dart
+++ b/apps/app_user/lib/src/features/my_tickets/ui/my_ticket_card.dart
@@ -278,7 +278,7 @@ class _DDayChip extends StatelessWidget {
       ),
       decoration: BoxDecoration(
         color: bgColor,
-        borderRadius: BorderRadius.circular(100),
+        borderRadius: BorderRadius.circular(MinglitRadius.chip),
         border: isPast
             ? Border.all(color: theme.colorScheme.outlineVariant)
             : null,


### PR DESCRIPTION
Scheduler: needs-swe-glm-subagents-1

## Summary

이슈 #1195에 명시된 `BorderRadius` 하드코딩과 `Colors.white` 하드코딩을 디자인 토큰으로 교체.

### BorderRadius → MinglitRadius

| 파일 | 변경 | 토큰 |
|------|------|------|
| `deletion_info_page.dart` (app_user, L39/L86) | `circular(16)` → `MinglitRadius.card` | 16→16 ✅ |
| `deletion_info_page.dart` (app_partner, L39/L86) | `circular(16)` → `MinglitRadius.card` | 16→16 ✅ |
| `my_ticket_card.dart` (app_user, L281) | `circular(100)` → `MinglitRadius.chip` | 100→100 ✅ |
| `settlement_shimmer.dart` (app_partner, L131) | `circular(4)` → `MinglitRadius.badge` | 4→4 ✅ |

### Colors.white → colorScheme.onPrimary

| 파일 | 변경 |
|------|------|
| `settlement_page.dart` L192 | `Colors.white.withValues(alpha: 0.8)` → `colorScheme.onPrimary.withValues(alpha: MinglitOpacity.scrimLight)` |
| `settlement_page.dart` L199, L217, L236 | `Colors.white` → `colorScheme.onPrimary` |
| `settlement_page.dart` L211, L230 | `Colors.white.withValues(alpha: 0.7)` → `colorScheme.onPrimary.withValues(alpha: 0.7)` (토큰 없음) |

## Test plan

- [x] `flutter analyze` 통과 (CI)
- [x] Flutter 테스트 통과 (app_user, app_partner, minglit_kit)
- [ ] 다크/라이트 모드 시각적 변화 없음 (토큰 값이 동일)

Closes #1195

🤖 Generated with [Claude Code](https://claude.com/claude-code)