### PR TITLE
feat(dev-seed): 유저 풀 60→560명 확대 — 연령/성별/지역 다차원 시딩

### DIFF
--- a/.github/workflows/daily-backend-simulation.yml
+++ b/.github/workflows/daily-backend-simulation.yml
@@ -15,13 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Static seed (users/partners)
+      # Fix #1334: 560 users seeded in 6 batches × 100 (EF wall-time limit 150s)
+      - name: Seed users/partners (batched — 6 × 100 = 560 total)
         run: |
-          curl -sf -X POST \
-            "${{ secrets.SUPABASE_DEV_URL }}/functions/v1/dev-seed?mode=static" \
-            -H "Authorization: Bearer ${{ secrets.SUPABASE_DEV_SECRET_KEY }}" \
-            -H "Content-Type: application/json" \
-            --max-time 180
+          for offset in 0 100 200 300 400 500; do
+            curl -sf -X POST \
+              "${{ secrets.SUPABASE_DEV_URL }}/functions/v1/dev-seed?mode=static&offset=$offset&limit=100" \
+              -H "Authorization: Bearer ${{ secrets.SUPABASE_DEV_SECRET_KEY }}" \
+              -H "Content-Type: application/json" \
+              --max-time 180
+            echo "Batch offset=$offset done"
+          done
 
       - name: Create parties and events
         run: |

--- a/supabase/functions/dev-seed/dev_seed_test.ts
+++ b/supabase/functions/dev-seed/dev_seed_test.ts
@@ -122,9 +122,9 @@ Deno.test({
         assertEquals(response.status, 200);
         const body = await readJson(response);
 
-        // static mode (default): 60 users (age 20-34 × 4 variants) + 5 partner owners
-        // created_users counts only generateAllPersonas() results (60), not partner owners
-        assertEquals(body.created_users, 60);
+        // static mode (default): 60 legacy users + 500 regional users = 560 total (#1334)
+        // created_users counts generateAllPersonas() results, not partner owners
+        assertEquals(body.created_users, 560);
         assertEquals(body.created_partners, 5);
         // static mode does not create parties/events — those require ?mode=full
         assertEquals(body.created_parties, undefined);
@@ -338,7 +338,7 @@ Deno.test({
         const response = await handler(new Request("http://localhost"));
         assertEquals(response.status, 200);
         const body = await readJson(response);
-        assertEquals(body.created_users, 60);
+        assertEquals(body.created_users, 560);
         // listUsers called exactly once (not per-user)
         assertEquals(listUsersCallCount, 1);
         // No update calls needed (empty list → all created fresh)
@@ -432,8 +432,8 @@ Deno.test({
         // Overall response is 200 even with 1 individual failure
         assertEquals(response.status, 200);
         const body = await readJson(response);
-        // 59 succeed, 1 fails (but doesn't crash)
-        assertEquals(body.created_users, 59);
+        // 559 succeed, 1 fails (but doesn't crash) — 560 total (#1334)
+        assertEquals(body.created_users, 559);
       });
     });
   },
@@ -538,6 +538,102 @@ Deno.test({
         assertEquals(response.status, 200);
         // listUsers called exactly once (cached)
         assertEquals(listUsersCallCount, 1);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "dev-seed - offset/limit seeds only the specified batch (#1334)",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+
+    let createUserCallCount = 0;
+
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: (req) =>
+          req.url.includes("/auth/v1/admin/users") && req.method === "GET",
+        handler: () => jsonResponse({ users: [] }),
+      },
+      {
+        matcher: (req) =>
+          req.url.includes("/auth/v1/admin/users") && req.method === "POST",
+        handler: async (req) => {
+          createUserCallCount++;
+          const body = await req.json();
+          return jsonResponse({
+            user: {
+              id: `user-${createUserCallCount}`,
+              email: body.email,
+              user_metadata: body.user_metadata,
+            },
+          });
+        },
+      },
+      {
+        matcher: (req) => req.url.includes("/storage/v1/object/list-v2/"),
+        handler: () =>
+          jsonResponse({
+            objects: [
+              { name: "seed-images/party_cafe_warm.jpg" },
+              { name: "seed-images/party_lounge_bright.jpg" },
+              { name: "seed-images/party_premium_lounge.jpg" },
+            ],
+          }),
+      },
+      {
+        matcher: (req) =>
+          req.url.includes("/rest/v1/") && req.method === "POST",
+        handler: () =>
+          jsonResponse({ id: crypto.randomUUID() }, {
+            status: 201,
+            headers: { "Content-Profile": "public" },
+          }),
+      },
+      {
+        matcher: (req) =>
+          req.url.includes("/rest/v1/verifications") && req.method === "GET",
+        handler: () => jsonResponse(null, { status: 200 }),
+      },
+      {
+        matcher: (req) =>
+          req.url.includes("/rest/v1/partners") && req.method === "GET",
+        handler: () => jsonResponse([]),
+      },
+      {
+        matcher: (req) =>
+          req.url.includes("/rest/v1/parties") && req.method === "GET",
+        handler: () => jsonResponse([]),
+      },
+    ]);
+
+    await withEnv({
+      ENVIRONMENT: "development",
+      SUPABASE_URL: "http://localhost:54321",
+      SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+    }, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        // Batch 1: offset=0, limit=100 → seeds first 100 of 560 personas
+        const response = await handler(
+          new Request("http://localhost?mode=static&offset=0&limit=100"),
+        );
+        assertEquals(response.status, 200);
+        const body = await readJson(response);
+        assertEquals(body.created_users, 100);
+
+        // Batch 6: offset=500, limit=100 → seeds remaining 60 personas (500..559)
+        createUserCallCount = 0;
+        const response2 = await handler(
+          new Request("http://localhost?mode=static&offset=500&limit=100"),
+        );
+        assertEquals(response2.status, 200);
+        const body2 = await readJson(response2);
+        assertEquals(body2.created_users, 60);
       });
     });
   },

--- a/supabase/functions/dev-seed/index.ts
+++ b/supabase/functions/dev-seed/index.ts
@@ -17,6 +17,10 @@ interface UserPersona {
     birth_date: string;
     phone_number: string;
     is_verified: boolean;
+    // Simulator location fields — only set for regional personas (#1334)
+    sim_region?: string;
+    sim_lat?: number;
+    sim_lng?: number;
   };
 }
 
@@ -387,6 +391,68 @@ function generateDescription(
 
 const SEED_PASSWORD = "password1234!";
 
+// ─── Regional Persona Generation (#1334) ───────────────────────────────────
+
+// 10 major regions with simulator GPS coordinates.
+const REGIONS = [
+  { name: "강남", lat: 37.4979, lng: 127.0276 },
+  { name: "홍대", lat: 37.5575, lng: 126.9245 },
+  { name: "성수", lat: 37.5445, lng: 127.0559 },
+  { name: "이태원", lat: 37.5340, lng: 126.9948 },
+  { name: "잠실", lat: 37.5133, lng: 127.1001 },
+  { name: "판교", lat: 37.3948, lng: 127.1112 },
+  { name: "부산_해운대", lat: 35.1631, lng: 129.1635 },
+  { name: "부산_서면", lat: 35.1578, lng: 129.0596 },
+  { name: "대구_동성로", lat: 35.8690, lng: 128.5941 },
+  { name: "제주", lat: 33.4996, lng: 126.5312 },
+] as const;
+
+// 25 ages(18-42) × 2 genders × 10 regions = 500 regional personas.
+// All regional users are is_verified: true for simulation.
+// Phone scheme: 010-5{regionIdx:1}{age-18:2}-{gender:1}000
+//   → 5000+regionIdx*100+(age-18), last4=1000(male)/2000(female)
+//   Max prefix = 5000+9*100+24 = 5924 (4 digits, no overflow).
+function generateRegionalPersonas(): UserPersona[] {
+  const currentYear = Temporal.Now.plainDateISO().year;
+  const personas: UserPersona[] = [];
+
+  for (let age = 18; age <= 42; age++) {
+    const birthYear = currentYear - age + 1;
+    const birthDate = `${birthYear}-01-01`;
+
+    for (const gender of ["male", "female"] as const) {
+      const genderShort = gender === "male" ? "m" : "f";
+      const last4 = gender === "male" ? "1000" : "2000";
+
+      for (let ri = 0; ri < REGIONS.length; ri++) {
+        const region = REGIONS[ri];
+        const prefix = 5000 + ri * 100 + (age - 18);
+        const username = `user_${age}_${genderShort}_${region.name}`;
+
+        personas.push({
+          email: `${username}@test.com`,
+          password: SEED_PASSWORD,
+          metadata: {
+            name: `${age}${gender === "male" ? "남" : "여"}_${region.name}`,
+            username,
+            gender,
+            birth_date: birthDate,
+            phone_number: `010-${prefix}-${last4}`,
+            is_verified: true,
+            sim_region: region.name,
+            sim_lat: region.lat,
+            sim_lng: region.lng,
+          },
+        });
+      }
+    }
+  }
+
+  return personas;
+}
+
+// ─── Legacy Persona Generation ──────────────────────────────────────────────
+
 // Merged generatePersonas + generate30sPersonas: covers age 20-34 in a single loop.
 // Phone prefix: 20-24 → 1000+age (preserves original), 25-34 → 2000+age (preserves original).
 // Email pattern: user_{age}_{m|f}_{ok|no}@test.com — preserved for E2E test compat.
@@ -435,6 +501,10 @@ function generateAllPersonas(): UserPersona[] {
       });
     }
   }
+
+  // Fix #1334: include 500 regional personas (25 ages × 2 genders × 10 regions)
+  // after the 60 legacy personas. generateAllPersonas() = 60 + 500 = 560 total.
+  personas.push(...generateRegionalPersonas());
 
   return personas;
 }
@@ -761,8 +831,16 @@ async function ensureGlobalVerifications(
 // ─── Domain Seeding Functions ───────────────────────────────────────
 
 // Fix #1272: listUsers를 1회만 호출하고 Map으로 캐시 — 60회 반복 호출 제거
-async function seedAllUsers(supabase: SupabaseClient): Promise<number> {
-  const personas = generateAllPersonas();
+// Fix #1334: offset/limit 지원 — 560명을 100명씩 6 배치로 분할 처리
+async function seedAllUsers(
+  supabase: SupabaseClient,
+  offset = 0,
+  limit: number | null = null,
+): Promise<number> {
+  const allPersonas = generateAllPersonas();
+  const personas = limit !== null
+    ? allPersonas.slice(offset, offset + limit)
+    : allPersonas.slice(offset);
 
   // 1회만 조회하고 Map으로 캐시 (240회 → 최소 1회)
   const { data: listData } = await supabase.auth.admin.listUsers({ perPage: 1000 });
@@ -1144,11 +1222,17 @@ Deno.serve(async (req) => {
     );
   }
 
+  // Fix #1334: offset/limit for batched user seeding (560 total ÷ 100/batch = 6 calls)
+  const offsetParam = url.searchParams.get("offset");
+  const limitParam = url.searchParams.get("limit");
+  const offset = offsetParam !== null ? parseInt(offsetParam, 10) : 0;
+  const limit = limitParam !== null ? parseInt(limitParam, 10) : null;
+
   try {
     const supabase = createServiceClient();
 
     // static mode: idempotent seed of users, verifications, partners, roles, images
-    const createdUsers = await seedAllUsers(supabase);
+    const createdUsers = await seedAllUsers(supabase, offset, limit);
     const globalVerifs = await seedGlobalVerifications(supabase);
     const { processedPartners } = await seedAllPartners(supabase, globalVerifs);
     await seedPartnerRoles(supabase);


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1334

변경: generateRegionalPersonas() 추가 (25연령 x 2성별 x 10지역 = 500명), offset/limit 배치 파라미터 추가, 워크플로우 6x100 배치 호출, 테스트 560명 기준 업데이트