### PR TITLE
chore(todo): annotate untracked TODOs with tracking issue refs

### DIFF
--- a/apps/app_user/lib/src/logic/feed_state_provider.dart
+++ b/apps/app_user/lib/src/logic/feed_state_provider.dart
@@ -442,8 +442,8 @@ class RecommendationFeedNotifier extends _$RecommendationFeedNotifier {
 /// - closingSoon → closingSoon
 /// - nearestDate → nearest
 ///
-// TODO: migrate to [recommendationEventsFromEf] once the user-event-feed EF
-// is validated in production.
+// TODO(#1891): migrate to [recommendationEventsFromEf] once the user-event-feed
+// EF is validated in production.
 @riverpod
 Future<List<Event>> recommendationEvents(Ref ref) async {
   final filters = ref.watch(activeFiltersProvider);
@@ -476,8 +476,8 @@ Future<List<Event>> recommendationEvents(Ref ref) async {
 /// and cursor pagination are handled by the DB function, so no
 /// client-side post-processing is needed.
 ///
-// TODO: wire this into the explore UI behind a feature flag, then remove the
-// legacy [recommendationEvents] path.
+// TODO(#1891): wire this into the explore UI behind a feature flag, then
+// remove the legacy [recommendationEvents] path.
 @riverpod
 Future<Map<String, dynamic>> recommendationEventsFromEf(Ref ref) async {
   final filters = ref.watch(activeFiltersProvider);

--- a/supabase/functions/payment-webhook/index.ts
+++ b/supabase/functions/payment-webhook/index.ts
@@ -1,4 +1,4 @@
-// TODO: verify_jwt=false 설정 후, 포트원 서버 호출자 검증 강화 필요
+// TODO(#1892): verify_jwt=false 설정 후, 포트원 서버 호출자 검증 강화 필요
 // 현재: IP whitelist만 사용 (ALLOWED_IPS)
 // 추가 필요: 포트원 V1 webhook signature 검증 또는 HMAC 검증
 // 참고: V1은 HMAC 미지원이므로 IP whitelist가 1차 보안. 추가 보안 레이어 검토 필요.
@@ -125,7 +125,7 @@ Deno.serve(withHandler(async (req) => {
 
       if (application) {
         logStatsigEvent(application.user_id, 'payment_completed', payment.amount, { imp_uid, merchant_uid }).catch(() => {});
-        // TODO: Migrate to produce_event() pattern via q_global_events
+        // TODO(#1892): Migrate to produce_event() pattern via q_global_events
         // Currently sends directly to q_notifications, bypassing 2-tier architecture
         // See: docs/architecture/global-event-pipeline.md
         await supabase.rpc("pgmq_send", {


### PR DESCRIPTION
Scheduler: needs-tpm-claude-1

Closes #1875

## Summary
Audit 리포트 #1867 (audit-arch §6)에서 발견된 추적 번호 없는 TODO 4건에 GitHub 이슈 번호를 부여한다. TPM 트리아지(#1875)의 후속.

| 파일 | 라인 | 부여한 이슈 |
|------|------|------------|
| apps/app_user/lib/src/logic/feed_state_provider.dart | L445 | #1891 |
| apps/app_user/lib/src/logic/feed_state_provider.dart | L479 | #1891 |
| supabase/functions/payment-webhook/index.ts | L1 | #1892 |
| supabase/functions/payment-webhook/index.ts | L128 | #1892 |

생성한 추적 이슈:
- #1891 — refactor(feed): legacy recommendationEvents → recommendationEventsFromEf 컷오버 (needs-arch, P3)
- #1892 — security/refactor(payment-webhook): 호출자 검증 강화 + produce_event() 컷오버 (needs-security, P2)

## Test plan
- [ ] CI green (no functional change — comment-only diff)
- [ ] flutter analyze 통과