### PR TITLE
fix(ui): TrendingTagSection usage_count → recentCount(최근 7일) 교체

### DIFF
--- a/apps/app_user/lib/src/features/home/widgets/trending_tag_section.dart
+++ b/apps/app_user/lib/src/features/home/widgets/trending_tag_section.dart
@@ -43,10 +43,13 @@ class TrendingTagSection extends ConsumerWidget {
                     const SizedBox(width: MinglitSpacing.small),
                 itemBuilder: (context, index) {
                   final tag = tags[index];
+                  // Fix #1224: use recentCount (7-day sum) for the trending
+                  // metric instead of usageCount (cumulative total).
                   return _TrendingTagCard(
                     tagId: tag.id,
                     tagName: tag.name,
-                    usageCount: tag.usageCount,
+                    // Fix #1224: recentCount(최근 7일 증가량)로 트렌딩 의도 반영
+                    recentCount: tag.recentCount,
                     onTap: () => ref
                         .read(tagCoordinatorProvider)
                         .goToTagEventList(tag.id, tag.name),
@@ -67,19 +70,20 @@ class _TrendingTagCard extends StatelessWidget {
   const _TrendingTagCard({
     required this.tagId,
     required this.tagName,
-    required this.usageCount,
+    // Fix #1224: recentCount(최근 7일 증가량)로 교체
+    required this.recentCount,
     required this.onTap,
   });
 
   final String tagId;
   final String tagName;
-  final int usageCount;
+  final int recentCount;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final countLabel = NumberFormat('#,###').format(usageCount);
+    final countLabel = NumberFormat('#,###').format(recentCount);
 
     return GestureDetector(
       onTap: onTap,
@@ -104,8 +108,9 @@ class _TrendingTagCard extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 2),
+            // Fix #1224: "이벤트 N개" → "7일 +N" 으로 트렌딩 의미 명확화
             Text(
-              '이벤트 $countLabel개',
+              '7일 +$countLabel',
               style: theme.textTheme.labelSmall?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),

--- a/shared/packages/minglit_kit/lib/src/data/models/event.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/event.freezed.dart
@@ -16,7 +16,8 @@ T _$identity<T>(T value) => value;
 mixin _$Event {
 
  String get id;@JsonKey(name: 'party_id') String get partyId;@JsonKey(name: 'start_time') DateTime get startTime;@JsonKey(name: 'end_time') DateTime get endTime;@JsonKey(name: 'created_at') DateTime get createdAt;@JsonKey(name: 'updated_at') DateTime get updatedAt;@JsonKey(name: 'location_id') String? get locationId; String? get title; Map<String, dynamic>? get description;@JsonKey(name: 'image_urls') List<String>? get imageUrls;@JsonKey(name: 'contact_options') Map<String, dynamic> get contactOptions; Map<String, dynamic> get metadata;@JsonKey(name: 'min_confirmed_count') int get minConfirmedCount;@JsonKey(name: 'max_participants') int get maxParticipants;@JsonKey(name: 'current_participants') int get currentParticipants; String get status; String? get visibility;@JsonKey(includeToJson: false) Location? get location;@JsonKey(includeToJson: false) Party? get party;@JsonKey(includeToJson: false) List<Ticket>? get tickets;@JsonKey(includeToJson: false) List<EntryGroup>? get entryGroups;// Fields from user-event-feed EF (#614)
-@JsonKey(name: 'remaining_slots', includeToJson: false) int? get remainingSlots;@JsonKey(name: 'distance_meters', includeToJson: false) double? get distanceMeters;@JsonKey(includeToJson: false) bool? get eligible;@JsonKey(includeToJson: false) List<Tag>? get tags;
+@JsonKey(name: 'remaining_slots', includeToJson: false) int? get remainingSlots;@JsonKey(name: 'distance_meters', includeToJson: false) double? get distanceMeters;@JsonKey(includeToJson: false) bool? get eligible;// Tag Discovery (#1094-1096)
+@JsonKey(includeToJson: false) List<Tag>? get tags;
 /// Create a copy of Event
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -330,7 +331,9 @@ class _Event extends Event {
 @override@JsonKey(name: 'remaining_slots', includeToJson: false) final  int? remainingSlots;
 @override@JsonKey(name: 'distance_meters', includeToJson: false) final  double? distanceMeters;
 @override@JsonKey(includeToJson: false) final  bool? eligible;
+// Tag Discovery (#1094-1096)
  final  List<Tag>? _tags;
+// Tag Discovery (#1094-1096)
 @override@JsonKey(includeToJson: false) List<Tag>? get tags {
   final value = _tags;
   if (value == null) return null;
@@ -338,6 +341,7 @@ class _Event extends Event {
   // ignore: implicit_dynamic_type
   return EqualUnmodifiableListView(value);
 }
+
 
 /// Create a copy of Event
 /// with the given fields replaced by the non-null parameter values.

--- a/shared/packages/minglit_kit/lib/src/data/models/party.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/party.freezed.dart
@@ -325,7 +325,8 @@ as double,
 mixin _$Party {
 
  String get id;@JsonKey(name: 'partner_id') String get partnerId; String get title;@JsonKey(name: 'created_at') DateTime get createdAt;@JsonKey(name: 'updated_at') DateTime get updatedAt;@JsonKey(name: 'location_id') String? get locationId;@JsonKey(includeToJson: false) Location? get location; Map<String, dynamic>? get description;// Quill Delta JSON
-@JsonKey(name: 'image_urls') List<String> get imageUrls;@JsonKey(name: 'contact_options') Map<String, dynamic> get contactOptions; Map<String, dynamic> get metadata;@JsonKey(name: 'required_verification_ids') List<String> get requiredVerificationIds;@JsonKey(name: 'min_confirmed_count') int get minConfirmedCount;@JsonKey(name: 'max_participants') int get maxParticipants; String get status; String get visibility;@JsonKey(includeToJson: false) List<TicketTemplate>? get ticketTemplates;@JsonKey(includeToJson: false) Partner? get partner;@JsonKey(name: 'entry_group_templates', includeToJson: false) List<EntryGroupTemplate>? get entryGroups;@JsonKey(includeToJson: false) List<Tag>? get tags;
+@JsonKey(name: 'image_urls') List<String> get imageUrls;@JsonKey(name: 'contact_options') Map<String, dynamic> get contactOptions; Map<String, dynamic> get metadata;@JsonKey(name: 'required_verification_ids') List<String> get requiredVerificationIds;@JsonKey(name: 'min_confirmed_count') int get minConfirmedCount;@JsonKey(name: 'max_participants') int get maxParticipants; String get status; String get visibility;@JsonKey(includeToJson: false) List<TicketTemplate>? get ticketTemplates;@JsonKey(includeToJson: false) Partner? get partner;@JsonKey(name: 'entry_group_templates', includeToJson: false) List<EntryGroupTemplate>? get entryGroups;// Tag Discovery (#1094-1096)
+@JsonKey(includeToJson: false) List<Tag>? get tags;
 /// Create a copy of Party
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -634,7 +635,9 @@ class _Party extends Party {
   return EqualUnmodifiableListView(value);
 }
 
+// Tag Discovery (#1094-1096)
  final  List<Tag>? _tags;
+// Tag Discovery (#1094-1096)
 @override@JsonKey(includeToJson: false) List<Tag>? get tags {
   final value = _tags;
   if (value == null) return null;
@@ -642,6 +645,7 @@ class _Party extends Party {
   // ignore: implicit_dynamic_type
   return EqualUnmodifiableListView(value);
 }
+
 
 /// Create a copy of Party
 /// with the given fields replaced by the non-null parameter values.

--- a/shared/packages/minglit_kit/lib/src/data/models/tag.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/tag.dart
@@ -14,6 +14,10 @@ abstract class Tag with _$Tag {
     required String name,
     @JsonKey(name: 'is_featured') @Default(false) bool isFeatured,
     @JsonKey(name: 'usage_count') @Default(0) int usageCount,
+    // Fix #1224: recent_count is the 7-day trending metric returned by the
+    // get_trending_tags RPC. Defaults to 0 so non-RPC sources (e.g. plain
+    // tag list) remain compatible without schema changes.
+    @JsonKey(name: 'recent_count') @Default(0) int recentCount,
   }) = _Tag;
 
   /// Creates a [Tag] from a JSON map.

--- a/shared/packages/minglit_kit/lib/src/data/models/tag.freezed.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/tag.freezed.dart
@@ -15,7 +15,10 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$Tag {
 
- String get id; String get name;@JsonKey(name: 'is_featured') bool get isFeatured;@JsonKey(name: 'usage_count') int get usageCount;
+ String get id; String get name;@JsonKey(name: 'is_featured') bool get isFeatured;@JsonKey(name: 'usage_count') int get usageCount;// Fix #1224: recent_count is the 7-day trending metric returned by the
+// get_trending_tags RPC. Defaults to 0 so non-RPC sources (e.g. plain
+// tag list) remain compatible without schema changes.
+@JsonKey(name: 'recent_count') int get recentCount;
 /// Create a copy of Tag
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +31,16 @@ $TagCopyWith<Tag> get copyWith => _$TagCopyWithImpl<Tag>(this as Tag, _$identity
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Tag&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.isFeatured, isFeatured) || other.isFeatured == isFeatured)&&(identical(other.usageCount, usageCount) || other.usageCount == usageCount));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Tag&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.isFeatured, isFeatured) || other.isFeatured == isFeatured)&&(identical(other.usageCount, usageCount) || other.usageCount == usageCount)&&(identical(other.recentCount, recentCount) || other.recentCount == recentCount));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,isFeatured,usageCount);
+int get hashCode => Object.hash(runtimeType,id,name,isFeatured,usageCount,recentCount);
 
 @override
 String toString() {
-  return 'Tag(id: $id, name: $name, isFeatured: $isFeatured, usageCount: $usageCount)';
+  return 'Tag(id: $id, name: $name, isFeatured: $isFeatured, usageCount: $usageCount, recentCount: $recentCount)';
 }
 
 
@@ -48,7 +51,7 @@ abstract mixin class $TagCopyWith<$Res>  {
   factory $TagCopyWith(Tag value, $Res Function(Tag) _then) = _$TagCopyWithImpl;
 @useResult
 $Res call({
- String id, String name,@JsonKey(name: 'is_featured') bool isFeatured,@JsonKey(name: 'usage_count') int usageCount
+ String id, String name,@JsonKey(name: 'is_featured') bool isFeatured,@JsonKey(name: 'usage_count') int usageCount,@JsonKey(name: 'recent_count') int recentCount
 });
 
 
@@ -65,12 +68,13 @@ class _$TagCopyWithImpl<$Res>
 
 /// Create a copy of Tag
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? isFeatured = null,Object? usageCount = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? isFeatured = null,Object? usageCount = null,Object? recentCount = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,isFeatured: null == isFeatured ? _self.isFeatured : isFeatured // ignore: cast_nullable_to_non_nullable
 as bool,usageCount: null == usageCount ? _self.usageCount : usageCount // ignore: cast_nullable_to_non_nullable
+as int,recentCount: null == recentCount ? _self.recentCount : recentCount // ignore: cast_nullable_to_non_nullable
 as int,
   ));
 }
@@ -81,6 +85,17 @@ as int,
 /// Adds pattern-matching-related methods to [Tag].
 extension TagPatterns on Tag {
 /// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
 @optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Tag value)?  $default,{required TResult orElse(),}){
 final _that = this;
 switch (_that) {
@@ -91,6 +106,18 @@ return $default(_that);case _:
 }
 }
 /// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
 @optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Tag value)  $default,){
 final _that = this;
 switch (_that) {
@@ -101,6 +128,17 @@ return $default(_that);case _:
 }
 }
 /// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
 @optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Tag value)?  $default,){
 final _that = this;
 switch (_that) {
@@ -111,28 +149,62 @@ return $default(_that);case _:
 }
 }
 /// A variant of `when` that fallback to an `orElse` callback.
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  bool isFeatured,  int usageCount)?  $default,{required TResult orElse(),}) {final _that = this;
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name, @JsonKey(name: 'is_featured')  bool isFeatured, @JsonKey(name: 'usage_count')  int usageCount, @JsonKey(name: 'recent_count')  int recentCount)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Tag() when $default != null:
-return $default(_that.id,_that.name,_that.isFeatured,_that.usageCount);case _:
+return $default(_that.id,_that.name,_that.isFeatured,_that.usageCount,_that.recentCount);case _:
   return orElse();
 
 }
 }
 /// A `switch`-like method, using callbacks.
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  bool isFeatured,  int usageCount)  $default,) {final _that = this;
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name, @JsonKey(name: 'is_featured')  bool isFeatured, @JsonKey(name: 'usage_count')  int usageCount, @JsonKey(name: 'recent_count')  int recentCount)  $default,) {final _that = this;
 switch (_that) {
 case _Tag():
-return $default(_that.id,_that.name,_that.isFeatured,_that.usageCount);case _:
+return $default(_that.id,_that.name,_that.isFeatured,_that.usageCount,_that.recentCount);case _:
   throw StateError('Unexpected subclass');
 
 }
 }
 /// A variant of `when` that fallback to returning `null`
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  bool isFeatured,  int usageCount)?  $default,) {final _that = this;
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name, @JsonKey(name: 'is_featured')  bool isFeatured, @JsonKey(name: 'usage_count')  int usageCount, @JsonKey(name: 'recent_count')  int recentCount)?  $default,) {final _that = this;
 switch (_that) {
 case _Tag() when $default != null:
-return $default(_that.id,_that.name,_that.isFeatured,_that.usageCount);case _:
+return $default(_that.id,_that.name,_that.isFeatured,_that.usageCount,_that.recentCount);case _:
   return null;
 
 }
@@ -141,15 +213,20 @@ return $default(_that.id,_that.name,_that.isFeatured,_that.usageCount);case _:
 }
 
 /// @nodoc
-
+@JsonSerializable()
 
 class _Tag implements Tag {
-  const _Tag({required this.id, required this.name, @JsonKey(name: 'is_featured') this.isFeatured = false, @JsonKey(name: 'usage_count') this.usageCount = 0});
+  const _Tag({required this.id, required this.name, @JsonKey(name: 'is_featured') this.isFeatured = false, @JsonKey(name: 'usage_count') this.usageCount = 0, @JsonKey(name: 'recent_count') this.recentCount = 0});
+  factory _Tag.fromJson(Map<String, dynamic> json) => _$TagFromJson(json);
 
 @override final  String id;
 @override final  String name;
 @override@JsonKey(name: 'is_featured') final  bool isFeatured;
 @override@JsonKey(name: 'usage_count') final  int usageCount;
+// Fix #1224: recent_count is the 7-day trending metric returned by the
+// get_trending_tags RPC. Defaults to 0 so non-RPC sources (e.g. plain
+// tag list) remain compatible without schema changes.
+@override@JsonKey(name: 'recent_count') final  int recentCount;
 
 /// Create a copy of Tag
 /// with the given fields replaced by the non-null parameter values.
@@ -164,16 +241,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Tag&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.isFeatured, isFeatured) || other.isFeatured == isFeatured)&&(identical(other.usageCount, usageCount) || other.usageCount == usageCount));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Tag&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.isFeatured, isFeatured) || other.isFeatured == isFeatured)&&(identical(other.usageCount, usageCount) || other.usageCount == usageCount)&&(identical(other.recentCount, recentCount) || other.recentCount == recentCount));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,isFeatured,usageCount);
+int get hashCode => Object.hash(runtimeType,id,name,isFeatured,usageCount,recentCount);
 
 @override
 String toString() {
-  return 'Tag(id: $id, name: $name, isFeatured: $isFeatured, usageCount: $usageCount)';
+  return 'Tag(id: $id, name: $name, isFeatured: $isFeatured, usageCount: $usageCount, recentCount: $recentCount)';
 }
 
 
@@ -184,7 +261,7 @@ abstract mixin class _$TagCopyWith<$Res> implements $TagCopyWith<$Res> {
   factory _$TagCopyWith(_Tag value, $Res Function(_Tag) _then) = __$TagCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name,@JsonKey(name: 'is_featured') bool isFeatured,@JsonKey(name: 'usage_count') int usageCount
+ String id, String name,@JsonKey(name: 'is_featured') bool isFeatured,@JsonKey(name: 'usage_count') int usageCount,@JsonKey(name: 'recent_count') int recentCount
 });
 
 
@@ -201,15 +278,17 @@ class __$TagCopyWithImpl<$Res>
 
 /// Create a copy of Tag
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? isFeatured = null,Object? usageCount = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? isFeatured = null,Object? usageCount = null,Object? recentCount = null,}) {
   return _then(_Tag(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,isFeatured: null == isFeatured ? _self.isFeatured : isFeatured // ignore: cast_nullable_to_non_nullable
 as bool,usageCount: null == usageCount ? _self.usageCount : usageCount // ignore: cast_nullable_to_non_nullable
+as int,recentCount: null == recentCount ? _self.recentCount : recentCount // ignore: cast_nullable_to_non_nullable
 as int,
   ));
 }
+
 
 }
 

--- a/shared/packages/minglit_kit/lib/src/data/models/tag.g.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/tag.g.dart
@@ -11,6 +11,7 @@ _Tag _$TagFromJson(Map<String, dynamic> json) => _Tag(
   name: json['name'] as String,
   isFeatured: json['is_featured'] as bool? ?? false,
   usageCount: (json['usage_count'] as num?)?.toInt() ?? 0,
+  recentCount: (json['recent_count'] as num?)?.toInt() ?? 0,
 );
 
 Map<String, dynamic> _$TagToJson(_Tag instance) => <String, dynamic>{
@@ -18,4 +19,5 @@ Map<String, dynamic> _$TagToJson(_Tag instance) => <String, dynamic>{
   'name': instance.name,
   'is_featured': instance.isFeatured,
   'usage_count': instance.usageCount,
+  'recent_count': instance.recentCount,
 };

--- a/shared/packages/minglit_kit/lib/src/data/repositories/tag_repository.g.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/tag_repository.g.dart
@@ -52,4 +52,4 @@ final class TagRepositoryProvider
   }
 }
 
-String _$tagRepositoryHash() => r'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0';
+String _$tagRepositoryHash() => r'1a1469f6205b0d9c8eb8ba96a5a364462c3512a1';

--- a/shared/packages/minglit_kit/lib/src/logic/providers/tag_providers.g.dart
+++ b/shared/packages/minglit_kit/lib/src/logic/providers/tag_providers.g.dart
@@ -8,9 +8,16 @@ part of 'tag_providers.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
+/// Provides the list of featured tags.
+///
+/// Kept alive indefinitely — invalidate manually when stale.
 
 @ProviderFor(featuredTags)
 const featuredTagsProvider = FeaturedTagsProvider._();
+
+/// Provides the list of featured tags.
+///
+/// Kept alive indefinitely — invalidate manually when stale.
 
 final class FeaturedTagsProvider
     extends
@@ -20,6 +27,9 @@ final class FeaturedTagsProvider
           FutureOr<List<Tag>>
         >
     with $FutureModifier<List<Tag>>, $FutureProvider<List<Tag>> {
+  /// Provides the list of featured tags.
+  ///
+  /// Kept alive indefinitely — invalidate manually when stale.
   const FeaturedTagsProvider._()
     : super(
         from: null,
@@ -36,9 +46,8 @@ final class FeaturedTagsProvider
 
   @$internal
   @override
-  $FutureProviderElement<List<Tag>> $createElement(
-    $ProviderPointer pointer,
-  ) => $FutureProviderElement(pointer);
+  $FutureProviderElement<List<Tag>> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<List<Tag>> create(Ref ref) {
@@ -46,10 +55,18 @@ final class FeaturedTagsProvider
   }
 }
 
-String _$featuredTagsHash() => r'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b1';
+String _$featuredTagsHash() => r'1eeee57e5f19fa6119b2351782f5852a656669fd';
+
+/// Provides the list of trending tags.
+///
+/// Kept alive indefinitely — invalidate manually when stale.
 
 @ProviderFor(trendingTags)
 const trendingTagsProvider = TrendingTagsProvider._();
+
+/// Provides the list of trending tags.
+///
+/// Kept alive indefinitely — invalidate manually when stale.
 
 final class TrendingTagsProvider
     extends
@@ -59,6 +76,9 @@ final class TrendingTagsProvider
           FutureOr<List<Tag>>
         >
     with $FutureModifier<List<Tag>>, $FutureProvider<List<Tag>> {
+  /// Provides the list of trending tags.
+  ///
+  /// Kept alive indefinitely — invalidate manually when stale.
   const TrendingTagsProvider._()
     : super(
         from: null,
@@ -75,9 +95,8 @@ final class TrendingTagsProvider
 
   @$internal
   @override
-  $FutureProviderElement<List<Tag>> $createElement(
-    $ProviderPointer pointer,
-  ) => $FutureProviderElement(pointer);
+  $FutureProviderElement<List<Tag>> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<List<Tag>> create(Ref ref) {
@@ -85,10 +104,18 @@ final class TrendingTagsProvider
   }
 }
 
-String _$trendingTagsHash() => r'b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1';
+String _$trendingTagsHash() => r'6306cb019311da5aa5c335f57674d5c0013efa16';
+
+/// Searches tags matching [query].
+///
+/// Empty query returns an empty list without calling the server.
 
 @ProviderFor(tagSearch)
 const tagSearchProvider = TagSearchFamily._();
+
+/// Searches tags matching [query].
+///
+/// Empty query returns an empty list without calling the server.
 
 final class TagSearchProvider
     extends
@@ -98,6 +125,9 @@ final class TagSearchProvider
           FutureOr<List<Tag>>
         >
     with $FutureModifier<List<Tag>>, $FutureProvider<List<Tag>> {
+  /// Searches tags matching [query].
+  ///
+  /// Empty query returns an empty list without calling the server.
   const TagSearchProvider._({
     required TagSearchFamily super.from,
     required String super.argument,
@@ -121,9 +151,8 @@ final class TagSearchProvider
 
   @$internal
   @override
-  $FutureProviderElement<List<Tag>> $createElement(
-    $ProviderPointer pointer,
-  ) => $FutureProviderElement(pointer);
+  $FutureProviderElement<List<Tag>> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<List<Tag>> create(Ref ref) {
@@ -142,7 +171,11 @@ final class TagSearchProvider
   }
 }
 
-String _$tagSearchHash() => r'c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2';
+String _$tagSearchHash() => r'1d3a6617e00e7779eb319eadc34475c9d0c54424';
+
+/// Searches tags matching [query].
+///
+/// Empty query returns an empty list without calling the server.
 
 final class TagSearchFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<List<Tag>>, String> {
@@ -155,6 +188,10 @@ final class TagSearchFamily extends $Family
         isAutoDispose: true,
       );
 
+  /// Searches tags matching [query].
+  ///
+  /// Empty query returns an empty list without calling the server.
+
   TagSearchProvider call(String query) =>
       TagSearchProvider._(argument: query, from: this);
 
@@ -162,8 +199,12 @@ final class TagSearchFamily extends $Family
   String toString() => r'tagSearchProvider';
 }
 
+/// Provides the current user's interest tags.
+
 @ProviderFor(userInterestTags)
 const userInterestTagsProvider = UserInterestTagsProvider._();
+
+/// Provides the current user's interest tags.
 
 final class UserInterestTagsProvider
     extends
@@ -173,6 +214,7 @@ final class UserInterestTagsProvider
           FutureOr<List<Tag>>
         >
     with $FutureModifier<List<Tag>>, $FutureProvider<List<Tag>> {
+  /// Provides the current user's interest tags.
   const UserInterestTagsProvider._()
     : super(
         from: null,
@@ -189,9 +231,8 @@ final class UserInterestTagsProvider
 
   @$internal
   @override
-  $FutureProviderElement<List<Tag>> $createElement(
-    $ProviderPointer pointer,
-  ) => $FutureProviderElement(pointer);
+  $FutureProviderElement<List<Tag>> $createElement($ProviderPointer pointer) =>
+      $FutureProviderElement(pointer);
 
   @override
   FutureOr<List<Tag>> create(Ref ref) {
@@ -199,4 +240,49 @@ final class UserInterestTagsProvider
   }
 }
 
-String _$userInterestTagsHash() => r'd4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3';
+String _$userInterestTagsHash() => r'626e159a409d3b7534382ef2557747aadbff998d';
+
+/// Provides personalized event recommendations based on user interest tags.
+
+@ProviderFor(tagRecommendationFeed)
+const tagRecommendationFeedProvider = TagRecommendationFeedProvider._();
+
+/// Provides personalized event recommendations based on user interest tags.
+
+final class TagRecommendationFeedProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<List<Event>>,
+          List<Event>,
+          FutureOr<List<Event>>
+        >
+    with $FutureModifier<List<Event>>, $FutureProvider<List<Event>> {
+  /// Provides personalized event recommendations based on user interest tags.
+  const TagRecommendationFeedProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'tagRecommendationFeedProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$tagRecommendationFeedHash();
+
+  @$internal
+  @override
+  $FutureProviderElement<List<Event>> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<List<Event>> create(Ref ref) {
+    return tagRecommendationFeed(ref);
+  }
+}
+
+String _$tagRecommendationFeedHash() =>
+    r'cffac2fa4d8c9c7350deb8912d49a87a54dbb80a';

--- a/shared/packages/minglit_kit/test/src/data/repositories/tag_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/tag_repository_test.dart
@@ -173,5 +173,22 @@ void main() {
       expect(json['is_featured'], isTrue);
       expect(json['usage_count'], 5);
     });
+
+    // Fix #1224: TrendingTagSection — recent_count 역직렬화 회귀 테스트
+    test('fromJson maps recent_count to recentCount', () {
+      final tag = Tag.fromJson({
+        'id': '1',
+        'name': 'test',
+        'recent_count': 42,
+      });
+
+      expect(tag.recentCount, 42);
+    });
+
+    test('recentCount defaults to 0 when recent_count absent', () {
+      final tag = Tag.fromJson({'id': '1', 'name': 'test'});
+
+      expect(tag.recentCount, 0);
+    });
   });
 }


### PR DESCRIPTION
## Summary

- `Tag` 모델에 `recentCount` 필드 추가 — RPC `get_trending_tags`가 이미 `recent_count`를 반환하고 있었지만 Dart 모델에 필드가 없어 드롭되고 있었음
- `TrendingTagSection`의 `_TrendingTagCard`에서 `usageCount`(누적 총합) 대신 `recentCount`(최근 7일 합산)를 표시
- 라벨 포맷 변경: `이벤트 N개` → `7일 +N` (트렌딩 의미 명확화)
- 회귀 테스트 2개 추가 (`recent_count` 역직렬화 + 기본값 0)

## Test plan

- [ ] `shared/packages/minglit_kit/test/src/data/repositories/tag_repository_test.dart` — 신규 테스트 2개 통과 확인
- [ ] `test-flutter-apps` CI job 통과 (flutter analyze + test)
- [ ] 홈 화면 트렌딩 태그 카드에 `7일 +N` 표시 확인
- [ ] 빈 태그 목록일 때 섹션 숨김 동작 유지 확인

Closes #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)