### PR TITLE
feat(retention): 부정 이용 기록 1년 보관 정책 등록 (#1706)

### DIFF
--- a/supabase/migrations/20260422000005_fraud_record_retention.sql
+++ b/supabase/migrations/20260422000005_fraud_record_retention.sql
@@ -1,0 +1,71 @@
+-- Migration: #1706 부정 이용 기록 1년 보관 정책 (PIPA §21, 개인정보처리방침)
+--
+-- 개인정보처리방침: "부정 이용 기록 1년 보관"
+--
+-- 대상 테이블 식별 결과:
+--   1. report_details  — 신고 기록 (신고자/피신고자 정보), 1년 보존 → enabled
+--   2. blocked_dis     — 기기 식별자 차단 목록, 30일 TTL 운영 중
+--                        선언(1년)과 실제 TTL(30일) 불일치 → legal-reviewer 컨설트 필요
+--                        enabled=false 로 등록해 추적만 수행
+--
+-- 제외 테이블:
+--   social_interactions (block/report 타입) — 현재 상태(current state) 테이블.
+--     이력이 아닌 현재 차단 상태만 저장. 삭제 시 차단 관계 자체가 해제됨.
+--     부정 이용 "기록" 범주에 해당하지 않음.
+
+-- ── 1. report_details: 신고 기록 1년 보존 ─────────────────────────────────────
+-- 신고 접수 후 1년이 경과한 기록은 파기. (생성일 기준)
+INSERT INTO admin.retention_policies (
+  id,
+  kind,
+  retention_days,
+  legal_min_days,
+  target,
+  enabled,
+  description
+) VALUES (
+  'report_details_fraud_record',
+  'db_table',
+  365,
+  365,
+  jsonb_build_object(
+    'schema', 'public',
+    'table',  'report_details',
+    'ts_col', 'created_at'
+  ),
+  true,
+  '부정 이용 기록 1년 보관 — 개인정보처리방침 §F5: 신고 기록(report_details) 1년 후 파기'
+);
+
+-- ── 2. blocked_dis: 기기 식별자 차단 — 불일치로 인해 비활성 등록 ─────────────
+-- blocked_until TTL 30일 운영 중이나 개인정보처리방침은 1년 보관 선언.
+-- cleanup-blocked-dis EF가 blocked_until < now() 행을 매일 삭제하므로
+-- 1년 보존 약속과 충돌. legal-reviewer 판단 전 enabled=false로 추적만 수행.
+INSERT INTO admin.retention_policies (
+  id,
+  kind,
+  retention_days,
+  legal_min_days,
+  target,
+  enabled,
+  description,
+  metadata
+) VALUES (
+  'blocked_dis_fraud_record',
+  'db_table',
+  365,
+  NULL,
+  jsonb_build_object(
+    'schema', 'public',
+    'table',  'blocked_dis',
+    'ts_col', 'created_at'
+  ),
+  false,
+  '부정 이용 기록 1년 보관 — blocked_dis: TTL 불일치로 비활성 (legal-reviewer 컨설트 필요)',
+  jsonb_build_object(
+    'conflict', 'blocked_until TTL=30일 vs 개인정보처리방침 선언=1년 불일치',
+    'existing_cleanup', 'cleanup-blocked-dis EF가 blocked_until < now() 삭제 중',
+    'action_required', 'legal-reviewer가 방침 개정(30일로 단축) 또는 TTL 연장(1년) 결정 필요',
+    'issue', 1706
+  )
+);

--- a/supabase/tests/database/92_fraud_record_retention_test.sql
+++ b/supabase/tests/database/92_fraud_record_retention_test.sql
@@ -1,0 +1,78 @@
+-- pgTAP tests for #1706: 부정 이용 기록 1년 보관 정책 등록 검증
+BEGIN;
+
+SELECT plan(10);
+
+SELECT tests.authenticate_as_service_role();
+
+-- ── report_details 정책 확인 ──────────────────────────────────────────────────
+
+-- 1. policy 존재
+SELECT ok(
+  EXISTS (SELECT 1 FROM admin.retention_policies WHERE id = 'report_details_fraud_record'),
+  '#1706: report_details_fraud_record policy registered'
+);
+
+-- 2. kind = db_table
+SELECT is(
+  (SELECT kind::text FROM admin.retention_policies WHERE id = 'report_details_fraud_record'),
+  'db_table',
+  '#1706: report_details policy kind is db_table'
+);
+
+-- 3. retention_days = 365
+SELECT is(
+  (SELECT retention_days FROM admin.retention_policies WHERE id = 'report_details_fraud_record'),
+  365,
+  '#1706: report_details retention_days = 365 (1년)'
+);
+
+-- 4. legal_min_days = 365
+SELECT is(
+  (SELECT legal_min_days FROM admin.retention_policies WHERE id = 'report_details_fraud_record'),
+  365,
+  '#1706: report_details legal_min_days = 365'
+);
+
+-- 5. enabled = true
+SELECT ok(
+  (SELECT enabled FROM admin.retention_policies WHERE id = 'report_details_fraud_record'),
+  '#1706: report_details policy enabled = true'
+);
+
+-- 6. target 스키마/테이블/컬럼 확인
+SELECT ok(
+  (SELECT target FROM admin.retention_policies WHERE id = 'report_details_fraud_record')
+    @> '{"schema":"public","table":"report_details","ts_col":"created_at"}'::jsonb,
+  '#1706: report_details target metadata correct'
+);
+
+-- ── blocked_dis 정책 확인 (비활성, 불일치 추적용) ─────────────────────────────
+
+-- 7. policy 존재
+SELECT ok(
+  EXISTS (SELECT 1 FROM admin.retention_policies WHERE id = 'blocked_dis_fraud_record'),
+  '#1706: blocked_dis_fraud_record policy registered'
+);
+
+-- 8. enabled = false (TTL 불일치로 비활성)
+SELECT ok(
+  NOT (SELECT enabled FROM admin.retention_policies WHERE id = 'blocked_dis_fraud_record'),
+  '#1706: blocked_dis policy enabled = false (legal-reviewer 컨설트 전)'
+);
+
+-- 9. retention_days = 365
+SELECT is(
+  (SELECT retention_days FROM admin.retention_policies WHERE id = 'blocked_dis_fraud_record'),
+  365,
+  '#1706: blocked_dis retention_days = 365 (선언된 보존 기간)'
+);
+
+-- 10. metadata에 conflict 정보 포함
+SELECT ok(
+  (SELECT metadata->>'conflict' FROM admin.retention_policies WHERE id = 'blocked_dis_fraud_record') IS NOT NULL,
+  '#1706: blocked_dis metadata documents TTL conflict for legal review'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1706

## Summary

개인정보처리방침 §F5 "부정 이용 기록 1년 보관" 집행 가능 상태로 전환.

| 테이블 | 처리 | 사유 |
|--------|------|------|
| `report_details` | retention_days=365, **enabled=true** | 신고 기록 — 명확한 1년 보존 대상 |
| `blocked_dis` | retention_days=365, **enabled=false** | TTL 불일치 → legal-reviewer 판단 필요 |
| `social_interactions` (block/report) | 제외 | 현재 상태 테이블 (이력 아님) |

## blocked_dis 불일치 이슈

`blocked_dis.blocked_until`은 현재 **30일 TTL** 운영 중 (cleanup-blocked-dis EF가 매일 삭제). 개인정보처리방침은 "1년 보관"을 선언. 상충 → `enabled=false`로 등록해 추적만 하고, **needs-legal 라벨**로 legal-reviewer 컨설트 요청.

## Changes

| 파일 | 내용 |
|------|------|
| `supabase/migrations/20260422000005_fraud_record_retention.sql` | 2개 정책 INSERT |
| `supabase/tests/database/92_fraud_record_retention_test.sql` | pgTAP 10건 |

## Test Plan

- [x] pgTAP 92_fraud_record_retention_test.sql (10건)
  - report_details: kind, retention_days, enabled, target, legal_min_days
  - blocked_dis: enabled=false, conflict metadata 존재