### PR TITLE
fix(db): remove event_participants when application is cancelled (#1515)

### DIFF
--- a/supabase/functions/user-cancel-order/index.ts
+++ b/supabase/functions/user-cancel-order/index.ts
@@ -185,9 +185,11 @@ Deno.serve(withHandler(async (req) => {
         throw e;
       }
 
-      // Update DB: refund_status + refund_amount
+      // Update DB: status=cancelled + refund_status + refund_amount
+      // Fix #1515: Set status='cancelled' so on_application_cancel trigger removes event_participants
       const refundAmount = paymentAmount ?? (cancelResponse.amount as number | undefined);
       const updatePayload: Record<string, unknown> = {
+        status: "cancelled",
         refund_status: "completed",
         updated_at: new Date().toISOString(),
       };

--- a/supabase/migrations/20260417000002_remove_event_participants_on_cancel.sql
+++ b/supabase/migrations/20260417000002_remove_event_participants_on_cancel.sql
@@ -1,0 +1,37 @@
+-- Fix #1515: Remove event_participants when application is cancelled
+--
+-- INV-03 invariant: "Cancelled applications with orphaned participant records" was
+-- already tracked by the invariant monitor (db_invariant_monitor.sql), but there
+-- was no trigger to enforce cleanup.
+--
+-- When an event_application's status transitions to 'cancelled', the corresponding
+-- event_participants row must be removed to maintain DB consistency.
+-- The symmetric trigger (issue_ticket_on_approval) inserts the row on approval.
+
+set search_path to public, extensions;
+
+-- ────────────────────────────────────────────────────────
+-- Trigger function: delete event_participants on cancel
+-- ────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.remove_participant_on_cancel()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Only fire when status transitions TO 'cancelled'
+  IF NEW.status = 'cancelled' AND (OLD.status IS DISTINCT FROM 'cancelled') THEN
+    DELETE FROM public.event_participants
+    WHERE event_id = NEW.event_id
+      AND user_id = NEW.user_id;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS on_application_cancel ON public.event_applications;
+
+CREATE TRIGGER on_application_cancel
+  AFTER UPDATE ON public.event_applications
+  FOR EACH ROW EXECUTE FUNCTION public.remove_participant_on_cancel();

--- a/supabase/migrations/20260417000002_remove_event_participants_on_cancel.sql
+++ b/supabase/migrations/20260417000002_remove_event_participants_on_cancel.sql
@@ -20,18 +20,20 @@ SECURITY DEFINER
 SET search_path = public
 AS $$
 BEGIN
-  -- Only fire when status transitions TO 'cancelled'
-  IF NEW.status = 'cancelled' AND (OLD.status IS DISTINCT FROM 'cancelled') THEN
-    DELETE FROM public.event_participants
-    WHERE event_id = NEW.event_id
-      AND user_id = NEW.user_id;
-  END IF;
+  DELETE FROM public.event_participants
+  WHERE event_id = NEW.event_id
+    AND user_id = NEW.user_id;
   RETURN NEW;
 END;
 $$;
 
 DROP TRIGGER IF EXISTS on_application_cancel ON public.event_applications;
 
+-- WHEN clause filters at the trigger level so remove_participant_on_cancel()
+-- is never invoked unless the row is actually transitioning to 'cancelled'.
+-- This avoids a function call on every event_applications UPDATE.
 CREATE TRIGGER on_application_cancel
   AFTER UPDATE ON public.event_applications
-  FOR EACH ROW EXECUTE FUNCTION public.remove_participant_on_cancel();
+  FOR EACH ROW
+  WHEN (NEW.status = 'cancelled' AND OLD.status IS DISTINCT FROM 'cancelled')
+  EXECUTE FUNCTION public.remove_participant_on_cancel();

--- a/supabase/tests/database/72_cancel_participant_cleanup_test.sql
+++ b/supabase/tests/database/72_cancel_participant_cleanup_test.sql
@@ -1,0 +1,165 @@
+-- Regression test for Fix #1515:
+-- Verifies on_application_cancel trigger correctly removes event_participants
+-- when an application status transitions to 'cancelled'.
+-- Symmetric to issue_ticket_on_approval which inserts on approval.
+--
+-- Cases:
+--   1. approved → cancelled : event_participants row deleted
+--   2. cancelled → cancelled: no-op (WHEN clause OLD.status IS DISTINCT FROM 'cancelled' guards re-fire)
+--   3. approved → rejected  : event_participants row preserved (trigger scoped to cancelled only)
+
+BEGIN;
+SELECT plan(4);
+
+SELECT tests.authenticate_as_service_role();
+
+-- ============================================================
+-- Shared result capture table
+-- ============================================================
+CREATE TEMP TABLE cancel_trigger_results (
+  test_case text,
+  participant_count int
+);
+
+-- ============================================================
+-- Case 1 + 2: approved → cancelled (deletion), then cancelled → cancelled (idempotency)
+-- ============================================================
+DO $$
+DECLARE
+  v_user_id    uuid;
+  v_partner_id uuid;
+  v_party_id   uuid;
+  v_event_id   uuid;
+  v_ticket_id  uuid;
+  v_app_id     uuid;
+BEGIN
+  v_user_id := tests.create_supabase_user('cancel_trigger_user_1');
+
+  INSERT INTO public.user_profiles (id, name, birth_date, gender, username)
+  VALUES (v_user_id, 'Cancel Test User 1', '2000-01-01', 'male', 'cancel_trigger_user_1')
+  ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, birth_date = EXCLUDED.birth_date;
+
+  INSERT INTO public.partners (name)
+  VALUES ('Cancel Trigger Partner 1')
+  RETURNING id INTO v_partner_id;
+
+  INSERT INTO public.parties (partner_id, title, min_confirmed_count, max_participants)
+  VALUES (v_partner_id, 'Cancel Party 1', 0, 10)
+  RETURNING id INTO v_party_id;
+
+  INSERT INTO public.events (party_id, start_time, end_time, min_confirmed_count, max_participants)
+  VALUES (v_party_id, now() + interval '1 day', now() + interval '1 day 2 hours', 0, 10)
+  RETURNING id INTO v_event_id;
+
+  INSERT INTO public.tickets (event_id, name, quantity, price)
+  VALUES (v_event_id, 'Cancel Ticket 1', 10, 5000)
+  RETURNING id INTO v_ticket_id;
+
+  INSERT INTO public.event_applications (event_id, ticket_id, user_id, status)
+  VALUES (v_event_id, v_ticket_id, v_user_id, 'pending_review')
+  RETURNING id INTO v_app_id;
+
+  -- Approve: issue_ticket_on_approval trigger inserts into event_participants
+  UPDATE public.event_applications SET status = 'approved' WHERE id = v_app_id;
+
+  INSERT INTO cancel_trigger_results (test_case, participant_count)
+  SELECT 'before_cancel', count(*)::int
+  FROM public.event_participants
+  WHERE event_id = v_event_id AND user_id = v_user_id;
+
+  -- Cancel: on_application_cancel trigger should delete from event_participants
+  UPDATE public.event_applications SET status = 'cancelled' WHERE id = v_app_id;
+
+  INSERT INTO cancel_trigger_results (test_case, participant_count)
+  SELECT 'after_cancel', count(*)::int
+  FROM public.event_participants
+  WHERE event_id = v_event_id AND user_id = v_user_id;
+
+  -- Second cancel: WHEN (OLD.status IS DISTINCT FROM 'cancelled') prevents re-fire
+  UPDATE public.event_applications SET status = 'cancelled' WHERE id = v_app_id;
+
+  INSERT INTO cancel_trigger_results (test_case, participant_count)
+  SELECT 'after_second_cancel', count(*)::int
+  FROM public.event_participants
+  WHERE event_id = v_event_id AND user_id = v_user_id;
+END $$;
+
+-- Pre-condition: participant exists after approval
+SELECT is(
+  (SELECT participant_count FROM cancel_trigger_results WHERE test_case = 'before_cancel'),
+  1,
+  'Participant row inserted after approval (pre-condition for cancel test)'
+);
+
+-- Fix #1515: approved → cancelled deletes participant
+SELECT is(
+  (SELECT participant_count FROM cancel_trigger_results WHERE test_case = 'after_cancel'),
+  0,
+  'approved → cancelled: event_participants row deleted by on_application_cancel trigger'
+);
+
+-- Idempotency: cancelled → cancelled is no-op
+SELECT is(
+  (SELECT participant_count FROM cancel_trigger_results WHERE test_case = 'after_second_cancel'),
+  0,
+  'cancelled → cancelled: WHEN clause prevents re-fire, no error, count stays 0'
+);
+
+-- ============================================================
+-- Case 3: approved → rejected preserves event_participants
+-- ============================================================
+DO $$
+DECLARE
+  v_user_id    uuid;
+  v_partner_id uuid;
+  v_party_id   uuid;
+  v_event_id   uuid;
+  v_ticket_id  uuid;
+  v_app_id     uuid;
+BEGIN
+  v_user_id := tests.create_supabase_user('cancel_trigger_user_2');
+
+  INSERT INTO public.user_profiles (id, name, birth_date, gender, username)
+  VALUES (v_user_id, 'Cancel Test User 2', '2001-06-15', 'female', 'cancel_trigger_user_2')
+  ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, birth_date = EXCLUDED.birth_date;
+
+  INSERT INTO public.partners (name)
+  VALUES ('Cancel Trigger Partner 2')
+  RETURNING id INTO v_partner_id;
+
+  INSERT INTO public.parties (partner_id, title, min_confirmed_count, max_participants)
+  VALUES (v_partner_id, 'Cancel Party 2', 0, 10)
+  RETURNING id INTO v_party_id;
+
+  INSERT INTO public.events (party_id, start_time, end_time, min_confirmed_count, max_participants)
+  VALUES (v_party_id, now() + interval '2 days', now() + interval '2 days 2 hours', 0, 10)
+  RETURNING id INTO v_event_id;
+
+  INSERT INTO public.tickets (event_id, name, quantity, price)
+  VALUES (v_event_id, 'Cancel Ticket 2', 10, 5000)
+  RETURNING id INTO v_ticket_id;
+
+  INSERT INTO public.event_applications (event_id, ticket_id, user_id, status)
+  VALUES (v_event_id, v_ticket_id, v_user_id, 'pending_review')
+  RETURNING id INTO v_app_id;
+
+  -- Approve: issue_ticket_on_approval inserts into event_participants
+  UPDATE public.event_applications SET status = 'approved' WHERE id = v_app_id;
+
+  -- Reject: on_application_cancel trigger WHEN clause (NEW.status = 'cancelled') does NOT fire
+  UPDATE public.event_applications SET status = 'rejected' WHERE id = v_app_id;
+
+  INSERT INTO cancel_trigger_results (test_case, participant_count)
+  SELECT 'after_reject', count(*)::int
+  FROM public.event_participants
+  WHERE event_id = v_event_id AND user_id = v_user_id;
+END $$;
+
+SELECT is(
+  (SELECT participant_count FROM cancel_trigger_results WHERE test_case = 'after_reject'),
+  1,
+  'approved → rejected: event_participants row preserved (trigger scoped to cancelled only)'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/backend_integration/src/scenario/refund_scenario_test.dart
+++ b/tests/backend_integration/src/scenario/refund_scenario_test.dart
@@ -496,5 +496,67 @@ void main() {
       expect(app['refund_status'], equals('none'),
           reason: 'refund_status must not change after ineligible refund attempt');
     });
+
+    test(
+        'S05-007: 취소 시 event_participants 삭제 — on_application_cancel 트리거 검증 (Fix #1515)',
+        () async {
+      // Regression test for #1515:
+      // INV-03: When event_applications.status → 'cancelled',
+      // on_application_cancel trigger must DELETE the event_participants row.
+
+      final ctx = await _createEvent(
+        fromNow: const Duration(days: 10),
+        price: 0,
+      );
+
+      // 1. Create application with status='approved' (triggers issue_ticket_on_approval → inserts participant)
+      final appRes = await adminClient
+          .from('event_applications')
+          .insert({
+            'event_id': ctx.eventId,
+            'ticket_id': ctx.ticketId,
+            'user_id': testUserId,
+            'status': 'approved',
+            'payment_amount': 0,
+            'refund_status': 'none',
+          })
+          .select()
+          .single();
+      final appId = appRes['id'] as String;
+
+      // 2. Wait for trigger: issue_ticket_on_approval inserts event_participants on status='approved'
+      final participantsBefore = await adminClient
+          .from('event_participants')
+          .select('id')
+          .eq('event_id', ctx.eventId)
+          .eq('user_id', testUserId);
+      expect(participantsBefore, isNotEmpty,
+          reason:
+              'Pre-condition: issue_ticket_on_approval should have inserted event_participants on approved');
+
+      // 3. Cancel the application (simulates what user-cancel-order EF does for free events)
+      await adminClient
+          .from('event_applications')
+          .update({'status': 'cancelled'}).eq('id', appId);
+
+      // 4. Verify: on_application_cancel trigger deleted the event_participants row
+      final participantsAfter = await adminClient
+          .from('event_participants')
+          .select('id')
+          .eq('event_id', ctx.eventId)
+          .eq('user_id', testUserId);
+      expect(participantsAfter, isEmpty,
+          reason:
+              'event_participants row must be deleted when application is cancelled (on_application_cancel trigger)');
+
+      // 5. Verify: application status is cancelled
+      final cancelledApp = await adminClient
+          .from('event_applications')
+          .select('status')
+          .eq('id', appId)
+          .single();
+      expect(cancelledApp['status'], equals('cancelled'),
+          reason: 'application status must be cancelled');
+    });
   });
 }


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1515

## 문제

E2E 시뮬레이터의 `user_refund` 액션이 `refund_db_participant_removed` assertion에서 실패:
- `user-cancel-order` EF는 status 200 반환
- 그러나 `event_participants` 행이 삭제되지 않음

**Root Cause 1**: `event_applications.status = 'cancelled'` 전환 시 `event_participants`를 삭제하는 DB 트리거가 없었음. `issue_ticket_on_approval` 트리거가 승인 시 삽입하지만, 대칭적인 삭제 트리거가 없었음 (INV-03 invariant 위반).

**Root Cause 2**: 유료 환불 경로(`isPaid` + `paymentAmount > 0`)에서 `refund_status='completed'`는 설정하지만 `status='cancelled'`는 설정하지 않아, 트리거가 있어도 발동되지 않음.

## 변경 사항

### 1. DB 마이그레이션 (`20260417000002_remove_event_participants_on_cancel.sql`)
- `on_application_cancel` 트리거 추가
- `event_applications.status → 'cancelled'` 전환 시 `event_participants` 행 삭제
- `issue_ticket_on_approval` (삽입)과 대칭적 관계

### 2. EF 수정 (`user-cancel-order/index.ts`)
- 유료 환불 경로에서 `status: "cancelled"` 추가하여 모든 취소 경로 일관성 확보

### 3. 회귀 테스트 (`refund_scenario_test.dart`)
- S05-007: 취소 시 `on_application_cancel` 트리거가 `event_participants` 행을 삭제하는지 직접 검증