### PR TITLE
fix(minglit_kit): applyEvent 비-200 응답 시 null cast crash 방지 (#1409)

### DIFF
--- a/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_commands.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_commands.dart
@@ -158,6 +158,16 @@ mixin _EventRepositoryCommands
         },
       );
 
+      // Fix #1409: 비-200 응답 시 response.data가 null이어서 캐스트 크래시 발생.
+      // cancelOrder와 동일한 패턴으로 status 먼저 확인 후 캐스트한다.
+      if (response.status != 200) {
+        final errData = response.data;
+        final errorMsg = errData is Map
+            ? (errData['error'] as String?) ?? '이벤트 신청에 실패했습니다.'
+            : '이벤트 신청에 실패했습니다.';
+        throw MinglitUserException(errorMsg);
+      }
+
       final data = response.data as Map<String, dynamic>;
       final type = data['type'] as String;
       final applicationId = data['application_id'] as String;

--- a/shared/packages/minglit_kit/test/src/data/repositories/event_repository_commands_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/event_repository_commands_test.dart
@@ -165,46 +165,52 @@ void main() {
     });
 
     // Fix #1409: 비-200 응답 시 response.data가 null → cast crash 재발 방지
-    test('throws MinglitUserException on non-200 response with null data', () async {
-      when(
-        () => mockFunctions.invoke(
-          'apply-event',
-          body: any(named: 'body'),
-        ),
-      ).thenAnswer(
-        (_) async => FunctionResponse(status: 409, data: null),
-      );
-
-      await expectLater(
-        repository.applyEvent(eventId: 'event_1', ticketId: 'ticket_1'),
-        throwsA(isA<MinglitUserException>()),
-      );
-    });
-
-    test('throws MinglitUserException on non-200 response with error message', () async {
-      when(
-        () => mockFunctions.invoke(
-          'apply-event',
-          body: any(named: 'body'),
-        ),
-      ).thenAnswer(
-        (_) async => FunctionResponse(
-          status: 409,
-          data: {'error': '이미 신청한 이벤트입니다.'},
-        ),
-      );
-
-      await expectLater(
-        repository.applyEvent(eventId: 'event_1', ticketId: 'ticket_1'),
-        throwsA(
-          isA<MinglitUserException>().having(
-            (e) => e.message,
-            'message',
-            '이미 신청한 이벤트입니다.',
+    test(
+      'throws MinglitUserException on non-200 response with null data',
+      () async {
+        when(
+          () => mockFunctions.invoke(
+            'apply-event',
+            body: any(named: 'body'),
           ),
-        ),
-      );
-    });
+        ).thenAnswer(
+          (_) async => FunctionResponse(status: 409),
+        );
+
+        await expectLater(
+          repository.applyEvent(eventId: 'event_1', ticketId: 'ticket_1'),
+          throwsA(isA<MinglitUserException>()),
+        );
+      },
+    );
+
+    test(
+      'throws MinglitUserException on non-200 response with error message',
+      () async {
+        when(
+          () => mockFunctions.invoke(
+            'apply-event',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 409,
+            data: {'error': '이미 신청한 이벤트입니다.'},
+          ),
+        );
+
+        await expectLater(
+          repository.applyEvent(eventId: 'event_1', ticketId: 'ticket_1'),
+          throwsA(
+            isA<MinglitUserException>().having(
+              (e) => e.message,
+              'message',
+              '이미 신청한 이벤트입니다.',
+            ),
+          ),
+        );
+      },
+    );
   });
 
   group('EventRepository.cancelPayment', () {

--- a/shared/packages/minglit_kit/test/src/data/repositories/event_repository_commands_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/event_repository_commands_test.dart
@@ -163,6 +163,48 @@ void main() {
         throwsA(anything),
       );
     });
+
+    // Fix #1409: 비-200 응답 시 response.data가 null → cast crash 재발 방지
+    test('throws MinglitUserException on non-200 response with null data', () async {
+      when(
+        () => mockFunctions.invoke(
+          'apply-event',
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer(
+        (_) async => FunctionResponse(status: 409, data: null),
+      );
+
+      await expectLater(
+        repository.applyEvent(eventId: 'event_1', ticketId: 'ticket_1'),
+        throwsA(isA<MinglitUserException>()),
+      );
+    });
+
+    test('throws MinglitUserException on non-200 response with error message', () async {
+      when(
+        () => mockFunctions.invoke(
+          'apply-event',
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer(
+        (_) async => FunctionResponse(
+          status: 409,
+          data: {'error': '이미 신청한 이벤트입니다.'},
+        ),
+      );
+
+      await expectLater(
+        repository.applyEvent(eventId: 'event_1', ticketId: 'ticket_1'),
+        throwsA(
+          isA<MinglitUserException>().having(
+            (e) => e.message,
+            'message',
+            '이미 신청한 이벤트입니다.',
+          ),
+        ),
+      );
+    });
   });
 
   group('EventRepository.cancelPayment', () {


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1409

## 문제

결제하기 버튼 탭 (Wizard Step 2) 시 `apply-event` Edge Function이 4xx/5xx 응답을 반환하면 `response.data`가 `null`이어서 `as Map<String, dynamic>` 캐스트 시 크래시 발생:

```
type 'Null' is not a subtype of type 'Map<String, dynamic>' in type cast
```

## 원인

`applyEvent()`에 상태 코드 체크 없이 바로 캐스트:
```dart
final data = response.data as Map<String, dynamic>;  // null일 때 크래시
```

## 수정

`cancelOrder()`와 동일한 패턴으로 status 체크 먼저:
```dart
if (response.status != 200) {
  final errData = response.data;
  final errorMsg = errData is Map
      ? (errData['error'] as String?) ?? '이벤트 신청에 실패했습니다.'
      : '이벤트 신청에 실패했습니다.';
  throw MinglitUserException(errorMsg);
}
final data = response.data as Map<String, dynamic>;
```

## 테스트

- `throws MinglitUserException on non-200 response with null data` — 409 + null data → 크래시 재발 방지
- `throws MinglitUserException on non-200 response with error message` — 409 + error body → 메시지 전달 검증