### PR TITLE
test(app_user): IT-U05 매칭 투표 → 결과 확인 통합 테스트 추가

### DIFF
--- a/apps/app_user/test/integration/cuj_matching_vote_test.dart
+++ b/apps/app_user/test/integration/cuj_matching_vote_test.dart
@@ -33,6 +33,7 @@ void main() {
     int maxVoteCount = 3,
     Set<String> votedIds = const {},
     bool metaHasError = false,
+    MatchingVoteController Function()? controllerFactory,
   }) {
     return ProviderScope(
       overrides: [
@@ -60,7 +61,9 @@ void main() {
             return votedIds;
           },
         ),
-        matchingVoteControllerProvider.overrideWith(_FakeVoteController.new),
+        matchingVoteControllerProvider.overrideWith(
+          controllerFactory ?? _FakeVoteController.new,
+        ),
       ],
       child: MaterialApp(
         theme: MinglitTheme.materialTheme,
@@ -167,7 +170,8 @@ void main() {
       expect(find.text('투표하기'), findsNothing);
     });
 
-    testWidgets('투표 버튼 탭 → 확인 다이얼로그 표시', (tester) async {
+    testWidgets('투표 버튼 탭 → 확인 다이얼로그 표시 + 투표하기 탭 → vote() 호출', (tester) async {
+      final spy = _SpyVoteController();
       final candidates = [
         const UserProfile(id: 'u1', name: '정수아', username: ''),
       ];
@@ -175,16 +179,21 @@ void main() {
       await tester.pumpWidget(
         buildVoteContent(
           candidates: candidates,
+          controllerFactory: () => spy,
         ),
       );
       await tester.pumpAndSettle();
 
-      // '선택' 버튼 탭
+      // '선택' 버튼 탭 → 확인 다이얼로그 표시
       await tester.tap(find.text('선택'));
       await tester.pumpAndSettle();
-
-      // 투표 확인 다이얼로그에 '투표하기' 버튼이 나타남
       expect(find.text('투표하기'), findsOneWidget);
+
+      // '투표하기' 탭 → vote() 실제 호출 검증
+      await tester.tap(find.text('투표하기'));
+      await tester.pumpAndSettle();
+      expect(spy.wasVoteCalled, isTrue);
+      expect(spy.lastCandidateId, 'u1');
     });
   });
 }
@@ -198,6 +207,25 @@ class _FakeVoteController extends MatchingVoteController {
     required String eventId,
     required String candidateId,
   }) async {
+    state = const AsyncData(null);
+  }
+}
+
+/// Spy controller that records vote() calls for assertion in tests.
+class _SpyVoteController extends MatchingVoteController {
+  bool wasVoteCalled = false;
+  String? lastCandidateId;
+
+  @override
+  FutureOr<void> build() {}
+
+  @override
+  Future<void> vote({
+    required String eventId,
+    required String candidateId,
+  }) async {
+    wasVoteCalled = true;
+    lastCandidateId = candidateId;
     state = const AsyncData(null);
   }
 }

--- a/apps/app_user/test/integration/cuj_matching_vote_test.dart
+++ b/apps/app_user/test/integration/cuj_matching_vote_test.dart
@@ -1,0 +1,201 @@
+// Ref #1312: IT-U05 — 매칭 투표 → 결과 확인 통합 테스트
+//
+// 검증 포인트:
+// 1. 빈 후보자 목록 — 안내 문구 표시
+// 2. 후보자 목록 렌더링 — 이름 표시
+// 3. 잔여 투표 수 표시 — 남은 투표 카운터
+// 4. 투표 완료 상태 — 투표 완료! 배지 표시
+// 5. 매칭 성공 시 — 매칭 성공 섹션 표시
+// 6. 매칭 없음 — 매칭 성공 섹션 미표시
+// 7. 투표 메타 에러 — 에러 안내 표시
+// 8. 이미 투표한 후보 — 투표 완료 버튼 비활성화
+// 9. 투표 버튼 탭 → 확인 다이얼로그 표시
+import 'dart:async';
+
+import 'package:app_user/src/common/widgets/matching_vote_content.dart';
+import 'package:app_user/src/features/event/matching/matching_vote_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+const _testEventId = 'test-event-u05';
+
+void main() {
+  setUpAll(() async {
+    await initializeDateFormatting('ko_KR');
+  });
+
+  Widget buildVoteContent({
+    List<UserProfile> candidates = const [],
+    List<MatchPair> matches = const [],
+    int voteCount = 0,
+    int maxVoteCount = 3,
+    Set<String> votedIds = const {},
+    bool metaHasError = false,
+  }) {
+    return ProviderScope(
+      overrides: [
+        matchCandidatesProvider(_testEventId).overrideWith(
+          (ref) async => candidates,
+        ),
+        myMatchesProvider(_testEventId).overrideWith(
+          (ref) async => matches,
+        ),
+        myVoteCountProvider(_testEventId).overrideWith(
+          (ref) async {
+            if (metaHasError) throw Exception('vote meta error');
+            return voteCount;
+          },
+        ),
+        maxVoteCountProvider(_testEventId).overrideWith(
+          (ref) async {
+            if (metaHasError) throw Exception('vote meta error');
+            return maxVoteCount;
+          },
+        ),
+        myVotedCandidateIdsProvider(_testEventId).overrideWith(
+          (ref) async {
+            if (metaHasError) throw Exception('vote meta error');
+            return votedIds;
+          },
+        ),
+        matchingVoteControllerProvider.overrideWith(_FakeVoteController.new),
+      ],
+      child: MaterialApp(
+        theme: MinglitTheme.materialTheme,
+        home: const Scaffold(
+          body: MatchingVoteContent(eventId: _testEventId),
+        ),
+      ),
+    );
+  }
+
+  group('IT-U05: 매칭 투표 → 결과 확인', () {
+    testWidgets('빈 후보자 목록 — 안내 문구 표시', (tester) async {
+      await tester.pumpWidget(buildVoteContent());
+      await tester.pumpAndSettle();
+
+      expect(find.text('투표 가능한 상대가 없습니다.'), findsOneWidget);
+    });
+
+    testWidgets('후보자 목록 렌더링 — 이름 표시', (tester) async {
+      final candidates = [
+        const UserProfile(id: 'u1', name: '박민준', username: ''),
+        const UserProfile(id: 'u2', name: '이서연', username: ''),
+      ];
+
+      await tester.pumpWidget(buildVoteContent(candidates: candidates));
+      await tester.pumpAndSettle();
+
+      expect(find.text('박민준'), findsOneWidget);
+      expect(find.text('이서연'), findsOneWidget);
+    });
+
+    testWidgets('잔여 투표 수 표시 — 남은 투표 카운터', (tester) async {
+      await tester.pumpWidget(
+        buildVoteContent(voteCount: 1, maxVoteCount: 3),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('남은 투표: 2/3'), findsOneWidget);
+    });
+
+    testWidgets('투표 완료 상태 — 투표 완료! 배지 표시', (tester) async {
+      await tester.pumpWidget(
+        buildVoteContent(voteCount: 3, maxVoteCount: 3),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('투표 완료!'), findsOneWidget);
+    });
+
+    testWidgets('매칭 성공 시 — 매칭 성공 섹션 표시', (tester) async {
+      final matches = [
+        MatchPair(
+          matchId: 'm1',
+          eventId: _testEventId,
+          partnerId: 'p1',
+          matchedAt: DateTime(2026, 4, 1),
+          partnerName: '김지우',
+        ),
+      ];
+
+      await tester.pumpWidget(buildVoteContent(matches: matches));
+      await tester.pumpAndSettle();
+
+      expect(find.text('매칭 성공! (1명)'), findsOneWidget);
+      expect(find.text('김지우'), findsOneWidget);
+    });
+
+    testWidgets('매칭 없음 — 매칭 성공 섹션 미표시', (tester) async {
+      await tester.pumpWidget(buildVoteContent());
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('매칭 성공'), findsNothing);
+    });
+
+    testWidgets('투표 메타 에러 — 에러 안내 표시', (tester) async {
+      await tester.pumpWidget(buildVoteContent(metaHasError: true));
+      await tester.pumpAndSettle();
+
+      expect(find.text('투표 정보를 불러올 수 없습니다.'), findsOneWidget);
+    });
+
+    testWidgets('이미 투표한 후보 — 투표 완료 버튼 비활성화', (tester) async {
+      final candidates = [
+        const UserProfile(id: 'u1', name: '최준혁', username: ''),
+      ];
+
+      await tester.pumpWidget(
+        buildVoteContent(
+          candidates: candidates,
+          votedIds: {'u1'},
+          voteCount: 1,
+          maxVoteCount: 3,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // 이미 투표한 후보는 '투표 완료' 버튼 텍스트 표시 (비활성화)
+      expect(find.text('투표 완료'), findsOneWidget);
+      // '선택' 버튼은 없음
+      expect(find.text('선택'), findsNothing);
+    });
+
+    testWidgets('투표 버튼 탭 → 확인 다이얼로그 표시', (tester) async {
+      final candidates = [
+        const UserProfile(id: 'u1', name: '정수아', username: ''),
+      ];
+
+      await tester.pumpWidget(
+        buildVoteContent(
+          candidates: candidates,
+          voteCount: 0,
+          maxVoteCount: 3,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // '선택' 버튼 탭
+      await tester.tap(find.text('선택'));
+      await tester.pumpAndSettle();
+
+      // 투표 확인 다이얼로그에 '투표하기' 버튼이 나타남
+      expect(find.text('투표하기'), findsOneWidget);
+    });
+  });
+}
+
+class _FakeVoteController extends MatchingVoteController {
+  @override
+  FutureOr<void> build() {}
+
+  @override
+  Future<void> vote({
+    required String eventId,
+    required String candidateId,
+  }) async {
+    state = const AsyncData(null);
+  }
+}

--- a/apps/app_user/test/integration/cuj_matching_vote_test.dart
+++ b/apps/app_user/test/integration/cuj_matching_vote_test.dart
@@ -94,7 +94,7 @@ void main() {
 
     testWidgets('잔여 투표 수 표시 — 남은 투표 카운터', (tester) async {
       await tester.pumpWidget(
-        buildVoteContent(voteCount: 1, maxVoteCount: 3),
+        buildVoteContent(voteCount: 1),
       );
       await tester.pumpAndSettle();
 
@@ -103,7 +103,7 @@ void main() {
 
     testWidgets('투표 완료 상태 — 투표 완료! 배지 표시', (tester) async {
       await tester.pumpWidget(
-        buildVoteContent(voteCount: 3, maxVoteCount: 3),
+        buildVoteContent(voteCount: 3),
       );
       await tester.pumpAndSettle();
 
@@ -116,7 +116,7 @@ void main() {
           matchId: 'm1',
           eventId: _testEventId,
           partnerId: 'p1',
-          matchedAt: DateTime(2026, 4, 1),
+          matchedAt: DateTime(2026, 4),
           partnerName: '김지우',
         ),
       ];
@@ -152,7 +152,6 @@ void main() {
           candidates: candidates,
           votedIds: {'u1'},
           voteCount: 1,
-          maxVoteCount: 3,
         ),
       );
       await tester.pumpAndSettle();
@@ -171,8 +170,6 @@ void main() {
       await tester.pumpWidget(
         buildVoteContent(
           candidates: candidates,
-          voteCount: 0,
-          maxVoteCount: 3,
         ),
       );
       await tester.pumpAndSettle();

--- a/apps/app_user/test/integration/cuj_matching_vote_test.dart
+++ b/apps/app_user/test/integration/cuj_matching_vote_test.dart
@@ -160,6 +160,11 @@ void main() {
       expect(find.text('투표 완료'), findsOneWidget);
       // '선택' 버튼은 없음
       expect(find.text('선택'), findsNothing);
+      // Fix #1312: 비활성화된 버튼이 실제로 동작하지 않는지 확인
+      // onPressed: null 이므로 탭해도 확인 다이얼로그가 열리지 않아야 함
+      await tester.tap(find.text('투표 완료'));
+      await tester.pump();
+      expect(find.text('투표하기'), findsNothing);
     });
 
     testWidgets('투표 버튼 탭 → 확인 다이얼로그 표시', (tester) async {


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1312

## 변경 내용

`MatchingVoteContent` 위젯에 대한 IT-U05 통합 테스트 9개를 추가한다.

실제 Supabase 없이 Riverpod 프로바이더 오버라이드 방식으로 데이터 상태를 시뮬레이션.

## 테스트 시나리오

| # | 시나리오 | 검증 포인트 |
|---|---------|------------|
| 1 | 빈 후보자 목록 | "투표 가능한 상대가 없습니다." 표시 |
| 2 | 후보자 목록 렌더링 | 후보자 이름 표시 |
| 3 | 잔여 투표 수 | "남은 투표: 2/3" 카운터 표시 |
| 4 | 투표 완료 상태 | "투표 완료!" 배지 표시 |
| 5 | 매칭 성공 | "매칭 성공! (1명)" + 파트너 이름 표시 |
| 6 | 매칭 없음 | 매칭 성공 섹션 미표시 |
| 7 | 투표 메타 에러 | "투표 정보를 불러올 수 없습니다." 표시 |
| 8 | 중복 투표 방지 | 이미 투표한 후보 → "투표 완료" 버튼 비활성화 |
| 9 | 투표 확인 다이얼로그 | "선택" 탭 → "투표하기" 다이얼로그 표시 |

## 설계 결정

- `MatchingVoteContent`는 독립 라우트 없이 바텀시트/페이지에 임베드되는 위젯이므로 라우터 기반 대신 직접 위젯 테스트 방식을 선택
- 투표 기한 만료 로직은 `MatchingVoteController` 유닛 테스트 영역 (이슈 원문 기재)