### PR TITLE
fix(ci): Patrol E2E — androidx.test:runner 1.6.2→1.5.1 버전 충돌 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,8 +375,35 @@ jobs:
           fi
           echo "✅ All workflow YAML files are valid"
 
+  # Fix #1780: androidx.test runner/orchestrator 버전 정합성 검증
+  # runner와 orchestrator는 동일 major.minor 계열이어야 함 (1.5.x↔1.5.x, 1.6.x↔1.6.x)
+  # Gradle consistent resolution이 혼용 시 빌드 실패를 발생시키므로 PR 단계에서 사전 차단.
+  check-android-test-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify androidx.test runner/orchestrator version alignment
+        run: |
+          GRADLE_FILE="apps/app_user/android/app/build.gradle.kts"
+          RUNNER=$(grep 'androidx\.test:runner:' "$GRADLE_FILE" | grep -oP '\d+\.\d+\.\d+' | head -1)
+          ORCHESTRATOR=$(grep 'androidx\.test:orchestrator:' "$GRADLE_FILE" | grep -oP '\d+\.\d+\.\d+' | head -1)
+          echo "runner: $RUNNER"
+          echo "orchestrator: $ORCHESTRATOR"
+          if [ -z "$RUNNER" ] || [ -z "$ORCHESTRATOR" ]; then
+            echo "❌ Could not parse runner or orchestrator version from $GRADLE_FILE"
+            exit 1
+          fi
+          RUNNER_MINOR=$(echo "$RUNNER" | cut -d. -f1,2)
+          ORCHESTRATOR_MINOR=$(echo "$ORCHESTRATOR" | cut -d. -f1,2)
+          if [ "$RUNNER_MINOR" != "$ORCHESTRATOR_MINOR" ]; then
+            echo "❌ Version mismatch: runner $RUNNER vs orchestrator $ORCHESTRATOR"
+            echo "Both must share the same major.minor series (e.g., both 1.5.x or both 1.6.x)"
+            exit 1
+          fi
+          echo "✅ runner $RUNNER and orchestrator $ORCHESTRATOR are compatible ($RUNNER_MINOR series)"
+
   ci-result:
-    needs: [check-migration-versions, check-env-manifest-sync, check-workflow-yaml, test-flutter-apps, lint-landing-user, lint-landing-partner, test-supabase, test-edge-functions]
+    needs: [check-migration-versions, check-env-manifest-sync, check-workflow-yaml, check-android-test-deps, test-flutter-apps, lint-landing-user, lint-landing-partner, test-supabase, test-edge-functions]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/apps/app_user/android/app/build.gradle.kts
+++ b/apps/app_user/android/app/build.gradle.kts
@@ -77,7 +77,8 @@ android {
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
-    androidTestImplementation("androidx.test:runner:1.6.2")
+    // Fix #1780: runner 1.6.2 vs orchestrator 1.5.1 버전 충돌 — 같은 1.5.x 계열로 정렬
+    androidTestImplementation("androidx.test:runner:1.5.1")
     androidTestUtil("androidx.test:orchestrator:1.5.1")
 }
 


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 문제

`androidx.test:runner:1.6.2` + `androidx.test:orchestrator:1.5.1` 혼용으로 Gradle consistent resolution 충돌 발생 → Patrol E2E CI 5회 연속 실패.

## 수정

`runner`를 `1.5.1`로 downgrade하여 `orchestrator 1.5.1`과 버전 정렬.

```kotlin
// Before
androidTestImplementation("androidx.test:runner:1.6.2")
androidTestUtil("androidx.test:orchestrator:1.5.1")

// After
androidTestImplementation("androidx.test:runner:1.5.1")
androidTestUtil("androidx.test:orchestrator:1.5.1")
```

## 검증

- orchestrator 1.5.1 ↔ runner 1.5.x는 공식 호환 쌍
- Patrol 4.5.0은 runner 1.5.x 호환

Closes #1780