### PR TITLE
fix(db): re-add 'draft' to partner_application_status enum + regression test (#1511)

### DIFF
--- a/supabase/migrations/20260417000001_fix_partner_application_status_draft.sql
+++ b/supabase/migrations/20260417000001_fix_partner_application_status_draft.sql
@@ -1,0 +1,8 @@
+-- Fix #1511: Re-apply 'draft' enum value for partner_application_status.
+--
+-- The original migration (20260307000001) was recorded as applied by the CLI
+-- but ALTER TYPE ADD VALUE failed inside a transaction block, leaving the
+-- 'draft' value absent from the live enum. IF NOT EXISTS makes this idempotent.
+--
+-- NOTE: ALTER TYPE ADD VALUE cannot run inside a transaction block.
+ALTER TYPE public.partner_application_status ADD VALUE IF NOT EXISTS 'draft';

--- a/supabase/tests/database/71_partner_application_status_enum_test.sql
+++ b/supabase/tests/database/71_partner_application_status_enum_test.sql
@@ -4,7 +4,7 @@
 -- silently failed inside a transaction in the original migration (20260307000001).
 
 BEGIN;
-SELECT plan(5);
+SELECT plan(6);
 
 SELECT has_enum('public', 'partner_application_status',
   'enum partner_application_status should exist');
@@ -20,6 +20,9 @@ SELECT enum_has_label('public', 'partner_application_status', 'approved',
 
 SELECT enum_has_label('public', 'partner_application_status', 'rejected',
   'partner_application_status must include rejected');
+
+SELECT enum_has_label('public', 'partner_application_status', 'needs_correction',
+  'partner_application_status must include needs_correction');
 
 SELECT * FROM finish();
 ROLLBACK;

--- a/supabase/tests/database/71_partner_application_status_enum_test.sql
+++ b/supabase/tests/database/71_partner_application_status_enum_test.sql
@@ -6,23 +6,53 @@
 BEGIN;
 SELECT plan(6);
 
-SELECT has_enum('public', 'partner_application_status',
+SELECT has_type('public', 'partner_application_status',
   'enum partner_application_status should exist');
 
-SELECT enum_has_label('public', 'partner_application_status', 'draft',
-  'partner_application_status must include draft (regression: #1511)');
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM pg_enum
+    WHERE enumlabel = 'draft'
+      AND enumtypid = 'public.partner_application_status'::regtype
+  ),
+  'partner_application_status must include draft (regression: #1511)'
+);
 
-SELECT enum_has_label('public', 'partner_application_status', 'pending',
-  'partner_application_status must include pending');
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM pg_enum
+    WHERE enumlabel = 'pending'
+      AND enumtypid = 'public.partner_application_status'::regtype
+  ),
+  'partner_application_status must include pending'
+);
 
-SELECT enum_has_label('public', 'partner_application_status', 'approved',
-  'partner_application_status must include approved');
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM pg_enum
+    WHERE enumlabel = 'approved'
+      AND enumtypid = 'public.partner_application_status'::regtype
+  ),
+  'partner_application_status must include approved'
+);
 
-SELECT enum_has_label('public', 'partner_application_status', 'rejected',
-  'partner_application_status must include rejected');
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM pg_enum
+    WHERE enumlabel = 'rejected'
+      AND enumtypid = 'public.partner_application_status'::regtype
+  ),
+  'partner_application_status must include rejected'
+);
 
-SELECT enum_has_label('public', 'partner_application_status', 'needs_correction',
-  'partner_application_status must include needs_correction');
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM pg_enum
+    WHERE enumlabel = 'needs_correction'
+      AND enumtypid = 'public.partner_application_status'::regtype
+  ),
+  'partner_application_status must include needs_correction'
+);
 
 SELECT * FROM finish();
 ROLLBACK;

--- a/supabase/tests/database/71_partner_application_status_enum_test.sql
+++ b/supabase/tests/database/71_partner_application_status_enum_test.sql
@@ -1,0 +1,25 @@
+-- Regression test for Fix #1511:
+-- Ensures all expected partner_application_status enum labels exist.
+-- The 'draft' value was absent from the live DB because ALTER TYPE ADD VALUE
+-- silently failed inside a transaction in the original migration (20260307000001).
+
+BEGIN;
+SELECT plan(5);
+
+SELECT has_enum('public', 'partner_application_status',
+  'enum partner_application_status should exist');
+
+SELECT enum_has_label('public', 'partner_application_status', 'draft',
+  'partner_application_status must include draft (regression: #1511)');
+
+SELECT enum_has_label('public', 'partner_application_status', 'pending',
+  'partner_application_status must include pending');
+
+SELECT enum_has_label('public', 'partner_application_status', 'approved',
+  'partner_application_status must include approved');
+
+SELECT enum_has_label('public', 'partner_application_status', 'rejected',
+  'partner_application_status must include rejected');
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary

- Every `saveDraft` call in the partner registration wizard crashed with `500: Failed to create draft: invalid input value for enum partner_application_status: "draft"`
- Root cause: original migration `20260307000001` was recorded as applied by the Supabase CLI, but `ALTER TYPE ADD VALUE` silently failed inside the CLI's transaction wrapper, leaving `'draft'` absent from the live DB
- Brand name/description data entered in Step 1 could never be persisted; Apply button stayed disabled
- **Fix**: new idempotent migration `20260417000001` re-applies `ADD VALUE IF NOT EXISTS 'draft'`
- **Regression test**: `71_partner_application_status_enum_test.sql` — 6 pgTAP assertions covering all expected enum labels so CI catches any future recurrence

## Changes

- `supabase/migrations/20260417000001_fix_partner_application_status_draft.sql` — idempotent enum fix
- `supabase/tests/database/71_partner_application_status_enum_test.sql` — pgTAP regression test

## Test plan

- [ ] Confirm `supabase db push` applies migration `20260417000001`
- [ ] `test-supabase` CI passes (pgTAP regression test included)
- [ ] Run CUJ-P01: enter brand info in Step 1, verify it appears in final review screen
- [ ] Verify Apply button becomes enabled when all required fields are filled

Closes #1511

🤖 Generated with [Claude Code](https://claude.com/claude-code)