### PR TITLE
fix(dev-tool): BugReporter FAB 제거 → 앱바 액션 버튼으로 변경

### DIFF
--- a/apps/app_partner/lib/src/features/home/partner_home_page.dart
+++ b/apps/app_partner/lib/src/features/home/partner_home_page.dart
@@ -37,6 +37,8 @@ class PartnerHomePage extends ConsumerWidget {
         centerTitle: false,
         surfaceTintColor: Colors.transparent,
         actions: [
+          // Fix #1285: FAB 대체 — dev 전용 버그 리포트 액션 버튼
+          const BugReportAction(),
           Stack(
             clipBehavior: Clip.none,
             children: [

--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -109,6 +109,8 @@ class _HomePageState extends ConsumerState<HomePage> {
               ),
               // Fix #141: Equalize action button spacing and padding alignment
               actions: [
+                // Fix #1285: FAB 대체 — dev 전용 버그 리포트 액션 버튼
+                const BugReportAction(),
                 IconButton(
                   icon: const Icon(Icons.search),
                   onPressed: () => const SearchRoute().push<void>(context),

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
@@ -15,6 +15,27 @@ import 'package:minglit_kit/src/utils/environment_info.dart';
 import 'package:minglit_kit/src/utils/layout_dump.dart';
 import 'package:minglit_kit/src/utils/log.dart';
 
+/// Dev-only: callback registered by [BugReporterWrapper] so that any screen
+/// can trigger the bug report dialog via [BugReportAction].
+// Fix #1285: FAB 제거 후 앱바 액션 버튼 지원 — callback을 Provider로 노출
+final bugReporterCallbackProvider =
+    NotifierProvider<_BugReporterCallbackNotifier, Future<void> Function()?>(
+  _BugReporterCallbackNotifier.new,
+);
+
+class _BugReporterCallbackNotifier
+    extends Notifier<Future<void> Function()?> {
+  @override
+  Future<void> Function()? build() => null;
+
+  /// Registers or clears the bug report callback.
+  ///
+  /// A setter is not used here: the paired getter required by
+  /// `avoid_setters_without_getters` would add unnecessary boilerplate.
+  // ignore: use_setters_to_change_properties
+  void update(Future<void> Function()? callback) => state = callback;
+}
+
 /// Wraps [child] with bug reporting UI.
 // Fix #412: ConsumerStatefulWidget 전환 — Supabase 직접 접근 제거, Riverpod Provider 주입
 class BugReporterWrapper extends ConsumerStatefulWidget {
@@ -58,6 +79,29 @@ class _BugReporterWrapperState extends ConsumerState<BugReporterWrapper> {
   /// where the FAB already has a valid context.
   BuildContext? get _dialogContext =>
       widget.navigatorKey?.currentState?.overlay?.context ?? context;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        ref
+            .read(bugReporterCallbackProvider.notifier)
+            .update(_showReportDialog);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    // Note: the callback intentionally holds a reference to this state's
+    // _showReportDialog, which guards unmounted access at its top.
+    // Clearing the provider here is unsafe in Riverpod v3 (modifying providers
+    // during finalization is forbidden), so cleanup is omitted.
+    // BugReporterWrapper lives for the app's lifetime, so stale callbacks
+    // are not a concern in practice.
+    super.dispose();
+  }
 
   /// Captures a screenshot of the wrapped child and uploads it to Storage.
   ///
@@ -341,32 +385,28 @@ class _BugReporterWrapperState extends ConsumerState<BugReporterWrapper> {
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      children: [
-        RepaintBoundary(key: _boundaryKey, child: widget.child),
-        // Fix #1262: bottom → top 이동 — BottomNavigationBar 탭 터치 영역 침범 방지
-        if (widget.enabled)
-          Positioned(
-            right: MinglitSpacing.medium,
-            top: MediaQuery.of(context).padding.top + MinglitSpacing.medium,
-            child: Material(
-              type: MaterialType.transparency,
-              // Fix #147: show progress indicator while capturing
-              child: FloatingActionButton(
-                mini: true,
-                onPressed: _isCapturing ? null : _showReportDialog,
-                backgroundColor: MinglitColors.error,
-                child: _isCapturing
-                    ? const SizedBox(
-                        width: 20,
-                        height: 20,
-                        child: MinglitCircularProgressIndicator(),
-                      )
-                    : const Icon(Icons.bug_report),
-              ),
-            ),
-          ),
-      ],
+    return RepaintBoundary(key: _boundaryKey, child: widget.child);
+  }
+}
+
+/// Action button for the app bar that triggers the bug reporter.
+///
+/// Only renders in non-release mode when [BugReporterWrapper] is active.
+// Fix #1285: FAB 대체 — 앱바 액션 버튼 (dev only)
+class BugReportAction extends ConsumerWidget {
+  /// Creates a bug report action button.
+  const BugReportAction({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (kReleaseMode) return const SizedBox.shrink();
+    final showDialog = ref.watch(bugReporterCallbackProvider);
+    if (showDialog == null) return const SizedBox.shrink();
+    return IconButton(
+      icon: const Icon(Icons.bug_report),
+      color: MinglitColors.error,
+      tooltip: 'Bug Report',
+      onPressed: showDialog,
     );
   }
 }

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
@@ -20,11 +20,10 @@ import 'package:minglit_kit/src/utils/log.dart';
 // Fix #1285: FAB 제거 후 앱바 액션 버튼 지원 — callback을 Provider로 노출
 final bugReporterCallbackProvider =
     NotifierProvider<_BugReporterCallbackNotifier, Future<void> Function()?>(
-  _BugReporterCallbackNotifier.new,
-);
+      _BugReporterCallbackNotifier.new,
+    );
 
-class _BugReporterCallbackNotifier
-    extends Notifier<Future<void> Function()?> {
+class _BugReporterCallbackNotifier extends Notifier<Future<void> Function()?> {
   @override
   Future<void> Function()? build() => null;
 

--- a/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
+++ b/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
@@ -3,8 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/ui/widgets/bug_reporter_wrapper.dart';
 
-// ignore_for_file: avoid_dynamic_calls
-
 void main() {
   group('BugReporterWrapper Widget Tests', () {
     testWidgets('renders child widget correctly', (tester) async {
@@ -153,8 +151,9 @@ void main() {
 
     // Fix #1285: FAB has been removed. BugReporterWrapper now registers
     // _showReportDialog via bugReporterCallbackProvider instead of rendering a FAB.
-    testWidgets('no FAB rendered when enabled (FAB removed in #1285)',
-        (tester) async {
+    testWidgets('no FAB rendered when enabled (FAB removed in #1285)', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         const ProviderScope(
           child: MaterialApp(
@@ -175,31 +174,34 @@ void main() {
     });
 
     // Regression test for #1285: callback is registered in provider after mount.
-    testWidgets('bugReporterCallbackProvider is set when BugReporterWrapper is mounted', (
-      tester,
-    ) async {
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
+    testWidgets(
+      'bugReporterCallbackProvider is set when BugReporterWrapper is mounted',
+      (
+        tester,
+      ) async {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
 
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: const MaterialApp(
-            home: Scaffold(
-              body: BugReporterWrapper(
-                child: Text('content'),
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(
+              home: Scaffold(
+                body: BugReporterWrapper(
+                  child: Text('content'),
+                ),
               ),
             ),
           ),
-        ),
-      );
+        );
 
-      // postFrameCallback fires after first pump
-      await tester.pump();
+        // postFrameCallback fires after first pump
+        await tester.pump();
 
-      // Callback should now be registered
-      expect(container.read(bugReporterCallbackProvider), isNotNull);
-    });
+        // Callback should now be registered
+        expect(container.read(bugReporterCallbackProvider), isNotNull);
+      },
+    );
 
     // Regression test for #1285: BugReporterWrapper disposes cleanly even
     // when a callback is registered. The provider is not explicitly cleared on

--- a/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
+++ b/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:minglit_kit/src/theme/minglit_theme.dart';
 import 'package:minglit_kit/src/ui/widgets/bug_reporter_wrapper.dart';
+
+// ignore_for_file: avoid_dynamic_calls
 
 void main() {
   group('BugReporterWrapper Widget Tests', () {
@@ -14,7 +15,7 @@ void main() {
           child: MaterialApp(
             home: Scaffold(
               body: BugReporterWrapper(
-                enabled: false, // Disable FAB rendering
+                enabled: false,
                 child: testChild,
               ),
             ),
@@ -25,7 +26,7 @@ void main() {
       expect(find.text('Test Child Widget'), findsOneWidget);
     });
 
-    testWidgets('does not render FAB when disabled', (tester) async {
+    testWidgets('does not render FAB (FAB removed in #1285)', (tester) async {
       await tester.pumpWidget(
         const ProviderScope(
           child: MaterialApp(
@@ -39,7 +40,7 @@ void main() {
         ),
       );
 
-      // When disabled, no FAB should be rendered
+      // FAB has been removed in #1285 — no FAB should be present
       expect(find.byType(FloatingActionButton), findsNothing);
     });
 
@@ -62,7 +63,7 @@ void main() {
       expect(find.byType(BugReporterWrapper), findsOneWidget);
     });
 
-    testWidgets('renders Stack with child and optional FAB', (tester) async {
+    testWidgets('renders RepaintBoundary with child', (tester) async {
       await tester.pumpWidget(
         const ProviderScope(
           child: MaterialApp(
@@ -76,8 +77,8 @@ void main() {
         ),
       );
 
-      // Verify the BugReporterWrapper widget is used (which uses Stack
-      // internally)
+      // Verify the BugReporterWrapper widget is used (which uses RepaintBoundary
+      // internally after #1285 FAB removal)
       expect(find.byType(BugReporterWrapper), findsOneWidget);
       expect(find.text('Stack Child'), findsOneWidget);
     });
@@ -150,7 +151,10 @@ void main() {
       // No crash = state was properly cleaned up
     });
 
-    testWidgets('renders FAB when enabled', (tester) async {
+    // Fix #1285: FAB has been removed. BugReporterWrapper now registers
+    // _showReportDialog via bugReporterCallbackProvider instead of rendering a FAB.
+    testWidgets('no FAB rendered when enabled (FAB removed in #1285)',
+        (tester) async {
       await tester.pumpWidget(
         const ProviderScope(
           child: MaterialApp(
@@ -166,18 +170,21 @@ void main() {
       // Verify child is rendered
       expect(find.text('content'), findsOneWidget);
 
-      // Verify FAB is rendered when enabled
-      expect(find.byType(FloatingActionButton), findsOneWidget);
+      // FAB removed in #1285 — no FloatingActionButton should be in the tree
+      expect(find.byType(FloatingActionButton), findsNothing);
     });
 
-    // Regression test for #1262: FAB must be anchored at top, not bottom,
-    // to avoid overlapping BottomNavigationBar touch targets.
-    testWidgets('FAB is positioned at top-right, not bottom-right', (
+    // Regression test for #1285: callback is registered in provider after mount.
+    testWidgets('bugReporterCallbackProvider is set when BugReporterWrapper is mounted', (
       tester,
     ) async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
       await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
             home: Scaffold(
               body: BugReporterWrapper(
                 child: Text('content'),
@@ -187,19 +194,49 @@ void main() {
         ),
       );
 
-      final positioned = tester.widget<Positioned>(
-        find
-            .ancestor(
-              of: find.byType(FloatingActionButton),
-              matching: find.byType(Positioned),
-            )
-            .first,
-      );
+      // postFrameCallback fires after first pump
+      await tester.pump();
 
-      // Must use top anchor, not bottom — bottom anchor overlaps BottomNav.
-      expect(positioned.top, MinglitSpacing.medium);
-      expect(positioned.right, MinglitSpacing.medium);
-      expect(positioned.bottom, isNull);
+      // Callback should now be registered
+      expect(container.read(bugReporterCallbackProvider), isNotNull);
+    });
+
+    // Regression test for #1285: BugReporterWrapper disposes cleanly even
+    // when a callback is registered. The provider is not explicitly cleared on
+    // dispose because Riverpod v3 forbids modifying providers during widget
+    // tree finalization; BugReporterWrapper lives for the app's lifetime, so
+    // a stale callback reference is not a concern in practice.
+    testWidgets('disposes cleanly with callback registered', (
+      tester,
+    ) async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: Scaffold(
+              body: BugReporterWrapper(
+                child: Text('content'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Verify callback is set
+      expect(container.read(bugReporterCallbackProvider), isNotNull);
+
+      // Dispose by replacing widget tree — must not throw
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(home: SizedBox()),
+        ),
+      );
+      // No crash = dispose completed cleanly
     });
   });
 }


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1285

## 변경 요약

### 문제
PR #1268에서 FAB를 bottom→top으로 이동했으나, top 위치가 홈 화면 MyPage 버튼(우측 상단)과 겹쳐 탭 이벤트를 가로채는 문제가 발생.

### 수정
- `BugReporterWrapper`: Positioned FAB 제거, RepaintBoundary만 유지
- `bugReporterCallbackProvider`: `showReportDialog` 콜백을 Riverpod으로 노출
- `BugReportAction`: 앱바에 삽입할 dev-only 아이콘 버튼 위젯 추가 (kReleaseMode에서 자동 숨김)
- `HomePage` (app_user): `SliverAppBar` actions에 `BugReportAction` 추가
- `PartnerHomePage` (app_partner): `AppBar` actions에 `BugReportAction` 추가