### PR TITLE
fix(infra): config.toml에 Edge Function 11개 섹션 추가 (#1357)

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -642,3 +642,72 @@ enabled = true
 verify_jwt = false  # JWT verification handled in function code
 import_map = "./deno.json"
 entrypoint = "./functions/user-update-verification/index.ts"
+
+# Fix #1357: 신규 Edge Function 11개 섹션 추가 — Supabase 배포 실패 방지
+# 아래 함수들은 supabase/functions/ 에 존재하지만 config.toml 에 등록되지 않아
+# "failed to create the graph" 오류로 supabase functions deploy 가 실패했다.
+[functions.apply-event]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/apply-event/index.ts"
+
+[functions.cleanup-blocked-dis]
+enabled = true
+verify_jwt = false
+import_map = "./deno.json"
+entrypoint = "./functions/cleanup-blocked-dis/index.ts"
+
+[functions.partner-approve-application]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/partner-approve-application/index.ts"
+
+[functions.partner-reject-application]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/partner-reject-application/index.ts"
+
+[functions.process-pending-deletions]
+enabled = true
+verify_jwt = false
+import_map = "./deno.json"
+entrypoint = "./functions/process-pending-deletions/index.ts"
+
+[functions.recurrence-cron]
+enabled = true
+verify_jwt = false
+import_map = "./deno.json"
+entrypoint = "./functions/recurrence-cron/index.ts"
+
+[functions.recurrence-rules]
+enabled = true
+verify_jwt = false
+import_map = "./deno.json"
+entrypoint = "./functions/recurrence-rules/index.ts"
+
+[functions.user-cancel-deletion]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/user-cancel-deletion/index.ts"
+
+[functions.user-delete-account]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/user-delete-account/index.ts"
+
+[functions.user-event-feed]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/user-event-feed/index.ts"
+
+[functions.user-get-ticket-token]
+enabled = true
+verify_jwt = false  # JWT verification handled in function code
+import_map = "./deno.json"
+entrypoint = "./functions/user-get-ticket-token/index.ts"


### PR DESCRIPTION
## Summary

- `supabase/functions/` 에 존재하지만 `config.toml` 에 등록되지 않은 Edge Function 11개 섹션 추가
- 각 섹션에 `import_map = "./deno.json"` 을 추가해 `@supabase/supabase-js` 등 JSR 패키지 resolve 가능하게 함
- 2026-03-30부터 지속 발생하던 `supabase functions deploy` 실패 해결

**추가된 함수**: `apply-event`, `cleanup-blocked-dis`, `partner-approve-application`, `partner-reject-application`, `process-pending-deletions`, `recurrence-cron`, `recurrence-rules`, `user-cancel-deletion`, `user-delete-account`, `user-event-feed`, `user-get-ticket-token`

## Root Cause

`supabase functions deploy` 는 `ghcr.io/supabase/edge-runtime` 컨테이너를 사용해 모든 함수의 의존성 그래프를 생성한다. `config.toml` 에 `[functions.<name>]` 섹션이 없으면 `import_map` 이 없어 `jsr:@supabase/supabase-js@2` 등 JSR 패키지를 resolve할 수 없어 "failed to create the graph" 오류가 발생한다.

## Test plan

- [ ] `ci-result` 통과 확인 (supabase 관련 CI job 포함)
- [ ] `test-supabase` 및 `test-edge-functions` job 통과 확인

Closes #1357

🤖 Generated with [Claude Code](https://claude.com/claude-code)