### PR TITLE
fix(#1824,#1830): add bottom safe-area padding in More page and PartyInfo tab

### DIFF
--- a/apps/app_partner/lib/src/features/more/more_page.dart
+++ b/apps/app_partner/lib/src/features/more/more_page.dart
@@ -26,8 +26,7 @@ class MorePage extends ConsumerWidget {
         // Fix #1824: add bottom safe-area so last item clears the home bar
         padding: EdgeInsets.only(
           top: MinglitSpacing.medium,
-          bottom:
-              MinglitSpacing.medium + MediaQuery.paddingOf(context).bottom,
+          bottom: MinglitSpacing.medium + MediaQuery.paddingOf(context).bottom,
         ),
         children: [
           // Group 1: Profile

--- a/apps/app_partner/lib/src/features/more/more_page.dart
+++ b/apps/app_partner/lib/src/features/more/more_page.dart
@@ -23,7 +23,12 @@ class MorePage extends ConsumerWidget {
     return Scaffold(
       appBar: MinglitTheme.simpleAppBar(title: '더보기', showBackButton: false),
       body: ListView(
-        padding: const EdgeInsets.symmetric(vertical: MinglitSpacing.medium),
+        // Fix #1824: add bottom safe-area so last item clears the home bar
+        padding: EdgeInsets.only(
+          top: MinglitSpacing.medium,
+          bottom:
+              MinglitSpacing.medium + MediaQuery.paddingOf(context).bottom,
+        ),
         children: [
           // Group 1: Profile
           partnerAsync.when(

--- a/apps/app_partner/lib/src/features/party/detail/tabs/party_info_tab.dart
+++ b/apps/app_partner/lib/src/features/party/detail/tabs/party_info_tab.dart
@@ -22,7 +22,13 @@ class PartyInfoTab extends ConsumerWidget {
 
     // Fix #142: Add padding to match PartyRuleManagementTab
     return SingleChildScrollView(
-      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      // Fix #1830: add bottom safe-area so last section clears the home bar
+      padding: EdgeInsets.only(
+        left: MinglitSpacing.medium,
+        right: MinglitSpacing.medium,
+        top: MinglitSpacing.medium,
+        bottom: MinglitSpacing.medium + MediaQuery.paddingOf(context).bottom,
+      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [


### PR DESCRIPTION
## Summary

- `MorePage` ListView was missing bottom safe-area padding, causing the last list item to be obscured by the device home indicator on notched devices
- `PartyInfoTab` SingleChildScrollView had the same issue — last section obscured by home indicator

## Changes

- `more_page.dart`: `EdgeInsets.symmetric(vertical:)` → `EdgeInsets.only(top:, bottom: + MediaQuery.paddingOf(context).bottom)` (Fix #1824)
- `party_info_tab.dart`: `EdgeInsets.all()` → `EdgeInsets.only(left:, right:, top:, bottom: + MediaQuery.paddingOf(context).bottom)` (Fix #1830)

## Test plan

- [ ] Open More page on a device with home indicator → last list item fully visible above indicator
- [ ] Open Party detail → Info tab → scroll to bottom → last section fully visible

Closes #1824, closes #1830