### PR TITLE
fix(event): PopScope로 Android 뒤로가기 앱 이탈 방지

### DIFF
--- a/apps/app_user/lib/src/features/event/admission/payment_success_screen.dart
+++ b/apps/app_user/lib/src/features/event/admission/payment_success_screen.dart
@@ -29,12 +29,18 @@ class PaymentSuccessScreen extends StatelessWidget {
     ).format(event.startTime);
     final location = event.location ?? event.party?.location;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('결제 완료'),
-        leading: const CloseButton(),
-      ),
-      body: SingleChildScrollView(
+    // Fix #1656: Navigator.pushReplacement + GoRouter 혼용 시 Android 뒤로가기로
+    // 앱이 홈 화면으로 이탈하는 문제 방지 — CloseButton과 Android 뒤로가기 모두
+    // GoRouter 기반의 onBackToEvent로 위임하여 route 상태 일관성 보장.
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (_, __) => onBackToEvent(),
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('결제 완료'),
+          leading: CloseButton(onPressed: onBackToEvent),
+        ),
+        body: SingleChildScrollView(
         padding: const EdgeInsets.all(MinglitSpacing.large),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -136,7 +142,8 @@ class PaymentSuccessScreen extends StatelessWidget {
           ],
         ),
       ),
-    );
+    ),
+  );
   }
 
   Ticket? _findTicket() {

--- a/apps/app_user/lib/src/features/event/admission/payment_success_screen.dart
+++ b/apps/app_user/lib/src/features/event/admission/payment_success_screen.dart
@@ -34,116 +34,116 @@ class PaymentSuccessScreen extends StatelessWidget {
     // GoRouter 기반의 onBackToEvent로 위임하여 route 상태 일관성 보장.
     return PopScope(
       canPop: false,
-      onPopInvokedWithResult: (_, __) => onBackToEvent(),
+      onPopInvokedWithResult: (_, _) => onBackToEvent(),
       child: Scaffold(
         appBar: AppBar(
           title: const Text('결제 완료'),
           leading: CloseButton(onPressed: onBackToEvent),
         ),
         body: SingleChildScrollView(
-        padding: const EdgeInsets.all(MinglitSpacing.large),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Container(
-              padding: const EdgeInsets.all(MinglitSpacing.large),
-              decoration: BoxDecoration(
-                color: theme.colorScheme.primaryContainer,
-                borderRadius: BorderRadius.circular(MinglitRadius.card),
-              ),
-              child: Row(
-                children: [
-                  Icon(
-                    Icons.check_circle,
-                    color: theme.colorScheme.primary,
-                    size: 36,
-                  ),
-                  const SizedBox(width: MinglitSpacing.medium),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          '결제가 완료되었습니다! ',
-                          style: theme.textTheme.titleMedium?.copyWith(
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                        const SizedBox(height: MinglitSpacing.xxsmall),
-                        Text(
-                          '내 티켓에서 확인하실 수 있어요.',
-                          style: theme.textTheme.bodySmall,
-                        ),
-                      ],
+          padding: const EdgeInsets.all(MinglitSpacing.large),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                padding: const EdgeInsets.all(MinglitSpacing.large),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.primaryContainer,
+                  borderRadius: BorderRadius.circular(MinglitRadius.card),
+                ),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.check_circle,
+                      color: theme.colorScheme.primary,
+                      size: 36,
                     ),
-                  ),
-                ],
+                    const SizedBox(width: MinglitSpacing.medium),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '결제가 완료되었습니다! ',
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: MinglitSpacing.xxsmall),
+                          Text(
+                            '내 티켓에서 확인하실 수 있어요.',
+                            style: theme.textTheme.bodySmall,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
               ),
-            ),
-            const SizedBox(height: MinglitSpacing.xlarge),
-            Text(
-              '티켓 요약',
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.bold,
+              const SizedBox(height: MinglitSpacing.xlarge),
+              Text(
+                '티켓 요약',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
               ),
-            ),
-            const SizedBox(height: MinglitSpacing.medium),
-            Container(
-              padding: const EdgeInsets.all(MinglitSpacing.medium),
-              decoration: BoxDecoration(
-                color: theme.colorScheme.surface,
-                borderRadius: BorderRadius.circular(MinglitRadius.card),
-                border: Border.all(color: theme.colorScheme.outlineVariant),
+              const SizedBox(height: MinglitSpacing.medium),
+              Container(
+                padding: const EdgeInsets.all(MinglitSpacing.medium),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.surface,
+                  borderRadius: BorderRadius.circular(MinglitRadius.card),
+                  border: Border.all(color: theme.colorScheme.outlineVariant),
+                ),
+                child: Column(
+                  children: [
+                    _SummaryRow(
+                      label: '이벤트',
+                      value: event.title ?? '이벤트 정보 없음',
+                    ),
+                    _SummaryRow(
+                      label: '일시',
+                      value: dateLabel,
+                    ),
+                    _SummaryRow(
+                      label: '장소',
+                      value: location?.name ?? '장소 정보 없음',
+                    ),
+                    _SummaryRow(
+                      label: '티켓',
+                      value: ticket?.name ?? '티켓 정보 없음',
+                    ),
+                    _SummaryRow(
+                      label: '결제 금액',
+                      value: ticket == null
+                          ? '-'
+                          : '${formatter.format(ticket.price)}원',
+                      isLast: true,
+                    ),
+                  ],
+                ),
               ),
-              child: Column(
-                children: [
-                  _SummaryRow(
-                    label: '이벤트',
-                    value: event.title ?? '이벤트 정보 없음',
-                  ),
-                  _SummaryRow(
-                    label: '일시',
-                    value: dateLabel,
-                  ),
-                  _SummaryRow(
-                    label: '장소',
-                    value: location?.name ?? '장소 정보 없음',
-                  ),
-                  _SummaryRow(
-                    label: '티켓',
-                    value: ticket?.name ?? '티켓 정보 없음',
-                  ),
-                  _SummaryRow(
-                    label: '결제 금액',
-                    value: ticket == null
-                        ? '-'
-                        : '${formatter.format(ticket.price)}원',
-                    isLast: true,
-                  ),
-                ],
+              const SizedBox(height: MinglitSpacing.xlarge),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: onViewTickets,
+                  child: const Text('내 티켓 보기'),
+                ),
               ),
-            ),
-            const SizedBox(height: MinglitSpacing.xlarge),
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton(
-                onPressed: onViewTickets,
-                child: const Text('내 티켓 보기'),
+              const SizedBox(height: MinglitSpacing.small),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton(
+                  onPressed: onBackToEvent,
+                  child: const Text('이벤트로 돌아가기'),
+                ),
               ),
-            ),
-            const SizedBox(height: MinglitSpacing.small),
-            SizedBox(
-              width: double.infinity,
-              child: OutlinedButton(
-                onPressed: onBackToEvent,
-                child: const Text('이벤트로 돌아가기'),
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
-    ),
-  );
+    );
   }
 
   Ticket? _findTicket() {

--- a/apps/app_user/test/src/features/event/admission/payment_success_screen_test.dart
+++ b/apps/app_user/test/src/features/event/admission/payment_success_screen_test.dart
@@ -1,0 +1,113 @@
+// Fix #1656: PaymentSuccessScreen Android 뒤로가기 앱 이탈 회귀 방지
+//
+// Navigator.pushReplacement + GoRouter 혼용 시 Android 뒤로가기로 앱이 홈으로 이탈하는
+// 버그를 재현하는 테스트. PopScope(canPop: false)와 CloseButton이 onBackToEvent를
+// 위임하는지 검증한다.
+import 'package:app_user/src/features/event/admission/payment_success_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+void main() {
+  setUpAll(() async {
+    await initializeDateFormatting('ko_KR');
+  });
+
+  final now = DateTime(2026, 4, 5, 15);
+
+  final testTicket = Ticket(
+    id: 'ticket-1',
+    name: '일반 티켓',
+    price: 0,
+    createdAt: now,
+    updatedAt: now,
+  );
+
+  final testEvent = Event(
+    id: 'event-1',
+    partyId: 'party-1',
+    title: '무료 소개팅 파티',
+    startTime: now.add(const Duration(days: 1)),
+    endTime: now.add(const Duration(days: 1, hours: 3)),
+    createdAt: now,
+    updatedAt: now,
+    tickets: [testTicket],
+    entryGroups: [],
+  );
+
+  Widget buildWidget({
+    VoidCallback? onViewTickets,
+    VoidCallback? onBackToEvent,
+  }) {
+    return MaterialApp(
+      home: PaymentSuccessScreen(
+        event: testEvent,
+        ticketId: testTicket.id,
+        onViewTickets: onViewTickets ?? () {},
+        onBackToEvent: onBackToEvent ?? () {},
+      ),
+    );
+  }
+
+  group('PaymentSuccessScreen (Fix #1656 회귀)', () {
+    testWidgets('Android 뒤로가기 시 onBackToEvent 콜백이 호출된다', (tester) async {
+      var backCount = 0;
+      await tester.pumpWidget(buildWidget(onBackToEvent: () => backCount++));
+      await tester.pumpAndSettle();
+
+      // Simulate Android back button
+      final dynamic widgetsAppState =
+          tester.state(find.byType(WidgetsApp).first);
+      // ignore: avoid_dynamic_calls
+      await (widgetsAppState as dynamic).didPopRoute();
+      await tester.pumpAndSettle();
+
+      expect(backCount, 1);
+    });
+
+    testWidgets('CloseButton이 onBackToEvent 콜백을 사용한다 (Navigator.pop 금지)',
+        (tester) async {
+      var closeCount = 0;
+      await tester.pumpWidget(buildWidget(onBackToEvent: () => closeCount++));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(CloseButton));
+      await tester.pumpAndSettle();
+
+      expect(closeCount, 1);
+    });
+
+    testWidgets('"이벤트로 돌아가기" 버튼이 onBackToEvent 콜백을 호출한다', (tester) async {
+      var backCount = 0;
+      await tester.pumpWidget(buildWidget(onBackToEvent: () => backCount++));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('이벤트로 돌아가기'));
+      await tester.pumpAndSettle();
+
+      expect(backCount, 1);
+    });
+
+    testWidgets('"내 티켓 보기" 버튼이 onViewTickets 콜백을 호출한다', (tester) async {
+      var ticketsCount = 0;
+      await tester.pumpWidget(buildWidget(onViewTickets: () => ticketsCount++));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('내 티켓 보기'));
+      await tester.pumpAndSettle();
+
+      expect(ticketsCount, 1);
+    });
+
+    testWidgets('결제 완료 메시지와 티켓 요약이 표시된다', (tester) async {
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('결제가 완료되었습니다! '), findsOneWidget);
+      expect(find.text('티켓 요약'), findsOneWidget);
+      expect(find.text('무료 소개팅 파티'), findsOneWidget);
+      expect(find.text('일반 티켓'), findsOneWidget);
+    });
+  });
+}

--- a/apps/app_user/test/src/features/event/admission/payment_success_screen_test.dart
+++ b/apps/app_user/test/src/features/event/admission/payment_success_screen_test.dart
@@ -19,7 +19,6 @@ void main() {
   final testTicket = Ticket(
     id: 'ticket-1',
     name: '일반 티켓',
-    price: 0,
     createdAt: now,
     updatedAt: now,
   );
@@ -57,17 +56,18 @@ void main() {
       await tester.pumpAndSettle();
 
       // Simulate Android back button
-      final dynamic widgetsAppState =
-          tester.state(find.byType(WidgetsApp).first);
-      // ignore: avoid_dynamic_calls
+      final dynamic widgetsAppState = tester.state(
+        find.byType(WidgetsApp).first,
+      );
       await (widgetsAppState as dynamic).didPopRoute();
       await tester.pumpAndSettle();
 
       expect(backCount, 1);
     });
 
-    testWidgets('CloseButton이 onBackToEvent 콜백을 사용한다 (Navigator.pop 금지)',
-        (tester) async {
+    testWidgets('CloseButton이 onBackToEvent 콜백을 사용한다 (Navigator.pop 금지)', (
+      tester,
+    ) async {
       var closeCount = 0;
       await tester.pumpWidget(buildWidget(onBackToEvent: () => closeCount++));
       await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary

- `PaymentSuccessScreen`을 `PopScope(canPop: false)`로 감싸 Android 뒤로가기 차단
- `CloseButton`을 `onBackToEvent` 콜백으로 연결 (`Navigator.pop` 호출 제거)
- `PopScope`의 `onPopInvokedWithResult`에서 `onBackToEvent` 위임으로 route 상태 일관성 보장
- 회귀 방지 위젯 테스트 5개 추가 (`payment_success_screen_test.dart`)

**Root cause**: `Navigator.pushReplacement()`로 GoRouter 외부 스택에 push되어 Android 뒤로가기 시 GoRouter가 모르는 route에서 pop 발생 → 앱이 홈으로 이탈.

Closes #1656

## Test plan

- [x] `payment_success_screen_test.dart` — Android 뒤로가기 → `onBackToEvent` 호출 검증
- [x] CloseButton → `onBackToEvent` 콜백 호출 검증
- [x] "이벤트로 돌아가기" 버튼 → `onBackToEvent` 호출 검증
- [x] "내 티켓 보기" 버튼 → `onViewTickets` 호출 검증
- [x] 결제 완료 메시지 및 티켓 요약 렌더링 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)