### PR TITLE
feat(theme): complete semantic status color tokens

### DIFF
--- a/apps/app_user/lib/src/common/widgets/status_badge.dart
+++ b/apps/app_user/lib/src/common/widgets/status_badge.dart
@@ -14,6 +14,10 @@ class StatusBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final brightness = Theme.of(context).brightness;
+    final colors = brightness == Brightness.dark
+        ? MinglitColorSet.dark
+        : MinglitColorSet.light;
     String label;
     Color color;
 
@@ -21,29 +25,29 @@ class StatusBadge extends StatelessWidget {
       case 'pending':
         label = '결제대기';
         // Fix #1236: info blue — 결제 완료를 기다리는 대기 상태
-        color = MinglitColors.info;
+        color = colors.info;
       case 'pending_review':
         label = '심사중';
         // Fix #1236: warning amber — 심사 진행 중 (결과 미확정)
-        color = MinglitColors.warning;
+        color = colors.warning;
       case 'approved':
         label = '승인됨';
         // Fix #1236: success green — 긍정 상태
-        color = MinglitColors.success;
+        color = colors.success;
       case 'paid':
         label = '결제완료';
         // Fix #1236: success green — 결제 완료된 긍정 상태
-        color = MinglitColors.success;
+        color = colors.success;
       case 'rejected':
         label = '반려됨';
-        color = MinglitColors.error;
+        color = colors.error;
       case 'cancelled':
         label = '취소됨';
         // Fix #1236: neutral grey — 취소는 오류가 아닌 종료 상태
-        color = MinglitColors.textSecondary;
+        color = colors.textSecondary;
       default:
         label = '알수없음';
-        color = MinglitColors.textSecondary;
+        color = colors.textSecondary;
     }
 
     // Fix #1236: MinglitChip(solid bg) → MinglitBadge(tinted bg + color text)

--- a/apps/app_user/test/src/common/widgets/status_badge_test.dart
+++ b/apps/app_user/test/src/common/widgets/status_badge_test.dart
@@ -83,4 +83,63 @@ void main() {
       expect(badge.color, isNot(MinglitColors.primary));
     });
   });
+
+  group('StatusBadge — dark mode', () {
+    Widget createDarkTestWidget(String status) {
+      return MaterialApp(
+        theme: MinglitTheme.materialThemeDark,
+        home: Scaffold(
+          body: StatusBadge(status: status),
+        ),
+      );
+    }
+
+    testWidgets('dark mode uses correct brightness', (tester) async {
+      await tester.pumpWidget(createDarkTestWidget('paid'));
+      final context = tester.element(find.byType(StatusBadge));
+      expect(Theme.of(context).brightness, Brightness.dark);
+    });
+
+    testWidgets('dark mode renders all statuses without error', (tester) async {
+      for (final status in [
+        'pending',
+        'pending_review',
+        'approved',
+        'paid',
+        'rejected',
+        'cancelled',
+      ]) {
+        await tester.pumpWidget(createDarkTestWidget(status));
+        expect(find.byType(MinglitBadge), findsOneWidget);
+      }
+    });
+  });
+
+  group('MinglitColorSet — semantic color tokens', () {
+    test('light set contains all semantic colors from MinglitColors', () {
+      expect(MinglitColorSet.light.success, MinglitColors.success);
+      expect(MinglitColorSet.light.info, MinglitColors.info);
+      expect(MinglitColorSet.light.warning, MinglitColors.warning);
+      expect(MinglitColorSet.light.error, MinglitColors.error);
+    });
+
+    test('dark set has distinct success/info/warning tokens', () {
+      expect(
+        MinglitColorSet.dark.success,
+        isNot(MinglitColorSet.light.success),
+      );
+      expect(
+        MinglitColorSet.dark.info,
+        isNot(MinglitColorSet.light.info),
+      );
+      expect(
+        MinglitColorSet.dark.warning,
+        isNot(MinglitColorSet.light.warning),
+      );
+    });
+
+    test('dark error matches light error (shared)', () {
+      expect(MinglitColorSet.dark.error, MinglitColors.error);
+    });
+  });
 }

--- a/shared/packages/minglit_kit/lib/src/theme/minglit_design_tokens.dart
+++ b/shared/packages/minglit_kit/lib/src/theme/minglit_design_tokens.dart
@@ -65,6 +65,12 @@ class MinglitColorsDark {
   static const tertiary = MinglitColors.tertiary;
   static const error = MinglitColors.error;
   // ignore: minglit_no_hardcoded_colors -- dark theme definition
+  static const success = Color(0xFF4ADE80);
+  // ignore: minglit_no_hardcoded_colors -- dark theme definition
+  static const info = Color(0xFF60A5FA);
+  // ignore: minglit_no_hardcoded_colors -- dark theme definition
+  static const warning = Color(0xFFFBBF24);
+  // ignore: minglit_no_hardcoded_colors -- dark theme definition
   static const divider = Color(0xFF3D3D3D);
 }
 
@@ -79,6 +85,10 @@ class MinglitColorSet {
     required this.textPrimary,
     required this.textSecondary,
     required this.divider,
+    required this.success,
+    required this.info,
+    required this.warning,
+    required this.error,
   });
 
   final Color background;
@@ -88,6 +98,10 @@ class MinglitColorSet {
   final Color textPrimary;
   final Color textSecondary;
   final Color divider;
+  final Color success;
+  final Color info;
+  final Color warning;
+  final Color error;
 
   static const light = MinglitColorSet(
     background: MinglitColors.background,
@@ -99,6 +113,10 @@ class MinglitColorSet {
     divider: Color(
       0xFFE5E7EB,
     ), // ignore: minglit_no_hardcoded_colors -- light divider token
+    success: MinglitColors.success,
+    info: MinglitColors.info,
+    warning: MinglitColors.warning,
+    error: MinglitColors.error,
   );
 
   static const dark = MinglitColorSet(
@@ -109,6 +127,10 @@ class MinglitColorSet {
     textPrimary: MinglitColorsDark.textPrimary,
     textSecondary: MinglitColorsDark.textSecondary,
     divider: MinglitColorsDark.divider,
+    success: MinglitColorsDark.success,
+    info: MinglitColorsDark.info,
+    warning: MinglitColorsDark.warning,
+    error: MinglitColorsDark.error,
   );
 }
 


### PR DESCRIPTION
Scheduler: needs-arch-claude-team-1

## Summary

- `MinglitColorsDark`에 `success`, `info`, `warning` 토큰 추가 (다크 모드 가독성 최적화)
- `MinglitColorSet`에 `success`, `info`, `warning`, `error` 필드 확장
- `StatusBadge`를 `Theme.of(context).brightness` 기반 테마 인식으로 전환
- 다크 모드 테스트 및 `MinglitColorSet` 토큰 값 검증 테스트 추가

## Test plan

- [x] 기존 16개 light mode 테스트 통과 확인
- [x] 다크 모드 brightness 감지 테스트 추가
- [x] 다크 모드 전체 상태 렌더링 smoke 테스트
- [x] MinglitColorSet light/dark 토큰 값 단언 테스트
- [x] `flutter analyze` 이슈 없음

Closes #1384

🤖 Generated with [Claude Code](https://claude.com/claude-code)