### PR TITLE
test(eligibility): age, verification, and persona matrix tests (#1634)

### DIFF
--- a/apps/app_user/test/src/features/explore/logic/eligibility_filter_test.dart
+++ b/apps/app_user/test/src/features/explore/logic/eligibility_filter_test.dart
@@ -253,5 +253,234 @@ void main() {
 
       expect(result, isEmpty);
     });
+
+    test('filters out events when user birth year is below entry group minimum', () {
+      // Fix #1634: age restriction — user born 1980 cannot enter group requiring birthYearMin 1990
+      final events = [
+        makeEvent(
+          tickets: [makeTicket(targetEntryGroupIds: ['g1'])],
+          entryGroups: [
+            const EntryGroup(
+              id: 'g1',
+              eventId: 'e1',
+              gender: 'male',
+              birthYearMin: 1990,
+              birthYearMax: 2005,
+            ),
+          ],
+        ),
+      ];
+      final data = BulkEligibilityData.fromJson({
+        'user_profile': {
+          'gender': 'male',
+          'birth_year': 1980,
+          'is_verified': true,
+        },
+        'approved_verifications': <dynamic>[],
+      });
+
+      final result = EligibilityFilter.filter(
+        events: events,
+        eligibilityData: data,
+      );
+
+      expect(result, isEmpty);
+    });
+
+    test('filters out events when user birth year exceeds entry group maximum', () {
+      // Fix #1634: age restriction — user born 2010 cannot enter group with birthYearMax 2005
+      final events = [
+        makeEvent(
+          tickets: [makeTicket(targetEntryGroupIds: ['g1'])],
+          entryGroups: [
+            const EntryGroup(
+              id: 'g1',
+              eventId: 'e1',
+              gender: 'male',
+              birthYearMin: 1990,
+              birthYearMax: 2005,
+            ),
+          ],
+        ),
+      ];
+      final data = BulkEligibilityData.fromJson({
+        'user_profile': {
+          'gender': 'male',
+          'birth_year': 2010,
+          'is_verified': true,
+        },
+        'approved_verifications': <dynamic>[],
+      });
+
+      final result = EligibilityFilter.filter(
+        events: events,
+        eligibilityData: data,
+      );
+
+      expect(result, isEmpty);
+    });
+
+    test('filters out events requiring verification when user lacks it', () {
+      // Fix #1634: verification requirement — event requires career verification
+      final events = [
+        makeEvent(
+          tickets: [makeTicket(requiredVerificationIds: ['verif_career'])],
+        ),
+      ];
+      final data = BulkEligibilityData.fromJson({
+        'user_profile': {
+          'gender': 'male',
+          'birth_year': 1995,
+          'is_verified': true,
+        },
+        'approved_verifications': <dynamic>[],
+      });
+
+      final result = EligibilityFilter.filter(
+        events: events,
+        eligibilityData: data,
+      );
+
+      expect(result, isEmpty);
+    });
+
+    test('keeps events requiring verification when user has it', () {
+      // Fix #1634: verification — user with approved career verification is eligible
+      final events = [
+        makeEvent(
+          tickets: [makeTicket(requiredVerificationIds: ['verif_career'])],
+        ),
+      ];
+      final data = BulkEligibilityData.fromJson({
+        'user_profile': {
+          'gender': 'male',
+          'birth_year': 1995,
+          'is_verified': true,
+        },
+        'approved_verifications': [
+          {
+            'partner_id': 'p1',
+            'verification_id': 'verif_career',
+            'verified_at': '2025-01-01',
+          },
+        ],
+      });
+
+      final result = EligibilityFilter.filter(
+        events: events,
+        eligibilityData: data,
+      );
+
+      expect(result, hasLength(1));
+    });
+  });
+
+  // Fix #1634: Persona matrix — common dev seed personas against realistic event
+  // types. Regression guard: eligibility filter must not silently exclude all events.
+  group('persona matrix', () {
+    final currentYear = DateTime.now().year;
+
+    BulkEligibilityData makeProfile({
+      required String gender,
+      required int age,
+      List<Map<String, dynamic>> verifications = const [],
+    }) {
+      return BulkEligibilityData.fromJson({
+        'user_profile': {
+          'gender': gender,
+          'birth_year': currentYear - age,
+          'is_verified': true,
+        },
+        'approved_verifications': verifications,
+      });
+    }
+
+    // No tickets → always eligible regardless of profile.
+    Event openEvent() => makeEvent(id: 'open');
+
+    // Male-only, no age restriction.
+    Event maleOnlyEvent() => makeEvent(
+          id: 'male_only',
+          tickets: [makeTicket(id: 'tm', targetEntryGroupIds: ['gm'])],
+          entryGroups: [const EntryGroup(id: 'gm', eventId: 'male_only', gender: 'male')],
+        );
+
+    // Male-only with age range 25–40. birthYearMin = currentYear-40, birthYearMax = currentYear-25.
+    Event maleAgeRestrictedEvent() => makeEvent(
+          id: 'age_restricted',
+          tickets: [makeTicket(id: 'ta', targetEntryGroupIds: ['ga'])],
+          entryGroups: [
+            EntryGroup(
+              id: 'ga',
+              eventId: 'age_restricted',
+              gender: 'male',
+              birthYearMin: currentYear - 40,
+              birthYearMax: currentYear - 25,
+            ),
+          ],
+        );
+
+    // Requires career verification.
+    Event verificationEvent() => makeEvent(
+          id: 'verif',
+          tickets: [makeTicket(id: 'tv', requiredVerificationIds: ['verif_career'])],
+        );
+
+    test('18F — eligible only for open event', () {
+      final profile = makeProfile(gender: 'female', age: 18);
+      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
+
+      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
+
+      expect(result.map((e) => e.id).toList(), equals(['open']));
+    });
+
+    test('25F — eligible for open event only (gender mismatch on male-only)', () {
+      final profile = makeProfile(gender: 'female', age: 25);
+      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
+
+      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
+
+      expect(result.map((e) => e.id).toList(), equals(['open']));
+    });
+
+    test('35M — eligible for open, male-only, and age-restricted events', () {
+      final profile = makeProfile(gender: 'male', age: 35);
+      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
+
+      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
+
+      expect(result.map((e) => e.id), containsAll(['open', 'male_only', 'age_restricted']));
+      expect(result.any((e) => e.id == 'verif'), isFalse);
+    });
+
+    test('42M — eligible for open and male-only events, not age-restricted (too old)', () {
+      final profile = makeProfile(gender: 'male', age: 42);
+      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
+
+      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
+
+      expect(result.map((e) => e.id), containsAll(['open', 'male_only']));
+      expect(result.any((e) => e.id == 'age_restricted'), isFalse);
+      expect(result.any((e) => e.id == 'verif'), isFalse);
+    });
+
+    test('all personas — eligible for open event (seed data regression guard)', () {
+      // Fix #1634: this is the core regression — all verified users must see open events.
+      final personas = [
+        makeProfile(gender: 'female', age: 18),
+        makeProfile(gender: 'female', age: 25),
+        makeProfile(gender: 'male', age: 35),
+        makeProfile(gender: 'male', age: 42),
+      ];
+
+      for (final profile in personas) {
+        final result = EligibilityFilter.filter(
+          events: [openEvent()],
+          eligibilityData: profile,
+        );
+        expect(result, hasLength(1), reason: 'All personas should see open events');
+      }
+    });
   });
 }


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1634

## 변경 내용

QA(`needs-qa-claude-1`)가 요청한 eligibility filter 회귀 방지 테스트 추가.

### 추가된 테스트

**`EligibilityFilter` 단위 테스트:**
- 나이 제한: 너무 나이 많은 유저 (1980년생, min 1990), 너무 어린 유저 (2010년생, max 2005)
- 인증 요구: 인증 없는/있는 유저 각각 검증

**페르소나 매트릭스 (18F, 25F, 35M, 42M × 4 이벤트 유형):**
- 핵심 회귀 가드: 모든 페르소나가 오픈 이벤트는 반드시 볼 수 있어야 함

### 기존 PR과의 관계

- **PR #1638**: dev 환경 eligibility 필터 비활성화 (증상 수정)
- **이 PR**: eligibility 로직 단위 테스트 회귀 가드 (로직 검증)

두 PR은 독립적이며 충돌 없음.