### PR TITLE
fix(test): visual_qa runAsync 30s timeout — headless CI hang 방지

### DIFF
--- a/apps/app_partner/test/visual_qa/visual_qa_helper.dart
+++ b/apps/app_partner/test/visual_qa/visual_qa_helper.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
@@ -62,9 +63,14 @@ extension VisualQaTester on WidgetTester {
       // Widget tree dump is synchronous — do it before the async image capture.
       _captureWidgetTree(step, label);
       // Image capture uses real async I/O and GPU rendering; must use runAsync.
+      // Fix #1536: runAsync can hang in headless CI (GPU unavailable). Timeout
+      // after 30 s and swallow — capture failure must never block the test.
       await runAsync(() async {
         await _captureScreenshot(step, label);
-      });
+      }).timeout(
+        const Duration(seconds: 30),
+        onTimeout: () => null,
+      );
     } catch (e, st) {
       // ignore: avoid_print
       print('[VisualQA] capture("$label") failed: $e\n$st');

--- a/apps/app_partner/test/visual_qa/visual_qa_helper.dart
+++ b/apps/app_partner/test/visual_qa/visual_qa_helper.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui;

--- a/apps/app_user/test/visual_qa/visual_qa_helper.dart
+++ b/apps/app_user/test/visual_qa/visual_qa_helper.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
@@ -62,9 +63,14 @@ extension VisualQaTester on WidgetTester {
       // Widget tree dump is synchronous — do it before the async image capture.
       _captureWidgetTree(step, label);
       // Image capture uses real async I/O and GPU rendering; must use runAsync.
+      // Fix #1536: runAsync can hang in headless CI (GPU unavailable). Timeout
+      // after 30 s and swallow — capture failure must never block the test.
       await runAsync(() async {
         await _captureScreenshot(step, label);
-      });
+      }).timeout(
+        const Duration(seconds: 30),
+        onTimeout: () => null,
+      );
     } catch (e, st) {
       // ignore: avoid_print
       print('[VisualQA] capture("$label") failed: $e\n$st');

--- a/apps/app_user/test/visual_qa/visual_qa_helper.dart
+++ b/apps/app_user/test/visual_qa/visual_qa_helper.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui;


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1536

## Summary

- `visual_qa_helper.dart`의 `runAsync` 블록에 30초 timeout 추가
- headless Linux CI 환경에서 GPU 없이 `captureImage()`가 영구 hang되는 문제 수정
- app_partner + app_user 두 파일 동시 수정 (KEEP IN SYNC 주석 준수)

## Root Cause

PR #1496에서 도입된 `tester.capture()` 호출이 headless CI에서 10분 timeout으로 테스트를 blocking:

```dart
// 문제: GPU 없는 환경에서 captureImage()가 hang → runAsync Future가 resolve되지 않음
await runAsync(() async {
  await _captureScreenshot(step, label);
});
```

## Fix

```dart
// 수정: 30초 timeout 추가 — timeout 시 null 반환으로 capture 실패를 swallow
await runAsync(() async {
  await _captureScreenshot(step, label);
}).timeout(
  const Duration(seconds: 30),
  onTimeout: () => null,
);
```

## Evidence

- 성공 run (24509193909, Apr 16 12:12): PR #1496 이전 — 8+8 tests PASSED
- 실패 run (24555611341, Apr 17): PR #1496 이후 — 8+8 tests FAILED (TimeoutException)

## Test plan

- [ ] CI `test-flutter-apps (app_partner)` 통과 확인
- [ ] CI `test-flutter-apps (app_user)` 통과 확인