### PR TITLE
chore(mds_storybook): mark deprecated, scheduled removal 2026-06

### DIFF
--- a/apps/mds/storybook/README.md
+++ b/apps/mds/storybook/README.md
@@ -1,10 +1,32 @@
-# mds_storybook
+# mds_storybook (DEPRECATED)
 
-Widgetbook-based storybook app for the Minglit Design System (MDS).
+> ⚠️ **This package is deprecated as of 2026-04. Scheduled for removal: 2026-06.**
+>
+> Use **mds_docs** (https://dev.design.minglit.com — TBD) as the canonical design system catalog.
+> The component-level showcase functionality of this app is being absorbed into `apps/mds/docs/components/` (Phase 2).
 
-Provides an isolated environment to browse and test MDS components without running the full app.
+## Why deprecated
 
-## Running
+- Maintaining two separate catalogs (Widgetbook + mds_docs) at minglit's team scale exceeds the value
+- Golden test infrastructure that justified Widgetbook is not yet active
+- Designers/PM workflow centers on browser-based mds_docs — Flutter-only Widgetbook adds friction
+- See `docs/architecture/mds-storybook-wiring-plan.md` for the original consolidation discussion
+
+## Migration path
+
+If you currently use mds_storybook for:
+
+| Use case | Replacement |
+|---|---|
+| Browse mds components | `apps/mds/docs/` `/components` page (Phase 2) |
+| Design review with isolated rendering | `apps/mds/docs/` + future component preview iframes |
+| Golden test snapshots | TBD — direct `alchemist` integration in `apps/mds/storybook` will be considered if/when golden tests become a priority |
+
+## Status
+
+Until removal, this app remains buildable and functional for backward compatibility. **Do not add new stories here** — author them in mds_docs `/components` instead.
+
+## Running (until removal)
 
 ```bash
 cd apps/mds/storybook
@@ -17,13 +39,8 @@ flutter run --flavor dev --target lib/main.dart
 flutter build apk --flavor dev --debug
 ```
 
-## Status
-
-This is the bootstrap skeleton (PoC). Real MDS component stories will be migrated from
-`features/dev/catalog_tabs/` in a follow-up PR once `shared/packages/mds/core` is wired in.
-
 ## Dependencies
 
-- [widgetbook](https://pub.dev/packages/widgetbook) ^3.22.0 — Flutter Storybook
-- [widgetbook_annotation](https://pub.dev/packages/widgetbook_annotation) ^3.11.0 — codegen annotations (for follow-up PR)
-- [widgetbook_generator](https://pub.dev/packages/widgetbook_generator) ^3.22.0 — build_runner codegen
+- [widgetbook](https://pub.dev/packages/widgetbook) ^3.22.0
+- [widgetbook_annotation](https://pub.dev/packages/widgetbook_annotation) ^3.11.0
+- [widgetbook_generator](https://pub.dev/packages/widgetbook_generator) ^3.22.0

--- a/apps/mds/storybook/lib/main.dart
+++ b/apps/mds/storybook/lib/main.dart
@@ -1,3 +1,8 @@
+// DEPRECATED — removal scheduled 2026-06.
+// Use apps/mds/docs (mds_docs) as the canonical Minglit Design System
+// catalog. Do NOT add new stories here.
+// See apps/mds/storybook/README.md for migration path.
+
 import 'package:flutter/material.dart';
 import 'package:mds/mds.dart';
 import 'package:widgetbook/widgetbook.dart';

--- a/apps/mds/storybook/pubspec.yaml
+++ b/apps/mds/storybook/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mds_storybook
-description: "Widgetbook app for Minglit Design System (MDS) component exploration."
+description: "[DEPRECATED — removal scheduled 2026-06] Widgetbook app for Minglit Design System (MDS). Use apps/mds/docs as the canonical catalog instead."
 publish_to: 'none'
 
 # Version follows YY.MM.PR# CalVer (CLAUDE.md). PR# = 1865 (bootstrap PR).


### PR DESCRIPTION
## Summary

Marks `apps/mds/storybook` as **deprecated** with scheduled removal in 2026-06. Per discussion during #1887, maintaining two design system catalogs (Widgetbook + mds_docs) at minglit's team scale exceeds value. mds_docs becomes the canonical catalog.

## What changed (lightweight, no code paths)

- `apps/mds/storybook/README.md`: rewritten with deprecation notice + migration table + status
- `apps/mds/storybook/pubspec.yaml`: description prefixed `[DEPRECATED — removal scheduled 2026-06]`
- `apps/mds/storybook/lib/main.dart`: top-of-file comment block warning future authors not to add stories

App still builds and tests pass.

## Migration path (in README)

| Use case | Replacement |
|---|---|
| Browse mds components | `apps/mds/docs` `/components` page (Phase 2) |
| Design review with isolated rendering | mds_docs + future component preview iframes |
| Golden test snapshots | TBD — direct alchemist integration if/when goldens become priority |

## Test plan

- [x] `apps/mds/storybook` flutter analyze: 0 errors (2 pre-existing infos)
- [x] `apps/mds/storybook` smoke test: PASS
- [ ] CI lint-mds-docs (none — only storybook touched)
- [ ] CodeRabbit review
- [ ] Auto-merge

## What's NOT in this PR

- Actual removal of mds_storybook (scheduled 2026-06 after mds_docs `/components` is built in Phase 2)
- mds_docs `/components` page implementation (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)