### PR TITLE
refactor(simulator): hourly 워크플로우를 tick 모드로 전환

### DIFF
--- a/.github/workflows/hourly-user-activity.yml
+++ b/.github/workflows/hourly-user-activity.yml
@@ -17,16 +17,12 @@ jobs:
     steps:
       - name: Run user activity simulation
         run: |
-          for phase in approve refund run settle; do
-            echo "▶ Running phase: $phase"
-            curl -sf -X POST \
-              "${{ secrets.SUPABASE_DEV_URL }}/functions/v1/backend-simulator" \
-              -H "Authorization: Bearer ${{ secrets.SUPABASE_DEV_SECRET_KEY }}" \
-              -H "Content-Type: application/json" \
-              -d "{\"phase\":\"$phase\",\"config\":{\"apps_per_event\":2}}" \
-              --max-time 120
-            echo "✅ Phase $phase complete"
-          done
+          curl -sf -X POST \
+            "${{ secrets.SUPABASE_DEV_URL }}/functions/v1/backend-simulator" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_DEV_SECRET_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d '{"mode":"tick"}' \
+            --max-time 120
 
   notify-failure:
     needs: [simulate]


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1459

## Summary

`hourly-user-activity.yml`의 구 phase 방식을 tick 모드 단일 호출로 교체.

## 변경 내용

**Before:**
\`\`\`yaml
for phase in approve refund run settle; do
  curl ... -d '{"phase":"$phase","config":{"apps_per_event":2}}'
done
\`\`\`

**After:**
\`\`\`yaml
curl ... -d '{"mode":"tick"}'
\`\`\`

## 개선 효과

- DB 상태 기반 자동 액션 선택 — phase 순서 고정 문제 해소
- create phase 포함 → 이벤트 자동 생성 → 피드 0건(#964) 방지
- `simCompleteEvents` 강제 전환 없음 — scheduled 이벤트 정상 유지
- tick simulator #1355 구현 + #1430 버그픽스 완료 상태를 hourly CI에 반영

## Test plan

- [ ] `workflow_dispatch`로 수동 실행 → tick 모드 정상 동작 확인
- [ ] 이후 1시간 뒤 cron 실행 → events/applications/matches 생성 확인