### PR TITLE
fix(settlement): correct non-existent 'date' column to 'start_time' in getEventInfo

### DIFF
--- a/shared/packages/minglit_kit/lib/src/data/repositories/settlement_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/settlement_repository.dart
@@ -217,7 +217,8 @@ class SettlementRepository {
     try {
       final data = await _supabase
           .from('events')
-          .select('id, title, date, parties(name)')
+          // Fix #1937: 'date' column does not exist; actual column is start_time
+          .select('id, title, start_time, parties(name)')
           .eq('id', eventId)
           .maybeSingle();
 

--- a/shared/packages/minglit_kit/test/src/data/repositories/settlement_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/settlement_repository_test.dart
@@ -395,6 +395,38 @@ void main() {
           throwsA(isA<Exception>()),
         );
       });
+
+      // Fix #1937: 'date' column does not exist; actual column is start_time.
+      // Regression guard: if someone reverts select() back to include 'date',
+      // this assertion fails before the real DB does.
+      test(
+        'Fix #1937: selects start_time, not date',
+        () async {
+          final eventsBuilder = mockTable(
+            mockClient,
+            'events',
+            maybeSingleData: {
+              'id': 'event_1',
+              'title': '테스트 이벤트',
+              'start_time': '2026-03-01T10:00:00.000Z',
+              'parties': {'name': '테스트 파티'},
+            },
+          );
+
+          await repository.getEventInfo('event_1');
+
+          expect(
+            eventsBuilder.lastSelectColumns,
+            contains('start_time'),
+            reason: 'select() must include start_time (not date)',
+          );
+          expect(
+            eventsBuilder.lastSelectColumns,
+            isNot(contains('date')),
+            reason: "events table has no 'date' column — Fix #1937",
+          );
+        },
+      );
     });
 
     // -------------------------------------------------------------------------

--- a/shared/packages/minglit_kit/test/src/data/repositories/settlement_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/settlement_repository_test.dart
@@ -362,7 +362,7 @@ void main() {
         final eventJson = {
           'id': 'event_1',
           'title': '테스트 이벤트',
-          'date': '2026-03-01',
+          'start_time': '2026-03-01T10:00:00.000Z',
           'parties': {'name': '테스트 파티'},
         };
         mockTable(mockClient, 'events', maybeSingleData: eventJson);
@@ -372,6 +372,7 @@ void main() {
         expect(result, isNotNull);
         expect(result!['id'], 'event_1');
         expect(result['title'], '테스트 이벤트');
+        expect(result['start_time'], isNotNull);
       });
 
       test('returns null when event not found', () async {


### PR DESCRIPTION
## Summary

- `getEventInfo` was selecting a non-existent `date` column from the `events` table — causing every call to throw `PostgrestException` (verified via schema at `20260301000003_03_schema_events.sql`, the actual column is `start_time`)
- Changed `.select('id, title, date, ...')` → `.select('id, title, start_time, ...')` at `settlement_repository.dart:220`
- Updated the test mock key from `'date'` to `'start_time'` and added an assertion for the returned field

## Test plan

- [ ] `test-app-unit-widget-golden (minglit_kit)` CI passes with updated test
- [ ] No DB migration needed — this is a query column name fix only

Closes #1937

🤖 Generated with [Claude Code](https://claude.com/claude-code) by **needs-swe-sonnet-1**