### PR TITLE
feat(ui): 버그 리포트 FAB 토글 — 액션 버튼으로 표시/숨김 전환

### DIFF
--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -71,6 +71,8 @@ class _HomePageState extends ConsumerState<HomePage> {
     });
 
     return Scaffold(
+      // Fix #1466: FAB 토글 — BugReportAction으로 표시/숨김 전환
+      floatingActionButton: const BugReportFab(),
       // Fix #667: Scaffold.bottomSheet does not preserve the parent bottom
       // inset here, so pad the bar manually above the home indicator.
       bottomSheet: reservesNowBarSpace

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
@@ -30,7 +30,19 @@ final bugReporterCallbackProvider =
 /// Toggled by [BugReportAction]. State persists across screen transitions
 /// but resets on app restart (in-memory only).
 // Fix #1466: FAB 토글 — 액션 버튼으로 FAB 표시/숨김 전환
-final bugReportFabVisibleProvider = StateProvider<bool>((_) => false);
+// StateProvider is removed in Riverpod v3; use Notifier instead.
+final bugReportFabVisibleProvider =
+    NotifierProvider<_BugReportFabVisibleNotifier, bool>(
+      _BugReportFabVisibleNotifier.new,
+    );
+
+class _BugReportFabVisibleNotifier extends Notifier<bool> {
+  @override
+  bool build() => false;
+
+  /// Toggles FAB visibility.
+  void toggle() => state = !state;
+}
 
 class _BugReporterCallbackNotifier extends Notifier<Future<void> Function()?> {
   @override
@@ -424,8 +436,7 @@ class BugReportAction extends ConsumerWidget {
       color: MinglitColors.error,
       tooltip: 'Bug Report',
       // Fix #1466: toggle FAB visibility instead of opening dialog directly
-      onPressed: () =>
-          ref.read(bugReportFabVisibleProvider.notifier).update((v) => !v),
+      onPressed: () => ref.read(bugReportFabVisibleProvider.notifier).toggle(),
     );
   }
 }

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/bug_reporter_wrapper.dart
@@ -25,6 +25,13 @@ final bugReporterCallbackProvider =
       _BugReporterCallbackNotifier.new,
     );
 
+/// Dev-only: controls whether [BugReportFab] is visible.
+///
+/// Toggled by [BugReportAction]. State persists across screen transitions
+/// but resets on app restart (in-memory only).
+// Fix #1466: FAB 토글 — 액션 버튼으로 FAB 표시/숨김 전환
+final bugReportFabVisibleProvider = StateProvider<bool>((_) => false);
+
 class _BugReporterCallbackNotifier extends Notifier<Future<void> Function()?> {
   @override
   Future<void> Function()? build() => null;
@@ -396,10 +403,12 @@ class _BugReporterWrapperState extends ConsumerState<BugReporterWrapper> {
   }
 }
 
-/// Action button for the app bar that triggers the bug reporter.
+/// Action button for the app bar that toggles [BugReportFab] visibility.
 ///
 /// Only renders in non-release mode when [BugReporterWrapper] is active.
-// Fix #1285: FAB 대체 — 앱바 액션 버튼 (dev only)
+/// Tapping toggles [bugReportFabVisibleProvider]; the FAB itself opens the
+/// bug report dialog.
+// Fix #1466: 액션 버튼이 다이얼로그를 직접 열지 않고 FAB 표시/숨김을 토글
 class BugReportAction extends ConsumerWidget {
   /// Creates a bug report action button.
   const BugReportAction({super.key});
@@ -407,13 +416,41 @@ class BugReportAction extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     if (kReleaseMode) return const SizedBox.shrink();
-    final showDialog = ref.watch(bugReporterCallbackProvider);
-    if (showDialog == null) return const SizedBox.shrink();
+    if (ref.watch(bugReporterCallbackProvider) == null) {
+      return const SizedBox.shrink();
+    }
     return IconButton(
       icon: const Icon(Icons.bug_report),
       color: MinglitColors.error,
       tooltip: 'Bug Report',
-      onPressed: showDialog,
+      // Fix #1466: toggle FAB visibility instead of opening dialog directly
+      onPressed: () =>
+          ref.read(bugReportFabVisibleProvider.notifier).update((v) => !v),
+    );
+  }
+}
+
+/// Dev-only FAB that opens the bug report dialog.
+///
+/// Visibility is controlled by [bugReportFabVisibleProvider], which is
+/// toggled via [BugReportAction] in the app bar. Add this to your
+/// [Scaffold.floatingActionButton] on screens that show [BugReportAction].
+// Fix #1466: FAB 토글 — 기본 숨김, 액션 버튼으로 표시
+class BugReportFab extends ConsumerWidget {
+  /// Creates a bug report FAB.
+  const BugReportFab({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (kReleaseMode) return const SizedBox.shrink();
+    final isFabVisible = ref.watch(bugReportFabVisibleProvider);
+    final openDialog = ref.watch(bugReporterCallbackProvider);
+    if (!isFabVisible || openDialog == null) return const SizedBox.shrink();
+    return FloatingActionButton(
+      backgroundColor: MinglitColors.error,
+      tooltip: 'Bug Report',
+      onPressed: openDialog,
+      child: const Icon(Icons.bug_report),
     );
   }
 }

--- a/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
+++ b/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
@@ -315,13 +315,13 @@ void main() {
         ),
       );
 
-      expect(container.read(bugReportFabVisibleProvider), isFalse);
+      expect(container.read<bool>(bugReportFabVisibleProvider), isFalse);
 
       await tester.tap(find.byType(IconButton).first);
-      expect(container.read(bugReportFabVisibleProvider), isTrue);
+      expect(container.read<bool>(bugReportFabVisibleProvider), isTrue);
 
       await tester.tap(find.byType(IconButton).first);
-      expect(container.read(bugReportFabVisibleProvider), isFalse);
+      expect(container.read<bool>(bugReportFabVisibleProvider), isFalse);
     });
   });
 }

--- a/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
+++ b/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
@@ -264,16 +264,13 @@ void main() {
     });
 
     // Fix #1466: BugReportFab는 FAB visible + callback 모두 set 시에만 보임.
-    // _BugReporterCallbackNotifier는 private이므로 overrideWith 대신
-    // BugReporterWrapper를 마운트하여 실제 callback을 등록한다.
+    // _BugReporterCallbackNotifier와 _BugReportFabVisibleNotifier 모두 private이므로
+    // BugReporterWrapper를 마운트하여 실제 callback을 등록하고,
+    // notifier.toggle()로 FAB visible 상태를 활성화한다.
     testWidgets('visible when provider is true and callback is set', (
       tester,
     ) async {
-      final container = ProviderContainer(
-        overrides: [
-          bugReportFabVisibleProvider.overrideWith((_) => true),
-        ],
-      );
+      final container = ProviderContainer();
       addTearDown(container.dispose);
 
       await tester.pumpWidget(
@@ -288,6 +285,10 @@ void main() {
         ),
       );
       // postFrameCallback fires — BugReporterWrapper registers callback
+      await tester.pump();
+
+      // Toggle FAB visible via notifier (StateProvider removed in Riverpod v3)
+      container.read(bugReportFabVisibleProvider.notifier).toggle();
       await tester.pump();
 
       expect(find.byType(FloatingActionButton), findsOneWidget);

--- a/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
+++ b/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
@@ -307,7 +307,7 @@ void main() {
           child: MaterialApp(
             home: Scaffold(
               appBar: AppBar(actions: const [BugReportAction()]),
-              body: BugReporterWrapper(child: const Text('content')),
+              body: const BugReporterWrapper(child: Text('content')),
             ),
           ),
         ),

--- a/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
+++ b/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
@@ -24,7 +24,9 @@ void main() {
       expect(find.text('Test Child Widget'), findsOneWidget);
     });
 
-    testWidgets('does not render FAB (FAB removed in #1285)', (tester) async {
+    testWidgets('BugReporterWrapper does not render a FAB directly', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         const ProviderScope(
           child: MaterialApp(
@@ -38,7 +40,8 @@ void main() {
         ),
       );
 
-      // FAB has been removed in #1285 — no FAB should be present
+      // BugReporterWrapper itself does not render a FAB.
+      // FAB is in Scaffold.floatingActionButton (home_page), not here.
       expect(find.byType(FloatingActionButton), findsNothing);
     });
 
@@ -149,9 +152,9 @@ void main() {
       // No crash = state was properly cleaned up
     });
 
-    // Fix #1285: FAB has been removed. BugReporterWrapper now registers
-    // _showReportDialog via bugReporterCallbackProvider instead of rendering a FAB.
-    testWidgets('no FAB rendered when enabled (FAB removed in #1285)', (
+    // BugReporterWrapper registers _showReportDialog via bugReporterCallbackProvider.
+    // FAB (#1466) is in Scaffold.floatingActionButton, not inside BugReporterWrapper.
+    testWidgets('BugReporterWrapper does not render a FAB directly', (
       tester,
     ) async {
       await tester.pumpWidget(
@@ -166,10 +169,8 @@ void main() {
         ),
       );
 
-      // Verify child is rendered
       expect(find.text('content'), findsOneWidget);
-
-      // FAB removed in #1285 — no FloatingActionButton should be in the tree
+      // FAB lives in Scaffold.floatingActionButton (home_page), not here
       expect(find.byType(FloatingActionButton), findsNothing);
     });
 
@@ -241,4 +242,91 @@ void main() {
       // No crash = dispose completed cleanly
     });
   });
+
+  // Fix #1466: BugReportFab toggle behavior
+  group('BugReportFab', () {
+    testWidgets('hidden by default (bugReportFabVisibleProvider == false)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              floatingActionButton: BugReportFab(),
+              body: Text('content'),
+            ),
+          ),
+        ),
+      );
+
+      // Default: FAB not visible
+      expect(find.byType(FloatingActionButton), findsNothing);
+    });
+
+    testWidgets('visible when provider is true and callback is set', (
+      tester,
+    ) async {
+      final container = ProviderContainer(
+        overrides: [
+          bugReportFabVisibleProvider.overrideWith((_) => true),
+          bugReporterCallbackProvider.overrideWith(
+            () => _TestCallbackNotifier(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(
+            home: Scaffold(
+              floatingActionButton: BugReportFab(),
+              body: Text('content'),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(FloatingActionButton), findsOneWidget);
+    });
+
+    testWidgets('BugReportAction tap toggles bugReportFabVisibleProvider', (
+      tester,
+    ) async {
+      final container = ProviderContainer(
+        overrides: [
+          bugReporterCallbackProvider.overrideWith(
+            () => _TestCallbackNotifier(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            home: Scaffold(
+              appBar: AppBar(actions: const [BugReportAction()]),
+              body: const Text('content'),
+            ),
+          ),
+        ),
+      );
+
+      expect(container.read(bugReportFabVisibleProvider), isFalse);
+
+      await tester.tap(find.byType(IconButton).first);
+      expect(container.read(bugReportFabVisibleProvider), isTrue);
+
+      await tester.tap(find.byType(IconButton).first);
+      expect(container.read(bugReportFabVisibleProvider), isFalse);
+    });
+  });
+}
+
+class _TestCallbackNotifier extends Notifier<Future<void> Function()?> {
+  @override
+  Future<void> Function()? build() => () async {};
 }

--- a/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
+++ b/shared/packages/minglit_kit/test/ui/widgets/bug_reporter_wrapper_test.dart
@@ -263,15 +263,15 @@ void main() {
       expect(find.byType(FloatingActionButton), findsNothing);
     });
 
+    // Fix #1466: BugReportFab는 FAB visible + callback 모두 set 시에만 보임.
+    // _BugReporterCallbackNotifier는 private이므로 overrideWith 대신
+    // BugReporterWrapper를 마운트하여 실제 callback을 등록한다.
     testWidgets('visible when provider is true and callback is set', (
       tester,
     ) async {
       final container = ProviderContainer(
         overrides: [
           bugReportFabVisibleProvider.overrideWith((_) => true),
-          bugReporterCallbackProvider.overrideWith(
-            () => _TestCallbackNotifier(),
-          ),
         ],
       );
       addTearDown(container.dispose);
@@ -282,25 +282,23 @@ void main() {
           child: const MaterialApp(
             home: Scaffold(
               floatingActionButton: BugReportFab(),
-              body: Text('content'),
+              body: BugReporterWrapper(child: Text('content')),
             ),
           ),
         ),
       );
+      // postFrameCallback fires — BugReporterWrapper registers callback
+      await tester.pump();
 
       expect(find.byType(FloatingActionButton), findsOneWidget);
     });
 
+    // Fix #1466: BugReportAction은 callback이 등록되어 있을 때만 IconButton을 렌더링.
+    // BugReporterWrapper를 마운트하여 실제 callback을 등록한다.
     testWidgets('BugReportAction tap toggles bugReportFabVisibleProvider', (
       tester,
     ) async {
-      final container = ProviderContainer(
-        overrides: [
-          bugReporterCallbackProvider.overrideWith(
-            () => _TestCallbackNotifier(),
-          ),
-        ],
-      );
+      final container = ProviderContainer();
       addTearDown(container.dispose);
 
       await tester.pumpWidget(
@@ -309,24 +307,23 @@ void main() {
           child: MaterialApp(
             home: Scaffold(
               appBar: AppBar(actions: const [BugReportAction()]),
-              body: const Text('content'),
+              body: BugReporterWrapper(child: const Text('content')),
             ),
           ),
         ),
       );
+      // postFrameCallback fires — BugReporterWrapper registers callback
+      await tester.pump();
 
       expect(container.read<bool>(bugReportFabVisibleProvider), isFalse);
 
       await tester.tap(find.byType(IconButton).first);
+      await tester.pump();
       expect(container.read<bool>(bugReportFabVisibleProvider), isTrue);
 
       await tester.tap(find.byType(IconButton).first);
+      await tester.pump();
       expect(container.read<bool>(bugReportFabVisibleProvider), isFalse);
     });
   });
-}
-
-class _TestCallbackNotifier extends Notifier<Future<void> Function()?> {
-  @override
-  Future<void> Function()? build() => () async {};
 }


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1466

## Summary

- `BugReportAction` (앱바 버튼)이 버그 리포트 다이얼로그를 직접 열지 않고, FAB 표시/숨김을 토글
- FAB 탭 시 기존과 동일하게 버그 리포트 다이얼로그 오픈
- 기본값: FAB 숨김 (깔끔한 UI 유지)

## 변경 사항

| 파일 | 변경 내용 |
|------|----------|
| `minglit_kit/bug_reporter_wrapper.dart` | `bugReportFabVisibleProvider` 추가, `BugReportAction` 동작 변경, `BugReportFab` 위젯 추가 |
| `app_user/home_page.dart` | Scaffold에 `floatingActionButton: BugReportFab()` 추가 |
| `minglit_kit/bug_reporter_wrapper_test.dart` | 토글 동작 테스트 3개 추가 |

## 동작 플로우

```
기본: FAB 숨김
[앱바 🐛 탭] → FAB 표시 (우하단, 빨간)
[앱바 🐛 다시 탭] → FAB 숨김
[FAB 탭] → 버그 리포트 다이얼로그 열기 (기존 동작 유지)
```

## Test plan

- [ ] 앱바 버그 리포트 버튼 탭 → FAB 표시 확인
- [ ] 다시 탭 → FAB 숨김 확인
- [ ] FAB 탭 → 버그 리포트 다이얼로그 열림 확인
- [ ] 화면 전환 후 홈 복귀 → FAB 상태 유지 확인
- [ ] 앱 재시작 → FAB 기본값 숨김 확인