### PR TITLE
fix(ui): 파트너 컨텍스트 이벤트 카드 뱃지 중복 + 오버플로 수정 (#1214)

### DIFF
--- a/apps/app_user/lib/src/features/partner/detail/partner_events_page.dart
+++ b/apps/app_user/lib/src/features/partner/detail/partner_events_page.dart
@@ -40,11 +40,13 @@ class PartnerEventsPage extends ConsumerWidget {
             itemBuilder: (context, index) {
               final event = events[index];
               // Fix #634: home_coordinator 직접 참조 → partner_coordinator 전환
+              // Fix #1214: 파트너 컨텍스트에서 파트너 뱃지 중복 표시 방지
               return MinglitEventCard(
                 event: event,
                 onTap: () => ref
                     .read(partnerCoordinatorProvider)
                     .pushEventDetail(event.id),
+                showPartnerOverlay: false,
               );
             },
           );

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/partner/partner_detail_view.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/partner/partner_detail_view.dart
@@ -172,7 +172,8 @@ class PartnerDetailView extends ConsumerWidget {
     // Card width = ~2/3 of available width so ~1.5 cards show
     final screenWidth = MediaQuery.sizeOf(context).width;
     final cardWidth = (screenWidth - MinglitSpacing.large * 2) * 0.65;
-    const eventCardContentHeight = 64.0;
+    // Fix #1214: 1px 하단 오버플로 해결 — 디바이스별 폰트 메트릭 차이 감안 4px 여유 확보
+    const eventCardContentHeight = 68.0;
 
     return SizedBox(
       // Keep enough room for the event card metadata row across CI font metrics.
@@ -187,9 +188,11 @@ class PartnerDetailView extends ConsumerWidget {
             width: cardWidth,
             child: ClipRRect(
               borderRadius: BorderRadius.circular(MinglitRadius.card),
+              // Fix #1214: 파트너 컨텍스트에서 파트너 뱃지 중복 표시 방지
               child: MinglitEventCard(
                 event: event,
                 onTap: onEventTap != null ? () => onEventTap!(event) : null,
+                showPartnerOverlay: false,
               ),
             ),
           );

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart
@@ -34,6 +34,7 @@ class MinglitEventCard extends StatelessWidget {
     required this.event,
     super.key,
     this.onTap,
+    this.showPartnerOverlay = true,
     @visibleForTesting this.currentTime,
   }) : _isLoading = false;
 
@@ -42,6 +43,7 @@ class MinglitEventCard extends StatelessWidget {
     super.key,
     this.event,
     this.onTap,
+    this.showPartnerOverlay = true,
     this.currentTime,
   }) : _isLoading = true;
 
@@ -50,6 +52,13 @@ class MinglitEventCard extends StatelessWidget {
 
   /// Optional tap handler for the card.
   final VoidCallback? onTap;
+
+  /// Whether to show the partner badge overlay on the card image.
+  ///
+  /// Set to [false] when the card is displayed within a partner-scoped context
+  /// (e.g., PartnerDetailView, PartnerEventsPage) to avoid redundant branding.
+  // Fix #1214: 파트너 컨텍스트 내에서 뱃지 중복 표시 방지
+  final bool showPartnerOverlay;
 
   /// Override current time for D-day calculation (testing only).
   final DateTime? currentTime;
@@ -195,8 +204,9 @@ class MinglitEventCard extends StatelessWidget {
                         ),
                       ),
                     ),
-                  // Partner overlay (top-left) - only if partner exists
-                  if (partner != null)
+                  // Partner overlay (top-left) - only if partner exists and overlay is enabled
+                  // Fix #1214: showPartnerOverlay=false hides redundant badge in partner context
+                  if (partner != null && showPartnerOverlay)
                     Positioned(
                       top: MinglitSpacing.small,
                       left: MinglitSpacing.small,

--- a/shared/packages/minglit_kit/test/src/ui/widgets/party/event_card_state_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/party/event_card_state_test.dart
@@ -183,12 +183,6 @@ void main() {
     final partner = Partner(
       id: 'partner-1',
       name: '밍글 스튜디오',
-      bizName: '밍글',
-      representativeName: '홍길동',
-      bizNumber: '123-45-67890',
-      contactEmail: 'test@minglit.com',
-      createdAt: baseTime,
-      updatedAt: baseTime,
     );
 
     final partyWithPartner = Party(

--- a/shared/packages/minglit_kit/test/src/ui/widgets/party/event_card_state_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/party/event_card_state_test.dart
@@ -180,7 +180,7 @@ void main() {
   });
 
   group('EventCard showPartnerOverlay', () {
-    final partner = Partner(
+    const partner = Partner(
       id: 'partner-1',
       name: '밍글 스튜디오',
     );

--- a/shared/packages/minglit_kit/test/src/ui/widgets/party/event_card_state_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/party/event_card_state_test.dart
@@ -178,4 +178,76 @@ void main() {
       );
     });
   });
+
+  group('EventCard showPartnerOverlay', () {
+    final partner = Partner(
+      id: 'partner-1',
+      name: '밍글 스튜디오',
+      bizName: '밍글',
+      representativeName: '홍길동',
+      bizNumber: '123-45-67890',
+      contactEmail: 'test@minglit.com',
+      createdAt: baseTime,
+      updatedAt: baseTime,
+    );
+
+    final partyWithPartner = Party(
+      id: 'party-2',
+      partnerId: 'partner-1',
+      title: '파트너 이벤트',
+      createdAt: baseTime,
+      updatedAt: baseTime,
+      partner: partner,
+    );
+
+    final eventWithPartner = Event(
+      id: 'e-partner',
+      partyId: 'party-2',
+      startTime: baseTime,
+      endTime: baseTime.add(const Duration(hours: 2)),
+      createdAt: baseTime,
+      updatedAt: baseTime,
+      currentParticipants: 3,
+      party: partyWithPartner,
+    );
+
+    final fiveDaysBefore = DateTime(2026, 6, 10, 12);
+
+    testWidgets('showPartnerOverlay=true shows partner name', (tester) async {
+      // Fix #1214: 기본값(true)일 때 파트너 이름 표시 확인
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: MinglitTheme.materialTheme,
+          home: Scaffold(
+            body: MinglitEventCard(
+              event: eventWithPartner,
+              currentTime: fiveDaysBefore,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('밍글 스튜디오'), findsOneWidget);
+    });
+
+    testWidgets('showPartnerOverlay=false hides partner name', (tester) async {
+      // Fix #1214: 파트너 컨텍스트(showPartnerOverlay=false)에서 뱃지 숨김 확인
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: MinglitTheme.materialTheme,
+          home: Scaffold(
+            body: MinglitEventCard(
+              event: eventWithPartner,
+              showPartnerOverlay: false,
+              currentTime: fiveDaysBefore,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('밍글 스튜디오'), findsNothing);
+    });
+  });
 }


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-2

## Summary
- `MinglitEventCard`에 `showPartnerOverlay` 파라미터 추가 (기본값 `true`)
- `PartnerDetailView`, `PartnerEventsPage`에서 `showPartnerOverlay: false` 전달하여 파트너 컨텍스트 내 뱃지 중복 제거
- `eventCardContentHeight` 64→68px 수정으로 1px 하단 오버플로 해결

## Test plan
- [ ] `MinglitEventCard(showPartnerOverlay: true)` → 파트너 뱃지 표시 확인
- [ ] `MinglitEventCard(showPartnerOverlay: false)` → 파트너 뱃지 미표시 확인
- [ ] 파트너 상세 페이지에서 이벤트 카드 하단 오버플로 없음 확인
- [ ] 홈 피드, 검색 등 기타 컨텍스트에서 파트너 뱃지 정상 표시 유지

Closes #1214

🤖 Generated with [Claude Code](https://claude.com/claude-code)