### PR TITLE
fix(partner): 파티 생성 버튼 탭 무응답 — GoRouter 인스턴스 직접 사용 (#1680)

### DIFF
--- a/apps/app_partner/lib/src/features/party/list/party_list_coordinator.dart
+++ b/apps/app_partner/lib/src/features/party/list/party_list_coordinator.dart
@@ -1,40 +1,27 @@
 import 'dart:async';
 
-import 'package:app_partner/src/features/party/create/party_create_wizard_page.dart';
-import 'package:app_partner/src/features/party/detail/party_detail_page.dart';
+import 'package:app_partner/src/routing/app_router.dart';
 import 'package:app_partner/src/routing/app_routes.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+final partyListCoordinatorProvider = Provider<PartyListCoordinator>((ref) {
+  return PartyListCoordinator(ref.read(goRouterProvider));
+});
 
 class PartyListCoordinator {
-  const PartyListCoordinator(this.context);
+  const PartyListCoordinator(this._router);
 
-  final BuildContext context;
+  final GoRouter _router;
 
+  // Fix #1680: context.push() fails silently when called from a page pushed via
+  // _router.push() — unawaited() drops async errors so the catch block is never
+  // reached. Use GoRouter instance directly, matching MoreCoordinator pattern.
   void goToCreate() {
-    try {
-      unawaited(const PartyCreateRoute().push<void>(context));
-    } on Object {
-      unawaited(
-        Navigator.of(context).push(
-          MaterialPageRoute<void>(
-            builder: (_) => const PartyCreateWizardPage(),
-          ),
-        ),
-      );
-    }
+    unawaited(_router.push(const PartyCreateRoute().location));
   }
 
   void goToDetail(String partyId) {
-    try {
-      unawaited(PartyDetailRoute(partyId: partyId).push<void>(context));
-    } on Object {
-      unawaited(
-        Navigator.of(context).push(
-          MaterialPageRoute<void>(
-            builder: (_) => PartyDetailPage(partyId: partyId),
-          ),
-        ),
-      );
-    }
+    unawaited(_router.push(PartyDetailRoute(partyId: partyId).location));
   }
 }

--- a/apps/app_partner/lib/src/features/party/list/party_list_page.dart
+++ b/apps/app_partner/lib/src/features/party/list/party_list_page.dart
@@ -11,13 +11,13 @@ class PartyListPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final partiesAsync = ref.watch(partyListProvider);
-    final coordinator = PartyListCoordinator(context);
+    final coordinator = ref.read(partyListCoordinatorProvider);
 
     return Scaffold(
       appBar: MinglitTheme.simpleAppBar(
         title: '파티 기획 관리',
         actions: [
-          // Fix #540: route-based navigation to checkin — removes qr→checkin cross-feature import
+          // Fix #540: route-based nav to checkin
           IconButton(
             icon: const Icon(Icons.qr_code_scanner),
             tooltip: 'QR 스캔',

--- a/apps/app_partner/test/src/features/party/list/party_list_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/party/list/party_list_coordinator_test.dart
@@ -1,79 +1,52 @@
 import 'package:app_partner/src/features/party/list/party_list_coordinator.dart';
-import 'package:flutter/material.dart';
+import 'package:app_partner/src/routing/app_router.dart';
+import 'package:app_partner/src/routing/app_routes.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 
-void main() {
-  group('PartyListCoordinator', () {
-    testWidgets('goToCreate triggers route push', (tester) async {
-      late PartyListCoordinator coordinator;
-      var pushCount = 0;
-
-      final observer = _CountingObserver(onPushed: () => pushCount++);
-
-      await tester.pumpWidget(
-        MaterialApp(
-          navigatorObservers: [observer],
-          home: Builder(
-            builder: (context) {
-              coordinator = PartyListCoordinator(context);
-              return const Scaffold(body: Text('test'));
-            },
-          ),
-        ),
-      );
-
-      final initialPushCount = pushCount;
-
-      // goToCreate falls back to Navigator.push when GoRouter is unavailable.
-      // The pushed page may throw during build (no ProviderScope), which is
-      // expected in this unit test scope — we only verify navigation triggers.
-      final originalOnError = FlutterError.onError;
-      FlutterError.onError = (details) {};
-      coordinator.goToCreate();
-      await tester.pump();
-      FlutterError.onError = originalOnError;
-
-      expect(pushCount, greaterThan(initialPushCount));
-    });
-
-    testWidgets('goToDetail triggers route push', (tester) async {
-      late PartyListCoordinator coordinator;
-      var pushCount = 0;
-
-      final observer = _CountingObserver(onPushed: () => pushCount++);
-
-      await tester.pumpWidget(
-        MaterialApp(
-          navigatorObservers: [observer],
-          home: Builder(
-            builder: (context) {
-              coordinator = PartyListCoordinator(context);
-              return const Scaffold(body: Text('test'));
-            },
-          ),
-        ),
-      );
-
-      final initialPushCount = pushCount;
-
-      final originalOnError = FlutterError.onError;
-      FlutterError.onError = (details) {};
-      coordinator.goToDetail('party-1');
-      await tester.pump();
-      FlutterError.onError = originalOnError;
-
-      expect(pushCount, greaterThan(initialPushCount));
-    });
-  });
-}
-
-class _CountingObserver extends NavigatorObserver {
-  _CountingObserver({required this.onPushed});
-
-  final VoidCallback onPushed;
+class FakeGoRouter extends Fake implements GoRouter {
+  final List<String> pushed = [];
 
   @override
-  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    onPushed();
+  Future<T?> push<T extends Object?>(String location, {Object? extra}) async {
+    pushed.add(location);
+    return null;
   }
+}
+
+void main() {
+  group('PartyListCoordinator (#1680)', () {
+    ProviderContainer buildContainer(FakeGoRouter fakeRouter) {
+      return ProviderContainer(
+        overrides: [goRouterProvider.overrideWithValue(fakeRouter)],
+      );
+    }
+
+    // Regression: context.push() discards async errors via unawaited() — catch
+    // block never reached. GoRouter instance must be used directly.
+    test('goToCreate pushes /more/parties/create via GoRouter instance', () {
+      final fakeRouter = FakeGoRouter();
+      final container = buildContainer(fakeRouter);
+      addTearDown(container.dispose);
+
+      container.read(partyListCoordinatorProvider).goToCreate();
+
+      expect(fakeRouter.pushed, [const PartyCreateRoute().location]);
+    });
+
+    test('goToDetail pushes /more/parties/:id via GoRouter instance', () {
+      const partyId = 'party-abc';
+      final fakeRouter = FakeGoRouter();
+      final container = buildContainer(fakeRouter);
+      addTearDown(container.dispose);
+
+      container.read(partyListCoordinatorProvider).goToDetail(partyId);
+
+      expect(
+        fakeRouter.pushed,
+        [PartyDetailRoute(partyId: partyId).location],
+      );
+    });
+  });
 }

--- a/apps/app_partner/test/src/features/party/list/party_list_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/party/list/party_list_coordinator_test.dart
@@ -45,7 +45,7 @@ void main() {
 
       expect(
         fakeRouter.pushed,
-        [PartyDetailRoute(partyId: partyId).location],
+        [const PartyDetailRoute(partyId: partyId).location],
       );
     });
   });


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1680

## 근본 원인

`PartyListCoordinator.goToCreate()`에서 `context.push('/more/parties/create')`를 호출 시:
1. `context.push()`가 `unawaited()`로 감싸져 async 예외를 버림
2. `on Object` catch block은 sync 예외만 잡음 → async 예외는 catch 미도달
3. `Navigator.of(context).push()` 폴백도 실행되지 않음 → 화면 전환 없음

`MoreCoordinator`는 `_router.push()` (GoRouter 인스턴스 직접)를 사용해 정상 동작.

## 변경 사항

- `PartyListCoordinator`: `BuildContext` → `GoRouter` 주입, `partyListCoordinatorProvider` 추가
- `PartyListPage`: `PartyListCoordinator(context)` → `ref.read(partyListCoordinatorProvider)`
- `goToDetail()`도 동일 패턴 적용 (미재현이었으나 동일 버그 보유)

## 테스트

- 2개 회귀 테스트: `goToCreate`/`goToDetail` 각각 올바른 GoRouter 경로 push 확인
- `flutter analyze`: No issues