### PR TITLE
fix(router): U-R04 — minglit://explore/... 딥링크 홈 리다이렉트 누락 (#1701)

### DIFF
--- a/apps/app_user/lib/src/routing/app_router.dart
+++ b/apps/app_user/lib/src/routing/app_router.dart
@@ -37,7 +37,9 @@ GoRouter goRouter(Ref ref) {
       final consentState = ref.read(hasRequiredConsentsProvider);
 
       // Redirect /explore deep links to home (backward compat)
-      if (path.startsWith('/explore')) return '/';
+      // Fix #1701: minglit://explore/... comes in as host='explore', path='/*'
+      // so also check state.uri.host to catch both path and scheme forms.
+      if (path.startsWith('/explore') || state.uri.host == 'explore') return '/';
 
       // Allow dev pages without authentication
       if (path.startsWith('/dev')) return null;

--- a/apps/app_user/lib/src/routing/app_router.dart
+++ b/apps/app_user/lib/src/routing/app_router.dart
@@ -39,8 +39,9 @@ GoRouter goRouter(Ref ref) {
       // Redirect /explore deep links to home (backward compat)
       // Fix #1701: minglit://explore/... comes in as host='explore', path='/*'
       // so also check state.uri.host to catch both path and scheme forms.
-      if (path.startsWith('/explore') || state.uri.host == 'explore')
+      if (path.startsWith('/explore') || state.uri.host == 'explore') {
         return '/';
+      }
 
       // Allow dev pages without authentication
       if (path.startsWith('/dev')) return null;

--- a/apps/app_user/lib/src/routing/app_router.dart
+++ b/apps/app_user/lib/src/routing/app_router.dart
@@ -39,7 +39,8 @@ GoRouter goRouter(Ref ref) {
       // Redirect /explore deep links to home (backward compat)
       // Fix #1701: minglit://explore/... comes in as host='explore', path='/*'
       // so also check state.uri.host to catch both path and scheme forms.
-      if (path.startsWith('/explore') || state.uri.host == 'explore') return '/';
+      if (path.startsWith('/explore') || state.uri.host == 'explore')
+        return '/';
 
       // Allow dev pages without authentication
       if (path.startsWith('/dev')) return null;

--- a/apps/app_user/test/integration/utils/test_app.dart
+++ b/apps/app_user/test/integration/utils/test_app.dart
@@ -32,8 +32,9 @@ Widget createTestApp({
 
       // /explore → / (backward compat)
       // Fix #1701: minglit://explore/... arrives as host='explore', path='/*'
-      if (path.startsWith('/explore') || state.uri.host == 'explore')
+      if (path.startsWith('/explore') || state.uri.host == 'explore') {
         return '/';
+      }
 
       // /dev → bypass auth
       if (path.startsWith('/dev')) return null;

--- a/apps/app_user/test/integration/utils/test_app.dart
+++ b/apps/app_user/test/integration/utils/test_app.dart
@@ -31,7 +31,8 @@ Widget createTestApp({
       final path = state.uri.path;
 
       // /explore → / (backward compat)
-      if (path.startsWith('/explore')) return '/';
+      // Fix #1701: minglit://explore/... arrives as host='explore', path='/*'
+      if (path.startsWith('/explore') || state.uri.host == 'explore') return '/';
 
       // /dev → bypass auth
       if (path.startsWith('/dev')) return null;

--- a/apps/app_user/test/integration/utils/test_app.dart
+++ b/apps/app_user/test/integration/utils/test_app.dart
@@ -32,7 +32,8 @@ Widget createTestApp({
 
       // /explore → / (backward compat)
       // Fix #1701: minglit://explore/... arrives as host='explore', path='/*'
-      if (path.startsWith('/explore') || state.uri.host == 'explore') return '/';
+      if (path.startsWith('/explore') || state.uri.host == 'explore')
+        return '/';
 
       // /dev → bypass auth
       if (path.startsWith('/dev')) return null;

--- a/apps/app_user/test/src/routing/app_router_redirect_test.dart
+++ b/apps/app_user/test/src/routing/app_router_redirect_test.dart
@@ -37,7 +37,8 @@ String? _redirect({
   final queryParameters = uri.queryParameters;
 
   // Redirect /explore deep links to home (backward compat)
-  if (path.startsWith('/explore')) return '/';
+  // Fix #1701: minglit://explore/... comes in as host='explore', path='/*'
+  if (path.startsWith('/explore') || uri.host == 'explore') return '/';
 
   // Allow dev pages without authentication
   if (path.startsWith('/dev')) return null;
@@ -127,6 +128,24 @@ void main() {
     test('/explore/something redirects to /', () {
       final result = _redirect(
         location: '/explore/something',
+        isLoggedIn: false,
+      );
+      expect(result, '/');
+    });
+
+    // Fix #1701: Android intent delivers minglit://explore/events as a URI
+    // where host='explore' and path='/events', bypassing the path check above.
+    test('minglit://explore/events (scheme URL) redirects to /', () {
+      final result = _redirect(
+        location: 'minglit://explore/events',
+        isLoggedIn: false,
+      );
+      expect(result, '/');
+    });
+
+    test('minglit://explore/curation (scheme URL) redirects to /', () {
+      final result = _redirect(
+        location: 'minglit://explore/curation',
         isLoggedIn: false,
       );
       expect(result, '/');


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Root Cause

Android 인텐트로 `minglit://explore/events` URL이 전달될 때, GoRouter가 URI를 파싱하면:
- `host = 'explore'`
- `path = '/events'`

기존 redirect 조건 `path.startsWith('/explore')` 는 `path='/events'` に 매칭되지 않아 Unknown Route 에러 화면이 표시됐다.

## Fix

`state.uri.host == 'explore'` 조건을 추가해 scheme 형태의 딥링크(`minglit://explore/...`)도 홈(`/`)으로 리다이렉트.

세 파일 모두 동기 업데이트:
- `app_router.dart` — 실제 redirect 로직
- `app_router_redirect_test.dart` — 순수함수 미러 + 새 테스트 케이스 2개 추가
- `test/integration/utils/test_app.dart` — 위젯 테스트용 미러

Closes #1701

## Test plan

- [x] `app_router_redirect_test.dart` — `minglit://explore/events`, `minglit://explore/curation` 두 케이스 추가
- [x] 기존 `/explore`, `/explore/something` 테스트 그대로 통과
- [ ] CI flutter test 통과 확인