### PR TITLE
fix(#1819): add SecureStorage read timeout to prevent QR screen infinite loading

### DIFF
--- a/apps/app_user/lib/src/features/ticket/data/ticket_wallet_repository.dart
+++ b/apps/app_user/lib/src/features/ticket/data/ticket_wallet_repository.dart
@@ -43,7 +43,9 @@ class TicketWalletRepository {
     try {
       value = await _storage.read(key: key).timeout(_readTimeout);
     } on TimeoutException {
-      Log.w('SecureStorage read timed out for ticket $ticketId — skipping cache');
+      Log.w(
+        'SecureStorage read timed out for ticket $ticketId — skipping cache',
+      );
       return null;
     } on Object catch (e) {
       Log.e('SecureStorage read failed for ticket $ticketId', e);

--- a/apps/app_user/lib/src/features/ticket/data/ticket_wallet_repository.dart
+++ b/apps/app_user/lib/src/features/ticket/data/ticket_wallet_repository.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -31,10 +32,23 @@ class TicketWalletRepository {
     await _storage.write(key: key, value: value);
   }
 
+  // Fix #1819: SecureStorage read can hang on Android when KeyStore is locked.
+  // Timeout after 5s and return null so the caller falls through to network.
+  static const _readTimeout = Duration(seconds: 5);
+
   /// Retrieves a [TicketToken] by ID.
   Future<TicketToken?> getTicket(String ticketId) async {
     final key = '$_keyPrefix$ticketId';
-    final value = await _storage.read(key: key);
+    final String? value;
+    try {
+      value = await _storage.read(key: key).timeout(_readTimeout);
+    } on TimeoutException {
+      Log.w('SecureStorage read timed out for ticket $ticketId — skipping cache');
+      return null;
+    } on Object catch (e) {
+      Log.e('SecureStorage read failed for ticket $ticketId', e);
+      return null;
+    }
     if (value == null) return null;
 
     try {

--- a/apps/app_user/test/src/features/ticket/data/ticket_wallet_repository_test.dart
+++ b/apps/app_user/test/src/features/ticket/data/ticket_wallet_repository_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:app_user/src/features/ticket/data/ticket_wallet_repository.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -61,6 +62,32 @@ void main() {
       ).thenAnswer((_) async => null);
 
       final result = await repository.getTicket('non_existent');
+
+      expect(result, isNull);
+    });
+
+    // Fix #1819: SecureStorage can hang on Android (KeyStore locked) — must timeout
+    test('getTicket returns null when storage read hangs (timeout)', () async {
+      when(
+        () => mockStorage.read(key: any(named: 'key')),
+      ).thenAnswer((_) async {
+        await Future<void>.delayed(const Duration(seconds: 10));
+        return 'should_not_reach';
+      });
+
+      final result = await repository
+          .getTicket('hanging_ticket')
+          .timeout(const Duration(seconds: 7));
+
+      expect(result, isNull);
+    });
+
+    test('getTicket returns null when storage throws', () async {
+      when(
+        () => mockStorage.read(key: any(named: 'key')),
+      ).thenThrow(Exception('KeyStore error'));
+
+      final result = await repository.getTicket('ticket_1');
 
       expect(result, isNull);
     });

--- a/apps/app_user/test/src/features/ticket/data/ticket_wallet_repository_test.dart
+++ b/apps/app_user/test/src/features/ticket/data/ticket_wallet_repository_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 import 'package:app_user/src/features/ticket/data/ticket_wallet_repository.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1819

## 문제

Android에서 `FlutterSecureStorage.read()`가 OS KeyStore가 잠긴 상태(기기 보안 정책, OS 업그레이드 후 하드웨어 키 불일치 등)일 때 무기한 hang됩니다. 이로 인해 `FutureProvider`가 완료되지 않아 QR 화면이 영구 로딩 상태에 멈췄습니다.

## 원인

`TicketWalletRepository.getTicket()` → `_storage.read()` → hang → `TicketTokenService.getToken()` never completes → `_ticketTokenProvider` never resolves → `MinglitAsyncValueWidget` 무한 로딩

## 수정

`_storage.read()`에 5초 timeout 추가. Timeout 발생 시 null 반환(캐시 미스), `TicketTokenService`가 Edge Function 폴백으로 넘어가 항상 QR 코드를 표시합니다.

## 테스트

- `getTicket returns null when storage read hangs (timeout)` — hang 시 5초 후 null 반환 검증
- `getTicket returns null when storage throws` — 예외 발생 시 null 반환 검증