### PR TITLE
fix(#1800): replace CircularProgressIndicator with MinglitSkeleton in tag selection

### DIFF
--- a/apps/app_partner/lib/src/features/party/create/widgets/tag_selection_section.dart
+++ b/apps/app_partner/lib/src/features/party/create/widgets/tag_selection_section.dart
@@ -221,15 +221,10 @@ class _TagSearchResults extends ConsumerWidget {
     final searchAsync = ref.watch(tagSearchProvider(query));
 
     return searchAsync.when(
-      loading: () => const SizedBox(
+      loading: () => const MinglitSkeleton(
+        width: 64,
         height: 36,
-        child: Center(
-          child: SizedBox(
-            width: 20,
-            height: 20,
-            child: CircularProgressIndicator(strokeWidth: 2),
-          ),
-        ),
+        borderRadius: BorderRadius.all(Radius.circular(MinglitRadius.chip)),
       ),
       error: (_, _) => const SizedBox.shrink(),
       data: (tags) {
@@ -274,15 +269,10 @@ class _FeaturedTagsQuickSelect extends ConsumerWidget {
     final controller = ref.read(tagSelectionControllerProvider.notifier);
 
     return featuredAsync.when(
-      loading: () => const SizedBox(
+      loading: () => const MinglitSkeleton(
+        width: 64,
         height: 36,
-        child: Center(
-          child: SizedBox(
-            width: 20,
-            height: 20,
-            child: CircularProgressIndicator(strokeWidth: 2),
-          ),
-        ),
+        borderRadius: BorderRadius.all(Radius.circular(MinglitRadius.chip)),
       ),
       error: (_, _) => const SizedBox.shrink(),
       data: (tags) {

--- a/apps/app_partner/lib/src/features/party/create/widgets/tag_selection_section.dart
+++ b/apps/app_partner/lib/src/features/party/create/widgets/tag_selection_section.dart
@@ -221,6 +221,7 @@ class _TagSearchResults extends ConsumerWidget {
     final searchAsync = ref.watch(tagSearchProvider(query));
 
     return searchAsync.when(
+      // Fix #1800: CircularProgressIndicator caused teardown failures on image load errors — replaced with MinglitSkeleton
       loading: () => const MinglitSkeleton(
         width: 64,
         height: 36,
@@ -269,6 +270,7 @@ class _FeaturedTagsQuickSelect extends ConsumerWidget {
     final controller = ref.read(tagSelectionControllerProvider.notifier);
 
     return featuredAsync.when(
+      // Fix #1800: CircularProgressIndicator caused teardown failures on image load errors — replaced with MinglitSkeleton
       loading: () => const MinglitSkeleton(
         width: 64,
         height: 36,

--- a/apps/app_partner/test/src/features/party/create/widgets/tag_selection_section_test.dart
+++ b/apps/app_partner/test/src/features/party/create/widgets/tag_selection_section_test.dart
@@ -4,6 +4,9 @@
 // - 태그 선택/해제 동작 검증
 // - 5개 초과 선택 비활성화 검증
 // - 검색 필드 렌더링 검증
+// Fix #1800: 로딩 상태에서 MinglitSkeleton 표시 회귀 검증
+import 'dart:async';
+
 import 'package:app_partner/src/features/party/create/logic/tag_selection_controller.dart';
 import 'package:app_partner/src/features/party/create/party_create_wizard_controller.dart';
 import 'package:app_partner/src/features/party/create/widgets/tag_selection_section.dart';
@@ -174,6 +177,48 @@ void main() {
       );
       expect(controller.isMaxReached, isTrue);
       expect(container.read(tagSelectionControllerProvider).length, 5);
+    });
+
+    // Fix #1800: 로딩 중에 MinglitSkeleton이 표시되어야 함 (CircularProgressIndicator 금지)
+    testWidgets('로딩 중에 MinglitSkeleton이 표시되고 CircularProgressIndicator는 없다', (tester) async {
+      final featuredCompleter = Completer<List<Tag>>();
+      final repo = _MockTagRepository();
+      // _buildWidget과 별도로 직접 mock 설정 — 완료되지 않는 Future로 로딩 상태 유지
+      when(repo.getFeaturedTags).thenAnswer((_) => featuredCompleter.future);
+      when(() => repo.getTagsByIds(any())).thenAnswer((_) async => []);
+      when(() => repo.getTagsByPartyId(any())).thenAnswer((_) async => []);
+      when(() => repo.searchTags(any())).thenAnswer((_) async => []);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            tagRepositoryProvider.overrideWithValue(repo),
+            partyCreateWizardControllerProvider.overrideWith(
+              () => _FakeWizardController(tagIds: []),
+            ),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(
+              body: SingleChildScrollView(
+                child: Padding(
+                  padding: EdgeInsets.all(16),
+                  child: TagSelectionSection(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      // pumpAndSettle 대신 pump — 비동기 완료 전 로딩 상태 확인
+      await tester.pump();
+
+      expect(find.byType(MinglitSkeleton), findsWidgets);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+
+      // 완료 후 스켈레톤이 사라지는지 확인
+      featuredCompleter.complete(_featuredTags);
+      await tester.pumpAndSettle();
+      expect(find.text('인기 태그'), findsOneWidget);
     });
 
     testWidgets('태그 없이도 크래시 없이 렌더링된다', (tester) async {

--- a/apps/app_partner/test/src/features/party/create/widgets/tag_selection_section_test.dart
+++ b/apps/app_partner/test/src/features/party/create/widgets/tag_selection_section_test.dart
@@ -180,7 +180,9 @@ void main() {
     });
 
     // Fix #1800: 로딩 중에 MinglitSkeleton이 표시되어야 함 (CircularProgressIndicator 금지)
-    testWidgets('로딩 중에 MinglitSkeleton이 표시되고 CircularProgressIndicator는 없다', (tester) async {
+    testWidgets('로딩 중에 MinglitSkeleton이 표시되고 CircularProgressIndicator는 없다', (
+      tester,
+    ) async {
       final featuredCompleter = Completer<List<Tag>>();
       final repo = _MockTagRepository();
       // _buildWidget과 별도로 직접 mock 설정 — 완료되지 않는 Future로 로딩 상태 유지


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1800

## UX 가이드

이슈 #1800 UX 가이드: https://github.com/Mark-Yun/minglit/issues/1800#issuecomment-4308174143

## 변경 내용

\`tag_selection_section.dart\`의 두 로딩 상태(\`_TagSearchResults\`, \`_FeaturedTagsQuickSelect\`)에서 \`CircularProgressIndicator\`를 \`MinglitSkeleton\`으로 교체했습니다.

- Before: \`CircularProgressIndicator(strokeWidth: 2)\` — 이미지 로드 실패 시 teardown 안 됨
- After: \`MinglitSkeleton(width: 64, height: 36, borderRadius: chip radius)\` — FilterChip과 동일한 시각적 무게감

## 테스트

- \`tag_selection_section_test.dart\` 회귀 테스트 추가: MinglitSkeleton 렌더링 확인, CircularProgressIndicator 부재 확인, 로딩 완료 후 태그 렌더링 확인