### PR TITLE
fix(ai-embed): DB 쿼리 에러 미검증 + vectorization 에러 삼킴 + 벡터 차원 불일치

### DIFF
--- a/supabase/functions/_shared/logger.ts
+++ b/supabase/functions/_shared/logger.ts
@@ -128,6 +128,17 @@ export async function withSpan<T>(
   }
 }
 
+/**
+ * Capture an exception to Sentry. No-ops if Sentry is not initialized.
+ * Use in handlers that catch exceptions internally and return error responses
+ * (i.e., exceptions that never propagate to withHandler's catch block).
+ */
+export function captureException(error: unknown): void {
+  if (_enabled && _Sentry) {
+    _Sentry.captureException(error);
+  }
+}
+
 /** Reset internal state. For testing only. */
 export function _resetForTesting(): void {
   _initialized = false;

--- a/supabase/functions/ai-embed/ai_embed_test.ts
+++ b/supabase/functions/ai-embed/ai_embed_test.ts
@@ -1,5 +1,6 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import { stub } from "@std/testing/mock";
+import { HybridCalculator } from "./calculator.ts";
 import {
   captureServeHandler,
   createFetchMock,
@@ -217,7 +218,8 @@ Deno.test({
 });
 
 Deno.test({
-  name: "ai-embed - embedding error returns processed 0",
+  // Fix #1441: 파티 벡터화 에러는 더 이상 삼키지 않고 500으로 전파 — PGMQ retry 활용
+  name: "ai-embed - embedding error returns 500",
   fn: async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
@@ -255,6 +257,64 @@ Deno.test({
             const response = await handler(jsonRequest("http://localhost", {}));
             const payload = await readJson(response);
 
+            assertEquals(response.status, 500);
+            assertEquals(typeof payload.error, "string");
+          });
+        });
+      },
+    );
+  } finally {
+    stubs.forEach((s) => s.restore());
+  }
+  },
+});
+
+Deno.test({
+  // Fix #1441: user_embeddings DB 쿼리 에러 시 해당 task만 스킵하고 processed: 0 반환
+  name: "ai-embed - user_embeddings db error skips interaction task",
+  fn: async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const stubs = [
+    stub(WorkerUtils.prototype, "isProcessed", async () => false),
+    stub(WorkerUtils.prototype, "markProcessed", async () => {}),
+    stub(WorkerUtils.prototype, "moveToDLQ", async () => {}),
+    stub(WorkerUtils.prototype, "logTimeLag", () => {}),
+    stub(OpenAIEmbedding.prototype, "generateEmbeddings", async () => []),
+  ];
+
+  const { fetchMock } = createFetchMock([
+    {
+      matcher: (req) => req.url.includes("/rest/v1/debug_logs") && req.method === "POST",
+      handler: () => jsonResponse({}),
+    },
+    {
+      matcher: (req) => req.url.includes("/rest/v1/rpc/pgmq_read"),
+      handler: () => jsonResponse([mockVectorInteractionMessage]),
+    },
+    {
+      matcher: (req) => req.url.includes("/rest/v1/user_embeddings") && req.method === "GET",
+      handler: () => jsonResponse({ message: "DB connection error" }, { status: 500 }),
+    },
+    {
+      matcher: (req) => req.url.includes("/rest/v1/party_embeddings") && req.method === "GET",
+      handler: () => jsonResponse({ embedding: embedding(0.2) }),
+    },
+  ]);
+
+  try {
+    await withEnv(
+      {
+        SUPABASE_URL: "https://supabase.test",
+        SUPABASE_SERVICE_ROLE_KEY: "service-key",
+        OPENAI_API_KEY: "openai-key",
+      },
+      async () => {
+        await withMockedFetch(fetchMock, async () => {
+          await withNoIntervals(async () => {
+            const response = await handler(jsonRequest("http://localhost", {}));
+            const payload = await readJson(response);
+
             assertEquals(response.status, 200);
             assertEquals(payload.processed, 0);
           });
@@ -264,5 +324,76 @@ Deno.test({
   } finally {
     stubs.forEach((s) => s.restore());
   }
+  },
+});
+
+Deno.test({
+  // Fix #1441: party_embeddings DB 쿼리 에러 시 해당 task만 스킵하고 processed: 0 반환
+  name: "ai-embed - party_embeddings db error skips interaction task",
+  fn: async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+  const stubs = [
+    stub(WorkerUtils.prototype, "isProcessed", async () => false),
+    stub(WorkerUtils.prototype, "markProcessed", async () => {}),
+    stub(WorkerUtils.prototype, "moveToDLQ", async () => {}),
+    stub(WorkerUtils.prototype, "logTimeLag", () => {}),
+    stub(OpenAIEmbedding.prototype, "generateEmbeddings", async () => []),
+  ];
+
+  const { fetchMock } = createFetchMock([
+    {
+      matcher: (req) => req.url.includes("/rest/v1/debug_logs") && req.method === "POST",
+      handler: () => jsonResponse({}),
+    },
+    {
+      matcher: (req) => req.url.includes("/rest/v1/rpc/pgmq_read"),
+      handler: () => jsonResponse([mockVectorInteractionMessage]),
+    },
+    {
+      matcher: (req) => req.url.includes("/rest/v1/user_embeddings") && req.method === "GET",
+      handler: () => jsonResponse({ embedding: embedding(0) }),
+    },
+    {
+      matcher: (req) => req.url.includes("/rest/v1/party_embeddings") && req.method === "GET",
+      handler: () => jsonResponse({ message: "DB connection error" }, { status: 500 }),
+    },
+  ]);
+
+  try {
+    await withEnv(
+      {
+        SUPABASE_URL: "https://supabase.test",
+        SUPABASE_SERVICE_ROLE_KEY: "service-key",
+        OPENAI_API_KEY: "openai-key",
+      },
+      async () => {
+        await withMockedFetch(fetchMock, async () => {
+          await withNoIntervals(async () => {
+            const response = await handler(jsonRequest("http://localhost", {}));
+            const payload = await readJson(response);
+
+            assertEquals(response.status, 200);
+            assertEquals(payload.processed, 0);
+          });
+        });
+      },
+    );
+  } finally {
+    stubs.forEach((s) => s.restore());
+  }
+  },
+});
+
+Deno.test({
+  // Fix #1441: HybridCalculator 벡터 차원 불일치 시 에러 발생
+  name: "HybridCalculator - throws on vector dimension mismatch",
+  fn: () => {
+    const calculator = new HybridCalculator({ decayRate: 0.05 });
+    assertThrows(
+      () => calculator.calculate([0.1, 0.2, 0.3], [0.1, 0.2], 0.5),
+      Error,
+      "Vector dimension mismatch",
+    );
   },
 });

--- a/supabase/functions/ai-embed/calculator.ts
+++ b/supabase/functions/ai-embed/calculator.ts
@@ -10,6 +10,10 @@ export class HybridCalculator implements VectorCalculator {
   constructor(private config: CalculatorConfig) {}
 
   calculate(oldVector: number[], actionVector: number[], weight: number): number[] {
+    // Fix #1441: 벡터 차원 불일치 방어 — NaN 생성 방지
+    if (oldVector.length !== actionVector.length) {
+      throw new Error(`Vector dimension mismatch: oldVector(${oldVector.length}) !== actionVector(${actionVector.length})`);
+    }
     const decay = 1 - this.config.decayRate;
     const combined = oldVector.map((val, i) => (val * decay) + (actionVector[i] * weight));
     const magnitude = Math.sqrt(combined.reduce((sum, val) => sum + val * val, 0));

--- a/supabase/functions/ai-embed/index.ts
+++ b/supabase/functions/ai-embed/index.ts
@@ -4,7 +4,7 @@ import { createEmbeddingAdapter } from '../_shared/ai/factory.ts'
 import { serializeParty } from './party_serializer.ts'
 import { HybridCalculator } from './calculator.ts'
 import { WorkerUtils } from '../_shared/worker_utils.ts'
-import { initSentry, withHandler, log } from '../_shared/logger.ts'
+import { initSentry, withHandler, log, captureException } from '../_shared/logger.ts'
 
 const FN = "ai-embed";
 
@@ -191,6 +191,8 @@ Deno.serve(withHandler(async (req) => {
   } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : String(err);
     log({ function: FN, level: "error", message: `AI Embed Worker Error: ${errorMessage}` });
+    // captureException: withHandler의 catch에 도달하지 않으므로 여기서 직접 Sentry에 캡처
+    captureException(err);
     return new Response(JSON.stringify({ error: errorMessage }), {
       status: 500,
       headers: { "Content-Type": "application/json" }

--- a/supabase/functions/ai-embed/index.ts
+++ b/supabase/functions/ai-embed/index.ts
@@ -129,7 +129,9 @@ Deno.serve(withHandler(async (req) => {
           }
         }
       } catch (e) {
+        // Fix #1441: 에러를 삼키지 말고 throw — PGMQ retry 활용 (silent failure 방지)
         log({ function: FN, level: "error", message: "Party Vectorization Error", metadata: { error: e } });
+        throw e;
       }
     }
 
@@ -143,6 +145,10 @@ Deno.serve(withHandler(async (req) => {
           supabase.from('user_embeddings').select('embedding').eq('user_id', user_id).maybeSingle(),
           supabase.from('party_embeddings').select('embedding').eq('party_id', party_id).maybeSingle()
         ]);
+
+        // Fix #1441: DB 쿼리 에러 미검증 — 에러 시 throw로 PGMQ retry 활용
+        if (userRes.error) throw userRes.error;
+        if (partyRes.error) throw partyRes.error;
 
         if (partyRes.data && partyRes.data.embedding) {
           const oldVector = userRes.data?.embedding ?? new Array(1536).fill(0);


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1441

## 변경 사항

### Fix 1: DB 쿼리 에러 미검증
- `userRes.error` / `partyRes.error` 체크 추가
- 에러 시 throw → per-task catch에서 로깅 → PGMQ retry 자동 활용

### Fix 2: Party vectorization 에러 삼킴
- 기존: catch에서 로그만 하고 계속 진행 (silent failure)
- 수정: `throw e` 추가 → 500 반환 → Sentry 캡처 + PGMQ VT 만료 후 retry

### Fix 3: HybridCalculator 벡터 차원 불일치
- `if (oldVector.length !== actionVector.length) throw Error` 추가
- NaN 생성 방지

## 테스트

회귀 방지 테스트 3개 추가, 기존 "embedding error" 테스트 1개 수정 (8개 전체 통과):
- `user_embeddings DB 에러 → processed: 0` (Fix 1)
- `party_embeddings DB 에러 → processed: 0` (Fix 1)
- `HybridCalculator 차원 불일치 → Error throw` (Fix 3)
- 기존 "embedding error returns processed 0" → "returns 500" 으로 업데이트 (Fix 2)