### PR TITLE
fix(seed): CUJ-U04 검색 제안 키워드 매칭 파티 추가 (클래스/스포츠/아트)

### DIFF
--- a/supabase/seed.dev.sql
+++ b/supabase/seed.dev.sql
@@ -495,3 +495,57 @@ BEGIN
     VALUES (test_event_id, '일반 참가권', 0, 50, 'on_sale');
   END IF;
 END $$;
+
+-- Fix #1617: CUJ-U04 검색 키워드('클래스', '스포츠', '아트') 매칭 파티 추가.
+-- search_events_pgroonga는 parties.title을 검색하므로 제안 키워드가 포함된 파티가 필요.
+-- 멱등: 이미 존재하면 생성 건너뜀.
+DO $$
+DECLARE
+  qa_partner_id  uuid;
+  qa_location_id uuid;
+  party_id_      uuid;
+  event_id_      uuid;
+  rec            RECORD;
+BEGIN
+  SELECT id INTO qa_partner_id FROM public.partners WHERE biz_number = '123-45-67890';
+  IF qa_partner_id IS NULL THEN
+    RAISE NOTICE 'QA seed (phase 7): 밍글 스튜디오 없음, 스킵.';
+    RETURN;
+  END IF;
+
+  SELECT id INTO qa_location_id FROM public.locations
+  WHERE partner_id = qa_partner_id AND name = '서울 강남' LIMIT 1;
+
+  FOR rec IN SELECT * FROM (VALUES
+    ('[QA] 소셜 클래스',          '[QA] 소셜 클래스 이벤트'),
+    ('[QA] 스포츠 소셜 모임',     '[QA] 스포츠 소셜 이벤트'),
+    ('[QA] 아트 & 문화 이벤트',   '[QA] 아트 문화 이벤트')
+  ) AS t(party_title, event_title)
+  LOOP
+    SELECT id INTO party_id_ FROM public.parties
+    WHERE partner_id = qa_partner_id AND title = rec.party_title;
+    IF party_id_ IS NULL THEN
+      INSERT INTO public.parties (partner_id, location_id, title, max_participants, status)
+      VALUES (qa_partner_id, qa_location_id, rec.party_title, 30, 'active')
+      RETURNING id INTO party_id_;
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1 FROM public.events
+      WHERE party_id = party_id_ AND title = rec.event_title AND start_time > now()
+    ) THEN
+      INSERT INTO public.events (party_id, location_id, title, start_time, end_time, max_participants, status)
+      VALUES (
+        party_id_, qa_location_id,
+        rec.event_title,
+        now() + interval '30 days',
+        now() + interval '30 days' + interval '3 hours',
+        30, 'scheduled'
+      )
+      RETURNING id INTO event_id_;
+
+      INSERT INTO public.tickets (event_id, name, price, quantity, status)
+      VALUES (event_id_, '일반 참가권', 0, 30, 'on_sale');
+    END IF;
+  END LOOP;
+END $$;


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1617

## 원인

`search_events_pgroonga` RPC는 `parties.title`에 대해 PGroonga 전문 검색을 수행.
검색 화면의 제안 키워드 4개 중 '클래스', '스포츠', '아트'를 포함한 파티 타이틀이 dev seed에 없어 검색 결과 0개 반환.

## 변경 내용

`seed.dev.sql`에 Phase 7 블록 추가 — 3개 QA 파티 + 각 파티에 이벤트 + 무료 티켓:

| 파티 타이틀 | 매칭 키워드 |
|---|---|
| `[QA] 소셜 클래스` | 클래스 |
| `[QA] 스포츠 소셜 모임` | 스포츠 |
| `[QA] 아트 & 문화 이벤트` | 아트 |

- 이벤트: `status='scheduled'`, `start_time = now() + 30 days`
- 티켓: 무료(0원), 30석
- 멱등 설계: 이미 존재하거나 미래 이벤트가 있으면 건너뜀

## 조사 결과

- PGroonga: **활성화** (`20260308000002_enable_pgroonga.sql`)
- 검색 API 호출: **정상** (empty 반환, error 아님)
- 기존 '파티' 키워드: Phase 6 seed의 `[QA] 오픈 소셜 파티`로 이미 매칭 가능

## Test plan

- [ ] dev 배포 후 검색 화면에서 '클래스', '스포츠', '아트' 탭 → 각각 결과 1개 이상 반환 확인
- [ ] '파티' 탭 → 기존 동작 유지 확인
- [ ] CI: `check-migration-versions` (seed는 migration 아님, 영향 없음)