### PR TITLE
chore(retention): net._http_response retention 연장 — dev 1→7일, main 7→14일 (#1759)

### DIFF
--- a/supabase/migrations/20260423000002_extend_net_http_response_retention.sql
+++ b/supabase/migrations/20260423000002_extend_net_http_response_retention.sql
@@ -5,3 +5,14 @@
 UPDATE admin.retention_policies
 SET retention_days = 14
 WHERE id = 'net_http_response';
+
+-- Fix #1759: migration-time assertion — seed.sql은 이 값을 7로 덮어쓰므로
+-- pgTAP에서 14를 검증할 수 없음. migration 자체에서 즉시 단언.
+DO $$
+BEGIN
+  ASSERT (
+    SELECT retention_days FROM admin.retention_policies WHERE id = 'net_http_response'
+  ) = 14,
+    'net_http_response retention_days must be 14 after Fix #1759 migration';
+END;
+$$;

--- a/supabase/migrations/20260423000002_extend_net_http_response_retention.sql
+++ b/supabase/migrations/20260423000002_extend_net_http_response_retention.sql
@@ -1,0 +1,7 @@
+-- Fix #1759: net._http_response retention 연장
+-- dev: 1일 → 7일, main: 7일 → 14일
+-- 이유: #1758 디버깅 시 24시간 이내 cleanup으로 로그 소실 → drift 재발 시 원인 추적 난항
+
+UPDATE admin.retention_policies
+SET retention_days = 14
+WHERE id = 'net_http_response';

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -47,7 +47,7 @@ values
 UPDATE admin.retention_policies
 SET retention_days = CASE id
   WHEN 'cron_job_run_details'          THEN 7
-  WHEN 'net_http_response'             THEN 1
+  WHEN 'net_http_response'             THEN 7
   WHEN 'pgmq_global_events_archive'    THEN 3
   WHEN 'pgmq_vectors_archive'          THEN 3
   WHEN 'pgmq_notifications_archive'    THEN 3

--- a/supabase/tests/database/94_net_http_response_retention_test.sql
+++ b/supabase/tests/database/94_net_http_response_retention_test.sql
@@ -1,0 +1,38 @@
+-- Fix #1759: net._http_response retention 연장 — 값 고정 검증
+-- main: 7일 → 14일, dev(seed): 1일 → 7일
+-- 이 테스트는 dev 환경(seed.sql 적용 후)에서 실행 → 7일 값 검증
+-- drift 재발 시 CI에서 즉시 감지
+
+BEGIN;
+SELECT plan(4);
+
+-- 1. net_http_response 정책 존재 확인
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM admin.retention_policies
+    WHERE id = 'net_http_response'
+  ),
+  'net_http_response retention policy exists'
+);
+
+-- 2. 정책이 활성화 상태
+SELECT ok(
+  (SELECT enabled FROM admin.retention_policies WHERE id = 'net_http_response') = true,
+  'net_http_response retention policy is enabled'
+);
+
+-- 3. dev 환경(seed override): retention_days = 7
+-- seed.sql이 적용된 dev/test 환경에서 7일로 설정되는지 검증
+SELECT ok(
+  (SELECT retention_days FROM admin.retention_policies WHERE id = 'net_http_response') = 7,
+  'net_http_response retention_days = 7 in dev environment (seed override)'
+);
+
+-- 4. retention_days >= 7 (최솟값 보장 — main에서는 14, dev에서는 7)
+SELECT ok(
+  (SELECT retention_days FROM admin.retention_policies WHERE id = 'net_http_response') >= 7,
+  'net_http_response retention_days >= 7 (min window for debugging)'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1759

## 요약

#1758 디버깅 시 net._http_response의 24시간 retention으로 EF 응답 로그가 소실되어 원인 추적이 불가했던 문제 해소.

## 변경 내용

- migration: `net_http_response` retention_days 14일로 설정 (main 기본값)
- seed.sql: dev override 1 → 7일로 업데이트

## 결과

| 환경 | 변경 전 | 변경 후 |
|------|---------|---------|
| dev | 1일 | 7일 |
| main | 7일 | 14일 |