### PR TITLE
fix(partner): improve member management role display and alignment (#1662)

### DIFF
--- a/apps/app_partner/lib/l10n/app_ko.arb
+++ b/apps/app_partner/lib/l10n/app_ko.arb
@@ -165,6 +165,9 @@
   "memberList_title": "직원 관리",
   "memberList_button_add": "직원 추가",
   "memberList_empty": "등록된 직원이 없습니다.",
+  "memberList_role_owner": "소유자",
+  "memberList_role_manager": "매니저",
+  "memberList_role_staff": "스태프",
   "memberList_label_roleAndEmail": "역할: {role} ({email})",
   "@memberList_label_roleAndEmail": {
     "placeholders": {

--- a/apps/app_partner/lib/src/features/member/partner_member_list_page.dart
+++ b/apps/app_partner/lib/src/features/member/partner_member_list_page.dart
@@ -101,30 +101,76 @@ class PartnerMemberListPage extends ConsumerWidget {
     final userEmail = user['email'] as String? ?? '';
     final role = member['role'] as String? ?? 'staff';
 
-    return Card(
-      margin: const EdgeInsets.only(bottom: MinglitSpacing.small),
-      child: ListTile(
-        leading: const CircleAvatar(child: Icon(Icons.person)),
-        title: Text(
-          userName,
-          style: theme.textTheme.bodyLarge?.copyWith(
-            fontWeight: FontWeight.bold,
-          ),
+    final roleName = _getRoleName(context, role);
+    final roleInfo = userEmail.isNotEmpty ? '$roleName ($userEmail)' : roleName;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: MinglitSpacing.cardGap),
+      child: MinglitContentCard(
+        padding: const EdgeInsets.symmetric(
+          horizontal: MinglitSpacing.medium,
+          vertical: MinglitSpacing.sm,
         ),
-        subtitle: Text(
-          context.l10n.memberList_label_roleAndEmail(role, userEmail),
-        ),
-        trailing: const Icon(Icons.settings, size: MinglitIconSize.small),
         onTap: () {
-          // Fix #270: dynamic map에서 안전 캐스팅 — null이면 무시
           final targetUserId = member['user_id'] as String?;
           if (targetUserId == null) return;
           ref
               .read(memberCoordinatorProvider.notifier)
               .goToMemberPermission(partnerId, targetUserId);
         },
+        child: Row(
+          children: [
+            CircleAvatar(
+              backgroundColor: theme.colorScheme.primaryContainer,
+              child: Icon(
+                Icons.person,
+                color: theme.colorScheme.onPrimaryContainer,
+              ),
+            ),
+            const SizedBox(width: MinglitSpacing.medium),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    userName,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: MinglitSpacing.xxsmall),
+                  Text(
+                    roleInfo,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.outline,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Icon(
+              Icons.settings,
+              size: MinglitIconSize.small,
+              color: theme.colorScheme.outline,
+            ),
+          ],
+        ),
       ),
     );
+  }
+
+  String _getRoleName(BuildContext context, String role) {
+    switch (role) {
+      case 'owner':
+        return context.l10n.memberList_role_owner;
+      case 'manager':
+        return context.l10n.memberList_role_manager;
+      case 'staff':
+        return context.l10n.memberList_role_staff;
+      default:
+        return role;
+    }
   }
 
   Widget _buildErrorView(BuildContext context, WidgetRef ref, Object error) {

--- a/apps/app_partner/lib/src/l10n/generated/app_localizations.dart
+++ b/apps/app_partner/lib/src/l10n/generated/app_localizations.dart
@@ -802,6 +802,24 @@ abstract class AppLocalizations {
   /// **'등록된 직원이 없습니다.'**
   String get memberList_empty;
 
+  /// No description provided for @memberList_role_owner.
+  ///
+  /// In ko, this message translates to:
+  /// **'소유자'**
+  String get memberList_role_owner;
+
+  /// No description provided for @memberList_role_manager.
+  ///
+  /// In ko, this message translates to:
+  /// **'매니저'**
+  String get memberList_role_manager;
+
+  /// No description provided for @memberList_role_staff.
+  ///
+  /// In ko, this message translates to:
+  /// **'스태프'**
+  String get memberList_role_staff;
+
   /// No description provided for @memberList_label_roleAndEmail.
   ///
   /// In ko, this message translates to:

--- a/apps/app_partner/lib/src/l10n/generated/app_localizations_ko.dart
+++ b/apps/app_partner/lib/src/l10n/generated/app_localizations_ko.dart
@@ -388,6 +388,15 @@ class AppLocalizationsKo extends AppLocalizations {
   String get memberList_empty => '등록된 직원이 없습니다.';
 
   @override
+  String get memberList_role_owner => '소유자';
+
+  @override
+  String get memberList_role_manager => '매니저';
+
+  @override
+  String get memberList_role_staff => '스태프';
+
+  @override
   String memberList_label_roleAndEmail(String role, String email) {
     return '역할: $role ($email)';
   }


### PR DESCRIPTION
Scheduler: needs-uiux-gemini-1

### Summary
Fixes the role display bug and improves the vertical alignment in the Member Management list.

### Changes
1. **Role Display Bug Fix**: 
   - Added localized role names ('소유자', '매니저', '스태프') to app_ko.arb.
   - Prevented displaying empty parentheses when a member's email is missing.
   - Example: 'owner ()' -> '소유자'
2. **UI/UX Enhancement**:
   - Replaced standard Card + ListTile with MinglitContentCard for a more modern look consistent with the design system.
   - Used a custom Row + Column layout to perfectly center member name and role vertically relative to the avatar.
   - Applied MinglitSpacing.cardGap (12px) for consistent spacing between list items.

### Verification
- Ran flutter analyze on the modified file - Pass.
- Verified l10n generation - Pass.

Closes #1662
