### PR TITLE
fix(ci): version-bump push retry on race condition

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -72,7 +72,23 @@ jobs:
           git add -A
           git diff --cached --quiet && { echo "No version changes to commit."; exit 0; }
           git commit -m "chore: bump version to v${NEW_VERSION} [skip ci]"
-          git push origin HEAD:${BRANCH}
+          # Fix #1554: push race — dev가 다른 경로로 전진할 수 있어 pull --rebase + retry
+          MAX_ATTEMPTS=5
+          ATTEMPT=0
+          until git push origin HEAD:${BRANCH}; do
+            ATTEMPT=$((ATTEMPT+1))
+            if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
+              echo "::error::push failed after $MAX_ATTEMPTS attempts"
+              exit 1
+            fi
+            echo "::warning::push rejected (attempt $ATTEMPT/$MAX_ATTEMPTS), rebasing on origin/${BRANCH} and retrying..."
+            git fetch origin ${BRANCH}
+            git rebase origin/${BRANCH} || {
+              echo "::error::rebase failed — manual resolution required"
+              exit 1
+            }
+            sleep $((2 * ATTEMPT))
+          done
 
       - name: Create GitHub release (main only)
         if: github.base_ref == 'main'


### PR DESCRIPTION
## Summary
- Replaces single `git push` with a pull-rebase + retry loop (up to 5 attempts, linear backoff 2s·4s·6s·8s) in the version-bump workflow
- Prevents silent bump failures when two PRs merge concurrently and the second push is rejected

## Root Cause
When two PRs merge to `dev` within seconds of each other, both version-bump runs checkout the same HEAD. The second run commits its bump on top of the same parent, then `git push` is rejected (non-fast-forward). The job fails silently and the version is never bumped.

## Test Plan
- [ ] Review YAML diff — logic follows standard retry-rebase pattern
- [ ] Verify no force-push path exists in the retry loop
- [ ] Confirm `MAX_ATTEMPTS=5` cap prevents infinite loops

Closes #1554

🤖 Generated with [Claude Code](https://claude.com/claude-code)