### PR TITLE
chore(reports): sync runtime-qa ops/incidents reports (#2020, #2037, #2050, #2056)

### DIFF
--- a/docs/reports/ops/incidents/2026-04-28-issue2020-hard-block-galaxy-s10e-device-not-reachable-runtime-qa-smoke-partner.md
+++ b/docs/reports/ops/incidents/2026-04-28-issue2020-hard-block-galaxy-s10e-device-not-reachable-runtime-qa-smoke-partner.md
@@ -1,0 +1,54 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2020
+captured_at: 2026-04-28
+issue_number: 2020
+state: open
+labels: [report-runtime-qa]
+author: Mark-Yun
+title: "🛑 Hard Block — Galaxy S10e Device Not Reachable (runtime-qa-smoke-partner-sonnet-subagents)"
+---
+
+# 🛑 Hard Block — Galaxy S10e Device Not Reachable (runtime-qa-smoke-partner-sonnet-subagents)
+
+> Issue #2020 · open · created 2026-04-28 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2020
+
+## Body
+
+Scheduler: runtime-qa-smoke-partner-sonnet-subagents
+
+## 요약
+
+Galaxy S10e (adb-R39M2033LFZ-McLWol._adb-tls-connect._tcp) 장치가 연결되지 않아 QA 세션을 시작할 수 없습니다.
+
+## 증상
+
+```
+$ adb devices -l
+List of devices attached
+(장치 없음)
+
+$ adb connect adb-R39M2033LFZ-McLWol._adb-tls-connect._tcp
+failed to resolve host: 'adb-R39M2033LFZ-McLWol._adb-tls-connect._tcp': nodename nor servname provided, or not known
+```
+
+- DNS 해석 실패 (mDNS/Bonjour 서비스 미탐지)
+- `adb devices` 목록에 장치 없음
+
+## 영향
+
+- `runtime-qa-smoke-partner-sonnet-subagents` 세션 전체 블로킹
+- `app-partner-smoke.md` P0+P1 시나리오 실행 불가
+
+## 대응 필요
+
+- [ ] Galaxy S10e 물리적 연결 상태 확인 (USB/WiFi)
+- [ ] ADB 무선 디버깅 재활성화 (`adb pair` / 개발자 옵션 확인)
+- [ ] mDNS 네트워크 탐지 문제 시 직접 IP로 `adb connect <IP>:PORT` 시도
+
+## 환경
+
+- Scheduler: runtime-qa-smoke-partner-sonnet-subagents
+- Device: Galaxy S10e (`adb-R39M2033LFZ-McLWol._adb-tls-connect._tcp`)
+- 발생 시각: 2026-04-28
+- 플랫폼: macOS Darwin 23.6.0

--- a/docs/reports/ops/incidents/2026-04-29-issue2037-hard-block-no-adb-device-reachable-user-smoke.md
+++ b/docs/reports/ops/incidents/2026-04-29-issue2037-hard-block-no-adb-device-reachable-user-smoke.md
@@ -1,0 +1,60 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2037
+captured_at: 2026-04-29
+issue_number: 2037
+state: open
+labels: [report-runtime-qa, needs-tpm]
+author: Mark-Yun
+title: "🛑 Hard Block — No ADB Device Reachable (runtime-qa-smoke-user-sonnet-subagents)"
+---
+
+# 🛑 Hard Block — No ADB Device Reachable (runtime-qa-smoke-user-sonnet-subagents)
+
+> Issue #2037 · open · created 2026-04-29 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2037
+
+## Body
+
+Scheduler: runtime-qa-smoke-user-sonnet-subagents
+
+## 요약
+
+ADB 연결 가능한 디바이스가 없어 QA 세션을 시작할 수 없습니다.  
+`adb devices -l` 결과가 비어 있고, 알려진 두 디바이스 모두 DNS 해석 실패입니다.
+
+## 증상
+
+```
+$ adb devices -l
+List of devices attached
+(장치 없음)
+
+$ adb connect adb-R39M2033LFZ-McLWol._adb-tls-connect._tcp
+failed to resolve host: nodename nor servname provided, or not known
+
+$ adb connect adb-36141JEHN14570-SNEsXf._adb-tls-connect._tcp
+failed to resolve host: nodename nor servname provided, or not known
+```
+
+## 영향
+
+- `runtime-qa-smoke-user-sonnet-subagents` 세션 전체 블로킹
+- `app-user-smoke.md` P0+P1 시나리오 실행 불가
+
+## 관련 이슈
+
+- #1883 — Pixel 7a Not Reachable (여전히 열림, 2026-04-27)
+- #2020 — Galaxy S10e Not Reachable (여전히 열림, 2026-04-28)
+
+## 대응 필요
+
+- [ ] 디바이스 물리적 연결 상태 확인
+- [ ] ADB 무선 디버깅 재활성화 (개발자 옵션 → 무선 디버깅)
+- [ ] mDNS 탐지 실패 시 직접 IP로 `adb connect <IP>:PORT` 시도
+- [ ] 인프라 복구 후 본 이슈 및 #1883, #2020 일괄 종료
+
+## 환경
+
+- Scheduler: runtime-qa-smoke-user-sonnet-subagents
+- 발생 시각: 2026-04-29
+- 플랫폼: macOS Darwin 23.6.0

--- a/docs/reports/ops/incidents/2026-04-29-issue2050-hard-block-no-adb-device-reachable-runtime-qa-cuj-partner.md
+++ b/docs/reports/ops/incidents/2026-04-29-issue2050-hard-block-no-adb-device-reachable-runtime-qa-cuj-partner.md
@@ -1,0 +1,51 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2050
+captured_at: 2026-04-29
+issue_number: 2050
+state: open
+labels: [report-runtime-qa]
+author: runtime-qa-cuj-partner-sonnet-subagents
+title: "🛑 Hard Block — No ADB Device Reachable (runtime-qa-cuj-partner-sonnet-subagents)"
+---
+
+# 🛑 Hard Block — No ADB Device Reachable (runtime-qa-cuj-partner-sonnet-subagents)
+
+> Issue #2050 · open · created 2026-04-29 · author @runtime-qa-cuj-partner-sonnet-subagents
+> https://github.com/Mark-Yun/minglit/issues/2050
+
+## Body
+
+Scheduler: runtime-qa-cuj-partner-sonnet-subagents
+
+## Hard Block: ADB 디바이스 미연결
+
+**발생 시각**: 2026-04-29
+**스케줄러**: runtime-qa-cuj-partner-sonnet-subagents
+**예정 작업**: Mode B — cuj-partner.md P0+P1 시나리오 실행
+
+## 상황
+
+`adb devices -l` 실행 결과 연결된 디바이스 없음:
+
+```
+List of devices attached
+(empty)
+```
+
+스케줄러 이름이 `-sonnet-subagents`로 끝나 gemini/haiku 패턴과 불일치. 디바이스 테이블에 없는 패턴이므로 연결된 첫 번째 디바이스를 사용하려 했으나 연결 자체가 없음.
+
+## 영향
+
+- cuj-partner.md P0+P1 시나리오 전체 스킵
+- 앱 빌드 불가
+- QA 세션 시작 불가
+
+## 조치 필요
+
+1. 테스트 디바이스 ADB 연결 복구
+2. `adb devices -l`로 연결 확인 후 scheduler 재실행
+
+## 관련 이슈
+
+- #2037 (runtime-qa-smoke-user-sonnet-subagents)
+- #2020 (runtime-qa-smoke-partner-sonnet-subagents)

--- a/docs/reports/ops/incidents/2026-04-30-issue2056-hard-block-galaxy-s10e-tls-connection-failure-cuj-user.md
+++ b/docs/reports/ops/incidents/2026-04-30-issue2056-hard-block-galaxy-s10e-tls-connection-failure-cuj-user.md
@@ -1,0 +1,66 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2056
+captured_at: 2026-04-30
+issue_number: 2056
+state: open
+labels: [report-runtime-qa]
+author: Mark-Yun
+title: "🛑 Hard Block — Galaxy S10e TLS Connection Failure (runtime-qa-cuj-user-sonnet-subagents)"
+---
+
+# 🛑 Hard Block — Galaxy S10e TLS Connection Failure (runtime-qa-cuj-user-sonnet-subagents)
+
+> Issue #2056 · open · created 2026-04-30 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2056
+
+## Body
+
+Scheduler: runtime-qa-cuj-user-sonnet-subagents
+
+## Hard Block: Galaxy S10e ADB TLS 연결 실패
+
+**발생 시각**: 2026-04-30 15:00 KST
+**스케줄러**: runtime-qa-cuj-user-sonnet-subagents
+**예정 작업**: Mode B — cuj-user.md P0+P1 시나리오 실행
+
+## 상황
+
+`adb devices -l` 결과 연결된 디바이스 없음.
+
+mDNS에서는 디바이스가 검색됨:
+```
+adb-R39M2033LFZ-McLWol	_adb-tls-connect._tcp	192.168.219.105:34655
+```
+
+그러나 직접 연결 시도 시 실패:
+```
+$ adb connect 192.168.219.105:34655
+failed to connect to 192.168.219.105:34655
+
+$ adb -s adb-R39M2033LFZ-McLWol._adb-tls-connect._tcp shell echo ok
+adb: device 'adb-R39M2033LFZ-McLWol._adb-tls-connect._tcp' not found
+```
+
+## 원인 추정
+
+`_adb-tls-connect._tcp` 서비스는 사전 페어링된 TLS 인증서가 필요함. 디바이스가 mDNS에 보이지만 TLS 인증서 페어링이 유실되어 연결 불가.
+
+## 영향
+
+- cuj-user.md P0+P1 시나리오 전체 스킵
+- app_user 빌드 불가
+- QA 세션 시작 불가
+
+## 조치 필요
+
+1. Galaxy S10e에서 무선 디버깅 재페어링:
+   - 디바이스 → 설정 → 개발자 옵션 → 무선 디버깅 → 새 기기와 페어링
+   - `adb pair <ip>:<pairing-port>` 실행
+2. TLS 연결 복구 확인: `adb devices -l`
+3. scheduler 재실행
+
+## 관련 이슈
+
+- #2050 (runtime-qa-cuj-partner-sonnet-subagents — no device)
+- #2037 (runtime-qa-smoke-user-sonnet-subagents — no device)
+- #2020 (runtime-qa-smoke-partner-sonnet-subagents — no device)


### PR DESCRIPTION
## Summary

- Hard block 이슈 4건에 대한 `docs/reports/ops/incidents/` 리포트 동기화
  - #2020: Galaxy S10e Not Reachable (runtime-qa-smoke-partner-sonnet-subagents)
  - #2037: No ADB Device (runtime-qa-smoke-user-sonnet-subagents)
  - #2050: No ADB Device (runtime-qa-cuj-partner-sonnet-subagents)
  - #2056: Galaxy S10e TLS Connection Failure (runtime-qa-cuj-user-sonnet-subagents)

## Test plan

- [ ] docs/reports/ops/incidents/ 디렉토리에 4개 md 파일 추가 확인
- [ ] CI: check-migration-versions 통과 (migration 변경 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)