### PR TITLE
fix(app_partner): party create 버튼 무응답 + pending 테스트 계정 상태 초기화 (#1680, #1679)

### DIFF
--- a/apps/app_partner/lib/src/features/home/partner_home_coordinator.dart
+++ b/apps/app_partner/lib/src/features/home/partner_home_coordinator.dart
@@ -44,4 +44,10 @@ class PartnerHomeCoordinator {
   void pushEventCreate(String partyId) {
     unawaited(_router.push(EventCreateRoute(partyId: partyId).location));
   }
+
+  // Fix #1680: context.push() from HomeBranch fails for MoreBranch routes —
+  // use root GoRouter instance to cross shell-branch boundaries correctly.
+  void pushPartyCreate() {
+    unawaited(_router.push(const PartyCreateRoute().location));
+  }
 }

--- a/apps/app_partner/lib/src/features/home/partner_home_page.dart
+++ b/apps/app_partner/lib/src/features/home/partner_home_page.dart
@@ -108,9 +108,8 @@ class PartnerHomePage extends ConsumerWidget {
                       partyName: hasParties
                           ? state.activeParties.first.title
                           : null,
-                      onCreateParty: () {
-                        unawaited(const PartyCreateRoute().push<void>(context));
-                      },
+                      // Fix #1680: use coordinator to cross shell-branch boundary
+                      onCreateParty: coordinator.pushPartyCreate,
                       onCreateEvent: () async {
                         final parties = state.activeParties;
                         if (parties.length == 1) {
@@ -240,9 +239,8 @@ class PartnerHomePage extends ConsumerWidget {
             );
           }
         },
-        onCreateParty: () {
-          unawaited(const PartyCreateRoute().push<void>(context));
-        },
+        // Fix #1680: use coordinator to cross shell-branch boundary
+        onCreateParty: ref.read(partnerHomeCoordinatorProvider).pushPartyCreate,
       );
     }
 

--- a/apps/app_partner/lib/src/features/party/list/party_list_coordinator.dart
+++ b/apps/app_partner/lib/src/features/party/list/party_list_coordinator.dart
@@ -1,40 +1,28 @@
 import 'dart:async';
 
-import 'package:app_partner/src/features/party/create/party_create_wizard_page.dart';
-import 'package:app_partner/src/features/party/detail/party_detail_page.dart';
+import 'package:app_partner/src/routing/app_router.dart';
 import 'package:app_partner/src/routing/app_routes.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+// Fix #1680: inject GoRouter from provider so push() uses the root router
+// instance, not the shell-branch's nested navigator. context.push() from
+// within a StatefulShellBranch can fail silently when crossing branch
+// boundaries (e.g., HomeBranch → MoreBranch).
+final partyListCoordinatorProvider = Provider<PartyListCoordinator>((ref) {
+  return PartyListCoordinator(ref.read(goRouterProvider));
+});
 
 class PartyListCoordinator {
-  const PartyListCoordinator(this.context);
+  const PartyListCoordinator(this._router);
 
-  final BuildContext context;
+  final GoRouter _router;
 
   void goToCreate() {
-    try {
-      unawaited(const PartyCreateRoute().push<void>(context));
-    } on Object {
-      unawaited(
-        Navigator.of(context).push(
-          MaterialPageRoute<void>(
-            builder: (_) => const PartyCreateWizardPage(),
-          ),
-        ),
-      );
-    }
+    unawaited(_router.push(const PartyCreateRoute().location));
   }
 
   void goToDetail(String partyId) {
-    try {
-      unawaited(PartyDetailRoute(partyId: partyId).push<void>(context));
-    } on Object {
-      unawaited(
-        Navigator.of(context).push(
-          MaterialPageRoute<void>(
-            builder: (_) => PartyDetailPage(partyId: partyId),
-          ),
-        ),
-      );
-    }
+    unawaited(_router.push(PartyDetailRoute(partyId: partyId).location));
   }
 }

--- a/apps/app_partner/lib/src/features/party/list/party_list_page.dart
+++ b/apps/app_partner/lib/src/features/party/list/party_list_page.dart
@@ -11,7 +11,7 @@ class PartyListPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final partiesAsync = ref.watch(partyListProvider);
-    final coordinator = PartyListCoordinator(context);
+    final coordinator = ref.read(partyListCoordinatorProvider);
 
     return Scaffold(
       appBar: MinglitTheme.simpleAppBar(

--- a/apps/app_partner/lib/src/features/settlement/settlement_coordinator.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_coordinator.dart
@@ -31,6 +31,14 @@ class SettlementCoordinator extends _$SettlementCoordinator {
     );
   }
 
+  // Fix #1680: use root GoRouter to avoid silent failure when crossing shell
+  // branch boundaries (SettlementBranch → MoreBranch).
+  void goToPartyCreate() {
+    unawaited(
+      ref.read(goRouterProvider).push(const PartyCreateRoute().location),
+    );
+  }
+
   Future<void> retryPayout(
     BuildContext context, {
     required String payoutId,

--- a/apps/app_partner/lib/src/features/settlement/settlement_page.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_page.dart
@@ -449,6 +449,9 @@ class _ListTabState extends ConsumerState<_ListTab> {
                   actionLabel: listState.selectedStatus == null
                       ? '첫 이벤트 만들기'
                       : null,
+                  // Fix #1680: 동일 패턴 — StatefulShellBranch cross-branch push 방지
+                  // SettlementBranch → MoreBranch 경계에서 context.push()가 무음 실패하므로
+                  // root GoRouter를 사용하는 coordinator에 위임한다.
                   onAction: listState.selectedStatus == null
                       ? () => ref
                             .read(settlementCoordinatorProvider.notifier)

--- a/apps/app_partner/lib/src/features/settlement/settlement_page.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_page.dart
@@ -5,7 +5,6 @@ import 'package:app_partner/src/features/settlement/widgets/settlement_card.dart
 import 'package:app_partner/src/features/settlement/widgets/settlement_status_badge.dart';
 import 'package:app_partner/src/features/settlement/widgets/status_filter_chips.dart';
 import 'package:app_partner/src/logic/current_partner_provider.dart';
-import 'package:app_partner/src/routing/app_routes.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -451,7 +450,9 @@ class _ListTabState extends ConsumerState<_ListTab> {
                       ? '첫 이벤트 만들기'
                       : null,
                   onAction: listState.selectedStatus == null
-                      ? () => const PartyCreateRoute().push<void>(context)
+                      ? () => ref
+                            .read(settlementCoordinatorProvider.notifier)
+                            .goToPartyCreate()
                       : null,
                 )
               : RefreshIndicator(

--- a/apps/app_partner/test/src/features/party/list/party_list_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/party/list/party_list_coordinator_test.dart
@@ -1,79 +1,29 @@
 import 'package:app_partner/src/features/party/list/party_list_coordinator.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockGoRouter extends Mock implements GoRouter {}
 
 void main() {
   group('PartyListCoordinator', () {
-    testWidgets('goToCreate triggers route push', (tester) async {
-      late PartyListCoordinator coordinator;
-      var pushCount = 0;
+    late _MockGoRouter mockRouter;
+    late PartyListCoordinator coordinator;
 
-      final observer = _CountingObserver(onPushed: () => pushCount++);
-
-      await tester.pumpWidget(
-        MaterialApp(
-          navigatorObservers: [observer],
-          home: Builder(
-            builder: (context) {
-              coordinator = PartyListCoordinator(context);
-              return const Scaffold(body: Text('test'));
-            },
-          ),
-        ),
-      );
-
-      final initialPushCount = pushCount;
-
-      // goToCreate falls back to Navigator.push when GoRouter is unavailable.
-      // The pushed page may throw during build (no ProviderScope), which is
-      // expected in this unit test scope — we only verify navigation triggers.
-      final originalOnError = FlutterError.onError;
-      FlutterError.onError = (details) {};
-      coordinator.goToCreate();
-      await tester.pump();
-      FlutterError.onError = originalOnError;
-
-      expect(pushCount, greaterThan(initialPushCount));
+    setUp(() {
+      mockRouter = _MockGoRouter();
+      coordinator = PartyListCoordinator(mockRouter);
+      when(() => mockRouter.push(any())).thenAnswer((_) async => null);
     });
 
-    testWidgets('goToDetail triggers route push', (tester) async {
-      late PartyListCoordinator coordinator;
-      var pushCount = 0;
+    test('goToCreate pushes /more/parties/create', () {
+      coordinator.goToCreate();
+      verify(() => mockRouter.push('/more/parties/create')).called(1);
+    });
 
-      final observer = _CountingObserver(onPushed: () => pushCount++);
-
-      await tester.pumpWidget(
-        MaterialApp(
-          navigatorObservers: [observer],
-          home: Builder(
-            builder: (context) {
-              coordinator = PartyListCoordinator(context);
-              return const Scaffold(body: Text('test'));
-            },
-          ),
-        ),
-      );
-
-      final initialPushCount = pushCount;
-
-      final originalOnError = FlutterError.onError;
-      FlutterError.onError = (details) {};
-      coordinator.goToDetail('party-1');
-      await tester.pump();
-      FlutterError.onError = originalOnError;
-
-      expect(pushCount, greaterThan(initialPushCount));
+    test('goToDetail pushes /more/parties/<partyId>', () {
+      coordinator.goToDetail('party-123');
+      verify(() => mockRouter.push('/more/parties/party-123')).called(1);
     });
   });
-}
-
-class _CountingObserver extends NavigatorObserver {
-  _CountingObserver({required this.onPushed});
-
-  final VoidCallback onPushed;
-
-  @override
-  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    onPushed();
-  }
 }

--- a/supabase/seed.dev.sql
+++ b/supabase/seed.dev.sql
@@ -510,6 +510,10 @@ BEGIN
   END IF;
 
   -- pendingReview: partner_apply_pending
+  -- Fix #1679: INSERT if no application exists, then always UPDATE the most
+  -- recent row to status='pending'. Re-running seed now resets status even
+  -- when admin tests changed it to 'approved', preventing the account from
+  -- routing to / instead of /apply/status in QA smoke tests.
   SELECT id INTO apply_user_id FROM auth.users WHERE email = 'partner_apply_pending@test.com';
   IF apply_user_id IS NOT NULL THEN
     INSERT INTO public.partner_applications (
@@ -522,6 +526,15 @@ BEGIN
            'seed/biz_registration.png', 'seed/bankbook.png'
     WHERE NOT EXISTS (
       SELECT 1 FROM public.partner_applications WHERE user_id = apply_user_id
+    );
+    -- Reset to pending regardless (handles manually-changed status)
+    UPDATE public.partner_applications
+    SET status = 'pending'
+    WHERE id = (
+      SELECT id FROM public.partner_applications
+      WHERE user_id = apply_user_id
+      ORDER BY created_at DESC
+      LIMIT 1
     );
   END IF;
 END $$;

--- a/supabase/tests/database/86_seed_partner_apply_pending_regression_test.sql
+++ b/supabase/tests/database/86_seed_partner_apply_pending_regression_test.sql
@@ -1,0 +1,101 @@
+-- Regression test for #1679: partner_apply_pending seed must always reset
+-- application status to 'pending', even when it was manually changed to
+-- 'approved'. Without the fix, an admin test corrupts the account and it
+-- routes to / instead of /apply/status in QA smoke runs.
+BEGIN;
+
+SELECT plan(5);
+
+-- ── helpers ──────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION _seed_reset_partner_apply_pending()
+RETURNS void AS $$
+DECLARE
+  apply_user_id uuid;
+BEGIN
+  SELECT id INTO apply_user_id
+  FROM auth.users
+  WHERE email = 'partner_apply_pending@test.com';
+
+  IF apply_user_id IS NOT NULL THEN
+    -- Mirrors seed.dev.sql Fix #1679: INSERT if missing, then force-reset.
+    INSERT INTO public.partner_applications (
+      user_id, status, brand_name, biz_type, biz_name, biz_number,
+      representative_name, bank_name, account_number, account_holder,
+      biz_registration_path, bankbook_path
+    )
+    SELECT apply_user_id, 'pending', '심사 대기 브랜드', 'individual', '심사 대기 사업자',
+           '888-88-88888', '심사 대기 대표', '신한은행', '110-888-888880', '심사 대기 대표',
+           'seed/biz_registration.png', 'seed/bankbook.png'
+    WHERE NOT EXISTS (
+      SELECT 1 FROM public.partner_applications WHERE user_id = apply_user_id
+    );
+    UPDATE public.partner_applications
+    SET status = 'pending'
+    WHERE id = (
+      SELECT id FROM public.partner_applications
+      WHERE user_id = apply_user_id
+      ORDER BY created_at DESC
+      LIMIT 1
+    );
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 1. Seed user exists
+SELECT ok(
+  EXISTS(SELECT 1 FROM auth.users WHERE email = 'partner_apply_pending@test.com'),
+  'partner_apply_pending@test.com user exists in seed'
+);
+
+-- 2. After initial seed: status is 'pending'
+SELECT ok(
+  EXISTS(
+    SELECT 1
+    FROM public.partner_applications pa
+    JOIN auth.users u ON u.id = pa.user_id
+    WHERE u.email = 'partner_apply_pending@test.com'
+      AND pa.status = 'pending'
+  ),
+  'initial seed: most-recent application has status=pending'
+);
+
+-- 3. Simulate contamination: admin changes status to 'approved'
+UPDATE public.partner_applications
+SET status = 'approved'
+WHERE user_id = (SELECT id FROM auth.users WHERE email = 'partner_apply_pending@test.com')
+  AND id = (
+    SELECT pa.id FROM public.partner_applications pa
+    JOIN auth.users u ON u.id = pa.user_id
+    WHERE u.email = 'partner_apply_pending@test.com'
+    ORDER BY pa.created_at DESC
+    LIMIT 1
+  );
+
+SELECT ok(
+  EXISTS(
+    SELECT 1
+    FROM public.partner_applications pa
+    JOIN auth.users u ON u.id = pa.user_id
+    WHERE u.email = 'partner_apply_pending@test.com'
+      AND pa.status = 'approved'
+  ),
+  'contamination simulated: status changed to approved'
+);
+
+-- 4. Re-run seed reset (reproduces what seed.dev.sql does on next run)
+SELECT _seed_reset_partner_apply_pending();
+
+-- 5. After re-seed: status is back to 'pending'
+SELECT ok(
+  EXISTS(
+    SELECT 1
+    FROM public.partner_applications pa
+    JOIN auth.users u ON u.id = pa.user_id
+    WHERE u.email = 'partner_apply_pending@test.com'
+      AND pa.status = 'pending'
+  ),
+  'after re-seed: status reset to pending even when previously approved'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/86_seed_partner_apply_pending_regression_test.sql
+++ b/supabase/tests/database/86_seed_partner_apply_pending_regression_test.sql
@@ -34,7 +34,8 @@ BEGIN
 END $$;
 
 -- ── helper: mirrors seed.dev.sql Fix #1679 reset logic ───────────────────────
-CREATE OR REPLACE FUNCTION _regression_reset_apply_pending()
+-- pg_temp schema: session always has CREATE privilege (no public schema ownership needed)
+CREATE OR REPLACE FUNCTION pg_temp._regression_reset_apply_pending()
 RETURNS void AS $$
 DECLARE
   apply_user_id uuid;
@@ -113,7 +114,7 @@ SELECT ok(
 );
 
 -- 4. Re-run seed reset (reproduces what seed.dev.sql does on next run)
-SELECT _regression_reset_apply_pending();
+SELECT pg_temp._regression_reset_apply_pending();
 
 -- 5. After re-seed: status is back to 'pending'
 SELECT ok(

--- a/supabase/tests/database/86_seed_partner_apply_pending_regression_test.sql
+++ b/supabase/tests/database/86_seed_partner_apply_pending_regression_test.sql
@@ -1,23 +1,50 @@
--- Regression test for #1679: partner_apply_pending seed must always reset
--- application status to 'pending', even when it was manually changed to
--- 'approved'. Without the fix, an admin test corrupts the account and it
--- routes to / instead of /apply/status in QA smoke runs.
+-- Regression test for #1679: seed reset logic must always restore
+-- partner_apply_pending application status to 'pending', even when it was
+-- manually changed to 'approved'. Without the fix, an admin test corrupts
+-- the account and it routes to / instead of /apply/status in QA smoke runs.
+--
+-- Self-contained: creates its own fixtures — does NOT rely on dev seed data.
 BEGIN;
 
 SELECT plan(5);
 
--- ── helpers ──────────────────────────────────────────────────────────────────
-CREATE OR REPLACE FUNCTION _seed_reset_partner_apply_pending()
+SELECT tests.authenticate_as_service_role();
+
+-- ── fixtures ──────────────────────────────────────────────────────────────────
+DO $$
+DECLARE
+  v_user_id uuid;
+BEGIN
+  -- Create test user with a unique identifier; email is auto-generated.
+  v_user_id := tests.create_supabase_user(
+    'regression_apply_pending_1679',
+    'regression_apply_pending_1679@pgtap.local'
+  );
+
+  -- Insert a partner_applications row in 'pending' state (mirrors seed logic).
+  INSERT INTO public.partner_applications (
+    user_id, status, brand_name, biz_type, biz_name, biz_number,
+    representative_name, bank_name, account_number, account_holder,
+    biz_registration_path, bankbook_path
+  ) VALUES (
+    v_user_id, 'pending', '심사 대기 브랜드', 'individual', '심사 대기 사업자',
+    '888-88-88888', '심사 대기 대표', '신한은행', '110-888-888880', '심사 대기 대표',
+    'seed/biz_registration.png', 'seed/bankbook.png'
+  );
+END $$;
+
+-- ── helper: mirrors seed.dev.sql Fix #1679 reset logic ───────────────────────
+CREATE OR REPLACE FUNCTION _regression_reset_apply_pending()
 RETURNS void AS $$
 DECLARE
   apply_user_id uuid;
 BEGIN
   SELECT id INTO apply_user_id
   FROM auth.users
-  WHERE email = 'partner_apply_pending@test.com';
+  WHERE email = 'regression_apply_pending_1679@pgtap.local';
 
   IF apply_user_id IS NOT NULL THEN
-    -- Mirrors seed.dev.sql Fix #1679: INSERT if missing, then force-reset.
+    -- INSERT if somehow missing (mirrors seed idempotency guard).
     INSERT INTO public.partner_applications (
       user_id, status, brand_name, biz_type, biz_name, biz_number,
       representative_name, bank_name, account_number, account_holder,
@@ -29,6 +56,7 @@ BEGIN
     WHERE NOT EXISTS (
       SELECT 1 FROM public.partner_applications WHERE user_id = apply_user_id
     );
+    -- Force-reset status to 'pending' (the Fix #1679 invariant).
     UPDATE public.partner_applications
     SET status = 'pending'
     WHERE id = (
@@ -41,49 +69,51 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- 1. Seed user exists
+-- 1. Fixture user was created successfully
 SELECT ok(
-  EXISTS(SELECT 1 FROM auth.users WHERE email = 'partner_apply_pending@test.com'),
-  'partner_apply_pending@test.com user exists in seed'
+  EXISTS(SELECT 1 FROM auth.users WHERE email = 'regression_apply_pending_1679@pgtap.local'),
+  'fixture user regression_apply_pending_1679@pgtap.local exists'
 );
 
--- 2. After initial seed: status is 'pending'
+-- 2. After fixture insert: status is 'pending'
 SELECT ok(
   EXISTS(
     SELECT 1
     FROM public.partner_applications pa
     JOIN auth.users u ON u.id = pa.user_id
-    WHERE u.email = 'partner_apply_pending@test.com'
+    WHERE u.email = 'regression_apply_pending_1679@pgtap.local'
       AND pa.status = 'pending'
   ),
-  'initial seed: most-recent application has status=pending'
+  'initial fixture: most-recent application has status=pending'
 );
 
 -- 3. Simulate contamination: admin changes status to 'approved'
 UPDATE public.partner_applications
 SET status = 'approved'
-WHERE user_id = (SELECT id FROM auth.users WHERE email = 'partner_apply_pending@test.com')
-  AND id = (
-    SELECT pa.id FROM public.partner_applications pa
-    JOIN auth.users u ON u.id = pa.user_id
-    WHERE u.email = 'partner_apply_pending@test.com'
-    ORDER BY pa.created_at DESC
-    LIMIT 1
-  );
+WHERE user_id = (
+  SELECT id FROM auth.users WHERE email = 'regression_apply_pending_1679@pgtap.local'
+)
+AND id = (
+  SELECT pa.id FROM public.partner_applications pa
+  JOIN auth.users u ON u.id = pa.user_id
+  WHERE u.email = 'regression_apply_pending_1679@pgtap.local'
+  ORDER BY pa.created_at DESC
+  LIMIT 1
+);
 
 SELECT ok(
   EXISTS(
     SELECT 1
     FROM public.partner_applications pa
     JOIN auth.users u ON u.id = pa.user_id
-    WHERE u.email = 'partner_apply_pending@test.com'
+    WHERE u.email = 'regression_apply_pending_1679@pgtap.local'
       AND pa.status = 'approved'
   ),
   'contamination simulated: status changed to approved'
 );
 
 -- 4. Re-run seed reset (reproduces what seed.dev.sql does on next run)
-SELECT _seed_reset_partner_apply_pending();
+SELECT _regression_reset_apply_pending();
 
 -- 5. After re-seed: status is back to 'pending'
 SELECT ok(
@@ -91,7 +121,7 @@ SELECT ok(
     SELECT 1
     FROM public.partner_applications pa
     JOIN auth.users u ON u.id = pa.user_id
-    WHERE u.email = 'partner_apply_pending@test.com'
+    WHERE u.email = 'regression_apply_pending_1679@pgtap.local'
       AND pa.status = 'pending'
   ),
   'after re-seed: status reset to pending even when previously approved'

--- a/supabase/tests/database/86_seed_partner_apply_pending_regression_test.sql
+++ b/supabase/tests/database/86_seed_partner_apply_pending_regression_test.sql
@@ -6,7 +6,7 @@
 -- Self-contained: creates its own fixtures — does NOT rely on dev seed data.
 BEGIN;
 
-SELECT plan(5);
+SELECT plan(4);
 
 SELECT tests.authenticate_as_service_role();
 

--- a/supabase/tests/database/86_seed_partner_apply_pending_regression_test.sql
+++ b/supabase/tests/database/86_seed_partner_apply_pending_regression_test.sql
@@ -10,18 +10,23 @@ SELECT plan(5);
 
 SELECT tests.authenticate_as_service_role();
 
+-- TEMP TABLE to pass user_id between DO blocks without querying auth.users directly
+CREATE TEMP TABLE _regression_1679_state (
+  user_id uuid
+) ON COMMIT DROP;
+
 -- ── fixtures ──────────────────────────────────────────────────────────────────
 DO $$
 DECLARE
   v_user_id uuid;
 BEGIN
-  -- Create test user with a unique identifier; email is auto-generated.
   v_user_id := tests.create_supabase_user(
     'regression_apply_pending_1679',
     'regression_apply_pending_1679@pgtap.local'
   );
 
-  -- Insert a partner_applications row in 'pending' state (mirrors seed logic).
+  INSERT INTO _regression_1679_state (user_id) VALUES (v_user_id);
+
   INSERT INTO public.partner_applications (
     user_id, status, brand_name, biz_type, biz_name, biz_number,
     representative_name, bank_name, account_number, account_holder,
@@ -40,12 +45,9 @@ RETURNS void AS $$
 DECLARE
   apply_user_id uuid;
 BEGIN
-  SELECT id INTO apply_user_id
-  FROM auth.users
-  WHERE email = 'regression_apply_pending_1679@pgtap.local';
+  SELECT user_id INTO apply_user_id FROM _regression_1679_state LIMIT 1;
 
   IF apply_user_id IS NOT NULL THEN
-    -- INSERT if somehow missing (mirrors seed idempotency guard).
     INSERT INTO public.partner_applications (
       user_id, status, brand_name, biz_type, biz_name, biz_number,
       representative_name, bank_name, account_number, account_holder,
@@ -57,7 +59,6 @@ BEGIN
     WHERE NOT EXISTS (
       SELECT 1 FROM public.partner_applications WHERE user_id = apply_user_id
     );
-    -- Force-reset status to 'pending' (the Fix #1679 invariant).
     UPDATE public.partner_applications
     SET status = 'pending'
     WHERE id = (
@@ -72,8 +73,8 @@ $$ LANGUAGE plpgsql;
 
 -- 1. Fixture user was created successfully
 SELECT ok(
-  EXISTS(SELECT 1 FROM auth.users WHERE email = 'regression_apply_pending_1679@pgtap.local'),
-  'fixture user regression_apply_pending_1679@pgtap.local exists'
+  (SELECT count(*) FROM _regression_1679_state) = 1,
+  'fixture user created successfully'
 );
 
 -- 2. After fixture insert: status is 'pending'
@@ -81,8 +82,7 @@ SELECT ok(
   EXISTS(
     SELECT 1
     FROM public.partner_applications pa
-    JOIN auth.users u ON u.id = pa.user_id
-    WHERE u.email = 'regression_apply_pending_1679@pgtap.local'
+    WHERE pa.user_id = (SELECT user_id FROM _regression_1679_state LIMIT 1)
       AND pa.status = 'pending'
   ),
   'initial fixture: most-recent application has status=pending'
@@ -91,14 +91,11 @@ SELECT ok(
 -- 3. Simulate contamination: admin changes status to 'approved'
 UPDATE public.partner_applications
 SET status = 'approved'
-WHERE user_id = (
-  SELECT id FROM auth.users WHERE email = 'regression_apply_pending_1679@pgtap.local'
-)
+WHERE user_id = (SELECT user_id FROM _regression_1679_state LIMIT 1)
 AND id = (
-  SELECT pa.id FROM public.partner_applications pa
-  JOIN auth.users u ON u.id = pa.user_id
-  WHERE u.email = 'regression_apply_pending_1679@pgtap.local'
-  ORDER BY pa.created_at DESC
+  SELECT id FROM public.partner_applications
+  WHERE user_id = (SELECT user_id FROM _regression_1679_state LIMIT 1)
+  ORDER BY created_at DESC
   LIMIT 1
 );
 
@@ -106,8 +103,7 @@ SELECT ok(
   EXISTS(
     SELECT 1
     FROM public.partner_applications pa
-    JOIN auth.users u ON u.id = pa.user_id
-    WHERE u.email = 'regression_apply_pending_1679@pgtap.local'
+    WHERE pa.user_id = (SELECT user_id FROM _regression_1679_state LIMIT 1)
       AND pa.status = 'approved'
   ),
   'contamination simulated: status changed to approved'
@@ -121,8 +117,7 @@ SELECT ok(
   EXISTS(
     SELECT 1
     FROM public.partner_applications pa
-    JOIN auth.users u ON u.id = pa.user_id
-    WHERE u.email = 'regression_apply_pending_1679@pgtap.local'
+    WHERE pa.user_id = (SELECT user_id FROM _regression_1679_state LIMIT 1)
       AND pa.status = 'pending'
   ),
   'after re-seed: status reset to pending even when previously approved'


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1680
Closes #1679

## 문제

### #1680 — P-S15: 파티 생성 버튼 탭 무응답
`PartyListCoordinator.goToCreate()`와 `PartnerHomePage`의 `onCreateParty`에서
`context.push()`를 사용해 `PartyCreateRoute`를 push하면, `StatefulShellBranch`
내부 또는 cross-branch 경계에서 Future가 무음 실패하여 화면 전환이 발생하지 않음.

### #1679 — P-S04: partner_apply_pending 계정이 PENDING 대신 홈 화면 표시
`seed.dev.sql`의 INSERT 로직이 `WHERE NOT EXISTS`로만 동작해, DB 상태가
admin 테스트 등으로 `approved`로 변경된 경우 재시드해도 복구되지 않음.

## 수정 내용

### Fix #1680
- `PartyListCoordinator`: `BuildContext` 기반에서 `GoRouter` 인스턴스 주입으로 변경 (`goRouterProvider`)
- `partyListCoordinatorProvider` 추가 — `MoreCoordinator`와 동일한 패턴
- `PartyListPage`: `PartyListCoordinator(context)` → `ref.read(partyListCoordinatorProvider)`
- `PartnerHomeCoordinator`: `pushPartyCreate()` 추가
- `PartnerHomePage`: `onCreateParty` 콜백 → `coordinator.pushPartyCreate` 위임

### Fix #1679
- `seed.dev.sql`: INSERT 후 항상 최신 application을 `status = 'pending'`으로 UPDATE