### PR TITLE
fix(ticket): use theme-aware colors in BoardingPassCard for dark mode

### DIFF
--- a/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card_info.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card_info.dart
@@ -165,9 +165,13 @@ class _EventInfoSection extends StatelessWidget {
           ),
 
           // Divider
-          const Padding(
-            padding: EdgeInsets.symmetric(vertical: MinglitSpacing.sm),
-            child: Divider(height: 1, color: MinglitColors.surface),
+          // Fix #1931: use theme-aware color so divider renders correctly in dark mode
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: MinglitSpacing.sm),
+            child: Divider(
+              height: 1,
+              color: Theme.of(context).colorScheme.outlineVariant,
+            ),
           ),
 
           // Event title (center aligned, 2-line ellipsis)

--- a/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card_qr.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card_qr.dart
@@ -104,7 +104,9 @@ class _DashLinePainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(_DashLinePainter oldDelegate) => false;
+  bool shouldRepaint(_DashLinePainter oldDelegate) =>
+      oldDelegate.dashColor != dashColor ||
+      oldDelegate.notchRadius != notchRadius;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card_qr.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card_qr.dart
@@ -34,13 +34,13 @@ class _PerforationLine extends StatelessWidget {
             ),
           ),
           // Left notch — positioned to overlap card left edge
-          Positioned(
+          const Positioned(
             left: -_notchRadius,
             top: 0,
             child: _NotchCircle(size: _notchDiameter),
           ),
           // Right notch — positioned to overlap card right edge
-          Positioned(
+          const Positioned(
             right: -_notchRadius,
             top: 0,
             child: _NotchCircle(size: _notchDiameter),

--- a/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card_qr.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card_qr.dart
@@ -16,10 +16,12 @@ class _PerforationLine extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Fix #1931: use theme-aware color so dash line is visible in dark mode
+    final dashColor = Theme.of(context).colorScheme.outlineVariant;
     return Container(
       color: MinglitColors.background,
       height: _notchDiameter,
-      child: const Stack(
+      child: Stack(
         clipBehavior: Clip.none,
         children: [
           // Dashed center line (excludes the notch areas)
@@ -27,7 +29,7 @@ class _PerforationLine extends StatelessWidget {
             child: CustomPaint(
               painter: _DashLinePainter(
                 notchRadius: _notchRadius,
-                dashColor: MinglitColors.divider,
+                dashColor: dashColor,
               ),
             ),
           ),
@@ -49,7 +51,7 @@ class _PerforationLine extends StatelessWidget {
   }
 }
 
-/// Solid circle in scaffold surface color — creates the "cutout" illusion.
+/// Solid circle matching page background — creates the "cutout" illusion.
 class _NotchCircle extends StatelessWidget {
   const _NotchCircle({required this.size});
 
@@ -57,11 +59,12 @@ class _NotchCircle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Fix #1931: match scaffold background so dark mode doesn't show white circles
     return Container(
       width: size,
       height: size,
-      decoration: const BoxDecoration(
-        color: MinglitColors.surface,
+      decoration: BoxDecoration(
+        color: Theme.of(context).scaffoldBackgroundColor,
         shape: BoxShape.circle,
       ),
     );

--- a/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
+++ b/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
@@ -344,7 +344,9 @@ void main() {
 
         // Divider in _EventInfoSection must also use theme-aware color, not
         // MinglitColors.surface. outlineVariant in dark theme != lightSurface.
-        final dividers = tester.widgetList<Divider>(find.byType(Divider)).toList();
+        final dividers = tester
+            .widgetList<Divider>(find.byType(Divider))
+            .toList();
         expect(dividers, isNotEmpty, reason: 'Expected Divider in event info');
         for (final d in dividers) {
           expect(

--- a/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
+++ b/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
@@ -322,13 +322,16 @@ void main() {
                 (w) =>
                     w is Container &&
                     w.decoration is BoxDecoration &&
-                    (w.decoration as BoxDecoration).shape == BoxShape.circle,
+                    (w.decoration! as BoxDecoration).shape == BoxShape.circle,
               ),
             )
             .toList();
 
-        expect(circleContainers, isNotEmpty,
-            reason: 'Expected notch circle Containers in the widget tree');
+        expect(
+          circleContainers,
+          isNotEmpty,
+          reason: 'Expected notch circle Containers in the widget tree',
+        );
         for (final c in circleContainers) {
           final color = (c.decoration! as BoxDecoration).color;
           expect(

--- a/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
+++ b/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
@@ -292,5 +292,53 @@ void main() {
         );
       },
     );
+
+    // Fix #1931 regression guard: _NotchCircle must not use hardcoded
+    // MinglitColors.surface in dark mode (causes bright circles on dark page).
+    testWidgets(
+      'dark mode: notch circles use scaffoldBackgroundColor, not hardcoded surface (Fix #1931)',
+      (tester) async {
+        final darkTheme = ThemeData.dark(useMaterial3: true);
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: darkTheme,
+            home: Scaffold(
+              body: SingleChildScrollView(
+                child: _Host(token: _makeToken(), eventMeta: _makeMeta()),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.byType(BoardingPassCard), findsOneWidget);
+
+        // MinglitColors.surface = 0xFFF9FAFB (light-mode only).
+        // In dark mode, notch circles must match scaffoldBackgroundColor.
+        const lightSurface = Color(0xFFF9FAFB);
+        final circleContainers = tester
+            .widgetList<Container>(
+              find.byWidgetPredicate(
+                (w) =>
+                    w is Container &&
+                    w.decoration is BoxDecoration &&
+                    (w.decoration as BoxDecoration).shape == BoxShape.circle,
+              ),
+            )
+            .toList();
+
+        expect(circleContainers, isNotEmpty,
+            reason: 'Expected notch circle Containers in the widget tree');
+        for (final c in circleContainers) {
+          final color = (c.decoration! as BoxDecoration).color;
+          expect(
+            color,
+            isNot(lightSurface),
+            reason:
+                '_NotchCircle must not use MinglitColors.surface in dark mode',
+          );
+        }
+      },
+    );
   });
 }

--- a/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
+++ b/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
@@ -341,6 +341,18 @@ void main() {
                 '_NotchCircle must not use MinglitColors.surface in dark mode',
           );
         }
+
+        // Divider in _EventInfoSection must also use theme-aware color, not
+        // MinglitColors.surface. outlineVariant in dark theme != lightSurface.
+        final dividers = tester.widgetList<Divider>(find.byType(Divider)).toList();
+        expect(dividers, isNotEmpty, reason: 'Expected Divider in event info');
+        for (final d in dividers) {
+          expect(
+            d.color,
+            isNot(lightSurface),
+            reason: 'Divider must not use MinglitColors.surface in dark mode',
+          );
+        }
       },
     );
   });


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Summary

- `_NotchCircle` used hardcoded `MinglitColors.surface` (0xFFF9FAFB, light-mode only) — in dark mode, notch circles appeared as bright white circles against a dark page background
- `_PerforationLine` passed `MinglitColors.divider` (light-mode hardcoded) to `_DashLinePainter` as `dashColor`
- `Divider` in `_EventInfoSection` used `MinglitColors.surface` for color

All three now use `Theme.of(context)` for theme-aware rendering.

## Changes

- `boarding_pass_card_qr.dart`: `_NotchCircle.color` → `Theme.of(context).scaffoldBackgroundColor`; `_PerforationLine` `dashColor` → `Theme.of(context).colorScheme.outlineVariant`
- `boarding_pass_card_info.dart`: `Divider(color: MinglitColors.surface)` → `Theme.of(context).colorScheme.outlineVariant`
- `boarding_pass_card_test.dart`: adds dark-mode regression guard (no circular Container uses 0xFFF9FAFB)

## Test plan
- [ ] Widget renders without crash in dark mode
- [ ] New dark-mode test: notch circles do not use `MinglitColors.surface`
- [ ] Existing `BoardingPassCard` widget tests still pass

Closes #1931