### PR TITLE
refactor(simulator): strict mode 기본화 + direct DB fallback 삭제 (#1283)

### DIFF
--- a/supabase/functions/backend-simulator/index.ts
+++ b/supabase/functions/backend-simulator/index.ts
@@ -46,7 +46,6 @@ const DEFAULT_CONFIG: SimConfig = {
   user_batch_size: 10,
   checkin_rate: 0.7,
   no_show_rate: 0.3,
-  strict: false,
 };
 
 // ─────────────────────────────────────────────────────────
@@ -119,7 +118,6 @@ Deno.serve(async (req: Request): Promise<Response> => {
       createResult.eventIds,
       supabaseUrl,
       anonKey,
-      config.strict,
     );
     return successResponse({
       success: true,
@@ -157,7 +155,6 @@ Deno.serve(async (req: Request): Promise<Response> => {
       undefined,
       supabaseUrl,
       anonKey,
-      config.strict,
     );
     return successResponse({
       success: true,
@@ -190,7 +187,6 @@ Deno.serve(async (req: Request): Promise<Response> => {
       config.refund_rate,
       supabaseUrl,
       anonKey,
-      config.strict,
     );
     return successResponse({
       success: true,
@@ -224,9 +220,8 @@ Deno.serve(async (req: Request): Promise<Response> => {
       config.checkin_rate,
       supabaseUrl,
       anonKey,
-      config.strict,
     );
-    const matchResult = await simMatch(supabase, eventIds, logFn, supabaseUrl, serviceRoleKey, config.strict);
+    const matchResult = await simMatch(supabase, eventIds, logFn, supabaseUrl, serviceRoleKey);
     const completeResult = await simCompleteEvents(supabase, eventIds, logFn);
 
     const allAssertions: SimAssertionResult[] = [
@@ -357,7 +352,6 @@ Deno.serve(async (req: Request): Promise<Response> => {
     createResult.eventIds,
     supabaseUrl,
     anonKey,
-    config.strict,
   );
 
   // Phase 3: Approve verifications (80% approve, 20% reject)
@@ -368,7 +362,6 @@ Deno.serve(async (req: Request): Promise<Response> => {
     undefined,
     supabaseUrl,
     anonKey,
-    config.strict,
   );
 
   // Phase 4: Refund requests (refund_rate % of paid)
@@ -379,7 +372,6 @@ Deno.serve(async (req: Request): Promise<Response> => {
     config.refund_rate,
     supabaseUrl,
     anonKey,
-    config.strict,
   );
 
   // Phase 5: Check-in + Match + Complete
@@ -390,9 +382,8 @@ Deno.serve(async (req: Request): Promise<Response> => {
     config.checkin_rate,
     supabaseUrl,
     anonKey,
-    config.strict,
   );
-  const matchResult = await simMatch(supabase, createResult.eventIds, logFn, supabaseUrl, serviceRoleKey, config.strict);
+  const matchResult = await simMatch(supabase, createResult.eventIds, logFn, supabaseUrl, serviceRoleKey);
   const completeResult = await simCompleteEvents(
     supabase,
     createResult.eventIds,

--- a/supabase/functions/backend-simulator/sim_approve.ts
+++ b/supabase/functions/backend-simulator/sim_approve.ts
@@ -33,7 +33,6 @@ export async function simApproveVerifications(
   approveRate: number = 0.8,
   supabaseUrl?: string,
   anonKey?: string,
-  strict?: boolean,
 ): Promise<SimApproveResult> {
   const approvedApplicationIds: string[] = [];
   const rejectedApplicationIds: string[] = [];
@@ -174,8 +173,8 @@ export async function simApproveVerifications(
         }
       }
     } catch (e) {
-      if (strict) throw e;
       log({ level: "error", phase: "approve", step: "approve_loop", message: `Unexpected error for app ${appId}: ${String(e)}` });
+      throw e;
     }
   }
 
@@ -294,8 +293,8 @@ export async function simApproveVerifications(
         }
       }
     } catch (e) {
-      if (strict) throw e;
       log({ level: "error", phase: "approve", step: "reject_loop", message: `Unexpected error for app ${appId}: ${String(e)}` });
+      throw e;
     }
   }
 

--- a/supabase/functions/backend-simulator/sim_approve_test.ts
+++ b/supabase/functions/backend-simulator/sim_approve_test.ts
@@ -338,9 +338,9 @@ Deno.test("simApproveVerifications - handles DB error gracefully (no throw)", as
   assertEquals(result.rejectedApplicationIds.length, 0);
 });
 
-// Fix #1280: EF failure (verification flow) must throw regardless of strict flag.
+// Fix #1283: EF failure always throws (strict parameter removed).
 Deno.test({
-  name: "simApproveVerifications - EF failure on verification flow throws error (strict=false)",
+  name: "simApproveVerifications - EF failure on verification flow throws error",
   sanitizeResources: false,
   sanitizeOps: false,
   fn: async () => {
@@ -366,11 +366,6 @@ Deno.test({
         },
       }),
     });
-
-    const logs: string[] = [];
-    const logFn = (entry: { level: string; message: string }) => {
-      logs.push(`${entry.level}: ${entry.message}`);
-    };
 
     Deno.env.set("SIM_USER_PASSWORD", "test-password");
     try {
@@ -392,83 +387,14 @@ Deno.test({
         }
         return new Response(JSON.stringify({}), { status: 404 });
       }, async () => {
-        // strict=false: error is logged, not propagated; result has 0 approved
-        const result = await simApproveVerifications(
-          mock as unknown as SupabaseClient,
-          ["app-ef-fail-1"],
-          logFn as unknown as Parameters<typeof simApproveVerifications>[2],
-          1.0,
-          "https://mock.supabase.co",
-          "anon-key",
-          false,
-        );
-        assertEquals(result.approvedApplicationIds.length, 0);
-        // Error was logged (not silent)
-        assertEquals(logs.some((l) => l.includes("error:")), true);
-      });
-    } finally {
-      Deno.env.delete("SIM_USER_PASSWORD");
-    }
-  },
-});
-
-// Fix #1280: EF failure (verification flow) must throw when strict=true.
-Deno.test({
-  name: "simApproveVerifications - EF failure on verification flow throws when strict=true",
-  sanitizeResources: false,
-  sanitizeOps: false,
-  fn: async () => {
-    const mock = createMockSupabaseClient({
-      ...makePartnerEmailMockOptions({
-        event_applications: {
-          select: ({ filters }: { filters: Record<string, unknown> }) => ({
-            data: {
-              id: filters["id"] as string,
-              event_id: "event-1",
-              ticket_id: "ticket-1",
-              user_id: "user-1",
-              status: "pending_review",
-            },
-            error: null,
-          }),
-        },
-        events: { select: makeEventSelectHandler() },
-        verifications: { select: makeVerificationSelectHandler("verif-1") },
-        // Fix #1326: user-submit-verification EF로 전환 — verification_submissions 직접 insert 제거
-        user_profiles: {
-          select: () => ({ data: { username: "user_001" }, error: null }),
-        },
-      }),
-    });
-
-    Deno.env.set("SIM_USER_PASSWORD", "test-password");
-    try {
-      await withMockFetch((url, init) => {
-        if (url.includes("auth/v1/token")) {
-          return new Response(
-            JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }),
-            { status: 200 },
-          );
-        }
-        // Fix #1326: user-submit-verification EF mock — succeeds so partner-review-submission is reached
-        if (url.includes("user-submit-verification")) {
-          const body = JSON.parse((init.body as string) ?? "{}");
-          return new Response(JSON.stringify({ submission_id: `sub-${body.application_id as string}` }), { status: 200 });
-        }
-        if (url.includes("partner-review-submission")) {
-          return new Response(JSON.stringify({ error: "internal" }), { status: 500 });
-        }
-        return new Response(JSON.stringify({}), { status: 404 });
-      }, async () => {
         await assertRejects(
           () => simApproveVerifications(
             mock as unknown as SupabaseClient,
-            ["app-strict-1"],
+            ["app-ef-fail-1"],
             noop,
             1.0,
             "https://mock.supabase.co",
             "anon-key",
-            true,
           ),
           Error,
           "partner-review-submission EF returned 500",

--- a/supabase/functions/backend-simulator/sim_create.ts
+++ b/supabase/functions/backend-simulator/sim_create.ts
@@ -449,7 +449,7 @@ async function applyForUser(
 }
 
 // Fix #1323: User-centric discover-and-apply loop
-// Note: #1283 에서 strict 파라미터 제거 및 EF-only 전환 예정 (simCreateParties/simCreateDisplayEvents와 일관성)
+// Fix #1283: strict 파라미터 제거 — EF-only 전환 완료
 export async function simDiscoverAndApply(
   supabase: SupabaseClient,
   config: SimConfig,
@@ -457,7 +457,6 @@ export async function simDiscoverAndApply(
   newEventIds: string[],
   supabaseUrl?: string,
   anonKey?: string,
-  strict?: boolean,
 ): Promise<{ applicationIds: string[]; paidApplicationIds: string[]; pendingReviewApplicationIds: string[] }> {
   const applicationIds: string[] = [];
   const paidApplicationIds: string[] = [];
@@ -465,16 +464,11 @@ export async function simDiscoverAndApply(
 
   const simUserPassword = Deno.env.get("SIM_USER_PASSWORD");
   if (!simUserPassword) {
-    const errMsg = "SIM_USER_PASSWORD not set; cannot acquire user token for user-event-feed EF";
-    if (strict) throw new Error(errMsg);
-    log({ level: "warn", phase: "apply", step: "sim_user_password", message: errMsg });
+    throw new Error("SIM_USER_PASSWORD not set; cannot acquire user token for user-event-feed EF");
   }
 
   if (!supabaseUrl || !anonKey || !simUserPassword) {
-    const errMsg = "supabaseUrl, anonKey, or SIM_USER_PASSWORD not available — cannot call user-event-feed EF";
-    if (strict) throw new Error(errMsg);
-    log({ level: "error", phase: "apply", step: "event_feed", message: errMsg });
-    return { applicationIds, paidApplicationIds, pendingReviewApplicationIds };
+    throw new Error("supabaseUrl, anonKey, or SIM_USER_PASSWORD not available — cannot call user-event-feed EF");
   }
 
   const { data: usersRaw } = await supabase

--- a/supabase/functions/backend-simulator/sim_create_test.ts
+++ b/supabase/functions/backend-simulator/sim_create_test.ts
@@ -816,44 +816,21 @@ Deno.test({
   },
 });
 
-// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
-// token auto-refresh even when persistSession=false. The interval leaks within the test but is
-// harmless — suppressing the leak check is correct here rather than patching the library.
-Deno.test({
-  name: "simDiscoverAndApply - skips when credentials not available",
-  sanitizeResources: false,
-  sanitizeOps: false,
-  fn: async () => {
-  const warnings: string[] = [];
-  const warnLog = (entry: { level: string; message: string }) => {
-    if (entry.level === "error" || entry.level === "warn") warnings.push(entry.message);
-  };
+// Fix #1283: credentials 누락 시 즉시 throw (strict 제거 후 유일한 동작)
+Deno.test("simDiscoverAndApply - throws when credentials not available", async () => {
+  const mock = createMockSupabaseClient({});
 
-  const mock = createMockSupabaseClient({
-    tables: {
-      user_profiles: {
-        select: () => ({
-          data: [{ id: "user-1", gender: "male", birth_date: "1998-01-01", username: "user1" }],
-          error: null,
-        }),
-      },
-    },
-  });
-
-  // No SIM_USER_PASSWORD set, no supabaseUrl/anonKey — credentials unavailable
-  const result = await simDiscoverAndApply(
-    mock as unknown as SupabaseClient,
-    DEFAULT_CONFIG,
-    warnLog as Parameters<typeof simDiscoverAndApply>[2],
-    ["event-1"],
-    // supabaseUrl and anonKey intentionally omitted
+  // No SIM_USER_PASSWORD set — throws immediately
+  await assertRejects(
+    () => simDiscoverAndApply(
+      mock as unknown as SupabaseClient,
+      DEFAULT_CONFIG,
+      noop,
+      ["event-1"],
+    ),
+    Error,
+    "SIM_USER_PASSWORD not set",
   );
-
-  // No applications created because credentials are missing
-  assertEquals(result.applicationIds.length, 0);
-  // A warning/error about missing credentials was logged
-  assertEquals(warnings.some((w) => w.includes("SIM_USER_PASSWORD") || w.includes("supabaseUrl") || w.includes("cannot")), true);
-  },
 });
 
 // sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for

--- a/supabase/functions/backend-simulator/sim_create_test.ts
+++ b/supabase/functions/backend-simulator/sim_create_test.ts
@@ -13,7 +13,6 @@ const DEFAULT_CONFIG: SimConfig = {
   user_batch_size: 10,
   checkin_rate: 0.7,
   no_show_rate: 0.3,
-  strict: false,
 };
 
 const noop = () => {};

--- a/supabase/functions/backend-simulator/sim_event.ts
+++ b/supabase/functions/backend-simulator/sim_event.ts
@@ -39,9 +39,8 @@ export interface SimEventResult {
  * - checkinRate (default 0.7) fraction → status='checked_in' via event-checkin EF
  * - remaining fraction → status='no_show' via direct DB (no EF for passive state)
  *
- * EF is the primary path for checked_in. Direct DB fallback only applies when
- * supabaseUrl/anonKey are missing AND strict=false. With strict=true, missing
- * credentials cause an immediate error.
+ * EF is the only path for checked_in. supabaseUrl/anonKey are required.
+ * Missing credentials cause an immediate error.
  *
  * Asserts checkin ratio within ±0.15 tolerance.
  */
@@ -52,7 +51,6 @@ export async function simCheckin(
   checkinRate: number = 0.7,
   supabaseUrl?: string,
   anonKey?: string,
-  strict?: boolean,
 ): Promise<{ checkedInParticipantIds: string[]; noShowParticipantIds: string[]; assertions: SimAssertionResult[] }> {
   const checkedInParticipantIds: string[] = [];
   const noShowParticipantIds: string[] = [];
@@ -65,31 +63,10 @@ export async function simCheckin(
     return { checkedInParticipantIds, noShowParticipantIds, assertions };
   }
 
-  // Fix #1281: EF-first — supabaseUrl/anonKey are required for checked_in path.
-  // In strict mode, fail fast before processing any events.
+  // Fix #1281: EF-only — supabaseUrl/anonKey are required for checked_in path.
+  // Fix #1283: strict parameter removed — fail fast always.
   if (!supabaseUrl || !anonKey) {
-    if (strict) {
-      throw new Error("Strict mode: supabaseUrl and anonKey are required for event-checkin EF");
-    }
-    log({ level: "warn", phase: "checkin", step: "no_credentials", message: "supabaseUrl/anonKey not provided — checked_in participants will use direct DB fallback" });
-  }
-
-  // Fix #998: event-checkin EF requires status='active' or 'ongoing', but simCheckin is called
-  // before simCompleteEvents (which drives scheduled→active→ongoing→completed). Pre-activate
-  // all scheduled events here so the EF status gate passes — mirrors real-world cron activation.
-  // Skip pre-activation in strict mode: events should already be active in a production-like run.
-  if (!strict) {
-    const { error: preActivateErr } = await supabase
-      .from("events")
-      .update({ status: "active" })
-      .eq("status", "scheduled")
-      .in("id", eventIds);
-
-    if (preActivateErr) {
-      log({ level: "warn", phase: "checkin", step: "pre_activate", message: `Failed to pre-activate scheduled events: ${preActivateErr.message}` });
-    } else {
-      log({ level: "info", phase: "checkin", step: "pre_activate", message: `Pre-activated scheduled events to active for EF check-in (${eventIds.length} event IDs processed)` });
-    }
+    throw new Error("supabaseUrl and anonKey are required for event-checkin EF");
   }
 
   // Fix #531: Process events in batches to prevent curl 120s timeout.
@@ -167,20 +144,6 @@ export async function simCheckin(
             log({ level: "info", phase: "checkin", step: "direct_checkin", message: `Checked in partner participant ${participant.id} via direct DB (no user token available)` });
             continue;
           }
-        } else {
-          // No credentials provided and strict=false — direct DB fallback with warning already logged above
-          const { error: updErr } = await supabase
-            .from("event_participants")
-            .update({ status: "checked_in" })
-            .eq("id", participant.id);
-
-          if (updErr) {
-            log({ level: "error", phase: "checkin", step: "update_participant", message: `Failed to update participant ${participant.id}: ${updErr.message}` });
-            continue;
-          }
-
-          checkedInParticipantIds.push(participant.id);
-          continue;
         }
       }
 
@@ -247,7 +210,6 @@ export async function simMatch(
   log: (entry: Omit<SimLogEntry, "timestamp">) => void,
   supabaseUrl?: string,
   serviceRoleKey?: string,
-  strict?: boolean,
 ): Promise<{ matchPairs: Array<{ userId1: string; userId2: string; eventId: string }>; assertions: SimAssertionResult[] }> {
   const matchPairs: Array<{ userId1: string; userId2: string; eventId: string }> = [];
   const assertions: SimAssertionResult[] = [];
@@ -258,14 +220,9 @@ export async function simMatch(
   }
 
   // Fix #1281: EF-only — supabaseUrl/serviceRoleKey are required
+  // Fix #1283: strict parameter removed — fail fast always.
   if (!supabaseUrl || !serviceRoleKey) {
-    const msg = "supabaseUrl and serviceRoleKey are required for event-matching EF";
-    if (strict) {
-      throw new Error(`Strict mode: ${msg}`);
-    }
-    // Non-strict: log warning and return empty result — no direct DB fallback
-    log({ level: "warn", phase: "match", step: "no_credentials", message: `${msg} — skipping match phase` });
-    return { matchPairs, assertions };
+    throw new Error("supabaseUrl and serviceRoleKey are required for event-matching EF");
   }
 
   // Fix #531: Process events in batches to prevent curl 120s timeout.

--- a/supabase/functions/backend-simulator/sim_event_test.ts
+++ b/supabase/functions/backend-simulator/sim_event_test.ts
@@ -220,6 +220,8 @@ Deno.test({ name: "simCheckin - empty participants returns empty", sanitizeOps: 
     ["event-empty"],
     noop,
     0.7,
+    "https://example.supabase.co",
+    "anon-key",
   );
 
   assertEquals(result.checkedInParticipantIds, []);

--- a/supabase/functions/backend-simulator/sim_event_test.ts
+++ b/supabase/functions/backend-simulator/sim_event_test.ts
@@ -284,7 +284,7 @@ Deno.test({
   },
 });
 
-Deno.test("simCheckin - strict mode + no credentials throws immediately", async () => {
+Deno.test("simCheckin - no credentials throws immediately", async () => {
   const mock = createMockSupabaseClient({});
 
   await assertRejects(
@@ -293,76 +293,10 @@ Deno.test("simCheckin - strict mode + no credentials throws immediately", async 
       ["event-1"],
       noop,
       0.7,
-      undefined,
-      undefined,
-      true, // strict
     ),
     Error,
     "supabaseUrl and anonKey are required",
   );
-});
-
-Deno.test("simCheckin - no credentials + strict=false falls back to direct DB", async () => {
-  const participantStatuses: Record<string, string> = {};
-
-  const participants = [
-    { id: "p-1", user_id: "u-1", status: "ticket_issued" },
-    { id: "p-2", user_id: "u-2", status: "ticket_issued" },
-    { id: "p-3", user_id: "u-3", status: "ticket_issued" },
-    { id: "p-4", user_id: "u-4", status: "ticket_issued" },
-    { id: "p-5", user_id: "u-5", status: "ticket_issued" },
-    { id: "p-6", user_id: "u-6", status: "ticket_issued" },
-    { id: "p-7", user_id: "u-7", status: "ticket_issued" },
-    { id: "p-8", user_id: "u-8", status: "ticket_issued" },
-    { id: "p-9", user_id: "u-9", status: "ticket_issued" },
-    { id: "p-10", user_id: "u-10", status: "ticket_issued" },
-  ];
-
-  const mock = createMockSupabaseClient({
-    tables: {
-      events: {
-        update: () => ({ data: null, error: null }),
-      },
-      event_participants: {
-        select: ({ filters }) => {
-          if (filters["event_id"] && filters["status"] === "checked_in") {
-            const checkedIn = Object.entries(participantStatuses)
-              .filter(([, s]) => s === "checked_in").length;
-            return { data: new Array(checkedIn).fill({ id: "x", status: "checked_in" }), error: null };
-          }
-          if (filters["event_id"]) {
-            return {
-              data: participants.map((p) => ({
-                ...p,
-                status: participantStatuses[p.id] ?? p.status,
-              })),
-              error: null,
-            };
-          }
-          return { data: [], error: null };
-        },
-        update: ({ values, filters }) => {
-          const id = filters["id"] as string;
-          const v = values as { status: string };
-          participantStatuses[id] = v.status;
-          return { data: null, error: null };
-        },
-      },
-    },
-  });
-
-  const result = await simCheckin(
-    mock as unknown as SupabaseClient,
-    ["event-1"],
-    noop,
-    0.7,
-    // No supabaseUrl/anonKey — strict=false (default) → direct DB fallback
-  );
-
-  assertEquals(result.checkedInParticipantIds.length, 7);
-  assertEquals(result.noShowParticipantIds.length, 3);
-  assertEquals(result.assertions.length, 1);
-  assertEquals(result.assertions[0].passed, true);
 });
 
 // ─────────────────────────────────────────────────────────
@@ -446,7 +380,7 @@ Deno.test("simMatch - empty event list returns empty result", async () => {
   assertEquals(result.assertions, []);
 });
 
-Deno.test("simMatch - strict mode + no credentials throws immediately", async () => {
+Deno.test("simMatch - no credentials throws immediately", async () => {
   const mock = createMockSupabaseClient({});
 
   await assertRejects(
@@ -454,35 +388,10 @@ Deno.test("simMatch - strict mode + no credentials throws immediately", async ()
       mock as unknown as SupabaseClient,
       ["event-1"],
       noop,
-      undefined,
-      undefined,
-      true, // strict
     ),
     Error,
-    "supabaseUrl and serviceRoleKey are required",
+    "supabaseUrl and serviceRoleKey are required for event-matching EF",
   );
-});
-
-Deno.test("simMatch - no credentials + strict=false returns empty (no direct DB fallback)", async () => {
-  const mock = createMockSupabaseClient({});
-
-  const logs: string[] = [];
-  const collectLog = (entry: { level: string; message: string }) => {
-    logs.push(`${entry.level}: ${entry.message}`);
-  };
-
-  const result = await simMatch(
-    mock as unknown as SupabaseClient,
-    ["event-1"],
-    collectLog,
-    // No supabaseUrl/serviceRoleKey
-  );
-
-  assertEquals(result.matchPairs, []);
-  assertEquals(result.assertions, []);
-  // Should warn about missing credentials
-  const warnLogs = logs.filter((l) => l.startsWith("warn:"));
-  assertEquals(warnLogs.length >= 1, true);
 });
 
 Deno.test("simMatch - multiple events, multiple pairs via EF", async () => {

--- a/supabase/functions/backend-simulator/sim_refund.ts
+++ b/supabase/functions/backend-simulator/sim_refund.ts
@@ -21,7 +21,7 @@ export interface SimRefundResult {
  *   5. Assert refund processed correctly
  *
  * Fix #1327: Replace payment-cancel EF + direct DB with user-cancel-order EF as the sole
- * refund path. EF failure throws regardless of strict mode.
+ * refund path. EF failure throws.
  */
 export async function simRefundRequests(
   supabase: SupabaseClient,
@@ -30,7 +30,6 @@ export async function simRefundRequests(
   refundRate: number = 0.2,
   supabaseUrl?: string,
   anonKey?: string,
-  _strict?: boolean,
 ): Promise<SimRefundResult> {
   const refundedApplicationIds: string[] = [];
   const assertions: SimAssertionResult[] = [];

--- a/supabase/functions/backend-simulator/sim_types.ts
+++ b/supabase/functions/backend-simulator/sim_types.ts
@@ -9,9 +9,6 @@ export interface SimConfig {
   user_batch_size: number;    // concurrent user processing batch size (default: 10)
   checkin_rate: number;       // 0-1, 70% = 0.7
   no_show_rate: number;       // 0-1, 30% = 0.3
-  // Controls EF failure behaviour: true = throw on EF failure (no fallback),
-  // false (default) = log warning and fall back to direct DB operations.
-  strict: boolean;
 }
 
 export interface SimPhaseResult {


### PR DESCRIPTION
Scheduler: needs-arch-claude-team-1

## Summary

- `SimConfig.strict` 필드 제거 (sim_types.ts) — 이전 커밋에서 완료
- 모든 sim 함수에서 `strict` 파라미터 제거 및 EF 실패 시 direct DB fallback 코드 삭제
- 테스트 파일 3개에서 strict 관련 테스트 삭제/통합, `assertRejects`로 전환
- 총 236줄 삭제, 19줄 추가 — fallback 경로 완전 제거

## Changes

| 파일 | 변경 내용 |
|------|-----------|
| `sim_approve.ts` | `strict` 파라미터 제거, catch에서 무조건 throw |
| `sim_create.ts` | `strict` 파라미터 제거, credentials 누락 시 즉시 throw |
| `sim_event.ts` | `strict` 파라미터 제거, direct DB fallback 삭제, pre-activation 삭제 |
| `sim_refund.ts` | 미사용 `_strict` 파라미터 제거, 주석 정리 |
| `sim_approve_test.ts` | strict=true/false 분리 테스트 → 단일 throw 테스트로 통합 |
| `sim_create_test.ts` | `DEFAULT_CONFIG`에서 `strict: false` 제거 |
| `sim_event_test.ts` | fallback 테스트 삭제, strict 테스트 → 무조건 throw 테스트로 전환 |

## Test plan

- [ ] `deno test supabase/functions/backend-simulator/` 전체 테스트 통과
- [ ] `grep -rn "\.insert\|\.update\|\.delete" sim_*.ts`에서 assertion 외 0건 확인
- [ ] CI `ci-result` 통과

Closes #1283

🤖 Generated with [Claude Code](https://claude.com/claude-code)