### PR TITLE
docs(mds): purchase history detail + event application review specs + MinglitTimeline

### DIFF
--- a/apps/mds/docs/public/specs/event_application_review_page.html
+++ b/apps/mds/docs/public/specs/event_application_review_page.html
@@ -1,0 +1,1486 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<title>Spec — EventApplicationReviewPage (app_user · EventApplicationReviewRoute)</title>
+<link rel="stylesheet" href="/specs/_spec.css">
+<style>
+/* ============================================================
+   EventApplicationReviewPage-specific atoms.
+   "ear" prefix = Event Application Review.
+   Timeline stepper · status별 종결 step inline 사유 + CTA.
+   ============================================================ */
+
+.ear-viewport { background: var(--color-surface); position: relative; overflow: hidden; }
+body.dark-mode .ear-viewport { background: var(--color-dark-background); }
+
+/* AppBar — title "심사 상태" */
+.ear-appbar {
+  height: 56px;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-medium);
+  padding: 0 var(--spacing-screen-edge);
+  background: var(--color-surface);
+}
+.ear-appbar__back svg { width: 24px; height: 24px; color: var(--color-text-primary); }
+.ear-appbar h2 {
+  font-size: var(--typography-font-size-app-bar-title);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+body.dark-mode .ear-appbar { background: var(--color-dark-background); }
+body.dark-mode .ear-appbar h2 { color: var(--color-dark-text-primary); }
+
+/* Body (v1.6: top padding 제거 — AppBar 밑 불필요한 여백 제거 · 좌우/하단만 유지) */
+.ear-body {
+  position: absolute;
+  top: 56px; left: 0; right: 0; bottom: 0;
+  overflow-y: auto;
+  scrollbar-width: none;
+  padding: 0 var(--spacing-medium) var(--spacing-medium);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-medium);
+}
+.ear-body::-webkit-scrollbar { display: none; }
+
+/* Card */
+.ear-card {
+  background: var(--color-background);
+  border-radius: var(--radius-card);
+  padding: var(--spacing-medium);
+  box-shadow: 0 2px 8px rgba(31, 41, 55, 0.06);
+  display: flex;
+  flex-direction: column;
+}
+body.dark-mode .ear-card { background: var(--color-dark-surface); }
+
+/* --- Hero card (v1.1 — 부모 detail의 Hero와 동일 디자인 재사용 · v1.6 — tappable → EventDetailPage) --- */
+.ear-hero {
+  cursor: pointer;
+}
+.ear-hero__heading {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-small);
+}
+.ear-hero__heading .ear-hero__title { flex: 1; min-width: 0; }
+.ear-hero__chevron {
+  flex-shrink: 0;
+  color: var(--color-text-secondary);
+  margin-top: 2px;
+}
+.ear-hero__chevron svg { width: 20px; height: 20px; }
+.ear-hero__thumb {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: var(--radius-medium);
+  background: var(--color-surface);
+  display: grid;
+  place-items: center;
+  color: var(--color-text-secondary);
+  overflow: hidden;
+  margin-bottom: var(--spacing-medium);
+}
+.ear-hero__thumb svg { width: 40px; height: 40px; }
+.ear-hero__title {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  line-height: 1.4;
+}
+.ear-hero__meta {
+  font-size: 14px;
+  color: var(--color-text-primary);
+  margin-top: var(--spacing-xsmall);
+}
+.ear-hero__meta--muted { color: var(--color-text-secondary); }
+
+/* --- Section title --- */
+.ear-section__title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin-bottom: var(--spacing-medium);
+}
+
+/* --- Timeline (v1.1: dot/line 정렬 보정 · dot 크기 축소 · step 간 마진 증가) --- */
+.ear-timeline {
+  position: relative;
+  padding-left: 32px; /* dot column 좀 더 넓게 — content 호흡 ↑ */
+}
+.ear-step {
+  position: relative;
+  padding-bottom: var(--spacing-xlarge); /* spacing-large(24) → spacing-xlarge(32) — step 간격 확보 */
+}
+.ear-step:last-child { padding-bottom: 0; }
+
+/* connecting line — dot 중앙 기준으로 정렬 (dot 12px border-box · left -28 → center -22, line width 2 → left -23) */
+.ear-step:not(:last-child)::before {
+  content: '';
+  position: absolute;
+  left: -23px;
+  top: 18px;
+  bottom: -8px;
+  width: 2px;
+  background: var(--color-divider);
+}
+
+/* Dot (border-box로 size 일관 · 작아짐) */
+.ear-step__dot {
+  position: absolute;
+  left: -28px;
+  top: 4px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--color-text-secondary);
+  border: 2px solid var(--color-background);
+  box-sizing: border-box;
+}
+.ear-step--completed .ear-step__dot { background: var(--color-success); }
+.ear-step--active .ear-step__dot {
+  background: var(--color-primary);
+  animation: ear-pulse 1.4s ease-in-out infinite;
+}
+.ear-step--failed .ear-step__dot { background: var(--color-error); }
+.ear-step--cancelled .ear-step__dot { background: var(--color-text-secondary); }
+@keyframes ear-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(0.85); }
+}
+
+/* Step content (v1.3: title + time inline · 가독성 ↑) */
+.ear-step__heading {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--spacing-small);
+}
+.ear-step__title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  line-height: 1.3;
+}
+.ear-step--active .ear-step__title { color: var(--color-primary); }
+.ear-step--failed .ear-step__title { color: var(--color-error); }
+.ear-step__time {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+.ear-step__detail {
+  font-size: 13px;
+  color: var(--color-text-primary);
+  margin-top: var(--spacing-xsmall);
+}
+.ear-step__detail--muted { color: var(--color-text-secondary); }
+
+/* 사유 박스 — 말풍선 톤 (v1.2: 좌측 border 제거 · 빨간색 강조 약화 · 단일 neutral 스타일)
+   라벨 자리에는 "검토자 이름 / 시스템 / 본인" 등 sender가 들어감 — 검토자 라인은 폐기. */
+.ear-step__reason {
+  margin-top: var(--spacing-small);
+  padding: var(--spacing-sm) var(--spacing-medium);
+  background: rgba(31, 41, 55, 0.04);
+  border-radius: 12px;
+  font-size: 13px;
+  color: var(--color-text-primary);
+  line-height: 1.5;
+}
+.ear-step__reason__label {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-text-secondary);
+  display: block;
+  margin-bottom: var(--spacing-xsmall);
+}
+
+/* CTA — 종결 step 바깥 · timeline card 마지막 element로 위치 (v1.2: step 내부 X) */
+.ear-card-cta {
+  display: block;
+  width: 100%;
+  height: 48px;
+  margin-top: var(--spacing-large);
+  border: none;
+  border-radius: var(--radius-button);
+  background: var(--color-primary);
+  color: white;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+/* --- 신청 step 안 collapsible 제출한 정보 영역 (v1.3 — 별도 카드 폐기, timeline 안 통합) ---
+   "신청" step은 항상 제출한 정보 collapsible을 가짐 (snapshotData entry 1개당 답변 + comments).
+   v1.4: 모든 status에서 default 접힘 — 사용자가 명시적으로 펼쳐 봐야 함 (status별 분기 폐기). */
+.ear-step__answers {
+  margin-top: var(--spacing-small);
+}
+.ear-step__answers__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xsmall);
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.ear-step__answers__toggle svg {
+  width: 14px;
+  height: 14px;
+  transition: transform 0.2s;
+}
+.ear-step__answers--expanded .ear-step__answers__toggle svg { transform: rotate(180deg); }
+.ear-step__answers__content {
+  margin-top: var(--spacing-small);
+  padding: var(--spacing-sm) var(--spacing-medium);
+  background: rgba(31, 41, 55, 0.04);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-medium);
+}
+.ear-step__answers--collapsed .ear-step__answers__content { display: none; }
+
+.ear-answer-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xsmall);
+}
+.ear-answer-row__label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--color-text-secondary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.ear-answer-row__value {
+  font-size: 13px;
+  color: var(--color-text-primary);
+  line-height: 1.5;
+}
+.ear-answer-row__photo {
+  margin-top: var(--spacing-xsmall);
+  width: 64px;
+  height: 64px;
+  border-radius: var(--radius-small);
+  background: var(--color-background);
+  display: grid;
+  place-items: center;
+  color: var(--color-text-secondary);
+}
+.ear-answer-row__photo svg { width: 28px; height: 28px; }
+
+/* 검토자 코멘트 — 답변 content 마지막 row */
+.ear-step__answers__comment {
+  border-top: 1px solid rgba(31, 41, 55, 0.08);
+  padding-top: var(--spacing-small);
+}
+.ear-step__answers__comment__label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--color-text-secondary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  display: block;
+  margin-bottom: var(--spacing-xsmall);
+}
+.ear-step__answers__comment__body {
+  font-size: 13px;
+  color: var(--color-text-primary);
+  line-height: 1.5;
+}
+
+/* Loading / Error */
+.ear-loading, .ear-error {
+  position: absolute;
+  inset: 56px 0 0 0;
+  display: grid;
+  place-items: center;
+}
+.ear-error {
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  padding: 0 var(--spacing-large);
+  justify-content: center;
+}
+.ear-error__icon { color: var(--color-error); }
+.ear-error__icon svg { width: 32px; height: 32px; }
+.ear-error__title {
+  margin-top: var(--spacing-medium);
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+.ear-spinner {
+  width: 36px; height: 36px;
+  border: 3px solid var(--color-divider);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: ear-spin 0.7s linear infinite;
+}
+@keyframes ear-spin { to { transform: rotate(360deg); } }
+</style>
+</head>
+<body>
+
+<div class="toolbar">
+  <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>
+  <label><input type="checkbox" id="dark-toggle"> Dark mode (viewports flip dark)</label>
+</div>
+
+<div class="page">
+
+<header>
+  <h1>Event Application Review</h1>
+</header>
+
+<!-- ============================================================
+     OVERVIEW
+     ============================================================ -->
+<section class="doc">
+  <h2>Overview</h2>
+  <table class="ref">
+    <tbody>
+      <tr>
+        <th style="width: 140px;">Status</th>
+        <td><strong>🚧 디자인중</strong> <em style="color: var(--color-text-secondary);">— PurchaseHistoryDetailPage 심사 상태 row tap 시 push할 자식 spec. Flutter 미구현 (TBD).</em></td>
+      </tr>
+      <tr><th>App</th><td><code>app_user</code></td></tr>
+      <tr><th>Category</th><td>my · payment · review</td></tr>
+      <tr><th>Route / Surface</th><td><code>EventApplicationReviewRoute</code> · widget: <code>EventApplicationReviewPage</code> <em style="color: var(--color-text-secondary);">(TBD)</em></td></tr>
+      <tr><th>Path</th><td><code>/purchase-history/:applicationId/review</code></td></tr>
+      <tr>
+        <th>Hierarchy</th>
+        <td>
+          <strong>Parent</strong>: <a href="/specs/purchase_history_detail_page.html"><code>PurchaseHistoryDetailPage</code></a> <em style="color: var(--color-text-secondary);">(심사 상태 row tap 시 push)</em><br>
+          <strong>Children</strong>: <em>—</em> (terminal — review의 CTA "다시 신청하기"는 외부 — <a href="/specs/event_detail_page.html"><code>EventDetailPage</code></a>로 push, detail에서 신청 흐름 진행)
+        </td>
+      </tr>
+      <tr>
+        <th>Purpose</th>
+        <td>
+          사용자가 자기 신청 1건이 <strong>시간 흐름상 어떻게 진행됐는지</strong>를 timeline으로 확인하고, 종결된 결제(거절/취소/결제 실패)에서는 사유 + 다음 액션(다시 신청하기)으로 연결한다.
+          부모 detail은 "지금 어떤 상태"만 답하고, 이 페이지는 "어떻게 그 상태가 됐나" + "왜 그렇게 됐나"를 답한다. 신청 시 제출한 답변(snapshotData) 스냅샷도 같이 확인 가능.
+        </td>
+      </tr>
+      <tr>
+        <th>User journey</th>
+        <td>
+          <strong>Entry points</strong>: PurchaseHistoryDetail의 ④ 심사 상태 row tap (단일 진입점).<br>
+          <strong>Exit points</strong>: "다시 신청하기" CTA tap → <strong>같은 이벤트 detail page로 push</strong> (모든 case 통일 동작 — detail에서 status 분기 처리). · 뒤로 가기 → PurchaseHistoryDetail로 복귀.
+        </td>
+      </tr>
+      <tr>
+        <th>Background</th>
+        <td>
+          PurchaseHistoryDetail이 정보-과다를 막기 위해 <strong>심층 정보(거절 사유 / 신청 답변 / 검토 시점 / timeline)를 본문에 펴지 않고</strong> 한 뎁스 위임받은 페이지.
+          핵심 가치는 "<strong>시간 흐름 + 사유</strong>" — 사용자가 부모 detail에서 못 보는 유일한 정보. 자동 취소(이벤트 시작 도래 등)도 별도 use case로 빼지 않고 <strong>timeline 마지막 step의 사유</strong>로 통합 표현 (사용자 직접 취소도 같은 step, reason만 다름).
+          제출한 정보(<code>VerificationSubmission.snapshotData</code>)는 timeline의 "신청" step 안 collapsible로 통합 — default 접힘. 사용자가 토글로 펼쳐 봄 (v1.3 통합 + v1.4 default 접힘).
+        </td>
+      </tr>
+      <tr>
+        <th>Frequency</th>
+        <td>거절/취소/심사 중일 때만 의미 있음. 결제 직후 paid/approved 상태에선 진입 빈도 매우 낮음 (timeline이 단순). 신청 1건당 0-1회.</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ============================================================
+     HISTORY
+     ============================================================ -->
+<section class="doc">
+  <h2>History</h2>
+  <p class="intro">이 spec의 주요 변경 이력. 최신 항목 위.</p>
+  <table class="ref">
+    <thead>
+      <tr><th style="width: 110px;">Date</th><th style="width: 80px;">Version</th><th style="width: 120px;">Author</th><th>Changes</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>2026-05-03</td>
+        <td>1.10</td>
+        <td>mark-yun</td>
+        <td>
+          <strong>"다시 신청하기" 동작 명확화</strong> — 이전: 모호한 "wizard 또는 list" 분기. 변경: <strong>모든 status에서 EventDetailRoute push 통일</strong>. 이유: (a) 단일 destination으로 코드/spec 단순, (b) detail이 이벤트 현재 상태(모집 중/종료/만석/가격 변동)를 보여줘 사용자 인지 ↑, (c) detail의 신청 흐름을 review가 재사용 (코드 중복 X), (d) rejected 케이스에서 자격 조건 다시 확인 자연스러움.
+          <strong>Backend 재신청 / 결제 재시도 모델 = Model 1 (history 누적)</strong> — 같은 applicationId 안에서 status 전환 (rejected/cancelled → pending_review · payment_failed → paid) + snapshot_data array에 새 entry append. 새 application 생성하지 않음. 이유: timeline의 핵심 가치(시간 흐름)가 history 분리 시 약해짐. 후속 작업 표에 backend 정책 확인 필요 항목 명시 (status 전환 허용 / DB unique constraint 검토).
+        </td>
+      </tr>
+      <tr>
+        <td>2026-05-03</td>
+        <td>1.9</td>
+        <td>mark-yun</td>
+        <td>
+          <strong>MinglitTimeline 컴포넌트 generic화</strong> — v1.8에서 promote한 컴포넌트가 review-specific이라 더 generic하게 재설계.
+          (a) <code>status: completed/active/failed/cancelled</code> enum (신청 lifecycle 어휘) → <code>tone: success/progress/error/neutral/muted</code> (semantic-neutral) — 어떤 도메인 lifecycle도 매핑 가능.
+          (b) <code>pulsing</code>을 tone과 orthogonal한 별도 prop으로 분리 — review의 active 강조용 시각 효과지만, 어떤 tone과도 결합 가능.
+          (c) <code>time</code> string prop → <code>trailing</code> Widget slot으로 일반화 — 시점/금액/badge/icon 무엇이든.
+          (d) <code>muted</code> tone 신규 — outline only로 미래/대기 step 표현 (review는 미사용, order tracking 등에서 활용).
+          <strong>Review의 lifecycle → tone 매핑 표</strong>를 Sub-anatomy ②에 명시 (completed→success / active→progress+pulsing / failed→error / cancelled→neutral). 다른 use case(정산/배송 등)는 자체 매핑.
+        </td>
+      </tr>
+      <tr>
+        <td>2026-05-03</td>
+        <td>1.8</td>
+        <td>mark-yun</td>
+        <td>
+          <strong>Timeline 패턴을 MinglitTimeline 컴포넌트로 promote</strong> — Sub-anatomy ②의 inline timeline 패턴(dot/line/heading + status enum)을 mds 공용 컴포넌트로 분리. <code>MinglitTimeline</code> + <code>MinglitTimelineStep</code> 작성 (<a href="/components#MinglitTimeline">/components#MinglitTimeline</a>). 다른 use case(정산 진행 / 환불 진행 / 배송 추적 등)에서 재사용 가능.
+          <strong>Page-specific은 children slot으로 주입</strong> — ReasonBox / "제출한 정보" collapsible / 검토자 메모 / "다시 신청하기" CTA는 모두 review-specific이므로 컴포넌트 안에 들어가지 않음. step의 children slot으로 작성 측에서 자유 컨텐츠 주입. 컴포넌트는 dot/line/heading만 책임.
+          <strong>Implementation source 갱신</strong> — 기존 file-private <code>_Timeline</code> / <code>_TimelineStep</code> 표현 → <code>MinglitTimeline</code> + <code>MinglitTimelineStep</code> reference로 변경. mds_core에 widget 신규 추가 필요 (후속 PR).
+        </td>
+      </tr>
+      <tr>
+        <td>2026-05-03</td>
+        <td>1.7</td>
+        <td>mark-yun</td>
+        <td>
+          <strong>Spec internal cleanup pass</strong> — v1.0~v1.6 evolution 과정에서 누락된 stale references 일괄 정리:
+          (a) state summary table의 모든 row를 v1.4(default 접힘) + v1.6(Hero tap) 반영하게 갱신,
+          (b) state 2/3/4/5 mini-table의 사용자 액션·에지케이스·컴포넌트·노트 셀에서 "신청 답변 카드 자동 펼침/접힘" → "제출한 정보 default 접힘 / 토글 펼침" 표현으로 통일,
+          (c) 변형 표(Step 4 결과)의 paid 행을 "신청 완료" terminal → "결제 완료" terminal (step 2개 압축) 으로 정정 — v1.5에서 첫 step "신청"으로 바뀌면서 "신청 완료" terminal과 충돌 해결,
+          (d) approved 행을 "검토자 라인" → "ReasonBox 라벨=검토자 이름 / 본문=환영 메시지" (v1.3 통일 패턴) 으로 정정,
+          (e) Background paragraph / Motion timing / Global edge cases / 접근성 조항에서 "신청 답변 카드" 표현 → "신청 step의 제출한 정보 collapsible"로 일괄 갱신.
+          <strong>Spec ↔ mockup 동기화 확인 완료</strong> — 모든 mockup HTML이 최신 결정사항 반영, spec text와 충돌 없음.
+        </td>
+      </tr>
+      <tr>
+        <td>2026-05-03</td>
+        <td>1.6</td>
+        <td>mark-yun</td>
+        <td>
+          <strong>Hero card tappable</strong> — 카드 전체가 InkWell · onTap → push EventDetailRoute. 이벤트명 옆에 chevron right 한 개로 시각 시그널. 모든 state에서 동일 동작 (Hero는 status에 무관).
+          <strong>Body top padding 제거</strong> — AppBar 바로 아래 불필요한 여백 제거. 첫 카드(Hero)가 AppBar에 더 붙어 시작감 ↑. 좌우 / 하단 padding은 그대로 유지 (spacing-medium).
+        </td>
+      </tr>
+      <tr>
+        <td>2026-05-03</td>
+        <td>1.5</td>
+        <td>mark-yun</td>
+        <td>
+          <strong>State 5 (결제 실패) 첫 step 카피 정정</strong> — "신청 시도" → "신청". 다른 state와 동일 카피로 일관. snapshotData가 backend에 생성됐다면 신청 행위는 완료된 거고, 실패한 건 결제 단계뿐. "시도" prefix는 불필요한 mental gymnastics.
+        </td>
+      </tr>
+      <tr>
+        <td>2026-05-03</td>
+        <td>1.4</td>
+        <td>mark-yun</td>
+        <td>
+          <strong>제출한 정보 collapsible default 접힘 통일</strong> — 기존 status별 분기(pending_review/rejected 자동 펼침 / 그 외 접힘) 폐기. 모든 status / 모든 entry에서 default 접힘. 사용자가 명시적으로 토글 탭해야 펼침. 일관 동작 + 화면 진입 시 노이즈 ↓.
+          <strong>워딩 변경</strong> — "답변 보기/닫기" → "제출한 정보 보기/닫기". "답변"이 Q&amp;A처럼 모호했고, snapshotData가 텍스트 + 이미지 mix이므로 "정보"가 더 포괄적. 시점("제출한")으로 신청 wizard에서 입력한 것임을 명확히. 검토자 메모(같은 카드 내 다른 row)와 의미상 분리.
+        </td>
+      </tr>
+      <tr>
+        <td>2026-05-03</td>
+        <td>1.3</td>
+        <td>mark-yun</td>
+        <td>
+          <strong>신청 답변 카드 폐기 → "신청" step 안 collapsible 통합</strong> — snapshot_data가 submission attempt history array(entry당 신청 시도 1번)이라는 본질에 맞춰, 모든 entry를 timeline의 별도 "신청" step으로 노출. 각 step 안 collapsible content에 그 entry의 data + comments 포함. 별도 신청 답변 카드 삭제 (Sub-anatomy ③ 폐기) → 본문 카드 3 → 2.
+          <strong>step 라벨은 단순 "신청"</strong> (1차/2차 분기 X — 시간순 노출로 자연 구분). 재제출은 entry 추가로 timeline이 자동 확장됨 — entries 사이 result='rejected'가 있으면 synthetic 거절됨 step 삽입.
+          <strong>검토자 코멘트 노출</strong> — entry.comments가 있으면 답변 row 아래 1px divider + "검토자 메모" 라벨로 자연 구분.
+          <strong>step heading inline 변경</strong> — 기존 title 아래 줄 time 별도 → title + time이 한 줄에 inline (flex baseline · gap spacing-small). 메타데이터 가독성 ↑.
+          <strong>심사 진행 중 step의 time 제거</strong> — "진행 중"이라 specific 시점 모호. 카피만 노출.
+          <strong>승인됨 step에도 ReasonBox 적용</strong> — 기존 "검토: ..." 별도 라인을 ReasonBox 라벨/본문 형태로 통일 (검토자 메시지 톤). 별도 .ear-step__reviewer 클래스 폐기.
+        </td>
+      </tr>
+      <tr>
+        <td>2026-05-03</td>
+        <td>1.2</td>
+        <td>mark-yun</td>
+        <td>
+          <strong>ReasonBox 톤 다운 + 말풍선화</strong> — (a) 좌측 3px error border 제거 · (b) bg 빨간색 6% tint → onSurface 4% subtle neutral 단일 스타일 (rejected/cancelled 색 분기 폐기) · (c) radius radius-small(8) → radius-medium(12) softer corners · (d) 라벨 자리에 일반 "사유" 대신 <strong>sender 이름</strong>(검토자 / 시스템 / 본인) — 별도 검토자 라인 폐기 후 흡수.
+          <strong>CTA "다시 신청하기" 위치 변경</strong> — 종결 step 내부 → <strong>timeline card 마지막 element</strong>(step 바깥, 카드 자체의 액션처럼). full-width filled 스타일은 그대로. step 내부 full width가 step의 일부로 안 보였던 이슈 해결.
+          <strong>cancelled 사유 라벨 "시스템" / "본인" 분기</strong> — 자동 취소 = "시스템", 사용자 직접 취소 = "본인". rejected = 검토자 이름. payment_failed = "시스템".
+        </td>
+      </tr>
+      <tr>
+        <td>2026-05-03</td>
+        <td>1.1</td>
+        <td>mark-yun</td>
+        <td>
+          <strong>Hero 디자인 부모 detail과 통일</strong> — compact(이벤트명+일시)에서 풀 hero(thumb 16:9 + 제목 + 일시 + 장소)로 변경. 시각 일관성 우선.
+          <strong>Timeline dot/line 정렬 보정 + dot 크기 축소 + step 간격 증가</strong> — dot 14×14 → 12×12 (border-box), dot ↔ line center 일치 (둘 다 -22 center), step 간 gap spacing-large(24) → spacing-xlarge(32).
+          <strong>Active step copy 변경</strong> — "예상 결과 발표일" 대신 "이벤트 시작 시점까지 심사가 완료되지 않으면 자동 취소되며, 결제 금액은 자동 환불됩니다" — 사용자에게 더 의미 있는 안내.
+          <strong>"다시 신청하기" CTA 스타일 변경</strong> — OutlinedButton(primary border + transparent bg) → <strong>FilledButton</strong>(primary bg + white fg · full width 48px). 부모 detail의 예매 취소 버튼과 같은 시각 무게감.
+          <strong>Cancelled state CTA 제거</strong> — 사용자가 직접 취소했거나 시스템이 자동 취소한 케이스에서 즉각 재신청 prompt가 부자연스럽고, 자동 취소(이벤트 시작 도래)는 같은 이벤트 재신청 자체가 의미 없음. CTA는 rejected / payment_failed에서만 노출.
+          <strong>snapshotData 실제 backend 스키마 확인 결과 반영</strong> — Q&amp;A list가 아니라 submission attempt history array (각 entry: submitted_at / data / comments / result). spec 안 ⚠ 박스로 명시. 재제출 history를 어떻게 표현할지(최근만 vs 전체 vs 재제출 시만)는 다음 iteration 결정 사항.
+        </td>
+      </tr>
+      <tr>
+        <td>2026-05-03</td>
+        <td>1.0</td>
+        <td>mark-yun</td>
+        <td>
+          v1.4 template으로 신규 작성. PurchaseHistoryDetailPage의 심사 상태 row가 push할 자식 spec.
+          IA: Hero(compact) → Timeline card(메인 vertical stepper) → 신청 답변 card(collapsible). Timeline 단계: 신청 → 결제 → [심사 — 자격 심사 있는 이벤트만] → 결과/취소. 종결 step 안에 사유 + 검토자 + CTA "다시 신청하기" inline.
+          7 state 정의: 심사 진행 중 / 승인 완료 / 거절됨 / 취소됨(user/auto 통합) / 결제 실패 / Loading / Error. 자동 취소(이벤트 시작 도래 등)는 별도 state가 아니라 cancelled state의 reason 변형으로 흡수.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- Anchor nav -->
+<nav class="perspective-nav">
+  <a href="#layout"><span class="glyph">🧱</span> Layout</a>
+  <a href="#states"><span class="glyph">🎨</span> States</a>
+  <a href="#global-behavior"><span class="glyph">🔄</span> Global Behavior</a>
+  <a href="#reference"><span class="glyph">📖</span> Reference</a>
+</nav>
+
+<!-- ============================================================
+     LAYOUT
+     ============================================================ -->
+<div class="perspective" id="layout">
+  <div class="perspective__header">
+    <span class="glyph">🧱</span>
+    <h2>Layout</h2>
+    <span class="lede">AppBar + 스크롤 body(<strong>2 카드 — Hero + Timeline</strong>). Hero 카드는 부모 detail과 동일 디자인. 메인 Timeline 카드는 <a href="/components#MinglitTimeline"><code>MinglitTimeline</code></a> 컴포넌트(v1.8 promoted) · "신청" step 안 collapsible로 답변+검토자 메모 통합 (v1.3).</span>
+  </div>
+
+  <section class="doc">
+    <h2>Blueprint &amp; tree</h2>
+    <p class="intro">
+      Scaffold + Material default AppBar (title "심사 상태") + MinglitAsyncValueWidget. data branch: 단일 EventApplication(+ joined VerificationSubmission)을 받아 Hero → Timeline 카드 2개 stack. Sticky CTA 없음 — "다시 신청하기"는 timeline 카드 마지막 element로 inline. v1.3에서 신청 답변 카드 폐기, "신청" step의 collapsible로 통합.
+    </p>
+
+    <div class="layout-grid">
+      <div class="blueprint" style="height: 540px;">
+        <div class="blueprint__region blueprint__region--full"></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:0;left:0;right:0;height:56px;">
+          <span class="blueprint__region-label">① AppBar — back arrow + "심사 상태"</span>
+        </div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:56px;left:16px;right:16px;height:208px;">
+          <span class="blueprint__region-label">② Hero card — thumb 16:9 + 제목/일시/장소 · AppBar 바로 아래(top 0 padding · v1.6)</span>
+        </div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:280px;left:16px;right:16px;height:240px;">
+          <span class="blueprint__region-label">③ Timeline card — vertical stepper · 신청 step 안 답변 collapsible · 종결 step 안 사유 · 카드 마지막 CTA</span>
+        </div>
+        <div class="blueprint__align-marker" style="bottom:8px;right:8px;">scrollable body — sticky CTA 없음</div>
+      </div>
+
+      <div class="layout-tree"><b>Scaffold</b>
+└─ <b>AppBar</b>(<i>title: "심사 상태"</i>)                           ← ①
+└─ <b>MinglitAsyncValueWidget&lt;EventApplication&gt;</b>
+   ├─ loading → <b>MinglitCircularProgressIndicator</b>
+   ├─ error   → <b>_DefaultErrorView</b>
+   └─ data    → <b>SingleChildScrollView</b>(padding: <i>0 / spacing-medium / spacing-medium / spacing-medium</i> · top 0 — v1.6)
+      └─ <b>Column</b>(gap: <i>spacing-medium</i>)
+         ├─ <em>Hero card</em>                                 ← ②
+         └─ <em>Timeline card</em>                             ← ③
+            <em>(신청 step 안 답변 collapsible · 종결 step 안 사유 · 카드 마지막 CTA "다시 신청하기")</em></div>
+    </div>
+
+    <table class="ref" style="margin-top: 16px;">
+      <thead>
+        <tr><th style="width: 60px;">#</th><th style="width: 200px;">Region</th><th style="width: 220px;">Alignment</th><th>Spacing</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>—</td><td>Body padding</td><td>—</td><td>SingleChildScrollView padding: <strong>top 0</strong> (v1.6 — AppBar 바로 아래 첫 카드 시작) · 좌/우 <code>spacing-medium (16px)</code> · bottom <code>spacing-medium (16px)</code></td></tr>
+        <tr><td>①</td><td>AppBar</td><td>title left + auto back arrow</td><td>height: 56 · scaffold gray bg · border-bottom 없음</td></tr>
+        <tr><td>②③</td><td>본문 카드 (Hero + Timeline · v1.3에서 신청 답변 카드 폐기 후 2개)</td><td>full width · vertical stack</td><td>radius: <code>radius-card (16px)</code> · padding all: <code>spacing-medium (16px)</code> · shadow blur 8 offset (0,2) opacity <code>shadowXs (0.06)</code> · 카드 사이 gap <code>spacing-medium (16px)</code></td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Sub-anatomy ① — Hero card (tappable · v1.6)</h2>
+    <p class="intro">
+      <strong>v1.1: 부모 detail의 Hero 디자인 재사용</strong> — thumb 16:9 + 이벤트명 + 일시 + 장소. 부모 detail과 동일 patterns/tokens.
+      <strong>v1.6: 카드 전체가 InkWell tappable → push EventDetailRoute</strong> — 사용자가 "이 신청이 어떤 이벤트였는지" 더 깊이 보고 싶을 때 한 탭으로 이벤트 상세 진입. 시각 시그널은 이벤트명 옆 chevron right 한 개 (오른쪽 끝 정렬). InkWell ripple은 카드 전체에 적용.
+      StatusBadge는 노출하지 않음 (부모 detail의 ② 심사 상태 row가 status indicator 담당, review 페이지는 timeline이 status 표현).
+    </p>
+    <div class="layout-grid">
+      <div class="blueprint" style="height: 200px;">
+        <div class="blueprint__region blueprint__region--full"></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:16px;left:16px;right:16px;height:90px;"><span class="blueprint__region-label">㉠ thumb 16:9 · radius-medium</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:120px;left:16px;right:60px;height:24px;"><span class="blueprint__region-label">㉡ 이벤트명 (titleLarge bold · maxLines 2)</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:120px;right:16px;width:24px;height:24px;"><span class="blueprint__region-label">㉤ ›</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:152px;left:16px;right:16px;height:18px;"><span class="blueprint__region-label">㉢ 일시 (bodyMedium)</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:174px;left:16px;right:16px;height:18px;"><span class="blueprint__region-label">㉣ 장소 (bodyMedium · onSurfaceVariant)</span></div>
+      </div>
+      <div class="layout-tree"><b>InkWell</b>(onTap → push EventDetailRoute · v1.6)
+└─ <b>Container</b>(card chrome)
+   └─ <b>Padding</b>(<code>spacing-medium</code>)
+      └─ <b>Column</b>(crossAxis: start)
+         ├─ <em>thumb</em>                                    ← ㉠
+         ├─ Gap: <code>spacing-medium</code>
+         ├─ <b>Row</b>(crossAxis: start · gap small)
+         │  ├─ <em>이벤트명</em>(flex 1)                       ← ㉡
+         │  └─ <em>chevron right</em> (Icons.chevron_right · 20 · onSurfaceVariant) ← ㉤
+         ├─ Gap: <code>spacing-xsmall</code>
+         ├─ <em>일시</em>                                      ← ㉢
+         └─ <em>장소</em>                                      ← ㉣</div>
+    </div>
+    <table class="ref" style="margin-top: 16px;">
+      <thead><tr><th style="width: 60px;">#</th><th style="width: 180px;">Region</th><th style="width: 220px;">Alignment</th><th>Spacing / tokens</th></tr></thead>
+      <tbody>
+        <tr><td>㉠</td><td>thumb</td><td>full width · 16:9</td><td><code>radius-medium (12px)</code> · 누락 시 placeholder bg <code>color-surface</code></td></tr>
+        <tr><td>㉡</td><td>이벤트명</td><td>start · flex 1 · maxLines 2</td><td>typography <code>titleLarge</code> w700</td></tr>
+        <tr><td>㉤</td><td>chevron right</td><td>flex-shrink 0 · 우측 끝 · 제목 baseline 살짝 위(margin-top 2px)</td><td>20×20 · color <code>color-text-secondary</code> · gap from 제목 <code>spacing-small (8px)</code></td></tr>
+        <tr><td>㉢</td><td>일시</td><td>start</td><td>typography <code>bodyMedium</code></td></tr>
+        <tr><td>㉣</td><td>장소</td><td>start</td><td>typography <code>bodyMedium</code> · color <code>color-text-secondary</code></td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Sub-anatomy ② — Timeline card (메인)</h2>
+    <p class="intro">
+      Vertical stepper. 단계 = 신청 → 결제 → [심사 — 자격 심사 있는 이벤트만 노출] → 결과(승인 / 거절 / 취소). 각 step은 dot + 연결 line + 라벨 + 시점 + (있으면) 추가 detail. <strong>종결 step</strong>에는 사유 박스 + 검토자 + CTA "다시 신청하기"가 inline.
+      <strong>미래 step은 노출하지 않음</strong> — 현재 진행 중인 step까지만 (회색 미래 dot은 wizard 톤이라 review에 부적합). 진행 중 step은 active(primary color + pulsing dot)으로 강조.
+    </p>
+    <div class="layout-grid">
+      <div class="blueprint" style="height: 320px;">
+        <div class="blueprint__region blueprint__region--full"></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:16px;left:16px;right:16px;height:24px;"><span class="blueprint__region-label">㉠ "진행 단계" 섹션 제목</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:56px;left:32px;right:16px;height:60px;"><span class="blueprint__region-label">㉡ Step 1 — 신청 (completed dot · 시점)</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:128px;left:32px;right:16px;height:60px;"><span class="blueprint__region-label">㉢ Step 2 — 결제 (completed dot · 시점 · 금액)</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:200px;left:32px;right:16px;height:60px;"><span class="blueprint__region-label">㉣ Step 3 — 심사 (active dot · 진행 중 · 자격 심사 있는 이벤트)</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:268px;left:32px;right:16px;height:48px; opacity:0.6;"><span class="blueprint__region-label">㉤ Step 4 — 결과 (종결 시 dot + 사유 + CTA)</span></div>
+      </div>
+      <div class="layout-tree"><b>Container</b>(card chrome)
+└─ <b>Padding</b>(<code>spacing-medium</code>)
+   └─ <b>Column</b>(crossAxis: stretch)
+      ├─ <em>"진행 단계"</em>                                  ← ㉠
+      ├─ Gap: <code>spacing-medium</code>
+      ├─ <b>MinglitTimeline</b> (v1.8 mds 컴포넌트 — vertical stepper · dot/line/heading은 컴포넌트 책임 · step 내부 children은 page-specific)
+      │  ├─ <b>Step 신청</b> × <em>snapshot_data.length</em>     ← ㉡ (각 entry당 1개)
+      │  │  ├─ <b>Dot</b>(completed · success · 12×12 border-box)
+      │  │  ├─ <b>Line</b>(아래 step과 연결 · 2px · color-divider)
+      │  │  ├─ <b>Heading row</b> (inline · v1.3)
+      │  │  │  ├─ <b>Text</b>(title "신청" · <code>bodyMedium</code> w600)
+      │  │  │  └─ <b>Text</b>(time = entry.submitted_at · <code>bodySmall</code> onSurfaceVariant)
+      │  │  └─ <b>StepAnswers</b> (collapsible — v1.3 통합)
+      │  │     ├─ <b>ToggleButton</b> "제출한 정보 보기/닫기" + chevron 14 (default 접힘 — v1.4)
+      │  │     └─ <em>if expanded</em>
+      │  │        └─ <b>Container</b>(bg onSurface 4% · radius 12 · padding sm/medium)
+      │  │           ├─ <b>AnswerRow</b> × N (data 항목별 — text / 이미지)
+      │  │           │  ├─ <b>Text</b>(label · <code>labelSmall</code> w700 onSurfaceVariant uppercase)
+      │  │           │  └─ <b>Text</b> 또는 <b>MinglitImage</b>(64×64 radius-small)
+      │  │           └─ <em>if entry.comments.length &gt; 0</em>
+      │  │              └─ <b>CommentRow</b> (위 1px divider)
+      │  │                 ├─ <b>Text</b>("검토자 메모" · labelSmall w700 onSurfaceVariant uppercase)
+      │  │                 └─ <b>Text</b>(comments join · bodySmall onSurface)
+      │  ├─ <b>Step 결제</b>                                   ← ㉢
+      │  │  ├─ <b>Dot</b> + <b>Line</b>
+      │  │  └─ <b>Heading row</b> (inline title + time + amount)
+      │  ├─ <em>entries 사이에 result='rejected'면</em>
+      │  │  └─ <b>Step 거절됨</b> (synthetic — 다음 신청 step과 분기)
+      │  ├─ <em>if 자격 심사 있는 이벤트 + 마지막 entry result null</em>
+      │  │  └─ <b>Step 심사 진행 중</b>                        ← ㉣
+      │  │     ├─ <b>Dot</b>(active · primary · pulsing) + <b>Line</b>
+      │  │     ├─ <b>Heading</b>("심사 진행 중" · primary · <em>time 미노출 · v1.3</em>)
+      │  │     └─ <b>Text</b>(detail · "이벤트 시작까지 자동 환불 안내")
+      │  └─ <em>if 종결 (승인 / 거절 / 취소 / 결제 실패)</em>     ← ㉤
+      │     └─ <b>Step 결과</b> (terminal · last · line 없음)
+      │        ├─ <b>Dot</b>(success / error / neutral 분기)
+      │        ├─ <b>Heading</b>(title + time)
+      │        └─ <em>if 거절 / 취소 / 결제 실패 / 승인</em>
+      │           └─ <b>ReasonBox</b> (말풍선 톤 · v1.2)
+      │              ├─ <b>Text</b>(label = sender — 검토자명 / "시스템" / "본인")
+      │              └─ <b>Text</b>(본문 = 사유 또는 검토자 메시지)
+      └─ <em>if rejected / payment_failed (cancelled X · v1.2)</em>
+         └─ <b>FilledButton</b>("다시 신청하기" · primary · full width 48 · margin-top spacing-large)</div>
+    </div>
+    <table class="ref" style="margin-top: 16px;">
+      <thead><tr><th style="width: 60px;">#</th><th style="width: 180px;">Region</th><th style="width: 220px;">Alignment</th><th>Spacing / tokens</th></tr></thead>
+      <tbody>
+        <tr><td>㉠</td><td>섹션 제목</td><td>start</td><td>typography <code>labelLarge</code> w700</td></tr>
+        <tr><td>㉡㉢㉣㉤</td><td>Timeline step</td><td>start · 좌측 32px(dot 영역) padding</td><td>step 사이 gap <strong><code>spacing-xlarge (32px)</code></strong> (v1.1 — was 24) · dot <strong>12×12</strong> border-box (v1.1 — was 14×14) radius 50% · dot ↔ line 정렬 보정 (dot left -28 · line left -23 · 둘 다 center -22) · line 2px width · line 색 <code>color-divider</code></td></tr>
+        <tr><td>—</td><td>Step title</td><td>start</td><td>typography <code>bodyMedium</code> w600 · color: completed = onSurface · active = <code>color-primary</code> · failed = <code>color-error</code> · cancelled = onSurface</td></tr>
+        <tr><td>—</td><td>Step time</td><td>start</td><td>typography <code>bodySmall</code> · color <code>color-text-secondary</code> · 2px gap from title</td></tr>
+        <tr><td>—</td><td>ReasonBox <em>(말풍선 톤 v1.2)</em></td><td>full width</td><td>padding <code>spacing-sm</code> v + <code>spacing-medium</code> h · radius <strong><code>radius-medium (12px)</code></strong> (softer corners) · <strong>좌측 border 제거</strong> (v1.2) · bg <strong>단일 neutral subtle tint</strong> (onSurface 4% — rejected/cancelled 색 분기 폐기) · 라벨 자리 = <strong>sender</strong> (검토자 이름 / "시스템" / "본인" 등) · 본문 = 사유 텍스트 · 라벨 <code>bodySmall (12px)</code> w700 onSurfaceVariant · 본문 <code>bodySmall (13px)</code> onSurface line-height 1.5 · margin-top <code>spacing-small</code></td></tr>
+        <tr><td>—</td><td>"다시 신청하기" CTA</td><td>full width · 가운데 정렬</td><td><strong>v1.2: timeline card 마지막 element로 이동 (step 내부 X)</strong> — step과 분리되어 카드 액션처럼 인지. FilledButton · height 48 · width 100% · bg <code>color-primary</code> · fg white · border 없음 · radius <code>radius-button (12px)</code> · typography <code>labelLarge</code> w600 · margin-top <code>spacing-large (24px)</code> from timeline. 부모 detail의 예매 취소 버튼과 같은 시각 무게감(forward-looking이라 destructive errorContainer 대신 primary).</td></tr>
+      </tbody>
+    </table>
+
+    <p class="variant-label">신청 lifecycle → MinglitTimelineStep tone 매핑 (review use case)</p>
+    <table class="ref">
+      <thead><tr><th style="width: 180px;">신청 상황</th><th style="width: 140px;">tone</th><th style="width: 100px;">pulsing</th><th>의미 / 사용 시점</th></tr></thead>
+      <tbody>
+        <tr><td><strong>이미 통과한 step</strong> (신청·결제 완료·승인됨)</td><td><code>success</code></td><td>—</td><td>color-success (초록) — 달성/통과된 단계</td></tr>
+        <tr><td><strong>현재 진행 중</strong> (심사 진행 중 / 결제 처리 중)</td><td><code>progress</code></td><td>true</td><td>color-primary + 1.4s pulse — "지금 여기" 강조</td></tr>
+        <tr><td><strong>실패 종결</strong> (결제 실패 / 거절됨)</td><td><code>error</code></td><td>—</td><td>color-error (빨강) — 종결되었으나 실패</td></tr>
+        <tr><td><strong>취소 종결</strong> (사용자 취소 / 자동 취소)</td><td><code>neutral</code></td><td>—</td><td>color-text-secondary — 종결됐으나 강조 안 함</td></tr>
+        <tr><td>(미래 step)</td><td><code>muted</code></td><td>—</td><td>review에서는 미사용 — 현재까지만 노출. order tracking 등 다른 use case에서 활용</td></tr>
+      </tbody>
+    </table>
+    <p class="intro" style="margin-top: 8px;">
+      <strong>note</strong> — <code>tone</code>은 semantic-neutral. review 도메인의 lifecycle을 위 표대로 매핑해서 사용. 다른 use case (정산/배송/알림 등)는 자체 매핑.
+    </p>
+
+    <p class="variant-label">Step 4 결과 — status별 변형</p>
+    <table class="ref">
+      <thead>
+        <tr>
+          <th style="width: 140px;">application.status</th>
+          <th style="width: 100px;">dot 색</th>
+          <th style="width: 140px;">title</th>
+          <th>본문 (사유 박스 / CTA)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>paid (자격 심사 X)</td><td>completed</td><td>마지막 step "결제 완료"</td><td>심사 step skip — 결제 완료가 terminal step. detail "이벤트 당일 체크인하세요" · CTA 없음 · 사실상 step 2개로 압축 (신청 → 결제 완료)</td></tr>
+        <tr><td>approved</td><td>completed</td><td>"승인됨"</td><td>ReasonBox 라벨 = <strong>검토자 이름</strong> (예: "강남 라운지 운영팀") · 본문 = 환영 메시지 (예: "신청 감사합니다. 이벤트 당일 뵙겠습니다.") · CTA 없음 · v1.3 — 별도 검토자 라인 폐기, ReasonBox로 통일</td></tr>
+        <tr><td>pending_review</td><td>active (pulsing)</td><td>"심사 진행 중"</td><td>"이벤트 시작 시점까지 심사가 완료되지 않으면 자동 취소되며, 결제 금액은 자동 환불됩니다." · 마지막 step (terminal · 미완) · CTA 없음 · line 없음 (v1.1 — 예상 발표일 대신 자동 환불 안내로 변경)</td></tr>
+        <tr><td>pending · payment_pending</td><td>active</td><td>"결제 처리 중"</td><td>결제 step에서 active 상태로 멈춤 · 그 위 신청 step은 completed · CTA 없음</td></tr>
+        <tr><td>cancelled (사용자 직접)</td><td>cancelled</td><td>"취소됨"</td><td>ReasonBox 라벨 "<strong>본인</strong>" · 본문 "직접 취소했습니다" 또는 사용자 입력 사유 · <strong>CTA 없음</strong></td></tr>
+        <tr><td>cancelled (자동 — 이벤트 시작 도래)</td><td>cancelled</td><td>"취소됨"</td><td>ReasonBox 라벨 "<strong>시스템</strong>" · 본문 "이벤트 시작 시점에 도달하여 자동 취소되었습니다. 결제 금액은 자동 환불 처리됐어요." · <strong>CTA 없음</strong></td></tr>
+        <tr><td>cancelled (자동 — 심사 지연)</td><td>cancelled</td><td>"취소됨"</td><td>ReasonBox 라벨 "<strong>시스템</strong>" · 본문 "심사가 완료되지 못해 자동 취소되었습니다" · <strong>CTA 없음</strong></td></tr>
+        <tr><td>rejected</td><td>failed</td><td>"거절됨"</td><td>ReasonBox 라벨 = <strong>검토자 이름</strong> (예: "서울 숲 파티 운영팀") · 본문 = 파트너 거절 사유 (<code>rejectionReason</code>) · CTA "다시 신청하기" (timeline card 마지막 element)</td></tr>
+        <tr><td>payment_failed</td><td>failed</td><td>"결제 실패"</td><td>결제 step에서 실패 · 그 위 신청 step만 completed · ReasonBox 라벨 "<strong>시스템</strong>" · 본문 "카드 인증 실패" 등 PG 응답 메시지 · CTA "다시 신청하기"</td></tr>
+      </tbody>
+    </table>
+    <p class="intro" style="margin-top: 12px;">
+      <strong>note</strong> — 자동 취소(이벤트 시작 도래 / 심사 지연 등)는 별도 state로 빼지 않고 cancelled state의 reason 변형으로 통합. 사용자 직접 취소도 같은 step, reason만 다름. 카피는 backend가 setting하는 cancellation_reason 필드(또는 동등) 그대로 노출 — 시스템 사유는 문장 그대로, 사용자 입력 사유는 따옴표로 감쌈.
+    </p>
+  </section>
+
+  <section class="doc">
+    <h2>신청 답변 — Sub-anatomy ② 안 통합 (v1.3)</h2>
+    <p class="intro">
+      <strong>v1.3 변경: 별도 신청 답변 카드 폐기 → "신청" step 안 collapsible로 통합.</strong>
+      이유: snapshotData가 submission entry 단위(각 entry = 1번의 신청 시도)이고, 사용자가 "내가 어떻게 여기까지 왔는지"를 timeline의 시간축 위에서 보는 게 자연. 별도 카드로 따로 두면 두 timeline(메인 진행 단계 + 답변 history)을 머리속에서 join해야 하는 부담.
+    </p>
+    <p class="variant-label">실제 backend 스키마 (v1.1 확인 결과 · v1.3에서 history mode 채택)</p>
+    <pre style="background: var(--color-surface); padding: 12px; border-radius: 4px; font-size: 12px; overflow-x: auto;">snapshot_data: [
+  {
+    submitted_at: "2026-03-15",         // ISO timestamp
+    data: { university: "서울대", ... }, // verification 정의별 자유 key-value
+    comments: [],                       // 검토자가 단 코멘트 array (v1.3: 사용자에게 노출)
+    result: "rejected" | null,          // 그 시도의 결과
+  },
+  // 재제출 시 새 entry append
+]</pre>
+    <p class="intro">
+      <strong>v1.3 채택 결정 사항</strong>:
+      <ul style="margin: var(--spacing-small) 0;">
+        <li><strong>모든 entry 노출</strong> — array의 각 entry는 timeline의 별도 "신청" step으로. 1번 제출한 사용자는 step 1개, 재제출 사용자는 step 여러 개.</li>
+        <li><strong>각 entry의 data + comments</strong>를 그 step의 collapsible 안에 함께 노출. 검토자 메모가 있으면 답변 row 아래에 1px divider + "검토자 메모" 라벨로 구분.</li>
+        <li><strong>step 라벨은 단순히 "신청"</strong> — "1차/2차" 등 분기 안 함 (시간순으로 나열되면 자연스럽게 구분됨).</li>
+        <li><strong>entry 사이의 거절</strong> — 첫 entry result='rejected' + 다음 entry 존재 시, 두 신청 step 사이에 "거절됨" 종결 step 형태로 자동 삽입 (단, 최근 result가 null이면 마지막 step은 active "심사 진행 중").</li>
+        <li><strong>default 접힘 (v1.4)</strong> — 모든 status / 모든 entry에서 default 접힘. 사용자가 명시적으로 "제출한 정보 보기" 토글을 탭해야 펼쳐짐. status별 분기 폐기 — 일관 동작.</li>
+      </ul>
+      <strong>verification field 메타 (key → user-facing label 매핑)</strong>는 <code>Verification</code> 모델에 정의되어 있을 것 — 이벤트별로 항목이 다름. UI는 verification에서 받은 메타 + snapshot_data.data를 join해서 친화적 라벨 노출. backend 스키마 확정 시 동기화 필요 (TBD).
+    </p>
+    <p class="variant-label">data 안 항목 종류별 표시 형태</p>
+    <table class="ref">
+      <thead><tr><th style="width: 200px;">data 안 항목</th><th>표시</th></tr></thead>
+      <tbody>
+        <tr><td>텍스트 값 (자기소개 / 자유 답변 / 직업 등)</td><td>label + 본문 텍스트 (line-height 1.5)</td></tr>
+        <tr><td>이미지 URL (인증 사진)</td><td>label + 64×64 thumbnail (radius-small) · 탭 시 풀스크린 모달 (Phase 2)</td></tr>
+        <tr><td>선택지 (단일 / 다중)</td><td>label + 선택된 옵션 텍스트 (다중이면 쉼표 구분)</td></tr>
+        <tr><td>날짜 / timestamp</td><td>label + "yyyy.MM.dd" 포맷</td></tr>
+        <tr><td><code>comments</code> (검토자 메모)</td><td>data row 아래 divider 1px + "검토자 메모" 라벨(uppercase) + 본문 (배열이 여러 개면 줄바꿈으로 join)</td></tr>
+        <tr><td><code>submitted_at</code></td><td>step의 inline time으로 노출 (heading 옆)</td></tr>
+        <tr><td><code>result</code></td><td>다음 step(거절됨 등)의 존재로 표현. 별도 visual 없음.</td></tr>
+      </tbody>
+    </table>
+  </section>
+</div>
+
+<!-- ============================================================
+     STATES
+     ============================================================ -->
+<div class="perspective" id="states">
+  <div class="perspective__header">
+    <span class="glyph">🎨</span>
+    <h2>States</h2>
+    <span class="lede">7 state. Timeline 종결 step의 dot 색 / 사유 박스 / CTA 노출 / 신청 step 답변 펼침 default로 갈라짐. v1.3에서 신청 답변 카드를 timeline 안 통합. 자동 취소(시스템 사유)는 cancelled state에 reason 변형으로 흡수. 재제출 history는 entry당 step 추가로 자연스럽게 표현.</span>
+  </div>
+
+  <section class="doc">
+    <h3 style="margin-top: 24px;">State summary <small style="font-size:12px;font-weight:400;color:var(--color-text-secondary);">— 7 states</small></h3>
+    <table class="ref">
+      <thead>
+        <tr><th style="width: 200px;">State</th><th style="width: 100px;">Tag</th><th style="width: 200px;">조건</th><th>Key visual differentiator</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><strong>Default · 심사 진행 중</strong></td><td>baseline</td><td>pending_review (또는 pending · payment_pending)</td><td>마지막 step active (pulsing primary dot) · 종결 step 없음 · 제출한 정보 default 접힘</td></tr>
+        <tr><td><strong>Default · 완료 (paid / approved)</strong></td><td>variant</td><td>paid (자격 심사 X · step 2개) 또는 approved (자격 심사 통과 · step 4개)</td><td>모든 step completed · paid 마지막 "결제 완료" + detail("이벤트 당일 체크인") · approved 마지막 "승인됨" + ReasonBox 환영 메시지 · CTA 없음 · 제출한 정보 default 접힘</td></tr>
+        <tr><td><strong>Default · 거절됨</strong></td><td>variant</td><td>rejected</td><td>마지막 step failed (error red dot) · ReasonBox 말풍선 톤 — 라벨 검토자 / 본문 거절 사유 · CTA "다시 신청하기" · 제출한 정보 default 접힘 (검토자 메모도 같이)</td></tr>
+        <tr><td><strong>Default · 취소됨</strong></td><td>variant</td><td>cancelled (user / auto 통합)</td><td>마지막 step cancelled (neutral) · ReasonBox 라벨 "시스템" 또는 "본인" · <strong>CTA 없음 (v1.1)</strong> · 제출한 정보 default 접힘</td></tr>
+        <tr><td><strong>Default · 결제 실패</strong></td><td>variant</td><td>payment_failed</td><td>결제 step에서 failed · timeline 2 steps (신청 → 결제 실패) · ReasonBox 라벨 "시스템" · CTA "다시 신청하기" · 제출한 정보 토글 미렌더 가능 (snapshot 없으면)</td></tr>
+        <tr><td><strong>Loading</strong></td><td>async</td><td>fetch 중</td><td>화면 중앙 spinner</td></tr>
+        <tr><td><strong>Error</strong></td><td>network/server</td><td>로드 실패</td><td>error_outline icon + "오류가 발생했습니다."</td></tr>
+      </tbody>
+    </table>
+
+    <div class="visual-gallery" style="background: var(--color-surface); padding: 16px; border-radius: var(--radius-card); display: flex; flex-direction: column; gap: 16px;">
+
+      <!-- ─── State 1: 심사 진행 중 (baseline) ──────────── -->
+      <table class="ref state-mini is-baseline-tint">
+        <thead><tr><th colspan="3"><strong>Default · 심사 진행 중</strong> 🎯 <small>baseline · pending_review · 마지막 step active · 제출한 정보 default 접힘 (v1.4)</small></th></tr></thead>
+        <tbody>
+          <tr>
+            <td class="state-mini__mock" rowspan="6">
+              <div class="viewport ear-viewport">
+                <div class="ear-appbar">
+                  <span class="ear-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg></span>
+                  <h2>심사 상태</h2>
+                </div>
+                <div class="ear-body">
+                  <div class="ear-card ear-hero">
+                    <div class="ear-hero__thumb">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><circle cx="12" cy="15" r="2"/></svg>
+                    </div>
+                    <div class="ear-hero__heading">
+                      <span class="ear-hero__title">스피드 데이팅 · 강남 라운지</span>
+                      <span class="ear-hero__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></span>
+                    </div>
+                    <div class="ear-hero__meta">5월 4일 (월) 20:00</div>
+                    <div class="ear-hero__meta ear-hero__meta--muted">강남역 5번 출구 · 라운지B</div>
+                  </div>
+                  <div class="ear-card">
+                    <div class="ear-section__title">진행 단계</div>
+                    <div class="ear-timeline">
+                      <div class="ear-step ear-step--completed">
+                        <span class="ear-step__dot"></span>
+                        <div class="ear-step__heading">
+                          <span class="ear-step__title">신청</span>
+                          <span class="ear-step__time">2026.04.10 19:42</span>
+                        </div>
+                        <div class="ear-step__answers ear-step__answers--collapsed">
+                          <button class="ear-step__answers__toggle">
+                            제출한 정보 보기
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+                          </button>
+                          <div class="ear-step__answers__content">
+                            <div class="ear-answer-row">
+                              <span class="ear-answer-row__label">자기소개</span>
+                              <span class="ear-answer-row__value">안녕하세요, 강남에서 일하는 30대 디자이너입니다.</span>
+                            </div>
+                            <div class="ear-answer-row">
+                              <span class="ear-answer-row__label">MBTI</span>
+                              <span class="ear-answer-row__value">ENFP</span>
+                            </div>
+                            <div class="ear-answer-row">
+                              <span class="ear-answer-row__label">프로필 사진</span>
+                              <div class="ear-answer-row__photo"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="9" r="3"/><path d="M5 20c0-3.5 3-6 7-6s7 2.5 7 6"/></svg></div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="ear-step ear-step--completed">
+                        <span class="ear-step__dot"></span>
+                        <div class="ear-step__heading">
+                          <span class="ear-step__title">결제 완료</span>
+                          <span class="ear-step__time">2026.04.10 19:43 · 25,000원</span>
+                        </div>
+                      </div>
+                      <div class="ear-step ear-step--active">
+                        <span class="ear-step__dot"></span>
+                        <div class="ear-step__heading">
+                          <span class="ear-step__title">심사 진행 중</span>
+                        </div>
+                        <div class="ear-step__detail ear-step__detail--muted">이벤트 시작 시점까지 심사가 완료되지 않으면 자동 취소되며, 결제 금액은 자동 환불됩니다.</div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <span class="callout" style="top:88px;left:24px;">ⓐ</span>
+                <span class="callout" style="top:172px;left:24px;">ⓑ</span>
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>결제 완료, 파트너가 신청을 검토 중인 상태. 자격 심사가 있는 이벤트.</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">사용자 액션</td>
+            <td>
+              ① <strong>Hero card tap</strong> → EventDetailRoute push (이벤트 상세) — v1.6<br>
+              ② <strong>"제출한 정보 보기" 토글 탭</strong> (신청 step 안) → collapsible 펼침/닫힘 (default 접힘 — v1.4)<br>
+              ③ <strong>이미지 답변 thumbnail 탭</strong> → 풀스크린 미리보기 (Phase 2 — 현재는 무반응)<br>
+              ④ <strong>스크롤</strong> → timeline 끝까지<br>
+              ⑤ <strong>뒤로 가기</strong> → 부모 detail로 복귀
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">에지케이스</td>
+            <td>
+              · <strong>자동 환불 안내 카피</strong> — "이벤트 시작 시점까지 심사가 완료되지 않으면 자동 취소되며, 결제 금액은 자동 환불됩니다". 이벤트 시작 시점 정보가 없으면 "(검토 중)" fallback<br>
+              · <strong>심사 진행 중 step에 시간 미노출</strong> (v1.3) — "진행 중"이라 specific 시점이 모호 · 카피만 노출<br>
+              · <strong>snapshotData 비어 있음</strong> — 신청 step의 답변 toggle 자체 미렌더 (자격 심사 없는 이벤트)<br>
+              · <strong>답변에 이미지 + 텍스트 mix</strong> — 항목별 row 분리 노출, 순서는 backend가 보낸 array 순서대로<br>
+              · <strong>재제출 case</strong> — snapshot_data array에 entry가 2개 이상이면, 각 entry당 "신청" step 추가 + 그 사이 거절됨 step 삽입 (v1.3 — 모든 history를 timeline에 노출)
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">컴포넌트</td>
+            <td>
+              · <code>Scaffold</code> + Material <code>AppBar(title: '심사 상태')</code><br>
+              · <a href="/components#MinglitAsyncValueWidget"><code>MinglitAsyncValueWidget&lt;EventApplication&gt;</code></a><br>
+              · <code>SingleChildScrollView</code> + <code>Column</code> (<strong>2 카드 stack — Hero + Timeline</strong>) — v1.3에서 신청 답변 카드 폐기, timeline 안 통합<br>
+              · Hero card: thumb + 이벤트명 + 일시 + 장소<br>
+              · Timeline card: <a href="/components#MinglitTimeline"><code>MinglitTimeline</code></a> + <code>MinglitTimelineStep</code> (v1.8 — mds 컴포넌트로 promoted) + step 내부 children에 <code>_StepAnswers</code>(collapsible · <code>AnimatedSize</code>) + <code>_AnswerRow</code> × N + 검토자 코멘트 row 주입<br>
+              · <code>MinglitImage</code> (이미지 답변 thumbnail)
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">토큰</td>
+            <td>
+              · color: <code>color-surface</code> (scaffold + AppBar bg), <code>color-background</code> (카드 bg), <code>color-text-primary</code> (제목 / 답변 본문), <code>color-text-secondary</code> (일시 / 라벨 / 시점 / chevron / muted detail), <code>color-divider</code> (timeline line · KeyValueRow separator), <code>color-success</code> (completed dot), <code>color-primary</code> (active dot · pulse), <code>color-error</code> (failed dot — state 3·5에서)<br>
+              · radius: <code>radius-card (16px)</code>, <code>radius-small (8px)</code> (이미지 thumbnail · ReasonBox), 50% (timeline dot)<br>
+              · spacing: <code>spacing-medium (16px)</code> (body padding 좌/우/하단 · top은 0 v1.6 · card padding · 카드 gap · 섹션 제목→내용), <code>spacing-large (24px)</code> (timeline step 간 gap), <code>spacing-sm (12px)</code> (ReasonBox padding · timeline dot column width 32-2*dot edge), <code>spacing-small (8px)</code> (step title↔time gap inline · step→reason gap · Hero 제목↔chevron gap), <code>spacing-xsmall (4px)</code> (이미지 라벨 gap · 답변 row label↔value gap)<br>
+              · animation: <code>MinglitAnimation.fast (200ms)</code> (chevron rotate · expand/collapse), 1.4s (active dot pulse — 토큰 미정의 · ms 직접 명시)<br>
+              · typography: appBarTitle (18/600), titleMedium bold (Hero 이벤트명), labelLarge bold (섹션 제목 · 신청 답변 헤더), bodyMedium w600 (step title), bodyMedium (답변 본문), bodySmall (Hero 일시 · step time · detail muted), labelSmall bold uppercase (ReasonBox 라벨 · 답변 라벨)
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">노트</td>
+            <td>📝 ⓐ Hero (tappable v1.6 — chevron right) · ⓑ Timeline (제출한 정보 default 접힘 v1.4 · 사용자가 토글로 펼침). v1.3에서 신청 답변 카드를 timeline 안 통합. v1.4에서 default 접힘 통일.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <!-- ─── State 2: 완료 (paid / approved) ──────────── -->
+      <table class="ref state-mini">
+        <thead><tr><th colspan="3"><strong>Default · 완료 (paid / approved)</strong> <small>모든 step completed · CTA 없음 · 제출한 정보 default 접힘</small></th></tr></thead>
+        <tbody>
+          <tr>
+            <td class="state-mini__mock" rowspan="6">
+              <div class="viewport ear-viewport">
+                <div class="ear-appbar">
+                  <span class="ear-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg></span>
+                  <h2>심사 상태</h2>
+                </div>
+                <div class="ear-body">
+                  <div class="ear-card ear-hero">
+                    <div class="ear-hero__thumb">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><circle cx="12" cy="15" r="2"/></svg>
+                    </div>
+                    <div class="ear-hero__heading">
+                      <span class="ear-hero__title">스피드 데이팅 · 강남 라운지</span>
+                      <span class="ear-hero__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></span>
+                    </div>
+                    <div class="ear-hero__meta">5월 4일 (월) 20:00</div>
+                    <div class="ear-hero__meta ear-hero__meta--muted">강남역 5번 출구 · 라운지B</div>
+                  </div>
+                  <div class="ear-card">
+                    <div class="ear-section__title">진행 단계</div>
+                    <div class="ear-timeline">
+                      <div class="ear-step ear-step--completed">
+                        <span class="ear-step__dot"></span>
+                        <div class="ear-step__heading">
+                          <span class="ear-step__title">신청</span>
+                          <span class="ear-step__time">2026.04.10 19:42</span>
+                        </div>
+                        <div class="ear-step__answers ear-step__answers--collapsed">
+                          <button class="ear-step__answers__toggle">
+                            제출한 정보 보기
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+                          </button>
+                        </div>
+                      </div>
+                      <div class="ear-step ear-step--completed">
+                        <span class="ear-step__dot"></span>
+                        <div class="ear-step__heading">
+                          <span class="ear-step__title">결제 완료</span>
+                          <span class="ear-step__time">2026.04.10 19:43 · 25,000원</span>
+                        </div>
+                      </div>
+                      <div class="ear-step ear-step--completed">
+                        <span class="ear-step__dot"></span>
+                        <div class="ear-step__heading">
+                          <span class="ear-step__title">승인됨</span>
+                          <span class="ear-step__time">2026.04.13 11:08</span>
+                        </div>
+                        <div class="ear-step__reason">
+                          <span class="ear-step__reason__label">강남 라운지 운영팀</span>
+                          신청 감사합니다. 이벤트 당일 뵙겠습니다.
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>↔ 신청·결제·심사 모두 통과한 happy path. paid(자격 심사 X)와 approved(자격 심사 O 통과)로 분기되지만 시각적으로는 거의 동일 — title만 "신청 완료" / "승인됨" 다름.</td>
+          </tr>
+          <tr><td class="state-mini__aspect">사용자 액션</td><td>동일: Hero tap / 신청 step의 "제출한 정보 보기" 토글 / 뒤로 가기<br>− 종결 step CTA 없음 (이미 통과 — "다시 신청하기" 미렌더)</td></tr>
+          <tr><td class="state-mini__aspect">에지케이스</td><td>· paid (자격 심사 X)에서 step 2개로 압축 — "심사" step skip · 마지막 step "결제 완료"가 terminal (detail "이벤트 당일 체크인하세요")<br>· approved에서 마지막 step "승인됨" + ReasonBox(라벨 검토자 이름, 본문 환영 메시지) 노출. paid에서는 ReasonBox 미렌더 (검토자 개념 없음)</td></tr>
+          <tr><td class="state-mini__aspect">컴포넌트</td><td>↔ 마지막 step dot: active → completed (success)<br>− CTA "다시 신청하기" 미렌더<br>+ <strong>ReasonBox</strong> (approved일 때 — 라벨 검토자 / 본문 환영 메시지)</td></tr>
+          <tr><td class="state-mini__aspect">토큰</td><td>− <code>color-primary</code> · pulse animation 미사용<br>동일: 그 외</td></tr>
+          <tr><td class="state-mini__aspect">노트</td><td>📝 paid·approved에서 사용자 진입 빈도 낮음 (timeline이 단순). 다만 "내가 뭘 적어 냈지?" 확인하러 들어오는 케이스를 위해 제출한 정보 collapsible은 살아있음 (default 접힘 · 토글로 펼침).</td></tr>
+        </tbody>
+      </table>
+
+      <!-- ─── State 3: 거절됨 ──────────── -->
+      <table class="ref state-mini">
+        <thead><tr><th colspan="3"><strong>Default · 거절됨</strong> <small>rejected · 마지막 step failed (error) · ReasonBox + 검토자 + CTA · 제출한 정보 default 접힘 (v1.4)</small></th></tr></thead>
+        <tbody>
+          <tr>
+            <td class="state-mini__mock" rowspan="6">
+              <div class="viewport ear-viewport">
+                <div class="ear-appbar">
+                  <span class="ear-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg></span>
+                  <h2>심사 상태</h2>
+                </div>
+                <div class="ear-body">
+                  <div class="ear-card ear-hero">
+                    <div class="ear-hero__thumb">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><circle cx="12" cy="15" r="2"/></svg>
+                    </div>
+                    <div class="ear-hero__heading">
+                      <span class="ear-hero__title">봄 가든 파티</span>
+                      <span class="ear-hero__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></span>
+                    </div>
+                    <div class="ear-hero__meta">4월 20일 (일) 18:00</div>
+                    <div class="ear-hero__meta ear-hero__meta--muted">서울숲 가든존</div>
+                  </div>
+                  <div class="ear-card">
+                    <div class="ear-section__title">진행 단계</div>
+                    <div class="ear-timeline">
+                      <div class="ear-step ear-step--completed">
+                        <span class="ear-step__dot"></span>
+                        <div class="ear-step__heading">
+                          <span class="ear-step__title">신청</span>
+                          <span class="ear-step__time">2026.04.10 19:42</span>
+                        </div>
+                        <div class="ear-step__answers ear-step__answers--collapsed">
+                          <button class="ear-step__answers__toggle">
+                            제출한 정보 보기
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+                          </button>
+                          <div class="ear-step__answers__content">
+                            <div class="ear-answer-row">
+                              <span class="ear-answer-row__label">자기소개</span>
+                              <span class="ear-answer-row__value">야외 모임 좋아하는 직장인입니다.</span>
+                            </div>
+                            <div class="ear-answer-row">
+                              <span class="ear-answer-row__label">프로필 사진</span>
+                              <div class="ear-answer-row__photo"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="9" r="3"/><path d="M5 20c0-3.5 3-6 7-6s7 2.5 7 6"/></svg></div>
+                            </div>
+                            <div class="ear-step__answers__comment">
+                              <span class="ear-step__answers__comment__label">검토자 메모</span>
+                              <div class="ear-step__answers__comment__body">사진이 흐려서 본인 확인 어려움</div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="ear-step ear-step--completed">
+                        <span class="ear-step__dot"></span>
+                        <div class="ear-step__heading">
+                          <span class="ear-step__title">결제 완료</span>
+                          <span class="ear-step__time">2026.04.10 19:43 · 15,000원</span>
+                        </div>
+                      </div>
+                      <div class="ear-step ear-step--failed">
+                        <span class="ear-step__dot"></span>
+                        <div class="ear-step__heading">
+                          <span class="ear-step__title">거절됨</span>
+                          <span class="ear-step__time">2026.04.13 11:08</span>
+                        </div>
+                        <div class="ear-step__reason">
+                          <span class="ear-step__reason__label">서울 숲 파티 운영팀</span>
+                          제출하신 프로필 사진의 화질이 낮아 본인 확인이 어렵습니다. 다음 신청 시에는 정면 사진을 부탁드려요.
+                        </div>
+                      </div>
+                    </div>
+                    <button class="ear-card-cta">다시 신청하기</button>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>↔ 파트너가 신청을 거절. 자동 환불도 함께 처리됨 (부모 detail의 State 3 환불 완료와 짝).</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">사용자 액션</td>
+            <td>
+              + <strong>"다시 신청하기" 탭</strong> (timeline 카드 마지막 FilledButton) → <strong>이벤트 detail page push</strong> (status 통일 동작 · v1.10). detail에서 사용자가 신청 버튼 다시 누르면 wizard 진입 — backend는 같은 applicationId의 snapshot_data array에 새 entry append + status 'pending_review' 전환 (Model 1 — history 누적)<br>
+              + <strong>"제출한 정보 보기" 토글 탭</strong> (신청 step 안) → 답변 + 검토자 메모 펼침 — 거절 사유와 비교 가능<br>
+              동일: Hero tap / 뒤로 가기
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">에지케이스</td>
+            <td>
+              · <strong>거절 사유 미설정</strong> — ReasonBox에 "(사유 미기재)" placeholder<br>
+              · <strong>거절 사유가 매우 김</strong> — 줄바꿈 그대로 노출, 카드가 길어짐<br>
+              · <strong>이벤트 종료 후 진입</strong> — detail page에서 모집 종료 상태가 보임 (신청 버튼 disabled). 사용자가 detail에서 다른 이벤트 탐색하거나 뒤로 가기<br>
+              · <strong>검토자 정보 누락</strong> — ReasonBox 라벨이 "(검토자)" 또는 비워둠 — 본문(사유)만 노출
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">컴포넌트</td>
+            <td>
+              + <strong>Step "심사 진행"</strong> (completed · success — 심사가 진행됐다가 거절됨) + <strong>Step "거절됨"</strong> (failed · error)<br>
+              + <strong>ReasonBox 말풍선 톤</strong> (v1.2 — bg 4% subtle neutral · radius 12 · border 없음) — 라벨 = 검토자 이름 / 본문 = 거절 사유<br>
+              + <strong>검토자 메모</strong> (신청 step의 collapsible 안 — entry.comments)<br>
+              + <strong>FilledButton</strong> "다시 신청하기" (primary 채움 · timeline card 마지막 element · v1.6)
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">토큰</td>
+            <td>
+              + <code>color-error</code> (failed dot · ReasonBox border / bg tint · step title)<br>
+              + 6% (ReasonBox bg alpha)<br>
+              + <code>color-primary</code> (CTA 텍스트 + border)<br>
+              동일: 그 외
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">노트</td>
+            <td>📝 거절 사유는 부모 detail에서 미노출이었던 핵심 정보 — 이 페이지의 가장 중요한 가치. ReasonBox 좌측 3px error border가 "이게 핵심" 시그널. CTA OutlinedButton(채우지 않은 형태)을 쓴 이유: 이 페이지의 종결 액션이 destructive 아니라 forward-looking — primary 채워진 ElevatedButton보다 가벼운 위계가 자연.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <!-- ─── State 4: 취소됨 (user / auto 통합) ──────────── -->
+      <table class="ref state-mini">
+        <thead><tr><th colspan="3"><strong>Default · 취소됨</strong> <small>cancelled — user / auto(이벤트 시작 / 심사 지연) 통합 · ReasonBox neutral · CTA</small></th></tr></thead>
+        <tbody>
+          <tr>
+            <td class="state-mini__mock" rowspan="6">
+              <div class="viewport ear-viewport">
+                <div class="ear-appbar">
+                  <span class="ear-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg></span>
+                  <h2>심사 상태</h2>
+                </div>
+                <div class="ear-body">
+                  <div class="ear-card ear-hero">
+                    <div class="ear-hero__thumb">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><circle cx="12" cy="15" r="2"/></svg>
+                    </div>
+                    <div class="ear-hero__heading">
+                      <span class="ear-hero__title">봄 가든 파티</span>
+                      <span class="ear-hero__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></span>
+                    </div>
+                    <div class="ear-hero__meta">4월 20일 (일) 18:00</div>
+                    <div class="ear-hero__meta ear-hero__meta--muted">서울숲 가든존</div>
+                  </div>
+                  <div class="ear-card">
+                    <div class="ear-section__title">진행 단계</div>
+                    <div class="ear-timeline">
+                      <div class="ear-step ear-step--completed">
+                        <span class="ear-step__dot"></span>
+                        <div class="ear-step__heading">
+                          <span class="ear-step__title">신청</span>
+                          <span class="ear-step__time">2026.04.10 19:42</span>
+                        </div>
+                        <div class="ear-step__answers ear-step__answers--collapsed">
+                          <button class="ear-step__answers__toggle">
+                            제출한 정보 보기
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+                          </button>
+                        </div>
+                      </div>
+                      <div class="ear-step ear-step--completed">
+                        <span class="ear-step__dot"></span>
+                        <div class="ear-step__heading">
+                          <span class="ear-step__title">결제 완료</span>
+                          <span class="ear-step__time">2026.04.10 19:43 · 15,000원</span>
+                        </div>
+                      </div>
+                      <div class="ear-step ear-step--cancelled">
+                        <span class="ear-step__dot"></span>
+                        <div class="ear-step__heading">
+                          <span class="ear-step__title">취소됨</span>
+                          <span class="ear-step__time">2026.04.13 11:08</span>
+                        </div>
+                        <div class="ear-step__reason">
+                          <span class="ear-step__reason__label">시스템</span>
+                          이벤트 시작 시점에 도달하여 자동 취소되었습니다. 결제 금액은 자동 환불 처리됐어요.
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>↔ 사용자가 직접 취소했거나 시스템이 자동 취소(이벤트 시작 도래 / 심사 지연 등)한 상태. 자동 환불 처리도 보통 함께 (부모 detail의 State 3과 짝).</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">사용자 액션</td>
+            <td>
+              − "다시 신청하기" 탭 (CTA 미노출 — v1.1: 사용자가 이미 결정한 액션 직후 즉각 재신청 prompt는 부자연스럽고, 자동 취소 케이스도 같은 이벤트 재신청 의미 X)<br>
+              동일: Hero tap / 신청 step의 "제출한 정보 보기" 토글 / 뒤로 가기
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">에지케이스</td>
+            <td>
+              · <strong>사용자 직접 취소</strong> — 사유 카피: "사용자가 직접 취소했습니다" 또는 사용자 입력 사유 (있으면)<br>
+              · <strong>이벤트 시작 도래 자동 취소</strong> — "이벤트 시작 시점에 도달하여 자동 취소되었습니다. 결제 금액은 자동 환불 처리됐어요."<br>
+              · <strong>심사 지연 자동 취소</strong> — "심사가 완료되지 못해 자동 취소되었습니다."<br>
+              · 카피는 backend가 setting하는 cancellation_reason 필드 그대로 노출 — 시스템 사유는 문장 그대로, 사용자 입력 사유는 따옴표로 감싸 표기 (UI가 구분 어휘 제공)
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">컴포넌트</td>
+            <td>
+              ↔ 마지막 step dot: success → <strong>cancelled (neutral)</strong><br>
+              ↔ ReasonBox 라벨: 검토자 이름 → <strong>"시스템" 또는 "본인"</strong> (자동 vs 사용자 직접 분기)<br>
+              − ReasonBox 색 분기 폐기 (v1.2 — 단일 neutral 스타일)<br>
+              − CTA "다시 신청하기" (v1.1 — cancelled에서는 미렌더)
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">토큰</td>
+            <td>
+              ↔ ReasonBox color: <code>color-error</code> → <code>color-text-secondary</code> (border + bg tint)<br>
+              ↔ 마지막 step title color: error → onSurface (cancelled는 강조 없음)<br>
+              − pulse animation 미사용
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">노트</td>
+            <td>📝 자동 취소를 별도 state로 빼지 않은 게 핵심 결정. user/system 통합한 "취소됨" 단일 state + reason 변형으로 처리. 사용자에게 "왜 취소됐는지"가 명확하면 충분 — 시스템/사용자 출처는 카피 어휘로 자연스럽게 구분 (예: "자동 취소되었습니다" vs "직접 취소했습니다").</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <!-- ─── State 5: 결제 실패 ──────────── -->
+      <table class="ref state-mini">
+        <thead><tr><th colspan="3"><strong>Default · 결제 실패</strong> <small>payment_failed · 결제 step에서 failed · ReasonBox + CTA</small></th></tr></thead>
+        <tbody>
+          <tr>
+            <td class="state-mini__mock" rowspan="6">
+              <div class="viewport ear-viewport">
+                <div class="ear-appbar">
+                  <span class="ear-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg></span>
+                  <h2>심사 상태</h2>
+                </div>
+                <div class="ear-body">
+                  <div class="ear-card ear-hero">
+                    <div class="ear-hero__thumb">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><circle cx="12" cy="15" r="2"/></svg>
+                    </div>
+                    <div class="ear-hero__heading">
+                      <span class="ear-hero__title">봄 가든 파티</span>
+                      <span class="ear-hero__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></span>
+                    </div>
+                    <div class="ear-hero__meta">4월 20일 (일) 18:00</div>
+                    <div class="ear-hero__meta ear-hero__meta--muted">서울숲 가든존</div>
+                  </div>
+                  <div class="ear-card">
+                    <div class="ear-section__title">진행 단계</div>
+                    <div class="ear-timeline">
+                      <div class="ear-step ear-step--completed">
+                        <span class="ear-step__dot"></span>
+                        <div class="ear-step__heading">
+                          <span class="ear-step__title">신청</span>
+                          <span class="ear-step__time">2026.04.18 21:14</span>
+                        </div>
+                      </div>
+                      <div class="ear-step ear-step--failed">
+                        <span class="ear-step__dot"></span>
+                        <div class="ear-step__heading">
+                          <span class="ear-step__title">결제 실패</span>
+                          <span class="ear-step__time">2026.04.18 21:14</span>
+                        </div>
+                        <div class="ear-step__reason">
+                          <span class="ear-step__reason__label">시스템</span>
+                          카드 인증에 실패했습니다. 다른 결제 수단으로 다시 시도해주세요.
+                        </div>
+                      </div>
+                    </div>
+                    <button class="ear-card-cta">다시 신청하기</button>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>↔ 결제 자체가 실패한 상태 — 신청은 시도됐으나 결제 처리가 안 됨. 환불 자체 개념 없음 (부모 detail의 State 4와 짝).</td>
+          </tr>
+          <tr><td class="state-mini__aspect">사용자 액션</td><td>+ "다시 신청하기" 탭 (timeline card 마지막) → 이벤트 detail page push (v1.10 통일 동작). detail에서 신청 버튼 → 결제 재시도. backend는 같은 applicationId status 전환 (payment_failed → paid · Model 1)<br>− 신청 step의 "제출한 정보 보기" 토글 미렌더 가능 (snapshotData 비어있을 때)<br>동일: Hero tap / 뒤로 가기</td></tr>
+          <tr><td class="state-mini__aspect">에지케이스</td><td>· timeline step이 2개로 짧음 (신청 → 결제 실패) — 심사 step 도달 못 함<br>· 첫 step title "신청" — 다른 state와 동일 카피로 일관 (snapshotData가 만들어졌다면 신청은 끝났고 결제만 실패)<br>· snapshotData 비어 있으면 신청 step의 "제출한 정보 보기" 토글 자체 미렌더 — 결제 실패 케이스에선 답변 입력 전에 결제 실패할 수도</td></tr>
+          <tr><td class="state-mini__aspect">컴포넌트</td><td>↔ Step 수: 4 → 2 (신청 + 결제 실패)<br>− Step "심사 진행" + Step "결과" 미렌더<br>↔ Step 2(결제) dot: completed → <strong>failed (error)</strong><br>+ ReasonBox 말풍선 톤 (state 3과 동일 스타일 · 라벨 "시스템")<br>+ CTA "다시 신청하기" (timeline 카드 마지막)</td></tr>
+          <tr><td class="state-mini__aspect">토큰</td><td>+ <code>color-error</code> (Step 2 dot · step title)<br>동일: 그 외</td></tr>
+          <tr><td class="state-mini__aspect">노트</td><td>📝 결제 실패는 자격 인증 답변(snapshotData) 입력 전에 발생할 수도 있음. 그 경우 신청 step의 "제출한 정보 보기" 토글 미렌더. 첫 step 카피는 단순히 "신청" — 다른 state와 일관 (v1.5).</td></tr>
+        </tbody>
+      </table>
+
+      <!-- ─── State 6: Loading ──────────── -->
+      <table class="ref state-mini">
+        <thead><tr><th colspan="3"><strong>Loading</strong> <small>async fetch 진행 중</small></th></tr></thead>
+        <tbody>
+          <tr>
+            <td class="state-mini__mock" rowspan="6">
+              <div class="viewport ear-viewport">
+                <div class="ear-appbar">
+                  <span class="ear-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg></span>
+                  <h2>심사 상태</h2>
+                </div>
+                <div class="ear-loading"><div class="ear-spinner"></div></div>
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>화면 진입 직후 application + submission 정보를 불러오는 중. 부모 detail에서 이미 application을 갖고 진입하므로 보통 거의 발생 안 함 — deep-link 진입 시만.</td>
+          </tr>
+          <tr><td class="state-mini__aspect">사용자 액션</td><td>↔ 모든 액션 무반응<br>동일: 뒤로 → 부모 detail로 복귀</td></tr>
+          <tr><td class="state-mini__aspect">에지케이스</td><td>· 네트워크 느릴 때 spinner 길게 노출<br>· 토큰 만료 시 자동으로 error 화면으로 전환</td></tr>
+          <tr><td class="state-mini__aspect">컴포넌트</td><td>↔ 모든 카드 → <code>MinglitCircularProgressIndicator</code> · 화면 중앙</td></tr>
+          <tr><td class="state-mini__aspect">토큰</td><td>− 카드 토큰 모두 미사용<br>+ <code>color-primary</code> (spinner)</td></tr>
+          <tr><td class="state-mini__aspect">노트</td><td>📝 부모 detail에서 객체 함께 push하면 즉시 default state. Loading은 deep-link에서만.</td></tr>
+        </tbody>
+      </table>
+
+      <!-- ─── State 7: Error ──────────── -->
+      <table class="ref state-mini">
+        <thead><tr><th colspan="3"><strong>Error</strong> <small>fetch 실패 — 네트워크 / RLS / 서버</small></th></tr></thead>
+        <tbody>
+          <tr>
+            <td class="state-mini__mock" rowspan="6">
+              <div class="viewport ear-viewport">
+                <div class="ear-appbar">
+                  <span class="ear-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg></span>
+                  <h2>심사 상태</h2>
+                </div>
+                <div class="ear-error">
+                  <div class="ear-error__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="13"/><circle cx="12" cy="16.5" r="0.7" fill="currentColor"/></svg></div>
+                  <div class="ear-error__title">오류가 발생했습니다.</div>
+                </div>
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>↔ 네트워크 / 권한 / 서버 오류로 application + submission을 받아오지 못함.</td>
+          </tr>
+          <tr><td class="state-mini__aspect">사용자 액션</td><td>− 모든 카드/버튼 액션 없음<br>동일: 뒤로 → 부모 detail로 복귀<br>− 화면 내 재시도 버튼 없음</td></tr>
+          <tr><td class="state-mini__aspect">에지케이스</td><td>· 에러 본문 노출 X<br>· 토큰 만료도 동일 화면</td></tr>
+          <tr><td class="state-mini__aspect">컴포넌트</td><td>↔ 모든 카드 → <code>_DefaultErrorView</code> (Icons.error_outline + Text)</td></tr>
+          <tr><td class="state-mini__aspect">토큰</td><td>+ <code>color-error</code> (icon)<br>+ <code>color-text-primary</code> (title)<br>+ spacing: <code>spacing-large</code> · <code>spacing-medium</code></td></tr>
+          <tr><td class="state-mini__aspect">노트</td><td>📝 화면 내 재시도 CTA 없음 (Phase 2). 부모 detail spec과 동일 패턴.</td></tr>
+        </tbody>
+      </table>
+
+    </div>
+  </section>
+</div>
+
+<!-- ============================================================
+     GLOBAL BEHAVIOR
+     ============================================================ -->
+<div class="perspective" id="global-behavior">
+  <div class="perspective__header">
+    <span class="glyph">🔄</span>
+    <h2>Global Behavior</h2>
+    <span class="lede">cross-cutting — 모든 state에 적용되는 액션, motion, 글로벌 에지케이스.</span>
+  </div>
+
+  <section class="doc">
+    <h2>Cross-cutting interactions</h2>
+    <table class="ref">
+      <thead><tr><th style="width: 220px;">사용자 액션</th><th>화면에 보이는 결과</th></tr></thead>
+      <tbody>
+        <tr><td>뒤로 가기</td><td>부모 PurchaseHistoryDetailPage로 복귀.</td></tr>
+        <tr><td>다크 모드 토글</td><td>scaffold / 카드 / dot / ReasonBox 모두 dark 토큰으로 swap. dot success/error/primary는 light/dark colorset 자동 대응.</td></tr>
+        <tr><td>버튼 / row tap haptic</td><td>InkWell ripple + Material default haptic light. 카드 본체 자체는 tap 액션 없음 — 신청 답변 헤더, 종결 step CTA만 액션.</td></tr>
+        <tr><td>풀-다운 새로고침</td><td><strong>구현 안 함</strong> — review는 본질적으로 historical view. 갱신은 부모 detail로 돌아갔다 다시 진입.</td></tr>
+        <tr><td>부모 detail → 진입</td><td>extra: application + submission 함께 push 권장. id만으로 deep-link도 허용 — 이때 Loading.</td></tr>
+        <tr><td>"다시 신청하기" tap (v1.10)</td><td><strong>이벤트 detail page로 push</strong> (모든 status에서 통일 동작 — rejected / payment_failed). detail이 이벤트 현재 상태(모집 중/종료/만석)를 보여주고 사용자가 detail의 신청 버튼 → wizard 또는 결제 재시도. backend 측은 <strong>Model 1 — 같은 applicationId 안 status 전환 + snapshot_data array append</strong> (history 누적). 새 application 생성 X.</td></tr>
+        <tr><td>Hero card tap (v1.6)</td><td>EventDetailRoute로 push — 이벤트 상세 페이지로 이동. 모든 state에서 동일 동작 (Hero card 자체는 status에 무관). 이벤트가 삭제됐으면 EventDetailPage가 ErrorView 표시 (별도 fallback 없음).</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Motion timing</h2>
+    <p class="intro">Source: <code>shared/packages/mds/core/lib/src/theme/minglit_design_tokens.dart</code> → <code>MinglitAnimation</code>.</p>
+    <table class="ref">
+      <thead><tr><th style="width: 240px;">Transition</th><th style="width: 200px;">Token / Duration</th><th>Notes</th></tr></thead>
+      <tbody>
+        <tr><td>부모 detail → review push</td><td><code>MinglitAnimation.fast</code> (200ms)</td><td>GoRouter Material default 좌→우 slide.</td></tr>
+        <tr><td>"제출한 정보" collapsible expand/collapse (신청 step 안)</td><td><code>MinglitAnimation.fast</code> (200ms)</td><td>AnimatedSize 자동 ease + toggle chevron rotate 180°.</td></tr>
+        <tr><td>Active step dot pulse</td><td><em>(unscoped)</em> 1.4s loop</td><td>opacity 1 → 0.5 → 1 + scale 1 → 0.85 → 1. 토큰 미정의 — ms 직접 명시. 현재 단계가 진행 중임을 시각 시그널.</td></tr>
+        <tr><td>"다시 신청하기" tap → 이벤트 detail push</td><td><code>MinglitAnimation.fast</code> (200ms)</td><td>GoRouter default. detail에서 추가 신청 흐름은 EventDetailPage spec 참조.</td></tr>
+        <tr><td>InkWell ripple</td><td><code>MinglitAnimation.micro</code> (100ms)</td><td>Material default ripple.</td></tr>
+        <tr><td>Step dot 색 변경 (status 변동 시)</td><td>cut</td><td>화면 진입 시 한 번만 결정 — 진입 중 status 변경되면 재진입까지 갱신 안 됨.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Global edge cases</h2>
+    <ul class="notes">
+      <li><strong>application + submission 둘 다 fetch 필요</strong> — application은 부모 detail에서 받아온 것 재사용 권장(extra push). submission은 별도 fetch 또는 application과 함께 join. submission 없으면 신청 step의 "제출한 정보 보기" 토글이 미렌더 (timeline은 그대로).</li>
+      <li><strong>자격 심사 없는 이벤트 (submission == null)</strong> — 신청 step의 제출한 정보 토글 미렌더 + timeline의 "심사" step skip → step 2개로 압축 (신청 → 결제 완료, 결제가 terminal).</li>
+      <li><strong>cancellation_reason / rejectionReason 시스템 vs 사용자 입력 구분</strong> — backend가 시스템 사유는 plain text, 사용자 입력 사유는 quoted 또는 별도 flag로 구분. UI는 카피 어휘로 자연스럽게 ("자동 취소되었습니다" vs "직접 취소했습니다") — backend 스키마 확정 시 동기화 필요 (TBD).</li>
+      <li><strong>다크 모드</strong> — 카드 bg → <code>color-dark-surface</code>, scaffold → <code>color-dark-background</code>, ReasonBox bg/border는 dark colorset 알파로 swap.</li>
+      <li><strong>접근성</strong> — Active dot pulse는 시각 단서. screen reader에는 step title이 명확("심사 진행 중", "거절됨", "결제 실패") + reason 본문이 그대로 읽힘. 신청 step의 "제출한 정보 보기" 토글은 <code>aria-expanded</code> 적용 권장. Hero card는 <code>InkWell</code>이라 screen reader가 "버튼 — 이벤트 상세로 이동"으로 읽음.</li>
+      <li><strong>저성능 디바이스</strong> — pulse animation이 부담될 수 있음 — <code>MediaQuery.of(context).disableAnimations</code> 시 pulse 제거하고 정적 dot으로 fallback.</li>
+    </ul>
+  </section>
+</div>
+
+<!-- ============================================================
+     REFERENCE
+     ============================================================ -->
+<div class="perspective" id="reference">
+  <div class="perspective__header">
+    <span class="glyph">📖</span>
+    <h2>Reference</h2>
+    <span class="lede">implementation source + 인접 화면. 🚧 디자인중 — 미존재 항목은 TBD.</span>
+  </div>
+
+  <section class="doc">
+    <h2>Implementation source</h2>
+    <table class="ref">
+      <tbody>
+        <tr><th style="width: 200px;">Widget class</th><td><code>EventApplicationReviewPage</code> · <code>TBD</code></td></tr>
+        <tr><th>File path</th><td><code>apps/app_user/lib/src/features/event/admission/event_application_review_page.dart</code> · <code>TBD</code></td></tr>
+        <tr><th>Controller</th><td>부모 detail의 <code>PurchaseHistoryController</code> 재사용 (단일 application 조회) 또는 별도 <code>EventApplicationReviewController</code> 신규 — submission(VerificationSubmission) join 포함 · <code>TBD</code></td></tr>
+        <tr><th>Route</th><td><code>EventApplicationReviewRoute</code> · path: <code>/purchase-history/:applicationId/review</code> · <code>TBD</code></td></tr>
+        <tr><th>Repository</th><td><code>eventRepositoryProvider.getApplicationById(id)</code> + <code>verificationRepositoryProvider.getSubmissionByApplicationId(id)</code> · <code>TBD</code></td></tr>
+        <tr><th>Async wrapper</th><td><a href="/components#MinglitAsyncValueWidget"><code>MinglitAsyncValueWidget</code></a></td></tr>
+        <tr><th>Timeline 컴포넌트</th><td><a href="/components#MinglitTimeline"><code>MinglitTimeline</code></a> + <code>MinglitTimelineStep</code> (v1.8 promoted) — mds_core에 widget 신규 추가 필요 (TBD). step 내부 컨텐츠는 children slot으로 주입.</td></tr>
+        <tr><th>신청 답변 위젯</th><td>file-private <code>_AnswersCard</code> + <code>_AnswerRow</code> — collapsible (AnimatedSize · ExpansionTile 변형 또는 직접 구현)</td></tr>
+        <tr><th>"다시 신청하기" 라우팅</th><td><code>EventDetailRoute(eventId)</code>로 단일 push (v1.10 통일 동작). detail에서 status 분기 처리.</td></tr>
+        <tr><th>Icons (Material)</th><td><code>arrow_back</code> · <code>error_outline</code> · <code>expand_more</code> (chevron — 답변 카드 toggle) · <code>chevron_right</code> (CTA 화살표)</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>후속 작업 (이 review가 활성되려면 필요한 변경)</h2>
+    <table class="ref">
+      <thead><tr><th style="width: 280px;">변경 항목</th><th>설명</th></tr></thead>
+      <tbody>
+        <tr><td><strong>Flutter — 위젯 / 라우트 신규</strong></td><td><code>EventApplicationReviewPage</code> + <code>EventApplicationReviewRoute</code> 추가 (app_user). 부모 detail의 심사 상태 row tap이 이 라우트로 push.</td></tr>
+        <tr><td><strong>Backend — cancellation_reason 필드 표준화</strong></td><td>EventApplication에 <code>cancellation_reason</code> 컬럼 (또는 동등) 추가 + 시스템 사유 / 사용자 입력 사유 구분 (별도 enum 또는 flag). 현재 모델은 <code>rejectionReason</code>만 있음 — cancelled 케이스의 사유 표현 필드 부재.</td></tr>
+        <tr><td><strong>Backend — review_started_at / reviewedAt 노출</strong></td><td>timeline의 "심사 진행" step time을 표시하려면 검토 시작 시점이 backend 응답에 있어야 함. 현재 <code>VerificationSubmission.reviewedAt</code>은 종료 시점만 — <code>reviewStartedAt</code>(또는 동등) 추가 필요. 또는 application의 <code>updatedAt</code> + 상태 전이 history로 유추.</td></tr>
+        <tr><td><strong>Backend — snapshotData 스키마 확정</strong></td><td>현재 <code>List&lt;dynamic&gt;</code> 자유형 — UI가 라벨/본문/이미지 매핑하려면 typed item structure 필요 (예: <code>{type: 'text'|'image'|'choice', label: string, value: any}</code>).</td></tr>
+        <tr><td><strong>"다시 신청하기" 라우팅 로직</strong></td><td>v1.10에서 <code>EventDetailRoute(eventId)</code> 단일 push로 통일 — detail이 이벤트 현재 상태 + 신청 흐름을 처리. controller는 분기 없이 단순 push.</td></tr>
+        <tr><td><strong>Backend — 재신청 / 결제 재시도 모델 (Model 1)</strong></td><td>같은 applicationId 안에서 status 전환 + snapshot_data array에 새 entry append (history 누적). 검토: (a) rejected / cancelled → pending_review 전환 허용, (b) payment_failed → paid 전환 허용, (c) DB 측 user_id × event_id unique constraint 여부 (있으면 Model 1 강제, 없으면 정책 결정 필요). 새 application 생성 모델(Model 2)은 history 분리되어 timeline의 의미 약해짐 — 채택 X.</td></tr>
+        <tr><td><strong>Spec — 부모 detail의 후속 작업 표 업데이트</strong></td><td><a href="/specs/purchase_history_detail_page.html"><code>PurchaseHistoryDetailPage</code></a>의 후속 작업 표에서 "심사 상태 detail spec 신규" 항목 → 머지됨으로 표시 (이번 spec 머지 후).</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Related screens</h2>
+    <table class="ref">
+      <thead><tr><th style="width: 240px;">Spec</th><th>Relation</th></tr></thead>
+      <tbody>
+        <tr><td><a href="/specs/purchase_history_detail_page.html"><code>PurchaseHistoryDetailPage</code></a></td><td>부모 — 심사 상태 row tap 시 이 review page로 push.</td></tr>
+        <tr><td><a href="/specs/purchase_history_page.html"><code>PurchaseHistoryPage</code></a></td><td>조부 — 리스트 → detail → review 흐름.</td></tr>
+        <tr><td><a href="/specs/event_detail_page.html"><code>EventDetailPage</code></a></td><td>"다시 신청하기" CTA의 단일 push 대상 (v1.10). detail이 이벤트 현재 상태 + 신청 흐름을 통합 처리.</td></tr>
+        <tr><td><a href="/specs/event_application_wizard_page.html"><code>EventApplicationWizardPage</code></a></td><td>EventDetail의 신청 버튼 → 이 wizard로 push (간접). review에서 직접 진입하지 않음.</td></tr>
+        <tr><td><a href="/specs/event_application_detail_page.html"><code>EventApplicationDetailPage</code></a> <em>(app_partner)</em></td><td>대칭 화면 — 파트너가 보는 신청 detail. 같은 application을 다른 시점(파트너→신청자)에서 봄. 거절 사유 작성도 그쪽에서.</td></tr>
+      </tbody>
+    </table>
+  </section>
+</div>
+
+</div>
+
+<script>
+  document.getElementById('spec-toggle').addEventListener('change', (e) => {
+    document.body.classList.toggle('spec-mode', e.target.checked);
+  });
+  document.getElementById('dark-toggle').addEventListener('change', (e) => {
+    document.body.classList.toggle('dark-mode', e.target.checked);
+  });
+</script>
+
+</body>
+</html>

--- a/apps/mds/docs/public/specs/purchase_history_detail_page.html
+++ b/apps/mds/docs/public/specs/purchase_history_detail_page.html
@@ -1,0 +1,1699 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<title>Spec — PurchaseHistoryDetailPage (app_user · PurchaseHistoryDetailRoute)</title>
+<link rel="stylesheet" href="/specs/_spec.css">
+<style>
+/* ============================================================
+   PurchaseHistoryDetailPage-specific atoms.
+   Tokens / chrome / mini-table은 /specs/_spec.css에서 import.
+   ============================================================ */
+
+.phd-viewport { background: var(--color-surface); position: relative; overflow: hidden; }
+body.dark-mode .phd-viewport { background: var(--color-dark-background); }
+
+/* AppBar */
+.phd-appbar {
+  height: 56px;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-medium);
+  padding: 0 var(--spacing-screen-edge);
+  background: var(--color-surface);
+}
+.phd-appbar__back svg { width: 24px; height: 24px; color: var(--color-text-primary); }
+.phd-appbar h2 {
+  font-size: var(--typography-font-size-app-bar-title);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+body.dark-mode .phd-appbar { background: var(--color-dark-background); }
+body.dark-mode .phd-appbar h2 { color: var(--color-dark-text-primary); }
+
+/* Scrollable body */
+.phd-body {
+  position: absolute;
+  top: 56px; left: 0; right: 0; bottom: 0;
+  overflow-y: auto;
+  scrollbar-width: none;
+  padding: var(--spacing-medium);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-medium);
+}
+.phd-body::-webkit-scrollbar { display: none; }
+
+/* Card */
+.phd-card {
+  background: var(--color-background);
+  border-radius: var(--radius-card);
+  padding: var(--spacing-medium);
+  box-shadow: 0 2px 8px rgba(31, 41, 55, 0.06);
+  display: flex;
+  flex-direction: column;
+}
+body.dark-mode .phd-card { background: var(--color-dark-surface); }
+
+/* --- Hero card (StatusBadge 제거됨 v1.2) --- */
+.phd-hero__thumb {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: var(--radius-medium);
+  background: var(--color-surface);
+  display: grid;
+  place-items: center;
+  color: var(--color-text-secondary);
+  overflow: hidden;
+  margin-bottom: var(--spacing-medium);
+}
+.phd-hero__thumb svg { width: 40px; height: 40px; }
+.phd-hero__title {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  line-height: 1.4;
+}
+.phd-hero__meta {
+  font-size: 14px;
+  color: var(--color-text-primary);
+  margin-top: var(--spacing-xsmall);
+}
+.phd-hero__meta--muted { color: var(--color-text-secondary); }
+
+/* StatusBadge */
+.phd-status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--spacing-xsmall) var(--spacing-sm);
+  border-radius: var(--radius-small);
+  font-size: 12px;
+  font-weight: 600;
+}
+.phd-status-badge--success { background: rgba(22, 163, 74, 0.20); color: var(--color-success); }
+.phd-status-badge--warning { background: rgba(245, 158, 11, 0.20); color: var(--color-warning); }
+.phd-status-badge--info    { background: rgba(59, 130, 246, 0.20); color: #3b82f6; }
+.phd-status-badge--neutral { background: rgba(107, 114, 128, 0.20); color: var(--color-text-secondary); }
+.phd-status-badge--error   { background: rgba(239, 68, 68, 0.20); color: var(--color-error); }
+
+/* Section title */
+.phd-section__title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin-bottom: var(--spacing-medium);
+}
+
+/* KeyValueRow */
+.phd-kv {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: var(--spacing-sm) 0;
+  font-size: 14px;
+}
+.phd-kv + .phd-kv { border-top: 1px solid var(--color-divider); }
+.phd-kv__label { color: var(--color-text-secondary); }
+.phd-kv__value { color: var(--color-text-primary); font-weight: 500; }
+.phd-kv__value--strong { font-weight: 700; }
+
+/* 카드 내부 보조 액션 (영수증 / 문의하기) — v1.2: margin-top 제거 + 검정 톤 */
+.phd-card-action {
+  padding-top: var(--spacing-medium);
+  border-top: 1px solid var(--color-divider);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 40px;
+  background: transparent;
+  border-left: none;
+  border-right: none;
+  border-bottom: none;
+  color: var(--color-text-primary);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  width: 100%;
+}
+
+/* --- 파트너 정보 카드 --- */
+.phd-partner-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-medium);
+  cursor: pointer;
+  padding: var(--spacing-xsmall) 0;
+}
+.phd-partner-row__avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--color-surface);
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  color: var(--color-text-secondary);
+  overflow: hidden;
+}
+.phd-partner-row__avatar svg { width: 22px; height: 22px; }
+.phd-partner-row__text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.phd-partner-row__name {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.phd-partner-row__intro {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.phd-partner-row__chevron {
+  flex-shrink: 0;
+  color: var(--color-text-secondary);
+}
+.phd-partner-row__chevron svg { width: 18px; height: 18px; }
+
+/* --- 심사 상태 row card (v1.4: title + subtitle ListTile) --- */
+.phd-listtile {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  gap: var(--spacing-medium);
+}
+.phd-listtile__main {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.phd-listtile__label {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+.phd-listtile__subtitle {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+.phd-listtile__trail {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+  color: var(--color-text-secondary);
+  flex-shrink: 0;
+}
+.phd-listtile__trail svg { width: 18px; height: 18px; flex-shrink: 0; }
+
+/* --- 환불 정책 카드 --- */
+.phd-refund-section + .phd-refund-section,
+.phd-card-cancel + .phd-refund-section {
+  margin-top: var(--spacing-medium);
+  padding-top: var(--spacing-medium);
+  border-top: 1px solid var(--color-divider);
+}
+.phd-refund-section__heading {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-text-secondary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin-bottom: var(--spacing-small);
+}
+.phd-policy-row {
+  display: flex;
+  justify-content: space-between;
+  padding: var(--spacing-xsmall) 0;
+  font-size: 13px;
+}
+.phd-policy-row__label { color: var(--color-text-primary); }
+.phd-policy-row__value { color: var(--color-text-secondary); font-weight: 500; }
+/* v1.3: 정렬 어긋남 방지를 위해 padding/bg 제거 — 그냥 label/value 모두 bold */
+.phd-policy-row--current .phd-policy-row__label,
+.phd-policy-row--current .phd-policy-row__value {
+  font-weight: 700;
+}
+.phd-refund-section__copy {
+  font-size: 13px;
+  color: var(--color-text-primary);
+  line-height: 1.5;
+  margin-bottom: var(--spacing-small);
+}
+.phd-refund-section__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xsmall);
+  margin-top: var(--spacing-xsmall);
+  color: var(--color-primary);
+  font-size: 13px;
+  font-weight: 600;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+/* --- 환불 정책 카드 내 예매 취소 버튼 (sticky BottomCTA 대체 · v1.6) ---
+   카드 마지막 element로 위치. canCancel false일 때 disabled (Material default — 회색).
+   active 상태는 errorContainer tint, disabled는 onSurface 12%/38% 알파. */
+.phd-card-cancel {
+  display: block;
+  width: 100%;
+  height: 48px;
+  margin-top: var(--spacing-medium);
+  border: none;
+  border-radius: var(--radius-button);
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--color-error);
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.phd-card-cancel:disabled,
+.phd-card-cancel--disabled {
+  background: rgba(31, 41, 55, 0.05);
+  color: rgba(31, 41, 55, 0.38);
+  cursor: not-allowed;
+}
+
+/* --- Loading / Error --- */
+.phd-loading, .phd-error {
+  position: absolute;
+  inset: 56px 0 0 0;
+  display: grid;
+  place-items: center;
+}
+.phd-error {
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  padding: 0 var(--spacing-large);
+  justify-content: center;
+}
+.phd-error__icon { color: var(--color-error); }
+.phd-error__icon svg { width: 32px; height: 32px; }
+.phd-error__title {
+  margin-top: var(--spacing-medium);
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+.phd-spinner {
+  width: 36px; height: 36px;
+  border: 3px solid var(--color-divider);
+  border-top-color: var(--color-primary);
+  border-radius: 50%;
+  animation: phd-spin 0.7s linear infinite;
+}
+@keyframes phd-spin { to { transform: rotate(360deg); } }
+
+/* --- Refund confirm dialog --- */
+.phd-dialog-shade {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: grid;
+  place-items: center;
+}
+.phd-dialog {
+  width: 304px;
+  background: var(--color-background);
+  border-radius: var(--radius-card);
+  padding: var(--spacing-large);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+.phd-dialog__title {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+.phd-dialog__event-name {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin-top: var(--spacing-xsmall);
+}
+.phd-dialog__row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  padding: var(--spacing-xsmall) 0;
+}
+.phd-dialog__row span:first-child { color: var(--color-text-secondary); }
+.phd-dialog__row span:last-child { color: var(--color-text-primary); font-weight: 600; }
+.phd-dialog__note {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  margin-top: var(--spacing-xsmall);
+}
+.phd-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-small);
+  margin-top: var(--spacing-medium);
+}
+.phd-dialog__btn {
+  height: 36px;
+  padding: 0 var(--spacing-medium);
+  border-radius: var(--radius-button);
+  font-size: 14px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+}
+.phd-dialog__btn--text { background: transparent; color: var(--color-text-secondary); }
+.phd-dialog__btn--danger {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--color-error);
+}
+</style>
+</head>
+<body>
+
+<div class="toolbar">
+  <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>
+  <label><input type="checkbox" id="dark-toggle"> Dark mode (viewports flip dark)</label>
+</div>
+
+<div class="page">
+
+<header>
+  <h1>Purchase History Detail</h1>
+</header>
+
+<!-- ============================================================
+     OVERVIEW
+     ============================================================ -->
+<section class="doc">
+  <h2>Overview</h2>
+  <table class="ref">
+    <tbody>
+      <tr>
+        <th style="width: 140px;">Status</th>
+        <td><strong>🚧 디자인중</strong> <em style="color: var(--color-text-secondary);">— PurchaseHistoryPage 카드 분리 제안. Flutter 미구현 (TBD).</em></td>
+      </tr>
+      <tr><th>App</th><td><code>app_user</code></td></tr>
+      <tr><th>Category</th><td>my · payment · history</td></tr>
+      <tr><th>Route / Surface</th><td><code>PurchaseHistoryDetailRoute</code> · widget: <code>PurchaseHistoryDetailPage</code> <em style="color: var(--color-text-secondary);">(TBD)</em></td></tr>
+      <tr><th>Path</th><td><code>/purchase-history/:applicationId</code></td></tr>
+      <tr>
+        <th>Hierarchy</th>
+        <td>
+          <strong>Parent</strong>: <a href="/specs/purchase_history_page.html"><code>PurchaseHistoryPage</code></a> <em style="color: var(--color-text-secondary);">(list 카드 tap 시 push)</em><br>
+          <strong>Children</strong>:
+          <a href="/specs/partner_detail_page.html"><code>PartnerDetailPage</code></a> (파트너 정보 row tap),
+          <a href="/specs/event_application_review_page.html"><code>EventApplicationReviewPage</code></a> <em style="color: var(--color-text-secondary);">(가칭 · 후속 spec — 심사 상태 row tap. 거절 사유 / 신청 답변 / 검토 시점)</em>
+        </td>
+      </tr>
+      <tr>
+        <th>Purpose</th>
+        <td>
+          결제 1건의 모든 정보를 한 화면에서 보여주고, "이 결제와 관련된 4가지 외부 진입점"(영수증 · 파트너 · 문의 · 심사 상태)을 모은 뒤 환불 정책 카드 안에서 정책 안내와 같은 자리에 예매 취소 버튼을 둬 환불을 진행한다.
+          이 페이지의 핵심 책임은 <strong>결제 정보 + 환불 정책(플랫폼/파트너 두 갈래) 안내</strong>. 거절 사유·신청 답변 같은 심층 정보는 한 뎁스 더 들어간 심사 상태 detail로 분리.
+        </td>
+      </tr>
+      <tr>
+        <th>User journey</th>
+        <td>
+          <strong>Entry points</strong>: PurchaseHistory 리스트 카드 tap (단일 진입점).<br>
+          <strong>Exit points</strong>: <strong>4가지 outbound</strong> — ① 영수증 (외부 브라우저 · service.iamport.kr) · ② 문의하기 (시스템 dialer/메일앱) · ③ 파트너 detail push · ④ 심사 상태 detail push. 그 외: "예매 취소" tap → MinglitDialog confirm → cancelOrder EF → 성공 시 list로 복귀 · 뒤로 가기 → list로 복귀.
+        </td>
+      </tr>
+      <tr>
+        <th>Background</th>
+        <td>
+          기존 <a href="/specs/purchase_history_page.html"><code>PurchaseHistoryPage</code></a> 카드는 1장이 곧 미니 상세 — 카드마다 errorContainer 빨간 버튼이 박혀 list 전체가 위험 신호로 도배되고, 1장이 짊어진 책임 과다(식별 + 다단계 액션)가 누적된 결과로 분리.
+          이 detail은 정보 과다를 막기 위해 <strong>심층 정보(거절 사유 / 신청 답변)를 본문에 펴지 않고</strong> 심사 상태 detail로 위임. 본문은 결제·환불·관련 페이지 진입에 집중.
+          <strong>환불 정책은 두 갈래</strong> — 플랫폼 환불 정책(정책 단계표 + 카드 내 예매 취소 버튼으로 진행) + 파트너 직접 환불(자동 환불 외 케이스 안내). 두 갈래 모두 단일 카드에 묶음. 파트너 환불 안내 옆에 별도 CTA는 두지 않고, 바로 아래 ⑤ 파트너 정보 카드의 "문의하기"로 일원화(v1.3) — 동일 페이지 안에서 같은 launcher가 두 번 나오는 중복 제거.
+          <strong>심사 상태는 ② 자리</strong>에 배치 — Hero(① 식별)에서 결제 상태(StatusBadge)를 분리해 status는 status 섹션에 모았다. 사용자 인지 흐름: "어떤 이벤트 → 지금 어떤 상태 → 얼마/언제 냈나 → 누구한테 → 환불은 어떻게."
+        </td>
+      </tr>
+      <tr>
+        <th>Frequency</th>
+        <td>리스트에서 1건을 골랐을 때만 — 결제 1건당 0-2회 (영수증 확인 + 환불/문의 결심 시).</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ============================================================
+     HISTORY
+     ============================================================ -->
+<section class="doc">
+  <h2>History</h2>
+  <p class="intro">이 spec의 주요 변경 이력. 최신 항목 위.</p>
+  <table class="ref">
+    <thead>
+      <tr><th style="width: 110px;">Date</th><th style="width: 80px;">Version</th><th style="width: 120px;">Author</th><th>Changes</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>2026-05-03</td>
+        <td>1.8</td>
+        <td>mark-yun</td>
+        <td>
+          <strong>State 4 (결제 실패) 결제 정보 카드 라벨 정정</strong> — "결제 금액" → "결제 시도 금액". 결제 자체가 일어나지 않은 케이스에서 "결제 금액"이라는 표현이 misleading. 이미 적용된 "결제일 → 결제 시도일" 패턴과 동일한 결로 일관 처리.
+        </td>
+      </tr>
+      <tr>
+        <td>2026-05-03</td>
+        <td>1.7</td>
+        <td>mark-yun</td>
+        <td>
+          <strong>예매 취소 버튼 위치 미세 조정</strong> — 환불 정책 카드 안에서 버튼 위치를 "카드 마지막"에서 "플랫폼 정책 ↔ 파트너 직접 환불 사이 (divider 위)"로 이동. 흐름이 "정책 안내 → 액션(버튼) → divider → 자동 환불 외 대안 안내"로 정렬되어 카드 안에서 정보→액션→대안 사이클이 자연스럽게 마무리됨.
+          <strong>파트너 직접 환불 섹션은 항상 노출</strong> — 처음에 disabled일 때만 노출하는 옵션도 검토했으나, active 사용자가 "다른 환불 경로"의 존재를 모를 수 있다는 discoverability 우려로 두 상태 모두 노출 유지.
+        </td>
+      </tr>
+      <tr>
+        <td>2026-05-03</td>
+        <td>1.6</td>
+        <td>mark-yun</td>
+        <td>
+          <strong>예매 취소 버튼을 환불 정책 카드 안으로 이전</strong> — sticky BottomCTA 제거. 카드 마지막 element로 위치(margin-top spacing-medium · height 48 · radius-button). "정책을 본 직후 같은 카드에서 액션" 흐름.
+          <strong>canCancel false면 미렌더가 아니라 disabled로 노출</strong> — Material default disabled tokens (onSurface 5%/38%) 사용해 암묵적 합의 UI 그대로 활용. disabled 버튼이 마지막 단계 highlight 바로 아래 위치해 "왜 안 되는지" self-explain. errorContainer를 유지하면서 opacity만 낮추는 방식은 채택 X (모호한 시그널 회피).
+          <strong>State별 처리</strong> — 1: active / 2: disabled / 3: 카드 swap으로 미렌더 / 4: 카드 미노출로 미렌더 / 5: "신청 취소 안내" 카드 안 동일 패턴(카피만 "신청 취소"). body의 80px bottom padding 제거, sticky CTA 영역 제거 — 화면 밀도 ↑.
+        </td>
+      </tr>
+      <tr>
+        <td>2026-05-03</td>
+        <td>1.5</td>
+        <td>mark-yun</td>
+        <td>
+          <strong>심사 상태 row trail에 RefundBadge 추가</strong> — <code>refundStatus != 'none'</code>일 때 StatusBadge 옆에 두 번째 badge 노출 ("환불 완료" neutral / "환불 처리 중" warning / "환불 실패" error). cancelled / rejected는 backend가 자동으로 'refunded' 동기화 → 두 badge 항상 함께.
+          <strong>State 4를 payment_failed 단독으로 좁힘</strong> — 도메인 가정에 따라 cancelled / rejected는 항상 refundStatus 'refunded'를 동반하므로 State 3(환불 완료)에 통합. State 4는 결제 자체가 실패한 케이스(paymentId 없음, 환불 개념 자체 없음)만 담음. mockup도 결제 실패 예시로 변경.
+          <strong>Sub-anatomy ② status 표 보강</strong> — "함의되는 refundStatus" 컬럼 추가 + RefundBadge 별도 표 + status × refundStatus 조합 가이드 문단 추가.
+        </td>
+      </tr>
+      <tr>
+        <td>2026-05-03</td>
+        <td>1.4</td>
+        <td>mark-yun</td>
+        <td>
+          <strong>심사 상태 row 2-line ListTile로 확장</strong> — 라벨 아래에 subtitle "마지막 업데이트: {relative time}" 추가 (<code>VerificationSubmission.reviewedAt</code> 또는 <code>application.updatedAt</code> 기준 · 방금/N분 전/N시간 전/N일 전/N주 전/yyyy.MM.dd 단계 포맷). 사용자가 detail로 진입하지 않고도 "최근 변동" 시점을 인지.
+          <strong>심사 상태 명세 보강</strong> — Sub-anatomy ②에 8 status 분기마다 "사용자 관점 의미 + 다음 단계" 컬럼 추가. cancelled / rejected는 보통 자동 환불을 동반함을 명시.
+          <strong>환불 완료 카드 → 환불 정보 카드로 통합</strong> — refundStatus 'refunded' 상태에서 결제 정보 카드를 미노출하고, 환불 정책 카드를 "환불 정보" 카드로 swap. 카드 내용을 결제 정보 + 환불 결과 통합(티켓 · 결제 금액 · 환불일 · 환불 비율 · 환불 금액 · 수수료) — 한 카드에서 "원래 얼마 → 얼마 돌려받음" 비교 가능. 영수증 버튼도 그쪽으로 이전.
+        </td>
+      </tr>
+      <tr>
+        <td>2026-05-03</td>
+        <td>1.3</td>
+        <td>mark-yun</td>
+        <td>
+          <strong>환불 정책 카드 정리</strong> — 카피 변경: "환불 정보" → "환불 정책", "플랫폼 자동 환불" → "플랫폼 환불 정책". 현재 단계 highlight를 primary color tint + h-padding(12px) 강조 → <strong>label/value 모두 bold</strong>로 변경 (색·padding 변경 없음 — row 정렬 어긋남 방지).
+          <strong>파트너 환불 CTA 제거</strong> — "파트너 문의하기 →" 버튼 삭제. 파트너 환불 안내는 안내 문구만 남기고, 문의 진입은 ⑤ 파트너 정보 카드의 "문의하기"로 일원화 (동일 launcher 중복 제거).
+          <strong>카드 순서 재배치</strong> — 환불 정책 ↔ 파트너 정보 swap. 새 순서: Hero → 심사 상태 → 결제 정보 → 환불 정책 → 파트너 정보. "이 결제는 환불 어떻게 되는데? 안 되면 → 바로 아래 파트너에게 직접 연락" 자연 흐름.
+        </td>
+      </tr>
+      <tr>
+        <td>2026-05-03</td>
+        <td>1.2</td>
+        <td>mark-yun</td>
+        <td>
+          IA 미세 조정 — <strong>StatusBadge를 Hero에서 심사 상태 row로 이관</strong>. status는 status 섹션에 모음. <strong>심사 상태 row를 ② 자리</strong>로 이동(기존 ④). row 내부 패턴: <code>[심사 상태 · StatusBadge · ›]</code> · "자세히" 텍스트 제거(chevron이 affordance 충분).
+          <strong>보조 액션 톤 다운</strong> — 영수증 / 문의하기 TextButton 색을 <code>color-primary</code>(브랜드) → <code>color-text-primary</code>(검정/짙은 회색)으로. plain TextButton 위계.
+          <strong>여백 정리</strong> — 결제 정보 / 파트너 정보 카드의 보조 액션 row에서 <code>margin-top: spacing-medium</code> 제거. divider가 마지막 row 바로 아래 붙고, 버튼 padding-top만 유지.
+        </td>
+      </tr>
+      <tr>
+        <td>2026-05-03</td>
+        <td>1.1</td>
+        <td>mark-yun</td>
+        <td>
+          IA 재정렬 — <strong>5섹션 + BottomCTA</strong>로 재구성. 파트너 정보 카드 신규(프로필+이름+소개+chevron+문의하기), 심사 상태 row 신규(상태 무관 일관 카피 + chevron · 심사 상태 detail로 push), 환불 정책 카드를 <strong>플랫폼 환불 정책 + 파트너 직접 환불</strong> 두 섹션으로 통합.
+          <strong>canCancel 조건 확장</strong> — 기존 paid/approved만 → paid/approved + pending/pending_review 추가 (파트너 미수락 단계에서도 유저 측 자유 환불 가능). Flutter <code>PurchaseHistoryController.isActiveTicket</code> 변경 필요 (후속 PR).
+          <strong>refundStatus 'refunded' state 신규</strong> — 환불 정책 카드 → 환불 완료 카드(환불일/비율/금액/수수료)로 swap. 거절 사유 안내 박스 제거 (심사 상태 detail로 위임).
+        </td>
+      </tr>
+      <tr>
+        <td>2026-05-02</td>
+        <td>1.0</td>
+        <td>mark-yun</td>
+        <td>v1.4 template으로 신규 작성. PurchaseHistoryPage 카드의 책임 과다(식별 + 결제 상세 + 다단계 액션 + 위험 액션)를 분리하기 위한 detail 화면 초안. Hero / 결제 정보 / 환불 정책 / BottomCTA(예매 취소) 4섹션. 7 state 정의.</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- Anchor nav -->
+<nav class="perspective-nav">
+  <a href="#layout"><span class="glyph">🧱</span> Layout</a>
+  <a href="#states"><span class="glyph">🎨</span> States</a>
+  <a href="#global-behavior"><span class="glyph">🔄</span> Global Behavior</a>
+  <a href="#reference"><span class="glyph">📖</span> Reference</a>
+</nav>
+
+<!-- ============================================================
+     LAYOUT
+     ============================================================ -->
+<div class="perspective" id="layout">
+  <div class="perspective__header">
+    <span class="glyph">🧱</span>
+    <h2>Layout</h2>
+    <span class="lede">AppBar + 스크롤 body(5 카드). 본문 카드 사이 vertical medium(16) gap. 카드는 흰 배경 + radius-card(16) + 약한 drop shadow. 예매 취소 액션은 sticky BottomCTA가 아니라 <strong>환불 정책 카드 안 마지막 element</strong>로 통합 (v1.6 — canCancel false면 disabled).</span>
+  </div>
+
+  <section class="doc">
+    <h2>Blueprint &amp; tree</h2>
+    <p class="intro">
+      Scaffold + Material default AppBar (title "구매 상세") + MinglitAsyncValueWidget. data branch: 단일 EventApplication을 받아 Hero → 심사 상태 → 결제 정보 → 환불 정책 → 파트너 정보 5개 카드를 vertical stack으로 출력. <strong>예매 취소는 환불 정책 카드 안 마지막 element</strong>로 위치 — sticky BottomCTA 없음.
+      <strong>v1.3: 정보 흐름 재정렬</strong> — "이건 어떤 이벤트인가 → 지금 어떤 상태인가 → 얼마/언제 냈나 → 환불은 어떻게 가능한가 → (자동 환불 외) 누구에게 직접 연락하나" 순. 환불 정책이 파트너 정보보다 위에 있어야 "자동 환불 안 되면 → 파트너에 직접 연락" 흐름이 자연스럽게 시선에 걸림.
+      <strong>v1.6: 예매 취소 카드 내 통합</strong> — 환불 정책을 본 직후 같은 카드 안에서 액션 가능. canCancel false일 때 sticky 버튼이 사라지는 게 아니라 <strong>같은 자리에 disabled로 노출</strong> — "왜 안 되는지" 정책 마지막 단계 highlight와 직관적으로 연결됨.
+    </p>
+
+    <div class="layout-grid">
+      <div class="blueprint" style="height: 720px;">
+        <div class="blueprint__region blueprint__region--full"></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:0;left:0;right:0;height:56px;">
+          <span class="blueprint__region-label">① AppBar — back arrow + "구매 상세"</span>
+        </div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:72px;left:16px;right:16px;height:208px;">
+          <span class="blueprint__region-label">② Hero card — thumb 16:9 + 제목/일시/장소</span>
+        </div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:296px;left:16px;right:16px;height:56px;">
+          <span class="blueprint__region-label">③ 심사 상태 row — 라벨 + StatusBadge + chevron</span>
+        </div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:368px;left:16px;right:16px;height:160px;">
+          <span class="blueprint__region-label">④ 결제 정보 card — KeyValueRow × N + 영수증</span>
+        </div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:544px;left:16px;right:16px;height:88px; opacity:0.6;">
+          <span class="blueprint__region-label">⑤ 환불 정책 (예매 취소 포함) · ⑥ 파트너 정보 (스크롤)</span>
+        </div>
+        <div class="blueprint__align-marker" style="bottom:8px;right:8px;">scrollable body — sticky CTA 없음</div>
+      </div>
+
+      <div class="layout-tree"><b>Scaffold</b>
+└─ <b>AppBar</b>(<i>title: "구매 상세"</i>)                           ← ①
+└─ <b>MinglitAsyncValueWidget&lt;EventApplication&gt;</b>
+   ├─ loading → <b>MinglitCircularProgressIndicator</b>
+   ├─ error   → <b>_DefaultErrorView</b>
+   └─ data    → <b>SingleChildScrollView</b>(padding all <i>spacing-medium</i>)
+      └─ <b>Column</b>(gap: <i>spacing-medium</i>)
+         ├─ <em>Hero card</em>                                ← ②
+         ├─ <em>심사 상태 row card</em>                        ← ③
+         ├─ <em>결제 정보 card</em>                            ← ④
+         ├─ <em>환불 정책 card</em> (예매 취소 버튼 포함)       ← ⑤
+         └─ <em>파트너 정보 card</em>                          ← ⑥</div>
+    </div>
+
+    <table class="ref" style="margin-top: 16px;">
+      <thead>
+        <tr><th style="width: 60px;">#</th><th style="width: 200px;">Region</th><th style="width: 220px;">Alignment</th><th>Spacing</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>—</td><td>Body padding</td><td>—</td><td>SingleChildScrollView padding all: <code>spacing-medium (16px)</code> — sticky CTA 없으므로 bottom 추가 padding 불필요 (v1.6)</td></tr>
+        <tr><td>①</td><td>AppBar</td><td>title left + auto back arrow</td><td>height: 56 · scaffold gray bg · border-bottom 없음</td></tr>
+        <tr><td>②③④⑤⑥</td><td>본문 5 카드</td><td>full width · vertical stack</td><td>radius: <code>radius-card (16px)</code> · padding all: <code>spacing-medium (16px)</code> · shadow blur 8 offset (0,2) opacity <code>shadowXs (0.06)</code> · 카드 사이 gap <code>spacing-medium (16px)</code></td></tr>
+        <tr><td>⑤ 내부</td><td>예매 취소 버튼</td><td>full width · 카드 마지막 element</td><td>height 48 · margin-top <code>spacing-medium</code> · radius <code>radius-button (12px)</code> · active: bg <code>color-error 12% tint</code> + fg <code>color-error</code> · disabled: bg <code>onSurface 5%</code> + fg <code>onSurface 38%</code> + cursor not-allowed (Material default)</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Sub-anatomy ① — Hero card</h2>
+    <p class="intro">
+      이벤트 식별 영역. 큰 thumbnail + 제목/일시/장소를 세로로 쌓음. <strong>StatusBadge는 Hero에 두지 않음</strong> — status 시각 indicator는 ③ 심사 상태 row에 모음. 이로써 Hero는 "이건 어떤 이벤트인가?" 한 가지 질문에만 답함.
+    </p>
+    <div class="layout-grid">
+      <div class="blueprint" style="height: 200px;">
+        <div class="blueprint__region blueprint__region--full"></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:16px;left:16px;right:16px;height:90px;"><span class="blueprint__region-label">㉠ thumb 16:9 · radius-medium</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:120px;left:16px;right:16px;height:24px;"><span class="blueprint__region-label">㉡ 이벤트명 (titleLarge bold)</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:152px;left:16px;right:16px;height:18px;"><span class="blueprint__region-label">㉢ 일시 (bodyMedium)</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:174px;left:16px;right:16px;height:18px;"><span class="blueprint__region-label">㉣ 장소 (bodyMedium · onSurfaceVariant)</span></div>
+      </div>
+      <div class="layout-tree"><b>Container</b>(card chrome)
+└─ <b>Padding</b>(<code>spacing-medium</code>)
+   └─ <b>Column</b>(crossAxis: start)
+      ├─ <em>thumb</em>                                       ← ㉠
+      ├─ Gap: <code>spacing-medium</code>
+      ├─ <em>이벤트명</em>                                     ← ㉡
+      ├─ Gap: <code>spacing-xsmall</code>
+      ├─ <em>일시</em>                                         ← ㉢
+      └─ <em>장소</em>                                         ← ㉣</div>
+    </div>
+    <table class="ref" style="margin-top: 16px;">
+      <thead><tr><th style="width: 60px;">#</th><th style="width: 180px;">Region</th><th style="width: 220px;">Alignment</th><th>Spacing / tokens</th></tr></thead>
+      <tbody>
+        <tr><td>㉠</td><td>thumb</td><td>full width · 16:9</td><td><code>radius-medium (12px)</code> · 누락 시 placeholder bg <code>color-surface</code></td></tr>
+        <tr><td>㉡</td><td>이벤트명</td><td>start · maxLines 2</td><td>typography <code>titleLarge</code> w700</td></tr>
+        <tr><td>㉢</td><td>일시</td><td>start</td><td>typography <code>bodyMedium</code></td></tr>
+        <tr><td>㉣</td><td>장소</td><td>start</td><td>typography <code>bodyMedium</code> · color <code>color-text-secondary</code></td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Sub-anatomy ② — 심사 상태 row card</h2>
+    <p class="intro">
+      현재 결제 상태(StatusBadge)와 심사 detail 진입을 단일 row에 묶음. <strong>2-line ListTile</strong> — 위에 라벨 "심사 상태", 아래에 마지막 업데이트 상대 시간(<code>application.updatedAt</code> 또는 <code>VerificationSubmission.reviewedAt</code> 기준 · "방금" / "{N}시간 전" / "{N}일 전" / "{yyyy.MM.dd}"). 라벨은 <strong>status에 따라 분기하지 않음</strong> — 항상 "심사 상태". status별 시각 indicator는 inline StatusBadge로, 심층 정보(거절 사유 / 신청 답변 / 검토 시점)는 한 뎁스 더 들어간 <a href="/specs/event_application_review_page.html"><code>EventApplicationReviewPage</code></a>(가칭)에서.
+      "자세히" 텍스트는 의도적으로 제거 — chevron이 tappable affordance 충분히 전달. <strong>v1.4 추가</strong>: subtitle "마지막 업데이트: ..." — 사용자가 carrier로 진입하지 않고도 신청·심사·환불 처리의 최근 활동 시점을 인지.
+    </p>
+    <div class="layout-grid">
+      <div class="blueprint" style="height: 100px;">
+        <div class="blueprint__region blueprint__region--full"></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:16px;left:16px;width:140px;height:24px;"><span class="blueprint__region-label">㉠ "심사 상태" 라벨</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:42px;left:16px;width:200px;height:18px;"><span class="blueprint__region-label">㉡ 마지막 업데이트 시간</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:24px;right:16px;width:120px;height:24px;"><span class="blueprint__region-label">㉢ StatusBadge + ›</span></div>
+      </div>
+      <div class="layout-tree"><b>Container</b>(card chrome · padding all <code>spacing-medium</code>)
+└─ <b>InkWell</b>(onTap → push EventApplicationReviewRoute)
+   └─ <b>Row</b>(spaceBetween · center crossAxis · gap <code>spacing-medium</code>)
+      ├─ <b>Column</b>(crossAxis: start · gap 2px)
+      │  ├─ <b>Text</b>("심사 상태" · <code>bodyLarge</code> w500)               ← ㉠
+      │  └─ <b>Text</b>("마지막 업데이트: {relative}" · <code>bodySmall</code>)   ← ㉡
+      └─ <b>Row</b>(<code>spacing-small</code> gap · center)                  ← ㉢
+         ├─ <b>StatusBadge</b>(application.status · 8 분기)
+         ├─ <em>if refundStatus != 'none'</em> → <b>RefundBadge</b>(refundStatus)
+         │     <em>("환불 완료" · neutral / "환불 처리 중" · warning / "환불 실패" · error)</em>
+         └─ <b>Icon</b>(Icons.chevron_right · onSurfaceVariant)</div>
+    </div>
+    <table class="ref" style="margin-top: 16px;">
+      <thead><tr><th style="width: 60px;">#</th><th style="width: 180px;">Region</th><th style="width: 220px;">Alignment</th><th>Spacing / tokens</th></tr></thead>
+      <tbody>
+        <tr><td>㉠</td><td>"심사 상태" 라벨</td><td>start</td><td>typography <code>bodyLarge</code> w500 · color <code>color-text-primary</code></td></tr>
+        <tr><td>㉡</td><td>마지막 업데이트 시간</td><td>start</td><td>typography <code>bodySmall</code> · color <code>color-text-secondary</code> · gap 2px (㉠과 사이)</td></tr>
+        <tr><td>㉢</td><td>trail (StatusBadge + chevron)</td><td>center · 사이 gap <code>spacing-small (8px)</code></td><td>StatusBadge 토큰: <code>radius-small (8px)</code> v-padding <code>spacing-xsmall</code> h-padding <code>spacing-sm</code> · chevron 18 onSurfaceVariant · 전체 InkWell ripple</td></tr>
+      </tbody>
+    </table>
+
+    <p class="variant-label">마지막 업데이트 — 데이터 소스 + 상대 시간 포맷</p>
+    <table class="ref">
+      <thead><tr><th style="width: 220px;">조건</th><th>표시</th></tr></thead>
+      <tbody>
+        <tr><td>심사 처리된 적 있음 (<code>VerificationSubmission.reviewedAt</code> 존재)</td><td>reviewedAt 기준 상대 시간</td></tr>
+        <tr><td>심사 처리 전</td><td><code>application.updatedAt</code> 기준 상대 시간 (결제·신청·자동 동기화 등 가장 최근 변경)</td></tr>
+        <tr><td>1분 미만</td><td>"방금"</td></tr>
+        <tr><td>1시간 미만</td><td>"{N}분 전"</td></tr>
+        <tr><td>24시간 미만</td><td>"{N}시간 전"</td></tr>
+        <tr><td>7일 미만</td><td>"{N}일 전"</td></tr>
+        <tr><td>4주 미만</td><td>"{N}주 전"</td></tr>
+        <tr><td>그 이상</td><td>"{yyyy.MM.dd}" (절대 날짜)</td></tr>
+      </tbody>
+    </table>
+
+    <p class="variant-label">StatusBadge — application.status 8 분기 · 함의되는 환불 상태</p>
+    <table class="ref">
+      <thead>
+        <tr>
+          <th style="width: 140px;">application.status</th>
+          <th style="width: 110px;">status badge 라벨 / 색</th>
+          <th style="width: 200px;">함의되는 refundStatus</th>
+          <th style="width: 220px;">사용자 관점 의미</th>
+          <th>다음 단계</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td><code>paid</code></td><td>"결제완료" / success</td><td>'none' (정상) — 환불 badge 없음</td><td>결제 완료, 입장권 확보됨. 자격 심사 없는 이벤트.</td><td>이벤트 당일 체크인. 환불은 환불 정책 카드 내 "예매 취소" 버튼.</td></tr>
+        <tr><td><code>approved</code></td><td>"승인됨" / success</td><td>'none' (정상) — 환불 badge 없음</td><td>파트너가 신청 승인. 결제도 완료.</td><td>이벤트 당일 체크인.</td></tr>
+        <tr><td><code>pending_review</code></td><td>"심사 중" / warning</td><td>'none' (정상) — 환불 badge 없음</td><td>파트너 검토 중. 결제는 끝났고 승인 대기.</td><td>알림 대기. 본인 의사로 취소도 가능.</td></tr>
+        <tr><td><code>pending</code> · <code>payment_pending</code></td><td>"결제 대기" / info</td><td>'none' (정상) — 환불 badge 없음</td><td>결제 처리 중 (PG 응답 대기).</td><td>잠시 후 자동 갱신.</td></tr>
+        <tr><td><code>cancelled</code></td><td>"취소됨" / neutral</td><td><strong>'refunded' (정상)</strong> — "환불 완료" badge 함께 노출</td><td>사용자가 직접 취소 → 자동 환불 처리됨.</td><td>없음 — 환불 정보 카드 확인 또는 새 이벤트.</td></tr>
+        <tr><td><code>rejected</code></td><td>"거절됨" / error</td><td><strong>'refunded' (정상)</strong> — "환불 완료" badge 함께 노출</td><td>파트너가 신청 거절 → 자동 환불 처리됨.</td><td>심사 detail에서 거절 사유 확인. 결제는 환불됨.</td></tr>
+        <tr><td><code>payment_failed</code></td><td>"결제 실패" / error</td><td>'none' (환불 개념 자체 없음) — 환불 badge 없음</td><td>결제 자체 실패 (카드/잔액/네트워크). 결제 행위 없음.</td><td>다른 결제 수단으로 새 신청 (별도 흐름).</td></tr>
+        <tr><td>그 외 (예외)</td><td>"알수없음" / neutral</td><td>—</td><td>backend가 알 수 없는 status 반환. 이론상 발생 X.</td><td>새로고침 또는 고객센터.</td></tr>
+      </tbody>
+    </table>
+
+    <p class="variant-label">RefundBadge — refundStatus별 별도 badge (status badge 옆에 함께 노출)</p>
+    <table class="ref">
+      <thead><tr><th style="width: 200px;">refundStatus</th><th style="width: 200px;">badge 라벨 / 색</th><th>표시 조건</th></tr></thead>
+      <tbody>
+        <tr><td><code>'none'</code> (default)</td><td>—</td><td>badge 미노출 (환불 행위가 없거나 진행 중 아님)</td></tr>
+        <tr><td><code>'refunded'</code></td><td>"환불 완료" / neutral</td><td>cancelled / rejected와 함께 — 자동 환불 처리 완료</td></tr>
+        <tr><td><code>'refund_pending'</code> (가칭 · backend TBD)</td><td>"환불 처리 중" / warning</td><td>환불 EF 호출 후 PG 응답 대기 — 잠깐 보일 수 있음</td></tr>
+        <tr><td><code>'refund_failed'</code> (가칭 · backend TBD)</td><td>"환불 실패" / error</td><td>환불 시도 실패 — 사용자가 고객센터로 우회 필요</td></tr>
+      </tbody>
+    </table>
+
+    <p class="intro" style="margin-top: 12px;">
+      <strong>note — application.status × refundStatus 조합 가이드</strong><br>
+      · <code>cancelled</code>·<code>rejected</code> 는 backend가 자동으로 <code>refundStatus = 'refunded'</code>로 동기화 → 두 badge가 항상 함께 (status badge + "환불 완료"). 이 케이스는 화면이 <strong>State 3(환불 완료)</strong>로 분류되어 결제 정보 카드 미노출 + 환불 정보 카드 노출.<br>
+      · <code>payment_failed</code> 는 결제 자체가 안 됐으므로 환불 개념 없음 (refundStatus 'none' 유지) → 환불 badge 미노출. 화면은 <strong>State 4(결제 실패)</strong>로 분류되어 결제 정보 카드만 노출, 영수증 버튼은 paymentId 없어 자동 미노출.<br>
+      · cancelled / rejected에서 refundStatus가 'none'인 경우는 비정상 — backend 일관성 문제. spec 기본 가정 외, 후속에서 처리.
+    </p>
+  </section>
+
+  <section class="doc">
+    <h2>Sub-anatomy ③ — 결제 정보 card</h2>
+    <p class="intro">
+      결제 1건의 raw fact + 영수증 진입. KeyValueRow 패턴 — label은 onSurfaceVariant, value는 onSurface. 결제 금액은 강조(w700). 카드 하단 1px divider 바로 아래 "영수증" plain TextButton — 외부 브라우저로 iamport 영수증 페이지 열기.
+      <strong>v1.2: divider와 마지막 KV row 사이 여백 제거</strong> · <strong>버튼 색 검정 톤(plain)</strong>.
+    </p>
+    <div class="layout-grid">
+      <div class="blueprint" style="height: 180px;">
+        <div class="blueprint__region blueprint__region--full"></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:16px;left:16px;right:16px;height:24px;"><span class="blueprint__region-label">㉠ "결제 정보" 섹션 제목</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:56px;left:16px;right:16px;height:80px;"><span class="blueprint__region-label">㉡ KeyValueRow × 3</span></div>
+        <div class="blueprint__region" style="top:140px;left:16px;right:16px;height:1px;"><span class="blueprint__region-label">— 1px divider (margin 0)</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:144px;left:16px;right:16px;height:32px;"><span class="blueprint__region-label">㉢ TextButton "영수증" (paymentId 있을 때만)</span></div>
+      </div>
+      <div class="layout-tree"><b>Container</b>(card chrome)
+└─ <b>Padding</b>(<code>spacing-medium</code>)
+   └─ <b>Column</b>(crossAxis: stretch)
+      ├─ <em>"결제 정보"</em>                                  ← ㉠
+      ├─ Gap: <code>spacing-medium</code>
+      ├─ <em>KeyValueRow list</em>                             ← ㉡
+      │  ├─ <b>MinglitKeyValueRow</b>("결제일", "yyyy.MM.dd HH:mm")
+      │  ├─ <b>MinglitKeyValueRow</b>("티켓", ticket.name ?? "티켓 정보 없음")
+      │  └─ <b>MinglitKeyValueRow</b>("결제 금액", "{amount}원" · value strong)
+      ├─ <b>Divider</b>(1px · margin-top 0 · 마지막 KV row의 padding-bottom 그대로 유지)
+      └─ <em>if paymentId 있음</em>                           ← ㉢
+         └─ <b>TextButton</b>("영수증" full width · color <code>color-text-primary</code> · padding-top <code>spacing-medium</code>)</div>
+    </div>
+    <table class="ref" style="margin-top: 16px;">
+      <thead><tr><th style="width: 60px;">#</th><th style="width: 180px;">Region</th><th style="width: 220px;">Alignment</th><th>Spacing / tokens</th></tr></thead>
+      <tbody>
+        <tr><td>㉠</td><td>섹션 제목</td><td>start</td><td>typography <code>labelLarge</code> w700</td></tr>
+        <tr><td>㉡</td><td>KeyValueRow list</td><td>spaceBetween (label ↔ value)</td><td>row v-padding <code>spacing-sm</code> · 사이 1px <code>color-divider</code> · label <code>bodyMedium</code> onSurfaceVariant · value <code>bodyMedium</code> w500 · 결제 금액 value <code>bodyLarge</code> w700</td></tr>
+        <tr><td>㉢</td><td>영수증 버튼</td><td>full width · 가운데 정렬</td><td>height 40 · color <code>color-text-primary</code> (<strong>v1.2</strong> · 검정/짙은 회색 plain) · typography <code>labelLarge</code> w500 · padding-top <code>spacing-medium</code> · top border 1px <code>color-divider</code> · margin-top 0</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Sub-anatomy ④ — 환불 정책 card</h2>
+    <p class="intro">
+      두 갈래 환불 정책을 단일 카드로 안내. 상단 "플랫폼 환불 정책"은 RefundCalculator 정책(grace_period_hours / cutoff_days · 기본 2/7)을 4단계 row로 풀어 보여주고 현재 시점 단계를 <strong>label/value 모두 bold</strong>로 강조 (v1.3 — 색·padding 강조 제거 · 정렬 어긋남 방지). 중간 "파트너 직접 환불"은 자동 환불 외 케이스에서 파트너에게 직접 연락하는 안내만 (CTA 버튼은 ⑤ 파트너 정보 카드의 "문의하기"로 일원화 — v1.3에서 중복 CTA 제거).
+      <strong>v1.6: "예매 취소" 버튼을 카드 안으로 통합</strong> — 정책을 본 직후 같은 카드 안에서 액션. canCancel 충족 시 active(errorContainer), 미충족 시 disabled(Material default 회색). disabled 상태가 단계 row 바로 아래 위치해 "왜 안 되는지" 시각적으로 self-explain.
+      <strong>v1.7: 버튼 위치 — 플랫폼 정책과 파트너 직접 환불 사이</strong>로 이동. 버튼 아래에 divider + 파트너 직접 환불 안내가 옴. 흐름: "정책 → 액션 → (자동 환불 외) 대안 안내". 파트너 직접 환불 안내는 active / disabled 두 상태 모두 노출 — 사용자가 카드 진입 전부터 "다른 환불 경로" 존재를 인지하도록 (discoverability).
+      <strong>v1.4: refundStatus가 'refunded'면 이 카드와 결제 정보 카드 둘 다 사라지고, 두 정보가 합쳐진 "환불 정보" 카드 1개로 swap</strong> — 결제 정보(티켓·결제 금액)와 환불 결과(환불일·환불 비율·환불 금액·수수료)를 한 카드에서 비교 가능. 영수증 버튼도 그쪽으로 이전 (paymentId 있을 때). 환불 완료 카드에는 예매 취소 버튼 자체가 없음.
+    </p>
+    <div class="layout-grid">
+      <div class="blueprint" style="height: 360px;">
+        <div class="blueprint__region blueprint__region--full"></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:16px;left:16px;right:16px;height:24px;"><span class="blueprint__region-label">㉠ "환불 정책" 섹션 제목</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:56px;left:16px;right:16px;height:24px;"><span class="blueprint__region-label">㉡ "플랫폼 환불 정책" 서브 헤딩</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:88px;left:16px;right:16px;height:96px;"><span class="blueprint__region-label">㉢ 단계별 row × 4 (현재 단계 bold)</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:200px;left:16px;right:16px;height:48px;"><span class="blueprint__region-label">㉣ 예매 취소 버튼 (active / disabled · v1.7 — 디바이더 위로 이동)</span></div>
+        <div class="blueprint__region" style="top:264px;left:16px;right:16px;height:1px;"><span class="blueprint__region-label">— 1px divider (버튼 ↔ 파트너 직접 환불 사이)</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:280px;left:16px;right:16px;height:24px;"><span class="blueprint__region-label">㉤ "파트너 직접 환불" 서브 헤딩</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:312px;left:16px;right:16px;height:24px;"><span class="blueprint__region-label">㉥ 안내 문구 (항상 노출)</span></div>
+      </div>
+      <div class="layout-tree"><b>Container</b>(card chrome)
+└─ <b>Padding</b>(<code>spacing-medium</code>)
+   └─ <b>Column</b>(crossAxis: stretch)
+      ├─ <em>"환불 정책"</em>                                  ← ㉠
+      ├─ Gap: <code>spacing-medium</code>
+      ├─ <em>플랫폼 환불 정책 섹션</em>
+      │  ├─ <b>Text</b>("플랫폼 환불 정책" · <code>labelSmall</code> w700 onSurfaceVariant · uppercase) ← ㉡
+      │  ├─ Gap: <code>spacing-small</code>
+      │  └─ <em>단계별 row × 4</em>                           ← ㉢
+      │     <em>(현재 단계 row만 label/value 모두 w700 — 색·bg·padding 변경 없음)</em>
+      ├─ <em>예매 취소 버튼</em>                                ← ㉣
+      │  └─ <b>FilledButton</b>("예매 취소" · width 100% · height 48 · margin-top <code>spacing-medium</code>)
+      │     ├─ <em>if canCancel</em> → enabled · errorContainer bg / onErrorContainer fg
+      │     └─ <em>else</em> → disabled · onSurface 5% bg / onSurface 38% fg · cursor not-allowed
+      ├─ <b>Divider</b>(1px) + <code>spacing-medium</code> v-margin <em>(버튼과 파트너 환불 안내 사이 명확한 구분)</em>
+      └─ <em>파트너 직접 환불 섹션</em>
+         ├─ <b>Text</b>("파트너 직접 환불" · <code>labelSmall</code> w700 onSurfaceVariant · uppercase) ← ㉤
+         └─ <b>Text</b>("자동 환불 기간 외에도 파트너에게 환불 요청 가능" · <code>bodySmall</code>) ← ㉥
+            <em>(CTA 버튼 없음 — 바로 아래 ⑤ 파트너 정보 카드의 "문의하기" 사용 · 항상 노출 — discoverability 확보)</em></div>
+    </div>
+    <table class="ref" style="margin-top: 16px;">
+      <thead><tr><th style="width: 60px;">#</th><th style="width: 180px;">Region</th><th style="width: 220px;">Alignment</th><th>Spacing / tokens</th></tr></thead>
+      <tbody>
+        <tr><td>㉠</td><td>섹션 제목</td><td>start</td><td>typography <code>labelLarge</code> w700</td></tr>
+        <tr><td>㉡㉤</td><td>서브 헤딩</td><td>start</td><td>typography <code>labelSmall</code> w700 · color <code>color-text-secondary</code> · uppercase · letter-spacing 0.04em</td></tr>
+        <tr><td>㉢</td><td>플랫폼 단계별 row × 4</td><td>spaceBetween</td><td>row v-padding <code>spacing-xsmall</code> · h-padding 0 (모든 row 동일 — v1.3) · label <code>bodyMedium</code> onSurface · value <code>bodyMedium</code> w500 onSurfaceVariant · <strong>현재 단계 row: label w700 + value w700</strong> (색은 동일 유지 — 차분한 강조)</td></tr>
+        <tr><td>㉣</td><td>예매 취소 버튼</td><td>full width · 가운데 정렬</td><td>height 48 · radius <code>radius-button (12px)</code> · margin-top <code>spacing-medium</code> · typography <code>labelLarge</code> w600 · <strong>active</strong>: bg <code>color-error</code> 12% tint + fg <code>color-error</code> · <strong>disabled</strong>: bg <code>onSurface</code> 5% tint + fg <code>onSurface</code> 38% tint + cursor not-allowed (Material default) · <strong>v1.7</strong>: 위치가 플랫폼 정책 ↔ 파트너 직접 환불 사이로 이동 — divider가 버튼 아래에 위치하여 "정책 → 액션 → (자동 환불 외) 대안" 흐름 자연스러움</td></tr>
+        <tr><td>㉥</td><td>파트너 환불 안내</td><td>start</td><td>안내 <code>bodySmall</code> · color <code>color-text-primary</code> · CTA 없음 · <strong>active/disabled 모두 노출</strong> (v1.7 — discoverability 확보 위해 항상)</td></tr>
+      </tbody>
+    </table>
+
+    <p class="variant-label">예매 취소 버튼 — canCancel 분기 · 노출 방식</p>
+    <table class="ref">
+      <thead><tr><th style="width: 200px;">상태 조건</th><th>버튼 표시</th><th>적용 state</th></tr></thead>
+      <tbody>
+        <tr><td>canCancel == true</td><td><strong>active</strong> — errorContainer · 탭 시 환불 확인 다이얼로그 (state 8)</td><td>State 1 (활성 + 환불 가능)</td></tr>
+        <tr><td>canCancel == false (자동 환불 기간 종료 / 시작 후)</td><td><strong>disabled</strong> — Material 회색 · 탭 무반응 · cursor not-allowed</td><td>State 2 (환불 기간 종료)</td></tr>
+        <tr><td>refundStatus == 'refunded'</td><td><strong>버튼 미렌더</strong> — 카드 자체가 "환불 정보" 카드로 swap</td><td>State 3 (환불 완료)</td></tr>
+        <tr><td>status == payment_failed</td><td><strong>버튼 미렌더</strong> — 환불 정책 카드 자체 미노출</td><td>State 4 (결제 실패)</td></tr>
+        <tr><td>무료 티켓 (paymentAmount 0 + paymentId 없음)</td><td>"신청 취소 안내" 카드 안에 동일 패턴 — 카피만 "신청 취소"로 미세 조정. 시작 전 active, 시작 후 disabled</td><td>State 5 (무료 티켓)</td></tr>
+      </tbody>
+    </table>
+    <p class="intro" style="margin-top: 12px;">
+      <strong>note — disabled 시각</strong>: Material default disabled tokens 사용 (별도 disabled colorset 신규 정의 X). 이로써 "비활성화된 버튼"이라는 암묵적 합의 UI를 그대로 활용 — 사용자가 학습 비용 없이 인지. errorContainer 색을 유지한 채 opacity만 낮추는 방식은 채택하지 않음 ("빨간 액션이지만 잠겨있다"는 모호한 시그널을 피하기 위해).
+    </p>
+
+    <p class="variant-label">플랫폼 환불 정책 단계 row 라벨 — 정책값에 따라 동적</p>
+    <table class="ref">
+      <thead><tr><th style="width: 240px;">단계</th><th>label 패턴</th><th>value</th></tr></thead>
+      <tbody>
+        <tr><td>1. Grace 기간 내</td><td>"결제 후 {graceHours}시간 이내"</td><td>"100% 환불"</td></tr>
+        <tr><td>2. Cutoff 이전</td><td>"이벤트 시작 {cutoffDays}일 이전"</td><td>"100% 환불"</td></tr>
+        <tr><td>3. Cutoff 이내 ~ 시작 직전</td><td>"이벤트 시작 {cutoffDays}일 이내"</td><td>"부분 환불 (RefundCalculator 비율)"</td></tr>
+        <tr><td>4. 시작 후</td><td>"이벤트 시작 후"</td><td>"자동 환불 불가"</td></tr>
+      </tbody>
+    </table>
+    <p class="intro" style="margin-top: 12px;">
+      <strong>note</strong> — 정확한 단계 비율(50/80/100 등)은 <code>RefundCalculator</code> 로직과 일치해야 함. 정책 조회 실패 시 default(grace 2h / cutoff 7d) fallback (Fix #133).
+    </p>
+  </section>
+
+  <section class="doc">
+    <h2>Sub-anatomy ⑤ — 파트너 정보 card</h2>
+    <p class="intro">
+      파트너 식별 + 두 갈래 진입(파트너 detail · 문의하기). 상단 row 전체가 tap target — 작은 원형 프로필 + 파트너명 + 한 줄 소개 + 우측 chevron으로 "이 파트너에 대해 더 알아보기" 시그널. 하단 1px divider 바로 아래 "문의하기" plain TextButton — 시스템 dialer/메일앱 연결.
+      <strong>v1.3: 환불 정책 카드 바로 아래 위치</strong> — "자동 환불 안 되면 → 파트너에 직접 연락" 흐름이 시선에 자연스럽게 걸리도록.
+    </p>
+    <div class="layout-grid">
+      <div class="blueprint" style="height: 160px;">
+        <div class="blueprint__region blueprint__region--full"></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:16px;left:16px;right:16px;height:24px;"><span class="blueprint__region-label">㉠ "파트너" 섹션 제목</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:56px;left:16px;right:16px;height:56px;"><span class="blueprint__region-label">㉡ 파트너 row · avatar + 이름/소개 + chevron</span></div>
+        <div class="blueprint__region" style="top:120px;left:16px;right:16px;height:1px;"><span class="blueprint__region-label">— 1px divider (margin 0)</span></div>
+        <div class="blueprint__region blueprint__region--shaded" style="top:124px;left:16px;right:16px;height:32px;"><span class="blueprint__region-label">㉢ TextButton "문의하기"</span></div>
+      </div>
+      <div class="layout-tree"><b>Container</b>(card chrome)
+└─ <b>Padding</b>(<code>spacing-medium</code>)
+   └─ <b>Column</b>(crossAxis: stretch)
+      ├─ <em>"파트너"</em>                                     ← ㉠
+      ├─ Gap: <code>spacing-medium</code>
+      ├─ <em>파트너 row</em> (InkWell · onTap → PartnerDetail)  ← ㉡
+      │  ├─ <b>CircleAvatar</b>(48 · partner.profileImageUrl ?? placeholder)
+      │  ├─ Gap: <code>spacing-medium</code>
+      │  ├─ <b>Expanded</b>(Column)
+      │  │  ├─ <b>Text</b>(partner.name · titleSmall w700 · maxLines 1 ellipsis)
+      │  │  └─ <b>Text</b>(partner.introduction ?? "" · bodySmall onSurfaceVariant · maxLines 1 ellipsis)
+      │  └─ <b>Icon</b>(Icons.chevron_right · onSurfaceVariant)
+      ├─ <b>Divider</b>(1px · margin 0)
+      └─ <b>TextButton</b>("문의하기" full width · color <code>color-text-primary</code> · padding-top <code>spacing-medium</code>) ← ㉢</div>
+    </div>
+    <table class="ref" style="margin-top: 16px;">
+      <thead><tr><th style="width: 60px;">#</th><th style="width: 180px;">Region</th><th style="width: 220px;">Alignment</th><th>Spacing / tokens</th></tr></thead>
+      <tbody>
+        <tr><td>㉠</td><td>섹션 제목</td><td>start</td><td>typography <code>labelLarge</code> w700</td></tr>
+        <tr><td>㉡</td><td>파트너 row</td><td>center · gap medium</td><td>avatar 48×48 radius 50% · 누락 시 placeholder bg <code>color-surface</code> + 아이콘 onSurfaceVariant · name <code>titleSmall</code> w700 · intro <code>bodySmall</code> onSurfaceVariant · chevron 18 onSurfaceVariant · 전체 InkWell</td></tr>
+        <tr><td>㉢</td><td>문의하기 버튼</td><td>full width · 가운데 정렬</td><td>height 40 · color <code>color-text-primary</code> · typography <code>labelLarge</code> w500 · padding-top <code>spacing-medium</code> · top border 1px <code>color-divider</code> · margin-top 0</td></tr>
+      </tbody>
+    </table>
+    <p class="variant-label">파트너 row · 데이터 누락 시 변형</p>
+    <table class="ref">
+      <thead><tr><th style="width: 200px;">조건</th><th>표시</th></tr></thead>
+      <tbody>
+        <tr><td>profileImageUrl 없음</td><td>placeholder 아이콘 (Icons.storefront 또는 Icons.person · onSurfaceVariant)</td></tr>
+        <tr><td>introduction 없음</td><td>두 번째 line 자체 미렌더 — name 1행만 노출</td></tr>
+        <tr><td>partner 자체 누락</td><td>카드 전체 미렌더. 이 경우 "문의하기" 진입점이 사라짐 — 사용자는 환불 정책 카드의 안내 문구만 보고 다른 경로(고객센터 등)로 우회</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>canCancel 판정 — Flutter 후속 변경 필요</h2>
+    <p class="intro">
+      "예매 취소" 버튼은 Sub-anatomy ④ 환불 정책 카드 안에 통합되었음 (v1.6). canCancel 판정 로직은 그대로 — true면 active, false면 disabled로 노출.
+      <strong>v1.1 확장</strong>: 활성 status 화이트리스트에 <code>pending</code>, <code>pending_review</code> 추가 — 파트너 미수락 단계에서도 유저는 자유롭게 환불(=신청 취소) 가능. 현재 Flutter <code>isActiveTicket</code>은 paid/approved만 — 후속 PR에서 확장 필요.
+    </p>
+    <table class="ref">
+      <thead><tr><th style="width: 240px;">조건</th><th>결과</th></tr></thead>
+      <tbody>
+        <tr><td><code>status</code> ∈ {paid, approved, pending, pending_review}</td><td>활성 티켓으로 간주 — <strong>기존 paid/approved에 pending/pending_review 추가</strong></td></tr>
+        <tr><td><code>refundStatus</code> == 'none'</td><td>중복 환불 방지</td></tr>
+        <tr><td><code>eventStartTime &gt; now</code></td><td>이벤트 시작 전만</td></tr>
+        <tr><td>유료(paymentAmount &gt; 0 || paymentId 있음): paymentId/paymentAmount/eventStartTime 모두 not-null</td><td>iamport 환불 호출 가능</td></tr>
+        <tr><td>무료(paymentAmount == 0 &amp;&amp; paymentId 없음): eventStartTime not-null</td><td>user-cancel-order EF가 무료 케이스 분기 처리 (Fix #1652)</td></tr>
+      </tbody>
+    </table>
+  </section>
+</div>
+
+<!-- ============================================================
+     STATES
+     ============================================================ -->
+<div class="perspective" id="states">
+  <div class="perspective__header">
+    <span class="glyph">🎨</span>
+    <h2>States</h2>
+    <span class="lede">8 state. baseline = Default · 활성 + 환불 가능. 변형은 환불 정책 카드 내 예매 취소 버튼 active/disabled / 환불 정책 카드 노출 여부 / 환불 완료 swap / 심사 상태 row의 StatusBadge 색으로 갈라짐.</span>
+  </div>
+
+  <section class="doc">
+    <p class="intro">
+      <strong>State 종류 식별 기준</strong>: <code>MinglitAsyncValueWidget</code>의 3-way + data 안에서 결제 상태(<code>application.status</code>) + 환불 상태(<code>application.refundStatus</code>) + 환불 가능 여부(<code>canCancel</code>) + 무료/유료(<code>paymentId</code> 유무)로 분기.
+    </p>
+
+    <h3 style="margin-top: 24px;">State summary <small style="font-size:12px;font-weight:400;color:var(--color-text-secondary);">— 8 states</small></h3>
+    <table class="ref">
+      <thead>
+        <tr><th style="width: 220px;">State</th><th style="width: 100px;">Tag</th><th style="width: 240px;">조건 (요약)</th><th>Key visual differentiator</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><strong>Default · 활성 + 환불 가능</strong></td><td>baseline</td><td>활성 (paid/approved/pending/pending_review) + 시작 전 + 자동 환불 기간 내</td><td>환불 정책 카드 현재 단계 highlight + <strong>카드 내 예매 취소 버튼 active</strong> (errorContainer) + 심사 상태 badge success</td></tr>
+        <tr><td><strong>Default · 환불 기간 종료</strong></td><td>variant</td><td>활성이지만 시작 후 또는 자동 환불 기간 만료</td><td>환불 정책 카드 마지막 단계 highlight + <strong>카드 내 예매 취소 버튼 disabled</strong> (Material 회색) + 파트너 환불 안내 강조</td></tr>
+        <tr><td><strong>Default · 환불 완료</strong></td><td>variant</td><td>refundStatus == 'refunded' (보통 cancelled / rejected와 함께)</td><td><strong>결제 정보 카드 미노출</strong> · 환불 정책 → 환불 정보 카드로 통합 swap (티켓·결제 금액·환불 결과 모두 포함) · 예매 취소 버튼 미렌더 · 심사 상태 badge neutral/error + RefundBadge "환불 완료"</td></tr>
+        <tr><td><strong>Default · 결제 실패</strong></td><td>variant</td><td>payment_failed (환불 개념 없음)</td><td>환불 정책 / 환불 정보 카드 둘 다 미노출 + 영수증 미노출(paymentId 없음) + 예매 취소 버튼 미렌더 + 심사 상태 badge error</td></tr>
+        <tr><td><strong>Default · 무료 티켓</strong></td><td>variant</td><td>paymentAmount 0 + paymentId 없음 + 활성 + 시작 전</td><td>영수증 버튼 미노출 · 결제 금액 0원 · 환불 정책 → "신청 취소 안내" 카드 단순화 + <strong>카드 내 "신청 취소" 버튼 active</strong></td></tr>
+        <tr><td><strong>Loading</strong></td><td>async</td><td>fetch 중</td><td>화면 중앙 spinner</td></tr>
+        <tr><td><strong>Error</strong></td><td>network/server</td><td>로드 실패</td><td>error_outline icon + "오류가 발생했습니다."</td></tr>
+        <tr><td><strong>Refund Confirm Dialog</strong></td><td>overlay</td><td>"예매 취소" tap → 정책 조회 → refundPercentage &gt; 0</td><td>본문 위 scrim + MinglitDialog</td></tr>
+      </tbody>
+    </table>
+
+    <div class="visual-gallery" style="background: var(--color-surface); padding: 16px; border-radius: var(--radius-card); display: flex; flex-direction: column; gap: 16px;">
+
+      <!-- ─── State 1: Default · 활성 + 환불 가능 (baseline) ──────────── -->
+      <table class="ref state-mini is-baseline-tint">
+        <thead>
+          <tr><th colspan="3"><strong>Default · 활성 + 환불 가능</strong> 🎯 <small>baseline · 5 카드 · 환불 정책 카드 내 예매 취소 버튼 active</small></th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="state-mini__mock" rowspan="6">
+              <div class="viewport phd-viewport">
+                <div class="phd-appbar">
+                  <span class="phd-appbar__back">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg>
+                  </span>
+                  <h2>구매 상세</h2>
+                </div>
+                <div class="phd-body">
+                  <!-- ② Hero card (no StatusBadge) -->
+                  <div class="phd-card">
+                    <div class="phd-hero__thumb">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><circle cx="12" cy="15" r="2"/></svg>
+                    </div>
+                    <div class="phd-hero__title">스피드 데이팅 · 강남 라운지</div>
+                    <div class="phd-hero__meta">5월 4일 (월) 20:00</div>
+                    <div class="phd-hero__meta phd-hero__meta--muted">강남역 5번 출구 · 라운지B</div>
+                  </div>
+                  <!-- ③ 심사 상태 row (with StatusBadge) -->
+                  <div class="phd-card">
+                    <div class="phd-listtile">
+                      <div class="phd-listtile__main">
+                        <span class="phd-listtile__label">심사 상태</span>
+                        <span class="phd-listtile__subtitle">마지막 업데이트: 2시간 전</span>
+                      </div>
+                      <span class="phd-listtile__trail">
+                        <span class="phd-status-badge phd-status-badge--success">결제완료</span>
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+                      </span>
+                    </div>
+                  </div>
+                  <!-- ④ 결제 정보 -->
+                  <div class="phd-card">
+                    <div class="phd-section__title">결제 정보</div>
+                    <div class="phd-kv"><span class="phd-kv__label">결제일</span><span class="phd-kv__value">2026.04.28 14:32</span></div>
+                    <div class="phd-kv"><span class="phd-kv__label">티켓</span><span class="phd-kv__value">스탠다드 입장권</span></div>
+                    <div class="phd-kv"><span class="phd-kv__label">결제 금액</span><span class="phd-kv__value phd-kv__value--strong">25,000원</span></div>
+                    <button class="phd-card-action">영수증</button>
+                  </div>
+                  <!-- ⑤ 환불 정책 -->
+                  <div class="phd-card">
+                    <div class="phd-section__title">환불 정책</div>
+                    <div class="phd-refund-section">
+                      <div class="phd-refund-section__heading">플랫폼 환불 정책</div>
+                      <div class="phd-policy-row"><span class="phd-policy-row__label">결제 후 2시간 이내</span><span class="phd-policy-row__value">100% 환불</span></div>
+                      <div class="phd-policy-row phd-policy-row--current"><span class="phd-policy-row__label">이벤트 시작 7일 이전</span><span class="phd-policy-row__value">100% 환불</span></div>
+                      <div class="phd-policy-row"><span class="phd-policy-row__label">이벤트 시작 7일 이내</span><span class="phd-policy-row__value">부분 환불</span></div>
+                      <div class="phd-policy-row"><span class="phd-policy-row__label">이벤트 시작 후</span><span class="phd-policy-row__value">자동 환불 불가</span></div>
+                    </div>
+                    <button class="phd-card-cancel">예매 취소</button>
+                    <div class="phd-refund-section">
+                      <div class="phd-refund-section__heading">파트너 직접 환불</div>
+                      <div class="phd-refund-section__copy">자동 환불 기간 외에도 파트너에게 환불을 요청할 수 있습니다.</div>
+                    </div>
+                  </div>
+                  <!-- ⑥ 파트너 정보 -->
+                  <div class="phd-card">
+                    <div class="phd-section__title">파트너</div>
+                    <div class="phd-partner-row">
+                      <div class="phd-partner-row__avatar">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 9l1-4h16l1 4M3 9v10h18V9M3 9h18M9 13h6"/></svg>
+                      </div>
+                      <div class="phd-partner-row__text">
+                        <div class="phd-partner-row__name">강남 라운지</div>
+                        <div class="phd-partner-row__intro">데이팅 전용 프리미엄 공간</div>
+                      </div>
+                      <div class="phd-partner-row__chevron">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+                      </div>
+                    </div>
+                    <button class="phd-card-action">문의하기</button>
+                  </div>
+                </div>
+                <span class="callout" style="top:88px;left:24px;">ⓐ</span>
+                <span class="callout" style="top:300px;left:24px;">ⓑ</span>
+                <span class="callout" style="top:372px;left:24px;">ⓒ</span>
+                <span class="callout" style="top:548px;left:24px;">ⓓ</span>
+                <span class="callout" style="top:760px;left:24px;">ⓔ</span>
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>활성 결제 상태(결제 완료 또는 신청 완료/심사 진행 중)이고, 자동 환불 기간 내이며, 이벤트가 아직 시작되지 않은 결제. 결제·이벤트 정보 모두 유효.</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">사용자 액션</td>
+            <td>
+              ① <strong>"영수증" 탭</strong> → 외부 브라우저로 영수증 페이지 열기. 열 수 없으면 "영수증 페이지를 열 수 없습니다." 안내<br>
+              ② <strong>심사 상태 row 탭</strong> → 심사 상태 detail로 이동 (거절 사유 / 신청 답변 / 검토 시점 등)<br>
+              ③ <strong>스크롤</strong> → 환불 정책 카드 → 파트너 정보 카드 순으로 노출<br>
+              ④ <strong>파트너 row 탭</strong> → 파트너 detail로 이동<br>
+              ⑤ <strong>"문의하기" 탭</strong> (파트너 정보 카드) → 연락처가 있으면 전화 앱(우선) 또는 메일 앱이 열림. 둘 다 없으면 "연락처 정보가 없습니다." 안내. 환불 정책 카드의 "파트너 직접 환불" 안내를 본 사용자가 자연스럽게 바로 아래 카드의 이 버튼을 탭하는 흐름<br>
+              ⑥ <strong>"예매 취소" 탭</strong> → 환불 확인 다이얼로그 노출 (state 8)<br>
+              ⑦ <strong>뒤로 가기</strong> → 구매 내역 리스트로 복귀
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">에지케이스</td>
+            <td>
+              · <strong>이벤트 정보 누락</strong> — 이벤트명 "제목 없음" / 일시 "-" / 장소 "장소 정보 없음"으로 fallback<br>
+              · <strong>썸네일 누락</strong> — placeholder 아이콘이 들어간 회색 박스<br>
+              · <strong>파트너 정보 누락</strong> — 파트너 카드 자체 미렌더<br>
+              · <strong>파트너 소개 누락</strong> — 파트너 row의 두 번째 line 미렌더 (이름만 1행)<br>
+              · <strong>연락처 우선순위</strong> — 이벤트 → 모임 → 파트너 fallback. 같은 source 내 phone &gt; email<br>
+              · <strong>환불 정책 조회 실패</strong> — 기본 정책(2시간 / 7일)으로 표시<br>
+              · <strong>현재 단계 highlight</strong> — paid/시작 시점 기준으로 4 단계 중 1개에 label/value 모두 bold (v1.3 · 색·padding 변경 없음)
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">컴포넌트</td>
+            <td>
+              · <code>Scaffold</code> + Material <code>AppBar(title: Text('구매 상세'))</code> · auto back arrow<br>
+              · <a href="/components#MinglitAsyncValueWidget"><code>MinglitAsyncValueWidget&lt;EventApplication&gt;</code></a> 외곽<br>
+              · <code>SingleChildScrollView</code> + <code>Column</code> (5 카드 stack · sticky CTA 없음 v1.6)<br>
+              · <a href="/components#MinglitContentCard"><code>MinglitContentCard</code></a> × 5 — 또는 file-private wrapper<br>
+              · Hero: <a href="/components#MinglitImage"><code>MinglitImage</code></a>(16:9 · radius-medium) (StatusBadge 없음)<br>
+              · 심사 상태 row: <code>InkWell</code> + Row(<strong>Column(label "심사 상태" · subtitle "마지막 업데이트: ...")</strong> · <a href="/components#StatusBadge"><code>StatusBadge</code></a> + chevron) — 2-line ListTile (v1.4)<br>
+              · 결제 정보: <a href="/components#MinglitKeyValueRow"><code>MinglitKeyValueRow</code></a> × 3 + plain <code>TextButton</code> "영수증" (color-text-primary)<br>
+              · 파트너 정보: <code>InkWell</code> + <code>CircleAvatar</code> + <code>Text</code> × 2 + <code>Icon</code>(chevron_right) + <code>Divider</code> + plain <code>TextButton</code> "문의하기" (color-text-primary)<br>
+              · 환불 정책: 두 sub-section (플랫폼 단계 row × 4 + 파트너 안내) — CTA 버튼 없음 (v1.3 · ⑤ 파트너 정보의 "문의하기"로 일원화)<br>
+              · 환불 정책 카드 내 <code>FilledButton</code> "예매 취소" — active(errorContainer / onErrorContainer) / disabled(Material default — onSurface 5%/38%) v1.6<br>
+              · <code>url_launcher</code>: 영수증 · tel: · mailto:
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">토큰</td>
+            <td>
+              · color: <code>color-surface</code> (scaffold + AppBar + thumb fallback + avatar fallback bg), <code>color-background</code> (카드 · BottomCTA bg), <code>color-text-primary</code> (제목 · 값 · 라벨 · 정책 label · 영수증/문의 버튼), <code>color-text-secondary</code> (KeyValueRow label · 정책 value · 안내 · 장소 · 소개 · chevron · 서브 헤딩), <code>color-divider</code> (KeyValueRow separator · 카드 내 divider · BottomCTA top border), <code>color-error</code> + errorContainer tint (예매 취소), 의미론적 status: <code>color-success</code> · <code>color-warning</code> · 정보 파랑 · <code>color-error</code> · <em>color-primary는 사용 안 함 (v1.3 — 환불 현재 단계 tint 제거 · 파트너 환불 CTA 제거)</em><br>
+              · radius: <code>radius-card (16px)</code>, <code>radius-medium (12px)</code> (Hero thumb), <code>radius-small (8px)</code> (StatusBadge), 50% (파트너 avatar), <code>radius-button (12px)</code> (예매 취소)<br>
+              · spacing: <code>spacing-medium (16px)</code> (body padding · card padding · 카드 사이 gap · 섹션 제목→내용 · KeyValueRow→영수증 padding-top · 파트너 row→문의하기 padding-top · Hero thumb→title · 두 환불 섹션 사이 v-margin), <code>spacing-sm (12px)</code> (KeyValueRow v-padding · StatusBadge h-padding), <code>spacing-small (8px)</code> (서브 헤딩→본문 · 심사 상태 row trail gap · 심사 상태 badge↔chevron gap), <code>spacing-xsmall (4px)</code> (제목→일시 · 정책 row v-padding · StatusBadge v-padding)<br>
+              · opacity: <code>shadowXs (0.06)</code>, <code>subtle (0.20)</code> (StatusBadge bg tint), 12% (예매 취소 tint)<br>
+              · typography: appBarTitle (18/600), titleLarge bold (이벤트명), titleSmall bold (파트너명), bodyLarge w500 (심사 상태 라벨 · 결제 금액 value), bodyMedium (일시 · KeyValueRow · 정책 row · <strong>현재 단계 row의 label/value 모두 w700</strong>), labelLarge bold (섹션 제목), labelLarge w500 (TextButton 영수증/문의), labelMedium w600 (StatusBadge), labelSmall bold uppercase (서브 헤딩), bodySmall (장소 · 파트너 소개 · 정책 안내 · 파트너 환불 안내)
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">노트</td>
+            <td>📝 ⓐ Hero · ⓑ 심사 상태 · ⓒ 결제 정보 · ⓓ 환불 정책 (예매 취소 버튼 포함) · ⓔ 파트너 정보. v1.6: sticky BottomCTA 제거, 예매 취소 버튼이 환불 정책 카드 안 마지막 element로 이전. v1.3: 카드 순서를 결제 → 환불 → 파트너로 재배치(자동 환불 안 되면 → 파트너 직접 연락 흐름).</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <!-- ─── State 2: Default · 환불 기간 종료 ──────────── -->
+      <table class="ref state-mini">
+        <thead>
+          <tr><th colspan="3"><strong>Default · 환불 기간 종료</strong> <small>환불 정책 카드 내 예매 취소 버튼 disabled · 마지막 단계 highlight + 파트너 환불 강조</small></th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="state-mini__mock" rowspan="6">
+              <div class="viewport phd-viewport">
+                <div class="phd-appbar">
+                  <span class="phd-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg></span>
+                  <h2>구매 상세</h2>
+                </div>
+                <div class="phd-body">
+                  <div class="phd-card">
+                    <div class="phd-hero__thumb"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><circle cx="12" cy="15" r="2"/></svg></div>
+                    <div class="phd-hero__title">스피드 데이팅 · 강남 라운지</div>
+                    <div class="phd-hero__meta">4월 27일 (일) 20:00</div>
+                    <div class="phd-hero__meta phd-hero__meta--muted">강남역 5번 출구 · 라운지B</div>
+                  </div>
+                  <div class="phd-card">
+                    <div class="phd-listtile">
+                      <div class="phd-listtile__main">
+                        <span class="phd-listtile__label">심사 상태</span>
+                        <span class="phd-listtile__subtitle">마지막 업데이트: 1일 전</span>
+                      </div>
+                      <span class="phd-listtile__trail">
+                        <span class="phd-status-badge phd-status-badge--success">결제완료</span>
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+                      </span>
+                    </div>
+                  </div>
+                  <div class="phd-card">
+                    <div class="phd-section__title">결제 정보</div>
+                    <div class="phd-kv"><span class="phd-kv__label">결제일</span><span class="phd-kv__value">2026.04.20 09:14</span></div>
+                    <div class="phd-kv"><span class="phd-kv__label">티켓</span><span class="phd-kv__value">스탠다드 입장권</span></div>
+                    <div class="phd-kv"><span class="phd-kv__label">결제 금액</span><span class="phd-kv__value phd-kv__value--strong">25,000원</span></div>
+                    <button class="phd-card-action">영수증</button>
+                  </div>
+                  <div class="phd-card">
+                    <div class="phd-section__title">환불 정책</div>
+                    <div class="phd-refund-section">
+                      <div class="phd-refund-section__heading">플랫폼 환불 정책</div>
+                      <div class="phd-policy-row"><span class="phd-policy-row__label">결제 후 2시간 이내</span><span class="phd-policy-row__value">100% 환불</span></div>
+                      <div class="phd-policy-row"><span class="phd-policy-row__label">이벤트 시작 7일 이전</span><span class="phd-policy-row__value">100% 환불</span></div>
+                      <div class="phd-policy-row"><span class="phd-policy-row__label">이벤트 시작 7일 이내</span><span class="phd-policy-row__value">부분 환불</span></div>
+                      <div class="phd-policy-row phd-policy-row--current"><span class="phd-policy-row__label">이벤트 시작 후</span><span class="phd-policy-row__value">자동 환불 불가</span></div>
+                    </div>
+                    <button class="phd-card-cancel phd-card-cancel--disabled" disabled>예매 취소</button>
+                    <div class="phd-refund-section">
+                      <div class="phd-refund-section__heading">파트너 직접 환불</div>
+                      <div class="phd-refund-section__copy">자동 환불 기간이 지났습니다. 환불을 원하시면 파트너에게 직접 요청해주세요.</div>
+                    </div>
+                  </div>
+                  <div class="phd-card">
+                    <div class="phd-section__title">파트너</div>
+                    <div class="phd-partner-row">
+                      <div class="phd-partner-row__avatar"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 9l1-4h16l1 4M3 9v10h18V9"/></svg></div>
+                      <div class="phd-partner-row__text">
+                        <div class="phd-partner-row__name">강남 라운지</div>
+                        <div class="phd-partner-row__intro">데이팅 전용 프리미엄 공간</div>
+                      </div>
+                      <div class="phd-partner-row__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+                    </div>
+                    <button class="phd-card-action">문의하기</button>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>↔ 활성 결제이지만 이벤트가 이미 시작됐거나 자동 환불 기간이 지난 상태.</td>
+          </tr>
+          <tr><td class="state-mini__aspect">사용자 액션</td><td>− "예매 취소" 탭 (CTA 미노출)<br>↔ 환불 정책 카드의 "파트너 직접 환불" 안내 카피 강조("자동 환불 기간이 지났습니다 — 파트너에게 직접 요청") → 사용자가 바로 아래 ⑤ 파트너 정보 카드의 "문의하기" 탭<br>동일: 영수증 / 심사 상태 row / 파트너 row / 문의하기 / 스크롤 / 뒤로</td></tr>
+          <tr><td class="state-mini__aspect">에지케이스</td><td>· 환불 정책 카드 마지막 단계 highlight로 사용자가 "왜 자동 취소가 안 되는지" 즉시 인지<br>· 파트너 환불 안내 카피가 "지났습니다 — 파트너에게 직접 요청" 톤으로 미세 조정 (현재 단계가 4번일 때만)</td></tr>
+          <tr><td class="state-mini__aspect">컴포넌트</td><td>↔ 환불 정책 카드 내 예매 취소 버튼: active → <strong>disabled</strong> (Material default 회색 · cursor not-allowed). 위치 그대로, 시각만 변경<br>동일: 그 외 모두</td></tr>
+          <tr><td class="state-mini__aspect">토큰</td><td>↔ 예매 취소 버튼 색: <code>color-error</code> 12% tint + <code>color-error</code> fg → <code>onSurface</code> 5% bg + <code>onSurface</code> 38% fg (Material disabled defaults)<br>동일: 그 외</td></tr>
+          <tr><td class="state-mini__aspect">노트</td><td>📝 body 하단 80px 비움 제거 — scaffold body 끝까지 차지. "파트너 직접 환불"이 핵심 다음 액션으로 부각.</td></tr>
+        </tbody>
+      </table>
+
+      <!-- ─── State 3: Default · 환불 완료 ──────────── -->
+      <table class="ref state-mini">
+        <thead>
+          <tr><th colspan="3"><strong>Default · 환불 완료</strong> <small>refundStatus == 'refunded' — 환불 정책 → 환불 완료 카드 swap · 심사 상태 badge neutral</small></th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="state-mini__mock" rowspan="6">
+              <div class="viewport phd-viewport">
+                <div class="phd-appbar">
+                  <span class="phd-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg></span>
+                  <h2>구매 상세</h2>
+                </div>
+                <div class="phd-body">
+                  <div class="phd-card">
+                    <div class="phd-hero__thumb"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></div>
+                    <div class="phd-hero__title">봄 가든 파티</div>
+                    <div class="phd-hero__meta">4월 20일 (일) 18:00</div>
+                    <div class="phd-hero__meta phd-hero__meta--muted">서울숲 가든존</div>
+                  </div>
+                  <div class="phd-card">
+                    <div class="phd-listtile">
+                      <div class="phd-listtile__main">
+                        <span class="phd-listtile__label">심사 상태</span>
+                        <span class="phd-listtile__subtitle">마지막 업데이트: 방금</span>
+                      </div>
+                      <span class="phd-listtile__trail">
+                        <span class="phd-status-badge phd-status-badge--neutral">취소됨</span>
+                        <span class="phd-status-badge phd-status-badge--neutral">환불 완료</span>
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+                      </span>
+                    </div>
+                  </div>
+                  <!-- 환불 정보 카드 (결제 정보 카드 미노출 · 환불 정보로 통합 v1.4) -->
+                  <div class="phd-card">
+                    <div class="phd-section__title">환불 정보</div>
+                    <div class="phd-kv"><span class="phd-kv__label">환불일</span><span class="phd-kv__value">2026.04.13 11:08</span></div>
+                    <div class="phd-kv"><span class="phd-kv__label">티켓</span><span class="phd-kv__value">얼리버드 입장권</span></div>
+                    <div class="phd-kv"><span class="phd-kv__label">결제 금액</span><span class="phd-kv__value">15,000원</span></div>
+                    <div class="phd-kv"><span class="phd-kv__label">환불 비율</span><span class="phd-kv__value">80%</span></div>
+                    <div class="phd-kv"><span class="phd-kv__label">환불 금액</span><span class="phd-kv__value phd-kv__value--strong">12,000원</span></div>
+                    <div class="phd-kv"><span class="phd-kv__label">수수료</span><span class="phd-kv__value">3,000원</span></div>
+                    <button class="phd-card-action">영수증</button>
+                  </div>
+                  <div class="phd-card">
+                    <div class="phd-section__title">파트너</div>
+                    <div class="phd-partner-row">
+                      <div class="phd-partner-row__avatar"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 9l1-4h16l1 4"/></svg></div>
+                      <div class="phd-partner-row__text">
+                        <div class="phd-partner-row__name">서울숲 파티</div>
+                        <div class="phd-partner-row__intro">야외 가든 모임 전문</div>
+                      </div>
+                      <div class="phd-partner-row__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+                    </div>
+                    <button class="phd-card-action">문의하기</button>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>↔ 환불이 이미 처리 완료된 결제 (<code>refundStatus == 'refunded'</code>). status는 cancelled 또는 종결 상태.</td>
+          </tr>
+          <tr><td class="state-mini__aspect">사용자 액션</td><td>− "예매 취소" 탭 (환불 정책 → 환불 정보 카드 swap으로 버튼 자체 미렌더)<br>↔ "영수증" 탭 (위치가 환불 정보 카드 내부로 이동 · paymentId 있을 때만)<br>동일: 심사 상태 row / 파트너 row / 문의하기 / 뒤로<br>− 환불 정책 단계 안내 액션 없음 (이미 환불 완료)</td></tr>
+          <tr><td class="state-mini__aspect">에지케이스</td><td>· <strong>결제 정보 카드 미노출 (v1.4)</strong> — 환불된 결제는 결제 사실보다 환불 결과가 핵심이라 결제 정보를 환불 정보 카드로 통합. 결제일/티켓/결제 금액/환불일/환불 비율/환불 금액/수수료 모두 한 카드<br>· 환불 비율 / 환불 금액 / 수수료가 누락된 결제 (구버전) → 해당 행 미렌더, "환불일"·"결제 금액"만 표시<br>· 환불 처리 직후 list invalidate되며 detail unmount → 다시 진입 시 이 state 표시<br>· 심사 상태 row의 StatusBadge: cancelled(취소됨 · neutral) 또는 rejected(거절됨 · error)</td></tr>
+          <tr><td class="state-mini__aspect">컴포넌트</td><td>− 예매 취소 버튼 (환불 정보 카드에는 없음 · v1.6)<br>− <strong>결제 정보 카드 전체</strong> (v1.4 · 환불 정보 카드로 통합)<br>↔ 환불 정책 카드 (플랫폼 + 파트너 두 섹션) → <strong>환불 정보 카드</strong> (KeyValueRow × 6 + 영수증 버튼)<br>↔ 심사 상태 row의 StatusBadge: success → neutral / error<br>+ <strong>RefundBadge "환불 완료"</strong> (StatusBadge 옆에 함께 노출 · v1.5)</td></tr>
+          <tr><td class="state-mini__aspect">토큰</td><td>↔ 환불 정책 row 토큰 미사용 → KeyValueRow 토큰 (이전 결제 정보 카드의 패턴 재사용)<br>− <code>color-error</code> · errorContainer tint</td></tr>
+          <tr><td class="state-mini__aspect">노트</td><td>📝 환불 정보 카드의 6행 = 결제 정보 3행(티켓 · 결제 금액) + 환불 결과 4행(환불일·비율·금액·수수료) 통합. 사용자가 한 카드에서 "원래 얼마 → 얼마 돌려받음"을 비교 가능. 환불 처리 시점(환불일)은 EF 응답 또는 별도 컬럼 추가 필요 (TBD).</td></tr>
+        </tbody>
+      </table>
+
+      <!-- ─── State 4: Default · 결제 실패 ──────────── -->
+      <table class="ref state-mini">
+        <thead>
+          <tr><th colspan="3"><strong>Default · 결제 실패</strong> <small>payment_failed — 환불 자체 개념 없음 · 환불 카드 미노출 · 심사 상태 badge error</small></th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="state-mini__mock" rowspan="6">
+              <div class="viewport phd-viewport">
+                <div class="phd-appbar">
+                  <span class="phd-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg></span>
+                  <h2>구매 상세</h2>
+                </div>
+                <div class="phd-body">
+                  <div class="phd-card">
+                    <div class="phd-hero__thumb"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></div>
+                    <div class="phd-hero__title">봄 가든 파티</div>
+                    <div class="phd-hero__meta">4월 20일 (일) 18:00</div>
+                    <div class="phd-hero__meta phd-hero__meta--muted">서울숲 가든존</div>
+                  </div>
+                  <div class="phd-card">
+                    <div class="phd-listtile">
+                      <div class="phd-listtile__main">
+                        <span class="phd-listtile__label">심사 상태</span>
+                        <span class="phd-listtile__subtitle">마지막 업데이트: 5일 전</span>
+                      </div>
+                      <span class="phd-listtile__trail">
+                        <span class="phd-status-badge phd-status-badge--error">결제 실패</span>
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+                      </span>
+                    </div>
+                  </div>
+                  <div class="phd-card">
+                    <div class="phd-section__title">결제 정보</div>
+                    <div class="phd-kv"><span class="phd-kv__label">결제 시도일</span><span class="phd-kv__value">2026.04.18 21:14</span></div>
+                    <div class="phd-kv"><span class="phd-kv__label">티켓</span><span class="phd-kv__value">얼리버드 입장권</span></div>
+                    <div class="phd-kv"><span class="phd-kv__label">결제 시도 금액</span><span class="phd-kv__value phd-kv__value--strong">15,000원</span></div>
+                    <!-- 영수증 버튼 미노출 — paymentId 없음 -->
+                  </div>
+                  <div class="phd-card">
+                    <div class="phd-section__title">파트너</div>
+                    <div class="phd-partner-row">
+                      <div class="phd-partner-row__avatar"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 9l1-4h16l1 4"/></svg></div>
+                      <div class="phd-partner-row__text">
+                        <div class="phd-partner-row__name">서울숲 파티</div>
+                        <div class="phd-partner-row__intro">야외 가든 모임 전문</div>
+                      </div>
+                      <div class="phd-partner-row__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+                    </div>
+                    <button class="phd-card-action">문의하기</button>
+                  </div>
+                  <!-- 환불 정책 / 환불 정보 카드 모두 미노출 -->
+                </div>
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>↔ 결제 자체가 실패한 상태 (PG 인증 실패 / 카드 잔액 부족 / 네트워크 오류 등). <strong>결제 행위가 일어나지 않았으므로 환불 자체 개념 없음</strong> — refundStatus는 'none'이어야 정상.</td>
+          </tr>
+          <tr><td class="state-mini__aspect">사용자 액션</td><td>− "영수증" 탭 (paymentId 없음 → 버튼 미노출)<br>− "예매 취소" 탭 (환불 정책 카드 미노출로 버튼 자체 미렌더)<br>+ <strong>심사 상태 row</strong>가 핵심 다음 액션 — 결제 실패 원인을 심사 detail에서 확인<br>동일: 파트너 row / 문의하기 / 뒤로<br><em>실제로는 별도 "다시 결제" 흐름이 필요하지만 현재 spec 범위 외 — Phase 2</em></td></tr>
+          <tr><td class="state-mini__aspect">에지케이스</td><td>· paymentId가 null이라 영수증 버튼 자동 미노출<br>· "환불 정책" / "환불 정보" 카드 둘 다 미노출 — 환불 자체 개념이 없는 케이스<br>· StatusBadge: error red — 사용자가 즉시 "뭔가 잘못됨" 인지<br>· 결제 정보 카드 라벨 미세 조정: 첫 행 "결제일" → "<strong>결제 시도일</strong>" (createdAt 사용 · 실제 결제 없음), 마지막 행 "결제 금액" → "<strong>결제 시도 금액</strong>" (실제 결제 안 됐음을 명확히 · v1.8)</td></tr>
+          <tr><td class="state-mini__aspect">컴포넌트</td><td>− 환불 정책 / 환불 정보 card 전체 → 예매 취소 버튼도 자동 미렌더<br>− 영수증 <code>TextButton</code> (paymentId 없음)<br>↔ 심사 상태 row의 <code>StatusBadge</code> 색 → error</td></tr>
+          <tr><td class="state-mini__aspect">토큰</td><td>↔ status color: success → <code>color-error</code> (badge)<br>− 환불 정책 관련 토큰 미사용</td></tr>
+          <tr><td class="state-mini__aspect">노트</td><td>📝 v1.5: State 4를 payment_failed 단독으로 좁힘. cancelled / rejected는 (사용자 도메인 가정) refundStatus 'refunded'와 함께 와 State 3(환불 완료)로 분류됨. 이 가정이 깨지는 케이스(rejected + 'none' 등)는 비정상 — 후속에서 backend 일관성 확보 필요.</td></tr>
+        </tbody>
+      </table>
+
+      <!-- ─── State 5: Default · 무료 티켓 ──────────── -->
+      <table class="ref state-mini">
+        <thead>
+          <tr><th colspan="3"><strong>Default · 무료 티켓</strong> <small>paymentId 없음 · 영수증 미노출 · "신청 취소 안내" 카드 + 카드 내 "신청 취소" 버튼 active</small></th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="state-mini__mock" rowspan="6">
+              <div class="viewport phd-viewport">
+                <div class="phd-appbar">
+                  <span class="phd-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg></span>
+                  <h2>구매 상세</h2>
+                </div>
+                <div class="phd-body">
+                  <div class="phd-card">
+                    <div class="phd-hero__thumb"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></div>
+                    <div class="phd-hero__title">오픈 카페 모임 — 무료</div>
+                    <div class="phd-hero__meta">5월 8일 (금) 19:00</div>
+                    <div class="phd-hero__meta phd-hero__meta--muted">홍대입구역 9번 출구 · 카페노아</div>
+                  </div>
+                  <div class="phd-card">
+                    <div class="phd-listtile">
+                      <div class="phd-listtile__main">
+                        <span class="phd-listtile__label">심사 상태</span>
+                        <span class="phd-listtile__subtitle">마지막 업데이트: 5시간 전</span>
+                      </div>
+                      <span class="phd-listtile__trail">
+                        <span class="phd-status-badge phd-status-badge--success">신청완료</span>
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+                      </span>
+                    </div>
+                  </div>
+                  <div class="phd-card">
+                    <div class="phd-section__title">결제 정보</div>
+                    <div class="phd-kv"><span class="phd-kv__label">신청일</span><span class="phd-kv__value">2026.05.01 22:08</span></div>
+                    <div class="phd-kv"><span class="phd-kv__label">티켓</span><span class="phd-kv__value">무료 입장권</span></div>
+                    <div class="phd-kv"><span class="phd-kv__label">결제 금액</span><span class="phd-kv__value phd-kv__value--strong">0원</span></div>
+                  </div>
+                  <div class="phd-card">
+                    <div class="phd-section__title">신청 취소 안내</div>
+                    <div class="phd-refund-section">
+                      <div class="phd-policy-row phd-policy-row--current"><span class="phd-policy-row__label">이벤트 시작 전</span><span class="phd-policy-row__value">언제든 신청 취소</span></div>
+                      <div class="phd-policy-row"><span class="phd-policy-row__label">이벤트 시작 후</span><span class="phd-policy-row__value">취소 불가</span></div>
+                      <div class="phd-refund-section__copy" style="margin-top: 12px; margin-bottom: 0;">무료 티켓은 환불 절차 없이 신청 취소만 진행됩니다.</div>
+                    </div>
+                    <button class="phd-card-cancel">신청 취소</button>
+                  </div>
+                  <div class="phd-card">
+                    <div class="phd-section__title">파트너</div>
+                    <div class="phd-partner-row">
+                      <div class="phd-partner-row__avatar"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 9l1-4h16l1 4"/></svg></div>
+                      <div class="phd-partner-row__text">
+                        <div class="phd-partner-row__name">카페노아</div>
+                        <div class="phd-partner-row__intro">홍대 모임 전문 카페</div>
+                      </div>
+                      <div class="phd-partner-row__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+                    </div>
+                    <button class="phd-card-action">문의하기</button>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>↔ 결제 금액이 0원이고 결제 식별자가 없는 무료 신청. 활성 + 시작 전이면 취소(=신청 취소) 가능.</td>
+          </tr>
+          <tr><td class="state-mini__aspect">사용자 액션</td><td>− "영수증" 탭 (버튼 미노출)<br>↔ "예매 취소" → 환불 다이얼로그 (state 8) — 비율 100% / 금액 0원 / 수수료 0원으로 단순화<br>동일: 심사 상태 row / 파트너 row / 문의하기 / 스크롤 / 뒤로</td></tr>
+          <tr><td class="state-mini__aspect">에지케이스</td><td>· 결제 정보 카드 첫 행 라벨이 "신청일" (paid 이력 없으므로 createdAt 사용)<br>· 환불 정책 카드 → "신청 취소 안내" 카드로 카피·구조 단순화 (플랫폼/파트너 두 갈래 분리 제거 · 단계 2개)<br>· 심사 상태 row badge 라벨이 "신청완료" (결제 개념이 아니므로 미세 조정)</td></tr>
+          <tr><td class="state-mini__aspect">컴포넌트</td><td>− 영수증 <code>TextButton</code><br>↔ "환불 정책" → "신청 취소 안내" 카드 (단계 row × 2 + 안내 문구 · 파트너 환불 섹션 미노출)</td></tr>
+          <tr><td class="state-mini__aspect">토큰</td><td>동일 (Default 활성 참조)</td></tr>
+          <tr><td class="state-mini__aspect">노트</td><td>📝 무료 변형은 RefundCalculator를 거치지 않고 고정 문구. 정책 spec 동기화 불필요. "신청 취소" 카피는 무료에서만, 유료는 "예매 취소" 그대로.</td></tr>
+        </tbody>
+      </table>
+
+      <!-- ─── State 6: Loading ──────────── -->
+      <table class="ref state-mini">
+        <thead><tr><th colspan="3"><strong>Loading</strong> <small>async fetch 진행 중</small></th></tr></thead>
+        <tbody>
+          <tr>
+            <td class="state-mini__mock" rowspan="6">
+              <div class="viewport phd-viewport">
+                <div class="phd-appbar">
+                  <span class="phd-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg></span>
+                  <h2>구매 상세</h2>
+                </div>
+                <div class="phd-loading"><div class="phd-spinner"></div></div>
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>화면 진입 직후 결제 1건의 정보를 불러오는 중. (list에서 객체를 함께 push하면 거의 발생하지 않고, applicationId만으로 진입한 경우에만 보임)</td>
+          </tr>
+          <tr><td class="state-mini__aspect">사용자 액션</td><td>↔ 모든 액션 무반응<br>동일: 뒤로 → list로 복귀</td></tr>
+          <tr><td class="state-mini__aspect">에지케이스</td><td>· 네트워크가 느리면 spinner가 길게 노출<br>· 인증 만료 시 자동으로 오류 상태로 전환</td></tr>
+          <tr><td class="state-mini__aspect">컴포넌트</td><td>↔ 5 카드 전부 → <code>MinglitCircularProgressIndicator</code> · 화면 중앙</td></tr>
+          <tr><td class="state-mini__aspect">토큰</td><td>− 카드 토큰 모두 미사용<br>+ <code>color-primary</code> (spinner)<br>동일: <code>color-surface</code> scaffold bg</td></tr>
+          <tr><td class="state-mini__aspect">노트</td><td>📝 list에서 객체를 함께 넘기면 즉시 default state — Loading은 deep-link에서만.</td></tr>
+        </tbody>
+      </table>
+
+      <!-- ─── State 7: Error ──────────── -->
+      <table class="ref state-mini">
+        <thead><tr><th colspan="3"><strong>Error</strong> <small>fetch 실패 — 네트워크 / RLS / 서버</small></th></tr></thead>
+        <tbody>
+          <tr>
+            <td class="state-mini__mock" rowspan="6">
+              <div class="viewport phd-viewport">
+                <div class="phd-appbar">
+                  <span class="phd-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg></span>
+                  <h2>구매 상세</h2>
+                </div>
+                <div class="phd-error">
+                  <div class="phd-error__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="13"/><circle cx="12" cy="16.5" r="0.7" fill="currentColor"/></svg></div>
+                  <div class="phd-error__title">오류가 발생했습니다.</div>
+                </div>
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>↔ 네트워크 / 권한 / 서버 오류로 결제 1건을 받아오지 못한 상태.</td>
+          </tr>
+          <tr><td class="state-mini__aspect">사용자 액션</td><td>− 모든 카드/버튼 액션 없음<br>동일: 뒤로 → list로 복귀<br>− 화면 내 재시도 버튼 없음</td></tr>
+          <tr><td class="state-mini__aspect">에지케이스</td><td>· 에러 본문 노출 X (디버깅은 logger / Sentry)<br>· 토큰 만료도 동일 error 화면</td></tr>
+          <tr><td class="state-mini__aspect">컴포넌트</td><td>↔ 5 카드 전부 → <code>_DefaultErrorView</code> (Icons.error_outline + Text)</td></tr>
+          <tr><td class="state-mini__aspect">토큰</td><td>− 카드 토큰 미사용<br>+ <code>color-error</code> (icon)<br>+ <code>color-text-primary</code> (title)<br>+ spacing: <code>spacing-large</code> · <code>spacing-medium</code></td></tr>
+          <tr><td class="state-mini__aspect">노트</td><td>📝 화면 내 재시도 CTA 없음 (list spec과 동일).</td></tr>
+        </tbody>
+      </table>
+
+      <!-- ─── State 8: Refund Confirm Dialog ──────────── -->
+      <table class="ref state-mini">
+        <thead><tr><th colspan="3"><strong>Refund Confirm Dialog</strong> <small>"예매 취소" tap → MinglitDialog overlay</small></th></tr></thead>
+        <tbody>
+          <tr>
+            <td class="state-mini__mock" rowspan="6">
+              <div class="viewport phd-viewport">
+                <div class="phd-appbar">
+                  <span class="phd-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg></span>
+                  <h2>구매 상세</h2>
+                </div>
+                <div class="phd-body" style="opacity:0.4;">
+                  <div class="phd-card">
+                    <div class="phd-hero__thumb"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="4" width="18" height="18" rx="2"/></svg></div>
+                    <div class="phd-hero__title">스피드 데이팅 · 강남 라운지</div>
+                    <div class="phd-hero__meta">5월 4일 (월) 20:00</div>
+                  </div>
+                </div>
+                <div class="phd-dialog-shade">
+                  <div class="phd-dialog">
+                    <div class="phd-dialog__title">예매 취소 확인</div>
+                    <div class="phd-dialog__event-name">스피드 데이팅 · 강남 라운지</div>
+                    <div class="phd-dialog__row"><span>결제 금액</span><span>25,000원</span></div>
+                    <div class="phd-dialog__row"><span>환불 비율</span><span>80%</span></div>
+                    <div class="phd-dialog__row"><span>환불 금액</span><span>20,000원</span></div>
+                    <div class="phd-dialog__row"><span>수수료</span><span>5,000원</span></div>
+                    <div class="phd-dialog__note">환불 수수료는 취소 시점에 따라 달라집니다.</div>
+                    <div class="phd-dialog__actions">
+                      <button class="phd-dialog__btn phd-dialog__btn--text">닫기</button>
+                      <button class="phd-dialog__btn phd-dialog__btn--danger">예매 취소</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td class="state-mini__aspect">조건</td>
+            <td>+ "예매 취소" tap → 정책 조회 → 환불 비율 계산 → 0%가 아닐 때만 다이얼로그 표시. 0%이면 환불 불가 안내로 분기.</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">사용자 액션</td>
+            <td>
+              + <strong>"예매 취소" 탭</strong> → 환불 처리 → 성공 시 "예매가 취소되었습니다." + list로 복귀<br>
+              + <strong>"닫기" 탭</strong> → 다이얼로그 닫힘 + detail로 복귀<br>
+              + <strong>scrim 탭</strong> → "닫기"와 동일<br>
+              + <strong>환불 처리 실패</strong> → "다시 시도 / 닫기" 옵션이 있는 오류 다이얼로그
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">에지케이스</td>
+            <td>
+              · 무료 티켓: 비율 100 / 금액 0 / 수수료 0 고정<br>
+              · 정책 조회 실패: 기본 정책(2/7) fallback — 사용자에게 에러 노출 없음<br>
+              · 비율 0%: 다이얼로그 미노출 → "환불 불가" 안내로 분기<br>
+              · 결제 정보 누락: "환불 정보를 확인할 수 없습니다" 안내<br>
+              · 환불 처리 중: 글로벌 dim + spinner (별도 spec)
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">컴포넌트</td>
+            <td>
+              + <code>MinglitDialog.show&lt;bool&gt;</code><br>
+              + content: Column(eventName titleSmall bold + <code>_RefundRow</code> × 4 + 안내 bodySmall onSurfaceVariant)<br>
+              + <code>_RefundRow</code> (private · part of detail page)<br>
+              + actions: <code>TextButton</code> "닫기" + <code>ElevatedButton</code> "예매 취소" (errorContainer / onErrorContainer)<br>
+              + 실패 시 <code>MinglitDialog.show</code>("환불 처리 실패")<br>
+              + 환불 불가 / 결제 정보 누락 시 <code>context.showMinglitAlert</code>
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">토큰</td>
+            <td>
+              + <code>color-background</code> (dialog bg)<br>
+              + <code>color-text-primary</code> · <code>color-text-secondary</code><br>
+              + <code>color-error</code> + errorContainer tint<br>
+              + radius: <code>radius-card</code>, <code>radius-button</code><br>
+              + spacing: <code>spacing-large</code>, <code>spacing-medium</code>, <code>spacing-small</code>, <code>spacing-xsmall</code><br>
+              + scrim: 검은 알파 (Material default · 0.32~0.45)
+            </td>
+          </tr>
+          <tr><td class="state-mini__aspect">노트</td><td>📝 list spec과 동일 다이얼로그를 detail로 이관 — list 카드는 다이얼로그 호출 책임을 잃음. 80% 예시는 "이벤트 시작 7d 전 + grace 통과" 케이스.</td></tr>
+        </tbody>
+      </table>
+
+    </div>
+  </section>
+</div>
+
+<!-- ============================================================
+     GLOBAL BEHAVIOR
+     ============================================================ -->
+<div class="perspective" id="global-behavior">
+  <div class="perspective__header">
+    <span class="glyph">🔄</span>
+    <h2>Global Behavior</h2>
+    <span class="lede">cross-cutting — 모든 state에 적용되는 액션, motion, 글로벌 에지케이스.</span>
+  </div>
+
+  <section class="doc">
+    <h2>Cross-cutting interactions</h2>
+    <table class="ref">
+      <thead><tr><th style="width: 220px;">사용자 액션</th><th>화면에 보이는 결과</th></tr></thead>
+      <tbody>
+        <tr><td>뒤로 가기</td><td>구매 내역 리스트로 복귀.</td></tr>
+        <tr><td>다크 모드 토글</td><td>scaffold / 카드 / dialog 모두 dark 토큰으로 swap. StatusBadge는 light/dark colorset 분리. 예매 취소 버튼 disabled 색도 dark onSurface 알파로 자동 swap.</td></tr>
+        <tr><td>버튼 / row tap haptic</td><td>InkWell ripple + Material default haptic light. 카드 본체 자체는 tap 액션 없음 — 심사 상태 row / 파트너 row / 영수증 / 문의 / 예매 취소 버튼만 액션.</td></tr>
+        <tr><td>풀-다운 새로고침</td><td><strong>구현 안 함</strong> — 단일 결제 detail이라 갱신은 (a) 환불 성공 후 list로 복귀 (b) 화면 재진입.</td></tr>
+        <tr><td>리스트 → detail push (entry)</td><td>list 카드 tap → <code>extra: application</code>으로 함께 push 권장. applicationId만으로 deep-link도 허용 — 이때 Loading.</td></tr>
+        <tr><td>외부 url_launcher 실패</td><td>browser·dialer·메일앱 부재 시 launchUrl false → <code>showMinglitWarning</code> 토스트.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Motion timing</h2>
+    <p class="intro">Source: <code>shared/packages/mds/core/lib/src/theme/minglit_design_tokens.dart</code> → <code>MinglitAnimation</code>.</p>
+    <table class="ref">
+      <thead><tr><th style="width: 240px;">Transition</th><th style="width: 200px;">Token / Duration</th><th>Notes</th></tr></thead>
+      <tbody>
+        <tr><td>list → detail push</td><td><code>MinglitAnimation.fast</code> (200ms)</td><td>GoRouter Material default 좌→우 slide.</td></tr>
+        <tr><td>심사 상태 row tap → 심사 detail push</td><td><code>MinglitAnimation.fast</code> (200ms)</td><td>동일 GoRouter 패턴.</td></tr>
+        <tr><td>파트너 row tap → PartnerDetail push</td><td><code>MinglitAnimation.fast</code> (200ms)</td><td>동일 GoRouter 패턴.</td></tr>
+        <tr><td>"예매 취소" tap → MinglitDialog show</td><td><code>MinglitAnimation.medium</code> (350ms)</td><td>fade + scale-in.</td></tr>
+        <tr><td>EF cancelOrder 진행 중</td><td>—</td><td>화면 전체 dim + spinner (글로벌 로딩 오버레이).</td></tr>
+        <tr><td>환불 성공 → list로 복귀 + invalidate</td><td>cut</td><td>Navigator.maybePop + ref.invalidate. detail 화면 unmount.</td></tr>
+        <tr><td>InkWell ripple</td><td><code>MinglitAnimation.micro</code> (100ms)</td><td>Material default ripple.</td></tr>
+        <tr><td>예매 취소 버튼 active/disabled (canCancel 변동)</td><td>cut</td><td>화면 진입 시 한 번만 결정 — 시간 경과로 false 전환 시 재진입까지 갱신 안 됨. disabled 전환 시 fade 등 transition 없음 (re-render).</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Global edge cases</h2>
+    <ul class="notes">
+      <li><strong>paidAt 누락</strong> — webhook 처리 전이면 null. <code>paidAt ?? createdAt</code> fallback (Fix #579 패턴). 무료 티켓에서는 결제 정보 카드 첫 행 라벨이 "신청일"로 미세 조정.</li>
+      <li><strong>환불 정책 조회 실패</strong> — 기본 정책(grace 2h / cutoff 7d) fallback (Fix #133 패턴).</li>
+      <li><strong>이벤트 시작 후 cancel 시도</strong> — canCancel false면 환불 정책 카드 안 예매 취소 버튼이 disabled로 노출 (cursor not-allowed). 시간 경과 자동 재계산 안 됨 — 재진입 시 갱신.</li>
+      <li><strong>중복 invalidate 방지</strong> — onSuccess(maybePop) 후 invalidate (Fix #1951 패턴).</li>
+      <li><strong>contactOptions 누락</strong> — phone/email 모두 없으면 "연락처 정보가 없습니다" 토스트만. ④ 파트너 카드 + ⑥ 환불 정책 카드의 "문의하기"가 동일 fallback 경로.</li>
+      <li><strong>파트너 정보 누락</strong> — ⑤ 파트너 정보 카드 자체 미렌더 → 화면에서 "문의하기" 진입점이 사라짐. 환불 정책 카드의 안내 문구는 그대로 노출되지만 사용자는 다른 경로(고객센터 등)로 우회. <em>v1.3에서 환불 정책 카드의 CTA를 제거했기 때문에, 파트너 카드가 미렌더되면 in-app 문의 경로 자체가 끊김 — 후속 PR에서 fallback CTA(고객센터 등) 추가 검토 필요.</em></li>
+      <li><strong>iamport 영수증 URL 의존성</strong> — Phase 2에서 backend가 보낸 receipt URL 사용 검토.</li>
+      <li><strong>다크 모드</strong> — 카드 bg → <code>color-dark-surface</code>, scaffold → <code>color-dark-background</code>.</li>
+      <li><strong>접근성</strong> — 예매 취소 버튼 라벨 명확("예매 취소" / 무료는 "신청 취소"). disabled 상태도 screen reader가 "비활성화됨"을 읽을 수 있게 <code>aria-disabled</code> 또는 native <code>disabled</code> 속성 사용. 환불 정책 현재 단계 highlight는 색에만 의존하지 않고 row 위치/bold로도 식별 가능. 심사 상태 row의 StatusBadge 색은 8 status 분기가 명확한 라벨과 함께 노출됨.</li>
+    </ul>
+  </section>
+</div>
+
+<!-- ============================================================
+     REFERENCE
+     ============================================================ -->
+<div class="perspective" id="reference">
+  <div class="perspective__header">
+    <span class="glyph">📖</span>
+    <h2>Reference</h2>
+    <span class="lede">implementation source + 인접 화면. 🚧 디자인중 — 미존재 항목은 TBD.</span>
+  </div>
+
+  <section class="doc">
+    <h2>Implementation source</h2>
+    <p class="intro">이 spec과 매칭되는 실제 Flutter source 위치. Status 🚧 디자인중이므로 대부분 TBD.</p>
+    <table class="ref">
+      <tbody>
+        <tr><th style="width: 200px;">Widget class</th><td><code>PurchaseHistoryDetailPage</code> · <code>TBD</code></td></tr>
+        <tr><th>File path</th><td><code>apps/app_user/lib/src/features/payment/ui/purchase_history_detail_page.dart</code> · <code>TBD</code></td></tr>
+        <tr><th>Refund row atom</th><td><code>_RefundRow</code> — list spec의 <a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_user/lib/src/features/payment/ui/purchase_history_refund_row.dart"><code>purchase_history_refund_row.dart</code></a>를 detail part로 이관 권장</td></tr>
+        <tr><th>Controller</th><td><code>PurchaseHistoryDetailController</code> · 또는 list와 동일 <a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_user/lib/src/features/payment/logic/purchase_history_controller.dart"><code>PurchaseHistoryController</code></a> 재사용 · <code>TBD</code></td></tr>
+        <tr><th>Route</th><td><code>PurchaseHistoryDetailRoute</code> · path: <code>/purchase-history/:applicationId</code> · <code>TBD</code></td></tr>
+        <tr><th>List entry</th><td><a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_user/lib/src/routing/app_routes.dart"><code>app_routes.dart</code></a>의 <code>PurchaseHistoryRoute</code> 하위로 추가</td></tr>
+        <tr><th>Repository</th><td>list와 동일 — <code>eventRepositoryProvider.getMyPurchaseHistory(userId)</code>로 받은 list에서 단일 application을 push (extra) · 또는 <code>getApplicationById(id)</code> 별도 정의 · <code>TBD</code></td></tr>
+        <tr><th>Cancel EF</th><td><code>eventRepositoryProvider.cancelOrder(eventId, reason)</code> — list spec과 동일 EF 재사용</td></tr>
+        <tr><th>Policy repository</th><td><code>policyRepositoryProvider.getRefundPolicy()</code> — Fix #133 fallback</td></tr>
+        <tr><th>Refund calculator</th><td><code>RefundCalculator.calculate(...)</code></td></tr>
+        <tr><th>Async wrapper</th><td><a href="/components#MinglitAsyncValueWidget"><code>MinglitAsyncValueWidget</code></a></td></tr>
+        <tr><th>StatusBadge</th><td><a href="/components#StatusBadge"><code>StatusBadge</code></a> = <a href="/components#MinglitBadge"><code>MinglitBadge</code></a> · 8 status 분기 (심사 상태 row 내부에 inline)</td></tr>
+        <tr><th>예매 취소 버튼</th><td>환불 정책 카드 내 <code>FilledButton</code>(또는 <code>ElevatedButton</code>) — Material default disabled style 적용 · 별도 <code>MinglitBottomCta</code> 미사용 (v1.6)</td></tr>
+        <tr><th>KeyValueRow</th><td><a href="/components#MinglitKeyValueRow"><code>MinglitKeyValueRow</code></a> — 결제 정보 / 환불 완료 카드</td></tr>
+        <tr><th>MinglitDialog</th><td><a href="/components#MinglitDialog"><code>MinglitDialog.show&lt;T&gt;</code></a> — 환불 confirm</td></tr>
+        <tr><th>External launcher</th><td><code>url_launcher.launchUrl</code> — 영수증·tel:·mailto:</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>후속 작업 (이 detail이 활성되려면 필요한 변경)</h2>
+    <p class="intro">이 spec은 <strong>이번 PR에서 spec만 머지</strong> · 아래 변경은 별도 후속 PR.</p>
+    <table class="ref">
+      <thead><tr><th style="width: 280px;">변경 항목</th><th>설명</th></tr></thead>
+      <tbody>
+        <tr>
+          <td><strong>Flutter — canCancel 조건 확장</strong></td>
+          <td><code>PurchaseHistoryController.isActiveTicket</code>의 status 화이트리스트에 <code>pending</code>, <code>pending_review</code> 추가. 파트너 미수락 단계에서도 유저가 자유롭게 환불(=신청 취소) 가능하게.</td>
+        </tr>
+        <tr>
+          <td><strong>Flutter — detail 위젯/라우트 신규</strong></td>
+          <td><code>PurchaseHistoryDetailPage</code> + <code>PurchaseHistoryDetailRoute</code> 추가. list 카드 위젯의 <code>_onCancelPressed</code> / <code>_showRefundConfirmDialog</code> / <code>_showRefundErrorDialog</code> + <code>part 'purchase_history_refund_row.dart'</code>를 detail로 이관.</td>
+        </tr>
+        <tr>
+          <td><strong>Spec — list spec 슬림화</strong></td>
+          <td><a href="/specs/purchase_history_page.html"><code>PurchaseHistoryPage</code></a> 카드 sub-anatomy 축소: header(date · StatusBadge) + info(thumb · 제목 · 일시 · 장소) + 우측 chevron만. divider/pay-row/actions row 제거. 카드 자체가 tap target. State 5(Refund Confirm Dialog) 제거 — detail spec 단일 정의.</td>
+        </tr>
+        <tr>
+          <td><strong>Spec — 심사 상태 detail 신규 (가칭)</strong></td>
+          <td><code>event_application_review_page.html</code> 신규 spec — 거절 사유(<code>rejectionReason</code>) / 신청 답변 스냅샷(<code>VerificationSubmission.snapshotData</code>) / 검토 시점(<code>reviewedAt</code>) / 검토자(<code>reviewedBy</code>) / 단계별 진행 표시. 라우트 path: <code>/purchase-history/:applicationId/review</code> 등.</td>
+        </tr>
+        <tr>
+          <td><strong>Spec — 파트너 detail 확인</strong></td>
+          <td><a href="/specs/partner_detail_page.html"><code>PartnerDetailPage</code></a> 존재 여부 확인 · 미존재 시 별도 spec 작업 필요.</td>
+        </tr>
+        <tr>
+          <td><strong>Backend — refundedAt 컬럼</strong></td>
+          <td>State 3(환불 완료)의 환불 완료 카드 첫 행 "환불일"이 표시 가능하려면 EF 응답 또는 EventApplication에 환불 처리 시점 필요. 현재 <code>refundStatus</code>만 있고 시점 컬럼 없음 — DB 마이그레이션 또는 응답 enrichment 필요.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Related screens</h2>
+    <table class="ref">
+      <thead><tr><th style="width: 240px;">Spec</th><th>Relation</th></tr></thead>
+      <tbody>
+        <tr><td><a href="/specs/purchase_history_page.html"><code>PurchaseHistoryPage</code></a></td><td>부모 — list 카드 tap 시 detail push.</td></tr>
+        <tr><td><a href="/specs/partner_detail_page.html"><code>PartnerDetailPage</code></a></td><td>자식 — 파트너 row tap 시 push.</td></tr>
+        <tr><td><a href="/specs/event_application_review_page.html"><code>EventApplicationReviewPage</code></a> <em>(가칭)</em></td><td>자식 — 심사 상태 row tap 시 push. 거절 사유 / 신청 답변 / 검토 시점 등.</td></tr>
+        <tr><td><a href="/specs/my_tickets_page.html"><code>MyTicketsPage</code></a></td><td>형제 — active 티켓만. Phase 2에서 동일 detail로 deep-link 가능.</td></tr>
+        <tr><td><a href="/specs/event_detail_page.html"><code>EventDetailPage</code></a></td><td>EventApplicationWizard 결제 완료 후 detail로 직접 push redirect 가능 (Phase 2).</td></tr>
+        <tr><td><a href="/specs/login_page.html"><code>LoginPage</code></a></td><td>비로그인 deep-link 시 RLS 차단 → Error state.</td></tr>
+      </tbody>
+    </table>
+  </section>
+</div>
+
+</div>
+
+<script>
+  document.getElementById('spec-toggle').addEventListener('change', (e) => {
+    document.body.classList.toggle('spec-mode', e.target.checked);
+  });
+  document.getElementById('dark-toggle').addEventListener('change', (e) => {
+    document.body.classList.toggle('dark-mode', e.target.checked);
+  });
+</script>
+
+</body>
+</html>

--- a/apps/mds/docs/src/app/components/page.tsx
+++ b/apps/mds/docs/src/app/components/page.tsx
@@ -104,6 +104,9 @@ import MinglitContentLayoutSpec, {
 import MinglitHorizontalScrollGroupSpec, {
   GUIDELINE_RECIPES as MINGLIT_HORIZONTAL_SCROLL_GROUP_RECIPES,
 } from '@/components/specs/MinglitHorizontalScrollGroupSpec';
+import MinglitTimelineSpec, {
+  GUIDELINE_RECIPES as MINGLIT_TIMELINE_RECIPES,
+} from '@/components/specs/MinglitTimelineSpec';
 
 /**
  * Inline visual specs registered by component name.
@@ -159,6 +162,7 @@ const INLINE_SPECS: Record<string, InlineSpecModule> = {
   MinglitKeyValueRow:         { Visual: MinglitKeyValueRowSpec,         recipes: MINGLIT_KEY_VALUE_ROW_RECIPES },
   MinglitContentLayout:       { Visual: MinglitContentLayoutSpec,       recipes: MINGLIT_CONTENT_LAYOUT_RECIPES },
   MinglitHorizontalScrollGroup: { Visual: MinglitHorizontalScrollGroupSpec, recipes: MINGLIT_HORIZONTAL_SCROLL_GROUP_RECIPES },
+  MinglitTimeline:            { Visual: MinglitTimelineSpec,            recipes: MINGLIT_TIMELINE_RECIPES },
 };
 
 // ---------------------------------------------------------------------------

--- a/apps/mds/docs/src/components/specs/MinglitTimelineSpec.tsx
+++ b/apps/mds/docs/src/components/specs/MinglitTimelineSpec.tsx
@@ -138,7 +138,7 @@ function TimelineDemo({ children }: { children: ReactNode }) {
     <div
       style={{
         position: 'relative',
-        background: 'white',
+        background: 'var(--color-background)',
         padding: '16px 16px 16px 48px',
         borderRadius: 16,
         border: '1px solid var(--color-divider)',

--- a/apps/mds/docs/src/components/specs/MinglitTimelineSpec.tsx
+++ b/apps/mds/docs/src/components/specs/MinglitTimelineSpec.tsx
@@ -1,0 +1,450 @@
+/**
+ * MinglitTimeline — vertical stepper showing time-ordered events.
+ *
+ * Source: TBD — Flutter widget 신규 작성 필요 (이 spec이 design intent).
+ *
+ * Visual contract:
+ *   세로 stepper. 각 step은 좌측 dot + 그 아래로 이어지는 line + 우측 컨텐츠
+ *   영역(title + 자유 trailing slot + 자유 children slot). 마지막 step은 line 없음.
+ *   Dot 색은 tone에 따라 분기 — success / progress / error / neutral / muted.
+ *
+ * Tone vs status:
+ *   tone은 semantic-neutral (성공/진행/실패/완료/대기). 어떤 도메인의 lifecycle도
+ *   매핑 가능. 신청 review에서는 completed→success, active→progress(+pulsing),
+ *   failed→error, cancelled→neutral 로 매핑. 다른 use case는 자체 매핑.
+ *
+ * Pulsing:
+ *   tone과 orthogonal한 별도 prop. 보통 "현재 진행 중인 step"을 강조할 때 사용.
+ *   tone=progress와 함께 쓰는 게 일반적이지만, 어떤 tone과도 결합 가능.
+ *
+ * Composability:
+ *   step의 trailing slot에 시점 / 금액 / badge / icon 무엇이든. children slot에
+ *   사유 박스 / collapsible / CTA 등 page-specific 컨텐츠 주입. 컴포넌트 자체는
+ *   structure (dot/line/heading row)만 책임.
+ */
+
+import type { ComponentType, ReactNode } from 'react';
+import {
+  PreviewTable,
+  SpecAnatomy,
+  SpecHero,
+  SpecRoot,
+  SpecSection,
+} from './_atoms';
+
+// ---------------------------------------------------------------------------
+// Atoms
+// ---------------------------------------------------------------------------
+
+type Tone = 'success' | 'progress' | 'error' | 'neutral' | 'muted';
+
+const DOT_BG: Record<Tone, string> = {
+  success: 'var(--color-success)',
+  progress: 'var(--color-primary)',
+  error: 'var(--color-error)',
+  neutral: 'var(--color-text-secondary)',
+  muted: 'transparent',
+};
+
+const DOT_BORDER: Record<Tone, string> = {
+  success: '2px solid var(--color-background, white)',
+  progress: '2px solid var(--color-background, white)',
+  error: '2px solid var(--color-background, white)',
+  neutral: '2px solid var(--color-background, white)',
+  muted: '2px solid var(--color-text-secondary)',
+};
+
+const TITLE_COLOR: Record<Tone, string> = {
+  success: 'var(--color-text-primary)',
+  progress: 'var(--color-primary)',
+  error: 'var(--color-error)',
+  neutral: 'var(--color-text-primary)',
+  muted: 'var(--color-text-secondary)',
+};
+
+function TimelineStepDemo({
+  tone,
+  pulsing = false,
+  title,
+  trailing,
+  isLast = false,
+  children,
+}: {
+  tone: Tone;
+  pulsing?: boolean;
+  title: string;
+  trailing?: ReactNode;
+  isLast?: boolean;
+  children?: ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        position: 'relative',
+        paddingBottom: isLast ? 0 : 32,
+      }}
+    >
+      {/* connecting line */}
+      {!isLast && (
+        <span
+          style={{
+            position: 'absolute',
+            left: -23,
+            top: 18,
+            bottom: -8,
+            width: 2,
+            background: 'var(--color-divider)',
+          }}
+        />
+      )}
+      {/* dot */}
+      <span
+        style={{
+          position: 'absolute',
+          left: -28,
+          top: 4,
+          width: 12,
+          height: 12,
+          borderRadius: '50%',
+          background: DOT_BG[tone],
+          border: DOT_BORDER[tone],
+          boxSizing: 'border-box',
+          animation: pulsing ? 'mds-spec-pulse 1.4s ease-in-out infinite' : undefined,
+        }}
+      />
+      {/* heading row — title + trailing slot */}
+      <div style={{ display: 'flex', alignItems: 'baseline', flexWrap: 'wrap', gap: 8 }}>
+        <span
+          style={{
+            fontSize: 14,
+            fontWeight: 600,
+            color: TITLE_COLOR[tone],
+            lineHeight: 1.3,
+          }}
+        >
+          {title}
+        </span>
+        {trailing && (
+          <span style={{ fontSize: 12, color: 'var(--color-text-secondary)' }}>{trailing}</span>
+        )}
+      </div>
+      {children && <div style={{ marginTop: 8, fontSize: 13 }}>{children}</div>}
+    </div>
+  );
+}
+
+function TimelineDemo({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        position: 'relative',
+        background: 'white',
+        padding: '16px 16px 16px 48px',
+        borderRadius: 16,
+        border: '1px solid var(--color-divider)',
+      }}
+    >
+      <style>{`
+        @keyframes mds-spec-pulse {
+          0%, 100% { opacity: 1; transform: scale(1); }
+          50% { opacity: 0.5; transform: scale(0.85); }
+        }
+      `}</style>
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Default export
+// ---------------------------------------------------------------------------
+export default function MinglitTimelineSpec() {
+  return (
+    <SpecRoot>
+      <SpecHero>
+        <TimelineDemo>
+          <TimelineStepDemo tone="success" title="신청" trailing="2026.04.10 19:42" />
+          <TimelineStepDemo tone="success" title="결제 완료" trailing="2026.04.10 19:43 · 25,000원" />
+          <TimelineStepDemo tone="progress" pulsing title="심사 진행 중" isLast>
+            <span style={{ color: 'var(--color-text-secondary)' }}>
+              이벤트 시작까지 자동 환불 안내
+            </span>
+          </TimelineStepDemo>
+        </TimelineDemo>
+      </SpecHero>
+
+      <SpecAnatomy
+        subject={
+          <TimelineDemo>
+            <TimelineStepDemo tone="success" title="첫 단계" trailing="시점" />
+            <TimelineStepDemo tone="progress" pulsing title="진행 중" isLast />
+          </TimelineDemo>
+        }
+        labels={[
+          { text: 'dot 12×12 · tone별 색', style: { top: 18, left: 0 } },
+          { text: '연결 line 2px · color-divider', style: { top: '50%', left: 14 } },
+          { text: 'heading row · title + trailing slot · gap spacing-small', style: { top: 18, right: 0 } },
+          { text: 'step 간격 spacing-xlarge (32px)', style: { bottom: 8, right: 0 } },
+        ]}
+        minHeight={140}
+      />
+
+      <SpecSection title="Tone — semantic-neutral 색 분기">
+        <PreviewTable
+          rows={[
+            {
+              name: 'success',
+              preview: (
+                <TimelineDemo>
+                  <TimelineStepDemo tone="success" title="완료" trailing="시점" isLast />
+                </TimelineDemo>
+              ),
+              description:
+                'color-success (초록). 달성 / 통과 / 도달. 신청 review의 completed, order tracking의 delivered 등.',
+            },
+            {
+              name: 'progress',
+              preview: (
+                <TimelineDemo>
+                  <TimelineStepDemo tone="progress" title="진행 중" isLast />
+                </TimelineDemo>
+              ),
+              description:
+                'color-primary. 현재 진행 중. pulsing prop과 함께 쓰면 박동 효과 추가.',
+            },
+            {
+              name: 'error',
+              preview: (
+                <TimelineDemo>
+                  <TimelineStepDemo tone="error" title="실패" trailing="시점" isLast />
+                </TimelineDemo>
+              ),
+              description:
+                'color-error (빨강). 실패 / 거절 / 결제 오류. dot + title 모두 error 색.',
+            },
+            {
+              name: 'neutral',
+              preview: (
+                <TimelineDemo>
+                  <TimelineStepDemo tone="neutral" title="종결" trailing="시점" isLast />
+                </TimelineDemo>
+              ),
+              description:
+                'color-text-secondary (회색). 종결됐으나 강조 안 함. 사용자/시스템 취소, 묻힘 처리 등.',
+            },
+            {
+              name: 'muted',
+              preview: (
+                <TimelineDemo>
+                  <TimelineStepDemo tone="muted" title="대기" isLast />
+                </TimelineDemo>
+              ),
+              description:
+                'outline only (filled X · border만). 미래 / 대기 / 아직 도달하지 않은 step. 미래 step도 보여줘야 할 때.',
+            },
+          ]}
+        />
+      </SpecSection>
+
+      <SpecSection title="Pulsing — tone과 orthogonal한 박동 효과">
+        <PreviewTable
+          rows={[
+            {
+              name: 'pulsing=false (default)',
+              preview: (
+                <TimelineDemo>
+                  <TimelineStepDemo tone="progress" title="정적 progress" isLast />
+                </TimelineDemo>
+              ),
+              description: '정적 dot. tone progress라도 pulsing은 별도.',
+            },
+            {
+              name: 'pulsing=true',
+              preview: (
+                <TimelineDemo>
+                  <TimelineStepDemo tone="progress" pulsing title="박동 progress" isLast />
+                </TimelineDemo>
+              ),
+              description:
+                '1.4s loop · opacity 1↔0.5 + scale 1↔0.85. 보통 "지금 진행 중인 단계"를 강조할 때.',
+            },
+          ]}
+        />
+      </SpecSection>
+
+      <SpecSection title="Slots — trailing / child">
+        <PreviewTable
+          rows={[
+            {
+              name: 'trailing — 시점',
+              preview: (
+                <TimelineDemo>
+                  <TimelineStepDemo tone="success" title="신청" trailing="2026.04.10 19:42" isLast />
+                </TimelineDemo>
+              ),
+              description: '시간 metadata 한 줄. heading row의 title 옆 inline.',
+            },
+            {
+              name: 'trailing — 금액',
+              preview: (
+                <TimelineDemo>
+                  <TimelineStepDemo tone="success" title="결제 완료" trailing="2026.04.10 · 25,000원" isLast />
+                </TimelineDemo>
+              ),
+              description: '시점 + 금액 등 자유 형태. consumer가 String 또는 Widget 결정.',
+            },
+            {
+              name: 'child — 안내 텍스트',
+              preview: (
+                <TimelineDemo>
+                  <TimelineStepDemo tone="progress" pulsing title="심사 진행 중" isLast>
+                    <span style={{ color: 'var(--color-text-secondary)' }}>
+                      이벤트 시작까지 자동 환불 안내
+                    </span>
+                  </TimelineStepDemo>
+                </TimelineDemo>
+              ),
+              description: 'step heading 아래 보조 텍스트. 진행 중 안내 / 메모 등.',
+            },
+            {
+              name: 'child — message box',
+              preview: (
+                <TimelineDemo>
+                  <TimelineStepDemo
+                    tone="error"
+                    title="거절됨"
+                    trailing="2026.04.13"
+                    isLast
+                  >
+                    <div
+                      style={{
+                        marginTop: 8,
+                        padding: '12px 16px',
+                        background: 'rgba(31, 41, 55, 0.04)',
+                        borderRadius: 12,
+                      }}
+                    >
+                      <span
+                        style={{
+                          fontSize: 12,
+                          fontWeight: 700,
+                          color: 'var(--color-text-secondary)',
+                          display: 'block',
+                          marginBottom: 4,
+                        }}
+                      >
+                        서울 숲 파티 운영팀
+                      </span>
+                      사진이 흐려 본인 확인이 어렵습니다.
+                    </div>
+                  </TimelineStepDemo>
+                </TimelineDemo>
+              ),
+              description:
+                'page-specific 사유/메시지 컨테이너를 child slot으로 주입. 컴포넌트는 구조만, 안 컨텐츠는 작성 측 자유.',
+            },
+          ]}
+        />
+      </SpecSection>
+
+      <SpecSection title="Last step — line 유무">
+        <PreviewTable
+          rows={[
+            {
+              name: 'isLast=false',
+              preview: (
+                <TimelineDemo>
+                  <TimelineStepDemo tone="success" title="중간" trailing="시점" />
+                  <TimelineStepDemo tone="progress" pulsing title="진행 중" isLast />
+                </TimelineDemo>
+              ),
+              description: '중간 step — dot 아래로 연결 line.',
+            },
+            {
+              name: 'isLast=true',
+              preview: (
+                <TimelineDemo>
+                  <TimelineStepDemo tone="success" title="끝" trailing="시점" isLast />
+                </TimelineDemo>
+              ),
+              description: '마지막 step — line 미렌더.',
+            },
+          ]}
+        />
+      </SpecSection>
+    </SpecRoot>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Recipes — semantic use case 매핑 예시
+// ---------------------------------------------------------------------------
+function ApplicationReviewRecipe() {
+  // 신청 review use case: completed→success, active→progress+pulsing
+  return (
+    <TimelineDemo>
+      <TimelineStepDemo tone="success" title="신청" trailing="2026.04.10 19:42" />
+      <TimelineStepDemo
+        tone="success"
+        title="결제 완료"
+        trailing="2026.04.10 19:43 · 25,000원"
+      />
+      <TimelineStepDemo tone="progress" pulsing title="심사 진행 중" isLast>
+        <span style={{ color: 'var(--color-text-secondary)' }}>
+          이벤트 시작까지 자동 환불 안내
+        </span>
+      </TimelineStepDemo>
+    </TimelineDemo>
+  );
+}
+
+function OrderTrackingRecipe() {
+  // Order tracking use case: delivered→success, shipping→progress, pending→muted
+  return (
+    <TimelineDemo>
+      <TimelineStepDemo tone="success" title="주문 접수" trailing="2026.04.10" />
+      <TimelineStepDemo tone="success" title="결제 완료" trailing="2026.04.10" />
+      <TimelineStepDemo tone="progress" pulsing title="배송 중" trailing="2026.04.11" />
+      <TimelineStepDemo tone="muted" title="배송 완료" isLast />
+    </TimelineDemo>
+  );
+}
+
+function RejectionRecipe() {
+  return (
+    <TimelineDemo>
+      <TimelineStepDemo tone="success" title="신청" trailing="2026.04.10" />
+      <TimelineStepDemo tone="success" title="결제 완료" trailing="2026.04.10" />
+      <TimelineStepDemo tone="success" title="심사 진행" trailing="2026.04.11" />
+      <TimelineStepDemo tone="error" title="거절됨" trailing="2026.04.13" isLast>
+        <div
+          style={{
+            marginTop: 8,
+            padding: '12px 16px',
+            background: 'rgba(31, 41, 55, 0.04)',
+            borderRadius: 12,
+          }}
+        >
+          <span
+            style={{
+              fontSize: 12,
+              fontWeight: 700,
+              color: 'var(--color-text-secondary)',
+              display: 'block',
+              marginBottom: 4,
+            }}
+          >
+            서울 숲 파티 운영팀
+          </span>
+          제출하신 프로필 사진이 흐려 본인 확인이 어렵습니다.
+        </div>
+      </TimelineStepDemo>
+    </TimelineDemo>
+  );
+}
+
+export const GUIDELINE_RECIPES: Record<string, ComponentType> = {
+  'application-review': ApplicationReviewRecipe,
+  'order-tracking': OrderTrackingRecipe,
+  'rejection-flow': RejectionRecipe,
+};

--- a/apps/mds/docs/src/lib/components.ts
+++ b/apps/mds/docs/src/lib/components.ts
@@ -1420,6 +1420,80 @@ MinglitContentLayout(
   ),
 )`,
   },
+  {
+    name: 'MinglitTimeline',
+    category: 'Lists',
+    purpose:
+      '시간 순으로 진행된 이벤트를 vertical stepper로 보여주는 generic wrapper. 각 step은 좌측 dot + 그 아래로 이어지는 line + 우측 heading row(title + trailing slot) + 자유 children slot. 마지막 step은 line 없음. dot 색은 tone 분기 — success / progress / error / neutral / muted (semantic-neutral · 어떤 도메인 lifecycle도 매핑 가능). pulsing은 tone과 orthogonal한 박동 효과 (현재 진행 강조).',
+    props: [
+      { name: 'children', type: 'List<MinglitTimelineStep>', required: true, notes: '하나 이상의 step. 시간 순 (위→아래).' },
+    ],
+    variants: ['(step의 tone 별로 분기 — Tone 표 참조)'],
+    states: [
+      'success (dot color-success — 달성/통과)',
+      'progress (dot color-primary — 현재 진행)',
+      'error (dot + title color-error — 실패/거절)',
+      'neutral (dot color-text-secondary — 종결 비강조)',
+      'muted (outline only · color-text-secondary border — 미래/대기)',
+      'pulsing=true (1.4s loop — tone과 orthogonal)',
+    ],
+    tokens: [
+      { name: 'color-success',        where: 'success tone dot.' },
+      { name: 'color-primary',        where: 'progress tone dot + title.' },
+      { name: 'color-error',          where: 'error tone dot + title.' },
+      { name: 'color-text-secondary', where: 'neutral / muted dot · trailing 메타 텍스트 색.' },
+      { name: 'color-divider',        where: 'connecting line 2px 색.' },
+      { name: 'spacing-xlarge',       where: 'step 간 vertical gap (32px).' },
+      { name: 'spacing-small',        where: 'title ↔ trailing inline gap (8px).' },
+    ],
+    accessibility: [
+      'step title은 의미를 한국어로 명확히 전달 — 색에 의존하지 않고 라벨로도 인지 가능.',
+      'pulsing은 시각 단서 — screen reader는 title만 읽음.',
+      '저성능 디바이스 / OS 모션 감소 설정 시 pulsing 제거하고 정적 dot으로 fallback 권장.',
+    ],
+    guidelines: [
+      { kind: 'do',   text: '시간 순 진행을 보여줄 때 (신청/심사 review · 정산 진행 · 환불 진행 · 주문 추적 등). tone 매핑은 use case별로 자유.', recipeKey: 'application-review' },
+      { kind: 'do',   text: '주문 추적 같이 미래 step도 보여주려면 muted tone 사용 — outline only로 "아직 도달 안 함" 시각화.', recipeKey: 'order-tracking' },
+      { kind: 'do',   text: 'step 안 사유 / 메시지 / collapsible 같은 page-specific 컨텐츠는 children slot으로 주입. component 자체는 structure(dot/line/heading)만 책임.', recipeKey: 'rejection-flow' },
+      { kind: 'dont', text: '단순 step 리스트(번호 매김 / 순서 안내)에 쓰지 말 것 — 시간 / 진행 metaphor가 있을 때만.' },
+    ],
+    placement: {
+      where: [
+        '카드 안의 메인 컨텐츠 — 카드 전체가 timeline 한 개일 때.',
+        '사용 예: EventApplicationReviewPage 진행 단계 카드 (첫 use case).',
+        '향후 use case: 정산 진행 / 환불 진행 / 주문/배송 추적 / 알림 history 등.',
+      ],
+      spacing: [
+        { neighbor: '카드 padding 안쪽', gap: 'spacing-medium (16px)', note: 'dot column 32px 추가 padding-left' },
+        { neighbor: 'step 간',           gap: 'spacing-xlarge (32px)' },
+      ],
+    },
+    dartUsage: `// 신청 review use case (tone 매핑 — completed→success / active→progress+pulsing / failed→error / cancelled→neutral)
+MinglitTimeline(
+  children: [
+    MinglitTimelineStep(
+      tone: TimelineTone.success,
+      title: '신청',
+      trailing: Text('2026.04.10 19:42'),
+    ),
+    MinglitTimelineStep(
+      tone: TimelineTone.success,
+      title: '결제 완료',
+      trailing: Text('2026.04.10 19:43 · 25,000원'),
+    ),
+    MinglitTimelineStep(
+      tone: TimelineTone.progress,
+      pulsing: true,
+      title: '심사 진행 중',
+      isLast: true,
+      child: Text('이벤트 시작까지 자동 환불 안내'),
+    ),
+  ],
+)`,
+    usedIn: [
+      'event_application_review_page',
+    ],
+  },
 
   // ---------- Settings ----------
   {
@@ -1941,8 +2015,7 @@ final reason = await MinglitDialog.show<String>(
       { name: 'color-divider',        where: '드래그 핸들 색상 (with muted opacity)' },
       { name: 'spacing-small',        where: '핸들 상하 여백 8px' },
       { name: 'spacing-screen-edge',  where: '콘텐츠 좌우 패딩 16px' },
-      { name: 'spacing-medium',       where: '콘텐츠 하단 패딩 16px' },
-      { name: 'spacing-medium',       where: '타이틀 → 콘텐츠 간격 16px (MinglitDialog와 통일)' },
+      { name: 'spacing-medium',       where: '콘텐츠 하단 패딩 16px · 타이틀 → 콘텐츠 간격 16px (MinglitDialog와 통일)' },
     ],
     accessibility: [
       'showModalBottomSheet — barrier dismissible by tapping scrim (default isDismissible=true)',


### PR DESCRIPTION
## Summary

- **PurchaseHistoryDetailPage** spec — list 카드의 책임 과다(식별 + 결제 상세 + 다단계 액션 + 위험 액션) 분리. 5섹션 IA(Hero / 심사 상태 / 결제 정보 / 환불 정책 / 파트너 정보) + 환불 정책 카드 안 통합 "예매 취소" 버튼(canCancel false면 Material disabled).
- **EventApplicationReviewPage** spec — PurchaseHistoryDetail의 ④ 심사 상태 row가 push할 자식. 사용자가 자기 신청의 시간 흐름 + 사유 + 신청 답변 history를 한 timeline에서 본다.
- **MinglitTimeline** 컴포넌트 신규 — vertical stepper. semantic-neutral tone(success/progress/error/neutral/muted) + orthogonal pulsing + trailing/child slot. 어떤 도메인의 시간 순 progression도 표현 가능.

## 핵심 디자인 결정 (commit message에 trailers로 박힘)

- ReasonBox 말풍선 톤 (라벨 = sender · 본문 = 메시지) — 모든 종결 step 같은 패턴
- 자동 취소(이벤트 시작 도래 등)는 별도 state X — cancelled state의 reason 변형
- 신청 답변 별도 카드 X — timeline의 "신청" step 안 collapsible 통합 (snapshot_data array entry당 step 노출 → 재제출 시 timeline 자동 확장)
- "다시 신청하기" → 모든 status에서 EventDetailRoute push 통일
- Backend 재신청/결제 재시도 = **Model 1** (같은 applicationId 안 status 전환 + snapshot_data array append → history 누적)

## 후속 PR

이 spec이 활성되려면 별도 후속 PR들 필요 (Reference 섹션 / "후속 작업" 표 참조):
- Flutter — purchase_history_detail / event_application_review 위젯 + 라우트 + canCancel 화이트리스트 확장
- Flutter — MinglitTimeline 위젯 (mds_core)
- Backend — Model 1 정책 확정 + EventApplication/VerificationSubmission schema 확장 (cancellation_reason / reviewStartedAt / refundedAt / snapshotData typed)
- Spec — PurchaseHistoryPage list 슬림화
- Spec — PartnerDetailPage 존재 확인 / 신규 작업

## Test plan

- [ ] localhost:3003 dev server에서 spec 페이지 시각 검토
  - [ ] /specs/purchase_history_detail_page.html (8 state)
  - [ ] /specs/event_application_review_page.html (7 state)
  - [ ] /components#MinglitTimeline (Hero / Anatomy / Tone / Pulsing / Slots / Last step)
- [ ] 부모 ↔ 자식 spec link 양방향 동작 확인
- [ ] Dark mode toggle 시 토큰 swap 확인
- [ ] Spec mode toggle 시 첫 state mockup의 callout 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)