### PR TITLE
fix(event-now-bar): watch eventRealtimeProvider to activate Realtime subscription (#2022)

### DIFF
--- a/apps/app_user/lib/src/features/home/widgets/event_now_bar.dart
+++ b/apps/app_user/lib/src/features/home/widgets/event_now_bar.dart
@@ -112,6 +112,12 @@ class _EventNowBarContentState extends ConsumerState<_EventNowBarContent>
 
   @override
   Widget build(BuildContext context) {
+    // Fix #2022: Watch eventRealtimeProvider to activate the Supabase Realtime
+    // subscription for this event. Without this watch, EventRealtime.build()
+    // is never called, so CHECKED_IN→MATCHING/RESULTS transitions require an
+    // app restart instead of happening automatically.
+    ref.watch(eventRealtimeProvider(widget.activeEvent.event.id));
+
     final stateAsync = ref.watch(eventNowBarStateProvider(widget.activeEvent));
 
     return stateAsync.when(

--- a/apps/app_user/test/integration/cuj_event_now_bar_test.dart
+++ b/apps/app_user/test/integration/cuj_event_now_bar_test.dart
@@ -75,6 +75,12 @@ void main() {
           eventNowBarStateProvider(eventList.first).overrideWith(
             () => _FakeEventNowBarStateNotifier(state),
           ),
+        // Fix #2022: prevent EventRealtime.build() from calling supabaseClientProvider
+        // in integration tests where Supabase is not initialized.
+        if (eventList.isNotEmpty)
+          eventRealtimeProvider(eventList.first.event.id).overrideWith(
+            () => _NoOpEventRealtime(),
+          ),
         // Phase 1: QR 토큰 프로바이더 — null 반환으로 에러 위젯 폴백
         if (state == EventNowBarState.checkInReady ||
             state == EventNowBarState.waiting)
@@ -386,6 +392,13 @@ class _FakeEventNowBarStateNotifier extends EventNowBarStateNotifier {
   @override
   FutureOr<EventNowBarState> build(TodayActiveEvent activeEvent) async =>
       _state;
+}
+
+/// Fix #2022: No-op EventRealtime stub — prevents Supabase Realtime
+/// initialization in integration tests.
+class _NoOpEventRealtime extends EventRealtime {
+  @override
+  void build(String eventId) {}
 }
 
 /// 테스트용 MatchingVoteController — 실제 네트워크 호출 없이 즉시 성공 반환.

--- a/apps/app_user/test/integration/cuj_event_now_bar_test.dart
+++ b/apps/app_user/test/integration/cuj_event_now_bar_test.dart
@@ -79,7 +79,7 @@ void main() {
         // in integration tests where Supabase is not initialized.
         if (eventList.isNotEmpty)
           eventRealtimeProvider(eventList.first.event.id).overrideWith(
-            () => _NoOpEventRealtime(),
+            _NoOpEventRealtime.new,
           ),
         // Phase 1: QR 토큰 프로바이더 — null 반환으로 에러 위젯 폴백
         if (state == EventNowBarState.checkInReady ||

--- a/apps/app_user/test/src/features/home/home_page_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_test.dart
@@ -248,7 +248,7 @@ void main() {
             ),
             // Fix #2022: prevent EventRealtime from touching Supabase in tests
             eventRealtimeProvider('active_event').overrideWith(
-              () => _NoOpEventRealtime(),
+              _NoOpEventRealtime.new,
             ),
           ],
         ),
@@ -288,7 +288,7 @@ void main() {
             ),
             // Fix #2022: prevent EventRealtime from touching Supabase in tests
             eventRealtimeProvider('active_event').overrideWith(
-              () => _NoOpEventRealtime(),
+              _NoOpEventRealtime.new,
             ),
           ],
         ),
@@ -369,7 +369,7 @@ void main() {
             ),
             // Fix #2022: prevent EventRealtime from touching Supabase in tests
             eventRealtimeProvider('active_event').overrideWith(
-              () => _NoOpEventRealtime(),
+              _NoOpEventRealtime.new,
             ),
           ],
         ),

--- a/apps/app_user/test/src/features/home/home_page_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_test.dart
@@ -246,6 +246,10 @@ void main() {
             eventNowBarStateProvider(activeEvent).overrideWith(
               () => _FixedNowBarStateNotifier(EventNowBarState.matching),
             ),
+            // Fix #2022: prevent EventRealtime from touching Supabase in tests
+            eventRealtimeProvider('active_event').overrideWith(
+              () => _NoOpEventRealtime(),
+            ),
           ],
         ),
       );
@@ -281,6 +285,10 @@ void main() {
             todayActiveEventsProvider.overrideWith((_) => [activeEvent]),
             eventNowBarStateProvider(activeEvent).overrideWith(
               () => _FixedNowBarStateNotifier(EventNowBarState.waiting),
+            ),
+            // Fix #2022: prevent EventRealtime from touching Supabase in tests
+            eventRealtimeProvider('active_event').overrideWith(
+              () => _NoOpEventRealtime(),
             ),
           ],
         ),
@@ -358,6 +366,10 @@ void main() {
             todayActiveEventsProvider.overrideWith((_) => [activeEvent]),
             eventNowBarStateProvider(activeEvent).overrideWith(
               () => _FixedNowBarStateNotifier(EventNowBarState.matching),
+            ),
+            // Fix #2022: prevent EventRealtime from touching Supabase in tests
+            eventRealtimeProvider('active_event').overrideWith(
+              () => _NoOpEventRealtime(),
             ),
           ],
         ),
@@ -466,6 +478,13 @@ class _MockNoMoreNotifier extends RecommendationFeedNotifier {
       hasMore: false,
     );
   }
+}
+
+/// Fix #2022: No-op EventRealtime stub — prevents Supabase Realtime
+/// initialization in tests.
+class _NoOpEventRealtime extends EventRealtime {
+  @override
+  void build(String eventId) {}
 }
 
 class _FixedNowBarStateNotifier extends EventNowBarStateNotifier {

--- a/apps/app_user/test/src/features/home/widgets/event_now_bar_test.dart
+++ b/apps/app_user/test/src/features/home/widgets/event_now_bar_test.dart
@@ -71,6 +71,10 @@ void main() {
           if (throwError) throw Exception('Network error');
           return activeEvents;
         }),
+        // Fix #2022: prevent EventRealtime from touching Supabase in tests.
+        // Caller overrides (via ...overrides.cast()) take precedence.
+        for (final e in activeEvents)
+          eventRealtimeProvider(e.event.id).overrideWith(_NoOpEventRealtime.new),
         ...overrides.cast(),
       ],
       child: MaterialApp(
@@ -299,6 +303,11 @@ class _ThrowingStateNotifier extends EventNowBarStateNotifier {
   FutureOr<EventNowBarState> build(TodayActiveEvent activeEvent) {
     throw Exception('state failure');
   }
+}
+
+class _NoOpEventRealtime extends EventRealtime {
+  @override
+  void build(String eventId) {}
 }
 
 class _TrackingEventRealtime extends EventRealtime {

--- a/apps/app_user/test/src/features/home/widgets/event_now_bar_test.dart
+++ b/apps/app_user/test/src/features/home/widgets/event_now_bar_test.dart
@@ -259,10 +259,13 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(realtimeBuilt, isTrue,
-          reason:
-              'EventNowBar must watch eventRealtimeProvider to activate the '
-              'Supabase Realtime subscription');
+      expect(
+        realtimeBuilt,
+        isTrue,
+        reason:
+            'EventNowBar must watch eventRealtimeProvider to activate the '
+            'Supabase Realtime subscription',
+      );
     });
 
     testWidgets('keeps cached event visible when state resolution fails', (

--- a/apps/app_user/test/src/features/home/widgets/event_now_bar_test.dart
+++ b/apps/app_user/test/src/features/home/widgets/event_now_bar_test.dart
@@ -237,6 +237,34 @@ void main() {
       expect(find.text('종료됨'), findsOneWidget);
     });
 
+    // Fix #2022: regression guard — eventRealtimeProvider must be watched so
+    // the Supabase Realtime subscription activates on mount.
+    testWidgets('eventRealtimeProvider is watched when active event shown', (
+      tester,
+    ) async {
+      final event = makeActiveEvent();
+      stubMatchingNotAvailable('event_1');
+
+      var realtimeBuilt = false;
+
+      await tester.pumpWidget(
+        createTestWidget(
+          activeEvents: [event],
+          overrides: [
+            eventRealtimeProvider('event_1').overrideWith((_) {
+              realtimeBuilt = true;
+            }),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(realtimeBuilt, isTrue,
+          reason:
+              'EventNowBar must watch eventRealtimeProvider to activate the '
+              'Supabase Realtime subscription');
+    });
+
     testWidgets('keeps cached event visible when state resolution fails', (
       tester,
     ) async {

--- a/apps/app_user/test/src/features/home/widgets/event_now_bar_test.dart
+++ b/apps/app_user/test/src/features/home/widgets/event_now_bar_test.dart
@@ -74,7 +74,9 @@ void main() {
         // Fix #2022: prevent EventRealtime from touching Supabase in tests.
         // Caller overrides (via ...overrides.cast()) take precedence.
         for (final e in activeEvents)
-          eventRealtimeProvider(e.event.id).overrideWith(_NoOpEventRealtime.new),
+          eventRealtimeProvider(
+            e.event.id,
+          ).overrideWith(_NoOpEventRealtime.new),
         ...overrides.cast(),
       ],
       child: MaterialApp(

--- a/apps/app_user/test/src/features/home/widgets/event_now_bar_test.dart
+++ b/apps/app_user/test/src/features/home/widgets/event_now_bar_test.dart
@@ -251,9 +251,9 @@ void main() {
         createTestWidget(
           activeEvents: [event],
           overrides: [
-            eventRealtimeProvider('event_1').overrideWith((_) {
-              realtimeBuilt = true;
-            }),
+            eventRealtimeProvider('event_1').overrideWith(
+              () => _TrackingEventRealtime(() { realtimeBuilt = true; }),
+            ),
           ],
         ),
       );
@@ -297,4 +297,12 @@ class _ThrowingStateNotifier extends EventNowBarStateNotifier {
   FutureOr<EventNowBarState> build(TodayActiveEvent activeEvent) {
     throw Exception('state failure');
   }
+}
+
+class _TrackingEventRealtime extends EventRealtime {
+  _TrackingEventRealtime(this._onBuild);
+  final void Function() _onBuild;
+
+  @override
+  void build(String eventId) => _onBuild();
 }

--- a/apps/app_user/test/src/features/home/widgets/event_now_bar_test.dart
+++ b/apps/app_user/test/src/features/home/widgets/event_now_bar_test.dart
@@ -252,7 +252,9 @@ void main() {
           activeEvents: [event],
           overrides: [
             eventRealtimeProvider('event_1').overrideWith(
-              () => _TrackingEventRealtime(() { realtimeBuilt = true; }),
+              () => _TrackingEventRealtime(() {
+                realtimeBuilt = true;
+              }),
             ),
           ],
         ),

--- a/apps/app_user/test/src/features/home/widgets/event_now_bar_test.dart
+++ b/apps/app_user/test/src/features/home/widgets/event_now_bar_test.dart
@@ -72,7 +72,8 @@ void main() {
           return activeEvents;
         }),
         // Fix #2022: prevent EventRealtime from touching Supabase in tests.
-        // Caller overrides (via ...overrides.cast()) take precedence.
+        // Do not pass eventRealtimeProvider overrides via the overrides param —
+        // duplicate overrides for the same provider key cause an AssertionError.
         for (final e in activeEvents)
           eventRealtimeProvider(
             e.event.id,
@@ -245,6 +246,8 @@ void main() {
 
     // Fix #2022: regression guard — eventRealtimeProvider must be watched so
     // the Supabase Realtime subscription activates on mount.
+    // Uses raw ProviderScope to avoid duplicate override with createTestWidget's
+    // default _NoOpEventRealtime injection.
     testWidgets('eventRealtimeProvider is watched when active event shown', (
       tester,
     ) async {
@@ -254,15 +257,24 @@ void main() {
       var realtimeBuilt = false;
 
       await tester.pumpWidget(
-        createTestWidget(
-          activeEvents: [event],
+        ProviderScope(
           overrides: [
+            eventRepositoryProvider.overrideWithValue(mockEventRepo),
+            matchingRepositoryProvider.overrideWith((ref) => mockMatchingRepo),
+            todayActiveEventsProvider.overrideWith((ref) => [event]),
             eventRealtimeProvider('event_1').overrideWith(
               () => _TrackingEventRealtime(() {
                 realtimeBuilt = true;
               }),
             ),
           ],
+          child: MaterialApp(
+            theme: MinglitTheme.materialTheme,
+            home: const Scaffold(
+              body: SizedBox.expand(),
+              bottomSheet: EventNowBar(),
+            ),
+          ),
         ),
       );
       await tester.pumpAndSettle();


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #2022

## 문제

eventRealtimeProvider를 watch하는 위젯이 없어 Supabase Realtime 구독이 활성화되지 않음. 체크인 후 MATCHING/RESULTS 전이가 앱 재시작 없이 불가.

## Fix

_EventNowBarContentState.build()에 ref.watch(eventRealtimeProvider(event.id)) 추가.

## 테스트

회귀 가드 위젯 테스트: EventNowBar 렌더 시 eventRealtimeProvider가 watch되는지 검증.