### PR TITLE
docs(qa): 배포 Secret 검증 + 스크린샷 캡처 포인트 정의

### DIFF
--- a/docs/qa/screenshot-capture-points.md
+++ b/docs/qa/screenshot-capture-points.md
@@ -1,0 +1,454 @@
+# Integration 테스트 스텝별 스크린샷 캡처 포인트 정의
+
+> 관련: #1458 (Patrol 통합 + 스크린샷 내장)
+>
+> 목적: 기존 37개 integration 테스트 + 3개 patrol 테스트에 스텝별 스크린샷을 내장할 때,
+> 각 테스트의 어느 시점에 어떤 이름으로 캡처할지 정의한다.
+>
+> SWE는 이 문서를 보고 `takeScreenshot()` 호출을 삽입한다.
+
+---
+
+## 네이밍 규칙
+
+```
+{test_id}_step{N}_{phase}.png
+```
+
+| 요소 | 설명 | 예시 |
+|------|------|------|
+| `test_id` | 테스트 파일의 고유 ID (아래 매핑 참고) | `cuj_u01`, `flow_u_search` |
+| `N` | 스텝 번호 (0부터) | `0`, `1`, `2` |
+| `phase` | 캡처 시점 | `setup`, `before`, `after`, `error` |
+
+### phase 정의
+
+| phase | 언제 캡처하는가 | 용도 |
+|-------|---------------|------|
+| `setup` | 테스트 앱 pumpWidget 직후, 첫 액션 전 | 초기 상태 (로딩, 리다이렉트 결과) 확인 |
+| `before` | 사용자 액션(tap, input) 직전 | 액션 대상이 화면에 있는지 확인 |
+| `after` | 사용자 액션 후 pumpAndSettle 완료 | 액션 결과 확인 |
+| `error` | 에러 상태 유발 후 | 에러 UI가 정상 렌더링되는지 확인 |
+
+---
+
+## 캡처 포인트 밀도 기준
+
+모든 testWidgets에 무조건 캡처를 넣지 않는다. 아래 기준으로 선별:
+
+| 기준 | 캡처 여부 | 이유 |
+|------|----------|------|
+| 화면 전환이 있는 테스트 | **캡처** | 전환 전후 시각적 확인 |
+| 단순 리다이렉트 검증 (expect만) | **setup 1장** | 리다이렉트 목적지 확인 |
+| 위저드 스텝 진행 | **스텝마다 캡처** | 각 스텝의 UI 상태 |
+| 에러/엣지 케이스 | **error 1장** | 에러 UI 확인 |
+| 데이터 로드 후 목록 표시 | **after 1장** | 렌더링 결과 확인 |
+
+---
+
+## app_user CUJ 테스트 (12 files)
+
+### cuj_signup_to_apply_test.dart — `cuj_u01` (8 tests, ~8 captures)
+
+> 이미 `tester.capture()` 적용됨. Patrol 전환 시 네이밍만 통일.
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 비로그인 → 리다이렉트 | `cuj_u01_step0_setup` | setup |
+| 로그인 페이지 (from 파라미터) | `cuj_u01_step1_setup` | setup |
+| 위저드 접근 | `cuj_u01_step2_after` | after |
+| 위저드 진행 바 | `cuj_u01_step3_after` | after |
+| 무료 이벤트 위저드 | `cuj_u01_step4_after` | after |
+| 에러 상태 | `cuj_u01_step5_error` | error |
+| 제출 중 상태 | `cuj_u01_step6_after` | after |
+| 성공 상태 | `cuj_u01_step7_after` | after |
+
+### cuj_checkin_matching_test.dart — `cuj_u02` (8 tests, ~5 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 비로그인 → 티켓 목록 차단 | `cuj_u02_step0_setup` | setup |
+| 로그인 → 티켓 목록 접근 | `cuj_u02_step1_after` | after |
+| QR 화면 렌더링 | `cuj_u02_step2_after` | after |
+| 투표 화면 | `cuj_u02_step3_after` | after |
+| 매칭 결과 화면 | `cuj_u02_step4_after` | after |
+
+### cuj_refund_test.dart — `cuj_u03` (5 tests, ~4 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 환불 신청 화면 | `cuj_u03_step0_setup` | setup |
+| 환불 정책 표시 | `cuj_u03_step1_after` | after |
+| 환불 확인 다이얼로그 | `cuj_u03_step2_before` | before |
+| 환불 완료 상태 | `cuj_u03_step3_after` | after |
+
+### cuj_event_application_test.dart — `cuj_u04` (1 test, ~1 capture)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 신청 위저드 전체 플로우 | `cuj_u04_step0_after` | after |
+
+### cuj_event_detail_test.dart — `cuj_u05` (1 test, ~1 capture)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 이벤트 상세 렌더링 | `cuj_u05_step0_setup` | setup |
+
+### cuj_account_deletion_test.dart — `cuj_u06` (12 tests, ~6 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 삭제 확인 화면 | `cuj_u06_step0_setup` | setup |
+| 유예 기간 안내 | `cuj_u06_step1_after` | after |
+| 삭제 확인 다이얼로그 | `cuj_u06_step2_before` | before |
+| 삭제 처리 완료 | `cuj_u06_step3_after` | after |
+| 복구 다이얼로그 | `cuj_u06_step4_after` | after |
+| 에러 상태 | `cuj_u06_step5_error` | error |
+
+### cuj_matching_vote_test.dart — `cuj_u07` (9 tests, ~5 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 투표 화면 렌더링 | `cuj_u07_step0_setup` | setup |
+| 투표 선택 UI | `cuj_u07_step1_before` | before |
+| 투표 제출 후 | `cuj_u07_step2_after` | after |
+| 결과 화면 | `cuj_u07_step3_after` | after |
+| 타임아웃 상태 | `cuj_u07_step4_error` | error |
+
+### cuj_identity_verification_test.dart — `cuj_u08` (4 tests, ~3 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 인증 화면 | `cuj_u08_step0_setup` | setup |
+| 인증 진행 중 | `cuj_u08_step1_after` | after |
+| 인증 완료 | `cuj_u08_step2_after` | after |
+
+### cuj_event_now_bar_test.dart — `cuj_u09` (15 tests, ~4 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 나우바 표시 (진행 중 이벤트) | `cuj_u09_step0_setup` | setup |
+| 나우바 탭 → 이벤트 상세 | `cuj_u09_step1_after` | after |
+| 나우바 미표시 (이벤트 없음) | `cuj_u09_step2_setup` | setup |
+| 나우바 카운트다운 | `cuj_u09_step3_after` | after |
+
+### cuj_ticket_qr_test.dart — `cuj_u10` (3 tests, ~2 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| QR 코드 렌더링 | `cuj_u10_step0_after` | after |
+| QR 새로고침 | `cuj_u10_step1_after` | after |
+
+### cuj_notification_test.dart — `cuj_u11` (1 test, ~1 capture)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 알림 목록 렌더링 | `cuj_u11_step0_setup` | setup |
+
+### cuj_tag_discovery_test.dart — `cuj_u12` (2 tests, ~2 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 태그 검색 UI | `cuj_u12_step0_setup` | setup |
+| 태그 선택 결과 | `cuj_u12_step1_after` | after |
+
+---
+
+## app_user Flow 테스트 (7 files)
+
+### flow_event_browse_test.dart — `flow_u_browse` (10 tests, ~4 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 홈 피드 렌더링 | `flow_u_browse_step0_setup` | setup |
+| 이벤트 카드 탭 → 상세 | `flow_u_browse_step1_after` | after |
+| 카테고리 필터 | `flow_u_browse_step2_after` | after |
+| 빈 상태 | `flow_u_browse_step3_setup` | setup |
+
+### flow_search_test.dart — `flow_u_search` (7 tests, ~3 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 검색 화면 초기 | `flow_u_search_step0_setup` | setup |
+| 검색 결과 표시 | `flow_u_search_step1_after` | after |
+| 검색 결과 없음 | `flow_u_search_step2_after` | after |
+
+### flow_my_page_test.dart — `flow_u_mypage` (12 tests, ~4 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 마이페이지 렌더링 | `flow_u_mypage_step0_setup` | setup |
+| 구매 내역 | `flow_u_mypage_step1_after` | after |
+| 개인정보 설정 | `flow_u_mypage_step2_after` | after |
+| 비로그인 상태 | `flow_u_mypage_step3_setup` | setup |
+
+### flow_ticket_application_test.dart — `flow_u_ticket` (10 tests, ~4 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 신청 목록 | `flow_u_ticket_step0_setup` | setup |
+| 신청 상세 | `flow_u_ticket_step1_after` | after |
+| 결제 진행 | `flow_u_ticket_step2_after` | after |
+| 에러 상태 | `flow_u_ticket_step3_error` | error |
+
+### flow_admission_status_test.dart — `flow_u_admission` (13 tests, ~4 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 입장 상태 화면 | `flow_u_admission_step0_setup` | setup |
+| 체크인 완료 상태 | `flow_u_admission_step1_after` | after |
+| 대기 상태 | `flow_u_admission_step2_after` | after |
+| 거절 상태 | `flow_u_admission_step3_after` | after |
+
+### flow_notification_routing_test.dart — `flow_u_noti` (10 tests, ~3 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 알림 목록 | `flow_u_noti_step0_setup` | setup |
+| 알림 탭 → 딥링크 이동 | `flow_u_noti_step1_after` | after |
+| 빈 알림 상태 | `flow_u_noti_step2_setup` | setup |
+
+### flow_error_edge_cases_test.dart — `flow_u_error` (10 tests, ~3 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 네트워크 에러 화면 | `flow_u_error_step0_error` | error |
+| 404 화면 | `flow_u_error_step1_error` | error |
+| 재시도 후 복구 | `flow_u_error_step2_after` | after |
+
+---
+
+## app_user 기타 테스트 (6 files)
+
+### auth_redirect_test.dart — `redirect_u_auth` (8 tests, ~3 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| GUEST → /login 리다이렉트 | `redirect_u_auth_step0_setup` | setup |
+| AUTH → 보호 페이지 접근 | `redirect_u_auth_step1_setup` | setup |
+| VERIFIED → 모든 페이지 접근 | `redirect_u_auth_step2_setup` | setup |
+
+### consent_redirect_test.dart — `redirect_u_consent` (8 tests, ~2 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 약관 미동의 → 동의 화면 | `redirect_u_consent_step0_setup` | setup |
+| 약관 동의 완료 → 원래 페이지 | `redirect_u_consent_step1_after` | after |
+
+### home_navigation_test.dart — `nav_u_home` (5 tests, ~3 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 홈 탭 초기 | `nav_u_home_step0_setup` | setup |
+| 탭 전환 | `nav_u_home_step1_after` | after |
+| 딥링크 → 탭 복귀 | `nav_u_home_step2_after` | after |
+
+### login_page_test.dart — `login_u` (3 tests, ~2 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 로그인 페이지 렌더링 | `login_u_step0_setup` | setup |
+| 소셜 로그인 버튼 | `login_u_step1_before` | before |
+
+### my_page_test.dart — `my_u` (3 tests, ~2 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 마이페이지 렌더링 | `my_u_step0_setup` | setup |
+| 메뉴 항목 표시 | `my_u_step1_after` | after |
+
+### smoke_test.dart / edge_cases_test.dart — 캡처 불필요
+
+> Smoke: 전 화면 크래시 없이 렌더링만 검증 → `scenario_screenshots_test.dart`로 이미 커버
+> Edge cases: 파라미터 검증 → 캡처 가치 낮음
+
+---
+
+## app_partner CUJ 테스트 (10 files)
+
+### cuj_onboarding_to_event_test.dart — `cuj_p01` (8 tests, ~8 captures)
+
+> 이미 `tester.capture()` 적용됨. Patrol 전환 시 네이밍 통일.
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 비로그인 → 리다이렉트 | `cuj_p01_step0_setup` | setup |
+| needsApplication → /welcome | `cuj_p01_step1_setup` | setup |
+| draftInProgress → /apply | `cuj_p01_step2_setup` | setup |
+| pendingReview → /apply/status | `cuj_p01_step3_setup` | setup |
+| needsCorrection → /apply/status | `cuj_p01_step4_setup` | setup |
+| hasPartner → 홈 | `cuj_p01_step5_setup` | setup |
+| 파티 목록 접근 | `cuj_p01_step6_after` | after |
+| 등록 완료 → /apply 리다이렉트 | `cuj_p01_step7_setup` | setup |
+
+### cuj_application_review_test.dart — `cuj_p02` (6 tests, ~4 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 신청 목록 화면 | `cuj_p02_step0_setup` | setup |
+| 신청 상세 | `cuj_p02_step1_after` | after |
+| 승인 처리 | `cuj_p02_step2_after` | after |
+| 거절 처리 | `cuj_p02_step3_after` | after |
+
+### cuj_application_action_test.dart — `cuj_p02a` (7 tests, ~4 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 승인 버튼 탭 전 | `cuj_p02a_step0_before` | before |
+| 승인 완료 | `cuj_p02a_step1_after` | after |
+| 거절 확인 다이얼로그 | `cuj_p02a_step2_before` | before |
+| 거절 완료 | `cuj_p02a_step3_after` | after |
+
+### cuj_checkin_manage_test.dart — `cuj_p03` (4 tests, ~3 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 체크인 화면 | `cuj_p03_step0_setup` | setup |
+| QR 스캔 결과 | `cuj_p03_step1_after` | after |
+| 중복 체크인 에러 | `cuj_p03_step2_error` | error |
+
+### cuj_checkin_qr_test.dart — `cuj_p03a` (9 tests, ~3 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| QR 스캐너 화면 | `cuj_p03a_step0_setup` | setup |
+| 스캔 성공 | `cuj_p03a_step1_after` | after |
+| 유효하지 않은 QR | `cuj_p03a_step2_error` | error |
+
+### cuj_settlement_test.dart — `cuj_p04` (6 tests, ~4 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 정산 목록 | `cuj_p04_step0_setup` | setup |
+| 정산 상세 | `cuj_p04_step1_after` | after |
+| 계좌 등록 | `cuj_p04_step2_after` | after |
+| 계좌 수정 | `cuj_p04_step3_after` | after |
+
+### cuj_event_create_wizard_test.dart — `cuj_p05` (스텝 수 확인 필요, ~6 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 위저드 Step 1: 기본정보 | `cuj_p05_step0_setup` | setup |
+| 위저드 Step 2: 날짜/시간 | `cuj_p05_step1_after` | after |
+| 위저드 Step 3: 티켓 | `cuj_p05_step2_after` | after |
+| 위저드 Step 4: 검토 | `cuj_p05_step3_after` | after |
+| 생성 완료 | `cuj_p05_step4_after` | after |
+| 유효성 검사 에러 | `cuj_p05_step5_error` | error |
+
+### cuj_team_management_test.dart — `cuj_p06` (8 tests, ~4 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 멤버 목록 | `cuj_p06_step0_setup` | setup |
+| 멤버 초대 | `cuj_p06_step1_after` | after |
+| 권한 변경 | `cuj_p06_step2_after` | after |
+| 멤버 제거 | `cuj_p06_step3_after` | after |
+
+### cuj_partner_account_deletion_test.dart — `cuj_p07` (8 tests, ~4 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 계정 삭제 화면 | `cuj_p07_step0_setup` | setup |
+| 삭제 확인 다이얼로그 | `cuj_p07_step1_before` | before |
+| 삭제 완료 | `cuj_p07_step2_after` | after |
+| 에러 상태 | `cuj_p07_step3_error` | error |
+
+### cuj_recurring_event_test.dart — `cuj_p08` (5 tests, ~3 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| 반복 설정 화면 | `cuj_p08_step0_setup` | setup |
+| 반복 규칙 저장 | `cuj_p08_step1_after` | after |
+| 반복 이벤트 목록 | `cuj_p08_step2_after` | after |
+
+---
+
+## app_partner 기타 테스트 (1 file)
+
+### partner_redirect_test.dart — `redirect_p` (10 tests, ~4 captures)
+
+| testWidgets | 캡처 포인트 | phase |
+|-------------|-----------|-------|
+| GUEST → /login | `redirect_p_step0_setup` | setup |
+| NEEDS_APP → /welcome | `redirect_p_step1_setup` | setup |
+| PENDING → /apply/status | `redirect_p_step2_setup` | setup |
+| PARTNER → 홈 | `redirect_p_step3_setup` | setup |
+
+---
+
+## Patrol 테스트 (3 files)
+
+### kakao_login_test.dart — `patrol_login`
+
+| 캡처 포인트 | phase | 설명 |
+|-----------|-------|------|
+| `patrol_login_step0_setup` | setup | 로그인 화면 |
+| `patrol_login_step1_before` | before | 카카오 로그인 버튼 탭 전 |
+| `patrol_login_step2_after` | after | 카카오 WebView (네이티브) |
+| `patrol_login_step3_after` | after | 로그인 완료 → 홈 |
+
+### payment_pg_test.dart — `patrol_payment`
+
+| 캡처 포인트 | phase | 설명 |
+|-----------|-------|------|
+| `patrol_payment_step0_setup` | setup | 결제 화면 |
+| `patrol_payment_step1_before` | before | PG 결제 시작 전 |
+| `patrol_payment_step2_after` | after | PG WebView (네이티브) |
+| `patrol_payment_step3_after` | after | 결제 완료 |
+
+### permission_grant_test.dart — `patrol_permission`
+
+| 캡처 포인트 | phase | 설명 |
+|-----------|-------|------|
+| `patrol_permission_step0_setup` | setup | 권한 요청 전 |
+| `patrol_permission_step1_after` | after | 시스템 권한 다이얼로그 (네이티브) |
+| `patrol_permission_step2_after` | after | 권한 허용 후 |
+
+---
+
+## 요약
+
+| 앱 | 테스트 유형 | 파일 수 | 예상 캡처 수 |
+|----|-----------|---------|------------|
+| app_user | CUJ | 12 | ~46 |
+| app_user | Flow | 7 | ~25 |
+| app_user | 기타 (redirect, nav, login) | 6 | ~12 |
+| app_partner | CUJ | 10 | ~43 |
+| app_partner | 기타 (redirect) | 1 | ~4 |
+| patrol | E2E (네이티브) | 3 | ~11 |
+| **합계** | | **39** | **~141** |
+
+> 이슈 예상치 ~120장 대비 약간 많음. 실제 구현 시 단순 리다이렉트 검증의 setup 캡처를 줄이면 120장 수준으로 조정 가능.
+
+---
+
+## SWE 구현 가이드
+
+### 1. takeScreenshot 호출 위치
+
+```dart
+// Widget test (test/integration/)에서는 Patrol의 PatrolTester 사용
+await $.takeScreenshot(name: 'cuj_u01_step0_setup');
+
+// Integration test (integration_test/)에서는 binding 사용
+await binding.takeScreenshot('cuj_u01_step0_setup');
+```
+
+### 2. 삽입 원칙
+
+- `pumpWidget()` 직후 → `setup` 캡처
+- `tap()` / `enterText()` 직전 → `before` 캡처 (위저드/다이얼로그만)
+- `pumpAndSettle()` 직후 → `after` 캡처
+- expect에서 에러 UI 검증하는 테스트 → `error` 캡처
+
+### 3. CI 아티팩트
+
+캡처된 스크린샷은 CI에서 아티팩트로 업로드:
+
+```yaml
+- name: Upload screenshots
+  uses: actions/upload-artifact@v7
+  with:
+    name: integration-screenshots-${{ matrix.app }}
+    path: '**/screenshots/*.png'
+```

--- a/docs/qa/test-cases/ci-deploy-tests.md
+++ b/docs/qa/test-cases/ci-deploy-tests.md
@@ -1,0 +1,156 @@
+# CI/CD 배포 파이프라인 테스트 케이스
+
+> 목적: 배포 워크플로우에 필요한 Secret/환경 설정이 누락 없이 구성되어 있는지 검증.
+> Secret 미설정으로 인한 배포 실패(#1433, #1434)를 사전에 탐지한다.
+>
+> 검증 주체: CI 워크플로우 자체 (self-validating) + 수동 체크리스트
+
+---
+
+## 1. 배포 워크플로우별 필수 Secret 매트릭스
+
+### 1.1 Android 배포 (Reusable: `android-deploy-reusable.yml`)
+
+| Secret | User (`android-deploy.yml`) | Partner (`android-deploy-partner.yml`) | 용도 |
+|--------|:---:|:---:|------|
+| `ANDROID_KEYSTORE_BASE64` | **필수** | **필수** | 서명용 keystore (base64) |
+| `ANDROID_KEYSTORE_PASSWORD` | **필수** | **필수** | keystore 비밀번호 |
+| `ANDROID_KEY_PASSWORD` | **필수** | **필수** | key 비밀번호 |
+| `ANDROID_KEY_ALIAS` | **필수** | **필수** | key alias |
+| `SUPABASE_DEV_URL` | **필수** | **필수** | dev 환경 Supabase URL |
+| `SUPABASE_DEV_PUBLISHABLE_KEY` | **필수** | **필수** | dev 환경 Supabase key |
+| `SUPABASE_MAIN_URL` | **필수** | **필수** | prod 환경 Supabase URL |
+| `SUPABASE_MAIN_PUBLISHABLE_KEY` | **필수** | **필수** | prod 환경 Supabase key |
+| `SENTRY_DSN_FLUTTER` | **필수** | **필수** | Sentry 에러 리포팅 DSN |
+| `FIREBASE_APP_ID_ANDROID` | **필수** (DEV) | **필수** (PARTNER_DEV) | Firebase App Distribution ID |
+| `FIREBASE_SERVICE_ACCOUNT_JSON_DEV` | **필수** | **필수** | Firebase 서비스 계정 |
+| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | **필수** | **필수** | Google Play 업로드 |
+| `JUSO_CONFIRM_KEY` | 선택 | **필수** | 행정안전부 도로명주소 API 키 |
+
+> **주의**: `JUSO_CONFIRM_KEY`는 reusable workflow에서 `required: false`로 선언되어 있지만, partner 앱 빌드 시 `Validate JUSO key for partner` 스텝에서 빈 값이면 **빌드 실패**한다. 이 불일치가 #1433/#1434의 근본 원인이었다.
+
+### 1.2 iOS 배포 (Action: `.github/actions/ios-deploy/`)
+
+| Secret | User (`ios-deploy-user.yml`) | Partner (`ios-deploy-partner.yml`) | 용도 |
+|--------|:---:|:---:|------|
+| `APPLE_CERTIFICATE_BASE64` | **필수** | **필수** | Apple 서명 인증서 |
+| `APPLE_CERTIFICATE_PASSWORD` | **필수** | **필수** | 인증서 비밀번호 |
+| `APPLE_PROVISION_PROFILE_*_DEV_BASE64` | **필수** (USER) | **필수** (PARTNER) | dev 프로비저닝 프로파일 |
+| `APPLE_PROVISION_PROFILE_*_BASE64` | **필수** (USER) | **필수** (PARTNER) | prod 프로비저닝 프로파일 |
+| `APP_STORE_CONNECT_API_KEY_BASE64` | **필수** | **필수** | App Store Connect API 키 |
+| `APP_STORE_CONNECT_API_KEY_ID` | **필수** | **필수** | API 키 ID |
+| `APP_STORE_CONNECT_ISSUER_ID` | **필수** | **필수** | 발급자 ID |
+| `SUPABASE_DEV_URL` | **필수** | **필수** | dev 환경 Supabase URL |
+| `SUPABASE_DEV_PUBLISHABLE_KEY` | **필수** | **필수** | dev 환경 Supabase key |
+| `SUPABASE_MAIN_URL` | **필수** | **필수** | prod 환경 Supabase URL |
+| `SUPABASE_MAIN_PUBLISHABLE_KEY` | **필수** | **필수** | prod 환경 Supabase key |
+| `KAKAO_LOCAL_REST_API_KEY` | **필수** | **필수** | 카카오 로컬 REST API |
+| `JUSO_CONFIRM_KEY` | 선택 | **필수** | 행정안전부 도로명주소 API 키 |
+| `SENTRY_DSN_FLUTTER` | **필수** | **필수** | Sentry DSN |
+
+---
+
+## 2. 테스트 시나리오
+
+### 2.1 Secret 존재 검증 (수동 체크리스트)
+
+Secret 추가/변경 시 아래 체크리스트로 검증한다:
+
+| # | 검증 항목 | 명령어 | 기대 결과 |
+|---|----------|--------|-----------|
+| CD-C01 | 전체 Secret 목록 확인 | `gh secret list` | 아래 §3 필수 Secret 전부 존재 |
+| CD-C02 | Partner 전용 Secret 확인 | `gh secret list \| grep JUSO` | `JUSO_CONFIRM_KEY` 존재 |
+| CD-C03 | Firebase App ID 구분 | `gh secret list \| grep FIREBASE_APP_ID` | `_DEV`, `_PARTNER_DEV` 각각 존재 |
+| CD-C04 | Provisioning Profile 구분 | `gh secret list \| grep PROVISION` | `_USER_DEV`, `_USER`, `_PARTNER_DEV`, `_PARTNER` 각각 존재 |
+
+### 2.2 CI 자체 검증 스텝 (워크플로우 내장)
+
+| # | 워크플로우 | 스텝 | 트리거 조건 | 기대 동작 | 실패 시 |
+|---|-----------|------|-----------|-----------|---------|
+| CD-V01 | `android-deploy-reusable.yml` | `Validate JUSO key for partner` | `app-name == 'partner'` | `JUSO_CONFIRM_KEY` 비어있으면 exit 1 | 빌드 중단 + 에러 메시지 |
+| CD-V02 | `.github/actions/ios-deploy/` | `Validate JUSO key for partner` | `app-name == 'partner'` | 동일 | 빌드 중단 + 에러 메시지 |
+| CD-V03 | `android-deploy-reusable.yml` | `Decode Keystore` | 항상 | keystore base64 디코딩 성공 | 서명 실패 → 빌드 에러 |
+| CD-V04 | `ios-deploy` action | `Import signing certificate` | 항상 | 인증서 임포트 성공 | codesign 실패 |
+| CD-V05 | `ios-deploy` action | `Install provisioning profile` | 항상 | UUID 추출 + 설치 성공 | 아카이브 실패 |
+
+### 2.3 배포 실패 알림 검증
+
+| # | 시나리오 | 트리거 | 기대 결과 |
+|---|----------|--------|-----------|
+| CD-N01 | Android Partner 빌드 실패 | `build` job 실패 | `notify-failure.yml` → 이슈 자동 생성 |
+| CD-N02 | iOS Partner 빌드 실패 | `ios-deploy` job 실패 | `notify-failure.yml` → 이슈 자동 생성 |
+| CD-N03 | Android User 빌드 성공 | `build` job 성공 | 알림 이슈 미생성 |
+| CD-N04 | iOS User 빌드 성공 | `ios-deploy` job 성공 | 알림 이슈 미생성 |
+
+### 2.4 환경별 빌드 분기 검증
+
+| # | 시나리오 | 브랜치 | 기대 빌드 산출물 |
+|---|----------|--------|-----------------|
+| CD-B01 | Android dev 빌드 | `dev` | APK (dev flavor, `--release`) + Firebase App Distribution 업로드 |
+| CD-B02 | Android prod 빌드 | `main` | AAB (prod flavor, `--release`) + Google Play internal 업로드 |
+| CD-B03 | iOS dev 빌드 | `dev` | IPA (dev bundle ID `.dev` 접미사) + TestFlight |
+| CD-B04 | iOS prod 빌드 | `main` | IPA (prod bundle ID) + App Store Connect |
+| CD-B05 | iOS dev URL scheme (user only) | `dev` + `app_user` | `minglit-dev://` scheme 추가 |
+| CD-B06 | iOS dev URL scheme (partner) | `dev` + `app_partner` | URL scheme 미추가 |
+
+---
+
+## 3. 필수 Secret 전체 목록 (운영 체크리스트)
+
+새 환경 셋업 또는 Secret 로테이션 시 아래 목록을 확인한다:
+
+### 공통 (User + Partner)
+
+| Secret | 설명 |
+|--------|------|
+| `ANDROID_KEYSTORE_BASE64` | Android 서명 keystore |
+| `ANDROID_KEYSTORE_PASSWORD` | keystore 비밀번호 |
+| `ANDROID_KEY_PASSWORD` | key 비밀번호 |
+| `ANDROID_KEY_ALIAS` | key alias |
+| `APPLE_CERTIFICATE_BASE64` | Apple 서명 인증서 |
+| `APPLE_CERTIFICATE_PASSWORD` | 인증서 비밀번호 |
+| `APP_STORE_CONNECT_API_KEY_BASE64` | App Store Connect API 키 |
+| `APP_STORE_CONNECT_API_KEY_ID` | API 키 ID |
+| `APP_STORE_CONNECT_ISSUER_ID` | 발급자 ID |
+| `SUPABASE_DEV_URL` | dev Supabase URL |
+| `SUPABASE_DEV_PUBLISHABLE_KEY` | dev Supabase publishable key |
+| `SUPABASE_MAIN_URL` | prod Supabase URL |
+| `SUPABASE_MAIN_PUBLISHABLE_KEY` | prod Supabase publishable key |
+| `SENTRY_DSN_FLUTTER` | Sentry DSN |
+| `KAKAO_LOCAL_REST_API_KEY` | 카카오 로컬 REST API |
+| `FIREBASE_SERVICE_ACCOUNT_JSON_DEV` | Firebase 서비스 계정 |
+
+### 앱별 고유
+
+| Secret | 앱 | 설명 |
+|--------|-----|------|
+| `FIREBASE_APP_ID_ANDROID_DEV` | User | Firebase App ID (User dev) |
+| `FIREBASE_APP_ID_ANDROID_PARTNER_DEV` | Partner | Firebase App ID (Partner dev) |
+| `APPLE_PROVISION_PROFILE_USER_DEV_BASE64` | User | iOS dev 프로비저닝 |
+| `APPLE_PROVISION_PROFILE_USER_BASE64` | User | iOS prod 프로비저닝 |
+| `APPLE_PROVISION_PROFILE_PARTNER_DEV_BASE64` | Partner | iOS dev 프로비저닝 |
+| `APPLE_PROVISION_PROFILE_PARTNER_BASE64` | Partner | iOS prod 프로비저닝 |
+| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | 공통 | Google Play 서비스 계정 |
+| `JUSO_CONFIRM_KEY` | **Partner 필수** | 행정안전부 도로명주소 API 키 |
+
+---
+
+## 4. 알려진 취약점 및 개선 제안
+
+| # | 취약점 | 영향 | 제안 |
+|---|--------|------|------|
+| CD-I01 | `JUSO_CONFIRM_KEY`가 reusable workflow에서 `required: false` | Partner 빌드 시 런타임 실패 (빌드 스텝까지 가야 발견) | `required: true`로 변경하거나, partner workflow에서 전달 전 검증 |
+| CD-I02 | User 앱에 `JUSO_CONFIRM_KEY` 전달 안 됨 (android-deploy.yml) | User 앱에서 주소 검색 기능 사용 시 빈 값 → 런타임 에러 가능 | User 앱에서 JUSO API 사용 여부 확인 후 필요 시 추가 |
+| CD-I03 | Secret 만료 모니터링 없음 | Apple 인증서/프로비저닝 만료 시 배포 중단 | 인증서 만료일 체크 워크플로우 추가 (월 1회 cron) |
+
+---
+
+## 5. 총 테스트 케이스 수
+
+| 구분 | 수량 |
+|------|------|
+| Secret 존재 검증 (수동) | 4 |
+| CI 자체 검증 스텝 | 5 |
+| 배포 실패 알림 검증 | 4 |
+| 환경별 빌드 분기 검증 | 6 |
+| **합계** | **19** |

--- a/docs/qa/test-strategy.md
+++ b/docs/qa/test-strategy.md
@@ -307,7 +307,24 @@ Flutter 앱은 Skia/Impeller 엔진으로 단일 `FlutterSurfaceView` 위에 렌
 
 ---
 
-## 8.1 에러/환경/미등록라우트 테스트 케이스 (Phase 2.1 — #1421)
+## 8.1 CI/CD 배포 파이프라인 테스트 (Phase 2.1 — #1433, #1434)
+
+> 2026-04-15 배포 실패 인시던트(#1433 iOS, #1434 Android)로 추가.
+> Partner 앱 배포 시 `JUSO_CONFIRM_KEY` Secret 미설정으로 빌드 실패.
+
+| 문서 | 내용 | 케이스 수 |
+|------|------|-----------|
+| `ci-deploy-tests.md` | 배포 Secret 매트릭스, CI 자체 검증 스텝, 빌드 분기 검증 | 19 |
+
+### 핵심 포인트
+
+- **4개 배포 워크플로우** (Android/iOS × User/Partner)의 필수 Secret을 매트릭스로 정리
+- Partner 전용 Secret (`JUSO_CONFIRM_KEY`)의 `required: false` 선언 불일치 식별 → 개선 제안 포함
+- 배포 실패 알림(`notify-failure.yml`) 동작 검증 케이스 포함
+
+---
+
+## 8.2 에러/환경/미등록라우트 테스트 케이스 (Phase 2.1 — #1421)
 
 > 2026-04-13 갭 분석(#1421) 결과 추가된 테스트 케이스 문서.
 

--- a/docs/qa/test-strategy.md
+++ b/docs/qa/test-strategy.md
@@ -229,20 +229,41 @@ Future<void> pumpApp(
 
 ---
 
-## 6. E2E 테스트 (실물 디바이스) 계획
+## 6. E2E 테스트 (Patrol 통합) 계획
 
-P0 CUJ 중 네이티브 SDK 연동이 필요한 2건은 E2E로만 검증 가능하다:
+> 2026-04-15 업데이트: #1458에서 Patrol 통합 + 스크린샷 내장 결정.
 
-| 시나리오 | 이유 |
-|----------|------|
-| 실제 PG 결제 (Iamport) | 네이티브 WebView + PG SDK 연동 |
-| QR 코드 스캔 (카메라) | 디바이스 카메라 API |
+### 6.1 Patrol 전환 배경
 
-**방향:**
-- 기존 `integration_test/` 디렉토리 활용 (Flutter integration_test driver)
-- Dev 환경 PG 테스트 모드 사용
-- CI에서는 실행하지 않음 (수동 디바이스 테스트)
-- 상세 계획은 Phase 3에서 SWE와 협의
+기존 `IntegrationTestWidgetsFlutterBinding` 기반 E2E는 네이티브 인터랙션(카카오 로그인 WebView, PG 결제, 시스템 권한)을 처리할 수 없었다. Patrol(`patrol_test/` 3개)이 이미 도입되어 있으므로, 전체 integration 테스트를 Patrol로 통합한다.
+
+### 6.2 스크린샷 내장 전략
+
+기존 `scenario_screenshots_test.dart`(정적 화면 캡처)를 제거하고, 각 integration 테스트에 스텝별 `takeScreenshot()`을 삽입한다.
+
+| 항목 | Before | After |
+|------|--------|-------|
+| 스크린샷 위치 | 별도 파일 (scenario_screenshots_test.dart) | 각 테스트 내부 |
+| 캡처 시점 | 정적 화면만 | setup/before/after/error |
+| 네이티브 인터랙션 | 불가 | Patrol로 가능 |
+| 예상 캡처 수 | ~40장 (골든 시나리오) | **~141장** (플로우 중간 상태 포함) |
+
+### 6.3 캡처 포인트 정의
+
+상세 포인트는 `docs/qa/screenshot-capture-points.md` 참고.
+
+| 앱 | 파일 수 | 예상 캡처 수 |
+|----|---------|------------|
+| app_user (CUJ + Flow + 기타) | 25 | ~83 |
+| app_partner (CUJ + 기타) | 11 | ~47 |
+| patrol (E2E 네이티브) | 3 | ~11 |
+| **합계** | **39** | **~141** |
+
+### 6.4 CI 연동
+
+- `patrol-e2e.yml`에 통합 (주 1회 또는 매일)
+- 스크린샷 아티팩트 업로드 → QA 워커가 베이스라인 비교에 활용
+- 네이티브 E2E (카카오 로그인, PG 결제, 권한)는 실물 디바이스에서만 실행
 
 ---
 


### PR DESCRIPTION
Scheduler: needs-qa-claude-1

## Summary

- #1433(iOS)/#1434(Android) Partner 배포 실패 인시던트 후속 QA 산출물
- 4개 배포 워크플로우(Android/iOS × User/Partner)의 **필수 Secret 매트릭스** 정리
- CI 자체 검증 스텝, 빌드 분기, 알림 검증 등 **19건 테스트 시나리오** 정의
- `JUSO_CONFIRM_KEY`의 `required: false` 선언 불일치 등 **3건 개선 제안** 포함
- `test-strategy.md` §8.1 CI/CD 섹션 추가

## 변경 파일

- `docs/qa/test-cases/ci-deploy-tests.md` (신규)
- `docs/qa/test-strategy.md` (§8.1 추가, 기존 §8.1→§8.2 재번호)

## Test plan

- [ ] ci-deploy-tests.md 내 Secret 매트릭스가 실제 워크플로우 파일과 일치하는지 교차 검증
- [ ] test-strategy.md 섹션 번호가 순차적인지 확인

Closes #1433, closes #1434

🤖 Generated with [Claude Code](https://claude.com/claude-code)