### PR TITLE
fix(user-app): isDevEnv에 'dev' 추가 + GUEST 로그인 from=/my 수정

### DIFF
--- a/apps/app_user/lib/src/features/auth/login_page.dart
+++ b/apps/app_user/lib/src/features/auth/login_page.dart
@@ -35,7 +35,11 @@ class LoginPage extends ConsumerWidget {
       'ENVIRONMENT',
       defaultValue: 'production',
     );
-    const isDevEnv = environment == 'local' || environment == 'development';
+    // Fix #1633: 'dev' 추가 — Supabase dev 프로젝트는 ENVIRONMENT=dev 사용
+    const isDevEnv =
+        environment == 'local' ||
+        environment == 'development' ||
+        environment == 'dev';
 
     // When redirected from a protected route (from != null),
     // back key should return to home instead of closing the app.

--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -148,7 +148,8 @@ class _HomePageState extends ConsumerState<HomePage> {
                     // Fix #102: use go (not push) so GoRouter redirect
                     // fires after login
                     // Fix #634: auth_coordinator 직접 참조 → home_coordinator.goToLogin 전환
-                    onPressed: () => homeCoordinator.goToLogin(from: '/'),
+                    // Fix #1633: from='/my' — 로그인 후 MyPage로 복귀
+                    onPressed: () => homeCoordinator.goToLogin(from: '/my'),
                   ),
                 const SizedBox(width: MinglitSpacing.small),
               ],

--- a/apps/app_user/lib/src/features/home/my_page.dart
+++ b/apps/app_user/lib/src/features/home/my_page.dart
@@ -207,6 +207,7 @@ class MyPage extends ConsumerWidget {
             ),
 
             // Dev Only
+            // Fix #1633: 'dev' 추가 — Supabase dev 프로젝트는 ENVIRONMENT=dev 사용
             if (const String.fromEnvironment(
                       'ENVIRONMENT',
                       defaultValue: 'production',
@@ -216,7 +217,12 @@ class MyPage extends ConsumerWidget {
                       'ENVIRONMENT',
                       defaultValue: 'production',
                     ) ==
-                    'development') ...[
+                    'development' ||
+                const String.fromEnvironment(
+                      'ENVIRONMENT',
+                      defaultValue: 'production',
+                    ) ==
+                    'dev') ...[
               const SizedBox(height: MinglitSpacing.large),
               MinglitSettingsGroup(
                 header: '개발자 도구',

--- a/apps/app_user/test/src/features/home/home_page_app_bar_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_app_bar_test.dart
@@ -119,8 +119,8 @@ void main() {
         await tester.tap(find.byIcon(Icons.person_outline));
         await tester.pump();
 
-        // Must include '/my' so login redirects back to MyPage after sign-in.
-        // LoginRoute(from: '/my').location = '/login?from=%2Fmy'
+        // Verify login route with from=/my: LoginRoute(from: '/my').location
+        // generates '/login?from=%2Fmy'. Parse the URL to assert path + param.
         final captured = verify(
           () => mockRouter.go(
             captureAny(that: isA<String>()),
@@ -128,13 +128,9 @@ void main() {
           ),
         ).captured;
 
-        expect(
-          captured.single,
-          predicate<String>(
-            (s) => s.contains('%2Fmy') || s.contains('/my'),
-            'must contain /my (URL-encoded or plain)',
-          ),
-        );
+        final uri = Uri.parse(captured.single as String);
+        expect(uri.path, '/login');
+        expect(uri.queryParameters['from'], '/my');
       });
     });
 

--- a/apps/app_user/test/src/features/home/home_page_app_bar_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_app_bar_test.dart
@@ -1,12 +1,16 @@
 import 'package:app_user/src/features/home/home_page.dart';
 import 'package:app_user/src/logic/feed_state_provider.dart';
+import 'package:app_user/src/routing/app_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
 
 import '../../../utils/mocks.dart';
+
+class MockGoRouter extends Mock implements GoRouter {}
 
 void main() {
   setUpAll(() async {
@@ -91,6 +95,45 @@ void main() {
         await tester.pump();
 
         expect(find.byType(CircleAvatar), findsNothing);
+      });
+
+      // Fix #1633: GUEST 프로필 탭 시 from=/my 전달 (기존 from=/ 버그 회귀 방지)
+      testWidgets('tapping profile icon navigates to login with from=/my',
+          (tester) async {
+        final mockRouter = MockGoRouter();
+        when(
+          () => mockRouter.go(any(), extra: any(named: 'extra')),
+        ).thenReturn(null);
+
+        await tester.pumpWidget(
+          createTestWidget(
+            overrides: [
+              currentUserProvider.overrideWith((_) => null),
+              goRouterProvider.overrideWithValue(mockRouter),
+            ],
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.byIcon(Icons.person_outline));
+        await tester.pump();
+
+        // Must include '/my' so login redirects back to MyPage after sign-in.
+        // LoginRoute(from: '/my').location = '/login?from=%2Fmy'
+        final captured = verify(
+          () => mockRouter.go(
+            captureAny(that: isA<String>()),
+            extra: any(named: 'extra'),
+          ),
+        ).captured;
+
+        expect(
+          captured.single,
+          predicate<String>(
+            (s) => s.contains('%2Fmy') || s.contains('/my'),
+            'must contain /my (URL-encoded or plain)',
+          ),
+        );
       });
     });
 

--- a/apps/app_user/test/src/features/home/home_page_app_bar_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_app_bar_test.dart
@@ -98,8 +98,9 @@ void main() {
       });
 
       // Fix #1633: GUEST 프로필 탭 시 from=/my 전달 (기존 from=/ 버그 회귀 방지)
-      testWidgets('tapping profile icon navigates to login with from=/my',
-          (tester) async {
+      testWidgets('tapping profile icon navigates to login with from=/my', (
+        tester,
+      ) async {
         final mockRouter = MockGoRouter();
         when(
           () => mockRouter.go(any(), extra: any(named: 'extra')),


### PR DESCRIPTION
## Summary

- `login_page.dart`, `my_page.dart`: `ENVIRONMENT=dev` 케이스 누락으로 dev 앱에서 개발자 도구(5탭 트리거, Design Catalog)가 노출되지 않던 버그 수정
- `home_page.dart`: GUEST 상태에서 프로필 아이콘 탭 시 `goToLogin(from: '/')` → `goToLogin(from: '/my')`로 변경, 로그인 후 MyPage로 정상 복귀
- `home_page_app_bar_test.dart`: `from=/my` 회귀 방지 테스트 추가

Closes #1633

## Test plan

- [ ] dev 앱에서 로그아웃 상태로 홈 화면 진입
- [ ] 프로필 아이콘(person_outline) 탭 → 로그인 화면으로 이동 확인
- [ ] 로그인 완료 후 MyPage(`/my`)로 복귀 확인 (기존: `/` 즉 홈으로 잘못 복귀)
- [ ] dev 앱 마이페이지 하단 '개발자 도구' 섹션 노출 확인 (ENVIRONMENT=dev 빌드)
- [ ] 로그인 화면 5탭 → Dev User Switch 트리거 노출 확인 (ENVIRONMENT=dev 빌드)
- [ ] `flutter test apps/app_user/test/src/features/home/` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)