### PR TITLE
fix(partner): 이번 주 성과 null 지표 '-' → '₩0'/'0%' (#1611)

### DIFF
--- a/apps/app_partner/lib/src/features/home/widgets/weekly_stats_row.dart
+++ b/apps/app_partner/lib/src/features/home/widgets/weekly_stats_row.dart
@@ -15,11 +15,11 @@ class WeeklyStatsRow extends StatelessWidget {
     super.key,
   });
 
-  /// Null means data is not yet available — UI shows '-' placeholder.
+  /// Null means data is not yet available — UI shows zero value.
   final int? totalRevenue;
   final int totalApplications;
 
-  /// Null means data is not yet available — UI shows '-' placeholder.
+  /// Null means data is not yet available — UI shows zero value.
   final double? checkinRate;
   final double? revenueChange;
   final double? applicationChange;
@@ -38,9 +38,8 @@ class WeeklyStatsRow extends StatelessWidget {
       child: Row(
         children: [
           _StatItem(
-            value: totalRevenue != null
-                ? '₩${_formatCompact(totalRevenue!)}'
-                : '-',
+            // Fix #1611: null → '₩0' (no-data week looks dead with '-')
+            value: '₩${_formatCompact(totalRevenue ?? 0)}',
             label: '매출',
             change: revenueChange,
             isFirst: true,
@@ -53,7 +52,8 @@ class WeeklyStatsRow extends StatelessWidget {
             theme: theme,
           ),
           _StatItem(
-            value: checkinRate != null ? '${checkinRate!.round()}%' : '-',
+            // Fix #1611: null → '0%' (no-data week looks dead with '-')
+            value: '${(checkinRate ?? 0).round()}%',
             label: '체크인율',
             change: checkinRateChange,
             isLast: true,

--- a/apps/app_partner/test/src/features/home/widgets/weekly_stats_row_test.dart
+++ b/apps/app_partner/test/src/features/home/widgets/weekly_stats_row_test.dart
@@ -29,6 +29,28 @@ void main() {
       },
     );
 
+    // Fix #1611: null values show zero, not '-'
+    testWidgets(
+      'shows ₩0 and 0% when revenue and checkinRate are null',
+      (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(
+              body: WeeklyStatsRow(
+                totalRevenue: null,
+                totalApplications: 0,
+                checkinRate: null,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('₩0'), findsOneWidget);
+        expect(find.text('0%'), findsOneWidget);
+        expect(find.text('-'), findsNothing);
+      },
+    );
+
     testWidgets(
       'shows green positive change text when change is greater than zero',
       (tester) async {

--- a/apps/app_user/test/src/features/explore/logic/eligibility_filter_test.dart
+++ b/apps/app_user/test/src/features/explore/logic/eligibility_filter_test.dart
@@ -254,77 +254,89 @@ void main() {
       expect(result, isEmpty);
     });
 
-    test('filters out events when user birth year is below entry group minimum', () {
-      // Fix #1634: age restriction — user born 1980 cannot enter group requiring birthYearMin 1990
-      final events = [
-        makeEvent(
-          tickets: [makeTicket(targetEntryGroupIds: ['g1'])],
-          entryGroups: [
-            const EntryGroup(
-              id: 'g1',
-              eventId: 'e1',
-              gender: 'male',
-              birthYearMin: 1990,
-              birthYearMax: 2005,
-            ),
-          ],
-        ),
-      ];
-      final data = BulkEligibilityData.fromJson({
-        'user_profile': {
-          'gender': 'male',
-          'birth_year': 1980,
-          'is_verified': true,
-        },
-        'approved_verifications': <dynamic>[],
-      });
+    test(
+      'filters out events when user birth year is below entry group minimum',
+      () {
+        // Fix #1634: age restriction — user born 1980 cannot enter group requiring birthYearMin 1990
+        final events = [
+          makeEvent(
+            tickets: [
+              makeTicket(targetEntryGroupIds: ['g1']),
+            ],
+            entryGroups: [
+              const EntryGroup(
+                id: 'g1',
+                eventId: 'e1',
+                gender: 'male',
+                birthYearMin: 1990,
+                birthYearMax: 2005,
+              ),
+            ],
+          ),
+        ];
+        final data = BulkEligibilityData.fromJson({
+          'user_profile': {
+            'gender': 'male',
+            'birth_year': 1980,
+            'is_verified': true,
+          },
+          'approved_verifications': <dynamic>[],
+        });
 
-      final result = EligibilityFilter.filter(
-        events: events,
-        eligibilityData: data,
-      );
+        final result = EligibilityFilter.filter(
+          events: events,
+          eligibilityData: data,
+        );
 
-      expect(result, isEmpty);
-    });
+        expect(result, isEmpty);
+      },
+    );
 
-    test('filters out events when user birth year exceeds entry group maximum', () {
-      // Fix #1634: age restriction — user born 2010 cannot enter group with birthYearMax 2005
-      final events = [
-        makeEvent(
-          tickets: [makeTicket(targetEntryGroupIds: ['g1'])],
-          entryGroups: [
-            const EntryGroup(
-              id: 'g1',
-              eventId: 'e1',
-              gender: 'male',
-              birthYearMin: 1990,
-              birthYearMax: 2005,
-            ),
-          ],
-        ),
-      ];
-      final data = BulkEligibilityData.fromJson({
-        'user_profile': {
-          'gender': 'male',
-          'birth_year': 2010,
-          'is_verified': true,
-        },
-        'approved_verifications': <dynamic>[],
-      });
+    test(
+      'filters out events when user birth year exceeds entry group maximum',
+      () {
+        // Fix #1634: age restriction — user born 2010 cannot enter group with birthYearMax 2005
+        final events = [
+          makeEvent(
+            tickets: [
+              makeTicket(targetEntryGroupIds: ['g1']),
+            ],
+            entryGroups: [
+              const EntryGroup(
+                id: 'g1',
+                eventId: 'e1',
+                gender: 'male',
+                birthYearMin: 1990,
+                birthYearMax: 2005,
+              ),
+            ],
+          ),
+        ];
+        final data = BulkEligibilityData.fromJson({
+          'user_profile': {
+            'gender': 'male',
+            'birth_year': 2010,
+            'is_verified': true,
+          },
+          'approved_verifications': <dynamic>[],
+        });
 
-      final result = EligibilityFilter.filter(
-        events: events,
-        eligibilityData: data,
-      );
+        final result = EligibilityFilter.filter(
+          events: events,
+          eligibilityData: data,
+        );
 
-      expect(result, isEmpty);
-    });
+        expect(result, isEmpty);
+      },
+    );
 
     test('filters out events requiring verification when user lacks it', () {
       // Fix #1634: verification requirement — event requires career verification
       final events = [
         makeEvent(
-          tickets: [makeTicket(requiredVerificationIds: ['verif_career'])],
+          tickets: [
+            makeTicket(requiredVerificationIds: ['verif_career']),
+          ],
         ),
       ];
       final data = BulkEligibilityData.fromJson({
@@ -348,7 +360,9 @@ void main() {
       // Fix #1634: verification — user with approved career verification is eligible
       final events = [
         makeEvent(
-          tickets: [makeTicket(requiredVerificationIds: ['verif_career'])],
+          tickets: [
+            makeTicket(requiredVerificationIds: ['verif_career']),
+          ],
         ),
       ];
       final data = BulkEligibilityData.fromJson({
@@ -400,87 +414,143 @@ void main() {
 
     // Male-only, no age restriction.
     Event maleOnlyEvent() => makeEvent(
-          id: 'male_only',
-          tickets: [makeTicket(id: 'tm', targetEntryGroupIds: ['gm'])],
-          entryGroups: [const EntryGroup(id: 'gm', eventId: 'male_only', gender: 'male')],
-        );
+      id: 'male_only',
+      tickets: [
+        makeTicket(id: 'tm', targetEntryGroupIds: ['gm']),
+      ],
+      entryGroups: [
+        const EntryGroup(id: 'gm', eventId: 'male_only', gender: 'male'),
+      ],
+    );
 
     // Male-only with age range 25–40. birthYearMin = currentYear-40, birthYearMax = currentYear-25.
     Event maleAgeRestrictedEvent() => makeEvent(
-          id: 'age_restricted',
-          tickets: [makeTicket(id: 'ta', targetEntryGroupIds: ['ga'])],
-          entryGroups: [
-            EntryGroup(
-              id: 'ga',
-              eventId: 'age_restricted',
-              gender: 'male',
-              birthYearMin: currentYear - 40,
-              birthYearMax: currentYear - 25,
-            ),
-          ],
-        );
+      id: 'age_restricted',
+      tickets: [
+        makeTicket(id: 'ta', targetEntryGroupIds: ['ga']),
+      ],
+      entryGroups: [
+        EntryGroup(
+          id: 'ga',
+          eventId: 'age_restricted',
+          gender: 'male',
+          birthYearMin: currentYear - 40,
+          birthYearMax: currentYear - 25,
+        ),
+      ],
+    );
 
     // Requires career verification.
     Event verificationEvent() => makeEvent(
-          id: 'verif',
-          tickets: [makeTicket(id: 'tv', requiredVerificationIds: ['verif_career'])],
-        );
+      id: 'verif',
+      tickets: [
+        makeTicket(id: 'tv', requiredVerificationIds: ['verif_career']),
+      ],
+    );
 
     test('18F — eligible only for open event', () {
       final profile = makeProfile(gender: 'female', age: 18);
-      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
+      final events = [
+        openEvent(),
+        maleOnlyEvent(),
+        maleAgeRestrictedEvent(),
+        verificationEvent(),
+      ];
 
-      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
+      final result = EligibilityFilter.filter(
+        events: events,
+        eligibilityData: profile,
+      );
 
       expect(result.map((e) => e.id).toList(), equals(['open']));
     });
 
-    test('25F — eligible for open event only (gender mismatch on male-only)', () {
-      final profile = makeProfile(gender: 'female', age: 25);
-      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
+    test(
+      '25F — eligible for open event only (gender mismatch on male-only)',
+      () {
+        final profile = makeProfile(gender: 'female', age: 25);
+        final events = [
+          openEvent(),
+          maleOnlyEvent(),
+          maleAgeRestrictedEvent(),
+          verificationEvent(),
+        ];
 
-      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
+        final result = EligibilityFilter.filter(
+          events: events,
+          eligibilityData: profile,
+        );
 
-      expect(result.map((e) => e.id).toList(), equals(['open']));
-    });
+        expect(result.map((e) => e.id).toList(), equals(['open']));
+      },
+    );
 
     test('35M — eligible for open, male-only, and age-restricted events', () {
       final profile = makeProfile(gender: 'male', age: 35);
-      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
-
-      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
-
-      expect(result.map((e) => e.id), containsAll(['open', 'male_only', 'age_restricted']));
-      expect(result.any((e) => e.id == 'verif'), isFalse);
-    });
-
-    test('42M — eligible for open and male-only events, not age-restricted (too old)', () {
-      final profile = makeProfile(gender: 'male', age: 42);
-      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
-
-      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
-
-      expect(result.map((e) => e.id), containsAll(['open', 'male_only']));
-      expect(result.any((e) => e.id == 'age_restricted'), isFalse);
-      expect(result.any((e) => e.id == 'verif'), isFalse);
-    });
-
-    test('all personas — eligible for open event (seed data regression guard)', () {
-      // Fix #1634: this is the core regression — all verified users must see open events.
-      final personas = [
-        makeProfile(gender: 'female', age: 18),
-        makeProfile(gender: 'female', age: 25),
-        makeProfile(gender: 'male', age: 35),
-        makeProfile(gender: 'male', age: 42),
+      final events = [
+        openEvent(),
+        maleOnlyEvent(),
+        maleAgeRestrictedEvent(),
+        verificationEvent(),
       ];
 
-      for (final profile in personas) {
+      final result = EligibilityFilter.filter(
+        events: events,
+        eligibilityData: profile,
+      );
+
+      expect(
+        result.map((e) => e.id),
+        containsAll(['open', 'male_only', 'age_restricted']),
+      );
+      expect(result.any((e) => e.id == 'verif'), isFalse);
+    });
+
+    test(
+      '42M — eligible for open and male-only events, not age-restricted (too old)',
+      () {
+        final profile = makeProfile(gender: 'male', age: 42);
+        final events = [
+          openEvent(),
+          maleOnlyEvent(),
+          maleAgeRestrictedEvent(),
+          verificationEvent(),
+        ];
+
         final result = EligibilityFilter.filter(
-          events: [openEvent()],
+          events: events,
           eligibilityData: profile,
         );
-        expect(result, hasLength(1), reason: 'All personas should see open events');
-      }
-    });
+
+        expect(result.map((e) => e.id), containsAll(['open', 'male_only']));
+        expect(result.any((e) => e.id == 'age_restricted'), isFalse);
+        expect(result.any((e) => e.id == 'verif'), isFalse);
+      },
+    );
+
+    test(
+      'all personas — eligible for open event (seed data regression guard)',
+      () {
+        // Fix #1634: this is the core regression — all verified users must see open events.
+        final personas = [
+          makeProfile(gender: 'female', age: 18),
+          makeProfile(gender: 'female', age: 25),
+          makeProfile(gender: 'male', age: 35),
+          makeProfile(gender: 'male', age: 42),
+        ];
+
+        for (final profile in personas) {
+          final result = EligibilityFilter.filter(
+            events: [openEvent()],
+            eligibilityData: profile,
+          );
+          expect(
+            result,
+            hasLength(1),
+            reason: 'All personas should see open events',
+          );
+        }
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

- 이번 주 성과 섹션에서 `totalRevenue`/`checkinRate`가 null일 때 `'-'`로 표시 → UI가 죽어있는 느낌
- `'-'` 대신 `'₩0'`/`'0%'` 표시: 이 주에 활동이 없음을 명확히 전달
- `totalApplications`(non-nullable)는 이미 `'0'` 표시 → 이제 세 지표 모두 일관성 확보
- 테스트 추가: null 입력 시 `'-'` 미표시 + `'₩0'`/`'0%'` 표시 검증

Closes #1611

## UX 가이드

**ux-designer 승인**: [needs-uiux-claude-1 가이드](https://github.com/Mark-Yun/minglit/issues/1611#issuecomment-4281129324)

- `'₩0'`/`'0%'` zero-state 표현이 `totalApplications`와의 일관성 확보
- 스크린 리더 접근성 개선 (`'-'` 은 의미 불명, `'₩0'`/`'0%'` 은 명확)
- 데이터 없음/로딩/에러 상태는 상위 위젯에서 별도 처리되므로 이 위젯은 zero-state만 다룸

## Test plan

- [ ] Flutter analyze 통과
- [ ] Widget 테스트 통과 (null → ₩0/0% 신규 테스트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
