### PR TITLE
fix(#1803): wrap More screen bottom spacer with SafeArea for gesture nav bar

### DIFF
--- a/apps/app_partner/lib/src/features/more/more_page.dart
+++ b/apps/app_partner/lib/src/features/more/more_page.dart
@@ -219,7 +219,11 @@ class MorePage extends ConsumerWidget {
             ),
           ],
 
-          const SizedBox(height: MinglitSpacing.xxlarge),
+          // Fix #1803: SafeArea prevents last item overlap with gesture nav bar
+          const SafeArea(
+            top: false,
+            child: SizedBox(height: MinglitSpacing.xxlarge),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1803

## 변경 내용

`more_page.dart` 최하단 `SizedBox`를 `SafeArea(top: false)`로 감쌌습니다.

- Before: 고정 `SizedBox(height: MinglitSpacing.xxlarge)` — 제스처 네비게이션 바와 간섭 가능
- After: `SafeArea(top: false, child: SizedBox(...))` — 시스템 인셋이 자동으로 추가되어 모든 기기에서 안전

## 테스트
`flutter analyze` 0 issues 확인.