### PR TITLE
fix(ci): warn on same-day migration sequence gaps + document known gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,24 @@ jobs:
             exit 1
           fi
           echo "✅ All migration versions unique ($(echo "$VERSIONS" | wc -l | tr -d ' ') files checked)"
+      - name: Warn on same-day sequence gaps
+        run: |
+          GAP_FOUND=false
+          for DATE in $(ls supabase/migrations/*.sql 2>/dev/null | xargs -n1 basename | sed 's/^\([0-9]\{8\}\).*/\1/' | sort -u); do
+            SEQS=$(ls supabase/migrations/${DATE}*.sql 2>/dev/null | xargs -n1 basename | sed "s/^${DATE}\([0-9]*\)_.*/\1/" | sort -n)
+            PREV=""
+            for SEQ in $SEQS; do
+              if [ -n "$PREV" ] && [ $((10#$SEQ - 10#$PREV)) -gt 1 ]; then
+                echo "⚠️  Gap: ${DATE} jumps from ${PREV} to ${SEQ} — check KNOWN_GAPS.md or git history"
+                GAP_FOUND=true
+              fi
+              PREV="$SEQ"
+            done
+          done
+          if [ "$GAP_FOUND" = "true" ]; then
+            echo "→ Undocumented gaps may indicate a deleted migration. Verify intentional."
+          fi
+          echo "✅ Sequence gap check complete"
 
   # env-manifest.json ↔ EnvKeyStore drift 검사 (항상 실행 — path filter 없음)
   check-env-manifest-sync:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ adb -s adb-R3CX803P2ND-8btuuD._adb-tls-connect._tcp install -r build/app/outputs
 - 새 migration 생성 시, 반드시 `ls supabase/migrations/` 로 기존 version 확인 후 다음 번호 사용.
 - Feature branch에서 migration 작성 시, dev branch의 최신 상태와 비교 필수:
   `git diff dev -- supabase/migrations/` 로 충돌 여부 확인.
-- 같은 날짜에 여러 migration 필요 시 순차 번호 사용 (예: 000001, 000002, 000003).
+- 같은 날짜에 여러 migration 필요 시 순차 번호 사용 (예: 000001, 000002, 000003). **번호를 건너뛰지 말 것** — gap은 CI 경고를 발생시키고 삭제된 migration이 있는지 의심받는다. 의도적으로 건너뛴 경우 `supabase/migrations/KNOWN_GAPS.md`에 이유를 기록한다.
 - Migration 파일은 한번 dev/main에 머지되면 내용 수정 금지. 수정 필요 시 새 migration 추가.
 
 ## Branch Protection

--- a/supabase/migrations/KNOWN_GAPS.md
+++ b/supabase/migrations/KNOWN_GAPS.md
@@ -1,0 +1,10 @@
+# Known Migration Sequence Gaps
+
+CI warns when a same-day migration sequence skips a number. Known intentional gaps are documented here.
+
+| Gap | Reason |
+|-----|--------|
+| `20260322000003` | Intentional skip — accepted as harmless (Issue #1092) |
+| `20260422000008` | Never authored — migration was planned but cancelled before commit (Issue #1968) |
+
+If CI reports a new gap, confirm via `git log --all --full-history -- supabase/migrations/<date><seq>_*.sql`. If the file never existed (no git history), add a row here and close the loop.


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1968

## Summary

- **CI**: Added "Warn on same-day sequence gaps" step to `check-migration-versions` job. Logs warnings when a per-day sequence skips a number (warn-only, not fail — two accepted gaps already exist).
- **Docs**: Created `supabase/migrations/KNOWN_GAPS.md` documenting the two intentional gaps (20260322000003 from #1092, 20260422000008 from #1968) with git history confirmation.
- **CLAUDE.md**: Added "don't skip numbers" rule with pointer to KNOWN_GAPS.md for intentional exceptions.

Investigation: git log shows 20260422000008 was never committed — intentional planned-but-cancelled migration.

## Test plan

- [x] Workflow YAML validated (check-workflow-yaml CI job)
- [x] Gap check warns on skips without failing the build