### PR TITLE
fix(ci): add shared/packages/** catch-all to minglit_kit paths filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
             - 'apps/app_partner/**'
           minglit_kit:
             - 'shared/packages/minglit_kit/**'
+            - 'shared/packages/**'
           mds_core:
             - 'shared/packages/mds/core/**'
           mds_storybook:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,11 @@ adb -s adb-R3CX803P2ND-8btuuD._adb-tls-connect._tcp install -r build/app/outputs
 - 같은 날짜에 여러 migration 필요 시 순차 번호 사용 (예: 000001, 000002, 000003).
 - Migration 파일은 한번 dev/main에 머지되면 내용 수정 금지. 수정 필요 시 새 migration 추가.
 
+## Branch Rebase Rules
+
+- `shared/packages/**`를 수정하는 PR을 생성하기 전에 반드시 `git rebase origin/dev`를 수행한다.
+  ci.yml의 paths filter가 업데이트될 수 있으며, stale branch에서는 새 패키지가 CI 트리거에서 누락될 수 있다.
+
 ## Branch Protection
 
 - `dev` 브랜치는 direct push 금지. 반드시 feature branch에서 PR을 통해 머지.


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1962

## Summary

- Added `shared/packages/**` as a catch-all entry to the `minglit_kit` paths filter in `ci.yml`.
- Added CLAUDE.md section: PRs touching `shared/packages/**` must rebase against dev before creating a PR.

This ensures (1) any new shared package added in the future automatically triggers Flutter tests without a ci.yml update, and (2) provides belt-and-suspenders coverage for packages not individually listed (e.g., `minglit_iamport_v1`, `minglit_lints`).

Note: The dev branch already has specific paths for `mds_core`, `mds_storybook`, `mds_tokens`, `mds_icons` from PR #1916. This catch-all is an additional safety net, not a replacement.

## Test plan

- [x] Workflow YAML validated (check-workflow-yaml CI job)
- [x] Existing specific paths still work — catch-all is additive, not replacing