### PR TITLE
fix(settlement): move minus sign before ₩ for negative net_amount

### DIFF
--- a/apps/app_partner/lib/src/features/settlement/widgets/settlement_card.dart
+++ b/apps/app_partner/lib/src/features/settlement/widgets/settlement_card.dart
@@ -46,7 +46,8 @@ class SettlementCard extends StatelessWidget {
                   ),
                   const SizedBox(height: MinglitSpacing.xsmall),
                   Text(
-                    '₩${_formatAmount(netAmount)}',
+                    // Fix #1932: minus sign before ₩, not after it
+                    '${netAmount < 0 ? '-' : ''}₩${_formatAmount(netAmount)}',
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
                 ],
@@ -68,6 +69,6 @@ class SettlementCard extends StatelessWidget {
       if (i > 0 && (str.length - i) % 3 == 0) buffer.write(',');
       buffer.write(str[i]);
     }
-    return amount < 0 ? '-$buffer' : buffer.toString();
+    return buffer.toString();
   }
 }

--- a/apps/app_partner/test/src/features/settlement/widgets/settlement_card_test.dart
+++ b/apps/app_partner/test/src/features/settlement/widgets/settlement_card_test.dart
@@ -121,7 +121,8 @@ void main() {
       expect(find.text('-'), findsOneWidget);
     });
 
-    testWidgets('renders negative net_amount with minus prefix', (
+    // Fix #1932: minus sign should precede ₩, not follow it
+    testWidgets('renders negative net_amount as -₩ not ₩-', (
       tester,
     ) async {
       await tester.pumpWidget(
@@ -131,7 +132,8 @@ void main() {
           'created_at': '2026-01-15T10:00:00.000Z',
         }),
       );
-      expect(find.text('₩-5,000'), findsOneWidget);
+      expect(find.text('-₩5,000'), findsOneWidget);
+      expect(find.text('₩-5,000'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Summary

- `SettlementCard` was displaying `-₩1,500,000` as `₩-1,500,000` — incorrect for Korean financial UI
- Moved the minus sign to the call site: `'${netAmount < 0 ? '-' : ''}₩${_formatAmount(netAmount)}'`
- Simplified `_formatAmount` to always return an unsigned formatted string
- Updated existing test at `settlement_card_test.dart:124` to assert `-₩5,000` (correct) and assert `₩-5,000` is absent

## Test plan

- [ ] `test-app-unit-widget-golden (app_partner)` CI passes
- [ ] Widget test `renders negative net_amount as -₩ not ₩-` passes

Closes #1932

🤖 Generated with [Claude Code](https://claude.com/claude-code) by **needs-swe-sonnet-1**