### PR TITLE
fix(partner/onboarding): extract inline FutureProvider to break rebuild loop (#2074)

### DIFF
--- a/apps/app_partner/lib/src/features/onboarding/partner_apply_status_page.dart
+++ b/apps/app_partner/lib/src/features/onboarding/partner_apply_status_page.dart
@@ -6,6 +6,16 @@ import 'package:flutter/material.dart';
 
 import 'package:minglit_kit/minglit_kit.dart';
 
+// Fix #2074: inline FutureProvider inside build() creates a new provider
+// instance on every rebuild → infinite rebuild loop and getMyApplication spam.
+// Top-level provider has stable identity, breaking the cycle.
+// ignore: specify_nonobvious_property_types
+final _myApplicationProvider =
+    FutureProvider.autoDispose<PartnerApplication?>((ref) {
+  final repo = ref.read(partnerRepositoryProvider);
+  return repo.getMyApplication();
+});
+
 /// Application status page shown when user has a pending
 /// or needs_correction application.
 class PartnerApplyStatusPage extends ConsumerWidget {
@@ -15,12 +25,7 @@ class PartnerApplyStatusPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;
     final onboardingAsync = ref.watch(onboardingStateProvider);
-    final applicationAsync = ref.watch(
-      FutureProvider((ref) {
-        final repo = ref.read(partnerRepositoryProvider);
-        return repo.getMyApplication();
-      }),
-    );
+    final applicationAsync = ref.watch(_myApplicationProvider);
 
     return Scaffold(
       appBar: AppBar(

--- a/apps/app_partner/lib/src/features/onboarding/partner_apply_status_page.dart
+++ b/apps/app_partner/lib/src/features/onboarding/partner_apply_status_page.dart
@@ -10,8 +10,9 @@ import 'package:minglit_kit/minglit_kit.dart';
 // instance on every rebuild → infinite rebuild loop and getMyApplication spam.
 // Top-level provider has stable identity, breaking the cycle.
 // ignore: specify_nonobvious_property_types
-final _myApplicationProvider =
-    FutureProvider.autoDispose<PartnerApplication?>((ref) {
+final _myApplicationProvider = FutureProvider.autoDispose<PartnerApplication?>((
+  ref,
+) {
   final repo = ref.read(partnerRepositoryProvider);
   return repo.getMyApplication();
 });

--- a/apps/app_partner/test/src/features/onboarding/partner_apply_status_page_test.dart
+++ b/apps/app_partner/test/src/features/onboarding/partner_apply_status_page_test.dart
@@ -19,11 +19,6 @@ void main() {
       mockRepo = MockPartnerRepository();
     });
 
-    /// Builds the widget under test with the given provider overrides.
-    ///
-    /// Uses [SynchronousFuture] for [getMyApplication] so the anonymous
-    /// inline FutureProvider in [PartnerApplyStatusPage] resolves immediately
-    /// without triggering an infinite rebuild loop in tests.
     Widget buildWidget({required List<dynamic> overrides}) {
       return ProviderScope(
         overrides: overrides.cast(),
@@ -39,7 +34,6 @@ void main() {
     testWidgets(
       'shows loading indicator when onboardingStateProvider is loading',
       (tester) async {
-        // Stub getMyApplication so the inline FutureProvider can call it.
         when(
           () => mockRepo.getMyApplication(),
         ).thenAnswer((_) => SynchronousFuture<PartnerApplication?>(null));
@@ -66,8 +60,6 @@ void main() {
     testWidgets(
       'shows pending message when state is pendingReview',
       (tester) async {
-        // SynchronousFuture resolves the inline FutureProvider immediately
-        // so the widget never enters the applicationAsync loading state.
         when(() => mockRepo.getMyApplication()).thenAnswer(
           (_) => SynchronousFuture<PartnerApplication?>(
             const PartnerApplication(
@@ -195,6 +187,44 @@ void main() {
         await tester.pump();
 
         expect(find.text('신청서 수정하기'), findsNothing);
+      },
+    );
+
+    // Regression test for #2074: inline FutureProvider inside build() caused
+    // an infinite rebuild loop — getMyApplication was called on every rebuild.
+    // After the fix (top-level _myApplicationProvider), the provider is created
+    // once and getMyApplication must be called exactly once per widget mount.
+    testWidgets(
+      'getMyApplication is called exactly once — no rebuild loop (regression #2074)',
+      (tester) async {
+        var callCount = 0;
+        when(() => mockRepo.getMyApplication()).thenAnswer((_) async {
+          callCount++;
+          return const PartnerApplication(
+            id: 'app_1',
+            userId: 'user_1',
+            status: 'pending',
+          );
+        });
+
+        await tester.pumpWidget(
+          buildWidget(
+            overrides: [
+              partnerRepositoryProvider.overrideWith((ref) => mockRepo),
+              onboardingStateProvider.overrideWith(
+                (ref) async => OnboardingState.pendingReview,
+              ),
+            ],
+          ),
+        );
+
+        // Pump several frames to surface any rebuild loops.
+        for (var i = 0; i < 10; i++) {
+          await tester.pump(const Duration(milliseconds: 16));
+        }
+
+        // The provider must not call getMyApplication more than once.
+        expect(callCount, 1);
       },
     );
   });


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 요약

`PartnerApplyStatusPage.build()` 내 익명 `FutureProvider`가 매 rebuild마다 새 인스턴스를 생성, 무한 rebuild 루프 → `getMyApplication` 초당 수십 회 호출.

## Root Cause

인라인 `FutureProvider` in `build()` → 매 rebuild마다 새 provider 인스턴스 생성 → Riverpod이 old 버리고 new subscribe → async 완료 시 rebuild → 무한 루프.

## Fix

`_myApplicationProvider`를 파일 레벨 top-level 변수로 추출 → 안정적인 identity → rebuild loop 차단.

## 검증

- 기존 5개 테스트 + 신규 1개 (callCount == 1 검증) = 6개 all pass
- regression test: 픽스 revert 시 fail

Closes #2074