### PR TITLE
fix(#1834): use go() for cross-branch bank account navigation from More page

### DIFF
--- a/apps/app_partner/lib/src/features/more/more_coordinator.dart
+++ b/apps/app_partner/lib/src/features/more/more_coordinator.dart
@@ -32,8 +32,11 @@ class MoreCoordinator {
   }
 
   // Fix #1568: 정산 계좌 관리 진입점
+  // Fix #1834: push() cross-branch (/more → /settlement) fails silently in
+  // StatefulShellRoute (same class of bug as #1680). Use go() to switch branch
+  // directly — matching the pattern of goToSettlement() in SettlementCoordinator.
   void pushBankAccountManagement() {
-    unawaited(_router.push(const BankAccountRoute().location));
+    _router.go(const BankAccountRoute().location);
   }
 
   void pushAccountDeletion() {

--- a/apps/app_partner/test/src/features/more/more_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/more/more_coordinator_test.dart
@@ -12,6 +12,7 @@ void main() {
   setUp(() {
     mockRouter = MockGoRouter();
     when(() => mockRouter.push(any())).thenAnswer((_) async => null);
+    when(() => mockRouter.go(any())).thenReturn(null);
   });
 
   group('MoreCoordinator', () {
@@ -66,6 +67,21 @@ void main() {
 
       verify(
         () => mockRouter.push(any(that: equals('/more/parties'))),
+      ).called(1);
+    });
+
+    // Fix #1834: push() cross-branch (more → settlement) fails in StatefulShellRoute.
+    // Must use go() — not push() — so this test guards against regression.
+    test('pushBankAccountManagement calls router.go with /settlement/bank-account', () {
+      final container = createContainer(
+        overrides: [goRouterProvider.overrideWithValue(mockRouter)],
+      );
+
+      container.read(moreCoordinatorProvider).pushBankAccountManagement();
+
+      verifyNever(() => mockRouter.push(any()));
+      verify(
+        () => mockRouter.go(any(that: equals('/settlement/bank-account'))),
       ).called(1);
     });
 

--- a/apps/app_partner/test/src/features/more/more_coordinator_test.dart
+++ b/apps/app_partner/test/src/features/more/more_coordinator_test.dart
@@ -72,18 +72,21 @@ void main() {
 
     // Fix #1834: push() cross-branch (more → settlement) fails in StatefulShellRoute.
     // Must use go() — not push() — so this test guards against regression.
-    test('pushBankAccountManagement calls router.go with /settlement/bank-account', () {
-      final container = createContainer(
-        overrides: [goRouterProvider.overrideWithValue(mockRouter)],
-      );
+    test(
+      'pushBankAccountManagement calls router.go with /settlement/bank-account',
+      () {
+        final container = createContainer(
+          overrides: [goRouterProvider.overrideWithValue(mockRouter)],
+        );
 
-      container.read(moreCoordinatorProvider).pushBankAccountManagement();
+        container.read(moreCoordinatorProvider).pushBankAccountManagement();
 
-      verifyNever(() => mockRouter.push(any()));
-      verify(
-        () => mockRouter.go(any(that: equals('/settlement/bank-account'))),
-      ).called(1);
-    });
+        verifyNever(() => mockRouter.push(any()));
+        verify(
+          () => mockRouter.go(any(that: equals('/settlement/bank-account'))),
+        ).called(1);
+      },
+    );
 
     test('pushAccountDeletion calls router.push', () {
       final container = createContainer(


### PR DESCRIPTION
## Summary

- `MoreCoordinator.pushBankAccountManagement()` was calling `router.push('/settlement/bank-account')` from the `/more` StatefulShellRoute branch
- Same class of bug as #1680: `push()` fails silently when crossing StatefulShellRoute branch boundaries — observed result was navigation to `/more/parties/create` instead of `/settlement/bank-account`
- Fix: use `router.go('/settlement/bank-account')` which correctly switches the active shell branch and navigates to the target route

## Test plan

- [x] Regression test added to `more_coordinator_test.dart`: verifies `push()` is NOT called and `go('/settlement/bank-account')` IS called
- [x] All existing coordinator tests still pass (7/7)
- [x] `test-flutter-apps` CI job will run the full app_partner test suite

Closes #1834