### PR TITLE
fix(security): EF 인가 결함 — requireServiceRole 4개 EF에 추가

### DIFF
--- a/supabase/functions/ai-embed/ai_embed_test.ts
+++ b/supabase/functions/ai-embed/ai_embed_test.ts
@@ -4,7 +4,6 @@ import { HybridCalculator } from "./calculator.ts";
 import {
   captureServeHandler,
   createFetchMock,
-  jsonRequest,
   jsonResponse,
   readJson,
   withNoIntervals,
@@ -14,6 +13,17 @@ import {
 import { mockVectorInteractionMessage, mockVectorPartyMessage } from "../_test_utils/fixtures.ts";
 import { OpenAIEmbedding } from "../_shared/ai/adapters/openai_embedding.ts";
 import { WorkerUtils } from "../_shared/worker_utils.ts";
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": "Bearer service-key",
+    },
+    body: JSON.stringify(body),
+  });
+}
 
 function embedding(value: number, size = 3) {
   return new Array(size).fill(value);
@@ -61,7 +71,7 @@ Deno.test({
       async () => {
         await withMockedFetch(fetchMock, async () => {
           await withNoIntervals(async () => {
-            const response = await handler(jsonRequest("http://localhost", {}));
+            const response = await handler(makeRequest({}));
             const payload = await readJson(response);
 
             assertEquals(response.status, 200);
@@ -126,7 +136,7 @@ Deno.test({
       async () => {
         await withMockedFetch(fetchMock, async () => {
           await withNoIntervals(async () => {
-            const response = await handler(jsonRequest("http://localhost", {}));
+            const response = await handler(makeRequest({}));
             const payload = await readJson(response);
 
             assertEquals(response.status, 200);
@@ -175,7 +185,7 @@ Deno.test({
       async () => {
         await withMockedFetch(fetchMock, async () => {
           await withNoIntervals(async () => {
-            const response = await handler(jsonRequest("http://localhost", {}));
+            const response = await handler(makeRequest({}));
             const payload = await readJson(response);
 
             assertEquals(response.status, 200);
@@ -254,7 +264,7 @@ Deno.test({
       async () => {
         await withMockedFetch(fetchMock, async () => {
           await withNoIntervals(async () => {
-            const response = await handler(jsonRequest("http://localhost", {}));
+            const response = await handler(makeRequest({}));
             const payload = await readJson(response);
 
             assertEquals(response.status, 500);
@@ -312,7 +322,7 @@ Deno.test({
       async () => {
         await withMockedFetch(fetchMock, async () => {
           await withNoIntervals(async () => {
-            const response = await handler(jsonRequest("http://localhost", {}));
+            const response = await handler(makeRequest({}));
             const payload = await readJson(response);
 
             assertEquals(response.status, 200);
@@ -370,7 +380,7 @@ Deno.test({
       async () => {
         await withMockedFetch(fetchMock, async () => {
           await withNoIntervals(async () => {
-            const response = await handler(jsonRequest("http://localhost", {}));
+            const response = await handler(makeRequest({}));
             const payload = await readJson(response);
 
             assertEquals(response.status, 200);
@@ -382,6 +392,57 @@ Deno.test({
   } finally {
     stubs.forEach((s) => s.restore());
   }
+  },
+});
+
+Deno.test({
+  name: "ai-embed - unauthorized: no auth header returns 401",
+  fn: async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+  const { fetchMock } = createFetchMock([]);
+
+  await withEnv(
+    {
+      SUPABASE_URL: "https://supabase.test",
+      SUPABASE_SERVICE_ROLE_KEY: "service-key",
+      OPENAI_API_KEY: "openai-key",
+    },
+    async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const response = await handler(new Request("http://localhost", { method: "POST" }));
+          assertEquals(response.status, 401);
+        });
+      });
+    },
+  );
+  },
+});
+
+Deno.test({
+  name: "ai-embed - unauthorized: wrong token returns 401",
+  fn: async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+  const { fetchMock } = createFetchMock([]);
+
+  await withEnv(
+    {
+      SUPABASE_URL: "https://supabase.test",
+      SUPABASE_SERVICE_ROLE_KEY: "service-key",
+      OPENAI_API_KEY: "openai-key",
+    },
+    async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const response = await handler(new Request("http://localhost", {
+            method: "POST",
+            headers: { "Authorization": "Bearer bad-key" },
+          }));
+          assertEquals(response.status, 401);
+        });
+      });
+    },
+  );
   },
 });
 

--- a/supabase/functions/ai-embed/index.ts
+++ b/supabase/functions/ai-embed/index.ts
@@ -27,7 +27,8 @@ Deno.serve(withHandler(async (req) => {
   log({ function: FN, level: "info", message: "AI Embed Worker Triggered! Checking environment and auth..." });
   try {
     const payload = await req.json().catch(() => ({}));
-    const batchSize = Math.min(payload.batch_size ?? 50, 50);
+    const rawBatch = Math.floor(Number(payload.batch_size));
+    const batchSize = Number.isFinite(rawBatch) && rawBatch >= 1 ? Math.min(rawBatch, 50) : 50;
 
     const supabase = createServiceClient();
     const adapter = createEmbeddingAdapter();

--- a/supabase/functions/ai-embed/index.ts
+++ b/supabase/functions/ai-embed/index.ts
@@ -5,6 +5,7 @@ import { serializeParty } from './party_serializer.ts'
 import { HybridCalculator } from './calculator.ts'
 import { WorkerUtils } from '../_shared/worker_utils.ts'
 import { initSentry, withHandler, log, captureException } from '../_shared/logger.ts'
+import { requireServiceRole } from '../_shared/auth_utils.ts'
 
 const FN = "ai-embed";
 
@@ -20,10 +21,13 @@ const calculator = new HybridCalculator({ decayRate: 0.05 });
 initSentry();
 
 Deno.serve(withHandler(async (req) => {
+  // Fix #1489: 시스템 전용 EF — service_role만 허용
+  const auth = requireServiceRole(req);
+  if (auth instanceof Response) return auth;
   log({ function: FN, level: "info", message: "AI Embed Worker Triggered! Checking environment and auth..." });
   try {
     const payload = await req.json().catch(() => ({}));
-    const batchSize = payload.batch_size ?? 50;
+    const batchSize = Math.min(payload.batch_size ?? 50, 50);
 
     const supabase = createServiceClient();
     const adapter = createEmbeddingAdapter();

--- a/supabase/functions/ai-extract-tags/ai_extract_tags_test.ts
+++ b/supabase/functions/ai-extract-tags/ai_extract_tags_test.ts
@@ -18,13 +18,13 @@ const BASE_ENV = {
   OPENAI_API_KEY: "openai-key",
 };
 
-// JWT verification is handled by the Supabase edge runtime (verify_jwt=true).
-// In unit tests we bypass the runtime layer and call the handler directly,
-// so no Authorization header is needed here.
 function makeRequest(body: unknown): Request {
   return new Request("http://localhost", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": "Bearer service-key",
+    },
     body: JSON.stringify(body),
   });
 }
@@ -268,9 +268,52 @@ Deno.test({
   },
 });
 
-// Note: 401 (missing/invalid JWT) and auth-related 500 tests are intentionally omitted.
-// With verify_jwt=true, the Supabase edge runtime rejects unauthenticated requests
-// before the function handler runs — this cannot be unit-tested at the handler level.
+// Fix #1489: requireServiceRole 가드 추가 — 401 회귀 테스트
+
+Deno.test({
+  name: "ai-extract-tags - unauthorized: no auth header returns 401",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([]);
+
+    await withEnv(BASE_ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const response = await handler(new Request("http://localhost", { method: "POST" }));
+          assertEquals(response.status, 401);
+        });
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "ai-extract-tags - unauthorized: wrong token returns 401",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock } = createFetchMock([]);
+
+    await withEnv(BASE_ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const response = await handler(new Request("http://localhost", {
+            method: "POST",
+            headers: { "Authorization": "Bearer bad-key" },
+          }));
+          assertEquals(response.status, 401);
+        });
+      });
+    });
+  },
+});
 
 Deno.test({
   name: "ai-extract-tags - tags INSERT 23505 race condition: re-fetches and links party_tags",

--- a/supabase/functions/ai-extract-tags/index.ts
+++ b/supabase/functions/ai-extract-tags/index.ts
@@ -2,6 +2,7 @@ import { createServiceClient } from "../_shared/supabase_client.ts";
 import { createLLMAdapter } from "../_shared/ai/factory.ts";
 import { WorkerUtils } from "../_shared/worker_utils.ts";
 import { initSentry, withHandler } from "../_shared/logger.ts";
+import { requireServiceRole } from "../_shared/auth_utils.ts";
 import {
   buildTagExtractionPrompt,
   extractDescriptionText,
@@ -27,15 +28,14 @@ const TAGS_SKIP_CODES = new Set([
 initSentry();
 
 Deno.serve(withHandler(async (req) => {
+  // Fix #1489: 시스템 전용 EF — service_role만 허용
+  const auth = requireServiceRole(req);
+  if (auth instanceof Response) return auth;
   console.log(`[${FN}] triggered`);
-
-  // JWT verification is handled by Supabase edge runtime (verify_jwt=true in config.toml).
-  // The cron sends a valid anon JWT (publishable_key) which passes Supabase verification.
-  // Elevated DB access is handled internally via createServiceClient().
 
   try {
     const payload = await req.json().catch(() => ({}));
-    const batchSize = (payload as { batch_size?: number }).batch_size ?? 10;
+    const batchSize = Math.min((payload as { batch_size?: number }).batch_size ?? 10, 50);
 
     const supabase = createServiceClient();
     // createLLMAdapter() throws if OPENAI_API_KEY is missing

--- a/supabase/functions/ai-extract-tags/index.ts
+++ b/supabase/functions/ai-extract-tags/index.ts
@@ -35,7 +35,8 @@ Deno.serve(withHandler(async (req) => {
 
   try {
     const payload = await req.json().catch(() => ({}));
-    const batchSize = Math.min((payload as { batch_size?: number }).batch_size ?? 10, 50);
+    const rawBatch = Math.floor(Number((payload as { batch_size?: number }).batch_size));
+    const batchSize = Number.isFinite(rawBatch) && rawBatch >= 1 ? Math.min(rawBatch, 50) : 10;
 
     const supabase = createServiceClient();
     // createLLMAdapter() throws if OPENAI_API_KEY is missing

--- a/supabase/functions/notification-worker/index.ts
+++ b/supabase/functions/notification-worker/index.ts
@@ -5,6 +5,7 @@ import { WorkerUtils } from '../_shared/worker_utils.ts'
 import { isoToUnix } from '../_shared/temporal_utils.ts'
 import * as jose from 'jose'
 import { initSentry, withHandler, log } from '../_shared/logger.ts'
+import { requireServiceRole } from '../_shared/auth_utils.ts'
 
 const FN = "notification-worker";
 
@@ -240,7 +241,10 @@ async function sendToAllParticipants(
 
 initSentry();
 
-Deno.serve(withHandler(async (_req) => {
+Deno.serve(withHandler(async (req) => {
+  // Fix #1489: 시스템 전용 EF — service_role만 허용
+  const auth = requireServiceRole(req);
+  if (auth instanceof Response) return auth;
   // env-manifest: validate all required env vars for this function
   const envErr = requireEnv("notification-worker");
   if (envErr) return envErr;

--- a/supabase/functions/notification-worker/notification_worker_test.ts
+++ b/supabase/functions/notification-worker/notification_worker_test.ts
@@ -84,7 +84,7 @@ Deno.test({
         await withMockedFetch(fetchMock, async () => {
           await withNoIntervals(async () => {
             await withFastTimers(async () => {
-              const response = await handler(new Request("http://localhost"));
+              const response = await handler(new Request("http://localhost", { headers: { "Authorization": "Bearer service-key" } }));
               const payload = await readJson(response);
 
               assertEquals(response.status, 200);
@@ -154,7 +154,7 @@ Deno.test({
         await withMockedFetch(fetchMock, async () => {
           await withNoIntervals(async () => {
             await withFastTimers(async () => {
-              const response = await handler(new Request("http://localhost"));
+              const response = await handler(new Request("http://localhost", { headers: { "Authorization": "Bearer service-key" } }));
               const payload = await readJson(response);
 
               assertEquals(response.status, 200);
@@ -171,6 +171,60 @@ Deno.test({
     assertEquals(Boolean(deleteCall), true);
     stubs.forEach((s) => s.restore());
   }
+  },
+});
+
+Deno.test({
+  name: "notification-worker - unauthorized: no auth returns 401",
+  fn: async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+  const { fetchMock } = createFetchMock([]);
+
+  await withEnv(
+    {
+      SUPABASE_URL: "https://supabase.test",
+      SUPABASE_SERVICE_ROLE_KEY: "service-key",
+      FIREBASE_SERVICE_ACCOUNT: firebaseServiceAccountJson,
+    },
+    async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          await withFastTimers(async () => {
+            const response = await handler(new Request("http://localhost"));
+            assertEquals(response.status, 401);
+          });
+        });
+      });
+    },
+  );
+  },
+});
+
+Deno.test({
+  name: "notification-worker - unauthorized: wrong token returns 401",
+  fn: async () => {
+  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+  const { fetchMock } = createFetchMock([]);
+
+  await withEnv(
+    {
+      SUPABASE_URL: "https://supabase.test",
+      SUPABASE_SERVICE_ROLE_KEY: "service-key",
+      FIREBASE_SERVICE_ACCOUNT: firebaseServiceAccountJson,
+    },
+    async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          await withFastTimers(async () => {
+            const response = await handler(new Request("http://localhost", {
+              headers: { "Authorization": "Bearer bad-key" },
+            }));
+            assertEquals(response.status, 401);
+          });
+        });
+      });
+    },
+  );
   },
 });
 

--- a/supabase/functions/settlement-transfer/index.ts
+++ b/supabase/functions/settlement-transfer/index.ts
@@ -2,7 +2,7 @@
 import { createServiceClient } from "../_shared/supabase_client.ts";
 import { PortoneV2Client } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
+import { requireServiceRole } from "../_shared/auth_utils.ts";
 import { initSentry, withHandler, log } from "../_shared/logger.ts";
 
 const FN = "settlement-transfer";
@@ -18,7 +18,8 @@ initSentry();
 Deno.serve(withHandler(async (req) => {
   if (req.method === "OPTIONS") return corsResponse();
 
-  const auth = await requireAuth(req);
+  // Fix #1489: 벌크 금융 작업 — service_role 전용으로 전환, 일반 유저 접근 차단
+  const auth = requireServiceRole(req);
   if (auth instanceof Response) return auth;
   try {
     let reqBody: Record<string, unknown>;

--- a/supabase/functions/settlement-transfer/settlement_transfer_test.ts
+++ b/supabase/functions/settlement-transfer/settlement_transfer_test.ts
@@ -1,6 +1,5 @@
 import { assertEquals } from "@std/assert";
 import {
-  authenticatedJsonRequest,
   captureServeHandler,
   createFetchMock,
   jsonResponse,
@@ -9,7 +8,6 @@ import {
   withMockedFetch,
   withNoIntervals,
 } from "../_test_utils/mock_http.ts";
-import { authRoute } from "../_test_utils/fixtures.ts";
 
 const ENV = {
   PORTONE_V2_API_KEY: "test-v2-key",
@@ -17,12 +15,22 @@ const ENV = {
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
 };
 
+function serviceRoleRequest(url: string, body: unknown): Request {
+  return new Request(url, {
+    method: "POST",
+    headers: {
+      "Authorization": "Bearer service-key",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
 Deno.test("settlement-transfer - happy path creates transfer", async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
     const { fetchMock, calls } = createFetchMock([
-      authRoute,
       {
         matcher: (req) => req.url.includes("/rest/v1/partners") && req.method === "GET",
         handler: () => jsonResponse({ portone_partner_id: "portone-partner-123" }),
@@ -35,7 +43,7 @@ Deno.test("settlement-transfer - happy path creates transfer", async () => {
 
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const request = authenticatedJsonRequest("http://localhost", {
+        const request = serviceRoleRequest("http://localhost", {
           partner_id: "partner-uuid",
           payment_id: "imp_123",
           order_amount: 15000,
@@ -62,7 +70,6 @@ Deno.test("settlement-transfer - partner not synced returns 400", async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
     const { fetchMock } = createFetchMock([
-      authRoute,
       {
         matcher: (req) => req.url.includes("/rest/v1/partners") && req.method === "GET",
         handler: () => jsonResponse({ portone_partner_id: null }),
@@ -71,7 +78,7 @@ Deno.test("settlement-transfer - partner not synced returns 400", async () => {
 
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const request = authenticatedJsonRequest("http://localhost", {
+        const request = serviceRoleRequest("http://localhost", {
           partner_id: "partner-uuid",
           payment_id: "imp_123",
           order_amount: 15000,
@@ -91,7 +98,6 @@ Deno.test("settlement-transfer - partner not found returns 404", async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
     const { fetchMock } = createFetchMock([
-      authRoute,
       {
         matcher: (req) => req.url.includes("/rest/v1/partners") && req.method === "GET",
         handler: () => jsonResponse({ error: { message: "not found" } }, { status: 406 }),
@@ -100,7 +106,7 @@ Deno.test("settlement-transfer - partner not found returns 404", async () => {
 
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const request = authenticatedJsonRequest("http://localhost", {
+        const request = serviceRoleRequest("http://localhost", {
           partner_id: "nonexistent",
           payment_id: "imp_123",
           order_amount: 15000,
@@ -118,11 +124,11 @@ Deno.test("settlement-transfer - partner not found returns 404", async () => {
 Deno.test("settlement-transfer - missing required fields returns 400", async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-    const { fetchMock } = createFetchMock([authRoute]);
+    const { fetchMock } = createFetchMock([]);
 
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const request = authenticatedJsonRequest("http://localhost", { partner_id: "partner-uuid" });
+        const request = serviceRoleRequest("http://localhost", { partner_id: "partner-uuid" });
         const response = await handler(request);
         const payload = await readJson(response);
 
@@ -138,7 +144,6 @@ Deno.test("settlement-transfer - PortOne API error returns 502", async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
     const { fetchMock } = createFetchMock([
-      authRoute,
       {
         matcher: (req) => req.url.includes("/rest/v1/partners") && req.method === "GET",
         handler: () => jsonResponse({ portone_partner_id: "portone-partner-123" }),
@@ -151,7 +156,7 @@ Deno.test("settlement-transfer - PortOne API error returns 502", async () => {
 
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const request = authenticatedJsonRequest("http://localhost", {
+        const request = serviceRoleRequest("http://localhost", {
           partner_id: "partner-uuid",
           payment_id: "imp_123",
           order_amount: 15000,
@@ -161,6 +166,47 @@ Deno.test("settlement-transfer - PortOne API error returns 502", async () => {
 
         assertEquals(response.status, 502);
         assertEquals(payload.error, "Failed to create order transfer");
+      });
+    });
+  });
+});
+
+Deno.test("settlement-transfer - unauthorized: no auth returns 401", async () => {
+  await withEnv(ENV, async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([]);
+
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = new Request("http://localhost", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ partner_id: "p", payment_id: "i", order_amount: 100 }),
+        });
+        const response = await handler(request);
+        assertEquals(response.status, 401);
+      });
+    });
+  });
+});
+
+Deno.test("settlement-transfer - unauthorized: wrong token returns 401", async () => {
+  await withEnv(ENV, async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([]);
+
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = new Request("http://localhost", {
+          method: "POST",
+          headers: {
+            "Authorization": "Bearer bad-key",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ partner_id: "p", payment_id: "i", order_amount: 100 }),
+        });
+        const response = await handler(request);
+        assertEquals(response.status, 401);
       });
     });
   });


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-subagents-1

Closes #1489

ai-embed, ai-extract-tags, settlement-transfer, notification-worker에 requireServiceRole 가드 추가.
기존 테스트 업데이트 + 401 회귀 테스트 8개 추가.