### PR TITLE
fix(storage): bug-report-attachments RLS INSERT 정책 재설정 + pgTAP 테스트 (#1675)

### DIFF
--- a/supabase/migrations/20260421000001_fix_bug_report_storage_rls.sql
+++ b/supabase/migrations/20260421000001_fix_bug_report_storage_rls.sql
@@ -1,0 +1,34 @@
+-- Fix #1675: bug-report-attachments 버킷 RLS 정책 재설정
+-- 증상: 인증된 사용자가 스토리지 업로드 시 403 (new row violates row-level security policy)
+-- 원인: dev 인스턴스에서 INSERT 정책이 누락됐거나 비활성화됐을 가능성
+
+-- 버킷이 없으면 생성 (dev 인스턴스 리셋 후에도 안전하도록)
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'bug-report-attachments',
+  'bug-report-attachments',
+  true,
+  5242880,
+  ARRAY['image/png', 'image/jpeg', 'image/webp', 'text/plain']
+)
+ON CONFLICT (id) DO UPDATE
+  SET allowed_mime_types = ARRAY['image/png', 'image/jpeg', 'image/webp', 'text/plain'];
+
+-- 기존 정책 제거 후 재생성 (멱등성 보장)
+DROP POLICY IF EXISTS "Authenticated users can upload bug report attachments"
+  ON storage.objects;
+
+DROP POLICY IF EXISTS "Public read for bug report attachments"
+  ON storage.objects;
+
+-- Fix #1675: authenticated 사용자 업로드 허용
+CREATE POLICY "Authenticated users can upload bug report attachments"
+  ON storage.objects FOR INSERT
+  TO authenticated
+  WITH CHECK (bucket_id = 'bug-report-attachments');
+
+-- 공개 읽기 허용 (버그 리포트 이미지/덤프 링크 접근용)
+CREATE POLICY "Public read for bug report attachments"
+  ON storage.objects FOR SELECT
+  TO public
+  USING (bucket_id = 'bug-report-attachments');

--- a/supabase/tests/database/13_storage_rls_test.sql
+++ b/supabase/tests/database/13_storage_rls_test.sql
@@ -1,0 +1,61 @@
+-- Fix #1675: bug-report-attachments 스토리지 RLS 정책 검증
+BEGIN;
+SELECT plan(5);
+
+SET search_path TO storage, public, extensions;
+
+-- 버킷 존재 확인
+SELECT ok(
+  EXISTS (SELECT 1 FROM storage.buckets WHERE id = 'bug-report-attachments'),
+  'bug-report-attachments 버킷이 존재해야 함'
+);
+
+-- INSERT 정책 존재 확인
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'Authenticated users can upload bug report attachments'
+      AND cmd = 'INSERT'
+  ),
+  'authenticated INSERT 정책이 storage.objects에 존재해야 함'
+);
+
+-- SELECT 정책 존재 확인
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'Public read for bug report attachments'
+      AND cmd = 'SELECT'
+  ),
+  'public SELECT 정책이 storage.objects에 존재해야 함'
+);
+
+-- anon 사용자는 bug-report-attachments에 INSERT 불가
+SELECT tests.clear_authentication();
+SELECT is_empty(
+  $$INSERT INTO storage.objects (id, bucket_id, name, owner_id)
+    VALUES (gen_random_uuid(), 'bug-report-attachments', 'screenshots/anon-test.png', NULL)
+    RETURNING id$$,
+  'anon 사용자는 bug-report-attachments에 업로드할 수 없음'
+);
+
+-- authenticated 사용자는 bug-report-attachments에 INSERT 가능
+SELECT tests.create_supabase_user('qa_bug_report_tester');
+SELECT tests.authenticate_as('qa_bug_report_tester');
+SELECT lives_ok(
+  $$INSERT INTO storage.objects (id, bucket_id, name, owner_id)
+    VALUES (
+      gen_random_uuid(),
+      'bug-report-attachments',
+      'screenshots/auth-test.png',
+      tests.get_supabase_uid('qa_bug_report_tester')
+    )$$,
+  'authenticated 사용자는 bug-report-attachments에 업로드 가능'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/82_bug_report_storage_rls_test.sql
+++ b/supabase/tests/database/82_bug_report_storage_rls_test.sql
@@ -34,12 +34,12 @@ SELECT ok(
   'public SELECT 정책이 storage.objects에 존재해야 함'
 );
 
--- anon 사용자는 bug-report-attachments에 INSERT 불가
+-- anon 사용자는 bug-report-attachments에 INSERT 불가 (RLS exception 발생)
 SELECT tests.clear_authentication();
-SELECT is_empty(
+SELECT throws_ok(
   $$INSERT INTO storage.objects (id, bucket_id, name, owner_id)
-    VALUES (gen_random_uuid(), 'bug-report-attachments', 'screenshots/anon-test.png', NULL)
-    RETURNING id$$,
+    VALUES (gen_random_uuid(), 'bug-report-attachments', 'screenshots/anon-test.png', NULL)$$,
+  '42501',
   'anon 사용자는 bug-report-attachments에 업로드할 수 없음'
 );
 

--- a/supabase/tests/database/82_bug_report_storage_rls_test.sql
+++ b/supabase/tests/database/82_bug_report_storage_rls_test.sql
@@ -34,24 +34,27 @@ SELECT ok(
   'public SELECT 정책이 storage.objects에 존재해야 함'
 );
 
--- anon 사용자는 bug-report-attachments에 INSERT 불가 (RLS exception 발생)
+-- anon 사용자는 bug-report-attachments에 INSERT 불가 (RLS 42501 exception 발생)
 SELECT tests.clear_authentication();
 SELECT throws_ok(
-  $$INSERT INTO storage.objects (id, bucket_id, name, owner_id)
-    VALUES (gen_random_uuid(), 'bug-report-attachments', 'screenshots/anon-test.png', NULL)$$,
+  $$INSERT INTO storage.objects (id, bucket_id, name, owner, owner_id)
+    VALUES (gen_random_uuid(), 'bug-report-attachments', 'screenshots/anon-test.png', NULL, NULL)$$,
   '42501',
+  'new row violates row-level security policy for table "objects"',
   'anon 사용자는 bug-report-attachments에 업로드할 수 없음'
 );
 
 -- authenticated 사용자는 bug-report-attachments에 INSERT 가능
+-- owner: handle_storage_object_created trigger가 new.owner → minglit_files.owner_id에 씀
 SELECT tests.create_supabase_user('qa_bug_report_tester');
 SELECT tests.authenticate_as('qa_bug_report_tester');
 SELECT lives_ok(
-  $$INSERT INTO storage.objects (id, bucket_id, name, owner_id)
+  $$INSERT INTO storage.objects (id, bucket_id, name, owner, owner_id)
     VALUES (
       gen_random_uuid(),
       'bug-report-attachments',
       'screenshots/auth-test.png',
+      tests.get_supabase_uid('qa_bug_report_tester'),
       tests.get_supabase_uid('qa_bug_report_tester')
     )$$,
   'authenticated 사용자는 bug-report-attachments에 업로드 가능'


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1675

## 문제

QaBugReportChannel ADB broadcast 트리거 시 스토리지 업로드가 403으로 실패:
```
StorageException(message: new row violates row-level security policy, statusCode: 403, error: Unauthorized)
```

## 원인 분석

`bug-report-attachments` 버킷의 `storage.objects` INSERT 정책이 dev 인스턴스에서 누락되거나 drop된 상태. 기존 마이그레이션(`20260308000001`)은 `CREATE POLICY`로 작성되어 정책이 이미 존재하면 재실행 불가.

## 수정 내용

**`supabase/migrations/20260421000001_fix_bug_report_storage_rls.sql`**
- `DROP POLICY IF EXISTS` + `CREATE POLICY`로 멱등 재설정
- `ON CONFLICT DO UPDATE`로 버킷 `allowed_mime_types`도 최신화 (`text/plain` 포함 보장)

**`supabase/tests/database/13_storage_rls_test.sql`** (pgTAP)
- 버킷 존재 확인
- INSERT/SELECT 정책 존재 확인
- `anon` 업로드 차단 검증
- `authenticated` 업로드 허용 검증

## 검증

pgTAP 테스트로 정책 존재 + 역할별 접근 제어를 DB 레이어에서 검증.