### PR TITLE
fix(env): TICKET_SIGNING_*_KEY_JWK를 env-manifest.json에 등록

### DIFF
--- a/env-manifest.json
+++ b/env-manifest.json
@@ -191,6 +191,20 @@
             "desc": "OpenAI API key for tag extraction"
           }
         }
+      },
+      "user-get-ticket-token": {
+        "required": {
+          "TICKET_SIGNING_PRIVATE_KEY_JWK": {
+            "desc": "Ed25519 private key (OKP JWK) for signing ticket QR tokens"
+          }
+        }
+      },
+      "event-checkin": {
+        "required": {
+          "TICKET_SIGNING_PUBLIC_KEY_JWK": {
+            "desc": "Ed25519 public key (OKP JWK) for verifying QR token signatures"
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
## Summary

- `env-manifest.json`에 `user-get-ticket-token` Edge Function의 필수 환경 변수 2개 등록
  - `TICKET_SIGNING_PRIVATE_KEY_JWK`: Ed25519 private key (OKP JWK)
  - `TICKET_SIGNING_PUBLIC_KEY_JWK`: Ed25519 public key (OKP JWK)
- `check-env-manifest-sync` CI 검사에서 해당 env가 탐지되도록 함

**참고**: 실제 키 생성 및 Supabase Secret 설정은 issue #1657 코멘트 참조 (수동 처리 필요).

Closes #1657

## Test plan

- [x] `check-env-manifest-sync` CI job 통과 확인
- [ ] Mark님이 dev/prod Supabase에 Ed25519 키 쌍 시크릿 설정 후 QA에서 티켓 QR 코드 정상 로드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)