### PR TITLE
fix(#1829): propagate from through DevUserSwitch so post-login redirect works

### DIFF
--- a/apps/app_user/lib/src/features/auth/logic/auth_coordinator.dart
+++ b/apps/app_user/lib/src/features/auth/logic/auth_coordinator.dart
@@ -34,7 +34,8 @@ class AuthCoordinator {
     _router.go('/');
   }
 
-  void pushDevUserSwitch() {
-    unawaited(_router.push(const DevUserSwitchRoute().location));
+  // Fix #1829: pass `from` so DevUserSwitch can redirect after login
+  void pushDevUserSwitch({String? from}) {
+    unawaited(_router.push(DevUserSwitchRoute(from: from).location));
   }
 }

--- a/apps/app_user/lib/src/features/auth/login_page.dart
+++ b/apps/app_user/lib/src/features/auth/login_page.dart
@@ -129,8 +129,10 @@ class LoginPage extends ConsumerWidget {
         },
         // Fix #188: 데브맵 제거 — 5클릭 시 세션 스위처로 직접 이동
         // Fix #404: Use coordinator instead of direct route push
+        // Fix #1829: pass `from` so DevUserSwitch redirects to intended page after login
         onDevTrigger: isDevEnv
-            ? () => ref.read(authCoordinatorProvider).pushDevUserSwitch()
+            ? () =>
+                ref.read(authCoordinatorProvider).pushDevUserSwitch(from: from)
             : null,
       ),
     );

--- a/apps/app_user/lib/src/features/auth/login_page.dart
+++ b/apps/app_user/lib/src/features/auth/login_page.dart
@@ -131,8 +131,9 @@ class LoginPage extends ConsumerWidget {
         // Fix #404: Use coordinator instead of direct route push
         // Fix #1829: pass `from` so DevUserSwitch redirects to intended page after login
         onDevTrigger: isDevEnv
-            ? () =>
-                ref.read(authCoordinatorProvider).pushDevUserSwitch(from: from)
+            ? () => ref
+                  .read(authCoordinatorProvider)
+                  .pushDevUserSwitch(from: from)
             : null,
       ),
     );

--- a/apps/app_user/lib/src/routing/app_routes.dart
+++ b/apps/app_user/lib/src/routing/app_routes.dart
@@ -37,11 +37,14 @@ part 'app_routes.g.dart';
 /// Path: `/dev/switch`
 @TypedGoRoute<DevUserSwitchRoute>(path: '/dev/switch')
 class DevUserSwitchRoute extends GoRouteData with $DevUserSwitchRoute {
-  const DevUserSwitchRoute();
+  // Fix #1829: propagate `from` so post-login redirect returns to intended page
+  const DevUserSwitchRoute({this.from});
+
+  final String? from;
 
   @override
   Widget build(BuildContext context, GoRouterState state) =>
-      const DevUserSwitchScreen();
+      DevUserSwitchScreen(from: from);
 }
 
 /// **Auth Route**: Login Screen.

--- a/apps/app_user/lib/src/routing/app_routes.g.dart
+++ b/apps/app_user/lib/src/routing/app_routes.g.dart
@@ -41,10 +41,15 @@ RouteBase get $devUserSwitchRoute => GoRouteData.$route(
 
 mixin $DevUserSwitchRoute on GoRouteData {
   static DevUserSwitchRoute _fromState(GoRouterState state) =>
-      const DevUserSwitchRoute();
+      DevUserSwitchRoute(from: state.uri.queryParameters['from']);
+
+  DevUserSwitchRoute get _self => this as DevUserSwitchRoute;
 
   @override
-  String get location => GoRouteData.$location('/dev/switch');
+  String get location => GoRouteData.$location(
+    '/dev/switch',
+    queryParams: {if (_self.from != null) 'from': _self.from},
+  );
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/apps/app_user/test/src/features/auth/logic/auth_coordinator_test.dart
+++ b/apps/app_user/test/src/features/auth/logic/auth_coordinator_test.dart
@@ -60,5 +60,26 @@ void main() {
 
       verify(() => mockRouter.go(location)).called(1);
     });
+
+    // Fix #1829: DevUserSwitch must forward `from` so post-login redirect works
+    test('pushDevUserSwitch without from calls router.push with /dev/switch', () {
+      AuthCoordinator(mockRouter).pushDevUserSwitch();
+
+      verify(
+        () => mockRouter.push(any(that: contains('/dev/switch'))),
+      ).called(1);
+    });
+
+    test('pushDevUserSwitch with from includes from in path', () {
+      AuthCoordinator(mockRouter).pushDevUserSwitch(
+        from: '/events/abc',
+      );
+
+      verify(
+        () => mockRouter.push(
+          any(that: contains('/dev/switch') & contains('from=')),
+        ),
+      ).called(1);
+    });
   });
 }

--- a/apps/app_user/test/src/features/auth/logic/auth_coordinator_test.dart
+++ b/apps/app_user/test/src/features/auth/logic/auth_coordinator_test.dart
@@ -80,7 +80,7 @@ void main() {
 
       verify(
         () => mockRouter.push(
-          any(that: contains('/dev/switch') & contains('from=')),
+          any(that: allOf(contains('/dev/switch'), contains('from='))),
         ),
       ).called(1);
     });

--- a/apps/app_user/test/src/features/auth/logic/auth_coordinator_test.dart
+++ b/apps/app_user/test/src/features/auth/logic/auth_coordinator_test.dart
@@ -62,13 +62,16 @@ void main() {
     });
 
     // Fix #1829: DevUserSwitch must forward `from` so post-login redirect works
-    test('pushDevUserSwitch without from calls router.push with /dev/switch', () {
-      AuthCoordinator(mockRouter).pushDevUserSwitch();
+    test(
+      'pushDevUserSwitch without from calls router.push with /dev/switch',
+      () {
+        AuthCoordinator(mockRouter).pushDevUserSwitch();
 
-      verify(
-        () => mockRouter.push(any(that: contains('/dev/switch'))),
-      ).called(1);
-    });
+        verify(
+          () => mockRouter.push(any(that: contains('/dev/switch'))),
+        ).called(1);
+      },
+    );
 
     test('pushDevUserSwitch with from includes from in path', () {
       AuthCoordinator(mockRouter).pushDevUserSwitch(

--- a/shared/packages/minglit_kit/lib/src/features/dev/dev_user_switch_screen.dart
+++ b/shared/packages/minglit_kit/lib/src/features/dev/dev_user_switch_screen.dart
@@ -23,7 +23,10 @@ part 'dev_user_switch_screen.g.dart';
 /// `flutter test shared/packages/minglit_seeder` CLI commands instead.
 class DevUserSwitchScreen extends ConsumerStatefulWidget {
   /// Creates a dev-only user switch screen.
-  const DevUserSwitchScreen({super.key});
+  // Fix #1829: accept `from` to redirect after login instead of defaulting to '/'
+  const DevUserSwitchScreen({super.key, this.from});
+
+  final String? from;
 
   /// Creates the state for the dev user switch screen.
   @override
@@ -44,7 +47,8 @@ class _DevUserSwitchScreenState extends ConsumerState<DevUserSwitchScreen> {
 
       if (mounted) {
         ref.invalidate(currentUserProfileProvider);
-        GoRouter.of(context).go('/');
+        // Fix #1829: redirect to `from` if provided, else home
+        GoRouter.of(context).go(widget.from ?? '/');
       }
     } on Exception catch (e, st) {
       Log.e('❌ Failed to switch user to $email', e, st);


### PR DESCRIPTION
## Summary

- **Root cause**: `DevUserSwitchRoute`에 `from` 필드가 없어서 `/dev/switch` 경유 시 로그인 후 목적지(`from`)가 유실되고 항상 `/`(홈)으로 이동했습니다.
- **Fix**: `DevUserSwitchRoute`, `AuthCoordinator.pushDevUserSwitch()`, `LoginPage.onDevTrigger`, `DevUserSwitchScreen._switchUser()`을 모두 수정하여 `from` 파라미터를 체인 전체에 전파.

## 수정 파일

- `app_routes.dart` / `app_routes.g.dart` — `DevUserSwitchRoute`에 `from` 쿼리 파라미터 추가
- `auth_coordinator.dart` — `pushDevUserSwitch({String? from})` 시그니처 추가  
- `login_page.dart` — `pushDevUserSwitch(from: from)` 전달
- `dev_user_switch_screen.dart` (minglit_kit) — `widget.from ?? '/'`로 리디렉트

## Test plan
- [ ] `pushDevUserSwitch(from: ...)` 경로에 `from=` 포함 검증 (auth_coordinator_test)
- [ ] 무 `from` 케이스도 `/dev/switch` 경로 검증

Closes #1829

🤖 Generated with [Claude Code](https://claude.com/claude-code)