### PR TITLE
docs(ux): 설정/마이페이지 디자인 시스템 정의 — MinglitSettingsTile + MinglitSettingsGroup

### DIFF
--- a/docs/features/settings-redesign/ui-ux-design.md
+++ b/docs/features/settings-redesign/ui-ux-design.md
@@ -1,0 +1,348 @@
+# Settings/MyPage Design System Redesign
+
+> Issue: #1475
+> Status: Design Spec
+> Last Updated: 2026-04-15
+
+## 1. Problem Statement
+
+현재 설정 화면(User App MyPage, Partner App MorePage)의 문제점:
+
+| 문제 | 현재 상태 | 목표 |
+|------|-----------|------|
+| 레이아웃 | raw `ListTile`, 카드 그룹 없음 | 카드 기반 섹션 그룹 |
+| 밀도 | ~56px 높이, 넓은 간격 | 48px compact 타일 |
+| 정보 | 현재 값 subtitle 없음 | 테마, 알림 등 현재 값 표시 |
+| 일관성 | trailing 위젯 불일치 | chevron/switch/value 패턴 통일 |
+| 구분 | plain `Divider()` | 시맨틱 카드 그룹 + 섹션 헤더 |
+
+벤치마크: Claude 앱 수준의 compact, information-dense 설정 화면.
+
+---
+
+## 2. Design Tokens (기존 토큰만 사용)
+
+### 사용하는 토큰
+
+| 용도 | 토큰 | 값 |
+|------|------|----|
+| 타일 제목 | `bodyMedium` | 16px normal |
+| 타일 부제 (현재 값) | `bodySmall` | 13px |
+| 섹션 헤더 | `labelMedium` | 12px w500 |
+| 프로필 이름 | `titleMedium` | 16px bold |
+| 프로필 부제 | `bodySmall` | 13px |
+| 아이콘 사이즈 | `MinglitIconSize.small` | 20px |
+| 카드 라운딩 | `MinglitRadius.card` | 16px |
+| 화면 가장자리 | `MinglitSpacing.medium` | 16px |
+| 그룹 간 간격 | `MinglitSpacing.large` | 24px |
+| 타일 수평 패딩 | `MinglitSpacing.medium` | 16px |
+| 타일 수직 패딩 | `MinglitSpacing.xsmall` | 4px |
+| 섹션 헤더 하단 마진 | `MinglitSpacing.small` | 8px |
+
+### 신규 토큰 제안 없음
+
+모든 스펙은 기존 `MinglitSpacing`, `MinglitRadius`, `MinglitIconSize` 토큰으로 충족된다.
+
+---
+
+## 3. Component Specs
+
+### 3.1 MinglitSettingsTile
+
+설정 화면 전용 compact 타일 위젯.
+
+```
+┌─────────────────────────────────────────────────────┐
+│ [icon 20px]  Title (bodyMedium 16px)    [trailing]  │  48px height
+│              Subtitle (bodySmall 13px)              │
+└─────────────────────────────────────────────────────┘
+     ↕4px        ←16px→                    ←16px→
+```
+
+#### Properties
+
+| Property | Type | 설명 |
+|----------|------|------|
+| `leading` | `IconData` | 좌측 아이콘 (20px, `onSurfaceVariant`) |
+| `title` | `String` | 제목 (`bodyMedium`, 16px) |
+| `subtitle` | `String?` | 현재 값 표시 (`bodySmall`, 13px, `onSurfaceVariant`) |
+| `trailing` | `SettingsTileTrailing` | chevron / switch / value / none |
+| `onTap` | `VoidCallback?` | 탭 액션 |
+| `destructive` | `bool` | true이면 title/icon을 `error` 색상으로 표시 |
+
+#### Trailing Types
+
+| 타입 | 위젯 | 용도 |
+|------|------|------|
+| `navigation` | `Icon(Icons.chevron_right, size: 20, color: onSurfaceVariant)` | 페이지 이동 |
+| `toggle` | `Switch.adaptive()` | on/off 토글 |
+| `value` | `Text(value, style: bodySmall, color: onSurfaceVariant)` | 읽기 전용 값 표시 |
+| `none` | 없음 | trailing 불필요 시 |
+
+#### Layout Rules
+
+- **Height**: 48dp (compact). subtitle이 있어도 48dp 유지 (2줄 텍스트가 아이콘 높이 안에 들어감).
+- **Horizontal padding**: `MinglitSpacing.medium` (16px) 양쪽.
+- **Vertical padding**: `MinglitSpacing.xsmall` (4px) 상하.
+- **Icon-to-title gap**: `MinglitSpacing.medium` (16px).
+- **Touch target**: 48dp minimum (Material accessibility guideline 충족).
+- **Ink ripple**: bounded within tile area.
+- **Icon color**: `colorScheme.onSurfaceVariant` (destructive일 때 `colorScheme.error`).
+- **Title color**: `colorScheme.onSurface` (destructive일 때 `colorScheme.error`).
+- **Subtitle color**: `colorScheme.onSurfaceVariant`.
+
+### 3.2 MinglitSettingsGroup
+
+카드 형태로 관련 설정 항목을 묶는 컨테이너.
+
+```
+            SECTION HEADER (labelMedium, uppercase)
+          ┌─────────────────────────────────────────┐
+          │  Setting Item 1                         │
+          │─────────────────────────────────────────│  ← divider (left inset 56px)
+          │  Setting Item 2                         │
+          │─────────────────────────────────────────│
+          │  Setting Item 3                         │
+          └─────────────────────────────────────────┘
+   ←16px→                                     ←16px→
+                        ↕24px (group gap)
+```
+
+#### Properties
+
+| Property | Type | 설명 |
+|----------|------|------|
+| `header` | `String?` | 섹션 헤더 텍스트 (optional) |
+| `children` | `List<Widget>` | `MinglitSettingsTile` 목록 |
+
+#### Layout Rules
+
+- **Background**: `surfaceContainerLowest` (light) / `surfaceContainerHigh` (dark)
+  - M3 `ColorScheme.fromSeed()`가 자동 생성하는 surface container 계열 사용.
+  - 페이지 배경(`scaffoldBackgroundColor`)과 미세한 대비 제공.
+- **Border radius**: `MinglitRadius.card` (16px).
+- **Internal padding**: 0 (타일이 자체 패딩 처리).
+- **Margin**: horizontal `MinglitSpacing.medium` (16px).
+- **Gap between groups**: `MinglitSpacing.large` (24px).
+- **Elevation**: 0 (플랫 디자인, 배경색 대비로만 구분).
+- **Clip behavior**: `Clip.antiAlias` (첫/마지막 타일의 ripple이 radius를 넘지 않도록).
+
+#### Section Header Rules
+
+- **Typography**: `labelMedium` (12px, w500).
+- **Transform**: uppercase (한글은 그대로, 영문만 해당).
+- **Color**: `colorScheme.onSurfaceVariant`.
+- **Alignment**: left, `MinglitSpacing.medium` (16px) padding.
+- **Bottom margin**: `MinglitSpacing.small` (8px).
+
+#### Internal Divider
+
+- **Thickness**: 0.5px.
+- **Color**: `colorScheme.outlineVariant`.
+- **Left inset**: 56px (16px padding + 20px icon + 16px gap + 4px extra = 아이콘 이후 정렬).
+- **Right inset**: 0.
+
+### 3.3 Profile Area
+
+프로필 섹션은 독립된 `MinglitSettingsGroup` 카드 안에 위치.
+
+```
+          ┌─────────────────────────────────────────┐
+          │  ┌──────┐                               │
+          │  │Avatar│  Name (titleMedium 16px bold)  [>]│
+          │  │ 48px │  email@ex.com (bodySmall 13px)│
+          │  └──────┘                               │
+          └─────────────────────────────────────────┘
+```
+
+#### Layout Rules
+
+- **Avatar**: `CircleAvatar(radius: 24)` → 48px diameter (기존 32px에서 증가).
+- **Name**: `titleMedium` (16px bold), `colorScheme.onSurface`.
+- **Email/info**: `bodySmall` (13px), `colorScheme.onSurfaceVariant`.
+- **Trailing**: chevron (프로필 편집 진입).
+- **Internal padding**: `MinglitSpacing.medium` (16px) all sides.
+- **Avatar-to-text gap**: `MinglitSpacing.medium` (16px).
+- **Top margin from AppBar**: `MinglitSpacing.medium` (16px).
+
+---
+
+## 4. Page Structure
+
+### 4.1 Overall Layout
+
+```
+┌──────────────────────────────────┐
+│  AppBar (no elevation, simple)   │
+├──────────────────────────────────┤
+│                                  │
+│  [ScrollView]                    │
+│    ↕16px (top padding)           │
+│    ┌──── Profile Group ────┐     │
+│    └───────────────────────┘     │
+│    ↕24px                         │
+│    SECTION HEADER                │
+│    ┌──── Settings Group ───┐     │
+│    └───────────────────────┘     │
+│    ↕24px                         │
+│    SECTION HEADER                │
+│    ┌──── Settings Group ───┐     │
+│    └───────────────────────┘     │
+│    ...                           │
+│    ↕ bottom safe area            │
+│                                  │
+└──────────────────────────────────┘
+```
+
+- **Page background**: `scaffoldBackgroundColor` (light: `#FFFFFF`, dark: `#0F0F0F`).
+- **AppBar**: `title` only, `elevation: 0`, `scrolledUnderElevation: 0`.
+- **ScrollView**: `ListView` with `padding: EdgeInsets.only(top: medium, bottom: safeArea)`.
+
+### 4.2 User App (MyPage) 시맨틱 그룹
+
+| # | 그룹 | 헤더 | 항목 | trailing |
+|---|------|------|------|----------|
+| 1 | 프로필 | (없음) | Avatar + 이름 + 이메일 | chevron |
+| 2 | 활동 | 활동 | 구매 내역 | chevron |
+|   |      |      | 내 티켓 | chevron |
+| 3 | 설정 | 설정 | 알림 설정 | chevron |
+|   |      |      | 테마 (subtitle: 현재 모드) | chevron |
+| 4 | 개인정보 및 보안 | 개인정보 및 보안 | 개인정보 | chevron |
+|   |                |                | 권한 설정 | chevron |
+|   |                |                | 차단 목록 | chevron |
+| 5 | 약관 및 정보 | 약관 및 정보 | 개인정보처리방침 | chevron |
+|   |            |            | 이용약관 | chevron |
+|   |            |            | 앱 버전 (subtitle: 버전 값) | value |
+| 6 | 계정 | 계정 | 로그아웃 (destructive) | none |
+| 7 | Dev | DEV | Design Catalog | chevron |
+
+**Group 7 (Dev)**: `kDebugMode` 또는 환경 변수로 dev 환경에서만 표시.
+
+### 4.3 Partner App (MorePage) 시맨틱 그룹
+
+| # | 그룹 | 헤더 | 항목 | trailing |
+|---|------|------|------|----------|
+| 1 | 프로필 | (없음) | Avatar + 파트너 이름 + 이메일 | chevron |
+| 2 | 비즈니스 관리 | 비즈니스 관리 | 멤버 관리 | chevron |
+|   |              |              | 본인인증 관리 | chevron |
+| 3 | 설정 | 설정 | 알림 설정 | chevron |
+|   |      |      | 테마 (subtitle: 현재 모드) | chevron |
+| 4 | 약관 및 정보 | 약관 및 정보 | 권한 | chevron |
+|   |            |            | 개인정보처리방침 | chevron |
+|   |            |            | 이용약관 | chevron |
+|   |            |            | 앱 버전 (subtitle: 버전 값) | value |
+| 5 | 계정 | 계정 | 로그아웃 (destructive) | none |
+| 6 | Dev | DEV | Design Catalog | chevron |
+
+---
+
+## 5. Light / Dark Mode
+
+### 5.1 Color Mapping
+
+| 요소 | Light | Dark |
+|------|-------|------|
+| Page background | `#FFFFFF` (scaffoldBg) | `#0F0F0F` (scaffoldBg) |
+| Card background | `surfaceContainerLowest` (M3 auto) | `surfaceContainerHigh` (M3 auto) |
+| Title text | `onSurface` | `onSurface` |
+| Subtitle text | `onSurfaceVariant` (`#4B5563`) | `onSurfaceVariant` (`#AAAAAA`) |
+| Icon color | `onSurfaceVariant` | `onSurfaceVariant` |
+| Divider | `outlineVariant` | `outlineVariant` |
+| Destructive | `error` (`#EF4444`) | `error` (`#EF4444`) |
+| Section header | `onSurfaceVariant` | `onSurfaceVariant` |
+
+### 5.2 Surface Container 전략
+
+M3의 `ColorScheme.fromSeed()`는 자동으로 `surfaceContainerLowest`~`surfaceContainerHighest` 계열을 생성한다.
+이 자동 생성 색상을 활용하여 페이지 배경과 카드 배경 사이의 미세한 대비를 구현한다.
+
+- Light: 페이지 `#FFFFFF` → 카드 `surfaceContainerLowest` (약간 따뜻한 회색)
+- Dark: 페이지 `#0F0F0F` → 카드 `surfaceContainerHigh` (약간 밝은 회색)
+
+---
+
+## 6. Interaction
+
+### 6.1 Tap Feedback
+
+- **Navigation tiles**: InkWell ripple → 페이지 이동.
+- **Toggle tiles**: Switch toggle, 타일 자체 탭도 토글 동작.
+- **Destructive tiles**: ripple → 확인 다이얼로그 → 액션.
+- **Value tiles** (앱 버전 등): 탭 불가, ripple 없음.
+
+### 6.2 Animation
+
+- Switch 토글: Material default animation (`MinglitAnimation.fast`, 200ms).
+- 페이지 전환: 기존 라우터 전환 유지.
+
+---
+
+## 7. Accessibility
+
+| 요소 | 처리 |
+|------|------|
+| Touch target | 48dp minimum height (WCAG) |
+| Semantics | `Semantics(label: ...)` for icon-only items |
+| Contrast | `onSurfaceVariant` vs card bg — WCAG AA 충족 (M3 보장) |
+| Screen reader | tile 전체가 하나의 `Semantics` 노드 |
+
+---
+
+## 8. Implementation Notes
+
+### 8.1 Widget Hierarchy
+
+```dart
+Scaffold(
+  appBar: AppBar(title: Text('마이페이지')),
+  body: ListView(
+    padding: EdgeInsets.only(
+      top: MinglitSpacing.medium,
+      bottom: MediaQuery.of(context).padding.bottom + MinglitSpacing.large,
+    ),
+    children: [
+      MinglitSettingsGroup(       // 프로필
+        children: [ProfileTile(...)],
+      ),
+      SizedBox(height: MinglitSpacing.large),
+      MinglitSettingsGroup(       // 활동
+        header: '활동',
+        children: [...],
+      ),
+      SizedBox(height: MinglitSpacing.large),
+      // ...more groups
+    ],
+  ),
+)
+```
+
+### 8.2 파일 구조 (제안)
+
+```
+shared/packages/minglit_kit/lib/src/ui/widgets/settings/
+  ├── minglit_settings_tile.dart      # MinglitSettingsTile
+  ├── minglit_settings_group.dart     # MinglitSettingsGroup
+  └── minglit_settings_profile.dart   # Profile area widget
+
+apps/app_user/lib/src/features/home/
+  └── my_page.dart                    # 기존 파일 리팩터링
+
+apps/app_partner/lib/src/features/more/
+  └── more_page.dart                  # 기존 파일 리팩터링
+```
+
+### 8.3 Breaking Changes
+
+- `ThemeSettingsTile`: `MinglitSettingsTile` 기반으로 리팩터링 필요.
+- `my_page.dart`, `more_page.dart`: 전면 리팩터링 (기존 raw ListTile 교체).
+- 기존 `MinglitListTile`은 변경 없음 (설정 외 화면에서 계속 사용).
+
+---
+
+## 9. Wireframe Reference
+
+인터랙티브 와이어프레임: [`docs/features/settings-redesign/wireframe.html`](./wireframe.html)
+
+- Current vs Redesigned 비교
+- User App / Partner App 탭
+- Light / Dark 모드 토글

--- a/docs/features/settings-redesign/wireframe.html
+++ b/docs/features/settings-redesign/wireframe.html
@@ -1,0 +1,530 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Settings Redesign Wireframe — Minglit #1475</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Pretendard:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --font: 'Pretendard', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: var(--font);
+    background: #f3f4f6;
+    color: #111827;
+    min-height: 100vh;
+  }
+
+  /* ── Controls bar ── */
+  .controls {
+    position: sticky; top: 0; z-index: 100;
+    background: #fff; border-bottom: 1px solid #e5e7eb;
+    padding: 12px 24px; display: flex; gap: 16px; align-items: center; flex-wrap: wrap;
+  }
+  .controls h1 { font-size: 16px; font-weight: 700; margin-right: auto; }
+  .tab-group { display: flex; gap: 0; border: 1px solid #d1d5db; border-radius: 8px; overflow: hidden; }
+  .tab-group button {
+    font-family: var(--font); font-size: 13px; font-weight: 500;
+    padding: 6px 16px; border: none; cursor: pointer;
+    background: #fff; color: #4b5563; transition: all .15s;
+  }
+  .tab-group button.active { background: #9900FF; color: #fff; }
+  .tab-group button:not(:last-child) { border-right: 1px solid #d1d5db; }
+
+  /* ── Frame container ── */
+  .frames { display: flex; gap: 32px; justify-content: center; padding: 32px 24px; flex-wrap: wrap; }
+
+  /* ── Phone frame ── */
+  .phone {
+    width: 375px; min-height: 720px; border-radius: 32px;
+    overflow: hidden; position: relative;
+    box-shadow: 0 8px 32px rgba(0,0,0,.12), 0 2px 8px rgba(0,0,0,.08);
+    flex-shrink: 0;
+  }
+  .phone-label {
+    text-align: center; font-size: 13px; font-weight: 600; color: #6b7280;
+    margin-bottom: 12px; text-transform: uppercase; letter-spacing: 0.5px;
+  }
+
+  /* ── Theme colors ── */
+  .phone.light {
+    --page-bg: #FFFFFF;
+    --card-bg: #F5F3F0;
+    --text-primary: #111827;
+    --text-secondary: #4B5563;
+    --divider: #E8E5E0;
+    --outline-variant: #E0DDD8;
+    --error: #EF4444;
+    --appbar-bg: #FFFFFF;
+    --switch-track: #9900FF;
+  }
+  .phone.dark {
+    --page-bg: #0F0F0F;
+    --card-bg: #2A2A2A;
+    --text-primary: #FFFFFF;
+    --text-secondary: #AAAAAA;
+    --divider: #3D3D3D;
+    --outline-variant: #404040;
+    --error: #EF4444;
+    --appbar-bg: #0F0F0F;
+    --switch-track: #AA33FF;
+  }
+
+  .phone-screen {
+    background: var(--page-bg);
+    min-height: 720px;
+    overflow-y: auto;
+  }
+
+  /* ── AppBar ── */
+  .appbar {
+    height: 56px; display: flex; align-items: center; padding: 0 16px;
+    background: var(--appbar-bg);
+    font-size: 18px; font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  /* ── Settings Group ── */
+  .settings-group {
+    margin: 0 16px; border-radius: 16px;
+    background: var(--card-bg);
+    overflow: hidden;
+  }
+  .settings-group + .section-header { margin-top: 24px; }
+  .settings-group:first-child { margin-top: 0; }
+
+  .section-header {
+    font-size: 12px; font-weight: 500; color: var(--text-secondary);
+    text-transform: uppercase; letter-spacing: 0.3px;
+    padding: 0 16px; margin-bottom: 8px;
+  }
+
+  .group-gap { height: 24px; }
+
+  /* ── Settings Tile (redesigned) ── */
+  .settings-tile {
+    display: flex; align-items: center;
+    height: 48px; padding: 0 16px;
+    cursor: pointer; position: relative;
+    transition: background .12s;
+  }
+  .settings-tile:hover { background: rgba(0,0,0,.04); }
+  .dark .settings-tile:hover { background: rgba(255,255,255,.06); }
+
+  .settings-tile .tile-icon {
+    width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;
+    color: var(--text-secondary); font-size: 20px; flex-shrink: 0;
+  }
+  .settings-tile .tile-content {
+    flex: 1; margin-left: 16px; min-width: 0;
+    display: flex; flex-direction: column; justify-content: center;
+  }
+  .settings-tile .tile-title {
+    font-size: 16px; font-weight: 400; color: var(--text-primary);
+    line-height: 1.3; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .settings-tile .tile-subtitle {
+    font-size: 13px; font-weight: 400; color: var(--text-secondary);
+    line-height: 1.2; margin-top: 1px;
+  }
+  .settings-tile .tile-trailing {
+    color: var(--text-secondary); font-size: 20px; flex-shrink: 0; margin-left: 8px;
+    display: flex; align-items: center;
+  }
+  .settings-tile .tile-trailing .value-text {
+    font-size: 13px; font-weight: 400; color: var(--text-secondary);
+  }
+  .settings-tile.destructive .tile-icon,
+  .settings-tile.destructive .tile-title { color: var(--error); }
+  .settings-tile.no-tap { cursor: default; }
+  .settings-tile.no-tap:hover { background: transparent; }
+
+  .tile-divider {
+    height: 0.5px; background: var(--outline-variant);
+    margin-left: 52px;
+  }
+
+  /* ── Profile tile (redesigned) ── */
+  .profile-tile {
+    display: flex; align-items: center;
+    padding: 16px; cursor: pointer;
+    transition: background .12s;
+  }
+  .profile-tile:hover { background: rgba(0,0,0,.04); }
+  .dark .profile-tile:hover { background: rgba(255,255,255,.06); }
+
+  .profile-avatar {
+    width: 48px; height: 48px; border-radius: 50%;
+    background: linear-gradient(135deg, #9900FF 0%, #CC66FF 100%);
+    display: flex; align-items: center; justify-content: center;
+    color: #fff; font-size: 22px; flex-shrink: 0;
+  }
+  .profile-info { flex: 1; margin-left: 16px; }
+  .profile-name { font-size: 16px; font-weight: 700; color: var(--text-primary); }
+  .profile-email { font-size: 13px; color: var(--text-secondary); margin-top: 2px; }
+  .profile-chevron { color: var(--text-secondary); font-size: 20px; }
+
+  /* ── Old-style tiles (current) ── */
+  .old-tile {
+    display: flex; align-items: center;
+    min-height: 56px; padding: 8px 16px;
+    cursor: pointer;
+  }
+  .old-tile .old-icon {
+    width: 24px; height: 24px; color: var(--text-secondary);
+    font-size: 24px; display: flex; align-items: center; justify-content: center;
+  }
+  .old-tile .old-content { flex: 1; margin-left: 16px; }
+  .old-tile .old-title { font-size: 18px; color: var(--text-primary); }
+  .old-tile .old-trailing { color: var(--text-secondary); font-size: 24px; }
+  .old-tile.destructive .old-icon,
+  .old-tile.destructive .old-title { color: var(--error); }
+
+  .old-divider { height: 1px; background: var(--divider); margin: 0 16px; }
+  .old-full-divider { height: 1px; background: var(--divider); }
+
+  .old-profile {
+    display: flex; align-items: center; padding: 24px;
+  }
+  .old-avatar {
+    width: 64px; height: 64px; border-radius: 50%;
+    background: linear-gradient(135deg, #9900FF 0%, #CC66FF 100%);
+    display: flex; align-items: center; justify-content: center;
+    color: #fff; font-size: 28px; flex-shrink: 0;
+  }
+  .old-profile-info { margin-left: 16px; }
+  .old-profile-name { font-size: 20px; font-weight: 700; color: var(--text-primary); }
+  .old-profile-email { font-size: 16px; color: var(--text-secondary); margin-top: 4px; }
+
+  /* ── SVG Icons (inline) ── */
+  .icon { display: inline-flex; }
+
+  .content-area { padding: 16px 0; }
+
+  /* ── Hidden state ── */
+  .hidden { display: none !important; }
+</style>
+</head>
+<body>
+
+<div class="controls">
+  <h1>Settings Redesign #1475</h1>
+
+  <div class="tab-group" id="viewTabs">
+    <button class="active" data-view="compare">Current vs Redesigned</button>
+    <button data-view="redesigned">Redesigned Only</button>
+  </div>
+
+  <div class="tab-group" id="appTabs">
+    <button class="active" data-app="user">User App</button>
+    <button data-app="partner">Partner App</button>
+  </div>
+
+  <div class="tab-group" id="themeTabs">
+    <button class="active" data-theme="light">Light</button>
+    <button data-theme="dark">Dark</button>
+  </div>
+</div>
+
+<div class="frames" id="framesContainer">
+
+  <!-- ============================================ -->
+  <!-- CURRENT: USER APP                            -->
+  <!-- ============================================ -->
+  <div id="current-user" data-role="current" data-app="user">
+    <div class="phone-label">Current</div>
+    <div class="phone light">
+      <div class="phone-screen">
+        <div class="appbar">마이페이지</div>
+
+        <div class="old-profile">
+          <div class="old-avatar">
+            <span class="icon">&#x1F464;</span>
+          </div>
+          <div class="old-profile-info">
+            <div class="old-profile-name">홍길동</div>
+            <div class="old-profile-email">hong@email.com</div>
+          </div>
+        </div>
+        <div class="old-full-divider"></div>
+
+        <div class="old-tile"><div class="old-icon">&#x1F4CB;</div><div class="old-content"><div class="old-title">구매 내역</div></div><div class="old-trailing">&#x203A;</div></div>
+        <div class="old-tile"><div class="old-icon">&#x1F3AB;</div><div class="old-content"><div class="old-title">내 티켓</div></div><div class="old-trailing">&#x203A;</div></div>
+        <div class="old-full-divider"></div>
+
+        <div class="old-tile"><div class="old-icon">&#x1F514;</div><div class="old-content"><div class="old-title">알림 설정</div></div><div class="old-trailing">&#x203A;</div></div>
+        <div class="old-tile"><div class="old-icon">&#x2600;</div><div class="old-content"><div class="old-title">테마</div></div><div class="old-trailing">&#x203A;</div></div>
+        <div class="old-tile"><div class="old-icon">&#x1F6AB;</div><div class="old-content"><div class="old-title">차단 목록</div></div><div class="old-trailing">&#x203A;</div></div>
+        <div class="old-full-divider"></div>
+
+        <div class="old-tile"><div class="old-icon">&#x1F512;</div><div class="old-content"><div class="old-title">권한</div></div><div class="old-trailing">&#x203A;</div></div>
+        <div class="old-tile"><div class="old-icon">&#x1F6E1;</div><div class="old-content"><div class="old-title">개인정보처리방침</div></div><div class="old-trailing">&#x203A;</div></div>
+        <div class="old-tile"><div class="old-icon">&#x1F4C4;</div><div class="old-content"><div class="old-title">이용약관</div></div><div class="old-trailing">&#x203A;</div></div>
+        <div class="old-tile"><div class="old-icon">&#x2139;</div><div class="old-content"><div class="old-title">앱 버전</div></div><div class="old-trailing" style="font-size:14px;">26.04.1455</div></div>
+        <div class="old-full-divider"></div>
+
+        <div class="old-tile destructive"><div class="old-icon">&#x2190;</div><div class="old-content"><div class="old-title">로그아웃</div></div></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============================================ -->
+  <!-- REDESIGNED: USER APP                         -->
+  <!-- ============================================ -->
+  <div id="redesigned-user" data-role="redesigned" data-app="user">
+    <div class="phone-label">Redesigned</div>
+    <div class="phone light">
+      <div class="phone-screen">
+        <div class="appbar">마이페이지</div>
+        <div class="content-area">
+
+          <!-- Profile -->
+          <div class="settings-group">
+            <div class="profile-tile">
+              <div class="profile-avatar">&#x1F464;</div>
+              <div class="profile-info">
+                <div class="profile-name">홍길동</div>
+                <div class="profile-email">hong@email.com</div>
+              </div>
+              <div class="profile-chevron">&#x203A;</div>
+            </div>
+          </div>
+
+          <div class="group-gap"></div>
+          <div class="section-header">활동</div>
+          <div class="settings-group">
+            <div class="settings-tile"><div class="tile-icon">&#x1F4CB;</div><div class="tile-content"><div class="tile-title">구매 내역</div></div><div class="tile-trailing">&#x203A;</div></div>
+            <div class="tile-divider"></div>
+            <div class="settings-tile"><div class="tile-icon">&#x1F3AB;</div><div class="tile-content"><div class="tile-title">내 티켓</div></div><div class="tile-trailing">&#x203A;</div></div>
+          </div>
+
+          <div class="group-gap"></div>
+          <div class="section-header">설정</div>
+          <div class="settings-group">
+            <div class="settings-tile"><div class="tile-icon">&#x1F514;</div><div class="tile-content"><div class="tile-title">알림 설정</div></div><div class="tile-trailing">&#x203A;</div></div>
+            <div class="tile-divider"></div>
+            <div class="settings-tile"><div class="tile-icon">&#x2600;</div><div class="tile-content"><div class="tile-title">테마</div><div class="tile-subtitle">시스템 설정</div></div><div class="tile-trailing">&#x203A;</div></div>
+          </div>
+
+          <div class="group-gap"></div>
+          <div class="section-header">개인정보 및 보안</div>
+          <div class="settings-group">
+            <div class="settings-tile"><div class="tile-icon">&#x1F512;</div><div class="tile-content"><div class="tile-title">권한 설정</div></div><div class="tile-trailing">&#x203A;</div></div>
+            <div class="tile-divider"></div>
+            <div class="settings-tile"><div class="tile-icon">&#x1F6AB;</div><div class="tile-content"><div class="tile-title">차단 목록</div></div><div class="tile-trailing">&#x203A;</div></div>
+          </div>
+
+          <div class="group-gap"></div>
+          <div class="section-header">약관 및 정보</div>
+          <div class="settings-group">
+            <div class="settings-tile"><div class="tile-icon">&#x1F6E1;</div><div class="tile-content"><div class="tile-title">개인정보처리방침</div></div><div class="tile-trailing">&#x203A;</div></div>
+            <div class="tile-divider"></div>
+            <div class="settings-tile"><div class="tile-icon">&#x1F4C4;</div><div class="tile-content"><div class="tile-title">이용약관</div></div><div class="tile-trailing">&#x203A;</div></div>
+            <div class="tile-divider"></div>
+            <div class="settings-tile no-tap"><div class="tile-icon">&#x2139;</div><div class="tile-content"><div class="tile-title">앱 버전</div><div class="tile-subtitle">26.04.1455</div></div><div class="tile-trailing"><span class="value-text"></span></div></div>
+          </div>
+
+          <div class="group-gap"></div>
+          <div class="section-header">계정</div>
+          <div class="settings-group">
+            <div class="settings-tile destructive"><div class="tile-icon">&#x2190;</div><div class="tile-content"><div class="tile-title">로그아웃</div></div></div>
+          </div>
+
+          <div style="height:32px;"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============================================ -->
+  <!-- CURRENT: PARTNER APP                         -->
+  <!-- ============================================ -->
+  <div id="current-partner" class="hidden" data-role="current" data-app="partner">
+    <div class="phone-label">Current</div>
+    <div class="phone light">
+      <div class="phone-screen">
+        <div class="appbar">더보기</div>
+
+        <div class="old-profile">
+          <div class="old-avatar">&#x1F464;</div>
+          <div class="old-profile-info">
+            <div class="old-profile-name">밍글릿 파트너</div>
+            <div class="old-profile-email">partner@minglit.com</div>
+          </div>
+        </div>
+        <div class="old-full-divider"></div>
+
+        <div class="old-tile"><div class="old-icon">&#x1F465;</div><div class="old-content"><div class="old-title">멤버 관리</div></div><div class="old-trailing">&#x203A;</div></div>
+        <div class="old-tile"><div class="old-icon">&#x2714;</div><div class="old-content"><div class="old-title">본인인증 관리</div></div><div class="old-trailing">&#x203A;</div></div>
+        <div class="old-full-divider"></div>
+
+        <div class="old-tile"><div class="old-icon">&#x1F514;</div><div class="old-content"><div class="old-title">알림 설정</div></div><div class="old-trailing">&#x203A;</div></div>
+        <div class="old-tile"><div class="old-icon">&#x2600;</div><div class="old-content"><div class="old-title">테마</div></div><div class="old-trailing">&#x203A;</div></div>
+        <div class="old-full-divider"></div>
+
+        <div class="old-tile"><div class="old-icon">&#x1F512;</div><div class="old-content"><div class="old-title">권한</div></div><div class="old-trailing">&#x203A;</div></div>
+        <div class="old-tile"><div class="old-icon">&#x1F6E1;</div><div class="old-content"><div class="old-title">개인정보처리방침</div></div><div class="old-trailing">&#x203A;</div></div>
+        <div class="old-tile"><div class="old-icon">&#x1F4C4;</div><div class="old-content"><div class="old-title">이용약관</div></div><div class="old-trailing">&#x203A;</div></div>
+        <div class="old-tile"><div class="old-icon">&#x2139;</div><div class="old-content"><div class="old-title">앱 버전</div></div><div class="old-trailing" style="font-size:14px;">26.04.1455</div></div>
+        <div class="old-full-divider"></div>
+
+        <div class="old-tile destructive"><div class="old-icon">&#x2190;</div><div class="old-content"><div class="old-title">로그아웃</div></div></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ============================================ -->
+  <!-- REDESIGNED: PARTNER APP                      -->
+  <!-- ============================================ -->
+  <div id="redesigned-partner" class="hidden" data-role="redesigned" data-app="partner">
+    <div class="phone-label">Redesigned</div>
+    <div class="phone light">
+      <div class="phone-screen">
+        <div class="appbar">더보기</div>
+        <div class="content-area">
+
+          <!-- Profile -->
+          <div class="settings-group">
+            <div class="profile-tile">
+              <div class="profile-avatar">&#x1F464;</div>
+              <div class="profile-info">
+                <div class="profile-name">밍글릿 파트너</div>
+                <div class="profile-email">partner@minglit.com</div>
+              </div>
+              <div class="profile-chevron">&#x203A;</div>
+            </div>
+          </div>
+
+          <div class="group-gap"></div>
+          <div class="section-header">비즈니스 관리</div>
+          <div class="settings-group">
+            <div class="settings-tile"><div class="tile-icon">&#x1F465;</div><div class="tile-content"><div class="tile-title">멤버 관리</div></div><div class="tile-trailing">&#x203A;</div></div>
+            <div class="tile-divider"></div>
+            <div class="settings-tile"><div class="tile-icon">&#x2714;</div><div class="tile-content"><div class="tile-title">본인인증 관리</div></div><div class="tile-trailing">&#x203A;</div></div>
+          </div>
+
+          <div class="group-gap"></div>
+          <div class="section-header">설정</div>
+          <div class="settings-group">
+            <div class="settings-tile"><div class="tile-icon">&#x1F514;</div><div class="tile-content"><div class="tile-title">알림 설정</div></div><div class="tile-trailing">&#x203A;</div></div>
+            <div class="tile-divider"></div>
+            <div class="settings-tile"><div class="tile-icon">&#x2600;</div><div class="tile-content"><div class="tile-title">테마</div><div class="tile-subtitle">시스템 설정</div></div><div class="tile-trailing">&#x203A;</div></div>
+          </div>
+
+          <div class="group-gap"></div>
+          <div class="section-header">약관 및 정보</div>
+          <div class="settings-group">
+            <div class="settings-tile"><div class="tile-icon">&#x1F512;</div><div class="tile-content"><div class="tile-title">권한</div></div><div class="tile-trailing">&#x203A;</div></div>
+            <div class="tile-divider"></div>
+            <div class="settings-tile"><div class="tile-icon">&#x1F6E1;</div><div class="tile-content"><div class="tile-title">개인정보처리방침</div></div><div class="tile-trailing">&#x203A;</div></div>
+            <div class="tile-divider"></div>
+            <div class="settings-tile"><div class="tile-icon">&#x1F4C4;</div><div class="tile-content"><div class="tile-title">이용약관</div></div><div class="tile-trailing">&#x203A;</div></div>
+            <div class="tile-divider"></div>
+            <div class="settings-tile no-tap"><div class="tile-icon">&#x2139;</div><div class="tile-content"><div class="tile-title">앱 버전</div><div class="tile-subtitle">26.04.1455</div></div><div class="tile-trailing"><span class="value-text"></span></div></div>
+          </div>
+
+          <div class="group-gap"></div>
+          <div class="section-header">계정</div>
+          <div class="settings-group">
+            <div class="settings-tile destructive"><div class="tile-icon">&#x2190;</div><div class="tile-content"><div class="tile-title">로그아웃</div></div></div>
+          </div>
+
+          <div style="height:32px;"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<script>
+(function() {
+  // State
+  let currentView = 'compare';   // compare | redesigned
+  let currentApp  = 'user';      // user | partner
+  let currentTheme = 'light';    // light | dark
+
+  // Theme palettes
+  const themes = {
+    light: {
+      pageBg: '#FFFFFF',
+      cardBg: '#F5F3F0',
+      textPrimary: '#111827',
+      textSecondary: '#4B5563',
+      divider: '#E8E5E0',
+      outlineVariant: '#E0DDD8',
+      error: '#EF4444',
+      appbarBg: '#FFFFFF',
+    },
+    dark: {
+      pageBg: '#0F0F0F',
+      cardBg: '#2A2A2A',
+      textPrimary: '#FFFFFF',
+      textSecondary: '#AAAAAA',
+      divider: '#3D3D3D',
+      outlineVariant: '#404040',
+      error: '#EF4444',
+      appbarBg: '#0F0F0F',
+    }
+  };
+
+  function applyTheme(phoneEl, themeName) {
+    phoneEl.classList.remove('light', 'dark');
+    phoneEl.classList.add(themeName);
+    const t = themes[themeName];
+    phoneEl.style.setProperty('--page-bg', t.pageBg);
+    phoneEl.style.setProperty('--card-bg', t.cardBg);
+    phoneEl.style.setProperty('--text-primary', t.textPrimary);
+    phoneEl.style.setProperty('--text-secondary', t.textSecondary);
+    phoneEl.style.setProperty('--divider', t.divider);
+    phoneEl.style.setProperty('--outline-variant', t.outlineVariant);
+    phoneEl.style.setProperty('--error', t.error);
+    phoneEl.style.setProperty('--appbar-bg', t.appbarBg);
+  }
+
+  function render() {
+    const allFrames = document.querySelectorAll('[data-role]');
+    allFrames.forEach(f => f.classList.add('hidden'));
+
+    // Show current frames based on state
+    if (currentView === 'compare') {
+      const cur = document.getElementById('current-' + currentApp);
+      const red = document.getElementById('redesigned-' + currentApp);
+      if (cur) cur.classList.remove('hidden');
+      if (red) red.classList.remove('hidden');
+    } else {
+      const red = document.getElementById('redesigned-' + currentApp);
+      if (red) red.classList.remove('hidden');
+    }
+
+    // Apply theme to all phones
+    document.querySelectorAll('.phone').forEach(p => applyTheme(p, currentTheme));
+  }
+
+  // Tab handlers
+  function setupTabs(containerId, callback) {
+    const container = document.getElementById(containerId);
+    container.querySelectorAll('button').forEach(btn => {
+      btn.addEventListener('click', () => {
+        container.querySelectorAll('button').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        callback(btn);
+      });
+    });
+  }
+
+  setupTabs('viewTabs', btn => { currentView = btn.dataset.view; render(); });
+  setupTabs('appTabs', btn => { currentApp = btn.dataset.app; render(); });
+  setupTabs('themeTabs', btn => { currentTheme = btn.dataset.theme; render(); });
+
+  // Initial render
+  render();
+})();
+</script>
+
+</body>
+</html>

--- a/docs/ux/design-system/03-patterns.md
+++ b/docs/ux/design-system/03-patterns.md
@@ -540,6 +540,201 @@ MinglitSectionDivider.thin()
 
 ---
 
+## 14. Settings Layout
+
+> Feature reference: [`docs/features/settings-redesign/ui-ux-design.md`](../../features/settings-redesign/ui-ux-design.md)
+> Issue: #1475
+
+설정/마이페이지 화면을 위한 compact, information-dense 레이아웃 패턴.
+Claude 앱 수준의 밀도를 목표로 하며, 카드 기반 시맨틱 그룹핑을 적용한다.
+
+### 14.1 MinglitSettingsTile
+
+설정 항목 하나를 표현하는 compact 타일.
+
+#### Anatomy
+
+```text
+┌───────────────────────────────────────────────┐
+│ [icon]  Title                     [trailing]  │  48px
+│         Subtitle (optional)                   │
+└───────────────────────────────────────────────┘
+```
+
+#### Spec
+
+| 속성 | 값 | 토큰 |
+|------|-----|------|
+| Height | 48px | — |
+| Title style | 16px normal | `bodyMedium` |
+| Subtitle style | 13px, `onSurfaceVariant` | `bodySmall` |
+| Leading icon size | 20px | `MinglitIconSize.small` |
+| Icon color | `onSurfaceVariant` | — |
+| Horizontal padding | 16px | `MinglitSpacing.medium` |
+| Vertical padding | 4px | `MinglitSpacing.xsmall` |
+| Icon-to-title gap | 16px | `MinglitSpacing.medium` |
+| Touch target | 48dp minimum | WCAG compliance |
+
+#### Trailing Variants
+
+| Variant | Widget | 용도 |
+|---------|--------|------|
+| Navigation | chevron icon 20px, `onSurfaceVariant` | 페이지 이동 항목 |
+| Toggle | `Switch.adaptive()` | on/off 설정 |
+| Value | text `bodySmall`, `onSurfaceVariant` | 읽기 전용 표시 (앱 버전 등) |
+| None | — | trailing 불필요 (로그아웃 등) |
+
+#### Destructive Variant
+
+`destructive: true` 설정 시 title과 icon을 `colorScheme.error` 색상으로 표시한다.
+로그아웃, 계정 삭제 등에 사용.
+
+#### Usage
+
+```dart
+MinglitSettingsTile(
+  leading: Icons.notifications_outlined,
+  title: '알림 설정',
+  trailing: SettingsTileTrailing.navigation,
+  onTap: () => context.push('/settings/notifications'),
+)
+
+MinglitSettingsTile(
+  leading: Icons.brightness_auto,
+  title: '테마',
+  subtitle: '시스템 설정',  // 현재 값
+  trailing: SettingsTileTrailing.navigation,
+  onTap: () => showThemePicker(context),
+)
+
+MinglitSettingsTile(
+  leading: Icons.logout,
+  title: '로그아웃',
+  trailing: SettingsTileTrailing.none,
+  destructive: true,
+  onTap: () => showLogoutDialog(context),
+)
+```
+
+### 14.2 MinglitSettingsGroup
+
+관련 설정 항목을 카드 형태로 묶는 컨테이너.
+
+#### Anatomy
+
+```text
+          SECTION HEADER
+        ┌──────────────────────┐
+        │  Tile 1              │
+        │──────────────────────│  ← divider (52px left inset)
+        │  Tile 2              │
+        │──────────────────────│
+        │  Tile 3              │
+        └──────────────────────┘
+```
+
+#### Spec
+
+| 속성 | 값 | 토큰 |
+|------|-----|------|
+| Background (light) | `surfaceContainerLowest` | M3 auto |
+| Background (dark) | `surfaceContainerHigh` | M3 auto |
+| Border radius | 16px | `MinglitRadius.card` |
+| Horizontal margin | 16px | `MinglitSpacing.medium` |
+| Internal padding | 0px | tiles handle own padding |
+| Gap between groups | 24px | `MinglitSpacing.large` |
+| Elevation | 0 | flat design |
+| Clip | `Clip.antiAlias` | ripple containment |
+
+#### Section Header
+
+| 속성 | 값 | 토큰 |
+|------|-----|------|
+| Typography | 12px, w500 | `labelMedium` |
+| Color | `onSurfaceVariant` | — |
+| Left padding | 16px | `MinglitSpacing.medium` |
+| Bottom margin | 8px | `MinglitSpacing.small` |
+| Case | uppercase (영문만) | — |
+
+#### Internal Divider
+
+| 속성 | 값 |
+|------|-----|
+| Thickness | 0.5px |
+| Color | `outlineVariant` |
+| Left inset | 52px (16px pad + 20px icon + 16px gap) |
+| Right inset | 0px |
+
+#### Usage
+
+```dart
+MinglitSettingsGroup(
+  header: '설정',
+  children: [
+    MinglitSettingsTile(
+      leading: Icons.notifications_outlined,
+      title: '알림 설정',
+      trailing: SettingsTileTrailing.navigation,
+      onTap: onNotificationsTap,
+    ),
+    MinglitSettingsTile(
+      leading: Icons.brightness_auto,
+      title: '테마',
+      subtitle: currentThemeLabel,
+      trailing: SettingsTileTrailing.navigation,
+      onTap: onThemeTap,
+    ),
+  ],
+)
+```
+
+### 14.3 Compact Density Application
+
+Settings Layout은 기존 Compact density guide (section 12)를 따르되, 설정 화면에 맞게 특화한다.
+
+| 일반 화면 | Settings Layout |
+|-----------|-----------------|
+| screenEdge: 16px | 동일 |
+| item gap: 8px | group gap: 24px (그룹 간), 0px (그룹 내) |
+| item height: varies | 48px fixed |
+| item padding: 12px | horizontal 16px, vertical 4px |
+| section gap: 24px | group gap: 24px (동일) |
+
+#### Page Structure
+
+```dart
+Scaffold(
+  appBar: AppBar(title: Text('마이페이지')),
+  body: ListView(
+    padding: EdgeInsets.only(
+      top: MinglitSpacing.medium,     // 16px
+      bottom: safeAreaBottom + MinglitSpacing.large,
+    ),
+    children: [
+      MinglitSettingsGroup(children: [profileTile]),
+      SizedBox(height: MinglitSpacing.large),   // 24px
+      MinglitSettingsGroup(header: '활동', children: [...]),
+      SizedBox(height: MinglitSpacing.large),
+      MinglitSettingsGroup(header: '설정', children: [...]),
+      // ...
+    ],
+  ),
+)
+```
+
+### 14.4 Design Decisions
+
+| 결정 | 근거 |
+|------|------|
+| `bodyMedium` (16px) for title, not `bodyLarge` (18px) | compact density; 18px는 설정 목록에서 너무 크다 |
+| 48px tile height | Material minimum touch target 충족 + 10+ 항목을 스크롤 없이 표시 |
+| Card grouping (not flat dividers) | 시맨틱 구분 명확, iOS Settings / Claude 앱 벤치마크 |
+| `surfaceContainer` variants for card bg | M3 표준, 별도 하드코딩 없이 light/dark 자동 대응 |
+| 16px card radius | 기존 `MinglitRadius.card` 토큰 재사용 |
+| 52px divider left inset | 아이콘 이후 정렬 (16 + 20 + 16 = 52) |
+
+---
+
 ## 관련 문서
 
 - [01-foundation.md](01-foundation.md) -- 디자인 토큰


### PR DESCRIPTION
Scheduler: needs-uiux-claude-1

Closes #1475

## Summary
- **MinglitSettingsTile** 위젯 스펙: 48px compact 타일, bodyMedium title, 4가지 trailing variant (navigation/toggle/value/none), destructive mode
- **MinglitSettingsGroup** 위젯 스펙: 카드 기반 시맨틱 그룹핑, surfaceContainer 배경, 16px radius, 0.5px internal divider
- User App (마이페이지) + Partner App (더보기) 양 앱 시맨틱 그룹 정의
- Light/Dark 모드 컬러 매핑 (M3 surfaceContainer 계열 활용)
- 인터랙티브 wireframe (Current vs Redesigned 비교, 앱/테마 토글)
- 03-patterns.md에 Settings Layout 패턴 (Section 14) 추가

## Deliverables
| 파일 | 내용 |
|------|------|
| `docs/features/settings-redesign/ui-ux-design.md` | 전체 디자인 스펙 |
| `docs/features/settings-redesign/wireframe.html` | 인터랙티브 와이어프레임 |
| `docs/ux/design-system/03-patterns.md` | Section 14 추가 |

## Design Decisions
- 기존 디자인 토큰만 사용 (MinglitSpacing, MinglitRadius, MinglitIconSize) — 신규 토큰 없음
- 기존 MinglitListTile은 변경 없음 — 설정 전용 별도 위젯으로 분리
- Card grouping (iOS Settings / Claude 앱 벤치마크)
- 48px tile height (Material minimum touch target + compact density)

## Test plan
- [ ] wireframe.html 브라우저에서 열어 Current/Redesigned, User/Partner, Light/Dark 모든 조합 확인
- [ ] 디자인 스펙의 토큰 값이 `minglit_design_tokens.dart` 실제 값과 일치하는지 확인
- [ ] SWE가 구현 시 스펙대로 위젯 구현 가능한지 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)