### PR TITLE
fix(checkin): add per-row in-flight guard to manual check-in (#1947)

### DIFF
--- a/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_sheet.dart
+++ b/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_sheet.dart
@@ -248,8 +248,11 @@ class _ManualCheckinSheetState extends ConsumerState<ManualCheckinSheet> {
   }
 
   Future<void> _checkin(CheckinParticipant participant) async {
-    // Fix #1947: mark in-flight before any async gap to block duplicate taps.
-    setState(() => _inFlightTicketIds.add(participant.ticketId));
+    // Fix #1947: synchronous guard — blocks duplicate RPCs that arrive before
+    // the next setState rebuild schedules a frame.
+    if (_inFlightTicketIds.contains(participant.ticketId)) return;
+    _inFlightTicketIds.add(participant.ticketId);
+    setState(() {});
     HapticFeedback.selectionClick();
     try {
       final result = await ref

--- a/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_sheet.dart
+++ b/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_sheet.dart
@@ -269,8 +269,9 @@ class _ManualCheckinSheetState extends ConsumerState<ManualCheckinSheet> {
         const SnackBar(content: Text('체크인 처리 중 오류가 발생했습니다')),
       );
     } finally {
-      if (mounted)
+      if (mounted) {
         setState(() => _inFlightTicketIds.remove(participant.ticketId));
+      }
     }
   }
 }

--- a/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_sheet.dart
+++ b/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_sheet.dart
@@ -23,6 +23,8 @@ class _ManualCheckinSheetState extends ConsumerState<ManualCheckinSheet> {
   final _searchController = TextEditingController();
   Timer? _debounce;
   String _query = '';
+  // Fix #1947: guard rapid taps — track ticket IDs with an in-flight RPC call.
+  final Set<String> _inFlightTicketIds = {};
 
   @override
   void dispose() {
@@ -208,7 +210,13 @@ class _ManualCheckinSheetState extends ConsumerState<ManualCheckinSheet> {
                               (p) => _ParticipantRow(
                                 key: ValueKey(p.id),
                                 participant: p,
-                                onCheckin: () => _checkin(p),
+                                isLoading: _inFlightTicketIds.contains(
+                                  p.ticketId,
+                                ),
+                                onCheckin:
+                                    _inFlightTicketIds.contains(p.ticketId)
+                                    ? null
+                                    : () => _checkin(p),
                               ),
                             ),
                           ],
@@ -240,6 +248,8 @@ class _ManualCheckinSheetState extends ConsumerState<ManualCheckinSheet> {
   }
 
   Future<void> _checkin(CheckinParticipant participant) async {
+    // Fix #1947: mark in-flight before any async gap to block duplicate taps.
+    setState(() => _inFlightTicketIds.add(participant.ticketId));
     HapticFeedback.selectionClick();
     try {
       final result = await ref
@@ -258,6 +268,8 @@ class _ManualCheckinSheetState extends ConsumerState<ManualCheckinSheet> {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('체크인 처리 중 오류가 발생했습니다')),
       );
+    } finally {
+      if (mounted) setState(() => _inFlightTicketIds.remove(participant.ticketId));
     }
   }
 }
@@ -293,11 +305,13 @@ class _ParticipantRow extends StatelessWidget {
   const _ParticipantRow({
     required this.participant,
     required this.onCheckin,
+    this.isLoading = false,
     super.key,
   });
 
   final CheckinParticipant participant;
   final VoidCallback? onCheckin;
+  final bool isLoading;
 
   @override
   Widget build(BuildContext context) {
@@ -354,7 +368,18 @@ class _ParticipantRow extends StatelessWidget {
             ),
 
             // 체크인 버튼 또는 완료 표시
-            if (onCheckin != null)
+            // Fix #1947: show spinner while in-flight to block duplicate taps.
+            if (isLoading)
+              const SizedBox.square(
+                dimension: 44,
+                child: Center(
+                  child: SizedBox.square(
+                    dimension: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                ),
+              )
+            else if (onCheckin != null)
               SizedBox(
                 height: 44,
                 child: Center(

--- a/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_sheet.dart
+++ b/apps/app_partner/lib/src/features/checkin/manual/manual_checkin_sheet.dart
@@ -269,7 +269,8 @@ class _ManualCheckinSheetState extends ConsumerState<ManualCheckinSheet> {
         const SnackBar(content: Text('체크인 처리 중 오류가 발생했습니다')),
       );
     } finally {
-      if (mounted) setState(() => _inFlightTicketIds.remove(participant.ticketId));
+      if (mounted)
+        setState(() => _inFlightTicketIds.remove(participant.ticketId));
     }
   }
 }

--- a/apps/app_partner/test/src/features/checkin/manual/manual_checkin_sheet_test.dart
+++ b/apps/app_partner/test/src/features/checkin/manual/manual_checkin_sheet_test.dart
@@ -211,12 +211,8 @@ void main() {
       // 체크인 button is gone (replaced by spinner), so a second tap is blocked.
       expect(find.text('체크인'), findsNothing);
 
-      // Simulate a second tap while the RPC is still in-flight.
-      // The button widget is gone, so tryTap falls through — but even if the
-      // callback were somehow invoked, the synchronous guard in _checkin()
-      // must prevent a second RPC call.
-      await tester.tap(find.text('체크인'), warnIfMissed: false);
-      await tester.pump();
+      // Button is gone — a second UI tap is physically impossible.
+      // The checkinCallCount assertion below confirms the guard held.
 
       // Complete the RPC.
       completer.complete();

--- a/apps/app_partner/test/src/features/checkin/manual/manual_checkin_sheet_test.dart
+++ b/apps/app_partner/test/src/features/checkin/manual/manual_checkin_sheet_test.dart
@@ -34,12 +34,14 @@ class _SlowController extends ManualCheckinController {
   _SlowController(this._participants, this._completer);
   final List<CheckinParticipant> _participants;
   final Completer<void> _completer;
+  int checkinCallCount = 0;
 
   @override
   Future<List<CheckinParticipant>> build(String eventId) async => _participants;
 
   @override
   Future<String> checkin(String ticketId) async {
+    checkinCallCount++;
     await _completer.future;
     state = state.whenData(
       (list) => list
@@ -179,12 +181,14 @@ void main() {
     // Fix #1947: rapid taps must not fire duplicate process_manual_checkin RPC
     testWidgets('체크인 버튼 탭 중 스피너 표시 — 중복 탭 차단', (tester) async {
       final completer = Completer<void>();
+      late _SlowController controller;
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            manualCheckinControllerProvider('event-1').overrideWith(
-              () => _SlowController([_participantA], completer),
-            ),
+            manualCheckinControllerProvider('event-1').overrideWith(() {
+              controller = _SlowController([_participantA], completer);
+              return controller;
+            }),
           ],
           child: const MaterialApp(
             home: Scaffold(body: ManualCheckinSheet(eventId: 'event-1')),
@@ -203,14 +207,26 @@ void main() {
         findsOneWidget,
         reason: 'expected loading spinner while checkin RPC is in-flight',
       );
-      // 체크인 button is gone (replaced by spinner).
+      // 체크인 button is gone (replaced by spinner), so a second tap is blocked.
       expect(find.text('체크인'), findsNothing);
+
+      // Simulate a second tap while the RPC is still in-flight.
+      // The button widget is gone, so tryTap falls through — but even if the
+      // callback were somehow invoked, the synchronous guard in _checkin()
+      // must prevent a second RPC call.
+      await tester.tap(find.text('체크인'), warnIfMissed: false);
+      await tester.pump();
 
       // Complete the RPC.
       completer.complete();
       await tester.pumpAndSettle();
 
-      // Participant moves to checked-in section.
+      // checkin() was called exactly once — no duplicate RPC.
+      expect(
+        controller.checkinCallCount,
+        1,
+        reason: 'duplicate tap must not fire a second checkin() RPC',
+      );
       expect(find.byType(CircularProgressIndicator), findsNothing);
       expect(find.text('체크인 완료 (1명)'), findsOneWidget);
     });

--- a/apps/app_partner/test/src/features/checkin/manual/manual_checkin_sheet_test.dart
+++ b/apps/app_partner/test/src/features/checkin/manual/manual_checkin_sheet_test.dart
@@ -198,8 +198,11 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // Tap 체크인 — RPC call starts but doesn't finish yet.
-      await tester.tap(find.text('체크인'));
+      // Rapid double tap before next frame — exercises the synchronous
+      // _inFlightTicketIds guard in _checkin() directly.
+      final checkinButton = find.text('체크인');
+      await tester.tap(checkinButton);
+      await tester.tap(checkinButton);
       await tester.pump();
 
       // Spinner is shown while in-flight.
@@ -208,11 +211,8 @@ void main() {
         findsOneWidget,
         reason: 'expected loading spinner while checkin RPC is in-flight',
       );
-      // 체크인 button is gone (replaced by spinner), so a second tap is blocked.
+      // 체크인 button is gone (replaced by spinner).
       expect(find.text('체크인'), findsNothing);
-
-      // Button is gone — a second UI tap is physically impossible.
-      // The checkinCallCount assertion below confirms the guard held.
 
       // Complete the RPC.
       completer.complete();

--- a/apps/app_partner/test/src/features/checkin/manual/manual_checkin_sheet_test.dart
+++ b/apps/app_partner/test/src/features/checkin/manual/manual_checkin_sheet_test.dart
@@ -186,12 +186,13 @@ void main() {
         ProviderScope(
           overrides: [
             manualCheckinControllerProvider('event-1').overrideWith(() {
-              controller = _SlowController([_participantA], completer);
-              return controller;
+              return controller = _SlowController([_participantA], completer);
             }),
           ],
-          child: const MaterialApp(
-            home: Scaffold(body: ManualCheckinSheet(eventId: 'event-1')),
+          child: MaterialApp(
+            home: Scaffold(
+              body: ManualCheckinSheet(eventId: 'event-1'),
+            ),
           ),
         ),
       );

--- a/apps/app_partner/test/src/features/checkin/manual/manual_checkin_sheet_test.dart
+++ b/apps/app_partner/test/src/features/checkin/manual/manual_checkin_sheet_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:app_partner/src/features/checkin/manual/checkin_participant.dart';
 import 'package:app_partner/src/features/checkin/manual/manual_checkin_controller.dart';
 import 'package:app_partner/src/features/checkin/manual/manual_checkin_sheet.dart';
@@ -24,6 +26,30 @@ class _DataController extends ManualCheckinController {
       );
     }
     return checkinResult;
+  }
+}
+
+/// Controller with a controllable delay — used to test in-flight guard.
+class _SlowController extends ManualCheckinController {
+  _SlowController(this._participants, this._completer);
+  final List<CheckinParticipant> _participants;
+  final Completer<void> _completer;
+
+  @override
+  Future<List<CheckinParticipant>> build(String eventId) async => _participants;
+
+  @override
+  Future<String> checkin(String ticketId) async {
+    await _completer.future;
+    state = state.whenData(
+      (list) => list
+          .map(
+            (p) =>
+                p.ticketId == ticketId ? p.copyWith(status: 'checked_in') : p,
+          )
+          .toList(),
+    );
+    return 'success';
   }
 }
 
@@ -148,6 +174,45 @@ void main() {
 
       final btn = tester.widget<OutlinedButton>(find.byType(OutlinedButton));
       expect(btn.onPressed, isNull);
+    });
+
+    // Fix #1947: rapid taps must not fire duplicate process_manual_checkin RPC
+    testWidgets('체크인 버튼 탭 중 스피너 표시 — 중복 탭 차단', (tester) async {
+      final completer = Completer<void>();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            manualCheckinControllerProvider('event-1').overrideWith(
+              () => _SlowController([_participantA], completer),
+            ),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(body: ManualCheckinSheet(eventId: 'event-1')),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Tap 체크인 — RPC call starts but doesn't finish yet.
+      await tester.tap(find.text('체크인'));
+      await tester.pump();
+
+      // Spinner is shown while in-flight.
+      expect(
+        find.byType(CircularProgressIndicator),
+        findsOneWidget,
+        reason: 'expected loading spinner while checkin RPC is in-flight',
+      );
+      // 체크인 button is gone (replaced by spinner).
+      expect(find.text('체크인'), findsNothing);
+
+      // Complete the RPC.
+      completer.complete();
+      await tester.pumpAndSettle();
+
+      // Participant moves to checked-in section.
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.text('체크인 완료 (1명)'), findsOneWidget);
     });
   });
 }

--- a/apps/app_partner/test/src/features/checkin/manual/manual_checkin_sheet_test.dart
+++ b/apps/app_partner/test/src/features/checkin/manual/manual_checkin_sheet_test.dart
@@ -189,7 +189,7 @@ void main() {
               return controller = _SlowController([_participantA], completer);
             }),
           ],
-          child: MaterialApp(
+          child: const MaterialApp(
             home: Scaffold(
               body: ManualCheckinSheet(eventId: 'event-1'),
             ),

--- a/apps/app_partner/test/src/features/checkin/stats/checkin_stats_controller_test.dart
+++ b/apps/app_partner/test/src/features/checkin/stats/checkin_stats_controller_test.dart
@@ -79,7 +79,7 @@ void main() {
         'get_event_checkin_stats',
         params: any(named: 'params'),
       ),
-    ).thenAnswer((_) => _FakeRpcBuilder(statsResponse));
+    ).thenAnswer((_) => _FakeRpcBuilder<dynamic>(statsResponse));
 
     return ProviderContainer(
       overrides: [supabaseClientProvider.overrideWithValue(mockClient)],

--- a/apps/app_partner/test/src/features/checkin/stats/entry_group_checkin_stats_controller_test.dart
+++ b/apps/app_partner/test/src/features/checkin/stats/entry_group_checkin_stats_controller_test.dart
@@ -67,7 +67,7 @@ void main() {
         'get_event_checkin_stats_by_group',
         params: any(named: 'params'),
       ),
-    ).thenAnswer((_) => _FakeRpcBuilder(response));
+    ).thenAnswer((_) => _FakeRpcBuilder<dynamic>(response));
   }
 
   ProviderContainer makeContainer({required List<dynamic> groupsResponse}) {


### PR DESCRIPTION
## Summary

- Manual check-in sheet had no per-row guard — rapid taps could fire duplicate `process_manual_checkin` RPCs before the optimistic state propagated
- Added `_inFlightTicketIds` set in sheet state; `onCheckin` is nulled and a `CircularProgressIndicator` is shown for the specific row while the RPC is in-flight
- `finally` block ensures in-flight state is cleared even on error

Closes #1947

## Test plan

- [ ] Existing 5 sheet tests still pass
- [ ] New test: `체크인 버튼 탭 중 스피너 표시 — 중복 탭 차단` passes (spinner shown while in-flight, gone after completion)
- [ ] CI `test-flutter-apps` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)