### PR TITLE
feat(infra): admin schema + retention_policies — DB/Storage auto cleanup

### DIFF
--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -28,6 +28,24 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Fix: CI checkout does not include the private minglit_env submodule.
+      # Rebuild the dev Flutter env file from Actions secrets before running Patrol.
+      # Same pattern as daily-backend-simulation.yml (Fix #1169).
+      - name: Create dev Flutter env file
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_DEV_URL }}
+          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }}
+          ENVIRONMENT: development
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN_FLUTTER }}
+          STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
+          GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_DEV_WEB_CLIENT_ID }}
+          KAKAO_LOCAL_REST_API_KEY: ${{ secrets.KAKAO_LOCAL_REST_API_KEY }}
+          KAKAO_MAP_JAVASCRIPT_KEY: ${{ secrets.KAKAO_MAP_JAVASCRIPT_KEY }}
+          JUSO_CONFIRM_KEY: ${{ secrets.JUSO_CONFIRM_KEY }}
+          IAMPORT_USER_CODE: ${{ secrets.IAMPORT_USER_CODE }}
+          MOBILE_REDIRECT_SCHEME: ${{ secrets.MOBILE_REDIRECT_SCHEME }}
+        run: bash .github/scripts/create-dev-flutter-env.sh
+
       - name: Set up Java
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
## Summary

- **Phase 2**: Creates `admin` schema with `retention_policies` + `retention_policy_audit` tables, audit trigger, `delete_old_rows` and `archive_old_pgmq_messages` RPCs, and seeds 6 default policies (cron/net/pgmq/storage)
- **Phase 3**: Appends dev-environment retention overrides to `seed.sql` (shorter retention days to reduce disk usage)
- **Phase 4**: `cleanup-retention` Edge Function that processes all enabled policies — DB row deletion, Storage file removal in batches, PGMQ message archiving — with per-policy audit logging
- **Phase 5**: `pg_cron` schedule migration running `cleanup-retention` daily at 03:00 UTC (KST 12:00) via vault-sourced secrets

> Phase 1 (manual dev cleanup of existing 534MB accumulation) is handled separately via Supabase MCP.

## Migrations

| File | Description |
|------|-------------|
| `20260421000001_add_admin_schema_retention_policies.sql` | Admin schema + tables + RPCs + default seed |
| `20260421000002_schedule_cleanup_retention_cron.sql` | pg_cron job registration |

## Test plan

- [ ] Verify `deno check supabase/functions/cleanup-retention/index.ts` passes (confirmed locally)
- [ ] Apply migrations to dev Supabase and confirm `admin.retention_policies` has 6 rows
- [ ] Invoke `cleanup-retention` EF manually and confirm `last_run_*` fields update
- [ ] Confirm `admin.retention_policy_audit` rows are written after each run
- [ ] Verify `cron.job` has `cleanup-retention` entry after migration
- [ ] Confirm vault secrets `supabase_url` and `publishable_key` exist before cron fires
- [ ] Verify dev seed overrides apply (e.g. `net_http_response` should have `retention_days=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)