### PR TITLE
fix: IdentityVerificationScreen — consentControllerProvider disposed 에러 방지

### DIFF
--- a/shared/packages/minglit_kit/lib/src/features/verification/ui/identity_verification_screen.dart
+++ b/shared/packages/minglit_kit/lib/src/features/verification/ui/identity_verification_screen.dart
@@ -129,6 +129,9 @@ class _IdentityVerificationScreenState
 
   @override
   Widget build(BuildContext context) {
+    // Fix #1271: consentControllerProvider가 isAutoDispose=true이므로 비동기 작업 중
+    // disposed되지 않도록 watch로 생명주기를 화면에 고정한다.
+    ref.watch(consentControllerProvider);
     final theme = Theme.of(context);
 
     return Scaffold(

--- a/shared/packages/minglit_kit/test/src/features/verification/ui/identity_verification_screen_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/verification/ui/identity_verification_screen_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 

--- a/shared/packages/minglit_kit/test/src/features/verification/ui/identity_verification_screen_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/verification/ui/identity_verification_screen_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+/// ProviderObserver that records the names of providers that have been
+/// initialized in the container.
+base class _ProviderInitObserver extends ProviderObserver {
+  final List<String> initialized = [];
+
+  @override
+  void didAddProvider(ProviderObserverContext context, Object? value) {
+    final name = context.provider.name ?? 'unnamed';
+    initialized.add(name);
+  }
+}
+
+void main() {
+  group('IdentityVerificationScreen', () {
+    // Fix #1271 regression: consentControllerProvider (isAutoDispose=true)이 build()에서
+    // watch되지 않으면 비동기 toggleConsent 호출 시 "Ref disposed" 에러 발생.
+    // build()에 ref.watch(consentControllerProvider)를 추가하여 화면 생명주기와 일치시킨다.
+    testWidgets(
+      'watches consentControllerProvider to prevent disposal during async flow',
+      (tester) async {
+        final observer = _ProviderInitObserver();
+
+        // currentUserProvider = null → _ensureIdentityVerificationConsent이 즉시 false
+        // 반환, getCertificationService() 호출을 방지한다.
+        await tester.pumpWidget(
+          ProviderScope(
+            observers: [observer],
+            overrides: [
+              currentUserProvider.overrideWithValue(null),
+            ],
+            child: const MaterialApp(
+              home: IdentityVerificationScreen(),
+            ),
+          ),
+        );
+
+        // postFrameCallback 및 async 상태 변경 처리
+        await tester.pump();
+        await tester.pump();
+
+        // build()에서 ref.watch(consentControllerProvider)가 호출되면
+        // 해당 provider가 container에 초기화(didAddProvider)된다.
+        expect(
+          observer.initialized,
+          contains('consentControllerProvider'),
+          reason:
+              'consentControllerProvider는 build()에서 watch되어야 isAutoDispose로 인한 '
+              'disposed 에러를 방지할 수 있다.',
+        );
+      },
+    );
+
+    testWidgets(
+      'renders loading state initially',
+      (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              currentUserProvider.overrideWithValue(null),
+            ],
+            child: const MaterialApp(
+              home: IdentityVerificationScreen(),
+            ),
+          ),
+        );
+
+        // 첫 프레임: loading state
+        expect(find.byType(CircularProgressIndicator), findsAny);
+      },
+    );
+  });
+}

--- a/shared/packages/minglit_kit/test/src/features/verification/ui/identity_verification_screen_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/verification/ui/identity_verification_screen_test.dart
@@ -16,8 +16,8 @@ base class _ProviderInitObserver extends ProviderObserver {
 
 void main() {
   group('IdentityVerificationScreen', () {
-    // Fix #1271 regression: consentControllerProvider (isAutoDispose=true)이 build()에서
-    // watch되지 않으면 비동기 toggleConsent 호출 시 "Ref disposed" 에러 발생.
+    // Fix #1271: consentControllerProvider (isAutoDispose=true)이 build()에서
+    // watch되지 않으면 비동기 toggleConsent 호출 시 "Ref disposed" 에러 발생 (regression 방지).
     // build()에 ref.watch(consentControllerProvider)를 추가하여 화면 생명주기와 일치시킨다.
     testWidgets(
       'watches consentControllerProvider to prevent disposal during async flow',


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1271

## 변경 요약

### 원인
`consentControllerProvider`는 `isAutoDispose: true`로 설정되어 있다. `IdentityVerificationScreen`에서 동의 바텀시트(`showIdentityVerificationConsentSheet()`)가 표시되는 동안 해당 provider를 `watch`하는 리스너가 없으면 Riverpod이 provider를 dispose한다. 이후 `toggleConsent()` 호출 시 "Cannot use the Ref of consentControllerProvider after it has been disposed." 에러 발생 → 유저의 본인인증 플로우 차단.

### 수정
`build()` 메서드에 `ref.watch(consentControllerProvider)` 추가. 화면이 마운트된 동안 provider가 유지된다.

### 테스트
`ProviderObserver`로 `build()` 호출 시 `consentControllerProvider`가 초기화(watched)됨을 검증하는 위젯 테스트 추가.