### PR TITLE
fix(payment-webhook): add imp_uid idempotency guard to prevent replay side-effects

### DIFF
--- a/supabase/functions/payment-webhook/index.ts
+++ b/supabase/functions/payment-webhook/index.ts
@@ -62,6 +62,20 @@ Deno.serve(withHandler(async (req) => {
       return new Response("Missing parameters", { status: 400 });
     }
 
+    // Fix #1949: Idempotency check — reject replayed webhooks before hitting PortOne API.
+    // SELECT-first is intentional: INSERT-first would consume the key on transient failures,
+    // blocking PortOne retries. We insert only after a successful DB update below.
+    const supabase = createServiceClient();
+    const { data: existingLog } = await supabase
+      .from("webhook_imp_uid_log")
+      .select("imp_uid")
+      .eq("imp_uid", imp_uid)
+      .maybeSingle();
+    if (existingLog) {
+      log({ function: FN, level: "info", message: `Duplicate webhook rejected (already processed): ${imp_uid}` });
+      return new Response("OK", { status: 200 });
+    }
+
     // 2. Verify with Portone API (Cross-Check)
     const client = new IamportClient(IMP_KEY, IMP_SECRET);
     const payment = await client.getPayment(imp_uid);
@@ -73,7 +87,6 @@ Deno.serve(withHandler(async (req) => {
     }
 
     // 4. Update DB (idempotent)
-    const supabase = createServiceClient();
 
     let dbStatus = "pending";
     // Map Iamport status to Minglit status
@@ -118,6 +131,11 @@ Deno.serve(withHandler(async (req) => {
       log({ function: FN, level: "error", message: "DB Update Error", metadata: { detail: error } });
       return new Response("DB Error", { status: 500 });
     }
+
+    // Fix #1949: Record successful processing so retries/replays are blocked above.
+    await supabase
+      .from("webhook_imp_uid_log")
+      .insert({ imp_uid, merchant_uid });
 
     log({ function: FN, level: "info", message: `Updated order ${merchant_uid} to status ${dbStatus}` });
 

--- a/supabase/functions/payment-webhook/payment_webhook_test.ts
+++ b/supabase/functions/payment-webhook/payment_webhook_test.ts
@@ -26,6 +26,15 @@ Deno.test("payment-webhook - happy path updates status", async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
+      // Fix #1949: idempotency SELECT (not found → null) and INSERT (success)
+      {
+        matcher: (req) => req.url.includes("/rest/v1/webhook_imp_uid_log") && req.method === "GET",
+        handler: () => new Response("null", { status: 200, headers: { "Content-Type": "application/json" } }),
+      },
+      {
+        matcher: (req) => req.url.includes("/rest/v1/webhook_imp_uid_log") && req.method === "POST",
+        handler: () => jsonResponse({}),
+      },
       {
         matcher: "https://api.iamport.kr/users/getToken",
         handler: () => jsonResponse({ code: 0, response: { access_token: "token" } }),
@@ -102,6 +111,14 @@ Deno.test("payment-webhook - localhost IP allowed in dev env", async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       {
+        matcher: (req) => req.url.includes("/rest/v1/webhook_imp_uid_log") && req.method === "GET",
+        handler: () => new Response("null", { status: 200, headers: { "Content-Type": "application/json" } }),
+      },
+      {
+        matcher: (req) => req.url.includes("/rest/v1/webhook_imp_uid_log") && req.method === "POST",
+        handler: () => jsonResponse({}),
+      },
+      {
         matcher: "https://api.iamport.kr/users/getToken",
         handler: () => jsonResponse({ code: 0, response: { access_token: "token" } }),
       },
@@ -158,6 +175,14 @@ Deno.test("payment-webhook - cf-connecting-ip accepted when x-real-ip absent", a
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       {
+        matcher: (req) => req.url.includes("/rest/v1/webhook_imp_uid_log") && req.method === "GET",
+        handler: () => new Response("null", { status: 200, headers: { "Content-Type": "application/json" } }),
+      },
+      {
+        matcher: (req) => req.url.includes("/rest/v1/webhook_imp_uid_log") && req.method === "POST",
+        handler: () => jsonResponse({}),
+      },
+      {
         matcher: "https://api.iamport.kr/users/getToken",
         handler: () => jsonResponse({ code: 0, response: { access_token: "token" } }),
       },
@@ -191,6 +216,14 @@ Deno.test("payment-webhook - x-real-ip takes precedence over XFF", async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
+      {
+        matcher: (req) => req.url.includes("/rest/v1/webhook_imp_uid_log") && req.method === "GET",
+        handler: () => new Response("null", { status: 200, headers: { "Content-Type": "application/json" } }),
+      },
+      {
+        matcher: (req) => req.url.includes("/rest/v1/webhook_imp_uid_log") && req.method === "POST",
+        handler: () => jsonResponse({}),
+      },
       {
         matcher: "https://api.iamport.kr/users/getToken",
         handler: () => jsonResponse({ code: 0, response: { access_token: "token" } }),
@@ -245,6 +278,10 @@ Deno.test("payment-webhook - merchant UID mismatch returns 400", async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       {
+        matcher: (req) => req.url.includes("/rest/v1/webhook_imp_uid_log") && req.method === "GET",
+        handler: () => new Response("null", { status: 200, headers: { "Content-Type": "application/json" } }),
+      },
+      {
         matcher: "https://api.iamport.kr/users/getToken",
         handler: () => jsonResponse({ code: 0, response: { access_token: "token" } }),
       },
@@ -273,6 +310,10 @@ Deno.test("payment-webhook - iamport error returns 500", async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
+      {
+        matcher: (req) => req.url.includes("/rest/v1/webhook_imp_uid_log") && req.method === "GET",
+        handler: () => new Response("null", { status: 200, headers: { "Content-Type": "application/json" } }),
+      },
       {
         matcher: "https://api.iamport.kr/users/getToken",
         handler: () => new Response("error", { status: 500 }),
@@ -317,6 +358,14 @@ Deno.test("payment-webhook - cancelled status sets refund_status completed", asy
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock, calls } = createFetchMock([
       {
+        matcher: (req) => req.url.includes("/rest/v1/webhook_imp_uid_log") && req.method === "GET",
+        handler: () => new Response("null", { status: 200, headers: { "Content-Type": "application/json" } }),
+      },
+      {
+        matcher: (req) => req.url.includes("/rest/v1/webhook_imp_uid_log") && req.method === "POST",
+        handler: () => jsonResponse({}),
+      },
+      {
         matcher: "https://api.iamport.kr/users/getToken",
         handler: () => jsonResponse({ code: 0, response: { access_token: "token" } }),
       },
@@ -354,6 +403,14 @@ Deno.test("payment-webhook - paid status does not set refund_status", async () =
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock, calls } = createFetchMock([
       {
+        matcher: (req) => req.url.includes("/rest/v1/webhook_imp_uid_log") && req.method === "GET",
+        handler: () => new Response("null", { status: 200, headers: { "Content-Type": "application/json" } }),
+      },
+      {
+        matcher: (req) => req.url.includes("/rest/v1/webhook_imp_uid_log") && req.method === "POST",
+        handler: () => jsonResponse({}),
+      },
+      {
         matcher: "https://api.iamport.kr/users/getToken",
         handler: () => jsonResponse({ code: 0, response: { access_token: "token" } }),
       },
@@ -381,6 +438,41 @@ Deno.test("payment-webhook - paid status does not set refund_status", async () =
         const dbBody = JSON.parse(dbCall!.body!);
         assertEquals(dbBody.status, "approved");
         assertEquals(dbBody.refund_status, undefined);
+      });
+    });
+  });
+});
+
+// Fix #1949: replayed webhook with same imp_uid must be rejected without side-effects
+Deno.test("payment-webhook - duplicate imp_uid returns 200 without DB update or PortOne call", async () => {
+  await withEnv(ENV, async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock, calls } = createFetchMock([
+      {
+        // Idempotency SELECT returns existing record — already processed
+        matcher: (req) => req.url.includes("/rest/v1/webhook_imp_uid_log") && req.method === "GET",
+        handler: () => jsonResponse({ imp_uid: "imp_dup", merchant_uid: "order-dup" }),
+      },
+    ]);
+
+    await withMockedFetch(fetchMock, async () => {
+      await withNoIntervals(async () => {
+        const request = jsonRequest(
+          "http://localhost",
+          { imp_uid: "imp_dup", merchant_uid: "order-dup", status: "paid" },
+          { headers: { "x-real-ip": PORTONE_IP } },
+        );
+        const response = await handler(request);
+        assertEquals(response.status, 200);
+        assertEquals(await response.text(), "OK");
+
+        // No PortOne API call should have been made
+        const portoneCall = calls.find((c) => c.url.includes("api.iamport.kr"));
+        assertEquals(portoneCall, undefined);
+
+        // No DB update should have been made
+        const dbPatch = calls.find((c) => c.url.includes("/rest/v1/event_applications") && c.method === "PATCH");
+        assertEquals(dbPatch, undefined);
       });
     });
   });

--- a/supabase/migrations/20260428000001_create_webhook_imp_uid_log.sql
+++ b/supabase/migrations/20260428000001_create_webhook_imp_uid_log.sql
@@ -1,0 +1,15 @@
+-- Fix #1949: idempotency log for PortOne V1 payment webhooks.
+-- Records successfully processed imp_uid values so replayed webhooks
+-- are rejected before making a duplicate cross-check call to PortOne API.
+CREATE TABLE IF NOT EXISTS webhook_imp_uid_log (
+  imp_uid       text        NOT NULL,
+  merchant_uid  text        NOT NULL,
+  processed_at  timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT webhook_imp_uid_log_pkey PRIMARY KEY (imp_uid)
+);
+
+-- Only the payment-webhook Edge Function should write to this table.
+ALTER TABLE webhook_imp_uid_log ENABLE ROW LEVEL SECURITY;
+
+-- Service role (used by Edge Functions) bypasses RLS by default.
+-- No explicit policy needed — RLS is enabled to block anon/authenticated roles.


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1949

## Summary

- **`webhook_imp_uid_log` 테이블 생성** (migration `20260428000001`): `imp_uid` PRIMARY KEY로 중복 처리 방지
- **idempotency guard 추가** (`index.ts`): DB 업데이트 전 `imp_uid` 조회 → 이미 처리된 경우 즉시 200 반환 (PortOne API 호출 없음)
- **처리 완료 후 로그 INSERT**: DB 업데이트 성공 시에만 기록 → 트랜지언트 실패 시 PortOne 재시도 차단 방지
- **테스트 추가/업데이트**: 전체 테스트에 `webhook_imp_uid_log` 목 추가, 중복 webhook 시나리오 검증 테스트 신규 추가

## 설계 근거

PortOne V1은 HMAC 서명을 지원하지 않아 IP allowlist가 1차 보안 계층. 기존 구현에서 동일 imp_uid가 재전송될 경우:
- PortOne API 중복 호출 (rate limit 위험)
- Statsig 이벤트 중복 로깅
- payment_complete 푸시 알림 중복 발송

SELECT-first 방식 채택 이유: INSERT-first는 트랜지언트 실패 시 키를 소모해 PortOne 정상 재시도를 차단할 위험이 있음.

## Test plan

- [x] "duplicate imp_uid returns 200 without DB update or PortOne call" 테스트 추가
- [x] 기존 테스트 전체에 webhook_imp_uid_log 목 추가
- [ ] CI test-edge-functions 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)