### PR TITLE
test(app_user): DateTime.now() 의존 테스트 고정 시간 교체

### DIFF
--- a/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.dart
+++ b/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.dart
@@ -30,6 +30,12 @@ enum EventNowBarState {
   ended,
 }
 
+/// Returns the current [DateTime] used for time-state computations.
+///
+/// Override in tests with a fixed time to make state transitions deterministic.
+@riverpod
+DateTime clock(Ref ref) => DateTime.now();
+
 /// Fetches today's active events for the current user.
 ///
 /// Returns events where the user is a participant and the event is within
@@ -108,7 +114,7 @@ class EventNowBarStateNotifier extends _$EventNowBarStateNotifier {
     }
 
     // CHECK_IN_READY: event start time has been reached.
-    final now = DateTime.now();
+    final now = ref.watch(clockProvider);
     if (!now.isBefore(event.startTime)) {
       return EventNowBarState.checkInReady;
     }

--- a/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.dart
+++ b/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.dart
@@ -36,7 +36,7 @@ enum EventNowBarState {
 /// timestamp instead of a cached value. Override in tests with
 /// `() => fixedNow` to make state transitions deterministic.
 @riverpod
-DateTime Function() clock(Ref ref) => () => DateTime.now();
+DateTime Function() clock(Ref ref) => DateTime.now;
 
 /// Fetches today's active events for the current user.
 ///

--- a/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.dart
+++ b/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.dart
@@ -67,8 +67,17 @@ class EventNowBarStateNotifier extends _$EventNowBarStateNotifier {
   FutureOr<EventNowBarState> build(TodayActiveEvent activeEvent) async {
     final event = activeEvent.event;
 
+    // Fix #1321: Read clock BEFORE any async gaps — ref.watch/read throws
+    // "Ref disposed" if called after an await when myMatchesProvider or
+    // matchCandidatesProvider resolution triggers a rebuild of this provider.
+    final now = ref.watch(clockProvider)();
+
     // Compute the raw state from current data.
-    final rawState = await _computeState(event, activeEvent.participantStatus);
+    final rawState = await _computeState(
+      event,
+      activeEvent.participantStatus,
+      now,
+    );
 
     // Enforce forward-only transitions.
     if (rawState.index > _highWaterMark.index) {
@@ -81,6 +90,7 @@ class EventNowBarStateNotifier extends _$EventNowBarStateNotifier {
   Future<EventNowBarState> _computeState(
     Event event,
     String participantStatus,
+    DateTime now,
   ) async {
     // ENDED: event is completed or cancelled.
     if (event.status == 'completed' || event.status == 'cancelled') {
@@ -116,7 +126,8 @@ class EventNowBarStateNotifier extends _$EventNowBarStateNotifier {
     }
 
     // CHECK_IN_READY: event start time has been reached.
-    final now = ref.watch(clockProvider)();
+    // Note: `now` is captured in build() before any awaits to avoid
+    // using ref after async gaps (see Fix #1321 comment in build()).
     if (!now.isBefore(event.startTime)) {
       return EventNowBarState.checkInReady;
     }

--- a/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.dart
+++ b/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.dart
@@ -30,11 +30,13 @@ enum EventNowBarState {
   ended,
 }
 
-/// Returns the current [DateTime] used for time-state computations.
+/// Returns a clock function that produces the current [DateTime].
 ///
-/// Override in tests with a fixed time to make state transitions deterministic.
+/// The provider returns `() => DateTime.now()` so each call site gets a fresh
+/// timestamp instead of a cached value. Override in tests with
+/// `() => fixedNow` to make state transitions deterministic.
 @riverpod
-DateTime clock(Ref ref) => DateTime.now();
+DateTime Function() clock(Ref ref) => () => DateTime.now();
 
 /// Fetches today's active events for the current user.
 ///
@@ -114,7 +116,7 @@ class EventNowBarStateNotifier extends _$EventNowBarStateNotifier {
     }
 
     // CHECK_IN_READY: event start time has been reached.
-    final now = ref.watch(clockProvider);
+    final now = ref.watch(clockProvider)();
     if (!now.isBefore(event.startTime)) {
       return EventNowBarState.checkInReady;
     }

--- a/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.g.dart
+++ b/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.g.dart
@@ -24,8 +24,12 @@ const clockProvider = ClockProvider._();
 /// `() => fixedNow` to make state transitions deterministic.
 
 final class ClockProvider
-    extends $FunctionalProvider<DateTime Function(), DateTime Function(),
-        DateTime Function()>
+    extends
+        $FunctionalProvider<
+          DateTime Function(),
+          DateTime Function(),
+          DateTime Function()
+        >
     with $Provider<DateTime Function()> {
   const ClockProvider._()
     : super(

--- a/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.g.dart
+++ b/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.g.dart
@@ -8,20 +8,25 @@ part of 'event_now_bar_controller.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
-/// Returns the current [DateTime] used for time-state computations.
+/// Returns a clock function that produces the current [DateTime].
 ///
-/// Override in tests with a fixed time to make state transitions deterministic.
+/// The provider returns `() => DateTime.now()` so each call site gets a fresh
+/// timestamp instead of a cached value. Override in tests with
+/// `() => fixedNow` to make state transitions deterministic.
 
 @ProviderFor(clock)
 const clockProvider = ClockProvider._();
 
-/// Returns the current [DateTime] used for time-state computations.
+/// Returns a clock function that produces the current [DateTime].
 ///
-/// Override in tests with a fixed time to make state transitions deterministic.
+/// The provider returns `() => DateTime.now()` so each call site gets a fresh
+/// timestamp instead of a cached value. Override in tests with
+/// `() => fixedNow` to make state transitions deterministic.
 
 final class ClockProvider
-    extends $FunctionalProvider<DateTime, DateTime, DateTime>
-    with $Provider<DateTime> {
+    extends $FunctionalProvider<DateTime Function(), DateTime Function(),
+        DateTime Function()>
+    with $Provider<DateTime Function()> {
   const ClockProvider._()
     : super(
         from: null,
@@ -38,19 +43,20 @@ final class ClockProvider
 
   @$internal
   @override
-  $ProviderElement<DateTime> $createElement($ProviderPointer pointer) =>
-      $ProviderElement(pointer);
+  $ProviderElement<DateTime Function()> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
 
   @override
-  DateTime create(Ref ref) {
+  DateTime Function() create(Ref ref) {
     return clock(ref);
   }
 
   /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(DateTime value) {
+  Override overrideWithValue(DateTime Function() value) {
     return $ProviderOverride(
       origin: this,
-      providerOverride: $SyncValueProvider<DateTime>(value),
+      providerOverride: $SyncValueProvider<DateTime Function()>(value),
     );
   }
 }

--- a/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.g.dart
+++ b/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.g.dart
@@ -8,6 +8,55 @@ part of 'event_now_bar_controller.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
+/// Returns the current [DateTime] used for time-state computations.
+///
+/// Override in tests with a fixed time to make state transitions deterministic.
+
+@ProviderFor(clock)
+const clockProvider = ClockProvider._();
+
+/// Returns the current [DateTime] used for time-state computations.
+///
+/// Override in tests with a fixed time to make state transitions deterministic.
+
+final class ClockProvider
+    extends $FunctionalProvider<DateTime, DateTime, DateTime>
+    with $Provider<DateTime> {
+  const ClockProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'clockProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$clockHash();
+
+  @$internal
+  @override
+  $ProviderElement<DateTime> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  DateTime create(Ref ref) {
+    return clock(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(DateTime value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<DateTime>(value),
+    );
+  }
+}
+
+String _$clockHash() => r'clock_provider_fixed_time_injection';
+
 /// Fetches today's active events for the current user.
 ///
 /// Returns events where the user is a participant and the event is within

--- a/apps/app_user/test/integration/flow_my_page_test.dart
+++ b/apps/app_user/test/integration/flow_my_page_test.dart
@@ -15,7 +15,7 @@ import 'utils/test_app.dart';
 import 'utils/test_mocks.dart';
 
 // Fix #1321: DateTime.now() → 고정 시간으로 교체 (flaky test 방지)
-final _fixedNow = DateTime(2026, 4, 13, 12, 0, 0);
+final _fixedNow = DateTime(2026, 4, 13, 12);
 
 void main() {
   setUpAll(() async {

--- a/apps/app_user/test/integration/flow_my_page_test.dart
+++ b/apps/app_user/test/integration/flow_my_page_test.dart
@@ -14,6 +14,9 @@ import 'package:minglit_kit/minglit_kit.dart';
 import 'utils/test_app.dart';
 import 'utils/test_mocks.dart';
 
+// Fix #1321: DateTime.now() → 고정 시간으로 교체 (flaky test 방지)
+final _fixedNow = DateTime(2026, 4, 13, 12, 0, 0);
+
 void main() {
   setUpAll(() async {
     await initializeDateFormatting('ko_KR');
@@ -216,7 +219,7 @@ void main() {
     testWidgets('구매 목록 → 상태 배지 렌더링 (7종)', (tester) async {
       setKoreanLocale(tester);
       final user = createMockUserForTest();
-      final now = DateTime.now();
+      final now = _fixedNow;
       final applications = [
         _createApplication(status: 'pending', createdAt: now),
         _createApplication(status: 'pending_review', createdAt: now),
@@ -265,7 +268,7 @@ void main() {
     testWidgets('환불 가능 시 → "예매 취소" 버튼 표시', (tester) async {
       setKoreanLocale(tester);
       final user = createMockUserForTest();
-      final now = DateTime.now();
+      final now = _fixedNow;
       // canCancel:
       // paid + paymentId + paymentAmount + event.startTime +
       // refundStatus == 'none'
@@ -324,7 +327,7 @@ void main() {
     testWidgets('환불 불가 시 → "예매 취소" 버튼 미표시', (tester) async {
       setKoreanLocale(tester);
       final user = createMockUserForTest();
-      final now = DateTime.now();
+      final now = _fixedNow;
       // cancelled status → isActiveTicket returns false → canCancel false
       final nonRefundableApp = _createApplication(
         status: 'cancelled',
@@ -429,7 +432,7 @@ class _MockNotificationSettingsWithData extends NotificationSettingsController {
   @override
   FutureOr<UserSettings?> build() async => UserSettings(
     userId: 'test-user-id',
-    updatedAt: DateTime.now(),
+    updatedAt: _fixedNow,
   );
 }
 
@@ -448,32 +451,32 @@ class _MockConsentController extends ConsentController {
       userId: 'test-user-id',
       consentKey: ConsentType.termsOfService,
       consented: true,
-      consentedAt: DateTime.now(),
-      createdAt: DateTime.now(),
+      consentedAt: _fixedNow,
+      createdAt: _fixedNow,
     ),
     UserConsent(
       id: 'c2',
       userId: 'test-user-id',
       consentKey: ConsentType.privacyCollection,
       consented: true,
-      consentedAt: DateTime.now(),
-      createdAt: DateTime.now(),
+      consentedAt: _fixedNow,
+      createdAt: _fixedNow,
     ),
     UserConsent(
       id: 'c3',
       userId: 'test-user-id',
       consentKey: ConsentType.thirdPartyProvision,
       consented: false,
-      consentedAt: DateTime.now(),
-      createdAt: DateTime.now(),
+      consentedAt: _fixedNow,
+      createdAt: _fixedNow,
     ),
     UserConsent(
       id: 'c4',
       userId: 'test-user-id',
       consentKey: ConsentType.marketingConsent,
       consented: false,
-      consentedAt: DateTime.now(),
-      createdAt: DateTime.now(),
+      consentedAt: _fixedNow,
+      createdAt: _fixedNow,
     ),
   ];
 }

--- a/apps/app_user/test/src/features/event/admission/admission_state_edge_cases_test.dart
+++ b/apps/app_user/test/src/features/event/admission/admission_state_edge_cases_test.dart
@@ -6,6 +6,9 @@ import 'package:mocktail/mocktail.dart';
 import '../../../../utils/mocks.dart';
 import '../../../../utils/test_utils.dart';
 
+// Fix #1321: DateTime.now() → 고정 시간으로 교체 (flaky test 방지)
+final _fixedNow = DateTime(2026, 4, 13, 12, 0, 0);
+
 void main() {
   late MockEventRepository mockEventRepo;
   late MockUserRepository mockUserRepo;
@@ -14,18 +17,18 @@ void main() {
   final testEvent = Event(
     id: 'event_1',
     partyId: 'party_1',
-    startTime: DateTime.now(),
-    endTime: DateTime.now().add(const Duration(hours: 2)),
-    createdAt: DateTime.now(),
-    updatedAt: DateTime.now(),
+    startTime: _fixedNow,
+    endTime: _fixedNow.add(const Duration(hours: 2)),
+    createdAt: _fixedNow,
+    updatedAt: _fixedNow,
     contactOptions: {},
     tickets: [
       Ticket(
         id: 'ticket_1',
         eventId: 'event_1',
         name: 'Normal',
-        createdAt: DateTime.now(),
-        updatedAt: DateTime.now(),
+        createdAt: _fixedNow,
+        updatedAt: _fixedNow,
         targetEntryGroupIds: [],
         requiredVerificationIds: [],
         price: 10000,
@@ -55,8 +58,8 @@ void main() {
           ticketId: 'ticket_1',
           userId: 'user_1',
           status: 'pending',
-          createdAt: DateTime.now(),
-          updatedAt: DateTime.now(),
+          createdAt: _fixedNow,
+          updatedAt: _fixedNow,
         ),
       );
 
@@ -88,8 +91,8 @@ void main() {
           userId: 'user_1',
           status: 'rejected',
           rejectionReason: '서류 부족',
-          createdAt: DateTime.now(),
-          updatedAt: DateTime.now(),
+          createdAt: _fixedNow,
+          updatedAt: _fixedNow,
         ),
       );
 
@@ -157,8 +160,8 @@ void main() {
           ticketId: 'ticket_1',
           userId: 'user_1',
           status: 'cancelled',
-          createdAt: DateTime.now(),
-          updatedAt: DateTime.now(),
+          createdAt: _fixedNow,
+          updatedAt: _fixedNow,
         ),
       );
       when(() => mockUserRepo.getUserProfile('user_1')).thenAnswer(

--- a/apps/app_user/test/src/features/event/admission/admission_state_edge_cases_test.dart
+++ b/apps/app_user/test/src/features/event/admission/admission_state_edge_cases_test.dart
@@ -7,7 +7,7 @@ import '../../../../utils/mocks.dart';
 import '../../../../utils/test_utils.dart';
 
 // Fix #1321: DateTime.now() → 고정 시간으로 교체 (flaky test 방지)
-final _fixedNow = DateTime(2026, 4, 13, 12, 0, 0);
+final _fixedNow = DateTime(2026, 4, 13, 12);
 
 void main() {
   late MockEventRepository mockEventRepo;

--- a/apps/app_user/test/src/features/event/admission/event_admission_controller_test.dart
+++ b/apps/app_user/test/src/features/event/admission/event_admission_controller_test.dart
@@ -6,6 +6,9 @@ import 'package:mocktail/mocktail.dart';
 import '../../../../utils/mocks.dart';
 import '../../../../utils/test_utils.dart';
 
+// Fix #1321: DateTime.now() → 고정 시간으로 교체 (flaky test 방지)
+final _fixedNow = DateTime(2026, 4, 13, 12, 0, 0);
+
 void main() {
   late MockEventRepository mockEventRepo;
   late MockUserRepository mockUserRepo;
@@ -16,18 +19,18 @@ void main() {
   final testEvent = Event(
     id: 'event_1',
     partyId: 'party_1',
-    startTime: DateTime.now(),
-    endTime: DateTime.now().add(const Duration(hours: 2)),
-    createdAt: DateTime.now(),
-    updatedAt: DateTime.now(),
+    startTime: _fixedNow,
+    endTime: _fixedNow.add(const Duration(hours: 2)),
+    createdAt: _fixedNow,
+    updatedAt: _fixedNow,
     contactOptions: {},
     tickets: [
       Ticket(
         id: 'ticket_1',
         eventId: 'event_1',
         name: 'Normal Ticket',
-        createdAt: DateTime.now(),
-        updatedAt: DateTime.now(),
+        createdAt: _fixedNow,
+        updatedAt: _fixedNow,
         targetEntryGroupIds: ['group_1'],
         requiredVerificationIds: [],
         price: 10000,
@@ -51,7 +54,7 @@ void main() {
     matchId: 'match_1',
     eventId: 'event_1',
     partnerId: 'partner_1',
-    matchedAt: DateTime.now(),
+    matchedAt: _fixedNow,
   );
 
   final testEventWithQualification = testEvent.copyWith(
@@ -107,8 +110,8 @@ void main() {
           ticketId: 'ticket_1',
           userId: 'user_1',
           status: 'confirmed',
-          createdAt: DateTime.now(),
-          updatedAt: DateTime.now(),
+          createdAt: _fixedNow,
+          updatedAt: _fixedNow,
         ),
       );
 
@@ -355,8 +358,8 @@ void main() {
             ticketId: 'ticket_1',
             userId: 'user_1',
             status: 'confirmed',
-            createdAt: DateTime.now(),
-            updatedAt: DateTime.now(),
+            createdAt: _fixedNow,
+            updatedAt: _fixedNow,
           ),
         );
 
@@ -463,8 +466,8 @@ void main() {
             ticketId: 'ticket_1',
             userId: 'user_1',
             status: 'cancelled',
-            createdAt: DateTime.now(),
-            updatedAt: DateTime.now(),
+            createdAt: _fixedNow,
+            updatedAt: _fixedNow,
           ),
         );
 
@@ -501,8 +504,8 @@ void main() {
             ticketId: 'ticket_1',
             userId: 'user_1',
             status: 'confirmed',
-            createdAt: DateTime.now(),
-            updatedAt: DateTime.now(),
+            createdAt: _fixedNow,
+            updatedAt: _fixedNow,
           ),
         );
         when(
@@ -542,8 +545,8 @@ void main() {
             ticketId: 'ticket_1',
             userId: 'user_1',
             status: 'confirmed',
-            createdAt: DateTime.now(),
-            updatedAt: DateTime.now(),
+            createdAt: _fixedNow,
+            updatedAt: _fixedNow,
           ),
         );
         when(
@@ -820,8 +823,8 @@ void main() {
             ticketId: 'ticket_1',
             userId: 'user_1',
             status: 'confirmed',
-            createdAt: DateTime.now(),
-            updatedAt: DateTime.now(),
+            createdAt: _fixedNow,
+            updatedAt: _fixedNow,
           ),
         );
         when(

--- a/apps/app_user/test/src/features/event/admission/event_admission_controller_test.dart
+++ b/apps/app_user/test/src/features/event/admission/event_admission_controller_test.dart
@@ -7,7 +7,7 @@ import '../../../../utils/mocks.dart';
 import '../../../../utils/test_utils.dart';
 
 // Fix #1321: DateTime.now() → 고정 시간으로 교체 (flaky test 방지)
-final _fixedNow = DateTime(2026, 4, 13, 12, 0, 0);
+final _fixedNow = DateTime(2026, 4, 13, 12);
 
 void main() {
   late MockEventRepository mockEventRepo;

--- a/apps/app_user/test/src/features/event/logic/event_detail_controller_test.dart
+++ b/apps/app_user/test/src/features/event/logic/event_detail_controller_test.dart
@@ -8,6 +8,9 @@ import 'package:mocktail/mocktail.dart';
 import '../../../../utils/mocks.dart';
 import '../../../../utils/test_utils.dart';
 
+// Fix #1321: DateTime.now() → 고정 시간으로 교체 (flaky test 방지)
+final _fixedNow = DateTime(2026, 4, 13, 12, 0, 0);
+
 void main() {
   late MockEventRepository mockEventRepo;
 
@@ -15,10 +18,10 @@ void main() {
   final testEvent = Event(
     id: 'event_1',
     partyId: 'party_1',
-    startTime: DateTime.now(),
-    endTime: DateTime.now().add(const Duration(hours: 2)),
-    createdAt: DateTime.now(),
-    updatedAt: DateTime.now(),
+    startTime: _fixedNow,
+    endTime: _fixedNow.add(const Duration(hours: 2)),
+    createdAt: _fixedNow,
+    updatedAt: _fixedNow,
     title: 'Test Event',
   );
 

--- a/apps/app_user/test/src/features/event/logic/event_detail_controller_test.dart
+++ b/apps/app_user/test/src/features/event/logic/event_detail_controller_test.dart
@@ -9,7 +9,7 @@ import '../../../../utils/mocks.dart';
 import '../../../../utils/test_utils.dart';
 
 // Fix #1321: DateTime.now() → 고정 시간으로 교체 (flaky test 방지)
-final _fixedNow = DateTime(2026, 4, 13, 12, 0, 0);
+final _fixedNow = DateTime(2026, 4, 13, 12);
 
 void main() {
   late MockEventRepository mockEventRepo;

--- a/apps/app_user/test/src/features/home/logic/event_now_bar_state_provider_test.dart
+++ b/apps/app_user/test/src/features/home/logic/event_now_bar_state_provider_test.dart
@@ -8,7 +8,7 @@ import '../../../../utils/test_utils.dart';
 
 // Fix #1321: DateTime.now() → 고정 시간으로 교체 (flaky test 방지)
 // clockProvider를 override하여 production code의 DateTime.now() 호출도 고정
-final _fixedNow = DateTime(2026, 4, 13, 12, 0, 0);
+final _fixedNow = DateTime(2026, 4, 13, 12);
 
 void main() {
   late MockMatchingRepository mockMatchingRepo;

--- a/apps/app_user/test/src/features/home/logic/event_now_bar_state_provider_test.dart
+++ b/apps/app_user/test/src/features/home/logic/event_now_bar_state_provider_test.dart
@@ -7,7 +7,7 @@ import '../../../../utils/mocks.dart';
 import '../../../../utils/test_utils.dart';
 
 // Fix #1321: DateTime.now() → 고정 시간으로 교체 (flaky test 방지)
-// clockProvider를 override하여 production code의 DateTime.now() 호출도 고정
+// clockProvider를 () => _fixedNow 함수로 override하여 호출 시점마다 고정 시간 반환
 final _fixedNow = DateTime(2026, 4, 13, 12);
 
 void main() {
@@ -46,7 +46,7 @@ void main() {
     List<MatchPair>? matches,
   }) {
     final overrides = <dynamic>[
-      clockProvider.overrideWithValue(_fixedNow),
+      clockProvider.overrideWithValue(() => _fixedNow),
       matchingRepositoryProvider.overrideWith((ref) => mockMatchingRepo),
     ];
 

--- a/apps/app_user/test/src/features/home/logic/event_now_bar_state_provider_test.dart
+++ b/apps/app_user/test/src/features/home/logic/event_now_bar_state_provider_test.dart
@@ -6,6 +6,10 @@ import 'package:mocktail/mocktail.dart';
 import '../../../../utils/mocks.dart';
 import '../../../../utils/test_utils.dart';
 
+// Fix #1321: DateTime.now() → 고정 시간으로 교체 (flaky test 방지)
+// clockProvider를 override하여 production code의 DateTime.now() 호출도 고정
+final _fixedNow = DateTime(2026, 4, 13, 12, 0, 0);
+
 void main() {
   late MockMatchingRepository mockMatchingRepo;
 
@@ -21,15 +25,14 @@ void main() {
     DateTime? startTime,
     DateTime? endTime,
   }) {
-    final now = DateTime.now();
     return TodayActiveEvent(
       event: Event(
         id: id,
         partyId: 'party_1',
-        startTime: startTime ?? now.subtract(const Duration(hours: 1)),
-        endTime: endTime ?? now.add(const Duration(hours: 2)),
-        createdAt: now,
-        updatedAt: now,
+        startTime: startTime ?? _fixedNow.subtract(const Duration(hours: 1)),
+        endTime: endTime ?? _fixedNow.add(const Duration(hours: 2)),
+        createdAt: _fixedNow,
+        updatedAt: _fixedNow,
         status: status,
       ),
       participantStatus: participantStatus,
@@ -43,6 +46,7 @@ void main() {
     List<MatchPair>? matches,
   }) {
     final overrides = <dynamic>[
+      clockProvider.overrideWithValue(_fixedNow),
       matchingRepositoryProvider.overrideWith((ref) => mockMatchingRepo),
     ];
 
@@ -74,8 +78,8 @@ void main() {
   group('eventNowBarStateProvider — 6-state 상태 머신', () {
     test('WAITING: 시작 3시간 전 ~ 시작 시간 전', () async {
       final activeEvent = makeActiveEvent(
-        startTime: DateTime.now().add(const Duration(hours: 2)),
-        endTime: DateTime.now().add(const Duration(hours: 5)),
+        startTime: _fixedNow.add(const Duration(hours: 2)),
+        endTime: _fixedNow.add(const Duration(hours: 5)),
       );
 
       final container = makeContainer(eventId: 'event_1');
@@ -91,7 +95,7 @@ void main() {
       'CHECK_IN_READY: 시작 시간 도달 + participant.status != checked_in',
       () async {
         final activeEvent = makeActiveEvent(
-          startTime: DateTime.now().subtract(const Duration(minutes: 30)),
+          startTime: _fixedNow.subtract(const Duration(minutes: 30)),
         );
 
         final container = makeContainer(eventId: 'event_1');
@@ -167,7 +171,7 @@ void main() {
             matchId: 'match_1',
             eventId: 'event_1',
             partnerId: 'user_2',
-            matchedAt: DateTime.now(),
+            matchedAt: _fixedNow,
           ),
         ],
       );
@@ -254,8 +258,8 @@ void main() {
 
       final waitingEvent = makeActiveEvent(
         id: 'event_2',
-        startTime: DateTime.now().add(const Duration(hours: 2)),
-        endTime: DateTime.now().add(const Duration(hours: 5)),
+        startTime: _fixedNow.add(const Duration(hours: 2)),
+        endTime: _fixedNow.add(const Duration(hours: 5)),
       );
 
       final result2 = await container.read(


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1321

## 변경 요약

5개 시간 민감 테스트 파일에서 `DateTime.now()` → 고정 시간(`_fixedNow = DateTime(2026, 4, 13, 12, 0, 0)`) 교체.

### 핵심 변경: clockProvider 주입

`event_now_bar_controller.dart`에 `clockProvider` 추가:
- Production 코드의 `DateTime.now()` 직접 호출을 `ref.watch(clockProvider)`로 교체
- 테스트에서 `clockProvider.overrideWithValue(_fixedNow)`로 시간 고정 가능
- `.g.dart` 파일에 `ClockProvider` 수동 추가 (build_runner 환경 없음)

### 파일별 변경

| 파일 | 유형 | 처리 방식 |
|------|------|----------|
| `event_now_bar_controller.dart` | 프로덕션 | `clockProvider` 추가, `DateTime.now()` → `ref.watch(clockProvider)` |
| `event_now_bar_state_provider_test.dart` | 테스트 | `clockProvider` override + `_fixedNow` 적용 |
| `event_admission_controller_test.dart` | 테스트 | 메타데이터 필드 `_fixedNow` 교체 |
| `admission_state_edge_cases_test.dart` | 테스트 | 메타데이터 필드 `_fixedNow` 교체 |
| `event_detail_controller_test.dart` | 테스트 | 이벤트 시간 필드 `_fixedNow` 교체 |
| `flow_my_page_test.dart` | 테스트 | 테스트 데이터 + mock 클래스 `_fixedNow` 교체 |

## Test plan

- [ ] `flutter test apps/app_user/test/src/features/home/logic/event_now_bar_state_provider_test.dart` — WAITING/CHECK_IN_READY 상태 전이 10회 연속 통과
- [ ] `flutter test apps/app_user/test/src/features/event/` — admission 관련 테스트 통과
- [ ] `flutter test apps/app_user/test/integration/flow_my_page_test.dart` — 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)