### PR TITLE
test(party/create): Step4-6 widget tests — party create wizard coverage

### DIFF
--- a/apps/app_partner/test/src/features/party/create/steps/step4_entry_rules_test.dart
+++ b/apps/app_partner/test/src/features/party/create/steps/step4_entry_rules_test.dart
@@ -1,0 +1,93 @@
+import 'package:app_partner/main.dart' show kPartnerLocalizationsDelegates;
+import 'package:app_partner/src/features/party/create/party_create_wizard_controller.dart';
+import 'package:app_partner/src/features/party/create/steps/step4_entry_rules.dart';
+import 'package:app_partner/src/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+EntryGroupTemplate _makeGroup(String id) => EntryGroupTemplate(
+      id: id,
+      partyId: 'party-test',
+    );
+
+Widget _buildStep4({List<EntryGroupTemplate> entryGroups = const []}) {
+  return ProviderScope(
+    overrides: [
+      partyCreateWizardControllerProvider.overrideWith(
+        () => _FakeWizardController(
+          PartyCreateWizardState(entryGroups: entryGroups),
+        ),
+      ),
+    ],
+    child: const MaterialApp(
+      localizationsDelegates: kPartnerLocalizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: Step4EntryRules()),
+    ),
+  );
+}
+
+void main() {
+  group('Step4EntryRules', () {
+    testWidgets('입장 그룹 없으면 MinglitEmptyState 표시, AddActionCard 표시', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_buildStep4());
+      await tester.pump();
+
+      expect(find.byType(MinglitEmptyState), findsOneWidget);
+      expect(find.byType(AddActionCard), findsOneWidget);
+    });
+
+    testWidgets('입장 그룹 2개이면 카드 2개 렌더, 빈 상태 없음', (tester) async {
+      await tester.pumpWidget(
+        _buildStep4(
+          entryGroups: [_makeGroup('eg-1'), _makeGroup('eg-2')],
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(MinglitEmptyState), findsNothing);
+      // Each group renders one Card + header close IconButton
+      expect(find.byIcon(Icons.close), findsNWidgets(2));
+    });
+
+    testWidgets('닫기 버튼 탭 시 해당 그룹이 목록에서 제거됨', (tester) async {
+      await tester.pumpWidget(
+        _buildStep4(
+          entryGroups: [_makeGroup('eg-1'), _makeGroup('eg-2')],
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byIcon(Icons.close), findsNWidgets(2));
+
+      // Remove first group
+      await tester.tap(find.byIcon(Icons.close).first);
+      await tester.pump();
+
+      expect(find.byIcon(Icons.close), findsOneWidget);
+    });
+
+    testWidgets('그룹 모두 삭제하면 MinglitEmptyState로 돌아감', (tester) async {
+      await tester.pumpWidget(
+        _buildStep4(entryGroups: [_makeGroup('eg-1')]),
+      );
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.close).first);
+      await tester.pump();
+
+      expect(find.byType(MinglitEmptyState), findsOneWidget);
+    });
+  });
+}
+
+class _FakeWizardController extends PartyCreateWizardController {
+  _FakeWizardController(this._initialState);
+  final PartyCreateWizardState _initialState;
+
+  @override
+  PartyCreateWizardState build() => _initialState;
+}

--- a/apps/app_partner/test/src/features/party/create/steps/step4_entry_rules_test.dart
+++ b/apps/app_partner/test/src/features/party/create/steps/step4_entry_rules_test.dart
@@ -7,9 +7,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
 EntryGroupTemplate _makeGroup(String id) => EntryGroupTemplate(
-      id: id,
-      partyId: 'party-test',
-    );
+  id: id,
+  partyId: 'party-test',
+);
 
 Widget _buildStep4({List<EntryGroupTemplate> entryGroups = const []}) {
   return ProviderScope(

--- a/apps/app_partner/test/src/features/party/create/steps/step5_tickets_test.dart
+++ b/apps/app_partner/test/src/features/party/create/steps/step5_tickets_test.dart
@@ -1,0 +1,78 @@
+import 'package:app_partner/main.dart' show kPartnerLocalizationsDelegates;
+import 'package:app_partner/src/features/party/create/party_create_wizard_controller.dart';
+import 'package:app_partner/src/features/party/create/steps/step5_tickets.dart';
+import 'package:app_partner/src/features/party/ticket/widgets/party_ticket_template_input.dart';
+import 'package:app_partner/src/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+TicketTemplate _makeTicket(String id) => TicketTemplate(
+      id: id,
+      partyId: 'party-test',
+      name: '일반 티켓',
+      quantity: 10,
+      createdAt: DateTime(2024),
+      updatedAt: DateTime(2024),
+    );
+
+Widget _buildStep5({
+  List<TicketTemplate> tickets = const [],
+  List<EntryGroupTemplate> entryGroups = const [],
+  int maxParticipants = 0,
+}) {
+  return ProviderScope(
+    overrides: [
+      partyCreateWizardControllerProvider.overrideWith(
+        () => _FakeWizardController(
+          PartyCreateWizardState(
+            tickets: tickets,
+            entryGroups: entryGroups,
+            maxParticipants: maxParticipants,
+          ),
+        ),
+      ),
+    ],
+    child: const MaterialApp(
+      localizationsDelegates: kPartnerLocalizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: Step5Tickets()),
+    ),
+  );
+}
+
+void main() {
+  group('Step5Tickets', () {
+    testWidgets('PartyTicketTemplateInput 위젯이 렌더됨', (tester) async {
+      await tester.pumpWidget(_buildStep5());
+      await tester.pump();
+
+      expect(find.byType(PartyTicketTemplateInput), findsOneWidget);
+    });
+
+    testWidgets('티켓 없이도 크래시 없이 렌더, 추가 버튼 표시', (tester) async {
+      await tester.pumpWidget(_buildStep5());
+      await tester.pump();
+
+      expect(find.byType(Step5Tickets), findsOneWidget);
+      expect(find.text('기본 티켓 추가하기'), findsOneWidget);
+    });
+
+    testWidgets('티켓 1개 있으면 닫기 아이콘 표시', (tester) async {
+      await tester.pumpWidget(
+        _buildStep5(tickets: [_makeTicket('ticket-1')]),
+      );
+      await tester.pump();
+
+      expect(find.byIcon(Icons.close), findsOneWidget);
+    });
+  });
+}
+
+class _FakeWizardController extends PartyCreateWizardController {
+  _FakeWizardController(this._initialState);
+  final PartyCreateWizardState _initialState;
+
+  @override
+  PartyCreateWizardState build() => _initialState;
+}

--- a/apps/app_partner/test/src/features/party/create/steps/step5_tickets_test.dart
+++ b/apps/app_partner/test/src/features/party/create/steps/step5_tickets_test.dart
@@ -8,13 +8,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
 TicketTemplate _makeTicket(String id) => TicketTemplate(
-      id: id,
-      partyId: 'party-test',
-      name: '일반 티켓',
-      quantity: 10,
-      createdAt: DateTime(2024),
-      updatedAt: DateTime(2024),
-    );
+  id: id,
+  partyId: 'party-test',
+  name: '일반 티켓',
+  quantity: 10,
+  createdAt: DateTime(2024),
+  updatedAt: DateTime(2024),
+);
 
 Widget _buildStep5({
   List<TicketTemplate> tickets = const [],

--- a/apps/app_partner/test/src/features/party/create/steps/step6_review_test.dart
+++ b/apps/app_partner/test/src/features/party/create/steps/step6_review_test.dart
@@ -55,7 +55,14 @@ void main() {
     });
 
     testWidgets('기본 정보 섹션 탭 시 currentStep이 basicInfo로 변경됨', (tester) async {
-      await tester.pumpWidget(_buildStep6());
+      // Fix: start from a non-basicInfo step so the tap actually causes a state transition
+      await tester.pumpWidget(
+        _buildStep6(
+          state: const PartyCreateWizardState(
+            currentStep: PartyCreateStep.review,
+          ),
+        ),
+      );
       await tester.pump();
 
       await tester.tap(find.text('기본 정보'));

--- a/apps/app_partner/test/src/features/party/create/steps/step6_review_test.dart
+++ b/apps/app_partner/test/src/features/party/create/steps/step6_review_test.dart
@@ -1,0 +1,79 @@
+import 'package:app_partner/main.dart' show kPartnerLocalizationsDelegates;
+import 'package:app_partner/src/features/party/create/party_create_wizard_controller.dart';
+import 'package:app_partner/src/features/party/create/steps/step6_review.dart';
+import 'package:app_partner/src/l10n/generated/app_localizations.dart';
+import 'package:app_partner/src/ui/widgets/common/minglit_editable_section.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+Widget _buildStep6({
+  PartyCreateWizardState state = const PartyCreateWizardState(),
+}) {
+  return ProviderScope(
+    overrides: [
+      partyCreateWizardControllerProvider.overrideWith(
+        () => _FakeWizardController(state),
+      ),
+    ],
+    child: const MaterialApp(
+      localizationsDelegates: kPartnerLocalizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: SingleChildScrollView(child: Step6Review()),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('Step6Review', () {
+    testWidgets('리뷰 섹션 5개 모두 표시됨 (MinglitEditableSection)', (tester) async {
+      await tester.pumpWidget(_buildStep6());
+      await tester.pump();
+
+      expect(find.byType(MinglitEditableSection), findsNWidgets(5));
+    });
+
+    testWidgets('기본 상태에서 validation 에러 카드 표시 (누락된 정보)', (tester) async {
+      await tester.pumpWidget(_buildStep6());
+      await tester.pump();
+
+      // Default empty state triggers all validation errors
+      expect(find.text('누락된 정보를 입력해주세요.'), findsOneWidget);
+    });
+
+    testWidgets('섹션 제목 5개 모두 표시됨', (tester) async {
+      await tester.pumpWidget(_buildStep6());
+      await tester.pump();
+
+      expect(find.text('기본 정보'), findsOneWidget);
+      expect(find.text('장소 정보'), findsOneWidget);
+      expect(find.text('인원 및 연락처'), findsOneWidget);
+      expect(find.text('입장 규칙'), findsOneWidget);
+      expect(find.text('티켓 정보'), findsOneWidget);
+    });
+
+    testWidgets('기본 정보 섹션 탭 시 currentStep이 basicInfo로 변경됨', (tester) async {
+      await tester.pumpWidget(_buildStep6());
+      await tester.pump();
+
+      await tester.tap(find.text('기본 정보'));
+      await tester.pump();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(Step6Review)),
+      );
+      final state = container.read(partyCreateWizardControllerProvider);
+      expect(state.currentStep, PartyCreateStep.basicInfo);
+    });
+  });
+}
+
+class _FakeWizardController extends PartyCreateWizardController {
+  _FakeWizardController(this._initialState);
+  final PartyCreateWizardState _initialState;
+
+  @override
+  PartyCreateWizardState build() => _initialState;
+}


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes (partial) #1876

## 배경

issue #1876 (app_partner/party 커버리지 27% → 60+%)의 일환.
PR #1896 (P0: PartyStatusEditSheet) 에 이어 create steps 4, 5, 6 위젯 테스트 추가.

## 신규 테스트 (11건)

Step4EntryRules (4건): 빈 상태, 그룹 렌더, 닫기 버튼 → removeEntryGroup, 마지막 그룹 제거 시 빈 상태 복귀
Step5Tickets (3건): PartyTicketTemplateInput 렌더, 티켓 없이 크래시 없음, 티켓 1개 닫기 아이콘
Step6Review (4건): 5개 MinglitEditableSection, validation 에러 카드, 섹션 제목 5개, 섹션 탭 → currentStep 변경

## 로컬 결과

11/11 passed / flutter analyze: No issues found.

## 참고

Steps 1-3 (ConsumerStatefulWidget + QuillController)는 후속 PR 예정.