### PR TITLE
chore(reports): add TPM exec report for #2083

### DIFF
--- a/docs/reports/tpm/2026-05-02-issue2083-p0-infra-blockers-24h-no-progress-submodule.md
+++ b/docs/reports/tpm/2026-05-02-issue2083-p0-infra-blockers-24h-no-progress-submodule.md
@@ -1,0 +1,104 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2083
+captured_at: 2026-05-02
+issue_number: 2083
+state: open
+labels: [report-exec]
+author: Mark-Yun
+title: "⚠️ TPM Report — 2026-05-02: P0 인프라 블로커 24h 무진전 + minglit_env submodule 미초기화 발견"
+---
+
+# ⚠️ TPM Report — 2026-05-02: P0 인프라 블로커 24h 무진전 + minglit_env submodule 미초기화 발견
+
+> Issue #2083 · open · created 2026-05-02 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2083
+
+## Body
+
+Scheduler: tpm-exec-report-claude-subagents
+
+## Headline
+
+- 어제(05-01) 리포트의 P0 인프라 블로커 3건 모두 **24시간 동안 진전 0** — #2049 iOS Deploy User (~50h), #2061 iOS Deploy Partner (~42h), #2064 runtime-qa Flutter SDK 3.41.0 미설치, 그리고 #1883 Pixel 7a. 어제 리포트 #2070에 코멘트도 없음 → escalate.
+- **NEW 근본 원인 발견**: runtime-qa가 `minglit_env/dev/flutter.env` 부재로 hard block을 보고했으나, 실제로는 **`minglit_env`가 git submodule** (`.gitmodules` 확인). 워커 워크트리에서 `git submodule update --init --recursive`만 실행하면 즉시 해소. 디바이스 문제와 분리 가능.
+- Vercel Deploy 100% 실패율 지속(10/10), iOS 양쪽 0/1, 메인 CI(dev push)는 hourly monitor 12/12 success로 견고.
+- 신규 PR-level CI 실패: dependabot #2081 (flutter-deps, BLOCKED + CHANGES_REQUESTED, 4개 test job fail) — 코멘트로 alert 부착 완료.
+- 오늘 신규 이슈 0건. 백로그 안정 (open 18, P0 4 + 나머지 report-exec/runtime-qa).
+
+## 1. 사람 판단 필요 사항 (반복, 24h 무진전이라 escalate)
+
+### A. iOS Deploy 양쪽 P0 — 50h+ / 42h+ 누적
+
+| 이슈 | 워크플로 | 첫 발생 | 경과 | 패턴 |
+|------|----------|---------|------|------|
+| #2049 | iOS Deploy User | 2026-04-29 11:34Z | ~50h | 매일 cron 동일 실패 |
+| #2061 | iOS Deploy Partner | 2026-04-30 11:32Z | ~42h | 매일 cron 동일 실패 |
+
+- 양쪽 동시 실패 + 코드 회귀 가능성 낮음 → **Apple 자격증명 만료 의심** (인증서/프로비저닝/App Store Connect API/Fastlane Match)
+- swe가 자체 해결 불가 — Mark가 Apple Developer 계정 직접 점검 필요
+
+### B. runtime-qa Flutter SDK 3.41.0 — 1일째
+
+- #2064: `mds_icons`가 SDK ≥ 3.41.0 요구, 워커 환경 3.38.5
+- 옵션 1 (권장): 워커 SDK 업그레이드 — Mark가 워커 셋업 보유
+- 옵션 2: `mds_icons` SDK constraint 다운그레이드 — #1969 의도와 충돌
+- runtime-qa가 모든 신규 변경 검증 불가 상태
+
+### C. Pixel 7a Hard Block (#1883) — 5일째
+
+- 14개 코멘트 누적, 워커가 진입할 때마다 동일 디바이스 미연결 보고
+- 디바이스 재연결 또는 대체 단말 정책(emulator fallback) 결정 필요
+
+## 2. 신규 발견 — TPM이 처리 시도/완료
+
+### D. #1883 추가 코멘트의 "flutter.env 부재" — submodule 미초기화
+
+- 2026-05-01 23:34 runtime-qa-smoke-user-gemini가 보고: "환경변수 누락: 'minglit_env/dev/flutter.env' 파일이 존재하지 않아 빌드가 불가능함"
+- 확인 결과: `minglit_env`는 `.gitmodules`에 정의된 submodule
+  ```
+  [submodule "minglit_env"]
+      path = minglit_env
+      url = https://github.com/Mark-Yun/minglit_env.git
+  ```
+- `git submodule status` → `-39ae66bc...` (leading minus = uninitialized)
+- **즉시 해소**: 워커 워크트리 생성 후 `git submodule update --init --recursive` 실행
+- TPM 액션 완료: #1883에 root cause + 해결 명령 코멘트 추가
+- **요청**: 워커 셋업 스크립트(워크트리 생성)에 submodule init 추가 — Mark가 워커 셋업 보유
+
+### E. dependabot #2081 BLOCKED — alert 부착
+
+- "chore(deps): Bump the flutter-deps group with 5 updates" (2026-05-01 생성)
+- 4개 test job 실패: minglit_kit / app_partner / mds_storybook / app_user
+- 패키지 호환성 회귀 의심
+- TPM 액션 완료: PR에 분석 코멘트 추가 (라벨 부착은 token scope 제약으로 실패, 코멘트로 swe alert)
+
+## 3. 메트릭 (24h, 2026-05-01 ~ 02 06:00 KST 기준)
+
+| 지표 | 수치 | 추세 |
+|------|------|------|
+| 신규 이슈 | 0 | 어제 1건 → 오늘 0건 (정체) |
+| 메인 CI on dev | hourly 12/12 | 견고 |
+| Vercel Deploy | 0/10 (100% 실패) | 어제 0/2 → 오늘 0/10 (#1917 지속) |
+| iOS Deploy User | 0/1 | 동일 (#2049) |
+| iOS Deploy Partner | 0/1 | 동일 (#2061) |
+| 메인 CI on PR | 1 success / 2 fail | 둘 다 PR 자체 이슈 (dependabot, mds-icons) |
+| review-presence | 7/15 (53% 실패) | 어제 22% → 오늘 53%, 악화 (required 아님, 다음 사이클 조사) |
+
+## 4. 트리아지 결과
+
+- audit-report 라벨 이슈 0건 — 트리아지 스킵
+- 미아 이슈(라벨 없음): 0건
+- 라벨 정리: #2081 PR에 코멘트 부착 (라벨 부착은 token scope 부족)
+
+## 5. 결론
+
+- **3개 P0 blocker는 Mark의 직접 액션 없이 해소 불가** — 어제 리포트 후 24h 무응답
+- 그러나 #1883의 env-file 부분은 submodule 미초기화로 **워커 셋업 1줄 추가만 하면 해소** 가능
+- 코드 사이드 / dev 브랜치는 견고 (hourly 12/12)
+- 신규 #2081 (dependabot)은 swe 처리 흐름으로 진입 가능
+
+**Mark에게 우선 요청**:
+1. Apple Developer 계정 점검 (iOS deploy)
+2. 워커 SDK 3.41.0 업그레이드 결정
+3. Pixel 7a 디바이스 정책 결정
+4. 워커 셋업 스크립트에 `git submodule update --init --recursive` 추가 (#1883 env 부분 즉시 해소)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
-# Graph Report - /private/tmp/fix-2085-mds-ci  (2026-05-03)
+# Graph Report - /private/tmp/tpm-report-2083  (2026-05-03)
 
 ## Corpus Check
-- 1171 files · ~1,745,232 words
+- 1171 files · ~1,745,992 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
@@ -2421,11 +2421,11 @@ _Questions this graph is uniquely positioned to answer:_
 - **What is the exact relationship between `Architecture Audit #1092 — 2026-04-06` and `AI Basic Law Compliance (Korea 2026)`?**
   _Edge tagged AMBIGUOUS (relation: conceptually_related_to) - confidence is low._
 - **Why does `package:flutter/material.dart` connect `Community 0` to `Community 1`, `Community 6`, `Community 7`, `Community 8`, `Community 13`, `Community 16`, `Community 17`, `Community 20`, `Community 21`, `Community 22`?**
-  _High betweenness centrality (0.063) - this node is a cross-community bridge._
+  _High betweenness centrality (0.069) - this node is a cross-community bridge._
 - **Why does `package:minglit_kit/minglit_kit.dart` connect `Community 0` to `Community 1`, `Community 7`, `Community 8`, `Community 13`, `Community 16`, `Community 20`, `Community 22`?**
-  _High betweenness centrality (0.036) - this node is a cross-community bridge._
+  _High betweenness centrality (0.041) - this node is a cross-community bridge._
 - **Why does `dart:async` connect `Community 0` to `Community 1`, `Community 6`, `Community 7`, `Community 8`, `Community 16`, `Community 20`, `Community 22`?**
-  _High betweenness centrality (0.020) - this node is a cross-community bridge._
+  _High betweenness centrality (0.014) - this node is a cross-community bridge._
 - **What connects `reporter (AutoLabelAllureReporter)`, `BugReporterWrapper Widget Test Suite`, `MinglitListTile Widget Test Suite` to the rest of the system?**
   _1861 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
-# Graph Report - /Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react  (2026-05-01)
+# Graph Report - /private/tmp/tpm-report-2083  (2026-05-02)
 
 ## Corpus Check
-- 1172 files · ~1,719,149 words
+- 1171 files · ~1,514,281 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3579 nodes · 4982 edges · 322 communities detected
+- 3578 nodes · 4982 edges · 321 communities detected
 - Extraction: 89% EXTRACTED · 11% INFERRED · 0% AMBIGUOUS · INFERRED: 527 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
@@ -331,7 +331,6 @@
 - [[_COMMUNITY_Community 318|Community 318]]
 - [[_COMMUNITY_Community 319|Community 319]]
 - [[_COMMUNITY_Community 320|Community 320]]
-- [[_COMMUNITY_Community 321|Community 321]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `package:flutter/material.dart` - 98 edges
@@ -1698,289 +1697,285 @@ Nodes (0):
 
 ### Community 250 - "Community 250"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): landing_user ESLint Config
 
 ### Community 251 - "Community 251"
 Cohesion: 1.0
-Nodes (1): landing_user ESLint Config
+Nodes (1): LandingUserPage
 
 ### Community 252 - "Community 252"
 Cohesion: 1.0
-Nodes (1): LandingUserPage
+Nodes (1): Integration Test Driver
 
 ### Community 253 - "Community 253"
 Cohesion: 1.0
-Nodes (1): Integration Test Driver
+Nodes (1): reporter.dart (AutoLabelAllureReporter)
 
 ### Community 254 - "Community 254"
 Cohesion: 1.0
-Nodes (1): reporter.dart (AutoLabelAllureReporter)
+Nodes (1): Alchemist Package
 
 ### Community 255 - "Community 255"
 Cohesion: 1.0
-Nodes (1): Alchemist Package
+Nodes (1): AuthCoordinator Unit Test
 
 ### Community 256 - "Community 256"
 Cohesion: 1.0
-Nodes (1): AuthCoordinator Unit Test
+Nodes (1): DeletionCompletePage Test
 
 ### Community 257 - "Community 257"
 Cohesion: 1.0
-Nodes (1): DeletionCompletePage Test
+Nodes (1): StatusBadge Widget Test
 
 ### Community 258 - "Community 258"
 Cohesion: 1.0
-Nodes (1): StatusBadge Widget Test
+Nodes (1): permission_grant_test (patrol, skipped)
 
 ### Community 259 - "Community 259"
 Cohesion: 1.0
-Nodes (1): permission_grant_test (patrol, skipped)
+Nodes (1): payment_pg_test (patrol, skipped)
 
 ### Community 260 - "Community 260"
 Cohesion: 1.0
-Nodes (1): payment_pg_test (patrol, skipped)
+Nodes (1): kakao_login_test (patrol, skipped)
 
 ### Community 261 - "Community 261"
 Cohesion: 1.0
-Nodes (1): kakao_login_test (patrol, skipped)
+Nodes (0): 
 
 ### Community 262 - "Community 262"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): app_user AppRoutes (app_routes.dart)
 
 ### Community 263 - "Community 263"
 Cohesion: 1.0
-Nodes (1): app_user AppRoutes (app_routes.dart)
+Nodes (1): app_user AppRouter (app_router.dart)
 
 ### Community 264 - "Community 264"
 Cohesion: 1.0
-Nodes (1): app_user AppRouter (app_router.dart)
+Nodes (1): DownloadBottomSheet CSV Test
 
 ### Community 265 - "Community 265"
 Cohesion: 1.0
-Nodes (1): DownloadBottomSheet CSV Test
+Nodes (1): ReviewVerificationScreen snapshot_data Type Guard Test
 
 ### Community 266 - "Community 266"
 Cohesion: 1.0
-Nodes (1): ReviewVerificationScreen snapshot_data Type Guard Test
+Nodes (1): AccountDeletion Flow Logic Unit Test
 
 ### Community 267 - "Community 267"
 Cohesion: 1.0
-Nodes (1): AccountDeletion Flow Logic Unit Test
+Nodes (1): DefaultFirebaseOptions
 
 ### Community 268 - "Community 268"
 Cohesion: 1.0
-Nodes (1): DefaultFirebaseOptions
+Nodes (1): MinglitEditableSection
 
 ### Community 269 - "Community 269"
 Cohesion: 1.0
-Nodes (1): MinglitEditableSection
+Nodes (1): TodayPartyCard
 
 ### Community 270 - "Community 270"
 Cohesion: 1.0
-Nodes (1): TodayPartyCard
+Nodes (1): SettlementListShimmer
 
 ### Community 271 - "Community 271"
 Cohesion: 1.0
-Nodes (1): SettlementListShimmer
+Nodes (1): EventCard
 
 ### Community 272 - "Community 272"
 Cohesion: 1.0
-Nodes (1): EventCard
+Nodes (1): PartyImageEditor
 
 ### Community 273 - "Community 273"
 Cohesion: 1.0
-Nodes (1): PartyImageEditor
+Nodes (1): PartyStatusEditSheet
 
 ### Community 274 - "Community 274"
 Cohesion: 1.0
-Nodes (1): PartyStatusEditSheet
+Nodes (1): PartyVerificationInput
 
 ### Community 275 - "Community 275"
 Cohesion: 1.0
-Nodes (1): PartyVerificationInput
+Nodes (1): app_partner AppRoutes (app_routes.dart)
 
 ### Community 276 - "Community 276"
 Cohesion: 1.0
-Nodes (1): app_partner AppRoutes (app_routes.dart)
+Nodes (1): app_partner AppRouter (app_router.dart)
 
 ### Community 277 - "Community 277"
 Cohesion: 1.0
-Nodes (1): app_partner AppRouter (app_router.dart)
+Nodes (1): Landing Partner PostCSS Config
 
 ### Community 278 - "Community 278"
 Cohesion: 1.0
-Nodes (1): Landing Partner PostCSS Config
+Nodes (1): Landing Partner ESLint Config
 
 ### Community 279 - "Community 279"
 Cohesion: 1.0
-Nodes (1): Landing Partner ESLint Config
+Nodes (1): Landing Partner Home Page
 
 ### Community 280 - "Community 280"
 Cohesion: 1.0
-Nodes (1): Landing Partner Home Page
+Nodes (1): Landing Partner Privacy Policy Page
 
 ### Community 281 - "Community 281"
 Cohesion: 1.0
-Nodes (1): Landing Partner Privacy Policy Page
+Nodes (1): AppUser README
 
 ### Community 282 - "Community 282"
 Cohesion: 1.0
-Nodes (1): AppUser README
+Nodes (1): App Partner README
 
 ### Community 283 - "Community 283"
 Cohesion: 1.0
-Nodes (1): App Partner README
+Nodes (1): landing_user README
 
 ### Community 284 - "Community 284"
 Cohesion: 1.0
-Nodes (1): landing_user README
+Nodes (1): Landing Partner README
 
 ### Community 285 - "Community 285"
 Cohesion: 1.0
-Nodes (1): Landing Partner README
+Nodes (1): minglit_kit CHANGELOG
 
 ### Community 286 - "Community 286"
 Cohesion: 1.0
-Nodes (1): minglit_kit CHANGELOG
+Nodes (1): minglit_kit README
 
 ### Community 287 - "Community 287"
 Cohesion: 1.0
-Nodes (1): minglit_kit README
+Nodes (1): Pretendard Font OFL License
 
 ### Community 288 - "Community 288"
 Cohesion: 1.0
-Nodes (1): Pretendard Font OFL License
+Nodes (1): 구매 내역 색상 위계 리디자인 와이어프레임
 
 ### Community 289 - "Community 289"
 Cohesion: 1.0
-Nodes (1): 구매 내역 색상 위계 리디자인 와이어프레임
+Nodes (1): My Tickets Test Plan
 
 ### Community 290 - "Community 290"
 Cohesion: 1.0
-Nodes (1): My Tickets Test Plan
+Nodes (1): Partner Detail Event Card Wireframe
 
 ### Community 291 - "Community 291"
 Cohesion: 1.0
-Nodes (1): Partner Detail Event Card Wireframe
+Nodes (1): MinglitEmptyState Variants Wireframe
 
 ### Community 292 - "Community 292"
 Cohesion: 1.0
-Nodes (1): MinglitEmptyState Variants Wireframe
+Nodes (1): 파트너 정산 어드민 UI/UX 설계
 
 ### Community 293 - "Community 293"
 Cohesion: 1.0
-Nodes (1): 파트너 정산 어드민 UI/UX 설계
+Nodes (1): Event Now Bar Technical Plan
 
 ### Community 294 - "Community 294"
 Cohesion: 1.0
-Nodes (1): Event Now Bar Technical Plan
+Nodes (1): Security Audit Report — Tag Discovery Phase 1
 
 ### Community 295 - "Community 295"
 Cohesion: 1.0
-Nodes (1): Security Audit Report — Tag Discovery Phase 1
+Nodes (1): Runtime QA Bug — app_partner DevUserSwitchScreen Non-functional + am force-stop Auto-login Failure
 
 ### Community 296 - "Community 296"
 Cohesion: 1.0
-Nodes (1): Runtime QA Bug — app_partner DevUserSwitchScreen Non-functional + am force-stop Auto-login Failure
+Nodes (1): Issue #1542: Login 페이지 다크 테마 일관성 (P3-low)
 
 ### Community 297 - "Community 297"
 Cohesion: 1.0
-Nodes (1): Issue #1542: Login 페이지 다크 테마 일관성 (P3-low)
+Nodes (1): Bug Report — P-S31 /dev Deeplink 404
 
 ### Community 298 - "Community 298"
 Cohesion: 1.0
-Nodes (1): Bug Report — P-S31 /dev Deeplink 404
+Nodes (1): Runtime QA — CUJ-U03 Refund Button Label Mismatch
 
 ### Community 299 - "Community 299"
 Cohesion: 1.0
-Nodes (1): Runtime QA — CUJ-U03 Refund Button Label Mismatch
+Nodes (1): Runtime QA Bug — Build Server Disk Full (98%)
 
 ### Community 300 - "Community 300"
 Cohesion: 1.0
-Nodes (1): Runtime QA Bug — Build Server Disk Full (98%)
+Nodes (1): Runtime QA Bug — Pixel 7a ADB Wireless Session Disconnect
 
 ### Community 301 - "Community 301"
 Cohesion: 1.0
-Nodes (1): Runtime QA Bug — Pixel 7a ADB Wireless Session Disconnect
+Nodes (1): Ops Alert #990 — Dependabot CI Actions Update (actions/checkout v4->v6)
 
 ### Community 302 - "Community 302"
 Cohesion: 1.0
-Nodes (1): Ops Alert #990 — Dependabot CI Actions Update (actions/checkout v4->v6)
+Nodes (1): App logo: purple gradient speech bubble with white 'm', orange sparkle accent
 
 ### Community 303 - "Community 303"
 Cohesion: 1.0
-Nodes (1): App logo: purple gradient speech bubble with white 'm', orange sparkle accent
+Nodes (1): App splash icon: purple gradient chat bubble with white 'm' and orange sparkle
 
 ### Community 304 - "Community 304"
 Cohesion: 1.0
-Nodes (1): App splash icon: purple gradient chat bubble with white 'm' and orange sparkle
+Nodes (1): Minglit app splash icon: purple chat bubble with white 'm' and orange sparkle
 
 ### Community 305 - "Community 305"
 Cohesion: 1.0
-Nodes (1): Minglit app splash icon: purple chat bubble with white 'm' and orange sparkle
+Nodes (1): App icon foreground: purple chat bubble with white 'm' and orange sparkle
 
 ### Community 306 - "Community 306"
 Cohesion: 1.0
-Nodes (1): App icon foreground: purple chat bubble with white 'm' and orange sparkle
+Nodes (1): Purple-blue gradient background image for app_partner icon
 
 ### Community 307 - "Community 307"
 Cohesion: 1.0
-Nodes (1): Purple-blue gradient background image for app_partner icon
+Nodes (1): Minglit inverted logo: white wordmark with cyan and orange shadow layers on transparent background
 
 ### Community 308 - "Community 308"
 Cohesion: 1.0
-Nodes (1): Minglit inverted logo: white wordmark with cyan and orange shadow layers on transparent background
+Nodes (1): Minglit wordmark logo SVG with transparent background, cyan/orange layered text
 
 ### Community 309 - "Community 309"
 Cohesion: 1.0
-Nodes (1): Minglit wordmark logo SVG with transparent background, cyan/orange layered text
+Nodes (1): Minglit app bar logo — bold italic 'Minglit' text in purple with cyan and orange shadow layers
 
 ### Community 310 - "Community 310"
 Cohesion: 1.0
-Nodes (1): Minglit app bar logo — bold italic 'Minglit' text in purple with cyan and orange shadow layers
+Nodes (1): Upscale lounge/restaurant interior with bar, green velvet chairs, Asian art, warm lighting
 
 ### Community 311 - "Community 311"
 Cohesion: 1.0
-Nodes (1): Upscale lounge/restaurant interior with bar, green velvet chairs, Asian art, warm lighting
+Nodes (1): Bright minimalist Korean cafe interior with numbered wooden tables, plants, string lights, and coffee bar
 
 ### Community 312 - "Community 312"
 Cohesion: 1.0
-Nodes (1): Bright minimalist Korean cafe interior with numbered wooden tables, plants, string lights, and coffee bar
+Nodes (1): Warm sunlit cafe interior with wood furniture, plants, string lights, and menu board
 
 ### Community 313 - "Community 313"
 Cohesion: 1.0
-Nodes (1): Warm sunlit cafe interior with wood furniture, plants, string lights, and menu board
+Nodes (1): Participation status redesign (after) — not-logged-in state with counts and login prompt
 
 ### Community 314 - "Community 314"
 Cohesion: 1.0
-Nodes (1): Participation status redesign (after) — not-logged-in state with counts and login prompt
+Nodes (1): Dark theme participation status redesign, 2-group male/female layout with progress bars
 
 ### Community 315 - "Community 315"
 Cohesion: 1.0
-Nodes (1): Dark theme participation status redesign, 2-group male/female layout with progress bars
+Nodes (1): Participation status redesign after-state with 4 groups showing 12/40 total and per-group cards
 
 ### Community 316 - "Community 316"
 Cohesion: 1.0
-Nodes (1): Participation status redesign after-state with 4 groups showing 12/40 total and per-group cards
+Nodes (1): Empty participation status UI: 0/20 total, 0/10 male/female, empty state message
 
 ### Community 317 - "Community 317"
 Cohesion: 1.0
-Nodes (1): Empty participation status UI: 0/20 total, 0/10 male/female, empty state message
+Nodes (1): Participation status redesign after variant: 2-group (male/female) split with progress bars
 
 ### Community 318 - "Community 318"
 Cohesion: 1.0
-Nodes (1): Participation status redesign after variant: 2-group (male/female) split with progress bars
+Nodes (1): Participation status redesign: 2-group (male/female) expanded view with counts and age breakdowns
 
 ### Community 319 - "Community 319"
 Cohesion: 1.0
-Nodes (1): Participation status redesign: 2-group (male/female) expanded view with counts and age breakdowns
-
-### Community 320 - "Community 320"
-Cohesion: 1.0
 Nodes (1): Before state: participation status UI with male/female groups, 2/10 capacity each
 
-### Community 321 - "Community 321"
+### Community 320 - "Community 320"
 Cohesion: 1.0
 Nodes (1): user_profiles Table
 
@@ -2231,193 +2226,191 @@ Nodes (1): user_profiles Table
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 227`** (1 nodes): `postcss.config.mjs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (1 nodes): `next-env.d.ts`
+- **Thin community `Community 228`** (1 nodes): `tailwind.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 229`** (1 nodes): `tailwind.config.ts`
+- **Thin community `Community 229`** (1 nodes): `eslint.config.mjs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (1 nodes): `eslint.config.mjs`
+- **Thin community `Community 230`** (1 nodes): `next.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 231`** (1 nodes): `next.config.ts`
+- **Thin community `Community 231`** (1 nodes): `page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 232`** (1 nodes): `page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 233`** (1 nodes): `page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 234`** (1 nodes): `page.tsx`
+- **Thin community `Community 234`** (1 nodes): `Sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 235`** (1 nodes): `Sidebar.tsx`
+- **Thin community `Community 235`** (1 nodes): `MinglitSettingsTileSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 236`** (1 nodes): `MinglitSettingsTileSpec.tsx`
+- **Thin community `Community 236`** (1 nodes): `MinglitKeyValueRowSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 237`** (1 nodes): `MinglitKeyValueRowSpec.tsx`
+- **Thin community `Community 237`** (1 nodes): `MinglitErrorStateSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 238`** (1 nodes): `MinglitErrorStateSpec.tsx`
+- **Thin community `Community 238`** (1 nodes): `LoadingIndicatorSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 239`** (1 nodes): `LoadingIndicatorSpec.tsx`
+- **Thin community `Community 239`** (1 nodes): `MinglitSettingsGroupSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 240`** (1 nodes): `MinglitSettingsGroupSpec.tsx`
+- **Thin community `Community 240`** (1 nodes): `MinglitTextFieldSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 241`** (1 nodes): `MinglitTextFieldSpec.tsx`
+- **Thin community `Community 241`** (1 nodes): `NumberStepperInputSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 242`** (1 nodes): `NumberStepperInputSpec.tsx`
+- **Thin community `Community 242`** (1 nodes): `MinglitChipSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 243`** (1 nodes): `MinglitChipSpec.tsx`
+- **Thin community `Community 243`** (1 nodes): `MinglitChipGroupSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 244`** (1 nodes): `MinglitChipGroupSpec.tsx`
+- **Thin community `Community 244`** (1 nodes): `MinglitContentLayoutSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 245`** (1 nodes): `MinglitContentLayoutSpec.tsx`
+- **Thin community `Community 245`** (1 nodes): `MinglitBadgeSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 246`** (1 nodes): `MinglitBadgeSpec.tsx`
+- **Thin community `Community 246`** (1 nodes): `MinglitFilterChipSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 247`** (1 nodes): `MinglitFilterChipSpec.tsx`
+- **Thin community `Community 247`** (1 nodes): `MinglitSectionSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 248`** (1 nodes): `MinglitSectionSpec.tsx`
+- **Thin community `Community 248`** (1 nodes): `mds-icons-react.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 249`** (1 nodes): `mds-icons-react.ts`
+- **Thin community `Community 249`** (1 nodes): `postcss.config.mjs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 250`** (1 nodes): `postcss.config.mjs`
+- **Thin community `Community 250`** (1 nodes): `landing_user ESLint Config`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 251`** (1 nodes): `landing_user ESLint Config`
+- **Thin community `Community 251`** (1 nodes): `LandingUserPage`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 252`** (1 nodes): `LandingUserPage`
+- **Thin community `Community 252`** (1 nodes): `Integration Test Driver`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 253`** (1 nodes): `Integration Test Driver`
+- **Thin community `Community 253`** (1 nodes): `reporter.dart (AutoLabelAllureReporter)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 254`** (1 nodes): `reporter.dart (AutoLabelAllureReporter)`
+- **Thin community `Community 254`** (1 nodes): `Alchemist Package`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 255`** (1 nodes): `Alchemist Package`
+- **Thin community `Community 255`** (1 nodes): `AuthCoordinator Unit Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 256`** (1 nodes): `AuthCoordinator Unit Test`
+- **Thin community `Community 256`** (1 nodes): `DeletionCompletePage Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 257`** (1 nodes): `DeletionCompletePage Test`
+- **Thin community `Community 257`** (1 nodes): `StatusBadge Widget Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 258`** (1 nodes): `StatusBadge Widget Test`
+- **Thin community `Community 258`** (1 nodes): `permission_grant_test (patrol, skipped)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 259`** (1 nodes): `permission_grant_test (patrol, skipped)`
+- **Thin community `Community 259`** (1 nodes): `payment_pg_test (patrol, skipped)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 260`** (1 nodes): `payment_pg_test (patrol, skipped)`
+- **Thin community `Community 260`** (1 nodes): `kakao_login_test (patrol, skipped)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 261`** (1 nodes): `kakao_login_test (patrol, skipped)`
+- **Thin community `Community 261`** (1 nodes): `consent_detail_sheet.dart`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 262`** (1 nodes): `consent_detail_sheet.dart`
+- **Thin community `Community 262`** (1 nodes): `app_user AppRoutes (app_routes.dart)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 263`** (1 nodes): `app_user AppRoutes (app_routes.dart)`
+- **Thin community `Community 263`** (1 nodes): `app_user AppRouter (app_router.dart)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 264`** (1 nodes): `app_user AppRouter (app_router.dart)`
+- **Thin community `Community 264`** (1 nodes): `DownloadBottomSheet CSV Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 265`** (1 nodes): `DownloadBottomSheet CSV Test`
+- **Thin community `Community 265`** (1 nodes): `ReviewVerificationScreen snapshot_data Type Guard Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 266`** (1 nodes): `ReviewVerificationScreen snapshot_data Type Guard Test`
+- **Thin community `Community 266`** (1 nodes): `AccountDeletion Flow Logic Unit Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 267`** (1 nodes): `AccountDeletion Flow Logic Unit Test`
+- **Thin community `Community 267`** (1 nodes): `DefaultFirebaseOptions`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 268`** (1 nodes): `DefaultFirebaseOptions`
+- **Thin community `Community 268`** (1 nodes): `MinglitEditableSection`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 269`** (1 nodes): `MinglitEditableSection`
+- **Thin community `Community 269`** (1 nodes): `TodayPartyCard`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 270`** (1 nodes): `TodayPartyCard`
+- **Thin community `Community 270`** (1 nodes): `SettlementListShimmer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 271`** (1 nodes): `SettlementListShimmer`
+- **Thin community `Community 271`** (1 nodes): `EventCard`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 272`** (1 nodes): `EventCard`
+- **Thin community `Community 272`** (1 nodes): `PartyImageEditor`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 273`** (1 nodes): `PartyImageEditor`
+- **Thin community `Community 273`** (1 nodes): `PartyStatusEditSheet`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 274`** (1 nodes): `PartyStatusEditSheet`
+- **Thin community `Community 274`** (1 nodes): `PartyVerificationInput`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 275`** (1 nodes): `PartyVerificationInput`
+- **Thin community `Community 275`** (1 nodes): `app_partner AppRoutes (app_routes.dart)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 276`** (1 nodes): `app_partner AppRoutes (app_routes.dart)`
+- **Thin community `Community 276`** (1 nodes): `app_partner AppRouter (app_router.dart)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 277`** (1 nodes): `app_partner AppRouter (app_router.dart)`
+- **Thin community `Community 277`** (1 nodes): `Landing Partner PostCSS Config`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 278`** (1 nodes): `Landing Partner PostCSS Config`
+- **Thin community `Community 278`** (1 nodes): `Landing Partner ESLint Config`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 279`** (1 nodes): `Landing Partner ESLint Config`
+- **Thin community `Community 279`** (1 nodes): `Landing Partner Home Page`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 280`** (1 nodes): `Landing Partner Home Page`
+- **Thin community `Community 280`** (1 nodes): `Landing Partner Privacy Policy Page`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 281`** (1 nodes): `Landing Partner Privacy Policy Page`
+- **Thin community `Community 281`** (1 nodes): `AppUser README`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 282`** (1 nodes): `AppUser README`
+- **Thin community `Community 282`** (1 nodes): `App Partner README`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 283`** (1 nodes): `App Partner README`
+- **Thin community `Community 283`** (1 nodes): `landing_user README`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 284`** (1 nodes): `landing_user README`
+- **Thin community `Community 284`** (1 nodes): `Landing Partner README`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 285`** (1 nodes): `Landing Partner README`
+- **Thin community `Community 285`** (1 nodes): `minglit_kit CHANGELOG`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 286`** (1 nodes): `minglit_kit CHANGELOG`
+- **Thin community `Community 286`** (1 nodes): `minglit_kit README`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 287`** (1 nodes): `minglit_kit README`
+- **Thin community `Community 287`** (1 nodes): `Pretendard Font OFL License`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 288`** (1 nodes): `Pretendard Font OFL License`
+- **Thin community `Community 288`** (1 nodes): `구매 내역 색상 위계 리디자인 와이어프레임`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 289`** (1 nodes): `구매 내역 색상 위계 리디자인 와이어프레임`
+- **Thin community `Community 289`** (1 nodes): `My Tickets Test Plan`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 290`** (1 nodes): `My Tickets Test Plan`
+- **Thin community `Community 290`** (1 nodes): `Partner Detail Event Card Wireframe`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 291`** (1 nodes): `Partner Detail Event Card Wireframe`
+- **Thin community `Community 291`** (1 nodes): `MinglitEmptyState Variants Wireframe`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 292`** (1 nodes): `MinglitEmptyState Variants Wireframe`
+- **Thin community `Community 292`** (1 nodes): `파트너 정산 어드민 UI/UX 설계`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 293`** (1 nodes): `파트너 정산 어드민 UI/UX 설계`
+- **Thin community `Community 293`** (1 nodes): `Event Now Bar Technical Plan`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 294`** (1 nodes): `Event Now Bar Technical Plan`
+- **Thin community `Community 294`** (1 nodes): `Security Audit Report — Tag Discovery Phase 1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 295`** (1 nodes): `Security Audit Report — Tag Discovery Phase 1`
+- **Thin community `Community 295`** (1 nodes): `Runtime QA Bug — app_partner DevUserSwitchScreen Non-functional + am force-stop Auto-login Failure`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 296`** (1 nodes): `Runtime QA Bug — app_partner DevUserSwitchScreen Non-functional + am force-stop Auto-login Failure`
+- **Thin community `Community 296`** (1 nodes): `Issue #1542: Login 페이지 다크 테마 일관성 (P3-low)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 297`** (1 nodes): `Issue #1542: Login 페이지 다크 테마 일관성 (P3-low)`
+- **Thin community `Community 297`** (1 nodes): `Bug Report — P-S31 /dev Deeplink 404`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 298`** (1 nodes): `Bug Report — P-S31 /dev Deeplink 404`
+- **Thin community `Community 298`** (1 nodes): `Runtime QA — CUJ-U03 Refund Button Label Mismatch`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 299`** (1 nodes): `Runtime QA — CUJ-U03 Refund Button Label Mismatch`
+- **Thin community `Community 299`** (1 nodes): `Runtime QA Bug — Build Server Disk Full (98%)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (1 nodes): `Runtime QA Bug — Build Server Disk Full (98%)`
+- **Thin community `Community 300`** (1 nodes): `Runtime QA Bug — Pixel 7a ADB Wireless Session Disconnect`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (1 nodes): `Runtime QA Bug — Pixel 7a ADB Wireless Session Disconnect`
+- **Thin community `Community 301`** (1 nodes): `Ops Alert #990 — Dependabot CI Actions Update (actions/checkout v4->v6)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (1 nodes): `Ops Alert #990 — Dependabot CI Actions Update (actions/checkout v4->v6)`
+- **Thin community `Community 302`** (1 nodes): `App logo: purple gradient speech bubble with white 'm', orange sparkle accent`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (1 nodes): `App logo: purple gradient speech bubble with white 'm', orange sparkle accent`
+- **Thin community `Community 303`** (1 nodes): `App splash icon: purple gradient chat bubble with white 'm' and orange sparkle`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 304`** (1 nodes): `App splash icon: purple gradient chat bubble with white 'm' and orange sparkle`
+- **Thin community `Community 304`** (1 nodes): `Minglit app splash icon: purple chat bubble with white 'm' and orange sparkle`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 305`** (1 nodes): `Minglit app splash icon: purple chat bubble with white 'm' and orange sparkle`
+- **Thin community `Community 305`** (1 nodes): `App icon foreground: purple chat bubble with white 'm' and orange sparkle`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 306`** (1 nodes): `App icon foreground: purple chat bubble with white 'm' and orange sparkle`
+- **Thin community `Community 306`** (1 nodes): `Purple-blue gradient background image for app_partner icon`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 307`** (1 nodes): `Purple-blue gradient background image for app_partner icon`
+- **Thin community `Community 307`** (1 nodes): `Minglit inverted logo: white wordmark with cyan and orange shadow layers on transparent background`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 308`** (1 nodes): `Minglit inverted logo: white wordmark with cyan and orange shadow layers on transparent background`
+- **Thin community `Community 308`** (1 nodes): `Minglit wordmark logo SVG with transparent background, cyan/orange layered text`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 309`** (1 nodes): `Minglit wordmark logo SVG with transparent background, cyan/orange layered text`
+- **Thin community `Community 309`** (1 nodes): `Minglit app bar logo — bold italic 'Minglit' text in purple with cyan and orange shadow layers`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 310`** (1 nodes): `Minglit app bar logo — bold italic 'Minglit' text in purple with cyan and orange shadow layers`
+- **Thin community `Community 310`** (1 nodes): `Upscale lounge/restaurant interior with bar, green velvet chairs, Asian art, warm lighting`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 311`** (1 nodes): `Upscale lounge/restaurant interior with bar, green velvet chairs, Asian art, warm lighting`
+- **Thin community `Community 311`** (1 nodes): `Bright minimalist Korean cafe interior with numbered wooden tables, plants, string lights, and coffee bar`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 312`** (1 nodes): `Bright minimalist Korean cafe interior with numbered wooden tables, plants, string lights, and coffee bar`
+- **Thin community `Community 312`** (1 nodes): `Warm sunlit cafe interior with wood furniture, plants, string lights, and menu board`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 313`** (1 nodes): `Warm sunlit cafe interior with wood furniture, plants, string lights, and menu board`
+- **Thin community `Community 313`** (1 nodes): `Participation status redesign (after) — not-logged-in state with counts and login prompt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 314`** (1 nodes): `Participation status redesign (after) — not-logged-in state with counts and login prompt`
+- **Thin community `Community 314`** (1 nodes): `Dark theme participation status redesign, 2-group male/female layout with progress bars`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 315`** (1 nodes): `Dark theme participation status redesign, 2-group male/female layout with progress bars`
+- **Thin community `Community 315`** (1 nodes): `Participation status redesign after-state with 4 groups showing 12/40 total and per-group cards`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 316`** (1 nodes): `Participation status redesign after-state with 4 groups showing 12/40 total and per-group cards`
+- **Thin community `Community 316`** (1 nodes): `Empty participation status UI: 0/20 total, 0/10 male/female, empty state message`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 317`** (1 nodes): `Empty participation status UI: 0/20 total, 0/10 male/female, empty state message`
+- **Thin community `Community 317`** (1 nodes): `Participation status redesign after variant: 2-group (male/female) split with progress bars`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 318`** (1 nodes): `Participation status redesign after variant: 2-group (male/female) split with progress bars`
+- **Thin community `Community 318`** (1 nodes): `Participation status redesign: 2-group (male/female) expanded view with counts and age breakdowns`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 319`** (1 nodes): `Participation status redesign: 2-group (male/female) expanded view with counts and age breakdowns`
+- **Thin community `Community 319`** (1 nodes): `Before state: participation status UI with male/female groups, 2/10 capacity each`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 320`** (1 nodes): `Before state: participation status UI with male/female groups, 2/10 capacity each`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 321`** (1 nodes): `user_profiles Table`
+- **Thin community `Community 320`** (1 nodes): `user_profiles Table`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -2428,11 +2421,11 @@ _Questions this graph is uniquely positioned to answer:_
 - **What is the exact relationship between `Architecture Audit #1092 — 2026-04-06` and `AI Basic Law Compliance (Korea 2026)`?**
   _Edge tagged AMBIGUOUS (relation: conceptually_related_to) - confidence is low._
 - **Why does `package:flutter/material.dart` connect `Community 0` to `Community 1`, `Community 6`, `Community 7`, `Community 8`, `Community 13`, `Community 16`, `Community 17`, `Community 20`, `Community 21`, `Community 22`?**
-  _High betweenness centrality (0.062) - this node is a cross-community bridge._
+  _High betweenness centrality (0.065) - this node is a cross-community bridge._
 - **Why does `package:minglit_kit/minglit_kit.dart` connect `Community 0` to `Community 1`, `Community 7`, `Community 8`, `Community 13`, `Community 16`, `Community 20`, `Community 22`?**
   _High betweenness centrality (0.028) - this node is a cross-community bridge._
-- **Why does `minglit_kit Package` connect `Community 2` to `Community 9`, `Community 26`, `Community 5`?**
-  _High betweenness centrality (0.014) - this node is a cross-community bridge._
+- **Why does `PolicyRepository` connect `Community 2` to `Community 3`, `Community 4`?**
+  _High betweenness centrality (0.021) - this node is a cross-community bridge._
 - **What connects `reporter (AutoLabelAllureReporter)`, `BugReporterWrapper Widget Test Suite`, `MinglitListTile Widget Test Suite` to the rest of the system?**
   _1861 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -18945,21 +18945,12 @@
       "norm_label": "postcss.config.mjs"
     },
     {
-      "label": "next-env.d.ts",
-      "file_type": "code",
-      "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/next-env.d.ts",
-      "source_location": "L1",
-      "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_next_env_d_ts",
-      "community": 228,
-      "norm_label": "next-env.d.ts"
-    },
-    {
       "label": "tailwind.config.ts",
       "file_type": "code",
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-nesting/apps/mds/docs/tailwind.config.ts",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_nesting_apps_mds_docs_tailwind_config_ts",
-      "community": 229,
+      "community": 228,
       "norm_label": "tailwind.config.ts"
     },
     {
@@ -18968,7 +18959,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-nesting/apps/mds/docs/eslint.config.mjs",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_nesting_apps_mds_docs_eslint_config_mjs",
-      "community": 230,
+      "community": 229,
       "norm_label": "eslint.config.mjs"
     },
     {
@@ -18977,7 +18968,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/next.config.ts",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_next_config_ts",
-      "community": 231,
+      "community": 230,
       "norm_label": "next.config.ts"
     },
     {
@@ -19004,7 +18995,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/src/app/page.tsx",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_src_app_page_tsx",
-      "community": 232,
+      "community": 231,
       "norm_label": "page.tsx"
     },
     {
@@ -19013,7 +19004,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/src/app/foundations/layout/page.tsx",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_src_app_foundations_layout_page_tsx",
-      "community": 233,
+      "community": 232,
       "norm_label": "page.tsx"
     },
     {
@@ -19112,7 +19103,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/src/app/flows/page.tsx",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_src_app_flows_page_tsx",
-      "community": 234,
+      "community": 233,
       "norm_label": "page.tsx"
     },
     {
@@ -19139,7 +19130,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/src/components/Sidebar.tsx",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_src_components_sidebar_tsx",
-      "community": 235,
+      "community": 234,
       "norm_label": "sidebar.tsx"
     },
     {
@@ -19220,7 +19211,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/src/components/specs/MinglitSettingsTileSpec.tsx",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_src_components_specs_minglitsettingstilespec_tsx",
-      "community": 236,
+      "community": 235,
       "norm_label": "minglitsettingstilespec.tsx"
     },
     {
@@ -19229,7 +19220,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/src/components/specs/MinglitKeyValueRowSpec.tsx",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_src_components_specs_minglitkeyvaluerowspec_tsx",
-      "community": 237,
+      "community": 236,
       "norm_label": "minglitkeyvaluerowspec.tsx"
     },
     {
@@ -19256,7 +19247,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/src/components/specs/MinglitErrorStateSpec.tsx",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_src_components_specs_mingliterrorstatespec_tsx",
-      "community": 238,
+      "community": 237,
       "norm_label": "mingliterrorstatespec.tsx"
     },
     {
@@ -19265,7 +19256,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/src/components/specs/LoadingIndicatorSpec.tsx",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_src_components_specs_loadingindicatorspec_tsx",
-      "community": 239,
+      "community": 238,
       "norm_label": "loadingindicatorspec.tsx"
     },
     {
@@ -19319,7 +19310,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/src/components/specs/MinglitSettingsGroupSpec.tsx",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_src_components_specs_minglitsettingsgroupspec_tsx",
-      "community": 240,
+      "community": 239,
       "norm_label": "minglitsettingsgroupspec.tsx"
     },
     {
@@ -19472,7 +19463,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/src/components/specs/MinglitTextFieldSpec.tsx",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_src_components_specs_minglittextfieldspec_tsx",
-      "community": 241,
+      "community": 240,
       "norm_label": "minglittextfieldspec.tsx"
     },
     {
@@ -19481,7 +19472,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/src/components/specs/NumberStepperInputSpec.tsx",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_src_components_specs_numberstepperinputspec_tsx",
-      "community": 242,
+      "community": 241,
       "norm_label": "numberstepperinputspec.tsx"
     },
     {
@@ -19490,7 +19481,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/src/components/specs/MinglitChipSpec.tsx",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_src_components_specs_minglitchipspec_tsx",
-      "community": 243,
+      "community": 242,
       "norm_label": "minglitchipspec.tsx"
     },
     {
@@ -19607,7 +19598,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/src/components/specs/MinglitChipGroupSpec.tsx",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_src_components_specs_minglitchipgroupspec_tsx",
-      "community": 244,
+      "community": 243,
       "norm_label": "minglitchipgroupspec.tsx"
     },
     {
@@ -19652,7 +19643,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/src/components/specs/MinglitContentLayoutSpec.tsx",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_src_components_specs_minglitcontentlayoutspec_tsx",
-      "community": 245,
+      "community": 244,
       "norm_label": "minglitcontentlayoutspec.tsx"
     },
     {
@@ -19661,7 +19652,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/src/components/specs/MinglitBadgeSpec.tsx",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_src_components_specs_minglitbadgespec_tsx",
-      "community": 246,
+      "community": 245,
       "norm_label": "minglitbadgespec.tsx"
     },
     {
@@ -19724,7 +19715,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/src/components/specs/MinglitFilterChipSpec.tsx",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_src_components_specs_minglitfilterchipspec_tsx",
-      "community": 247,
+      "community": 246,
       "norm_label": "minglitfilterchipspec.tsx"
     },
     {
@@ -19751,7 +19742,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/src/components/specs/MinglitSectionSpec.tsx",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_src_components_specs_minglitsectionspec_tsx",
-      "community": 248,
+      "community": 247,
       "norm_label": "minglitsectionspec.tsx"
     },
     {
@@ -19841,7 +19832,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/mds/docs/src/lib/mds-icons-react.ts",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_mds_docs_src_lib_mds_icons_react_ts",
-      "community": 249,
+      "community": 248,
       "norm_label": "mds-icons-react.ts"
     },
     {
@@ -19958,7 +19949,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-extraction/apps/landing_user/postcss.config.mjs",
       "source_location": "L1",
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_extraction_apps_landing_user_postcss_config_mjs",
-      "community": 250,
+      "community": 249,
       "norm_label": "postcss.config.mjs"
     },
     {
@@ -19971,7 +19962,7 @@
       "author": null,
       "contributor": null,
       "id": "landing_user_eslint_config",
-      "community": 251,
+      "community": 250,
       "norm_label": "landing_user eslint config"
     },
     {
@@ -20023,7 +20014,7 @@
       "author": null,
       "contributor": null,
       "id": "landing_user_home_page",
-      "community": 252,
+      "community": 251,
       "norm_label": "landinguserpage"
     },
     {
@@ -20132,7 +20123,7 @@
       "author": null,
       "contributor": null,
       "id": "integration_test_driver",
-      "community": 253,
+      "community": 252,
       "norm_label": "integration test driver"
     },
     {
@@ -20158,7 +20149,7 @@
       "author": null,
       "contributor": null,
       "id": "reporter",
-      "community": 254,
+      "community": 253,
       "norm_label": "reporter.dart (autolabelallurereporter)"
     },
     {
@@ -21402,7 +21393,7 @@
       "author": null,
       "contributor": null,
       "id": "alchemist_package",
-      "community": 255,
+      "community": 254,
       "norm_label": "alchemist package"
     },
     {
@@ -22780,7 +22771,7 @@
       "author": null,
       "contributor": null,
       "id": "auth_coordinator_test",
-      "community": 256,
+      "community": 255,
       "norm_label": "authcoordinator unit test"
     },
     {
@@ -23419,7 +23410,7 @@
       "author": null,
       "contributor": null,
       "id": "deletion_complete_page_test",
-      "community": 257,
+      "community": 256,
       "norm_label": "deletioncompletepage test"
     },
     {
@@ -23729,7 +23720,7 @@
       "author": null,
       "contributor": null,
       "id": "status_badge_test",
-      "community": 258,
+      "community": 257,
       "norm_label": "statusbadge widget test"
     },
     {
@@ -23946,7 +23937,7 @@
       "author": null,
       "contributor": null,
       "id": "permission_grant_test",
-      "community": 259,
+      "community": 258,
       "norm_label": "permission_grant_test (patrol, skipped)"
     },
     {
@@ -23959,7 +23950,7 @@
       "author": null,
       "contributor": null,
       "id": "payment_pg_test",
-      "community": 260,
+      "community": 259,
       "norm_label": "payment_pg_test (patrol, skipped)"
     },
     {
@@ -23972,7 +23963,7 @@
       "author": null,
       "contributor": null,
       "id": "kakao_login_test",
-      "community": 261,
+      "community": 260,
       "norm_label": "kakao_login_test (patrol, skipped)"
     },
     {
@@ -25501,7 +25492,7 @@
       "source_file": "/Users/mark/workspace/minglit/.claude/worktrees/mds-icons-react/apps/app_user/lib/src/features/consent/ui/consent_detail_sheet.dart",
       "source_location": null,
       "id": "users_mark_workspace_minglit_claude_worktrees_mds_icons_react_apps_app_user_lib_src_features_consent_ui_consent_detail_sheet_dart",
-      "community": 262,
+      "community": 261,
       "norm_label": "consent_detail_sheet.dart"
     },
     {
@@ -27335,7 +27326,7 @@
       "author": null,
       "contributor": null,
       "id": "app_user_app_routes",
-      "community": 263,
+      "community": 262,
       "norm_label": "app_user approutes (app_routes.dart)"
     },
     {
@@ -27374,7 +27365,7 @@
       "author": null,
       "contributor": null,
       "id": "app_user_app_router",
-      "community": 264,
+      "community": 263,
       "norm_label": "app_user approuter (app_router.dart)"
     },
     {
@@ -29330,7 +29321,7 @@
       "author": null,
       "contributor": null,
       "id": "download_bottom_sheet_test",
-      "community": 265,
+      "community": 264,
       "norm_label": "downloadbottomsheet csv test"
     },
     {
@@ -30867,7 +30858,7 @@
       "author": null,
       "contributor": null,
       "id": "review_verification_screen_test",
-      "community": 266,
+      "community": 265,
       "norm_label": "reviewverificationscreen snapshot_data type guard test"
     },
     {
@@ -31417,7 +31408,7 @@
       "author": null,
       "contributor": null,
       "id": "account_deletion_flow_test",
-      "community": 267,
+      "community": 266,
       "norm_label": "accountdeletion flow logic unit test"
     },
     {
@@ -31586,7 +31577,7 @@
       "author": null,
       "contributor": null,
       "id": "firebase_options",
-      "community": 268,
+      "community": 267,
       "norm_label": "defaultfirebaseoptions"
     },
     {
@@ -31760,7 +31751,7 @@
       "author": null,
       "contributor": null,
       "id": "minglit_editable_section",
-      "community": 269,
+      "community": 268,
       "norm_label": "mingliteditablesection"
     },
     {
@@ -32120,7 +32111,7 @@
       "author": null,
       "contributor": null,
       "id": "today_party_card",
-      "community": 270,
+      "community": 269,
       "norm_label": "todaypartycard"
     },
     {
@@ -32862,7 +32853,7 @@
       "author": null,
       "contributor": null,
       "id": "settlement_shimmer",
-      "community": 271,
+      "community": 270,
       "norm_label": "settlementlistshimmer"
     },
     {
@@ -33914,7 +33905,7 @@
       "author": null,
       "contributor": null,
       "id": "event_card",
-      "community": 272,
+      "community": 271,
       "norm_label": "eventcard"
     },
     {
@@ -34044,7 +34035,7 @@
       "author": null,
       "contributor": null,
       "id": "party_image_editor",
-      "community": 273,
+      "community": 272,
       "norm_label": "partyimageeditor"
     },
     {
@@ -34070,7 +34061,7 @@
       "author": null,
       "contributor": null,
       "id": "party_status_edit_sheet",
-      "community": 274,
+      "community": 273,
       "norm_label": "partystatuseditsheet"
     },
     {
@@ -34213,7 +34204,7 @@
       "author": null,
       "contributor": null,
       "id": "party_verification_input",
-      "community": 275,
+      "community": 274,
       "norm_label": "partyverificationinput"
     },
     {
@@ -35877,7 +35868,7 @@
       "author": null,
       "contributor": null,
       "id": "app_partner_app_routes",
-      "community": 276,
+      "community": 275,
       "norm_label": "app_partner approutes (app_routes.dart)"
     },
     {
@@ -35916,7 +35907,7 @@
       "author": null,
       "contributor": null,
       "id": "app_partner_app_router",
-      "community": 277,
+      "community": 276,
       "norm_label": "app_partner approuter (app_router.dart)"
     },
     {
@@ -35942,7 +35933,7 @@
       "author": null,
       "contributor": null,
       "id": "landing_partner_postcss",
-      "community": 278,
+      "community": 277,
       "norm_label": "landing partner postcss config"
     },
     {
@@ -35955,7 +35946,7 @@
       "author": null,
       "contributor": null,
       "id": "landing_partner_eslint",
-      "community": 279,
+      "community": 278,
       "norm_label": "landing partner eslint config"
     },
     {
@@ -36007,7 +35998,7 @@
       "author": null,
       "contributor": null,
       "id": "landing_partner_page",
-      "community": 280,
+      "community": 279,
       "norm_label": "landing partner home page"
     },
     {
@@ -36020,7 +36011,7 @@
       "author": null,
       "contributor": null,
       "id": "landing_partner_privacy",
-      "community": 281,
+      "community": 280,
       "norm_label": "landing partner privacy policy page"
     },
     {
@@ -36058,7 +36049,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 282,
+      "community": 281,
       "norm_label": "appuser readme",
       "id": "app_user_readme"
     },
@@ -36071,7 +36062,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 283,
+      "community": 282,
       "norm_label": "app partner readme",
       "id": "app_partner_readme"
     },
@@ -36084,7 +36075,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 284,
+      "community": 283,
       "norm_label": "landing_user readme",
       "id": "landing_user_readme"
     },
@@ -36097,7 +36088,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 285,
+      "community": 284,
       "norm_label": "landing partner readme",
       "id": "landing_partner_readme"
     },
@@ -36110,7 +36101,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 286,
+      "community": 285,
       "norm_label": "minglit_kit changelog",
       "id": "minglit_kit_changelog"
     },
@@ -36123,7 +36114,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 287,
+      "community": 286,
       "norm_label": "minglit_kit readme",
       "id": "minglit_kit_readme"
     },
@@ -36149,7 +36140,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 288,
+      "community": 287,
       "norm_label": "pretendard font ofl license",
       "id": "pretendard_ofl"
     },
@@ -36292,7 +36283,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 289,
+      "community": 288,
       "norm_label": "\u1100\u116e\u1106\u1162 \u1102\u1162\u110b\u1167\u11a8 \u1109\u1162\u11a8\u1109\u1161\u11bc \u110b\u1171\u1100\u1168 \u1105\u1175\u1103\u1175\u110c\u1161\u110b\u1175\u11ab \u110b\u116a\u110b\u1175\u110b\u1165\u1111\u1173\u1105\u1166\u110b\u1175\u11b7",
       "id": "purchase_history_color_hierarchy_wireframe"
     },
@@ -36578,7 +36569,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 290,
+      "community": 289,
       "norm_label": "my tickets test plan",
       "id": "my_tickets_test_plan"
     },
@@ -37059,7 +37050,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 291,
+      "community": 290,
       "norm_label": "partner detail event card wireframe",
       "id": "partner_detail_event_card_wireframe"
     },
@@ -37293,7 +37284,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 292,
+      "community": 291,
       "norm_label": "minglitemptystate variants wireframe",
       "id": "empty_state_variants_wireframe"
     },
@@ -37449,7 +37440,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 293,
+      "community": 292,
       "norm_label": "\u1111\u1161\u1110\u1173\u1102\u1165 \u110c\u1165\u11bc\u1109\u1161\u11ab \u110b\u1165\u1103\u1173\u1106\u1175\u11ab ui/ux \u1109\u1165\u11af\u1100\u1168",
       "id": "partner_settlement_admin_uiux"
     },
@@ -37618,7 +37609,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 294,
+      "community": 293,
       "norm_label": "event now bar technical plan",
       "id": "event_now_bar_plan"
     },
@@ -39515,7 +39506,7 @@
       "captured_at": "2026-04-08",
       "author": "Mark-Yun",
       "contributor": null,
-      "community": 295,
+      "community": 294,
       "norm_label": "security audit report \u2014 tag discovery phase 1",
       "id": "security_report_1175"
     },
@@ -39983,7 +39974,7 @@
       "captured_at": "2026-04-23",
       "author": "Mark-Yun",
       "contributor": null,
-      "community": 296,
+      "community": 295,
       "norm_label": "runtime qa bug \u2014 app_partner devuserswitchscreen non-functional + am force-stop auto-login failure",
       "id": "qa_report_1776"
     },
@@ -40321,7 +40312,7 @@
       "captured_at": "2026-04-17",
       "author": "Mark-Yun",
       "contributor": null,
-      "community": 297,
+      "community": 296,
       "norm_label": "issue #1542: login \u1111\u1166\u110b\u1175\u110c\u1175 \u1103\u1161\u110f\u1173 \u1110\u1166\u1106\u1161 \u110b\u1175\u11af\u1100\u116a\u11ab\u1109\u1165\u11bc (p3-low)",
       "id": "issue1542_login_theme"
     },
@@ -40334,7 +40325,7 @@
       "captured_at": "2026-04-24",
       "author": "Mark-Yun",
       "contributor": null,
-      "community": 298,
+      "community": 297,
       "norm_label": "bug report \u2014 p-s31 /dev deeplink 404",
       "id": "qa_report_1825"
     },
@@ -40412,7 +40403,7 @@
       "captured_at": "2026-04-21",
       "author": "Mark-Yun",
       "contributor": null,
-      "community": 299,
+      "community": 298,
       "norm_label": "runtime qa \u2014 cuj-u03 refund button label mismatch",
       "id": "qa_report_1681"
     },
@@ -40490,7 +40481,7 @@
       "captured_at": "2026-04-20",
       "author": "Mark-Yun",
       "contributor": null,
-      "community": 300,
+      "community": 299,
       "norm_label": "runtime qa bug \u2014 build server disk full (98%)",
       "id": "qa_report_1663"
     },
@@ -40581,7 +40572,7 @@
       "captured_at": "2026-04-25",
       "author": "Mark-Yun",
       "contributor": null,
-      "community": 301,
+      "community": 300,
       "norm_label": "runtime qa bug \u2014 pixel 7a adb wireless session disconnect",
       "id": "qa_report_1849"
     },
@@ -41699,7 +41690,7 @@
       "captured_at": "2026-04-04",
       "author": "Mark-Yun",
       "contributor": null,
-      "community": 302,
+      "community": 301,
       "norm_label": "ops alert #990 \u2014 dependabot ci actions update (actions/checkout v4->v6)",
       "id": "ops_alert_990"
     },
@@ -42297,7 +42288,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 303,
+      "community": 302,
       "norm_label": "app logo: purple gradient speech bubble with white 'm', orange sparkle accent",
       "id": "icon_full_png"
     },
@@ -42310,7 +42301,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 304,
+      "community": 303,
       "norm_label": "app splash icon: purple gradient chat bubble with white 'm' and orange sparkle",
       "id": "splash_icon_png"
     },
@@ -42323,7 +42314,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 305,
+      "community": 304,
       "norm_label": "minglit app splash icon: purple chat bubble with white 'm' and orange sparkle",
       "id": "splash_icon_android12_png"
     },
@@ -42336,7 +42327,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 306,
+      "community": 305,
       "norm_label": "app icon foreground: purple chat bubble with white 'm' and orange sparkle",
       "id": "icon_foreground_png"
     },
@@ -42349,7 +42340,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 307,
+      "community": 306,
       "norm_label": "purple-blue gradient background image for app_partner icon",
       "id": "icon_background_png"
     },
@@ -42362,7 +42353,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 308,
+      "community": 307,
       "norm_label": "minglit inverted logo: white wordmark with cyan and orange shadow layers on transparent background",
       "id": "minglit_logo_inverted_svg"
     },
@@ -42375,7 +42366,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 309,
+      "community": 308,
       "norm_label": "minglit wordmark logo svg with transparent background, cyan/orange layered text",
       "id": "minglit_logo_background_transparent_svg"
     },
@@ -42388,7 +42379,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 310,
+      "community": 309,
       "norm_label": "minglit app bar logo \u2014 bold italic 'minglit' text in purple with cyan and orange shadow layers",
       "id": "minglit_app_bar_logo_png"
     },
@@ -42401,7 +42392,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 311,
+      "community": 310,
       "norm_label": "upscale lounge/restaurant interior with bar, green velvet chairs, asian art, warm lighting",
       "id": "party_premium_lounge"
     },
@@ -42414,7 +42405,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 312,
+      "community": 311,
       "norm_label": "bright minimalist korean cafe interior with numbered wooden tables, plants, string lights, and coffee bar",
       "id": "party_lounge_bright_jpg"
     },
@@ -42427,7 +42418,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 313,
+      "community": 312,
       "norm_label": "warm sunlit cafe interior with wood furniture, plants, string lights, and menu board",
       "id": "party_cafe_warm_jpg"
     },
@@ -42440,7 +42431,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 314,
+      "community": 313,
       "norm_label": "participation status redesign (after) \u2014 not-logged-in state with counts and login prompt",
       "id": "screenshot_05_nologin_png"
     },
@@ -42453,7 +42444,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 315,
+      "community": 314,
       "norm_label": "dark theme participation status redesign, 2-group male/female layout with progress bars",
       "id": "screenshot_07_dark_2group"
     },
@@ -42466,7 +42457,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 316,
+      "community": 315,
       "norm_label": "participation status redesign after-state with 4 groups showing 12/40 total and per-group cards",
       "id": "04_after_4group_png"
     },
@@ -42479,7 +42470,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 317,
+      "community": 316,
       "norm_label": "empty participation status ui: 0/20 total, 0/10 male/female, empty state message",
       "id": "06_empty_png"
     },
@@ -42492,7 +42483,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 318,
+      "community": 317,
       "norm_label": "participation status redesign after variant: 2-group (male/female) split with progress bars",
       "id": "02_after_2group_png"
     },
@@ -42505,7 +42496,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 319,
+      "community": 318,
       "norm_label": "participation status redesign: 2-group (male/female) expanded view with counts and age breakdowns",
       "id": "03_after_2group_expanded"
     },
@@ -42518,7 +42509,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 320,
+      "community": 319,
       "norm_label": "before state: participation status ui with male/female groups, 2/10 capacity each",
       "id": "01_before_png"
     },
@@ -42973,7 +42964,7 @@
       "captured_at": null,
       "author": null,
       "contributor": null,
-      "community": 321,
+      "community": 320,
       "norm_label": "user_profiles table",
       "id": "user_profiles_table"
     },
@@ -64842,9 +64833,9 @@
       "weight": 1.0,
       "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_fixtures_ts",
       "_tgt": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
-      "confidence_score": 1.0,
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_fixtures_ts",
-      "target": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts"
+      "target": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports_from",
@@ -64852,11 +64843,11 @@
       "source_file": "/private/tmp/feat-2040-marketing-guards/supabase/functions/notification-worker/notification_worker_test.ts",
       "source_location": "L12",
       "weight": 1.0,
-      "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_fixtures_ts",
-      "_tgt": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_notification_worker_test_ts",
-      "confidence_score": 1.0,
+      "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_notification_worker_test_ts",
+      "_tgt": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_fixtures_ts",
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_fixtures_ts",
-      "target": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_notification_worker_test_ts"
+      "target": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_notification_worker_test_ts",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports_from",
@@ -64864,11 +64855,11 @@
       "source_file": "/private/tmp/feat-2040-marketing-guards/supabase/functions/user-manage-settings/user_manage_settings_test.ts",
       "source_location": "L13",
       "weight": 1.0,
-      "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_fixtures_ts",
-      "_tgt": "private_tmp_feat_2040_marketing_guards_supabase_functions_user_manage_settings_user_manage_settings_test_ts",
-      "confidence_score": 1.0,
+      "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_user_manage_settings_user_manage_settings_test_ts",
+      "_tgt": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_fixtures_ts",
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_fixtures_ts",
-      "target": "private_tmp_feat_2040_marketing_guards_supabase_functions_user_manage_settings_user_manage_settings_test_ts"
+      "target": "private_tmp_feat_2040_marketing_guards_supabase_functions_user_manage_settings_user_manage_settings_test_ts",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -64878,9 +64869,9 @@
       "weight": 1.0,
       "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
       "_tgt": "mock_http_jsonresponse",
-      "confidence_score": 1.0,
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
-      "target": "mock_http_jsonresponse"
+      "target": "mock_http_jsonresponse",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -64890,9 +64881,9 @@
       "weight": 1.0,
       "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
       "_tgt": "mock_http_textresponse",
-      "confidence_score": 1.0,
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
-      "target": "mock_http_textresponse"
+      "target": "mock_http_textresponse",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -64902,9 +64893,9 @@
       "weight": 1.0,
       "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
       "_tgt": "mock_http_jsonrequest",
-      "confidence_score": 1.0,
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
-      "target": "mock_http_jsonrequest"
+      "target": "mock_http_jsonrequest",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -64921,14 +64912,14 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
-      "source_file": "/Users/mark/workspace/minglit-graphify-init/supabase/functions/user-manage-settings/user_manage_settings_test.ts",
-      "source_location": null,
+      "source_file": "/private/tmp/feat-2040-marketing-guards/supabase/functions/_test_utils/mock_http.ts",
+      "source_location": "L48",
       "weight": 1.0,
       "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
       "_tgt": "mock_http_authenticatedjsonrequest",
-      "confidence_score": 1.0,
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
-      "target": "mock_http_authenticatedjsonrequest"
+      "target": "mock_http_authenticatedjsonrequest",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -64938,9 +64929,9 @@
       "weight": 1.0,
       "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
       "_tgt": "mock_http_readjson",
-      "confidence_score": 1.0,
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
-      "target": "mock_http_readjson"
+      "target": "mock_http_readjson",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -64950,9 +64941,9 @@
       "weight": 1.0,
       "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
       "_tgt": "mock_http_createfetchmock",
-      "confidence_score": 1.0,
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
-      "target": "mock_http_createfetchmock"
+      "target": "mock_http_createfetchmock",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -64962,9 +64953,9 @@
       "weight": 1.0,
       "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
       "_tgt": "mock_http_withmockedfetch",
-      "confidence_score": 1.0,
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
-      "target": "mock_http_withmockedfetch"
+      "target": "mock_http_withmockedfetch",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -64974,9 +64965,9 @@
       "weight": 1.0,
       "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
       "_tgt": "mock_http_withnointervals",
-      "confidence_score": 1.0,
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
-      "target": "mock_http_withnointervals"
+      "target": "mock_http_withnointervals",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -64986,9 +64977,9 @@
       "weight": 1.0,
       "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
       "_tgt": "mock_http_withenv",
-      "confidence_score": 1.0,
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
-      "target": "mock_http_withenv"
+      "target": "mock_http_withenv",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -64998,9 +64989,9 @@
       "weight": 1.0,
       "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
       "_tgt": "mock_http_captureservehandler",
-      "confidence_score": 1.0,
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
-      "target": "mock_http_captureservehandler"
+      "target": "mock_http_captureservehandler",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports_from",
@@ -65008,11 +64999,11 @@
       "source_file": "/private/tmp/feat-2040-marketing-guards/supabase/functions/notification-worker/notification_worker_test.ts",
       "source_location": "L3",
       "weight": 1.0,
-      "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
-      "_tgt": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_notification_worker_test_ts",
-      "confidence_score": 1.0,
+      "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_notification_worker_test_ts",
+      "_tgt": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
-      "target": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_notification_worker_test_ts"
+      "target": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_notification_worker_test_ts",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports_from",
@@ -65020,11 +65011,11 @@
       "source_file": "/private/tmp/feat-2040-marketing-guards/supabase/functions/user-manage-settings/user_manage_settings_test.ts",
       "source_location": "L2",
       "weight": 1.0,
-      "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
-      "_tgt": "private_tmp_feat_2040_marketing_guards_supabase_functions_user_manage_settings_user_manage_settings_test_ts",
-      "confidence_score": 1.0,
+      "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_user_manage_settings_user_manage_settings_test_ts",
+      "_tgt": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_test_utils_mock_http_ts",
-      "target": "private_tmp_feat_2040_marketing_guards_supabase_functions_user_manage_settings_user_manage_settings_test_ts"
+      "target": "private_tmp_feat_2040_marketing_guards_supabase_functions_user_manage_settings_user_manage_settings_test_ts",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
@@ -66630,9 +66621,9 @@
       "weight": 1.0,
       "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_marketing_guards_ts",
       "_tgt": "marketing_guards_isnighttimekst",
-      "confidence_score": 1.0,
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_marketing_guards_ts",
-      "target": "marketing_guards_isnighttimekst"
+      "target": "marketing_guards_isnighttimekst",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -66642,9 +66633,9 @@
       "weight": 1.0,
       "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_marketing_guards_ts",
       "_tgt": "marketing_guards_secondsuntilkst8am",
-      "confidence_score": 1.0,
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_marketing_guards_ts",
-      "target": "marketing_guards_secondsuntilkst8am"
+      "target": "marketing_guards_secondsuntilkst8am",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports_from",
@@ -66652,11 +66643,11 @@
       "source_file": "/private/tmp/feat-2040-marketing-guards/supabase/functions/notification-worker/notification_worker_test.ts",
       "source_location": "L14",
       "weight": 1.0,
-      "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_marketing_guards_ts",
-      "_tgt": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_notification_worker_test_ts",
-      "confidence_score": 1.0,
+      "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_notification_worker_test_ts",
+      "_tgt": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_marketing_guards_ts",
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_marketing_guards_ts",
-      "target": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_notification_worker_test_ts"
+      "target": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_notification_worker_test_ts",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -66666,9 +66657,9 @@
       "weight": 1.0,
       "_src": "users_mark_workspace_minglit_worker_runtime_repos_workspace_fix_2054_save_user_consents_timestamp_supabase_functions_notification_worker_index_ts",
       "_tgt": "index_masktoken",
-      "confidence_score": 1.0,
       "source": "users_mark_workspace_minglit_worker_runtime_repos_workspace_fix_2054_save_user_consents_timestamp_supabase_functions_notification_worker_index_ts",
-      "target": "index_masktoken"
+      "target": "index_masktoken",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -66678,9 +66669,9 @@
       "weight": 1.0,
       "_src": "users_mark_workspace_minglit_worker_runtime_repos_workspace_fix_2054_save_user_consents_timestamp_supabase_functions_notification_worker_index_ts",
       "_tgt": "index_getaccesstoken",
-      "confidence_score": 1.0,
       "source": "users_mark_workspace_minglit_worker_runtime_repos_workspace_fix_2054_save_user_consents_timestamp_supabase_functions_notification_worker_index_ts",
-      "target": "index_getaccesstoken"
+      "target": "index_getaccesstoken",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -66690,9 +66681,9 @@
       "weight": 1.0,
       "_src": "users_mark_workspace_minglit_worker_runtime_repos_workspace_fix_2054_save_user_consents_timestamp_supabase_functions_notification_worker_index_ts",
       "_tgt": "index_sendfcm",
-      "confidence_score": 1.0,
       "source": "users_mark_workspace_minglit_worker_runtime_repos_workspace_fix_2054_save_user_consents_timestamp_supabase_functions_notification_worker_index_ts",
-      "target": "index_sendfcm"
+      "target": "index_sendfcm",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -66702,9 +66693,9 @@
       "weight": 1.0,
       "_src": "users_mark_workspace_minglit_worker_runtime_repos_workspace_fix_2054_save_user_consents_timestamp_supabase_functions_notification_worker_index_ts",
       "_tgt": "index_getaffecteduserid",
-      "confidence_score": 1.0,
       "source": "users_mark_workspace_minglit_worker_runtime_repos_workspace_fix_2054_save_user_consents_timestamp_supabase_functions_notification_worker_index_ts",
-      "target": "index_getaffecteduserid"
+      "target": "index_getaffecteduserid",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -66714,9 +66705,9 @@
       "weight": 1.0,
       "_src": "users_mark_workspace_minglit_worker_runtime_repos_workspace_fix_2054_save_user_consents_timestamp_supabase_functions_notification_worker_index_ts",
       "_tgt": "index_sendtoallparticipants",
-      "confidence_score": 1.0,
       "source": "users_mark_workspace_minglit_worker_runtime_repos_workspace_fix_2054_save_user_consents_timestamp_supabase_functions_notification_worker_index_ts",
-      "target": "index_sendtoallparticipants"
+      "target": "index_sendtoallparticipants",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
@@ -66724,11 +66715,11 @@
       "source_file": "/Users/mark/workspace/minglit-worker-runtime/repos/workspace/fix-2054-save-user-consents-timestamp/supabase/functions/notification-worker/index.ts",
       "source_location": "L80",
       "weight": 1.0,
-      "_src": "index_masktoken",
-      "_tgt": "index_sendfcm",
-      "confidence_score": 1.0,
+      "_src": "index_sendfcm",
+      "_tgt": "index_masktoken",
       "source": "index_masktoken",
-      "target": "index_sendfcm"
+      "target": "index_sendfcm",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
@@ -66736,11 +66727,11 @@
       "source_file": "/Users/mark/workspace/minglit-worker-runtime/repos/workspace/fix-2054-save-user-consents-timestamp/supabase/functions/notification-worker/index.ts",
       "source_location": "L228",
       "weight": 1.0,
-      "_src": "index_masktoken",
-      "_tgt": "index_sendtoallparticipants",
-      "confidence_score": 1.0,
+      "_src": "index_sendtoallparticipants",
+      "_tgt": "index_masktoken",
       "source": "index_masktoken",
-      "target": "index_sendtoallparticipants"
+      "target": "index_sendtoallparticipants",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
@@ -66748,11 +66739,11 @@
       "source_file": "/Users/mark/workspace/minglit-worker-runtime/repos/workspace/fix-2054-save-user-consents-timestamp/supabase/functions/notification-worker/index.ts",
       "source_location": "L225",
       "weight": 1.0,
-      "_src": "index_sendfcm",
-      "_tgt": "index_sendtoallparticipants",
-      "confidence_score": 1.0,
+      "_src": "index_sendtoallparticipants",
+      "_tgt": "index_sendfcm",
       "source": "index_sendfcm",
-      "target": "index_sendtoallparticipants"
+      "target": "index_sendtoallparticipants",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
@@ -66774,9 +66765,9 @@
       "weight": 1.0,
       "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_notification_worker_test_ts",
       "_tgt": "notification_worker_test_withnighttimers",
-      "confidence_score": 1.0,
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_notification_worker_test_ts",
-      "target": "notification_worker_test_withnighttimers"
+      "target": "notification_worker_test_withnighttimers",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -66786,9 +66777,9 @@
       "weight": 1.0,
       "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_notification_worker_test_ts",
       "_tgt": "notification_worker_test_withdaytimers",
-      "confidence_score": 1.0,
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_notification_worker_test_ts",
-      "target": "notification_worker_test_withdaytimers"
+      "target": "notification_worker_test_withdaytimers",
+      "confidence_score": 1.0
     },
     {
       "relation": "contains",
@@ -66798,9 +66789,9 @@
       "weight": 1.0,
       "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_notification_worker_test_ts",
       "_tgt": "notification_worker_test_withfasttimers",
-      "confidence_score": 1.0,
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_notification_worker_notification_worker_test_ts",
-      "target": "notification_worker_test_withfasttimers"
+      "target": "notification_worker_test_withfasttimers",
+      "confidence_score": 1.0
     },
     {
       "relation": "calls",
@@ -67698,9 +67689,9 @@
       "weight": 1.0,
       "_src": "private_tmp_feat_2040_marketing_guards_supabase_functions_user_manage_settings_user_manage_settings_test_ts",
       "_tgt": "user_manage_settings_test_dbupsertsettingsrpcroute",
-      "confidence_score": 1.0,
       "source": "private_tmp_feat_2040_marketing_guards_supabase_functions_user_manage_settings_user_manage_settings_test_ts",
-      "target": "user_manage_settings_test_dbupsertsettingsrpcroute"
+      "target": "user_manage_settings_test_dbupsertsettingsrpcroute",
+      "confidence_score": 1.0
     },
     {
       "relation": "references",
@@ -70758,9 +70749,9 @@
       "weight": 1.0,
       "_src": "private_tmp_feat_2041_consent_renewal_apps_landing_user_src_app_privacy_page_tsx",
       "_tgt": "page_privacypage",
-      "confidence_score": 1.0,
       "source": "private_tmp_feat_2041_consent_renewal_apps_landing_user_src_app_privacy_page_tsx",
-      "target": "page_privacypage"
+      "target": "page_privacypage",
+      "confidence_score": 1.0
     },
     {
       "relation": "references",
@@ -71087,7 +71078,7 @@
       "target": "package_app_user_src_features_home_widgets_event_now_bar_controller_dart"
     },
     {
-      "relation": "references",
+      "relation": "imports",
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "/Users/mark/workspace/minglit-worker-runtime/workspace/audit-legal-claude-subagents/apps/app_user/test/integration/cuj_event_now_bar_test.dart",
@@ -71129,8 +71120,8 @@
       "source_file": "/Users/mark/workspace/minglit-worker-runtime/workspace/audit-legal-claude-subagents/apps/app_user/test/src/features/home/home_page_test.dart",
       "source_location": null,
       "weight": 1.0,
-      "_src": "package_app_user_src_features_home_widgets_event_now_bar_dart",
-      "_tgt": "users_mark_workspace_minglit_worker_runtime_workspace_audit_legal_claude_subagents_apps_app_user_test_src_features_home_home_page_test_dart",
+      "_src": "users_mark_workspace_minglit_worker_runtime_workspace_audit_legal_claude_subagents_apps_app_user_test_src_features_home_home_page_test_dart",
+      "_tgt": "package_app_user_src_features_home_widgets_event_now_bar_dart",
       "source": "package_app_user_src_features_home_widgets_event_now_bar_dart",
       "target": "users_mark_workspace_minglit_worker_runtime_workspace_audit_legal_claude_subagents_apps_app_user_test_src_features_home_home_page_test_dart"
     },
@@ -71237,8 +71228,8 @@
       "source_file": "/Users/mark/workspace/minglit-worker-runtime/workspace/audit-legal-claude-subagents/apps/app_user/test/src/features/home/widgets/event_now_bottom_sheet_test.dart",
       "source_location": null,
       "weight": 1.0,
-      "_src": "package_app_user_src_features_home_widgets_event_now_bottom_sheet_dart",
-      "_tgt": "users_mark_workspace_minglit_worker_runtime_workspace_audit_legal_claude_subagents_apps_app_user_test_src_features_home_widgets_event_now_bottom_sheet_test_dart",
+      "_src": "users_mark_workspace_minglit_worker_runtime_workspace_audit_legal_claude_subagents_apps_app_user_test_src_features_home_widgets_event_now_bottom_sheet_test_dart",
+      "_tgt": "package_app_user_src_features_home_widgets_event_now_bottom_sheet_dart",
       "source": "package_app_user_src_features_home_widgets_event_now_bottom_sheet_dart",
       "target": "users_mark_workspace_minglit_worker_runtime_workspace_audit_legal_claude_subagents_apps_app_user_test_src_features_home_widgets_event_now_bottom_sheet_test_dart"
     },
@@ -71249,8 +71240,8 @@
       "source_file": "/Users/mark/workspace/minglit-worker-runtime/workspace/audit-legal-claude-subagents/apps/app_user/lib/src/features/home/widgets/event_now_bar.dart",
       "source_location": null,
       "weight": 1.0,
-      "_src": "package_app_user_src_features_home_widgets_event_now_bottom_sheet_dart",
-      "_tgt": "users_mark_workspace_minglit_worker_runtime_workspace_audit_legal_claude_subagents_apps_app_user_lib_src_features_home_widgets_event_now_bar_dart",
+      "_src": "users_mark_workspace_minglit_worker_runtime_workspace_audit_legal_claude_subagents_apps_app_user_lib_src_features_home_widgets_event_now_bar_dart",
+      "_tgt": "package_app_user_src_features_home_widgets_event_now_bottom_sheet_dart",
       "source": "package_app_user_src_features_home_widgets_event_now_bottom_sheet_dart",
       "target": "users_mark_workspace_minglit_worker_runtime_workspace_audit_legal_claude_subagents_apps_app_user_lib_src_features_home_widgets_event_now_bar_dart"
     },
@@ -72017,8 +72008,8 @@
       "source_file": "/Users/mark/workspace/minglit-worker-runtime/workspace/audit-legal-claude-subagents/apps/app_user/test/integration/cuj_account_deletion_test.dart",
       "source_location": null,
       "weight": 1.0,
-      "_src": "utils_golden_capture_dart",
-      "_tgt": "users_mark_workspace_minglit_worker_runtime_workspace_audit_legal_claude_subagents_apps_app_user_test_integration_cuj_account_deletion_test_dart",
+      "_src": "users_mark_workspace_minglit_worker_runtime_workspace_audit_legal_claude_subagents_apps_app_user_test_integration_cuj_account_deletion_test_dart",
+      "_tgt": "utils_golden_capture_dart",
       "source": "utils_golden_capture_dart",
       "target": "users_mark_workspace_minglit_worker_runtime_workspace_audit_legal_claude_subagents_apps_app_user_test_integration_cuj_account_deletion_test_dart"
     },
@@ -72029,8 +72020,8 @@
       "source_file": "/Users/mark/workspace/minglit-worker-runtime/workspace/audit-legal-claude-subagents/apps/app_user/test/integration/my_page_test.dart",
       "source_location": null,
       "weight": 1.0,
-      "_src": "utils_golden_capture_dart",
-      "_tgt": "users_mark_workspace_minglit_worker_runtime_workspace_audit_legal_claude_subagents_apps_app_user_test_integration_my_page_test_dart",
+      "_src": "users_mark_workspace_minglit_worker_runtime_workspace_audit_legal_claude_subagents_apps_app_user_test_integration_my_page_test_dart",
+      "_tgt": "utils_golden_capture_dart",
       "source": "utils_golden_capture_dart",
       "target": "users_mark_workspace_minglit_worker_runtime_workspace_audit_legal_claude_subagents_apps_app_user_test_integration_my_page_test_dart"
     },
@@ -75149,8 +75140,8 @@
       "source_file": "/Users/mark/workspace/minglit-graphify-init/apps/app_user/lib/src/features/account_deletion/ui/deletion_info_page.dart",
       "source_location": null,
       "weight": 1.0,
-      "_src": "deletion_info_page",
-      "_tgt": "consent_coordinator",
+      "_src": "consent_coordinator",
+      "_tgt": "deletion_info_page",
       "source": "consent_coordinator",
       "target": "deletion_info_page"
     },
@@ -77621,8 +77612,8 @@
       "source_file": "/private/tmp/fix-1936-avatar-image/apps/app_user/lib/src/features/home/home_page.dart",
       "source_location": null,
       "weight": 1.0,
-      "_src": "package_app_user_src_logic_feed_state_provider_dart",
-      "_tgt": "private_tmp_fix_1936_avatar_image_apps_app_user_lib_src_features_home_home_page_dart",
+      "_src": "private_tmp_fix_1936_avatar_image_apps_app_user_lib_src_features_home_home_page_dart",
+      "_tgt": "package_app_user_src_logic_feed_state_provider_dart",
       "source": "package_app_user_src_logic_feed_state_provider_dart",
       "target": "private_tmp_fix_1936_avatar_image_apps_app_user_lib_src_features_home_home_page_dart"
     },
@@ -86501,8 +86492,8 @@
       "source_file": "/Users/mark/workspace/minglit-worker-runtime/workspace/audit-legal-claude-subagents/apps/app_partner/test/src/features/party/event/create/event_create_controller_test.dart",
       "source_location": null,
       "weight": 1.0,
-      "_src": "package_app_partner_src_features_home_partner_dashboard_controller_dart",
-      "_tgt": "users_mark_workspace_minglit_worker_runtime_workspace_audit_legal_claude_subagents_apps_app_partner_test_src_features_party_event_create_event_create_controller_test_dart",
+      "_src": "users_mark_workspace_minglit_worker_runtime_workspace_audit_legal_claude_subagents_apps_app_partner_test_src_features_party_event_create_event_create_controller_test_dart",
+      "_tgt": "package_app_partner_src_features_home_partner_dashboard_controller_dart",
       "source": "package_app_partner_src_features_home_partner_dashboard_controller_dart",
       "target": "users_mark_workspace_minglit_worker_runtime_workspace_audit_legal_claude_subagents_apps_app_partner_test_src_features_party_event_create_event_create_controller_test_dart"
     },


### PR DESCRIPTION
Scheduler: tpm-exec-report-claude-subagents

## Summary
- TPM 정기 exec report (#2083)을 `docs/reports/tpm/`에 동기화
- 24h 무진전 P0 인프라 블로커 4건 (#2049 iOS User, #2061 iOS Partner, #2064 SDK 3.41, #1883 Pixel 7a) 재escalate
- 신규 발견: `minglit_env`가 git submodule이며 미초기화 상태로 runtime-qa의 flutter.env 부재 hard block의 root cause

## Test plan
- [ ] 파일이 `docs/reports/tpm/`에 정상 추가됨
- [ ] Frontmatter + body가 이슈 #2083 본문과 일치

🤖 Generated with [Claude Code](https://claude.com/claude-code)