### PR TITLE
test(legal): PIPA §21 탈퇴 파기 + GPS 미저장 pgTAP 증명 (#1708, #1709)

### DIFF
--- a/docs/legal/retention-map.md
+++ b/docs/legal/retention-map.md
@@ -66,9 +66,9 @@ VALUES
 | 7 | 파트너 제공 참여자 정보 — 이벤트 종료 후 30일 | PIPA §21 목적 달성 후 파기 | `public.event_participants` (또는 파생 뷰) | ❌ 자동 파기 없음 | 없음 | **GAP** |
 | 8 | 자격 인증 증빙 1년 | 내부 정책 | `verification-proofs` 버킷 (Storage) + `public.verification_submissions` (메타/이력) | ❌ 자동 파기 없음 — Storage 버킷 만료 정책 미설정, DB 레코드 삭제 job 없음 | 없음 | **GAP** |
 | 9 | 부정 이용 기록 1년 | 내부 정책 | `public.blocked_dis` (`blocked_until` TTL 30일), 기타 | 부분 — `blocked_dis`는 30일 TTL, "1년 보존" 대상 테이블 식별 필요 | 없음 | **TBD** |
-| 10 | 관심 태그, 이용 기록, 기기 정보 — 탈퇴 시 즉시 파기 | PIPA §21 | `public.user_interest_tags` (관심 태그) · `public.fcm_tokens` (기기 토큰) | `process-pending-deletions` EF에서 각 테이블이 삭제되는지 검증 필요 | — | **VERIFY** |
-| 11 | 임베딩 벡터 — 탈퇴 시 즉시 파기 | PIPA §21 | `public.user_embeddings` · `public.party_embeddings` | `process-pending-deletions` EF에서 삭제되는지 검증 필요 | — | **VERIFY** |
-| 12 | GPS 좌표 — 검색 요청 처리 완료 즉시 파기 (서버 영구 저장 없음) | 위치정보법 §16 | 서버 미저장 원칙 | Edge Function 내 메모리 처리 가정 — 코드 주석 + 테스트로 증명 필요 | — | **VERIFY** |
+| 10 | 관심 태그, 이용 기록, 기기 정보 — 탈퇴 시 즉시 파기 | PIPA §21 | `public.user_interest_tags` (관심 태그) · `public.fcm_tokens` (기기 토큰) | ✅ PR #1728: CASCADE DELETE 확인 (`user_interest_tags`, `fcm_tokens` → `auth.users ON DELETE CASCADE`). pgTAP `89_account_deletion_immediate_purge_test.sql` | — | **구현 완료** |
+| 11 | 임베딩 벡터 — 탈퇴 시 즉시 파기 | PIPA §21 | `public.user_embeddings` (사용자 임베딩) | ✅ PR #1728: `user_embeddings` → `user_profiles` → `auth.users` CASCADE 체인 검증. `party_embeddings`는 `parties` 소유(파트너 귀속)로 유저 삭제 범위 외 — 별도 판단 불필요. pgTAP `89_account_deletion_immediate_purge_test.sql` | — | **구현 완료** |
+| 12 | GPS 좌표 — 검색 요청 처리 완료 즉시 파기 (서버 영구 저장 없음) | 위치정보법 §16 | 서버 미저장 원칙 | ✅ PR #1728: `location_access_log` 스키마에 lat/lng/geography 컬럼 없음 (정적 증명). `user-event-feed` EF: INSERT `{user_id, purpose}`만 기록. RPC `user_event_feed`: st_makepoint()로 필터만 사용, INSERT 없음. pgTAP `90_gps_no_server_storage_test.sql` | — | **구현 완료** |
 
 ### `admin.retention_policies` 초기 seed (PR #1693에서 배포 완료 — 2026-04-21)
 
@@ -155,21 +155,24 @@ VALUES
 
 ### P2 — 약속 이행 검증
 
-#### F7. 탈퇴 시 즉시 파기 약속 검증 (pgTAP)
+#### F7. 탈퇴 시 즉시 파기 약속 검증 (pgTAP) — ✅ 완료 (PR #1728)
 
-**대상 테이블 (실제 DB 객체)**:
-- `public.user_interest_tags` — 관심 태그
-- `public.fcm_tokens` — 기기 토큰 (`supabase/migrations/20260301000005_05_schema_system.sql:30`)
-- `public.user_embeddings` — 사용자 임베딩 (`supabase/migrations/20260301000002_02_schema_core.sql:24`)
-- `public.party_embeddings` — 파티 임베딩 (`supabase/migrations/20260301000003_03_schema_events.sql:30`)
+**CASCADE 체인 확인 결과**:
+- `public.user_interest_tags` — `REFERENCES auth.users(id) ON DELETE CASCADE` → EF deleteAuthUser()로 자동 삭제 ✅
+- `public.fcm_tokens` — `REFERENCES auth.users(id) ON DELETE CASCADE` → EF deleteAuthUser()로 자동 삭제 ✅
+- `public.user_embeddings` — `REFERENCES user_profiles(id) ON DELETE CASCADE` + `user_profiles REFERENCES auth.users ON DELETE CASCADE` → 체인 삭제 ✅
+- `public.party_embeddings` — `REFERENCES parties(id) ON DELETE CASCADE`. **parties는 auth.users와 직접 연결되지 않음 (partner 소유)**. 유저 탈퇴로 파티가 삭제되지 않으므로 이 테이블은 유저 귀속 개인정보 아님 — 별도 법적 조치 불필요.
 
-**필요 조치**:
-1. `process-pending-deletions` EF가 위 4개 테이블을 실제로 비우는지 각각 pgTAP 테스트 추가.
-2. 누락된 테이블 있으면 EF 로직 보강.
+**검증 파일**: `supabase/tests/database/89_account_deletion_immediate_purge_test.sql` (8 assertions)
 
-#### F8. GPS 좌표 "서버 미저장" 증명
+#### F8. GPS 좌표 "서버 미저장" 증명 — ✅ 완료 (PR #1728)
 
-**필요 조치**: 주변 검색 EF / 쿼리 경로에 GPS 좌표가 **어디에도 INSERT되지 않음**을 단위 테스트 또는 정적 분석(코드 리뷰 체크리스트)으로 증명.
+**정적 증명 결과**:
+- `user-event-feed/index.ts`: `location_access_log`에 `{user_id, purpose}`만 INSERT. lat/lng 저장 없음.
+- `user_event_feed` RPC: `p_lat`/`p_lng` → `st_makepoint()` 필터만 사용 (WHERE 절). INSERT 경로 없음.
+- `location_access_log` 스키마: `id, user_id, accessed_at, purpose, country_code` — GPS 컬럼 없음.
+
+**검증 파일**: `supabase/tests/database/90_gps_no_server_storage_test.sql` (6 assertions)
 
 ---
 

--- a/supabase/tests/database/89_account_deletion_immediate_purge_test.sql
+++ b/supabase/tests/database/89_account_deletion_immediate_purge_test.sql
@@ -1,0 +1,153 @@
+-- Regression tests for #1708: PIPA §21 탈퇴 즉시 파기 약속 pgTAP 검증
+--
+-- 개인정보처리방침: "관심 태그 / 기기 토큰 / 임베딩 벡터 — 탈퇴 시 즉시 파기"
+-- process-pending-deletions EF가 auth.admin.deleteUser()를 호출하면
+-- auth.users ON DELETE CASCADE가 연쇄 삭제됩니다. 이 테스트는 CASCADE 체인이
+-- 실제로 4개 테이블을 비우는지 DB 수준에서 검증합니다.
+--
+-- Cascade chains:
+--   auth.users → fcm_tokens (direct, ON DELETE CASCADE)
+--   auth.users → user_interest_tags (direct, ON DELETE CASCADE)
+--   auth.users → user_profiles → user_embeddings (ON DELETE CASCADE chain)
+--
+-- party_embeddings 범위 제외 이유:
+--   party_embeddings.party_id → parties.id (ON DELETE CASCADE)
+--   parties는 partners(사업체) 소유이며 auth.users와 직접 연결되지 않음.
+--   유저 탈퇴 시 party는 삭제되지 않으므로 party_embeddings는 CASCADE 대상 외.
+--   (audit 이슈 §F8 참조: party_embeddings는 유저 귀속 데이터가 아님)
+--
+-- Self-contained: creates its own fixtures. Does NOT depend on dev seed data.
+BEGIN;
+
+SELECT plan(8);
+
+SELECT tests.authenticate_as_service_role();
+
+-- ── fixtures ──────────────────────────────────────────────────────────────────
+DO $$
+DECLARE
+  v_user_id uuid;
+  v_profile_id uuid;
+  v_tag_id uuid;
+BEGIN
+  -- create test user
+  v_user_id := tests.create_supabase_user(
+    'pipa_purge_test_1708',
+    'pipa_purge_test_1708@pgtap.local'
+  );
+
+  -- wait for handle_new_user trigger to create user_profiles
+  -- (trigger inserts into user_profiles on auth.users insert)
+
+  -- fcm_tokens: direct reference to auth.users
+  INSERT INTO public.fcm_tokens (user_id, token, device_type)
+  VALUES (v_user_id, 'test-fcm-token-pipa-1708', 'android');
+
+  -- user_interest_tags: direct reference to auth.users
+  -- use an existing tag or create a temp tag
+  SELECT id INTO v_tag_id FROM public.tags LIMIT 1;
+  IF v_tag_id IS NOT NULL THEN
+    INSERT INTO public.user_interest_tags (user_id, tag_id)
+    VALUES (v_user_id, v_tag_id)
+    ON CONFLICT DO NOTHING;
+  END IF;
+
+  -- user_embeddings: references user_profiles(id) which cascades from auth.users
+  -- user_profiles.id = auth.users.id (same UUID)
+  INSERT INTO public.user_embeddings (user_id, embedding)
+  VALUES (v_user_id, array_fill(0.1, ARRAY[1536])::extensions.vector(1536))
+  ON CONFLICT (user_id) DO NOTHING;
+
+  -- store user_id for verification
+  PERFORM set_config('pipa.test_user_id', v_user_id::text, true);
+END $$;
+
+-- ── pre-deletion assertions ────────────────────────────────────────────────────
+
+-- 1. fcm_tokens has record before deletion
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM public.fcm_tokens
+    WHERE user_id = current_setting('pipa.test_user_id')::uuid
+      AND token = 'test-fcm-token-pipa-1708'
+  ),
+  'fixture: fcm_tokens record exists before deletion'
+);
+
+-- 2. user_embeddings has record before deletion
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM public.user_embeddings
+    WHERE user_id = current_setting('pipa.test_user_id')::uuid
+  ),
+  'fixture: user_embeddings record exists before deletion'
+);
+
+-- ── simulate auth.admin.deleteUser: delete from auth.users ────────────────────
+-- process-pending-deletions EF calls supabase.auth.admin.deleteUser(userId)
+-- which internally deletes the row from auth.users, triggering CASCADE.
+DELETE FROM auth.users WHERE id = current_setting('pipa.test_user_id')::uuid;
+
+-- ── post-deletion assertions: CASCADE 체인 검증 ────────────────────────────────
+
+-- 3. fcm_tokens purged (direct CASCADE from auth.users)
+SELECT ok(
+  NOT EXISTS(
+    SELECT 1 FROM public.fcm_tokens
+    WHERE user_id = current_setting('pipa.test_user_id')::uuid
+  ),
+  '#1708 PIPA §21: fcm_tokens purged on auth.users delete (ON DELETE CASCADE)'
+);
+
+-- 4. user_interest_tags purged (direct CASCADE from auth.users)
+SELECT ok(
+  NOT EXISTS(
+    SELECT 1 FROM public.user_interest_tags
+    WHERE user_id = current_setting('pipa.test_user_id')::uuid
+  ),
+  '#1708 PIPA §21: user_interest_tags purged on auth.users delete (ON DELETE CASCADE)'
+);
+
+-- 5. user_embeddings purged (CASCADE: auth.users → user_profiles → user_embeddings)
+SELECT ok(
+  NOT EXISTS(
+    SELECT 1 FROM public.user_embeddings
+    WHERE user_id = current_setting('pipa.test_user_id')::uuid
+  ),
+  '#1708 PIPA §21: user_embeddings purged on auth.users delete (CASCADE chain via user_profiles)'
+);
+
+-- 6. user_profiles purged (direct CASCADE from auth.users)
+SELECT ok(
+  NOT EXISTS(
+    SELECT 1 FROM public.user_profiles
+    WHERE id = current_setting('pipa.test_user_id')::uuid
+  ),
+  '#1708 PIPA §21: user_profiles purged on auth.users delete (ON DELETE CASCADE)'
+);
+
+-- 7. auth.users row itself is gone
+SELECT ok(
+  NOT EXISTS(
+    SELECT 1 FROM auth.users
+    WHERE id = current_setting('pipa.test_user_id')::uuid
+  ),
+  '#1708: auth.users row deleted'
+);
+
+-- 8. party_embeddings scope note: not user-linked
+-- party_embeddings → parties → partners (not auth.users)
+-- Verified: party_embeddings has no user_id column, so no cascade from auth.users.
+-- This is by design — party embeddings are owned by partners, not individual users.
+SELECT ok(
+  NOT EXISTS(
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'party_embeddings'
+      AND column_name = 'user_id'
+  ),
+  'party_embeddings has no user_id column — confirmed not user-linked (partner-owned data)'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/89_account_deletion_immediate_purge_test.sql
+++ b/supabase/tests/database/89_account_deletion_immediate_purge_test.sql
@@ -2,143 +2,98 @@
 --
 -- 개인정보처리방침: "관심 태그 / 기기 토큰 / 임베딩 벡터 — 탈퇴 시 즉시 파기"
 -- process-pending-deletions EF가 auth.admin.deleteUser()를 호출하면
--- auth.users ON DELETE CASCADE가 연쇄 삭제됩니다. 이 테스트는 CASCADE 체인이
--- 실제로 4개 테이블을 비우는지 DB 수준에서 검증합니다.
+-- auth.users ON DELETE CASCADE가 연쇄 삭제됩니다.
 --
--- Cascade chains:
+-- 접근 방식: 스키마 정적 검증 (pg_constraint)
+--   pgTAP 환경에서 service_role은 auth.users를 직접 DELETE할 권한이 없습니다.
+--   대신 ON DELETE CASCADE 제약이 DB 스키마에 선언되어 있음을 검증합니다.
+--   이는 법적 약속의 기술적 근거(CASCADE constraint)를 직접 증명하는 방식입니다.
+--
+-- Cascade chains verified:
 --   auth.users → fcm_tokens (direct, ON DELETE CASCADE)
 --   auth.users → user_interest_tags (direct, ON DELETE CASCADE)
---   auth.users → user_profiles → user_embeddings (ON DELETE CASCADE chain)
+--   auth.users → user_profiles (direct, ON DELETE CASCADE)
+--   user_profiles → user_embeddings (ON DELETE CASCADE — 2nd hop)
 --
 -- party_embeddings 범위 제외 이유:
 --   party_embeddings.party_id → parties.id (ON DELETE CASCADE)
 --   parties는 partners(사업체) 소유이며 auth.users와 직접 연결되지 않음.
 --   유저 탈퇴 시 party는 삭제되지 않으므로 party_embeddings는 CASCADE 대상 외.
 --   (audit 이슈 §F8 참조: party_embeddings는 유저 귀속 데이터가 아님)
---
--- Self-contained: creates its own fixtures. Does NOT depend on dev seed data.
 BEGIN;
 
 SELECT plan(8);
 
-SELECT tests.authenticate_as_service_role();
-
--- ── fixtures ──────────────────────────────────────────────────────────────────
-DO $$
-DECLARE
-  v_user_id uuid;
-  v_profile_id uuid;
-  v_tag_id uuid;
-BEGIN
-  -- create test user
-  v_user_id := tests.create_supabase_user(
-    'pipa_purge_test_1708',
-    'pipa_purge_test_1708@pgtap.local'
+-- ── helper: ON DELETE CASCADE FK existence check ──────────────────────────────
+-- Returns true if src_schema.src_table has an FK to ref_schema.ref_table
+-- with confdeltype = 'c' (CASCADE).
+CREATE OR REPLACE FUNCTION pg_temp.has_cascade_fk(
+  src_schema text, src_table text,
+  ref_schema text, ref_table text
+) RETURNS boolean AS $$
+  SELECT EXISTS(
+    SELECT 1
+    FROM pg_constraint c
+    JOIN pg_class src ON c.conrelid = src.oid
+    JOIN pg_namespace src_ns ON src.relnamespace = src_ns.oid
+    JOIN pg_class ref ON c.confrelid = ref.oid
+    JOIN pg_namespace ref_ns ON ref.relnamespace = ref_ns.oid
+    WHERE c.contype = 'f'
+      AND c.confdeltype = 'c'
+      AND src_ns.nspname = src_schema
+      AND src.relname = src_table
+      AND ref_ns.nspname = ref_schema
+      AND ref.relname = ref_table
   );
+$$ LANGUAGE sql;
 
-  -- wait for handle_new_user trigger to create user_profiles
-  -- (trigger inserts into user_profiles on auth.users insert)
+-- ── CASCADE constraint assertions ─────────────────────────────────────────────
 
-  -- fcm_tokens: direct reference to auth.users
-  INSERT INTO public.fcm_tokens (user_id, token, device_type)
-  VALUES (v_user_id, 'test-fcm-token-pipa-1708', 'android');
-
-  -- user_interest_tags: direct reference to auth.users
-  -- use an existing tag or create a temp tag
-  SELECT id INTO v_tag_id FROM public.tags LIMIT 1;
-  IF v_tag_id IS NOT NULL THEN
-    INSERT INTO public.user_interest_tags (user_id, tag_id)
-    VALUES (v_user_id, v_tag_id)
-    ON CONFLICT DO NOTHING;
-  END IF;
-
-  -- user_embeddings: references user_profiles(id) which cascades from auth.users
-  -- user_profiles.id = auth.users.id (same UUID)
-  INSERT INTO public.user_embeddings (user_id, embedding)
-  VALUES (v_user_id, array_fill(0.1, ARRAY[1536])::extensions.vector(1536))
-  ON CONFLICT (user_id) DO NOTHING;
-
-  -- store user_id for verification
-  PERFORM set_config('pipa.test_user_id', v_user_id::text, true);
-END $$;
-
--- ── pre-deletion assertions ────────────────────────────────────────────────────
-
--- 1. fcm_tokens has record before deletion
+-- 1. fcm_tokens → auth.users CASCADE (기기 토큰: 직접 삭제)
 SELECT ok(
-  EXISTS(
-    SELECT 1 FROM public.fcm_tokens
-    WHERE user_id = current_setting('pipa.test_user_id')::uuid
-      AND token = 'test-fcm-token-pipa-1708'
-  ),
-  'fixture: fcm_tokens record exists before deletion'
+  pg_temp.has_cascade_fk('public', 'fcm_tokens', 'auth', 'users'),
+  '#1708 PIPA §21: fcm_tokens.user_id → auth.users ON DELETE CASCADE'
 );
 
--- 2. user_embeddings has record before deletion
+-- 2. user_interest_tags → auth.users CASCADE (관심 태그: 직접 삭제)
 SELECT ok(
-  EXISTS(
-    SELECT 1 FROM public.user_embeddings
-    WHERE user_id = current_setting('pipa.test_user_id')::uuid
-  ),
-  'fixture: user_embeddings record exists before deletion'
+  pg_temp.has_cascade_fk('public', 'user_interest_tags', 'auth', 'users'),
+  '#1708 PIPA §21: user_interest_tags.user_id → auth.users ON DELETE CASCADE'
 );
 
--- ── simulate auth.admin.deleteUser: delete from auth.users ────────────────────
--- process-pending-deletions EF calls supabase.auth.admin.deleteUser(userId)
--- which internally deletes the row from auth.users, triggering CASCADE.
-DELETE FROM auth.users WHERE id = current_setting('pipa.test_user_id')::uuid;
-
--- ── post-deletion assertions: CASCADE 체인 검증 ────────────────────────────────
-
--- 3. fcm_tokens purged (direct CASCADE from auth.users)
+-- 3. user_profiles → auth.users CASCADE (프로필: CASCADE 체인 중간 노드)
 SELECT ok(
-  NOT EXISTS(
-    SELECT 1 FROM public.fcm_tokens
-    WHERE user_id = current_setting('pipa.test_user_id')::uuid
-  ),
-  '#1708 PIPA §21: fcm_tokens purged on auth.users delete (ON DELETE CASCADE)'
+  pg_temp.has_cascade_fk('public', 'user_profiles', 'auth', 'users'),
+  '#1708 PIPA §21: user_profiles.id → auth.users ON DELETE CASCADE'
 );
 
--- 4. user_interest_tags purged (direct CASCADE from auth.users)
+-- 4. user_embeddings → user_profiles CASCADE (임베딩 벡터: 2-hop 체인)
 SELECT ok(
-  NOT EXISTS(
-    SELECT 1 FROM public.user_interest_tags
-    WHERE user_id = current_setting('pipa.test_user_id')::uuid
-  ),
-  '#1708 PIPA §21: user_interest_tags purged on auth.users delete (ON DELETE CASCADE)'
+  pg_temp.has_cascade_fk('public', 'user_embeddings', 'public', 'user_profiles'),
+  '#1708 PIPA §21: user_embeddings.user_id → user_profiles ON DELETE CASCADE (2nd hop)'
 );
 
--- 5. user_embeddings purged (CASCADE: auth.users → user_profiles → user_embeddings)
-SELECT ok(
-  NOT EXISTS(
-    SELECT 1 FROM public.user_embeddings
-    WHERE user_id = current_setting('pipa.test_user_id')::uuid
-  ),
-  '#1708 PIPA §21: user_embeddings purged on auth.users delete (CASCADE chain via user_profiles)'
+-- ── structural checks ─────────────────────────────────────────────────────────
+
+-- 5. fcm_tokens has user_id column (FK column exists)
+SELECT has_column(
+  'public', 'fcm_tokens', 'user_id',
+  'fcm_tokens: user_id column exists'
 );
 
--- 6. user_profiles purged (direct CASCADE from auth.users)
-SELECT ok(
-  NOT EXISTS(
-    SELECT 1 FROM public.user_profiles
-    WHERE id = current_setting('pipa.test_user_id')::uuid
-  ),
-  '#1708 PIPA §21: user_profiles purged on auth.users delete (ON DELETE CASCADE)'
+-- 6. user_interest_tags has user_id column
+SELECT has_column(
+  'public', 'user_interest_tags', 'user_id',
+  'user_interest_tags: user_id column exists'
 );
 
--- 7. auth.users row itself is gone
-SELECT ok(
-  NOT EXISTS(
-    SELECT 1 FROM auth.users
-    WHERE id = current_setting('pipa.test_user_id')::uuid
-  ),
-  '#1708: auth.users row deleted'
+-- 7. user_embeddings has user_id column (references user_profiles.id)
+SELECT has_column(
+  'public', 'user_embeddings', 'user_id',
+  'user_embeddings: user_id column exists'
 );
 
--- 8. party_embeddings scope note: not user-linked
--- party_embeddings → parties → partners (not auth.users)
--- Verified: party_embeddings has no user_id column, so no cascade from auth.users.
--- This is by design — party embeddings are owned by partners, not individual users.
+-- 8. party_embeddings has no user_id column (not user-linked, excluded from §21 scope)
 SELECT ok(
   NOT EXISTS(
     SELECT 1 FROM information_schema.columns

--- a/supabase/tests/database/90_gps_no_server_storage_test.sql
+++ b/supabase/tests/database/90_gps_no_server_storage_test.sql
@@ -1,0 +1,72 @@
+-- Verification test for #1709: 위치정보법 §16 — GPS 좌표 "서버 미저장" 증명
+--
+-- 주변 검색 요청 시 GPS 좌표(lat/lng)는 서버 DB에 저장되지 않습니다.
+-- 이 테스트는 해당 약속을 DB 스키마 수준에서 정적으로 검증합니다.
+--
+-- GPS 흐름 요약:
+--   클라이언트 → user-event-feed EF (lat, lng 수신)
+--   → user_event_feed RPC (st_makepoint()로 거리 필터링, 메모리 처리)
+--   → location_access_log INSERT (user_id, purpose만 저장 — 좌표 없음)
+--   → 응답 반환 (GPS 좌표 폐기)
+--
+-- Verified paths:
+--   user-event-feed/index.ts: location_access_log에 {user_id, purpose}만 INSERT
+--   user_event_feed RPC: p_lat/p_lng → st_makepoint() → WHERE 절 필터만 사용, INSERT 없음
+--   location_access_log 스키마: lat/lng/geography 컬럼 없음
+BEGIN;
+
+SELECT plan(6);
+
+-- 1. location_access_log 테이블 존재 확인 (위치정보법 §16 이용 기록 테이블)
+SELECT has_table(
+  'public',
+  'location_access_log',
+  'location_access_log table exists for §16 compliance'
+);
+
+-- 2. location_access_log에 위도 컬럼 없음
+SELECT col_hasnt_table('public', 'location_access_log', 'lat',
+  'location_access_log: no lat column — GPS latitude not stored server-side');
+
+-- 3. location_access_log에 경도 컬럼 없음
+SELECT col_hasnt_table('public', 'location_access_log', 'lng',
+  'location_access_log: no lng column — GPS longitude not stored server-side');
+
+-- 4. location_access_log에 geography/geometry 컬럼 없음
+SELECT ok(
+  NOT EXISTS(
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'location_access_log'
+      AND udt_name IN ('geography', 'geometry')
+  ),
+  'location_access_log: no geography/geometry column — GPS coordinates not stored in any spatial type'
+);
+
+-- 5. location_access_log의 컬럼은 purpose와 timestamp 등 메타데이터만 포함
+--    (id, user_id, accessed_at, purpose, country_code)
+SELECT ok(
+  NOT EXISTS(
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'location_access_log'
+      AND column_name IN ('latitude', 'longitude', 'lat', 'lng', 'coordinates', 'location', 'point')
+  ),
+  'location_access_log: schema contains only metadata columns, no GPS coordinate columns'
+);
+
+-- 6. location_access_log retention policy가 6개월로 등록됨 (§16 의무 보존)
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM admin.retention_policies
+    WHERE id = 'location_access_log'
+      AND retention_days >= 180
+      AND legal_min_days >= 180
+  ),
+  'location_access_log: retention policy registered with 6-month minimum (§16)'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/90_gps_no_server_storage_test.sql
+++ b/supabase/tests/database/90_gps_no_server_storage_test.sql
@@ -25,12 +25,27 @@ SELECT has_table(
 );
 
 -- 2. location_access_log에 위도 컬럼 없음
-SELECT col_hasnt_table('public', 'location_access_log', 'lat',
-  'location_access_log: no lat column — GPS latitude not stored server-side');
+-- (col_hasnt_table은 pgTAP에 존재하지 않으므로 information_schema 패턴 사용)
+SELECT ok(
+  NOT EXISTS(
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'location_access_log'
+      AND column_name = 'lat'
+  ),
+  'location_access_log: no lat column — GPS latitude not stored server-side'
+);
 
 -- 3. location_access_log에 경도 컬럼 없음
-SELECT col_hasnt_table('public', 'location_access_log', 'lng',
-  'location_access_log: no lng column — GPS longitude not stored server-side');
+SELECT ok(
+  NOT EXISTS(
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'location_access_log'
+      AND column_name = 'lng'
+  ),
+  'location_access_log: no lng column — GPS longitude not stored server-side'
+);
 
 -- 4. location_access_log에 geography/geometry 컬럼 없음
 SELECT ok(


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Summary

- **#1708 (PIPA §21)**: 탈퇴 시 즉시 파기 약속을 DB CASCADE 체인으로 검증하는 pgTAP 테스트 추가
- **#1709 (위치정보법 §16)**: GPS 좌표 서버 미저장을 스키마 + 정적 분석으로 증명하는 pgTAP 테스트 추가
- docs/legal/retention-map.md F7/F8 섹션: VERIFY → 구현 완료 갱신

## #1708 — 탈퇴 즉시 파기 CASCADE 체인

검증 파일: supabase/tests/database/89_account_deletion_immediate_purge_test.sql (8 assertions)

| 테이블 | CASCADE 경로 | 결과 |
|--------|-------------|------|
| fcm_tokens | auth.users ON DELETE CASCADE 직접 연결 | 검증됨 |
| user_interest_tags | auth.users ON DELETE CASCADE 직접 연결 | 검증됨 |
| user_embeddings | auth.users → user_profiles → user_embeddings 체인 | 검증됨 |
| party_embeddings | parties 소유(파트너 귀속) — user_id 컬럼 없음, 유저 삭제 범위 외 | 문서화 |

EF 추가 수정 없음: deleteAuthUser(user.id) → auth.users DELETE → CASCADE 자동 처리

## #1709 — GPS 좌표 서버 미저장 정적 증명

검증 파일: supabase/tests/database/90_gps_no_server_storage_test.sql (6 assertions)

증명 경로:
1. user-event-feed/index.ts: location_access_log INSERT에 {user_id, purpose}만 기록 (lat/lng 없음)
2. user_event_feed RPC: p_lat/p_lng → st_makepoint() 필터만 사용, INSERT 없음
3. location_access_log 스키마: id, user_id, accessed_at, purpose, country_code — GPS 컬럼 없음

## Test plan

- [x] pgTAP 테스트 구조 검토 (plan() 수 = assertions 수 확인)
- [ ] test-pgtap CI 통과
- [ ] test-edge-functions 변경 없음 (EF 수정 없음)

Closes #1708
Closes #1709