### PR TITLE
fix(simulator): 미처리 예외 catch + daily 워크플로우 curl -sf → -s (#1620, #1635)

### DIFF
--- a/.github/workflows/daily-backend-simulation.yml
+++ b/.github/workflows/daily-backend-simulation.yml
@@ -36,31 +36,49 @@ jobs:
 
       - name: Upload seed images
         run: |
-          curl -sf -X POST \
+          # Fix #1635: use -s (not -sf) so error response body is printed before failing
+          http_code=$(curl -s -o /tmp/seed_response.json -w "%{http_code}" -X POST \
             "${{ secrets.SUPABASE_DEV_URL }}/functions/v1/dev-seed?mode=images-only" \
             -H "Authorization: Bearer ${{ secrets.SUPABASE_DEV_SECRET_KEY }}" \
-            --max-time 30
+            --max-time 30)
+          cat /tmp/seed_response.json
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "HTTP $http_code — dev-seed images-only returned an error"
+            exit 1
+          fi
 
       - name: Create parties and events
         run: |
           # Fix #705: backend-simulator create phase needs more time (cold start + data growth)
-          curl -sf -X POST \
+          # Fix #1635: use -s (not -sf) so error response body is printed before failing
+          http_code=$(curl -s -o /tmp/sim_response.json -w "%{http_code}" -X POST \
             "${{ secrets.SUPABASE_DEV_URL }}/functions/v1/backend-simulator" \
             -H "Authorization: Bearer ${{ secrets.SUPABASE_DEV_SECRET_KEY }}" \
             -H "Content-Type: application/json" \
             -d '{"phase":"create"}' \
-            --max-time 300
+            --max-time 300)
+          cat /tmp/sim_response.json
+          if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "HTTP $http_code — backend-simulator phase=create returned an error"
+            exit 1
+          fi
 
       - name: Run full simulation (approve → refund → run → settle)
         run: |
+          # Fix #1635: use -s (not -sf) so error response body is printed before failing
           for phase in approve refund run settle; do
             echo "▶ Running phase: $phase"
-            curl -sf -X POST \
+            http_code=$(curl -s -o /tmp/sim_response.json -w "%{http_code}" -X POST \
               "${{ secrets.SUPABASE_DEV_URL }}/functions/v1/backend-simulator" \
               -H "Authorization: Bearer ${{ secrets.SUPABASE_DEV_SECRET_KEY }}" \
               -H "Content-Type: application/json" \
               -d "{\"phase\":\"$phase\"}" \
-              --max-time 120
+              --max-time 120)
+            cat /tmp/sim_response.json
+            if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+              echo "HTTP $http_code — backend-simulator phase=$phase returned an error"
+              exit 1
+            fi
             echo "✅ Phase $phase complete"
           done
 

--- a/apps/app_user/test/src/features/explore/logic/eligibility_filter_test.dart
+++ b/apps/app_user/test/src/features/explore/logic/eligibility_filter_test.dart
@@ -254,77 +254,89 @@ void main() {
       expect(result, isEmpty);
     });
 
-    test('filters out events when user birth year is below entry group minimum', () {
-      // Fix #1634: age restriction — user born 1980 cannot enter group requiring birthYearMin 1990
-      final events = [
-        makeEvent(
-          tickets: [makeTicket(targetEntryGroupIds: ['g1'])],
-          entryGroups: [
-            const EntryGroup(
-              id: 'g1',
-              eventId: 'e1',
-              gender: 'male',
-              birthYearMin: 1990,
-              birthYearMax: 2005,
-            ),
-          ],
-        ),
-      ];
-      final data = BulkEligibilityData.fromJson({
-        'user_profile': {
-          'gender': 'male',
-          'birth_year': 1980,
-          'is_verified': true,
-        },
-        'approved_verifications': <dynamic>[],
-      });
+    test(
+      'filters out events when user birth year is below entry group minimum',
+      () {
+        // Fix #1634: age restriction — user born 1980 cannot enter group requiring birthYearMin 1990
+        final events = [
+          makeEvent(
+            tickets: [
+              makeTicket(targetEntryGroupIds: ['g1']),
+            ],
+            entryGroups: [
+              const EntryGroup(
+                id: 'g1',
+                eventId: 'e1',
+                gender: 'male',
+                birthYearMin: 1990,
+                birthYearMax: 2005,
+              ),
+            ],
+          ),
+        ];
+        final data = BulkEligibilityData.fromJson({
+          'user_profile': {
+            'gender': 'male',
+            'birth_year': 1980,
+            'is_verified': true,
+          },
+          'approved_verifications': <dynamic>[],
+        });
 
-      final result = EligibilityFilter.filter(
-        events: events,
-        eligibilityData: data,
-      );
+        final result = EligibilityFilter.filter(
+          events: events,
+          eligibilityData: data,
+        );
 
-      expect(result, isEmpty);
-    });
+        expect(result, isEmpty);
+      },
+    );
 
-    test('filters out events when user birth year exceeds entry group maximum', () {
-      // Fix #1634: age restriction — user born 2010 cannot enter group with birthYearMax 2005
-      final events = [
-        makeEvent(
-          tickets: [makeTicket(targetEntryGroupIds: ['g1'])],
-          entryGroups: [
-            const EntryGroup(
-              id: 'g1',
-              eventId: 'e1',
-              gender: 'male',
-              birthYearMin: 1990,
-              birthYearMax: 2005,
-            ),
-          ],
-        ),
-      ];
-      final data = BulkEligibilityData.fromJson({
-        'user_profile': {
-          'gender': 'male',
-          'birth_year': 2010,
-          'is_verified': true,
-        },
-        'approved_verifications': <dynamic>[],
-      });
+    test(
+      'filters out events when user birth year exceeds entry group maximum',
+      () {
+        // Fix #1634: age restriction — user born 2010 cannot enter group with birthYearMax 2005
+        final events = [
+          makeEvent(
+            tickets: [
+              makeTicket(targetEntryGroupIds: ['g1']),
+            ],
+            entryGroups: [
+              const EntryGroup(
+                id: 'g1',
+                eventId: 'e1',
+                gender: 'male',
+                birthYearMin: 1990,
+                birthYearMax: 2005,
+              ),
+            ],
+          ),
+        ];
+        final data = BulkEligibilityData.fromJson({
+          'user_profile': {
+            'gender': 'male',
+            'birth_year': 2010,
+            'is_verified': true,
+          },
+          'approved_verifications': <dynamic>[],
+        });
 
-      final result = EligibilityFilter.filter(
-        events: events,
-        eligibilityData: data,
-      );
+        final result = EligibilityFilter.filter(
+          events: events,
+          eligibilityData: data,
+        );
 
-      expect(result, isEmpty);
-    });
+        expect(result, isEmpty);
+      },
+    );
 
     test('filters out events requiring verification when user lacks it', () {
       // Fix #1634: verification requirement — event requires career verification
       final events = [
         makeEvent(
-          tickets: [makeTicket(requiredVerificationIds: ['verif_career'])],
+          tickets: [
+            makeTicket(requiredVerificationIds: ['verif_career']),
+          ],
         ),
       ];
       final data = BulkEligibilityData.fromJson({
@@ -348,7 +360,9 @@ void main() {
       // Fix #1634: verification — user with approved career verification is eligible
       final events = [
         makeEvent(
-          tickets: [makeTicket(requiredVerificationIds: ['verif_career'])],
+          tickets: [
+            makeTicket(requiredVerificationIds: ['verif_career']),
+          ],
         ),
       ];
       final data = BulkEligibilityData.fromJson({
@@ -400,87 +414,143 @@ void main() {
 
     // Male-only, no age restriction.
     Event maleOnlyEvent() => makeEvent(
-          id: 'male_only',
-          tickets: [makeTicket(id: 'tm', targetEntryGroupIds: ['gm'])],
-          entryGroups: [const EntryGroup(id: 'gm', eventId: 'male_only', gender: 'male')],
-        );
+      id: 'male_only',
+      tickets: [
+        makeTicket(id: 'tm', targetEntryGroupIds: ['gm']),
+      ],
+      entryGroups: [
+        const EntryGroup(id: 'gm', eventId: 'male_only', gender: 'male'),
+      ],
+    );
 
     // Male-only with age range 25–40. birthYearMin = currentYear-40, birthYearMax = currentYear-25.
     Event maleAgeRestrictedEvent() => makeEvent(
-          id: 'age_restricted',
-          tickets: [makeTicket(id: 'ta', targetEntryGroupIds: ['ga'])],
-          entryGroups: [
-            EntryGroup(
-              id: 'ga',
-              eventId: 'age_restricted',
-              gender: 'male',
-              birthYearMin: currentYear - 40,
-              birthYearMax: currentYear - 25,
-            ),
-          ],
-        );
+      id: 'age_restricted',
+      tickets: [
+        makeTicket(id: 'ta', targetEntryGroupIds: ['ga']),
+      ],
+      entryGroups: [
+        EntryGroup(
+          id: 'ga',
+          eventId: 'age_restricted',
+          gender: 'male',
+          birthYearMin: currentYear - 40,
+          birthYearMax: currentYear - 25,
+        ),
+      ],
+    );
 
     // Requires career verification.
     Event verificationEvent() => makeEvent(
-          id: 'verif',
-          tickets: [makeTicket(id: 'tv', requiredVerificationIds: ['verif_career'])],
-        );
+      id: 'verif',
+      tickets: [
+        makeTicket(id: 'tv', requiredVerificationIds: ['verif_career']),
+      ],
+    );
 
     test('18F — eligible only for open event', () {
       final profile = makeProfile(gender: 'female', age: 18);
-      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
+      final events = [
+        openEvent(),
+        maleOnlyEvent(),
+        maleAgeRestrictedEvent(),
+        verificationEvent(),
+      ];
 
-      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
+      final result = EligibilityFilter.filter(
+        events: events,
+        eligibilityData: profile,
+      );
 
       expect(result.map((e) => e.id).toList(), equals(['open']));
     });
 
-    test('25F — eligible for open event only (gender mismatch on male-only)', () {
-      final profile = makeProfile(gender: 'female', age: 25);
-      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
+    test(
+      '25F — eligible for open event only (gender mismatch on male-only)',
+      () {
+        final profile = makeProfile(gender: 'female', age: 25);
+        final events = [
+          openEvent(),
+          maleOnlyEvent(),
+          maleAgeRestrictedEvent(),
+          verificationEvent(),
+        ];
 
-      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
+        final result = EligibilityFilter.filter(
+          events: events,
+          eligibilityData: profile,
+        );
 
-      expect(result.map((e) => e.id).toList(), equals(['open']));
-    });
+        expect(result.map((e) => e.id).toList(), equals(['open']));
+      },
+    );
 
     test('35M — eligible for open, male-only, and age-restricted events', () {
       final profile = makeProfile(gender: 'male', age: 35);
-      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
-
-      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
-
-      expect(result.map((e) => e.id), containsAll(['open', 'male_only', 'age_restricted']));
-      expect(result.any((e) => e.id == 'verif'), isFalse);
-    });
-
-    test('42M — eligible for open and male-only events, not age-restricted (too old)', () {
-      final profile = makeProfile(gender: 'male', age: 42);
-      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
-
-      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
-
-      expect(result.map((e) => e.id), containsAll(['open', 'male_only']));
-      expect(result.any((e) => e.id == 'age_restricted'), isFalse);
-      expect(result.any((e) => e.id == 'verif'), isFalse);
-    });
-
-    test('all personas — eligible for open event (seed data regression guard)', () {
-      // Fix #1634: this is the core regression — all verified users must see open events.
-      final personas = [
-        makeProfile(gender: 'female', age: 18),
-        makeProfile(gender: 'female', age: 25),
-        makeProfile(gender: 'male', age: 35),
-        makeProfile(gender: 'male', age: 42),
+      final events = [
+        openEvent(),
+        maleOnlyEvent(),
+        maleAgeRestrictedEvent(),
+        verificationEvent(),
       ];
 
-      for (final profile in personas) {
+      final result = EligibilityFilter.filter(
+        events: events,
+        eligibilityData: profile,
+      );
+
+      expect(
+        result.map((e) => e.id),
+        containsAll(['open', 'male_only', 'age_restricted']),
+      );
+      expect(result.any((e) => e.id == 'verif'), isFalse);
+    });
+
+    test(
+      '42M — eligible for open and male-only events, not age-restricted (too old)',
+      () {
+        final profile = makeProfile(gender: 'male', age: 42);
+        final events = [
+          openEvent(),
+          maleOnlyEvent(),
+          maleAgeRestrictedEvent(),
+          verificationEvent(),
+        ];
+
         final result = EligibilityFilter.filter(
-          events: [openEvent()],
+          events: events,
           eligibilityData: profile,
         );
-        expect(result, hasLength(1), reason: 'All personas should see open events');
-      }
-    });
+
+        expect(result.map((e) => e.id), containsAll(['open', 'male_only']));
+        expect(result.any((e) => e.id == 'age_restricted'), isFalse);
+        expect(result.any((e) => e.id == 'verif'), isFalse);
+      },
+    );
+
+    test(
+      'all personas — eligible for open event (seed data regression guard)',
+      () {
+        // Fix #1634: this is the core regression — all verified users must see open events.
+        final personas = [
+          makeProfile(gender: 'female', age: 18),
+          makeProfile(gender: 'female', age: 25),
+          makeProfile(gender: 'male', age: 35),
+          makeProfile(gender: 'male', age: 42),
+        ];
+
+        for (final profile in personas) {
+          final result = EligibilityFilter.filter(
+            events: [openEvent()],
+            eligibilityData: profile,
+          );
+          expect(
+            result,
+            hasLength(1),
+            reason: 'All personas should see open events',
+          );
+        }
+      },
+    );
   });
 }

--- a/supabase/functions/backend-simulator/e2e_test.ts
+++ b/supabase/functions/backend-simulator/e2e_test.ts
@@ -661,5 +661,42 @@ Deno.test({
   },
 });
 
+// Fix #1620: uncaught exception in dev → JSON error response (not bare 500)
+Deno.test({
+  name: "backend-simulator - unhandled exception returns JSON error (not bare 500)",
+  fn: async () => {
+    const h = await getHandler();
+
+    // SIM_USER_PASSWORD missing causes simCreateParties to throw.
+    // Before the catch block fix, Deno returned a bare "Internal Server Error"
+    // text body. After the fix, the response is JSON with the error message.
+    await withEnv(
+      {
+        ENVIRONMENT: "dev",
+        SUPABASE_URL: "http://localhost:54321",
+        SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+        SUPABASE_ANON_KEY: "test-anon-key",
+        SIM_USER_PASSWORD: undefined, // intentionally missing to trigger throw
+      },
+      async () => {
+        const { fetchMock } = createFetchMock([
+          {
+            matcher: (req) => req.url.includes("/rest/v1/partners"),
+            handler: (req) => jsonResponse(wrapSingle(req, [{ id: "partner-1" }])),
+          },
+        ]);
+        await withMockedFetch(fetchMock, async () => {
+          const response = await h(jsonRequest("http://localhost", {}));
+          assertEquals(response.status, 500);
+          const contentType = response.headers.get("content-type") ?? "";
+          assertStringIncludes(contentType, "application/json");
+          const body = await readJson(response);
+          assertStringIncludes(body.error ?? "", "SIM_USER_PASSWORD");
+        });
+      },
+    );
+  },
+});
+
 // Note: auto-complete cron job registration and SQL condition (end_time < now())
 // are tested at the database level in supabase/tests/database/59_auto_complete_cron_test.sql.

--- a/supabase/functions/backend-simulator/index.ts
+++ b/supabase/functions/backend-simulator/index.ts
@@ -518,6 +518,11 @@ Deno.serve(async (req: Request): Promise<Response> => {
     log({ function: FN, level: "error", message: "unhandled exception", metadata: { runId, error: message } });
     return errorResponse(`Unhandled exception: ${message}`, 500);
   } finally {
-    await flush();
+    // Wrap flush so a log-flush failure cannot replace the JSON error response.
+    try {
+      await flush();
+    } catch (flushErr) {
+      console.error("[backend-simulator] failed to flush logs", flushErr);
+    }
   }
 });

--- a/supabase/functions/backend-simulator/index.ts
+++ b/supabase/functions/backend-simulator/index.ts
@@ -510,6 +510,13 @@ Deno.serve(async (req: Request): Promise<Response> => {
     github_issue_url: githubIssueUrl,
   });
 
+  } catch (err) {
+    // Fix #1620: Unhandled exceptions caused Deno to return a bare "Internal
+    // Server Error" with no body, making the root cause invisible in CI logs.
+    // Catch here to return a JSON error response with the message.
+    const message = err instanceof Error ? err.message : String(err);
+    log({ function: FN, level: "error", message: "unhandled exception", metadata: { runId, error: message } });
+    return errorResponse(`Unhandled exception: ${message}`, 500);
   } finally {
     await flush();
   }


### PR DESCRIPTION
## Summary

### Fix #1620 — backend-simulator 미처리 예외 JSON 응답
- \`try/finally\` 블록에 \`catch\`가 없어 내부 예외가 Deno 기본 처리기를 거쳐 body 없는 \`"Internal Server Error"\` 500으로 반환됐음
- \`catch\` 블록 추가: 예외 메시지를 Axiom에 로깅 후 JSON 에러 응답 반환
- 회귀 테스트: \`SIM_USER_PASSWORD\` 미설정 시 JSON + \`error\` 필드 검증

### Fix #1635 — daily-backend-simulation.yml curl -sf → -s
- \`curl -sf\`는 4xx/5xx 응답에서 exit 22를 반환하며 응답 body를 숨겼음
- PR #1596에서 hourly 워크플로우에 적용된 패턴을 daily 워크플로우에도 동일하게 적용
- 이제 실패 시 JSON 에러 body가 CI 로그에 출력됨

Closes #1620
Closes #1635

## Test plan

- [ ] Deno EF 테스트 통과 (e2e_test.ts에 새 테스트 추가)
- [ ] 다음 hourly/daily 실행 시 JSON 에러 응답으로 실제 원인 노출 확인