### PR TITLE
feat(lint): block new cross-feature imports via CI check

### DIFF
--- a/.cross-feature-import-baseline
+++ b/.cross-feature-import-baseline
@@ -1,0 +1,23 @@
+# Cross-feature import baseline — Fix #1872
+# Each line is a grandfathered violation in the format:
+#   <relative-path-from-features>: <src_feature> -> <tgt_feature>
+# Remove a line here once the corresponding import is cleaned up.
+# DO NOT add new entries — fix the import instead.
+
+# app_user (13 violations as of 2026-04-27)
+account_deletion/ui/deletion_complete_page.dart: account_deletion -> home
+event/admission/event_admission_controller.dart: event -> auth
+event/admission/event_admission_controller.dart: event -> home
+event/logic/event_coordinator.dart: event -> ticket
+home/logic/home_coordinator.dart: home -> ticket
+home/my_page.dart: home -> auth
+home/widgets/featured_tag_chip_bar.dart: home -> tag
+home/widgets/trending_tag_section.dart: home -> tag
+my_tickets/ui/my_tickets_page.dart: my_tickets -> home
+my_tickets/ui/my_tickets_page.dart: my_tickets -> ticket
+settings/privacy_page.dart: settings -> account_deletion
+settings/privacy_page.dart: settings -> consent
+tag/ui/tag_event_list_page.dart: tag -> event
+
+# app_partner (1 violation as of 2026-04-27)
+party/event/create/event_create_controller.dart: party -> home

--- a/.cross-feature-import-baseline
+++ b/.cross-feature-import-baseline
@@ -19,5 +19,6 @@ settings/privacy_page.dart: settings -> account_deletion
 settings/privacy_page.dart: settings -> consent
 tag/ui/tag_event_list_page.dart: tag -> event
 
-# app_partner (1 violation as of 2026-04-27)
+# app_partner (2 violations as of 2026-04-27)
+application/event_application_detail_page.dart: application -> party
 party/event/create/event_create_controller.dart: party -> home

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,8 +406,16 @@ jobs:
           fi
           echo "✅ runner $RUNNER and orchestrator $ORCHESTRATOR are compatible ($RUNNER_MINOR series)"
 
+  # Fix #1872: block new cross-feature imports; existing violations are grandfathered in baseline
+  check-cross-feature-imports:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check cross-feature imports
+        run: bash scripts/check-cross-feature-imports.sh
+
   ci-result:
-    needs: [check-migration-versions, check-env-manifest-sync, check-workflow-yaml, check-android-test-deps, test-flutter-apps, lint-landing-user, lint-landing-partner, test-supabase, test-edge-functions]
+    needs: [check-migration-versions, check-env-manifest-sync, check-workflow-yaml, check-android-test-deps, check-cross-feature-imports, test-flutter-apps, lint-landing-user, lint-landing-partner, test-supabase, test-edge-functions]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/scripts/check-cross-feature-imports.sh
+++ b/scripts/check-cross-feature-imports.sh
@@ -4,8 +4,9 @@
 # Violations that exist in .cross-feature-import-baseline are allowed (grandfathered).
 # Any NEW violation causes a non-zero exit.
 #
-# A cross-feature import is: feature X imports from feature Y (X != Y)
-# via `import 'package:<app>/src/features/<Y>/...`
+# Detects two forms of cross-feature import (feature X importing from Y, X != Y):
+#   1. package imports:  import 'package:<app>/src/features/<Y>/...'
+#   2. relative imports: import '../<Y>/...' (resolved via Python path normalisation)
 #
 # Fix #1872: enforce no new cross-feature imports; existing violations are
 # tracked in .cross-feature-import-baseline pending removal (#1872 follow-ups).
@@ -30,6 +31,7 @@ check_app() {
 
     # Scan each import line for a cross-feature reference
     while IFS= read -r line; do
+      # 1. package: imports
       if [[ "$line" =~ import\ \'package:${pkg}/src/features/([^/\']+)/ ]]; then
         tgt_feature="${BASH_REMATCH[1]}"
         if [[ "$tgt_feature" != "$src_feature" ]]; then
@@ -37,6 +39,26 @@ check_app() {
           if ! grep -qxF "$entry" "$BASELINE_FILE" 2>/dev/null; then
             NEW_VIOLATIONS+=("$app/$entry")
             FAIL=1
+          fi
+        fi
+      fi
+
+      # 2. relative imports starting with ../
+      if [[ "$line" =~ import\ \'(\.\.[^\']*)\'  ]]; then
+        rel_import="${BASH_REMATCH[1]}"
+        file_dir="$(dirname "$dart_file")"
+        # Normalise the relative path using Python (available on all CI runners)
+        import_resolved="$(python3 -c "import os,sys; print(os.path.normpath(os.path.join(sys.argv[1], sys.argv[2])))" "$file_dir" "$rel_import" 2>/dev/null || true)"
+        # Check whether the resolved path falls inside a different feature
+        if [[ "$import_resolved" == "${features_dir}/"* ]]; then
+          import_inner="${import_resolved#${features_dir}/}"
+          tgt_feature_rel="${import_inner%%/*}"
+          if [[ -n "$tgt_feature_rel" && "$tgt_feature_rel" != "$src_feature" ]]; then
+            entry="${rel}: ${src_feature} -> ${tgt_feature_rel}"
+            if ! grep -qxF "$entry" "$BASELINE_FILE" 2>/dev/null; then
+              NEW_VIOLATIONS+=("$app/$entry")
+              FAIL=1
+            fi
           fi
         fi
       fi

--- a/scripts/check-cross-feature-imports.sh
+++ b/scripts/check-cross-feature-imports.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# check-cross-feature-imports.sh
+# Detects cross-feature imports inside apps/app_user and apps/app_partner.
+# Violations that exist in .cross-feature-import-baseline are allowed (grandfathered).
+# Any NEW violation causes a non-zero exit.
+#
+# A cross-feature import is: feature X imports from feature Y (X != Y)
+# via `import 'package:<app>/src/features/<Y>/...`
+#
+# Fix #1872: enforce no new cross-feature imports; existing violations are
+# tracked in .cross-feature-import-baseline pending removal (#1872 follow-ups).
+
+set -euo pipefail
+
+BASELINE_FILE="${BASELINE_FILE:-.cross-feature-import-baseline}"
+FAIL=0
+NEW_VIOLATIONS=()
+
+check_app() {
+  local app="$1"          # e.g. apps/app_user
+  local pkg="$2"          # e.g. app_user
+  local features_dir="${app}/lib/src/features"
+
+  [[ -d "$features_dir" ]] || return 0
+
+  while IFS= read -r -d '' dart_file; do
+    # Derive source feature from path
+    rel="${dart_file#${features_dir}/}"
+    src_feature="${rel%%/*}"
+
+    # Scan each import line for a cross-feature reference
+    while IFS= read -r line; do
+      if [[ "$line" =~ import\ \'package:${pkg}/src/features/([^/\']+)/ ]]; then
+        tgt_feature="${BASH_REMATCH[1]}"
+        if [[ "$tgt_feature" != "$src_feature" ]]; then
+          entry="${rel}: ${src_feature} -> ${tgt_feature}"
+          if ! grep -qxF "$entry" "$BASELINE_FILE" 2>/dev/null; then
+            NEW_VIOLATIONS+=("$app/$entry")
+            FAIL=1
+          fi
+        fi
+      fi
+    done < "$dart_file"
+  done < <(find "$features_dir" -name "*.dart" -print0)
+}
+
+check_app "apps/app_user"    "app_user"
+check_app "apps/app_partner" "app_partner"
+
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "✅ No new cross-feature imports detected."
+  exit 0
+fi
+
+echo "❌ New cross-feature imports found (not in baseline):"
+for v in "${NEW_VIOLATIONS[@]}"; do
+  echo "  $v"
+done
+echo ""
+echo "To grandfather an existing violation, add it to $BASELINE_FILE."
+echo "To fix it properly, route through a shared module or coordinator."
+exit 1


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1872

## Summary

- `scripts/check-cross-feature-imports.sh`: 새 cross-feature import 감지 스크립트 (bash + grep, zero-dependency)
- `.cross-feature-import-baseline`: 기존 위반 14건 grandfather 처리
- `.github/workflows/ci.yml`: `check-cross-feature-imports` job 추가 → `ci-result` 게이트에 포함

## 동작 방식

`apps/app_user/lib/src/features/<X>/...`에서 `package:app_user/src/features/<Y>/...` import 시 `X != Y`이면 violation으로 판단. baseline에 없는 신규 위반만 fail.

## 선택한 구현 방법

- **Option C (grep/bash)** 채택: custom_lint는 새 패키지 + Dart plugin infra가 필요해 도입 비용이 큼. bash+grep은 CI-native, zero-dependency, 즉시 적용 가능.
- 기존 14건은 baseline에 grandfather → 이후 별도 이슈로 순차 해소 예정.

## 검증

```bash
# 신규 위반 시 fail
bash scripts/check-cross-feature-imports.sh
# ❌ New cross-feature imports found...

# baseline 위반은 통과
# ✅ No new cross-feature imports detected.
```