### PR TITLE
refactor(test): patrol_test/ → integration_test/ 통합 + Patrol E2E CI 업데이트

### DIFF
--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -1,6 +1,11 @@
 # Patrol E2E Tests — weekly scheduled run (매주 월요일 06:00 UTC).
 # This workflow is NOT part of ci-result and does NOT block PR merges.
 # Failures here are informational only; investigation happens separately.
+#
+# Runs only Patrol-native tests (patrolTest) in integration_test/.
+# scenario_screenshots_test.dart and apple_sign_in_test.dart use
+# IntegrationTestWidgetsFlutterBinding (incompatible with PatrolBinding)
+# and are excluded from this workflow — run them via `flutter test integration_test/`.
 
 name: Patrol E2E
 
@@ -49,7 +54,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true
-          script: cd apps/app_user && patrol test --flavor dev --dart-define-from-file=../../minglit_env/dev/flutter.env patrol_test/
+          script: cd apps/app_user && patrol test --flavor dev --dart-define-from-file=../../minglit_env/dev/flutter.env integration_test/kakao_login_test.dart integration_test/payment_pg_test.dart integration_test/permission_grant_test.dart
 
       - name: Upload test results
         if: failure()

--- a/apps/app_user/integration_test/kakao_login_test.dart
+++ b/apps/app_user/integration_test/kakao_login_test.dart
@@ -3,7 +3,7 @@
 //   - Real device/emulator + patrol_cli
 //   - Kakao test OAuth account credentials (see docs/features/patrol-introduction/)
 //
-// Run: cd apps/app_user && patrol test patrol_test/kakao_login_test.dart
+// Run: cd apps/app_user && patrol test integration_test/kakao_login_test.dart
 
 import 'package:patrol/patrol.dart';
 

--- a/apps/app_user/integration_test/payment_pg_test.dart
+++ b/apps/app_user/integration_test/payment_pg_test.dart
@@ -3,7 +3,7 @@
 //   - Real device/emulator + patrol_cli
 //   - PG sandbox credentials (see docs/features/patrol-introduction/)
 //
-// Run: cd apps/app_user && patrol test patrol_test/payment_pg_test.dart
+// Run: cd apps/app_user && patrol test integration_test/payment_pg_test.dart
 
 import 'package:patrol/patrol.dart';
 

--- a/apps/app_user/integration_test/permission_grant_test.dart
+++ b/apps/app_user/integration_test/permission_grant_test.dart
@@ -1,6 +1,6 @@
 // Phase 2: Native permission tests
 // Requires real device/emulator + patrol_cli to run:
-//   cd apps/app_user && patrol test patrol_test/permission_grant_test.dart
+//   cd apps/app_user && patrol test integration_test/permission_grant_test.dart
 //
 // These tests verify OS-level permission dialogs that cannot be tested
 // with Flutter's integration_test framework.


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1458

## Summary

- `patrol_test/` 하위 3개 Patrol native 테스트를 `integration_test/` 로 이동
- `patrol-e2e.yml` CI 스크립트를 전체 디렉토리 대신 개별 파일 명시로 변경
- `patrol_test/` 디렉토리 제거

## 변경 파일

| 변경 | 내용 |
|------|------|
| `apps/app_user/patrol_test/kakao_login_test.dart` → `integration_test/kakao_login_test.dart` | 디렉토리 이동 + run 경로 주석 업데이트 |
| `apps/app_user/patrol_test/payment_pg_test.dart` → `integration_test/payment_pg_test.dart` | 동일 |
| `apps/app_user/patrol_test/permission_grant_test.dart` → `integration_test/permission_grant_test.dart` | 동일 |
| `.github/workflows/patrol-e2e.yml` | `patrol_test/` → 개별 파일 명시 |

## 기술 결정 근거

`IntegrationTestWidgetsFlutterBinding` (scenario_screenshots, apple_sign_in)과 `PatrolBinding` (kakao_login, payment_pg, permission_grant)은 서로 다른 Flutter 바인딩 계층이다. `patrol test integration_test/` 로 전체 디렉토리를 지정하면 두 바인딩이 혼재해 충돌이 발생하므로 Patrol native 테스트 파일만 개별 지정했다.

## 미구현 항목 (블로커 존재)

이슈 #1458에서 요청한 다음 항목은 별도 추적 필요:

- **IntegrationTestWidgetsFlutterBinding → PatrolIntegrationTester 전환**: Patrol 4.5.0에 `takeScreenshot` API가 없음. PatrolBinding으로 완전 전환 시 `binding.takeScreenshot()` 기능 유실. 해결책 논의 후 구현 필요.
- **CUJ 테스트에 스텝별 스크린샷 삽입**: QA의 캡처 시점 정의(`needs-qa` 작업) 완료 후 구현 예정.

## Test plan

- [ ] CI `patrol-e2e.yml` 수동 실행 — 3개 파일이 `skip: true`이므로 빌드 성공 + 테스트 0건 결과 예상
- [ ] `flutter test apps/app_user` — `integration_test/` 변경 없음, 기존 테스트 정상 통과 확인