### PR TITLE
fix(ci): supabase-deploy.yml — PortOne secrets 자동 주입 추가 (#1575 해소)

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -60,6 +60,15 @@ jobs:
           STATSIG_SERVER_KEY: ${{ secrets.STATSIG_SERVER_KEY }}
           AXIOM_API_TOKEN: ${{ secrets.AXIOM_API_TOKEN }}
           SIM_USER_PASSWORD: ${{ secrets.SIM_USER_PASSWORD }}
+          # Fix #1683: PortOne secrets — dev/main 환경별 분기
+          PORTONE_API_KEY_DEV: ${{ secrets.PORTONE_DEV_API_KEY }}
+          PORTONE_API_SECRET_DEV: ${{ secrets.PORTONE_DEV_API_SECRET }}
+          PORTONE_V2_API_KEY_DEV: ${{ secrets.PORTONE_DEV_V2_API_KEY }}
+          PORTONE_V2_WEBHOOK_SECRET_DEV: ${{ secrets.PORTONE_DEV_V2_WEBHOOK_SECRET }}
+          PORTONE_API_KEY_MAIN: ${{ secrets.PORTONE_MAIN_API_KEY }}
+          PORTONE_API_SECRET_MAIN: ${{ secrets.PORTONE_MAIN_API_SECRET }}
+          PORTONE_V2_API_KEY_MAIN: ${{ secrets.PORTONE_MAIN_V2_API_KEY }}
+          PORTONE_V2_WEBHOOK_SECRET_MAIN: ${{ secrets.PORTONE_MAIN_V2_WEBHOOK_SECRET }}
         run: |
           supabase link --project-ref $SUPABASE_PROJECT_ID --password $SUPABASE_DB_PASSWORD
 
@@ -85,6 +94,35 @@ jobs:
               exit 1
             fi
             supabase secrets set SIM_USER_PASSWORD=$SIM_USER_PASSWORD
+          fi
+
+          # Fix #1683: PortOne secrets 환경별 선택 후 주입 — dev/main 분기
+          if [ "${{ steps.env.outputs.ENV }}" = "dev" ]; then
+            PK=$PORTONE_API_KEY_DEV
+            PS=$PORTONE_API_SECRET_DEV
+            PV2=$PORTONE_V2_API_KEY_DEV
+            PWH=$PORTONE_V2_WEBHOOK_SECRET_DEV
+          else
+            PK=$PORTONE_API_KEY_MAIN
+            PS=$PORTONE_API_SECRET_MAIN
+            PV2=$PORTONE_V2_API_KEY_MAIN
+            PWH=$PORTONE_V2_WEBHOOK_SECRET_MAIN
+          fi
+          if [ -n "$PK" ]; then
+            supabase secrets set PORTONE_API_KEY=$PK
+            supabase secrets set PORTONE_API_SECRET=$PS
+          else
+            echo "PORTONE_API_KEY not set — skipping V1 secrets injection"
+          fi
+          if [ -n "$PV2" ]; then
+            supabase secrets set PORTONE_V2_API_KEY=$PV2
+          else
+            echo "PORTONE_V2_API_KEY not set — skipping V2 API key injection"
+          fi
+          if [ -n "$PWH" ]; then
+            supabase secrets set PORTONE_V2_WEBHOOK_SECRET=$PWH
+          else
+            echo "PORTONE_V2_WEBHOOK_SECRET not set — skipping webhook secret injection"
           fi
 
           supabase db push --password $SUPABASE_DB_PASSWORD --include-all


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1683

## Summary

- `supabase-deploy.yml` Deploy step에 PortOne secrets 주입 추가
- 9개 Edge Function이 `PORTONE_API_KEY`/`PORTONE_API_SECRET`/`PORTONE_V2_API_KEY` 사용 중이나 미주입으로 런타임 throw 발생 (#1575, 4일째 자동 재생성)
- dev 분 GitHub secrets(`PORTONE_DEV_*`) 등록 완료 상태, main은 관리자 입력 대기

## 변경 내용

- `env:` 블록에 `PORTONE_*_DEV` / `PORTONE_*_MAIN` 8개 secret 참조 추가
- `ENV=dev/main` 분기로 적합한 secret 선택 후 `supabase secrets set` 호출
- 값 없으면 skip(echo) — main secrets 미등록 상태에서도 배포 실패 없음

## Test plan

- [ ] PR 머지 → dev 배포 시 `supabase secrets set PORTONE_*` 실행 로그 확인
- [ ] `Verify Edge Function env vars` step에서 PortOne 관련 누락 감지 0
- [ ] `#1575` 이슈에 새 auto-comment 생성 중단
- [ ] `payment-verify` / `settlement-register-transfers` EF 호출 시 env var throw 없음