### PR TITLE
fix(settings): refactor BlockedPartnersPage — Log.e + Riverpod FutureProvider (#1927, #1929)

### DIFF
--- a/apps/app_user/lib/src/features/settings/blocked_partners_page.dart
+++ b/apps/app_user/lib/src/features/settings/blocked_partners_page.dart
@@ -5,20 +5,19 @@ import 'package:minglit_kit/minglit_kit.dart';
 
 // Fix #1929: manual widget state를 Riverpod FutureProvider로 대체해 차단 목록 로딩을 관리
 // Fix #1927: autoDispose로 페이지 재진입 시마다 최신 목록을 새로 fetch
-final blockedPartnersProvider = FutureProvider.autoDispose<
-  List<Map<String, dynamic>>
->((
-  ref,
-) async {
-  // Fix #270: 네트워크 실패 시 에러 처리 — 영구 로딩 상태 방지
-  try {
-    return await ref.watch(socialRepositoryProvider).getBlockedPartners();
-  } on Object catch (e, st) {
-    // Fix #1927: structured error logging을 위해 debugPrint 대신 Log.e 사용
-    Log.e('Failed to load blocked partners', e, st);
-    rethrow;
-  }
-});
+final FutureProvider<List<Map<String, dynamic>>> blockedPartnersProvider =
+    FutureProvider.autoDispose<List<Map<String, dynamic>>>((
+      ref,
+    ) async {
+      // Fix #270: 네트워크 실패 시 에러 처리 — 영구 로딩 상태 방지
+      try {
+        return await ref.watch(socialRepositoryProvider).getBlockedPartners();
+      } on Object catch (e, st) {
+        // Fix #1927: structured error logging을 위해 debugPrint 대신 Log.e 사용
+        Log.e('Failed to load blocked partners', e, st);
+        rethrow;
+      }
+    });
 
 class BlockedPartnersPage extends ConsumerWidget {
   const BlockedPartnersPage({super.key});

--- a/apps/app_user/lib/src/features/settings/blocked_partners_page.dart
+++ b/apps/app_user/lib/src/features/settings/blocked_partners_page.dart
@@ -3,49 +3,28 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
-class BlockedPartnersPage extends ConsumerStatefulWidget {
+// Fix #1929: manual widget state를 Riverpod FutureProvider로 대체해 차단 목록 로딩을 관리
+final blockedPartnersProvider = FutureProvider<List<Map<String, dynamic>>>((
+  ref,
+) async {
+  // Fix #270: 네트워크 실패 시 에러 처리 — 영구 로딩 상태 방지
+  try {
+    return await ref.watch(socialRepositoryProvider).getBlockedPartners();
+  } on Object catch (e, st) {
+    // Fix #1927: structured error logging을 위해 debugPrint 대신 Log.e 사용
+    Log.e('Failed to load blocked partners', e, st);
+    rethrow;
+  }
+});
+
+class BlockedPartnersPage extends ConsumerWidget {
   const BlockedPartnersPage({super.key});
 
-  @override
-  ConsumerState<BlockedPartnersPage> createState() =>
-      _BlockedPartnersPageState();
-}
-
-class _BlockedPartnersPageState extends ConsumerState<BlockedPartnersPage> {
-  List<Map<String, dynamic>>? _partners;
-  bool _loading = true;
-
-  @override
-  void initState() {
-    super.initState();
-    unawaited(_load());
-  }
-
-  Future<void> _load() async {
-    setState(() => _loading = true);
-    // Fix #270: 네트워크 실패 시 에러 처리 — 영구 로딩 상태 방지
-    try {
-      final data = await ref
-          .read(socialRepositoryProvider)
-          .getBlockedPartners();
-      if (mounted) {
-        setState(() {
-          _partners = data;
-          _loading = false;
-        });
-      }
-    } on Object catch (e) {
-      debugPrint('Failed to load blocked partners: $e');
-      if (mounted) {
-        setState(() => _loading = false);
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('차단 목록을 불러오지 못했습니다')),
-        );
-      }
-    }
-  }
-
-  Future<void> _unblock(String partnerId) async {
+  Future<void> _unblock(
+    BuildContext context,
+    WidgetRef ref,
+    String partnerId,
+  ) async {
     final confirmed = await MinglitAlert.showConfirm(
       context: context,
       title: '차단 해제',
@@ -55,52 +34,66 @@ class _BlockedPartnersPageState extends ConsumerState<BlockedPartnersPage> {
     if (!confirmed) return;
 
     await ref.read(socialRepositoryProvider).unblockPartner(partnerId);
-    if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('차단이 해제되었습니다')),
-      );
-      unawaited(_load());
-    }
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('차단이 해제되었습니다')));
+    ref.invalidate(blockedPartnersProvider);
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
+    final partnersAsync = ref.watch(blockedPartnersProvider);
+
     return Scaffold(
       appBar: AppBar(title: const Text('차단 목록')),
-      body: _loading
-          ? const Center(child: MinglitCircularProgressIndicator())
-          : _partners == null || _partners!.isEmpty
-          ? Center(
+      body: partnersAsync.when(
+        loading: () => const Center(child: MinglitCircularProgressIndicator()),
+        error: (_, _) => Center(
+          child: Text(
+            '차단 목록을 불러오지 못했습니다',
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+        data: (partners) {
+          if (partners.isEmpty) {
+            return Center(
               child: Text(
                 '차단된 파트너가 없습니다',
                 style: theme.textTheme.bodyLarge?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
               ),
-            )
-          : ListView.builder(
-              itemCount: _partners!.length,
-              itemBuilder: (context, index) {
-                final p = _partners![index];
-                final id = p['id'] as String;
-                final name = p['name'] as String? ?? '';
-                final imageUrl = p['profile_image_url'] as String?;
-                return ListTile(
-                  leading: CircleAvatar(
-                    backgroundImage: imageUrl != null
-                        ? NetworkImage(imageUrl)
-                        : null,
-                    child: imageUrl == null ? const Icon(Icons.store) : null,
-                  ),
-                  title: Text(name),
-                  trailing: TextButton(
-                    onPressed: () => _unblock(id),
-                    child: const Text('차단 해제'),
-                  ),
-                );
-              },
-            ),
+            );
+          }
+
+          return ListView.builder(
+            itemCount: partners.length,
+            itemBuilder: (context, index) {
+              final p = partners[index];
+              final id = p['id'] as String;
+              final name = p['name'] as String? ?? '';
+              final imageUrl = p['profile_image_url'] as String?;
+              return ListTile(
+                leading: CircleAvatar(
+                  backgroundImage: imageUrl != null
+                      ? NetworkImage(imageUrl)
+                      : null,
+                  child: imageUrl == null ? const Icon(Icons.store) : null,
+                ),
+                title: Text(name),
+                trailing: TextButton(
+                  onPressed: () => unawaited(_unblock(context, ref, id)),
+                  child: const Text('차단 해제'),
+                ),
+              );
+            },
+          );
+        },
+      ),
     );
   }
 }

--- a/apps/app_user/lib/src/features/settings/blocked_partners_page.dart
+++ b/apps/app_user/lib/src/features/settings/blocked_partners_page.dart
@@ -4,7 +4,10 @@ import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
 // Fix #1929: manual widget state를 Riverpod FutureProvider로 대체해 차단 목록 로딩을 관리
-final blockedPartnersProvider = FutureProvider<List<Map<String, dynamic>>>((
+// Fix #1927: autoDispose로 페이지 재진입 시마다 최신 목록을 새로 fetch
+final blockedPartnersProvider = FutureProvider.autoDispose<
+  List<Map<String, dynamic>>
+>((
   ref,
 ) async {
   // Fix #270: 네트워크 실패 시 에러 처리 — 영구 로딩 상태 방지

--- a/apps/app_user/test/src/features/settings/blocked_partners_page_test.dart
+++ b/apps/app_user/test/src/features/settings/blocked_partners_page_test.dart
@@ -113,7 +113,7 @@ void main() {
         expect(callCount, 1);
 
         // Navigate back — autoDispose disposes the provider when widget unmounts
-        final NavigatorState nav = tester.state<NavigatorState>(
+        final nav = tester.state<NavigatorState>(
           find.byType(Navigator),
         );
         nav.pop();

--- a/apps/app_user/test/src/features/settings/blocked_partners_page_test.dart
+++ b/apps/app_user/test/src/features/settings/blocked_partners_page_test.dart
@@ -24,8 +24,11 @@ void main() {
     );
   }
 
-  group('BlockedPartnersPage — Fix #270 회귀 테스트', () {
-    testWidgets('network failure shows snackbar and stops loading', (
+  // Fix #270: network failure regression
+  // Fix #1927: Log.e replaces debugPrint; error body replaces snackbar
+  // Fix #1929: Riverpod FutureProvider replaces manual ConsumerStatefulWidget state
+  group('BlockedPartnersPage', () {
+    testWidgets('network failure shows error body and stops loading', (
       tester,
     ) async {
       when(
@@ -33,14 +36,11 @@ void main() {
       ).thenAnswer((_) async => throw Exception('Network error'));
 
       await tester.pumpWidget(buildTestWidget());
-      await tester.pump(); // initState → _load()
-      await tester.pump(); // Future completes with error
-      await tester.pump(); // SnackBar animation
+      await tester.pump();
+      await tester.pump();
 
-      // SnackBar 표시 확인
+      // Fix #1929: error body rendered by FutureProvider.when(error:)
       expect(find.text('차단 목록을 불러오지 못했습니다'), findsOneWidget);
-
-      // 로딩 인디케이터가 더 이상 표시되지 않아야 함
       expect(find.byType(CircularProgressIndicator), findsNothing);
     });
 
@@ -58,10 +58,57 @@ void main() {
       await tester.pumpWidget(buildTestWidget());
       await tester.pump();
       await tester.pump();
-      await tester.pump();
 
       expect(find.text('Blocked Partner'), findsOneWidget);
       expect(find.text('차단 해제'), findsOneWidget);
     });
+
+    testWidgets('empty list shows empty state message', (tester) async {
+      when(
+        () => mockSocialRepo.getBlockedPartners(),
+      ).thenAnswer((_) async => []);
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('차단된 파트너가 없습니다'), findsOneWidget);
+    });
+
+    testWidgets(
+      'Fix #1929: blockedPartnersProvider invalidated after unblock',
+      (tester) async {
+        when(() => mockSocialRepo.getBlockedPartners()).thenAnswer(
+          (_) async => [
+            {'id': 'p1', 'name': 'Partner A', 'profile_image_url': null},
+          ],
+        );
+        when(
+          () => mockSocialRepo.unblockPartner('p1'),
+        ).thenAnswer((_) async {});
+
+        await tester.pumpWidget(buildTestWidget());
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.text('Partner A'), findsOneWidget);
+
+        // After unblock, provider should reload
+        when(
+          () => mockSocialRepo.getBlockedPartners(),
+        ).thenAnswer((_) async => []);
+
+        await tester.tap(find.text('차단 해제'));
+        // Dismiss the dialog
+        await tester.pumpAndSettle();
+        // MinglitAlert.showConfirm uses AlertDialog — tap confirm button
+        if (find.text('해제').evaluate().isNotEmpty) {
+          await tester.tap(find.text('해제'));
+          await tester.pumpAndSettle();
+        }
+
+        verify(() => mockSocialRepo.unblockPartner('p1')).called(1);
+      },
+    );
   });
 }

--- a/apps/app_user/test/src/features/settings/blocked_partners_page_test.dart
+++ b/apps/app_user/test/src/features/settings/blocked_partners_page_test.dart
@@ -113,7 +113,9 @@ void main() {
         expect(callCount, 1);
 
         // Navigate back — autoDispose disposes the provider when widget unmounts
-        final nav = tester.state(find.byType(Navigator));
+        final NavigatorState nav = tester.state<NavigatorState>(
+          find.byType(Navigator),
+        );
         nav.pop();
         await tester.pumpAndSettle();
 

--- a/apps/app_user/test/src/features/settings/blocked_partners_page_test.dart
+++ b/apps/app_user/test/src/features/settings/blocked_partners_page_test.dart
@@ -113,7 +113,7 @@ void main() {
         expect(callCount, 1);
 
         // Navigate back — autoDispose disposes the provider when widget unmounts
-        final NavigatorState nav = tester.state(find.byType(Navigator));
+        final nav = tester.state(find.byType(Navigator));
         nav.pop();
         await tester.pumpAndSettle();
 

--- a/apps/app_user/test/src/features/settings/blocked_partners_page_test.dart
+++ b/apps/app_user/test/src/features/settings/blocked_partners_page_test.dart
@@ -154,7 +154,6 @@ void main() {
         ).thenAnswer((_) async => []);
 
         await tester.tap(find.text('차단 해제'));
-        // Dismiss the dialog
         await tester.pumpAndSettle();
         // MinglitAlert.showConfirm uses AlertDialog — tap confirm button
         if (find.text('해제').evaluate().isNotEmpty) {
@@ -163,6 +162,15 @@ void main() {
         }
 
         verify(() => mockSocialRepo.unblockPartner('p1')).called(1);
+        // Fix #1929: ref.invalidate(blockedPartnersProvider) must trigger re-fetch
+        // Verify getBlockedPartners() was called a second time (initial + after invalidate)
+        verify(() => mockSocialRepo.getBlockedPartners()).called(2);
+        // UI must reflect the empty list returned by the second fetch
+        expect(
+          find.text('차단된 파트너가 없습니다'),
+          findsOneWidget,
+          reason: 'invalidate must cause re-fetch; UI must show empty state',
+        );
       },
     );
   });

--- a/apps/app_user/test/src/features/settings/blocked_partners_page_test.dart
+++ b/apps/app_user/test/src/features/settings/blocked_partners_page_test.dart
@@ -36,8 +36,10 @@ void main() {
       ).thenAnswer((_) async => throw Exception('Network error'));
 
       await tester.pumpWidget(buildTestWidget());
-      await tester.pump();
-      await tester.pump();
+      // pumpAndSettle waits for FutureProvider error state to propagate through
+      // the async chain (mock → FutureProvider catch/rethrow → Riverpod rebuild).
+      // Two pump() calls were insufficient for this multi-hop async chain.
+      await tester.pumpAndSettle();
 
       // Fix #1929: error body rendered by FutureProvider.when(error:)
       expect(find.text('차단 목록을 불러오지 못했습니다'), findsOneWidget);

--- a/apps/app_user/test/src/features/settings/blocked_partners_page_test.dart
+++ b/apps/app_user/test/src/features/settings/blocked_partners_page_test.dart
@@ -76,6 +76,59 @@ void main() {
     });
 
     testWidgets(
+      'Fix #1929: autoDispose re-fetches on page re-entry in same ProviderScope',
+      (tester) async {
+        // Without autoDispose, FutureProvider caches the result in the shared
+        // ProviderScope indefinitely. Re-entry would show stale data.
+        var callCount = 0;
+        when(() => mockSocialRepo.getBlockedPartners()).thenAnswer((_) async {
+          callCount++;
+          return <Map<String, dynamic>>[];
+        });
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              socialRepositoryProvider.overrideWithValue(mockSocialRepo),
+            ],
+            child: MaterialApp(
+              home: Builder(
+                builder: (context) => ElevatedButton(
+                  onPressed: () => Navigator.push(
+                    context,
+                    MaterialPageRoute<void>(
+                      builder: (_) => const BlockedPartnersPage(),
+                    ),
+                  ),
+                  child: const Text('Open'),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        // First visit
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+        expect(callCount, 1);
+
+        // Navigate back — autoDispose disposes the provider when widget unmounts
+        final NavigatorState nav = tester.state(find.byType(Navigator));
+        nav.pop();
+        await tester.pumpAndSettle();
+
+        // Second visit — autoDispose must have fired; provider re-fetches
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+        expect(
+          callCount,
+          2,
+          reason: 'autoDispose provider must re-fetch on re-entry',
+        );
+      },
+    );
+
+    testWidgets(
       'Fix #1929: blockedPartnersProvider invalidated after unblock',
       (tester) async {
         when(() => mockSocialRepo.getBlockedPartners()).thenAnswer(


### PR DESCRIPTION
## Summary

- **Fix #1927**: Replace `debugPrint` with `Log.e` for structured error logging (doesn't leak to production console)
- **Fix #1929**: Replace manual `ConsumerStatefulWidget` state (`_partners`, `_loading`) with `blockedPartnersProvider` (Riverpod `FutureProvider`)
  - Eliminates stale state on hot-reload
  - `ref.invalidate(blockedPartnersProvider)` triggers fresh load after unblock
  - `.when(loading:, error:, data:)` pattern used for rendering

Closes #1927
Closes #1929

## Test plan
- [ ] Network failure shows error body (not snackbar separately)
- [ ] Successful load renders partner list
- [ ] Empty list shows placeholder
- [ ] Unblock invalidates provider and reloads list

🤖 Generated with [Claude Code](https://claude.com/claude-code)