### PR TITLE
refactor(ef): JSON body parse 공통화 → _shared/request_utils (#1787)

### DIFF
--- a/supabase/functions/_shared/request_utils.ts
+++ b/supabase/functions/_shared/request_utils.ts
@@ -1,0 +1,29 @@
+import { errorResponse } from "./response_utils.ts";
+
+export async function parseJsonBody(
+  req: Request,
+): Promise<Record<string, unknown> | Response> {
+  try {
+    const parsed = await req.json();
+    if (
+      typeof parsed !== "object" || parsed === null || Array.isArray(parsed)
+    ) {
+      return errorResponse("Request body must be a JSON object", 400);
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return errorResponse("Invalid JSON body", 400);
+  }
+}
+
+export async function parseAction(
+  req: Request,
+): Promise<{ action: string; body: Record<string, unknown> } | Response> {
+  const body = await parseJsonBody(req);
+  if (body instanceof Response) return body;
+  const action = body.action as string | undefined;
+  if (typeof action !== "string") {
+    return errorResponse('Missing or invalid "action" field', 400);
+  }
+  return { action, body };
+}

--- a/supabase/functions/_shared/request_utils_test.ts
+++ b/supabase/functions/_shared/request_utils_test.ts
@@ -1,0 +1,95 @@
+import { assertEquals } from "@std/assert";
+import { parseJsonBody, parseAction } from "./request_utils.ts";
+
+// parseJsonBody
+
+Deno.test("parseJsonBody - valid object → returns parsed body", async () => {
+  const req = new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({ foo: "bar" }),
+    headers: { "Content-Type": "application/json" },
+  });
+  const result = await parseJsonBody(req);
+  assertEquals(result instanceof Response, false);
+  assertEquals((result as Record<string, unknown>).foo, "bar");
+});
+
+Deno.test("parseJsonBody - invalid JSON → 400 Invalid JSON body", async () => {
+  const req = new Request("http://localhost", {
+    method: "POST",
+    body: "not-json",
+    headers: { "Content-Type": "application/json" },
+  });
+  const result = await parseJsonBody(req);
+  assertEquals(result instanceof Response, true);
+  assertEquals((result as Response).status, 400);
+  const body = await (result as Response).json();
+  assertEquals(body.error, "Invalid JSON body");
+});
+
+Deno.test("parseJsonBody - null body → 400 Request body must be a JSON object", async () => {
+  const req = new Request("http://localhost", {
+    method: "POST",
+    body: "null",
+    headers: { "Content-Type": "application/json" },
+  });
+  const result = await parseJsonBody(req);
+  assertEquals(result instanceof Response, true);
+  assertEquals((result as Response).status, 400);
+  const body = await (result as Response).json();
+  assertEquals(body.error, "Request body must be a JSON object");
+});
+
+Deno.test("parseJsonBody - array body → 400 Request body must be a JSON object", async () => {
+  const req = new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify([1, 2, 3]),
+    headers: { "Content-Type": "application/json" },
+  });
+  const result = await parseJsonBody(req);
+  assertEquals(result instanceof Response, true);
+  assertEquals((result as Response).status, 400);
+  const body = await (result as Response).json();
+  assertEquals(body.error, "Request body must be a JSON object");
+});
+
+// parseAction
+
+Deno.test("parseAction - valid action → returns { action, body }", async () => {
+  const req = new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({ action: "create", data: 42 }),
+    headers: { "Content-Type": "application/json" },
+  });
+  const result = await parseAction(req);
+  assertEquals(result instanceof Response, false);
+  const r = result as { action: string; body: Record<string, unknown> };
+  assertEquals(r.action, "create");
+  assertEquals(r.body.data, 42);
+});
+
+Deno.test("parseAction - action field missing → 400 Missing or invalid action field", async () => {
+  const req = new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({ data: "no-action" }),
+    headers: { "Content-Type": "application/json" },
+  });
+  const result = await parseAction(req);
+  assertEquals(result instanceof Response, true);
+  assertEquals((result as Response).status, 400);
+  const body = await (result as Response).json();
+  assertEquals(body.error, 'Missing or invalid "action" field');
+});
+
+Deno.test("parseAction - action is number → 400 Missing or invalid action field", async () => {
+  const req = new Request("http://localhost", {
+    method: "POST",
+    body: JSON.stringify({ action: 123 }),
+    headers: { "Content-Type": "application/json" },
+  });
+  const result = await parseAction(req);
+  assertEquals(result instanceof Response, true);
+  assertEquals((result as Response).status, 400);
+  const body = await (result as Response).json();
+  assertEquals(body.error, 'Missing or invalid "action" field');
+});

--- a/supabase/functions/ai-embed/index.ts
+++ b/supabase/functions/ai-embed/index.ts
@@ -1,11 +1,17 @@
-import { createServiceClient } from '../_shared/supabase_client.ts'
-import { nowISO } from '../_shared/temporal_utils.ts'
-import { createEmbeddingAdapter } from '../_shared/ai/factory.ts'
-import { serializeParty } from './party_serializer.ts'
-import { HybridCalculator } from './calculator.ts'
-import { WorkerUtils } from '../_shared/worker_utils.ts'
-import { initSentry, withHandler, log, captureException } from '../_shared/logger.ts'
-import { requireServiceRole } from '../_shared/auth_utils.ts'
+import { createServiceClient } from "../_shared/supabase_client.ts";
+import { nowISO } from "../_shared/temporal_utils.ts";
+import { createEmbeddingAdapter } from "../_shared/ai/factory.ts";
+import { serializeParty } from "./party_serializer.ts";
+import { HybridCalculator } from "./calculator.ts";
+import { WorkerUtils } from "../_shared/worker_utils.ts";
+import {
+  captureException,
+  initSentry,
+  log,
+  withHandler,
+} from "../_shared/logger.ts";
+import { requireServiceRole } from "../_shared/auth_utils.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
 
 const FN = "ai-embed";
 
@@ -13,7 +19,7 @@ const WEIGHTS: Record<string, number> = {
   view: 0.1,
   like: 0.5,
   purchase: 1.0,
-  dislike: -0.5
+  dislike: -0.5,
 };
 
 const calculator = new HybridCalculator({ decayRate: 0.05 });
@@ -24,36 +30,55 @@ Deno.serve(withHandler(async (req) => {
   // Fix #1489: 시스템 전용 EF — service_role만 허용
   const auth = requireServiceRole(req);
   if (auth instanceof Response) return auth;
-  log({ function: FN, level: "info", message: "AI Embed Worker Triggered! Checking environment and auth..." });
+  log({
+    function: FN,
+    level: "info",
+    message: "AI Embed Worker Triggered! Checking environment and auth...",
+  });
   try {
-    const payload = await req.json().catch(() => ({}));
+    const body = await parseJsonBody(req);
+    const payload = body instanceof Response ? {} : body;
     const rawBatch = Math.floor(Number(payload.batch_size));
-    const batchSize = Number.isFinite(rawBatch) && rawBatch >= 1 ? Math.min(rawBatch, 50) : 50;
+    const batchSize = Number.isFinite(rawBatch) && rawBatch >= 1
+      ? Math.min(rawBatch, 50)
+      : 50;
 
     const supabase = createServiceClient();
     const adapter = createEmbeddingAdapter();
-    const utils = new WorkerUtils(supabase, 'q_vectors');
+    const utils = new WorkerUtils(supabase, "q_vectors");
 
     // 1. Read Batch from PGMQ
-    const { data: messages, error: readError } = await supabase.rpc('pgmq_read', {
-      queue_name: 'q_vectors',
-      vt: 60, // Increase VT for batch processing
-      limit: batchSize
-    });
+    const { data: messages, error: readError } = await supabase.rpc(
+      "pgmq_read",
+      {
+        queue_name: "q_vectors",
+        vt: 60, // Increase VT for batch processing
+        limit: batchSize,
+      },
+    );
 
     if (readError) {
-        log({ function: FN, level: "error", message: "PGMQ Read Error", metadata: { detail: readError } });
-        throw readError;
+      log({
+        function: FN,
+        level: "error",
+        message: "PGMQ Read Error",
+        metadata: { detail: readError },
+      });
+      throw readError;
     }
 
     if (!messages || (Array.isArray(messages) && messages.length === 0)) {
       return new Response(JSON.stringify({ processed: 0 }), {
-        headers: { "Content-Type": "application/json" }
+        headers: { "Content-Type": "application/json" },
       });
     }
 
     const msgArray = Array.isArray(messages) ? messages : [messages];
-    log({ function: FN, level: "info", message: `Processing v2 batch of ${msgArray.length} messages` });
+    log({
+      function: FN,
+      level: "info",
+      message: `Processing v2 batch of ${msgArray.length} messages`,
+    });
 
     // deno-lint-ignore no-explicit-any
     const partyTasks: any[] = [];
@@ -73,7 +98,11 @@ Deno.serve(withHandler(async (req) => {
 
       // B. Idempotency Check
       if (await utils.isProcessed(traceId)) {
-        log({ function: FN, level: "info", message: `[${traceId}] Already processed. Skipping.` });
+        log({
+          function: FN,
+          level: "info",
+          message: `[${traceId}] Already processed. Skipping.`,
+        });
         processedMsgIds.push(msg.msg_id);
         continue;
       }
@@ -84,12 +113,16 @@ Deno.serve(withHandler(async (req) => {
       }
 
       // D. Queue for Processing
-      if (p.type === 'party_created') {
+      if (p.type === "party_created") {
         partyTasks.push({ msgId: msg.msg_id, record: p.payload, traceId });
-      } else if (p.type === 'user_interaction') {
-        interactionTasks.push({ msgId: msg.msg_id, record: p.payload, traceId });
+      } else if (p.type === "user_interaction") {
+        interactionTasks.push({
+          msgId: msg.msg_id,
+          record: p.payload,
+          traceId,
+        });
       } else {
-          processedMsgIds.push(msg.msg_id);
+        processedMsgIds.push(msg.msg_id);
       }
     }
 
@@ -97,37 +130,68 @@ Deno.serve(withHandler(async (req) => {
     if (partyTasks.length > 0) {
       try {
         // Separate public and private parties
-        const publicPartyTasks = partyTasks.filter(t => t.record.visibility !== 'private');
-        const privatePartyTasks = partyTasks.filter(t => t.record.visibility === 'private');
+        const publicPartyTasks = partyTasks.filter((t) =>
+          t.record.visibility !== "private"
+        );
+        const privatePartyTasks = partyTasks.filter((t) =>
+          t.record.visibility === "private"
+        );
 
         // Handle private parties - skip embedding, delete existing
         for (const t of privatePartyTasks) {
-          log({ function: FN, level: "info", message: `Skipping private party: ${t.record.id}` });
-          await supabase.from('party_embeddings').delete().eq('party_id', t.record.id);
+          log({
+            function: FN,
+            level: "info",
+            message: `Skipping private party: ${t.record.id}`,
+          });
+          await supabase.from("party_embeddings").delete().eq(
+            "party_id",
+            t.record.id,
+          );
           await utils.markProcessed(t.traceId);
           processedMsgIds.push(t.msgId);
         }
 
         // Process only public parties
         if (publicPartyTasks.length > 0) {
-          const texts = publicPartyTasks.map(t => serializeParty(t.record));
-          log({ function: FN, level: "info", message: `Requesting ${texts.length} embeddings...` });
+          const texts = publicPartyTasks.map((t) => serializeParty(t.record));
+          log({
+            function: FN,
+            level: "info",
+            message: `Requesting ${texts.length} embeddings...`,
+          });
           const embeddings = await adapter.generateEmbeddings(texts);
-          log({ function: FN, level: "info", message: `Received ${embeddings.length} embeddings.` });
+          log({
+            function: FN,
+            level: "info",
+            message: `Received ${embeddings.length} embeddings.`,
+          });
 
           for (let i = 0; i < publicPartyTasks.length; i++) {
             const t = publicPartyTasks[i];
             const item = {
               party_id: t.record.id,
               embedding: embeddings[i],
-              updated_at: nowISO()
+              updated_at: nowISO(),
             };
 
-            const { error: upsertError } = await supabase.from('party_embeddings').upsert(item);
+            const { error: upsertError } = await supabase.from(
+              "party_embeddings",
+            ).upsert(item);
             if (upsertError) {
-              log({ function: FN, level: "error", message: `Upsert Error for party ${t.record.id}`, metadata: { detail: JSON.stringify(upsertError) } });
+              log({
+                function: FN,
+                level: "error",
+                message: `Upsert Error for party ${t.record.id}`,
+                metadata: { detail: JSON.stringify(upsertError) },
+              });
             } else {
-              log({ function: FN, level: "info", message: `Successfully saved embedding for party ${t.record.id}` });
+              log({
+                function: FN,
+                level: "info",
+                message:
+                  `Successfully saved embedding for party ${t.record.id}`,
+              });
               await utils.markProcessed(t.traceId);
               processedMsgIds.push(t.msgId);
             }
@@ -135,7 +199,12 @@ Deno.serve(withHandler(async (req) => {
         }
       } catch (e) {
         // Fix #1441: 에러를 삼키지 말고 throw — PGMQ retry 활용 (silent failure 방지)
-        log({ function: FN, level: "error", message: "Party Vectorization Error", metadata: { error: e } });
+        log({
+          function: FN,
+          level: "error",
+          message: "Party Vectorization Error",
+          metadata: { error: e },
+        });
         throw e;
       }
     }
@@ -147,8 +216,14 @@ Deno.serve(withHandler(async (req) => {
         const weight = WEIGHTS[action_type] ?? 0;
 
         const [userRes, partyRes] = await Promise.all([
-          supabase.from('user_embeddings').select('embedding').eq('user_id', user_id).maybeSingle(),
-          supabase.from('party_embeddings').select('embedding').eq('party_id', party_id).maybeSingle()
+          supabase.from("user_embeddings").select("embedding").eq(
+            "user_id",
+            user_id,
+          ).maybeSingle(),
+          supabase.from("party_embeddings").select("embedding").eq(
+            "party_id",
+            party_id,
+          ).maybeSingle(),
         ]);
 
         // Fix #1441: DB 쿼리 에러 미검증 — 에러 시 throw로 PGMQ retry 활용
@@ -157,50 +232,78 @@ Deno.serve(withHandler(async (req) => {
 
         if (partyRes.data && partyRes.data.embedding) {
           const oldVector = userRes.data?.embedding ?? new Array(1536).fill(0);
-          const newVector = calculator.calculate(oldVector, partyRes.data.embedding, weight);
+          const newVector = calculator.calculate(
+            oldVector,
+            partyRes.data.embedding,
+            weight,
+          );
 
-          const { error } = await supabase.from('user_embeddings').upsert({
+          const { error } = await supabase.from("user_embeddings").upsert({
             user_id,
             embedding: newVector,
-            updated_at: nowISO()
+            updated_at: nowISO(),
           });
           if (error) throw error;
 
           await utils.markProcessed(task.traceId);
           processedMsgIds.push(task.msgId);
         } else {
-          log({ function: FN, level: "warn", message: `Skipping interaction: Party ${party_id} embedding not found.` });
+          log({
+            function: FN,
+            level: "warn",
+            message:
+              `Skipping interaction: Party ${party_id} embedding not found.`,
+          });
           processedMsgIds.push(task.msgId);
         }
       } catch (e) {
-        log({ function: FN, level: "error", message: "Interaction Error", metadata: { error: e } });
+        log({
+          function: FN,
+          level: "error",
+          message: "Interaction Error",
+          metadata: { error: e },
+        });
       }
     }
 
     // 4. Delete processed messages from queue individually for reliability
     if (processedMsgIds.length > 0) {
-      log({ function: FN, level: "info", message: `Deleting ${processedMsgIds.length} messages from queue...` });
+      log({
+        function: FN,
+        level: "info",
+        message: `Deleting ${processedMsgIds.length} messages from queue...`,
+      });
       for (const msgId of processedMsgIds) {
-        const { error: delError } = await supabase.rpc('pgmq_delete', {
-          queue_name: 'q_vectors',
-          msg_id: msgId
+        const { error: delError } = await supabase.rpc("pgmq_delete", {
+          queue_name: "q_vectors",
+          msg_id: msgId,
         });
-        if (delError) log({ function: FN, level: "error", message: `PGMQ Delete Error for ${msgId}`, metadata: { detail: delError } });
+        if (delError) {
+          log({
+            function: FN,
+            level: "error",
+            message: `PGMQ Delete Error for ${msgId}`,
+            metadata: { detail: delError },
+          });
+        }
       }
     }
 
     return new Response(JSON.stringify({ processed: processedMsgIds.length }), {
       headers: { "Content-Type": "application/json" },
     });
-
   } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : String(err);
-    log({ function: FN, level: "error", message: `AI Embed Worker Error: ${errorMessage}` });
+    log({
+      function: FN,
+      level: "error",
+      message: `AI Embed Worker Error: ${errorMessage}`,
+    });
     // captureException: withHandler의 catch에 도달하지 않으므로 여기서 직접 Sentry에 캡처
     captureException(err);
     return new Response(JSON.stringify({ error: errorMessage }), {
       status: 500,
-      headers: { "Content-Type": "application/json" }
+      headers: { "Content-Type": "application/json" },
     });
   }
-}))
+}));

--- a/supabase/functions/ai-extract-tags/index.ts
+++ b/supabase/functions/ai-extract-tags/index.ts
@@ -3,6 +3,7 @@ import { createLLMAdapter } from "../_shared/ai/factory.ts";
 import { WorkerUtils } from "../_shared/worker_utils.ts";
 import { initSentry, withHandler } from "../_shared/logger.ts";
 import { requireServiceRole } from "../_shared/auth_utils.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
 import {
   buildTagExtractionPrompt,
   extractDescriptionText,
@@ -34,9 +35,14 @@ Deno.serve(withHandler(async (req) => {
   console.log(`[${FN}] triggered`);
 
   try {
-    const payload = await req.json().catch(() => ({}));
-    const rawBatch = Math.floor(Number((payload as { batch_size?: number }).batch_size));
-    const batchSize = Number.isFinite(rawBatch) && rawBatch >= 1 ? Math.min(rawBatch, 50) : 10;
+    const body = await parseJsonBody(req);
+    const payload = body instanceof Response ? {} : body;
+    const rawBatch = Math.floor(
+      Number((payload as { batch_size?: number }).batch_size),
+    );
+    const batchSize = Number.isFinite(rawBatch) && rawBatch >= 1
+      ? Math.min(rawBatch, 50)
+      : 10;
 
     const supabase = createServiceClient();
     // createLLMAdapter() throws if OPENAI_API_KEY is missing
@@ -187,7 +193,11 @@ Deno.serve(withHandler(async (req) => {
           // party_tags에 연결 (source='ai')
           const { error: linkError } = await supabase
             .from("party_tags")
-            .insert({ party_id: party.id, tag_id: existingTag.id, source: "ai" });
+            .insert({
+              party_id: party.id,
+              tag_id: existingTag.id,
+              source: "ai",
+            });
 
           if (linkError) {
             if (PARTY_TAGS_SKIP_CODES.has(linkError.code)) {

--- a/supabase/functions/apply-event/index.ts
+++ b/supabase/functions/apply-event/index.ts
@@ -1,6 +1,11 @@
 import { createServiceClient } from "../_shared/supabase_client.ts";
-import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
 import { initSentry, withHandler } from "../_shared/logger.ts";
 
 initSentry();
@@ -13,21 +18,20 @@ Deno.serve(withHandler(async (req) => {
   const userId = auth;
 
   try {
-    let reqBody: Record<string, unknown>;
-    try {
-      reqBody = await req.json();
-    } catch {
-      return errorResponse("Invalid JSON body", 400);
-    }
+    const body = await parseJsonBody(req);
+    if (body instanceof Response) return body;
 
-    const { event_id, ticket_id, verification_data } = reqBody as {
+    const { event_id, ticket_id, verification_data } = body as {
       event_id?: string;
       ticket_id?: string;
       verification_data?: Record<string, unknown>;
     };
 
     if (!event_id || !ticket_id) {
-      return errorResponse("Missing required parameters: event_id, ticket_id", 400);
+      return errorResponse(
+        "Missing required parameters: event_id, ticket_id",
+        400,
+      );
     }
 
     const supabase = createServiceClient();
@@ -45,7 +49,9 @@ Deno.serve(withHandler(async (req) => {
 
     // 2. 이벤트 상태 확인 — scheduled 상태여야 신청 가능
     if (event.status !== "scheduled") {
-      return errorResponse("Event is not accepting applications", 409, { status: event.status });
+      return errorResponse("Event is not accepting applications", 409, {
+        status: event.status,
+      });
     }
 
     // 3. capacity guard — current_participants >= max_participants
@@ -59,7 +65,9 @@ Deno.serve(withHandler(async (req) => {
     // 4. 티켓 정보 조회
     const { data: ticket, error: ticketError } = await supabase
       .from("tickets")
-      .select("id, price, quantity, sold_count, status, required_verification_ids, event_id")
+      .select(
+        "id, price, quantity, sold_count, status, required_verification_ids, event_id",
+      )
       .eq("id", ticket_id)
       .single();
 
@@ -74,7 +82,9 @@ Deno.serve(withHandler(async (req) => {
 
     // 티켓 판매 상태 확인
     if (ticket.status !== "on_sale") {
-      return errorResponse("Ticket is not available", 409, { ticket_status: ticket.status });
+      return errorResponse("Ticket is not available", 409, {
+        ticket_status: ticket.status,
+      });
     }
 
     // 티켓 capacity guard — sold_count >= quantity
@@ -90,12 +100,16 @@ Deno.serve(withHandler(async (req) => {
       .eq("user_id", userId)
       .maybeSingle();
 
-    if (existingApp && existingApp.status !== "cancelled" && existingApp.status !== "payment_failed") {
+    if (
+      existingApp && existingApp.status !== "cancelled" &&
+      existingApp.status !== "payment_failed"
+    ) {
       return errorResponse("Already applied to this event", 409);
     }
 
     // 6. eligibility 체크 — 티켓에 required_verification_ids가 있는 경우 확인
-    const requiredVerificationIds: string[] = ticket.required_verification_ids ?? [];
+    const requiredVerificationIds: string[] =
+      ticket.required_verification_ids ?? [];
     if (requiredVerificationIds.length > 0) {
       const { data: verifications } = await supabase
         .from("user_verifications")
@@ -103,11 +117,19 @@ Deno.serve(withHandler(async (req) => {
         .eq("user_id", userId)
         .in("verification_id", requiredVerificationIds);
 
-      const verifiedIds = new Set((verifications ?? []).map((v: { verification_id: string }) => v.verification_id));
-      const missingIds = requiredVerificationIds.filter((id) => !verifiedIds.has(id));
+      const verifiedIds = new Set(
+        (verifications ?? []).map((v: { verification_id: string }) =>
+          v.verification_id
+        ),
+      );
+      const missingIds = requiredVerificationIds.filter((id) =>
+        !verifiedIds.has(id)
+      );
 
       if (missingIds.length > 0) {
-        return errorResponse("Eligibility requirements not met", 403, { missing_verification_ids: missingIds });
+        return errorResponse("Eligibility requirements not met", 403, {
+          missing_verification_ids: missingIds,
+        });
       }
     }
 
@@ -117,15 +139,24 @@ Deno.serve(withHandler(async (req) => {
     if (price > 0) {
       // 유료: payment_pending 상태로 신청 레코드 생성 후 주문 정보 반환
       // Fix #1492: 유료 경로 성별 균형 검증 누락 — 무료 경로와 동일하게 check_party_balance 추가
-      const { data: balanceResult, error: balanceError } = await supabase.rpc("check_party_balance", {
-        p_event_id: event_id,
-        p_ticket_id: ticket_id,
-      });
+      const { data: balanceResult, error: balanceError } = await supabase.rpc(
+        "check_party_balance",
+        {
+          p_event_id: event_id,
+          p_ticket_id: ticket_id,
+        },
+      );
       if (balanceError) {
-        console.error("check_party_balance error on paid application:", balanceError.message);
+        console.error(
+          "check_party_balance error on paid application:",
+          balanceError.message,
+        );
         return errorResponse("Failed to check balance", 500);
       }
-      const balance = balanceResult as { allowed: boolean; reason: string | null } | null;
+      const balance = balanceResult as {
+        allowed: boolean;
+        reason: string | null;
+      } | null;
       if (!balance?.allowed) {
         return errorResponse(balance?.reason ?? "성비 균형 제한", 409);
       }
@@ -147,7 +178,10 @@ Deno.serve(withHandler(async (req) => {
           .eq("id", existingApp.id);
 
         if (updateError) {
-          console.error("Failed to update paid application for re-application:", updateError.message);
+          console.error(
+            "Failed to update paid application for re-application:",
+            updateError.message,
+          );
           return errorResponse("Failed to create application", 500);
         }
       } else {
@@ -166,7 +200,10 @@ Deno.serve(withHandler(async (req) => {
           });
 
         if (insertError) {
-          console.error("Failed to create paid application:", insertError.message);
+          console.error(
+            "Failed to create paid application:",
+            insertError.message,
+          );
           // unique constraint violation (23505) → race condition으로 중복 신청 발생
           if (insertError.code === "23505") {
             return errorResponse("Already applied to this event", 409);
@@ -177,7 +214,9 @@ Deno.serve(withHandler(async (req) => {
 
       // Fix #1342 Bug2: 유료 경로에서 verification_data 처리 — RPC 미사용으로 인해 직접 삽입
       if (verification_data) {
-        const verificationId = verification_data["verification_id"] as string | undefined;
+        const verificationId = verification_data["verification_id"] as
+          | string
+          | undefined;
         const partnerId = verification_data["partner_id"] as string | undefined;
         const data = verification_data["data"] ?? {};
 
@@ -190,7 +229,10 @@ Deno.serve(withHandler(async (req) => {
             );
 
           if (uvError) {
-            console.error("Failed to upsert user_verifications:", uvError.message);
+            console.error(
+              "Failed to upsert user_verifications:",
+              uvError.message,
+            );
             return errorResponse("Failed to process verification data", 500);
           }
 
@@ -206,7 +248,10 @@ Deno.serve(withHandler(async (req) => {
             });
 
           if (vsError) {
-            console.error("Failed to insert verification_submissions:", vsError.message);
+            console.error(
+              "Failed to insert verification_submissions:",
+              vsError.message,
+            );
             return errorResponse("Failed to process verification data", 500);
           }
         }
@@ -223,15 +268,24 @@ Deno.serve(withHandler(async (req) => {
       if (existingApp) {
         // Fix #1342 Bug1: 취소/결제실패 후 재신청 — apply_event RPC는 plain INSERT이므로 직접 UPDATE
         // Fix #1345: apply_event RPC 미사용으로 인해 check_party_balance 누락 — 명시적 호출
-        const { data: balanceResult, error: balanceError } = await supabase.rpc("check_party_balance", {
-          p_event_id: event_id,
-          p_ticket_id: ticket_id,
-        });
+        const { data: balanceResult, error: balanceError } = await supabase.rpc(
+          "check_party_balance",
+          {
+            p_event_id: event_id,
+            p_ticket_id: ticket_id,
+          },
+        );
         if (balanceError) {
-          console.error("check_party_balance error on free re-application:", balanceError.message);
+          console.error(
+            "check_party_balance error on free re-application:",
+            balanceError.message,
+          );
           return errorResponse("Failed to check balance", 500);
         }
-        const balance = balanceResult as { allowed: boolean; reason: string | null } | null;
+        const balance = balanceResult as {
+          allowed: boolean;
+          reason: string | null;
+        } | null;
         if (!balance?.allowed) {
           return errorResponse(balance?.reason ?? "성비 균형 제한", 409);
         }
@@ -250,14 +304,21 @@ Deno.serve(withHandler(async (req) => {
           .eq("id", existingApp.id);
 
         if (updateError) {
-          console.error("Failed to update free application for re-application:", updateError.message);
+          console.error(
+            "Failed to update free application for re-application:",
+            updateError.message,
+          );
           return errorResponse("Failed to apply to event", 500);
         }
 
         // Fix #1342 Bug2: 무료 재신청 경로에서 verification_data 처리
         if (verification_data) {
-          const verificationId = verification_data["verification_id"] as string | undefined;
-          const partnerId = verification_data["partner_id"] as string | undefined;
+          const verificationId = verification_data["verification_id"] as
+            | string
+            | undefined;
+          const partnerId = verification_data["partner_id"] as
+            | string
+            | undefined;
           const data = verification_data["data"] ?? {};
 
           if (verificationId && partnerId) {
@@ -269,7 +330,10 @@ Deno.serve(withHandler(async (req) => {
               );
 
             if (uvError) {
-              console.error("Failed to upsert user_verifications:", uvError.message);
+              console.error(
+                "Failed to upsert user_verifications:",
+                uvError.message,
+              );
               return errorResponse("Failed to process verification data", 500);
             }
 
@@ -285,7 +349,10 @@ Deno.serve(withHandler(async (req) => {
               });
 
             if (vsError) {
-              console.error("Failed to insert verification_submissions:", vsError.message);
+              console.error(
+                "Failed to insert verification_submissions:",
+                vsError.message,
+              );
               return errorResponse("Failed to process verification data", 500);
             }
           }
@@ -298,14 +365,17 @@ Deno.serve(withHandler(async (req) => {
       }
 
       // 신규 무료 신청: apply_event RPC 호출 — DB 레벨 balance 체크 + 신청 완료
-      const { data: applicationId, error: rpcError } = await supabase.rpc("apply_event", {
-        p_event_id: event_id,
-        p_ticket_id: ticket_id,
-        p_user_id: userId,
-        p_payment_id: null,
-        p_payment_amount: 0,
-        p_verification_data: verification_data ?? null,
-      });
+      const { data: applicationId, error: rpcError } = await supabase.rpc(
+        "apply_event",
+        {
+          p_event_id: event_id,
+          p_ticket_id: ticket_id,
+          p_user_id: userId,
+          p_payment_id: null,
+          p_payment_amount: 0,
+          p_verification_data: verification_data ?? null,
+        },
+      );
 
       if (rpcError) {
         console.error("apply_event RPC error:", rpcError.message);

--- a/supabase/functions/backend-simulator/index.ts
+++ b/supabase/functions/backend-simulator/index.ts
@@ -6,13 +6,18 @@ import {
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { log, flush, debugStatus } from "../_shared/axiom_logger.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
+import { debugStatus, flush, log } from "../_shared/axiom_logger.ts";
 import {
-  SimLogCollector,
   simCreateGitHubIssue,
+  SimLogCollector,
   simUploadLog,
 } from "./sim_reporter.ts";
-import { simCreateParties, simCreateDisplayEvents, simDiscoverAndApply } from "./sim_create.ts";
+import {
+  simCreateDisplayEvents,
+  simCreateParties,
+  simDiscoverAndApply,
+} from "./sim_create.ts";
 import { simApproveVerifications } from "./sim_approve.ts";
 import { simRefundRequests } from "./sim_refund.ts";
 import { simCheckin, simCompleteEvents, simMatch } from "./sim_event.ts";
@@ -81,7 +86,10 @@ Deno.serve(async (req: Request): Promise<Response> => {
   } = {};
   try {
     if (req.headers.get("content-type")?.includes("application/json")) {
-      body = await req.json();
+      const parsedBody = await parseJsonBody(req);
+      if (!(parsedBody instanceof Response)) {
+        body = parsedBody as typeof body;
+      }
     }
   } catch {
     // ignore parse errors — use defaults
@@ -93,72 +101,359 @@ Deno.serve(async (req: Request): Promise<Response> => {
   const mode = body.mode;
 
   const runId = crypto.randomUUID();
-  log({ function: FN, level: "info", message: "invoked", metadata: { runId, mode: mode ?? "phase", phase: body.phase ?? "full", forceFail } });
+  log({
+    function: FN,
+    level: "info",
+    message: "invoked",
+    metadata: {
+      runId,
+      mode: mode ?? "phase",
+      phase: body.phase ?? "full",
+      forceFail,
+    },
+  });
 
   try {
+    const collector = new SimLogCollector();
 
-  const collector = new SimLogCollector();
-
-  // Log adapter: sim modules expect (entry: Omit<SimLogEntry, "timestamp">) => void
-  const logFn = (entry: Omit<SimLogEntry, "timestamp">) => {
-    collector.log(
-      entry.level,
-      entry.phase,
-      entry.step,
-      entry.message,
-      entry.data,
-    );
-  };
-
-  // ─────────────────────────────────────────────────────────
-  // Mode: "tick" → Continuous tick simulation
-  // ─────────────────────────────────────────────────────────
-
-  if (mode === "tick") {
-    const tickConfig: TickConfig = {
-      ...DEFAULT_TICK_CONFIG,
-      ...(body.config as Partial<TickConfig> ?? {}),
+    // Log adapter: sim modules expect (entry: Omit<SimLogEntry, "timestamp">) => void
+    const logFn = (entry: Omit<SimLogEntry, "timestamp">) => {
+      collector.log(
+        entry.level,
+        entry.phase,
+        entry.step,
+        entry.message,
+        entry.data,
+      );
     };
 
-    const summary = await tick(supabase, supabaseUrl, anonKey, logFn, tickConfig);
+    // ─────────────────────────────────────────────────────────
+    // Mode: "tick" → Continuous tick simulation
+    // ─────────────────────────────────────────────────────────
 
-    // Create GitHub issue on failures
-    if (summary.failed > 0) {
-      const simSummary = {
-        total_checks: summary.total_actions,
-        passed: summary.passed,
-        failed: summary.failed,
-        assertion_results: summary.results
-          .filter((r) => !r.passed)
-          .map((r) => ({
-            check_name: `${r.actionType}:${r.description}`,
-            passed: false,
-            expected: "success",
-            actual: r.error
-              ? String(r.error)
-              : r.efAssertion?.details ?? r.dbAssertion?.details ?? "failed",
-          })),
+    if (mode === "tick") {
+      const tickConfig: TickConfig = {
+        ...DEFAULT_TICK_CONFIG,
+        ...(body.config as Partial<TickConfig> ?? {}),
       };
-      const logText = collector.formatAsText();
-      const logUrl = await simUploadLog(supabase, runId, logText);
-      await simCreateGitHubIssue(simSummary, logUrl, runId, logText);
+
+      const summary = await tick(
+        supabase,
+        supabaseUrl,
+        anonKey,
+        logFn,
+        tickConfig,
+      );
+
+      // Create GitHub issue on failures
+      if (summary.failed > 0) {
+        const simSummary = {
+          total_checks: summary.total_actions,
+          passed: summary.passed,
+          failed: summary.failed,
+          assertion_results: summary.results
+            .filter((r) => !r.passed)
+            .map((r) => ({
+              check_name: `${r.actionType}:${r.description}`,
+              passed: false,
+              expected: "success",
+              actual: r.error
+                ? String(r.error)
+                : r.efAssertion?.details ?? r.dbAssertion?.details ?? "failed",
+            })),
+        };
+        const logText = collector.formatAsText();
+        const logUrl = await simUploadLog(supabase, runId, logText);
+        await simCreateGitHubIssue(simSummary, logUrl, runId, logText);
+      }
+
+      return successResponse(
+        { success: summary.failed === 0, run_id: runId, ...summary },
+        summary.failed > 0 ? 500 : 200,
+      );
     }
 
-    return successResponse(
-      { success: summary.failed === 0, run_id: runId, ...summary },
-      summary.failed > 0 ? 500 : 200,
+    // ─────────────────────────────────────────────────────────
+    // Phase routing
+    // ─────────────────────────────────────────────────────────
+
+    // Phase: "create" → Phase 1-2 only
+    if (phase === "create") {
+      const createResult = await simCreateParties(
+        supabase,
+        config,
+        logFn,
+        supabaseUrl,
+        anonKey,
+      );
+      // Fix #964: 피드 전시용 이벤트 생성 — 일반 유저 피드에 표시할 display 이벤트를 E2E와 분리해 생성
+      const displayResult = await simCreateDisplayEvents(
+        supabase,
+        logFn,
+        supabaseUrl,
+        anonKey,
+      );
+      const applyResult = await simDiscoverAndApply(
+        supabase,
+        config,
+        logFn,
+        createResult.eventIds,
+        supabaseUrl,
+        anonKey,
+      );
+      return successResponse({
+        success: true,
+        run_id: runId,
+        party_ids: createResult.partyIds,
+        event_ids: createResult.eventIds,
+        display_party_ids: displayResult.displayPartyIds,
+        display_event_ids: displayResult.displayEventIds,
+        application_ids: applyResult.applicationIds,
+        paid_application_ids: applyResult.paidApplicationIds,
+        pending_review_application_ids: applyResult.pendingReviewApplicationIds,
+      });
+    }
+
+    // Phase: "approve" → Phase 3 only
+    if (phase === "approve") {
+      // Fetch current pendingReview applications from DB
+      const { data: pendingApps, error: fetchErr } = await supabase
+        .from("event_applications")
+        .select("id")
+        .eq("status", "pending_review")
+        .limit(50);
+
+      if (fetchErr) {
+        return errorResponse(
+          `Failed to fetch pending applications: ${fetchErr.message}`,
+          500,
+        );
+      }
+
+      const pendingIds = ((pendingApps ?? []) as Array<{ id: string }>).map(
+        (a) => a.id,
+      );
+      const approveResult = await simApproveVerifications(
+        supabase,
+        pendingIds,
+        logFn,
+        undefined,
+        supabaseUrl,
+        anonKey,
+      );
+      return successResponse({
+        success: true,
+        run_id: runId,
+        approved_application_ids: approveResult.approvedApplicationIds,
+        rejected_application_ids: approveResult.rejectedApplicationIds,
+        assertions: approveResult.assertions,
+      });
+    }
+
+    // Phase: "refund" → Phase 4 only
+    if (phase === "refund") {
+      const { data: paidApps, error: fetchErr } = await supabase
+        .from("event_applications")
+        .select("id")
+        .eq("status", "paid")
+        .limit(50);
+
+      if (fetchErr) {
+        return errorResponse(
+          `Failed to fetch paid applications: ${fetchErr.message}`,
+          500,
+        );
+      }
+
+      const paidIds = ((paidApps ?? []) as Array<{ id: string }>).map(
+        (a) => a.id,
+      );
+      const refundResult = await simRefundRequests(
+        supabase,
+        paidIds,
+        logFn,
+        config.refund_rate,
+        supabaseUrl,
+        anonKey,
+      );
+      return successResponse({
+        success: true,
+        run_id: runId,
+        refunded_application_ids: refundResult.refundedApplicationIds,
+        assertions: refundResult.assertions,
+      });
+    }
+
+    // Phase: "run" → Phase 5 only (checkin + match + complete)
+    if (phase === "run") {
+      // Fix #964: E2E 전용 필터 — run phase는 [E2E] 파티 이벤트만 처리해 비E2E 데이터 오염 방지
+      const { data: scheduledEvents, error: fetchErr } = await supabase
+        .from("events")
+        .select("id, parties!inner(title)")
+        .eq("status", "scheduled")
+        .filter("parties.title", "like", "[E2E]%")
+        .limit(50);
+
+      if (fetchErr) {
+        return errorResponse(
+          `Failed to fetch events: ${fetchErr.message}`,
+          500,
+        );
+      }
+
+      const eventIds = ((scheduledEvents ?? []) as Array<{ id: string }>).map(
+        (e) => e.id,
+      );
+      const checkinResult = await simCheckin(
+        supabase,
+        eventIds,
+        logFn,
+        config.checkin_rate,
+        supabaseUrl,
+        anonKey,
+      );
+      const matchResult = await simMatch(
+        supabase,
+        eventIds,
+        logFn,
+        supabaseUrl,
+        serviceRoleKey,
+      );
+      const completeResult = await simCompleteEvents(supabase, eventIds, logFn);
+
+      const allAssertions: SimAssertionResult[] = [
+        ...checkinResult.assertions,
+        ...matchResult.assertions,
+        ...completeResult.assertions,
+      ];
+
+      return successResponse({
+        success: true,
+        run_id: runId,
+        checked_in_participant_ids: checkinResult.checkedInParticipantIds,
+        no_show_participant_ids: checkinResult.noShowParticipantIds,
+        match_pairs: matchResult.matchPairs,
+        completed_event_ids: completeResult.completedEventIds,
+        assertions: allAssertions,
+      });
+    }
+
+    // Phase: "settle" → Phase 6 only
+    if (phase === "settle") {
+      // Fix #964: E2E 전용 필터 — settle phase는 [E2E] 파티 이벤트만 처리해 비E2E 데이터 오염 방지
+      const { data: completedEvents, error: fetchErr } = await supabase
+        .from("events")
+        .select("id, parties!inner(title)")
+        .eq("status", "completed")
+        .filter("parties.title", "like", "[E2E]%")
+        .limit(50);
+
+      if (fetchErr) {
+        return errorResponse(
+          `Failed to fetch completed events: ${fetchErr.message}`,
+          500,
+        );
+      }
+
+      const completedEventIds = (
+        (completedEvents ?? []) as Array<{ id: string }>
+      ).map((e) => e.id);
+      const settleResult = await simVerifySettlement(
+        supabase,
+        completedEventIds,
+        logFn,
+      );
+      const readyResult = await simTransitionToReady(
+        supabase,
+        settleResult.settlementIds,
+        logFn,
+      );
+
+      const allAssertions: SimAssertionResult[] = [
+        ...settleResult.assertions,
+        ...readyResult.assertions,
+      ];
+
+      return successResponse({
+        success: true,
+        run_id: runId,
+        settlement_ids: settleResult.settlementIds,
+        ready_ids: readyResult.readyIds,
+        assertions: allAssertions,
+      });
+    }
+
+    // Phase: "verify" → read-only assertion check against current DB state
+    if (phase === "verify") {
+      // Fix #964: E2E 전용 필터 — verify phase는 [E2E] 파티 이벤트만 검증해 비E2E 데이터 오염 방지
+      // Collect assertions from settlement state only (non-destructive)
+      const { data: completedEvents, error: fetchErr } = await supabase
+        .from("events")
+        .select("id, parties!inner(title)")
+        .eq("status", "completed")
+        .filter("parties.title", "like", "[E2E]%")
+        .limit(50);
+
+      if (fetchErr) {
+        return errorResponse(
+          `Failed to fetch completed events: ${fetchErr.message}`,
+          500,
+        );
+      }
+
+      const completedEventIds = (
+        (completedEvents ?? []) as Array<{ id: string }>
+      ).map((e) => e.id);
+
+      const settleResult = await simVerifySettlement(
+        supabase,
+        completedEventIds,
+        logFn,
+      );
+
+      const summary: SimSummary = {
+        total_checks: settleResult.assertions.length,
+        passed: settleResult.assertions.filter((a) => a.passed).length,
+        failed: settleResult.assertions.filter((a) => !a.passed).length,
+        assertion_results: settleResult.assertions,
+      };
+
+      // Create GitHub issue on assertion failure
+      let githubIssueUrl: string | null = null;
+      if (summary.failed > 0) {
+        const logText = collector.formatAsText();
+        const logUrl = await simUploadLog(supabase, runId, logText);
+        githubIssueUrl = await simCreateGitHubIssue(
+          summary,
+          logUrl,
+          runId,
+          logText,
+        );
+      }
+
+      return successResponse({
+        success: summary.failed === 0,
+        run_id: runId,
+        summary,
+        github_issue_url: githubIssueUrl,
+        _axiom_debug: debugStatus(),
+      });
+    }
+
+    // ─────────────────────────────────────────────────────────
+    // Full 6-phase run (no phase param)
+    // ─────────────────────────────────────────────────────────
+
+    // Phase 1-2: Create parties + display events + discover & apply
+    const createResult = await simCreateParties(
+      supabase,
+      config,
+      logFn,
+      supabaseUrl,
+      anonKey,
     );
-  }
-
-  // ─────────────────────────────────────────────────────────
-  // Phase routing
-  // ─────────────────────────────────────────────────────────
-
-  // Phase: "create" → Phase 1-2 only
-  if (phase === "create") {
-    const createResult = await simCreateParties(supabase, config, logFn, supabaseUrl, anonKey);
     // Fix #964: 피드 전시용 이벤트 생성 — 일반 유저 피드에 표시할 display 이벤트를 E2E와 분리해 생성
-    const displayResult = await simCreateDisplayEvents(supabase, logFn, supabaseUrl, anonKey);
+    await simCreateDisplayEvents(supabase, logFn, supabaseUrl, anonKey);
     const applyResult = await simDiscoverAndApply(
       supabase,
       config,
@@ -167,148 +462,53 @@ Deno.serve(async (req: Request): Promise<Response> => {
       supabaseUrl,
       anonKey,
     );
-    return successResponse({
-      success: true,
-      run_id: runId,
-      party_ids: createResult.partyIds,
-      event_ids: createResult.eventIds,
-      display_party_ids: displayResult.displayPartyIds,
-      display_event_ids: displayResult.displayEventIds,
-      application_ids: applyResult.applicationIds,
-      paid_application_ids: applyResult.paidApplicationIds,
-      pending_review_application_ids: applyResult.pendingReviewApplicationIds,
-    });
-  }
 
-  // Phase: "approve" → Phase 3 only
-  if (phase === "approve") {
-    // Fetch current pendingReview applications from DB
-    const { data: pendingApps, error: fetchErr } = await supabase
-      .from("event_applications")
-      .select("id")
-      .eq("status", "pending_review")
-      .limit(50);
-
-    if (fetchErr) {
-      return errorResponse(`Failed to fetch pending applications: ${fetchErr.message}`, 500);
-    }
-
-    const pendingIds = ((pendingApps ?? []) as Array<{ id: string }>).map(
-      (a) => a.id,
-    );
+    // Phase 3: Approve verifications (80% approve, 20% reject)
     const approveResult = await simApproveVerifications(
       supabase,
-      pendingIds,
+      applyResult.pendingReviewApplicationIds,
       logFn,
       undefined,
       supabaseUrl,
       anonKey,
     );
-    return successResponse({
-      success: true,
-      run_id: runId,
-      approved_application_ids: approveResult.approvedApplicationIds,
-      rejected_application_ids: approveResult.rejectedApplicationIds,
-      assertions: approveResult.assertions,
-    });
-  }
 
-  // Phase: "refund" → Phase 4 only
-  if (phase === "refund") {
-    const { data: paidApps, error: fetchErr } = await supabase
-      .from("event_applications")
-      .select("id")
-      .eq("status", "paid")
-      .limit(50);
-
-    if (fetchErr) {
-      return errorResponse(`Failed to fetch paid applications: ${fetchErr.message}`, 500);
-    }
-
-    const paidIds = ((paidApps ?? []) as Array<{ id: string }>).map(
-      (a) => a.id,
-    );
+    // Phase 4: Refund requests (refund_rate % of paid)
     const refundResult = await simRefundRequests(
       supabase,
-      paidIds,
+      applyResult.paidApplicationIds,
       logFn,
       config.refund_rate,
       supabaseUrl,
       anonKey,
     );
-    return successResponse({
-      success: true,
-      run_id: runId,
-      refunded_application_ids: refundResult.refundedApplicationIds,
-      assertions: refundResult.assertions,
-    });
-  }
 
-  // Phase: "run" → Phase 5 only (checkin + match + complete)
-  if (phase === "run") {
-    // Fix #964: E2E 전용 필터 — run phase는 [E2E] 파티 이벤트만 처리해 비E2E 데이터 오염 방지
-    const { data: scheduledEvents, error: fetchErr } = await supabase
-      .from("events")
-      .select("id, parties!inner(title)")
-      .eq("status", "scheduled")
-      .filter("parties.title", "like", "[E2E]%")
-      .limit(50);
-
-    if (fetchErr) {
-      return errorResponse(`Failed to fetch events: ${fetchErr.message}`, 500);
-    }
-
-    const eventIds = ((scheduledEvents ?? []) as Array<{ id: string }>).map(
-      (e) => e.id,
-    );
+    // Phase 5: Check-in + Match + Complete
     const checkinResult = await simCheckin(
       supabase,
-      eventIds,
+      createResult.eventIds,
       logFn,
       config.checkin_rate,
       supabaseUrl,
       anonKey,
     );
-    const matchResult = await simMatch(supabase, eventIds, logFn, supabaseUrl, serviceRoleKey);
-    const completeResult = await simCompleteEvents(supabase, eventIds, logFn);
+    const matchResult = await simMatch(
+      supabase,
+      createResult.eventIds,
+      logFn,
+      supabaseUrl,
+      serviceRoleKey,
+    );
+    const completeResult = await simCompleteEvents(
+      supabase,
+      createResult.eventIds,
+      logFn,
+    );
 
-    const allAssertions: SimAssertionResult[] = [
-      ...checkinResult.assertions,
-      ...matchResult.assertions,
-      ...completeResult.assertions,
-    ];
-
-    return successResponse({
-      success: true,
-      run_id: runId,
-      checked_in_participant_ids: checkinResult.checkedInParticipantIds,
-      no_show_participant_ids: checkinResult.noShowParticipantIds,
-      match_pairs: matchResult.matchPairs,
-      completed_event_ids: completeResult.completedEventIds,
-      assertions: allAssertions,
-    });
-  }
-
-  // Phase: "settle" → Phase 6 only
-  if (phase === "settle") {
-    // Fix #964: E2E 전용 필터 — settle phase는 [E2E] 파티 이벤트만 처리해 비E2E 데이터 오염 방지
-    const { data: completedEvents, error: fetchErr } = await supabase
-      .from("events")
-      .select("id, parties!inner(title)")
-      .eq("status", "completed")
-      .filter("parties.title", "like", "[E2E]%")
-      .limit(50);
-
-    if (fetchErr) {
-      return errorResponse(`Failed to fetch completed events: ${fetchErr.message}`, 500);
-    }
-
-    const completedEventIds = (
-      (completedEvents ?? []) as Array<{ id: string }>
-    ).map((e) => e.id);
+    // Phase 6: Verify settlement + transition to ready
     const settleResult = await simVerifySettlement(
       supabase,
-      completedEventIds,
+      completeResult.completedEventIds,
       logFn,
     );
     const readyResult = await simTransitionToReady(
@@ -317,57 +517,43 @@ Deno.serve(async (req: Request): Promise<Response> => {
       logFn,
     );
 
+    // Collect ALL assertions
     const allAssertions: SimAssertionResult[] = [
+      ...approveResult.assertions,
+      ...refundResult.assertions,
+      ...checkinResult.assertions,
+      ...matchResult.assertions,
+      ...completeResult.assertions,
       ...settleResult.assertions,
       ...readyResult.assertions,
     ];
 
-    return successResponse({
-      success: true,
-      run_id: runId,
-      settlement_ids: settleResult.settlementIds,
-      ready_ids: readyResult.readyIds,
-      assertions: allAssertions,
-    });
-  }
-
-  // Phase: "verify" → read-only assertion check against current DB state
-  if (phase === "verify") {
-    // Fix #964: E2E 전용 필터 — verify phase는 [E2E] 파티 이벤트만 검증해 비E2E 데이터 오염 방지
-    // Collect assertions from settlement state only (non-destructive)
-    const { data: completedEvents, error: fetchErr } = await supabase
-      .from("events")
-      .select("id, parties!inner(title)")
-      .eq("status", "completed")
-      .filter("parties.title", "like", "[E2E]%")
-      .limit(50);
-
-    if (fetchErr) {
-      return errorResponse(`Failed to fetch completed events: ${fetchErr.message}`, 500);
+    // force_fail: add a deliberate failing assertion for reporter testing
+    if (forceFail) {
+      allAssertions.push({
+        check_name: "force_fail_test",
+        passed: false,
+        expected: "always_fail",
+        actual: "force_fail_triggered",
+        details: "Deliberate failure for testing reporter",
+      });
     }
 
-    const completedEventIds = (
-      (completedEvents ?? []) as Array<{ id: string }>
-    ).map((e) => e.id);
-
-    const settleResult = await simVerifySettlement(
-      supabase,
-      completedEventIds,
-      logFn,
-    );
-
+    // Build summary
     const summary: SimSummary = {
-      total_checks: settleResult.assertions.length,
-      passed: settleResult.assertions.filter((a) => a.passed).length,
-      failed: settleResult.assertions.filter((a) => !a.passed).length,
-      assertion_results: settleResult.assertions,
+      total_checks: allAssertions.length,
+      passed: allAssertions.filter((a) => a.passed).length,
+      failed: allAssertions.filter((a) => !a.passed).length,
+      assertion_results: allAssertions,
     };
 
-    // Create GitHub issue on assertion failure
+    // Upload log to Storage
+    const logText = collector.formatAsText();
+    const logUrl = await simUploadLog(supabase, runId, logText);
+
+    // Create GitHub Issue if there are failures
     let githubIssueUrl: string | null = null;
     if (summary.failed > 0) {
-      const logText = collector.formatAsText();
-      const logUrl = await simUploadLog(supabase, runId, logText);
       githubIssueUrl = await simCreateGitHubIssue(
         summary,
         logUrl,
@@ -376,146 +562,38 @@ Deno.serve(async (req: Request): Promise<Response> => {
       );
     }
 
+    log({
+      function: FN,
+      level: summary.failed > 0 ? "error" : "info",
+      message: "completed",
+      metadata: {
+        runId,
+        passed: summary.passed,
+        failed: summary.failed,
+        total: summary.total_checks,
+        logUrl,
+        githubIssueUrl,
+      },
+    });
+
     return successResponse({
       success: summary.failed === 0,
       run_id: runId,
       summary,
+      log_url: logUrl,
       github_issue_url: githubIssueUrl,
-      _axiom_debug: debugStatus(),
     });
-  }
-
-  // ─────────────────────────────────────────────────────────
-  // Full 6-phase run (no phase param)
-  // ─────────────────────────────────────────────────────────
-
-  // Phase 1-2: Create parties + display events + discover & apply
-  const createResult = await simCreateParties(supabase, config, logFn, supabaseUrl, anonKey);
-  // Fix #964: 피드 전시용 이벤트 생성 — 일반 유저 피드에 표시할 display 이벤트를 E2E와 분리해 생성
-  await simCreateDisplayEvents(supabase, logFn, supabaseUrl, anonKey);
-  const applyResult = await simDiscoverAndApply(
-    supabase,
-    config,
-    logFn,
-    createResult.eventIds,
-    supabaseUrl,
-    anonKey,
-  );
-
-  // Phase 3: Approve verifications (80% approve, 20% reject)
-  const approveResult = await simApproveVerifications(
-    supabase,
-    applyResult.pendingReviewApplicationIds,
-    logFn,
-    undefined,
-    supabaseUrl,
-    anonKey,
-  );
-
-  // Phase 4: Refund requests (refund_rate % of paid)
-  const refundResult = await simRefundRequests(
-    supabase,
-    applyResult.paidApplicationIds,
-    logFn,
-    config.refund_rate,
-    supabaseUrl,
-    anonKey,
-  );
-
-  // Phase 5: Check-in + Match + Complete
-  const checkinResult = await simCheckin(
-    supabase,
-    createResult.eventIds,
-    logFn,
-    config.checkin_rate,
-    supabaseUrl,
-    anonKey,
-  );
-  const matchResult = await simMatch(supabase, createResult.eventIds, logFn, supabaseUrl, serviceRoleKey);
-  const completeResult = await simCompleteEvents(
-    supabase,
-    createResult.eventIds,
-    logFn,
-  );
-
-  // Phase 6: Verify settlement + transition to ready
-  const settleResult = await simVerifySettlement(
-    supabase,
-    completeResult.completedEventIds,
-    logFn,
-  );
-  const readyResult = await simTransitionToReady(
-    supabase,
-    settleResult.settlementIds,
-    logFn,
-  );
-
-  // Collect ALL assertions
-  const allAssertions: SimAssertionResult[] = [
-    ...approveResult.assertions,
-    ...refundResult.assertions,
-    ...checkinResult.assertions,
-    ...matchResult.assertions,
-    ...completeResult.assertions,
-    ...settleResult.assertions,
-    ...readyResult.assertions,
-  ];
-
-  // force_fail: add a deliberate failing assertion for reporter testing
-  if (forceFail) {
-    allAssertions.push({
-      check_name: "force_fail_test",
-      passed: false,
-      expected: "always_fail",
-      actual: "force_fail_triggered",
-      details: "Deliberate failure for testing reporter",
-    });
-  }
-
-  // Build summary
-  const summary: SimSummary = {
-    total_checks: allAssertions.length,
-    passed: allAssertions.filter((a) => a.passed).length,
-    failed: allAssertions.filter((a) => !a.passed).length,
-    assertion_results: allAssertions,
-  };
-
-  // Upload log to Storage
-  const logText = collector.formatAsText();
-  const logUrl = await simUploadLog(supabase, runId, logText);
-
-  // Create GitHub Issue if there are failures
-  let githubIssueUrl: string | null = null;
-  if (summary.failed > 0) {
-    githubIssueUrl = await simCreateGitHubIssue(
-      summary,
-      logUrl,
-      runId,
-      logText,
-    );
-  }
-
-  log({
-    function: FN,
-    level: summary.failed > 0 ? "error" : "info",
-    message: "completed",
-    metadata: { runId, passed: summary.passed, failed: summary.failed, total: summary.total_checks, logUrl, githubIssueUrl },
-  });
-
-  return successResponse({
-    success: summary.failed === 0,
-    run_id: runId,
-    summary,
-    log_url: logUrl,
-    github_issue_url: githubIssueUrl,
-  });
-
   } catch (err) {
     // Fix #1620: Unhandled exceptions caused Deno to return a bare "Internal
     // Server Error" with no body, making the root cause invisible in CI logs.
     // Catch here to return a JSON error response with the message.
     const message = err instanceof Error ? err.message : String(err);
-    log({ function: FN, level: "error", message: "unhandled exception", metadata: { runId, error: message } });
+    log({
+      function: FN,
+      level: "error",
+      message: "unhandled exception",
+      metadata: { runId, error: message },
+    });
     return errorResponse(`Unhandled exception: ${message}`, 500);
   } finally {
     // Wrap flush so a log-flush failure cannot replace the JSON error response.

--- a/supabase/functions/bug-report/index.ts
+++ b/supabase/functions/bug-report/index.ts
@@ -1,6 +1,11 @@
-import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler, log } from "../_shared/logger.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
+import { initSentry, log, withHandler } from "../_shared/logger.ts";
 
 const FN = "bug-report";
 
@@ -17,14 +22,19 @@ Deno.serve(withHandler(async (req) => {
   if (auth instanceof Response) return auth;
 
   try {
-    let reqBody: Record<string, unknown>;
-    try {
-      reqBody = await req.json();
-    } catch {
-      return errorResponse("Invalid JSON body", 400);
-    }
+    const body = await parseJsonBody(req);
+    if (body instanceof Response) return body;
 
-    const { title, description, logs, timestamp, platform, screenshotUrl, environment, layoutDumpUrl } = reqBody as {
+    const {
+      title,
+      description,
+      logs,
+      timestamp,
+      platform,
+      screenshotUrl,
+      environment,
+      layoutDumpUrl,
+    } = body as {
       title?: string;
       description?: string;
       logs?: string;
@@ -40,30 +50,30 @@ Deno.serve(withHandler(async (req) => {
     }
 
     const MAX_BODY_LENGTH = 60000;
-    const logsStr = logs ?? '';
+    const logsStr = logs ?? "";
     const truncatedLogs = logsStr.length > MAX_BODY_LENGTH
-      ? logsStr.substring(0, MAX_BODY_LENGTH) + '\n...[truncated]'
+      ? logsStr.substring(0, MAX_BODY_LENGTH) + "\n...[truncated]"
       : logsStr;
 
     // Screenshot section (only if screenshotUrl is truthy)
     const screenshotSection = screenshotUrl
       ? `\n\n## Screenshot\n![Screenshot](${screenshotUrl})\n`
-      : '';
+      : "";
 
     // Environment section (only if environment is a non-null object)
-    const environmentSection = environment && typeof environment === 'object'
+    const environmentSection = environment && typeof environment === "object"
       ? `\n\n## Environment\n| Key | Value |\n|-----|-------|\n${
-          Object.entries(environment)
-            .filter(([, v]) => v != null)
-            .map(([k, v]) => `| ${k} | ${v} |`)
-            .join('\n')
-        }\n`
-      : '';
+        Object.entries(environment)
+          .filter(([, v]) => v != null)
+          .map(([k, v]) => `| ${k} | ${v} |`)
+          .join("\n")
+      }\n`
+      : "";
 
     // Layout Dump section (only if layoutDumpUrl is truthy)
     const layoutDumpSection = layoutDumpUrl
       ? `\n\n## Layout Dump\n[📐 View Layout Dump](${layoutDumpUrl})\n`
-      : '';
+      : "";
 
     if (!GITHUB_TOKEN) {
       throw new Error("GITHUB_ACCESS_TOKEN is not set");
@@ -76,7 +86,7 @@ Deno.serve(withHandler(async (req) => {
 ${description}
 
 **Environment:**
-- Platform: ${platform ?? 'Unknown'}
+- Platform: ${platform ?? "Unknown"}
 - Timestamp: ${timestamp}
 
 <details>
@@ -89,33 +99,45 @@ ${truncatedLogs}
 </details>
 ${screenshotSection}${environmentSection}${layoutDumpSection}`;
 
-    const response = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/issues`, {
-      method: "POST",
-      headers: {
-        "Authorization": `Bearer ${GITHUB_TOKEN}`,
-        "Content-Type": "application/json",
-        "User-Agent": "Minglit-Bug-Reporter"
+    const response = await fetch(
+      `https://api.github.com/repos/${GITHUB_REPO}/issues`,
+      {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${GITHUB_TOKEN}`,
+          "Content-Type": "application/json",
+          "User-Agent": "Minglit-Bug-Reporter",
+        },
+        body: JSON.stringify({
+          title: `[Bug Report] ${title}`,
+          body: body,
+          labels: ["bug-report", "from-app"],
+        }),
       },
-      body: JSON.stringify({
-        title: `[Bug Report] ${title}`,
-        body: body,
-        labels: ["bug-report", "from-app"]
-      })
-    });
+    );
 
     if (!response.ok) {
       const errorText = await response.text();
-      log({ function: FN, level: "error", message: "GitHub API Error", metadata: { detail: errorText } });
+      log({
+        function: FN,
+        level: "error",
+        message: "GitHub API Error",
+        metadata: { detail: errorText },
+      });
       throw new Error(`GitHub API Error: ${response.status}`);
     }
 
     const data = await response.json();
 
     return successResponse({ success: true, url: data.html_url });
-
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    log({ function: FN, level: "error", message: "Internal Error", metadata: { detail: message } });
+    log({
+      function: FN,
+      level: "error",
+      message: "Internal Error",
+      metadata: { detail: message },
+    });
     return errorResponse(message, 500);
   }
 }));

--- a/supabase/functions/bug-report/index.ts
+++ b/supabase/functions/bug-report/index.ts
@@ -79,7 +79,7 @@ Deno.serve(withHandler(async (req) => {
       throw new Error("GITHUB_ACCESS_TOKEN is not set");
     }
 
-    const body = `
+    const issueBody = `
 ### 🐞 Bug Report
 
 **Description:**
@@ -110,7 +110,7 @@ ${screenshotSection}${environmentSection}${layoutDumpSection}`;
         },
         body: JSON.stringify({
           title: `[Bug Report] ${title}`,
-          body: body,
+          body: issueBody,
           labels: ["bug-report", "from-app"],
         }),
       },

--- a/supabase/functions/dev-mock-portone/index.ts
+++ b/supabase/functions/dev-mock-portone/index.ts
@@ -1,84 +1,81 @@
 import { initSentry, withHandler } from "../_shared/logger.ts";
-
+import { parseJsonBody } from "../_shared/request_utils.ts";
 
 initSentry();
 
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-}
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+};
 
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-  })
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
 }
 
 Deno.serve(withHandler(async (req) => {
   // Handle CORS preflight
-  if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders })
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
   }
 
   // Dev-only guard
-  const env = Deno.env.get('ENVIRONMENT')
+  const env = Deno.env.get("ENVIRONMENT");
   // Fix #1614: "dev" = Supabase dev project (set by supabase-deploy.yml secrets)
-  if (env !== 'local' && env !== 'development' && env !== 'dev') {
-    return json({ error: 'Dev-only function. Blocked in production.' }, 403)
+  if (env !== "local" && env !== "development" && env !== "dev") {
+    return json({ error: "Dev-only function. Blocked in production." }, 403);
   }
 
-  const url = new URL(req.url)
-  const path = url.pathname
+  const url = new URL(req.url);
+  const path = url.pathname;
 
   // Strip function prefix if present (e.g. /functions/v1/dev-mock-portone/users/getToken)
-  const apiPath = path.replace(/^.*\/dev-mock-portone/, '') || '/'
+  const apiPath = path.replace(/^.*\/dev-mock-portone/, "") || "/";
 
   // POST /users/getToken
-  if (req.method === 'POST' && apiPath === '/users/getToken') {
+  if (req.method === "POST" && apiPath === "/users/getToken") {
     return json({
       code: 0,
-      response: { access_token: 'mock-token-for-testing' },
-    })
+      response: { access_token: "mock-token-for-testing" },
+    });
   }
 
   // GET /payments/:imp_uid
-  const paymentsGetMatch = apiPath.match(/^\/payments\/([^/]+)$/)
-  if (req.method === 'GET' && paymentsGetMatch) {
-    const impUid = paymentsGetMatch[1]
-    if (impUid.startsWith('imp_fail_')) {
-      return json({ code: 0, response: { status: 'failed' } })
+  const paymentsGetMatch = apiPath.match(/^\/payments\/([^/]+)$/);
+  if (req.method === "GET" && paymentsGetMatch) {
+    const impUid = paymentsGetMatch[1];
+    if (impUid.startsWith("imp_fail_")) {
+      return json({ code: 0, response: { status: "failed" } });
     }
     return json({
       code: 0,
       response: {
-        status: 'paid',
+        status: "paid",
         amount: 15000,
-        merchant_uid: 'order-test-123',
+        merchant_uid: "order-test-123",
         imp_uid: impUid,
       },
-    })
+    });
   }
 
   // POST /payments/cancel
-  if (req.method === 'POST' && apiPath === '/payments/cancel') {
-    let body: Record<string, unknown> = {}
-    try {
-      body = await req.json()
-    } catch {
-      return json({ error: 'Invalid JSON body' }, 400)
-    }
-    const impUid = body.imp_uid as string
+  if (req.method === "POST" && apiPath === "/payments/cancel") {
+    const body = await parseJsonBody(req);
+    if (body instanceof Response) return body;
+    const impUid = body.imp_uid as string;
     return json({
       code: 0,
       response: {
         imp_uid: impUid,
-        status: 'cancelled',
+        status: "cancelled",
         cancel_amount: 15000,
       },
-    })
+    });
   }
 
-  return json({ error: 'Not found' }, 404)
+  return json({ error: "Not found" }, 404);
 }));

--- a/supabase/functions/event-checkin/index.ts
+++ b/supabase/functions/event-checkin/index.ts
@@ -1,9 +1,14 @@
 // event-checkin/index.ts — Check-in a participant for an event
 
 import { createServiceClient } from "../_shared/supabase_client.ts";
-import { corsResponse, errorResponse, successResponse } from "../_shared/response_utils.ts";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler, log } from "../_shared/logger.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
+import { initSentry, log, withHandler } from "../_shared/logger.ts";
 
 const FN = "event-checkin";
 
@@ -11,9 +16,9 @@ initSentry();
 
 // Fix #1491: base64url 디코딩 — Ed25519 서명 바이트 복원
 function base64UrlDecode(str: string): Uint8Array {
-  const padded = str.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = str.replace(/-/g, "+").replace(/_/g, "/");
   const padding = (4 - (padded.length % 4)) % 4;
-  const base64 = padded + '='.repeat(padding);
+  const base64 = padded + "=".repeat(padding);
   const binary = atob(base64);
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) {
@@ -28,14 +33,10 @@ Deno.serve(withHandler(async (req) => {
   const auth = await requireAuth(req);
   if (auth instanceof Response) return auth;
 
-  let reqBody: Record<string, unknown>;
-  try {
-    reqBody = await req.json();
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
+  const body = await parseJsonBody(req);
+  if (body instanceof Response) return body;
 
-  const { event_id, participant_id, signature, expires_at } = reqBody as {
+  const { event_id, participant_id, signature, expires_at } = body as {
     event_id?: string;
     participant_id?: string;
     signature?: string;
@@ -43,12 +44,18 @@ Deno.serve(withHandler(async (req) => {
   };
 
   if (!event_id || !participant_id) {
-    return errorResponse("Missing required parameters: event_id, participant_id", 400);
+    return errorResponse(
+      "Missing required parameters: event_id, participant_id",
+      400,
+    );
   }
 
   // Fix #1491: QR 서명 검증을 위한 파라미터 — signature/expires_at이 없으면 요청 거부
   if (!signature || !expires_at) {
-    return errorResponse("Missing required parameters: signature, expires_at", 400);
+    return errorResponse(
+      "Missing required parameters: signature, expires_at",
+      400,
+    );
   }
 
   // Fix #1491: expires_at 만료 확인
@@ -68,7 +75,12 @@ Deno.serve(withHandler(async (req) => {
     .maybeSingle();
 
   if (fetchErr) {
-    log({ function: FN, level: "error", message: "Failed to fetch participant", metadata: { detail: fetchErr.message } });
+    log({
+      function: FN,
+      level: "error",
+      message: "Failed to fetch participant",
+      metadata: { detail: fetchErr.message },
+    });
     return errorResponse("Failed to fetch participant", 500);
   }
 
@@ -78,13 +90,20 @@ Deno.serve(withHandler(async (req) => {
 
   // Validate caller is the participant's user
   if ((participant as { user_id: string }).user_id !== auth) {
-    return errorResponse("Forbidden: caller is not the participant's user", 403);
+    return errorResponse(
+      "Forbidden: caller is not the participant's user",
+      403,
+    );
   }
 
   // Fix #1491: 서버 측 Ed25519 QR 서명 검증 — 클라이언트 우회 방지
   const publicKeyJwkStr = Deno.env.get("TICKET_SIGNING_PUBLIC_KEY_JWK");
   if (!publicKeyJwkStr) {
-    log({ function: FN, level: "error", message: "TICKET_SIGNING_PUBLIC_KEY_JWK not configured" });
+    log({
+      function: FN,
+      level: "error",
+      message: "TICKET_SIGNING_PUBLIC_KEY_JWK not configured",
+    });
     return errorResponse("Ticket verification key not configured", 500);
   }
 
@@ -103,13 +122,28 @@ Deno.serve(withHandler(async (req) => {
     const message = new TextEncoder().encode(payload);
     const sigBytes = base64UrlDecode(signature);
 
-    const valid = await crypto.subtle.verify("Ed25519", publicKey, sigBytes, message);
+    const valid = await crypto.subtle.verify(
+      "Ed25519",
+      publicKey,
+      sigBytes,
+      message,
+    );
     if (!valid) {
-      log({ function: FN, level: "warn", message: "QR signature verification failed", metadata: { participant_id, event_id } });
+      log({
+        function: FN,
+        level: "warn",
+        message: "QR signature verification failed",
+        metadata: { participant_id, event_id },
+      });
       return errorResponse("Invalid QR signature", 403);
     }
   } catch (e) {
-    log({ function: FN, level: "error", message: "Signature verification error", metadata: { detail: String(e) } });
+    log({
+      function: FN,
+      level: "error",
+      message: "Signature verification error",
+      metadata: { detail: String(e) },
+    });
     return errorResponse("Signature verification failed", 500);
   }
 
@@ -121,7 +155,12 @@ Deno.serve(withHandler(async (req) => {
     .maybeSingle();
 
   if (eventFetchErr) {
-    log({ function: FN, level: "error", message: "Failed to fetch event", metadata: { detail: eventFetchErr.message } });
+    log({
+      function: FN,
+      level: "error",
+      message: "Failed to fetch event",
+      metadata: { detail: eventFetchErr.message },
+    });
     return errorResponse("Failed to fetch event", 500);
   }
 
@@ -131,7 +170,10 @@ Deno.serve(withHandler(async (req) => {
 
   const eventStatus = (event as { status: string }).status;
   if (eventStatus !== "active" && eventStatus !== "ongoing") {
-    return errorResponse("체크인은 active 또는 ongoing 상태의 이벤트에서만 가능합니다", 400);
+    return errorResponse(
+      "체크인은 active 또는 ongoing 상태의 이벤트에서만 가능합니다",
+      400,
+    );
   }
 
   const currentStatus = (participant as { status: string }).status;
@@ -141,7 +183,10 @@ Deno.serve(withHandler(async (req) => {
   }
 
   if (currentStatus !== "ticket_issued") {
-    return errorResponse(`Cannot check in participant with status '${currentStatus}'`, 400);
+    return errorResponse(
+      `Cannot check in participant with status '${currentStatus}'`,
+      400,
+    );
   }
 
   // Transition status: ticket_issued → checked_in
@@ -152,15 +197,28 @@ Deno.serve(withHandler(async (req) => {
     .eq("status", "ticket_issued");
 
   if (updateErr) {
-    log({ function: FN, level: "error", message: "Failed to update participant status", metadata: { detail: updateErr.message } });
+    log({
+      function: FN,
+      level: "error",
+      message: "Failed to update participant status",
+      metadata: { detail: updateErr.message },
+    });
     return errorResponse("Failed to check in participant", 500);
   }
 
   if ((count ?? 0) === 0) {
-    return errorResponse("Participant status changed concurrently, please retry", 409);
+    return errorResponse(
+      "Participant status changed concurrently, please retry",
+      409,
+    );
   }
 
-  log({ function: FN, level: "info", message: "Participant checked in", metadata: { participant_id, event_id } });
+  log({
+    function: FN,
+    level: "info",
+    message: "Participant checked in",
+    metadata: { participant_id, event_id },
+  });
 
   return successResponse({
     success: true,

--- a/supabase/functions/event-matching/index.ts
+++ b/supabase/functions/event-matching/index.ts
@@ -1,10 +1,15 @@
 // event-matching/index.ts — Create match pairs for checked-in participants of an event
 
 import { createServiceClient } from "../_shared/supabase_client.ts";
-import { corsResponse, errorResponse, successResponse } from "../_shared/response_utils.ts";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
 // Fix #592: requireAuth(일반 JWT) → requireServiceRole로 전환하여 인가 우회 차단
 import { requireServiceRole } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler, log } from "../_shared/logger.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
+import { initSentry, log, withHandler } from "../_shared/logger.ts";
 
 const FN = "event-matching";
 
@@ -17,14 +22,10 @@ Deno.serve(withHandler(async (req) => {
   const auth = requireServiceRole(req);
   if (auth instanceof Response) return auth;
 
-  let reqBody: Record<string, unknown>;
-  try {
-    reqBody = await req.json();
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
+  const body = await parseJsonBody(req);
+  if (body instanceof Response) return body;
 
-  const { event_id } = reqBody as { event_id?: string };
+  const { event_id } = body as { event_id?: string };
 
   if (!event_id) {
     return errorResponse("Missing required parameter: event_id", 400);
@@ -39,16 +40,28 @@ Deno.serve(withHandler(async (req) => {
     .eq("event_id", event_id);
 
   if (existingErr) {
-    log({ function: FN, level: "error", message: "Failed to check existing pairs", metadata: { detail: existingErr.message } });
+    log({
+      function: FN,
+      level: "error",
+      message: "Failed to check existing pairs",
+      metadata: { detail: existingErr.message },
+    });
     return errorResponse("Failed to check existing match pairs", 500);
   }
 
   if (existingPairs && existingPairs.length > 0) {
-    log({ function: FN, level: "info", message: "Match pairs already exist, returning existing", metadata: { event_id, count: existingPairs.length } });
+    log({
+      function: FN,
+      level: "info",
+      message: "Match pairs already exist, returning existing",
+      metadata: { event_id, count: existingPairs.length },
+    });
     return successResponse({
       success: true,
       match_count: existingPairs.length,
-      pairs: (existingPairs as Array<{ id: string; user_lower_id: string; user_higher_id: string }>).map((p) => ({
+      pairs: (existingPairs as Array<
+        { id: string; user_lower_id: string; user_higher_id: string }
+      >).map((p) => ({
         user1: p.user_lower_id,
         user2: p.user_higher_id,
       })),
@@ -63,12 +76,20 @@ Deno.serve(withHandler(async (req) => {
     .eq("event_id", event_id);
 
   if (groupsErr) {
-    log({ function: FN, level: "error", message: "Failed to fetch entry_groups", metadata: { detail: groupsErr.message } });
+    log({
+      function: FN,
+      level: "error",
+      message: "Failed to fetch entry_groups",
+      metadata: { detail: groupsErr.message },
+    });
     return errorResponse("Failed to fetch entry groups", 500);
   }
 
   if (!groups || groups.length < 2) {
-    return errorResponse("Event must have at least 2 entry groups for matching", 400);
+    return errorResponse(
+      "Event must have at least 2 entry groups for matching",
+      400,
+    );
   }
 
   const groupList = groups as Array<{ id: string; gender: string }>;
@@ -83,28 +104,51 @@ Deno.serve(withHandler(async (req) => {
     .eq("status", "checked_in");
 
   if (partErr) {
-    log({ function: FN, level: "error", message: "Failed to fetch participants", metadata: { detail: partErr.message } });
+    log({
+      function: FN,
+      level: "error",
+      message: "Failed to fetch participants",
+      metadata: { detail: partErr.message },
+    });
     return errorResponse("Failed to fetch checked-in participants", 500);
   }
 
-  const partList = (participants ?? []) as Array<{ id: string; user_id: string; entry_group_id: string }>;
-  const groupAParticipants = partList.filter((p) => p.entry_group_id === groupAId);
-  const groupBParticipants = partList.filter((p) => p.entry_group_id === groupBId);
+  const partList = (participants ?? []) as Array<
+    { id: string; user_id: string; entry_group_id: string }
+  >;
+  const groupAParticipants = partList.filter((p) =>
+    p.entry_group_id === groupAId
+  );
+  const groupBParticipants = partList.filter((p) =>
+    p.entry_group_id === groupBId
+  );
 
   if (groupAParticipants.length === 0 || groupBParticipants.length === 0) {
-    return errorResponse("Both groups must have checked-in participants for matching", 400);
+    return errorResponse(
+      "Both groups must have checked-in participants for matching",
+      400,
+    );
   }
 
   // Create match pairs: pair up across groups (up to min count)
-  const pairsToInsert: Array<{ event_id: string; user_lower_id: string; user_higher_id: string }> = [];
-  const minCount = Math.min(groupAParticipants.length, groupBParticipants.length);
+  const pairsToInsert: Array<
+    { event_id: string; user_lower_id: string; user_higher_id: string }
+  > = [];
+  const minCount = Math.min(
+    groupAParticipants.length,
+    groupBParticipants.length,
+  );
 
   for (let i = 0; i < minCount; i++) {
     const userA = groupAParticipants[i].user_id;
     const userB = groupBParticipants[i].user_id;
     const lowerUserId = userA < userB ? userA : userB;
     const higherUserId = userA < userB ? userB : userA;
-    pairsToInsert.push({ event_id, user_lower_id: lowerUserId, user_higher_id: higherUserId });
+    pairsToInsert.push({
+      event_id,
+      user_lower_id: lowerUserId,
+      user_higher_id: higherUserId,
+    });
   }
 
   const { data: insertedPairs, error: insertErr } = await supabase
@@ -113,13 +157,25 @@ Deno.serve(withHandler(async (req) => {
     .select("id, user_lower_id, user_higher_id");
 
   if (insertErr) {
-    log({ function: FN, level: "error", message: "Failed to insert match pairs", metadata: { detail: insertErr.message } });
+    log({
+      function: FN,
+      level: "error",
+      message: "Failed to insert match pairs",
+      metadata: { detail: insertErr.message },
+    });
     return errorResponse("Failed to create match pairs", 500);
   }
 
-  const resultPairs = (insertedPairs ?? []) as Array<{ id: string; user_lower_id: string; user_higher_id: string }>;
+  const resultPairs = (insertedPairs ?? []) as Array<
+    { id: string; user_lower_id: string; user_higher_id: string }
+  >;
 
-  log({ function: FN, level: "info", message: "Match pairs created", metadata: { event_id, match_count: resultPairs.length } });
+  log({
+    function: FN,
+    level: "info",
+    message: "Match pairs created",
+    metadata: { event_id, match_count: resultPairs.length },
+  });
 
   return successResponse({
     success: true,

--- a/supabase/functions/identity-verify/identity_verify_test.ts
+++ b/supabase/functions/identity-verify/identity_verify_test.ts
@@ -150,7 +150,7 @@ Deno.test("identity-verify - unauthorized returns 401", async () => {
   );
 });
 
-Deno.test("identity-verify - malformed JSON returns 500", async () => {
+Deno.test("identity-verify - malformed JSON returns 400", async () => {
   await withEnv(
     {
       PORTONE_V2_API_KEY: "test-key",
@@ -167,8 +167,8 @@ Deno.test("identity-verify - malformed JSON returns 500", async () => {
           const response = await handler(request);
           const payload = await readJson(response);
 
-          assertEquals(response.status, 500);
-          assertEquals(typeof payload.error, "string");
+          assertEquals(response.status, 400);
+          assertEquals(payload.error, "Invalid JSON body");
         });
       });
     },

--- a/supabase/functions/identity-verify/index.ts
+++ b/supabase/functions/identity-verify/index.ts
@@ -3,7 +3,8 @@ import { createServiceClient } from "../_shared/supabase_client.ts";
 import { getPortoneClient } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler, log } from "../_shared/logger.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
+import { initSentry, log, withHandler } from "../_shared/logger.ts";
 // Fix #763: Portone 에러 응답에 PII 포함 가능 — JSON 문자열 내 PII 마스킹
 import { maskJsonString } from "../_shared/pii_masker.ts";
 
@@ -19,7 +20,11 @@ Deno.serve(withHandler(async (req) => {
   if (auth instanceof Response) return auth;
   const userId = auth;
   try {
-    const { identity_verification_id } = await req.json();
+    const body = await parseJsonBody(req);
+    if (body instanceof Response) return body;
+    const { identity_verification_id } = body as {
+      identity_verification_id?: string;
+    };
 
     if (!identity_verification_id) {
       return errorResponse("Missing identity_verification_id", 400);
@@ -29,21 +34,34 @@ Deno.serve(withHandler(async (req) => {
     const portone = getPortoneClient();
     let verification: Record<string, unknown>;
     try {
-      verification = await portone.getIdentityVerification(identity_verification_id);
+      verification = await portone.getIdentityVerification(
+        identity_verification_id,
+      );
     } catch (fetchError) {
       // Fix #763: Portone 에러에 이름/전화번호 등 PII 포함 가능.
       // JSON 파싱 시도하여 필드 단위 마스킹, 실패 시 상세 내용 로깅하지 않음.
-      const rawMsg = fetchError instanceof Error ? fetchError.message : String(fetchError);
+      const rawMsg = fetchError instanceof Error
+        ? fetchError.message
+        : String(fetchError);
       const maskedMsg = maskJsonString(rawMsg);
-      log({ function: FN, level: "error", message: "Portone V2 API Error", metadata: { detail: maskedMsg } });
+      log({
+        function: FN,
+        level: "error",
+        message: "Portone V2 API Error",
+        metadata: { detail: maskedMsg },
+      });
       return errorResponse("Failed to fetch verification info", 502, maskedMsg);
     }
 
     if (verification.status !== "VERIFIED") {
-      return errorResponse("Identity not verified", 400, { status: verification.status });
+      return errorResponse("Identity not verified", 400, {
+        status: verification.status,
+      });
     }
 
-    const customer = verification.verifiedCustomer as Record<string, unknown> | undefined;
+    const customer = verification.verifiedCustomer as
+      | Record<string, unknown>
+      | undefined;
     if (!customer) {
       return errorResponse("Verified customer data missing", 500);
     }
@@ -52,7 +70,9 @@ Deno.serve(withHandler(async (req) => {
     // Fix #809: ci/di 평문 컬럼 제거 후 ci_encrypted/di_encrypted/di_hash로 전환
     const supabase = createServiceClient();
 
-    const gender = typeof customer.gender === "string" ? customer.gender.toLowerCase() : undefined;
+    const gender = typeof customer.gender === "string"
+      ? customer.gender.toLowerCase()
+      : undefined;
 
     const { error: updateError } = await supabase.rpc("update_user_identity", {
       p_user_id: userId,
@@ -65,15 +85,24 @@ Deno.serve(withHandler(async (req) => {
     });
 
     if (updateError) {
-      log({ function: FN, level: "error", message: "DB Update Error", metadata: { detail: updateError } });
+      log({
+        function: FN,
+        level: "error",
+        message: "DB Update Error",
+        metadata: { detail: updateError },
+      });
       return errorResponse("Failed to update user profile", 500);
     }
 
     return successResponse({ success: true, user: userId });
-
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    log({ function: FN, level: "error", message: "Error in verify-identity", metadata: { detail: message } });
+    log({
+      function: FN,
+      level: "error",
+      message: "Error in verify-identity",
+      metadata: { detail: message },
+    });
     return errorResponse(message, 500);
   }
 }));

--- a/supabase/functions/metrics-alert/index.ts
+++ b/supabase/functions/metrics-alert/index.ts
@@ -1,4 +1,9 @@
-import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
 import { initSentry, withHandler } from "../_shared/logger.ts";
 
 const GITHUB_TOKEN = Deno.env.get("GITHUB_ACCESS_TOKEN");
@@ -25,12 +30,8 @@ Deno.serve(withHandler(async (req) => {
     return errorResponse("Unauthorized", 401);
   }
 
-  let body: Record<string, unknown>;
-  try {
-    body = await req.json();
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
+  const body = await parseJsonBody(req);
+  if (body instanceof Response) return body;
 
   const { type, title, body: alertBody } = body as {
     type?: string;
@@ -48,9 +49,11 @@ Deno.serve(withHandler(async (req) => {
 
   const labels = ALERT_LABELS[type] ?? ["metrics-alert", "auto-generated"];
 
-  const searchUrl = `https://api.github.com/search/issues?q=${encodeURIComponent(
-    `repo:${GITHUB_REPO} is:issue is:open label:metrics-alert "${title}" in:title`,
-  )}`;
+  const searchUrl = `https://api.github.com/search/issues?q=${
+    encodeURIComponent(
+      `repo:${GITHUB_REPO} is:issue is:open label:metrics-alert "${title}" in:title`,
+    )
+  }`;
 
   const searchRes = await fetch(searchUrl, {
     headers: {
@@ -87,19 +90,25 @@ Deno.serve(withHandler(async (req) => {
       return errorResponse(`GitHub API comment failed: ${errorText}`, 502);
     }
     await commentRes.body?.cancel();
-    return successResponse({ action: "commented", issue_number: existingIssue.number });
+    return successResponse({
+      action: "commented",
+      issue_number: existingIssue.number,
+    });
   }
 
-  const createRes = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/issues`, {
-    method: "POST",
-    headers: {
-      "Authorization": `Bearer ${GITHUB_TOKEN}`,
-      "Accept": "application/vnd.github.v3+json",
-      "Content-Type": "application/json",
-      "X-GitHub-Api-Version": "2022-11-28",
+  const createRes = await fetch(
+    `https://api.github.com/repos/${GITHUB_REPO}/issues`,
+    {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${GITHUB_TOKEN}`,
+        "Accept": "application/vnd.github.v3+json",
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: JSON.stringify({ title, body: alertBody, labels }),
     },
-    body: JSON.stringify({ title, body: alertBody, labels }),
-  });
+  );
 
   if (!createRes.ok) {
     const errorText = await createRes.text();
@@ -107,5 +116,9 @@ Deno.serve(withHandler(async (req) => {
   }
 
   const issue = await createRes.json();
-  return successResponse({ action: "created", issue_number: issue.number, url: issue.html_url });
+  return successResponse({
+    action: "created",
+    issue_number: issue.number,
+    url: issue.html_url,
+  });
 }));

--- a/supabase/functions/partner-approve-application/index.ts
+++ b/supabase/functions/partner-approve-application/index.ts
@@ -10,13 +10,15 @@ import {
 } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
+import { parseAction } from "../_shared/request_utils.ts";
 import { initSentry, withHandler, log } from "../_shared/logger.ts";
 
 const FN = "partner-approve-application";
 
 initSentry();
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 // Fix #1219: keep approval status filtering aligned with the capacity guard paths.
 const APPROVABLE_STATUSES = ["pending", "pending_review"] as const;
 
@@ -28,10 +30,18 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
     return await handleRequest(req);
   } catch (e) {
     const detail = e instanceof Error ? e.message : String(e);
-    log({ function: FN, level: "error", message: "partner-approve-application error", metadata: { detail } });
+    log({
+      function: FN,
+      level: "error",
+      message: "partner-approve-application error",
+      metadata: { detail },
+    });
     const env = Deno.env.get("ENVIRONMENT");
     const exposeDetail = env === "local" || env === "development";
-    return errorResponse(exposeDetail ? `${FN}: ${detail}` : "Internal server error", 500);
+    return errorResponse(
+      exposeDetail ? `${FN}: ${detail}` : "Internal server error",
+      500,
+    );
   }
 }));
 
@@ -42,19 +52,10 @@ async function handleRequest(req: Request): Promise<Response> {
   const userId = auth;
 
   // 2. Parse body
-  let body: Record<string, unknown>;
-  try {
-    const parsed = await req.json();
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return errorResponse("Request body must be a JSON object", 400);
-    }
-    body = parsed as Record<string, unknown>;
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
-
-  const action = body.action as string | undefined;
-  if (typeof action !== "string" || !action) {
+  const result = await parseAction(req);
+  if (result instanceof Response) return result;
+  const { action, body } = result;
+  if (!action) {
     return errorResponse("Missing action", 400);
   }
 
@@ -108,7 +109,11 @@ async function handleApprove(
   if (permCheck) return permCheck;
 
   // Verify status is approvable (after permission check)
-  if (!APPROVABLE_STATUSES.includes(app.status as typeof APPROVABLE_STATUSES[number])) {
+  if (
+    !APPROVABLE_STATUSES.includes(
+      app.status as typeof APPROVABLE_STATUSES[number],
+    )
+  ) {
     return errorResponse(
       `Cannot approve application with status '${app.status}'`,
       400,
@@ -123,7 +128,9 @@ async function handleApprove(
 
   if (approvalError) return errorResponse("Failed to approve application", 500);
 
-  const result = Array.isArray(approvalResult) ? approvalResult[0] : approvalResult;
+  const result = Array.isArray(approvalResult)
+    ? approvalResult[0]
+    : approvalResult;
   const resultStatus = result?.result_status as string | undefined;
 
   if (resultStatus === "approved") {
@@ -185,7 +192,9 @@ async function handleBulkApprove(
 
   if (bulkApprovalError) return errorResponse("Failed to bulk approve", 500);
 
-  const result = Array.isArray(bulkApprovalResult) ? bulkApprovalResult[0] : bulkApprovalResult;
+  const result = Array.isArray(bulkApprovalResult)
+    ? bulkApprovalResult[0]
+    : bulkApprovalResult;
   const resultStatus = result?.result_status as string | undefined;
 
   if (resultStatus === "invalid_capacity") {
@@ -198,8 +207,9 @@ async function handleBulkApprove(
     return errorResponse("Event not found", 404);
   }
 
-  const approvedCount =
-    typeof result?.approved_count === "number" ? result.approved_count : 0;
+  const approvedCount = typeof result?.approved_count === "number"
+    ? result.approved_count
+    : 0;
   const skippedDueToCapacity =
     typeof result?.skipped_due_to_capacity === "number"
       ? result.skipped_due_to_capacity

--- a/supabase/functions/partner-approve-application/partner_approve_application_test.ts
+++ b/supabase/functions/partner-approve-application/partner_approve_application_test.ts
@@ -194,7 +194,7 @@ Deno.test({
         const res = await handler(req);
         assertEquals(res.status, 400);
         const json = await readJson(res);
-        assertEquals(json.error, "Missing action");
+        assertEquals(json.error, "Missing or invalid \"action\" field");
       });
     });
   },

--- a/supabase/functions/partner-manage-event/index.ts
+++ b/supabase/functions/partner-manage-event/index.ts
@@ -10,8 +10,8 @@ import {
 } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
+import { parseAction } from "../_shared/request_utils.ts";
 import { initSentry, withHandler } from "../_shared/logger.ts";
-
 
 initSentry();
 
@@ -61,19 +61,10 @@ async function handleRequest(req: Request): Promise<Response> {
   const userId = auth;
 
   // 3. Parse body
-  let body: Record<string, unknown>;
-  try {
-    const parsed = await req.json();
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return errorResponse("Request body must be a JSON object", 400);
-    }
-    body = parsed as Record<string, unknown>;
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
-
-  const action = body.action as string | undefined;
-  if (typeof action !== "string" || !action) return errorResponse("Missing action", 400);
+  const result = await parseAction(req);
+  if (result instanceof Response) return result;
+  const { action, body } = result;
+  if (!action) return errorResponse("Missing action", 400);
 
   // 4. Supabase client (service role)
   const supabase = createServiceClient();
@@ -114,7 +105,10 @@ async function handleCreate(
   }
 
   const eventData = body.event;
-  if (typeof eventData !== "object" || eventData === null || Array.isArray(eventData)) {
+  if (
+    typeof eventData !== "object" || eventData === null ||
+    Array.isArray(eventData)
+  ) {
     return errorResponse("Missing or invalid event object", 400);
   }
   const event = eventData as Record<string, unknown>;
@@ -168,7 +162,10 @@ async function handleCreate(
         return errorResponse(`tickets[${i}].template_id is required`, 400);
       }
       if (typeof t.quantity !== "number" || t.quantity < 0) {
-        return errorResponse(`tickets[${i}].quantity must be a non-negative number`, 400);
+        return errorResponse(
+          `tickets[${i}].quantity must be a non-negative number`,
+          400,
+        );
       }
     }
   }
@@ -194,7 +191,10 @@ async function handleCreate(
     .single();
 
   if (eventInsertError) {
-    return errorResponse(`Failed to create event: ${eventInsertError.message}`, 500);
+    return errorResponse(
+      `Failed to create event: ${eventInsertError.message}`,
+      500,
+    );
   }
 
   const eventId = newEvent.id as string;
@@ -203,11 +203,16 @@ async function handleCreate(
   // Fix #317: ID를 포함해서 조회하여 target_entry_group_ids 재매핑에 사용
   const { data: templates, error: tplError } = await supabase
     .from("entry_group_templates")
-    .select("id, label, gender, birth_year_min, birth_year_max, required_verification_ids")
+    .select(
+      "id, label, gender, birth_year_min, birth_year_max, required_verification_ids",
+    )
     .eq("party_id", partyId);
 
   if (tplError) {
-    return errorResponse(`Failed to fetch entry group templates: ${tplError.message}`, 500);
+    return errorResponse(
+      `Failed to fetch entry group templates: ${tplError.message}`,
+      500,
+    );
   }
 
   // Map: template ID → new entry_group ID (for target_entry_group_ids remapping)
@@ -229,7 +234,10 @@ async function handleCreate(
       .select("id");
 
     if (egError) {
-      return errorResponse(`Failed to create entry groups: ${egError.message}`, 500);
+      return errorResponse(
+        `Failed to create entry groups: ${egError.message}`,
+        500,
+      );
     }
 
     // Build mapping from template ID to new entry_group ID (same order)
@@ -246,15 +254,22 @@ async function handleCreate(
   // Create tickets from ticket_templates
   if (Array.isArray(ticketInputs) && ticketInputs.length > 0) {
     // Fetch referenced ticket templates
-    const templateIds = ticketInputs.map((t: Record<string, unknown>) => t.template_id as string);
+    const templateIds = ticketInputs.map((t: Record<string, unknown>) =>
+      t.template_id as string
+    );
     const { data: ticketTemplates, error: ttError } = await supabase
       .from("ticket_templates")
-      .select("id, name, description, price, target_entry_group_ids, required_verification_ids")
+      .select(
+        "id, name, description, price, target_entry_group_ids, required_verification_ids",
+      )
       .eq("party_id", partyId)
       .in("id", templateIds);
 
     if (ttError) {
-      return errorResponse(`Failed to fetch ticket templates: ${ttError.message}`, 500);
+      return errorResponse(
+        `Failed to fetch ticket templates: ${ttError.message}`,
+        500,
+      );
     }
 
     const templateMap = new Map(
@@ -265,7 +280,10 @@ async function handleCreate(
     for (let i = 0; i < ticketInputs.length; i++) {
       const input = ticketInputs[i] as Record<string, unknown>;
       if (!templateMap.has(input.template_id)) {
-        return errorResponse(`tickets[${i}].template_id not found in party templates`, 400);
+        return errorResponse(
+          `tickets[${i}].template_id not found in party templates`,
+          400,
+        );
       }
     }
 
@@ -293,7 +311,10 @@ async function handleCreate(
       .insert(tickets);
 
     if (ticketInsertError) {
-      return errorResponse(`Failed to create tickets: ${ticketInsertError.message}`, 500);
+      return errorResponse(
+        `Failed to create tickets: ${ticketInsertError.message}`,
+        500,
+      );
     }
   }
 
@@ -320,7 +341,8 @@ async function handleUpdate(
   if (fetchError) return errorResponse("Failed to load event", 500);
   if (!event) return errorResponse("Event not found", 404);
 
-  const partnerId = (event.parties as Record<string, unknown>).partner_id as string;
+  const partnerId = (event.parties as Record<string, unknown>)
+    .partner_id as string;
 
   // Check partner permission
   const permCheck = await requirePartnerPermission(supabase, partnerId, userId, ["PARTY_MANAGE", "EVENT_MANAGE"]);
@@ -328,7 +350,10 @@ async function handleUpdate(
 
   // Build update fields
   const eventData = body.event;
-  if (typeof eventData !== "object" || eventData === null || Array.isArray(eventData)) {
+  if (
+    typeof eventData !== "object" || eventData === null ||
+    Array.isArray(eventData)
+  ) {
     return errorResponse("Missing or invalid event object", 400);
   }
   const input = eventData as Record<string, unknown>;
@@ -346,7 +371,9 @@ async function handleUpdate(
 
   // Validate time fields if provided
   if (updates.start_time !== undefined || updates.end_time !== undefined) {
-    const st = updates.start_time ? new Date(updates.start_time as string) : null;
+    const st = updates.start_time
+      ? new Date(updates.start_time as string)
+      : null;
     const et = updates.end_time ? new Date(updates.end_time as string) : null;
     if (st && isNaN(st.getTime())) {
       return errorResponse("Invalid start_time format", 400);
@@ -393,7 +420,10 @@ async function handleUpdateStatus(
   }
 
   if (!VALID_EVENT_STATUSES.includes(status)) {
-    return errorResponse(`Invalid status. Must be one of: ${VALID_EVENT_STATUSES.join(", ")}`, 400);
+    return errorResponse(
+      `Invalid status. Must be one of: ${VALID_EVENT_STATUSES.join(", ")}`,
+      400,
+    );
   }
 
   // Fetch event → party → partner
@@ -408,10 +438,14 @@ async function handleUpdateStatus(
 
   // Only scheduled → cancelled is allowed
   if (event.status !== "scheduled") {
-    return errorResponse(`Cannot change status from ${event.status} to ${status}`, 400);
+    return errorResponse(
+      `Cannot change status from ${event.status} to ${status}`,
+      400,
+    );
   }
 
-  const partnerId = (event.parties as Record<string, unknown>).partner_id as string;
+  const partnerId = (event.parties as Record<string, unknown>)
+    .partner_id as string;
 
   // Check partner permission
   const permCheck = await requirePartnerPermission(supabase, partnerId, userId, ["PARTY_MANAGE", "EVENT_MANAGE"]);
@@ -423,7 +457,10 @@ async function handleUpdateStatus(
     .eq("id", eventId);
 
   if (updateError) {
-    return errorResponse(`Failed to update event status: ${updateError.message}`, 500);
+    return errorResponse(
+      `Failed to update event status: ${updateError.message}`,
+      500,
+    );
   }
 
   return successResponse({ success: true });
@@ -456,8 +493,14 @@ async function handleUpdateTickets(
     if (t.price !== undefined && (typeof t.price !== "number" || t.price < 0)) {
       return errorResponse(`tickets[${i}].price must be >= 0`, 400);
     }
-    if (t.quantity !== undefined && (typeof t.quantity !== "number" || t.quantity < 0)) {
-      return errorResponse(`tickets[${i}].quantity must be a non-negative number`, 400);
+    if (
+      t.quantity !== undefined &&
+      (typeof t.quantity !== "number" || t.quantity < 0)
+    ) {
+      return errorResponse(
+        `tickets[${i}].quantity must be a non-negative number`,
+        400,
+      );
     }
   }
 
@@ -471,14 +514,17 @@ async function handleUpdateTickets(
   if (fetchError) return errorResponse("Failed to load event", 500);
   if (!event) return errorResponse("Event not found", 404);
 
-  const partnerId = (event.parties as Record<string, unknown>).partner_id as string;
+  const partnerId = (event.parties as Record<string, unknown>)
+    .partner_id as string;
 
   // Check partner permission
   const permCheck = await requirePartnerPermission(supabase, partnerId, userId, ["PARTY_MANAGE", "EVENT_MANAGE"]);
   if (permCheck) return permCheck;
 
   // Fetch existing tickets to validate sold_count
-  const ticketIds = ticketUpdates.map((t: Record<string, unknown>) => t.ticket_id as string);
+  const ticketIds = ticketUpdates.map((t: Record<string, unknown>) =>
+    t.ticket_id as string
+  );
   const { data: existingTickets, error: ticketFetchError } = await supabase
     .from("tickets")
     .select("id, sold_count, event_id")
@@ -498,11 +544,15 @@ async function handleUpdateTickets(
     const input = ticketUpdates[i] as Record<string, unknown>;
     const existing = ticketMap.get(input.ticket_id);
     if (!existing) {
-      return errorResponse(`tickets[${i}].ticket_id not found in this event`, 400);
+      return errorResponse(
+        `tickets[${i}].ticket_id not found in this event`,
+        400,
+      );
     }
     // Validate quantity >= sold_count
     if (input.quantity !== undefined) {
-      const soldCount = (existing as Record<string, unknown>).sold_count as number;
+      const soldCount = (existing as Record<string, unknown>)
+        .sold_count as number;
       if ((input.quantity as number) < soldCount) {
         return errorResponse(
           `tickets[${i}].quantity (${input.quantity}) cannot be less than sold_count (${soldCount})`,
@@ -531,7 +581,10 @@ async function handleUpdateTickets(
       .eq("event_id", eventId);
 
     if (updateError) {
-      return errorResponse(`Failed to update ticket: ${updateError.message}`, 500);
+      return errorResponse(
+        `Failed to update ticket: ${updateError.message}`,
+        500,
+      );
     }
   }
 

--- a/supabase/functions/partner-manage-event/partner_manage_event_test.ts
+++ b/supabase/functions/partner-manage-event/partner_manage_event_test.ts
@@ -284,7 +284,7 @@ Deno.test({
         const res = await handler(req);
         assertEquals(res.status, 400);
         const body = await readJson(res);
-        assertEquals(body.error, "Missing action");
+        assertEquals(body.error, "Missing or invalid \"action\" field");
       });
     });
   },

--- a/supabase/functions/partner-manage-match/index.ts
+++ b/supabase/functions/partner-manage-match/index.ts
@@ -9,8 +9,8 @@ import {
 } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
+import { parseAction } from "../_shared/request_utils.ts";
 import { initSentry, withHandler } from "../_shared/logger.ts";
-
 
 initSentry();
 
@@ -30,22 +30,15 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
   const userId = auth;
 
   // 3. Parse body
-  let body: Record<string, unknown>;
-  try {
-    const parsed = await req.json();
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return errorResponse("Request body must be a JSON object", 400);
-    }
-    body = parsed as Record<string, unknown>;
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
-
-  const action = body.action as string | undefined;
-  if (typeof action !== "string" || !action) return errorResponse("Missing action", 400);
+  const result = await parseAction(req);
+  if (result instanceof Response) return result;
+  const { action, body } = result;
+  if (!action) return errorResponse("Missing action", 400);
 
   const eventId = body.event_id;
-  if (typeof eventId !== "string" || !eventId) return errorResponse("Missing event_id", 400);
+  if (typeof eventId !== "string" || !eventId) {
+    return errorResponse("Missing event_id", 400);
+  }
 
   // 4. Supabase client (service role)
   const supabase = createServiceClient();
@@ -91,10 +84,16 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
     // Validate each rule
     for (const rule of rules) {
       if (!rule.source_group_id || !rule.target_group_id) {
-        return errorResponse("Each rule must have source_group_id and target_group_id", 400);
+        return errorResponse(
+          "Each rule must have source_group_id and target_group_id",
+          400,
+        );
       }
       if (rule.source_group_id === rule.target_group_id) {
-        return errorResponse("source_group_id and target_group_id must be different", 400);
+        return errorResponse(
+          "source_group_id and target_group_id must be different",
+          400,
+        );
       }
       const voteCount = rule.vote_count ?? 1;
       if (!Number.isInteger(voteCount) || voteCount < 1) {
@@ -105,7 +104,9 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
     // Validate all group IDs belong to this event
     if (rules.length > 0) {
       const allGroupIds = [
-        ...new Set(rules.flatMap((r) => [r.source_group_id, r.target_group_id])),
+        ...new Set(
+          rules.flatMap((r) => [r.source_group_id, r.target_group_id]),
+        ),
       ];
 
       const { data: groups, error: groupsError } = await supabase
@@ -118,7 +119,9 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
         return errorResponse("Failed to verify entry groups", 500);
       }
 
-      const validGroupIds = new Set((groups ?? []).map((g: { id: string }) => g.id));
+      const validGroupIds = new Set(
+        (groups ?? []).map((g: { id: string }) => g.id),
+      );
       const invalidIds = allGroupIds.filter((id) => !validGroupIds.has(id));
       if (invalidIds.length > 0) {
         return errorResponse(
@@ -141,7 +144,10 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
     });
 
     if (replaceError) {
-      return errorResponse(`Failed to replace rules: ${replaceError.message}`, 500);
+      return errorResponse(
+        `Failed to replace rules: ${replaceError.message}`,
+        500,
+      );
     }
 
     return successResponse({ success: true, count: rules.length });

--- a/supabase/functions/partner-manage-match/partner_manage_match_test.ts
+++ b/supabase/functions/partner-manage-match/partner_manage_match_test.ts
@@ -114,7 +114,7 @@ Deno.test({
         );
         assertEquals(res.status, 400);
         const body = await readJson(res);
-        assertEquals(body.error, "Missing action");
+        assertEquals(body.error, "Missing or invalid \"action\" field");
       });
     });
   },

--- a/supabase/functions/partner-manage-member/index.ts
+++ b/supabase/functions/partner-manage-member/index.ts
@@ -9,6 +9,7 @@ import {
 } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
+import { parseAction } from "../_shared/request_utils.ts";
 import { initSentry, withHandler, log } from "../_shared/logger.ts";
 
 const FN = "partner-manage-member";
@@ -42,29 +43,24 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
     const userId = auth;
 
     // 2. Parse body
-    let body: Record<string, unknown>;
-    try {
-      const parsed = await req.json();
-      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-        return errorResponse("Request body must be a JSON object", 400);
-      }
-      body = parsed as Record<string, unknown>;
-    } catch {
-      return errorResponse("Invalid JSON body", 400);
-    }
-
-    const action = body.action as string | undefined;
-    if (typeof action !== "string" || !action) return errorResponse("Missing action", 400);
+    const result = await parseAction(req);
+    if (result instanceof Response) return result;
+    const { action, body } = result;
+    if (!action) return errorResponse("Missing action", 400);
 
     // 3. Supabase client (service role)
     const supabase = createServiceClient();
 
     // ─── update_role ───
     if (action === "update_role") {
-      const partnerId = typeof body.partner_id === "string" ? body.partner_id.trim() : "";
+      const partnerId = typeof body.partner_id === "string"
+        ? body.partner_id.trim()
+        : "";
       if (!partnerId) return errorResponse("Missing partner_id", 400);
 
-      const targetUserId = typeof body.user_id === "string" ? body.user_id.trim() : "";
+      const targetUserId = typeof body.user_id === "string"
+        ? body.user_id.trim()
+        : "";
       if (!targetUserId) return errorResponse("Missing user_id", 400);
 
       const role = typeof body.role === "string" ? body.role.trim() : "";
@@ -91,7 +87,10 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
         .eq("user_id", targetUserId);
 
       if (updateError) {
-        return errorResponse(`Failed to update role: ${updateError.message}`, 500);
+        return errorResponse(
+          `Failed to update role: ${updateError.message}`,
+          500,
+        );
       }
 
       return successResponse({ success: true });
@@ -99,10 +98,14 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
 
     // ─── update_permissions ───
     if (action === "update_permissions") {
-      const partnerId = typeof body.partner_id === "string" ? body.partner_id.trim() : "";
+      const partnerId = typeof body.partner_id === "string"
+        ? body.partner_id.trim()
+        : "";
       if (!partnerId) return errorResponse("Missing partner_id", 400);
 
-      const targetUserId = typeof body.user_id === "string" ? body.user_id.trim() : "";
+      const targetUserId = typeof body.user_id === "string"
+        ? body.user_id.trim()
+        : "";
       if (!targetUserId) return errorResponse("Missing user_id", 400);
 
       if (!Array.isArray(body.permissions)) {
@@ -113,7 +116,10 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
 
       // Fix #313: permissions 화이트리스트 검증
       for (const perm of permissions) {
-        if (typeof perm !== "string" || !VALID_PERMISSIONS.includes(perm as typeof VALID_PERMISSIONS[number])) {
+        if (
+          typeof perm !== "string" ||
+          !VALID_PERMISSIONS.includes(perm as typeof VALID_PERMISSIONS[number])
+        ) {
           return errorResponse(`Invalid permission: ${perm}`, 400);
         }
       }
@@ -129,7 +135,10 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
         .eq("user_id", targetUserId);
 
       if (updateError) {
-        return errorResponse(`Failed to update permissions: ${updateError.message}`, 500);
+        return errorResponse(
+          `Failed to update permissions: ${updateError.message}`,
+          500,
+        );
       }
 
       return successResponse({ success: true });
@@ -138,9 +147,17 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
     return errorResponse(`Unknown action: ${action}`, 400);
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
-    log({ function: FN, level: "error", message: "partner-manage-member failed", metadata: { detail } });
+    log({
+      function: FN,
+      level: "error",
+      message: "partner-manage-member failed",
+      metadata: { detail },
+    });
     const env = Deno.env.get("ENVIRONMENT");
     const exposeDetail = env === "local" || env === "development";
-    return errorResponse(exposeDetail ? `${FN}: ${detail}` : "Internal server error", 500);
+    return errorResponse(
+      exposeDetail ? `${FN}: ${detail}` : "Internal server error",
+      500,
+    );
   }
 }));

--- a/supabase/functions/partner-manage-member/partner_manage_member_test.ts
+++ b/supabase/functions/partner-manage-member/partner_manage_member_test.ts
@@ -121,7 +121,7 @@ Deno.test({
         );
         assertEquals(res.status, 400);
         const body = await readJson(res);
-        assertEquals(body.error, "Missing action");
+        assertEquals(body.error, "Missing or invalid \"action\" field");
       });
     });
   },

--- a/supabase/functions/partner-manage-party/index.ts
+++ b/supabase/functions/partner-manage-party/index.ts
@@ -9,6 +9,7 @@ import {
 } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
+import { parseAction } from "../_shared/request_utils.ts";
 import { initSentry, withHandler } from "../_shared/logger.ts";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
@@ -73,21 +74,10 @@ async function handleRequest(req: Request): Promise<Response> {
   if (auth instanceof Response) return auth;
   const userId = auth;
 
-  let body: Record<string, unknown>;
-  try {
-    const parsed = await req.json();
-    if (
-      typeof parsed !== "object" || parsed === null || Array.isArray(parsed)
-    ) {
-      return errorResponse("Request body must be a JSON object", 400);
-    }
-    body = parsed as Record<string, unknown>;
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
-
-  const action = body.action as string | undefined;
-  if (typeof action !== "string" || !action) {
+  const result = await parseAction(req);
+  if (result instanceof Response) return result;
+  const { action, body } = result;
+  if (!action) {
     return errorResponse("Missing action", 400);
   }
 

--- a/supabase/functions/partner-manage-party/partner_manage_party_test.ts
+++ b/supabase/functions/partner-manage-party/partner_manage_party_test.ts
@@ -331,7 +331,7 @@ Deno.test({
         const res = await handler(req);
         assertEquals(res.status, 400);
         const body = await readJson(res);
-        assertEquals(body.error, "Missing action");
+        assertEquals(body.error, "Missing or invalid \"action\" field");
       });
     });
   },

--- a/supabase/functions/partner-manage-settlement/index.ts
+++ b/supabase/functions/partner-manage-settlement/index.ts
@@ -9,6 +9,7 @@ import {
 } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
+import { parseAction } from "../_shared/request_utils.ts";
 import { initSentry, withHandler, log } from "../_shared/logger.ts";
 
 const FN = "partner-manage-settlement";
@@ -36,42 +37,41 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
     const userId = auth;
 
     // 2. Parse body
-    let body: Record<string, unknown>;
-    try {
-      const parsed = await req.json();
-      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-        return errorResponse("Request body must be a JSON object", 400);
-      }
-      body = parsed as Record<string, unknown>;
-    } catch {
-      return errorResponse("Invalid JSON body", 400);
-    }
-
-    const action = body.action as string | undefined;
-    if (typeof action !== "string" || !action) return errorResponse("Missing action", 400);
+    const result = await parseAction(req);
+    if (result instanceof Response) return result;
+    const { action, body } = result;
+    if (!action) return errorResponse("Missing action", 400);
 
     // 3. Supabase client (service role)
     const supabase = createServiceClient();
 
     // ─── upsert_bank_account ───
     if (action === "upsert_bank_account") {
-      const partnerId = typeof body.partner_id === "string" ? body.partner_id.trim() : "";
+      const partnerId = typeof body.partner_id === "string"
+        ? body.partner_id.trim()
+        : "";
       if (!partnerId) {
         return errorResponse("Missing partner_id", 400);
       }
 
       // Validate required fields with trim
-      const bankName = typeof body.bank_name === "string" ? body.bank_name.trim() : "";
+      const bankName = typeof body.bank_name === "string"
+        ? body.bank_name.trim()
+        : "";
       if (!bankName) {
         return errorResponse("Missing bank_name", 400);
       }
 
-      const accountHolder = typeof body.account_holder === "string" ? body.account_holder.trim() : "";
+      const accountHolder = typeof body.account_holder === "string"
+        ? body.account_holder.trim()
+        : "";
       if (!accountHolder) {
         return errorResponse("Missing account_holder", 400);
       }
 
-      const rawAccountNumber = typeof body.account_number === "string" ? body.account_number.trim() : "";
+      const rawAccountNumber = typeof body.account_number === "string"
+        ? body.account_number.trim()
+        : "";
       if (!rawAccountNumber) {
         return errorResponse("Missing account_number", 400);
       }
@@ -99,7 +99,10 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
         .upsert(record, { onConflict: "partner_id" });
 
       if (upsertError) {
-        return errorResponse(`Failed to upsert bank account: ${upsertError.message}`, 500);
+        return errorResponse(
+          `Failed to upsert bank account: ${upsertError.message}`,
+          500,
+        );
       }
 
       return successResponse({ success: true });
@@ -107,7 +110,14 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
 
     return errorResponse(`Unknown action: ${action}`, 400);
   } catch (error) {
-    log({ function: FN, level: "error", message: "partner-manage-settlement failed", metadata: { detail: error instanceof Error ? error.message : String(error) } });
+    log({
+      function: FN,
+      level: "error",
+      message: "partner-manage-settlement failed",
+      metadata: {
+        detail: error instanceof Error ? error.message : String(error),
+      },
+    });
     return errorResponse("Internal server error", 500);
   }
 }));

--- a/supabase/functions/partner-manage-settlement/partner_manage_settlement_test.ts
+++ b/supabase/functions/partner-manage-settlement/partner_manage_settlement_test.ts
@@ -121,7 +121,7 @@ Deno.test({
         );
         assertEquals(res.status, 400);
         const body = await readJson(res);
-        assertEquals(body.error, "Missing action");
+        assertEquals(body.error, "Missing or invalid \"action\" field");
       });
     });
   },

--- a/supabase/functions/partner-manage-verification/index.ts
+++ b/supabase/functions/partner-manage-verification/index.ts
@@ -9,12 +9,19 @@ import {
 } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
+import { parseAction } from "../_shared/request_utils.ts";
 import { initSentry, withHandler } from "../_shared/logger.ts";
-
 
 initSentry();
 
-const VALID_CATEGORIES = ["career", "asset", "marriage", "academic", "vehicle", "etc"];
+const VALID_CATEGORIES = [
+  "career",
+  "asset",
+  "marriage",
+  "academic",
+  "vehicle",
+  "etc",
+];
 
 // Fields allowed in create action
 const CREATE_FIELDS = [
@@ -49,19 +56,10 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
   const userId = auth;
 
   // 3. Parse body
-  let body: Record<string, unknown>;
-  try {
-    const parsed = await req.json();
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return errorResponse("Request body must be a JSON object", 400);
-    }
-    body = parsed as Record<string, unknown>;
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
-
-  const action = body.action as string | undefined;
-  if (typeof action !== "string" || !action) return errorResponse("Missing action", 400);
+  const result = await parseAction(req);
+  if (result instanceof Response) return result;
+  const { action, body } = result;
+  if (!action) return errorResponse("Missing action", 400);
 
   // 4. Supabase client (service role)
   const supabase = createServiceClient();
@@ -108,7 +106,10 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
       .single();
 
     if (insertError) {
-      return errorResponse(`Failed to create verification: ${insertError.message}`, 500);
+      return errorResponse(
+        `Failed to create verification: ${insertError.message}`,
+        500,
+      );
     }
 
     return successResponse({ success: true, id: data.id });
@@ -123,7 +124,10 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
 
     // Validate category if provided
     if (body.category !== undefined) {
-      if (typeof body.category !== "string" || !VALID_CATEGORIES.includes(body.category)) {
+      if (
+        typeof body.category !== "string" ||
+        !VALID_CATEGORIES.includes(body.category)
+      ) {
         return errorResponse("Invalid category", 400);
       }
     }
@@ -164,7 +168,10 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
       .eq("id", verificationId);
 
     if (updateError) {
-      return errorResponse(`Failed to update verification: ${updateError.message}`, 500);
+      return errorResponse(
+        `Failed to update verification: ${updateError.message}`,
+        500,
+      );
     }
 
     return successResponse({ success: true });

--- a/supabase/functions/partner-manage-verification/partner_manage_verification_test.ts
+++ b/supabase/functions/partner-manage-verification/partner_manage_verification_test.ts
@@ -163,7 +163,7 @@ Deno.test({
         );
         assertEquals(res.status, 400);
         const body = await readJson(res);
-        assertEquals(body.error, "Missing action");
+        assertEquals(body.error, "Missing or invalid \"action\" field");
       });
     });
   },

--- a/supabase/functions/partner-register/index.ts
+++ b/supabase/functions/partner-register/index.ts
@@ -8,8 +8,8 @@ import {
   successResponse,
 } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
+import { parseAction } from "../_shared/request_utils.ts";
 import { initSentry, withHandler } from "../_shared/logger.ts";
-
 
 initSentry();
 import {
@@ -71,19 +71,10 @@ async function handleRequest(req: Request): Promise<Response> {
   const userId = auth;
 
   // 3. Parse body
-  let body: Record<string, unknown>;
-  try {
-    const parsed = await req.json();
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return errorResponse("Request body must be a JSON object", 400);
-    }
-    body = parsed as Record<string, unknown>;
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
-
-  const action = body.action as string | undefined;
-  if (typeof action !== "string" || !action) return errorResponse("Missing action", 400);
+  const result = await parseAction(req);
+  if (result instanceof Response) return result;
+  const { action, body } = result;
+  if (!action) return errorResponse("Missing action", 400);
 
   // 4. Supabase client (service role)
   const supabase = createServiceClient();
@@ -99,7 +90,9 @@ async function handleRequest(req: Request): Promise<Response> {
     for (const field of DRAFT_FIELDS) {
       if (body.data && typeof body.data === "object") {
         const val = (body.data as Record<string, unknown>)[field];
-        if (val !== undefined && (val !== null || CLEARABLE_FIELDS.has(field))) {
+        if (
+          val !== undefined && (val !== null || CLEARABLE_FIELDS.has(field))
+        ) {
           record[field] = val;
         }
       }
@@ -120,7 +113,10 @@ async function handleRequest(req: Request): Promise<Response> {
       }
       // Fix #311: pending/approved 신청서는 save_draft로 되돌릴 수 없음
       if (app.status !== "draft" && app.status !== "needs_correction") {
-        return errorResponse("Application cannot be updated in current status", 400);
+        return errorResponse(
+          "Application cannot be updated in current status",
+          400,
+        );
       }
 
       // Fix #311: 상태 조건을 UPDATE WHERE에 포함하여 원자적 검사
@@ -132,7 +128,10 @@ async function handleRequest(req: Request): Promise<Response> {
         .in("status", ["draft", "needs_correction"]);
 
       if (updateError) {
-        return errorResponse(`Failed to update draft: ${updateError.message}`, 500);
+        return errorResponse(
+          `Failed to update draft: ${updateError.message}`,
+          500,
+        );
       }
 
       return successResponse({ success: true, application_id: applicationId });
@@ -147,7 +146,10 @@ async function handleRequest(req: Request): Promise<Response> {
         .single();
 
       if (insertError) {
-        return errorResponse(`Failed to create draft: ${insertError.message}`, 500);
+        return errorResponse(
+          `Failed to create draft: ${insertError.message}`,
+          500,
+        );
       }
 
       return successResponse({ success: true, application_id: data.id });
@@ -182,7 +184,10 @@ async function handleRequest(req: Request): Promise<Response> {
 
     // Fix #311: draft/needs_correction 상태만 제출 가능
     if (app.status !== "draft" && app.status !== "needs_correction") {
-      return errorResponse("Application cannot be submitted in current status", 400);
+      return errorResponse(
+        "Application cannot be submitted in current status",
+        400,
+      );
     }
 
     // Server-side validation
@@ -216,8 +221,16 @@ async function handleRequest(req: Request): Promise<Response> {
 
     // Storage file existence checks
     const fileChecks: Array<[unknown, string, string]> = [
-      [app.biz_registration_path, "biz_registration_path", "사업자등록증 파일이 업로드되지 않았습니다"],
-      [app.bankbook_path, "bankbook_path", "통장사본 파일이 업로드되지 않았습니다"],
+      [
+        app.biz_registration_path,
+        "biz_registration_path",
+        "사업자등록증 파일이 업로드되지 않았습니다",
+      ],
+      [
+        app.bankbook_path,
+        "bankbook_path",
+        "통장사본 파일이 업로드되지 않았습니다",
+      ],
     ];
 
     for (const [path, field, message] of fileChecks) {
@@ -260,7 +273,10 @@ async function handleRequest(req: Request): Promise<Response> {
       .in("status", ["draft", "needs_correction"]);
 
     if (updateError) {
-      return errorResponse(`Failed to submit application: ${updateError.message}`, 500);
+      return errorResponse(
+        `Failed to submit application: ${updateError.message}`,
+        500,
+      );
     }
 
     return successResponse({ success: true });
@@ -294,7 +310,10 @@ async function handleRequest(req: Request): Promise<Response> {
 
     // Fix #311: draft/needs_correction 상태만 수정 가능
     if (app.status !== "draft" && app.status !== "needs_correction") {
-      return errorResponse("Application cannot be updated in current status", 400);
+      return errorResponse(
+        "Application cannot be updated in current status",
+        400,
+      );
     }
 
     // Build update record — only allow whitelisted fields; skip null for non-clearable fields.
@@ -303,7 +322,9 @@ async function handleRequest(req: Request): Promise<Response> {
     for (const field of DRAFT_FIELDS) {
       if (body.data && typeof body.data === "object") {
         const val = (body.data as Record<string, unknown>)[field];
-        if (val !== undefined && (val !== null || CLEARABLE_FIELDS.has(field))) {
+        if (
+          val !== undefined && (val !== null || CLEARABLE_FIELDS.has(field))
+        ) {
           updates[field] = val;
         }
       }
@@ -322,7 +343,10 @@ async function handleRequest(req: Request): Promise<Response> {
       .in("status", ["draft", "needs_correction"]);
 
     if (updateError) {
-      return errorResponse(`Failed to update application: ${updateError.message}`, 500);
+      return errorResponse(
+        `Failed to update application: ${updateError.message}`,
+        500,
+      );
     }
 
     return successResponse({ success: true, application_id: applicationId });
@@ -330,4 +354,3 @@ async function handleRequest(req: Request): Promise<Response> {
 
   return errorResponse(`Unknown action: ${action}`, 400);
 }
-

--- a/supabase/functions/partner-register/partner_register_test.ts
+++ b/supabase/functions/partner-register/partner_register_test.ts
@@ -166,7 +166,7 @@ Deno.test({
         );
         assertEquals(res.status, 400);
         const body = await readJson(res);
-        assertEquals(body.error, "Missing action");
+        assertEquals(body.error, "Missing or invalid \"action\" field");
       });
     });
   },

--- a/supabase/functions/partner-reject-application/index.ts
+++ b/supabase/functions/partner-reject-application/index.ts
@@ -9,13 +9,15 @@ import {
 } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
 import { initSentry, withHandler, log } from "../_shared/logger.ts";
 
 const FN = "partner-reject-application";
 
 initSentry();
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 Deno.serve(withHandler(async (req: Request): Promise<Response> => {
   if (req.method === "OPTIONS") return corsResponse();
@@ -24,7 +26,12 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
   try {
     return await handleRequest(req);
   } catch (e) {
-    log({ function: FN, level: "error", message: "partner-reject-application error", metadata: { detail: e instanceof Error ? e.message : String(e) } });
+    log({
+      function: FN,
+      level: "error",
+      message: "partner-reject-application error",
+      metadata: { detail: e instanceof Error ? e.message : String(e) },
+    });
     return errorResponse("Internal server error", 500);
   }
 }));
@@ -36,16 +43,8 @@ async function handleRequest(req: Request): Promise<Response> {
   const userId = auth;
 
   // 2. Parse body
-  let body: Record<string, unknown>;
-  try {
-    const parsed = await req.json();
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return errorResponse("Request body must be a JSON object", 400);
-    }
-    body = parsed as Record<string, unknown>;
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
+  const body = await parseJsonBody(req);
+  if (body instanceof Response) return body;
 
   const supabase = createServiceClient();
 
@@ -65,7 +64,9 @@ async function handleRequest(req: Request): Promise<Response> {
   // Fetch application with event → party → partner chain
   const { data: app, error: fetchError } = await supabase
     .from("event_applications")
-    .select("id, status, event_id, events!inner(party_id, parties!inner(partner_id))")
+    .select(
+      "id, status, event_id, events!inner(party_id, parties!inner(partner_id))",
+    )
     .eq("id", applicationId)
     .maybeSingle();
 

--- a/supabase/functions/partner-review-submission/index.ts
+++ b/supabase/functions/partner-review-submission/index.ts
@@ -9,8 +9,8 @@ import {
 } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
+import { parseAction } from "../_shared/request_utils.ts";
 import { initSentry, withHandler } from "../_shared/logger.ts";
-
 
 initSentry();
 
@@ -37,19 +37,10 @@ async function handleRequest(req: Request): Promise<Response> {
   const userId = auth;
 
   // 3. Parse body
-  let body: Record<string, unknown>;
-  try {
-    const parsed = await req.json();
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return errorResponse("Request body must be a JSON object", 400);
-    }
-    body = parsed as Record<string, unknown>;
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
-
-  const action = body.action as string | undefined;
-  if (typeof action !== "string" || !action) return errorResponse("Missing action", 400);
+  const result = await parseAction(req);
+  if (result instanceof Response) return result;
+  const { action, body } = result;
+  if (!action) return errorResponse("Missing action", 400);
 
   // 4. Supabase client (service role)
   const supabase = createServiceClient();
@@ -63,7 +54,10 @@ async function handleRequest(req: Request): Promise<Response> {
 
     const result = body.result;
     if (typeof result !== "string" || !VALID_RESULTS.includes(result)) {
-      return errorResponse("Invalid result. Must be 'approved' or 'rejected'", 400);
+      return errorResponse(
+        "Invalid result. Must be 'approved' or 'rejected'",
+        400,
+      );
     }
 
     // Fetch submission
@@ -107,7 +101,9 @@ async function handleRequest(req: Request): Promise<Response> {
     // Fix #309: review action에 comment가 있으면 함께 기록
     const comment = body.comment;
     if (typeof comment === "string" && comment.trim().length > 0) {
-      const comments = Array.isArray(lastEntry.comments) ? [...lastEntry.comments] : [];
+      const comments = Array.isArray(lastEntry.comments)
+        ? [...lastEntry.comments]
+        : [];
       comments.push({
         author: userId,
         at: now,
@@ -129,7 +125,10 @@ async function handleRequest(req: Request): Promise<Response> {
       .eq("id", submissionId);
 
     if (updateError) {
-      return errorResponse(`Failed to update submission: ${updateError.message}`, 500);
+      return errorResponse(
+        `Failed to update submission: ${updateError.message}`,
+        500,
+      );
     }
 
     return successResponse({ success: true });
@@ -175,7 +174,9 @@ async function handleRequest(req: Request): Promise<Response> {
     }
 
     const lastEntry = { ...snapshotArray[snapshotArray.length - 1] };
-    const comments = Array.isArray(lastEntry.comments) ? [...lastEntry.comments] : [];
+    const comments = Array.isArray(lastEntry.comments)
+      ? [...lastEntry.comments]
+      : [];
     comments.push({
       author: userId,
       at: new Date().toISOString(),
@@ -190,7 +191,10 @@ async function handleRequest(req: Request): Promise<Response> {
       .eq("id", submissionId);
 
     if (updateError) {
-      return errorResponse(`Failed to add comment: ${updateError.message}`, 500);
+      return errorResponse(
+        `Failed to add comment: ${updateError.message}`,
+        500,
+      );
     }
 
     return successResponse({ success: true });

--- a/supabase/functions/partner-review-submission/partner_review_submission_test.ts
+++ b/supabase/functions/partner-review-submission/partner_review_submission_test.ts
@@ -162,7 +162,7 @@ Deno.test({
         );
         assertEquals(res.status, 400);
         const body = await readJson(res);
-        assertEquals(body.error, "Missing action");
+        assertEquals(body.error, "Missing or invalid \"action\" field");
       });
     });
   },

--- a/supabase/functions/partner-sync/index.ts
+++ b/supabase/functions/partner-sync/index.ts
@@ -3,7 +3,8 @@ import { createServiceClient } from "../_shared/supabase_client.ts";
 import { getPortoneClient } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler, log } from "../_shared/logger.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
+import { initSentry, log, withHandler } from "../_shared/logger.ts";
 
 const FN = "partner-sync";
 
@@ -16,14 +17,10 @@ Deno.serve(withHandler(async (req) => {
   const auth = await requireAuth(req);
   if (auth instanceof Response) return auth;
   try {
-    let reqBody: Record<string, unknown>;
-    try {
-      reqBody = await req.json();
-    } catch {
-      return errorResponse("Invalid JSON body", 400);
-    }
+    const body = await parseJsonBody(req);
+    if (body instanceof Response) return body;
 
-    const { partner_id } = reqBody as { partner_id?: string };
+    const { partner_id } = body as { partner_id?: string };
     if (!partner_id) {
       return errorResponse("Missing partner_id", 400);
     }
@@ -41,7 +38,11 @@ Deno.serve(withHandler(async (req) => {
     }
 
     if (partner.portone_partner_id) {
-      return successResponse({ success: true, portone_partner_id: partner.portone_partner_id, skipped: true });
+      return successResponse({
+        success: true,
+        portone_partner_id: partner.portone_partner_id,
+        skipped: true,
+      });
     }
 
     const portone = getPortoneClient();
@@ -53,7 +54,12 @@ Deno.serve(withHandler(async (req) => {
       });
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
-      log({ function: FN, level: "error", message: "PortOne createPartner error", metadata: { detail: message } });
+      log({
+        function: FN,
+        level: "error",
+        message: "PortOne createPartner error",
+        metadata: { detail: message },
+      });
       return errorResponse("Failed to create PortOne partner", 502);
     }
 
@@ -63,15 +69,27 @@ Deno.serve(withHandler(async (req) => {
       .eq("id", partner_id);
 
     if (updateError) {
-      log({ function: FN, level: "error", message: "DB Update Error", metadata: { detail: updateError } });
+      log({
+        function: FN,
+        level: "error",
+        message: "DB Update Error",
+        metadata: { detail: updateError },
+      });
       return errorResponse("Failed to save portone_partner_id", 500);
     }
 
-    return successResponse({ success: true, portone_partner_id: portonePartner.id });
-
+    return successResponse({
+      success: true,
+      portone_partner_id: portonePartner.id,
+    });
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    log({ function: FN, level: "error", message: "Error in partner-sync", metadata: { detail: message } });
+    log({
+      function: FN,
+      level: "error",
+      message: "Error in partner-sync",
+      metadata: { detail: message },
+    });
     return errorResponse(message, 500);
   }
 }));

--- a/supabase/functions/payment-cancel/index.ts
+++ b/supabase/functions/payment-cancel/index.ts
@@ -1,11 +1,20 @@
 // Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
 import { createServiceClient } from "../_shared/supabase_client.ts";
 import { nowISO } from "../_shared/temporal_utils.ts";
-import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler, log } from "../_shared/logger.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
+import { initSentry, log, withHandler } from "../_shared/logger.ts";
 // Fix #299: 환불 로직을 shared 모듈로 추출 — user-cancel-order와 공유
-import { verifyRefundEligibility, executeRefund, RefundError } from "../_shared/refund_utils.ts";
+import {
+  executeRefund,
+  RefundError,
+  verifyRefundEligibility,
+} from "../_shared/refund_utils.ts";
 
 const FN = "payment-cancel";
 
@@ -18,13 +27,9 @@ Deno.serve(withHandler(async (req) => {
   if (auth instanceof Response) return auth;
   try {
     // 1. Parse Request
-    let reqBody: Record<string, unknown>;
-    try {
-      reqBody = await req.json();
-    } catch {
-      return errorResponse("Invalid JSON body", 400);
-    }
-    const { payment_id, reason, amount, checksum } = reqBody as {
+    const body = await parseJsonBody(req);
+    if (body instanceof Response) return body;
+    const { payment_id, reason, amount, checksum } = body as {
       payment_id?: string;
       reason?: string;
       amount?: number;
@@ -73,12 +78,22 @@ Deno.serve(withHandler(async (req) => {
 
     // Fix #133: 이벤트/정책 조회 실패 시 적격성 검사를 건너뛰지 않고 명시적으로 에러 반환
     if (eventResult.error || !eventResult.data) {
-      log({ function: FN, level: "error", message: "Failed to fetch event", metadata: { detail: eventResult.error } });
+      log({
+        function: FN,
+        level: "error",
+        message: "Failed to fetch event",
+        metadata: { detail: eventResult.error },
+      });
       return errorResponse("Failed to verify refund eligibility", 500);
     }
 
     if (policyResult.error || !policyResult.data) {
-      log({ function: FN, level: "error", message: "Failed to fetch policy", metadata: { detail: policyResult.error } });
+      log({
+        function: FN,
+        level: "error",
+        message: "Failed to fetch policy",
+        metadata: { detail: policyResult.error },
+      });
       return errorResponse("Failed to verify refund eligibility", 500);
     }
 
@@ -120,7 +135,8 @@ Deno.serve(withHandler(async (req) => {
     }
 
     // 4. Update DB: refund_status + refund_amount
-    const refundAmount = amount ?? (cancelResponse.amount as number | undefined);
+    const refundAmount = amount ??
+      (cancelResponse.amount as number | undefined);
     const updatePayload: Record<string, unknown> = {
       refund_status: "completed",
       updated_at: nowISO(),
@@ -134,16 +150,24 @@ Deno.serve(withHandler(async (req) => {
       .eq("payment_id", payment_id);
 
     if (dbError) {
-      log({ function: FN, level: "error", message: "DB Update Error", metadata: { detail: dbError } });
+      log({
+        function: FN,
+        level: "error",
+        message: "DB Update Error",
+        metadata: { detail: dbError },
+      });
       // Non-fatal: payment was cancelled, just log the DB error
     }
 
     // 5. Success
     return successResponse({ success: true, data: cancelResponse });
-
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    log({ function: FN, level: "error", message: `Error in payment-cancel: ${message}` });
+    log({
+      function: FN,
+      level: "error",
+      message: `Error in payment-cancel: ${message}`,
+    });
     return errorResponse(message, 500);
   }
 }));

--- a/supabase/functions/payment-verify/index.ts
+++ b/supabase/functions/payment-verify/index.ts
@@ -2,9 +2,14 @@
 import { createServiceClient } from "../_shared/supabase_client.ts";
 import { nowISO } from "../_shared/temporal_utils.ts";
 import { IamportClient } from "../_shared/iamport_client.ts";
-import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler, withSpan, log } from "../_shared/logger.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
+import { initSentry, log, withHandler, withSpan } from "../_shared/logger.ts";
 
 const FN = "payment-verify";
 import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
@@ -13,7 +18,9 @@ const IMP_KEY = Deno.env.get("PORTONE_API_KEY");
 const IMP_SECRET = Deno.env.get("PORTONE_API_SECRET");
 
 if (!IMP_KEY || !IMP_SECRET) {
-  throw new Error("Missing required environment variables: PORTONE_API_KEY, PORTONE_API_SECRET");
+  throw new Error(
+    "Missing required environment variables: PORTONE_API_KEY, PORTONE_API_SECRET",
+  );
 }
 
 initSentry();
@@ -25,13 +32,12 @@ Deno.serve(withHandler(async (req) => {
   const auth = await requireAuth(req);
   if (auth instanceof Response) return auth;
   try {
-    let reqBody: Record<string, unknown>;
-    try {
-      reqBody = await req.json();
-    } catch {
-      return errorResponse("Invalid JSON body", 400);
-    }
-    const { imp_uid, merchant_uid } = reqBody as { imp_uid?: string; merchant_uid?: string };
+    const body = await parseJsonBody(req);
+    if (body instanceof Response) return body;
+    const { imp_uid, merchant_uid } = body as {
+      imp_uid?: string;
+      merchant_uid?: string;
+    };
 
     if (!imp_uid || !merchant_uid) {
       return errorResponse("Missing required parameters", 400);
@@ -42,13 +48,14 @@ Deno.serve(withHandler(async (req) => {
 
     // 1. DB에서 주문 정보 조회 (금액 확인)
     const { data: order, error: orderError } = await withSpan(
-      'db.query.event_applications',
-      'db.query',
-      async () => supabase
-        .from("event_applications")
-        .select("payment_amount, status, user_id")
-        .eq("id", merchant_uid)
-        .single()
+      "db.query.event_applications",
+      "db.query",
+      async () =>
+        supabase
+          .from("event_applications")
+          .select("payment_amount, status, user_id")
+          .eq("id", merchant_uid)
+          .single(),
     );
 
     if (orderError || !order) {
@@ -61,7 +68,7 @@ Deno.serve(withHandler(async (req) => {
     }
 
     // 이미 처리된 주문인지 확인
-    if (order.status === 'approved' || order.status === 'paid') {
+    if (order.status === "approved" || order.status === "paid") {
       return successResponse({ success: true, message: "Already processed" });
     }
 
@@ -71,16 +78,31 @@ Deno.serve(withHandler(async (req) => {
 
     // 3. 결제 상태 및 금액 검증
     if (payment.status !== "paid") {
-      logStatsigEvent(auth, 'payment_failed', undefined, { reason: 'payment_not_completed', imp_uid }).catch(() => {});
-      return errorResponse("Payment not completed", 400, { status: payment.status });
+      logStatsigEvent(auth, "payment_failed", undefined, {
+        reason: "payment_not_completed",
+        imp_uid,
+      }).catch(() => {});
+      return errorResponse("Payment not completed", 400, {
+        status: payment.status,
+      });
     }
 
     if (payment.amount !== order.payment_amount) {
-      await client.cancelPayment(imp_uid, "결제 금액 위변조로 자동 취소").catch((e: unknown) => {
-        const msg = e instanceof Error ? e.message : String(e);
-        log({ function: FN, level: "error", message: "Cancel on mismatch failed", metadata: { detail: msg } });
-      });
-      logStatsigEvent(auth, 'payment_failed', undefined, { reason: 'amount_mismatch', imp_uid }).catch(() => {});
+      await client.cancelPayment(imp_uid, "결제 금액 위변조로 자동 취소").catch(
+        (e: unknown) => {
+          const msg = e instanceof Error ? e.message : String(e);
+          log({
+            function: FN,
+            level: "error",
+            message: "Cancel on mismatch failed",
+            metadata: { detail: msg },
+          });
+        },
+      );
+      logStatsigEvent(auth, "payment_failed", undefined, {
+        reason: "amount_mismatch",
+        imp_uid,
+      }).catch(() => {});
       return errorResponse("Amount mismatch", 400, {
         expected: order.payment_amount,
         actual: payment.amount,
@@ -89,36 +111,52 @@ Deno.serve(withHandler(async (req) => {
 
     // Fix #133: paid_at 없을 때 now 폴백하면 재시도마다 값이 밀려 멱등성 깨짐 — payment-webhook과 동일하게 null 처리
     const paidAtIso = payment.paid_at && payment.paid_at > 0
-      ? Temporal.Instant.fromEpochMilliseconds(payment.paid_at * 1000).toString()
+      ? Temporal.Instant.fromEpochMilliseconds(payment.paid_at * 1000)
+        .toString()
       : null;
 
     const { error: updateError } = await withSpan(
-      'db.update.event_applications',
-      'db.update',
-      async () => supabase
-        .from("event_applications")
-        .update({
-          status: "approved",
-          payment_id: imp_uid,
-          ...(paidAtIso ? { paid_at: paidAtIso } : {}),
-          updated_at: nowISO(),
-        })
-        .eq("id", merchant_uid)
+      "db.update.event_applications",
+      "db.update",
+      async () =>
+        supabase
+          .from("event_applications")
+          .update({
+            status: "approved",
+            payment_id: imp_uid,
+            ...(paidAtIso ? { paid_at: paidAtIso } : {}),
+            updated_at: nowISO(),
+          })
+          .eq("id", merchant_uid),
     );
 
     if (updateError) {
-      log({ function: FN, level: "error", message: "DB Update Error", metadata: { detail: updateError } });
-      logStatsigEvent(auth, 'payment_failed', undefined, { reason: 'db_update_error', imp_uid }).catch(() => {});
+      log({
+        function: FN,
+        level: "error",
+        message: "DB Update Error",
+        metadata: { detail: updateError },
+      });
+      logStatsigEvent(auth, "payment_failed", undefined, {
+        reason: "db_update_error",
+        imp_uid,
+      }).catch(() => {});
       return errorResponse("Failed to update order status", 500);
     }
 
-    logStatsigEvent(auth, 'payment_completed', payment.amount, { imp_uid, merchant_uid }).catch(() => {});
+    logStatsigEvent(auth, "payment_completed", payment.amount, {
+      imp_uid,
+      merchant_uid,
+    }).catch(() => {});
     return successResponse({ success: true, imp_uid });
-
-
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    log({ function: FN, level: "error", message: "Error in payment-verify", metadata: { detail: message } });
+    log({
+      function: FN,
+      level: "error",
+      message: "Error in payment-verify",
+      metadata: { detail: message },
+    });
     return errorResponse(message, 500);
   }
 }));

--- a/supabase/functions/recurrence-rules/index.ts
+++ b/supabase/functions/recurrence-rules/index.ts
@@ -10,8 +10,8 @@ import {
 } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
+import { parseAction } from "../_shared/request_utils.ts";
 import { initSentry, withHandler } from "../_shared/logger.ts";
-
 
 initSentry();
 
@@ -51,19 +51,10 @@ async function handleRequest(req: Request): Promise<Response> {
   const userId = auth;
 
   // Parse body
-  let body: Record<string, unknown>;
-  try {
-    const parsed = await req.json();
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return errorResponse("Request body must be a JSON object", 400);
-    }
-    body = parsed as Record<string, unknown>;
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
-
-  const action = body.action as string | undefined;
-  if (typeof action !== "string" || !action) return errorResponse("Missing action", 400);
+  const result = await parseAction(req);
+  if (result instanceof Response) return result;
+  const { action, body } = result;
+  if (!action) return errorResponse("Missing action", 400);
 
   const supabase = createServiceClient();
 
@@ -89,8 +80,13 @@ async function handleCreate(
   }
 
   const pattern = body.pattern;
-  if (typeof pattern !== "string" || !VALID_PATTERNS.includes(pattern as Pattern)) {
-    return errorResponse(`Invalid pattern. Must be one of: ${VALID_PATTERNS.join(", ")}`, 400);
+  if (
+    typeof pattern !== "string" || !VALID_PATTERNS.includes(pattern as Pattern)
+  ) {
+    return errorResponse(
+      `Invalid pattern. Must be one of: ${VALID_PATTERNS.join(", ")}`,
+      400,
+    );
   }
 
   const daysOfWeek = body.days_of_week;
@@ -104,7 +100,10 @@ async function handleCreate(
   }
 
   const monthDay = body.month_day ?? null;
-  if (monthDay !== null && (typeof monthDay !== "number" || monthDay < 1 || monthDay > 31)) {
+  if (
+    monthDay !== null &&
+    (typeof monthDay !== "number" || monthDay < 1 || monthDay > 31)
+  ) {
     return errorResponse("month_day must be between 1 and 31", 400);
   }
 
@@ -127,8 +126,13 @@ async function handleCreate(
   if (pattern === "monthly" && monthDay === null) {
     return errorResponse("month_day is required for monthly pattern", 400);
   }
-  if ((pattern === "weekly" || pattern === "biweekly") && daysOfWeek.length === 0) {
-    return errorResponse("days_of_week is required for weekly/biweekly pattern", 400);
+  if (
+    (pattern === "weekly" || pattern === "biweekly") && daysOfWeek.length === 0
+  ) {
+    return errorResponse(
+      "days_of_week is required for weekly/biweekly pattern",
+      400,
+    );
   }
 
   // Fetch party to verify it exists and get partner_id
@@ -157,11 +161,16 @@ async function handleCreate(
       end_time: endTime,
       end_date: endDate,
     })
-    .select("id, party_id, pattern, days_of_week, month_day, start_time, end_time, end_date, status, last_generated_date, created_at")
+    .select(
+      "id, party_id, pattern, days_of_week, month_day, start_time, end_time, end_date, status, last_generated_date, created_at",
+    )
     .single();
 
   if (insertError) {
-    return errorResponse(`Failed to create recurrence rule: ${insertError.message}`, 500);
+    return errorResponse(
+      `Failed to create recurrence rule: ${insertError.message}`,
+      500,
+    );
   }
 
   // Generate events for today → today+30 days
@@ -170,9 +179,18 @@ async function handleCreate(
   const toDate = new Date(today);
   toDate.setUTCDate(toDate.getUTCDate() + 30);
 
-  const eventsCreated = await generateEvents(supabase, rule as RecurrenceRule, today, toDate);
+  const eventsCreated = await generateEvents(
+    supabase,
+    rule as RecurrenceRule,
+    today,
+    toDate,
+  );
 
-  return successResponse({ success: true, rule_id: rule.id, events_created: eventsCreated });
+  return successResponse({
+    success: true,
+    rule_id: rule.id,
+    events_created: eventsCreated,
+  });
 }
 
 async function handleUpdate(
@@ -208,7 +226,10 @@ async function handleUpdate(
 
   if (body.pattern !== undefined) {
     if (!VALID_PATTERNS.includes(body.pattern as Pattern)) {
-      return errorResponse(`Invalid pattern. Must be one of: ${VALID_PATTERNS.join(", ")}`, 400);
+      return errorResponse(
+        `Invalid pattern. Must be one of: ${VALID_PATTERNS.join(", ")}`,
+        400,
+      );
     }
     updates.pattern = body.pattern;
   }
@@ -225,14 +246,19 @@ async function handleUpdate(
   }
 
   if (body.start_time !== undefined) {
-    if (typeof body.start_time !== "string" || !/^\d{2}:\d{2}$/.test(body.start_time)) {
+    if (
+      typeof body.start_time !== "string" ||
+      !/^\d{2}:\d{2}$/.test(body.start_time)
+    ) {
       return errorResponse("start_time must be in HH:MM format", 400);
     }
     updates.start_time = body.start_time;
   }
 
   if (body.end_time !== undefined) {
-    if (typeof body.end_time !== "string" || !/^\d{2}:\d{2}$/.test(body.end_time)) {
+    if (
+      typeof body.end_time !== "string" || !/^\d{2}:\d{2}$/.test(body.end_time)
+    ) {
       return errorResponse("end_time must be in HH:MM format", 400);
     }
     updates.end_time = body.end_time;
@@ -257,7 +283,10 @@ async function handleUpdate(
     .eq("id", ruleId);
 
   if (updateError) {
-    return errorResponse(`Failed to update recurrence rule: ${updateError.message}`, 500);
+    return errorResponse(
+      `Failed to update recurrence rule: ${updateError.message}`,
+      500,
+    );
   }
 
   return successResponse({ success: true });
@@ -283,7 +312,10 @@ async function handlePause(
   if (!rule) return errorResponse("Recurrence rule not found", 404);
 
   if (rule.status !== "active") {
-    return errorResponse(`Cannot pause a rule with status: ${rule.status}`, 400);
+    return errorResponse(
+      `Cannot pause a rule with status: ${rule.status}`,
+      400,
+    );
   }
 
   const partnerId = (rule.parties as Record<string, unknown>).partner_id as string;
@@ -314,7 +346,9 @@ async function handleResume(
 
   const { data: rule, error: fetchError } = await supabase
     .from("recurrence_rules")
-    .select("id, party_id, pattern, days_of_week, month_day, start_time, end_time, end_date, status, last_generated_date, created_at, parties!inner(partner_id)")
+    .select(
+      "id, party_id, pattern, days_of_week, month_day, start_time, end_time, end_date, status, last_generated_date, created_at, parties!inner(partner_id)",
+    )
     .eq("id", ruleId)
     .maybeSingle();
 
@@ -322,7 +356,10 @@ async function handleResume(
   if (!rule) return errorResponse("Recurrence rule not found", 404);
 
   if (rule.status !== "paused") {
-    return errorResponse(`Cannot resume a rule with status: ${rule.status}`, 400);
+    return errorResponse(
+      `Cannot resume a rule with status: ${rule.status}`,
+      400,
+    );
   }
 
   const partnerId = (rule.parties as Record<string, unknown>).partner_id as string;
@@ -371,7 +408,12 @@ async function handleResume(
     created_at: rule.created_at,
   };
 
-  const eventsCreated = await generateEvents(supabase, ruleData, fromDate, toDate);
+  const eventsCreated = await generateEvents(
+    supabase,
+    ruleData,
+    fromDate,
+    toDate,
+  );
 
   return successResponse({ success: true, events_created: eventsCreated });
 }
@@ -429,17 +471,27 @@ async function generateEvents(
   // Fetch templates for this party
   const { data: entryGroupTemplates, error: egtError } = await supabase
     .from("entry_group_templates")
-    .select("id, label, gender, birth_year_min, birth_year_max, required_verification_ids")
+    .select(
+      "id, label, gender, birth_year_min, birth_year_max, required_verification_ids",
+    )
     .eq("party_id", rule.party_id);
 
-  if (egtError) throw new Error(`Failed to fetch entry group templates: ${egtError.message}`);
+  if (egtError) {
+    throw new Error(
+      `Failed to fetch entry group templates: ${egtError.message}`,
+    );
+  }
 
   const { data: ticketTemplates, error: ttError } = await supabase
     .from("ticket_templates")
-    .select("id, name, description, price, quantity, target_entry_group_ids, required_verification_ids")
+    .select(
+      "id, name, description, price, quantity, target_entry_group_ids, required_verification_ids",
+    )
     .eq("party_id", rule.party_id);
 
-  if (ttError) throw new Error(`Failed to fetch ticket templates: ${ttError.message}`);
+  if (ttError) {
+    throw new Error(`Failed to fetch ticket templates: ${ttError.message}`);
+  }
 
   let eventsInserted = 0;
 
@@ -466,7 +518,9 @@ async function generateEvents(
     if (eventError) {
       // Unique constraint violation — skip (duplicate)
       if (eventError.code === "23505") continue;
-      throw new Error(`Failed to insert event for ${dateStr}: ${eventError.message}`);
+      throw new Error(
+        `Failed to insert event for ${dateStr}: ${eventError.message}`,
+      );
     }
 
     if (!newEvent) {
@@ -481,7 +535,9 @@ async function generateEvents(
     const templateToGroupMap = new Map<string, string>();
 
     if (entryGroupTemplates && entryGroupTemplates.length > 0) {
-      const entryGroups = entryGroupTemplates.map((t: Record<string, unknown>) => ({
+      const entryGroups = entryGroupTemplates.map((
+        t: Record<string, unknown>,
+      ) => ({
         event_id: eventId,
         label: t.label ?? null,
         gender: t.gender ?? null,
@@ -495,7 +551,9 @@ async function generateEvents(
         .insert(entryGroups)
         .select("id");
 
-      if (egError) throw new Error(`Failed to create entry groups: ${egError.message}`);
+      if (egError) {
+        throw new Error(`Failed to create entry groups: ${egError.message}`);
+      }
 
       if (insertedGroups) {
         for (let i = 0; i < entryGroupTemplates.length; i++) {
@@ -510,7 +568,8 @@ async function generateEvents(
     // Copy ticket_templates → tickets
     if (ticketTemplates && ticketTemplates.length > 0) {
       const tickets = ticketTemplates.map((tpl: Record<string, unknown>) => {
-        const originalTargetIds = (tpl.target_entry_group_ids as string[]) ?? [];
+        const originalTargetIds = (tpl.target_entry_group_ids as string[]) ??
+          [];
         const remappedTargetIds = originalTargetIds
           .map((id: string) => templateToGroupMap.get(id))
           .filter((id): id is string => id !== undefined);
@@ -530,7 +589,9 @@ async function generateEvents(
         .from("tickets")
         .insert(tickets);
 
-      if (ticketError) throw new Error(`Failed to create tickets: ${ticketError.message}`);
+      if (ticketError) {
+        throw new Error(`Failed to create tickets: ${ticketError.message}`);
+      }
     }
   }
 

--- a/supabase/functions/settlement-query/index.ts
+++ b/supabase/functions/settlement-query/index.ts
@@ -1,7 +1,8 @@
 import { getPortoneClient } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler, log } from "../_shared/logger.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
+import { initSentry, log, withHandler } from "../_shared/logger.ts";
 
 const FN = "settlement-query";
 
@@ -14,14 +15,10 @@ Deno.serve(withHandler(async (req) => {
   const auth = await requireAuth(req);
   if (auth instanceof Response) return auth;
   try {
-    let reqBody: Record<string, unknown>;
-    try {
-      reqBody = await req.json();
-    } catch {
-      return errorResponse("Invalid JSON body", 400);
-    }
+    const body = await parseJsonBody(req);
+    if (body instanceof Response) return body;
 
-    const { partner_id, from_date, to_date, type } = reqBody as {
+    const { partner_id, from_date, to_date, type } = body as {
       partner_id?: string;
       from_date?: string;
       to_date?: string;
@@ -29,7 +26,10 @@ Deno.serve(withHandler(async (req) => {
     };
 
     if (!type || (type !== "settlements" && type !== "payouts")) {
-      return errorResponse("Missing or invalid type: must be 'settlements' or 'payouts'", 400);
+      return errorResponse(
+        "Missing or invalid type: must be 'settlements' or 'payouts'",
+        400,
+      );
     }
 
     const portone = getPortoneClient();
@@ -39,11 +39,18 @@ Deno.serve(withHandler(async (req) => {
       try {
         result = await portone.getPartnerSettlements({
           partnerId: partner_id,
-          dateRange: from_date || to_date ? { from: from_date, until: to_date } : undefined,
+          dateRange: from_date || to_date
+            ? { from: from_date, until: to_date }
+            : undefined,
         });
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e);
-        log({ function: FN, level: "error", message: "PortOne getPartnerSettlements error", metadata: { detail: message } });
+        log({
+          function: FN,
+          level: "error",
+          message: "PortOne getPartnerSettlements error",
+          metadata: { detail: message },
+        });
         return errorResponse("Failed to fetch settlements", 502);
       }
       return successResponse({ success: true, ...result });
@@ -56,14 +63,23 @@ Deno.serve(withHandler(async (req) => {
       });
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
-      log({ function: FN, level: "error", message: "PortOne getPayouts error", metadata: { detail: message } });
+      log({
+        function: FN,
+        level: "error",
+        message: "PortOne getPayouts error",
+        metadata: { detail: message },
+      });
       return errorResponse("Failed to fetch payouts", 502);
     }
     return successResponse({ success: true, ...result });
-
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    log({ function: FN, level: "error", message: "Error in settlement-query", metadata: { detail: message } });
+    log({
+      function: FN,
+      level: "error",
+      message: "Error in settlement-query",
+      metadata: { detail: message },
+    });
     return errorResponse(message, 500);
   }
 }));

--- a/supabase/functions/settlement-transfer/index.ts
+++ b/supabase/functions/settlement-transfer/index.ts
@@ -3,7 +3,8 @@ import { createServiceClient } from "../_shared/supabase_client.ts";
 import { getPortoneClient } from "../_shared/portone_client.ts";
 import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
 import { requireServiceRole } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler, log } from "../_shared/logger.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
+import { initSentry, log, withHandler } from "../_shared/logger.ts";
 
 const FN = "settlement-transfer";
 
@@ -17,14 +18,10 @@ Deno.serve(withHandler(async (req) => {
   const auth = requireServiceRole(req);
   if (auth instanceof Response) return auth;
   try {
-    let reqBody: Record<string, unknown>;
-    try {
-      reqBody = await req.json();
-    } catch {
-      return errorResponse("Invalid JSON body", 400);
-    }
+    const body = await parseJsonBody(req);
+    if (body instanceof Response) return body;
 
-    const { partner_id, payment_id, order_amount, settlement_date } = reqBody as {
+    const { partner_id, payment_id, order_amount, settlement_date } = body as {
       partner_id?: string;
       payment_id?: string;
       order_amount?: number;
@@ -32,7 +29,10 @@ Deno.serve(withHandler(async (req) => {
     };
 
     if (!partner_id || !payment_id || order_amount === undefined) {
-      return errorResponse("Missing required fields: partner_id, payment_id, order_amount", 400);
+      return errorResponse(
+        "Missing required fields: partner_id, payment_id, order_amount",
+        400,
+      );
     }
 
     const supabase = createServiceClient();
@@ -63,18 +63,29 @@ Deno.serve(withHandler(async (req) => {
 
     let transfer: Record<string, unknown>;
     try {
-      transfer = await portone.createOrderTransfer(transferBody as Parameters<typeof portone.createOrderTransfer>[0]);
+      transfer = await portone.createOrderTransfer(
+        transferBody as Parameters<typeof portone.createOrderTransfer>[0],
+      );
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
-      log({ function: FN, level: "error", message: "PortOne createOrderTransfer error", metadata: { detail: message } });
+      log({
+        function: FN,
+        level: "error",
+        message: "PortOne createOrderTransfer error",
+        metadata: { detail: message },
+      });
       return errorResponse("Failed to create order transfer", 502);
     }
 
     return successResponse({ success: true, transfer });
-
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    log({ function: FN, level: "error", message: "Error in settlement-transfer", metadata: { detail: message } });
+    log({
+      function: FN,
+      level: "error",
+      message: "Error in settlement-transfer",
+      metadata: { detail: message },
+    });
     return errorResponse(message, 500);
   }
 }));

--- a/supabase/functions/user-cancel-order/index.ts
+++ b/supabase/functions/user-cancel-order/index.ts
@@ -1,9 +1,18 @@
 import { createServiceClient } from "../_shared/supabase_client.ts";
-import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler, withSpan, log } from "../_shared/logger.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
+import { initSentry, log, withHandler, withSpan } from "../_shared/logger.ts";
 import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
-import { verifyRefundEligibility, executeRefund, RefundError } from "../_shared/refund_utils.ts";
+import {
+  executeRefund,
+  RefundError,
+  verifyRefundEligibility,
+} from "../_shared/refund_utils.ts";
 
 const FN = "user-cancel-order";
 
@@ -19,14 +28,10 @@ Deno.serve(withHandler(async (req) => {
 
   try {
     // 1. Parse Request
-    let reqBody: Record<string, unknown>;
-    try {
-      reqBody = await req.json();
-    } catch {
-      return errorResponse("Invalid JSON body", 400);
-    }
+    const body = await parseJsonBody(req);
+    if (body instanceof Response) return body;
 
-    const { event_id, reason } = reqBody as {
+    const { event_id, reason } = body as {
       event_id?: string;
       reason?: string;
     };
@@ -40,13 +45,17 @@ Deno.serve(withHandler(async (req) => {
 
     // 3. Fetch application by (event_id, user_id)
     const { data: application, error: appError } = await withSpan(
-      "db.query.event_applications", "db.query",
-      () => supabase
-        .from("event_applications")
-        .select("id, status, payment_id, payment_amount, paid_at, refund_status, event_id, user_id")
-        .eq("event_id", event_id)
-        .eq("user_id", userId)
-        .single(),
+      "db.query.event_applications",
+      "db.query",
+      () =>
+        supabase
+          .from("event_applications")
+          .select(
+            "id, status, payment_id, payment_amount, paid_at, refund_status, event_id, user_id",
+          )
+          .eq("event_id", event_id)
+          .eq("user_id", userId)
+          .single(),
     );
 
     if (appError || !application) {
@@ -60,26 +69,31 @@ Deno.serve(withHandler(async (req) => {
     }
 
     // 5. Branch: pre-payment vs post-payment
-    const isPaid = status === "paid" || status === "pending_review" || status === "approved";
+    const isPaid = status === "paid" || status === "pending_review" ||
+      status === "approved";
     const isPrePayment = status === "pending" || status === "payment_failed";
 
     if (isPrePayment) {
       // Pre-payment cancellation: delete verification_submissions + delete application
       await withSpan(
-        "db.delete.verification_submissions", "db.delete",
-        () => supabase
-          .from("verification_submissions")
-          .delete()
-          .eq("application_id", application.id)
-          .eq("status", "pending"),
+        "db.delete.verification_submissions",
+        "db.delete",
+        () =>
+          supabase
+            .from("verification_submissions")
+            .delete()
+            .eq("application_id", application.id)
+            .eq("status", "pending"),
       );
 
       await withSpan(
-        "db.delete.event_applications", "db.delete",
-        () => supabase
-          .from("event_applications")
-          .delete()
-          .eq("id", application.id),
+        "db.delete.event_applications",
+        "db.delete",
+        () =>
+          supabase
+            .from("event_applications")
+            .delete()
+            .eq("id", application.id),
       );
 
       logStatsigEvent(userId, "order_cancelled", undefined, {
@@ -96,23 +110,35 @@ Deno.serve(withHandler(async (req) => {
 
       // Fix #1652: payment_amount=null means damaged data — reject, do not treat as free.
       if (paymentAmount === null) {
-        log({ function: FN, level: "error", message: "Damaged data: payment_amount=null on paid application", metadata: { application_id: application.id } });
+        log({
+          function: FN,
+          level: "error",
+          message: "Damaged data: payment_amount=null on paid application",
+          metadata: { application_id: application.id },
+        });
         return errorResponse("결제 정보가 손상된 신청입니다", 400);
       }
 
       // Free event (payment_amount === 0): verify event hasn't started, then cancel.
       if (paymentAmount === 0) {
         const { data: eventData, error: eventError } = await withSpan(
-          "db.query.events.free_cancel", "db.query",
-          () => supabase
-            .from("events")
-            .select("start_time")
-            .eq("id", event_id)
-            .single(),
+          "db.query.events.free_cancel",
+          "db.query",
+          () =>
+            supabase
+              .from("events")
+              .select("start_time")
+              .eq("id", event_id)
+              .single(),
         );
 
         if (eventError || !eventData) {
-          log({ function: FN, level: "error", message: "Failed to fetch event for free cancel", metadata: { detail: eventError } });
+          log({
+            function: FN,
+            level: "error",
+            message: "Failed to fetch event for free cancel",
+            metadata: { detail: eventError },
+          });
           return errorResponse("이벤트 정보를 가져올 수 없습니다", 500);
         }
 
@@ -123,18 +149,25 @@ Deno.serve(withHandler(async (req) => {
         }
 
         const { error: updateError } = await withSpan(
-          "db.update.event_applications.cancel", "db.update",
-          () => supabase
-            .from("event_applications")
-            .update({
-              status: "cancelled",
-              updated_at: new Date().toISOString(),
-            })
-            .eq("id", application.id),
+          "db.update.event_applications.cancel",
+          "db.update",
+          () =>
+            supabase
+              .from("event_applications")
+              .update({
+                status: "cancelled",
+                updated_at: new Date().toISOString(),
+              })
+              .eq("id", application.id),
         );
 
         if (updateError) {
-          log({ function: FN, level: "error", message: "DB Update Error (free cancel)", metadata: { detail: updateError } });
+          log({
+            function: FN,
+            level: "error",
+            message: "DB Update Error (free cancel)",
+            metadata: { detail: updateError },
+          });
         }
 
         logStatsigEvent(userId, "order_cancelled", undefined, {
@@ -160,20 +193,31 @@ Deno.serve(withHandler(async (req) => {
             .from("events")
             .select("start_time")
             .eq("id", event_id)
-            .single(),
-        ),
-        withSpan("db.rpc.get_current_policy", "db.rpc", () =>
-          supabase.rpc("get_current_policy", { p_key: "refund" }),
+            .single()),
+        withSpan(
+          "db.rpc.get_current_policy",
+          "db.rpc",
+          () => supabase.rpc("get_current_policy", { p_key: "refund" }),
         ),
       ]);
 
       if (eventResult.error || !eventResult.data) {
-        log({ function: FN, level: "error", message: "Failed to fetch event", metadata: { detail: eventResult.error } });
+        log({
+          function: FN,
+          level: "error",
+          message: "Failed to fetch event",
+          metadata: { detail: eventResult.error },
+        });
         return errorResponse("Failed to verify refund eligibility", 500);
       }
 
       if (policyResult.error || !policyResult.data) {
-        log({ function: FN, level: "error", message: "Failed to fetch policy", metadata: { detail: policyResult.error } });
+        log({
+          function: FN,
+          level: "error",
+          message: "Failed to fetch policy",
+          metadata: { detail: policyResult.error },
+        });
         return errorResponse("Failed to verify refund eligibility", 500);
       }
 
@@ -213,7 +257,8 @@ Deno.serve(withHandler(async (req) => {
 
       // Update DB: status=cancelled + refund_status + refund_amount
       // Fix #1515: Set status='cancelled' so on_application_cancel trigger removes event_participants
-      const refundAmount = paymentAmount ?? (cancelResponse.amount as number | undefined);
+      const refundAmount = paymentAmount ??
+        (cancelResponse.amount as number | undefined);
       const updatePayload: Record<string, unknown> = {
         status: "cancelled",
         refund_status: "completed",
@@ -224,15 +269,22 @@ Deno.serve(withHandler(async (req) => {
       }
 
       const { error: dbError } = await withSpan(
-        "db.update.event_applications.refund", "db.update",
-        () => supabase
-          .from("event_applications")
-          .update(updatePayload)
-          .eq("id", application.id),
+        "db.update.event_applications.refund",
+        "db.update",
+        () =>
+          supabase
+            .from("event_applications")
+            .update(updatePayload)
+            .eq("id", application.id),
       );
 
       if (dbError) {
-        log({ function: FN, level: "error", message: "DB Update Error", metadata: { detail: dbError } });
+        log({
+          function: FN,
+          level: "error",
+          message: "DB Update Error",
+          metadata: { detail: dbError },
+        });
         // Non-fatal: payment was already refunded
       }
 
@@ -250,12 +302,20 @@ Deno.serve(withHandler(async (req) => {
     }
 
     // Unhandled status
-    log({ function: FN, level: "error", message: `Unhandled status: ${status}`, metadata: { application_id: application.id } });
+    log({
+      function: FN,
+      level: "error",
+      message: `Unhandled status: ${status}`,
+      metadata: { application_id: application.id },
+    });
     return errorResponse("지원하지 않는 신청 상태입니다", 400);
-
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    log({ function: FN, level: "error", message: `Error in user-cancel-order: ${message}` });
+    log({
+      function: FN,
+      level: "error",
+      message: `Error in user-cancel-order: ${message}`,
+    });
     return errorResponse(message, 500);
   }
 }));

--- a/supabase/functions/user-cast-vote/index.ts
+++ b/supabase/functions/user-cast-vote/index.ts
@@ -8,8 +8,8 @@ import {
   successResponse,
 } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
 import { initSentry, withHandler } from "../_shared/logger.ts";
-
 
 initSentry();
 
@@ -22,19 +22,17 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
 
   const supabase = createServiceClient();
 
-  let body: Record<string, unknown>;
-  try {
-    body = await req.json();
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
+  const body = await parseJsonBody(req);
+  if (body instanceof Response) return body;
 
   const eventId = body.event_id as string | undefined;
   const candidateId = body.candidate_id as string | undefined;
 
   if (!eventId) return errorResponse("Missing event_id", 400);
   if (!candidateId) return errorResponse("Missing candidate_id", 400);
-  if (candidateId === voterId) return errorResponse("자기 자신에게 투표할 수 없습니다", 400);
+  if (candidateId === voterId) {
+    return errorResponse("자기 자신에게 투표할 수 없습니다", 400);
+  }
 
   // 1. Fetch event with vote period + end_time fallback
   const { data: event, error: eventError } = await supabase
@@ -84,7 +82,9 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
     .maybeSingle();
 
   if (candidateError) return errorResponse("Failed to verify candidate", 500);
-  if (!candidateParticipant) return errorResponse("후보자가 이벤트 참가자가 아닙니다", 400);
+  if (!candidateParticipant) {
+    return errorResponse("후보자가 이벤트 참가자가 아닙니다", 400);
+  }
   if (candidateParticipant.status !== "checked_in") {
     return errorResponse("후보자가 체크인하지 않았습니다", 400);
   }
@@ -96,7 +96,9 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
     .eq("id", voterParticipant.ticket_id)
     .maybeSingle();
 
-  if (voterTicketError) return errorResponse("Failed to load voter ticket", 500);
+  if (voterTicketError) {
+    return errorResponse("Failed to load voter ticket", 500);
+  }
 
   const { data: candidateTicket, error: candidateTicketError } = await supabase
     .from("tickets")
@@ -104,10 +106,13 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
     .eq("id", candidateParticipant.ticket_id)
     .maybeSingle();
 
-  if (candidateTicketError) return errorResponse("Failed to load candidate ticket", 500);
+  if (candidateTicketError) {
+    return errorResponse("Failed to load candidate ticket", 500);
+  }
 
   const voterGroupIds: string[] = voterTicket?.target_entry_group_ids ?? [];
-  const candidateGroupIds: string[] = candidateTicket?.target_entry_group_ids ?? [];
+  const candidateGroupIds: string[] = candidateTicket?.target_entry_group_ids ??
+    [];
 
   // Fix #306: 그룹 정보가 없으면 거부 (fail-closed)
   if (voterGroupIds.length === 0 || candidateGroupIds.length === 0) {
@@ -128,14 +133,19 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
   }
 
   // 7. Atomic vote count check + insert via RPC (prevents race condition)
-  const maxVoteCount = Math.max(...rules.map((r: { vote_count: number }) => r.vote_count));
+  const maxVoteCount = Math.max(
+    ...rules.map((r: { vote_count: number }) => r.vote_count),
+  );
 
-  const { data: _rpcResult, error: rpcError } = await supabase.rpc("cast_match_vote", {
-    p_event_id: eventId,
-    p_voter_id: voterId,
-    p_candidate_id: candidateId,
-    p_max_vote_count: maxVoteCount,
-  });
+  const { data: _rpcResult, error: rpcError } = await supabase.rpc(
+    "cast_match_vote",
+    {
+      p_event_id: eventId,
+      p_voter_id: voterId,
+      p_candidate_id: candidateId,
+      p_max_vote_count: maxVoteCount,
+    },
+  );
 
   if (rpcError) {
     if (rpcError.message?.includes("투표 수를 초과했습니다")) {

--- a/supabase/functions/user-create-order/index.ts
+++ b/supabase/functions/user-create-order/index.ts
@@ -1,7 +1,12 @@
 import { createServiceClient } from "../_shared/supabase_client.ts";
-import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler, withSpan, log } from "../_shared/logger.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
+import { initSentry, log, withHandler, withSpan } from "../_shared/logger.ts";
 import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
 
 const FN = "user-create-order";
@@ -17,33 +22,40 @@ Deno.serve(withHandler(async (req) => {
   const userId = auth;
 
   try {
-    let reqBody: Record<string, unknown>;
-    try {
-      reqBody = await req.json();
-    } catch {
-      return errorResponse("Invalid JSON body", 400);
-    }
+    const body = await parseJsonBody(req);
+    if (body instanceof Response) return body;
 
-    const { event_id, ticket_id, verification_data } = reqBody as {
+    const { event_id, ticket_id, verification_data } = body as {
       event_id?: string;
       ticket_id?: string;
-      verification_data?: { verification_id: string; data: Record<string, unknown> };
+      verification_data?: {
+        verification_id: string;
+        data: Record<string, unknown>;
+      };
     };
 
     // 1. Input validation
-    if (!event_id) return errorResponse("Missing required field: event_id", 400);
-    if (!ticket_id) return errorResponse("Missing required field: ticket_id", 400);
+    if (!event_id) {
+      return errorResponse("Missing required field: event_id", 400);
+    }
+    if (!ticket_id) {
+      return errorResponse("Missing required field: ticket_id", 400);
+    }
 
     const supabase = createServiceClient();
 
     // 2. Fetch event
     const { data: event, error: eventError } = await withSpan(
-      "db.query.events", "db.query",
-      () => supabase
-        .from("events")
-        .select("id, party_id, status, start_time, max_participants, current_participants")
-        .eq("id", event_id)
-        .single(),
+      "db.query.events",
+      "db.query",
+      () =>
+        supabase
+          .from("events")
+          .select(
+            "id, party_id, status, start_time, max_participants, current_participants",
+          )
+          .eq("id", event_id)
+          .single(),
     );
 
     if (eventError || !event) {
@@ -52,21 +64,29 @@ Deno.serve(withHandler(async (req) => {
 
     // Fix #998: active 상태 이벤트도 신청 허용 (apply_event RPC가 scheduled/active 모두 허용)
     if (event.status !== "scheduled" && event.status !== "active") {
-      return errorResponse("이벤트가 마감되었습니다.", 400, { code: "EVENT_CLOSED" });
+      return errorResponse("이벤트가 마감되었습니다.", 400, {
+        code: "EVENT_CLOSED",
+      });
     }
 
     if (new Date(event.start_time) <= new Date()) {
-      return errorResponse("이벤트가 마감되었습니다.", 400, { code: "EVENT_NOT_SCHEDULED" });
+      return errorResponse("이벤트가 마감되었습니다.", 400, {
+        code: "EVENT_NOT_SCHEDULED",
+      });
     }
 
     // 3. Fetch ticket and verify it belongs to the event
     const { data: ticket, error: ticketError } = await withSpan(
-      "db.query.tickets", "db.query",
-      () => supabase
-        .from("tickets")
-        .select("id, event_id, name, price, quantity, sold_count, target_entry_group_ids")
-        .eq("id", ticket_id)
-        .single(),
+      "db.query.tickets",
+      "db.query",
+      () =>
+        supabase
+          .from("tickets")
+          .select(
+            "id, event_id, name, price, quantity, sold_count, target_entry_group_ids",
+          )
+          .eq("id", ticket_id)
+          .single(),
     );
 
     if (ticketError || !ticket) {
@@ -79,22 +99,28 @@ Deno.serve(withHandler(async (req) => {
 
     // 4. Check ticket availability
     if (ticket.sold_count >= ticket.quantity) {
-      return errorResponse("티켓이 매진되었습니다.", 400, { code: "TICKET_SOLD_OUT" });
+      return errorResponse("티켓이 매진되었습니다.", 400, {
+        code: "TICKET_SOLD_OUT",
+      });
     }
 
     // 5. Check event capacity
     if (event.current_participants >= event.max_participants) {
-      return errorResponse("정원이 초과되었습니다.", 400, { code: "EVENT_FULL" });
+      return errorResponse("정원이 초과되었습니다.", 400, {
+        code: "EVENT_FULL",
+      });
     }
 
     // 6. Fetch user profile
     const { data: userProfile, error: profileError } = await withSpan(
-      "db.query.user_profiles", "db.query",
-      () => supabase
-        .from("user_profiles")
-        .select("id, is_verified, gender, birth_date")
-        .eq("id", userId)
-        .single(),
+      "db.query.user_profiles",
+      "db.query",
+      () =>
+        supabase
+          .from("user_profiles")
+          .select("id, is_verified, gender, birth_date")
+          .eq("id", userId)
+          .single(),
     );
 
     if (profileError || !userProfile) {
@@ -103,79 +129,114 @@ Deno.serve(withHandler(async (req) => {
 
     // 7. Check identity verification
     if (!userProfile.is_verified) {
-      return errorResponse("본인인증이 필요합니다.", 400, { code: "IDENTITY_REQUIRED" });
+      return errorResponse("본인인증이 필요합니다.", 400, {
+        code: "IDENTITY_REQUIRED",
+      });
     }
 
     // 8. Check entry group eligibility (gender/age)
     const targetGroupIds: string[] = ticket.target_entry_group_ids ?? [];
     if (targetGroupIds.length > 0) {
       const { data: entryGroups } = await withSpan(
-        "db.query.entry_groups", "db.query",
-        () => supabase
-          .from("entry_groups")
-          .select("id, gender, birth_year_min, birth_year_max, required_verification_ids")
-          .eq("event_id", event_id)
-          .in("id", targetGroupIds),
+        "db.query.entry_groups",
+        "db.query",
+        () =>
+          supabase
+            .from("entry_groups")
+            .select(
+              "id, gender, birth_year_min, birth_year_max, required_verification_ids",
+            )
+            .eq("event_id", event_id)
+            .in("id", targetGroupIds),
       );
 
       if (entryGroups && entryGroups.length > 0) {
         const group = entryGroups[0];
 
         // Gender check
-        if (group.gender && userProfile.gender && group.gender !== userProfile.gender) {
-          return errorResponse("성별 조건이 맞지 않습니다.", 400, { code: "GENDER_MISMATCH" });
+        if (
+          group.gender && userProfile.gender &&
+          group.gender !== userProfile.gender
+        ) {
+          return errorResponse("성별 조건이 맞지 않습니다.", 400, {
+            code: "GENDER_MISMATCH",
+          });
         }
 
         // Age check
         if (userProfile.birth_date) {
           const birthYear = new Date(userProfile.birth_date).getFullYear();
           if (group.birth_year_min && birthYear < group.birth_year_min) {
-            return errorResponse("나이 조건이 맞지 않습니다.", 400, { code: "AGE_MISMATCH" });
+            return errorResponse("나이 조건이 맞지 않습니다.", 400, {
+              code: "AGE_MISMATCH",
+            });
           }
           if (group.birth_year_max && birthYear > group.birth_year_max) {
-            return errorResponse("나이 조건이 맞지 않습니다.", 400, { code: "AGE_MISMATCH" });
+            return errorResponse("나이 조건이 맞지 않습니다.", 400, {
+              code: "AGE_MISMATCH",
+            });
           }
         }
 
         // Required verification check
         const requiredIds: string[] = entryGroups
-          .flatMap((g: { required_verification_ids?: string[] }) => g.required_verification_ids ?? []);
+          .flatMap((g: { required_verification_ids?: string[] }) =>
+            g.required_verification_ids ?? []
+          );
         if (requiredIds.length > 0 && !verification_data) {
-          return errorResponse("자격 인증 정보가 필요합니다.", 400, { code: "VERIFICATION_REQUIRED" });
+          return errorResponse("자격 인증 정보가 필요합니다.", 400, {
+            code: "VERIFICATION_REQUIRED",
+          });
         }
       }
     }
 
     // 9. Check party balance (gender balance)
     const { data: balanceResult, error: balanceError } = await withSpan(
-      "db.rpc.check_party_balance", "db.rpc",
-      () => supabase.rpc("check_party_balance", {
-        p_event_id: event_id,
-        p_ticket_id: ticket_id,
-      }),
+      "db.rpc.check_party_balance",
+      "db.rpc",
+      () =>
+        supabase.rpc("check_party_balance", {
+          p_event_id: event_id,
+          p_ticket_id: ticket_id,
+        }),
     );
 
     if (balanceError) {
-      log({ function: FN, level: "error", message: "check_party_balance error", metadata: { detail: balanceError } });
+      log({
+        function: FN,
+        level: "error",
+        message: "check_party_balance error",
+        metadata: { detail: balanceError },
+      });
     }
 
     if (balanceResult && balanceResult.allowed === false) {
-      return errorResponse("성비 균형 제한입니다.", 400, { code: "BALANCE_LIMIT" });
+      return errorResponse("성비 균형 제한입니다.", 400, {
+        code: "BALANCE_LIMIT",
+      });
     }
 
     // 10. Check duplicate application
     const { data: existingApp } = await withSpan(
-      "db.query.existing_application", "db.query",
-      () => supabase
-        .from("event_applications")
-        .select("id, status")
-        .eq("event_id", event_id)
-        .eq("user_id", userId)
-        .single(),
+      "db.query.existing_application",
+      "db.query",
+      () =>
+        supabase
+          .from("event_applications")
+          .select("id, status")
+          .eq("event_id", event_id)
+          .eq("user_id", userId)
+          .single(),
     );
 
-    if (existingApp && existingApp.status !== "cancelled" && existingApp.status !== "payment_failed") {
-      return errorResponse("이미 신청한 이벤트입니다.", 400, { code: "ALREADY_APPLIED" });
+    if (
+      existingApp && existingApp.status !== "cancelled" &&
+      existingApp.status !== "payment_failed"
+    ) {
+      return errorResponse("이미 신청한 이벤트입니다.", 400, {
+        code: "ALREADY_APPLIED",
+      });
     }
 
     // 11. Determine status based on price
@@ -186,50 +247,61 @@ Deno.serve(withHandler(async (req) => {
 
     // 12. Create or update application via apply_event RPC
     const { data: appId, error: applyError } = await withSpan(
-      "db.rpc.apply_event", "db.rpc",
-      () => supabase.rpc("apply_event", {
-        p_event_id: event_id,
-        p_ticket_id: ticket_id,
-        p_user_id: userId,
-        p_payment_id: pendingPaymentId,
-        p_payment_amount: amount,
-        p_verification_data: verification_data ?? null,
-      }),
+      "db.rpc.apply_event",
+      "db.rpc",
+      () =>
+        supabase.rpc("apply_event", {
+          p_event_id: event_id,
+          p_ticket_id: ticket_id,
+          p_user_id: userId,
+          p_payment_id: pendingPaymentId,
+          p_payment_amount: amount,
+          p_verification_data: verification_data ?? null,
+        }),
     );
 
     if (applyError) {
-      log({ function: FN, level: "error", message: "apply_event error", metadata: { detail: applyError } });
+      log({
+        function: FN,
+        level: "error",
+        message: "apply_event error",
+        metadata: { detail: applyError },
+      });
       return errorResponse("주문 생성 중 오류가 발생했습니다.", 500);
     }
 
     // If existing cancelled/failed app was reused, update it
     if (existingApp) {
       await withSpan(
-        "db.update.event_applications", "db.update",
-        () => supabase
-          .from("event_applications")
-          .update({
-            status: initialStatus,
-            payment_id: pendingPaymentId,
-            ticket_id: ticket_id,
-            payment_amount: amount,
-            updated_at: new Date().toISOString(),
-          })
-          .eq("id", appId),
+        "db.update.event_applications",
+        "db.update",
+        () =>
+          supabase
+            .from("event_applications")
+            .update({
+              status: initialStatus,
+              payment_id: pendingPaymentId,
+              ticket_id: ticket_id,
+              payment_amount: amount,
+              updated_at: new Date().toISOString(),
+            })
+            .eq("id", appId),
       );
     } else {
       // Set status to pending (for paid) or paid (for free)
       await withSpan(
-        "db.update.event_applications.status", "db.update",
-        () => supabase
-          .from("event_applications")
-          .update({
-            status: initialStatus,
-            payment_id: pendingPaymentId,
-            payment_amount: amount,
-            updated_at: new Date().toISOString(),
-          })
-          .eq("id", appId),
+        "db.update.event_applications.status",
+        "db.update",
+        () =>
+          supabase
+            .from("event_applications")
+            .update({
+              status: initialStatus,
+              payment_id: pendingPaymentId,
+              payment_amount: amount,
+              updated_at: new Date().toISOString(),
+            })
+            .eq("id", appId),
       );
     }
 
@@ -248,7 +320,12 @@ Deno.serve(withHandler(async (req) => {
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    log({ function: FN, level: "error", message: "Error in user-create-order", metadata: { detail: message } });
+    log({
+      function: FN,
+      level: "error",
+      message: "Error in user-create-order",
+      metadata: { detail: message },
+    });
     return errorResponse("주문 생성 중 오류가 발생했습니다.", 500);
   }
 }));

--- a/supabase/functions/user-delete-account/index.ts
+++ b/supabase/functions/user-delete-account/index.ts
@@ -5,6 +5,7 @@ import {
   successResponse,
 } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
 import { initSentry, log, withHandler, withSpan } from "../_shared/logger.ts";
 
 const FN = "user-delete-account";
@@ -32,11 +33,15 @@ async function parseRequestBody(
     return {};
   }
 
-  try {
-    return JSON.parse(raw) as DeleteAccountRequest;
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
+  const body = await parseJsonBody(
+    new Request(req.url, {
+      method: req.method,
+      headers: req.headers,
+      body: raw,
+    }),
+  );
+  if (body instanceof Response) return body;
+  return body as DeleteAccountRequest;
 }
 
 Deno.serve(withHandler(async (req) => {

--- a/supabase/functions/user-event-feed/index.ts
+++ b/supabase/functions/user-event-feed/index.ts
@@ -1,9 +1,14 @@
 // user-event-feed/index.ts — Server-side event feed with sorting, filtering & cursor pagination (#614)
 
 import { createServiceClient } from "../_shared/supabase_client.ts";
-import { corsResponse, errorResponse, successResponse } from "../_shared/response_utils.ts";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
 import { optionalAuth, requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler, log } from "../_shared/logger.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
+import { initSentry, log, withHandler } from "../_shared/logger.ts";
 
 const FN = "user-event-feed";
 
@@ -22,19 +27,15 @@ Deno.serve(withHandler(async (req) => {
     return errorResponse("Method not allowed", 405);
   }
 
-  let reqBody: Record<string, unknown>;
-  try {
-    reqBody = await req.json();
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
+  const body = await parseJsonBody(req);
+  if (body instanceof Response) return body;
 
   const {
     sort_by = "recommended",
     filters = {},
     limit: rawLimit = 20,
     cursor = null,
-  } = reqBody as {
+  } = body as {
     sort_by?: string;
     filters?: Record<string, unknown>;
     limit?: number;
@@ -67,7 +68,9 @@ Deno.serve(withHandler(async (req) => {
   // Validate sort_by
   if (!VALID_SORT_BY.includes(sort_by as SortBy)) {
     return errorResponse(
-      `Invalid sort_by: "${sort_by}". Must be one of: ${VALID_SORT_BY.join(", ")}`,
+      `Invalid sort_by: "${sort_by}". Must be one of: ${
+        VALID_SORT_BY.join(", ")
+      }`,
       400,
     );
   }
@@ -82,17 +85,23 @@ Deno.serve(withHandler(async (req) => {
       typeof cursor.sort_key !== "string" ||
       typeof cursor.id !== "string"
     ) {
-      return errorResponse("Invalid cursor: must be {sort_key: string, id: string}", 400);
+      return errorResponse(
+        "Invalid cursor: must be {sort_key: string, id: string}",
+        400,
+      );
     }
   }
 
   // Fix #1748: validate nearby shape before any DB access
-  let nearbyTyped: { lat: number; lng: number; radius_km: number } | null = null;
+  let nearbyTyped: { lat: number; lng: number; radius_km: number } | null =
+    null;
   if (nearby !== null) {
     const { lat, lng, radius_km } = nearby as Record<string, unknown>;
     if (
-      typeof lat !== "number" || !Number.isFinite(lat) || lat < -90 || lat > 90 ||
-      typeof lng !== "number" || !Number.isFinite(lng) || lng < -180 || lng > 180 ||
+      typeof lat !== "number" || !Number.isFinite(lat) || lat < -90 ||
+      lat > 90 ||
+      typeof lng !== "number" || !Number.isFinite(lng) || lng < -180 ||
+      lng > 180 ||
       typeof radius_km !== "number" || !Number.isFinite(radius_km) ||
       radius_km <= 0 || radius_km > 50
     ) {
@@ -168,15 +177,29 @@ Deno.serve(withHandler(async (req) => {
       .from("location_access_log")
       .insert({ user_id: userId, purpose: "nearby_search" });
     if (logError) {
-      log({ function: FN, level: "error", message: "location_access_log INSERT failed", metadata: { detail: logError.message } });
-      return errorResponse("Failed to record location access log", 500, logError.message);
+      log({
+        function: FN,
+        level: "error",
+        message: "location_access_log INSERT failed",
+        metadata: { detail: logError.message },
+      });
+      return errorResponse(
+        "Failed to record location access log",
+        500,
+        logError.message,
+      );
     }
   }
 
   const { data, error } = await supabase.rpc("user_event_feed", rpcParams);
 
   if (error) {
-    log({ function: FN, level: "error", message: "RPC error", metadata: { detail: error.message } });
+    log({
+      function: FN,
+      level: "error",
+      message: "RPC error",
+      metadata: { detail: error.message },
+    });
     return errorResponse("Failed to fetch event feed", 500, error.message);
   }
 

--- a/supabase/functions/user-get-ticket-token/index.ts
+++ b/supabase/functions/user-get-ticket-token/index.ts
@@ -2,20 +2,25 @@
 // Fix #1206: QR screen now fetches token from Edge Function if not in local wallet
 
 import { createServiceClient } from "../_shared/supabase_client.ts";
-import { corsResponse, errorResponse, successResponse } from "../_shared/response_utils.ts";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler, log } from "../_shared/logger.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
+import { initSentry, log, withHandler } from "../_shared/logger.ts";
 
 const FN = "user-get-ticket-token";
 
 initSentry();
 
 function base64UrlEncode(bytes: Uint8Array): string {
-  let binary = '';
+  let binary = "";
   for (let i = 0; i < bytes.byteLength; i++) {
     binary += String.fromCharCode(bytes[i]);
   }
-  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
 }
 
 Deno.serve(withHandler(async (req) => {
@@ -25,14 +30,10 @@ Deno.serve(withHandler(async (req) => {
   if (auth instanceof Response) return auth;
   const authUid = auth;
 
-  let reqBody: Record<string, unknown>;
-  try {
-    reqBody = await req.json();
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
+  const body = await parseJsonBody(req);
+  if (body instanceof Response) return body;
 
-  const { ticket_id } = reqBody as { ticket_id?: string };
+  const { ticket_id } = body as { ticket_id?: string };
 
   if (!ticket_id) {
     return errorResponse("Missing required parameter: ticket_id", 400);
@@ -50,7 +51,12 @@ Deno.serve(withHandler(async (req) => {
     .maybeSingle();
 
   if (appErr) {
-    log({ function: FN, level: "error", message: "Failed to fetch application", metadata: { detail: appErr.message } });
+    log({
+      function: FN,
+      level: "error",
+      message: "Failed to fetch application",
+      metadata: { detail: appErr.message },
+    });
     return errorResponse("Failed to fetch application", 500);
   }
 
@@ -63,7 +69,11 @@ Deno.serve(withHandler(async (req) => {
   // Read the signing key from environment
   const privateKeyJwkStr = Deno.env.get("TICKET_SIGNING_PRIVATE_KEY_JWK");
   if (!privateKeyJwkStr) {
-    log({ function: FN, level: "error", message: "TICKET_SIGNING_PRIVATE_KEY_JWK not configured" });
+    log({
+      function: FN,
+      level: "error",
+      message: "TICKET_SIGNING_PRIVATE_KEY_JWK not configured",
+    });
     return errorResponse("Ticket signing key not configured", 500);
   }
 
@@ -77,25 +87,41 @@ Deno.serve(withHandler(async (req) => {
       ["sign"],
     );
   } catch (e) {
-    log({ function: FN, level: "error", message: "Failed to import signing key", metadata: { detail: String(e) } });
+    log({
+      function: FN,
+      level: "error",
+      message: "Failed to import signing key",
+      metadata: { detail: String(e) },
+    });
     return errorResponse("Failed to import signing key", 500);
   }
 
   const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
-  const payload = `${ticket_id}|${eventId}|${authUid}|${expiresAt.toISOString()}`;
+  const payload =
+    `${ticket_id}|${eventId}|${authUid}|${expiresAt.toISOString()}`;
   const message = new TextEncoder().encode(payload);
 
   let sigBytes: ArrayBuffer;
   try {
     sigBytes = await crypto.subtle.sign("Ed25519", privateKey, message);
   } catch (e) {
-    log({ function: FN, level: "error", message: "Failed to sign ticket token", metadata: { detail: String(e) } });
+    log({
+      function: FN,
+      level: "error",
+      message: "Failed to sign ticket token",
+      metadata: { detail: String(e) },
+    });
     return errorResponse("Failed to sign ticket token", 500);
   }
 
   const signature = base64UrlEncode(new Uint8Array(sigBytes));
 
-  log({ function: FN, level: "info", message: "Ticket token issued", metadata: { ticket_id, event_id: eventId } });
+  log({
+    function: FN,
+    level: "info",
+    message: "Ticket token issued",
+    metadata: { ticket_id, event_id: eventId },
+  });
 
   return successResponse({
     ticket_id,

--- a/supabase/functions/user-manage-notification/index.ts
+++ b/supabase/functions/user-manage-notification/index.ts
@@ -1,8 +1,12 @@
 import { createServiceClient } from "../_shared/supabase_client.ts";
-import { corsResponse, errorResponse, successResponse } from "../_shared/response_utils.ts";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
+import { parseAction } from "../_shared/request_utils.ts";
 import { initSentry, withHandler } from "../_shared/logger.ts";
-
 
 initSentry();
 
@@ -13,18 +17,12 @@ Deno.serve(withHandler(async (req) => {
   if (auth instanceof Response) return auth;
   const userId = auth;
 
-  let body: Record<string, unknown>;
-  try {
-    body = await req.json();
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
-
-  const { action, notification_id } = body as {
-    action?: string;
+  const result = await parseAction(req);
+  if (result instanceof Response) return result;
+  const { action, body } = result;
+  const { notification_id } = body as {
     notification_id?: string;
   };
-
   if (!action) {
     return errorResponse("Missing required parameter: action", 400);
   }

--- a/supabase/functions/user-manage-settings/index.ts
+++ b/supabase/functions/user-manage-settings/index.ts
@@ -1,7 +1,12 @@
 import { createServiceClient } from "../_shared/supabase_client.ts";
-import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler, withSpan, log } from "../_shared/logger.ts";
+import { parseAction } from "../_shared/request_utils.ts";
+import { initSentry, log, withHandler, withSpan } from "../_shared/logger.ts";
 import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
 
 const FN = "user-manage-settings";
@@ -21,14 +26,9 @@ Deno.serve(withHandler(async (req) => {
 
   try {
     // 1. Parse Request
-    let reqBody: Record<string, unknown>;
-    try {
-      reqBody = await req.json();
-    } catch {
-      return errorResponse("Invalid JSON body", 400);
-    }
-
-    const { action } = reqBody as { action?: string };
+    const result = await parseAction(req);
+    if (result instanceof Response) return result;
+    const { action, body } = result;
 
     if (!action) {
       return errorResponse("Missing required field: action", 400);
@@ -39,7 +39,7 @@ Deno.serve(withHandler(async (req) => {
 
     switch (action) {
       case "upsert_token": {
-        const { token, device_type } = reqBody as {
+        const { token, device_type } = body as {
           token?: string;
           device_type?: string;
         };
@@ -49,28 +49,37 @@ Deno.serve(withHandler(async (req) => {
         }
         if (!device_type || !VALID_DEVICE_TYPES.includes(device_type)) {
           return errorResponse(
-            `Invalid device_type. Must be one of: ${VALID_DEVICE_TYPES.join(", ")}`,
+            `Invalid device_type. Must be one of: ${
+              VALID_DEVICE_TYPES.join(", ")
+            }`,
             400,
           );
         }
 
         const { error } = await withSpan(
-          "db.upsert.fcm_tokens", "db.upsert",
-          () => supabase
-            .from("fcm_tokens")
-            .upsert(
-              {
-                user_id: userId,
-                token,
-                device_type,
-                last_updated_at: new Date().toISOString(),
-              },
-              { onConflict: "token" },
-            ),
+          "db.upsert.fcm_tokens",
+          "db.upsert",
+          () =>
+            supabase
+              .from("fcm_tokens")
+              .upsert(
+                {
+                  user_id: userId,
+                  token,
+                  device_type,
+                  last_updated_at: new Date().toISOString(),
+                },
+                { onConflict: "token" },
+              ),
         );
 
         if (error) {
-          log({ function: FN, level: "error", message: "Failed to upsert FCM token", metadata: { detail: error } });
+          log({
+            function: FN,
+            level: "error",
+            message: "Failed to upsert FCM token",
+            metadata: { detail: error },
+          });
           return errorResponse("Failed to upsert token", 500);
         }
 
@@ -82,23 +91,30 @@ Deno.serve(withHandler(async (req) => {
       }
 
       case "delete_token": {
-        const { token } = reqBody as { token?: string };
+        const { token } = body as { token?: string };
 
         if (!token) {
           return errorResponse("Missing required field: token", 400);
         }
 
         const { error } = await withSpan(
-          "db.delete.fcm_tokens", "db.delete",
-          () => supabase
-            .from("fcm_tokens")
-            .delete()
-            .eq("token", token)
-            .eq("user_id", userId),
+          "db.delete.fcm_tokens",
+          "db.delete",
+          () =>
+            supabase
+              .from("fcm_tokens")
+              .delete()
+              .eq("token", token)
+              .eq("user_id", userId),
         );
 
         if (error) {
-          log({ function: FN, level: "error", message: "Failed to delete FCM token", metadata: { detail: error } });
+          log({
+            function: FN,
+            level: "error",
+            message: "Failed to delete FCM token",
+            metadata: { detail: error },
+          });
           return errorResponse("Failed to delete token", 500);
         }
 
@@ -108,7 +124,7 @@ Deno.serve(withHandler(async (req) => {
       }
 
       case "update_settings": {
-        const { settings } = reqBody as {
+        const { settings } = body as {
           settings?: Record<string, unknown>;
         };
 
@@ -129,33 +145,45 @@ Deno.serve(withHandler(async (req) => {
 
         if (Object.keys(sanitized).length === 0) {
           return errorResponse(
-            `No valid settings fields. Allowed: ${ALLOWED_SETTINGS_FIELDS.join(", ")}`,
+            `No valid settings fields. Allowed: ${
+              ALLOWED_SETTINGS_FIELDS.join(", ")
+            }`,
             400,
           );
         }
 
         const { data, error } = await withSpan(
-          "db.upsert.user_settings", "db.upsert",
-          () => supabase
-            .from("user_settings")
-            .upsert(
-              {
-                user_id: userId,
-                ...sanitized,
-                updated_at: new Date().toISOString(),
-              },
-              { onConflict: "user_id" },
-            )
-            .select()
-            .single(),
+          "db.upsert.user_settings",
+          "db.upsert",
+          () =>
+            supabase
+              .from("user_settings")
+              .upsert(
+                {
+                  user_id: userId,
+                  ...sanitized,
+                  updated_at: new Date().toISOString(),
+                },
+                { onConflict: "user_id" },
+              )
+              .select()
+              .single(),
         );
 
         if (error) {
-          log({ function: FN, level: "error", message: "Failed to update settings", metadata: { detail: error } });
+          log({
+            function: FN,
+            level: "error",
+            message: "Failed to update settings",
+            metadata: { detail: error },
+          });
           return errorResponse("Failed to update settings", 500);
         }
 
-        logStatsigEvent(userId, "settings_updated", undefined,
+        logStatsigEvent(
+          userId,
+          "settings_updated",
+          undefined,
           Object.fromEntries(
             Object.entries(sanitized).map(([k, v]) => [k, String(v)]),
           ),
@@ -169,7 +197,11 @@ Deno.serve(withHandler(async (req) => {
     }
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    log({ function: FN, level: "error", message: `Error in ${FN}: ${message}` });
+    log({
+      function: FN,
+      level: "error",
+      message: `Error in ${FN}: ${message}`,
+    });
     return errorResponse(message, 500);
   }
 }));

--- a/supabase/functions/user-manage-settings/user_manage_settings_test.ts
+++ b/supabase/functions/user-manage-settings/user_manage_settings_test.ts
@@ -435,7 +435,7 @@ Deno.test("action 누락 → 400", async () => {
         const payload = await readJson(response);
 
         assertEquals(response.status, 400);
-        assertEquals(payload.error, "Missing required field: action");
+        assertEquals(payload.error, "Missing or invalid \"action\" field");
       });
     });
   });

--- a/supabase/functions/user-manage-social/index.ts
+++ b/supabase/functions/user-manage-social/index.ts
@@ -8,8 +8,8 @@ import {
   successResponse,
 } from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
+import { parseAction } from "../_shared/request_utils.ts";
 import { initSentry, withHandler } from "../_shared/logger.ts";
-
 
 initSentry();
 
@@ -32,14 +32,9 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
 
   const supabase = createServiceClient();
 
-  let body: Record<string, unknown>;
-  try {
-    body = await req.json();
-  } catch {
-    return errorResponse("Invalid JSON body", 400);
-  }
-
-  const action = body.action as string | undefined;
+  const result = await parseAction(req);
+  if (result instanceof Response) return result;
+  const { action, body } = result;
   if (!action) return errorResponse("Missing action", 400);
 
   // ─────────────────────────────────────────
@@ -51,7 +46,10 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
     const interactionType = body.interaction_type as string | undefined;
 
     if (!targetId || !targetType || !interactionType) {
-      return errorResponse("Missing target_id, target_type, or interaction_type", 400);
+      return errorResponse(
+        "Missing target_id, target_type, or interaction_type",
+        400,
+      );
     }
     if (!VALID_TARGET_TYPES.includes(targetType)) {
       return errorResponse(`Invalid target_type: ${targetType}`, 400);
@@ -149,7 +147,9 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
     if (!VALID_REPORT_REASONS.includes(reason)) {
       return errorResponse(`Invalid reason: ${reason}`, 400);
     }
-    if (targetId === userId) return errorResponse("Cannot report yourself", 400);
+    if (targetId === userId) {
+      return errorResponse("Cannot report yourself", 400);
+    }
 
     // 1. Block
     await supabase.from("social_interactions").upsert({

--- a/supabase/functions/user-submit-verification/index.ts
+++ b/supabase/functions/user-submit-verification/index.ts
@@ -1,7 +1,12 @@
 import { createServiceClient } from "../_shared/supabase_client.ts";
-import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler, withSpan, log } from "../_shared/logger.ts";
+import { parseAction } from "../_shared/request_utils.ts";
+import { initSentry, log, withHandler, withSpan } from "../_shared/logger.ts";
 import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
 
 const FN = "user-submit-verification";
@@ -17,14 +22,9 @@ Deno.serve(withHandler(async (req) => {
   const userId = auth;
 
   try {
-    let reqBody: Record<string, unknown>;
-    try {
-      reqBody = await req.json();
-    } catch {
-      return errorResponse("Invalid JSON body", 400);
-    }
-
-    const { action } = reqBody as { action?: string };
+    const result = await parseAction(req);
+    if (result instanceof Response) return result;
+    const { action, body } = result;
     if (!action) {
       return errorResponse("Missing required field: action", 400);
     }
@@ -33,7 +33,7 @@ Deno.serve(withHandler(async (req) => {
 
     switch (action) {
       case "submit": {
-        const { partner_id, verification_id, application_id } = reqBody as {
+        const { partner_id, verification_id, application_id } = body as {
           partner_id?: string;
           verification_id?: string;
           application_id?: string;
@@ -48,21 +48,31 @@ Deno.serve(withHandler(async (req) => {
 
         // 1. Fetch user's verification data (snapshot source)
         const { data: userVerification, error: uvError } = await withSpan(
-          "db.select.user_verifications", "db.select",
-          () => supabase
-            .from("user_verifications")
-            .select("data")
-            .eq("user_id", userId)
-            .eq("verification_id", verification_id)
-            .maybeSingle(),
+          "db.select.user_verifications",
+          "db.select",
+          () =>
+            supabase
+              .from("user_verifications")
+              .select("data")
+              .eq("user_id", userId)
+              .eq("verification_id", verification_id)
+              .maybeSingle(),
         );
 
         if (uvError) {
-          log({ function: FN, level: "error", message: "Failed to fetch user verification", metadata: { detail: uvError } });
+          log({
+            function: FN,
+            level: "error",
+            message: "Failed to fetch user verification",
+            metadata: { detail: uvError },
+          });
           return errorResponse("Failed to fetch user verification data", 500);
         }
         if (!userVerification) {
-          return errorResponse("No verification data found. Save your data first.", 400);
+          return errorResponse(
+            "No verification data found. Save your data first.",
+            400,
+          );
         }
 
         const now = new Date().toISOString();
@@ -77,18 +87,25 @@ Deno.serve(withHandler(async (req) => {
 
         // 2. Check for existing submission
         const { data: existing, error: existError } = await withSpan(
-          "db.select.verification_submissions", "db.select",
-          () => supabase
-            .from("verification_submissions")
-            .select("id, snapshot_data")
-            .eq("user_id", userId)
-            .eq("partner_id", partner_id)
-            .eq("verification_id", verification_id)
-            .maybeSingle(),
+          "db.select.verification_submissions",
+          "db.select",
+          () =>
+            supabase
+              .from("verification_submissions")
+              .select("id, snapshot_data")
+              .eq("user_id", userId)
+              .eq("partner_id", partner_id)
+              .eq("verification_id", verification_id)
+              .maybeSingle(),
         );
 
         if (existError) {
-          log({ function: FN, level: "error", message: "Failed to check existing submission", metadata: { detail: existError } });
+          log({
+            function: FN,
+            level: "error",
+            message: "Failed to check existing submission",
+            metadata: { detail: existError },
+          });
           return errorResponse("Failed to check existing submission", 500);
         }
 
@@ -101,20 +118,27 @@ Deno.serve(withHandler(async (req) => {
             : [snapshotEntry];
 
           const { error: updateError } = await withSpan(
-            "db.update.verification_submissions", "db.update",
-            () => supabase
-              .from("verification_submissions")
-              .update({
-                snapshot_data: snapshotArray,
-                status: "pending",
-                reviewed_at: null,
-                reviewed_by: null,
-              })
-              .eq("id", existing.id),
+            "db.update.verification_submissions",
+            "db.update",
+            () =>
+              supabase
+                .from("verification_submissions")
+                .update({
+                  snapshot_data: snapshotArray,
+                  status: "pending",
+                  reviewed_at: null,
+                  reviewed_by: null,
+                })
+                .eq("id", existing.id),
           );
 
           if (updateError) {
-            log({ function: FN, level: "error", message: "Failed to update submission", metadata: { detail: updateError } });
+            log({
+              function: FN,
+              level: "error",
+              message: "Failed to update submission",
+              metadata: { detail: updateError },
+            });
             return errorResponse("Failed to update submission", 500);
           }
           submissionId = existing.id;
@@ -132,16 +156,23 @@ Deno.serve(withHandler(async (req) => {
           }
 
           const { data: inserted, error: insertError } = await withSpan(
-            "db.insert.verification_submissions", "db.insert",
-            () => supabase
-              .from("verification_submissions")
-              .insert(insertData)
-              .select("id")
-              .single(),
+            "db.insert.verification_submissions",
+            "db.insert",
+            () =>
+              supabase
+                .from("verification_submissions")
+                .insert(insertData)
+                .select("id")
+                .single(),
           );
 
           if (insertError) {
-            log({ function: FN, level: "error", message: "Failed to create submission", metadata: { detail: insertError } });
+            log({
+              function: FN,
+              level: "error",
+              message: "Failed to create submission",
+              metadata: { detail: insertError },
+            });
             return errorResponse("Failed to create submission", 500);
           }
           submissionId = inserted.id;
@@ -157,7 +188,7 @@ Deno.serve(withHandler(async (req) => {
       }
 
       case "comment": {
-        const { submission_id, text } = reqBody as {
+        const { submission_id, text } = body as {
           submission_id?: string;
           text?: string;
         };
@@ -171,16 +202,23 @@ Deno.serve(withHandler(async (req) => {
 
         // Fetch submission and verify ownership
         const { data: submission, error: fetchError } = await withSpan(
-          "db.select.verification_submissions", "db.select",
-          () => supabase
-            .from("verification_submissions")
-            .select("id, user_id, snapshot_data")
-            .eq("id", submission_id)
-            .maybeSingle(),
+          "db.select.verification_submissions",
+          "db.select",
+          () =>
+            supabase
+              .from("verification_submissions")
+              .select("id, user_id, snapshot_data")
+              .eq("id", submission_id)
+              .maybeSingle(),
         );
 
         if (fetchError) {
-          log({ function: FN, level: "error", message: "Failed to fetch submission", metadata: { detail: fetchError } });
+          log({
+            function: FN,
+            level: "error",
+            message: "Failed to fetch submission",
+            metadata: { detail: fetchError },
+          });
           return errorResponse("Failed to fetch submission", 500);
         }
         if (!submission) {
@@ -200,7 +238,9 @@ Deno.serve(withHandler(async (req) => {
         }
 
         const lastEntry = { ...snapshotArray[snapshotArray.length - 1] };
-        const comments = Array.isArray(lastEntry.comments) ? [...lastEntry.comments] : [];
+        const comments = Array.isArray(lastEntry.comments)
+          ? [...lastEntry.comments]
+          : [];
         comments.push({
           author: userId,
           at: new Date().toISOString(),
@@ -210,15 +250,22 @@ Deno.serve(withHandler(async (req) => {
         snapshotArray[snapshotArray.length - 1] = lastEntry;
 
         const { error: updateError } = await withSpan(
-          "db.update.verification_submissions", "db.update",
-          () => supabase
-            .from("verification_submissions")
-            .update({ snapshot_data: snapshotArray })
-            .eq("id", submission_id),
+          "db.update.verification_submissions",
+          "db.update",
+          () =>
+            supabase
+              .from("verification_submissions")
+              .update({ snapshot_data: snapshotArray })
+              .eq("id", submission_id),
         );
 
         if (updateError) {
-          log({ function: FN, level: "error", message: "Failed to add comment", metadata: { detail: updateError } });
+          log({
+            function: FN,
+            level: "error",
+            message: "Failed to add comment",
+            metadata: { detail: updateError },
+          });
           return errorResponse("Failed to add comment", 500);
         }
 
@@ -234,7 +281,11 @@ Deno.serve(withHandler(async (req) => {
     }
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    log({ function: FN, level: "error", message: `Error in ${FN}: ${message}` });
+    log({
+      function: FN,
+      level: "error",
+      message: `Error in ${FN}: ${message}`,
+    });
     return errorResponse(message, 500);
   }
 }));

--- a/supabase/functions/user-submit-verification/user_submit_verification_test.ts
+++ b/supabase/functions/user-submit-verification/user_submit_verification_test.ts
@@ -428,7 +428,7 @@ Deno.test("action 누락 → 400", async () => {
         const payload = await readJson(response);
 
         assertEquals(response.status, 400);
-        assertEquals(payload.error, "Missing required field: action");
+        assertEquals(payload.error, "Missing or invalid \"action\" field");
       });
     });
   });

--- a/supabase/functions/user-update-verification/index.ts
+++ b/supabase/functions/user-update-verification/index.ts
@@ -1,7 +1,12 @@
 import { createServiceClient } from "../_shared/supabase_client.ts";
-import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
 import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler, withSpan, log } from "../_shared/logger.ts";
+import { parseJsonBody } from "../_shared/request_utils.ts";
+import { initSentry, log, withHandler, withSpan } from "../_shared/logger.ts";
 import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
 
 const FN = "user-update-verification";
@@ -17,14 +22,10 @@ Deno.serve(withHandler(async (req) => {
   const userId = auth;
 
   try {
-    let reqBody: Record<string, unknown>;
-    try {
-      reqBody = await req.json();
-    } catch {
-      return errorResponse("Invalid JSON body", 400);
-    }
+    const body = await parseJsonBody(req);
+    if (body instanceof Response) return body;
 
-    const { verification_id, data } = reqBody as {
+    const { verification_id, data } = body as {
       verification_id?: string;
       data?: Record<string, unknown>;
     };
@@ -40,17 +41,24 @@ Deno.serve(withHandler(async (req) => {
 
     // Verify that the verification definition exists
     const { data: verification, error: verificationError } = await withSpan(
-      "db.select.verifications", "db.select",
-      () => supabase
-        .from("verifications")
-        .select("id")
-        .eq("id", verification_id)
-        .eq("is_active", true)
-        .maybeSingle(),
+      "db.select.verifications",
+      "db.select",
+      () =>
+        supabase
+          .from("verifications")
+          .select("id")
+          .eq("id", verification_id)
+          .eq("is_active", true)
+          .maybeSingle(),
     );
 
     if (verificationError) {
-      log({ function: FN, level: "error", message: "Failed to check verification", metadata: { detail: verificationError } });
+      log({
+        function: FN,
+        level: "error",
+        message: "Failed to check verification",
+        metadata: { detail: verificationError },
+      });
       return errorResponse("Failed to check verification", 500);
     }
     if (!verification) {
@@ -59,22 +67,29 @@ Deno.serve(withHandler(async (req) => {
 
     // Upsert user_verifications (user_id + verification_id unique constraint)
     const { error } = await withSpan(
-      "db.upsert.user_verifications", "db.upsert",
-      () => supabase
-        .from("user_verifications")
-        .upsert(
-          {
-            user_id: userId,
-            verification_id,
-            data,
-            updated_at: new Date().toISOString(),
-          },
-          { onConflict: "user_id,verification_id" },
-        ),
+      "db.upsert.user_verifications",
+      "db.upsert",
+      () =>
+        supabase
+          .from("user_verifications")
+          .upsert(
+            {
+              user_id: userId,
+              verification_id,
+              data,
+              updated_at: new Date().toISOString(),
+            },
+            { onConflict: "user_id,verification_id" },
+          ),
     );
 
     if (error) {
-      log({ function: FN, level: "error", message: "Failed to upsert user verification", metadata: { detail: error } });
+      log({
+        function: FN,
+        level: "error",
+        message: "Failed to upsert user verification",
+        metadata: { detail: error },
+      });
       return errorResponse("Failed to save verification data", 500);
     }
 
@@ -85,7 +100,11 @@ Deno.serve(withHandler(async (req) => {
     return successResponse({ success: true });
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    log({ function: FN, level: "error", message: `Error in ${FN}: ${message}` });
+    log({
+      function: FN,
+      level: "error",
+      message: `Error in ${FN}: ${message}`,
+    });
     return errorResponse(message, 500);
   }
 }));


### PR DESCRIPTION
## Summary

- `_shared/request_utils.ts` 신설: `parseJsonBody` / `parseAction` 유틸
- 36개 Edge Function의 try-catch JSON parse 보일러플레이트 → 공통 유틸로 치환
- 에러 메시지 통일: `"Invalid JSON body"`, `"Request body must be a JSON object"`
- 약 288 lines 감소

## Changes

- `supabase/functions/_shared/request_utils.ts` 생성
- 36개 `index.ts` 파일: `parseJsonBody` 또는 `parseAction` 사용으로 교체
- `requirePartnerPermission` (#1791) 포함 모든 기존 로직 보존

## Test plan

- [ ] `test-deno-ef` CI 통과 확인
- [ ] 기존 EF 테스트 모두 pass

Closes #1787