### PR TITLE
feat(ux): 티켓 QR 화면을 Boarding Pass 메타포로 개선

### DIFF
--- a/apps/app_partner/pubspec.yaml
+++ b/apps/app_partner/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1530-dev+26041530
+version: 26.04.1537-dev+26041537
 resolution: workspace
 
 environment:

--- a/apps/app_partner/test/integration/utils/golden_capture.dart
+++ b/apps/app_partner/test/integration/utils/golden_capture.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
@@ -57,11 +56,15 @@ class GoldenCapture {
       if (rootElement == null) return;
 
       // Fix #1536: 30s timeout to prevent CI hang in headless (GPU-less) environment
-      final image = await captureImage(rootElement).timeout(const Duration(seconds: 30));
+      final image = await captureImage(
+        rootElement,
+      ).timeout(const Duration(seconds: 30));
       // Fix #1458: ensure dispose is called even if toByteData throws
       late final Uint8List bytes;
       try {
-        final byteData = await image.toByteData(format: ui.ImageByteFormat.png).timeout(const Duration(seconds: 30));
+        final byteData = await image
+            .toByteData(format: ui.ImageByteFormat.png)
+            .timeout(const Duration(seconds: 30));
         if (byteData == null) return;
         bytes = Uint8List.view(byteData.buffer);
       } finally {

--- a/apps/app_partner/test/integration/utils/golden_capture.dart
+++ b/apps/app_partner/test/integration/utils/golden_capture.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
@@ -55,11 +56,12 @@ class GoldenCapture {
       final rootElement = tester.binding.rootElement;
       if (rootElement == null) return;
 
-      final image = await captureImage(rootElement);
+      // Fix #1536: 30s timeout to prevent CI hang in headless (GPU-less) environment
+      final image = await captureImage(rootElement).timeout(const Duration(seconds: 30));
       // Fix #1458: ensure dispose is called even if toByteData throws
       late final Uint8List bytes;
       try {
-        final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
+        final byteData = await image.toByteData(format: ui.ImageByteFormat.png).timeout(const Duration(seconds: 30));
         if (byteData == null) return;
         bytes = Uint8List.view(byteData.buffer);
       } finally {

--- a/apps/app_partner/test/visual_qa/visual_qa_helper.dart
+++ b/apps/app_partner/test/visual_qa/visual_qa_helper.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
-import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 // KEEP IN SYNC WITH apps/app_user/test/visual_qa/visual_qa_helper.dart
@@ -61,15 +60,11 @@ extension VisualQaTester on WidgetTester {
       final step = _nextStep();
       // Widget tree dump is synchronous — do it before the async image capture.
       _captureWidgetTree(step, label);
-      // Image capture uses real async I/O and GPU rendering; must use runAsync.
-      // Fix #1536: runAsync can hang in headless CI (GPU unavailable). Timeout
-      // after 30 s and swallow — capture failure must never block the test.
-      await runAsync(() async {
-        await _captureScreenshot(step, label);
-      }).timeout(
-        const Duration(seconds: 30),
-        onTimeout: () => null,
-      );
+      // Fix #1536: Do NOT use runAsync — captureImage() hangs permanently in
+      // headless CI (no GPU) and .timeout() does not cancel the internal Future,
+      // leaving a leaked async operation that blocks subsequent tests.
+      // GoldenCapture uses the same direct-await pattern and works correctly.
+      await _captureScreenshot(step, label);
     } catch (e, st) {
       // ignore: avoid_print
       print('[VisualQA] capture("$label") failed: $e\n$st');
@@ -116,15 +111,19 @@ extension VisualQaTester on WidgetTester {
   // ---------------------------------------------------------------------------
 
   Future<void> _captureScreenshot(int step, String label) async {
-    final image = await _renderToImage();
-    final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
-    image.dispose();
-    if (byteData == null) {
-      throw StateError('toByteData returned null for step $step "$label"');
+    final rootElement = binding.rootElement;
+    if (rootElement == null) return;
+    final image = await captureImage(rootElement);
+    late final Uint8List bytes;
+    try {
+      final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
+      if (byteData == null) return;
+      bytes = Uint8List.view(byteData.buffer);
+    } finally {
+      image.dispose();
     }
-    final bytes = Uint8List.view(byteData.buffer);
-    final file = _ensureFile('${step}_$label.png');
-    await file.writeAsBytes(bytes, flush: true);
+    // Synchronous I/O — avoids runAsync and the associated async leak risk.
+    _ensureFile('${step}_$label.png').writeAsBytesSync(bytes);
   }
 
   void _captureWidgetTree(int step, String label) {
@@ -141,25 +140,4 @@ extension VisualQaTester on WidgetTester {
     return File('${dir.path}/$filename');
   }
 
-  /// Renders the root render view to a [ui.Image].
-  ///
-  /// Uses [captureImage] from flutter_test when a root element is available.
-  /// Falls back to the render view's layer tree otherwise.
-  Future<ui.Image> _renderToImage() async {
-    // Try flutter_test's built-in captureImage using the root element.
-    final rootElement = binding.rootElement;
-    if (rootElement != null) {
-      // captureImage walks up to the nearest repaint boundary automatically.
-      return captureImage(rootElement);
-    }
-
-    // Fallback: use the render view layer directly.
-    final renderView = binding.renderViews.first;
-    final layer = renderView.debugLayer;
-    if (layer is OffsetLayer) {
-      return layer.toImage(renderView.paintBounds);
-    }
-
-    throw StateError('Could not find a paintable layer to capture.');
-  }
 }

--- a/apps/app_partner/test/visual_qa/visual_qa_helper.dart
+++ b/apps/app_partner/test/visual_qa/visual_qa_helper.dart
@@ -139,5 +139,4 @@ extension VisualQaTester on WidgetTester {
     if (!dir.existsSync()) dir.createSync(recursive: true);
     return File('${dir.path}/$filename');
   }
-
 }

--- a/apps/app_partner/test/visual_qa/visual_qa_helper.dart
+++ b/apps/app_partner/test/visual_qa/visual_qa_helper.dart
@@ -62,9 +62,14 @@ extension VisualQaTester on WidgetTester {
       // Widget tree dump is synchronous — do it before the async image capture.
       _captureWidgetTree(step, label);
       // Image capture uses real async I/O and GPU rendering; must use runAsync.
+      // Fix #1536: runAsync can hang in headless CI (GPU unavailable). Timeout
+      // after 30 s and swallow — capture failure must never block the test.
       await runAsync(() async {
         await _captureScreenshot(step, label);
-      });
+      }).timeout(
+        const Duration(seconds: 30),
+        onTimeout: () => null,
+      );
     } catch (e, st) {
       // ignore: avoid_print
       print('[VisualQA] capture("$label") failed: $e\n$st');

--- a/apps/app_user/lib/src/features/home/logic/home_coordinator.dart
+++ b/apps/app_user/lib/src/features/home/logic/home_coordinator.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:app_user/src/features/ticket/ui/model/ticket_event_meta.dart';
 import 'package:app_user/src/routing/app_router.dart';
 import 'package:app_user/src/routing/app_routes.dart';
 import 'package:flutter/material.dart';
@@ -56,8 +57,14 @@ class HomeCoordinator {
 
   // Fix #852: Navigate to ticket QR via coordinator
   // — removes cross-feature import
-  void pushTicketQR(String ticketId) {
-    unawaited(_router.push(TicketQRRoute(ticketId: ticketId).location));
+  // Fix #1526: eventMeta 추가 — 보딩패스 이벤트 정보 표시
+  void pushTicketQR(String ticketId, {TicketEventMeta? eventMeta}) {
+    unawaited(
+      _router.push(
+        TicketQRRoute(ticketId: ticketId).location,
+        extra: eventMeta,
+      ),
+    );
   }
 
   void pushEventDetail(String eventId) {

--- a/apps/app_user/lib/src/features/my_tickets/ui/my_tickets_page.dart
+++ b/apps/app_user/lib/src/features/my_tickets/ui/my_tickets_page.dart
@@ -1,6 +1,7 @@
 import 'package:app_user/src/features/home/logic/home_coordinator.dart';
 import 'package:app_user/src/features/my_tickets/logic/my_tickets_controller.dart';
 import 'package:app_user/src/features/my_tickets/ui/my_ticket_card.dart';
+import 'package:app_user/src/features/ticket/ui/model/ticket_event_meta.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -34,10 +35,14 @@ class MyTicketsPage extends ConsumerWidget {
           return ListView(
             children: [
               // Today event banner
-              if (state.todayEvent != null)
+              if (state.todayEvent case final todayEvent?)
                 _TodayBanner(
-                  application: state.todayEvent!,
-                  onQRTap: () => _onQRTap(ref, state.todayEvent!.ticketId),
+                  application: todayEvent,
+                  onQRTap: () => _onQRTap(
+                    ref,
+                    todayEvent.ticketId,
+                    application: todayEvent,
+                  ),
                 ),
 
               // Upcoming section
@@ -48,7 +53,11 @@ class MyTicketsPage extends ConsumerWidget {
                     application: app,
                     isPast: false,
                     onTap: () => _onCardTap(ref, app),
-                    onQRTap: () => _onQRTap(ref, app.ticketId),
+                    onQRTap: () => _onQRTap(
+                      ref,
+                      app.ticketId,
+                      application: app,
+                    ),
                   ),
                 ),
               ],
@@ -79,8 +88,22 @@ class MyTicketsPage extends ConsumerWidget {
 
   // Fix #852: Navigate to ticket QR via coordinator
   // — removes cross-feature import
-  void _onQRTap(WidgetRef ref, String ticketId) {
-    ref.read(homeCoordinatorProvider).pushTicketQR(ticketId);
+  // Fix #1526: EventApplication 전달 → TicketEventMeta 생성 → 보딩패스에 표시
+  void _onQRTap(
+    WidgetRef ref,
+    String ticketId, {
+    EventApplication? application,
+  }) {
+    final event = application?.event;
+    final meta = event != null
+        ? TicketEventMeta(
+            eventTitle: event.title ?? event.party?.title ?? '',
+            eventDateTime: event.startTime,
+            eventVenue: event.location?.name ?? event.party?.location?.name,
+            ticketName: application?.ticket?.name,
+          )
+        : null;
+    ref.read(homeCoordinatorProvider).pushTicketQR(ticketId, eventMeta: meta);
   }
 }
 

--- a/apps/app_user/lib/src/features/my_tickets/ui/my_tickets_page.dart
+++ b/apps/app_user/lib/src/features/my_tickets/ui/my_tickets_page.dart
@@ -95,9 +95,10 @@ class MyTicketsPage extends ConsumerWidget {
     EventApplication? application,
   }) {
     final event = application?.event;
-    final meta = event != null
+    final title = event?.title ?? event?.party?.title;
+    final meta = (event != null && title != null)
         ? TicketEventMeta(
-            eventTitle: event.title ?? event.party?.title ?? '',
+            eventTitle: title,
             eventDateTime: event.startTime,
             eventVenue: event.location?.name ?? event.party?.location?.name,
             ticketName: application?.ticket?.name,

--- a/apps/app_user/lib/src/features/ticket/logic/boarding_pass_status.dart
+++ b/apps/app_user/lib/src/features/ticket/logic/boarding_pass_status.dart
@@ -1,0 +1,40 @@
+/// Boarding pass status based on event start time compared to today's date.
+///
+/// Date comparison uses **local timezone** (not UTC) per spec requirement.
+enum BoardingPassStatus {
+  /// Event starts today — user should present QR at the gate.
+  boarding,
+
+  /// Event starts in the future (tomorrow or later).
+  confirmed,
+
+  /// Event was in the past (started yesterday or earlier).
+  used,
+}
+
+/// Determines the [BoardingPassStatus] for an event starting at
+/// [eventStartTime].
+///
+/// The comparison is day-based (local timezone), not time-based:
+/// - Any event starting today (00:00–23:59) → [BoardingPassStatus.boarding]
+/// - Any event starting tomorrow or later → [BoardingPassStatus.confirmed]
+/// - Any event that started yesterday or earlier → [BoardingPassStatus.used]
+///
+/// [now] can be overridden for testing. Defaults to [DateTime.now()].
+BoardingPassStatus boardingPassStatus(
+  DateTime eventStartTime, {
+  DateTime? now,
+}) {
+  final current = now ?? DateTime.now();
+  // Day boundaries in local timezone
+  final todayStart = DateTime(current.year, current.month, current.day);
+  final tomorrowStart = todayStart.add(const Duration(days: 1));
+
+  if (eventStartTime.isBefore(todayStart)) {
+    return BoardingPassStatus.used;
+  } else if (eventStartTime.isBefore(tomorrowStart)) {
+    return BoardingPassStatus.boarding;
+  } else {
+    return BoardingPassStatus.confirmed;
+  }
+}

--- a/apps/app_user/lib/src/features/ticket/ui/model/ticket_event_meta.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/model/ticket_event_meta.dart
@@ -1,0 +1,27 @@
+/// Event metadata passed to the QR screen for the boarding pass display.
+///
+/// Holds display-only information about the event — not used for QR
+/// verification. All fields are optional to maintain backwards compatibility
+/// with callers that have not yet been updated to pass metadata
+/// (e.g. deep link navigation).
+class TicketEventMeta {
+  const TicketEventMeta({
+    required this.eventTitle,
+    required this.eventDateTime,
+    this.eventVenue,
+    this.ticketName,
+  });
+
+  /// Event name shown as the boarding pass title.
+  final String eventTitle;
+
+  /// Event start time — used to determine boarding pass status and format the
+  /// DATE section of the boarding pass.
+  final DateTime eventDateTime;
+
+  /// Venue name shown in the VENUE section.
+  final String? eventVenue;
+
+  /// Ticket type label (e.g. "일반 입장권").
+  final String? ticketName;
+}

--- a/apps/app_user/lib/src/features/ticket/ui/ticket_qr_screen.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/ticket_qr_screen.dart
@@ -1,44 +1,153 @@
+import 'dart:async';
+
 import 'package:app_user/src/features/ticket/data/ticket_token_service.dart';
-import 'package:app_user/src/features/ticket/ui/widgets/ticket_qr_viewer.dart';
+import 'package:app_user/src/features/ticket/ui/model/ticket_event_meta.dart';
+import 'package:app_user/src/features/ticket/ui/widgets/boarding_pass_card.dart';
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
+import 'package:screen_brightness/screen_brightness.dart';
+
+// Fix #1526: TicketQRScreen 리팩터링 — BoardingPassCard 통합 + 이벤트 메타 전달
 
 /// **Ticket QR Screen**
 ///
-/// Shows the QR code for a specific ticket.
+/// Displays the ticket as a boarding-pass-style card with the QR code.
+/// [eventMeta] provides display context (title, date, venue, ticket type).
+/// When [eventMeta] is null the card still renders, showing placeholder text.
+///
 /// Supports offline mode via cached tokens in the local wallet.
-class TicketQRScreen extends ConsumerWidget {
-  const TicketQRScreen({required this.ticketId, super.key});
+class TicketQRScreen extends StatefulWidget {
+  const TicketQRScreen({
+    required this.ticketId,
+    this.eventMeta,
+    super.key,
+  });
 
   final String ticketId;
 
+  /// Event metadata for boarding pass display. Optional — callers that cannot
+  /// provide it (e.g. deep links) will still see the QR but without event info.
+  final TicketEventMeta? eventMeta;
+
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final ticketAsync = ref.watch(_ticketTokenProvider(ticketId));
+  State<TicketQRScreen> createState() => _TicketQRScreenState();
+}
+
+class _TicketQRScreenState extends State<TicketQRScreen>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _scanningController;
+  double? _originalBrightness;
+
+  @override
+  void initState() {
+    super.initState();
+    _scanningController = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 2),
+    );
+    unawaited(_scanningController.repeat(reverse: true));
+    unawaited(_maximizeBrightness());
+  }
+
+  @override
+  void dispose() {
+    _scanningController.dispose();
+    unawaited(_restoreBrightness());
+    super.dispose();
+  }
+
+  Future<void> _maximizeBrightness() async {
+    try {
+      _originalBrightness = await ScreenBrightness().application;
+      await ScreenBrightness().setApplicationScreenBrightness(1);
+    } on Object catch (e) {
+      Log.e('Failed to set screen brightness', e);
+    }
+  }
+
+  Future<void> _restoreBrightness() async {
+    // Fix #382: 강제 언래핑 제거 — local variable로 null 안전성 확보
+    final brightness = _originalBrightness;
+    if (brightness != null) {
+      try {
+        await ScreenBrightness().setApplicationScreenBrightness(brightness);
+      } on Object catch (e) {
+        Log.e('Failed to restore screen brightness', e);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
 
     return Scaffold(
+      backgroundColor: MinglitColors.surface,
       appBar: MinglitTheme.simpleAppBar(title: '내 티켓'),
-      body: Center(
-        child: MinglitAsyncValueWidget<TicketToken?>(
-          value: ticketAsync,
-          data: (token) {
-            if (token == null) {
-              return const Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(
-                    Icons.error_outline,
-                    size: 48,
-                    color: MinglitColors.error,
+      body: Consumer(
+        builder: (context, ref, _) {
+          final ticketAsync = ref.watch(_ticketTokenProvider(widget.ticketId));
+
+          return MinglitAsyncValueWidget<TicketToken?>(
+            value: ticketAsync,
+            data: (token) {
+              if (token == null) {
+                return const Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        Icons.error_outline,
+                        size: 48,
+                        color: MinglitColors.error,
+                      ),
+                      SizedBox(height: MinglitSpacing.medium),
+                      Text('티켓 정보를 찾을 수 없습니다.'),
+                    ],
                   ),
-                  SizedBox(height: MinglitSpacing.medium),
-                  Text('티켓 정보를 찾을 수 없습니다.'),
-                ],
+                );
+              }
+
+              return SingleChildScrollView(
+                padding: const EdgeInsets.all(MinglitSpacing.large),
+                child: Column(
+                  children: [
+                    // Boarding pass card
+                    BoardingPassCard(
+                      token: token,
+                      eventMeta: widget.eventMeta,
+                      scanningAnimation: _scanningController,
+                    ),
+
+                    const SizedBox(height: MinglitSpacing.large),
+
+                    // Instruction text (below card)
+                    Text(
+                      '입장 시 파트너에게 이 화면을 보여주세요',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+
+                    const SizedBox(height: MinglitSpacing.small),
+
+                    // Anti-fraud notice
+                    Text(
+                      '스크린샷은 입장에 사용할 수 없습니다',
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant.withValues(
+                          alpha: MinglitOpacity.muted,
+                        ),
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
               );
-            }
-            return TicketQRViewer(token: token);
-          },
-        ),
+            },
+          );
+        },
       ),
     );
   }

--- a/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card.dart
@@ -42,12 +42,14 @@ class BoardingPassCard extends StatefulWidget {
 }
 
 class _BoardingPassCardState extends State<BoardingPassCard>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, WidgetsBindingObserver {
   late AnimationController _pulseController;
+  Timer? _midnightTimer;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _pulseController = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 900),
@@ -55,23 +57,54 @@ class _BoardingPassCardState extends State<BoardingPassCard>
     if (_computeStatus() == BoardingPassStatus.boarding) {
       unawaited(_pulseController.repeat(reverse: true));
     }
+    _scheduleMidnightRefresh();
   }
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _midnightTimer?.cancel();
     _pulseController.dispose();
     super.dispose();
   }
 
+  /// Schedules a one-shot timer that fires at the next local midnight,
+  /// triggering a status re-evaluation so BOARDING→USED transition is shown
+  /// without the user needing to leave and re-enter the screen.
+  void _scheduleMidnightRefresh() {
+    _midnightTimer?.cancel();
+    final now = DateTime.now();
+    final tomorrow = DateTime(now.year, now.month, now.day + 1);
+    final durationUntilMidnight = tomorrow.difference(now);
+    _midnightTimer = Timer(durationUntilMidnight, _onMidnight);
+  }
+
+  void _onMidnight() {
+    if (!mounted) return;
+    setState(_updatePulse);
+    _scheduleMidnightRefresh();
+  }
+
   @override
-  void didUpdateWidget(covariant BoardingPassCard oldWidget) {
-    super.didUpdateWidget(oldWidget);
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      setState(_updatePulse);
+    }
+  }
+
+  void _updatePulse() {
     final shouldPulse = _computeStatus() == BoardingPassStatus.boarding;
     if (shouldPulse && !_pulseController.isAnimating) {
       unawaited(_pulseController.repeat(reverse: true));
     } else if (!shouldPulse && _pulseController.isAnimating) {
       _pulseController.stop();
     }
+  }
+
+  @override
+  void didUpdateWidget(covariant BoardingPassCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _updatePulse();
   }
 
   BoardingPassStatus _computeStatus() {

--- a/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card.dart
@@ -63,6 +63,17 @@ class _BoardingPassCardState extends State<BoardingPassCard>
     super.dispose();
   }
 
+  @override
+  void didUpdateWidget(covariant BoardingPassCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final shouldPulse = _computeStatus() == BoardingPassStatus.boarding;
+    if (shouldPulse && !_pulseController.isAnimating) {
+      unawaited(_pulseController.repeat(reverse: true));
+    } else if (!shouldPulse && _pulseController.isAnimating) {
+      _pulseController.stop();
+    }
+  }
+
   BoardingPassStatus _computeStatus() {
     final meta = widget.eventMeta;
     if (meta == null) return BoardingPassStatus.confirmed;
@@ -92,9 +103,9 @@ class _BoardingPassCardState extends State<BoardingPassCard>
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              _HeaderStrip(),
+              const _HeaderStrip(),
               _EventInfoSection(eventMeta: widget.eventMeta),
-              _PerforationLine(),
+              const _PerforationLine(),
               _QRStubSection(
                 token: widget.token,
                 status: status,
@@ -116,6 +127,8 @@ class _BoardingPassCardState extends State<BoardingPassCard>
 /// Brand header strip — omagio of airline top bar.
 /// Gradient background, Minglit logo (white) on left, "BOARDING PASS" on right.
 class _HeaderStrip extends StatelessWidget {
+  const _HeaderStrip();
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -338,6 +351,8 @@ class _FieldLabel extends StatelessWidget {
 /// Renders a dashed line with semicircle notches at the card left/right edges.
 // Fix #1526: PerforationPainter — "진짜 티켓" 느낌의 핵심 디테일
 class _PerforationLine extends StatelessWidget {
+  const _PerforationLine();
+
   static const double _notchDiameter = 28;
   static const double _notchRadius = _notchDiameter / 2;
 
@@ -486,6 +501,7 @@ class _QRStubSection extends StatelessWidget {
                   // Scanning line (disabled for USED)
                   if (!isUsed)
                     AnimatedBuilder(
+                      key: const ValueKey('scanning-line'),
                       animation: scanningAnimation,
                       builder: (context, _) {
                         return Positioned(

--- a/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card.dart
@@ -1,0 +1,657 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math' as math;
+
+import 'package:app_user/src/features/ticket/logic/boarding_pass_status.dart';
+import 'package:app_user/src/features/ticket/ui/model/ticket_event_meta.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+
+// Fix #1526: BoardingPassCard — 항공 보딩패스 메타포 적용 (4영역 카드 구조)
+
+/// **BoardingPassCard**
+///
+/// Displays a ticket as an airline boarding pass.
+/// 4-section layout: brand header → event info → perforation → QR stub.
+///
+/// [token] provides QR payload. [eventMeta] provides display context.
+/// When [eventMeta] is null, placeholder dashes are shown (graceful
+/// degradation).
+class BoardingPassCard extends StatefulWidget {
+  const BoardingPassCard({
+    required this.token,
+    required this.scanningAnimation,
+    this.eventMeta,
+    super.key,
+  });
+
+  final TicketToken token;
+
+  /// Event metadata for display. Optional to support deep-link callers
+  /// that do not yet pass metadata.
+  final TicketEventMeta? eventMeta;
+
+  /// External [AnimationController] driving the scanning line.
+  /// Should be a repeating controller with `reverse: true`.
+  final AnimationController scanningAnimation;
+
+  @override
+  State<BoardingPassCard> createState() => _BoardingPassCardState();
+}
+
+class _BoardingPassCardState extends State<BoardingPassCard>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _pulseController;
+
+  @override
+  void initState() {
+    super.initState();
+    _pulseController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 900),
+    );
+    if (_computeStatus() == BoardingPassStatus.boarding) {
+      unawaited(_pulseController.repeat(reverse: true));
+    }
+  }
+
+  @override
+  void dispose() {
+    _pulseController.dispose();
+    super.dispose();
+  }
+
+  BoardingPassStatus _computeStatus() {
+    final meta = widget.eventMeta;
+    if (meta == null) return BoardingPassStatus.confirmed;
+    return boardingPassStatus(meta.eventDateTime);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final status = _computeStatus();
+    final isUsed = status == BoardingPassStatus.used;
+
+    return Opacity(
+      opacity: isUsed ? MinglitOpacity.overlay : 1.0,
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(MinglitRadius.card),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.12),
+              blurRadius: 20,
+              offset: const Offset(0, 6),
+            ),
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(MinglitRadius.card),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _HeaderStrip(),
+              _EventInfoSection(eventMeta: widget.eventMeta),
+              _PerforationLine(),
+              _QRStubSection(
+                token: widget.token,
+                status: status,
+                scanningAnimation: widget.scanningAnimation,
+                pulseAnimation: _pulseController,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Section 1: Header Strip
+// ---------------------------------------------------------------------------
+
+/// Brand header strip — omagio of airline top bar.
+/// Gradient background, Minglit logo (white) on left, "BOARDING PASS" on right.
+class _HeaderStrip extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 64,
+      decoration: const BoxDecoration(
+        gradient: LinearGradient(
+          colors: [MinglitColors.primary, MinglitColors.primaryDark],
+        ),
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: MinglitSpacing.large,
+      ),
+      child: Row(
+        children: [
+          // White logo — ColorFiltered wraps the themed SVG
+          ColorFiltered(
+            colorFilter: const ColorFilter.mode(
+              Colors.white,
+              BlendMode.srcIn,
+            ),
+            child: MinglitTheme.appBarLogo(height: 24),
+          ),
+          const Spacer(),
+          Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              const Text(
+                'BOARDING PASS',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 2,
+                ),
+              ),
+              Text(
+                '입장권',
+                style: TextStyle(
+                  color: Colors.white.withValues(alpha: 0.7),
+                  fontSize: 10,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Section 2: Event Info
+// ---------------------------------------------------------------------------
+
+/// Event info section — omagio of airline FROM/TO flight info zone.
+/// DATE (left) → arrow → VENUE (right), then event title and ticket type.
+class _EventInfoSection extends StatelessWidget {
+  const _EventInfoSection({this.eventMeta});
+
+  final TicketEventMeta? eventMeta;
+
+  @override
+  Widget build(BuildContext context) {
+    final meta = eventMeta;
+    final dateLabel = meta != null
+        ? DateFormat('M월 d일 (E)', 'ko_KR').format(meta.eventDateTime)
+        : '—';
+    final timeLabel = meta != null
+        ? DateFormat('HH:mm').format(meta.eventDateTime)
+        : '—';
+    final venueLabel = meta?.eventVenue ?? '—';
+    final eventTitle = meta?.eventTitle ?? '—';
+    final ticketName = meta?.ticketName;
+
+    return Container(
+      color: MinglitColors.background,
+      padding: const EdgeInsets.fromLTRB(
+        MinglitSpacing.large,
+        MinglitSpacing.medium,
+        MinglitSpacing.large,
+        MinglitSpacing.medium,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Flight-style info row: DATE → VENUE
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Left: DATE section
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const _FieldLabel('DATE'),
+                    const SizedBox(height: 2),
+                    Text(
+                      dateLabel,
+                      style: const TextStyle(
+                        color: MinglitColors.textPrimary,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    Text(
+                      timeLabel,
+                      style: const TextStyle(
+                        color: MinglitColors.primary,
+                        fontSize: 22,
+                        fontWeight: FontWeight.w800,
+                        height: 1.1,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              // Center: arrow aligned to time row
+              const Padding(
+                padding: EdgeInsets.only(top: 30),
+                child: Text(
+                  '→',
+                  style: TextStyle(
+                    color: MinglitColors.textSecondary,
+                    fontSize: 18,
+                  ),
+                ),
+              ),
+              // Right: VENUE section
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    const _FieldLabel('VENUE', rightAligned: true),
+                    const SizedBox(height: 2),
+                    Text(
+                      venueLabel,
+                      style: const TextStyle(
+                        color: MinglitColors.textPrimary,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                      ),
+                      textAlign: TextAlign.right,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+
+          // Divider
+          const Padding(
+            padding: EdgeInsets.symmetric(vertical: MinglitSpacing.sm),
+            child: Divider(height: 1, color: MinglitColors.surface),
+          ),
+
+          // Event title (center aligned, 2-line ellipsis)
+          Text(
+            eventTitle,
+            style: const TextStyle(
+              color: MinglitColors.textPrimary,
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+            ),
+            textAlign: TextAlign.center,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+
+          // Ticket type (optional)
+          if (ticketName != null) ...[
+            const SizedBox(height: MinglitSpacing.xsmall),
+            Text(
+              'TICKET · $ticketName',
+              style: const TextStyle(
+                color: MinglitColors.textSecondary,
+                fontSize: 11,
+                fontWeight: FontWeight.w500,
+                letterSpacing: 0.5,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _FieldLabel extends StatelessWidget {
+  const _FieldLabel(this.text, {this.rightAligned = false});
+
+  final String text;
+  final bool rightAligned;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: const TextStyle(
+        color: MinglitColors.textSecondary,
+        fontSize: 9,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 1,
+      ),
+      textAlign: rightAligned ? TextAlign.right : TextAlign.left,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Section 3: Perforation Line
+// ---------------------------------------------------------------------------
+
+/// Airline-ticket perforation line — the key detail that makes it feel like
+/// a real physical ticket.
+/// Renders a dashed line with semicircle notches at the card left/right edges.
+// Fix #1526: PerforationPainter — "진짜 티켓" 느낌의 핵심 디테일
+class _PerforationLine extends StatelessWidget {
+  static const double _notchDiameter = 28;
+  static const double _notchRadius = _notchDiameter / 2;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: MinglitColors.background,
+      height: _notchDiameter,
+      child: const Stack(
+        clipBehavior: Clip.none,
+        children: [
+          // Dashed center line (excludes the notch areas)
+          Positioned.fill(
+            child: CustomPaint(
+              painter: _DashLinePainter(
+                notchRadius: _notchRadius,
+                dashColor: Color(0xFFE5E7EB),
+              ),
+            ),
+          ),
+          // Left notch — positioned to overlap card left edge
+          Positioned(
+            left: -_notchRadius,
+            top: 0,
+            child: _NotchCircle(size: _notchDiameter),
+          ),
+          // Right notch — positioned to overlap card right edge
+          Positioned(
+            right: -_notchRadius,
+            top: 0,
+            child: _NotchCircle(size: _notchDiameter),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Solid circle in scaffold surface color — creates the "cutout" illusion.
+class _NotchCircle extends StatelessWidget {
+  const _NotchCircle({required this.size});
+
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: const BoxDecoration(
+        color: MinglitColors.surface,
+        shape: BoxShape.circle,
+      ),
+    );
+  }
+}
+
+/// Draws a horizontal dashed line, skipping the notch areas at each end.
+class _DashLinePainter extends CustomPainter {
+  const _DashLinePainter({
+    required this.notchRadius,
+    required this.dashColor,
+  });
+
+  final double notchRadius;
+  final Color dashColor;
+
+  static const double _dashWidth = 6;
+  static const double _dashGap = 5;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = dashColor
+      ..strokeWidth = 1.5
+      ..style = PaintingStyle.stroke;
+
+    final y = size.height / 2;
+    final startX = notchRadius;
+    final endX = size.width - notchRadius;
+
+    var x = startX;
+    while (x < endX) {
+      final segmentEnd = math.min(x + _dashWidth, endX);
+      canvas.drawLine(Offset(x, y), Offset(segmentEnd, y), paint);
+      x += _dashWidth + _dashGap;
+    }
+  }
+
+  @override
+  bool shouldRepaint(_DashLinePainter oldDelegate) => false;
+}
+
+// ---------------------------------------------------------------------------
+// Section 4: QR Stub
+// ---------------------------------------------------------------------------
+
+/// QR stub section — omagio of the barcode area on airline boarding passes.
+/// Contains: QR code (with scanning animation), ticket number, status badge.
+class _QRStubSection extends StatelessWidget {
+  const _QRStubSection({
+    required this.token,
+    required this.status,
+    required this.scanningAnimation,
+    required this.pulseAnimation,
+  });
+
+  final TicketToken token;
+  final BoardingPassStatus status;
+  final AnimationController scanningAnimation;
+  final AnimationController pulseAnimation;
+
+  static const _qrSize = 200.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final qrData = jsonEncode(token.toJson());
+    final isUsed = status == BoardingPassStatus.used;
+
+    return Container(
+      color: MinglitColors.background,
+      padding: const EdgeInsets.fromLTRB(
+        MinglitSpacing.large,
+        MinglitSpacing.medium,
+        MinglitSpacing.large,
+        MinglitSpacing.large,
+      ),
+      child: Column(
+        children: [
+          // QR + scanning line overlay
+          Center(
+            child: SizedBox(
+              width: _qrSize,
+              height: _qrSize,
+              child: Stack(
+                children: [
+                  // QR code
+                  Semantics(
+                    label: '이벤트 입장 QR 코드',
+                    child: QrImageView(
+                      data: qrData,
+                      size: _qrSize,
+                      gapless: false,
+                    ),
+                  ),
+                  // Scanning line (disabled for USED)
+                  if (!isUsed)
+                    AnimatedBuilder(
+                      animation: scanningAnimation,
+                      builder: (context, _) {
+                        return Positioned(
+                          top: _qrSize * scanningAnimation.value,
+                          left: 0,
+                          right: 0,
+                          child: Container(
+                            height: 2,
+                            decoration: BoxDecoration(
+                              color: MinglitColors.primary,
+                              boxShadow: [
+                                BoxShadow(
+                                  color: MinglitColors.primary.withValues(
+                                    alpha: MinglitOpacity.strong,
+                                  ),
+                                  blurRadius: 8,
+                                  spreadRadius: 2,
+                                ),
+                              ],
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                ],
+              ),
+            ),
+          ),
+
+          const SizedBox(height: MinglitSpacing.medium),
+
+          // TICKET NO. / STATUS row
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Left: ticket number
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const _MetaLabel('TICKET NO.'),
+                  const SizedBox(height: 2),
+                  Text(
+                    _formatTicketNo(token.ticketId),
+                    style: const TextStyle(
+                      color: MinglitColors.textPrimary,
+                      fontSize: 11,
+                      fontWeight: FontWeight.w600,
+                      letterSpacing: 0.5,
+                    ),
+                  ),
+                ],
+              ),
+              const Spacer(),
+              // Right: status badge
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  const _MetaLabel('STATUS'),
+                  const SizedBox(height: 2),
+                  _StatusBadge(
+                    status: status,
+                    pulseAnimation: pulseAnimation,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Formats ticketId as "#TK-XXXX" (8-char hex prefix).
+  static String _formatTicketNo(String ticketId) {
+    final prefix = ticketId.length > 8
+        ? ticketId.substring(0, 8).toUpperCase()
+        : ticketId.toUpperCase();
+    return '#TK-$prefix';
+  }
+}
+
+class _MetaLabel extends StatelessWidget {
+  const _MetaLabel(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: const TextStyle(
+        color: MinglitColors.textSecondary,
+        fontSize: 9,
+        fontWeight: FontWeight.w600,
+        letterSpacing: 1,
+      ),
+    );
+  }
+}
+
+/// Status badge with three visual states: BOARDING (green pulse), CONFIRMED
+/// (primary), USED (gray).
+class _StatusBadge extends StatelessWidget {
+  const _StatusBadge({
+    required this.status,
+    required this.pulseAnimation,
+  });
+
+  final BoardingPassStatus status;
+  final AnimationController pulseAnimation;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (status) {
+      BoardingPassStatus.boarding => _boardingBadge(),
+      BoardingPassStatus.confirmed => const Text(
+        'CONFIRMED',
+        style: TextStyle(
+          color: MinglitColors.primary,
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.5,
+        ),
+      ),
+      BoardingPassStatus.used => const Text(
+        'USED',
+        style: TextStyle(
+          color: MinglitColors.textSecondary,
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.5,
+        ),
+      ),
+    };
+  }
+
+  Widget _boardingBadge() {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AnimatedBuilder(
+          animation: pulseAnimation,
+          builder: (context, _) {
+            return Container(
+              width: 7,
+              height: 7,
+              decoration: BoxDecoration(
+                color: MinglitColors.success.withValues(
+                  alpha: 0.4 + 0.6 * pulseAnimation.value,
+                ),
+                shape: BoxShape.circle,
+              ),
+            );
+          },
+        ),
+        const SizedBox(width: 4),
+        const Text(
+          'BOARDING',
+          style: TextStyle(
+            color: MinglitColors.success,
+            fontSize: 11,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 0.5,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card.dart
@@ -92,7 +92,7 @@ class _BoardingPassCardState extends State<BoardingPassCard>
           borderRadius: BorderRadius.circular(MinglitRadius.card),
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withValues(alpha: 0.12),
+              color: Colors.black.withValues(alpha: MinglitOpacity.shadowMd),
               blurRadius: 20,
               offset: const Offset(0, 6),
             ),
@@ -146,7 +146,7 @@ class _HeaderStrip extends StatelessWidget {
           // White logo — ColorFiltered wraps the themed SVG
           ColorFiltered(
             colorFilter: const ColorFilter.mode(
-              Colors.white,
+              MinglitColors.background,
               BlendMode.srcIn,
             ),
             child: MinglitTheme.appBarLogo(height: 24),
@@ -159,7 +159,7 @@ class _HeaderStrip extends StatelessWidget {
               const Text(
                 'BOARDING PASS',
                 style: TextStyle(
-                  color: Colors.white,
+                  color: MinglitColors.background,
                   fontSize: 11,
                   fontWeight: FontWeight.w700,
                   letterSpacing: 2,
@@ -168,7 +168,9 @@ class _HeaderStrip extends StatelessWidget {
               Text(
                 '입장권',
                 style: TextStyle(
-                  color: Colors.white.withValues(alpha: 0.7),
+                  color: MinglitColors.background.withValues(
+                    alpha: MinglitOpacity.scrimDark,
+                  ),
                   fontSize: 10,
                   fontWeight: FontWeight.w500,
                 ),
@@ -369,7 +371,7 @@ class _PerforationLine extends StatelessWidget {
             child: CustomPaint(
               painter: _DashLinePainter(
                 notchRadius: _notchRadius,
-                dashColor: Color(0xFFE5E7EB),
+                dashColor: MinglitColors.divider,
               ),
             ),
           ),

--- a/apps/app_user/lib/src/routing/app_routes.dart
+++ b/apps/app_user/lib/src/routing/app_routes.dart
@@ -20,6 +20,7 @@ import 'package:app_user/src/features/search/search_page.dart';
 import 'package:app_user/src/features/settings/blocked_partners_page.dart';
 import 'package:app_user/src/features/settings/privacy_page.dart';
 import 'package:app_user/src/features/tag/ui/tag_event_list_page.dart';
+import 'package:app_user/src/features/ticket/ui/model/ticket_event_meta.dart';
 import 'package:app_user/src/features/ticket/ui/ticket_qr_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -168,15 +169,24 @@ class MyTicketsRoute extends GoRouteData with $MyTicketsRoute {
 
 /// **Ticket QR Route**: QR code screen for a specific ticket.
 /// Path: `/tickets/:ticketId/qr`
+///
+/// [TicketEventMeta] is passed via [GoRouterState.extra] — not in the URL —
+/// so that complex event metadata can be forwarded from callers that already
+/// hold the data (e.g. MyTicketsPage) without a round-trip query.
+// Fix #1526: $extra 활용해 TicketEventMeta 전달 — URL에 포함 불가한 complex object
 @TypedGoRoute<TicketQRRoute>(path: '/tickets/:ticketId/qr')
 class TicketQRRoute extends GoRouteData with $TicketQRRoute {
-  const TicketQRRoute({required this.ticketId});
+  const TicketQRRoute({required this.ticketId, this.$extra});
 
   final String ticketId;
 
+  /// Optional event metadata forwarded from the calling screen.
+  /// Accessed via [GoRouterState.extra] — not serialized in the URL.
+  final TicketEventMeta? $extra;
+
   @override
   Widget build(BuildContext context, GoRouterState state) =>
-      TicketQRScreen(ticketId: ticketId);
+      TicketQRScreen(ticketId: ticketId, eventMeta: $extra);
 }
 
 /// **Purchase History Route**

--- a/apps/app_user/lib/src/routing/app_routes.dart
+++ b/apps/app_user/lib/src/routing/app_routes.dart
@@ -182,6 +182,11 @@ class TicketQRRoute extends GoRouteData with $TicketQRRoute {
 
   /// Optional event metadata forwarded from the calling screen.
   /// Accessed via [GoRouterState.extra] — not serialized in the URL.
+  ///
+  // Directive: go_router_builder 4.x does not auto-generate state.extra
+  // forwarding. After running build_runner, manually re-apply:
+  //   `$extra: state.extra as TicketEventMeta?`
+  // in app_routes.g.dart _fromState. See PR #1532.
   final TicketEventMeta? $extra;
 
   @override

--- a/apps/app_user/lib/src/routing/app_routes.g.dart
+++ b/apps/app_user/lib/src/routing/app_routes.g.dart
@@ -331,8 +331,10 @@ RouteBase get $ticketQRRoute => GoRouteData.$route(
 );
 
 mixin $TicketQRRoute on GoRouteData {
-  static TicketQRRoute _fromState(GoRouterState state) =>
-      TicketQRRoute(ticketId: state.pathParameters['ticketId']!);
+  static TicketQRRoute _fromState(GoRouterState state) => TicketQRRoute(
+    ticketId: state.pathParameters['ticketId']!,
+    $extra: state.extra as TicketEventMeta?,
+  );
 
   TicketQRRoute get _self => this as TicketQRRoute;
 
@@ -342,17 +344,19 @@ mixin $TicketQRRoute on GoRouteData {
   );
 
   @override
-  void go(BuildContext context) => context.go(location);
+  void go(BuildContext context) => context.go(location, extra: _self.$extra);
 
   @override
-  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+  Future<T?> push<T>(BuildContext context) =>
+      context.push<T>(location, extra: _self.$extra);
 
   @override
   void pushReplacement(BuildContext context) =>
-      context.pushReplacement(location);
+      context.pushReplacement(location, extra: _self.$extra);
 
   @override
-  void replace(BuildContext context) => context.replace(location);
+  void replace(BuildContext context) =>
+      context.replace(location, extra: _self.$extra);
 }
 
 RouteBase get $purchaseHistoryRoute => GoRouteData.$route(

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1530-dev+26041530
+version: 26.04.1537-dev+26041537
 resolution: workspace
 
 environment:

--- a/apps/app_user/test/integration/utils/golden_capture.dart
+++ b/apps/app_user/test/integration/utils/golden_capture.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
@@ -57,11 +56,15 @@ class GoldenCapture {
       if (rootElement == null) return;
 
       // Fix #1536: 30s timeout to prevent CI hang in headless (GPU-less) environment
-      final image = await captureImage(rootElement).timeout(const Duration(seconds: 30));
+      final image = await captureImage(
+        rootElement,
+      ).timeout(const Duration(seconds: 30));
       // Fix #1458: ensure dispose is called even if toByteData throws
       late final Uint8List bytes;
       try {
-        final byteData = await image.toByteData(format: ui.ImageByteFormat.png).timeout(const Duration(seconds: 30));
+        final byteData = await image
+            .toByteData(format: ui.ImageByteFormat.png)
+            .timeout(const Duration(seconds: 30));
         if (byteData == null) return;
         bytes = Uint8List.view(byteData.buffer);
       } finally {

--- a/apps/app_user/test/integration/utils/golden_capture.dart
+++ b/apps/app_user/test/integration/utils/golden_capture.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
@@ -55,11 +56,12 @@ class GoldenCapture {
       final rootElement = tester.binding.rootElement;
       if (rootElement == null) return;
 
-      final image = await captureImage(rootElement);
+      // Fix #1536: 30s timeout to prevent CI hang in headless (GPU-less) environment
+      final image = await captureImage(rootElement).timeout(const Duration(seconds: 30));
       // Fix #1458: ensure dispose is called even if toByteData throws
       late final Uint8List bytes;
       try {
-        final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
+        final byteData = await image.toByteData(format: ui.ImageByteFormat.png).timeout(const Duration(seconds: 30));
         if (byteData == null) return;
         bytes = Uint8List.view(byteData.buffer);
       } finally {

--- a/apps/app_user/test/scenarios/ticket_qr_scenarios.dart
+++ b/apps/app_user/test/scenarios/ticket_qr_scenarios.dart
@@ -1,4 +1,5 @@
 import 'package:app_user/src/features/ticket/data/ticket_wallet_repository.dart';
+import 'package:app_user/src/features/ticket/ui/model/ticket_event_meta.dart';
 import 'package:app_user/src/features/ticket/ui/ticket_qr_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -20,6 +21,15 @@ class TicketQRScenarios {
     expiresAt: _now.add(const Duration(hours: 3)),
   );
 
+  // Fix #1526: TicketEventMeta 추가 — 보딩패스 이벤트 정보 표시
+  static TicketEventMeta get _eventMeta => TicketEventMeta(
+    eventTitle: '봄밤 와인 테이스팅',
+    // Future event → CONFIRMED badge
+    eventDateTime: _now.add(const Duration(days: 5)),
+    eventVenue: '강남 라운지바',
+    ticketName: '일반 입장권',
+  );
+
   static List<dynamic> _validOverrides() {
     final mockRepo = _MockTicketWalletRepository();
     when(() => mockRepo.getTicket('ticket-1')).thenAnswer((_) async => _token);
@@ -37,7 +47,7 @@ class TicketQRScenarios {
   static List<ScreenshotScenario> get all => [
     ScreenshotScenario(
       name: 'ticket_qr_screen_valid',
-      page: const TicketQRScreen(ticketId: 'ticket-1'),
+      page: TicketQRScreen(ticketId: 'ticket-1', eventMeta: _eventMeta),
       overrides: _validOverrides(),
     ),
     ScreenshotScenario(

--- a/apps/app_user/test/scenarios/ticket_qr_scenarios.dart
+++ b/apps/app_user/test/scenarios/ticket_qr_scenarios.dart
@@ -11,7 +11,9 @@ class _MockTicketWalletRepository extends Mock
     implements TicketWalletRepository {}
 
 class TicketQRScenarios {
-  static final _now = DateTime(2026, 4, 1, 12);
+  // Fix #1526: 실행 시점 기준으로 계산 — 고정 날짜 사용 시 날짜가 지나면
+  // USED로 렌더링되어 시나리오 의도와 어긋남
+  static final _now = DateTime.now();
 
   static TicketToken get _token => TicketToken(
     ticketId: 'ticket-1',

--- a/apps/app_user/test/src/features/home/logic/home_coordinator_test.dart
+++ b/apps/app_user/test/src/features/home/logic/home_coordinator_test.dart
@@ -146,11 +146,14 @@ void main() {
       test('eventMeta 없이 호출하면 extra=null로 전달한다', () {
         HomeCoordinator(mockRouter).pushTicketQR('ticket-456');
 
-        verify(
+        final captured = verify(
           () => mockRouter.push(
             any(that: contains('ticket-456')),
+            extra: captureAny(named: 'extra'),
           ),
-        ).called(1);
+        ).captured;
+
+        expect(captured.single, isNull);
       });
     });
   });

--- a/apps/app_user/test/src/features/home/logic/home_coordinator_test.dart
+++ b/apps/app_user/test/src/features/home/logic/home_coordinator_test.dart
@@ -149,7 +149,6 @@ void main() {
         verify(
           () => mockRouter.push(
             any(that: contains('ticket-456')),
-            extra: null,
           ),
         ).called(1);
       });

--- a/apps/app_user/test/src/features/home/logic/home_coordinator_test.dart
+++ b/apps/app_user/test/src/features/home/logic/home_coordinator_test.dart
@@ -1,4 +1,5 @@
 import 'package:app_user/src/features/home/logic/home_coordinator.dart';
+import 'package:app_user/src/features/ticket/ui/model/ticket_event_meta.dart';
 import 'package:app_user/src/routing/app_router.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -111,6 +112,47 @@ void main() {
       verify(
         () => mockRouter.push(any(that: contains('p_1'))),
       ).called(1);
+    });
+
+    // Fix #1526: pushTicketQR는 eventMeta를 GoRouter.push의 extra로 전달해야 한다.
+    // app_routes.g.dart의 _fromState가 state.extra를 드롭하면 이 테스트가 실패한다.
+    group('pushTicketQR', () {
+      setUp(() {
+        when(
+          () => mockRouter.push(any(), extra: any(named: 'extra')),
+        ).thenAnswer((_) async => null);
+      });
+
+      test('eventMeta를 GoRouter extra로 전달한다', () {
+        final meta = TicketEventMeta(
+          eventTitle: '테스트 이벤트',
+          eventDateTime: DateTime(2026, 5, 1, 18),
+          eventVenue: '강남 라운지',
+          ticketName: '일반 입장권',
+        );
+
+        HomeCoordinator(mockRouter).pushTicketQR('ticket-123', eventMeta: meta);
+
+        final captured = verify(
+          () => mockRouter.push(
+            any(that: contains('ticket-123')),
+            extra: captureAny(named: 'extra'),
+          ),
+        ).captured;
+
+        expect(captured.single, same(meta));
+      });
+
+      test('eventMeta 없이 호출하면 extra=null로 전달한다', () {
+        HomeCoordinator(mockRouter).pushTicketQR('ticket-456');
+
+        verify(
+          () => mockRouter.push(
+            any(that: contains('ticket-456')),
+            extra: null,
+          ),
+        ).called(1);
+      });
     });
   });
 }

--- a/apps/app_user/test/src/features/my_tickets/ui/my_tickets_page_test.dart
+++ b/apps/app_user/test/src/features/my_tickets/ui/my_tickets_page_test.dart
@@ -259,7 +259,12 @@ void main() {
       await tester.tap(find.text('입장 QR'));
       await tester.pump();
 
-      verify(() => mockHomeCoordinator.pushTicketQR('ticket_1')).called(1);
+      verify(
+        () => mockHomeCoordinator.pushTicketQR(
+          'ticket_1',
+          eventMeta: any(named: 'eventMeta'),
+        ),
+      ).called(1);
     });
 
     // Fix #642: P2 — banner not shown when no todayEvent

--- a/apps/app_user/test/src/features/ticket/logic/boarding_pass_status_test.dart
+++ b/apps/app_user/test/src/features/ticket/logic/boarding_pass_status_test.dart
@@ -1,0 +1,81 @@
+import 'package:app_user/src/features/ticket/logic/boarding_pass_status.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// Tests for BoardingPassStatus determination logic.
+// Covers P1 cases from test-plan.md Layer 2.
+
+void main() {
+  group('boardingPassStatus', () {
+    // Pin a reference "now" to make tests deterministic.
+    final now = DateTime(2026, 4, 15, 12); // Wednesday 2026-04-15 12:00
+
+    test('오늘 이벤트 (startTime이 오늘) → BOARDING', () {
+      final todayMorning = DateTime(2026, 4, 15, 9);
+      final todayEvening = DateTime(2026, 4, 15, 21);
+
+      expect(
+        boardingPassStatus(todayMorning, now: now),
+        BoardingPassStatus.boarding,
+      );
+      expect(
+        boardingPassStatus(todayEvening, now: now),
+        BoardingPassStatus.boarding,
+      );
+    });
+
+    test('미래 이벤트 (startTime이 내일 이후) → CONFIRMED', () {
+      final tomorrow = DateTime(2026, 4, 16, 19);
+      final nextWeek = DateTime(2026, 4, 22, 10);
+
+      expect(
+        boardingPassStatus(tomorrow, now: now),
+        BoardingPassStatus.confirmed,
+      );
+      expect(
+        boardingPassStatus(nextWeek, now: now),
+        BoardingPassStatus.confirmed,
+      );
+    });
+
+    test('지난 이벤트 (startTime이 어제 이전) → USED', () {
+      final yesterday = DateTime(2026, 4, 14, 19);
+      final lastWeek = DateTime(2026, 4, 8, 10);
+
+      expect(
+        boardingPassStatus(yesterday, now: now),
+        BoardingPassStatus.used,
+      );
+      expect(
+        boardingPassStatus(lastWeek, now: now),
+        BoardingPassStatus.used,
+      );
+    });
+
+    test('오늘 자정 경계 — 23:59 시작 이벤트가 BOARDING으로 분류', () {
+      // 23:59 today must be BOARDING, not CONFIRMED
+      final lateTonight = DateTime(2026, 4, 15, 23, 59);
+
+      expect(
+        boardingPassStatus(lateTonight, now: now),
+        BoardingPassStatus.boarding,
+      );
+    });
+
+    test('오늘 자정 00:00 — BOARDING 경계의 시작', () {
+      final midnight = DateTime(2026, 4, 15);
+
+      expect(
+        boardingPassStatus(midnight, now: now),
+        BoardingPassStatus.boarding,
+      );
+    });
+
+    test('now 파라미터 미지정 시 DateTime.now() 기준으로 동작', () {
+      // Cannot pin the exact result, but must not throw
+      expect(
+        () => boardingPassStatus(DateTime.now()),
+        returnsNormally,
+      );
+    });
+  });
+}

--- a/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
+++ b/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
@@ -143,7 +143,10 @@ void main() {
     testWidgets('긴 이벤트명 (50자+) — 크래시 없고 말줄임 적용', (tester) async {
       final longTitle = 'A' * 55;
       await tester.pumpWidget(
-        _wrap(token: _makeToken(), eventMeta: _makeMeta(title: longTitle)),
+        _wrap(
+          token: _makeToken(),
+          eventMeta: _makeMeta(title: longTitle),
+        ),
       );
       await tester.pump();
 
@@ -152,7 +155,10 @@ void main() {
 
     testWidgets('긴 장소명 — 크래시 없고 말줄임 적용', (tester) async {
       await tester.pumpWidget(
-        _wrap(token: _makeToken(), eventMeta: _makeMeta(venue: 'B' * 40)),
+        _wrap(
+          token: _makeToken(),
+          eventMeta: _makeMeta(venue: 'B' * 40),
+        ),
       );
       await tester.pump();
 
@@ -234,9 +240,7 @@ void main() {
         // more reliable in headless test environments.
         expect(
           find.byWidgetPredicate(
-            (w) =>
-                w is Semantics &&
-                w.properties.label == '이벤트 입장 QR 코드',
+            (w) => w is Semantics && w.properties.label == '이벤트 입장 QR 코드',
           ),
           findsOneWidget,
         );

--- a/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
+++ b/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
@@ -170,12 +170,13 @@ void main() {
     // -----------------------------------------------------------------------
 
     testWidgets('BOARDING 상태: "BOARDING" 텍스트 (오늘 이벤트)', (tester) async {
-      // _now is today's date, so boardingPassStatus(_now) → boarding
-      // When the test runs, DateTime.now() will be today, so we use a date
-      // explicitly set to today by relying on the meta being equal to _now.
-      // Since boardingPassStatus uses DateTime.now() internally, use
-      // today's date for the test:
-      final todayMeta = _makeMeta(dateTime: DateTime.now());
+      // Use midday (12:00) to avoid midnight boundary flakiness.
+      // boardingPassStatus uses DateTime.now() internally, so both sides
+      // must agree on "today" — a fixed midday timestamp is safe.
+      final today = DateTime.now();
+      final todayMeta = _makeMeta(
+        dateTime: DateTime(today.year, today.month, today.day, 12),
+      );
 
       await tester.pumpWidget(
         _wrap(token: _makeToken(), eventMeta: todayMeta),
@@ -266,9 +267,9 @@ void main() {
       );
       await tester.pump();
 
-      // USED status observable contract —
-      // status text confirms scanning disabled
       expect(find.text('USED'), findsOneWidget);
+      // Scanning line widget must be absent for USED status
+      expect(find.byKey(const ValueKey('scanning-line')), findsNothing);
     });
 
     // -----------------------------------------------------------------------

--- a/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
+++ b/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
@@ -138,6 +138,8 @@ void main() {
 
       // Must not throw; header still renders
       expect(find.text('BOARDING PASS'), findsOneWidget);
+      // Fix #1532: null-meta graceful degradation — all info fields show "—"
+      expect(find.text('—'), findsWidgets);
     });
 
     testWidgets('긴 이벤트명 (50자+) — 크래시 없고 말줄임 적용', (tester) async {

--- a/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
+++ b/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
@@ -1,0 +1,289 @@
+import 'dart:async';
+
+import 'package:app_user/src/features/ticket/ui/model/ticket_event_meta.dart';
+import 'package:app_user/src/features/ticket/ui/widgets/boarding_pass_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+// Widget tests for BoardingPassCard — Layer 3 per test-plan.md
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+final _now = DateTime(2026, 4, 15, 12);
+
+TicketToken _makeToken({String ticketId = 'ticket-abc123'}) {
+  return TicketToken(
+    ticketId: ticketId,
+    eventId: 'event-1',
+    userId: 'user-1',
+    signature: 'signed-token',
+    expiresAt: _now.add(const Duration(days: 1)),
+  );
+}
+
+TicketEventMeta _makeMeta({
+  String title = '금요일 밤 와인 테이스팅',
+  DateTime? dateTime,
+  String? venue = '강남 라운지바',
+  String? ticketName = '일반 입장권',
+}) {
+  return TicketEventMeta(
+    eventTitle: title,
+    eventDateTime: dateTime ?? _now,
+    eventVenue: venue,
+    ticketName: ticketName,
+  );
+}
+
+/// Host widget that owns the [AnimationController] and passes it to
+/// [BoardingPassCard]. This avoids creating a vsync outside the widget tree.
+class _Host extends StatefulWidget {
+  const _Host({required this.token, this.eventMeta});
+
+  final TicketToken token;
+  final TicketEventMeta? eventMeta;
+
+  @override
+  State<_Host> createState() => _HostState();
+}
+
+class _HostState extends State<_Host> with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 2),
+    );
+    unawaited(_controller.repeat(reverse: true));
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BoardingPassCard(
+      token: widget.token,
+      scanningAnimation: _controller,
+      eventMeta: widget.eventMeta,
+    );
+  }
+}
+
+Widget _wrap({required TicketToken token, TicketEventMeta? eventMeta}) {
+  return MaterialApp(
+    theme: ThemeData(useMaterial3: true),
+    home: Scaffold(
+      body: SingleChildScrollView(
+        child: _Host(token: token, eventMeta: eventMeta),
+      ),
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  setUpAll(() async {
+    await initializeDateFormatting();
+  });
+
+  group('BoardingPassCard', () {
+    // -----------------------------------------------------------------------
+    // Header rendering
+    // -----------------------------------------------------------------------
+
+    testWidgets('헤더 스트립: "BOARDING PASS" + "입장권" 텍스트 존재', (tester) async {
+      await tester.pumpWidget(
+        _wrap(token: _makeToken(), eventMeta: _makeMeta()),
+      );
+      await tester.pump();
+
+      expect(find.text('BOARDING PASS'), findsOneWidget);
+      expect(find.text('입장권'), findsOneWidget);
+    });
+
+    // -----------------------------------------------------------------------
+    // Event info section
+    // -----------------------------------------------------------------------
+
+    testWidgets('이벤트 정보 섹션: DATE/VENUE 라벨 + 이벤트명 표시', (tester) async {
+      await tester.pumpWidget(
+        _wrap(token: _makeToken(), eventMeta: _makeMeta()),
+      );
+      await tester.pump();
+
+      expect(find.text('DATE'), findsOneWidget);
+      expect(find.text('VENUE'), findsOneWidget);
+      expect(find.text('금요일 밤 와인 테이스팅'), findsOneWidget);
+      expect(find.textContaining('강남 라운지바'), findsOneWidget);
+      expect(find.textContaining('TICKET · 일반 입장권'), findsOneWidget);
+    });
+
+    testWidgets('이벤트 메타 null → placeholder "—" 표시 (크래시 없음)', (tester) async {
+      await tester.pumpWidget(_wrap(token: _makeToken()));
+      await tester.pump();
+
+      // Must not throw; header still renders
+      expect(find.text('BOARDING PASS'), findsOneWidget);
+    });
+
+    testWidgets('긴 이벤트명 (50자+) — 크래시 없고 말줄임 적용', (tester) async {
+      final longTitle = 'A' * 55;
+      await tester.pumpWidget(
+        _wrap(token: _makeToken(), eventMeta: _makeMeta(title: longTitle)),
+      );
+      await tester.pump();
+
+      expect(find.byType(BoardingPassCard), findsOneWidget);
+    });
+
+    testWidgets('긴 장소명 — 크래시 없고 말줄임 적용', (tester) async {
+      await tester.pumpWidget(
+        _wrap(token: _makeToken(), eventMeta: _makeMeta(venue: 'B' * 40)),
+      );
+      await tester.pump();
+
+      expect(find.byType(BoardingPassCard), findsOneWidget);
+    });
+
+    // -----------------------------------------------------------------------
+    // Status badge — uses _now as event DateTime (same day → boarding)
+    // -----------------------------------------------------------------------
+
+    testWidgets('BOARDING 상태: "BOARDING" 텍스트 (오늘 이벤트)', (tester) async {
+      // _now is today's date, so boardingPassStatus(_now) → boarding
+      // When the test runs, DateTime.now() will be today, so we use a date
+      // explicitly set to today by relying on the meta being equal to _now.
+      // Since boardingPassStatus uses DateTime.now() internally, use
+      // today's date for the test:
+      final todayMeta = _makeMeta(dateTime: DateTime.now());
+
+      await tester.pumpWidget(
+        _wrap(token: _makeToken(), eventMeta: todayMeta),
+      );
+      await tester.pump();
+
+      expect(find.text('BOARDING'), findsOneWidget);
+      expect(find.text('STATUS'), findsOneWidget);
+    });
+
+    testWidgets('CONFIRMED 상태: "CONFIRMED" 텍스트 (미래 이벤트)', (tester) async {
+      final futureMeta = _makeMeta(
+        dateTime: DateTime.now().add(const Duration(days: 7)),
+      );
+
+      await tester.pumpWidget(
+        _wrap(token: _makeToken(), eventMeta: futureMeta),
+      );
+      await tester.pump();
+
+      expect(find.text('CONFIRMED'), findsOneWidget);
+    });
+
+    testWidgets(
+      'USED 상태: "USED" 텍스트 + 카드 opacity 0.55 (지난 이벤트)',
+      (tester) async {
+        final pastMeta = _makeMeta(
+          dateTime: DateTime.now().subtract(const Duration(days: 2)),
+        );
+
+        await tester.pumpWidget(
+          _wrap(token: _makeToken(), eventMeta: pastMeta),
+        );
+        await tester.pump();
+
+        expect(find.text('USED'), findsOneWidget);
+
+        // Verify Opacity widget wrapping the card has 0.55
+        final opacityWidget = tester.widget<Opacity>(
+          find.ancestor(
+            of: find.byType(ClipRRect),
+            matching: find.byType(Opacity),
+          ),
+        );
+        expect(opacityWidget.opacity, closeTo(MinglitOpacity.overlay, 0.01));
+      },
+    );
+
+    // -----------------------------------------------------------------------
+    // QR stub
+    // -----------------------------------------------------------------------
+
+    testWidgets(
+      'QR 코드: Semantics label "이벤트 입장 QR 코드" 존재 (접근성)',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(token: _makeToken(), eventMeta: _makeMeta()),
+        );
+        await tester.pump();
+
+        // Use widget predicate instead of semantics tree traversal —
+        // more reliable in headless test environments.
+        expect(
+          find.byWidgetPredicate(
+            (w) =>
+                w is Semantics &&
+                w.properties.label == '이벤트 입장 QR 코드',
+          ),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets('TICKET NO. 라벨 표시', (tester) async {
+      await tester.pumpWidget(
+        _wrap(token: _makeToken(), eventMeta: _makeMeta()),
+      );
+      await tester.pump();
+
+      expect(find.text('TICKET NO.'), findsOneWidget);
+    });
+
+    testWidgets('USED 상태: 스캐닝 라인 없음 ("USED" 상태 계약 확인)', (tester) async {
+      final pastMeta = _makeMeta(
+        dateTime: DateTime.now().subtract(const Duration(days: 2)),
+      );
+
+      await tester.pumpWidget(
+        _wrap(token: _makeToken(), eventMeta: pastMeta),
+      );
+      await tester.pump();
+
+      // USED status observable contract —
+      // status text confirms scanning disabled
+      expect(find.text('USED'), findsOneWidget);
+    });
+
+    // -----------------------------------------------------------------------
+    // Instruction text not in card
+    // -----------------------------------------------------------------------
+
+    testWidgets(
+      '카드 자체에 안내 문구("입장 시 파트너에게") 없음 — TicketQRScreen 책임',
+      (tester) async {
+        await tester.pumpWidget(
+          _wrap(token: _makeToken(), eventMeta: _makeMeta()),
+        );
+        await tester.pump();
+
+        expect(
+          find.text('입장 시 파트너에게 이 화면을 보여주세요'),
+          findsNothing,
+        );
+      },
+    );
+  });
+}

--- a/apps/app_user/test/visual_qa/visual_qa_helper.dart
+++ b/apps/app_user/test/visual_qa/visual_qa_helper.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
-import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 // KEEP IN SYNC WITH apps/app_partner/test/visual_qa/visual_qa_helper.dart
@@ -61,15 +60,11 @@ extension VisualQaTester on WidgetTester {
       final step = _nextStep();
       // Widget tree dump is synchronous — do it before the async image capture.
       _captureWidgetTree(step, label);
-      // Image capture uses real async I/O and GPU rendering; must use runAsync.
-      // Fix #1536: runAsync can hang in headless CI (GPU unavailable). Timeout
-      // after 30 s and swallow — capture failure must never block the test.
-      await runAsync(() async {
-        await _captureScreenshot(step, label);
-      }).timeout(
-        const Duration(seconds: 30),
-        onTimeout: () => null,
-      );
+      // Fix #1536: Do NOT use runAsync — captureImage() hangs permanently in
+      // headless CI (no GPU) and .timeout() does not cancel the internal Future,
+      // leaving a leaked async operation that blocks subsequent tests.
+      // GoldenCapture uses the same direct-await pattern and works correctly.
+      await _captureScreenshot(step, label);
     } catch (e, st) {
       // ignore: avoid_print
       print('[VisualQA] capture("$label") failed: $e\n$st');
@@ -116,15 +111,19 @@ extension VisualQaTester on WidgetTester {
   // ---------------------------------------------------------------------------
 
   Future<void> _captureScreenshot(int step, String label) async {
-    final image = await _renderToImage();
-    final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
-    image.dispose();
-    if (byteData == null) {
-      throw StateError('toByteData returned null for step $step "$label"');
+    final rootElement = binding.rootElement;
+    if (rootElement == null) return;
+    final image = await captureImage(rootElement);
+    late final Uint8List bytes;
+    try {
+      final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
+      if (byteData == null) return;
+      bytes = Uint8List.view(byteData.buffer);
+    } finally {
+      image.dispose();
     }
-    final bytes = Uint8List.view(byteData.buffer);
-    final file = _ensureFile('${step}_$label.png');
-    await file.writeAsBytes(bytes, flush: true);
+    // Synchronous I/O — avoids runAsync and the associated async leak risk.
+    _ensureFile('${step}_$label.png').writeAsBytesSync(bytes);
   }
 
   void _captureWidgetTree(int step, String label) {
@@ -141,25 +140,4 @@ extension VisualQaTester on WidgetTester {
     return File('${dir.path}/$filename');
   }
 
-  /// Renders the root render view to a [ui.Image].
-  ///
-  /// Uses [captureImage] from flutter_test when a root element is available.
-  /// Falls back to the render view's layer tree otherwise.
-  Future<ui.Image> _renderToImage() async {
-    // Try flutter_test's built-in captureImage using the root element.
-    final rootElement = binding.rootElement;
-    if (rootElement != null) {
-      // captureImage walks up to the nearest repaint boundary automatically.
-      return captureImage(rootElement);
-    }
-
-    // Fallback: use the render view layer directly.
-    final renderView = binding.renderViews.first;
-    final layer = renderView.debugLayer;
-    if (layer is OffsetLayer) {
-      return layer.toImage(renderView.paintBounds);
-    }
-
-    throw StateError('Could not find a paintable layer to capture.');
-  }
 }

--- a/apps/app_user/test/visual_qa/visual_qa_helper.dart
+++ b/apps/app_user/test/visual_qa/visual_qa_helper.dart
@@ -139,5 +139,4 @@ extension VisualQaTester on WidgetTester {
     if (!dir.existsSync()) dir.createSync(recursive: true);
     return File('${dir.path}/$filename');
   }
-
 }

--- a/apps/app_user/test/visual_qa/visual_qa_helper.dart
+++ b/apps/app_user/test/visual_qa/visual_qa_helper.dart
@@ -62,9 +62,14 @@ extension VisualQaTester on WidgetTester {
       // Widget tree dump is synchronous — do it before the async image capture.
       _captureWidgetTree(step, label);
       // Image capture uses real async I/O and GPU rendering; must use runAsync.
+      // Fix #1536: runAsync can hang in headless CI (GPU unavailable). Timeout
+      // after 30 s and swallow — capture failure must never block the test.
       await runAsync(() async {
         await _captureScreenshot(step, label);
-      });
+      }).timeout(
+        const Duration(seconds: 30),
+        onTimeout: () => null,
+      );
     } catch (e, st) {
       // ignore: avoid_print
       print('[VisualQA] capture("$label") failed: $e\n$st');

--- a/apps/landing_partner/package.json
+++ b/apps/landing_partner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_partner",
-  "version": "26.04.1530-dev",
+  "version": "26.04.1537-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3003",

--- a/apps/landing_user/package.json
+++ b/apps/landing_user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_user",
-  "version": "26.04.1530-dev",
+  "version": "26.04.1537-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minglit-root",
-  "version": "26.04.1530-dev",
+  "version": "26.04.1537-dev",
   "private": true,
   "workspaces": [
     "apps/*"

--- a/shared/packages/minglit_iamport_v1/pubspec.yaml
+++ b/shared/packages/minglit_iamport_v1/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_iamport_v1
 description: "Iamport V1 Payment and Certification package for Minglit."
-version: 26.04.1530-dev
+version: 26.04.1537-dev
 publish_to: 'none'
 
 environment:

--- a/shared/packages/minglit_kit/lib/src/theme/minglit_design_tokens.dart
+++ b/shared/packages/minglit_kit/lib/src/theme/minglit_design_tokens.dart
@@ -40,6 +40,11 @@ class MinglitColors {
   /// Fully transparent color.
   static const transparent = Color(0x00000000);
 
+  /// Light theme border/divider separator color.
+  static const divider = Color(
+    0xFFE5E7EB,
+  ); // ignore: minglit_no_hardcoded_colors -- light divider token
+
   /// Semi-transparent black scrim for overlays.
   static const scrim = Color(0x80000000);
 
@@ -110,9 +115,7 @@ class MinglitColorSet {
     secondary: MinglitColors.secondary,
     textPrimary: MinglitColors.textPrimary,
     textSecondary: MinglitColors.textSecondary,
-    divider: Color(
-      0xFFE5E7EB,
-    ), // ignore: minglit_no_hardcoded_colors -- light divider token
+    divider: MinglitColors.divider,
     success: MinglitColors.success,
     info: MinglitColors.info,
     warning: MinglitColors.warning,
@@ -283,6 +286,9 @@ class MinglitOpacity {
 
   /// 3% opacity — soft elevated shadow.
   static const double shadowSm = 0.03;
+
+  /// 12% opacity — medium-depth card shadow.
+  static const double shadowMd = 0.12;
 
   /// 4% opacity — shimmer highlight.
   static const double shimmerHighlight = 0.04;

--- a/shared/packages/minglit_kit/pubspec.yaml
+++ b/shared/packages/minglit_kit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_kit
 description: "A new Flutter package project."
-version: 26.04.1530-dev
+version: 26.04.1537-dev
 resolution: workspace
 publish_to: 'none'
 environment:

--- a/shared/packages/minglit_lints/pubspec.yaml
+++ b/shared/packages/minglit_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_lints
 description: Custom lint rules for Minglit project to enforce UI consistency and design tokens.
-version: 26.04.1530-dev
+version: 26.04.1537-dev
 publish_to: none
 resolution: workspace
 


### PR DESCRIPTION
## Summary

- 기존 단순 QR 뷰를 항공 탑승권 스타일 카드(BoardingPassCard)로 교체
- 이벤트명·일시·장소·티켓 종류를 카드 안에 표시
- 상태 배지(BOARDING/CONFIRMED/USED) 도입 — 당일 이벤트 강조, 사용 후 시각적 처리
- `TicketEventMeta`를 GoRouter `$extra`로 전달해 URL 직렬화 없이 복잡 객체 포워딩

## Changes

- **NEW** `boarding_pass_status.dart` — 날짜 기준 상태 판단 순수 함수
- **NEW** `ticket_event_meta.dart` — 보딩패스 표시용 이벤트 메타 데이터 클래스
- **NEW** `boarding_pass_card.dart` — 4-섹션 카드 위젯 (그라디언트 헤더, 이벤트 정보, 미싱선, QR 스텁)
- **MOD** `ticket_qr_screen.dart` — StatefulWidget으로 변환, AnimationController 소유
- **MOD** `home_coordinator.dart` — `pushTicketQR(eventMeta?)` 확장
- **MOD** `my_tickets_page.dart` — EventApplication → TicketEventMeta 변환 및 전달
- **MOD** `app_routes.dart` — `TicketQRRoute.$extra` 필드 추가

## Tests

- `boarding_pass_status_test.dart` — 6 unit cases (BOARDING/CONFIRMED/USED 경계 포함)
- `boarding_pass_card_test.dart` — 12 widget cases (헤더, 이벤트 정보, null 처리, 상태 배지, 접근성)

## Test plan

- [ ] 티켓 QR 화면에서 Boarding Pass 카드가 렌더되는지 확인
- [ ] 오늘 이벤트 → BOARDING 배지 + 스캐닝 라인 확인
- [ ] 미래 이벤트 → CONFIRMED 배지 확인
- [ ] 지난 이벤트 → USED 배지 + 카드 opacity 낮아짐 확인
- [ ] 딥링크 진입(eventMeta=null) → placeholder "—" 표시 (크래시 없음) 확인
- [ ] `flutter test test/src/features/ticket/` 전체 통과

Closes #1526

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1526, closes #1539