### PR TITLE
test(repositories): add lastSelectColumns regression guards (#2011)

### DIFF
--- a/shared/packages/minglit_kit/test/helpers/supabase_mock_helpers.dart
+++ b/shared/packages/minglit_kit/test/helpers/supabase_mock_helpers.dart
@@ -90,6 +90,11 @@ class FakeTableBuilder extends Fake implements SupabaseQueryBuilder {
   // Tracks the columns string passed to .select() — used in regression tests
   // to assert that specific columns (e.g. 'event_at') are queried.
   String? lastSelectColumns;
+  // Tracks every columns string passed to .select() across all calls.
+  // Useful when the same mock is reused for multiple calls (e.g. two queries
+  // on the same table overwrite each other in mocktail, so lastSelectColumns
+  // only reflects the final call).
+  final List<String> selectHistory = [];
   // Tracks column names passed to .order() — used in regression tests.
   final List<String> recordedOrderColumns = [];
 
@@ -99,6 +104,7 @@ class FakeTableBuilder extends Fake implements SupabaseQueryBuilder {
   ]) {
     if (shouldThrow != null) throw shouldThrow!;
     lastSelectColumns = columns;
+    selectHistory.add(columns);
     return _FakeFilterBuilder(
       selectData: selectData,
       singleData: singleData,

--- a/shared/packages/minglit_kit/test/src/data/repositories/account_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/account_repository_test.dart
@@ -142,13 +142,12 @@ void main() {
 
     group('getDeletionStatus', () {
       test('returns pending status when deleted_at exists', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'user_profiles',
-            maybeSingleData: {'deleted_at': '2026-03-30T00:00:00Z'},
-          ),
+        final builder = mockTable(
+          mockClient,
+          'user_profiles',
+          maybeSingleData: {'deleted_at': '2026-03-30T00:00:00Z'},
         );
+        unawaited(builder);
 
         final result = await repository.getDeletionStatus();
 
@@ -156,6 +155,12 @@ void main() {
         expect(result!.isPending, true);
         expect(result.deletedAt, DateTime.parse('2026-03-30T00:00:00Z'));
         expect(result.gracePeriodEnds, DateTime.parse('2026-04-06T00:00:00Z'));
+        // Fix #2011: regression guard — lastSelectColumns must include expected column
+        expect(
+          builder.lastSelectColumns,
+          contains('deleted_at'),
+          reason: 'Fix #2011: select() must include deleted_at',
+        );
       });
 
       test('returns non-pending status when deleted_at is null', () async {

--- a/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
@@ -318,12 +318,12 @@ void main() {
             },
           },
         );
+        // Empty rules → code falls back to gender-based entry_groups path,
+        // allowing the entry_groups select() regression guards below to run.
         final rulesBuilder = mockTable(
           mockClient,
           'match_rules',
-          selectData: [
-            {'target_group_id': 'group_f'},
-          ],
+          selectData: [],
         );
         final entryGroupsBuilder = mockTable(
           mockClient,
@@ -332,11 +332,14 @@ void main() {
             {'id': 'group_m', 'gender': 'male'},
           ],
         );
+        // oppositeGroupsBuilder overwrites entryGroupsBuilder for 'entry_groups'
+        // in mocktail, so both entry_groups calls go through this builder.
+        // Includes 'gender' so myGender is resolved and the second query runs.
         final oppositeGroupsBuilder = mockTable(
           mockClient,
           'entry_groups',
           selectData: [
-            {'id': 'group_f'},
+            {'id': 'group_f', 'gender': 'female'},
           ],
         );
         unawaited(participantBuilder);

--- a/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
@@ -298,6 +298,79 @@ void main() {
 
         final result = await repository.getMatchingCandidates('event_1');
         expect(result, isEmpty);
+
+        final participantBuilder = mockTable(
+          mockClient,
+          'event_participants',
+          selectData: [
+            {
+              'user_id': 'user_2',
+              'display_name': '상대방',
+              'birth_year': 1996,
+              'ticket': {
+                'target_entry_group_ids': ['group_f'],
+              },
+            },
+          ],
+          maybeSingleData: {
+            'ticket': {
+              'target_entry_group_ids': ['group_m'],
+            },
+          },
+        );
+        final rulesBuilder = mockTable(
+          mockClient,
+          'match_rules',
+          selectData: [
+            {'target_group_id': 'group_f'},
+          ],
+        );
+        final entryGroupsBuilder = mockTable(
+          mockClient,
+          'entry_groups',
+          selectData: [
+            {'id': 'group_m', 'gender': 'male'},
+          ],
+        );
+        final oppositeGroupsBuilder = mockTable(
+          mockClient,
+          'entry_groups',
+          selectData: [
+            {'id': 'group_f'},
+          ],
+        );
+        unawaited(participantBuilder);
+        unawaited(rulesBuilder);
+        unawaited(entryGroupsBuilder);
+        unawaited(oppositeGroupsBuilder);
+
+        final candidates = await repository.getMatchingCandidates('event_1');
+
+        expect(candidates, hasLength(1));
+        // Fix #2011: regression guard — lastSelectColumns must include expected column
+        expect(
+          rulesBuilder.lastSelectColumns,
+          contains('target_group_id'),
+          reason: 'Fix #2011: select() must include target_group_id',
+        );
+        // Fix #2011: regression guard — lastSelectColumns must include expected column
+        expect(
+          entryGroupsBuilder.lastSelectColumns,
+          contains('gender'),
+          reason: 'Fix #2011: select() must include gender',
+        );
+        // Fix #2011: regression guard — lastSelectColumns must include expected column
+        expect(
+          oppositeGroupsBuilder.lastSelectColumns,
+          contains('id'),
+          reason: 'Fix #2011: select() must include id',
+        );
+        // Fix #2011: regression guard — lastSelectColumns must include expected column
+        expect(
+          participantBuilder.lastSelectColumns,
+          contains('user_id'),
+          reason: 'Fix #2011: select() must include user_id',
+        );
       });
     });
   });

--- a/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
@@ -353,10 +353,12 @@ void main() {
           contains('target_group_id'),
           reason: 'Fix #2011: select() must include target_group_id',
         );
-        // Fix #2011: regression guard — lastSelectColumns must include expected column
+        // Fix #2011: regression guard — both entry_groups calls go through
+        // oppositeGroupsBuilder because mocktail overwrites stubs with the same
+        // table name. Use selectHistory (all calls) to assert 'gender' appeared.
         expect(
-          entryGroupsBuilder.lastSelectColumns,
-          contains('gender'),
+          oppositeGroupsBuilder.selectHistory,
+          contains('id, gender'),
           reason: 'Fix #2011: select() must include gender',
         );
         // Fix #2011: regression guard — lastSelectColumns must include expected column

--- a/shared/packages/minglit_kit/test/src/data/repositories/partner_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/partner_repository_test.dart
@@ -110,21 +110,26 @@ void main() {
       );
 
       test('returns managed partners when permissions exist', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'partner_member_permissions',
-            selectData: [
-              {'partner_id': 'partner_1'},
-            ],
-          ),
+        final permissionsBuilder = mockTable(
+          mockClient,
+          'partner_member_permissions',
+          selectData: [
+            {'partner_id': 'partner_1'},
+          ],
         );
+        unawaited(permissionsBuilder);
         unawaited(mockTable(mockClient, 'partners', selectData: [partnerJson]));
 
         final result = await repository.getMyManagedPartners();
 
         expect(result, hasLength(1));
         expect(result.first.id, 'partner_1');
+        // Fix #2011: regression guard — lastSelectColumns must include expected column
+        expect(
+          permissionsBuilder.lastSelectColumns,
+          contains('partner_id'),
+          reason: 'Fix #2011: select() must include partner_id',
+        );
       });
 
       // Fix #1217: Fallback via approved applications when permissions missing
@@ -181,21 +186,26 @@ void main() {
       });
 
       test('returns role data when found', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'partner_member_permissions',
-            maybeSingleData: {
-              'role': 'owner',
-              'permissions': ['all'],
-            },
-          ),
+        final builder = mockTable(
+          mockClient,
+          'partner_member_permissions',
+          maybeSingleData: {
+            'role': 'owner',
+            'permissions': ['all'],
+          },
         );
+        unawaited(builder);
 
         final result = await repository.getMyMemberRole('partner_1');
 
         expect(result, isNotNull);
         expect(result!['role'], 'owner');
+        // Fix #2011: regression guard — lastSelectColumns must include expected column
+        expect(
+          builder.lastSelectColumns,
+          contains('role'),
+          reason: 'Fix #2011: select() must include role',
+        );
       });
     });
 

--- a/shared/packages/minglit_kit/test/src/data/repositories/social_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/social_repository_test.dart
@@ -172,6 +172,56 @@ void main() {
         );
 
         expect(result, 3);
+
+        final blockedIdsBuilder = mockTable(
+          mockClient,
+          'social_interactions',
+          selectData: [
+            {'target_id': 'partner_1'},
+          ],
+        );
+        unawaited(blockedIdsBuilder);
+
+        final blockedPartnerIds = await repository.getBlockedPartnerIds();
+
+        expect(blockedPartnerIds, ['partner_1']);
+        // Fix #2011: regression guard — lastSelectColumns must include expected column
+        expect(
+          blockedIdsBuilder.lastSelectColumns,
+          contains('target_id'),
+          reason: 'Fix #2011: select() must include target_id',
+        );
+
+        final partnersBuilder = mockTable(
+          mockClient,
+          'partners',
+          selectData: [
+            {
+              'id': 'partner_1',
+              'name': '파트너',
+              'profile_image_url': 'https://example.com/profile.png',
+            },
+          ],
+        );
+        final blockedIdsForPartnersBuilder = mockTable(
+          mockClient,
+          'social_interactions',
+          selectData: [
+            {'target_id': 'partner_1'},
+          ],
+        );
+        unawaited(partnersBuilder);
+        unawaited(blockedIdsForPartnersBuilder);
+
+        final blockedPartners = await repository.getBlockedPartners();
+
+        expect(blockedPartners, hasLength(1));
+        // Fix #2011: regression guard — lastSelectColumns must include expected column
+        expect(
+          partnersBuilder.lastSelectColumns,
+          contains('profile_image_url'),
+          reason: 'Fix #2011: select() must include profile_image_url',
+        );
       });
     });
   });

--- a/shared/packages/minglit_kit/test/src/data/repositories/tag_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/tag_repository_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async' show unawaited;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/models/tag.dart';
 import 'package:minglit_kit/src/data/repositories/tag_repository.dart';
@@ -143,6 +145,54 @@ void main() {
         expect(result, isEmpty);
         // from('user_interest_tags') should never be called
         verifyNever(() => unauthClient.from('user_interest_tags'));
+
+        final mockUser = MockUser();
+        when(() => mockUser.id).thenReturn('user_1');
+        final authedClient = createMockSupabase(currentUser: mockUser);
+        final authedRepo = TagRepository(supabase: authedClient);
+
+        final interestTagsBuilder = mockTable(
+          authedClient,
+          'user_interest_tags',
+          selectData: [
+            {
+              'tag_id': 'tag_1',
+              'tags': tagJson1,
+            },
+          ],
+        );
+        unawaited(interestTagsBuilder);
+
+        final interestTags = await authedRepo.getUserInterestTags();
+
+        expect(interestTags, hasLength(1));
+        expect(interestTags.first.id, 'tag_1');
+        // Fix #2011: regression guard — lastSelectColumns must include expected column
+        expect(
+          interestTagsBuilder.lastSelectColumns,
+          contains('tag_id'),
+          reason: 'Fix #2011: select() must include tag_id',
+        );
+
+        final partyTagsBuilder = mockTable(
+          authedClient,
+          'party_tags',
+          selectData: [
+            {'tags': tagJson2},
+          ],
+        );
+        unawaited(partyTagsBuilder);
+
+        final partyTags = await authedRepo.getTagsByPartyId('party_1');
+
+        expect(partyTags, hasLength(1));
+        expect(partyTags.first.id, 'tag_2');
+        // Fix #2011: regression guard — lastSelectColumns must include expected column
+        expect(
+          partyTagsBuilder.lastSelectColumns,
+          contains('tags(*)'),
+          reason: 'Fix #2011: select() must include tags(*)',
+        );
       });
     });
   });

--- a/shared/packages/minglit_kit/test/src/data/repositories/user_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/user_repository_test.dart
@@ -106,22 +106,27 @@ void main() {
 
     group('getApprovedVerificationIds', () {
       test('returns list of verification IDs', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'partner_verified_users',
-            selectData: [
-              {'verification_id': 'v_1'},
-              {'verification_id': 'v_2'},
-              {'verification_id': 'v_3'},
-            ],
-          ),
+        final builder = mockTable(
+          mockClient,
+          'partner_verified_users',
+          selectData: [
+            {'verification_id': 'v_1'},
+            {'verification_id': 'v_2'},
+            {'verification_id': 'v_3'},
+          ],
         );
+        unawaited(builder);
 
         final result = await repository.getApprovedVerificationIds('user_1');
 
         expect(result, hasLength(3));
         expect(result, containsAll(['v_1', 'v_2', 'v_3']));
+        // Fix #2011: regression guard — lastSelectColumns must include expected column
+        expect(
+          builder.lastSelectColumns,
+          contains('verification_id'),
+          reason: 'Fix #2011: select() must include verification_id',
+        );
       });
 
       test('returns empty list when no verifications', () async {

--- a/shared/packages/minglit_kit/test/src/data/repositories/verification_query_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/verification_query_repository_test.dart
@@ -275,33 +275,58 @@ void main() {
     // Fix #301: getVerificationComments now reads from snapshot_data JSON
     group('getVerificationComments', () {
       test('returns comments from snapshot_data', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'verification_submissions',
-            maybeSingleData: {
-              'snapshot_data': [
-                {
-                  'submitted_at': '2026-03-15',
-                  'data': {'university': '서울대'},
-                  'comments': [
-                    {
-                      'author': 'user-1',
-                      'at': '2026-03-16T10:00:00Z',
-                      'text': '다시 올리겠습니다',
-                    },
-                  ],
-                },
-              ],
-            },
-          ),
+        final snapshotBuilder = mockTable(
+          mockClient,
+          'verification_submissions',
+          maybeSingleData: {
+            'snapshot_data': [
+              {
+                'submitted_at': '2026-03-15',
+                'data': {'university': '서울대'},
+                'comments': [
+                  {
+                    'author': 'user-1',
+                    'at': '2026-03-16T10:00:00Z',
+                    'text': '다시 올리겠습니다',
+                  },
+                ],
+              },
+            ],
+          },
         );
+        unawaited(snapshotBuilder);
 
         final result = await repository.getVerificationComments('sub_1');
 
         expect(result, hasLength(1));
         expect(result.first['author_id'], 'user-1');
         expect((result.first['content'] as Map)['text'], '다시 올리겠습니다');
+        // Fix #2011: regression guard — lastSelectColumns must include expected column
+        expect(
+          snapshotBuilder.lastSelectColumns,
+          contains('snapshot_data'),
+          reason: 'Fix #2011: select() must include snapshot_data',
+        );
+
+        final submissionBuilder = mockTable(
+          mockClient,
+          'verification_submissions',
+          maybeSingleData: {'id': 'sub_1'},
+        );
+        unawaited(submissionBuilder);
+
+        final submission = await repository.getSubmissionByApplicationId(
+          'app_1',
+        );
+
+        expect(submission, isNotNull);
+        expect(submission!['id'], 'sub_1');
+        // Fix #2011: regression guard — lastSelectColumns must include expected column
+        expect(
+          submissionBuilder.lastSelectColumns,
+          contains('id'),
+          reason: 'Fix #2011: select() must include id',
+        );
       });
 
       test('returns empty list when no submission found', () async {


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #2011

## 배경

P1 버그 Fix #1566, #1937가 동일 패턴(존재하지 않는 컬럼 SELECT)으로 발생했다. `settlement_repository_test.dart`에만 회귀 가드가 있었고, 나머지 7개 리포지토리는 무방비였다.

## 변경 사항

7개 테스트 파일에 `lastSelectColumns` 어설션 추가:

| 테스트 파일 | 보호하는 메서드 | 핵심 컬럼 |
|---|---|---|
| `matching_repository_test.dart` | getRuleTargets, getMyEntryGroups, getOppositeGroups, getUnmatchedParticipants | target_group_id, id/gender, id, user_id |
| `user_repository_test.dart` | getUserVerificationIds | verification_id |
| `account_repository_test.dart` | getUserDeletedStatus | deleted_at |
| `social_repository_test.dart` | getBlockedPartnerIds, getPartnersByIds | target_id, id/name/profile_image_url |
| `partner_repository_test.dart` | getPartnerPermissions, getPermissionsByPartnerId | partner_id, role/permissions |
| `verification_query_repository_test.dart` | getSubmissionByApplicationId, getSnapshotData | id, snapshot_data |
| `tag_repository_test.dart` | getUserInterestTags, getTagsByPartyId | tag_id, tags(*) |

## 검증 방법

기존 모든 테스트가 통과해야 함. 의도적으로 컬럼명을 바꾸면 해당 테스트가 실패함.