### PR TITLE
fix(simulator): email 없는 파트너 throw → skip으로 변경 (#1664)

### DIFF
--- a/supabase/functions/backend-simulator/sim_create.ts
+++ b/supabase/functions/backend-simulator/sim_create.ts
@@ -77,7 +77,9 @@ export async function simCreateParties(
     // ── Step 1: Acquire partner JWT ───────────────────────────────────────────
     const partnerEmail = await getPartnerEmail(supabase, partner.id);
     if (!partnerEmail) {
-      throw new Error(`No email for partner ${partner.id}`);
+      // Fix #1664: skip partner with no email instead of crashing the simulation
+      log({ level: "warn", phase: "create", step: "get_partner_email", message: `No email for partner ${partner.id} — skipping` });
+      continue;
     }
     const partnerToken = await getSimPartnerToken(supabaseUrl, anonKey, partnerEmail, simUserPassword);
 
@@ -218,7 +220,9 @@ export async function simCreateDisplayEvents(
     // Acquire partner JWT for EF calls
     const partnerEmail = await getPartnerEmail(supabase, partner.id);
     if (!partnerEmail) {
-      throw new Error(`No email for partner ${partner.id}`);
+      // Fix #1664: skip partner with no email instead of crashing the simulation
+      log({ level: "warn", phase: "create", step: "get_display_partner_email", message: `No email for partner ${partner.id} — skipping` });
+      continue;
     }
     const partnerToken = await getSimPartnerToken(supabaseUrl, anonKey, partnerEmail, simUserPassword);
 

--- a/supabase/functions/backend-simulator/sim_create_test.ts
+++ b/supabase/functions/backend-simulator/sim_create_test.ts
@@ -914,3 +914,60 @@ Deno.test({
   }
   },
 });
+
+Deno.test({
+  name: "simCreateParties - skips partner with no email instead of throwing (#1664)",
+  fn: async () => {
+  const efCalls: string[] = [];
+
+  // First partner has no email, second has email — simulation should skip first and succeed with second.
+  let callCount = 0;
+  const mock = createMockSupabaseClient({
+    tables: {
+      partners: { select: () => ({ data: [{ id: "no-email-partner" }, { id: "partner-2" }], error: null }) },
+      locations: { select: () => ({ data: { id: "loc-1" }, error: null }) },
+      partner_members: { select: () => ({ data: [{ user_id: "user-1" }], error: null }) },
+      ticket_templates: { select: () => ({ data: [{ id: "tmpl-1", name: "일반" }], error: null }) },
+    },
+    authAdminGetUserById: (_userId: string) => {
+      callCount++;
+      // First call (no-email-partner) returns null email, second returns valid email
+      if (callCount === 1) return { data: { user: { email: null } }, error: null };
+      return { data: { user: { email: "partner2@test.com" } }, error: null };
+    },
+  });
+
+  const config: SimConfig = { ...DEFAULT_CONFIG, party_count: 2, events_per_party: 1 };
+
+  Deno.env.set("SIM_USER_PASSWORD", "test-password");
+  try {
+    await withMockFetch((url) => {
+      if (url.includes("auth/v1/token")) {
+        return new Response(JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }), { status: 200 });
+      }
+      if (url.includes("partner-manage-party")) {
+        efCalls.push(url);
+        return new Response(JSON.stringify({ success: true, party_id: "ef-party-2" }), { status: 200 });
+      }
+      if (url.includes("partner-manage-event")) {
+        efCalls.push(url);
+        return new Response(JSON.stringify({ success: true, event_id: "ef-event-2" }), { status: 200 });
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    }, async () => {
+      // Should not throw — partner with no email is skipped
+      const result = await simCreateParties(
+        mock as unknown as SupabaseClient,
+        config,
+        noop,
+        "https://mock.supabase.co",
+        "anon-key",
+      );
+      // Second partner succeeded, so at least one party was created
+      assertEquals(result.partyIds.length >= 1, true);
+    });
+  } finally {
+    Deno.env.delete("SIM_USER_PASSWORD");
+  }
+  },
+});

--- a/supabase/functions/backend-simulator/sim_create_test.ts
+++ b/supabase/functions/backend-simulator/sim_create_test.ts
@@ -931,8 +931,8 @@ Deno.test({
     },
     authAdminGetUserById: (_userId: string) => {
       callCount++;
-      // First call (no-email-partner) returns null email, second returns valid email
-      if (callCount === 1) return { data: { user: { email: null } }, error: null };
+      // First call (no-email-partner) simulates missing email via null user
+      if (callCount === 1) return { data: { user: null }, error: null };
       return { data: { user: { email: "partner2@test.com" } }, error: null };
     },
   });
@@ -965,6 +965,75 @@ Deno.test({
       );
       // Second partner succeeded, so at least one party was created
       assertEquals(result.partyIds.length >= 1, true);
+    });
+  } finally {
+    Deno.env.delete("SIM_USER_PASSWORD");
+  }
+  },
+});
+
+Deno.test({
+  name: "simCreateDisplayEvents - skips partner with no email instead of throwing (#1664)",
+  fn: async () => {
+  const efCalls: string[] = [];
+
+  // Two partners: first has no email, second has email.
+  // DISPLAY_SCENARIOS (5 items) cycle: [no-email, with-email, no-email, with-email, no-email]
+  // → 2 display parties created, 3 skipped — must not throw.
+  const mock = createMockSupabaseClient({
+    tables: {
+      parties: { select: () => ({ data: [], error: null }) },
+      partners: {
+        select: () => ({
+          data: [{ id: "no-email-partner" }, { id: "partner-with-email" }],
+          error: null,
+        }),
+      },
+      partner_members: {
+        select: ({ filters }: { filters: Record<string, unknown> }) => ({
+          data: [{ user_id: filters["partner_id"] === "no-email-partner" ? "user-no-email" : "user-with-email" }],
+          error: null,
+        }),
+      },
+      locations: { select: () => ({ data: null, error: null }) },
+      ticket_templates: { select: () => ({ data: [{ id: "tmpl-1", name: "일반 티켓" }], error: null }) },
+    },
+    authAdminGetUserById: (userId: string) => {
+      if (userId === "user-no-email") return { data: { user: null }, error: null };
+      return { data: { user: { email: "partner-email@test.com" } }, error: null };
+    },
+  });
+
+  Deno.env.set("SIM_USER_PASSWORD", "test-password");
+  let partyCallCount = 0;
+  let eventCallCount = 0;
+  try {
+    await withMockFetch((url) => {
+      if (url.includes("auth/v1/token")) {
+        return new Response(JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "r", user: {} }), { status: 200 });
+      }
+      if (url.includes("partner-manage-party")) {
+        partyCallCount++;
+        efCalls.push(url);
+        return new Response(JSON.stringify({ success: true, party_id: `ef-display-party-${partyCallCount}` }), { status: 200 });
+      }
+      if (url.includes("partner-manage-event")) {
+        eventCallCount++;
+        efCalls.push(url);
+        return new Response(JSON.stringify({ success: true, event_id: `ef-display-event-${eventCallCount}` }), { status: 200 });
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    }, async () => {
+      // Must not throw — no-email partners are skipped gracefully
+      const result = await simCreateDisplayEvents(
+        mock as unknown as SupabaseClient,
+        noop,
+        "https://mock.supabase.co",
+        "anon-key",
+      );
+      // partner-with-email handles 2 of 5 scenarios → 2 display parties created
+      assertEquals(result.displayPartyIds.length, 2);
+      assertEquals(result.displayEventIds.length, 4);
     });
   } finally {
     Deno.env.delete("SIM_USER_PASSWORD");


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1664

## Root Cause

`sim_create.ts`의 `simCreateParties()` / `simCreateDisplayEvents()` 두 함수에서 파트너 email을 가져오지 못하면 `throw`해서 시뮬레이터 전체가 HTTP 500으로 중단됨.

파트너 `55032dc6-3aa5-4ef3-8c6b-0f9e964cd9d8`에 email이 없어 PR #1640 머지 이후에도 매시간 simulator가 실패했음.

## Changes

- `simCreateParties()` / `simCreateDisplayEvents()`: email 없는 파트너를 만나면 `throw` → `warn 로그 + continue` (graceful skip)
- `sim_create_test.ts`: email 없는 파트너가 있을 때 throw 대신 skip되어 나머지 파트너로 시뮬레이션이 계속되는지 검증하는 regression 테스트 추가