### PR TITLE
feat(infra): pg_cron ↔ EF auth drift 방지 — ef_auth_manifest + pgTAP (#1760)

### DIFF
--- a/supabase/migrations/20260423000003_ef_auth_manifest.sql
+++ b/supabase/migrations/20260423000003_ef_auth_manifest.sql
@@ -1,24 +1,27 @@
 -- Fix #1760: pg_cron ↔ EF auth drift 방지 — ef_auth_manifest 선언 테이블
 --
+-- 범위: pg_cron에서 net.http_post로 호출하는 EF만 등록한다.
+--   (사용자 요청 EF는 포함하지 않음 — auth 계층이 달라 일관성 보장 범위 밖)
+--
 -- 목적: PR #1494의 requireServiceRole() 추가 후 pg_cron Authorization이
 --       업데이트되지 않아 6일간 무음 401 발생. 이를 재발 방지하기 위해
---       EF별 필요 인증 레벨을 선언하고 pgTAP으로 cron.job과의 일관성을 검증한다.
+--       cron 대상 EF의 필요 인증 레벨을 선언하고 pgTAP으로 일관성을 검증한다.
 --
--- 유지보수 규칙: EF에 requireServiceRole() 추가/제거 시
---   같은 PR에서 이 테이블의 required_auth도 반드시 업데이트할 것.
+-- 유지보수 규칙: pg_cron에서 새 EF를 HTTP 호출할 때
+--   같은 PR에서 이 테이블에 항목을 추가할 것.
 
 CREATE TABLE IF NOT EXISTS public.ef_auth_manifest (
   ef_name     text PRIMARY KEY,
   required_auth text NOT NULL CHECK (required_auth IN (
-    'public', 'authenticated', 'service_role'
+    'service_role'
   )),
   description text,
   updated_at  timestamptz NOT NULL DEFAULT now()
 );
 
 COMMENT ON TABLE public.ef_auth_manifest IS
-  'Edge Function별 필요 인증 레벨 선언. '
-  'EF에 requireServiceRole() 추가/제거 시 required_auth도 같은 PR에서 업데이트 필수. '
+  'pg_cron에서 net.http_post로 호출하는 EF의 인증 레벨 선언 (cron-targeted EF 전용). '
+  'pg_cron에서 새 EF를 HTTP 호출할 때 required_auth도 같은 PR에서 추가 필수. '
   'pgTAP 95_ef_auth_manifest_cron_consistency_test.sql이 cron.job과의 일관성을 검증한다.';
 
 ALTER TABLE public.ef_auth_manifest ENABLE ROW LEVEL SECURITY;
@@ -26,56 +29,23 @@ CREATE POLICY ef_auth_manifest_select ON public.ef_auth_manifest
   FOR SELECT USING (true);
 
 -- ──────────────────────────────────────────────────────────
--- 초기 seed: 알려진 모든 EF의 인증 레벨 선언
--- (PR #1494 기준 + #1758 수정 반영)
+-- 초기 seed: pg_cron에서 HTTP 호출하는 EF 목록
+-- (20260423000001_cron_use_service_role_key.sql 기준 + 기존 cron EF 포함)
 -- ──────────────────────────────────────────────────────────
 
 INSERT INTO public.ef_auth_manifest (ef_name, required_auth, description) VALUES
-  -- service_role: pg_cron에서 호출 / requireServiceRole() 가드
-  ('ai-embed',                  'service_role', 'pgvector 임베딩 생성 — pg_cron 호출'),
-  ('ai-extract-tags',           'service_role', 'AI 태그 추출 — pg_cron 매분 호출'),
-  ('backend-simulator',         'service_role', '백엔드 시뮬레이션 — pg_cron 매시간 호출'),
-  ('cleanup-blocked-dis',       'service_role', '차단/신고 삭제 정리 — pg_cron 호출'),
-  ('cleanup-retention',         'service_role', 'retention 정책 실행 — pg_cron 호출'),
-  ('event-matching',            'service_role', '이벤트 매칭 처리 — pg_cron 호출'),
-  ('github-stats-sync',         'service_role', 'GitHub 통계 동기화 — pg_cron 매일 호출'),
-  ('metrics-alert',             'service_role', '메트릭 알람 — pg_cron 매 30분 호출'),
-  ('notification-worker',       'service_role', '알림 워커 — pg_cron 매분 호출'),
-  ('payout-sync',               'service_role', '정산 지급 동기화 — pg_cron 호출'),
-  ('process-pending-deletions', 'service_role', '지연 삭제 처리 — pg_cron 호출'),
-  ('reconciliation-daily',      'service_role', '정산 대사 — pg_cron 매일 호출'),
-  ('recurrence-cron',           'service_role', '반복 이벤트 생성 — pg_cron 호출'),
-  ('settlement-register-transfers', 'service_role', '정산 이전 등록 — pg_cron 호출'),
-  ('settlement-transfer',       'service_role', '정산 이전 실행 — requireServiceRole'),
-
-  -- authenticated: 유저/파트너 인증 필요
-  ('apply-event',               'authenticated', '이벤트 신청'),
-  ('event-checkin',             'authenticated', '이벤트 체크인'),
-  ('identity-verify',           'authenticated', '신원 인증'),
-  ('partner-approve-application', 'authenticated', '파트너 신청 승인'),
-  ('partner-manage-event',      'authenticated', '파트너 이벤트 관리'),
-  ('partner-manage-match',      'authenticated', '파트너 매칭 관리'),
-  ('partner-manage-member',     'authenticated', '파트너 멤버 관리'),
-  ('partner-manage-party',      'authenticated', '파트너 파티 관리'),
-  ('partner-manage-settlement', 'authenticated', '파트너 정산 관리'),
-  ('partner-manage-verification', 'authenticated', '파트너 인증 관리'),
-  ('partner-register',          'authenticated', '파트너 등록'),
-  ('partner-reject-application', 'authenticated', '파트너 신청 거부'),
-  ('partner-review-submission', 'authenticated', '파트너 제출 리뷰'),
-  ('user-cancel-deletion',      'authenticated', '회원 탈퇴 취소'),
-  ('user-cancel-order',         'authenticated', '주문 취소'),
-  ('user-create-order',         'authenticated', '주문 생성'),
-  ('user-delete-account',       'authenticated', '회원 탈퇴'),
-  ('user-event-feed',           'authenticated', '이벤트 피드'),
-  ('user-manage-notification',  'authenticated', '알림 설정'),
-  ('user-manage-settings',      'authenticated', '사용자 설정'),
-  ('user-manage-social',        'authenticated', '소셜 관리'),
-  ('user-submit-verification',  'authenticated', '인증 제출'),
-  ('user-update-verification',  'authenticated', '인증 업데이트'),
-  ('recurrence-rules',          'authenticated', '반복 규칙 조회'),
-
-  -- public: 인증 불필요
-  ('health',                    'public',        'Health check')
+  ('ai-extract-tags',               'service_role', 'AI 태그 추출 — pg_cron 매분 호출'),
+  ('backend-simulator',             'service_role', '백엔드 시뮬레이션 — pg_cron 매시간 호출'),
+  ('cleanup-blocked-dis',           'service_role', '차단/신고 삭제 정리 — pg_cron 호출'),
+  ('cleanup-retention',             'service_role', 'retention 정책 실행 — pg_cron 호출'),
+  ('github-stats-sync',             'service_role', 'GitHub 통계 동기화 — pg_cron 매일 호출'),
+  ('metrics-alert',                 'service_role', '메트릭 알람 — pg_cron 매 30분 호출'),
+  ('notification-worker',           'service_role', '알림 워커 — pg_cron 매분 호출'),
+  ('payout-sync',                   'service_role', '정산 지급 동기화 — pg_cron 호출'),
+  ('process-pending-deletions',     'service_role', '지연 삭제 처리 — pg_cron 호출'),
+  ('reconciliation-daily',          'service_role', '정산 대사 — pg_cron 매일 호출'),
+  ('recurrence-cron',               'service_role', '반복 이벤트 생성 — pg_cron 호출'),
+  ('settlement-register-transfers', 'service_role', '정산 이전 등록 — pg_cron 호출')
 
 ON CONFLICT (ef_name) DO UPDATE SET
   required_auth = EXCLUDED.required_auth,

--- a/supabase/migrations/20260423000003_ef_auth_manifest.sql
+++ b/supabase/migrations/20260423000003_ef_auth_manifest.sql
@@ -1,0 +1,83 @@
+-- Fix #1760: pg_cron ↔ EF auth drift 방지 — ef_auth_manifest 선언 테이블
+--
+-- 목적: PR #1494의 requireServiceRole() 추가 후 pg_cron Authorization이
+--       업데이트되지 않아 6일간 무음 401 발생. 이를 재발 방지하기 위해
+--       EF별 필요 인증 레벨을 선언하고 pgTAP으로 cron.job과의 일관성을 검증한다.
+--
+-- 유지보수 규칙: EF에 requireServiceRole() 추가/제거 시
+--   같은 PR에서 이 테이블의 required_auth도 반드시 업데이트할 것.
+
+CREATE TABLE IF NOT EXISTS public.ef_auth_manifest (
+  ef_name     text PRIMARY KEY,
+  required_auth text NOT NULL CHECK (required_auth IN (
+    'public', 'authenticated', 'service_role'
+  )),
+  description text,
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.ef_auth_manifest IS
+  'Edge Function별 필요 인증 레벨 선언. '
+  'EF에 requireServiceRole() 추가/제거 시 required_auth도 같은 PR에서 업데이트 필수. '
+  'pgTAP 95_ef_auth_manifest_cron_consistency_test.sql이 cron.job과의 일관성을 검증한다.';
+
+ALTER TABLE public.ef_auth_manifest ENABLE ROW LEVEL SECURITY;
+CREATE POLICY ef_auth_manifest_select ON public.ef_auth_manifest
+  FOR SELECT USING (true);
+
+-- ──────────────────────────────────────────────────────────
+-- 초기 seed: 알려진 모든 EF의 인증 레벨 선언
+-- (PR #1494 기준 + #1758 수정 반영)
+-- ──────────────────────────────────────────────────────────
+
+INSERT INTO public.ef_auth_manifest (ef_name, required_auth, description) VALUES
+  -- service_role: pg_cron에서 호출 / requireServiceRole() 가드
+  ('ai-embed',                  'service_role', 'pgvector 임베딩 생성 — pg_cron 호출'),
+  ('ai-extract-tags',           'service_role', 'AI 태그 추출 — pg_cron 매분 호출'),
+  ('backend-simulator',         'service_role', '백엔드 시뮬레이션 — pg_cron 매시간 호출'),
+  ('cleanup-blocked-dis',       'service_role', '차단/신고 삭제 정리 — pg_cron 호출'),
+  ('cleanup-retention',         'service_role', 'retention 정책 실행 — pg_cron 호출'),
+  ('event-matching',            'service_role', '이벤트 매칭 처리 — pg_cron 호출'),
+  ('github-stats-sync',         'service_role', 'GitHub 통계 동기화 — pg_cron 매일 호출'),
+  ('metrics-alert',             'service_role', '메트릭 알람 — pg_cron 매 30분 호출'),
+  ('notification-worker',       'service_role', '알림 워커 — pg_cron 매분 호출'),
+  ('payout-sync',               'service_role', '정산 지급 동기화 — pg_cron 호출'),
+  ('process-pending-deletions', 'service_role', '지연 삭제 처리 — pg_cron 호출'),
+  ('reconciliation-daily',      'service_role', '정산 대사 — pg_cron 매일 호출'),
+  ('recurrence-cron',           'service_role', '반복 이벤트 생성 — pg_cron 호출'),
+  ('settlement-register-transfers', 'service_role', '정산 이전 등록 — pg_cron 호출'),
+  ('settlement-transfer',       'service_role', '정산 이전 실행 — requireServiceRole'),
+
+  -- authenticated: 유저/파트너 인증 필요
+  ('apply-event',               'authenticated', '이벤트 신청'),
+  ('event-checkin',             'authenticated', '이벤트 체크인'),
+  ('identity-verify',           'authenticated', '신원 인증'),
+  ('partner-approve-application', 'authenticated', '파트너 신청 승인'),
+  ('partner-manage-event',      'authenticated', '파트너 이벤트 관리'),
+  ('partner-manage-match',      'authenticated', '파트너 매칭 관리'),
+  ('partner-manage-member',     'authenticated', '파트너 멤버 관리'),
+  ('partner-manage-party',      'authenticated', '파트너 파티 관리'),
+  ('partner-manage-settlement', 'authenticated', '파트너 정산 관리'),
+  ('partner-manage-verification', 'authenticated', '파트너 인증 관리'),
+  ('partner-register',          'authenticated', '파트너 등록'),
+  ('partner-reject-application', 'authenticated', '파트너 신청 거부'),
+  ('partner-review-submission', 'authenticated', '파트너 제출 리뷰'),
+  ('user-cancel-deletion',      'authenticated', '회원 탈퇴 취소'),
+  ('user-cancel-order',         'authenticated', '주문 취소'),
+  ('user-create-order',         'authenticated', '주문 생성'),
+  ('user-delete-account',       'authenticated', '회원 탈퇴'),
+  ('user-event-feed',           'authenticated', '이벤트 피드'),
+  ('user-manage-notification',  'authenticated', '알림 설정'),
+  ('user-manage-settings',      'authenticated', '사용자 설정'),
+  ('user-manage-social',        'authenticated', '소셜 관리'),
+  ('user-submit-verification',  'authenticated', '인증 제출'),
+  ('user-update-verification',  'authenticated', '인증 업데이트'),
+  ('recurrence-rules',          'authenticated', '반복 규칙 조회'),
+
+  -- public: 인증 불필요
+  ('health',                    'public',        'Health check')
+
+ON CONFLICT (ef_name) DO UPDATE SET
+  required_auth = EXCLUDED.required_auth,
+  description   = EXCLUDED.description,
+  updated_at    = now();

--- a/supabase/tests/database/95_ef_auth_manifest_cron_consistency_test.sql
+++ b/supabase/tests/database/95_ef_auth_manifest_cron_consistency_test.sql
@@ -1,0 +1,62 @@
+-- Fix #1760: pg_cron ↔ ef_auth_manifest 일관성 검증
+-- 목적: cron.job의 Authorization vault key가 manifest의 required_auth와 일치하는지 검증.
+--       service_role EF는 service_role_key, 그 외 EF는 pg_cron에서 호출하면 안 됨.
+--
+-- 재발 방지: PR #1494에서 requireServiceRole() 추가 후 pg_cron Authorization이 누락되어
+--            6일간 401 무음 실패. 이 테스트가 PR 차단으로 즉시 감지한다.
+
+BEGIN;
+SELECT plan(3);
+
+-- ── 헬퍼: cron.job에서 EF 이름과 Authorization vault key 추출
+CREATE TEMP TABLE _cron_ef_calls AS
+SELECT
+  jobname,
+  (regexp_matches(command, E'/functions/v1/([a-z][a-z0-9-]+)'))[1]      AS ef_name,
+  (regexp_matches(command, E'WHERE name\\s*=\\s*''([a-z_]+)''\\s+LIMIT', 'g'))[1] AS vault_key
+FROM cron.job
+WHERE command LIKE '%net.http_post%'
+  AND command LIKE '%/functions/v1/%';
+
+-- ── 1. service_role EF는 반드시 service_role_key vault secret 사용
+--    (publishable_key 또는 다른 key → 401 발생)
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM _cron_ef_calls c
+    JOIN public.ef_auth_manifest m ON m.ef_name = c.ef_name
+    WHERE m.required_auth = 'service_role'
+      AND (c.vault_key IS NULL OR c.vault_key != 'service_role_key')
+  ),
+  0,
+  'All service_role EFs in pg_cron must use service_role_key vault secret'
+);
+
+-- ── 2. authenticated/public EF는 pg_cron에서 호출하면 안 됨
+--    (pg_cron은 사용자 세션이 없으므로 JWT에 user 정보가 없음)
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM _cron_ef_calls c
+    JOIN public.ef_auth_manifest m ON m.ef_name = c.ef_name
+    WHERE m.required_auth IN ('authenticated', 'public')
+  ),
+  0,
+  'authenticated/public EFs must not be called from pg_cron'
+);
+
+-- ── 3. pg_cron에서 호출하는 EF는 manifest에 등록되어 있어야 함
+--    (신규 EF 추가 시 manifest 업데이트 강제)
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM _cron_ef_calls c
+    LEFT JOIN public.ef_auth_manifest m ON m.ef_name = c.ef_name
+    WHERE m.ef_name IS NULL
+  ),
+  0,
+  'All EFs called by pg_cron must be declared in ef_auth_manifest'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/95_ef_auth_manifest_cron_consistency_test.sql
+++ b/supabase/tests/database/95_ef_auth_manifest_cron_consistency_test.sql
@@ -9,11 +9,14 @@ BEGIN;
 SELECT plan(3);
 
 -- ── 헬퍼: cron.job에서 EF 이름과 Authorization vault key 추출
+-- regexp_match (scalar, Pg10+) 사용 — regexp_matches with 'g' is set-returning and
+-- produces extra NULL-ef_name rows when combined with another SRF in SELECT.
+-- vault_key는 Authorization 헤더에 사용되는 두 번째 vault lookup을 특정.
 CREATE TEMP TABLE _cron_ef_calls AS
 SELECT
   jobname,
-  (regexp_matches(command, E'/functions/v1/([a-z][a-z0-9-]+)'))[1]      AS ef_name,
-  (regexp_matches(command, E'WHERE name\\s*=\\s*''([a-z_]+)''\\s+LIMIT', 'g'))[1] AS vault_key
+  (regexp_match(command, '/functions/v1/([a-z][a-z0-9-]+)'))[1]      AS ef_name,
+  (regexp_match(command, 'Authorization.+WHERE name\s*=\s*''([a-z_]+)''\s+LIMIT', 's'))[1] AS vault_key
 FROM cron.job
 WHERE command LIKE '%net.http_post%'
   AND command LIKE '%/functions/v1/%';

--- a/supabase/tests/database/95_ef_auth_manifest_cron_consistency_test.sql
+++ b/supabase/tests/database/95_ef_auth_manifest_cron_consistency_test.sql
@@ -1,12 +1,13 @@
 -- Fix #1760: pg_cron ↔ ef_auth_manifest 일관성 검증
--- 목적: cron.job의 Authorization vault key가 manifest의 required_auth와 일치하는지 검증.
---       service_role EF는 service_role_key, 그 외 EF는 pg_cron에서 호출하면 안 됨.
+--
+-- 범위: pg_cron에서 net.http_post로 호출하는 EF만 검증 (cron-targeted EF 전용).
+--   ef_auth_manifest는 cron 대상 EF만 포함하므로 사용자 요청 EF는 검증 범위 밖.
 --
 -- 재발 방지: PR #1494에서 requireServiceRole() 추가 후 pg_cron Authorization이 누락되어
 --            6일간 401 무음 실패. 이 테스트가 PR 차단으로 즉시 감지한다.
 
 BEGIN;
-SELECT plan(3);
+SELECT plan(2);
 
 -- ── 헬퍼: cron.job에서 EF 이름과 Authorization vault key 추출
 -- regexp_match (scalar, Pg10+) 사용 — regexp_matches with 'g' is set-returning and
@@ -21,35 +22,21 @@ FROM cron.job
 WHERE command LIKE '%net.http_post%'
   AND command LIKE '%/functions/v1/%';
 
--- ── 1. service_role EF는 반드시 service_role_key vault secret 사용
+-- ── 1. manifest에 등록된 EF는 반드시 service_role_key vault secret 사용
 --    (publishable_key 또는 다른 key → 401 발생)
 SELECT is(
   (
     SELECT count(*)::int
     FROM _cron_ef_calls c
     JOIN public.ef_auth_manifest m ON m.ef_name = c.ef_name
-    WHERE m.required_auth = 'service_role'
-      AND (c.vault_key IS NULL OR c.vault_key != 'service_role_key')
+    WHERE (c.vault_key IS NULL OR c.vault_key != 'service_role_key')
   ),
   0,
-  'All service_role EFs in pg_cron must use service_role_key vault secret'
+  'All pg_cron EFs in manifest must use service_role_key vault secret'
 );
 
--- ── 2. authenticated/public EF는 pg_cron에서 호출하면 안 됨
---    (pg_cron은 사용자 세션이 없으므로 JWT에 user 정보가 없음)
-SELECT is(
-  (
-    SELECT count(*)::int
-    FROM _cron_ef_calls c
-    JOIN public.ef_auth_manifest m ON m.ef_name = c.ef_name
-    WHERE m.required_auth IN ('authenticated', 'public')
-  ),
-  0,
-  'authenticated/public EFs must not be called from pg_cron'
-);
-
--- ── 3. pg_cron에서 호출하는 EF는 manifest에 등록되어 있어야 함
---    (신규 EF 추가 시 manifest 업데이트 강제)
+-- ── 2. pg_cron에서 HTTP 호출하는 EF는 반드시 manifest에 등록되어 있어야 함
+--    (신규 EF를 pg_cron에 추가할 때 manifest 업데이트를 강제)
 SELECT is(
   (
     SELECT count(*)::int
@@ -58,7 +45,7 @@ SELECT is(
     WHERE m.ef_name IS NULL
   ),
   0,
-  'All EFs called by pg_cron must be declared in ef_auth_manifest'
+  'All EFs called by pg_cron via HTTP must be declared in ef_auth_manifest'
 );
 
 SELECT * FROM finish();


### PR DESCRIPTION
## 요약

Closes #1760

PR #1494에서 `requireServiceRole()` 추가 후 pg_cron Authorization이 업데이트되지 않아 **6일간 401 무음 실패**가 발생한 패턴의 재발 방지.

## 변경 사항

### Migration: `ef_auth_manifest` 선언 테이블
- `public.ef_auth_manifest` 테이블 생성 — EF별 필요 인증 레벨(`public` / `authenticated` / `service_role`) 선언
- RLS 활성화 (SELECT only, public)
- 초기 seed: 36개 EF 등록 (service_role 15개, authenticated 20개, public 1개)

### pgTAP 테스트: `95_ef_auth_manifest_cron_consistency_test.sql`
3가지 일관성 검증:
1. **service_role EF → `service_role_key` vault secret 필수** (publishable_key 사용 시 실패)
2. **authenticated/public EF는 pg_cron에서 호출 금지** (user 세션 없음)
3. **pg_cron이 호출하는 모든 EF는 manifest에 등록 필수** (신규 EF 누락 방지)

## 유지보수 규칙

> EF에 `requireServiceRole()` 추가/제거 시 **같은 PR에서** `ef_auth_manifest`의 `required_auth`도 반드시 업데이트할 것.
> pgTAP 테스트가 PR을 차단하여 드리프트를 즉시 감지한다.

## 테스트
- `supabase/tests/database/95_ef_auth_manifest_cron_consistency_test.sql` — 3 assertions
- CI `test-supabase` job에서 자동 실행