### PR TITLE
fix(app_partner): Chip/ActionChip → MinglitKit 위젯 표준화

### DIFF
--- a/apps/app_partner/lib/src/features/home/widgets/today_party_card.dart
+++ b/apps/app_partner/lib/src/features/home/widgets/today_party_card.dart
@@ -160,14 +160,10 @@ class _EventItem extends StatelessWidget {
                 ),
               ),
               const SizedBox(width: MinglitSpacing.small),
-              Chip(
-                label: const Text('관리'),
-                visualDensity: VisualDensity.compact,
-                padding: EdgeInsets.zero,
-                backgroundColor: colorScheme.primaryContainer,
-                labelStyle: theme.textTheme.bodyMedium!.copyWith(
-                  color: colorScheme.onPrimaryContainer,
-                ),
+              MinglitChip(
+                label: '관리',
+                size: MinglitChipSize.small,
+                color: colorScheme.primaryContainer,
               ),
             ],
           ),

--- a/apps/app_partner/lib/src/features/party/detail/tabs/party_info_tab.dart
+++ b/apps/app_partner/lib/src/features/party/detail/tabs/party_info_tab.dart
@@ -58,18 +58,10 @@ class PartyInfoTab extends ConsumerWidget {
                 if (party.isPrivate)
                   Padding(
                     padding: const EdgeInsets.only(top: MinglitSpacing.small),
-                    child: Chip(
-                      label: const Text('비공개'),
-                      avatar: const Icon(Icons.lock, size: 16),
-                      backgroundColor: Theme.of(
-                        context,
-                      ).colorScheme.errorContainer,
-                      labelStyle: Theme.of(context).textTheme.labelSmall!
-                          .copyWith(
-                            color: Theme.of(
-                              context,
-                            ).colorScheme.onErrorContainer,
-                          ),
+                    child: MinglitTag(
+                      label: '비공개',
+                      icon: Icons.lock,
+                      color: Theme.of(context).colorScheme.error,
                     ),
                   ),
               ],

--- a/apps/app_partner/lib/src/features/party/recurrence/recurrence_management_screen.dart
+++ b/apps/app_partner/lib/src/features/party/recurrence/recurrence_management_screen.dart
@@ -80,12 +80,7 @@ class _RecurrenceRuleContent extends ConsumerWidget {
       RecurrenceStatus.cancelled => ('취소됨', theme.colorScheme.error),
     };
 
-    return Chip(
-      label: Text(label),
-      backgroundColor: color.withOpacity(0.12),
-      labelStyle: TextStyle(color: color, fontWeight: FontWeight.w600),
-      side: BorderSide.none,
-    );
+    return MinglitTag(label: label, color: color);
   }
 
   Widget _buildInfoCard(BuildContext context, RecurrenceRule rule) {

--- a/apps/app_partner/lib/src/features/verification/review/review_verification_screen.dart
+++ b/apps/app_partner/lib/src/features/verification/review/review_verification_screen.dart
@@ -226,7 +226,7 @@ class _ReviewVerificationScreenState
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                const Chip(label: Text('VERIFICATION')),
+                const MinglitChip(label: 'VERIFICATION'),
                 Text(
                   (user['email'] as String?) ?? 'Unknown User',
                   style: theme.textTheme.labelSmall?.copyWith(


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1385

## 변경 내용

전사 감사에서 발견된 Flutter 기본 `Chip` 4곳을 MinglitKit 디자인 시스템 위젯으로 교체합니다.

| 파일 | 기존 | 교체 | 용도 |
|------|------|------|------|
| `today_party_card.dart` | `Chip('관리')` | `MinglitChip(size: small)` | 관리 배지 |
| `recurrence_management_screen.dart` | `Chip(상태 레이블)` | `MinglitTag(semantic color)` | 반복 규칙 상태 표시 |
| `party_info_tab.dart` | `Chip('비공개', avatar: lock)` | `MinglitTag(icon: lock, color: error)` | 비공개 상태 표시 |
| `review_verification_screen.dart` | `Chip('VERIFICATION')` | `MinglitChip` | 인증 레이블 |

모두 read-only 사용이므로 interactive `MinglitFilterChip` 대신 display-only `MinglitTag`/`MinglitChip` 적용.