### PR TITLE
refactor(simulator): 파티/이벤트 생성을 EF-only로 전환 (#1282)

### DIFF
--- a/supabase/functions/backend-simulator/e2e_test.ts
+++ b/supabase/functions/backend-simulator/e2e_test.ts
@@ -39,6 +39,39 @@ function createBroadMock() {
   }
 
   return createFetchMock([
+    // ── Auth token endpoint (partner/user sign-in for EF path) ───────────────
+    {
+      matcher: (req) => req.url.includes("/auth/v1/token"),
+      handler: () =>
+        jsonResponse({
+          access_token: "mock-ef-token",
+          token_type: "bearer",
+          expires_in: 3600,
+          refresh_token: "mock-refresh",
+          user: { id: "mock-user-id" },
+        }),
+    },
+    // ── Admin: getUserById — called by getPartnerEmail to resolve partner email ──
+    {
+      matcher: (req) => req.url.includes("/auth/v1/admin/users/"),
+      handler: () =>
+        jsonResponse({ user: { id: "00000000-0000-0000-0000-000000000001", email: "partner1@test.com" } }),
+    },
+    // ── EF functions (partner-manage-party, partner-manage-event, etc.) ──────
+    {
+      matcher: (req) => req.url.includes("/functions/v1/partner-manage-party"),
+      handler: () =>
+        jsonResponse({ success: true, party_id: crypto.randomUUID() }),
+    },
+    {
+      matcher: (req) => req.url.includes("/functions/v1/partner-manage-event"),
+      handler: () =>
+        jsonResponse({ success: true, event_id: crypto.randomUUID() }),
+    },
+    {
+      matcher: (req) => req.url.includes("/functions/v1/"),
+      handler: () => jsonResponse({}),
+    },
     {
       matcher: (req) =>
         req.url.includes("/rest/v1/") &&
@@ -50,6 +83,12 @@ function createBroadMock() {
 
         if (table === "partners") {
           return jsonResponse(wrapSingle(req, [{ id: "partner-1" }]));
+        }
+        if (table === "partner_members") {
+          return jsonResponse(wrapSingle(req, [{ user_id: "00000000-0000-0000-0000-000000000001" }]));
+        }
+        if (table === "ticket_templates") {
+          return jsonResponse(wrapSingle(req, [{ id: "tmpl-1", name: "일반" }]));
         }
         if (table === "user_profiles") {
           return jsonResponse(wrapSingle(req, [
@@ -244,6 +283,8 @@ Deno.test({
         ENVIRONMENT: "development",
         SUPABASE_URL: "http://localhost:54321",
         SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+        SUPABASE_ANON_KEY: "test-anon-key",
+        SIM_USER_PASSWORD: "test-password",
         GITHUB_ACCESS_TOKEN: "test-github-token",
       },
       async () => {
@@ -282,6 +323,8 @@ Deno.test({
         ENVIRONMENT: "development",
         SUPABASE_URL: "http://localhost:54321",
         SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+        SUPABASE_ANON_KEY: "test-anon-key",
+        SIM_USER_PASSWORD: "test-password",
         GITHUB_ACCESS_TOKEN: "test-github-token",
       },
       async () => {
@@ -314,6 +357,8 @@ Deno.test({
         ENVIRONMENT: "development",
         SUPABASE_URL: "http://localhost:54321",
         SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+        SUPABASE_ANON_KEY: "test-anon-key",
+        SIM_USER_PASSWORD: "test-password",
       },
       async () => {
         await withMockedFetch(fetchMock, async () => {
@@ -346,6 +391,8 @@ Deno.test({
         ENVIRONMENT: "development",
         SUPABASE_URL: "http://localhost:54321",
         SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+        SUPABASE_ANON_KEY: "test-anon-key",
+        SIM_USER_PASSWORD: "test-password",
         GITHUB_ACCESS_TOKEN: "test-github-token",
       },
       async () => {
@@ -452,6 +499,8 @@ Deno.test({
         ENVIRONMENT: "development",
         SUPABASE_URL: "http://localhost:54321",
         SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+        SUPABASE_ANON_KEY: "test-anon-key",
+        SIM_USER_PASSWORD: "test-password",
       },
       async () => {
         await withMockedFetch(fetchMock, async () => {
@@ -487,47 +536,67 @@ Deno.test({
   fn: async () => {
     const h = await getHandler();
 
-    // Track created parties to distinguish E2E vs display
-    const createdParties: { title?: string }[] = [];
+    // Track EF party creation calls to verify titles
+    const efPartyTitles: string[] = [];
 
     const { fetchMock } = createFetchMock([
+      // Auth token sign-in
       {
-        matcher: (req) =>
-          req.url.includes("/rest/v1/partners") && req.method === "GET",
-        handler: (req) => jsonResponse(wrapSingle(req, [{ id: "partner-1" }])),
+        matcher: (req) => req.url.includes("/auth/v1/token"),
+        handler: () =>
+          jsonResponse({
+            access_token: "mock-token",
+            token_type: "bearer",
+            expires_in: 3600,
+            refresh_token: "mock-refresh",
+            user: { id: "mock-user-id" },
+          }),
       },
+      // Auth admin: getUserById — called by getPartnerEmail
       {
-        matcher: (req) =>
-          req.url.includes("/rest/v1/locations") && req.method === "GET",
-        handler: (req) => jsonResponse(wrapSingle(req, [{ id: "loc-1" }])),
+        matcher: (req) => req.url.includes("/auth/v1/admin/users/"),
+        handler: () =>
+          jsonResponse({ user: { id: "00000000-0000-0000-0000-000000000001", email: "partner1@test.com" } }),
       },
+      // EF: partner-manage-party — capture party title
       {
-        matcher: (req) =>
-          req.url.includes("/rest/v1/parties") && req.method === "POST",
+        matcher: (req) => req.url.includes("/functions/v1/partner-manage-party"),
         handler: async (req) => {
-          const body = await req.json() as { title?: string };
-          createdParties.push({ title: body.title });
-          return jsonResponse({ id: crypto.randomUUID() }, { status: 201 });
+          try {
+            const body = await req.json() as { party?: { title?: string } };
+            if (body.party?.title) efPartyTitles.push(body.party.title);
+          } catch { /* intentionally empty */ }
+          return jsonResponse({ success: true, party_id: crypto.randomUUID() });
         },
       },
+      // EF: partner-manage-event
       {
-        matcher: (req) =>
-          req.url.includes("/rest/v1/events") && req.method === "POST",
-        handler: () =>
-          jsonResponse({ id: crypto.randomUUID() }, { status: 201 }),
+        matcher: (req) => req.url.includes("/functions/v1/partner-manage-event"),
+        handler: () => jsonResponse({ success: true, event_id: crypto.randomUUID() }),
       },
+      // EF: other functions (user-event-feed, apply-event, etc.)
       {
-        matcher: (req) =>
-          req.url.includes("/rest/v1/events") && req.method === "GET",
-        handler: (req) => jsonResponse(wrapSingle(req, [])),
+        matcher: (req) => req.url.includes("/functions/v1/"),
+        handler: () => jsonResponse({}),
+      },
+      // DB: REST API
+      {
+        matcher: (req) => req.url.includes("/rest/v1/") && req.method === "GET",
+        handler: (req) => {
+          const url = new URL(req.url);
+          const table = url.pathname.split("/rest/v1/")[1]?.split("?")[0];
+          if (table === "partners") return jsonResponse(wrapSingle(req, [{ id: "partner-1" }]));
+          if (table === "partner_members") return jsonResponse(wrapSingle(req, [{ user_id: "00000000-0000-0000-0000-000000000001" }]));
+          if (table === "ticket_templates") return jsonResponse(wrapSingle(req, [{ id: "tmpl-1", name: "일반" }]));
+          if (table === "locations") return jsonResponse(wrapSingle(req, [{ id: "loc-1" }]));
+          if (table === "events") return jsonResponse(wrapSingle(req, []));
+          if (table === "user_profiles") return jsonResponse(wrapSingle(req, []));
+          return jsonResponse(wrapSingle(req, []));
+        },
       },
       {
         matcher: (req) => req.url.includes("/rest/v1/") && req.method === "POST",
         handler: () => jsonResponse({ id: crypto.randomUUID() }, { status: 201 }),
-      },
-      {
-        matcher: (req) => req.url.includes("/rest/v1/") && req.method === "GET",
-        handler: (req) => jsonResponse(wrapSingle(req, [])),
       },
       {
         matcher: (req) => req.url.includes("/storage/v1/"),
@@ -540,6 +609,8 @@ Deno.test({
         ENVIRONMENT: "development",
         SUPABASE_URL: "http://localhost:54321",
         SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+        SUPABASE_ANON_KEY: "test-anon-key",
+        SIM_USER_PASSWORD: "test-password",
       },
       async () => {
         await withMockedFetch(fetchMock, async () => {
@@ -562,16 +633,14 @@ Deno.test({
           assertEquals(Array.isArray(body.display_party_ids), true);
           assertEquals(Array.isArray(body.display_event_ids), true);
 
-          // Display events must NOT have [E2E] prefix in their parties
-          const displayOnlyParties = createdParties.filter(
-            (p) => p.title && !p.title.startsWith("[E2E]"),
-          );
+          // Display parties must NOT have [E2E] prefix in their titles
+          const displayOnlyTitles = efPartyTitles.filter((t) => !t.startsWith("[E2E]"));
           // If simCreateDisplayEvents created any parties, they must not be E2E-prefixed
-          for (const party of displayOnlyParties) {
+          for (const title of displayOnlyTitles) {
             assertEquals(
-              party.title?.startsWith("[E2E]"),
+              title.startsWith("[E2E]"),
               false,
-              `Display party title must not start with [E2E], got: ${party.title}`,
+              `Display party title must not start with [E2E], got: ${title}`,
             );
           }
         });

--- a/supabase/functions/backend-simulator/index.ts
+++ b/supabase/functions/backend-simulator/index.ts
@@ -62,7 +62,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
   const supabaseUrl = Deno.env.get("SUPABASE_URL");
   const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
   const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
-  if (!supabaseUrl || !serviceRoleKey) {
+  if (!supabaseUrl || !serviceRoleKey || !anonKey) {
     return errorResponse("Missing required environment variables", 500);
   }
   const supabase = createServiceClient();
@@ -109,9 +109,9 @@ Deno.serve(async (req: Request): Promise<Response> => {
 
   // Phase: "create" → Phase 1-2 only
   if (phase === "create") {
-    const createResult = await simCreateParties(supabase, config, logFn, supabaseUrl, anonKey, config.strict);
+    const createResult = await simCreateParties(supabase, config, logFn, supabaseUrl, anonKey);
     // Fix #964: 피드 전시용 이벤트 생성 — 일반 유저 피드에 표시할 display 이벤트를 E2E와 분리해 생성
-    const displayResult = await simCreateDisplayEvents(supabase, logFn);
+    const displayResult = await simCreateDisplayEvents(supabase, logFn, supabaseUrl, anonKey);
     const applyResult = await simDiscoverAndApply(
       supabase,
       config,
@@ -347,9 +347,9 @@ Deno.serve(async (req: Request): Promise<Response> => {
   // ─────────────────────────────────────────────────────────
 
   // Phase 1-2: Create parties + display events + discover & apply
-  const createResult = await simCreateParties(supabase, config, logFn, supabaseUrl, anonKey, config.strict);
+  const createResult = await simCreateParties(supabase, config, logFn, supabaseUrl, anonKey);
   // Fix #964: 피드 전시용 이벤트 생성 — 일반 유저 피드에 표시할 display 이벤트를 E2E와 분리해 생성
-  await simCreateDisplayEvents(supabase, logFn);
+  await simCreateDisplayEvents(supabase, logFn, supabaseUrl, anonKey);
   const applyResult = await simDiscoverAndApply(
     supabase,
     config,

--- a/supabase/functions/backend-simulator/sim_create.ts
+++ b/supabase/functions/backend-simulator/sim_create.ts
@@ -275,6 +275,7 @@ export async function simCreateDisplayEvents(
         action: "create",
         party_id: partyId,
         event: {
+          title: `${scenario.title} #${ei + 1}`,
           start_time: startTime.toISOString(),
           end_time: endTime.toISOString(),
           max_participants: 30,
@@ -448,6 +449,7 @@ async function applyForUser(
 }
 
 // Fix #1323: User-centric discover-and-apply loop
+// Note: #1283 에서 strict 파라미터 제거 및 EF-only 전환 예정 (simCreateParties/simCreateDisplayEvents와 일관성)
 export async function simDiscoverAndApply(
   supabase: SupabaseClient,
   config: SimConfig,

--- a/supabase/functions/backend-simulator/sim_create.ts
+++ b/supabase/functions/backend-simulator/sim_create.ts
@@ -29,18 +29,15 @@ export async function simCreateParties(
   supabase: SupabaseClient,
   config: SimConfig,
   log: (entry: Omit<SimLogEntry, "timestamp">) => void,
-  supabaseUrl?: string,
-  anonKey?: string,
-  strict?: boolean,
+  supabaseUrl: string,
+  anonKey: string,
 ): Promise<{ partyIds: string[]; eventIds: string[] }> {
   const partyIds: string[] = [];
   const eventIds: string[] = [];
 
   const simUserPassword = Deno.env.get("SIM_USER_PASSWORD");
-  if (supabaseUrl && anonKey && !simUserPassword) {
-    const errMsg = "SIM_USER_PASSWORD is required for EF path";
-    if (strict) throw new Error(errMsg);
-    log({ level: "warn", phase: "create", step: "sim_user_password", message: `${errMsg}, falling back to direct DB` });
+  if (!simUserPassword) {
+    throw new Error("SIM_USER_PASSWORD is required for EF path");
   }
 
   const { data: partners, error: pErr } = await supabase
@@ -63,109 +60,18 @@ export async function simCreateParties(
 
     const locationId_existing = location?.id as string | undefined;
 
-    // ── Step 1: Acquire partner JWT (needed for EF path) ──────────────────────
-    let partnerToken: string | null = null;
-    if (supabaseUrl && anonKey && simUserPassword) {
-      try {
-        const partnerEmail = await getPartnerEmail(supabase, partner.id);
-        if (partnerEmail) {
-          partnerToken = await getSimPartnerToken(supabaseUrl, anonKey, partnerEmail, simUserPassword);
-        } else {
-          const errMsg = `No email for partner ${partner.id}, EF path skipped`;
-          if (strict) throw new Error(errMsg);
-          log({ level: "warn", phase: "create", step: "get_partner_email", message: errMsg });
-        }
-      } catch (authErr) {
-        if (strict) throw authErr;
-        log({ level: "warn", phase: "create", step: "get_partner_token", message: `Failed to get partner token: ${String(authErr)}` });
-      }
+    // ── Step 1: Acquire partner JWT ───────────────────────────────────────────
+    const partnerEmail = await getPartnerEmail(supabase, partner.id);
+    if (!partnerEmail) {
+      throw new Error(`No email for partner ${partner.id}`);
     }
+    const partnerToken = await getSimPartnerToken(supabaseUrl, anonKey, partnerEmail, simUserPassword);
 
-    // ── Step 2: Create party ──────────────────────────────────────────────────
-    let partyId: string | null = null;
-    let partyCreatedViaEf = false;
-    // Tracked from the direct DB fallback path; used in the event direct DB fallback
-    // to avoid a redundant per-event parties query.
-    let directDbLocationId: string | null = null;
-
-    if (supabaseUrl && anonKey && partnerToken) {
-      try {
-        const efResult = await callEdgeFunction(supabaseUrl, "partner-manage-party", {
-          action: "create",
-          partner_id: partner.id,
-          party: {
-            title: scenario.title,
-            description: { ops: [{ insert: "[E2E] 시뮬레이션 테스트 파티입니다.\n" }] },
-            image_urls: [],
-            required_verification_ids: [],
-            min_confirmed_count: 4,
-            max_participants: 20,
-            status: "active",
-            metadata: { show_participant_list: true, visibility: "public" },
-          },
-          ...(locationId_existing
-            ? { location_id: locationId_existing }
-            : {
-                location: {
-                  name: "[E2E] 테스트 장소",
-                  address: "서울특별시 강남구 역삼동",
-                  region_1: "서울",
-                  region_2: "강남구",
-                },
-              }),
-          entry_group_templates: [
-            { label: "남성", gender: "male", birth_year_min: scenario.birthYearMin, birth_year_max: scenario.birthYearMax },
-            { label: "여성", gender: "female", birth_year_min: scenario.birthYearMin, birth_year_max: scenario.birthYearMax },
-          ],
-          ticket_templates: [
-            { name: "일반", price: 20000, quantity: 10 },
-          ],
-        }, partnerToken);
-
-        const efData = efResult.data as { success?: boolean; party_id?: string } | null;
-        if (efResult.status === 200 && efData?.success && efData?.party_id) {
-          partyId = efData.party_id;
-          partyCreatedViaEf = true;
-          log({ level: "info", phase: "create", step: "ef_create_party", message: `EF created party: ${scenario.title}`, data: { partyId } });
-        } else {
-          const errMsg = `EF partner-manage-party returned status=${efResult.status}`;
-          if (strict) throw new Error(errMsg);
-          log({ level: "warn", phase: "create", step: "ef_create_party", message: `${errMsg}, falling back to direct DB` });
-        }
-      } catch (efErr) {
-        if (strict) throw efErr;
-        log({ level: "warn", phase: "create", step: "ef_create_party", message: `EF partner-manage-party threw: ${String(efErr)}, falling back to direct DB` });
-      }
-    }
-
-    // Fallback: direct DB insert (when EF not available or EF failed in non-strict mode)
-    if (!partyId) {
-      // Ensure location exists for direct DB path
-      let locationId: string;
-      if (locationId_existing) {
-        locationId = locationId_existing;
-      } else {
-        const newLocId = crypto.randomUUID();
-        const { error: locErr } = await supabase.from("locations").insert({
-          id: newLocId,
-          partner_id: partner.id,
-          name: "[E2E] 테스트 장소",
-          address: "서울특별시 강남구 역삼동",
-          region_1: "서울",
-          region_2: "강남구",
-        });
-        if (locErr) {
-          log({ level: "error", phase: "create", step: "create_location", message: `Failed: ${locErr.message}` });
-          continue;
-        }
-        locationId = newLocId;
-      }
-
-      const directPartyId = crypto.randomUUID();
-      const { error: partyErr } = await supabase.from("parties").insert({
-        id: directPartyId,
-        partner_id: partner.id,
-        location_id: locationId,
+    // ── Step 2: Create party via EF ───────────────────────────────────────────
+    const partyEfResult = await callEdgeFunction(supabaseUrl, "partner-manage-party", {
+      action: "create",
+      partner_id: partner.id,
+      party: {
         title: scenario.title,
         description: { ops: [{ insert: "[E2E] 시뮬레이션 테스트 파티입니다.\n" }] },
         image_urls: [],
@@ -174,160 +80,71 @@ export async function simCreateParties(
         max_participants: 20,
         status: "active",
         metadata: { show_participant_list: true, visibility: "public" },
-      });
-      if (partyErr) {
-        log({ level: "error", phase: "create", step: "create_party", message: `Failed: ${partyErr.message}` });
-        continue;
-      }
-      partyId = directPartyId;
-      directDbLocationId = locationId;
+      },
+      ...(locationId_existing
+        ? { location_id: locationId_existing }
+        : {
+            location: {
+              name: "[E2E] 테스트 장소",
+              address: "서울특별시 강남구 역삼동",
+              region_1: "서울",
+              region_2: "강남구",
+            },
+          }),
+      entry_group_templates: [
+        { label: "남성", gender: "male", birth_year_min: scenario.birthYearMin, birth_year_max: scenario.birthYearMax },
+        { label: "여성", gender: "female", birth_year_min: scenario.birthYearMin, birth_year_max: scenario.birthYearMax },
+      ],
+      ticket_templates: [
+        { name: "일반", price: 20000, quantity: 10 },
+      ],
+    }, partnerToken);
 
-      // For direct DB path: create entry groups and ticket templates on the party level
-      // (events will also get entry_groups + tickets created inline below)
+    const partyEfData = partyEfResult.data as { success?: boolean; party_id?: string } | null;
+    if (partyEfResult.status !== 200 || !partyEfData?.success || !partyEfData?.party_id) {
+      throw new Error(`EF partner-manage-party returned status=${partyEfResult.status}`);
     }
+    const partyId = partyEfData.party_id;
+    log({ level: "info", phase: "create", step: "ef_create_party", message: `EF created party: ${scenario.title}`, data: { partyId } });
+    partyIds.push(partyId);
 
-    // At this point partyId is always set: EF success sets it, fallback continues on error
-    partyIds.push(partyId!);
+    // ── Step 3: Fetch ticket_templates created by the party EF ───────────────
+    const { data: templates } = await supabase
+      .from("ticket_templates")
+      .select("id, name")
+      .eq("party_id", partyId);
+    const ticketTemplates = (templates ?? []) as { id: string; name: string }[];
 
-    // ── Step 3: Create events ─────────────────────────────────────────────────
-
-    // Fetch ticket_templates created by the EF (needed for event EF payload).
-    // Only relevant when the party was created via EF — direct DB parties have no ticket_templates.
-    let ticketTemplates: { id: string; name: string }[] = [];
-    if (partyCreatedViaEf && supabaseUrl && anonKey && partnerToken) {
-      const { data: templates } = await supabase
-        .from("ticket_templates")
-        .select("id, name")
-        .eq("party_id", partyId!);
-      ticketTemplates = (templates ?? []) as { id: string; name: string }[];
-    }
-
+    // ── Step 4: Create events via EF ──────────────────────────────────────────
     for (let ei = 0; ei < config.events_per_party; ei++) {
       const now = new Date();
       const startTime = new Date(now.getTime() + START_TIME_OFFSETS_MS[ei % 4]);
       const endTime = new Date(startTime.getTime() + 3 * 60 * 60 * 1000);
 
-      let eventId: string | null = null;
-
-      // Only attempt the event EF when the party was created via EF (which guarantees
-      // ticket_templates exist). A direct-DB party has no ticket_templates, so the
-      // event EF would produce a ticket-less event — skip it and use direct DB instead.
-      if (partyCreatedViaEf && supabaseUrl && anonKey && partnerToken) {
-        try {
-          const efResult = await callEdgeFunction(supabaseUrl, "partner-manage-event", {
-            action: "create",
-            party_id: partyId,
-            event: {
-              start_time: startTime.toISOString(),
-              end_time: endTime.toISOString(),
-              max_participants: 20,
-              title: `${scenario.title} #${ei + 1}`,
-            },
-            tickets: ticketTemplates.map((t) => ({
-              template_id: t.id,
-              quantity: 10,
-            })),
-          }, partnerToken);
-
-          const efData = efResult.data as { success?: boolean; event_id?: string } | null;
-          if (efResult.status === 200 && efData?.success && efData?.event_id) {
-            eventId = efData.event_id;
-            log({ level: "info", phase: "create", step: "ef_create_event", message: `EF created event ${ei + 1} for party ${partyId}`, data: { eventId } });
-          } else {
-            const errMsg = `EF partner-manage-event returned status=${efResult.status}`;
-            if (strict) throw new Error(errMsg);
-            log({ level: "warn", phase: "create", step: "ef_create_event", message: `${errMsg}, falling back to direct DB` });
-          }
-        } catch (efErr) {
-          if (strict) throw efErr;
-          log({ level: "warn", phase: "create", step: "ef_create_event", message: `EF partner-manage-event threw: ${String(efErr)}, falling back to direct DB` });
-        }
-      }
-
-      // Fallback: direct DB insert for event + entry_groups + tickets.
-      // locationId is known from the party creation step — no per-event DB query needed.
-      if (!eventId) {
-        let resolvedLocationId: string | null = directDbLocationId ?? locationId_existing ?? null;
-        if (partyCreatedViaEf && !resolvedLocationId) {
-          const { data: partyRow, error: partyLookupErr } = await supabase
-            .from("parties")
-            .select("location_id")
-            .eq("id", partyId!)
-            .maybeSingle();
-
-          if (partyLookupErr || !partyRow?.location_id) {
-            log({
-              level: "error",
-              phase: "create",
-              step: "resolve_location_id",
-              message: `Failed to resolve location_id for party ${partyId}: ${partyLookupErr?.message ?? "empty"}`,
-            });
-            continue;
-          }
-          resolvedLocationId = partyRow.location_id as string;
-        }
-        if (!resolvedLocationId) {
-          log({ level: "error", phase: "create", step: "resolve_location_id", message: `No location_id for party ${partyId}` });
-          continue;
-        }
-
-        const directEventId = crypto.randomUUID();
-        const { error: evErr } = await supabase.from("events").insert({
-          id: directEventId,
-          party_id: partyId,
-          location_id: resolvedLocationId,
+      const eventEfResult = await callEdgeFunction(supabaseUrl, "partner-manage-event", {
+        action: "create",
+        party_id: partyId,
+        event: {
           start_time: startTime.toISOString(),
           end_time: endTime.toISOString(),
-          min_confirmed_count: 4,
           max_participants: 20,
-          status: "scheduled",
+          min_confirmed_count: 4,
+          title: `${scenario.title} #${ei + 1}`,
           metadata: { show_participant_list: true, visibility: "public" },
-        });
-        if (evErr) {
-          log({ level: "error", phase: "create", step: "create_event", message: `Failed: ${evErr.message}` });
-          continue;
-        }
-        eventId = directEventId;
-
-        const maleGroupId = crypto.randomUUID();
-        const femaleGroupId = crypto.randomUUID();
-
-        const { error: maleGroupErr } = await supabase.from("entry_groups").insert({
-          id: maleGroupId,
-          event_id: eventId, label: "남성", gender: "male",
-          birth_year_min: scenario.birthYearMin, birth_year_max: scenario.birthYearMax,
-          required_verification_ids: [],
-        });
-        if (maleGroupErr) {
-          log({ level: "warn", phase: "create", step: "create_entry_group", message: `Failed to create male entry_group: ${maleGroupErr.message}` });
-        }
-
-        const { error: femaleGroupErr } = await supabase.from("entry_groups").insert({
-          id: femaleGroupId,
-          event_id: eventId, label: "여성", gender: "female",
-          birth_year_min: scenario.birthYearMin, birth_year_max: scenario.birthYearMax,
-          required_verification_ids: [],
-        });
-        if (femaleGroupErr) {
-          log({ level: "warn", phase: "create", step: "create_entry_group", message: `Failed to create female entry_group: ${femaleGroupErr.message}` });
-        }
-
-        const { error: ticketErr } = await supabase.from("tickets").insert({
-          id: crypto.randomUUID(),
-          event_id: eventId,
-          name: "[E2E] 일반 티켓",
-          price: 20000,
+        },
+        tickets: ticketTemplates.map((t) => ({
+          template_id: t.id,
           quantity: 10,
-          target_entry_group_ids: [maleGroupId, femaleGroupId],
-          status: "on_sale",
-        });
-        if (ticketErr) {
-          log({ level: "warn", phase: "create", step: "create_ticket", message: `Failed to create ticket: ${ticketErr.message}` });
-        }
-      }
+        })),
+      }, partnerToken);
 
-      // At this point eventId is always set: EF success sets it, fallback continues on error
-      eventIds.push(eventId!);
+      const eventEfData = eventEfResult.data as { success?: boolean; event_id?: string } | null;
+      if (eventEfResult.status !== 200 || !eventEfData?.success || !eventEfData?.event_id) {
+        throw new Error(`EF partner-manage-event returned status=${eventEfResult.status}`);
+      }
+      const eventId = eventEfData.event_id;
+      log({ level: "info", phase: "create", step: "ef_create_event", message: `EF created event ${ei + 1} for party ${partyId}`, data: { eventId } });
+      eventIds.push(eventId);
     }
 
     log({ level: "info", phase: "create", step: "party_created", message: `Created: ${scenario.title}`, data: { partyId } });
@@ -349,9 +166,16 @@ const DISPLAY_SCENARIOS = [
 export async function simCreateDisplayEvents(
   supabase: SupabaseClient,
   log: (entry: Omit<SimLogEntry, "timestamp">) => void,
+  supabaseUrl: string,
+  anonKey: string,
 ): Promise<{ displayPartyIds: string[]; displayEventIds: string[] }> {
   const displayPartyIds: string[] = [];
   const displayEventIds: string[] = [];
+
+  const simUserPassword = Deno.env.get("SIM_USER_PASSWORD");
+  if (!simUserPassword) {
+    throw new Error("SIM_USER_PASSWORD is required for EF path");
+  }
 
   // Fix #964: Dedup — skip creation if display parties already exist to prevent infinite accumulation
   const { data: existing } = await supabase
@@ -377,6 +201,13 @@ export async function simCreateDisplayEvents(
     const partner = partners[i % partners.length] as { id: string };
     const scenario = DISPLAY_SCENARIOS[i];
 
+    // Acquire partner JWT for EF calls
+    const partnerEmail = await getPartnerEmail(supabase, partner.id);
+    if (!partnerEmail) {
+      throw new Error(`No email for partner ${partner.id}`);
+    }
+    const partnerToken = await getSimPartnerToken(supabaseUrl, anonKey, partnerEmail, simUserPassword);
+
     // Fix #964: [E2E] location 재사용 방지 — display 이벤트가 E2E 테스트용 location에 붙지 않도록 필터링
     const { data: location } = await supabase
       .from("locations")
@@ -385,45 +216,54 @@ export async function simCreateDisplayEvents(
       .not("name", "ilike", "[E2E]%")
       .maybeSingle();
 
-    let locationId: string;
-    if (location?.id) {
-      locationId = location.id;
-    } else {
-      const newLocId = crypto.randomUUID();
-      const { error: locErr } = await supabase.from("locations").insert({
-        id: newLocId,
-        partner_id: partner.id,
-        name: "전시용 테스트 장소",
-        address: "서울특별시 강남구 역삼동",
-        region_1: "서울",
-        region_2: "강남구",
-      });
-      if (locErr) {
-        log({ level: "error", phase: "create", step: "display_create_location", message: `Failed: ${locErr.message}` });
-        continue;
-      }
-      locationId = newLocId;
-    }
+    const locationId_existing = location?.id as string | undefined;
 
-    const partyId = crypto.randomUUID();
-    const { error: partyErr } = await supabase.from("parties").insert({
-      id: partyId,
+    // Create display party via EF
+    const partyEfResult = await callEdgeFunction(supabaseUrl, "partner-manage-party", {
+      action: "create",
       partner_id: partner.id,
-      location_id: locationId,
-      title: scenario.title,
-      description: { ops: [{ insert: `${scenario.description}\n` }] },
-      image_urls: [],
-      required_verification_ids: [],
-      min_confirmed_count: 4,
-      max_participants: 20,
-      status: "active",
-      metadata: { show_participant_list: true, visibility: "public" },
-    });
-    if (partyErr) {
-      log({ level: "error", phase: "create", step: "display_create_party", message: `Failed: ${partyErr.message}` });
-      continue;
+      party: {
+        title: scenario.title,
+        description: { ops: [{ insert: `${scenario.description}\n` }] },
+        image_urls: [],
+        required_verification_ids: [],
+        min_confirmed_count: 4,
+        max_participants: 30,
+        status: "active",
+        metadata: { show_participant_list: true, visibility: "public" },
+      },
+      ...(locationId_existing
+        ? { location_id: locationId_existing }
+        : {
+            location: {
+              name: "전시용 테스트 장소",
+              address: "서울특별시 강남구 역삼동",
+              region_1: "서울",
+              region_2: "강남구",
+            },
+          }),
+      entry_group_templates: [
+        { label: "남성", gender: "male", birth_year_min: 1990, birth_year_max: 2005 },
+        { label: "여성", gender: "female", birth_year_min: 1990, birth_year_max: 2005 },
+      ],
+      ticket_templates: [
+        { name: "일반 티켓", price: 0, quantity: 30 },
+      ],
+    }, partnerToken);
+
+    const partyEfData = partyEfResult.data as { success?: boolean; party_id?: string } | null;
+    if (partyEfResult.status !== 200 || !partyEfData?.success || !partyEfData?.party_id) {
+      throw new Error(`EF partner-manage-party returned status=${partyEfResult.status} for display party`);
     }
+    const partyId = partyEfData.party_id;
     displayPartyIds.push(partyId);
+
+    // Fetch ticket_templates created by the party EF
+    const { data: templates } = await supabase
+      .from("ticket_templates")
+      .select("id, name")
+      .eq("party_id", partyId);
+    const ticketTemplates = (templates ?? []) as { id: string; name: string }[];
 
     // 파티당 이벤트 2개 (같은 시나리오, 시작 시간만 +3시간 차이)
     for (let ei = 0; ei < 2; ei++) {
@@ -431,59 +271,27 @@ export async function simCreateDisplayEvents(
       const startTime = new Date(now.getTime() + scenario.offsetDays * 24 * 60 * 60 * 1000 + ei * 3 * 60 * 60 * 1000);
       const endTime = new Date(startTime.getTime() + 3 * 60 * 60 * 1000);
 
-      const eventId = crypto.randomUUID();
-      const { error: evErr } = await supabase.from("events").insert({
-        id: eventId,
+      const eventEfResult = await callEdgeFunction(supabaseUrl, "partner-manage-event", {
+        action: "create",
         party_id: partyId,
-        location_id: locationId,
-        start_time: startTime.toISOString(),
-        end_time: endTime.toISOString(),
-        min_confirmed_count: 4,
-        max_participants: 20,
-        status: "scheduled",
-        metadata: { show_participant_list: true, visibility: "public" },
-      });
-      if (evErr) {
-        log({ level: "error", phase: "create", step: "display_create_event", message: `Failed: ${evErr.message}` });
-        continue;
-      }
-      displayEventIds.push(eventId);
+        event: {
+          start_time: startTime.toISOString(),
+          end_time: endTime.toISOString(),
+          max_participants: 30,
+          min_confirmed_count: 4,
+          metadata: { show_participant_list: true, visibility: "public" },
+        },
+        tickets: ticketTemplates.map((t) => ({
+          template_id: t.id,
+          quantity: 30,
+        })),
+      }, partnerToken);
 
-      const maleGroupId = crypto.randomUUID();
-      const femaleGroupId = crypto.randomUUID();
-
-      const { error: maleGroupErr } = await supabase.from("entry_groups").insert({
-        id: maleGroupId,
-        event_id: eventId, label: "남성", gender: "male",
-        birth_year_min: 1990, birth_year_max: 2005,
-        required_verification_ids: [],
-      });
-      if (maleGroupErr) {
-        log({ level: "warn", phase: "create", step: "display_create_entry_group", message: `Failed to create male entry_group: ${maleGroupErr.message}` });
+      const eventEfData = eventEfResult.data as { success?: boolean; event_id?: string } | null;
+      if (eventEfResult.status !== 200 || !eventEfData?.success || !eventEfData?.event_id) {
+        throw new Error(`EF partner-manage-event returned status=${eventEfResult.status} for display event`);
       }
-
-      const { error: femaleGroupErr } = await supabase.from("entry_groups").insert({
-        id: femaleGroupId,
-        event_id: eventId, label: "여성", gender: "female",
-        birth_year_min: 1990, birth_year_max: 2005,
-        required_verification_ids: [],
-      });
-      if (femaleGroupErr) {
-        log({ level: "warn", phase: "create", step: "display_create_entry_group", message: `Failed to create female entry_group: ${femaleGroupErr.message}` });
-      }
-
-      const { error: ticketErr } = await supabase.from("tickets").insert({
-        id: crypto.randomUUID(),
-        event_id: eventId,
-        name: "일반 티켓",
-        price: 20000,
-        quantity: 10,
-        target_entry_group_ids: [maleGroupId, femaleGroupId],
-        status: "on_sale",
-      });
-      if (ticketErr) {
-        log({ level: "warn", phase: "create", step: "display_create_ticket", message: `Failed to create ticket: ${ticketErr.message}` });
-      }
+      displayEventIds.push(eventEfData.event_id);
     }
 
     log({ level: "info", phase: "create", step: "display_party_created", message: `Created display party: ${scenario.title}`, data: { partyId } });

--- a/supabase/functions/backend-simulator/sim_create_test.ts
+++ b/supabase/functions/backend-simulator/sim_create_test.ts
@@ -1,6 +1,6 @@
-import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import { createMockSupabaseClient } from "../_test_utils/mock_supabase_client.ts";
-import { simCreateParties, simDiscoverAndApply } from "./sim_create.ts";
+import { simCreateParties, simCreateDisplayEvents, simDiscoverAndApply } from "./sim_create.ts";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { SimConfig } from "./sim_types.ts";
 
@@ -18,97 +18,7 @@ const DEFAULT_CONFIG: SimConfig = {
 
 const noop = () => {};
 
-Deno.test("simCreateParties - creates parties with [E2E] prefix", async () => {
-  const createdParties: unknown[] = [];
-  const createdEvents: unknown[] = [];
-  const createdGroups: unknown[] = [];
-  const createdTickets: unknown[] = [];
-
-  const mock = createMockSupabaseClient({
-    tables: {
-      partners: { select: () => ({ data: [{ id: "partner-1" }, { id: "partner-2" }], error: null }) },
-      locations: { select: () => ({ data: { id: "loc-1" }, error: null }) },
-      parties: {
-        insert: ({ values }: { values: unknown }) => {
-          createdParties.push(values);
-          return { data: { id: "party-1" }, error: null };
-        },
-      },
-      events: {
-        insert: ({ values }) => {
-          createdEvents.push(values as { start_time: string });
-          return { data: { id: `event-${createdEvents.length}` }, error: null };
-        },
-      },
-      entry_groups: {
-        insert: ({ values }: { values: unknown }) => {
-          createdGroups.push(values);
-          return { data: { id: `group-${createdGroups.length}` }, error: null };
-        },
-      },
-      tickets: {
-        insert: ({ values }: { values: unknown }) => {
-          createdTickets.push(values);
-          return { data: null, error: null };
-        },
-      },
-    },
-  });
-
-  await simCreateParties(mock as unknown as SupabaseClient, DEFAULT_CONFIG, noop);
-
-  assertEquals(createdParties.length, 2);
-  const party = createdParties[0] as { title: string };
-  assertStringIncludes(party.title, "[E2E]");
-  assertEquals(createdEvents.length, 4);
-});
-
-Deno.test("simCreateParties - creates 4 distinct start_time zones", async () => {
-  const createdEvents: { start_time: string }[] = [];
-
-  const mock = createMockSupabaseClient({
-    tables: {
-      partners: { select: () => ({ data: [{ id: "partner-1" }], error: null }) },
-      locations: { select: () => ({ data: { id: "loc-1" }, error: null }) },
-      parties: { insert: () => ({ data: { id: "party-1" }, error: null }) },
-      events: {
-        insert: ({ values }) => {
-          const v = values as { start_time: string };
-          createdEvents.push(v);
-          return { data: { id: `event-${createdEvents.length}` }, error: null };
-        },
-      },
-      entry_groups: { insert: () => ({ data: { id: "group-1" }, error: null }) },
-      tickets: { insert: () => ({ data: null, error: null }) },
-    },
-  });
-
-  const config: SimConfig = { ...DEFAULT_CONFIG, party_count: 1, events_per_party: 4 };
-  await simCreateParties(mock as unknown as SupabaseClient, config, noop);
-
-  assertEquals(createdEvents.length, 4);
-  const now = Date.now();
-  const times = createdEvents.map((e) => new Date(e.start_time).getTime());
-
-  const plusTwoDays = now + 2 * 24 * 60 * 60 * 1000;
-  const plusFiveDays = now + 5 * 24 * 60 * 60 * 1000;
-  const plusThirtyDays = now + 30 * 24 * 60 * 60 * 1000;
-  const plusTwelveHours = now + 12 * 60 * 60 * 1000;
-
-  const allAboveTwoHours = times.every((t) => t - now > 2 * 60 * 60 * 1000);
-  assertEquals(allAboveTwoHours, true);
-
-  const hasManyDaysApart = times.some((t) => t > plusThirtyDays - 60000);
-  assertEquals(hasManyDaysApart, true);
-  const hasFiveDays = times.some((t) => t > plusFiveDays - 60000 && t < plusFiveDays + 60000);
-  assertEquals(hasFiveDays, true);
-  const hasTwoDays = times.some((t) => t > plusTwoDays - 60000 && t < plusTwoDays + 60000);
-  assertEquals(hasTwoDays, true);
-  const hasTwelveHours = times.some((t) => t > plusTwelveHours - 60000 && t < plusTwelveHours + 60000);
-  assertEquals(hasTwelveHours, true);
-});
-
-// ── EF path tests ────────────────────────────────────────────────────────────
+// ── simCreateParties / simCreateDisplayEvents EF-only tests ──────────────────
 
 // Intercept module-level EF calls via mock fetch. We replace globalThis.fetch
 // for the duration of the test to simulate EF responses without a real server.
@@ -129,12 +39,11 @@ function withMockFetch<T>(
 // token auto-refresh even when persistSession=false. The interval leaks within the test but is
 // harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
-  name: "simCreateParties - uses EF path when supabaseUrl/anonKey provided and EF succeeds",
+  name: "simCreateParties - creates parties and events via EF and returns IDs",
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
   const efCalls: { url: string; body: unknown }[] = [];
-  const directInserts: string[] = [];
 
   const mock = createMockSupabaseClient({
     tables: {
@@ -142,21 +51,6 @@ Deno.test({
       locations: { select: () => ({ data: { id: "loc-1" }, error: null }) },
       partner_members: { select: () => ({ data: [{ user_id: "partner-user-1" }], error: null }) },
       ticket_templates: { select: () => ({ data: [{ id: "tmpl-1", name: "일반" }], error: null }) },
-      // direct DB inserts should NOT be called on EF success path
-      parties: {
-        insert: ({ values }: { values: unknown }) => {
-          directInserts.push("party");
-          return { data: { id: "direct-party" }, error: null };
-        },
-      },
-      events: {
-        insert: ({ values }: { values: unknown }) => {
-          directInserts.push("event");
-          return { data: { id: "direct-event" }, error: null };
-        },
-      },
-      entry_groups: { insert: () => ({ data: { id: "grp-1" }, error: null }) },
-      tickets: { insert: () => ({ data: null, error: null }) },
     },
     authAdminGetUserById: (_userId: string) => ({ data: { user: { email: "partner1@test.com" } }, error: null }),
   });
@@ -165,111 +59,34 @@ Deno.test({
 
   Deno.env.set("SIM_USER_PASSWORD", "test-password");
   try {
-  await withMockFetch((url, init) => {
-    const body = JSON.parse((init.body as string) ?? "{}");
-    efCalls.push({ url, body });
+    await withMockFetch((url, init) => {
+      const body = JSON.parse((init.body as string) ?? "{}");
+      efCalls.push({ url, body });
 
-    if (url.includes("auth/v1/token")) {
-      // Simulate successful partner sign-in
-      return new Response(JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }), { status: 200 });
-    }
-    if (url.includes("partner-manage-party")) {
-      return new Response(JSON.stringify({ success: true, party_id: "ef-party-1" }), { status: 200 });
-    }
-    if (url.includes("partner-manage-event")) {
-      return new Response(JSON.stringify({ success: true, event_id: "ef-event-1" }), { status: 200 });
-    }
-    return new Response(JSON.stringify({}), { status: 404 });
-  }, async () => {
-    const result = await simCreateParties(
-      mock as unknown as SupabaseClient,
-      config,
-      noop,
-      "https://mock.supabase.co",
-      "anon-key",
-    );
-
-    assertEquals(result.partyIds, ["ef-party-1"]);
-    assertEquals(result.eventIds, ["ef-event-1"]);
-    // Direct DB inserts should not have been called for party/event
-    assertEquals(directInserts.filter((d) => d === "party").length, 0);
-    assertEquals(directInserts.filter((d) => d === "event").length, 0);
-    // EF calls were made for party and event
-    assertEquals(efCalls.some((c) => c.url.includes("partner-manage-party")), true);
-    assertEquals(efCalls.some((c) => c.url.includes("partner-manage-event")), true);
-  });
-  } finally {
-    Deno.env.delete("SIM_USER_PASSWORD");
-  }
-  },
-});
-
-// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
-// token auto-refresh even when persistSession=false. The interval leaks within the test but is
-// harmless — suppressing the leak check is correct here rather than patching the library.
-Deno.test({
-  name: "simCreateParties - falls back to direct DB when EF fails and strict=false",
-  sanitizeResources: false,
-  sanitizeOps: false,
-  fn: async () => {
-  const directPartyInserts: unknown[] = [];
-  const directEventInserts: unknown[] = [];
-
-  const mock = createMockSupabaseClient({
-    tables: {
-      partners: { select: () => ({ data: [{ id: "partner-1" }], error: null }) },
-      locations: { select: () => ({ data: { id: "loc-1" }, error: null }) },
-      partner_members: { select: () => ({ data: [{ user_id: "partner-user-1" }], error: null }) },
-      ticket_templates: { select: () => ({ data: [], error: null }) },
-      parties: {
-        insert: ({ values }: { values: unknown }) => {
-          directPartyInserts.push(values);
-          return { data: { id: "db-party-1" }, error: null };
-        },
-      },
-      events: {
-        insert: ({ values }: { values: unknown }) => {
-          directEventInserts.push(values);
-          return { data: { id: "db-event-1" }, error: null };
-        },
-      },
-      entry_groups: { insert: () => ({ data: { id: "grp-1" }, error: null }) },
-      tickets: { insert: () => ({ data: null, error: null }) },
-    },
-    authAdminGetUserById: (_userId: string) => ({ data: { user: { email: "partner1@test.com" } }, error: null }),
-  });
-
-  const config: SimConfig = { ...DEFAULT_CONFIG, party_count: 1, events_per_party: 1 };
-  const warnings: string[] = [];
-  const warnLog = (entry: { level: string; message: string }) => {
-    if (entry.level === "warn") warnings.push(entry.message);
-  };
-
-  Deno.env.set("SIM_USER_PASSWORD", "test-password");
-  try {
-    await withMockFetch((url) => {
       if (url.includes("auth/v1/token")) {
         return new Response(JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }), { status: 200 });
       }
-      // EF returns 500 to simulate failure
-      return new Response(JSON.stringify({ error: "internal" }), { status: 500 });
+      if (url.includes("partner-manage-party")) {
+        return new Response(JSON.stringify({ success: true, party_id: "ef-party-1" }), { status: 200 });
+      }
+      if (url.includes("partner-manage-event")) {
+        return new Response(JSON.stringify({ success: true, event_id: "ef-event-1" }), { status: 200 });
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
     }, async () => {
       const result = await simCreateParties(
         mock as unknown as SupabaseClient,
         config,
-        warnLog as Parameters<typeof simCreateParties>[2],
+        noop,
         "https://mock.supabase.co",
         "anon-key",
-        false, // strict=false
       );
 
-      // Should have fallen back to direct DB for both party and event
-      assertEquals(directPartyInserts.length, 1);
-      assertEquals(directEventInserts.length, 1);
-      assertEquals(result.partyIds.length, 1);
-      assertEquals(result.eventIds.length, 1);
-      // Warning was emitted for EF failure
-      assertEquals(warnings.some((w) => w.includes("falling back to direct DB")), true);
+      assertEquals(result.partyIds, ["ef-party-1"]);
+      assertEquals(result.eventIds, ["ef-event-1"]);
+      // EF calls were made for party and event
+      assertEquals(efCalls.some((c) => c.url.includes("partner-manage-party")), true);
+      assertEquals(efCalls.some((c) => c.url.includes("partner-manage-event")), true);
     });
   } finally {
     Deno.env.delete("SIM_USER_PASSWORD");
@@ -281,7 +98,66 @@ Deno.test({
 // token auto-refresh even when persistSession=false. The interval leaks within the test but is
 // harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
-  name: "simCreateParties - throws when EF fails and strict=true",
+  name: "simCreateParties - event EF body includes min_confirmed_count and metadata",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+  const eventEfBodies: Record<string, unknown>[] = [];
+
+  const mock = createMockSupabaseClient({
+    tables: {
+      partners: { select: () => ({ data: [{ id: "partner-1" }], error: null }) },
+      locations: { select: () => ({ data: { id: "loc-1" }, error: null }) },
+      partner_members: { select: () => ({ data: [{ user_id: "partner-user-1" }], error: null }) },
+      ticket_templates: { select: () => ({ data: [{ id: "tmpl-1", name: "일반" }], error: null }) },
+    },
+    authAdminGetUserById: (_userId: string) => ({ data: { user: { email: "partner1@test.com" } }, error: null }),
+  });
+
+  const config: SimConfig = { ...DEFAULT_CONFIG, party_count: 1, events_per_party: 1 };
+
+  Deno.env.set("SIM_USER_PASSWORD", "test-password");
+  try {
+    await withMockFetch((url, init) => {
+      if (url.includes("auth/v1/token")) {
+        return new Response(JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }), { status: 200 });
+      }
+      if (url.includes("partner-manage-party")) {
+        return new Response(JSON.stringify({ success: true, party_id: "ef-party-1" }), { status: 200 });
+      }
+      if (url.includes("partner-manage-event")) {
+        try {
+          eventEfBodies.push(JSON.parse((init.body as string) ?? "{}") as Record<string, unknown>);
+        } catch { /* intentionally empty */ }
+        return new Response(JSON.stringify({ success: true, event_id: "ef-event-1" }), { status: 200 });
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    }, async () => {
+      await simCreateParties(
+        mock as unknown as SupabaseClient,
+        config,
+        noop,
+        "https://mock.supabase.co",
+        "anon-key",
+      );
+
+      assertEquals(eventEfBodies.length, 1);
+      const eventBody = eventEfBodies[0].event as Record<string, unknown>;
+      assertEquals(eventBody.min_confirmed_count, 4);
+      assertEquals((eventBody.metadata as Record<string, unknown>).show_participant_list, true);
+      assertEquals((eventBody.metadata as Record<string, unknown>).visibility, "public");
+    });
+  } finally {
+    Deno.env.delete("SIM_USER_PASSWORD");
+  }
+  },
+});
+
+// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
+// token auto-refresh even when persistSession=false. The interval leaks within the test but is
+// harmless — suppressing the leak check is correct here rather than patching the library.
+Deno.test({
+  name: "simCreateParties - throws when EF fails",
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
@@ -291,10 +167,6 @@ Deno.test({
       locations: { select: () => ({ data: { id: "loc-1" }, error: null }) },
       partner_members: { select: () => ({ data: [{ user_id: "partner-user-1" }], error: null }) },
       ticket_templates: { select: () => ({ data: [], error: null }) },
-      parties: { insert: () => ({ data: { id: "db-party-1" }, error: null }) },
-      events: { insert: () => ({ data: { id: "db-event-1" }, error: null }) },
-      entry_groups: { insert: () => ({ data: { id: "grp-1" }, error: null }) },
-      tickets: { insert: () => ({ data: null, error: null }) },
     },
     authAdminGetUserById: (_userId: string) => ({ data: { user: { email: "partner1@test.com" } }, error: null }),
   });
@@ -303,64 +175,277 @@ Deno.test({
 
   Deno.env.set("SIM_USER_PASSWORD", "test-password");
   try {
-  await withMockFetch((url) => {
-    if (url.includes("auth/v1/token")) {
-      return new Response(JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }), { status: 200 });
-    }
-    return new Response(JSON.stringify({ error: "internal" }), { status: 500 });
-  }, async () => {
-    await assertRejects(
-      () => simCreateParties(
-        mock as unknown as SupabaseClient,
-        config,
-        noop,
-        "https://mock.supabase.co",
-        "anon-key",
-        true, // strict=true → should throw
-      ),
-      Error,
-      "EF partner-manage-party returned status=500",
-    );
-  });
+    await withMockFetch((url) => {
+      if (url.includes("auth/v1/token")) {
+        return new Response(JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "internal" }), { status: 500 });
+    }, async () => {
+      await assertRejects(
+        () => simCreateParties(
+          mock as unknown as SupabaseClient,
+          config,
+          noop,
+          "https://mock.supabase.co",
+          "anon-key",
+        ),
+        Error,
+        "EF partner-manage-party returned status=500",
+      );
+    });
   } finally {
     Deno.env.delete("SIM_USER_PASSWORD");
   }
   },
 });
 
-Deno.test("simCreateParties - direct DB path when supabaseUrl/anonKey not provided", async () => {
-  const createdParties: unknown[] = [];
-  const createdEvents: unknown[] = [];
+Deno.test({
+  name: "simCreateParties - throws when SIM_USER_PASSWORD not set",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+  const mock = createMockSupabaseClient({
+    tables: {
+      partners: { select: () => ({ data: [{ id: "partner-1" }], error: null }) },
+      locations: { select: () => ({ data: { id: "loc-1" }, error: null }) },
+    },
+  });
+
+  // Ensure SIM_USER_PASSWORD is not set
+  Deno.env.delete("SIM_USER_PASSWORD");
+
+  await assertRejects(
+    () => simCreateParties(
+      mock as unknown as SupabaseClient,
+      DEFAULT_CONFIG,
+      noop,
+      "https://mock.supabase.co",
+      "anon-key",
+    ),
+    Error,
+    "SIM_USER_PASSWORD is required",
+  );
+  },
+});
+
+// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
+// token auto-refresh even when persistSession=false. The interval leaks within the test but is
+// harmless — suppressing the leak check is correct here rather than patching the library.
+Deno.test({
+  name: "simCreateParties - creates 4 distinct start_time zones via EF",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+  const eventStartTimes: string[] = [];
 
   const mock = createMockSupabaseClient({
     tables: {
       partners: { select: () => ({ data: [{ id: "partner-1" }], error: null }) },
       locations: { select: () => ({ data: { id: "loc-1" }, error: null }) },
+      partner_members: { select: () => ({ data: [{ user_id: "partner-user-1" }], error: null }) },
+      ticket_templates: { select: () => ({ data: [{ id: "tmpl-1", name: "일반" }], error: null }) },
+    },
+    authAdminGetUserById: (_userId: string) => ({ data: { user: { email: "partner1@test.com" } }, error: null }),
+  });
+
+  const config: SimConfig = { ...DEFAULT_CONFIG, party_count: 1, events_per_party: 4 };
+
+  Deno.env.set("SIM_USER_PASSWORD", "test-password");
+  try {
+    await withMockFetch((url, init) => {
+      if (url.includes("auth/v1/token")) {
+        return new Response(JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }), { status: 200 });
+      }
+      if (url.includes("partner-manage-party")) {
+        return new Response(JSON.stringify({ success: true, party_id: "ef-party-1" }), { status: 200 });
+      }
+      if (url.includes("partner-manage-event")) {
+        try {
+          const body = JSON.parse((init.body as string) ?? "{}") as { event?: { start_time?: string } };
+          if (body.event?.start_time) eventStartTimes.push(body.event.start_time);
+        } catch { /* intentionally empty */ }
+        return new Response(JSON.stringify({ success: true, event_id: `ef-event-${eventStartTimes.length}` }), { status: 200 });
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    }, async () => {
+      await simCreateParties(
+        mock as unknown as SupabaseClient,
+        config,
+        noop,
+        "https://mock.supabase.co",
+        "anon-key",
+      );
+
+      assertEquals(eventStartTimes.length, 4);
+      const now = Date.now();
+      const times = eventStartTimes.map((t) => new Date(t).getTime());
+
+      const plusTwoDays = now + 2 * 24 * 60 * 60 * 1000;
+      const plusFiveDays = now + 5 * 24 * 60 * 60 * 1000;
+      const plusThirtyDays = now + 30 * 24 * 60 * 60 * 1000;
+      const plusTwelveHours = now + 12 * 60 * 60 * 1000;
+
+      assertEquals(times.every((t) => t - now > 2 * 60 * 60 * 1000), true);
+      assertEquals(times.some((t) => t > plusThirtyDays - 60000), true);
+      assertEquals(times.some((t) => t > plusFiveDays - 60000 && t < plusFiveDays + 60000), true);
+      assertEquals(times.some((t) => t > plusTwoDays - 60000 && t < plusTwoDays + 60000), true);
+      assertEquals(times.some((t) => t > plusTwelveHours - 60000 && t < plusTwelveHours + 60000), true);
+    });
+  } finally {
+    Deno.env.delete("SIM_USER_PASSWORD");
+  }
+  },
+});
+
+// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
+// token auto-refresh even when persistSession=false. The interval leaks within the test but is
+// harmless — suppressing the leak check is correct here rather than patching the library.
+Deno.test({
+  name: "simCreateDisplayEvents - creates display parties and events via EF",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+  const efCalls: { url: string; body: unknown }[] = [];
+  let partyCallCount = 0;
+  let eventCallCount = 0;
+
+  const mock = createMockSupabaseClient({
+    tables: {
+      parties: { select: () => ({ data: [], error: null }) },
+      partners: { select: () => ({ data: [{ id: "partner-1" }], error: null }) },
+      locations: { select: () => ({ data: null, error: null }) },
+      partner_members: { select: () => ({ data: [{ user_id: "partner-user-1" }], error: null }) },
+      ticket_templates: { select: () => ({ data: [{ id: "tmpl-display-1", name: "일반 티켓" }], error: null }) },
+    },
+    authAdminGetUserById: (_userId: string) => ({ data: { user: { email: "partner1@test.com" } }, error: null }),
+  });
+
+  Deno.env.set("SIM_USER_PASSWORD", "test-password");
+  try {
+    await withMockFetch((url, init) => {
+      const body = JSON.parse((init.body as string) ?? "{}");
+      efCalls.push({ url, body });
+
+      if (url.includes("auth/v1/token")) {
+        return new Response(JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }), { status: 200 });
+      }
+      if (url.includes("partner-manage-party")) {
+        partyCallCount++;
+        return new Response(JSON.stringify({ success: true, party_id: `ef-display-party-${partyCallCount}` }), { status: 200 });
+      }
+      if (url.includes("partner-manage-event")) {
+        eventCallCount++;
+        return new Response(JSON.stringify({ success: true, event_id: `ef-display-event-${eventCallCount}` }), { status: 200 });
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    }, async () => {
+      const result = await simCreateDisplayEvents(
+        mock as unknown as SupabaseClient,
+        noop,
+        "https://mock.supabase.co",
+        "anon-key",
+      );
+
+      // 5 display scenarios → 5 parties, 2 events each = 10 events
+      assertEquals(result.displayPartyIds.length, 5);
+      assertEquals(result.displayEventIds.length, 10);
+      assertEquals(partyCallCount, 5);
+      assertEquals(eventCallCount, 10);
+    });
+  } finally {
+    Deno.env.delete("SIM_USER_PASSWORD");
+  }
+  },
+});
+
+// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
+// token auto-refresh even when persistSession=false. The interval leaks within the test but is
+// harmless — suppressing the leak check is correct here rather than patching the library.
+Deno.test({
+  name: "simCreateDisplayEvents - skips when display parties already exist",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+  let efCallCount = 0;
+
+  // Return 5 existing parties (all DISPLAY_SCENARIOS already exist)
+  const mock = createMockSupabaseClient({
+    tables: {
       parties: {
-        insert: ({ values }: { values: unknown }) => {
-          createdParties.push(values);
-          return { data: { id: "db-party-1" }, error: null };
-        },
+        select: () => ({
+          data: Array.from({ length: 5 }, (_, i) => ({ id: `existing-party-${i}` })),
+          error: null,
+        }),
       },
-      events: {
-        insert: ({ values }: { values: unknown }) => {
-          createdEvents.push(values);
-          return { data: { id: "db-event-1" }, error: null };
-        },
-      },
-      entry_groups: { insert: () => ({ data: { id: "grp-1" }, error: null }) },
-      tickets: { insert: () => ({ data: null, error: null }) },
     },
   });
 
-  const config: SimConfig = { ...DEFAULT_CONFIG, party_count: 1, events_per_party: 2 };
-  // No supabaseUrl/anonKey → always direct DB
-  const result = await simCreateParties(mock as unknown as SupabaseClient, config, noop);
+  Deno.env.set("SIM_USER_PASSWORD", "test-password");
+  try {
+    await withMockFetch((url) => {
+      if (!url.includes("auth/v1/token")) efCallCount++;
+      return new Response(JSON.stringify({}), { status: 200 });
+    }, async () => {
+      const result = await simCreateDisplayEvents(
+        mock as unknown as SupabaseClient,
+        noop,
+        "https://mock.supabase.co",
+        "anon-key",
+      );
 
-  assertEquals(result.partyIds.length, 1);
-  assertEquals(result.eventIds.length, 2);
-  assertEquals(createdParties.length, 1);
-  assertEquals(createdEvents.length, 2);
+      // No EF calls made — dedup check triggered early return
+      assertEquals(efCallCount, 0);
+      assertEquals(result.displayPartyIds.length, 0);
+      assertEquals(result.displayEventIds.length, 0);
+    });
+  } finally {
+    Deno.env.delete("SIM_USER_PASSWORD");
+  }
+  },
+});
+
+// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
+// token auto-refresh even when persistSession=false. The interval leaks within the test but is
+// harmless — suppressing the leak check is correct here rather than patching the library.
+Deno.test({
+  name: "simCreateDisplayEvents - throws when display party EF fails",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+  const mock = createMockSupabaseClient({
+    tables: {
+      parties: { select: () => ({ data: [], error: null }) },
+      partners: { select: () => ({ data: [{ id: "partner-1" }], error: null }) },
+      locations: { select: () => ({ data: null, error: null }) },
+      partner_members: { select: () => ({ data: [{ user_id: "partner-user-1" }], error: null }) },
+      ticket_templates: { select: () => ({ data: [], error: null }) },
+    },
+    authAdminGetUserById: (_userId: string) => ({ data: { user: { email: "partner1@test.com" } }, error: null }),
+  });
+
+  Deno.env.set("SIM_USER_PASSWORD", "test-password");
+  try {
+    await withMockFetch((url) => {
+      if (url.includes("auth/v1/token")) {
+        return new Response(JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ error: "internal" }), { status: 500 });
+    }, async () => {
+      await assertRejects(
+        () => simCreateDisplayEvents(
+          mock as unknown as SupabaseClient,
+          noop,
+          "https://mock.supabase.co",
+          "anon-key",
+        ),
+        Error,
+        "EF partner-manage-party returned status=500",
+      );
+    });
+  } finally {
+    Deno.env.delete("SIM_USER_PASSWORD");
+  }
+  },
 });
 
 // ── simDiscoverAndApply — user-centric loop tests (Fix #1323) ────────────────

--- a/supabase/functions/backend-simulator/sim_create_test.ts
+++ b/supabase/functions/backend-simulator/sim_create_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "@std/assert";
+import { assertEquals, assertExists, assertRejects } from "@std/assert";
 import { createMockSupabaseClient } from "../_test_utils/mock_supabase_client.ts";
 import { simCreateParties, simCreateDisplayEvents, simDiscoverAndApply } from "./sim_create.ts";
 import type { SupabaseClient } from "@supabase/supabase-js";
@@ -351,6 +351,13 @@ Deno.test({
       assertEquals(result.displayEventIds.length, 10);
       assertEquals(partyCallCount, 5);
       assertEquals(eventCallCount, 10);
+
+      // Verify event payloads include title
+      const eventCalls = efCalls.filter(c => c.url.includes("partner-manage-event"));
+      for (const call of eventCalls) {
+        const body = call.body as { event?: { title?: string } };
+        assertExists(body.event?.title, "display event must have a title");
+      }
     });
   } finally {
     Deno.env.delete("SIM_USER_PASSWORD");

--- a/supabase/functions/partner-manage-event/index.ts
+++ b/supabase/functions/partner-manage-event/index.ts
@@ -25,6 +25,7 @@ const EVENT_FIELDS = [
   "contact_options",
   "vote_start_at",
   "vote_end_at",
+  "metadata",
 ] as const;
 
 // Fields allowed in ticket update

--- a/supabase/functions/partner-manage-party/index.ts
+++ b/supabase/functions/partner-manage-party/index.ts
@@ -24,6 +24,7 @@ const PARTY_FIELDS = [
   "max_participants",
   "balance_config",
   "status",
+  "metadata",
 ] as const;
 
 // Fields allowed in location create/update


### PR DESCRIPTION
Scheduler: needs-arch-claude-team-1

Closes #1282

## Summary

- `partner-manage-party`/`partner-manage-event` EF에 `metadata` 필드 지원 추가
- `simCreateParties`에서 direct DB fallback 제거, EF-only로 전환 (`strict` 파라미터 제거)
- `simCreateDisplayEvents`를 전체 EF 호출로 전환 (기존 pure direct DB → partner-manage-party + partner-manage-event EF)
- `index.ts` 호출자 시그니처 업데이트 (supabaseUrl, anonKey 필수 전달)
- EF-only 테스트 8개 작성 (기존 direct DB 테스트 5개 제거 → 대체)
- E2E 테스트 mock에 auth/EF 엔드포인트 추가

## Test plan

- [x] `deno test --allow-all --no-check` — 106 passed, 0 failed
- [ ] CI `test-edge-functions` 통과 확인
- [ ] CodeRabbit 리뷰 대응

🤖 Generated with [Claude Code](https://claude.com/claude-code)