### PR TITLE
feat(db): drop temp diagnostic SECURITY DEFINER functions

### DIFF
--- a/supabase/migrations/20260427000001_cleanup_temp_diag_functions.sql
+++ b/supabase/migrations/20260427000001_cleanup_temp_diag_functions.sql
@@ -1,0 +1,5 @@
+-- Fix #1870: Drop temporary diagnostic SECURITY DEFINER functions added for
+-- auth debugging. These are no longer needed in production.
+DROP FUNCTION IF EXISTS public.temp_auth_diag();
+DROP FUNCTION IF EXISTS public.temp_auth_diag2();
+DROP FUNCTION IF EXISTS public.temp_compare_users();

--- a/supabase/tests/database/99_cleanup_temp_diag_functions_test.sql
+++ b/supabase/tests/database/99_cleanup_temp_diag_functions_test.sql
@@ -1,0 +1,33 @@
+-- pgTAP test: verify temp diagnostic SECURITY DEFINER functions are removed
+BEGIN;
+SELECT plan(3);
+
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'temp_auth_diag'
+  ),
+  'temp_auth_diag() should not exist'
+);
+
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'temp_auth_diag2'
+  ),
+  'temp_auth_diag2() should not exist'
+);
+
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'temp_compare_users'
+  ),
+  'temp_compare_users() should not exist'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary

- Drops `public.temp_auth_diag()`, `public.temp_auth_diag2()`, `public.temp_compare_users()` — temporary diagnostic functions added for one-off auth debugging, no longer needed
- Migration uses `DROP FUNCTION IF EXISTS` so it is safe even if the functions were already removed manually
- Adds pgTAP test (`99_cleanup_temp_diag_functions_test.sql`) to assert all three functions are absent

## Test plan
- [ ] `test-supabase` CI job runs pgTAP and passes all 3 new assertions
- [ ] `check-migration-versions` passes (new `20260427000001` version)

Closes #1870

🤖 Generated with [Claude Code](https://claude.com/claude-code)