### PR TITLE
fix(#1835): block ghost taps on outgoing page during FadeThroughTransition

### DIFF
--- a/apps/app_partner/lib/src/ui/shell/partner_scaffold.dart
+++ b/apps/app_partner/lib/src/ui/shell/partner_scaffold.dart
@@ -110,14 +110,17 @@ class PartnerScaffold extends ConsumerWidget {
         // secondaryController.forward() (secondaryAnimation: 0→1), while the
         // INCOMING entry's primaryAnimation goes 0→1. Opacity-0 widgets remain
         // hit-testable in Flutter, so wrap each entry in IgnorePointer and block
-        // pointer events while secondaryAnimation.value > 0 (i.e. this entry is
-        // fading out). Listen on secondaryAnimation so AnimatedBuilder rebuilds
-        // on each tick of the fade-out.
+        // pointer events as soon as the outgoing animation starts. Use
+        // `status != dismissed` instead of `value > 0` so the very first frame
+        // (value still 0.0, status already forward/completed) is also blocked.
         transitionBuilder: (child, animation, secondaryAnimation) =>
             AnimatedBuilder(
               animation: secondaryAnimation,
               builder: (context, widget) => IgnorePointer(
-                ignoring: secondaryAnimation.value > 0.0,
+                // Fix #1835: block on status, not value — value is 0.0 on
+                // the first frame even after forward() is called.
+                ignoring:
+                    secondaryAnimation.status != AnimationStatus.dismissed,
                 child: widget,
               ),
               child: FadeThroughTransition(

--- a/apps/app_partner/lib/src/ui/shell/partner_scaffold.dart
+++ b/apps/app_partner/lib/src/ui/shell/partner_scaffold.dart
@@ -106,11 +106,25 @@ class PartnerScaffold extends ConsumerWidget {
 
     return Scaffold(
       body: PageTransitionSwitcher(
+        // Fix #1835: PageTransitionSwitcher drives the OUTGOING entry by calling
+        // secondaryController.forward() (secondaryAnimation: 0→1), while the
+        // INCOMING entry's primaryAnimation goes 0→1. Opacity-0 widgets remain
+        // hit-testable in Flutter, so wrap each entry in IgnorePointer and block
+        // pointer events while secondaryAnimation.value > 0 (i.e. this entry is
+        // fading out). Listen on secondaryAnimation so AnimatedBuilder rebuilds
+        // on each tick of the fade-out.
         transitionBuilder: (child, animation, secondaryAnimation) =>
-            FadeThroughTransition(
-              animation: animation,
-              secondaryAnimation: secondaryAnimation,
-              child: child,
+            AnimatedBuilder(
+              animation: secondaryAnimation,
+              builder: (context, widget) => IgnorePointer(
+                ignoring: secondaryAnimation.value > 0.0,
+                child: widget,
+              ),
+              child: FadeThroughTransition(
+                animation: animation,
+                secondaryAnimation: secondaryAnimation,
+                child: child,
+              ),
             ),
         child: KeyedSubtree(
           key: ValueKey<int>(navigationShell.currentIndex),

--- a/apps/app_partner/test/src/ui/shell/partner_scaffold_test.dart
+++ b/apps/app_partner/test/src/ui/shell/partner_scaffold_test.dart
@@ -1,3 +1,4 @@
+import 'package:animations/animations.dart';
 import 'package:app_partner/src/logic/current_partner_provider.dart';
 import 'package:app_partner/src/ui/shell/partner_scaffold.dart';
 import 'package:flutter/material.dart';
@@ -222,10 +223,11 @@ void main() {
     }
 
     testWidgets(
-      'outgoing child has IgnorePointer(ignoring: true) during tab-switch '
-      'animation',
+      'outgoing child has IgnorePointer(ignoring: true) on FIRST frame of '
+      'tab-switch animation',
       (tester) async {
         final shellIndex = ValueNotifier<int>(0);
+        addTearDown(shellIndex.dispose);
 
         await tester.pumpWidget(
           buildAnimationSubject(shellIndexNotifier: shellIndex),
@@ -234,20 +236,24 @@ void main() {
 
         // Trigger tab switch — KeyedSubtree key changes, starting animation.
         shellIndex.value = 4;
-        await tester.pump(); // start animation frame
-        await tester.pump(const Duration(milliseconds: 50)); // mid-animation
+        // Single pump: value is still 0.0 but status is already forward.
+        // Fix #1835 uses status != dismissed, so this frame must already block.
+        await tester.pump();
 
-        // The outgoing page must have ignoring=true so opacity-0 buttons
-        // cannot steal taps from the incoming page.
+        // IgnorePointer wraps FadeThroughTransition (ancestor, not descendant),
+        // so use find.ancestor to scope to only our own IgnorePointers.
         final ignorePointers = tester.widgetList<IgnorePointer>(
-          find.byType(IgnorePointer),
+          find.ancestor(
+            of: find.byType(FadeThroughTransition),
+            matching: find.byType(IgnorePointer),
+          ),
         );
         expect(
           ignorePointers.any((ip) => ip.ignoring),
           isTrue,
           reason:
               'Outgoing page must be wrapped in IgnorePointer(ignoring: true) '
-              'during FadeThroughTransition to block ghost taps',
+              'on the very first animation frame to block ghost taps',
         );
       },
     );
@@ -256,6 +262,7 @@ void main() {
       'no IgnorePointer blocks interaction after animation completes',
       (tester) async {
         final shellIndex = ValueNotifier<int>(0);
+        addTearDown(shellIndex.dispose);
 
         await tester.pumpWidget(
           buildAnimationSubject(shellIndexNotifier: shellIndex),
@@ -267,7 +274,10 @@ void main() {
 
         // After the transition, the incoming page must be fully interactive.
         final ignorePointers = tester.widgetList<IgnorePointer>(
-          find.byType(IgnorePointer),
+          find.ancestor(
+            of: find.byType(FadeThroughTransition),
+            matching: find.byType(IgnorePointer),
+          ),
         );
         expect(
           ignorePointers.every((ip) => !ip.ignoring),

--- a/apps/app_partner/test/src/ui/shell/partner_scaffold_test.dart
+++ b/apps/app_partner/test/src/ui/shell/partner_scaffold_test.dart
@@ -186,4 +186,96 @@ void main() {
       },
     );
   });
+
+  // Fix #1835: Ghost navigation regression — PageTransitionSwitcher renders
+  // both outgoing and incoming pages simultaneously. Without IgnorePointer,
+  // opacity-0 buttons on the outgoing page remain hit-testable and race with
+  // buttons on the incoming page at the same coordinates.
+  group('PartnerScaffold — ghost navigation prevention (Fix #1835)', () {
+    Widget buildAnimationSubject({
+      required ValueNotifier<int> shellIndexNotifier,
+      bool hasSettlementAccess = true,
+    }) {
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => ValueListenableBuilder<int>(
+              valueListenable: shellIndexNotifier,
+              builder: (context, idx, _) => PartnerScaffold(
+                navigationShell: _FakeNavigationShell(currentIdx: idx),
+              ),
+            ),
+          ),
+        ],
+      );
+
+      return ProviderScope(
+        overrides: [
+          hasSettlementAccessProvider.overrideWith(
+            (ref) => Future.value(hasSettlementAccess),
+          ),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      );
+    }
+
+    testWidgets(
+      'outgoing child has IgnorePointer(ignoring: true) during tab-switch '
+      'animation',
+      (tester) async {
+        final shellIndex = ValueNotifier<int>(0);
+
+        await tester.pumpWidget(
+          buildAnimationSubject(shellIndexNotifier: shellIndex),
+        );
+        await tester.pumpAndSettle();
+
+        // Trigger tab switch — KeyedSubtree key changes, starting animation.
+        shellIndex.value = 4;
+        await tester.pump(); // start animation frame
+        await tester.pump(const Duration(milliseconds: 50)); // mid-animation
+
+        // The outgoing page must have ignoring=true so opacity-0 buttons
+        // cannot steal taps from the incoming page.
+        final ignorePointers = tester.widgetList<IgnorePointer>(
+          find.byType(IgnorePointer),
+        );
+        expect(
+          ignorePointers.any((ip) => ip.ignoring),
+          isTrue,
+          reason:
+              'Outgoing page must be wrapped in IgnorePointer(ignoring: true) '
+              'during FadeThroughTransition to block ghost taps',
+        );
+      },
+    );
+
+    testWidgets(
+      'no IgnorePointer blocks interaction after animation completes',
+      (tester) async {
+        final shellIndex = ValueNotifier<int>(0);
+
+        await tester.pumpWidget(
+          buildAnimationSubject(shellIndexNotifier: shellIndex),
+        );
+        await tester.pumpAndSettle();
+
+        shellIndex.value = 4;
+        await tester.pumpAndSettle(); // let animation finish
+
+        // After the transition, the incoming page must be fully interactive.
+        final ignorePointers = tester.widgetList<IgnorePointer>(
+          find.byType(IgnorePointer),
+        );
+        expect(
+          ignorePointers.every((ip) => !ip.ignoring),
+          isTrue,
+          reason:
+              'No IgnorePointer should be ignoring after animation completes',
+        );
+      },
+    );
+  });
 }


### PR DESCRIPTION
## Summary

- `PageTransitionSwitcher` renders both outgoing and incoming pages simultaneously during `FadeThroughTransition`. Opacity-0 widgets remain hit-testable in Flutter, causing ghost taps when two pages have buttons at the same coordinates (e.g. More/"+" party button and Settlement/"계좌 관리" button both at top-right).
- Root cause: the outgoing entry is faded via `secondaryAnimation` (0→1), NOT by reversing `primaryAnimation`. Wrapping in `AnimatedBuilder(animation: secondaryAnimation)` + `IgnorePointer(ignoring: secondaryAnimation.value > 0.0)` blocks pointer events on the outgoing page throughout the fade.
- Adds 2 regression tests: mid-animation outgoing child has `IgnorePointer(ignoring: true)`; incoming child is fully interactive after settle.

Closes #1835

## Test plan

- [ ] Run `flutter test test/src/ui/shell/partner_scaffold_test.dart` — all 13 tests pass
- [ ] Tap "계좌 관리" in Settlement tab immediately after switching from More/파티 tab — should navigate to bank account, NOT party creation
- [ ] Tab switches animate smoothly with no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)