### PR TITLE
fix(admission): add ended-event CTA states (#1208)

### DIFF
--- a/apps/app_user/lib/src/features/event/admission/admission_action_handler.dart
+++ b/apps/app_user/lib/src/features/event/admission/admission_action_handler.dart
@@ -30,6 +30,21 @@ extension AdmissionActions on EventAdmissionController {
           label: '심사 반려 (사유 확인)',
           style: AdmissionButtonStyle.destructive,
         );
+      // Fix #1208: Ended event button configs
+      case EventAdmissionStatus.eventEnded:
+        return const AdmissionButtonConfig(
+          label: '종료된 이벤트',
+          enabled: false,
+          style: AdmissionButtonStyle.disabled,
+        );
+      case EventAdmissionStatus.eventEndedWithResults:
+        return const AdmissionButtonConfig(label: '매칭 결과 보기');
+      case EventAdmissionStatus.eventEndedParticipated:
+        return const AdmissionButtonConfig(
+          label: '참여 완료',
+          enabled: false,
+          style: AdmissionButtonStyle.disabled,
+        );
     }
   }
 }

--- a/apps/app_user/lib/src/features/event/admission/event_admission_controller.dart
+++ b/apps/app_user/lib/src/features/event/admission/event_admission_controller.dart
@@ -33,7 +33,8 @@ class EventAdmissionController extends _$EventAdmissionController {
 
       // Fix #1208: pending(결제 미완료) 신청은 참여로 간주하지 않음
       // rejected: user did not participate — treat same as cancelled for ended events
-      final hasActiveApplication = existingApp != null &&
+      final hasActiveApplication =
+          existingApp != null &&
           existingApp.status != 'pending' &&
           existingApp.status != 'cancelled' &&
           existingApp.status != 'rejected';

--- a/apps/app_user/lib/src/features/event/admission/event_admission_controller.dart
+++ b/apps/app_user/lib/src/features/event/admission/event_admission_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:app_user/src/features/auth/logic/auth_coordinator.dart';
+import 'package:app_user/src/features/home/widgets/event_now_phases/results_content.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -14,6 +15,51 @@ part 'event_admission_state.dart';
 class EventAdmissionController extends _$EventAdmissionController {
   @override
   FutureOr<AdmissionState> build(Event event) async {
+    // Fix #1208: Check event status before any user-state logic.
+    // Completed/cancelled events show ended-state CTAs regardless of login/eligibility.
+    final isEnded =
+        event.status == 'completed' || event.status == 'cancelled';
+    if (isEnded) {
+      final currentUser = ref.watch(currentUserProvider);
+      if (currentUser == null) {
+        return AdmissionState(status: EventAdmissionStatus.eventEnded);
+      }
+
+      final existingApp =
+          await ref.watch(eventRepositoryProvider).getApplication(
+                eventId: event.id,
+                userId: currentUser.id,
+              );
+
+      // rejected: user did not participate — treat same as cancelled for ended events
+      final hasActiveApplication = existingApp != null &&
+          existingApp.status != 'cancelled' &&
+          existingApp.status != 'rejected';
+
+      if (!hasActiveApplication) {
+        return AdmissionState(
+          status: EventAdmissionStatus.eventEnded,
+          user: currentUser,
+        );
+      }
+
+      // Check for match results
+      final matchingRepo = ref.watch(matchingRepositoryProvider);
+      final matches = await matchingRepo.getMyMatches(event.id);
+
+      if (matches.isNotEmpty) {
+        return AdmissionState(
+          status: EventAdmissionStatus.eventEndedWithResults,
+          user: currentUser,
+        );
+      }
+
+      return AdmissionState(
+        status: EventAdmissionStatus.eventEndedParticipated,
+        user: currentUser,
+      );
+    }
+
     final currentUser = ref.watch(currentUserProvider);
     final repository = ref.watch(eventRepositoryProvider);
     final userRepository = ref.watch(userRepositoryProvider);
@@ -157,6 +203,37 @@ class EventAdmissionController extends _$EventAdmissionController {
             loading.hide();
           }
         }
+        return;
+      // Fix #1208: Ended event CTA actions
+      case EventAdmissionStatus.eventEnded:
+      case EventAdmissionStatus.eventEndedParticipated:
+        return;
+      case EventAdmissionStatus.eventEndedWithResults:
+        showModalBottomSheet<void>(
+          context: context,
+          isScrollControlled: true,
+          shape: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.vertical(
+              top: Radius.circular(MinglitRadius.card),
+            ),
+          ),
+          builder: (sheetContext) => SafeArea(
+            child: Padding(
+              padding: EdgeInsets.only(
+                bottom:
+                    MediaQuery.of(sheetContext).viewPadding.bottom,
+              ),
+              // ResultsContent only reads activeEvent.event (title)
+              // and myMatchesProvider(event.id) — participantStatus is unused.
+              child: ResultsContent(
+                activeEvent: TodayActiveEvent(
+                  event: event,
+                  participantStatus: 'checked_in',
+                ),
+              ),
+            ),
+          ),
+        );
         return;
     }
   }

--- a/apps/app_user/lib/src/features/event/admission/event_admission_controller.dart
+++ b/apps/app_user/lib/src/features/event/admission/event_admission_controller.dart
@@ -31,8 +31,10 @@ class EventAdmissionController extends _$EventAdmissionController {
                 userId: currentUser.id,
               );
 
+      // Fix #1208: pending(결제 미완료) 신청은 참여로 간주하지 않음
       // rejected: user did not participate — treat same as cancelled for ended events
       final hasActiveApplication = existingApp != null &&
+          existingApp.status != 'pending' &&
           existingApp.status != 'cancelled' &&
           existingApp.status != 'rejected';
 

--- a/apps/app_user/lib/src/features/event/admission/event_admission_controller.dart
+++ b/apps/app_user/lib/src/features/event/admission/event_admission_controller.dart
@@ -17,22 +17,23 @@ class EventAdmissionController extends _$EventAdmissionController {
   FutureOr<AdmissionState> build(Event event) async {
     // Fix #1208: Check event status before any user-state logic.
     // Completed/cancelled events show ended-state CTAs regardless of login/eligibility.
-    final isEnded =
-        event.status == 'completed' || event.status == 'cancelled';
+    final isEnded = event.status == 'completed' || event.status == 'cancelled';
     if (isEnded) {
       final currentUser = ref.watch(currentUserProvider);
       if (currentUser == null) {
         return AdmissionState(status: EventAdmissionStatus.eventEnded);
       }
 
-      final existingApp =
-          await ref.watch(eventRepositoryProvider).getApplication(
-                eventId: event.id,
-                userId: currentUser.id,
-              );
+      final existingApp = await ref
+          .watch(eventRepositoryProvider)
+          .getApplication(
+            eventId: event.id,
+            userId: currentUser.id,
+          );
 
       // rejected: user did not participate — treat same as cancelled for ended events
-      final hasActiveApplication = existingApp != null &&
+      final hasActiveApplication =
+          existingApp != null &&
           existingApp.status != 'cancelled' &&
           existingApp.status != 'rejected';
 
@@ -220,8 +221,7 @@ class EventAdmissionController extends _$EventAdmissionController {
           builder: (sheetContext) => SafeArea(
             child: Padding(
               padding: EdgeInsets.only(
-                bottom:
-                    MediaQuery.of(sheetContext).viewPadding.bottom,
+                bottom: MediaQuery.of(sheetContext).viewPadding.bottom,
               ),
               // ResultsContent only reads activeEvent.event (title)
               // and myMatchesProvider(event.id) — participantStatus is unused.

--- a/apps/app_user/lib/src/features/event/admission/event_admission_state.dart
+++ b/apps/app_user/lib/src/features/event/admission/event_admission_state.dart
@@ -9,6 +9,10 @@ enum EventAdmissionStatus {
   pendingPayment, // 결제 미완료 (이어하기)
   applied, // 이미 신청함/참여중 (결제 완료/심사 대기/승인)
   rejected, // 심사 거절됨 (재신청 가능하도록 유도)
+  // Fix #1208: 종료된 이벤트 전용 상태
+  eventEnded, // 종료된 이벤트 (미신청 또는 비로그인)
+  eventEndedWithResults, // 종료 + 매칭 결과 있음
+  eventEndedParticipated, // 종료 + 참여했지만 매칭 결과 없음
 }
 
 /// **Admission State**

--- a/apps/app_user/test/src/features/event/admission/event_admission_controller_test.dart
+++ b/apps/app_user/test/src/features/event/admission/event_admission_controller_test.dart
@@ -9,6 +9,7 @@ import '../../../../utils/test_utils.dart';
 void main() {
   late MockEventRepository mockEventRepo;
   late MockUserRepository mockUserRepo;
+  late MockMatchingRepository mockMatchingRepo;
   late MockUser mockUser;
 
   // --- Test Data ---
@@ -43,6 +44,16 @@ void main() {
     ],
   );
 
+  final completedEvent = testEvent.copyWith(status: 'completed');
+  final cancelledEvent = testEvent.copyWith(status: 'cancelled');
+
+  final testMatchPair = MatchPair(
+    matchId: 'match_1',
+    eventId: 'event_1',
+    partnerId: 'partner_1',
+    matchedAt: DateTime.now(),
+  );
+
   final testEventWithQualification = testEvent.copyWith(
     entryGroups: [
       const EntryGroup(
@@ -59,6 +70,7 @@ void main() {
   setUp(() {
     mockEventRepo = MockEventRepository();
     mockUserRepo = MockUserRepository();
+    mockMatchingRepo = MockMatchingRepository();
     mockUser = MockUser();
     when(() => mockUser.id).thenReturn('user_1');
     when(() => mockEventRepo.getEventById(any())).thenAnswer(
@@ -263,6 +275,313 @@ void main() {
         eventAdmissionControllerProvider(testEventWithQualification).future,
       );
       expect(state.status, EventAdmissionStatus.eligible);
+    });
+  });
+
+  group('Ended event states', () {
+    test(
+      'State is eventEnded when event is completed and user is not logged in',
+      () async {
+        final container = createContainer(
+          overrides: [
+            currentUserProvider.overrideWith((ref) => null),
+            eventRepositoryProvider.overrideWith((ref) => mockEventRepo),
+            userRepositoryProvider.overrideWith((ref) => mockUserRepo),
+            matchingRepositoryProvider.overrideWith(
+              (ref) => mockMatchingRepo,
+            ),
+          ],
+        );
+
+        final state = await container.read(
+          eventAdmissionControllerProvider(completedEvent).future,
+        );
+        expect(state.status, EventAdmissionStatus.eventEnded);
+      },
+    );
+
+    test(
+      'State is eventEnded when event is cancelled and user is not logged in',
+      () async {
+        final container = createContainer(
+          overrides: [
+            currentUserProvider.overrideWith((ref) => null),
+            eventRepositoryProvider.overrideWith((ref) => mockEventRepo),
+            userRepositoryProvider.overrideWith((ref) => mockUserRepo),
+            matchingRepositoryProvider.overrideWith(
+              (ref) => mockMatchingRepo,
+            ),
+          ],
+        );
+
+        final state = await container.read(
+          eventAdmissionControllerProvider(cancelledEvent).future,
+        );
+        expect(state.status, EventAdmissionStatus.eventEnded);
+      },
+    );
+
+    test(
+      'State is eventEnded when event is completed and user has no application',
+      () async {
+        when(
+          () => mockEventRepo.getApplication(
+            eventId: any(named: 'eventId'),
+            userId: any(named: 'userId'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        final container = createContainer(
+          overrides: [
+            currentUserProvider.overrideWith((ref) => mockUser),
+            eventRepositoryProvider.overrideWith((ref) => mockEventRepo),
+            userRepositoryProvider.overrideWith((ref) => mockUserRepo),
+            matchingRepositoryProvider.overrideWith(
+              (ref) => mockMatchingRepo,
+            ),
+          ],
+        );
+
+        final state = await container.read(
+          eventAdmissionControllerProvider(completedEvent).future,
+        );
+        expect(state.status, EventAdmissionStatus.eventEnded);
+      },
+    );
+
+    test(
+      'State is eventEnded when event is completed and application was cancelled',
+      () async {
+        when(
+          () => mockEventRepo.getApplication(
+            eventId: any(named: 'eventId'),
+            userId: any(named: 'userId'),
+          ),
+        ).thenAnswer(
+          (_) async => EventApplication(
+            id: 'app_1',
+            eventId: 'event_1',
+            ticketId: 'ticket_1',
+            userId: 'user_1',
+            status: 'cancelled',
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ),
+        );
+
+        final container = createContainer(
+          overrides: [
+            currentUserProvider.overrideWith((ref) => mockUser),
+            eventRepositoryProvider.overrideWith((ref) => mockEventRepo),
+            userRepositoryProvider.overrideWith((ref) => mockUserRepo),
+            matchingRepositoryProvider.overrideWith(
+              (ref) => mockMatchingRepo,
+            ),
+          ],
+        );
+
+        final state = await container.read(
+          eventAdmissionControllerProvider(completedEvent).future,
+        );
+        expect(state.status, EventAdmissionStatus.eventEnded);
+      },
+    );
+
+    test(
+      'State is eventEndedWithResults when completed event has match results',
+      () async {
+        when(
+          () => mockEventRepo.getApplication(
+            eventId: any(named: 'eventId'),
+            userId: any(named: 'userId'),
+          ),
+        ).thenAnswer(
+          (_) async => EventApplication(
+            id: 'app_1',
+            eventId: 'event_1',
+            ticketId: 'ticket_1',
+            userId: 'user_1',
+            status: 'confirmed',
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ),
+        );
+        when(
+          () => mockMatchingRepo.getMyMatches(any()),
+        ).thenAnswer((_) async => [testMatchPair]);
+
+        final container = createContainer(
+          overrides: [
+            currentUserProvider.overrideWith((ref) => mockUser),
+            eventRepositoryProvider.overrideWith((ref) => mockEventRepo),
+            userRepositoryProvider.overrideWith((ref) => mockUserRepo),
+            matchingRepositoryProvider.overrideWith(
+              (ref) => mockMatchingRepo,
+            ),
+          ],
+        );
+
+        final state = await container.read(
+          eventAdmissionControllerProvider(completedEvent).future,
+        );
+        expect(state.status, EventAdmissionStatus.eventEndedWithResults);
+      },
+    );
+
+    test(
+      'State is eventEndedParticipated when completed event has no match results',
+      () async {
+        when(
+          () => mockEventRepo.getApplication(
+            eventId: any(named: 'eventId'),
+            userId: any(named: 'userId'),
+          ),
+        ).thenAnswer(
+          (_) async => EventApplication(
+            id: 'app_1',
+            eventId: 'event_1',
+            ticketId: 'ticket_1',
+            userId: 'user_1',
+            status: 'confirmed',
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          ),
+        );
+        when(
+          () => mockMatchingRepo.getMyMatches(any()),
+        ).thenAnswer((_) async => []);
+
+        final container = createContainer(
+          overrides: [
+            currentUserProvider.overrideWith((ref) => mockUser),
+            eventRepositoryProvider.overrideWith((ref) => mockEventRepo),
+            userRepositoryProvider.overrideWith((ref) => mockUserRepo),
+            matchingRepositoryProvider.overrideWith(
+              (ref) => mockMatchingRepo,
+            ),
+          ],
+        );
+
+        final state = await container.read(
+          eventAdmissionControllerProvider(completedEvent).future,
+        );
+        expect(state.status, EventAdmissionStatus.eventEndedParticipated);
+      },
+    );
+
+    test(
+      'Ended event short-circuits before eligibility — logged-in user without application',
+      () async {
+        // Even though user is verified and eligible, the ended-event check exits
+        // before any eligibility logic runs.
+        when(
+          () => mockEventRepo.getApplication(
+            eventId: any(named: 'eventId'),
+            userId: any(named: 'userId'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        final container = createContainer(
+          overrides: [
+            currentUserProvider.overrideWith((ref) => mockUser),
+            eventRepositoryProvider.overrideWith((ref) => mockEventRepo),
+            userRepositoryProvider.overrideWith((ref) => mockUserRepo),
+            matchingRepositoryProvider.overrideWith((ref) => mockMatchingRepo),
+          ],
+        );
+
+        final state = await container.read(
+          eventAdmissionControllerProvider(completedEvent).future,
+        );
+        expect(state.status, EventAdmissionStatus.eventEnded);
+
+        // Verify eligibility-related repos were never called
+        verifyNever(() => mockUserRepo.getUserProfile(any()));
+        verifyNever(() => mockUserRepo.getApprovedVerificationIds(any()));
+      },
+    );
+  });
+
+  group('Ended event button config', () {
+    test('eventEnded shows disabled button', () async {
+      final container = createContainer(
+        overrides: [
+          currentUserProvider.overrideWith((ref) => null),
+          eventRepositoryProvider.overrideWith((ref) => mockEventRepo),
+          userRepositoryProvider.overrideWith((ref) => mockUserRepo),
+          matchingRepositoryProvider.overrideWith(
+            (ref) => mockMatchingRepo,
+          ),
+        ],
+      );
+
+      // Wait for the provider to resolve before accessing notifier
+      await container.read(
+        eventAdmissionControllerProvider(completedEvent).future,
+      );
+      final controller = container.read(
+        eventAdmissionControllerProvider(completedEvent).notifier,
+      );
+      final config = controller.buttonConfig(
+        AdmissionState(status: EventAdmissionStatus.eventEnded),
+      );
+
+      expect(config.label, '종료된 이벤트');
+      expect(config.enabled, isFalse);
+      expect(config.style, AdmissionButtonStyle.disabled);
+    });
+
+    test('eventEndedWithResults shows enabled button', () async {
+      final container = createContainer(
+        overrides: [
+          currentUserProvider.overrideWith((ref) => null),
+          eventRepositoryProvider.overrideWith((ref) => mockEventRepo),
+          userRepositoryProvider.overrideWith((ref) => mockUserRepo),
+          matchingRepositoryProvider.overrideWith(
+            (ref) => mockMatchingRepo,
+          ),
+        ],
+      );
+
+      await container.read(
+        eventAdmissionControllerProvider(completedEvent).future,
+      );
+      final controller = container.read(
+        eventAdmissionControllerProvider(completedEvent).notifier,
+      );
+      final config = controller.buttonConfig(
+        AdmissionState(status: EventAdmissionStatus.eventEndedWithResults),
+      );
+
+      expect(config.label, '매칭 결과 보기');
+      expect(config.enabled, isTrue);
+    });
+
+    test('eventEndedParticipated shows disabled button', () async {
+      final container = createContainer(
+        overrides: [
+          currentUserProvider.overrideWith((ref) => null),
+          eventRepositoryProvider.overrideWith((ref) => mockEventRepo),
+          userRepositoryProvider.overrideWith((ref) => mockUserRepo),
+          matchingRepositoryProvider.overrideWith(
+            (ref) => mockMatchingRepo,
+          ),
+        ],
+      );
+
+      await container.read(
+        eventAdmissionControllerProvider(completedEvent).future,
+      );
+      final controller = container.read(
+        eventAdmissionControllerProvider(completedEvent).notifier,
+      );
+      final config = controller.buttonConfig(
+        AdmissionState(status: EventAdmissionStatus.eventEndedParticipated),
+      );
+
+      expect(config.label, '참여 완료');
+      expect(config.enabled, isFalse);
+      expect(config.style, AdmissionButtonStyle.disabled);
     });
   });
 }


### PR DESCRIPTION
Scheduler: needs-arch-claude-team-1

## Summary

- `EventAdmissionController`가 `event.status`를 확인하지 않아 종료된 이벤트에서도 "이미 신청한 이벤트" CTA가 표시되던 버그 수정
- 3개의 새로운 `EventAdmissionStatus` 추가: `eventEnded`, `eventEndedWithResults`, `eventEndedParticipated`
- 종료 이벤트에서 매칭 결과가 있는 경우 "매칭 결과 보기" 버튼으로 `ResultsContent` 바텀시트 표시
- 10개 신규 테스트 (7 상태 테스트 + 3 버튼 설정 테스트)

## Changes

| 상태 | CTA 버튼 | 동작 |
|------|----------|------|
| 종료 + 미신청/비로그인 | "종료된 이벤트" (disabled) | 없음 |
| 종료 + 매칭 결과 있음 | "매칭 결과 보기" (enabled) | ResultsContent 바텀시트 |
| 종료 + 참여완료 + 결과 없음 | "참여 완료" (disabled) | 없음 |

## Test plan

- [x] eventEnded: completed event, guest user
- [x] eventEnded: cancelled event, guest user
- [x] eventEnded: completed event, no application
- [x] eventEnded: completed event, cancelled application
- [x] eventEndedWithResults: completed event with match results
- [x] eventEndedParticipated: completed event, no match results
- [x] Ended check short-circuits before eligibility logic
- [x] Button config: label, enabled, style for all 3 new states

Closes #1208

🤖 Generated with [Claude Code](https://claude.com/claude-code)