### PR TITLE
fix(#1825): redirect /dev deeplink to /dev/user-switch

### DIFF
--- a/apps/app_partner/lib/src/routing/app_router.dart
+++ b/apps/app_partner/lib/src/routing/app_router.dart
@@ -48,7 +48,9 @@ GoRouter goRouter(Ref ref) {
       final isApplyPage = state.uri.path.startsWith('/apply');
       final isWelcomePage = state.uri.path == '/welcome';
 
-      // Allow dev pages without authentication
+      // Allow dev pages without authentication.
+      // Fix #1825: /dev 단독 경로는 /dev/user-switch로 리디렉트.
+      if (state.uri.path == '/dev') return '/dev/user-switch';
       if (state.uri.path.startsWith('/dev')) return null;
 
       // 1. If not logged in and not on login page -> Redirect to Login

--- a/apps/app_partner/test/integration/partner_redirect_test.dart
+++ b/apps/app_partner/test/integration/partner_redirect_test.dart
@@ -6,6 +6,7 @@ import 'package:app_partner/src/features/onboarding/partner_apply_page.dart';
 import 'package:app_partner/src/features/onboarding/partner_apply_status_page.dart';
 import 'package:app_partner/src/features/onboarding/partner_welcome_page.dart';
 import 'package:app_partner/src/l10n/generated/app_localizations.dart';
+import 'package:minglit_kit/minglit_dev.dart';
 import 'package:app_partner/src/logic/onboarding_state_provider.dart';
 import 'package:app_partner/src/routing/app_routes.dart';
 import 'package:flutter/material.dart';
@@ -42,7 +43,9 @@ Widget _createPartnerTestApp({
       final isApplyPage = path.startsWith('/apply');
       final isWelcomePage = path == '/welcome';
 
-      // Allow dev pages without authentication
+      // Allow dev pages without authentication.
+      // Fix #1825: /dev 단독 경로는 /dev/user-switch로 리디렉트.
+      if (path == '/dev') return '/dev/user-switch';
       if (path.startsWith('/dev')) return null;
 
       // 1. Not logged in and not on login page → /login
@@ -333,6 +336,19 @@ void main() {
 
       // Should NOT redirect to login
       expect(find.byType(PartnerLoginPage), findsNothing);
+    });
+
+    // Test 9-b: Fix #1825 — /dev (no trailing path) → redirected to /dev/user-switch
+    testWidgets('비로그인: /dev 접근 시 /dev/user-switch로 리디렉트', (tester) async {
+      await tester.pumpWidget(
+        _createPartnerTestApp(initialLocation: '/dev'),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      // Should land on DevUserSwitchScreen, not PartnerLoginPage
+      expect(find.byType(PartnerLoginPage), findsNothing);
+      expect(find.byType(DevUserSwitchScreen), findsOneWidget);
     });
 
     // Test 10: hasPartner → home accessible without redirect


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1825

## 문제

`minglit-partner-dev://minglit-partner-dev/dev` deeplink 호출 시 404 "페이지를 찾을 수 없습니다" 화면 표시.

**원인**: `/dev/user-switch` route만 존재하며, `/dev` 단독 route는 commit `2ffbd34b7`에서 `PartnerDevMap` 제거 시 함께 삭제됨.

## 수정

`app_router.dart` redirect 함수에 `/dev` → `/dev/user-switch` redirect 규칙 추가.

```dart
// Fix #1825: /dev 단독 경로는 /dev/user-switch로 리디렉트.
if (state.uri.path == '/dev') return '/dev/user-switch';
if (state.uri.path.startsWith('/dev')) return null;
```

이미 존재하는 `/dev`-prefix 허용 로직 바로 앞에 추가하여 순서를 보장.