### PR TITLE
docs(qa): app_user 스모크 테스트 네비게이션 경로 명확화

### DIFF
--- a/docs/qa/test-cases/app-user-smoke.md
+++ b/docs/qa/test-cases/app-user-smoke.md
@@ -23,7 +23,7 @@
 | # | 화면 | 경로 | Page 클래스 | GUEST | AUTH | VERIFIED | 비고 |
 |---|------|------|------------|-------|------|----------|------|
 | U-S01 | 홈 | `/` | `HomePage` | OK | OK | OK | 앱 진입점 |
-| U-S02 | 큐레이션 목록 | `/curation` | `PartyCurationPage` | OK | OK | OK | 홈 → 큐레이션 |
+| U-S02 | 큐레이션 목록 | `/curation` | `PartyCurationPage` | OK | OK | OK | ⚠️ BLOCKED — 홈에서 진입 UI 없음 (see #1293). 라우트는 존재하나 네비게이션 경로 orphaned |
 | U-S03 | 검색 | `/search` | `SearchPage` | OK | OK | OK | |
 | U-S04 | 이벤트 상세 | `/events/:eventId` | `EventDetailPage` | OK | OK | OK | 유효한 eventId 필요 |
 | U-S05 | 파트너 상세 | `/partners/:partnerId` | `PartnerDetailPage` | OK | OK | OK | 유효한 partnerId 필요 |
@@ -88,13 +88,15 @@
 
 ### 5.1 홈 (HomePage)
 
+> **참고**: app_user는 BottomNav를 사용하지 않음. 모든 네비게이션은 AppBar 아이콘 또는 콘텐츠 내 탭으로 수행.
+
 | 액션 | 기대 결과 | 에러 시나리오 |
 |------|-----------|-------------|
 | 이벤트 카드 탭 | `/events/:eventId`로 이동 | - |
-| 큐레이션 섹션 탭 | `/curation`으로 이동 | - |
-| 검색 아이콘 탭 | `/search`로 이동 | - |
-| 마이페이지 아이콘 탭 | `/my`로 이동 (GUEST → 로그인) | - |
-| 알림 아이콘 탭 | `/notifications`로 이동 | - |
+| 큐레이션 섹션 탭 | `/curation`으로 이동 | ⚠️ 진입점 미구현 (see #1293) |
+| AppBar 검색 아이콘 탭 | `/search`로 이동 | - |
+| AppBar 프로필 아이콘 탭 | `/my`로 이동 (GUEST → 로그인) | - |
+| AppBar 알림 아이콘 탭 | `/notifications`로 이동 | - |
 | 풀투리프레시 | 홈 데이터 갱신 | 네트워크 오류 → 에러 표시 |
 
 ### 5.2 검색 (SearchPage)

--- a/docs/qa/test-strategy.md
+++ b/docs/qa/test-strategy.md
@@ -247,7 +247,39 @@ P0 CUJ 중 네이티브 SDK 연동이 필요한 2건은 E2E로만 검증 가능�
 
 ---
 
-## 7. 갭 정량 요약
+## 7. Runtime QA (실물 디바이스 자동화)
+
+Runtime QA 워커는 실물 Android 디바이스에 APK를 설치하고, ADB를 통해 화면 네비게이션과 시각적 검증을 수행한다.
+
+### 역할
+
+- **Smoke 검증**: `docs/qa/test-cases/app-user-smoke.md`, `app-partner-smoke.md` 시나리오를 실물 디바이스에서 실행
+- **CUJ 검증**: `cuj-user.md`, `cuj-partner.md`의 핵심 여정을 실물 디바이스에서 재현
+- **시각적 회귀 탐지**: 스크린샷 기반으로 UI 렌더링 이상 확인
+
+### 알려진 제약: Flutter + UIautomator 비호환
+
+Flutter 앱은 Skia/Impeller 엔진으로 단일 `FlutterSurfaceView` 위에 렌더링한다. Android UIautomator는 네이티브 View hierarchy를 탐색하므로, **Flutter 위젯의 개별 bounds를 추출할 수 없다** (`bounds="[0,0][0,0]"` 반환). 이는 모든 Flutter 앱 + 모든 Android 디바이스에서 동일하게 발생하는 구조적 제약이다.
+
+**결론**: UIautomator 기반 좌표 추출은 Flutter 앱에서 사용 불가.
+
+### 네비게이션 방법별 비교
+
+| 방법 | Flutter 호환 | 장점 | 단점 | 상태 |
+|------|-------------|------|------|------|
+| Vision 기반 (Gemini 등) | ✅ | 프레임워크 무관. 실제 화면 기반. | Vision 모델 필요. API 비용. | 운영 중 |
+| `adb shell dumpsys accessibility` | ⚠️ 검증 필요 | 네이티브 API. | Flutter semantics 활성화 필요. 좌표 정확도 미검증. | PoC 필요 |
+| Flutter Integration Test Driver | ✅ | 가장 안정적. Flutter 네이티브. | 별도 test harness. 워커 아키텍처 변경. | 장기 목표 |
+| UIautomator dump | ❌ | — | Flutter에서 bounds 추출 불가. | **사용 불가** |
+| 고정 좌표 매핑 | ✅ | 구현 간단. | 해상도/레이아웃 변경 시 깨짐. | 비권장 |
+
+### 관련 이슈
+
+- #1274 — UIautomator dump bounds=[0,0][0,0] 문제 분석 및 전략 결정
+
+---
+
+## 8. 갭 정량 요약
 
 ### 테스트 피라미드 현황 vs 목표
 
@@ -276,7 +308,7 @@ P0 CUJ 중 네이티브 SDK 연동이 필요한 2건은 E2E로만 검증 가능�
 
 ---
 
-## 8. 실행 순서 요약
+## 9. 실행 순서 요약
 
 | 단계 | 내용 | 예상 테스트 수 | 우선순위 |
 |------|------|-------------|---------|
@@ -288,7 +320,7 @@ P0 CUJ 중 네이티브 SDK 연동이 필요한 2건은 E2E로만 검증 가능�
 
 ---
 
-## 9. automation-test-guide.md 업데이트 계획
+## 10. automation-test-guide.md 업데이트 계획
 
 Phase 3 (SWE 구현) 시 아래 섹션을 업데이트한다:
 


### PR DESCRIPTION
Scheduler: needs-qa-claude-1

## Summary
- app_user에 BottomNav가 없음을 명시하고 AppBar 아이콘 기반 네비게이션으로 테스트 케이스 업데이트
- U-S02 큐레이션 항목에 진입점 부재 BLOCKED 마크 추가 (#1293 참조)
- 홈 액션 매트릭스의 아이콘 명칭을 AppBar 기반으로 명확화

Closes #1290, closes #1291

## Test plan
- [ ] `app-user-smoke.md` 문서 내용이 실제 앱 네비게이션 구조와 일치하는지 확인
- [ ] Runtime QA가 업데이트된 경로로 U-S09~U-S13 시나리오 수행 가능한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)