### PR TITLE
chore(ci,ef): migration gap warning + payment-webhook TODO cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,20 @@ jobs:
             exit 1
           fi
           echo "✅ All migration versions unique ($(echo "$VERSIONS" | wc -l | tr -d ' ') files checked)"
+          # Fix #1968: warn on gaps in same-day sequence numbers (does not fail CI)
+          DATES=$(echo "$VERSIONS" | cut -c1-8 | sort -u)
+          for DATE in $DATES; do
+            SEQS=$(echo "$VERSIONS" | grep "^$DATE" | cut -c9-14 | sort -n | sed 's/^0*//')
+            PREV=""
+            for SEQ in $SEQS; do
+              if [ -n "$PREV" ] && [ "$SEQ" -ne "$((PREV + 1))" ]; then
+                GAP_FROM=$(printf "%06d" $((PREV + 1)))
+                GAP_TO=$(printf "%06d" $((SEQ - 1)))
+                echo "⚠️  Gap detected in migration sequence: ${DATE}${GAP_FROM}..${DATE}${GAP_TO} (between ${DATE}$(printf "%06d" $PREV) and ${DATE}$(printf "%06d" $SEQ))"
+              fi
+              PREV="$SEQ"
+            done
+          done
 
   # env-manifest.json ↔ EnvKeyStore drift 검사 (항상 실행 — path filter 없음)
   check-env-manifest-sync:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ adb -s adb-R3CX803P2ND-8btuuD._adb-tls-connect._tcp install -r build/app/outputs
 - 새 migration 생성 시, 반드시 `ls supabase/migrations/` 로 기존 version 확인 후 다음 번호 사용.
 - Feature branch에서 migration 작성 시, dev branch의 최신 상태와 비교 필수:
   `git diff dev -- supabase/migrations/` 로 충돌 여부 확인.
-- 같은 날짜에 여러 migration 필요 시 순차 번호 사용 (예: 000001, 000002, 000003).
+- 같은 날짜에 여러 migration 필요 시 순차 번호 사용 (예: 000001, 000002, 000003). **번호를 건너뛰지 말 것** — CI가 gap을 경고로 표시한다.
 - Migration 파일은 한번 dev/main에 머지되면 내용 수정 금지. 수정 필요 시 새 migration 추가.
 
 ## Branch Protection

--- a/supabase/functions/payment-webhook/index.ts
+++ b/supabase/functions/payment-webhook/index.ts
@@ -154,9 +154,7 @@ Deno.serve(withHandler(async (req) => {
 
       if (application) {
         logStatsigEvent(application.user_id, 'payment_completed', payment.amount, { imp_uid, merchant_uid }).catch(() => {});
-        // TODO(#1892): Migrate to produce_event() pattern via q_global_events
-        // Currently sends directly to q_notifications, bypassing 2-tier architecture
-        // See: docs/architecture/global-event-pipeline.md
+        // Fix #2026: direct q_notifications push — tracked for migration to produce_event() pattern
         await supabase.rpc("pgmq_send", {
           queue_name: "q_notifications",
           message: {


### PR DESCRIPTION
## Summary

- **#1968**: Extended `check-migration-versions` CI step to warn (not fail) when same-day migration sequence numbers have gaps (e.g. 000007 → 000009). Added explicit "번호를 건너뛰지 말 것" rule to `CLAUDE.md`.
- **#1970**: Replaced `TODO(#1892)` comment in `payment-webhook/index.ts` with `// Fix #2026` reference. Created tracking issue #2026 for the `produce_event()` migration refactor.

Closes #1968, Closes #1970

## Test plan

- [ ] CI `check-workflow-yaml` validates ci.yml syntax
- [ ] CI `check-migration-versions` passes with existing migration files
- [ ] No other required CI checks are affected (docs + EF only changes)