### PR TITLE
fix(partner): DB 컬럼 불일치 수정 — adjustment_items + entry_group_templates (#1739, #1740)

### DIFF
--- a/shared/packages/minglit_kit/lib/src/data/repositories/party_matching_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/party_matching_repository.dart
@@ -11,8 +11,9 @@ mixin _PartyMatchingRepository on _SupabasePartyContext {
       'count: ${templates.length}',
     );
     try {
+      // Fix #1740: entry_groups(Event Level)은 party_id 컬럼 없음 — entry_group_templates(Party Level) 사용
       await supabaseClient
-          .from('entry_groups')
+          .from('entry_group_templates')
           .delete()
           .eq('party_id', partyId);
 
@@ -26,7 +27,7 @@ mixin _PartyMatchingRepository on _SupabasePartyContext {
           )
           .toList();
 
-      await supabaseClient.from('entry_groups').insert(groupsJson);
+      await supabaseClient.from('entry_group_templates').insert(groupsJson);
       Log.d('replaceEntryGroupTemplates success');
     } catch (e, st) {
       Log.e('❌ [PartyRepo] replaceEntryGroupTemplates Error', e, st);

--- a/shared/packages/minglit_kit/lib/src/data/repositories/settlement_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/settlement_repository.dart
@@ -128,7 +128,8 @@ class SettlementRepository {
                   .select(
                     'id, adjustment_type, amount_signed, reason_code, status',
                   )
-                  .eq('settlement_item_id', itemId)
+                  // Fix #1739: adjustment_items FK 컬럼명은 related_settlement_item_id
+                  .eq('related_settlement_item_id', itemId)
               as List;
 
       final adjustmentsData = adjustmentsRaw

--- a/shared/packages/minglit_kit/test/src/data/repositories/party_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/party_repository_test.dart
@@ -725,8 +725,11 @@ void main() {
 
   group('PartyRepository (matching)', () {
     group('replaceEntryGroupTemplates', () {
+      // Fix #1740: entry_groups(Event Level)에는 party_id 컬럼 없음 —
+      // entry_group_templates(Party Level) 테이블 사용으로 수정.
+
       test('completes with empty templates (delete only)', () async {
-        unawaited(mockTable(mockClient, 'entry_groups'));
+        unawaited(mockTable(mockClient, 'entry_group_templates'));
 
         await expectLater(
           repository.replaceEntryGroupTemplates('party_1', []),
@@ -735,7 +738,7 @@ void main() {
       });
 
       test('completes with templates (delete + insert)', () async {
-        unawaited(mockTable(mockClient, 'entry_groups'));
+        unawaited(mockTable(mockClient, 'entry_group_templates'));
 
         final templates = [
           const EntryGroupTemplate(
@@ -758,7 +761,7 @@ void main() {
         unawaited(
           mockTable(
             mockClient,
-            'entry_groups',
+            'entry_group_templates',
             shouldThrow: Exception('error'),
           ),
         );
@@ -768,6 +771,29 @@ void main() {
           throwsA(anything),
         );
       });
+
+      test(
+        'Fix #1740: uses entry_group_templates table (not entry_groups)',
+        () async {
+          final templatesBuilder = mockTable(
+            mockClient,
+            'entry_group_templates',
+          );
+
+          await repository.replaceEntryGroupTemplates('party_1', []);
+
+          final eqFilters = templatesBuilder.recordedFilters
+              .where((f) => f.method == 'eq')
+              .toList();
+          expect(
+            eqFilters.any((f) => f.column == 'party_id'),
+            isTrue,
+            reason: 'entry_group_templates must be filtered by party_id',
+          );
+          // entry_groups 테이블 호출 없음 확인
+          verifyNever(() => mockClient.from('entry_groups'));
+        },
+      );
     });
   });
 }

--- a/shared/packages/minglit_kit/test/src/data/repositories/settlement_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/settlement_repository_test.dart
@@ -155,6 +155,44 @@ void main() {
         );
       });
 
+      // Fix #1739: adjustment_items.settlement_item_id → related_settlement_item_id
+      // Regression guard: if someone reverts the column name the assertion below
+      // will fail before the real DB does.
+      test(
+        'Fix #1739: queries adjustment_items by related_settlement_item_id',
+        () async {
+          mockTable(
+            mockClient,
+            'settlement_items',
+            maybeSingleData: _settlementItemJson(),
+          );
+          mockTable(mockClient, 'settlement_histories', selectData: []);
+          final adjustmentsBuilder = mockTable(
+            mockClient,
+            'adjustment_items',
+            selectData: [],
+          );
+
+          await repository.getSettlementItemDetail('item_1');
+
+          final eqFilters = adjustmentsBuilder.recordedFilters
+              .where((f) => f.method == 'eq')
+              .toList();
+          expect(
+            eqFilters.any((f) => f.column == 'related_settlement_item_id'),
+            isTrue,
+            reason:
+                'adjustment_items must be filtered by related_settlement_item_id (not settlement_item_id)',
+          );
+          expect(
+            eqFilters.any((f) => f.column == 'settlement_item_id'),
+            isFalse,
+            reason:
+                'adjustment_items has no settlement_item_id column — Fix #1739',
+          );
+        },
+      );
+
       // Fix #1566: settlement_histories.created_at → event_at column rename.
       // Regression guard: verify that the repository selects and orders by
       // 'event_at', not 'created_at'. If someone reverts the column name the


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 수정 내용

### #1739 — `adjustment_items.settlement_item_id` 컬럼 없음
- `settlement_repository.dart`: `.eq('settlement_item_id', itemId)` → `.eq('related_settlement_item_id', itemId)`
- `settlement_histories`는 `settlement_item_id` 보유, `adjustment_items`는 `related_settlement_item_id` 보유 (phase1_schema.sql 참고)

### #1740 — `entry_groups.party_id` 컬럼 없음
- `party_matching_repository.dart`: `entry_groups` → `entry_group_templates`
- `entry_groups`(Event Level)은 `event_id`만 보유
- `entry_group_templates`(Party Level)이 `party_id` 보유

## 테스트
- settlement_repository_test: `related_settlement_item_id` 컬럼 사용 assertion (regression guard)
- party_repository_test: `entry_group_templates` 테이블 사용 + `verifyNever(entry_groups)` assertion

Closes #1739
Closes #1740