### PR TITLE
feat(retention): 결제 레코드 원본 테이블 5년 보호 메타 등록 (#1704)

### DIFF
--- a/supabase/migrations/20260422000003_payment_retention_protection.sql
+++ b/supabase/migrations/20260422000003_payment_retention_protection.sql
@@ -1,0 +1,35 @@
+-- feat #1704: 결제 레코드 원본 테이블 삭제 방어 (전자상거래법 §6 5년)
+-- enabled=false: 자동 파기 대상 아님 (원본 유지)
+-- legal_min_days=1825: 최소 5년 보관 강제 (전자상거래법 §6)
+
+INSERT INTO admin.retention_policies
+  (id, kind, retention_days, legal_min_days, target, enabled, description)
+VALUES
+  (
+    'event_applications_payment',
+    'db_table',
+    1825,
+    1825,
+    '{"schema":"public","table":"event_applications","ts_col":"created_at"}',
+    false,
+    '전자상거래법 §6 — 결제/계약 기록 5년 보존. enabled=false: 자동 파기 없음, legal_min_days로 최소 기간 방어'
+  ),
+  (
+    'tickets_payment',
+    'db_table',
+    1825,
+    1825,
+    '{"schema":"public","table":"tickets","ts_col":"created_at"}',
+    false,
+    '전자상거래법 §6 — 티켓/재화공급 기록 5년 보존. enabled=false: 자동 파기 없음'
+  ),
+  (
+    'ticket_templates_payment',
+    'db_table',
+    1825,
+    1825,
+    '{"schema":"public","table":"ticket_templates","ts_col":"created_at"}',
+    false,
+    '전자상거래법 §6 — 티켓 템플릿 기록 5년 보존. enabled=false: 자동 파기 없음'
+  )
+ON CONFLICT (id) DO NOTHING;

--- a/supabase/tests/database/88_payment_retention_protection_test.sql
+++ b/supabase/tests/database/88_payment_retention_protection_test.sql
@@ -1,0 +1,87 @@
+-- pgTAP tests for payment retention protection (feat #1704)
+-- 전자상거래법 §6 — 결제 원본 테이블 5년 보호 메타 등록 검증
+BEGIN;
+
+SELECT plan(13);
+
+-- 1. 3개 보호 레코드 존재 확인
+SELECT ok(
+  EXISTS (SELECT 1 FROM admin.retention_policies WHERE id = 'event_applications_payment'),
+  'event_applications_payment policy exists'
+);
+SELECT ok(
+  EXISTS (SELECT 1 FROM admin.retention_policies WHERE id = 'tickets_payment'),
+  'tickets_payment policy exists'
+);
+SELECT ok(
+  EXISTS (SELECT 1 FROM admin.retention_policies WHERE id = 'ticket_templates_payment'),
+  'ticket_templates_payment policy exists'
+);
+
+-- 2. enabled = false 확인 (자동 파기 대상 아님)
+SELECT ok(
+  NOT (SELECT enabled FROM admin.retention_policies WHERE id = 'event_applications_payment'),
+  'event_applications_payment is disabled (no auto-purge)'
+);
+SELECT ok(
+  NOT (SELECT enabled FROM admin.retention_policies WHERE id = 'tickets_payment'),
+  'tickets_payment is disabled (no auto-purge)'
+);
+SELECT ok(
+  NOT (SELECT enabled FROM admin.retention_policies WHERE id = 'ticket_templates_payment'),
+  'ticket_templates_payment is disabled (no auto-purge)'
+);
+
+-- 3. legal_min_days >= 1825 확인 (전자상거래법 §6 5년)
+SELECT ok(
+  (SELECT legal_min_days FROM admin.retention_policies WHERE id = 'event_applications_payment') >= 1825,
+  'event_applications_payment legal_min_days >= 1825'
+);
+SELECT ok(
+  (SELECT legal_min_days FROM admin.retention_policies WHERE id = 'tickets_payment') >= 1825,
+  'tickets_payment legal_min_days >= 1825'
+);
+SELECT ok(
+  (SELECT legal_min_days FROM admin.retention_policies WHERE id = 'ticket_templates_payment') >= 1825,
+  'ticket_templates_payment legal_min_days >= 1825'
+);
+
+-- 4. retention_days >= legal_min_days 확인 (CHECK 제약 통과 보장)
+SELECT ok(
+  (SELECT retention_days FROM admin.retention_policies WHERE id = 'event_applications_payment')
+    >= (SELECT legal_min_days FROM admin.retention_policies WHERE id = 'event_applications_payment'),
+  'event_applications_payment retention_days >= legal_min_days'
+);
+SELECT ok(
+  (SELECT retention_days FROM admin.retention_policies WHERE id = 'tickets_payment')
+    >= (SELECT legal_min_days FROM admin.retention_policies WHERE id = 'tickets_payment'),
+  'tickets_payment retention_days >= legal_min_days'
+);
+SELECT ok(
+  (SELECT retention_days FROM admin.retention_policies WHERE id = 'ticket_templates_payment')
+    >= (SELECT legal_min_days FROM admin.retention_policies WHERE id = 'ticket_templates_payment'),
+  'ticket_templates_payment retention_days >= legal_min_days'
+);
+
+-- 5. CHECK 제약 `retention_above_legal_min` 동작 확인
+--    retention_days < legal_min_days 인 레코드 삽입 시 예외 발생 검증
+SELECT throws_ok(
+  $$
+    INSERT INTO admin.retention_policies
+      (id, kind, retention_days, legal_min_days, target, enabled)
+    VALUES (
+      'test_check_violation',
+      'db_table',
+      100,
+      1825,
+      '{"schema":"public","table":"test","ts_col":"created_at"}',
+      false
+    )
+  $$,
+  'P0001',
+  NULL,
+  'retention_above_legal_min CHECK rejects retention_days < legal_min_days'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/88_payment_retention_protection_test.sql
+++ b/supabase/tests/database/88_payment_retention_protection_test.sql
@@ -78,7 +78,7 @@ SELECT throws_ok(
       false
     )
   $$,
-  'P0001',
+  '23514',
   NULL,
   'retention_above_legal_min CHECK rejects retention_days < legal_min_days'
 );


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1704

## 구현 내용

### 결제 원본 테이블 보호 메타 등록 (3개)
- `event_applications_payment`: 결제/계약 기록 — payment_id, payment_amount 포함
- `tickets_payment`: 티켓/재화공급 기록  
- `ticket_templates_payment`: 티켓 템플릿 기록

### 보호 방식
- `enabled=false`: cleanup 파이프라인 대상 아님 (자동 파기 없음)
- `legal_min_days=1825`: `retention_above_legal_min` CHECK 제약이 1825일 미만 설정 차단
- `retention_days=1825`: CHECK 통과를 위한 최솟값

### 법적 근거
전자상거래법 §6 — 계약/결제/재화공급 기록 최소 5년 보존 의무

### pgTAP 테스트 (`88_payment_retention_protection_test.sql`)
- 3개 보호 레코드 존재 확인
- `enabled=false` 확인
- `legal_min_days >= 1825` 확인
- CHECK 제약 `retention_days >= legal_min_days` 동작 확인