### PR TITLE
fix(ci): version-bump workflow — push race condition 방지 (pull --rebase + retry)

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -72,7 +72,25 @@ jobs:
           git add -A
           git diff --cached --quiet && { echo "No version changes to commit."; exit 0; }
           git commit -m "chore: bump version to v${NEW_VERSION} [skip ci]"
-          git push origin HEAD:${BRANCH}
+
+          # Fix #1506: push race — dev가 다른 경로로 전진할 수 있어 pull --rebase + retry
+          MAX_ATTEMPTS=5
+          ATTEMPT=0
+          until git push origin HEAD:${BRANCH}; do
+            ATTEMPT=$((ATTEMPT+1))
+            if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
+              echo "::error::push failed after $MAX_ATTEMPTS attempts"
+              exit 1
+            fi
+            echo "::warning::push rejected (attempt $ATTEMPT/$MAX_ATTEMPTS), rebasing on origin/${BRANCH} and retrying..."
+            git fetch origin ${BRANCH}
+            git rebase origin/${BRANCH} || {
+              echo "::error::rebase failed — manual resolution required"
+              exit 1
+            }
+            # linear backoff: 2s, 4s, 6s, 8s
+            sleep $((2 * ATTEMPT))
+          done
 
       - name: Create GitHub release (main only)
         if: github.base_ref == 'main'


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1554

push step에 pull --rebase + retry 루프 추가. race condition으로 인한 non-fast-forward reject를 최대 5회 재시도로 처리.

## 변경 사항
- push 실패 시 `git fetch origin ${BRANCH}` + `git rebase` 후 재시도 (최대 5회)
- linear backoff: 2s, 4s, 6s, 8s
- rebase 실패(실제 충돌) 시 즉시 fail-fast
- 5회 전부 실패 시 명확한 에러 메시지로 종료