### PR TITLE
fix: 핫 태그 섹션에서 recentCount=0 태그 필터링

### DIFF
--- a/apps/app_user/lib/src/features/home/widgets/trending_tag_section.dart
+++ b/apps/app_user/lib/src/features/home/widgets/trending_tag_section.dart
@@ -16,8 +16,7 @@ class TrendingTagSection extends ConsumerWidget {
     return tagsAsync.when(
       data: (tags) {
         // Fix #1286: recentCount가 0인 태그는 '핫 태그'가 아님 — 필터링 후 빈 목록이면 숨김
-        final activeTags =
-            tags.where((tag) => tag.recentCount > 0).toList();
+        final activeTags = tags.where((tag) => tag.recentCount > 0).toList();
         if (activeTags.isEmpty) return const SizedBox.shrink();
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/apps/app_user/lib/src/features/home/widgets/trending_tag_section.dart
+++ b/apps/app_user/lib/src/features/home/widgets/trending_tag_section.dart
@@ -15,7 +15,10 @@ class TrendingTagSection extends ConsumerWidget {
 
     return tagsAsync.when(
       data: (tags) {
-        if (tags.isEmpty) return const SizedBox.shrink();
+        // Fix #1286: recentCount가 0인 태그는 '핫 태그'가 아님 — 필터링 후 빈 목록이면 숨김
+        final activeTags =
+            tags.where((tag) => tag.recentCount > 0).toList();
+        if (activeTags.isEmpty) return const SizedBox.shrink();
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -38,11 +41,11 @@ class TrendingTagSection extends ConsumerWidget {
                 padding: const EdgeInsets.symmetric(
                   horizontal: MinglitSpacing.medium,
                 ),
-                itemCount: tags.length,
+                itemCount: activeTags.length,
                 separatorBuilder: (_, _) =>
                     const SizedBox(width: MinglitSpacing.small),
                 itemBuilder: (context, index) {
-                  final tag = tags[index];
+                  final tag = activeTags[index];
                   // Fix #1224: use recentCount (7-day sum) for the trending
                   // metric instead of usageCount (cumulative total).
                   return _TrendingTagCard(

--- a/apps/app_user/test/src/features/home/widgets/trending_tag_section_test.dart
+++ b/apps/app_user/test/src/features/home/widgets/trending_tag_section_test.dart
@@ -35,7 +35,7 @@ void main() {
   });
 
   group('TrendingTagSection', () {
-    // Fix #1286 regression: recentCount가 0인 태그는 핫 태그 섹션에서 숨겨야 한다.
+    // Fix #1286: recentCount가 0인 태그는 핫 태그 섹션에서 숨겨야 함을 회귀 테스트로 보장
     testWidgets(
       'hides section entirely when all tags have recentCount == 0',
       (tester) async {

--- a/apps/app_user/test/src/features/home/widgets/trending_tag_section_test.dart
+++ b/apps/app_user/test/src/features/home/widgets/trending_tag_section_test.dart
@@ -1,6 +1,5 @@
 import 'package:app_user/src/features/home/widgets/trending_tag_section.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
@@ -13,12 +12,11 @@ void main() {
   Tag makeTag({
     required String name,
     required int recentCount,
-  }) =>
-      Tag(
-        id: 'tag-$name',
-        name: name,
-        recentCount: recentCount,
-      );
+  }) => Tag(
+    id: 'tag-$name',
+    name: name,
+    recentCount: recentCount,
+  );
 
   Widget buildSubject({
     required List<Tag> tags,

--- a/apps/app_user/test/src/features/home/widgets/trending_tag_section_test.dart
+++ b/apps/app_user/test/src/features/home/widgets/trending_tag_section_test.dart
@@ -1,0 +1,99 @@
+import 'package:app_user/src/features/home/widgets/trending_tag_section.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../utils/mocks.dart';
+
+void main() {
+  late MockTagRepository mockTagRepo;
+
+  Tag makeTag({
+    required String name,
+    required int recentCount,
+  }) =>
+      Tag(
+        id: 'tag-$name',
+        name: name,
+        recentCount: recentCount,
+      );
+
+  Widget buildSubject({
+    required List<Tag> tags,
+  }) {
+    when(() => mockTagRepo.getTrendingTags()).thenAnswer((_) async => tags);
+    return ProviderScope(
+      overrides: [
+        tagRepositoryProvider.overrideWithValue(mockTagRepo),
+      ],
+      child: const MaterialApp(home: Scaffold(body: TrendingTagSection())),
+    );
+  }
+
+  setUp(() {
+    mockTagRepo = MockTagRepository();
+  });
+
+  group('TrendingTagSection', () {
+    // Fix #1286 regression: recentCount가 0인 태그는 핫 태그 섹션에서 숨겨야 한다.
+    testWidgets(
+      'hides section entirely when all tags have recentCount == 0',
+      (tester) async {
+        final tags = [
+          makeTag(name: '독서', recentCount: 0),
+          makeTag(name: '스터디', recentCount: 0),
+        ];
+
+        await tester.pumpWidget(buildSubject(tags: tags));
+        await tester.pump(); // let async provider resolve
+
+        expect(find.text('🔥 핫 태그'), findsNothing);
+        expect(find.text('#독서'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'shows only tags with recentCount > 0',
+      (tester) async {
+        final tags = [
+          makeTag(name: '독서', recentCount: 5),
+          makeTag(name: '스터디', recentCount: 0),
+          makeTag(name: '영화', recentCount: 3),
+        ];
+
+        await tester.pumpWidget(buildSubject(tags: tags));
+        await tester.pump();
+
+        expect(find.text('🔥 핫 태그'), findsOneWidget);
+        expect(find.text('#독서'), findsOneWidget);
+        expect(find.text('#영화'), findsOneWidget);
+        // 스터디는 recentCount=0이므로 숨겨져야 함
+        expect(find.text('#스터디'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'hides section when tag list is empty',
+      (tester) async {
+        await tester.pumpWidget(buildSubject(tags: []));
+        await tester.pump();
+
+        expect(find.text('🔥 핫 태그'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'renders 7일 +N label for active tags',
+      (tester) async {
+        final tags = [makeTag(name: '클럽', recentCount: 42)];
+
+        await tester.pumpWidget(buildSubject(tags: tags));
+        await tester.pump();
+
+        expect(find.text('7일 +42'), findsOneWidget);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1286

## 변경 요약

### 문제
`get_trending_tags` RPC는 `recent_count > 0` 필터 없이 태그를 반환한다. dev 환경에서 최근 7일간 이벤트가 없으면 모든 태그의 `recentCount = 0`이 되어 "7일 +0"이 표시된다. 핫 태그 섹션에 활성화되지 않은 태그가 노출되는 것은 개념적 모순.

### 수정
`TrendingTagSection`에서 렌더링 전 `recentCount == 0` 태그를 필터링. 필터링 후 남은 태그가 없으면 섹션 전체를 숨김.