### PR TITLE
fix(home): 메인 피드 초기 로딩 시 shimmer skeleton으로 통일 (#1856)

### DIFF
--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -260,15 +260,14 @@ class _HomePageState extends ConsumerState<HomePage> {
 
   // Fix #1856: skeleton list to replace progress indicator during initial feed load
   static Widget _eventFeedSkeleton() => SliverPadding(
-        padding: const EdgeInsets.only(
-          top: MinglitSpacing.small,
-          bottom: MinglitSpacing.medium,
-        ),
-        sliver: SliverList.separated(
-          itemCount: 5,
-          separatorBuilder: (_, _) =>
-              const SizedBox(height: MinglitSpacing.small),
-          itemBuilder: (_, _) => const MinglitEventCard.loading(),
-        ),
-      );
+    padding: const EdgeInsets.only(
+      top: MinglitSpacing.small,
+      bottom: MinglitSpacing.medium,
+    ),
+    sliver: SliverList.separated(
+      itemCount: 5,
+      separatorBuilder: (_, _) => const SizedBox(height: MinglitSpacing.small),
+      itemBuilder: (_, _) => const MinglitEventCard.loading(),
+    ),
+  );
 }

--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -193,10 +193,9 @@ class _HomePageState extends ConsumerState<HomePage> {
                 }
                 // First page fully filtered client-side: show loading while
                 // auto-fetch (triggered by ref.listen above) loads next page.
+                // Fix #1856: shimmer skeleton instead of progress indicator
                 if (state.events.isEmpty) {
-                  return const SliverFillRemaining(
-                    child: Center(child: MinglitCircularProgressIndicator()),
-                  );
+                  return _eventFeedSkeleton();
                 }
                 return SliverPadding(
                   padding: const EdgeInsets.only(
@@ -218,9 +217,8 @@ class _HomePageState extends ConsumerState<HomePage> {
                   ),
                 );
               },
-              loading: () => const SliverFillRemaining(
-                child: Center(child: MinglitCircularProgressIndicator()),
-              ),
+              // Fix #1856: shimmer skeleton instead of progress indicator
+              loading: _eventFeedSkeleton,
               // Fix #192: 피드 로드 실패 시 에러 메시지와 재시도 버튼 표시
               error: (_, _) => SliverFillRemaining(
                 child: Center(
@@ -259,4 +257,18 @@ class _HomePageState extends ConsumerState<HomePage> {
       ),
     );
   }
+
+  // Fix #1856: skeleton list to replace progress indicator during initial feed load
+  static Widget _eventFeedSkeleton() => SliverPadding(
+        padding: const EdgeInsets.only(
+          top: MinglitSpacing.small,
+          bottom: MinglitSpacing.medium,
+        ),
+        sliver: SliverList.separated(
+          itemCount: 5,
+          separatorBuilder: (_, _) =>
+              const SizedBox(height: MinglitSpacing.small),
+          itemBuilder: (_, _) => const MinglitEventCard.loading(),
+        ),
+      );
 }

--- a/apps/app_user/test/integration/flow_event_browse_test.dart
+++ b/apps/app_user/test/integration/flow_event_browse_test.dart
@@ -19,7 +19,8 @@ void main() {
 
   group('이벤트 탐색 플로우 — 홈→상세→파트너', () {
     // ── 홈 화면: AsyncLoading ──
-    testWidgets('홈 AsyncLoading → MinglitCircularProgressIndicator 표시', (
+    // Fix #1856: loading state now shows skeleton cards instead of progress indicator
+    testWidgets('홈 AsyncLoading → skeleton card 표시', (
       tester,
     ) async {
       setKoreanLocale(tester);
@@ -34,7 +35,7 @@ void main() {
       );
       await tester.pump();
 
-      expect(find.byType(MinglitCircularProgressIndicator), findsOneWidget);
+      expect(find.byType(MinglitEventCard), findsWidgets);
     });
 
     // ── 홈 화면: AsyncError ──

--- a/apps/app_user/test/src/features/home/home_page_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:app_user/src/features/home/home_page.dart';
 import 'package:app_user/src/features/home/widgets/event_now_bar.dart';
 import 'package:app_user/src/features/home/widgets/event_now_bar_controller.dart';
@@ -138,9 +140,32 @@ void main() {
       expect(find.text('Test Party Event'), findsOneWidget);
     });
 
+    // Fix #1856: initial feed loading shows skeleton cards, not progress indicator
+    testWidgets('Fix #1856: shows skeleton cards during initial feed loading', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        createTestWidget(
+          overrides: [
+            recommendationFeedProvider.overrideWith(
+              _MockLoadingSkeletonNotifier.new,
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(MinglitEventCard), findsWidgets);
+      expect(find.byType(MinglitCircularProgressIndicator), findsNothing);
+    });
+
     testWidgets('shows loading indicator when isLoadingMore is true', (
       tester,
     ) async {
+      // Use a tall viewport so the event card + progress indicator both fit
+      await tester.binding.setSurfaceSize(const Size(800, 2000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
       await tester.pumpWidget(
         createTestWidget(
           overrides: [
@@ -153,6 +178,7 @@ void main() {
       await tester.pump();
 
       // Fix #113: SliverFillRemaining fills viewport, SliverToBoxAdapter skips
+      // isLoadingMore shows progress indicator below the existing event list
       expect(find.byType(MinglitCircularProgressIndicator), findsOneWidget);
     });
 
@@ -398,13 +424,24 @@ class _NoFiltersNotifier extends ActiveFilters {
   ExploreFilters build() => const ExploreFilters();
 }
 
-/// A notifier that returns isLoadingMore=true to test the loading indicator.
+/// Fix #1856: notifier that stays in AsyncLoading (build never resolves) to
+/// verify the loading: branch shows skeleton cards, not a progress indicator.
+class _MockLoadingSkeletonNotifier extends RecommendationFeedNotifier {
+  @override
+  Future<RecommendationFeedState> build() {
+    // Never completes — keeps provider in AsyncLoading so we enter loading: branch
+    return Completer<RecommendationFeedState>().future;
+  }
+}
+
+/// A notifier that returns isLoadingMore=true with existing events to test
+/// the pagination loading indicator (realistic: loading more after initial load).
 class _MockLoadingMoreNotifier extends RecommendationFeedNotifier {
   @override
   Future<RecommendationFeedState> build() async {
-    return const RecommendationFeedState(
-      events: [],
-      serverOffset: 0,
+    return RecommendationFeedState(
+      events: [_makeFeedEvent(0)],
+      serverOffset: 1,
       hasMore: true,
       isLoadingMore: true,
     );

--- a/apps/app_user/test/widget_test.dart
+++ b/apps/app_user/test/widget_test.dart
@@ -95,8 +95,8 @@ void main() {
     );
 
     await tester.pump();
-    expect(find.byType(MinglitCircularProgressIndicator), findsOneWidget);
-    // completer never resolved → always loading
+    // Fix #1856: loading state now shows skeleton cards instead of progress indicator
+    expect(find.byType(MinglitEventCard), findsWidgets);
   });
 
   testWidgets('HomePage shows empty state text when no events returned', (


### PR DESCRIPTION
## Summary

- 메인 피드 초기 로딩 시 중앙 `MinglitCircularProgressIndicator`와 하단 `EventNowBar` shimmer가 동시에 노출되던 시각 충돌 수정 (#1856)
- `loading:` 브랜치와 "첫 페이지 클라이언트 필터링 대기" 브랜치 모두 `MinglitEventCard.loading()` skeleton 5개로 교체
- 무한스크롤 `isLoadingMore` progress indicator는 유지 (페이지 추가 로딩 알림에 적합한 패턴)

## Test plan

- [x] `flutter analyze lib/src/features/home/home_page.dart` — warning 없음 (info only)
- [x] `flutter test test/src/features/home/home_page_test.dart` — 14/14 통과 (Fix #1856 회귀 테스트 포함)
- [ ] 기기에서 메인 화면 진입 시 shimmer skeleton만 표시되는지 확인 (progress + shimmer 중복 없음)

Closes #1856

🤖 Generated with [Claude Code](https://claude.com/claude-code)