### PR TITLE
fix(db): INV-01/INV-05 — free event 'approved' status + trigger INSERT fix

### DIFF
--- a/supabase/functions/apply-event/apply_event_test.ts
+++ b/supabase/functions/apply-event/apply_event_test.ts
@@ -493,6 +493,8 @@ Deno.test("apply-event - 취소 후 무료 재신청 성공 (UPDATE 경로, appl
     let patchCalled = false;
     let applyEventRpcCalled = false;
     let checkBalanceRpcCalled = false;
+    // Fix #1660: capture PATCH body to assert status='approved'
+    let patchBody: Record<string, unknown> = {};
 
     const { fetchMock } = createFetchMock([
       authRoute(),
@@ -525,6 +527,10 @@ Deno.test("apply-event - 취소 후 무료 재신청 성공 (UPDATE 경로, appl
         matcher: (req) => {
           if (req.url.includes("/rest/v1/event_applications") && req.method === "PATCH") {
             patchCalled = true;
+            // Fix #1660: capture body to assert status='approved' (not 'paid')
+            req.json().then((body: Record<string, unknown>) => {
+              patchBody = body;
+            });
             return true;
           }
           return false;
@@ -559,6 +565,8 @@ Deno.test("apply-event - 취소 후 무료 재신청 성공 (UPDATE 경로, appl
         assertEquals(checkBalanceRpcCalled, true, "check_party_balance RPC가 호출되어야 함 — Fix #1345");
         assertEquals(patchCalled, true, "PATCH(UPDATE)가 호출되어야 함 — INSERT 금지");
         assertEquals(applyEventRpcCalled, false, "apply_event RPC는 호출되면 안 됨 — plain INSERT로 충돌 발생");
+        // Fix #1660: free re-application must use 'approved' status, not 'paid'
+        assertEquals(patchBody?.status, "approved", "Fix #1660: 무료 재신청 PATCH status='approved' (not 'paid')");
       });
     });
   });

--- a/supabase/functions/apply-event/index.ts
+++ b/supabase/functions/apply-event/index.ts
@@ -236,7 +236,8 @@ Deno.serve(withHandler(async (req) => {
           return errorResponse(balance?.reason ?? "성비 균형 제한", 409);
         }
 
-        const newStatus = verification_data ? "pending_review" : "paid";
+        // Fix #1660: free re-applications use 'approved' (not 'paid') — payment_id is null for free events
+        const newStatus = verification_data ? "pending_review" : "approved";
         const { error: updateError } = await supabase
           .from("event_applications")
           .update({

--- a/supabase/migrations/20260420000002_fix_inv01_inv05_free_event_status.sql
+++ b/supabase/migrations/20260420000002_fix_inv01_inv05_free_event_status.sql
@@ -1,0 +1,172 @@
+-- Fix #1660: INV-01 (approved/paid apps without participant) + INV-05 (paid apps with null payment_id)
+--
+-- Root cause 1 (INV-05): apply_event RPC sets status='paid' for ALL apps without verification data,
+--   including free events where p_payment_id IS NULL. INV-05 requires status='paid' → payment_id IS NOT NULL.
+--   Fix: Use status='approved' when p_payment_id IS NULL (free events are auto-approved, not paid).
+--
+-- Root cause 2 (INV-01): issue_ticket_on_approval trigger fires on INSERT/UPDATE but the condition
+--   `old.status NOT IN ('approved', 'paid')` evaluates to NULL (falsy) for INSERTs because OLD IS NULL.
+--   So direct INSERTs with status='paid'/'approved' never create participant records.
+--   Fix: Add `OLD IS NULL` guard so INSERT with terminal status also triggers participant creation.
+
+-- ─────────────────────────────────────────────────────────
+-- 1. Data cleanup: paid apps with null payment_id → 'approved'
+--    These are free-event applications incorrectly marked as 'paid'.
+-- ─────────────────────────────────────────────────────────
+UPDATE public.event_applications
+SET status = 'approved'
+WHERE status = 'paid' AND payment_id IS NULL;
+
+-- ─────────────────────────────────────────────────────────
+-- 2. Data cleanup: create missing participant records for INV-01 violators
+--    Backfills participant rows for approved/paid apps that have none.
+-- ─────────────────────────────────────────────────────────
+INSERT INTO public.event_participants (
+  event_id, ticket_id, user_id, application_id, status, ticket_code,
+  display_name, birth_year
+)
+SELECT
+  a.event_id,
+  a.ticket_id,
+  a.user_id,
+  a.id,
+  'ticket_issued',
+  upper(substring(md5(gen_random_uuid()::text) FROM 1 FOR 8)),
+  up.name,
+  extract(year FROM up.birth_date)::int
+FROM public.event_applications a
+JOIN public.user_profiles up ON up.id = a.user_id
+LEFT JOIN public.event_participants p
+  ON p.event_id = a.event_id AND p.user_id = a.user_id
+WHERE a.status IN ('approved', 'paid')
+  AND p.id IS NULL;
+
+-- ─────────────────────────────────────────────────────────
+-- 3. Fix issue_ticket_on_approval trigger: handle INSERT (OLD IS NULL)
+--    Original condition: `old.status NOT IN ('approved', 'paid')`
+--    For INSERT triggers OLD IS NULL, so `NULL NOT IN (...)` = NULL (falsy) → trigger never fires.
+--    Fix: `(OLD IS NULL OR old.status NOT IN ('approved', 'paid'))` covers INSERT case.
+-- ─────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.issue_ticket_on_approval()
+RETURNS trigger
+SET search_path = public
+AS $$
+DECLARE
+  v_display_name text;
+  v_birth_year int;
+BEGIN
+  -- Fix #1660: OLD IS NULL for INSERT triggers; the original condition missed direct-insert applications.
+  IF (new.status IN ('approved', 'paid')
+      AND (OLD IS NULL OR old.status NOT IN ('approved', 'paid'))) THEN
+    SELECT name, extract(year FROM birth_date)::int
+    INTO v_display_name, v_birth_year
+    FROM public.user_profiles WHERE id = new.user_id;
+
+    INSERT INTO public.event_participants (
+      event_id, ticket_id, user_id, application_id, status, ticket_code,
+      display_name, birth_year
+    )
+    VALUES (
+      new.event_id, new.ticket_id, new.user_id, new.id, 'ticket_issued',
+      upper(substring(md5(gen_random_uuid()::text) FROM 1 FOR 8)),
+      v_display_name, v_birth_year
+    )
+    ON CONFLICT (event_id, user_id) DO NOTHING;
+  END IF;
+  RETURN new;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ─────────────────────────────────────────────────────────
+-- 4. Fix apply_event RPC: free events use 'approved' status (not 'paid')
+--    Old logic: p_verification_data IS NULL → v_status = 'paid' (incorrect for free events)
+--    New logic: only 'paid' when payment_id is provided; free events (payment_id IS NULL) get 'approved'
+-- ─────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.apply_event(
+  p_event_id uuid,
+  p_ticket_id uuid,
+  p_user_id uuid,
+  p_payment_id text,
+  p_payment_amount int,
+  p_verification_data jsonb DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_app_id uuid;
+  v_status text := 'pending_review';
+  v_balance_result jsonb;
+  v_event_status text;
+BEGIN
+  -- Fix #998: Validate event status — only 'scheduled' and 'active' allow applications
+  SELECT status INTO v_event_status
+  FROM public.events
+  WHERE id = p_event_id;
+
+  IF v_event_status IS NULL THEN
+    RAISE EXCEPTION '존재하지 않는 이벤트입니다.'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_event_status NOT IN ('scheduled', 'active') THEN
+    RAISE EXCEPTION '신청 불가 상태의 이벤트입니다: %', v_event_status
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  v_balance_result := public.check_party_balance(p_event_id, p_ticket_id);
+  IF (v_balance_result->>'allowed')::boolean IS NOT TRUE THEN
+    RAISE EXCEPTION '성비 균형 제한: %', v_balance_result->>'reason'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  -- Fix #1660: paid apps must have payment_id (INV-05).
+  --   Free events (payment_id IS NULL) → 'approved' (auto-approved, no payment).
+  --   Paid events (payment_id IS NOT NULL, no verification) → 'paid'.
+  IF p_verification_data IS NULL THEN
+    IF p_payment_id IS NOT NULL THEN
+      v_status := 'paid';
+    ELSE
+      v_status := 'approved';
+    END IF;
+  END IF;
+
+  INSERT INTO public.event_applications (
+    event_id, ticket_id, user_id,
+    payment_id, payment_amount, status
+  )
+  VALUES (
+    p_event_id, p_ticket_id, p_user_id,
+    p_payment_id, p_payment_amount, v_status
+  )
+  RETURNING id INTO v_app_id;
+
+  IF (p_verification_data IS NOT NULL) THEN
+    INSERT INTO public.user_verifications (user_id, verification_id, data)
+    VALUES (
+      p_user_id,
+      (p_verification_data->>'verification_id')::uuid,
+      p_verification_data->'data'
+    )
+    ON CONFLICT (user_id, verification_id)
+    DO UPDATE SET data = EXCLUDED.data, updated_at = now();
+
+    INSERT INTO public.verification_submissions (
+      partner_id, user_id, verification_id, application_id,
+      status, snapshot_data
+    )
+    VALUES (
+      (p_verification_data->>'partner_id')::uuid,
+      p_user_id,
+      (p_verification_data->>'verification_id')::uuid,
+      v_app_id,
+      'pending',
+      p_verification_data->'data'
+    );
+  END IF;
+
+  RETURN v_app_id;
+END;
+$$;

--- a/supabase/tests/database/81_inv01_inv05_regression_test.sql
+++ b/supabase/tests/database/81_inv01_inv05_regression_test.sql
@@ -1,0 +1,160 @@
+-- Regression tests for Fix #1660: INV-01 + INV-05
+--
+-- INV-01: approved/paid apps without participant record
+--   Root cause: issue_ticket_on_approval trigger skipped INSERT (OLD IS NULL → falsy)
+--   Fix: Added `OLD IS NULL` guard in trigger condition
+--
+-- INV-05: paid apps with NULL payment_id
+--   Root cause: apply_event RPC set status='paid' for free events (payment_id=NULL)
+--   Fix: apply_event uses status='approved' when payment_id IS NULL
+--
+-- Cases:
+--   1. apply_event(payment_id=NULL, amount=0) → status='approved' (not 'paid')
+--   2. apply_event(payment_id=NULL, amount=0) → participant record created by trigger
+--   3. Direct INSERT with status='approved' → participant record created by trigger
+--   4. apply_event(payment_id='some_id', amount=1000) → status='paid' (unchanged)
+
+BEGIN;
+SELECT plan(5);
+
+SELECT tests.authenticate_as_service_role();
+
+-- ============================================================
+-- Shared setup
+-- ============================================================
+CREATE TEMP TABLE inv_test_results (
+  test_case  text,
+  int_value  int,
+  text_value text
+);
+
+DO $$
+DECLARE
+  v_user1_id   uuid;
+  v_user2_id   uuid;
+  v_user3_id   uuid;
+  v_partner_id uuid;
+  v_party_id   uuid;
+  v_event1_id  uuid;
+  v_event2_id  uuid;
+  v_ticket1_id uuid;
+  v_ticket2_id uuid;
+  v_app_id     uuid;
+BEGIN
+  -- Users
+  v_user1_id := tests.create_supabase_user('inv_test_free_user_1');
+  v_user2_id := tests.create_supabase_user('inv_test_free_user_2');
+  v_user3_id := tests.create_supabase_user('inv_test_paid_user_1');
+
+  INSERT INTO public.user_profiles (id, name, birth_date, gender, username)
+  VALUES
+    (v_user1_id, 'INV Test User 1', '2000-01-01', 'male',   'inv_test_free_user_1'),
+    (v_user2_id, 'INV Test User 2', '2001-02-02', 'female', 'inv_test_free_user_2'),
+    (v_user3_id, 'INV Test User 3', '2000-03-03', 'male',   'inv_test_paid_user_1')
+  ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, birth_date = EXCLUDED.birth_date;
+
+  -- Partner / Party
+  INSERT INTO public.partners (name)
+  VALUES ('INV Test Partner')
+  RETURNING id INTO v_partner_id;
+
+  INSERT INTO public.parties (partner_id, title, min_confirmed_count, max_participants)
+  VALUES (v_partner_id, 'INV Test Party', 0, 10)
+  RETURNING id INTO v_party_id;
+
+  -- Free event
+  INSERT INTO public.events (party_id, start_time, end_time, min_confirmed_count, max_participants, status)
+  VALUES (v_party_id, now() + interval '1 day', now() + interval '1 day 2 hours', 0, 10, 'scheduled')
+  RETURNING id INTO v_event1_id;
+
+  INSERT INTO public.tickets (event_id, name, quantity, price)
+  VALUES (v_event1_id, 'Free Ticket', 10, 0)
+  RETURNING id INTO v_ticket1_id;
+
+  -- Paid event
+  INSERT INTO public.events (party_id, start_time, end_time, min_confirmed_count, max_participants, status)
+  VALUES (v_party_id, now() + interval '2 days', now() + interval '2 days 2 hours', 0, 10, 'scheduled')
+  RETURNING id INTO v_event2_id;
+
+  INSERT INTO public.tickets (event_id, name, quantity, price)
+  VALUES (v_event2_id, 'Paid Ticket', 10, 10000)
+  RETURNING id INTO v_ticket2_id;
+
+  -- ──────────────────────────────────────────────────────────
+  -- Case 1 + 2: apply_event with NULL payment_id (free event)
+  --   Expected: status='approved', participant created by trigger
+  -- ──────────────────────────────────────────────────────────
+  SELECT public.apply_event(v_event1_id, v_ticket1_id, v_user1_id, NULL, 0, NULL)
+  INTO v_app_id;
+
+  INSERT INTO inv_test_results (test_case, text_value)
+  SELECT 'free_apply_status', a.status
+  FROM public.event_applications a
+  WHERE a.id = v_app_id;
+
+  INSERT INTO inv_test_results (test_case, int_value)
+  SELECT 'free_apply_participant_count', count(*)::int
+  FROM public.event_participants
+  WHERE event_id = v_event1_id AND user_id = v_user1_id;
+
+  -- ──────────────────────────────────────────────────────────
+  -- Case 3: Direct INSERT with status='approved' → trigger must create participant
+  -- ──────────────────────────────────────────────────────────
+  INSERT INTO public.event_applications (event_id, ticket_id, user_id, status, payment_id, payment_amount)
+  VALUES (v_event1_id, v_ticket1_id, v_user2_id, 'approved', NULL, 0)
+  RETURNING id INTO v_app_id;
+
+  INSERT INTO inv_test_results (test_case, int_value)
+  SELECT 'direct_insert_approved_participant', count(*)::int
+  FROM public.event_participants
+  WHERE event_id = v_event1_id AND user_id = v_user2_id;
+
+  -- ──────────────────────────────────────────────────────────
+  -- Case 4: apply_event with non-null payment_id (paid event)
+  --   Expected: status='paid' (unchanged behavior)
+  -- ──────────────────────────────────────────────────────────
+  SELECT public.apply_event(v_event2_id, v_ticket2_id, v_user3_id, 'pay_test_001', 10000, NULL)
+  INTO v_app_id;
+
+  INSERT INTO inv_test_results (test_case, text_value)
+  SELECT 'paid_apply_status', a.status
+  FROM public.event_applications a
+  WHERE a.id = v_app_id;
+END $$;
+
+-- Test 1: free event apply → status='approved' (INV-05 fix)
+SELECT results_eq(
+  $$SELECT text_value FROM inv_test_results WHERE test_case = 'free_apply_status'$$,
+  $$VALUES ('approved')$$,
+  'INV-05 fix: apply_event(payment_id=NULL) → status=approved (not paid)'
+);
+
+-- Test 2: free event apply → participant created by trigger (INV-01 fix)
+SELECT results_eq(
+  $$SELECT int_value FROM inv_test_results WHERE test_case = 'free_apply_participant_count'$$,
+  $$SELECT 1::int$$,
+  'INV-01 fix: apply_event(payment_id=NULL) → trigger creates participant on INSERT'
+);
+
+-- Test 3: direct INSERT with status='approved' → trigger fires (INV-01 trigger fix)
+SELECT results_eq(
+  $$SELECT int_value FROM inv_test_results WHERE test_case = 'direct_insert_approved_participant'$$,
+  $$SELECT 1::int$$,
+  'INV-01 fix: direct INSERT with status=approved → trigger creates participant'
+);
+
+-- Test 4: paid event apply → status='paid' (existing behavior preserved)
+SELECT results_eq(
+  $$SELECT text_value FROM inv_test_results WHERE test_case = 'paid_apply_status'$$,
+  $$VALUES ('paid')$$,
+  'apply_event(payment_id NOT NULL) → status=paid (behavior preserved)'
+);
+
+-- Test 5: check_db_invariants passes after all operations above
+SELECT ok(
+  (SELECT (check_db_invariants())::json->>'passed' = 'true'),
+  'check_db_invariants() passes after INV-01/INV-05 fix'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Summary

P0 DB 불변 위반 INV-01, INV-05 두 건을 근본 원인 수준에서 수정합니다.

### Root cause 1 (INV-05): apply_event RPC
`apply_event` RPC가 `p_verification_data IS NULL`인 경우 모두 `status='paid'`로 설정했는데, 무료 이벤트도 해당 조건에 해당하여 `payment_id=NULL`인 상태에서 `paid`가 설정됨.

**Fix**: `p_payment_id IS NULL`이면 `status='approved'`, 실제 payment_id가 있을 때만 `status='paid'`.

### Root cause 2 (INV-01): issue_ticket_on_approval trigger
trigger는 INSERT/UPDATE 양쪽에서 실행되지만 `OLD.status NOT IN ('approved','paid')` 조건이 INSERT 시 OLD가 NULL이어서 NULL(falsy)로 평가됨. 직접 INSERT로 terminal status를 넣으면 participant record가 생성되지 않았음.

**Fix**: `OLD IS NULL` 가드를 추가하여 INSERT 시 `approved`/`paid` 상태도 trigger 조건을 만족하도록.

### One-time data fix (migration)
기존 위반 데이터 2건:
- `payment_id=NULL`인 `paid` application → `approved`로 정정
- participant 없는 `approved` application → trigger 재실행으로 participant 생성

Closes #1660

## Test plan

- [ ] `supabase/tests/database/81_inv01_inv05_regression_test.sql` pgTAP 테스트 통과
- [ ] `apply_event_test.ts` 무료 이벤트 시나리오 테스트 통과
- [ ] CI `test-supabase` job 통과
- [ ] 배포 후 `check_db_invariants()` → `passed: true`