### PR TITLE
fix(privacy): mask phone number in match results UI

### DIFF
--- a/apps/app_user/lib/src/common/widgets/match_results_content.dart
+++ b/apps/app_user/lib/src/common/widgets/match_results_content.dart
@@ -165,7 +165,9 @@ class _MatchResultCard extends StatelessWidget {
                 if (match.partnerContact != null) ...[
                   const SizedBox(height: MinglitSpacing.xxsmall),
                   Text(
-                    match.partnerContact!,
+                    // Fix #1925: mask phone number to prevent PII exposure in UI
+                    // (개인정보보호법 §24 — phone numbers are sensitive PII)
+                    _maskPhone(match.partnerContact!),
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: MinglitColors.textSecondary,
                     ),
@@ -183,6 +185,24 @@ class _MatchResultCard extends StatelessWidget {
       ),
     );
   }
+}
+
+/// Fix #1925: masks middle digits of a Korean phone number to protect PII.
+/// Handles both raw (+821012345678) and local (01012345678) formats.
+/// Result: 010-****-5678
+String _maskPhone(String phone) {
+  final digits = phone.replaceAll(RegExp(r'\D'), '');
+  // Normalize country code: +82XX... → 0XX...
+  final local =
+      digits.startsWith('82') && digits.length > 10 ? '0${digits.substring(2)}' : digits;
+  if (local.length == 11) {
+    return '${local.substring(0, 3)}-****-${local.substring(7)}';
+  }
+  if (local.length == 10) {
+    return '${local.substring(0, 3)}-***-${local.substring(6)}';
+  }
+  // Fallback: mask all but last 4
+  return '***-****-${local.length >= 4 ? local.substring(local.length - 4) : '****'}';
 }
 
 class _DragHandle extends StatelessWidget {

--- a/apps/app_user/lib/src/common/widgets/match_results_content.dart
+++ b/apps/app_user/lib/src/common/widgets/match_results_content.dart
@@ -202,8 +202,9 @@ String _maskPhone(String phone) {
   if (local.length == 10) {
     return '${local.substring(0, 3)}-***-${local.substring(6)}';
   }
-  // Fallback: mask all but last 4
-  return '***-****-${local.length >= 4 ? local.substring(local.length - 4) : '****'}';
+  // Fallback: never expose full input — short numbers (<=4 digits) are fully masked
+  if (local.length <= 4) return '***-****-****';
+  return '***-****-${local.substring(local.length - 4)}';
 }
 
 class _DragHandle extends StatelessWidget {

--- a/apps/app_user/lib/src/common/widgets/match_results_content.dart
+++ b/apps/app_user/lib/src/common/widgets/match_results_content.dart
@@ -193,8 +193,9 @@ class _MatchResultCard extends StatelessWidget {
 String _maskPhone(String phone) {
   final digits = phone.replaceAll(RegExp(r'\D'), '');
   // Normalize country code: +82XX... → 0XX...
-  final local =
-      digits.startsWith('82') && digits.length > 10 ? '0${digits.substring(2)}' : digits;
+  final local = digits.startsWith('82') && digits.length > 10
+      ? '0${digits.substring(2)}'
+      : digits;
   if (local.length == 11) {
     return '${local.substring(0, 3)}-****-${local.substring(7)}';
   }

--- a/apps/app_user/test/src/common/widgets/match_results_content_test.dart
+++ b/apps/app_user/test/src/common/widgets/match_results_content_test.dart
@@ -1,0 +1,102 @@
+// Fix #1925: partnerContact (phone number) must be masked in ResultsContent UI.
+// Personal phone numbers are sensitive PII under 개인정보보호법 §24.
+
+import 'package:app_user/src/common/widgets/match_results_content.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+void main() {
+  final testEvent = Event(
+    id: 'event-1',
+    partyId: 'party-1',
+    title: '테스트 이벤트',
+    startTime: DateTime.now().subtract(const Duration(hours: 2)),
+    endTime: DateTime.now().add(const Duration(hours: 1)),
+    createdAt: DateTime.now(),
+    updatedAt: DateTime.now(),
+  );
+
+  final activeEvent = TodayActiveEvent(
+    event: testEvent,
+    participantStatus: 'ticket_issued',
+  );
+
+  Widget buildWidget({required List<MatchPair> matches}) {
+    return ProviderScope(
+      overrides: [
+        myMatchesProvider(testEvent.id).overrideWith(
+          (ref, eventId) async => matches,
+        ),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: MatchResultsContent(activeEvent: activeEvent),
+        ),
+      ),
+    );
+  }
+
+  group('MatchResultsContent — phone masking (Fix #1925)', () {
+    testWidgets('partnerContact is masked — raw phone not shown', (
+      tester,
+    ) async {
+      const rawPhone = '01012345678';
+      final match = MatchPair(
+        matchId: 'match-1',
+        eventId: testEvent.id,
+        partnerId: 'partner-1',
+        matchedAt: DateTime.now(),
+        partnerName: '홍길동',
+        partnerContact: rawPhone,
+      );
+
+      await tester.pumpWidget(buildWidget(matches: [match]));
+      await tester.pumpAndSettle();
+
+      // Raw phone must not appear
+      expect(find.text(rawPhone), findsNothing,
+          reason: 'Raw phone number must not be displayed (PII)');
+
+      // Masked version must appear
+      expect(find.text('010-****-5678'), findsOneWidget);
+    });
+
+    testWidgets('+82 country-code phone is also masked correctly', (
+      tester,
+    ) async {
+      const rawPhone = '+821012345678';
+      final match = MatchPair(
+        matchId: 'match-2',
+        eventId: testEvent.id,
+        partnerId: 'partner-2',
+        matchedAt: DateTime.now(),
+        partnerName: '김철수',
+        partnerContact: rawPhone,
+      );
+
+      await tester.pumpWidget(buildWidget(matches: [match]));
+      await tester.pumpAndSettle();
+
+      expect(find.text(rawPhone), findsNothing);
+      expect(find.text('010-****-5678'), findsOneWidget);
+    });
+
+    testWidgets('null partnerContact renders no phone text', (tester) async {
+      final match = MatchPair(
+        matchId: 'match-3',
+        eventId: testEvent.id,
+        partnerId: 'partner-3',
+        matchedAt: DateTime.now(),
+        partnerName: '이영희',
+      );
+
+      await tester.pumpWidget(buildWidget(matches: [match]));
+      await tester.pumpAndSettle();
+
+      // Partner name should appear but no masked-phone text
+      expect(find.text('이영희'), findsOneWidget);
+      expect(find.textContaining('****'), findsNothing);
+    });
+  });
+}

--- a/apps/app_user/test/src/common/widgets/match_results_content_test.dart
+++ b/apps/app_user/test/src/common/widgets/match_results_content_test.dart
@@ -55,8 +55,11 @@ void main() {
       await tester.pumpAndSettle();
 
       // Raw phone must not appear
-      expect(find.text(rawPhone), findsNothing,
-          reason: 'Raw phone number must not be displayed (PII)');
+      expect(
+        find.text(rawPhone),
+        findsNothing,
+        reason: 'Raw phone number must not be displayed (PII)',
+      );
 
       // Masked version must appear
       expect(find.text('010-****-5678'), findsOneWidget);

--- a/apps/app_user/test/src/common/widgets/match_results_content_test.dart
+++ b/apps/app_user/test/src/common/widgets/match_results_content_test.dart
@@ -26,7 +26,7 @@ void main() {
     return ProviderScope(
       overrides: [
         myMatchesProvider(testEvent.id).overrideWith(
-          (ref, eventId) async => matches,
+          (ref) async => matches,
         ),
       ],
       child: MaterialApp(

--- a/apps/app_user/test/src/common/widgets/match_results_content_test.dart
+++ b/apps/app_user/test/src/common/widgets/match_results_content_test.dart
@@ -1,6 +1,3 @@
-// Fix #1925: partnerContact (phone number) must be masked in ResultsContent UI.
-// Personal phone numbers are sensitive PII under 개인정보보호법 §24.
-
 import 'package:app_user/src/common/widgets/match_results_content.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -37,6 +34,8 @@ void main() {
     );
   }
 
+  // Fix #1925: partnerContact (phone number) must be masked in ResultsContent UI.
+  // Personal phone numbers are sensitive PII under 개인정보보호법 §24.
   group('MatchResultsContent — phone masking (Fix #1925)', () {
     testWidgets('partnerContact is masked — raw phone not shown', (
       tester,

--- a/apps/app_user/test/src/features/home/widgets/event_now_bottom_sheet_test.dart
+++ b/apps/app_user/test/src/features/home/widgets/event_now_bottom_sheet_test.dart
@@ -419,7 +419,7 @@ void main() {
         expect(find.text('매칭 결과'), findsOneWidget);
         expect(find.text('1명과 매칭되었어요!'), findsOneWidget);
         expect(find.text('김민지'), findsOneWidget);
-        expect(find.text('010-1234-5678'), findsOneWidget);
+        expect(find.text('010-****-5678'), findsOneWidget);
         expect(find.byIcon(Icons.favorite), findsWidgets);
       },
     );


### PR DESCRIPTION
## Summary

- `partnerContact` (raw phone number from Supabase `get_matched_user_info` RPC) was rendered as plain text in the match results bottom sheet
- Masked to `010-****-5678` format — keeps the area code and last 4 digits visible while protecting the middle digits
- Handles both local (`01012345678`) and international (`+821012345678`) formats

## Privacy context

Phone numbers are sensitive PII under 개인정보보호법 §24. Displaying them in full in the UI enables screenshot leakage and goes beyond what the consent form describes.

## Test plan

- [ ] Match with phone `01012345678` → displays `010-****-5678`, raw number not visible
- [ ] Match with phone `+821012345678` → same masked output
- [ ] Match without phone → no phone text rendered
- [ ] Three new widget tests in `match_results_content_test.dart`

Closes #1925

🤖 Generated with [Claude Code](https://claude.com/claude-code)