### PR TITLE
fix(payment): use empty string for buyer_tel when user.phone is null

### DIFF
--- a/apps/app_user/lib/src/features/event/admission/event_application_controller.dart
+++ b/apps/app_user/lib/src/features/event/admission/event_application_controller.dart
@@ -147,7 +147,9 @@ class EventApplicationController extends _$EventApplicationController {
             'name': ticket.name,
             'amount': result.paymentAmount,
             'buyer_name': user.userMetadata?['name'] ?? '게스트',
-            'buyer_tel': user.phone ?? '01000000000',
+            // Fix #1924: never fabricate a phone number — omit with '' when phone is null.
+            // Iamport accepts an empty string; a hardcoded stub causes false PG records.
+            'buyer_tel': user.phone ?? '',
             'buyer_email': user.email ?? 'guest@minglit.com',
             'app_scheme': 'minglit',
           },

--- a/apps/app_user/test/src/features/event/admission/event_application_controller_test.dart
+++ b/apps/app_user/test/src/features/event/admission/event_application_controller_test.dart
@@ -846,39 +846,42 @@ void main() {
       expect(spy.capturedData?['buyer_tel'], '01012345678');
     });
 
-    test('user without phone → buyer_tel is empty string, not stub number', () async {
-      when(() => mockUser.phone).thenReturn(null);
-      when(
-        () => mockEventRepo.applyEvent(
-          eventId: any(named: 'eventId'),
-          ticketId: any(named: 'ticketId'),
-          verificationData: any(named: 'verificationData'),
-        ),
-      ).thenAnswer(
-        (_) async => const PaidApplyEventResult(
-          applicationId: 'app_tel2',
-          orderId: 'order_tel2',
-          paymentAmount: 10000,
-        ),
-      );
+    test(
+      'user without phone → buyer_tel is empty string, not stub number',
+      () async {
+        when(() => mockUser.phone).thenReturn(null);
+        when(
+          () => mockEventRepo.applyEvent(
+            eventId: any(named: 'eventId'),
+            ticketId: any(named: 'ticketId'),
+            verificationData: any(named: 'verificationData'),
+          ),
+        ).thenAnswer(
+          (_) async => const PaidApplyEventResult(
+            applicationId: 'app_tel2',
+            orderId: 'order_tel2',
+            paymentAmount: 10000,
+          ),
+        );
 
-      final spy = _SpyIamportController();
-      final container = createContainer(
-        overrides: [
-          currentUserProvider.overrideWith((ref) => mockUser),
-          eventRepositoryProvider.overrideWith((ref) => mockEventRepo),
-          iamportControllerProvider.overrideWith(() => spy),
-        ],
-      );
-      final notifier = container.read(
-        eventApplicationControllerProvider(testEvent).notifier,
-      );
-      notifier.selectTicket(testEvent.tickets!.first);
-      await notifier.submitApplication(mockContext);
+        final spy = _SpyIamportController();
+        final container = createContainer(
+          overrides: [
+            currentUserProvider.overrideWith((ref) => mockUser),
+            eventRepositoryProvider.overrideWith((ref) => mockEventRepo),
+            iamportControllerProvider.overrideWith(() => spy),
+          ],
+        );
+        final notifier = container.read(
+          eventApplicationControllerProvider(testEvent).notifier,
+        );
+        notifier.selectTicket(testEvent.tickets!.first);
+        await notifier.submitApplication(mockContext);
 
-      expect(spy.capturedData?['buyer_tel'], '');
-      expect(spy.capturedData?['buyer_tel'], isNot('01000000000'));
-    });
+        expect(spy.capturedData?['buyer_tel'], '');
+        expect(spy.capturedData?['buyer_tel'], isNot('01000000000'));
+      },
+    );
   });
 
   group('EventApplicationState.copyWith', () {

--- a/apps/app_user/test/src/features/event/admission/event_application_controller_test.dart
+++ b/apps/app_user/test/src/features/event/admission/event_application_controller_test.dart
@@ -811,6 +811,76 @@ void main() {
     );
   });
 
+  // Fix #1924: buyer_tel must never contain a fabricated phone number.
+  group('payment payload — buyer_tel (Fix #1924)', () {
+    test('user with phone → buyer_tel is the real phone number', () async {
+      when(() => mockUser.phone).thenReturn('01012345678');
+      when(
+        () => mockEventRepo.applyEvent(
+          eventId: any(named: 'eventId'),
+          ticketId: any(named: 'ticketId'),
+          verificationData: any(named: 'verificationData'),
+        ),
+      ).thenAnswer(
+        (_) async => const PaidApplyEventResult(
+          applicationId: 'app_tel1',
+          orderId: 'order_tel1',
+          paymentAmount: 10000,
+        ),
+      );
+
+      final spy = _SpyIamportController();
+      final container = createContainer(
+        overrides: [
+          currentUserProvider.overrideWith((ref) => mockUser),
+          eventRepositoryProvider.overrideWith((ref) => mockEventRepo),
+          iamportControllerProvider.overrideWith(() => spy),
+        ],
+      );
+      final notifier = container.read(
+        eventApplicationControllerProvider(testEvent).notifier,
+      );
+      notifier.selectTicket(testEvent.tickets!.first);
+      await notifier.submitApplication(mockContext);
+
+      expect(spy.capturedData?['buyer_tel'], '01012345678');
+    });
+
+    test('user without phone → buyer_tel is empty string, not stub number', () async {
+      when(() => mockUser.phone).thenReturn(null);
+      when(
+        () => mockEventRepo.applyEvent(
+          eventId: any(named: 'eventId'),
+          ticketId: any(named: 'ticketId'),
+          verificationData: any(named: 'verificationData'),
+        ),
+      ).thenAnswer(
+        (_) async => const PaidApplyEventResult(
+          applicationId: 'app_tel2',
+          orderId: 'order_tel2',
+          paymentAmount: 10000,
+        ),
+      );
+
+      final spy = _SpyIamportController();
+      final container = createContainer(
+        overrides: [
+          currentUserProvider.overrideWith((ref) => mockUser),
+          eventRepositoryProvider.overrideWith((ref) => mockEventRepo),
+          iamportControllerProvider.overrideWith(() => spy),
+        ],
+      );
+      final notifier = container.read(
+        eventApplicationControllerProvider(testEvent).notifier,
+      );
+      notifier.selectTicket(testEvent.tickets!.first);
+      await notifier.submitApplication(mockContext);
+
+      expect(spy.capturedData?['buyer_tel'], '');
+      expect(spy.capturedData?['buyer_tel'], isNot('01000000000'));
+    });
+  });
+
   group('EventApplicationState.copyWith', () {
     test('copies all fields', () {
       final ticket = Ticket(
@@ -860,4 +930,22 @@ void main() {
       expect(copied.errorMessage, 'msg');
     });
   });
+}
+
+/// Captures the data argument passed to startPayment for assertion in tests.
+class _SpyIamportController extends IamportController {
+  Map<String, dynamic>? capturedData;
+
+  @override
+  AsyncValue<IamportResultModel?> build() => const AsyncData(null);
+
+  @override
+  Future<String?> startPayment({
+    required BuildContext context,
+    required String userCode,
+    required Map<String, dynamic> data,
+  }) async {
+    capturedData = data;
+    return null; // simulate user cancellation to keep test simple
+  }
 }


### PR DESCRIPTION
## Summary

- Removes hardcoded `'01000000000'` stub phone number from Iamport payment payload
- When `user.phone` is `null` (all OAuth/social-login users), `buyer_tel` is now `''` — Iamport accepts an absent/empty tel field
- Prevents false payment records and addresses regulatory risk under 전자상거래법 §13

## Test plan

- [ ] Payment with null phone → `buyer_tel` is `''` (not `'01000000000'`)
- [ ] Payment with real phone → `buyer_tel` contains the actual number
- [ ] Two new unit tests in `event_application_controller_test.dart`

Closes #1924

🤖 Generated with [Claude Code](https://claude.com/claude-code)