### PR TITLE
docs: clarify V1 SDK + V2 backend for identity verification

### DIFF
--- a/docs/architecture/client.md
+++ b/docs/architecture/client.md
@@ -27,14 +27,14 @@ minglit_kit/lib/src/features/
 ├── auth/           # 로그인, 회원가입, OAuth
 ├── consent/        # 이용약관/개인정보 동의 관리 (동의 화면, 동의 이력 추적)
 ├── dev/            # 개발 유틸리티 (세션 스위처, 미리보기)
-├── iamport/        # 결제 연동 (Iamport SDK 래퍼)
+├── iamport/        # 결제 연동 + 본인인증 UI 진입점 (Iamport V1 SDK 래퍼 — 결제·본인인증 양쪽 사용)
 ├── loading/        # 글로벌 로딩 오버레이
 ├── notification/   # 푸시 알림, FCM, 알림 목록/설정
 ├── search/         # 전문 검색 (PGroonga)
 ├── social/         # 소셜 기능 (좋아요, 구독, 차단)
 ├── permission/     # 앱 권한 설정 (카메라, 위치 등 시스템 권한 관리 화면)
 ├── theme/          # 테마 모드 컨트롤러 (라이트/다크/시스템)
-└── verification/   # 본인인증 (Identity Verification) — Iamport V2 기반 실명 인증 화면
+└── verification/   # 본인인증 (Identity Verification) — 클라이언트: minglit_iamport_v1(V1 SDK), 백엔드 검증: Edge Function identity-verify(Portone V2)
 ```
 
 #### app_user Features
@@ -144,7 +144,7 @@ Minglit은 **"신뢰(Trust)"**를 가장 중요한 자산으로 취급하며, �
 ### 5.1 Layer 1: Identity (신원)
 *   **정의**: "이 사람은 실존하며, 주장하는 나이/성별이 맞는가?"
 *   **데이터**: `user_profiles` 테이블 (`birth_date`, `gender`, `is_verified`).
-*   **검증 주체**: 플랫폼 (Iamport 본인인증 API).
+*   **검증 주체**: 플랫폼 — 클라이언트 SDK: `minglit_iamport_v1`(Iamport V1), 백엔드 검증: Edge Function `identity-verify`(Portone V2 API). V1 SDK + V2 백엔드 병행 구조.
 *   **특징**: 모든 유저가 갖춰야 할 **기본 자격(Base Layer)**. 파트너 승인이 불필요하며, 즉시 필터링(나이 제한 등)에 사용됩니다.
 
 ### 5.2 Layer 2: Qualification (자격)

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -150,7 +150,7 @@ Minglit은 **"신뢰(Trust)"**를 핵심 자산으로 취급하며, 2단계 레�
 
 - **정의**: "이 사람은 실존하며, 주장하는 나이/성별이 맞는가?"
 - **데이터**: `user_profiles` 테이블 (`birth_date`, `gender`, `is_verified`)
-- **검증 주체**: 플랫폼 (Iamport 본인인증 API)
+- **검증 주체**: 플랫폼 — 클라이언트 SDK는 `minglit_iamport_v1`(Iamport V1), 백엔드 검증은 Edge Function `identity-verify`(Portone V2 API)
 - **특징**: 모든 유저의 기본 자격. 나이 제한 필터링 등에 즉시 사용.
 
 ### 4.2 Layer 2: Qualification (자격)

--- a/docs/architecture/trust-and-verification.md
+++ b/docs/architecture/trust-and-verification.md
@@ -26,7 +26,9 @@ Layer 2 (Qualification): user_verifications → verification_submissions → par
 ## 2. Layer 1 — Identity Verification
 
 ### 2.1 Flow
-User App → Portone SDK → identity-verify → user_profiles 업데이트
+User App (minglit_iamport_v1 SDK) → identity-verify EF → user_profiles 업데이트
+
+> **클라이언트 SDK 현황**: 클라이언트는 `minglit_iamport_v1` (Iamport V1 SDK)를 사용해 본인인증 UI를 띄운다. 백엔드 Edge Function `identity-verify`는 Portone V2 API로 검증한다. V1 SDK + V2 백엔드 혼용 구조이며, SDK V2 전환은 별도 에픽으로 추적 중.
 
 ### 2.2 Edge Functions
 - `identity-verify`: Portone V2 API를 사용한다. `getIdentityVerification(identity_verification_id)` 호출 후 `status === "VERIFIED"` 임을 확인한다. `verifiedCustomer` 데이터를 추출하여 `update_user_identity` RPC를 호출해 name, birth_date, gender, phone_number와 CI/DI(암호화 저장)를 업데이트하고 is_verified를 true로 설정한다.


### PR DESCRIPTION
## Summary

- `docs/architecture/overview.md`: '검증 주체' line now explicitly names `minglit_iamport_v1` (client SDK, V1) and Edge Function `identity-verify` (Portone V2 API, backend)
- `docs/architecture/client.md`: corrects `iamport/` feature comment (결제 + 본인인증 양쪽 명시), fixes `verification/` from misleading "Iamport V2 기반" to accurate V1 SDK + V2 backend description
- `docs/architecture/trust-and-verification.md`: flow line updated, adds callout explaining V1/V2 coexistence; SDK migration tracked as separate epic

No code changes — docs-only fix.

## Test plan
- [ ] `grep -r "Iamport V2" docs/architecture/` returns zero results
- [ ] `grep -r "minglit_iamport_v1" docs/architecture/` matches `grep -r "minglit_iamport_v1" shared/packages/minglit_kit/lib/src/features/verification`

Closes #1871

🤖 Generated with [Claude Code](https://claude.com/claude-code)