### PR TITLE
docs(qa): 7-layer taxonomy 도입 + 문서/README 일관화 (#1586 Phase A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,24 @@ source scripts/load-env.sh dev     # 데브 환경변수 export
 
 ## Testing
 
+테스트 전략 / Layer taxonomy / 작성 규칙은 `docs/qa/` 하위 문서가 SSOT.
+
+- [`docs/qa/test-strategy.md`](docs/qa/test-strategy.md) — 7-layer taxonomy (SSOT). Layer 책임 / 커버리지 / 로드맵.
+- [`docs/qa/automation-test-guide.md`](docs/qa/automation-test-guide.md) — Layer 별 작성 규칙 + 샘플 코드 + 체크리스트.
+- [`docs/qa/screenshot-capture-points.md`](docs/qa/screenshot-capture-points.md) — 시나리오 스크린샷 (Tier B) 캡처 포인트 매핑.
+
 ```bash
-# Flutter
+# Flutter (Layer 1 + 2a + 2b)
 cd shared/packages/minglit_kit && flutter test
 cd apps/app_user && flutter test
 cd apps/app_partner && flutter test
 
-# Edge Functions (Deno)
+# Edge Functions (Layer 5)
 cd supabase/functions/dev-session-switch && deno test --allow-env --allow-net
 cd supabase/functions/dev-seed && deno test --allow-env --allow-net
+
+# pgTAP (Layer 4)
+supabase test db
 
 # Lint
 flutter analyze

--- a/docs/qa/automation-test-guide.md
+++ b/docs/qa/automation-test-guide.md
@@ -1,66 +1,57 @@
 # Automation Test Guide
 
-Claude가 새 피쳐를 구현할 때 반드시 따라야 하는 자동화 테스트 가이드.
+새 피쳐를 구현할 때 따라야 하는 자동화 테스트 가이드.
+
+> 📖 Taxonomy SSOT: [`test-strategy.md`](test-strategy.md) — Layer 정의 / 책임 / 커버리지 수치
+>
+> 이 문서는 각 Layer 의 **작성 규칙 + 샘플 코드 + 체크리스트** 를 다룬다.
 
 ---
 
-## 1. 현재 테스트 커버리지 현황
+## 1. Layer 선택 결정 트리
 
-### 요약 통계 (2026-04-05 기준)
+구현 전 반드시 본 트리로 어느 Layer 에 테스트를 추가할지 결정한다.
 
-| 계층 | 테스트 파일 수 | 커버리지 상태 |
-|------|-------------|-------------|
-| minglit_kit (공유 로직) | 80 | 양호 — 핵심 repository 대부분 커버 |
-| app_user (사용자 앱) | 85 | 양호 (P0 Integration +3건, Smoke +2건) |
-| app_partner (파트너 앱) | 73 | 개선됨 (Integration +4건, Smoke +5건) |
-| Supabase DB (pgTAP) | 54 | 양호 |
-| Edge Functions (Deno) | 61 | 양호 |
-| Client CUJ (E2E) | 6 | 핵심 경로만 |
+```
+새 테스트 추가 필요?
+│
+├── DB 스키마 / RLS / RPC 계약 변경?         → Layer 4 (pgTAP)
+├── 신규 Edge Function 로직?                 → Layer 5 (Deno EF)
+├── 네이티브 surface 필요?
+│   (카카오 로그인, PG SDK, 시스템 권한)      → Layer 3 (Patrol emulator)
+├── 다화면 플로우 / GoRouter guard / redirect? → Layer 2a (widget flow)
+├── 디자인 토큰 / 시각 회귀 감지?             → Layer 2b (Alchemist golden)
+├── repository / controller / util / model?   → Layer 1 (unit)
+├── 매시간 실 DB 데이터 이상 감시?            → Layer 6 (DB monitor RPC)
+└── 파이프라인 연쇄 동작 (tick) 감시?         → Layer 7 (backend-simulator)
+```
 
-### 커버리지 갭
+**복수 Layer 필요 사례**:
 
-#### 🟡 SEVERE — 40% 미만
-| 영역 | 소스 파일 | 테스트 파일 | 상태 |
-|------|----------|-----------|---------|
-| app_partner/party | 70 | 12 | 개선됨 (1.4% → 17%) |
-| app_partner/ticket | 12 | 1 | 심각 — 미결 |
-| app_partner/settlement | 14 | 6 | 개선됨 (21% → 43%) |
-| app_partner/verification | 6 | 4 | 개선됨 (17% → 67%) |
-| app_user/event | 31 | 19 | 개선됨 (24% → 61%) |
-
-#### 해소된 갭 (2026-04 기준)
-- `app_user/settings`: 2 테스트 추가 ✅
-- `app_user/search`: 2 테스트 추가 ✅
-- `app_user/payment`: 6 테스트 (완전 커버) ✅
-- `app_partner/checkin`: 2 테스트 추가 ✅
-- `minglit_kit/iamport`: 3 테스트 추가 ✅
-
-#### 미테스트 Repository (minglit_kit)
-- `party_event_repository.dart`
-- `party_matching_repository.dart`
-
-#### 해소된 Repository 갭
-- `auth_repository.dart` ✅
-- `event_repository_commands.dart` / `event_repository_queries.dart` ✅
-- `kakao_location_repository.dart` ✅
-- `policy_repository.dart` ✅
-- `staff_repository.dart` ✅
-- `user_repository.dart` ✅
-- `verification_repository.dart` ✅
+- 신규 EF + 소비하는 controller → Layer 5 + Layer 1
+- 신규 테이블 + RLS + 읽는 repository → Layer 4 + Layer 1
+- 신규 화면 + 디자인 신규 컴포넌트 → Layer 2b (골든) + Layer 1 (controller) + Layer 2a (flow)
+- 신규 CUJ + 네이티브 결제 → Layer 3 (Patrol) **필수**, Layer 2a 는 생략 가능
 
 ---
 
-## 2. 테스트 계층별 작성 규칙
+## 2. Layer 별 작성 규칙
 
-### Layer 1: Repository 테스트 (minglit_kit)
+### 📱 Layer 1 — Unit test
 
-**위치:** `shared/packages/minglit_kit/test/src/data/repositories/`
-**우선순위:** 가장 높음 — 모든 비즈니스 로직의 기반
+**위치**:
+- `shared/packages/minglit_kit/test/src/`
+- `apps/app_user/test/src/features/{feature}/`
+- `apps/app_partner/test/src/features/{feature}/`
+
+**파일 명**: `{name}_test.dart` (controller 는 `{name}_controller_test.dart`)
+
+**프레임워크**: `flutter_test` (headless), `mocktail`
+
+**샘플 (repository)**:
 
 ```dart
-// 파일명: {feature}_repository_test.dart
 import 'package:flutter_test/flutter_test.dart';
-import 'package:minglit_kit/src/data/repositories/event_repository.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../helpers/mocks.dart';
@@ -75,101 +66,63 @@ void main() {
     repository = EventRepository(supabase: mockClient);
   });
 
-  group('EventRepository', () {
-    group('getEventById', () {
-      test('returns event when found', () async {
-        mockTable(mockClient, 'events', singleData: {
-          'id': 'event_1',
-          'title': 'Test Event',
-          'status': 'scheduled',
-          // ... 필수 필드
-        });
-
-        final result = await repository.getEventById('event_1');
-        expect(result.id, 'event_1');
+  group('EventRepository.getEventById', () {
+    test('returns event when found', () async {
+      mockTable(mockClient, 'events', singleData: {
+        'id': 'event_1', 'title': 'Test', 'status': 'scheduled',
       });
 
-      test('throws MingleException when not found', () async {
-        mockTable(mockClient, 'events',
-          shouldThrow: PostgrestException(message: 'not found'),
-        );
+      final result = await repository.getEventById('event_1');
+      expect(result.id, 'event_1');
+    });
 
-        expect(
-          () => repository.getEventById('nonexistent'),
-          throwsA(isA<MingleException>()),
-        );
-      });
+    test('throws MingleException when not found', () async {
+      mockTable(mockClient, 'events',
+        shouldThrow: PostgrestException(message: 'not found'));
+      expect(() => repository.getEventById('x'), throwsA(isA<MingleException>()));
     });
   });
 }
 ```
 
-**핵심 패턴:**
-- `createMockSupabase()` — Supabase 클라이언트 Mock 생성
-- `mockTable()` — 테이블 쿼리 결과 Fake 설정
-- Mock은 `mocktail` 사용 (mockito 아님)
-- JSON mock 데이터는 실제 DB 스키마와 일치해야 함
-
-### Layer 2: Controller/Provider 테스트 (앱별)
-
-**위치:** `apps/app_user/test/src/features/{feature}/logic/`
-**우선순위:** 높음 — UI와 데이터를 연결하는 상태 관리
+**샘플 (controller / provider)**:
 
 ```dart
-// 파일명: {feature}_controller_test.dart
-import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:mocktail/mocktail.dart';
+test('loads event data on init', () async {
+  when(() => mockRepo.getEventById(any())).thenAnswer((_) async => testEvent);
 
-import '../../../../utils/mocks.dart';
-import '../../../../utils/test_utils.dart';
+  final container = createContainer(overrides: [
+    eventRepositoryProvider.overrideWithValue(mockRepo),
+  ]);
 
-void main() {
-  late MockEventRepository mockRepo;
+  final state = await container.read(
+    eventDetailControllerProvider('event_1').future,
+  );
 
-  setUp(() {
-    mockRepo = MockEventRepository();
-  });
-
-  group('EventDetailController', () {
-    test('loads event data on init', () async {
-      when(() => mockRepo.getEventById(any()))
-          .thenAnswer((_) async => testEvent);
-
-      final container = createContainer(
-        overrides: [
-          eventRepositoryProvider.overrideWithValue(mockRepo),
-        ],
-      );
-
-      final state = await container.read(
-        eventDetailControllerProvider('event_1').future,
-      );
-
-      expect(state.event.id, 'event_1');
-      verify(() => mockRepo.getEventById('event_1')).called(1);
-    });
-  });
-}
+  expect(state.event.id, 'event_1');
+  verify(() => mockRepo.getEventById('event_1')).called(1);
+});
 ```
 
-**핵심 패턴:**
-- `createContainer()` — Riverpod 테스트용 컨테이너 (`test_utils.dart`)
-- Repository를 Mock으로 override
-- `when()`으로 Mock 행동 정의 → 테스트 → `verify()`로 호출 검증
+**핵심 패턴**:
+- `createMockSupabase()` — Supabase 클라이언트 Mock (`minglit_kit/test/helpers/supabase_mock_helpers.dart`)
+- `mockTable()` — 테이블 쿼리 Fake 결과
+- `createContainer()` — Riverpod 테스트 컨테이너 (`apps/{app}/test/utils/test_utils.dart`)
+- `mocktail` 사용 (mockito 아님)
 
-### Layer 2.5: Integration 테스트 (CUJ 기반)
+---
 
-**위치:**
-- `apps/app_user/test/integration/cuj_*.dart` — app_user CUJ
-- `apps/app_partner/test/integration/cuj_*.dart` — app_partner CUJ
+### 📱 Layer 2a — Widget flow test
 
-**공통 헬퍼:**
-- `apps/app_user/test/integration/utils/test_app.dart` — `createTestApp()`
-- `apps/app_partner/test/integration/utils/test_app.dart` — `createPartnerTestApp()`
+**위치**: `apps/app_*/test/integration/` (향후 `test/flows/` rename 검토)
+
+**파일 명**: `{scenario}_test.dart` 또는 `cuj_*_test.dart`
+
+**프레임워크**: `flutter_test` (headless) + `createTestApp()` 헬퍼
+
+**샘플**:
 
 ```dart
-// app_user CUJ 테스트 패턴
 void main() {
   testWidgets('비로그인 사용자 → 보호 경로 리다이렉트', (tester) async {
     await tester.pumpWidget(
@@ -184,94 +137,30 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    expect(find.byType(Scaffold), findsOneWidget);
-  });
-}
-
-// app_partner CUJ 테스트 패턴
-void main() {
-  testWidgets('needsApplication → /welcome 리다이렉트', (tester) async {
-    await tester.pumpWidget(
-      createPartnerTestApp(
-        isLoggedIn: true,
-        currentUser: testUser,
-        onboardingState: OnboardingState.needsApplication,
-        initialLocation: '/',
-      ),
-    );
-    await tester.pumpAndSettle();
-    expect(find.byType(Scaffold), findsOneWidget);
+    expect(find.text('로그인'), findsOneWidget);
   });
 }
 ```
 
-**핵심 패턴:**
+**핵심 패턴**:
 - `createTestApp()` / `createPartnerTestApp()` — 라우터 + Provider 설정 (Supabase 불필요)
-- `overrideWith()` — AsyncNotifier/Notifier를 Fake 구현으로 교체
-- `overrideWithValue()` — NotifierProvider를 특정 상태 값으로 교체
-- `AsyncData/AsyncLoading/AsyncError` — 비동기 상태 시뮬레이션
+- `overrideWith()` — AsyncNotifier/Notifier 를 Fake 구현으로 교체
+- `overrideWithValue()` — NotifierProvider 를 특정 상태 값으로 교체
+- 실 네트워크 / 실 DB 호출 **금지** (→ Layer 3 에서 처리)
 
-### Layer 3: Widget/UI 테스트
+---
 
-**위치:** `apps/app_user/test/integration/` 또는 `apps/app_user/test/src/features/{feature}/ui/`
-**우선순위:** 중간 — 렌더링과 사용자 인터랙션
+### 📱 Layer 2b — Golden image test (Alchemist)
 
-```dart
-// 파일명: {widget_name}_test.dart
-import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+**위치**: `apps/app_*/test/goldens/` (향후 `test/alchemist/` rename — PR #1582)
 
-void main() {
-  testWidgets('PurchaseHistoryScreen shows empty state', (tester) async {
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          purchaseHistoryProvider.overrideWith(
-            (_) => AsyncData([]),
-          ),
-        ],
-        child: const MaterialApp(
-          home: PurchaseHistoryScreen(),
-        ),
-      ),
-    );
-    await tester.pumpAndSettle();
+**파일 명**: `{widget_name}_golden_test.dart`
 
-    expect(find.text('구매 내역이 없습니다'), findsOneWidget);
-  });
+**프레임워크**: [alchemist](https://pub.dev/packages/alchemist)
 
-  testWidgets('shows list when data exists', (tester) async {
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          purchaseHistoryProvider.overrideWith(
-            (_) => AsyncData([testPurchase]),
-          ),
-        ],
-        child: const MaterialApp(
-          home: PurchaseHistoryScreen(),
-        ),
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    expect(find.byType(PurchaseHistoryCard), findsOneWidget);
-  });
-}
-```
-
-### Layer 3.5: Golden (Snapshot) 테스트 — Alchemist
-
-**위치:** `apps/{app}/test/goldens/`, `shared/packages/minglit_kit/test/goldens/`
-**우선순위:** 디자인 토큰 변경, 레이아웃 회귀 방지
-**패키지:** [alchemist](https://pub.dev/packages/alchemist) (VGV + Betterment)
-
-Golden Test는 위젯 렌더링 결과를 이미지로 저장해두고 이후 픽셀 비교로 시각적 회귀를 감지한다.
-Alchemist를 사용하여 CI(Ahem 폰트) / 로컬(플랫폼 폰트) 골든을 분리 관리한다.
+**샘플**:
 
 ```dart
-// 파일명: {widget_name}_golden_test.dart
 @Tags(['golden'])
 library;
 
@@ -300,37 +189,84 @@ void main() {
 }
 ```
 
-**CI 비교 모드 동작:**
-- **CI** (`flutter test --dart-define=CI=true --tags golden`): Ahem 폰트 기반 CI 골든과 비교 → 다르면 FAIL + `failures/` diff 이미지 아티팩트 업로드
-- **로컬**: 플랫폼별 골든(macOS/Linux)으로 비교 — `.gitignore`로 커밋 제외
+**CI 비교 모드**:
+- CI (`flutter test --dart-define=CI=true --tags golden`) — Ahem 폰트 기반 CI 골든 비교 → 다르면 FAIL + `failures/` diff artifact
+- 로컬 — 플랫폼별 골든(`macos/`, `linux/`). `.gitignore` 로 제외
 
-**의도된 UI 변경 시 워크플로우:**
+**의도된 UI 변경 시**:
 1. 로컬에서 `flutter test --update-goldens --tags golden --dart-define=CI=true`
 2. 새 CI 골든 PNG 커밋 → push
 3. CI 재실행 → PASS
 
-**핵심 규칙:**
-- `@Tags(['golden'])`으로 태깅하여 일반 테스트와 분리 실행
-- `flutter_test_config.dart`에서 `AlchemistConfig`로 CI/플랫폼 모드 자동 전환
-- CI 골든은 Ahem 폰트 → OS 무관 일관성 보장
-- 플랫폼 골든(`test/**/goldens/macos/`, `linux/`)은 `.gitignore`로 제외
-- CI에서 golden 불일치 시 diff 이미지가 `golden-failures-{app}` artifact로 업로드됨
+**핵심 규칙**:
+- `@Tags(['golden'])` 태깅 — 일반 테스트와 분리 실행
+- `flutter_test_config.dart` 의 `AlchemistConfig` 가 CI/플랫폼 모드 자동 전환
+- CI 골든 = Ahem 폰트 (OS 무관)
 
-### Layer 4: Database 테스트 (pgTAP)
+---
 
-**위치:** `supabase/tests/database/`
-**우선순위:** DB 스키마나 RLS 변경 시 필수
+### 📱 Layer 3 — Emulator test (Patrol)
+
+**위치**: `apps/app_*/integration_test/` (향후 `emulator_test/` rename — PR #1582)
+
+**파일 명**: `cuj_{scenario}_test.dart` (CUJ) 또는 `{feature}_native_test.dart` (native surface)
+
+**프레임워크**: [Patrol](https://patrol.leancode.co/) + 실 dev Supabase
+
+**샘플** (CUJ):
+
+```dart
+import 'package:patrol/patrol.dart';
+
+import 'helpers/e2e_init.dart';
+
+void main() {
+  patrolTest('U01 — 유저가 이벤트 신청한다', ($) async {
+    await initializeE2E();
+    await signInAsTestUser($, email: $testEmail);
+
+    await $.pumpWidgetAndSettle(const MinglitApp());
+    await $.native.screenshot(name: 'u01_step1_home');
+
+    await $('신청하기').tap();
+    await $.native.screenshot(name: 'u01_step2_apply_sheet');
+
+    await $('결제').waitUntilVisible();
+    await $.native.screenshot(name: 'u01_step3_payment');
+  });
+}
+```
+
+**핵심 패턴**:
+- `find.text` → `$('text')`
+- `pumpAndSettle` → `waitUntilVisible` / `waitUntilExists`
+- 스텝별 `$.native.screenshot(name: ...)` 삽입 → Tier B ("시나리오 스크린샷") 생성
+- `SUPABASE_DEV_*` secret 만 사용 (main 도달 구조적 불가)
+
+**상태 (2026-04-18)**: CUJ 이관률 **0%**. 이관 계획은 #1586 Phase D-2 참고.
+
+**네이티브 surface 전용 기존 파일** (유지):
+- `apple_sign_in_test.dart`, `kakao_login_test.dart`, `payment_pg_test.dart`, `permission_grant_test.dart`
+
+---
+
+### 🗄️ Layer 4 — pgTAP test
+
+**위치**: `supabase/tests/database/`
+
+**파일 명**: `{번호}_{feature}_test.sql`
+
+**번호 규칙**: `ls supabase/tests/database/` 로 기존 번호 확인 후 다음 번호 사용.
+
+**샘플**:
 
 ```sql
--- 파일명: {번호}_{feature}_test.sql
 BEGIN;
 SELECT plan(3);
 
--- 스키마 검증
-SELECT has_table('public', 'new_feature_table', 'new_feature_table exists');
+SELECT has_table('public', 'new_feature_table', 'table exists');
 SELECT has_column('public', 'new_feature_table', 'name', 'has name column');
 
--- RLS 검증
 SET LOCAL role = 'authenticated';
 SET LOCAL request.jwt.claims = '{"sub": "user_1"}';
 
@@ -344,23 +280,26 @@ SELECT * FROM finish();
 ROLLBACK;
 ```
 
-### Layer 5: Edge Function 테스트 (Deno)
+**핵심 규칙**:
+- 파일 시작 `BEGIN;` + 끝 `ROLLBACK;` — 테스트 격리
+- `SET LOCAL role` + `SET LOCAL request.jwt.claims` — RLS 시뮬
+- 새 migration 과 **반드시 동반** (테이블/컬럼/RLS 추가 시)
 
-**위치:** `supabase/functions/{function_name}/{function_name}_test.ts`
-**우선순위:** 새 Edge Function 추가 시 필수
+---
+
+### 🗄️ Layer 5 — Deno EF test
+
+**위치**: `supabase/functions/{function_name}/{function_name}_test.ts`
+
+**프레임워크**: `deno test`
+
+**샘플**:
 
 ```typescript
-// 파일명: {function_name}_test.ts
 import { assertEquals } from "@std/assert";
 import {
-  authenticatedJsonRequest,
-  captureServeHandler,
-  createFetchMock,
-  jsonResponse,
-  readJson,
-  withEnv,
-  withMockedFetch,
-  withNoIntervals,
+  authenticatedJsonRequest, captureServeHandler, createFetchMock,
+  withEnv, withMockedFetch, withNoIntervals,
 } from "../_test_utils/mock_http.ts";
 
 const ENV = {
@@ -370,195 +309,250 @@ const ENV = {
 
 Deno.test("function-name - happy path", async () => {
   await withEnv(ENV, async () => {
-    const handler = await captureServeHandler(
-      new URL("./index.ts", import.meta.url),
-    );
-    const { fetchMock } = createFetchMock([/* mock routes */]);
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([/* routes */]);
 
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
-        const request = authenticatedJsonRequest("http://localhost", {
-          /* payload */
-        });
+        const request = authenticatedJsonRequest("http://localhost", { /* body */ });
         const response = await handler(request);
-
         assertEquals(response.status, 200);
       });
     });
   });
 });
-
-Deno.test("function-name - missing params returns 400", async () => {
-  // 에러 케이스 테스트
-});
 ```
 
-**핵심 패턴:**
-- `captureServeHandler()` — Edge Function의 handler 캡처
-- `createFetchMock()` — 외부 API 호출 Mock (Iamport, Supabase 등)
-- `withEnv()` — 환경변수 설정
-- `withMockedFetch()` — fetch 함수 대체
-- `withNoIntervals()` — setInterval 비활성화 (타이머 기반 로직)
+**핵심 패턴**:
+- `captureServeHandler()` — handler 캡처
+- `createFetchMock()` — 외부 API 모킹 (Iamport, Supabase REST 등)
+- `withEnv()` — 환경변수 주입
+- `withMockedFetch()` — `fetch` 대체
+- `withNoIntervals()` — `setInterval` 비활성화 (타이머 기반 로직)
+- 외부 API 호출은 **반드시 mock**
 
 ---
 
-## 3. 새 피쳐 구현 시 테스트 체크리스트
+### 🗄️ Layer 6 — DB monitor
 
-Claude가 새 피쳐를 구현할 때 아래 체크리스트를 따른다:
+**위치**: `supabase/migrations/` 내부 `check_db_invariants()` RPC + `.github/workflows/db-invariants.yml`
 
-### 필수 (MUST)
+**샘플 (migration)**:
 
-- [ ] **Repository 테스트** — 새로운 Repository 메서드마다 happy path + error case
-- [ ] **Controller 테스트** — 새로운 Controller/Provider의 상태 변환 검증
-- [ ] **DB Migration 테스트** — 새 테이블/컬럼 추가 시 pgTAP 스키마 테스트
-- [ ] **RLS 테스트** — 새 테이블 또는 RLS 정책 변경 시 pgTAP RLS 테스트
-- [ ] **Edge Function 테스트** — 새 Edge Function 추가 시 Deno 테스트
+```sql
+CREATE OR REPLACE FUNCTION public.check_db_invariants()
+RETURNS TABLE(invariant_name text, violation_count int, details text) AS $$
+BEGIN
+  -- 고아 party_application (event 삭제됨)
+  RETURN QUERY
+    SELECT 'orphan_party_applications'::text,
+           COUNT(*)::int,
+           'party_applications with deleted event'::text
+    FROM party_applications pa
+    LEFT JOIN events e ON e.id = pa.event_id
+    WHERE e.id IS NULL;
 
-### 권장 (SHOULD)
+  -- 추가 invariant ...
+END;
+$$ LANGUAGE plpgsql;
+```
 
-- [ ] **Golden 테스트** — 디자인 토큰이나 레이아웃에 영향을 주는 UI 변경 시 (`@Tags(['golden'])`)
-- [ ] **Widget 테스트** — 복잡한 상태 분기가 있는 UI 위젯
-- [ ] **Coordinator 테스트** — 네비게이션 로직이 있는 Coordinator
-- [ ] **에러 핸들링** — 네트워크 오류, 인증 만료 등 에러 시나리오
-- [ ] **엣지 케이스** — 빈 목록, null 값, 경계값 등
+**워크플로우**: 매시간 cron — 위반 수 > 0 이면 alert.
 
-### 필수 (MUST) — 추가 항목
-
-- [ ] **Smoke 테스트** — 새 화면 추가 시 `test/src/features/{feature}/ui/{page}_smoke_test.dart` 작성
-  - P0 화면: `event_application_wizard`, `purchase_history`, `settlement`, `checkin`, `partner_apply`, `party_create_wizard`, `application_manage`
-  - 최소 1개: 정상 렌더링 + 로딩 상태
-- [ ] **Integration 테스트** — 여러 화면을 걸치는 CUJ 플로우
-  - 신규 CUJ 추가 시 `test/integration/cuj_*.dart` 작성 필수
+**핵심 규칙**:
+- **계약 회귀가 아닌 runtime 이상 감시** (계약은 Layer 4)
+- RPC 는 read-only — 데이터 수정 금지
+- 신규 invariant 추가 시 `db-invariants.yml` 도 업데이트
 
 ---
 
-## 4. 테스트 파일 네이밍 & 위치 규칙
+### 🗄️ Layer 7 — Tick simulator
+
+**위치**: `supabase/functions/backend-simulator/` EF + 워크플로우:
+- `daily-backend-simulation.yml` — 매일 실행 (시간 전진 시뮬)
+- `hourly-user-activity.yml` — 매시간 user 활동 시뮬
+
+**성격**: 기능 테스트가 아니라 **파이프라인 관통 시뮬**. 매칭/결제/정산/알림 파이프라인이 엔드투엔드로 동작하는지 감시.
+
+**작성 대상 아님** (신규 EF 단위 테스트는 Layer 5). Layer 7 은 시뮬 시나리오 확장 시에만 수정.
+
+---
+
+## 3. 파일 네이밍 & 위치 규칙
 
 ```
-# Repository 테스트 (minglit_kit)
+# Layer 1 — Unit
 shared/packages/minglit_kit/test/src/data/repositories/{name}_repository_test.dart
-
-# Model 테스트 (minglit_kit)
 shared/packages/minglit_kit/test/src/data/models/{name}_test.dart
-
-# Controller 테스트 (앱별)
 apps/{app}/test/src/features/{feature}/logic/{name}_controller_test.dart
-
-# Coordinator 테스트 (앱별)
 apps/{app}/test/src/features/{feature}/logic/{name}_coordinator_test.dart
+apps/{app}/test/src/features/{feature}/ui/{widget}_test.dart
 
-# Widget 테스트 (앱별)
-apps/{app}/test/src/features/{feature}/ui/{widget_name}_test.dart
+# Layer 2a — Widget flow
+apps/{app}/test/integration/{scenario}_test.dart
+apps/{app}/test/integration/cuj_{scenario}_test.dart
 
-# Golden 테스트 (앱별)
-apps/{app}/test/goldens/{widget_name}_golden_test.dart
+# Layer 2b — Golden (Alchemist)
+apps/{app}/test/goldens/{widget}_golden_test.dart
+shared/packages/minglit_kit/test/goldens/{widget}_golden_test.dart
 
-# Integration 테스트 (앱별)
-apps/{app}/test/integration/{scenario_name}_test.dart
+# Layer 3 — Emulator (Patrol)
+apps/{app}/integration_test/cuj_{scenario}_test.dart
+apps/{app}/integration_test/{feature}_native_test.dart
 
-# DB 테스트 (pgTAP)
+# Layer 4 — pgTAP
 supabase/tests/database/{번호}_{feature}_test.sql
 
-# Edge Function 테스트
+# Layer 5 — Deno EF
 supabase/functions/{function_name}/{function_name}_test.ts
 ```
 
-**번호 규칙 (pgTAP):** `ls supabase/tests/database/`로 기존 번호 확인 후 다음 번호 사용.
+---
+
+## 4. 새 피쳐 구현 시 체크리스트
+
+### MUST
+
+- [ ] **Layer 1 unit** — 새 repository 메서드 / controller 마다 happy path + error case
+- [ ] **Layer 4 pgTAP** — 새 테이블 / 컬럼 / RLS 정책 추가 시
+- [ ] **Layer 5 Deno EF** — 새 Edge Function 추가 시
+- [ ] **Layer 2a widget flow** — 신규 CUJ 또는 신규 화면 플로우 추가 시 `test/integration/cuj_*_test.dart`
+- [ ] **Layer 2b golden** — 신규 컴포넌트 / 디자인 토큰 변경 시 (`@Tags(['golden'])`)
+
+### SHOULD
+
+- [ ] **Layer 3 Patrol** — 네이티브 surface 또는 실 DB 경로 검증이 핵심인 CUJ
+- [ ] **Layer 1 widget** — 복잡한 상태 분기가 있는 UI 위젯
+- [ ] **에러 핸들링** — 네트워크 오류, 인증 만료, 엣지 케이스
+
+### MAY
+
+- [ ] **Layer 6 invariant** — 새 테이블이 "절대 N 초과하면 안 된다" 같은 런타임 제약을 가질 때
+- [ ] **Layer 7 tick** — 새 파이프라인 단계가 시간 기반 trigger 에 의존할 때
 
 ---
 
-## 5. Mock 유틸리티 참조
+## 5. 현재 커버리지 현황 (2026-04-18)
 
-### Dart (minglit_kit)
+> 전체 수치 / 갭 상세는 [`test-strategy.md §4`](test-strategy.md#4-현재-커버리지-수치-2026-04-18) 참고.
 
-| 유틸 | 위치 | 용도 |
-|------|------|------|
-| `createMockSupabase()` | `minglit_kit/test/helpers/supabase_mock_helpers.dart` | Supabase 클라이언트 Mock |
-| `mockTable()` | 동일 파일 | 테이블 쿼리 Fake 결과 설정 |
-| `MockSupabaseClient` | `minglit_kit/test/helpers/mocks.dart` | 기본 Supabase Mock 클래스들 |
-| `createContainer()` | `apps/{app}/test/utils/test_utils.dart` | Riverpod 테스트 컨테이너 |
-| Repository Mocks | `apps/{app}/test/utils/mocks.dart` | `MockEventRepository` 등 |
+| Layer | 위치 | 파일 수 |
+|-------|------|--------|
+| 1 (unit) | minglit_kit / app_user / app_partner `test/src/` | 99 / 65 / 71 |
+| 2a (widget flow) | app_user / app_partner `test/integration/` | 26 / 11 |
+| 2b (golden) | app_user / app_partner `test/goldens/**_golden_test.dart` | 14 / 15 |
+| 3 (Patrol) | app_user / app_partner `integration_test/` | 5 / 1 (native surface 전용) |
+| 4 (pgTAP) | `supabase/tests/database/*.sql` | 80 |
+| 5 (Deno EF) | `supabase/functions/**/*_test.ts` | 75 |
+| 6 (DB monitor) | `check_db_invariants()` RPC | 1 RPC (매시간) |
+| 7 (tick simulator) | `backend-simulator` EF + 2 workflows | 매시간 + 매일 |
 
-### Deno (Edge Functions)
-
-| 유틸 | 위치 | 용도 |
-|------|------|------|
-| `captureServeHandler()` | `supabase/functions/_test_utils/mock_http.ts` | Edge Function handler 캡처 |
-| `createFetchMock()` | 동일 파일 | HTTP fetch Mock |
-| `authenticatedJsonRequest()` | 동일 파일 | 인증된 JSON 요청 생성 |
-| `withEnv()` | 동일 파일 | 환경변수 설정 |
-| `withMockedFetch()` | 동일 파일 | fetch 대체 |
-| fixtures | `supabase/functions/_test_utils/fixtures.ts` | Mock 데이터 (mockOrder, mockPaidPayment 등) |
+**핵심 갭**:
+- 🔴 **Layer 3 CUJ 이관 0%** — 37 widget flow 를 Patrol 로 전환 필요 (#1586 Phase D-2)
+- 🟡 **Layer 2a 일부 feature 부족** — app_partner integration 11 vs 요구 20+
 
 ---
 
-## 6. 테스트 실행 명령어
+## 6. 실행 명령어
 
 ```bash
-# Flutter 단위/위젯 테스트 (앱별)
+# Layer 1 + 2a + 2b — Flutter 앱별
 cd apps/app_user && flutter test
 cd apps/app_partner && flutter test
 cd shared/packages/minglit_kit && flutter test
 
-# Flutter 특정 파일만
+# 특정 파일만
 flutter test test/src/features/event/logic/event_detail_controller_test.dart
 
-# Flutter 통합 테스트 (Mock 기반) — app_user
+# Layer 2a 만 (widget flow)
 cd apps/app_user && flutter test test/integration/
-
-# Flutter 통합 테스트 (Mock 기반) — app_partner
 cd apps/app_partner && flutter test test/integration/
 
-# 태그로 분리 실행
-cd apps/app_user && flutter test --tags integration
+# Layer 2b 만 (golden)
+cd apps/app_user && flutter test --tags golden --dart-define=CI=true
+# Golden 갱신
+cd apps/app_user && flutter test --update-goldens --tags golden --dart-define=CI=true
 
-# pgTAP DB 테스트
+# Layer 3 (Patrol) — 로컬 emulator 필요
+cd apps/app_user && patrol test --target integration_test/cuj_signup_to_apply_test.dart
+# CI 에서는 patrol-e2e.yml 워크플로우
+
+# Layer 4 pgTAP
 supabase test db
 
-# Edge Function 테스트
+# Layer 5 Deno EF
 deno test --allow-all supabase/functions/
-
-# 특정 Edge Function만
 deno test --allow-all supabase/functions/payment-verify/
 
-# CI 전체 재현
-flutter analyze && flutter test  # Flutter
-supabase test db                 # DB
-deno test --allow-all functions/ # Edge Functions
+# Layer 6 — 수동 실행
+psql -c "SELECT * FROM check_db_invariants();"
+
+# Layer 7 — workflow_dispatch 로 수동 trigger
+gh workflow run daily-backend-simulation.yml --ref dev
 ```
 
 ---
 
-## 7. 테스트 작성 시 주의사항
+## 7. 주의사항
 
 ### DO
 
-- Mock 데이터는 실제 DB 스키마 (`supabase/migrations/`)의 컬럼명과 일치시킨다
-- `group()`으로 테스트를 논리적으로 묶는다 (클래스명 → 메서드명)
-- Happy path와 Error case를 모두 작성한다
-- `setUp()`에서 Mock을 초기화한다 (테스트 간 격리)
-- Edge Function 테스트에서는 외부 API를 반드시 Mock한다
+- Mock 데이터는 실제 DB 스키마(`supabase/migrations/`) 컬럼명과 일치
+- `group()` 으로 논리 묶음 (클래스 → 메서드)
+- Happy path + Error case 둘 다 작성
+- `setUp()` 에서 Mock 초기화 — 테스트 격리
+- Layer 5 EF 테스트에서 외부 API 는 **반드시 mock**
 
 ### DON'T
 
-- 테스트에서 실제 네트워크 호출을 하지 않는다 (CUJ 통합 테스트 제외)
-- 테스트 간 상태를 공유하지 않는다
-- Mock의 반환값을 하드코딩하지 않는다 — 변수로 선언하여 재사용한다
-- `sleep()`이나 `Future.delayed()`로 비동기를 기다리지 않는다
-- generated 파일 (`*.g.dart`, `*.freezed.dart`)은 테스트 대상에서 제외한다
+- Layer 1 / 2a / 2b 에서 실제 네트워크 호출 금지 (실 호출은 Layer 3 만)
+- 테스트 간 상태 공유 금지
+- Mock 반환값 하드코딩 금지 — 변수로 재사용
+- `sleep()` / `Future.delayed()` 로 비동기 대기 금지
+- generated 파일 (`*.g.dart`, `*.freezed.dart`) 테스트 대상 제외
 
 ---
 
 ## 8. CI 파이프라인 연동
 
-테스트는 `.github/workflows/ci.yml`에서 자동 실행된다:
+`.github/workflows/ci.yml` 이 PR 마다 Layer 1 / 2a / 2b / 4 / 5 를 실행.
 
-| 변경 영역 | 실행되는 테스트 |
-|----------|-------------|
-| `apps/app_user/**` | Flutter analyze + test + **integration test** (app_user) |
-| `apps/app_partner/**` | Flutter analyze + test + **integration test** (app_partner) |
-| `shared/packages/minglit_kit/**` | Flutter analyze + test (모든 앱) |
-| `supabase/**` | pgTAP + Edge Function 테스트 |
+| 변경 영역 | 실행 Layer |
+|----------|-----------|
+| `apps/app_user/**`, `apps/app_partner/**` | 1 + 2a + 2b (해당 앱) |
+| `shared/packages/minglit_kit/**` | 1 (모든 앱) |
+| `supabase/migrations/**`, `supabase/tests/**` | 4 |
+| `supabase/functions/**` | 5 |
 | `apps/landing_*/**` | npm lint + build |
 
-커버리지는 Codecov에 업로드된다. `minglit_kit`은 60% patch 커버리지 목표.
+추가 워크플로우:
+- `patrol-e2e.yml` — Layer 3 (주 1회 예정, 현재 런 0건)
+- `db-invariants.yml` — Layer 6 (매시간)
+- `daily-backend-simulation.yml` / `hourly-user-activity.yml` — Layer 7
+
+---
+
+## 9. Mock 유틸 참조
+
+### Dart
+
+| 유틸 | 위치 | 용도 |
+|------|------|------|
+| `createMockSupabase()` | `minglit_kit/test/helpers/supabase_mock_helpers.dart` | Supabase 클라이언트 Mock |
+| `mockTable()` | 동일 | 테이블 쿼리 Fake |
+| `MockSupabaseClient` | `minglit_kit/test/helpers/mocks.dart` | 기본 Mock 클래스 |
+| `createContainer()` | `apps/{app}/test/utils/test_utils.dart` | Riverpod 컨테이너 |
+| Repository Mocks | `apps/{app}/test/utils/mocks.dart` | `MockEventRepository` 등 |
+| `createTestApp()` | `apps/app_user/test/integration/utils/test_app.dart` | Layer 2a 라우터 + Provider |
+| `createPartnerTestApp()` | `apps/app_partner/test/integration/utils/test_app.dart` | 동일 (partner) |
+
+### Deno (Edge Functions)
+
+| 유틸 | 위치 | 용도 |
+|------|------|------|
+| `captureServeHandler()` | `supabase/functions/_test_utils/mock_http.ts` | EF handler 캡처 |
+| `createFetchMock()` | 동일 | HTTP fetch Mock |
+| `authenticatedJsonRequest()` | 동일 | 인증 JSON 요청 |
+| `withEnv()` | 동일 | env 주입 |
+| `withMockedFetch()` | 동일 | fetch 대체 |
+| fixtures | `supabase/functions/_test_utils/fixtures.ts` | Mock 데이터 |

--- a/docs/qa/automation-test-guide.md
+++ b/docs/qa/automation-test-guide.md
@@ -473,8 +473,11 @@ cd apps/app_user && flutter test --tags golden --dart-define=CI=true
 # Golden 갱신
 cd apps/app_user && flutter test --update-goldens --tags golden --dart-define=CI=true
 
+# Layer 2a 특정 CUJ (flutter_test / WidgetTester)
+cd apps/app_user && flutter test test/integration/cuj_signup_to_apply_test.dart
+
 # Layer 3 (Patrol) — 로컬 emulator 필요
-cd apps/app_user && patrol test --target integration_test/cuj_signup_to_apply_test.dart
+cd apps/app_user && patrol test integration_test/permission_grant_test.dart
 # CI 에서는 patrol-e2e.yml 워크플로우
 
 # Layer 4 pgTAP

--- a/docs/qa/screenshot-capture-points.md
+++ b/docs/qa/screenshot-capture-points.md
@@ -22,56 +22,63 @@
 | 3. CUJ 테스트 실행 경로 | `apps/app_user/test/integration/` 순회 | `.github/scripts/run-client-cuj.sh`는 `apps/app_user/integration_test/*_test.dart`를 탐색 → **경로 mismatch로 실행 0건** | run-client-cuj.sh / run-partner-cuj.sh 경로 상수가 Patrol 전환 이전 형태 유지 |
 | 4. 상위 파이프라인 (`client-cuj-test`, `partner-cuj-test` job) | 매일 실행 | **skip 지속** | `needs: seed-and-simulate` 의존 — #1553 (Supabase pooler `aws-0 → aws-1`) 미해결로 upstream job 실패 |
 | 5. Patrol E2E (`patrol-e2e.yml`) | weekly cron | **run 이력 0건** | 한 번도 trigger되지 않음. 수동 실행도 없음 |
-| 6. 아티팩트 업로드 | 생성된 png 보존 | `patrol-e2e.yml:66`은 `if: failure()` + build outputs만 업로드 (스크린샷 아님). `ci.yml`은 golden 실패 / coverage / allure만 업로드 | Layer 2 용 retention 경로 미구축 |
+| 6. 아티팩트 업로드 | 생성된 png 보존 | `patrol-e2e.yml:66`은 `if: failure()` + build outputs만 업로드 (스크린샷 아님). `ci.yml`은 golden 실패 / coverage / allure만 업로드 | Tier B 용 retention 경로 미구축 |
 
-### 3-Layer 스크린샷 아키텍처
+### 3-Tier 스크린샷 아키텍처
 
-본 문서가 속한 **Layer 2**의 위치를 명확히 한다. 전체 전략은 `docs/qa/test-strategy.md`의 "스크린샷 3-layer 파이프라인" 섹션이 SSOT.
+본 문서가 속한 **Tier B** (시나리오 스크린샷) 의 위치를 명확히 한다. 전체 전략은 `docs/qa/test-strategy.md` 의 "스크린샷 3-Tier 아키텍처" 섹션이 SSOT.
+
+> **용어 주의**: 아래 "Tier" 는 7-layer taxonomy 의 "Layer" 와 다른 차원이다.
+> - **Tier**: 스크린샷 자산의 성격 구분 (A=픽셀비교 / B=증거사진 / C=AI리뷰)
+> - **Layer**: 테스트 계층 taxonomy (1-7) — `docs/qa/test-strategy.md §2`
+>
+> 연결: Tier A = 7-layer Layer 2b (Alchemist golden), Tier B = 7-layer Layer 3 (Patrol emulator) 내부 자산, Tier C = Layer 3 output 을 소비하는 후속 AI pipeline.
 
 ```
-[Layer 1] 골든 스크린샷 테스트 (기존, 유지)
-  - Alchemist 기반 widget 단위 golden (app_user 40 / app_partner 91)
+[Tier A] 골든 스크린샷 테스트 (7-layer Layer 2b, 기존 유지)
+  - Alchemist 기반 widget 단위 golden (app_user 14 / app_partner 15 — 2026-04-18)
   - 픽셀 레벨 회귀 차단
-  - 경로: apps/*/test/**/*_golden_test.dart + goldens/ (또는 equivalent)
+  - 경로: apps/*/test/goldens/**/*_golden_test.dart (향후 test/alchemist/)
 
          ▲
          │
-[Layer 2] 시나리오 스크린샷 (본 문서 = 캡처 포인트 매핑)
-  - CUJ integration test의 스텝별 실제 플로우 스냅샷
+[Tier B] 시나리오 스크린샷 (7-layer Layer 3 내부, 본 문서 = 캡처 포인트 매핑)
+  - Patrol CUJ 테스트의 스텝별 실제 플로우 스냅샷
   - 목적: "현재 실제 화면"의 시각적 로그 (픽셀 비교 아님)
-  - 대상 경로: apps/app_user/test/integration/ + apps/app_partner/test/integration/
-  - 저장: artifact retention 14d 이상 (Layer 3 agent가 pull할 수 있어야 함)
+  - 대상 경로: apps/app_*/integration_test/ (향후 emulator_test/)
+  - 저장: artifact retention 14d 이상 (Tier C agent 가 pull 할 수 있어야 함)
 
          ▲
          │
-[Layer 3] AI agent 스크린샷 점검 (후속 구현)
-  - 매일 저장된 Layer 2 스크린샷을 agent가 전수 리뷰
+[Tier C] AI agent 스크린샷 리뷰 (후속 구현)
+  - 매일 저장된 Tier B 스크린샷을 agent 가 전수 리뷰
   - 감지 대상: 깨진 이미지, 누락된 라벨, 레이아웃 오류, 품질 저하
   - 출력: bug-report 이슈 자동 생성
 ```
 
-### Layer 2의 의미 재정의 (2026-04-18, 이슈 #1557 기반)
+### Tier B 의 의미 재정의 (2026-04-18, 이슈 #1557 기반)
 
-- **캡처는 "비교"가 아니라 "증거 사진"** — Layer 3 AI agent의 semantic 리뷰 입력용.
-- 따라서 아티팩트 저장 요구사항이 기존 Layer 1(골든 픽셀 비교)과 다름:
+- **캡처는 "비교"가 아니라 "증거 사진"** — Tier C AI agent 의 semantic 리뷰 입력용.
+- 따라서 아티팩트 저장 요구사항이 Tier A (골든 픽셀 비교) 와 다름:
   - ❌ PR 실패 시에만 업로드 (현재 `patrol-e2e.yml:66` 패턴)
-  - ✅ **매일 성공 run에서도 전량 저장**, retention 14일 이상, Layer 3 agent가 접근 가능한 경로
+  - ✅ **매일 성공 run 에서도 전량 저장**, retention 14 일 이상, Tier C agent 가 접근 가능한 경로
 - 따라서 이 문서의 매핑은 "픽셀 고정"이 아니라 **"뭘 촬영할지"** 를 정의하는 쇼트 리스트로 해석.
 
 ### 시나리오 스크린샷이 죽어있는 동안 놓친 버그 (샘플)
 
-- #1538 — CUJ-P01 파티 생성 위저드 FlutterQuill localization 에러. `cuj_event_create_wizard_test.dart`가 동작했으면 Layer 2에서 포착 가능.
+- #1538 — CUJ-P01 파티 생성 위저드 FlutterQuill localization 에러. `cuj_event_create_wizard_test.dart` 가 동작했으면 Tier B 에서 포착 가능.
 - #1540 — Home/EventDetail broken image. `cuj_event_detail_test.dart` / flow 테스트 범위.
 
 ### 경로 구분 (혼동 방지)
 
-| 경로 | 역할 | Layer |
-|------|------|-------|
-| `apps/app_user/test/integration/` | Flutter 위젯 통합 + CUJ 시나리오 테스트 | **Layer 2 대상** |
-| `apps/app_partner/test/integration/` | 동일 | **Layer 2 대상** |
-| `tests/client_cuj_integration/` | 백엔드 통합 테스트 (별도 패키지, 20개 파일) | **Layer 2 아님** — Layer 2로 혼동 금지 |
-| `goldens/` 또는 Alchemist 골든 경로 | 픽셀 레벨 widget 골든 | Layer 1 |
-| (미정) `scenario_screenshots/` | Layer 2 artifact 저장 경로 후보 | Layer 2 — 저장 전략은 이슈 #1557에서 결정 대기 |
+| 경로 | 역할 | Tier | 7-layer |
+|------|------|------|---------|
+| `apps/app_user/test/integration/` | Flutter 위젯 플로우 (mock 기반) — 향후 Patrol 이관 대상 (#1586 Phase D-2) | **Tier B 이관 대상** | Layer 2a |
+| `apps/app_partner/test/integration/` | 동일 | **Tier B 이관 대상** | Layer 2a |
+| `apps/app_*/integration_test/` (향후 `emulator_test/`) | Patrol 네이티브 테스트 — 현재 native surface 특수 테스트만 존재 | **Tier B 생성 위치** | Layer 3 |
+| `apps/*/test/goldens/` | 픽셀 레벨 widget 골든 | Tier A | Layer 2b |
+| `tests/client_cuj_integration/` | 삭제됨 (#1564) | — | — |
+| (미정) `apps/app_*/emulator_test/screenshots/` | Tier B artifact 저장 경로 후보 | Tier B 저장 | Layer 3 output |
 
 ### 재가동 선결 의존성
 

--- a/docs/qa/screenshot-capture-points.md
+++ b/docs/qa/screenshot-capture-points.md
@@ -5,7 +5,7 @@
 > 목적: 기존 37개 integration 테스트 + 3개 patrol 테스트에 스텝별 스크린샷을 내장할 때,
 > 각 테스트의 어느 시점에 어떤 이름으로 캡처할지 정의한다.
 >
-> SWE는 이 문서를 보고 `takeScreenshot()` 호출을 삽입한다.
+> SWE는 이 문서를 보고 `GoldenCapture` 또는 Patrol `$.native.screenshot()` 호출을 삽입한다.
 
 ---
 
@@ -503,14 +503,18 @@
 
 ## SWE 구현 가이드
 
-### 1. takeScreenshot 호출 위치
+### 1. 스크린샷 캡처 호출 위치
 
 ```dart
-// Widget test (test/integration/)에서는 Patrol의 PatrolTester 사용
-await $.takeScreenshot(name: 'cuj_u01_step0_setup');
+// apps/*/test/integration/ — flutter_test 기반 WidgetTester 테스트
+final capture = GoldenCapture('cuj_u01');
+await capture.setup(tester, 0);  // cuj_u01_step0_setup.png
+await capture.before(tester, 1); // cuj_u01_step1_before.png
+await capture.after(tester, 2);  // cuj_u01_step2_after.png
+await capture.error(tester, 3);  // cuj_u01_step3_error.png
 
-// Integration test (integration_test/)에서는 binding 사용
-await binding.takeScreenshot('cuj_u01_step0_setup');
+// apps/*/integration_test/ — Patrol 기반 네이티브/E2E 테스트
+await $.native.screenshot(name: 'permission_step1_after');
 ```
 
 ### 2. 삽입 원칙

--- a/docs/qa/screenshot-capture-points.md
+++ b/docs/qa/screenshot-capture-points.md
@@ -17,10 +17,10 @@
 
 | 단계 | 계획 | 실제 상태 (2026-04-18) | 차단 원인 |
 |------|------|---------------------|----------|
-| 1. 테스트 코드 내 캡처 호출 | 각 CUJ 테스트에 `takeScreenshot()` / `matchesGoldenFile()` 삽입 | **0건** — `apps/app_user/test/integration/` 및 `apps/app_partner/test/integration/` 전체에서 호출 미발견 | PR #1496에서 추가됐던 호출이 후속 변경 과정에서 유실 |
+| 1. 테스트 코드 내 캡처 호출 | 각 CUJ 테스트에 `takeScreenshot()` / `matchesGoldenFile()` 삽입 | `tester.capture()` / `GoldenCapture` 호출 존재 (app_user 62건 이상) — 포인트 매핑 기준 부분 구현 | 전 CUJ/flow 파일에 고르게 분포하지 않음. 본 문서 기준 완전 삽입은 Phase D 작업 |
 | 2. `GoldenCapture` 유틸 실행 | CI headless 환경에서 동작 | **런타임 skip** (PR #1539) | headless hang 방지를 위한 임시 조치 — 대체 구현 미완 |
-| 3. CUJ 테스트 실행 경로 | `apps/app_user/test/integration/` 순회 | `.github/scripts/run-client-cuj.sh`는 `apps/app_user/integration_test/*_test.dart`를 탐색 → **경로 mismatch로 실행 0건** | run-client-cuj.sh / run-partner-cuj.sh 경로 상수가 Patrol 전환 이전 형태 유지 |
-| 4. 상위 파이프라인 (`client-cuj-test`, `partner-cuj-test` job) | 매일 실행 | **skip 지속** | `needs: seed-and-simulate` 의존 — #1553 (Supabase pooler `aws-0 → aws-1`) 미해결로 upstream job 실패 |
+| 3. CUJ 테스트 실행 경로 | `apps/app_user/test/integration/` 순회 | `run-client-cuj.sh` / `run-partner-cuj.sh` 모두 `test/integration/*_test.dart` 순회 — **경로 수정 완료** (#1557) | 차단 없음 |
+| 4. 상위 파이프라인 (`client-cuj-test`, `partner-cuj-test` job) | 매일 실행 | **skip 지속** | `needs: seed-and-simulate` 의존 — #1553 (CLOSED) / PR #1556 (MERGED 2026-04-18) 으로 선결 해소. 재가동 확인 필요 |
 | 5. Patrol E2E (`patrol-e2e.yml`) | weekly cron | **run 이력 0건** | 한 번도 trigger되지 않음. 수동 실행도 없음 |
 | 6. 아티팩트 업로드 | 생성된 png 보존 | `patrol-e2e.yml:66`은 `if: failure()` + build outputs만 업로드 (스크린샷 아님). `ci.yml`은 golden 실패 / coverage / allure만 업로드 | Tier B 용 retention 경로 미구축 |
 
@@ -82,9 +82,9 @@
 
 ### 재가동 선결 의존성
 
-- **#1553 (needs-swe)** — Supabase pooler `aws-0 → aws-1` fix. 머지되어야 `seed-and-simulate` 성공 → `client-cuj-test` / `partner-cuj-test` 실행 가능.
-- **PR #1556 (open)** — #1553의 실제 fix PR. 머지 대기.
-- 선결 해제 후에만 이 문서 기반 캡처 포인트 삽입 실효성을 검증할 수 있다.
+- **#1553** — CLOSED (2026-04-18).
+- **PR #1556** — MERGED (2026-04-18 04:44:53Z). Supabase pooler `aws-0 → aws-1` fix 완료.
+- 선결 차단 해소됨. `seed-and-simulate` 재가동 확인 후 이 문서 기반 캡처 포인트 삽입 검증 가능.
 
 ---
 

--- a/docs/qa/test-strategy.md
+++ b/docs/qa/test-strategy.md
@@ -1,510 +1,306 @@
-# 통합 테스트 전면 보강 — 테스트 전략 (Phase 2)
+# 테스트 전략 — 7-Layer Taxonomy (SSOT)
 
-> Phase 1 산출물 (PM): `docs/qa/test-cases/app-user-smoke.md`, `app-partner-smoke.md`, `cuj-user.md`, `cuj-partner.md`
->
-> 이 문서는 PM이 설계한 테스트 케이스를 **어떤 계층으로, 어떤 순서로 구현할지** 매핑한다.
+> 이 문서는 Minglit 모노레포의 테스트 계층 정의 **Single Source of Truth**.
+> 관련 이슈: #1586 (Phase A — 본 문서 재작성)
+> 최근 업데이트: 2026-04-18 (taxonomy 확정, 용어 통일)
 
 ---
 
-## 1. 현재 상태 vs 목표
+## 1. 왜 7-layer 인가
 
-### 현재 (2026-04-05)
+테스트 코드/워크플로우/문서가 여러 위치에 흩어져 있어 **이름 충돌**과 **용도 불명** 이 혼재했다.
 
-| 계층 | app_user | app_partner | 비고 |
-|------|----------|-------------|------|
-| Unit/Widget 테스트 | 78 파일 | 59 파일 | 개별 화면/로직 단위 |
-| Golden 테스트 | 40 파일 | 91 파일 | Alchemist 기반 시각적 회귀 |
-| Integration 테스트 (Mock) | 2 파일 | 0 파일 | `apple_sign_in`, `party_browse` |
-| E2E 테스트 (실물 디바이스) | 0 | 0 | 없음 |
+| 혼동 예 | 기존 상황 | 원인 |
+|--------|----------|------|
+| "integration" 4중 의미 | `apps/*/test/integration/` (위젯 플로우) + `apps/*/integration_test/` (Patrol) + `tests/backend_integration/` (DB — 이미 이관) + `tests/client_cuj_integration/` (삭제) | 계층 이름에 `integration` 범람 |
+| "Golden" 스크린샷 vs "시나리오" 스크린샷 | 동일 단어 "스크린샷"이 Alchemist 픽셀 비교 / CUJ 증거 사진 / AI agent 리뷰 3가지를 지칭 | Layer 정의 부재 |
+| "E2E" 의미 불명 | "Patrol e2e" + "client-cuj-test" + "backend-simulator" 모두 E2E 로 불림 | 범위가 서로 다름 |
 
-### PM 케이스 총량
+**해결**: 테스트 대상/프레임워크/주기 기준으로 7-layer 로 정규화. 이하 모든 문서/워크플로우/폴더명은 이 이름을 따른다.
 
-| 구분 | app_user | app_partner | 합계 |
-|------|----------|-------------|------|
-| Smoke (화면 진입) | 18 화면 / 68 케이스 | 30 화면 / 98 케이스 | 166 |
-| CUJ (핵심 여정) | 8 여정 / 42 스텝 / 10 변형 | 7 여정 / 51 스텝 / 9 변형 | 93 스텝 + 19 변형 |
+---
 
-### 목표 (Phase 3 구현 후)
+## 2. 7-Layer Taxonomy
 
-| 계층 | 목표 | 근거 |
+### 📱 App Level (`apps/app_*/`)
+
+| # | Layer | 대상 | 위치 (현재 — 2026-04-18) | 프레임워크 | 주기 |
+|---|-------|------|---------------------------|-----------|------|
+| 1 | **Unit test** | Feature/logic 순수 단위 (repository, controller, util) | `apps/app_*/test/src/`, `shared/packages/minglit_kit/test/src/` | `flutter_test` (headless) | PR 마다 |
+| 2a | **Widget flow test** | 다화면 위젯 인터랙션 (mock 기반) | `apps/app_*/test/integration/` *(향후 `test/flows/` rename 검토 — #1586 Phase C)* | `flutter_test` (headless) | PR 마다 |
+| 2b | **Golden image test** | 시각 회귀 감지 (픽셀 비교) | `apps/app_*/test/goldens/` *(향후 `test/alchemist/` rename — #1586 Phase C, PR #1582)* | Alchemist | PR 마다 |
+| 3 | **Emulator test** | Patrol 기반 네이티브 surface + 실 DB CUJ + 시나리오 스크린샷 | `apps/app_*/integration_test/` *(향후 `emulator_test/` rename — #1582)* | Patrol | 주 1회 + 수동 |
+
+### 🗄️ Backend Level (`supabase/` + EF)
+
+| # | Layer | 대상 | 위치 | 프레임워크 | 주기 |
+|---|-------|------|------|-----------|------|
+| 4 | **pgTAP** | DB 스키마 / 트리거 / RPC / RLS 계약 | `supabase/tests/database/` | pgTAP | PR 마다 |
+| 5 | **Deno EF test** | Edge Function TypeScript 로직 단위 | `supabase/functions/**/*_test.ts` | `deno test` | PR 마다 |
+| 6 | **DB monitor** | Runtime invariant 감시 | `check_db_invariants()` RPC + `.github/workflows/db-invariants.yml` | SQL | 매시간 cron |
+| 7 | **Tick simulator** | 서버 pipeline 관통 시뮬 (시간 전진 + 파이프라인 부하) | `backend-simulator` EF + `.github/workflows/daily-backend-simulation.yml` + `hourly-user-activity.yml` | EF + HTTP | 매시간 + 매일 |
+
+### 보조 (taxonomy 밖, 유지)
+
+| 항목 | 위치 | 성격 |
 |------|------|------|
-| Smoke (Widget) | 전 화면 48건 (18 + 30) | 크래시 없이 렌더링 보장 |
-| CUJ Integration (Mock) | P0 7건 + P1 5건 = 12건 | 핵심 비즈니스 플로우 회귀 방지 |
-| 리다이렉트/가드 | 12건 (5 user + 7 partner) | 인증 상태별 라우팅 정확성 |
-| E2E (실물 디바이스) | 2~3건 | 결제/체크인 등 네이티브 연동 |
+| Secret scan | `.github/workflows/secret-scan.yml` | 보안 |
+| Migration version check | `ci.yml` job | Pre-test gate |
+| Env manifest sync | `ci.yml` job | 환경변수 정합성 |
+| Landing lint/build | `ci.yml` job | Next.js 빌드 |
+| Allure report | `allure-report.yml` | 결과 집계 |
+| Update goldens | `update-goldens.yml` | Layer 2b 유지보수 |
 
 ---
 
-## 2. 테스트 계층 매핑
+## 3. Layer 별 책임 / 비책임
 
-### 매핑 원칙
+**원칙**: 각 layer 는 본인 책임 범위에만 집중한다. 다른 layer 가 담당하는 것을 테스트하면 **중복** 이 생기고, 실패 분석과 유지보수 비용이 증가한다.
 
-| PM 케이스 유형 | 테스트 계층 | 이유 |
-|---------------|-----------|------|
-| 화면 진입 Smoke | **Widget Test** | Mock Provider로 화면 렌더링만 검증. 빠르고 안정적 |
-| 리다이렉트 검증 | **Widget Test** (Router) | GoRouter 설정 + Guard 로직을 단위 테스트로 검증 |
-| 파라미터 엣지 케이스 | **Widget Test** | 에러 화면/빈 상태 렌더링 검증 |
-| 화면별 액션 매트릭스 | **Widget Test** (대부분) / **Integration** (다화면 연동) | 단일 화면 내 액션은 Widget, 화면 전환은 Integration |
-| CUJ P0 (결제/매칭/정산) | **Integration Test** (Mock) | 다화면 플로우. Mock으로 전체 여정 시뮬레이션 |
-| CUJ P0 (결제 실제 PG) | **E2E Test** (실물 디바이스) | PG SDK 네이티브 연동은 Mock 불가 |
-| CUJ P1 (검색/계정삭제) | **Integration Test** (Mock) | 다화면 플로우 |
-| CUJ P2 (알림/차단) | **Widget Test** | 단순 CRUD, Integration 불필요 |
+### Layer 1 — Unit
 
----
+| ✅ 책임 | ❌ 비책임 |
+|--------|----------|
+| repository 메서드 happy path + error case | UI 렌더링 (→ 2a/2b) |
+| controller/provider 상태 전이 | 외부 서비스 호출 (→ 5/7) |
+| util/formatter 순수 함수 | 네이티브 surface (→ 3) |
+| minglit_kit 공유 로직 | DB 스키마 검증 (→ 4) |
 
-## 3. 우선순위별 구현 계획
+### Layer 2a — Widget flow
 
-### 🔴 P0 — 핵심 수익/비즈니스 경로 (1단계)
+| ✅ 책임 | ❌ 비책임 |
+|--------|----------|
+| GoRouter guard / redirect 로직 | 실 네트워크 / 실 DB (→ 3) |
+| 다화면 위젯 조합 (mock provider override) | 픽셀 레벨 시각 검증 (→ 2b) |
+| 로그인 상태별 분기 렌더링 | PG/WebView 등 네이티브 브릿지 (→ 3) |
+| 딥링크 파라미터 처리 | |
 
-실패 시 서비스 가치 없음. **반드시 먼저 구현.**
+### Layer 2b — Golden image
 
-#### Integration Tests (Mock 기반)
+| ✅ 책임 | ❌ 비책임 |
+|--------|----------|
+| 디자인 토큰 / 컴포넌트 시각 회귀 차단 | 상태 변화 / 인터랙션 (→ 2a) |
+| Ahem 폰트 기반 CI golden (OS 무관) | 실 DB 데이터 렌더링 (→ 3) |
+| `@Tags(['golden'])` 로 분리 실행 | 스텝별 플로우 스냅샷 (→ 3, "시나리오 스크린샷") |
 
-| ID | CUJ | 테스트 파일 | 스텝 | 검증 포인트 |
-|----|-----|-----------|------|------------|
-| IT-U01 | 회원가입→결제→신청 | `app_user/test/integration/cuj_signup_to_apply_test.dart` | 8 | 로그인 리다이렉트 복귀, 위저드 스텝 진행, Mock PG 결과 처리 |
-| IT-U02 | 체크인→매칭투표→결과 | `app_user/test/integration/cuj_checkin_matching_test.dart` | 8 | QR 표시, 투표 UI 인터랙션, 매칭 결과 화면 |
-| IT-U03 | 환불 신청 | `app_user/test/integration/cuj_refund_test.dart` | 5 | 환불 정책 검증, 상태 변경 |
-| IT-P01 | 파트너가입→파티→이벤트 | `app_partner/test/integration/cuj_onboarding_to_event_test.dart` | 20 | 온보딩 위저드 전체 플로우, 파티 생성, 이벤트+티켓 |
-| IT-P02 | 신청 심사 (승인/거절) | `app_partner/test/integration/cuj_application_review_test.dart` | 6 | 승인/거절 상태 전환, 동시 처리 방지 |
-| IT-P03 | 체크인 관리 | `app_partner/test/integration/cuj_checkin_manage_test.dart` | 4 | QR 스캔 결과 처리, 중복 체크인 |
-| IT-P04 | 정산 확인+계좌 | `app_partner/test/integration/cuj_settlement_test.dart` | 6 | 정산 내역, 계좌 CRUD |
+### Layer 3 — Emulator
 
-**총 7건, 57 스텝**
+| ✅ 책임 | ❌ 비책임 |
+|--------|----------|
+| 실 Android emulator 에서 Patrol 실행 | 단위 로직 회귀 감지 (→ 1) |
+| 네이티브 surface (카카오 WebView, PG SDK, 시스템 권한) | 픽셀 비교 (→ 2b) |
+| 실 dev Supabase 연동 CUJ (auth/RLS 실경로) | DB 스키마 계약 (→ 4) |
+| 스텝별 "시나리오 스크린샷" 생성 (Layer 3 agent 리뷰 input) | |
 
-#### Smoke Widget Tests (P0 화면)
+### Layer 4 — pgTAP
 
-| 화면 | 테스트 파일 | 케이스 수 |
-|------|-----------|----------|
-| 이벤트 신청 위저드 | `app_user/test/src/features/event/ui/event_application_wizard_smoke_test.dart` | 6 |
-| 구매 내역 | `app_user/test/src/features/purchase/ui/purchase_history_smoke_test.dart` | 3 |
-| 파트너 신청 위저드 | `app_partner/test/src/features/onboarding/ui/partner_apply_smoke_test.dart` | 5 |
-| 파티 생성 위저드 | `app_partner/test/src/features/party/ui/party_create_wizard_smoke_test.dart` | 8 |
-| 신청 관리 | `app_partner/test/src/features/application/ui/application_manage_smoke_test.dart` | 3 |
-| 정산 | `app_partner/test/src/features/settlement/ui/settlement_smoke_test.dart` | 4 |
-| 체크인 | `app_partner/test/src/features/checkin/ui/checkin_smoke_test.dart` | 2 |
+| ✅ 책임 | ❌ 비책임 |
+|--------|----------|
+| 테이블 / 컬럼 존재 검증 | EF 로직 (→ 5) |
+| RLS 정책 / 트리거 동작 | 앱 렌더링 (→ 1-3) |
+| RPC 함수 시그니처 | runtime invariant 감시 (→ 6) |
 
-**총 31건**
+### Layer 5 — Deno EF
 
----
+| ✅ 책임 | ❌ 비책임 |
+|--------|----------|
+| EF handler TypeScript 로직 | DB 스키마 (→ 4) |
+| 외부 API mock (Iamport, FCM) | 실 DB 데이터 (→ 7) |
+| 입력 검증 / 에러 분기 | 다중 EF 파이프라인 관통 (→ 7) |
 
-### 🟡 P1 — 필수 사용자 경험 (2단계)
+### Layer 6 — DB monitor
 
-실패 시 유저 이탈. P0 완료 후 구현.
+| ✅ 책임 | ❌ 비책임 |
+|--------|----------|
+| 매시간 invariant 감시 (고아 row, 정원 초과 등) | 계약 회귀 감지 (→ 4) |
+| 실 dev DB 데이터에 대한 실시간 검증 | 기능 테스트 (→ 1-5) |
+| alert 발송 | |
 
-#### Integration Tests
+### Layer 7 — Tick simulator
 
-| ID | CUJ | 테스트 파일 | 스텝 |
-|----|-----|-----------|------|
-| IT-U04 | 검색→필터→신청 | `app_user/test/integration/cuj_search_to_apply_test.dart` | 5 |
-| IT-U05 | 계정 삭제 | `app_user/test/integration/cuj_account_deletion_test.dart` | 5 |
-| IT-P05 | 파티/이벤트/티켓 편집 | `app_partner/test/integration/cuj_party_edit_test.dart` | 8 |
-
-**총 3건, 18 스텝**
-
-#### Smoke Widget Tests (P1 화면)
-
-| 화면 | 테스트 파일 | 케이스 수 |
-|------|-----------|----------|
-| 검색 | `app_user/test/src/features/search/ui/search_page_smoke_test.dart` | 4 |
-| 마이페이지 | `app_user/test/src/features/my/ui/my_page_smoke_test.dart` | 5 |
-| 개인정보 설정 | `app_user/test/src/features/settings/ui/privacy_page_smoke_test.dart` | 2 |
-| 파티 상세 | `app_partner/test/src/features/party/ui/party_detail_smoke_test.dart` | 5 |
-| 이벤트 생성 | `app_partner/test/src/features/event/ui/event_create_smoke_test.dart` | 2 |
-
-**총 18건**
-
-#### 리다이렉트/가드 테스트
-
-| 앱 | 테스트 파일 | 케이스 수 |
-|----|-----------|----------|
-| app_user | `app_user/test/src/routing/auth_guard_test.dart` | 5 (U-R01~R05) |
-| app_partner | `app_partner/test/src/routing/onboarding_guard_test.dart` | 7 (P-R01~R07) |
-
-**총 12건**
+| ✅ 책임 | ❌ 비책임 |
+|--------|----------|
+| 시간 전진 (시뮬레이션 tick) → 이벤트 생명주기 관통 | 단일 EF 단위 테스트 (→ 5) |
+| 매칭 / 결제 / 정산 파이프라인 연쇄 검증 | 앱 UI (→ 1-3) |
+| 매시간 user activity 시뮬 | 스키마 검증 (→ 4) |
 
 ---
 
-### 🟢 P2 — 전체 커버리지 확보 (3단계)
+## 4. 현재 커버리지 수치 (2026-04-18)
 
-서비스 운영에 불편하지만 가능. P1 완료 후 점진적 구현.
+실측 기반. Issue #1586 Phase D-1 측정 결과.
 
-#### Smoke Widget Tests (나머지 화면)
+### Layer 1 — Unit
 
-| 앱 | 대상 화면 수 | 예상 케이스 |
-|----|------------|-----------|
-| app_user | 6 (홈, 이벤트상세, 파트너상세, 알림, 차단, 알림설정) | 22 |
-| app_partner | 13 (홈, 멤버, 권한, 인증, 알림, 이벤트상세, 티켓편집 등) | 40 |
+| 앱 | 위치 | 파일 수 |
+|----|------|--------|
+| minglit_kit | `shared/packages/minglit_kit/test/` | 99 |
+| app_user | `apps/app_user/test/src/` | 65 |
+| app_partner | `apps/app_partner/test/src/` | 71 |
 
-**총 65건**
+### Layer 2a — Widget flow
 
-#### CUJ P2 (Widget Test로 충분)
+| 앱 | 위치 | 파일 수 |
+|----|------|--------|
+| app_user | `apps/app_user/test/integration/` | 26 |
+| app_partner | `apps/app_partner/test/integration/` | 11 |
 
-| ID | CUJ | 테스트 파일 |
-|----|-----|-----------|
-| WT-U07 | 알림 기반 재방문 | `app_user/test/src/features/notification/ui/notification_deeplink_test.dart` |
-| WT-U08 | 파트너 차단/해제 | `app_user/test/src/features/block/ui/block_partner_test.dart` |
-| WT-P06 | 멤버 관리+권한 | `app_partner/test/src/features/member/ui/member_permission_test.dart` |
-| WT-P07 | 인증 관리 | `app_partner/test/src/features/verification/ui/verification_manage_test.dart` |
+### Layer 2b — Golden image
 
-**총 4건**
+| 앱 | 위치 | `*_golden_test.dart` |
+|----|------|---------------------|
+| app_user | `apps/app_user/test/goldens/` | 14 |
+| app_partner | `apps/app_partner/test/goldens/` | 15 |
 
-#### 엣지 케이스 (파라미터 검증)
+### Layer 3 — Emulator (Patrol)
 
-| 앱 | 케이스 수 | 범위 |
-|----|----------|------|
-| app_user | 7 (U-E01~E07) | 존재하지 않는 ID, 빈 목록 등 |
-| app_partner | 9 (P-E01~E09) | 존재하지 않는 ID, 빈 상태 등 |
+| 앱 | 위치 | 파일 수 | 성격 |
+|----|------|--------|------|
+| app_user | `apps/app_user/integration_test/` | 5 | `apple_sign_in`, `kakao_login`, `payment_pg`, `permission_grant`, `scenario_screenshots` — **native surface 특수 테스트만**. CUJ 이관 0% |
+| app_partner | `apps/app_partner/integration_test/` | 1 | `scenario_screenshots` 만 |
 
-기존 Widget Test에 추가 케이스로 통합. 별도 파일 불필요.
+**Layer 3 런타임 상태**: `patrol-e2e.yml` 실행 이력 0건. `scenario_screenshots_test.dart` 내부 캡처 호출 0건. **사실상 죽은 상태.** 재가동 계획은 §6 로드맵 및 #1586 Phase D-2 참고.
 
----
+### Layer 4 — pgTAP
 
-## 4. 변형 시나리오 처리
+- `supabase/tests/database/` : 80 파일 (*.sql)
+- `tests/backend_integration/` → 2026-04-18 Deno/pgTAP 흡수 완료 (#1574)
 
-PM이 정의한 변형 시나리오(19건)는 해당 CUJ Integration Test 내 `group()`으로 포함한다.
+### Layer 5 — Deno EF
 
-| CUJ | 변형 | 처리 방식 |
-|-----|------|----------|
-| U01-V1: 기존 유저 재구매 | IT-U01 내 별도 test | 스텝 자동 스킵 검증 |
-| U01-V2: 결제 중 앱 종료 | **P3 (선택)** — 앱 생명주기 테스트는 E2E에서만 가능 |
-| U01-V3: 무료 이벤트 | IT-U01 내 별도 test | 결제 스킵 검증 |
-| U02-V1: 투표 시간 초과 | IT-U02 내 별도 test | 타이머 Mock |
-| U02-V2: 체크인 없이 매칭 | IT-U02 내 별도 test | 접근 차단 검증 |
-| U03-V1~V3: 환불 변형 | IT-U03 내 group | 부분환불, 당일환불, 무료취소 |
-| P01-V1: 심사 보완 | IT-P01 내 별도 test | `needsCorrection` 상태 |
-| P01-V2: 무료 이벤트 | IT-P01 내 별도 test | |
-| P01-V3: 위저드 이탈 | **P3** — 앱 종료 시나리오 |
-| P02-V1~V2: 심사 변형 | IT-P02 내 group | 정원 초과, 일괄 승인 |
-| P03-V1~V2: 체크인 변형 | IT-P03 내 group | 카메라 거부, 오프라인 |
-| P05-V1~V2: 편집 변형 | IT-P05 내 group | 진행중 이벤트, 티켓 템플릿 |
+- `supabase/functions/**/*_test.ts` : 75 파일
 
----
+### Layer 6 — DB monitor
 
-## 5. 테스트 인프라 보강
+- RPC: `check_db_invariants()` (supabase/migrations 에서 정의)
+- 워크플로우: `.github/workflows/db-invariants.yml` — 매시간 cron
+- 상태: **구현 존재. 2026-04-15 이슈 #1549 로 재등록 확인.**
 
-### 5.1 Integration Test 헬퍼 (신규)
+### Layer 7 — Tick simulator
 
-현재 Integration Test 인프라가 거의 없다 (app_user 2개, app_partner 0개). 공통 헬퍼가 필요하다.
-
-**필요한 유틸리티:**
-
-| 파일 | 용도 |
-|------|------|
-| `apps/{app}/test/integration/utils/pump_app.dart` | 테스트용 앱 빌드 (ProviderScope + GoRouter + 필요한 Override) |
-| `apps/{app}/test/integration/utils/cuj_helpers.dart` | 로그인/온보딩 등 반복 스텝 헬퍼 |
-| `apps/{app}/test/integration/utils/mock_providers.dart` | CUJ별 Mock Provider 설정 |
-
-**`pumpApp()` 설계:**
-```dart
-Future<void> pumpApp(
-  WidgetTester tester, {
-  required String initialRoute,
-  required List<Override> overrides,
-  AuthState authState = AuthState.guest,
-}) async {
-  await tester.pumpWidget(
-    ProviderScope(
-      overrides: [
-        authStateProvider.overrideWithValue(authState),
-        ...overrides,
-      ],
-      child: MaterialApp.router(
-        routerConfig: createTestRouter(initialRoute: initialRoute),
-      ),
-    ),
-  );
-  await tester.pumpAndSettle();
-}
-```
-
-### 5.2 CI 변경 사항
-
-현재 CI(`ci.yml`)는 app_user의 `test/integration/`만 실행한다. 변경 필요:
-
-| 변경 | 내용 |
-|------|------|
-| app_partner integration | `flutter test test/integration/` 추가 (app_partner에도) |
-| 테스트 태그 | Integration Test에 `@Tags(['integration'])` 적용 — 필요시 분리 실행 |
+- EF: `supabase/functions/backend-simulator/`
+- 워크플로우:
+  - `daily-backend-simulation.yml` — 매일 (PR #1584 로 pg_cron 에서 GH Actions 로 이관)
+  - `hourly-user-activity.yml` — 매시간
+- 상태: **정상 동작.**
 
 ---
 
-## 6. E2E 테스트 (Patrol 통합) 계획
+## 5. 스크린샷 3-Tier 아키텍처 (Layer 2b + 3 + Layer 3-agent 의 관계)
 
-> 2026-04-15 업데이트: #1458에서 Patrol 통합 + 스크린샷 내장 결정.
-> 2026-04-18 업데이트: #1557에서 스크린샷 3-layer 아키텍처 명문화. 용어 혼동 방지 섹션(§6.0) 추가.
+"스크린샷" 이라는 단어가 세 가지 독립 자산을 가리키므로 용어를 분리한다. 본 섹션이 팀 전체의 SSOT.
 
-### 6.0 스크린샷 3-layer 파이프라인 (SSOT)
-
-이 프로젝트에서 "스크린샷"이라는 단어는 3개의 독립 계층을 가리키며, 용어를 섞어 쓰지 않는다. 본 섹션이 팀 전체의 Single Source of Truth.
+> 주의: 아래 **Tier** 는 7-layer taxonomy 의 **Layer** 와 별개 차원이다. 혼동 방지 위해 "Tier" 용어 사용.
 
 ```
-[Layer 1] 골든 스크린샷 테스트 (Alchemist, 기존)
-  - 픽셀 레벨 widget 회귀 차단 — 디자인 토큰/컴포넌트 일관성
-  - 실패 시 PR 차단 (diff 비교)
-  - 대상: apps/*/test/**/*_golden_test.dart
-  - 수량: app_user 40 / app_partner 91
+[Tier A] 골든 스크린샷 (7-layer 의 Layer 2b)
+  - Alchemist 픽셀 비교
+  - 디자인 토큰 / 컴포넌트 회귀 차단
+  - 실패 시 PR 차단
 
-[Layer 2] "시나리오 스크린샷" (CUJ integration 내장 캡처)
-  - CUJ integration test의 스텝별 실제 플로우 스냅샷
-  - 비교 목적 아님 — "지금 실제 화면이 이렇더라"의 증거 사진
-  - 대상: apps/app_user/test/integration/ + apps/app_partner/test/integration/
-  - 캡처 포인트 매핑: docs/qa/screenshot-capture-points.md
-  - 현재 상태(2026-04-18): 머지됐지만 실행 0건 — #1557에서 재가동 추적 중
+[Tier B] 시나리오 스크린샷 (7-layer 의 Layer 3 내부)
+  - Patrol CUJ 테스트 내 스텝별 `$.native.screenshot(name: ...)`
+  - "지금 실제 화면" 증거 사진 — 픽셀 비교 아님
+  - 출력: artifact retention 14d 이상 (Tier C agent 접근용)
 
-[Layer 3] AI agent 스크린샷 점검 (후속 구현)
-  - Layer 2 아티팩트를 agent가 전수 리뷰
-  - 감지 대상: 깨진 이미지, 누락 라벨, 레이아웃 오류, 품질 저하
-  - 출력: bug-report 이슈 자동 생성 (현재 QA agent 파이프라인과 유사 경로)
+[Tier C] AI agent 스크린샷 리뷰 (후속 구현)
+  - Tier B 아티팩트를 agent 가 전수 semantic 리뷰
+  - 감지: 깨진 이미지, 누락 라벨, 레이아웃 오류
+  - 출력: bug-report 이슈 자동 생성
 ```
 
 **용어 규칙**:
 
-| 표현 | 정의 | 사용 예 |
-|------|------|--------|
-| "골든 스크린샷" / "golden" | Layer 1만 지칭. 픽셀 비교 | "이 위젯 golden 깨졌어" |
-| **"시나리오 스크린샷"** | Layer 2만 지칭. CUJ 플로우 캡처 | "시나리오 스크린샷이 안 찍힌다" |
-| "스크린샷 리뷰" / "agent 리뷰" | Layer 3만 지칭 | "agent 리뷰에서 잡혔다" |
-| "스크린샷" (단독) | 혼동 유발 — 반드시 Layer 명시해서 사용 |
-
-**경로 구분 (Layer 1 vs Layer 2)**:
-
-- `goldens/` (또는 Alchemist 지정 경로) — Layer 1 전용. Layer 2 아티팩트를 여기 저장 금지.
-- Layer 2 저장 경로는 아직 미정 (후보: `scenario_screenshots/` 하위, GitHub Artifacts 14d retention, 외부 버킷). 결정은 이슈 #1557에서 `report-exec` 라벨로 Mark 판단 대기.
-
-**경로 구분 (Layer 2 대상 vs 비대상)**:
-
-- `apps/app_user/test/integration/` + `apps/app_partner/test/integration/` → Layer 2 대상
-- `tests/client_cuj_integration/` (백엔드 통합 테스트, 별도 패키지, 20개 파일) → **Layer 2 아님.** Layer 2 캡처 호출 삽입 금지.
-
-### 6.1 Patrol 전환 배경
-
-기존 `IntegrationTestWidgetsFlutterBinding` 기반 E2E는 네이티브 인터랙션(카카오 로그인 WebView, PG 결제, 시스템 권한)을 처리할 수 없었다. Patrol(`patrol_test/` 3개)이 이미 도입되어 있으므로, 전체 integration 테스트를 Patrol로 통합한다.
-
-### 6.2 스크린샷 내장 전략
-
-기존 `scenario_screenshots_test.dart`(정적 화면 캡처)를 제거하고, 각 integration 테스트에 스텝별 `takeScreenshot()`을 삽입한다.
-
-| 항목 | Before | After |
-|------|--------|-------|
-| 스크린샷 위치 | 별도 파일 (scenario_screenshots_test.dart) | 각 테스트 내부 |
-| 캡처 시점 | 정적 화면만 | setup/before/after/error |
-| 네이티브 인터랙션 | 불가 | Patrol로 가능 |
-| 예상 캡처 수 | ~40장 (골든 시나리오) | **~141장** (플로우 중간 상태 포함) |
-
-### 6.3 캡처 포인트 정의
-
-상세 포인트는 `docs/qa/screenshot-capture-points.md` 참고.
-
-| 앱 | 파일 수 | 예상 캡처 수 |
-|----|---------|------------|
-| app_user (CUJ + Flow + 기타) | 25 | ~83 |
-| app_partner (CUJ + 기타) | 11 | ~47 |
-| patrol (E2E 네이티브) | 3 | ~11 |
-| **합계** | **39** | **~141** |
-
-### 6.4 CI 연동
-
-- `patrol-e2e.yml`에 통합 (주 1회 또는 매일)
-- 스크린샷 아티팩트 업로드 → Layer 3 agent의 semantic 리뷰 입력으로 활용 (픽셀 비교 아님 — §6.0 참고)
-- 네이티브 E2E (카카오 로그인, PG 결제, 권한)는 실물 디바이스에서만 실행
-
-### 6.5 Layer 2 재가동 현황 (2026-04-18)
-
-이 섹션의 계획(§6.2~§6.4)은 머지됐지만 **실제 CI 실행 0건**. 전수 점검 및 복구 작업은 이슈 #1557에서 추적한다. 상세 갭 분석은 `docs/qa/screenshot-capture-points.md` 첫머리 "현재 상태" 블록 참고.
-
-**재가동 선결 의존성**:
-
-- #1553 / PR #1556 — Supabase pooler `aws-0 → aws-1` fix 머지. `seed-and-simulate` 복구 없이는 `client-cuj-test` / `partner-cuj-test` 실행 불가.
-- #1539 — `GoldenCapture` CI headless hang 회피 skip을 재활성화 가능한 형태로 대체.
-- `.github/scripts/run-client-cuj.sh` / `run-partner-cuj.sh` — 탐색 경로를 `apps/*/test/integration/`로 교정 (현재 `apps/*/integration_test/` 순회 중).
-
----
-
-## 7. Runtime QA (실물 디바이스 자동화)
-
-Runtime QA 워커는 실물 Android 디바이스에 APK를 설치하고, ADB를 통해 화면 네비게이션과 시각적 검증을 수행한다.
-
-### 역할
-
-- **Smoke 검증**: `docs/qa/test-cases/app-user-smoke.md`, `app-partner-smoke.md` 시나리오를 실물 디바이스에서 실행
-- **CUJ 검증**: `cuj-user.md`, `cuj-partner.md`의 핵심 여정을 실물 디바이스에서 재현
-- **시각적 회귀 탐지**: 스크린샷 기반으로 UI 렌더링 이상 확인
-
-### 알려진 제약: Flutter + UIautomator 비호환
-
-Flutter 앱은 Skia/Impeller 엔진으로 단일 `FlutterSurfaceView` 위에 렌더링한다. Android UIautomator는 네이티브 View hierarchy를 탐색하므로, **Flutter 위젯의 개별 bounds를 추출할 수 없다** (`bounds="[0,0][0,0]"` 반환). 이는 모든 Flutter 앱 + 모든 Android 디바이스에서 동일하게 발생하는 구조적 제약이다.
-
-**결론**: UIautomator 기반 좌표 추출은 Flutter 앱에서 사용 불가.
-
-### 네비게이션 방법별 비교
-
-| 방법 | Flutter 호환 | 장점 | 단점 | 상태 |
-|------|-------------|------|------|------|
-| Vision 기반 (Gemini 등) | ✅ | 프레임워크 무관. 실제 화면 기반. | Vision 모델 필요. API 비용. | 운영 중 |
-| `adb shell dumpsys accessibility` | ⚠️ 검증 필요 | 네이티브 API. | Flutter semantics 활성화 필요. 좌표 정확도 미검증. | PoC 필요 |
-| Flutter Integration Test Driver | ✅ | 가장 안정적. Flutter 네이티브. | 별도 test harness. 워커 아키텍처 변경. | 장기 목표 |
-| UIautomator dump | ❌ | — | Flutter에서 bounds 추출 불가. | **사용 불가** |
-| 고정 좌표 매핑 | ✅ | 구현 간단. | 해상도/레이아웃 변경 시 깨짐. | 비권장 |
-
-### 관련 이슈
-
-- #1274 — UIautomator dump bounds=[0,0][0,0] 문제 분석 및 전략 결정
-
----
-
-## 8. 갭 정량 요약
-
-### 테스트 피라미드 현황 vs 목표
-
-```
-                     현재              목표 (Phase 3 후)
-                   ┌──────┐           ┌──────┐
-  E2E (디바이스)   │  0건  │           │  2건  │
-                   ├──────┤           ├──────┤
-  Integration      │  2건  │           │ 13건  │  ← 가장 큰 갭
-  (Mock CUJ)       ├──────┤           ├──────┤
-  Smoke/Widget     │137건  │           │251건  │  ← +114건 (48 smoke + 66 기타)
-                   ├──────┤           ├──────┤
-  Unit (기존)      │343건  │           │343건+ │  ← 유지 + α
-                   └──────┘           └──────┘
-```
-
-### 핵심 갭
-
-| 갭 | 현재 | 목표 | 위험도 |
-|----|------|------|--------|
-| **CUJ Integration (app_user)** | 2 | 9 | 🔴 결제/매칭/환불 플로우 미검증 |
-| **CUJ Integration (app_partner)** | 0 | 4 | 🔴 파트너 운영 플로우 전무 |
-| **Smoke (app_user)** | 부분적 | 18 화면 전체 | 🟡 일부 화면 크래시 미탐지 |
-| **Smoke (app_partner)** | 부분적 | 30 화면 전체 | 🟡 신규 화면 추가 시 누락 |
-| **라우팅 가드** | 0 (전용) | 12 | 🟡 #970, #965 같은 회귀 |
-
----
-
-## 8.1 CI/CD 배포 파이프라인 테스트 (Phase 2.1 — #1433, #1434)
-
-> 2026-04-15 배포 실패 인시던트(#1433 iOS, #1434 Android)로 추가.
-> Partner 앱 배포 시 `JUSO_CONFIRM_KEY` Secret 미설정으로 빌드 실패.
-
-| 문서 | 내용 | 케이스 수 |
-|------|------|-----------|
-| `ci-deploy-tests.md` | 배포 Secret 매트릭스, CI 자체 검증 스텝, 빌드 분기 검증 | 19 |
-
-### 핵심 포인트
-
-- **4개 배포 워크플로우** (Android/iOS × User/Partner)의 필수 Secret을 매트릭스로 정리
-- Partner 전용 Secret (`JUSO_CONFIRM_KEY`)의 `required: false` 선언 불일치 식별 → 개선 제안 포함
-- 배포 실패 알림(`notify-failure.yml`) 동작 검증 케이스 포함
-
----
-
-## 8.2 에러/환경/미등록라우트 테스트 케이스 (Phase 2.1 — #1421)
-
-> 2026-04-13 갭 분석(#1421) 결과 추가된 테스트 케이스 문서.
-
-| 문서 | 내용 | 케이스 수 |
-|------|------|-----------|
-| `error-scenarios.md` | P1 에러 3건 (QR 토큰, 카메라 권한, 보완 재제출) + P2 에러 6건 | 35 |
-| `environment-tests.md` | P1 딥링크 cold start, 세션 만료 + P2 warm start, 오프라인 복구 | 25 |
-| `unregistered-route-tests.md` | GoRouter 미등록 화면 6개 위젯/통합 테스트 정의 | 30 |
-
-### 구현 우선순위
-
-| 순서 | 대상 | 근거 |
+| 표현 | 정의 | 예시 |
 |------|------|------|
-| 1 | ERR-01~03 (P1 에러) | 체크인/인증 현장 실패 — 유저/파트너 이탈 직결 |
-| 2 | ENV-01~03 (P1 환경) | 딥링크/세션 실패 — 앱 진입 불가 |
-| 3 | URT-01~02 (P0 미등록 라우트) | 매칭/체크인 핵심 화면 — 위젯 테스트 필수 |
-| 4 | ERR-04~09, ENV-04~05, URT-03~05 (P2) | 보조 기능 — 점진적 구현 |
+| "golden" / "골든" | Tier A 만 지칭 (7-layer Layer 2b) | "이 위젯 golden 깨졌어" |
+| **"시나리오 스크린샷"** | Tier B 만 지칭 (7-layer Layer 3) | "시나리오 스크린샷이 안 찍힌다" |
+| "스크린샷 리뷰" / "agent 리뷰" | Tier C 만 지칭 | "agent 리뷰에서 잡혔다" |
+| "스크린샷" (단독) | **혼동 유발 — Tier 명시 필수** | |
+
+**경로 구분**:
+
+| 경로 | Tier | Layer |
+|------|------|-------|
+| `apps/*/test/goldens/` (향후 `test/alchemist/`) | Tier A | Layer 2b |
+| `apps/*/integration_test/` (향후 `emulator_test/`) — Patrol | Tier B 생성 위치 | Layer 3 |
+| `apps/*/*/screenshots/` (Patrol 출력 — 향후 경로) | Tier B 저장 | Layer 3 |
+
+상세 캡처 포인트 매핑: `docs/qa/screenshot-capture-points.md`.
 
 ---
 
-## 9. 실행 순서 요약
+## 6. 로드맵
 
-| 단계 | 내용 | 예상 테스트 수 | 우선순위 |
-|------|------|-------------|---------|
-| **1단계** | P0 CUJ Integration (7건) + P0 Smoke (31건) + 인프라 헬퍼 | 38 | 🔴 필수 |
-| **2단계** | P1 CUJ Integration (4건) + P1 Smoke (18건) + 가드 (12건) | 34 | 🟡 권장 |
-| **3단계** | P2 Smoke (65건) + P2 Widget (4건) + 엣지케이스 (16건) | 85 | 🟢 선택 |
-| **E2E** | 실물 디바이스 결제/체크인 (2~3건) | 3 | Phase 3 협의 |
-| **합계** | | **160건** | |
+### 🔴 최우선 — Layer 3 재가동 (Issue #1586 Phase D-2)
+
+현재 Patrol 이관률 0%. 37 CUJ/flow 파일 (`apps/app_user/test/integration/` 26 + `apps/app_partner/test/integration/` 11) 을 Patrol + 실 dev Supabase 로 전환.
+
+- D-2 PoC: 2-3 CUJ Patrol 변환 + CI 돌아감 + 스크린샷 생성 (2026-04)
+- D-2 전량: CUJ 5-10 개 단위로 쪼갠 PR 병합 (15-23일 FTE 예상)
+- D-3-a: `patrol-e2e.yml` 수동 trigger 성공 1회 확인
+- D-3-b: matrix shard 6-8 → wall-clock < 20min 달성
+- D-4: 스크린샷 git commit 파이프라인 (또는 auto-PR) 가동
+
+### 🟡 중기 — 폴더 / 워크플로우 정합 (Issue #1586 Phase B / C)
+
+- Phase B: 워크플로우 이름 layer 명시 (`Weekly: Emulator Test (Patrol)` 등)
+- Phase C: `test/visual_qa/` 삭제, `test/scenarios/` 흡수, `test/integration/` → `test/flows/` rename 검토
+
+### 🟢 상시 — Layer 1-2 보강
+
+- CUJ P0 범위 widget flow 보강 (체크인, 매칭, 정산)
+- 신규 화면 추가 시 Layer 1 unit + Layer 2a flow 동반 필수
+
+### ✅ 최근 완료
+
+| 완료 | 내용 | PR / Issue |
+|------|------|-----------|
+| Layer 4 통합 | `tests/backend_integration/` → pgTAP 이관 | #1574 |
+| Layer 7 복구 | backend-simulation pg_cron → GH Actions | #1584 |
+| 스크린샷 3-tier 아키텍처 명문화 | `screenshot-capture-points.md` | #1559 |
+| Layer 3 artifact upload wiring | `run-client/partner-cuj.sh` 경로 수정 | #1577 |
 
 ---
 
-## 10. automation-test-guide.md 업데이트 계획
+## 7. Layer 선택 결정 트리 (구현 전 참고)
 
-Phase 3 (SWE 구현) 시 아래 섹션을 업데이트한다:
+```
+새 테스트 추가 필요?
+├── DB 스키마 / RLS / RPC 계약 변경?  → Layer 4 (pgTAP)
+├── 신규 Edge Function 로직?          → Layer 5 (Deno EF)
+├── 네이티브 surface 필요?
+│   (카카오 로그인, PG SDK, 시스템 권한) → Layer 3 (Patrol emulator)
+├── 다화면 플로우 / GoRouter 분기?     → Layer 2a (widget flow)
+├── 디자인 토큰 / 시각 회귀 감지?      → Layer 2b (Alchemist golden)
+├── repository / controller / util?    → Layer 1 (unit)
+├── 매시간 실 DB 데이터 이상 감시?     → Layer 6 (DB monitor RPC)
+└── 파이프라인 연쇄 동작 (tick)?       → Layer 7 (backend-simulator)
+```
 
-| 섹션 | 변경 내용 |
-|------|----------|
-| §1 커버리지 현황 | Integration 수 업데이트, Smoke 수 추가 |
-| §2 계층별 규칙 | Integration Test 패턴 추가 (`pumpApp`, CUJ 헬퍼) |
-| §3 체크리스트 | Smoke Test를 "권장"에서 "필수"로 격상 (새 화면 추가 시) |
-| §6 실행 명령어 | `flutter test test/integration/ --tags integration` 추가 |
-| §8 CI 연동 | app_partner integration 실행 추가 |
+상세 작성 규칙 / 샘플 코드: `docs/qa/automation-test-guide.md`.
 
 ---
 
-## 부록: PM 케이스 → 테스트 계층 전수 매핑
+## 8. 관련 문서
 
-### app_user Smoke (U-S01 ~ U-S18)
+| 문서 | 역할 |
+|------|------|
+| [automation-test-guide.md](automation-test-guide.md) | Layer 별 작성 규칙 + 샘플 코드 + 체크리스트 |
+| [screenshot-capture-points.md](screenshot-capture-points.md) | Tier B (시나리오 스크린샷) 캡처 포인트 매핑 |
+| [routing-test-plan.md](routing-test-plan.md) | Layer 2a 라우팅 테스트 상세 계획 |
+| [test-cases/](test-cases/) | runtime-qa 워커가 실행하는 실물 디바이스 시나리오 카탈로그 |
+| [dev-deeplink-guide.md](dev-deeplink-guide.md) | 딥링크 수동 테스트 가이드 |
 
-| ID | 화면 | 계층 | 기존 테스트 여부 | 비고 |
-|----|------|------|----------------|------|
-| U-S01 | 홈 | Widget | ✅ (golden 있음) | smoke 추가 불필요 |
-| U-S02 | 검색 | Widget | ✅ (golden 있음) | smoke 추가 불필요 |
-| U-S04 | 이벤트 상세 | Widget | ✅ (golden 있음) | smoke 추가 불필요 |
-| U-S05 | 파트너 상세 | Widget | ❌ | 신규 |
-| U-S06 | 파트너 이벤트 목록 | Widget | ❌ | 신규 |
-| U-S07 | 로그인 | Widget | ✅ (golden 있음) | smoke 추가 불필요 |
-| U-S08 | OAuth 콜백 | Widget | ❌ | 신규 |
-| U-S09 | 마이페이지 | Widget | ✅ (golden 있음) | smoke 추가 불필요 |
-| U-S10 | 개인정보 설정 | Widget | ❌ | 신규 |
-| U-S11 | 차단 파트너 관리 | Widget | ✅ (golden 있음) | smoke 추가 불필요 |
-| U-S12 | 알림 설정 | Widget | ❌ | 신규 |
-| U-S13 | 구매 내역 | Widget | ❌ | 신규 — P0 |
-| U-S14 | 알림 센터 | Widget | ❌ | 신규 |
-| U-S15 | 본인인증 | Widget | ❌ | 신규 |
-| U-S16 | 신청 위저드 | Widget | ✅ (golden 있음) | smoke 추가 불필요 |
-| U-S17 | 개발 도구 | Widget | ❌ | P3 — dev only |
-| U-S18 | 유저 전환 | Widget | ❌ | P3 — dev only |
+---
 
-**신규 Smoke 필요: 8건** (golden 기존 커버 제외, dev only 제외)
+## 9. 변경 이력
 
-### app_partner Smoke (P-S01 ~ P-S30)
-
-| ID | 화면 | 계층 | 기존 테스트 여부 | 비고 |
-|----|------|------|----------------|------|
-| P-S01 | 로그인 | Widget | ✅ (golden) | smoke 불필요 |
-| P-S02 | 웰컴 | Widget | ❌ | 신규 |
-| P-S03 | 파트너 신청 | Widget | ✅ (golden) | smoke 불필요 |
-| P-S04 | 신청 상태 | Widget | ✅ (golden) | smoke 불필요 |
-| P-S05 | 홈 | Widget | ✅ (golden) | smoke 불필요 |
-| P-S06 | 장소 가이드 | Widget | ❌ | 신규 |
-| P-S07 | 신청 관리 | Widget | ❌ | 신규 — P0 |
-| P-S08 | 신청 상세 | Widget | ❌ | 신규 — P0 |
-| P-S09 | 체크인 | Widget | ❌ | 신규 — P0 |
-| P-S10 | 정산 | Widget | ✅ (golden) | smoke 불필요 |
-| P-S11 | 계좌 관리 | Widget | ❌ | 신규 — P0 |
-| P-S12 | 정산 상세 | Widget | ❌ | 신규 |
-| P-S13 | 더보기 | Widget | ✅ (golden) | smoke 불필요 |
-| P-S14 | 파티 목록 | Widget | ✅ (golden) | smoke 불필요 |
-| P-S15 | 파티 생성 | Widget | ✅ (golden) | smoke 불필요 |
-| P-S16 | 파티 상세 | Widget | ❌ | 신규 |
-| P-S17 | 파티 편집 | Widget | ❌ | 신규 |
-| P-S18 | 파티 티켓 편집 | Widget | ❌ | 신규 |
-| P-S19 | 이벤트 생성 | Widget | ❌ | 신규 |
-| P-S20 | 이벤트 상세 | Widget | ✅ (golden) | smoke 불필요 |
-| P-S21 | 티켓 생성 | Widget | ❌ | 신규 |
-| P-S22 | 티켓 편집 | Widget | ❌ | 신규 |
-| P-S23 | 인증 관리 | Widget | ✅ (golden) | smoke 불필요 |
-| P-S24 | 인증 생성 | Widget | ✅ (golden) | smoke 불필요 |
-| P-S25 | 알림 설정 | Widget | ❌ | 신규 |
-| P-S26 | 멤버 목록 | Widget | ❌ | 신규 |
-| P-S27 | 멤버 권한 | Widget | ❌ | 신규 |
-| P-S28 | 알림 센터 | Widget | ❌ | 신규 |
-| P-S29 | 개발 도구 | Widget | ❌ | P3 — dev only |
-| P-S30 | 유저 전환 | Widget | ❌ | P3 — dev only |
-
-**신규 Smoke 필요: 18건** (golden 기존 커버 제외, dev only 제외)
+| 날짜 | 변경 | 이슈 |
+|------|------|------|
+| 2026-04-18 | 7-layer taxonomy 정식 도입. Phase 2 초안 전면 재작성 | #1586 Phase A |
+| 2026-04-18 | 스크린샷 3-tier 용어 통일 ("Layer" → "Tier" 로 분리) | #1586 Phase A |
+| 2026-04-18 | `tests/backend_integration/` → pgTAP 흡수 반영 | #1574 |
+| 2026-04-15 | 스크린샷 3-layer 아키텍처 초안 | #1557 |
+| 2026-04-15 | Patrol 전환 + 스크린샷 내장 결정 | #1458 |
+| 2026-04-05 | Phase 2 초안 (Widget / Integration / E2E 3 계층) | — |

--- a/docs/qa/test-strategy.md
+++ b/docs/qa/test-strategy.md
@@ -263,26 +263,7 @@
 
 ---
 
-## 7. Layer 선택 결정 트리 (구현 전 참고)
-
-```
-새 테스트 추가 필요?
-├── DB 스키마 / RLS / RPC 계약 변경?  → Layer 4 (pgTAP)
-├── 신규 Edge Function 로직?          → Layer 5 (Deno EF)
-├── 네이티브 surface 필요?
-│   (카카오 로그인, PG SDK, 시스템 권한) → Layer 3 (Patrol emulator)
-├── 다화면 플로우 / GoRouter 분기?     → Layer 2a (widget flow)
-├── 디자인 토큰 / 시각 회귀 감지?      → Layer 2b (Alchemist golden)
-├── repository / controller / util?    → Layer 1 (unit)
-├── 매시간 실 DB 데이터 이상 감시?     → Layer 6 (DB monitor RPC)
-└── 파이프라인 연쇄 동작 (tick)?       → Layer 7 (backend-simulator)
-```
-
-상세 작성 규칙 / 샘플 코드: `docs/qa/automation-test-guide.md`.
-
----
-
-## 8. 관련 문서
+## 7. 관련 문서
 
 | 문서 | 역할 |
 |------|------|
@@ -294,7 +275,7 @@
 
 ---
 
-## 9. 변경 이력
+## 8. 변경 이력
 
 | 날짜 | 변경 | 이슈 |
 |------|------|------|


### PR DESCRIPTION
Scheduler: needs-qa-claude-1

Refs #1586 (Phase A only — B/C/D 는 후속 PR)

## Summary

- \`docs/qa/test-strategy.md\` 전면 재작성 — 7-layer taxonomy 를 팀 SSOT 로 정식 도입. Layer 별 책임/비책임/경계 명시, 2026-04-18 실측 커버리지 수치 반영.
- \`docs/qa/automation-test-guide.md\` 재편 — Layer 선택 결정 트리, Layer 별 샘플 코드, Layer 6/7 신규 섹션 추가.
- \`docs/qa/screenshot-capture-points.md\` — 스크린샷 "Layer 1/2/3" → "Tier A/B/C" 재명명 (7-layer 의 Layer 와 충돌 해소). 경로 구분 표에 7-layer 연결 컬럼 추가.
- \`README.md\` Testing 섹션 — \`docs/qa/\` 포인터 3건 추가.

## 배경

#1586 에서 합의된 7-layer taxonomy:

| # | Layer | 위치 | 프레임워크 |
|---|-------|------|-----------|
| 1 | Unit test | \`test/src/\` | \`flutter_test\` |
| 2a | Widget flow test | \`test/integration/\` | \`flutter_test\` |
| 2b | Golden image test | \`test/goldens/\` | Alchemist |
| 3 | Emulator test | \`integration_test/\` | Patrol |
| 4 | pgTAP | \`supabase/tests/database/\` | pgTAP |
| 5 | Deno EF test | \`supabase/functions/**/*_test.ts\` | \`deno test\` |
| 6 | DB monitor | \`check_db_invariants()\` RPC | SQL (매시간) |
| 7 | Tick simulator | \`backend-simulator\` EF | EF + HTTP |

기존 문서는 "integration" 이 4중 의미로, "스크린샷" 이 3중 의미로 쓰이고 있어 혼동 유발. 본 PR 로 용어 고정.

## 스코프 구분

- ✅ Phase A (본 PR) — 문서 정비 (needs-qa 범위)
- ⏳ Phase B — 워크플로우 \`name:\` 필드 layer 명시 (\`needs-swe\`)
- ⏳ Phase C — \`test/visual_qa/\` 삭제 / \`test/scenarios/\` 흡수 / \`test/integration/\` → \`test/flows/\` rename (\`needs-swe\`, 일부 PR #1582 에 포함)
- ⏳ Phase D-1 — 각 Layer 정량 커버리지 측정 보고 (\`needs-qa\`, 후속)
- ⏳ Phase D-2/3/4 — Layer 3 Patrol 전면 이관 (\`needs-swe\`)

## Test plan

- [ ] 문서 렌더링 확인 (GitHub web UI 에서 표/코드블록 깨짐 여부)
- [ ] \`docs/qa/test-strategy.md\` §2 의 7-layer 표가 현재 실제 폴더 구조와 일치 (2026-04-18 기준)
- [ ] 커버리지 수치 (§4) 가 실측과 일치 — app_user 65/26/14/5, app_partner 71/11/15/1, pgTAP 80, Deno EF 75, minglit_kit 99
- [ ] 스크린샷 3-Tier (A/B/C) 와 7-layer 의 Layer 2b / Layer 3 mapping 이 screenshot-capture-points.md 와 일치

🤖 Generated with [Claude Code](https://claude.com/claude-code)