### PR TITLE
perf(matching): use server-side count in getMyVoteCount

### DIFF
--- a/shared/packages/minglit_kit/lib/src/data/repositories/matching_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/matching_repository.dart
@@ -221,19 +221,19 @@ class MatchingRepository {
 
   /// Fetches the voter's current vote count for an event.
   // Fix #306: 잔여 투표 수 표시용
+  // Fix #1959: Use server-side count instead of fetching full rows
   Future<int> getMyVoteCount(String eventId) async {
     final userId = _supabase.auth.currentUser?.id;
     if (userId == null) return 0;
 
     try {
-      final data =
-          await _supabase
-                  .from('match_votes')
-                  .select()
-                  .eq('event_id', eventId)
-                  .eq('voter_id', userId)
-              as List;
-      return data.length;
+      final res = await _supabase
+          .from('match_votes')
+          .select('voter_id')
+          .eq('event_id', eventId)
+          .eq('voter_id', userId)
+          .count(CountOption.exact);
+      return res.count;
     } catch (e, st) {
       Log.e('❌ [MatchingRepo] getMyVoteCount Error', e, st);
       rethrow;

--- a/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
@@ -378,6 +378,48 @@ void main() {
         );
       });
     });
+
+    // Fix #1959: server-side count path
+    group('getMyVoteCount', () {
+      test('returns 0 when user is not authenticated', () async {
+        mockClient = createMockSupabase(); // no user
+        repository = MatchingRepository(supabase: mockClient);
+
+        final result = await repository.getMyVoteCount('event_1');
+        expect(result, 0);
+      });
+
+      test('returns server-side count from PostgREST count response', () async {
+        unawaited(
+          mockTable(mockClient, 'match_votes', countValue: 3),
+        );
+
+        final result = await repository.getMyVoteCount('event_1');
+        expect(result, 3);
+      });
+
+      test('passes event_id and voter_id filters to the query', () async {
+        final builder = mockTable(
+          mockClient,
+          'match_votes',
+          countValue: 2,
+        );
+
+        await repository.getMyVoteCount('event_1');
+
+        final filters = builder.recordedFilters;
+        expect(
+          filters.any((f) => f.method == 'eq' && f.column == 'event_id' && f.value == 'event_1'),
+          isTrue,
+          reason: 'Must filter by event_id',
+        );
+        expect(
+          filters.any((f) => f.method == 'eq' && f.column == 'voter_id' && f.value == 'user_1'),
+          isTrue,
+          reason: 'Must filter by voter_id (current user)',
+        );
+      });
+    });
   });
 
   group('MatchingRepository providers', () {

--- a/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/matching_repository_test.dart
@@ -409,12 +409,22 @@ void main() {
 
         final filters = builder.recordedFilters;
         expect(
-          filters.any((f) => f.method == 'eq' && f.column == 'event_id' && f.value == 'event_1'),
+          filters.any(
+            (f) =>
+                f.method == 'eq' &&
+                f.column == 'event_id' &&
+                f.value == 'event_1',
+          ),
           isTrue,
           reason: 'Must filter by event_id',
         );
         expect(
-          filters.any((f) => f.method == 'eq' && f.column == 'voter_id' && f.value == 'user_1'),
+          filters.any(
+            (f) =>
+                f.method == 'eq' &&
+                f.column == 'voter_id' &&
+                f.value == 'user_1',
+          ),
           isTrue,
           reason: 'Must filter by voter_id (current user)',
         );


### PR DESCRIPTION
## Summary

- Replace `select()` + Dart `data.length` with `.select('voter_id').count(CountOption.exact)` in `getMyVoteCount`
- Server-side count avoids fetching and deserializing full `match_votes` rows just to count them
- Consistent with the pattern already used in `getPendingApplicationCount` and `getInteractionCount`

Closes #1959

## Test plan

- [ ] Existing `myVoteCountProvider` tests exercise this method via the repository
- [ ] CI unit + widget tests pass