### PR TITLE
docs(ux): UX 리뷰 wireframe — Pretendard 폰트 + 구매 내역 색상 위계

### DIFF
--- a/docs/features/font-migration-pretendard/typography-review.html
+++ b/docs/features/font-migration-pretendard/typography-review.html
@@ -1,0 +1,957 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>밍릿 — Pretendard 폰트 마이그레이션 타이포그래피 리뷰</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700&display=swap');
+  @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css');
+
+  :root {
+    --color-background: #FFFFFF;
+    --color-primary: #9900FF;
+    --color-primary-light: rgba(153, 0, 255, 0.08);
+    --color-secondary: #FF9900;
+    --color-surface: #F9FAFB;
+    --color-error: #EF4444;
+    --color-text-primary: #111827;
+    --color-text-secondary: #4B5563;
+    --color-text-tertiary: #9CA3AF;
+    --color-success: #22C55E;
+    --color-divider: #E5E7EB;
+    --color-divider-light: #F3F4F6;
+
+    --sp-xxsmall: 2px;
+    --sp-xsmall: 4px;
+    --sp-xsmall2: 6px;
+    --sp-small: 8px;
+    --sp-sm: 12px;
+    --sp-medium: 16px;
+    --sp-large: 24px;
+    --sp-xlarge: 32px;
+    --sp-screen-edge: 20px;
+
+    --radius-small: 8px;
+    --radius-button: 12px;
+    --radius-card: 16px;
+    --radius-chip: 100px;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: 'Pretendard Variable', -apple-system, sans-serif;
+    background: #E5E7EB;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 40px 20px;
+    color: var(--color-text-primary);
+  }
+
+  .page-title {
+    font-size: 28px;
+    font-weight: 700;
+    margin-bottom: 8px;
+    text-align: center;
+  }
+
+  .page-subtitle {
+    font-size: 14px;
+    color: var(--color-text-secondary);
+    margin-bottom: 40px;
+    text-align: center;
+  }
+
+  .section {
+    width: 100%;
+    max-width: 900px;
+    margin-bottom: 40px;
+  }
+
+  .section-title {
+    font-size: 18px;
+    font-weight: 700;
+    margin-bottom: 16px;
+    color: var(--color-primary);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .section-title::before {
+    content: '';
+    width: 4px;
+    height: 20px;
+    background: var(--color-primary);
+    border-radius: 2px;
+    flex-shrink: 0;
+  }
+
+  .card {
+    background: var(--color-background);
+    border-radius: var(--radius-card);
+    padding: var(--sp-large);
+    margin-bottom: 16px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+  }
+
+  /* === Comparison Grid === */
+  .comparison-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
+
+  .comparison-col {
+    background: var(--color-background);
+    border-radius: var(--radius-card);
+    padding: var(--sp-large);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+  }
+
+  .comparison-col.before {
+    border-top: 3px solid var(--color-text-tertiary);
+  }
+
+  .comparison-col.after {
+    border-top: 3px solid var(--color-primary);
+  }
+
+  .col-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 16px;
+    padding: 4px 10px;
+    border-radius: 4px;
+    display: inline-block;
+  }
+
+  .before .col-label {
+    background: #F3F4F6;
+    color: var(--color-text-secondary);
+  }
+
+  .after .col-label {
+    background: var(--color-primary-light);
+    color: var(--color-primary);
+  }
+
+  .font-noto { font-family: 'Noto Sans KR', sans-serif; }
+  .font-pretendard { font-family: 'Pretendard Variable', sans-serif; }
+
+  /* === Type Scale === */
+  .type-row {
+    padding: 12px 0;
+    border-bottom: 1px solid var(--color-divider-light);
+  }
+
+  .type-row:last-child {
+    border-bottom: none;
+  }
+
+  .type-meta {
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--color-text-tertiary);
+    margin-bottom: 4px;
+    letter-spacing: 0.5px;
+  }
+
+  .type-sample {
+    color: var(--color-text-primary);
+    line-height: 1.4;
+  }
+
+  /* === Tuning Table === */
+  .tuning-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+  }
+
+  .tuning-table th {
+    text-align: left;
+    padding: 10px 12px;
+    background: var(--color-surface);
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--color-text-secondary);
+    border-bottom: 2px solid var(--color-divider);
+  }
+
+  .tuning-table td {
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--color-divider-light);
+    vertical-align: top;
+  }
+
+  .tuning-table tr:last-child td {
+    border-bottom: none;
+  }
+
+  .badge {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 100px;
+    white-space: nowrap;
+  }
+
+  .badge-keep {
+    background: #F0FDF4;
+    color: #16A34A;
+  }
+
+  .badge-adjust {
+    background: #FFF7ED;
+    color: #EA580C;
+  }
+
+  .badge-new {
+    background: #EFF6FF;
+    color: #2563EB;
+  }
+
+  .badge-remove {
+    background: #FEF2F2;
+    color: #DC2626;
+  }
+
+  /* === Phone Mockup === */
+  .phone-mockup-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 24px;
+    justify-items: center;
+  }
+
+  .phone-frame {
+    width: 320px;
+    height: 640px;
+    background: var(--color-background);
+    border-radius: 36px;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.12), inset 0 0 0 2px #E5E7EB;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+  }
+
+  .phone-frame.dark {
+    background: #0F0F0F;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.3), inset 0 0 0 2px #333;
+  }
+
+  .phone-status-bar {
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 600;
+    flex-shrink: 0;
+  }
+
+  .phone-status-bar .notch {
+    width: 120px;
+    height: 28px;
+    background: #000;
+    border-radius: 0 0 16px 16px;
+  }
+
+  .phone-frame.dark .phone-status-bar .notch {
+    background: #1a1a1a;
+  }
+
+  .phone-appbar {
+    height: 56px;
+    padding: 0 var(--sp-medium);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-shrink: 0;
+    border-bottom: 1px solid var(--color-divider-light);
+  }
+
+  .phone-frame.dark .phone-appbar {
+    border-bottom-color: #2a2a2a;
+  }
+
+  .phone-appbar-title {
+    font-size: 18px;
+    font-weight: 600;
+  }
+
+  .phone-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--sp-medium);
+  }
+
+  .phone-nav {
+    height: 64px;
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    border-top: 1px solid var(--color-divider-light);
+    flex-shrink: 0;
+  }
+
+  .phone-frame.dark .phone-nav {
+    border-top-color: #2a2a2a;
+  }
+
+  .nav-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    font-size: 10px;
+    color: var(--color-text-tertiary);
+  }
+
+  .nav-item.active {
+    color: var(--color-primary);
+  }
+
+  .nav-icon {
+    width: 24px;
+    height: 24px;
+    border-radius: 6px;
+    background: currentColor;
+    opacity: 0.3;
+  }
+
+  .nav-item.active .nav-icon {
+    opacity: 0.5;
+  }
+
+  /* Phone content elements */
+  .mock-greeting {
+    margin-bottom: 20px;
+  }
+
+  .mock-greeting .name {
+    font-size: 20px;
+    font-weight: 700;
+  }
+
+  .mock-greeting .sub {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+    margin-top: 4px;
+    line-height: 1.5;
+  }
+
+  .mock-event-card {
+    background: var(--color-surface);
+    border-radius: var(--radius-card);
+    padding: var(--sp-medium);
+    margin-bottom: 12px;
+  }
+
+  .phone-frame.dark .mock-event-card {
+    background: #212121;
+  }
+
+  .mock-event-card .event-img {
+    width: 100%;
+    height: 100px;
+    background: linear-gradient(135deg, #9900FF22, #FF990022);
+    border-radius: var(--radius-small);
+    margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+  }
+
+  .mock-event-card .event-title {
+    font-size: 16px;
+    font-weight: 700;
+  }
+
+  .mock-event-card .event-meta {
+    font-size: 12px;
+    color: var(--color-text-secondary);
+    margin-top: 4px;
+  }
+
+  .mock-chip-row {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+    flex-wrap: wrap;
+  }
+
+  .mock-chip {
+    font-size: 11px;
+    font-weight: 500;
+    padding: 4px 10px;
+    border-radius: 100px;
+    background: var(--color-primary-light);
+    color: var(--color-primary);
+  }
+
+  .phone-frame.dark .mock-chip {
+    background: rgba(153, 0, 255, 0.2);
+  }
+
+  .mock-btn {
+    width: 100%;
+    height: 48px;
+    border-radius: var(--radius-button);
+    background: var(--color-primary);
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 16px;
+    font-weight: 700;
+    margin-top: 16px;
+  }
+
+  /* === Verdict Section === */
+  .verdict {
+    display: flex;
+    gap: 16px;
+    align-items: flex-start;
+  }
+
+  .verdict-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+    flex-shrink: 0;
+  }
+
+  .verdict-icon.approve {
+    background: #F0FDF4;
+  }
+
+  .verdict-text h3 {
+    font-size: 16px;
+    font-weight: 700;
+    margin-bottom: 4px;
+  }
+
+  .verdict-text p {
+    font-size: 14px;
+    color: var(--color-text-secondary);
+    line-height: 1.6;
+  }
+
+  /* === Checklist === */
+  .checklist-item {
+    display: flex;
+    gap: 12px;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--color-divider-light);
+    font-size: 14px;
+    line-height: 1.5;
+  }
+
+  .checklist-item:last-child {
+    border-bottom: none;
+  }
+
+  .check-icon {
+    width: 20px;
+    height: 20px;
+    border: 2px solid var(--color-primary);
+    border-radius: 50%;
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  /* === Weight Compare === */
+  .weight-row {
+    display: flex;
+    align-items: baseline;
+    gap: 16px;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--color-divider-light);
+  }
+
+  .weight-row:last-child {
+    border-bottom: none;
+  }
+
+  .weight-label {
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--color-text-tertiary);
+    width: 60px;
+    flex-shrink: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .weight-sample {
+    font-size: 18px;
+    flex: 1;
+  }
+
+  .annotation {
+    font-size: 11px;
+    color: var(--color-text-tertiary);
+    font-style: italic;
+    margin-top: 8px;
+    padding-left: 16px;
+    border-left: 2px solid var(--color-divider);
+  }
+
+  /* Responsive */
+  @media (max-width: 768px) {
+    .comparison-grid, .phone-mockup-row {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>
+</head>
+<body>
+
+<div class="page-title">Pretendard 폰트 마이그레이션 — UX 리뷰</div>
+<div class="page-subtitle">Issue #1231 · needs-uiux-claude-1 · 2026-04-10</div>
+
+<!-- Section 1: Verdict -->
+<div class="section">
+  <div class="section-title">UX 판정</div>
+  <div class="card">
+    <div class="verdict">
+      <div class="verdict-icon approve">✅</div>
+      <div class="verdict-text">
+        <h3>승인 — Pretendard Variable 전환을 적극 지지한다</h3>
+        <p>
+          Pretendard는 한글 가독성에 최적화된 폰트로, 토스·당근·네이버·쿠팡·야놀자 등 국내 톱티어 앱들이 채택한 업계 표준이다.
+          높은 x-height, 명확한 스트로크 대비, 컴팩트한 자폭이 모바일 환경에서 텍스트를 또렷하게 보이게 만든다.
+          현재 NotoSansKR의 "글자가 배경에 가라앉는 느낌" 문제를 근본적으로 해결할 수 있다.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Section 2: Typography Scale Comparison -->
+<div class="section">
+  <div class="section-title">타이포그래피 스케일 비교</div>
+  <div class="comparison-grid">
+    <!-- Before: NotoSansKR -->
+    <div class="comparison-col before">
+      <div class="col-label">Before — Noto Sans KR</div>
+
+      <div class="type-row">
+        <div class="type-meta">displayLarge · 32px · bold · h1.25</div>
+        <div class="type-sample font-noto" style="font-size:32px; font-weight:700; line-height:1.25;">이벤트를 발견하세요</div>
+      </div>
+      <div class="type-row">
+        <div class="type-meta">headlineSmall · 24px · bold · h1.33</div>
+        <div class="type-sample font-noto" style="font-size:24px; font-weight:700; line-height:1.33;">이번 주 인기 이벤트</div>
+      </div>
+      <div class="type-row">
+        <div class="type-meta">titleLarge · 20px · bold · h1.4</div>
+        <div class="type-sample font-noto" style="font-size:20px; font-weight:700; line-height:1.4;">강남 와인 테이스팅</div>
+      </div>
+      <div class="type-row">
+        <div class="type-meta">titleMedium · 16px · bold · h1.5</div>
+        <div class="type-sample font-noto" style="font-size:16px; font-weight:700; line-height:1.5;">참가자 12명 / 20명</div>
+      </div>
+      <div class="type-row">
+        <div class="type-meta">bodyMedium · 16px · normal · h1.5</div>
+        <div class="type-sample font-noto" style="font-size:16px; font-weight:400; line-height:1.5; color:#4B5563;">와인을 좋아하는 분들이 모여 함께 시음하고 이야기를 나누는 자리입니다. 소규모로 진행되며 편안한 분위기에서 진행됩니다.</div>
+      </div>
+      <div class="type-row">
+        <div class="type-meta">bodySmall · 13px · normal · h1.5</div>
+        <div class="type-sample font-noto" style="font-size:13px; font-weight:400; line-height:1.5; color:#4B5563;">2026년 4월 15일 화요일 · 서울 강남구</div>
+      </div>
+      <div class="type-row">
+        <div class="type-meta">labelMedium · 12px · w500 · h1.5</div>
+        <div class="type-sample font-noto" style="font-size:12px; font-weight:500; line-height:1.5;">마감 D-3</div>
+      </div>
+      <div class="type-row">
+        <div class="type-meta">labelSmall · 11px · w500 · h1.45</div>
+        <div class="type-sample font-noto" style="font-size:11px; font-weight:500; line-height:1.45;">인증 완료 · 리뷰 4.8</div>
+      </div>
+      <div class="type-row">
+        <div class="type-meta">captionTiny · 10px · w500</div>
+        <div class="type-sample font-noto" style="font-size:10px; font-weight:500;">STEP 2 / 3</div>
+      </div>
+    </div>
+
+    <!-- After: Pretendard -->
+    <div class="comparison-col after">
+      <div class="col-label">After — Pretendard Variable</div>
+
+      <div class="type-row">
+        <div class="type-meta">displayLarge · 32px · bold · h1.25</div>
+        <div class="type-sample font-pretendard" style="font-size:32px; font-weight:700; line-height:1.25;">이벤트를 발견하세요</div>
+      </div>
+      <div class="type-row">
+        <div class="type-meta">headlineSmall · 24px · bold · h1.33</div>
+        <div class="type-sample font-pretendard" style="font-size:24px; font-weight:700; line-height:1.33;">이번 주 인기 이벤트</div>
+      </div>
+      <div class="type-row">
+        <div class="type-meta">titleLarge · 20px · bold · h1.4</div>
+        <div class="type-sample font-pretendard" style="font-size:20px; font-weight:700; line-height:1.4;">강남 와인 테이스팅</div>
+      </div>
+      <div class="type-row">
+        <div class="type-meta">titleMedium · 16px · bold · h1.5</div>
+        <div class="type-sample font-pretendard" style="font-size:16px; font-weight:700; line-height:1.5;">참가자 12명 / 20명</div>
+      </div>
+      <div class="type-row">
+        <div class="type-meta">bodyMedium · 16px · normal · h1.5</div>
+        <div class="type-sample font-pretendard" style="font-size:16px; font-weight:400; line-height:1.5; color:#4B5563;">와인을 좋아하는 분들이 모여 함께 시음하고 이야기를 나누는 자리입니다. 소규모로 진행되며 편안한 분위기에서 진행됩니다.</div>
+      </div>
+      <div class="type-row">
+        <div class="type-meta">bodySmall · 13px · normal · h1.5</div>
+        <div class="type-sample font-pretendard" style="font-size:13px; font-weight:400; line-height:1.5; color:#4B5563;">2026년 4월 15일 화요일 · 서울 강남구</div>
+      </div>
+      <div class="type-row">
+        <div class="type-meta">labelMedium · 12px · w500 · h1.5</div>
+        <div class="type-sample font-pretendard" style="font-size:12px; font-weight:500; line-height:1.5;">마감 D-3</div>
+      </div>
+      <div class="type-row">
+        <div class="type-meta">labelSmall · 11px · w500 · h1.45</div>
+        <div class="type-sample font-pretendard" style="font-size:11px; font-weight:500; line-height:1.45;">인증 완료 · 리뷰 4.8</div>
+      </div>
+      <div class="type-row">
+        <div class="type-meta">captionTiny · 10px · w500</div>
+        <div class="type-sample font-pretendard" style="font-size:10px; font-weight:500;">STEP 2 / 3</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Section 3: Weight Rendering -->
+<div class="section">
+  <div class="section-title">Weight 렌더링 비교</div>
+  <div class="comparison-grid">
+    <div class="comparison-col before">
+      <div class="col-label">Noto Sans KR</div>
+      <div class="weight-row">
+        <div class="weight-label">w400</div>
+        <div class="weight-sample font-noto" style="font-weight:400;">밍글릿에서 만나요</div>
+      </div>
+      <div class="weight-row">
+        <div class="weight-label">w500</div>
+        <div class="weight-sample font-noto" style="font-weight:500;">밍글릿에서 만나요</div>
+      </div>
+      <div class="weight-row">
+        <div class="weight-label">w600</div>
+        <div class="weight-sample font-noto" style="font-weight:600;">밍글릿에서 만나요</div>
+      </div>
+      <div class="weight-row">
+        <div class="weight-label">w700</div>
+        <div class="weight-sample font-noto" style="font-weight:700;">밍글릿에서 만나요</div>
+      </div>
+    </div>
+    <div class="comparison-col after">
+      <div class="col-label">Pretendard Variable</div>
+      <div class="weight-row">
+        <div class="weight-label">w400</div>
+        <div class="weight-sample font-pretendard" style="font-weight:400;">밍글릿에서 만나요</div>
+      </div>
+      <div class="weight-row">
+        <div class="weight-label">w500</div>
+        <div class="weight-sample font-pretendard" style="font-weight:500;">밍글릿에서 만나요</div>
+      </div>
+      <div class="weight-row">
+        <div class="weight-label">w600</div>
+        <div class="weight-sample font-pretendard" style="font-weight:600;">밍글릿에서 만나요</div>
+      </div>
+      <div class="weight-row">
+        <div class="weight-label">w700</div>
+        <div class="weight-sample font-pretendard" style="font-weight:700;">밍글릿에서 만나요</div>
+      </div>
+      <div class="annotation">Pretendard w500-w600 구간의 굵기 차이가 NotoSansKR보다 명확하다. 이는 label/chip 텍스트의 시각적 구분을 개선한다.</div>
+    </div>
+  </div>
+</div>
+
+<!-- Section 4: Phone Mockup -->
+<div class="section">
+  <div class="section-title">화면 목업 — 홈 화면 비교</div>
+  <div class="phone-mockup-row">
+    <!-- Before -->
+    <div>
+      <div style="text-align:center; font-size:12px; font-weight:600; color:var(--color-text-secondary); margin-bottom:12px;">BEFORE — Noto Sans KR</div>
+      <div class="phone-frame font-noto">
+        <div class="phone-status-bar"><div class="notch"></div></div>
+        <div class="phone-appbar">
+          <div style="width:32px; height:32px; background:linear-gradient(135deg, #9900FF, #FF9900); border-radius:8px;"></div>
+          <div class="phone-appbar-title font-noto" style="font-weight:600;">밍글릿</div>
+        </div>
+        <div class="phone-content font-noto">
+          <div class="mock-greeting">
+            <div class="name font-noto">안녕하세요, 지원님 👋</div>
+            <div class="sub font-noto">새로운 이벤트가 3개 있어요</div>
+          </div>
+          <div class="mock-event-card">
+            <div class="event-img">🍷</div>
+            <div class="event-title font-noto">강남 와인 테이스팅</div>
+            <div class="event-meta font-noto">4월 15일 화 · 강남역 3번출구 · 20명</div>
+            <div class="mock-chip-row">
+              <div class="mock-chip font-noto">와인</div>
+              <div class="mock-chip font-noto">20대</div>
+              <div class="mock-chip font-noto">소규모</div>
+            </div>
+          </div>
+          <div class="mock-event-card">
+            <div class="event-img">📚</div>
+            <div class="event-title font-noto">독서모임 북클럽</div>
+            <div class="event-meta font-noto">4월 18일 금 · 성수동 카페 · 12명</div>
+            <div class="mock-chip-row">
+              <div class="mock-chip font-noto">독서</div>
+              <div class="mock-chip font-noto">30대</div>
+            </div>
+          </div>
+          <div class="mock-btn font-noto">이벤트 더보기</div>
+        </div>
+        <div class="phone-nav font-noto">
+          <div class="nav-item active"><div class="nav-icon"></div>홈</div>
+          <div class="nav-item"><div class="nav-icon"></div>탐색</div>
+          <div class="nav-item"><div class="nav-icon"></div>채팅</div>
+          <div class="nav-item"><div class="nav-icon"></div>MY</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- After -->
+    <div>
+      <div style="text-align:center; font-size:12px; font-weight:600; color:var(--color-primary); margin-bottom:12px;">AFTER — Pretendard Variable</div>
+      <div class="phone-frame font-pretendard">
+        <div class="phone-status-bar"><div class="notch"></div></div>
+        <div class="phone-appbar">
+          <div style="width:32px; height:32px; background:linear-gradient(135deg, #9900FF, #FF9900); border-radius:8px;"></div>
+          <div class="phone-appbar-title font-pretendard" style="font-weight:600;">밍글릿</div>
+        </div>
+        <div class="phone-content font-pretendard">
+          <div class="mock-greeting">
+            <div class="name font-pretendard">안녕하세요, 지원님 👋</div>
+            <div class="sub font-pretendard">새로운 이벤트가 3개 있어요</div>
+          </div>
+          <div class="mock-event-card">
+            <div class="event-img">🍷</div>
+            <div class="event-title font-pretendard">강남 와인 테이스팅</div>
+            <div class="event-meta font-pretendard">4월 15일 화 · 강남역 3번출구 · 20명</div>
+            <div class="mock-chip-row">
+              <div class="mock-chip font-pretendard">와인</div>
+              <div class="mock-chip font-pretendard">20대</div>
+              <div class="mock-chip font-pretendard">소규모</div>
+            </div>
+          </div>
+          <div class="mock-event-card">
+            <div class="event-img">📚</div>
+            <div class="event-title font-pretendard">독서모임 북클럽</div>
+            <div class="event-meta font-pretendard">4월 18일 금 · 성수동 카페 · 12명</div>
+            <div class="mock-chip-row">
+              <div class="mock-chip font-pretendard">독서</div>
+              <div class="mock-chip font-pretendard">30대</div>
+            </div>
+          </div>
+          <div class="mock-btn font-pretendard">이벤트 더보기</div>
+        </div>
+        <div class="phone-nav font-pretendard">
+          <div class="nav-item active"><div class="nav-icon"></div>홈</div>
+          <div class="nav-item"><div class="nav-icon"></div>탐색</div>
+          <div class="nav-item"><div class="nav-icon"></div>채팅</div>
+          <div class="nav-item"><div class="nav-icon"></div>MY</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Section 5: Tuning Recommendations -->
+<div class="section">
+  <div class="section-title">타이포그래피 튜닝 권고사항</div>
+  <div class="card">
+    <table class="tuning-table">
+      <thead>
+        <tr>
+          <th>항목</th>
+          <th>현재값</th>
+          <th>권고</th>
+          <th>상태</th>
+          <th>이유</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>fontFamily</strong></td>
+          <td>NotoSansKR</td>
+          <td>Pretendard</td>
+          <td><span class="badge badge-adjust">변경</span></td>
+          <td>이슈 스펙대로 전환</td>
+        </tr>
+        <tr>
+          <td><strong>fontSize 전체</strong></td>
+          <td>10–32px</td>
+          <td>유지</td>
+          <td><span class="badge badge-keep">유지</span></td>
+          <td>Pretendard의 높은 x-height로 체감 크기가 자연스럽게 개선됨. 사이즈 변경 불필요.</td>
+        </tr>
+        <tr>
+          <td><strong>fontWeight 전체</strong></td>
+          <td>w400–w700</td>
+          <td>유지</td>
+          <td><span class="badge badge-keep">유지</span></td>
+          <td>Pretendard Variable의 weight axis가 동일 범위를 커버. 매핑 변경 불필요.</td>
+        </tr>
+        <tr>
+          <td><strong>line-height 전체</strong></td>
+          <td>1.25–1.5</td>
+          <td>유지</td>
+          <td><span class="badge badge-keep">유지</span></td>
+          <td>현재 line-height는 4pt grid 기반으로 잘 설계됨. Pretendard에서도 적절한 여백 유지.</td>
+        </tr>
+        <tr>
+          <td><strong>letterSpacing (11–13px)</strong></td>
+          <td>없음</td>
+          <td><code>letterSpacing: 0.1</code></td>
+          <td><span class="badge badge-new">후속 검토</span></td>
+          <td>Pretendard는 컴팩트해서 소형 텍스트가 다닥다닥 붙을 수 있음. <strong>1차 PR에서는 추가하지 않고</strong>, 실기기 테스트 후 필요 시 후속 PR로 조정.</td>
+        </tr>
+        <tr>
+          <td><strong>NotoSansKR 에셋</strong></td>
+          <td>유지</td>
+          <td>1차: 유지 (Option B)</td>
+          <td><span class="badge badge-keep">유지</span></td>
+          <td>안전한 폴백. 후속 PR에서 제거 (Option A) 권장. Pretendard가 KS X 1001 전체 커버하므로 폴백 필요성은 낮음.</td>
+        </tr>
+        <tr>
+          <td><strong>RacingSansOne</strong></td>
+          <td>브랜드 로고용</td>
+          <td>절대 변경 금지</td>
+          <td><span class="badge badge-keep">유지</span></td>
+          <td>브랜드 아이덴티티. 교체 대상 아님.</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<!-- Section 6: Implementation Notes for SWE -->
+<div class="section">
+  <div class="section-title">SWE 구현 가이드 (UX 관점)</div>
+  <div class="card">
+    <table class="tuning-table">
+      <thead>
+        <tr>
+          <th>파일</th>
+          <th>변경 위치</th>
+          <th>주의사항</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>minglit_theme.dart</code></td>
+          <td>L65 fontFamily, L310, L419</td>
+          <td>materialTheme + partnerTheme + darkTheme 모두 교체 필수</td>
+        </tr>
+        <tr>
+          <td><code>minglit_text_theme_extension.dart</code></td>
+          <td>L68, L89</td>
+          <td>light/dark 양쪽 appBarTitle의 fontFamily</td>
+        </tr>
+        <tr>
+          <td><code>minglit_component_theme.dart</code></td>
+          <td>L15, L134, L140</td>
+          <td>appBar titleTextStyle, tabBar labelStyle/unselectedLabelStyle</td>
+        </tr>
+        <tr>
+          <td><code>pubspec.yaml</code></td>
+          <td>fonts 섹션</td>
+          <td>Variable font 단일 등록. Flutter 3.16+ 기준.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="annotation" style="margin-top:16px;">
+      총 <strong>9곳</strong>의 fontFamily: 'NotoSansKR' 하드코딩을 'Pretendard'로 교체해야 한다.
+      ThemeData.fontFamily가 전체 앱에 적용되므로, fontFamily를 명시하지 않은 TextStyle들은 자동으로 Pretendard를 상속한다.
+    </div>
+  </div>
+</div>
+
+<!-- Section 7: Visual Verification Checklist -->
+<div class="section">
+  <div class="section-title">시각적 검증 체크리스트 (UX 리뷰 시 확인할 것)</div>
+  <div class="card">
+    <div class="checklist-item">
+      <div class="check-icon"></div>
+      <div><strong>x-height 개선</strong> — 동일 px 대비 글자가 더 또렷하게 보이는지. 특히 13px 이하 소형 텍스트에서 차이가 명확해야 한다.</div>
+    </div>
+    <div class="checklist-item">
+      <div class="check-icon"></div>
+      <div><strong>Weight 구분</strong> — w400(본문) ↔ w500(라벨) ↔ w600(AppBar) ↔ w700(타이틀) 각 단계가 육안으로 구분되는지.</div>
+    </div>
+    <div class="checklist-item">
+      <div class="check-icon"></div>
+      <div><strong>복잡 자소</strong> — ㅉ, ㅎ, ㅙ, ㅢ, 됐, 뷁 등 복잡한 한글 자소가 깨지거나 뭉개지지 않는지.</div>
+    </div>
+    <div class="checklist-item">
+      <div class="check-icon"></div>
+      <div><strong>숫자·영문 혼합</strong> — "참가자 12/20명", "D-3", "4.8점" 등 한영 혼합 텍스트에서 baseline 정렬이 맞는지.</div>
+    </div>
+    <div class="checklist-item">
+      <div class="check-icon"></div>
+      <div><strong>긴 텍스트 줄바꿈</strong> — 이벤트 설명 등 multi-line 본문에서 줄간격(line-height)이 답답하지 않은지.</div>
+    </div>
+    <div class="checklist-item">
+      <div class="check-icon"></div>
+      <div><strong>칩/배지 오버플로</strong> — Pretendard가 컴팩트하므로 기존에 빡빡했던 칩이 여유로워질 수 있음. 반대로 padding이 과해 보이지 않는지 확인.</div>
+    </div>
+    <div class="checklist-item">
+      <div class="check-icon"></div>
+      <div><strong>다크 모드</strong> — Pretendard의 스트로크 대비가 다크 배경에서도 가독성을 유지하는지.</div>
+    </div>
+    <div class="checklist-item">
+      <div class="check-icon"></div>
+      <div><strong>RacingSansOne 무결성</strong> — 브랜드 로고/히어로 텍스트가 Pretendard로 바뀌지 않았는지 반드시 확인.</div>
+    </div>
+    <div class="checklist-item">
+      <div class="check-icon"></div>
+      <div><strong>Design Catalog</strong> — Dev Only 메뉴의 타이포그래피 탭에서 전체 스케일이 정상 렌더링되는지.</div>
+    </div>
+  </div>
+</div>
+
+<!-- Section 8: Design System Doc Update -->
+<div class="section">
+  <div class="section-title">디자인 시스템 문서 업데이트 필요사항</div>
+  <div class="card">
+    <table class="tuning-table">
+      <thead>
+        <tr>
+          <th>문서</th>
+          <th>변경</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>docs/ux/design-system/01-foundation.md</code></td>
+          <td>Section 3 "기본 폰트 패밀리: NotoSansKR" → "Pretendard" 변경. PR 머지 후 UX 디자이너(나)가 업데이트할 것.</td>
+        </tr>
+        <tr>
+          <td><code>docs/ux/design-system/02-components.md</code></td>
+          <td>AppBar titleTextStyle.fontFamily 값 업데이트</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+</body>
+</html>

--- a/docs/features/purchase-history-color-hierarchy/wireframe.html
+++ b/docs/features/purchase-history-color-hierarchy/wireframe.html
@@ -1,0 +1,1000 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>밍릿 — 구매 내역 색상 위계 리디자인</title>
+<style>
+  @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css');
+
+  :root {
+    --color-background: #FFFFFF;
+    --color-primary: #9900FF;
+    --color-primary-light: rgba(153, 0, 255, 0.08);
+    --color-secondary: #FF9900;
+    --color-surface: #F9FAFB;
+    --color-error: #EF4444;
+    --color-text-primary: #111827;
+    --color-text-secondary: #4B5563;
+    --color-text-tertiary: #9CA3AF;
+    --color-success: #22C55E;
+    --color-warning: #F59E0B;
+    --color-info: #3B82F6;
+    --color-divider: #E5E7EB;
+    --color-divider-light: #F3F4F6;
+    --color-outline: #D1D5DB;
+
+    --sp-xxsmall: 2px;
+    --sp-xsmall: 4px;
+    --sp-xsmall2: 6px;
+    --sp-small: 8px;
+    --sp-sm: 12px;
+    --sp-medium: 16px;
+    --sp-large: 24px;
+    --sp-xlarge: 32px;
+    --sp-screen-edge: 20px;
+
+    --radius-small: 8px;
+    --radius-button: 12px;
+    --radius-card: 16px;
+    --radius-chip: 100px;
+
+    --font-family: 'Pretendard Variable', -apple-system, BlinkMacSystemFont, sans-serif;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: var(--font-family);
+    background: #E5E7EB;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 40px 20px;
+    color: var(--color-text-primary);
+  }
+
+  .page-title {
+    font-size: 28px;
+    font-weight: 700;
+    margin-bottom: 8px;
+    text-align: center;
+  }
+
+  .page-subtitle {
+    font-size: 14px;
+    color: var(--color-text-secondary);
+    margin-bottom: 40px;
+    text-align: center;
+  }
+
+  .section {
+    width: 100%;
+    max-width: 900px;
+    margin-bottom: 40px;
+  }
+
+  .section-title {
+    font-size: 18px;
+    font-weight: 700;
+    margin-bottom: 16px;
+    color: var(--color-primary);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .section-title::before {
+    content: '';
+    width: 4px;
+    height: 20px;
+    background: var(--color-primary);
+    border-radius: 2px;
+    flex-shrink: 0;
+  }
+
+  .card {
+    background: var(--color-background);
+    border-radius: var(--radius-card);
+    padding: var(--sp-large);
+    margin-bottom: 16px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+  }
+
+  /* === Phone Mockup === */
+  .phone-mockup-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 24px;
+    justify-items: center;
+  }
+
+  .phone-frame {
+    width: 340px;
+    background: var(--color-surface);
+    border-radius: 36px;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.12), inset 0 0 0 2px #E5E7EB;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+  }
+
+  .phone-status-bar {
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--color-background);
+  }
+
+  .phone-status-bar .notch {
+    width: 120px;
+    height: 28px;
+    background: #000;
+    border-radius: 0 0 16px 16px;
+  }
+
+  .phone-appbar {
+    height: 56px;
+    padding: 0 var(--sp-medium);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--color-background);
+    position: relative;
+  }
+
+  .phone-appbar .back-icon {
+    position: absolute;
+    left: 16px;
+    font-size: 20px;
+    color: var(--color-text-primary);
+  }
+
+  .phone-appbar-title {
+    font-size: 18px;
+    font-weight: 600;
+  }
+
+  .phone-content {
+    flex: 1;
+    padding: var(--sp-medium);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  /* === Purchase Card === */
+  .purchase-card {
+    background: var(--color-background);
+    border-radius: var(--radius-card);
+    padding: var(--sp-medium);
+    border: 1px solid var(--color-divider);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.02);
+  }
+
+  .purchase-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+  }
+
+  .purchase-date {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--color-text-tertiary);
+  }
+
+  /* === Status Badges === */
+  .status-badge {
+    font-size: 11px;
+    font-weight: 600;
+    padding: 3px 10px;
+    border-radius: var(--radius-small);
+    letter-spacing: 0.2px;
+  }
+
+  .badge-paid {
+    background: rgba(34, 197, 94, 0.12);
+    color: #16A34A;
+  }
+
+  .badge-approved {
+    background: rgba(59, 130, 246, 0.12);
+    color: #2563EB;
+  }
+
+  .badge-pending {
+    background: rgba(156, 163, 175, 0.15);
+    color: #6B7280;
+  }
+
+  .badge-pending-review {
+    background: rgba(245, 158, 11, 0.12);
+    color: #D97706;
+  }
+
+  .badge-cancelled {
+    background: rgba(239, 68, 68, 0.12);
+    color: #DC2626;
+  }
+
+  .badge-rejected {
+    background: rgba(239, 68, 68, 0.12);
+    color: #DC2626;
+  }
+
+  /* Before: Purple badges */
+  .badge-paid-before {
+    background: rgba(153, 0, 255, 0.2);
+    color: #9900FF;
+  }
+
+  .badge-approved-before {
+    background: rgba(153, 0, 255, 0.2);
+    color: #9900FF;
+  }
+
+  /* === Event Info === */
+  .event-row {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 12px;
+  }
+
+  .event-thumb {
+    width: 72px;
+    height: 72px;
+    border-radius: var(--radius-small);
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    color: var(--color-text-tertiary);
+  }
+
+  .event-thumb.before {
+    background: rgba(153, 0, 255, 0.06);
+  }
+
+  .event-thumb.after {
+    background: var(--color-divider-light);
+  }
+
+  .event-thumb-icon {
+    width: 28px;
+    height: 28px;
+    opacity: 0.4;
+    background: currentColor;
+    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z'/%3E%3C/svg%3E") center/contain no-repeat;
+    -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z'/%3E%3C/svg%3E") center/contain no-repeat;
+  }
+
+  .event-info {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .event-name {
+    font-size: 15px;
+    font-weight: 700;
+    margin-bottom: 3px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .event-meta {
+    font-size: 12px;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+  }
+
+  .purchase-divider {
+    height: 1px;
+    background: var(--color-divider-light);
+    margin: 12px 0;
+  }
+
+  /* === Ticket & Price === */
+  .ticket-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+  }
+
+  .ticket-name {
+    font-size: 14px;
+    color: var(--color-text-secondary);
+  }
+
+  .ticket-price {
+    font-size: 16px;
+    font-weight: 700;
+  }
+
+  /* === Action Buttons === */
+  .action-row {
+    display: flex;
+    gap: 8px;
+  }
+
+  .action-btn {
+    flex: 1;
+    height: 44px;
+    border-radius: var(--radius-button);
+    font-size: 14px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+
+  /* Before: All purple */
+  .btn-outline-purple {
+    background: transparent;
+    border: 1.5px solid var(--color-primary);
+    color: var(--color-primary);
+  }
+
+  .btn-filled-pink {
+    background: rgba(239, 68, 68, 0.12);
+    border: none;
+    color: #DC2626;
+  }
+
+  /* After: Differentiated hierarchy */
+  .btn-outline-neutral {
+    background: transparent;
+    border: 1.5px solid var(--color-outline);
+    color: var(--color-text-primary);
+  }
+
+  .btn-text-secondary {
+    background: transparent;
+    border: 1.5px solid transparent;
+    color: var(--color-text-secondary);
+    text-decoration: underline;
+    text-decoration-color: var(--color-divider);
+    text-underline-offset: 3px;
+  }
+
+  .btn-text-destructive {
+    background: transparent;
+    border: 1.5px solid transparent;
+    color: var(--color-text-tertiary);
+    font-weight: 500;
+  }
+
+  /* === Comparison Table === */
+  .compare-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+  }
+
+  .compare-table th {
+    text-align: left;
+    padding: 10px 12px;
+    background: var(--color-surface);
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--color-text-secondary);
+    border-bottom: 2px solid var(--color-divider);
+  }
+
+  .compare-table td {
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--color-divider-light);
+    vertical-align: middle;
+  }
+
+  .compare-table tr:last-child td {
+    border-bottom: none;
+  }
+
+  .inline-badge {
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 6px;
+    white-space: nowrap;
+  }
+
+  .arrow {
+    color: var(--color-text-tertiary);
+    font-size: 16px;
+  }
+
+  .annotation {
+    font-size: 12px;
+    color: var(--color-text-tertiary);
+    font-style: italic;
+    margin-top: 12px;
+    padding: 10px 14px;
+    border-left: 3px solid var(--color-primary);
+    background: var(--color-primary-light);
+    border-radius: 0 8px 8px 0;
+    line-height: 1.6;
+  }
+
+  /* === Badge Legend === */
+  .badge-legend {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+  }
+
+  /* === Color Swatch === */
+  .swatch-row {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    padding: 8px 0;
+  }
+
+  .swatch {
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    flex-shrink: 0;
+  }
+
+  .swatch-label {
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  .swatch-hex {
+    font-size: 11px;
+    color: var(--color-text-tertiary);
+    font-family: monospace;
+  }
+
+  /* === Design Principle === */
+  .principle {
+    display: flex;
+    gap: 16px;
+    padding: 16px 0;
+    border-bottom: 1px solid var(--color-divider-light);
+  }
+
+  .principle:last-child {
+    border-bottom: none;
+  }
+
+  .principle-number {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: var(--color-primary-light);
+    color: var(--color-primary);
+    font-weight: 700;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  .principle h4 {
+    font-size: 14px;
+    font-weight: 700;
+    margin-bottom: 4px;
+  }
+
+  .principle p {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+  }
+
+  /* Responsive */
+  @media (max-width: 768px) {
+    .phone-mockup-row { grid-template-columns: 1fr; }
+    .badge-legend { grid-template-columns: repeat(2, 1fr); }
+  }
+</style>
+</head>
+<body>
+
+<div class="page-title">구매 내역 화면 — 색상 위계 리디자인</div>
+<div class="page-subtitle">Issue #1236 · needs-uiux-claude-1 · 2026-04-10</div>
+
+<!-- Section 1: Problem → Solution -->
+<div class="section">
+  <div class="section-title">문제 요약 & 디자인 원칙</div>
+  <div class="card">
+    <div class="principle">
+      <div class="principle-number">1</div>
+      <div>
+        <h4>60-30-10 색상 규칙</h4>
+        <p>화면의 60%는 중성색(흰/회), 30%는 보조색(회색 변형), 10% 이하만 브랜드 컬러. 현재는 보라가 40%+ 차지하여 피로도가 높다.</p>
+      </div>
+    </div>
+    <div class="principle">
+      <div class="principle-number">2</div>
+      <div>
+        <h4>상태 배지는 의미 기반 색상</h4>
+        <p>결제완료=초록(성공), 승인됨=파랑(정보), 심사중=노랑(주의), 결제대기=회색(비활성), 취소/반려=빨강(오류). 브랜드 컬러는 상태를 전달하지 않는다.</p>
+      </div>
+    </div>
+    <div class="principle">
+      <div class="principle-number">3</div>
+      <div>
+        <h4>버튼 위계를 시각적으로 분리</h4>
+        <p>Primary CTA만 브랜드 컬러, 보조 액션은 중성색 outline, 3차 액션은 text only. Destructive 액션은 최소 visual weight로 실수 방지.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Section 2: Status Badge Redesign -->
+<div class="section">
+  <div class="section-title">상태 배지 색상 재정의</div>
+  <div class="card">
+    <div class="badge-legend">
+      <div class="legend-item">
+        <span class="inline-badge badge-paid">결제완료</span>
+        <span style="font-size:12px; color:var(--color-text-tertiary);">success</span>
+      </div>
+      <div class="legend-item">
+        <span class="inline-badge badge-approved">승인됨</span>
+        <span style="font-size:12px; color:var(--color-text-tertiary);">info</span>
+      </div>
+      <div class="legend-item">
+        <span class="inline-badge badge-pending-review">심사중</span>
+        <span style="font-size:12px; color:var(--color-text-tertiary);">warning</span>
+      </div>
+      <div class="legend-item">
+        <span class="inline-badge badge-pending">결제대기</span>
+        <span style="font-size:12px; color:var(--color-text-tertiary);">neutral</span>
+      </div>
+      <div class="legend-item">
+        <span class="inline-badge badge-cancelled">취소됨</span>
+        <span style="font-size:12px; color:var(--color-text-tertiary);">error</span>
+      </div>
+      <div class="legend-item">
+        <span class="inline-badge badge-rejected">반려됨</span>
+        <span style="font-size:12px; color:var(--color-text-tertiary);">error</span>
+      </div>
+    </div>
+
+    <table class="compare-table">
+      <thead>
+        <tr>
+          <th>상태</th>
+          <th>현재 (Before)</th>
+          <th></th>
+          <th>리디자인 (After)</th>
+          <th>이유</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>결제완료</strong></td>
+          <td><span class="inline-badge badge-paid-before">결제완료</span></td>
+          <td class="arrow">→</td>
+          <td><span class="inline-badge badge-paid">결제완료</span></td>
+          <td>결제 성공 = 긍정 상태. 초록은 보편적 성공 색.</td>
+        </tr>
+        <tr>
+          <td><strong>승인됨</strong></td>
+          <td><span class="inline-badge badge-approved-before">승인됨</span></td>
+          <td class="arrow">→</td>
+          <td><span class="inline-badge badge-approved">승인됨</span></td>
+          <td>승인 = 정보성 확인 상태. 파랑으로 결제완료와 구분.</td>
+        </tr>
+        <tr>
+          <td><strong>심사중</strong></td>
+          <td><span class="inline-badge" style="background:rgba(72,201,176,0.2); color:#48C9B0;">심사중</span></td>
+          <td class="arrow">→</td>
+          <td><span class="inline-badge badge-pending-review">심사중</span></td>
+          <td>대기/주의 상태. 민트→노랑으로 주의 의미 강화.</td>
+        </tr>
+        <tr>
+          <td><strong>결제대기</strong></td>
+          <td><span class="inline-badge" style="background:rgba(156,163,175,0.15); color:#6B7280;">결제대기</span></td>
+          <td class="arrow">→</td>
+          <td><span class="inline-badge badge-pending">결제대기</span></td>
+          <td>유지. 비활성/대기 = 회색이 적절.</td>
+        </tr>
+        <tr>
+          <td><strong>취소됨/반려됨</strong></td>
+          <td><span class="inline-badge badge-cancelled">취소됨</span></td>
+          <td class="arrow">→</td>
+          <td><span class="inline-badge badge-cancelled">취소됨</span></td>
+          <td>유지. 오류/취소 = 빨강이 적절.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="annotation">
+      핵심: <strong>결제완료(paid)와 승인됨(approved)을 더 이상 같은 색으로 표시하지 않는다.</strong>
+      결제완료는 금전 거래 완료(초록), 승인됨은 참가 확정(파랑)으로 의미 분리.
+    </div>
+  </div>
+</div>
+
+<!-- Section 3: Button Hierarchy -->
+<div class="section">
+  <div class="section-title">버튼 위계 재설계</div>
+  <div class="card">
+    <table class="compare-table">
+      <thead>
+        <tr>
+          <th>버튼</th>
+          <th>현재</th>
+          <th></th>
+          <th>리디자인</th>
+          <th>이유</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>영수증</strong></td>
+          <td><span style="padding:4px 12px; border:1.5px solid var(--color-primary); border-radius:8px; color:var(--color-primary); font-size:12px; font-weight:600;">영수증</span></td>
+          <td class="arrow">→</td>
+          <td><span style="padding:4px 12px; border:1.5px solid var(--color-outline); border-radius:8px; color:var(--color-text-primary); font-size:12px; font-weight:600;">영수증</span></td>
+          <td>보조 액션. 중성 outline으로 강도 낮춤.</td>
+        </tr>
+        <tr>
+          <td><strong>문의하기</strong></td>
+          <td><span style="padding:4px 12px; border:1.5px solid var(--color-primary); border-radius:8px; color:var(--color-primary); font-size:12px; font-weight:600;">문의하기</span></td>
+          <td class="arrow">→</td>
+          <td><span style="padding:4px 12px; color:var(--color-text-secondary); font-size:12px; font-weight:600; text-decoration:underline; text-decoration-color:var(--color-divider); text-underline-offset:3px;">문의하기</span></td>
+          <td>3차 액션. text button으로 최소화.</td>
+        </tr>
+        <tr>
+          <td><strong>예매 취소</strong></td>
+          <td><span style="padding:4px 12px; background:rgba(239,68,68,0.12); border-radius:8px; color:#DC2626; font-size:12px; font-weight:600;">예매 취소</span></td>
+          <td class="arrow">→</td>
+          <td><span style="padding:4px 12px; color:var(--color-text-tertiary); font-size:12px; font-weight:500;">예매 취소</span></td>
+          <td>Destructive action. 최소 visual weight + 탭 시 confirm dialog.</td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="annotation">
+      버튼 위계: <strong>Primary(filled) > Secondary(outlined neutral) > Tertiary(text) > Destructive(text muted).</strong>
+      구매 내역에는 Primary CTA가 없으므로 가장 강한 버튼이 neutral outline. 보라색은 이 화면에서 사라진다.
+    </div>
+  </div>
+</div>
+
+<!-- Section 4: Phone Mockup Before/After -->
+<div class="section">
+  <div class="section-title">화면 비교 — Before / After</div>
+  <div class="phone-mockup-row">
+    <!-- BEFORE -->
+    <div>
+      <div style="text-align:center; font-size:12px; font-weight:600; color:var(--color-text-tertiary); margin-bottom:12px; text-transform:uppercase; letter-spacing:1px;">Before — 보라 과포화</div>
+      <div class="phone-frame">
+        <div class="phone-status-bar"><div class="notch"></div></div>
+        <div class="phone-appbar">
+          <span class="back-icon">←</span>
+          <div class="phone-appbar-title">구매 내역</div>
+        </div>
+        <div class="phone-content">
+          <!-- Card 1: 결제완료 -->
+          <div class="purchase-card">
+            <div class="purchase-header">
+              <span class="purchase-date">2026.04.10</span>
+              <span class="status-badge badge-paid-before">결제완료</span>
+            </div>
+            <div class="event-row">
+              <div class="event-thumb before"><div class="event-thumb-icon"></div></div>
+              <div class="event-info">
+                <div class="event-name">[E2E] 네트워킹</div>
+                <div class="event-meta">4월 10일 (금) 10:36<br>서울 강남</div>
+              </div>
+            </div>
+            <div class="purchase-divider"></div>
+            <div class="ticket-row">
+              <span class="ticket-name">[E2E] 일반 티켓</span>
+              <span class="ticket-price">20,000원</span>
+            </div>
+            <div class="action-row">
+              <div class="action-btn btn-outline-purple">영수증</div>
+              <div class="action-btn btn-outline-purple">문의하기</div>
+              <div class="action-btn btn-filled-pink">예매 취소</div>
+            </div>
+          </div>
+
+          <!-- Card 2: 취소됨 -->
+          <div class="purchase-card">
+            <div class="purchase-header">
+              <span class="purchase-date">2026.04.10</span>
+              <span class="status-badge badge-cancelled">취소됨</span>
+            </div>
+            <div class="event-row">
+              <div class="event-thumb before"><div class="event-thumb-icon"></div></div>
+              <div class="event-info">
+                <div class="event-name">[E2E] 직장인 밍글</div>
+                <div class="event-meta">4월 11일 (토) 22:35<br>서울 강남</div>
+              </div>
+            </div>
+            <div class="purchase-divider"></div>
+            <div class="ticket-row">
+              <span class="ticket-name">[E2E] 일반 티켓</span>
+              <span class="ticket-price">20,000원</span>
+            </div>
+            <div class="action-row">
+              <div class="action-btn btn-outline-purple">영수증</div>
+              <div class="action-btn btn-outline-purple">문의하기</div>
+            </div>
+          </div>
+
+          <!-- Card 3: 승인됨 -->
+          <div class="purchase-card">
+            <div class="purchase-header">
+              <span class="purchase-date">2026.04.10</span>
+              <span class="status-badge badge-approved-before">승인됨</span>
+            </div>
+            <div class="event-row">
+              <div class="event-thumb before"><div class="event-thumb-icon"></div></div>
+              <div class="event-info">
+                <div class="event-name">[E2E] 직장인 밍글</div>
+                <div class="event-meta">4월 10일 (금) 10:35<br>서울 강남</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- AFTER -->
+    <div>
+      <div style="text-align:center; font-size:12px; font-weight:600; color:var(--color-primary); margin-bottom:12px; text-transform:uppercase; letter-spacing:1px;">After — 의미 기반 색상</div>
+      <div class="phone-frame">
+        <div class="phone-status-bar"><div class="notch"></div></div>
+        <div class="phone-appbar">
+          <span class="back-icon">←</span>
+          <div class="phone-appbar-title">구매 내역</div>
+        </div>
+        <div class="phone-content">
+          <!-- Card 1: 결제완료 — GREEN -->
+          <div class="purchase-card">
+            <div class="purchase-header">
+              <span class="purchase-date">2026.04.10</span>
+              <span class="status-badge badge-paid">결제완료</span>
+            </div>
+            <div class="event-row">
+              <div class="event-thumb after"><div class="event-thumb-icon"></div></div>
+              <div class="event-info">
+                <div class="event-name">[E2E] 네트워킹</div>
+                <div class="event-meta">4월 10일 (금) 10:36<br>서울 강남</div>
+              </div>
+            </div>
+            <div class="purchase-divider"></div>
+            <div class="ticket-row">
+              <span class="ticket-name">[E2E] 일반 티켓</span>
+              <span class="ticket-price">20,000원</span>
+            </div>
+            <div class="action-row">
+              <div class="action-btn btn-outline-neutral">영수증</div>
+              <div class="action-btn btn-text-secondary">문의하기</div>
+              <div class="action-btn btn-text-destructive">예매 취소</div>
+            </div>
+          </div>
+
+          <!-- Card 2: 취소됨 — RED (unchanged) -->
+          <div class="purchase-card">
+            <div class="purchase-header">
+              <span class="purchase-date">2026.04.10</span>
+              <span class="status-badge badge-cancelled">취소됨</span>
+            </div>
+            <div class="event-row">
+              <div class="event-thumb after"><div class="event-thumb-icon"></div></div>
+              <div class="event-info">
+                <div class="event-name">[E2E] 직장인 밍글</div>
+                <div class="event-meta">4월 11일 (토) 22:35<br>서울 강남</div>
+              </div>
+            </div>
+            <div class="purchase-divider"></div>
+            <div class="ticket-row">
+              <span class="ticket-name">[E2E] 일반 티켓</span>
+              <span class="ticket-price">20,000원</span>
+            </div>
+            <div class="action-row">
+              <div class="action-btn btn-outline-neutral">영수증</div>
+              <div class="action-btn btn-text-secondary">문의하기</div>
+            </div>
+          </div>
+
+          <!-- Card 3: 승인됨 — BLUE -->
+          <div class="purchase-card">
+            <div class="purchase-header">
+              <span class="purchase-date">2026.04.10</span>
+              <span class="status-badge badge-approved">승인됨</span>
+            </div>
+            <div class="event-row">
+              <div class="event-thumb after"><div class="event-thumb-icon"></div></div>
+              <div class="event-info">
+                <div class="event-name">[E2E] 직장인 밍글</div>
+                <div class="event-meta">4월 10일 (금) 10:35<br>서울 강남</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Section 5: New Design Tokens -->
+<div class="section">
+  <div class="section-title">신규 디자인 토큰 제안</div>
+  <div class="card">
+    <p style="font-size:13px; color:var(--color-text-secondary); margin-bottom:16px;">
+      <code>minglit_design_tokens.dart</code>에 추가할 시맨틱 상태 색상 토큰.
+      기존 <code>MinglitColors.success/warning/error</code>와 함께 사용.
+    </p>
+
+    <table class="compare-table">
+      <thead>
+        <tr>
+          <th>토큰명</th>
+          <th>색상</th>
+          <th>Hex</th>
+          <th>용도</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>statusSuccess</code></td>
+          <td><div style="display:inline-block; width:20px; height:20px; border-radius:4px; background:#22C55E; vertical-align:middle;"></div></td>
+          <td><code>#22C55E</code> (= 기존 success)</td>
+          <td>결제완료 배지</td>
+        </tr>
+        <tr>
+          <td><code>statusInfo</code></td>
+          <td><div style="display:inline-block; width:20px; height:20px; border-radius:4px; background:#3B82F6; vertical-align:middle;"></div></td>
+          <td><code>#3B82F6</code></td>
+          <td>승인됨 배지</td>
+        </tr>
+        <tr>
+          <td><code>statusWarning</code></td>
+          <td><div style="display:inline-block; width:20px; height:20px; border-radius:4px; background:#F59E0B; vertical-align:middle;"></div></td>
+          <td><code>#F59E0B</code> (= 기존 warning)</td>
+          <td>심사중 배지</td>
+        </tr>
+        <tr>
+          <td><code>statusNeutral</code></td>
+          <td><div style="display:inline-block; width:20px; height:20px; border-radius:4px; background:#9CA3AF; vertical-align:middle;"></div></td>
+          <td><code>#9CA3AF</code></td>
+          <td>결제대기 배지</td>
+        </tr>
+        <tr>
+          <td><code>statusError</code></td>
+          <td><div style="display:inline-block; width:20px; height:20px; border-radius:4px; background:#EF4444; vertical-align:middle;"></div></td>
+          <td><code>#EF4444</code> (= 기존 error)</td>
+          <td>취소됨/반려됨 배지</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="annotation">
+      <strong>기존 success/warning/error와 값이 같은 토큰도 별도 시맨틱 이름을 부여하는 이유:</strong>
+      status* 토큰은 배지 전용이고, success/warning/error는 범용이다. 나중에 배지 색만 변경해야 할 때 분리되어 있어야 안전하다.
+    </div>
+  </div>
+</div>
+
+<!-- Section 6: Implementation Spec -->
+<div class="section">
+  <div class="section-title">구현 명세 — StatusBadge 수정</div>
+  <div class="card">
+    <p style="font-size:13px; color:var(--color-text-secondary); margin-bottom:16px;">
+      <code>apps/app_user/lib/src/common/widgets/status_badge.dart</code> 변경:
+    </p>
+    <pre style="background:var(--color-surface); padding:16px; border-radius:12px; font-size:12px; line-height:1.6; overflow-x:auto;"><code>// Before
+case 'approved':
+  color = theme.colorScheme.primary;  // ← 보라
+case 'paid':
+  color = theme.colorScheme.primary;  // ← 보라
+
+// After
+case 'approved':
+  color = MinglitColors.statusInfo;   // ← 파랑 #3B82F6
+case 'paid':
+  color = MinglitColors.statusSuccess; // ← 초록 #22C55E
+case 'pending_review':
+  color = MinglitColors.statusWarning; // ← 노랑 #F59E0B</code></pre>
+
+    <p style="font-size:13px; color:var(--color-text-secondary); margin-top:16px; margin-bottom:16px;">
+      <code>purchase_history_card.dart</code> 버튼 변경:
+    </p>
+    <pre style="background:var(--color-surface); padding:16px; border-radius:12px; font-size:12px; line-height:1.6; overflow-x:auto;"><code>// 영수증: OutlinedButton → neutral outline
+OutlinedButton(
+  style: OutlinedButton.styleFrom(
+    foregroundColor: theme.colorScheme.onSurface,
+    side: BorderSide(color: theme.colorScheme.outlineVariant),
+  ),
+  child: const Text('영수증'),
+),
+
+// 문의하기: OutlinedButton → TextButton
+TextButton(
+  style: TextButton.styleFrom(
+    foregroundColor: theme.colorScheme.onSurfaceVariant,
+  ),
+  child: const Text('문의하기'),
+),
+
+// 예매 취소: ElevatedButton → TextButton (muted)
+TextButton(
+  style: TextButton.styleFrom(
+    foregroundColor: theme.colorScheme.outline,
+  ),
+  child: const Text('예매 취소'),
+),</code></pre>
+  </div>
+</div>
+
+<!-- Section 7: Scope & Impact -->
+<div class="section">
+  <div class="section-title">영향 범위 & 후속 작업</div>
+  <div class="card">
+    <table class="compare-table">
+      <thead>
+        <tr>
+          <th>범위</th>
+          <th>이번 PR</th>
+          <th>후속 작업</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>StatusBadge 색상</strong></td>
+          <td>paid→초록, approved→파랑, pending_review→노랑</td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td><strong>구매 내역 버튼</strong></td>
+          <td>neutral outline + text button 적용</td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td><strong>이미지 플레이스홀더</strong></td>
+          <td>MinglitImage의 기본 placeholder 색 neutral gray 확인</td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td><strong>Design Token</strong></td>
+          <td>status* 토큰 5종 추가</td>
+          <td>—</td>
+        </tr>
+        <tr>
+          <td><strong>전체 앱 보라색 감사</strong></td>
+          <td>—</td>
+          <td>별도 이슈 (다른 화면도 동일 문제 가능)</td>
+        </tr>
+        <tr>
+          <td><strong>디자인 시스템 문서</strong></td>
+          <td>—</td>
+          <td>UX 디자이너가 01-foundation.md 업데이트</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+</body>
+</html>

--- a/docs/features/signup-consent/wireframe-v2.html
+++ b/docs/features/signup-consent/wireframe-v2.html
@@ -1,0 +1,829 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>밍릿 — 회원가입 동의 리디자인 v2</title>
+<style>
+  /* ===== Minglit Design Tokens ===== */
+  :root {
+    --color-background: #FFFFFF;
+    --color-primary: #9900FF;
+    --color-primary-light: rgba(153, 0, 255, 0.08);
+    --color-primary-container: rgba(153, 0, 255, 0.12);
+    --color-secondary: #FF9900;
+    --color-surface: #F9FAFB;
+    --color-error: #EF4444;
+    --color-text-primary: #111827;
+    --color-text-secondary: #4B5563;
+    --color-text-tertiary: #9CA3AF;
+    --color-success: #22C55E;
+    --color-divider: #E5E7EB;
+    --color-divider-light: #F3F4F6;
+    --color-scrim: rgba(0,0,0,0.5);
+
+    --sp-xxsmall: 2px;
+    --sp-xsmall: 4px;
+    --sp-xsmall2: 6px;
+    --sp-small: 8px;
+    --sp-sm: 12px;
+    --sp-medium: 16px;
+    --sp-large: 24px;
+    --sp-xlarge: 32px;
+    --sp-screen-edge: 20px;
+
+    --radius-small: 8px;
+    --radius-button: 12px;
+    --radius-card: 16px;
+    --radius-chip: 100px;
+
+    --font-family: 'Noto Sans KR', -apple-system, BlinkMacSystemFont, sans-serif;
+  }
+
+  @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;600;700&display=swap');
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: var(--font-family);
+    background: #E5E7EB;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 40px;
+    padding: 40px;
+  }
+
+  /* ===== Screen Frame ===== */
+  .screen-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+  }
+  .screen-label {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--color-text-primary);
+    text-align: center;
+  }
+  .screen-sublabel {
+    font-size: 12px;
+    color: var(--color-text-secondary);
+    text-align: center;
+    margin-top: -8px;
+  }
+  .version-tag {
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--color-primary);
+    background: var(--color-primary-light);
+    padding: 2px 8px;
+    border-radius: var(--radius-chip);
+    margin-bottom: 4px;
+  }
+  .phone-frame {
+    width: 375px;
+    height: 812px;
+    background: var(--color-background);
+    border-radius: 40px;
+    overflow: hidden;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.12);
+    position: relative;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* ===== Status Bar ===== */
+  .status-bar {
+    height: 54px;
+    background: var(--color-background);
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    padding-bottom: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    flex-shrink: 0;
+  }
+
+  /* ===== Content ===== */
+  .content {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .content-scroll {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--sp-xlarge) var(--sp-screen-edge) var(--sp-large);
+  }
+
+  /* ===== Header ===== */
+  .page-header {
+    margin-bottom: var(--sp-xlarge);
+  }
+  .page-header .greeting {
+    font-size: 26px;
+    font-weight: 700;
+    line-height: 1.3;
+    color: var(--color-text-primary);
+    letter-spacing: -0.5px;
+  }
+  .page-header .subtitle {
+    font-size: 15px;
+    font-weight: 400;
+    line-height: 1.6;
+    color: var(--color-text-secondary);
+    margin-top: 8px;
+  }
+
+  /* ===== Select All ===== */
+  .select-all {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px;
+    background: var(--color-primary-light);
+    border-radius: var(--radius-card);
+    cursor: pointer;
+    margin-bottom: 8px;
+    transition: background 0.15s;
+    border: 1.5px solid transparent;
+  }
+  .select-all.checked {
+    border-color: var(--color-primary);
+    background: var(--color-primary-light);
+  }
+  .select-all .check-circle {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    border: 2px solid var(--color-text-tertiary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition: all 0.15s;
+  }
+  .select-all.checked .check-circle {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+  }
+  .select-all.checked .check-circle::after {
+    content: '✓';
+    color: white;
+    font-size: 14px;
+    font-weight: 700;
+  }
+  .select-all .label-group {
+    flex: 1;
+  }
+  .select-all .label-group .main {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--color-text-primary);
+  }
+  .select-all .label-group .sub {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+    margin-top: 2px;
+  }
+
+  /* ===== Divider ===== */
+  .section-divider {
+    height: 1px;
+    background: var(--color-divider-light);
+    margin: 12px 0;
+  }
+
+  /* ===== Consent Item ===== */
+  .consent-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 14px 4px;
+    cursor: pointer;
+    border-radius: var(--radius-small);
+    transition: background 0.1s;
+  }
+  .consent-item:hover {
+    background: var(--color-surface);
+  }
+  .consent-item .check-circle {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    border: 1.5px solid var(--color-divider);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    margin-top: 1px;
+    transition: all 0.15s;
+  }
+  .consent-item.checked .check-circle {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+  }
+  .consent-item.checked .check-circle::after {
+    content: '✓';
+    color: white;
+    font-size: 12px;
+    font-weight: 700;
+  }
+  .consent-item .item-content {
+    flex: 1;
+    min-width: 0;
+  }
+  .consent-item .item-title-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .consent-item .tag {
+    font-size: 11px;
+    font-weight: 600;
+    padding: 1px 6px;
+    border-radius: var(--radius-chip);
+    flex-shrink: 0;
+    letter-spacing: 0.2px;
+  }
+  .consent-item .tag.required {
+    color: var(--color-primary);
+    background: var(--color-primary-container);
+  }
+  .consent-item .tag.optional {
+    color: var(--color-text-tertiary);
+    background: var(--color-divider-light);
+  }
+  .consent-item .item-title {
+    font-size: 15px;
+    font-weight: 500;
+    color: var(--color-text-primary);
+    line-height: 1.4;
+  }
+  .consent-item .item-desc {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+    margin-top: 3px;
+    line-height: 1.5;
+  }
+  .consent-item .view-link {
+    flex-shrink: 0;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--color-text-tertiary);
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    margin-top: 2px;
+    padding: 4px 0;
+  }
+  .consent-item .view-link .chevron {
+    font-size: 16px;
+    line-height: 1;
+  }
+
+  /* ===== Footer Note ===== */
+  .footer-note {
+    font-size: 12px;
+    color: var(--color-text-tertiary);
+    padding: 8px 4px 0;
+    line-height: 1.5;
+  }
+
+  /* ===== Bottom CTA ===== */
+  .bottom-cta {
+    padding: 12px var(--sp-screen-edge);
+    padding-bottom: max(12px, env(safe-area-inset-bottom, 20px));
+    border-top: 0.5px solid var(--color-divider-light);
+    flex-shrink: 0;
+  }
+  .cta-button {
+    width: 100%;
+    height: 54px;
+    border: none;
+    border-radius: var(--radius-button);
+    font-size: 16px;
+    font-weight: 700;
+    font-family: var(--font-family);
+    cursor: pointer;
+    transition: all 0.15s;
+    letter-spacing: -0.2px;
+  }
+  .cta-button.enabled {
+    background: var(--color-primary);
+    color: white;
+    box-shadow: 0 2px 12px rgba(153, 0, 255, 0.25);
+  }
+  .cta-button.disabled {
+    background: var(--color-divider-light);
+    color: var(--color-text-tertiary);
+    cursor: not-allowed;
+  }
+
+  /* ===== Comparison Annotation ===== */
+  .annotation {
+    position: absolute;
+    background: #FEF3C7;
+    border: 1px solid #FDE68A;
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 11px;
+    color: #92400E;
+    line-height: 1.4;
+    max-width: 160px;
+    z-index: 10;
+  }
+  .annotation::before {
+    content: '💡';
+    margin-right: 4px;
+  }
+
+  /* ===== Before/After Header ===== */
+  .comparison-header {
+    width: 100%;
+    text-align: center;
+    margin-bottom: 16px;
+  }
+  .comparison-header h1 {
+    font-size: 24px;
+    font-weight: 700;
+    color: var(--color-text-primary);
+    margin-bottom: 8px;
+  }
+  .comparison-header p {
+    font-size: 14px;
+    color: var(--color-text-secondary);
+    max-width: 600px;
+    margin: 0 auto;
+    line-height: 1.6;
+  }
+
+  /* ===== Issue List ===== */
+  .issues-panel {
+    width: 100%;
+    max-width: 800px;
+    background: white;
+    border-radius: var(--radius-card);
+    padding: 24px;
+    margin-bottom: 20px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+  }
+  .issues-panel h2 {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--color-text-primary);
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .issues-panel .issue-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+  }
+  .issue-card {
+    display: flex;
+    gap: 10px;
+    padding: 12px;
+    background: var(--color-surface);
+    border-radius: var(--radius-small);
+  }
+  .issue-card .number {
+    width: 22px;
+    height: 22px;
+    background: var(--color-error);
+    color: white;
+    border-radius: 50%;
+    font-size: 11px;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+  .issue-card .number.fix {
+    background: var(--color-success);
+  }
+  .issue-card .issue-text {
+    font-size: 13px;
+    color: var(--color-text-primary);
+    line-height: 1.5;
+  }
+  .issue-card .issue-text strong {
+    font-weight: 600;
+  }
+</style>
+</head>
+<body>
+
+<!-- ===== Issues Panel ===== -->
+<div class="issues-panel">
+  <h2>🔍 현재 이용약관 동의 화면 UX 이슈 분석</h2>
+  <div class="issue-grid">
+    <div class="issue-card">
+      <div class="number">1</div>
+      <div class="issue-text"><strong>Card soup:</strong> 각 항목이 개별 Card로 감싸져 시각적 노이즈가 과다. 카드 테두리/그림자 반복으로 시선이 분산됨</div>
+    </div>
+    <div class="issue-card">
+      <div class="number">2</div>
+      <div class="issue-text"><strong>SwitchListTile:</strong> "전체 동의"에 시스템 설정 스타일 Switch 사용 → 동의 행위라기보다 설정 토글처럼 보임</div>
+    </div>
+    <div class="issue-card">
+      <div class="number">3</div>
+      <div class="issue-text"><strong>Checkbox 정렬:</strong> Material 기본 Checkbox의 내장 패딩으로 텍스트와 정렬이 어긋남</div>
+    </div>
+    <div class="issue-card">
+      <div class="number">4</div>
+      <div class="issue-text"><strong>"보기" 버튼:</strong> TextButton이 카드 우상단에 떠있어 각 항목마다 높이가 달라지고 시각적 일관성 부족</div>
+    </div>
+    <div class="issue-card">
+      <div class="number">5</div>
+      <div class="issue-text"><strong>브랜드 표현 부재:</strong> 보라색 primary가 태그에만 살짝 사용됨. 밍릿다운 개성이 없는 기본 Material 느낌</div>
+    </div>
+    <div class="issue-card">
+      <div class="number">6</div>
+      <div class="issue-text"><strong>마지막 항목 잘림:</strong> "마케팅 정보 수신 동의"가 CTA 버튼에 가려 스크롤 필요. 시각적 단서 없음</div>
+    </div>
+    <div class="issue-card">
+      <div class="number">7</div>
+      <div class="issue-text"><strong>필수/선택 구분 약함:</strong> 작은 태그만으로 구분 → 유저가 어떤 것이 필수인지 한눈에 파악 어려움</div>
+    </div>
+    <div class="issue-card">
+      <div class="number">8</div>
+      <div class="issue-text"><strong>CTA 비활성 상태:</strong> 회색 배경 + 회색 텍스트로 "죽은" 느낌. 활성 상태와의 시각적 격차가 커서 불안감 유발</div>
+    </div>
+  </div>
+</div>
+
+<!-- ===== Before: Current Design ===== -->
+<div class="screen-wrapper">
+  <div class="screen-label">❌ 현재 (Before)</div>
+  <div class="screen-sublabel">Material 기본 위젯 조합, 카드 과다 사용</div>
+  <div class="phone-frame" style="background: var(--color-surface);">
+    <div class="status-bar">9:41</div>
+
+    <div class="content">
+      <div class="content-scroll">
+        <!-- Header -->
+        <div style="margin-bottom: 24px;">
+          <div style="font-size: 24px; font-weight: 700; color: var(--color-text-primary);">환영합니다!</div>
+          <div style="font-size: 16px; color: var(--color-text-secondary); margin-top: 8px; line-height: 1.5;">밍릿 이용을 시작하기 전에 꼭 필요한 약관을 확인해주세요.</div>
+        </div>
+
+        <!-- Select All Card (Switch style - current) -->
+        <div style="background: white; border-radius: 16px; padding: 16px; margin-bottom: 16px; border: 1px solid var(--color-divider);">
+          <div style="display: flex; justify-content: space-between; align-items: center;">
+            <div>
+              <div style="font-size: 16px; font-weight: 700;">전체 동의</div>
+              <div style="font-size: 14px; color: var(--color-text-secondary); margin-top: 4px;">필수와 선택 약관을 한 번에 설정할 수 있어요.</div>
+            </div>
+            <div style="width: 50px; height: 28px; background: #CCC; border-radius: 14px; position: relative;">
+              <div style="width: 24px; height: 24px; background: white; border-radius: 50%; position: absolute; top: 2px; left: 2px; box-shadow: 0 1px 3px rgba(0,0,0,0.2);"></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Item Cards (current style - heavy cards) -->
+        <div style="display: flex; flex-direction: column; gap: 8px;">
+          <!-- Item 1 -->
+          <div style="background: white; border-radius: 16px; padding: 16px; border: 1px solid var(--color-divider);">
+            <div style="display: flex; gap: 12px; align-items: flex-start;">
+              <div style="width: 20px; height: 20px; border: 2px solid #CCC; border-radius: 4px; margin-top: 2px; flex-shrink: 0;"></div>
+              <div style="flex: 1;">
+                <div style="display: flex; align-items: center; gap: 4px;">
+                  <span style="font-size: 11px; color: var(--color-primary); background: var(--color-primary-container); padding: 1px 6px; border-radius: 100px; font-weight: 600;">필수</span>
+                  <span style="font-size: 14px; font-weight: 500;">서비스 이용약관</span>
+                </div>
+                <div style="font-size: 14px; color: var(--color-text-secondary); margin-top: 4px;">계정 생성과 서비스 이용을 위한 기본 약관이에요.</div>
+              </div>
+              <button style="border: none; background: none; color: var(--color-primary); font-size: 14px; font-weight: 700; cursor: pointer; padding: 4px;">보기</button>
+            </div>
+          </div>
+
+          <!-- Item 2 -->
+          <div style="background: white; border-radius: 16px; padding: 16px; border: 1px solid var(--color-divider);">
+            <div style="display: flex; gap: 12px; align-items: flex-start;">
+              <div style="width: 20px; height: 20px; border: 2px solid #CCC; border-radius: 4px; margin-top: 2px; flex-shrink: 0;"></div>
+              <div style="flex: 1;">
+                <div style="display: flex; align-items: center; gap: 4px;">
+                  <span style="font-size: 11px; color: var(--color-primary); background: var(--color-primary-container); padding: 1px 6px; border-radius: 100px; font-weight: 600;">필수</span>
+                  <span style="font-size: 14px; font-weight: 500;">개인정보 수집·이용 동의</span>
+                </div>
+                <div style="font-size: 14px; color: var(--color-text-secondary); margin-top: 4px;">회원가입과 맞춤형 서비스 제공에 필요한 정보를 수집해요.</div>
+              </div>
+              <button style="border: none; background: none; color: var(--color-primary); font-size: 14px; font-weight: 700; cursor: pointer; padding: 4px;">보기</button>
+            </div>
+          </div>
+
+          <!-- Item 3 -->
+          <div style="background: white; border-radius: 16px; padding: 16px; border: 1px solid var(--color-divider);">
+            <div style="display: flex; gap: 12px; align-items: flex-start;">
+              <div style="width: 20px; height: 20px; border: 2px solid #CCC; border-radius: 4px; margin-top: 2px; flex-shrink: 0;"></div>
+              <div style="flex: 1;">
+                <div style="display: flex; align-items: center; gap: 4px;">
+                  <span style="font-size: 11px; color: var(--color-primary); background: var(--color-primary-container); padding: 1px 6px; border-radius: 100px; font-weight: 600;">필수</span>
+                  <span style="font-size: 14px; font-weight: 500;">만 14세 이상 확인</span>
+                </div>
+                <div style="font-size: 14px; color: var(--color-text-secondary); margin-top: 4px;">만 14세 이상만 회원가입할 수 있어요.</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Item 4 -->
+          <div style="background: white; border-radius: 16px; padding: 16px; border: 1px solid var(--color-divider);">
+            <div style="display: flex; gap: 12px; align-items: flex-start;">
+              <div style="width: 20px; height: 20px; border: 2px solid #CCC; border-radius: 4px; margin-top: 2px; flex-shrink: 0;"></div>
+              <div style="flex: 1;">
+                <div style="display: flex; align-items: center; gap: 4px;">
+                  <span style="font-size: 11px; color: var(--color-text-tertiary); background: var(--color-divider-light); padding: 1px 6px; border-radius: 100px; font-weight: 600;">선택</span>
+                  <span style="font-size: 14px; font-weight: 500;">본인인증(CI/DI) 수집 동의</span>
+                </div>
+                <div style="font-size: 14px; color: var(--color-text-secondary); margin-top: 4px;">본인 확인을 위해 CI/DI 정보를 수집해요.</div>
+              </div>
+              <button style="border: none; background: none; color: var(--color-primary); font-size: 14px; font-weight: 700; cursor: pointer; padding: 4px;">보기</button>
+            </div>
+          </div>
+
+          <!-- Item 5 (partially hidden) -->
+          <div style="background: white; border-radius: 16px; padding: 16px; border: 1px solid var(--color-divider); opacity: 0.5; clip-path: inset(0 0 40% 0);">
+            <div style="display: flex; gap: 12px; align-items: flex-start;">
+              <div style="width: 20px; height: 20px; border: 2px solid #CCC; border-radius: 4px; margin-top: 2px; flex-shrink: 0;"></div>
+              <div style="flex: 1;">
+                <div style="display: flex; align-items: center; gap: 4px;">
+                  <span style="font-size: 11px; color: var(--color-text-tertiary); background: var(--color-divider-light); padding: 1px 6px; border-radius: 100px; font-weight: 600;">선택</span>
+                  <span style="font-size: 14px; font-weight: 500;">마케팅 정보 수신 동의</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Bottom CTA (current - disabled gray) -->
+      <div class="bottom-cta">
+        <button class="cta-button disabled">다 같이 시작하기</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ===== After: Redesign (Unchecked State) ===== -->
+<div class="screen-wrapper">
+  <div class="version-tag">REDESIGN v2</div>
+  <div class="screen-label">✨ 리디자인 — 초기 상태</div>
+  <div class="screen-sublabel">카드 제거, 원형 체크, 플랫 리스트, 브랜드 강화</div>
+  <div class="phone-frame">
+    <div class="status-bar">9:41</div>
+
+    <div class="content">
+      <div class="content-scroll">
+        <!-- Header -->
+        <div class="page-header">
+          <div class="greeting">환영합니다!</div>
+          <div class="subtitle">서비스 이용을 위해 약관에 동의해주세요.</div>
+        </div>
+
+        <!-- Select All -->
+        <div class="select-all" onclick="this.classList.toggle('checked')">
+          <div class="check-circle"></div>
+          <div class="label-group">
+            <div class="main">전체 동의</div>
+            <div class="sub">필수와 선택 약관을 한 번에 동의해요</div>
+          </div>
+        </div>
+
+        <div class="section-divider" style="margin: 16px 0;"></div>
+
+        <!-- Consent Items -->
+        <!-- Item 1 -->
+        <div class="consent-item" onclick="this.classList.toggle('checked')">
+          <div class="check-circle"></div>
+          <div class="item-content">
+            <div class="item-title-row">
+              <span class="tag required">필수</span>
+              <span class="item-title">서비스 이용약관</span>
+            </div>
+            <div class="item-desc">계정 생성과 서비스 이용을 위한 기본 약관이에요</div>
+          </div>
+          <div class="view-link">보기 <span class="chevron">›</span></div>
+        </div>
+
+        <!-- Item 2 -->
+        <div class="consent-item" onclick="this.classList.toggle('checked')">
+          <div class="check-circle"></div>
+          <div class="item-content">
+            <div class="item-title-row">
+              <span class="tag required">필수</span>
+              <span class="item-title">개인정보 수집·이용 동의</span>
+            </div>
+            <div class="item-desc">회원가입과 맞춤형 서비스 제공에 필요한 정보를 수집해요</div>
+          </div>
+          <div class="view-link">보기 <span class="chevron">›</span></div>
+        </div>
+
+        <!-- Item 3 -->
+        <div class="consent-item" onclick="this.classList.toggle('checked')">
+          <div class="check-circle"></div>
+          <div class="item-content">
+            <div class="item-title-row">
+              <span class="tag required">필수</span>
+              <span class="item-title">만 14세 이상 확인</span>
+            </div>
+            <div class="item-desc">만 14세 이상만 회원가입할 수 있어요</div>
+          </div>
+        </div>
+
+        <div class="section-divider"></div>
+
+        <!-- Item 4 -->
+        <div class="consent-item" onclick="this.classList.toggle('checked')">
+          <div class="check-circle"></div>
+          <div class="item-content">
+            <div class="item-title-row">
+              <span class="tag optional">선택</span>
+              <span class="item-title">본인인증(CI/DI) 수집 동의</span>
+            </div>
+            <div class="item-desc">본인 확인을 위해 CI/DI 정보를 수집해요</div>
+          </div>
+          <div class="view-link">보기 <span class="chevron">›</span></div>
+        </div>
+
+        <!-- Item 5 -->
+        <div class="consent-item" onclick="this.classList.toggle('checked')">
+          <div class="check-circle"></div>
+          <div class="item-content">
+            <div class="item-title-row">
+              <span class="tag optional">선택</span>
+              <span class="item-title">마케팅 정보 수신 동의</span>
+            </div>
+            <div class="item-desc">새 이벤트와 혜택 소식을 푸시나 이메일로 받아볼 수 있어요</div>
+          </div>
+          <div class="view-link">보기 <span class="chevron">›</span></div>
+        </div>
+
+        <!-- Footer Note -->
+        <div class="footer-note">
+          선택 항목에 동의하지 않아도 서비스 이용에 영향이 없습니다.
+        </div>
+      </div>
+
+      <!-- Bottom CTA (disabled) -->
+      <div class="bottom-cta">
+        <button class="cta-button disabled">동의하고 시작하기</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ===== After: Redesign (All Checked State) ===== -->
+<div class="screen-wrapper">
+  <div class="version-tag">REDESIGN v2</div>
+  <div class="screen-label">✨ 리디자인 — 전체 동의 완료</div>
+  <div class="screen-sublabel">모든 항목 체크됨, CTA 활성 상태</div>
+  <div class="phone-frame">
+    <div class="status-bar">9:41</div>
+
+    <div class="content">
+      <div class="content-scroll">
+        <!-- Header -->
+        <div class="page-header">
+          <div class="greeting">환영합니다!</div>
+          <div class="subtitle">서비스 이용을 위해 약관에 동의해주세요.</div>
+        </div>
+
+        <!-- Select All (checked) -->
+        <div class="select-all checked">
+          <div class="check-circle"></div>
+          <div class="label-group">
+            <div class="main">전체 동의</div>
+            <div class="sub">필수와 선택 약관을 한 번에 동의해요</div>
+          </div>
+        </div>
+
+        <div class="section-divider" style="margin: 16px 0;"></div>
+
+        <!-- All items checked -->
+        <div class="consent-item checked">
+          <div class="check-circle"></div>
+          <div class="item-content">
+            <div class="item-title-row">
+              <span class="tag required">필수</span>
+              <span class="item-title">서비스 이용약관</span>
+            </div>
+            <div class="item-desc">계정 생성과 서비스 이용을 위한 기본 약관이에요</div>
+          </div>
+          <div class="view-link">보기 <span class="chevron">›</span></div>
+        </div>
+
+        <div class="consent-item checked">
+          <div class="check-circle"></div>
+          <div class="item-content">
+            <div class="item-title-row">
+              <span class="tag required">필수</span>
+              <span class="item-title">개인정보 수집·이용 동의</span>
+            </div>
+            <div class="item-desc">회원가입과 맞춤형 서비스 제공에 필요한 정보를 수집해요</div>
+          </div>
+          <div class="view-link">보기 <span class="chevron">›</span></div>
+        </div>
+
+        <div class="consent-item checked">
+          <div class="check-circle"></div>
+          <div class="item-content">
+            <div class="item-title-row">
+              <span class="tag required">필수</span>
+              <span class="item-title">만 14세 이상 확인</span>
+            </div>
+            <div class="item-desc">만 14세 이상만 회원가입할 수 있어요</div>
+          </div>
+        </div>
+
+        <div class="section-divider"></div>
+
+        <div class="consent-item checked">
+          <div class="check-circle"></div>
+          <div class="item-content">
+            <div class="item-title-row">
+              <span class="tag optional">선택</span>
+              <span class="item-title">본인인증(CI/DI) 수집 동의</span>
+            </div>
+            <div class="item-desc">본인 확인을 위해 CI/DI 정보를 수집해요</div>
+          </div>
+          <div class="view-link">보기 <span class="chevron">›</span></div>
+        </div>
+
+        <div class="consent-item checked">
+          <div class="check-circle"></div>
+          <div class="item-content">
+            <div class="item-title-row">
+              <span class="tag optional">선택</span>
+              <span class="item-title">마케팅 정보 수신 동의</span>
+            </div>
+            <div class="item-desc">새 이벤트와 혜택 소식을 푸시나 이메일로 받아볼 수 있어요</div>
+          </div>
+          <div class="view-link">보기 <span class="chevron">›</span></div>
+        </div>
+
+        <!-- Footer Note -->
+        <div class="footer-note">
+          선택 항목에 동의하지 않아도 서비스 이용에 영향이 없습니다.
+        </div>
+      </div>
+
+      <!-- Bottom CTA (enabled) -->
+      <div class="bottom-cta">
+        <button class="cta-button enabled">동의하고 시작하기</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ===== Improvement Summary ===== -->
+<div class="issues-panel">
+  <h2>✅ 리디자인 개선 사항</h2>
+  <div class="issue-grid">
+    <div class="issue-card">
+      <div class="number fix">1</div>
+      <div class="issue-text"><strong>카드 → 플랫 리스트:</strong> 개별 Card 제거. 깔끔한 리스트 형태로 시각적 노이즈 제거. 토스/당근 스타일</div>
+    </div>
+    <div class="issue-card">
+      <div class="number fix">2</div>
+      <div class="issue-text"><strong>Switch → 원형 체크:</strong> 전체 동의도 통일된 원형 체크 UI 사용. 동의 행위에 맞는 시각적 메타포</div>
+    </div>
+    <div class="issue-card">
+      <div class="number fix">3</div>
+      <div class="issue-text"><strong>원형 체크박스:</strong> 커스텀 CircleCheckbox로 정렬 일관성 확보. 체크 시 보라색 fill + 애니메이션</div>
+    </div>
+    <div class="issue-card">
+      <div class="number fix">4</div>
+      <div class="issue-text"><strong>"보기" → 인라인 링크:</strong> 우측에 "보기 ›" 형태로 자연스럽게 배치. 높이 일관성 확보</div>
+    </div>
+    <div class="issue-card">
+      <div class="number fix">5</div>
+      <div class="issue-text"><strong>브랜드 강화:</strong> 전체 동의 배경에 보라색 틴트, 체크 시 보라색 circle fill, CTA 보라색 + 글로우 섀도</div>
+    </div>
+    <div class="issue-card">
+      <div class="number fix">6</div>
+      <div class="issue-text"><strong>전체 항목 노출:</strong> 플랫 리스트로 높이 절약 → 모든 항목이 스크롤 없이 화면에 노출</div>
+    </div>
+    <div class="issue-card">
+      <div class="number fix">7</div>
+      <div class="issue-text"><strong>필수/선택 구분 강화:</strong> 필수와 선택 사이에 구분선 추가. 필수 태그는 보라색, 선택은 회색으로 차별화</div>
+    </div>
+    <div class="issue-card">
+      <div class="number fix">8</div>
+      <div class="issue-text"><strong>CTA 텍스트 변경:</strong> "다 같이 시작하기" → "동의하고 시작하기" (행위의 의미 명확화). 활성 시 보라색 글로우</div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Scheduler: needs-uiux-claude-1

## Summary

- **#1231** Pretendard 폰트 마이그레이션 UX 리뷰: 타이포그래피 스케일 비교, 가중치 렌더링, 폰 목업, 튜닝 권고사항, 검증 체크리스트
- **#1236** 구매 내역 화면 색상 위계 리디자인: Before/After 목업, 의미 기반 상태 배지 (초록/파랑/노랑/회색/빨강), 버튼 위계 재설계, 신규 status 토큰 명세
- 회원가입 동의 wireframe v2 추가

## Files

| 파일 | 설명 |
|------|------|
| `docs/features/font-migration-pretendard/typography-review.html` | NotoSansKR ↔ Pretendard 비교 wireframe |
| `docs/features/purchase-history-color-hierarchy/wireframe.html` | 구매 내역 색상 리디자인 wireframe |
| `docs/features/signup-consent/wireframe-v2.html` | 회원가입 동의 v2 wireframe |

## Test plan

- [ ] HTML 파일을 브라우저에서 열어 렌더링 정상 확인
- [ ] GitHub Pages 배포 후 링크 접근 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)