### PR TITLE
fix(partner): decouple event_create_controller from home feature

### DIFF
--- a/.cross-feature-import-baseline
+++ b/.cross-feature-import-baseline
@@ -19,6 +19,5 @@ settings/privacy_page.dart: settings -> account_deletion
 settings/privacy_page.dart: settings -> consent
 tag/ui/tag_event_list_page.dart: tag -> event
 
-# app_partner (2 violations as of 2026-04-27)
+# app_partner (1 violation as of 2026-04-27)
 application/event_application_detail_page.dart: application -> party
-party/event/create/event_create_controller.dart: party -> home

--- a/apps/app_partner/lib/src/features/home/partner_dashboard_controller.dart
+++ b/apps/app_partner/lib/src/features/home/partner_dashboard_controller.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:app_partner/src/logic/current_partner_provider.dart';
-
+import 'package:app_partner/src/logic/dashboard_refresh_notifier.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -28,6 +28,9 @@ abstract class PartnerDashboardState with _$PartnerDashboardState {
 class PartnerDashboardController extends _$PartnerDashboardController {
   @override
   PartnerDashboardState build() {
+    // Fix #1943: watch shared refresh signal — bumped by event_create_controller
+    // after successful creation, triggering auto-rebuild without cross-feature coupling.
+    ref.watch(dashboardRefreshProvider);
     // Schedule loading after build() returns so that `state` is initialized.
     // unawaited() runs synchronously until the first await, which would
     // access `state` before build() has returned — causing

--- a/apps/app_partner/lib/src/features/party/event/create/event_create_controller.dart
+++ b/apps/app_partner/lib/src/features/party/event/create/event_create_controller.dart
@@ -1,4 +1,4 @@
-import 'package:app_partner/src/features/home/partner_dashboard_controller.dart';
+import 'package:app_partner/src/logic/dashboard_refresh_notifier.dart';
 import 'package:app_partner/src/features/party/detail/party_detail_controller.dart';
 import 'package:app_partner/src/features/party/logic/recurrence_settings_controller.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -193,8 +193,8 @@ class EventCreateController extends _$EventCreateController {
       }
 
       ref.invalidate(partyEventsProvider(state.partyId));
-      // Fix #1264: 이벤트 생성 후 파트너 대시보드 통계 즉시 갱신
-      ref.invalidate(partnerDashboardControllerProvider);
+      // Fix #1943: bump shared signal so dashboard refreshes without cross-feature import
+      ref.read(dashboardRefreshProvider.notifier).bump();
     });
 
     state = state.copyWith(status: result);

--- a/apps/app_partner/lib/src/features/party/event/create/event_create_controller.dart
+++ b/apps/app_partner/lib/src/features/party/event/create/event_create_controller.dart
@@ -1,6 +1,6 @@
-import 'package:app_partner/src/logic/dashboard_refresh_notifier.dart';
 import 'package:app_partner/src/features/party/detail/party_detail_controller.dart';
 import 'package:app_partner/src/features/party/logic/recurrence_settings_controller.dart';
+import 'package:app_partner/src/logic/dashboard_refresh_notifier.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';

--- a/apps/app_partner/lib/src/logic/dashboard_refresh_notifier.dart
+++ b/apps/app_partner/lib/src/logic/dashboard_refresh_notifier.dart
@@ -1,13 +1,11 @@
-import 'package:app_partner/src/features/home/partner_dashboard_controller.dart'
-    show PartnerDashboardController;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'dashboard_refresh_notifier.g.dart';
 
 /// Shared refresh signal for the partner dashboard.
 /// Features that cause dashboard-relevant state changes (e.g. event creation)
-/// call [DashboardRefreshNotifier.bump] instead of directly invalidating
-/// [PartnerDashboardController], avoiding cross-feature coupling.
+/// call `DashboardRefreshNotifier.bump` instead of directly invalidating
+/// `PartnerDashboardController`, avoiding cross-feature coupling.
 @Riverpod(keepAlive: true)
 class DashboardRefresh extends _$DashboardRefresh {
   @override

--- a/apps/app_partner/lib/src/logic/dashboard_refresh_notifier.dart
+++ b/apps/app_partner/lib/src/logic/dashboard_refresh_notifier.dart
@@ -1,3 +1,5 @@
+import 'package:app_partner/src/features/home/partner_dashboard_controller.dart'
+    show PartnerDashboardController;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'dashboard_refresh_notifier.g.dart';

--- a/apps/app_partner/lib/src/logic/dashboard_refresh_notifier.dart
+++ b/apps/app_partner/lib/src/logic/dashboard_refresh_notifier.dart
@@ -1,0 +1,16 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'dashboard_refresh_notifier.g.dart';
+
+/// Shared refresh signal for the partner dashboard.
+/// Features that cause dashboard-relevant state changes (e.g. event creation)
+/// call [DashboardRefreshNotifier.bump] instead of directly invalidating
+/// [PartnerDashboardController], avoiding cross-feature coupling.
+@Riverpod(keepAlive: true)
+class DashboardRefresh extends _$DashboardRefresh {
+  @override
+  int build() => 0;
+
+  // Fix #1943: bump triggers any provider watching this to rebuild
+  void bump() => state++;
+}

--- a/apps/app_partner/lib/src/logic/dashboard_refresh_notifier.g.dart
+++ b/apps/app_partner/lib/src/logic/dashboard_refresh_notifier.g.dart
@@ -1,0 +1,63 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'dashboard_refresh_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(DashboardRefresh)
+const dashboardRefreshProvider = DashboardRefreshProvider._();
+
+final class DashboardRefreshProvider
+    extends $NotifierProvider<DashboardRefresh, int> {
+  const DashboardRefreshProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'dashboardRefreshProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$dashboardRefreshHash();
+
+  @$internal
+  @override
+  DashboardRefresh create() => DashboardRefresh();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(int value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<int>(value),
+    );
+  }
+}
+
+String _$dashboardRefreshHash() => r'dashboard_refresh_notifier_v1';
+
+abstract class _$DashboardRefresh extends $Notifier<int> {
+  int build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref as $Ref<int, int>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<int, int>,
+              int,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
@@ -706,7 +706,8 @@ void main() {
                 .read(partnerDashboardControllerProvider)
                 .pendingReviewCount,
             isNot(99),
-            reason: 'Dashboard must rebuild via DashboardRefresh signal after event creation',
+            reason:
+                'Dashboard must rebuild via DashboardRefresh signal after event creation',
           );
         },
       );

--- a/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
+++ b/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart
@@ -615,8 +615,9 @@ void main() {
       });
 
       // Fix #1264: 이벤트 생성 후 대시보드 '다가오는 이벤트' 카운트 미갱신
+      // Fix #1943: dashboard refresh via DashboardRefresh signal (no cross-feature import)
       test(
-        'invalidates partnerDashboardControllerProvider after successful event creation',
+        'bumps DashboardRefresh signal, triggering PartnerDashboardController rebuild after event creation',
         () async {
           final party = _makeParty(locationId: 'loc-1');
 
@@ -691,7 +692,7 @@ void main() {
 
           await notifier.submit();
 
-          // 대시보드 재빌드의 loadDashboardData 완료까지 대기
+          // DashboardRefresh 신호 bump 후 대시보드 재빌드의 loadDashboardData 완료까지 대기
           await container.read(currentPartnerInfoProvider.future);
           await Future<void>.delayed(const Duration(milliseconds: 50));
 
@@ -699,13 +700,13 @@ void main() {
             container.read(eventCreateControllerProvider('party-1')).status,
             isA<AsyncData<void>>(),
           );
-          // invalidate 후 대시보드가 재빌드되면 sentinel 값이 사라진다
+          // DashboardRefresh bump 후 대시보드가 재빌드되면 sentinel 값이 사라진다
           expect(
             container
                 .read(partnerDashboardControllerProvider)
                 .pendingReviewCount,
             isNot(99),
-            reason: 'Dashboard must be invalidated after event creation',
+            reason: 'Dashboard must rebuild via DashboardRefresh signal after event creation',
           );
         },
       );


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #1943

## Summary

- `event_create_controller.dart`가 `home/partner_dashboard_controller.dart`를 직접 import해 `party→home` 크로스 피처 커플링이 발생하던 문제 해결
- 중립 위치(`apps/app_partner/lib/src/logic/`)에 `DashboardRefresh` notifier(keepAlive) 추가
- `event_create_controller`는 이벤트 생성 후 `DashboardRefresh.bump()` 호출 (home import 불필요)
- `PartnerDashboardController`는 `ref.watch(dashboardRefreshProvider)` 추가 → bump 시 자동 rebuild
- `.cross-feature-import-baseline`에서 `party→home` 항목 제거 (위반 해소)

## Architecture

```
Before:
  party/event/create/event_create_controller
    └─ import home/partner_dashboard_controller  ← cross-feature violation

After:
  logic/dashboard_refresh_notifier (neutral)
    ├── read by: party/event/create/event_create_controller (bump)
    └── watched by: home/partner_dashboard_controller (auto-rebuild)
```

## Test

기존 테스트 `invalidates partnerDashboardControllerProvider after successful event creation`이 새 메커니즘(DashboardRefresh signal → PartnerDashboardController rebuild)으로도 동일하게 통과하도록 업데이트.