### PR TITLE
fix(ci): backend-simulation pg_cron → GitHub Actions로 이관

### DIFF
--- a/.github/workflows/hourly-backend-simulation.yml
+++ b/.github/workflows/hourly-backend-simulation.yml
@@ -1,0 +1,36 @@
+name: Hourly Backend Simulation
+
+on:
+  schedule:
+    - cron: '0 * * * *'  # Every hour at :00 (hourly-user-activity.yml runs at :30)
+  workflow_dispatch:
+
+concurrency:
+  group: supabase-dev-simulation  # Same group as hourly-user-activity to prevent concurrent EF calls
+  cancel-in-progress: false
+
+jobs:
+  simulate:
+    name: Run backend-simulator (full phase)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Trigger backend-simulator EF
+        run: |
+          curl -sf -X POST \
+            "${{ secrets.SUPABASE_DEV_URL }}/functions/v1/backend-simulator" \
+            -H "Authorization: Bearer ${{ secrets.SUPABASE_DEV_SECRET_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d '{}' \
+            --max-time 600
+
+  notify-failure:
+    needs: [simulate]
+    if: always()
+    permissions:
+      issues: write
+    uses: ./.github/workflows/notify-failure.yml
+    with:
+      success: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+      workflow_name: 'Hourly Backend Simulation'
+    secrets: inherit

--- a/.github/workflows/hourly-backend-simulation.yml
+++ b/.github/workflows/hourly-backend-simulation.yml
@@ -17,12 +17,14 @@ jobs:
     steps:
       - name: Trigger backend-simulator EF
         run: |
-          curl -sf -X POST \
+          response=$(curl -sf -X POST \
             "${{ secrets.SUPABASE_DEV_URL }}/functions/v1/backend-simulator" \
             -H "Authorization: Bearer ${{ secrets.SUPABASE_DEV_SECRET_KEY }}" \
             -H "Content-Type: application/json" \
             -d '{}' \
-            --max-time 600
+            --max-time 600)
+          echo "$response"
+          echo "$response" | jq -e '.success == true'
 
   notify-failure:
     needs: [simulate]

--- a/scripts/verify-db-objects.sql
+++ b/scripts/verify-db-objects.sql
@@ -137,9 +137,6 @@ BEGIN
   IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname='process-notifications') THEN
     missing := missing || 'cron:process-notifications';
   END IF;
-  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname='backend-simulation') THEN
-    missing := missing || 'cron:backend-simulation';
-  END IF;
   IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname='send-event-reminders') THEN
     missing := missing || 'cron:send-event-reminders';
   END IF;

--- a/supabase/migrations/20260418000001_remove_backend_simulation_cron.sql
+++ b/supabase/migrations/20260418000001_remove_backend_simulation_cron.sql
@@ -1,0 +1,13 @@
+-- Fix #1583: backend-simulation pg_cron → GitHub Actions로 이관
+-- pg_cron은 dev + main 양쪽에서 매시간 EF를 호출했으나,
+-- main에서는 불필요한 HTTP POST이며 EF 가드 단일 레이어 의존 위험이 있다.
+-- GitHub Actions는 SUPABASE_DEV_* secret만 참조하므로 구조적으로 main 도달 불가.
+--
+-- process-notifications, settlement-*, account-deletion-* 등 production-critical cron은 유지.
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'backend-simulation') THEN
+    PERFORM cron.unschedule('backend-simulation');
+  END IF;
+END $$;


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1583

## 변경 사항

### `.github/workflows/hourly-backend-simulation.yml` (신규)
- 매시간 :00에 `backend-simulator` EF를 full phase mode로 호출
- `SUPABASE_DEV_*` secret만 참조 → 구조적으로 main 도달 불가
- `supabase-dev-simulation` concurrency group 공유 → `hourly-user-activity.yml`과 동시 실행 방지
- 실패 시 `notify-failure.yml` 경로로 자동 이슈 생성

### `supabase/migrations/20260418000001_remove_backend_simulation_cron.sql` (신규)
- `cron.unschedule('backend-simulation')` — dev + main 양쪽에서 pg_cron 제거
- IF EXISTS 체크로 이미 없는 경우 safe

## 방어 레이어 변화
- Before: EF `isProduction()` 체크 1개
- After: GH Actions secret 격리 (구조적) + EF `isProduction()` 체크 = 2개 독립 레이어

## 머지 후 검증
- [ ] 새 workflow 수동 dispatch 1회 성공 확인
- [ ] `SELECT jobname FROM cron.job WHERE jobname LIKE '%simulation%';` 빈 결과 확인