### PR TITLE
docs(architecture): update client.md and backend.md for April 2026 additions

### DIFF
--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -41,7 +41,7 @@ Minglit의 Supabase 기반 백엔드 인프라를 기술한다.
 
 ### 2.1 Table Inventory
 
-총 **54개 테이블(analytics 스키마 5개 포함)** + **4개 뷰** + **4개 PGMQ 인프라 테이블**.
+총 **56개 테이블(analytics 스키마 5개 포함)** + **4개 뷰** + **4개 PGMQ 인프라 테이블** + **admin 스키마 3개 테이블(컴플라이언스 인프라, 별도 집계)**.
 
 > **Note**: 아래 테이블 목록이 실제 migration과 일치하는지 정기적으로 검증합니다.
 
@@ -101,6 +101,8 @@ Minglit의 Supabase 기반 백엔드 인프라를 기술한다.
 | `system_settings` | 시스템 설정 키-값 | key (PK), value jsonb, description, updated_at, updated_by |
 | `policies` | 약관/정책 버전 관리 | id (PK uuid), key, value jsonb, version, effective_date, description, created_at |
 | `user_consents` | 유저 약관 동의 기록 | user_id, policy_id, consented_at, revoked_at |
+| `location_access_log` | 위치정보 이용 확인자료 (위치정보법 §16, 6개월 보관) | user_id, accessed_at, purpose (nearby_search), country_code |
+| `ef_auth_manifest` | pg_cron 대상 EF 인증 레벨 선언 (Fix #1760, cron-targeted EF 전용) | ef_name (PK), required_auth (service_role), description |
 
 #### Account Management (계정 관리)
 
@@ -133,6 +135,17 @@ Minglit의 Supabase 기반 백엔드 인프라를 기술한다.
 | `daily_revenue` | analytics | 일별 매출 집계 | date, gross, net, refunds |
 | `funnel_daily` | analytics | 일별 퍼널 전환율 | date, step, count, conversion_rate |
 | `github_daily_stats` | analytics | 일별 GitHub 이슈/PR 통계 | date, metric, count |
+
+#### Admin Schema — Compliance Infrastructure (admin 스키마, service_role 전용)
+
+> `admin` 스키마 테이블은 public 집계(56개)에 포함되지 않습니다.
+> authenticated/anon 역할은 접근 불가; service_role 또는 DB 직접 접근만 허용.
+
+| Table | Purpose | Key Columns |
+|-------|---------|-------------|
+| `retention_policies` | 데이터 보존 정책 정의 (법적 의무 기간 관리) | id, kind (cron/event), target (table/queue), retention_days, legal_min_days |
+| `retention_policy_audit` | 보존 정책 실행 이력 감사 로그 | policy_id, run_at, deleted_count, error |
+| `retention_allowed_targets` | 보존 정책 적용 허용 테이블 화이트리스트 (Fix #1749) | schema_name, table_name (PK 복합), ts_col, legal_min_days |
 
 #### PGMQ Infrastructure
 

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -41,7 +41,7 @@ Minglit의 Supabase 기반 백엔드 인프라를 기술한다.
 
 ### 2.1 Table Inventory
 
-총 **56개 테이블(analytics 스키마 5개 포함)** + **4개 뷰** + **4개 PGMQ 인프라 테이블** + **admin 스키마 3개 테이블(컴플라이언스 인프라, 별도 집계)**.
+총 **62개 테이블(analytics 스키마 5개 포함)** + **4개 뷰** + **4개 PGMQ 인프라 테이블** + **admin 스키마 3개 테이블(컴플라이언스 인프라, 별도 집계)**.
 
 > **Note**: 아래 테이블 목록이 실제 migration과 일치하는지 정기적으로 검증합니다.
 
@@ -103,6 +103,17 @@ Minglit의 Supabase 기반 백엔드 인프라를 기술한다.
 | `user_consents` | 유저 약관 동의 기록 | user_id, policy_id, consented_at, revoked_at |
 | `location_access_log` | 위치정보 이용 확인자료 (위치정보법 §16, 6개월 보관) | user_id, accessed_at, purpose (nearby_search), country_code |
 | `ef_auth_manifest` | pg_cron 대상 EF 인증 레벨 선언 (Fix #1760, cron-targeted EF 전용) | ef_name (PK), required_auth (service_role), description |
+| `webhook_imp_uid_log` | PortOne V1 결제 웹훅 idempotency 로그 (Fix #1949, 재처리 방지) | imp_uid (PK), merchant_uid, processed_at |
+
+#### Tags & Discovery (태그/디스커버리)
+
+| Table | Purpose | Key Columns |
+|-------|---------|-------------|
+| `tags` | 태그 마스터 (PGroonga prefix match 지원) | id (PK), name (UNIQUE), is_featured, usage_count |
+| `party_tags` | 파티↔태그 연결 (M:N) | party_id, tag_id (PK 복합) |
+| `user_interest_tags` | 유저 관심 태그 (M:N) | user_id, tag_id (PK 복합) |
+| `tag_usage_daily` | 태그 일별 사용량 집계 | tag_id, date (PK 복합), daily_count |
+| `tag_usage_monthly` | 태그 월별 사용량 집계 (일별 롤업) | tag_id, month (PK 복합), monthly_count |
 
 #### Account Management (계정 관리)
 

--- a/docs/architecture/client.md
+++ b/docs/architecture/client.md
@@ -77,11 +77,16 @@ apps/app_partner/lib/src/features/
 
 `shared/packages/` 디렉토리에는 모노레포 전체에서 공유되는 패키지가 위치합니다.
 
-| 패키지 | 역할 |
-|--------|------|
-| `minglit_kit` | 핵심 공유 라이브러리 (모델, 리포지토리, 위젯, 유틸리티) |
-| `minglit_iamport_v1` | Iamport V1 API 결제 연동 래퍼 |
-| `minglit_lints` | 모노레포 공통 린트 규칙 |
+| 패키지 | 경로 | 역할 |
+|--------|------|------|
+| `mds` | `shared/packages/mds/core/` | Minglit Design System 핵심 — 순수 UI 컴포넌트, 테마, 디자인 토큰 통합 |
+| `mds_tokens` | `shared/packages/mds/tokens/` | 디자인 토큰 SSOT — Style Dictionary → Dart 상수 코드젠 |
+| `mds_icons` | `shared/packages/mds/icons/` | SVG 기반 테마-어웨어 아이콘 패키지 |
+| `minglit_kit` | `shared/packages/minglit_kit/` | 핵심 공유 라이브러리 (모델, 리포지토리, 위젯, 유틸리티) |
+| `minglit_iamport_v1` | `shared/packages/minglit_iamport_v1/` | Iamport V1 API 결제 연동 래퍼 |
+| `minglit_lints` | `shared/packages/minglit_lints/` | 모노레포 공통 린트 규칙 |
+
+> `mds_storybook` (`apps/mds/storybook/`)는 MDS 컴포넌트 Widgetbook 스토리 앱으로, 패키지가 아닌 앱으로 분류됩니다.
 
 ### 2.2 Coordinator Pattern (Navigation)
 **UI는 "어디로 갈지" 모릅니다.** 단순히 Coordinator에게 "이 버튼이 눌렸다"고 알릴 뿐입니다.


### PR DESCRIPTION
## Summary

- **client.md**: Added `mds`, `mds_tokens`, `mds_icons` packages to Shared Packages table with their paths (added in PR #1916)
- **backend.md**: Added `location_access_log` and `ef_auth_manifest` to public table inventory, added new Admin Schema section (`retention_policies`, `retention_policy_audit`, `retention_allowed_targets`), updated table count 54 → 56

Closes #1958, Closes #1960

## Test plan

- [ ] Docs-only change, no code impact
- [ ] CI `check-migration-versions` and `check-env-manifest-sync` pass