### PR TITLE
ci(flutter): minglit_kit 경로 필터 분리 + 회귀 감지 사각지대 제거 (Phase A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
     outputs:
       app_user: ${{ steps.filter.outputs.app_user }}
       app_partner: ${{ steps.filter.outputs.app_partner }}
+      minglit_kit: ${{ steps.filter.outputs.minglit_kit }}
+      app_user_or_kit: ${{ steps.filter.outputs.app_user == 'true' || steps.filter.outputs.minglit_kit == 'true' }}
+      app_partner_or_kit: ${{ steps.filter.outputs.app_partner == 'true' || steps.filter.outputs.minglit_kit == 'true' }}
       landing_user: ${{ steps.filter.outputs.landing_user }}
       landing_partner: ${{ steps.filter.outputs.landing_partner }}
       supabase: ${{ steps.filter.outputs.supabase }}
@@ -56,9 +59,9 @@ jobs:
         filters: |
           app_user:
             - 'apps/app_user/**'
-            - 'shared/packages/minglit_kit/**'
           app_partner:
             - 'apps/app_partner/**'
+          minglit_kit:
             - 'shared/packages/minglit_kit/**'
           landing_user:
             - 'apps/landing_user/**'
@@ -72,7 +75,7 @@ jobs:
   # App CI (User + Partner)
   test-flutter-apps:
     needs: changes
-    if: ${{ needs.changes.outputs.app_user == 'true' || needs.changes.outputs.app_partner == 'true' }}
+    if: ${{ needs.changes.outputs.app_user == 'true' || needs.changes.outputs.app_partner == 'true' || needs.changes.outputs.minglit_kit == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -82,21 +85,21 @@ jobs:
       matrix:
         include:
           - app: app_user
-            change_key: app_user
+            change_key: app_user_or_kit
             directory: apps/app_user
             report_name: 'User App Tests'
             artifact_name: app-user-coverage
             coverage_flag: app-user
             coverage_flag_logic: app-user-logic
           - app: app_partner
-            change_key: app_partner
+            change_key: app_partner_or_kit
             directory: apps/app_partner
             report_name: 'Partner App Tests'
             artifact_name: app-partner-coverage
             coverage_flag: app-partner
             coverage_flag_logic: app-partner-logic
           - app: minglit_kit
-            change_key: app_user
+            change_key: minglit_kit
             directory: shared/packages/minglit_kit
             report_name: 'Minglit Kit Tests'
             artifact_name: minglit-kit-coverage


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1585 (Phase A)

## Summary

- changes job의 paths-filter에서 minglit_kit 경로를 독립 필터로 분리
- 복합 출력 app_user_or_kit, app_partner_or_kit 추가
- test-flutter-apps matrix의 change_key 의미론 불일치 해소

## 변경 전/후 동작

minglit_kit만 변경: app_user + app_partner + minglit_kit 세 entry 모두 실행
app_user만 변경: app_user entry만 실행 (minglit_kit 불필요 실행 제거)
app_partner만 변경: app_partner entry만 실행

## 핵심 수정

Before: minglit_kit matrix entry가 change_key: app_user를 사용 → apps/app_user 변경 시 불필요하게 실행

After: 각 entry가 의미적으로 명확한 change_key 사용
- app_user: app_user_or_kit
- app_partner: app_partner_or_kit
- minglit_kit: minglit_kit

## Test plan

- [ ] apps/app_user 만 변경한 PR → app_user 만 테스트, minglit_kit 스킵
- [ ] apps/app_partner 만 변경한 PR → app_partner 만 테스트
- [ ] shared/packages/minglit_kit 만 변경한 PR → 세 entry 모두 테스트

Generated with Claude Code