### PR TITLE
test(party/create): Step1-3 widget tests — party create wizard coverage

### DIFF
--- a/apps/app_partner/test/src/features/party/create/steps/step1_basic_info_test.dart
+++ b/apps/app_partner/test/src/features/party/create/steps/step1_basic_info_test.dart
@@ -17,10 +17,10 @@ Widget _buildStep1({
         () => _FakeWizardController(state),
       ),
     ],
-    child: MaterialApp(
+    child: const MaterialApp(
       localizationsDelegates: kPartnerLocalizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: const Scaffold(
+      home: Scaffold(
         body: SingleChildScrollView(child: Step1BasicInfo()),
       ),
     ),

--- a/apps/app_partner/test/src/features/party/create/steps/step1_basic_info_test.dart
+++ b/apps/app_partner/test/src/features/party/create/steps/step1_basic_info_test.dart
@@ -1,0 +1,83 @@
+// Fix #1538 regression guard: Step1 uses kPartnerLocalizationsDelegates
+// (includes FlutterQuillLocalizations.delegate) — must pumpAndSettle for Quill.
+import 'package:app_partner/main.dart' show kPartnerLocalizationsDelegates;
+import 'package:app_partner/src/features/party/create/party_create_wizard_controller.dart';
+import 'package:app_partner/src/features/party/create/steps/step1_basic_info.dart';
+import 'package:app_partner/src/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+Widget _buildStep1({
+  PartyCreateWizardState state = const PartyCreateWizardState(),
+}) {
+  return ProviderScope(
+    overrides: [
+      partyCreateWizardControllerProvider.overrideWith(
+        () => _FakeWizardController(state),
+      ),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: kPartnerLocalizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: const Scaffold(
+        body: SingleChildScrollView(child: Step1BasicInfo()),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('Step1BasicInfo', () {
+    testWidgets('크래시 없이 렌더링됨', (tester) async {
+      await tester.pumpWidget(_buildStep1());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Step1BasicInfo), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('파티 제목 / 상세 설명 / 커버 이미지 섹션 라벨 표시됨', (tester) async {
+      await tester.pumpWidget(_buildStep1());
+      await tester.pumpAndSettle();
+
+      expect(find.text('파티 제목'), findsOneWidget);
+      expect(find.text('상세 설명'), findsOneWidget);
+      expect(find.text('커버 이미지'), findsOneWidget);
+    });
+
+    testWidgets('비공개 스위치 기본값 off (visibility == public)', (tester) async {
+      await tester.pumpWidget(_buildStep1());
+      await tester.pumpAndSettle();
+
+      final switchFinder = find.byType(SwitchListTile);
+      expect(switchFinder, findsOneWidget);
+      final switchWidget = tester.widget<SwitchListTile>(switchFinder);
+      expect(switchWidget.value, isFalse);
+    });
+
+    testWidgets('비공개 스위치 토글 → visibility private으로 변경', (tester) async {
+      await tester.pumpWidget(_buildStep1());
+      await tester.pumpAndSettle();
+
+      final switchFinder = find.byType(SwitchListTile);
+      await tester.ensureVisible(switchFinder);
+      await tester.tap(switchFinder);
+      await tester.pump();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(Step1BasicInfo)),
+      );
+      final state = container.read(partyCreateWizardControllerProvider);
+      expect(state.visibility, 'private');
+    });
+  });
+}
+
+class _FakeWizardController extends PartyCreateWizardController {
+  _FakeWizardController(this._initialState);
+  final PartyCreateWizardState _initialState;
+
+  @override
+  PartyCreateWizardState build() => _initialState;
+}

--- a/apps/app_partner/test/src/features/party/create/steps/step2_location_test.dart
+++ b/apps/app_partner/test/src/features/party/create/steps/step2_location_test.dart
@@ -17,10 +17,10 @@ Widget _buildStep2({
         () => _FakeWizardController(state),
       ),
     ],
-    child: MaterialApp(
+    child: const MaterialApp(
       localizationsDelegates: kPartnerLocalizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: const Scaffold(
+      home: Scaffold(
         body: SingleChildScrollView(child: Step2Location()),
       ),
     ),

--- a/apps/app_partner/test/src/features/party/create/steps/step2_location_test.dart
+++ b/apps/app_partner/test/src/features/party/create/steps/step2_location_test.dart
@@ -1,0 +1,74 @@
+import 'package:app_partner/main.dart' show kPartnerLocalizationsDelegates;
+import 'package:app_partner/src/features/party/create/party_create_wizard_controller.dart';
+import 'package:app_partner/src/features/party/create/steps/step2_location.dart';
+import 'package:app_partner/src/features/party/widgets/party_location_detail_input.dart';
+import 'package:app_partner/src/features/party/widgets/party_location_input.dart';
+import 'package:app_partner/src/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+Widget _buildStep2({
+  PartyCreateWizardState state = const PartyCreateWizardState(),
+}) {
+  return ProviderScope(
+    overrides: [
+      partyCreateWizardControllerProvider.overrideWith(
+        () => _FakeWizardController(state),
+      ),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: kPartnerLocalizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: const Scaffold(
+        body: SingleChildScrollView(child: Step2Location()),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('Step2Location', () {
+    testWidgets('크래시 없이 렌더링됨', (tester) async {
+      await tester.pumpWidget(_buildStep2());
+      await tester.pump();
+
+      expect(find.byType(Step2Location), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('파티 장소 라벨과 PartyLocationInput 표시됨', (tester) async {
+      await tester.pumpWidget(_buildStep2());
+      await tester.pump();
+
+      expect(find.text('파티 장소'), findsOneWidget);
+      expect(find.byType(PartyLocationInput), findsOneWidget);
+    });
+
+    testWidgets('PartyLocationDetailInput 표시됨', (tester) async {
+      await tester.pumpWidget(_buildStep2());
+      await tester.pump();
+
+      expect(find.byType(PartyLocationDetailInput), findsOneWidget);
+    });
+
+    testWidgets('장소 미선택 시 입력 필드 비활성 힌트 표시됨', (tester) async {
+      // selectedLocation == null → enabled: false → hint '장소를 먼저 선택해주세요.'
+      await tester.pumpWidget(_buildStep2());
+      await tester.pump();
+
+      expect(
+        find.text('장소를 먼저 선택해주세요.'),
+        findsWidgets,
+      );
+    });
+  });
+}
+
+class _FakeWizardController extends PartyCreateWizardController {
+  _FakeWizardController(this._initialState);
+  final PartyCreateWizardState _initialState;
+
+  @override
+  PartyCreateWizardState build() => _initialState;
+}

--- a/apps/app_partner/test/src/features/party/create/steps/step3_capacity_contact_test.dart
+++ b/apps/app_partner/test/src/features/party/create/steps/step3_capacity_contact_test.dart
@@ -20,10 +20,10 @@ Widget _buildStep3({
       // Prevent network call; no autofill behavior needed in widget tests
       currentPartnerInfoProvider.overrideWith((ref) async => null),
     ],
-    child: MaterialApp(
+    child: const MaterialApp(
       localizationsDelegates: kPartnerLocalizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: const Scaffold(
+      home: Scaffold(
         body: SingleChildScrollView(child: Step3CapacityContact()),
       ),
     ),
@@ -40,22 +40,22 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
-    testWidgets('모집 인원 / 문의 연락처 라벨, PartyCapacityInput, PartyContactInput 표시됨',
-        (tester) async {
-      await tester.pumpWidget(_buildStep3());
-      await tester.pump();
+    testWidgets(
+      '모집 인원 / 문의 연락처 라벨, PartyCapacityInput, PartyContactInput 표시됨',
+      (tester) async {
+        await tester.pumpWidget(_buildStep3());
+        await tester.pump();
 
-      expect(find.text('모집 인원'), findsOneWidget);
-      expect(find.text('문의 연락처'), findsOneWidget);
-      expect(find.byType(PartyCapacityInput), findsOneWidget);
-      expect(find.byType(PartyContactInput), findsOneWidget);
-    });
+        expect(find.text('모집 인원'), findsOneWidget);
+        expect(find.text('문의 연락처'), findsOneWidget);
+        expect(find.byType(PartyCapacityInput), findsOneWidget);
+        expect(find.byType(PartyContactInput), findsOneWidget);
+      },
+    );
 
     testWidgets('성비 균형 off 시 허용 오차 NumberStepper 숨김', (tester) async {
       await tester.pumpWidget(
-        _buildStep3(
-          state: const PartyCreateWizardState(balanceEnabled: false),
-        ),
+        _buildStep3(),
       );
       await tester.pump();
 

--- a/apps/app_partner/test/src/features/party/create/steps/step3_capacity_contact_test.dart
+++ b/apps/app_partner/test/src/features/party/create/steps/step3_capacity_contact_test.dart
@@ -1,0 +1,84 @@
+import 'package:app_partner/main.dart' show kPartnerLocalizationsDelegates;
+import 'package:app_partner/src/features/party/create/party_create_wizard_controller.dart';
+import 'package:app_partner/src/features/party/create/steps/step3_capacity_contact.dart';
+import 'package:app_partner/src/features/party/widgets/party_capacity_input.dart';
+import 'package:app_partner/src/features/party/widgets/party_contact_input.dart';
+import 'package:app_partner/src/l10n/generated/app_localizations.dart';
+import 'package:app_partner/src/logic/current_partner_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+Widget _buildStep3({
+  PartyCreateWizardState state = const PartyCreateWizardState(),
+}) {
+  return ProviderScope(
+    overrides: [
+      partyCreateWizardControllerProvider.overrideWith(
+        () => _FakeWizardController(state),
+      ),
+      // Prevent network call; no autofill behavior needed in widget tests
+      currentPartnerInfoProvider.overrideWith((ref) async => null),
+    ],
+    child: MaterialApp(
+      localizationsDelegates: kPartnerLocalizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: const Scaffold(
+        body: SingleChildScrollView(child: Step3CapacityContact()),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('Step3CapacityContact', () {
+    testWidgets('크래시 없이 렌더링됨', (tester) async {
+      await tester.pumpWidget(_buildStep3());
+      await tester.pump();
+
+      expect(find.byType(Step3CapacityContact), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('모집 인원 / 문의 연락처 라벨, PartyCapacityInput, PartyContactInput 표시됨',
+        (tester) async {
+      await tester.pumpWidget(_buildStep3());
+      await tester.pump();
+
+      expect(find.text('모집 인원'), findsOneWidget);
+      expect(find.text('문의 연락처'), findsOneWidget);
+      expect(find.byType(PartyCapacityInput), findsOneWidget);
+      expect(find.byType(PartyContactInput), findsOneWidget);
+    });
+
+    testWidgets('성비 균형 off 시 허용 오차 NumberStepper 숨김', (tester) async {
+      await tester.pumpWidget(
+        _buildStep3(
+          state: const PartyCreateWizardState(balanceEnabled: false),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('허용 오차'), findsNothing);
+    });
+
+    testWidgets('성비 균형 on 시 허용 오차 NumberStepper 표시', (tester) async {
+      await tester.pumpWidget(
+        _buildStep3(
+          state: const PartyCreateWizardState(balanceEnabled: true),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('허용 오차'), findsOneWidget);
+    });
+  });
+}
+
+class _FakeWizardController extends PartyCreateWizardController {
+  _FakeWizardController(this._initialState);
+  final PartyCreateWizardState _initialState;
+
+  @override
+  PartyCreateWizardState build() => _initialState;
+}


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1876 (partial — P0 Step1-3)

Step1BasicInfo, Step2Location, Step3CapacityContact 위젯 테스트 12건 추가.

**Step1BasicInfo (4건)**: crash-free 렌더, 라벨 3개, 스위치 기본값, 스위치 토글 → visibility private
**Step2Location (4건)**: crash-free 렌더, 장소 라벨+PartyLocationInput, DetailInput, 비활성 힌트  
**Step3CapacityContact (4건)**: crash-free 렌더, 라벨+입력위젯, balance off→숨김, balance on→표시

연관: PR #1896 (merged), PR #1897 (in review)