### PR TITLE
fix(partner): dev flavor에 minglit-partner-dev:// deep link scheme 추가

### DIFF
--- a/apps/app_partner/android/app/src/dev/AndroidManifest.xml
+++ b/apps/app_partner/android/app/src/dev/AndroidManifest.xml
@@ -9,7 +9,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <!-- Fix #1776: minglit-partner-dev:// custom scheme (dev flavor only) -->
                 <!-- Mirrors app_user's minglit-dev:// — enables CUJ automation without coordinate tapping -->
-                <!-- adb: am start -a VIEW -d "minglit-partner-dev://dev/user-switch" com.minglit.app_partner.dev -->
+                <!-- adb: am start -a VIEW -d "minglit-partner-dev:///dev/user-switch" com.minglit.app_partner.dev -->
                 <data android:scheme="minglit-partner-dev" />
             </intent-filter>
         </activity>

--- a/apps/app_partner/android/app/src/dev/AndroidManifest.xml
+++ b/apps/app_partner/android/app/src/dev/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Dev flavor only: deep link + QA bug report receiver -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <application>
         <activity android:name=".MainActivity">
             <intent-filter>
@@ -12,6 +13,12 @@
                 <!-- adb: am start -a VIEW -d "minglit-partner-dev:///dev/user-switch" com.minglit.app_partner.dev -->
                 <data android:scheme="minglit-partner-dev" />
             </intent-filter>
+            <!-- Fix #1776: main manifest의 flutter_deeplinking_enabled=false를 dev에서 override -->
+            <!-- tools:replace 없이는 Gradle merge 시 main의 false가 우선됨 -->
+            <meta-data
+                android:name="flutter_deeplinking_enabled"
+                android:value="true"
+                tools:replace="android:value" />
         </activity>
         <!-- Dev-only: ADB intent receiver for QA automated bug reporting -->
         <receiver

--- a/apps/app_partner/android/app/src/dev/AndroidManifest.xml
+++ b/apps/app_partner/android/app/src/dev/AndroidManifest.xml
@@ -1,5 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Dev flavor only: deep link + QA bug report receiver -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <!-- Fix #1776: minglit-partner-dev:// custom scheme (dev flavor only) -->
+                <!-- Mirrors app_user's minglit-dev:// — enables CUJ automation without coordinate tapping -->
+                <!-- adb: am start -a VIEW -d "minglit-partner-dev://dev/user-switch" com.minglit.app_partner.dev -->
+                <data android:scheme="minglit-partner-dev" />
+            </intent-filter>
+        </activity>
         <!-- Dev-only: ADB intent receiver for QA automated bug reporting -->
         <receiver
             android:name=".QaBugReportReceiver"


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1776

## 문제

`app_user` dev manifest에는 `minglit-dev://` scheme이 존재해 CUJ 자동화에서
`adb shell am start -a android.intent.action.VIEW`로 특정 라우트(DevUserSwitchScreen 등)에 직접 진입 가능.

`app_partner`에는 이 scheme이 없어서 DevUserSwitchScreen 진입 시 좌표 기반 탭에 의존하다 실패.

## Root Cause

`apps/app_partner/android/app/src/dev/AndroidManifest.xml`에 deep link intent-filter가 없음.  
`apps/app_user`와 달리 QA bot의 좌표 기반 탭(y=200, y=560, y=650)은 로고 위치(스크린 중앙 ~y=900)와 맞지 않아 5-tap 감지 실패.

## 수정

`app_partner` dev manifest에 `minglit-partner-dev://` scheme intent-filter 추가:

```bash
# DevUserSwitchScreen 진입
adb shell am start -a android.intent.action.VIEW \
  -d "minglit-partner-dev:///dev/user-switch" \
  com.minglit.app_partner.dev
```

GoRouter redirect에서 `/dev/*` 경로는 인증 없이 허용 — DevUserSwitchScreen에 바로 진입 가능.

## Bug 1 분석

`am force-stop`은 앱 데이터를 지우지 않으므로 토큰 만료 또는 기기 특이적 FlutterSecureStorage 이슈로 추정. Bug 2 해결 시 CUJ 봇이 재로그인 처리 가능.

## 변경 범위

`apps/app_partner/android/app/src/dev/AndroidManifest.xml` only — production 빌드에 영향 없음.