### PR TITLE
fix(ci): run-partner-cuj.sh exit code 1 수정 (#1755)

### DIFF
--- a/.github/scripts/run-partner-cuj.sh
+++ b/.github/scripts/run-partner-cuj.sh
@@ -9,4 +9,5 @@ for f in test/integration/*_test.dart; do
   echo "▶ Running: $f"
   flutter test "$f" --flavor dev --dart-define-from-file=../../minglit_env/dev/flutter.env
 done
-[ "$found" -eq 0 ] && echo "⏭ No integration tests found, skipping."
+# Fix #1755: [ ... ] && echo 패턴은 found=1 일 때 마지막 명령이 exit 1 → 스크립트 종료 코드 1
+if [ "$found" -eq 0 ]; then echo "⏭ No integration tests found, skipping."; fi


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 문제

\`[ "\$found" -eq 0 ] && echo "..."\` 패턴에서 \`\$found=1\`(테스트 발견)이면 \`[ 1 -eq 0 ]\` 평가가 exit 1을 반환. 이것이 스크립트 마지막 명령이므로 \`set -euo pipefail\`에 의해 스크립트 전체가 exit 1로 종료됨.

결과: 103 tests passed 에도 daily-backend-simulation 30일 연속 실패.

## 수정

\`[ ... ] && echo\` → \`if [...]; then ...; fi\` 패턴으로 교체.
조건 결과와 무관하게 exit 0 보장.

## 검증

PR merge 후 다음 daily 실행에서 partner-cuj-test 성공 확인으로 검증.

Closes #1755
Closes #1747