### PR TITLE
fix(startup): Statsig 초기화 병렬화로 cold-start splash 시간 단축

### DIFF
--- a/apps/app_user/lib/main.dart
+++ b/apps/app_user/lib/main.dart
@@ -88,22 +88,24 @@ Future<void> appStartup(Ref ref) async {
     );
   }
 
-  try {
-    await Future.wait([
-      initializeDateFormatting('ko_KR'),
-      Supabase.initialize(url: supabaseUrl, anonKey: supabasePublishableKey),
-      Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform),
-    ]);
-  } on Exception catch (e) {
-    Log.e('App startup warning', e);
-  }
-
   const statsigClientKey = String.fromEnvironment('STATSIG_CLIENT_KEY');
   const environment = String.fromEnvironment(
     'ENVIRONMENT',
     defaultValue: 'local',
   );
-  await StatsigAnalytics.initialize(statsigClientKey, tier: environment);
+
+  // Fix #1746: parallelize Statsig with Supabase/Firebase to reduce cold-start
+  // splash duration. Statsig has no dependency on Firebase or Supabase.
+  try {
+    await Future.wait([
+      initializeDateFormatting('ko_KR'),
+      Supabase.initialize(url: supabaseUrl, anonKey: supabasePublishableKey),
+      Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform),
+      StatsigAnalytics.initialize(statsigClientKey, tier: environment),
+    ]);
+  } on Exception catch (e) {
+    Log.e('App startup warning', e);
+  }
   StatsigAnalytics.logEvent(MingLitEvent.appOpened);
 
   // Sync Statsig user context with auth state changes
@@ -140,10 +142,17 @@ class _AppView extends ConsumerWidget {
     // Activate notification initializer to listen for sign-in events
     ref
       ..watch(notificationInitializerProvider)
-      // Remove native splash when startup completes (or fails).
+      // Fix #1746: guard with ref.watch to handle the case where startup
+      // already completed before this listener was registered (listener only
+      // fires on transitions, not on the current state).
       ..listen(appStartupProvider, (prev, next) {
         if (next is! AsyncLoading) FlutterNativeSplash.remove();
       });
+
+    // Eagerly remove splash if startup is already done (covers fast-init path).
+    if (startupState is! AsyncLoading) {
+      FlutterNativeSplash.remove();
+    }
 
     // ignore: use_minglit_async_value_widget - This is the app entry point, MaterialApp is not yet available.
     return MaterialApp.router(


### PR DESCRIPTION
## Summary

- Fix #1746: `StatsigAnalytics.initialize()`를 `Future.wait([...])` 안으로 이동하여 Supabase/Firebase와 병렬 초기화 — 순차 대기 제거로 cold-start splash 시간 단축
- Fix #1746: `_AppView.build()`에 eager splash 제거 가드 추가 — `ref.listen`은 상태 전환 시에만 발화하므로, startup이 build 전에 이미 완료된 경우(fast-init path) splash가 영원히 남는 버그 차단

## Test plan

- [ ] Cold-start 시 native splash 제거 시간이 단축되는지 확인 (Statsig 병렬화)
- [ ] 앱 재시작 시 splash가 정상적으로 제거되는지 확인 (fast-init path)
- [ ] `flutter analyze` 통과 확인

Closes #1746

🤖 Generated with [Claude Code](https://claude.com/claude-code)