### PR TITLE
fix(minglit_kit): MinglitButton 하드코딩 색상 → colorScheme 전환 (#1374)

### DIFF
--- a/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_button.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_button.dart
@@ -210,10 +210,11 @@ class MinglitButton extends StatelessWidget {
   }
 
   ButtonStyle _primaryStyle(BuildContext context) {
+    // Fix #1374: Use theme colors instead of hardcoded values for dark mode / partner theme support
+    final colorScheme = Theme.of(context).colorScheme;
     return ElevatedButton.styleFrom(
-      backgroundColor: MinglitColors.primary,
-      // ignore: minglit_no_hardcoded_colors -- button theme definition
-      foregroundColor: Colors.white,
+      backgroundColor: colorScheme.primary,
+      foregroundColor: colorScheme.onPrimary,
       minimumSize: Size(0, _height),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(MinglitRadius.button),
@@ -228,13 +229,15 @@ class MinglitButton extends StatelessWidget {
   }
 
   ButtonStyle _secondaryStyle(BuildContext context) {
+    // Fix #1374: Use theme colors instead of hardcoded values for dark mode / partner theme support
+    final primary = Theme.of(context).colorScheme.primary;
     return OutlinedButton.styleFrom(
-      foregroundColor: MinglitColors.primary,
+      foregroundColor: primary,
       minimumSize: Size(0, _height),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(MinglitRadius.button),
       ),
-      side: const BorderSide(color: MinglitColors.primary),
+      side: BorderSide(color: primary),
       textStyle: TextStyle(
         // ignore: minglit_no_hardcoded_text_style -- button theme definition
         fontSize: _fontSize,
@@ -244,8 +247,9 @@ class MinglitButton extends StatelessWidget {
   }
 
   ButtonStyle _textStyle(BuildContext context) {
+    // Fix #1374: Use theme colors instead of hardcoded values for dark mode / partner theme support
     return TextButton.styleFrom(
-      foregroundColor: MinglitColors.primary,
+      foregroundColor: Theme.of(context).colorScheme.primary,
       minimumSize: Size(0, _height),
       textStyle: TextStyle(
         // ignore: minglit_no_hardcoded_text_style -- button theme definition

--- a/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_button_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_button_test.dart
@@ -154,7 +154,9 @@ void main() {
     });
 
     // Fix #1374: Regression tests — buttons must use theme colorScheme, not hardcoded colors
-    testWidgets('primary button uses colorScheme.primary background', (tester) async {
+    testWidgets('primary button uses colorScheme.primary background', (
+      tester,
+    ) async {
       const lightPrimary = Color(0xFF9900FF);
       await tester.pumpWidget(
         MaterialApp(
@@ -173,7 +175,9 @@ void main() {
       expect(bg, lightPrimary);
     });
 
-    testWidgets('secondary button uses colorScheme.primary for border', (tester) async {
+    testWidgets('secondary button uses colorScheme.primary for border', (
+      tester,
+    ) async {
       const testPrimary = Color(0xFF1234AB);
       await tester.pumpWidget(
         MaterialApp(
@@ -191,7 +195,9 @@ void main() {
       expect(side?.color, testPrimary);
     });
 
-    testWidgets('dark mode: primary button adapts to dark theme color', (tester) async {
+    testWidgets('dark mode: primary button adapts to dark theme color', (
+      tester,
+    ) async {
       const darkPrimary = Color(0xFFAA33FF);
       await tester.pumpWidget(
         MaterialApp(

--- a/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_button_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_button_test.dart
@@ -195,6 +195,26 @@ void main() {
       expect(side?.color, testPrimary);
     });
 
+    testWidgets('text button uses colorScheme.primary foreground', (
+      tester,
+    ) async {
+      const testPrimary = Color(0xFF00A3FF);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            colorScheme: const ColorScheme.light(primary: testPrimary),
+          ),
+          home: Scaffold(
+            body: MinglitButton.text(label: '텍스트 색상', onPressed: () {}),
+          ),
+        ),
+      );
+
+      final button = tester.widget<TextButton>(find.byType(TextButton));
+      final fg = button.style!.foregroundColor?.resolve({});
+      expect(fg, testPrimary);
+    });
+
     testWidgets('dark mode: primary button adapts to dark theme color', (
       tester,
     ) async {

--- a/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_button_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_button_test.dart
@@ -152,5 +152,61 @@ void main() {
 
       expect(find.text('작은 버튼'), findsOneWidget);
     });
+
+    // Fix #1374: Regression tests — buttons must use theme colorScheme, not hardcoded colors
+    testWidgets('primary button uses colorScheme.primary background', (tester) async {
+      const lightPrimary = Color(0xFF9900FF);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            colorScheme: const ColorScheme.light(primary: lightPrimary),
+          ),
+          home: Scaffold(
+            body: MinglitButton(label: '테마 테스트', onPressed: () {}),
+          ),
+        ),
+      );
+
+      final button = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+      final style = button.style!;
+      final bg = style.backgroundColor?.resolve({});
+      expect(bg, lightPrimary);
+    });
+
+    testWidgets('secondary button uses colorScheme.primary for border', (tester) async {
+      const testPrimary = Color(0xFF1234AB);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            colorScheme: const ColorScheme.light(primary: testPrimary),
+          ),
+          home: Scaffold(
+            body: MinglitButton.secondary(label: '보더 테스트', onPressed: () {}),
+          ),
+        ),
+      );
+
+      final button = tester.widget<OutlinedButton>(find.byType(OutlinedButton));
+      final side = button.style!.side?.resolve({});
+      expect(side?.color, testPrimary);
+    });
+
+    testWidgets('dark mode: primary button adapts to dark theme color', (tester) async {
+      const darkPrimary = Color(0xFFAA33FF);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            colorScheme: const ColorScheme.dark(primary: darkPrimary),
+          ),
+          home: Scaffold(
+            body: MinglitButton(label: '다크모드', onPressed: () {}),
+          ),
+        ),
+      );
+
+      final button = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+      final bg = button.style!.backgroundColor?.resolve({});
+      expect(bg, darkPrimary);
+    });
   });
 }


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1374

## 변경 내용

`MinglitButton`의 `_primaryStyle`, `_secondaryStyle`, `_textStyle`에서 `MinglitColors.primary` 하드코딩을 제거하고 `Theme.of(context).colorScheme.primary`로 교체.

| 이전 | 이후 |
|------|------|
| `backgroundColor: MinglitColors.primary` | `backgroundColor: colorScheme.primary` |
| `foregroundColor: Colors.white` | `foregroundColor: colorScheme.onPrimary` |
| `foregroundColor: MinglitColors.primary` | `foregroundColor: Theme.of(context).colorScheme.primary` |
| `side: const BorderSide(color: MinglitColors.primary)` | `side: BorderSide(color: primary)` |

## 회귀 방지 테스트

3개 테스트 추가:
- `primary button uses colorScheme.primary background`
- `secondary button uses colorScheme.primary for border`
- `dark mode: primary button adapts to dark theme color`