### PR TITLE
fix(ci): patrol_test/ 디렉토리 신설 — patrol_cli 4.x Weekly Emulator Test 복구 (#1673)

### DIFF
--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -61,7 +61,14 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true
-          script: cd apps/app_user && patrol test --flavor dev --dart-define-from-file=../../minglit_env/dev/flutter.env patrol_test/kakao_login_test.dart patrol_test/payment_pg_test.dart patrol_test/permission_grant_test.dart
+          script: >
+            cd apps/app_user &&
+            patrol test
+            --flavor dev
+            --dart-define-from-file=../../minglit_env/dev/flutter.env
+            --target patrol_test/kakao_login_test.dart
+            --target patrol_test/payment_pg_test.dart
+            --target patrol_test/permission_grant_test.dart
 
       - name: Upload test results
         if: failure()

--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -2,10 +2,12 @@
 # This workflow is NOT part of ci-result and does NOT block PR merges.
 # Failures here are informational only; investigation happens separately.
 #
-# Runs only Patrol-native tests (patrolTest) in integration_test/.
+# Runs only Patrol-native tests (patrolTest) in patrol_test/.
 # scenario_screenshots_test.dart and apple_sign_in_test.dart use
 # IntegrationTestWidgetsFlutterBinding (incompatible with PatrolBinding)
 # and are excluded from this workflow — run them via `flutter test integration_test/`.
+#
+# Fix #1673: patrol_cli 4.x requires patrol_test/ directory — moved tests from integration_test/
 
 name: "Weekly: Emulator Test (Patrol native surface)"
 
@@ -59,7 +61,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true
-          script: cd apps/app_user && patrol test --flavor dev --dart-define-from-file=../../minglit_env/dev/flutter.env integration_test/kakao_login_test.dart integration_test/payment_pg_test.dart integration_test/permission_grant_test.dart
+          script: cd apps/app_user && patrol test --flavor dev --dart-define-from-file=../../minglit_env/dev/flutter.env patrol_test/kakao_login_test.dart patrol_test/payment_pg_test.dart patrol_test/permission_grant_test.dart
 
       - name: Upload test results
         if: failure()

--- a/apps/app_user/patrol_test/kakao_login_test.dart
+++ b/apps/app_user/patrol_test/kakao_login_test.dart
@@ -3,7 +3,7 @@
 //   - Real device/emulator + patrol_cli
 //   - Kakao test OAuth account credentials (see docs/features/patrol-introduction/)
 //
-// Run: cd apps/app_user && patrol test integration_test/kakao_login_test.dart
+// Run: cd apps/app_user && patrol test patrol_test/kakao_login_test.dart
 
 import 'package:patrol/patrol.dart';
 

--- a/apps/app_user/patrol_test/kakao_login_test.dart
+++ b/apps/app_user/patrol_test/kakao_login_test.dart
@@ -3,7 +3,8 @@
 //   - Real device/emulator + patrol_cli
 //   - Kakao test OAuth account credentials (see docs/features/patrol-introduction/)
 //
-// Run: cd apps/app_user && patrol test patrol_test/kakao_login_test.dart
+// Fix #1673: patrol_cli 4.x 문법으로 특정 테스트 실행
+// Run: cd apps/app_user && patrol test --target patrol_test/kakao_login_test.dart
 
 import 'package:patrol/patrol.dart';
 

--- a/apps/app_user/patrol_test/payment_pg_test.dart
+++ b/apps/app_user/patrol_test/payment_pg_test.dart
@@ -3,7 +3,8 @@
 //   - Real device/emulator + patrol_cli
 //   - PG sandbox credentials (see docs/features/patrol-introduction/)
 //
-// Run: cd apps/app_user && patrol test patrol_test/payment_pg_test.dart
+// Fix #1673: patrol_cli 4.x 문법으로 특정 테스트 실행
+// Run: cd apps/app_user && patrol test --target patrol_test/payment_pg_test.dart
 
 import 'package:patrol/patrol.dart';
 

--- a/apps/app_user/patrol_test/payment_pg_test.dart
+++ b/apps/app_user/patrol_test/payment_pg_test.dart
@@ -3,7 +3,7 @@
 //   - Real device/emulator + patrol_cli
 //   - PG sandbox credentials (see docs/features/patrol-introduction/)
 //
-// Run: cd apps/app_user && patrol test integration_test/payment_pg_test.dart
+// Run: cd apps/app_user && patrol test patrol_test/payment_pg_test.dart
 
 import 'package:patrol/patrol.dart';
 

--- a/apps/app_user/patrol_test/permission_grant_test.dart
+++ b/apps/app_user/patrol_test/permission_grant_test.dart
@@ -1,6 +1,6 @@
 // Phase 2: Native permission tests
 // Requires real device/emulator + patrol_cli to run:
-//   cd apps/app_user && patrol test integration_test/permission_grant_test.dart
+//   cd apps/app_user && patrol test patrol_test/permission_grant_test.dart
 //
 // These tests verify OS-level permission dialogs that cannot be tested
 // with Flutter's integration_test framework.

--- a/apps/app_user/patrol_test/permission_grant_test.dart
+++ b/apps/app_user/patrol_test/permission_grant_test.dart
@@ -1,6 +1,7 @@
 // Phase 2: Native permission tests
 // Requires real device/emulator + patrol_cli to run:
-//   cd apps/app_user && patrol test patrol_test/permission_grant_test.dart
+// Fix #1673: patrol_cli 4.x runs selected tests from patrol_test/
+//   cd apps/app_user && patrol test --target patrol_test/permission_grant_test.dart
 //
 // These tests verify OS-level permission dialogs that cannot be tested
 // with Flutter's integration_test framework.

--- a/docs/qa/automation-test-guide.md
+++ b/docs/qa/automation-test-guide.md
@@ -477,7 +477,8 @@ cd apps/app_user && flutter test --update-goldens --tags golden --dart-define=CI
 cd apps/app_user && flutter test test/integration/cuj_signup_to_apply_test.dart
 
 # Layer 3 (Patrol) — 로컬 emulator 필요
-cd apps/app_user && patrol test integration_test/permission_grant_test.dart
+cd apps/app_user && patrol test --target patrol_test/permission_grant_test.dart
+# 여러 파일: --target 반복 또는 --targets 콤마 구분
 # CI 에서는 patrol-e2e.yml 워크플로우
 
 # Layer 4 pgTAP

--- a/docs/qa/test-strategy.md
+++ b/docs/qa/test-strategy.md
@@ -156,10 +156,11 @@
 
 | 앱 | 위치 | 파일 수 | 성격 |
 |----|------|--------|------|
-| app_user | `apps/app_user/integration_test/` | 5 | `apple_sign_in`, `kakao_login`, `payment_pg`, `permission_grant`, `scenario_screenshots` — **native surface 특수 테스트만**. CUJ 이관 0% |
+| app_user | `apps/app_user/patrol_test/` | 3 | `kakao_login`, `payment_pg`, `permission_grant` — PatrolBinding, patrol_cli 4.x (`--target`) |
+| app_user | `apps/app_user/integration_test/` | 2 | `apple_sign_in`, `scenario_screenshots` — IntegrationTestWidgetsFlutterBinding |
 | app_partner | `apps/app_partner/integration_test/` | 1 | `scenario_screenshots` 만 |
 
-**Layer 3 런타임 상태**: `patrol-e2e.yml` 실행 이력 0건. `scenario_screenshots_test.dart` 내부 캡처 호출 0건. **사실상 죽은 상태.** 재가동 계획은 §6 로드맵 및 #1586 Phase D-2 참고.
+**Layer 3 런타임 상태**: `patrol-e2e.yml` 복구 완료 (#1673). `scenario_screenshots_test.dart` 내부 캡처 호출 0건. 재가동 계획은 §6 로드맵 및 #1586 Phase D-2 참고.
 
 ### Layer 4 — pgTAP
 


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1673

## 문제

patrol_cli 4.3.1부터 `patrol test` 실행 전 `patrol_test/` 디렉토리 존재 여부를 검증.
명시적 파일 경로를 전달해도 이 검증을 통과하지 못하면 즉시 실패:
```
Error: Directory .../apps/app_user/patrol_test doesn't exist
```

2주 연속 Weekly Emulator Test가 같은 원인으로 실패.

## 변경 내용

- `apps/app_user/patrol_test/` 디렉토리 신설 (patrol_cli 4.x 컨벤션 준수)
- PatrolBinding 기반 테스트 3개를 `integration_test/` → `patrol_test/`로 이동:
  - `kakao_login_test.dart`
  - `payment_pg_test.dart`
  - `permission_grant_test.dart`
- `IntegrationTestWidgetsFlutterBinding` 기반 테스트는 `integration_test/` 유지:
  - `scenario_screenshots_test.dart`
  - `apple_sign_in_test.dart`
- `.github/workflows/patrol-e2e.yml` 스크립트 경로 업데이트

## 참고

PR #1582도 `patrol-e2e.yml`을 수정하지만 `patrol_test/` 디렉토리는 다루지 않아 별도 처리.