### PR TITLE
fix(db): INV-03 — 취소된 신청의 고아 participant 레코드 정리 (#1613)

### DIFF
--- a/supabase/migrations/20260420000001_cleanup_orphaned_participants.sql
+++ b/supabase/migrations/20260420000001_cleanup_orphaned_participants.sql
@@ -1,0 +1,17 @@
+-- Fix #1613: Clean up orphaned event_participants rows for cancelled applications
+--
+-- INV-03 invariant fires when event_participants rows exist for applications
+-- with status='cancelled'. The trigger (20260417000002) prevents new violations,
+-- but pre-existing orphaned rows must be removed manually.
+--
+-- This one-time cleanup deletes rows in event_participants that are linked to
+-- a cancelled event_applications row via (event_id, user_id).
+
+DELETE FROM public.event_participants ep
+WHERE EXISTS (
+  SELECT 1
+  FROM public.event_applications a
+  WHERE a.event_id = ep.event_id
+    AND a.user_id = ep.user_id
+    AND a.status = 'cancelled'
+);


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Summary

- `event_participants` 테이블에 `status='cancelled'`인 `event_applications`와 연결된 고아 레코드 1건이 존재하여 INV-03 불변조건 위반 중
- `20260417000002` 마이그레이션의 `on_application_cancel` 트리거가 신규 위반을 방지하지만, 기존 데이터는 정리하지 못함
- 이 PR은 기존 orphaned 데이터를 일회성 DELETE로 정리

## Root Cause

`on_application_cancel` 트리거는 `AFTER UPDATE`로 동작하므로 이미 cancelled 상태인 기존 rows에는 적용되지 않음.

## Test Plan

- [ ] migration 적용 후 INV-03 monitor 실행 결과 0건 확인
- [ ] `test-supabase` (pgTAP) 통과 확인

Closes #1613