### PR TITLE
test(refund): pin 1ms-past-grace-period boundary is not refundable

### DIFF
--- a/shared/packages/minglit_kit/test/src/utils/refund_calculator_test.dart
+++ b/shared/packages/minglit_kit/test/src/utils/refund_calculator_test.dart
@@ -104,7 +104,7 @@ void main() {
       final paidAt = now.subtract(
         const Duration(hours: 2, milliseconds: 1),
       );
-      final eventStart = now.add(const Duration(days: 3)); // inside cutoff
+      final eventStart = now.add(const Duration(days: 3)); // outside cutoff
       final result = RefundCalculator.calculate(
         eventStartTime: eventStart,
         paymentAmount: amount,

--- a/shared/packages/minglit_kit/test/src/utils/refund_calculator_test.dart
+++ b/shared/packages/minglit_kit/test/src/utils/refund_calculator_test.dart
@@ -96,6 +96,28 @@ void main() {
       expect(result.refundPercentage, 100);
     });
 
+    // Fix #1967: one millisecond past grace period boundary must NOT be refundable
+    // (unless the cutoff window is also still open). The <= operator in the
+    // implementation makes the boundary inclusive; this test pins that a 1ms
+    // overshoot correctly falls outside.
+    test('1ms past grace period boundary + outside cutoff → no refund', () {
+      final paidAt = now.subtract(
+        const Duration(hours: 2, milliseconds: 1),
+      );
+      final eventStart = now.add(const Duration(days: 3)); // inside cutoff
+      final result = RefundCalculator.calculate(
+        eventStartTime: eventStart,
+        paymentAmount: amount,
+        paidAt: paidAt,
+        gracePeriodHours: 2,
+        cutoffDays: 7,
+        now: now,
+      );
+      expect(result.refundPercentage, 0);
+      expect(result.refundAmount, 0);
+      expect(result.feeAmount, amount);
+    });
+
     test('exactly at cutoff boundary → full refund', () {
       final paidAt = now.subtract(const Duration(hours: 5));
       final eventStart = now.add(const Duration(days: 7));


### PR DESCRIPTION
## Summary

Closes #1967

Adds the missing edge case: `paidAt` exactly 1ms past the grace period boundary (with no cutoff window open) must return `refundPercentage=0`. The `<=` operator in `RefundCalculator.calculate` makes the boundary inclusive, but this was not pinned — an accidental `<` change would silently break the refund policy.

All other edge cases from the issue were already present (`paidAt=null`, exact boundary, `paymentAmount=0`).

## Test plan

- [x] `flutter test shared/packages/minglit_kit/test/src/utils/refund_calculator_test.dart` passes
- [x] No production code changes — pure test addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)