### PR TITLE
fix(ci): remove continue-on-error from npm audit in landing app CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,6 @@ jobs:
           cache-dependency-path: ./apps/landing_user/package-lock.json
       - run: npm ci
       - run: npm audit --audit-level=high
-        continue-on-error: true
       - run: npm run lint
       - run: npm run build
 
@@ -310,7 +309,6 @@ jobs:
           cache-dependency-path: ./apps/landing_partner/package-lock.json
       - run: npm ci
       - run: npm audit --audit-level=high
-        continue-on-error: true
       - run: npm run lint
       - run: npm run build
 


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1964

## Summary

Removes `continue-on-error: true` from `npm audit --audit-level=high` in `lint-landing-user` and `lint-landing-partner` CI jobs.

With `continue-on-error: true`, high/critical CVEs silently passed without failing the build. This change makes the audit a real security gate.

**Verified locally**: Both landing apps currently have only **moderate** severity findings (postcss XSS: `GHSA-qx2v-qp2m-jg93`), none at `--audit-level=high`. Removing `continue-on-error` will not break the current CI.

The fix available for the postcss finding requires a breaking Next.js downgrade (`npm audit fix --force` would install Next.js 9.3.3), which is not acceptable. Since the severity is moderate (not high), it remains below the threshold.

## Test plan

- [ ] `lint-landing-user` CI passes (only moderate CVEs, none at high+)
- [ ] `lint-landing-partner` CI passes (same)
- [ ] Future PRs that introduce high/critical CVEs in landing deps will now fail CI