### PR TITLE
feat(mds): consume mds_tokens for color/spacing/radius SSOT (Follow-up #2)

### DIFF
--- a/docs/architecture/mds-tokens-wiring-plan.md
+++ b/docs/architecture/mds-tokens-wiring-plan.md
@@ -1,0 +1,123 @@
+# mds_tokens Wiring Plan — Follow-up #2
+
+**Status:** PoC, feature/mds-tokens-wiring 브랜치
+**Goal:** mds 패키지가 mds_tokens.g.dart의 codegen된 const를 소비하도록 wiring
+**Predecessors:** #1869 (MDS extraction), #1887 (storybook wiring)
+
+## 문제
+
+현재 상태:
+- `mds/lib/src/theme/minglit_design_tokens.dart`의 `MinglitColors` 클래스는 hardcoded `Color(0xFFXXXXXX)` 상수들을 들고 있음
+- `mds_tokens/lib/generated/tokens.g.dart`의 `MdsTokens` 클래스는 같은 값들을 `int` 상수로 codegen함
+- 두 소스가 **이중 정의**되어 있어 SSOT 의미가 없음 — 디자이너가 `tokens.json`만 바꿔도 mds가 반영하지 않음
+
+## 결정
+
+**Approach: 단방향 단일 소스화**
+
+`mds_tokens`을 SSOT로 두고, `mds`의 `MinglitColors`는 `MdsTokens`의 int 값을 `Color()`로 래핑하는 얇은 어댑터로 만든다.
+
+```dart
+// Before:
+class MinglitColors {
+  static const background = Color(0xFFFFFFFF);
+  static const primary = Color(0xFF9900FF);
+}
+
+// After:
+class MinglitColors {
+  static const background = Color(MdsTokens.colorBackground);
+  static const primary = Color(MdsTokens.colorPrimary);
+}
+```
+
+**효과:**
+- `tokens.json` → `npm run build` → `tokens.g.dart` → `MinglitColors`로 한 방향만 흐름
+- `MinglitColors` API surface는 그대로 유지 → app code, mds 내부 widget 영향 0
+- 디자이너 토큰 변경이 자동으로 mds 컴포넌트에 반영
+
+## 작업 범위
+
+### 1. 의존성 추가
+
+`shared/packages/mds/pubspec.yaml`에:
+```yaml
+dependencies:
+  mds_tokens:
+    path: ../mds_tokens
+```
+
+### 2. MinglitColors 마이그레이션
+
+`mds/lib/src/theme/minglit_design_tokens.dart`의 `MinglitColors` 클래스 — hardcoded `Color(0x...)`를 `Color(MdsTokens.colorX)`로 교체.
+
+**매핑 (예상):**
+
+| MinglitColors entry | MdsTokens entry |
+|---|---|
+| `background` | `colorBackground` |
+| `primary` | `colorPrimary` |
+| `secondary` | `colorSecondary` |
+| `tertiary` | `colorTertiary` |
+| `surface` | `colorSurface` |
+| `error` | `colorError` |
+| `textPrimary` | `colorTextPrimary` |
+| `textSecondary` | `colorTextSecondary` |
+| `success` | `colorSuccess` |
+| `info` | `colorInfo` |
+| `warning` | `colorWarning` |
+| `transparent` | `colorTransparent` |
+| `divider` | `colorDivider` |
+| `scrim` | `colorScrim` |
+| ... (기타) | ... |
+
+**중요:** `MdsTokens`에 없는 항목 처리:
+- 직접 매핑 없음 → 일단 hardcoded 유지 + `// TODO(mds-tokens): add to tokens.json` 주석
+- 다크모드 variant도 동일 — `MdsTokens.colorBackgroundDark` 같은 게 있으면 사용, 없으면 TODO
+
+**ABSOLUTE constraint:** 값을 절대 변경하지 말 것. 단순 `Color(0xFF...)` → `Color(MdsTokens.X)` 치환만. 16진수 값이 다르면 즉시 STOP하고 보고.
+
+### 3. Spacing / Radius / Typography 검토 (best-effort)
+
+`MinglitColors` 외에 `mds/lib/src/theme/`에 `MinglitSpacing`, `MinglitRadius`, `MinglitTypography` 등 비슷한 hardcoded 토큰 클래스가 있다면 동일 패턴으로 마이그레이션.
+
+- 단, **Color 마이그레이션이 우선**. 시간/복잡도 부족하면 spacing/radius/typography는 후속 PR로 미룸.
+- 마이그레이션하지 않은 카테고리는 plan 문서에 명시하고 TODO 코멘트 남김.
+
+### 4. 검증
+
+- `cd shared/packages/mds && flutter analyze` — 0 errors
+- `cd shared/packages/mds && flutter test` (있다면) — pass
+- `cd shared/packages/minglit_kit && flutter analyze && flutter test` — pre-existing 골든 실패 외 NEW 실패 없음
+- `cd apps/app_user && flutter analyze` — 0 errors
+- `cd apps/app_partner && flutter analyze` — 0 errors
+- `cd apps/mds_storybook && flutter analyze && flutter test` — smoke test pass
+- **시각 회귀 sanity check**: `MdsTokens.colorPrimary == 0xFF9900FF` 같이 spot-check 5-10개 색상 값이 일치하는지 grep으로 검증
+
+### 5. CI 변경
+
+이미 #1869에서 mds path filter가 추가됐으니 CI 워크플로우 자체는 변경 불필요. mds 내부 변경이므로 기존 `app_user_or_kit / app_partner_or_kit` 매트릭스 트리거.
+
+## 위험
+
+- **시각 회귀**: 토큰 값이 잘못 매핑되면 색이 미묘하게 달라짐. 골든 테스트가 잡아주지만 dev/CI 환경에서만 실행되니 PR 시 reviewer 확인 필요.
+- **이중 정의 잔존**: `MdsTokens`에 없는 색상은 여전히 `MinglitColors`에 hardcoded — 부분적 SSOT. 후속 PR에서 토큰 보강.
+- **패키지 의존 그래프**: `mds → mds_tokens` 의존 추가 — 순환은 아니지만 mds의 "pure UI" 약속에 톤이 약간 다름 (tokens도 SSOT의 일부니까 OK).
+
+## PR
+
+- Base: dev
+- Title: `feat(mds): consume mds_tokens for color SSOT (Follow-up #2)`
+- Auto-merge: ON
+- Body: plan 링크 + 매핑 표 + 마이그레이션 안 한 토큰 카테고리 (있다면) 명시
+
+## 후속 PR (이번 범위 X)
+
+1. `MdsTokens`에 누락된 토큰들 추가 (다크모드 variants, 누락 색상)
+2. Spacing/Radius/Typography wiring (이번 PR에서 미룸 시)
+3. Web 타겟 codegen 추가 (CSS 변수 → mds-react로 공유)
+4. 디자인 시스템 문서 업데이트 — `tokens.json`이 SSOT임을 명시
+
+---
+
+**Date:** 2026-04-27

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ workspace:
   - apps/app_user
   - apps/mds_storybook
   - shared/packages/mds
+  - shared/packages/mds_tokens
   - shared/packages/minglit_kit
   - shared/packages/minglit_lints
 

--- a/shared/packages/mds/lib/src/theme/minglit_design_tokens.dart
+++ b/shared/packages/mds/lib/src/theme/minglit_design_tokens.dart
@@ -4,79 +4,80 @@ part of 'minglit_theme.dart';
 /// 테마에 담기 애매한 수치들과 브랜드 색상을 상수로 관리합니다.
 class MinglitColors {
   /// White background color.
-  static const background = Color(0xFFFFFFFF);
+  static const background = Color(MdsTokens.colorBackground);
 
   /// Primary brand purple.
-  static const primary = Color(0xFF9900FF);
+  static const primary = Color(MdsTokens.colorPrimary);
 
   /// Secondary amber accent.
-  static const secondary = Color(0xFFFF9900); // Auxiliary 1
+  static const secondary = Color(MdsTokens.colorSecondary); // Auxiliary 1
 
   /// Tertiary mint accent.
-  static const tertiary = Color(0xFF48C9B0); // Toned down Mint
+  static const tertiary = Color(MdsTokens.colorTertiary); // Toned down Mint
 
   /// Light surface background.
-  static const surface = Color(0xFFF9FAFB); // 부드러운 회색 배경
+  static const surface = Color(MdsTokens.colorSurface); // 부드러운 회색 배경
 
   /// Error red color.
-  static const error = Color(0xFFEF4444);
+  static const error = Color(MdsTokens.colorError);
 
   /// Primary text color (near-black).
-  static const textPrimary = Color(0xFF111827);
+  static const textPrimary = Color(MdsTokens.colorTextPrimary);
 
   /// Secondary text color (dark gray).
-  static const textSecondary = Color(0xFF4B5563);
+  static const textSecondary = Color(MdsTokens.colorTextSecondary);
 
   /// Success green color (green-600 for better contrast vs white).
-  static const success = Color(0xFF16A34A);
+  static const success = Color(MdsTokens.colorSuccess);
 
   /// Info blue color — neutral informational state (e.g. pending payment).
   // Fix #1236: 상태 배지 의미론적 색상 — 결제대기 등 중립 정보 상태
-  static const info = Color(0xFF3B82F6);
+  static const info = Color(MdsTokens.colorInfo);
 
   /// Warning amber color (amber-600 for better contrast vs white).
-  static const warning = Color(0xFFD97706);
+  static const warning = Color(MdsTokens.colorWarning);
 
   /// Fully transparent color.
+  // TODO(mds-tokens): add colorTransparent to tokens.json and migrate
   static const transparent = Color(0x00000000);
 
   /// Light theme border/divider separator color.
   static const divider = Color(
-    0xFFE5E7EB,
+    MdsTokens.colorDivider,
   ); // ignore: minglit_no_hardcoded_colors -- light divider token
 
   /// Semi-transparent black scrim for overlays.
-  static const scrim = Color(0x80000000);
+  static const scrim = Color(MdsTokens.colorScrim);
 
   /// Glitch effect cyan — splash screen text shadow.
-  static const glitchCyan = Color(0xFF21FFFE);
+  static const glitchCyan = Color(MdsTokens.colorGlitchCyan);
 
   /// Darker primary variant — splash gradient mid-tone.
-  static const primaryDark = Color(0xFF7B2FBE);
+  static const primaryDark = Color(MdsTokens.colorPrimaryDark);
 }
 
 class MinglitColorsDark {
   // ignore: minglit_no_hardcoded_colors -- dark theme definition
-  static const background = Color(0xFF0F0F0F);
+  static const background = Color(MdsTokens.colorDarkBackground);
   // ignore: minglit_no_hardcoded_colors -- dark theme definition
-  static const surface = Color(0xFF212121);
+  static const surface = Color(MdsTokens.colorDarkSurface);
   // ignore: minglit_no_hardcoded_colors -- dark theme definition
-  static const textPrimary = Color(0xFFFFFFFF);
+  static const textPrimary = Color(MdsTokens.colorDarkTextPrimary);
   // ignore: minglit_no_hardcoded_colors -- dark theme definition
-  static const textSecondary = Color(0xFFAAAAAA);
+  static const textSecondary = Color(MdsTokens.colorDarkTextSecondary);
   // ignore: minglit_no_hardcoded_colors -- dark theme definition
-  static const primary = Color(0xFFAA33FF);
-  static const secondary = MinglitColors.secondary;
-  static const tertiary = MinglitColors.tertiary;
-  static const error = MinglitColors.error;
+  static const primary = Color(MdsTokens.colorDarkPrimary);
+  static const Color secondary = MinglitColors.secondary;
+  static const Color tertiary = MinglitColors.tertiary;
+  static const Color error = MinglitColors.error;
   // ignore: minglit_no_hardcoded_colors -- dark theme definition
-  static const success = Color(0xFF4ADE80);
+  static const success = Color(MdsTokens.colorDarkSuccess);
   // ignore: minglit_no_hardcoded_colors -- dark theme definition
-  static const info = Color(0xFF60A5FA);
+  static const info = Color(MdsTokens.colorDarkInfo);
   // ignore: minglit_no_hardcoded_colors -- dark theme definition
-  static const warning = Color(0xFFFBBF24);
+  static const warning = Color(MdsTokens.colorDarkWarning);
   // ignore: minglit_no_hardcoded_colors -- dark theme definition
-  static const divider = Color(0xFF3D3D3D);
+  static const divider = Color(MdsTokens.colorDarkDivider);
 }
 
 /// 컴포넌트 테마에서 사용하는 색상 세트.
@@ -140,148 +141,160 @@ class MinglitColorSet {
 /// Spacing scale constants for consistent layout.
 class MinglitSpacing {
   /// 0px zero spacing.
-  static const double zero = 0;
+  static const double zero = MdsTokens.spacingZero;
 
   /// 2px extra-extra-small spacing.
-  static const double xxsmall = 2;
+  static const double xxsmall = MdsTokens.spacingXxsmall;
 
   /// 4px extra-small spacing.
-  static const double xsmall = 4;
+  static const double xsmall = MdsTokens.spacingXsmall;
 
   /// 6px extra-small-2 spacing.
-  static const double xsmall2 = 6;
+  static const double xsmall2 = MdsTokens.spacingXsmall2;
 
   /// 8px small spacing.
-  static const double small = 8;
+  static const double small = MdsTokens.spacingSmall;
 
   /// 12px small-medium spacing.
-  static const double sm = 12;
+  static const double sm = MdsTokens.spacingSm;
 
   /// 16px medium spacing.
-  static const double medium = 16;
+  static const double medium = MdsTokens.spacingMedium;
 
   /// 24px large spacing.
-  static const double large = 24;
+  static const double large = MdsTokens.spacingLarge;
 
   /// 32px extra-large spacing.
-  static const double xlarge = 32;
+  static const double xlarge = MdsTokens.spacingXlarge;
 
   /// 48px extra-extra-large spacing.
-  static const double xxlarge = 48;
+  static const double xxlarge = MdsTokens.spacingXxlarge;
 
   /// 64px extra-extra-extra-large spacing.
-  static const double xxxlarge = 64;
+  static const double xxxlarge = MdsTokens.spacingXxxlarge;
 
   // 시맨틱 토큰 (용도별)
 
   /// 16px screen edge padding (left/right).
-  static const double screenEdge = 16;
+  static const double screenEdge = MdsTokens.spacingScreenEdge;
 
   /// 12px gap between cards.
-  static const double cardGap = 12;
+  static const double cardGap = MdsTokens.spacingCardGap;
 
   /// 16px card internal vertical padding.
-  static const double cardContentV = 16;
+  static const double cardContentV = MdsTokens.spacingCardContentV;
 
   /// 4px title-to-body spacing.
-  static const double titleToBody = 4;
+  static const double titleToBody = MdsTokens.spacingTitleToBody;
 
   /// 40px section gap.
-  static const double sectionGap = 40;
+  static const double sectionGap = MdsTokens.spacingSectionGap;
 }
 
 /// Border radius constants for consistent rounding.
 class MinglitRadius {
   /// 8px small border radius.
-  static const double small = 8;
+  static const double small = MdsTokens.radiusSmall;
 
   /// 12px button border radius.
-  static const double button = 12;
+  static const double button = MdsTokens.radiusButton;
 
   /// 16px card border radius.
-  static const double card = 16;
+  static const double card = MdsTokens.radiusCard;
 
   /// 28px dialog border radius.
-  static const double dialog = 28;
+  static const double dialog = MdsTokens.radiusDialog;
 
   /// 12px input border radius.
-  static const double input = 12;
+  static const double input = MdsTokens.radiusInput;
 
   /// 4px badge border radius.
-  static const double badge = 4;
+  static const double badge = MdsTokens.radiusBadge;
 
   /// 100px chip border radius (fully rounded).
-  static const double chip = 100;
+  static const double chip = MdsTokens.radiusChip;
 }
 
 /// Icon size constants for consistent icon rendering.
 class MinglitIconSize {
   /// 16px extra-small icon size.
+  // TODO(mds-tokens): add iconSizeXsmall to tokens.json and migrate
   static const double xsmall = 16;
 
   /// 20px small icon size.
+  // TODO(mds-tokens): add iconSizeSmall to tokens.json and migrate
   static const double small = 20;
 
   /// 24px medium icon size.
+  // TODO(mds-tokens): add iconSizeMedium to tokens.json and migrate
   static const double medium = 24;
 
   /// 28px large icon size.
+  // TODO(mds-tokens): add iconSizeLarge to tokens.json and migrate
   static const double large = 28;
 
   /// 32px extra-large icon size.
+  // TODO(mds-tokens): add iconSizeXlarge to tokens.json and migrate
   static const double xlarge = 32;
 
   /// 40px extra-extra-large icon size.
+  // TODO(mds-tokens): add iconSizeXxlarge to tokens.json and migrate
   static const double xxlarge = 40;
 
   /// 48px display icon size — empty state full-page variant.
+  // TODO(mds-tokens): add iconSizeDisplay to tokens.json and migrate
   static const double display = 48;
 }
 
 /// Partner app brand colors — same purple family, toned down for business feel.
 class MinglitPartnerColors {
   /// Primary brand indigo (toned-down purple).
-  static const primary = Color(0xFF6C3CE1);
+  static const primary = Color(MdsTokens.colorPartnerPrimary);
 
   /// Lighter variant for gradients.
-  static const primaryLight = Color(0xFF8B5CF6);
+  static const primaryLight = Color(MdsTokens.colorPartnerPrimaryLight);
 
   /// Surface tint for cards and containers.
-  static const primarySurface = Color(0xFFF5F0FF);
+  static const primarySurface = Color(MdsTokens.colorPartnerPrimarySurface);
 
   /// Border color for highlighted cards.
-  static const primaryBorder = Color(0xFFE8E0FF);
+  static const primaryBorder = Color(MdsTokens.colorPartnerPrimaryBorder);
 
   /// Container fill for secondary buttons.
-  static const primaryContainer = Color(0xFFF0EDFF);
+  static const primaryContainer = Color(MdsTokens.colorPartnerPrimaryContainer);
 }
 
 /// Partner app dark mode colors.
 class MinglitPartnerColorsDark {
   // ignore: minglit_no_hardcoded_colors -- partner dark theme definition
-  static const primary = Color(0xFF9B7BEC);
+  static const primary = Color(MdsTokens.colorPartnerDarkPrimary);
   // ignore: minglit_no_hardcoded_colors -- partner dark theme definition
-  static const primaryLight = Color(0xFFB39DFF);
+  static const primaryLight = Color(MdsTokens.colorPartnerDarkPrimaryLight);
 }
 
 /// Animation duration constants.
 class MinglitAnimation {
   /// 100ms micro animation duration for micro-interactions.
+  // TODO(mds-tokens): add animationDurationMicro to tokens.json and migrate
   static const Duration micro = Duration(milliseconds: 100);
 
   /// 200ms fast animation duration.
+  // TODO(mds-tokens): add animationDurationFast to tokens.json and migrate
   static const Duration fast = Duration(milliseconds: 200);
 
   /// 350ms medium animation duration.
+  // TODO(mds-tokens): add animationDurationMedium to tokens.json and migrate
   static const Duration medium = Duration(milliseconds: 350);
 
   /// 500ms slow animation duration.
+  // TODO(mds-tokens): add animationDurationSlow to tokens.json and migrate
   static const Duration slow = Duration(milliseconds: 500);
 }
 
 /// Opacity constants for consistent transparency values.
 class MinglitOpacity {
   /// 0% opacity — fully transparent overlays.
+  // TODO(mds-tokens): add opacity tokens to tokens.json and migrate
   static const double none = 0;
 
   /// 2% opacity — ultra subtle shadow wash.

--- a/shared/packages/mds/lib/src/theme/minglit_theme.dart
+++ b/shared/packages/mds/lib/src/theme/minglit_theme.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:mds/src/theme/minglit_text_theme_extension.dart';
+import 'package:mds_tokens/mds_tokens.dart';
 
 part 'minglit_design_tokens.dart';
 part 'minglit_design_utils.dart';

--- a/shared/packages/mds/pubspec.yaml
+++ b/shared/packages/mds/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
   flutter_riverpod: ^3.0.3
   flutter_svg: ^2.2.2
   image_picker: ^1.2.1
+  mds_tokens:
+    path: ../mds_tokens
   shimmer: ^3.0.0
 
 flutter:

--- a/shared/packages/mds_tokens/pubspec.yaml
+++ b/shared/packages/mds_tokens/pubspec.yaml
@@ -2,6 +2,7 @@ name: mds_tokens
 description: "Design tokens (SSOT) — codegen Dart consts via Style Dictionary"
 version: 26.04.1865-dev
 publish_to: 'none'
+resolution: workspace
 
 environment:
   sdk: ^3.10.4
@@ -10,4 +11,4 @@ environment:
 # Consumers get typed const values for color, spacing, radius, typography.
 
 dev_dependencies:
-  lints: ^5.0.0
+  lints: ^6.0.0


### PR DESCRIPTION
## Summary

Follow-up to #1869 / #1887. Closes the SSOT loop by making `mds` consume `mds_tokens.g.dart` instead of carrying duplicate hardcoded values.

`MinglitColors`, `MinglitSpacing`, `MinglitRadius` now wrap `MdsTokens` constants. Same API surface, single source of truth (tokens.json).

See `docs/architecture/mds-tokens-wiring-plan.md`.

## What changed

### Colors — 31 of 32 entries migrated

| Class | Migrated |
|---|---|
| `MinglitColors` | 15/16 |
| `MinglitColorsDark` | 9/12 (3 already delegated to base) |
| `MinglitPartnerColors` | 5/5 |
| `MinglitPartnerColorsDark` | 2/2 |

Only `MinglitColors.transparent` left hardcoded — no `colorTransparent` in `tokens.json` yet. TODO marker added.

```dart
// Before
static const background = Color(0xFFFFFFFF);
static const primary = Color(0xFF9900FF);

// After
static const background = Color(MdsTokens.colorBackground);
static const primary = Color(MdsTokens.colorPrimary);
```

### Spacing & Radius — full migration

- `MinglitSpacing`: 15/15 entries → `MdsTokens.spacing*`
- `MinglitRadius`: 7/7 entries → `MdsTokens.radius*`

### Deferred (no matching MdsTokens entries)

- `MinglitIconSize` (7 entries)
- `MinglitAnimation`, `MinglitOpacity` — non-standard W3C token types, deferred per #1869's mds_tokens scope cut
- `MinglitTypography` is theme-driven via `MinglitTextThemeExtension`, not const-driven — separate migration path

### Plumbing side effects

- `mds_tokens` added to root workspace `pubspec.yaml` + `resolution: workspace` in its own pubspec
- `mds_tokens` bumped `lints` constraint `^5.0.0` → `^6.0.0` to match workspace
- 3 `MinglitColorsDark` entries got explicit `Color` type annotations (lint: `specify_nonobvious_property_types`)

## Verification

- [x] **Byte-identical hex values**: every migrated entry verified against MdsTokens int values — zero drift
- [x] `mds_tokens`: `dart analyze` 0 issues
- [x] `mds`: `flutter analyze` 0 errors
- [x] `minglit_kit`: 0 errors
- [x] `app_user`: 0 errors
- [x] `app_partner`: 0 errors
- [x] `mds_storybook`: 0 errors + smoke test passes

## Constraint observed

Pure constant substitution — no value changes. The "consume tokens" refactor is invisible at runtime.

## What's NOT in this PR (deferred)

1. `colorTransparent` token in tokens.json (1 hardcoded leftover)
2. `MdsTokens.iconSize*` and `MdsTokens.animation*` token categories
3. `MinglitTypography` text theme migration (separate codepath)
4. Web codegen target (CSS variables for mds-react)
5. Visual regression suite — relies on byte-identical const values

## Test plan

- [ ] CI `ci-result` passes (mds + minglit_kit + apps matrix)
- [ ] CodeRabbit review
- [ ] Reviewer worker (`onlyhyeok-cmd`) approval
- [ ] Auto-merge into dev once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)