### PR TITLE
fix(feed): dev 환경 eligibility 필터 기본 비활성화

### DIFF
--- a/apps/app_user/lib/src/logic/feed_state_provider.dart
+++ b/apps/app_user/lib/src/logic/feed_state_provider.dart
@@ -60,11 +60,17 @@ class SearchQuery extends _$SearchQuery {
   void clear() => state = '';
 }
 
+// Fix #1634: dev 환경에서는 eligibility 필터 기본 비활성화 —
+// 시드 유저의 age/gender가 이벤트 entry_group과 충돌해 홈 피드가 비어 보이는 문제 방지.
+const _isProductionEnv =
+    String.fromEnvironment('ENVIRONMENT', defaultValue: 'production') ==
+    'production';
+
 @riverpod
 class ActiveFilters extends _$ActiveFilters {
   @override
   ExploreFilters build() => const ExploreFilters(
-    eligibilityEnabled: true,
+    eligibilityEnabled: _isProductionEnv,
     nearbyEnabled: true,
   );
 

--- a/apps/app_user/test/src/features/explore/logic/eligibility_filter_test.dart
+++ b/apps/app_user/test/src/features/explore/logic/eligibility_filter_test.dart
@@ -254,77 +254,89 @@ void main() {
       expect(result, isEmpty);
     });
 
-    test('filters out events when user birth year is below entry group minimum', () {
-      // Fix #1634: age restriction — user born 1980 cannot enter group requiring birthYearMin 1990
-      final events = [
-        makeEvent(
-          tickets: [makeTicket(targetEntryGroupIds: ['g1'])],
-          entryGroups: [
-            const EntryGroup(
-              id: 'g1',
-              eventId: 'e1',
-              gender: 'male',
-              birthYearMin: 1990,
-              birthYearMax: 2005,
-            ),
-          ],
-        ),
-      ];
-      final data = BulkEligibilityData.fromJson({
-        'user_profile': {
-          'gender': 'male',
-          'birth_year': 1980,
-          'is_verified': true,
-        },
-        'approved_verifications': <dynamic>[],
-      });
+    test(
+      'filters out events when user birth year is below entry group minimum',
+      () {
+        // Fix #1634: age restriction — user born 1980 cannot enter group requiring birthYearMin 1990
+        final events = [
+          makeEvent(
+            tickets: [
+              makeTicket(targetEntryGroupIds: ['g1']),
+            ],
+            entryGroups: [
+              const EntryGroup(
+                id: 'g1',
+                eventId: 'e1',
+                gender: 'male',
+                birthYearMin: 1990,
+                birthYearMax: 2005,
+              ),
+            ],
+          ),
+        ];
+        final data = BulkEligibilityData.fromJson({
+          'user_profile': {
+            'gender': 'male',
+            'birth_year': 1980,
+            'is_verified': true,
+          },
+          'approved_verifications': <dynamic>[],
+        });
 
-      final result = EligibilityFilter.filter(
-        events: events,
-        eligibilityData: data,
-      );
+        final result = EligibilityFilter.filter(
+          events: events,
+          eligibilityData: data,
+        );
 
-      expect(result, isEmpty);
-    });
+        expect(result, isEmpty);
+      },
+    );
 
-    test('filters out events when user birth year exceeds entry group maximum', () {
-      // Fix #1634: age restriction — user born 2010 cannot enter group with birthYearMax 2005
-      final events = [
-        makeEvent(
-          tickets: [makeTicket(targetEntryGroupIds: ['g1'])],
-          entryGroups: [
-            const EntryGroup(
-              id: 'g1',
-              eventId: 'e1',
-              gender: 'male',
-              birthYearMin: 1990,
-              birthYearMax: 2005,
-            ),
-          ],
-        ),
-      ];
-      final data = BulkEligibilityData.fromJson({
-        'user_profile': {
-          'gender': 'male',
-          'birth_year': 2010,
-          'is_verified': true,
-        },
-        'approved_verifications': <dynamic>[],
-      });
+    test(
+      'filters out events when user birth year exceeds entry group maximum',
+      () {
+        // Fix #1634: age restriction — user born 2010 cannot enter group with birthYearMax 2005
+        final events = [
+          makeEvent(
+            tickets: [
+              makeTicket(targetEntryGroupIds: ['g1']),
+            ],
+            entryGroups: [
+              const EntryGroup(
+                id: 'g1',
+                eventId: 'e1',
+                gender: 'male',
+                birthYearMin: 1990,
+                birthYearMax: 2005,
+              ),
+            ],
+          ),
+        ];
+        final data = BulkEligibilityData.fromJson({
+          'user_profile': {
+            'gender': 'male',
+            'birth_year': 2010,
+            'is_verified': true,
+          },
+          'approved_verifications': <dynamic>[],
+        });
 
-      final result = EligibilityFilter.filter(
-        events: events,
-        eligibilityData: data,
-      );
+        final result = EligibilityFilter.filter(
+          events: events,
+          eligibilityData: data,
+        );
 
-      expect(result, isEmpty);
-    });
+        expect(result, isEmpty);
+      },
+    );
 
     test('filters out events requiring verification when user lacks it', () {
       // Fix #1634: verification requirement — event requires career verification
       final events = [
         makeEvent(
-          tickets: [makeTicket(requiredVerificationIds: ['verif_career'])],
+          tickets: [
+            makeTicket(requiredVerificationIds: ['verif_career']),
+          ],
         ),
       ];
       final data = BulkEligibilityData.fromJson({
@@ -348,7 +360,9 @@ void main() {
       // Fix #1634: verification — user with approved career verification is eligible
       final events = [
         makeEvent(
-          tickets: [makeTicket(requiredVerificationIds: ['verif_career'])],
+          tickets: [
+            makeTicket(requiredVerificationIds: ['verif_career']),
+          ],
         ),
       ];
       final data = BulkEligibilityData.fromJson({
@@ -400,87 +414,143 @@ void main() {
 
     // Male-only, no age restriction.
     Event maleOnlyEvent() => makeEvent(
-          id: 'male_only',
-          tickets: [makeTicket(id: 'tm', targetEntryGroupIds: ['gm'])],
-          entryGroups: [const EntryGroup(id: 'gm', eventId: 'male_only', gender: 'male')],
-        );
+      id: 'male_only',
+      tickets: [
+        makeTicket(id: 'tm', targetEntryGroupIds: ['gm']),
+      ],
+      entryGroups: [
+        const EntryGroup(id: 'gm', eventId: 'male_only', gender: 'male'),
+      ],
+    );
 
     // Male-only with age range 25–40. birthYearMin = currentYear-40, birthYearMax = currentYear-25.
     Event maleAgeRestrictedEvent() => makeEvent(
-          id: 'age_restricted',
-          tickets: [makeTicket(id: 'ta', targetEntryGroupIds: ['ga'])],
-          entryGroups: [
-            EntryGroup(
-              id: 'ga',
-              eventId: 'age_restricted',
-              gender: 'male',
-              birthYearMin: currentYear - 40,
-              birthYearMax: currentYear - 25,
-            ),
-          ],
-        );
+      id: 'age_restricted',
+      tickets: [
+        makeTicket(id: 'ta', targetEntryGroupIds: ['ga']),
+      ],
+      entryGroups: [
+        EntryGroup(
+          id: 'ga',
+          eventId: 'age_restricted',
+          gender: 'male',
+          birthYearMin: currentYear - 40,
+          birthYearMax: currentYear - 25,
+        ),
+      ],
+    );
 
     // Requires career verification.
     Event verificationEvent() => makeEvent(
-          id: 'verif',
-          tickets: [makeTicket(id: 'tv', requiredVerificationIds: ['verif_career'])],
-        );
+      id: 'verif',
+      tickets: [
+        makeTicket(id: 'tv', requiredVerificationIds: ['verif_career']),
+      ],
+    );
 
     test('18F — eligible only for open event', () {
       final profile = makeProfile(gender: 'female', age: 18);
-      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
+      final events = [
+        openEvent(),
+        maleOnlyEvent(),
+        maleAgeRestrictedEvent(),
+        verificationEvent(),
+      ];
 
-      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
+      final result = EligibilityFilter.filter(
+        events: events,
+        eligibilityData: profile,
+      );
 
       expect(result.map((e) => e.id).toList(), equals(['open']));
     });
 
-    test('25F — eligible for open event only (gender mismatch on male-only)', () {
-      final profile = makeProfile(gender: 'female', age: 25);
-      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
+    test(
+      '25F — eligible for open event only (gender mismatch on male-only)',
+      () {
+        final profile = makeProfile(gender: 'female', age: 25);
+        final events = [
+          openEvent(),
+          maleOnlyEvent(),
+          maleAgeRestrictedEvent(),
+          verificationEvent(),
+        ];
 
-      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
+        final result = EligibilityFilter.filter(
+          events: events,
+          eligibilityData: profile,
+        );
 
-      expect(result.map((e) => e.id).toList(), equals(['open']));
-    });
+        expect(result.map((e) => e.id).toList(), equals(['open']));
+      },
+    );
 
     test('35M — eligible for open, male-only, and age-restricted events', () {
       final profile = makeProfile(gender: 'male', age: 35);
-      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
-
-      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
-
-      expect(result.map((e) => e.id), containsAll(['open', 'male_only', 'age_restricted']));
-      expect(result.any((e) => e.id == 'verif'), isFalse);
-    });
-
-    test('42M — eligible for open and male-only events, not age-restricted (too old)', () {
-      final profile = makeProfile(gender: 'male', age: 42);
-      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
-
-      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
-
-      expect(result.map((e) => e.id), containsAll(['open', 'male_only']));
-      expect(result.any((e) => e.id == 'age_restricted'), isFalse);
-      expect(result.any((e) => e.id == 'verif'), isFalse);
-    });
-
-    test('all personas — eligible for open event (seed data regression guard)', () {
-      // Fix #1634: this is the core regression — all verified users must see open events.
-      final personas = [
-        makeProfile(gender: 'female', age: 18),
-        makeProfile(gender: 'female', age: 25),
-        makeProfile(gender: 'male', age: 35),
-        makeProfile(gender: 'male', age: 42),
+      final events = [
+        openEvent(),
+        maleOnlyEvent(),
+        maleAgeRestrictedEvent(),
+        verificationEvent(),
       ];
 
-      for (final profile in personas) {
+      final result = EligibilityFilter.filter(
+        events: events,
+        eligibilityData: profile,
+      );
+
+      expect(
+        result.map((e) => e.id),
+        containsAll(['open', 'male_only', 'age_restricted']),
+      );
+      expect(result.any((e) => e.id == 'verif'), isFalse);
+    });
+
+    test(
+      '42M — eligible for open and male-only events, not age-restricted (too old)',
+      () {
+        final profile = makeProfile(gender: 'male', age: 42);
+        final events = [
+          openEvent(),
+          maleOnlyEvent(),
+          maleAgeRestrictedEvent(),
+          verificationEvent(),
+        ];
+
         final result = EligibilityFilter.filter(
-          events: [openEvent()],
+          events: events,
           eligibilityData: profile,
         );
-        expect(result, hasLength(1), reason: 'All personas should see open events');
-      }
-    });
+
+        expect(result.map((e) => e.id), containsAll(['open', 'male_only']));
+        expect(result.any((e) => e.id == 'age_restricted'), isFalse);
+        expect(result.any((e) => e.id == 'verif'), isFalse);
+      },
+    );
+
+    test(
+      'all personas — eligible for open event (seed data regression guard)',
+      () {
+        // Fix #1634: this is the core regression — all verified users must see open events.
+        final personas = [
+          makeProfile(gender: 'female', age: 18),
+          makeProfile(gender: 'female', age: 25),
+          makeProfile(gender: 'male', age: 35),
+          makeProfile(gender: 'male', age: 42),
+        ];
+
+        for (final profile in personas) {
+          final result = EligibilityFilter.filter(
+            events: [openEvent()],
+            eligibilityData: profile,
+          );
+          expect(
+            result,
+            hasLength(1),
+            reason: 'All personas should see open events',
+          );
+        }
+      },
+    );
   });
 }

--- a/apps/app_user/test/src/logic/feed_state_provider_test.dart
+++ b/apps/app_user/test/src/logic/feed_state_provider_test.dart
@@ -123,6 +123,56 @@ void main() {
   });
 }
 
+// Fix #1634: regression group — verifies dev-env eligibility behavior.
+// _isProductionEnv is compile-time (String.fromEnvironment), so we cannot
+// override it at runtime. Instead, we simulate the dev-env state by overriding
+// activeFiltersProvider with a notifier that sets eligibilityEnabled: false.
+group('ActiveFilters dev-env regression (Fix #1634)', () {
+  test('ExploreFilters default has eligibilityEnabled false', () {
+    // In dev env _isProductionEnv == false → eligibilityEnabled starts false.
+    // ExploreFilters() mirrors that default — this guards against accidental
+    // change to the constructor's default value.
+    const filters = ExploreFilters();
+    expect(filters.eligibilityEnabled, isFalse,
+        reason: 'Default ExploreFilters must not enable eligibility filter');
+  });
+
+  test('feed loads events without eligibility filtering in dev-like env',
+      () async {
+    final mockRepo = MockEventRepository();
+    when(
+      () => mockRepo.getEventsByType(
+        type: any(named: 'type'),
+        offset: any(named: 'offset'),
+        latitude: any(named: 'latitude'),
+        longitude: any(named: 'longitude'),
+        limit: any(named: 'limit'),
+        blockedPartnerIds: any(named: 'blockedPartnerIds'),
+      ),
+    ).thenAnswer(
+      (_) async => List.generate(5, (i) => _createMinimalEvent(id: 'e_$i')),
+    );
+
+    final container = ProviderContainer(
+      overrides: [
+        eventRepositoryProvider.overrideWithValue(mockRepo),
+        activeFiltersProvider.overrideWith(_DevEnvFiltersNotifier.new),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final state = await container.read(recommendationFeedProvider.future);
+    // Dev env: eligibility not applied → all 5 events should be visible.
+    expect(state.events, hasLength(5));
+  });
+});
+
+/// Simulates dev-env ActiveFilters state: eligibility disabled, nearby disabled.
+class _DevEnvFiltersNotifier extends ActiveFilters {
+  @override
+  ExploreFilters build() => const ExploreFilters(eligibilityEnabled: false);
+}
+
 /// Notifier that starts with all filters disabled to avoid triggering
 /// location services or eligibility checks.
 class _NoFiltersNotifier extends ActiveFilters {

--- a/apps/app_user/test/src/logic/feed_state_provider_test.dart
+++ b/apps/app_user/test/src/logic/feed_state_provider_test.dart
@@ -132,45 +132,50 @@ void main() {
       // ExploreFilters() mirrors that default — this guards against accidental
       // change to the constructor's default value.
       const filters = ExploreFilters();
-      expect(filters.eligibilityEnabled, isFalse,
-          reason: 'Default ExploreFilters must not enable eligibility filter');
+      expect(
+        filters.eligibilityEnabled,
+        isFalse,
+        reason: 'Default ExploreFilters must not enable eligibility filter',
+      );
     });
 
-    test('feed loads events without eligibility filtering in dev-like env',
-        () async {
-      final mockRepo = MockEventRepository();
-      when(
-        () => mockRepo.getEventsByType(
-          type: any(named: 'type'),
-          offset: any(named: 'offset'),
-          latitude: any(named: 'latitude'),
-          longitude: any(named: 'longitude'),
-          limit: any(named: 'limit'),
-          blockedPartnerIds: any(named: 'blockedPartnerIds'),
-        ),
-      ).thenAnswer(
-        (_) async => List.generate(5, (i) => _createMinimalEvent(id: 'e_$i')),
-      );
+    test(
+      'feed loads events without eligibility filtering in dev-like env',
+      () async {
+        final mockRepo = MockEventRepository();
+        when(
+          () => mockRepo.getEventsByType(
+            type: any(named: 'type'),
+            offset: any(named: 'offset'),
+            latitude: any(named: 'latitude'),
+            longitude: any(named: 'longitude'),
+            limit: any(named: 'limit'),
+            blockedPartnerIds: any(named: 'blockedPartnerIds'),
+          ),
+        ).thenAnswer(
+          (_) async => List.generate(5, (i) => _createMinimalEvent(id: 'e_$i')),
+        );
 
-      final container = ProviderContainer(
-        overrides: [
-          eventRepositoryProvider.overrideWithValue(mockRepo),
-          activeFiltersProvider.overrideWith(_DevEnvFiltersNotifier.new),
-        ],
-      );
-      addTearDown(container.dispose);
+        final container = ProviderContainer(
+          overrides: [
+            eventRepositoryProvider.overrideWithValue(mockRepo),
+            activeFiltersProvider.overrideWith(_DevEnvFiltersNotifier.new),
+          ],
+        );
+        addTearDown(container.dispose);
 
-      final state = await container.read(recommendationFeedProvider.future);
-      // Dev env: eligibility not applied → all 5 events should be visible.
-      expect(state.events, hasLength(5));
-    });
+        final state = await container.read(recommendationFeedProvider.future);
+        // Dev env: eligibility not applied → all 5 events should be visible.
+        expect(state.events, hasLength(5));
+      },
+    );
   });
 }
 
 /// Simulates dev-env ActiveFilters state: eligibility disabled, nearby disabled.
 class _DevEnvFiltersNotifier extends ActiveFilters {
   @override
-  ExploreFilters build() => const ExploreFilters(eligibilityEnabled: false);
+  ExploreFilters build() => const ExploreFilters();
 }
 
 /// Notifier that starts with all filters disabled to avoid triggering

--- a/apps/app_user/test/src/logic/feed_state_provider_test.dart
+++ b/apps/app_user/test/src/logic/feed_state_provider_test.dart
@@ -121,51 +121,51 @@ void main() {
       });
     });
   });
+
+  // Fix #1634: regression group — verifies dev-env eligibility behavior.
+  // _isProductionEnv is compile-time (String.fromEnvironment), so we cannot
+  // override it at runtime. Instead, we simulate the dev-env state by overriding
+  // activeFiltersProvider with a notifier that sets eligibilityEnabled: false.
+  group('ActiveFilters dev-env regression (Fix #1634)', () {
+    test('ExploreFilters default has eligibilityEnabled false', () {
+      // In dev env _isProductionEnv == false → eligibilityEnabled starts false.
+      // ExploreFilters() mirrors that default — this guards against accidental
+      // change to the constructor's default value.
+      const filters = ExploreFilters();
+      expect(filters.eligibilityEnabled, isFalse,
+          reason: 'Default ExploreFilters must not enable eligibility filter');
+    });
+
+    test('feed loads events without eligibility filtering in dev-like env',
+        () async {
+      final mockRepo = MockEventRepository();
+      when(
+        () => mockRepo.getEventsByType(
+          type: any(named: 'type'),
+          offset: any(named: 'offset'),
+          latitude: any(named: 'latitude'),
+          longitude: any(named: 'longitude'),
+          limit: any(named: 'limit'),
+          blockedPartnerIds: any(named: 'blockedPartnerIds'),
+        ),
+      ).thenAnswer(
+        (_) async => List.generate(5, (i) => _createMinimalEvent(id: 'e_$i')),
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          eventRepositoryProvider.overrideWithValue(mockRepo),
+          activeFiltersProvider.overrideWith(_DevEnvFiltersNotifier.new),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final state = await container.read(recommendationFeedProvider.future);
+      // Dev env: eligibility not applied → all 5 events should be visible.
+      expect(state.events, hasLength(5));
+    });
+  });
 }
-
-// Fix #1634: regression group — verifies dev-env eligibility behavior.
-// _isProductionEnv is compile-time (String.fromEnvironment), so we cannot
-// override it at runtime. Instead, we simulate the dev-env state by overriding
-// activeFiltersProvider with a notifier that sets eligibilityEnabled: false.
-group('ActiveFilters dev-env regression (Fix #1634)', () {
-  test('ExploreFilters default has eligibilityEnabled false', () {
-    // In dev env _isProductionEnv == false → eligibilityEnabled starts false.
-    // ExploreFilters() mirrors that default — this guards against accidental
-    // change to the constructor's default value.
-    const filters = ExploreFilters();
-    expect(filters.eligibilityEnabled, isFalse,
-        reason: 'Default ExploreFilters must not enable eligibility filter');
-  });
-
-  test('feed loads events without eligibility filtering in dev-like env',
-      () async {
-    final mockRepo = MockEventRepository();
-    when(
-      () => mockRepo.getEventsByType(
-        type: any(named: 'type'),
-        offset: any(named: 'offset'),
-        latitude: any(named: 'latitude'),
-        longitude: any(named: 'longitude'),
-        limit: any(named: 'limit'),
-        blockedPartnerIds: any(named: 'blockedPartnerIds'),
-      ),
-    ).thenAnswer(
-      (_) async => List.generate(5, (i) => _createMinimalEvent(id: 'e_$i')),
-    );
-
-    final container = ProviderContainer(
-      overrides: [
-        eventRepositoryProvider.overrideWithValue(mockRepo),
-        activeFiltersProvider.overrideWith(_DevEnvFiltersNotifier.new),
-      ],
-    );
-    addTearDown(container.dispose);
-
-    final state = await container.read(recommendationFeedProvider.future);
-    // Dev env: eligibility not applied → all 5 events should be visible.
-    expect(state.events, hasLength(5));
-  });
-});
 
 /// Simulates dev-env ActiveFilters state: eligibility disabled, nearby disabled.
 class _DevEnvFiltersNotifier extends ActiveFilters {


### PR DESCRIPTION
## Summary

- `ENVIRONMENT=dev|local|development` 빌드에서 `eligibilityEnabled: true` 기본값으로 인해 시드 유저의 demographics(age/gender)가 이벤트 entry_group 조건과 불일치 시 홈 피드 이벤트가 0개 표시되던 문제 수정
- `_isProductionEnv` 빌드타임 상수로 production 빌드에서만 eligibility 필터 활성화
- 테스트 환경은 `ENVIRONMENT` dart-define 미설정 시 `defaultValue='production'` 적용 → 기존 테스트 그대로 통과

Closes #1634

## Root Cause

`ActiveFilters.build()`가 `eligibilityEnabled: true`를 기본값으로 반환하므로, dev 환경에서도 eligibility 필터가 동작함.  
`get_bulk_eligibility_data` RPC가 `user_profiles.is_verified=true`인 사용자를 반환해도, seeded 이벤트의 entry_group과 demographics 불일치 시 0개로 필터링됨.

## Test plan

- [ ] `ENVIRONMENT=dev` 빌드에서 홈 피드 이벤트 정상 표시 확인 (U-S03)
- [ ] `ENVIRONMENT=production` 빌드에서 eligibility 필터 정상 동작 확인
- [ ] `flutter test apps/app_user/test/src/features/explore/` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)