### PR TITLE
feat(retention): archived_records 자동 파기 + delete_expired_rows RPC (#1703)

### DIFF
--- a/supabase/functions/cleanup-retention/index.ts
+++ b/supabase/functions/cleanup-retention/index.ts
@@ -11,7 +11,7 @@ interface RetentionPolicy {
   id: string;
   kind: RetentionKind;
   retention_days: number;
-  target: Record<string, string>;
+  target: Record<string, string> & { use_absolute_ts?: boolean };
 }
 
 interface PolicyResult {
@@ -26,7 +26,16 @@ async function runDbTableCleanup(
   supabase: ReturnType<typeof createServiceClient>,
   policy: RetentionPolicy,
 ): Promise<{ rows_deleted: number }> {
-  const { schema, table, ts_col } = policy.target;
+  const { schema, table, ts_col, use_absolute_ts } = policy.target as { schema: string; table: string; ts_col: string; use_absolute_ts?: boolean };
+  if (use_absolute_ts) {
+    const { data, error } = await supabase.schema("admin").rpc("delete_expired_rows", {
+      p_schema: schema,
+      p_table: table,
+      p_ts_col: ts_col,
+    });
+    if (error) throw new Error(error.message);
+    return { rows_deleted: Number(data ?? 0) };
+  }
   const { data, error } = await supabase.schema("admin").rpc("delete_old_rows", {
     p_schema: schema,
     p_table: table,

--- a/supabase/migrations/20260422000002_archived_records_retention.sql
+++ b/supabase/migrations/20260422000002_archived_records_retention.sql
@@ -1,0 +1,44 @@
+-- feat #1703: archived_records 자동 파기 + legal_min_days 방어
+
+-- 1. New helper for absolute-expiry deletion (WHERE ts_col < now())
+CREATE OR REPLACE FUNCTION admin.delete_expired_rows(
+  p_schema text,
+  p_table  text,
+  p_ts_col text
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, admin, cron, net, auth, public, pgmq
+AS $$
+DECLARE
+  deleted_count bigint;
+BEGIN
+  IF p_schema NOT IN ('cron', 'net', 'auth', 'public', 'pgmq') THEN
+    RAISE EXCEPTION 'Disallowed schema: %', p_schema;
+  END IF;
+  EXECUTE format(
+    'DELETE FROM %I.%I WHERE %I < now()',
+    p_schema, p_table, p_ts_col
+  );
+  GET DIAGNOSTICS deleted_count = ROW_COUNT;
+  RETURN deleted_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION admin.delete_expired_rows(text, text, text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION admin.delete_expired_rows(text, text, text) TO service_role;
+
+-- 2. Register archived_records policy with legal_min_days=1825 (5y PIPA §21 + e-commerce §6)
+INSERT INTO admin.retention_policies
+  (id, kind, retention_days, legal_min_days, target, description)
+VALUES
+  (
+    'archived_records_expired',
+    'db_table',
+    1826,
+    1825,
+    '{"schema":"public","table":"archived_records","ts_col":"retention_until","use_absolute_ts":true}',
+    '전자상거래법 §6 + PIPA §21 기반 archive의 retention_until 경과 후 파기'
+  )
+ON CONFLICT (id) DO NOTHING;

--- a/supabase/tests/database/87_archived_records_retention_test.sql
+++ b/supabase/tests/database/87_archived_records_retention_test.sql
@@ -1,0 +1,98 @@
+-- pgTAP tests for archived_records 자동 파기 + delete_expired_rows RPC (feat #1703)
+BEGIN;
+
+SELECT plan(10);
+
+-- 1. delete_expired_rows 함수 존재 확인
+SELECT has_function('admin', 'delete_expired_rows', ARRAY['text','text','text'], 'delete_expired_rows function exists');
+
+-- 2. service_role은 실행 가능, anon은 불가
+SELECT function_privs_are(
+  'admin', 'delete_expired_rows', ARRAY['text','text','text'],
+  'service_role', ARRAY['EXECUTE'],
+  'service_role can execute delete_expired_rows'
+);
+SELECT function_privs_are(
+  'admin', 'delete_expired_rows', ARRAY['text','text','text'],
+  'anon', ARRAY[]::text[],
+  'anon cannot execute delete_expired_rows'
+);
+
+-- 3. archived_records_expired 정책 등록 확인
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM admin.retention_policies
+    WHERE id = 'archived_records_expired'
+      AND kind = 'db_table'
+      AND enabled = true
+  ),
+  'archived_records_expired policy exists and is enabled'
+);
+
+-- 4. legal_min_days >= 1825 (5년, 전자상거래법 §6)
+SELECT ok(
+  (SELECT legal_min_days FROM admin.retention_policies WHERE id = 'archived_records_expired') >= 1825,
+  'archived_records_expired legal_min_days >= 1825'
+);
+
+-- 5. target.use_absolute_ts = true
+SELECT ok(
+  (SELECT target->>'use_absolute_ts' FROM admin.retention_policies WHERE id = 'archived_records_expired') = 'true',
+  'archived_records_expired target.use_absolute_ts = true'
+);
+
+-- 6. CHECK 제약: retention_days < legal_min_days 거절
+SELECT throws_ok(
+  $$UPDATE admin.retention_policies SET retention_days = 100 WHERE id = 'archived_records_expired'$$,
+  '23514',
+  NULL,
+  'CHECK constraint rejects retention_days < legal_min_days for archived_records_expired'
+);
+
+-- 7. 기능 테스트: 만료 레코드 삭제 (BEGIN..ROLLBACK 내부)
+SAVEPOINT before_functional_test;
+
+-- 만료된 레코드 삽입 (retention_until = 어제)
+INSERT INTO public.archived_records (user_id, record_type, data, retention_until)
+VALUES (
+  gen_random_uuid(),
+  'account',
+  '{"test": "expired"}'::jsonb,
+  now() - interval '1 day'
+);
+
+SELECT ok(
+  (SELECT admin.delete_expired_rows('public', 'archived_records', 'retention_until')) > 0,
+  'delete_expired_rows deletes expired rows (retention_until < now)'
+);
+
+ROLLBACK TO SAVEPOINT before_functional_test;
+
+-- 8. 기능 테스트: 미만료 레코드 보존
+SAVEPOINT before_live_test;
+
+INSERT INTO public.archived_records (user_id, record_type, data, retention_until)
+VALUES (
+  gen_random_uuid(),
+  'account',
+  '{"test": "live"}'::jsonb,
+  now() + interval '1 day'
+);
+
+SELECT ok(
+  (SELECT admin.delete_expired_rows('public', 'archived_records', 'retention_until')) = 0,
+  'delete_expired_rows does NOT delete non-expired rows (retention_until > now)'
+);
+
+ROLLBACK TO SAVEPOINT before_live_test;
+
+-- 9. 허용되지 않은 schema 거절
+SELECT throws_ok(
+  $$SELECT admin.delete_expired_rows('private', 'some_table', 'created_at')$$,
+  'P0001',
+  NULL,
+  'delete_expired_rows rejects disallowed schema'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/87_archived_records_retention_test.sql
+++ b/supabase/tests/database/87_archived_records_retention_test.sql
@@ -53,10 +53,11 @@ SELECT throws_ok(
 SAVEPOINT before_functional_test;
 
 -- 만료된 레코드 삽입 (retention_until = 어제)
-INSERT INTO public.archived_records (user_id, record_type, data, retention_until)
+-- archived_records schema: user_id_hash text, record_data jsonb, record_type IN ('contract','payment','dispute','login')
+INSERT INTO public.archived_records (user_id_hash, record_type, record_data, retention_until)
 VALUES (
-  gen_random_uuid(),
-  'account',
+  'test-hash-expired',
+  'payment',
   '{"test": "expired"}'::jsonb,
   now() - interval '1 day'
 );
@@ -71,10 +72,10 @@ ROLLBACK TO SAVEPOINT before_functional_test;
 -- 8. 기능 테스트: 미만료 레코드 보존
 SAVEPOINT before_live_test;
 
-INSERT INTO public.archived_records (user_id, record_type, data, retention_until)
+INSERT INTO public.archived_records (user_id_hash, record_type, record_data, retention_until)
 VALUES (
-  gen_random_uuid(),
-  'account',
+  'test-hash-live',
+  'payment',
   '{"test": "live"}'::jsonb,
   now() + interval '1 day'
 );


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1703

## 구현 내용

### 신규 RPC: `admin.delete_expired_rows(p_schema, p_table, p_ts_col)`
- `retention_until` 같은 절대 만료 timestamp 컬럼에 대응
- `WHERE ts_col < now()` — cutoff_days 없이 컬럼 값 자체가 만료 기준
- schema whitelist 동일 (`cron/net/auth/public/pgmq`)

### `admin.retention_policies` 레코드 추가
- id: `archived_records_expired`, kind: `db_table`
- `retention_days=1826, legal_min_days=1825` — 전자상거래법 §6 5년 방어
- `target.use_absolute_ts=true` — cleanup EF가 `delete_expired_rows` 경로로 분기

### Edge Function 업데이트
- `target.use_absolute_ts === true`이면 `delete_expired_rows` RPC 호출
- 기존 `delete_old_rows` 경로는 변경 없음

### pgTAP 테스트 (`87_archived_records_retention_test.sql`)
- RPC 존재 + 권한 검증
- 정책 등록 + `legal_min_days >= 1825` 검증
- 만료 레코드 삭제 / 미만료 레코드 보존 기능 검증