### PR TITLE
docs(event-detail): 상세 소개 빈 상태 UX 가이드 (#1757)

### DIFF
--- a/docs/features/event-detail-empty-state/ui-ux-design.md
+++ b/docs/features/event-detail-empty-state/ui-ux-design.md
@@ -1,0 +1,143 @@
+# 이벤트 상세 — "상세 소개" 빈 상태 UX
+
+Issue: [#1757](https://github.com/Mark-Yun/minglit/issues/1757)
+
+## 1. 배경
+
+유저 앱 이벤트 상세 페이지의 "상세 소개" 섹션(`_QuillViewer`)이 비어 있을 때
+현재는 스타일 없는 평문 한 줄만 노출된다.
+
+```dart
+// 현재 (apps/app_user/lib/src/features/event/detail/event_quill_viewer.dart:10)
+if (description.isEmpty) return const Text('상세 소개 정보가 없습니다.');
+```
+
+### 문제점
+
+1. **톤 불일치** — 앱 전역의 빈 상태는 `MinglitEmptyState.card` / `.inline` 패턴을
+   쓰는데(예: 티켓 선택, 파트너 인증 관리) 이 화면만 평문이다.
+2. **시각적 무게 부재** — 섹션 타이틀도 없고 구분도 없어서 "버그로 인한 렌더 실패"
+   처럼 보인다. 호스트가 의도적으로 소개를 생략한 경우에도 앱의 완성도가 낮아 보인다.
+3. **문구가 건조하다** — "~없습니다" 는 선언형이라 거리감을 준다. 밍글릿의
+   브랜드 보이스(부드럽고 대화적)와 맞지 않는다.
+
+---
+
+## 2. 개선 방향
+
+### 2.1 컴포넌트 — `MinglitEmptyState.card`
+
+이미 디자인 시스템에 존재하는 card variant을 그대로 사용한다.
+(`shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_empty_state.dart`)
+
+| Slot | 값 | 근거 |
+|---|---|---|
+| `icon` | `Icons.description_outlined` | 섹션 성격(본문/설명)과 중립적으로 일치 |
+| `title` | **"아직 상세 소개가 없어요"** | 부드러운 진행형. 호스트를 탓하지 않음 |
+| `subtitle` | **"궁금한 점은 호스트에게 문의해 보세요."** | 대안 액션 제시 — 유저가 다음에 할 일 |
+
+### 2.2 카피 선정 근거
+
+| 후보 | 채택 여부 | 이유 |
+|---|---|---|
+| ~~"상세 소개 정보가 없습니다."~~ | X (현재) | 건조, 에러 메시지처럼 보임 |
+| ~~"상세 소개가 없습니다."~~ | X | 위와 동일 |
+| **"아직 상세 소개가 없어요"** | ✅ | "아직"이 미래 가능성을 암시, "~어요" 가 대화적 |
+| ~~"호스트가 소개를 준비하고 있어요"~~ | X | 사실 여부 단정 불가 — 준비 중인지 포기했는지 모름 |
+| ~~"상세 소개 없이 준비된 이벤트예요"~~ | X | 호스트 태만을 정당화하는 톤 |
+
+Subtitle은 **액션 제안**을 우선으로 한다. 유저가 "정보가 없네" 에서 끝나지 않고
+"그럼 물어봐야지" 로 이어지게.
+
+### 2.3 Placement
+
+섹션 2의 기존 래핑을 그대로 유지한다 — `SliverToBoxAdapter` → `Padding`(좌우
+`MinglitSpacing.screenEdge`, 상단 `MinglitSpacing.sectionGap`). `MinglitEmptyState.card`
+는 내부에 `MinglitSpacing.xlarge`(32px) 패딩과 `surfaceContainerLowest` 배경,
+`MinglitRadius.card` 라운드를 자체 제공하므로 추가 래핑 불필요.
+
+```
+┌──────────────────────────────────────┐ ← screenEdge 16px
+│                                      │   sectionGap 40px above
+│    ┌────────────────────────────┐   │
+│    │                            │   │
+│    │        📄 (32px)          │   │   ← MinglitEmptyState.card
+│    │                            │   │     • surfaceContainerLowest bg
+│    │   아직 상세 소개가 없어요    │   │     • 16px radius
+│    │                            │   │     • xlarge(32px) padding
+│    │  궁금한 점은 호스트에게     │   │
+│    │      문의해 보세요.         │   │
+│    │                            │   │
+│    └────────────────────────────┘   │
+│                                      │
+└──────────────────────────────────────┘
+```
+
+---
+
+## 3. 구현 가이드 (SWE용)
+
+### 3.1 변경 파일
+
+`apps/app_user/lib/src/features/event/detail/event_quill_viewer.dart`
+
+### 3.2 Diff
+
+```dart
+// Before
+if (description.isEmpty) return const Text('상세 소개 정보가 없습니다.');
+
+// After — Fix #1757: 빈 상태 일관성 (MinglitEmptyState.card)
+if (description.isEmpty) {
+  return const MinglitEmptyState.card(
+    icon: Icons.description_outlined,
+    title: '아직 상세 소개가 없어요',
+    subtitle: '궁금한 점은 호스트에게 문의해 보세요.',
+  );
+}
+```
+
+`MinglitEmptyState` 는 `minglit_kit` 의 public export 에 이미 포함되어 있으므로
+import 한 줄 추가 또는 기존 import에 병합.
+
+### 3.3 추가로 고려할 엣지 케이스 (선택)
+
+Quill document 구조 특성상 `description` 이 `{"ops": [{"insert": "\n"}]}` 같이
+"구조만 존재하고 실질 콘텐츠가 없는" 경우 `description.isEmpty` 는 false 지만
+렌더링 결과는 사실상 빈 문자열이다.
+
+이번 수정 범위는 **#1757 의 명시적 케이스(빈 map)** 에 한정하고, Quill 문서가
+텍스트/이미지 delta 가 전무한 케이스는 별도 이슈로 다루는 것을 권장한다. 본
+PR 에서 범위를 넓히면 Quill delta 검사 로직(`ops` 배열 내 실제 insert 존재 여부)이
+더해져야 하므로 리뷰 복잡도가 증가한다.
+
+### 3.4 테스트
+
+회귀 방지 Widget 테스트를 `_QuillViewer` 에 대해 추가:
+
+| 케이스 | 기대 |
+|---|---|
+| `description = {}` | `MinglitEmptyState` 가 렌더되고 아이콘 `description_outlined`, 타이틀 "아직 상세 소개가 없어요" 노출 |
+| `description = {"ops": [{"insert": "hello\n"}]}` | `QuillEditor.basic` 렌더 (기존 동작 유지) |
+
+---
+
+## 4. 체크리스트
+
+- [ ] `event_quill_viewer.dart` 의 `Text` 를 `MinglitEmptyState.card` 로 교체
+- [ ] `Fix #1757:` 주석 추가 (프로젝트 규칙)
+- [ ] 기존 Quill 렌더 케이스 회귀 없음 확인 (description 이 있을 때)
+- [ ] Widget 테스트 2건 추가 (3.4)
+- [ ] 라이트/다크 모드 골든 이미지 캡처 — 카드 배경/텍스트 대비 확인
+- [ ] PR body 에 본 가이드 링크 인용 (`docs/features/event-detail-empty-state/ui-ux-design.md`)
+
+---
+
+## 5. 참조
+
+- 원본 이슈: [#1757](https://github.com/Mark-Yun/minglit/issues/1757)
+- 관련 위젯: `MinglitEmptyState` (`shared/packages/minglit_kit/lib/src/ui/widgets/common/minglit_empty_state.dart`)
+- 유사 적용 사례:
+  - `apps/app_user/lib/src/features/ticket/ui/ticket_selection_widgets.dart:175`
+  - `apps/app_partner/lib/src/features/verification/manage/verification_manage_page.dart:122`
+- 와이어프레임: [wireframe.html](./wireframe.html)

--- a/docs/features/event-detail-empty-state/wireframe.html
+++ b/docs/features/event-detail-empty-state/wireframe.html
@@ -1,0 +1,332 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>이벤트 상세 — 상세 소개 빈 상태 (#1757)</title>
+<style>
+  :root {
+    --bg: #f7f7fa;
+    --surface: #ffffff;
+    --surface-container-lowest: #fafafa;
+    --on-surface: #1a1c1e;
+    --on-surface-variant: #6b7280;
+    --outline-variant: #d8dadf;
+    --primary: #5E4AE3;
+    --radius-card: 16px;
+    --radius-lg: 12px;
+    --screen-edge: 16px;
+    --section-gap: 40px;
+    --xlarge: 32px;
+    --medium: 12px;
+    --small: 8px;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Pretendard", "Apple SD Gothic Neo", sans-serif;
+    background: #eceef2;
+    color: var(--on-surface);
+    padding: 32px 16px 64px;
+  }
+  h1 {
+    text-align: center;
+    font-size: 18px;
+    font-weight: 700;
+    margin: 0 0 4px;
+  }
+  .subtitle {
+    text-align: center;
+    color: var(--on-surface-variant);
+    font-size: 13px;
+    margin: 0 0 32px;
+  }
+  .comparison {
+    display: flex;
+    gap: 24px;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+  .phone-col {
+    flex: 0 0 auto;
+  }
+  .phone-label {
+    text-align: center;
+    font-weight: 700;
+    font-size: 14px;
+    margin-bottom: 12px;
+    padding: 6px 14px;
+    border-radius: 999px;
+    display: inline-block;
+  }
+  .phone-label.as-is {
+    background: #fee;
+    color: #a03a3a;
+  }
+  .phone-label.to-be {
+    background: #e8f5ec;
+    color: #2e7d4a;
+  }
+  .phone {
+    width: 360px;
+    height: 720px;
+    background: var(--surface);
+    border-radius: 32px;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.12);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid #d8dadf;
+  }
+  .status-bar {
+    height: 28px;
+    background: var(--surface);
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding: 0 16px;
+    font-size: 11px;
+    color: var(--on-surface-variant);
+  }
+  .app-bar {
+    height: 48px;
+    display: flex;
+    align-items: center;
+    padding: 0 12px;
+    gap: 8px;
+    border-bottom: 1px solid var(--outline-variant);
+  }
+  .app-bar .icon {
+    width: 32px; height: 32px;
+    display: flex; align-items: center; justify-content: center;
+    color: var(--on-surface);
+  }
+  .app-bar .title {
+    flex: 1;
+    font-weight: 600;
+    font-size: 15px;
+  }
+  .scroll-area {
+    flex: 1;
+    overflow-y: auto;
+    padding-bottom: 32px;
+  }
+  /* Section 1 — hero */
+  .hero {
+    width: 100%;
+    height: 160px;
+    background: linear-gradient(135deg, #8a7bff 0%, #5E4AE3 100%);
+    position: relative;
+  }
+  .hero::after {
+    content: "이벤트 이미지";
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: rgba(255,255,255,0.8);
+    font-size: 12px;
+  }
+  .hero-meta {
+    padding: 16px var(--screen-edge) 0;
+  }
+  .hero-title {
+    font-size: 18px;
+    font-weight: 700;
+    margin-bottom: 4px;
+  }
+  .hero-sub {
+    font-size: 12px;
+    color: var(--on-surface-variant);
+  }
+  /* Section separators */
+  .section {
+    padding: 0 var(--screen-edge);
+    margin-top: var(--section-gap);
+  }
+  .section-title-row {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--on-surface-variant);
+    margin-bottom: 12px;
+  }
+  /* AS-IS plain text */
+  .as-is-empty {
+    padding: 0 var(--screen-edge);
+    margin-top: var(--section-gap);
+    font-size: 14px;
+    color: var(--on-surface);
+  }
+  /* TO-BE empty state card */
+  .empty-card {
+    background: var(--surface-container-lowest);
+    border-radius: var(--radius-card);
+    padding: var(--xlarge);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+  .empty-card .ic {
+    width: 32px;
+    height: 32px;
+    color: var(--outline-variant);
+    margin-bottom: var(--medium);
+  }
+  .empty-card .ic svg {
+    width: 100%; height: 100%;
+  }
+  .empty-card .t {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--on-surface);
+    margin-bottom: var(--small);
+  }
+  .empty-card .s {
+    font-size: 14px;
+    color: var(--on-surface-variant);
+    line-height: 1.5;
+  }
+  /* next section preview */
+  .next-section {
+    padding: 20px var(--screen-edge);
+    margin-top: var(--section-gap);
+    border-top: 1px dashed var(--outline-variant);
+    color: var(--on-surface-variant);
+    font-size: 12px;
+    text-align: center;
+  }
+  .annotations {
+    max-width: 820px;
+    margin: 48px auto 0;
+    background: var(--surface);
+    border-radius: 12px;
+    padding: 24px 28px;
+    border: 1px solid var(--outline-variant);
+  }
+  .annotations h2 {
+    font-size: 16px;
+    margin: 0 0 12px;
+  }
+  .annotations ul {
+    margin: 0;
+    padding-left: 20px;
+    color: #333;
+    font-size: 14px;
+    line-height: 1.8;
+  }
+  .annotations code {
+    background: #f1f1f4;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 13px;
+  }
+  .tokens {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px 24px;
+    margin-top: 12px;
+  }
+  .tokens div {
+    font-size: 13px;
+    color: #444;
+  }
+  .tokens strong {
+    color: #000;
+  }
+</style>
+</head>
+<body>
+  <h1>이벤트 상세 — "상세 소개" 빈 상태</h1>
+  <p class="subtitle">Issue #1757 · 소유: needs-uiux-claude-1 · AS-IS vs TO-BE</p>
+
+  <div class="comparison">
+    <!-- AS-IS -->
+    <div class="phone-col">
+      <div style="text-align:center;">
+        <span class="phone-label as-is">AS-IS (현재)</span>
+      </div>
+      <div class="phone">
+        <div class="status-bar">9:41</div>
+        <div class="app-bar">
+          <div class="icon">←</div>
+          <div class="title">이벤트 상세</div>
+          <div class="icon">⋮</div>
+        </div>
+        <div class="scroll-area">
+          <div class="hero"></div>
+          <div class="hero-meta">
+            <div class="hero-title">[QA] 아트 & 문화 이벤트</div>
+            <div class="hero-sub">서울 강남 · 5월 19일 22:27 · 무료</div>
+          </div>
+          <div class="as-is-empty">상세 소개 정보가 없습니다.</div>
+          <div class="next-section">— 참가 현황 섹션 —</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- TO-BE -->
+    <div class="phone-col">
+      <div style="text-align:center;">
+        <span class="phone-label to-be">TO-BE (개선)</span>
+      </div>
+      <div class="phone">
+        <div class="status-bar">9:41</div>
+        <div class="app-bar">
+          <div class="icon">←</div>
+          <div class="title">이벤트 상세</div>
+          <div class="icon">⋮</div>
+        </div>
+        <div class="scroll-area">
+          <div class="hero"></div>
+          <div class="hero-meta">
+            <div class="hero-title">[QA] 아트 & 문화 이벤트</div>
+            <div class="hero-sub">서울 강남 · 5월 19일 22:27 · 무료</div>
+          </div>
+          <div class="section">
+            <div class="empty-card">
+              <div class="ic">
+                <!-- Icons.description_outlined equivalent -->
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/>
+                  <path d="M14 3v6h6"/>
+                  <path d="M8 13h8"/>
+                  <path d="M8 17h6"/>
+                </svg>
+              </div>
+              <div class="t">아직 상세 소개가 없어요</div>
+              <div class="s">궁금한 점은 호스트에게<br/>문의해 보세요.</div>
+            </div>
+          </div>
+          <div class="next-section">— 참가 현황 섹션 —</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="annotations">
+    <h2>디자인 결정 요약</h2>
+    <ul>
+      <li><strong>컴포넌트</strong> — <code>MinglitEmptyState.card</code> (이미 디자인 시스템에 존재, 재사용).</li>
+      <li><strong>아이콘</strong> — <code>Icons.description_outlined</code>. 섹션 성격(본문/설명)을 중립적으로 암시.</li>
+      <li><strong>카피</strong> — 현재 "없습니다"(선언형) → "아직 … 없어요"(진행형 + 대화적). 호스트를 탓하지 않으면서도 미래 가능성을 열어둔다.</li>
+      <li><strong>서브카피</strong> — "궁금한 점은 호스트에게 문의해 보세요." 로 유저에게 <em>다음 액션</em>을 제시 (디자인 시 데드엔드 방지).</li>
+      <li><strong>여백</strong> — 기존 섹션 간격(<code>sectionGap 40px</code>, <code>screenEdge 16px</code>)을 그대로 유지. 카드 내부 패딩은 <code>xlarge 32px</code>.</li>
+      <li><strong>배경/라운드</strong> — <code>surfaceContainerLowest</code> + <code>MinglitRadius.card(16px)</code>. 다크모드 자동 대응.</li>
+    </ul>
+
+    <h2 style="margin-top:20px;">토큰 (참고)</h2>
+    <div class="tokens">
+      <div><strong>Icon size</strong> · MinglitIconSize.xlarge (32px)</div>
+      <div><strong>Icon color</strong> · colorScheme.outlineVariant</div>
+      <div><strong>Title</strong> · textTheme.titleMedium</div>
+      <div><strong>Subtitle</strong> · textTheme.bodyMedium · onSurfaceVariant</div>
+      <div><strong>Card bg</strong> · colorScheme.surfaceContainerLowest</div>
+      <div><strong>Card radius</strong> · MinglitRadius.card (16px)</div>
+      <div><strong>Card inner padding</strong> · MinglitSpacing.xlarge (32px)</div>
+      <div><strong>Title→Subtitle gap</strong> · MinglitSpacing.small (8px)</div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Scheduler: needs-uiux-claude-1

Closes #1757

## Summary

이벤트 상세 "상세 소개" 섹션 빈 상태 UX 개선 가이드.

- 현재: `event_quill_viewer.dart:10` 이 평문 `Text('상세 소개 정보가 없습니다.')` 로 렌더링 — 앱 전역 empty-state 패턴(`MinglitEmptyState.card`)과 불일치
- 제안: 기존 디자인 시스템의 `MinglitEmptyState.card` 를 그대로 사용 + 카피 브랜드 보이스에 맞게 수정
- 가이드 문서: [`docs/features/event-detail-empty-state/ui-ux-design.md`](docs/features/event-detail-empty-state/ui-ux-design.md)
- 와이어프레임: [`docs/features/event-detail-empty-state/wireframe.html`](docs/features/event-detail-empty-state/wireframe.html)

## 핵심 변경 포인트 (SWE 구현용)

\`\`\`dart
// apps/app_user/lib/src/features/event/detail/event_quill_viewer.dart

// Before
if (description.isEmpty) return const Text('상세 소개 정보가 없습니다.');

// After (Fix #1757)
if (description.isEmpty) {
  return const MinglitEmptyState.card(
    icon: Icons.description_outlined,
    title: '아직 상세 소개가 없어요',
    subtitle: '궁금한 점은 호스트에게 문의해 보세요.',
  );
}
\`\`\`

## 이전 이력

needs-uiux-gemini-1 이 작성했다고 한 가이드(\`docs/features/event-detail-empty-state/*\`)가 실제로는 레포에 커밋되지 않은 상태였음. 본 PR 이 실제 파일을 추가하고 카피/근거/테스트 체크리스트를 보강.

## Test plan
- [ ] \`docs/features/event-detail-empty-state/wireframe.html\` 을 브라우저에서 열어 AS-IS / TO-BE 비교가 의도대로 보이는지 확인
- [ ] SWE 가 가이드의 diff/체크리스트를 따라 구현 — 회귀 Widget 테스트 2건 포함

🤖 Generated with [Claude Code](https://claude.com/claude-code)