### PR TITLE
feat(bug-report): ADB 인텐트 기반 QA 버그 리포트 트리거 (dev only)

### DIFF
--- a/apps/app_partner/android/app/src/dev/AndroidManifest.xml
+++ b/apps/app_partner/android/app/src/dev/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <!-- Dev-only: ADB intent receiver for QA automated bug reporting -->
+        <receiver
+            android:name=".QaBugReportReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.minglit.dev.QA_BUG_REPORT" />
+            </intent-filter>
+        </receiver>
+    </application>
+</manifest>

--- a/apps/app_partner/android/app/src/dev/kotlin/com/minglit/app_partner/MainActivity.kt
+++ b/apps/app_partner/android/app/src/dev/kotlin/com/minglit/app_partner/MainActivity.kt
@@ -1,0 +1,26 @@
+package com.minglit.app_partner
+
+import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.FlutterEngineCache
+
+/**
+ * Dev-flavor MainActivity that registers the [FlutterEngine] in
+ * [FlutterEngineCache] so that [QaBugReportReceiver] can obtain a reference
+ * to it and invoke MethodChannel calls from a BroadcastReceiver context.
+ */
+class MainActivity : FlutterActivity() {
+    companion object {
+        const val ENGINE_CACHE_ID = "minglit_main_engine"
+    }
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        FlutterEngineCache.getInstance().put(ENGINE_CACHE_ID, flutterEngine)
+    }
+
+    override fun cleanUpFlutterEngine(flutterEngine: FlutterEngine) {
+        FlutterEngineCache.getInstance().remove(ENGINE_CACHE_ID)
+        super.cleanUpFlutterEngine(flutterEngine)
+    }
+}

--- a/apps/app_partner/android/app/src/dev/kotlin/com/minglit/app_partner/QaBugReportReceiver.kt
+++ b/apps/app_partner/android/app/src/dev/kotlin/com/minglit/app_partner/QaBugReportReceiver.kt
@@ -1,0 +1,51 @@
+package com.minglit.app_partner
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import io.flutter.embedding.engine.FlutterEngineCache
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Dev-only BroadcastReceiver that forwards ADB-triggered bug report intents
+ * to Flutter via MethodChannel.
+ *
+ * Usage from ADB:
+ * ```
+ * adb shell am broadcast \
+ *   -a com.minglit.dev.QA_BUG_REPORT \
+ *   --es title "Bug title" \
+ *   --es description "Bug description" \
+ *   --es scenario_id "P-S01" \
+ *   --es session_id "20260412-173833"
+ * ```
+ *
+ * The Flutter engine must be running (app in foreground) for the channel
+ * call to reach Dart. If the engine is not available the broadcast is
+ * silently ignored.
+ */
+class QaBugReportReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val title = intent.getStringExtra("title") ?: "QA Bug Report"
+        val description = intent.getStringExtra("description") ?: ""
+        val scenarioId = intent.getStringExtra("scenario_id") ?: ""
+        val sessionId = intent.getStringExtra("session_id") ?: ""
+
+        val engine = FlutterEngineCache.getInstance()
+            .get(MainActivity.ENGINE_CACHE_ID) ?: return
+
+        val channel = MethodChannel(
+            engine.dartExecutor.binaryMessenger,
+            "com.minglit.dev/qa_bug_report",
+        )
+        channel.invokeMethod(
+            "triggerBugReport",
+            mapOf(
+                "title" to title,
+                "description" to description,
+                "scenario_id" to scenarioId,
+                "session_id" to sessionId,
+            ),
+        )
+    }
+}

--- a/apps/app_user/android/app/src/dev/AndroidManifest.xml
+++ b/apps/app_user/android/app/src/dev/AndroidManifest.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Dev flavor only: minglit-dev:// custom scheme deep link -->
-<!-- This manifest is merged into dev flavor builds only via Android manifest merger. -->
-<!-- prod flavor will NOT include this intent-filter. -->
-<!-- Fix #1249: dev 전용 딥링크(/dev/switch 등) 접근을 위한 minglit-dev:// scheme 등록 -->
-<!-- ADB test: adb shell am start -a android.intent.action.VIEW -d 'minglit-dev:///dev/switch' -p com.minglit.app_user.dev -->
+<!-- Dev flavor only: deep link + QA bug report receiver -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
         <activity android:name=".MainActivity">
@@ -15,5 +11,13 @@
                 <data android:scheme="minglit-dev" />
             </intent-filter>
         </activity>
+        <!-- Dev-only: ADB intent receiver for QA automated bug reporting -->
+        <receiver
+            android:name=".QaBugReportReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.minglit.dev.QA_BUG_REPORT" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/apps/app_user/android/app/src/dev/kotlin/com/minglit/app_user/MainActivity.kt
+++ b/apps/app_user/android/app/src/dev/kotlin/com/minglit/app_user/MainActivity.kt
@@ -1,0 +1,26 @@
+package com.minglit.app_user
+
+import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.FlutterEngineCache
+
+/**
+ * Dev-flavor MainActivity that registers the [FlutterEngine] in
+ * [FlutterEngineCache] so that [QaBugReportReceiver] can obtain a reference
+ * to it and invoke MethodChannel calls from a BroadcastReceiver context.
+ */
+class MainActivity : FlutterActivity() {
+    companion object {
+        const val ENGINE_CACHE_ID = "minglit_main_engine"
+    }
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        FlutterEngineCache.getInstance().put(ENGINE_CACHE_ID, flutterEngine)
+    }
+
+    override fun cleanUpFlutterEngine(flutterEngine: FlutterEngine) {
+        FlutterEngineCache.getInstance().remove(ENGINE_CACHE_ID)
+        super.cleanUpFlutterEngine(flutterEngine)
+    }
+}

--- a/apps/app_user/android/app/src/dev/kotlin/com/minglit/app_user/QaBugReportReceiver.kt
+++ b/apps/app_user/android/app/src/dev/kotlin/com/minglit/app_user/QaBugReportReceiver.kt
@@ -1,0 +1,51 @@
+package com.minglit.app_user
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import io.flutter.embedding.engine.FlutterEngineCache
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Dev-only BroadcastReceiver that forwards ADB-triggered bug report intents
+ * to Flutter via MethodChannel.
+ *
+ * Usage from ADB:
+ * ```
+ * adb shell am broadcast \
+ *   -a com.minglit.dev.QA_BUG_REPORT \
+ *   --es title "Bug title" \
+ *   --es description "Bug description" \
+ *   --es scenario_id "U-S04" \
+ *   --es session_id "20260412-173833"
+ * ```
+ *
+ * The Flutter engine must be running (app in foreground) for the channel
+ * call to reach Dart. If the engine is not available the broadcast is
+ * silently ignored.
+ */
+class QaBugReportReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val title = intent.getStringExtra("title") ?: "QA Bug Report"
+        val description = intent.getStringExtra("description") ?: ""
+        val scenarioId = intent.getStringExtra("scenario_id") ?: ""
+        val sessionId = intent.getStringExtra("session_id") ?: ""
+
+        val engine = FlutterEngineCache.getInstance()
+            .get(MainActivity.ENGINE_CACHE_ID) ?: return
+
+        val channel = MethodChannel(
+            engine.dartExecutor.binaryMessenger,
+            "com.minglit.dev/qa_bug_report",
+        )
+        channel.invokeMethod(
+            "triggerBugReport",
+            mapOf(
+                "title" to title,
+                "description" to description,
+                "scenario_id" to scenarioId,
+                "session_id" to sessionId,
+            ),
+        )
+    }
+}

--- a/shared/packages/minglit_kit/lib/minglit_dev.dart
+++ b/shared/packages/minglit_kit/lib/minglit_dev.dart
@@ -1,3 +1,4 @@
+export 'src/data/services/bug_report_collector.dart';
 export 'src/features/dev/catalog_tabs/patterns/async_wrapper_demo.dart';
 export 'src/features/dev/catalog_tabs/patterns/data_states_demo.dart';
 export 'src/features/dev/catalog_tabs/patterns/transaction_flow_demo.dart';
@@ -10,3 +11,4 @@ export 'src/features/dev/party_list_preview_screen.dart';
 export 'src/features/dev/widgets/party_detail_view.dart';
 export 'src/ui/widgets/debug/user_session_info.dart';
 export 'src/utils/dev_screen_list.dart';
+export 'src/utils/qa_bug_report_channel.dart';

--- a/shared/packages/minglit_kit/lib/src/data/services/bug_report_collector.dart
+++ b/shared/packages/minglit_kit/lib/src/data/services/bug_report_collector.dart
@@ -1,0 +1,130 @@
+import 'dart:convert';
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:minglit_kit/src/data/repositories/bug_report_repository.dart';
+import 'package:minglit_kit/src/data/repositories/storage_repository.dart';
+import 'package:minglit_kit/src/utils/environment_info.dart';
+import 'package:minglit_kit/src/utils/layout_dump.dart';
+import 'package:minglit_kit/src/utils/log.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// Collects bug report data (screenshot, layout dump, environment info, logs)
+/// and submits it via [BugReportRepository].
+///
+/// Extracted from [BugReporterWrapper] so that programmatic callers
+/// (e.g. [QaBugReportChannel]) can trigger a report without UI interaction.
+class BugReportCollector {
+  /// Creates a [BugReportCollector] bound to [boundaryKey].
+  ///
+  /// [boundaryKey] must be attached to a [RepaintBoundary] widget.
+  const BugReportCollector({required this.boundaryKey});
+
+  /// The key attached to the [RepaintBoundary] for screenshot capture.
+  final GlobalKey boundaryKey;
+
+  /// Captures a screenshot of the widget subtree under [boundaryKey].
+  ///
+  /// Returns the public Storage URL on success, or null on failure
+  /// (best-effort — never throws).
+  Future<String?> captureScreenshot() async {
+    if (kIsWeb) return null;
+    try {
+      final boundary =
+          boundaryKey.currentContext?.findRenderObject()
+              as RenderRepaintBoundary?;
+      if (boundary == null) return null;
+      final image = await boundary.toImage();
+      final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
+      if (byteData == null) return null;
+      final bytes = byteData.buffer.asUint8List();
+      return StorageRepository().uploadBytes(
+        bytes: bytes,
+        bucket: 'bug-report-attachments',
+        pathPrefix: 'screenshots',
+      );
+    } on Exception catch (e) {
+      Log.e('Screenshot capture failed (best-effort)', e);
+      return null;
+    }
+  }
+
+  /// Captures the layout dump and uploads it to Storage.
+  ///
+  /// Returns the public Storage URL on success, or null on failure
+  /// (best-effort — never throws).
+  Future<String?> captureAndUploadLayoutDump() async {
+    final layoutDump = await captureLayoutDump();
+    if (layoutDump == null) return null;
+    try {
+      return await StorageRepository().uploadBytes(
+        bytes: Uint8List.fromList(utf8.encode(layoutDump)),
+        bucket: 'bug-report-attachments',
+        pathPrefix: 'layout-dumps',
+        contentType: 'text/plain',
+        extension: '.txt',
+      );
+    } on Object catch (e) {
+      Log.e('Layout dump upload failed (best-effort)', e);
+      return null;
+    }
+  }
+
+  /// Collects all artifacts in parallel and submits the bug report.
+  ///
+  /// Prepends `[QA]` to [title] when [scenarioId] or [sessionId] is provided
+  /// to distinguish automated QA reports from manual shake-triggered ones.
+  Future<void> submitReport({
+    required String title,
+    required String description,
+    String? scenarioId,
+    String? sessionId,
+  }) async {
+    final results = await Future.wait([
+      captureScreenshot(),
+      collectEnvironmentInfo(),
+      captureAndUploadLayoutDump(),
+    ]);
+
+    final screenshotUrl = results[0] as String?;
+    final environment = results[1] as Map<String, dynamic>?;
+    final layoutDumpUrl = results[2] as String?;
+    final logs = Log.export();
+
+    final effectiveTitle =
+        (scenarioId != null || sessionId != null) ? '[QA] $title' : title;
+    final effectiveDescription = _buildDescription(
+      description,
+      scenarioId,
+      sessionId,
+    );
+
+    final repo = BugReportRepository(Supabase.instance.client);
+    await repo.reportBug(
+      title: effectiveTitle,
+      description: effectiveDescription,
+      logs: logs,
+      screenshotUrl: screenshotUrl,
+      environment: environment,
+      platform: defaultTargetPlatform.name,
+      layoutDumpUrl: layoutDumpUrl,
+    );
+  }
+
+  String _buildDescription(
+    String description,
+    String? scenarioId,
+    String? sessionId,
+  ) {
+    final buffer = StringBuffer(description);
+    if (scenarioId != null && scenarioId.isNotEmpty) {
+      buffer.write('\n\nScenario: $scenarioId');
+    }
+    if (sessionId != null && sessionId.isNotEmpty) {
+      buffer.write('\nSession: $sessionId');
+    }
+    return buffer.toString();
+  }
+}

--- a/shared/packages/minglit_kit/lib/src/data/services/bug_report_collector.dart
+++ b/shared/packages/minglit_kit/lib/src/data/services/bug_report_collector.dart
@@ -4,11 +4,18 @@ import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
+import 'package:minglit_kit/minglit_dev.dart' show QaBugReportChannel;
+import 'package:minglit_kit/minglit_kit.dart' show BugReporterWrapper;
+import 'package:minglit_kit/minglit_ui.dart' show BugReporterWrapper;
 import 'package:minglit_kit/src/data/repositories/bug_report_repository.dart';
 import 'package:minglit_kit/src/data/repositories/storage_repository.dart';
+import 'package:minglit_kit/src/ui/widgets/bug_reporter_wrapper.dart'
+    show BugReporterWrapper;
 import 'package:minglit_kit/src/utils/environment_info.dart';
 import 'package:minglit_kit/src/utils/layout_dump.dart';
 import 'package:minglit_kit/src/utils/log.dart';
+import 'package:minglit_kit/src/utils/qa_bug_report_channel.dart'
+    show QaBugReportChannel;
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 /// Collects bug report data (screenshot, layout dump, environment info, logs)
@@ -93,8 +100,9 @@ class BugReportCollector {
     final layoutDumpUrl = results[2] as String?;
     final logs = Log.export();
 
-    final effectiveTitle =
-        (scenarioId != null || sessionId != null) ? '[QA] $title' : title;
+    final effectiveTitle = (scenarioId != null || sessionId != null)
+        ? '[QA] $title'
+        : title;
     final effectiveDescription = _buildDescription(
       description,
       scenarioId,

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
@@ -11,9 +11,12 @@ import 'package:minglit_kit/src/data/repositories/storage_repository.dart';
 import 'package:minglit_kit/src/logic/providers/supabase_provider.dart';
 import 'package:minglit_kit/src/theme/minglit_theme.dart';
 import 'package:minglit_kit/src/ui/widgets/common/loading_indicator.dart';
+
+import 'package:minglit_kit/src/data/services/bug_report_collector.dart';
 import 'package:minglit_kit/src/utils/environment_info.dart';
 import 'package:minglit_kit/src/utils/layout_dump.dart';
 import 'package:minglit_kit/src/utils/log.dart';
+import 'package:minglit_kit/src/utils/qa_bug_report_channel.dart';
 
 /// Wraps [child] with bug reporting UI.
 // Fix #412: ConsumerStatefulWidget 전환 — Supabase 직접 접근 제거, Riverpod Provider 주입
@@ -50,6 +53,16 @@ class _BugReporterWrapperState extends ConsumerState<BugReporterWrapper> {
   String? _screenshotUrl;
   Map<String, dynamic>? _environmentInfo;
   String? _layoutDumpUrl;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.enabled) {
+      QaBugReportChannel.initialize(
+        BugReportCollector(boundaryKey: _boundaryKey),
+      );
+    }
+  }
 
   /// Returns a [BuildContext] that has a [Navigator] ancestor.
   ///

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
@@ -8,11 +8,10 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:minglit_kit/src/data/repositories/bug_report_repository.dart';
 import 'package:minglit_kit/src/data/repositories/storage_repository.dart';
+import 'package:minglit_kit/src/data/services/bug_report_collector.dart';
 import 'package:minglit_kit/src/logic/providers/supabase_provider.dart';
 import 'package:minglit_kit/src/theme/minglit_theme.dart';
 import 'package:minglit_kit/src/ui/widgets/common/loading_indicator.dart';
-
-import 'package:minglit_kit/src/data/services/bug_report_collector.dart';
 import 'package:minglit_kit/src/utils/environment_info.dart';
 import 'package:minglit_kit/src/utils/layout_dump.dart';
 import 'package:minglit_kit/src/utils/log.dart';

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
@@ -76,11 +76,19 @@ class _BugReporterWrapperState extends ConsumerState<BugReporterWrapper> {
   @override
   void initState() {
     super.initState();
+    // Fix #1295: QaBugReportChannel 초기화 — ADB 인텐트 기반 버그 리포트 수신
     if (widget.enabled) {
       QaBugReportChannel.initialize(
         BugReportCollector(boundaryKey: _boundaryKey),
       );
     }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        ref
+            .read(bugReporterCallbackProvider.notifier)
+            .update(_showReportDialog);
+      }
+    });
   }
 
   /// Returns a [BuildContext] that has a [Navigator] ancestor.
@@ -90,18 +98,6 @@ class _BugReporterWrapperState extends ConsumerState<BugReporterWrapper> {
   /// where the FAB already has a valid context.
   BuildContext? get _dialogContext =>
       widget.navigatorKey?.currentState?.overlay?.context ?? context;
-
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
-        ref
-            .read(bugReporterCallbackProvider.notifier)
-            .update(_showReportDialog);
-      }
-    });
-  }
 
   @override
   void dispose() {

--- a/shared/packages/minglit_kit/lib/src/utils/qa_bug_report_channel.dart
+++ b/shared/packages/minglit_kit/lib/src/utils/qa_bug_report_channel.dart
@@ -1,6 +1,13 @@
+import 'package:flutter/cupertino.dart' show RepaintBoundary;
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart' show RepaintBoundary;
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart' show RepaintBoundary;
+import 'package:minglit_kit/minglit_kit.dart' show BugReporterWrapper;
+import 'package:minglit_kit/minglit_ui.dart' show BugReporterWrapper;
 import 'package:minglit_kit/src/data/services/bug_report_collector.dart';
+import 'package:minglit_kit/src/ui/widgets/bug_reporter_wrapper.dart'
+    show BugReporterWrapper;
 import 'package:minglit_kit/src/utils/log.dart';
 
 /// Listens on the native MethodChannel `com.minglit.dev/qa_bug_report` and

--- a/shared/packages/minglit_kit/lib/src/utils/qa_bug_report_channel.dart
+++ b/shared/packages/minglit_kit/lib/src/utils/qa_bug_report_channel.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:minglit_kit/src/data/services/bug_report_collector.dart';
+import 'package:minglit_kit/src/utils/log.dart';
+
+/// Listens on the native MethodChannel `com.minglit.dev/qa_bug_report` and
+/// triggers a programmatic bug report when the Android [QaBugReportReceiver]
+/// broadcasts `com.minglit.dev.QA_BUG_REPORT`.
+///
+/// Only active on Android — the channel is a no-op on other platforms.
+/// Intended for dev flavor only; the native receiver is registered only in
+/// the dev flavor manifest.
+class QaBugReportChannel {
+  QaBugReportChannel._();
+
+  static const _channel = MethodChannel('com.minglit.dev/qa_bug_report');
+
+  /// Initialises the MethodChannel handler.
+  ///
+  /// Call once from [BugReporterWrapper.initState] when [enabled] is true
+  /// and the platform is Android.
+  ///
+  /// [collector] must be bound to the [RepaintBoundary] key of the wrapped
+  /// widget tree so screenshots capture the correct content.
+  static void initialize(BugReportCollector collector) {
+    if (kIsWeb || defaultTargetPlatform != TargetPlatform.android) return;
+
+    _channel.setMethodCallHandler((call) async {
+      if (call.method != 'triggerBugReport') return;
+
+      final args = call.arguments as Map<Object?, Object?>;
+      final title = (args['title'] as String?) ?? 'QA Bug Report';
+      final description = (args['description'] as String?) ?? '';
+      final scenarioId = args['scenario_id'] as String?;
+      final sessionId = args['session_id'] as String?;
+
+      Log.i(
+        'QaBugReportChannel: received triggerBugReport '
+        'title="$title" scenario=$scenarioId session=$sessionId',
+      );
+
+      try {
+        await collector.submitReport(
+          title: title,
+          description: description,
+          scenarioId: scenarioId,
+          sessionId: sessionId,
+        );
+        Log.i('QaBugReportChannel: report submitted successfully');
+      } on Exception catch (e, st) {
+        Log.e('QaBugReportChannel: report submission failed', e, st);
+      }
+    });
+  }
+}

--- a/shared/packages/minglit_kit/lib/src/utils/qa_bug_report_channel.dart
+++ b/shared/packages/minglit_kit/lib/src/utils/qa_bug_report_channel.dart
@@ -1,6 +1,4 @@
-import 'package:flutter/cupertino.dart' show RepaintBoundary;
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart' show RepaintBoundary;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart' show RepaintBoundary;
 import 'package:minglit_kit/src/data/services/bug_report_collector.dart';

--- a/shared/packages/minglit_kit/lib/src/utils/qa_bug_report_channel.dart
+++ b/shared/packages/minglit_kit/lib/src/utils/qa_bug_report_channel.dart
@@ -3,11 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' show RepaintBoundary;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart' show RepaintBoundary;
-import 'package:minglit_kit/minglit_kit.dart' show BugReporterWrapper;
-import 'package:minglit_kit/minglit_ui.dart' show BugReporterWrapper;
 import 'package:minglit_kit/src/data/services/bug_report_collector.dart';
-import 'package:minglit_kit/src/ui/widgets/bug_reporter_wrapper.dart'
-    show BugReporterWrapper;
 import 'package:minglit_kit/src/utils/log.dart';
 
 /// Listens on the native MethodChannel `com.minglit.dev/qa_bug_report` and

--- a/shared/packages/minglit_kit/lib/src/utils/qa_bug_report_channel.dart
+++ b/shared/packages/minglit_kit/lib/src/utils/qa_bug_report_channel.dart
@@ -11,7 +11,7 @@ import 'package:minglit_kit/src/ui/widgets/bug_reporter_wrapper.dart'
 import 'package:minglit_kit/src/utils/log.dart';
 
 /// Listens on the native MethodChannel `com.minglit.dev/qa_bug_report` and
-/// triggers a programmatic bug report when the Android [QaBugReportReceiver]
+/// triggers a programmatic bug report when the Android `QaBugReportReceiver`
 /// broadcasts `com.minglit.dev.QA_BUG_REPORT`.
 ///
 /// Only active on Android — the channel is a no-op on other platforms.
@@ -24,7 +24,7 @@ class QaBugReportChannel {
 
   /// Initialises the MethodChannel handler.
   ///
-  /// Call once from [BugReporterWrapper.initState] when [enabled] is true
+  /// Call once from `BugReporterWrapper.initState` when `enabled` is true
   /// and the platform is Android.
   ///
   /// [collector] must be bound to the [RepaintBoundary] key of the wrapped
@@ -38,8 +38,8 @@ class QaBugReportChannel {
       final args = call.arguments as Map<Object?, Object?>;
       final title = (args['title'] as String?) ?? 'QA Bug Report';
       final description = (args['description'] as String?) ?? '';
-      final scenarioId = args['scenario_id'] as String?;
-      final sessionId = args['session_id'] as String?;
+      final scenarioId = _nonEmptyString(args['scenario_id'] as String?);
+      final sessionId = _nonEmptyString(args['session_id'] as String?);
 
       Log.i(
         'QaBugReportChannel: received triggerBugReport '
@@ -59,4 +59,10 @@ class QaBugReportChannel {
       }
     });
   }
+
+  /// Returns [value] unchanged unless it is empty, in which case null is
+  /// returned. Android broadcasts missing optional IDs as empty strings;
+  /// normalising here keeps downstream consumers free of empty-string checks.
+  static String? _nonEmptyString(String? value) =>
+      (value == null || value.isEmpty) ? null : value;
 }

--- a/shared/packages/minglit_kit/test/src/data/services/qa_bug_report_channel_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/services/qa_bug_report_channel_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/data/services/bug_report_collector.dart';
+import 'package:minglit_kit/src/utils/qa_bug_report_channel.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockBugReportCollector extends Mock implements BugReportCollector {
+  MockBugReportCollector() : super();
+
+  @override
+  GlobalKey get boundaryKey => GlobalKey();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('QaBugReportChannel', () {
+    late MockBugReportCollector mockCollector;
+
+    setUp(() {
+      mockCollector = MockBugReportCollector();
+      when(
+        () => mockCollector.submitReport(
+          title: any(named: 'title'),
+          description: any(named: 'description'),
+          scenarioId: any(named: 'scenarioId'),
+          sessionId: any(named: 'sessionId'),
+        ),
+      ).thenAnswer((_) async {});
+    });
+
+    tearDown(() {
+      // Reset the channel handler after each test
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        const MethodChannel('com.minglit.dev/qa_bug_report'),
+        null,
+      );
+    });
+
+    test(
+      'triggerBugReport call invokes BugReportCollector.submitReport',
+      () async {
+        QaBugReportChannel.initialize(mockCollector);
+
+        // Simulate what the Android BroadcastReceiver sends to Flutter
+        const channel = MethodChannel('com.minglit.dev/qa_bug_report');
+        await TestDefaultBinaryMessengerBinding
+            .instance
+            .defaultBinaryMessenger
+            .handlePlatformMessage(
+          channel.name,
+          channel.codec.encodeMethodCall(
+            const MethodCall(
+              'triggerBugReport',
+              {
+                'title': 'U-S04 이벤트 상세 — CTA 버튼 잘림',
+                'description': '이벤트 상세 하단 신청하기 버튼이 SafeArea 밖으로 나감',
+                'scenario_id': 'U-S04',
+                'session_id': '20260412-173833',
+              },
+            ),
+          ),
+          (_) {},
+        );
+
+        verify(
+          () => mockCollector.submitReport(
+            title: 'U-S04 이벤트 상세 — CTA 버튼 잘림',
+            description: '이벤트 상세 하단 신청하기 버튼이 SafeArea 밖으로 나감',
+            scenarioId: 'U-S04',
+            sessionId: '20260412-173833',
+          ),
+        ).called(1);
+      },
+    );
+
+    test('unknown method call is ignored without error', () async {
+      QaBugReportChannel.initialize(mockCollector);
+
+      const channel = MethodChannel('com.minglit.dev/qa_bug_report');
+      await TestDefaultBinaryMessengerBinding
+          .instance
+          .defaultBinaryMessenger
+          .handlePlatformMessage(
+        channel.name,
+        channel.codec.encodeMethodCall(
+          const MethodCall('unknownMethod', {}),
+        ),
+        (_) {},
+      );
+
+      verifyNever(
+        () => mockCollector.submitReport(
+          title: any(named: 'title'),
+          description: any(named: 'description'),
+          scenarioId: any(named: 'scenarioId'),
+          sessionId: any(named: 'sessionId'),
+        ),
+      );
+    });
+
+    test('missing optional fields use defaults', () async {
+      QaBugReportChannel.initialize(mockCollector);
+
+      const channel = MethodChannel('com.minglit.dev/qa_bug_report');
+      await TestDefaultBinaryMessengerBinding
+          .instance
+          .defaultBinaryMessenger
+          .handlePlatformMessage(
+        channel.name,
+        channel.codec.encodeMethodCall(
+          const MethodCall('triggerBugReport', <String, dynamic>{}),
+        ),
+        (_) {},
+      );
+
+      verify(
+        () => mockCollector.submitReport(
+          title: 'QA Bug Report',
+          description: '',
+          scenarioId: null,
+          sessionId: null,
+        ),
+      ).called(1);
+    });
+  });
+}

--- a/shared/packages/minglit_kit/test/src/data/services/qa_bug_report_channel_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/services/qa_bug_report_channel_test.dart
@@ -34,9 +34,9 @@ void main() {
       // Reset the channel handler after each test
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
-        const MethodChannel('com.minglit.dev/qa_bug_report'),
-        null,
-      );
+            const MethodChannel('com.minglit.dev/qa_bug_report'),
+            null,
+          );
     });
 
     test(
@@ -46,24 +46,22 @@ void main() {
 
         // Simulate what the Android BroadcastReceiver sends to Flutter
         const channel = MethodChannel('com.minglit.dev/qa_bug_report');
-        await TestDefaultBinaryMessengerBinding
-            .instance
-            .defaultBinaryMessenger
+        await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .handlePlatformMessage(
-          channel.name,
-          channel.codec.encodeMethodCall(
-            const MethodCall(
-              'triggerBugReport',
-              {
-                'title': 'U-S04 이벤트 상세 — CTA 버튼 잘림',
-                'description': '이벤트 상세 하단 신청하기 버튼이 SafeArea 밖으로 나감',
-                'scenario_id': 'U-S04',
-                'session_id': '20260412-173833',
-              },
-            ),
-          ),
-          (_) {},
-        );
+              channel.name,
+              channel.codec.encodeMethodCall(
+                const MethodCall(
+                  'triggerBugReport',
+                  {
+                    'title': 'U-S04 이벤트 상세 — CTA 버튼 잘림',
+                    'description': '이벤트 상세 하단 신청하기 버튼이 SafeArea 밖으로 나감',
+                    'scenario_id': 'U-S04',
+                    'session_id': '20260412-173833',
+                  },
+                ),
+              ),
+              (_) {},
+            );
 
         verify(
           () => mockCollector.submitReport(
@@ -80,16 +78,14 @@ void main() {
       QaBugReportChannel.initialize(mockCollector);
 
       const channel = MethodChannel('com.minglit.dev/qa_bug_report');
-      await TestDefaultBinaryMessengerBinding
-          .instance
-          .defaultBinaryMessenger
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .handlePlatformMessage(
-        channel.name,
-        channel.codec.encodeMethodCall(
-          const MethodCall('unknownMethod', {}),
-        ),
-        (_) {},
-      );
+            channel.name,
+            channel.codec.encodeMethodCall(
+              const MethodCall('unknownMethod', {}),
+            ),
+            (_) {},
+          );
 
       verifyNever(
         () => mockCollector.submitReport(
@@ -105,23 +101,19 @@ void main() {
       QaBugReportChannel.initialize(mockCollector);
 
       const channel = MethodChannel('com.minglit.dev/qa_bug_report');
-      await TestDefaultBinaryMessengerBinding
-          .instance
-          .defaultBinaryMessenger
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .handlePlatformMessage(
-        channel.name,
-        channel.codec.encodeMethodCall(
-          const MethodCall('triggerBugReport', <String, dynamic>{}),
-        ),
-        (_) {},
-      );
+            channel.name,
+            channel.codec.encodeMethodCall(
+              const MethodCall('triggerBugReport', <String, dynamic>{}),
+            ),
+            (_) {},
+          );
 
       verify(
         () => mockCollector.submitReport(
           title: 'QA Bug Report',
           description: '',
-          scenarioId: null,
-          sessionId: null,
         ),
       ).called(1);
     });

--- a/shared/packages/minglit_kit/test/src/data/services/qa_bug_report_channel_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/services/qa_bug_report_channel_test.dart
@@ -82,7 +82,7 @@ void main() {
           .handlePlatformMessage(
             channel.name,
             channel.codec.encodeMethodCall(
-              const MethodCall('unknownMethod', {}),
+              const MethodCall('unknownMethod', <String, dynamic>{}),
             ),
             (_) {},
           );


### PR DESCRIPTION
## Summary
- QA 워커가 ADB 한 줄로 현재 화면 버그 리포트 자동 생성
- BugReportCollector: 수집/제출 로직 분리 (BugReporterWrapper에서 추출)
- QaBugReportChannel: MethodChannel 리스너
- QaBugReportReceiver: Android BroadcastReceiver (dev flavor only)
- app_user + app_partner 둘 다 적용

## 사용법
```bash
adb shell am broadcast \
  -a com.minglit.dev.QA_BUG_REPORT \
  --es title "U-S04 이벤트 상세 — CTA 버튼 잘림" \
  --es description "하단 신청하기 버튼이 SafeArea 밖으로" \
  --es scenario_id "U-S04" \
  --es session_id "20260412-173833"
```

## Test plan
- [ ] dev APK 빌드 → 설치 → ADB broadcast 명령어로 버그 리포트 생성 확인
- [ ] release 빌드에 Receiver 미포함 확인
- [ ] 기존 FAB 버그 리포트 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)