### PR TITLE
fix(partner/more): migrate _ProfileTile avatar to MinglitAvatarImage

### DIFF
--- a/apps/app_partner/lib/src/features/more/more_page.dart
+++ b/apps/app_partner/lib/src/features/more/more_page.dart
@@ -219,15 +219,13 @@ class _ProfileTile extends StatelessWidget {
         padding: const EdgeInsets.all(MinglitSpacing.medium),
         child: Row(
           children: [
-            CircleAvatar(
+            // Fix #2069: MinglitAvatarImage handles caching + error fallback
+            MinglitAvatarImage(
               radius: 24,
+              url: avatarUrl,
+              fallbackIcon: Icons.store,
               backgroundColor: colorScheme.primaryContainer,
-              backgroundImage: avatarUrl != null
-                  ? NetworkImage(avatarUrl!)
-                  : null,
-              child: avatarUrl == null
-                  ? Icon(Icons.store, color: colorScheme.primary)
-                  : null,
+              fallbackIconColor: colorScheme.primary,
             ),
             const SizedBox(width: MinglitSpacing.medium),
             Expanded(

--- a/apps/app_partner/test/src/features/more/more_page_test.dart
+++ b/apps/app_partner/test/src/features/more/more_page_test.dart
@@ -223,5 +223,62 @@ void main() {
       expect(find.byType(OverflowBar), findsNothing);
       expect(tester.takeException(), isNull);
     });
+
+    // Fix #2069: regression guard — _ProfileTile must use MinglitAvatarImage
+    testWidgets(
+      'shows Icons.store fallback when profileImageUrl is null',
+      (tester) async {
+        // testPartner has no profileImageUrl, so MinglitAvatarImage renders CircleAvatar fallback
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        expect(find.byType(MinglitAvatarImage), findsOneWidget);
+        expect(find.byIcon(Icons.store), findsOneWidget);
+        // No ClipOval: url is null so MinglitAvatarImage renders CircleAvatar directly
+        expect(find.byType(ClipOval), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'renders MinglitAvatarImage (not CircleAvatar+NetworkImage) when profileImageUrl is set',
+      (tester) async {
+        const partnerWithAvatar = Partner(
+          id: 'test-partner-id',
+          name: 'Test Partner',
+          contactEmail: 'test@partner.com',
+          profileImageUrl: 'https://example.com/avatar.png',
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            partnerValue: const AsyncValue.data(partnerWithAvatar),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(MinglitAvatarImage), findsOneWidget);
+        // With a URL, MinglitAvatarImage wraps MinglitImage in ClipOval
+        expect(find.byType(ClipOval), findsOneWidget);
+        // No bare CircleAvatar visible (it's inside the error fallback, not on screen)
+        expect(
+          find.ancestor(
+            of: find.byType(ClipOval),
+            matching: find.byType(MinglitAvatarImage),
+          ),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      '_ProfileTile displayName and email are still rendered correctly',
+      (tester) async {
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Test Partner'), findsOneWidget);
+        expect(find.text('test@partner.com'), findsOneWidget);
+      },
+    );
   });
 }


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #2069

## 변경 내용

- `apps/app_partner/lib/src/features/more/more_page.dart`: `_ProfileTile`의 `CircleAvatar+NetworkImage` → `MinglitAvatarImage` 교체
- `apps/app_partner/test/src/features/more/more_page_test.dart`: 회귀 방지 위젯 테스트 3개 추가

## 배경

audit-uiux (#2063)에서 파트너 앱 더보기 페이지의 프로필 타일이 `CircleAvatar+NetworkImage` 안티패턴 사용 중임을 확인. 유저 앱(#1936, PR #2035)과 동일하게 MDS의 `MinglitAvatarImage`로 교체.

## 검증

- `flutter analyze` 통과 확인 (CI에서 검증)
- 회귀 방지 테스트: null URL → Icons.store 폴백, 유효 URL → ClipOval 위젯 트리, displayName/email 필드 회귀 없음
