### PR TITLE
fix(security): gate health ?env=true behind service_role (#1944)

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -210,12 +210,13 @@ jobs:
       - name: Verify Edge Function env vars
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ANON_KEY: ${{ steps.env.outputs.PUBLISHABLE_KEY }}
+          # Fix #1944: ?env=true now requires service_role — anon key would return 401.
+          SERVICE_ROLE_KEY: ${{ steps.env.outputs.SERVICE_ROLE_KEY }}
           PROJECT_ID: ${{ steps.env.outputs.PROJECT_ID }}
           ENV_NAME: ${{ steps.env.outputs.ENV }}
         run: |
           RESPONSE=$(curl -sf "https://${PROJECT_ID}.supabase.co/functions/v1/health?env=true" \
-            -H "Authorization: Bearer ${ANON_KEY}" --max-time 15) || {
+            -H "Authorization: Bearer ${SERVICE_ROLE_KEY}" --max-time 15) || {
             echo "::warning::Health endpoint unreachable — skipping EF env check"
             exit 0
           }

--- a/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
+++ b/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:app_partner/src/logic/current_partner_provider.dart';
+import 'package:app_partner/src/routing/app_routes.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/minglit_kit.dart';

--- a/apps/app_partner/lib/src/features/application/event_application_manage_tab.dart
+++ b/apps/app_partner/lib/src/features/application/event_application_manage_tab.dart
@@ -220,9 +220,11 @@ class _ApplicationTab extends ConsumerWidget {
           context,
         ).showSnackBar(SnackBar(content: Text('$total건 승인 완료')));
       } else {
+        // Fix #1953: show all failed event titles, not just the first.
+        final failureList = failures.join('\n');
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text('일부 승인 실패 (${failures.length}건): ${failures.first}'),
+            content: Text('일부 승인 실패 (${failures.length}건):\n$failureList'),
           ),
         );
       }

--- a/apps/app_partner/lib/src/features/application/event_application_manage_widgets.dart
+++ b/apps/app_partner/lib/src/features/application/event_application_manage_widgets.dart
@@ -149,84 +149,92 @@ class _ApplicationItem extends StatelessWidget {
       timeAgo,
     ].join(' · ');
 
-    return Container(
-      padding: const EdgeInsets.symmetric(
-        horizontal: MinglitSpacing.medium,
-        vertical: MinglitSpacing.sm,
-      ),
-      decoration: BoxDecoration(
-        border: Border(
-          bottom: BorderSide(
-            color: theme.dividerColor.withValues(alpha: MinglitOpacity.muted),
+    // Fix #1860: 승인됨/거절됨 탭 항목 클릭 시 상세 화면으로 이동 (regression from refactor #1914)
+    return InkWell(
+      onTap: showActions
+          ? null
+          : () => EventApplicationDetailRoute(
+              applicationId: application.id,
+            ).push<void>(context),
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: MinglitSpacing.medium,
+          vertical: MinglitSpacing.sm,
+        ),
+        decoration: BoxDecoration(
+          border: Border(
+            bottom: BorderSide(
+              color: theme.dividerColor.withValues(alpha: MinglitOpacity.muted),
+            ),
           ),
         ),
-      ),
-      child: Row(
-        children: [
-          // Avatar
-          CircleAvatar(
-            radius: 20,
-            backgroundColor: theme.colorScheme.primary.withValues(
-              alpha: MinglitOpacity.highlight,
-            ),
-            child: Text(
-              name.isNotEmpty ? name[0] : '?',
-              style: theme.textTheme.titleSmall?.copyWith(
-                color: theme.colorScheme.primary,
-                fontWeight: FontWeight.w700,
+        child: Row(
+          children: [
+            // Avatar
+            CircleAvatar(
+              radius: 20,
+              backgroundColor: theme.colorScheme.primary.withValues(
+                alpha: MinglitOpacity.highlight,
+              ),
+              child: Text(
+                name.isNotEmpty ? name[0] : '?',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  color: theme.colorScheme.primary,
+                  fontWeight: FontWeight.w700,
+                ),
               ),
             ),
-          ),
-          const SizedBox(width: MinglitSpacing.sm),
-          // Info
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  name,
-                  style: theme.textTheme.labelLarge?.copyWith(
-                    fontWeight: FontWeight.w700,
+            const SizedBox(width: MinglitSpacing.sm),
+            // Info
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    name,
+                    style: theme.textTheme.labelLarge?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
                   ),
+                  Text(subtitle, style: theme.textTheme.labelSmall),
+                ],
+              ),
+            ),
+            // Actions or status
+            if (showActions) ...[
+              IconButton(
+                icon: const Icon(
+                  Icons.close,
+                  color: MinglitColors.error,
+                  size: MinglitIconSize.small,
                 ),
-                Text(subtitle, style: theme.textTheme.labelSmall),
-              ],
-            ),
-          ),
-          // Actions or status
-          if (showActions) ...[
-            IconButton(
-              icon: const Icon(
-                Icons.close,
-                color: MinglitColors.error,
-                size: MinglitIconSize.small,
-              ),
-              onPressed: onReject,
-              tooltip: '거절',
-              style: IconButton.styleFrom(
-                shape: CircleBorder(
-                  side: BorderSide(color: theme.dividerColor),
+                onPressed: onReject,
+                tooltip: '거절',
+                style: IconButton.styleFrom(
+                  shape: CircleBorder(
+                    side: BorderSide(color: theme.dividerColor),
+                  ),
+                  minimumSize: const Size(36, 36),
                 ),
-                minimumSize: const Size(36, 36),
               ),
-            ),
-            const SizedBox(width: MinglitSpacing.xsmall),
-            IconButton(
-              icon: Icon(
-                Icons.check,
-                color: theme.colorScheme.onPrimary,
-                size: MinglitIconSize.small,
+              const SizedBox(width: MinglitSpacing.xsmall),
+              IconButton(
+                icon: Icon(
+                  Icons.check,
+                  color: theme.colorScheme.onPrimary,
+                  size: MinglitIconSize.small,
+                ),
+                onPressed: onApprove,
+                tooltip: '승인',
+                style: IconButton.styleFrom(
+                  backgroundColor: theme.colorScheme.primary,
+                  minimumSize: const Size(36, 36),
+                ),
               ),
-              onPressed: onApprove,
-              tooltip: '승인',
-              style: IconButton.styleFrom(
-                backgroundColor: theme.colorScheme.primary,
-                minimumSize: const Size(36, 36),
-              ),
-            ),
-          ] else
-            _StatusBadge(status: application.status),
-        ],
+            ] else
+              _StatusBadge(status: application.status),
+          ],
+        ),
       ),
     );
   }

--- a/apps/app_partner/pubspec.yaml
+++ b/apps/app_partner/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1974-dev+26041974
+version: 26.04.1982-dev+26041982
 resolution: workspace
 
 environment:

--- a/apps/app_partner/pubspec.yaml
+++ b/apps/app_partner/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1933-dev+26041933
+version: 26.04.1974-dev+26041974
 resolution: workspace
 
 environment:

--- a/apps/app_partner/pubspec.yaml
+++ b/apps/app_partner/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1975-dev+26041975
+version: 26.04.1933-dev+26041933
 resolution: workspace
 
 environment:

--- a/apps/app_partner/pubspec.yaml
+++ b/apps/app_partner/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1980-dev+26041980
+version: 26.04.1978-dev+26041978
 resolution: workspace
 
 environment:

--- a/apps/app_partner/pubspec.yaml
+++ b/apps/app_partner/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1978-dev+26041978
+version: 26.04.1977-dev+26041977
 resolution: workspace
 
 environment:

--- a/apps/app_partner/pubspec.yaml
+++ b/apps/app_partner/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1981-dev+26041981
+version: 26.04.1979-dev+26041979
 resolution: workspace
 
 environment:

--- a/apps/app_partner/pubspec.yaml
+++ b/apps/app_partner/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1969-dev+26041969
+version: 26.04.1981-dev+26041981
 resolution: workspace
 
 environment:

--- a/apps/app_partner/pubspec.yaml
+++ b/apps/app_partner/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1979-dev+26041979
+version: 26.04.1980-dev+26041980
 resolution: workspace
 
 environment:

--- a/apps/app_partner/pubspec.yaml
+++ b/apps/app_partner/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1976-dev+26041976
+version: 26.04.1975-dev+26041975
 resolution: workspace
 
 environment:

--- a/apps/app_partner/pubspec.yaml
+++ b/apps/app_partner/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1977-dev+26041977
+version: 26.04.1976-dev+26041976
 resolution: workspace
 
 environment:

--- a/apps/app_partner/test/src/features/application/ui/event_application_manage_page_test.dart
+++ b/apps/app_partner/test/src/features/application/ui/event_application_manage_page_test.dart
@@ -302,6 +302,80 @@ void main() {
     });
   });
 
+  // Fix #1953: bulk-approve partial failure must show ALL failed event titles.
+  group('bulk approve failure message', () {
+    testWidgets(
+      'shows all failed event titles on partial failure (not just first)',
+      (tester) async {
+        final mockEventRepo = _MockEventRepository();
+
+        final event2 = Event(
+          id: 'event_2',
+          partyId: 'party_1',
+          title: '이벤트 B',
+          startTime: now.add(const Duration(hours: 3)),
+          endTime: now.add(const Duration(hours: 6)),
+          createdAt: now,
+          updatedAt: now,
+          currentParticipants: 2,
+        );
+
+        when(
+          () => mockEventRepo.bulkApproveApplications(
+            eventId: any(named: 'eventId'),
+          ),
+        ).thenThrow(Exception('서버 오류'));
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              currentPartnerInfoProvider.overrideWith(
+                (ref) async => testPartner,
+              ),
+              eventApplicationsGroupedProvider.overrideWith(
+                (ref, params) async => params.statusFilter.contains('pending')
+                    ? {
+                        testEvent: [
+                          makeApp(id: 'app_1', status: 'pending'),
+                        ],
+                        event2: [
+                          makeApp(id: 'app_2', status: 'pending'),
+                        ],
+                      }
+                    : {},
+              ),
+              eventRepositoryProvider.overrideWithValue(mockEventRepo),
+            ].cast(),
+            child: const MaterialApp(home: EventApplicationManagePage()),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Tap bulk approve button
+        await tester.tap(find.textContaining('전체 승인 (2건)'));
+        await tester.pumpAndSettle();
+
+        // Confirm the dialog
+        await tester.tap(
+          find.widgetWithText(TextButton, '전체 승인').last,
+        );
+        await tester.pumpAndSettle();
+
+        // Fix #1953: snackbar must contain both event titles.
+        final snackbarText = tester
+            .widget<Text>(
+              find.descendant(
+                of: find.byType(SnackBar),
+                matching: find.byType(Text),
+              ),
+            )
+            .data!;
+        expect(snackbarText, contains(testEvent.title));
+        expect(snackbarText, contains(event2.title));
+      },
+    );
+  });
+
   // Fix #1597: verify concurrent RPC calls are bounded to ≤10 per chunk.
   group('eventApplicationsGroupedProvider chunk concurrency', () {
     test(

--- a/apps/app_partner/test/src/ui/bug_report_fab_global_test.dart
+++ b/apps/app_partner/test/src/ui/bug_report_fab_global_test.dart
@@ -1,0 +1,94 @@
+// Regression tests for #1858: BugReportFab must be visible in partner app
+// via BugReporterWrapper overlay (Fix #1858, PR #1885).
+//
+// Failure condition: someone removes BugReporterWrapper from main.dart or
+// sets enabled: false — both scenarios are covered below.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+void main() {
+  group('BugReportFab 회귀 (#1858)', () {
+    // Verifies the core mechanism: BugReporterWrapper registers the callback
+    // that allows BugReportFab to render. Without it the FAB stays invisible
+    // even when bugReportFabVisibleProvider is true.
+    testWidgets(
+      'BugReporterWrapper 없으면 FAB toggle해도 나타나지 않는다',
+      (tester) async {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(
+              // No BugReporterWrapper — simulates the bug from #1858.
+              home: Scaffold(body: Text('content')),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // Toggle visible — but callback was never registered, so FAB stays hidden.
+        container.read(bugReportFabVisibleProvider.notifier).toggle();
+        await tester.pump();
+
+        expect(find.byType(FloatingActionButton), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'BugReporterWrapper 있으면 FAB toggle 시 나타난다',
+      (tester) async {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(
+              home: Scaffold(
+                body: BugReporterWrapper(child: Text('content')),
+              ),
+            ),
+          ),
+        );
+        // postFrameCallback fires — BugReporterWrapper registers callback.
+        await tester.pump();
+
+        container.read(bugReportFabVisibleProvider.notifier).toggle();
+        await tester.pump();
+
+        expect(find.byType(FloatingActionButton), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'enabled=false 시 FAB toggle해도 나타나지 않는다',
+      (tester) async {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(
+              home: Scaffold(
+                body: BugReporterWrapper(
+                  enabled: false,
+                  child: Text('content'),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        container.read(bugReportFabVisibleProvider.notifier).toggle();
+        await tester.pump();
+
+        expect(find.byType(FloatingActionButton), findsNothing);
+      },
+    );
+  });
+}

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1974-dev+26041974
+version: 26.04.1982-dev+26041982
 resolution: workspace
 
 environment:

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1933-dev+26041933
+version: 26.04.1974-dev+26041974
 resolution: workspace
 
 environment:

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1975-dev+26041975
+version: 26.04.1933-dev+26041933
 resolution: workspace
 
 environment:

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1980-dev+26041980
+version: 26.04.1978-dev+26041978
 resolution: workspace
 
 environment:

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1978-dev+26041978
+version: 26.04.1977-dev+26041977
 resolution: workspace
 
 environment:

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1981-dev+26041981
+version: 26.04.1979-dev+26041979
 resolution: workspace
 
 environment:

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1969-dev+26041969
+version: 26.04.1981-dev+26041981
 resolution: workspace
 
 environment:

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1979-dev+26041979
+version: 26.04.1980-dev+26041980
 resolution: workspace
 
 environment:

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1976-dev+26041976
+version: 26.04.1975-dev+26041975
 resolution: workspace
 
 environment:

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.04.1977-dev+26041977
+version: 26.04.1976-dev+26041976
 resolution: workspace
 
 environment:

--- a/apps/landing_partner/package.json
+++ b/apps/landing_partner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_partner",
-  "version": "26.04.1978-dev",
+  "version": "26.04.1977-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3003",

--- a/apps/landing_partner/package.json
+++ b/apps/landing_partner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_partner",
-  "version": "26.04.1975-dev",
+  "version": "26.04.1933-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3003",

--- a/apps/landing_partner/package.json
+++ b/apps/landing_partner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_partner",
-  "version": "26.04.1969-dev",
+  "version": "26.04.1981-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3003",

--- a/apps/landing_partner/package.json
+++ b/apps/landing_partner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_partner",
-  "version": "26.04.1933-dev",
+  "version": "26.04.1974-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3003",

--- a/apps/landing_partner/package.json
+++ b/apps/landing_partner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_partner",
-  "version": "26.04.1981-dev",
+  "version": "26.04.1979-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3003",

--- a/apps/landing_partner/package.json
+++ b/apps/landing_partner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_partner",
-  "version": "26.04.1974-dev",
+  "version": "26.04.1982-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3003",

--- a/apps/landing_partner/package.json
+++ b/apps/landing_partner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_partner",
-  "version": "26.04.1979-dev",
+  "version": "26.04.1980-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3003",

--- a/apps/landing_partner/package.json
+++ b/apps/landing_partner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_partner",
-  "version": "26.04.1980-dev",
+  "version": "26.04.1978-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3003",

--- a/apps/landing_partner/package.json
+++ b/apps/landing_partner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_partner",
-  "version": "26.04.1976-dev",
+  "version": "26.04.1975-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3003",

--- a/apps/landing_partner/package.json
+++ b/apps/landing_partner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_partner",
-  "version": "26.04.1977-dev",
+  "version": "26.04.1976-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3003",

--- a/apps/landing_user/package.json
+++ b/apps/landing_user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_user",
-  "version": "26.04.1978-dev",
+  "version": "26.04.1977-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",

--- a/apps/landing_user/package.json
+++ b/apps/landing_user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_user",
-  "version": "26.04.1933-dev",
+  "version": "26.04.1974-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",

--- a/apps/landing_user/package.json
+++ b/apps/landing_user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_user",
-  "version": "26.04.1974-dev",
+  "version": "26.04.1982-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",

--- a/apps/landing_user/package.json
+++ b/apps/landing_user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_user",
-  "version": "26.04.1975-dev",
+  "version": "26.04.1933-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",

--- a/apps/landing_user/package.json
+++ b/apps/landing_user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_user",
-  "version": "26.04.1976-dev",
+  "version": "26.04.1975-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",

--- a/apps/landing_user/package.json
+++ b/apps/landing_user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_user",
-  "version": "26.04.1977-dev",
+  "version": "26.04.1976-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",

--- a/apps/landing_user/package.json
+++ b/apps/landing_user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_user",
-  "version": "26.04.1981-dev",
+  "version": "26.04.1979-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",

--- a/apps/landing_user/package.json
+++ b/apps/landing_user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_user",
-  "version": "26.04.1979-dev",
+  "version": "26.04.1980-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",

--- a/apps/landing_user/package.json
+++ b/apps/landing_user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_user",
-  "version": "26.04.1969-dev",
+  "version": "26.04.1981-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",

--- a/apps/landing_user/package.json
+++ b/apps/landing_user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landing_user",
-  "version": "26.04.1980-dev",
+  "version": "26.04.1978-dev",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minglit-root",
-  "version": "26.04.1975-dev",
+  "version": "26.04.1933-dev",
   "private": true,
   "workspaces": [
     "apps/app_user",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minglit-root",
-  "version": "26.04.1977-dev",
+  "version": "26.04.1976-dev",
   "private": true,
   "workspaces": [
     "apps/app_user",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minglit-root",
-  "version": "26.04.1980-dev",
+  "version": "26.04.1978-dev",
   "private": true,
   "workspaces": [
     "apps/app_user",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minglit-root",
-  "version": "26.04.1979-dev",
+  "version": "26.04.1980-dev",
   "private": true,
   "workspaces": [
     "apps/app_user",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minglit-root",
-  "version": "26.04.1969-dev",
+  "version": "26.04.1981-dev",
   "private": true,
   "workspaces": [
     "apps/app_user",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,6 @@
   "version": "26.04.1982-dev",
   "private": true,
   "workspaces": [
-    "apps/app_user",
-    "apps/app_partner",
     "apps/landing_user",
     "apps/landing_partner",
     "apps/mds/docs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minglit-root",
-  "version": "26.04.1974-dev",
+  "version": "26.04.1982-dev",
   "private": true,
   "workspaces": [
     "apps/app_user",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minglit-root",
-  "version": "26.04.1933-dev",
+  "version": "26.04.1974-dev",
   "private": true,
   "workspaces": [
     "apps/app_user",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minglit-root",
-  "version": "26.04.1981-dev",
+  "version": "26.04.1979-dev",
   "private": true,
   "workspaces": [
     "apps/app_user",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minglit-root",
-  "version": "26.04.1978-dev",
+  "version": "26.04.1977-dev",
   "private": true,
   "workspaces": [
     "apps/app_user",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minglit-root",
-  "version": "26.04.1976-dev",
+  "version": "26.04.1975-dev",
   "private": true,
   "workspaces": [
     "apps/app_user",

--- a/shared/packages/mds/core/lib/src/ui/widgets/common/minglit_image.dart
+++ b/shared/packages/mds/core/lib/src/ui/widgets/common/minglit_image.dart
@@ -72,13 +72,7 @@ class MinglitImage extends StatelessWidget {
 
     ImageProvider provider;
 
-    // Derive pixel-aligned cache dimensions from logical size × DPR to avoid
-    // decoding full-resolution images for small thumbnails during scroll.
-    // Only applied when a finite, positive logical dimension is provided.
-    // Guard against double.infinity (e.g. callers that pass width: double.infinity
-    // for fill-parent semantics) — infinity × DPR cannot be converted to int.
-    // perf: cacheWidth/cacheHeight reduce memory and decode cost on scroll.
-    // Directive: cacheW must always be paired with a finite explicit width param.
+    // perf: decode at physical pixel size to avoid full-res decode on scroll.
     final dpr = MediaQuery.devicePixelRatioOf(context);
     final cacheW = (width != null && width!.isFinite && width! > 0)
         ? (width! * dpr).round()

--- a/shared/packages/minglit_iamport_v1/pubspec.yaml
+++ b/shared/packages/minglit_iamport_v1/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_iamport_v1
 description: "Iamport V1 Payment and Certification package for Minglit."
-version: 26.04.1933-dev
+version: 26.04.1974-dev
 publish_to: 'none'
 
 environment:

--- a/shared/packages/minglit_iamport_v1/pubspec.yaml
+++ b/shared/packages/minglit_iamport_v1/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_iamport_v1
 description: "Iamport V1 Payment and Certification package for Minglit."
-version: 26.04.1980-dev
+version: 26.04.1978-dev
 publish_to: 'none'
 
 environment:

--- a/shared/packages/minglit_iamport_v1/pubspec.yaml
+++ b/shared/packages/minglit_iamport_v1/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_iamport_v1
 description: "Iamport V1 Payment and Certification package for Minglit."
-version: 26.04.1978-dev
+version: 26.04.1977-dev
 publish_to: 'none'
 
 environment:

--- a/shared/packages/minglit_iamport_v1/pubspec.yaml
+++ b/shared/packages/minglit_iamport_v1/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_iamport_v1
 description: "Iamport V1 Payment and Certification package for Minglit."
-version: 26.04.1969-dev
+version: 26.04.1981-dev
 publish_to: 'none'
 
 environment:

--- a/shared/packages/minglit_iamport_v1/pubspec.yaml
+++ b/shared/packages/minglit_iamport_v1/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_iamport_v1
 description: "Iamport V1 Payment and Certification package for Minglit."
-version: 26.04.1976-dev
+version: 26.04.1975-dev
 publish_to: 'none'
 
 environment:

--- a/shared/packages/minglit_iamport_v1/pubspec.yaml
+++ b/shared/packages/minglit_iamport_v1/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_iamport_v1
 description: "Iamport V1 Payment and Certification package for Minglit."
-version: 26.04.1974-dev
+version: 26.04.1982-dev
 publish_to: 'none'
 
 environment:

--- a/shared/packages/minglit_iamport_v1/pubspec.yaml
+++ b/shared/packages/minglit_iamport_v1/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_iamport_v1
 description: "Iamport V1 Payment and Certification package for Minglit."
-version: 26.04.1979-dev
+version: 26.04.1980-dev
 publish_to: 'none'
 
 environment:

--- a/shared/packages/minglit_iamport_v1/pubspec.yaml
+++ b/shared/packages/minglit_iamport_v1/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_iamport_v1
 description: "Iamport V1 Payment and Certification package for Minglit."
-version: 26.04.1981-dev
+version: 26.04.1979-dev
 publish_to: 'none'
 
 environment:

--- a/shared/packages/minglit_iamport_v1/pubspec.yaml
+++ b/shared/packages/minglit_iamport_v1/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_iamport_v1
 description: "Iamport V1 Payment and Certification package for Minglit."
-version: 26.04.1977-dev
+version: 26.04.1976-dev
 publish_to: 'none'
 
 environment:

--- a/shared/packages/minglit_iamport_v1/pubspec.yaml
+++ b/shared/packages/minglit_iamport_v1/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_iamport_v1
 description: "Iamport V1 Payment and Certification package for Minglit."
-version: 26.04.1975-dev
+version: 26.04.1933-dev
 publish_to: 'none'
 
 environment:

--- a/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_commands.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_commands.dart
@@ -96,10 +96,18 @@ mixin _EventRepositoryCommands
   }) async {
     Log.d('confirmPayment called | impUid: $impUid');
     try {
-      await supabaseClient.functions.invoke(
+      // Fix #1945: functions.invoke() never throws on 4xx/5xx — check status.
+      final response = await supabaseClient.functions.invoke(
         'payment-verify',
         body: {'imp_uid': impUid, 'merchant_uid': merchantUid},
       );
+      if (response.status != 200) {
+        final data = response.data;
+        final msg = data is Map
+            ? (data['error'] as String?) ?? '결제 검증에 실패했습니다.'
+            : '결제 검증에 실패했습니다.';
+        throw MinglitUserException(msg);
+      }
       Log.i('✅ [EventRepo] Payment verified.');
     } catch (e, st) {
       Log.e('❌ [EventRepo] confirmPayment Error', e, st);
@@ -197,10 +205,18 @@ mixin _EventRepositoryCommands
   Future<void> approveApplication({required String applicationId}) async {
     Log.d('approveApplication called | applicationId: $applicationId');
     try {
-      await supabaseClient.functions.invoke(
+      // Fix #1945: functions.invoke() never throws on 4xx/5xx — check status.
+      final response = await supabaseClient.functions.invoke(
         'partner-approve-application',
         body: {'action': 'approve', 'application_id': applicationId},
       );
+      if (response.status != 200) {
+        final data = response.data;
+        final msg = data is Map
+            ? (data['error'] as String?) ?? '승인 요청에 실패했습니다.'
+            : '승인 요청에 실패했습니다.';
+        throw MinglitUserException(msg);
+      }
       Log.i('✅ [EventRepo] Application approved: $applicationId');
     } catch (e, st) {
       Log.e('❌ [EventRepo] approveApplication Error', e, st);
@@ -215,10 +231,18 @@ mixin _EventRepositoryCommands
   }) async {
     Log.d('rejectApplication called | applicationId: $applicationId');
     try {
-      await supabaseClient.functions.invoke(
+      // Fix #1945: functions.invoke() never throws on 4xx/5xx — check status.
+      final response = await supabaseClient.functions.invoke(
         'partner-reject-application',
         body: {'application_id': applicationId, 'reason': reason},
       );
+      if (response.status != 200) {
+        final data = response.data;
+        final msg = data is Map
+            ? (data['error'] as String?) ?? '거절 요청에 실패했습니다.'
+            : '거절 요청에 실패했습니다.';
+        throw MinglitUserException(msg);
+      }
       Log.i('✅ [EventRepo] Application rejected: $applicationId');
     } catch (e, st) {
       Log.e('❌ [EventRepo] rejectApplication Error', e, st);
@@ -230,10 +254,18 @@ mixin _EventRepositoryCommands
   Future<void> bulkApproveApplications({required String eventId}) async {
     Log.d('bulkApproveApplications called | eventId: $eventId');
     try {
-      await supabaseClient.functions.invoke(
+      // Fix #1945: functions.invoke() never throws on 4xx/5xx — check status.
+      final response = await supabaseClient.functions.invoke(
         'partner-approve-application',
         body: {'action': 'bulk_approve', 'event_id': eventId},
       );
+      if (response.status != 200) {
+        final data = response.data;
+        final msg = data is Map
+            ? (data['error'] as String?) ?? '일괄 승인에 실패했습니다.'
+            : '일괄 승인에 실패했습니다.';
+        throw MinglitUserException(msg);
+      }
       Log.i('✅ [EventRepo] Bulk approve completed for event: $eventId');
     } catch (e, st) {
       Log.e('❌ [EventRepo] bulkApproveApplications Error', e, st);

--- a/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_partner_queries.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_partner_queries.dart
@@ -70,8 +70,11 @@ mixin _EventRepositoryPartnerQueries on _SupabaseEventContext {
             'entryGroups:entry_groups(*), tickets(*)',
           )
           .eq('party.partner_id', partnerId)
-          .eq('status', 'scheduled')
-          .gte('start_time', DateTime.now().toIso8601String())
+          // Fix #1941: include active/ongoing so in-flight events stay visible.
+          // Fix #1941 v2: use gt('end_time') — ongoing events have start_time <= now
+          // so gte('start_time') incorrectly excludes them (end_time NOT NULL per schema).
+          .inFilter('status', ['scheduled', 'active', 'ongoing'])
+          .gt('end_time', DateTime.now().toIso8601String())
           .order('start_time');
       final result = data.map(Event.fromJson).toList();
 

--- a/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_queries.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_queries.dart
@@ -69,10 +69,16 @@ mixin _EventRepositoryQueries on _SupabaseEventContext {
       dynamic query = supabaseClient.from('events').select(selectQuery);
 
       // 2. Common Filters
+      // Fix #1941: include active/ongoing so events within 30-min pre-checkin
+      // window stay visible in the feed (status machine added in migration
+      // 20260405000001).
+      // Fix #1941 v2: ongoing events have start_time <= now, so gte('start_time')
+      // would exclude them. Use gt('end_time') instead — ongoing events are still
+      // running (end_time > now) and end_time is NOT NULL per schema.
       // ignore: avoid_dynamic_calls, Reason: Supabase builder chaining
-      query = query.eq('status', 'scheduled');
+      query = query.inFilter('status', ['scheduled', 'active', 'ongoing']);
       // ignore: avoid_dynamic_calls, Reason: Supabase builder chaining
-      query = query.gte('start_time', DateTime.now().toIso8601String());
+      query = query.gt('end_time', DateTime.now().toIso8601String());
       // ignore: avoid_dynamic_calls, Reason: Supabase builder chaining
       query = query.eq('party.visibility', 'public');
 

--- a/shared/packages/minglit_kit/lib/src/data/repositories/matching_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/matching_repository.dart
@@ -1,5 +1,6 @@
 import 'package:minglit_kit/src/data/models/matching.dart';
 import 'package:minglit_kit/src/data/models/user_profile.dart';
+import 'package:minglit_kit/src/utils/exceptions.dart';
 import 'package:minglit_kit/src/utils/log.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -81,7 +82,8 @@ class MatchingRepository {
     required List<Map<String, dynamic>> rules,
   }) async {
     try {
-      await _supabase.functions.invoke(
+      // Fix #1945: functions.invoke() never throws on 4xx/5xx — check status.
+      final response = await _supabase.functions.invoke(
         'partner-manage-match',
         body: {
           'action': 'set_rules',
@@ -98,6 +100,13 @@ class MatchingRepository {
           }).toList(),
         },
       );
+      if (response.status != 200) {
+        final data = response.data;
+        final msg = data is Map
+            ? (data['error'] as String?) ?? '매칭 규칙 설정에 실패했습니다.'
+            : '매칭 규칙 설정에 실패했습니다.';
+        throw MinglitUserException(msg);
+      }
       Log.d('updateMatchRules success | count: ${rules.length}');
     } catch (e, st) {
       Log.e('❌ [MatchingRepo] updateMatchRules Error', e, st);
@@ -109,13 +118,21 @@ class MatchingRepository {
   // Fix #305: RLS write → EF 전환
   Future<void> clearMatchRules({required String eventId}) async {
     try {
-      await _supabase.functions.invoke(
+      // Fix #1945: functions.invoke() never throws on 4xx/5xx — check status.
+      final response = await _supabase.functions.invoke(
         'partner-manage-match',
         body: {
           'action': 'clear_rules',
           'event_id': eventId,
         },
       );
+      if (response.status != 200) {
+        final data = response.data;
+        final msg = data is Map
+            ? (data['error'] as String?) ?? '매칭 규칙 초기화에 실패했습니다.'
+            : '매칭 규칙 초기화에 실패했습니다.';
+        throw MinglitUserException(msg);
+      }
       Log.d('clearMatchRules success | eventId: $eventId');
     } catch (e, st) {
       Log.e('❌ [MatchingRepo] clearMatchRules Error', e, st);
@@ -130,13 +147,21 @@ class MatchingRepository {
     required String candidateId,
   }) async {
     try {
-      await _supabase.functions.invoke(
+      // Fix #1945: functions.invoke() never throws on 4xx/5xx — check status.
+      final response = await _supabase.functions.invoke(
         'user-cast-vote',
         body: {
           'event_id': eventId,
           'candidate_id': candidateId,
         },
       );
+      if (response.status != 200) {
+        final data = response.data;
+        final msg = data is Map
+            ? (data['error'] as String?) ?? '투표 요청에 실패했습니다.'
+            : '투표 요청에 실패했습니다.';
+        throw MinglitUserException(msg);
+      }
       Log.d('castVote success | candidate: $candidateId');
     } catch (e, st) {
       Log.e('❌ [MatchingRepo] castVote Error', e, st);

--- a/shared/packages/minglit_kit/lib/src/data/repositories/notification_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/notification_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:minglit_kit/src/data/models/user_settings.dart';
+import 'package:minglit_kit/src/utils/log.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 /// Repository for user notification data and settings.
@@ -17,27 +18,37 @@ class NotificationRepository {
     required String token,
     required String deviceType,
   }) async {
-    final response = await _client.functions.invoke(
-      _efName,
-      body: {
-        'action': 'upsert_token',
-        'token': token,
-        'device_type': deviceType,
-      },
-    );
-    _ensureSuccess(response);
+    try {
+      final response = await _client.functions.invoke(
+        _efName,
+        body: {
+          'action': 'upsert_token',
+          'token': token,
+          'device_type': deviceType,
+        },
+      );
+      _ensureSuccess(response);
+    } catch (e, st) {
+      Log.e('❌ [NotificationRepo] upsertToken Error', e, st);
+      rethrow;
+    }
   }
 
   /// 로그아웃 시 토큰 삭제 (선택 사항)
   Future<void> deleteToken(String token) async {
-    final response = await _client.functions.invoke(
-      _efName,
-      body: {
-        'action': 'delete_token',
-        'token': token,
-      },
-    );
-    _ensureSuccess(response);
+    try {
+      final response = await _client.functions.invoke(
+        _efName,
+        body: {
+          'action': 'delete_token',
+          'token': token,
+        },
+      );
+      _ensureSuccess(response);
+    } catch (e, st) {
+      Log.e('❌ [NotificationRepo] deleteToken Error', e, st);
+      rethrow;
+    }
   }
 
   /// 알림 목록 조회 (페이지네이션)
@@ -45,44 +56,78 @@ class NotificationRepository {
     int limit = 20,
     int offset = 0,
   }) async {
-    return await _client
-        .from('user_notifications')
-        .select()
-        .order('created_at', ascending: false)
-        .range(offset, offset + limit - 1);
+    try {
+      return await _client
+          .from('user_notifications')
+          .select()
+          .order('created_at', ascending: false)
+          .range(offset, offset + limit - 1);
+    } catch (e, st) {
+      Log.e('❌ [NotificationRepo] getNotifications Error', e, st);
+      rethrow;
+    }
   }
 
   /// 알림 읽음 처리
+  ///
+  /// Fix #1955: swallows errors — read-state mutation failure must not
+  /// crash the UI; logged for debuggability.
   Future<void> markAsRead(String notificationId) async {
-    await _client
-        .from('user_notifications')
-        .update({'is_read': true})
-        .eq('id', notificationId);
+    try {
+      await _client
+          .from('user_notifications')
+          .update({'is_read': true})
+          .eq('id', notificationId);
+    } catch (e, st) {
+      Log.e('❌ [NotificationRepo] markAsRead Error', e, st);
+    }
   }
 
   /// 모든 알림 읽음 처리
+  ///
+  /// Fix #1955: swallows errors — read-state mutation failure must not
+  /// crash the UI; logged for debuggability.
   Future<void> markAllAsRead(String userId) async {
-    await _client
-        .from('user_notifications')
-        .update({'is_read': true})
-        .eq('user_id', userId);
+    try {
+      await _client
+          .from('user_notifications')
+          .update({'is_read': true})
+          .eq('user_id', userId);
+    } catch (e, st) {
+      Log.e('❌ [NotificationRepo] markAllAsRead Error', e, st);
+    }
   }
 
   /// 알림 삭제
+  ///
+  /// Fix #1955: swallows errors — delete failure must not crash the UI;
+  /// logged for debuggability.
   Future<void> deleteNotification(String notificationId) async {
-    await _client.from('user_notifications').delete().eq('id', notificationId);
+    try {
+      await _client
+          .from('user_notifications')
+          .delete()
+          .eq('id', notificationId);
+    } catch (e, st) {
+      Log.e('❌ [NotificationRepo] deleteNotification Error', e, st);
+    }
   }
 
   /// 유저 알림 설정 조회
   Future<UserSettings?> getSettings(String userId) async {
-    final response = await _client
-        .from('user_settings')
-        .select()
-        .eq('user_id', userId)
-        .maybeSingle();
+    try {
+      final response = await _client
+          .from('user_settings')
+          .select()
+          .eq('user_id', userId)
+          .maybeSingle();
 
-    if (response == null) return null;
-    return UserSettings.fromJson(response);
+      if (response == null) return null;
+      return UserSettings.fromJson(response);
+    } catch (e, st) {
+      Log.e('❌ [NotificationRepo] getSettings Error', e, st);
+      rethrow;
+    }
   }
 
   /// 유저 알림 설정 업데이트
@@ -90,21 +135,26 @@ class NotificationRepository {
     String userId,
     Map<String, dynamic> updates,
   ) async {
-    final response = await _client.functions.invoke(
-      _efName,
-      body: {
-        'action': 'update_settings',
-        'settings': updates,
-      },
-    );
-    _ensureSuccess(response);
+    try {
+      final response = await _client.functions.invoke(
+        _efName,
+        body: {
+          'action': 'update_settings',
+          'settings': updates,
+        },
+      );
+      _ensureSuccess(response);
 
-    final data = response.data is String
-        ? jsonDecode(response.data as String) as Map<String, dynamic>
-        : response.data as Map<String, dynamic>;
-    final settings = data['settings'] as Map<String, dynamic>?;
-    if (settings == null) return null;
-    return UserSettings.fromJson(settings);
+      final data = response.data is String
+          ? jsonDecode(response.data as String) as Map<String, dynamic>
+          : response.data as Map<String, dynamic>;
+      final settings = data['settings'] as Map<String, dynamic>?;
+      if (settings == null) return null;
+      return UserSettings.fromJson(settings);
+    } catch (e, st) {
+      Log.e('❌ [NotificationRepo] updateSettings Error', e, st);
+      rethrow;
+    }
   }
 
   void _ensureSuccess(FunctionResponse response) {

--- a/shared/packages/minglit_kit/lib/src/data/repositories/user_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/user_repository.dart
@@ -1,4 +1,5 @@
 import 'package:minglit_kit/src/data/models/user_profile.dart';
+import 'package:minglit_kit/src/utils/log.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -36,8 +37,14 @@ class SupabaseUserRepository implements UserRepository {
           .eq('id', userId)
           .single();
       return UserProfile.fromJson(data);
-    } on Object {
-      return null;
+    } on PostgrestException catch (e, st) {
+      // Fix #1952: PGRST116 = no rows — valid "not found" case.
+      if (e.code == 'PGRST116') return null;
+      Log.e('❌ [UserRepo] getUserProfile Error', e, st);
+      rethrow;
+    } catch (e, st) {
+      Log.e('❌ [UserRepo] getUserProfile Error', e, st);
+      rethrow;
     }
   }
 
@@ -55,8 +62,10 @@ class SupabaseUserRepository implements UserRepository {
           )
           .whereType<String>()
           .toList();
-    } on Object {
-      return [];
+    } catch (e, st) {
+      // Fix #1952: rethrow instead of silently returning [].
+      Log.e('❌ [UserRepo] getApprovedVerificationIds Error', e, st);
+      rethrow;
     }
   }
 }

--- a/shared/packages/minglit_kit/lib/src/logic/providers/user_profile_provider.dart
+++ b/shared/packages/minglit_kit/lib/src/logic/providers/user_profile_provider.dart
@@ -1,22 +1,17 @@
 import 'package:minglit_kit/src/data/models/user_profile.dart';
 import 'package:minglit_kit/src/data/repositories/auth_repository.dart';
+import 'package:minglit_kit/src/data/repositories/user_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 
 part 'user_profile_provider.g.dart';
 
 @Riverpod(keepAlive: true)
-/// Provides the current signed-in user's profile, if available.
+// Fix #1948: use UserRepository instead of direct Supabase — adds error handling,
+// PGRST116 → null, and a proper test seam.
 Future<UserProfile?> currentUserProfile(Ref ref) async {
   final user = ref.watch(currentUserProvider);
   if (user == null) return null;
 
-  final supabase = Supabase.instance.client;
-  final data = await supabase
-      .from('user_profiles')
-      .select()
-      .eq('id', user.id)
-      .single();
-
-  return UserProfile.fromJson(data);
+  final repo = ref.read(userRepositoryProvider);
+  return repo.getUserProfile(user.id);
 }

--- a/shared/packages/minglit_kit/lib/src/utils/supabase_image_url.dart
+++ b/shared/packages/minglit_kit/lib/src/utils/supabase_image_url.dart
@@ -26,13 +26,14 @@ String supabaseImageUrl(String url, {int? width, int quality = 70}) {
     return url;
   }
 
+  // Fix #1918: render path requires Image Transformations to be enabled in
+  // Supabase settings; skip the rewrite entirely when no transform is needed.
+  if (width == null) {
+    return url;
+  }
+
   // Rewrite public-object URLs to the render/image transform endpoint.
   final base = isObjectUrl ? url.replaceFirst(objectPath, renderPath) : url;
-
-  if (width == null) {
-    // No sizing requested — return (possibly rewritten) URL without query.
-    return base;
-  }
 
   // Merge width + quality into the existing query string.
   final uri = Uri.parse(base);

--- a/shared/packages/minglit_kit/pubspec.yaml
+++ b/shared/packages/minglit_kit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_kit
 description: "A new Flutter package project."
-version: 26.04.1974-dev
+version: 26.04.1982-dev
 resolution: workspace
 publish_to: 'none'
 environment:

--- a/shared/packages/minglit_kit/pubspec.yaml
+++ b/shared/packages/minglit_kit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_kit
 description: "A new Flutter package project."
-version: 26.04.1981-dev
+version: 26.04.1979-dev
 resolution: workspace
 publish_to: 'none'
 environment:

--- a/shared/packages/minglit_kit/pubspec.yaml
+++ b/shared/packages/minglit_kit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_kit
 description: "A new Flutter package project."
-version: 26.04.1975-dev
+version: 26.04.1933-dev
 resolution: workspace
 publish_to: 'none'
 environment:

--- a/shared/packages/minglit_kit/pubspec.yaml
+++ b/shared/packages/minglit_kit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_kit
 description: "A new Flutter package project."
-version: 26.04.1976-dev
+version: 26.04.1975-dev
 resolution: workspace
 publish_to: 'none'
 environment:

--- a/shared/packages/minglit_kit/pubspec.yaml
+++ b/shared/packages/minglit_kit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_kit
 description: "A new Flutter package project."
-version: 26.04.1977-dev
+version: 26.04.1976-dev
 resolution: workspace
 publish_to: 'none'
 environment:

--- a/shared/packages/minglit_kit/pubspec.yaml
+++ b/shared/packages/minglit_kit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_kit
 description: "A new Flutter package project."
-version: 26.04.1969-dev
+version: 26.04.1981-dev
 resolution: workspace
 publish_to: 'none'
 environment:

--- a/shared/packages/minglit_kit/pubspec.yaml
+++ b/shared/packages/minglit_kit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_kit
 description: "A new Flutter package project."
-version: 26.04.1978-dev
+version: 26.04.1977-dev
 resolution: workspace
 publish_to: 'none'
 environment:

--- a/shared/packages/minglit_kit/pubspec.yaml
+++ b/shared/packages/minglit_kit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_kit
 description: "A new Flutter package project."
-version: 26.04.1933-dev
+version: 26.04.1974-dev
 resolution: workspace
 publish_to: 'none'
 environment:

--- a/shared/packages/minglit_kit/pubspec.yaml
+++ b/shared/packages/minglit_kit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_kit
 description: "A new Flutter package project."
-version: 26.04.1979-dev
+version: 26.04.1980-dev
 resolution: workspace
 publish_to: 'none'
 environment:

--- a/shared/packages/minglit_kit/pubspec.yaml
+++ b/shared/packages/minglit_kit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_kit
 description: "A new Flutter package project."
-version: 26.04.1980-dev
+version: 26.04.1978-dev
 resolution: workspace
 publish_to: 'none'
 environment:

--- a/shared/packages/minglit_kit/test/helpers/supabase_mock_helpers.dart
+++ b/shared/packages/minglit_kit/test/helpers/supabase_mock_helpers.dart
@@ -277,6 +277,39 @@ class _FakeFilterBuilder extends Fake
   }
 
   @override
+  PostgrestFilterBuilder<List<Map<String, dynamic>>> gt(
+    String column,
+    Object value,
+  ) {
+    recordedFilters.add(
+      RecordedFilterOperation(method: 'gt', column: column, value: value),
+    );
+    return this;
+  }
+
+  @override
+  PostgrestFilterBuilder<List<Map<String, dynamic>>> lt(
+    String column,
+    Object value,
+  ) {
+    recordedFilters.add(
+      RecordedFilterOperation(method: 'lt', column: column, value: value),
+    );
+    return this;
+  }
+
+  @override
+  PostgrestFilterBuilder<List<Map<String, dynamic>>> or(
+    String filters, {
+    String? referencedTable,
+  }) {
+    recordedFilters.add(
+      RecordedFilterOperation(method: 'or', column: '*', value: filters),
+    );
+    return this;
+  }
+
+  @override
   PostgrestFilterBuilder<List<Map<String, dynamic>>> ilike(
     String column,
     String pattern,

--- a/shared/packages/minglit_kit/test/src/data/repositories/event_repository_commands_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/event_repository_commands_test.dart
@@ -254,6 +254,205 @@ void main() {
     });
   });
 
+  // Fix #1945: confirmPayment must throw on non-200 (functions.invoke never throws for HTTP errors)
+  group('EventRepository.confirmPayment', () {
+    test('completes without error on 200 response', () async {
+      when(
+        () => mockFunctions.invoke(
+          'payment-verify',
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer(
+        (_) async => FunctionResponse(status: 200, data: {'verified': true}),
+      );
+
+      await expectLater(
+        repository.confirmPayment(
+          impUid: 'imp_123',
+          merchantUid: 'merchant_123',
+        ),
+        completes,
+      );
+    });
+
+    test('throws MinglitUserException on non-200 with error message', () async {
+      when(
+        () => mockFunctions.invoke(
+          'payment-verify',
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer(
+        (_) async => FunctionResponse(
+          status: 400,
+          data: {'error': '결제 정보가 일치하지 않습니다.'},
+        ),
+      );
+
+      await expectLater(
+        repository.confirmPayment(
+          impUid: 'imp_bad',
+          merchantUid: 'merchant_bad',
+        ),
+        throwsA(
+          isA<MinglitUserException>().having(
+            (e) => e.message,
+            'message',
+            '결제 정보가 일치하지 않습니다.',
+          ),
+        ),
+      );
+    });
+
+    test('throws MinglitUserException on 500 with fallback message', () async {
+      when(
+        () => mockFunctions.invoke(
+          'payment-verify',
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer((_) async => FunctionResponse(status: 500));
+
+      await expectLater(
+        repository.confirmPayment(
+          impUid: 'imp_err',
+          merchantUid: 'merchant_err',
+        ),
+        throwsA(isA<MinglitUserException>()),
+      );
+    });
+  });
+
+  // Fix #1945: approveApplication must throw on non-200
+  group('EventRepository.approveApplication', () {
+    test('completes without error on 200 response', () async {
+      when(
+        () => mockFunctions.invoke(
+          'partner-approve-application',
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer(
+        (_) async => FunctionResponse(status: 200, data: {'approved': true}),
+      );
+
+      await expectLater(
+        repository.approveApplication(applicationId: 'app_1'),
+        completes,
+      );
+    });
+
+    test('throws MinglitUserException on non-200', () async {
+      when(
+        () => mockFunctions.invoke(
+          'partner-approve-application',
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer(
+        (_) async => FunctionResponse(
+          status: 409,
+          data: {'error': '이미 처리된 신청입니다.'},
+        ),
+      );
+
+      await expectLater(
+        repository.approveApplication(applicationId: 'app_1'),
+        throwsA(
+          isA<MinglitUserException>().having(
+            (e) => e.message,
+            'message',
+            '이미 처리된 신청입니다.',
+          ),
+        ),
+      );
+    });
+  });
+
+  // Fix #1945: rejectApplication must throw on non-200
+  group('EventRepository.rejectApplication', () {
+    test('completes without error on 200 response', () async {
+      when(
+        () => mockFunctions.invoke(
+          'partner-reject-application',
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer(
+        (_) async => FunctionResponse(status: 200, data: {'rejected': true}),
+      );
+
+      await expectLater(
+        repository.rejectApplication(
+          applicationId: 'app_1',
+          reason: '조건 불충족',
+        ),
+        completes,
+      );
+    });
+
+    test('throws MinglitUserException on non-200', () async {
+      when(
+        () => mockFunctions.invoke(
+          'partner-reject-application',
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer(
+        (_) async => FunctionResponse(
+          status: 500,
+          data: {'error': '서버 오류'},
+        ),
+      );
+
+      await expectLater(
+        repository.rejectApplication(
+          applicationId: 'app_1',
+          reason: '조건 불충족',
+        ),
+        throwsA(isA<MinglitUserException>()),
+      );
+    });
+  });
+
+  // Fix #1945: bulkApproveApplications must throw on non-200
+  group('EventRepository.bulkApproveApplications', () {
+    test('completes without error on 200 response', () async {
+      when(
+        () => mockFunctions.invoke(
+          'partner-approve-application',
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer(
+        (_) async => FunctionResponse(status: 200, data: {'approved': 5}),
+      );
+
+      await expectLater(
+        repository.bulkApproveApplications(eventId: 'event_1'),
+        completes,
+      );
+    });
+
+    test('throws MinglitUserException on non-200', () async {
+      when(
+        () => mockFunctions.invoke(
+          'partner-approve-application',
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer(
+        (_) async => FunctionResponse(
+          status: 500,
+          data: {'error': '일괄 승인 실패'},
+        ),
+      );
+
+      await expectLater(
+        repository.bulkApproveApplications(eventId: 'event_1'),
+        throwsA(
+          isA<MinglitUserException>().having(
+            (e) => e.message,
+            'message',
+            '일괄 승인 실패',
+          ),
+        ),
+      );
+    });
+  });
+
   group('EventRepository.deleteApplication', () {
     test('completes without error', () async {
       mockTable(mockClient, 'event_applications');

--- a/shared/packages/minglit_kit/test/src/data/repositories/event_repository_queries_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/event_repository_queries_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async' show unawaited;
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/data/models/event_feed_type.dart';
 import 'package:minglit_kit/src/data/repositories/event_repository.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -842,6 +843,80 @@ void main() {
       });
     });
 
+    // Fix #1941: active/ongoing events must appear in the user event feed
+    group('getEventsByType', () {
+      test(
+        'returns active-status event in feed (regression for #1941)',
+        () async {
+          final activeEventJson = {
+            ...eventJson,
+            'id': 'event_active',
+            'status': 'active',
+          };
+          unawaited(
+            mockTable(mockClient, 'events', selectData: [activeEventJson]),
+          );
+
+          final result = await repository.getEventsByType(
+            type: EventFeedType.newArrivals,
+          );
+
+          expect(result, hasLength(1));
+          expect(result.first.id, 'event_active');
+          expect(result.first.status, 'active');
+        },
+      );
+
+      // Fix #1941 v2: ongoing events have start_time in the PAST — the original
+      // gte('start_time', now) filter excluded them. Verify the query uses
+      // gt('end_time') instead, which correctly includes ongoing events.
+      test(
+        'returns ongoing-status event with past start_time in feed (regression for #1941)',
+        () async {
+          final ongoingEventJson = {
+            ...eventJson,
+            'id': 'event_ongoing',
+            'status': 'ongoing',
+            // Ongoing events have already started — start_time is in the past
+            'start_time': now
+                .subtract(const Duration(hours: 1))
+                .toIso8601String(),
+            'end_time': now.add(const Duration(hours: 2)).toIso8601String(),
+          };
+          final builder = mockTable(
+            mockClient,
+            'events',
+            selectData: [ongoingEventJson],
+          );
+
+          final result = await repository.getEventsByType(
+            type: EventFeedType.closingSoon,
+          );
+
+          expect(result, hasLength(1));
+          expect(result.first.status, 'ongoing');
+          // Filter must use gt('end_time'), NOT gte('start_time') —
+          // ongoing events have start_time <= now, so gte('start_time') would
+          // incorrectly exclude them from the feed.
+          expect(
+            builder.recordedFilters.any(
+              (f) => f.method == 'gt' && f.column == 'end_time',
+            ),
+            isTrue,
+            reason: 'expected gt(end_time) filter to include ongoing events',
+          );
+          expect(
+            builder.recordedFilters.any(
+              (f) => f.method == 'gte' && f.column == 'start_time',
+            ),
+            isFalse,
+            reason:
+                'gte(start_time) must not be used — it excludes ongoing events',
+          );
+        },
+      );
+    });
+
     group('getEventsByPartnerId', () {
       test('returns events for partner', () async {
         unawaited(
@@ -876,6 +951,69 @@ void main() {
           throwsA(anything),
         );
       });
+
+      // Fix #1941: active/ongoing events must appear in partner detail list
+      test('returns active-status event (regression for #1941)', () async {
+        final activeEventJson = {
+          ...eventJson,
+          'id': 'event_active',
+          'status': 'active',
+        };
+        unawaited(
+          mockTable(mockClient, 'events', selectData: [activeEventJson]),
+        );
+
+        final result = await repository.getEventsByPartnerId('partner_1');
+
+        expect(result, hasLength(1));
+        expect(result.first.id, 'event_active');
+        expect(result.first.status, 'active');
+      });
+
+      // Fix #1941 v2: ongoing events have start_time in the PAST — verify
+      // gt('end_time') is used so they are not excluded from the partner list.
+      test(
+        'returns ongoing-status event with past start_time (regression for #1941)',
+        () async {
+          final ongoingEventJson = {
+            ...eventJson,
+            'id': 'event_ongoing',
+            'status': 'ongoing',
+            // Ongoing events have already started — start_time is in the past
+            'start_time': now
+                .subtract(const Duration(hours: 1))
+                .toIso8601String(),
+            'end_time': now.add(const Duration(hours: 2)).toIso8601String(),
+          };
+          final builder = mockTable(
+            mockClient,
+            'events',
+            selectData: [ongoingEventJson],
+          );
+
+          final result = await repository.getEventsByPartnerId('partner_1');
+
+          expect(result, hasLength(1));
+          expect(result.first.status, 'ongoing');
+          // Filter must use gt('end_time') so ongoing events (start_time <= now)
+          // are not excluded.
+          expect(
+            builder.recordedFilters.any(
+              (f) => f.method == 'gt' && f.column == 'end_time',
+            ),
+            isTrue,
+            reason: 'expected gt(end_time) filter to include ongoing events',
+          );
+          expect(
+            builder.recordedFilters.any(
+              (f) => f.method == 'gte' && f.column == 'start_time',
+            ),
+            isFalse,
+            reason:
+                'gte(start_time) must not be used — it excludes ongoing events',
+          );
+        },
+      );
     });
 
     group('getTodayEvents', () {

--- a/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/models/matching.dart';
 import 'package:minglit_kit/src/data/models/user_profile.dart';
 import 'package:minglit_kit/src/data/repositories/matching_repository.dart';
+import 'package:minglit_kit/src/utils/exceptions.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -110,6 +111,31 @@ void main() {
         );
       });
 
+      // Fix #1945: non-200 must throw MinglitUserException
+      test('throws MinglitUserException on non-200 response', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-match',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 403,
+            data: {'error': '권한이 없습니다.'},
+          ),
+        );
+
+        await expectLater(
+          repository.updateMatchRules(
+            eventId: 'event_1',
+            rules: [
+              {'source_group_id': 'g1', 'target_group_id': 'g2'},
+            ],
+          ),
+          throwsA(isA<MinglitUserException>()),
+        );
+      });
+
       test('handles empty rules list via EF', () async {
         when(
           () => mockFunctions.invoke(
@@ -163,6 +189,26 @@ void main() {
           completes,
         );
       });
+
+      // Fix #1945: non-200 must throw MinglitUserException
+      test('throws MinglitUserException on non-200 response', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-match',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 500,
+            data: {'error': '서버 오류'},
+          ),
+        );
+
+        await expectLater(
+          repository.clearMatchRules(eventId: 'event_1'),
+          throwsA(isA<MinglitUserException>()),
+        );
+      });
     });
 
     // Fix #306: castVote → EF 전환 후 테스트 업데이트
@@ -193,6 +239,30 @@ void main() {
         expect(
           () => repository.castVote(eventId: 'event_1', candidateId: 'user_2'),
           throwsA(isA<Exception>()),
+        );
+      });
+
+      // Fix #1945: non-200 must throw MinglitUserException
+      test('throws MinglitUserException on non-200 response', () async {
+        when(
+          () =>
+              mockFunctions.invoke('user-cast-vote', body: any(named: 'body')),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 409,
+            data: {'error': '이미 투표했습니다.'},
+          ),
+        );
+
+        await expectLater(
+          repository.castVote(eventId: 'event_1', candidateId: 'user_2'),
+          throwsA(
+            isA<MinglitUserException>().having(
+              (e) => e.message,
+              'message',
+              '이미 투표했습니다.',
+            ),
+          ),
         );
       });
     });

--- a/shared/packages/minglit_kit/test/src/data/repositories/notification_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/notification_repository_test.dart
@@ -151,6 +151,23 @@ void main() {
       });
     });
 
+    group('getNotifications', () {
+      test('rethrows on error', () async {
+        unawaited(
+          mockTable(
+            mockClient,
+            'user_notifications',
+            shouldThrow: Exception('network error'),
+          ),
+        );
+
+        expect(
+          () => repository.getNotifications(),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
+
     group('markAsRead', () {
       test('completes without error', () async {
         unawaited(mockTable(mockClient, 'user_notifications'));
@@ -159,6 +176,19 @@ void main() {
           repository.markAsRead('notif_1'),
           completes,
         );
+      });
+
+      // Fix #1955: swallows error so read-state mutations don't crash the UI.
+      test('swallows error — does not throw on failure', () async {
+        unawaited(
+          mockTable(
+            mockClient,
+            'user_notifications',
+            shouldThrow: Exception('db error'),
+          ),
+        );
+
+        await expectLater(repository.markAsRead('notif_1'), completes);
       });
     });
 
@@ -171,11 +201,40 @@ void main() {
           completes,
         );
       });
+
+      // Fix #1955: swallows error so read-state mutations don't crash the UI.
+      test('swallows error — does not throw on failure', () async {
+        unawaited(
+          mockTable(
+            mockClient,
+            'user_notifications',
+            shouldThrow: Exception('db error'),
+          ),
+        );
+
+        await expectLater(repository.markAllAsRead('user_1'), completes);
+      });
     });
 
     group('deleteNotification', () {
       test('completes without error', () async {
         unawaited(mockTable(mockClient, 'user_notifications'));
+
+        await expectLater(
+          repository.deleteNotification('notif_1'),
+          completes,
+        );
+      });
+
+      // Fix #1955: swallows error so delete failures don't crash the UI.
+      test('swallows error — does not throw on failure', () async {
+        unawaited(
+          mockTable(
+            mockClient,
+            'user_notifications',
+            shouldThrow: Exception('db error'),
+          ),
+        );
 
         await expectLater(
           repository.deleteNotification('notif_1'),
@@ -211,6 +270,22 @@ void main() {
 
         final result = await repository.getSettings('user_unknown');
         expect(result, isNull);
+      });
+
+      // Fix #1955: read operations rethrow.
+      test('rethrows on error', () async {
+        unawaited(
+          mockTable(
+            mockClient,
+            'user_settings',
+            shouldThrow: Exception('network error'),
+          ),
+        );
+
+        expect(
+          () => repository.getSettings('user_1'),
+          throwsA(isA<Exception>()),
+        );
       });
     });
 

--- a/shared/packages/minglit_kit/test/src/data/repositories/user_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/user_repository_test.dart
@@ -2,6 +2,7 @@ import 'dart:async' show unawaited;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/repositories/user_repository.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../../helpers/mocks.dart';
 import '../../../helpers/supabase_mock_helpers.dart';
@@ -51,18 +52,55 @@ void main() {
         expect(result.birthYear, 1990);
       });
 
-      test('returns null on error', () async {
+      // Fix #1952: PGRST116 (no rows) → null; other errors → rethrow.
+      test('returns null for PGRST116 (no rows found)', () async {
         unawaited(
           mockTable(
             mockClient,
             'user_profiles',
-            shouldThrow: Exception('not found'),
+            shouldThrow: const PostgrestException(
+              message: 'no rows found',
+              code: 'PGRST116',
+            ),
           ),
         );
 
         final result = await repository.getUserProfile('user_unknown');
 
         expect(result, isNull);
+      });
+
+      test('rethrows on non-PGRST116 database error', () async {
+        unawaited(
+          mockTable(
+            mockClient,
+            'user_profiles',
+            shouldThrow: const PostgrestException(
+              message: 'server error',
+              code: '500',
+            ),
+          ),
+        );
+
+        expect(
+          () => repository.getUserProfile('user_1'),
+          throwsA(isA<PostgrestException>()),
+        );
+      });
+
+      test('rethrows on generic network error', () async {
+        unawaited(
+          mockTable(
+            mockClient,
+            'user_profiles',
+            shouldThrow: Exception('network failure'),
+          ),
+        );
+
+        expect(
+          () => repository.getUserProfile('user_1'),
+          throwsA(isA<Exception>()),
+        );
       });
     });
 
@@ -96,7 +134,8 @@ void main() {
         expect(result, isEmpty);
       });
 
-      test('returns empty list on error', () async {
+      // Fix #1952: errors must be rethrown, not silently dropped.
+      test('rethrows on error', () async {
         unawaited(
           mockTable(
             mockClient,
@@ -105,9 +144,10 @@ void main() {
           ),
         );
 
-        final result = await repository.getApprovedVerificationIds('user_1');
-
-        expect(result, isEmpty);
+        expect(
+          () => repository.getApprovedVerificationIds('user_1'),
+          throwsA(isA<Exception>()),
+        );
       });
 
       test('filters out null verification IDs', () async {

--- a/shared/packages/minglit_kit/test/src/logic/providers/current_user_profile_provider_test.dart
+++ b/shared/packages/minglit_kit/test/src/logic/providers/current_user_profile_provider_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/data/models/user_profile.dart';
+import 'package:minglit_kit/src/data/repositories/auth_repository.dart';
+import 'package:minglit_kit/src/data/repositories/user_repository.dart';
+import 'package:minglit_kit/src/logic/providers/user_profile_provider.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../../../helpers/test_utils.dart';
+
+class _MockUserRepository extends Mock implements UserRepository {}
+
+class _MockUser extends Mock implements User {}
+
+void main() {
+  late _MockUserRepository mockRepo;
+  late _MockUser mockUser;
+
+  const testProfile = UserProfile(
+    id: 'user_1',
+    name: '홍길동',
+    username: 'gildong',
+  );
+
+  setUp(() {
+    mockRepo = _MockUserRepository();
+    mockUser = _MockUser();
+    when(() => mockUser.id).thenReturn('user_1');
+  });
+
+  group('currentUserProfileProvider', () {
+    // Fix #1948: must route through UserRepository, not direct Supabase
+    test('returns null when user is not logged in', () async {
+      final container = createContainer(
+        overrides: [
+          currentUserProvider.overrideWith((ref) => null),
+          userRepositoryProvider.overrideWithValue(mockRepo),
+        ],
+      );
+
+      final result = await container.read(currentUserProfileProvider.future);
+
+      expect(result, isNull);
+      verifyNever(() => mockRepo.getUserProfile(any()));
+    });
+
+    test(
+      'returns profile from UserRepository when user is logged in',
+      () async {
+        when(
+          () => mockRepo.getUserProfile('user_1'),
+        ).thenAnswer((_) async => testProfile);
+
+        final container = createContainer(
+          overrides: [
+            currentUserProvider.overrideWith((ref) => mockUser),
+            userRepositoryProvider.overrideWithValue(mockRepo),
+          ],
+        );
+
+        final result = await container.read(currentUserProfileProvider.future);
+
+        expect(result, isNotNull);
+        expect(result!.id, 'user_1');
+        expect(result.name, '홍길동');
+        verify(() => mockRepo.getUserProfile('user_1')).called(1);
+      },
+    );
+
+    // Fix #1948: PGRST116 (no rows) should return null, not crash
+    test('returns null when UserRepository returns null (PGRST116)', () async {
+      when(
+        () => mockRepo.getUserProfile('user_1'),
+      ).thenAnswer((_) async => null);
+
+      final container = createContainer(
+        overrides: [
+          currentUserProvider.overrideWith((ref) => mockUser),
+          userRepositoryProvider.overrideWithValue(mockRepo),
+        ],
+      );
+
+      final result = await container.read(currentUserProfileProvider.future);
+
+      expect(result, isNull);
+    });
+
+    // Fix #1948: non-PGRST116 errors must propagate as AsyncError.
+    // Note: .future stays pending on keepAlive providers with Riverpod 3 retry
+    // logic, so we trigger build, pump the event queue (first attempt), then
+    // read the AsyncValue state directly.
+    test('propagates error when UserRepository throws', () async {
+      when(
+        () => mockRepo.getUserProfile('user_1'),
+      ).thenAnswer((_) async => throw Exception('network error'));
+
+      final container = createContainer(
+        overrides: [
+          currentUserProvider.overrideWith((ref) => mockUser),
+          userRepositoryProvider.overrideWithValue(mockRepo),
+        ],
+      );
+
+      container.read(currentUserProfileProvider);
+      await pumpEventQueue();
+
+      final state = container.read(currentUserProfileProvider);
+      expect(state.hasError, isTrue);
+    });
+  });
+}

--- a/shared/packages/minglit_kit/test/utils/supabase_image_url_test.dart
+++ b/shared/packages/minglit_kit/test/utils/supabase_image_url_test.dart
@@ -44,17 +44,21 @@ void main() {
       expect(result, contains('quality=85'));
     });
 
-    test('public-object URL, width 없음 → render/image로 재작성되지만 쿼리 없음', () {
+    test('public-object URL, width 없음 → 원본 URL 그대로 반환 (render path 미변환)', () {
       const url = '$base/storage/v1/object/public/images/foo.jpg';
       final result = supabaseImageUrl(url);
 
-      // URL is rewritten to render path even without width (no-op but harmless).
-      expect(
-        result,
-        contains('/storage/v1/render/image/public/images/foo.jpg'),
-      );
-      expect(result, isNot(contains('width=')));
-      expect(result, isNot(contains('quality=')));
+      // Fix #1918: render path requires Image Transformations to be enabled.
+      // Without width, no transform is needed — return original object URL.
+      expect(result, url);
+      expect(result, isNot(contains('/storage/v1/render/image/')));
+    });
+
+    test('render URL, width 없음 → 원본 URL 그대로 반환', () {
+      const url = '$base/storage/v1/render/image/public/avatars/user.jpg';
+      final result = supabaseImageUrl(url);
+
+      expect(result, url);
     });
 
     test('이미-render URL + width → 쿼리 병합', () {

--- a/shared/packages/minglit_lints/pubspec.yaml
+++ b/shared/packages/minglit_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_lints
 description: Custom lint rules for Minglit project to enforce UI consistency and design tokens.
-version: 26.04.1933-dev
+version: 26.04.1974-dev
 publish_to: none
 resolution: workspace
 

--- a/shared/packages/minglit_lints/pubspec.yaml
+++ b/shared/packages/minglit_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_lints
 description: Custom lint rules for Minglit project to enforce UI consistency and design tokens.
-version: 26.04.1977-dev
+version: 26.04.1976-dev
 publish_to: none
 resolution: workspace
 

--- a/shared/packages/minglit_lints/pubspec.yaml
+++ b/shared/packages/minglit_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_lints
 description: Custom lint rules for Minglit project to enforce UI consistency and design tokens.
-version: 26.04.1969-dev
+version: 26.04.1981-dev
 publish_to: none
 resolution: workspace
 

--- a/shared/packages/minglit_lints/pubspec.yaml
+++ b/shared/packages/minglit_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_lints
 description: Custom lint rules for Minglit project to enforce UI consistency and design tokens.
-version: 26.04.1976-dev
+version: 26.04.1975-dev
 publish_to: none
 resolution: workspace
 

--- a/shared/packages/minglit_lints/pubspec.yaml
+++ b/shared/packages/minglit_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_lints
 description: Custom lint rules for Minglit project to enforce UI consistency and design tokens.
-version: 26.04.1980-dev
+version: 26.04.1978-dev
 publish_to: none
 resolution: workspace
 

--- a/shared/packages/minglit_lints/pubspec.yaml
+++ b/shared/packages/minglit_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_lints
 description: Custom lint rules for Minglit project to enforce UI consistency and design tokens.
-version: 26.04.1975-dev
+version: 26.04.1933-dev
 publish_to: none
 resolution: workspace
 

--- a/shared/packages/minglit_lints/pubspec.yaml
+++ b/shared/packages/minglit_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_lints
 description: Custom lint rules for Minglit project to enforce UI consistency and design tokens.
-version: 26.04.1978-dev
+version: 26.04.1977-dev
 publish_to: none
 resolution: workspace
 

--- a/shared/packages/minglit_lints/pubspec.yaml
+++ b/shared/packages/minglit_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_lints
 description: Custom lint rules for Minglit project to enforce UI consistency and design tokens.
-version: 26.04.1981-dev
+version: 26.04.1979-dev
 publish_to: none
 resolution: workspace
 

--- a/shared/packages/minglit_lints/pubspec.yaml
+++ b/shared/packages/minglit_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_lints
 description: Custom lint rules for Minglit project to enforce UI consistency and design tokens.
-version: 26.04.1979-dev
+version: 26.04.1980-dev
 publish_to: none
 resolution: workspace
 

--- a/shared/packages/minglit_lints/pubspec.yaml
+++ b/shared/packages/minglit_lints/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minglit_lints
 description: Custom lint rules for Minglit project to enforce UI consistency and design tokens.
-version: 26.04.1974-dev
+version: 26.04.1982-dev
 publish_to: none
 resolution: workspace
 

--- a/supabase/functions/health/health_test.ts
+++ b/supabase/functions/health/health_test.ts
@@ -131,3 +131,90 @@ Deno.test({
     assertEquals(response.status, 405);
   },
 });
+
+// Fix #1944: ?env=true must require service_role — key names are infrastructure-sensitive
+Deno.test({
+  name: "health - ?env=true without auth returns 401",
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+    const { fetchMock } = createFetchMock([
+      { matcher: "/rest/v1/", handler: () => new Response(null, { status: 200 }) },
+      { matcher: "/auth/v1/health", handler: () => jsonResponse({ status: "ok" }) },
+      { matcher: "/storage/v1/bucket", handler: () => jsonResponse([]) },
+    ]);
+
+    await withEnv({
+      SUPABASE_URL: "http://localhost:54321",
+      SUPABASE_ANON_KEY: "test-anon-key",
+      SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+    }, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const response = await handler(
+          new Request("http://localhost?env=true", { method: "GET" }),
+        );
+        assertEquals(response.status, 401);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "health - ?env=true with wrong bearer returns 401",
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+    const { fetchMock } = createFetchMock([
+      { matcher: "/rest/v1/", handler: () => new Response(null, { status: 200 }) },
+      { matcher: "/auth/v1/health", handler: () => jsonResponse({ status: "ok" }) },
+      { matcher: "/storage/v1/bucket", handler: () => jsonResponse([]) },
+    ]);
+
+    await withEnv({
+      SUPABASE_URL: "http://localhost:54321",
+      SUPABASE_ANON_KEY: "test-anon-key",
+      SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+    }, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const response = await handler(
+          new Request("http://localhost?env=true", {
+            method: "GET",
+            headers: { Authorization: "Bearer wrong-key" },
+          }),
+        );
+        assertEquals(response.status, 401);
+      });
+    });
+  },
+});
+
+Deno.test({
+  name: "health - ?env=true with correct service role returns env_check",
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+    const { fetchMock } = createFetchMock([
+      { matcher: "/rest/v1/", handler: () => new Response(null, { status: 200 }) },
+      { matcher: "/auth/v1/health", handler: () => jsonResponse({ status: "ok" }) },
+      { matcher: "/storage/v1/bucket", handler: () => jsonResponse([]) },
+    ]);
+
+    await withEnv({
+      SUPABASE_URL: "http://localhost:54321",
+      SUPABASE_ANON_KEY: "test-anon-key",
+      SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+    }, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const response = await handler(
+          new Request("http://localhost?env=true", {
+            method: "GET",
+            headers: { Authorization: "Bearer test-service-key" },
+          }),
+        );
+        const body = await readJson(response);
+        assertEquals(typeof body.env_check, "object");
+        assertEquals(typeof body.env_check.status, "string");
+      });
+    });
+  },
+});

--- a/supabase/functions/health/index.ts
+++ b/supabase/functions/health/index.ts
@@ -2,6 +2,7 @@ import { successResponse, errorResponse } from "../_shared/response_utils.ts";
 import { initSentry, withHandler } from "../_shared/logger.ts";
 import { checkAllFunctions } from "../_shared/env_keystore.ts";
 import { nowISO } from "../_shared/temporal_utils.ts";
+import { requireServiceRole } from "../_shared/auth_utils.ts";
 
 initSentry();
 
@@ -142,8 +143,12 @@ Deno.serve(withHandler(async (req) => {
     },
   };
 
-  // env-check: report missing env vars per function (key names only, no values)
+  // Fix #1944: env-check exposes infra key names — require service role.
+  // The no-arg health check remains public for smoke tests.
   if (includeEnv) {
+    const auth = requireServiceRole(req);
+    if (auth instanceof Response) return auth;
+
     const missingByFunction = checkAllFunctions();
     const totalMissing = Object.values(missingByFunction).flat().length;
     body.env_check = {


### PR DESCRIPTION
## Summary

- `?env=true` on the health EF was publicly accessible — no auth check despite `verify_jwt = false`
- Leaked complete list of required infra key names per function (e.g. `PORTONE_API_KEY`, `FIREBASE_SERVICE_ACCOUNT`) to unauthenticated callers
- Added `requireServiceRole(req)` guard before the env-check block; no-arg `/health` remains public for smoke tests
- Updated deploy workflow to use `SERVICE_ROLE_KEY` (was using anon key which now returns 401)
- Added 3 regression tests: no-auth → 401, wrong bearer → 401, correct service role → env_check present

Closes #1944

## Test plan

- [ ] `deno test supabase/functions/health/health_test.ts` — all tests pass including 3 new auth tests
- [ ] CI `test-edge-functions` passes
- [ ] Supabase deploy workflow succeeds (uses `SERVICE_ROLE_KEY` for env check)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)