### PR TITLE
fix(ci): seed-dev.yml → psql -f seed.dev.sql (remove stale Dart seeder)

### DIFF
--- a/.github/workflows/seed-dev.yml
+++ b/.github/workflows/seed-dev.yml
@@ -22,17 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # Flutter Setup (for Dart Seeder)
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: 'stable'
-          cache: true
-      
-      # Supabase CLI Setup (for linking)
-      - uses: supabase/setup-cli@v1
-        with:
-          version: latest
-
       # Safety Guard 2: Explicitly verify we are NOT targeting the MAIN project
       - name: Verify Target Project
         env:
@@ -43,36 +32,25 @@ jobs:
              echo "❌ Error: SUPABASE_DEV_PROJECT_ID secret is missing."
              exit 1
           fi
-          
+
           if [ "$TARGET_PROJECT_ID" == "$MAIN_PROJECT_ID" ]; then
             echo "🔥 CRITICAL ERROR: Safety Guard Triggered!"
-            echo "Attempting to reset the MAIN database project ($MAIN_PROJECT_ID)."
+            echo "Attempting to seed the MAIN database project ($MAIN_PROJECT_ID)."
             echo "This operation is strictly forbidden in this workflow."
             exit 1
           fi
           echo "✅ Safety Check Passed: Target Project ($TARGET_PROJECT_ID) is NOT Main DB."
 
-      # Step 1: Link to remote project
-      - name: Link Remote Dev Database
+      # Fix #1600: Dart seeder (tests/test_data_seeder) was removed in #1413.
+      # seed.dev.sql is now the source of truth — run via psql direct connection.
+      - name: Run seed.dev.sql
         env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DEV_DB_PASSWORD }}
+          PGPASSWORD: ${{ secrets.SUPABASE_DEV_DB_PASSWORD }}
           SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_DEV_PROJECT_ID }}
         run: |
-          supabase link --project-ref $SUPABASE_PROJECT_ID --password $SUPABASE_DB_PASSWORD
-
-      # Step 2: Install Dart Dependencies
-      - name: Install Dart Dependencies
-        run: flutter pub get
-        working-directory: tests/test_data_seeder
-
-      # Step 3: Run Dart Seeder (Dynamic Data)
-      - name: Run Dart Seeder
-        working-directory: tests/test_data_seeder
-        env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_DEV_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_DEV_SECRET_KEY }}
-        run: flutter test test/runner.dart
+          psql \
+            "postgresql://postgres:${PGPASSWORD}@db.${SUPABASE_PROJECT_ID}.supabase.co:5432/postgres?sslmode=require" \
+            -f supabase/seed.dev.sql
 
 
   notify-failure:

--- a/.github/workflows/seed-dev.yml
+++ b/.github/workflows/seed-dev.yml
@@ -48,8 +48,10 @@ jobs:
           PGPASSWORD: ${{ secrets.SUPABASE_DEV_DB_PASSWORD }}
           SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_DEV_PROJECT_ID }}
         run: |
+          # PGPASSWORD env is read by psql automatically — omit password from URI
+          # so special characters in the secret never need percent-encoding.
           psql \
-            "postgresql://postgres:${PGPASSWORD}@db.${SUPABASE_PROJECT_ID}.supabase.co:5432/postgres?sslmode=require" \
+            "postgresql://postgres@db.${SUPABASE_PROJECT_ID}.supabase.co:5432/postgres?sslmode=require" \
             -f supabase/seed.dev.sql
 
 


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1600
Closes #1576

## Summary

- `tests/test_data_seeder` was removed in #1413 when seeding was switched to `seed.dev.sql + psql`
- `seed-dev.yml` still referenced the deleted Dart seeder → fails with "No such file or directory"
- This caused every seed run to fail (#1576), leaving the dev database unseeded after migration deploys
- Unseeded dev DB = no `partner_member_permissions` for seeded partner accounts → partner app fully broken (#1600)

**Fix**: Replace Flutter/Dart steps with a single `psql -f supabase/seed.dev.sql` call.

## Changes

- `.github/workflows/seed-dev.yml`: Remove `subosito/flutter-action`, `supabase/setup-cli`, Dart dependency install, and `flutter test` steps. Replace with `psql "postgresql://postgres:...@db.${PROJECT_ID}.supabase.co:5432/postgres" -f supabase/seed.dev.sql`.

## Verification

- `seed.dev.sql` header already documents this exact command: `PGPASSWORD="..." psql "<pooler-url>" -f supabase/seed.dev.sql`
- `seed.dev.sql` is idempotent: uses `SELECT/INSERT` pattern for users, `biz_number` existence checks for partners, `ON CONFLICT` for permissions
- Direct connection (port 5432) supports `DO $$...END $$` blocks needed by the seed
- `seed-dev.yml` YAML validated via `ruby -ryaml`

## Post-merge Action Required

After this PR merges, manually trigger **"Seed Dev Database"** workflow to re-seed the dev database and restore partner permissions.