### PR TITLE
fix(design-catalog): 반지름 레이블 불일치 + 타이포 계층 오류 수정 (#1717, #1718)

### DIFF
--- a/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/tokens/radius_section.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/tokens/radius_section.dart
@@ -12,8 +12,9 @@ class RadiusSection extends StatelessWidget {
     const radii = <String, double>{
       'small (8)': MinglitRadius.small,
       'input (12)': MinglitRadius.input,
-      'button (16)': MinglitRadius.button,
-      'card (24)': MinglitRadius.card,
+      // Fix #1718: labels corrected to match actual constant values
+      'button (12)': MinglitRadius.button,
+      'card (16)': MinglitRadius.card,
     };
 
     return ListView.builder(

--- a/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/tokens/typography_section.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/catalog_tabs/tokens/typography_section.dart
@@ -9,11 +9,10 @@ class TypographySection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
+    // Fix #1717: only show slots defined in MinglitTheme (omit M3-default displayMedium/headlineLarge)
     final styles = <String, TextStyle?>{
       'displayLarge': textTheme.displayLarge,
-      'displayMedium': textTheme.displayMedium,
       'displaySmall': textTheme.displaySmall,
-      'headlineLarge': textTheme.headlineLarge,
       'headlineMedium': textTheme.headlineMedium,
       'headlineSmall': textTheme.headlineSmall,
       'titleLarge': textTheme.titleLarge,

--- a/shared/packages/minglit_kit/lib/src/theme/minglit_theme.dart
+++ b/shared/packages/minglit_kit/lib/src/theme/minglit_theme.dart
@@ -87,6 +87,14 @@ class MinglitTheme {
           height: 1.25,
           color: MinglitColors.textPrimary,
         ),
+        // Fix #1717: define displaySmall so hierarchy displayLarge(32)>displaySmall(26) holds
+        displaySmall: TextStyle(
+          // ignore: minglit_no_hardcoded_text_style -- theme definition
+          fontSize: 26,
+          fontWeight: FontWeight.bold,
+          height: 1.3,
+          color: MinglitColors.textPrimary,
+        ),
         headlineSmall: TextStyle(
           // ignore: minglit_no_hardcoded_text_style -- theme definition
           fontSize: 24,
@@ -345,6 +353,14 @@ class MinglitTheme {
           fontSize: 32,
           fontWeight: FontWeight.bold,
           height: 1.25,
+          color: MinglitColorsDark.textPrimary,
+        ),
+        // Fix #1717: define displaySmall so hierarchy displayLarge(32)>displaySmall(26) holds
+        displaySmall: TextStyle(
+          // ignore: minglit_no_hardcoded_text_style -- theme definition
+          fontSize: 26,
+          fontWeight: FontWeight.bold,
+          height: 1.3,
           color: MinglitColorsDark.textPrimary,
         ),
         headlineSmall: TextStyle(


### PR DESCRIPTION
## 요약

Closes #1717
Closes #1718

## Fix #1718 — Radius Value Inconsistency

`radius_section.dart`의 레이블이 실제 `MinglitRadius` 상수값과 불일치:
- `'button (16)'` → `'button (12)'` (실제: `MinglitRadius.button = 12`)
- `'card (24)'` → `'card (16)'` (실제: `MinglitRadius.card = 16`)

## Fix #1717 — Typography Hierarchy Inconsistency

`displaySmall`이 정의되지 않아 Flutter M3 기본값(36sp)을 사용 → `displayLarge`(32sp)보다 커지는 계층 역전 발생.

`approval_waiting_card.dart`가 실제로 `displaySmall`을 사용하므로 26sp로 명시 정의:
- `displayLarge`: 32sp (유지)
- `displaySmall`: 26sp (신규, light/dark 모두)

계층: `displayLarge(32) > displaySmall(26) > headlineMedium(28)...`

> 주의: `displayMedium`은 앱 코드에서 사용하지 않아 정의 제외 (M3 기본값 45sp 유지).

## 테스트

- `test-app-unit-widget-golden (minglit_kit)` — Design Catalog 자동 테스트