### PR TITLE
ci(workflows): Phase B — workflow name 필드에 테스트 layer 명시 (#1586)

### DIFF
--- a/.github/workflows/allure-report.yml
+++ b/.github/workflows/allure-report.yml
@@ -1,4 +1,4 @@
-name: Daily: Allure Test Report Aggregation
+name: "Daily: Allure Test Report Aggregation"
 
 on:
   schedule:

--- a/.github/workflows/allure-report.yml
+++ b/.github/workflows/allure-report.yml
@@ -1,4 +1,4 @@
-name: Allure Report
+name: Daily: Allure Test Report Aggregation
 
 on:
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI: Unit + Widget + Golden + pgTAP + Deno EF + Landing Lint
 
 on:
   push:
@@ -71,6 +71,7 @@ jobs:
 
   # App CI (User + Partner)
   test-flutter-apps:
+    name: test-app-unit-widget-golden
     needs: changes
     if: ${{ needs.changes.outputs.app_user == 'true' || needs.changes.outputs.app_partner == 'true' }}
     runs-on: ubuntu-latest
@@ -237,6 +238,7 @@ jobs:
 
   # Landing User CI
   lint-landing-user:
+    name: lint-and-build-landing-user
     needs: changes
     if: ${{ needs.changes.outputs.landing_user == 'true' }}
     runs-on: ubuntu-latest
@@ -258,6 +260,7 @@ jobs:
 
   # Landing Partner CI
   lint-landing-partner:
+    name: lint-and-build-landing-partner
     needs: changes
     if: ${{ needs.changes.outputs.landing_partner == 'true' }}
     runs-on: ubuntu-latest
@@ -279,6 +282,7 @@ jobs:
 
   # Supabase 통합 테스트 (pgTAP + backend-integration + e2e-scenarios)
   test-supabase:
+    name: test-pgtap
     needs: changes
     if: ${{ needs.changes.outputs.supabase == 'true' }}
     runs-on: ubuntu-latest
@@ -307,6 +311,7 @@ jobs:
 
   # Deno Edge Function 테스트 (supabase 불필요)
   test-edge-functions:
+    name: test-deno-ef
     needs: changes
     if: ${{ needs.changes.outputs.supabase == 'true' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI: Unit + Widget + Golden + pgTAP + Deno EF + Landing Lint
+name: "CI: Unit + Widget + Golden + pgTAP + Deno EF + Landing Lint"
 
 on:
   push:

--- a/.github/workflows/daily-backend-simulation.yml
+++ b/.github/workflows/daily-backend-simulation.yml
@@ -1,4 +1,4 @@
-name: Daily Backend Simulation + CUJ Tests
+name: Daily: Tick Simulator Pipeline + Emulator CUJ
 
 on:
   schedule:

--- a/.github/workflows/daily-backend-simulation.yml
+++ b/.github/workflows/daily-backend-simulation.yml
@@ -172,5 +172,5 @@ jobs:
     uses: ./.github/workflows/notify-failure.yml
     with:
       success: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
-      workflow_name: 'Daily Backend Simulation'
+      workflow_name: 'Daily: Tick Simulator Pipeline + Emulator CUJ'
     secrets: inherit

--- a/.github/workflows/daily-backend-simulation.yml
+++ b/.github/workflows/daily-backend-simulation.yml
@@ -1,4 +1,4 @@
-name: Daily: Tick Simulator Pipeline + Emulator CUJ
+name: "Daily: Tick Simulator Pipeline + Emulator CUJ"
 
 on:
   schedule:

--- a/.github/workflows/db-invariants.yml
+++ b/.github/workflows/db-invariants.yml
@@ -1,4 +1,4 @@
-name: Hourly: DB Invariant Monitor
+name: "Hourly: DB Invariant Monitor"
 
 on:
   schedule:

--- a/.github/workflows/db-invariants.yml
+++ b/.github/workflows/db-invariants.yml
@@ -1,4 +1,4 @@
-name: DB Invariant Monitor
+name: Hourly: DB Invariant Monitor
 
 on:
   schedule:

--- a/.github/workflows/hourly-backend-simulation.yml
+++ b/.github/workflows/hourly-backend-simulation.yml
@@ -1,4 +1,4 @@
-name: Hourly Backend Simulation
+name: "Hourly: Tick Simulator (backend full-phase)"
 
 on:
   schedule:
@@ -34,5 +34,5 @@ jobs:
     uses: ./.github/workflows/notify-failure.yml
     with:
       success: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
-      workflow_name: 'Hourly Backend Simulation'
+      workflow_name: 'Hourly: Tick Simulator (backend full-phase)'
     secrets: inherit

--- a/.github/workflows/hourly-backend-simulation.yml
+++ b/.github/workflows/hourly-backend-simulation.yml
@@ -2,11 +2,11 @@ name: Hourly Backend Simulation
 
 on:
   schedule:
-    - cron: '0 * * * *'  # Every hour at :00 (hourly-user-activity.yml runs at :30)
+    - cron: '0 * * * *'  # Every hour at :00 (hourly-tick-simulator.yml runs at :30)
   workflow_dispatch:
 
 concurrency:
-  group: supabase-dev-simulation  # Same group as hourly-user-activity to prevent concurrent EF calls
+  group: supabase-dev-simulation  # Same group as hourly-tick-simulator to prevent concurrent EF calls
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/hourly-tick-simulator.yml
+++ b/.github/workflows/hourly-tick-simulator.yml
@@ -1,4 +1,4 @@
-name: Hourly: Tick Simulator (user activity mode)
+name: "Hourly: Tick Simulator (user activity mode)"
 
 on:
   schedule:

--- a/.github/workflows/hourly-tick-simulator.yml
+++ b/.github/workflows/hourly-tick-simulator.yml
@@ -1,4 +1,4 @@
-name: Hourly User Activity Simulation
+name: Hourly: Tick Simulator (user activity mode)
 
 on:
   schedule:
@@ -32,5 +32,5 @@ jobs:
     uses: ./.github/workflows/notify-failure.yml
     with:
       success: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
-      workflow_name: 'Hourly User Activity'
+      workflow_name: 'Hourly Tick Simulator (user activity mode)'
     secrets: inherit

--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -7,7 +7,7 @@
 # IntegrationTestWidgetsFlutterBinding (incompatible with PatrolBinding)
 # and are excluded from this workflow — run them via `flutter test integration_test/`.
 
-name: Weekly: Emulator Test (Patrol native surface)
+name: "Weekly: Emulator Test (Patrol native surface)"
 
 on:
   schedule:

--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -7,7 +7,7 @@
 # IntegrationTestWidgetsFlutterBinding (incompatible with PatrolBinding)
 # and are excluded from this workflow — run them via `flutter test integration_test/`.
 
-name: Patrol E2E
+name: Weekly: Emulator Test (Patrol native surface)
 
 on:
   schedule:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,4 +1,4 @@
-name: PR: Gitleaks Secret Scan
+name: "PR: Gitleaks Secret Scan"
 
 on:
   pull_request:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,4 +1,4 @@
-name: Secret Scanning
+name: PR: Gitleaks Secret Scan
 
 on:
   pull_request:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -33,6 +33,6 @@ jobs:
     uses: ./.github/workflows/notify-failure.yml
     with:
       success: false
-      workflow_name: 'Secret Scan'
+      workflow_name: 'PR: Gitleaks Secret Scan'
       # Fix #976: PR-triggered workflows should not create P0 noise issues
       create_issue: false

--- a/.github/workflows/update-goldens.yml
+++ b/.github/workflows/update-goldens.yml
@@ -1,4 +1,4 @@
-name: Maintenance: Update Alchemist Goldens
+name: "Maintenance: Update Alchemist Goldens"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/update-goldens.yml
+++ b/.github/workflows/update-goldens.yml
@@ -1,4 +1,4 @@
-name: Update CI Goldens
+name: Maintenance: Update Alchemist Goldens
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1586 (Phase B)

## Summary

Issue #1586 Phase B — 각 workflow와 `ci.yml` job의 `name:` 필드를 7-layer taxonomy에 맞게 갱신.

### 변경 내용

| 파일 | 변경 전 | 변경 후 |
|------|---------|---------|
| `ci.yml` | `name: CI` | `name: CI: Unit + Widget + Golden + pgTAP + Deno EF + Landing Lint` |
| `ci.yml` jobs | (name 필드 없음) | `test-app-unit-widget-golden`, `test-pgtap`, `test-deno-ef`, `lint-and-build-landing-user/partner` |
| `daily-backend-simulation.yml` | `Daily Backend Simulation + CUJ Tests` | `Daily: Tick Simulator Pipeline + Emulator CUJ` |
| `hourly-user-activity.yml` | — | **파일명 rename** → `hourly-tick-simulator.yml` + `Hourly: Tick Simulator (user activity mode)` |
| `patrol-e2e.yml` | `Patrol E2E` | `Weekly: Emulator Test (Patrol native surface)` |
| `db-invariants.yml` | `DB Invariant Monitor` | `Hourly: DB Invariant Monitor` |
| `update-goldens.yml` | `Update CI Goldens` | `Maintenance: Update Alchemist Goldens` |
| `allure-report.yml` | `Allure Report` | `Daily: Allure Test Report Aggregation` |
| `secret-scan.yml` | `Secret Scanning` | `PR: Gitleaks Secret Scan` |

### 보류 항목 (별도 처리 필요)

- `patrol-e2e.yml` → `weekly-emulator-patrol.yml` 파일명 rename: PR #1582와 동일 파일 수정 → 충돌 방지를 위해 #1582 머지 후 후속 PR
- `update-goldens.yml` → `update-alchemist-goldens.yml` 파일명 rename: 동일 이유
- `ci.yml` job ID rename: PR #1587과 충돌 방지 → `name:` 필드 추가로 대체, #1587 머지 후 후속 PR에서 rename 가능

## Test plan

- [ ] CI 통과 확인 (`ci-result`)
- [ ] `ci-result` job ID 변경 없음 — branch protection 설정 영향 없음
- [ ] `hourly-backend-simulation.yml` 주석 내 파일명 참조 업데이트 확인