### PR TITLE
fix(ci): seed-dev.yml db.{ref}.supabase.co → pooler 엔드포인트 (#1621)

### DIFF
--- a/.github/workflows/seed-dev.yml
+++ b/.github/workflows/seed-dev.yml
@@ -47,11 +47,14 @@ jobs:
         env:
           PGPASSWORD: ${{ secrets.SUPABASE_DEV_DB_PASSWORD }}
           SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_DEV_PROJECT_ID }}
+          # Fix #1621: db.{ref}.supabase.co → pooler endpoint (IPv4).
+          # GitHub runners cannot reach IPv6-only endpoints.
+          # Fix #1553: aws-0 → aws-1 (Supabase infra migration)
+          POOLER_HOST: aws-1-ap-northeast-2.pooler.supabase.com
         run: |
-          # PGPASSWORD env is read by psql automatically — omit password from URI
-          # so special characters in the secret never need percent-encoding.
+          # Pooler requires tenant-qualified username: postgres.{project_ref}
           psql \
-            "postgresql://postgres@db.${SUPABASE_PROJECT_ID}.supabase.co:5432/postgres?sslmode=require" \
+            "postgresql://postgres.${SUPABASE_PROJECT_ID}@${POOLER_HOST}:5432/postgres?sslmode=require" \
             -f supabase/seed.dev.sql
 
 


### PR DESCRIPTION
## Summary

- `seed-dev.yml`이 `db.{ref}.supabase.co:5432`로 psql 연결 시도
- GitHub Actions runner는 IPv6 outbound 불가 → `Network is unreachable` 오류
- `supabase-deploy.yml`의 Fix #1228 패턴 동일 적용: pooler 엔드포인트로 전환
- Pooler는 IPv4 ELB A 레코드 유지, tenant-qualified username 사용

Closes #1621

## Test plan

- [ ] seed-dev 워크플로우 수동 트리거 후 psql 연결 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)