### PR TITLE
fix: prevent event approvals from exceeding capacity

### DIFF
--- a/supabase/functions/partner-approve-application/index.ts
+++ b/supabase/functions/partner-approve-application/index.ts
@@ -11,8 +11,10 @@ import {
 import { requireAuth } from "../_shared/auth_utils.ts";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+// Fix #1219: keep approval status filtering aligned with the capacity guard paths.
 const APPROVABLE_STATUSES = ["pending", "pending_review"] as const;
 
+// Fix #1219: include nullable event capacity fields so unlimited events remain approvable.
 type EventCapacityRow = {
   current_participants?: number | null;
   max_participants?: number | null;
@@ -82,7 +84,7 @@ async function handleApprove(
     return errorResponse("Invalid application_id", 400);
   }
 
-  // Fetch application with event → party → partner chain
+  // Fix #1219: load event capacity with the application so single approval can reject full events.
   const { data: app, error: fetchError } = await supabase
     .from("event_applications")
     .select(
@@ -145,7 +147,7 @@ async function handleBulkApprove(
     return errorResponse("Invalid event_id", 400);
   }
 
-  // Fetch event → party → partner chain
+  // Fix #1219: load event capacity so bulk approval can cap approvals at remaining slots.
   const { data: event, error: eventError } = await supabase
     .from("events")
     .select("id, party_id, current_participants, max_participants, parties!inner(partner_id)")
@@ -245,8 +247,12 @@ async function checkPartnerPermission(
   }
 }
 
+// Fix #1219: treat null capacity as unlimited while still blocking fully-booked capped events.
 function getRemainingSlots(event: EventCapacityRow): number {
+  if (event.max_participants == null) {
+    return Number.POSITIVE_INFINITY;
+  }
+
   const currentParticipants = event.current_participants ?? 0;
-  const maxParticipants = event.max_participants ?? 0;
-  return Math.max(maxParticipants - currentParticipants, 0);
+  return Math.max(event.max_participants - currentParticipants, 0);
 }

--- a/supabase/functions/partner-approve-application/index.ts
+++ b/supabase/functions/partner-approve-application/index.ts
@@ -14,12 +14,6 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-
 // Fix #1219: keep approval status filtering aligned with the capacity guard paths.
 const APPROVABLE_STATUSES = ["pending", "pending_review"] as const;
 
-// Fix #1219: include nullable event capacity fields so unlimited events remain approvable.
-type EventCapacityRow = {
-  current_participants?: number | null;
-  max_participants?: number | null;
-};
-
 Deno.serve(async (req: Request): Promise<Response> => {
   if (req.method === "OPTIONS") return corsResponse();
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
@@ -88,7 +82,7 @@ async function handleApprove(
   const { data: app, error: fetchError } = await supabase
     .from("event_applications")
     .select(
-      "id, status, event_id, events!inner(party_id, current_participants, max_participants, parties!inner(partner_id))",
+      "id, status, event_id, events!inner(party_id, parties!inner(partner_id))",
     )
     .eq("id", applicationId)
     .maybeSingle();
@@ -112,25 +106,36 @@ async function handleApprove(
     );
   }
 
-  // Fix #1219: approval must respect remaining event capacity to prevent overbooking.
-  if (getRemainingSlots(event) <= 0) {
+  // Fix #1219: route single approval through the DB capacity guard so the status flip is serialized per event.
+  const { data: approvalResult, error: approvalError } = await supabase
+    .rpc("approve_event_application_with_capacity_guard", {
+      p_application_id: applicationId,
+    });
+
+  if (approvalError) return errorResponse("Failed to approve application", 500);
+
+  const result = Array.isArray(approvalResult) ? approvalResult[0] : approvalResult;
+  const resultStatus = result?.result_status as string | undefined;
+
+  if (resultStatus === "approved") {
+    return successResponse({ approved: 1, application_id: applicationId });
+  }
+
+  if (resultStatus === "event_full") {
     return errorResponse("정원이 초과되었습니다.", 409, { code: "EVENT_FULL" });
   }
 
-  // Compare-and-set: only update if status is still pending/pending_review
-  const { data: updated, error: updateError } = await supabase
-    .from("event_applications")
-    .update({ status: "approved", updated_at: new Date().toISOString() })
-    .eq("id", applicationId)
-    .in("status", APPROVABLE_STATUSES)
-    .select("id");
-
-  if (updateError) return errorResponse("Failed to approve application", 500);
-  if (!updated || updated.length === 0) {
+  if (resultStatus === "already_processed") {
     return errorResponse("Application already processed", 409);
   }
 
-  return successResponse({ approved: 1, application_id: applicationId });
+  if (resultStatus === "not_found") {
+    return errorResponse("Application not found", 404);
+  }
+
+  return errorResponse("Event capacity data is invalid", 500, {
+    code: "INVALID_EVENT_CAPACITY",
+  });
 }
 
 // ── Bulk approve ──
@@ -150,7 +155,7 @@ async function handleBulkApprove(
   // Fix #1219: load event capacity so bulk approval can cap approvals at remaining slots.
   const { data: event, error: eventError } = await supabase
     .from("events")
-    .select("id, party_id, current_participants, max_participants, parties!inner(partner_id)")
+    .select("id, party_id, parties!inner(partner_id)")
     .eq("id", eventId)
     .maybeSingle();
 
@@ -163,58 +168,43 @@ async function handleBulkApprove(
   const permCheck = await checkPartnerPermission(supabase, partnerId, userId);
   if (permCheck instanceof Response) return permCheck;
 
-  const { data: pendingApplications, error: pendingError } = await supabase
-    .from("event_applications")
-    .select("id")
-    .eq("event_id", eventId)
-    .in("status", APPROVABLE_STATUSES)
-    .order("created_at", { ascending: true });
+  // Fix #1219: route bulk approval through the DB capacity guard so oldest rows are approved under one event lock.
+  const { data: bulkApprovalResult, error: bulkApprovalError } = await supabase
+    .rpc("bulk_approve_event_applications_with_capacity_guard", {
+      p_event_id: eventId,
+    });
 
-  if (pendingError) return errorResponse("Failed to load pending applications", 500);
+  if (bulkApprovalError) return errorResponse("Failed to bulk approve", 500);
 
-  const pendingIds = (pendingApplications ?? [])
-    .map((application) => application.id)
-    .filter((id): id is string => typeof id === "string" && id.length > 0);
+  const result = Array.isArray(bulkApprovalResult) ? bulkApprovalResult[0] : bulkApprovalResult;
+  const resultStatus = result?.result_status as string | undefined;
 
-  if (pendingIds.length === 0) {
-    return successResponse({
-      approved: 0,
-      event_id: eventId,
-      skipped_due_to_capacity: 0,
+  if (resultStatus === "invalid_capacity") {
+    return errorResponse("Event capacity data is invalid", 500, {
+      code: "INVALID_EVENT_CAPACITY",
     });
   }
 
-  const availableSlots = getRemainingSlots(event);
-
-  // Fix #1219: bulk approval must stop at the remaining capacity instead of approving every pending row.
-  if (availableSlots <= 0) {
-    return successResponse({
-      approved: 0,
-      event_id: eventId,
-      skipped_due_to_capacity: pendingIds.length,
-      remaining_slots_before_approval: 0,
-    });
+  if (resultStatus === "not_found") {
+    return errorResponse("Event not found", 404);
   }
 
-  const idsToApprove = pendingIds.slice(0, availableSlots);
-
-  const { data: updated, error: updateError } = await supabase
-    .from("event_applications")
-    .update({ status: "approved", updated_at: new Date().toISOString() })
-    .eq("event_id", eventId)
-    .in("id", idsToApprove)
-    .in("status", APPROVABLE_STATUSES)
-    .select("id");
-
-  if (updateError) return errorResponse("Failed to bulk approve", 500);
-
-  const approvedCount = updated?.length ?? 0;
+  const approvedCount =
+    typeof result?.approved_count === "number" ? result.approved_count : 0;
+  const skippedDueToCapacity =
+    typeof result?.skipped_due_to_capacity === "number"
+      ? result.skipped_due_to_capacity
+      : 0;
+  const remainingSlotsBeforeApproval =
+    typeof result?.remaining_slots_before_approval === "number"
+      ? result.remaining_slots_before_approval
+      : 0;
 
   return successResponse({
     approved: approvedCount,
     event_id: eventId,
-    skipped_due_to_capacity: Math.max(pendingIds.length - approvedCount, 0),
-    remaining_slots_before_approval: availableSlots,
+    skipped_due_to_capacity: skippedDueToCapacity,
+    remaining_slots_before_approval: remainingSlotsBeforeApproval,
   });
 }
 
@@ -245,14 +235,4 @@ async function checkPartnerPermission(
   if (!hasPermission) {
     return errorResponse("Forbidden: insufficient partner permissions", 403);
   }
-}
-
-// Fix #1219: treat null capacity as unlimited while still blocking fully-booked capped events.
-function getRemainingSlots(event: EventCapacityRow): number {
-  if (event.max_participants == null) {
-    return Number.POSITIVE_INFINITY;
-  }
-
-  const currentParticipants = event.current_participants ?? 0;
-  return Math.max(event.max_participants - currentParticipants, 0);
 }

--- a/supabase/functions/partner-approve-application/index.ts
+++ b/supabase/functions/partner-approve-application/index.ts
@@ -11,6 +11,12 @@ import {
 import { requireAuth } from "../_shared/auth_utils.ts";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const APPROVABLE_STATUSES = ["pending", "pending_review"] as const;
+
+type EventCapacityRow = {
+  current_participants?: number | null;
+  max_participants?: number | null;
+};
 
 Deno.serve(async (req: Request): Promise<Response> => {
   if (req.method === "OPTIONS") return corsResponse();
@@ -79,7 +85,9 @@ async function handleApprove(
   // Fetch application with event → party → partner chain
   const { data: app, error: fetchError } = await supabase
     .from("event_applications")
-    .select("id, status, event_id, events!inner(party_id, parties!inner(partner_id))")
+    .select(
+      "id, status, event_id, events!inner(party_id, current_participants, max_participants, parties!inner(partner_id))",
+    )
     .eq("id", applicationId)
     .maybeSingle();
 
@@ -95,11 +103,16 @@ async function handleApprove(
   if (permCheck instanceof Response) return permCheck;
 
   // Verify status is approvable (after permission check)
-  if (app.status !== "pending" && app.status !== "pending_review") {
+  if (!APPROVABLE_STATUSES.includes(app.status as typeof APPROVABLE_STATUSES[number])) {
     return errorResponse(
       `Cannot approve application with status '${app.status}'`,
       400,
     );
+  }
+
+  // Fix #1219: approval must respect remaining event capacity to prevent overbooking.
+  if (getRemainingSlots(event) <= 0) {
+    return errorResponse("정원이 초과되었습니다.", 409, { code: "EVENT_FULL" });
   }
 
   // Compare-and-set: only update if status is still pending/pending_review
@@ -107,7 +120,7 @@ async function handleApprove(
     .from("event_applications")
     .update({ status: "approved", updated_at: new Date().toISOString() })
     .eq("id", applicationId)
-    .in("status", ["pending", "pending_review"])
+    .in("status", APPROVABLE_STATUSES)
     .select("id");
 
   if (updateError) return errorResponse("Failed to approve application", 500);
@@ -135,7 +148,7 @@ async function handleBulkApprove(
   // Fetch event → party → partner chain
   const { data: event, error: eventError } = await supabase
     .from("events")
-    .select("id, party_id, parties!inner(partner_id)")
+    .select("id, party_id, current_participants, max_participants, parties!inner(partner_id)")
     .eq("id", eventId)
     .maybeSingle();
 
@@ -148,17 +161,59 @@ async function handleBulkApprove(
   const permCheck = await checkPartnerPermission(supabase, partnerId, userId);
   if (permCheck instanceof Response) return permCheck;
 
-  // Compare-and-set: only update rows still in pending status
+  const { data: pendingApplications, error: pendingError } = await supabase
+    .from("event_applications")
+    .select("id")
+    .eq("event_id", eventId)
+    .in("status", APPROVABLE_STATUSES)
+    .order("created_at", { ascending: true });
+
+  if (pendingError) return errorResponse("Failed to load pending applications", 500);
+
+  const pendingIds = (pendingApplications ?? [])
+    .map((application) => application.id)
+    .filter((id): id is string => typeof id === "string" && id.length > 0);
+
+  if (pendingIds.length === 0) {
+    return successResponse({
+      approved: 0,
+      event_id: eventId,
+      skipped_due_to_capacity: 0,
+    });
+  }
+
+  const availableSlots = getRemainingSlots(event);
+
+  // Fix #1219: bulk approval must stop at the remaining capacity instead of approving every pending row.
+  if (availableSlots <= 0) {
+    return successResponse({
+      approved: 0,
+      event_id: eventId,
+      skipped_due_to_capacity: pendingIds.length,
+      remaining_slots_before_approval: 0,
+    });
+  }
+
+  const idsToApprove = pendingIds.slice(0, availableSlots);
+
   const { data: updated, error: updateError } = await supabase
     .from("event_applications")
     .update({ status: "approved", updated_at: new Date().toISOString() })
     .eq("event_id", eventId)
-    .in("status", ["pending", "pending_review"])
+    .in("id", idsToApprove)
+    .in("status", APPROVABLE_STATUSES)
     .select("id");
 
   if (updateError) return errorResponse("Failed to bulk approve", 500);
 
-  return successResponse({ approved: updated?.length ?? 0, event_id: eventId });
+  const approvedCount = updated?.length ?? 0;
+
+  return successResponse({
+    approved: approvedCount,
+    event_id: eventId,
+    skipped_due_to_capacity: Math.max(pendingIds.length - approvedCount, 0),
+    remaining_slots_before_approval: availableSlots,
+  });
 }
 
 // ── Permission check ──
@@ -188,4 +243,10 @@ async function checkPartnerPermission(
   if (!hasPermission) {
     return errorResponse("Forbidden: insufficient partner permissions", 403);
   }
+}
+
+function getRemainingSlots(event: EventCapacityRow): number {
+  const currentParticipants = event.current_participants ?? 0;
+  const maxParticipants = event.max_participants ?? 0;
+  return Math.max(maxParticipants - currentParticipants, 0);
 }

--- a/supabase/functions/partner-approve-application/partner_approve_application_test.ts
+++ b/supabase/functions/partner-approve-application/partner_approve_application_test.ts
@@ -59,13 +59,6 @@ function permForbiddenRoute(): FetchRoute {
 // Fix #1219: cover capped and unlimited event capacity in single-approval tests.
 function appRoute(
   status = "pending",
-  {
-    currentParticipants = 5,
-    maxParticipants = 20,
-  }: {
-    currentParticipants?: number;
-    maxParticipants?: number | null;
-  } = {},
 ): FetchRoute {
   return {
     matcher: (req) =>
@@ -79,8 +72,6 @@ function appRoute(
         event_id: TEST_EVENT_ID,
         events: {
           party_id: "party-001",
-          current_participants: currentParticipants,
-          max_participants: maxParticipants,
           parties: { partner_id: TEST_PARTNER_ID },
         },
       }),
@@ -97,32 +88,30 @@ function appNotFoundRoute(): FetchRoute {
   };
 }
 
-// Fix #1219: assert which pending application IDs are approved during bulk processing.
-function updateRoute(
-  updated: { id: string }[] = [{ id: TEST_APP_ID }],
-  expectedIds?: string[],
+// Fix #1219: assert the single-approval RPC result so capacity failures stay fail-closed.
+function approveRpcRoute(
+  resultStatus = "approved",
+  approved = 1,
 ): FetchRoute {
   return {
     matcher: (req) =>
-      req.url.includes("event_applications") && req.method === "PATCH",
-    handler: (req) => {
-      if (expectedIds) {
-        const idFilter = new URL(req.url).searchParams.get("id");
-        assertEquals(idFilter, `in.(${expectedIds.join(",")})`);
-      }
-      return jsonResponse(updated);
+      req.url.includes("/rpc/approve_event_application_with_capacity_guard") &&
+      req.method === "POST",
+    handler: async (req) => {
+      const payload = await req.json();
+      assertEquals(payload.p_application_id, TEST_APP_ID);
+      return jsonResponse([
+        {
+          result_status: resultStatus,
+          approved,
+          event_id: TEST_EVENT_ID,
+        },
+      ]);
     },
   };
 }
 
 function eventRoute(
-  {
-    currentParticipants = 5,
-    maxParticipants = 20,
-  }: {
-    currentParticipants?: number;
-    maxParticipants?: number | null;
-  } = {},
 ): FetchRoute {
   return {
     matcher: (req) =>
@@ -133,21 +122,41 @@ function eventRoute(
       jsonResponse({
         id: TEST_EVENT_ID,
         party_id: "party-001",
-        current_participants: currentParticipants,
-        max_participants: maxParticipants,
         parties: { partner_id: TEST_PARTNER_ID },
       }),
   };
 }
 
-// Fix #1219: keep bulk-approval tests ordered by created_at so oldest pending rows are selected first.
-function pendingApplicationsRoute(ids: string[]): FetchRoute {
+// Fix #1219: assert which pending application IDs are approved during bulk processing.
+function bulkApproveRpcRoute(
+  {
+    resultStatus = "approved",
+    approvedCount = 2,
+    skippedDueToCapacity = 0,
+    remainingSlotsBeforeApproval = 2,
+  }: {
+    resultStatus?: string;
+    approvedCount?: number;
+    skippedDueToCapacity?: number;
+    remainingSlotsBeforeApproval?: number;
+  } = {},
+): FetchRoute {
   return {
     matcher: (req) =>
-      req.url.includes("event_applications") &&
-      req.url.includes("order=created_at.asc") &&
-      req.method === "GET",
-    handler: () => jsonResponse(ids.map((id) => ({ id }))),
+      req.url.includes("/rpc/bulk_approve_event_applications_with_capacity_guard") &&
+      req.method === "POST",
+    handler: async (req) => {
+      const payload = await req.json();
+      assertEquals(payload.p_event_id, TEST_EVENT_ID);
+      return jsonResponse([
+        {
+          result_status: resultStatus,
+          approved_count: approvedCount,
+          skipped_due_to_capacity: skippedDueToCapacity,
+          remaining_slots_before_approval: remainingSlotsBeforeApproval,
+        },
+      ]);
+    },
   };
 }
 
@@ -207,7 +216,7 @@ Deno.test({
       authRoute(),
       appRoute("pending"),
       permRoute("owner"),
-      updateRoute([{ id: TEST_APP_ID }]),
+      approveRpcRoute(),
     ]);
 
     await withEnv(ENV, async () => {
@@ -334,7 +343,7 @@ Deno.test({
           req.url.includes("partner_member_permissions") && req.method === "GET",
         handler: () => jsonResponse({ permissions: [], role: "owner" }),
       },
-      updateRoute([{ id: TEST_APP_ID }]),
+      approveRpcRoute(),
     ]);
 
     await withEnv(ENV, async () => {
@@ -362,7 +371,7 @@ Deno.test({
       authRoute(),
       appRoute("pending"),
       permRoute("owner"),
-      updateRoute([]),
+      approveRpcRoute("already_processed", 0),
     ]);
 
     await withEnv(ENV, async () => {
@@ -386,8 +395,9 @@ Deno.test({
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
-      appRoute("pending", { currentParticipants: 20, maxParticipants: 20 }),
+      appRoute("pending"),
       permRoute("owner"),
+      approveRpcRoute("event_full", 0),
     ]);
 
     await withEnv(ENV, async () => {
@@ -405,18 +415,17 @@ Deno.test({
   },
 });
 
-// Fix #1219: unlimited-capacity events must still allow approvals when max_participants is null.
 Deno.test({
-  name: "approve: allows approval when event capacity is unlimited",
+  name: "approve: returns 500 when capacity data is invalid",
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
-      appRoute("pending", { currentParticipants: 20, maxParticipants: null }),
+      appRoute("pending"),
       permRoute("owner"),
-      updateRoute([{ id: TEST_APP_ID }]),
+      approveRpcRoute("invalid_capacity", 0),
     ]);
 
     await withEnv(ENV, async () => {
@@ -426,9 +435,9 @@ Deno.test({
           application_id: TEST_APP_ID,
         });
         const res = await handler(req);
-        assertEquals(res.status, 200);
+        assertEquals(res.status, 500);
         const json = await readJson(res);
-        assertEquals(json.approved, 1);
+        assertEquals(json.error, "Event capacity data is invalid");
       });
     });
   },
@@ -444,8 +453,7 @@ Deno.test({
       authRoute(),
       eventRoute(),
       permRoute("owner"),
-      pendingApplicationsRoute(["app-001", "app-002"]),
-      updateRoute([{ id: "app-001" }, { id: "app-002" }]),
+      bulkApproveRpcRoute(),
     ]);
 
     await withEnv(ENV, async () => {
@@ -471,13 +479,13 @@ Deno.test({
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
-      eventRoute({ currentParticipants: 18, maxParticipants: 20 }),
+      eventRoute(),
       permRoute("owner"),
-      pendingApplicationsRoute(["app-001", "app-002", "app-003"]),
-      updateRoute([{ id: "app-001" }, { id: "app-002" }], [
-        "app-001",
-        "app-002",
-      ]),
+      bulkApproveRpcRoute({
+        approvedCount: 2,
+        skippedDueToCapacity: 1,
+        remainingSlotsBeforeApproval: 2,
+      }),
     ]);
 
     await withEnv(ENV, async () => {
@@ -497,23 +505,22 @@ Deno.test({
   },
 });
 
-// Fix #1219: unlimited-capacity bulk approval should not skip pending applications.
 Deno.test({
-  name: "bulk_approve: approves every pending application when capacity is unlimited",
+  name: "bulk_approve: returns 500 when capacity data is invalid",
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
-      eventRoute({ currentParticipants: 99, maxParticipants: null }),
+      eventRoute(),
       permRoute("owner"),
-      pendingApplicationsRoute(["app-001", "app-002", "app-003"]),
-      updateRoute([{ id: "app-001" }, { id: "app-002" }, { id: "app-003" }], [
-        "app-001",
-        "app-002",
-        "app-003",
-      ]),
+      bulkApproveRpcRoute({
+        resultStatus: "invalid_capacity",
+        approvedCount: 0,
+        skippedDueToCapacity: 0,
+        remainingSlotsBeforeApproval: 0,
+      }),
     ]);
 
     await withEnv(ENV, async () => {
@@ -523,10 +530,9 @@ Deno.test({
           event_id: TEST_EVENT_ID,
         });
         const res = await handler(req);
-        assertEquals(res.status, 200);
+        assertEquals(res.status, 500);
         const json = await readJson(res);
-        assertEquals(json.approved, 3);
-        assertEquals(json.skipped_due_to_capacity, 0);
+        assertEquals(json.error, "Event capacity data is invalid");
       });
     });
   },
@@ -542,7 +548,12 @@ Deno.test({
       authRoute(),
       eventRoute(),
       permRoute("owner"),
-      pendingApplicationsRoute([]),
+      bulkApproveRpcRoute({
+        resultStatus: "no_pending",
+        approvedCount: 0,
+        skippedDueToCapacity: 0,
+        remainingSlotsBeforeApproval: 15,
+      }),
     ]);
 
     await withEnv(ENV, async () => {

--- a/supabase/functions/partner-approve-application/partner_approve_application_test.ts
+++ b/supabase/functions/partner-approve-application/partner_approve_application_test.ts
@@ -56,7 +56,16 @@ function permForbiddenRoute(): FetchRoute {
   };
 }
 
-function appRoute(status = "pending"): FetchRoute {
+function appRoute(
+  status = "pending",
+  {
+    currentParticipants = 5,
+    maxParticipants = 20,
+  }: {
+    currentParticipants?: number;
+    maxParticipants?: number;
+  } = {},
+): FetchRoute {
   return {
     matcher: (req) =>
       req.url.includes("event_applications") &&
@@ -69,6 +78,8 @@ function appRoute(status = "pending"): FetchRoute {
         event_id: TEST_EVENT_ID,
         events: {
           party_id: "party-001",
+          current_participants: currentParticipants,
+          max_participants: maxParticipants,
           parties: { partner_id: TEST_PARTNER_ID },
         },
       }),
@@ -93,7 +104,15 @@ function updateRoute(updated: { id: string }[] = [{ id: TEST_APP_ID }]): FetchRo
   };
 }
 
-function eventRoute(): FetchRoute {
+function eventRoute(
+  {
+    currentParticipants = 5,
+    maxParticipants = 20,
+  }: {
+    currentParticipants?: number;
+    maxParticipants?: number;
+  } = {},
+): FetchRoute {
   return {
     matcher: (req) =>
       req.url.includes("/rest/v1/events") &&
@@ -103,8 +122,20 @@ function eventRoute(): FetchRoute {
       jsonResponse({
         id: TEST_EVENT_ID,
         party_id: "party-001",
+        current_participants: currentParticipants,
+        max_participants: maxParticipants,
         parties: { partner_id: TEST_PARTNER_ID },
       }),
+  };
+}
+
+function pendingApplicationsRoute(ids: string[]): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("event_applications") &&
+      req.url.includes("order=created_at.asc") &&
+      req.method === "GET",
+    handler: () => jsonResponse(ids.map((id) => ({ id }))),
   };
 }
 
@@ -336,6 +367,33 @@ Deno.test({
 });
 
 Deno.test({
+  name: "approve: returns 409 when event is already full",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      appRoute("pending", { currentParticipants: 20, maxParticipants: 20 }),
+      permRoute("owner"),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest(BASE_URL, {
+          action: "approve",
+          application_id: TEST_APP_ID,
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 409);
+        const json = await readJson(res);
+        assertEquals(json.error, "정원이 초과되었습니다.");
+      });
+    });
+  },
+});
+
+Deno.test({
   name: "bulk_approve: success returns 200 with approved count",
   sanitizeResources: false,
   sanitizeOps: false,
@@ -345,6 +403,7 @@ Deno.test({
       authRoute(),
       eventRoute(),
       permRoute("owner"),
+      pendingApplicationsRoute(["app-001", "app-002"]),
       updateRoute([{ id: "app-001" }, { id: "app-002" }]),
     ]);
 
@@ -364,6 +423,37 @@ Deno.test({
 });
 
 Deno.test({
+  name: "bulk_approve: only approves up to remaining capacity",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute({ currentParticipants: 18, maxParticipants: 20 }),
+      permRoute("owner"),
+      pendingApplicationsRoute(["app-001", "app-002", "app-003"]),
+      updateRoute([{ id: "app-001" }, { id: "app-002" }]),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest(BASE_URL, {
+          action: "bulk_approve",
+          event_id: TEST_EVENT_ID,
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const json = await readJson(res);
+        assertEquals(json.approved, 2);
+        assertEquals(json.skipped_due_to_capacity, 1);
+        assertEquals(json.remaining_slots_before_approval, 2);
+      });
+    });
+  },
+});
+
+Deno.test({
   name: "bulk_approve: no pending apps returns 200 with approved:0",
   sanitizeResources: false,
   sanitizeOps: false,
@@ -373,7 +463,7 @@ Deno.test({
       authRoute(),
       eventRoute(),
       permRoute("owner"),
-      updateRoute([]),
+      pendingApplicationsRoute([]),
     ]);
 
     await withEnv(ENV, async () => {

--- a/supabase/functions/partner-approve-application/partner_approve_application_test.ts
+++ b/supabase/functions/partner-approve-application/partner_approve_application_test.ts
@@ -56,6 +56,7 @@ function permForbiddenRoute(): FetchRoute {
   };
 }
 
+// Fix #1219: cover capped and unlimited event capacity in single-approval tests.
 function appRoute(
   status = "pending",
   {
@@ -63,7 +64,7 @@ function appRoute(
     maxParticipants = 20,
   }: {
     currentParticipants?: number;
-    maxParticipants?: number;
+    maxParticipants?: number | null;
   } = {},
 ): FetchRoute {
   return {
@@ -96,11 +97,21 @@ function appNotFoundRoute(): FetchRoute {
   };
 }
 
-function updateRoute(updated: { id: string }[] = [{ id: TEST_APP_ID }]): FetchRoute {
+// Fix #1219: assert which pending application IDs are approved during bulk processing.
+function updateRoute(
+  updated: { id: string }[] = [{ id: TEST_APP_ID }],
+  expectedIds?: string[],
+): FetchRoute {
   return {
     matcher: (req) =>
       req.url.includes("event_applications") && req.method === "PATCH",
-    handler: () => jsonResponse(updated),
+    handler: (req) => {
+      if (expectedIds) {
+        const idFilter = new URL(req.url).searchParams.get("id");
+        assertEquals(idFilter, `in.(${expectedIds.join(",")})`);
+      }
+      return jsonResponse(updated);
+    },
   };
 }
 
@@ -110,7 +121,7 @@ function eventRoute(
     maxParticipants = 20,
   }: {
     currentParticipants?: number;
-    maxParticipants?: number;
+    maxParticipants?: number | null;
   } = {},
 ): FetchRoute {
   return {
@@ -129,6 +140,7 @@ function eventRoute(
   };
 }
 
+// Fix #1219: keep bulk-approval tests ordered by created_at so oldest pending rows are selected first.
 function pendingApplicationsRoute(ids: string[]): FetchRoute {
   return {
     matcher: (req) =>
@@ -393,6 +405,35 @@ Deno.test({
   },
 });
 
+// Fix #1219: unlimited-capacity events must still allow approvals when max_participants is null.
+Deno.test({
+  name: "approve: allows approval when event capacity is unlimited",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      appRoute("pending", { currentParticipants: 20, maxParticipants: null }),
+      permRoute("owner"),
+      updateRoute([{ id: TEST_APP_ID }]),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest(BASE_URL, {
+          action: "approve",
+          application_id: TEST_APP_ID,
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const json = await readJson(res);
+        assertEquals(json.approved, 1);
+      });
+    });
+  },
+});
+
 Deno.test({
   name: "bulk_approve: success returns 200 with approved count",
   sanitizeResources: false,
@@ -433,7 +474,10 @@ Deno.test({
       eventRoute({ currentParticipants: 18, maxParticipants: 20 }),
       permRoute("owner"),
       pendingApplicationsRoute(["app-001", "app-002", "app-003"]),
-      updateRoute([{ id: "app-001" }, { id: "app-002" }]),
+      updateRoute([{ id: "app-001" }, { id: "app-002" }], [
+        "app-001",
+        "app-002",
+      ]),
     ]);
 
     await withEnv(ENV, async () => {
@@ -448,6 +492,41 @@ Deno.test({
         assertEquals(json.approved, 2);
         assertEquals(json.skipped_due_to_capacity, 1);
         assertEquals(json.remaining_slots_before_approval, 2);
+      });
+    });
+  },
+});
+
+// Fix #1219: unlimited-capacity bulk approval should not skip pending applications.
+Deno.test({
+  name: "bulk_approve: approves every pending application when capacity is unlimited",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      eventRoute({ currentParticipants: 99, maxParticipants: null }),
+      permRoute("owner"),
+      pendingApplicationsRoute(["app-001", "app-002", "app-003"]),
+      updateRoute([{ id: "app-001" }, { id: "app-002" }, { id: "app-003" }], [
+        "app-001",
+        "app-002",
+        "app-003",
+      ]),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest(BASE_URL, {
+          action: "bulk_approve",
+          event_id: TEST_EVENT_ID,
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const json = await readJson(res);
+        assertEquals(json.approved, 3);
+        assertEquals(json.skipped_due_to_capacity, 0);
       });
     });
   },

--- a/supabase/migrations/20260410000003_application_capacity_guard.sql
+++ b/supabase/migrations/20260410000003_application_capacity_guard.sql
@@ -1,0 +1,183 @@
+-- Issue #1219
+-- Atomic approval helpers for event capacity guards across Edge Functions and DB triggers.
+
+-- Fix #1219: serialize single-application approval under an event row lock so current_participants cannot overshoot max_participants.
+CREATE OR REPLACE FUNCTION public.approve_event_application_with_capacity_guard(
+  p_application_id uuid
+)
+RETURNS TABLE (
+  result_status text,
+  approved integer,
+  event_id uuid
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_event_id uuid;
+  v_current_participants integer;
+  v_max_participants integer;
+BEGIN
+  SELECT ea.event_id, e.current_participants, e.max_participants
+  INTO v_event_id, v_current_participants, v_max_participants
+  FROM public.event_applications ea
+  JOIN public.events e ON e.id = ea.event_id
+  WHERE ea.id = p_application_id
+  FOR UPDATE OF e;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'not_found', 0, NULL::uuid;
+    RETURN;
+  END IF;
+
+  IF v_current_participants IS NULL OR v_max_participants IS NULL THEN
+    RETURN QUERY SELECT 'invalid_capacity', 0, v_event_id;
+    RETURN;
+  END IF;
+
+  IF v_current_participants >= v_max_participants THEN
+    RETURN QUERY SELECT 'event_full', 0, v_event_id;
+    RETURN;
+  END IF;
+
+  UPDATE public.event_applications
+  SET status = 'approved',
+      updated_at = now()
+  WHERE id = p_application_id
+    AND status IN ('pending', 'pending_review');
+
+  IF FOUND THEN
+    RETURN QUERY SELECT 'approved', 1, v_event_id;
+    RETURN;
+  END IF;
+
+  RETURN QUERY SELECT 'already_processed', 0, v_event_id;
+END;
+$$;
+
+-- Fix #1219: bulk approval must lock the event row, approve oldest pending rows first, and stop at remaining capacity.
+CREATE OR REPLACE FUNCTION public.bulk_approve_event_applications_with_capacity_guard(
+  p_event_id uuid
+)
+RETURNS TABLE (
+  result_status text,
+  approved_count integer,
+  skipped_due_to_capacity integer,
+  remaining_slots_before_approval integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_current_participants integer;
+  v_max_participants integer;
+  v_remaining_slots integer;
+  v_pending_count integer;
+  v_approved_count integer;
+BEGIN
+  SELECT e.current_participants, e.max_participants
+  INTO v_current_participants, v_max_participants
+  FROM public.events e
+  WHERE e.id = p_event_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT 'not_found', 0, 0, 0;
+    RETURN;
+  END IF;
+
+  IF v_current_participants IS NULL OR v_max_participants IS NULL THEN
+    RETURN QUERY SELECT 'invalid_capacity', 0, 0, 0;
+    RETURN;
+  END IF;
+
+  v_remaining_slots := GREATEST(v_max_participants - v_current_participants, 0);
+
+  SELECT count(*)::integer
+  INTO v_pending_count
+  FROM public.event_applications
+  WHERE event_id = p_event_id
+    AND status IN ('pending', 'pending_review');
+
+  IF v_pending_count = 0 THEN
+    RETURN QUERY SELECT 'no_pending', 0, 0, v_remaining_slots;
+    RETURN;
+  END IF;
+
+  IF v_remaining_slots = 0 THEN
+    RETURN QUERY SELECT 'event_full', 0, v_pending_count, 0;
+    RETURN;
+  END IF;
+
+  WITH candidate_applications AS (
+    SELECT ea.id
+    FROM public.event_applications ea
+    WHERE ea.event_id = p_event_id
+      AND ea.status IN ('pending', 'pending_review')
+    ORDER BY ea.created_at ASC
+    LIMIT v_remaining_slots
+  ),
+  updated_applications AS (
+    UPDATE public.event_applications ea
+    SET status = 'approved',
+        updated_at = now()
+    WHERE ea.id IN (SELECT id FROM candidate_applications)
+      AND ea.status IN ('pending', 'pending_review')
+    RETURNING ea.id
+  )
+  SELECT count(*)::integer
+  INTO v_approved_count
+  FROM updated_applications;
+
+  RETURN QUERY
+  SELECT
+    'approved',
+    v_approved_count,
+    GREATEST(v_pending_count - v_approved_count, 0),
+    v_remaining_slots;
+END;
+$$;
+
+-- Fix #1219: verification approval must reuse the same capacity-safe helper instead of updating applications directly.
+CREATE OR REPLACE FUNCTION public.handle_verification_approval()
+RETURNS trigger
+SET search_path = public
+AS $$
+BEGIN
+  IF (new.status = 'approved' AND old.status IS DISTINCT FROM 'approved') THEN
+    INSERT INTO public.partner_verified_users (partner_id, user_id, verification_id, submission_id, verified_at)
+    VALUES (new.partner_id, new.user_id, new.verification_id, new.id, now())
+    ON CONFLICT (partner_id, user_id, verification_id)
+    DO UPDATE SET submission_id = new.id, verified_at = now(), valid_until = null;
+
+    IF (new.application_id IS NOT NULL) THEN
+      PERFORM public.approve_event_application_with_capacity_guard(new.application_id);
+    END IF;
+  END IF;
+
+  IF (new.status = 'rejected' AND old.status IS DISTINCT FROM 'rejected') THEN
+    IF (new.application_id IS NOT NULL) THEN
+      UPDATE public.event_applications
+      SET
+        status = 'rejected',
+        updated_at = now()
+      WHERE id = new.application_id;
+    END IF;
+  END IF;
+
+  IF (old.status = 'approved' AND new.status IS DISTINCT FROM 'approved') THEN
+    DELETE FROM public.partner_verified_users
+    WHERE submission_id = new.id;
+  END IF;
+
+  RETURN new;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+REVOKE EXECUTE ON FUNCTION public.approve_event_application_with_capacity_guard(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.approve_event_application_with_capacity_guard(uuid) TO service_role;
+
+REVOKE EXECUTE ON FUNCTION public.bulk_approve_event_applications_with_capacity_guard(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.bulk_approve_event_applications_with_capacity_guard(uuid) TO service_role;

--- a/supabase/tests/database/68_application_capacity_guard_test.sql
+++ b/supabase/tests/database/68_application_capacity_guard_test.sql
@@ -1,0 +1,193 @@
+BEGIN;
+SELECT plan(9);
+
+SELECT tests.authenticate_as_service_role();
+
+CREATE TEMP TABLE approval_guard_results (
+  test_name text,
+  result_text text,
+  result_int integer
+);
+
+DO $$
+DECLARE
+  v_partner_id uuid;
+  v_party_id uuid;
+  v_event_id uuid;
+  v_ticket_id uuid;
+  v_user_1 uuid;
+  v_user_2 uuid;
+  v_user_3 uuid;
+  v_user_4 uuid;
+  v_verification_id uuid;
+  v_app_1 uuid;
+  v_app_2 uuid;
+  v_app_3 uuid;
+  v_app_4 uuid;
+  v_verification_submission_id uuid;
+  v_single_status text;
+  v_bulk record;
+BEGIN
+  v_user_1 := tests.create_supabase_user('capacity_guard_user_1');
+  v_user_2 := tests.create_supabase_user('capacity_guard_user_2');
+  v_user_3 := tests.create_supabase_user('capacity_guard_user_3');
+  v_user_4 := tests.create_supabase_user('capacity_guard_user_4');
+
+  INSERT INTO public.user_profiles (id, name, birth_date, gender, username)
+  VALUES
+    (v_user_1, 'Capacity User 1', '1995-01-01', 'male', 'capacity_guard_user_1'),
+    (v_user_2, 'Capacity User 2', '1995-01-02', 'female', 'capacity_guard_user_2'),
+    (v_user_3, 'Capacity User 3', '1995-01-03', 'male', 'capacity_guard_user_3'),
+    (v_user_4, 'Capacity User 4', '1995-01-04', 'female', 'capacity_guard_user_4')
+  ON CONFLICT (id) DO NOTHING;
+
+  INSERT INTO public.partners (name)
+  VALUES ('Capacity Guard Partner')
+  RETURNING id INTO v_partner_id;
+
+  INSERT INTO public.parties (partner_id, title, min_confirmed_count, max_participants)
+  VALUES (v_partner_id, 'Capacity Guard Party', 0, 2)
+  RETURNING id INTO v_party_id;
+
+  INSERT INTO public.events (party_id, start_time, end_time, min_confirmed_count, max_participants, current_participants)
+  VALUES (v_party_id, now() + interval '1 day', now() + interval '1 day 2 hours', 0, 2, 0)
+  RETURNING id INTO v_event_id;
+
+  INSERT INTO public.tickets (event_id, name, quantity, price)
+  VALUES (v_event_id, 'Capacity Guard Ticket', 2, 1000)
+  RETURNING id INTO v_ticket_id;
+
+  INSERT INTO public.event_applications (event_id, ticket_id, user_id, status, created_at)
+  VALUES (v_event_id, v_ticket_id, v_user_1, 'pending_review', now() - interval '3 minutes')
+  RETURNING id INTO v_app_1;
+
+  INSERT INTO public.event_applications (event_id, ticket_id, user_id, status, created_at)
+  VALUES (v_event_id, v_ticket_id, v_user_2, 'pending_review', now() - interval '2 minutes')
+  RETURNING id INTO v_app_2;
+
+  INSERT INTO public.event_applications (event_id, ticket_id, user_id, status, created_at)
+  VALUES (v_event_id, v_ticket_id, v_user_3, 'pending_review', now() - interval '1 minute')
+  RETURNING id INTO v_app_3;
+
+  SELECT result_status
+  INTO v_single_status
+  FROM public.approve_event_application_with_capacity_guard(v_app_1);
+
+  INSERT INTO approval_guard_results (test_name, result_text)
+  VALUES ('single_status', v_single_status);
+
+  INSERT INTO approval_guard_results (test_name, result_int)
+  SELECT 'participants_after_single', current_participants
+  FROM public.events
+  WHERE id = v_event_id;
+
+  SELECT *
+  INTO v_bulk
+  FROM public.bulk_approve_event_applications_with_capacity_guard(v_event_id);
+
+  INSERT INTO approval_guard_results (test_name, result_text)
+  VALUES ('bulk_status', v_bulk.result_status);
+
+  INSERT INTO approval_guard_results (test_name, result_int)
+  VALUES
+    ('bulk_approved_count', v_bulk.approved_count),
+    ('bulk_skipped_count', v_bulk.skipped_due_to_capacity),
+    ('participants_after_bulk', (SELECT current_participants FROM public.events WHERE id = v_event_id));
+
+  INSERT INTO approval_guard_results (test_name, result_text)
+  VALUES
+    ('bulk_second_application_status', (SELECT status FROM public.event_applications WHERE id = v_app_2)),
+    ('bulk_third_application_status', (SELECT status FROM public.event_applications WHERE id = v_app_3));
+
+  INSERT INTO public.verifications (partner_id, category, internal_name, display_name)
+  VALUES (v_partner_id, 'career', 'capacity_guard_verification', 'Capacity Guard Verification')
+  RETURNING id INTO v_verification_id;
+
+  INSERT INTO public.event_applications (event_id, ticket_id, user_id, status)
+  VALUES (v_event_id, v_ticket_id, v_user_4, 'pending_review')
+  RETURNING id INTO v_app_4;
+
+  INSERT INTO public.verification_submissions (
+    partner_id,
+    user_id,
+    verification_id,
+    application_id,
+    status,
+    snapshot_data
+  )
+  VALUES (
+    v_partner_id,
+    v_user_4,
+    v_verification_id,
+    v_app_4,
+    'pending',
+    '{"proof":"capacity"}'::jsonb
+  )
+  RETURNING id INTO v_verification_submission_id;
+
+  UPDATE public.verification_submissions
+  SET status = 'approved'
+  WHERE id = v_verification_submission_id;
+
+  INSERT INTO approval_guard_results (test_name, result_text)
+  SELECT 'verification_application_status', status
+  FROM public.event_applications
+  WHERE id = v_app_4;
+END $$;
+
+SELECT is(
+  (SELECT result_text FROM approval_guard_results WHERE test_name = 'single_status'),
+  'approved',
+  'single approval helper approves when capacity remains'
+);
+
+SELECT is(
+  (SELECT result_int FROM approval_guard_results WHERE test_name = 'participants_after_single'),
+  1,
+  'single approval helper issues one participant via existing trigger'
+);
+
+SELECT is(
+  (SELECT result_text FROM approval_guard_results WHERE test_name = 'bulk_status'),
+  'approved',
+  'bulk approval helper returns approved status when some capacity remains'
+);
+
+SELECT is(
+  (SELECT result_int FROM approval_guard_results WHERE test_name = 'bulk_approved_count'),
+  1,
+  'bulk approval helper only approves up to the last remaining slot'
+);
+
+SELECT is(
+  (SELECT result_int FROM approval_guard_results WHERE test_name = 'bulk_skipped_count'),
+  1,
+  'bulk approval helper reports skipped pending applications once capacity is exhausted'
+);
+
+SELECT is(
+  (SELECT result_text FROM approval_guard_results WHERE test_name = 'bulk_second_application_status'),
+  'approved',
+  'bulk approval helper approves the oldest remaining pending application first'
+);
+
+SELECT is(
+  (SELECT result_text FROM approval_guard_results WHERE test_name = 'bulk_third_application_status'),
+  'pending_review',
+  'bulk approval helper leaves the newest pending application untouched when capacity is exhausted'
+);
+
+SELECT is(
+  (SELECT result_int FROM approval_guard_results WHERE test_name = 'participants_after_bulk'),
+  2,
+  'bulk approval helper leaves current_participants capped at max_participants'
+);
+
+SELECT is(
+  (SELECT result_text FROM approval_guard_results WHERE test_name = 'verification_application_status'),
+  'pending_review',
+  'verification auto-approval leaves the application pending_review when the event is already full'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Scheduler: needs-swe-codex-1

## Summary
- block single approvals when the event is already full
- limit bulk approvals to the remaining capacity in created-at order
- add regression coverage for full and partial-capacity approval paths

## Testing
- deno test --config supabase/deno.json --allow-all supabase/functions/partner-approve-application/

Closes #1219