### PR TITLE
docs: Admin 대시보드 스펙 + 와이어프레임

### DIFF
--- a/docs/features/admin-dashboard/spec.md
+++ b/docs/features/admin-dashboard/spec.md
@@ -1,0 +1,499 @@
+# Admin Dashboard 스펙
+
+**문서 상태:** 초안
+**담당 PM:** needs-pm-claude-1 | **버전:** 1.0.0
+**핵심 전략:** #WorkingBackwards #HypothesisDriven #JTBD #OperationalExcellence
+
+---
+
+## 1. 가상 보도자료 (Working Backwards)
+
+> **[출시일: 2026년 6월]** "오늘 Minglit은 Admin Dashboard를 통해 운영팀이 유저·파트너·이벤트·결제를 하나의 화면에서 관리할 수 있게 되었음을 발표합니다. 이제 수동 DB 쿼리와 Metabase 대시보드를 오가며 운영하던 시대는 끝났습니다. 운영자는 파트너 심사를 평균 3분 내에 완료하고, 환불 처리를 클릭 한 번으로 실행하며, 실시간 KPI를 통해 서비스 건강도를 즉시 파악할 수 있습니다. Minglit의 '신뢰(Trust)' 가치는 운영 효율의 향상으로 더욱 강화됩니다 — 빠른 심사는 파트너의 신뢰를, 신속한 환불은 유저의 신뢰를 높입니다."
+
+---
+
+## 2. 가설 기반 문제 정의 및 신뢰 레이어 설계
+
+### 관측된 문제 (The Pain)
+
+- 파트너 입점 심사, 유저 정지, 환불 처리 등 운영 액션이 DB 직접 접근 또는 Edge Function 수동 호출에 의존
+- Metabase는 조회 전용 — 운영 "액션"을 취할 수 없음
+- 운영자 액션에 대한 감사 로그가 없어 "누가 언제 뭘 했는지" 추적 불가
+- 7월 출시 전 운영 체계가 갖춰지지 않으면 유저 CS 대응 불가
+
+### 핵심 가설
+
+"운영 액션을 하나의 웹 대시보드로 통합하면, 파트너 심사 완료 시간이 현재 대비 70% 단축되고, 환불/정산 오류가 0건에 수렴하며, 감사 로그를 통해 운영 투명성이 확보될 것이다."
+
+### 신뢰 레이어 매핑
+
+- **Layer 1 (Identity):** 유저 관리 — 실존 인물 확인(CI/DI) 상태 조회, 계정 정지/해제
+- **Layer 2 (Qualification):** 파트너 심사 — 사업자등록, 인증 서류 검토 후 승인/거절
+
+---
+
+## 3. 잡 스토리 및 심층 ICP 분석
+
+### ICP 1: 운영 관리자 (Super Admin)
+
+Minglit 운영팀 멤버. 서비스 전체를 관리하며, 유저 CS 대응, 파트너 심사, 결제/정산 관리, KPI 모니터링을 담당.
+
+**Job Story:** "파트너 입점 신청이 들어왔을 때, 나는 사업자 서류를 빠르게 검토하고 승인/거절 처리를 하고 싶다. 왜냐하면 심사 지연은 파트너의 이탈과 첫인상 저하로 직결되기 때문이다."
+
+### ICP 2: 콘텐츠 모더레이터 (Moderator)
+
+파트너 심사와 유저 신고 처리를 담당하는 제한된 역할. 결제/정산/시스템 설정에는 접근 불가.
+
+**Job Story:** "신고가 접수된 유저 프로필을 확인할 때, 해당 유저의 이벤트 참여 이력과 신고 내역을 한 화면에서 보고 싶다. 왜냐하면 맥락 없이 처분을 내리면 오판이 발생하기 때문이다."
+
+### ICP 3: 재무 담당자 (Finance Admin — 향후 확장)
+
+정산/환불에 특화된 역할. P1 단계에서 역할 분리 예정.
+
+**Job Story:** "월말 정산 처리 시, 매칭되지 않은 거래와 미정산 건을 필터링해서 일괄 처리하고 싶다. 왜냐하면 건별 처리는 실수와 누락의 원인이기 때문이다."
+
+---
+
+## 4. 성공 지표, 가드레일 및 도메인 이벤트
+
+### North Star Metric
+
+- **파트너 심사 완료 시간:** 신청 접수 → 승인/거절까지 평균 24시간 이내 (현재: 수일)
+- **환불 처리 시간:** 요청 접수 → 처리 완료까지 평균 1시간 이내
+
+### Counter-Metrics (Guardrails)
+
+- 운영자 실수율 (잘못된 승인/거절) 증가 감시
+- Admin 페이지 로딩 시간 3초 이내 유지
+- 감사 로그 누락률 0% 유지
+
+### 정의할 도메인 이벤트 (Domain Probes)
+
+| 이벤트 | 설명 |
+|--------|------|
+| `admin.login` | 관리자 로그인 (MFA 포함) |
+| `admin.partner_application.reviewed` | 파트너 심사 완료 (approve/reject) |
+| `admin.user.suspended` | 유저 정지 처리 |
+| `admin.user.unsuspended` | 유저 정지 해제 |
+| `admin.refund.processed` | 환불 처리 완료 |
+| `admin.settlement.status_changed` | 정산 상태 변경 |
+| `admin.system_setting.updated` | 시스템 설정 변경 |
+| `admin.event.force_cancelled` | 이벤트 강제 취소 |
+
+---
+
+## 5. 구성 요소
+
+### 5.1 기술 스택
+
+| 항목 | 선택 | 근거 |
+|------|------|------|
+| 프레임워크 | **Next.js** | 기존 landing 프로젝트와 동일 스택, SSR/SSG 지원, 풍부한 admin UI 라이브러리 생태계 |
+| UI 라이브러리 | **Shadcn/UI** | Tailwind 기반, 커스터마이징 용이, 접근성 내장 |
+| 데이터 테이블 | **TanStack Table** | 서버사이드 페이지네이션/필터링/정렬 지원 |
+| 차트 | **Recharts** | 경량, 스파크라인 지원, React 네이티브 |
+| 백엔드 | **Supabase** (기존) | DB/RLS/Edge Functions 재사용 |
+| 인증 | **Supabase Auth + TOTP MFA** | 네이티브 MFA 지원, 추가 인프라 불필요 |
+| 배포 | **Vercel** | 기존 landing과 동일 파이프라인 |
+
+### 5.2 정보 구조 (IA) — Sidebar Navigation
+
+Stripe의 3-tier 사이드바 + Shopify의 7-item 제한 원칙 적용. `app_roles`에 따라 항목 가시성 제어.
+
+```
+Admin Dashboard
+├── 대시보드 (홈)           ← 모든 역할
+├── 유저 관리               ← super_admin
+│   ├── 전체 유저
+│   ├── 인증 완료 유저
+│   └── 신고/정지 유저
+├── 파트너 관리             ← super_admin, moderator
+│   ├── 활성 파트너
+│   ├── 입점 심사            ← 심사 큐
+│   └── 정산 관리            ← super_admin only
+├── 이벤트 관리             ← super_admin
+│   ├── 전체 이벤트
+│   └── 활성 이벤트
+├── 결제/환불               ← super_admin
+│   ├── 거래 내역
+│   └── 환불 처리
+├── 모더레이션              ← super_admin, moderator
+│   ├── 심사 큐
+│   └── 인증 서류 검토
+├── 시스템                  ← super_admin only
+│   ├── 감사 로그
+│   ├── 시스템 설정
+│   └── 알림/알람
+└── 설정                    ← super_admin only
+    └── 관리자 계정/역할
+```
+
+### 5.3 화면별 상세
+
+#### 5.3.1 대시보드 (홈)
+
+Stripe의 KPI 카드 + Linear의 액션 큐 패턴. "지금 뭘 해야 하는가?"에 답하는 화면.
+
+**Row 1: KPI 카드 4개** (F-패턴 스캔, 좌상단 = 가장 중요)
+
+| 카드 | 데이터 소스 | 표시 |
+|------|------------|------|
+| 활성 유저 (7일) | `analytics.daily_active_users` | 수치 + 7일 트렌드 스파크라인 |
+| 대기 중 심사 | `partner_applications WHERE status='pending'` | 건수 + "심사 큐로 →" 링크 |
+| 오늘 매출 | `analytics.daily_revenue` | ₩ 금액 + 전일 대비 % |
+| 미정산 건 | `settlement_items WHERE status='pending'` | 건수 + 총 금액 |
+
+**Row 2: 차트 2개** (2-column)
+
+| 차트 | 타입 | 기간 |
+|------|------|------|
+| 이벤트 신청 현황 | Stacked bar (승인/대기/거절) | 최근 30일 |
+| 매출 트렌드 | Line chart | 최근 30일 |
+
+**Row 3: 액션 큐 2개** (최근 5건)
+
+| 큐 | 내용 |
+|----|------|
+| 모더레이션 큐 | 최신 대기 중 심사/신고 5건, 클릭 시 상세로 이동 |
+| 파트너 입점 심사 | 최신 pending 5건, 클릭 시 심사 상세로 이동 |
+
+#### 5.3.2 유저 관리
+
+**목록 뷰:**
+- **검색:** username, phone, email 통합 검색
+- **필터 바:** 인증 상태 (전체/인증/미인증) | 상태 (전체/활성/정지) | 성별 | 가입일 범위
+- **테이블 컬럼:** 프로필 이미지 | username | 성별 | 나이 | 인증 뱃지 | 가입일 | 최근 활동 | 이벤트 참여 수
+- **페이지네이션:** 서버사이드, 25건/페이지
+- **정렬:** 모든 컬럼 ASC/DESC 토글
+
+**상세 뷰 (사이드 드로어):** — Stripe 패턴, 목록 컨텍스트 유지
+
+| 탭 | 내용 |
+|----|------|
+| 프로필 | 기본 정보, CI/DI 인증 상태, 가입일 |
+| 이벤트 | 참여한 이벤트 목록 (상태, 이벤트명, 날짜) |
+| 결제 | 거래 내역, 환불 이력 |
+| 인증 | 파트너별 인증 제출 내역 |
+| 활동 로그 | 조회/좋아요/구매 등 주요 활동 |
+| 관리 액션 | [정지] [정지 해제] [인증 초기화] — super_admin only |
+
+#### 5.3.3 파트너 심사
+
+**심사 큐 (Linear 워크플로우 패턴):**
+
+상태 파이프라인: `pending` → `approved` / `rejected` / `needs_correction`
+
+- **카드 뷰:** 우선순위 뱃지 | 업체명 | 사업자번호 | 제출일 | 카테고리
+- **필터:** 상태 | 제출일 범위 | 카테고리
+- **Summary bar:** "12건 대기 / 340건 승인 / 5건 거절" — 각 클릭 시 프리필터
+
+**심사 상세 뷰:**
+
+```
+┌─────────────────────────────────────────────────┐
+│ [상태 뱃지: PENDING]  서울라운지                    │
+│ 사업자번호: 123-45-67890 | 제출일: 2026-04-14     │
+├─────────────────────────────────────────────────┤
+│ 좌측: 제출 서류 뷰어                               │
+│ - 사업자등록증 (이미지/PDF 미리보기)                  │
+│ - 대표자 신분증                                    │
+│ - 기타 첨부 서류                                   │
+├─────────────────────────────────────────────────┤
+│ 우측: 심사 액션                                    │
+│ - 관리자 코멘트 (텍스트 입력)                        │
+│ - [승인] [거절 ▾ (사유 선택)] [보완 요청]            │
+└─────────────────────────────────────────────────┘
+```
+
+#### 5.3.4 이벤트 관리
+
+**목록 뷰:**
+- **검색:** 이벤트명, 파트너명 통합 검색
+- **필터:** 상태 (draft/active/closed/cancelled) | 날짜 범위 | 파트너 | 카테고리
+- **테이블 컬럼:** 이벤트명 | 파트너 | 상태 뱃지 | 날짜 | 참가 신청 수 | 매출
+- **액션:** [강제 취소] [숨김 처리] — 확인 다이얼로그 필수
+
+**상세 뷰:**
+- 이벤트 기본 정보 (파티 정보 포함)
+- 티켓별 판매 현황
+- 참가 신청 목록 (상태별)
+- 관련 결제 내역
+
+#### 5.3.5 결제/환불
+
+**거래 내역:**
+- **필터:** 상태 | 결제일 범위 | 금액 범위 | 파트너
+- **테이블:** 거래 ID | 유저 | 이벤트 | 금액 | 상태 | 결제일
+- **상세:** Portone 결제 정보, 환불 이력
+
+**환불 처리:**
+- **대기 큐:** 환불 요청 건 목록
+- **처리 뷰:** 원결제 정보 | 환불 사유 | 환불 금액 (부분 환불 지원) | [환불 실행]
+- **Portone API 연동:** 실제 환불은 Portone API를 통해 처리
+
+#### 5.3.6 정산 관리
+
+**정산 항목 목록:**
+- **필터:** 상태 (pending/confirmed/paid/cancelled) | 정산 기간 | 파트너
+- **테이블:** 정산 ID | 파트너 | 총 매출 | 수수료 | 정산액 | 상태 | 정산일
+- **일괄 처리:** 체크박스 선택 → [일괄 확정] [일괄 지급 처리]
+
+**정산 상세:**
+- 정산 항목별 거래 내역
+- 조정 항목 (환불, 수수료 등)
+- 정산 이력 (status 변경 타임라인)
+- 지급 정보 (은행/계좌)
+
+#### 5.3.7 신고 처리
+
+**신고 큐:**
+- **상태:** open → investigating → resolved / dismissed
+- **카드:** 신고 유형 | 대상 유저/이벤트 | 신고자 | 접수일
+- **상세:** 신고 내용 | 대상 프로필/이벤트 | 이전 신고 이력 | [경고] [정지] [해제]
+
+#### 5.3.8 시스템 설정
+
+- **환불 정책 편집:** `policies` 테이블 — 버전 관리, 변경 이력
+- **약관 버전 관리:** 이용약관, 개인정보처리방침, 위치정보 이용약관
+- **시스템 설정값:** `system_settings` 테이블 — key/value 편집 UI
+- **알림 설정:** `settlement_alarm_results` — 알람 임계값 설정
+
+#### 5.3.9 감사 로그
+
+모든 관리 액션의 불변(immutable) 로그.
+
+- **테이블:** 시각 | 관리자 | 액션 유형 | 대상 | 변경 전/후 | IP
+- **필터:** 관리자 | 액션 유형 | 대상 테이블 | 날짜 범위
+- **데이터 소스:** 신규 `admin_audit_logs` 테이블 (아래 데이터 소스 섹션 참고)
+
+#### 5.3.10 KPI 대시보드 (상세)
+
+대시보드 홈의 확장 버전. Metabase 대체가 아닌 보완.
+
+| 차트 | 소스 | 타입 |
+|------|------|------|
+| DAU/WAU/MAU 트렌드 | `analytics.daily_active_users` | Line chart |
+| 신규 가입 트렌드 | `analytics.funnel_daily` | Line chart |
+| 매출 (일/주/월) | `analytics.daily_revenue` | Bar chart |
+| 이벤트 현황 | `analytics.daily_events` | Stacked bar |
+| 전환 퍼널 | `analytics.funnel_daily` | Funnel chart |
+| 환불률 | `analytics.daily_revenue` (gross vs refunds) | Line chart |
+
+---
+
+## 6. 보안 요구사항
+
+### 인증 (Authentication)
+
+| 항목 | 사양 |
+|------|------|
+| 기본 인증 | Supabase Auth (이메일/비밀번호) |
+| MFA | TOTP 필수 — Supabase Auth 네이티브 지원 |
+| 세션 타임아웃 | 유휴 30분, 절대 8시간 |
+| IP 화이트리스트 | P1 (선택적, `system_settings`에서 관리) |
+
+### 인가 (Authorization)
+
+기존 `app_roles` 테이블 활용. RLS 정책으로 DB 레벨 접근 제어.
+
+| 역할 | 접근 범위 |
+|------|----------|
+| `super_admin` | 전체 접근 — 유저/파트너/이벤트/결제/정산/시스템/감사로그 |
+| `moderator` | 제한 접근 — 파트너 심사, 모더레이션 큐, 유저 프로필 (읽기 전용) |
+
+### 감사 로그
+
+신규 테이블 `admin_audit_logs` 생성:
+
+```sql
+CREATE TABLE admin_audit_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  admin_user_id UUID NOT NULL REFERENCES auth.users(id),
+  action_type TEXT NOT NULL,        -- 'partner_application.approved', 'user.suspended', etc.
+  target_table TEXT NOT NULL,       -- 'partner_applications', 'user_profiles', etc.
+  target_id UUID,
+  old_values JSONB,
+  new_values JSONB,
+  ip_address INET,
+  user_agent TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- 불변성 보장: UPDATE/DELETE 불가
+-- RLS: super_admin만 SELECT 가능
+```
+
+---
+
+## 7. 데이터 소스
+
+### 기존 테이블 (재사용)
+
+| 테이블 | 용도 |
+|--------|------|
+| `app_roles` | 관리자 역할 (super_admin/moderator) |
+| `user_profiles` | 유저 기본 정보 |
+| `partner_applications` | 파트너 입점 심사 |
+| `partners` | 파트너 조직 정보 |
+| `parties` | 파티(이벤트 그룹) 정보 |
+| `events` | 개별 이벤트 |
+| `event_applications` | 이벤트 참가 신청 |
+| `tickets` | 티켓 정보 |
+| `settlement_items` | 정산 항목 |
+| `payouts` | 지급 정보 |
+| `settlement_histories` | 정산 이력 |
+| `adjustment_items` | 조정(환불 등) 항목 |
+| `reconciliation_runs` | 일일 대사 |
+| `system_settings` | 시스템 설정 KV |
+| `policies` | 정책/약관 버전 관리 |
+| `verification_submissions` | 인증 서류 제출 |
+| `settlement_alarm_results` | 시스템 알람 |
+| `analytics.daily_active_users` | DAU 메트릭 |
+| `analytics.daily_revenue` | 일매출 |
+| `analytics.daily_events` | 이벤트 볼륨 |
+| `analytics.funnel_daily` | 전환 퍼널 |
+
+### 신규 테이블
+
+| 테이블 | 용도 |
+|--------|------|
+| `admin_audit_logs` | 관리 액션 감사 로그 (위 스키마 참고) |
+
+### API 연동
+
+| API | 용도 |
+|-----|------|
+| Portone API | 결제 조회, 환불 처리 |
+| Supabase Auth Admin API | MFA 관리, 세션 관리 |
+
+---
+
+## 8. 라우트 변경
+
+### 신규 라우트 (Next.js App Router)
+
+```
+/admin
+├── /                        → 대시보드 (홈)
+├── /users                   → 유저 목록
+├── /users/[id]              → 유저 상세
+├── /partners                → 파트너 목록
+├── /partners/applications   → 입점 심사 큐
+├── /partners/applications/[id] → 심사 상세
+├── /partners/settlements    → 정산 관리
+├── /partners/settlements/[id]  → 정산 상세
+├── /events                  → 이벤트 목록
+├── /events/[id]             → 이벤트 상세
+├── /payments                → 거래 내역
+├── /payments/refunds        → 환불 처리
+├── /moderation              → 모더레이션 큐
+├── /moderation/[id]         → 신고 상세
+├── /system/audit-log        → 감사 로그
+├── /system/settings         → 시스템 설정
+├── /system/alarms           → 알림/알람
+├── /settings/roles          → 관리자 계정/역할
+└── /login                   → 로그인 (MFA 포함)
+```
+
+### 기존 라우트 변경: 없음
+
+Admin은 독립 웹앱으로 기존 Flutter 앱 라우트에 영향 없음.
+
+---
+
+## 9. 에러/로딩 상태
+
+| 섹션 | 로딩 | 빈 상태 | 에러 |
+|------|------|---------|------|
+| 대시보드 KPI | Shimmer 카드 (Stripe 패턴) | N/A (항상 데이터 있음) | "데이터를 불러올 수 없습니다. 새로고침해주세요." |
+| 데이터 테이블 | Skeleton rows (5행) | "조건에 맞는 데이터가 없습니다." + 필터 초기화 버튼 | "데이터 로딩 실패. 잠시 후 다시 시도해주세요." + 재시도 버튼 |
+| 심사 큐 | Skeleton cards | "처리할 심사 건이 없습니다 🎉" | 재시도 안내 |
+| 서류 뷰어 | Spinner | "첨부된 서류가 없습니다." | "서류를 불러올 수 없습니다." + 다운로드 링크 |
+| 차트 | Shimmer chart area | "아직 데이터가 충분하지 않습니다." | 차트 영역에 에러 텍스트 |
+| 환불 실행 | 버튼 로딩 스피너 | N/A | Toast: "환불 처리에 실패했습니다. Portone 상태를 확인해주세요." |
+
+---
+
+## 10. 핵심 요구사항 및 비목표
+
+### P0 (Must — 7월 출시 필수)
+
+1. **로그인 + MFA** — Supabase Auth TOTP, 역할 기반 사이드바 렌더링
+2. **대시보드 홈** — KPI 카드 4개 + 차트 2개 + 액션 큐 2개
+3. **유저 관리** — 목록/검색/필터 + 상세 드로어 + 정지/해제
+4. **파트너 심사** — 심사 큐 + 서류 뷰어 + 승인/거절/보완 요청
+5. **이벤트 관리** — 목록/검색/필터 + 강제 취소/숨김
+6. **결제/환불** — 거래 내역 조회 + 수동 환불 (Portone API)
+7. **정산 관리** — 상태 조회/전환 + 지급 처리
+8. **감사 로그** — 모든 관리 액션 기록, 조회 UI
+
+### P1 (Should — 출시 후 1개월)
+
+9. **신고 처리** — 신고 큐 + 처리 워크플로우
+10. **시스템 설정** — 환불 정책, 약관 버전 관리
+11. **인증 서류 미리보기/심사** — 이미지/PDF 인라인 뷰어
+12. **일괄 처리** — 정산 일괄 확정/지급, 심사 일괄 처리
+13. **IP 화이트리스트** — 선택적 접근 제한
+
+### P2 (Nice to have)
+
+14. 공지/푸시 발송
+15. 파트너 멤버 권한 관리
+16. 매칭 성공률/환불률 심층 분석
+17. 크론잡 모니터링
+18. 실시간 알림 (Supabase Realtime)
+
+### Non-Goals (하지 않을 것)
+
+- **Metabase 대체:** Admin은 운영 "액션" 도구. 분석/BI는 Metabase 유지.
+- **유저/파트너 앱 기능 복제:** 앱에서 가능한 건 앱에서. Admin은 운영자 전용 액션만.
+- **자동 심사:** AI 기반 자동 승인/거절은 범위 밖. 사람이 판단하고 도구가 실행.
+- **모바일 최적화:** Admin은 데스크톱 웹 전용. 태블릿은 반응형으로 최소 지원.
+- **다국어:** 초기 버전은 한국어 단일 언어.
+
+---
+
+## 11. 구현 이슈 분할 (예상)
+
+순서대로 진행. 각 이슈는 독립 배포 가능하도록 설계.
+
+| # | 제목 | 의존성 | 우선순위 |
+|---|------|--------|---------|
+| 1 | Admin 프로젝트 초기 설정 (Next.js + Shadcn/UI + Supabase) | 없음 | P0 |
+| 2 | 인증 — 로그인 + TOTP MFA + 역할 기반 라우팅 | #1 | P0 |
+| 3 | 감사 로그 테이블 + 미들웨어 | #2 | P0 |
+| 4 | 대시보드 홈 — KPI 카드 + 차트 + 액션 큐 | #2 | P0 |
+| 5 | 유저 관리 — 목록/검색/상세/정지 | #2, #3 | P0 |
+| 6 | 파트너 심사 — 큐 + 서류 뷰어 + 심사 액션 | #2, #3 | P0 |
+| 7 | 이벤트 관리 — 목록/검색/강제 취소 | #2, #3 | P0 |
+| 8 | 결제/환불 — 거래 조회 + Portone 환불 | #2, #3 | P0 |
+| 9 | 정산 관리 — 상태 조회/전환/지급 | #2, #3 | P0 |
+| 10 | 신고 처리 — 큐 + 워크플로우 | #2, #3 | P1 |
+| 11 | 시스템 설정 — 정책/약관/설정값 편집 | #2 | P1 |
+| 12 | 일괄 처리 + 고급 필터링 | #5-9 | P1 |
+
+---
+
+## 12. 참고 문헌 및 방법론 근거
+
+### 시장 조사 참고 앱
+
+| 앱 | 참고 포인트 | 적용 |
+|----|-----------|------|
+| **Stripe Dashboard** | KPI 카드 + 스파크라인, 사이드 드로어 상세, shimmer 로딩 | 대시보드 홈, 유저/결제 상세 뷰 |
+| **Shopify Admin (Polaris)** | 축소형 사이드바, 7-item 제한, 명사형 네비게이션 | IA 설계, 사이드바 구조 |
+| **Linear** | 상태 파이프라인, 키보드 퍼스트, 최소 UI | 심사 큐 워크플로우, 모더레이션 |
+| **Retool/Appsmith** | 서버사이드 필터/정렬/페이지네이션, 벌크 액션 | 데이터 테이블 패턴 |
+| **Airbnb Host Dashboard** | 파트너 퍼포먼스 뷰, 심사 워크플로우 | 파트너 관리 구조 |
+
+### 방법론
+
+1. **Ian McAllister (Amazon):** "Working Backwards: The PR/FAQ Process"
+2. **Marty Cagan (SVPG):** "Inspired: How to Create Tech Products Customers Love"
+3. **Minglit Architecture Guide:** Section 5 (Trust & Verification Architecture)
+4. **Minglit Engineering Principles:** Section 1 (Domain-Oriented Observability)
+
+### Confidence & Scope Risk
+
+- **Confidence:** High — 기존 DB 스키마/RLS/Edge Functions 재사용, 검증된 기술 스택
+- **Scope Risk:** Moderate — 8개 P0 화면은 많지만, 패턴이 반복적 (목록+상세+액션). 정산/환불의 Portone API 연동이 가장 큰 리스크.

--- a/docs/features/admin-dashboard/wireframe.html
+++ b/docs/features/admin-dashboard/wireframe.html
@@ -1,0 +1,2023 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Minglit Admin Dashboard — Wireframe</title>
+<style>
+  :root {
+    /* Minglit Design Tokens */
+    --primary: #9900FF;
+    --primary-light: #E8D5FF;
+    --secondary: #FF9900;
+    --tertiary: #48C9B0;
+    --success: #22C55E;
+    --error: #EF4444;
+    --warning: #F59E0B;
+    --bg: #FFFFFF;
+    --surface: #F9FAFB;
+    --surface-alt: #F3F4F6;
+    --border: #E5E7EB;
+    --text-primary: #111827;
+    --text-secondary: #4B5563;
+    --text-tertiary: #9CA3AF;
+    /* Spacing */
+    --sp-xs: 4px;
+    --sp-sm: 8px;
+    --sp-md: 12px;
+    --sp-base: 16px;
+    --sp-lg: 24px;
+    --sp-xl: 32px;
+    --sp-2xl: 40px;
+    /* Radius */
+    --r-sm: 8px;
+    --r-md: 12px;
+    --r-lg: 16px;
+    /* Typography */
+    --font: 'Pretendard', 'Noto Sans KR', -apple-system, sans-serif;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: var(--font);
+    color: var(--text-primary);
+    background: var(--surface);
+    line-height: 1.5;
+  }
+
+  /* === Layout === */
+  .app { display: flex; min-height: 100vh; }
+
+  .sidebar {
+    width: 260px;
+    background: var(--bg);
+    border-right: 1px solid var(--border);
+    padding: var(--sp-base) 0;
+    flex-shrink: 0;
+    position: sticky;
+    top: 0;
+    height: 100vh;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .sidebar-logo {
+    padding: var(--sp-sm) var(--sp-base) var(--sp-lg);
+    display: flex;
+    align-items: center;
+    gap: var(--sp-sm);
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--primary);
+    border-bottom: 1px solid var(--border);
+    margin-bottom: var(--sp-base);
+  }
+
+  .sidebar-logo .badge {
+    font-size: 11px;
+    font-weight: 500;
+    background: var(--primary-light);
+    color: var(--primary);
+    padding: 2px 8px;
+    border-radius: 99px;
+  }
+
+  .sidebar-section {
+    padding: var(--sp-xs) var(--sp-base);
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-tertiary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-top: var(--sp-md);
+  }
+
+  .sidebar-item {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-sm);
+    padding: var(--sp-sm) var(--sp-base);
+    font-size: 14px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: all 0.15s;
+    border-left: 3px solid transparent;
+  }
+
+  .sidebar-item:hover { background: var(--surface); color: var(--text-primary); }
+  .sidebar-item.active {
+    background: var(--primary-light);
+    color: var(--primary);
+    font-weight: 600;
+    border-left-color: var(--primary);
+  }
+
+  .sidebar-item .count {
+    margin-left: auto;
+    font-size: 12px;
+    font-weight: 600;
+    background: var(--error);
+    color: white;
+    padding: 1px 7px;
+    border-radius: 99px;
+    min-width: 22px;
+    text-align: center;
+  }
+
+  .sidebar-item .icon { width: 20px; text-align: center; font-size: 16px; }
+
+  .sidebar-footer {
+    margin-top: auto;
+    padding: var(--sp-base);
+    border-top: 1px solid var(--border);
+  }
+
+  .admin-profile {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-sm);
+    font-size: 13px;
+  }
+
+  .admin-avatar {
+    width: 32px; height: 32px;
+    border-radius: 50%;
+    background: var(--primary);
+    color: white;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 13px; font-weight: 600;
+  }
+
+  .admin-name { font-weight: 600; }
+  .admin-role { font-size: 11px; color: var(--text-tertiary); }
+
+  /* === Main Content === */
+  .main {
+    flex: 1;
+    padding: var(--sp-lg) var(--sp-xl);
+    max-width: 1280px;
+  }
+
+  .page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--sp-lg);
+  }
+
+  .page-title { font-size: 24px; font-weight: 700; }
+  .page-subtitle { font-size: 14px; color: var(--text-secondary); margin-top: 2px; }
+
+  /* === Screen Tabs (for wireframe navigation) === */
+  .screen-tabs {
+    display: flex;
+    gap: var(--sp-xs);
+    padding: var(--sp-base);
+    background: var(--bg);
+    border-bottom: 1px solid var(--border);
+    overflow-x: auto;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+  }
+
+  .screen-tab {
+    padding: var(--sp-sm) var(--sp-base);
+    font-size: 13px;
+    font-weight: 500;
+    border-radius: var(--r-sm);
+    cursor: pointer;
+    white-space: nowrap;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--text-secondary);
+    transition: all 0.15s;
+  }
+
+  .screen-tab:hover { border-color: var(--primary); color: var(--primary); }
+  .screen-tab.active { background: var(--primary); color: white; border-color: var(--primary); }
+
+  .screen { display: none; }
+  .screen.active { display: block; }
+
+  /* === KPI Cards === */
+  .kpi-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: var(--sp-base);
+    margin-bottom: var(--sp-lg);
+  }
+
+  .kpi-card {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    padding: var(--sp-lg);
+  }
+
+  .kpi-label { font-size: 13px; color: var(--text-secondary); font-weight: 500; }
+
+  .kpi-value {
+    font-size: 28px;
+    font-weight: 700;
+    margin: var(--sp-xs) 0;
+  }
+
+  .kpi-trend {
+    font-size: 13px;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .kpi-trend.up { color: var(--success); }
+  .kpi-trend.down { color: var(--error); }
+
+  .kpi-sparkline {
+    height: 32px;
+    margin-top: var(--sp-sm);
+    background: linear-gradient(90deg, var(--primary-light) 0%, var(--primary-light) 100%);
+    border-radius: var(--r-sm);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .kpi-sparkline::after {
+    content: '';
+    position: absolute;
+    bottom: 0; left: 0; right: 0;
+    height: 60%;
+    background: linear-gradient(90deg,
+      transparent 0%, var(--primary) 10%, var(--primary) 12%,
+      transparent 14%, transparent 20%, var(--primary) 25%,
+      var(--primary) 27%, transparent 30%, transparent 40%,
+      var(--primary) 45%, transparent 50%, transparent 55%,
+      var(--primary) 60%, var(--primary) 62%, transparent 65%,
+      transparent 70%, var(--primary) 78%, transparent 82%,
+      transparent 88%, var(--primary) 95%, var(--primary) 100%
+    );
+    opacity: 0.3;
+  }
+
+  /* === Charts === */
+  .chart-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--sp-base);
+    margin-bottom: var(--sp-lg);
+  }
+
+  .chart-card {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    padding: var(--sp-lg);
+  }
+
+  .chart-title { font-size: 15px; font-weight: 600; margin-bottom: var(--sp-base); }
+
+  .chart-placeholder {
+    height: 180px;
+    background: var(--surface);
+    border-radius: var(--r-sm);
+    display: flex;
+    align-items: flex-end;
+    padding: var(--sp-sm);
+    gap: var(--sp-xs);
+  }
+
+  .chart-bar {
+    flex: 1;
+    border-radius: 4px 4px 0 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+  }
+
+  .chart-bar .approved { background: var(--success); border-radius: 4px 4px 0 0; }
+  .chart-bar .pending { background: var(--warning); }
+  .chart-bar .rejected { background: var(--error); border-radius: 0; }
+
+  .chart-line-placeholder {
+    height: 180px;
+    background: var(--surface);
+    border-radius: var(--r-sm);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .chart-line-placeholder::after {
+    content: '';
+    position: absolute;
+    bottom: 20%; left: 5%; right: 5%;
+    height: 2px;
+    background: var(--primary);
+    transform: rotate(-3deg);
+    box-shadow: 0 -20px 0 0 rgba(153, 0, 255, 0.05),
+                0 -40px 0 0 rgba(153, 0, 255, 0.03);
+  }
+
+  /* === Action Queues === */
+  .queue-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--sp-base);
+  }
+
+  .queue-card {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    padding: var(--sp-lg);
+  }
+
+  .queue-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--sp-base);
+  }
+
+  .queue-title { font-size: 15px; font-weight: 600; }
+  .queue-link { font-size: 13px; color: var(--primary); font-weight: 500; cursor: pointer; }
+
+  .queue-item {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-sm);
+    padding: var(--sp-sm) 0;
+    border-bottom: 1px solid var(--surface-alt);
+    font-size: 14px;
+  }
+
+  .queue-item:last-child { border-bottom: none; }
+
+  .queue-badge {
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 99px;
+  }
+
+  .badge-pending { background: #FEF3C7; color: #92400E; }
+  .badge-approved { background: #D1FAE5; color: #065F46; }
+  .badge-rejected { background: #FEE2E2; color: #991B1B; }
+  .badge-open { background: #DBEAFE; color: #1E40AF; }
+
+  .queue-item-meta { margin-left: auto; font-size: 12px; color: var(--text-tertiary); }
+
+  /* === Data Table === */
+  .table-toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--sp-base);
+    gap: var(--sp-sm);
+    flex-wrap: wrap;
+  }
+
+  .filter-group { display: flex; gap: var(--sp-sm); flex-wrap: wrap; }
+
+  .filter-select, .filter-input {
+    padding: var(--sp-sm) var(--sp-md);
+    border: 1px solid var(--border);
+    border-radius: var(--r-sm);
+    font-size: 13px;
+    background: var(--bg);
+    color: var(--text-primary);
+    font-family: var(--font);
+  }
+
+  .filter-input { width: 240px; }
+
+  .btn {
+    padding: var(--sp-sm) var(--sp-base);
+    border: none;
+    border-radius: var(--r-md);
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    font-family: var(--font);
+    transition: all 0.15s;
+  }
+
+  .btn-primary { background: var(--primary); color: white; }
+  .btn-primary:hover { background: #7700CC; }
+  .btn-secondary { background: var(--surface); color: var(--text-primary); border: 1px solid var(--border); }
+  .btn-danger { background: var(--error); color: white; }
+  .btn-success { background: var(--success); color: white; }
+  .btn-warning { background: var(--warning); color: white; }
+
+  .summary-bar {
+    display: flex;
+    gap: var(--sp-base);
+    margin-bottom: var(--sp-base);
+    font-size: 14px;
+  }
+
+  .summary-item {
+    cursor: pointer;
+    padding: var(--sp-sm) var(--sp-base);
+    border-radius: var(--r-sm);
+    background: var(--surface);
+    transition: all 0.15s;
+  }
+
+  .summary-item:hover { background: var(--primary-light); }
+  .summary-item .num { font-weight: 700; }
+
+  .data-table {
+    width: 100%;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    overflow: hidden;
+  }
+
+  .data-table table { width: 100%; border-collapse: collapse; }
+
+  .data-table th {
+    text-align: left;
+    padding: var(--sp-md) var(--sp-base);
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-tertiary);
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    cursor: pointer;
+  }
+
+  .data-table th:hover { color: var(--text-primary); }
+  .data-table th .sort { font-size: 10px; margin-left: 4px; }
+
+  .data-table td {
+    padding: var(--sp-md) var(--sp-base);
+    font-size: 14px;
+    border-bottom: 1px solid var(--surface-alt);
+  }
+
+  .data-table tr:hover td { background: var(--surface); }
+  .data-table tr:last-child td { border-bottom: none; }
+
+  .user-cell {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-sm);
+  }
+
+  .user-avatar {
+    width: 32px; height: 32px;
+    border-radius: 50%;
+    background: var(--surface-alt);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 14px;
+  }
+
+  .status-badge {
+    display: inline-block;
+    font-size: 12px;
+    font-weight: 600;
+    padding: 2px 10px;
+    border-radius: 99px;
+  }
+
+  .status-active { background: #D1FAE5; color: #065F46; }
+  .status-suspended { background: #FEE2E2; color: #991B1B; }
+  .status-pending { background: #FEF3C7; color: #92400E; }
+  .status-verified { background: #DBEAFE; color: #1E40AF; }
+
+  .pagination {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--sp-md) var(--sp-base);
+    font-size: 13px;
+    color: var(--text-secondary);
+  }
+
+  .page-btns { display: flex; gap: var(--sp-xs); }
+
+  .page-btn {
+    width: 32px; height: 32px;
+    display: flex; align-items: center; justify-content: center;
+    border: 1px solid var(--border);
+    border-radius: var(--r-sm);
+    font-size: 13px;
+    cursor: pointer;
+    background: var(--bg);
+  }
+
+  .page-btn.active { background: var(--primary); color: white; border-color: var(--primary); }
+
+  /* === Detail Drawer === */
+  .drawer-overlay {
+    display: flex;
+    gap: var(--sp-base);
+    margin-top: var(--sp-lg);
+  }
+
+  .drawer {
+    width: 420px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    flex-shrink: 0;
+  }
+
+  .drawer-header {
+    padding: var(--sp-lg);
+    border-bottom: 1px solid var(--border);
+  }
+
+  .drawer-user {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-md);
+  }
+
+  .drawer-avatar {
+    width: 48px; height: 48px;
+    border-radius: 50%;
+    background: var(--primary-light);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 20px;
+  }
+
+  .drawer-name { font-size: 18px; font-weight: 700; }
+  .drawer-meta { font-size: 13px; color: var(--text-secondary); }
+
+  .drawer-tabs {
+    display: flex;
+    border-bottom: 1px solid var(--border);
+    padding: 0 var(--sp-base);
+  }
+
+  .drawer-tab {
+    padding: var(--sp-md) var(--sp-base);
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+  }
+
+  .drawer-tab.active {
+    color: var(--primary);
+    border-bottom-color: var(--primary);
+    font-weight: 600;
+  }
+
+  .drawer-body { padding: var(--sp-lg); }
+
+  .drawer-field {
+    display: flex;
+    justify-content: space-between;
+    padding: var(--sp-sm) 0;
+    font-size: 14px;
+    border-bottom: 1px solid var(--surface-alt);
+  }
+
+  .drawer-field-label { color: var(--text-secondary); }
+  .drawer-field-value { font-weight: 500; }
+
+  .drawer-actions {
+    padding: var(--sp-base) var(--sp-lg);
+    border-top: 1px solid var(--border);
+    display: flex;
+    gap: var(--sp-sm);
+  }
+
+  /* === Review Screen === */
+  .review-layout {
+    display: grid;
+    grid-template-columns: 1fr 380px;
+    gap: var(--sp-lg);
+  }
+
+  .doc-viewer {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    padding: var(--sp-lg);
+  }
+
+  .doc-preview {
+    height: 400px;
+    background: var(--surface);
+    border-radius: var(--r-sm);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-tertiary);
+    font-size: 14px;
+    flex-direction: column;
+    gap: var(--sp-sm);
+  }
+
+  .doc-preview .icon { font-size: 48px; }
+
+  .doc-tabs {
+    display: flex;
+    gap: var(--sp-sm);
+    margin-bottom: var(--sp-base);
+  }
+
+  .doc-tab {
+    padding: var(--sp-sm) var(--sp-md);
+    font-size: 13px;
+    border: 1px solid var(--border);
+    border-radius: var(--r-sm);
+    cursor: pointer;
+    background: var(--bg);
+  }
+
+  .doc-tab.active { background: var(--primary); color: white; border-color: var(--primary); }
+
+  .review-panel {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    padding: var(--sp-lg);
+  }
+
+  .review-info { margin-bottom: var(--sp-lg); }
+
+  .review-info-item {
+    display: flex;
+    justify-content: space-between;
+    padding: var(--sp-sm) 0;
+    font-size: 14px;
+    border-bottom: 1px solid var(--surface-alt);
+  }
+
+  .review-info-label { color: var(--text-secondary); }
+
+  .review-comment {
+    width: 100%;
+    min-height: 100px;
+    padding: var(--sp-md);
+    border: 1px solid var(--border);
+    border-radius: var(--r-sm);
+    font-family: var(--font);
+    font-size: 14px;
+    resize: vertical;
+    margin-bottom: var(--sp-base);
+  }
+
+  .review-actions {
+    display: flex;
+    gap: var(--sp-sm);
+  }
+
+  .review-actions .btn { flex: 1; padding: var(--sp-md); }
+
+  /* === Login Screen === */
+  .login-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    background: var(--surface);
+  }
+
+  .login-card {
+    width: 400px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    padding: var(--sp-xl);
+  }
+
+  .login-logo {
+    text-align: center;
+    font-size: 24px;
+    font-weight: 700;
+    color: var(--primary);
+    margin-bottom: var(--sp-lg);
+  }
+
+  .login-logo .sub { font-size: 14px; color: var(--text-secondary); font-weight: 400; }
+
+  .form-group {
+    margin-bottom: var(--sp-base);
+  }
+
+  .form-label {
+    display: block;
+    font-size: 13px;
+    font-weight: 600;
+    margin-bottom: var(--sp-xs);
+    color: var(--text-secondary);
+  }
+
+  .form-input {
+    width: 100%;
+    padding: var(--sp-md);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    font-size: 14px;
+    font-family: var(--font);
+  }
+
+  .form-input:focus { outline: none; border-color: var(--primary); box-shadow: 0 0 0 3px var(--primary-light); }
+
+  .login-btn {
+    width: 100%;
+    padding: var(--sp-md);
+    background: var(--primary);
+    color: white;
+    border: none;
+    border-radius: var(--r-md);
+    font-size: 15px;
+    font-weight: 600;
+    cursor: pointer;
+    font-family: var(--font);
+  }
+
+  .mfa-section {
+    margin-top: var(--sp-lg);
+    padding-top: var(--sp-lg);
+    border-top: 1px solid var(--border);
+  }
+
+  .mfa-digits {
+    display: flex;
+    gap: var(--sp-sm);
+    justify-content: center;
+    margin: var(--sp-base) 0;
+  }
+
+  .mfa-digit {
+    width: 48px; height: 56px;
+    border: 2px solid var(--border);
+    border-radius: var(--r-md);
+    text-align: center;
+    font-size: 24px;
+    font-weight: 700;
+    font-family: var(--font);
+  }
+
+  .mfa-digit:focus { border-color: var(--primary); outline: none; }
+
+  /* === Audit Log === */
+  .log-entry {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--sp-md);
+    padding: var(--sp-md) var(--sp-base);
+    border-bottom: 1px solid var(--surface-alt);
+    font-size: 14px;
+  }
+
+  .log-icon {
+    width: 32px; height: 32px;
+    border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 14px;
+    flex-shrink: 0;
+  }
+
+  .log-icon.approve { background: #D1FAE5; }
+  .log-icon.reject { background: #FEE2E2; }
+  .log-icon.suspend { background: #FEF3C7; }
+  .log-icon.setting { background: #DBEAFE; }
+  .log-icon.refund { background: #E8D5FF; }
+
+  .log-content { flex: 1; }
+  .log-action { font-weight: 500; }
+  .log-target { color: var(--primary); font-weight: 500; }
+  .log-time { font-size: 12px; color: var(--text-tertiary); margin-top: 2px; }
+  .log-admin { font-size: 12px; color: var(--text-secondary); }
+
+  /* === Empty / Error States === */
+  .empty-state {
+    text-align: center;
+    padding: var(--sp-2xl);
+    color: var(--text-tertiary);
+  }
+
+  .empty-state .icon { font-size: 48px; margin-bottom: var(--sp-base); }
+  .empty-state .title { font-size: 16px; font-weight: 600; color: var(--text-secondary); margin-bottom: var(--sp-sm); }
+  .empty-state .desc { font-size: 14px; }
+
+  .error-state {
+    text-align: center;
+    padding: var(--sp-2xl);
+    background: #FEF2F2;
+    border: 1px solid #FECACA;
+    border-radius: var(--r-lg);
+  }
+
+  .error-state .icon { font-size: 48px; margin-bottom: var(--sp-base); }
+  .error-state .title { font-size: 16px; font-weight: 600; color: var(--error); margin-bottom: var(--sp-sm); }
+
+  /* === Shimmer Loading === */
+  .shimmer {
+    background: linear-gradient(90deg, var(--surface) 25%, var(--surface-alt) 50%, var(--surface) 75%);
+    background-size: 200% 100%;
+    animation: shimmer 1.5s infinite;
+    border-radius: var(--r-sm);
+  }
+
+  @keyframes shimmer {
+    0% { background-position: -200% 0; }
+    100% { background-position: 200% 0; }
+  }
+
+  .shimmer-card {
+    height: 120px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    padding: var(--sp-lg);
+  }
+
+  .shimmer-line { height: 14px; margin-bottom: var(--sp-sm); }
+  .shimmer-line.w60 { width: 60%; }
+  .shimmer-line.w40 { width: 40%; }
+  .shimmer-line.w80 { width: 80%; }
+  .shimmer-line.h28 { height: 28px; width: 50%; }
+
+  /* === Responsive hint === */
+  .desktop-only {
+    display: none;
+    text-align: center;
+    padding: var(--sp-2xl);
+    color: var(--text-secondary);
+  }
+
+  @media (max-width: 768px) {
+    .desktop-only { display: block; }
+    .app, .screen-tabs { display: none; }
+  }
+
+  /* === Screen label === */
+  .screen-label {
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--primary);
+    background: var(--primary-light);
+    padding: 2px 10px;
+    border-radius: 99px;
+    margin-bottom: var(--sp-sm);
+  }
+
+  /* === Settlement Table extras === */
+  .checkbox { width: 16px; height: 16px; accent-color: var(--primary); cursor: pointer; }
+
+  .bulk-toolbar {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-sm);
+    padding: var(--sp-sm) var(--sp-base);
+    background: var(--primary-light);
+    border-radius: var(--r-sm);
+    margin-bottom: var(--sp-base);
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--primary);
+  }
+</style>
+</head>
+<body>
+
+<!-- Mobile notice -->
+<div class="desktop-only">
+  <p style="font-size:48px;">&#128187;</p>
+  <p style="font-size:18px;font-weight:700;margin:16px 0 8px;">데스크톱 전용 와이어프레임</p>
+  <p>Admin Dashboard는 데스크톱 웹 환경에서 사용합니다.<br>데스크톱 브라우저에서 열어주세요.</p>
+</div>
+
+<!-- Screen Tabs (wireframe navigation) -->
+<div class="screen-tabs" id="screenTabs">
+  <div class="screen-tab active" data-screen="login">로그인 + MFA</div>
+  <div class="screen-tab" data-screen="dashboard">대시보드 (홈)</div>
+  <div class="screen-tab" data-screen="users">유저 관리</div>
+  <div class="screen-tab" data-screen="review">파트너 심사</div>
+  <div class="screen-tab" data-screen="events">이벤트 관리</div>
+  <div class="screen-tab" data-screen="payments">결제/환불</div>
+  <div class="screen-tab" data-screen="settlements">정산 관리</div>
+  <div class="screen-tab" data-screen="audit">감사 로그</div>
+  <div class="screen-tab" data-screen="loading">로딩 상태</div>
+  <div class="screen-tab" data-screen="empty">빈/에러 상태</div>
+</div>
+
+<!-- ============================================================ -->
+<!-- SCREEN: Login + MFA -->
+<!-- ============================================================ -->
+<div class="screen active" id="screen-login">
+  <div class="login-container">
+    <div>
+      <div class="login-card">
+        <div class="login-logo">
+          <div style="color:var(--primary);">Minglit</div>
+          <div class="sub">Admin Dashboard</div>
+        </div>
+        <div class="form-group">
+          <label class="form-label">이메일</label>
+          <input class="form-input" type="email" placeholder="admin@minglit.com" value="admin@minglit.com">
+        </div>
+        <div class="form-group">
+          <label class="form-label">비밀번호</label>
+          <input class="form-input" type="password" placeholder="********" value="********">
+        </div>
+        <button class="login-btn">로그인</button>
+      </div>
+
+      <div class="login-card" style="margin-top:16px;">
+        <div style="text-align:center;">
+          <div class="screen-label">MFA 인증 (TOTP)</div>
+          <p style="font-size:14px;color:var(--text-secondary);margin:8px 0 16px;">인증 앱에서 6자리 코드를 입력하세요</p>
+        </div>
+        <div class="mfa-digits">
+          <input class="mfa-digit" maxlength="1" value="4">
+          <input class="mfa-digit" maxlength="1" value="8">
+          <input class="mfa-digit" maxlength="1" value="2">
+          <input class="mfa-digit" maxlength="1" value="">
+          <input class="mfa-digit" maxlength="1" value="">
+          <input class="mfa-digit" maxlength="1" value="">
+        </div>
+        <button class="login-btn">인증 확인</button>
+        <p style="text-align:center;margin-top:12px;font-size:12px;color:var(--text-tertiary);">
+          세션 타임아웃: 유휴 30분 / 절대 8시간
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- SCREEN: Dashboard -->
+<!-- ============================================================ -->
+<div class="screen" id="screen-dashboard">
+  <div class="app">
+    <!-- Sidebar -->
+    <nav class="sidebar">
+      <div class="sidebar-logo">
+        <span>Minglit</span>
+        <span class="badge">Admin</span>
+      </div>
+      <div class="sidebar-item active"><span class="icon">&#128200;</span> 대시보드</div>
+      <div class="sidebar-section">관리</div>
+      <div class="sidebar-item"><span class="icon">&#128100;</span> 유저 관리</div>
+      <div class="sidebar-item"><span class="icon">&#127970;</span> 파트너 관리 <span class="count">23</span></div>
+      <div class="sidebar-item"><span class="icon">&#127881;</span> 이벤트 관리</div>
+      <div class="sidebar-item"><span class="icon">&#128179;</span> 결제/환불</div>
+      <div class="sidebar-item"><span class="icon">&#128176;</span> 정산 관리 <span class="count">8</span></div>
+      <div class="sidebar-section">운영</div>
+      <div class="sidebar-item"><span class="icon">&#128101;</span> 모더레이션 <span class="count">5</span></div>
+      <div class="sidebar-item"><span class="icon">&#128221;</span> 감사 로그</div>
+      <div class="sidebar-item"><span class="icon">&#9881;</span> 시스템 설정</div>
+      <div class="sidebar-section">설정</div>
+      <div class="sidebar-item"><span class="icon">&#128274;</span> 관리자 계정</div>
+      <div class="sidebar-footer">
+        <div class="admin-profile">
+          <div class="admin-avatar">M</div>
+          <div>
+            <div class="admin-name">Mark</div>
+            <div class="admin-role">super_admin</div>
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    <!-- Main -->
+    <main class="main">
+      <div class="page-header">
+        <div>
+          <div class="page-title">대시보드</div>
+          <div class="page-subtitle">서비스 현황을 한눈에 확인하세요</div>
+        </div>
+        <div style="font-size:13px;color:var(--text-tertiary);">마지막 업데이트: 2026-04-15 10:30</div>
+      </div>
+
+      <!-- KPI Cards -->
+      <div class="kpi-grid">
+        <div class="kpi-card">
+          <div class="kpi-label">활성 유저 (7일)</div>
+          <div class="kpi-value">2,847</div>
+          <div class="kpi-trend up">&#9650; 12.3% vs 지난주</div>
+          <div class="kpi-sparkline"></div>
+        </div>
+        <div class="kpi-card">
+          <div class="kpi-label">대기 중 심사</div>
+          <div class="kpi-value" style="color:var(--warning);">23</div>
+          <div class="kpi-trend" style="color:var(--text-secondary);">평균 대기 18시간</div>
+          <div style="margin-top:8px;"><a href="#" style="font-size:13px;color:var(--primary);font-weight:500;">심사 큐로 &#8594;</a></div>
+        </div>
+        <div class="kpi-card">
+          <div class="kpi-label">오늘 매출</div>
+          <div class="kpi-value">&#8361;2,340,000</div>
+          <div class="kpi-trend up">&#9650; 8.1% vs 어제</div>
+          <div class="kpi-sparkline"></div>
+        </div>
+        <div class="kpi-card">
+          <div class="kpi-label">미정산 건</div>
+          <div class="kpi-value" style="color:var(--error);">8</div>
+          <div class="kpi-trend" style="color:var(--text-secondary);">총 &#8361;4,200,000</div>
+          <div style="margin-top:8px;"><a href="#" style="font-size:13px;color:var(--primary);font-weight:500;">정산 관리 &#8594;</a></div>
+        </div>
+      </div>
+
+      <!-- Charts -->
+      <div class="chart-grid">
+        <div class="chart-card">
+          <div class="chart-title">이벤트 신청 현황 (30일)</div>
+          <div class="chart-placeholder">
+            <div class="chart-bar"><div class="approved" style="height:60px;"></div><div class="pending" style="height:15px;"></div><div class="rejected" style="height:5px;"></div></div>
+            <div class="chart-bar"><div class="approved" style="height:45px;"></div><div class="pending" style="height:20px;"></div><div class="rejected" style="height:8px;"></div></div>
+            <div class="chart-bar"><div class="approved" style="height:70px;"></div><div class="pending" style="height:10px;"></div><div class="rejected" style="height:3px;"></div></div>
+            <div class="chart-bar"><div class="approved" style="height:55px;"></div><div class="pending" style="height:25px;"></div><div class="rejected" style="height:5px;"></div></div>
+            <div class="chart-bar"><div class="approved" style="height:80px;"></div><div class="pending" style="height:12px;"></div><div class="rejected" style="height:4px;"></div></div>
+            <div class="chart-bar"><div class="approved" style="height:65px;"></div><div class="pending" style="height:18px;"></div><div class="rejected" style="height:6px;"></div></div>
+            <div class="chart-bar"><div class="approved" style="height:90px;"></div><div class="pending" style="height:8px;"></div><div class="rejected" style="height:2px;"></div></div>
+            <div class="chart-bar"><div class="approved" style="height:75px;"></div><div class="pending" style="height:15px;"></div><div class="rejected" style="height:5px;"></div></div>
+            <div class="chart-bar"><div class="approved" style="height:50px;"></div><div class="pending" style="height:22px;"></div><div class="rejected" style="height:8px;"></div></div>
+            <div class="chart-bar"><div class="approved" style="height:85px;"></div><div class="pending" style="height:10px;"></div><div class="rejected" style="height:3px;"></div></div>
+          </div>
+          <div style="display:flex;gap:16px;margin-top:12px;font-size:12px;">
+            <span style="display:flex;align-items:center;gap:4px;"><span style="width:10px;height:10px;background:var(--success);border-radius:2px;display:inline-block;"></span> 승인</span>
+            <span style="display:flex;align-items:center;gap:4px;"><span style="width:10px;height:10px;background:var(--warning);border-radius:2px;display:inline-block;"></span> 대기</span>
+            <span style="display:flex;align-items:center;gap:4px;"><span style="width:10px;height:10px;background:var(--error);border-radius:2px;display:inline-block;"></span> 거절</span>
+          </div>
+        </div>
+        <div class="chart-card">
+          <div class="chart-title">매출 트렌드 (30일)</div>
+          <div class="chart-line-placeholder"></div>
+          <div style="display:flex;justify-content:space-between;margin-top:12px;font-size:12px;color:var(--text-tertiary);">
+            <span>3/16</span><span>3/23</span><span>3/30</span><span>4/06</span><span>4/15</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Action Queues -->
+      <div class="queue-grid">
+        <div class="queue-card">
+          <div class="queue-header">
+            <div class="queue-title">&#128680; 모더레이션 큐</div>
+            <div class="queue-link">전체 보기 &#8594;</div>
+          </div>
+          <div class="queue-item">
+            <span class="queue-badge badge-open">신고</span>
+            <span>부적절한 프로필 이미지 — user_2847</span>
+            <span class="queue-item-meta">2시간 전</span>
+          </div>
+          <div class="queue-item">
+            <span class="queue-badge badge-open">신고</span>
+            <span>스팸 메시지 — user_1293</span>
+            <span class="queue-item-meta">3시간 전</span>
+          </div>
+          <div class="queue-item">
+            <span class="queue-badge badge-pending">검토</span>
+            <span>인증 서류 재제출 — partner_45</span>
+            <span class="queue-item-meta">5시간 전</span>
+          </div>
+        </div>
+
+        <div class="queue-card">
+          <div class="queue-header">
+            <div class="queue-title">&#127970; 파트너 입점 심사</div>
+            <div class="queue-link">심사 큐 &#8594;</div>
+          </div>
+          <div class="queue-item">
+            <span class="queue-badge badge-pending">대기</span>
+            <span>서울라운지 — Nightlife</span>
+            <span class="queue-item-meta">6시간 전</span>
+          </div>
+          <div class="queue-item">
+            <span class="queue-badge badge-pending">대기</span>
+            <span>강남소셜클럽 — Social</span>
+            <span class="queue-item-meta">12시간 전</span>
+          </div>
+          <div class="queue-item">
+            <span class="queue-badge badge-pending">대기</span>
+            <span>홍대믹서 — Party</span>
+            <span class="queue-item-meta">18시간 전</span>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- SCREEN: User Management -->
+<!-- ============================================================ -->
+<div class="screen" id="screen-users">
+  <div class="app">
+    <nav class="sidebar">
+      <div class="sidebar-logo"><span>Minglit</span><span class="badge">Admin</span></div>
+      <div class="sidebar-item"><span class="icon">&#128200;</span> 대시보드</div>
+      <div class="sidebar-section">관리</div>
+      <div class="sidebar-item active"><span class="icon">&#128100;</span> 유저 관리</div>
+      <div class="sidebar-item"><span class="icon">&#127970;</span> 파트너 관리</div>
+      <div class="sidebar-item"><span class="icon">&#127881;</span> 이벤트 관리</div>
+      <div class="sidebar-item"><span class="icon">&#128179;</span> 결제/환불</div>
+      <div class="sidebar-item"><span class="icon">&#128176;</span> 정산 관리</div>
+      <div class="sidebar-section">운영</div>
+      <div class="sidebar-item"><span class="icon">&#128101;</span> 모더레이션</div>
+      <div class="sidebar-item"><span class="icon">&#128221;</span> 감사 로그</div>
+      <div class="sidebar-item"><span class="icon">&#9881;</span> 시스템 설정</div>
+      <div class="sidebar-footer">
+        <div class="admin-profile">
+          <div class="admin-avatar">M</div>
+          <div><div class="admin-name">Mark</div><div class="admin-role">super_admin</div></div>
+        </div>
+      </div>
+    </nav>
+
+    <main class="main">
+      <div class="page-header">
+        <div>
+          <div class="page-title">유저 관리</div>
+          <div class="page-subtitle">전체 유저 목록 및 상세 정보</div>
+        </div>
+        <button class="btn btn-secondary">CSV 내보내기</button>
+      </div>
+
+      <!-- Summary Bar -->
+      <div class="summary-bar">
+        <div class="summary-item"><span class="num">4,521</span> 전체</div>
+        <div class="summary-item"><span class="num">3,890</span> 활성</div>
+        <div class="summary-item"><span class="num">2,134</span> 인증 완료</div>
+        <div class="summary-item"><span class="num">12</span> 정지</div>
+      </div>
+
+      <!-- Filters -->
+      <div class="table-toolbar">
+        <div class="filter-group">
+          <input class="filter-input" placeholder="&#128269; 이름, 전화번호, 이메일 검색...">
+          <select class="filter-select">
+            <option>인증 상태: 전체</option>
+            <option>인증 완료</option>
+            <option>미인증</option>
+          </select>
+          <select class="filter-select">
+            <option>상태: 전체</option>
+            <option>활성</option>
+            <option>정지</option>
+          </select>
+          <select class="filter-select">
+            <option>성별: 전체</option>
+            <option>남성</option>
+            <option>여성</option>
+          </select>
+        </div>
+      </div>
+
+      <!-- Table + Drawer -->
+      <div class="drawer-overlay">
+        <div class="data-table" style="flex:1;">
+          <table>
+            <thead>
+              <tr>
+                <th>유저 <span class="sort">&#9650;&#9660;</span></th>
+                <th>성별</th>
+                <th>나이</th>
+                <th>인증 <span class="sort">&#9650;&#9660;</span></th>
+                <th>상태</th>
+                <th>가입일 <span class="sort">&#9650;&#9660;</span></th>
+                <th>이벤트</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr style="background:var(--primary-light);">
+                <td><div class="user-cell"><div class="user-avatar">&#128100;</div><div><strong>김서연</strong><br><span style="font-size:12px;color:var(--text-tertiary);">kim_sy@email.com</span></div></div></td>
+                <td>F</td>
+                <td>28</td>
+                <td><span class="status-badge status-verified">인증</span></td>
+                <td><span class="status-badge status-active">활성</span></td>
+                <td>2026-03-15</td>
+                <td>12</td>
+              </tr>
+              <tr>
+                <td><div class="user-cell"><div class="user-avatar">&#128100;</div><div><strong>박준혁</strong><br><span style="font-size:12px;color:var(--text-tertiary);">park_jh@email.com</span></div></div></td>
+                <td>M</td>
+                <td>31</td>
+                <td><span class="status-badge status-verified">인증</span></td>
+                <td><span class="status-badge status-active">활성</span></td>
+                <td>2026-02-28</td>
+                <td>8</td>
+              </tr>
+              <tr>
+                <td><div class="user-cell"><div class="user-avatar">&#128100;</div><div><strong>이민지</strong><br><span style="font-size:12px;color:var(--text-tertiary);">lee_mj@email.com</span></div></div></td>
+                <td>F</td>
+                <td>25</td>
+                <td><span class="status-badge status-pending">미인증</span></td>
+                <td><span class="status-badge status-active">활성</span></td>
+                <td>2026-04-10</td>
+                <td>2</td>
+              </tr>
+              <tr>
+                <td><div class="user-cell"><div class="user-avatar">&#128100;</div><div><strong>최동우</strong><br><span style="font-size:12px;color:var(--text-tertiary);">choi_dw@email.com</span></div></div></td>
+                <td>M</td>
+                <td>29</td>
+                <td><span class="status-badge status-verified">인증</span></td>
+                <td><span class="status-badge status-suspended">정지</span></td>
+                <td>2026-01-05</td>
+                <td>0</td>
+              </tr>
+              <tr>
+                <td><div class="user-cell"><div class="user-avatar">&#128100;</div><div><strong>장하은</strong><br><span style="font-size:12px;color:var(--text-tertiary);">jang_he@email.com</span></div></div></td>
+                <td>F</td>
+                <td>27</td>
+                <td><span class="status-badge status-verified">인증</span></td>
+                <td><span class="status-badge status-active">활성</span></td>
+                <td>2026-03-22</td>
+                <td>6</td>
+              </tr>
+            </tbody>
+          </table>
+          <div class="pagination">
+            <span>1-25 / 4,521건</span>
+            <div class="page-btns">
+              <div class="page-btn">&#8249;</div>
+              <div class="page-btn active">1</div>
+              <div class="page-btn">2</div>
+              <div class="page-btn">3</div>
+              <div class="page-btn">...</div>
+              <div class="page-btn">181</div>
+              <div class="page-btn">&#8250;</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Detail Drawer -->
+        <div class="drawer">
+          <div class="drawer-header">
+            <div class="drawer-user">
+              <div class="drawer-avatar">&#128100;</div>
+              <div>
+                <div class="drawer-name">김서연</div>
+                <div class="drawer-meta">F / 28세 / <span class="status-badge status-verified" style="font-size:11px;">인증</span></div>
+              </div>
+            </div>
+          </div>
+          <div class="drawer-tabs">
+            <div class="drawer-tab active">프로필</div>
+            <div class="drawer-tab">이벤트</div>
+            <div class="drawer-tab">결제</div>
+            <div class="drawer-tab">인증</div>
+            <div class="drawer-tab">활동</div>
+          </div>
+          <div class="drawer-body">
+            <div class="drawer-field"><span class="drawer-field-label">이메일</span><span class="drawer-field-value">kim_sy@email.com</span></div>
+            <div class="drawer-field"><span class="drawer-field-label">전화번호</span><span class="drawer-field-value">010-****-5678</span></div>
+            <div class="drawer-field"><span class="drawer-field-label">생년월일</span><span class="drawer-field-value">1998-05-12</span></div>
+            <div class="drawer-field"><span class="drawer-field-label">성별</span><span class="drawer-field-value">여성</span></div>
+            <div class="drawer-field"><span class="drawer-field-label">CI 인증</span><span class="drawer-field-value" style="color:var(--success);">완료</span></div>
+            <div class="drawer-field"><span class="drawer-field-label">가입일</span><span class="drawer-field-value">2026-03-15</span></div>
+            <div class="drawer-field"><span class="drawer-field-label">최근 활동</span><span class="drawer-field-value">2026-04-15 09:22</span></div>
+            <div class="drawer-field"><span class="drawer-field-label">이벤트 참여</span><span class="drawer-field-value">12건</span></div>
+            <div class="drawer-field"><span class="drawer-field-label">총 결제 금액</span><span class="drawer-field-value">&#8361;340,000</span></div>
+          </div>
+          <div class="drawer-actions">
+            <button class="btn btn-danger" style="flex:1;">&#9888; 정지</button>
+            <button class="btn btn-secondary" style="flex:1;">인증 초기화</button>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- SCREEN: Partner Review -->
+<!-- ============================================================ -->
+<div class="screen" id="screen-review">
+  <div class="app">
+    <nav class="sidebar">
+      <div class="sidebar-logo"><span>Minglit</span><span class="badge">Admin</span></div>
+      <div class="sidebar-item"><span class="icon">&#128200;</span> 대시보드</div>
+      <div class="sidebar-section">관리</div>
+      <div class="sidebar-item"><span class="icon">&#128100;</span> 유저 관리</div>
+      <div class="sidebar-item active"><span class="icon">&#127970;</span> 파트너 관리 <span class="count">23</span></div>
+      <div class="sidebar-item"><span class="icon">&#127881;</span> 이벤트 관리</div>
+      <div class="sidebar-item"><span class="icon">&#128179;</span> 결제/환불</div>
+      <div class="sidebar-item"><span class="icon">&#128176;</span> 정산 관리</div>
+      <div class="sidebar-section">운영</div>
+      <div class="sidebar-item"><span class="icon">&#128101;</span> 모더레이션</div>
+      <div class="sidebar-item"><span class="icon">&#128221;</span> 감사 로그</div>
+      <div class="sidebar-item"><span class="icon">&#9881;</span> 시스템 설정</div>
+      <div class="sidebar-footer">
+        <div class="admin-profile">
+          <div class="admin-avatar">M</div>
+          <div><div class="admin-name">Mark</div><div class="admin-role">super_admin</div></div>
+        </div>
+      </div>
+    </nav>
+
+    <main class="main">
+      <div class="page-header">
+        <div>
+          <div class="screen-label">파트너 관리 &gt; 입점 심사</div>
+          <div class="page-title">서울라운지 입점 심사</div>
+          <div class="page-subtitle">제출일: 2026-04-14 14:30 | 카테고리: Nightlife</div>
+        </div>
+        <button class="btn btn-secondary">&#8592; 심사 큐로 돌아가기</button>
+      </div>
+
+      <div class="summary-bar">
+        <div class="summary-item"><span class="num" style="color:var(--warning);">23</span> 대기</div>
+        <div class="summary-item"><span class="num" style="color:var(--success);">340</span> 승인</div>
+        <div class="summary-item"><span class="num" style="color:var(--error);">5</span> 거절</div>
+        <div class="summary-item"><span class="num" style="color:var(--text-secondary);">7</span> 보완 요청</div>
+      </div>
+
+      <div class="review-layout">
+        <!-- Document Viewer -->
+        <div class="doc-viewer">
+          <div class="doc-tabs">
+            <div class="doc-tab active">사업자등록증</div>
+            <div class="doc-tab">대표자 신분증</div>
+            <div class="doc-tab">영업허가증</div>
+          </div>
+          <div class="doc-preview">
+            <div class="icon">&#128196;</div>
+            <div>사업자등록증.pdf</div>
+            <div style="font-size:12px;">사업자번호: 123-45-67890</div>
+            <div style="font-size:12px;margin-top:8px;padding:8px 16px;background:var(--surface-alt);border-radius:8px;">
+              (PDF/이미지 미리보기 영역 — 400px 높이)
+            </div>
+          </div>
+        </div>
+
+        <!-- Review Panel -->
+        <div class="review-panel">
+          <h3 style="font-size:16px;font-weight:600;margin-bottom:16px;">심사 정보</h3>
+          <div class="review-info">
+            <div class="review-info-item"><span class="review-info-label">업체명</span><span>서울라운지</span></div>
+            <div class="review-info-item"><span class="review-info-label">사업자번호</span><span>123-45-67890</span></div>
+            <div class="review-info-item"><span class="review-info-label">대표자</span><span>홍길동</span></div>
+            <div class="review-info-item"><span class="review-info-label">카테고리</span><span>Nightlife</span></div>
+            <div class="review-info-item"><span class="review-info-label">주소</span><span>서울시 강남구 역삼동 123-4</span></div>
+            <div class="review-info-item"><span class="review-info-label">연락처</span><span>02-1234-5678</span></div>
+            <div class="review-info-item"><span class="review-info-label">제출일</span><span>2026-04-14</span></div>
+            <div class="review-info-item"><span class="review-info-label">대기 시간</span><span style="color:var(--warning);font-weight:600;">18시간</span></div>
+          </div>
+
+          <h3 style="font-size:14px;font-weight:600;margin-bottom:8px;">관리자 코멘트</h3>
+          <textarea class="review-comment" placeholder="심사 의견을 입력하세요. 거절 시 사유를 상세히 작성해주세요."></textarea>
+
+          <div class="review-actions">
+            <button class="btn btn-success">&#10003; 승인</button>
+            <button class="btn btn-danger">&#10007; 거절</button>
+            <button class="btn btn-warning">&#8635; 보완 요청</button>
+          </div>
+
+          <div style="margin-top:16px;padding:12px;background:var(--surface);border-radius:8px;font-size:12px;color:var(--text-tertiary);">
+            &#128274; 이 액션은 감사 로그에 기록됩니다.
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- SCREEN: Event Management -->
+<!-- ============================================================ -->
+<div class="screen" id="screen-events">
+  <div class="app">
+    <nav class="sidebar">
+      <div class="sidebar-logo"><span>Minglit</span><span class="badge">Admin</span></div>
+      <div class="sidebar-item"><span class="icon">&#128200;</span> 대시보드</div>
+      <div class="sidebar-section">관리</div>
+      <div class="sidebar-item"><span class="icon">&#128100;</span> 유저 관리</div>
+      <div class="sidebar-item"><span class="icon">&#127970;</span> 파트너 관리</div>
+      <div class="sidebar-item active"><span class="icon">&#127881;</span> 이벤트 관리</div>
+      <div class="sidebar-item"><span class="icon">&#128179;</span> 결제/환불</div>
+      <div class="sidebar-item"><span class="icon">&#128176;</span> 정산 관리</div>
+      <div class="sidebar-section">운영</div>
+      <div class="sidebar-item"><span class="icon">&#128101;</span> 모더레이션</div>
+      <div class="sidebar-item"><span class="icon">&#128221;</span> 감사 로그</div>
+      <div class="sidebar-item"><span class="icon">&#9881;</span> 시스템 설정</div>
+      <div class="sidebar-footer">
+        <div class="admin-profile">
+          <div class="admin-avatar">M</div>
+          <div><div class="admin-name">Mark</div><div class="admin-role">super_admin</div></div>
+        </div>
+      </div>
+    </nav>
+
+    <main class="main">
+      <div class="page-header">
+        <div>
+          <div class="page-title">이벤트 관리</div>
+          <div class="page-subtitle">전체 이벤트 및 파티 관리</div>
+        </div>
+      </div>
+
+      <div class="table-toolbar">
+        <div class="filter-group">
+          <input class="filter-input" placeholder="&#128269; 이벤트명, 파트너명 검색...">
+          <select class="filter-select">
+            <option>상태: 전체</option>
+            <option>active</option>
+            <option>scheduled</option>
+            <option>cancelled</option>
+            <option>completed</option>
+          </select>
+          <select class="filter-select">
+            <option>카테고리: 전체</option>
+            <option>Nightlife</option>
+            <option>Social</option>
+            <option>Party</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="data-table">
+        <table>
+          <thead>
+            <tr>
+              <th>이벤트 <span class="sort">&#9650;&#9660;</span></th>
+              <th>파트너</th>
+              <th>상태</th>
+              <th>날짜 <span class="sort">&#9650;&#9660;</span></th>
+              <th>신청/정원</th>
+              <th>매출 <span class="sort">&#9650;&#9660;</span></th>
+              <th>액션</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>금요 소셜 나이트</strong><br><span style="font-size:12px;color:var(--text-tertiary);">서울라운지</span></td>
+              <td>서울라운지</td>
+              <td><span class="status-badge status-active">active</span></td>
+              <td>2026-04-18</td>
+              <td>45/50</td>
+              <td>&#8361;1,350,000</td>
+              <td><button class="btn btn-secondary" style="font-size:12px;padding:4px 10px;">상세</button></td>
+            </tr>
+            <tr>
+              <td><strong>주말 와인 파티</strong><br><span style="font-size:12px;color:var(--text-tertiary);">강남소셜클럽</span></td>
+              <td>강남소셜클럽</td>
+              <td><span class="status-badge status-active">active</span></td>
+              <td>2026-04-19</td>
+              <td>28/30</td>
+              <td>&#8361;840,000</td>
+              <td><button class="btn btn-secondary" style="font-size:12px;padding:4px 10px;">상세</button></td>
+            </tr>
+            <tr>
+              <td><strong>보드게임 모임</strong><br><span style="font-size:12px;color:var(--text-tertiary);">홍대믹서</span></td>
+              <td>홍대믹서</td>
+              <td><span class="status-badge" style="background:#DBEAFE;color:#1E40AF;">scheduled</span></td>
+              <td>2026-04-20</td>
+              <td>12/20</td>
+              <td>&#8361;240,000</td>
+              <td><button class="btn btn-secondary" style="font-size:12px;padding:4px 10px;">상세</button></td>
+            </tr>
+            <tr>
+              <td><strong>커플 쿠킹 클래스</strong><br><span style="font-size:12px;color:var(--text-tertiary);">요리의민족</span></td>
+              <td>요리의민족</td>
+              <td><span class="status-badge status-suspended">cancelled</span></td>
+              <td>2026-04-16</td>
+              <td>8/16</td>
+              <td>&#8361;0</td>
+              <td><button class="btn btn-secondary" style="font-size:12px;padding:4px 10px;">상세</button></td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="pagination">
+          <span>1-25 / 892건</span>
+          <div class="page-btns">
+            <div class="page-btn">&#8249;</div>
+            <div class="page-btn active">1</div>
+            <div class="page-btn">2</div>
+            <div class="page-btn">3</div>
+            <div class="page-btn">&#8250;</div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- SCREEN: Payments -->
+<!-- ============================================================ -->
+<div class="screen" id="screen-payments">
+  <div class="app">
+    <nav class="sidebar">
+      <div class="sidebar-logo"><span>Minglit</span><span class="badge">Admin</span></div>
+      <div class="sidebar-item"><span class="icon">&#128200;</span> 대시보드</div>
+      <div class="sidebar-section">관리</div>
+      <div class="sidebar-item"><span class="icon">&#128100;</span> 유저 관리</div>
+      <div class="sidebar-item"><span class="icon">&#127970;</span> 파트너 관리</div>
+      <div class="sidebar-item"><span class="icon">&#127881;</span> 이벤트 관리</div>
+      <div class="sidebar-item active"><span class="icon">&#128179;</span> 결제/환불</div>
+      <div class="sidebar-item"><span class="icon">&#128176;</span> 정산 관리</div>
+      <div class="sidebar-section">운영</div>
+      <div class="sidebar-item"><span class="icon">&#128101;</span> 모더레이션</div>
+      <div class="sidebar-item"><span class="icon">&#128221;</span> 감사 로그</div>
+      <div class="sidebar-item"><span class="icon">&#9881;</span> 시스템 설정</div>
+      <div class="sidebar-footer">
+        <div class="admin-profile">
+          <div class="admin-avatar">M</div>
+          <div><div class="admin-name">Mark</div><div class="admin-role">super_admin</div></div>
+        </div>
+      </div>
+    </nav>
+
+    <main class="main">
+      <div class="page-header">
+        <div>
+          <div class="page-title">결제/환불</div>
+          <div class="page-subtitle">거래 내역 조회 및 환불 처리</div>
+        </div>
+      </div>
+
+      <div class="table-toolbar">
+        <div class="filter-group">
+          <input class="filter-input" placeholder="&#128269; 거래 ID, 유저명, 이벤트명...">
+          <select class="filter-select">
+            <option>상태: 전체</option>
+            <option>결제 완료</option>
+            <option>환불 완료</option>
+            <option>환불 대기</option>
+          </select>
+          <input class="filter-input" type="date" style="width:160px;" value="2026-04-01">
+          <span style="line-height:36px;color:var(--text-tertiary);">~</span>
+          <input class="filter-input" type="date" style="width:160px;" value="2026-04-15">
+        </div>
+      </div>
+
+      <div class="data-table">
+        <table>
+          <thead>
+            <tr>
+              <th>거래 ID</th>
+              <th>유저</th>
+              <th>이벤트</th>
+              <th>금액 <span class="sort">&#9650;&#9660;</span></th>
+              <th>상태</th>
+              <th>결제일 <span class="sort">&#9650;&#9660;</span></th>
+              <th>액션</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td style="font-family:monospace;font-size:12px;">PAY-20260415-001</td>
+              <td>김서연</td>
+              <td>금요 소셜 나이트</td>
+              <td>&#8361;30,000</td>
+              <td><span class="status-badge status-active">결제 완료</span></td>
+              <td>2026-04-15</td>
+              <td><button class="btn btn-danger" style="font-size:12px;padding:4px 10px;">환불</button></td>
+            </tr>
+            <tr>
+              <td style="font-family:monospace;font-size:12px;">PAY-20260414-042</td>
+              <td>박준혁</td>
+              <td>주말 와인 파티</td>
+              <td>&#8361;30,000</td>
+              <td><span class="status-badge status-active">결제 완료</span></td>
+              <td>2026-04-14</td>
+              <td><button class="btn btn-danger" style="font-size:12px;padding:4px 10px;">환불</button></td>
+            </tr>
+            <tr>
+              <td style="font-family:monospace;font-size:12px;">PAY-20260413-018</td>
+              <td>장하은</td>
+              <td>커플 쿠킹 클래스</td>
+              <td style="color:var(--error);">-&#8361;20,000</td>
+              <td><span class="status-badge" style="background:#FEE2E2;color:#991B1B;">환불 완료</span></td>
+              <td>2026-04-13</td>
+              <td><span style="font-size:12px;color:var(--text-tertiary);">처리됨</span></td>
+            </tr>
+            <tr>
+              <td style="font-family:monospace;font-size:12px;">PAY-20260412-033</td>
+              <td>이민지</td>
+              <td>보드게임 모임</td>
+              <td>&#8361;20,000</td>
+              <td><span class="status-badge status-pending">환불 대기</span></td>
+              <td>2026-04-12</td>
+              <td><button class="btn btn-danger" style="font-size:12px;padding:4px 10px;">환불 처리</button></td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="pagination">
+          <span>1-25 / 1,247건</span>
+          <div class="page-btns">
+            <div class="page-btn">&#8249;</div>
+            <div class="page-btn active">1</div>
+            <div class="page-btn">2</div>
+            <div class="page-btn">3</div>
+            <div class="page-btn">&#8250;</div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- SCREEN: Settlements -->
+<!-- ============================================================ -->
+<div class="screen" id="screen-settlements">
+  <div class="app">
+    <nav class="sidebar">
+      <div class="sidebar-logo"><span>Minglit</span><span class="badge">Admin</span></div>
+      <div class="sidebar-item"><span class="icon">&#128200;</span> 대시보드</div>
+      <div class="sidebar-section">관리</div>
+      <div class="sidebar-item"><span class="icon">&#128100;</span> 유저 관리</div>
+      <div class="sidebar-item"><span class="icon">&#127970;</span> 파트너 관리</div>
+      <div class="sidebar-item"><span class="icon">&#127881;</span> 이벤트 관리</div>
+      <div class="sidebar-item"><span class="icon">&#128179;</span> 결제/환불</div>
+      <div class="sidebar-item active"><span class="icon">&#128176;</span> 정산 관리 <span class="count">8</span></div>
+      <div class="sidebar-section">운영</div>
+      <div class="sidebar-item"><span class="icon">&#128101;</span> 모더레이션</div>
+      <div class="sidebar-item"><span class="icon">&#128221;</span> 감사 로그</div>
+      <div class="sidebar-item"><span class="icon">&#9881;</span> 시스템 설정</div>
+      <div class="sidebar-footer">
+        <div class="admin-profile">
+          <div class="admin-avatar">M</div>
+          <div><div class="admin-name">Mark</div><div class="admin-role">super_admin</div></div>
+        </div>
+      </div>
+    </nav>
+
+    <main class="main">
+      <div class="page-header">
+        <div>
+          <div class="page-title">정산 관리</div>
+          <div class="page-subtitle">파트너 정산 상태 관리 및 지급 처리</div>
+        </div>
+      </div>
+
+      <div class="bulk-toolbar">
+        <input type="checkbox" class="checkbox" checked> 3건 선택됨
+        <button class="btn btn-primary" style="font-size:12px;padding:4px 12px;margin-left:auto;">일괄 확정</button>
+        <button class="btn btn-success" style="font-size:12px;padding:4px 12px;">일괄 지급</button>
+      </div>
+
+      <div class="data-table">
+        <table>
+          <thead>
+            <tr>
+              <th style="width:40px;"><input type="checkbox" class="checkbox"></th>
+              <th>정산 ID</th>
+              <th>파트너</th>
+              <th>기간</th>
+              <th>총 매출 <span class="sort">&#9650;&#9660;</span></th>
+              <th>수수료</th>
+              <th>정산액 <span class="sort">&#9650;&#9660;</span></th>
+              <th>상태</th>
+              <th>액션</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><input type="checkbox" class="checkbox" checked></td>
+              <td style="font-family:monospace;font-size:12px;">STL-2604-001</td>
+              <td>서울라운지</td>
+              <td>4/1~4/7</td>
+              <td>&#8361;2,700,000</td>
+              <td>&#8361;270,000</td>
+              <td style="font-weight:600;">&#8361;2,430,000</td>
+              <td><span class="status-badge status-pending">pending</span></td>
+              <td>
+                <button class="btn btn-primary" style="font-size:12px;padding:4px 10px;">확정</button>
+              </td>
+            </tr>
+            <tr>
+              <td><input type="checkbox" class="checkbox" checked></td>
+              <td style="font-family:monospace;font-size:12px;">STL-2604-002</td>
+              <td>강남소셜클럽</td>
+              <td>4/1~4/7</td>
+              <td>&#8361;1,680,000</td>
+              <td>&#8361;168,000</td>
+              <td style="font-weight:600;">&#8361;1,512,000</td>
+              <td><span class="status-badge status-pending">pending</span></td>
+              <td>
+                <button class="btn btn-primary" style="font-size:12px;padding:4px 10px;">확정</button>
+              </td>
+            </tr>
+            <tr>
+              <td><input type="checkbox" class="checkbox" checked></td>
+              <td style="font-family:monospace;font-size:12px;">STL-2604-003</td>
+              <td>홍대믹서</td>
+              <td>4/1~4/7</td>
+              <td>&#8361;480,000</td>
+              <td>&#8361;48,000</td>
+              <td style="font-weight:600;">&#8361;432,000</td>
+              <td><span class="status-badge" style="background:#DBEAFE;color:#1E40AF;">confirmed</span></td>
+              <td>
+                <button class="btn btn-success" style="font-size:12px;padding:4px 10px;">지급</button>
+              </td>
+            </tr>
+            <tr>
+              <td><input type="checkbox" class="checkbox"></td>
+              <td style="font-family:monospace;font-size:12px;">STL-2603-015</td>
+              <td>요리의민족</td>
+              <td>3/25~3/31</td>
+              <td>&#8361;960,000</td>
+              <td>&#8361;96,000</td>
+              <td style="font-weight:600;">&#8361;864,000</td>
+              <td><span class="status-badge status-active">paid</span></td>
+              <td>
+                <span style="font-size:12px;color:var(--text-tertiary);">완료</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="pagination">
+          <span>1-25 / 156건</span>
+          <div class="page-btns">
+            <div class="page-btn">&#8249;</div>
+            <div class="page-btn active">1</div>
+            <div class="page-btn">2</div>
+            <div class="page-btn">&#8250;</div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- SCREEN: Audit Log -->
+<!-- ============================================================ -->
+<div class="screen" id="screen-audit">
+  <div class="app">
+    <nav class="sidebar">
+      <div class="sidebar-logo"><span>Minglit</span><span class="badge">Admin</span></div>
+      <div class="sidebar-item"><span class="icon">&#128200;</span> 대시보드</div>
+      <div class="sidebar-section">관리</div>
+      <div class="sidebar-item"><span class="icon">&#128100;</span> 유저 관리</div>
+      <div class="sidebar-item"><span class="icon">&#127970;</span> 파트너 관리</div>
+      <div class="sidebar-item"><span class="icon">&#127881;</span> 이벤트 관리</div>
+      <div class="sidebar-item"><span class="icon">&#128179;</span> 결제/환불</div>
+      <div class="sidebar-item"><span class="icon">&#128176;</span> 정산 관리</div>
+      <div class="sidebar-section">운영</div>
+      <div class="sidebar-item"><span class="icon">&#128101;</span> 모더레이션</div>
+      <div class="sidebar-item active"><span class="icon">&#128221;</span> 감사 로그</div>
+      <div class="sidebar-item"><span class="icon">&#9881;</span> 시스템 설정</div>
+      <div class="sidebar-footer">
+        <div class="admin-profile">
+          <div class="admin-avatar">M</div>
+          <div><div class="admin-name">Mark</div><div class="admin-role">super_admin</div></div>
+        </div>
+      </div>
+    </nav>
+
+    <main class="main">
+      <div class="page-header">
+        <div>
+          <div class="page-title">감사 로그</div>
+          <div class="page-subtitle">모든 관리 액션의 불변 기록</div>
+        </div>
+      </div>
+
+      <div class="table-toolbar">
+        <div class="filter-group">
+          <select class="filter-select">
+            <option>관리자: 전체</option>
+            <option>Mark (super_admin)</option>
+            <option>Kim (moderator)</option>
+          </select>
+          <select class="filter-select">
+            <option>액션: 전체</option>
+            <option>파트너 심사</option>
+            <option>유저 정지</option>
+            <option>환불 처리</option>
+            <option>설정 변경</option>
+          </select>
+          <input class="filter-input" type="date" style="width:160px;" value="2026-04-15">
+        </div>
+      </div>
+
+      <div class="data-table" style="padding:0;">
+        <div class="log-entry">
+          <div class="log-icon approve">&#10003;</div>
+          <div class="log-content">
+            <div><span class="log-action">파트너 심사 승인</span> — <span class="log-target">강남소셜클럽</span></div>
+            <div class="log-admin">Mark (super_admin) · 192.168.1.100</div>
+            <div class="log-time">2026-04-15 10:23:45</div>
+          </div>
+        </div>
+        <div class="log-entry">
+          <div class="log-icon reject">&#10007;</div>
+          <div class="log-content">
+            <div><span class="log-action">파트너 심사 거절</span> — <span class="log-target">미등록업체A</span></div>
+            <div class="log-admin">Kim (moderator) · 192.168.1.105</div>
+            <div class="log-time">2026-04-15 09:58:12</div>
+          </div>
+        </div>
+        <div class="log-entry">
+          <div class="log-icon suspend">&#9888;</div>
+          <div class="log-content">
+            <div><span class="log-action">유저 정지</span> — <span class="log-target">user_최동우</span></div>
+            <div class="log-admin">Mark (super_admin) · 192.168.1.100</div>
+            <div class="log-time">2026-04-15 09:15:33</div>
+          </div>
+        </div>
+        <div class="log-entry">
+          <div class="log-icon refund">&#8617;</div>
+          <div class="log-content">
+            <div><span class="log-action">환불 처리</span> — <span class="log-target">PAY-20260413-018</span> &#8361;20,000</div>
+            <div class="log-admin">Mark (super_admin) · 192.168.1.100</div>
+            <div class="log-time">2026-04-14 16:42:01</div>
+          </div>
+        </div>
+        <div class="log-entry">
+          <div class="log-icon setting">&#9881;</div>
+          <div class="log-content">
+            <div><span class="log-action">시스템 설정 변경</span> — <span class="log-target">refund_policy_version</span> v2.1 &#8594; v2.2</div>
+            <div class="log-admin">Mark (super_admin) · 192.168.1.100</div>
+            <div class="log-time">2026-04-14 14:20:55</div>
+          </div>
+        </div>
+        <div class="log-entry">
+          <div class="log-icon approve">&#10003;</div>
+          <div class="log-content">
+            <div><span class="log-action">정산 확정</span> — <span class="log-target">STL-2604-003</span> 홍대믹서 &#8361;432,000</div>
+            <div class="log-admin">Mark (super_admin) · 192.168.1.100</div>
+            <div class="log-time">2026-04-14 11:05:18</div>
+          </div>
+        </div>
+        <div class="pagination">
+          <span>1-25 / 2,847건</span>
+          <div class="page-btns">
+            <div class="page-btn">&#8249;</div>
+            <div class="page-btn active">1</div>
+            <div class="page-btn">2</div>
+            <div class="page-btn">3</div>
+            <div class="page-btn">&#8250;</div>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- SCREEN: Loading States -->
+<!-- ============================================================ -->
+<div class="screen" id="screen-loading">
+  <div class="app">
+    <nav class="sidebar">
+      <div class="sidebar-logo"><span>Minglit</span><span class="badge">Admin</span></div>
+      <div class="sidebar-item active"><span class="icon">&#128200;</span> 대시보드</div>
+      <div class="sidebar-section">관리</div>
+      <div class="sidebar-item"><span class="icon">&#128100;</span> 유저 관리</div>
+      <div class="sidebar-item"><span class="icon">&#127970;</span> 파트너 관리</div>
+      <div class="sidebar-item"><span class="icon">&#127881;</span> 이벤트 관리</div>
+      <div class="sidebar-item"><span class="icon">&#128179;</span> 결제/환불</div>
+      <div class="sidebar-item"><span class="icon">&#128176;</span> 정산 관리</div>
+      <div class="sidebar-footer">
+        <div class="admin-profile">
+          <div class="admin-avatar">M</div>
+          <div><div class="admin-name">Mark</div><div class="admin-role">super_admin</div></div>
+        </div>
+      </div>
+    </nav>
+
+    <main class="main">
+      <div class="page-header">
+        <div>
+          <div class="screen-label">로딩 상태 (Shimmer)</div>
+          <div class="page-title">대시보드</div>
+        </div>
+      </div>
+
+      <!-- Shimmer KPI Cards -->
+      <div class="kpi-grid">
+        <div class="shimmer-card">
+          <div class="shimmer shimmer-line w60"></div>
+          <div style="height:8px;"></div>
+          <div class="shimmer shimmer-line h28"></div>
+          <div style="height:8px;"></div>
+          <div class="shimmer shimmer-line w40"></div>
+        </div>
+        <div class="shimmer-card">
+          <div class="shimmer shimmer-line w60"></div>
+          <div style="height:8px;"></div>
+          <div class="shimmer shimmer-line h28"></div>
+          <div style="height:8px;"></div>
+          <div class="shimmer shimmer-line w40"></div>
+        </div>
+        <div class="shimmer-card">
+          <div class="shimmer shimmer-line w60"></div>
+          <div style="height:8px;"></div>
+          <div class="shimmer shimmer-line h28"></div>
+          <div style="height:8px;"></div>
+          <div class="shimmer shimmer-line w40"></div>
+        </div>
+        <div class="shimmer-card">
+          <div class="shimmer shimmer-line w60"></div>
+          <div style="height:8px;"></div>
+          <div class="shimmer shimmer-line h28"></div>
+          <div style="height:8px;"></div>
+          <div class="shimmer shimmer-line w40"></div>
+        </div>
+      </div>
+
+      <!-- Shimmer Table -->
+      <div class="data-table" style="padding:16px;">
+        <div style="margin-bottom:12px;"><div class="shimmer shimmer-line w80"></div></div>
+        <div style="margin-bottom:12px;"><div class="shimmer shimmer-line" style="width:100%;"></div></div>
+        <div style="margin-bottom:12px;"><div class="shimmer shimmer-line" style="width:95%;"></div></div>
+        <div style="margin-bottom:12px;"><div class="shimmer shimmer-line" style="width:100%;"></div></div>
+        <div style="margin-bottom:12px;"><div class="shimmer shimmer-line" style="width:90%;"></div></div>
+        <div style="margin-bottom:12px;"><div class="shimmer shimmer-line" style="width:100%;"></div></div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- SCREEN: Empty / Error States -->
+<!-- ============================================================ -->
+<div class="screen" id="screen-empty">
+  <div class="app">
+    <nav class="sidebar">
+      <div class="sidebar-logo"><span>Minglit</span><span class="badge">Admin</span></div>
+      <div class="sidebar-item"><span class="icon">&#128200;</span> 대시보드</div>
+      <div class="sidebar-section">관리</div>
+      <div class="sidebar-item"><span class="icon">&#128100;</span> 유저 관리</div>
+      <div class="sidebar-item active"><span class="icon">&#127970;</span> 파트너 관리</div>
+      <div class="sidebar-item"><span class="icon">&#127881;</span> 이벤트 관리</div>
+      <div class="sidebar-item"><span class="icon">&#128179;</span> 결제/환불</div>
+      <div class="sidebar-item"><span class="icon">&#128176;</span> 정산 관리</div>
+      <div class="sidebar-footer">
+        <div class="admin-profile">
+          <div class="admin-avatar">M</div>
+          <div><div class="admin-name">Mark</div><div class="admin-role">super_admin</div></div>
+        </div>
+      </div>
+    </nav>
+
+    <main class="main">
+      <div class="page-header">
+        <div>
+          <div class="screen-label">상태 변형</div>
+          <div class="page-title">빈 상태 / 에러 상태</div>
+        </div>
+      </div>
+
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:24px;">
+        <!-- Empty: Queue -->
+        <div class="data-table">
+          <div style="padding:12px 16px;font-weight:600;border-bottom:1px solid var(--border);">심사 큐 — 빈 상태</div>
+          <div class="empty-state">
+            <div class="icon">&#127881;</div>
+            <div class="title">처리할 심사 건이 없습니다</div>
+            <div class="desc">모든 심사가 완료되었습니다. 수고하셨습니다!</div>
+          </div>
+        </div>
+
+        <!-- Empty: Search -->
+        <div class="data-table">
+          <div style="padding:12px 16px;font-weight:600;border-bottom:1px solid var(--border);">검색 결과 — 빈 상태</div>
+          <div class="empty-state">
+            <div class="icon">&#128269;</div>
+            <div class="title">조건에 맞는 데이터가 없습니다</div>
+            <div class="desc">검색어나 필터 조건을 변경해보세요.</div>
+            <button class="btn btn-secondary" style="margin-top:16px;">필터 초기화</button>
+          </div>
+        </div>
+
+        <!-- Error: Data Load -->
+        <div class="error-state">
+          <div class="icon">&#9888;</div>
+          <div class="title">데이터를 불러올 수 없습니다</div>
+          <div class="desc" style="font-size:14px;color:var(--text-secondary);">서버와의 연결에 문제가 있습니다. 잠시 후 다시 시도해주세요.</div>
+          <button class="btn btn-primary" style="margin-top:16px;">다시 시도</button>
+        </div>
+
+        <!-- Error: Refund -->
+        <div style="background:var(--bg);border:1px solid var(--border);border-radius:16px;padding:24px;">
+          <div style="font-weight:600;margin-bottom:16px;">환불 실패 — Toast 알림</div>
+          <div style="background:#FEF2F2;border:1px solid #FECACA;border-radius:12px;padding:16px;display:flex;align-items:center;gap:12px;">
+            <span style="font-size:20px;">&#9888;</span>
+            <div>
+              <div style="font-weight:600;color:var(--error);">환불 처리에 실패했습니다</div>
+              <div style="font-size:13px;color:var(--text-secondary);">Portone 상태를 확인해주세요. (에러코드: PG_TIMEOUT)</div>
+            </div>
+            <button class="btn btn-secondary" style="margin-left:auto;font-size:12px;">재시도</button>
+          </div>
+        </div>
+      </div>
+    </main>
+  </div>
+</div>
+
+<script>
+  // Screen tab navigation
+  document.querySelectorAll('.screen-tab').forEach(tab => {
+    tab.addEventListener('click', () => {
+      document.querySelectorAll('.screen-tab').forEach(t => t.classList.remove('active'));
+      document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
+      tab.classList.add('active');
+      document.getElementById('screen-' + tab.dataset.screen).classList.add('active');
+    });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Scheduler: needs-pm-claude-1

## Summary

Closes #1462

Admin Dashboard의 PRD(spec.md)와 인터랙티브 와이어프레임(wireframe.html)을 작성했습니다.

- **spec.md**: Working Backwards + JTBD 기반 PRD. P0 8개 화면 상세 설계, 기존 DB 스키마 매핑, 보안(MFA+RBAC+감사로그) 설계 포함
- **wireframe.html**: 10개 화면(로그인/MFA, 대시보드, 유저관리, 파트너심사, 이벤트, 결제/환불, 정산, 감사로그, 로딩, 빈/에러 상태) 인터랙티브 프로토타입

### 시장 조사 참고
Stripe Dashboard, Shopify Admin(Polaris), Linear, Retool/Appsmith, Airbnb Host Dashboard 분석 후 밍글릿 운영에 최적화된 패턴 적용.

### 기술 스택 제안
Next.js + Shadcn/UI + TanStack Table + Recharts + Supabase(기존) + TOTP MFA

### Mark 승인 요청
PRD + Wireframe 검토 후 승인해주시면 `needs-uiux` → `needs-arch` → `needs-swe` 순서로 진행합니다.

## Test plan
- [ ] wireframe.html을 브라우저에서 열어 10개 화면 탭 전환 확인
- [ ] spec.md의 P0 요구사항 8개 화면이 wireframe에 모두 반영되었는지 대조
- [ ] 기존 DB 테이블(app_roles, partner_applications 등)과 스펙의 데이터 소스 매핑 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)