### PR TITLE
chore(ef): replace 3-line TODO with concise tracked comment in payment-webhook

### DIFF
--- a/supabase/functions/payment-webhook/index.ts
+++ b/supabase/functions/payment-webhook/index.ts
@@ -154,7 +154,7 @@ Deno.serve(withHandler(async (req) => {
 
       if (application) {
         logStatsigEvent(application.user_id, 'payment_completed', payment.amount, { imp_uid, merchant_uid }).catch(() => {});
-        // Fix #2026: direct q_notifications push — tracked for migration to produce_event() pattern
+        // TODO(#2026): migrate to produce_event() pattern
         await supabase.rpc("pgmq_send", {
           queue_name: "q_notifications",
           message: {

--- a/supabase/functions/payment-webhook/index.ts
+++ b/supabase/functions/payment-webhook/index.ts
@@ -154,9 +154,7 @@ Deno.serve(withHandler(async (req) => {
 
       if (application) {
         logStatsigEvent(application.user_id, 'payment_completed', payment.amount, { imp_uid, merchant_uid }).catch(() => {});
-        // TODO(#1892): Migrate to produce_event() pattern via q_global_events
-        // Currently sends directly to q_notifications, bypassing 2-tier architecture
-        // See: docs/architecture/global-event-pipeline.md
+        // Fix #2026: direct q_notifications push — tracked for migration to produce_event() pattern
         await supabase.rpc("pgmq_send", {
           queue_name: "q_notifications",
           message: {


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1970

## Summary

`payment-webhook/index.ts`의 3줄 TODO 주석을 한 줄 추적 코멘트로 교체합니다.

- 제거: `TODO(#1892): Migrate to produce_event()...` (3줄)
- 추가: `// Fix #2026: direct q_notifications push — tracked for migration to produce_event() pattern` (1줄)

runtime behavior 변경 없음. 주석 정리만.

> PR #2027 (`chore/1968-1970-migration-gap-todo-cleanup`)에서 분리. #1968(migration gap CI)과 단일 관심사 원칙 위반 지적에 따라 #1970만 독립 PR로 재제출.