### PR TITLE
fix(ef): dev-only functions blocked in deployed dev env (ENVIRONMENT=dev)

### DIFF
--- a/supabase/functions/dev-mock-portone/index.ts
+++ b/supabase/functions/dev-mock-portone/index.ts
@@ -24,7 +24,8 @@ Deno.serve(withHandler(async (req) => {
 
   // Dev-only guard
   const env = Deno.env.get('ENVIRONMENT')
-  if (env !== 'local' && env !== 'development') {
+  // Fix #1614: "dev" = Supabase dev project (set by supabase-deploy.yml secrets)
+  if (env !== 'local' && env !== 'development' && env !== 'dev') {
     return json({ error: 'Dev-only function. Blocked in production.' }, 403)
   }
 

--- a/supabase/functions/dev-seed/dev_seed_test.ts
+++ b/supabase/functions/dev-seed/dev_seed_test.ts
@@ -26,6 +26,64 @@ Deno.test({
   },
 });
 
+// Fix #1614: regression — unset ENVIRONMENT must be blocked (fail-safe)
+Deno.test({
+  name: "dev-seed - blocks when ENVIRONMENT is unset (fail-safe production guard)",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+
+    await withEnv({ ENVIRONMENT: undefined }, async () => {
+      const response = await handler(new Request("http://localhost"));
+      assertEquals(response.status, 403);
+    });
+  },
+});
+
+// Fix #1614: regression — ENVIRONMENT=dev (Supabase dev project secret) must be allowed
+Deno.test({
+  name: "dev-seed - allows ENVIRONMENT=dev (deployed dev project)",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: (req) => req.url.includes("/storage/v1/object/list-v2/"),
+        handler: () =>
+          jsonResponse({
+            objects: [
+              { name: "seed-images/party_cafe_warm.jpg" },
+              { name: "seed-images/party_lounge_bright.jpg" },
+              { name: "seed-images/party_premium_lounge.jpg" },
+            ],
+          }),
+      },
+      {
+        matcher: (req) => req.url.includes("/storage/v1/object/public/"),
+        handler: (req) => jsonResponse({ publicUrl: req.url }),
+      },
+    ]);
+
+    await withEnv({
+      ENVIRONMENT: "dev",
+      SUPABASE_URL: "http://localhost:54321",
+      SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+    }, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const response = await handler(
+          new Request("http://localhost?mode=images-only"),
+        );
+        assertEquals(response.status, 200);
+        const body = await readJson(response);
+        assertEquals(body.mode, "images-only");
+      });
+    });
+  },
+});
+
 Deno.test({
   name: "dev-seed - images-only mode returns 200 with image_urls (images already in storage)",
   fn: async () => {

--- a/supabase/functions/dev-seed/index.ts
+++ b/supabase/functions/dev-seed/index.ts
@@ -11,7 +11,8 @@ initSentry();
 
 function isProduction(): boolean {
   const env = Deno.env.get("ENVIRONMENT");
-  return env !== "local" && env !== "development";
+  // Fix #1614: "dev" = Supabase dev project (set by supabase-deploy.yml secrets)
+  return env !== "local" && env !== "development" && env !== "dev";
 }
 
 // Partner owner that already exists via seed.dev.sql (used for authed storage upload)

--- a/supabase/functions/dev-session-switch/index.ts
+++ b/supabase/functions/dev-session-switch/index.ts
@@ -17,7 +17,8 @@ Deno.serve(withHandler(async (req) => {
   }
 
   const env = Deno.env.get('ENVIRONMENT')
-  if (env !== 'local' && env !== 'development') {
+  // Fix #1614: "dev" = Supabase dev project (set by supabase-deploy.yml secrets)
+  if (env !== 'local' && env !== 'development' && env !== 'dev') {
     return new Response(
       JSON.stringify({ error: 'Dev-only function. Blocked in production.' }),
       { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1614

## Summary

- \`dev-seed\`, \`dev-mock-portone\`, \`dev-session-switch\`의 dev-only guard가 \`"local" | "development"\`만 허용하고 \`"dev"\`를 차단함
- \`supabase-deploy.yml\`이 Supabase dev 프로젝트에 \`ENVIRONMENT=dev\`를 설정(line 80)하므로 배포 후 \`dev-seed?mode=images-only\` 호출 시 403 반환 → Deploy Supabase Migrations 실패
- PR #1607에서 \`backend-simulator\`에 동일한 패턴으로 수정했으나 나머지 3개 함수가 누락됨

## Root Cause

구버전 (dev 환경에서 차단): \`return env !== "local" && env !== "development"\`
수정 후 ("dev" 추가): \`return env !== "local" && env !== "development" && env !== "dev"\`

## Test plan

- [x] \`deno test dev_seed_test.ts\` — 8 passed (new: unset=403, dev=200)
- [x] \`deno test dev_mock_portone_test.ts\` — 6 passed
- [x] \`deno test dev_session_switch_test.ts\` — 3 passed
- [ ] Deploy Supabase Migrations 재실행 → success 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)