### PR TITLE
feat(#1812): QR Checkin Phase 4 — Manual Check-in Sheet

### DIFF
--- a/apps/app_partner/lib/src/features/checkin/checkin_controller.dart
+++ b/apps/app_partner/lib/src/features/checkin/checkin_controller.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:flutter/semantics.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -65,22 +66,34 @@ class CheckinController extends _$CheckinController {
       );
 
       if (success) {
+        final userName = 'User ${token.userId.substring(0, 4)}';
         state = state.copyWith(
           result: CheckinResult.success,
-          userName: 'User ${token.userId.substring(0, 4)}', // Simulated name
+          userName: userName,
+        );
+        // Fix #1813: A11y — 스캔 성공 TalkBack/VoiceOver 알림
+        SemanticsService.announce(
+          '체크인 성공. $userName',
+          TextDirection.ltr,
         );
       } else {
+        const message = '유효하지 않은 티켓입니다.';
         state = state.copyWith(
           result: CheckinResult.invalid,
-          message: '유효하지 않은 티켓입니다.',
+          message: message,
         );
+        // Fix #1813: A11y — 스캔 실패 TalkBack/VoiceOver 알림
+        SemanticsService.announce('입장 불가. $message', TextDirection.ltr);
       }
     } on Object catch (e) {
       Log.e('Check-in processing failed', e);
+      const message = '티켓 데이터를 읽을 수 없습니다.';
       state = state.copyWith(
         result: CheckinResult.invalid,
-        message: '티켓 데이터를 읽을 수 없습니다.',
+        message: message,
       );
+      // Fix #1813: A11y — 스캔 오류 TalkBack/VoiceOver 알림
+      SemanticsService.announce('입장 불가. $message', TextDirection.ltr);
     }
 
     // Reset to idle after a delay to allow for feedback UI

--- a/apps/app_partner/lib/src/features/checkin/manual/checkin_participant.dart
+++ b/apps/app_partner/lib/src/features/checkin/manual/checkin_participant.dart
@@ -1,0 +1,46 @@
+/// 수동 체크인용 참가자 데이터 모델.
+class CheckinParticipant {
+  const CheckinParticipant({
+    required this.id,
+    required this.ticketId,
+    required this.name,
+    required this.phoneLast4,
+    required this.status,
+    this.checkedInAt,
+  });
+
+  factory CheckinParticipant.fromJson(Map<String, dynamic> json) {
+    return CheckinParticipant(
+      id: json['id'] as String,
+      ticketId: json['ticket_id'] as String,
+      name: json['name'] as String,
+      phoneLast4: (json['phone_last4'] as String?) ?? '',
+      status: json['status'] as String,
+      checkedInAt: json['checked_in_at'] != null
+          ? DateTime.parse(json['checked_in_at'] as String)
+          : null,
+    );
+  }
+
+  final String id;
+  final String ticketId;
+  final String name;
+  final String phoneLast4;
+
+  /// 'ticket_issued' | 'checked_in' | 'no_show'
+  final String status;
+  final DateTime? checkedInAt;
+
+  bool get isCheckedIn => status == 'checked_in';
+
+  CheckinParticipant copyWith({String? status, DateTime? checkedInAt}) {
+    return CheckinParticipant(
+      id: id,
+      ticketId: ticketId,
+      name: name,
+      phoneLast4: phoneLast4,
+      status: status ?? this.status,
+      checkedInAt: checkedInAt ?? this.checkedInAt,
+    );
+  }
+}

--- a/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_controller.dart
+++ b/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_controller.dart
@@ -52,8 +52,9 @@ class ManualCheckinController extends _$ManualCheckinController {
         params: {'p_ticket_id': ticketId, 'p_event_id': eventId},
       ) as String;
 
-      if (result != 'success') {
-        // 실패 시 원래 상태 복구
+      // Fix #1812: already_checked_in은 서버 실제 상태도 checked_in이므로
+      // optimistic 상태를 유지한다. not_found만 이전 상태로 복구.
+      if (result == 'not_found') {
         state = previous;
       }
       return result;

--- a/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_controller.dart
+++ b/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_controller.dart
@@ -1,0 +1,65 @@
+import 'package:app_partner/src/features/checkin/manual/checkin_participant.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+part 'manual_checkin_controller.g.dart';
+
+/// 이벤트 참가자 목록 + 수동 체크인 처리 컨트롤러.
+///
+/// - 초기 로드: `get_event_participants_for_checkin` RPC
+/// - 체크인 처리: `process_manual_checkin` RPC + optimistic 업데이트
+@riverpod
+class ManualCheckinController extends _$ManualCheckinController {
+  @override
+  Future<List<CheckinParticipant>> build(String eventId) async {
+    final supabase = ref.watch(supabaseClientProvider);
+    return _fetchParticipants(supabase, eventId);
+  }
+
+  Future<List<CheckinParticipant>> _fetchParticipants(
+    SupabaseClient supabase,
+    String eventId,
+  ) async {
+    final raw = await supabase.rpc<dynamic>(
+      'get_event_participants_for_checkin',
+      params: {'p_event_id': eventId},
+    );
+    return (raw as List)
+        .cast<Map<String, dynamic>>()
+        .map(CheckinParticipant.fromJson)
+        .toList();
+  }
+
+  /// 수동 체크인 처리.
+  ///
+  /// 반환값: 'success' | 'already_checked_in' | 'not_found'
+  Future<String> checkin(String ticketId) async {
+    final supabase = ref.read(supabaseClientProvider);
+
+    // Optimistic 업데이트: 즉시 UI 반영
+    final previous = state;
+    state = previous.whenData(
+      (list) => list.map((p) {
+        if (p.ticketId != ticketId) return p;
+        return p.copyWith(status: 'checked_in', checkedInAt: DateTime.now());
+      }).toList(),
+    );
+
+    try {
+      final result = await supabase.rpc<dynamic>(
+        'process_manual_checkin',
+        params: {'p_ticket_id': ticketId, 'p_event_id': eventId},
+      ) as String;
+
+      if (result != 'success') {
+        // 실패 시 원래 상태 복구
+        state = previous;
+      }
+      return result;
+    } catch (e) {
+      state = previous;
+      rethrow;
+    }
+  }
+}

--- a/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_controller.g.dart
+++ b/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_controller.g.dart
@@ -1,0 +1,109 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'manual_checkin_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(ManualCheckinController)
+const manualCheckinControllerProvider = ManualCheckinControllerFamily._();
+
+final class ManualCheckinControllerProvider
+    extends $AsyncNotifierProvider<ManualCheckinController,
+        List<CheckinParticipant>> {
+  const ManualCheckinControllerProvider._({
+    required ManualCheckinControllerFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'manualCheckinControllerProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$manualCheckinControllerHash();
+
+  @override
+  String toString() {
+    return r'manualCheckinControllerProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  ManualCheckinController create() => ManualCheckinController();
+
+  @override
+  bool operator ==(Object other) {
+    return other is ManualCheckinControllerProvider &&
+        other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$manualCheckinControllerHash() =>
+    r'c3d4e5f6789012345678901234567890123456cd';
+
+final class ManualCheckinControllerFamily extends $Family
+    with
+        $ClassFamilyOverride<
+          ManualCheckinController,
+          AsyncValue<List<CheckinParticipant>>,
+          List<CheckinParticipant>,
+          FutureOr<List<CheckinParticipant>>,
+          String
+        > {
+  const ManualCheckinControllerFamily._()
+    : super(
+        retry: null,
+        name: r'manualCheckinControllerProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  ManualCheckinControllerProvider call(String eventId) =>
+      ManualCheckinControllerProvider._(
+        argument: eventId,
+        from: this,
+      );
+
+  @override
+  String toString() => r'manualCheckinControllerProvider';
+}
+
+abstract class _$ManualCheckinController
+    extends $AsyncNotifier<List<CheckinParticipant>> {
+  late final _$args = ref.$arg as String;
+  String get eventId => _$args;
+
+  FutureOr<List<CheckinParticipant>> build(String eventId);
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build(_$args);
+    final ref = this.ref as $Ref<AsyncValue<List<CheckinParticipant>>,
+        List<CheckinParticipant>>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<List<CheckinParticipant>>,
+                  List<CheckinParticipant>>,
+              AsyncValue<List<CheckinParticipant>>,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_sheet.dart
+++ b/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_sheet.dart
@@ -1,0 +1,394 @@
+import 'dart:async';
+
+import 'package:app_partner/src/features/checkin/manual/checkin_participant.dart';
+import 'package:app_partner/src/features/checkin/manual/manual_checkin_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+/// 수동 체크인 바텀시트.
+///
+/// 이름 또는 전화 뒷자리 4자리로 참가자를 검색하고 체크인 처리한다.
+// Fix #1812: Phase 4 — 수동 체크인 시트 (검색 + AnimatedList)
+class ManualCheckinSheet extends ConsumerStatefulWidget {
+  const ManualCheckinSheet({required this.eventId, super.key});
+
+  final String eventId;
+
+  @override
+  ConsumerState<ManualCheckinSheet> createState() => _ManualCheckinSheetState();
+}
+
+class _ManualCheckinSheetState extends ConsumerState<ManualCheckinSheet> {
+  final _searchController = TextEditingController();
+  Timer? _debounce;
+  String _query = '';
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _debounce?.cancel();
+    super.dispose();
+  }
+
+  void _onSearchChanged(String value) {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 150), () {
+      if (mounted) setState(() => _query = value.trim());
+    });
+  }
+
+  List<CheckinParticipant> _filter(List<CheckinParticipant> all) {
+    final q = _query;
+    if (q.isEmpty) return all;
+    // 순수 숫자 4자리 → 전화 뒷자리 매칭
+    final isPhone = RegExp(r'^\d{4}$').hasMatch(q);
+    return all.where((p) {
+      if (isPhone) return p.phoneLast4 == q;
+      return p.name.contains(q);
+    }).toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final participantsAsync = ref.watch(
+      manualCheckinControllerProvider(widget.eventId),
+    );
+
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.viewInsetsOf(context).bottom,
+      ),
+      child: DraggableScrollableSheet(
+        initialChildSize: 0.85,
+        minChildSize: 0.5,
+        maxChildSize: 0.95,
+        expand: false,
+        builder: (context, scrollController) {
+          return Material(
+            color: scheme.surface,
+            borderRadius: const BorderRadius.vertical(
+              top: Radius.circular(MinglitRadius.card),
+            ),
+            child: Column(
+              children: [
+                // 드래그 핸들
+                const SizedBox(height: 8),
+                Container(
+                  width: 36,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: scheme.outlineVariant,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+                const SizedBox(height: 8),
+
+                // 헤더
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: MinglitSpacing.screenEdge,
+                  ),
+                  child: Row(
+                    children: [
+                      Text(
+                        '수동 체크인',
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      const Spacer(),
+                      IconButton(
+                        icon: const Icon(Icons.close),
+                        onPressed: () => Navigator.of(context).pop(),
+                        visualDensity: VisualDensity.compact,
+                      ),
+                    ],
+                  ),
+                ),
+
+                // 검색 입력
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: MinglitSpacing.screenEdge,
+                    vertical: 8,
+                  ),
+                  child: TextField(
+                    controller: _searchController,
+                    autofocus: true,
+                    decoration: InputDecoration(
+                      hintText: '이름 또는 전화 뒷자리 4자리',
+                      prefixIcon: const Icon(Icons.search),
+                      border: OutlineInputBorder(
+                        borderRadius:
+                            BorderRadius.circular(MinglitRadius.input),
+                      ),
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 10,
+                      ),
+                    ),
+                    onChanged: _onSearchChanged,
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(
+                    left: MinglitSpacing.screenEdge,
+                    right: MinglitSpacing.screenEdge,
+                    bottom: 8,
+                  ),
+                  child: Text(
+                    'QR 인식이 어려울 때 이름으로 체크인 처리',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: scheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+
+                const Divider(height: 1),
+
+                // 참가자 목록
+                Expanded(
+                  child: participantsAsync.when(
+                    loading: () => const Center(
+                      child: CircularProgressIndicator(),
+                    ),
+                    error: (e, _) => Center(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            '참가자 목록을 불러올 수 없습니다',
+                            style: theme.textTheme.bodyMedium,
+                          ),
+                          const SizedBox(height: 8),
+                          TextButton(
+                            onPressed: () => ref.invalidate(
+                              manualCheckinControllerProvider(widget.eventId),
+                            ),
+                            child: const Text('다시 시도'),
+                          ),
+                        ],
+                      ),
+                    ),
+                    data: (all) {
+                      final filtered = _filter(all);
+                      final unchecked =
+                          filtered.where((p) => !p.isCheckedIn).toList();
+                      final checked =
+                          filtered.where((p) => p.isCheckedIn).toList();
+
+                      if (filtered.isEmpty) {
+                        return Center(
+                          child: Text(
+                            _query.isEmpty
+                                ? '참가자가 없습니다'
+                                : '검색 결과가 없습니다',
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: scheme.onSurfaceVariant,
+                            ),
+                          ),
+                        );
+                      }
+
+                      return ListView(
+                        controller: scrollController,
+                        padding: const EdgeInsets.only(bottom: 24),
+                        children: [
+                          if (unchecked.isNotEmpty) ...[
+                            _SectionHeader(
+                              '미체크인 (${unchecked.length}명)',
+                              scheme: scheme,
+                              theme: theme,
+                            ),
+                            ...unchecked.map(
+                              (p) => _ParticipantRow(
+                                key: ValueKey(p.id),
+                                participant: p,
+                                onCheckin: () => _checkin(p),
+                              ),
+                            ),
+                          ],
+                          if (checked.isNotEmpty) ...[
+                            _SectionHeader(
+                              '체크인 완료 (${checked.length}명)',
+                              scheme: scheme,
+                              theme: theme,
+                            ),
+                            ...checked.map(
+                              (p) => _ParticipantRow(
+                                key: ValueKey(p.id),
+                                participant: p,
+                                onCheckin: null,
+                              ),
+                            ),
+                          ],
+                        ],
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Future<void> _checkin(CheckinParticipant participant) async {
+    HapticFeedback.selectionClick();
+    try {
+      final result = await ref
+          .read(manualCheckinControllerProvider(widget.eventId).notifier)
+          .checkin(participant.ticketId);
+
+      if (!mounted) return;
+
+      if (result == 'already_checked_in') {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('${participant.name}님은 이미 체크인되었습니다')),
+        );
+      }
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('체크인 처리 중 오류가 발생했습니다')),
+      );
+    }
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.label, {required this.scheme, required this.theme});
+
+  final String label;
+  final ColorScheme scheme;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(
+        left: MinglitSpacing.screenEdge,
+        right: MinglitSpacing.screenEdge,
+        top: 12,
+        bottom: 4,
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelMedium?.copyWith(
+          color: scheme.onSurfaceVariant,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class _ParticipantRow extends StatelessWidget {
+  const _ParticipantRow({
+    required this.participant,
+    required this.onCheckin,
+    super.key,
+  });
+
+  final CheckinParticipant participant;
+  final VoidCallback? onCheckin;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final initial =
+        participant.name.isNotEmpty ? participant.name[0] : '?';
+
+    return Semantics(
+      label: '${participant.name}, '
+          '전화 뒷자리 ${participant.phoneLast4}, '
+          '${participant.isCheckedIn ? "체크인 완료" : "미체크인"}',
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: MinglitSpacing.screenEdge,
+          vertical: 6,
+        ),
+        child: Row(
+          children: [
+            // 아바타
+            CircleAvatar(
+              radius: 20,
+              backgroundColor: scheme.primary.withValues(alpha: 0.15),
+              child: Text(
+                initial,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: scheme.primary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+
+            // 이름 + 전화 뒷자리
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    participant.name,
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  if (participant.phoneLast4.isNotEmpty)
+                    Text(
+                      '010-****-${participant.phoneLast4}',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: scheme.onSurfaceVariant,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+
+            // 체크인 버튼 또는 완료 표시
+            if (onCheckin != null)
+              SizedBox(
+                height: 44,
+                child: Center(
+                  child: FilledButton(
+                    onPressed: onCheckin,
+                    style: FilledButton.styleFrom(
+                      minimumSize: const Size(72, 36),
+                      padding: const EdgeInsets.symmetric(horizontal: 14),
+                      shape: RoundedRectangleBorder(
+                        borderRadius:
+                            BorderRadius.circular(MinglitRadius.button),
+                      ),
+                    ),
+                    child: const Text('체크인'),
+                  ),
+                ),
+              )
+            else
+              OutlinedButton(
+                onPressed: null,
+                style: OutlinedButton.styleFrom(
+                  minimumSize: const Size(72, 36),
+                  padding: const EdgeInsets.symmetric(horizontal: 14),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(MinglitRadius.button),
+                  ),
+                  foregroundColor: MinglitColors.success,
+                  side: BorderSide(color: MinglitColors.success),
+                ),
+                child: const Text('완료'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/app_partner/lib/src/features/checkin/qr_scanner_screen.dart
+++ b/apps/app_partner/lib/src/features/checkin/qr_scanner_screen.dart
@@ -4,6 +4,7 @@ import 'package:app_partner/src/features/checkin/checkin_controller.dart';
 import 'package:app_partner/src/features/checkin/stats/checkin_stats_controller.dart';
 import 'package:app_partner/src/features/checkin/widgets/checkin_scanner_overlay.dart';
 import 'package:app_partner/src/features/checkin/widgets/checkin_summary_card.dart';
+import 'package:app_partner/src/features/checkin/manual/manual_checkin_sheet.dart';
 import 'package:app_partner/src/features/checkin/widgets/entry_group_bottom_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -135,14 +136,12 @@ class _QRScannerScreenState extends ConsumerState<QRScannerScreen> {
   }
 
   void _showManualCheckinSheet(BuildContext context) {
-    // Phase 4: ManualCheckinSheet
+    // Fix #1812: Phase 4 — ManualCheckinSheet 실제 구현
     showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
-      builder: (_) => const SizedBox(
-        height: 200,
-        child: Center(child: Text('수동 체크인 — Phase 4에서 구현 예정')),
-      ),
+      useSafeArea: true,
+      builder: (_) => ManualCheckinSheet(eventId: widget.event.id),
     );
   }
 }

--- a/apps/app_partner/lib/src/features/checkin/widgets/checkin_scanner_overlay.dart
+++ b/apps/app_partner/lib/src/features/checkin/widgets/checkin_scanner_overlay.dart
@@ -179,7 +179,7 @@ class _CheckinScannerOverlayState extends State<CheckinScannerOverlay>
                   position: _bannerSlide,
                   child: SafeArea(
                     bottom: false,
-                    child: _ScanResultBanner(state: widget.state),
+                    child: CheckinResultBanner(state: widget.state),
                   ),
                 ),
               ),
@@ -239,58 +239,68 @@ class _ScanFab extends StatelessWidget {
   }
 }
 
-class _ScanResultBanner extends StatelessWidget {
-  const _ScanResultBanner({required this.state});
+/// 스캔 결과 배너 위젯.
+///
+/// VoiceOver/TalkBack liveRegion으로 마크업되어 결과 변경 시 자동으로 읽힌다.
+// Fix #1813: A11y — public 추출로 골든 테스트 가능하게 하고 liveRegion Semantics 추가
+class CheckinResultBanner extends StatelessWidget {
+  const CheckinResultBanner({required this.state, super.key});
   final CheckinState state;
 
   @override
   Widget build(BuildContext context) {
     final (color, icon, title, subtitle) = _bannerContent(state);
+    final semanticLabel = subtitle.isNotEmpty ? '$title. $subtitle' : title;
 
-    return Container(
-      margin: const EdgeInsets.symmetric(horizontal: MinglitSpacing.screenEdge),
-      padding: const EdgeInsets.symmetric(
-        horizontal: MinglitSpacing.medium,
-        vertical: MinglitSpacing.sm,
-      ),
-      decoration: BoxDecoration(
-        color: color,
-        borderRadius: BorderRadius.circular(MinglitRadius.card),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.2),
-            blurRadius: 8,
-            offset: const Offset(0, 2),
-          ),
-        ],
-      ),
-      child: Row(
-        children: [
-          Icon(icon, color: Colors.white, size: 24),
-          const SizedBox(width: MinglitSpacing.sm),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  title,
-                  style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                    color: Colors.white,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-                if (subtitle.isNotEmpty)
+    return Semantics(
+      liveRegion: true,
+      label: semanticLabel.isEmpty ? null : semanticLabel,
+      child: Container(
+        margin:
+            const EdgeInsets.symmetric(horizontal: MinglitSpacing.screenEdge),
+        padding: const EdgeInsets.symmetric(
+          horizontal: MinglitSpacing.medium,
+          vertical: MinglitSpacing.sm,
+        ),
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: BorderRadius.circular(MinglitRadius.card),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.2),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Row(
+          children: [
+            Icon(icon, color: Colors.white, size: 24),
+            const SizedBox(width: MinglitSpacing.sm),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
                   Text(
-                    subtitle,
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    title,
+                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                       color: Colors.white,
+                      fontWeight: FontWeight.w700,
                     ),
                   ),
-              ],
+                  if (subtitle.isNotEmpty)
+                    Text(
+                      subtitle,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Colors.white,
+                      ),
+                    ),
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/apps/app_partner/test/alchemist/qr_checkin_golden_test.dart
+++ b/apps/app_partner/test/alchemist/qr_checkin_golden_test.dart
@@ -1,0 +1,22 @@
+@Tags(['golden'])
+library;
+
+import 'package:alchemist/alchemist.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../utils/golden_test_helpers.dart';
+import 'scenarios/qr_checkin_scenarios.dart';
+
+void main() {
+  for (final scenario in QrCheckinScenarios.all) {
+    // ignore: discarded_futures
+    goldenTest(
+      scenario.name,
+      fileName: scenario.name,
+      builder: () => GoldenTestGroup(
+        columnWidthBuilder: (_) => const FixedColumnWidth(420),
+        children: [scenario.toGoldenTestScenario()],
+      ),
+    );
+  }
+}

--- a/apps/app_partner/test/alchemist/scenarios/qr_checkin_scenarios.dart
+++ b/apps/app_partner/test/alchemist/scenarios/qr_checkin_scenarios.dart
@@ -1,0 +1,311 @@
+import 'package:app_partner/src/features/checkin/checkin_controller.dart';
+import 'package:app_partner/src/features/checkin/manual/checkin_participant.dart';
+import 'package:app_partner/src/features/checkin/manual/manual_checkin_controller.dart';
+import 'package:app_partner/src/features/checkin/manual/manual_checkin_sheet.dart';
+import 'package:app_partner/src/features/checkin/stats/entry_group_checkin_stats_controller.dart';
+import 'package:app_partner/src/features/checkin/widgets/checkin_scanner_overlay.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import 'partner_screenshot_scenario.dart';
+
+// ---------------------------------------------------------------------------
+// Fake controllers for golden snapshots
+// ---------------------------------------------------------------------------
+
+class _FakeManualCheckinController extends ManualCheckinController {
+  _FakeManualCheckinController(this._participants);
+  final List<CheckinParticipant> _participants;
+
+  @override
+  Future<List<CheckinParticipant>> build(String eventId) async => _participants;
+
+  @override
+  Future<String> checkin(String ticketId) async => 'success';
+}
+
+class _ErrorManualCheckinController extends ManualCheckinController {
+  @override
+  Future<List<CheckinParticipant>> build(String eventId) async {
+    throw Exception('네트워크 연결을 확인해주세요');
+  }
+
+  @override
+  Future<String> checkin(String ticketId) async => 'error';
+}
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const _kEventId = 'golden-event';
+
+const _participantA = CheckinParticipant(
+  id: 'ep-1',
+  ticketId: 'tk-1',
+  name: '김민지',
+  phoneLast4: '1234',
+  status: 'ticket_issued',
+);
+
+const _participantB = CheckinParticipant(
+  id: 'ep-2',
+  ticketId: 'tk-2',
+  name: '박재훈',
+  phoneLast4: '5678',
+  status: 'checked_in',
+);
+
+final _groupLow = EntryGroupCheckinStats(
+  id: 'g-1',
+  label: 'A구역',
+  total: 100,
+  checkedIn: 30,
+);
+
+final _groupHigh = EntryGroupCheckinStats(
+  id: 'g-2',
+  label: 'B구역',
+  total: 100,
+  checkedIn: 95,
+);
+
+final _groupMid = EntryGroupCheckinStats(
+  id: 'g-3',
+  label: 'C구역',
+  total: 80,
+  checkedIn: 55,
+);
+
+// ---------------------------------------------------------------------------
+// Wrapper widgets
+// ---------------------------------------------------------------------------
+
+/// 체크인 결과 배너 — 고정 너비 카드로 골든 렌더.
+class _BannerCard extends StatelessWidget {
+  const _BannerCard({required this.state, required this.brightness});
+  final CheckinState state;
+  final Brightness brightness;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      theme: brightness == Brightness.dark
+          ? MinglitTheme.materialThemeDark
+          : MinglitTheme.materialTheme,
+      home: Scaffold(
+        backgroundColor: brightness == Brightness.dark
+            ? Colors.black
+            : const Color(0xFF1A1A1A),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: CheckinResultBanner(state: state),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 엔트리 그룹 행 목록 — 고정 카드로 골든 렌더.
+class _GroupListCard extends StatelessWidget {
+  const _GroupListCard({
+    required this.groups,
+    required this.brightness,
+  });
+  final List<EntryGroupCheckinStats> groups;
+  final Brightness brightness;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = brightness == Brightness.dark
+        ? MinglitTheme.materialThemeDark
+        : MinglitTheme.materialTheme;
+
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      theme: theme,
+      home: Scaffold(
+        body: Padding(
+          padding: const EdgeInsets.all(MinglitSpacing.screenEdge),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              for (int i = 0; i < groups.length; i++)
+                Semantics(
+                  label: '${groups[i].label}, ${groups[i].checkedIn}명 체크인, '
+                      '총 ${groups[i].total}명 중, '
+                      '${(groups[i].ratio * 100).toStringAsFixed(0)}퍼센트',
+                  child: EntryGroupRow(
+                    stats: groups[i],
+                    showDivider: i < groups.length - 1,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// ManualCheckinSheet 골든 래퍼 — ProviderScope 포함.
+class _ManualSheetGolden extends StatelessWidget {
+  const _ManualSheetGolden({
+    required this.controller,
+    required this.brightness,
+  });
+  final ManualCheckinController Function() controller;
+  final Brightness brightness;
+
+  @override
+  Widget build(BuildContext context) {
+    return ProviderScope(
+      overrides: [
+        manualCheckinControllerProvider(_kEventId).overrideWith(controller),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
+        home: Scaffold(
+          body: ManualCheckinSheet(eventId: _kEventId),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario definitions
+// ---------------------------------------------------------------------------
+
+class QrCheckinScenarios {
+  static List<PartnerScreenshotScenario> get all => [
+    // 1. 스캔 성공 배너 (light / dark)
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_success_banner',
+      page: _BannerCard(
+        state: const CheckinState(
+          result: CheckinResult.success,
+          userName: '홍길동',
+        ),
+        brightness: Brightness.light,
+      ),
+      isComponent: true,
+    ),
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_success_banner_dark',
+      page: _BannerCard(
+        state: const CheckinState(
+          result: CheckinResult.success,
+          userName: '홍길동',
+        ),
+        brightness: Brightness.dark,
+      ),
+      isComponent: true,
+    ),
+
+    // 2. 스캔 오류 배너 (light / dark)
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_error_banner',
+      page: _BannerCard(
+        state: const CheckinState(
+          result: CheckinResult.invalid,
+          message: '유효하지 않은 티켓입니다.',
+        ),
+        brightness: Brightness.light,
+      ),
+      isComponent: true,
+    ),
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_error_banner_dark',
+      page: _BannerCard(
+        state: const CheckinState(
+          result: CheckinResult.invalid,
+          message: '유효하지 않은 티켓입니다.',
+        ),
+        brightness: Brightness.dark,
+      ),
+      isComponent: true,
+    ),
+
+    // 3. 엔트리 그룹 확장 (light / dark)
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_group',
+      page: _GroupListCard(
+        groups: [_groupHigh, _groupMid, _groupLow],
+        brightness: Brightness.light,
+      ),
+      isComponent: true,
+    ),
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_group_dark',
+      page: _GroupListCard(
+        groups: [_groupHigh, _groupMid, _groupLow],
+        brightness: Brightness.dark,
+      ),
+      isComponent: true,
+    ),
+
+    // 4. 수동 체크인 — 참가자 있음 (light / dark)
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_manual_data',
+      page: _ManualSheetGolden(
+        controller: () =>
+            _FakeManualCheckinController([_participantA, _participantB]),
+        brightness: Brightness.light,
+      ),
+      isComponent: true,
+    ),
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_manual_data_dark',
+      page: _ManualSheetGolden(
+        controller: () =>
+            _FakeManualCheckinController([_participantA, _participantB]),
+        brightness: Brightness.dark,
+      ),
+      isComponent: true,
+    ),
+
+    // 5. 수동 체크인 — 빈 상태 (light / dark)
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_manual_empty',
+      page: _ManualSheetGolden(
+        controller: () => _FakeManualCheckinController([]),
+        brightness: Brightness.light,
+      ),
+      isComponent: true,
+    ),
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_manual_empty_dark',
+      page: _ManualSheetGolden(
+        controller: () => _FakeManualCheckinController([]),
+        brightness: Brightness.dark,
+      ),
+      isComponent: true,
+    ),
+
+    // 6. 수동 체크인 — 오프라인/오류 (light / dark)
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_manual_offline',
+      page: _ManualSheetGolden(
+        controller: _ErrorManualCheckinController.new,
+        brightness: Brightness.light,
+      ),
+      isComponent: true,
+    ),
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_manual_offline_dark',
+      page: _ManualSheetGolden(
+        controller: _ErrorManualCheckinController.new,
+        brightness: Brightness.dark,
+      ),
+      isComponent: true,
+    ),
+  ];
+}

--- a/apps/app_partner/test/src/features/checkin/manual/checkin_participant_test.dart
+++ b/apps/app_partner/test/src/features/checkin/manual/checkin_participant_test.dart
@@ -1,0 +1,66 @@
+import 'package:app_partner/src/features/checkin/manual/checkin_participant.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('CheckinParticipant', () {
+    test('fromJson — ticket_issued 상태', () {
+      final p = CheckinParticipant.fromJson({
+        'id': 'ep-1',
+        'ticket_id': 'tk-1',
+        'name': '김민지',
+        'phone_last4': '1234',
+        'status': 'ticket_issued',
+        'checked_in_at': null,
+      });
+
+      expect(p.id, 'ep-1');
+      expect(p.name, '김민지');
+      expect(p.phoneLast4, '1234');
+      expect(p.isCheckedIn, isFalse);
+      expect(p.checkedInAt, isNull);
+    });
+
+    test('fromJson — checked_in 상태 + 시각', () {
+      final p = CheckinParticipant.fromJson({
+        'id': 'ep-2',
+        'ticket_id': 'tk-2',
+        'name': '박재훈',
+        'phone_last4': '5678',
+        'status': 'checked_in',
+        'checked_in_at': '2026-04-24T10:30:00.000Z',
+      });
+
+      expect(p.isCheckedIn, isTrue);
+      expect(p.checkedInAt, isNotNull);
+      expect(p.checkedInAt!.year, 2026);
+    });
+
+    test('fromJson — phone_last4 null 허용', () {
+      final p = CheckinParticipant.fromJson({
+        'id': 'ep-3',
+        'ticket_id': 'tk-3',
+        'name': '이름 없음',
+        'phone_last4': null,
+        'status': 'ticket_issued',
+        'checked_in_at': null,
+      });
+
+      expect(p.phoneLast4, '');
+    });
+
+    test('copyWith — status 업데이트', () {
+      const original = CheckinParticipant(
+        id: 'ep-1',
+        ticketId: 'tk-1',
+        name: '홍길동',
+        phoneLast4: '0001',
+        status: 'ticket_issued',
+      );
+
+      final updated = original.copyWith(status: 'checked_in');
+      expect(updated.status, 'checked_in');
+      expect(updated.id, original.id);
+      expect(updated.name, original.name);
+    });
+  });
+}

--- a/apps/app_partner/test/src/features/checkin/manual/manual_checkin_controller_test.dart
+++ b/apps/app_partner/test/src/features/checkin/manual/manual_checkin_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:app_partner/src/features/checkin/manual/checkin_participant.dart';
 import 'package:app_partner/src/features/checkin/manual/manual_checkin_controller.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -7,6 +9,23 @@ import 'package:mocktail/mocktail.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 class _MockSupabaseClient extends Mock implements SupabaseClient {}
+
+/// PostgrestFilterBuilder를 구현하는 fake. rpc() 스텁 반환값으로 사용.
+class _FakeRpcBuilder<T> implements PostgrestFilterBuilder<T> {
+  _FakeRpcBuilder(this._data);
+  final T _data;
+
+  @override
+  Future<U> then<U>(
+    FutureOr<U> Function(T) onValue, {
+    Function? onError,
+  }) {
+    return Future<T>.value(_data).then(onValue, onError: onError);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => this;
+}
 
 void main() {
   late _MockSupabaseClient mockClient;
@@ -18,19 +37,19 @@ void main() {
   void stubFetch(List<dynamic> response) {
     when(
       () => mockClient.rpc<dynamic>(
-            'get_event_participants_for_checkin',
-            params: any(named: 'params'),
-          ) as Future<dynamic>,
-    ).thenAnswer((_) async => response);
+        'get_event_participants_for_checkin',
+        params: any(named: 'params'),
+      ),
+    ).thenAnswer((_) => _FakeRpcBuilder<dynamic>(response));
   }
 
   void stubCheckin(String result) {
     when(
       () => mockClient.rpc<dynamic>(
-            'process_manual_checkin',
-            params: any(named: 'params'),
-          ) as Future<dynamic>,
-    ).thenAnswer((_) async => result);
+        'process_manual_checkin',
+        params: any(named: 'params'),
+      ),
+    ).thenAnswer((_) => _FakeRpcBuilder<dynamic>(result));
   }
 
   ProviderContainer makeContainer() {
@@ -114,6 +133,35 @@ void main() {
       final updated = container.read(manualCheckinControllerProvider('event-1'));
       final participant = updated.value!.first;
       expect(participant.isCheckedIn, isTrue);
+    });
+
+    test('checkin — not_found: optimistic 업데이트 롤백', () async {
+      stubFetch([
+        {
+          'id': 'ep-1',
+          'ticket_id': 'tk-1',
+          'name': '김민지',
+          'phone_last4': '1234',
+          'status': 'ticket_issued',
+          'checked_in_at': null,
+        },
+      ]);
+      stubCheckin('not_found');
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      await container.read(manualCheckinControllerProvider('event-1').future);
+
+      final result = await container
+          .read(manualCheckinControllerProvider('event-1').notifier)
+          .checkin('tk-1');
+
+      expect(result, 'not_found');
+
+      // Fix #1812: not_found이면 티켓이 존재하지 않으므로 optimistic 상태를 이전으로 복구
+      final state = container.read(manualCheckinControllerProvider('event-1'));
+      expect(state.value!.first.isCheckedIn, isFalse);
     });
 
     test('checkin — already_checked_in: optimistic 상태 유지 (서버도 checked_in)', () async {

--- a/apps/app_partner/test/src/features/checkin/manual/manual_checkin_controller_test.dart
+++ b/apps/app_partner/test/src/features/checkin/manual/manual_checkin_controller_test.dart
@@ -1,0 +1,148 @@
+import 'package:app_partner/src/features/checkin/manual/checkin_participant.dart';
+import 'package:app_partner/src/features/checkin/manual/manual_checkin_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/logic/providers/supabase_provider.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class _MockSupabaseClient extends Mock implements SupabaseClient {}
+
+void main() {
+  late _MockSupabaseClient mockClient;
+
+  setUp(() {
+    mockClient = _MockSupabaseClient();
+  });
+
+  void stubFetch(List<dynamic> response) {
+    when(
+      () => mockClient.rpc<dynamic>(
+            'get_event_participants_for_checkin',
+            params: any(named: 'params'),
+          ) as Future<dynamic>,
+    ).thenAnswer((_) async => response);
+  }
+
+  void stubCheckin(String result) {
+    when(
+      () => mockClient.rpc<dynamic>(
+            'process_manual_checkin',
+            params: any(named: 'params'),
+          ) as Future<dynamic>,
+    ).thenAnswer((_) async => result);
+  }
+
+  ProviderContainer makeContainer() {
+    return ProviderContainer(
+      overrides: [supabaseClientProvider.overrideWithValue(mockClient)],
+    );
+  }
+
+  group('ManualCheckinController', () {
+    test('RPC 호출 후 참가자 목록 파싱', () async {
+      stubFetch([
+        {
+          'id': 'ep-1',
+          'ticket_id': 'tk-1',
+          'name': '김민지',
+          'phone_last4': '1234',
+          'status': 'ticket_issued',
+          'checked_in_at': null,
+        },
+        {
+          'id': 'ep-2',
+          'ticket_id': 'tk-2',
+          'name': '박재훈',
+          'phone_last4': '5678',
+          'status': 'checked_in',
+          'checked_in_at': '2026-04-24T09:00:00Z',
+        },
+      ]);
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      final participants = await container.read(
+        manualCheckinControllerProvider('event-1').future,
+      );
+
+      expect(participants, hasLength(2));
+      expect(participants[0].name, '김민지');
+      expect(participants[0].isCheckedIn, isFalse);
+      expect(participants[1].name, '박재훈');
+      expect(participants[1].isCheckedIn, isTrue);
+    });
+
+    test('빈 참가자 목록', () async {
+      stubFetch([]);
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      final participants = await container.read(
+        manualCheckinControllerProvider('event-empty').future,
+      );
+
+      expect(participants, isEmpty);
+    });
+
+    test('checkin — success: optimistic 업데이트 후 유지', () async {
+      stubFetch([
+        {
+          'id': 'ep-1',
+          'ticket_id': 'tk-1',
+          'name': '김민지',
+          'phone_last4': '1234',
+          'status': 'ticket_issued',
+          'checked_in_at': null,
+        },
+      ]);
+      stubCheckin('success');
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      await container.read(manualCheckinControllerProvider('event-1').future);
+
+      final result = await container
+          .read(manualCheckinControllerProvider('event-1').notifier)
+          .checkin('tk-1');
+
+      expect(result, 'success');
+
+      final updated = container.read(manualCheckinControllerProvider('event-1'));
+      final participant = updated.value!.first;
+      expect(participant.isCheckedIn, isTrue);
+    });
+
+    test('checkin — already_checked_in: 상태 복구', () async {
+      stubFetch([
+        {
+          'id': 'ep-1',
+          'ticket_id': 'tk-1',
+          'name': '김민지',
+          'phone_last4': '1234',
+          'status': 'ticket_issued',
+          'checked_in_at': null,
+        },
+      ]);
+      stubCheckin('already_checked_in');
+
+      final container = makeContainer();
+      addTearDown(container.dispose);
+
+      await container.read(manualCheckinControllerProvider('event-1').future);
+
+      final result = await container
+          .read(manualCheckinControllerProvider('event-1').notifier)
+          .checkin('tk-1');
+
+      expect(result, 'already_checked_in');
+
+      // 실패 시 원래 상태로 복구
+      final state = container.read(manualCheckinControllerProvider('event-1'));
+      expect(state.value!.first.isCheckedIn, isFalse);
+    });
+  });
+}

--- a/apps/app_partner/test/src/features/checkin/manual/manual_checkin_controller_test.dart
+++ b/apps/app_partner/test/src/features/checkin/manual/manual_checkin_controller_test.dart
@@ -116,7 +116,7 @@ void main() {
       expect(participant.isCheckedIn, isTrue);
     });
 
-    test('checkin — already_checked_in: 상태 복구', () async {
+    test('checkin — already_checked_in: optimistic 상태 유지 (서버도 checked_in)', () async {
       stubFetch([
         {
           'id': 'ep-1',
@@ -140,9 +140,10 @@ void main() {
 
       expect(result, 'already_checked_in');
 
-      // 실패 시 원래 상태로 복구
+      // Fix #1812: already_checked_in은 서버 실제 상태도 checked_in이므로
+      // optimistic 상태(checked_in)를 유지해야 한다.
       final state = container.read(manualCheckinControllerProvider('event-1'));
-      expect(state.value!.first.isCheckedIn, isFalse);
+      expect(state.value!.first.isCheckedIn, isTrue);
     });
   });
 }

--- a/apps/app_partner/test/src/features/checkin/manual/manual_checkin_sheet_test.dart
+++ b/apps/app_partner/test/src/features/checkin/manual/manual_checkin_sheet_test.dart
@@ -1,0 +1,153 @@
+import 'package:app_partner/src/features/checkin/manual/checkin_participant.dart';
+import 'package:app_partner/src/features/checkin/manual/manual_checkin_controller.dart';
+import 'package:app_partner/src/features/checkin/manual/manual_checkin_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _DataController extends ManualCheckinController {
+  _DataController(this._participants, {this.checkinResult = 'success'});
+  final List<CheckinParticipant> _participants;
+  final String checkinResult;
+
+  @override
+  Future<List<CheckinParticipant>> build(String eventId) async => _participants;
+
+  @override
+  Future<String> checkin(String ticketId) async {
+    if (checkinResult == 'success') {
+      state = state.whenData(
+        (list) => list.map((p) {
+          if (p.ticketId != ticketId) return p;
+          return p.copyWith(status: 'checked_in');
+        }).toList(),
+      );
+    }
+    return checkinResult;
+  }
+}
+
+Widget _wrapSheet({
+  required String eventId,
+  required List<CheckinParticipant> participants,
+  String checkinResult = 'success',
+}) {
+  return ProviderScope(
+    overrides: [
+      manualCheckinControllerProvider(eventId).overrideWith(
+        () => _DataController(participants, checkinResult: checkinResult),
+      ),
+    ],
+    child: MaterialApp(
+      home: Scaffold(
+        body: ManualCheckinSheet(eventId: eventId),
+      ),
+    ),
+  );
+}
+
+const _participantA = CheckinParticipant(
+  id: 'ep-1',
+  ticketId: 'tk-1',
+  name: '김민지',
+  phoneLast4: '1234',
+  status: 'ticket_issued',
+);
+
+const _participantB = CheckinParticipant(
+  id: 'ep-2',
+  ticketId: 'tk-2',
+  name: '박재훈',
+  phoneLast4: '5678',
+  status: 'checked_in',
+);
+
+void main() {
+  group('ManualCheckinSheet', () {
+    testWidgets('참가자 있음 — 섹션 헤더 표시', (tester) async {
+      await tester.pumpWidget(
+        _wrapSheet(
+          eventId: 'event-1',
+          participants: [_participantA, _participantB],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('미체크인 (1명)'), findsOneWidget);
+      expect(find.text('체크인 완료 (1명)'), findsOneWidget);
+    });
+
+    testWidgets('빈 참가자 — "참가자가 없습니다" 표시', (tester) async {
+      await tester.pumpWidget(
+        _wrapSheet(eventId: 'event-empty', participants: []),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('참가자가 없습니다'), findsOneWidget);
+    });
+
+    testWidgets('이름 검색 — "박" 입력 시 박재훈만 표시', (tester) async {
+      await tester.pumpWidget(
+        _wrapSheet(
+          eventId: 'event-1',
+          participants: [_participantA, _participantB],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '박');
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pumpAndSettle();
+
+      expect(find.text('박재훈'), findsOneWidget);
+      expect(find.text('김민지'), findsNothing);
+    });
+
+    testWidgets('전화 뒷자리 검색 — "1234" 입력 시 김민지만 표시', (tester) async {
+      await tester.pumpWidget(
+        _wrapSheet(
+          eventId: 'event-1',
+          participants: [_participantA, _participantB],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '1234');
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pumpAndSettle();
+
+      expect(find.text('김민지'), findsOneWidget);
+      expect(find.text('박재훈'), findsNothing);
+    });
+
+    testWidgets('체크인 버튼 탭 — 미체크인 참가자 이동', (tester) async {
+      await tester.pumpWidget(
+        _wrapSheet(
+          eventId: 'event-1',
+          participants: [_participantA],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('미체크인 (1명)'), findsOneWidget);
+      await tester.tap(find.text('체크인'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('미체크인 (0명)'), findsNothing);
+      expect(find.text('체크인 완료 (1명)'), findsOneWidget);
+    });
+
+    testWidgets('완료 버튼은 비활성화 — onPressed null', (tester) async {
+      await tester.pumpWidget(
+        _wrapSheet(
+          eventId: 'event-1',
+          participants: [_participantB],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final btn = tester.widget<OutlinedButton>(find.byType(OutlinedButton));
+      expect(btn.onPressed, isNull);
+    });
+  });
+}

--- a/supabase/migrations/20260424000006_manual_checkin_rpcs.sql
+++ b/supabase/migrations/20260424000006_manual_checkin_rpcs.sql
@@ -120,6 +120,11 @@ BEGIN
     RETURN 'already_checked_in';
   END IF;
 
+  -- 4b. ticket_issued 상태만 체크인 허용 (no_show 등 비정상 상태 차단)
+  IF v_current_status != 'ticket_issued' THEN
+    RETURN 'not_found';
+  END IF;
+
   -- 5. 체크인 처리
   UPDATE public.event_participants
      SET status = 'checked_in',

--- a/supabase/migrations/20260424000006_manual_checkin_rpcs.sql
+++ b/supabase/migrations/20260424000006_manual_checkin_rpcs.sql
@@ -40,6 +40,7 @@ BEGIN
   END IF;
 
   -- 3. 참가자 목록 조회 (미체크인 → 완료 순, 이름 오름차순)
+  --    ticket_issued / checked_in 상태만 포함. no_show 등 비정상 상태는 UI에서 dead-end를 유발하므로 제외.
   SELECT COALESCE(
     jsonb_agg(
       jsonb_build_object(
@@ -59,7 +60,8 @@ BEGIN
     INTO v_result
     FROM public.event_participants ep
     JOIN public.user_profiles up ON up.id = ep.user_id
-   WHERE ep.event_id = p_event_id;
+   WHERE ep.event_id = p_event_id
+     AND ep.status IN ('ticket_issued', 'checked_in');
 
   RETURN v_result;
 END;
@@ -84,17 +86,23 @@ SECURITY DEFINER
 SET search_path = public
 AS $$
 DECLARE
-  v_partner_id    uuid;
+  v_partner_id     uuid;
+  v_event_status   text;
   v_current_status text;
 BEGIN
-  -- 1. 이벤트 → 파트너 조회
-  SELECT pa.partner_id
-    INTO v_partner_id
+  -- 1. 이벤트 → 파트너 조회 (이벤트 상태도 함께)
+  SELECT pa.partner_id, e.status
+    INTO v_partner_id, v_event_status
     FROM public.events e
     JOIN public.parties pa ON pa.id = e.party_id
    WHERE e.id = p_event_id;
 
   IF v_partner_id IS NULL THEN
+    RETURN 'not_found';
+  END IF;
+
+  -- 1b. 이벤트 상태 게이트 — cancelled/completed 이벤트는 체크인 불가
+  IF v_event_status IN ('cancelled', 'completed') THEN
     RETURN 'not_found';
   END IF;
 

--- a/supabase/migrations/20260424000006_manual_checkin_rpcs.sql
+++ b/supabase/migrations/20260424000006_manual_checkin_rpcs.sql
@@ -1,0 +1,135 @@
+-- [QR Checkin] Phase 4 — 수동 체크인 RPC
+-- Issue #1812
+--
+-- 1. get_event_participants_for_checkin: 이벤트 참가자 목록 + 체크인 현황 반환
+-- 2. process_manual_checkin: 수동 체크인 원자적 처리 (QR 서명 검증 없음)
+--    PARTY_MANAGE 권한 있는 파트너 스태프만 호출 가능
+
+-- ============================================================
+-- 1. get_event_participants_for_checkin
+--    반환: [{ "id": uuid, "ticket_id": uuid, "name": text,
+--             "phone_last4": text, "status": text, "checked_in_at": timestamp? }]
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_event_participants_for_checkin(
+  p_event_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_partner_id uuid;
+  v_result     jsonb;
+BEGIN
+  -- 1. 이벤트 → 파트너 조회
+  SELECT pa.partner_id
+    INTO v_partner_id
+    FROM public.events e
+    JOIN public.parties pa ON pa.id = e.party_id
+   WHERE e.id = p_event_id;
+
+  IF v_partner_id IS NULL THEN
+    RAISE EXCEPTION 'event not found';
+  END IF;
+
+  -- 2. PARTY_MANAGE 권한 확인
+  IF NOT public.has_partner_permission(v_partner_id, 'PARTY_MANAGE') THEN
+    RAISE EXCEPTION 'permission denied: PARTY_MANAGE required';
+  END IF;
+
+  -- 3. 참가자 목록 조회 (미체크인 → 완료 순, 이름 오름차순)
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'id',           ep.id::text,
+        'ticket_id',    ep.ticket_id::text,
+        'name',         COALESCE(ep.display_name, up.name, '이름 없음'),
+        'phone_last4',  RIGHT(up.phone_number, 4),
+        'status',       ep.status,
+        'checked_in_at', ep.checked_in_at
+      )
+      ORDER BY
+        (ep.status = 'checked_in') ASC,   -- 미체크인 먼저
+        COALESCE(ep.display_name, up.name)
+    ),
+    '[]'::jsonb
+  )
+    INTO v_result
+    FROM public.event_participants ep
+    JOIN public.user_profiles up ON up.id = ep.user_id
+   WHERE ep.event_id = p_event_id;
+
+  RETURN v_result;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_event_participants_for_checkin(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_event_participants_for_checkin(uuid) TO authenticated;
+
+-- ============================================================
+-- 2. process_manual_checkin
+--    반환값: 'success' | 'already_checked_in' | 'not_found'
+--    QR 서명 검증 없이 티켓 ID만으로 체크인 처리.
+--    PARTY_MANAGE 권한 게이트로 무단 체크인 방지.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.process_manual_checkin(
+  p_ticket_id uuid,
+  p_event_id  uuid
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_partner_id    uuid;
+  v_current_status text;
+BEGIN
+  -- 1. 이벤트 → 파트너 조회
+  SELECT pa.partner_id
+    INTO v_partner_id
+    FROM public.events e
+    JOIN public.parties pa ON pa.id = e.party_id
+   WHERE e.id = p_event_id;
+
+  IF v_partner_id IS NULL THEN
+    RETURN 'not_found';
+  END IF;
+
+  -- 2. PARTY_MANAGE 권한 확인
+  IF NOT public.has_partner_permission(v_partner_id, 'PARTY_MANAGE') THEN
+    RAISE EXCEPTION 'permission denied: PARTY_MANAGE required';
+  END IF;
+
+  -- 3. 티켓 레코드 조회 (비관적 잠금)
+  SELECT status
+    INTO v_current_status
+    FROM public.event_participants
+   WHERE ticket_id = p_ticket_id
+     AND event_id  = p_event_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN 'not_found';
+  END IF;
+
+  -- 4. 이미 체크인된 경우
+  IF v_current_status = 'checked_in' THEN
+    RETURN 'already_checked_in';
+  END IF;
+
+  -- 5. 체크인 처리
+  UPDATE public.event_participants
+     SET status = 'checked_in',
+         checked_in_at = now()
+   WHERE ticket_id = p_ticket_id
+     AND event_id  = p_event_id;
+
+  RETURN 'success';
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.process_manual_checkin(uuid, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.process_manual_checkin(uuid, uuid) TO authenticated;

--- a/supabase/tests/database/99_manual_checkin_rpcs_test.sql
+++ b/supabase/tests/database/99_manual_checkin_rpcs_test.sql
@@ -1,5 +1,5 @@
 BEGIN;
-SELECT plan(10);
+SELECT plan(11);
 
 -- ============================================================
 -- Setup: service role로 파트너/이벤트/티켓/참가자 데이터 구성
@@ -15,12 +15,14 @@ SELECT tests.create_supabase_user('mc_user_c');
 
 DO $$
 DECLARE
-  v_partner_id  uuid;
-  v_party_id    uuid;
-  v_event_id    uuid;
-  v_ticket_id   uuid;
-  v_ticket_b_id uuid;
-  v_ticket_c_id uuid;
+  v_partner_id       uuid;
+  v_party_id         uuid;
+  v_event_id         uuid;
+  v_ticket_id        uuid;
+  v_ticket_b_id      uuid;
+  v_ticket_c_id      uuid;
+  v_cancelled_evt_id uuid;
+  v_ticket_d_id      uuid;
 BEGIN
   INSERT INTO public.partners (name) VALUES ('Manual Checkin Test Partner')
   RETURNING id INTO v_partner_id;
@@ -57,10 +59,23 @@ BEGIN
   INSERT INTO public.event_participants (event_id, ticket_id, user_id, status, ticket_code, display_name)
   VALUES (v_event_id, v_ticket_c_id, tests.get_supabase_uid('mc_user_c'), 'no_show', 'MC0003', 'User C');
 
-  PERFORM set_config('tests.mc_event_id',    v_event_id::text,    true);
-  PERFORM set_config('tests.mc_ticket_id',   v_ticket_id::text,   true);
-  PERFORM set_config('tests.mc_ticket_b_id', v_ticket_b_id::text, true);
-  PERFORM set_config('tests.mc_ticket_c_id', v_ticket_c_id::text, true);
+  -- cancelled 이벤트 (이벤트 상태 게이트 테스트용)
+  INSERT INTO public.events (party_id, start_time, end_time, min_confirmed_count, max_participants, status)
+  VALUES (v_party_id, now() - interval '3 hours', now() - interval '1 hour', 0, 20, 'cancelled')
+  RETURNING id INTO v_cancelled_evt_id;
+
+  INSERT INTO public.tickets (event_id, name, quantity, price)
+  VALUES (v_cancelled_evt_id, 'Ticket D', 10, 0) RETURNING id INTO v_ticket_d_id;
+
+  INSERT INTO public.event_participants (event_id, ticket_id, user_id, status, ticket_code, display_name)
+  VALUES (v_cancelled_evt_id, v_ticket_d_id, tests.get_supabase_uid('mc_user_a'), 'ticket_issued', 'MC0004', 'User A Cancelled');
+
+  PERFORM set_config('tests.mc_event_id',         v_event_id::text,         true);
+  PERFORM set_config('tests.mc_ticket_id',         v_ticket_id::text,        true);
+  PERFORM set_config('tests.mc_ticket_b_id',       v_ticket_b_id::text,      true);
+  PERFORM set_config('tests.mc_ticket_c_id',       v_ticket_c_id::text,      true);
+  PERFORM set_config('tests.mc_cancelled_evt_id',  v_cancelled_evt_id::text, true);
+  PERFORM set_config('tests.mc_ticket_d_id',       v_ticket_d_id::text,      true);
 END $$;
 
 -- ============================================================
@@ -91,7 +106,7 @@ SELECT throws_like(
 );
 
 -- ============================================================
--- Test 3: 정상 조회 — 참가자 수 일치
+-- Test 3: 정상 조회 — ticket_issued + checked_in만 반환 (no_show 제외)
 -- ============================================================
 
 SELECT is(
@@ -101,7 +116,7 @@ SELECT is(
     )
   )),
   2,
-  'get_event_participants_for_checkin: 참가자 2명 반환'
+  'get_event_participants_for_checkin: 참가자 2명 반환 (no_show 제외)'
 );
 
 -- ============================================================
@@ -196,6 +211,19 @@ SELECT is(
   ),
   'not_found',
   'process_manual_checkin: no_show 참가자 → not_found (상태 전이 차단)'
+);
+
+-- ============================================================
+-- Test 11: cancelled 이벤트 → not_found (이벤트 상태 게이트)
+-- ============================================================
+
+SELECT is(
+  public.process_manual_checkin(
+    current_setting('tests.mc_ticket_d_id')::uuid,
+    current_setting('tests.mc_cancelled_evt_id')::uuid
+  ),
+  'not_found',
+  'process_manual_checkin: cancelled 이벤트 → not_found (이벤트 상태 게이트)'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/database/99_manual_checkin_rpcs_test.sql
+++ b/supabase/tests/database/99_manual_checkin_rpcs_test.sql
@@ -1,5 +1,5 @@
 BEGIN;
-SELECT plan(9);
+SELECT plan(10);
 
 -- ============================================================
 -- Setup: service role로 파트너/이벤트/티켓/참가자 데이터 구성
@@ -11,6 +11,7 @@ SELECT tests.create_supabase_user('mc_staff');
 SELECT tests.create_supabase_user('mc_no_perm');
 SELECT tests.create_supabase_user('mc_user_a');
 SELECT tests.create_supabase_user('mc_user_b');
+SELECT tests.create_supabase_user('mc_user_c');
 
 DO $$
 DECLARE
@@ -19,6 +20,7 @@ DECLARE
   v_event_id    uuid;
   v_ticket_id   uuid;
   v_ticket_b_id uuid;
+  v_ticket_c_id uuid;
 BEGIN
   INSERT INTO public.partners (name) VALUES ('Manual Checkin Test Partner')
   RETURNING id INTO v_partner_id;
@@ -44,13 +46,21 @@ BEGIN
   INSERT INTO public.event_participants (event_id, ticket_id, user_id, status, ticket_code, display_name)
   VALUES (v_event_id, v_ticket_id, tests.get_supabase_uid('mc_user_a'), 'ticket_issued', 'MC0001', 'User A');
 
+  INSERT INTO public.tickets (event_id, name, quantity, price)
+  VALUES (v_event_id, 'Ticket C', 10, 0) RETURNING id INTO v_ticket_c_id;
+
   -- mc_user_b: already checked_in
   INSERT INTO public.event_participants (event_id, ticket_id, user_id, status, ticket_code, display_name, checked_in_at)
   VALUES (v_event_id, v_ticket_b_id, tests.get_supabase_uid('mc_user_b'), 'checked_in', 'MC0002', 'User B', now());
 
+  -- mc_user_c: no_show (체크인 불가 상태)
+  INSERT INTO public.event_participants (event_id, ticket_id, user_id, status, ticket_code, display_name)
+  VALUES (v_event_id, v_ticket_c_id, tests.get_supabase_uid('mc_user_c'), 'no_show', 'MC0003', 'User C');
+
   PERFORM set_config('tests.mc_event_id',    v_event_id::text,    true);
   PERFORM set_config('tests.mc_ticket_id',   v_ticket_id::text,   true);
   PERFORM set_config('tests.mc_ticket_b_id', v_ticket_b_id::text, true);
+  PERFORM set_config('tests.mc_ticket_c_id', v_ticket_c_id::text, true);
 END $$;
 
 -- ============================================================
@@ -173,6 +183,19 @@ SELECT is(
      AND event_id  = current_setting('tests.mc_event_id')::uuid),
   'checked_in',
   'process_manual_checkin: 체크인 후 status = checked_in'
+);
+
+-- ============================================================
+-- Test 10: no_show 참가자 → not_found (ticket_issued 외 상태 차단)
+-- ============================================================
+
+SELECT is(
+  public.process_manual_checkin(
+    current_setting('tests.mc_ticket_c_id')::uuid,
+    current_setting('tests.mc_event_id')::uuid
+  ),
+  'not_found',
+  'process_manual_checkin: no_show 참가자 → not_found (상태 전이 차단)'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/database/99_manual_checkin_rpcs_test.sql
+++ b/supabase/tests/database/99_manual_checkin_rpcs_test.sql
@@ -1,0 +1,179 @@
+BEGIN;
+SELECT plan(9);
+
+-- ============================================================
+-- Setup: service role로 파트너/이벤트/티켓/참가자 데이터 구성
+-- ============================================================
+
+SELECT tests.authenticate_as_service_role();
+
+SELECT tests.create_supabase_user('mc_staff');
+SELECT tests.create_supabase_user('mc_no_perm');
+SELECT tests.create_supabase_user('mc_user_a');
+SELECT tests.create_supabase_user('mc_user_b');
+
+DO $$
+DECLARE
+  v_partner_id  uuid;
+  v_party_id    uuid;
+  v_event_id    uuid;
+  v_ticket_id   uuid;
+  v_ticket_b_id uuid;
+BEGIN
+  INSERT INTO public.partners (name) VALUES ('Manual Checkin Test Partner')
+  RETURNING id INTO v_partner_id;
+
+  INSERT INTO public.partner_member_permissions (partner_id, user_id, role, permissions)
+  VALUES (v_partner_id, tests.get_supabase_uid('mc_staff'), 'staff', ARRAY['PARTY_MANAGE']::text[]);
+
+  INSERT INTO public.parties (partner_id, title, min_confirmed_count, max_participants)
+  VALUES (v_partner_id, 'Manual Checkin Party', 0, 20)
+  RETURNING id INTO v_party_id;
+
+  INSERT INTO public.events (party_id, start_time, end_time, min_confirmed_count, max_participants)
+  VALUES (v_party_id, now() - interval '1 hour', now() + interval '2 hours', 0, 20)
+  RETURNING id INTO v_event_id;
+
+  INSERT INTO public.tickets (event_id, name, quantity, price)
+  VALUES (v_event_id, 'Ticket A', 10, 0) RETURNING id INTO v_ticket_id;
+
+  INSERT INTO public.tickets (event_id, name, quantity, price)
+  VALUES (v_event_id, 'Ticket B', 10, 0) RETURNING id INTO v_ticket_b_id;
+
+  -- mc_user_a: ticket_issued
+  INSERT INTO public.event_participants (event_id, ticket_id, user_id, status, ticket_code, display_name)
+  VALUES (v_event_id, v_ticket_id, tests.get_supabase_uid('mc_user_a'), 'ticket_issued', 'MC0001', 'User A');
+
+  -- mc_user_b: already checked_in
+  INSERT INTO public.event_participants (event_id, ticket_id, user_id, status, ticket_code, display_name, checked_in_at)
+  VALUES (v_event_id, v_ticket_b_id, tests.get_supabase_uid('mc_user_b'), 'checked_in', 'MC0002', 'User B', now());
+
+  PERFORM set_config('tests.mc_event_id',    v_event_id::text,    true);
+  PERFORM set_config('tests.mc_ticket_id',   v_ticket_id::text,   true);
+  PERFORM set_config('tests.mc_ticket_b_id', v_ticket_b_id::text, true);
+END $$;
+
+-- ============================================================
+-- Test 1: PARTY_MANAGE 없는 유저 → get_event_participants_for_checkin permission denied
+-- ============================================================
+
+SELECT tests.authenticate_as('mc_no_perm');
+
+SELECT throws_like(
+  format(
+    $$SELECT public.get_event_participants_for_checkin('%s'::uuid)$$,
+    current_setting('tests.mc_event_id')
+  ),
+  '%permission denied%',
+  'get_event_participants_for_checkin: PARTY_MANAGE 없는 유저 → permission denied'
+);
+
+-- ============================================================
+-- Test 2: 존재하지 않는 event_id → event not found
+-- ============================================================
+
+SELECT tests.authenticate_as('mc_staff');
+
+SELECT throws_like(
+  $$SELECT public.get_event_participants_for_checkin(gen_random_uuid())$$,
+  '%event not found%',
+  'get_event_participants_for_checkin: 존재하지 않는 event_id → event not found'
+);
+
+-- ============================================================
+-- Test 3: 정상 조회 — 참가자 수 일치
+-- ============================================================
+
+SELECT is(
+  (SELECT jsonb_array_length(
+    public.get_event_participants_for_checkin(
+      current_setting('tests.mc_event_id')::uuid
+    )
+  )),
+  2,
+  'get_event_participants_for_checkin: 참가자 2명 반환'
+);
+
+-- ============================================================
+-- Test 4: 미체크인 참가자가 먼저 정렬 (User A = ticket_issued)
+-- ============================================================
+
+SELECT is(
+  (SELECT (elem ->> 'status')
+   FROM jsonb_array_elements(
+     public.get_event_participants_for_checkin(
+       current_setting('tests.mc_event_id')::uuid
+     )
+   ) WITH ORDINALITY AS t(elem, ord)
+   WHERE ord = 1),
+  'ticket_issued',
+  'get_event_participants_for_checkin: 미체크인 참가자가 첫 번째'
+);
+
+-- ============================================================
+-- Test 5: PARTY_MANAGE 없는 유저 → process_manual_checkin permission denied
+-- ============================================================
+
+SELECT tests.authenticate_as('mc_no_perm');
+
+SELECT throws_like(
+  format(
+    $$SELECT public.process_manual_checkin('%s'::uuid, '%s'::uuid)$$,
+    current_setting('tests.mc_ticket_id'),
+    current_setting('tests.mc_event_id')
+  ),
+  '%permission denied%',
+  'process_manual_checkin: PARTY_MANAGE 없는 유저 → permission denied'
+);
+
+-- ============================================================
+-- Test 6: 존재하지 않는 ticket_id → not_found
+-- ============================================================
+
+SELECT tests.authenticate_as('mc_staff');
+
+SELECT is(
+  public.process_manual_checkin(
+    gen_random_uuid(),
+    current_setting('tests.mc_event_id')::uuid
+  ),
+  'not_found',
+  'process_manual_checkin: 존재하지 않는 ticket_id → not_found'
+);
+
+-- ============================================================
+-- Test 7: 이미 checked_in 상태 → already_checked_in
+-- ============================================================
+
+SELECT is(
+  public.process_manual_checkin(
+    current_setting('tests.mc_ticket_b_id')::uuid,
+    current_setting('tests.mc_event_id')::uuid
+  ),
+  'already_checked_in',
+  'process_manual_checkin: 이미 체크인된 참가자 → already_checked_in'
+);
+
+-- ============================================================
+-- Test 8: 정상 체크인 → success + status 변경 확인
+-- ============================================================
+
+SELECT is(
+  public.process_manual_checkin(
+    current_setting('tests.mc_ticket_id')::uuid,
+    current_setting('tests.mc_event_id')::uuid
+  ),
+  'success',
+  'process_manual_checkin: 정상 체크인 → success'
+);
+
+SELECT is(
+  (SELECT status FROM public.event_participants
+   WHERE ticket_id = current_setting('tests.mc_ticket_id')::uuid
+     AND event_id  = current_setting('tests.mc_event_id')::uuid),
+  'checked_in',
+  'process_manual_checkin: 체크인 후 status = checked_in'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1812

## UX 가이드

UI 변경(ManualCheckinSheet 신규 화면) — Phase 4 가이드 준수.

- 설계 문서: [docs/features/partner-qr-checkin-ux/ui-ux-design.md](https://github.com/Mark-Yun/minglit/blob/dev/docs/features/partner-qr-checkin-ux/ui-ux-design.md)
- 이슈: #1812

## 변경 사항

Phase 3(#1811) 기반, 수동 체크인 시트 구현.

### 핵심 컴포넌트

**ManualCheckinSheet** (manual/manual_checkin_sheet.dart)
- showModalBottomSheet로 진입 (QR 화면 우상단 FAB 탭)
- DraggableScrollableSheet: initial 85%, min 50%, max 95%
- 이름/전화 뒷자리 검색 + debounce 150ms
- 섹션 분리: 미체크인 / 체크인 완료
- HapticFeedback.selectionClick() on check-in

**ManualCheckinController** (manual/manual_checkin_controller.dart)
- get_event_participants_for_checkin RPC로 초기 로드
- process_manual_checkin RPC + optimistic 업데이트
- already_checked_in → optimistic 상태 유지 (서버 확인이므로 롤백 안 함)
- not_found / exception → 이전 상태 복구

**CheckinParticipant** (manual/checkin_participant.dart)
- 참가자 모델 (id, ticketId, name, phoneLast4, status, checkedInAt)

**DB 마이그레이션** (20260424000006_manual_checkin_rpcs.sql)
- get_event_participants_for_checkin: 참가자 목록 (PARTY_MANAGE 권한 게이트)
  - ticket_issued / checked_in 상태만 반환 (no_show 등 dead-end 상태 제외)
- process_manual_checkin: 수동 체크인 원자적 처리 (QR 서명 검증 없음)
  - 이벤트 상태 게이트: cancelled/completed 이벤트 체크인 차단
  - ticket_issued 상태만 허용, no_show 등 비정상 상태 차단
- 두 함수 모두 REVOKE FROM PUBLIC + GRANT TO authenticated

### 검색 로직
- 입력이 순수 4자리 숫자 → 전화 뒷자리 매칭
- 아니면 → 이름 contains

## 테스트

- checkin_participant_test.dart: fromJson(각 상태), copyWith
- manual_checkin_controller_test.dart: RPC 파싱, success/already_checked_in 처리, 상태 복구
- manual_checkin_sheet_test.dart: 섹션 헤더, 빈 참가자, 이름/전화 검색, 체크인 버튼 탭, 완료 버튼 비활성
- 99_manual_checkin_rpcs_test.sql (11개): PARTY_MANAGE 권한, 정상 조회, no_show 차단, cancelled 이벤트 게이트

## 의존성

이 PR은 Phase 3 (feat/1811-qr-checkin-phase3) 기반. Phase 1 → Phase 3 순서로 머지 완료 후 base를 dev로 변경하여 머지.