### PR TITLE
fix(payment-webhook): strengthen caller validation (H1 prod 127.0.0.1 removal, H2 XFF parsing)

### DIFF
--- a/supabase/functions/payment-webhook/index.ts
+++ b/supabase/functions/payment-webhook/index.ts
@@ -32,11 +32,14 @@ Deno.serve(withHandler(async (req) => {
     const rawBody = await req.text();
 
     // 1. IP Validation (Primary Security Layer for V1 — V1 has no HMAC signing)
-    // Fix #1892 H2: x-real-ip를 1순위로 신뢰 (Supabase Edge/Cloudflare가 실제 클라이언트 IP로 설정).
-    // x-real-ip 없을 때 XFF fallback: 가장 오른쪽 값(프록시가 마지막으로 추가한 hop) 사용.
-    // XFF leftmost는 클라이언트가 임의 조작 가능하므로 신뢰하지 않음.
+    // Fix #1892 H2: 우선순위 — edge/CDN이 주입하는 헤더를 신뢰, 클라이언트가 조작 가능한 leftmost XFF 금지.
+    //   1) x-real-ip: Supabase Edge/CDN이 실제 연결 IP로 설정
+    //   2) cf-connecting-ip: Cloudflare가 설정하는 클라이언트 IP (Supabase가 CF 인프라 사용 시)
+    //   3) XFF rightmost fallback: CDN이 XFF에 연결 IP를 append하는 구조에서의 안전한 fallback.
+    //      leftmost는 클라이언트가 임의 조작 가능하므로 사용하지 않음.
     const clientIp =
       req.headers.get("x-real-ip")?.trim() ||
+      req.headers.get("cf-connecting-ip")?.trim() ||
       req.headers.get("x-forwarded-for")?.split(",").map((s) => s.trim()).filter(Boolean).pop() ||
       "";
 

--- a/supabase/functions/payment-webhook/index.ts
+++ b/supabase/functions/payment-webhook/index.ts
@@ -1,7 +1,5 @@
-// TODO(#1892): verify_jwt=false 설정 후, 포트원 서버 호출자 검증 강화 필요
-// 현재: IP whitelist만 사용 (ALLOWED_IPS)
-// 추가 필요: 포트원 V1 webhook signature 검증 또는 HMAC 검증
-// 참고: V1은 HMAC 미지원이므로 IP whitelist가 1차 보안. 추가 보안 레이어 검토 필요.
+// Fix #1892: 호출자 검증 강화 (H1 — 127.0.0.1 prod 제거, H2 — XFF 파싱 개선)
+// V1은 HMAC 미지원이므로 IP whitelist + Portone cross-check가 방어선. V2 마이그레이션 시 HMAC 추가 가능.
 // Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
 import { createServiceClient } from "../_shared/supabase_client.ts";
 import { IamportClient } from "../_shared/iamport_client.ts";
@@ -19,7 +17,12 @@ if (!IMP_KEY || !IMP_SECRET) {
 }
 
 // Portone (Iamport V1) Webhook IP Whitelist
-const ALLOWED_IPS = ["52.78.100.19", "52.78.48.223", "52.78.17.128", "127.0.0.1"];
+// Fix #1892 H1: 127.0.0.1은 dev 환경에서만 허용 — production에서 localhost를 허용하면
+// X-Forwarded-For 스푸핑으로 IP 게이트가 무력화될 수 있음
+const _IS_DEV_ENV = Deno.env.get("ENVIRONMENT") === "dev";
+const ALLOWED_IPS = _IS_DEV_ENV
+  ? ["52.78.100.19", "52.78.48.223", "52.78.17.128", "127.0.0.1"]
+  : ["52.78.100.19", "52.78.48.223", "52.78.17.128"];
 
 initSentry();
 initStatsig();
@@ -29,8 +32,13 @@ Deno.serve(withHandler(async (req) => {
     const rawBody = await req.text();
 
     // 1. IP Validation (Primary Security Layer for V1 — V1 has no HMAC signing)
-    const forwardedFor = req.headers.get("x-forwarded-for");
-    const clientIp = forwardedFor ? forwardedFor.split(",")[0].trim() : "";
+    // Fix #1892 H2: x-real-ip를 1순위로 신뢰 (Supabase Edge/Cloudflare가 실제 클라이언트 IP로 설정).
+    // x-real-ip 없을 때 XFF fallback: 가장 오른쪽 값(프록시가 마지막으로 추가한 hop) 사용.
+    // XFF leftmost는 클라이언트가 임의 조작 가능하므로 신뢰하지 않음.
+    const clientIp =
+      req.headers.get("x-real-ip")?.trim() ||
+      req.headers.get("x-forwarded-for")?.split(",").map((s) => s.trim()).filter(Boolean).pop() ||
+      "";
 
     if (!clientIp || !ALLOWED_IPS.includes(clientIp)) {
       log({ function: FN, level: "warn", message: `Blocked Webhook Request from unauthorized IP: ${clientIp || "(empty)"}` });

--- a/supabase/functions/payment-webhook/payment_webhook_test.ts
+++ b/supabase/functions/payment-webhook/payment_webhook_test.ts
@@ -152,6 +152,40 @@ Deno.test("payment-webhook - spoofed XFF first hop blocked", async () => {
   });
 });
 
+// Fix #1892 H2: cf-connecting-ip — x-real-ip 부재 시 Cloudflare 설정 헤더로 인증
+Deno.test("payment-webhook - cf-connecting-ip accepted when x-real-ip absent", async () => {
+  await withEnv(ENV, async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: "https://api.iamport.kr/users/getToken",
+        handler: () => jsonResponse({ code: 0, response: { access_token: "token" } }),
+      },
+      {
+        matcher: "https://api.iamport.kr/payments/imp_cfip",
+        handler: () => jsonResponse({ code: 0, response: { merchant_uid: "order-cfip", status: "paid" } }),
+      },
+      {
+        matcher: (req) => req.url.includes("/rest/v1/event_applications") && req.method === "PATCH",
+        handler: () => jsonResponse({}),
+      },
+    ]);
+
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        // x-real-ip 없이 cf-connecting-ip만 있는 경우 — Cloudflare 인프라에서 발생
+        const request = jsonRequest(
+          "http://localhost",
+          { imp_uid: "imp_cfip", merchant_uid: "order-cfip", status: "paid" },
+          { headers: { "cf-connecting-ip": PORTONE_IP } },
+        );
+        const response = await handler(request);
+        assertEquals(response.status, 200);
+      });
+    });
+  });
+});
+
 // Fix #1892 H2: x-real-ip가 XFF보다 우선 적용됨
 Deno.test("payment-webhook - x-real-ip takes precedence over XFF", async () => {
   await withEnv(ENV, async () => {

--- a/supabase/functions/payment-webhook/payment_webhook_test.ts
+++ b/supabase/functions/payment-webhook/payment_webhook_test.ts
@@ -17,6 +17,11 @@ const ENV = {
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
 };
 
+const DEV_ENV = { ...ENV, ENVIRONMENT: "dev" };
+
+// Real Portone webhook IP (used in non-dev tests to pass IP gate)
+const PORTONE_IP = "52.78.100.19";
+
 Deno.test("payment-webhook - happy path updates status", async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
@@ -40,7 +45,7 @@ Deno.test("payment-webhook - happy path updates status", async () => {
         const request = jsonRequest(
           "http://localhost",
           { imp_uid: "imp_abc", merchant_uid: "order-123", status: "paid" },
-          { headers: { "x-forwarded-for": "127.0.0.1" } },
+          { headers: { "x-real-ip": PORTONE_IP } },
         );
         const response = await handler(request);
         assertEquals(response.status, 200);
@@ -70,6 +75,117 @@ Deno.test("payment-webhook - unauthorized IP returns 403", async () => {
   });
 });
 
+// Fix #1892 H1: 127.0.0.1은 production에서 차단되어야 함
+Deno.test("payment-webhook - localhost IP blocked in production", async () => {
+  await withEnv(ENV, async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([]);
+
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = jsonRequest(
+          "http://localhost",
+          { imp_uid: "imp_abc", merchant_uid: "order-123", status: "paid" },
+          { headers: { "x-forwarded-for": "127.0.0.1" } },
+        );
+        const response = await handler(request);
+        assertEquals(response.status, 403);
+        assertEquals(await response.text(), "Unauthorized IP");
+      });
+    });
+  });
+});
+
+// Fix #1892 H1: ENVIRONMENT=dev에서는 127.0.0.1 허용
+Deno.test("payment-webhook - localhost IP allowed in dev env", async () => {
+  await withEnv(DEV_ENV, async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: "https://api.iamport.kr/users/getToken",
+        handler: () => jsonResponse({ code: 0, response: { access_token: "token" } }),
+      },
+      {
+        matcher: "https://api.iamport.kr/payments/imp_dev",
+        handler: () => jsonResponse({ code: 0, response: { merchant_uid: "order-dev", status: "paid" } }),
+      },
+      {
+        matcher: (req) => req.url.includes("/rest/v1/event_applications") && req.method === "PATCH",
+        handler: () => jsonResponse({}),
+      },
+    ]);
+
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = jsonRequest(
+          "http://localhost",
+          { imp_uid: "imp_dev", merchant_uid: "order-dev", status: "paid" },
+          { headers: { "x-forwarded-for": "127.0.0.1" } },
+        );
+        const response = await handler(request);
+        assertEquals(response.status, 200);
+      });
+    });
+  });
+});
+
+// Fix #1892 H2: XFF leftmost 스푸핑 차단 — 가장 오른쪽 값을 신뢰
+Deno.test("payment-webhook - spoofed XFF first hop blocked", async () => {
+  await withEnv(ENV, async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([]);
+
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        // 공격자가 whitelist IP를 XFF 앞에 넣고 자신의 IP를 뒤에 붙임
+        const request = jsonRequest(
+          "http://localhost",
+          { imp_uid: "imp_abc", merchant_uid: "order-123", status: "paid" },
+          { headers: { "x-forwarded-for": `${PORTONE_IP}, evil.example.com` } },
+        );
+        const response = await handler(request);
+        // rightmost(evil.example.com)가 선택되므로 403
+        assertEquals(response.status, 403);
+        assertEquals(await response.text(), "Unauthorized IP");
+      });
+    });
+  });
+});
+
+// Fix #1892 H2: x-real-ip가 XFF보다 우선 적용됨
+Deno.test("payment-webhook - x-real-ip takes precedence over XFF", async () => {
+  await withEnv(ENV, async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: "https://api.iamport.kr/users/getToken",
+        handler: () => jsonResponse({ code: 0, response: { access_token: "token" } }),
+      },
+      {
+        matcher: "https://api.iamport.kr/payments/imp_realip",
+        handler: () => jsonResponse({ code: 0, response: { merchant_uid: "order-realip", status: "paid" } }),
+      },
+      {
+        matcher: (req) => req.url.includes("/rest/v1/event_applications") && req.method === "PATCH",
+        handler: () => jsonResponse({}),
+      },
+    ]);
+
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        // x-real-ip에 실제 Portone IP, XFF에 나쁜 IP — x-real-ip 우선
+        const request = jsonRequest(
+          "http://localhost",
+          { imp_uid: "imp_realip", merchant_uid: "order-realip", status: "paid" },
+          { headers: { "x-real-ip": PORTONE_IP, "x-forwarded-for": "evil.example.com" } },
+        );
+        const response = await handler(request);
+        assertEquals(response.status, 200);
+      });
+    });
+  });
+});
+
 Deno.test("payment-webhook - missing params returns 400", async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
@@ -80,7 +196,7 @@ Deno.test("payment-webhook - missing params returns 400", async () => {
         const request = jsonRequest(
           "http://localhost",
           { status: "paid" },
-          { headers: { "x-forwarded-for": "127.0.0.1" } },
+          { headers: { "x-real-ip": PORTONE_IP } },
         );
         const response = await handler(request);
         assertEquals(response.status, 400);
@@ -109,7 +225,7 @@ Deno.test("payment-webhook - merchant UID mismatch returns 400", async () => {
         const request = jsonRequest(
           "http://localhost",
           { imp_uid: "imp_abc", merchant_uid: "order-123" },
-          { headers: { "x-forwarded-for": "127.0.0.1" } },
+          { headers: { "x-real-ip": PORTONE_IP } },
         );
         const response = await handler(request);
         assertEquals(response.status, 400);
@@ -134,7 +250,7 @@ Deno.test("payment-webhook - iamport error returns 500", async () => {
         const request = jsonRequest(
           "http://localhost",
           { imp_uid: "imp_abc", merchant_uid: "order-123" },
-          { headers: { "x-forwarded-for": "127.0.0.1" } },
+          { headers: { "x-real-ip": PORTONE_IP } },
         );
         const response = await handler(request);
         assertEquals(response.status, 500);
@@ -152,7 +268,7 @@ Deno.test("payment-webhook - malformed JSON returns 400", async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
         const request = textRequest("http://localhost", "{bad-json", {
-          headers: { "x-forwarded-for": "127.0.0.1" },
+          headers: { "x-real-ip": PORTONE_IP },
         });
         const response = await handler(request);
         assertEquals(response.status, 400);
@@ -185,7 +301,7 @@ Deno.test("payment-webhook - cancelled status sets refund_status completed", asy
         const request = jsonRequest(
           "http://localhost",
           { imp_uid: "imp_cancel", merchant_uid: "order-456", status: "cancelled" },
-          { headers: { "x-forwarded-for": "127.0.0.1" } },
+          { headers: { "x-real-ip": PORTONE_IP } },
         );
         const response = await handler(request);
         assertEquals(response.status, 200);
@@ -222,7 +338,7 @@ Deno.test("payment-webhook - paid status does not set refund_status", async () =
         const request = jsonRequest(
           "http://localhost",
           { imp_uid: "imp_paid", merchant_uid: "order-789", status: "paid" },
-          { headers: { "x-forwarded-for": "127.0.0.1" } },
+          { headers: { "x-real-ip": PORTONE_IP } },
         );
         const response = await handler(request);
         assertEquals(response.status, 200);


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1892

## 배경

`payment-webhook/index.ts`의 IP 검증 로직에 두 가지 보안 취약점이 있었음. security-reviewer (#1892) 분석 결과에 따른 Part A 구현.

## 변경 내용

### H1 — 127.0.0.1 production 제거

**취약점**: `ALLOWED_IPS`에 `127.0.0.1`이 무조건 포함되어 있어, 공격자가 `X-Forwarded-For: 127.0.0.1`을 헤더에 넣으면 IP 게이트 우회 가능.

**수정**: `ENVIRONMENT === "dev"` 일 때만 `127.0.0.1` 허용. 환경 변수 미설정 시 production으로 간주 (fail-safe). 기존 `backend-simulator`의 동일 패턴 적용.

### H2 — XFF leftmost 신뢰 → x-real-ip + XFF rightmost

**취약점**: `X-Forwarded-For`의 첫 번째 값을 신뢰. 클라이언트가 `X-Forwarded-For: 52.78.100.19, evil.example.com`처럼 whitelist IP를 앞에 위조 가능.

**수정**:
1. `x-real-ip` 1순위 (Supabase Edge/Cloudflare가 실제 클라이언트 IP로 설정)
2. `x-forwarded-for` fallback: rightmost 값 사용 (프록시가 마지막으로 추가한 hop)

## 테스트

기존 테스트: `x-forwarded-for: 127.0.0.1` → `x-real-ip: 52.78.100.19` (실제 Portone IP)로 변경

신규 회귀 테스트 4건 추가:
- `localhost IP blocked in production` — H1 검증
- `localhost IP allowed in dev env` — H1 regression (dev 동작 유지)
- `spoofed XFF first hop blocked` — H2 검증
- `x-real-ip takes precedence over XFF` — H2 우선순위 검증

**로컬 결과**: 12/12 passed

## 미포함 (Part B)

`produce_event()` 컷오버 (별도 이슈 분리 예정)