### PR TITLE
fix(partner): 입장 조건 편집 — '준비 중' 토스트 → EntryGroupManagementScreen (#1733)

### DIFF
--- a/apps/app_partner/lib/l10n/app_ko.arb
+++ b/apps/app_partner/lib/l10n/app_ko.arb
@@ -69,6 +69,11 @@
   },
   "partyDetail_tab_operation": "회차 및 티켓",
   "partyDetail_tab_info": "파티 정보",
+  "partyDetail_title_entryGroupManagement": "입장 조건 관리",
+  "entryGroup_delete_title": "입장 조건 삭제",
+  "entryGroup_delete_message": "이 입장 조건을 삭제하시겠습니까? 연결된 티켓의 입장 조건 설정이 변경될 수 있습니다.",
+  "common_delete": "삭제",
+  "common_cancel": "취소",
 
   "partyList_badge_active": "운영중",
   "partyList_badge_closed": "종료됨",

--- a/apps/app_partner/lib/src/features/party/detail/party_detail_coordinator.dart
+++ b/apps/app_partner/lib/src/features/party/detail/party_detail_coordinator.dart
@@ -167,7 +167,9 @@ class PartyDetailCoordinator {
         ...(party.entryGroups ?? const <EntryGroupTemplate>[]),
         group.copyWith(partyId: partyId),
       ];
-      await _ref.read(partyRepositoryProvider).updateParty(
+      await _ref
+          .read(partyRepositoryProvider)
+          .updateParty(
             party.copyWith(entryGroups: updatedGroups),
           );
       _ref.invalidate(partyDetailProvider(partyId));
@@ -223,11 +225,12 @@ class PartyDetailCoordinator {
     final loading = _ref.read(globalLoadingControllerProvider.notifier)..show();
     try {
       final party = await _ref.read(partyDetailProvider(partyId).future);
-      final updatedGroups =
-          (party.entryGroups ?? const <EntryGroupTemplate>[])
-              .where((g) => g.id != groupId)
-              .toList();
-      await _ref.read(partyRepositoryProvider).updateParty(
+      final updatedGroups = (party.entryGroups ?? const <EntryGroupTemplate>[])
+          .where((g) => g.id != groupId)
+          .toList();
+      await _ref
+          .read(partyRepositoryProvider)
+          .updateParty(
             party.copyWith(entryGroups: updatedGroups),
           );
       _ref.invalidate(partyDetailProvider(partyId));

--- a/apps/app_partner/lib/src/features/party/detail/party_detail_coordinator.dart
+++ b/apps/app_partner/lib/src/features/party/detail/party_detail_coordinator.dart
@@ -163,8 +163,8 @@ class PartyDetailCoordinator {
     final loading = _ref.read(globalLoadingControllerProvider.notifier)..show();
     try {
       final party = await _ref.read(partyDetailProvider(partyId).future);
-      final updatedGroups = [
-        ...(party.entryGroups ?? []),
+      final updatedGroups = <EntryGroupTemplate>[
+        ...(party.entryGroups ?? const <EntryGroupTemplate>[]),
         group.copyWith(partyId: partyId),
       ];
       await _ref.read(partyRepositoryProvider).updateParty(
@@ -190,7 +190,7 @@ class PartyDetailCoordinator {
     try {
       final party = await _ref.read(partyDetailProvider(partyId).future);
 
-      final updatedGroups = (party.entryGroups ?? [])
+      final updatedGroups = (party.entryGroups ?? const <EntryGroupTemplate>[])
           .map((g) => g.id == updatedGroup.id ? updatedGroup : g)
           .toList();
 
@@ -224,7 +224,9 @@ class PartyDetailCoordinator {
     try {
       final party = await _ref.read(partyDetailProvider(partyId).future);
       final updatedGroups =
-          (party.entryGroups ?? []).where((g) => g.id != groupId).toList();
+          (party.entryGroups ?? const <EntryGroupTemplate>[])
+              .where((g) => g.id != groupId)
+              .toList();
       await _ref.read(partyRepositoryProvider).updateParty(
             party.copyWith(entryGroups: updatedGroups),
           );

--- a/apps/app_partner/lib/src/features/party/detail/party_detail_coordinator.dart
+++ b/apps/app_partner/lib/src/features/party/detail/party_detail_coordinator.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:app_partner/src/features/party/detail/party_detail_controller.dart';
+import 'package:app_partner/src/features/party/detail/widgets/party_entry_group_management_screen.dart';
 import 'package:app_partner/src/features/party/widgets/party_basic_info_edit_screen.dart';
 import 'package:app_partner/src/features/party/widgets/party_capacity_contact_edit_screen.dart';
 import 'package:app_partner/src/features/party/widgets/party_location_edit_screen.dart';
@@ -153,6 +154,17 @@ class PartyDetailCoordinator {
     } finally {
       loading.hide();
     }
+  }
+
+  // Fix #1733: 입장 조건 편집 화면 진입 — Coordinator 경유로 중앙화 (위젯 직접 Navigator 호출 제거)
+  void openEntryGroupManagement(BuildContext context, String partyId) {
+    unawaited(
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => PartyEntryGroupManagementScreen(partyId: partyId),
+        ),
+      ),
+    );
   }
 
   Future<void> addPartyEntryGroup(

--- a/apps/app_partner/lib/src/features/party/detail/party_detail_coordinator.dart
+++ b/apps/app_partner/lib/src/features/party/detail/party_detail_coordinator.dart
@@ -167,6 +167,7 @@ class PartyDetailCoordinator {
     );
   }
 
+  // Fix #1733: persist entry-group changes via entry_group_templates in EF body
   Future<void> addPartyEntryGroup(
     String partyId,
     PartyEntryGroup group,

--- a/apps/app_partner/lib/src/features/party/detail/party_detail_coordinator.dart
+++ b/apps/app_partner/lib/src/features/party/detail/party_detail_coordinator.dart
@@ -155,6 +155,32 @@ class PartyDetailCoordinator {
     }
   }
 
+  Future<void> addPartyEntryGroup(
+    String partyId,
+    PartyEntryGroup group,
+    BuildContext context,
+  ) async {
+    final loading = _ref.read(globalLoadingControllerProvider.notifier)..show();
+    try {
+      final party = await _ref.read(partyDetailProvider(partyId).future);
+      final updatedGroups = [
+        ...(party.entryGroups ?? []),
+        group.copyWith(partyId: partyId),
+      ];
+      await _ref.read(partyRepositoryProvider).updateParty(
+            party.copyWith(entryGroups: updatedGroups),
+          );
+      _ref.invalidate(partyDetailProvider(partyId));
+      if (context.mounted) {
+        context.showMinglitSuccess('입장 그룹이 추가되었습니다.');
+      }
+    } on Object catch (e, st) {
+      if (context.mounted) handleMinglitError(context, e, st);
+    } finally {
+      loading.hide();
+    }
+  }
+
   Future<void> updatePartyEntryGroup(
     String partyId,
     PartyEntryGroup updatedGroup,
@@ -163,9 +189,8 @@ class PartyDetailCoordinator {
     final loading = _ref.read(globalLoadingControllerProvider.notifier)..show();
     try {
       final party = await _ref.read(partyDetailProvider(partyId).future);
-      final currentGroups = party.entryGroups;
 
-      final updatedGroups = (currentGroups ?? [])
+      final updatedGroups = (party.entryGroups ?? [])
           .map((g) => g.id == updatedGroup.id ? updatedGroup : g)
           .toList();
 
@@ -185,6 +210,30 @@ class PartyDetailCoordinator {
       if (context.mounted) {
         handleMinglitError(context, e, st);
       }
+    } finally {
+      loading.hide();
+    }
+  }
+
+  Future<void> removePartyEntryGroup(
+    String partyId,
+    String groupId,
+    BuildContext context,
+  ) async {
+    final loading = _ref.read(globalLoadingControllerProvider.notifier)..show();
+    try {
+      final party = await _ref.read(partyDetailProvider(partyId).future);
+      final updatedGroups =
+          (party.entryGroups ?? []).where((g) => g.id != groupId).toList();
+      await _ref.read(partyRepositoryProvider).updateParty(
+            party.copyWith(entryGroups: updatedGroups),
+          );
+      _ref.invalidate(partyDetailProvider(partyId));
+      if (context.mounted) {
+        context.showMinglitSuccess('입장 그룹이 삭제되었습니다.');
+      }
+    } on Object catch (e, st) {
+      if (context.mounted) handleMinglitError(context, e, st);
     } finally {
       loading.hide();
     }

--- a/apps/app_partner/lib/src/features/party/detail/tabs/party_detail_info_tab.dart
+++ b/apps/app_partner/lib/src/features/party/detail/tabs/party_detail_info_tab.dart
@@ -1,6 +1,5 @@
 import 'package:app_partner/src/features/party/detail/party_detail_controller.dart';
 import 'package:app_partner/src/features/party/detail/party_detail_coordinator.dart';
-import 'package:app_partner/src/features/party/detail/widgets/party_entry_group_management_screen.dart';
 import 'package:app_partner/src/features/party/widgets/party_basic_info_summary.dart';
 import 'package:app_partner/src/features/party/widgets/party_capacity_summary.dart';
 import 'package:app_partner/src/features/party/widgets/party_contact_summary.dart';
@@ -140,17 +139,15 @@ class PartyDetailInfoTab extends ConsumerWidget {
     );
   }
 
-  // Fix #1733: navigate to entry group management screen
+  // Fix #1733: Coordinator를 통해 입장 조건 편집 화면 진입 (위젯 직접 Navigator 호출 제거)
   void _showEntranceConditionsEdit(
     BuildContext context,
     WidgetRef ref,
     Party party,
   ) {
-    Navigator.of(context).push(
-      MaterialPageRoute<void>(
-        builder: (_) => PartyEntryGroupManagementScreen(partyId: party.id),
-      ),
-    );
+    ref
+        .read(partyDetailCoordinatorProvider)
+        .openEntryGroupManagement(context, party.id);
   }
 
   Future<void> _handleUpdateLocation(

--- a/apps/app_partner/lib/src/features/party/detail/tabs/party_detail_info_tab.dart
+++ b/apps/app_partner/lib/src/features/party/detail/tabs/party_detail_info_tab.dart
@@ -1,5 +1,6 @@
 import 'package:app_partner/src/features/party/detail/party_detail_controller.dart';
 import 'package:app_partner/src/features/party/detail/party_detail_coordinator.dart';
+import 'package:app_partner/src/features/party/detail/widgets/party_entry_group_management_screen.dart';
 import 'package:app_partner/src/features/party/widgets/party_basic_info_summary.dart';
 import 'package:app_partner/src/features/party/widgets/party_capacity_summary.dart';
 import 'package:app_partner/src/features/party/widgets/party_contact_summary.dart';
@@ -139,15 +140,17 @@ class PartyDetailInfoTab extends ConsumerWidget {
     );
   }
 
+  // Fix #1733: navigate to entry group management screen
   void _showEntranceConditionsEdit(
     BuildContext context,
     WidgetRef ref,
     Party party,
   ) {
-    // Current UI doesn't have a specific group to edit,
-    // so we navigate to a screen or logic that handles groups.
-    // For now, keep the logic of tapping a group if needed,
-    // but the section itself is now clickable.
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => PartyEntryGroupManagementScreen(partyId: party.id),
+      ),
+    );
   }
 
   Future<void> _handleUpdateLocation(

--- a/apps/app_partner/lib/src/features/party/detail/tabs/party_rule_management_tab.dart
+++ b/apps/app_partner/lib/src/features/party/detail/tabs/party_rule_management_tab.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:app_partner/src/features/party/detail/party_detail_controller.dart';
+import 'package:app_partner/src/features/party/detail/widgets/party_entry_group_management_screen.dart';
 import 'package:app_partner/src/features/party/ticket/ticket_template_create_page.dart';
 import 'package:app_partner/src/features/party/ticket/widgets/party_tickets_summary.dart';
 import 'package:app_partner/src/features/party/widgets/party_entrance_condition_summary.dart';
@@ -73,14 +74,18 @@ class PartyRuleManagementTab extends ConsumerWidget {
     );
   }
 
+  // Fix #1733: navigate to entry group management screen instead of "under preparation" toast
   void _showEntranceConditionsEdit(
     BuildContext context,
     WidgetRef ref,
     Party party,
   ) {
-    // Placeholder for future implementation of Entry Group editing
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('입장 조건 수정 기능은 준비 중입니다.')),
+    unawaited(
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => PartyEntryGroupManagementScreen(partyId: party.id),
+        ),
+      ),
     );
   }
 

--- a/apps/app_partner/lib/src/features/party/detail/tabs/party_rule_management_tab.dart
+++ b/apps/app_partner/lib/src/features/party/detail/tabs/party_rule_management_tab.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:app_partner/src/features/party/detail/party_detail_controller.dart';
-import 'package:app_partner/src/features/party/detail/widgets/party_entry_group_management_screen.dart';
+import 'package:app_partner/src/features/party/detail/party_detail_coordinator.dart';
 import 'package:app_partner/src/features/party/ticket/ticket_template_create_page.dart';
 import 'package:app_partner/src/features/party/ticket/widgets/party_tickets_summary.dart';
 import 'package:app_partner/src/features/party/widgets/party_entrance_condition_summary.dart';
@@ -74,19 +74,15 @@ class PartyRuleManagementTab extends ConsumerWidget {
     );
   }
 
-  // Fix #1733: navigate to entry group management screen instead of "under preparation" toast
+  // Fix #1733: Coordinator를 통해 입장 조건 편집 화면 진입 (위젯 직접 Navigator 호출 제거)
   void _showEntranceConditionsEdit(
     BuildContext context,
     WidgetRef ref,
     Party party,
   ) {
-    unawaited(
-      Navigator.of(context).push(
-        MaterialPageRoute<void>(
-          builder: (_) => PartyEntryGroupManagementScreen(partyId: party.id),
-        ),
-      ),
-    );
+    ref
+        .read(partyDetailCoordinatorProvider)
+        .openEntryGroupManagement(context, party.id);
   }
 
   Future<void> _handleCreateTicket(BuildContext context, WidgetRef ref) async {

--- a/apps/app_partner/lib/src/features/party/detail/widgets/party_entry_group_management_screen.dart
+++ b/apps/app_partner/lib/src/features/party/detail/widgets/party_entry_group_management_screen.dart
@@ -22,7 +22,7 @@ class PartyEntryGroupManagementScreen extends ConsumerWidget {
 
     return Scaffold(
       appBar: MinglitTheme.simpleAppBar(
-        title: context.l10n.partyDetail_section_entranceCondition,
+        title: context.l10n.partyDetail_title_entryGroupManagement,
       ),
       body: MinglitAsyncValueWidget(
         value: partyAsync,
@@ -33,9 +33,27 @@ class PartyEntryGroupManagementScreen extends ConsumerWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
+                if (groups.isNotEmpty) ...[
+                  AddActionCard(
+                    title: context.l10n.partyCreate_button_addEntryGroup,
+                    subtitle: context.l10n.partyCreate_subtitle_addEntryGroup,
+                    onTap: () => _openGroupEditor(
+                      context,
+                      ref,
+                      coordinator: coordinator,
+                    ),
+                  ),
+                  const SizedBox(height: MinglitSpacing.medium),
+                ],
                 if (groups.isEmpty)
-                  MinglitEmptyState.inline(
+                  MinglitEmptyState(
                     title: context.l10n.partyCreate_empty_entryGroups,
+                    actionLabel: context.l10n.partyCreate_button_addEntryGroup,
+                    onAction: () => _openGroupEditor(
+                      context,
+                      ref,
+                      coordinator: coordinator,
+                    ),
                   )
                 else
                   ListView.separated(
@@ -84,13 +102,33 @@ class PartyEntryGroupManagementScreen extends ConsumerWidget {
                                     ),
                                   ),
                                   IconButton(
-                                    icon: const Icon(Icons.close, size: 18),
-                                    onPressed: () =>
+                                    icon: const Icon(
+                                      Icons.delete_outline,
+                                      size: 18,
+                                    ),
+                                    tooltip: context.l10n.common_delete,
+                                    onPressed: () async {
+                                      final confirmed =
+                                          await MinglitAlert.showConfirm(
+                                            context: context,
+                                            title: context
+                                                .l10n.entryGroup_delete_title,
+                                            content: context
+                                                .l10n.entryGroup_delete_message,
+                                            confirmText:
+                                                context.l10n.common_delete,
+                                            cancelText:
+                                                context.l10n.common_cancel,
+                                            isDestructive: true,
+                                          );
+                                      if (confirmed) {
                                         coordinator.removePartyEntryGroup(
                                           partyId,
                                           group.id,
                                           context,
-                                        ),
+                                        );
+                                      }
+                                    },
                                     color: colorScheme.onSurfaceVariant,
                                     visualDensity: VisualDensity.compact,
                                   ),
@@ -121,16 +159,6 @@ class PartyEntryGroupManagementScreen extends ConsumerWidget {
                       );
                     },
                   ),
-                const SizedBox(height: MinglitSpacing.xlarge),
-                AddActionCard(
-                  title: context.l10n.partyCreate_button_addEntryGroup,
-                  subtitle: context.l10n.partyCreate_subtitle_addEntryGroup,
-                  onTap: () => _openGroupEditor(
-                    context,
-                    ref,
-                    coordinator: coordinator,
-                  ),
-                ),
               ],
             ),
           );

--- a/apps/app_partner/lib/src/features/party/detail/widgets/party_entry_group_management_screen.dart
+++ b/apps/app_partner/lib/src/features/party/detail/widgets/party_entry_group_management_screen.dart
@@ -112,9 +112,11 @@ class PartyEntryGroupManagementScreen extends ConsumerWidget {
                                           await MinglitAlert.showConfirm(
                                             context: context,
                                             title: context
-                                                .l10n.entryGroup_delete_title,
+                                                .l10n
+                                                .entryGroup_delete_title,
                                             content: context
-                                                .l10n.entryGroup_delete_message,
+                                                .l10n
+                                                .entryGroup_delete_message,
                                             confirmText:
                                                 context.l10n.common_delete,
                                             cancelText:

--- a/apps/app_partner/lib/src/features/party/detail/widgets/party_entry_group_management_screen.dart
+++ b/apps/app_partner/lib/src/features/party/detail/widgets/party_entry_group_management_screen.dart
@@ -42,7 +42,7 @@ class PartyEntryGroupManagementScreen extends ConsumerWidget {
                     shrinkWrap: true,
                     physics: const NeverScrollableScrollPhysics(),
                     itemCount: groups.length,
-                    separatorBuilder: (_, __) =>
+                    separatorBuilder: (_, _) =>
                         const SizedBox(height: MinglitSpacing.medium),
                     itemBuilder: (context, index) {
                       final group = groups[index];
@@ -50,8 +50,9 @@ class PartyEntryGroupManagementScreen extends ConsumerWidget {
                         elevation: 0,
                         clipBehavior: Clip.antiAlias,
                         shape: RoundedRectangleBorder(
-                          borderRadius:
-                              BorderRadius.circular(MinglitRadius.card),
+                          borderRadius: BorderRadius.circular(
+                            MinglitRadius.card,
+                          ),
                           side: BorderSide(
                             color: colorScheme.outlineVariant.withValues(
                               alpha: MinglitOpacity.strong,
@@ -65,29 +66,31 @@ class PartyEntryGroupManagementScreen extends ConsumerWidget {
                                 horizontal: MinglitSpacing.medium,
                                 vertical: MinglitSpacing.small,
                               ),
-                              color:
-                                  colorScheme.surfaceContainerHighest.withValues(
-                                alpha: MinglitOpacity.muted,
-                              ),
+                              color: colorScheme.surfaceContainerHighest
+                                  .withValues(
+                                    alpha: MinglitOpacity.muted,
+                                  ),
                               child: Row(
                                 mainAxisAlignment:
                                     MainAxisAlignment.spaceBetween,
                                 children: [
                                   Text(
-                                    context.l10n.partyCreate_label_entryGroupHeader(
-                                      index + 1,
-                                    ),
+                                    context.l10n
+                                        .partyCreate_label_entryGroupHeader(
+                                          index + 1,
+                                        ),
                                     style: theme.textTheme.bodyMedium?.copyWith(
                                       fontWeight: FontWeight.bold,
                                     ),
                                   ),
                                   IconButton(
                                     icon: const Icon(Icons.close, size: 18),
-                                    onPressed: () => coordinator.removePartyEntryGroup(
-                                      partyId,
-                                      group.id,
-                                      context,
-                                    ),
+                                    onPressed: () =>
+                                        coordinator.removePartyEntryGroup(
+                                          partyId,
+                                          group.id,
+                                          context,
+                                        ),
                                     color: colorScheme.onSurfaceVariant,
                                     visualDensity: VisualDensity.compact,
                                   ),
@@ -102,12 +105,12 @@ class PartyEntryGroupManagementScreen extends ConsumerWidget {
                                 initialGroup: group,
                               ),
                               child: Padding(
-                                padding:
-                                    const EdgeInsets.all(MinglitSpacing.medium),
+                                padding: const EdgeInsets.all(
+                                  MinglitSpacing.medium,
+                                ),
                                 child: EntryGroupDetail(
                                   group: group,
-                                  anyLabel:
-                                      context.l10n.entryGroup_option_any,
+                                  anyLabel: context.l10n.entryGroup_option_any,
                                   anyYearLabel:
                                       context.l10n.entryGroup_option_anyYear,
                                 ),

--- a/apps/app_partner/lib/src/features/party/detail/widgets/party_entry_group_management_screen.dart
+++ b/apps/app_partner/lib/src/features/party/detail/widgets/party_entry_group_management_screen.dart
@@ -1,0 +1,158 @@
+import 'package:app_partner/src/features/party/create/party_create_coordinator.dart';
+import 'package:app_partner/src/features/party/detail/party_detail_controller.dart';
+import 'package:app_partner/src/features/party/detail/party_detail_coordinator.dart';
+import 'package:app_partner/src/utils/l10n_ext.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+class PartyEntryGroupManagementScreen extends ConsumerWidget {
+  const PartyEntryGroupManagementScreen({
+    required this.partyId,
+    super.key,
+  });
+
+  final String partyId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final partyAsync = ref.watch(partyDetailProvider(partyId));
+    final coordinator = ref.read(partyDetailCoordinatorProvider);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Scaffold(
+      appBar: MinglitTheme.simpleAppBar(
+        title: context.l10n.partyDetail_section_entranceCondition,
+      ),
+      body: MinglitAsyncValueWidget(
+        value: partyAsync,
+        data: (party) {
+          final groups = party.entryGroups ?? [];
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(MinglitSpacing.medium),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                if (groups.isEmpty)
+                  MinglitEmptyState.inline(
+                    title: context.l10n.partyCreate_empty_entryGroups,
+                  )
+                else
+                  ListView.separated(
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    itemCount: groups.length,
+                    separatorBuilder: (_, __) =>
+                        const SizedBox(height: MinglitSpacing.medium),
+                    itemBuilder: (context, index) {
+                      final group = groups[index];
+                      return Card(
+                        elevation: 0,
+                        clipBehavior: Clip.antiAlias,
+                        shape: RoundedRectangleBorder(
+                          borderRadius:
+                              BorderRadius.circular(MinglitRadius.card),
+                          side: BorderSide(
+                            color: colorScheme.outlineVariant.withValues(
+                              alpha: MinglitOpacity.strong,
+                            ),
+                          ),
+                        ),
+                        child: Column(
+                          children: [
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: MinglitSpacing.medium,
+                                vertical: MinglitSpacing.small,
+                              ),
+                              color:
+                                  colorScheme.surfaceContainerHighest.withValues(
+                                alpha: MinglitOpacity.muted,
+                              ),
+                              child: Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  Text(
+                                    context.l10n.partyCreate_label_entryGroupHeader(
+                                      index + 1,
+                                    ),
+                                    style: theme.textTheme.bodyMedium?.copyWith(
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                  IconButton(
+                                    icon: const Icon(Icons.close, size: 18),
+                                    onPressed: () => coordinator.removePartyEntryGroup(
+                                      partyId,
+                                      group.id,
+                                      context,
+                                    ),
+                                    color: colorScheme.onSurfaceVariant,
+                                    visualDensity: VisualDensity.compact,
+                                  ),
+                                ],
+                              ),
+                            ),
+                            InkWell(
+                              onTap: () => _openGroupEditor(
+                                context,
+                                ref,
+                                coordinator: coordinator,
+                                initialGroup: group,
+                              ),
+                              child: Padding(
+                                padding:
+                                    const EdgeInsets.all(MinglitSpacing.medium),
+                                child: EntryGroupDetail(
+                                  group: group,
+                                  anyLabel:
+                                      context.l10n.entryGroup_option_any,
+                                  anyYearLabel:
+                                      context.l10n.entryGroup_option_anyYear,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+                const SizedBox(height: MinglitSpacing.xlarge),
+                AddActionCard(
+                  title: context.l10n.partyCreate_button_addEntryGroup,
+                  subtitle: context.l10n.partyCreate_subtitle_addEntryGroup,
+                  onTap: () => _openGroupEditor(
+                    context,
+                    ref,
+                    coordinator: coordinator,
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _openGroupEditor(
+    BuildContext context,
+    WidgetRef ref, {
+    required PartyDetailCoordinator coordinator,
+    PartyEntryGroup? initialGroup,
+  }) async {
+    final createCoordinator = PartyCreateCoordinator(context, ref: ref);
+    await createCoordinator.goToEntryGroupEditor(
+      initialGroup: initialGroup,
+      onSaved: (group) async {
+        if (!context.mounted) return;
+        if (initialGroup != null) {
+          await coordinator.updatePartyEntryGroup(partyId, group, context);
+        } else {
+          await coordinator.addPartyEntryGroup(partyId, group, context);
+        }
+      },
+    );
+  }
+}

--- a/apps/app_partner/lib/src/features/party/ticket/entry_group_editor_screen.dart
+++ b/apps/app_partner/lib/src/features/party/ticket/entry_group_editor_screen.dart
@@ -4,7 +4,6 @@ import 'package:app_partner/src/features/party/widgets/party_verification_input.
 import 'package:app_partner/src/utils/l10n_ext.dart';
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
-import 'package:uuid/uuid.dart';
 
 class EntryGroupEditorScreen extends ConsumerStatefulWidget {
   const EntryGroupEditorScreen({
@@ -45,8 +44,9 @@ class _EntryGroupEditorScreenState
   }
 
   void _submit() {
+    // Fix #1733: 새 그룹은 빈 id로 EF에 전송 → DB가 UUID 생성 (기존 그룹은 id 유지)
     final group = PartyEntryGroup(
-      id: widget.initialGroup?.id ?? const Uuid().v4(),
+      id: widget.initialGroup?.id ?? '',
       partyId: '', // Will be set by controller/repo
       gender: _gender,
       birthYearMin: _minYear,

--- a/apps/app_partner/lib/src/l10n/generated/app_localizations.dart
+++ b/apps/app_partner/lib/src/l10n/generated/app_localizations.dart
@@ -340,6 +340,36 @@ abstract class AppLocalizations {
   /// **'파티 정보'**
   String get partyDetail_tab_info;
 
+  /// No description provided for @partyDetail_title_entryGroupManagement.
+  ///
+  /// In ko, this message translates to:
+  /// **'입장 조건 관리'**
+  String get partyDetail_title_entryGroupManagement;
+
+  /// No description provided for @entryGroup_delete_title.
+  ///
+  /// In ko, this message translates to:
+  /// **'입장 조건 삭제'**
+  String get entryGroup_delete_title;
+
+  /// No description provided for @entryGroup_delete_message.
+  ///
+  /// In ko, this message translates to:
+  /// **'이 입장 조건을 삭제하시겠습니까? 연결된 티켓의 입장 조건 설정이 변경될 수 있습니다.'**
+  String get entryGroup_delete_message;
+
+  /// No description provided for @common_delete.
+  ///
+  /// In ko, this message translates to:
+  /// **'삭제'**
+  String get common_delete;
+
+  /// No description provided for @common_cancel.
+  ///
+  /// In ko, this message translates to:
+  /// **'취소'**
+  String get common_cancel;
+
   /// No description provided for @partyList_badge_active.
   ///
   /// In ko, this message translates to:

--- a/apps/app_partner/lib/src/l10n/generated/app_localizations_ko.dart
+++ b/apps/app_partner/lib/src/l10n/generated/app_localizations_ko.dart
@@ -144,6 +144,22 @@ class AppLocalizationsKo extends AppLocalizations {
   String get partyDetail_tab_info => '파티 정보';
 
   @override
+  String get partyDetail_title_entryGroupManagement => '입장 조건 관리';
+
+  @override
+  String get entryGroup_delete_title => '입장 조건 삭제';
+
+  @override
+  String get entryGroup_delete_message =>
+      '이 입장 조건을 삭제하시겠습니까? 연결된 티켓의 입장 조건 설정이 변경될 수 있습니다.';
+
+  @override
+  String get common_delete => '삭제';
+
+  @override
+  String get common_cancel => '취소';
+
+  @override
   String get partyList_badge_active => '운영중';
 
   @override

--- a/apps/app_partner/pubspec.yaml
+++ b/apps/app_partner/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1752-dev+26041752
+version: 26.04.1756-dev+26041756
 resolution: workspace
 
 environment:

--- a/apps/app_partner/pubspec.yaml
+++ b/apps/app_partner/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1750-dev+26041750
+version: 26.04.1752-dev+26041752
 resolution: workspace
 
 environment:

--- a/apps/app_partner/test/src/features/party/detail/party_entry_group_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/party/detail/party_entry_group_coordinator_test.dart
@@ -3,7 +3,6 @@ import 'package:app_partner/src/features/party/detail/party_detail_controller.da
 import 'package:app_partner/src/features/party/detail/party_detail_coordinator.dart';
 import 'package:app_partner/src/routing/app_router.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
@@ -27,7 +26,6 @@ PartyEntryGroup _makeGroup(String id) {
   return PartyEntryGroup(
     id: id,
     partyId: 'party-1',
-    requiredVerificationIds: const [],
     createdAt: now,
     updatedAt: now,
   );
@@ -72,16 +70,18 @@ void main() {
   });
 
   group('PartyDetailCoordinator.addPartyEntryGroup', () {
-    testWidgets('appends new group to party and calls updateParty',
-        (tester) async {
+    testWidgets('appends new group to party and calls updateParty', (
+      tester,
+    ) async {
       final existing = _makeGroup('g-1');
       final newGroup = _makeGroup('g-2');
 
       when(() => mockPartyRepo.getPartyById('party-1')).thenAnswer(
         (_) async => _makeParty(entryGroups: [existing]),
       );
-      when(() => mockPartyRepo.updateParty(any()))
-          .thenAnswer((_) async => _makeParty());
+      when(
+        () => mockPartyRepo.updateParty(any()),
+      ).thenAnswer((_) async => _makeParty());
 
       final (:container, :ctx) = await _buildScope(
         tester,
@@ -110,16 +110,18 @@ void main() {
   });
 
   group('PartyDetailCoordinator.removePartyEntryGroup', () {
-    testWidgets('removes the specified group and calls updateParty',
-        (tester) async {
+    testWidgets('removes the specified group and calls updateParty', (
+      tester,
+    ) async {
       final groupA = _makeGroup('g-A');
       final groupB = _makeGroup('g-B');
 
       when(() => mockPartyRepo.getPartyById('party-1')).thenAnswer(
         (_) async => _makeParty(entryGroups: [groupA, groupB]),
       );
-      when(() => mockPartyRepo.updateParty(any()))
-          .thenAnswer((_) async => _makeParty());
+      when(
+        () => mockPartyRepo.updateParty(any()),
+      ).thenAnswer((_) async => _makeParty());
 
       final (:container, :ctx) = await _buildScope(
         tester,
@@ -144,14 +146,13 @@ void main() {
   });
 
   group('PartyDetailCoordinator.updatePartyEntryGroup', () {
-    testWidgets('replaces the matching group and calls updateParty',
-        (tester) async {
+    testWidgets('replaces the matching group and calls updateParty', (
+      tester,
+    ) async {
       final now = DateTime.now();
       final original = PartyEntryGroup(
         id: 'g-1',
         partyId: 'party-1',
-        gender: null,
-        requiredVerificationIds: const [],
         createdAt: now,
         updatedAt: now,
       );
@@ -160,8 +161,9 @@ void main() {
       when(() => mockPartyRepo.getPartyById('party-1')).thenAnswer(
         (_) async => _makeParty(entryGroups: [original]),
       );
-      when(() => mockPartyRepo.updateParty(any()))
-          .thenAnswer((_) async => _makeParty());
+      when(
+        () => mockPartyRepo.updateParty(any()),
+      ).thenAnswer((_) async => _makeParty());
 
       final (:container, :ctx) = await _buildScope(
         tester,

--- a/apps/app_partner/test/src/features/party/detail/party_entry_group_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/party/detail/party_entry_group_coordinator_test.dart
@@ -147,8 +147,9 @@ void main() {
 
   // Fix #1733: tap 경로 regression — 입장 조건 탭 시 toast가 아닌 화면 전환이 발생해야 함
   group('PartyDetailCoordinator.openEntryGroupManagement', () {
-    testWidgets('pushes PartyEntryGroupManagementScreen — not a toast',
-        (tester) async {
+    testWidgets('pushes PartyEntryGroupManagementScreen — not a toast', (
+      tester,
+    ) async {
       final mockObserver = MockNavigatorObserver();
 
       when(() => mockPartyRepo.getPartyById('party-1')).thenAnswer(
@@ -165,8 +166,9 @@ void main() {
             navigatorObservers: [mockObserver],
             home: Builder(
               builder: (context) {
-                final coordinator =
-                    ProviderScope.containerOf(context).read(partyDetailCoordinatorProvider);
+                final coordinator = ProviderScope.containerOf(
+                  context,
+                ).read(partyDetailCoordinatorProvider);
                 return ElevatedButton(
                   onPressed: () =>
                       coordinator.openEntryGroupManagement(context, 'party-1'),

--- a/apps/app_partner/test/src/features/party/detail/party_entry_group_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/party/detail/party_entry_group_coordinator_test.dart
@@ -70,9 +70,11 @@ void main() {
     mockRouter = MockGoRouter();
     registerFallbackValue(_makeParty());
     // Fix #1733: Route fallback required by Mocktail any() in verify()
-    registerFallbackValue(MaterialPageRoute<dynamic>(
-      builder: (_) => const SizedBox.shrink(),
-    ));
+    registerFallbackValue(
+      MaterialPageRoute<dynamic>(
+        builder: (_) => const SizedBox.shrink(),
+      ),
+    );
   });
 
   group('PartyDetailCoordinator.addPartyEntryGroup', () {
@@ -171,7 +173,7 @@ void main() {
           child: MaterialApp(
             navigatorObservers: [mockObserver],
             locale: const Locale('ko'),
-            localizationsDelegates: [
+            localizationsDelegates: const [
               AppLocalizations.delegate,
               ...GlobalMaterialLocalizations.delegates,
             ],

--- a/apps/app_partner/test/src/features/party/detail/party_entry_group_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/party/detail/party_entry_group_coordinator_test.dart
@@ -1,0 +1,187 @@
+// Fix #1733: regression tests for entry group add/update/remove in PartyDetailCoordinator
+import 'package:app_partner/src/features/party/detail/party_detail_controller.dart';
+import 'package:app_partner/src/features/party/detail/party_detail_coordinator.dart';
+import 'package:app_partner/src/routing/app_router.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../utils/mocks.dart';
+
+Party _makeParty({List<PartyEntryGroup>? entryGroups}) {
+  final now = DateTime.now();
+  return Party(
+    id: 'party-1',
+    partnerId: 'partner-1',
+    title: 'Test Party',
+    createdAt: now,
+    updatedAt: now,
+    entryGroups: entryGroups,
+  );
+}
+
+PartyEntryGroup _makeGroup(String id) {
+  final now = DateTime.now();
+  return PartyEntryGroup(
+    id: id,
+    partyId: 'party-1',
+    requiredVerificationIds: const [],
+    createdAt: now,
+    updatedAt: now,
+  );
+}
+
+/// Builds a ProviderScope widget for coordinator tests, captures BuildContext.
+Future<({ProviderContainer container, BuildContext ctx})> _buildScope(
+  WidgetTester tester, {
+  required MockPartyRepository mockRepo,
+  required MockGoRouter mockRouter,
+}) async {
+  late BuildContext captured;
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        partyRepositoryProvider.overrideWithValue(mockRepo),
+        goRouterProvider.overrideWithValue(mockRouter),
+      ],
+      child: MaterialApp(
+        home: Builder(
+          builder: (ctx) {
+            captured = ctx;
+            return const Scaffold(body: SizedBox.shrink());
+          },
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  final container = ProviderScope.containerOf(captured);
+  return (container: container, ctx: captured);
+}
+
+void main() {
+  late MockPartyRepository mockPartyRepo;
+  late MockGoRouter mockRouter;
+
+  setUp(() {
+    mockPartyRepo = MockPartyRepository();
+    mockRouter = MockGoRouter();
+    registerFallbackValue(_makeParty());
+  });
+
+  group('PartyDetailCoordinator.addPartyEntryGroup', () {
+    testWidgets('appends new group to party and calls updateParty',
+        (tester) async {
+      final existing = _makeGroup('g-1');
+      final newGroup = _makeGroup('g-2');
+
+      when(() => mockPartyRepo.getPartyById('party-1')).thenAnswer(
+        (_) async => _makeParty(entryGroups: [existing]),
+      );
+      when(() => mockPartyRepo.updateParty(any()))
+          .thenAnswer((_) async => _makeParty());
+
+      final (:container, :ctx) = await _buildScope(
+        tester,
+        mockRepo: mockPartyRepo,
+        mockRouter: mockRouter,
+      );
+      // Preload partyDetailProvider cache
+      final sub = container.listen(partyDetailProvider('party-1'), (_, _) {});
+      addTearDown(sub.close);
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await container
+          .read(partyDetailCoordinatorProvider)
+          .addPartyEntryGroup('party-1', newGroup, ctx);
+
+      final captured = verify(
+        () => mockPartyRepo.updateParty(captureAny()),
+      ).captured;
+      final updatedParty = captured.first as Party;
+      expect(updatedParty.entryGroups, hasLength(2));
+      expect(
+        updatedParty.entryGroups!.map((g) => g.id).toList(),
+        containsAll(['g-1', 'g-2']),
+      );
+    });
+  });
+
+  group('PartyDetailCoordinator.removePartyEntryGroup', () {
+    testWidgets('removes the specified group and calls updateParty',
+        (tester) async {
+      final groupA = _makeGroup('g-A');
+      final groupB = _makeGroup('g-B');
+
+      when(() => mockPartyRepo.getPartyById('party-1')).thenAnswer(
+        (_) async => _makeParty(entryGroups: [groupA, groupB]),
+      );
+      when(() => mockPartyRepo.updateParty(any()))
+          .thenAnswer((_) async => _makeParty());
+
+      final (:container, :ctx) = await _buildScope(
+        tester,
+        mockRepo: mockPartyRepo,
+        mockRouter: mockRouter,
+      );
+      final sub = container.listen(partyDetailProvider('party-1'), (_, _) {});
+      addTearDown(sub.close);
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await container
+          .read(partyDetailCoordinatorProvider)
+          .removePartyEntryGroup('party-1', 'g-A', ctx);
+
+      final captured = verify(
+        () => mockPartyRepo.updateParty(captureAny()),
+      ).captured;
+      final updatedParty = captured.first as Party;
+      expect(updatedParty.entryGroups, hasLength(1));
+      expect(updatedParty.entryGroups!.first.id, 'g-B');
+    });
+  });
+
+  group('PartyDetailCoordinator.updatePartyEntryGroup', () {
+    testWidgets('replaces the matching group and calls updateParty',
+        (tester) async {
+      final now = DateTime.now();
+      final original = PartyEntryGroup(
+        id: 'g-1',
+        partyId: 'party-1',
+        gender: null,
+        requiredVerificationIds: const [],
+        createdAt: now,
+        updatedAt: now,
+      );
+      final updated = original.copyWith(gender: 'female');
+
+      when(() => mockPartyRepo.getPartyById('party-1')).thenAnswer(
+        (_) async => _makeParty(entryGroups: [original]),
+      );
+      when(() => mockPartyRepo.updateParty(any()))
+          .thenAnswer((_) async => _makeParty());
+
+      final (:container, :ctx) = await _buildScope(
+        tester,
+        mockRepo: mockPartyRepo,
+        mockRouter: mockRouter,
+      );
+      final sub = container.listen(partyDetailProvider('party-1'), (_, _) {});
+      addTearDown(sub.close);
+      await tester.pump(const Duration(milliseconds: 100));
+
+      await container
+          .read(partyDetailCoordinatorProvider)
+          .updatePartyEntryGroup('party-1', updated, ctx);
+
+      final captured = verify(
+        () => mockPartyRepo.updateParty(captureAny()),
+      ).captured;
+      final updatedParty = captured.first as Party;
+      expect(updatedParty.entryGroups, hasLength(1));
+      expect(updatedParty.entryGroups!.first.gender, 'female');
+    });
+  });
+}

--- a/apps/app_partner/test/src/features/party/detail/party_entry_group_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/party/detail/party_entry_group_coordinator_test.dart
@@ -145,6 +145,47 @@ void main() {
     });
   });
 
+  // Fix #1733: tap 경로 regression — 입장 조건 탭 시 toast가 아닌 화면 전환이 발생해야 함
+  group('PartyDetailCoordinator.openEntryGroupManagement', () {
+    testWidgets('pushes PartyEntryGroupManagementScreen — not a toast',
+        (tester) async {
+      final mockObserver = MockNavigatorObserver();
+
+      when(() => mockPartyRepo.getPartyById('party-1')).thenAnswer(
+        (_) async => _makeParty(),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+            goRouterProvider.overrideWithValue(mockRouter),
+          ],
+          child: MaterialApp(
+            navigatorObservers: [mockObserver],
+            home: Builder(
+              builder: (context) {
+                final coordinator =
+                    ProviderScope.containerOf(context).read(partyDetailCoordinatorProvider);
+                return ElevatedButton(
+                  onPressed: () =>
+                      coordinator.openEntryGroupManagement(context, 'party-1'),
+                  child: const Text('open'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pump();
+
+      // Regression: 이전에는 toast/no-op이었으므로 실제 route push가 발생했는지 확인
+      verify(() => mockObserver.didPush(any(), any()));
+    });
+  });
+
   group('PartyDetailCoordinator.updatePartyEntryGroup', () {
     testWidgets('replaces the matching group and calls updateParty', (
       tester,

--- a/apps/app_partner/test/src/features/party/detail/party_entry_group_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/party/detail/party_entry_group_coordinator_test.dart
@@ -1,8 +1,10 @@
 // Fix #1733: regression tests for entry group add/update/remove in PartyDetailCoordinator
 import 'package:app_partner/src/features/party/detail/party_detail_controller.dart';
 import 'package:app_partner/src/features/party/detail/party_detail_coordinator.dart';
+import 'package:app_partner/src/l10n/generated/app_localizations.dart';
 import 'package:app_partner/src/routing/app_router.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
@@ -67,6 +69,10 @@ void main() {
     mockPartyRepo = MockPartyRepository();
     mockRouter = MockGoRouter();
     registerFallbackValue(_makeParty());
+    // Fix #1733: Route fallback required by Mocktail any() in verify()
+    registerFallbackValue(MaterialPageRoute<dynamic>(
+      builder: (_) => const SizedBox.shrink(),
+    ));
   });
 
   group('PartyDetailCoordinator.addPartyEntryGroup', () {
@@ -164,6 +170,12 @@ void main() {
           ],
           child: MaterialApp(
             navigatorObservers: [mockObserver],
+            locale: const Locale('ko'),
+            localizationsDelegates: [
+              AppLocalizations.delegate,
+              ...GlobalMaterialLocalizations.delegates,
+            ],
+            supportedLocales: AppLocalizations.supportedLocales,
             home: Builder(
               builder: (context) {
                 final coordinator = ProviderScope.containerOf(

--- a/apps/app_partner/test/src/features/party/detail/party_entry_group_entry_point_test.dart
+++ b/apps/app_partner/test/src/features/party/detail/party_entry_group_entry_point_test.dart
@@ -1,0 +1,189 @@
+// Fix #1733: regression test for the entry-condition tap path on Party Detail.
+//
+// Before the fix, tapping the "입장 조건" section in PartyRuleManagementTab /
+// PartyDetailInfoTab showed a "준비 중" toast (or no-op) instead of navigating
+// to the management screen. These tests exercise the actual tap entry points
+// and prove that PartyEntryGroupManagementScreen is pushed onto the navigator.
+// If someone reverts the entry-point wiring, these tests fail.
+
+import 'package:app_partner/src/features/party/detail/tabs/party_detail_info_tab.dart';
+import 'package:app_partner/src/features/party/detail/tabs/party_rule_management_tab.dart';
+import 'package:app_partner/src/features/party/detail/widgets/party_entry_group_management_screen.dart';
+import 'package:app_partner/src/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_quill/flutter_quill.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../utils/mocks.dart';
+
+Party _makeParty({List<PartyEntryGroup>? entryGroups}) {
+  final now = DateTime.now();
+  return Party(
+    id: 'party-1',
+    partnerId: 'partner-1',
+    title: 'Test Party',
+    createdAt: now,
+    updatedAt: now,
+    entryGroups: entryGroups,
+  );
+}
+
+class _PushObserver extends NavigatorObserver {
+  final List<Route<dynamic>> pushed = [];
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    if (previousRoute != null) {
+      pushed.add(route);
+    }
+  }
+}
+
+Widget _wrapTab({
+  required Widget tab,
+  required _PushObserver observer,
+  required List<Object> overrides,
+}) {
+  return ProviderScope(
+    overrides: overrides.cast(),
+    child: MaterialApp(
+      navigatorObservers: [observer],
+      locale: const Locale('ko'),
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        FlutterQuillLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: tab),
+    ),
+  );
+}
+
+void main() {
+  late MockPartyRepository mockPartyRepo;
+  late MockTicketRepository mockTicketRepo;
+  late MockLocationRepository mockLocationRepo;
+
+  setUp(() {
+    mockPartyRepo = MockPartyRepository();
+    mockTicketRepo = MockTicketRepository();
+    mockLocationRepo = MockLocationRepository();
+
+    when(() => mockPartyRepo.getPartyById(any())).thenAnswer(
+      (_) async => _makeParty(),
+    );
+    when(() => mockTicketRepo.getTicketTemplatesByPartyId(any()))
+        .thenAnswer((_) async => []);
+    when(() => mockLocationRepo.getLocationById(any()))
+        .thenAnswer((_) async => null);
+  });
+
+  group('PartyRuleManagementTab entry-condition tap (Fix #1733)', () {
+    testWidgets(
+      'pushes PartyEntryGroupManagementScreen instead of showing "준비 중" toast',
+      (tester) async {
+        final observer = _PushObserver();
+        final party = _makeParty();
+
+        await tester.pumpWidget(
+          _wrapTab(
+            tab: PartyRuleManagementTab(party: party),
+            observer: observer,
+            overrides: [
+              partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+              ticketRepositoryProvider.overrideWithValue(mockTicketRepo),
+            ],
+          ),
+        );
+        // Let the ticket provider resolve and UI render
+        await tester.pump();
+
+        // Tap the entry-condition section by its title
+        final entranceTitle = find.text(
+          AppLocalizations.of(
+            tester.element(find.byType(PartyRuleManagementTab)),
+          )!.partyDetail_section_entranceCondition,
+        );
+        expect(entranceTitle, findsOneWidget);
+        await tester.tap(entranceTitle);
+        await tester.pump();
+
+        // Must push the management screen (not show a toast)
+        expect(
+          observer.pushed.any((r) {
+            if (r is MaterialPageRoute) {
+              final w = r.builder(
+                tester.element(find.byType(PartyRuleManagementTab)),
+              );
+              return w is PartyEntryGroupManagementScreen;
+            }
+            return false;
+          }),
+          isTrue,
+          reason:
+              'Tapping the entry-condition section must push '
+              'PartyEntryGroupManagementScreen (Fix #1733).',
+        );
+
+        // Sanity: no "준비 중" toast content
+        expect(find.textContaining('준비 중'), findsNothing);
+      },
+    );
+  });
+
+  group('PartyDetailInfoTab entry-condition tap (Fix #1733)', () {
+    testWidgets(
+      'pushes PartyEntryGroupManagementScreen on entry-condition section tap',
+      (tester) async {
+        final observer = _PushObserver();
+        final party = _makeParty();
+
+        await tester.pumpWidget(
+          _wrapTab(
+            tab: PartyDetailInfoTab(party: party),
+            observer: observer,
+            overrides: [
+              partyRepositoryProvider.overrideWithValue(mockPartyRepo),
+              locationRepositoryProvider.overrideWithValue(mockLocationRepo),
+            ],
+          ),
+        );
+        await tester.pump();
+
+        final entranceTitle = find.text(
+          AppLocalizations.of(
+            tester.element(find.byType(PartyDetailInfoTab)),
+          )!.partyDetail_section_entranceCondition,
+        );
+        expect(entranceTitle, findsOneWidget);
+        // Scroll the section into view before tapping
+        await tester.ensureVisible(entranceTitle);
+        await tester.pump();
+        await tester.tap(entranceTitle);
+        await tester.pump();
+
+        expect(
+          observer.pushed.any((r) {
+            if (r is MaterialPageRoute) {
+              final w = r.builder(
+                tester.element(find.byType(PartyDetailInfoTab)),
+              );
+              return w is PartyEntryGroupManagementScreen;
+            }
+            return false;
+          }),
+          isTrue,
+          reason:
+              'Tapping the entry-condition section on the info tab must push '
+              'PartyEntryGroupManagementScreen (Fix #1733).',
+        );
+      },
+    );
+  });
+}

--- a/apps/app_partner/test/src/features/party/detail/party_entry_group_entry_point_test.dart
+++ b/apps/app_partner/test/src/features/party/detail/party_entry_group_entry_point_test.dart
@@ -78,10 +78,12 @@ void main() {
     when(() => mockPartyRepo.getPartyById(any())).thenAnswer(
       (_) async => _makeParty(),
     );
-    when(() => mockTicketRepo.getTicketTemplatesByPartyId(any()))
-        .thenAnswer((_) async => []);
-    when(() => mockLocationRepo.getLocationById(any()))
-        .thenAnswer((_) async => null);
+    when(
+      () => mockTicketRepo.getTicketTemplatesByPartyId(any()),
+    ).thenAnswer((_) async => []);
+    when(
+      () => mockLocationRepo.getLocationById(any()),
+    ).thenAnswer((_) async => null);
   });
 
   group('PartyRuleManagementTab entry-condition tap (Fix #1733)', () {

--- a/apps/app_partner/test/utils/mocks.dart
+++ b/apps/app_partner/test/utils/mocks.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
@@ -28,3 +29,5 @@ class MockTicketRepository extends Mock implements TicketRepository {}
 class MockLocationRepository extends Mock implements LocationRepository {}
 
 class MockMatchingRepository extends Mock implements MatchingRepository {}
+
+class MockNavigatorObserver extends Mock implements NavigatorObserver {}

--- a/apps/app_user/lib/main.dart
+++ b/apps/app_user/lib/main.dart
@@ -88,22 +88,24 @@ Future<void> appStartup(Ref ref) async {
     );
   }
 
-  try {
-    await Future.wait([
-      initializeDateFormatting('ko_KR'),
-      Supabase.initialize(url: supabaseUrl, anonKey: supabasePublishableKey),
-      Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform),
-    ]);
-  } on Exception catch (e) {
-    Log.e('App startup warning', e);
-  }
-
   const statsigClientKey = String.fromEnvironment('STATSIG_CLIENT_KEY');
   const environment = String.fromEnvironment(
     'ENVIRONMENT',
     defaultValue: 'local',
   );
-  await StatsigAnalytics.initialize(statsigClientKey, tier: environment);
+
+  // Fix #1746: parallelize Statsig with Supabase/Firebase to reduce cold-start
+  // splash duration. Statsig has no dependency on Firebase or Supabase.
+  try {
+    await Future.wait([
+      initializeDateFormatting('ko_KR'),
+      Supabase.initialize(url: supabaseUrl, anonKey: supabasePublishableKey),
+      Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform),
+      StatsigAnalytics.initialize(statsigClientKey, tier: environment),
+    ]);
+  } on Exception catch (e) {
+    Log.e('App startup warning', e);
+  }
   StatsigAnalytics.logEvent(MingLitEvent.appOpened);
 
   // Sync Statsig user context with auth state changes
@@ -140,10 +142,17 @@ class _AppView extends ConsumerWidget {
     // Activate notification initializer to listen for sign-in events
     ref
       ..watch(notificationInitializerProvider)
-      // Remove native splash when startup completes (or fails).
+      // Fix #1746: guard with ref.watch to handle the case where startup
+      // already completed before this listener was registered (listener only
+      // fires on transitions, not on the current state).
       ..listen(appStartupProvider, (prev, next) {
         if (next is! AsyncLoading) FlutterNativeSplash.remove();
       });
+
+    // Eagerly remove splash if startup is already done (covers fast-init path).
+    if (startupState is! AsyncLoading) {
+      FlutterNativeSplash.remove();
+    }
 
     // ignore: use_minglit_async_value_widget - This is the app entry point, MaterialApp is not yet available.
     return MaterialApp.router(

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1752-dev+26041752
+version: 26.04.1756-dev+26041756
 resolution: workspace
 
 environment:

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1750-dev+26041750
+version: 26.04.1752-dev+26041752
 resolution: workspace
 
 environment:

--- a/apps/landing_partner/package.json
+++ b/apps/landing_partner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_partner",
-  "version": "26.04.1750-dev",
+  "version": "26.04.1752-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3003",

--- a/apps/landing_partner/package.json
+++ b/apps/landing_partner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_partner",
-  "version": "26.04.1752-dev",
+  "version": "26.04.1756-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3003",

--- a/apps/landing_user/package.json
+++ b/apps/landing_user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_user",
-  "version": "26.04.1752-dev",
+  "version": "26.04.1756-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",

--- a/apps/landing_user/package.json
+++ b/apps/landing_user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_user",
-  "version": "26.04.1750-dev",
+  "version": "26.04.1752-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minglit-root",
-  "version": "26.04.1752-dev",
+  "version": "26.04.1756-dev",
   "private": true,
   "workspaces": [
     "apps/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minglit-root",
-  "version": "26.04.1750-dev",
+  "version": "26.04.1752-dev",
   "private": true,
   "workspaces": [
     "apps/*"

--- a/shared/packages/minglit_iamport_v1/pubspec.yaml
+++ b/shared/packages/minglit_iamport_v1/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_iamport_v1
 description: "Iamport V1 Payment and Certification package for Minglit."
-version: 26.04.1750-dev
+version: 26.04.1752-dev
 publish_to: 'none'
 
 environment:

--- a/shared/packages/minglit_iamport_v1/pubspec.yaml
+++ b/shared/packages/minglit_iamport_v1/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_iamport_v1
 description: "Iamport V1 Payment and Certification package for Minglit."
-version: 26.04.1752-dev
+version: 26.04.1756-dev
 publish_to: 'none'
 
 environment:

--- a/shared/packages/minglit_kit/lib/src/data/repositories/party_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/party_repository.dart
@@ -225,12 +225,24 @@ abstract class _SupabasePartyContextBase implements _SupabasePartyContext {
       partyJson.remove('location');
       partyJson.remove('location_id');
 
+      // Fix #1733: entry_group_templates는 @JsonKey(includeToJson: false)로 toDbJson에서 제외 —
+      // update 요청에도 명시적으로 포함해야 EF가 entry_group_templates를 교체할 수 있음
+      final entryGroups = party.entryGroups;
+
       final body = <String, dynamic>{
         'action': 'update',
         'party_id': party.id,
         'party': partyJson,
         // Fix #1136: tag_ids는 null일 때 키 자체를 제외 — undefined와 null 구분을 위해
         'tag_ids': ?tagIds,
+        if (entryGroups != null)
+          'entry_group_templates': entryGroups
+              .map(
+                (g) => g.toJson()
+                  ..remove('created_at')
+                  ..remove('updated_at'),
+              )
+              .toList(),
       };
 
       final response = await supabaseClient.functions.invoke(

--- a/shared/packages/minglit_kit/pubspec.yaml
+++ b/shared/packages/minglit_kit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_kit
 description: "A new Flutter package project."
-version: 26.04.1752-dev
+version: 26.04.1756-dev
 resolution: workspace
 publish_to: 'none'
 environment:

--- a/shared/packages/minglit_kit/pubspec.yaml
+++ b/shared/packages/minglit_kit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_kit
 description: "A new Flutter package project."
-version: 26.04.1750-dev
+version: 26.04.1752-dev
 resolution: workspace
 publish_to: 'none'
 environment:

--- a/shared/packages/minglit_kit/test/src/data/repositories/party_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/party_repository_test.dart
@@ -392,6 +392,114 @@ void main() {
         },
       );
 
+      test(
+        'preserves existing entry group id in entry_group_templates body',
+        () async {
+          when(
+            () => mockFunctions.invoke(
+              'partner-manage-party',
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer(
+            (_) async => FunctionResponse(
+              status: 200,
+              data: {'success': true},
+            ),
+          );
+          unawaited(
+            mockTable(
+              mockClient,
+              'parties',
+              maybeSingleData: partyJson,
+            ),
+          );
+
+          // Fix #1733: 기존 그룹 id는 EF update payload에 유지되어야 기존 row를 UPDATE할 수 있음
+          final partyWithExistingGroup = Party.fromJson({
+            ...partyJson,
+            'entry_group_templates': [
+              {
+                'id': 'existing-group-id',
+                'party_id': 'party_1',
+                'label': '기존 그룹',
+                'gender': 'male',
+                'birth_year_min': 1990,
+                'birth_year_max': 2000,
+                'required_verification_ids': <String>[],
+              },
+            ],
+          });
+
+          await repository.updateParty(partyWithExistingGroup);
+
+          final captured =
+              verify(
+                    () => mockFunctions.invoke(
+                      'partner-manage-party',
+                      body: captureAny(named: 'body'),
+                    ),
+                  ).captured.single
+                  as Map<String, dynamic>;
+
+          final groups = captured['entry_group_templates'] as List;
+          expect((groups.first as Map)['id'], 'existing-group-id');
+        },
+      );
+
+      test(
+        'sends empty string id for new entry group in entry_group_templates body',
+        () async {
+          when(
+            () => mockFunctions.invoke(
+              'partner-manage-party',
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer(
+            (_) async => FunctionResponse(
+              status: 200,
+              data: {'success': true},
+            ),
+          );
+          unawaited(
+            mockTable(
+              mockClient,
+              'parties',
+              maybeSingleData: partyJson,
+            ),
+          );
+
+          // Fix #1733: 새 그룹은 빈 id로 전송해 EF가 INSERT 경로로 분기하도록 보장
+          final partyWithNewGroup = Party.fromJson({
+            ...partyJson,
+            'entry_group_templates': [
+              {
+                'id': '',
+                'party_id': 'party_1',
+                'label': '신규 그룹',
+                'gender': 'female',
+                'birth_year_min': 1992,
+                'birth_year_max': 2002,
+                'required_verification_ids': <String>[],
+              },
+            ],
+          });
+
+          await repository.updateParty(partyWithNewGroup);
+
+          final captured =
+              verify(
+                    () => mockFunctions.invoke(
+                      'partner-manage-party',
+                      body: captureAny(named: 'body'),
+                    ),
+                  ).captured.single
+                  as Map<String, dynamic>;
+
+          final groups = captured['entry_group_templates'] as List;
+          expect((groups.first as Map)['id'], '');
+        },
+      );
+
       // Fix #1733: updateParty with null entryGroups omits entry_group_templates key
       test(
         'omits entry_group_templates key when entryGroups is null',

--- a/shared/packages/minglit_kit/test/src/data/repositories/party_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/party_repository_test.dart
@@ -336,6 +336,96 @@ void main() {
 
         expect(captured.containsKey('tag_ids'), isFalse);
       });
+
+      // Fix #1733: updateParty with entryGroups sends entry_group_templates in EF body
+      test('includes entry_group_templates in body when entryGroups provided',
+          () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-party',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true},
+          ),
+        );
+        unawaited(
+          mockTable(
+            mockClient,
+            'parties',
+            maybeSingleData: partyJson,
+          ),
+        );
+
+        final partyWithGroups = Party.fromJson({
+          ...partyJson,
+          'entry_group_templates': [
+            {
+              'id': 'egt_1',
+              'party_id': 'party_1',
+              'label': '남성 그룹',
+              'gender': 'male',
+              'birth_year_min': 1990,
+              'birth_year_max': 2000,
+              'required_verification_ids': <String>[],
+            }
+          ],
+        });
+        await repository.updateParty(partyWithGroups);
+
+        final captured =
+            verify(
+                  () => mockFunctions.invoke(
+                    'partner-manage-party',
+                    body: captureAny(named: 'body'),
+                  ),
+                ).captured.single
+                as Map<String, dynamic>;
+
+        expect(captured.containsKey('entry_group_templates'), isTrue);
+        final groups = captured['entry_group_templates'] as List;
+        expect(groups.length, 1);
+        expect((groups.first as Map)['gender'], 'male');
+      });
+
+      // Fix #1733: updateParty with null entryGroups omits entry_group_templates key
+      test('omits entry_group_templates key when entryGroups is null',
+          () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-party',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true},
+          ),
+        );
+        unawaited(
+          mockTable(
+            mockClient,
+            'parties',
+            maybeSingleData: partyJson,
+          ),
+        );
+
+        final party = Party.fromJson(partyJson);
+        await repository.updateParty(party);
+
+        final captured =
+            verify(
+                  () => mockFunctions.invoke(
+                    'partner-manage-party',
+                    body: captureAny(named: 'body'),
+                  ),
+                ).captured.single
+                as Map<String, dynamic>;
+
+        expect(captured.containsKey('entry_group_templates'), isFalse);
+      });
     });
 
     // Fix #316: updatePartyStatus now uses EF invoke

--- a/shared/packages/minglit_kit/test/src/data/repositories/party_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/party_repository_test.dart
@@ -338,94 +338,98 @@ void main() {
       });
 
       // Fix #1733: updateParty with entryGroups sends entry_group_templates in EF body
-      test('includes entry_group_templates in body when entryGroups provided',
-          () async {
-        when(
-          () => mockFunctions.invoke(
-            'partner-manage-party',
-            body: any(named: 'body'),
-          ),
-        ).thenAnswer(
-          (_) async => FunctionResponse(
-            status: 200,
-            data: {'success': true},
-          ),
-        );
-        unawaited(
-          mockTable(
-            mockClient,
-            'parties',
-            maybeSingleData: partyJson,
-          ),
-        );
+      test(
+        'includes entry_group_templates in body when entryGroups provided',
+        () async {
+          when(
+            () => mockFunctions.invoke(
+              'partner-manage-party',
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer(
+            (_) async => FunctionResponse(
+              status: 200,
+              data: {'success': true},
+            ),
+          );
+          unawaited(
+            mockTable(
+              mockClient,
+              'parties',
+              maybeSingleData: partyJson,
+            ),
+          );
 
-        final partyWithGroups = Party.fromJson({
-          ...partyJson,
-          'entry_group_templates': [
-            {
-              'id': 'egt_1',
-              'party_id': 'party_1',
-              'label': '남성 그룹',
-              'gender': 'male',
-              'birth_year_min': 1990,
-              'birth_year_max': 2000,
-              'required_verification_ids': <String>[],
-            }
-          ],
-        });
-        await repository.updateParty(partyWithGroups);
+          final partyWithGroups = Party.fromJson({
+            ...partyJson,
+            'entry_group_templates': [
+              {
+                'id': 'egt_1',
+                'party_id': 'party_1',
+                'label': '남성 그룹',
+                'gender': 'male',
+                'birth_year_min': 1990,
+                'birth_year_max': 2000,
+                'required_verification_ids': <String>[],
+              },
+            ],
+          });
+          await repository.updateParty(partyWithGroups);
 
-        final captured =
-            verify(
-                  () => mockFunctions.invoke(
-                    'partner-manage-party',
-                    body: captureAny(named: 'body'),
-                  ),
-                ).captured.single
-                as Map<String, dynamic>;
+          final captured =
+              verify(
+                    () => mockFunctions.invoke(
+                      'partner-manage-party',
+                      body: captureAny(named: 'body'),
+                    ),
+                  ).captured.single
+                  as Map<String, dynamic>;
 
-        expect(captured.containsKey('entry_group_templates'), isTrue);
-        final groups = captured['entry_group_templates'] as List;
-        expect(groups.length, 1);
-        expect((groups.first as Map)['gender'], 'male');
-      });
+          expect(captured.containsKey('entry_group_templates'), isTrue);
+          final groups = captured['entry_group_templates'] as List;
+          expect(groups.length, 1);
+          expect((groups.first as Map)['gender'], 'male');
+        },
+      );
 
       // Fix #1733: updateParty with null entryGroups omits entry_group_templates key
-      test('omits entry_group_templates key when entryGroups is null',
-          () async {
-        when(
-          () => mockFunctions.invoke(
-            'partner-manage-party',
-            body: any(named: 'body'),
-          ),
-        ).thenAnswer(
-          (_) async => FunctionResponse(
-            status: 200,
-            data: {'success': true},
-          ),
-        );
-        unawaited(
-          mockTable(
-            mockClient,
-            'parties',
-            maybeSingleData: partyJson,
-          ),
-        );
+      test(
+        'omits entry_group_templates key when entryGroups is null',
+        () async {
+          when(
+            () => mockFunctions.invoke(
+              'partner-manage-party',
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer(
+            (_) async => FunctionResponse(
+              status: 200,
+              data: {'success': true},
+            ),
+          );
+          unawaited(
+            mockTable(
+              mockClient,
+              'parties',
+              maybeSingleData: partyJson,
+            ),
+          );
 
-        final party = Party.fromJson(partyJson);
-        await repository.updateParty(party);
+          final party = Party.fromJson(partyJson);
+          await repository.updateParty(party);
 
-        final captured =
-            verify(
-                  () => mockFunctions.invoke(
-                    'partner-manage-party',
-                    body: captureAny(named: 'body'),
-                  ),
-                ).captured.single
-                as Map<String, dynamic>;
+          final captured =
+              verify(
+                    () => mockFunctions.invoke(
+                      'partner-manage-party',
+                      body: captureAny(named: 'body'),
+                    ),
+                  ).captured.single
+                  as Map<String, dynamic>;
 
-        expect(captured.containsKey('entry_group_templates'), isFalse);
-      });
+          expect(captured.containsKey('entry_group_templates'), isFalse);
+        },
+      );
     });
 
     // Fix #316: updatePartyStatus now uses EF invoke

--- a/shared/packages/minglit_lints/pubspec.yaml
+++ b/shared/packages/minglit_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_lints
 description: Custom lint rules for Minglit project to enforce UI consistency and design tokens.
-version: 26.04.1752-dev
+version: 26.04.1756-dev
 publish_to: none
 resolution: workspace
 

--- a/shared/packages/minglit_lints/pubspec.yaml
+++ b/shared/packages/minglit_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_lints
 description: Custom lint rules for Minglit project to enforce UI consistency and design tokens.
-version: 26.04.1750-dev
+version: 26.04.1752-dev
 publish_to: none
 resolution: workspace
 

--- a/supabase/functions/partner-manage-party/index.ts
+++ b/supabase/functions/partner-manage-party/index.ts
@@ -366,11 +366,22 @@ async function handleRequest(req: Request): Promise<Response> {
       }
     }
 
+    // Fix #1733: entry_group_templates 업데이트 검증 (write 전 사전 검증)
+    const updateEntryGroupTemplates = body.entry_group_templates;
+    if (updateEntryGroupTemplates !== undefined) {
+      if (!Array.isArray(updateEntryGroupTemplates)) {
+        return errorResponse("entry_group_templates must be an array", 400);
+      }
+      const egtValidationError = validateEntryGroupTemplates(updateEntryGroupTemplates);
+      if (egtValidationError) return egtValidationError;
+    }
+
     if (
       Object.keys(partyUpdates).length === 0 &&
       !body.location &&
       body.location_id === undefined &&
-      updateTagIds === undefined
+      updateTagIds === undefined &&
+      updateEntryGroupTemplates === undefined
     ) {
       return errorResponse("No fields to update", 400);
     }
@@ -465,6 +476,35 @@ async function handleRequest(req: Request): Promise<Response> {
         });
       if (ptRpcError) {
         return errorResponse(`Failed to update party tags: ${ptRpcError.message}`, 500);
+      }
+    }
+
+    // Fix #1733: entry_group_templates 업데이트 — DELETE-then-INSERT (undefined = no change, [] = clear all)
+    if (updateEntryGroupTemplates !== undefined) {
+      const { error: deleteEgtError } = await supabase
+        .from("entry_group_templates")
+        .delete()
+        .eq("party_id", partyId);
+      if (deleteEgtError) {
+        return errorResponse(`Failed to delete entry group templates: ${deleteEgtError.message}`, 500);
+      }
+
+      if ((updateEntryGroupTemplates as unknown[]).length > 0) {
+        const egt = (updateEntryGroupTemplates as Record<string, unknown>[]).map((t) => ({
+          party_id: partyId,
+          label: t.label ?? null,
+          gender: t.gender ?? null,
+          birth_year_min: t.birth_year_min ?? null,
+          birth_year_max: t.birth_year_max ?? null,
+          required_verification_ids: t.required_verification_ids ?? [],
+        }));
+
+        const { error: insertEgtError } = await supabase
+          .from("entry_group_templates")
+          .insert(egt);
+        if (insertEgtError) {
+          return errorResponse(`Failed to insert entry group templates: ${insertEgtError.message}`, 500);
+        }
       }
     }
 

--- a/supabase/functions/partner-manage-party/index.ts
+++ b/supabase/functions/partner-manage-party/index.ts
@@ -11,7 +11,6 @@ import {
 import { requireAuth } from "../_shared/auth_utils.ts";
 import { initSentry, withHandler } from "../_shared/logger.ts";
 
-
 initSentry();
 
 const VALID_STATUSES = ["draft", "active", "closed"];
@@ -68,7 +67,9 @@ async function handleRequest(req: Request): Promise<Response> {
   let body: Record<string, unknown>;
   try {
     const parsed = await req.json();
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    if (
+      typeof parsed !== "object" || parsed === null || Array.isArray(parsed)
+    ) {
       return errorResponse("Request body must be a JSON object", 400);
     }
     body = parsed as Record<string, unknown>;
@@ -77,7 +78,9 @@ async function handleRequest(req: Request): Promise<Response> {
   }
 
   const action = body.action as string | undefined;
-  if (typeof action !== "string" || !action) return errorResponse("Missing action", 400);
+  if (typeof action !== "string" || !action) {
+    return errorResponse("Missing action", 400);
+  }
 
   // 4. Supabase client (service role)
   const supabase = createServiceClient();
@@ -92,7 +95,10 @@ async function handleRequest(req: Request): Promise<Response> {
 
     // Validate party fields
     const partyData = body.party;
-    if (typeof partyData !== "object" || partyData === null || Array.isArray(partyData)) {
+    if (
+      typeof partyData !== "object" || partyData === null ||
+      Array.isArray(partyData)
+    ) {
       return errorResponse("Missing or invalid party object", 400);
     }
     const party = partyData as Record<string, unknown>;
@@ -109,20 +115,35 @@ async function handleRequest(req: Request): Promise<Response> {
 
     // Validate status if provided
     if (party.status !== undefined) {
-      if (typeof party.status !== "string" || !VALID_STATUSES.includes(party.status)) {
-        return errorResponse(`Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}`, 400);
+      if (
+        typeof party.status !== "string" ||
+        !VALID_STATUSES.includes(party.status)
+      ) {
+        return errorResponse(
+          `Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}`,
+          400,
+        );
       }
     }
 
     // Validate location input if new location
     let newLocationInput: Record<string, unknown> | null = null;
     const existingLocationId = body.location_id;
-    if (body.location && typeof body.location === "object" && !Array.isArray(body.location)) {
+    if (
+      body.location && typeof body.location === "object" &&
+      !Array.isArray(body.location)
+    ) {
       newLocationInput = body.location as Record<string, unknown>;
-      if (typeof newLocationInput.name !== "string" || !newLocationInput.name.trim()) {
+      if (
+        typeof newLocationInput.name !== "string" ||
+        !newLocationInput.name.trim()
+      ) {
         return errorResponse("Missing location name", 400);
       }
-      if (typeof newLocationInput.address !== "string" || !newLocationInput.address.trim()) {
+      if (
+        typeof newLocationInput.address !== "string" ||
+        !newLocationInput.address.trim()
+      ) {
         return errorResponse("Missing location address", 400);
       }
     }
@@ -142,7 +163,8 @@ async function handleRequest(req: Request): Promise<Response> {
         return errorResponse("tag_ids must contain at most 5 tags", 400);
       }
       // Fix #1182: UUID format validation (#12)
-      const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      const UUID_RE =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
       for (let i = 0; i < tagIds.length; i++) {
         if (!UUID_RE.test(tagIds[i])) {
           return errorResponse(`tag_ids[${i}] must be a valid UUID`, 400);
@@ -155,9 +177,14 @@ async function handleRequest(req: Request): Promise<Response> {
           .from("tags")
           .select("id")
           .in("id", tagIds as string[]);
-        if (tagCheckError) return errorResponse("Failed to validate tag IDs", 500);
-        if (!existingTags || existingTags.length !== (tagIds as string[]).length)
+        if (tagCheckError) {
+          return errorResponse("Failed to validate tag IDs", 500);
+        }
+        if (
+          !existingTags || existingTags.length !== (tagIds as string[]).length
+        ) {
           return errorResponse("One or more tag_ids do not exist", 400);
+        }
       }
     }
 
@@ -190,7 +217,10 @@ async function handleRequest(req: Request): Promise<Response> {
       if (locError) return errorResponse("Failed to verify location", 500);
       if (!loc) return errorResponse("Location not found", 404);
       if (loc.partner_id !== partnerId) {
-        return errorResponse("Forbidden: location belongs to another partner", 403);
+        return errorResponse(
+          "Forbidden: location belongs to another partner",
+          403,
+        );
       }
       locationId = existingLocationId;
     } else if (newLocationInput) {
@@ -208,7 +238,10 @@ async function handleRequest(req: Request): Promise<Response> {
         .single();
 
       if (locInsertError) {
-        return errorResponse(`Failed to create location: ${locInsertError.message}`, 500);
+        return errorResponse(
+          `Failed to create location: ${locInsertError.message}`,
+          500,
+        );
       }
       locationId = newLoc.id;
     }
@@ -259,7 +292,10 @@ async function handleRequest(req: Request): Promise<Response> {
         .insert(egt);
 
       if (egtError) {
-        return errorResponse(`Failed to create entry group templates: ${egtError.message}`, 500);
+        return errorResponse(
+          `Failed to create entry group templates: ${egtError.message}`,
+          500,
+        );
       }
     }
 
@@ -280,7 +316,10 @@ async function handleRequest(req: Request): Promise<Response> {
         .insert(tt);
 
       if (ttError) {
-        return errorResponse(`Failed to create ticket templates: ${ttError.message}`, 500);
+        return errorResponse(
+          `Failed to create ticket templates: ${ttError.message}`,
+          500,
+        );
       }
     }
 
@@ -305,7 +344,11 @@ async function handleRequest(req: Request): Promise<Response> {
     if (!existingParty) return errorResponse("Party not found", 404);
 
     // Check partner permission
-    const permCheck = await checkPartnerPermission(supabase, existingParty.partner_id, userId);
+    const permCheck = await checkPartnerPermission(
+      supabase,
+      existingParty.partner_id,
+      userId,
+    );
     if (permCheck instanceof Response) return permCheck;
 
     // ── Pre-validate all payloads before any DB writes ──
@@ -313,7 +356,10 @@ async function handleRequest(req: Request): Promise<Response> {
     // Build party updates
     const partyData = body.party;
     const partyUpdates: Record<string, unknown> = {};
-    if (typeof partyData === "object" && partyData !== null && !Array.isArray(partyData)) {
+    if (
+      typeof partyData === "object" && partyData !== null &&
+      !Array.isArray(partyData)
+    ) {
       const party = partyData as Record<string, unknown>;
       for (const field of PARTY_FIELDS) {
         if (party[field] !== undefined) {
@@ -323,8 +369,14 @@ async function handleRequest(req: Request): Promise<Response> {
 
       // Validate status if provided
       if (partyUpdates.status !== undefined) {
-        if (typeof partyUpdates.status !== "string" || !VALID_STATUSES.includes(partyUpdates.status)) {
-          return errorResponse(`Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}`, 400);
+        if (
+          typeof partyUpdates.status !== "string" ||
+          !VALID_STATUSES.includes(partyUpdates.status)
+        ) {
+          return errorResponse(
+            `Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}`,
+            400,
+          );
         }
       }
     }
@@ -333,9 +385,10 @@ async function handleRequest(req: Request): Promise<Response> {
     // Fix #1136: tag_ids 검증을 모든 write 전으로 이동 — 부분 업데이트 방지
     const rawUpdateTagIds = body.tag_ids;
     // Fix #1182: deduplicate tag_ids before validation (#13)
-    const updateTagIds = rawUpdateTagIds !== undefined && Array.isArray(rawUpdateTagIds)
-      ? [...new Set(rawUpdateTagIds as string[])]
-      : rawUpdateTagIds;
+    const updateTagIds =
+      rawUpdateTagIds !== undefined && Array.isArray(rawUpdateTagIds)
+        ? [...new Set(rawUpdateTagIds as string[])]
+        : rawUpdateTagIds;
     if (updateTagIds !== undefined) {
       if (!Array.isArray(updateTagIds)) {
         return errorResponse("tag_ids must be an array", 400);
@@ -344,7 +397,8 @@ async function handleRequest(req: Request): Promise<Response> {
         return errorResponse("tag_ids must contain at most 5 tags", 400);
       }
       // Fix #1182: UUID format validation (#12)
-      const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      const UUID_RE =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
       for (let i = 0; i < updateTagIds.length; i++) {
         if (!UUID_RE.test(updateTagIds[i])) {
           return errorResponse(`tag_ids[${i}] must be a valid UUID`, 400);
@@ -360,7 +414,10 @@ async function handleRequest(req: Request): Promise<Response> {
         if (tagCheckError) {
           return errorResponse("Failed to validate tag IDs", 500);
         }
-        if (!existingTags || existingTags.length !== (updateTagIds as string[]).length) {
+        if (
+          !existingTags ||
+          existingTags.length !== (updateTagIds as string[]).length
+        ) {
           return errorResponse("One or more tag_ids do not exist", 400);
         }
       }
@@ -372,7 +429,9 @@ async function handleRequest(req: Request): Promise<Response> {
       if (!Array.isArray(updateEntryGroupTemplates)) {
         return errorResponse("entry_group_templates must be an array", 400);
       }
-      const egtValidationError = validateEntryGroupTemplates(updateEntryGroupTemplates);
+      const egtValidationError = validateEntryGroupTemplates(
+        updateEntryGroupTemplates,
+      );
       if (egtValidationError) return egtValidationError;
     }
 
@@ -396,13 +455,19 @@ async function handleRequest(req: Request): Promise<Response> {
         .eq("id", partyId);
 
       if (updateError) {
-        return errorResponse(`Failed to update party: ${updateError.message}`, 500);
+        return errorResponse(
+          `Failed to update party: ${updateError.message}`,
+          500,
+        );
       }
     }
 
     // Update location if provided
     const locationData = body.location;
-    if (typeof locationData === "object" && locationData !== null && !Array.isArray(locationData)) {
+    if (
+      typeof locationData === "object" && locationData !== null &&
+      !Array.isArray(locationData)
+    ) {
       const locInput = locationData as Record<string, unknown>;
 
       // Check if party has a location_id to update
@@ -412,7 +477,9 @@ async function handleRequest(req: Request): Promise<Response> {
         .eq("id", partyId)
         .single();
 
-      if (locFetchError) return errorResponse("Failed to fetch party location", 500);
+      if (locFetchError) {
+        return errorResponse("Failed to fetch party location", 500);
+      }
 
       if (partyWithLoc.location_id) {
         // Update existing location
@@ -430,7 +497,10 @@ async function handleRequest(req: Request): Promise<Response> {
             .eq("id", partyWithLoc.location_id);
 
           if (locUpdateError) {
-            return errorResponse(`Failed to update location: ${locUpdateError.message}`, 500);
+            return errorResponse(
+              `Failed to update location: ${locUpdateError.message}`,
+              500,
+            );
           }
         }
       }
@@ -450,7 +520,10 @@ async function handleRequest(req: Request): Promise<Response> {
         if (locError) return errorResponse("Failed to verify location", 500);
         if (!loc) return errorResponse("Location not found", 404);
         if (loc.partner_id !== existingParty.partner_id) {
-          return errorResponse("Forbidden: location belongs to another partner", 403);
+          return errorResponse(
+            "Forbidden: location belongs to another partner",
+            403,
+          );
         }
       }
 
@@ -460,7 +533,10 @@ async function handleRequest(req: Request): Promise<Response> {
         .eq("id", partyId);
 
       if (locIdError) {
-        return errorResponse(`Failed to update party location: ${locIdError.message}`, 500);
+        return errorResponse(
+          `Failed to update party location: ${locIdError.message}`,
+          500,
+        );
       }
     }
 
@@ -475,22 +551,111 @@ async function handleRequest(req: Request): Promise<Response> {
           p_tag_ids: updateTagIds as string[],
         });
       if (ptRpcError) {
-        return errorResponse(`Failed to update party tags: ${ptRpcError.message}`, 500);
+        return errorResponse(
+          `Failed to update party tags: ${ptRpcError.message}`,
+          500,
+        );
       }
     }
 
-    // Fix #1733: entry_group_templates 업데이트 — DELETE-then-INSERT (undefined = no change, [] = clear all)
+    // Fix #1733: UPSERT + selective DELETE — 기존 ID 보존으로 ticket_templates 링크 유지
     if (updateEntryGroupTemplates !== undefined) {
-      const { error: deleteEgtError } = await supabase
+      const templates = updateEntryGroupTemplates as Record<string, unknown>[];
+
+      const { data: existing, error: fetchExistingError } = await supabase
         .from("entry_group_templates")
-        .delete()
+        .select("id")
         .eq("party_id", partyId);
-      if (deleteEgtError) {
-        return errorResponse(`Failed to delete entry group templates: ${deleteEgtError.message}`, 500);
+      if (fetchExistingError) {
+        return errorResponse(
+          `Failed to fetch existing entry group templates: ${fetchExistingError.message}`,
+          500,
+        );
       }
 
-      if ((updateEntryGroupTemplates as unknown[]).length > 0) {
-        const egt = (updateEntryGroupTemplates as Record<string, unknown>[]).map((t) => ({
+      const existingIds = (existing ?? []).map((r: { id: string }) =>
+        r.id as string
+      );
+      const incomingWithId = templates.filter((t) =>
+        typeof t.id === "string" && (t.id as string).length > 0
+      );
+      const incomingWithoutId = templates.filter((t) =>
+        !t.id || (t.id as string).length === 0
+      );
+      const keptIds = incomingWithId.map((t) => t.id as string);
+      const toDeleteIds = existingIds.filter((id: string) =>
+        !keptIds.includes(id)
+      );
+
+      if (toDeleteIds.length > 0) {
+        const { data: affectedTickets, error: fetchTicketsError } =
+          await supabase
+            .from("ticket_templates")
+            .select("id, target_entry_group_ids")
+            .eq("party_id", partyId);
+        if (fetchTicketsError) {
+          return errorResponse(
+            `Failed to fetch ticket templates: ${fetchTicketsError.message}`,
+            500,
+          );
+        }
+
+        for (const ticket of (affectedTickets ?? [])) {
+          const tt = ticket as { id: string; target_entry_group_ids: string[] };
+          const hadAny = toDeleteIds.some((d) =>
+            tt.target_entry_group_ids?.includes(d)
+          );
+          if (hadAny) {
+            const updatedIds = (tt.target_entry_group_ids ?? []).filter((
+              id: string,
+            ) => !toDeleteIds.includes(id));
+            const { error: ttUpdateError } = await supabase
+              .from("ticket_templates")
+              .update({ target_entry_group_ids: updatedIds })
+              .eq("id", tt.id);
+            if (ttUpdateError) {
+              return errorResponse(
+                `Failed to update ticket template references: ${ttUpdateError.message}`,
+                500,
+              );
+            }
+          }
+        }
+
+        const { error: deleteEgtError } = await supabase
+          .from("entry_group_templates")
+          .delete()
+          .in("id", toDeleteIds);
+        if (deleteEgtError) {
+          return errorResponse(
+            `Failed to delete entry group templates: ${deleteEgtError.message}`,
+            500,
+          );
+        }
+      }
+
+      for (const t of incomingWithId) {
+        const { error: updateEgtError } = await supabase
+          .from("entry_group_templates")
+          .update({
+            label: t.label ?? null,
+            gender: t.gender ?? null,
+            birth_year_min: t.birth_year_min ?? null,
+            birth_year_max: t.birth_year_max ?? null,
+            required_verification_ids: t.required_verification_ids ?? [],
+          })
+          .eq("id", t.id as string)
+          .eq("party_id", partyId);
+        if (updateEgtError) {
+          return errorResponse(
+            `Failed to update entry group template: ${updateEgtError.message}`,
+            500,
+          );
+        }
+      }
+
+      if (incomingWithoutId.length > 0) {
+        const newTemplates = incomingWithoutId.map((t) => ({
           party_id: partyId,
           label: t.label ?? null,
           gender: t.gender ?? null,
@@ -498,12 +663,14 @@ async function handleRequest(req: Request): Promise<Response> {
           birth_year_max: t.birth_year_max ?? null,
           required_verification_ids: t.required_verification_ids ?? [],
         }));
-
         const { error: insertEgtError } = await supabase
           .from("entry_group_templates")
-          .insert(egt);
+          .insert(newTemplates);
         if (insertEgtError) {
-          return errorResponse(`Failed to insert entry group templates: ${insertEgtError.message}`, 500);
+          return errorResponse(
+            `Failed to insert new entry group templates: ${insertEgtError.message}`,
+            500,
+          );
         }
       }
     }
@@ -520,7 +687,10 @@ async function handleRequest(req: Request): Promise<Response> {
 
     const status = body.status;
     if (typeof status !== "string" || !VALID_STATUSES.includes(status)) {
-      return errorResponse(`Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}`, 400);
+      return errorResponse(
+        `Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}`,
+        400,
+      );
     }
 
     // Fetch party to verify ownership
@@ -534,7 +704,11 @@ async function handleRequest(req: Request): Promise<Response> {
     if (!existingParty) return errorResponse("Party not found", 404);
 
     // Check partner permission
-    const permCheck = await checkPartnerPermission(supabase, existingParty.partner_id, userId);
+    const permCheck = await checkPartnerPermission(
+      supabase,
+      existingParty.partner_id,
+      userId,
+    );
     if (permCheck instanceof Response) return permCheck;
 
     const { error: updateError } = await supabase
@@ -543,7 +717,10 @@ async function handleRequest(req: Request): Promise<Response> {
       .eq("id", partyId);
 
     if (updateError) {
-      return errorResponse(`Failed to update party status: ${updateError.message}`, 500);
+      return errorResponse(
+        `Failed to update party status: ${updateError.message}`,
+        500,
+      );
     }
 
     return successResponse({ success: true });
@@ -570,7 +747,8 @@ async function checkPartnerPermission(
     return errorResponse("Failed to verify partner permissions", 500);
   }
 
-  const hasPermission = (perm?.permissions as string[] | null)?.includes("PARTY_MANAGE") ?? false;
+  const hasPermission =
+    (perm?.permissions as string[] | null)?.includes("PARTY_MANAGE") ?? false;
   if (!hasPermission) {
     return errorResponse("Forbidden: insufficient partner permissions", 403);
   }
@@ -580,27 +758,59 @@ function validateEntryGroupTemplates(templates: unknown[]): Response | null {
   for (let i = 0; i < templates.length; i++) {
     const t = templates[i] as Record<string, unknown>;
     if (typeof t !== "object" || t === null || Array.isArray(t)) {
-      return errorResponse(`entry_group_templates[${i}] must be an object`, 400);
+      return errorResponse(
+        `entry_group_templates[${i}] must be an object`,
+        400,
+      );
+    }
+    // Fix #1733: 새 그룹은 빈 id 또는 미전송 허용 — 기존 그룹만 id 유지
+    if (t.id !== undefined && typeof t.id !== "string") {
+      return errorResponse(
+        `entry_group_templates[${i}].id must be a string when provided`,
+        400,
+      );
     }
     if (t.gender !== undefined && t.gender !== null) {
       if (typeof t.gender !== "string" || !VALID_GENDERS.includes(t.gender)) {
-        return errorResponse(`entry_group_templates[${i}].gender must be one of: ${VALID_GENDERS.join(", ")}`, 400);
+        return errorResponse(
+          `entry_group_templates[${i}].gender must be one of: ${
+            VALID_GENDERS.join(", ")
+          }`,
+          400,
+        );
       }
     }
     if (t.birth_year_min !== undefined && t.birth_year_min !== null) {
-      if (typeof t.birth_year_min !== "number" || t.birth_year_min < 1900 || t.birth_year_min > 2100) {
-        return errorResponse(`entry_group_templates[${i}].birth_year_min must be a valid year`, 400);
+      if (
+        typeof t.birth_year_min !== "number" || t.birth_year_min < 1900 ||
+        t.birth_year_min > 2100
+      ) {
+        return errorResponse(
+          `entry_group_templates[${i}].birth_year_min must be a valid year`,
+          400,
+        );
       }
     }
     if (t.birth_year_max !== undefined && t.birth_year_max !== null) {
-      if (typeof t.birth_year_max !== "number" || t.birth_year_max < 1900 || t.birth_year_max > 2100) {
-        return errorResponse(`entry_group_templates[${i}].birth_year_max must be a valid year`, 400);
+      if (
+        typeof t.birth_year_max !== "number" || t.birth_year_max < 1900 ||
+        t.birth_year_max > 2100
+      ) {
+        return errorResponse(
+          `entry_group_templates[${i}].birth_year_max must be a valid year`,
+          400,
+        );
       }
     }
-    if (t.birth_year_min !== undefined && t.birth_year_max !== undefined &&
-        t.birth_year_min !== null && t.birth_year_max !== null) {
+    if (
+      t.birth_year_min !== undefined && t.birth_year_max !== undefined &&
+      t.birth_year_min !== null && t.birth_year_max !== null
+    ) {
       if ((t.birth_year_min as number) > (t.birth_year_max as number)) {
-        return errorResponse(`entry_group_templates[${i}].birth_year_min cannot exceed birth_year_max`, 400);
+        return errorResponse(
+          `entry_group_templates[${i}].birth_year_min cannot exceed birth_year_max`,
+          400,
+        );
       }
     }
   }
@@ -617,7 +827,10 @@ function validateTicketTemplates(templates: unknown[]): Response | null {
       return errorResponse(`ticket_templates[${i}].name is required`, 400);
     }
     if (typeof t.quantity !== "number" || t.quantity < 0) {
-      return errorResponse(`ticket_templates[${i}].quantity must be a non-negative number`, 400);
+      return errorResponse(
+        `ticket_templates[${i}].quantity must be a non-negative number`,
+        400,
+      );
     }
     if (t.price !== undefined && t.price !== null) {
       if (typeof t.price !== "number" || t.price < 0) {

--- a/supabase/functions/partner-manage-party/partner_manage_party_test.ts
+++ b/supabase/functions/partner-manage-party/partner_manage_party_test.ts
@@ -691,6 +691,119 @@ Deno.test({
   },
 });
 
+// Fix #1733: update action with entry_group_templates — DELETE-then-INSERT persistence
+Deno.test({
+  name: "update: entry_group_templates are deleted and re-inserted",
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+    let deleteEntryGroupsCalled = false;
+    let insertEntryGroupsCalled = false;
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectPartyRoute(),
+      permRoute(),
+      updatePartyRoute(),
+      {
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/entry_group_templates") && req.method === "DELETE",
+        handler: () => {
+          deleteEntryGroupsCalled = true;
+          return new Response(null, { status: 200 });
+        },
+      },
+      {
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/entry_group_templates") && req.method === "POST",
+        handler: () => {
+          insertEntryGroupsCalled = true;
+          return jsonResponse([]);
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update",
+          party_id: TEST_PARTY_ID,
+          party: { title: "수정된 제목" },
+          entry_group_templates: [
+            {
+              id: "egt_1",
+              party_id: TEST_PARTY_ID,
+              label: "남성 그룹",
+              gender: "male",
+              birth_year_min: 1990,
+              birth_year_max: 2000,
+              required_verification_ids: [],
+            },
+          ],
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+      });
+    });
+
+    assertEquals(deleteEntryGroupsCalled, true, "DELETE entry_group_templates was called");
+    assertEquals(insertEntryGroupsCalled, true, "INSERT entry_group_templates was called");
+  },
+});
+
+Deno.test({
+  name: "update: empty entry_group_templates clears existing groups",
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+    let deleteEntryGroupsCalled = false;
+    let insertEntryGroupsCalled = false;
+
+    const { fetchMock } = createFetchMock([
+      authRoute(),
+      selectPartyRoute(),
+      permRoute(),
+      updatePartyRoute(),
+      {
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/entry_group_templates") && req.method === "DELETE",
+        handler: () => {
+          deleteEntryGroupsCalled = true;
+          return new Response(null, { status: 200 });
+        },
+      },
+      {
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/entry_group_templates") && req.method === "POST",
+        handler: () => {
+          insertEntryGroupsCalled = true;
+          return jsonResponse([]);
+        },
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update",
+          party_id: TEST_PARTY_ID,
+          party: { title: "수정된 제목" },
+          entry_group_templates: [],
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+      });
+    });
+
+    assertEquals(deleteEntryGroupsCalled, true, "DELETE entry_group_templates was called on empty array");
+    assertEquals(insertEntryGroupsCalled, false, "INSERT entry_group_templates was NOT called for empty array");
+  },
+});
+
 // ─── update_status action ───
 
 Deno.test({

--- a/supabase/functions/partner-manage-party/partner_manage_party_test.ts
+++ b/supabase/functions/partner-manage-party/partner_manage_party_test.ts
@@ -3,12 +3,12 @@ import {
   authenticatedJsonRequest,
   captureServeHandler,
   createFetchMock,
+  type FetchRoute,
   jsonRequest,
   jsonResponse,
   readJson,
   withEnv,
   withMockedFetch,
-  type FetchRoute,
 } from "../_test_utils/mock_http.ts";
 
 const TEST_USER_ID = "user-partner-owner";
@@ -44,7 +44,10 @@ function permRoute(hasPermission = true): FetchRoute {
     handler: () =>
       jsonResponse(
         hasPermission
-          ? { partner_id: TEST_PARTNER_ID, permissions: ["PARTNER_EDIT", "PARTY_MANAGE"] }
+          ? {
+            partner_id: TEST_PARTNER_ID,
+            permissions: ["PARTNER_EDIT", "PARTY_MANAGE"],
+          }
           : null,
       ),
   };
@@ -55,7 +58,10 @@ function permNoPartyManageRoute(): FetchRoute {
     matcher: (req) =>
       req.url.includes("partner_member_permissions") && req.method === "GET",
     handler: () =>
-      jsonResponse({ partner_id: TEST_PARTNER_ID, permissions: ["PARTNER_EDIT"] }),
+      jsonResponse({
+        partner_id: TEST_PARTNER_ID,
+        permissions: ["PARTNER_EDIT"],
+      }),
   };
 }
 
@@ -74,7 +80,8 @@ function selectLocationRoute(partnerId = TEST_PARTNER_ID): FetchRoute {
       req.url.includes("/rest/v1/locations") &&
       req.url.includes("select=") &&
       req.method === "GET",
-    handler: () => jsonResponse({ id: TEST_LOCATION_ID, partner_id: partnerId }),
+    handler: () =>
+      jsonResponse({ id: TEST_LOCATION_ID, partner_id: partnerId }),
   };
 }
 
@@ -98,7 +105,8 @@ function updateLocationRoute(): FetchRoute {
 function insertPartyErrorRoute(): FetchRoute {
   return {
     matcher: (req) =>
-      req.url.includes("/rest/v1/rpc/create_party_with_tags") && req.method === "POST",
+      req.url.includes("/rest/v1/rpc/create_party_with_tags") &&
+      req.method === "POST",
     handler: () => jsonResponse({ message: "insert error" }, { status: 500 }),
   };
 }
@@ -113,7 +121,11 @@ function selectPartyRoute(
       req.url.includes("select=") &&
       req.method === "GET",
     handler: () =>
-      jsonResponse({ id: TEST_PARTY_ID, partner_id: partnerId, location_id: locationId }),
+      jsonResponse({
+        id: TEST_PARTY_ID,
+        partner_id: partnerId,
+        location_id: locationId,
+      }),
   };
 }
 
@@ -148,7 +160,8 @@ function updatePartyErrorRoute(): FetchRoute {
 function rpcCreatePartyRoute(id = TEST_PARTY_ID): FetchRoute {
   return {
     matcher: (req) =>
-      req.url.includes("/rest/v1/rpc/create_party_with_tags") && req.method === "POST",
+      req.url.includes("/rest/v1/rpc/create_party_with_tags") &&
+      req.method === "POST",
     handler: () => jsonResponse(id),
   };
 }
@@ -156,15 +169,15 @@ function rpcCreatePartyRoute(id = TEST_PARTY_ID): FetchRoute {
 function rpcUpdatePartyTagsRoute(): FetchRoute {
   return {
     matcher: (req) =>
-      req.url.includes("/rest/v1/rpc/update_party_tags") && req.method === "POST",
+      req.url.includes("/rest/v1/rpc/update_party_tags") &&
+      req.method === "POST",
     handler: () => jsonResponse(null),
   };
 }
 
 function selectTagsRoute(tagIds: string[]): FetchRoute {
   return {
-    matcher: (req) =>
-      req.url.includes("/rest/v1/tags") && req.method === "GET",
+    matcher: (req) => req.url.includes("/rest/v1/tags") && req.method === "GET",
     handler: () => jsonResponse(tagIds.map((id) => ({ id }))),
   };
 }
@@ -173,8 +186,57 @@ function selectTagsRoute(tagIds: string[]): FetchRoute {
 function insertEntryGroupTemplatesRoute(): FetchRoute {
   return {
     matcher: (req) =>
-      req.url.includes("/rest/v1/entry_group_templates") && req.method === "POST",
+      req.url.includes("/rest/v1/entry_group_templates") &&
+      req.method === "POST",
     handler: () => jsonResponse([]),
+  };
+}
+
+function selectEntryGroupTemplatesRoute(ids: string[]): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/entry_group_templates") &&
+      req.url.includes("select=id") &&
+      req.method === "GET",
+    handler: () => jsonResponse(ids.map((id) => ({ id }))),
+  };
+}
+
+function updateEntryGroupTemplateRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/entry_group_templates") &&
+      req.method === "PATCH",
+    handler: () => new Response(null, { status: 200 }),
+  };
+}
+
+function deleteEntryGroupTemplatesRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/entry_group_templates") &&
+      req.method === "DELETE",
+    handler: () => new Response(null, { status: 200 }),
+  };
+}
+
+function selectTicketTemplatesRoute(
+  tickets: Array<{ id: string; target_entry_group_ids: string[] }>,
+): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/ticket_templates") &&
+      req.url.includes("target_entry_group_ids") &&
+      req.method === "GET",
+    handler: () => jsonResponse(tickets),
+  };
+}
+
+function updateTicketTemplateRoute(): FetchRoute {
+  return {
+    matcher: (req) =>
+      req.url.includes("/rest/v1/ticket_templates") && req.method === "PATCH",
+    handler: () => new Response(null, { status: 200 }),
   };
 }
 
@@ -191,7 +253,9 @@ function insertTicketTemplatesRoute(): FetchRoute {
 Deno.test({
   name: "OPTIONS returns CORS preflight",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const req = new Request("http://localhost", { method: "OPTIONS" });
     const res = await handler(req);
     assertEquals(res.status, 200);
@@ -201,7 +265,9 @@ Deno.test({
 Deno.test({
   name: "GET returns 405",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const req = new Request("http://localhost", { method: "GET" });
     const res = await handler(req);
     assertEquals(res.status, 405);
@@ -211,7 +277,9 @@ Deno.test({
 Deno.test({
   name: "Missing auth returns 401",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authFailRoute()]);
 
     await withEnv(ENV, async () => {
@@ -227,7 +295,9 @@ Deno.test({
 Deno.test({
   name: "Invalid JSON body returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -250,7 +320,9 @@ Deno.test({
 Deno.test({
   name: "Missing action returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -268,12 +340,16 @@ Deno.test({
 Deno.test({
   name: "Unknown action returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const req = authenticatedJsonRequest("http://localhost", { action: "delete" });
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "delete",
+        });
         const res = await handler(req);
         assertEquals(res.status, 400);
         const body = await readJson(res);
@@ -288,7 +364,9 @@ Deno.test({
 Deno.test({
   name: "create: party + location + templates — full atomic creation",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       permRoute(),
@@ -303,11 +381,30 @@ Deno.test({
         const req = authenticatedJsonRequest("http://localhost", {
           action: "create",
           partner_id: TEST_PARTNER_ID,
-          party: { title: "대학생 밍글", description: {}, max_participants: 20 },
-          location: { name: "강남 라운지", address: "서울 강남구", region_1: "서울", region_2: "강남구" },
+          party: {
+            title: "대학생 밍글",
+            description: {},
+            max_participants: 20,
+          },
+          location: {
+            name: "강남 라운지",
+            address: "서울 강남구",
+            region_1: "서울",
+            region_2: "강남구",
+          },
           entry_group_templates: [
-            { label: "남성", gender: "male", birth_year_min: 2000, birth_year_max: 2005 },
-            { label: "여성", gender: "female", birth_year_min: 2000, birth_year_max: 2005 },
+            {
+              label: "남성",
+              gender: "male",
+              birth_year_min: 2000,
+              birth_year_max: 2005,
+            },
+            {
+              label: "여성",
+              gender: "female",
+              birth_year_min: 2000,
+              birth_year_max: 2005,
+            },
           ],
           ticket_templates: [
             { name: "남성 티켓", price: 30000, quantity: 10 },
@@ -327,7 +424,9 @@ Deno.test({
 Deno.test({
   name: "create: with existing location_id",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       permRoute(),
@@ -356,7 +455,9 @@ Deno.test({
 Deno.test({
   name: "create: missing party title returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute(), permRoute()]);
 
     await withEnv(ENV, async () => {
@@ -378,7 +479,9 @@ Deno.test({
 Deno.test({
   name: "create: missing partner_id returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -399,7 +502,9 @@ Deno.test({
 Deno.test({
   name: "create: missing party object returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -418,7 +523,9 @@ Deno.test({
 Deno.test({
   name: "create: no partner membership returns 403",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       permRoute(false),
@@ -441,7 +548,9 @@ Deno.test({
 Deno.test({
   name: "create: no PARTY_MANAGE permission returns 403",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       permNoPartyManageRoute(),
@@ -464,7 +573,9 @@ Deno.test({
 Deno.test({
   name: "create: invalid gender in entry_group_templates returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       permRoute(),
@@ -491,7 +602,9 @@ Deno.test({
 Deno.test({
   name: "create: negative ticket price returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       permRoute(),
@@ -518,7 +631,9 @@ Deno.test({
 Deno.test({
   name: "create: location belonging to other partner returns 403",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       permRoute(),
@@ -536,7 +651,10 @@ Deno.test({
         const res = await handler(req);
         assertEquals(res.status, 403);
         const body = await readJson(res);
-        assertEquals(body.error, "Forbidden: location belongs to another partner");
+        assertEquals(
+          body.error,
+          "Forbidden: location belongs to another partner",
+        );
       });
     });
   },
@@ -547,7 +665,9 @@ Deno.test({
 Deno.test({
   name: "update: party title change",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectPartyRoute(),
@@ -574,7 +694,9 @@ Deno.test({
 Deno.test({
   name: "update: location change",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectPartyRoute(),
@@ -601,7 +723,9 @@ Deno.test({
 Deno.test({
   name: "update: missing party_id returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -622,7 +746,9 @@ Deno.test({
 Deno.test({
   name: "update: party not found returns 404",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectPartyNotFoundRoute(),
@@ -645,7 +771,9 @@ Deno.test({
 Deno.test({
   name: "update: other partner's party returns 403",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectPartyRoute("other-partner"),
@@ -669,7 +797,9 @@ Deno.test({
 Deno.test({
   name: "update: no fields to update returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectPartyRoute(),
@@ -691,36 +821,21 @@ Deno.test({
   },
 });
 
-// Fix #1733: update action with entry_group_templates — DELETE-then-INSERT persistence
 Deno.test({
-  name: "update: entry_group_templates are deleted and re-inserted",
+  name:
+    "update: entry_group_templates with id updates existing row and preserves id",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
-    let deleteEntryGroupsCalled = false;
-    let insertEntryGroupsCalled = false;
-
-    const { fetchMock } = createFetchMock([
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock, calls } = createFetchMock([
       authRoute(),
       selectPartyRoute(),
       permRoute(),
       updatePartyRoute(),
-      {
-        matcher: (req: Request) =>
-          req.url.includes("/rest/v1/entry_group_templates") && req.method === "DELETE",
-        handler: () => {
-          deleteEntryGroupsCalled = true;
-          return new Response(null, { status: 200 });
-        },
-      },
-      {
-        matcher: (req: Request) =>
-          req.url.includes("/rest/v1/entry_group_templates") && req.method === "POST",
-        handler: () => {
-          insertEntryGroupsCalled = true;
-          return jsonResponse([]);
-        },
-      },
+      // Fix #1733: 기존 그룹 id 유지 시 DELETE/INSERT 대신 UPDATE 경로를 타야 함
+      selectEntryGroupTemplatesRoute(["egt_1"]),
+      updateEntryGroupTemplateRoute(),
     ]);
 
     await withEnv(ENV, async () => {
@@ -748,40 +863,186 @@ Deno.test({
       });
     });
 
-    assertEquals(deleteEntryGroupsCalled, true, "DELETE entry_group_templates was called");
-    assertEquals(insertEntryGroupsCalled, true, "INSERT entry_group_templates was called");
+    const entryGroupUpdates = calls.filter(
+      (c) =>
+        c.url.includes("/rest/v1/entry_group_templates") &&
+        c.method === "PATCH",
+    );
+    const entryGroupDeletes = calls.filter(
+      (c) =>
+        c.url.includes("/rest/v1/entry_group_templates") &&
+        c.method === "DELETE",
+    );
+    const entryGroupInserts = calls.filter(
+      (c) =>
+        c.url.includes("/rest/v1/entry_group_templates") && c.method === "POST",
+    );
+
+    assertEquals(entryGroupUpdates.length, 1);
+    assertEquals(entryGroupDeletes.length, 0);
+    assertEquals(entryGroupInserts.length, 0);
+    assertEquals(
+      JSON.parse(entryGroupUpdates[0].body ?? "{}"),
+      {
+        label: "남성 그룹",
+        gender: "male",
+        birth_year_min: 1990,
+        birth_year_max: 2000,
+        required_verification_ids: [],
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "update: entry_group_templates without id inserts new row",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock, calls } = createFetchMock([
+      authRoute(),
+      selectPartyRoute(),
+      permRoute(),
+      updatePartyRoute(),
+      // Fix #1733: 빈 id는 신규 그룹으로 간주되어 INSERT 경로를 타야 함
+      selectEntryGroupTemplatesRoute([]),
+      insertEntryGroupTemplatesRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update",
+          party_id: TEST_PARTY_ID,
+          party: { title: "수정된 제목" },
+          entry_group_templates: [
+            {
+              id: "",
+              label: "신규 그룹",
+              gender: "female",
+              birth_year_min: 1995,
+              birth_year_max: 2005,
+              required_verification_ids: [],
+            },
+          ],
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+      });
+    });
+
+    const entryGroupInserts = calls.filter(
+      (c) =>
+        c.url.includes("/rest/v1/entry_group_templates") && c.method === "POST",
+    );
+    const entryGroupUpdates = calls.filter(
+      (c) =>
+        c.url.includes("/rest/v1/entry_group_templates") &&
+        c.method === "PATCH",
+    );
+
+    assertEquals(entryGroupInserts.length, 1);
+    assertEquals(entryGroupUpdates.length, 0);
+    assertEquals(
+      JSON.parse(entryGroupInserts[0].body ?? "[]"),
+      [
+        {
+          party_id: TEST_PARTY_ID,
+          label: "신규 그룹",
+          gender: "female",
+          birth_year_min: 1995,
+          birth_year_max: 2005,
+          required_verification_ids: [],
+        },
+      ],
+    );
+  },
+});
+
+Deno.test({
+  name:
+    "update: deleted entry group is removed from ticket_template target_entry_group_ids",
+  fn: async () => {
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock, calls } = createFetchMock([
+      authRoute(),
+      selectPartyRoute(),
+      permRoute(),
+      updatePartyRoute(),
+      // Fix #1733: 삭제 대상 그룹을 ticket_templates에서 먼저 제거해 orphan 참조를 방지
+      selectEntryGroupTemplatesRoute(["egt_keep", "egt_delete"]),
+      selectTicketTemplatesRoute([
+        { id: "ticket_1", target_entry_group_ids: ["egt_keep", "egt_delete"] },
+        { id: "ticket_2", target_entry_group_ids: ["egt_keep"] },
+      ]),
+      updateTicketTemplateRoute(),
+      deleteEntryGroupTemplatesRoute(),
+      updateEntryGroupTemplateRoute(),
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const req = authenticatedJsonRequest("http://localhost", {
+          action: "update",
+          party_id: TEST_PARTY_ID,
+          entry_group_templates: [
+            {
+              id: "egt_keep",
+              label: "유지 그룹",
+              gender: "male",
+              birth_year_min: 1990,
+              birth_year_max: 2000,
+              required_verification_ids: [],
+            },
+          ],
+        });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+        const body = await readJson(res);
+        assertEquals(body.success, true);
+      });
+    });
+
+    const ticketUpdates = calls.filter(
+      (c) =>
+        c.url.includes("/rest/v1/ticket_templates") && c.method === "PATCH",
+    );
+    const entryGroupDeletes = calls.filter(
+      (c) =>
+        c.url.includes("/rest/v1/entry_group_templates") &&
+        c.method === "DELETE",
+    );
+
+    assertEquals(ticketUpdates.length, 1);
+    assertEquals(JSON.parse(ticketUpdates[0].body ?? "{}"), {
+      target_entry_group_ids: ["egt_keep"],
+    });
+    assertEquals(entryGroupDeletes.length, 1);
   },
 });
 
 Deno.test({
   name: "update: empty entry_group_templates clears existing groups",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
-    let deleteEntryGroupsCalled = false;
-    let insertEntryGroupsCalled = false;
-
-    const { fetchMock } = createFetchMock([
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
+    const { fetchMock, calls } = createFetchMock([
       authRoute(),
       selectPartyRoute(),
       permRoute(),
       updatePartyRoute(),
-      {
-        matcher: (req: Request) =>
-          req.url.includes("/rest/v1/entry_group_templates") && req.method === "DELETE",
-        handler: () => {
-          deleteEntryGroupsCalled = true;
-          return new Response(null, { status: 200 });
-        },
-      },
-      {
-        matcher: (req: Request) =>
-          req.url.includes("/rest/v1/entry_group_templates") && req.method === "POST",
-        handler: () => {
-          insertEntryGroupsCalled = true;
-          return jsonResponse([]);
-        },
-      },
+      selectEntryGroupTemplatesRoute(["egt_1"]),
+      selectTicketTemplatesRoute([
+        { id: "ticket_1", target_entry_group_ids: ["egt_1"] },
+      ]),
+      updateTicketTemplateRoute(),
+      deleteEntryGroupTemplatesRoute(),
     ]);
 
     await withEnv(ENV, async () => {
@@ -799,8 +1060,18 @@ Deno.test({
       });
     });
 
-    assertEquals(deleteEntryGroupsCalled, true, "DELETE entry_group_templates was called on empty array");
-    assertEquals(insertEntryGroupsCalled, false, "INSERT entry_group_templates was NOT called for empty array");
+    const entryGroupDeletes = calls.filter(
+      (c) =>
+        c.url.includes("/rest/v1/entry_group_templates") &&
+        c.method === "DELETE",
+    );
+    const entryGroupInserts = calls.filter(
+      (c) =>
+        c.url.includes("/rest/v1/entry_group_templates") && c.method === "POST",
+    );
+
+    assertEquals(entryGroupDeletes.length, 1);
+    assertEquals(entryGroupInserts.length, 0);
   },
 });
 
@@ -809,7 +1080,9 @@ Deno.test({
 Deno.test({
   name: "update_status: active → closed",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectPartyRoute(),
@@ -836,7 +1109,9 @@ Deno.test({
 Deno.test({
   name: "update_status: invalid status returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -858,7 +1133,9 @@ Deno.test({
 Deno.test({
   name: "update_status: missing party_id returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
@@ -877,7 +1154,9 @@ Deno.test({
 Deno.test({
   name: "update_status: party not found returns 404",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectPartyNotFoundRoute(),
@@ -900,7 +1179,9 @@ Deno.test({
 Deno.test({
   name: "update_status: other partner's party returns 403",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectPartyRoute("other-partner"),
@@ -926,7 +1207,9 @@ Deno.test({
 Deno.test({
   name: "create: with tag_ids 3 tags — party_tags inserted",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const tagIds = [
       "00000000-0000-0000-0000-000000000001",
       "00000000-0000-0000-0000-000000000002",
@@ -961,7 +1244,9 @@ Deno.test({
 Deno.test({
   name: "create: without tag_ids — party created without tags",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     // party_tags INSERT route 없이도 성공해야 함
     const { fetchMock } = createFetchMock([
       authRoute(),
@@ -988,7 +1273,9 @@ Deno.test({
 Deno.test({
   name: "create: tag_ids with 6 items returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     // tag_ids validation now runs before any DB write — no rpcCreatePartyRoute needed
     const { fetchMock } = createFetchMock([
       authRoute(),
@@ -1020,10 +1307,13 @@ Deno.test({
 });
 
 Deno.test({
-  name: "create: tag_ids with nonexistent IDs returns 400 — no party INSERT attempted",
+  name:
+    "create: tag_ids with nonexistent IDs returns 400 — no party INSERT attempted",
   fn: async () => {
     // Fix #1136: DB existence check on create path — orphaned party prevented
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const requestedIds = [
       "00000000-0000-0000-0000-000000000001",
       "00000000-0000-0000-0000-000000000099", // nonexistent
@@ -1049,7 +1339,9 @@ Deno.test({
         assertEquals(body.error, "One or more tag_ids do not exist");
         // Verify no create_party_with_tags RPC was called — orphan prevention confirmed
         const partyInserts = calls.filter(
-          (c) => c.url.includes("/rest/v1/rpc/create_party_with_tags") && c.method === "POST",
+          (c) =>
+            c.url.includes("/rest/v1/rpc/create_party_with_tags") &&
+            c.method === "POST",
         );
         assertEquals(partyInserts.length, 0);
       });
@@ -1062,7 +1354,9 @@ Deno.test({
 Deno.test({
   name: "update: tag_ids provided — existing tags replaced",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     // INSERT new tags first, then DELETE old ones not in new set (safe order)
     const tagIds = [
       "00000000-0000-0000-0000-000000000010",
@@ -1096,7 +1390,9 @@ Deno.test({
 Deno.test({
   name: "update: tag_ids empty array — all tags removed",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     // Fix #1223: update_party_tags RPC handles empty array (clears all tags) atomically
     const { fetchMock } = createFetchMock([
       authRoute(),
@@ -1124,7 +1420,9 @@ Deno.test({
 Deno.test({
   name: "update: tag_ids undefined — tags not changed",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     // tag_ids 없으면 party_tags route 불필요
     const { fetchMock } = createFetchMock([
       authRoute(),
@@ -1152,7 +1450,9 @@ Deno.test({
 Deno.test({
   name: "update: tag_ids with 6 items returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       selectPartyRoute(),
@@ -1187,7 +1487,9 @@ Deno.test({
 Deno.test({
   name: "create: tag_ids not array returns 400 — no party INSERT attempted",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     // No rpcCreatePartyRoute — if create_party_with_tags RPC were called it would throw "Unhandled fetch"
     const { fetchMock, calls } = createFetchMock([
       authRoute(),
@@ -1207,7 +1509,10 @@ Deno.test({
         const body = await readJson(res);
         assertEquals(body.error, "tag_ids must be an array");
         // Verify no create_party_with_tags RPC was called
-        const partyInserts = calls.filter((c) => c.url.includes("/rest/v1/rpc/create_party_with_tags") && c.method === "POST");
+        const partyInserts = calls.filter((c) =>
+          c.url.includes("/rest/v1/rpc/create_party_with_tags") &&
+          c.method === "POST"
+        );
         assertEquals(partyInserts.length, 0);
       });
     });
@@ -1217,7 +1522,9 @@ Deno.test({
 Deno.test({
   name: "update: tag_ids not array returns 400 — no party PATCH attempted",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     // No updatePartyRoute — if party PATCH were attempted it would throw "Unhandled fetch"
     const { fetchMock, calls } = createFetchMock([
       authRoute(),
@@ -1238,7 +1545,9 @@ Deno.test({
         const body = await readJson(res);
         assertEquals(body.error, "tag_ids must be an array");
         // Verify no party PATCH was attempted
-        const partyPatches = calls.filter((c) => c.url.includes("/rest/v1/parties") && c.method === "PATCH");
+        const partyPatches = calls.filter((c) =>
+          c.url.includes("/rest/v1/parties") && c.method === "PATCH"
+        );
         assertEquals(partyPatches.length, 0);
       });
     });
@@ -1250,7 +1559,9 @@ Deno.test({
 Deno.test({
   name: "create: tag_ids with invalid UUID format returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock, calls } = createFetchMock([
       authRoute(),
       permRoute(),
@@ -1270,7 +1581,9 @@ Deno.test({
         assertEquals(body.error, "tag_ids[0] must be a valid UUID");
         // Verify no create_party_with_tags RPC was called
         const partyInserts = calls.filter(
-          (c) => c.url.includes("/rest/v1/rpc/create_party_with_tags") && c.method === "POST",
+          (c) =>
+            c.url.includes("/rest/v1/rpc/create_party_with_tags") &&
+            c.method === "POST",
         );
         assertEquals(partyInserts.length, 0);
       });
@@ -1281,7 +1594,9 @@ Deno.test({
 Deno.test({
   name: "create: duplicate tag_ids are deduplicated",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const uniqueId = "00000000-0000-0000-0000-000000000001";
     // Fix #1223: create_party_with_tags RPC handles both party + deduped tags atomically
     const { fetchMock } = createFetchMock([
@@ -1311,7 +1626,9 @@ Deno.test({
 Deno.test({
   name: "update: tag_ids with invalid UUID format returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const handler = await captureServeHandler(
+      new URL("./index.ts", import.meta.url),
+    );
     const { fetchMock, calls } = createFetchMock([
       authRoute(),
       selectPartyRoute(),

--- a/supabase/functions/user-event-feed/index.ts
+++ b/supabase/functions/user-event-feed/index.ts
@@ -2,13 +2,16 @@
 
 import { createServiceClient } from "../_shared/supabase_client.ts";
 import { corsResponse, errorResponse, successResponse } from "../_shared/response_utils.ts";
-import { optionalAuth } from "../_shared/auth_utils.ts";
+import { optionalAuth, requireAuth } from "../_shared/auth_utils.ts";
 import { initSentry, withHandler, log } from "../_shared/logger.ts";
 
 const FN = "user-event-feed";
 
 const VALID_SORT_BY = ["recommended", "closing_soon", "nearest_date"] as const;
 type SortBy = typeof VALID_SORT_BY[number];
+
+// Fix #1748: nearby 분당 최대 요청 수
+const NEARBY_RATE_LIMIT_PER_MINUTE = 30;
 
 initSentry();
 
@@ -18,9 +21,6 @@ Deno.serve(withHandler(async (req) => {
   if (req.method !== "POST") {
     return errorResponse("Method not allowed", 405);
   }
-
-  // Optional auth — anonymous users get a basic feed
-  const userId = await optionalAuth(req);
 
   let reqBody: Record<string, unknown>;
   try {
@@ -40,6 +40,29 @@ Deno.serve(withHandler(async (req) => {
     limit?: number;
     cursor?: { sort_key: string; id: string } | null;
   };
+
+  // Extract filters early — nearby presence determines auth requirement
+  const {
+    has_remaining_slots = false,
+    eligible_only = false,
+    nearby = null,
+  } = filters as {
+    has_remaining_slots?: boolean;
+    eligible_only?: boolean;
+    nearby?: Record<string, unknown> | null;
+  };
+
+  // Fix #1748: nearby requires authentication — unauthenticated nearby would
+  // insert user_id=NULL into location_access_log, polluting the §16 legal log.
+  let userId: string | null;
+  if (nearby !== null) {
+    const authResult = await requireAuth(req);
+    if (authResult instanceof Response) return authResult;
+    userId = authResult;
+  } else {
+    // Non-nearby paths allow anonymous access for basic feed
+    userId = await optionalAuth(req);
+  }
 
   // Validate sort_by
   if (!VALID_SORT_BY.includes(sort_by as SortBy)) {
@@ -63,18 +86,51 @@ Deno.serve(withHandler(async (req) => {
     }
   }
 
-  // Extract filters
-  const {
-    has_remaining_slots = false,
-    eligible_only = false,
-    nearby = null,
-  } = filters as {
-    has_remaining_slots?: boolean;
-    eligible_only?: boolean;
-    nearby?: { lat: number; lng: number; radius_km: number } | null;
-  };
+  // Fix #1748: validate nearby shape before any DB access
+  let nearbyTyped: { lat: number; lng: number; radius_km: number } | null = null;
+  if (nearby !== null) {
+    const { lat, lng, radius_km } = nearby as Record<string, unknown>;
+    if (
+      typeof lat !== "number" || !Number.isFinite(lat) || lat < -90 || lat > 90 ||
+      typeof lng !== "number" || !Number.isFinite(lng) || lng < -180 || lng > 180 ||
+      typeof radius_km !== "number" || !Number.isFinite(radius_km) ||
+      radius_km <= 0 || radius_km > 50
+    ) {
+      return errorResponse(
+        "Invalid nearby filter: lat [-90,90], lng [-180,180], radius_km (0, 50]",
+        400,
+      );
+    }
+    nearbyTyped = { lat, lng, radius_km };
+  }
 
   const supabase = createServiceClient();
+
+  // Fix #1748: rate limit — max NEARBY_RATE_LIMIT_PER_MINUTE requests/minute/user.
+  // Fails open: a DB hiccup logs a warning but does not block the request.
+  if (nearbyTyped !== null && userId !== null) {
+    const since = new Date(Date.now() - 60_000).toISOString();
+    const { count, error: countError } = await supabase
+      .from("location_access_log")
+      .select("*", { count: "exact", head: true })
+      .eq("user_id", userId)
+      .eq("purpose", "nearby_search")
+      .gte("accessed_at", since);
+
+    if (countError) {
+      log({
+        function: FN,
+        level: "warn",
+        message: "rate limit check failed — proceeding",
+        metadata: { detail: countError.message },
+      });
+    } else if ((count ?? 0) >= NEARBY_RATE_LIMIT_PER_MINUTE) {
+      return errorResponse(
+        `Rate limit exceeded: max ${NEARBY_RATE_LIMIT_PER_MINUTE} nearby searches per minute`,
+        429,
+      );
+    }
+  }
 
   // Call the RPC function
   const rpcParams: Record<string, unknown> = {
@@ -82,9 +138,9 @@ Deno.serve(withHandler(async (req) => {
     p_sort_by: sort_by,
     p_eligible_only: eligible_only,
     p_has_remaining_slots: has_remaining_slots,
-    p_lat: nearby?.lat ?? null,
-    p_lng: nearby?.lng ?? null,
-    p_radius_km: nearby?.radius_km ?? null,
+    p_lat: nearbyTyped?.lat ?? null,
+    p_lng: nearbyTyped?.lng ?? null,
+    p_radius_km: nearbyTyped?.radius_km ?? null,
     p_limit: limit,
     p_cursor_sort_key: cursor?.sort_key ?? null,
     p_cursor_id: cursor?.id ?? null,
@@ -101,13 +157,13 @@ Deno.serve(withHandler(async (req) => {
       authenticated: userId !== null,
       has_remaining_slots,
       eligible_only,
-      has_nearby: nearby !== null,
+      has_nearby: nearbyTyped !== null,
     },
   });
 
   // 위치정보법 §16: 주변 검색 요청 1건 = 1 row 기록 (GPS 좌표 저장 금지)
   // INSERT 실패 시 요청 거부 — 기록 없이 위치 검색을 허용하면 법적 의무 미이행
-  if (nearby !== null) {
+  if (nearbyTyped !== null) {
     const { error: logError } = await supabase
       .from("location_access_log")
       .insert({ user_id: userId, purpose: "nearby_search" });

--- a/supabase/functions/user-event-feed/user_event_feed_test.ts
+++ b/supabase/functions/user-event-feed/user_event_feed_test.ts
@@ -27,6 +27,12 @@ function rpcFeedResponse(events: unknown[] = [], hasMore = false) {
   };
 }
 
+// Fix #1748: rate limit count HEAD response — PostgREST Content-Range format
+function rateLimitCountResponse(count: number): Response {
+  const contentRange = count === 0 ? "*/0" : `0-${count - 1}/${count}`;
+  return new Response(null, { status: 200, headers: { "Content-Range": contentRange } });
+}
+
 function createFeedFetchMock(rpcResult: unknown, authUser?: { id: string } | null) {
   return createFetchMock([
     // Auth endpoint — for optionalAuth
@@ -195,8 +201,16 @@ Deno.test({
         matcher: (req: Request) => req.url.includes("/auth/v1/user"),
         handler: () => jsonResponse({ id: "user-123" }),
       },
+      // Fix #1748: HEAD = rate limit count check (0 entries → under limit)
       {
-        matcher: (req: Request) => req.url.includes("/rest/v1/location_access_log"),
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/location_access_log") && req.method === "HEAD",
+        handler: () => rateLimitCountResponse(0),
+      },
+      // POST = actual INSERT of access log row
+      {
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/location_access_log") && req.method === "POST",
         handler: () => jsonResponse([], { status: 201 }),
       },
       {
@@ -215,7 +229,10 @@ Deno.test({
         );
         assertEquals(response.status, 200);
 
-        const logCall = calls.find((c) => c.url.includes("/rest/v1/location_access_log"));
+        // Fix #1748: match POST (INSERT), not HEAD (rate limit check)
+        const logCall = calls.find((c) =>
+          c.url.includes("/rest/v1/location_access_log") && c.method === "POST"
+        );
         assertEquals(logCall !== undefined, true, "location_access_log INSERT was called");
 
         const body = JSON.parse(logCall!.body!);
@@ -263,8 +280,16 @@ Deno.test({
         matcher: (req: Request) => req.url.includes("/auth/v1/user"),
         handler: () => jsonResponse({ id: "user-123" }),
       },
+      // Fix #1748: HEAD rate limit check fails → fails-open (warn + proceed)
       {
-        matcher: (req: Request) => req.url.includes("/rest/v1/location_access_log"),
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/location_access_log") && req.method === "HEAD",
+        handler: () => new Response(null, { status: 500 }),
+      },
+      // POST INSERT fails → 500 returned to caller (§16 legal obligation)
+      {
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/location_access_log") && req.method === "POST",
         handler: () => jsonResponse({ message: "DB error" }, { status: 500 }),
       },
     ]);
@@ -278,6 +303,126 @@ Deno.test({
           }),
         );
         assertEquals(response.status, 500, "location_access_log INSERT failure returns 500");
+      });
+    });
+  },
+});
+
+// ── Fix #1748: new security tests ────────────────────────────────────
+
+Deno.test({
+  name: "user-event-feed - anonymous nearby request returns 401",
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: (req: Request) => req.url.includes("/auth/v1/user"),
+        handler: () => jsonResponse({ error: "not authenticated" }, { status: 401 }),
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        // No Authorization header — requireAuth should reject
+        const response = await handler(
+          jsonRequest(BASE_URL, {
+            sort_by: "nearest_date",
+            filters: { nearby: { lat: 37.5, lng: 127.0, radius_km: 5 } },
+          }),
+        );
+        assertEquals(response.status, 401, "unauthenticated nearby returns 401");
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "user-event-feed - nearby with invalid shape returns 400",
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: (req: Request) => req.url.includes("/auth/v1/user"),
+        handler: () => jsonResponse({ id: "user-123" }),
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        // lat out of [-90, 90] range
+        const response = await handler(
+          authenticatedJsonRequest(BASE_URL, {
+            sort_by: "nearest_date",
+            filters: { nearby: { lat: 999, lng: 127.0, radius_km: 5 } },
+          }),
+        );
+        assertEquals(response.status, 400, "invalid lat returns 400");
+        const body = await readJson(response);
+        assertEquals(body.error.includes("Invalid nearby filter"), true);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "user-event-feed - nearby with radius_km > 50 returns 400",
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: (req: Request) => req.url.includes("/auth/v1/user"),
+        handler: () => jsonResponse({ id: "user-123" }),
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const response = await handler(
+          authenticatedJsonRequest(BASE_URL, {
+            sort_by: "nearest_date",
+            filters: { nearby: { lat: 37.5, lng: 127.0, radius_km: 100 } },
+          }),
+        );
+        assertEquals(response.status, 400, "radius_km > 50 returns 400");
+        const body = await readJson(response);
+        assertEquals(body.error.includes("Invalid nearby filter"), true);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "user-event-feed - rate limit exceeded returns 429",
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: (req: Request) => req.url.includes("/auth/v1/user"),
+        handler: () => jsonResponse({ id: "user-123" }),
+      },
+      // Fix #1748: HEAD returns count=30 (at limit) → 429
+      {
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/location_access_log") && req.method === "HEAD",
+        handler: () => rateLimitCountResponse(30),
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const response = await handler(
+          authenticatedJsonRequest(BASE_URL, {
+            sort_by: "nearest_date",
+            filters: { nearby: { lat: 37.5, lng: 127.0, radius_km: 5 } },
+          }),
+        );
+        assertEquals(response.status, 429, "rate limit exceeded returns 429");
+        const body = await readJson(response);
+        assertEquals(body.error.includes("Rate limit exceeded"), true);
       });
     });
   },


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1733

## 문제

Party Detail > 입장 그룹 및 티켓 탭에서 입장 조건 섹션을 탭하면 준비 중 토스트만 표시됨.
EntryGroupEditorScreen은 이미 구현되어 있었으나 진입점이 연결되지 않아 티켓 생성 전체 플로우가 차단됨.

## 변경 내용

- PartyDetailCoordinator: addPartyEntryGroup / updatePartyEntryGroup / removePartyEntryGroup 메서드 추가
- PartyEntryGroupManagementScreen (신설): 입장 그룹 목록, 추가/편집/삭제 UI
- party_rule_management_tab.dart: 토스트 → PartyEntryGroupManagementScreen push 네비게이션
- party_detail_info_tab.dart: 빈 구현 → 네비게이션 연결
- party_repository.dart: updateParty에 entry_group_templates 명시적 포함 (EF 영속화)
- partner-manage-party: update 액션에 entry_group_templates DELETE-then-INSERT 처리 추가

## UX 변경 게이트

PartyEntryGroupManagementScreen은 신설 화면이므로 UX 게이트 대상.

UX 가이드 승인: https://github.com/Mark-Yun/minglit/issues/1733#issuecomment-4301423401 (needs-uiux-claude-1)
UX 문서: docs/features/entry-group-management/ui-ux-design.md (PR #1764)

UX P0/P1 반영 완료:
- P0: Icons.delete_outline + Tooltip + 삭제 confirmation dialog (MinglitAlert.showConfirm isDestructive: true)
- P0: ticket_templates orphan 방지 — 삭제 전 사용자 확인 필수
- P1: AppBar 제목 입장 조건 관리, fullPage empty state + CTA, AddActionCard 리스트 상단 배치

## 테스트

- party_entry_group_coordinator_test.dart: add/update/remove 각 메서드 위젯 테스트
- party_entry_group_entry_point_test.dart: 탭 tap → 화면 push 네비게이션 회귀 방지
- party_repository_test.dart: updateParty에 entryGroups 있을 때 EF body에 entry_group_templates 포함 검증
- partner_manage_party_test.ts: action=update + entry_group_templates DELETE-then-INSERT 동작 검증