### PR TITLE
fix(settlement): safe int coercion for financial fields in SettlementItemDetail

### DIFF
--- a/shared/packages/minglit_kit/lib/src/data/models/settlement_item_detail.dart
+++ b/shared/packages/minglit_kit/lib/src/data/models/settlement_item_detail.dart
@@ -19,7 +19,8 @@ class PayoutSummary {
     return PayoutSummary(
       id: json['id'] as String,
       status: json['status'] as String,
-      totalNetAmount: json['total_net_amount'] as int,
+      // Fix #1926: Supabase may return numeric columns as double — use safe coercion
+      totalNetAmount: _toInt(json['total_net_amount']),
       scheduledAt: json['scheduled_at'] == null
           ? null
           : DateTime.parse(json['scheduled_at'] as String),
@@ -118,7 +119,8 @@ class AdjustmentItemModel {
     return AdjustmentItemModel(
       id: json['id'] as String,
       adjustmentType: json['adjustment_type'] as String,
-      amountSigned: json['amount_signed'] as int,
+      // Fix #1926: Supabase may return numeric columns as double — use safe coercion
+      amountSigned: _toInt(json['amount_signed']),
       status: json['status'] as String,
       reasonCode: json['reason_code'] as String?,
     );
@@ -197,11 +199,12 @@ class SettlementItemDetail {
       partnerId: json['partner_id'] as String,
       eventId: json['event_id'] as String?,
       status: json['status'] as String,
-      grossAmount: json['gross_amount'] as int,
-      platformFeeAmount: json['platform_fee_amount'] as int,
-      pgFeeAmount: json['pg_fee_amount'] as int,
-      vatAmount: json['vat_amount'] as int,
-      netAmount: json['net_amount'] as int,
+      // Fix #1926: Supabase may return numeric columns as double — use safe coercion
+      grossAmount: _toInt(json['gross_amount']),
+      platformFeeAmount: _toInt(json['platform_fee_amount']),
+      pgFeeAmount: _toInt(json['pg_fee_amount']),
+      vatAmount: _toInt(json['vat_amount']),
+      netAmount: _toInt(json['net_amount']),
       currency: json['currency'] as String,
       holdReasonCode: json['hold_reason_code'] as String?,
       holdReasonDetail: json['hold_reason_detail'] as String?,
@@ -341,4 +344,13 @@ class SettlementItemDetail {
     'retryable': retryable,
     'retry_count': retryCount,
   };
+}
+
+// Fix #1926: Supabase PostgREST may return Postgres numeric columns as double
+// (e.g. 10000.0). Direct `as int` casts throw TypeError in that case.
+int _toInt(dynamic value) {
+  if (value is int) return value;
+  if (value is num) return value.round();
+  if (value is String) return int.tryParse(value) ?? 0;
+  return 0;
 }

--- a/shared/packages/minglit_kit/test/src/data/models/settlement_item_detail_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/models/settlement_item_detail_test.dart
@@ -369,21 +369,24 @@ void main() {
 
     // Fix #1926: Supabase may return Postgres numeric columns as double.
     // Bare `as int` casts throw TypeError; use safe _toInt coercion instead.
-    test('Fix #1926: parses financial fields when Supabase returns them as double', () {
-      final result = SettlementItemDetail.fromJson({
-        ...baseItemJson(),
-        'gross_amount': 100000.0,
-        'platform_fee_amount': 5000.0,
-        'pg_fee_amount': 1500.0,
-        'vat_amount': 500.0,
-        'net_amount': 93000.0,
-      });
-      expect(result.grossAmount, 100000);
-      expect(result.platformFeeAmount, 5000);
-      expect(result.pgFeeAmount, 1500);
-      expect(result.vatAmount, 500);
-      expect(result.netAmount, 93000);
-    });
+    test(
+      'Fix #1926: parses financial fields when Supabase returns them as double',
+      () {
+        final result = SettlementItemDetail.fromJson({
+          ...baseItemJson(),
+          'gross_amount': 100000.0,
+          'platform_fee_amount': 5000.0,
+          'pg_fee_amount': 1500.0,
+          'vat_amount': 500.0,
+          'net_amount': 93000.0,
+        });
+        expect(result.grossAmount, 100000);
+        expect(result.platformFeeAmount, 5000);
+        expect(result.pgFeeAmount, 1500);
+        expect(result.vatAmount, 500);
+        expect(result.netAmount, 93000);
+      },
+    );
   });
 
   // Fix #1926: PayoutSummary and AdjustmentItemModel safe coercion tests.

--- a/shared/packages/minglit_kit/test/src/data/models/settlement_item_detail_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/models/settlement_item_detail_test.dart
@@ -366,5 +366,48 @@ void main() {
       expect(json['payout_id'], isNull);
       expect(json['settlement_period_start'], isNull);
     });
+
+    // Fix #1926: Supabase may return Postgres numeric columns as double.
+    // Bare `as int` casts throw TypeError; use safe _toInt coercion instead.
+    test('Fix #1926: parses financial fields when Supabase returns them as double', () {
+      final result = SettlementItemDetail.fromJson({
+        ...baseItemJson(),
+        'gross_amount': 100000.0,
+        'platform_fee_amount': 5000.0,
+        'pg_fee_amount': 1500.0,
+        'vat_amount': 500.0,
+        'net_amount': 93000.0,
+      });
+      expect(result.grossAmount, 100000);
+      expect(result.platformFeeAmount, 5000);
+      expect(result.pgFeeAmount, 1500);
+      expect(result.vatAmount, 500);
+      expect(result.netAmount, 93000);
+    });
+  });
+
+  // Fix #1926: PayoutSummary and AdjustmentItemModel safe coercion tests.
+  group('PayoutSummary.fromJson — Fix #1926 numeric coercion', () {
+    test('totalNetAmount parses double from Supabase numeric column', () {
+      final result = PayoutSummary.fromJson({
+        'id': 'payout-1',
+        'status': 'COMPLETED',
+        'total_net_amount': 93000.0,
+        'scheduled_at': null,
+      });
+      expect(result.totalNetAmount, 93000);
+    });
+  });
+
+  group('AdjustmentItemModel.fromJson — Fix #1926 numeric coercion', () {
+    test('amountSigned parses double from Supabase numeric column', () {
+      final result = AdjustmentItemModel.fromJson({
+        'id': 'adj-1',
+        'adjustment_type': 'REFUND',
+        'amount_signed': -5000.0,
+        'status': 'APPLIED',
+      });
+      expect(result.amountSigned, -5000);
+    });
   });
 }


### PR DESCRIPTION
## Summary

- Replaces bare `as int` casts with safe `_toInt()` helper in `SettlementItemDetail.fromJson`, `PayoutSummary.fromJson`, and `AdjustmentItemModel.fromJson`
- Supabase PostgREST returns Postgres `numeric` columns as `double` (e.g. `10000.0`), causing `TypeError` at runtime on the settlement detail page
- Follows the same `_toInt` pattern already used in `settlement_models.dart` (app_partner)

## Test plan

- [ ] `SettlementItemDetail.fromJson` with `double` financial values → no crash
- [ ] `PayoutSummary.fromJson` with `double` `total_net_amount` → correct value
- [ ] `AdjustmentItemModel.fromJson` with `double` `amount_signed` → correct value
- [ ] Three new regression tests in `settlement_item_detail_test.dart`

Closes #1926

🤖 Generated with [Claude Code](https://claude.com/claude-code)