### PR TITLE
feat(#1813): QR Checkin Phase 5 — A11y & Dark Mode Golden

### DIFF
--- a/apps/app_partner/lib/src/features/checkin/checkin_controller.dart
+++ b/apps/app_partner/lib/src/features/checkin/checkin_controller.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:flutter/semantics.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -65,22 +66,34 @@ class CheckinController extends _$CheckinController {
       );
 
       if (success) {
+        final userName = 'User ${token.userId.substring(0, 4)}';
         state = state.copyWith(
           result: CheckinResult.success,
-          userName: 'User ${token.userId.substring(0, 4)}', // Simulated name
+          userName: userName,
+        );
+        // Fix #1813: A11y — 스캔 성공 TalkBack/VoiceOver 알림
+        SemanticsService.announce(
+          '체크인 성공. $userName',
+          TextDirection.ltr,
         );
       } else {
+        const message = '유효하지 않은 티켓입니다.';
         state = state.copyWith(
           result: CheckinResult.invalid,
-          message: '유효하지 않은 티켓입니다.',
+          message: message,
         );
+        // Fix #1813: A11y — 스캔 실패 TalkBack/VoiceOver 알림
+        SemanticsService.announce('입장 불가. $message', TextDirection.ltr);
       }
     } on Object catch (e) {
       Log.e('Check-in processing failed', e);
+      const message = '티켓 데이터를 읽을 수 없습니다.';
       state = state.copyWith(
         result: CheckinResult.invalid,
-        message: '티켓 데이터를 읽을 수 없습니다.',
+        message: message,
       );
+      // Fix #1813: A11y — 스캔 오류 TalkBack/VoiceOver 알림
+      SemanticsService.announce('입장 불가. $message', TextDirection.ltr);
     }
 
     // Reset to idle after a delay to allow for feedback UI

--- a/apps/app_partner/lib/src/features/checkin/widgets/checkin_scanner_overlay.dart
+++ b/apps/app_partner/lib/src/features/checkin/widgets/checkin_scanner_overlay.dart
@@ -171,7 +171,7 @@ class _CheckinScannerOverlayState extends State<CheckinScannerOverlay>
                   position: _bannerSlide,
                   child: SafeArea(
                     bottom: false,
-                    child: _ScanResultBanner(state: widget.state),
+                    child: CheckinResultBanner(state: widget.state),
                   ),
                 ),
               ),
@@ -231,58 +231,68 @@ class _ScanFab extends StatelessWidget {
   }
 }
 
-class _ScanResultBanner extends StatelessWidget {
-  const _ScanResultBanner({required this.state});
+/// 스캔 결과 배너 위젯.
+///
+/// VoiceOver/TalkBack liveRegion으로 마크업되어 결과 변경 시 자동으로 읽힌다.
+// Fix #1813: A11y — public 추출로 골든 테스트 가능하게 하고 liveRegion Semantics 추가
+class CheckinResultBanner extends StatelessWidget {
+  const CheckinResultBanner({required this.state, super.key});
   final CheckinState state;
 
   @override
   Widget build(BuildContext context) {
     final (color, icon, title, subtitle) = _bannerContent(state);
+    final semanticLabel = subtitle.isNotEmpty ? '$title. $subtitle' : title;
 
-    return Container(
-      margin: const EdgeInsets.symmetric(horizontal: MinglitSpacing.screenEdge),
-      padding: const EdgeInsets.symmetric(
-        horizontal: MinglitSpacing.medium,
-        vertical: MinglitSpacing.sm,
-      ),
-      decoration: BoxDecoration(
-        color: color,
-        borderRadius: BorderRadius.circular(MinglitRadius.card),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.2),
-            blurRadius: 8,
-            offset: const Offset(0, 2),
-          ),
-        ],
-      ),
-      child: Row(
-        children: [
-          Icon(icon, color: Colors.white, size: 24),
-          const SizedBox(width: MinglitSpacing.sm),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  title,
-                  style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                    color: Colors.white,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-                if (subtitle.isNotEmpty)
+    return Semantics(
+      liveRegion: true,
+      label: semanticLabel.isEmpty ? null : semanticLabel,
+      child: Container(
+        margin:
+            const EdgeInsets.symmetric(horizontal: MinglitSpacing.screenEdge),
+        padding: const EdgeInsets.symmetric(
+          horizontal: MinglitSpacing.medium,
+          vertical: MinglitSpacing.sm,
+        ),
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: BorderRadius.circular(MinglitRadius.card),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.2),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Row(
+          children: [
+            Icon(icon, color: Colors.white, size: 24),
+            const SizedBox(width: MinglitSpacing.sm),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
                   Text(
-                    subtitle,
-                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    title,
+                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                       color: Colors.white,
+                      fontWeight: FontWeight.w700,
                     ),
                   ),
-              ],
+                  if (subtitle.isNotEmpty)
+                    Text(
+                      subtitle,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Colors.white,
+                      ),
+                    ),
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/apps/app_partner/test/alchemist/qr_checkin_golden_test.dart
+++ b/apps/app_partner/test/alchemist/qr_checkin_golden_test.dart
@@ -1,0 +1,22 @@
+@Tags(['golden'])
+library;
+
+import 'package:alchemist/alchemist.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../utils/golden_test_helpers.dart';
+import 'scenarios/qr_checkin_scenarios.dart';
+
+void main() {
+  for (final scenario in QrCheckinScenarios.all) {
+    // ignore: discarded_futures
+    goldenTest(
+      scenario.name,
+      fileName: scenario.name,
+      builder: () => GoldenTestGroup(
+        columnWidthBuilder: (_) => const FixedColumnWidth(420),
+        children: [scenario.toGoldenTestScenario()],
+      ),
+    );
+  }
+}

--- a/apps/app_partner/test/alchemist/scenarios/qr_checkin_scenarios.dart
+++ b/apps/app_partner/test/alchemist/scenarios/qr_checkin_scenarios.dart
@@ -1,0 +1,311 @@
+import 'package:app_partner/src/features/checkin/checkin_controller.dart';
+import 'package:app_partner/src/features/checkin/manual/checkin_participant.dart';
+import 'package:app_partner/src/features/checkin/manual/manual_checkin_controller.dart';
+import 'package:app_partner/src/features/checkin/manual/manual_checkin_sheet.dart';
+import 'package:app_partner/src/features/checkin/stats/entry_group_checkin_stats_controller.dart';
+import 'package:app_partner/src/features/checkin/widgets/checkin_scanner_overlay.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import 'partner_screenshot_scenario.dart';
+
+// ---------------------------------------------------------------------------
+// Fake controllers for golden snapshots
+// ---------------------------------------------------------------------------
+
+class _FakeManualCheckinController extends ManualCheckinController {
+  _FakeManualCheckinController(this._participants);
+  final List<CheckinParticipant> _participants;
+
+  @override
+  Future<List<CheckinParticipant>> build(String eventId) async => _participants;
+
+  @override
+  Future<String> checkin(String ticketId) async => 'success';
+}
+
+class _ErrorManualCheckinController extends ManualCheckinController {
+  @override
+  Future<List<CheckinParticipant>> build(String eventId) async {
+    throw Exception('네트워크 연결을 확인해주세요');
+  }
+
+  @override
+  Future<String> checkin(String ticketId) async => 'error';
+}
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const _kEventId = 'golden-event';
+
+const _participantA = CheckinParticipant(
+  id: 'ep-1',
+  ticketId: 'tk-1',
+  name: '김민지',
+  phoneLast4: '1234',
+  status: 'ticket_issued',
+);
+
+const _participantB = CheckinParticipant(
+  id: 'ep-2',
+  ticketId: 'tk-2',
+  name: '박재훈',
+  phoneLast4: '5678',
+  status: 'checked_in',
+);
+
+final _groupLow = EntryGroupCheckinStats(
+  id: 'g-1',
+  label: 'A구역',
+  total: 100,
+  checkedIn: 30,
+);
+
+final _groupHigh = EntryGroupCheckinStats(
+  id: 'g-2',
+  label: 'B구역',
+  total: 100,
+  checkedIn: 95,
+);
+
+final _groupMid = EntryGroupCheckinStats(
+  id: 'g-3',
+  label: 'C구역',
+  total: 80,
+  checkedIn: 55,
+);
+
+// ---------------------------------------------------------------------------
+// Wrapper widgets
+// ---------------------------------------------------------------------------
+
+/// 체크인 결과 배너 — 고정 너비 카드로 골든 렌더.
+class _BannerCard extends StatelessWidget {
+  const _BannerCard({required this.state, required this.brightness});
+  final CheckinState state;
+  final Brightness brightness;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      theme: brightness == Brightness.dark
+          ? MinglitTheme.materialThemeDark
+          : MinglitTheme.materialTheme,
+      home: Scaffold(
+        backgroundColor: brightness == Brightness.dark
+            ? Colors.black
+            : const Color(0xFF1A1A1A),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: CheckinResultBanner(state: state),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 엔트리 그룹 행 목록 — 고정 카드로 골든 렌더.
+class _GroupListCard extends StatelessWidget {
+  const _GroupListCard({
+    required this.groups,
+    required this.brightness,
+  });
+  final List<EntryGroupCheckinStats> groups;
+  final Brightness brightness;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = brightness == Brightness.dark
+        ? MinglitTheme.materialThemeDark
+        : MinglitTheme.materialTheme;
+
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      theme: theme,
+      home: Scaffold(
+        body: Padding(
+          padding: const EdgeInsets.all(MinglitSpacing.screenEdge),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              for (int i = 0; i < groups.length; i++)
+                Semantics(
+                  label: '${groups[i].label}, ${groups[i].checkedIn}명 체크인, '
+                      '총 ${groups[i].total}명 중, '
+                      '${(groups[i].ratio * 100).toStringAsFixed(0)}퍼센트',
+                  child: EntryGroupRow(
+                    stats: groups[i],
+                    showDivider: i < groups.length - 1,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// ManualCheckinSheet 골든 래퍼 — ProviderScope 포함.
+class _ManualSheetGolden extends StatelessWidget {
+  const _ManualSheetGolden({
+    required this.controller,
+    required this.brightness,
+  });
+  final ManualCheckinController Function() controller;
+  final Brightness brightness;
+
+  @override
+  Widget build(BuildContext context) {
+    return ProviderScope(
+      overrides: [
+        manualCheckinControllerProvider(_kEventId).overrideWith(controller),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
+        home: Scaffold(
+          body: ManualCheckinSheet(eventId: _kEventId),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario definitions
+// ---------------------------------------------------------------------------
+
+class QrCheckinScenarios {
+  static List<PartnerScreenshotScenario> get all => [
+    // 1. 스캔 성공 배너 (light / dark)
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_success_banner',
+      page: _BannerCard(
+        state: const CheckinState(
+          result: CheckinResult.success,
+          userName: '홍길동',
+        ),
+        brightness: Brightness.light,
+      ),
+      isComponent: true,
+    ),
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_success_banner_dark',
+      page: _BannerCard(
+        state: const CheckinState(
+          result: CheckinResult.success,
+          userName: '홍길동',
+        ),
+        brightness: Brightness.dark,
+      ),
+      isComponent: true,
+    ),
+
+    // 2. 스캔 오류 배너 (light / dark)
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_error_banner',
+      page: _BannerCard(
+        state: const CheckinState(
+          result: CheckinResult.invalid,
+          message: '유효하지 않은 티켓입니다.',
+        ),
+        brightness: Brightness.light,
+      ),
+      isComponent: true,
+    ),
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_error_banner_dark',
+      page: _BannerCard(
+        state: const CheckinState(
+          result: CheckinResult.invalid,
+          message: '유효하지 않은 티켓입니다.',
+        ),
+        brightness: Brightness.dark,
+      ),
+      isComponent: true,
+    ),
+
+    // 3. 엔트리 그룹 확장 (light / dark)
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_group',
+      page: _GroupListCard(
+        groups: [_groupHigh, _groupMid, _groupLow],
+        brightness: Brightness.light,
+      ),
+      isComponent: true,
+    ),
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_group_dark',
+      page: _GroupListCard(
+        groups: [_groupHigh, _groupMid, _groupLow],
+        brightness: Brightness.dark,
+      ),
+      isComponent: true,
+    ),
+
+    // 4. 수동 체크인 — 참가자 있음 (light / dark)
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_manual_data',
+      page: _ManualSheetGolden(
+        controller: () =>
+            _FakeManualCheckinController([_participantA, _participantB]),
+        brightness: Brightness.light,
+      ),
+      isComponent: true,
+    ),
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_manual_data_dark',
+      page: _ManualSheetGolden(
+        controller: () =>
+            _FakeManualCheckinController([_participantA, _participantB]),
+        brightness: Brightness.dark,
+      ),
+      isComponent: true,
+    ),
+
+    // 5. 수동 체크인 — 빈 상태 (light / dark)
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_manual_empty',
+      page: _ManualSheetGolden(
+        controller: () => _FakeManualCheckinController([]),
+        brightness: Brightness.light,
+      ),
+      isComponent: true,
+    ),
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_manual_empty_dark',
+      page: _ManualSheetGolden(
+        controller: () => _FakeManualCheckinController([]),
+        brightness: Brightness.dark,
+      ),
+      isComponent: true,
+    ),
+
+    // 6. 수동 체크인 — 오프라인/오류 (light / dark)
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_manual_offline',
+      page: _ManualSheetGolden(
+        controller: _ErrorManualCheckinController.new,
+        brightness: Brightness.light,
+      ),
+      isComponent: true,
+    ),
+    PartnerScreenshotScenario(
+      name: 'qr_checkin_manual_offline_dark',
+      page: _ManualSheetGolden(
+        controller: _ErrorManualCheckinController.new,
+        brightness: Brightness.dark,
+      ),
+      isComponent: true,
+    ),
+  ];
+}


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1813

## 변경 사항

Phase 4(#1812) 기반, 접근성 보강 및 다크모드 골든 테스트 추가.

### 핵심 변경

**`CheckinResultBanner`** (`checkin_scanner_overlay.dart`)
- `_ScanResultBanner` → `CheckinResultBanner`로 public 추출 (Golden 테스트 직접 참조 가능)
- `Semantics(liveRegion: true)` 추가 — 결과 변경 시 VoiceOver/TalkBack이 자동으로 읽음

**`CheckinController`** (`checkin_controller.dart`)
- `SemanticsService.announce` 추가: 성공/실패/오류 시점에 스크린리더 알림

**Golden 테스트** (`qr_checkin_golden_test.dart` + `qr_checkin_scenarios.dart`)
- 12개 시나리오 (6 상태 × light/dark):
  1. 스캔 성공 배너
  2. 스캔 오류 배너
  3. 엔트리 그룹 확장
  4. 수동 체크인 — 참가자 있음
  5. 수동 체크인 — 빈 상태
  6. 수동 체크인 — 오프라인/오류

## 의존성

이 PR은 Phase 4 (`feat/1812-qr-checkin-phase4`) 기반. Phase 1 → Phase 4 순서로 머지 완료 후 base를 `dev`로 변경하여 머지.