### PR TITLE
fix(backend-simulator): enforce EF-only path for approve and refund flows

### DIFF
--- a/supabase/functions/backend-simulator/sim_approve.ts
+++ b/supabase/functions/backend-simulator/sim_approve.ts
@@ -23,8 +23,8 @@ export interface SimApproveResult {
  * For each application:
  *   1. Fetch app details (event_id, user_id)
  *   2. Fetch event's party for partner_id + required_verification_ids
- *   3. If verification needed: create submission → update status → trigger fires
- *   4. If no verification: directly update application.status
+ *   3. If verification needed: create submission → call partner-review-submission EF
+ *   4. If no verification: call partner-approve-application EF (approve) or direct DB update (reject)
  */
 export async function simApproveVerifications(
   supabase: SupabaseClient,
@@ -75,7 +75,7 @@ export async function simApproveVerifications(
       }
 
       if (verificationId && partnerId) {
-        // Verification flow: insert submission → update to approved → trigger fires
+        // Verification flow: insert submission → call partner-review-submission EF
         const submissionId = crypto.randomUUID();
         const { error: insErr } = await supabase.from("verification_submissions").insert({
           id: submissionId,
@@ -91,52 +91,23 @@ export async function simApproveVerifications(
           continue;
         }
 
-        // Attempt to approve via partner-review-submission EF; fall back to direct DB update
-        if (supabaseUrl && anonKey && partnerId) {
-          const simUserPassword = Deno.env.get("SIM_USER_PASSWORD") ?? "password1234!";
-          try {
-            const partnerEmail = await getPartnerEmail(supabase, partnerId);
-            if (partnerEmail) {
-              const partnerToken = await getSimPartnerToken(supabaseUrl, anonKey, partnerEmail, simUserPassword);
-              const efResult = await callEdgeFunction(supabaseUrl, "partner-review-submission", {
-                action: "review",
-                submission_id: submissionId,
-                result: "approved",
-              }, partnerToken);
-              if (efResult.status === 200) {
-                log({ level: "info", phase: "approve", step: "ef_approve", message: `Approved submission ${submissionId} via EF` });
-                // EF handled the status update — skip direct DB update, continue to assertions below
-              } else {
-                throw new Error(`EF returned ${efResult.status}`);
-              }
-            } else {
-              throw new Error("Partner email not found");
-            }
-          } catch (efErr) {
-            if (strict) {
-              throw new Error(`Strict mode: EF failed for submission ${submissionId} (app ${appId}): ${String(efErr)}`);
-            }
-            log({ level: "warn", phase: "approve", step: "ef_approve_fallback", message: `EF failed, falling back to direct update: ${String(efErr)}` });
-            const { error: updErr } = await supabase
-              .from("verification_submissions")
-              .update({ status: "approved" })
-              .eq("id", submissionId);
-            if (updErr) {
-              log({ level: "error", phase: "approve", step: "update_submission", message: `Failed to approve submission ${submissionId}: ${updErr.message}` });
-              continue;
-            }
-          }
-        } else {
-          // No EF credentials — use direct DB update
-          const { error: updErr } = await supabase
-            .from("verification_submissions")
-            .update({ status: "approved" })
-            .eq("id", submissionId);
-          if (updErr) {
-            log({ level: "error", phase: "approve", step: "update_submission", message: `Failed to approve submission ${submissionId}: ${updErr.message}` });
-            continue;
-          }
+        // Call partner-review-submission EF — no fallback. EF is the only path.
+        // Fix #1280: remove direct DB fallback; EF failure is always an error.
+        const simUserPassword = Deno.env.get("SIM_USER_PASSWORD") ?? "password1234!";
+        const partnerEmail = await getPartnerEmail(supabase, partnerId);
+        if (!partnerEmail) {
+          throw new Error(`Partner email not found for partner ${partnerId} (submission ${submissionId}, app ${appId})`);
         }
+        const partnerToken = await getSimPartnerToken(supabaseUrl!, anonKey!, partnerEmail, simUserPassword);
+        const efResult = await callEdgeFunction(supabaseUrl!, "partner-review-submission", {
+          action: "review",
+          submission_id: submissionId,
+          result: "approved",
+        }, partnerToken);
+        if (efResult.status !== 200) {
+          throw new Error(`partner-review-submission EF returned ${efResult.status} for submission ${submissionId} (app ${appId})`);
+        }
+        log({ level: "info", phase: "approve", step: "ef_approve", message: `Approved submission ${submissionId} via EF` });
 
         // Assert verification approved (trigger should have created partner_verified_users)
         const verifAssertion = await simAssertVerificationApproved(supabase, submissionId);
@@ -153,15 +124,22 @@ export async function simApproveVerifications(
           log({ level: "warn", phase: "approve", step: "approved", message: `App ${appId} approval assertion failed: ${appAssertion.details}` });
         }
       } else {
-        // No verification needed: directly update application status
-        const { error: updErr } = await supabase
-          .from("event_applications")
-          .update({ status: "approved" })
-          .eq("id", appId);
-        if (updErr) {
-          log({ level: "error", phase: "approve", step: "direct_approve", message: `Failed to directly approve app ${appId}: ${updErr.message}` });
-          continue;
+        // No verification needed: call partner-approve-application EF
+        // Fix #1280: replace direct DB update with EF call for consistency.
+        const simUserPassword = Deno.env.get("SIM_USER_PASSWORD") ?? "password1234!";
+        const partnerEmail = partnerId ? await getPartnerEmail(supabase, partnerId) : null;
+        if (!partnerEmail) {
+          throw new Error(`Partner email not found for partner ${partnerId} (app ${appId})`);
         }
+        const partnerToken = await getSimPartnerToken(supabaseUrl!, anonKey!, partnerEmail, simUserPassword);
+        const efResult = await callEdgeFunction(supabaseUrl!, "partner-approve-application", {
+          action: "approve",
+          application_id: appId,
+        }, partnerToken);
+        if (efResult.status !== 200) {
+          throw new Error(`partner-approve-application EF returned ${efResult.status} for app ${appId}`);
+        }
+        log({ level: "info", phase: "approve", step: "ef_direct_approve", message: `Approved app ${appId} via partner-approve-application EF` });
 
         const appAssertion = await simAssertApplicationApproved(supabase, appId);
         assertions.push(appAssertion);
@@ -199,7 +177,7 @@ export async function simApproveVerifications(
       }
 
       if (verificationId && partnerId) {
-        // Verification flow: insert submission → update to rejected → trigger fires
+        // Verification flow: insert submission → call partner-review-submission EF
         const submissionId = crypto.randomUUID();
         const { error: insErr } = await supabase.from("verification_submissions").insert({
           id: submissionId,
@@ -215,52 +193,23 @@ export async function simApproveVerifications(
           continue;
         }
 
-        // Attempt to reject via partner-review-submission EF; fall back to direct DB update
-        if (supabaseUrl && anonKey && partnerId) {
-          const simUserPassword = Deno.env.get("SIM_USER_PASSWORD") ?? "password1234!";
-          try {
-            const partnerEmail = await getPartnerEmail(supabase, partnerId);
-            if (partnerEmail) {
-              const partnerToken = await getSimPartnerToken(supabaseUrl, anonKey, partnerEmail, simUserPassword);
-              const efResult = await callEdgeFunction(supabaseUrl, "partner-review-submission", {
-                action: "review",
-                submission_id: submissionId,
-                result: "rejected",
-              }, partnerToken);
-              if (efResult.status === 200) {
-                log({ level: "info", phase: "approve", step: "ef_reject", message: `Rejected submission ${submissionId} via EF` });
-                // EF handled the status update — skip direct DB update, continue to assertions below
-              } else {
-                throw new Error(`EF returned ${efResult.status}`);
-              }
-            } else {
-              throw new Error("Partner email not found");
-            }
-          } catch (efErr) {
-            if (strict) {
-              throw new Error(`Strict mode: EF failed for submission ${submissionId} (app ${appId}): ${String(efErr)}`);
-            }
-            log({ level: "warn", phase: "approve", step: "ef_reject_fallback", message: `EF failed, falling back to direct update: ${String(efErr)}` });
-            const { error: updErr } = await supabase
-              .from("verification_submissions")
-              .update({ status: "rejected" })
-              .eq("id", submissionId);
-            if (updErr) {
-              log({ level: "error", phase: "approve", step: "update_submission", message: `Failed to reject submission ${submissionId}: ${updErr.message}` });
-              continue;
-            }
-          }
-        } else {
-          // No EF credentials — use direct DB update
-          const { error: updErr } = await supabase
-            .from("verification_submissions")
-            .update({ status: "rejected" })
-            .eq("id", submissionId);
-          if (updErr) {
-            log({ level: "error", phase: "approve", step: "update_submission", message: `Failed to reject submission ${submissionId}: ${updErr.message}` });
-            continue;
-          }
+        // Call partner-review-submission EF — no fallback. EF is the only path.
+        // Fix #1280: remove direct DB fallback; EF failure is always an error.
+        const simUserPassword = Deno.env.get("SIM_USER_PASSWORD") ?? "password1234!";
+        const partnerEmail = await getPartnerEmail(supabase, partnerId);
+        if (!partnerEmail) {
+          throw new Error(`Partner email not found for partner ${partnerId} (submission ${submissionId}, app ${appId})`);
         }
+        const partnerToken = await getSimPartnerToken(supabaseUrl!, anonKey!, partnerEmail, simUserPassword);
+        const efResult = await callEdgeFunction(supabaseUrl!, "partner-review-submission", {
+          action: "review",
+          submission_id: submissionId,
+          result: "rejected",
+        }, partnerToken);
+        if (efResult.status !== 200) {
+          throw new Error(`partner-review-submission EF returned ${efResult.status} for submission ${submissionId} (app ${appId})`);
+        }
+        log({ level: "info", phase: "approve", step: "ef_reject", message: `Rejected submission ${submissionId} via EF` });
 
         // Assert application rejected (trigger should have updated status)
         const appAssertion = await simAssertApplicationRejected(supabase, appId);
@@ -273,7 +222,10 @@ export async function simApproveVerifications(
           log({ level: "warn", phase: "approve", step: "rejected", message: `App ${appId} rejection assertion failed: ${appAssertion.details}` });
         }
       } else {
-        // No verification needed: directly update application status
+        // No verification needed: reject via direct DB update.
+        // Fix #1280: partner-approve-application EF does not support a "reject" action,
+        // and there is no partner-reject-application EF. Direct DB update is intentional
+        // until a dedicated reject EF is introduced.
         const { error: updErr } = await supabase
           .from("event_applications")
           .update({ status: "rejected" })
@@ -288,7 +240,7 @@ export async function simApproveVerifications(
 
         if (appAssertion.passed) {
           rejectedApplicationIds.push(appId);
-          log({ level: "info", phase: "approve", step: "rejected", message: `App ${appId} directly rejected (no verification required)` });
+          log({ level: "info", phase: "approve", step: "rejected", message: `App ${appId} directly rejected (no verification required, no reject EF available)` });
         } else {
           log({ level: "warn", phase: "approve", step: "rejected", message: `App ${appId} direct rejection assertion failed: ${appAssertion.details}` });
         }

--- a/supabase/functions/backend-simulator/sim_approve.ts
+++ b/supabase/functions/backend-simulator/sim_approve.ts
@@ -93,13 +93,16 @@ export async function simApproveVerifications(
 
         // Call partner-review-submission EF — no fallback. EF is the only path.
         // Fix #1280: remove direct DB fallback; EF failure is always an error.
+        if (!supabaseUrl || !anonKey) {
+          throw new Error(`App ${appId}: supabaseUrl/anonKey required for partner-review-submission EF`);
+        }
         const simUserPassword = Deno.env.get("SIM_USER_PASSWORD") ?? "password1234!";
         const partnerEmail = await getPartnerEmail(supabase, partnerId);
         if (!partnerEmail) {
           throw new Error(`Partner email not found for partner ${partnerId} (submission ${submissionId}, app ${appId})`);
         }
-        const partnerToken = await getSimPartnerToken(supabaseUrl!, anonKey!, partnerEmail, simUserPassword);
-        const efResult = await callEdgeFunction(supabaseUrl!, "partner-review-submission", {
+        const partnerToken = await getSimPartnerToken(supabaseUrl, anonKey, partnerEmail, simUserPassword);
+        const efResult = await callEdgeFunction(supabaseUrl, "partner-review-submission", {
           action: "review",
           submission_id: submissionId,
           result: "approved",
@@ -126,13 +129,16 @@ export async function simApproveVerifications(
       } else {
         // No verification needed: call partner-approve-application EF
         // Fix #1280: replace direct DB update with EF call for consistency.
+        if (!supabaseUrl || !anonKey) {
+          throw new Error(`App ${appId}: supabaseUrl/anonKey required for partner-approve-application EF`);
+        }
         const simUserPassword = Deno.env.get("SIM_USER_PASSWORD") ?? "password1234!";
         const partnerEmail = partnerId ? await getPartnerEmail(supabase, partnerId) : null;
         if (!partnerEmail) {
           throw new Error(`Partner email not found for partner ${partnerId} (app ${appId})`);
         }
-        const partnerToken = await getSimPartnerToken(supabaseUrl!, anonKey!, partnerEmail, simUserPassword);
-        const efResult = await callEdgeFunction(supabaseUrl!, "partner-approve-application", {
+        const partnerToken = await getSimPartnerToken(supabaseUrl, anonKey, partnerEmail, simUserPassword);
+        const efResult = await callEdgeFunction(supabaseUrl, "partner-approve-application", {
           action: "approve",
           application_id: appId,
         }, partnerToken);
@@ -195,13 +201,16 @@ export async function simApproveVerifications(
 
         // Call partner-review-submission EF — no fallback. EF is the only path.
         // Fix #1280: remove direct DB fallback; EF failure is always an error.
+        if (!supabaseUrl || !anonKey) {
+          throw new Error(`App ${appId}: supabaseUrl/anonKey required for partner-review-submission EF`);
+        }
         const simUserPassword = Deno.env.get("SIM_USER_PASSWORD") ?? "password1234!";
         const partnerEmail = await getPartnerEmail(supabase, partnerId);
         if (!partnerEmail) {
           throw new Error(`Partner email not found for partner ${partnerId} (submission ${submissionId}, app ${appId})`);
         }
-        const partnerToken = await getSimPartnerToken(supabaseUrl!, anonKey!, partnerEmail, simUserPassword);
-        const efResult = await callEdgeFunction(supabaseUrl!, "partner-review-submission", {
+        const partnerToken = await getSimPartnerToken(supabaseUrl, anonKey, partnerEmail, simUserPassword);
+        const efResult = await callEdgeFunction(supabaseUrl, "partner-review-submission", {
           action: "review",
           submission_id: submissionId,
           result: "rejected",

--- a/supabase/functions/backend-simulator/sim_approve_test.ts
+++ b/supabase/functions/backend-simulator/sim_approve_test.ts
@@ -1,9 +1,23 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import { createMockSupabaseClient } from "../_test_utils/mock_supabase_client.ts";
 import { simApproveVerifications } from "./sim_approve.ts";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 const noop = () => {};
+
+// Intercept module-level EF calls via mock fetch. We replace globalThis.fetch
+// for the duration of the test to simulate EF responses without a real server.
+function withMockFetch<T>(
+  handler: (url: string, init: RequestInit) => Response,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const original = globalThis.fetch;
+  globalThis.fetch = (url: string | URL | Request, init?: RequestInit) =>
+    Promise.resolve(handler(url.toString(), init ?? {}));
+  return fn().finally(() => {
+    globalThis.fetch = original;
+  });
+}
 
 function makeEventSelectHandler() {
   return () => ({
@@ -25,6 +39,23 @@ function makeVerificationSelectHandler(verifId: string | null) {
   });
 }
 
+// Build a standard mock that handles partner_members + authAdminGetUserById
+// so getPartnerEmail() resolves to "partner@test.com".
+function makePartnerEmailMockOptions(extraTables: Record<string, unknown> = {}) {
+  return {
+    tables: {
+      partner_members: {
+        select: () => ({ data: [{ user_id: "partner-user-1" }], error: null }),
+      },
+      ...extraTables,
+    },
+    authAdminGetUserById: (_userId: string) => ({
+      data: { user: { email: "partner@test.com" } },
+      error: null,
+    }),
+  };
+}
+
 Deno.test("simApproveVerifications - empty list returns empty result", async () => {
   const mock = createMockSupabaseClient({});
   const result = await simApproveVerifications(
@@ -38,244 +69,280 @@ Deno.test("simApproveVerifications - empty list returns empty result", async () 
   assertEquals(result.assertions, []);
 });
 
-Deno.test("simApproveVerifications - 5 apps with approveRate=0.8 → 4 approved, 1 rejected", async () => {
-  const appIds = ["app-1", "app-2", "app-3", "app-4", "app-5"];
-  const submissionStatuses: Record<string, string> = {};
+// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
+// token auto-refresh even when persistSession=false. The interval leaks within the test but is
+// harmless — suppressing the leak check is correct here rather than patching the library.
+Deno.test({
+  name: "simApproveVerifications - 5 apps with approveRate=0.8 → 4 approved, 1 rejected",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const appIds = ["app-1", "app-2", "app-3", "app-4", "app-5"];
+    const appStatuses: Record<string, string> = {};
+    const subAppMap: Record<string, string> = {};
 
-  const insertedSubmissions: Array<{ id: string; appId: string; status: string }> = [];
+    const mock = createMockSupabaseClient({
+      ...makePartnerEmailMockOptions({
+        event_applications: {
+          select: ({ filters }: { filters: Record<string, unknown> }) => {
+            const appId = filters["id"] as string;
+            return {
+              data: {
+                id: appId,
+                event_id: "event-1",
+                ticket_id: "ticket-1",
+                user_id: "user-1",
+                status: appStatuses[appId] ?? "pending_review",
+              },
+              error: null,
+            };
+          },
+        },
+        events: { select: makeEventSelectHandler() },
+        verifications: { select: makeVerificationSelectHandler("verif-1") },
+        verification_submissions: {
+          insert: ({ values }: { values: unknown }) => {
+            const v = values as { id: string; application_id: string };
+            subAppMap[v.id] = v.application_id;
+            return { data: null, error: null };
+          },
+          select: ({ filters }: { filters: Record<string, unknown> }) => {
+            const subId = filters["id"] as string;
+            return {
+              data: {
+                id: subId,
+                status: "approved",
+                partner_id: "partner-1",
+                user_id: "user-1",
+                verification_id: "verif-1",
+              },
+              error: null,
+            };
+          },
+        },
+        partner_verified_users: {
+          select: () => ({ data: { id: "pvu-1" }, error: null }),
+        },
+      }),
+    });
 
-  const trackingMock = createMockSupabaseClient({
-    tables: {
-      event_applications: {
-        select: ({ filters }) => {
-          const appId = filters["id"] as string;
-          const status = submissionStatuses[`app_${appId}`] ?? "pending_review";
-          return {
-            data: {
-              id: appId,
-              event_id: "event-1",
-              ticket_id: "ticket-1",
-              user_id: "user-1",
-              status,
-            },
-            error: null,
-          };
-        },
-        update: ({ values, filters }) => {
-          const appId = filters["id"] as string;
-          const v = values as { status: string };
-          submissionStatuses[`app_${appId}`] = v.status;
-          return { data: null, error: null };
-        },
-      },
-      events: {
-        select: makeEventSelectHandler(),
-      },
-      verifications: {
-        select: makeVerificationSelectHandler("verif-1"),
-      },
-      verification_submissions: {
-        insert: ({ values }) => {
-          const v = values as { id: string; application_id: string; status: string };
-          submissionStatuses[`sub_${v.id}`] = v.status;
-          submissionStatuses[`sub_${v.id}_appId`] = v.application_id;
-          insertedSubmissions.push({ id: v.id, appId: v.application_id, status: v.status });
-          return { data: null, error: null };
-        },
-        update: ({ values, filters }) => {
-          const subId = filters["id"] as string;
-          const v = values as { status: string };
-          submissionStatuses[`sub_${subId}`] = v.status;
-          const appId = submissionStatuses[`sub_${subId}_appId`];
+    Deno.env.set("SIM_USER_PASSWORD", "test-password");
+    try {
+      await withMockFetch((url, init) => {
+        if (url.includes("auth/v1/token")) {
+          return new Response(
+            JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("partner-review-submission")) {
+          // Simulate EF approving/rejecting — update app status via side effect
+          const body = JSON.parse((init.body as string) ?? "{}");
+          const subId = body.submission_id as string;
+          const appId = subAppMap[subId];
           if (appId) {
-            submissionStatuses[`app_${appId}`] = v.status === "approved" ? "approved" : "rejected";
+            appStatuses[appId] = body.result === "approved" ? "approved" : "rejected";
           }
-          return { data: null, error: null };
-        },
-        select: ({ filters }) => {
-          const subId = filters["id"] as string;
-          const status = submissionStatuses[`sub_${subId}`] ?? "pending";
-          return {
-            data: {
-              id: subId,
-              status,
-              partner_id: "partner-1",
-              user_id: "user-1",
-              verification_id: "verif-1",
-            },
-            error: null,
-          };
-        },
-      },
-      partner_verified_users: {
-        select: () => ({ data: { id: "pvu-1" }, error: null }),
-      },
-    },
-  });
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return new Response(JSON.stringify({}), { status: 404 });
+      }, async () => {
+        const result = await simApproveVerifications(
+          mock as unknown as SupabaseClient,
+          appIds,
+          noop,
+          0.8,
+          "https://mock.supabase.co",
+          "anon-key",
+        );
 
-  const result = await simApproveVerifications(
-    trackingMock as unknown as SupabaseClient,
-    appIds,
-    noop,
-    0.8,
-  );
-
-  assertEquals(result.approvedApplicationIds.length, 4);
-  assertEquals(result.rejectedApplicationIds.length, 1);
+        assertEquals(result.approvedApplicationIds.length, 4);
+        assertEquals(result.rejectedApplicationIds.length, 1);
+      });
+    } finally {
+      Deno.env.delete("SIM_USER_PASSWORD");
+    }
+  },
 });
 
-Deno.test("simApproveVerifications - all approve when approveRate=1.0", async () => {
-  const appIds = ["app-a", "app-b", "app-c"];
-  const appStatuses: Record<string, string> = {};
-  const subStatuses: Record<string, string> = {};
-  const subAppMap: Record<string, string> = {};
+Deno.test({
+  name: "simApproveVerifications - all approve when approveRate=1.0",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const appIds = ["app-a", "app-b", "app-c"];
+    const appStatuses: Record<string, string> = {};
+    const subAppMap: Record<string, string> = {};
 
-  const mock = createMockSupabaseClient({
-    tables: {
-      event_applications: {
-        select: ({ filters }) => {
-          const appId = filters["id"] as string;
-          return {
-            data: {
-              id: appId,
-              event_id: "event-1",
-              ticket_id: "ticket-1",
-              user_id: "user-1",
-              status: appStatuses[appId] ?? "pending_review",
-            },
-            error: null,
-          };
+    const mock = createMockSupabaseClient({
+      ...makePartnerEmailMockOptions({
+        event_applications: {
+          select: ({ filters }: { filters: Record<string, unknown> }) => {
+            const appId = filters["id"] as string;
+            return {
+              data: {
+                id: appId,
+                event_id: "event-1",
+                ticket_id: "ticket-1",
+                user_id: "user-1",
+                status: appStatuses[appId] ?? "pending_review",
+              },
+              error: null,
+            };
+          },
         },
-        update: ({ values, filters }) => {
-          const appId = filters["id"] as string;
-          const v = values as { status: string };
-          appStatuses[appId] = v.status;
-          return { data: null, error: null };
+        events: { select: makeEventSelectHandler() },
+        verifications: { select: makeVerificationSelectHandler("verif-1") },
+        verification_submissions: {
+          insert: ({ values }: { values: unknown }) => {
+            const v = values as { id: string; application_id: string };
+            subAppMap[v.id] = v.application_id;
+            return { data: null, error: null };
+          },
+          select: ({ filters }: { filters: Record<string, unknown> }) => {
+            const subId = filters["id"] as string;
+            return {
+              data: {
+                id: subId,
+                status: appStatuses[subAppMap[subId]] ?? "approved",
+                partner_id: "partner-1",
+                user_id: "user-1",
+                verification_id: "verif-1",
+              },
+              error: null,
+            };
+          },
         },
-      },
-      events: { select: makeEventSelectHandler() },
-      verifications: { select: makeVerificationSelectHandler("verif-1") },
-      verification_submissions: {
-        insert: ({ values }) => {
-          const v = values as { id: string; application_id: string };
-          subStatuses[v.id] = "pending";
-          subAppMap[v.id] = v.application_id;
-          return { data: null, error: null };
+        partner_verified_users: {
+          select: () => ({ data: { id: "pvu-1" }, error: null }),
         },
-        update: ({ values, filters }) => {
-          const subId = filters["id"] as string;
-          const v = values as { status: string };
-          subStatuses[subId] = v.status;
+      }),
+    });
+
+    Deno.env.set("SIM_USER_PASSWORD", "test-password");
+    try {
+      await withMockFetch((url, init) => {
+        if (url.includes("auth/v1/token")) {
+          return new Response(
+            JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("partner-review-submission")) {
+          const body = JSON.parse((init.body as string) ?? "{}");
+          const subId = body.submission_id as string;
           const appId = subAppMap[subId];
-          if (appId) appStatuses[appId] = v.status === "approved" ? "approved" : "rejected";
-          return { data: null, error: null };
-        },
-        select: ({ filters }) => {
-          const subId = filters["id"] as string;
-          return {
-            data: {
-              id: subId,
-              status: subStatuses[subId] ?? "pending",
-              partner_id: "partner-1",
-              user_id: "user-1",
-              verification_id: "verif-1",
-            },
-            error: null,
-          };
-        },
-      },
-      partner_verified_users: {
-        select: () => ({ data: { id: "pvu-1" }, error: null }),
-      },
-    },
-  });
+          if (appId) appStatuses[appId] = "approved";
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return new Response(JSON.stringify({}), { status: 404 });
+      }, async () => {
+        const result = await simApproveVerifications(
+          mock as unknown as SupabaseClient,
+          appIds,
+          noop,
+          1.0,
+          "https://mock.supabase.co",
+          "anon-key",
+        );
 
-  const result = await simApproveVerifications(
-    mock as unknown as SupabaseClient,
-    appIds,
-    noop,
-    1.0,
-  );
-
-  assertEquals(result.approvedApplicationIds.length, 3);
-  assertEquals(result.rejectedApplicationIds.length, 0);
+        assertEquals(result.approvedApplicationIds.length, 3);
+        assertEquals(result.rejectedApplicationIds.length, 0);
+      });
+    } finally {
+      Deno.env.delete("SIM_USER_PASSWORD");
+    }
+  },
 });
 
-Deno.test("simApproveVerifications - all reject when approveRate=0.0", async () => {
-  const appIds = ["app-x", "app-y"];
-  const appStatuses: Record<string, string> = {};
-  const subStatuses: Record<string, string> = {};
-  const subAppMap: Record<string, string> = {};
+Deno.test({
+  name: "simApproveVerifications - all reject when approveRate=0.0",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const appIds = ["app-x", "app-y"];
+    const appStatuses: Record<string, string> = {};
+    const subAppMap: Record<string, string> = {};
 
-  const mock = createMockSupabaseClient({
-    tables: {
-      event_applications: {
-        select: ({ filters }) => {
-          const appId = filters["id"] as string;
-          return {
-            data: {
-              id: appId,
-              event_id: "event-1",
-              ticket_id: "ticket-1",
-              user_id: "user-1",
-              status: appStatuses[appId] ?? "pending_review",
-            },
-            error: null,
-          };
+    const mock = createMockSupabaseClient({
+      ...makePartnerEmailMockOptions({
+        event_applications: {
+          select: ({ filters }: { filters: Record<string, unknown> }) => {
+            const appId = filters["id"] as string;
+            return {
+              data: {
+                id: appId,
+                event_id: "event-1",
+                ticket_id: "ticket-1",
+                user_id: "user-1",
+                status: appStatuses[appId] ?? "pending_review",
+              },
+              error: null,
+            };
+          },
         },
-        update: ({ values, filters }) => {
-          const appId = filters["id"] as string;
-          const v = values as { status: string };
-          appStatuses[appId] = v.status;
-          return { data: null, error: null };
+        events: { select: makeEventSelectHandler() },
+        verifications: { select: makeVerificationSelectHandler("verif-1") },
+        verification_submissions: {
+          insert: ({ values }: { values: unknown }) => {
+            const v = values as { id: string; application_id: string };
+            subAppMap[v.id] = v.application_id;
+            return { data: null, error: null };
+          },
+          select: ({ filters }: { filters: Record<string, unknown> }) => {
+            const subId = filters["id"] as string;
+            return {
+              data: {
+                id: subId,
+                status: appStatuses[subAppMap[subId]] ?? "rejected",
+                partner_id: "partner-1",
+                user_id: "user-1",
+                verification_id: "verif-1",
+              },
+              error: null,
+            };
+          },
         },
-      },
-      events: { select: makeEventSelectHandler() },
-      verifications: { select: makeVerificationSelectHandler("verif-1") },
-      verification_submissions: {
-        insert: ({ values }) => {
-          const v = values as { id: string; application_id: string };
-          subStatuses[v.id] = "pending";
-          subAppMap[v.id] = v.application_id;
-          return { data: null, error: null };
+        partner_verified_users: {
+          select: () => ({ data: { id: "pvu-1" }, error: null }),
         },
-        update: ({ values, filters }) => {
-          const subId = filters["id"] as string;
-          const v = values as { status: string };
-          subStatuses[subId] = v.status;
+      }),
+    });
+
+    Deno.env.set("SIM_USER_PASSWORD", "test-password");
+    try {
+      await withMockFetch((url, init) => {
+        if (url.includes("auth/v1/token")) {
+          return new Response(
+            JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("partner-review-submission")) {
+          const body = JSON.parse((init.body as string) ?? "{}");
+          const subId = body.submission_id as string;
           const appId = subAppMap[subId];
-          if (appId) appStatuses[appId] = v.status === "approved" ? "approved" : "rejected";
-          return { data: null, error: null };
-        },
-        select: ({ filters }) => {
-          const subId = filters["id"] as string;
-          return {
-            data: {
-              id: subId,
-              status: subStatuses[subId] ?? "pending",
-              partner_id: "partner-1",
-              user_id: "user-1",
-              verification_id: "verif-1",
-            },
-            error: null,
-          };
-        },
-      },
-      partner_verified_users: {
-        select: () => ({ data: { id: "pvu-1" }, error: null }),
-      },
-    },
-  });
+          if (appId) appStatuses[appId] = "rejected";
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return new Response(JSON.stringify({}), { status: 404 });
+      }, async () => {
+        const result = await simApproveVerifications(
+          mock as unknown as SupabaseClient,
+          appIds,
+          noop,
+          0.0,
+          "https://mock.supabase.co",
+          "anon-key",
+        );
 
-  const result = await simApproveVerifications(
-    mock as unknown as SupabaseClient,
-    appIds,
-    noop,
-    0.0,
-  );
-
-  assertEquals(result.approvedApplicationIds.length, 0);
-  assertEquals(result.rejectedApplicationIds.length, 2);
+        assertEquals(result.approvedApplicationIds.length, 0);
+        assertEquals(result.rejectedApplicationIds.length, 2);
+      });
+    } finally {
+      Deno.env.delete("SIM_USER_PASSWORD");
+    }
+  },
 });
 
 Deno.test("simApproveVerifications - handles DB error gracefully (no throw)", async () => {
@@ -298,14 +365,238 @@ Deno.test("simApproveVerifications - handles DB error gracefully (no throw)", as
   assertEquals(result.rejectedApplicationIds.length, 0);
 });
 
-Deno.test("simApproveVerifications - no verification needed (direct status update)", async () => {
-  const appIds = ["app-direct-1", "app-direct-2"];
+// Fix #1280: EF failure (verification flow) must throw regardless of strict flag.
+Deno.test({
+  name: "simApproveVerifications - EF failure on verification flow throws error (strict=false)",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const mock = createMockSupabaseClient({
+      ...makePartnerEmailMockOptions({
+        event_applications: {
+          select: ({ filters }: { filters: Record<string, unknown> }) => ({
+            data: {
+              id: filters["id"] as string,
+              event_id: "event-1",
+              ticket_id: "ticket-1",
+              user_id: "user-1",
+              status: "pending_review",
+            },
+            error: null,
+          }),
+        },
+        events: { select: makeEventSelectHandler() },
+        verifications: { select: makeVerificationSelectHandler("verif-1") },
+        verification_submissions: {
+          insert: () => ({ data: null, error: null }),
+          select: () => ({ data: { id: "sub-1", status: "pending" }, error: null }),
+        },
+      }),
+    });
+
+    const logs: string[] = [];
+    const logFn = (entry: { level: string; message: string }) => {
+      logs.push(`${entry.level}: ${entry.message}`);
+    };
+
+    Deno.env.set("SIM_USER_PASSWORD", "test-password");
+    try {
+      await withMockFetch((url) => {
+        if (url.includes("auth/v1/token")) {
+          return new Response(
+            JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }),
+            { status: 200 },
+          );
+        }
+        // EF returns 500 — should not fall back, should throw
+        if (url.includes("partner-review-submission")) {
+          return new Response(JSON.stringify({ error: "internal" }), { status: 500 });
+        }
+        return new Response(JSON.stringify({}), { status: 404 });
+      }, async () => {
+        // strict=false: error is logged, not propagated; result has 0 approved
+        const result = await simApproveVerifications(
+          mock as unknown as SupabaseClient,
+          ["app-ef-fail-1"],
+          logFn as unknown as Parameters<typeof simApproveVerifications>[2],
+          1.0,
+          "https://mock.supabase.co",
+          "anon-key",
+          false,
+        );
+        assertEquals(result.approvedApplicationIds.length, 0);
+        // Error was logged (not silent)
+        assertEquals(logs.some((l) => l.includes("error:")), true);
+      });
+    } finally {
+      Deno.env.delete("SIM_USER_PASSWORD");
+    }
+  },
+});
+
+// Fix #1280: EF failure (verification flow) must throw when strict=true.
+Deno.test({
+  name: "simApproveVerifications - EF failure on verification flow throws when strict=true",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const mock = createMockSupabaseClient({
+      ...makePartnerEmailMockOptions({
+        event_applications: {
+          select: ({ filters }: { filters: Record<string, unknown> }) => ({
+            data: {
+              id: filters["id"] as string,
+              event_id: "event-1",
+              ticket_id: "ticket-1",
+              user_id: "user-1",
+              status: "pending_review",
+            },
+            error: null,
+          }),
+        },
+        events: { select: makeEventSelectHandler() },
+        verifications: { select: makeVerificationSelectHandler("verif-1") },
+        verification_submissions: {
+          insert: () => ({ data: null, error: null }),
+          select: () => ({ data: { id: "sub-1", status: "pending" }, error: null }),
+        },
+      }),
+    });
+
+    Deno.env.set("SIM_USER_PASSWORD", "test-password");
+    try {
+      await withMockFetch((url) => {
+        if (url.includes("auth/v1/token")) {
+          return new Response(
+            JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("partner-review-submission")) {
+          return new Response(JSON.stringify({ error: "internal" }), { status: 500 });
+        }
+        return new Response(JSON.stringify({}), { status: 404 });
+      }, async () => {
+        await assertRejects(
+          () => simApproveVerifications(
+            mock as unknown as SupabaseClient,
+            ["app-strict-1"],
+            noop,
+            1.0,
+            "https://mock.supabase.co",
+            "anon-key",
+            true,
+          ),
+          Error,
+          "partner-review-submission EF returned 500",
+        );
+      });
+    } finally {
+      Deno.env.delete("SIM_USER_PASSWORD");
+    }
+  },
+});
+
+// Fix #1280: no-verification approve path uses partner-approve-application EF.
+Deno.test({
+  name: "simApproveVerifications - no verification needed: approve uses EF, reject uses direct DB",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const appIds = ["app-direct-1", "app-direct-2"];
+    const appStatuses: Record<string, string> = {};
+    const efApproveIds: string[] = [];
+
+    const mock = createMockSupabaseClient({
+      ...makePartnerEmailMockOptions({
+        event_applications: {
+          select: ({ filters }: { filters: Record<string, unknown> }) => {
+            const appId = filters["id"] as string;
+            return {
+              data: {
+                id: appId,
+                event_id: "event-1",
+                ticket_id: "ticket-1",
+                user_id: "user-1",
+                status: appStatuses[appId] ?? "pending_review",
+              },
+              error: null,
+            };
+          },
+          update: ({ values, filters }: { values: unknown; filters: Record<string, unknown> }) => {
+            const appId = filters["id"] as string;
+            const v = values as { status: string };
+            appStatuses[appId] = v.status;
+            return { data: null, error: null };
+          },
+        },
+        events: {
+          select: () => ({
+            data: {
+              id: "event-1",
+              parties: {
+                partner_id: "partner-1",
+                required_verification_ids: [],
+              },
+            },
+            error: null,
+          }),
+        },
+        verifications: {
+          select: makeVerificationSelectHandler(null),
+        },
+      }),
+    });
+
+    Deno.env.set("SIM_USER_PASSWORD", "test-password");
+    try {
+      await withMockFetch((url, init) => {
+        if (url.includes("auth/v1/token")) {
+          return new Response(
+            JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("partner-approve-application")) {
+          const body = JSON.parse((init.body as string) ?? "{}");
+          const appId = body.application_id as string;
+          efApproveIds.push(appId);
+          appStatuses[appId] = "approved";
+          return new Response(JSON.stringify({ approved: 1, application_id: appId }), { status: 200 });
+        }
+        return new Response(JSON.stringify({}), { status: 404 });
+      }, async () => {
+        // approveRate=1.0 → both apps go to approve path (EF), 0 to reject
+        const result = await simApproveVerifications(
+          mock as unknown as SupabaseClient,
+          appIds,
+          noop,
+          1.0,
+          "https://mock.supabase.co",
+          "anon-key",
+        );
+
+        assertEquals(result.approvedApplicationIds.length, 2);
+        assertEquals(result.rejectedApplicationIds.length, 0);
+        // EF was called for both apps
+        assertEquals(efApproveIds.includes("app-direct-1"), true);
+        assertEquals(efApproveIds.includes("app-direct-2"), true);
+      });
+    } finally {
+      Deno.env.delete("SIM_USER_PASSWORD");
+    }
+  },
+});
+
+// Fix #1280: no-verification reject path remains direct DB (no reject EF available).
+Deno.test("simApproveVerifications - no verification needed: reject uses direct DB update", async () => {
+  const appIds = ["app-rej-1", "app-rej-2"];
   const appStatuses: Record<string, string> = {};
 
   const mock = createMockSupabaseClient({
     tables: {
       event_applications: {
-        select: ({ filters }) => {
+        select: ({ filters }: { filters: Record<string, unknown> }) => {
           const appId = filters["id"] as string;
           return {
             data: {
@@ -318,7 +609,7 @@ Deno.test("simApproveVerifications - no verification needed (direct status updat
             error: null,
           };
         },
-        update: ({ values, filters }) => {
+        update: ({ values, filters }: { values: unknown; filters: Record<string, unknown> }) => {
           const appId = filters["id"] as string;
           const v = values as { status: string };
           appStatuses[appId] = v.status;
@@ -343,15 +634,17 @@ Deno.test("simApproveVerifications - no verification needed (direct status updat
     },
   });
 
+  // approveRate=0.0 → all apps go to reject path (no EF available → direct DB)
+  // No supabaseUrl/anonKey needed since reject has no EF call
   const result = await simApproveVerifications(
     mock as unknown as SupabaseClient,
     appIds,
     noop,
-    1.0,
+    0.0,
   );
 
-  assertEquals(result.approvedApplicationIds.length, 2);
-  assertEquals(result.rejectedApplicationIds.length, 0);
-  assertEquals(appStatuses["app-direct-1"], "approved");
-  assertEquals(appStatuses["app-direct-2"], "approved");
+  assertEquals(result.approvedApplicationIds.length, 0);
+  assertEquals(result.rejectedApplicationIds.length, 2);
+  assertEquals(appStatuses["app-rej-1"], "rejected");
+  assertEquals(appStatuses["app-rej-2"], "rejected");
 });

--- a/supabase/functions/backend-simulator/sim_refund.ts
+++ b/supabase/functions/backend-simulator/sim_refund.ts
@@ -14,12 +14,16 @@ export interface SimRefundResult {
  * Simulates refund requests for a subset of paid applications.
  *
  * For each selected application:
- *   1. Fetch payment_amount + event_id from event_applications
+ *   1. Fetch payment_amount + payment_id + event_id + user_id from event_applications
  *   2. Fetch start_time from events
  *   3. Calculate refund using simCalcRefund()
- *   4. Update event_applications: status='cancelled', refund_status, refund_amount
- *   5. DELETE event_participants (triggers on_participant_change → decrements counts)
- *   6. Assert refund processed correctly
+ *   4. Call payment-cancel EF (the only refund path — no direct DB fallback)
+ *   5. Update event_applications: status='cancelled' (EF sets refund_status/refund_amount)
+ *   6. DELETE event_participants (no DB trigger handles this on refund)
+ *   7. Assert refund processed correctly
+ *
+ * Fix #1280: Remove direct DB fallback for refund. payment-cancel EF is now the sole
+ * refund path. EF failure throws regardless of strict mode.
  */
 export async function simRefundRequests(
   supabase: SupabaseClient,
@@ -28,7 +32,7 @@ export async function simRefundRequests(
   refundRate: number = 0.2,
   supabaseUrl?: string,
   anonKey?: string,
-  strict?: boolean,
+  _strict?: boolean,
 ): Promise<SimRefundResult> {
   const refundedApplicationIds: string[] = [];
   const assertions: SimAssertionResult[] = [];
@@ -109,108 +113,88 @@ export async function simRefundRequests(
 
     const refundCalc = simCalcRefund(startTime, paymentAmount, new Date(), null, 2, 7);
 
-    // Attempt to call payment-cancel EF with user token when credentials and payment_id are available
-    let efSuccess = false;
-    if (supabaseUrl && anonKey && paymentId) {
-      // Look up user email from user_profiles
-      const { data: profileData } = await supabase
-        .from("user_profiles")
-        .select("username")
-        .eq("id", userId)
-        .maybeSingle();
-      const username = (profileData as { username?: string } | null)?.username;
-
-      if (username && !username.startsWith("partner_")) {
-        const userEmail = `${username}@test.com`;
-        try {
-          const userToken = await getSimUserToken(supabaseUrl, anonKey, userEmail, simUserPassword);
-          const efResult = await callEdgeFunction(supabaseUrl, "payment-cancel", {
-            payment_id: paymentId,
-            reason: "[E2E] 시뮬레이션 환불",
-            amount: refundCalc.refund_amount > 0 ? refundCalc.refund_amount : undefined,
-          }, userToken);
-
-          if (efResult.status === 200) {
-            efSuccess = true;
-            log({
-              level: "info",
-              phase: "refund",
-              step: "ef_cancel",
-              message: `payment-cancel EF succeeded for app ${appId}`,
-              data: { appId, paymentId, efStatus: efResult.status },
-            });
-          } else {
-            log({
-              level: "warn",
-              phase: "refund",
-              step: "ef_cancel_failed",
-              message: `payment-cancel EF returned ${efResult.status} for app ${appId}, falling back to direct update`,
-              data: { appId, efStatus: efResult.status },
-            });
-          }
-        } catch (authErr) {
-          if (strict) {
-            throw new Error(`Strict mode: auth failed for ${username}, cannot refund app ${appId}: ${String(authErr)}`);
-          }
-          log({
-            level: "warn",
-            phase: "refund",
-            step: "ef_auth_fallback",
-            message: `Auth failed for ${username}, using direct update: ${String(authErr)}`,
-          });
-        }
-      }
+    // Fix #1280: payment-cancel EF is the only refund path. No direct DB fallback.
+    // Missing credentials or payment_id → throw immediately.
+    if (!supabaseUrl || !anonKey) {
+      throw new Error(`App ${appId}: supabaseUrl/anonKey required for payment-cancel EF`);
     }
 
-    if (!efSuccess) {
-      if (strict) {
-        // Strict mode: EF was attempted but failed — do not fall back to direct DB update
-        throw new Error(`Strict mode: EF failed for app ${appId}, direct DB fallback not permitted`);
-      }
-      // Fallback: direct DB update (used when EF call unavailable or failed)
-      const refundStatus = refundCalc.refund_percentage > 0 ? "completed" : "failed";
-      const { error: updateErr } = await supabase
+    if (!paymentId) {
+      throw new Error(`App ${appId}: payment_id is null, cannot call payment-cancel EF`);
+    }
+
+    // Look up user email from user_profiles
+    const { data: profileData } = await supabase
+      .from("user_profiles")
+      .select("username")
+      .eq("id", userId)
+      .maybeSingle();
+    const username = (profileData as { username?: string } | null)?.username;
+
+    if (!username || username.startsWith("partner_")) {
+      throw new Error(`App ${appId}: no valid user username (got: ${username ?? "null"}), cannot call payment-cancel EF`);
+    }
+
+    const userEmail = `${username}@test.com`;
+    const userToken = await getSimUserToken(supabaseUrl, anonKey, userEmail, simUserPassword);
+    const efResult = await callEdgeFunction(supabaseUrl, "payment-cancel", {
+      payment_id: paymentId,
+      reason: "[E2E] 시뮬레이션 환불",
+      amount: refundCalc.refund_amount > 0 ? refundCalc.refund_amount : undefined,
+    }, userToken);
+
+    if (efResult.status !== 200) {
+      throw new Error(`App ${appId}: payment-cancel EF returned ${efResult.status}`);
+    }
+
+    log({
+      level: "info",
+      phase: "refund",
+      step: "ef_cancel",
+      message: `payment-cancel EF succeeded for app ${appId}`,
+      data: { appId, paymentId, efStatus: efResult.status },
+    });
+
+    // EF sets refund_status and refund_amount. Update status='cancelled' separately,
+    // since payment-cancel EF does not touch the status field.
+    const { error: updateErr } = await supabase
+      .from("event_applications")
+      .update({ status: "cancelled" })
+      .eq("id", appId);
+
+    if (updateErr) {
+      log({
+        level: "error",
+        phase: "refund",
+        step: "update_app_status",
+        message: `Failed to set status=cancelled for app ${appId}: ${updateErr.message}`,
+      });
+      return null;
+    }
+
+    // Delete participant. No DB trigger handles this on refund — must be done explicitly.
+    const { error: deleteErr } = await supabase
+      .from("event_participants")
+      .delete()
+      .eq("event_id", eventId)
+      .eq("user_id", userId);
+
+    if (deleteErr) {
+      // Rollback: participant delete failed — revert application status to avoid cancelled-but-has-participant state
+      // Fix #507: capture rollback error to avoid masking failures
+      const { error: rollbackErr } = await supabase
         .from("event_applications")
-        .update({
-          status: "cancelled",
-          refund_status: refundStatus,
-          refund_amount: refundCalc.refund_amount,
-        })
+        .update({ status: "paid" })
         .eq("id", appId);
-
-      if (updateErr) {
-        log({
-          level: "error",
-          phase: "refund",
-          step: "update_app",
-          message: `Failed to update app ${appId}: ${updateErr.message}`,
-        });
-        return null;
-      }
-
-      const { error: deleteErr } = await supabase
-        .from("event_participants")
-        .delete()
-        .eq("event_id", eventId)
-        .eq("user_id", userId);
-
-      if (deleteErr) {
-        // Rollback: participant delete failed — revert application status to avoid cancelled-but-has-participant state
-        // Fix #507: capture rollback error to avoid masking failures
-        const { error: rollbackErr } = await supabase
-          .from("event_applications")
-          .update({ status: "paid", refund_status: null, refund_amount: null })
-          .eq("id", appId);
-        log({
-          level: "error",
-          phase: "refund",
-          step: rollbackErr ? "rollback_app_failed" : "delete_participant",
-          message: rollbackErr
-            ? `Participant delete failed and rollback also failed for app ${appId}: ${deleteErr.message}; rollback error: ${rollbackErr.message}`
-            : `Participant delete failed, reverted application ${appId}: ${deleteErr.message}`,
-        });
-        return null;
-      }
+      log({
+        level: "error",
+        phase: "refund",
+        step: rollbackErr ? "rollback_app_failed" : "delete_participant",
+        message: rollbackErr
+          ? `Participant delete failed and rollback also failed for app ${appId}: ${deleteErr.message}; rollback error: ${rollbackErr.message}`
+          : `Participant delete failed, reverted application ${appId}: ${deleteErr.message}`,
+      });
+      return null;
     }
 
     const assertion = await simAssertRefundProcessed(
@@ -225,13 +209,13 @@ export async function simRefundRequests(
         level: "info",
         phase: "refund",
         step: "refunded",
-        message: `App ${appId} refunded: ${refundCalc.refund_percentage}% (${refundCalc.refund_amount}/${paymentAmount}) via ${efSuccess ? "EF" : "direct"}`,
+        message: `App ${appId} refunded: ${refundCalc.refund_percentage}% (${refundCalc.refund_amount}/${paymentAmount}) via EF`,
         data: {
           appId,
           refund_percentage: refundCalc.refund_percentage,
           refund_amount: refundCalc.refund_amount,
           fee_amount: refundCalc.fee_amount,
-          via_ef: efSuccess,
+          via_ef: true,
         },
       });
     } else {

--- a/supabase/functions/backend-simulator/sim_refund_test.ts
+++ b/supabase/functions/backend-simulator/sim_refund_test.ts
@@ -446,7 +446,7 @@ Deno.test({
 // Tests: error cases — EF failure throws (no direct DB fallback)
 // ============================================================
 
-Deno.test("simRefundRequests - missing supabaseUrl → error logged, no refunds", async () => {
+Deno.test({ name: "simRefundRequests - missing supabaseUrl → error logged, no refunds", sanitizeOps: false, sanitizeResources: false, fn: async () => {
   const paymentAmount = 10000;
   const startTime = daysFromNow(30);
 
@@ -475,7 +475,7 @@ Deno.test("simRefundRequests - missing supabaseUrl → error logged, no refunds"
   assertEquals(result.refundedApplicationIds.length, 0);
   assertEquals(errors.length, 1);
   assertMatch(errors[0], /supabaseUrl\/anonKey required/);
-});
+}});
 
 Deno.test("simRefundRequests - missing payment_id → error logged, no refunds", async () => {
   const paymentAmount = 10000;

--- a/supabase/functions/backend-simulator/sim_refund_test.ts
+++ b/supabase/functions/backend-simulator/sim_refund_test.ts
@@ -1,10 +1,47 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertMatch } from "@std/assert";
 import { createMockSupabaseClient } from "../_test_utils/mock_supabase_client.ts";
+import { withMockedFetch } from "../_test_utils/mock_http.ts";
 import { simRefundRequests } from "./sim_refund.ts";
 import { simCalcRefund } from "./sim_assertions.ts";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 const noop = () => {};
+const SUPABASE_URL = "https://test.supabase.co";
+const ANON_KEY = "test-anon-key";
+
+/**
+ * Creates a fetch mock that handles:
+ *   - POST /auth/v1/token → returns a JWT (triggers supabase-js token refresh interval)
+ *   - POST /functions/v1/payment-cancel → returns configured response
+ *
+ * Tests that use this mock must set sanitizeOps: false to avoid interval leak
+ * failures caused by the supabase-js client's token refresh timer.
+ */
+function makeEfFetchMock(opts: {
+  paymentCancelStatus?: number;
+  paymentCancelBody?: unknown;
+} = {}) {
+  const { paymentCancelStatus = 200, paymentCancelBody = { success: true, data: {} } } = opts;
+
+  const fetchMock = async (input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    if (url.includes("/auth/v1/token")) {
+      return new Response(
+        JSON.stringify({ access_token: "mock-jwt", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: { id: "user-id" } }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (url.includes("/functions/v1/payment-cancel")) {
+      return new Response(
+        JSON.stringify(paymentCancelBody),
+        { status: paymentCancelStatus, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    throw new Error(`Unhandled fetch in test: ${url}`);
+  };
+
+  return fetchMock as typeof fetch;
+}
 
 function daysFromNow(days: number): string {
   const d = new Date();
@@ -17,6 +54,95 @@ function hoursFromNow(hours: number): string {
   d.setTime(d.getTime() + hours * 60 * 60 * 1000);
   return d.toISOString();
 }
+
+/**
+ * Builds a mock supabase client for the standard EF-based refund flow.
+ *
+ * The mock reflects post-EF DB state: refund_status and refund_amount are set
+ * by the EF (simulated via efRefundStatus/efRefundAmount in the select response).
+ * The sim itself then calls update({status:'cancelled'}) and delete on event_participants.
+ */
+function buildRefundMock(opts: {
+  paymentAmount: number;
+  startTime: string;
+  eventId: string;
+  userId: string;
+  username: string;
+  efRefundStatus: string;
+  efRefundAmount: number;
+}): {
+  mock: ReturnType<typeof createMockSupabaseClient>;
+  appStates: Record<string, { status?: string; refund_status?: string; refund_amount?: number }>;
+  deletedParticipants: Array<{ event_id: string; user_id: string }>;
+} {
+  const { paymentAmount, startTime, eventId, userId, username, efRefundStatus, efRefundAmount } = opts;
+
+  const appStates: Record<string, { status?: string; refund_status?: string; refund_amount?: number }> = {};
+  const deletedParticipants: Array<{ event_id: string; user_id: string }> = [];
+
+  const mock = createMockSupabaseClient({
+    tables: {
+      event_applications: {
+        select: ({ filters }) => {
+          const appId = filters["id"] as string;
+          const state = appStates[appId];
+          return {
+            data: {
+              id: appId,
+              payment_amount: paymentAmount,
+              payment_id: `pay-${appId}`,
+              event_id: eventId,
+              user_id: userId,
+              status: state?.status ?? "paid",
+              // After EF runs, DB has these values. Sim reads them for assertion.
+              refund_status: state?.refund_status ?? efRefundStatus,
+              refund_amount: state?.refund_amount ?? efRefundAmount,
+            },
+            error: null,
+          };
+        },
+        update: ({ values, filters }) => {
+          const appId = filters["id"] as string;
+          const v = values as Record<string, unknown>;
+          appStates[appId] = {
+            ...appStates[appId],
+            ...(v.status !== undefined ? { status: v.status as string } : {}),
+            ...(v.refund_status !== undefined ? { refund_status: v.refund_status as string } : {}),
+            ...(v.refund_amount !== undefined ? { refund_amount: v.refund_amount as number } : {}),
+          };
+          return { data: null, error: null };
+        },
+      },
+      events: {
+        select: () => ({
+          data: { id: eventId, start_time: startTime },
+          error: null,
+        }),
+      },
+      event_participants: {
+        delete: ({ filters }) => {
+          deletedParticipants.push({
+            event_id: filters["event_id"] as string,
+            user_id: filters["user_id"] as string,
+          });
+          return { data: null, error: null };
+        },
+      },
+      user_profiles: {
+        select: () => ({
+          data: { username },
+          error: null,
+        }),
+      },
+    },
+  });
+
+  return { mock, appStates, deletedParticipants };
+}
+
+// ============================================================
+// Tests: early-exit cases (no EF call needed)
+// ============================================================
 
 Deno.test("simRefundRequests - empty list returns empty result", async () => {
   const mock = createMockSupabaseClient({});
@@ -39,429 +165,414 @@ Deno.test("simRefundRequests - refundRate=0.0 → no refunds processed", async (
   assertEquals(result.assertions, []);
 });
 
-Deno.test("simRefundRequests - 100% refund (event +30 days) → refund_amount == payment_amount", async () => {
+// ============================================================
+// Tests: EF-only refund path
+// sanitizeOps: false required — supabase-js createClient starts a token refresh
+// interval after signIn succeeds, which outlives the test scope.
+// ============================================================
+
+Deno.test({
+  name: "simRefundRequests - 100% refund (event +30 days) → refund via EF",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const paymentAmount = 10000;
+    const startTime = daysFromNow(30);
+    const expectedCalc = simCalcRefund(new Date(startTime), paymentAmount, new Date());
+
+    assertEquals(expectedCalc.refund_percentage, 100);
+    assertEquals(expectedCalc.refund_amount, paymentAmount);
+
+    const { mock, appStates, deletedParticipants } = buildRefundMock({
+      paymentAmount,
+      startTime,
+      eventId: "event-30d",
+      userId: "user-1",
+      username: "user_001",
+      efRefundStatus: "completed",
+      efRefundAmount: paymentAmount,
+    });
+
+    const fetchMock = makeEfFetchMock();
+    const result = await withMockedFetch(fetchMock, () =>
+      simRefundRequests(
+        mock as unknown as SupabaseClient,
+        ["app-100pct"],
+        noop,
+        1.0,
+        SUPABASE_URL,
+        ANON_KEY,
+      )
+    );
+
+    assertEquals(result.refundedApplicationIds.length, 1);
+    assertEquals(result.refundedApplicationIds[0], "app-100pct");
+    // sim sets status='cancelled' after EF succeeds (EF does not touch status field)
+    assertEquals(appStates["app-100pct"].status, "cancelled");
+    // participant deleted explicitly (no DB trigger handles this on refund)
+    assertEquals(deletedParticipants.length, 1);
+    assertEquals(deletedParticipants[0].event_id, "event-30d");
+    assertEquals(deletedParticipants[0].user_id, "user-1");
+  },
+});
+
+Deno.test({
+  name: "simRefundRequests - 0% refund (event +5 days, binary policy) → refund_amount=0 via EF",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const paymentAmount = 10000;
+    const startTime = daysFromNow(5);
+    const expectedCalc = simCalcRefund(new Date(startTime), paymentAmount, new Date());
+
+    assertEquals(expectedCalc.refund_percentage, 0);
+    assertEquals(expectedCalc.refund_amount, 0);
+
+    const { mock, appStates } = buildRefundMock({
+      paymentAmount,
+      startTime,
+      eventId: "event-5d",
+      userId: "user-1",
+      username: "user_001",
+      efRefundStatus: "failed",
+      efRefundAmount: 0,
+    });
+
+    const fetchMock = makeEfFetchMock();
+    const result = await withMockedFetch(fetchMock, () =>
+      simRefundRequests(
+        mock as unknown as SupabaseClient,
+        ["app-0pct-5d"],
+        noop,
+        1.0,
+        SUPABASE_URL,
+        ANON_KEY,
+      )
+    );
+
+    assertEquals(result.refundedApplicationIds.length, 1);
+    assertEquals(appStates["app-0pct-5d"].status, "cancelled");
+  },
+});
+
+Deno.test({
+  name: "simRefundRequests - 0% refund (event +2 days, binary policy) → refund_amount=0 via EF",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const paymentAmount = 9999;
+    const startTime = daysFromNow(2);
+    const expectedCalc = simCalcRefund(new Date(startTime), paymentAmount, new Date());
+
+    assertEquals(expectedCalc.refund_percentage, 0);
+    assertEquals(expectedCalc.refund_amount, 0);
+
+    const { mock, appStates } = buildRefundMock({
+      paymentAmount,
+      startTime,
+      eventId: "event-2d",
+      userId: "user-1",
+      username: "user_001",
+      efRefundStatus: "failed",
+      efRefundAmount: 0,
+    });
+
+    const fetchMock = makeEfFetchMock();
+    const result = await withMockedFetch(fetchMock, () =>
+      simRefundRequests(
+        mock as unknown as SupabaseClient,
+        ["app-0pct-2d"],
+        noop,
+        1.0,
+        SUPABASE_URL,
+        ANON_KEY,
+      )
+    );
+
+    assertEquals(result.assertions.length, 1);
+    assertEquals(appStates["app-0pct-2d"].status, "cancelled");
+  },
+});
+
+Deno.test({
+  name: "simRefundRequests - 0% refund (+12 hours) → refund_amount=0 via EF",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const paymentAmount = 10000;
+    const startTime = hoursFromNow(12);
+    const expectedCalc = simCalcRefund(new Date(startTime), paymentAmount, new Date());
+
+    assertEquals(expectedCalc.refund_percentage, 0);
+    assertEquals(expectedCalc.refund_amount, 0);
+
+    const { mock, appStates, deletedParticipants } = buildRefundMock({
+      paymentAmount,
+      startTime,
+      eventId: "event-12h",
+      userId: "user-1",
+      username: "user_001",
+      efRefundStatus: "failed",
+      efRefundAmount: 0,
+    });
+
+    const fetchMock = makeEfFetchMock();
+    await withMockedFetch(fetchMock, () =>
+      simRefundRequests(
+        mock as unknown as SupabaseClient,
+        ["app-0pct-12h"],
+        noop,
+        1.0,
+        SUPABASE_URL,
+        ANON_KEY,
+      )
+    );
+
+    assertEquals(appStates["app-0pct-12h"].status, "cancelled");
+    assertEquals(deletedParticipants.length, 1);
+  },
+});
+
+Deno.test({
+  name: "simRefundRequests - participant is deleted after EF succeeds",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const paymentAmount = 5000;
+    const startTime = daysFromNow(30);
+
+    const { mock, deletedParticipants } = buildRefundMock({
+      paymentAmount,
+      startTime,
+      eventId: "event-del",
+      userId: "user-del",
+      username: "user_del",
+      efRefundStatus: "completed",
+      efRefundAmount: paymentAmount,
+    });
+
+    const fetchMock = makeEfFetchMock();
+    await withMockedFetch(fetchMock, () =>
+      simRefundRequests(
+        mock as unknown as SupabaseClient,
+        ["app-del-1"],
+        noop,
+        1.0,
+        SUPABASE_URL,
+        ANON_KEY,
+      )
+    );
+
+    assertEquals(deletedParticipants.length, 1);
+    assertEquals(deletedParticipants[0].event_id, "event-del");
+    assertEquals(deletedParticipants[0].user_id, "user-del");
+  },
+});
+
+Deno.test({
+  name: "simRefundRequests - 20% of 5 apps → 1 refunded via EF",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const paymentAmount = 10000;
+    const startTime = daysFromNow(30);
+    const appIds = ["app-a", "app-b", "app-c", "app-d", "app-e"];
+    const cancelledApps: string[] = [];
+
+    const mock = createMockSupabaseClient({
+      tables: {
+        event_applications: {
+          select: ({ filters }) => {
+            const appId = filters["id"] as string;
+            const wasCancelled = cancelledApps.includes(appId);
+            return {
+              data: {
+                id: appId,
+                payment_amount: paymentAmount,
+                payment_id: `pay-${appId}`,
+                event_id: "event-20pct",
+                user_id: "user-1",
+                status: wasCancelled ? "cancelled" : "paid",
+                refund_status: wasCancelled ? "completed" : "none",
+                refund_amount: wasCancelled ? paymentAmount : 0,
+              },
+              error: null,
+            };
+          },
+          update: ({ values, filters }) => {
+            const appId = filters["id"] as string;
+            const v = values as Record<string, unknown>;
+            if (v.status === "cancelled") cancelledApps.push(appId);
+            return { data: null, error: null };
+          },
+        },
+        events: {
+          select: () => ({
+            data: { id: "event-20pct", start_time: startTime },
+            error: null,
+          }),
+        },
+        event_participants: {
+          delete: () => ({ data: null, error: null }),
+        },
+        user_profiles: {
+          select: () => ({
+            data: { username: "user_001" },
+            error: null,
+          }),
+        },
+      },
+    });
+
+    const fetchMock = makeEfFetchMock();
+    const result = await withMockedFetch(fetchMock, () =>
+      simRefundRequests(
+        mock as unknown as SupabaseClient,
+        appIds,
+        noop,
+        0.2,
+        SUPABASE_URL,
+        ANON_KEY,
+      )
+    );
+
+    assertEquals(result.refundedApplicationIds.length, 1);
+    assertEquals(cancelledApps.length, 1);
+    assertEquals(cancelledApps[0], "app-a");
+  },
+});
+
+// ============================================================
+// Tests: error cases — EF failure throws (no direct DB fallback)
+// ============================================================
+
+Deno.test("simRefundRequests - missing supabaseUrl → error logged, no refunds", async () => {
   const paymentAmount = 10000;
   const startTime = daysFromNow(30);
-  const expectedCalc = simCalcRefund(new Date(startTime), paymentAmount, new Date());
 
-  assertEquals(expectedCalc.refund_percentage, 100);
-  assertEquals(expectedCalc.refund_amount, paymentAmount);
-
-  const appStates: Record<string, { status: string; refund_status: string; refund_amount: number }> = {};
-  const deletedParticipants: Array<{ event_id: string; user_id: string }> = [];
-
-  const mock = createMockSupabaseClient({
-    tables: {
-      event_applications: {
-        select: ({ filters }) => {
-          const appId = filters["id"] as string;
-          const state = appStates[appId];
-          if (state) {
-            return {
-              data: {
-                id: appId,
-                payment_amount: paymentAmount,
-                event_id: "event-30d",
-                user_id: "user-1",
-                status: state.status,
-                refund_status: state.refund_status,
-                refund_amount: state.refund_amount,
-              },
-              error: null,
-            };
-          }
-          return {
-            data: {
-              id: appId,
-              payment_amount: paymentAmount,
-              event_id: "event-30d",
-              user_id: "user-1",
-              status: "paid",
-              refund_status: "none",
-              refund_amount: 0,
-            },
-            error: null,
-          };
-        },
-        update: ({ values, filters }) => {
-          const appId = filters["id"] as string;
-          const v = values as { status: string; refund_status: string; refund_amount: number };
-          appStates[appId] = { status: v.status, refund_status: v.refund_status, refund_amount: v.refund_amount };
-          return { data: null, error: null };
-        },
-      },
-      events: {
-        select: () => ({
-          data: { id: "event-30d", start_time: startTime },
-          error: null,
-        }),
-      },
-      event_participants: {
-        delete: ({ filters }) => {
-          deletedParticipants.push({
-            event_id: filters["event_id"] as string,
-            user_id: filters["user_id"] as string,
-          });
-          return { data: null, error: null };
-        },
-      },
-    },
+  const { mock } = buildRefundMock({
+    paymentAmount,
+    startTime,
+    eventId: "event-err",
+    userId: "user-1",
+    username: "user_001",
+    efRefundStatus: "none",
+    efRefundAmount: 0,
   });
 
+  const errors: string[] = [];
   const result = await simRefundRequests(
     mock as unknown as SupabaseClient,
-    ["app-100pct"],
-    noop,
+    ["app-no-url"],
+    (entry) => {
+      if (entry.level === "error") errors.push(entry.message);
+    },
     1.0,
+    undefined, // supabaseUrl omitted → must throw
+    ANON_KEY,
   );
 
-  assertEquals(result.refundedApplicationIds.length, 1);
-  assertEquals(result.refundedApplicationIds[0], "app-100pct");
-  assertEquals(appStates["app-100pct"].status, "cancelled");
-  assertEquals(appStates["app-100pct"].refund_status, "completed");
-  assertEquals(appStates["app-100pct"].refund_amount, paymentAmount);
-  assertEquals(deletedParticipants.length, 1);
+  assertEquals(result.refundedApplicationIds.length, 0);
+  assertEquals(errors.length, 1);
+  assertMatch(errors[0], /supabaseUrl\/anonKey required/);
 });
 
-Deno.test("simRefundRequests - 0% refund (event +5 days, binary policy) → refund_amount=0", async () => {
+Deno.test("simRefundRequests - missing payment_id → error logged, no refunds", async () => {
   const paymentAmount = 10000;
-  const startTime = daysFromNow(5);
-  const expectedCalc = simCalcRefund(new Date(startTime), paymentAmount, new Date());
-
-  assertEquals(expectedCalc.refund_percentage, 0);
-  assertEquals(expectedCalc.refund_amount, 0);
-
-  const appStates: Record<string, { status: string; refund_status: string; refund_amount: number }> = {};
-
-  const mock = createMockSupabaseClient({
-    tables: {
-      event_applications: {
-        select: ({ filters }) => {
-          const appId = filters["id"] as string;
-          const state = appStates[appId];
-          if (state) {
-            return {
-              data: {
-                id: appId,
-                payment_amount: paymentAmount,
-                event_id: "event-5d",
-                user_id: "user-1",
-                status: state.status,
-                refund_status: state.refund_status,
-                refund_amount: state.refund_amount,
-              },
-              error: null,
-            };
-          }
-          return {
-            data: {
-              id: appId,
-              payment_amount: paymentAmount,
-              event_id: "event-5d",
-              user_id: "user-1",
-              status: "paid",
-              refund_status: "none",
-              refund_amount: 0,
-            },
-            error: null,
-          };
-        },
-        update: ({ values, filters }) => {
-          const appId = filters["id"] as string;
-          const v = values as { status: string; refund_status: string; refund_amount: number };
-          appStates[appId] = { status: v.status, refund_status: v.refund_status, refund_amount: v.refund_amount };
-          return { data: null, error: null };
-        },
-      },
-      events: {
-        select: () => ({
-          data: { id: "event-5d", start_time: startTime },
-          error: null,
-        }),
-      },
-      event_participants: {
-        delete: () => ({ data: null, error: null }),
-      },
-    },
-  });
-
-  const result = await simRefundRequests(
-    mock as unknown as SupabaseClient,
-    ["app-80pct"],
-    noop,
-    1.0,
-  );
-
-  // Fix #1a: 0%-refund assertion now passes (refund_status='failed' is valid for 0% case)
-  // So the application IS counted as processed (refundedApplicationIds.length === 1)
-  assertEquals(result.refundedApplicationIds.length, 1);
-  assertEquals(appStates["app-80pct"].refund_status, "failed");
-  assertEquals(appStates["app-80pct"].refund_amount, 0);
-});
-
-Deno.test("simRefundRequests - 0% refund (event +2 days, binary policy) → refund_amount=0", async () => {
-  const paymentAmount = 9999;
-  const startTime = daysFromNow(2);
-  const expectedCalc = simCalcRefund(new Date(startTime), paymentAmount, new Date());
-
-  assertEquals(expectedCalc.refund_percentage, 0);
-  assertEquals(expectedCalc.refund_amount, 0);
-
-  const appStates: Record<string, { status: string; refund_status: string; refund_amount: number }> = {};
-
-  const mock = createMockSupabaseClient({
-    tables: {
-      event_applications: {
-        select: ({ filters }) => {
-          const appId = filters["id"] as string;
-          const state = appStates[appId];
-          if (state) {
-            return {
-              data: {
-                id: appId,
-                payment_amount: paymentAmount,
-                event_id: "event-2d",
-                user_id: "user-1",
-                status: state.status,
-                refund_status: state.refund_status,
-                refund_amount: state.refund_amount,
-              },
-              error: null,
-            };
-          }
-          return {
-            data: {
-              id: appId,
-              payment_amount: paymentAmount,
-              event_id: "event-2d",
-              user_id: "user-1",
-              status: "paid",
-              refund_status: "none",
-              refund_amount: 0,
-            },
-            error: null,
-          };
-        },
-        update: ({ values, filters }) => {
-          const appId = filters["id"] as string;
-          const v = values as { status: string; refund_status: string; refund_amount: number };
-          appStates[appId] = { status: v.status, refund_status: v.refund_status, refund_amount: v.refund_amount };
-          return { data: null, error: null };
-        },
-      },
-      events: {
-        select: () => ({
-          data: { id: "event-2d", start_time: startTime },
-          error: null,
-        }),
-      },
-      event_participants: {
-        delete: () => ({ data: null, error: null }),
-      },
-    },
-  });
-
-  const result = await simRefundRequests(
-    mock as unknown as SupabaseClient,
-    ["app-50pct"],
-    noop,
-    1.0,
-  );
-
-  assertEquals(result.assertions.length, 1);
-  assertEquals(appStates["app-50pct"].status, "cancelled");
-  assertEquals(appStates["app-50pct"].refund_status, "failed");
-  assertEquals(appStates["app-50pct"].refund_amount, 0);
-});
-
-Deno.test("simRefundRequests - 0% refund (+12 hours) → refund_amount=0, status='failed'", async () => {
-  const paymentAmount = 10000;
-  const startTime = hoursFromNow(12);
-  const expectedCalc = simCalcRefund(new Date(startTime), paymentAmount, new Date());
-
-  assertEquals(expectedCalc.refund_percentage, 0);
-  assertEquals(expectedCalc.refund_amount, 0);
-
-  const appStates: Record<string, { status: string; refund_status: string; refund_amount: number }> = {};
-  const deletedParticipants: Array<{ event_id: string; user_id: string }> = [];
-
-  const mock = createMockSupabaseClient({
-    tables: {
-      event_applications: {
-        select: ({ filters }) => {
-          const appId = filters["id"] as string;
-          const state = appStates[appId];
-          if (state) {
-            return {
-              data: {
-                id: appId,
-                payment_amount: paymentAmount,
-                event_id: "event-12h",
-                user_id: "user-1",
-                status: state.status,
-                refund_status: state.refund_status,
-                refund_amount: state.refund_amount,
-              },
-              error: null,
-            };
-          }
-          return {
-            data: {
-              id: appId,
-              payment_amount: paymentAmount,
-              event_id: "event-12h",
-              user_id: "user-1",
-              status: "paid",
-              refund_status: "none",
-              refund_amount: 0,
-            },
-            error: null,
-          };
-        },
-        update: ({ values, filters }) => {
-          const appId = filters["id"] as string;
-          const v = values as { status: string; refund_status: string; refund_amount: number };
-          appStates[appId] = { status: v.status, refund_status: v.refund_status, refund_amount: v.refund_amount };
-          return { data: null, error: null };
-        },
-      },
-      events: {
-        select: () => ({
-          data: { id: "event-12h", start_time: startTime },
-          error: null,
-        }),
-      },
-      event_participants: {
-        delete: ({ filters }) => {
-          deletedParticipants.push({
-            event_id: filters["event_id"] as string,
-            user_id: filters["user_id"] as string,
-          });
-          return { data: null, error: null };
-        },
-      },
-    },
-  });
-
-  await simRefundRequests(
-    mock as unknown as SupabaseClient,
-    ["app-0pct"],
-    noop,
-    1.0,
-  );
-
-  assertEquals(appStates["app-0pct"].status, "cancelled");
-  assertEquals(appStates["app-0pct"].refund_status, "failed");
-  assertEquals(appStates["app-0pct"].refund_amount, 0);
-  assertEquals(deletedParticipants.length, 1);
-});
-
-Deno.test("simRefundRequests - participant is deleted when refund_percentage > 0", async () => {
-  const paymentAmount = 5000;
   const startTime = daysFromNow(30);
-  const deletedParticipants: Array<{ event_id: string; user_id: string }> = [];
 
   const mock = createMockSupabaseClient({
     tables: {
       event_applications: {
-        select: ({ filters }) => {
-          const appId = filters["id"] as string;
-          return {
-            data: {
-              id: appId,
-              payment_amount: paymentAmount,
-              event_id: "event-del",
-              user_id: "user-del",
-              status: "paid",
-              refund_status: "none",
-              refund_amount: 0,
-            },
-            error: null,
-          };
-        },
+        select: ({ filters }) => ({
+          data: {
+            id: filters["id"] as string,
+            payment_amount: paymentAmount,
+            payment_id: null, // no payment_id → must throw
+            event_id: "event-no-pid",
+            user_id: "user-1",
+            status: "paid",
+            refund_status: "none",
+            refund_amount: 0,
+          },
+          error: null,
+        }),
         update: () => ({ data: null, error: null }),
       },
       events: {
         select: () => ({
-          data: { id: "event-del", start_time: startTime },
-          error: null,
-        }),
-      },
-      event_participants: {
-        delete: ({ filters }) => {
-          deletedParticipants.push({
-            event_id: filters["event_id"] as string,
-            user_id: filters["user_id"] as string,
-          });
-          return { data: null, error: null };
-        },
-      },
-    },
-  });
-
-  await simRefundRequests(
-    mock as unknown as SupabaseClient,
-    ["app-del-1"],
-    noop,
-    1.0,
-  );
-
-  assertEquals(deletedParticipants.length, 1);
-  assertEquals(deletedParticipants[0].event_id, "event-del");
-  assertEquals(deletedParticipants[0].user_id, "user-del");
-});
-
-Deno.test("simRefundRequests - 20% of 5 apps → 1 refunded", async () => {
-  const paymentAmount = 10000;
-  const startTime = daysFromNow(30);
-  const appIds = ["app-a", "app-b", "app-c", "app-d", "app-e"];
-  const updatedApps: string[] = [];
-
-  const mock = createMockSupabaseClient({
-    tables: {
-      event_applications: {
-        select: ({ filters }) => {
-          const appId = filters["id"] as string;
-          const wasUpdated = updatedApps.includes(appId);
-          return {
-            data: {
-              id: appId,
-              payment_amount: paymentAmount,
-              event_id: "event-20pct",
-              user_id: "user-1",
-              status: wasUpdated ? "cancelled" : "paid",
-              refund_status: wasUpdated ? "completed" : "none",
-              refund_amount: wasUpdated ? paymentAmount : 0,
-            },
-            error: null,
-          };
-        },
-        update: ({ filters }) => {
-          const appId = filters["id"] as string;
-          updatedApps.push(appId);
-          return { data: null, error: null };
-        },
-      },
-      events: {
-        select: () => ({
-          data: { id: "event-20pct", start_time: startTime },
+          data: { id: "event-no-pid", start_time: startTime },
           error: null,
         }),
       },
       event_participants: {
         delete: () => ({ data: null, error: null }),
       },
+      user_profiles: {
+        select: () => ({ data: { username: "user_001" }, error: null }),
+      },
     },
   });
 
+  const errors: string[] = [];
   const result = await simRefundRequests(
     mock as unknown as SupabaseClient,
-    appIds,
-    noop,
-    0.2,
+    ["app-no-pid"],
+    (entry) => {
+      if (entry.level === "error") errors.push(entry.message);
+    },
+    1.0,
+    SUPABASE_URL,
+    ANON_KEY,
   );
 
-  assertEquals(result.refundedApplicationIds.length, 1);
-  assertEquals(updatedApps.length, 1);
-  assertEquals(updatedApps[0], "app-a");
+  assertEquals(result.refundedApplicationIds.length, 0);
+  assertEquals(errors.length, 1);
+  assertMatch(errors[0], /payment_id is null/);
+});
+
+Deno.test({
+  name: "simRefundRequests - EF returns non-200 → error logged, no refunds, no DB fallback",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const paymentAmount = 10000;
+    const startTime = daysFromNow(30);
+
+    const { mock, appStates } = buildRefundMock({
+      paymentAmount,
+      startTime,
+      eventId: "event-ef-fail",
+      userId: "user-1",
+      username: "user_001",
+      efRefundStatus: "none",
+      efRefundAmount: 0,
+    });
+
+    const fetchMock = makeEfFetchMock({
+      paymentCancelStatus: 500,
+      paymentCancelBody: { error: "internal error" },
+    });
+
+    const errors: string[] = [];
+    const result = await withMockedFetch(fetchMock, () =>
+      simRefundRequests(
+        mock as unknown as SupabaseClient,
+        ["app-ef-fail"],
+        (entry) => {
+          if (entry.level === "error") errors.push(entry.message);
+        },
+        1.0,
+        SUPABASE_URL,
+        ANON_KEY,
+      )
+    );
+
+    // No refunds succeed — error thrown, no direct DB fallback
+    assertEquals(result.refundedApplicationIds.length, 0);
+    assertEquals(errors.length, 1);
+    assertMatch(errors[0], /payment-cancel EF returned 500/);
+    // No status update was written to DB
+    assertEquals(appStates["app-ef-fail"], undefined);
+  },
 });


### PR DESCRIPTION
Scheduler: needs-arch-claude-team-1

Closes #1280

## Summary

- **sim_approve.ts**: Direct DB fallback 제거. 인증 심사(approve/reject)는 `partner-review-submission` EF만 사용. 인증 불필요 승인은 `partner-approve-application` EF 사용. Rejection은 reject EF 미존재로 direct DB 유지 (주석 표기).
- **sim_refund.ts**: `payment-cancel` EF가 유일한 환불 경로. Direct DB fallback 전면 제거. EF 성공 후 application status 업데이트 + participant 삭제는 기존 유지 (트리거/EF 미지원).
- **테스트**: sim_approve 9개 + sim_refund 11개 = 20개 전체 통과. EF mock 기반으로 전환.

## Changed files

| 파일 | 변경 |
|------|------|
| `sim_approve.ts` | verification review fallback 제거, no-verif approve → EF 전환 |
| `sim_approve_test.ts` | EF mock 기반 재작성 + 신규 3개 |
| `sim_refund.ts` | refund fallback 제거, EF-only 경로 |
| `sim_refund_test.ts` | EF mock 기반 재작성 + 신규 3개 |

## Test plan

- [x] `sim_approve_test.ts` 9개 전체 통과
- [x] `sim_refund_test.ts` 11개 전체 통과
- [ ] CI `test-edge-functions` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)