### PR TITLE
docs(ux): design system 문서 동기화 — Pretendard 폰트 + 구현 완료 TODO 정리

### DIFF
--- a/docs/ux/design-system/01-foundation.md
+++ b/docs/ux/design-system/01-foundation.md
@@ -58,7 +58,7 @@
 
 **소스**: `minglit_theme.dart:62-106` (Light), `minglit_theme.dart:121-167` (Dark)
 
-기본 폰트 패밀리: `NotoSansKR` (`minglit_theme.dart:64`)
+기본 폰트 패밀리: `Pretendard` (`minglit_theme.dart:64`)
 
 | TextTheme 슬롯 | fontSize | fontWeight | height | 실제 line-height | color (Light) |
 | :--- | :--- | :--- | :--- | :--- | :--- |

--- a/docs/ux/design-system/02-components.md
+++ b/docs/ux/design-system/02-components.md
@@ -18,7 +18,7 @@
 | iconTheme.color | `#111827` (`MinglitColors.textPrimary`) | `#FFFFFF` (`MinglitColorsDark.textPrimary`) | :9 |
 | titleTextStyle.fontSize | 18 | 18 | :12 |
 | titleTextStyle.fontWeight | w600 | w600 | :13 |
-| titleTextStyle.fontFamily | NotoSansKR | NotoSansKR | :14 |
+| titleTextStyle.fontFamily | Pretendard | Pretendard | :14 |
 | titleTextStyle.color | `#111827` | `#FFFFFF` | :11 |
 
 Dark Mode 소스: `minglit_theme.dart:395-407`
@@ -66,11 +66,27 @@ Dark Mode 소스: `minglit_theme.dart:395-407`
 | textStyle.fontSize | 14 | :58 |
 | textStyle.fontWeight | bold | :59 |
 
-<!-- TODO: Destructive 버튼 (error 색상) 테마 정의 필요 -->
+---
+
+## 5. Button — Destructive (MinglitButton.destructive)
+
+**소스**: `minglit_kit/lib/src/ui/widgets/common/minglit_button.dart`
+
+| 속성 | 값 |
+| :--- | :--- |
+| backgroundColor | `colorScheme.error` (#EF4444) |
+| foregroundColor | `colorScheme.onError` (white) |
+| minimumSize | `infinity x 56` |
+| borderRadius | 12 (`MinglitRadius.button`) |
+| elevation | 0 |
+| textStyle.fontSize | 16 |
+| textStyle.fontWeight | bold |
+
+삭제, 탈퇴, 취소 등 비가역적 액션에 사용한다.
 
 ---
 
-## 5. Card
+## 6. Card
 
 **소스**: `minglit_component_theme.dart:64-71`
 
@@ -85,7 +101,7 @@ Dark Mode 소스: `minglit_theme.dart:411-418`
 
 ---
 
-## 6. Input Field — InputDecoration
+## 7. Input Field — InputDecoration
 
 **소스**: `minglit_component_theme.dart:73-94`
 
@@ -106,7 +122,7 @@ Dark Mode 소스: `minglit_theme.dart:419-443`
 
 ---
 
-## 7. Chip
+## 8. Chip
 
 **소스**: `minglit_component_theme.dart:96-106`
 
@@ -122,7 +138,7 @@ Dark Mode 소스: `minglit_theme.dart:444-454`
 
 ---
 
-## 8. Checkbox
+## 9. Checkbox
 
 **소스**: `minglit_component_theme.dart:108-122`
 
@@ -136,7 +152,7 @@ Dark Mode 소스: `minglit_theme.dart:444-454`
 
 ---
 
-## 9. TabBar
+## 10. TabBar
 
 **소스**: `minglit_component_theme.dart:124-142`
 
@@ -147,12 +163,12 @@ Dark Mode 소스: `minglit_theme.dart:444-454`
 | indicatorColor | `#9900FF` (`MinglitColors.primary`) | :127 |
 | indicatorSize | tab | :128 |
 | dividerColor | transparent | :129 |
-| labelStyle | 14px / bold / NotoSansKR | :130-134 |
-| unselectedLabelStyle | 14px / w500 / NotoSansKR | :136-140 |
+| labelStyle | 14px / bold / Pretendard | :130-134 |
+| unselectedLabelStyle | 14px / w500 / Pretendard | :136-140 |
 
 ---
 
-## 10. Divider
+## 11. Divider
 
 **소스**: `minglit_component_theme.dart:144-151`
 
@@ -166,7 +182,7 @@ Dark Mode 소스: `minglit_theme.dart:457-461`
 
 ---
 
-## 11. Dialog / Alert
+## 12. Dialog / Alert
 
 **소스**: `minglit_kit/lib/src/ui/widgets/common/minglit_alert.dart`, `minglit_dialog.dart`
 
@@ -190,7 +206,7 @@ Dark Mode 소스: `minglit_theme.dart:457-461`
 
 ---
 
-## 12. BottomSheet
+## 13. BottomSheet
 
 **기본 스타일**: `BottomSheetThemeData` 별도 설정 없음 — Flutter 기본 `showModalBottomSheet` 스타일 적용.
 
@@ -204,7 +220,7 @@ Dark Mode 소스: `minglit_theme.dart:457-461`
 
 ---
 
-## 13. Badge / Tag
+## 14. Badge / Tag
 
 <!-- TODO: 커스텀 Badge/Tag 컴포넌트 테마 정의 필요. 현재는 Chip 기반으로 사용 중. -->
 
@@ -212,11 +228,21 @@ Dark Mode 소스: `minglit_theme.dart:457-461`
 
 ---
 
-## 14. Toast / Snackbar
+## 15. Toast / Snackbar
 
-<!-- TODO: SnackBarTheme 정의가 minglit_component_theme.dart에 없음. 별도 SnackBar 테마 추가 필요. -->
+**소스**: `minglit_component_theme.dart:152-165`
 
-현재 코드에 `SnackBarTheme` 설정이 없습니다. Flutter 기본 SnackBar 스타일이 적용됩니다.
+| 속성 | Light Mode | Dark Mode |
+| :--- | :--- | :--- |
+| backgroundColor | `#111827` (`c.textPrimary`) | `#FFFFFF` (`c.textPrimary`) |
+| contentTextStyle.color | `#FFFFFF` (`c.background`) | `#0F0F0F` (`c.background`) |
+| contentTextStyle.fontSize | 14 | 14 |
+| contentTextStyle.fontWeight | w500 | w500 |
+| shape.borderRadius | 8 (`MinglitRadius.small`) | 8 |
+| behavior | floating | floating |
+| elevation | 2 | 2 |
+
+배경색에 `textPrimary`, 텍스트에 `background`를 사용하여 라이트/다크 모드 모두에서 높은 대비를 보장한다.
 
 ---
 

--- a/docs/ux/design-system/04-navigation.md
+++ b/docs/ux/design-system/04-navigation.md
@@ -49,7 +49,7 @@
 | backgroundColor | `#FFFFFF` | :6 |
 | elevation | 0 (플랫) | :7 |
 | centerTitle | true | :8 |
-| titleTextStyle | 18px / w600 / NotoSansKR | :10-16 |
+| titleTextStyle | 18px / w600 / Pretendard | :10-16 |
 
 ### AppBar 유틸리티
 

--- a/docs/ux/partner-app/design-system.md
+++ b/docs/ux/partner-app/design-system.md
@@ -18,7 +18,7 @@
 
 | Layer | 역할 | 파일 |
 | :--- | :--- | :--- |
-| Layer 1 | 폰트·텍스트 통일 (NotoSansKR) | `minglit_theme.dart` |
+| Layer 1 | 폰트·텍스트 통일 (Pretendard) | `minglit_theme.dart` |
 | Layer 2 | Material 컴포넌트 커스터마이징 | `minglit_component_theme.dart` |
 | Layer 3 | 브랜드 상수 (색상·간격·곡률 등) | `minglit_design_tokens.dart` |
 
@@ -164,7 +164,7 @@ Material 3 기반 컴포넌트들을 밍릿 스타일로 커스터마이징한 �
 
 | 컴포넌트 | 주요 설정값 |
 | :--- | :--- |
-| **AppBar** | `elevation: 0`, `centerTitle: true`, `bg: #FFFFFF`, `titleTextStyle: 18px/w600/NotoSansKR` |
+| **AppBar** | `elevation: 0`, `centerTitle: true`, `bg: #FFFFFF`, `titleTextStyle: 18px/w600/Pretendard` |
 | **ElevatedButton** | `minSize: ∞×56`, `radius: 12`, `bg: primary(#9900FF)`, `fg: white`, `text: 16px/bold`, `elevation: 0` |
 | **OutlinedButton** | `minSize: ∞×56`, `radius: 12`, `border: primary`, `fg: primary`, `text: 16px/bold` |
 | **TextButton** | `fg: primary`, `text: 14px/bold` |


### PR DESCRIPTION
Scheduler: audit-uiux-claude-subagents

## Summary

- NotoSansKR → Pretendard 폰트 레퍼런스 전체 업데이트 (PR #1241 이후 6개 파일 미반영)
- Destructive Button 섹션 추가 (MinglitButton.destructive 구현 완료 — TODO만 남아있던 상태)
- SnackBar 테마 섹션 추가 (MinglitComponentTheme.snackBar 구현 완료 — TODO만 남아있던 상태)
- 구현 완료된 TODO 주석 제거, 섹션 번호 재정렬

## Test plan

- [ ] docs/ux/design-system/*.md 내 NotoSansKR 참조가 0건인지 확인
- [ ] 신규 Destructive Button / SnackBar 섹션이 실제 코드와 일치하는지 확인
- [ ] 문서 내 섹션 번호가 순차적인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)