### PR TITLE
fix(ui): MinglitImage 로드 실패 시 broken_image → placeholder 통일

### DIFF
--- a/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_image.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_image.dart
@@ -109,6 +109,7 @@ class MinglitImage extends StatelessWidget {
         );
       },
       // Fix #1558: errorBuilder에도 semantics 정책 적용
+      // Fix #1655: 로드 실패 시 broken_image 대신 placeholder — 네트워크 오류/404 엑박 방지
       errorBuilder: (context, error, stackTrace) {
         final theme = Theme.of(context);
         final fallback = Container(
@@ -118,7 +119,12 @@ class MinglitImage extends StatelessWidget {
             color: theme.colorScheme.surfaceContainerLow,
             borderRadius: BorderRadius.circular(MinglitRadius.small),
           ),
-          child: Icon(Icons.broken_image, color: theme.colorScheme.outline),
+          child: Center(
+            child: Icon(
+              Icons.image_not_supported_outlined,
+              color: theme.colorScheme.outline,
+            ),
+          ),
         );
         if (excludeFromSemantics) return ExcludeSemantics(child: fallback);
         if (semanticLabel != null) {

--- a/shared/packages/minglit_kit/test/ui/widgets/common/minglit_image_test.dart
+++ b/shared/packages/minglit_kit/test/ui/widgets/common/minglit_image_test.dart
@@ -6,44 +6,55 @@ Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
 
 void main() {
   group('MinglitImage', () {
-    testWidgets('빈 경로 → image_not_supported_outlined 표시, broken_image 없음', (tester) async {
-      await tester.pumpWidget(_wrap(
-        const MinglitImage(path: '', height: 100, width: 100),
-      ));
+    testWidgets('빈 경로 → image_not_supported_outlined 표시, broken_image 없음', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          const MinglitImage(path: '', height: 100, width: 100),
+        ),
+      );
       expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
       expect(find.byIcon(Icons.broken_image), findsNothing);
     });
 
     testWidgets('공백만 있는 경로 → image_not_supported_outlined 표시', (tester) async {
-      await tester.pumpWidget(_wrap(
-        const MinglitImage(path: '   ', height: 100, width: 100),
-      ));
+      await tester.pumpWidget(
+        _wrap(
+          const MinglitImage(path: '   ', height: 100, width: 100),
+        ),
+      );
       expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
     });
 
     // Fix #1655: 로드 실패 시 broken_image 대신 image_not_supported_outlined를 표시해야 함
-    testWidgets('네트워크 로드 실패 → image_not_supported_outlined 표시, broken_image 없음', (tester) async {
-      final errors = <FlutterErrorDetails>[];
-      final previousOnError = FlutterError.onError;
-      FlutterError.onError = errors.add;
-      addTearDown(() => FlutterError.onError = previousOnError);
+    testWidgets(
+      '네트워크 로드 실패 → image_not_supported_outlined 표시, broken_image 없음',
+      (tester) async {
+        final errors = <FlutterErrorDetails>[];
+        final previousOnError = FlutterError.onError;
+        FlutterError.onError = errors.add;
+        addTearDown(() => FlutterError.onError = previousOnError);
 
-      await tester.runAsync(() async {
-        await tester.pumpWidget(_wrap(
-          const MinglitImage(
-            // 존재하지 않는 호스트 — 테스트 환경에서 즉시 실패
-            path: 'http://localhost:0/nonexistent.jpg',
-            height: 100,
-            width: 100,
-          ),
-        ));
-        await Future<void>.delayed(const Duration(milliseconds: 500));
-      });
-      await tester.pump();
+        await tester.runAsync(() async {
+          await tester.pumpWidget(
+            _wrap(
+              const MinglitImage(
+                // 존재하지 않는 호스트 — 테스트 환경에서 즉시 실패
+                path: 'http://localhost:0/nonexistent.jpg',
+                height: 100,
+                width: 100,
+              ),
+            ),
+          );
+          await Future<void>.delayed(const Duration(milliseconds: 500));
+        });
+        await tester.pump();
 
-      expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
-      expect(find.byIcon(Icons.broken_image), findsNothing);
-    });
+        expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
+        expect(find.byIcon(Icons.broken_image), findsNothing);
+      },
+    );
 
     group('Semantics', () {
       testWidgets('semanticLabel is forwarded to underlying Image', (

--- a/shared/packages/minglit_kit/test/ui/widgets/common/minglit_image_test.dart
+++ b/shared/packages/minglit_kit/test/ui/widgets/common/minglit_image_test.dart
@@ -2,18 +2,47 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/ui/widgets/common/minglit_image.dart';
 
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
 void main() {
   group('MinglitImage', () {
-    testWidgets('empty path renders placeholder icon', (tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: MinglitImage(path: '', height: 80, width: 80),
+    testWidgets('빈 경로 → image_not_supported_outlined 표시, broken_image 없음', (tester) async {
+      await tester.pumpWidget(_wrap(
+        const MinglitImage(path: '', height: 100, width: 100),
+      ));
+      expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
+      expect(find.byIcon(Icons.broken_image), findsNothing);
+    });
+
+    testWidgets('공백만 있는 경로 → image_not_supported_outlined 표시', (tester) async {
+      await tester.pumpWidget(_wrap(
+        const MinglitImage(path: '   ', height: 100, width: 100),
+      ));
+      expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
+    });
+
+    // Fix #1655: 로드 실패 시 broken_image 대신 image_not_supported_outlined를 표시해야 함
+    testWidgets('네트워크 로드 실패 → image_not_supported_outlined 표시, broken_image 없음', (tester) async {
+      final errors = <FlutterErrorDetails>[];
+      final previousOnError = FlutterError.onError;
+      FlutterError.onError = errors.add;
+      addTearDown(() => FlutterError.onError = previousOnError);
+
+      await tester.runAsync(() async {
+        await tester.pumpWidget(_wrap(
+          const MinglitImage(
+            // 존재하지 않는 호스트 — 테스트 환경에서 즉시 실패
+            path: 'http://localhost:0/nonexistent.jpg',
+            height: 100,
+            width: 100,
           ),
-        ),
-      );
+        ));
+        await Future<void>.delayed(const Duration(milliseconds: 500));
+      });
+      await tester.pump();
 
       expect(find.byIcon(Icons.image_not_supported_outlined), findsOneWidget);
+      expect(find.byIcon(Icons.broken_image), findsNothing);
     });
 
     group('Semantics', () {


### PR DESCRIPTION
## Summary

- `MinglitImage.errorBuilder`에서 `Icons.broken_image` (엑박 아이콘) → `Icons.image_not_supported_outlined` + placeholder container로 교체
- 빈 URL 케이스(path.trim().isEmpty)와 로드 실패 케이스를 동일한 UI로 통일
- 네트워크 오류, 404, seed 데이터 URL 미존재 등 모든 실패 케이스에 일관된 플레이스홀더 표시

**Root cause**: PR #1637이 seed.dev.sql에 `picsum.photos` URL을 추가했으나 dev 환경에서 해당 URL 로드 실패 시 `errorBuilder`가 `Icons.broken_image` (엑박)을 표시.

Closes #1655

## Test plan

- [x] 빈 URL (`''`) → `image_not_supported_outlined` 아이콘 표시 (기존 동작)
- [x] 로드 실패 URL (404/네트워크 오류) → 동일하게 `image_not_supported_outlined` 아이콘 표시 (수정 동작)
- [x] 정상 로드 URL → 이미지 정상 표시 (영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)