### PR TITLE
fix(account-management): add /certification entry point to AccountManagementPage

### DIFF
--- a/apps/app_user/lib/src/routing/app_routes.dart
+++ b/apps/app_user/lib/src/routing/app_routes.dart
@@ -260,7 +260,8 @@ class AccountManagementRoute extends GoRouteData with $AccountManagementRoute {
             ref.read(accountDeletionCoordinatorProvider).start();
           },
           // Fix #1861: 계정 관리에서 본인인증 직접 진입 가능하도록
-          onCertification: () => const CertificationRoute().push(context),
+          onCertification: () =>
+              unawaited(context.push(const CertificationRoute().location)),
           isVerified:
               ref.watch(currentUserProfileProvider).asData?.value?.isVerified ??
               false,

--- a/apps/app_user/lib/src/routing/app_routes.dart
+++ b/apps/app_user/lib/src/routing/app_routes.dart
@@ -259,6 +259,11 @@ class AccountManagementRoute extends GoRouteData with $AccountManagementRoute {
             // Fix #1213: 기존 회원 탈퇴 플로우를 계정 관리에서 재사용
             ref.read(accountDeletionCoordinatorProvider).start();
           },
+          // Fix #1861: 계정 관리에서 본인인증 직접 진입 가능하도록
+          onCertification: () => context.push('/certification'),
+          isVerified:
+              ref.watch(currentUserProfileProvider).asData?.value?.isVerified ??
+              false,
         );
       },
     );

--- a/apps/app_user/lib/src/routing/app_routes.dart
+++ b/apps/app_user/lib/src/routing/app_routes.dart
@@ -260,7 +260,7 @@ class AccountManagementRoute extends GoRouteData with $AccountManagementRoute {
             ref.read(accountDeletionCoordinatorProvider).start();
           },
           // Fix #1861: 계정 관리에서 본인인증 직접 진입 가능하도록
-          onCertification: () => context.push('/certification'),
+          onCertification: () => const CertificationRoute().push(context),
           isVerified:
               ref.watch(currentUserProfileProvider).asData?.value?.isVerified ??
               false,

--- a/apps/app_user/test/integration/cuj_account_management_certification_test.dart
+++ b/apps/app_user/test/integration/cuj_account_management_certification_test.dart
@@ -29,7 +29,6 @@ void main() {
       id: 'test-user-id',
       name: 'Test User',
       username: 'test_user',
-      isVerified: false,
       gender: 'male',
       birthYear: 1995,
       createdAt: DateTime(2024),

--- a/apps/app_user/test/integration/cuj_account_management_certification_test.dart
+++ b/apps/app_user/test/integration/cuj_account_management_certification_test.dart
@@ -1,0 +1,121 @@
+// Fix #1861: AccountManagementRoute 본인인증 배선 회귀 방지 테스트
+//
+// 검증 포인트:
+// 1. /my/account 진입 시 '본인인증' 타일이 표시됨
+//    — AccountManagementRoute가 onCertification을 AccountManagementPage에 연결해야만 타일이 표시됨.
+//      onCertification이 제거되면 AccountManagementPage 위젯 테스트는 여전히 통과하지만,
+//      이 테스트가 실패하여 회귀를 감지한다.
+// 2. '본인인증' 타일 탭 시 IdentityVerificationScreen으로 이동함
+//    — const CertificationRoute().push(context) 배선이 끊기면 실패한다.
+
+import 'package:app_user/src/features/auth/login_page.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'utils/test_app.dart';
+import 'utils/test_mocks.dart';
+
+class _MockConsentRepository extends Mock implements ConsentRepository {}
+
+void main() {
+  late User testUser;
+  late UserProfile testProfile;
+  late _MockConsentRepository mockConsentRepo;
+
+  setUp(() {
+    testUser = createMockUserForTest();
+    testProfile = UserProfile(
+      id: 'test-user-id',
+      name: 'Test User',
+      username: 'test_user',
+      isVerified: false,
+      gender: 'male',
+      birthYear: 1995,
+      createdAt: DateTime(2024),
+      updatedAt: DateTime(2024),
+    );
+    mockConsentRepo = _MockConsentRepository();
+    when(
+      () => mockConsentRepo.hasRequiredConsents(),
+    ).thenAnswer((_) async => true);
+    when(
+      () => mockConsentRepo.getConsents(any()),
+    ).thenAnswer((_) async => <UserConsent>[]);
+  });
+
+  group('IT: AccountManagementRoute 본인인증 경로 배선 (#1861)', () {
+    testWidgets(
+      'TC-001: 비로그인 시 /my/account 접근 → 로그인으로 리다이렉트',
+      (tester) async {
+        await tester.pumpWidget(
+          createTestApp(initialLocation: '/my/account'),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.byType(LoginPage), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'TC-002: 로그인 시 /my/account에서 본인인증 타일 노출'
+      ' — AccountManagementRoute가 onCertification을 배선하지 않으면 실패',
+      (tester) async {
+        await tester.pumpWidget(
+          createTestApp(
+            isLoggedIn: true,
+            currentUser: testUser,
+            initialLocation: '/my/account',
+            additionalOverrides: [
+              // Fix #1861: AccountManagementRoute.build()가 currentUserProfileProvider를
+              // 읽어 isVerified를 AccountManagementPage에 전달한다.
+              currentUserProfileProvider.overrideWith(
+                (_) async => testProfile,
+              ),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // '본인인증' 타일은 onCertification이 non-null일 때만 표시된다.
+        // AccountManagementRoute가 onCertification을 제거하면 이 assert가 실패한다.
+        expect(find.text('본인인증'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'TC-003: 본인인증 타일 탭 시 IdentityVerificationScreen으로 이동'
+      ' — CertificationRoute 배선이 끊기면 실패',
+      (tester) async {
+        await tester.pumpWidget(
+          createTestApp(
+            isLoggedIn: true,
+            currentUser: testUser,
+            initialLocation: '/my/account',
+            additionalOverrides: [
+              currentUserProfileProvider.overrideWith(
+                (_) async => testProfile,
+              ),
+              // Fix #1861: IdentityVerificationScreen이 ConsentController를 통해
+              // consentRepositoryProvider를 사용한다. Supabase 호출 방지용 mock.
+              consentRepositoryProvider.overrideWithValue(mockConsentRepo),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('본인인증'));
+        // GoRouter push는 동기적으로 실행됨.
+        // 첫 pump에서 IdentityVerificationScreen 렌더링, 두 번째 pump에서 postFrameCallback 소진.
+        // pumpAndSettle을 쓰지 않는 이유: _startVerificationFlow()의 비동기 플로우가
+        // 네이티브 IamportCertification을 호출하여 테스트 환경에서 hang이 발생하기 때문.
+        await tester.pump();
+        await tester.pump();
+
+        // CertificationRoute 배선이 살아있으면 IdentityVerificationScreen이 보인다.
+        expect(find.byType(IdentityVerificationScreen), findsOneWidget);
+      },
+    );
+  });
+}

--- a/shared/packages/minglit_kit/lib/src/ui/pages/account_management_page.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/pages/account_management_page.dart
@@ -14,6 +14,9 @@ class AccountManagementPage extends StatelessWidget {
     required this.onDeleteAccount,
     super.key,
     this.onPartnerProfile, // app_partner only — null hides the tile
+    // Fix #1861: 본인인증 진입점 — null이면 타일 숨김 (app_partner)
+    this.onCertification,
+    this.isVerified = false,
   });
 
   final VoidCallback onLogout;
@@ -22,6 +25,14 @@ class AccountManagementPage extends StatelessWidget {
   /// Optional partner profile callback. When non-null, shows a partner profile
   /// tile at the top of the page (app_partner only).
   final VoidCallback? onPartnerProfile;
+
+  /// Optional certification callback. When non-null, shows an identity
+  /// verification tile (app_user only). Null hides the tile.
+  final VoidCallback? onCertification;
+
+  /// Whether the user has completed identity verification.
+  /// Only meaningful when [onCertification] is non-null.
+  final bool isVerified;
 
   @override
   Widget build(BuildContext context) {
@@ -35,6 +46,27 @@ class AccountManagementPage extends StatelessWidget {
               title: const Text('파트너 프로필'),
               trailing: const Icon(Icons.chevron_right),
               onTap: onPartnerProfile,
+            ),
+            const Divider(),
+          ],
+          // Fix #1861: 본인인증 진입점 — 계정에 귀속된 신원 속성
+          if (onCertification != null) ...[
+            ListTile(
+              leading: Icon(
+                isVerified ? Icons.verified_user : Icons.shield_outlined,
+                color: isVerified ? MinglitColors.success : null,
+              ),
+              title: const Text('본인인증'),
+              subtitle: Text(
+                isVerified ? '인증 완료' : '인증하기',
+                style: TextStyle(
+                  color: isVerified
+                      ? MinglitColors.success
+                      : MinglitColors.textSecondary,
+                ),
+              ),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: onCertification,
             ),
             const Divider(),
           ],

--- a/shared/packages/minglit_kit/test/src/ui/widgets/common/account_management_page_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/common/account_management_page_test.dart
@@ -74,7 +74,7 @@ void main() {
   group('AccountManagementPage certification tile', () {
     testWidgets('onCertification null이면 본인인증 타일 숨김', (tester) async {
       await tester.pumpWidget(
-        wrap(onLogout: () {}, onCertification: null),
+        wrap(onLogout: () {}),
       );
 
       expect(find.text('본인인증'), findsNothing);
@@ -90,7 +90,7 @@ void main() {
 
     testWidgets('isVerified false이면 "인증하기" 텍스트 표시', (tester) async {
       await tester.pumpWidget(
-        wrap(onLogout: () {}, onCertification: () {}, isVerified: false),
+        wrap(onLogout: () {}, onCertification: () {}),
       );
 
       expect(find.text('인증하기'), findsOneWidget);

--- a/shared/packages/minglit_kit/test/src/ui/widgets/common/account_management_page_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/common/account_management_page_test.dart
@@ -6,11 +6,15 @@ void main() {
   Widget wrap({
     required VoidCallback onLogout,
     VoidCallback? onDeleteAccount,
+    VoidCallback? onCertification,
+    bool isVerified = false,
   }) {
     return MaterialApp(
       home: AccountManagementPage(
         onLogout: onLogout,
         onDeleteAccount: onDeleteAccount ?? () {},
+        onCertification: onCertification,
+        isVerified: isVerified,
       ),
     );
   }
@@ -63,6 +67,58 @@ void main() {
       expect(logoutCalled, isFalse);
       // 다이얼로그가 닫히고 페이지가 유지됨
       expect(find.text('로그아웃'), findsOneWidget);
+    });
+  });
+
+  // Fix #1861: 본인인증 타일 표시 여부 및 상태 검증
+  group('AccountManagementPage certification tile', () {
+    testWidgets('onCertification null이면 본인인증 타일 숨김', (tester) async {
+      await tester.pumpWidget(
+        wrap(onLogout: () {}, onCertification: null),
+      );
+
+      expect(find.text('본인인증'), findsNothing);
+    });
+
+    testWidgets('onCertification non-null이면 본인인증 타일 표시', (tester) async {
+      await tester.pumpWidget(
+        wrap(onLogout: () {}, onCertification: () {}),
+      );
+
+      expect(find.text('본인인증'), findsOneWidget);
+    });
+
+    testWidgets('isVerified false이면 "인증하기" 텍스트 표시', (tester) async {
+      await tester.pumpWidget(
+        wrap(onLogout: () {}, onCertification: () {}, isVerified: false),
+      );
+
+      expect(find.text('인증하기'), findsOneWidget);
+      expect(find.text('인증 완료'), findsNothing);
+    });
+
+    testWidgets('isVerified true이면 "인증 완료" 텍스트 표시', (tester) async {
+      await tester.pumpWidget(
+        wrap(onLogout: () {}, onCertification: () {}, isVerified: true),
+      );
+
+      expect(find.text('인증 완료'), findsOneWidget);
+      expect(find.text('인증하기'), findsNothing);
+    });
+
+    testWidgets('본인인증 타일 탭 시 onCertification 호출', (tester) async {
+      var certificationCalled = false;
+      await tester.pumpWidget(
+        wrap(
+          onLogout: () {},
+          onCertification: () => certificationCalled = true,
+        ),
+      );
+
+      await tester.tap(find.text('본인인증'));
+      await tester.pumpAndSettle();
+
+      expect(certificationCalled, isTrue);
     });
   });
 }


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1861

## 배경

유저가 `/certification` (본인인증) 화면에 도달할 수 있는 UI 경로가 이벤트 신청 위저드 내부뿐이었음. 마이페이지/계정 관리/개인정보 설정 어디에도 본인인증 직접 진입 경로 없음.

UX 가이드: https://github.com/Mark-Yun/minglit/issues/1861#issuecomment-4282648000

## 변경 내용

### `AccountManagementPage` (`shared/packages/minglit_kit`)

- `onCertification` (nullable `VoidCallback`) 추가 — null이면 타일 숨김 (`onPartnerProfile` 패턴 동일)
- `isVerified` (`bool`, 기본값 false) 추가
- 본인인증 ListTile 추가: 인증 상태에 따라 `verified_user`/`shield_outlined` 아이콘, `인증 완료`/`인증하기` 텍스트

### `app_user` (`apps/app_user/lib/src/routing/app_routes.dart`)

- `onCertification: () => context.push('/certification')` 주입
- `isVerified: ref.watch(currentUserProfileProvider).asData?.value?.isVerified ?? false` 주입

### `app_partner`

변경 없음. `onCertification` 기본값이 `null`이므로 타일 자동으로 숨겨짐. Partner 인증 흐름이 확정되면 별도 PR에서 주입 가능.

## 테스트

신규 5건:
- `onCertification null이면 본인인증 타일 숨김`
- `onCertification non-null이면 본인인증 타일 표시`
- `isVerified false이면 "인증하기" 텍스트`
- `isVerified true이면 "인증 완료" 텍스트`
- `본인인증 탭 시 onCertification 호출`

로컬 결과: 8/8 passed