### PR TITLE
fix(party): #1644 RecurrenceManagementScreen 진입 경로 누락 — 반복 규칙 요약 카드 추가

### DIFF
--- a/apps/app_partner/lib/src/features/party/detail/party_detail_coordinator.dart
+++ b/apps/app_partner/lib/src/features/party/detail/party_detail_coordinator.dart
@@ -245,4 +245,12 @@ class PartyDetailCoordinator {
           .push(TicketCreateRoute(partyId: partyId, eventId: eventId).location),
     );
   }
+
+  void goToRecurrenceManagement(String partyId) {
+    unawaited(
+      _ref
+          .read(goRouterProvider)
+          .push(RecurrenceManagementRoute(partyId: partyId).location),
+    );
+  }
 }

--- a/apps/app_partner/lib/src/features/party/detail/tabs/party_event_management_tab.dart
+++ b/apps/app_partner/lib/src/features/party/detail/tabs/party_event_management_tab.dart
@@ -1,5 +1,6 @@
 import 'package:app_partner/src/features/party/detail/party_detail_coordinator.dart';
 import 'package:app_partner/src/features/party/widgets/party_event_list_summary.dart';
+import 'package:app_partner/src/features/party/widgets/recurrence_rule_summary_card.dart';
 import 'package:app_partner/src/utils/l10n_ext.dart';
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -20,6 +21,7 @@ class PartyEventManagementTab extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          RecurrenceRuleSummaryCard(partyId: party.id),
           // Events Section
           Text(
             context.l10n.partyDetail_section_events,

--- a/apps/app_partner/lib/src/features/party/widgets/recurrence_rule_summary_card.dart
+++ b/apps/app_partner/lib/src/features/party/widgets/recurrence_rule_summary_card.dart
@@ -1,4 +1,5 @@
 import 'package:app_partner/src/features/party/detail/party_detail_coordinator.dart';
+import 'package:app_partner/src/features/party/recurrence/recurrence_management_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 

--- a/apps/app_partner/lib/src/features/party/widgets/recurrence_rule_summary_card.dart
+++ b/apps/app_partner/lib/src/features/party/widgets/recurrence_rule_summary_card.dart
@@ -1,0 +1,131 @@
+import 'package:app_partner/src/features/party/detail/party_detail_coordinator.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+// Fix #1644: RecurrenceManagementScreen 진입 경로 누락 — 반복 규칙 요약 카드 추가
+class RecurrenceRuleSummaryCard extends ConsumerWidget {
+  const RecurrenceRuleSummaryCard({required this.partyId, super.key});
+
+  final String partyId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ruleAsync = ref.watch(partyRecurrenceRuleProvider(partyId));
+
+    return ruleAsync.when(
+      loading: () => const SizedBox.shrink(),
+      error: (_, __) => const SizedBox.shrink(),
+      data: (rule) {
+        if (rule == null || rule.status == RecurrenceStatus.cancelled) {
+          return const SizedBox.shrink();
+        }
+        return _RecurrenceRuleCard(partyId: partyId, rule: rule);
+      },
+    );
+  }
+}
+
+class _RecurrenceRuleCard extends ConsumerWidget {
+  const _RecurrenceRuleCard({required this.partyId, required this.rule});
+
+  final String partyId;
+  final RecurrenceRule rule;
+
+  static const _dayLabels = {
+    0: '일',
+    1: '월',
+    2: '화',
+    3: '수',
+    4: '목',
+    5: '금',
+    6: '토',
+  };
+
+  String _buildSummaryText() {
+    final patternLabel = switch (rule.pattern) {
+      RecurrencePattern.weekly => '매주',
+      RecurrencePattern.biweekly => '격주',
+      RecurrencePattern.monthly => '매월',
+    };
+
+    final periodPart = switch (rule.pattern) {
+      RecurrencePattern.weekly || RecurrencePattern.biweekly => () {
+        if (rule.daysOfWeek.isEmpty) return patternLabel;
+        final days = rule.daysOfWeek
+            .map((d) => _dayLabels[d] ?? '')
+            .where((s) => s.isNotEmpty)
+            .join(', ');
+        return '$patternLabel $days';
+      }(),
+      RecurrencePattern.monthly => () {
+        final day = rule.monthDay;
+        return day != null ? '$patternLabel ${day}일' : patternLabel;
+      }(),
+    };
+
+    final timePart = rule.startTime.length >= 5
+        ? rule.startTime.substring(0, 5)
+        : rule.startTime;
+
+    return '$periodPart · $timePart';
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final coordinator = ref.read(partyDetailCoordinatorProvider);
+
+    final (statusLabel, statusColor) = switch (rule.status) {
+      RecurrenceStatus.active => ('활성', theme.colorScheme.primary),
+      RecurrenceStatus.paused => ('일시 정지', theme.colorScheme.tertiary),
+      RecurrenceStatus.cancelled => ('취소됨', theme.colorScheme.error),
+    };
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: MinglitSpacing.large),
+      child: Semantics(
+        label:
+            '반복 규칙 요약, ${_buildSummaryText()}, 상태 $statusLabel, 관리 화면으로 이동',
+        child: Card(
+          child: InkWell(
+            onTap: () => coordinator.goToRecurrenceManagement(partyId),
+            borderRadius: BorderRadius.circular(12),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: MinglitSpacing.medium,
+                vertical: MinglitSpacing.small,
+              ),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.event_repeat,
+                    size: 20,
+                    color: theme.colorScheme.primary,
+                  ),
+                  const SizedBox(width: MinglitSpacing.small),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          _buildSummaryText(),
+                          style: theme.textTheme.bodyMedium,
+                        ),
+                        const SizedBox(height: 2),
+                        MinglitTag(label: statusLabel, color: statusColor),
+                      ],
+                    ),
+                  ),
+                  Icon(
+                    Icons.chevron_right,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/app_partner/lib/src/features/party/widgets/recurrence_rule_summary_card.dart
+++ b/apps/app_partner/lib/src/features/party/widgets/recurrence_rule_summary_card.dart
@@ -14,7 +14,7 @@ class RecurrenceRuleSummaryCard extends ConsumerWidget {
 
     return ruleAsync.when(
       loading: () => const SizedBox.shrink(),
-      error: (_, __) => const SizedBox.shrink(),
+      error: (_, _) => const SizedBox.shrink(),
       data: (rule) {
         if (rule == null || rule.status == RecurrenceStatus.cancelled) {
           return const SizedBox.shrink();
@@ -59,7 +59,7 @@ class _RecurrenceRuleCard extends ConsumerWidget {
       }(),
       RecurrencePattern.monthly => () {
         final day = rule.monthDay;
-        return day != null ? '$patternLabel ${day}일' : patternLabel;
+        return day != null ? '$patternLabel $day일' : patternLabel;
       }(),
     };
 
@@ -84,8 +84,7 @@ class _RecurrenceRuleCard extends ConsumerWidget {
     return Padding(
       padding: const EdgeInsets.only(bottom: MinglitSpacing.large),
       child: Semantics(
-        label:
-            '반복 규칙 요약, ${_buildSummaryText()}, 상태 $statusLabel, 관리 화면으로 이동',
+        label: '반복 규칙 요약, ${_buildSummaryText()}, 상태 $statusLabel, 관리 화면으로 이동',
         child: Card(
           child: InkWell(
             onTap: () => coordinator.goToRecurrenceManagement(partyId),

--- a/apps/app_partner/lib/src/features/party/widgets/recurrence_rule_summary_card.dart
+++ b/apps/app_partner/lib/src/features/party/widgets/recurrence_rule_summary_card.dart
@@ -89,7 +89,7 @@ class _RecurrenceRuleCard extends ConsumerWidget {
         child: Card(
           child: InkWell(
             onTap: () => coordinator.goToRecurrenceManagement(partyId),
-            borderRadius: BorderRadius.circular(12),
+            borderRadius: BorderRadius.circular(MinglitRadius.button),
             child: Padding(
               padding: const EdgeInsets.symmetric(
                 horizontal: MinglitSpacing.medium,

--- a/apps/app_partner/test/src/features/party/recurrence/recurrence_rule_summary_card_test.dart
+++ b/apps/app_partner/test/src/features/party/recurrence/recurrence_rule_summary_card_test.dart
@@ -1,4 +1,5 @@
 // Fix #1644: RecurrenceRuleSummaryCard 위젯 렌더링 테스트
+import 'package:app_partner/src/features/party/recurrence/recurrence_management_controller.dart';
 import 'package:app_partner/src/features/party/widgets/recurrence_rule_summary_card.dart';
 import 'package:app_partner/src/routing/app_router.dart';
 import 'package:flutter/material.dart';

--- a/apps/app_partner/test/src/features/party/recurrence/recurrence_rule_summary_card_test.dart
+++ b/apps/app_partner/test/src/features/party/recurrence/recurrence_rule_summary_card_test.dart
@@ -1,0 +1,135 @@
+// Fix #1644: RecurrenceRuleSummaryCard 위젯 렌더링 테스트
+import 'package:app_partner/src/features/party/widgets/recurrence_rule_summary_card.dart';
+import 'package:app_partner/src/routing/app_router.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../utils/mocks.dart';
+
+RecurrenceRule _makeRule({
+  RecurrenceStatus status = RecurrenceStatus.active,
+  RecurrencePattern pattern = RecurrencePattern.weekly,
+  List<int> daysOfWeek = const [6],
+  int? monthDay,
+}) {
+  return RecurrenceRule(
+    id: 'rule-1',
+    partyId: 'party-1',
+    pattern: pattern,
+    startTime: '19:00:00',
+    endTime: '21:00:00',
+    createdAt: DateTime(2026, 4),
+    updatedAt: DateTime(2026, 4),
+    daysOfWeek: daysOfWeek,
+    monthDay: monthDay,
+    status: status,
+  );
+}
+
+Widget _buildTestWidget({
+  required RecurrenceRule? rule,
+  MockGoRouter? router,
+}) {
+  final mockRouter = router ?? MockGoRouter();
+  when(() => mockRouter.push(any())).thenAnswer((_) => Future.value());
+
+  return ProviderScope(
+    overrides: [
+      goRouterProvider.overrideWithValue(mockRouter),
+      partyRecurrenceRuleProvider('party-1').overrideWith((_) async => rule),
+    ],
+    child: const MaterialApp(
+      home: Scaffold(
+        body: RecurrenceRuleSummaryCard(partyId: 'party-1'),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('RecurrenceRuleSummaryCard', () {
+    testWidgets('renders nothing when rule is null', (tester) async {
+      await tester.pumpWidget(_buildTestWidget(rule: null));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Card), findsNothing);
+      expect(find.byIcon(Icons.event_repeat), findsNothing);
+    });
+
+    testWidgets('renders nothing when rule is cancelled', (tester) async {
+      await tester.pumpWidget(
+        _buildTestWidget(rule: _makeRule(status: RecurrenceStatus.cancelled)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Card), findsNothing);
+    });
+
+    testWidgets('renders card for active weekly rule', (tester) async {
+      await tester.pumpWidget(
+        _buildTestWidget(
+          rule: _makeRule(
+            status: RecurrenceStatus.active,
+            daysOfWeek: [6, 0],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Card), findsOneWidget);
+      expect(find.text('매주 토, 일 · 19:00'), findsOneWidget);
+      expect(find.text('활성'), findsOneWidget);
+      expect(find.byIcon(Icons.event_repeat), findsOneWidget);
+      expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+    });
+
+    testWidgets('renders card for paused rule', (tester) async {
+      await tester.pumpWidget(
+        _buildTestWidget(rule: _makeRule(status: RecurrenceStatus.paused)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Card), findsOneWidget);
+      expect(find.text('일시 정지'), findsOneWidget);
+    });
+
+    testWidgets('renders monthly rule with monthDay', (tester) async {
+      await tester.pumpWidget(
+        _buildTestWidget(
+          rule: _makeRule(
+            pattern: RecurrencePattern.monthly,
+            daysOfWeek: [],
+            monthDay: 15,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Card), findsOneWidget);
+      expect(find.text('매월 15일 · 19:00'), findsOneWidget);
+    });
+
+    testWidgets('tapping card navigates to recurrence management', (
+      tester,
+    ) async {
+      final mockRouter = MockGoRouter();
+      when(() => mockRouter.push(any())).thenAnswer((_) => Future.value());
+
+      await tester.pumpWidget(
+        _buildTestWidget(rule: _makeRule(), router: mockRouter),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(InkWell));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => mockRouter.push(
+          any(that: contains('/recurrence')),
+        ),
+      ).called(1);
+    });
+  });
+}

--- a/apps/app_partner/test/src/features/party/recurrence/recurrence_rule_summary_card_test.dart
+++ b/apps/app_partner/test/src/features/party/recurrence/recurrence_rule_summary_card_test.dart
@@ -71,7 +71,6 @@ void main() {
       await tester.pumpWidget(
         _buildTestWidget(
           rule: _makeRule(
-            status: RecurrenceStatus.active,
             daysOfWeek: [6, 0],
           ),
         ),

--- a/apps/app_user/test/src/features/explore/logic/eligibility_filter_test.dart
+++ b/apps/app_user/test/src/features/explore/logic/eligibility_filter_test.dart
@@ -254,77 +254,89 @@ void main() {
       expect(result, isEmpty);
     });
 
-    test('filters out events when user birth year is below entry group minimum', () {
-      // Fix #1634: age restriction — user born 1980 cannot enter group requiring birthYearMin 1990
-      final events = [
-        makeEvent(
-          tickets: [makeTicket(targetEntryGroupIds: ['g1'])],
-          entryGroups: [
-            const EntryGroup(
-              id: 'g1',
-              eventId: 'e1',
-              gender: 'male',
-              birthYearMin: 1990,
-              birthYearMax: 2005,
-            ),
-          ],
-        ),
-      ];
-      final data = BulkEligibilityData.fromJson({
-        'user_profile': {
-          'gender': 'male',
-          'birth_year': 1980,
-          'is_verified': true,
-        },
-        'approved_verifications': <dynamic>[],
-      });
+    test(
+      'filters out events when user birth year is below entry group minimum',
+      () {
+        // Fix #1634: age restriction — user born 1980 cannot enter group requiring birthYearMin 1990
+        final events = [
+          makeEvent(
+            tickets: [
+              makeTicket(targetEntryGroupIds: ['g1']),
+            ],
+            entryGroups: [
+              const EntryGroup(
+                id: 'g1',
+                eventId: 'e1',
+                gender: 'male',
+                birthYearMin: 1990,
+                birthYearMax: 2005,
+              ),
+            ],
+          ),
+        ];
+        final data = BulkEligibilityData.fromJson({
+          'user_profile': {
+            'gender': 'male',
+            'birth_year': 1980,
+            'is_verified': true,
+          },
+          'approved_verifications': <dynamic>[],
+        });
 
-      final result = EligibilityFilter.filter(
-        events: events,
-        eligibilityData: data,
-      );
+        final result = EligibilityFilter.filter(
+          events: events,
+          eligibilityData: data,
+        );
 
-      expect(result, isEmpty);
-    });
+        expect(result, isEmpty);
+      },
+    );
 
-    test('filters out events when user birth year exceeds entry group maximum', () {
-      // Fix #1634: age restriction — user born 2010 cannot enter group with birthYearMax 2005
-      final events = [
-        makeEvent(
-          tickets: [makeTicket(targetEntryGroupIds: ['g1'])],
-          entryGroups: [
-            const EntryGroup(
-              id: 'g1',
-              eventId: 'e1',
-              gender: 'male',
-              birthYearMin: 1990,
-              birthYearMax: 2005,
-            ),
-          ],
-        ),
-      ];
-      final data = BulkEligibilityData.fromJson({
-        'user_profile': {
-          'gender': 'male',
-          'birth_year': 2010,
-          'is_verified': true,
-        },
-        'approved_verifications': <dynamic>[],
-      });
+    test(
+      'filters out events when user birth year exceeds entry group maximum',
+      () {
+        // Fix #1634: age restriction — user born 2010 cannot enter group with birthYearMax 2005
+        final events = [
+          makeEvent(
+            tickets: [
+              makeTicket(targetEntryGroupIds: ['g1']),
+            ],
+            entryGroups: [
+              const EntryGroup(
+                id: 'g1',
+                eventId: 'e1',
+                gender: 'male',
+                birthYearMin: 1990,
+                birthYearMax: 2005,
+              ),
+            ],
+          ),
+        ];
+        final data = BulkEligibilityData.fromJson({
+          'user_profile': {
+            'gender': 'male',
+            'birth_year': 2010,
+            'is_verified': true,
+          },
+          'approved_verifications': <dynamic>[],
+        });
 
-      final result = EligibilityFilter.filter(
-        events: events,
-        eligibilityData: data,
-      );
+        final result = EligibilityFilter.filter(
+          events: events,
+          eligibilityData: data,
+        );
 
-      expect(result, isEmpty);
-    });
+        expect(result, isEmpty);
+      },
+    );
 
     test('filters out events requiring verification when user lacks it', () {
       // Fix #1634: verification requirement — event requires career verification
       final events = [
         makeEvent(
-          tickets: [makeTicket(requiredVerificationIds: ['verif_career'])],
+          tickets: [
+            makeTicket(requiredVerificationIds: ['verif_career']),
+          ],
         ),
       ];
       final data = BulkEligibilityData.fromJson({
@@ -348,7 +360,9 @@ void main() {
       // Fix #1634: verification — user with approved career verification is eligible
       final events = [
         makeEvent(
-          tickets: [makeTicket(requiredVerificationIds: ['verif_career'])],
+          tickets: [
+            makeTicket(requiredVerificationIds: ['verif_career']),
+          ],
         ),
       ];
       final data = BulkEligibilityData.fromJson({
@@ -400,87 +414,143 @@ void main() {
 
     // Male-only, no age restriction.
     Event maleOnlyEvent() => makeEvent(
-          id: 'male_only',
-          tickets: [makeTicket(id: 'tm', targetEntryGroupIds: ['gm'])],
-          entryGroups: [const EntryGroup(id: 'gm', eventId: 'male_only', gender: 'male')],
-        );
+      id: 'male_only',
+      tickets: [
+        makeTicket(id: 'tm', targetEntryGroupIds: ['gm']),
+      ],
+      entryGroups: [
+        const EntryGroup(id: 'gm', eventId: 'male_only', gender: 'male'),
+      ],
+    );
 
     // Male-only with age range 25–40. birthYearMin = currentYear-40, birthYearMax = currentYear-25.
     Event maleAgeRestrictedEvent() => makeEvent(
-          id: 'age_restricted',
-          tickets: [makeTicket(id: 'ta', targetEntryGroupIds: ['ga'])],
-          entryGroups: [
-            EntryGroup(
-              id: 'ga',
-              eventId: 'age_restricted',
-              gender: 'male',
-              birthYearMin: currentYear - 40,
-              birthYearMax: currentYear - 25,
-            ),
-          ],
-        );
+      id: 'age_restricted',
+      tickets: [
+        makeTicket(id: 'ta', targetEntryGroupIds: ['ga']),
+      ],
+      entryGroups: [
+        EntryGroup(
+          id: 'ga',
+          eventId: 'age_restricted',
+          gender: 'male',
+          birthYearMin: currentYear - 40,
+          birthYearMax: currentYear - 25,
+        ),
+      ],
+    );
 
     // Requires career verification.
     Event verificationEvent() => makeEvent(
-          id: 'verif',
-          tickets: [makeTicket(id: 'tv', requiredVerificationIds: ['verif_career'])],
-        );
+      id: 'verif',
+      tickets: [
+        makeTicket(id: 'tv', requiredVerificationIds: ['verif_career']),
+      ],
+    );
 
     test('18F — eligible only for open event', () {
       final profile = makeProfile(gender: 'female', age: 18);
-      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
+      final events = [
+        openEvent(),
+        maleOnlyEvent(),
+        maleAgeRestrictedEvent(),
+        verificationEvent(),
+      ];
 
-      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
+      final result = EligibilityFilter.filter(
+        events: events,
+        eligibilityData: profile,
+      );
 
       expect(result.map((e) => e.id).toList(), equals(['open']));
     });
 
-    test('25F — eligible for open event only (gender mismatch on male-only)', () {
-      final profile = makeProfile(gender: 'female', age: 25);
-      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
+    test(
+      '25F — eligible for open event only (gender mismatch on male-only)',
+      () {
+        final profile = makeProfile(gender: 'female', age: 25);
+        final events = [
+          openEvent(),
+          maleOnlyEvent(),
+          maleAgeRestrictedEvent(),
+          verificationEvent(),
+        ];
 
-      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
+        final result = EligibilityFilter.filter(
+          events: events,
+          eligibilityData: profile,
+        );
 
-      expect(result.map((e) => e.id).toList(), equals(['open']));
-    });
+        expect(result.map((e) => e.id).toList(), equals(['open']));
+      },
+    );
 
     test('35M — eligible for open, male-only, and age-restricted events', () {
       final profile = makeProfile(gender: 'male', age: 35);
-      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
-
-      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
-
-      expect(result.map((e) => e.id), containsAll(['open', 'male_only', 'age_restricted']));
-      expect(result.any((e) => e.id == 'verif'), isFalse);
-    });
-
-    test('42M — eligible for open and male-only events, not age-restricted (too old)', () {
-      final profile = makeProfile(gender: 'male', age: 42);
-      final events = [openEvent(), maleOnlyEvent(), maleAgeRestrictedEvent(), verificationEvent()];
-
-      final result = EligibilityFilter.filter(events: events, eligibilityData: profile);
-
-      expect(result.map((e) => e.id), containsAll(['open', 'male_only']));
-      expect(result.any((e) => e.id == 'age_restricted'), isFalse);
-      expect(result.any((e) => e.id == 'verif'), isFalse);
-    });
-
-    test('all personas — eligible for open event (seed data regression guard)', () {
-      // Fix #1634: this is the core regression — all verified users must see open events.
-      final personas = [
-        makeProfile(gender: 'female', age: 18),
-        makeProfile(gender: 'female', age: 25),
-        makeProfile(gender: 'male', age: 35),
-        makeProfile(gender: 'male', age: 42),
+      final events = [
+        openEvent(),
+        maleOnlyEvent(),
+        maleAgeRestrictedEvent(),
+        verificationEvent(),
       ];
 
-      for (final profile in personas) {
+      final result = EligibilityFilter.filter(
+        events: events,
+        eligibilityData: profile,
+      );
+
+      expect(
+        result.map((e) => e.id),
+        containsAll(['open', 'male_only', 'age_restricted']),
+      );
+      expect(result.any((e) => e.id == 'verif'), isFalse);
+    });
+
+    test(
+      '42M — eligible for open and male-only events, not age-restricted (too old)',
+      () {
+        final profile = makeProfile(gender: 'male', age: 42);
+        final events = [
+          openEvent(),
+          maleOnlyEvent(),
+          maleAgeRestrictedEvent(),
+          verificationEvent(),
+        ];
+
         final result = EligibilityFilter.filter(
-          events: [openEvent()],
+          events: events,
           eligibilityData: profile,
         );
-        expect(result, hasLength(1), reason: 'All personas should see open events');
-      }
-    });
+
+        expect(result.map((e) => e.id), containsAll(['open', 'male_only']));
+        expect(result.any((e) => e.id == 'age_restricted'), isFalse);
+        expect(result.any((e) => e.id == 'verif'), isFalse);
+      },
+    );
+
+    test(
+      'all personas — eligible for open event (seed data regression guard)',
+      () {
+        // Fix #1634: this is the core regression — all verified users must see open events.
+        final personas = [
+          makeProfile(gender: 'female', age: 18),
+          makeProfile(gender: 'female', age: 25),
+          makeProfile(gender: 'male', age: 35),
+          makeProfile(gender: 'male', age: 42),
+        ];
+
+        for (final profile in personas) {
+          final result = EligibilityFilter.filter(
+            events: [openEvent()],
+            eligibilityData: profile,
+          );
+          expect(
+            result,
+            hasLength(1),
+            reason: 'All personas should see open events',
+          );
+        }
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

- `RecurrenceRuleSummaryCard` 신규 위젯 추가: 반복 규칙 요약을 카드 형태로 표시하고, 탭하면 `RecurrenceManagementScreen`으로 이동
- `PartyEventManagementTab` 상단에 카드 삽입 — 규칙이 없거나 cancelled 상태면 자동으로 숨김 (`SizedBox.shrink()`)
- `PartyDetailCoordinator`에 `goToRecurrenceManagement(partyId)` 메서드 추가
- 위젯 테스트 5 케이스: null/active/paused/cancelled 렌더링 + 탭 네비게이션 검증

## UX 가이드

UX 판단 (needs-uiux-claude-1): https://github.com/Mark-Yun/minglit/issues/1644#issuecomment-4277778803

## Test plan

- [ ] Flutter analyze passes (no new errors)
- [ ] Widget test: `recurrence_rule_summary_card_test.dart` 5케이스 모두 pass
- [ ] 반복 규칙이 없는 파티: 카드 미표시 확인
- [ ] 반복 규칙이 active인 파티: 요약 텍스트 + "활성" 태그 표시, 탭 시 관리 화면 이동 확인
- [ ] 반복 규칙이 paused인 파티: "일시 정지" 태그 표시 확인

Closes #1644

🤖 Generated with [Claude Code](https://claude.com/claude-code)