### PR TITLE
fix(partner): prevent approved application from routing to home without partner record

### DIFF
--- a/apps/app_partner/lib/src/logic/onboarding_state_provider.dart
+++ b/apps/app_partner/lib/src/logic/onboarding_state_provider.dart
@@ -44,7 +44,10 @@ Future<OnboardingState> onboardingState(Ref ref) async {
     'draft' => OnboardingState.draftInProgress,
     'pending' => OnboardingState.pendingReview,
     'needs_correction' => OnboardingState.needsCorrection,
-    'approved' => OnboardingState.hasPartner,
+    // Fix #1679: 'approved' without a partner record means the partner setup
+    // trigger hasn't completed yet. Keep the user on /apply/status rather
+    // than home, where they have no partner data to display.
+    'approved' => OnboardingState.pendingReview,
     _ => OnboardingState.needsApplication, // rejected or unknown
   };
 }

--- a/apps/app_partner/test/src/features/onboarding/onboarding_state_provider_test.dart
+++ b/apps/app_partner/test/src/features/onboarding/onboarding_state_provider_test.dart
@@ -11,7 +11,10 @@ import '../../../../utils/test_utils.dart';
 User _makeUser() {
   return User(
     id: 'user-1',
-    appMetadata: const {'provider': 'email', 'providers': ['email']},
+    appMetadata: const {
+      'provider': 'email',
+      'providers': ['email'],
+    },
     userMetadata: const {},
     aud: 'authenticated',
     createdAt: DateTime(2026).toIso8601String(),

--- a/apps/app_partner/test/src/features/onboarding/onboarding_state_provider_test.dart
+++ b/apps/app_partner/test/src/features/onboarding/onboarding_state_provider_test.dart
@@ -5,8 +5,8 @@ import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-import '../../../../utils/mocks.dart';
-import '../../../../utils/test_utils.dart';
+import '../../../utils/mocks.dart';
+import '../../../utils/test_utils.dart';
 
 User _makeUser() {
   return User(

--- a/apps/app_partner/test/src/features/onboarding/onboarding_state_provider_test.dart
+++ b/apps/app_partner/test/src/features/onboarding/onboarding_state_provider_test.dart
@@ -1,5 +1,4 @@
 import 'package:app_partner/src/logic/onboarding_state_provider.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';

--- a/apps/app_partner/test/src/features/onboarding/onboarding_state_provider_test.dart
+++ b/apps/app_partner/test/src/features/onboarding/onboarding_state_provider_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../../utils/mocks.dart';
 import '../../../utils/test_utils.dart';

--- a/apps/app_partner/test/src/features/onboarding/onboarding_state_provider_test.dart
+++ b/apps/app_partner/test/src/features/onboarding/onboarding_state_provider_test.dart
@@ -1,5 +1,23 @@
 import 'package:app_partner/src/logic/onboarding_state_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../../../utils/mocks.dart';
+import '../../../../utils/test_utils.dart';
+
+User _makeUser() {
+  return User(
+    id: 'user-1',
+    appMetadata: const {'provider': 'email', 'providers': ['email']},
+    userMetadata: const {},
+    aud: 'authenticated',
+    createdAt: DateTime(2026).toIso8601String(),
+    identities: const [],
+  );
+}
 
 void main() {
   group('OnboardingState', () {
@@ -36,6 +54,99 @@ void main() {
       expect(OnboardingState.pendingReview.name, 'pendingReview');
       expect(OnboardingState.needsCorrection.name, 'needsCorrection');
       expect(OnboardingState.hasPartner.name, 'hasPartner');
+    });
+  });
+
+  group('onboardingStateProvider (#1679)', () {
+    late MockPartnerRepository mockPartnerRepo;
+    final testUser = _makeUser();
+
+    const approvedApplication = PartnerApplication(
+      id: 'app-1',
+      userId: 'user-1',
+      status: 'approved',
+    );
+
+    const pendingApplication = PartnerApplication(
+      id: 'app-1',
+      userId: 'user-1',
+      status: 'pending',
+    );
+
+    ProviderContainer buildContainer() {
+      return createContainer(
+        overrides: [
+          currentUserProvider.overrideWith((_) => testUser),
+          partnerRepositoryProvider.overrideWithValue(mockPartnerRepo),
+        ],
+      );
+    }
+
+    setUp(() {
+      mockPartnerRepo = MockPartnerRepository();
+    });
+
+    // Regression #1679: application status='approved' with no partner record
+    // previously returned hasPartner, sending the user to home with no partner
+    // data. getMyManagedPartners already checks for approved applications via
+    // fallback — reaching this branch means the partner record was never
+    // created. Must stay on /apply/status (pendingReview), not home.
+    test(
+      'returns pendingReview when application is approved but no partner exists',
+      () async {
+        when(
+          () => mockPartnerRepo.getMyManagedPartners(),
+        ).thenAnswer((_) async => []);
+        when(
+          () => mockPartnerRepo.getMyApplication(),
+        ).thenAnswer((_) async => approvedApplication);
+
+        final container = buildContainer();
+        final state = await container.read(onboardingStateProvider.future);
+
+        expect(state, OnboardingState.pendingReview);
+      },
+    );
+
+    test('returns hasPartner when managed partners exist', () async {
+      const fakePartner = Partner(id: 'partner-1', name: '테스트 파트너');
+      when(
+        () => mockPartnerRepo.getMyManagedPartners(),
+      ).thenAnswer((_) async => [fakePartner]);
+
+      final container = buildContainer();
+      final state = await container.read(onboardingStateProvider.future);
+
+      expect(state, OnboardingState.hasPartner);
+      verifyNever(() => mockPartnerRepo.getMyApplication());
+    });
+
+    test('returns pendingReview when application status is pending', () async {
+      when(
+        () => mockPartnerRepo.getMyManagedPartners(),
+      ).thenAnswer((_) async => []);
+      when(
+        () => mockPartnerRepo.getMyApplication(),
+      ).thenAnswer((_) async => pendingApplication);
+
+      final container = buildContainer();
+      final state = await container.read(onboardingStateProvider.future);
+
+      expect(state, OnboardingState.pendingReview);
+    });
+
+    test('returns needsApplication when no application exists', () async {
+      when(
+        () => mockPartnerRepo.getMyManagedPartners(),
+      ).thenAnswer((_) async => []);
+      when(
+        () => mockPartnerRepo.getMyApplication(),
+      ).thenAnswer((_) async => null);
+
+      final container = buildContainer();
+      final state = await container.read(onboardingStateProvider.future);
+
+      expect(state, OnboardingState.needsApplication);
     });
   });
 }


### PR DESCRIPTION
## Summary

- Fixes `onboarding_state_provider.dart`: `'approved'` application status with no managed partner record now maps to `pendingReview` instead of `hasPartner`
- Previously, `partner_apply_pending@test.com` (and any account whose application was approved but partner record creation failed) would be routed to home, showing a broken state with no partner data
- `getMyManagedPartners` already checks approved applications via its fallback path — if we reach the switch with `status='approved'`, it guarantees no partner record exists, so `hasPartner` was always wrong in that branch
- Adds regression tests for the `onboardingStateProvider` provider logic

Closes #1679

## Test plan

- [x] `onboardingStateProvider` unit tests added covering: approved-without-partner → `pendingReview`, existing-partner → `hasPartner`, pending → `pendingReview`, no-application → `needsApplication`
- [x] Existing `partner_redirect_test.dart` integration tests cover router redirect behavior (not modified)
- [ ] Manual: login as `partner_apply_pending@test.com` — should land on `/apply/status` instead of home

🤖 Generated with [Claude Code](https://claude.com/claude-code)