### PR TITLE
refactor(ef): partner-manage-party 842 lines → action dispatch 패턴 분해 (#1785)

### DIFF
--- a/supabase/functions/partner-manage-party/index.ts
+++ b/supabase/functions/partner-manage-party/index.ts
@@ -10,6 +10,7 @@ import {
 import { requireAuth } from "../_shared/auth_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
 import { initSentry, withHandler } from "../_shared/logger.ts";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
 initSentry();
 
@@ -55,15 +56,23 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
   }
 }));
 
-async function handleRequest(req: Request): Promise<Response> {
-  // 1. Environment check (handled by createServiceClient)
+type ActionHandler = (
+  body: Record<string, unknown>,
+  supabase: SupabaseClient,
+  userId: string,
+) => Promise<Response>;
 
-  // 2. Auth
+const DISPATCH: Record<string, ActionHandler> = {
+  create: handleCreate,
+  update: handleUpdate,
+  update_status: handleUpdateStatus,
+};
+
+async function handleRequest(req: Request): Promise<Response> {
   const auth = await requireAuth(req);
   if (auth instanceof Response) return auth;
   const userId = auth;
 
-  // 3. Parse body
   let body: Record<string, unknown>;
   try {
     const parsed = await req.json();
@@ -82,42 +91,306 @@ async function handleRequest(req: Request): Promise<Response> {
     return errorResponse("Missing action", 400);
   }
 
-  // 4. Supabase client (service role)
   const supabase = createServiceClient();
+  const handler = DISPATCH[action];
+  if (!handler) return errorResponse(`Unknown action: ${action}`, 400);
+  return handler(body, supabase, userId);
+}
 
-  // ─── create ───
-  if (action === "create") {
-    // Require partner_id from client (supports multi-partner users)
-    const partnerId = body.partner_id;
-    if (typeof partnerId !== "string" || !partnerId) {
-      return errorResponse("Missing partner_id", 400);
-    }
+async function handleCreate(
+  body: Record<string, unknown>,
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<Response> {
+  // Require partner_id from client (supports multi-partner users)
+  const partnerId = body.partner_id;
+  if (typeof partnerId !== "string" || !partnerId) {
+    return errorResponse("Missing partner_id", 400);
+  }
 
-    // Validate party fields
-    const partyData = body.party;
+  // Validate party fields
+  const partyData = body.party;
+  if (
+    typeof partyData !== "object" || partyData === null ||
+    Array.isArray(partyData)
+  ) {
+    return errorResponse("Missing or invalid party object", 400);
+  }
+  const party = partyData as Record<string, unknown>;
+
+  if (typeof party.title !== "string" || !party.title.trim()) {
+    return errorResponse("Missing party title", 400);
+  }
+
+  // Check partner permission
+  const permCheck = await requirePartnerPermission(supabase, partnerId, userId, ["PARTY_MANAGE"]);
+  if (permCheck) return permCheck;
+
+  // ── Pre-validate all payloads before any DB writes ──
+
+  // Validate status if provided
+  if (party.status !== undefined) {
     if (
-      typeof partyData !== "object" || partyData === null ||
-      Array.isArray(partyData)
+      typeof party.status !== "string" ||
+      !VALID_STATUSES.includes(party.status)
     ) {
-      return errorResponse("Missing or invalid party object", 400);
+      return errorResponse(
+        `Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}`,
+        400,
+      );
     }
+  }
+
+  // Validate location input if new location
+  let newLocationInput: Record<string, unknown> | null = null;
+  const existingLocationId = body.location_id;
+  if (
+    body.location && typeof body.location === "object" &&
+    !Array.isArray(body.location)
+  ) {
+    newLocationInput = body.location as Record<string, unknown>;
+    if (
+      typeof newLocationInput.name !== "string" ||
+      !newLocationInput.name.trim()
+    ) {
+      return errorResponse("Missing location name", 400);
+    }
+    if (
+      typeof newLocationInput.address !== "string" ||
+      !newLocationInput.address.trim()
+    ) {
+      return errorResponse("Missing location address", 400);
+    }
+  }
+
+  // Validate tag_ids if provided (must validate before any DB write)
+  // Fix #1136: tag_ids 검증을 party INSERT 전으로 이동 — 잘못된 입력 시 고아 row 방지
+  const rawTagIds = body.tag_ids;
+  // Fix #1182: deduplicate tag_ids before validation (#13)
+  const tagIds = rawTagIds !== undefined && Array.isArray(rawTagIds)
+    ? [...new Set(rawTagIds as string[])]
+    : rawTagIds;
+  if (tagIds !== undefined) {
+    if (!Array.isArray(tagIds)) {
+      return errorResponse("tag_ids must be an array", 400);
+    }
+    if (tagIds.length > 5) {
+      return errorResponse("tag_ids must contain at most 5 tags", 400);
+    }
+    // Fix #1182: UUID format validation (#12)
+    const UUID_RE =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    for (let i = 0; i < tagIds.length; i++) {
+      if (!UUID_RE.test(tagIds[i])) {
+        return errorResponse(`tag_ids[${i}] must be a valid UUID`, 400);
+      }
+    }
+    // Fix #1136: validate tag IDs exist before party creation
+    // Prevents orphaned party rows when FK constraint would fail during party_tags INSERT
+    if (tagIds.length > 0) {
+      const { data: existingTags, error: tagCheckError } = await supabase
+        .from("tags")
+        .select("id")
+        .in("id", tagIds as string[]);
+      if (tagCheckError) {
+        return errorResponse("Failed to validate tag IDs", 500);
+      }
+      if (
+        !existingTags || existingTags.length !== (tagIds as string[]).length
+      ) {
+        return errorResponse("One or more tag_ids do not exist", 400);
+      }
+    }
+  }
+
+  // Validate entry_group_templates
+  const entryGroupTemplates = body.entry_group_templates;
+  if (Array.isArray(entryGroupTemplates) && entryGroupTemplates.length > 0) {
+    const validationError = validateEntryGroupTemplates(entryGroupTemplates);
+    if (validationError) return validationError;
+  }
+
+  // Validate ticket_templates
+  const ticketTemplates = body.ticket_templates;
+  if (Array.isArray(ticketTemplates) && ticketTemplates.length > 0) {
+    const validationError = validateTicketTemplates(ticketTemplates);
+    if (validationError) return validationError;
+  }
+
+  // ── All validations passed — now perform DB writes ──
+
+  // Build location record if provided
+  let locationId: string | null = null;
+  if (typeof existingLocationId === "string" && existingLocationId) {
+    // Use existing location — verify it belongs to this partner
+    const { data: loc, error: locError } = await supabase
+      .from("locations")
+      .select("id, partner_id")
+      .eq("id", existingLocationId)
+      .maybeSingle();
+
+    if (locError) return errorResponse("Failed to verify location", 500);
+    if (!loc) return errorResponse("Location not found", 404);
+    if (loc.partner_id !== partnerId) {
+      return errorResponse(
+        "Forbidden: location belongs to another partner",
+        403,
+      );
+    }
+    locationId = existingLocationId;
+  } else if (newLocationInput) {
+    const locRecord: Record<string, unknown> = { partner_id: partnerId };
+    for (const field of LOCATION_FIELDS) {
+      if (newLocationInput[field] !== undefined) {
+        locRecord[field] = newLocationInput[field];
+      }
+    }
+
+    const { data: newLoc, error: locInsertError } = await supabase
+      .from("locations")
+      .insert(locRecord)
+      .select("id")
+      .single();
+
+    if (locInsertError) {
+      return errorResponse(
+        `Failed to create location: ${locInsertError.message}`,
+        500,
+      );
+    }
+    locationId = newLoc.id;
+  }
+
+  // Build party record — only allow whitelisted fields
+  const partyRecord: Record<string, unknown> = {
+    partner_id: partnerId,
+  };
+  if (locationId) partyRecord.location_id = locationId;
+
+  for (const field of PARTY_FIELDS) {
+    if (party[field] !== undefined) {
+      partyRecord[field] = party[field];
+    }
+  }
+
+  // Fix #1223: parties INSERT + party_tags INSERT を RPC로 원자적 처리
+  // 기존 2단계 write(INSERT parties → INSERT party_tags) 는 2단계 실패 시 고아 row 발생.
+  // create_party_with_tags RPC 가 단일 트랜잭션으로 두 write를 묶어 처리한다.
+  const { data: rpcData, error: rpcError } = await supabase
+    .rpc("create_party_with_tags", {
+      p_party: partyRecord,
+      p_tag_ids: Array.isArray(tagIds) ? tagIds as string[] : [],
+    });
+
+  if (rpcError) {
+    return errorResponse(`Failed to create party: ${rpcError.message}`, 500);
+  }
+  if (!rpcData) {
+    return errorResponse("Failed to create party: no party_id returned", 500);
+  }
+
+  const partyId = rpcData as string;
+
+  // Insert entry_group_templates if provided (already validated above)
+  if (Array.isArray(entryGroupTemplates) && entryGroupTemplates.length > 0) {
+    const egt = entryGroupTemplates.map((t: Record<string, unknown>) => ({
+      party_id: partyId,
+      label: t.label ?? null,
+      gender: t.gender ?? null,
+      birth_year_min: t.birth_year_min ?? null,
+      birth_year_max: t.birth_year_max ?? null,
+      required_verification_ids: t.required_verification_ids ?? [],
+    }));
+
+    const { error: egtError } = await supabase
+      .from("entry_group_templates")
+      .insert(egt);
+
+    if (egtError) {
+      return errorResponse(
+        `Failed to create entry group templates: ${egtError.message}`,
+        500,
+      );
+    }
+  }
+
+  // Insert ticket_templates if provided (already validated above)
+  if (Array.isArray(ticketTemplates) && ticketTemplates.length > 0) {
+    const tt = ticketTemplates.map((t: Record<string, unknown>) => ({
+      party_id: partyId,
+      name: t.name,
+      description: t.description ?? null,
+      price: t.price ?? 0,
+      quantity: t.quantity,
+      target_entry_group_ids: t.target_entry_group_ids ?? [],
+      required_verification_ids: t.required_verification_ids ?? [],
+    }));
+
+    const { error: ttError } = await supabase
+      .from("ticket_templates")
+      .insert(tt);
+
+    if (ttError) {
+      return errorResponse(
+        `Failed to create ticket templates: ${ttError.message}`,
+        500,
+      );
+    }
+  }
+
+  return successResponse({ success: true, party_id: partyId });
+}
+
+async function handleUpdate(
+  body: Record<string, unknown>,
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<Response> {
+  const partyId = body.party_id;
+  if (typeof partyId !== "string" || !partyId) {
+    return errorResponse("Missing party_id", 400);
+  }
+
+  // Fetch party to verify ownership
+  const { data: existingParty, error: fetchError } = await supabase
+    .from("parties")
+    .select("id, partner_id")
+    .eq("id", partyId)
+    .maybeSingle();
+
+  if (fetchError) return errorResponse("Failed to load party", 500);
+  if (!existingParty) return errorResponse("Party not found", 404);
+
+  // Check partner permission
+  const permCheck = await requirePartnerPermission(
+    supabase,
+    existingParty.partner_id,
+    userId,
+    ["PARTY_MANAGE"],
+  );
+  if (permCheck) return permCheck;
+
+  // ── Pre-validate all payloads before any DB writes ──
+
+  // Build party updates
+  const partyData = body.party;
+  const partyUpdates: Record<string, unknown> = {};
+  if (
+    typeof partyData === "object" && partyData !== null &&
+    !Array.isArray(partyData)
+  ) {
     const party = partyData as Record<string, unknown>;
-
-    if (typeof party.title !== "string" || !party.title.trim()) {
-      return errorResponse("Missing party title", 400);
+    for (const field of PARTY_FIELDS) {
+      if (party[field] !== undefined) {
+        partyUpdates[field] = party[field];
+      }
     }
-
-    // Check partner permission
-    const permCheck = await requirePartnerPermission(supabase, partnerId, userId, ["PARTY_MANAGE"]);
-    if (permCheck) return permCheck;
-
-    // ── Pre-validate all payloads before any DB writes ──
 
     // Validate status if provided
-    if (party.status !== undefined) {
+    if (partyUpdates.status !== undefined) {
       if (
-        typeof party.status !== "string" ||
-        !VALID_STATUSES.includes(party.status)
+        typeof partyUpdates.status !== "string" ||
+        !VALID_STATUSES.includes(partyUpdates.status)
       ) {
         return errorResponse(
           `Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}`,
@@ -125,160 +398,283 @@ async function handleRequest(req: Request): Promise<Response> {
         );
       }
     }
+  }
 
-    // Validate location input if new location
-    let newLocationInput: Record<string, unknown> | null = null;
-    const existingLocationId = body.location_id;
-    if (
-      body.location && typeof body.location === "object" &&
-      !Array.isArray(body.location)
-    ) {
-      newLocationInput = body.location as Record<string, unknown>;
+  // Validate tag_ids before any DB writes
+  // Fix #1136: tag_ids 검증을 모든 write 전으로 이동 — 부분 업데이트 방지
+  const rawUpdateTagIds = body.tag_ids;
+  // Fix #1182: deduplicate tag_ids before validation (#13)
+  const updateTagIds =
+    rawUpdateTagIds !== undefined && Array.isArray(rawUpdateTagIds)
+      ? [...new Set(rawUpdateTagIds as string[])]
+      : rawUpdateTagIds;
+  if (updateTagIds !== undefined) {
+    if (!Array.isArray(updateTagIds)) {
+      return errorResponse("tag_ids must be an array", 400);
+    }
+    if (updateTagIds.length > 5) {
+      return errorResponse("tag_ids must contain at most 5 tags", 400);
+    }
+    // Fix #1182: UUID format validation (#12)
+    const UUID_RE =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    for (let i = 0; i < updateTagIds.length; i++) {
+      if (!UUID_RE.test(updateTagIds[i])) {
+        return errorResponse(`tag_ids[${i}] must be a valid UUID`, 400);
+      }
+    }
+    // Validate tag IDs exist in the database — prevents partial writes
+    // if FK constraint would fail during the INSERT phase
+    if (updateTagIds.length > 0) {
+      const { data: existingTags, error: tagCheckError } = await supabase
+        .from("tags")
+        .select("id")
+        .in("id", updateTagIds as string[]);
+      if (tagCheckError) {
+        return errorResponse("Failed to validate tag IDs", 500);
+      }
       if (
-        typeof newLocationInput.name !== "string" ||
-        !newLocationInput.name.trim()
+        !existingTags ||
+        existingTags.length !== (updateTagIds as string[]).length
       ) {
-        return errorResponse("Missing location name", 400);
-      }
-      if (
-        typeof newLocationInput.address !== "string" ||
-        !newLocationInput.address.trim()
-      ) {
-        return errorResponse("Missing location address", 400);
+        return errorResponse("One or more tag_ids do not exist", 400);
       }
     }
+  }
 
-    // Validate tag_ids if provided (must validate before any DB write)
-    // Fix #1136: tag_ids 검증을 party INSERT 전으로 이동 — 잘못된 입력 시 고아 row 방지
-    const rawTagIds = body.tag_ids;
-    // Fix #1182: deduplicate tag_ids before validation (#13)
-    const tagIds = rawTagIds !== undefined && Array.isArray(rawTagIds)
-      ? [...new Set(rawTagIds as string[])]
-      : rawTagIds;
-    if (tagIds !== undefined) {
-      if (!Array.isArray(tagIds)) {
-        return errorResponse("tag_ids must be an array", 400);
-      }
-      if (tagIds.length > 5) {
-        return errorResponse("tag_ids must contain at most 5 tags", 400);
-      }
-      // Fix #1182: UUID format validation (#12)
-      const UUID_RE =
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-      for (let i = 0; i < tagIds.length; i++) {
-        if (!UUID_RE.test(tagIds[i])) {
-          return errorResponse(`tag_ids[${i}] must be a valid UUID`, 400);
+  // Fix #1733: entry_group_templates 업데이트 검증 (write 전 사전 검증)
+  const updateEntryGroupTemplates = body.entry_group_templates;
+  if (updateEntryGroupTemplates !== undefined) {
+    if (!Array.isArray(updateEntryGroupTemplates)) {
+      return errorResponse("entry_group_templates must be an array", 400);
+    }
+    const egtValidationError = validateEntryGroupTemplates(
+      updateEntryGroupTemplates,
+    );
+    if (egtValidationError) return egtValidationError;
+  }
+
+  if (
+    Object.keys(partyUpdates).length === 0 &&
+    !body.location &&
+    body.location_id === undefined &&
+    updateTagIds === undefined &&
+    updateEntryGroupTemplates === undefined
+  ) {
+    return errorResponse("No fields to update", 400);
+  }
+
+  // ── All validations passed — now perform DB writes ──
+
+  // Update party fields if any
+  if (Object.keys(partyUpdates).length > 0) {
+    const { error: updateError } = await supabase
+      .from("parties")
+      .update(partyUpdates)
+      .eq("id", partyId);
+
+    if (updateError) {
+      return errorResponse(
+        `Failed to update party: ${updateError.message}`,
+        500,
+      );
+    }
+  }
+
+  // Update location if provided
+  const locationData = body.location;
+  if (
+    typeof locationData === "object" && locationData !== null &&
+    !Array.isArray(locationData)
+  ) {
+    const locInput = locationData as Record<string, unknown>;
+
+    // Check if party has a location_id to update
+    const { data: partyWithLoc, error: locFetchError } = await supabase
+      .from("parties")
+      .select("location_id")
+      .eq("id", partyId)
+      .single();
+
+    if (locFetchError) {
+      return errorResponse("Failed to fetch party location", 500);
+    }
+
+    if (partyWithLoc.location_id) {
+      // Update existing location
+      const locUpdates: Record<string, unknown> = {};
+      for (const field of LOCATION_FIELDS) {
+        if (locInput[field] !== undefined) {
+          locUpdates[field] = locInput[field];
         }
       }
-      // Fix #1136: validate tag IDs exist before party creation
-      // Prevents orphaned party rows when FK constraint would fail during party_tags INSERT
-      if (tagIds.length > 0) {
-        const { data: existingTags, error: tagCheckError } = await supabase
-          .from("tags")
-          .select("id")
-          .in("id", tagIds as string[]);
-        if (tagCheckError) {
-          return errorResponse("Failed to validate tag IDs", 500);
-        }
-        if (
-          !existingTags || existingTags.length !== (tagIds as string[]).length
-        ) {
-          return errorResponse("One or more tag_ids do not exist", 400);
+
+      if (Object.keys(locUpdates).length > 0) {
+        const { error: locUpdateError } = await supabase
+          .from("locations")
+          .update(locUpdates)
+          .eq("id", partyWithLoc.location_id);
+
+        if (locUpdateError) {
+          return errorResponse(
+            `Failed to update location: ${locUpdateError.message}`,
+            500,
+          );
         }
       }
     }
+  }
 
-    // Validate entry_group_templates
-    const entryGroupTemplates = body.entry_group_templates;
-    if (Array.isArray(entryGroupTemplates) && entryGroupTemplates.length > 0) {
-      const validationError = validateEntryGroupTemplates(entryGroupTemplates);
-      if (validationError) return validationError;
-    }
-
-    // Validate ticket_templates
-    const ticketTemplates = body.ticket_templates;
-    if (Array.isArray(ticketTemplates) && ticketTemplates.length > 0) {
-      const validationError = validateTicketTemplates(ticketTemplates);
-      if (validationError) return validationError;
-    }
-
-    // ── All validations passed — now perform DB writes ──
-
-    // Build location record if provided
-    let locationId: string | null = null;
-    if (typeof existingLocationId === "string" && existingLocationId) {
-      // Use existing location — verify it belongs to this partner
+  // Handle location_id change
+  if (body.location_id !== undefined) {
+    const newLocationId = body.location_id as string | null;
+    if (newLocationId !== null) {
+      // Verify location belongs to the same partner
       const { data: loc, error: locError } = await supabase
         .from("locations")
         .select("id, partner_id")
-        .eq("id", existingLocationId)
+        .eq("id", newLocationId)
         .maybeSingle();
 
       if (locError) return errorResponse("Failed to verify location", 500);
       if (!loc) return errorResponse("Location not found", 404);
-      if (loc.partner_id !== partnerId) {
+      if (loc.partner_id !== existingParty.partner_id) {
         return errorResponse(
           "Forbidden: location belongs to another partner",
           403,
         );
       }
-      locationId = existingLocationId;
-    } else if (newLocationInput) {
-      const locRecord: Record<string, unknown> = { partner_id: partnerId };
-      for (const field of LOCATION_FIELDS) {
-        if (newLocationInput[field] !== undefined) {
-          locRecord[field] = newLocationInput[field];
-        }
-      }
+    }
 
-      const { data: newLoc, error: locInsertError } = await supabase
-        .from("locations")
-        .insert(locRecord)
-        .select("id")
-        .single();
+    const { error: locIdError } = await supabase
+      .from("parties")
+      .update({ location_id: newLocationId })
+      .eq("id", partyId);
 
-      if (locInsertError) {
+    if (locIdError) {
+      return errorResponse(
+        `Failed to update party location: ${locIdError.message}`,
+        500,
+      );
+    }
+  }
+
+  // Update party_tags if tag_ids present in body (undefined = no change, [] = clear all)
+  // Fix #1223: 2단계 DELETE+UPSERT 를 RPC로 원자적 처리
+  // update_party_tags RPC 가 단일 트랜잭션으로 DELETE stale rows → INSERT new rows 처리.
+  // Fix #1149 패턴(DELETE-first)도 RPC 내부에서 동일하게 유지됨.
+  if (updateTagIds !== undefined) {
+    const { error: ptRpcError } = await supabase
+      .rpc("update_party_tags", {
+        p_party_id: partyId,
+        p_tag_ids: updateTagIds as string[],
+      });
+    if (ptRpcError) {
+      return errorResponse(
+        `Failed to update party tags: ${ptRpcError.message}`,
+        500,
+      );
+    }
+  }
+
+  // Fix #1733: UPSERT + selective DELETE — 기존 ID 보존으로 ticket_templates 링크 유지
+  if (updateEntryGroupTemplates !== undefined) {
+    const templates = updateEntryGroupTemplates as Record<string, unknown>[];
+
+    const { data: existing, error: fetchExistingError } = await supabase
+      .from("entry_group_templates")
+      .select("id")
+      .eq("party_id", partyId);
+    if (fetchExistingError) {
+      return errorResponse(
+        `Failed to fetch existing entry group templates: ${fetchExistingError.message}`,
+        500,
+      );
+    }
+
+    const existingIds = (existing ?? []).map((r: { id: string }) =>
+      r.id as string
+    );
+    const incomingWithId = templates.filter((t) =>
+      typeof t.id === "string" && (t.id as string).length > 0
+    );
+    const incomingWithoutId = templates.filter((t) =>
+      !t.id || (t.id as string).length === 0
+    );
+    const keptIds = incomingWithId.map((t) => t.id as string);
+    const toDeleteIds = existingIds.filter((id: string) =>
+      !keptIds.includes(id)
+    );
+
+    if (toDeleteIds.length > 0) {
+      const { data: affectedTickets, error: fetchTicketsError } =
+        await supabase
+          .from("ticket_templates")
+          .select("id, target_entry_group_ids")
+          .eq("party_id", partyId);
+      if (fetchTicketsError) {
         return errorResponse(
-          `Failed to create location: ${locInsertError.message}`,
+          `Failed to fetch ticket templates: ${fetchTicketsError.message}`,
           500,
         );
       }
-      locationId = newLoc.id;
-    }
 
-    // Build party record — only allow whitelisted fields
-    const partyRecord: Record<string, unknown> = {
-      partner_id: partnerId,
-    };
-    if (locationId) partyRecord.location_id = locationId;
+      for (const ticket of (affectedTickets ?? [])) {
+        const tt = ticket as { id: string; target_entry_group_ids: string[] };
+        const hadAny = toDeleteIds.some((d) =>
+          tt.target_entry_group_ids?.includes(d)
+        );
+        if (hadAny) {
+          const updatedIds = (tt.target_entry_group_ids ?? []).filter((
+            id: string,
+          ) => !toDeleteIds.includes(id));
+          const { error: ttUpdateError } = await supabase
+            .from("ticket_templates")
+            .update({ target_entry_group_ids: updatedIds })
+            .eq("id", tt.id);
+          if (ttUpdateError) {
+            return errorResponse(
+              `Failed to update ticket template references: ${ttUpdateError.message}`,
+              500,
+            );
+          }
+        }
+      }
 
-    for (const field of PARTY_FIELDS) {
-      if (party[field] !== undefined) {
-        partyRecord[field] = party[field];
+      const { error: deleteEgtError } = await supabase
+        .from("entry_group_templates")
+        .delete()
+        .in("id", toDeleteIds);
+      if (deleteEgtError) {
+        return errorResponse(
+          `Failed to delete entry group templates: ${deleteEgtError.message}`,
+          500,
+        );
       }
     }
 
-    // Fix #1223: parties INSERT + party_tags INSERT を RPC로 원자적 처리
-    // 기존 2단계 write(INSERT parties → INSERT party_tags) 는 2단계 실패 시 고아 row 발생.
-    // create_party_with_tags RPC 가 단일 트랜잭션으로 두 write를 묶어 처리한다.
-    const { data: rpcData, error: rpcError } = await supabase
-      .rpc("create_party_with_tags", {
-        p_party: partyRecord,
-        p_tag_ids: Array.isArray(tagIds) ? tagIds as string[] : [],
-      });
-
-    if (rpcError) {
-      return errorResponse(`Failed to create party: ${rpcError.message}`, 500);
+    for (const t of incomingWithId) {
+      const { error: updateEgtError } = await supabase
+        .from("entry_group_templates")
+        .update({
+          label: t.label ?? null,
+          gender: t.gender ?? null,
+          birth_year_min: t.birth_year_min ?? null,
+          birth_year_max: t.birth_year_max ?? null,
+          required_verification_ids: t.required_verification_ids ?? [],
+        })
+        .eq("id", t.id as string)
+        .eq("party_id", partyId);
+      if (updateEgtError) {
+        return errorResponse(
+          `Failed to update entry group template: ${updateEgtError.message}`,
+          500,
+        );
+      }
     }
-    if (!rpcData) {
-      return errorResponse("Failed to create party: no party_id returned", 500);
-    }
 
-    const partyId = rpcData as string;
-
-    // Insert entry_group_templates if provided (already validated above)
-    if (Array.isArray(entryGroupTemplates) && entryGroupTemplates.length > 0) {
-      const egt = entryGroupTemplates.map((t: Record<string, unknown>) => ({
+    if (incomingWithoutId.length > 0) {
+      const newTemplates = incomingWithoutId.map((t) => ({
         party_id: partyId,
         label: t.label ?? null,
         gender: t.gender ?? null,
@@ -286,449 +682,71 @@ async function handleRequest(req: Request): Promise<Response> {
         birth_year_max: t.birth_year_max ?? null,
         required_verification_ids: t.required_verification_ids ?? [],
       }));
-
-      const { error: egtError } = await supabase
+      const { error: insertEgtError } = await supabase
         .from("entry_group_templates")
-        .insert(egt);
-
-      if (egtError) {
+        .insert(newTemplates);
+      if (insertEgtError) {
         return errorResponse(
-          `Failed to create entry group templates: ${egtError.message}`,
+          `Failed to insert new entry group templates: ${insertEgtError.message}`,
           500,
         );
       }
     }
-
-    // Insert ticket_templates if provided (already validated above)
-    if (Array.isArray(ticketTemplates) && ticketTemplates.length > 0) {
-      const tt = ticketTemplates.map((t: Record<string, unknown>) => ({
-        party_id: partyId,
-        name: t.name,
-        description: t.description ?? null,
-        price: t.price ?? 0,
-        quantity: t.quantity,
-        target_entry_group_ids: t.target_entry_group_ids ?? [],
-        required_verification_ids: t.required_verification_ids ?? [],
-      }));
-
-      const { error: ttError } = await supabase
-        .from("ticket_templates")
-        .insert(tt);
-
-      if (ttError) {
-        return errorResponse(
-          `Failed to create ticket templates: ${ttError.message}`,
-          500,
-        );
-      }
-    }
-
-    return successResponse({ success: true, party_id: partyId });
   }
 
-  // ─── update ───
-  if (action === "update") {
-    const partyId = body.party_id;
-    if (typeof partyId !== "string" || !partyId) {
-      return errorResponse("Missing party_id", 400);
-    }
+  return successResponse({ success: true });
+}
 
-    // Fetch party to verify ownership
-    const { data: existingParty, error: fetchError } = await supabase
-      .from("parties")
-      .select("id, partner_id")
-      .eq("id", partyId)
-      .maybeSingle();
+async function handleUpdateStatus(
+  body: Record<string, unknown>,
+  supabase: SupabaseClient,
+  userId: string,
+): Promise<Response> {
+  const partyId = body.party_id;
+  if (typeof partyId !== "string" || !partyId) {
+    return errorResponse("Missing party_id", 400);
+  }
 
-    if (fetchError) return errorResponse("Failed to load party", 500);
-    if (!existingParty) return errorResponse("Party not found", 404);
-
-    // Check partner permission
-    const permCheck = await requirePartnerPermission(
-      supabase,
-      existingParty.partner_id,
-      userId,
-      ["PARTY_MANAGE"],
+  const status = body.status;
+  if (typeof status !== "string" || !VALID_STATUSES.includes(status)) {
+    return errorResponse(
+      `Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}`,
+      400,
     );
-    if (permCheck) return permCheck;
-
-    // ── Pre-validate all payloads before any DB writes ──
-
-    // Build party updates
-    const partyData = body.party;
-    const partyUpdates: Record<string, unknown> = {};
-    if (
-      typeof partyData === "object" && partyData !== null &&
-      !Array.isArray(partyData)
-    ) {
-      const party = partyData as Record<string, unknown>;
-      for (const field of PARTY_FIELDS) {
-        if (party[field] !== undefined) {
-          partyUpdates[field] = party[field];
-        }
-      }
-
-      // Validate status if provided
-      if (partyUpdates.status !== undefined) {
-        if (
-          typeof partyUpdates.status !== "string" ||
-          !VALID_STATUSES.includes(partyUpdates.status)
-        ) {
-          return errorResponse(
-            `Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}`,
-            400,
-          );
-        }
-      }
-    }
-
-    // Validate tag_ids before any DB writes
-    // Fix #1136: tag_ids 검증을 모든 write 전으로 이동 — 부분 업데이트 방지
-    const rawUpdateTagIds = body.tag_ids;
-    // Fix #1182: deduplicate tag_ids before validation (#13)
-    const updateTagIds =
-      rawUpdateTagIds !== undefined && Array.isArray(rawUpdateTagIds)
-        ? [...new Set(rawUpdateTagIds as string[])]
-        : rawUpdateTagIds;
-    if (updateTagIds !== undefined) {
-      if (!Array.isArray(updateTagIds)) {
-        return errorResponse("tag_ids must be an array", 400);
-      }
-      if (updateTagIds.length > 5) {
-        return errorResponse("tag_ids must contain at most 5 tags", 400);
-      }
-      // Fix #1182: UUID format validation (#12)
-      const UUID_RE =
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-      for (let i = 0; i < updateTagIds.length; i++) {
-        if (!UUID_RE.test(updateTagIds[i])) {
-          return errorResponse(`tag_ids[${i}] must be a valid UUID`, 400);
-        }
-      }
-      // Validate tag IDs exist in the database — prevents partial writes
-      // if FK constraint would fail during the INSERT phase
-      if (updateTagIds.length > 0) {
-        const { data: existingTags, error: tagCheckError } = await supabase
-          .from("tags")
-          .select("id")
-          .in("id", updateTagIds as string[]);
-        if (tagCheckError) {
-          return errorResponse("Failed to validate tag IDs", 500);
-        }
-        if (
-          !existingTags ||
-          existingTags.length !== (updateTagIds as string[]).length
-        ) {
-          return errorResponse("One or more tag_ids do not exist", 400);
-        }
-      }
-    }
-
-    // Fix #1733: entry_group_templates 업데이트 검증 (write 전 사전 검증)
-    const updateEntryGroupTemplates = body.entry_group_templates;
-    if (updateEntryGroupTemplates !== undefined) {
-      if (!Array.isArray(updateEntryGroupTemplates)) {
-        return errorResponse("entry_group_templates must be an array", 400);
-      }
-      const egtValidationError = validateEntryGroupTemplates(
-        updateEntryGroupTemplates,
-      );
-      if (egtValidationError) return egtValidationError;
-    }
-
-    if (
-      Object.keys(partyUpdates).length === 0 &&
-      !body.location &&
-      body.location_id === undefined &&
-      updateTagIds === undefined &&
-      updateEntryGroupTemplates === undefined
-    ) {
-      return errorResponse("No fields to update", 400);
-    }
-
-    // ── All validations passed — now perform DB writes ──
-
-    // Update party fields if any
-    if (Object.keys(partyUpdates).length > 0) {
-      const { error: updateError } = await supabase
-        .from("parties")
-        .update(partyUpdates)
-        .eq("id", partyId);
-
-      if (updateError) {
-        return errorResponse(
-          `Failed to update party: ${updateError.message}`,
-          500,
-        );
-      }
-    }
-
-    // Update location if provided
-    const locationData = body.location;
-    if (
-      typeof locationData === "object" && locationData !== null &&
-      !Array.isArray(locationData)
-    ) {
-      const locInput = locationData as Record<string, unknown>;
-
-      // Check if party has a location_id to update
-      const { data: partyWithLoc, error: locFetchError } = await supabase
-        .from("parties")
-        .select("location_id")
-        .eq("id", partyId)
-        .single();
-
-      if (locFetchError) {
-        return errorResponse("Failed to fetch party location", 500);
-      }
-
-      if (partyWithLoc.location_id) {
-        // Update existing location
-        const locUpdates: Record<string, unknown> = {};
-        for (const field of LOCATION_FIELDS) {
-          if (locInput[field] !== undefined) {
-            locUpdates[field] = locInput[field];
-          }
-        }
-
-        if (Object.keys(locUpdates).length > 0) {
-          const { error: locUpdateError } = await supabase
-            .from("locations")
-            .update(locUpdates)
-            .eq("id", partyWithLoc.location_id);
-
-          if (locUpdateError) {
-            return errorResponse(
-              `Failed to update location: ${locUpdateError.message}`,
-              500,
-            );
-          }
-        }
-      }
-    }
-
-    // Handle location_id change
-    if (body.location_id !== undefined) {
-      const newLocationId = body.location_id as string | null;
-      if (newLocationId !== null) {
-        // Verify location belongs to the same partner
-        const { data: loc, error: locError } = await supabase
-          .from("locations")
-          .select("id, partner_id")
-          .eq("id", newLocationId)
-          .maybeSingle();
-
-        if (locError) return errorResponse("Failed to verify location", 500);
-        if (!loc) return errorResponse("Location not found", 404);
-        if (loc.partner_id !== existingParty.partner_id) {
-          return errorResponse(
-            "Forbidden: location belongs to another partner",
-            403,
-          );
-        }
-      }
-
-      const { error: locIdError } = await supabase
-        .from("parties")
-        .update({ location_id: newLocationId })
-        .eq("id", partyId);
-
-      if (locIdError) {
-        return errorResponse(
-          `Failed to update party location: ${locIdError.message}`,
-          500,
-        );
-      }
-    }
-
-    // Update party_tags if tag_ids present in body (undefined = no change, [] = clear all)
-    // Fix #1223: 2단계 DELETE+UPSERT 를 RPC로 원자적 처리
-    // update_party_tags RPC 가 단일 트랜잭션으로 DELETE stale rows → INSERT new rows 처리.
-    // Fix #1149 패턴(DELETE-first)도 RPC 내부에서 동일하게 유지됨.
-    if (updateTagIds !== undefined) {
-      const { error: ptRpcError } = await supabase
-        .rpc("update_party_tags", {
-          p_party_id: partyId,
-          p_tag_ids: updateTagIds as string[],
-        });
-      if (ptRpcError) {
-        return errorResponse(
-          `Failed to update party tags: ${ptRpcError.message}`,
-          500,
-        );
-      }
-    }
-
-    // Fix #1733: UPSERT + selective DELETE — 기존 ID 보존으로 ticket_templates 링크 유지
-    if (updateEntryGroupTemplates !== undefined) {
-      const templates = updateEntryGroupTemplates as Record<string, unknown>[];
-
-      const { data: existing, error: fetchExistingError } = await supabase
-        .from("entry_group_templates")
-        .select("id")
-        .eq("party_id", partyId);
-      if (fetchExistingError) {
-        return errorResponse(
-          `Failed to fetch existing entry group templates: ${fetchExistingError.message}`,
-          500,
-        );
-      }
-
-      const existingIds = (existing ?? []).map((r: { id: string }) =>
-        r.id as string
-      );
-      const incomingWithId = templates.filter((t) =>
-        typeof t.id === "string" && (t.id as string).length > 0
-      );
-      const incomingWithoutId = templates.filter((t) =>
-        !t.id || (t.id as string).length === 0
-      );
-      const keptIds = incomingWithId.map((t) => t.id as string);
-      const toDeleteIds = existingIds.filter((id: string) =>
-        !keptIds.includes(id)
-      );
-
-      if (toDeleteIds.length > 0) {
-        const { data: affectedTickets, error: fetchTicketsError } =
-          await supabase
-            .from("ticket_templates")
-            .select("id, target_entry_group_ids")
-            .eq("party_id", partyId);
-        if (fetchTicketsError) {
-          return errorResponse(
-            `Failed to fetch ticket templates: ${fetchTicketsError.message}`,
-            500,
-          );
-        }
-
-        for (const ticket of (affectedTickets ?? [])) {
-          const tt = ticket as { id: string; target_entry_group_ids: string[] };
-          const hadAny = toDeleteIds.some((d) =>
-            tt.target_entry_group_ids?.includes(d)
-          );
-          if (hadAny) {
-            const updatedIds = (tt.target_entry_group_ids ?? []).filter((
-              id: string,
-            ) => !toDeleteIds.includes(id));
-            const { error: ttUpdateError } = await supabase
-              .from("ticket_templates")
-              .update({ target_entry_group_ids: updatedIds })
-              .eq("id", tt.id);
-            if (ttUpdateError) {
-              return errorResponse(
-                `Failed to update ticket template references: ${ttUpdateError.message}`,
-                500,
-              );
-            }
-          }
-        }
-
-        const { error: deleteEgtError } = await supabase
-          .from("entry_group_templates")
-          .delete()
-          .in("id", toDeleteIds);
-        if (deleteEgtError) {
-          return errorResponse(
-            `Failed to delete entry group templates: ${deleteEgtError.message}`,
-            500,
-          );
-        }
-      }
-
-      for (const t of incomingWithId) {
-        const { error: updateEgtError } = await supabase
-          .from("entry_group_templates")
-          .update({
-            label: t.label ?? null,
-            gender: t.gender ?? null,
-            birth_year_min: t.birth_year_min ?? null,
-            birth_year_max: t.birth_year_max ?? null,
-            required_verification_ids: t.required_verification_ids ?? [],
-          })
-          .eq("id", t.id as string)
-          .eq("party_id", partyId);
-        if (updateEgtError) {
-          return errorResponse(
-            `Failed to update entry group template: ${updateEgtError.message}`,
-            500,
-          );
-        }
-      }
-
-      if (incomingWithoutId.length > 0) {
-        const newTemplates = incomingWithoutId.map((t) => ({
-          party_id: partyId,
-          label: t.label ?? null,
-          gender: t.gender ?? null,
-          birth_year_min: t.birth_year_min ?? null,
-          birth_year_max: t.birth_year_max ?? null,
-          required_verification_ids: t.required_verification_ids ?? [],
-        }));
-        const { error: insertEgtError } = await supabase
-          .from("entry_group_templates")
-          .insert(newTemplates);
-        if (insertEgtError) {
-          return errorResponse(
-            `Failed to insert new entry group templates: ${insertEgtError.message}`,
-            500,
-          );
-        }
-      }
-    }
-
-    return successResponse({ success: true });
   }
 
-  // ─── update_status ───
-  if (action === "update_status") {
-    const partyId = body.party_id;
-    if (typeof partyId !== "string" || !partyId) {
-      return errorResponse("Missing party_id", 400);
-    }
+  // Fetch party to verify ownership
+  const { data: existingParty, error: fetchError } = await supabase
+    .from("parties")
+    .select("id, partner_id")
+    .eq("id", partyId)
+    .maybeSingle();
 
-    const status = body.status;
-    if (typeof status !== "string" || !VALID_STATUSES.includes(status)) {
-      return errorResponse(
-        `Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}`,
-        400,
-      );
-    }
+  if (fetchError) return errorResponse("Failed to load party", 500);
+  if (!existingParty) return errorResponse("Party not found", 404);
 
-    // Fetch party to verify ownership
-    const { data: existingParty, error: fetchError } = await supabase
-      .from("parties")
-      .select("id, partner_id")
-      .eq("id", partyId)
-      .maybeSingle();
+  // Check partner permission
+  const permCheck = await requirePartnerPermission(
+    supabase,
+    existingParty.partner_id,
+    userId,
+    ["PARTY_MANAGE"],
+  );
+  if (permCheck) return permCheck;
 
-    if (fetchError) return errorResponse("Failed to load party", 500);
-    if (!existingParty) return errorResponse("Party not found", 404);
+  const { error: updateError } = await supabase
+    .from("parties")
+    .update({ status })
+    .eq("id", partyId);
 
-    // Check partner permission
-    const permCheck = await requirePartnerPermission(
-      supabase,
-      existingParty.partner_id,
-      userId,
-      ["PARTY_MANAGE"],
+  if (updateError) {
+    return errorResponse(
+      `Failed to update party status: ${updateError.message}`,
+      500,
     );
-    if (permCheck) return permCheck;
-
-    const { error: updateError } = await supabase
-      .from("parties")
-      .update({ status })
-      .eq("id", partyId);
-
-    if (updateError) {
-      return errorResponse(
-        `Failed to update party status: ${updateError.message}`,
-        500,
-      );
-    }
-
-    return successResponse({ success: true });
   }
 
-  return errorResponse(`Unknown action: ${action}`, 400);
+  return successResponse({ success: true });
 }
 
 function validateEntryGroupTemplates(templates: unknown[]): Response | null {


### PR DESCRIPTION
## Summary

- `handleRequest` 내 중첩 if/else 3개 action 블록을 `DISPATCH` 테이블 패턴으로 분리
- `handleCreate` / `handleUpdate` / `handleUpdateStatus` 독립 핸들러로 추출
- 비즈니스 로직, Fix # 주석, 에러 메시지 원본 그대로 보존

## Changes

- `DISPATCH: Record<string, ActionHandler>` 테이블 신설
- `handleRequest` 단순화: auth → body parse → dispatch 3단계
- 각 action 핸들러가 단일 책임 유지

> Note: #1791 (`requirePartnerPermission` 시그니처 변경) 머지 후 rebase 필요

## Test plan

- [ ] `test-deno-ef` CI 통과 확인
- [ ] 기존 partner-manage-party 테스트 모두 pass

Closes #1785