### PR TITLE
fix(app_user): QuillEditor 마지막 줄 잘림 방지 — bottom padding 추가

### DIFF
--- a/apps/app_user/lib/src/features/event/detail/event_quill_viewer.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_quill_viewer.dart
@@ -15,6 +15,12 @@ class _QuillViewer extends StatelessWidget {
       readOnly: true,
     );
 
-    return QuillEditor.basic(controller: controller);
+    // Fix #1380: 마지막 줄 descender 잘림 방지 — bottom padding 추가
+    return QuillEditor.basic(
+      controller: controller,
+      config: const QuillEditorConfig(
+        padding: EdgeInsets.only(bottom: MinglitSpacing.medium),
+      ),
+    );
   }
 }


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1380

## 변경 내용

`event_quill_viewer.dart` — `QuillEditor.basic()`에 bottom padding 추가.

마지막 텍스트 라인의 descender가 paint boundary에 잘리는 현상 해결.

```dart
QuillEditor.basic(
  controller: controller,
  config: const QuillEditorConfig(
    padding: EdgeInsets.only(bottom: MinglitSpacing.medium),
  ),
);
```