### PR TITLE
fix(minglit_kit): 로그아웃 확인 다이얼로그 추가

### DIFF
--- a/apps/app_user/test/integration/flow_my_page_test.dart
+++ b/apps/app_user/test/integration/flow_my_page_test.dart
@@ -166,10 +166,11 @@ void main() {
       expect(find.byType(PurchaseHistoryPage), findsOneWidget);
     });
 
-    testWidgets('로그아웃 tap → 홈으로 이동', (tester) async {
+    testWidgets('로그아웃 tap → 확인 다이얼로그 → 홈으로 이동', (tester) async {
       setKoreanLocale(tester);
       final user = createMockUserForTest();
       // Fix #1213: 로그아웃은 계정 관리 서브페이지(/my/account)로 이동
+      // Fix #1378: 로그아웃 확인 다이얼로그 추가로 인해 두 단계로 처리
       await tester.pumpWidget(
         createTestApp(
           isLoggedIn: true,
@@ -180,7 +181,21 @@ void main() {
       await tester.pump();
       await tester.pump();
 
+      // 1단계: 로그아웃 버튼 탭 → 확인 다이얼로그 열림
       await tester.tap(find.text('로그아웃'));
+      await tester.pumpAndSettle();
+
+      // 다이얼로그 확인: 취소/로그아웃(확인) 버튼이 모두 표시됨
+      expect(find.text('로그아웃 하시겠어요?'), findsOneWidget);
+      expect(find.text('취소'), findsOneWidget);
+
+      // 2단계: 다이얼로그에서 '로그아웃' 확인 버튼 탭
+      // 다이얼로그 내의 '로그아웃' 버튼 (TextButton) 탭
+      final confirmButton = find.ancestor(
+        of: find.text('로그아웃').last,
+        matching: find.byType(TextButton),
+      );
+      await tester.tap(confirmButton);
       // GoRouter.go('/') + Future.delayed(Duration.zero) + signOut
       await tester.pumpAndSettle();
 

--- a/shared/packages/minglit_kit/lib/src/ui/pages/account_management_page.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/pages/account_management_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/src/theme/minglit_theme.dart';
+import 'package:minglit_kit/src/ui/widgets/common/minglit_alert.dart';
 
 /// Shared account management page for app_user and app_partner.
 ///
@@ -53,7 +54,16 @@ class AccountManagementPage extends StatelessWidget {
                   ListTile(
                     leading: const Icon(Icons.logout),
                     title: const Text('로그아웃'),
-                    onTap: onLogout,
+                    // Fix #1378: 로그아웃 즉시 실행 방지 — 확인 다이얼로그 추가
+                    onTap: () async {
+                      final confirmed = await MinglitAlert.showConfirm(
+                        context: context,
+                        title: '로그아웃',
+                        content: '로그아웃 하시겠어요?',
+                        confirmText: '로그아웃',
+                      );
+                      if (confirmed) onLogout();
+                    },
                   ),
                   const Divider(height: 1),
                   ListTile(

--- a/shared/packages/minglit_kit/test/src/ui/widgets/common/account_management_page_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/common/account_management_page_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/ui/pages/account_management_page.dart';
+
+void main() {
+  Widget wrap({
+    required VoidCallback onLogout,
+    VoidCallback? onDeleteAccount,
+  }) {
+    return MaterialApp(
+      home: AccountManagementPage(
+        onLogout: onLogout,
+        onDeleteAccount: onDeleteAccount ?? () {},
+      ),
+    );
+  }
+
+  group('AccountManagementPage logout confirm', () {
+    testWidgets('로그아웃 탭 시 확인 다이얼로그 표시', (tester) async {
+      var logoutCalled = false;
+      await tester.pumpWidget(
+        wrap(onLogout: () => logoutCalled = true),
+      );
+
+      await tester.tap(find.text('로그아웃'));
+      await tester.pumpAndSettle();
+
+      // 다이얼로그가 표시되고 로그아웃은 아직 실행되지 않음
+      expect(find.text('로그아웃 하시겠어요?'), findsOneWidget);
+      expect(logoutCalled, isFalse);
+    });
+
+    testWidgets('확인 시 onLogout 실행', (tester) async {
+      var logoutCalled = false;
+      await tester.pumpWidget(
+        wrap(onLogout: () => logoutCalled = true),
+      );
+
+      await tester.tap(find.text('로그아웃'));
+      await tester.pumpAndSettle();
+
+      // 다이얼로그에서 '로그아웃' 확인 버튼 탭
+      final confirmButtons = find.text('로그아웃');
+      // 두 번째 '로그아웃' 텍스트가 다이얼로그 확인 버튼
+      await tester.tap(confirmButtons.last);
+      await tester.pumpAndSettle();
+
+      expect(logoutCalled, isTrue);
+    });
+
+    testWidgets('취소 시 onLogout 미실행', (tester) async {
+      var logoutCalled = false;
+      await tester.pumpWidget(
+        wrap(onLogout: () => logoutCalled = true),
+      );
+
+      await tester.tap(find.text('로그아웃'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('취소'));
+      await tester.pumpAndSettle();
+
+      expect(logoutCalled, isFalse);
+      // 다이얼로그가 닫히고 페이지가 유지됨
+      expect(find.text('로그아웃'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1378

## 변경 내용

로그아웃 탭 즉시 실행을 `MinglitAlert.showConfirm()`으로 차단합니다.

**`AccountManagementPage`** (`account_management_page.dart`)
- 로그아웃 `ListTile.onTap` → async + `MinglitAlert.showConfirm()` 추가
- 확인 시만 `onLogout()` 호출, 취소 시 세션 유지
- 위젯 내부 처리이므로 app_user, app_partner 모두 자동 적용
- `MinglitAlert` import 추가

## 테스트

`account_management_page_test.dart` — 3케이스 추가:
- 로그아웃 탭 시 확인 다이얼로그 표시 (즉시 실행 방지 확인)
- 확인 탭 시 `onLogout` 실행
- 취소 탭 시 `onLogout` 미실행

## 수용 기준 체크
- [x] 로그아웃 탭 → 확인 다이얼로그 표시
- [x] 확인 시 로그아웃 실행, 취소 시 유지
- [x] app_user, app_partner 모두 적용