### PR TITLE
fix(auth): pg_cron EF 401 — publishable_key → service_role_key 교체 (#1758)

### DIFF
--- a/supabase/migrations/20260423000001_cron_use_service_role_key.sql
+++ b/supabase/migrations/20260423000001_cron_use_service_role_key.sql
@@ -10,7 +10,7 @@
 -- 대상 (publishable_key → service_role_key):
 --   backend-simulation, process-notifications, settlement-reconciliation-daily,
 --   settlement-register-transfers, settlement-payout-sync, settlement-alarm-check,
---   ai-extract-tags
+--   sync_github_stats, ai-extract-tags
 --
 -- 제외 (이미 service_role_key 사용 중):
 --   cleanup-retention (20260421000003), cleanup-blocked-dis / process-pending-deletions (20260330000006)
@@ -229,7 +229,40 @@ SELECT cron.schedule(
 );
 
 -- ============================================================
--- 7. ai-extract-tags  (매분)
+-- 7. sync_github_stats  (매일 20:30 UTC)
+-- ============================================================
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'sync_github_stats') THEN
+    PERFORM cron.unschedule('sync_github_stats');
+  END IF;
+END $$;
+
+SELECT cron.schedule(
+  'sync_github_stats',
+  '30 20 * * *',
+  $$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret FROM vault.decrypted_secrets
+        WHERE name = 'supabase_url' LIMIT 1
+      ) || '/functions/v1/github-stats-sync',
+      headers := (
+        jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (
+            SELECT decrypted_secret FROM vault.decrypted_secrets
+            WHERE name = 'service_role_key' LIMIT 1
+          )
+        )
+      ),
+      body := '{}'::jsonb
+    ) AS request_id;
+  $$
+);
+
+-- ============================================================
+-- 8. ai-extract-tags  (매분)
 -- ============================================================
 DO $$
 BEGIN

--- a/supabase/migrations/20260423000001_cron_use_service_role_key.sql
+++ b/supabase/migrations/20260423000001_cron_use_service_role_key.sql
@@ -1,0 +1,262 @@
+-- Fix #1758: pg_cron → EF 호출 401 — publishable_key → service_role_key 교체
+--
+-- 원인: PR #1494에서 requireServiceRole() 가드 추가 후 anon JWT(publishable_key)가
+--      service_role 가드를 통과하지 못해 모든 system EF 호출이 401.
+--
+-- 전제 조건: Supabase Vault에 'service_role_key' 시크릿이 등록되어 있어야 함.
+--   Dashboard → Database → Vault → New Secret
+--   Name: service_role_key  |  Secret: SUPABASE_SERVICE_ROLE_KEY 값
+--
+-- 대상 (publishable_key → service_role_key):
+--   backend-simulation, process-notifications, settlement-reconciliation-daily,
+--   settlement-register-transfers, settlement-payout-sync, settlement-alarm-check,
+--   ai-extract-tags
+--
+-- 제외 (이미 service_role_key 사용 중):
+--   cleanup-retention (20260421000003), cleanup-blocked-dis / process-pending-deletions (20260330000006)
+--
+-- 제외 (HTTP 미사용, SQL 함수 직접 호출):
+--   notify-match-results, cleanup-expired-match-votes
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM vault.decrypted_secrets WHERE name = 'service_role_key'
+  ) THEN
+    RAISE WARNING
+      'vault secret "service_role_key" not found — cron jobs will be rescheduled '
+      'but will return NULL JWT until the secret is added to Vault. '
+      'Add it via Dashboard → Database → Vault before applying this migration.';
+  END IF;
+END $$;
+
+-- ============================================================
+-- 1. backend-simulation  (매시간)
+-- ============================================================
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'backend-simulation') THEN
+    PERFORM cron.unschedule('backend-simulation');
+  END IF;
+END $$;
+
+SELECT cron.schedule(
+  'backend-simulation',
+  '0 * * * *',
+  $$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret FROM vault.decrypted_secrets
+        WHERE name = 'supabase_url' LIMIT 1
+      ) || '/functions/v1/backend-simulator',
+      headers := (
+        jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (
+            SELECT decrypted_secret FROM vault.decrypted_secrets
+            WHERE name = 'service_role_key' LIMIT 1
+          )
+        )
+      ),
+      body := '{}'::jsonb
+    ) AS request_id;
+  $$
+);
+
+-- ============================================================
+-- 2. process-notifications  (매분)
+-- ============================================================
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'process-notifications') THEN
+    PERFORM cron.unschedule('process-notifications');
+  END IF;
+END $$;
+
+SELECT cron.schedule(
+  'process-notifications',
+  '* * * * *',
+  $$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret FROM vault.decrypted_secrets
+        WHERE name = 'supabase_url' LIMIT 1
+      ) || '/functions/v1/notification-worker',
+      headers := (
+        jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (
+            SELECT decrypted_secret FROM vault.decrypted_secrets
+            WHERE name = 'service_role_key' LIMIT 1
+          )
+        )
+      ),
+      body := '{}'::jsonb
+    ) AS request_id;
+  $$
+);
+
+-- ============================================================
+-- 3. settlement-reconciliation-daily  (매일 13:00 UTC)
+-- ============================================================
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'settlement-reconciliation-daily') THEN
+    PERFORM cron.unschedule('settlement-reconciliation-daily');
+  END IF;
+END $$;
+
+SELECT cron.schedule(
+  'settlement-reconciliation-daily',
+  '0 13 * * *',
+  $$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret FROM vault.decrypted_secrets
+        WHERE name = 'supabase_url' LIMIT 1
+      ) || '/functions/v1/reconciliation-daily',
+      headers := (
+        jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (
+            SELECT decrypted_secret FROM vault.decrypted_secrets
+            WHERE name = 'service_role_key' LIMIT 1
+          )
+        )
+      ),
+      body := '{}'::jsonb
+    ) AS request_id;
+  $$
+);
+
+-- ============================================================
+-- 4. settlement-register-transfers  (매 15분)
+-- ============================================================
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'settlement-register-transfers') THEN
+    PERFORM cron.unschedule('settlement-register-transfers');
+  END IF;
+END $$;
+
+SELECT cron.schedule(
+  'settlement-register-transfers',
+  '*/15 * * * *',
+  $$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret FROM vault.decrypted_secrets
+        WHERE name = 'supabase_url' LIMIT 1
+      ) || '/functions/v1/settlement-register-transfers',
+      headers := (
+        jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (
+            SELECT decrypted_secret FROM vault.decrypted_secrets
+            WHERE name = 'service_role_key' LIMIT 1
+          )
+        )
+      ),
+      body := '{}'::jsonb
+    ) AS request_id;
+  $$
+);
+
+-- ============================================================
+-- 5. settlement-payout-sync  (매일 02:00, 05:00, 08:00 UTC)
+-- ============================================================
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'settlement-payout-sync') THEN
+    PERFORM cron.unschedule('settlement-payout-sync');
+  END IF;
+END $$;
+
+SELECT cron.schedule(
+  'settlement-payout-sync',
+  '0 2,5,8 * * *',
+  $$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret FROM vault.decrypted_secrets
+        WHERE name = 'supabase_url' LIMIT 1
+      ) || '/functions/v1/payout-sync',
+      headers := (
+        jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (
+            SELECT decrypted_secret FROM vault.decrypted_secrets
+            WHERE name = 'service_role_key' LIMIT 1
+          )
+        )
+      ),
+      body := '{}'::jsonb
+    ) AS request_id;
+  $$
+);
+
+-- ============================================================
+-- 6. settlement-alarm-check  (매 30분)
+-- ============================================================
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'settlement-alarm-check') THEN
+    PERFORM cron.unschedule('settlement-alarm-check');
+  END IF;
+END $$;
+
+SELECT cron.schedule(
+  'settlement-alarm-check',
+  '*/30 * * * *',
+  $$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret FROM vault.decrypted_secrets
+        WHERE name = 'supabase_url' LIMIT 1
+      ) || '/functions/v1/metrics-alert',
+      headers := (
+        jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (
+            SELECT decrypted_secret FROM vault.decrypted_secrets
+            WHERE name = 'service_role_key' LIMIT 1
+          )
+        )
+      ),
+      body := '{}'::jsonb
+    ) AS request_id;
+  $$
+);
+
+-- ============================================================
+-- 7. ai-extract-tags  (매분)
+-- ============================================================
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'ai-extract-tags') THEN
+    PERFORM cron.unschedule('ai-extract-tags');
+  END IF;
+END $$;
+
+SELECT cron.schedule(
+  'ai-extract-tags',
+  '* * * * *',
+  $$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret FROM vault.decrypted_secrets
+        WHERE name = 'supabase_url' LIMIT 1
+      ) || '/functions/v1/ai-extract-tags',
+      headers := (
+        jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' || (
+            SELECT decrypted_secret FROM vault.decrypted_secrets
+            WHERE name = 'service_role_key' LIMIT 1
+          )
+        )
+      ),
+      body := '{}'::jsonb
+    ) AS request_id;
+  $$
+);

--- a/supabase/migrations/20260423000001_cron_use_service_role_key.sql
+++ b/supabase/migrations/20260423000001_cron_use_service_role_key.sql
@@ -23,10 +23,10 @@ BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM vault.decrypted_secrets WHERE name = 'service_role_key'
   ) THEN
-    RAISE WARNING
-      'vault secret "service_role_key" not found — cron jobs will be rescheduled '
-      'but will return NULL JWT until the secret is added to Vault. '
-      'Add it via Dashboard → Database → Vault before applying this migration.';
+    RAISE EXCEPTION
+      'vault secret "service_role_key" not found. '
+      'Add it via Dashboard → Database → Vault before applying this migration, '
+      'otherwise cron jobs will be rescheduled with a NULL JWT and continue to return 401.';
   END IF;
 END $$;
 

--- a/supabase/migrations/20260423000001_cron_use_service_role_key.sql
+++ b/supabase/migrations/20260423000001_cron_use_service_role_key.sql
@@ -23,10 +23,13 @@ BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM vault.decrypted_secrets WHERE name = 'service_role_key'
   ) THEN
-    RAISE EXCEPTION
-      'vault secret "service_role_key" not found. '
-      'Add it via Dashboard → Database → Vault before applying this migration, '
-      'otherwise cron jobs will be rescheduled with a NULL JWT and continue to return 401.';
+    -- Intentional WARNING (not EXCEPTION): CI/dev vaults don't have this secret.
+    -- In production, add service_role_key to Vault BEFORE applying this migration.
+    -- Pattern consistent with 20260330000006_account_deletion_crons.sql.
+    RAISE WARNING
+      'vault secret "service_role_key" not found — cron jobs will be rescheduled '
+      'but will return NULL JWT until the secret is added to Vault. '
+      'Add it via Dashboard → Database → Vault before applying this migration.';
   END IF;
 END $$;
 

--- a/supabase/tests/database/70_ai_extract_tags_migration_test.sql
+++ b/supabase/tests/database/70_ai_extract_tags_migration_test.sql
@@ -92,10 +92,11 @@ SELECT ok(
   'ai-extract-tags cron uses vault supabase_url (not hardcoded URL)'
 );
 
--- cron SQL이 publishable_key Vault 시크릿을 참조하는지 확인
+-- Fix #1758: cron SQL이 service_role_key Vault 시크릿을 참조하는지 확인
+-- (이전: publishable_key — requireServiceRole() 가드 추가 후 401 발생, 교체됨)
 SELECT ok(
-  (SELECT command FROM cron.job WHERE jobname = 'ai-extract-tags') LIKE '%publishable_key%',
-  'ai-extract-tags cron uses vault publishable_key (not service_role_key)'
+  (SELECT command FROM cron.job WHERE jobname = 'ai-extract-tags') LIKE '%service_role_key%',
+  'ai-extract-tags cron uses vault service_role_key (not publishable_key)'
 );
 
 RESET ROLE;

--- a/supabase/tests/database/94_cron_service_role_key_test.sql
+++ b/supabase/tests/database/94_cron_service_role_key_test.sql
@@ -2,7 +2,7 @@
 -- publishable_key(anon JWT) 사용 시 requireServiceRole() 가드에서 401 반환
 
 BEGIN;
-SELECT plan(7);
+SELECT plan(8);
 
 -- Helper: 특정 cron job의 Authorization 헤더가 service_role_key를 참조하는지 확인
 CREATE OR REPLACE FUNCTION _check_cron_uses_service_role(p_jobname text)
@@ -59,6 +59,12 @@ SELECT ok(
 SELECT ok(
   _check_cron_uses_service_role('ai-extract-tags'),
   'ai-extract-tags cron uses service_role_key (not publishable_key)'
+);
+
+-- 8. sync_github_stats: service_role_key 사용
+SELECT ok(
+  _check_cron_uses_service_role('sync_github_stats'),
+  'sync_github_stats cron uses service_role_key (not publishable_key)'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/database/94_cron_service_role_key_test.sql
+++ b/supabase/tests/database/94_cron_service_role_key_test.sql
@@ -1,0 +1,65 @@
+-- Fix #1758: pg_cron 모든 HTTP EF 호출이 service_role_key를 사용하는지 검증
+-- publishable_key(anon JWT) 사용 시 requireServiceRole() 가드에서 401 반환
+
+BEGIN;
+SELECT plan(7);
+
+-- Helper: 특정 cron job의 Authorization 헤더가 service_role_key를 참조하는지 확인
+CREATE OR REPLACE FUNCTION _check_cron_uses_service_role(p_jobname text)
+RETURNS boolean
+LANGUAGE plpgsql AS $$
+DECLARE
+  v_command text;
+BEGIN
+  SELECT command INTO v_command FROM cron.job WHERE jobname = p_jobname;
+  IF v_command IS NULL THEN
+    RETURN false;
+  END IF;
+  RETURN v_command LIKE '%service_role_key%' AND v_command NOT LIKE '%publishable_key%';
+END;
+$$;
+
+-- 1. backend-simulation: service_role_key 사용
+SELECT ok(
+  _check_cron_uses_service_role('backend-simulation'),
+  'backend-simulation cron uses service_role_key (not publishable_key)'
+);
+
+-- 2. process-notifications: service_role_key 사용
+SELECT ok(
+  _check_cron_uses_service_role('process-notifications'),
+  'process-notifications cron uses service_role_key (not publishable_key)'
+);
+
+-- 3. settlement-reconciliation-daily: service_role_key 사용
+SELECT ok(
+  _check_cron_uses_service_role('settlement-reconciliation-daily'),
+  'settlement-reconciliation-daily cron uses service_role_key (not publishable_key)'
+);
+
+-- 4. settlement-register-transfers: service_role_key 사용
+SELECT ok(
+  _check_cron_uses_service_role('settlement-register-transfers'),
+  'settlement-register-transfers cron uses service_role_key (not publishable_key)'
+);
+
+-- 5. settlement-payout-sync: service_role_key 사용
+SELECT ok(
+  _check_cron_uses_service_role('settlement-payout-sync'),
+  'settlement-payout-sync cron uses service_role_key (not publishable_key)'
+);
+
+-- 6. settlement-alarm-check: service_role_key 사용
+SELECT ok(
+  _check_cron_uses_service_role('settlement-alarm-check'),
+  'settlement-alarm-check cron uses service_role_key (not publishable_key)'
+);
+
+-- 7. ai-extract-tags: service_role_key 사용
+SELECT ok(
+  _check_cron_uses_service_role('ai-extract-tags'),
+  'ai-extract-tags cron uses service_role_key (not publishable_key)'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1758

## 요약

PR #1494에서 `requireServiceRole()` 가드 추가 후, pg_cron이 anon JWT(publishable_key)로 EF를 호출해 모든 system cron이 401 실패.

7개 cron job을 `service_role_key`로 재등록하는 migration 추가.

## 변경 내용

- `supabase/migrations/20260423000001_cron_use_service_role_key.sql`: 7개 cron job unschedule + service_role_key로 재등록
- `supabase/tests/database/94_cron_service_role_key_test.sql`: 7개 cron job이 service_role_key 사용 검증

## 전제 조건 (관리자 수동)

**배포 전 반드시 필요**: Supabase Dashboard → Database → Vault → New Secret
- Name: `service_role_key`
- Secret: `SUPABASE_SERVICE_ROLE_KEY` 값

## 대상 cron job

| Job | 스케줄 | EF |
|-----|--------|-----|
| backend-simulation | 매시간 | backend-simulator |
| process-notifications | 매분 | notification-worker |
| settlement-reconciliation-daily | 매일 13:00 UTC | reconciliation-daily |
| settlement-register-transfers | 매 15분 | settlement-register-transfers |
| settlement-payout-sync | 매일 02/05/08 UTC | payout-sync |
| settlement-alarm-check | 매 30분 | metrics-alert |
| ai-extract-tags | 매분 | ai-extract-tags |

## 제외

- cleanup-retention, cleanup-blocked-dis, process-pending-deletions: 이미 service_role_key 사용
- notify-match-results, cleanup-expired-match-votes: HTTP 미사용 (SQL 함수 직접 호출)