### PR TITLE
fix(my_page): launch external privacy URL from 개인정보처리방침 tile

### DIFF
--- a/apps/app_user/lib/src/features/home/my_page.dart
+++ b/apps/app_user/lib/src/features/home/my_page.dart
@@ -147,7 +147,11 @@ class MyPage extends ConsumerWidget {
                 MinglitSettingsTile(
                   leading: Icons.shield_outlined,
                   title: '개인정보처리방침',
-                  onTap: homeCoordinator.pushPrivacy,
+                  onTap: () {
+                    // Fix #1939: '개인정보처리방침'은 동의 화면이 아닌 외부 개인정보처리방침 URL로 이동해야 함
+                    final url = ref.read(minglitUrlConfigProvider).privacyUrl;
+                    unawaited(launchUrl(Uri.parse(url)));
+                  },
                 ),
                 MinglitSettingsTile(
                   leading: Icons.description_outlined,

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -83,6 +83,8 @@ dev_dependencies:
   riverpod_lint: 3.0.3
   test: any
   test_reporter: ^1.3.0
+  plugin_platform_interface: ^2.1.8
+  url_launcher_platform_interface: ^2.3.2
   uuid: ^4.5.2
   very_good_analysis: ^10.0.0
 

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -78,12 +78,12 @@ dev_dependencies:
   mocktail: ^1.0.4
   patrol: ^4.5.0
   patrol_finders: ^3.2.0
+  plugin_platform_interface: ^2.1.8
   postgres: ^3.5.9
   riverpod_generator: ^3.0.3
   riverpod_lint: 3.0.3
   test: any
   test_reporter: ^1.3.0
-  plugin_platform_interface: ^2.1.8
   url_launcher_platform_interface: ^2.3.2
   uuid: ^4.5.2
   very_good_analysis: ^10.0.0

--- a/apps/app_user/test/integration/my_page_test.dart
+++ b/apps/app_user/test/integration/my_page_test.dart
@@ -2,6 +2,9 @@ import 'package:app_user/src/features/auth/login_page.dart';
 import 'package:app_user/src/features/home/my_page.dart';
 import 'package:app_user/src/features/payment/ui/purchase_history_page.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 import 'utils/golden_capture.dart';
 import 'utils/test_app.dart';
@@ -68,5 +71,60 @@ void main() {
 
       expect(find.byType(PurchaseHistoryPage), findsOneWidget);
     });
+
+    // Fix #1939: '개인정보처리방침' 탭은 외부 URL로 이동해야 함 (pushPrivacy 금지)
+    testWidgets('개인정보처리방침 탭 → 외부 privacyUrl 런치, 내부 네비게이션 없음', (tester) async {
+      setKoreanLocale(tester);
+      final launchedUrls = <String>[];
+      final fakeLauncher = _FakeUrlLauncher(launchedUrls);
+      UrlLauncherPlatform.instance = fakeLauncher;
+
+      final user = createMockUserForTest();
+      await tester.pumpWidget(
+        createTestApp(
+          isLoggedIn: true,
+          currentUser: user,
+          initialLocation: '/my',
+          additionalOverrides: [
+            minglitDomainsProvider.overrideWithValue(
+              const MinglitDomains(
+                userWeb: 'https://test.minglit.com',
+                partnerWeb: 'https://test-partner.minglit.com',
+                userApp: 'https://test-app.minglit.com',
+                partnerApp: 'https://test-app-partner.minglit.com',
+              ),
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      await tester.scrollUntilVisible(find.text('개인정보처리방침'), 100);
+      await tester.tap(find.text('개인정보처리방침'));
+      await tester.pump();
+
+      expect(launchedUrls, ['https://test.minglit.com/privacy']);
+      expect(find.byType(MyPage), findsOneWidget);
+    });
   });
+}
+
+class _FakeUrlLauncher extends Fake
+    with MockPlatformInterfaceMixin
+    implements UrlLauncherPlatform {
+  _FakeUrlLauncher(this.launchedUrls);
+  final List<String> launchedUrls;
+
+  @override
+  LinkDelegate? get linkDelegate => null;
+
+  @override
+  Future<bool> canLaunch(String url) async => true;
+
+  @override
+  Future<bool> launchUrl(String url, LaunchOptions options) async {
+    launchedUrls.add(url);
+    return true;
+  }
 }

--- a/apps/app_user/test/integration/my_page_test.dart
+++ b/apps/app_user/test/integration/my_page_test.dart
@@ -4,6 +4,7 @@ import 'package:app_user/src/features/payment/ui/purchase_history_page.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:url_launcher/url_launcher.dart' show LaunchMode;
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 import 'utils/golden_capture.dart';

--- a/apps/app_user/test/integration/my_page_test.dart
+++ b/apps/app_user/test/integration/my_page_test.dart
@@ -119,6 +119,11 @@ class _FakeUrlLauncher extends Fake
   @override
   Future<bool> canLaunch(String url) async => true;
 
+  // url_launcher calls supportsMode before launchUrl; without this override
+  // Fake throws UnimplementedError which unawaited() silently swallows.
+  @override
+  Future<bool> supportsMode(LaunchMode mode) async => true;
+
   @override
   Future<bool> launchUrl(String url, LaunchOptions options) async {
     launchedUrls.add(url);

--- a/apps/app_user/test/integration/my_page_test.dart
+++ b/apps/app_user/test/integration/my_page_test.dart
@@ -77,7 +77,6 @@ void main() {
       setKoreanLocale(tester);
       final launchedUrls = <String>[];
       final fakeLauncher = _FakeUrlLauncher(launchedUrls);
-      UrlLauncherPlatform.instance = fakeLauncher;
 
       final user = createMockUserForTest();
       await tester.pumpWidget(
@@ -100,7 +99,12 @@ void main() {
       await tester.pump();
       await tester.pump();
 
+      // Fix: set AFTER pumpWidget so that dartPluginClass auto-registration
+      // (e.g. url_launcher_linux on CI) doesn't override our fake.
+      UrlLauncherPlatform.instance = fakeLauncher;
+
       await tester.scrollUntilVisible(find.text('개인정보처리방침'), 100);
+      await tester.pump(); // Settle scroll before tap
       await tester.tap(find.text('개인정보처리방침'));
       await tester.pump();
 

--- a/apps/app_user/test/integration/my_page_test.dart
+++ b/apps/app_user/test/integration/my_page_test.dart
@@ -4,7 +4,6 @@ import 'package:app_user/src/features/payment/ui/purchase_history_page.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
-import 'package:url_launcher/url_launcher.dart' show LaunchMode;
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 import 'utils/golden_capture.dart';
@@ -123,7 +122,7 @@ class _FakeUrlLauncher extends Fake
   // url_launcher calls supportsMode before launchUrl; without this override
   // Fake throws UnimplementedError which unawaited() silently swallows.
   @override
-  Future<bool> supportsMode(LaunchMode mode) async => true;
+  Future<bool> supportsMode(PreferredLaunchMode mode) async => true;
 
   @override
   Future<bool> launchUrl(String url, LaunchOptions options) async {

--- a/apps/app_user/test/integration/my_page_test.dart
+++ b/apps/app_user/test/integration/my_page_test.dart
@@ -4,7 +4,6 @@ import 'package:app_user/src/features/payment/ui/purchase_history_page.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
-import 'package:url_launcher_platform_interface/link.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 import 'utils/golden_capture.dart';
@@ -116,9 +115,6 @@ class _FakeUrlLauncher extends Fake
     implements UrlLauncherPlatform {
   _FakeUrlLauncher(this.launchedUrls);
   final List<String> launchedUrls;
-
-  @override
-  LinkDelegate? get linkDelegate => null;
 
   @override
   Future<bool> canLaunch(String url) async => true;

--- a/apps/app_user/test/integration/my_page_test.dart
+++ b/apps/app_user/test/integration/my_page_test.dart
@@ -4,6 +4,7 @@ import 'package:app_user/src/features/payment/ui/purchase_history_page.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:url_launcher_platform_interface/link.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 import 'utils/golden_capture.dart';


### PR DESCRIPTION
## Summary

- Fixes `개인정보처리방침` tile in MyPage (Group 5: 약관 및 정보) — was incorrectly calling `homeCoordinator.pushPrivacy` (in-app consent screen) instead of launching the external privacy policy URL
- Uses `launchUrl(minglitUrlConfigProvider.privacyUrl)` pattern, identical to the existing `이용약관` tile
- Adds widget test verifying URL is launched and navigation does not occur

## Test plan

- [ ] `개인정보처리방침` tap opens `https://minglit.com/privacy` externally
- [ ] No in-app navigation occurs after tap (stays on MyPage)
- [ ] `이용약관` tile behaviour unchanged
- [ ] New integration test: `개인정보처리방침 탭 → 외부 privacyUrl 런치, 내부 네비게이션 없음`

Closes #1939

🤖 Generated with [Claude Code](https://claude.com/claude-code)