### PR TITLE
fix(partner): 수정 위저드 Step4/Step5 로드 회귀테스트 + CUJ-P05 시드 (#1743)

### DIFF
--- a/apps/app_partner/test/src/features/party/create/party_create_wizard_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/create/party_create_wizard_controller_test.dart
@@ -45,12 +45,14 @@ void main() {
   late MockPartnerRepository mockPartnerRepo;
   late MockTicketRepository mockTicketRepo;
   late MockLocationRepository mockLocationRepo;
+  late MockTagRepository mockTagRepo;
 
   setUp(() {
     mockPartyRepo = MockPartyRepository();
     mockPartnerRepo = MockPartnerRepository();
     mockTicketRepo = MockTicketRepository();
     mockLocationRepo = MockLocationRepository();
+    mockTagRepo = MockTagRepository();
   });
 
   ProviderContainer makeContainer() {
@@ -60,6 +62,7 @@ void main() {
         partnerRepositoryProvider.overrideWithValue(mockPartnerRepo),
         ticketRepositoryProvider.overrideWithValue(mockTicketRepo),
         locationRepositoryProvider.overrideWithValue(mockLocationRepo),
+        tagRepositoryProvider.overrideWithValue(mockTagRepo),
       ],
     );
   }
@@ -370,6 +373,105 @@ void main() {
             .read(partyCreateWizardControllerProvider)
             .entryGroups;
         expect(groups.first.gender, 'female');
+      });
+    });
+
+    // Fix #1743: loadForEdit이 entry_group_templates와 ticket_templates를 올바르게 로드하는지 검증.
+    // 수정 위저드 진입 시 Step4(입장규칙)/Step5(티켓)에 기존 데이터가 pre-fill 되어야 함.
+    group('loadForEdit', () {
+      test('pre-fills entryGroups and tickets from existing party data', () async {
+        final now = DateTime.now();
+        const partyId = 'party-edit-1';
+
+        final entryGroups = [
+          EntryGroupTemplate(
+            id: 'eg-1',
+            partyId: partyId,
+            gender: 'male',
+            birthYearMin: 1995,
+            birthYearMax: 2004,
+            createdAt: now,
+            updatedAt: now,
+          ),
+          EntryGroupTemplate(
+            id: 'eg-2',
+            partyId: partyId,
+            gender: 'female',
+            birthYearMin: 1995,
+            birthYearMax: 2004,
+            createdAt: now,
+            updatedAt: now,
+          ),
+        ];
+
+        final ticketTemplates = [
+          TicketTemplate(
+            id: 'tt-1',
+            partyId: partyId,
+            name: '일반 참가권',
+            quantity: 20,
+            createdAt: now,
+            updatedAt: now,
+          ),
+        ];
+
+        final party = Party(
+          id: partyId,
+          partnerId: 'partner-1',
+          title: '테스트 파티',
+          maxParticipants: 40,
+          entryGroups: entryGroups,
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        when(() => mockPartyRepo.getPartyById(partyId)).thenAnswer((_) async => party);
+        when(() => mockTicketRepo.getTicketTemplatesByPartyId(partyId))
+            .thenAnswer((_) async => ticketTemplates);
+        when(() => mockTagRepo.getTagsByPartyId(partyId)).thenAnswer((_) async => []);
+
+        final container = makeContainer();
+        final notifier = container.read(partyCreateWizardControllerProvider.notifier);
+
+        await notifier.loadForEdit(partyId);
+
+        final state = container.read(partyCreateWizardControllerProvider);
+        // Fix #1743: Step4 — 기존 입장 그룹이 로드되어야 함
+        expect(state.entryGroups, hasLength(2));
+        expect(state.entryGroups.first.id, 'eg-1');
+        expect(state.entryGroups.last.id, 'eg-2');
+        // Fix #1743: Step5 — 기존 티켓 템플릿이 로드되어야 함
+        expect(state.tickets, hasLength(1));
+        expect(state.tickets.first.id, 'tt-1');
+        expect(state.isPrefilled, isTrue);
+      });
+
+      test('pre-fills empty lists when party has no entry groups or tickets', () async {
+        final now = DateTime.now();
+        const partyId = 'party-empty-1';
+
+        final party = Party(
+          id: partyId,
+          partnerId: 'partner-1',
+          title: '빈 파티',
+          createdAt: now,
+          updatedAt: now,
+        );
+
+        when(() => mockPartyRepo.getPartyById(partyId)).thenAnswer((_) async => party);
+        when(() => mockTicketRepo.getTicketTemplatesByPartyId(partyId))
+            .thenAnswer((_) async => []);
+        when(() => mockTagRepo.getTagsByPartyId(partyId)).thenAnswer((_) async => []);
+
+        final container = makeContainer();
+        final notifier = container.read(partyCreateWizardControllerProvider.notifier);
+
+        await notifier.loadForEdit(partyId);
+
+        final state = container.read(partyCreateWizardControllerProvider);
+        expect(state.entryGroups, isEmpty);
+        expect(state.tickets, isEmpty);
+        expect(state.isPrefilled, isTrue);
       });
     });
 

--- a/apps/app_partner/test/src/features/party/create/party_create_wizard_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/create/party_create_wizard_controller_test.dart
@@ -379,100 +379,120 @@ void main() {
     // Fix #1743: loadForEdit이 entry_group_templates와 ticket_templates를 올바르게 로드하는지 검증.
     // 수정 위저드 진입 시 Step4(입장규칙)/Step5(티켓)에 기존 데이터가 pre-fill 되어야 함.
     group('loadForEdit', () {
-      test('pre-fills entryGroups and tickets from existing party data', () async {
-        final now = DateTime.now();
-        const partyId = 'party-edit-1';
+      test(
+        'pre-fills entryGroups and tickets from existing party data',
+        () async {
+          final now = DateTime.now();
+          const partyId = 'party-edit-1';
 
-        final entryGroups = [
-          EntryGroupTemplate(
-            id: 'eg-1',
-            partyId: partyId,
-            gender: 'male',
-            birthYearMin: 1995,
-            birthYearMax: 2004,
+          final entryGroups = [
+            EntryGroupTemplate(
+              id: 'eg-1',
+              partyId: partyId,
+              gender: 'male',
+              birthYearMin: 1995,
+              birthYearMax: 2004,
+              createdAt: now,
+              updatedAt: now,
+            ),
+            EntryGroupTemplate(
+              id: 'eg-2',
+              partyId: partyId,
+              gender: 'female',
+              birthYearMin: 1995,
+              birthYearMax: 2004,
+              createdAt: now,
+              updatedAt: now,
+            ),
+          ];
+
+          final ticketTemplates = [
+            TicketTemplate(
+              id: 'tt-1',
+              partyId: partyId,
+              name: '일반 참가권',
+              quantity: 20,
+              createdAt: now,
+              updatedAt: now,
+            ),
+          ];
+
+          final party = Party(
+            id: partyId,
+            partnerId: 'partner-1',
+            title: '테스트 파티',
+            maxParticipants: 40,
+            entryGroups: entryGroups,
             createdAt: now,
             updatedAt: now,
-          ),
-          EntryGroupTemplate(
-            id: 'eg-2',
-            partyId: partyId,
-            gender: 'female',
-            birthYearMin: 1995,
-            birthYearMax: 2004,
+          );
+
+          when(
+            () => mockPartyRepo.getPartyById(partyId),
+          ).thenAnswer((_) async => party);
+          when(
+            () => mockTicketRepo.getTicketTemplatesByPartyId(partyId),
+          ).thenAnswer((_) async => ticketTemplates);
+          when(
+            () => mockTagRepo.getTagsByPartyId(partyId),
+          ).thenAnswer((_) async => []);
+
+          final container = makeContainer();
+          final notifier = container.read(
+            partyCreateWizardControllerProvider.notifier,
+          );
+
+          await notifier.loadForEdit(partyId);
+
+          final state = container.read(partyCreateWizardControllerProvider);
+          // Fix #1743: Step4 — 기존 입장 그룹이 로드되어야 함
+          expect(state.entryGroups, hasLength(2));
+          expect(state.entryGroups.first.id, 'eg-1');
+          expect(state.entryGroups.last.id, 'eg-2');
+          // Fix #1743: Step5 — 기존 티켓 템플릿이 로드되어야 함
+          expect(state.tickets, hasLength(1));
+          expect(state.tickets.first.id, 'tt-1');
+          expect(state.isPrefilled, isTrue);
+        },
+      );
+
+      test(
+        'pre-fills empty lists when party has no entry groups or tickets',
+        () async {
+          final now = DateTime.now();
+          const partyId = 'party-empty-1';
+
+          final party = Party(
+            id: partyId,
+            partnerId: 'partner-1',
+            title: '빈 파티',
             createdAt: now,
             updatedAt: now,
-          ),
-        ];
+          );
 
-        final ticketTemplates = [
-          TicketTemplate(
-            id: 'tt-1',
-            partyId: partyId,
-            name: '일반 참가권',
-            quantity: 20,
-            createdAt: now,
-            updatedAt: now,
-          ),
-        ];
+          when(
+            () => mockPartyRepo.getPartyById(partyId),
+          ).thenAnswer((_) async => party);
+          when(
+            () => mockTicketRepo.getTicketTemplatesByPartyId(partyId),
+          ).thenAnswer((_) async => []);
+          when(
+            () => mockTagRepo.getTagsByPartyId(partyId),
+          ).thenAnswer((_) async => []);
 
-        final party = Party(
-          id: partyId,
-          partnerId: 'partner-1',
-          title: '테스트 파티',
-          maxParticipants: 40,
-          entryGroups: entryGroups,
-          createdAt: now,
-          updatedAt: now,
-        );
+          final container = makeContainer();
+          final notifier = container.read(
+            partyCreateWizardControllerProvider.notifier,
+          );
 
-        when(() => mockPartyRepo.getPartyById(partyId)).thenAnswer((_) async => party);
-        when(() => mockTicketRepo.getTicketTemplatesByPartyId(partyId))
-            .thenAnswer((_) async => ticketTemplates);
-        when(() => mockTagRepo.getTagsByPartyId(partyId)).thenAnswer((_) async => []);
+          await notifier.loadForEdit(partyId);
 
-        final container = makeContainer();
-        final notifier = container.read(partyCreateWizardControllerProvider.notifier);
-
-        await notifier.loadForEdit(partyId);
-
-        final state = container.read(partyCreateWizardControllerProvider);
-        // Fix #1743: Step4 — 기존 입장 그룹이 로드되어야 함
-        expect(state.entryGroups, hasLength(2));
-        expect(state.entryGroups.first.id, 'eg-1');
-        expect(state.entryGroups.last.id, 'eg-2');
-        // Fix #1743: Step5 — 기존 티켓 템플릿이 로드되어야 함
-        expect(state.tickets, hasLength(1));
-        expect(state.tickets.first.id, 'tt-1');
-        expect(state.isPrefilled, isTrue);
-      });
-
-      test('pre-fills empty lists when party has no entry groups or tickets', () async {
-        final now = DateTime.now();
-        const partyId = 'party-empty-1';
-
-        final party = Party(
-          id: partyId,
-          partnerId: 'partner-1',
-          title: '빈 파티',
-          createdAt: now,
-          updatedAt: now,
-        );
-
-        when(() => mockPartyRepo.getPartyById(partyId)).thenAnswer((_) async => party);
-        when(() => mockTicketRepo.getTicketTemplatesByPartyId(partyId))
-            .thenAnswer((_) async => []);
-        when(() => mockTagRepo.getTagsByPartyId(partyId)).thenAnswer((_) async => []);
-
-        final container = makeContainer();
-        final notifier = container.read(partyCreateWizardControllerProvider.notifier);
-
-        await notifier.loadForEdit(partyId);
-
-        final state = container.read(partyCreateWizardControllerProvider);
-        expect(state.entryGroups, isEmpty);
-        expect(state.tickets, isEmpty);
-        expect(state.isPrefilled, isTrue);
-      });
+          final state = container.read(partyCreateWizardControllerProvider);
+          expect(state.entryGroups, isEmpty);
+          expect(state.tickets, isEmpty);
+          expect(state.isPrefilled, isTrue);
+        },
+      );
     });
 
     group('submit', () {

--- a/apps/app_partner/test/utils/mocks.dart
+++ b/apps/app_partner/test/utils/mocks.dart
@@ -30,4 +30,6 @@ class MockLocationRepository extends Mock implements LocationRepository {}
 
 class MockMatchingRepository extends Mock implements MatchingRepository {}
 
+class MockTagRepository extends Mock implements TagRepository {}
+
 class MockNavigatorObserver extends Mock implements NavigatorObserver {}

--- a/supabase/seed.dev.sql
+++ b/supabase/seed.dev.sql
@@ -678,8 +678,6 @@ DECLARE
   partner_id_  uuid;
   location_id_ uuid;
   party_id_    uuid;
-  group_m_id   uuid;
-  group_f_id   uuid;
 BEGIN
   SELECT id INTO partner_id_ FROM public.partners WHERE biz_number = '000-00-00000';
   IF partner_id_ IS NULL THEN
@@ -707,11 +705,12 @@ BEGIN
 
   -- entry_group_templates: 남성 20-29, 여성 20-29
   IF NOT EXISTS (SELECT 1 FROM public.entry_group_templates WHERE party_id = party_id_) THEN
+    -- Fix #1772-review: 두 행 INSERT에 RETURNING INTO 하나 → "query returned more than one row" 에러.
+    -- group_m_id/group_f_id 는 이후에 쓰이지 않으므로 RETURNING 절 제거.
     INSERT INTO public.entry_group_templates (party_id, label, gender, birth_year_min, birth_year_max)
     VALUES
       (party_id_, '남성 그룹', 'male',   1995, 2004),
-      (party_id_, '여성 그룹', 'female', 1995, 2004)
-    RETURNING id INTO group_m_id;
+      (party_id_, '여성 그룹', 'female', 1995, 2004);
   END IF;
 
   -- ticket_templates: 일반 참가권 (무료, 20인)

--- a/supabase/seed.dev.sql
+++ b/supabase/seed.dev.sql
@@ -669,3 +669,54 @@ BEGIN
     END IF;
   END LOOP;
 END $$;
+
+-- Fix #1743: CUJ-P05 수정 위저드 테스트용 — entry_group_templates + ticket_templates 포함 파티.
+-- partner_hotplace_0 소속. 수정 위저드 진입 시 Step4/Step5에 기존 데이터가 로드되는지 확인.
+-- 멱등: 이미 존재하면 생성 건너뜀.
+DO $$
+DECLARE
+  partner_id_  uuid;
+  location_id_ uuid;
+  party_id_    uuid;
+  group_m_id   uuid;
+  group_f_id   uuid;
+BEGIN
+  SELECT id INTO partner_id_ FROM public.partners WHERE biz_number = '000-00-00000';
+  IF partner_id_ IS NULL THEN
+    RAISE NOTICE 'Fix #1743 seed: partner_hotplace_0 없음, 스킵.';
+    RETURN;
+  END IF;
+
+  SELECT id INTO location_id_ FROM public.locations
+  WHERE partner_id = partner_id_ AND name = '서울 강남' LIMIT 1;
+
+  -- CUJ-P05 전용 파티 (입장그룹 + 티켓 템플릿 포함)
+  SELECT id INTO party_id_ FROM public.parties
+  WHERE partner_id = partner_id_ AND title = '[QA] CUJ-P05 파티 수정 위저드 테스트';
+  IF party_id_ IS NULL THEN
+    INSERT INTO public.parties
+      (partner_id, location_id, title, max_participants, status, image_urls)
+    VALUES (
+      partner_id_, location_id_,
+      '[QA] CUJ-P05 파티 수정 위저드 테스트',
+      40, 'active',
+      ARRAY['https://picsum.photos/seed/minglit-qa-cuj-p05/800/600']
+    )
+    RETURNING id INTO party_id_;
+  END IF;
+
+  -- entry_group_templates: 남성 20-29, 여성 20-29
+  IF NOT EXISTS (SELECT 1 FROM public.entry_group_templates WHERE party_id = party_id_) THEN
+    INSERT INTO public.entry_group_templates (party_id, label, gender, birth_year_min, birth_year_max)
+    VALUES
+      (party_id_, '남성 그룹', 'male',   1995, 2004),
+      (party_id_, '여성 그룹', 'female', 1995, 2004)
+    RETURNING id INTO group_m_id;
+  END IF;
+
+  -- ticket_templates: 일반 참가권 (무료, 20인)
+  IF NOT EXISTS (SELECT 1 FROM public.ticket_templates WHERE party_id = party_id_) THEN
+    INSERT INTO public.ticket_templates (party_id, name, price, quantity)
+    VALUES (party_id_, '일반 참가권', 0, 20);
+  END IF;
+END $$;


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1743

## 분석

이슈 #1743은 파티 수정 위저드에서 기존 입장그룹(Step4)·티켓(Step5)이 로드되지 않는 문제다.

저장 버그는 #1740(PR #1739/1740)에서 이미 수정됨:
- `replaceEntryGroupTemplates`가 `entry_groups`(이벤트 레벨, `event_id NOT NULL`) 대신 `entry_group_templates`(파티 레벨)에 써야 하는 문제

**본 PR의 범위**: 로드 경로 회귀 검증 + QA 재현 환경 구비

## 변경 사항

### 1. `loadForEdit` 회귀 테스트 추가 (`party_create_wizard_controller_test.dart`)
- `pre-fills entryGroups and tickets from existing party data`: `party.entryGroups`와 `getTicketTemplatesByPartyId` 결과가 state에 올바르게 pre-fill됨을 검증
- `pre-fills empty lists when party has no entry groups or tickets`: 빈 데이터 케이스 검증
- `MockTagRepository` mock 추가 (`mocks.dart`)

### 2. CUJ-P05 시드 데이터 추가 (`seed.dev.sql`)
- `partner_hotplace_0` 파티에 `entry_group_templates`(남성/여성 그룹) + `ticket_templates`(일반 참가권) 포함
- CUJ-P05 독립 실행 가능 (CUJ-P01 먼저 실행 불필요)
- 멱등: 이미 존재하면 INSERT 건너뜀

## 테스트
- `party_create_wizard_controller_test.dart`: 21개 테스트 통과