### PR TITLE
fix(simulator): EF-first 전환 — verification/reject/refund direct DB 제거 (#1326, #1327, #1328)

### DIFF
--- a/supabase/functions/backend-simulator/sim_approve.ts
+++ b/supabase/functions/backend-simulator/sim_approve.ts
@@ -7,7 +7,7 @@ import {
   simAssertApplicationApproved,
   simAssertApplicationRejected,
 } from "./sim_assertions.ts";
-import { getSimPartnerToken, getPartnerEmail, callEdgeFunction } from "./sim_auth.ts";
+import { getSimUserToken, getSimPartnerToken, getPartnerEmail, callEdgeFunction } from "./sim_auth.ts";
 
 export interface SimApproveResult {
   approvedApplicationIds: string[];
@@ -75,28 +75,44 @@ export async function simApproveVerifications(
       }
 
       if (verificationId && partnerId) {
-        // Verification flow: insert submission → call partner-review-submission EF
-        const submissionId = crypto.randomUUID();
-        const { error: insErr } = await supabase.from("verification_submissions").insert({
-          id: submissionId,
+        // Verification flow: call user-submit-verification EF → call partner-review-submission EF
+        // Fix #1326: user-submit-verification EF로 전환 — direct DB insert 제거
+        if (!supabaseUrl || !anonKey) {
+          throw new Error(`App ${appId}: supabaseUrl/anonKey required for user-submit-verification EF`);
+        }
+        const simUserPassword = Deno.env.get("SIM_USER_PASSWORD") ?? "password1234!";
+
+        const { data: profileData } = await supabase
+          .from("user_profiles")
+          .select("username")
+          .eq("id", userId)
+          .maybeSingle();
+        const username = (profileData as { username?: string } | null)?.username;
+        if (!username || username.startsWith("partner_")) {
+          throw new Error(`App ${appId}: no valid user username (got: ${username ?? "null"}), cannot call user-submit-verification EF`);
+        }
+        const userEmail = `${username}@test.com`;
+        const userToken = await getSimUserToken(supabaseUrl, anonKey, userEmail, simUserPassword);
+        const submitResult = await callEdgeFunction(supabaseUrl, "user-submit-verification", {
+          action: "submit",
           partner_id: partnerId,
-          user_id: userId,
           verification_id: verificationId,
           application_id: appId,
-          status: "pending",
-          snapshot_data: {},
-        });
-        if (insErr) {
-          log({ level: "error", phase: "approve", step: "insert_submission", message: `Failed to insert submission for app ${appId}: ${insErr.message}` });
-          continue;
+        }, userToken);
+        if (submitResult.status !== 200 && submitResult.status !== 201) {
+          throw new Error(`user-submit-verification EF returned ${submitResult.status} for app ${appId}`);
         }
+
+        // Retrieve the submission_id from EF response to pass to partner-review-submission
+        // deno-lint-ignore no-explicit-any
+        const submissionId: string = (submitResult.data as any)?.submission_id ?? (submitResult.data as any)?.id;
+        if (!submissionId) {
+          throw new Error(`user-submit-verification EF did not return submission_id for app ${appId}`);
+        }
+        log({ level: "info", phase: "approve", step: "ef_submit_verification", message: `Submitted verification ${submissionId} via EF for app ${appId}` });
 
         // Call partner-review-submission EF — no fallback. EF is the only path.
         // Fix #1280: remove direct DB fallback; EF failure is always an error.
-        if (!supabaseUrl || !anonKey) {
-          throw new Error(`App ${appId}: supabaseUrl/anonKey required for partner-review-submission EF`);
-        }
-        const simUserPassword = Deno.env.get("SIM_USER_PASSWORD") ?? "password1234!";
         const partnerEmail = await getPartnerEmail(supabase, partnerId);
         if (!partnerEmail) {
           throw new Error(`Partner email not found for partner ${partnerId} (submission ${submissionId}, app ${appId})`);
@@ -183,28 +199,44 @@ export async function simApproveVerifications(
       }
 
       if (verificationId && partnerId) {
-        // Verification flow: insert submission → call partner-review-submission EF
-        const submissionId = crypto.randomUUID();
-        const { error: insErr } = await supabase.from("verification_submissions").insert({
-          id: submissionId,
+        // Verification flow: call user-submit-verification EF → call partner-review-submission EF
+        // Fix #1326: user-submit-verification EF로 전환 — direct DB insert 제거
+        if (!supabaseUrl || !anonKey) {
+          throw new Error(`App ${appId}: supabaseUrl/anonKey required for user-submit-verification EF`);
+        }
+        const simUserPassword = Deno.env.get("SIM_USER_PASSWORD") ?? "password1234!";
+
+        const { data: profileData } = await supabase
+          .from("user_profiles")
+          .select("username")
+          .eq("id", userId)
+          .maybeSingle();
+        const username = (profileData as { username?: string } | null)?.username;
+        if (!username || username.startsWith("partner_")) {
+          throw new Error(`App ${appId}: no valid user username (got: ${username ?? "null"}), cannot call user-submit-verification EF`);
+        }
+        const userEmail = `${username}@test.com`;
+        const userToken = await getSimUserToken(supabaseUrl, anonKey, userEmail, simUserPassword);
+        const submitResult = await callEdgeFunction(supabaseUrl, "user-submit-verification", {
+          action: "submit",
           partner_id: partnerId,
-          user_id: userId,
           verification_id: verificationId,
           application_id: appId,
-          status: "pending",
-          snapshot_data: {},
-        });
-        if (insErr) {
-          log({ level: "error", phase: "approve", step: "insert_submission", message: `Failed to insert submission for app ${appId}: ${insErr.message}` });
-          continue;
+        }, userToken);
+        if (submitResult.status !== 200 && submitResult.status !== 201) {
+          throw new Error(`user-submit-verification EF returned ${submitResult.status} for app ${appId}`);
         }
+
+        // Retrieve the submission_id from EF response to pass to partner-review-submission
+        // deno-lint-ignore no-explicit-any
+        const submissionId: string = (submitResult.data as any)?.submission_id ?? (submitResult.data as any)?.id;
+        if (!submissionId) {
+          throw new Error(`user-submit-verification EF did not return submission_id for app ${appId}`);
+        }
+        log({ level: "info", phase: "approve", step: "ef_submit_verification", message: `Submitted verification ${submissionId} via EF for app ${appId}` });
 
         // Call partner-review-submission EF — no fallback. EF is the only path.
         // Fix #1280: remove direct DB fallback; EF failure is always an error.
-        if (!supabaseUrl || !anonKey) {
-          throw new Error(`App ${appId}: supabaseUrl/anonKey required for partner-review-submission EF`);
-        }
-        const simUserPassword = Deno.env.get("SIM_USER_PASSWORD") ?? "password1234!";
         const partnerEmail = await getPartnerEmail(supabase, partnerId);
         if (!partnerEmail) {
           throw new Error(`Partner email not found for partner ${partnerId} (submission ${submissionId}, app ${appId})`);
@@ -231,27 +263,34 @@ export async function simApproveVerifications(
           log({ level: "warn", phase: "approve", step: "rejected", message: `App ${appId} rejection assertion failed: ${appAssertion.details}` });
         }
       } else {
-        // No verification needed: reject via direct DB update.
-        // Fix #1280: partner-approve-application EF does not support a "reject" action,
-        // and there is no partner-reject-application EF. Direct DB update is intentional
-        // until a dedicated reject EF is introduced.
-        const { error: updErr } = await supabase
-          .from("event_applications")
-          .update({ status: "rejected" })
-          .eq("id", appId);
-        if (updErr) {
-          log({ level: "error", phase: "approve", step: "direct_reject", message: `Failed to directly reject app ${appId}: ${updErr.message}` });
-          continue;
+        // No verification needed: reject via partner-reject-application EF
+        // Fix #1328: partner-reject-application EF 호출 — direct DB update 제거
+        if (!supabaseUrl || !anonKey) {
+          throw new Error(`App ${appId}: supabaseUrl/anonKey required for partner-reject-application EF`);
         }
+        const simUserPassword = Deno.env.get("SIM_USER_PASSWORD") ?? "password1234!";
+        const partnerEmail = partnerId ? await getPartnerEmail(supabase, partnerId) : null;
+        if (!partnerEmail) {
+          throw new Error(`Partner email not found for partner ${partnerId} (app ${appId})`);
+        }
+        const partnerToken = await getSimPartnerToken(supabaseUrl, anonKey, partnerEmail, simUserPassword);
+        const efResult = await callEdgeFunction(supabaseUrl, "partner-reject-application", {
+          application_id: appId,
+          reason: "[E2E] 시뮬레이션 거부",
+        }, partnerToken);
+        if (efResult.status !== 200) {
+          throw new Error(`partner-reject-application EF returned ${efResult.status} for app ${appId}`);
+        }
+        log({ level: "info", phase: "approve", step: "ef_direct_reject", message: `Rejected app ${appId} via partner-reject-application EF` });
 
         const appAssertion = await simAssertApplicationRejected(supabase, appId);
         assertions.push(appAssertion);
 
         if (appAssertion.passed) {
           rejectedApplicationIds.push(appId);
-          log({ level: "info", phase: "approve", step: "rejected", message: `App ${appId} directly rejected (no verification required, no reject EF available)` });
+          log({ level: "info", phase: "approve", step: "rejected", message: `App ${appId} directly rejected via EF (no verification required)` });
         } else {
-          log({ level: "warn", phase: "approve", step: "rejected", message: `App ${appId} direct rejection assertion failed: ${appAssertion.details}` });
+          log({ level: "warn", phase: "approve", step: "rejected", message: `App ${appId} EF rejection assertion failed: ${appAssertion.details}` });
         }
       }
     } catch (e) {

--- a/supabase/functions/backend-simulator/sim_approve_test.ts
+++ b/supabase/functions/backend-simulator/sim_approve_test.ts
@@ -100,25 +100,9 @@ Deno.test({
         },
         events: { select: makeEventSelectHandler() },
         verifications: { select: makeVerificationSelectHandler("verif-1") },
-        verification_submissions: {
-          insert: ({ values }: { values: unknown }) => {
-            const v = values as { id: string; application_id: string };
-            subAppMap[v.id] = v.application_id;
-            return { data: null, error: null };
-          },
-          select: ({ filters }: { filters: Record<string, unknown> }) => {
-            const subId = filters["id"] as string;
-            return {
-              data: {
-                id: subId,
-                status: "approved",
-                partner_id: "partner-1",
-                user_id: "user-1",
-                verification_id: "verif-1",
-              },
-              error: null,
-            };
-          },
+        // Fix #1326: user-submit-verification EF로 전환 — verification_submissions 직접 insert 제거
+        user_profiles: {
+          select: () => ({ data: { username: "user_001" }, error: null }),
         },
         partner_verified_users: {
           select: () => ({ data: { id: "pvu-1" }, error: null }),
@@ -134,6 +118,13 @@ Deno.test({
             JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }),
             { status: 200 },
           );
+        }
+        // Fix #1326: user-submit-verification EF mock — returns submission_id
+        if (url.includes("user-submit-verification")) {
+          const body = JSON.parse((init.body as string) ?? "{}");
+          const subId = `sub-${body.application_id as string}`;
+          subAppMap[subId] = body.application_id as string;
+          return new Response(JSON.stringify({ submission_id: subId }), { status: 200 });
         }
         if (url.includes("partner-review-submission")) {
           // Simulate EF approving/rejecting — update app status via side effect
@@ -193,25 +184,9 @@ Deno.test({
         },
         events: { select: makeEventSelectHandler() },
         verifications: { select: makeVerificationSelectHandler("verif-1") },
-        verification_submissions: {
-          insert: ({ values }: { values: unknown }) => {
-            const v = values as { id: string; application_id: string };
-            subAppMap[v.id] = v.application_id;
-            return { data: null, error: null };
-          },
-          select: ({ filters }: { filters: Record<string, unknown> }) => {
-            const subId = filters["id"] as string;
-            return {
-              data: {
-                id: subId,
-                status: appStatuses[subAppMap[subId]] ?? "approved",
-                partner_id: "partner-1",
-                user_id: "user-1",
-                verification_id: "verif-1",
-              },
-              error: null,
-            };
-          },
+        // Fix #1326: user-submit-verification EF로 전환 — verification_submissions 직접 insert 제거
+        user_profiles: {
+          select: () => ({ data: { username: "user_001" }, error: null }),
         },
         partner_verified_users: {
           select: () => ({ data: { id: "pvu-1" }, error: null }),
@@ -227,6 +202,13 @@ Deno.test({
             JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }),
             { status: 200 },
           );
+        }
+        // Fix #1326: user-submit-verification EF mock — returns submission_id
+        if (url.includes("user-submit-verification")) {
+          const body = JSON.parse((init.body as string) ?? "{}");
+          const subId = `sub-${body.application_id as string}`;
+          subAppMap[subId] = body.application_id as string;
+          return new Response(JSON.stringify({ submission_id: subId }), { status: 200 });
         }
         if (url.includes("partner-review-submission")) {
           const body = JSON.parse((init.body as string) ?? "{}");
@@ -283,25 +265,9 @@ Deno.test({
         },
         events: { select: makeEventSelectHandler() },
         verifications: { select: makeVerificationSelectHandler("verif-1") },
-        verification_submissions: {
-          insert: ({ values }: { values: unknown }) => {
-            const v = values as { id: string; application_id: string };
-            subAppMap[v.id] = v.application_id;
-            return { data: null, error: null };
-          },
-          select: ({ filters }: { filters: Record<string, unknown> }) => {
-            const subId = filters["id"] as string;
-            return {
-              data: {
-                id: subId,
-                status: appStatuses[subAppMap[subId]] ?? "rejected",
-                partner_id: "partner-1",
-                user_id: "user-1",
-                verification_id: "verif-1",
-              },
-              error: null,
-            };
-          },
+        // Fix #1326: user-submit-verification EF로 전환 — verification_submissions 직접 insert 제거
+        user_profiles: {
+          select: () => ({ data: { username: "user_001" }, error: null }),
         },
         partner_verified_users: {
           select: () => ({ data: { id: "pvu-1" }, error: null }),
@@ -317,6 +283,13 @@ Deno.test({
             JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }),
             { status: 200 },
           );
+        }
+        // Fix #1326: user-submit-verification EF mock — returns submission_id
+        if (url.includes("user-submit-verification")) {
+          const body = JSON.parse((init.body as string) ?? "{}");
+          const subId = `sub-${body.application_id as string}`;
+          subAppMap[subId] = body.application_id as string;
+          return new Response(JSON.stringify({ submission_id: subId }), { status: 200 });
         }
         if (url.includes("partner-review-submission")) {
           const body = JSON.parse((init.body as string) ?? "{}");
@@ -387,9 +360,9 @@ Deno.test({
         },
         events: { select: makeEventSelectHandler() },
         verifications: { select: makeVerificationSelectHandler("verif-1") },
-        verification_submissions: {
-          insert: () => ({ data: null, error: null }),
-          select: () => ({ data: { id: "sub-1", status: "pending" }, error: null }),
+        // Fix #1326: user-submit-verification EF로 전환 — verification_submissions 직접 insert 제거
+        user_profiles: {
+          select: () => ({ data: { username: "user_001" }, error: null }),
         },
       }),
     });
@@ -401,12 +374,17 @@ Deno.test({
 
     Deno.env.set("SIM_USER_PASSWORD", "test-password");
     try {
-      await withMockFetch((url) => {
+      await withMockFetch((url, init) => {
         if (url.includes("auth/v1/token")) {
           return new Response(
             JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }),
             { status: 200 },
           );
+        }
+        // Fix #1326: user-submit-verification EF mock — succeeds so partner-review-submission is reached
+        if (url.includes("user-submit-verification")) {
+          const body = JSON.parse((init.body as string) ?? "{}");
+          return new Response(JSON.stringify({ submission_id: `sub-${body.application_id as string}` }), { status: 200 });
         }
         // EF returns 500 — should not fall back, should throw
         if (url.includes("partner-review-submission")) {
@@ -456,21 +434,26 @@ Deno.test({
         },
         events: { select: makeEventSelectHandler() },
         verifications: { select: makeVerificationSelectHandler("verif-1") },
-        verification_submissions: {
-          insert: () => ({ data: null, error: null }),
-          select: () => ({ data: { id: "sub-1", status: "pending" }, error: null }),
+        // Fix #1326: user-submit-verification EF로 전환 — verification_submissions 직접 insert 제거
+        user_profiles: {
+          select: () => ({ data: { username: "user_001" }, error: null }),
         },
       }),
     });
 
     Deno.env.set("SIM_USER_PASSWORD", "test-password");
     try {
-      await withMockFetch((url) => {
+      await withMockFetch((url, init) => {
         if (url.includes("auth/v1/token")) {
           return new Response(
             JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }),
             { status: 200 },
           );
+        }
+        // Fix #1326: user-submit-verification EF mock — succeeds so partner-review-submission is reached
+        if (url.includes("user-submit-verification")) {
+          const body = JSON.parse((init.body as string) ?? "{}");
+          return new Response(JSON.stringify({ submission_id: `sub-${body.application_id as string}` }), { status: 200 });
         }
         if (url.includes("partner-review-submission")) {
           return new Response(JSON.stringify({ error: "internal" }), { status: 500 });
@@ -588,63 +571,88 @@ Deno.test({
   },
 });
 
-// Fix #1280: no-verification reject path remains direct DB (no reject EF available).
-Deno.test("simApproveVerifications - no verification needed: reject uses direct DB update", async () => {
-  const appIds = ["app-rej-1", "app-rej-2"];
-  const appStatuses: Record<string, string> = {};
+// Fix #1328: no-verification reject path now uses partner-reject-application EF.
+Deno.test({
+  name: "simApproveVerifications - no verification needed: reject uses partner-reject-application EF",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const appIds = ["app-rej-1", "app-rej-2"];
+    const appStatuses: Record<string, string> = {};
+    const efRejectIds: string[] = [];
 
-  const mock = createMockSupabaseClient({
-    tables: {
-      event_applications: {
-        select: ({ filters }: { filters: Record<string, unknown> }) => {
-          const appId = filters["id"] as string;
-          return {
+    const mock = createMockSupabaseClient({
+      ...makePartnerEmailMockOptions({
+        event_applications: {
+          select: ({ filters }: { filters: Record<string, unknown> }) => {
+            const appId = filters["id"] as string;
+            return {
+              data: {
+                id: appId,
+                event_id: "event-1",
+                ticket_id: "ticket-1",
+                user_id: "user-1",
+                status: appStatuses[appId] ?? "pending_review",
+              },
+              error: null,
+            };
+          },
+        },
+        events: {
+          select: () => ({
             data: {
-              id: appId,
-              event_id: "event-1",
-              ticket_id: "ticket-1",
-              user_id: "user-1",
-              status: appStatuses[appId] ?? "pending_review",
+              id: "event-1",
+              parties: {
+                partner_id: "partner-1",
+                required_verification_ids: [],
+              },
             },
             error: null,
-          };
+          }),
         },
-        update: ({ values, filters }: { values: unknown; filters: Record<string, unknown> }) => {
-          const appId = filters["id"] as string;
-          const v = values as { status: string };
-          appStatuses[appId] = v.status;
-          return { data: null, error: null };
+        verifications: {
+          select: makeVerificationSelectHandler(null),
         },
-      },
-      events: {
-        select: () => ({
-          data: {
-            id: "event-1",
-            parties: {
-              partner_id: "partner-1",
-              required_verification_ids: [],
-            },
-          },
-          error: null,
-        }),
-      },
-      verifications: {
-        select: makeVerificationSelectHandler(null),
-      },
-    },
-  });
+      }),
+    });
 
-  // approveRate=0.0 → all apps go to reject path (no EF available → direct DB)
-  // No supabaseUrl/anonKey needed since reject has no EF call
-  const result = await simApproveVerifications(
-    mock as unknown as SupabaseClient,
-    appIds,
-    noop,
-    0.0,
-  );
+    Deno.env.set("SIM_USER_PASSWORD", "test-password");
+    try {
+      await withMockFetch((url, init) => {
+        if (url.includes("auth/v1/token")) {
+          return new Response(
+            JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }),
+            { status: 200 },
+          );
+        }
+        // Fix #1328: partner-reject-application EF mock
+        if (url.includes("partner-reject-application")) {
+          const body = JSON.parse((init.body as string) ?? "{}");
+          const appId = body.application_id as string;
+          efRejectIds.push(appId);
+          appStatuses[appId] = "rejected";
+          return new Response(JSON.stringify({ success: true }), { status: 200 });
+        }
+        return new Response(JSON.stringify({}), { status: 404 });
+      }, async () => {
+        // approveRate=0.0 → all apps go to reject path → partner-reject-application EF
+        const result = await simApproveVerifications(
+          mock as unknown as SupabaseClient,
+          appIds,
+          noop,
+          0.0,
+          "https://mock.supabase.co",
+          "anon-key",
+        );
 
-  assertEquals(result.approvedApplicationIds.length, 0);
-  assertEquals(result.rejectedApplicationIds.length, 2);
-  assertEquals(appStatuses["app-rej-1"], "rejected");
-  assertEquals(appStatuses["app-rej-2"], "rejected");
+        assertEquals(result.approvedApplicationIds.length, 0);
+        assertEquals(result.rejectedApplicationIds.length, 2);
+        // EF was called for both apps
+        assertEquals(efRejectIds.includes("app-rej-1"), true);
+        assertEquals(efRejectIds.includes("app-rej-2"), true);
+      });
+    } finally {
+      Deno.env.delete("SIM_USER_PASSWORD");
+    }
+  },
 });

--- a/supabase/functions/backend-simulator/sim_refund.ts
+++ b/supabase/functions/backend-simulator/sim_refund.ts
@@ -14,15 +14,13 @@ export interface SimRefundResult {
  * Simulates refund requests for a subset of paid applications.
  *
  * For each selected application:
- *   1. Fetch payment_amount + payment_id + event_id + user_id from event_applications
+ *   1. Fetch payment_amount + event_id + user_id from event_applications
  *   2. Fetch start_time from events
  *   3. Calculate refund using simCalcRefund()
- *   4. Call payment-cancel EF (the only refund path — no direct DB fallback)
- *   5. Update event_applications: status='cancelled' (EF sets refund_status/refund_amount)
- *   6. DELETE event_participants (no DB trigger handles this on refund)
- *   7. Assert refund processed correctly
+ *   4. Call user-cancel-order EF (handles cancellation, refund, and participant cleanup atomically)
+ *   5. Assert refund processed correctly
  *
- * Fix #1280: Remove direct DB fallback for refund. payment-cancel EF is now the sole
+ * Fix #1327: Replace payment-cancel EF + direct DB with user-cancel-order EF as the sole
  * refund path. EF failure throws regardless of strict mode.
  */
 export async function simRefundRequests(
@@ -113,14 +111,10 @@ export async function simRefundRequests(
 
     const refundCalc = simCalcRefund(startTime, paymentAmount, new Date(), null, 2, 7);
 
-    // Fix #1280: payment-cancel EF is the only refund path. No direct DB fallback.
-    // Missing credentials or payment_id → throw immediately.
+    // Fix #1327: user-cancel-order EF로 전환 — payment-cancel 사용 중단 + direct DB 제거
+    // user-cancel-order EF handles cancellation, refund, participant cleanup atomically.
     if (!supabaseUrl || !anonKey) {
-      throw new Error(`App ${appId}: supabaseUrl/anonKey required for payment-cancel EF`);
-    }
-
-    if (!paymentId) {
-      throw new Error(`App ${appId}: payment_id is null, cannot call payment-cancel EF`);
+      throw new Error(`App ${appId}: supabaseUrl/anonKey required for user-cancel-order EF`);
     }
 
     // Look up user email from user_profiles
@@ -132,70 +126,26 @@ export async function simRefundRequests(
     const username = (profileData as { username?: string } | null)?.username;
 
     if (!username || username.startsWith("partner_")) {
-      throw new Error(`App ${appId}: no valid user username (got: ${username ?? "null"}), cannot call payment-cancel EF`);
+      throw new Error(`App ${appId}: no valid user username (got: ${username ?? "null"}), cannot call user-cancel-order EF`);
     }
 
     const userEmail = `${username}@test.com`;
     const userToken = await getSimUserToken(supabaseUrl, anonKey, userEmail, simUserPassword);
-    const efResult = await callEdgeFunction(supabaseUrl, "payment-cancel", {
-      payment_id: paymentId,
-      reason: "[E2E] 시뮬레이션 환불",
-      amount: refundCalc.refund_amount > 0 ? refundCalc.refund_amount : undefined,
+    const efResult = await callEdgeFunction(supabaseUrl, "user-cancel-order", {
+      event_id: eventId,
     }, userToken);
 
     if (efResult.status !== 200) {
-      throw new Error(`App ${appId}: payment-cancel EF returned ${efResult.status}`);
+      throw new Error(`user-cancel-order EF returned ${efResult.status} for app ${appId}`);
     }
 
     log({
       level: "info",
       phase: "refund",
       step: "ef_cancel",
-      message: `payment-cancel EF succeeded for app ${appId}`,
-      data: { appId, paymentId, efStatus: efResult.status },
+      message: `user-cancel-order EF succeeded for app ${appId}`,
+      data: { appId, eventId, efStatus: efResult.status },
     });
-
-    // EF sets refund_status and refund_amount. Update status='cancelled' separately,
-    // since payment-cancel EF does not touch the status field.
-    const { error: updateErr } = await supabase
-      .from("event_applications")
-      .update({ status: "cancelled" })
-      .eq("id", appId);
-
-    if (updateErr) {
-      log({
-        level: "error",
-        phase: "refund",
-        step: "update_app_status",
-        message: `Failed to set status=cancelled for app ${appId}: ${updateErr.message}`,
-      });
-      return null;
-    }
-
-    // Delete participant. No DB trigger handles this on refund — must be done explicitly.
-    const { error: deleteErr } = await supabase
-      .from("event_participants")
-      .delete()
-      .eq("event_id", eventId)
-      .eq("user_id", userId);
-
-    if (deleteErr) {
-      // Rollback: participant delete failed — revert application status to avoid cancelled-but-has-participant state
-      // Fix #507: capture rollback error to avoid masking failures
-      const { error: rollbackErr } = await supabase
-        .from("event_applications")
-        .update({ status: "paid" })
-        .eq("id", appId);
-      log({
-        level: "error",
-        phase: "refund",
-        step: rollbackErr ? "rollback_app_failed" : "delete_participant",
-        message: rollbackErr
-          ? `Participant delete failed and rollback also failed for app ${appId}: ${deleteErr.message}; rollback error: ${rollbackErr.message}`
-          : `Participant delete failed, reverted application ${appId}: ${deleteErr.message}`,
-      });
-      return null;
-    }
 
     const assertion = await simAssertRefundProcessed(
       supabase,

--- a/supabase/functions/backend-simulator/sim_refund_test.ts
+++ b/supabase/functions/backend-simulator/sim_refund_test.ts
@@ -12,16 +12,17 @@ const ANON_KEY = "test-anon-key";
 /**
  * Creates a fetch mock that handles:
  *   - POST /auth/v1/token → returns a JWT (triggers supabase-js token refresh interval)
- *   - POST /functions/v1/payment-cancel → returns configured response
+ *   - POST /functions/v1/user-cancel-order → returns configured response
  *
+ * Fix #1327: payment-cancel EF → user-cancel-order EF로 전환.
  * Tests that use this mock must set sanitizeOps: false to avoid interval leak
  * failures caused by the supabase-js client's token refresh timer.
  */
 function makeEfFetchMock(opts: {
-  paymentCancelStatus?: number;
-  paymentCancelBody?: unknown;
+  cancelOrderStatus?: number;
+  cancelOrderBody?: unknown;
 } = {}) {
-  const { paymentCancelStatus = 200, paymentCancelBody = { success: true, data: {} } } = opts;
+  const { cancelOrderStatus = 200, cancelOrderBody = { success: true, data: {} } } = opts;
 
   const fetchMock = async (input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
@@ -31,10 +32,11 @@ function makeEfFetchMock(opts: {
         { status: 200, headers: { "Content-Type": "application/json" } },
       );
     }
-    if (url.includes("/functions/v1/payment-cancel")) {
+    // Fix #1327: user-cancel-order EF mock (replaces payment-cancel)
+    if (url.includes("/functions/v1/user-cancel-order")) {
       return new Response(
-        JSON.stringify(paymentCancelBody),
-        { status: paymentCancelStatus, headers: { "Content-Type": "application/json" } },
+        JSON.stringify(cancelOrderBody),
+        { status: cancelOrderStatus, headers: { "Content-Type": "application/json" } },
       );
     }
     throw new Error(`Unhandled fetch in test: ${url}`);
@@ -58,9 +60,12 @@ function hoursFromNow(hours: number): string {
 /**
  * Builds a mock supabase client for the standard EF-based refund flow.
  *
+ * Fix #1327: user-cancel-order EF handles cancellation, refund, and participant cleanup
+ * atomically. The sim no longer calls event_applications.update or event_participants.delete
+ * directly — those are now done by the EF.
+ *
  * The mock reflects post-EF DB state: refund_status and refund_amount are set
  * by the EF (simulated via efRefundStatus/efRefundAmount in the select response).
- * The sim itself then calls update({status:'cancelled'}) and delete on event_participants.
  */
 function buildRefundMock(opts: {
   paymentAmount: number;
@@ -73,12 +78,10 @@ function buildRefundMock(opts: {
 }): {
   mock: ReturnType<typeof createMockSupabaseClient>;
   appStates: Record<string, { status?: string; refund_status?: string; refund_amount?: number }>;
-  deletedParticipants: Array<{ event_id: string; user_id: string }>;
 } {
   const { paymentAmount, startTime, eventId, userId, username, efRefundStatus, efRefundAmount } = opts;
 
   const appStates: Record<string, { status?: string; refund_status?: string; refund_amount?: number }> = {};
-  const deletedParticipants: Array<{ event_id: string; user_id: string }> = [];
 
   const mock = createMockSupabaseClient({
     tables: {
@@ -119,15 +122,6 @@ function buildRefundMock(opts: {
           error: null,
         }),
       },
-      event_participants: {
-        delete: ({ filters }) => {
-          deletedParticipants.push({
-            event_id: filters["event_id"] as string,
-            user_id: filters["user_id"] as string,
-          });
-          return { data: null, error: null };
-        },
-      },
       user_profiles: {
         select: () => ({
           data: { username },
@@ -137,7 +131,7 @@ function buildRefundMock(opts: {
     },
   });
 
-  return { mock, appStates, deletedParticipants };
+  return { mock, appStates };
 }
 
 // ============================================================
@@ -183,7 +177,7 @@ Deno.test({
     assertEquals(expectedCalc.refund_percentage, 100);
     assertEquals(expectedCalc.refund_amount, paymentAmount);
 
-    const { mock, appStates, deletedParticipants } = buildRefundMock({
+    const { mock } = buildRefundMock({
       paymentAmount,
       startTime,
       eventId: "event-30d",
@@ -207,12 +201,8 @@ Deno.test({
 
     assertEquals(result.refundedApplicationIds.length, 1);
     assertEquals(result.refundedApplicationIds[0], "app-100pct");
-    // sim sets status='cancelled' after EF succeeds (EF does not touch status field)
-    assertEquals(appStates["app-100pct"].status, "cancelled");
-    // participant deleted explicitly (no DB trigger handles this on refund)
-    assertEquals(deletedParticipants.length, 1);
-    assertEquals(deletedParticipants[0].event_id, "event-30d");
-    assertEquals(deletedParticipants[0].user_id, "user-1");
+    // Fix #1327: user-cancel-order EF handles status update + participant cleanup atomically
+    // The sim no longer calls event_applications.update or event_participants.delete directly.
   },
 });
 
@@ -228,7 +218,7 @@ Deno.test({
     assertEquals(expectedCalc.refund_percentage, 0);
     assertEquals(expectedCalc.refund_amount, 0);
 
-    const { mock, appStates } = buildRefundMock({
+    const { mock } = buildRefundMock({
       paymentAmount,
       startTime,
       eventId: "event-5d",
@@ -250,8 +240,8 @@ Deno.test({
       )
     );
 
+    // Fix #1327: user-cancel-order EF handles status update atomically; sim does not update DB directly
     assertEquals(result.refundedApplicationIds.length, 1);
-    assertEquals(appStates["app-0pct-5d"].status, "cancelled");
   },
 });
 
@@ -267,7 +257,7 @@ Deno.test({
     assertEquals(expectedCalc.refund_percentage, 0);
     assertEquals(expectedCalc.refund_amount, 0);
 
-    const { mock, appStates } = buildRefundMock({
+    const { mock } = buildRefundMock({
       paymentAmount,
       startTime,
       eventId: "event-2d",
@@ -289,8 +279,8 @@ Deno.test({
       )
     );
 
+    // Fix #1327: user-cancel-order EF handles status update atomically; sim does not update DB directly
     assertEquals(result.assertions.length, 1);
-    assertEquals(appStates["app-0pct-2d"].status, "cancelled");
   },
 });
 
@@ -306,7 +296,7 @@ Deno.test({
     assertEquals(expectedCalc.refund_percentage, 0);
     assertEquals(expectedCalc.refund_amount, 0);
 
-    const { mock, appStates, deletedParticipants } = buildRefundMock({
+    const { mock } = buildRefundMock({
       paymentAmount,
       startTime,
       eventId: "event-12h",
@@ -317,7 +307,7 @@ Deno.test({
     });
 
     const fetchMock = makeEfFetchMock();
-    await withMockedFetch(fetchMock, () =>
+    const result = await withMockedFetch(fetchMock, () =>
       simRefundRequests(
         mock as unknown as SupabaseClient,
         ["app-0pct-12h"],
@@ -328,20 +318,22 @@ Deno.test({
       )
     );
 
-    assertEquals(appStates["app-0pct-12h"].status, "cancelled");
-    assertEquals(deletedParticipants.length, 1);
+    // Fix #1327: user-cancel-order EF handles status update + participant cleanup atomically
+    assertEquals(result.refundedApplicationIds.length, 1);
   },
 });
 
+// Fix #1327: participant cleanup is now handled atomically by user-cancel-order EF.
+// The sim no longer calls event_participants.delete directly.
 Deno.test({
-  name: "simRefundRequests - participant is deleted after EF succeeds",
+  name: "simRefundRequests - EF succeeds → refund recorded (participant cleanup handled by EF)",
   sanitizeOps: false,
   sanitizeResources: false,
   fn: async () => {
     const paymentAmount = 5000;
     const startTime = daysFromNow(30);
 
-    const { mock, deletedParticipants } = buildRefundMock({
+    const { mock } = buildRefundMock({
       paymentAmount,
       startTime,
       eventId: "event-del",
@@ -352,7 +344,7 @@ Deno.test({
     });
 
     const fetchMock = makeEfFetchMock();
-    await withMockedFetch(fetchMock, () =>
+    const result = await withMockedFetch(fetchMock, () =>
       simRefundRequests(
         mock as unknown as SupabaseClient,
         ["app-del-1"],
@@ -363,9 +355,9 @@ Deno.test({
       )
     );
 
-    assertEquals(deletedParticipants.length, 1);
-    assertEquals(deletedParticipants[0].event_id, "event-del");
-    assertEquals(deletedParticipants[0].user_id, "user-del");
+    // EF handles participant cleanup atomically — sim only records the refund result
+    assertEquals(result.refundedApplicationIds.length, 1);
+    assertEquals(result.refundedApplicationIds[0], "app-del-1");
   },
 });
 
@@ -377,14 +369,12 @@ Deno.test({
     const paymentAmount = 10000;
     const startTime = daysFromNow(30);
     const appIds = ["app-a", "app-b", "app-c", "app-d", "app-e"];
-    const cancelledApps: string[] = [];
 
     const mock = createMockSupabaseClient({
       tables: {
         event_applications: {
           select: ({ filters }) => {
             const appId = filters["id"] as string;
-            const wasCancelled = cancelledApps.includes(appId);
             return {
               data: {
                 id: appId,
@@ -392,28 +382,21 @@ Deno.test({
                 payment_id: `pay-${appId}`,
                 event_id: "event-20pct",
                 user_id: "user-1",
-                status: wasCancelled ? "cancelled" : "paid",
-                refund_status: wasCancelled ? "completed" : "none",
-                refund_amount: wasCancelled ? paymentAmount : 0,
+                status: "paid",
+                // Fix #1327: EF sets these values; sim reads them for assertion
+                refund_status: "completed",
+                refund_amount: paymentAmount,
               },
               error: null,
             };
           },
-          update: ({ values, filters }) => {
-            const appId = filters["id"] as string;
-            const v = values as Record<string, unknown>;
-            if (v.status === "cancelled") cancelledApps.push(appId);
-            return { data: null, error: null };
-          },
+          update: () => ({ data: null, error: null }),
         },
         events: {
           select: () => ({
             data: { id: "event-20pct", start_time: startTime },
             error: null,
           }),
-        },
-        event_participants: {
-          delete: () => ({ data: null, error: null }),
         },
         user_profiles: {
           select: () => ({
@@ -436,9 +419,9 @@ Deno.test({
       )
     );
 
+    // Fix #1327: only 1 app (20% of 5) processed; EF handles status update atomically
     assertEquals(result.refundedApplicationIds.length, 1);
-    assertEquals(cancelledApps.length, 1);
-    assertEquals(cancelledApps[0], "app-a");
+    assertEquals(result.refundedApplicationIds[0], "app-a");
   },
 });
 
@@ -477,7 +460,9 @@ Deno.test({ name: "simRefundRequests - missing supabaseUrl → error logged, no 
   assertMatch(errors[0], /supabaseUrl\/anonKey required/);
 }});
 
-Deno.test("simRefundRequests - missing payment_id → error logged, no refunds", async () => {
+// Fix #1327: payment_id is no longer validated by sim (user-cancel-order EF uses event_id).
+// Instead test that a partner username (starts with "partner_") triggers an error.
+Deno.test("simRefundRequests - partner username → error logged, no refunds", async () => {
   const paymentAmount = 10000;
   const startTime = daysFromNow(30);
 
@@ -488,8 +473,8 @@ Deno.test("simRefundRequests - missing payment_id → error logged, no refunds",
           data: {
             id: filters["id"] as string,
             payment_amount: paymentAmount,
-            payment_id: null, // no payment_id → must throw
-            event_id: "event-no-pid",
+            payment_id: `pay-${filters["id"] as string}`,
+            event_id: "event-partner-user",
             user_id: "user-1",
             status: "paid",
             refund_status: "none",
@@ -501,15 +486,13 @@ Deno.test("simRefundRequests - missing payment_id → error logged, no refunds",
       },
       events: {
         select: () => ({
-          data: { id: "event-no-pid", start_time: startTime },
+          data: { id: "event-partner-user", start_time: startTime },
           error: null,
         }),
       },
-      event_participants: {
-        delete: () => ({ data: null, error: null }),
-      },
       user_profiles: {
-        select: () => ({ data: { username: "user_001" }, error: null }),
+        // Fix #1327: partner_ username is rejected — user-cancel-order EF requires a real user
+        select: () => ({ data: { username: "partner_001" }, error: null }),
       },
     },
   });
@@ -517,7 +500,7 @@ Deno.test("simRefundRequests - missing payment_id → error logged, no refunds",
   const errors: string[] = [];
   const result = await simRefundRequests(
     mock as unknown as SupabaseClient,
-    ["app-no-pid"],
+    ["app-partner-user"],
     (entry) => {
       if (entry.level === "error") errors.push(entry.message);
     },
@@ -528,7 +511,7 @@ Deno.test("simRefundRequests - missing payment_id → error logged, no refunds",
 
   assertEquals(result.refundedApplicationIds.length, 0);
   assertEquals(errors.length, 1);
-  assertMatch(errors[0], /payment_id is null/);
+  assertMatch(errors[0], /no valid user username/);
 });
 
 Deno.test({
@@ -549,9 +532,10 @@ Deno.test({
       efRefundAmount: 0,
     });
 
+    // Fix #1327: payment-cancel → user-cancel-order EF
     const fetchMock = makeEfFetchMock({
-      paymentCancelStatus: 500,
-      paymentCancelBody: { error: "internal error" },
+      cancelOrderStatus: 500,
+      cancelOrderBody: { error: "internal error" },
     });
 
     const errors: string[] = [];
@@ -571,7 +555,8 @@ Deno.test({
     // No refunds succeed — error thrown, no direct DB fallback
     assertEquals(result.refundedApplicationIds.length, 0);
     assertEquals(errors.length, 1);
-    assertMatch(errors[0], /payment-cancel EF returned 500/);
+    // Fix #1327: error message updated to reflect user-cancel-order EF
+    assertMatch(errors[0], /user-cancel-order EF returned 500/);
     // No status update was written to DB
     assertEquals(appStates["app-ef-fail"], undefined);
   },


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1326, closes #1327, closes #1328

## Summary
- **#1326**: `sim_approve.ts`의 `verification_submissions` direct insert를 `user-submit-verification` EF 호출로 교체
- **#1327**: `sim_refund.ts`의 `payment-cancel` + direct DB를 `user-cancel-order` EF 1개로 교체
- **#1328**: `sim_approve.ts`의 거부 direct DB update를 `partner-reject-application` EF로 교체

## Test plan
- [ ] Simulator 실행 시 EF 호출 경로 사용 확인
- [ ] CI test-edge-functions 통과 (해당 시 적용)