### PR TITLE
fix(ci): remove --password flag from supabase CLI and psql CONN_URL (#1971)

### DIFF
--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -70,7 +70,9 @@ jobs:
           PORTONE_V2_API_KEY_MAIN: ${{ secrets.PORTONE_MAIN_V2_API_KEY }}
           PORTONE_V2_WEBHOOK_SECRET_MAIN: ${{ secrets.PORTONE_MAIN_V2_WEBHOOK_SECRET }}
         run: |
-          supabase link --project-ref $SUPABASE_PROJECT_ID --password $SUPABASE_DB_PASSWORD
+          # Fix #1971: SUPABASE_DB_PASSWORD env var is set above — drop --password to avoid
+          # process-list exposure (/proc/pid/cmdline) on shared runners.
+          supabase link --project-ref $SUPABASE_PROJECT_ID
 
           supabase secrets set OPENAI_API_KEY=$OPENAI_API_KEY
           supabase secrets set GITHUB_ACCESS_TOKEN=$GITHUB_ACCESS_TOKEN
@@ -125,7 +127,7 @@ jobs:
             echo "PORTONE_V2_WEBHOOK_SECRET not set — skipping webhook secret injection"
           fi
 
-          supabase db push --password $SUPABASE_DB_PASSWORD --include-all
+          supabase db push --include-all
 
           supabase functions deploy
 
@@ -148,7 +150,7 @@ jobs:
             echo "::error::failed to switch db.seed.sql_paths to seed.dev.sql"
             exit 1
           }
-          yes | supabase db push --include-seed --password $SUPABASE_DB_PASSWORD
+          yes | supabase db push --include-seed
           echo "Dev seed complete"
 
       - name: Upload seed images
@@ -187,7 +189,9 @@ jobs:
         run: |
           # Fix #1228: pooler 사용으로 DNS fallback chain 불필요 — 삭제.
           # Pooler는 tenant-qualified username(postgres.{project_ref}) 사용, session mode(5432).
-          CONN_URL="postgresql://postgres.${PROJECT_ID}:${DB_PASSWORD}@${POOLER_HOST}:5432/postgres?sslmode=require"
+          # Fix #1971: remove password from URL — PGPASSWORD env var handles auth,
+          # embedding in URL exposes it via /proc/pid/cmdline when psql is invoked.
+          CONN_URL="postgresql://postgres.${PROJECT_ID}@${POOLER_HOST}:5432/postgres?sslmode=require"
 
           REQUIRED=$(jq -r '.vault.required | keys[]' env-manifest.json)
           VAULT_MISSING=""


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1971

## 변경 내용

`supabase-deploy.yml`에서 DB 패스워드를 프로세스 리스트(`/proc/pid/cmdline`)에 노출하는 CLI 인자를 제거합니다.

### 문제
1. `supabase link --password $SUPABASE_DB_PASSWORD` — CLI 인자로 전달 시 `/proc/pid/cmdline`에 평문 노출
2. `supabase db push --password $SUPABASE_DB_PASSWORD` — 동일 문제
3. `yes | supabase db push --include-seed --password $SUPABASE_DB_PASSWORD` — 동일
4. `CONN_URL="postgresql://postgres.${PROJECT_ID}:${DB_PASSWORD}@..."` → psql 인자로 전달 시 URL에 패스워드 포함

### 수정
- Supabase CLI는 `SUPABASE_DB_PASSWORD` 환경변수를 자동으로 읽으므로 `--password` 플래그 삭제 (해당 env는 이미 step level에 설정됨)
- psql CONN_URL에서 패스워드 제거 — 인증은 이미 설정된 `PGPASSWORD` env var로 처리

## 테스트
CI 워크플로우 변경 — 로컬 단위 테스트 없음. 다음 supabase deploy 실행으로 검증.