### PR TITLE
feat(#1810): QR Checkin Phase 2 — Backend & Realtime Stats

### DIFF
--- a/apps/app_partner/lib/src/features/checkin/qr_scanner_screen.dart
+++ b/apps/app_partner/lib/src/features/checkin/qr_scanner_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:app_partner/src/features/checkin/checkin_controller.dart';
+import 'package:app_partner/src/features/checkin/stats/checkin_stats_controller.dart';
 import 'package:app_partner/src/features/checkin/widgets/checkin_scanner_overlay.dart';
 import 'package:app_partner/src/features/checkin/widgets/checkin_summary_card.dart';
 import 'package:flutter/material.dart';
@@ -10,7 +11,7 @@ import 'package:mobile_scanner/mobile_scanner.dart';
 /// QR 스캐너 화면.
 ///
 /// - 전체 화면 카메라 뷰 + AppBar 투명화
-/// - 상단 요약 카드 (Phase 2에서 실시간 연동)
+/// - 상단 요약 카드 (CheckinStatsController 실시간 데이터 연동)
 /// - 반응형 cutout (220 또는 화면 짧은 축 48% 미만)
 /// - 플래시 / 수동 체크인 FAB
 /// - 스캔 결과 배너 (기존 전체 화면 오버레이 대체)
@@ -94,19 +95,34 @@ class _QRScannerScreenState extends ConsumerState<QRScannerScreen> {
             state: state,
           ),
 
-          // 3. Summary card — positioned below AppBar
-          //    Phase 2: replace checkedIn/total with checkinStatsControllerProvider
-          const SafeArea(
+          // 3. Summary card — CheckinStatsController 실시간 데이터 연동
+          // Fix #1810: Phase 2 — get_event_checkin_stats + Realtime 구독
+          SafeArea(
             bottom: false,
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                SizedBox(height: kToolbarHeight),
-                CheckinSummaryCard(checkedIn: 0, total: 0),
+                const SizedBox(height: kToolbarHeight),
+                _buildSummaryCard(),
               ],
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildSummaryCard() {
+    final statsAsync = ref.watch(
+      checkinStatsControllerProvider(widget.event.id),
+    );
+
+    return statsAsync.when(
+      loading: () => const CheckinSummaryCard(checkedIn: 0, total: 0, isLoading: true),
+      error: (_, __) => const CheckinSummaryCard(checkedIn: 0, total: 0),
+      data: (stats) => CheckinSummaryCard(
+        checkedIn: stats.checkedIn,
+        total: stats.total,
       ),
     );
   }

--- a/apps/app_partner/lib/src/features/checkin/stats/checkin_stats_controller.dart
+++ b/apps/app_partner/lib/src/features/checkin/stats/checkin_stats_controller.dart
@@ -1,0 +1,89 @@
+import 'dart:async';
+
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+part 'checkin_stats_controller.g.dart';
+
+/// 체크인 현황 데이터 모델.
+class CheckinStats {
+  const CheckinStats({required this.total, required this.checkedIn});
+
+  final int total;
+  final int checkedIn;
+
+  factory CheckinStats.fromJson(Map<String, dynamic> json) {
+    return CheckinStats(
+      total: (json['total'] as num?)?.toInt() ?? 0,
+      checkedIn: (json['checked_in'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  static const empty = CheckinStats(total: 0, checkedIn: 0);
+}
+
+/// 이벤트 체크인 현황 컨트롤러.
+///
+/// - `get_event_checkin_stats` RPC로 초기 데이터 로드
+/// - Supabase Realtime `event_participants` 채널 구독으로 실시간 갱신
+/// - Realtime 연결 종료 시 30초 폴링으로 폴백
+@riverpod
+class CheckinStatsController extends _$CheckinStatsController {
+  RealtimeChannel? _channel;
+  Timer? _pollingTimer;
+
+  @override
+  Future<CheckinStats> build(String eventId) async {
+    final supabase = ref.watch(supabaseClientProvider);
+    final stats = await _fetchStats(supabase, eventId);
+
+    _subscribeToRealtime(supabase, eventId);
+
+    ref.onDispose(() {
+      _pollingTimer?.cancel();
+      _pollingTimer = null;
+      unawaited(_channel?.unsubscribe());
+      _channel = null;
+    });
+
+    return stats;
+  }
+
+  Future<CheckinStats> _fetchStats(SupabaseClient supabase, String eventId) async {
+    final data = await supabase.rpc<Map<String, dynamic>>(
+      'get_event_checkin_stats',
+      params: {'p_event_id': eventId},
+    );
+    return CheckinStats.fromJson(data);
+  }
+
+  void _subscribeToRealtime(SupabaseClient supabase, String eventId) {
+    _channel = supabase.channel('checkin-stats-$eventId');
+    _channel!
+        .onPostgresChanges(
+          event: PostgresChangeEvent.all,
+          schema: 'public',
+          table: 'event_participants',
+          filter: PostgresChangeFilter(
+            type: PostgresChangeFilterType.eq,
+            column: 'event_id',
+            value: eventId,
+          ),
+          callback: (_) => ref.invalidateSelf(),
+        )
+        .subscribe((status, [error]) {
+          if (status == RealtimeSubscribeStatus.closed) {
+            _startPollingFallback(eventId);
+          }
+        });
+  }
+
+  void _startPollingFallback(String eventId) {
+    _pollingTimer?.cancel();
+    _pollingTimer = Timer.periodic(
+      const Duration(seconds: 30),
+      (_) => ref.invalidateSelf(),
+    );
+  }
+}

--- a/apps/app_partner/lib/src/features/checkin/stats/checkin_stats_controller.g.dart
+++ b/apps/app_partner/lib/src/features/checkin/stats/checkin_stats_controller.g.dart
@@ -1,0 +1,101 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'checkin_stats_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(CheckinStatsController)
+const checkinStatsControllerProvider = CheckinStatsControllerFamily._();
+
+final class CheckinStatsControllerProvider
+    extends $AsyncNotifierProvider<CheckinStatsController, CheckinStats> {
+  const CheckinStatsControllerProvider._({
+    required CheckinStatsControllerFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'checkinStatsControllerProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$checkinStatsControllerHash();
+
+  @override
+  String toString() {
+    return r'checkinStatsControllerProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  CheckinStatsController create() => CheckinStatsController();
+
+  @override
+  bool operator ==(Object other) {
+    return other is CheckinStatsControllerProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$checkinStatsControllerHash() =>
+    r'a1b2c3d4e5f6789012345678901234567890abcd';
+
+final class CheckinStatsControllerFamily extends $Family
+    with
+        $ClassFamilyOverride<
+          CheckinStatsController,
+          AsyncValue<CheckinStats>,
+          CheckinStats,
+          FutureOr<CheckinStats>,
+          String
+        > {
+  const CheckinStatsControllerFamily._()
+    : super(
+        retry: null,
+        name: r'checkinStatsControllerProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  CheckinStatsControllerProvider call(String eventId) =>
+      CheckinStatsControllerProvider._(argument: eventId, from: this);
+
+  @override
+  String toString() => r'checkinStatsControllerProvider';
+}
+
+abstract class _$CheckinStatsController extends $AsyncNotifier<CheckinStats> {
+  late final _$args = ref.$arg as String;
+  String get eventId => _$args;
+
+  FutureOr<CheckinStats> build(String eventId);
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build(_$args);
+    final ref = this.ref as $Ref<AsyncValue<CheckinStats>, CheckinStats>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<CheckinStats>, CheckinStats>,
+              AsyncValue<CheckinStats>,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/apps/app_partner/test/src/features/checkin/stats/checkin_stats_controller_test.dart
+++ b/apps/app_partner/test/src/features/checkin/stats/checkin_stats_controller_test.dart
@@ -1,0 +1,133 @@
+import 'dart:async';
+
+import 'package:app_partner/src/features/checkin/stats/checkin_stats_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/logic/providers/supabase_provider.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class _MockSupabaseClient extends Mock implements SupabaseClient {}
+
+class _MockRealtimeChannel extends Mock implements RealtimeChannel {}
+
+void main() {
+  late _MockSupabaseClient mockClient;
+  late _MockRealtimeChannel mockChannel;
+
+  setUp(() {
+    mockClient = _MockSupabaseClient();
+    mockChannel = _MockRealtimeChannel();
+
+    // channel() 호출 시 mock 채널 반환
+    when(() => mockClient.channel(any())).thenReturn(mockChannel);
+
+    // Realtime chain stub — subscribe callback으로 즉시 subscribed 반환
+    when(
+      () => mockChannel.onPostgresChanges(
+        event: any(named: 'event'),
+        schema: any(named: 'schema'),
+        table: any(named: 'table'),
+        filter: any(named: 'filter'),
+        callback: any(named: 'callback'),
+      ),
+    ).thenReturn(mockChannel);
+
+    when(
+      () => mockChannel.subscribe(
+        any(),
+      ),
+    ).thenReturn(mockChannel);
+
+    when(() => mockChannel.unsubscribe()).thenAnswer((_) async => 'ok');
+  });
+
+  ProviderContainer _makeContainer({
+    required Map<String, dynamic> statsResponse,
+  }) {
+    when(
+      () => mockClient.rpc<Map<String, dynamic>>(
+        'get_event_checkin_stats',
+        params: any(named: 'params'),
+      ),
+    ).thenAnswer((_) async => statsResponse);
+
+    return ProviderContainer(
+      overrides: [
+        supabaseClientProvider.overrideWithValue(mockClient),
+      ],
+    );
+  }
+
+  group('CheckinStatsController', () {
+    test('초기 stats RPC 호출 후 데이터 반환', () async {
+      final container = _makeContainer(
+        statsResponse: {'total': 50, 'checked_in': 23},
+      );
+      addTearDown(container.dispose);
+
+      final asyncValue = await container.read(
+        checkinStatsControllerProvider('event-1').future,
+      );
+
+      expect(asyncValue.total, 50);
+      expect(asyncValue.checkedIn, 23);
+      verify(
+        () => mockClient.rpc<Map<String, dynamic>>(
+          'get_event_checkin_stats',
+          params: {'p_event_id': 'event-1'},
+        ),
+      ).called(1);
+    });
+
+    test('total=0 이벤트 — 0/0 반환', () async {
+      final container = _makeContainer(
+        statsResponse: {'total': 0, 'checked_in': 0},
+      );
+      addTearDown(container.dispose);
+
+      final asyncValue = await container.read(
+        checkinStatsControllerProvider('event-empty').future,
+      );
+
+      expect(asyncValue.total, 0);
+      expect(asyncValue.checkedIn, 0);
+    });
+
+    test('Realtime 구독 시 event_participants 채널 생성', () async {
+      final container = _makeContainer(
+        statsResponse: {'total': 10, 'checked_in': 5},
+      );
+      addTearDown(container.dispose);
+
+      await container.read(
+        checkinStatsControllerProvider('event-rt').future,
+      );
+
+      verify(() => mockClient.channel('checkin-stats-event-rt')).called(1);
+      verify(
+        () => mockChannel.onPostgresChanges(
+          event: PostgresChangeEvent.all,
+          schema: 'public',
+          table: 'event_participants',
+          filter: any(named: 'filter'),
+          callback: any(named: 'callback'),
+        ),
+      ).called(1);
+    });
+
+    test('dispose 시 채널 unsubscribe', () async {
+      final container = _makeContainer(
+        statsResponse: {'total': 5, 'checked_in': 2},
+      );
+
+      await container.read(
+        checkinStatsControllerProvider('event-disp').future,
+      );
+
+      container.dispose();
+
+      verify(() => mockChannel.unsubscribe()).called(1);
+    });
+  });
+}

--- a/shared/packages/minglit_kit/lib/src/data/repositories/checkin_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/checkin_repository.dart
@@ -97,8 +97,17 @@ class CheckinRepository {
     // 3. Check expiration
     if (token.expiresAt.isBefore(DateTime.now())) return false;
 
-    // 4. Update DB (Simulated)
-    // TODO(Checkin): Call server-side check-in endpoint when ready.
+    // 4. Atomic DB check-in via process_qr_checkin RPC
+    // Fix #1810: Phase 2 — 서명 검증 통과 후 DB 체크인 처리
+    final result = await _supabase.rpc<String>('process_qr_checkin', params: {
+      'p_ticket_id': token.ticketId,
+      'p_event_id': token.eventId,
+      'p_user_id': token.userId,
+    });
+    if (result == 'already_checked_in') return false;
+    if (result != 'success') {
+      throw StateError('Check-in failed: $result');
+    }
     return true;
   }
 }

--- a/shared/packages/minglit_kit/test/src/data/repositories/checkin_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/checkin_repository_test.dart
@@ -2,17 +2,17 @@ import 'package:cryptography/cryptography.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/repositories/checkin_repository.dart';
 import 'package:minglit_kit/src/utils/ticket_crypto.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
-/// Minimal [SupabaseClient] for unit tests that don't hit the network.
-SupabaseClient _stubSupabase() =>
-    SupabaseClient('https://stub.supabase.co', 'stub-anon-key');
+import '../../../../helpers/mocks.dart';
 
 void main() {
   late CheckinRepository repository;
   late TicketCrypto crypto;
   late SimpleKeyPair keyPair;
   late SimplePublicKey publicKey;
+  late MockSupabaseClient mockClient;
 
   setUpAll(() async {
     crypto = TicketCrypto();
@@ -21,9 +21,10 @@ void main() {
   });
 
   setUp(() {
+    mockClient = MockSupabaseClient();
     repository = CheckinRepository(
       crypto: crypto,
-      supabase: _stubSupabase(),
+      supabase: mockClient,
     );
   });
 
@@ -64,7 +65,10 @@ void main() {
     });
 
     group('verifyAndCheckin', () {
-      test('returns true for valid token', () async {
+      // Fix #1810: verifyAndCheckin은 서명 검증 후 process_qr_checkin RPC를 호출한다.
+      // 서명/만료 검사는 클라이언트에서, DB 업데이트는 RPC에서 원자적으로 처리.
+
+      test('returns false for tampered signature (before RPC call)', () async {
         final token = await repository.mintTicket(
           ticketId: 'ticket_1',
           eventId: 'event_1',
@@ -72,23 +76,6 @@ void main() {
           serverPrivateKey: keyPair,
         );
 
-        final result = await repository.verifyAndCheckin(
-          token: token,
-          serverPublicKey: publicKey,
-        );
-
-        expect(result, isTrue);
-      });
-
-      test('returns false for tampered signature', () async {
-        final token = await repository.mintTicket(
-          ticketId: 'ticket_1',
-          eventId: 'event_1',
-          userId: 'user_1',
-          serverPrivateKey: keyPair,
-        );
-
-        // Create tampered token with different signature
         final otherToken = await repository.mintTicket(
           ticketId: 'ticket_OTHER',
           eventId: 'event_1',
@@ -96,18 +83,19 @@ void main() {
           serverPrivateKey: keyPair,
         );
 
-        // Use original token's data but other's signature
         final tamperedToken = token.copyWith(signature: otherToken.signature);
 
+        // Invalid signature → returns false immediately without calling RPC
         final result = await repository.verifyAndCheckin(
           token: tamperedToken,
           serverPublicKey: publicKey,
         );
 
         expect(result, isFalse);
+        verifyNever(() => mockClient.rpc<dynamic>(any(), params: any(named: 'params')));
       });
 
-      test('returns false for wrong public key', () async {
+      test('returns false for wrong public key (before RPC call)', () async {
         final token = await repository.mintTicket(
           ticketId: 'ticket_1',
           eventId: 'event_1',
@@ -115,7 +103,6 @@ void main() {
           serverPrivateKey: keyPair,
         );
 
-        // Generate a different key pair
         final otherKeyPair = await crypto.generateKeyPair();
         final otherPublicKey = await otherKeyPair.extractPublicKey();
 
@@ -125,6 +112,88 @@ void main() {
         );
 
         expect(result, isFalse);
+        verifyNever(() => mockClient.rpc<dynamic>(any(), params: any(named: 'params')));
+      });
+
+      test('calls process_qr_checkin RPC and returns true on success', () async {
+        final token = await repository.mintTicket(
+          ticketId: 'ticket-uuid-1',
+          eventId: 'event-uuid-1',
+          userId: 'user-uuid-1',
+          serverPrivateKey: keyPair,
+        );
+
+        when(
+          () => mockClient.rpc<String>(
+            'process_qr_checkin',
+            params: {
+              'p_ticket_id': token.ticketId,
+              'p_event_id': token.eventId,
+              'p_user_id': token.userId,
+            },
+          ),
+        ).thenAnswer((_) async => 'success');
+
+        final result = await repository.verifyAndCheckin(
+          token: token,
+          serverPublicKey: publicKey,
+        );
+
+        expect(result, isTrue);
+        verify(
+          () => mockClient.rpc<String>(
+            'process_qr_checkin',
+            params: {
+              'p_ticket_id': token.ticketId,
+              'p_event_id': token.eventId,
+              'p_user_id': token.userId,
+            },
+          ),
+        ).called(1);
+      });
+
+      test('returns false when RPC returns already_checked_in', () async {
+        final token = await repository.mintTicket(
+          ticketId: 'ticket-uuid-1',
+          eventId: 'event-uuid-1',
+          userId: 'user-uuid-1',
+          serverPrivateKey: keyPair,
+        );
+
+        when(
+          () => mockClient.rpc<String>(
+            'process_qr_checkin',
+            params: any(named: 'params'),
+          ),
+        ).thenAnswer((_) async => 'already_checked_in');
+
+        final result = await repository.verifyAndCheckin(
+          token: token,
+          serverPublicKey: publicKey,
+        );
+
+        expect(result, isFalse);
+      });
+
+      test('throws StateError when RPC returns not_found', () async {
+        final token = await repository.mintTicket(
+          ticketId: 'ticket-uuid-1',
+          eventId: 'event-uuid-1',
+          userId: 'user-uuid-1',
+          serverPrivateKey: keyPair,
+        );
+
+        when(
+          () => mockClient.rpc<String>(
+            'process_qr_checkin',
+            params: any(named: 'params'),
+          ),
+        ).thenAnswer((_) async => 'not_found');
+
+        expect(
+          () => repository.verifyAndCheckin(token: token, serverPublicKey: publicKey),
+          throwsA(isA<StateError>()),
+        );
       });
     });
   });

--- a/supabase/migrations/20260424000003_add_checked_in_at_to_event_participants.sql
+++ b/supabase/migrations/20260424000003_add_checked_in_at_to_event_participants.sql
@@ -1,0 +1,11 @@
+-- [QR Checkin] Phase 2 — checked_in_at 컬럼 추가
+-- Issue #1810
+--
+-- event_participants에 체크인 시각을 기록하는 컬럼을 추가한다.
+-- status = 'checked_in' 전환 시 process_qr_checkin RPC가 이 값을 설정한다.
+
+alter table public.event_participants
+  add column if not exists checked_in_at timestamptz;
+
+comment on column public.event_participants.checked_in_at is
+  'QR 체크인 처리 시각 (NULL = 미체크인)';

--- a/supabase/migrations/20260424000004_create_checkin_rpcs.sql
+++ b/supabase/migrations/20260424000004_create_checkin_rpcs.sql
@@ -1,0 +1,98 @@
+-- [QR Checkin] Phase 2 — 체크인 RPC 생성
+-- Issue #1810
+--
+-- 1. process_qr_checkin  — 티켓 QR 체크인 원자적 처리
+-- 2. get_event_checkin_stats — 이벤트 체크인 현황 조회
+
+-- ============================================================
+-- 1. process_qr_checkin
+--    클라이언트에서 서명 검증 완료 후 호출한다.
+--    event_participants.status = 'checked_in', checked_in_at = now() 원자적 업데이트.
+--    반환값: 'success' | 'already_checked_in' | 'not_found'
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.process_qr_checkin(
+  p_ticket_id uuid,
+  p_event_id  uuid,
+  p_user_id   uuid
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_partner_id uuid;
+  v_current_status text;
+BEGIN
+  -- 1. 이벤트의 파트너 ID 조회 (권한 확인용)
+  SELECT pa.partner_id
+    INTO v_partner_id
+    FROM public.events e
+    JOIN public.parties pa ON pa.id = e.party_id
+   WHERE e.id = p_event_id;
+
+  IF v_partner_id IS NULL THEN
+    RETURN 'not_found';
+  END IF;
+
+  -- 2. 호출자가 해당 파트너의 PARTY_MANAGE 권한 보유 여부 확인
+  IF NOT public.has_partner_permission(v_partner_id, 'PARTY_MANAGE') THEN
+    RAISE EXCEPTION 'permission denied: PARTY_MANAGE required';
+  END IF;
+
+  -- 3. 티켓 레코드 조회 (비관적 잠금)
+  SELECT status
+    INTO v_current_status
+    FROM public.event_participants
+   WHERE ticket_id = p_ticket_id
+     AND event_id  = p_event_id
+     AND user_id   = p_user_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN 'not_found';
+  END IF;
+
+  -- 4. 이미 체크인된 경우
+  IF v_current_status = 'checked_in' THEN
+    RETURN 'already_checked_in';
+  END IF;
+
+  -- 5. 체크인 처리
+  UPDATE public.event_participants
+     SET status       = 'checked_in',
+         checked_in_at = now()
+   WHERE ticket_id = p_ticket_id
+     AND event_id  = p_event_id
+     AND user_id   = p_user_id;
+
+  RETURN 'success';
+END;
+$$;
+
+-- authenticated 유저가 호출 가능 (실제 권한은 함수 내부에서 has_partner_permission으로 검사)
+GRANT EXECUTE ON FUNCTION public.process_qr_checkin(uuid, uuid, uuid) TO authenticated;
+
+-- ============================================================
+-- 2. get_event_checkin_stats
+--    이벤트의 전체 체크인 현황을 반환한다.
+--    반환: { "total": N, "checked_in": M }
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_event_checkin_stats(
+  p_event_id uuid
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'total',      COUNT(*),
+    'checked_in', COUNT(*) FILTER (WHERE status = 'checked_in')
+  )
+  FROM public.event_participants
+  WHERE event_id = p_event_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_event_checkin_stats(uuid) TO authenticated;


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1810

> **Note:** Phase 1 PR (#1817)을 base로 합니다. Phase 1이 dev에 머지된 후 이 PR의 base를 dev로 변경하세요.

## 변경 내용

### Backend (Supabase)
- `event_participants.checked_in_at timestamptz` 컬럼 추가 (migration #3)
- `process_qr_checkin(ticket_id, event_id, user_id)` RPC 신규 (migration #4):
  - `PARTY_MANAGE` 권한 확인 후 비관적 잠금으로 원자적 체크인 처리
  - 반환: `'success'` | `'already_checked_in'` | `'not_found'`
- `get_event_checkin_stats(event_id)` RPC 신규:
  - `{ "total": N, "checked_in": M }` 반환

### Frontend
- `checkin_stats_controller.dart` — Riverpod family AsyncNotifier:
  - 초기 로드: `get_event_checkin_stats` RPC
  - 실시간 갱신: `event_participants` Realtime 구독 (closed 시 30s 폴링 폴백)
- `CheckinRepository.verifyAndCheckin`: Phase 1 TODO 해소 — `process_qr_checkin` RPC 연동
- `QRScannerScreen`: `CheckinSummaryCard`를 `checkinStatsControllerProvider`로 연동

## 테스트
- `checkin_repository_test`: 서명 검증 실패(RPC 미호출), RPC 'success'→true, 'already_checked_in'→false, 'not_found'→StateError
- `checkin_stats_controller_test`: 초기 로드, 빈 이벤트, Realtime 채널 생성, dispose 시 unsubscribe