### PR TITLE
fix(ci): patrol-e2e.yml — create-dev-flutter-env.sh 호출 step 추가

### DIFF
--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -28,6 +28,24 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Fix: CI checkout does not include the private minglit_env submodule.
+      # Rebuild the dev Flutter env file from Actions secrets before running Patrol.
+      # Same pattern as daily-backend-simulation.yml (Fix #1169).
+      - name: Create dev Flutter env file
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_DEV_URL }}
+          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }}
+          ENVIRONMENT: development
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN_FLUTTER }}
+          STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
+          GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_DEV_WEB_CLIENT_ID }}
+          KAKAO_LOCAL_REST_API_KEY: ${{ secrets.KAKAO_LOCAL_REST_API_KEY }}
+          KAKAO_MAP_JAVASCRIPT_KEY: ${{ secrets.KAKAO_MAP_JAVASCRIPT_KEY }}
+          JUSO_CONFIRM_KEY: ${{ secrets.JUSO_CONFIRM_KEY }}
+          IAMPORT_USER_CODE: ${{ secrets.IAMPORT_USER_CODE }}
+          MOBILE_REDIRECT_SCHEME: ${{ secrets.MOBILE_REDIRECT_SCHEME }}
+        run: bash .github/scripts/create-dev-flutter-env.sh
+
       - name: Set up Java
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
## Summary

- \`patrol-e2e.yml\`이 \`minglit_env/dev/flutter.env\` (private submodule)를 참조하지만 checkout 기본값은 submodule 포함 안 함 → \`Exception: Did not find the file passed to "--dart-define-from-file"\` 로 즉시 실패
- \`daily-backend-simulation.yml\`이 이미 쓰는 \`create-dev-flutter-env.sh\` 패턴(Fix #1169) 동일하게 적용

## Root cause

2주 연속 Weekly Emulator Test 실패는 **2가지 원인이 겹친 상태**:
1. \`patrol_cli 4.x\`가 \`patrol_test/\` 디렉토리 요구 → **PR #1674로 해결됨**
2. \`minglit_env\` submodule 미체크아웃 → **본 PR로 해결**

#1674 머지 후 수동 trigger(run 24707973950) 해보니 첫 번째 blocker는 통과했으나 두 번째 blocker 에서 9분만에 실패.

## Test plan

- [ ] 본 PR head branch에서 수동 trigger한 patrol-e2e workflow가 성공 (Patrol 인프라 첫 성공 run 달성)
- [ ] 머지 후 다음 Weekly cron (2026-04-27 Mon) 자동 trigger 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)