### PR TITLE
fix(ef): Deno 테스트 sanitizer 복원 — sanitizeResources/sanitizeOps 비활성 제거

### DIFF
--- a/apps/app_user/test/integration/cuj_tag_discovery_test.dart
+++ b/apps/app_user/test/integration/cuj_tag_discovery_test.dart
@@ -1,0 +1,115 @@
+// Ref #1335: IT-U14 태그 탐색 CUJ 통합 테스트
+//
+// 검증 포인트:
+// TC-U14-001: TagEventListRoute → TagEventListPage 렌더링 + 이벤트 표시
+// TC-U14-002: 태그 이벤트 빈 상태 → "아직 이 태그의 이벤트가 없어요"
+//
+// 테스트 전략:
+// - TagEventListRoute를 initialLocation으로 사용하여 GoRouter 네비게이션을 통한
+//   TagEventListPage 렌더링을 검증한다.
+// - FeaturedTagChipBar 칩 탭 → 라우터 push → TagEventListPage 도달 경로는
+//   featured_tag_chip_bar_test.dart의 탭 테스트로 커버된다.
+import 'package:app_user/src/features/tag/ui/tag_event_list_page.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'utils/test_app.dart';
+import 'utils/test_mocks.dart';
+
+void main() {
+  setUpAll(() async {
+    await initializeDateFormatting('ko_KR');
+  });
+
+  late MockTagRepository mockTagRepo;
+
+  Event makeEvent(int i) => Event(
+        id: 'event-$i',
+        partyId: 'party-$i',
+        title: '태그 이벤트 $i',
+        startTime: DateTime(2026, 5, i + 1),
+        endTime: DateTime(2026, 5, i + 1, 2),
+        createdAt: DateTime(2026),
+        updatedAt: DateTime(2026),
+      );
+
+  setUp(() {
+    mockTagRepo = MockTagRepository();
+    // 기본: 모든 태그 요청에 빈 목록
+    when(
+      () => mockTagRepo.getFeaturedTags(),
+    ).thenAnswer((_) async => []);
+    when(
+      () => mockTagRepo.getTrendingTags(),
+    ).thenAnswer((_) async => []);
+    when(
+      () => mockTagRepo.getPartiesByTag(
+        any(),
+        offset: any(named: 'offset'),
+        limit: any(named: 'limit'),
+      ),
+    ).thenAnswer((_) async => []);
+  });
+
+  group('IT-U14 태그 탐색 CUJ', () {
+    // TC-U14-001: TagEventListRoute → TagEventListPage + 이벤트 렌더링
+    testWidgets(
+      'TC-U14-001: TagEventListRoute 진입 시 TagEventListPage가 렌더링되고 이벤트 목록이 표시된다',
+      (tester) async {
+        setKoreanLocale(tester);
+
+        final events = [makeEvent(0), makeEvent(1)];
+        when(
+          () => mockTagRepo.getPartiesByTag(
+            'tag-001',
+            offset: any(named: 'offset'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) async => events);
+
+        await tester.pumpWidget(
+          createTestApp(
+            initialLocation: '/tags/tag-001?tag-name=클럽',
+            additionalOverrides: [
+              tagRepositoryProvider.overrideWithValue(mockTagRepo),
+            ],
+          ),
+        );
+        await tester.pump(); // GoRouter 라우팅 완료
+        await tester.pump(); // provider 시작
+        await tester.pump(); // AsyncData 완료 → 리빌드
+
+        expect(find.byType(TagEventListPage), findsOneWidget);
+        expect(find.text('#클럽'), findsOneWidget); // AppBar title
+        expect(find.text('태그 이벤트 0'), findsOneWidget);
+        expect(find.text('태그 이벤트 1'), findsOneWidget);
+      },
+    );
+
+    // TC-U14-002: 태그 이벤트 빈 상태
+    testWidgets(
+      'TC-U14-002: 태그에 이벤트가 없으면 "아직 이 태그의 이벤트가 없어요" 메시지가 표시된다',
+      (tester) async {
+        setKoreanLocale(tester);
+
+        // mockTagRepo는 기본으로 빈 목록 반환 (setUp에서 설정)
+        await tester.pumpWidget(
+          createTestApp(
+            initialLocation: '/tags/tag-002?tag-name=독서',
+            additionalOverrides: [
+              tagRepositoryProvider.overrideWithValue(mockTagRepo),
+            ],
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.byType(TagEventListPage), findsOneWidget);
+        expect(find.text('아직 이 태그의 이벤트가 없어요'), findsOneWidget);
+        expect(find.text('홈으로 돌아가기'), findsOneWidget);
+      },
+    );
+  });
+}

--- a/apps/app_user/test/src/features/home/logic/tag_providers_test.dart
+++ b/apps/app_user/test/src/features/home/logic/tag_providers_test.dart
@@ -1,0 +1,103 @@
+// Ref #1335: featuredTagsProvider / trendingTagsProvider 상태 전환 테스트
+//
+// 검증 포인트:
+// 1. featuredTagsProvider — TagRepository.getFeaturedTags() 결과를 반환한다
+// 2. trendingTagsProvider — TagRepository.getTrendingTags() 결과를 반환한다
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../utils/mocks.dart';
+import '../../../../utils/test_utils.dart';
+
+void main() {
+  late MockTagRepository mockTagRepo;
+
+  Tag makeTag(String name) => Tag(id: 'tag-$name', name: name);
+
+  setUp(() {
+    mockTagRepo = MockTagRepository();
+  });
+
+  group('featuredTagsProvider', () {
+    test(
+      'TagRepository.getFeaturedTags() 결과를 반환한다',
+      () async {
+        final tags = [makeTag('클럽'), makeTag('독서')];
+        when(() => mockTagRepo.getFeaturedTags())
+            .thenAnswer((_) async => tags);
+
+        final container = createContainer(
+          overrides: [
+            tagRepositoryProvider.overrideWith((ref) => mockTagRepo),
+          ],
+        );
+
+        final result = await container.read(featuredTagsProvider.future);
+
+        expect(result, hasLength(2));
+        expect(result.first.name, '클럽');
+      },
+    );
+
+    test(
+      'TagRepository.getFeaturedTags() 빈 목록 — 빈 리스트 반환',
+      () async {
+        when(() => mockTagRepo.getFeaturedTags())
+            .thenAnswer((_) async => []);
+
+        final container = createContainer(
+          overrides: [
+            tagRepositoryProvider.overrideWith((ref) => mockTagRepo),
+          ],
+        );
+
+        final result = await container.read(featuredTagsProvider.future);
+
+        expect(result, isEmpty);
+      },
+    );
+  });
+
+  group('trendingTagsProvider', () {
+    test(
+      'TagRepository.getTrendingTags() 결과를 반환한다',
+      () async {
+        final tags = [
+          const Tag(id: 'tag-핫', name: '핫', recentCount: 42),
+        ];
+        when(() => mockTagRepo.getTrendingTags())
+            .thenAnswer((_) async => tags);
+
+        final container = createContainer(
+          overrides: [
+            tagRepositoryProvider.overrideWith((ref) => mockTagRepo),
+          ],
+        );
+
+        final result = await container.read(trendingTagsProvider.future);
+
+        expect(result, hasLength(1));
+        expect(result.first.recentCount, 42);
+      },
+    );
+
+    test(
+      'TagRepository.getTrendingTags() 빈 목록 — 빈 리스트 반환',
+      () async {
+        when(() => mockTagRepo.getTrendingTags())
+            .thenAnswer((_) async => []);
+
+        final container = createContainer(
+          overrides: [
+            tagRepositoryProvider.overrideWith((ref) => mockTagRepo),
+          ],
+        );
+
+        final result = await container.read(trendingTagsProvider.future);
+
+        expect(result, isEmpty);
+      },
+    );
+  });
+}

--- a/apps/app_user/test/src/features/home/widgets/featured_tag_chip_bar_test.dart
+++ b/apps/app_user/test/src/features/home/widgets/featured_tag_chip_bar_test.dart
@@ -1,0 +1,117 @@
+// Ref #1335: FeaturedTagChipBar widget 테스트
+//
+// 검증 포인트:
+// 1. 빈 태그 목록 → SizedBox.shrink (아무것도 렌더링 안 됨)
+// 2. 태그 목록 → #tagName 칩 렌더링
+// 3. 에러 상태 → SizedBox.shrink
+// 4. 칩 탭 → TagCoordinator.goToTagEventList() 호출
+import 'package:app_user/src/features/home/widgets/featured_tag_chip_bar.dart';
+import 'package:app_user/src/features/tag/logic/tag_coordinator.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../utils/mocks.dart';
+
+// Fix #1335: TagCoordinator는 GoRouter를 필요로 하므로,
+// implements로 호출 기록만 수행하는 fake를 정의한다.
+class _FakeTagCoordinator implements TagCoordinator {
+  final List<(String tagId, String tagName)> calls = [];
+
+  @override
+  void goToTagEventList(String tagId, String tagName) =>
+      calls.add((tagId, tagName));
+}
+
+void main() {
+  late MockTagRepository mockTagRepo;
+  late _FakeTagCoordinator fakeCoordinator;
+
+  Tag makeTag(String name) => Tag(id: 'tag-$name', name: name);
+
+  Widget buildSubject({
+    required void Function() stub,
+  }) {
+    stub();
+    return ProviderScope(
+      overrides: [
+        tagRepositoryProvider.overrideWithValue(mockTagRepo),
+        tagCoordinatorProvider.overrideWithValue(fakeCoordinator),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(body: FeaturedTagChipBar()),
+      ),
+    );
+  }
+
+  setUp(() {
+    mockTagRepo = MockTagRepository();
+    fakeCoordinator = _FakeTagCoordinator();
+  });
+
+  group('FeaturedTagChipBar', () {
+    testWidgets(
+      '빈 태그 목록 — 아무것도 렌더링하지 않는다',
+      (tester) async {
+        await tester.pumpWidget(buildSubject(
+          stub: () =>
+              when(() => mockTagRepo.getFeaturedTags())
+                  .thenAnswer((_) async => []),
+        ));
+        await tester.pump();
+
+        expect(find.byType(ListView), findsNothing);
+      },
+    );
+
+    testWidgets(
+      '태그 목록 — #tagName 칩이 렌더링된다',
+      (tester) async {
+        final tags = [makeTag('클럽'), makeTag('영화')];
+        await tester.pumpWidget(buildSubject(
+          stub: () =>
+              when(() => mockTagRepo.getFeaturedTags())
+                  .thenAnswer((_) async => tags),
+        ));
+        await tester.pump();
+
+        expect(find.text('#클럽'), findsOneWidget);
+        expect(find.text('#영화'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      '에러 상태 — 아무것도 렌더링하지 않는다',
+      (tester) async {
+        await tester.pumpWidget(buildSubject(
+          stub: () =>
+              when(() => mockTagRepo.getFeaturedTags())
+                  .thenThrow(Exception('network error')),
+        ));
+        await tester.pump();
+
+        expect(find.byType(ListView), findsNothing);
+      },
+    );
+
+    testWidgets(
+      '칩 탭 — TagCoordinator.goToTagEventList()가 올바른 tagId/tagName으로 호출된다',
+      (tester) async {
+        await tester.pumpWidget(buildSubject(
+          stub: () =>
+              when(() => mockTagRepo.getFeaturedTags())
+                  .thenAnswer((_) async => [makeTag('클럽')]),
+        ));
+        await tester.pump();
+
+        await tester.tap(find.text('#클럽'));
+        await tester.pump();
+
+        expect(fakeCoordinator.calls, hasLength(1));
+        expect(fakeCoordinator.calls.first.$1, 'tag-클럽');
+        expect(fakeCoordinator.calls.first.$2, '클럽');
+      },
+    );
+  });
+}

--- a/apps/app_user/test/src/features/tag/ui/tag_event_list_page_test.dart
+++ b/apps/app_user/test/src/features/tag/ui/tag_event_list_page_test.dart
@@ -1,0 +1,161 @@
+// Ref #1335: TagEventListPage widget 테스트
+//
+// 검증 포인트:
+// 1. 로딩 상태 → CircularProgressIndicator 렌더링
+// 2. 빈 상태 → "아직 이 태그의 이벤트가 없어요" 메시지
+// 3. 이벤트 목록 상태 → 이벤트 제목 렌더링
+// 4. 에러 상태 → "이벤트를 불러오지 못했습니다" + "다시 시도"
+// 5. AppBar 제목 — #tagName 형태
+//
+// 참고: eventCoordinatorProvider는 이벤트 탭 시에만 lazy 초기화되므로,
+// 탭 없이 렌더링만 검증하는 테스트에서는 override 불필요.
+import 'dart:async';
+
+import 'package:app_user/src/features/tag/ui/tag_event_list_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../utils/mocks.dart';
+
+Event makeEvent(int index) => Event(
+      id: 'event-$index',
+      partyId: 'party-$index',
+      title: 'Test Event $index',
+      startTime: DateTime(2026, 5, index + 1),
+      endTime: DateTime(2026, 5, index + 1, 2),
+      createdAt: DateTime(2026),
+      updatedAt: DateTime(2026),
+    );
+
+void main() {
+  setUpAll(() async {
+    await initializeDateFormatting('ko_KR');
+  });
+
+  const tagId = 'tag-001';
+  const tagName = '클럽';
+
+  late MockTagRepository mockTagRepo;
+
+  Widget buildSubject() {
+    return ProviderScope(
+      overrides: [
+        tagRepositoryProvider.overrideWithValue(mockTagRepo),
+      ],
+      child: MaterialApp(
+        theme: MinglitTheme.materialTheme,
+        home: const TagEventListPage(tagId: tagId, tagName: tagName),
+      ),
+    );
+  }
+
+  setUp(() {
+    mockTagRepo = MockTagRepository();
+  });
+
+  group('TagEventListPage', () {
+    testWidgets(
+      '로딩 상태 — CircularProgressIndicator가 렌더링된다',
+      (tester) async {
+        // Completer로 영원히 pending인 future를 만들어 loading 상태 유지
+        when(
+          () => mockTagRepo.getPartiesByTag(
+            tagId,
+            offset: any(named: 'offset'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) => Completer<List<Event>>().future);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      '빈 상태 — "아직 이 태그의 이벤트가 없어요" 메시지와 홈 버튼이 렌더링된다',
+      (tester) async {
+        when(
+          () => mockTagRepo.getPartiesByTag(
+            tagId,
+            offset: any(named: 'offset'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) async => []);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+
+        expect(find.text('아직 이 태그의 이벤트가 없어요'), findsOneWidget);
+        expect(find.text('홈으로 돌아가기'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      '이벤트 목록 상태 — 이벤트 제목이 렌더링된다',
+      (tester) async {
+        final events = [makeEvent(0), makeEvent(1)];
+        when(
+          () => mockTagRepo.getPartiesByTag(
+            tagId,
+            offset: any(named: 'offset'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) async => events);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pump(); // provider 시작
+        await tester.pump(); // AsyncData 완료 → 리빌드
+
+        expect(find.text('Test Event 0'), findsOneWidget);
+        expect(find.text('Test Event 1'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      '에러 상태 — 에러 메시지와 "다시 시도" 버튼이 렌더링된다',
+      (tester) async {
+        // Fix #1335: Future.error()로 비동기 에러를 명시적으로 반환하여
+        // Riverpod이 AsyncError state로 올바르게 전환하도록 한다.
+        when(
+          () => mockTagRepo.getPartiesByTag(
+            tagId,
+            offset: any(named: 'offset'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer(
+          (_) => Future.error(Exception('fetch failed'), StackTrace.empty),
+        );
+
+        await tester.pumpWidget(buildSubject());
+        // error 케이스는 ListView 없으므로 pumpAndSettle 사용 가능
+        await tester.pumpAndSettle();
+
+        expect(find.text('이벤트를 불러오지 못했습니다'), findsOneWidget);
+        expect(find.text('다시 시도'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'AppBar 제목 — #tagName 형태로 표시된다',
+      (tester) async {
+        when(
+          () => mockTagRepo.getPartiesByTag(
+            tagId,
+            offset: any(named: 'offset'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) async => []);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+
+        expect(find.text('#$tagName'), findsOneWidget);
+      },
+    );
+  });
+}

--- a/supabase/functions/_payment_integration_tests/payment_edge_cases_test.ts
+++ b/supabase/functions/_payment_integration_tests/payment_edge_cases_test.ts
@@ -16,7 +16,6 @@ import {
 import { authRoute } from "../_test_utils/fixtures.ts";
 
 // Statsig uses node:timers setInterval internally, which withNoIntervals cannot patch.
-const TEST_OPTS = { sanitizeOps: false, sanitizeResources: false };
 
 const ENV_CREATE_ORDER = {
   SUPABASE_URL: "https://supabase.test",
@@ -69,7 +68,6 @@ const MOCK_USER_PROFILE = {
 // ---
 Deno.test(
   "payment-integration - Test 4: free event bypasses PG, approved directly",
-  TEST_OPTS,
   async () => {
     await withEnv(ENV_CREATE_ORDER, async () => {
       const handler = await captureServeHandler(

--- a/supabase/functions/backend-simulator/e2e_test.ts
+++ b/supabase/functions/backend-simulator/e2e_test.ts
@@ -258,8 +258,6 @@ function createBroadMock() {
 
 Deno.test({
   name: "backend-simulator - blocks in production",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const h = await getHandler();
 
@@ -272,8 +270,6 @@ Deno.test({
 
 Deno.test({
   name: "backend-simulator - full run returns success structure",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const h = await getHandler();
     const { fetchMock } = createBroadMock();
@@ -312,8 +308,6 @@ Deno.test({
 
 Deno.test({
   name: "backend-simulator - force_fail creates failure and GitHub issue",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const h = await getHandler();
     const { fetchMock } = createBroadMock();
@@ -346,8 +340,6 @@ Deno.test({
 
 Deno.test({
   name: "backend-simulator - phase=create returns party_ids and event_ids",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const h = await getHandler();
     const { fetchMock } = createBroadMock();
@@ -380,8 +372,6 @@ Deno.test({
 
 Deno.test({
   name: "backend-simulator - phase=verify returns verification summary",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const h = await getHandler();
     const { fetchMock } = createBroadMock();
@@ -425,8 +415,6 @@ Deno.test({
 
 Deno.test({
   name: "backend-simulator - phase=run only processes [E2E] events (non-E2E events remain scheduled)",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const h = await getHandler();
 
@@ -531,8 +519,6 @@ Deno.test({
 
 Deno.test({
   name: "backend-simulator - phase=create response includes display_party_ids and display_event_ids",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const h = await getHandler();
 

--- a/supabase/functions/backend-simulator/sim_approve_test.ts
+++ b/supabase/functions/backend-simulator/sim_approve_test.ts
@@ -69,9 +69,7 @@ Deno.test("simApproveVerifications - empty list returns empty result", async () 
   assertEquals(result.assertions, []);
 });
 
-// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
-// token auto-refresh even when persistSession=false. The interval leaks within the test but is
-// harmless — suppressing the leak check is correct here rather than patching the library.
+// Fix #1292: sanitizer 복원 — autoRefreshToken: false로 supabase-js interval 누수 해결
 Deno.test({
   name: "simApproveVerifications - 5 apps with approveRate=0.8 → 4 approved, 1 rejected",
   fn: async () => {

--- a/supabase/functions/backend-simulator/sim_approve_test.ts
+++ b/supabase/functions/backend-simulator/sim_approve_test.ts
@@ -74,8 +74,6 @@ Deno.test("simApproveVerifications - empty list returns empty result", async () 
 // harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simApproveVerifications - 5 apps with approveRate=0.8 → 4 approved, 1 rejected",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const appIds = ["app-1", "app-2", "app-3", "app-4", "app-5"];
     const appStatuses: Record<string, string> = {};
@@ -158,8 +156,6 @@ Deno.test({
 
 Deno.test({
   name: "simApproveVerifications - all approve when approveRate=1.0",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const appIds = ["app-a", "app-b", "app-c"];
     const appStatuses: Record<string, string> = {};
@@ -239,8 +235,6 @@ Deno.test({
 
 Deno.test({
   name: "simApproveVerifications - all reject when approveRate=0.0",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const appIds = ["app-x", "app-y"];
     const appStatuses: Record<string, string> = {};
@@ -341,8 +335,6 @@ Deno.test("simApproveVerifications - handles DB error gracefully (no throw)", as
 // Fix #1283: EF failure always throws (strict parameter removed).
 Deno.test({
   name: "simApproveVerifications - EF failure on verification flow throws error",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const mock = createMockSupabaseClient({
       ...makePartnerEmailMockOptions({
@@ -409,8 +401,6 @@ Deno.test({
 // Fix #1280: no-verification approve path uses partner-approve-application EF.
 Deno.test({
   name: "simApproveVerifications - no verification needed: approve uses EF, reject uses direct DB",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const appIds = ["app-direct-1", "app-direct-2"];
     const appStatuses: Record<string, string> = {};
@@ -500,8 +490,6 @@ Deno.test({
 // Fix #1328: no-verification reject path now uses partner-reject-application EF.
 Deno.test({
   name: "simApproveVerifications - no verification needed: reject uses partner-reject-application EF",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const appIds = ["app-rej-1", "app-rej-2"];
     const appStatuses: Record<string, string> = {};

--- a/supabase/functions/backend-simulator/sim_auth.ts
+++ b/supabase/functions/backend-simulator/sim_auth.ts
@@ -20,8 +20,10 @@ export async function getSimUserToken(
   const cached = _tokenCache.get(email);
   if (cached) return cached;
 
+  // Fix #1292: autoRefreshToken: false prevents supabase-js from registering a
+  // setInterval for token refresh, which would outlive the test scope.
   const supabase = createClient(supabaseUrl, anonKey, {
-    auth: { persistSession: false },
+    auth: { persistSession: false, autoRefreshToken: false },
   });
 
   const { data, error } = await supabase.auth.signInWithPassword({ email, password });
@@ -86,8 +88,10 @@ export async function getSimPartnerToken(
   const cached = _tokenCache.get(cacheKey);
   if (cached) return cached;
 
+  // Fix #1292: autoRefreshToken: false prevents supabase-js from registering a
+  // setInterval for token refresh, which would outlive the test scope.
   const supabase = createClient(supabaseUrl, anonKey, {
-    auth: { persistSession: false },
+    auth: { persistSession: false, autoRefreshToken: false },
   });
 
   const { data, error } = await supabase.auth.signInWithPassword({ email: partnerEmail, password });

--- a/supabase/functions/backend-simulator/sim_create_test.ts
+++ b/supabase/functions/backend-simulator/sim_create_test.ts
@@ -39,8 +39,6 @@ function withMockFetch<T>(
 // harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simCreateParties - creates parties and events via EF and returns IDs",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   const efCalls: { url: string; body: unknown }[] = [];
 
@@ -98,8 +96,6 @@ Deno.test({
 // harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simCreateParties - event EF body includes min_confirmed_count and metadata",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   const eventEfBodies: Record<string, unknown>[] = [];
 
@@ -157,8 +153,6 @@ Deno.test({
 // harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simCreateParties - throws when EF fails",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   const mock = createMockSupabaseClient({
     tables: {
@@ -200,8 +194,6 @@ Deno.test({
 
 Deno.test({
   name: "simCreateParties - throws when SIM_USER_PASSWORD not set",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   const mock = createMockSupabaseClient({
     tables: {
@@ -232,8 +224,6 @@ Deno.test({
 // harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simCreateParties - creates 4 distinct start_time zones via EF",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   const eventStartTimes: string[] = [];
 
@@ -301,8 +291,6 @@ Deno.test({
 // harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simCreateDisplayEvents - creates display parties and events via EF",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   const efCalls: { url: string; body: unknown }[] = [];
   let partyCallCount = 0;
@@ -369,8 +357,6 @@ Deno.test({
 // harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simCreateDisplayEvents - skips when display parties already exist",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   let efCallCount = 0;
 
@@ -415,8 +401,6 @@ Deno.test({
 // harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simCreateDisplayEvents - throws when display party EF fails",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   const mock = createMockSupabaseClient({
     tables: {
@@ -461,8 +445,6 @@ Deno.test({
 // harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simDiscoverAndApply - basic user-centric flow: users discover and apply via own feed",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   let appCounter = 0;
   const feedCallUserTokens: string[] = [];
@@ -538,8 +520,6 @@ Deno.test({
 // harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simDiscoverAndApply - max_apps_per_user limit is respected",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   let appCounter = 0;
 
@@ -608,8 +588,6 @@ Deno.test({
 // harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simDiscoverAndApply - EF rejection handled gracefully (non-200 response)",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   const warnings: string[] = [];
   const warnLog = (entry: { level: string; message: string }) => {
@@ -677,8 +655,6 @@ Deno.test({
 // harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simDiscoverAndApply - empty feed for a user produces no applications",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   let applyCallCount = 0;
 
@@ -749,8 +725,6 @@ Deno.test({
 // harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simDiscoverAndApply - user_batch_size controls concurrent user processing",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   let appCounter = 0;
 
@@ -818,7 +792,7 @@ Deno.test({
 
 // Fix #1283: credentials 누락 시 즉시 throw (strict 제거 후 유일한 동작)
 // sanitizeOps disabled: preceding test (@supabase/auth-js setInterval leak) completes timers here
-Deno.test({ name: "simDiscoverAndApply - throws when credentials not available", sanitizeOps: false, sanitizeResources: false, fn: async () => {
+Deno.test({ name: "simDiscoverAndApply - throws when credentials not available", fn: async () => {
   const mock = createMockSupabaseClient({});
 
   // No SIM_USER_PASSWORD set — throws immediately
@@ -841,8 +815,6 @@ Deno.test({ name: "simDiscoverAndApply - throws when credentials not available",
 
 Deno.test({
   name: "simDiscoverAndApply - applies via apply-event EF with correct parameters",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   const efBodies: Record<string, unknown>[] = [];
 
@@ -927,8 +899,6 @@ Deno.test({
 // harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simDiscoverAndApply - classifies free applications from apply-event EF response",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   const mock = createMockSupabaseClient({
     tables: {

--- a/supabase/functions/backend-simulator/sim_create_test.ts
+++ b/supabase/functions/backend-simulator/sim_create_test.ts
@@ -34,9 +34,6 @@ function withMockFetch<T>(
   });
 }
 
-// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
-// token auto-refresh even when persistSession=false. The interval leaks within the test but is
-// harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simCreateParties - creates parties and events via EF and returns IDs",
   fn: async () => {
@@ -91,9 +88,6 @@ Deno.test({
   },
 });
 
-// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
-// token auto-refresh even when persistSession=false. The interval leaks within the test but is
-// harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simCreateParties - event EF body includes min_confirmed_count and metadata",
   fn: async () => {
@@ -148,9 +142,6 @@ Deno.test({
   },
 });
 
-// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
-// token auto-refresh even when persistSession=false. The interval leaks within the test but is
-// harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simCreateParties - throws when EF fails",
   fn: async () => {
@@ -219,9 +210,6 @@ Deno.test({
   },
 });
 
-// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
-// token auto-refresh even when persistSession=false. The interval leaks within the test but is
-// harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simCreateParties - creates 4 distinct start_time zones via EF",
   fn: async () => {
@@ -286,9 +274,6 @@ Deno.test({
   },
 });
 
-// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
-// token auto-refresh even when persistSession=false. The interval leaks within the test but is
-// harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simCreateDisplayEvents - creates display parties and events via EF",
   fn: async () => {
@@ -352,9 +337,6 @@ Deno.test({
   },
 });
 
-// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
-// token auto-refresh even when persistSession=false. The interval leaks within the test but is
-// harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simCreateDisplayEvents - skips when display parties already exist",
   fn: async () => {
@@ -396,9 +378,6 @@ Deno.test({
   },
 });
 
-// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
-// token auto-refresh even when persistSession=false. The interval leaks within the test but is
-// harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simCreateDisplayEvents - throws when display party EF fails",
   fn: async () => {
@@ -440,9 +419,6 @@ Deno.test({
 
 // ── simDiscoverAndApply — user-centric loop tests (Fix #1323) ────────────────
 
-// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
-// token auto-refresh even when persistSession=false. The interval leaks within the test but is
-// harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simDiscoverAndApply - basic user-centric flow: users discover and apply via own feed",
   fn: async () => {
@@ -515,9 +491,6 @@ Deno.test({
   },
 });
 
-// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
-// token auto-refresh even when persistSession=false. The interval leaks within the test but is
-// harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simDiscoverAndApply - max_apps_per_user limit is respected",
   fn: async () => {
@@ -583,9 +556,6 @@ Deno.test({
   },
 });
 
-// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
-// token auto-refresh even when persistSession=false. The interval leaks within the test but is
-// harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simDiscoverAndApply - EF rejection handled gracefully (non-200 response)",
   fn: async () => {
@@ -650,9 +620,6 @@ Deno.test({
   },
 });
 
-// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
-// token auto-refresh even when persistSession=false. The interval leaks within the test but is
-// harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simDiscoverAndApply - empty feed for a user produces no applications",
   fn: async () => {
@@ -720,9 +687,6 @@ Deno.test({
   },
 });
 
-// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
-// token auto-refresh even when persistSession=false. The interval leaks within the test but is
-// harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simDiscoverAndApply - user_batch_size controls concurrent user processing",
   fn: async () => {
@@ -791,7 +755,6 @@ Deno.test({
 });
 
 // Fix #1283: credentials 누락 시 즉시 throw (strict 제거 후 유일한 동작)
-// sanitizeOps disabled: preceding test (@supabase/auth-js setInterval leak) completes timers here
 Deno.test({ name: "simDiscoverAndApply - throws when credentials not available", fn: async () => {
   const mock = createMockSupabaseClient({});
 
@@ -808,9 +771,6 @@ Deno.test({ name: "simDiscoverAndApply - throws when credentials not available",
   );
 }});
 
-// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
-// token auto-refresh even when persistSession=false. The interval leaks within the test but is
-// harmless — suppressing the leak check is correct here rather than patching the library.
 // ── apply-event EF path tests (Fix #1323, #1324) ─────────────────────────────
 
 Deno.test({
@@ -894,9 +854,6 @@ Deno.test({
   },
 });
 
-// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
-// token auto-refresh even when persistSession=false. The interval leaks within the test but is
-// harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simDiscoverAndApply - classifies free applications from apply-event EF response",
   fn: async () => {

--- a/supabase/functions/backend-simulator/sim_event_test.ts
+++ b/supabase/functions/backend-simulator/sim_event_test.ts
@@ -81,9 +81,7 @@ function makeMatchFetchHandler(opts: { efStatus?: number; pairs?: Array<{ user1:
 // simCheckin tests
 // ─────────────────────────────────────────────────────────
 
-// sanitizeResources/sanitizeOps disabled: @supabase/auth-js internally calls setInterval for
-// token auto-refresh even when persistSession=false. The interval leaks within the test but is
-// harmless — suppressing the leak check is correct here rather than patching the library.
+// Fix #1292: sanitizer 복원 — autoRefreshToken: false로 supabase-js interval 누수 해결
 Deno.test({
   name: "simCheckin - 70% checked_in via EF, 30% no_show via direct DB",
   fn: async () => {
@@ -227,7 +225,6 @@ Deno.test({ name: "simCheckin - empty participants returns empty", fn: async () 
   assertEquals(result.assertions, []);
 }});
 
-// sanitizeResources/sanitizeOps disabled: supabase-js auth client leaks setInterval
 Deno.test({
   name: "simCheckin - EF failure is logged as error (not silently skipped)",
   fn: async () => {

--- a/supabase/functions/backend-simulator/sim_event_test.ts
+++ b/supabase/functions/backend-simulator/sim_event_test.ts
@@ -86,8 +86,6 @@ function makeMatchFetchHandler(opts: { efStatus?: number; pairs?: Array<{ user1:
 // harmless — suppressing the leak check is correct here rather than patching the library.
 Deno.test({
   name: "simCheckin - 70% checked_in via EF, 30% no_show via direct DB",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const noShowUpdated: string[] = [];
     // Track statuses for both EF (via fetch mock side-effect) and direct DB (via update mock)
@@ -203,7 +201,7 @@ Deno.test({
   },
 });
 
-Deno.test({ name: "simCheckin - empty participants returns empty", sanitizeOps: false, sanitizeResources: false, fn: async () => {
+Deno.test({ name: "simCheckin - empty participants returns empty", fn: async () => {
   const mock = createMockSupabaseClient({
     tables: {
       events: {
@@ -232,8 +230,6 @@ Deno.test({ name: "simCheckin - empty participants returns empty", sanitizeOps: 
 // sanitizeResources/sanitizeOps disabled: supabase-js auth client leaks setInterval
 Deno.test({
   name: "simCheckin - EF failure is logged as error (not silently skipped)",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const participants = [
       { id: "p-1", user_id: "u-1", status: "ticket_issued" },

--- a/supabase/functions/backend-simulator/sim_refund_test.ts
+++ b/supabase/functions/backend-simulator/sim_refund_test.ts
@@ -11,12 +11,11 @@ const ANON_KEY = "test-anon-key";
 
 /**
  * Creates a fetch mock that handles:
- *   - POST /auth/v1/token → returns a JWT (triggers supabase-js token refresh interval)
+ *   - POST /auth/v1/token → returns a JWT
  *   - POST /functions/v1/user-cancel-order → returns configured response
  *
  * Fix #1327: payment-cancel EF → user-cancel-order EF로 전환.
- * Tests that use this mock must set sanitizeOps: false to avoid interval leak
- * failures caused by the supabase-js client's token refresh timer.
+ * Fix #1292: sim_auth.ts에서 autoRefreshToken: false로 interval 누수 해결됨.
  */
 function makeEfFetchMock(opts: {
   cancelOrderStatus?: number;
@@ -161,14 +160,10 @@ Deno.test("simRefundRequests - refundRate=0.0 → no refunds processed", async (
 
 // ============================================================
 // Tests: EF-only refund path
-// sanitizeOps: false required — supabase-js createClient starts a token refresh
-// interval after signIn succeeds, which outlives the test scope.
 // ============================================================
 
 Deno.test({
   name: "simRefundRequests - 100% refund (event +30 days) → refund via EF",
-  sanitizeOps: false,
-  sanitizeResources: false,
   fn: async () => {
     const paymentAmount = 10000;
     const startTime = daysFromNow(30);
@@ -208,8 +203,6 @@ Deno.test({
 
 Deno.test({
   name: "simRefundRequests - 0% refund (event +5 days, binary policy) → refund_amount=0 via EF",
-  sanitizeOps: false,
-  sanitizeResources: false,
   fn: async () => {
     const paymentAmount = 10000;
     const startTime = daysFromNow(5);
@@ -247,8 +240,6 @@ Deno.test({
 
 Deno.test({
   name: "simRefundRequests - 0% refund (event +2 days, binary policy) → refund_amount=0 via EF",
-  sanitizeOps: false,
-  sanitizeResources: false,
   fn: async () => {
     const paymentAmount = 9999;
     const startTime = daysFromNow(2);
@@ -286,8 +277,6 @@ Deno.test({
 
 Deno.test({
   name: "simRefundRequests - 0% refund (+12 hours) → refund_amount=0 via EF",
-  sanitizeOps: false,
-  sanitizeResources: false,
   fn: async () => {
     const paymentAmount = 10000;
     const startTime = hoursFromNow(12);
@@ -327,8 +316,6 @@ Deno.test({
 // The sim no longer calls event_participants.delete directly.
 Deno.test({
   name: "simRefundRequests - EF succeeds → refund recorded (participant cleanup handled by EF)",
-  sanitizeOps: false,
-  sanitizeResources: false,
   fn: async () => {
     const paymentAmount = 5000;
     const startTime = daysFromNow(30);
@@ -363,8 +350,6 @@ Deno.test({
 
 Deno.test({
   name: "simRefundRequests - 20% of 5 apps → 1 refunded via EF",
-  sanitizeOps: false,
-  sanitizeResources: false,
   fn: async () => {
     const paymentAmount = 10000;
     const startTime = daysFromNow(30);
@@ -429,7 +414,7 @@ Deno.test({
 // Tests: error cases — EF failure throws (no direct DB fallback)
 // ============================================================
 
-Deno.test({ name: "simRefundRequests - missing supabaseUrl → error logged, no refunds", sanitizeOps: false, sanitizeResources: false, fn: async () => {
+Deno.test({ name: "simRefundRequests - missing supabaseUrl → error logged, no refunds", fn: async () => {
   const paymentAmount = 10000;
   const startTime = daysFromNow(30);
 
@@ -516,8 +501,6 @@ Deno.test("simRefundRequests - partner username → error logged, no refunds", a
 
 Deno.test({
   name: "simRefundRequests - EF returns non-200 → error logged, no refunds, no DB fallback",
-  sanitizeOps: false,
-  sanitizeResources: false,
   fn: async () => {
     const paymentAmount = 10000;
     const startTime = daysFromNow(30);

--- a/supabase/functions/backend-simulator/sim_refund_test.ts
+++ b/supabase/functions/backend-simulator/sim_refund_test.ts
@@ -414,6 +414,7 @@ Deno.test({
 // Tests: error cases — EF failure throws (no direct DB fallback)
 // ============================================================
 
+// Fix #1292: sanitizer 복원 — autoRefreshToken: false로 supabase-js interval 누수 해결
 Deno.test({ name: "simRefundRequests - missing supabaseUrl → error logged, no refunds", fn: async () => {
   const paymentAmount = 10000;
   const startTime = daysFromNow(30);

--- a/supabase/functions/backend-simulator/tick/action_runner_test.ts
+++ b/supabase/functions/backend-simulator/tick/action_runner_test.ts
@@ -97,7 +97,7 @@ function makeEFFetchHandler(opts: {
 // Tests
 // ─────────────────────────────────────────────────────────
 
-// sanitizeResources/sanitizeOps disabled: fetch mock interacts with Deno's resource tracking
+// Fix #1292: sanitizer 복원 — captureServeHandler/withMockedFetch로 리소스 추적 호환
 Deno.test({
   name: "ActionRunner.execute - calls EF, validates response, checks DB state",
   fn: async () => {

--- a/supabase/functions/backend-simulator/tick/action_runner_test.ts
+++ b/supabase/functions/backend-simulator/tick/action_runner_test.ts
@@ -100,8 +100,6 @@ function makeEFFetchHandler(opts: {
 // sanitizeResources/sanitizeOps disabled: fetch mock interacts with Deno's resource tracking
 Deno.test({
   name: "ActionRunner.execute - calls EF, validates response, checks DB state",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const mock = createMockSupabaseClient({});
     const { log, entries } = makeLogCollector();
@@ -137,8 +135,6 @@ Deno.test({
 
 Deno.test({
   name: "ActionRunner.execute - EF failure (non-2xx) does not throw; returns passed=false",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const mock = createMockSupabaseClient({});
     const { log, entries } = makeLogCollector();
@@ -173,8 +169,6 @@ Deno.test({
 
 Deno.test({
   name: "ActionRunner.execute - fetch throws; catches error and returns passed=false",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const mock = createMockSupabaseClient({});
     const { log, entries } = makeLogCollector();
@@ -211,8 +205,6 @@ Deno.test({
 
 Deno.test({
   name: "ActionRunner.execute - processes multiple actions in sequence",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const mock = createMockSupabaseClient({});
     const { log, entries } = makeLogCollector();
@@ -270,8 +262,6 @@ Deno.test({
 
 Deno.test({
   name: "ActionRunner.execute - DB assertion failure causes passed=false",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const mock = createMockSupabaseClient({});
     const { log, entries } = makeLogCollector();

--- a/supabase/functions/bug-report/bug_report_test.ts
+++ b/supabase/functions/bug-report/bug_report_test.ts
@@ -49,8 +49,6 @@ function authedTextRequest(url: string, body: string): Request {
 
 Deno.test({
   name: "bug-report - happy path creates GitHub issue",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     // GITHUB_ACCESS_TOKEN is read at module load time, so we must set it
     // before captureServeHandler imports the module.
@@ -90,8 +88,6 @@ Deno.test({
 
 Deno.test({
   name: "bug-report - missing title returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     await withEnv(
       BASE_ENV,
@@ -118,8 +114,6 @@ Deno.test({
 
 Deno.test({
   name: "bug-report - missing description returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     await withEnv(
       BASE_ENV,
@@ -146,8 +140,6 @@ Deno.test({
 
 Deno.test({
   name: "bug-report - malformed JSON returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     await withEnv(
       BASE_ENV,
@@ -172,8 +164,6 @@ Deno.test({
 
 Deno.test({
   name: "bug-report - missing GITHUB_ACCESS_TOKEN returns 500",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     await withEnv(
       { ...BASE_ENV, GITHUB_ACCESS_TOKEN: undefined },
@@ -201,8 +191,6 @@ Deno.test({
 
 Deno.test({
   name: "bug-report - GitHub API failure returns 500",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     await withEnv(
       BASE_ENV,
@@ -236,8 +224,6 @@ Deno.test({
 
 Deno.test({
   name: "bug-report - backward compat: old payload has no undefined and no new sections",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     await withEnv(
       BASE_ENV,
@@ -276,8 +262,6 @@ Deno.test({
 
 Deno.test({
   name: "bug-report - screenshot and environment sections are included when provided",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     await withEnv(
       BASE_ENV,
@@ -318,8 +302,6 @@ Deno.test({
 
 Deno.test({
   name: "bug-report - null screenshotUrl and environment produce no undefined in body",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     await withEnv(
       BASE_ENV,

--- a/supabase/functions/bug-report/bug_report_test.ts
+++ b/supabase/functions/bug-report/bug_report_test.ts
@@ -43,8 +43,7 @@ function authedTextRequest(url: string, body: string): Request {
 
 // ---------------------------------------------------------------------------
 // Tests
-// sanitizeResources/sanitizeOps disabled because supabase-js creates background
-// intervals for auth token management when createClient() is called.
+// Fix #1292: sanitizer 복원 — captureServeHandler가 Deno.serve/setInterval을 스텁하므로 플래그 불필요
 // ---------------------------------------------------------------------------
 
 Deno.test({

--- a/supabase/functions/cleanup-blocked-dis/cleanup-blocked-dis_test.ts
+++ b/supabase/functions/cleanup-blocked-dis/cleanup-blocked-dis_test.ts
@@ -10,7 +10,6 @@ import {
   withNoIntervals,
 } from "../_test_utils/mock_http.ts";
 
-const TEST_OPTS = { sanitizeOps: false, sanitizeResources: false };
 
 const ENV = {
   SUPABASE_URL: "https://supabase.test",
@@ -24,7 +23,7 @@ function serviceRoleRequest() {
   });
 }
 
-Deno.test("unauthorized request returns 401", TEST_OPTS, async () => {
+Deno.test("unauthorized request returns 401", async () => {
   const handler = await captureServeHandler(
     new URL("./index.ts", import.meta.url),
   );
@@ -42,7 +41,7 @@ Deno.test("unauthorized request returns 401", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("expired blocked_dis rows are deleted", TEST_OPTS, async () => {
+Deno.test("expired blocked_dis rows are deleted", async () => {
   const handler = await captureServeHandler(
     new URL("./index.ts", import.meta.url),
   );

--- a/supabase/functions/dev-mock-portone/dev_mock_portone_test.ts
+++ b/supabase/functions/dev-mock-portone/dev_mock_portone_test.ts
@@ -7,8 +7,6 @@ import {
 
 Deno.test({
   name: "dev-mock-portone - blocks in production (ENVIRONMENT=production)",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -23,8 +21,6 @@ Deno.test({
 
 Deno.test({
   name: "dev-mock-portone - POST /users/getToken returns mock token",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -46,8 +42,6 @@ Deno.test({
 
 Deno.test({
   name: "dev-mock-portone - GET /payments/:imp_uid returns paid payment",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -71,8 +65,6 @@ Deno.test({
 
 Deno.test({
   name: "dev-mock-portone - GET /payments/imp_fail_xxx returns failed status",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -93,8 +85,6 @@ Deno.test({
 
 Deno.test({
   name: "dev-mock-portone - POST /payments/cancel returns cancelled response",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -121,8 +111,6 @@ Deno.test({
 
 Deno.test({
   name: "dev-mock-portone - unknown path returns 404",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 

--- a/supabase/functions/dev-seed/dev_seed_test.ts
+++ b/supabase/functions/dev-seed/dev_seed_test.ts
@@ -10,8 +10,6 @@ import {
 
 Deno.test({
   name: "dev-seed - blocks in production (ENVIRONMENT=production)",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(
       new URL("./index.ts", import.meta.url),
@@ -28,8 +26,6 @@ Deno.test({
 
 Deno.test({
   name: "dev-seed - seeds users and partners in static mode (default)",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(
       new URL("./index.ts", import.meta.url),
@@ -137,8 +133,6 @@ Deno.test({
 
 Deno.test({
   name: "dev-seed - static mode assigns images to existing parties (Fix #1210)",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(
       new URL("./index.ts", import.meta.url),
@@ -245,8 +239,6 @@ Deno.test({
 
 Deno.test({
   name: "dev-seed - seedAllUsers caches listUsers and skips unchanged existing users",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(
       new URL("./index.ts", import.meta.url),
@@ -350,8 +342,6 @@ Deno.test({
 
 Deno.test({
   name: "dev-seed - seedAllUsers logs individual failures and continues",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(
       new URL("./index.ts", import.meta.url),
@@ -441,8 +431,6 @@ Deno.test({
 
 Deno.test({
   name: "dev-seed - mode=static is idempotent (re-run does not error)",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(
       new URL("./index.ts", import.meta.url),

--- a/supabase/functions/dev-session-switch/dev_session_switch_test.ts
+++ b/supabase/functions/dev-session-switch/dev_session_switch_test.ts
@@ -10,8 +10,6 @@ import {
 
 Deno.test({
   name: "dev-session-switch - blocks in production (ENVIRONMENT=production)",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     
@@ -26,8 +24,6 @@ Deno.test({
 
 Deno.test({
   name: "dev-session-switch - returns user profiles in local env",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     
@@ -61,8 +57,6 @@ Deno.test({
 
 Deno.test({
   name: "dev-session-switch - handles Supabase error",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     

--- a/supabase/functions/event-checkin/event_checkin_test.ts
+++ b/supabase/functions/event-checkin/event_checkin_test.ts
@@ -18,8 +18,6 @@ const BASE_URL = "http://localhost";
 
 Deno.test({
   name: "event-checkin - returns 200 and checks in participant",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -73,8 +71,6 @@ Deno.test({
 
 Deno.test({
   name: "event-checkin - returns 400 when missing parameters",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -101,8 +97,6 @@ Deno.test({
 
 Deno.test({
   name: "event-checkin - returns 404 when participant not found",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -136,8 +130,6 @@ Deno.test({
 
 Deno.test({
   name: "event-checkin - returns 403 when caller is not the participant",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -177,8 +169,6 @@ Deno.test({
 
 Deno.test({
   name: "event-checkin - returns 409 when already checked in",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -223,8 +213,6 @@ Deno.test({
 
 Deno.test({
   name: "event-checkin - returns 400 when status is not ticket_issued",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -269,8 +257,6 @@ Deno.test({
 
 Deno.test({
   name: "event-checkin - returns 401 without auth token",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -293,8 +279,6 @@ Deno.test({
 
 Deno.test({
   name: "event-checkin - OPTIONS returns CORS response",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 

--- a/supabase/functions/event-matching/event_matching_test.ts
+++ b/supabase/functions/event-matching/event_matching_test.ts
@@ -27,8 +27,6 @@ function serviceRoleJsonRequest(url: string, body: unknown): Request {
 
 Deno.test({
   name: "event-matching - returns 401 for regular user JWT",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -44,8 +42,6 @@ Deno.test({
 
 Deno.test({
   name: "event-matching - returns 401 when Authorization header is missing",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -61,8 +57,6 @@ Deno.test({
 
 Deno.test({
   name: "event-matching - creates match pairs from two groups",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -121,8 +115,6 @@ Deno.test({
 
 Deno.test({
   name: "event-matching - returns existing pairs when already matched (idempotent)",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -162,8 +154,6 @@ Deno.test({
 
 Deno.test({
   name: "event-matching - returns 400 when missing event_id",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -181,8 +171,6 @@ Deno.test({
 
 Deno.test({
   name: "event-matching - returns 400 when less than 2 entry groups",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -213,8 +201,6 @@ Deno.test({
 
 Deno.test({
   name: "event-matching - returns 400 when a group has no checked-in participants",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -257,8 +243,6 @@ Deno.test({
 
 Deno.test({
   name: "event-matching - user_lower_id < user_higher_id ordering",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -319,8 +303,6 @@ Deno.test({
 
 Deno.test({
   name: "event-matching - OPTIONS returns CORS response",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 

--- a/supabase/functions/health/health_test.ts
+++ b/supabase/functions/health/health_test.ts
@@ -10,8 +10,6 @@ import {
 
 Deno.test({
   name: "health - returns 200 with healthy status when all checks pass",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -42,8 +40,6 @@ Deno.test({
 
 Deno.test({
   name: "health - returns 503 when database is down",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -73,8 +69,6 @@ Deno.test({
 
 Deno.test({
   name: "health - response contains required keys",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -106,8 +100,6 @@ Deno.test({
 
 Deno.test({
   name: "health - returns Content-Type application/json",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -132,8 +124,6 @@ Deno.test({
 
 Deno.test({
   name: "health - rejects non-GET with 405",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 

--- a/supabase/functions/notification-worker/notification_worker_test.ts
+++ b/supabase/functions/notification-worker/notification_worker_test.ts
@@ -36,8 +36,6 @@ async function withFastTimers(fn: () => Promise<void>) {
 
 Deno.test({
   name: "notification-worker - processes one message and returns done",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -104,8 +102,6 @@ Deno.test({
 
 Deno.test({
   name: "notification-worker - FCM invalid token triggers cleanup",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -180,8 +176,6 @@ Deno.test({
 
 Deno.test({
   name: "notification-worker - missing env returns 500",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
   const { fetchMock } = createFetchMock([]);

--- a/supabase/functions/partner-approve-application/partner_approve_application_test.ts
+++ b/supabase/functions/partner-approve-application/partner_approve_application_test.ts
@@ -164,8 +164,6 @@ function bulkApproveRpcRoute(
 
 Deno.test({
   name: "OPTIONS returns CORS preflight",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const req = new Request(BASE_URL, { method: "OPTIONS" });
@@ -176,8 +174,6 @@ Deno.test({
 
 Deno.test({
   name: "GET returns 405",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const req = new Request(BASE_URL, { method: "GET" });
@@ -188,8 +184,6 @@ Deno.test({
 
 Deno.test({
   name: "Missing action returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -208,8 +202,6 @@ Deno.test({
 
 Deno.test({
   name: "approve: single approve success returns 200 with approved:1",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -236,8 +228,6 @@ Deno.test({
 
 Deno.test({
   name: "approve: application not found returns 404",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -260,8 +250,6 @@ Deno.test({
 
 Deno.test({
   name: "approve: already approved status returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -285,8 +273,6 @@ Deno.test({
 
 Deno.test({
   name: "approve: unauthorized (no auth) returns 401",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authFailRoute()]);
@@ -306,8 +292,6 @@ Deno.test({
 
 Deno.test({
   name: "approve: forbidden (insufficient permissions) returns 403",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -331,8 +315,6 @@ Deno.test({
 
 Deno.test({
   name: "approve: owner role bypasses permissions check returns 200",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -363,8 +345,6 @@ Deno.test({
 
 Deno.test({
   name: "approve: already processed (compare-and-set returns empty) returns 409",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -389,8 +369,6 @@ Deno.test({
 
 Deno.test({
   name: "approve: returns 409 when event is already full",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -417,8 +395,6 @@ Deno.test({
 
 Deno.test({
   name: "approve: returns 500 when capacity data is invalid",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -445,8 +421,6 @@ Deno.test({
 
 Deno.test({
   name: "bulk_approve: success returns 200 with approved count",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -473,8 +447,6 @@ Deno.test({
 
 Deno.test({
   name: "bulk_approve: only approves up to remaining capacity",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -507,8 +479,6 @@ Deno.test({
 
 Deno.test({
   name: "bulk_approve: returns 500 when capacity data is invalid",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -540,8 +510,6 @@ Deno.test({
 
 Deno.test({
   name: "bulk_approve: no pending apps returns 200 with approved:0",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([

--- a/supabase/functions/partner-manage-event/partner_manage_event_test.ts
+++ b/supabase/functions/partner-manage-event/partner_manage_event_test.ts
@@ -215,8 +215,6 @@ function updateTicketRoute(): FetchRoute {
 
 Deno.test({
   name: "OPTIONS returns CORS preflight",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const req = new Request("http://localhost", { method: "OPTIONS" });
@@ -227,8 +225,6 @@ Deno.test({
 
 Deno.test({
   name: "GET returns 405",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const req = new Request("http://localhost", { method: "GET" });
@@ -239,8 +235,6 @@ Deno.test({
 
 Deno.test({
   name: "Missing auth returns 401",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authFailRoute()]);
@@ -257,8 +251,6 @@ Deno.test({
 
 Deno.test({
   name: "Invalid JSON body returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -282,8 +274,6 @@ Deno.test({
 
 Deno.test({
   name: "Missing action returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -302,8 +292,6 @@ Deno.test({
 
 Deno.test({
   name: "Unknown action returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -324,8 +312,6 @@ Deno.test({
 
 Deno.test({
   name: "create: event + entry_groups + tickets from templates",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -362,8 +348,6 @@ Deno.test({
 
 Deno.test({
   name: "create: event with vote_start_at/vote_end_at",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -400,8 +384,6 @@ Deno.test({
 
 Deno.test({
   name: "create: past start_time returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -428,8 +410,6 @@ Deno.test({
 
 Deno.test({
   name: "create: start_time >= end_time returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -452,8 +432,6 @@ Deno.test({
 
 Deno.test({
   name: "create: missing party_id returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -475,8 +453,6 @@ Deno.test({
 
 Deno.test({
   name: "create: missing event object returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -496,8 +472,6 @@ Deno.test({
 
 Deno.test({
   name: "create: no partner membership returns 403",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -522,8 +496,6 @@ Deno.test({
 
 Deno.test({
   name: "create: no PARTY_MANAGE/EVENT_MANAGE permission returns 403",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -550,8 +522,6 @@ Deno.test({
 
 Deno.test({
   name: "update: start_time change",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -580,8 +550,6 @@ Deno.test({
 
 Deno.test({
   name: "update: missing event_id returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -603,8 +571,6 @@ Deno.test({
 
 Deno.test({
   name: "update: event not found returns 404",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -628,8 +594,6 @@ Deno.test({
 
 Deno.test({
   name: "update: other partner's event returns 403",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -654,8 +618,6 @@ Deno.test({
 
 Deno.test({
   name: "update: no fields to update returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -684,8 +646,6 @@ Deno.test({
 
 Deno.test({
   name: "update_status: scheduled → cancelled",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -713,8 +673,6 @@ Deno.test({
 
 Deno.test({
   name: "update_status: completed → 400 (system only)",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -737,8 +695,6 @@ Deno.test({
 
 Deno.test({
   name: "update_status: cancelled event cannot change status",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -765,8 +721,6 @@ Deno.test({
 
 Deno.test({
   name: "update_status: missing event_id returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -786,8 +740,6 @@ Deno.test({
 
 Deno.test({
   name: "update_status: event not found returns 404",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -811,8 +763,6 @@ Deno.test({
 
 Deno.test({
   name: "update_status: other partner's event returns 403",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -839,8 +789,6 @@ Deno.test({
 
 Deno.test({
   name: "update_tickets: price change",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -871,8 +819,6 @@ Deno.test({
 
 Deno.test({
   name: "update_tickets: quantity below sold_count returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -902,8 +848,6 @@ Deno.test({
 
 Deno.test({
   name: "update_tickets: missing event_id returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -925,8 +869,6 @@ Deno.test({
 
 Deno.test({
   name: "update_tickets: empty tickets array returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -947,8 +889,6 @@ Deno.test({
 
 Deno.test({
   name: "update_tickets: other partner's event returns 403",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([

--- a/supabase/functions/partner-manage-match/partner_manage_match_test.ts
+++ b/supabase/functions/partner-manage-match/partner_manage_match_test.ts
@@ -77,8 +77,6 @@ function rpcRoute(success = true): FetchRoute {
 // ─── 401: no auth ───
 Deno.test({
   name: "returns 401 without authorization",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -105,8 +103,6 @@ Deno.test({
 // ─── 400: missing action ───
 Deno.test({
   name: "returns 400 for missing action",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -127,8 +123,6 @@ Deno.test({
 // ─── 400: missing event_id ───
 Deno.test({
   name: "returns 400 for missing event_id",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -149,8 +143,6 @@ Deno.test({
 // ─── 500: event DB error ───
 Deno.test({
   name: "returns 500 when event query fails",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -181,8 +173,6 @@ Deno.test({
 // ─── 403: no partner permission ───
 Deno.test({
   name: "returns 403 when user lacks PARTY_MANAGE permission",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -209,8 +199,6 @@ Deno.test({
 // ─── 500: permission DB error ───
 Deno.test({
   name: "returns 500 when permission query fails",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -242,8 +230,6 @@ Deno.test({
 // ─── 400: completed event ───
 Deno.test({
   name: "returns 400 for completed event",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -272,8 +258,6 @@ Deno.test({
 // ─── set_rules: 2 rules with vote_count (via RPC) ───
 Deno.test({
   name: "set_rules: inserts 2 rules with vote_count via RPC",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -308,8 +292,6 @@ Deno.test({
 // ─── set_rules: empty array clears all rules ───
 Deno.test({
   name: "set_rules: empty array clears all rules via RPC",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -340,8 +322,6 @@ Deno.test({
 // ─── set_rules: verifies RPC is called with correct payload ───
 Deno.test({
   name: "set_rules: sends correct payload to replace_match_rules RPC",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     let rpcBody: string | null = null;
@@ -385,8 +365,6 @@ Deno.test({
 // ─── set_rules: invalid group_id → 400 ───
 Deno.test({
   name: "set_rules: returns 400 for non-existent group_id",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -418,8 +396,6 @@ Deno.test({
 // ─── set_rules: source === target → 400 ───
 Deno.test({
   name: "set_rules: returns 400 when source equals target group",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -450,8 +426,6 @@ Deno.test({
 // ─── set_rules: vote_count = 0 → 400 ───
 Deno.test({
   name: "set_rules: returns 400 for vote_count = 0",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -482,8 +456,6 @@ Deno.test({
 // ─── clear_rules ───
 Deno.test({
   name: "clear_rules: clears all rules via RPC",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -512,8 +484,6 @@ Deno.test({
 // ─── unknown action → 400 ───
 Deno.test({
   name: "returns 400 for unknown action",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -541,8 +511,6 @@ Deno.test({
 // ─── CORS preflight ───
 Deno.test({
   name: "handles OPTIONS preflight request",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([]);

--- a/supabase/functions/partner-manage-member/partner_manage_member_test.ts
+++ b/supabase/functions/partner-manage-member/partner_manage_member_test.ts
@@ -71,8 +71,6 @@ function updateErrorRoute(): FetchRoute {
 // ─── CORS preflight ───
 Deno.test({
   name: "handles OPTIONS preflight request",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([]);
@@ -91,8 +89,6 @@ Deno.test({
 // ─── 401: no auth ───
 Deno.test({
   name: "returns 401 without authorization",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authFailRoute()]);
@@ -114,8 +110,6 @@ Deno.test({
 // ─── 400: missing action ───
 Deno.test({
   name: "returns 400 for missing action",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -136,8 +130,6 @@ Deno.test({
 // ─── 400: unknown action ───
 Deno.test({
   name: "returns 400 for unknown action",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -158,8 +150,6 @@ Deno.test({
 // ─── update_role: success ───
 Deno.test({
   name: "update_role: updates role successfully",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -189,8 +179,6 @@ Deno.test({
 // ─── update_role: verify payload sent to DB ───
 Deno.test({
   name: "update_role: sends correct payload to DB",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     let updateBody: string | null = null;
@@ -230,8 +218,6 @@ Deno.test({
 // ─── update_role: missing partner_id → 400 ───
 Deno.test({
   name: "update_role: returns 400 for missing partner_id",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -256,8 +242,6 @@ Deno.test({
 // ─── update_role: missing user_id → 400 ───
 Deno.test({
   name: "update_role: returns 400 for missing user_id",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -282,8 +266,6 @@ Deno.test({
 // ─── update_role: missing role → 400 ───
 Deno.test({
   name: "update_role: returns 400 for missing role",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -308,8 +290,6 @@ Deno.test({
 // ─── update_role: invalid role → 400 ───
 Deno.test({
   name: "update_role: returns 400 for invalid role",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -335,8 +315,6 @@ Deno.test({
 // ─── update_role: self role change → 400 ───
 Deno.test({
   name: "update_role: returns 400 when changing own role",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -362,8 +340,6 @@ Deno.test({
 // ─── update_role: 403 no permission ───
 Deno.test({
   name: "update_role: returns 403 when user lacks MEMBER_MANAGE permission",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -390,8 +366,6 @@ Deno.test({
 // ─── update_role: 500 permission DB error ───
 Deno.test({
   name: "update_role: returns 500 when permission query fails",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -420,8 +394,6 @@ Deno.test({
 // ─── update_role: 500 update error ───
 Deno.test({
   name: "update_role: returns 500 when update fails",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -449,8 +421,6 @@ Deno.test({
 // ─── update_permissions: success ───
 Deno.test({
   name: "update_permissions: updates permissions successfully",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -480,8 +450,6 @@ Deno.test({
 // ─── update_permissions: verify payload sent to DB ───
 Deno.test({
   name: "update_permissions: sends correct payload to DB",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     let updateBody: string | null = null;
@@ -521,8 +489,6 @@ Deno.test({
 // ─── update_permissions: missing partner_id → 400 ───
 Deno.test({
   name: "update_permissions: returns 400 for missing partner_id",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -547,8 +513,6 @@ Deno.test({
 // ─── update_permissions: missing user_id → 400 ───
 Deno.test({
   name: "update_permissions: returns 400 for missing user_id",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -573,8 +537,6 @@ Deno.test({
 // ─── update_permissions: missing permissions → 400 ───
 Deno.test({
   name: "update_permissions: returns 400 for missing permissions",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -599,8 +561,6 @@ Deno.test({
 // ─── update_permissions: invalid permission → 400 ───
 Deno.test({
   name: "update_permissions: returns 400 for invalid permission",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -626,8 +586,6 @@ Deno.test({
 // ─── update_permissions: 403 no permission ───
 Deno.test({
   name: "update_permissions: returns 403 when user lacks MEMBER_MANAGE permission",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -654,8 +612,6 @@ Deno.test({
 // ─── update_permissions: 500 update error ───
 Deno.test({
   name: "update_permissions: returns 500 when update fails",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([

--- a/supabase/functions/partner-manage-party/partner_manage_party_test.ts
+++ b/supabase/functions/partner-manage-party/partner_manage_party_test.ts
@@ -190,8 +190,6 @@ function insertTicketTemplatesRoute(): FetchRoute {
 
 Deno.test({
   name: "OPTIONS returns CORS preflight",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const req = new Request("http://localhost", { method: "OPTIONS" });
@@ -202,8 +200,6 @@ Deno.test({
 
 Deno.test({
   name: "GET returns 405",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const req = new Request("http://localhost", { method: "GET" });
@@ -214,8 +210,6 @@ Deno.test({
 
 Deno.test({
   name: "Missing auth returns 401",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authFailRoute()]);
@@ -232,8 +226,6 @@ Deno.test({
 
 Deno.test({
   name: "Invalid JSON body returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -257,8 +249,6 @@ Deno.test({
 
 Deno.test({
   name: "Missing action returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -277,8 +267,6 @@ Deno.test({
 
 Deno.test({
   name: "Unknown action returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -299,8 +287,6 @@ Deno.test({
 
 Deno.test({
   name: "create: party + location + templates — full atomic creation",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -340,8 +326,6 @@ Deno.test({
 
 Deno.test({
   name: "create: with existing location_id",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -371,8 +355,6 @@ Deno.test({
 
 Deno.test({
   name: "create: missing party title returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute(), permRoute()]);
@@ -395,8 +377,6 @@ Deno.test({
 
 Deno.test({
   name: "create: missing partner_id returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -418,8 +398,6 @@ Deno.test({
 
 Deno.test({
   name: "create: missing party object returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -439,8 +417,6 @@ Deno.test({
 
 Deno.test({
   name: "create: no partner membership returns 403",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -464,8 +440,6 @@ Deno.test({
 
 Deno.test({
   name: "create: no PARTY_MANAGE permission returns 403",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -489,8 +463,6 @@ Deno.test({
 
 Deno.test({
   name: "create: invalid gender in entry_group_templates returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -518,8 +490,6 @@ Deno.test({
 
 Deno.test({
   name: "create: negative ticket price returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -547,8 +517,6 @@ Deno.test({
 
 Deno.test({
   name: "create: location belonging to other partner returns 403",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -578,8 +546,6 @@ Deno.test({
 
 Deno.test({
   name: "update: party title change",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -607,8 +573,6 @@ Deno.test({
 
 Deno.test({
   name: "update: location change",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -636,8 +600,6 @@ Deno.test({
 
 Deno.test({
   name: "update: missing party_id returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -659,8 +621,6 @@ Deno.test({
 
 Deno.test({
   name: "update: party not found returns 404",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -684,8 +644,6 @@ Deno.test({
 
 Deno.test({
   name: "update: other partner's party returns 403",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -710,8 +668,6 @@ Deno.test({
 
 Deno.test({
   name: "update: no fields to update returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -739,8 +695,6 @@ Deno.test({
 
 Deno.test({
   name: "update_status: active → closed",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -768,8 +722,6 @@ Deno.test({
 
 Deno.test({
   name: "update_status: invalid status returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -792,8 +744,6 @@ Deno.test({
 
 Deno.test({
   name: "update_status: missing party_id returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -813,8 +763,6 @@ Deno.test({
 
 Deno.test({
   name: "update_status: party not found returns 404",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -838,8 +786,6 @@ Deno.test({
 
 Deno.test({
   name: "update_status: other partner's party returns 403",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -866,8 +812,6 @@ Deno.test({
 
 Deno.test({
   name: "create: with tag_ids 3 tags — party_tags inserted",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const tagIds = [
@@ -903,8 +847,6 @@ Deno.test({
 
 Deno.test({
   name: "create: without tag_ids — party created without tags",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     // party_tags INSERT route 없이도 성공해야 함
@@ -932,8 +874,6 @@ Deno.test({
 
 Deno.test({
   name: "create: tag_ids with 6 items returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     // tag_ids validation now runs before any DB write — no rpcCreatePartyRoute needed
@@ -968,8 +908,6 @@ Deno.test({
 
 Deno.test({
   name: "create: tag_ids with nonexistent IDs returns 400 — no party INSERT attempted",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     // Fix #1136: DB existence check on create path — orphaned party prevented
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
@@ -1010,8 +948,6 @@ Deno.test({
 
 Deno.test({
   name: "update: tag_ids provided — existing tags replaced",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     // INSERT new tags first, then DELETE old ones not in new set (safe order)
@@ -1046,8 +982,6 @@ Deno.test({
 
 Deno.test({
   name: "update: tag_ids empty array — all tags removed",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     // Fix #1223: update_party_tags RPC handles empty array (clears all tags) atomically
@@ -1076,8 +1010,6 @@ Deno.test({
 
 Deno.test({
   name: "update: tag_ids undefined — tags not changed",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     // tag_ids 없으면 party_tags route 불필요
@@ -1106,8 +1038,6 @@ Deno.test({
 
 Deno.test({
   name: "update: tag_ids with 6 items returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -1143,8 +1073,6 @@ Deno.test({
 
 Deno.test({
   name: "create: tag_ids not array returns 400 — no party INSERT attempted",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     // No rpcCreatePartyRoute — if create_party_with_tags RPC were called it would throw "Unhandled fetch"
@@ -1175,8 +1103,6 @@ Deno.test({
 
 Deno.test({
   name: "update: tag_ids not array returns 400 — no party PATCH attempted",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     // No updatePartyRoute — if party PATCH were attempted it would throw "Unhandled fetch"
@@ -1210,8 +1136,6 @@ Deno.test({
 
 Deno.test({
   name: "create: tag_ids with invalid UUID format returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock, calls } = createFetchMock([
@@ -1243,8 +1167,6 @@ Deno.test({
 
 Deno.test({
   name: "create: duplicate tag_ids are deduplicated",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const uniqueId = "00000000-0000-0000-0000-000000000001";
@@ -1275,8 +1197,6 @@ Deno.test({
 
 Deno.test({
   name: "update: tag_ids with invalid UUID format returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock, calls } = createFetchMock([

--- a/supabase/functions/partner-manage-settlement/partner_manage_settlement_test.ts
+++ b/supabase/functions/partner-manage-settlement/partner_manage_settlement_test.ts
@@ -71,8 +71,6 @@ function upsertErrorRoute(): FetchRoute {
 // ─── CORS preflight ───
 Deno.test({
   name: "handles OPTIONS preflight request",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([]);
@@ -91,8 +89,6 @@ Deno.test({
 // ─── 401: no auth ───
 Deno.test({
   name: "returns 401 without authorization",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authFailRoute()]);
@@ -114,8 +110,6 @@ Deno.test({
 // ─── 400: missing action ───
 Deno.test({
   name: "returns 400 for missing action",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -136,8 +130,6 @@ Deno.test({
 // ─── 400: unknown action ───
 Deno.test({
   name: "returns 400 for unknown action",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -158,8 +150,6 @@ Deno.test({
 // ─── UPSERT: success ───
 Deno.test({
   name: "upsert_bank_account: upserts bank account successfully",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -190,8 +180,6 @@ Deno.test({
 // ─── UPSERT: verify payload sent to DB ───
 Deno.test({
   name: "upsert_bank_account: sends correct payload to DB",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     let upsertBody: string | null = null;
@@ -235,8 +223,6 @@ Deno.test({
 // ─── UPSERT: extra fields ignored ───
 Deno.test({
   name: "upsert_bank_account: ignores non-whitelisted fields",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     let upsertBody: string | null = null;
@@ -282,8 +268,6 @@ Deno.test({
 // ─── UPSERT: missing partner_id → 400 ───
 Deno.test({
   name: "upsert_bank_account: returns 400 for missing partner_id",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -309,8 +293,6 @@ Deno.test({
 // ─── UPSERT: missing bank_name → 400 ───
 Deno.test({
   name: "upsert_bank_account: returns 400 for missing bank_name",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -336,8 +318,6 @@ Deno.test({
 // ─── UPSERT: missing account_holder → 400 ───
 Deno.test({
   name: "upsert_bank_account: returns 400 for missing account_holder",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -363,8 +343,6 @@ Deno.test({
 // ─── UPSERT: missing account_number → 400 ───
 Deno.test({
   name: "upsert_bank_account: returns 400 for missing account_number",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -390,8 +368,6 @@ Deno.test({
 // ─── UPSERT: 403 no permission ───
 Deno.test({
   name: "upsert_bank_account: returns 403 when user lacks SETTLEMENT_EDIT permission",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -419,8 +395,6 @@ Deno.test({
 // ─── UPSERT: 500 permission DB error ───
 Deno.test({
   name: "upsert_bank_account: returns 500 when permission query fails",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -450,8 +424,6 @@ Deno.test({
 // ─── UPSERT: whitespace-only bank_name → 400 ───
 Deno.test({
   name: "upsert_bank_account: returns 400 for whitespace-only bank_name",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -478,8 +450,6 @@ Deno.test({
 // ─── UPSERT: invalid account_number format → 400 ───
 Deno.test({
   name: "upsert_bank_account: returns 400 for invalid account_number format",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -506,8 +476,6 @@ Deno.test({
 // ─── UPSERT: account_number with hyphens → normalized ───
 Deno.test({
   name: "upsert_bank_account: normalizes account_number by stripping hyphens",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     let upsertBody: string | null = null;
@@ -547,8 +515,6 @@ Deno.test({
 // ─── UPSERT: 500 upsert error ───
 Deno.test({
   name: "upsert_bank_account: returns 500 when upsert fails",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([

--- a/supabase/functions/partner-manage-verification/partner_manage_verification_test.ts
+++ b/supabase/functions/partner-manage-verification/partner_manage_verification_test.ts
@@ -113,8 +113,6 @@ function updateErrorRoute(): FetchRoute {
 // ─── CORS preflight ───
 Deno.test({
   name: "handles OPTIONS preflight request",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([]);
@@ -133,8 +131,6 @@ Deno.test({
 // ─── 401: no auth ───
 Deno.test({
   name: "returns 401 without authorization",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authFailRoute()]);
@@ -156,8 +152,6 @@ Deno.test({
 // ─── 400: missing action ───
 Deno.test({
   name: "returns 400 for missing action",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -178,8 +172,6 @@ Deno.test({
 // ─── 400: unknown action ───
 Deno.test({
   name: "returns 400 for unknown action",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -200,8 +192,6 @@ Deno.test({
 // ─── CREATE: success ───
 Deno.test({
   name: "create: inserts verification and returns id",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -236,8 +226,6 @@ Deno.test({
 // ─── CREATE: partner_id server-injected — verify POST body ───
 Deno.test({
   name: "create: sends partner_id in insert payload",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     let insertBody: string | null = null;
@@ -279,8 +267,6 @@ Deno.test({
 // ─── CREATE: missing partner_id → 400 ───
 Deno.test({
   name: "create: returns 400 for missing partner_id",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -306,8 +292,6 @@ Deno.test({
 // ─── CREATE: missing required fields → 400 ───
 Deno.test({
   name: "create: returns 400 for missing category",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -332,8 +316,6 @@ Deno.test({
 
 Deno.test({
   name: "create: returns 400 for invalid category",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -360,8 +342,6 @@ Deno.test({
 // ─── CREATE: 403 no permission ───
 Deno.test({
   name: "create: returns 403 when user lacks PARTY_MANAGE permission",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -389,8 +369,6 @@ Deno.test({
 // ─── CREATE: 500 permission DB error ───
 Deno.test({
   name: "create: returns 500 when permission query fails",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -420,8 +398,6 @@ Deno.test({
 // ─── CREATE: 500 insert error ───
 Deno.test({
   name: "create: returns 500 when insert fails",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -450,8 +426,6 @@ Deno.test({
 // ─── UPDATE: display_name ───
 Deno.test({
   name: "update: updates display_name successfully",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -481,8 +455,6 @@ Deno.test({
 // ─── UPDATE: is_active=false (soft delete) ───
 Deno.test({
   name: "update: is_active=false soft deletes",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     let patchBody: string | null = null;
@@ -521,8 +493,6 @@ Deno.test({
 // ─── UPDATE: is_active=true (restore) ───
 Deno.test({
   name: "update: is_active=true restores",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     let patchBody: string | null = null;
@@ -561,8 +531,6 @@ Deno.test({
 // ─── UPDATE: partial — only sent fields updated ───
 Deno.test({
   name: "update: partial update only sends provided fields",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     let patchBody: string | null = null;
@@ -603,8 +571,6 @@ Deno.test({
 // ─── UPDATE: other partner's verification → 403 ───
 Deno.test({
   name: "update: returns 403 for other partner's verification",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -631,8 +597,6 @@ Deno.test({
 // ─── UPDATE: partner_id change attempt ignored ───
 Deno.test({
   name: "update: partner_id in body is ignored (not in update fields)",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     let patchBody: string | null = null;
@@ -674,8 +638,6 @@ Deno.test({
 // ─── UPDATE: missing verification_id → 400 ───
 Deno.test({
   name: "update: returns 400 for missing verification_id",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -699,8 +661,6 @@ Deno.test({
 // ─── UPDATE: verification not found → 404 ───
 Deno.test({
   name: "update: returns 404 when verification not found",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -728,8 +688,6 @@ Deno.test({
 // ─── UPDATE: no fields to update → 400 ───
 Deno.test({
   name: "update: returns 400 when no valid fields provided",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -760,8 +718,6 @@ Deno.test({
 // ─── UPDATE: 500 update error ───
 Deno.test({
   name: "update: returns 500 when update fails",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([

--- a/supabase/functions/partner-register/partner_register_test.ts
+++ b/supabase/functions/partner-register/partner_register_test.ts
@@ -116,8 +116,6 @@ function storageListRoute(hasFiles = true): FetchRoute {
 // ─── CORS preflight ───
 Deno.test({
   name: "handles OPTIONS preflight request",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([]);
@@ -136,8 +134,6 @@ Deno.test({
 // ─── 401: no auth ───
 Deno.test({
   name: "returns 401 without authorization",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authFailRoute()]);
@@ -159,8 +155,6 @@ Deno.test({
 // ─── 400: missing action ───
 Deno.test({
   name: "returns 400 for missing action",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -181,8 +175,6 @@ Deno.test({
 // ─── 400: unknown action ───
 Deno.test({
   name: "returns 400 for unknown action",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -207,8 +199,6 @@ Deno.test({
 // ─── save_draft: new INSERT → returns application_id ───
 Deno.test({
   name: "save_draft: new insert returns application_id",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -236,8 +226,6 @@ Deno.test({
 // ─── save_draft: existing UPDATE ───
 Deno.test({
   name: "save_draft: existing update returns application_id",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -267,8 +255,6 @@ Deno.test({
 // ─── save_draft: current_step saved ───
 Deno.test({
   name: "save_draft: current_step is persisted",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     let insertBody: string | null = null;
@@ -305,8 +291,6 @@ Deno.test({
 // ─── save_draft: other user's draft → 403 ───
 Deno.test({
   name: "save_draft: returns 403 for other user's draft",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -332,8 +316,6 @@ Deno.test({
 // ─── save_draft: pending status → 400 ───
 Deno.test({
   name: "save_draft: returns 400 when application is pending",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -361,8 +343,6 @@ Deno.test({
 // ─── save_draft: insert error → 500 ───
 Deno.test({
   name: "save_draft: returns 500 when insert fails",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -391,8 +371,6 @@ Deno.test({
 // ─── submit: draft → pending with all fields valid ───
 Deno.test({
   name: "submit: draft → pending with valid data",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     // Use valid biz_number with correct checksum: 1208100083
@@ -423,8 +401,6 @@ Deno.test({
 // ─── submit: missing required fields → 400 + details ───
 Deno.test({
   name: "submit: returns 400 with validation details for missing fields",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const incompleteApp = {
@@ -477,8 +453,6 @@ Deno.test({
 // ─── submit: biz_number format error → 400 ───
 Deno.test({
   name: "submit: returns 400 for invalid biz_number format",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const badBizApp = { ...VALID_APP, biz_number: "123" };
@@ -509,8 +483,6 @@ Deno.test({
 // ─── submit: contact_email format error → 400 ───
 Deno.test({
   name: "submit: returns 400 for invalid email format",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const badEmailApp = { ...VALID_APP, biz_number: "1208100088", contact_email: "not-an-email" };
@@ -541,8 +513,6 @@ Deno.test({
 // ─── submit: biz_registration_path file not found → 400 ───
 Deno.test({
   name: "submit: returns 400 when storage file not found",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const validApp = { ...VALID_APP, biz_number: "1208100088" };
@@ -571,8 +541,6 @@ Deno.test({
 // ─── submit: other user's file path → 403 ───
 Deno.test({
   name: "submit: returns 403 for file path with other user's prefix",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const hackedApp = {
@@ -604,8 +572,6 @@ Deno.test({
 // ─── submit: storage error → 500 ───
 Deno.test({
   name: "submit: returns 500 when storage list fails",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const validApp = { ...VALID_APP, biz_number: "1208100088" };
@@ -637,8 +603,6 @@ Deno.test({
 // ─── submit: pending → re-submit → 400 ───
 Deno.test({
   name: "submit: returns 400 when already pending",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const pendingApp = { ...VALID_APP, status: "pending" };
@@ -666,8 +630,6 @@ Deno.test({
 // ─── submit: needs_correction → pending ───
 Deno.test({
   name: "submit: needs_correction → pending transition success",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const correctionApp = { ...VALID_APP, status: "needs_correction", biz_number: "1208100088" };
@@ -697,8 +659,6 @@ Deno.test({
 // ─── submit: missing application_id → 400 ───
 Deno.test({
   name: "submit: returns 400 for missing application_id",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -721,8 +681,6 @@ Deno.test({
 // ─── submit: other user's application → 403 ───
 Deno.test({
   name: "submit: returns 403 for other user's application",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const otherApp = { ...VALID_APP, user_id: OTHER_USER_ID };
@@ -752,8 +710,6 @@ Deno.test({
 // ─── update: draft → success ───
 Deno.test({
   name: "update: draft status allows update",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -783,8 +739,6 @@ Deno.test({
 // ─── update: needs_correction → success ───
 Deno.test({
   name: "update: needs_correction status allows update",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -813,8 +767,6 @@ Deno.test({
 // ─── update: pending → 400 ───
 Deno.test({
   name: "update: returns 400 when status is pending",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -842,8 +794,6 @@ Deno.test({
 // ─── update: other user → 403 ───
 Deno.test({
   name: "update: returns 403 for other user's application",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -869,8 +819,6 @@ Deno.test({
 // ─── update: missing application_id → 400 ───
 Deno.test({
   name: "update: returns 400 for missing application_id",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -894,8 +842,6 @@ Deno.test({
 // ─── update: no valid fields → 400 ───
 Deno.test({
   name: "update: returns 400 when no valid fields in data",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -923,8 +869,6 @@ Deno.test({
 // ─── update: whitelisted fields only — status/user_id ignored ───
 Deno.test({
   name: "update: only whitelisted fields are sent to DB",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     let patchBody: string | null = null;

--- a/supabase/functions/partner-reject-application/partner_reject_application_test.ts
+++ b/supabase/functions/partner-reject-application/partner_reject_application_test.ts
@@ -101,8 +101,6 @@ function updateRoute(updated = [{ id: TEST_APP_ID }]): FetchRoute {
 // ─── OPTIONS: CORS preflight ───
 Deno.test({
   name: "OPTIONS returns CORS",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([]);
@@ -119,8 +117,6 @@ Deno.test({
 // ─── GET: 405 ───
 Deno.test({
   name: "GET returns 405",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([]);
@@ -137,8 +133,6 @@ Deno.test({
 // ─── 400: missing application_id ───
 Deno.test({
   name: "Missing application_id returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -159,8 +153,6 @@ Deno.test({
 // ─── 400: missing reason ───
 Deno.test({
   name: "Missing reason returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -181,8 +173,6 @@ Deno.test({
 // ─── 200: reject success ───
 Deno.test({
   name: "Reject success returns 200 with rejected count",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -211,8 +201,6 @@ Deno.test({
 // ─── 404: application not found ───
 Deno.test({
   name: "Application not found returns 404",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -239,8 +227,6 @@ Deno.test({
 // ─── 400: already rejected status ───
 Deno.test({
   name: "Already rejected status returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -268,8 +254,6 @@ Deno.test({
 // ─── 401: unauthorized ───
 Deno.test({
   name: "Unauthorized returns 401",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authFailRoute()]);
@@ -291,8 +275,6 @@ Deno.test({
 // ─── 403: forbidden (insufficient permissions) ───
 Deno.test({
   name: "Forbidden (insufficient permissions) returns 403",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -320,8 +302,6 @@ Deno.test({
 // ─── 200: owner role bypasses permissions ───
 Deno.test({
   name: "Owner role bypasses permissions check",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -353,8 +333,6 @@ Deno.test({
 // ─── 409: already processed (compare-and-set empty) ───
 Deno.test({
   name: "Already processed (compare-and-set returns empty) returns 409",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([

--- a/supabase/functions/partner-review-submission/partner_review_submission_test.ts
+++ b/supabase/functions/partner-review-submission/partner_review_submission_test.ts
@@ -112,8 +112,6 @@ function updateErrorRoute(): FetchRoute {
 // ─── CORS preflight ───
 Deno.test({
   name: "handles OPTIONS preflight request",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([]);
@@ -132,8 +130,6 @@ Deno.test({
 // ─── 401: no auth ───
 Deno.test({
   name: "returns 401 without authorization",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authFailRoute()]);
@@ -155,8 +151,6 @@ Deno.test({
 // ─── 400: missing action ───
 Deno.test({
   name: "returns 400 for missing action",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -177,8 +171,6 @@ Deno.test({
 // ─── 400: unknown action ───
 Deno.test({
   name: "returns 400 for unknown action",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -199,8 +191,6 @@ Deno.test({
 // ─── REVIEW: approved → status + snapshot_data updated ───
 Deno.test({
   name: "review: approved updates status and snapshot_data",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     let patchBody: string | null = null;
@@ -251,8 +241,6 @@ Deno.test({
 // ─── REVIEW: rejected + comment ───
 Deno.test({
   name: "review: rejected with comment includes comment in snapshot",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     let patchBody: string | null = null;
@@ -298,8 +286,6 @@ Deno.test({
 // ─── REVIEW: reviewed_at, reviewed_by columns updated ───
 Deno.test({
   name: "review: updates reviewed_at and reviewed_by columns",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     let patchBody: string | null = null;
@@ -340,8 +326,6 @@ Deno.test({
 // ─── COMMENT: append to snapshot_data ───
 Deno.test({
   name: "comment: appends comment to last snapshot entry",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     let patchBody: string | null = null;
@@ -390,8 +374,6 @@ Deno.test({
 // ─── REVIEW: other partner's submission → 403 ───
 Deno.test({
   name: "review: returns 403 for other partner's submission",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -418,8 +400,6 @@ Deno.test({
 // ─── REVIEW: invalid result → 400 ───
 Deno.test({
   name: "review: returns 400 for invalid result value",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -444,8 +424,6 @@ Deno.test({
 // ─── REVIEW: nonexistent submission → 404 ───
 Deno.test({
   name: "review: returns 404 for nonexistent submission",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -473,8 +451,6 @@ Deno.test({
 // ─── COMMENT: nonexistent submission → 404 ───
 Deno.test({
   name: "comment: returns 404 for nonexistent submission",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -502,8 +478,6 @@ Deno.test({
 // ─── REVIEW: missing submission_id → 400 ───
 Deno.test({
   name: "review: returns 400 for missing submission_id",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -527,8 +501,6 @@ Deno.test({
 // ─── COMMENT: missing text → 400 ───
 Deno.test({
   name: "comment: returns 400 for missing text",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -552,8 +524,6 @@ Deno.test({
 // ─── REVIEW: 500 permission DB error ───
 Deno.test({
   name: "review: returns 500 when permission query fails",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -582,8 +552,6 @@ Deno.test({
 // ─── REVIEW: 500 update error ───
 Deno.test({
   name: "review: returns 500 when update fails",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -611,8 +579,6 @@ Deno.test({
 // ─── COMMENT: 500 update error ───
 Deno.test({
   name: "comment: returns 500 when update fails",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -640,8 +606,6 @@ Deno.test({
 // ─── REVIEW: already reviewed submission → 409 ───
 Deno.test({
   name: "review: returns 409 for already reviewed submission",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([

--- a/supabase/functions/process-pending-deletions/process-pending-deletions_test.ts
+++ b/supabase/functions/process-pending-deletions/process-pending-deletions_test.ts
@@ -10,7 +10,6 @@ import {
   withNoIntervals,
 } from "../_test_utils/mock_http.ts";
 
-const TEST_OPTS = { sanitizeOps: false, sanitizeResources: false };
 
 const ENV = {
   SUPABASE_URL: "https://supabase.test",
@@ -143,7 +142,7 @@ const userConsentsRoute = {
     ]),
 };
 
-Deno.test("unauthorized request returns 401", TEST_OPTS, async () => {
+Deno.test("unauthorized request returns 401", async () => {
   const handler = await captureServeHandler(
     new URL("./index.ts", import.meta.url),
   );
@@ -163,7 +162,6 @@ Deno.test("unauthorized request returns 401", TEST_OPTS, async () => {
 
 Deno.test(
   "successful run archives records, blocks DI, and deletes auth user",
-  TEST_OPTS,
   async () => {
     const handler = await captureServeHandler(
       new URL("./index.ts", import.meta.url),
@@ -249,7 +247,7 @@ Deno.test(
   },
 );
 
-Deno.test("no eligible users returns zero summary", TEST_OPTS, async () => {
+Deno.test("no eligible users returns zero summary", async () => {
   const handler = await captureServeHandler(
     new URL("./index.ts", import.meta.url),
   );

--- a/supabase/functions/recurrence-cron/recurrence-cron_test.ts
+++ b/supabase/functions/recurrence-cron/recurrence-cron_test.ts
@@ -11,7 +11,6 @@ import {
   type FetchRoute,
 } from "../_test_utils/mock_http.ts";
 
-const TEST_OPTS = { sanitizeOps: false, sanitizeResources: false };
 
 const ENV = {
   SUPABASE_URL: "https://supabase.test",
@@ -114,7 +113,7 @@ const rulesUpdateRoute: FetchRoute = {
 
 // ─── Auth tests ───────────────────────────────────────────────────────────────
 
-Deno.test("recurrence-cron - missing auth returns 401", TEST_OPTS, async () => {
+Deno.test("recurrence-cron - missing auth returns 401", async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(
       new URL("./index.ts", import.meta.url),
@@ -127,7 +126,7 @@ Deno.test("recurrence-cron - missing auth returns 401", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("recurrence-cron - wrong service role key returns 401", TEST_OPTS, async () => {
+Deno.test("recurrence-cron - wrong service role key returns 401", async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(
       new URL("./index.ts", import.meta.url),
@@ -143,7 +142,7 @@ Deno.test("recurrence-cron - wrong service role key returns 401", TEST_OPTS, asy
   });
 });
 
-Deno.test("recurrence-cron - OPTIONS preflight returns 200", TEST_OPTS, async () => {
+Deno.test("recurrence-cron - OPTIONS preflight returns 200", async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(
       new URL("./index.ts", import.meta.url),
@@ -159,9 +158,7 @@ Deno.test("recurrence-cron - OPTIONS preflight returns 200", TEST_OPTS, async ()
 // ─── Happy path: weekly rule generates correct events ──────────────────────────
 
 Deno.test(
-  "recurrence-cron - weekly rule with 2 days generates ~8-9 events over 30 days",
-  TEST_OPTS,
-  async () => {
+  "recurrence-cron - weekly rule with 2 days generates ~8-9 events over 30 days", async () => {
     await withEnv(ENV, async () => {
       const handler = await captureServeHandler(
         new URL("./index.ts", import.meta.url),
@@ -202,9 +199,7 @@ Deno.test(
 // ─── Paused rules are skipped ──────────────────────────────────────────────────
 
 Deno.test(
-  "recurrence-cron - paused rule is not returned by query and generates 0 events",
-  TEST_OPTS,
-  async () => {
+  "recurrence-cron - paused rule is not returned by query and generates 0 events", async () => {
     await withEnv(ENV, async () => {
       const handler = await captureServeHandler(
         new URL("./index.ts", import.meta.url),
@@ -232,9 +227,7 @@ Deno.test(
 // ─── Cancelled rules are skipped ──────────────────────────────────────────────
 
 Deno.test(
-  "recurrence-cron - cancelled rule generates 0 events",
-  TEST_OPTS,
-  async () => {
+  "recurrence-cron - cancelled rule generates 0 events", async () => {
     await withEnv(ENV, async () => {
       const handler = await captureServeHandler(
         new URL("./index.ts", import.meta.url),
@@ -262,9 +255,7 @@ Deno.test(
 // ─── end_date in the past → 0 events ─────────────────────────────────────────
 
 Deno.test(
-  "recurrence-cron - rule with end_date in the past generates 0 events",
-  TEST_OPTS,
-  async () => {
+  "recurrence-cron - rule with end_date in the past generates 0 events", async () => {
     await withEnv(ENV, async () => {
       const handler = await captureServeHandler(
         new URL("./index.ts", import.meta.url),
@@ -296,9 +287,7 @@ Deno.test(
 // ─── end_date in 10 days → events only up to end_date ─────────────────────────
 
 Deno.test(
-  "recurrence-cron - rule with end_date in 10 days limits event generation",
-  TEST_OPTS,
-  async () => {
+  "recurrence-cron - rule with end_date in 10 days limits event generation", async () => {
     await withEnv(ENV, async () => {
       const handler = await captureServeHandler(
         new URL("./index.ts", import.meta.url),
@@ -347,9 +336,7 @@ Deno.test(
 // ─── Monthly pattern: generates only on month_day ─────────────────────────────
 
 Deno.test(
-  "recurrence-cron - monthly rule generates events only on month_day",
-  TEST_OPTS,
-  async () => {
+  "recurrence-cron - monthly rule generates events only on month_day", async () => {
     // Freeze clock at 2026-04-05: window = [2026-04-05, 2026-05-05]
     // month_day=15 → only 2026-04-15 qualifies → exactly 1 event
     const fakeTime = new FakeTime("2026-04-05T00:00:00Z");
@@ -403,7 +390,6 @@ Deno.test(
 
 Deno.test(
   "recurrence-cron - duplicate events (23505) are counted as skipped, not errors",
-  TEST_OPTS,
   async () => {
     // Freeze clock: window [2026-04-05, 2026-05-05], month_day=15 → exactly 1 candidate date
     const fakeTime = new FakeTime("2026-04-05T00:00:00Z");
@@ -449,9 +435,7 @@ Deno.test(
 // ─── entry_group_templates + ticket_templates are copied ──────────────────────
 
 Deno.test(
-  "recurrence-cron - entry_group_templates and ticket_templates are copied for each event",
-  TEST_OPTS,
-  async () => {
+  "recurrence-cron - entry_group_templates and ticket_templates are copied for each event", async () => {
     // Freeze clock: window [2026-04-05, 2026-05-05], month_day=15 → exactly 1 event
     const fakeTime = new FakeTime("2026-04-05T00:00:00Z");
     try {
@@ -546,9 +530,7 @@ Deno.test(
 // ─── No active rules → processed=0 ───────────────────────────────────────────
 
 Deno.test(
-  "recurrence-cron - no active rules returns processed=0",
-  TEST_OPTS,
-  async () => {
+  "recurrence-cron - no active rules returns processed=0", async () => {
     await withEnv(ENV, async () => {
       const handler = await captureServeHandler(
         new URL("./index.ts", import.meta.url),

--- a/supabase/functions/recurrence-rules/recurrence-rules_test.ts
+++ b/supabase/functions/recurrence-rules/recurrence-rules_test.ts
@@ -188,8 +188,6 @@ function insertTicketsRoute(): FetchRoute {
 
 Deno.test({
   name: "OPTIONS returns CORS preflight",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const req = new Request("http://localhost", { method: "OPTIONS" });
@@ -200,8 +198,6 @@ Deno.test({
 
 Deno.test({
   name: "GET returns 405",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const req = new Request("http://localhost", { method: "GET" });
@@ -212,8 +208,6 @@ Deno.test({
 
 Deno.test({
   name: "Missing auth returns 401",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authFailRoute()]);
@@ -230,8 +224,6 @@ Deno.test({
 
 Deno.test({
   name: "Unknown action returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -252,8 +244,6 @@ Deno.test({
 
 Deno.test({
   name: "create: happy path returns rule_id and events_created",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -294,8 +284,6 @@ Deno.test({
 
 Deno.test({
   name: "create: missing party_id returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -320,8 +308,6 @@ Deno.test({
 
 Deno.test({
   name: "create: invalid pattern returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -347,8 +333,6 @@ Deno.test({
 
 Deno.test({
   name: "create: missing start_time returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -373,8 +357,6 @@ Deno.test({
 
 Deno.test({
   name: "create: permission denied returns 403",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -402,8 +384,6 @@ Deno.test({
 
 Deno.test({
   name: "create: monthly without month_day returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -429,8 +409,6 @@ Deno.test({
 
 Deno.test({
   name: "create: party not found returns 404",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -461,8 +439,6 @@ Deno.test({
 
 Deno.test({
   name: "update: happy path returns success",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -491,8 +467,6 @@ Deno.test({
 
 Deno.test({
   name: "update: missing rule_id returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -514,8 +488,6 @@ Deno.test({
 
 Deno.test({
   name: "update: cancelled rule returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -541,8 +513,6 @@ Deno.test({
 
 Deno.test({
   name: "update: rule not found returns 404",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -568,8 +538,6 @@ Deno.test({
 
 Deno.test({
   name: "pause: happy path returns success",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -596,8 +564,6 @@ Deno.test({
 
 Deno.test({
   name: "pause: already paused rule returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -622,8 +588,6 @@ Deno.test({
 
 Deno.test({
   name: "pause: cancelled rule returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -648,8 +612,6 @@ Deno.test({
 
 Deno.test({
   name: "resume: happy path returns success and events_created",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -681,8 +643,6 @@ Deno.test({
 
 Deno.test({
   name: "resume: active rule returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -709,8 +669,6 @@ Deno.test({
 
 Deno.test({
   name: "cancel: happy path returns success",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -737,8 +695,6 @@ Deno.test({
 
 Deno.test({
   name: "cancel: already cancelled rule returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -763,8 +719,6 @@ Deno.test({
 
 Deno.test({
   name: "cancel: rule not found returns 404",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -787,8 +741,6 @@ Deno.test({
 
 Deno.test({
   name: "cancel: permission denied returns 403",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([

--- a/supabase/functions/user-cancel-deletion/user-cancel-deletion_test.ts
+++ b/supabase/functions/user-cancel-deletion/user-cancel-deletion_test.ts
@@ -11,7 +11,6 @@ import {
 } from "../_test_utils/mock_http.ts";
 import { authRoute } from "../_test_utils/fixtures.ts";
 
-const TEST_OPTS = { sanitizeOps: false, sanitizeResources: false };
 
 const ENV = {
   SUPABASE_URL: "https://supabase.test",
@@ -32,7 +31,7 @@ const restoreRoute = {
   handler: () => jsonResponse({}),
 };
 
-Deno.test("인증 없는 요청 → 401", TEST_OPTS, async () => {
+Deno.test("인증 없는 요청 → 401", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([]);
@@ -50,7 +49,7 @@ Deno.test("인증 없는 요청 → 401", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("유예 기간 중 취소 → deleted_at 복구", TEST_OPTS, async () => {
+Deno.test("유예 기간 중 취소 → deleted_at 복구", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
   const deletedAt = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
 
@@ -79,7 +78,7 @@ Deno.test("유예 기간 중 취소 → deleted_at 복구", TEST_OPTS, async () 
   });
 });
 
-Deno.test("deleted_at 이 null인 유저 → 404", TEST_OPTS, async () => {
+Deno.test("deleted_at 이 null인 유저 → 404", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -100,7 +99,7 @@ Deno.test("deleted_at 이 null인 유저 → 404", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("유예 기간 초과 → 400", TEST_OPTS, async () => {
+Deno.test("유예 기간 초과 → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
   const deletedAt = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
 

--- a/supabase/functions/user-cancel-order/user_cancel_order_test.ts
+++ b/supabase/functions/user-cancel-order/user_cancel_order_test.ts
@@ -12,7 +12,6 @@ import {
 } from "../_test_utils/mock_http.ts";
 import { authRoute } from "../_test_utils/fixtures.ts";
 
-const TEST_OPTS = { sanitizeOps: false, sanitizeResources: false };
 
 const ENV = {
   PORTONE_API_KEY: "test-key",
@@ -106,7 +105,7 @@ const appNotFoundRoute = {
 
 // ===== Pre-payment cancellation tests =====
 
-Deno.test("pending 신청 → 취소 → event_applications 삭제", TEST_OPTS, async () => {
+Deno.test("pending 신청 → 취소 → event_applications 삭제", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock, calls } = createFetchMock([
@@ -142,7 +141,7 @@ Deno.test("pending 신청 → 취소 → event_applications 삭제", TEST_OPTS, 
   });
 });
 
-Deno.test("pending + verification_submissions → 함께 삭제", TEST_OPTS, async () => {
+Deno.test("pending + verification_submissions → 함께 삭제", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock, calls } = createFetchMock([
@@ -169,7 +168,7 @@ Deno.test("pending + verification_submissions → 함께 삭제", TEST_OPTS, asy
   });
 });
 
-Deno.test("payment_failed → 취소 → 삭제", TEST_OPTS, async () => {
+Deno.test("payment_failed → 취소 → 삭제", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -196,7 +195,7 @@ Deno.test("payment_failed → 취소 → 삭제", TEST_OPTS, async () => {
 
 // ===== Free event cancellation =====
 
-Deno.test("무료 이벤트 (payment_amount = 0) → 취소 → status = 'cancelled'", TEST_OPTS, async () => {
+Deno.test("무료 이벤트 (payment_amount = 0) → 취소 → status = 'cancelled'", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock, calls } = createFetchMock([
@@ -226,7 +225,7 @@ Deno.test("무료 이벤트 (payment_amount = 0) → 취소 → status = 'cancel
   });
 });
 
-Deno.test("무료 이벤트 (payment_amount = null) → 취소", TEST_OPTS, async () => {
+Deno.test("무료 이벤트 (payment_amount = null) → 취소", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -249,7 +248,7 @@ Deno.test("무료 이벤트 (payment_amount = null) → 취소", TEST_OPTS, asyn
   });
 });
 
-Deno.test("이미 cancelled → 400", TEST_OPTS, async () => {
+Deno.test("이미 cancelled → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -273,7 +272,7 @@ Deno.test("이미 cancelled → 400", TEST_OPTS, async () => {
 
 // ===== Paid event refund tests =====
 
-Deno.test("paid → grace period 내 → 환불 성공 + refund_status = 'completed'", TEST_OPTS, async () => {
+Deno.test("paid → grace period 내 → 환불 성공 + refund_status = 'completed'", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock, calls } = createFetchMock([
@@ -309,7 +308,7 @@ Deno.test("paid → grace period 내 → 환불 성공 + refund_status = 'comple
   });
 });
 
-Deno.test("paid → grace period 초과 + cutoff 내 → 환불 성공", TEST_OPTS, async () => {
+Deno.test("paid → grace period 초과 + cutoff 내 → 환불 성공", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -337,7 +336,7 @@ Deno.test("paid → grace period 초과 + cutoff 내 → 환불 성공", TEST_OP
   });
 });
 
-Deno.test("paid → grace period 초과 + cutoff 초과 → 400 (refund_not_eligible)", TEST_OPTS, async () => {
+Deno.test("paid → grace period 초과 + cutoff 초과 → 400 (refund_not_eligible)", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -361,7 +360,7 @@ Deno.test("paid → grace period 초과 + cutoff 초과 → 400 (refund_not_elig
   });
 });
 
-Deno.test("이미 환불됨 (refund_status != 'none') → 400 (already_refunded)", TEST_OPTS, async () => {
+Deno.test("이미 환불됨 (refund_status != 'none') → 400 (already_refunded)", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -383,7 +382,7 @@ Deno.test("이미 환불됨 (refund_status != 'none') → 400 (already_refunded)
   });
 });
 
-Deno.test("pending_review → 환불 정상 처리", TEST_OPTS, async () => {
+Deno.test("pending_review → 환불 정상 처리", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -410,7 +409,7 @@ Deno.test("pending_review → 환불 정상 처리", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("approved → 환불 정상 처리", TEST_OPTS, async () => {
+Deno.test("approved → 환불 정상 처리", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -437,7 +436,7 @@ Deno.test("approved → 환불 정상 처리", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("reason 포함 → 정상 처리", TEST_OPTS, async () => {
+Deno.test("reason 포함 → 정상 처리", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock, calls } = createFetchMock([
@@ -472,7 +471,7 @@ Deno.test("reason 포함 → 정상 처리", TEST_OPTS, async () => {
 
 // ===== Auth & Edge cases =====
 
-Deno.test("존재하지 않는 event_id → 404", TEST_OPTS, async () => {
+Deno.test("존재하지 않는 event_id → 404", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -494,7 +493,7 @@ Deno.test("존재하지 않는 event_id → 404", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("인증 없이 → 401", TEST_OPTS, async () => {
+Deno.test("인증 없이 → 401", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -516,7 +515,7 @@ Deno.test("인증 없이 → 401", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("rejected 상태 → 400", TEST_OPTS, async () => {
+Deno.test("rejected 상태 → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -538,7 +537,7 @@ Deno.test("rejected 상태 → 400", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("신청 없는 event_id → 404", TEST_OPTS, async () => {
+Deno.test("신청 없는 event_id → 404", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -560,7 +559,7 @@ Deno.test("신청 없는 event_id → 404", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("missing event_id → 400", TEST_OPTS, async () => {
+Deno.test("missing event_id → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
   const { fetchMock } = createFetchMock([authRoute]);
 
@@ -578,7 +577,7 @@ Deno.test("missing event_id → 400", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("malformed JSON → 400", TEST_OPTS, async () => {
+Deno.test("malformed JSON → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
   const { fetchMock } = createFetchMock([authRoute]);
 
@@ -598,7 +597,7 @@ Deno.test("malformed JSON → 400", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("token failure → 502", TEST_OPTS, async () => {
+Deno.test("token failure → 502", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -626,7 +625,7 @@ Deno.test("token failure → 502", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("DB error is non-fatal for refund → 200", TEST_OPTS, async () => {
+Deno.test("DB error is non-fatal for refund → 200", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([

--- a/supabase/functions/user-cast-vote/user_cast_vote_test.ts
+++ b/supabase/functions/user-cast-vote/user_cast_vote_test.ts
@@ -142,8 +142,6 @@ function happyPathRoutes(): FetchRoute[] {
 // ─── CORS preflight ───
 Deno.test({
   name: "handles OPTIONS preflight request",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([]);
@@ -162,8 +160,6 @@ Deno.test({
 // ─── 401: no auth ───
 Deno.test({
   name: "returns 401 without authorization",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -190,8 +186,6 @@ Deno.test({
 // ─── 400: missing event_id ───
 Deno.test({
   name: "returns 400 for missing event_id",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -212,8 +206,6 @@ Deno.test({
 // ─── 400: missing candidate_id ───
 Deno.test({
   name: "returns 400 for missing candidate_id",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -234,8 +226,6 @@ Deno.test({
 // ─── 400: self vote ───
 Deno.test({
   name: "returns 400 for self-vote",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -259,8 +249,6 @@ Deno.test({
 // ─── 404: event not found ───
 Deno.test({
   name: "returns 404 for non-existent event",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -290,8 +278,6 @@ Deno.test({
 // ─── 400: vote_start_at is null (voting not enabled) ───
 Deno.test({
   name: "returns 400 when vote_start_at is null",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -318,8 +304,6 @@ Deno.test({
 // ─── 400: vote not yet started ───
 Deno.test({
   name: "returns 400 when vote has not started yet",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -346,8 +330,6 @@ Deno.test({
 // ─── 400: vote deadline passed ───
 Deno.test({
   name: "returns 400 when vote deadline has passed",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -377,8 +359,6 @@ Deno.test({
 // ─── 400: end_time fallback when vote_end_at is null ───
 Deno.test({
   name: "returns 400 when vote_end_at is null but end_time has passed",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -409,8 +389,6 @@ Deno.test({
 // ─── 400: voter not participant ───
 Deno.test({
   name: "returns 400 when voter is not a participant",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -442,8 +420,6 @@ Deno.test({
 // ─── 400: voter not checked_in (ticket_issued) ───
 Deno.test({
   name: "returns 400 when voter status is ticket_issued",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -471,8 +447,6 @@ Deno.test({
 // ─── 400: voter is no_show ───
 Deno.test({
   name: "returns 400 when voter status is no_show",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -500,8 +474,6 @@ Deno.test({
 // ─── 400: candidate not checked_in ───
 Deno.test({
   name: "returns 400 when candidate is not checked_in",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -530,8 +502,6 @@ Deno.test({
 // ─── 400: empty group IDs (fail-closed) ───
 Deno.test({
   name: "returns 400 when voter has no group IDs",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -562,8 +532,6 @@ Deno.test({
 // ─── 400: match_rules에 없는 그룹간 투표 ───
 Deno.test({
   name: "returns 400 when groups are not in match_rules",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -595,8 +563,6 @@ Deno.test({
 // ─── 400: vote count exceeded (via RPC) ───
 Deno.test({
   name: "returns 400 when vote count is exceeded",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -629,8 +595,6 @@ Deno.test({
 // ─── 200: happy path — successful vote ───
 Deno.test({
   name: "returns 200 for successful vote",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock(happyPathRoutes());
@@ -654,8 +618,6 @@ Deno.test({
 // ─── 400: duplicate vote (via RPC) ───
 Deno.test({
   name: "returns 400 for duplicate vote",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([

--- a/supabase/functions/user-create-order/user_create_order_test.ts
+++ b/supabase/functions/user-create-order/user_create_order_test.ts
@@ -83,6 +83,7 @@ function rpcRoute(rpcName: string, response: unknown) {
 
 // ---------- Happy Path: Paid Event ----------
 
+// Fix #1292: sanitizer 복원 — captureServeHandler가 Deno.serve/setInterval을 스텁하므로 플래그 불필요
 Deno.test({ name: "user-create-order - happy path: paid event creates order", fn: async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));

--- a/supabase/functions/user-create-order/user_create_order_test.ts
+++ b/supabase/functions/user-create-order/user_create_order_test.ts
@@ -13,7 +13,6 @@ import {
 import { authRoute } from "../_test_utils/fixtures.ts";
 
 // Statsig uses node:timers setInterval internally, which withNoIntervals cannot patch.
-const TEST_OPTS = { sanitizeOps: false, sanitizeResources: false };
 
 const ENV = {
   SUPABASE_URL: "https://supabase.test",
@@ -84,7 +83,7 @@ function rpcRoute(rpcName: string, response: unknown) {
 
 // ---------- Happy Path: Paid Event ----------
 
-Deno.test({ name: "user-create-order - happy path: paid event creates order", ...TEST_OPTS, fn: async () => {
+Deno.test({ name: "user-create-order - happy path: paid event creates order", fn: async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -121,7 +120,7 @@ Deno.test({ name: "user-create-order - happy path: paid event creates order", ..
 
 // ---------- Happy Path: Free Event ----------
 
-Deno.test({ name: "user-create-order - happy path: free event creates order with requires_payment=false", ...TEST_OPTS, fn: async () => {
+Deno.test({ name: "user-create-order - happy path: free event creates order with requires_payment=false", fn: async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -156,7 +155,7 @@ Deno.test({ name: "user-create-order - happy path: free event creates order with
 
 // ---------- Auth Errors ----------
 
-Deno.test({ name: "user-create-order - unauthenticated request returns 401", ...TEST_OPTS, fn: async () => {
+Deno.test({ name: "user-create-order - unauthenticated request returns 401", fn: async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -182,7 +181,7 @@ Deno.test({ name: "user-create-order - unauthenticated request returns 401", ...
 
 // ---------- Input Validation ----------
 
-Deno.test({ name: "user-create-order - missing event_id returns 400", ...TEST_OPTS, fn: async () => {
+Deno.test({ name: "user-create-order - missing event_id returns 400", fn: async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute]);
@@ -202,7 +201,7 @@ Deno.test({ name: "user-create-order - missing event_id returns 400", ...TEST_OP
   });
 }});
 
-Deno.test({ name: "user-create-order - missing ticket_id returns 400", ...TEST_OPTS, fn: async () => {
+Deno.test({ name: "user-create-order - missing ticket_id returns 400", fn: async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute]);
@@ -222,7 +221,7 @@ Deno.test({ name: "user-create-order - missing ticket_id returns 400", ...TEST_O
   });
 }});
 
-Deno.test({ name: "user-create-order - malformed JSON returns 400", ...TEST_OPTS, fn: async () => {
+Deno.test({ name: "user-create-order - malformed JSON returns 400", fn: async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute]);
@@ -244,7 +243,7 @@ Deno.test({ name: "user-create-order - malformed JSON returns 400", ...TEST_OPTS
 
 // ---------- Event Validation ----------
 
-Deno.test({ name: "user-create-order - nonexistent event returns 404", ...TEST_OPTS, fn: async () => {
+Deno.test({ name: "user-create-order - nonexistent event returns 404", fn: async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -271,7 +270,7 @@ Deno.test({ name: "user-create-order - nonexistent event returns 404", ...TEST_O
   });
 }});
 
-Deno.test({ name: "user-create-order - cancelled event returns EVENT_CLOSED", ...TEST_OPTS, fn: async () => {
+Deno.test({ name: "user-create-order - cancelled event returns EVENT_CLOSED", fn: async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -297,7 +296,7 @@ Deno.test({ name: "user-create-order - cancelled event returns EVENT_CLOSED", ..
   });
 }});
 
-Deno.test({ name: "user-create-order - past event returns EVENT_NOT_SCHEDULED", ...TEST_OPTS, fn: async () => {
+Deno.test({ name: "user-create-order - past event returns EVENT_NOT_SCHEDULED", fn: async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -326,7 +325,7 @@ Deno.test({ name: "user-create-order - past event returns EVENT_NOT_SCHEDULED", 
 
 // ---------- Ticket Validation ----------
 
-Deno.test({ name: "user-create-order - ticket not belonging to event returns 404", ...TEST_OPTS, fn: async () => {
+Deno.test({ name: "user-create-order - ticket not belonging to event returns 404", fn: async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -351,7 +350,7 @@ Deno.test({ name: "user-create-order - ticket not belonging to event returns 404
   });
 }});
 
-Deno.test({ name: "user-create-order - sold out ticket returns TICKET_SOLD_OUT", ...TEST_OPTS, fn: async () => {
+Deno.test({ name: "user-create-order - sold out ticket returns TICKET_SOLD_OUT", fn: async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -378,7 +377,7 @@ Deno.test({ name: "user-create-order - sold out ticket returns TICKET_SOLD_OUT",
 
 // ---------- Capacity ----------
 
-Deno.test({ name: "user-create-order - full event returns EVENT_FULL", ...TEST_OPTS, fn: async () => {
+Deno.test({ name: "user-create-order - full event returns EVENT_FULL", fn: async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -405,7 +404,7 @@ Deno.test({ name: "user-create-order - full event returns EVENT_FULL", ...TEST_O
 
 // ---------- Identity Verification ----------
 
-Deno.test({ name: "user-create-order - unverified user returns IDENTITY_REQUIRED", ...TEST_OPTS, fn: async () => {
+Deno.test({ name: "user-create-order - unverified user returns IDENTITY_REQUIRED", fn: async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -433,7 +432,7 @@ Deno.test({ name: "user-create-order - unverified user returns IDENTITY_REQUIRED
 
 // ---------- Gender Mismatch ----------
 
-Deno.test({ name: "user-create-order - gender mismatch returns GENDER_MISMATCH", ...TEST_OPTS, fn: async () => {
+Deno.test({ name: "user-create-order - gender mismatch returns GENDER_MISMATCH", fn: async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -462,7 +461,7 @@ Deno.test({ name: "user-create-order - gender mismatch returns GENDER_MISMATCH",
 
 // ---------- Age Mismatch ----------
 
-Deno.test({ name: "user-create-order - age mismatch returns AGE_MISMATCH", ...TEST_OPTS, fn: async () => {
+Deno.test({ name: "user-create-order - age mismatch returns AGE_MISMATCH", fn: async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -491,7 +490,7 @@ Deno.test({ name: "user-create-order - age mismatch returns AGE_MISMATCH", ...TE
 
 // ---------- Balance Limit ----------
 
-Deno.test({ name: "user-create-order - balance limit returns BALANCE_LIMIT", ...TEST_OPTS, fn: async () => {
+Deno.test({ name: "user-create-order - balance limit returns BALANCE_LIMIT", fn: async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -521,7 +520,7 @@ Deno.test({ name: "user-create-order - balance limit returns BALANCE_LIMIT", ...
 
 // ---------- Duplicate Application ----------
 
-Deno.test({ name: "user-create-order - duplicate application returns ALREADY_APPLIED", ...TEST_OPTS, fn: async () => {
+Deno.test({ name: "user-create-order - duplicate application returns ALREADY_APPLIED", fn: async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -552,7 +551,7 @@ Deno.test({ name: "user-create-order - duplicate application returns ALREADY_APP
 
 // ---------- Verification Required ----------
 
-Deno.test({ name: "user-create-order - missing verification data returns VERIFICATION_REQUIRED", ...TEST_OPTS, fn: async () => {
+Deno.test({ name: "user-create-order - missing verification data returns VERIFICATION_REQUIRED", fn: async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([

--- a/supabase/functions/user-delete-account/user_delete_account_test.ts
+++ b/supabase/functions/user-delete-account/user_delete_account_test.ts
@@ -75,6 +75,7 @@ const deleteFcmTokensRoute = {
   handler: () => jsonResponse({}),
 };
 
+// Fix #1292: sanitizer 복원 — captureServeHandler가 Deno.serve/setInterval을 스텁하므로 플래그 불필요
 Deno.test("unauthorized request returns 401", async () => {
   const handler = await captureServeHandler(
     new URL("./index.ts", import.meta.url),

--- a/supabase/functions/user-delete-account/user_delete_account_test.ts
+++ b/supabase/functions/user-delete-account/user_delete_account_test.ts
@@ -12,7 +12,6 @@ import {
 } from "../_test_utils/mock_http.ts";
 import { authRoute } from "../_test_utils/fixtures.ts";
 
-const TEST_OPTS = { sanitizeOps: false, sanitizeResources: false };
 
 const ENV = {
   SUPABASE_URL: "https://supabase.test",
@@ -76,7 +75,7 @@ const deleteFcmTokensRoute = {
   handler: () => jsonResponse({}),
 };
 
-Deno.test("unauthorized request returns 401", TEST_OPTS, async () => {
+Deno.test("unauthorized request returns 401", async () => {
   const handler = await captureServeHandler(
     new URL("./index.ts", import.meta.url),
   );
@@ -101,7 +100,6 @@ Deno.test("unauthorized request returns 401", TEST_OPTS, async () => {
 
 Deno.test(
   "successful deletion sets deleted_at, stores anonymous reason, and removes FCM tokens",
-  TEST_OPTS,
   async () => {
     const handler = await captureServeHandler(
       new URL("./index.ts", import.meta.url),
@@ -163,7 +161,7 @@ Deno.test(
   },
 );
 
-Deno.test("active future booking blocks deletion", TEST_OPTS, async () => {
+Deno.test("active future booking blocks deletion", async () => {
   const handler = await captureServeHandler(
     new URL("./index.ts", import.meta.url),
   );
@@ -200,9 +198,7 @@ Deno.test("active future booking blocks deletion", TEST_OPTS, async () => {
 });
 
 Deno.test(
-  "pending refund blocks deletion as unsettled balance",
-  TEST_OPTS,
-  async () => {
+  "pending refund blocks deletion as unsettled balance", async () => {
     const handler = await captureServeHandler(
       new URL("./index.ts", import.meta.url),
     );
@@ -239,7 +235,7 @@ Deno.test(
   },
 );
 
-Deno.test("already deleted user returns 409", TEST_OPTS, async () => {
+Deno.test("already deleted user returns 409", async () => {
   const handler = await captureServeHandler(
     new URL("./index.ts", import.meta.url),
   );
@@ -265,9 +261,7 @@ Deno.test("already deleted user returns 409", TEST_OPTS, async () => {
 });
 
 Deno.test(
-  "reason_text without reason_code falls back to other",
-  TEST_OPTS,
-  async () => {
+  "reason_text without reason_code falls back to other", async () => {
     const handler = await captureServeHandler(
       new URL("./index.ts", import.meta.url),
     );

--- a/supabase/functions/user-event-feed/user_event_feed_test.ts
+++ b/supabase/functions/user-event-feed/user_event_feed_test.ts
@@ -49,8 +49,6 @@ function createFeedFetchMock(rpcResult: unknown, authUser?: { id: string } | nul
 
 Deno.test({
   name: "user-event-feed - valid request with recommended sort returns 200",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -85,8 +83,6 @@ Deno.test({
 
 Deno.test({
   name: "user-event-feed - anonymous request returns 200 with basic feed",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -116,8 +112,6 @@ Deno.test({
 
 Deno.test({
   name: "user-event-feed - invalid sort_by returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -135,8 +129,6 @@ Deno.test({
 
 Deno.test({
   name: "user-event-feed - invalid cursor returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -157,8 +149,6 @@ Deno.test({
 
 Deno.test({
   name: "user-event-feed - pagination with cursor returns next page",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -197,8 +187,6 @@ Deno.test({
 
 Deno.test({
   name: "user-event-feed - OPTIONS returns CORS response",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -209,8 +197,6 @@ Deno.test({
 
 Deno.test({
   name: "user-event-feed - GET method returns 405",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 

--- a/supabase/functions/user-get-ticket-token/user_get_ticket_token_test.ts
+++ b/supabase/functions/user-get-ticket-token/user_get_ticket_token_test.ts
@@ -30,8 +30,6 @@ const BASE_URL = "http://localhost";
 
 Deno.test({
   name: "user-get-ticket-token - returns 200 with valid token",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -75,8 +73,6 @@ Deno.test({
 
 Deno.test({
   name: "user-get-ticket-token - returns 400 when ticket_id is missing",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -103,8 +99,6 @@ Deno.test({
 
 Deno.test({
   name: "user-get-ticket-token - returns 404 when application not found",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -136,8 +130,6 @@ Deno.test({
 
 Deno.test({
   name: "user-get-ticket-token - returns 500 when signing key not configured",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -175,8 +167,6 @@ Deno.test({
 
 Deno.test({
   name: "user-get-ticket-token - returns 401 without auth token",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -199,8 +189,6 @@ Deno.test({
 
 Deno.test({
   name: "user-get-ticket-token - OPTIONS returns CORS response",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 

--- a/supabase/functions/user-manage-notification/user_manage_notification_test.ts
+++ b/supabase/functions/user-manage-notification/user_manage_notification_test.ts
@@ -27,8 +27,6 @@ function mockGetUser() {
 
 Deno.test({
   name: "user-manage-notification - mark_read success",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     await withEnv(ENV, async () => {
       const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
@@ -61,8 +59,6 @@ Deno.test({
 
 Deno.test({
   name: "user-manage-notification - mark_read not found returns 404",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     await withEnv(ENV, async () => {
       const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
@@ -95,8 +91,6 @@ Deno.test({
 
 Deno.test({
   name: "user-manage-notification - mark_read missing notification_id returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     await withEnv(ENV, async () => {
       const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
@@ -122,8 +116,6 @@ Deno.test({
 
 Deno.test({
   name: "user-manage-notification - mark_all_read success",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     await withEnv(ENV, async () => {
       const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
@@ -157,8 +149,6 @@ Deno.test({
 
 Deno.test({
   name: "user-manage-notification - mark_all_read nothing to read returns count 0",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     await withEnv(ENV, async () => {
       const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
@@ -192,8 +182,6 @@ Deno.test({
 
 Deno.test({
   name: "user-manage-notification - delete success",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     await withEnv(ENV, async () => {
       const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
@@ -226,8 +214,6 @@ Deno.test({
 
 Deno.test({
   name: "user-manage-notification - delete not found returns 404",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     await withEnv(ENV, async () => {
       const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
@@ -260,8 +246,6 @@ Deno.test({
 
 Deno.test({
   name: "user-manage-notification - no auth returns 401",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     await withEnv(ENV, async () => {
       const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
@@ -286,8 +270,6 @@ Deno.test({
 
 Deno.test({
   name: "user-manage-notification - unknown action returns 400",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     await withEnv(ENV, async () => {
       const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
@@ -313,8 +295,6 @@ Deno.test({
 
 Deno.test({
   name: "user-manage-notification - OPTIONS returns CORS response",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     await withEnv(ENV, async () => {
       const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));

--- a/supabase/functions/user-manage-settings/user_manage_settings_test.ts
+++ b/supabase/functions/user-manage-settings/user_manage_settings_test.ts
@@ -12,7 +12,6 @@ import {
 } from "../_test_utils/mock_http.ts";
 import { authRoute } from "../_test_utils/fixtures.ts";
 
-const TEST_OPTS = { sanitizeOps: false, sanitizeResources: false };
 
 const ENV = {
   SUPABASE_URL: "https://supabase.test",
@@ -50,7 +49,7 @@ function dbUpsertSettingsRoute(overrides?: Record<string, unknown>) {
 
 // ===== upsert_token tests =====
 
-Deno.test("upsert_token — 정상 등록", TEST_OPTS, async () => {
+Deno.test("upsert_token — 정상 등록", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock, calls } = createFetchMock([
@@ -85,7 +84,7 @@ Deno.test("upsert_token — 정상 등록", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("upsert_token — 같은 토큰 재등록 → last_updated_at 갱신", TEST_OPTS, async () => {
+Deno.test("upsert_token — 같은 토큰 재등록 → last_updated_at 갱신", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock, calls } = createFetchMock([
@@ -117,7 +116,7 @@ Deno.test("upsert_token — 같은 토큰 재등록 → last_updated_at 갱신",
   });
 });
 
-Deno.test("upsert_token — token 누락 → 400", TEST_OPTS, async () => {
+Deno.test("upsert_token — token 누락 → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([authRoute]);
@@ -139,7 +138,7 @@ Deno.test("upsert_token — token 누락 → 400", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("upsert_token — 잘못된 device_type → 400", TEST_OPTS, async () => {
+Deno.test("upsert_token — 잘못된 device_type → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([authRoute]);
@@ -167,7 +166,7 @@ Deno.test("upsert_token — 잘못된 device_type → 400", TEST_OPTS, async () 
 
 // ===== delete_token tests =====
 
-Deno.test("delete_token — 정상 삭제", TEST_OPTS, async () => {
+Deno.test("delete_token — 정상 삭제", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock, calls } = createFetchMock([
@@ -197,7 +196,7 @@ Deno.test("delete_token — 정상 삭제", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("delete_token — 존재하지 않는 토큰 → 에러 없이 성공", TEST_OPTS, async () => {
+Deno.test("delete_token — 존재하지 않는 토큰 → 에러 없이 성공", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -222,7 +221,7 @@ Deno.test("delete_token — 존재하지 않는 토큰 → 에러 없이 성공"
   });
 });
 
-Deno.test("delete_token — token 누락 → 400", TEST_OPTS, async () => {
+Deno.test("delete_token — token 누락 → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([authRoute]);
@@ -245,7 +244,7 @@ Deno.test("delete_token — token 누락 → 400", TEST_OPTS, async () => {
 
 // ===== update_settings tests =====
 
-Deno.test("update_settings — marketing_consent 변경 → DB 반영", TEST_OPTS, async () => {
+Deno.test("update_settings — marketing_consent 변경 → DB 반영", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock, calls } = createFetchMock([
@@ -278,7 +277,7 @@ Deno.test("update_settings — marketing_consent 변경 → DB 반영", TEST_OPT
   });
 });
 
-Deno.test("update_settings — service_notification 변경", TEST_OPTS, async () => {
+Deno.test("update_settings — service_notification 변경", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -304,7 +303,7 @@ Deno.test("update_settings — service_notification 변경", TEST_OPTS, async ()
   });
 });
 
-Deno.test("update_settings — 허용되지 않은 필드만 → 400", TEST_OPTS, async () => {
+Deno.test("update_settings — 허용되지 않은 필드만 → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([authRoute]);
@@ -329,7 +328,7 @@ Deno.test("update_settings — 허용되지 않은 필드만 → 400", TEST_OPTS
   });
 });
 
-Deno.test("update_settings — boolean이 아닌 값 → 400", TEST_OPTS, async () => {
+Deno.test("update_settings — boolean이 아닌 값 → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([authRoute]);
@@ -351,7 +350,7 @@ Deno.test("update_settings — boolean이 아닌 값 → 400", TEST_OPTS, async 
   });
 });
 
-Deno.test("update_settings — settings 누락 → 400", TEST_OPTS, async () => {
+Deno.test("update_settings — settings 누락 → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([authRoute]);
@@ -374,7 +373,7 @@ Deno.test("update_settings — settings 누락 → 400", TEST_OPTS, async () => 
 
 // ===== Auth & Edge cases =====
 
-Deno.test("인증 없이 호출 → 401", TEST_OPTS, async () => {
+Deno.test("인증 없이 호출 → 401", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -400,7 +399,7 @@ Deno.test("인증 없이 호출 → 401", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("잘못된 action → 400", TEST_OPTS, async () => {
+Deno.test("잘못된 action → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([authRoute]);
@@ -421,7 +420,7 @@ Deno.test("잘못된 action → 400", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("action 누락 → 400", TEST_OPTS, async () => {
+Deno.test("action 누락 → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([authRoute]);
@@ -442,7 +441,7 @@ Deno.test("action 누락 → 400", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("malformed JSON → 400", TEST_OPTS, async () => {
+Deno.test("malformed JSON → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([authRoute]);

--- a/supabase/functions/user-manage-social/user_manage_social_test.ts
+++ b/supabase/functions/user-manage-social/user_manage_social_test.ts
@@ -30,8 +30,6 @@ function authRoute() {
 
 Deno.test({
   name: "toggle like - adds interaction when not exists",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -63,8 +61,6 @@ Deno.test({
 
 Deno.test({
   name: "toggle - returns 400 for invalid interaction_type",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -85,8 +81,6 @@ Deno.test({
 
 Deno.test({
   name: "toggle - returns 400 for invalid target_type",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -107,8 +101,6 @@ Deno.test({
 
 Deno.test({
   name: "toggle - returns 400 for missing fields",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -132,8 +124,6 @@ Deno.test({
 
 Deno.test({
   name: "block - succeeds",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -157,8 +147,6 @@ Deno.test({
 
 Deno.test({
   name: "block - returns 400 when blocking self",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -177,8 +165,6 @@ Deno.test({
 
 Deno.test({
   name: "unblock - succeeds",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -206,8 +192,6 @@ Deno.test({
 
 Deno.test({
   name: "report - succeeds with block + report + details",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -238,8 +222,6 @@ Deno.test({
 
 Deno.test({
   name: "report - returns 400 for invalid reason",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -259,8 +241,6 @@ Deno.test({
 
 Deno.test({
   name: "report - returns 400 when reporting self",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -284,8 +264,6 @@ Deno.test({
 
 Deno.test({
   name: "returns 401 without auth",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
@@ -307,8 +285,6 @@ Deno.test({
 
 Deno.test({
   name: "returns 400 for unknown action",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
@@ -326,8 +302,6 @@ Deno.test({
 
 Deno.test({
   name: "returns CORS headers for OPTIONS",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const res = await handler(new Request("http://localhost", { method: "OPTIONS" }));

--- a/supabase/functions/user-submit-verification/user_submit_verification_test.ts
+++ b/supabase/functions/user-submit-verification/user_submit_verification_test.ts
@@ -50,6 +50,7 @@ const dbUpdateSubmissionRoute = {
 
 // ===== submit action =====
 
+// Fix #1292: sanitizer 복원 — captureServeHandler가 Deno.serve/setInterval을 스텁하므로 플래그 불필요
 Deno.test("submit — 첫 제출 → submission 생성, snapshot_data 배열 1개 항목", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 

--- a/supabase/functions/user-submit-verification/user_submit_verification_test.ts
+++ b/supabase/functions/user-submit-verification/user_submit_verification_test.ts
@@ -12,7 +12,6 @@ import {
 } from "../_test_utils/mock_http.ts";
 import { authRoute } from "../_test_utils/fixtures.ts";
 
-const TEST_OPTS = { sanitizeOps: false, sanitizeResources: false };
 
 const ENV = {
   SUPABASE_URL: "https://supabase.test",
@@ -51,7 +50,7 @@ const dbUpdateSubmissionRoute = {
 
 // ===== submit action =====
 
-Deno.test("submit — 첫 제출 → submission 생성, snapshot_data 배열 1개 항목", TEST_OPTS, async () => {
+Deno.test("submit — 첫 제출 → submission 생성, snapshot_data 배열 1개 항목", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock, calls } = createFetchMock([
@@ -94,7 +93,7 @@ Deno.test("submit — 첫 제출 → submission 생성, snapshot_data 배열 1�
   });
 });
 
-Deno.test("submit — 재제출 → snapshot_data 배열에 append, status = 'pending'", TEST_OPTS, async () => {
+Deno.test("submit — 재제출 → snapshot_data 배열에 append, status = 'pending'", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const existingSnapshot = [
@@ -145,7 +144,7 @@ Deno.test("submit — 재제출 → snapshot_data 배열에 append, status = 'pe
   });
 });
 
-Deno.test("submit — user_verifications에 데이터 없이 제출 → 400", TEST_OPTS, async () => {
+Deno.test("submit — user_verifications에 데이터 없이 제출 → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -171,7 +170,7 @@ Deno.test("submit — user_verifications에 데이터 없이 제출 → 400", TE
   });
 });
 
-Deno.test("submit — partner_id 누락 → 400", TEST_OPTS, async () => {
+Deno.test("submit — partner_id 누락 → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([authRoute]);
@@ -193,7 +192,7 @@ Deno.test("submit — partner_id 누락 → 400", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("submit — verification_id 누락 → 400", TEST_OPTS, async () => {
+Deno.test("submit — verification_id 누락 → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([authRoute]);
@@ -215,7 +214,7 @@ Deno.test("submit — verification_id 누락 → 400", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("submit — 인증 없이 → 401", TEST_OPTS, async () => {
+Deno.test("submit — 인증 없이 → 401", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -243,7 +242,7 @@ Deno.test("submit — 인증 없이 → 401", TEST_OPTS, async () => {
 
 // ===== comment action =====
 
-Deno.test("comment — 코멘트 추가 → 마지막 항목 comments 배열에 append", TEST_OPTS, async () => {
+Deno.test("comment — 코멘트 추가 → 마지막 항목 comments 배열에 append", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const existingSubmission = {
@@ -301,7 +300,7 @@ Deno.test("comment — 코멘트 추가 → 마지막 항목 comments 배열에 
   });
 });
 
-Deno.test("comment — 다른 유저 submission에 코멘트 → 403", TEST_OPTS, async () => {
+Deno.test("comment — 다른 유저 submission에 코멘트 → 403", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const otherUserSubmission = {
@@ -337,7 +336,7 @@ Deno.test("comment — 다른 유저 submission에 코멘트 → 403", TEST_OPTS
   });
 });
 
-Deno.test("comment — 존재하지 않는 submission → 404", TEST_OPTS, async () => {
+Deno.test("comment — 존재하지 않는 submission → 404", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -367,7 +366,7 @@ Deno.test("comment — 존재하지 않는 submission → 404", TEST_OPTS, async
   });
 });
 
-Deno.test("comment — submission_id 누락 → 400", TEST_OPTS, async () => {
+Deno.test("comment — submission_id 누락 → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([authRoute]);
@@ -389,7 +388,7 @@ Deno.test("comment — submission_id 누락 → 400", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("comment — text 누락 → 400", TEST_OPTS, async () => {
+Deno.test("comment — text 누락 → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([authRoute]);
@@ -413,7 +412,7 @@ Deno.test("comment — text 누락 → 400", TEST_OPTS, async () => {
 
 // ===== Common edge cases =====
 
-Deno.test("action 누락 → 400", TEST_OPTS, async () => {
+Deno.test("action 누락 → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([authRoute]);
@@ -434,7 +433,7 @@ Deno.test("action 누락 → 400", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("잘못된 action → 400", TEST_OPTS, async () => {
+Deno.test("잘못된 action → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([authRoute]);
@@ -455,7 +454,7 @@ Deno.test("잘못된 action → 400", TEST_OPTS, async () => {
   });
 });
 
-Deno.test("malformed JSON → 400", TEST_OPTS, async () => {
+Deno.test("malformed JSON → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([authRoute]);

--- a/supabase/functions/user-update-verification/user_update_verification_test.ts
+++ b/supabase/functions/user-update-verification/user_update_verification_test.ts
@@ -12,7 +12,6 @@ import {
 } from "../_test_utils/mock_http.ts";
 import { authRoute } from "../_test_utils/fixtures.ts";
 
-const TEST_OPTS = { sanitizeOps: false, sanitizeResources: false };
 
 const ENV = {
   SUPABASE_URL: "https://supabase.test",
@@ -47,7 +46,7 @@ const dbUpsertErrorRoute = {
 
 // ===== 정상 저장 =====
 
-Deno.test("신규 저장 → user_verifications UPSERT 확인", TEST_OPTS, async () => {
+Deno.test("신규 저장 → user_verifications UPSERT 확인", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock, calls } = createFetchMock([
@@ -82,7 +81,7 @@ Deno.test("신규 저장 → user_verifications UPSERT 확인", TEST_OPTS, async
   });
 });
 
-Deno.test("기존 업데이트 → data 갱신 확인", TEST_OPTS, async () => {
+Deno.test("기존 업데이트 → data 갱신 확인", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock, calls } = createFetchMock([
@@ -117,7 +116,7 @@ Deno.test("기존 업데이트 → data 갱신 확인", TEST_OPTS, async () => {
 
 // ===== 인증 없이 → 401 =====
 
-Deno.test("인증 없이 → 401", TEST_OPTS, async () => {
+Deno.test("인증 없이 → 401", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -144,7 +143,7 @@ Deno.test("인증 없이 → 401", TEST_OPTS, async () => {
 
 // ===== verification_id 누락 → 400 =====
 
-Deno.test("verification_id 누락 → 400", TEST_OPTS, async () => {
+Deno.test("verification_id 누락 → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([authRoute]);
@@ -167,7 +166,7 @@ Deno.test("verification_id 누락 → 400", TEST_OPTS, async () => {
 
 // ===== data 누락 → 400 =====
 
-Deno.test("data 누락 → 400", TEST_OPTS, async () => {
+Deno.test("data 누락 → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([authRoute]);
@@ -190,7 +189,7 @@ Deno.test("data 누락 → 400", TEST_OPTS, async () => {
 
 // ===== 존재하지 않는 verification → 404 =====
 
-Deno.test("존재하지 않는 verification → 404", TEST_OPTS, async () => {
+Deno.test("존재하지 않는 verification → 404", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([
@@ -217,7 +216,7 @@ Deno.test("존재하지 않는 verification → 404", TEST_OPTS, async () => {
 
 // ===== malformed JSON → 400 =====
 
-Deno.test("malformed JSON → 400", TEST_OPTS, async () => {
+Deno.test("malformed JSON → 400", async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const { fetchMock } = createFetchMock([authRoute]);

--- a/supabase/functions/vector-worker/vector_worker_test.ts
+++ b/supabase/functions/vector-worker/vector_worker_test.ts
@@ -20,8 +20,6 @@ function embedding(value: number, size = 3) {
 
 Deno.test({
   name: "vector-worker - processes party message",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -79,8 +77,6 @@ Deno.test({
 
 Deno.test({
   name: "vector-worker - processes interaction message",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -146,8 +142,6 @@ Deno.test({
 
 Deno.test({
   name: "vector-worker - empty queue returns processed 0",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -197,8 +191,6 @@ Deno.test({
 
 Deno.test({
   name: "vector-worker - missing env returns 500",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
   const { fetchMock } = createFetchMock([]);
@@ -226,8 +218,6 @@ Deno.test({
 
 Deno.test({
   name: "vector-worker - openai error returns processed 0",
-  sanitizeResources: false,
-  sanitizeOps: false,
   fn: async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

## Summary

- `sim_auth.ts`의 `createClient()` 호출에 `autoRefreshToken: false` 추가 — supabase-js 토큰 갱신 interval 누수 근본 원인 수정
- 43개 테스트 파일에서 `sanitizeResources: false`, `sanitizeOps: false` 전체 제거 (935줄 삭제)
- `captureServeHandler` 인프라가 이미 `Deno.serve` + `setInterval` 스텁으로 리소스 누수를 방지하고 있음

## Root cause

`getSimUserToken/getSimPartnerToken`에서 `createClient()` 호출 시 supabase-js가 `signInWithPassword` 후 토큰 갱신용 `setInterval`을 등록. 이 interval이 테스트 스코프를 벗어나 `sanitizeOps` 감지에 걸렸음. `autoRefreshToken: false`로 해결.

## Test plan

- [ ] `test-edge-functions` CI 통과 — 모든 sanitizer 활성 상태에서 테스트 통과
- [ ] `grep -rn "sanitizeResources: false" supabase/functions/` → 0건

Closes #1292