### PR TITLE
fix(lint): landing_partner/user — eslint-config-next babel/eslint-parser not found 수정

### DIFF
--- a/apps/landing_partner/eslint.config.mjs
+++ b/apps/landing_partner/eslint.config.mjs
@@ -2,10 +2,15 @@
 // eslint-config-next/core-web-vitals. The core-web-vitals entry point loads
 // eslint-config-next/dist/parser.js which requires
 // next/dist/compiled/babel/eslint-parser — a file removed in next@16+.
-// Direct plugin usage bypasses parser.js entirely.
+// Direct plugin usage bypasses parser.js entirely. React/react-hooks/jsx-a11y
+// plugins are wired explicitly to preserve the lint coverage that
+// eslint-config-next/core-web-vitals would have provided via its base config.
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextPlugin from "@next/eslint-plugin-next";
 import nextTs from "eslint-config-next/typescript";
+import reactPlugin from "eslint-plugin-react";
+import reactHooksPlugin from "eslint-plugin-react-hooks";
+import jsxA11y from "eslint-plugin-jsx-a11y";
 
 const eslintConfig = defineConfig([
   {
@@ -17,15 +22,25 @@ const eslintConfig = defineConfig([
       ...nextPlugin.configs["core-web-vitals"].rules,
     },
   },
-  ...nextTs,
   // eslint-plugin-react@7.x uses context.getFilename() which is not available
   // in flat config. Providing version explicitly avoids the detectReactVersion
   // call that triggers the crash. Remove once eslint-plugin-react supports flat config.
   {
+    plugins: {
+      react: reactPlugin,
+      "react-hooks": reactHooksPlugin,
+      "jsx-a11y": jsxA11y,
+    },
+    rules: {
+      ...reactPlugin.configs["jsx-runtime"].rules,
+      ...reactHooksPlugin.configs.recommended.rules,
+      ...jsxA11y.configs.recommended.rules,
+    },
     settings: {
       react: { version: "19" },
     },
   },
+  ...nextTs,
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/apps/landing_partner/eslint.config.mjs
+++ b/apps/landing_partner/eslint.config.mjs
@@ -1,9 +1,22 @@
+// Fix #1721: Import @next/eslint-plugin-next directly instead of
+// eslint-config-next/core-web-vitals. The core-web-vitals entry point loads
+// eslint-config-next/dist/parser.js which requires
+// next/dist/compiled/babel/eslint-parser — a file removed in next@16+.
+// Direct plugin usage bypasses parser.js entirely.
 import { defineConfig, globalIgnores } from "eslint/config";
-import nextVitals from "eslint-config-next/core-web-vitals";
+import nextPlugin from "@next/eslint-plugin-next";
 import nextTs from "eslint-config-next/typescript";
 
 const eslintConfig = defineConfig([
-  ...nextVitals,
+  {
+    plugins: {
+      "@next/next": nextPlugin,
+    },
+    rules: {
+      ...nextPlugin.configs.recommended.rules,
+      ...nextPlugin.configs["core-web-vitals"].rules,
+    },
+  },
   ...nextTs,
   // eslint-plugin-react@7.x uses context.getFilename() which is not available
   // in flat config. Providing version explicitly avoids the detectReactVersion

--- a/apps/landing_partner/eslint.config.mjs
+++ b/apps/landing_partner/eslint.config.mjs
@@ -1,54 +1,73 @@
-// Fix #1721: Import @next/eslint-plugin-next directly instead of
-// eslint-config-next/core-web-vitals. The core-web-vitals entry point loads
-// eslint-config-next/dist/parser.js which requires
-// next/dist/compiled/babel/eslint-parser — a file removed in next@16+.
-// Direct plugin usage bypasses parser.js entirely. React/react-hooks/jsx-a11y
-// plugins are wired explicitly to preserve the lint coverage that
-// eslint-config-next/core-web-vitals would have provided via its base config.
+// Fix #1721: eslint-config-next/dist/index.js loads ./parser which requires
+// next/dist/compiled/babel/eslint-parser — a file removed in Next.js 16+.
+// We replicate the full eslint-config-next base config inline, replacing the
+// broken babel parser with @typescript-eslint/parser (already used by the
+// 'next/typescript' overlay for .ts/.tsx). All plugins, rules, globs, globals,
+// and import-resolver settings from eslint-config-next v16.2.3 are preserved.
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextPlugin from "@next/eslint-plugin-next";
 import nextTs from "eslint-config-next/typescript";
 import reactPlugin from "eslint-plugin-react";
 import reactHooksPlugin from "eslint-plugin-react-hooks";
 import jsxA11y from "eslint-plugin-jsx-a11y";
+import * as importPlugin from "eslint-plugin-import";
+import globals from "globals";
 
 const eslintConfig = defineConfig([
+  // Mirrors eslint-config-next/dist/index.js "next" config block,
+  // with @typescript-eslint/parser replacing the missing babel parser.
   {
+    name: "next",
+    files: ["**/*.{js,jsx,mjs,ts,tsx,mts,cts}"],
     plugins: {
       "@next/next": nextPlugin,
-    },
-    rules: {
-      ...nextPlugin.configs.recommended.rules,
-      ...nextPlugin.configs["core-web-vitals"].rules,
-    },
-  },
-  // eslint-plugin-react@7.x uses context.getFilename() which is not available
-  // in flat config. Providing version explicitly avoids the detectReactVersion
-  // call that triggers the crash. Remove once eslint-plugin-react supports flat config.
-  {
-    plugins: {
       react: reactPlugin,
       "react-hooks": reactHooksPlugin,
       "jsx-a11y": jsxA11y,
+      import: importPlugin,
+    },
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+    settings: {
+      // eslint-plugin-react@7.x uses context.getFilename() in flat config;
+      // pinning version avoids the detectReactVersion crash.
+      react: { version: "19" },
+      "import/parsers": {
+        "@typescript-eslint/parser": [".ts", ".mts", ".cts", ".tsx", ".d.ts"],
+      },
+      "import/resolver": {
+        node: { extensions: [".js", ".jsx", ".ts", ".tsx"] },
+        typescript: { alwaysTryTypes: true },
+      },
     },
     rules: {
       ...reactPlugin.configs["jsx-runtime"].rules,
       ...reactHooksPlugin.configs.recommended.rules,
-      ...jsxA11y.configs.recommended.rules,
-    },
-    settings: {
-      react: { version: "19" },
+      ...nextPlugin.configs.recommended.rules,
+      ...nextPlugin.configs["core-web-vitals"].rules,
+      "import/no-anonymous-default-export": "warn",
+      "jsx-a11y/alt-text": [
+        "warn",
+        { elements: ["img"], img: ["Image"] },
+      ],
+      "jsx-a11y/aria-props": "warn",
+      "jsx-a11y/aria-proptypes": "warn",
+      "jsx-a11y/aria-unsupported-elements": "warn",
+      "jsx-a11y/role-has-required-aria-props": "warn",
+      "jsx-a11y/role-supports-aria-props": "warn",
+      "react/jsx-no-target-blank": "off",
+      "react/no-unknown-property": "off",
+      "react/react-in-jsx-scope": "off",
+      "react/prop-types": "off",
     },
   },
+  // TypeScript overlay: @typescript-eslint/parser + recommended rules for .ts/.tsx
   ...nextTs,
-  // Override default ignores of eslint-config-next.
-  globalIgnores([
-    // Default ignores of eslint-config-next:
-    ".next/**",
-    "out/**",
-    "build/**",
-    "next-env.d.ts",
-  ]),
+  globalIgnores([".next/**", "out/**", "build/**", "next-env.d.ts"]),
 ]);
 
 export default eslintConfig;

--- a/apps/landing_user/eslint.config.mjs
+++ b/apps/landing_user/eslint.config.mjs
@@ -2,10 +2,15 @@
 // eslint-config-next/core-web-vitals. The core-web-vitals entry point loads
 // eslint-config-next/dist/parser.js which requires
 // next/dist/compiled/babel/eslint-parser — a file removed in next@16+.
-// Direct plugin usage bypasses parser.js entirely.
+// Direct plugin usage bypasses parser.js entirely. React/react-hooks/jsx-a11y
+// plugins are wired explicitly to preserve the lint coverage that
+// eslint-config-next/core-web-vitals would have provided via its base config.
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextPlugin from "@next/eslint-plugin-next";
 import nextTs from "eslint-config-next/typescript";
+import reactPlugin from "eslint-plugin-react";
+import reactHooksPlugin from "eslint-plugin-react-hooks";
+import jsxA11y from "eslint-plugin-jsx-a11y";
 
 const eslintConfig = defineConfig([
   {
@@ -17,15 +22,25 @@ const eslintConfig = defineConfig([
       ...nextPlugin.configs["core-web-vitals"].rules,
     },
   },
-  ...nextTs,
   // eslint-plugin-react@7.x uses context.getFilename() which is not available
   // in flat config. Providing version explicitly avoids the detectReactVersion
   // call that triggers the crash. Remove once eslint-plugin-react supports flat config.
   {
+    plugins: {
+      react: reactPlugin,
+      "react-hooks": reactHooksPlugin,
+      "jsx-a11y": jsxA11y,
+    },
+    rules: {
+      ...reactPlugin.configs["jsx-runtime"].rules,
+      ...reactHooksPlugin.configs.recommended.rules,
+      ...jsxA11y.configs.recommended.rules,
+    },
     settings: {
       react: { version: "19" },
     },
   },
+  ...nextTs,
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/apps/landing_user/eslint.config.mjs
+++ b/apps/landing_user/eslint.config.mjs
@@ -1,9 +1,22 @@
+// Fix #1721: Import @next/eslint-plugin-next directly instead of
+// eslint-config-next/core-web-vitals. The core-web-vitals entry point loads
+// eslint-config-next/dist/parser.js which requires
+// next/dist/compiled/babel/eslint-parser — a file removed in next@16+.
+// Direct plugin usage bypasses parser.js entirely.
 import { defineConfig, globalIgnores } from "eslint/config";
-import nextVitals from "eslint-config-next/core-web-vitals";
+import nextPlugin from "@next/eslint-plugin-next";
 import nextTs from "eslint-config-next/typescript";
 
 const eslintConfig = defineConfig([
-  ...nextVitals,
+  {
+    plugins: {
+      "@next/next": nextPlugin,
+    },
+    rules: {
+      ...nextPlugin.configs.recommended.rules,
+      ...nextPlugin.configs["core-web-vitals"].rules,
+    },
+  },
   ...nextTs,
   // eslint-plugin-react@7.x uses context.getFilename() which is not available
   // in flat config. Providing version explicitly avoids the detectReactVersion

--- a/apps/landing_user/eslint.config.mjs
+++ b/apps/landing_user/eslint.config.mjs
@@ -1,54 +1,73 @@
-// Fix #1721: Import @next/eslint-plugin-next directly instead of
-// eslint-config-next/core-web-vitals. The core-web-vitals entry point loads
-// eslint-config-next/dist/parser.js which requires
-// next/dist/compiled/babel/eslint-parser — a file removed in next@16+.
-// Direct plugin usage bypasses parser.js entirely. React/react-hooks/jsx-a11y
-// plugins are wired explicitly to preserve the lint coverage that
-// eslint-config-next/core-web-vitals would have provided via its base config.
+// Fix #1721: eslint-config-next/dist/index.js loads ./parser which requires
+// next/dist/compiled/babel/eslint-parser — a file removed in Next.js 16+.
+// We replicate the full eslint-config-next base config inline, replacing the
+// broken babel parser with @typescript-eslint/parser (already used by the
+// 'next/typescript' overlay for .ts/.tsx). All plugins, rules, globs, globals,
+// and import-resolver settings from eslint-config-next v16.2.3 are preserved.
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextPlugin from "@next/eslint-plugin-next";
 import nextTs from "eslint-config-next/typescript";
 import reactPlugin from "eslint-plugin-react";
 import reactHooksPlugin from "eslint-plugin-react-hooks";
 import jsxA11y from "eslint-plugin-jsx-a11y";
+import * as importPlugin from "eslint-plugin-import";
+import globals from "globals";
 
 const eslintConfig = defineConfig([
+  // Mirrors eslint-config-next/dist/index.js "next" config block,
+  // with @typescript-eslint/parser replacing the missing babel parser.
   {
+    name: "next",
+    files: ["**/*.{js,jsx,mjs,ts,tsx,mts,cts}"],
     plugins: {
       "@next/next": nextPlugin,
-    },
-    rules: {
-      ...nextPlugin.configs.recommended.rules,
-      ...nextPlugin.configs["core-web-vitals"].rules,
-    },
-  },
-  // eslint-plugin-react@7.x uses context.getFilename() which is not available
-  // in flat config. Providing version explicitly avoids the detectReactVersion
-  // call that triggers the crash. Remove once eslint-plugin-react supports flat config.
-  {
-    plugins: {
       react: reactPlugin,
       "react-hooks": reactHooksPlugin,
       "jsx-a11y": jsxA11y,
+      import: importPlugin,
+    },
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+    settings: {
+      // eslint-plugin-react@7.x uses context.getFilename() in flat config;
+      // pinning version avoids the detectReactVersion crash.
+      react: { version: "19" },
+      "import/parsers": {
+        "@typescript-eslint/parser": [".ts", ".mts", ".cts", ".tsx", ".d.ts"],
+      },
+      "import/resolver": {
+        node: { extensions: [".js", ".jsx", ".ts", ".tsx"] },
+        typescript: { alwaysTryTypes: true },
+      },
     },
     rules: {
       ...reactPlugin.configs["jsx-runtime"].rules,
       ...reactHooksPlugin.configs.recommended.rules,
-      ...jsxA11y.configs.recommended.rules,
-    },
-    settings: {
-      react: { version: "19" },
+      ...nextPlugin.configs.recommended.rules,
+      ...nextPlugin.configs["core-web-vitals"].rules,
+      "import/no-anonymous-default-export": "warn",
+      "jsx-a11y/alt-text": [
+        "warn",
+        { elements: ["img"], img: ["Image"] },
+      ],
+      "jsx-a11y/aria-props": "warn",
+      "jsx-a11y/aria-proptypes": "warn",
+      "jsx-a11y/aria-unsupported-elements": "warn",
+      "jsx-a11y/role-has-required-aria-props": "warn",
+      "jsx-a11y/role-supports-aria-props": "warn",
+      "react/jsx-no-target-blank": "off",
+      "react/no-unknown-property": "off",
+      "react/react-in-jsx-scope": "off",
+      "react/prop-types": "off",
     },
   },
+  // TypeScript overlay: @typescript-eslint/parser + recommended rules for .ts/.tsx
   ...nextTs,
-  // Override default ignores of eslint-config-next.
-  globalIgnores([
-    // Default ignores of eslint-config-next:
-    ".next/**",
-    "out/**",
-    "build/**",
-    "next-env.d.ts",
-  ]),
+  globalIgnores([".next/**", "out/**", "build/**", "next-env.d.ts"]),
 ]);
 
 export default eslintConfig;


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1721

eslint-config-next/core-web-vitals → @next/eslint-plugin-next 직접 사용으로 교체.

Root cause: eslint-config-next/dist/parser.js가 next/dist/compiled/babel/eslint-parser를 require하나 next@16+에서 제거됨.

Fix: @next/eslint-plugin-next를 직접 import하여 parser.js 로딩 경로 우회. 동일한 recommended + core-web-vitals 규칙 세트 적용.