### PR TITLE
fix(user-event-feed): require auth for nearby + rate limit + shape validation

### DIFF
--- a/supabase/functions/user-event-feed/index.ts
+++ b/supabase/functions/user-event-feed/index.ts
@@ -2,13 +2,16 @@
 
 import { createServiceClient } from "../_shared/supabase_client.ts";
 import { corsResponse, errorResponse, successResponse } from "../_shared/response_utils.ts";
-import { optionalAuth } from "../_shared/auth_utils.ts";
+import { optionalAuth, requireAuth } from "../_shared/auth_utils.ts";
 import { initSentry, withHandler, log } from "../_shared/logger.ts";
 
 const FN = "user-event-feed";
 
 const VALID_SORT_BY = ["recommended", "closing_soon", "nearest_date"] as const;
 type SortBy = typeof VALID_SORT_BY[number];
+
+// Fix #1748: nearby 분당 최대 요청 수
+const NEARBY_RATE_LIMIT_PER_MINUTE = 30;
 
 initSentry();
 
@@ -18,9 +21,6 @@ Deno.serve(withHandler(async (req) => {
   if (req.method !== "POST") {
     return errorResponse("Method not allowed", 405);
   }
-
-  // Optional auth — anonymous users get a basic feed
-  const userId = await optionalAuth(req);
 
   let reqBody: Record<string, unknown>;
   try {
@@ -40,6 +40,29 @@ Deno.serve(withHandler(async (req) => {
     limit?: number;
     cursor?: { sort_key: string; id: string } | null;
   };
+
+  // Extract filters early — nearby presence determines auth requirement
+  const {
+    has_remaining_slots = false,
+    eligible_only = false,
+    nearby = null,
+  } = filters as {
+    has_remaining_slots?: boolean;
+    eligible_only?: boolean;
+    nearby?: Record<string, unknown> | null;
+  };
+
+  // Fix #1748: nearby requires authentication — unauthenticated nearby would
+  // insert user_id=NULL into location_access_log, polluting the §16 legal log.
+  let userId: string | null;
+  if (nearby !== null) {
+    const authResult = await requireAuth(req);
+    if (authResult instanceof Response) return authResult;
+    userId = authResult;
+  } else {
+    // Non-nearby paths allow anonymous access for basic feed
+    userId = await optionalAuth(req);
+  }
 
   // Validate sort_by
   if (!VALID_SORT_BY.includes(sort_by as SortBy)) {
@@ -63,18 +86,51 @@ Deno.serve(withHandler(async (req) => {
     }
   }
 
-  // Extract filters
-  const {
-    has_remaining_slots = false,
-    eligible_only = false,
-    nearby = null,
-  } = filters as {
-    has_remaining_slots?: boolean;
-    eligible_only?: boolean;
-    nearby?: { lat: number; lng: number; radius_km: number } | null;
-  };
+  // Fix #1748: validate nearby shape before any DB access
+  let nearbyTyped: { lat: number; lng: number; radius_km: number } | null = null;
+  if (nearby !== null) {
+    const { lat, lng, radius_km } = nearby as Record<string, unknown>;
+    if (
+      typeof lat !== "number" || !Number.isFinite(lat) || lat < -90 || lat > 90 ||
+      typeof lng !== "number" || !Number.isFinite(lng) || lng < -180 || lng > 180 ||
+      typeof radius_km !== "number" || !Number.isFinite(radius_km) ||
+      radius_km <= 0 || radius_km > 50
+    ) {
+      return errorResponse(
+        "Invalid nearby filter: lat [-90,90], lng [-180,180], radius_km (0, 50]",
+        400,
+      );
+    }
+    nearbyTyped = { lat, lng, radius_km };
+  }
 
   const supabase = createServiceClient();
+
+  // Fix #1748: rate limit — max NEARBY_RATE_LIMIT_PER_MINUTE requests/minute/user.
+  // Fails open: a DB hiccup logs a warning but does not block the request.
+  if (nearbyTyped !== null && userId !== null) {
+    const since = new Date(Date.now() - 60_000).toISOString();
+    const { count, error: countError } = await supabase
+      .from("location_access_log")
+      .select("*", { count: "exact", head: true })
+      .eq("user_id", userId)
+      .eq("purpose", "nearby_search")
+      .gte("accessed_at", since);
+
+    if (countError) {
+      log({
+        function: FN,
+        level: "warn",
+        message: "rate limit check failed — proceeding",
+        metadata: { detail: countError.message },
+      });
+    } else if ((count ?? 0) >= NEARBY_RATE_LIMIT_PER_MINUTE) {
+      return errorResponse(
+        `Rate limit exceeded: max ${NEARBY_RATE_LIMIT_PER_MINUTE} nearby searches per minute`,
+        429,
+      );
+    }
+  }
 
   // Call the RPC function
   const rpcParams: Record<string, unknown> = {
@@ -82,9 +138,9 @@ Deno.serve(withHandler(async (req) => {
     p_sort_by: sort_by,
     p_eligible_only: eligible_only,
     p_has_remaining_slots: has_remaining_slots,
-    p_lat: nearby?.lat ?? null,
-    p_lng: nearby?.lng ?? null,
-    p_radius_km: nearby?.radius_km ?? null,
+    p_lat: nearbyTyped?.lat ?? null,
+    p_lng: nearbyTyped?.lng ?? null,
+    p_radius_km: nearbyTyped?.radius_km ?? null,
     p_limit: limit,
     p_cursor_sort_key: cursor?.sort_key ?? null,
     p_cursor_id: cursor?.id ?? null,
@@ -101,13 +157,13 @@ Deno.serve(withHandler(async (req) => {
       authenticated: userId !== null,
       has_remaining_slots,
       eligible_only,
-      has_nearby: nearby !== null,
+      has_nearby: nearbyTyped !== null,
     },
   });
 
   // 위치정보법 §16: 주변 검색 요청 1건 = 1 row 기록 (GPS 좌표 저장 금지)
   // INSERT 실패 시 요청 거부 — 기록 없이 위치 검색을 허용하면 법적 의무 미이행
-  if (nearby !== null) {
+  if (nearbyTyped !== null) {
     const { error: logError } = await supabase
       .from("location_access_log")
       .insert({ user_id: userId, purpose: "nearby_search" });

--- a/supabase/functions/user-event-feed/user_event_feed_test.ts
+++ b/supabase/functions/user-event-feed/user_event_feed_test.ts
@@ -27,6 +27,12 @@ function rpcFeedResponse(events: unknown[] = [], hasMore = false) {
   };
 }
 
+// Fix #1748: rate limit count HEAD response — PostgREST Content-Range format
+function rateLimitCountResponse(count: number): Response {
+  const contentRange = count === 0 ? "*/0" : `0-${count - 1}/${count}`;
+  return new Response(null, { status: 200, headers: { "Content-Range": contentRange } });
+}
+
 function createFeedFetchMock(rpcResult: unknown, authUser?: { id: string } | null) {
   return createFetchMock([
     // Auth endpoint — for optionalAuth
@@ -195,8 +201,16 @@ Deno.test({
         matcher: (req: Request) => req.url.includes("/auth/v1/user"),
         handler: () => jsonResponse({ id: "user-123" }),
       },
+      // Fix #1748: HEAD = rate limit count check (0 entries → under limit)
       {
-        matcher: (req: Request) => req.url.includes("/rest/v1/location_access_log"),
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/location_access_log") && req.method === "HEAD",
+        handler: () => rateLimitCountResponse(0),
+      },
+      // POST = actual INSERT of access log row
+      {
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/location_access_log") && req.method === "POST",
         handler: () => jsonResponse([], { status: 201 }),
       },
       {
@@ -215,7 +229,10 @@ Deno.test({
         );
         assertEquals(response.status, 200);
 
-        const logCall = calls.find((c) => c.url.includes("/rest/v1/location_access_log"));
+        // Fix #1748: match POST (INSERT), not HEAD (rate limit check)
+        const logCall = calls.find((c) =>
+          c.url.includes("/rest/v1/location_access_log") && c.method === "POST"
+        );
         assertEquals(logCall !== undefined, true, "location_access_log INSERT was called");
 
         const body = JSON.parse(logCall!.body!);
@@ -263,8 +280,16 @@ Deno.test({
         matcher: (req: Request) => req.url.includes("/auth/v1/user"),
         handler: () => jsonResponse({ id: "user-123" }),
       },
+      // Fix #1748: HEAD rate limit check fails → fails-open (warn + proceed)
       {
-        matcher: (req: Request) => req.url.includes("/rest/v1/location_access_log"),
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/location_access_log") && req.method === "HEAD",
+        handler: () => new Response(null, { status: 500 }),
+      },
+      // POST INSERT fails → 500 returned to caller (§16 legal obligation)
+      {
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/location_access_log") && req.method === "POST",
         handler: () => jsonResponse({ message: "DB error" }, { status: 500 }),
       },
     ]);
@@ -278,6 +303,126 @@ Deno.test({
           }),
         );
         assertEquals(response.status, 500, "location_access_log INSERT failure returns 500");
+      });
+    });
+  },
+});
+
+// ── Fix #1748: new security tests ────────────────────────────────────
+
+Deno.test({
+  name: "user-event-feed - anonymous nearby request returns 401",
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: (req: Request) => req.url.includes("/auth/v1/user"),
+        handler: () => jsonResponse({ error: "not authenticated" }, { status: 401 }),
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        // No Authorization header — requireAuth should reject
+        const response = await handler(
+          jsonRequest(BASE_URL, {
+            sort_by: "nearest_date",
+            filters: { nearby: { lat: 37.5, lng: 127.0, radius_km: 5 } },
+          }),
+        );
+        assertEquals(response.status, 401, "unauthenticated nearby returns 401");
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "user-event-feed - nearby with invalid shape returns 400",
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: (req: Request) => req.url.includes("/auth/v1/user"),
+        handler: () => jsonResponse({ id: "user-123" }),
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        // lat out of [-90, 90] range
+        const response = await handler(
+          authenticatedJsonRequest(BASE_URL, {
+            sort_by: "nearest_date",
+            filters: { nearby: { lat: 999, lng: 127.0, radius_km: 5 } },
+          }),
+        );
+        assertEquals(response.status, 400, "invalid lat returns 400");
+        const body = await readJson(response);
+        assertEquals(body.error.includes("Invalid nearby filter"), true);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "user-event-feed - nearby with radius_km > 50 returns 400",
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: (req: Request) => req.url.includes("/auth/v1/user"),
+        handler: () => jsonResponse({ id: "user-123" }),
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const response = await handler(
+          authenticatedJsonRequest(BASE_URL, {
+            sort_by: "nearest_date",
+            filters: { nearby: { lat: 37.5, lng: 127.0, radius_km: 100 } },
+          }),
+        );
+        assertEquals(response.status, 400, "radius_km > 50 returns 400");
+        const body = await readJson(response);
+        assertEquals(body.error.includes("Invalid nearby filter"), true);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "user-event-feed - rate limit exceeded returns 429",
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: (req: Request) => req.url.includes("/auth/v1/user"),
+        handler: () => jsonResponse({ id: "user-123" }),
+      },
+      // Fix #1748: HEAD returns count=30 (at limit) → 429
+      {
+        matcher: (req: Request) =>
+          req.url.includes("/rest/v1/location_access_log") && req.method === "HEAD",
+        handler: () => rateLimitCountResponse(30),
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const response = await handler(
+          authenticatedJsonRequest(BASE_URL, {
+            sort_by: "nearest_date",
+            filters: { nearby: { lat: 37.5, lng: 127.0, radius_km: 5 } },
+          }),
+        );
+        assertEquals(response.status, 429, "rate limit exceeded returns 429");
+        const body = await readJson(response);
+        assertEquals(body.error.includes("Rate limit exceeded"), true);
       });
     });
   },


### PR DESCRIPTION
## Summary

- **Auth**: `nearby` filter now requires authentication (`requireAuth`), preventing `NULL` `user_id` in `location_access_log` — a 위치정보법 §16 violation
- **Shape validation**: validates `lat ∈ [-90, 90]`, `lng ∈ [-180, 180]`, `radius_km ∈ (0, 50]` before any DB access
- **Rate limiting**: max 30 nearby searches/minute/user via HEAD count on `location_access_log`; fails-open on DB error to avoid blocking legitimate requests on transient failures

## Test plan

- [x] Anonymous + nearby → 401
- [x] Invalid lat/radius → 400 with descriptive error
- [x] Rate limit at 30 → 429
- [x] Rate limit check DB failure → fails-open, request proceeds
- [x] `location_access_log` INSERT failure → 500 (§16 requires successful log)
- [x] HEAD vs POST mocks properly separated in existing nearby tests
- [x] Non-nearby requests remain anonymous-accessible (no regression)

Closes #1748

🤖 Generated with [Claude Code](https://claude.com/claude-code)