### PR TITLE
docs(mds): event application list redesign + review carousel/confirm specs

### DIFF
--- a/apps/mds/docs/public/specs/event_application_list_page.html
+++ b/apps/mds/docs/public/specs/event_application_list_page.html
@@ -1,0 +1,927 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<title>Spec — EventApplicationListPage (app_partner · EventApplicationListRoute)</title>
+<link rel="stylesheet" href="/specs/_spec.css">
+<style>
+/* ============================================================
+   EventApplicationListPage-specific atoms.
+
+   단일 이벤트의 참가 신청 풀 리스트 화면 (v2 — 입장그룹 sub-section + 심사 carousel 진입).
+   - 진입: partner_event_detail_page의 참가 현황 섹션 탭
+   - 심사 대기 카드 탭 → EventApplicationReviewCarouselRoute push (그 사용자부터)
+   - 처리 완료 카드 탭 → EventApplicationDetailRoute push (read-only 회고)
+   - Brand primary = MinglitPartnerColors.primary (#6c3ce1)
+   ============================================================ */
+.viewport {
+  --color-primary: var(--color-partner-primary);
+  --spec-blueprint-rgb: 108, 60, 225;
+}
+body.dark-mode .viewport {
+  --color-primary: var(--color-partner-dark-primary);
+}
+
+/* --- App bar --- */
+.eal-appbar {
+  height: 56px;
+  display: flex;
+  align-items: center;
+  background: var(--color-surface);
+}
+.eal-appbar__back {
+  width: 40px; height: 40px;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--color-text-primary);
+}
+.eal-appbar__back svg { width: 22px; height: 22px; }
+.eal-appbar__title {
+  flex: 1;
+  font-size: var(--typography-font-size-app-bar-title);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+.eal-appbar__count {
+  margin-right: var(--spacing-screen-edge);
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+/* --- Body --- */
+.eal-body {
+  position: absolute;
+  top: 56px;
+  left: 0; right: 0; bottom: 64px;
+  overflow-y: auto;
+  scrollbar-width: none;
+  background: var(--color-surface);
+  padding: var(--spacing-medium);
+  box-sizing: border-box;
+}
+.eal-body--no-cta { bottom: 0; }
+.eal-body::-webkit-scrollbar { display: none; }
+
+/* --- Group header --- */
+.eal-group {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin: 0 0 var(--spacing-small);
+}
+.eal-group--done {
+  color: var(--color-text-secondary);
+  margin-top: var(--spacing-large);
+  font-weight: 600;
+}
+
+/* --- Entry-group sub-section --- */
+.eal-eg {
+  margin-bottom: var(--spacing-medium);
+}
+.eal-eg__head {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xsmall);
+  margin: 0 0 6px;
+}
+.eal-eg__label {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+.eal-eg__count {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+}
+.eal-eg__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: var(--spacing-small);
+}
+.eal-eg__chip {
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  background: var(--color-divider);
+  border-radius: 999px;
+  padding: 2px 8px;
+  line-height: 1.4;
+}
+.eal-eg__chip--required {
+  color: var(--color-partner-primary);
+  background: rgba(108, 60, 225, 0.1);
+}
+
+/* --- Application card --- */
+.eal-card {
+  background: var(--color-background);
+  border-radius: var(--radius-card);
+  border: 1px solid var(--color-divider);
+  padding: var(--spacing-medium);
+  margin-bottom: var(--spacing-small);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-small);
+}
+.eal-card--done { opacity: 0.85; }
+.eal-card__avatar {
+  width: 40px; height: 40px;
+  border-radius: 50%;
+  background: rgba(108, 60, 225, 0.15);
+  color: var(--color-partner-primary);
+  display: flex; align-items: center; justify-content: center;
+  font-weight: 700;
+  font-size: 15px;
+}
+.eal-card__body { flex: 1; min-width: 0; }
+.eal-card__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+.eal-card__sub {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  margin-top: 2px;
+}
+.eal-card__badge {
+  padding: 4px 8px;
+  border-radius: var(--radius-small);
+  font-size: 11px;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+.eal-card__badge--pending {
+  color: var(--color-warning, #b85a00);
+  background: rgba(255, 165, 0, 0.12);
+  border-color: rgba(255, 165, 0, 0.25);
+}
+.eal-card__badge--approved {
+  color: #15803d;
+  background: rgba(34, 197, 94, 0.12);
+  border-color: rgba(34, 197, 94, 0.25);
+}
+.eal-card__badge--paid {
+  color: var(--color-partner-primary);
+  background: rgba(108, 60, 225, 0.12);
+  border-color: rgba(108, 60, 225, 0.25);
+}
+.eal-card__badge--rejected {
+  color: var(--color-error);
+  background: rgba(239, 68, 68, 0.12);
+  border-color: rgba(239, 68, 68, 0.25);
+}
+.eal-card__chevron {
+  color: var(--color-text-secondary);
+  flex-shrink: 0;
+  margin-left: 4px;
+}
+.eal-card__chevron svg { width: 14px; height: 14px; }
+
+/* --- Sticky bottom CTA --- */
+.eal-cta {
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-divider);
+  padding: var(--spacing-small) var(--spacing-medium);
+  box-sizing: border-box;
+}
+.eal-cta__btn {
+  width: 100%;
+  height: 48px;
+  border-radius: var(--radius-card);
+  background: var(--color-partner-primary);
+  color: white;
+  font-size: 15px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+/* --- Empty state --- */
+.eal-empty {
+  position: absolute;
+  inset: 56px 0 0 0;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  text-align: center;
+  padding: 0 var(--spacing-large);
+  gap: var(--spacing-small);
+}
+.eal-empty__icon {
+  width: 56px; height: 56px;
+  border-radius: 50%;
+  background: var(--color-divider);
+  display: flex; align-items: center; justify-content: center;
+  color: var(--color-text-secondary);
+  margin-bottom: var(--spacing-small);
+}
+.eal-empty__icon svg { width: 28px; height: 28px; }
+.eal-empty__title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+.eal-empty__sub {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+</style>
+</head>
+<body>
+
+<div class="toolbar">
+  <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>
+  <label><input type="checkbox" id="dark-toggle"> Dark mode (viewports flip dark)</label>
+</div>
+
+<div class="page">
+
+<!-- ============================================================
+     HEADER
+     ============================================================ -->
+<header>
+  <h1>Event Application List</h1>
+</header>
+
+<!-- ============================================================
+     OVERVIEW
+     ============================================================ -->
+<section class="doc">
+  <h2>Overview</h2>
+  <table class="ref">
+    <tbody>
+      <tr>
+        <th style="width: 140px;">Status</th>
+        <td><strong>📝 Redesign</strong> <em style="color: var(--color-text-secondary);">— v2 (입장그룹 sub-section + 심사 carousel 진입)</em></td>
+      </tr>
+      <tr>
+        <th>App</th>
+        <td><code>app_partner</code></td>
+      </tr>
+      <tr>
+        <th>Category</th>
+        <td>party · event · application · list (per-event)</td>
+      </tr>
+      <tr>
+        <th>Route / Surface</th>
+        <td><code>EventApplicationListRoute</code> · widget: <code>EventApplicationListPage</code></td>
+      </tr>
+      <tr>
+        <th>Path</th>
+        <td><code>/more/parties/:partyId/events/:eventId/applications</code></td>
+      </tr>
+      <tr>
+        <th>Hierarchy</th>
+        <td>
+          <strong>Parent</strong>: <a href="/specs/partner_event_detail_page.html"><code>EventDetailPage</code></a> (참가 현황 섹션 탭)<br>
+          <strong>Children</strong>:
+          <a href="/specs/event_application_review_carousel_page.html"><code>EventApplicationReviewCarouselRoute</code></a> (심사 대기 카드 탭 — 배치 심사 진입) ·
+          <a href="/specs/event_application_detail_page.html"><code>EventApplicationDetailRoute</code></a> (처리 완료 카드 탭 — read-only 회고)
+        </td>
+      </tr>
+      <tr>
+        <th>Purpose</th>
+        <td>
+          단일 이벤트에 들어온 참가 신청을 두 묶음(<em>심사 대기</em> · <em>처리 완료</em>)으로 보여주는 풀 리스트.
+          심사 대기 묶음은 <strong>입장그룹별 sub-section</strong>으로 정렬해 운영자가 그룹별 조건(성별·연령·required verifications)을 한눈에 확인할 수 있게 한다.
+          심사 대기 카드를 탭하면 <a href="/specs/event_application_review_carousel_page.html">EventApplicationReviewCarouselPage</a>(배치 심사 carousel)에 그 사용자부터 진입해 한 화면에서 연속 심사할 수 있다.
+        </td>
+      </tr>
+      <tr>
+        <th>User journey</th>
+        <td>
+          <strong>Entry points</strong>: 이벤트 상세(<a href="/specs/partner_event_detail_page.html">EventDetailPage</a>)의 "참가 현황" 섹션 탭. 또는 파트너 메인 nav의 <a href="/specs/event_application_manage_page.html">EventApplicationManagePage</a>(전체 이벤트 across)에서 특정 이벤트로 좁혀 진입(향후 — 본 spec 범위 밖).<br>
+          <strong>Exit points</strong>: AppBar back → EventDetailPage 복귀 / 심사 대기 카드 탭 → carousel push / 처리 완료 카드 탭 → detail page push / bottom CTA → carousel push (큐 처음부터).<br>
+          carousel / confirm 화면에서 최종 확정 후 본 화면으로 복귀하면 리스트가 자동 invalidate되어 카드가 적절한 그룹으로 재배치된다.
+        </td>
+      </tr>
+      <tr>
+        <th>Background</th>
+        <td>
+          v1은 신청을 단일 평면 리스트로 보여주고 카드별로 상세 페이지에서 개별 처리하는 구조였다. 입장그룹별 조건이 다른데도 그룹 시각화가 없어 운영자가 매번 카드 안으로 들어가서 조건을 재확인해야 했고, 신청이 많은 이벤트에서는 한 건씩 페이지를 오가는 비용이 컸다.
+          v2는 (1) 심사 대기를 입장그룹별로 묶어 조건을 한눈에 보이게 하고, (2) 카드 탭 시 배치 심사 carousel로 진입해 연속 심사 + 최종 확인 화면에서 한 번에 커밋하는 deferred batch 패턴을 도입한다.
+        </td>
+      </tr>
+      <tr>
+        <th>Frequency</th>
+        <td>이벤트 lifecycle 동안 운영자가 평균 5~20회 진입. 신청 흐름 활발한 이벤트일수록 빈도 높음.</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ============================================================
+     HISTORY
+     ============================================================ -->
+<section class="doc">
+  <h2>History</h2>
+  <table class="ref">
+    <thead>
+      <tr>
+        <th style="width: 110px;">날짜</th>
+        <th style="width: 120px;">버전</th>
+        <th>변경 사항</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>2026-05-03</td>
+        <td>v2 (redesign)</td>
+        <td>심사 대기 그룹을 입장그룹별 sub-section으로 분리. 카드 탭 라우팅 분기(심사 대기 → carousel · 처리 완료 → detail). bottom sticky CTA "심사 시작" 추가. Deferred batch review 패턴으로 carousel/confirm 자매 spec 도입.</td>
+      </tr>
+      <tr>
+        <td>2026-05-03</td>
+        <td>v1 (initial)</td>
+        <td>초안 작성. EventDetailPage Tab 2에 있던 신청 리스트를 별도 라우트로 승격. 신청 카드 탭 시 다이얼로그 대신 EventApplicationDetailRoute로 push 통일.</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ============================================================
+     LAYOUT
+     ============================================================ -->
+<div class="perspective" id="layout">
+  <div class="perspective__header">
+    <span class="glyph">🧱</span>
+    <h2>Layout</h2>
+    <span class="lede">화면 구조 — 영역, 정렬, 간격 규칙. 색·타이포 무시.</span>
+  </div>
+
+  <section class="doc">
+    <h2>Blueprint &amp; tree</h2>
+    <p class="intro">
+      <code>Scaffold</code> — AppBar(title + 우측 small count) + body(<code>ListView</code>: 심사 대기 그룹 → 입장그룹별 sub-section → 카드 / 처리 완료 그룹 → flat 카드) + bottom sticky CTA(심사 대기 ≥1일 때만). 심사 대기 카드 탭 시 carousel로 push, 처리 완료 카드 탭 시 detail로 push.
+    </p>
+    <div class="layout-grid">
+      <div class="blueprint">
+        <div class="blueprint__region blueprint__region--full"></div>
+
+        <!-- AppBar -->
+        <div class="blueprint__region blueprint__region--shaded" style="top:0;left:0;right:0;height:56px;">
+          <span class="blueprint__region-label">① AppBar — back + '참가 신청' (left) + count 배지(right · '심사 N · 완료 M')</span>
+        </div>
+
+        <!-- Pending group header -->
+        <div class="blueprint__region blueprint__region--shaded" style="top:80px;left:16px;right:16px;height:28px;">
+          <span class="blueprint__region-label" style="font-size:9px;">② 심사 대기 그룹 헤더 — '심사 대기 (N)'</span>
+        </div>
+
+        <!-- Entry group sub-section A -->
+        <div class="blueprint__region" style="top:116px;left:16px;right:16px;height:64px;">
+          <span class="blueprint__region-label">③ 입장그룹 sub-header — 라벨 + 조건 chips</span>
+        </div>
+        <div class="blueprint__region" style="top:188px;left:16px;right:16px;height:80px;">
+          <span class="blueprint__region-label">④ 입장그룹 A 카드 stack</span>
+        </div>
+
+        <!-- Entry group sub-section B -->
+        <div class="blueprint__region" style="top:284px;left:16px;right:16px;height:64px;">
+          <span class="blueprint__region-label">⑤ 입장그룹 B sub-header</span>
+        </div>
+        <div class="blueprint__region" style="top:356px;left:16px;right:16px;height:60px;">
+          <span class="blueprint__region-label">⑥ 입장그룹 B 카드 stack</span>
+        </div>
+
+        <!-- Done group -->
+        <div class="blueprint__region blueprint__region--shaded" style="top:440px;left:16px;right:16px;height:28px;">
+          <span class="blueprint__region-label" style="font-size:9px;">⑦ 처리 완료 그룹 헤더 — '처리 완료 (M)'</span>
+        </div>
+        <div class="blueprint__region" style="top:476px;left:16px;right:16px;height:88px;">
+          <span class="blueprint__region-label">⑧ 처리 완료 카드 stack — flat (입장그룹 무관 · 톤 가라앉힘)</span>
+        </div>
+
+        <!-- Sticky CTA -->
+        <div class="blueprint__region blueprint__region--shaded" style="bottom:0;left:0;right:0;height:64px;">
+          <span class="blueprint__region-label">⑨ Sticky '심사 시작 (N건)' — 심사 대기 ≥1일 때만</span>
+        </div>
+
+        <div class="blueprint__align-marker" style="top:8px;right:8px;">screen-edge pad 16</div>
+        <div class="blueprint__align-marker" style="top:424px;right:8px;">↕ spacing-large (24)</div>
+      </div>
+
+      <div class="layout-tree"><b>Scaffold</b>
+├─ <b>appBar</b>: <b>AppBar</b>                                  ← ①
+│  ├─ leading: BackButton (auto)
+│  ├─ title: Text('참가 신청')
+│  └─ actions: [Text('심사 N · 완료 M') <i>· bodySmall · text-secondary</i>]
+├─ <b>body</b>: <code>MinglitAsyncValueWidget&lt;Bundle&gt;</code>
+│  · Bundle = (entryGroups, applications) — 입장그룹과 신청을 같이 로드
+│  ├─ loading: full-page spinner
+│  ├─ error:   full-page error state
+│  └─ data:
+│     ├─ <em>case A — 빈 상태</em> (신청 0건)
+│     │  └─ Center → 안내 카피 + actionable hint
+│     │
+│     └─ <em>case B — 데이터 있음</em>
+│        └─ <b>ListView</b>(padding: <i>spacing-medium</i>)
+│           ├─ if pending.isNotEmpty:                          ← ②
+│           │  ├─ Text('심사 대기 (N)') <i>· 15px · w700</i>
+│           │  ├─ SizedBox(<i>spacing-small</i>)
+│           │  └─ for each entryGroup with pending ≥1:          ← ③④⑤⑥
+│           │     ├─ <b>_EntryGroupHeader</b>
+│           │     │  ├─ Text(group.label) <i>· 13px · w700</i>
+│           │     │  ├─ Text('· N건') <i>· 11px · secondary</i>
+│           │     │  └─ chip row
+│           │     │     · 성별 · 출생연도 범위 · required verifications (each chip)
+│           │     ├─ SizedBox(<i>spacing-small</i>)
+│           │     └─ <b>_ApplicationCard</b> × N
+│           │        · onTap → push <a href="/specs/event_application_review_carousel_page.html">CarouselRoute</a>(eventId, startApplicationId)
+│           │
+│           └─ if done.isNotEmpty:                              ← ⑦⑧
+│              ├─ SizedBox(<i>spacing-large</i>)
+│              ├─ Text('처리 완료 (M)') <i>· 15px · w600 · secondary</i>
+│              ├─ SizedBox(<i>spacing-small</i>)
+│              └─ <b>_ApplicationCard</b> × M (flat, 입장그룹 무관)
+│                 · status badge별 톤 (approved · paid · rejected)
+│                 · onTap → push <a href="/specs/event_application_detail_page.html">DetailRoute</a>(applicationId)
+│
+└─ <b>bottomNavigationBar</b>: <i>(if pending ≥1)</i>           ← ⑨
+   └─ <b>SafeArea</b> → Sticky CTA
+      └─ <code>FilledButton</code>('심사 시작 (N건)')
+         · onTap → push CarouselRoute(eventId, startApplicationId: 큐 첫 사용자)
+
+<em>각 _EntryGroupHeader chip 종류:</em>
+└─ 성별: '여성만' / '남성만' / '제한 없음' (gender 필드 기반)
+   출생연도: '1990~1999' / '20대 이상' / '제한 없음'
+   required: 'required: 신원확인' / 'required: 직업 인증' (각 verification id별 한 chip · primary 톤)
+
+<em>각 _ApplicationCard 내부:</em>
+└─ Card / InkWell wrap
+   └─ Row(padding: <i>spacing-medium</i>, gap: <i>spacing-small</i>)
+      ├─ <b>CircleAvatar</b>(40 · primaryContainer · 이름 첫 글자)
+      ├─ Expanded Column [
+      │    Text(user.name) · <i>14px · w600</i>
+      │    Text('남/여 · YYYY-MM-DD') · <i>12px · secondary</i>
+      │  ]
+      ├─ <b>_StatusBadge</b>
+      │  · pending_review → '심사 중' (warning 톤)
+      │  · approved       → '승인됨' (success 톤)
+      │  · paid           → '결제완료' (primary 톤)
+      │  · rejected       → '거절됨' (error 톤)
+      └─ Icon(chevron_right · 14 · text-secondary)</div>
+    </div>
+  </section>
+
+  <section class="doc">
+    <h2>Spacing &amp; alignment rules</h2>
+    <table class="ref">
+      <thead>
+        <tr>
+          <th style="width: 60px;">#</th>
+          <th style="width: 200px;">Region</th>
+          <th style="width: 220px;">Alignment</th>
+          <th>Spacing / tokens</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>①</td><td>AppBar</td><td>title left · count action right · 56px</td><td>centerTitle: false · h-pad <code>spacing-screen-edge</code> · count text <code>bodySmall</code> + <code>color-text-secondary</code> · margin-right <code>spacing-screen-edge</code></td></tr>
+        <tr><td>②⑦</td><td>Group header</td><td>좌측 정렬 · 단독 한 줄</td><td>심사 대기: 15px w700 <code>color-text-primary</code> · 처리 완료: 15px w600 <code>color-text-secondary</code> · 헤더↔첫 sub-section gap <code>spacing-small (8)</code></td></tr>
+        <tr><td>③⑤</td><td>Entry-group sub-header</td><td>좌측 정렬 · 라벨 + count + chip row</td><td>라벨 13px w700 · count 11px secondary · chip row gap 4px · sub-header↔첫 카드 <code>spacing-small</code></td></tr>
+        <tr><td>—</td><td>Entry-group chips</td><td>가로 wrap · primary 톤은 required만</td><td>font 10px w500 · radius 999 · padding 2/8 · 일반 chip <code>color-divider</code> bg + secondary text · required chip <code>color-partner-primary</code> 10% bg + primary text</td></tr>
+        <tr><td>④⑥⑧</td><td>Application card</td><td>풀폭 with screen-edge h-margin · row(avatar + body + badge + chevron)</td><td>padding <code>spacing-medium</code> · radius <code>radius-card</code> · border 1px <code>color-divider</code> · bg <code>color-background</code> · 카드 사이 <code>spacing-small (8)</code> · 처리 완료 카드 opacity 0.85</td></tr>
+        <tr><td>—</td><td>Sub-section 간 간격</td><td>—</td><td>이전 sub-section 마지막 카드 ↔ 다음 sub-header: <code>spacing-medium (16)</code></td></tr>
+        <tr><td>—</td><td>그룹 사이</td><td>—</td><td>심사 대기 마지막 카드 ↔ 처리 완료 헤더: <code>spacing-large (24)</code></td></tr>
+        <tr><td>—</td><td>Status badge</td><td>row trailing · before chevron</td><td>padding 4px 8px · radius <code>radius-small</code> · font-size 11px w600 · bg/border = 12% / 25% alpha 톤별</td></tr>
+        <tr><td>⑨</td><td>Sticky CTA</td><td>bottom · full width · SafeArea inset</td><td>bg <code>color-surface</code> + 1px top border <code>color-divider</code> · h-pad <code>spacing-medium</code> · v-pad <code>spacing-small</code> · 버튼 height 48 · radius <code>radius-card</code> · bg <code>color-partner-primary</code> · 라벨 15px w700 white</td></tr>
+        <tr><td>—</td><td>Empty state</td><td>centered · 화면 중앙 · column gap small</td><td>icon 56px circle · bg <code>color-divider</code> · title 15px w700 · sub 13px secondary line-height 1.5</td></tr>
+      </tbody>
+    </table>
+  </section>
+</div>
+
+<!-- ============================================================
+     STATES
+     ============================================================ -->
+<div class="perspective" id="states">
+  <div class="perspective__header">
+    <span class="glyph">🎨</span>
+    <h2>States</h2>
+    <span class="lede">시각 변형 4종. baseline = 입장그룹 2개 이상 + 처리 완료 모두 있음.</span>
+  </div>
+
+  <section class="doc">
+    <p class="intro">
+      <strong>State 식별 기준</strong>: (a) 심사 대기 그룹의 입장그룹 수(2+ / 1 / 0) (b) 처리 완료 그룹 비어있는지. 모든 카드 탭 동작은 출처 그룹별로 분기 — 심사 대기 카드 탭 시 carousel push, 처리 완료 카드 탭 시 detail push.
+    </p>
+
+    <!-- =================================================
+         STATE 1 — Default (입장그룹 2+ + 처리 완료 ≥1)
+         ================================================= -->
+    <table class="ref state-mini">
+      <thead>
+        <tr><th colspan="3"><strong>State 1 · Default</strong> 🎯 <span class="tag tag--mute">baseline</span> · <small>입장그룹 ≥2 · 처리 완료 ≥1</small></th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td rowspan="6" class="state-mini__mock"><div class="viewport">
+            <div class="eal-appbar">
+              <div class="eal-appbar__back">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+              </div>
+              <div class="eal-appbar__title">참가 신청</div>
+              <div class="eal-appbar__count">심사 4 · 완료 3</div>
+            </div>
+            <div class="eal-body">
+              <div class="eal-group">심사 대기 (4)</div>
+
+              <div class="eal-eg">
+                <div class="eal-eg__head">
+                  <span class="eal-eg__label">여성 그룹</span>
+                  <span class="eal-eg__count">· 2건</span>
+                </div>
+                <div class="eal-eg__chips">
+                  <span class="eal-eg__chip">여성만</span>
+                  <span class="eal-eg__chip">1990~1999</span>
+                  <span class="eal-eg__chip eal-eg__chip--required">required: 신원확인</span>
+                  <span class="eal-eg__chip eal-eg__chip--required">required: 직업 인증</span>
+                </div>
+                <div class="eal-card">
+                  <div class="eal-card__avatar">김</div>
+                  <div class="eal-card__body">
+                    <div class="eal-card__name">김민지</div>
+                    <div class="eal-card__sub">여 · 1996-03-12</div>
+                  </div>
+                  <div class="eal-card__badge eal-card__badge--pending">심사 중</div>
+                  <div class="eal-card__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+                </div>
+                <div class="eal-card">
+                  <div class="eal-card__avatar">정</div>
+                  <div class="eal-card__body">
+                    <div class="eal-card__name">정유진</div>
+                    <div class="eal-card__sub">여 · 1995-07-08</div>
+                  </div>
+                  <div class="eal-card__badge eal-card__badge--pending">심사 중</div>
+                  <div class="eal-card__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+                </div>
+              </div>
+
+              <div class="eal-eg">
+                <div class="eal-eg__head">
+                  <span class="eal-eg__label">남성 그룹</span>
+                  <span class="eal-eg__count">· 2건</span>
+                </div>
+                <div class="eal-eg__chips">
+                  <span class="eal-eg__chip">남성만</span>
+                  <span class="eal-eg__chip">1990~1999</span>
+                  <span class="eal-eg__chip eal-eg__chip--required">required: 신원확인</span>
+                </div>
+                <div class="eal-card">
+                  <div class="eal-card__avatar">박</div>
+                  <div class="eal-card__body">
+                    <div class="eal-card__name">박지호</div>
+                    <div class="eal-card__sub">남 · 1992-08-04</div>
+                  </div>
+                  <div class="eal-card__badge eal-card__badge--pending">심사 중</div>
+                  <div class="eal-card__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+                </div>
+                <div class="eal-card">
+                  <div class="eal-card__avatar">한</div>
+                  <div class="eal-card__body">
+                    <div class="eal-card__name">한승우</div>
+                    <div class="eal-card__sub">남 · 1994-11-22</div>
+                  </div>
+                  <div class="eal-card__badge eal-card__badge--pending">심사 중</div>
+                  <div class="eal-card__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+                </div>
+              </div>
+
+              <div class="eal-group eal-group--done">처리 완료 (3)</div>
+              <div class="eal-card eal-card--done">
+                <div class="eal-card__avatar">이</div>
+                <div class="eal-card__body">
+                  <div class="eal-card__name">이서연</div>
+                  <div class="eal-card__sub">여 · 1998-11-20</div>
+                </div>
+                <div class="eal-card__badge eal-card__badge--paid">결제완료</div>
+                <div class="eal-card__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+              </div>
+              <div class="eal-card eal-card--done">
+                <div class="eal-card__avatar">최</div>
+                <div class="eal-card__body">
+                  <div class="eal-card__name">최도윤</div>
+                  <div class="eal-card__sub">남 · 1990-05-15</div>
+                </div>
+                <div class="eal-card__badge eal-card__badge--rejected">거절됨</div>
+                <div class="eal-card__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+              </div>
+              <div class="eal-card eal-card--done">
+                <div class="eal-card__avatar">윤</div>
+                <div class="eal-card__body">
+                  <div class="eal-card__name">윤하늘</div>
+                  <div class="eal-card__sub">여 · 1997-02-18</div>
+                </div>
+                <div class="eal-card__badge eal-card__badge--approved">승인됨</div>
+                <div class="eal-card__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+              </div>
+            </div>
+            <div class="eal-cta">
+              <div class="eal-cta__btn">심사 시작 (4건)</div>
+            </div>
+          </div></td>
+          <td class="state-mini__aspect">조건</td>
+          <td>이벤트와 입장그룹 데이터 로드 완료. 심사 대기 신청이 둘 이상의 입장그룹에 분포 · 처리 완료(승인 / 결제완료 / 거절 합산) ≥1건. 두 그룹 헤더 + 두 sub-section 모두 노출 + bottom CTA 활성.</td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">사용자 액션</td>
+          <td>
+            · <strong>심사 대기 카드 탭</strong> → 그 사용자부터 carousel 진입 (carousel 내부 큐 = 모든 입장그룹의 pending across, 입장그룹 경계 무시)<br>
+            · <strong>bottom '심사 시작' 탭</strong> → 큐 첫 사용자부터 carousel 진입<br>
+            · <strong>처리 완료 카드 탭</strong> → 상세 페이지로 push (조회 + 환불 / 노트 등 후속 액션)<br>
+            · <strong>최종 확정 후 복귀</strong> → 자동 invalidate → 카드가 그룹 사이를 이동 (심사 대기 → 처리 완료)<br>
+            · <strong>뒤로가기</strong> → EventDetailPage 복귀 + 로컬 마킹 캐시 invalidate
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">에지케이스</td><td>· 입장그룹 sub-section은 그룹의 pending이 0이면 통째로 숨김 — 빈 헤더 노출 X<br>· 입장그룹 라벨이 비어있으면(template 미지정) "이름 없는 그룹"으로 fallback<br>· chip이 가로 폭을 초과하면 wrap (보존, ellipsis X)<br>· status badge 4종(pending_review / approved / paid / rejected) 모두 한 화면에 동시 가능</td></tr>
+        <tr>
+          <td class="state-mini__aspect">컴포넌트</td>
+          <td>
+            <code>Scaffold</code> · <code>AppBar</code> · <code>MinglitAsyncValueWidget&lt;Bundle&gt;</code> · <code>ListView</code> · <code>_GroupHeader</code> · <code>_EntryGroupHeader</code>(label · count · chip row) · <code>_ApplicationCard</code> · <code>_StatusBadge</code> · <code>FilledButton</code>(sticky CTA) · <code>SafeArea</code>
+          </td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">토큰</td>
+          <td>
+            <code>color-primary</code>(partner #6c3ce1 — avatar bg @ 15% / paid badge @ 12% / required chip 10% / sticky CTA bg 100%) · <code>color-text-primary</code>(이름 / 심사 대기 헤더 / sub-header 라벨) · <code>color-text-secondary</code>(서브 / 처리 완료 헤더 / 일반 chip / count) · <code>color-warning</code>(심사 중 badge) · <code>color-error</code>(거절 badge) · #15803d(승인 badge) · <code>radius-card</code> · <code>radius-small</code> · <code>spacing-screen-edge</code> · <code>spacing-medium</code> · <code>spacing-small</code> · <code>spacing-large</code> · typography 14px w600 (이름) / 12px secondary (서브) / 11px w600 (badge) / 13px w700 (sub-header 라벨) / 11px secondary (sub-header count) / 10px w500 (chip) / 15px w700 (CTA / 심사 대기 헤더) / 15px w600 secondary (처리 완료 헤더)
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">노트</td><td>📝 baseline. 입장그룹별 조건이 한눈에 들어오므로 운영자는 그룹 안 사용자만 빠르게 비교/판단할 수 있다. carousel 진입 시 순회는 입장그룹 경계를 넘어가는 점에 주의 — 큐는 created_at 정렬, 그룹별 batch가 아님.</td></tr>
+      </tbody>
+    </table>
+
+    <!-- =================================================
+         STATE 2 — 단일 입장그룹
+         ================================================= -->
+    <table class="ref state-mini">
+      <thead>
+        <tr><th colspan="3"><strong>State 2 · 단일 입장그룹</strong> <span class="tag tag--mute">single-group</span> · <small>심사 대기의 입장그룹 1개</small></th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td rowspan="3" class="state-mini__mock"><div class="viewport">
+            <div class="eal-appbar">
+              <div class="eal-appbar__back">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+              </div>
+              <div class="eal-appbar__title">참가 신청</div>
+              <div class="eal-appbar__count">심사 3 · 완료 0</div>
+            </div>
+            <div class="eal-body">
+              <div class="eal-group">심사 대기 (3)</div>
+              <div class="eal-eg">
+                <div class="eal-eg__head">
+                  <span class="eal-eg__label">기본 그룹</span>
+                  <span class="eal-eg__count">· 3건</span>
+                </div>
+                <div class="eal-eg__chips">
+                  <span class="eal-eg__chip">제한 없음</span>
+                  <span class="eal-eg__chip eal-eg__chip--required">required: 신원확인</span>
+                </div>
+                <div class="eal-card">
+                  <div class="eal-card__avatar">김</div>
+                  <div class="eal-card__body">
+                    <div class="eal-card__name">김민지</div>
+                    <div class="eal-card__sub">여 · 1996-03-12</div>
+                  </div>
+                  <div class="eal-card__badge eal-card__badge--pending">심사 중</div>
+                  <div class="eal-card__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+                </div>
+                <div class="eal-card">
+                  <div class="eal-card__avatar">박</div>
+                  <div class="eal-card__body">
+                    <div class="eal-card__name">박지호</div>
+                    <div class="eal-card__sub">남 · 1992-08-04</div>
+                  </div>
+                  <div class="eal-card__badge eal-card__badge--pending">심사 중</div>
+                  <div class="eal-card__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+                </div>
+                <div class="eal-card">
+                  <div class="eal-card__avatar">한</div>
+                  <div class="eal-card__body">
+                    <div class="eal-card__name">한승우</div>
+                    <div class="eal-card__sub">남 · 1994-11-22</div>
+                  </div>
+                  <div class="eal-card__badge eal-card__badge--pending">심사 중</div>
+                  <div class="eal-card__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+                </div>
+              </div>
+            </div>
+            <div class="eal-cta">
+              <div class="eal-cta__btn">심사 시작 (3건)</div>
+            </div>
+          </div></td>
+          <td class="state-mini__aspect">조건</td>
+          <td>심사 대기의 입장그룹이 1개만 있고 처리 완료 0건. State 1 대비 sub-section이 하나뿐 + "처리 완료" 그룹 헤더/카드 모두 렌더 X.</td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">사용자 액션</td>
+          <td>State 1과 동일. sub-section이 하나여도 헤더 + chip은 동일 표기 — 그룹 조건을 항상 명시.</td>
+        </tr>
+        <tr><td class="state-mini__aspect">노트</td><td>📝 첫 신청자 도착 직후 단계 또는 단일 입장그룹 정책의 이벤트. carousel 진입 시 큐는 단일 그룹 안에서만 순회된다(자연스럽게).</td></tr>
+      </tbody>
+    </table>
+
+    <!-- =================================================
+         STATE 3 — 처리 완료만
+         ================================================= -->
+    <table class="ref state-mini">
+      <thead>
+        <tr><th colspan="3"><strong>State 3 · 처리 완료만</strong> <span class="tag tag--mute">done-only</span> · <small>심사 대기 0건 · 처리 완료 ≥1건</small></th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td rowspan="3" class="state-mini__mock"><div class="viewport">
+            <div class="eal-appbar">
+              <div class="eal-appbar__back">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+              </div>
+              <div class="eal-appbar__title">참가 신청</div>
+              <div class="eal-appbar__count">심사 0 · 완료 5</div>
+            </div>
+            <div class="eal-body eal-body--no-cta">
+              <div class="eal-group eal-group--done" style="margin-top:0;">처리 완료 (5)</div>
+              <div class="eal-card eal-card--done">
+                <div class="eal-card__avatar">이</div>
+                <div class="eal-card__body">
+                  <div class="eal-card__name">이서연</div>
+                  <div class="eal-card__sub">여 · 1998-11-20</div>
+                </div>
+                <div class="eal-card__badge eal-card__badge--paid">결제완료</div>
+                <div class="eal-card__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+              </div>
+              <div class="eal-card eal-card--done">
+                <div class="eal-card__avatar">최</div>
+                <div class="eal-card__body">
+                  <div class="eal-card__name">최도윤</div>
+                  <div class="eal-card__sub">남 · 1990-05-15</div>
+                </div>
+                <div class="eal-card__badge eal-card__badge--approved">승인됨</div>
+                <div class="eal-card__chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg></div>
+              </div>
+            </div>
+          </div></td>
+          <td class="state-mini__aspect">조건</td>
+          <td>심사 대기 0건 · 처리 완료 ≥1건 (운영자의 todo zero 상태). 심사 대기 그룹 + sub-section + sticky CTA 모두 렌더 X.</td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">사용자 액션</td>
+          <td>처리 완료 그룹 헤더가 본문 최상단에 위치 (margin-top 0). 카드 탭 → 상세 페이지로 push (조회 모드).</td>
+        </tr>
+        <tr><td class="state-mini__aspect">노트</td><td>✅ 평온한 상태. 새 신청이 들어오면 자동으로 State 1 / 2로 전환되며 sticky CTA가 다시 등장.</td></tr>
+      </tbody>
+    </table>
+
+    <!-- =================================================
+         STATE 4 — 빈 상태
+         ================================================= -->
+    <table class="ref state-mini">
+      <thead>
+        <tr><th colspan="3"><strong>State 4 · 빈 상태</strong> <span class="tag tag--mute">empty</span> · <small>신청 0건 (이벤트 직후 또는 마감 후)</small></th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td rowspan="3" class="state-mini__mock"><div class="viewport">
+            <div class="eal-appbar">
+              <div class="eal-appbar__back">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+              </div>
+              <div class="eal-appbar__title">참가 신청</div>
+              <div class="eal-appbar__count">심사 0 · 완료 0</div>
+            </div>
+            <div class="eal-empty">
+              <div class="eal-empty__icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 16 12 14 15 10 15 8 12 2 12"/><path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></svg>
+              </div>
+              <div class="eal-empty__title">신청 내역이 없습니다.</div>
+              <div class="eal-empty__sub">신청이 들어오면 여기에 표시됩니다.<br>이벤트가 외부에 잘 노출되고 있는지 확인해보세요.</div>
+            </div>
+          </div></td>
+          <td class="state-mini__aspect">조건</td>
+          <td>심사 대기 0건 · 처리 완료 0건 (신청 자체가 없음 — 새 이벤트 직후 또는 비공개 / 노출 부족). sticky CTA 비활성.</td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">사용자 액션</td>
+          <td>· 화면 중앙에 빈 상태 가이드 노출<br>· 뒤로가기 → EventDetailPage 복귀<br>· 새 신청 발생 시 (자동 갱신) → State 1 / 2 / 3 중 하나로 자동 전환</td>
+        </tr>
+        <tr><td class="state-mini__aspect">노트</td><td>📭 가이드 텍스트가 운영자에게 다음 액션 힌트(노출 점검)를 던진다 — 단순 "비어있음"이 아니라 actionable copy.</td></tr>
+      </tbody>
+    </table>
+  </section>
+</div>
+
+<!-- ============================================================
+     GLOBAL BEHAVIOR
+     ============================================================ -->
+<div class="perspective" id="behavior">
+  <div class="perspective__header">
+    <span class="glyph">🔄</span>
+    <h2>Global Behavior</h2>
+    <span class="lede">모든 state에 동일하게 적용되는 동작.</span>
+  </div>
+
+  <section class="doc">
+    <h2>Sub-section 그룹화 규칙</h2>
+    <ul>
+      <li><strong>심사 대기 그룹</strong>은 입장그룹별 sub-section으로 묶여 표시된다. 매핑은 <code>application.ticketId</code> → <code>ticket.target_entry_group_id(s)</code> → <code>entry_group</code>으로 해석.</li>
+      <li>sub-section 정렬 — 입장그룹의 정의 순서(이벤트 생성 시 순서) 유지. 자연 정렬 외 정책 없음.</li>
+      <li>sub-section 안 카드 정렬 — <code>created_at DESC</code> (최근 신청이 위).</li>
+      <li>심사 대기 카운트(상단 헤더 + appbar count)는 모든 sub-section 합산.</li>
+      <li>입장그룹의 pending이 0이면 sub-section은 통째로 숨긴다(빈 헤더 노출 금지).</li>
+      <li><strong>처리 완료 그룹</strong>은 입장그룹 sub-grouping을 적용하지 않는다 — flat list, <code>updated_at DESC</code>(최근 처리한 게 위).</li>
+    </ul>
+  </section>
+
+  <section class="doc">
+    <h2>Carousel 진입 큐 정의</h2>
+    <ul>
+      <li>심사 대기 카드 탭 → carousel push에 <code>startApplicationId</code> 전달. carousel 내부 큐는 <strong>전체 심사 대기 신청</strong>(입장그룹 경계 무시) · <code>created_at ASC</code> 정렬.</li>
+      <li>예: 입장그룹 B의 두 번째 카드를 탭하면, carousel 큐 안에서 그 사용자의 위치(예: 4 / 6)에서 시작 → 자동 다음 사용자 이동 시 입장그룹 A의 사용자로 자연스럽게 넘어갈 수 있다.</li>
+      <li>bottom sticky '심사 시작' CTA → 큐 첫 사용자부터 시작.</li>
+      <li>carousel에서 페이지 이탈(리스트로 pop) 시 마킹은 보존. 본 리스트 화면을 추가로 이탈(EventDetailPage로 pop)하면 마킹 캐시가 invalidate (자세한 룰은 carousel spec 참조).</li>
+    </ul>
+  </section>
+
+  <section class="doc">
+    <h2>리스트 fresh 정책</h2>
+    <ul>
+      <li>화면 진입 시 (entryGroups, applications) 번들을 fresh fetch.</li>
+      <li>carousel/confirm에서 <strong>최종 확정</strong> 후 본 화면 복귀 시 자동 갱신 — 카드가 그룹 사이를 자연스럽게 이동(심사 대기 → 처리 완료).</li>
+      <li>processing 완료 직후 입장그룹 sub-section의 pending이 0이 되면 sub-section 자체가 사라짐 → 자연스러운 "비워짐" 시그널.</li>
+      <li>실시간 갱신(다른 운영자 동시 처리)은 본 spec 범위 밖 — 향후 realtime subscription 고려.</li>
+    </ul>
+  </section>
+
+  <section class="doc">
+    <h2>카드 탭 라우팅 분기</h2>
+    <ul>
+      <li><strong>심사 대기 카드</strong> → <a href="/specs/event_application_review_carousel_page.html"><code>EventApplicationReviewCarouselRoute</code></a> (그 사용자부터 배치 심사).</li>
+      <li><strong>처리 완료 카드</strong> → <a href="/specs/event_application_detail_page.html"><code>EventApplicationDetailRoute</code></a> (read-only 회고 + 환불 / 노트 등 후속 액션).</li>
+      <li>같은 카드 컴포넌트지만 출처 그룹에 따라 도착지가 다르다는 점이 핵심.</li>
+    </ul>
+  </section>
+
+  <section class="doc">
+    <h2>입장그룹 chip 정책</h2>
+    <ul>
+      <li>chip 종류와 표기:
+        <ul>
+          <li><strong>성별</strong>: gender가 'male' → '남성만', 'female' → '여성만', null → '제한 없음'</li>
+          <li><strong>출생연도</strong>: birthYearMin / Max가 모두 null이면 '제한 없음', 둘 다 있으면 '1990~1999', 한쪽만 있으면 '1990 이후' / '1999 이전'</li>
+          <li><strong>required verifications</strong>: 각 verificationId마다 한 chip — 'required: 신원확인' (verification 라벨로 해석)</li>
+        </ul>
+      </li>
+      <li>required chip은 primary 톤 — 운영자가 가장 먼저 봐야 할 시그널이기 때문에 강조.</li>
+      <li>일반 chip(성별 / 출생연도)은 secondary 톤 — 그룹의 인구통계 컨텍스트 제공.</li>
+      <li>chip 가로 폭이 부족하면 wrap (여러 줄 가능). ellipsis 사용 X.</li>
+    </ul>
+  </section>
+</div>
+
+<!-- ============================================================
+     REFERENCE
+     ============================================================ -->
+<div class="perspective" id="reference">
+  <div class="perspective__header">
+    <span class="glyph">🔗</span>
+    <h2>Reference</h2>
+    <span class="lede">관련 라우트 · 화면 · 구현 소스.</span>
+  </div>
+
+  <section class="doc">
+    <h2>Implementation source</h2>
+    <table class="ref">
+      <tbody>
+        <tr><td style="width: 160px;"><strong>Route</strong></td><td><code>EventApplicationListRoute</code></td></tr>
+        <tr><td><strong>Path</strong></td><td><code>/more/parties/:partyId/events/:eventId/applications</code></td></tr>
+        <tr><td><strong>Widget class</strong></td><td><code>EventApplicationListPage</code> (+ <code>_GroupHeader</code> · <code>_EntryGroupHeader</code> · <code>_ApplicationCard</code> · <code>_StatusBadge</code> internal widgets)</td></tr>
+        <tr><td><strong>App</strong></td><td><code>app_partner</code></td></tr>
+        <tr><td><strong>Source (예상)</strong></td><td><code>apps/app_partner/lib/src/features/event/applications/event_application_list_page.dart</code></td></tr>
+        <tr><td><strong>Bundle source</strong></td><td>입장그룹: <code>partyEntryGroupsProvider</code> 또는 이벤트 상세 cache · 신청: <code>eventApplicationsProvider(eventId)</code></td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Related screens</h2>
+    <table class="ref">
+      <thead><tr><th style="width: 280px;">Spec</th><th>관계</th></tr></thead>
+      <tbody>
+        <tr><td><a href="/specs/partner_event_detail_page.html"><code>EventDetailPage</code></a></td><td>Parent — 참가 현황 섹션 탭에서 진입.</td></tr>
+        <tr><td><a href="/specs/event_application_review_carousel_page.html"><code>EventApplicationReviewCarouselPage</code></a></td><td>Child (primary) — 심사 대기 카드 탭 / sticky CTA 탭 시 push되는 배치 심사 carousel.</td></tr>
+        <tr><td><a href="/specs/event_application_review_confirm_page.html"><code>EventApplicationReviewConfirmPage</code></a></td><td>Grandchild — carousel 큐가 끝나면 push되는 최종 확인 화면(리스트에서 직접 진입은 없음).</td></tr>
+        <tr><td><a href="/specs/event_application_detail_page.html"><code>EventApplicationDetailPage</code></a></td><td>Child (secondary) — 처리 완료 카드 탭 시 push. read-only 회고 + 환불 / 노트.</td></tr>
+        <tr><td><a href="/specs/event_application_manage_page.html"><code>EventApplicationManagePage</code></a></td><td>Sibling — 파트너 메인 nav의 cross-event 신청 리스트. 본 화면은 <em>단일 이벤트</em>로 좁힌 버전.</td></tr>
+      </tbody>
+    </table>
+  </section>
+</div>
+
+</div>
+</body>
+</html>

--- a/apps/mds/docs/public/specs/event_application_list_page.html
+++ b/apps/mds/docs/public/specs/event_application_list_page.html
@@ -829,7 +829,7 @@ body.dark-mode .viewport {
     <h2>Sub-section 그룹화 규칙</h2>
     <ul>
       <li><strong>심사 대기 그룹</strong>은 입장그룹별 sub-section으로 묶여 표시된다. 매핑은 <code>application.ticketId</code> → <code>ticket.target_entry_group_id(s)</code> → <code>entry_group</code>으로 해석.</li>
-      <li>sub-section 정렬 — 입장그룹의 정의 순서(이벤트 생성 시 순서) 유지. 자연 정렬 외 정책 없음.</li>
+      <li>sub-section 정렬 — <code>entry_group.created_at ASC</code> (이벤트 정의 시 입장그룹이 생성된 순서). 별도 position / display_order 컬럼은 도입하지 않는다 — 운영자가 사후 순서 조정을 요구한 적 없고, #2102 1:1 enforce 작업과 결합해 의도치 않은 컬럼 추가를 피한다.</li>
       <li>sub-section 안 카드 정렬 — <code>created_at DESC</code> (최근 신청이 위).</li>
       <li>심사 대기 카운트(상단 헤더 + appbar count)는 모든 sub-section 합산.</li>
       <li>입장그룹의 pending이 0이면 sub-section은 통째로 숨긴다(빈 헤더 노출 금지).</li>

--- a/apps/mds/docs/public/specs/event_application_review_carousel_page.html
+++ b/apps/mds/docs/public/specs/event_application_review_carousel_page.html
@@ -1,0 +1,874 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<title>Spec — EventApplicationReviewCarouselPage (app_partner · EventApplicationReviewCarouselRoute)</title>
+<link rel="stylesheet" href="/specs/_spec.css">
+<style>
+/* ============================================================
+   Review carousel — 풀스크린 단일 사용자 심사 화면.
+
+   - 진입: EventApplicationListPage 카드 탭 또는 sticky CTA
+   - 큐: 모든 심사 대기 신청 across 입장그룹, created_at ASC
+   - 마킹은 로컬 캐시(eventId 기준) — 페이지 이탈 시 invalidate
+   - 큐 끝 → confirm 화면으로 replace
+   ============================================================ */
+.viewport {
+  --color-primary: var(--color-partner-primary);
+  --spec-blueprint-rgb: 108, 60, 225;
+}
+body.dark-mode .viewport {
+  --color-primary: var(--color-partner-dark-primary);
+}
+
+/* --- App bar --- */
+.erc-appbar {
+  height: 56px;
+  display: flex;
+  align-items: center;
+  background: var(--color-surface);
+}
+.erc-appbar__back {
+  width: 40px; height: 40px;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--color-text-primary);
+}
+.erc-appbar__back svg { width: 22px; height: 22px; }
+.erc-appbar__title {
+  flex: 1;
+  font-size: var(--typography-font-size-app-bar-title);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+.erc-appbar__progress {
+  margin-right: var(--spacing-screen-edge);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-partner-primary);
+}
+
+/* --- Body --- */
+.erc-body {
+  position: absolute;
+  top: 56px;
+  left: 0; right: 0; bottom: 88px;
+  overflow-y: auto;
+  scrollbar-width: none;
+  background: var(--color-surface);
+  padding: var(--spacing-medium);
+  box-sizing: border-box;
+}
+.erc-body::-webkit-scrollbar { display: none; }
+
+/* --- User header --- */
+.erc-user {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: var(--spacing-large) var(--spacing-medium) var(--spacing-medium);
+}
+.erc-user__avatar {
+  width: 72px; height: 72px;
+  border-radius: 50%;
+  background: rgba(108, 60, 225, 0.15);
+  color: var(--color-partner-primary);
+  display: flex; align-items: center; justify-content: center;
+  font-weight: 700;
+  font-size: 26px;
+}
+.erc-user__name {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+.erc-user__sub {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+/* --- Entry-group banner --- */
+.erc-eg {
+  background: var(--color-background);
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-card);
+  padding: var(--spacing-small) var(--spacing-medium);
+  margin: var(--spacing-medium) 0;
+}
+.erc-eg__head {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xsmall);
+  margin-bottom: 6px;
+}
+.erc-eg__label {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+.erc-eg__caption {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+}
+.erc-eg__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.erc-eg__chip {
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  background: var(--color-divider);
+  border-radius: 999px;
+  padding: 2px 8px;
+  line-height: 1.4;
+}
+.erc-eg__chip--required {
+  color: var(--color-partner-primary);
+  background: rgba(108, 60, 225, 0.1);
+}
+
+/* --- Verification submission card --- */
+.erc-sub {
+  background: var(--color-background);
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-card);
+  padding: var(--spacing-medium);
+  margin-bottom: var(--spacing-small);
+}
+.erc-sub__head {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xsmall);
+  margin-bottom: 8px;
+}
+.erc-sub__title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  flex: 1;
+}
+.erc-sub__tag {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--color-partner-primary);
+  background: rgba(108, 60, 225, 0.1);
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+.erc-sub__row {
+  display: flex;
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+.erc-sub__key {
+  color: var(--color-text-secondary);
+  width: 90px;
+  flex-shrink: 0;
+}
+.erc-sub__val {
+  color: var(--color-text-primary);
+  flex: 1;
+  word-break: break-word;
+}
+.erc-sub__photo {
+  margin-top: var(--spacing-small);
+  height: 80px;
+  background: var(--color-divider);
+  border-radius: var(--radius-small);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-secondary);
+  font-size: 11px;
+}
+
+/* --- Marking pill (when re-entering from confirm) --- */
+.erc-mark {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 4px 10px;
+  border-radius: 999px;
+  margin-bottom: var(--spacing-small);
+}
+.erc-mark--approve {
+  color: #15803d;
+  background: rgba(34, 197, 94, 0.12);
+  border: 1px solid rgba(34, 197, 94, 0.25);
+}
+.erc-mark--reject {
+  color: var(--color-error);
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+}
+
+/* --- Bottom dual CTA --- */
+.erc-cta {
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  display: flex;
+  gap: var(--spacing-small);
+  padding: var(--spacing-small) var(--spacing-medium);
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-divider);
+  box-sizing: border-box;
+}
+.erc-cta__btn {
+  flex: 1;
+  height: 48px;
+  border-radius: var(--radius-card);
+  font-size: 15px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.erc-cta__btn--reject {
+  background: var(--color-background);
+  color: var(--color-error);
+  border: 1px solid var(--color-error);
+}
+.erc-cta__btn--approve {
+  background: var(--color-partner-primary);
+  color: white;
+}
+
+/* --- Reject reason bottom sheet --- */
+.erc-sheet-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+}
+.erc-sheet {
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  background: var(--color-surface);
+  border-top-left-radius: 20px;
+  border-top-right-radius: 20px;
+  padding: var(--spacing-medium);
+  box-sizing: border-box;
+}
+.erc-sheet__handle {
+  width: 36px; height: 4px;
+  border-radius: 2px;
+  background: var(--color-divider);
+  margin: 0 auto var(--spacing-small);
+}
+.erc-sheet__title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin-bottom: 6px;
+}
+.erc-sheet__sub {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  margin-bottom: var(--spacing-small);
+}
+.erc-sheet__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: var(--spacing-small);
+}
+.erc-sheet__chip {
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--color-divider);
+  font-size: 12px;
+  color: var(--color-text-primary);
+  background: var(--color-background);
+}
+.erc-sheet__chip--selected {
+  border-color: var(--color-error);
+  background: rgba(239, 68, 68, 0.08);
+  color: var(--color-error);
+  font-weight: 600;
+}
+.erc-sheet__input {
+  background: var(--color-background);
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-card);
+  padding: var(--spacing-small) var(--spacing-medium);
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  margin-bottom: var(--spacing-small);
+  min-height: 60px;
+}
+.erc-sheet__submit {
+  width: 100%;
+  height: 44px;
+  border-radius: var(--radius-card);
+  background: var(--color-error);
+  color: white;
+  font-size: 14px;
+  font-weight: 700;
+  display: flex; align-items: center; justify-content: center;
+}
+.erc-sheet__submit--disabled {
+  background: var(--color-divider);
+  color: var(--color-text-secondary);
+}
+</style>
+</head>
+<body>
+
+<div class="toolbar">
+  <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>
+  <label><input type="checkbox" id="dark-toggle"> Dark mode (viewports flip dark)</label>
+</div>
+
+<div class="page">
+
+<header>
+  <h1>Event Application Review Carousel</h1>
+</header>
+
+<!-- ============================================================
+     OVERVIEW
+     ============================================================ -->
+<section class="doc">
+  <h2>Overview</h2>
+  <table class="ref">
+    <tbody>
+      <tr>
+        <th style="width: 140px;">Status</th>
+        <td><strong>📝 신규작성</strong> <em style="color: var(--color-text-secondary);">— v1 (배치 심사 carousel · deferred marking)</em></td>
+      </tr>
+      <tr>
+        <th>App</th>
+        <td><code>app_partner</code></td>
+      </tr>
+      <tr>
+        <th>Category</th>
+        <td>party · event · application · review (batch)</td>
+      </tr>
+      <tr>
+        <th>Route / Surface</th>
+        <td><code>EventApplicationReviewCarouselRoute</code> · widget: <code>EventApplicationReviewCarouselPage</code></td>
+      </tr>
+      <tr>
+        <th>Path</th>
+        <td><code>/more/parties/:partyId/events/:eventId/applications/review</code> (query: <code>?start=:applicationId</code>)</td>
+      </tr>
+      <tr>
+        <th>Hierarchy</th>
+        <td>
+          <strong>Parent</strong>: <a href="/specs/event_application_list_page.html"><code>EventApplicationListPage</code></a> (심사 대기 카드 탭 / sticky CTA)<br>
+          <strong>Children (sequel)</strong>: <a href="/specs/event_application_review_confirm_page.html"><code>EventApplicationReviewConfirmRoute</code></a> (큐 종료 시 replace push)
+        </td>
+      </tr>
+      <tr>
+        <th>Purpose</th>
+        <td>
+          심사 대기 신청을 한 명씩 풀스크린에서 빠르게 검토하고 <strong>로컬에 마킹</strong>(승인 / 거절 + 사유)하기 위한 화면.
+          제출 정보는 입장그룹의 required verifications만 노출 — 운영자가 매번 무엇을 봐야 하는지 의식하지 않아도 그룹 정책이 자동으로 좁혀준다.
+          마킹은 즉시 백엔드로 커밋되지 않고, 큐가 끝난 뒤 <a href="/specs/event_application_review_confirm_page.html">확인 화면</a>에서 한 번에 커밋한다(deferred batch).
+        </td>
+      </tr>
+      <tr>
+        <th>User journey</th>
+        <td>
+          <strong>Entry</strong>: 리스트에서 카드 탭 → 그 사용자부터 시작 / sticky CTA 탭 → 큐 첫 사용자부터.<br>
+          <strong>Loop</strong>: 사용자 검토 → 승인 또는 거절(+ 사유 sheet) → 자동 다음 사용자 → 큐 끝까지 반복.<br>
+          <strong>Exit</strong>: 큐 끝 → confirm 화면으로 replace / 뒤로가기 → 리스트로 pop (마킹 보존) / appbar X(close) → 리스트로 pop (마킹 보존).
+        </td>
+      </tr>
+      <tr>
+        <th>Background</th>
+        <td>
+          기존 흐름은 카드 → 상세 페이지 → 승인/거절 → 리스트 복귀 → 다음 카드. 매 결정마다 페이지 전환과 리스트 invalidate 비용이 들었다.
+          carousel 패턴으로 (1) 페이지 전환을 큐 안에서 swipe-in으로 압축, (2) 백엔드 커밋을 confirm까지 연기해 부분 실패 위험을 줄인다.
+          tinder 스타일 swipe만 차용하지 않은 이유는 거절에 사유 입력이 필요하기 때문 — 듀얼 CTA + bottom sheet 조합으로 사유 명시를 강제한다.
+        </td>
+      </tr>
+      <tr>
+        <th>Frequency</th>
+        <td>이벤트별 심사 시점에 진입 — 보통 한 번에 5~30건 연속 처리.</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ============================================================
+     HISTORY
+     ============================================================ -->
+<section class="doc">
+  <h2>History</h2>
+  <table class="ref">
+    <thead><tr><th style="width: 110px;">날짜</th><th style="width: 120px;">버전</th><th>변경 사항</th></tr></thead>
+    <tbody>
+      <tr><td>2026-05-03</td><td>v1 (initial)</td><td>초안 — 듀얼 CTA + 거절 사유 sheet + 로컬 마킹 캐시 + 자동 다음 사용자 + 큐 끝 confirm replace.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ============================================================
+     LAYOUT
+     ============================================================ -->
+<div class="perspective" id="layout">
+  <div class="perspective__header">
+    <span class="glyph">🧱</span>
+    <h2>Layout</h2>
+    <span class="lede">화면 구조 — 영역, 정렬, 간격 규칙. 색·타이포 무시.</span>
+  </div>
+
+  <section class="doc">
+    <h2>Blueprint &amp; tree</h2>
+    <p class="intro">
+      <code>Scaffold</code> — AppBar(close + 'X / N' progress) + body(scrollable: 사용자 헤더 → 입장그룹 banner → required verifications 카드 stack) + bottom dual CTA(거절 좌 / 승인 우). 거절 탭 시 <code>showModalBottomSheet</code>로 사유 sheet.
+    </p>
+    <div class="layout-grid">
+      <div class="blueprint">
+        <div class="blueprint__region blueprint__region--full"></div>
+
+        <div class="blueprint__region blueprint__region--shaded" style="top:0;left:0;right:0;height:56px;">
+          <span class="blueprint__region-label">① AppBar — close X (left) + '심사' (left after) + 'X / N' progress (right)</span>
+        </div>
+
+        <div class="blueprint__region" style="top:80px;left:0;right:0;height:140px;">
+          <span class="blueprint__region-label">② User header — avatar 큰 사이즈 + 이름 + 성·생년</span>
+        </div>
+
+        <div class="blueprint__region blueprint__region--shaded" style="top:236px;left:16px;right:16px;height:80px;">
+          <span class="blueprint__region-label">③ Entry-group banner — 라벨 + 조건 chips</span>
+        </div>
+
+        <div class="blueprint__region" style="top:328px;left:16px;right:16px;height:120px;">
+          <span class="blueprint__region-label">④ Required verification card — 신원확인 (제출 데이터)</span>
+        </div>
+        <div class="blueprint__region" style="top:460px;left:16px;right:16px;height:120px;">
+          <span class="blueprint__region-label">⑤ Required verification card — 직업 인증 (제출 데이터)</span>
+        </div>
+
+        <div class="blueprint__region blueprint__region--shaded" style="bottom:0;left:0;right:0;height:88px;">
+          <span class="blueprint__region-label">⑥ Bottom dual CTA — 거절(좌 outline) / 승인(우 filled)</span>
+        </div>
+
+        <div class="blueprint__align-marker" style="top:8px;right:8px;">screen-edge pad 16</div>
+      </div>
+
+      <div class="layout-tree"><b>Scaffold</b>
+├─ <b>appBar</b>: <b>AppBar</b>                                  ← ①
+│  ├─ leading: <code>IconButton</code>(close · 22px) → pop with marking 보존
+│  ├─ title: Text('심사')
+│  └─ actions: [Text('X / N') <i>· 12px · w600 · primary 톤</i>]
+├─ <b>body</b>: <code>PageView.builder</code>(physics: NeverScrollable — auto-advance only)
+│  └─ <b>per page</b>: <code>SingleChildScrollView</code>(padding spacing-medium)
+│     ├─ <b>_UserHeader</b>                                       ← ②
+│     │  ├─ CircleAvatar(72 · primaryContainer · 이름 첫 글자)
+│     │  ├─ Text(user.name) <i>· 18px · w700</i>
+│     │  ├─ Text('남/여 · YYYY-MM-DD') <i>· 12px · secondary</i>
+│     │  └─ if 마킹됨: <b>_MarkPill</b> (수정 모드 시그널)
+│     ├─ SizedBox(<i>spacing-medium</i>)
+│     ├─ <b>_EntryGroupBanner</b>                                 ← ③
+│     │  ├─ row: Text(group.label) <i>· 13px · w700</i> · Text('이 사용자의 입장그룹') <i>· 11px · secondary</i>
+│     │  └─ chip row (성별 / 출생연도 / required verifications)
+│     ├─ SizedBox(<i>spacing-medium</i>)
+│     └─ for each required verification:                          ← ④⑤
+│        └─ <b>_VerificationSubmissionCard</b>
+│           ├─ Row [Text(verification.label) <i>· 13px · w700</i> · "필수" 태그]
+│           ├─ snapshot rows (key 90px / value flex)
+│           └─ if 사진/파일: thumbnail (80px height · radius-small)
+└─ <b>bottomNavigationBar</b>: <b>SafeArea</b>                    ← ⑥
+   └─ Row(gap: spacing-small, padding: spacing-medium)
+      ├─ <b>OutlinedButton</b>('거절') <i>· error 톤</i>
+      │  · onTap → showModalBottomSheet → <a href="#sheet">_RejectReasonSheet</a>
+      └─ <b>FilledButton</b>('승인') <i>· primary 톤</i>
+         · onTap → 마킹(approve) → 자동 다음 페이지 (200ms 후)
+
+<em>_MarkPill (수정 모드):</em>
+└─ Container(radius 999 · padding 4/10 · 12px w700 톤별)
+   · approve 톤: success bg 12% / border 25% / 텍스트 #15803d · "✓ 승인 마킹됨 — 변경하려면 다시 눌러주세요"
+   · reject 톤: error bg 12% / border 25% · "✕ 거절 마킹됨 — 사유: '신분증 미제출' (탭하여 수정)"
+
+<em>_RejectReasonSheet:</em> (showModalBottomSheet)
+└─ DraggableScrollableSheet(initialSize 0.5)
+   ├─ handle bar (36×4 · divider)
+   ├─ Text('거절 사유 선택') <i>· 15px · w700</i>
+   ├─ Text('제출 정보가 충분하지 않거나 행사 성격에 맞지 않으면 사유를 명확히 남겨주세요.') <i>· 12px · secondary</i>
+   ├─ <b>Wrap</b> (predefined chip × 5)
+   │  · '인증 정보 부족' / '신원 의심' / '행사 성격 부적합' / '중복 신청' / '기타'
+   │  · 선택 시 error 톤으로 활성
+   ├─ <b>TextField</b>(placeholder: '추가 설명 또는 자유 입력 (선택, "기타" 선택 시 필수)')
+   │  · multiline · min 60px · 12px
+   └─ <b>FilledButton</b>('거절 확정')
+      · disabled 조건: chip 미선택 AND 자유 입력 비어있음 / chip="기타" AND 자유 입력 비어있음
+      · onTap → 마킹(reject + reason 합성) → sheet dismiss → 자동 다음 페이지</div>
+    </div>
+  </section>
+
+  <section class="doc">
+    <h2>Spacing &amp; alignment rules</h2>
+    <table class="ref">
+      <thead><tr><th style="width:60px;">#</th><th style="width:200px;">Region</th><th style="width:220px;">Alignment</th><th>Spacing / tokens</th></tr></thead>
+      <tbody>
+        <tr><td>①</td><td>AppBar</td><td>close left · title · progress right</td><td>56px · centerTitle: false · progress text 12px w600 <code>color-partner-primary</code> · margin-right <code>spacing-screen-edge</code></td></tr>
+        <tr><td>②</td><td>User header</td><td>centered column · gap 6px</td><td>v-padding <code>spacing-large</code> top / <code>spacing-medium</code> bottom · avatar 72px · 이름 18px w700 · sub 12px secondary</td></tr>
+        <tr><td>③</td><td>Entry-group banner</td><td>풀폭 카드</td><td>radius <code>radius-card</code> · border 1px <code>color-divider</code> · padding <code>spacing-small</code>/<code>spacing-medium</code> · 라벨 13px w700 · caption 11px secondary · chip row gap 4px · margin-y <code>spacing-medium</code></td></tr>
+        <tr><td>④⑤</td><td>Verification card</td><td>풀폭 카드 stack</td><td>padding <code>spacing-medium</code> · radius <code>radius-card</code> · border 1px <code>color-divider</code> · bg <code>color-background</code> · 카드 사이 <code>spacing-small</code> · 제목 13px w700 · "필수" 태그 10px w600 primary 10% bg · row 12px · key width 90px secondary / val flex primary · 사진 thumb 80px height radius-small</td></tr>
+        <tr><td>⑥</td><td>Bottom dual CTA</td><td>row · gap small · SafeArea inset</td><td>height 48 + padding · gap <code>spacing-small</code> · 거절 outline 1px <code>color-error</code> + text error · 승인 filled <code>color-partner-primary</code> + white · 두 버튼 동일 weight 1</td></tr>
+        <tr><td>—</td><td>Reject sheet</td><td>bottom sheet · max 50% height</td><td>radius top 20px · handle 36×4 divider · 제목 15px w700 · sub 12px secondary · chip 12px outline · 선택 chip <code>color-error</code> 8% bg + error border · TextField multiline · 거절 확정 버튼 height 44 · disabled 시 divider bg + secondary text</td></tr>
+        <tr><td>—</td><td>Mark pill</td><td>좌측 상단 inline</td><td>radius 999 · padding 4/10 · 12px w700 · approve 톤 #15803d (12% bg + 25% border) · reject 톤 <code>color-error</code> (12% bg + 25% border)</td></tr>
+      </tbody>
+    </table>
+  </section>
+</div>
+
+<!-- ============================================================
+     STATES
+     ============================================================ -->
+<div class="perspective" id="states">
+  <div class="perspective__header">
+    <span class="glyph">🎨</span>
+    <h2>States</h2>
+    <span class="lede">시각 변형 4종.</span>
+  </div>
+
+  <section class="doc">
+    <p class="intro">
+      <strong>State 식별 기준</strong>: (a) 마킹 상태(없음 / 승인 / 거절) (b) 사유 sheet 노출 (c) 큐 종료 transition.
+    </p>
+
+    <!-- =================================================
+         STATE 1 — Default (review)
+         ================================================= -->
+    <table class="ref state-mini">
+      <thead><tr><th colspan="3"><strong>State 1 · Default 심사 화면</strong> 🎯 <span class="tag tag--mute">baseline</span></th></tr></thead>
+      <tbody>
+        <tr>
+          <td rowspan="6" class="state-mini__mock"><div class="viewport">
+            <div class="erc-appbar">
+              <div class="erc-appbar__back">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+              </div>
+              <div class="erc-appbar__title">심사</div>
+              <div class="erc-appbar__progress">2 / 4</div>
+            </div>
+            <div class="erc-body">
+              <div class="erc-user">
+                <div class="erc-user__avatar">박</div>
+                <div class="erc-user__name">박지호</div>
+                <div class="erc-user__sub">남 · 1992-08-04</div>
+              </div>
+              <div class="erc-eg">
+                <div class="erc-eg__head">
+                  <span class="erc-eg__label">남성 그룹</span>
+                  <span class="erc-eg__caption">· 이 사용자의 입장그룹</span>
+                </div>
+                <div class="erc-eg__chips">
+                  <span class="erc-eg__chip">남성만</span>
+                  <span class="erc-eg__chip">1990~1999</span>
+                  <span class="erc-eg__chip erc-eg__chip--required">required: 신원확인</span>
+                </div>
+              </div>
+              <div class="erc-sub">
+                <div class="erc-sub__head">
+                  <div class="erc-sub__title">신원확인</div>
+                  <div class="erc-sub__tag">필수</div>
+                </div>
+                <div class="erc-sub__row"><div class="erc-sub__key">이름</div><div class="erc-sub__val">박지호</div></div>
+                <div class="erc-sub__row"><div class="erc-sub__key">생년월일</div><div class="erc-sub__val">1992-08-04</div></div>
+                <div class="erc-sub__row"><div class="erc-sub__key">신분증 종류</div><div class="erc-sub__val">주민등록증</div></div>
+                <div class="erc-sub__photo">신분증 사진 (thumbnail · 탭하여 확대)</div>
+              </div>
+            </div>
+            <div class="erc-cta">
+              <div class="erc-cta__btn erc-cta__btn--reject">거절</div>
+              <div class="erc-cta__btn erc-cta__btn--approve">승인</div>
+            </div>
+          </div></td>
+          <td class="state-mini__aspect">조건</td>
+          <td>큐 안 한 사용자 진입 직후 (마킹 없음). 입장그룹 banner + required verifications만 노출 (그룹 정의 외 verification은 노출 X).</td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">사용자 액션</td>
+          <td>
+            · <strong>승인 탭</strong> → 로컬 마킹(approve) → 200ms 뒤 다음 페이지로 swipe-in (자동 advance)<br>
+            · <strong>거절 탭</strong> → 사유 sheet 모달 노출(State 2)<br>
+            · <strong>썸네일 탭</strong> → 풀스크린 이미지 viewer (별도 spec — 본 spec 범위 밖)<br>
+            · <strong>appbar close X</strong> → 리스트로 pop, 로컬 마킹 보존<br>
+            · <strong>뒤로가기 제스처</strong> → 동일 (리스트 pop + 마킹 보존)
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">에지케이스</td><td>· 입장그룹의 required가 0개면 verification 카드 영역이 비어있고 banner 아래 "추가 제출 정보 없음" 안내 노출(빈 줄 금지)<br>· 사용자가 required verification 일부를 미제출했으면 해당 카드에 "미제출" 시그널 + 거절 사유 자동 prefill 후보로 'required' chip 강조<br>· progress 'X / N' = 큐 안 위치(1-indexed) / 큐 총 길이</td></tr>
+        <tr>
+          <td class="state-mini__aspect">컴포넌트</td>
+          <td>
+            <code>Scaffold</code> · <code>AppBar</code> · <code>PageView.builder</code> · <code>SingleChildScrollView</code> · <code>_UserHeader</code> · <code>_EntryGroupBanner</code> · <code>_VerificationSubmissionCard</code> · <code>OutlinedButton</code>(거절) · <code>FilledButton</code>(승인) · <code>SafeArea</code>
+          </td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">토큰</td>
+          <td>
+            <code>color-primary</code>(partner — avatar bg @ 15% / progress text / 승인 버튼 / required chip 10%) · <code>color-text-primary</code>(이름 / 카드 제목 / val) · <code>color-text-secondary</code>(서브 / caption / key / 일반 chip) · <code>color-error</code>(거절 버튼 outline + text) · <code>color-divider</code>(카드 border / 일반 chip bg / 사진 placeholder bg) · <code>color-background</code>(카드 bg) · <code>radius-card</code> · <code>radius-small</code>(사진) · 999(chip / pill) · typography 18px w700 (이름) / 13px w700 (label · 카드 제목) / 12px (sub · key · val · caption) / 11px secondary / 10px w500 (chip) / 10px w600 ("필수" 태그) / 15px w700 (CTA)
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">노트</td><td>📝 baseline. PageView 자동 advance는 100ms 페이드 + 200ms slide. 사용자가 의도적으로 swipe하지 않도록 physics는 NeverScrollable.</td></tr>
+      </tbody>
+    </table>
+
+    <!-- =================================================
+         STATE 2 — Reject reason sheet
+         ================================================= -->
+    <table class="ref state-mini">
+      <thead><tr><th colspan="3"><strong>State 2 · 거절 사유 sheet</strong> <span class="tag tag--mute">reject-flow</span></th></tr></thead>
+      <tbody>
+        <tr>
+          <td rowspan="3" class="state-mini__mock"><div class="viewport">
+            <div class="erc-appbar">
+              <div class="erc-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></div>
+              <div class="erc-appbar__title">심사</div>
+              <div class="erc-appbar__progress">2 / 4</div>
+            </div>
+            <div class="erc-sheet-overlay"></div>
+            <div class="erc-sheet">
+              <div class="erc-sheet__handle"></div>
+              <div class="erc-sheet__title">거절 사유 선택</div>
+              <div class="erc-sheet__sub">제출 정보가 충분하지 않거나 행사 성격에 맞지 않으면 사유를 명확히 남겨주세요.</div>
+              <div class="erc-sheet__chips">
+                <div class="erc-sheet__chip erc-sheet__chip--selected">인증 정보 부족</div>
+                <div class="erc-sheet__chip">신원 의심</div>
+                <div class="erc-sheet__chip">행사 성격 부적합</div>
+                <div class="erc-sheet__chip">중복 신청</div>
+                <div class="erc-sheet__chip">기타</div>
+              </div>
+              <div class="erc-sheet__input">신분증 사진이 너무 흐려서 본인 확인이 어렵습니다.</div>
+              <div class="erc-sheet__submit">거절 확정</div>
+            </div>
+          </div></td>
+          <td class="state-mini__aspect">조건</td>
+          <td>거절 버튼 탭 시 등장. 단일 chip 선택 가능 + 자유 입력 텍스트 영역. predefined chip을 선택하지 않고 자유 입력만 채워도 거절 가능.</td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">사용자 액션</td>
+          <td>
+            · <strong>chip 탭</strong> → 단일 선택 토글 (다른 chip 선택 시 이전 chip 해제)<br>
+            · <strong>자유 입력</strong> → multiline 텍스트, predefined chip과 함께 저장됨<br>
+            · <strong>"기타" 선택</strong> → 자유 입력이 필수가 됨 (비어있으면 거절 확정 disabled)<br>
+            · <strong>거절 확정 탭</strong> → 마킹 합성("predefined: chip 라벨 / 추가: 자유입력") → sheet dismiss → 자동 다음 페이지<br>
+            · <strong>handle 드래그 다운 / overlay 탭</strong> → 사유 미선택 상태로 sheet dismiss (마킹 X · 사용자 결정 보류)
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">노트</td><td>📝 사유 강제는 하지 않되, 단순 거절을 한 발짝 늦춤으로써 운영자가 한 번 더 사유를 의식하게 한다. predefined chip은 5개 — 정책상 추가는 사용자 요청 후에.</td></tr>
+      </tbody>
+    </table>
+
+    <!-- =================================================
+         STATE 3 — Re-entered (modify mode)
+         ================================================= -->
+    <table class="ref state-mini">
+      <thead><tr><th colspan="3"><strong>State 3 · 이미 마킹된 사용자 재진입</strong> <span class="tag tag--mute">modify</span></th></tr></thead>
+      <tbody>
+        <tr>
+          <td rowspan="3" class="state-mini__mock"><div class="viewport">
+            <div class="erc-appbar">
+              <div class="erc-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></div>
+              <div class="erc-appbar__title">심사</div>
+              <div class="erc-appbar__progress">3 / 4</div>
+            </div>
+            <div class="erc-body">
+              <div class="erc-user">
+                <div class="erc-user__avatar">박</div>
+                <div class="erc-user__name">박지호</div>
+                <div class="erc-user__sub">남 · 1992-08-04</div>
+                <div class="erc-mark erc-mark--reject">✕ 거절 마킹됨 — 사유: '인증 정보 부족' (탭하여 수정)</div>
+              </div>
+              <div class="erc-eg">
+                <div class="erc-eg__head">
+                  <span class="erc-eg__label">남성 그룹</span>
+                  <span class="erc-eg__caption">· 이 사용자의 입장그룹</span>
+                </div>
+                <div class="erc-eg__chips">
+                  <span class="erc-eg__chip">남성만</span>
+                  <span class="erc-eg__chip">1990~1999</span>
+                  <span class="erc-eg__chip erc-eg__chip--required">required: 신원확인</span>
+                </div>
+              </div>
+              <div class="erc-sub">
+                <div class="erc-sub__head">
+                  <div class="erc-sub__title">신원확인</div>
+                  <div class="erc-sub__tag">필수</div>
+                </div>
+                <div class="erc-sub__row"><div class="erc-sub__key">이름</div><div class="erc-sub__val">박지호</div></div>
+                <div class="erc-sub__row"><div class="erc-sub__key">생년월일</div><div class="erc-sub__val">1992-08-04</div></div>
+              </div>
+            </div>
+            <div class="erc-cta">
+              <div class="erc-cta__btn erc-cta__btn--reject">거절 (수정)</div>
+              <div class="erc-cta__btn erc-cta__btn--approve">승인으로 변경</div>
+            </div>
+          </div></td>
+          <td class="state-mini__aspect">조건</td>
+          <td>confirm 화면에서 마킹된 사용자 카드 탭 → 그 사용자로 돌아온 경우, 또는 carousel 안에서 같은 사용자로 다시 swipe된 경우. <strong>_MarkPill</strong>이 사용자 헤더 아래 노출되어 현재 마킹 상태를 명시.</td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">사용자 액션</td>
+          <td>
+            · <strong>현재 마킹과 같은 버튼 탭</strong> → 마킹 변경 없음 (no-op) · 자동 advance도 없음 — 사용자가 의도를 한번 더 확인하도록<br>
+            · <strong>다른 버튼 탭</strong> → 마킹 덮어쓰기 (예: 거절 → 승인) · 거절일 경우 사유 sheet 다시 노출 → 마킹 갱신 후 confirm 화면으로 즉시 pop<br>
+            · <strong>_MarkPill 탭</strong> → 거절 마킹이면 사유 sheet 다시 열어 사유만 수정 가능, 승인 마킹이면 동작 없음<br>
+            · 수정 모드 진입은 confirm 화면에서 왔다는 것을 의미 — 액션 후 자동 advance 대신 confirm 화면으로 즉시 pop
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">노트</td><td>📝 수정 흐름은 confirm 화면에서 진입한 단일 사용자만 다룬다 — 수정 후 자동 다음 사용자 advance는 일어나지 않음. carousel 자연 흐름 vs confirm 진입 수정의 행동 차이가 핵심.</td></tr>
+      </tbody>
+    </table>
+
+    <!-- =================================================
+         STATE 4 — Queue end transition
+         ================================================= -->
+    <table class="ref state-mini">
+      <thead><tr><th colspan="3"><strong>State 4 · 큐 종료 transition</strong> <span class="tag tag--mute">end</span></th></tr></thead>
+      <tbody>
+        <tr>
+          <td rowspan="3" class="state-mini__mock"><div class="viewport">
+            <div class="erc-appbar">
+              <div class="erc-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></div>
+              <div class="erc-appbar__title">심사</div>
+              <div class="erc-appbar__progress">4 / 4</div>
+            </div>
+            <div class="erc-body" style="display:flex;align-items:center;justify-content:center;flex-direction:column;gap:12px;">
+              <div style="width:48px;height:48px;border-radius:50%;background:rgba(34,197,94,0.12);display:flex;align-items:center;justify-content:center;color:#15803d;font-size:24px;">✓</div>
+              <div style="font-size:15px;font-weight:700;color:var(--color-text-primary);">모든 신청 검토 완료</div>
+              <div style="font-size:12px;color:var(--color-text-secondary);">최종 확인 화면으로 이동합니다…</div>
+            </div>
+          </div></td>
+          <td class="state-mini__aspect">조건</td>
+          <td>마지막 사용자에 대해 마킹이 끝난 직후, confirm 화면 push 직전 짧은 transition. Auto-advance 200ms 이후 fade transition으로 confirm 화면 replace.</td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">사용자 액션</td>
+          <td>· 사용자 액션 없음 — 자동으로 <a href="/specs/event_application_review_confirm_page.html">confirm 화면</a>으로 replace push (carousel은 백 스택에서 제거되어 confirm에서 뒤로가기 시 리스트로 직접 복귀)</td>
+        </tr>
+        <tr><td class="state-mini__aspect">노트</td><td>📝 transition은 약 600ms — 중간 빈 시간이 어색하지 않도록 success 시그널을 잠시 노출. 운영자가 confirm 화면 도착을 명확히 인지.</td></tr>
+      </tbody>
+    </table>
+  </section>
+</div>
+
+<!-- ============================================================
+     GLOBAL BEHAVIOR
+     ============================================================ -->
+<div class="perspective" id="behavior">
+  <div class="perspective__header">
+    <span class="glyph">🔄</span>
+    <h2>Global Behavior</h2>
+    <span class="lede">모든 state에 동일하게 적용되는 동작.</span>
+  </div>
+
+  <section class="doc">
+    <h2>큐 정의 &amp; advance 규칙</h2>
+    <ul>
+      <li>큐 = 화면 진입 시점의 모든 심사 대기 신청 snapshot, <code>created_at ASC</code> 정렬 (입장그룹 경계 무시).</li>
+      <li>큐는 진입 후 고정 — 새 신청이 들어와도 진행 중인 큐에는 합류하지 않는다 (다음 진입 시 새 큐로).</li>
+      <li>승인 / 거절 마킹 → 200ms 후 <code>PageController.nextPage</code>로 다음 사용자 swipe-in.</li>
+      <li>마지막 사용자에서 마킹 → State 4 transition(약 600ms) → confirm 화면 <code>pushReplacement</code>.</li>
+      <li>수정 모드(State 3) 진입 시 advance 규칙은 다름: 마킹 갱신 후 confirm으로 즉시 pop, 다음 사용자로 advance하지 않음.</li>
+    </ul>
+  </section>
+
+  <section class="doc">
+    <h2>로컬 마킹 캐시</h2>
+    <ul>
+      <li>저장 단위: <code>(eventId)</code> 키. 값: <code>{ marks: Map&lt;applicationId, MarkEntry&gt; }</code> · MarkEntry = <code>{ action: 'approve'|'reject', reason?: string, predefinedReasonCode?: string }</code>.</li>
+      <li>저장 위치: 메모리(StateNotifier 또는 Riverpod state) — 디스크 영속화 안 함. "페이지 이탈 시 무효화" 정책과 일관.</li>
+      <li>무효화 트리거:
+        <ul>
+          <li>리스트 화면이 백 스택에서 pop될 때 (EventDetailPage 등 상위로 이동)</li>
+          <li>confirm 화면에서 최종 확정 성공 시</li>
+          <li>confirm 화면에서 명시적 "전체 취소" 액션 (제공된다면)</li>
+        </ul>
+      </li>
+      <li>보존되는 흐름: 리스트 ↔ carousel ↔ confirm 사이 이동, carousel 안 close 후 리스트로 pop.</li>
+      <li>주의: 앱 종료 / 강제 kill 시 마킹은 손실 — UX 가정상 한 세션 안에 끝낸다.</li>
+    </ul>
+  </section>
+
+  <section class="doc">
+    <h2>거절 사유 합성 규칙</h2>
+    <ul>
+      <li>predefined chip 단독 → <code>reason = chip 라벨</code> (예: "인증 정보 부족")</li>
+      <li>predefined chip + 자유 입력 → <code>reason = "{chip 라벨} — {자유 입력}"</code></li>
+      <li>"기타" chip + 자유 입력 → <code>reason = 자유 입력</code> (chip 라벨은 합치지 않음 — UX상 무의미)</li>
+      <li>chip 미선택 + 자유 입력만 → <code>reason = 자유 입력</code></li>
+      <li>chip 미선택 + 자유 입력 비어있음 → 거절 확정 버튼 disabled (사용자가 chip 또는 자유 입력 중 하나는 채워야 함)</li>
+      <li>"기타" chip 단독(자유 입력 비어있음) → 거절 확정 버튼 disabled (기타는 본문 필수)</li>
+    </ul>
+  </section>
+
+  <section class="doc">
+    <h2>Verification 노출 정책</h2>
+    <ul>
+      <li>그 사용자가 속한 입장그룹의 <strong>required_verification_ids만</strong> 노출. 그룹 정의 외 verification은 제출되었더라도 carousel에서는 노출 X (정보량을 운영자에게 강제 좁힘).</li>
+      <li>그룹 정의된 required 중 사용자가 미제출한 항목 → 카드 자리는 유지하되 "미제출" 시그널 + 자유 입력 prefill 후보 표기 (거절 사유로 자동 prefill하지는 않음 — 운영자 판단 보존).</li>
+      <li>verification 카드 안 표기는 verification.type별로 다름 — 신원확인은 이름/생년/신분증 종류 + 사진 thumbnail. 직업 인증은 회사명/직급/명함. (각 type별 세부 layout은 후속 spec에서 정리.)</li>
+      <li>thumbnail 탭 시 풀스크린 이미지 viewer는 본 spec 범위 밖 — 별도 PhotoViewerRoute 활용.</li>
+    </ul>
+  </section>
+
+  <section class="doc">
+    <h2>Capacity guard 미리보기</h2>
+    <ul>
+      <li>carousel은 capacity 검증을 수행하지 않음 — 마킹은 로컬, 커밋은 confirm에서 수행.</li>
+      <li>confirm 화면이 unified bulk review API를 호출하면 백엔드가 단일 트랜잭션 안에서 capacity guard를 적용 → 초과분은 <code>skipped_due_to_capacity</code>로 반환.</li>
+      <li>운영자가 capacity를 초과해 마킹할 수 있게 허용하는 이유: (1) 입장그룹별 capacity 분포가 변동될 수 있음 (2) 명시적 결과를 confirm에서 보여주는 것이 더 명확.</li>
+    </ul>
+  </section>
+</div>
+
+<!-- ============================================================
+     REFERENCE
+     ============================================================ -->
+<div class="perspective" id="reference">
+  <div class="perspective__header">
+    <span class="glyph">🔗</span>
+    <h2>Reference</h2>
+    <span class="lede">관련 라우트 · 화면 · 구현 소스.</span>
+  </div>
+
+  <section class="doc">
+    <h2>Implementation source</h2>
+    <table class="ref">
+      <tbody>
+        <tr><td style="width: 160px;"><strong>Route</strong></td><td><code>EventApplicationReviewCarouselRoute</code></td></tr>
+        <tr><td><strong>Path</strong></td><td><code>/more/parties/:partyId/events/:eventId/applications/review</code> (query: <code>?start=:applicationId</code>)</td></tr>
+        <tr><td><strong>Widget class</strong></td><td><code>EventApplicationReviewCarouselPage</code> (+ <code>_UserHeader</code> · <code>_EntryGroupBanner</code> · <code>_VerificationSubmissionCard</code> · <code>_RejectReasonSheet</code> · <code>_MarkPill</code>)</td></tr>
+        <tr><td><strong>App</strong></td><td><code>app_partner</code></td></tr>
+        <tr><td><strong>Source (예상)</strong></td><td><code>apps/app_partner/lib/src/features/event/applications/review/event_application_review_carousel_page.dart</code></td></tr>
+        <tr><td><strong>Marking state</strong></td><td>StateNotifier <code>reviewMarkingProvider(eventId)</code> 또는 동등한 in-memory 컨테이너</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Backend dependency</h2>
+    <table class="ref">
+      <tbody>
+        <tr><td style="width: 200px;"><strong>Final commit API</strong></td><td>Unified bulk review EF — <a href="https://github.com/Mark-Yun/minglit/issues/2101">#2101</a> 참조. carousel은 호출하지 않음 (confirm 화면에서 호출).</td></tr>
+        <tr><td><strong>Single approve fallback</strong></td><td><code>partner-approve-application</code> EF (action: <code>approve</code>) — confirm 화면이 unified API 미가용 시에 사용 가능한 fallback. 본 carousel은 호출 X.</td></tr>
+        <tr><td><strong>Single reject fallback</strong></td><td><code>partner-reject-application</code> EF — 동일하게 confirm 화면의 fallback.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Related screens</h2>
+    <table class="ref">
+      <thead><tr><th style="width: 280px;">Spec</th><th>관계</th></tr></thead>
+      <tbody>
+        <tr><td><a href="/specs/event_application_list_page.html"><code>EventApplicationListPage</code></a></td><td>Parent — 카드 탭 / sticky CTA로 진입.</td></tr>
+        <tr><td><a href="/specs/event_application_review_confirm_page.html"><code>EventApplicationReviewConfirmPage</code></a></td><td>Sequel — 큐 종료 시 replace push. 마킹 수정 시 carousel로 단일 사용자 push (State 3 진입).</td></tr>
+        <tr><td><a href="/specs/event_application_detail_page.html"><code>EventApplicationDetailPage</code></a></td><td>Sibling (alt path) — 처리 완료 신청은 carousel이 아니라 detail로 직접 push.</td></tr>
+      </tbody>
+    </table>
+  </section>
+</div>
+
+</div>
+</body>
+</html>

--- a/apps/mds/docs/public/specs/event_application_review_carousel_page.html
+++ b/apps/mds/docs/public/specs/event_application_review_carousel_page.html
@@ -591,8 +591,7 @@ body.dark-mode .viewport {
             · <strong>승인 탭</strong> → 로컬 마킹(approve) → 200ms 뒤 다음 페이지로 swipe-in (자동 advance)<br>
             · <strong>거절 탭</strong> → 사유 sheet 모달 노출(State 2)<br>
             · <strong>썸네일 탭</strong> → 풀스크린 이미지 viewer (별도 spec — 본 spec 범위 밖)<br>
-            · <strong>appbar close X</strong> → 리스트로 pop, 로컬 마킹 보존<br>
-            · <strong>뒤로가기 제스처</strong> → 동일 (리스트 pop + 마킹 보존)
+            · <strong>appbar close X / 뒤로가기 제스처</strong> → queue 모드에서는 리스트로 pop · modify 모드(State 3 진입 컨텍스트)에서는 confirm 화면으로 pop · 두 경우 모두 로컬 마킹은 보존
           </td>
         </tr>
         <tr><td class="state-mini__aspect">에지케이스</td><td>· 입장그룹의 required가 0개면 verification 카드 영역이 비어있고 banner 아래 "추가 제출 정보 없음" 안내 노출(빈 줄 금지)<br>· 사용자가 required verification 일부를 미제출했으면 해당 카드에 "미제출" 시그널 + 거절 사유 자동 prefill 후보로 'required' chip 강조<br>· progress 'X / N' = 큐 안 위치(1-indexed) / 큐 총 길이</td></tr>
@@ -608,7 +607,7 @@ body.dark-mode .viewport {
             <code>color-primary</code>(partner — avatar bg @ 15% / progress text / 승인 버튼 / required chip 10%) · <code>color-text-primary</code>(이름 / 카드 제목 / val) · <code>color-text-secondary</code>(서브 / caption / key / 일반 chip) · <code>color-error</code>(거절 버튼 outline + text) · <code>color-divider</code>(카드 border / 일반 chip bg / 사진 placeholder bg) · <code>color-background</code>(카드 bg) · <code>radius-card</code> · <code>radius-small</code>(사진) · 999(chip / pill) · typography 18px w700 (이름) / 13px w700 (label · 카드 제목) / 12px (sub · key · val · caption) / 11px secondary / 10px w500 (chip) / 10px w600 ("필수" 태그) / 15px w700 (CTA)
           </td>
         </tr>
-        <tr><td class="state-mini__aspect">노트</td><td>📝 baseline. PageView 자동 advance는 100ms 페이드 + 200ms slide. 사용자가 의도적으로 swipe하지 않도록 physics는 NeverScrollable.</td></tr>
+        <tr><td class="state-mini__aspect">노트</td><td>📝 baseline. 자동 advance는 <strong>마킹 후 200ms 지연</strong> → <code>PageController.nextPage</code> 호출(기본 페이지 전환 ~300ms slide). 운영자가 의도적으로 swipe하지 않도록 physics는 NeverScrollable.</td></tr>
       </tbody>
     </table>
 
@@ -699,23 +698,24 @@ body.dark-mode .viewport {
               </div>
             </div>
             <div class="erc-cta">
-              <div class="erc-cta__btn erc-cta__btn--reject">거절 (수정)</div>
-              <div class="erc-cta__btn erc-cta__btn--approve">승인으로 변경</div>
+              <div class="erc-cta__btn erc-cta__btn--reject">거절</div>
+              <div class="erc-cta__btn erc-cta__btn--approve">승인</div>
             </div>
           </div></td>
           <td class="state-mini__aspect">조건</td>
-          <td>confirm 화면에서 마킹된 사용자 카드 탭 → 그 사용자로 돌아온 경우, 또는 carousel 안에서 같은 사용자로 다시 swipe된 경우. <strong>_MarkPill</strong>이 사용자 헤더 아래 노출되어 현재 마킹 상태를 명시.</td>
+          <td>confirm 화면에서 마킹된 사용자 카드 탭으로 진입(modify 모드). <strong>_MarkPill</strong>이 사용자 헤더 아래 노출되어 현재 마킹 상태와 사유를 명시. CTA 라벨은 baseline과 동일('거절' / '승인') — 실제 동작은 진입 모드에 따라 달라진다.</td>
         </tr>
         <tr>
           <td class="state-mini__aspect">사용자 액션</td>
           <td>
-            · <strong>현재 마킹과 같은 버튼 탭</strong> → 마킹 변경 없음 (no-op) · 자동 advance도 없음 — 사용자가 의도를 한번 더 확인하도록<br>
-            · <strong>다른 버튼 탭</strong> → 마킹 덮어쓰기 (예: 거절 → 승인) · 거절일 경우 사유 sheet 다시 노출 → 마킹 갱신 후 confirm 화면으로 즉시 pop<br>
-            · <strong>_MarkPill 탭</strong> → 거절 마킹이면 사유 sheet 다시 열어 사유만 수정 가능, 승인 마킹이면 동작 없음<br>
-            · 수정 모드 진입은 confirm 화면에서 왔다는 것을 의미 — 액션 후 자동 advance 대신 confirm 화면으로 즉시 pop
+            · <strong>거절 버튼 탭</strong> → 사유 sheet 노출 (현재 거절 마킹이면 기존 사유 prefill 후 편집, 승인 마킹이면 새 사유 입력) → 확정 시 마킹 갱신 → confirm 화면으로 즉시 pop<br>
+            · <strong>승인 버튼 탭</strong> → 마킹을 승인으로 갱신(기존 거절 사유는 폐기, 변경 없으면 동일) → confirm 화면으로 즉시 pop<br>
+            · <strong>_MarkPill 탭</strong> → 거절 마킹이면 사유 sheet 다시 열어 사유만 수정 가능, 승인 마킹이면 동작 없음(시각적 시그널 역할만)<br>
+            · <strong>appbar close X / 시스템 back</strong> → confirm 화면으로 pop (queue 모드의 list pop과 다름) · 마킹은 보존<br>
+            · 수정 모드는 단일 사용자만 다룸 — 액션 후 자동 다음 사용자 advance는 일어나지 않고 항상 confirm으로 복귀
           </td>
         </tr>
-        <tr><td class="state-mini__aspect">노트</td><td>📝 수정 흐름은 confirm 화면에서 진입한 단일 사용자만 다룬다 — 수정 후 자동 다음 사용자 advance는 일어나지 않음. carousel 자연 흐름 vs confirm 진입 수정의 행동 차이가 핵심.</td></tr>
+        <tr><td class="state-mini__aspect">노트</td><td>📝 진입 모드는 라우트 인자(<code>mode: queue | modify</code>)로 carousel 페이지가 인식. 같은 화면이지만 close X 도착지와 advance 정책이 분기. CTA 라벨은 통일해 학습 비용을 낮춤.</td></tr>
       </tbody>
     </table>
 
@@ -769,6 +769,16 @@ body.dark-mode .viewport {
       <li>승인 / 거절 마킹 → 200ms 후 <code>PageController.nextPage</code>로 다음 사용자 swipe-in.</li>
       <li>마지막 사용자에서 마킹 → State 4 transition(약 600ms) → confirm 화면 <code>pushReplacement</code>.</li>
       <li>수정 모드(State 3) 진입 시 advance 규칙은 다름: 마킹 갱신 후 confirm으로 즉시 pop, 다음 사용자로 advance하지 않음.</li>
+    </ul>
+  </section>
+
+  <section class="doc">
+    <h2>진입 모드 &amp; close 동작 분기</h2>
+    <ul>
+      <li>라우트 인자로 진입 모드 식별 — <code>mode: queue</code>(리스트/CTA에서 진입) / <code>mode: modify</code>(confirm 카드 탭에서 진입).</li>
+      <li><strong>queue 모드</strong> — close X / 시스템 back → 리스트로 pop. 자동 advance + 큐 끝 confirm pushReplacement 흐름 동작.</li>
+      <li><strong>modify 모드</strong> — close X / 시스템 back → confirm 화면으로 pop (한 단계만). 자동 advance 없음, 결정 후 즉시 confirm으로 pop.</li>
+      <li>두 모드 모두 마킹 캐시는 동일 컨테이너를 공유 — 진입 모드만 동작 분기를 결정한다.</li>
     </ul>
   </section>
 

--- a/apps/mds/docs/public/specs/event_application_review_confirm_page.html
+++ b/apps/mds/docs/public/specs/event_application_review_confirm_page.html
@@ -812,6 +812,18 @@ body.dark-mode .viewport {
   </section>
 
   <section class="doc">
+    <h2>Capacity skip 결과 노출 규칙 (State 3)</h2>
+    <ul>
+      <li><strong>상단 banner</strong> — warn 톤. 제목 "정원 초과로 일부 보류" + 본문 "총 N건 중 M건이 정원 초과로 처리되지 않았습니다. 보류된 신청은 그대로 마킹이 남아있어 다음 시도에서 다시 확정할 수 있습니다."</li>
+      <li><strong>summary cell 라벨</strong> — 보류된 마킹 분포에 한해 라벨이 "승인 보류" / "거절 보류"로 변경(숫자는 보류된 건수 기준). 처리된 건은 캐시에서 제거되어 표시 X.</li>
+      <li><strong>섹션 카운트</strong> — "(N건)" 대신 "(N건 보류)" 표기로 보류 상태 명시.</li>
+      <li><strong>카드별 cap 시그널</strong> — 각 보류 카드 안에 warn 톤의 "⚠ 정원 초과로 다음 시도에서 보류됨" 메시지 노출.</li>
+      <li><strong>CTA 라벨</strong> — "확정 (총 N건)" → "다시 확정 (N건)"으로 변경 (재시도 의도 명시).</li>
+      <li>다시 시도 시도 시 capacity가 여전히 부족하면 같은 State 3가 반복 — 운영자가 carousel 수정으로 거절 전환하거나 캐시에서 제거할 수 있어야 함(후속 spec 보강).</li>
+    </ul>
+  </section>
+
+  <section class="doc">
     <h2>수정 진입 → 자동 복귀 흐름</h2>
     <ul>
       <li>본 화면 카드 탭 → <code>CarouselRoute</code>를 single-user mode로 push (기존 carousel 큐와는 별개의 페이지로 진입).</li>

--- a/apps/mds/docs/public/specs/event_application_review_confirm_page.html
+++ b/apps/mds/docs/public/specs/event_application_review_confirm_page.html
@@ -1,0 +1,897 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<title>Spec — EventApplicationReviewConfirmPage (app_partner · EventApplicationReviewConfirmRoute)</title>
+<link rel="stylesheet" href="/specs/_spec.css">
+<style>
+/* ============================================================
+   Review confirm — carousel 마킹의 최종 검토 + 단일 트랜잭션 커밋.
+
+   - 진입: carousel 큐 종료 시 pushReplacement
+   - body: 승인/거절 마킹 요약 + 카드별 수정 진입
+   - footer: '확정' 버튼 → unified bulk review API
+   ============================================================ */
+.viewport {
+  --color-primary: var(--color-partner-primary);
+  --spec-blueprint-rgb: 108, 60, 225;
+}
+body.dark-mode .viewport {
+  --color-primary: var(--color-partner-dark-primary);
+}
+
+/* --- App bar --- */
+.erfc-appbar {
+  height: 56px;
+  display: flex;
+  align-items: center;
+  background: var(--color-surface);
+}
+.erfc-appbar__back {
+  width: 40px; height: 40px;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--color-text-primary);
+}
+.erfc-appbar__back svg { width: 22px; height: 22px; }
+.erfc-appbar__title {
+  flex: 1;
+  font-size: var(--typography-font-size-app-bar-title);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+/* --- Body --- */
+.erfc-body {
+  position: absolute;
+  top: 56px;
+  left: 0; right: 0; bottom: 80px;
+  overflow-y: auto;
+  scrollbar-width: none;
+  background: var(--color-surface);
+  padding: var(--spacing-medium);
+  box-sizing: border-box;
+}
+.erfc-body::-webkit-scrollbar { display: none; }
+
+/* --- Summary --- */
+.erfc-summary {
+  display: flex;
+  gap: var(--spacing-small);
+  margin-bottom: var(--spacing-medium);
+}
+.erfc-summary__cell {
+  flex: 1;
+  background: var(--color-background);
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-card);
+  padding: var(--spacing-small) var(--spacing-medium);
+  text-align: center;
+}
+.erfc-summary__num {
+  font-size: 22px;
+  font-weight: 700;
+}
+.erfc-summary__num--approve { color: #15803d; }
+.erfc-summary__num--reject { color: var(--color-error); }
+.erfc-summary__cap { color: var(--color-partner-primary); }
+.erfc-summary__lbl {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  margin-top: 2px;
+}
+
+/* --- Section header --- */
+.erfc-sec {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin: var(--spacing-medium) 0 var(--spacing-small);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.erfc-sec__count { color: var(--color-text-secondary); font-weight: 500; font-size: 11px; }
+.erfc-sec--reject { color: var(--color-error); }
+.erfc-sec--approve { color: #15803d; }
+
+/* --- Mark card --- */
+.erfc-card {
+  background: var(--color-background);
+  border-radius: var(--radius-card);
+  border: 1px solid var(--color-divider);
+  padding: var(--spacing-medium);
+  margin-bottom: var(--spacing-small);
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-small);
+}
+.erfc-card__avatar {
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: rgba(108, 60, 225, 0.15);
+  color: var(--color-partner-primary);
+  display: flex; align-items: center; justify-content: center;
+  font-weight: 700;
+  font-size: 14px;
+  flex-shrink: 0;
+}
+.erfc-card__body { flex: 1; min-width: 0; }
+.erfc-card__row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 2px;
+}
+.erfc-card__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+.erfc-card__group {
+  font-size: 10px;
+  color: var(--color-text-secondary);
+  background: var(--color-divider);
+  border-radius: 999px;
+  padding: 1px 6px;
+}
+.erfc-card__sub {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  margin-bottom: 4px;
+}
+.erfc-card__reason {
+  font-size: 12px;
+  color: var(--color-error);
+  background: rgba(239, 68, 68, 0.08);
+  border-radius: var(--radius-small);
+  padding: 4px 8px;
+  margin-top: 4px;
+  line-height: 1.4;
+}
+.erfc-card__cap {
+  font-size: 11px;
+  color: var(--color-warning, #b85a00);
+  background: rgba(255, 165, 0, 0.1);
+  border-radius: var(--radius-small);
+  padding: 4px 8px;
+  margin-top: 4px;
+}
+.erfc-card__edit {
+  font-size: 11px;
+  color: var(--color-partner-primary);
+  font-weight: 600;
+  flex-shrink: 0;
+  align-self: center;
+}
+
+/* --- Bottom CTA --- */
+.erfc-cta {
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-divider);
+  padding: var(--spacing-small) var(--spacing-medium);
+  box-sizing: border-box;
+}
+.erfc-cta__btn {
+  width: 100%;
+  height: 48px;
+  border-radius: var(--radius-card);
+  background: var(--color-partner-primary);
+  color: white;
+  font-size: 15px;
+  font-weight: 700;
+  display: flex; align-items: center; justify-content: center;
+  gap: 6px;
+}
+.erfc-cta__btn--disabled {
+  background: var(--color-divider);
+  color: var(--color-text-secondary);
+}
+.erfc-cta__btn--loading {
+  background: rgba(108, 60, 225, 0.7);
+  color: white;
+}
+
+/* --- Capacity warning banner --- */
+.erfc-warn {
+  background: rgba(255, 165, 0, 0.08);
+  border: 1px solid rgba(255, 165, 0, 0.25);
+  border-radius: var(--radius-card);
+  padding: var(--spacing-small) var(--spacing-medium);
+  margin-bottom: var(--spacing-medium);
+}
+.erfc-warn__title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-warning, #b85a00);
+  margin-bottom: 2px;
+}
+.erfc-warn__sub {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+}
+
+/* --- Error banner --- */
+.erfc-err {
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  border-radius: var(--radius-card);
+  padding: var(--spacing-small) var(--spacing-medium);
+  margin-bottom: var(--spacing-medium);
+}
+.erfc-err__title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--color-error);
+  margin-bottom: 2px;
+}
+.erfc-err__sub {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+}
+</style>
+</head>
+<body>
+
+<div class="toolbar">
+  <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>
+  <label><input type="checkbox" id="dark-toggle"> Dark mode (viewports flip dark)</label>
+</div>
+
+<div class="page">
+
+<header>
+  <h1>Event Application Review Confirm</h1>
+</header>
+
+<!-- ============================================================
+     OVERVIEW
+     ============================================================ -->
+<section class="doc">
+  <h2>Overview</h2>
+  <table class="ref">
+    <tbody>
+      <tr>
+        <th style="width: 140px;">Status</th>
+        <td><strong>📝 신규작성</strong> <em style="color: var(--color-text-secondary);">— v1 (carousel 마킹 최종 확인 + 단일 트랜잭션 커밋)</em></td>
+      </tr>
+      <tr><th>App</th><td><code>app_partner</code></td></tr>
+      <tr><th>Category</th><td>party · event · application · review (commit)</td></tr>
+      <tr>
+        <th>Route / Surface</th>
+        <td><code>EventApplicationReviewConfirmRoute</code> · widget: <code>EventApplicationReviewConfirmPage</code></td>
+      </tr>
+      <tr>
+        <th>Path</th>
+        <td><code>/more/parties/:partyId/events/:eventId/applications/review/confirm</code></td>
+      </tr>
+      <tr>
+        <th>Hierarchy</th>
+        <td>
+          <strong>Parent (replace)</strong>: <a href="/specs/event_application_review_carousel_page.html"><code>EventApplicationReviewCarouselPage</code></a> (큐 종료 시 pushReplacement으로 진입 — carousel은 백 스택에서 제거)<br>
+          <strong>Modify entry</strong>: 본 화면에서 마킹된 사용자 카드 탭 → carousel 단일 사용자 push (수정 모드 · State 3)
+        </td>
+      </tr>
+      <tr>
+        <th>Purpose</th>
+        <td>
+          carousel에서 누적된 마킹(승인 / 거절)을 한 화면에서 검토하고 <strong>단일 트랜잭션</strong>으로 커밋하는 화면.
+          마킹 수정이 필요하면 카드 탭으로 carousel 수정 모드에 진입해 그 사용자만 다시 결정한 뒤 본 화면으로 자동 복귀한다.
+          확정 시 통합 bulk review API(<a href="https://github.com/Mark-Yun/minglit/issues/2101">#2101</a>)를 호출해 승인 + 거절을 같은 트랜잭션으로 처리하고, capacity 초과분은 결과 화면에 명시한다.
+        </td>
+      </tr>
+      <tr>
+        <th>User journey</th>
+        <td>
+          <strong>Entry</strong>: carousel 큐 종료 → State 4 transition → 본 화면 replace push<br>
+          <strong>Loop</strong>: 마킹 검토 → 카드 탭으로 수정(선택) → 확정 버튼 → 백엔드 호출 → 성공 시 리스트로 pop, 마킹 캐시 invalidate<br>
+          <strong>Exit</strong>: 확정 성공 → 리스트 / appbar back → 리스트 (마킹 보존, 다시 carousel 진입 가능)
+        </td>
+      </tr>
+      <tr>
+        <th>Background</th>
+        <td>
+          deferred batch 패턴의 마지막 단계. carousel 단계는 빠른 결정에 집중하고, 검토와 커밋은 분리해 부분 실패 위험을 줄였다.
+          단일 트랜잭션으로 보내는 이유는 (1) 일부만 처리되면 운영자가 어디까지 갔는지 파악하기 어렵고 (2) capacity guard가 batch 안에서 한 번에 적용되어야 정확하기 때문.
+        </td>
+      </tr>
+      <tr><th>Frequency</th><td>carousel 1회당 1번 — 한 세션 안에서 한 번만 도달.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ============================================================
+     HISTORY
+     ============================================================ -->
+<section class="doc">
+  <h2>History</h2>
+  <table class="ref">
+    <thead><tr><th style="width: 110px;">날짜</th><th style="width: 120px;">버전</th><th>변경 사항</th></tr></thead>
+    <tbody>
+      <tr><td>2026-05-03</td><td>v1 (initial)</td><td>초안 — summary header + 승인/거절 섹션 + 카드 탭 수정 진입 + 확정 버튼 → unified bulk review API. capacity skip 결과 처리 + error 회복 흐름 포함.</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ============================================================
+     LAYOUT
+     ============================================================ -->
+<div class="perspective" id="layout">
+  <div class="perspective__header">
+    <span class="glyph">🧱</span>
+    <h2>Layout</h2>
+    <span class="lede">화면 구조 — 영역, 정렬, 간격 규칙. 색·타이포 무시.</span>
+  </div>
+
+  <section class="doc">
+    <h2>Blueprint &amp; tree</h2>
+    <p class="intro">
+      <code>Scaffold</code> — AppBar(back + '최종 확인') + body(scrollable: summary 2-cell row → 승인 섹션 카드 stack → 거절 섹션 카드 stack) + bottom sticky '확정' 버튼.
+      capacity skip / error는 본문 상단 banner로 노출.
+    </p>
+    <div class="layout-grid">
+      <div class="blueprint">
+        <div class="blueprint__region blueprint__region--full"></div>
+
+        <div class="blueprint__region blueprint__region--shaded" style="top:0;left:0;right:0;height:56px;">
+          <span class="blueprint__region-label">① AppBar — back + '최종 확인'</span>
+        </div>
+
+        <div class="blueprint__region" style="top:80px;left:16px;right:16px;height:60px;">
+          <span class="blueprint__region-label">② Summary — 승인 N · 거절 M</span>
+        </div>
+
+        <div class="blueprint__region blueprint__region--shaded" style="top:160px;left:16px;right:16px;height:24px;">
+          <span class="blueprint__region-label" style="font-size:9px;">③ Section header — '승인 (N)'</span>
+        </div>
+        <div class="blueprint__region" style="top:192px;left:16px;right:16px;height:120px;">
+          <span class="blueprint__region-label">④ Approve mark card stack</span>
+        </div>
+
+        <div class="blueprint__region blueprint__region--shaded" style="top:336px;left:16px;right:16px;height:24px;">
+          <span class="blueprint__region-label" style="font-size:9px;">⑤ Section header — '거절 (M)'</span>
+        </div>
+        <div class="blueprint__region" style="top:368px;left:16px;right:16px;height:160px;">
+          <span class="blueprint__region-label">⑥ Reject mark card stack — 사유 preview 포함</span>
+        </div>
+
+        <div class="blueprint__region blueprint__region--shaded" style="bottom:0;left:0;right:0;height:64px;">
+          <span class="blueprint__region-label">⑦ Sticky '확정 (총 N건)' — 호출 직전 disabled 가드</span>
+        </div>
+
+        <div class="blueprint__align-marker" style="top:8px;right:8px;">screen-edge pad 16</div>
+      </div>
+
+      <div class="layout-tree"><b>Scaffold</b>
+├─ <b>appBar</b>: <b>AppBar</b>('최종 확인')                       ← ①
+│  · leading: BackButton → 리스트로 pop, 마킹 캐시 보존
+├─ <b>body</b>: <code>SingleChildScrollView</code>(padding: spacing-medium)
+│  ├─ <em>(if 직전 시도에서 capacity skip 또는 error 발생):</em>
+│  │  └─ <b>_Banner</b> (warn / err 톤)
+│  ├─ <b>_Summary</b>                                             ← ②
+│  │  · Row [
+│  │     · _SummaryCell(승인 · 22px w700 success 톤 · 'N건')
+│  │     · _SummaryCell(거절 · 22px w700 error 톤 · 'M건')
+│  │  ]
+│  ├─ if approveMarks.isNotEmpty:                                 ← ③④
+│  │  ├─ Text('승인 (N)') <i>· 13px · w700 · success 톤</i>
+│  │  └─ <b>_MarkCard</b> × N
+│  │     · onTap → push CarouselRoute(modifyMode: true, applicationId)
+│  └─ if rejectMarks.isNotEmpty:                                  ← ⑤⑥
+│     ├─ Text('거절 (M)') <i>· 13px · w700 · error 톤</i>
+│     └─ <b>_MarkCard</b> × M
+│        · 사유 preview row (error 톤 8% bg)
+│        · onTap → push CarouselRoute(modifyMode: true, applicationId)
+└─ <b>bottomNavigationBar</b>: <b>SafeArea</b>                    ← ⑦
+   └─ <b>FilledButton</b>('확정 (총 N건)')
+      · onTap → unified bulk review API 호출
+      · loading 중에는 spinner + 라벨 '확정 중...' (탭 무효화)
+      · 마킹 0건이면 disabled (이론상 발생 안 함 — carousel 큐가 1+ 일 때만 도달)
+
+<em>각 _MarkCard 내부:</em>
+└─ Container(InkWell wrap)
+   └─ Row(padding: spacing-medium, gap: spacing-small)
+      ├─ <b>CircleAvatar</b>(36 · primaryContainer · 이름 첫 글자)
+      ├─ Expanded Column [
+      │    Row [Text(user.name) <i>· 14px w600</i> · _GroupChip(group.label)]
+      │    Text('남/여 · YYYY-MM-DD') <i>· 12px secondary</i>
+      │    if reject: Container(reason · error 8% bg · 12px) <i>· max 2 줄 · ellipsis</i>
+      │    if 직전 capacity skip: Container('정원 초과로 다음 시도에서 보류됨' · warn 톤)
+      │  ]
+      └─ Text('수정') <i>· 11px w600 primary 톤 · 좌측 정렬 align-center</i></div>
+    </div>
+  </section>
+
+  <section class="doc">
+    <h2>Spacing &amp; alignment rules</h2>
+    <table class="ref">
+      <thead><tr><th style="width:60px;">#</th><th style="width:200px;">Region</th><th style="width:220px;">Alignment</th><th>Spacing / tokens</th></tr></thead>
+      <tbody>
+        <tr><td>①</td><td>AppBar</td><td>back left · title · 56px</td><td>centerTitle: false · h-pad <code>spacing-screen-edge</code></td></tr>
+        <tr><td>②</td><td>Summary row</td><td>row · gap small · cell flex 1</td><td>cell padding <code>spacing-small</code>/<code>spacing-medium</code> · radius <code>radius-card</code> · border 1px <code>color-divider</code> · 숫자 22px w700 톤별 (success / error / primary) · 라벨 11px secondary · margin-bottom <code>spacing-medium</code></td></tr>
+        <tr><td>③⑤</td><td>Section header</td><td>좌측 정렬 · 단독 한 줄</td><td>13px w700 톤별 (success/error) · margin-top <code>spacing-medium</code> · margin-bottom <code>spacing-small</code></td></tr>
+        <tr><td>④⑥</td><td>Mark card</td><td>풀폭 · row(avatar + body + edit affordance)</td><td>padding <code>spacing-medium</code> · radius <code>radius-card</code> · border 1px <code>color-divider</code> · bg <code>color-background</code> · 카드 사이 <code>spacing-small</code> · avatar 36px (carousel 72보다 작음 — 요약 화면) · 그룹 chip 10px secondary · 사유 텍스트 12px error · radius-small · padding 4/8 · max 2 줄</td></tr>
+        <tr><td>⑦</td><td>Sticky CTA</td><td>bottom · full width · SafeArea inset</td><td>height 48 · radius <code>radius-card</code> · bg <code>color-partner-primary</code> · 라벨 15px w700 white · disabled 시 divider bg + secondary text · loading 시 70% alpha bg + spinner</td></tr>
+        <tr><td>—</td><td>Capacity warn banner</td><td>풀폭 · summary 위</td><td>bg <code>color-warning</code> 8% · border 25% · 제목 12px w700 · sub 11px secondary line-height 1.4 · padding small/medium · radius <code>radius-card</code></td></tr>
+        <tr><td>—</td><td>Error banner</td><td>풀폭 · summary 위</td><td>bg <code>color-error</code> 8% · border 25% · 제목 12px w700 · sub 11px secondary</td></tr>
+      </tbody>
+    </table>
+  </section>
+</div>
+
+<!-- ============================================================
+     STATES
+     ============================================================ -->
+<div class="perspective" id="states">
+  <div class="perspective__header">
+    <span class="glyph">🎨</span>
+    <h2>States</h2>
+    <span class="lede">시각 변형 5종.</span>
+  </div>
+
+  <section class="doc">
+    <p class="intro">
+      <strong>State 식별 기준</strong>: (a) 마킹 분포(승인/거절 둘 다 / 한쪽만) (b) 제출 상태(idle / loading / capacity skip 결과 / error).
+    </p>
+
+    <!-- =================================================
+         STATE 1 — Default (mixed)
+         ================================================= -->
+    <table class="ref state-mini">
+      <thead><tr><th colspan="3"><strong>State 1 · Default</strong> 🎯 <span class="tag tag--mute">baseline</span> · <small>승인 + 거절 모두 있음</small></th></tr></thead>
+      <tbody>
+        <tr>
+          <td rowspan="6" class="state-mini__mock"><div class="viewport">
+            <div class="erfc-appbar">
+              <div class="erfc-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg></div>
+              <div class="erfc-appbar__title">최종 확인</div>
+            </div>
+            <div class="erfc-body">
+              <div class="erfc-summary">
+                <div class="erfc-summary__cell">
+                  <div class="erfc-summary__num erfc-summary__num--approve">3</div>
+                  <div class="erfc-summary__lbl">승인</div>
+                </div>
+                <div class="erfc-summary__cell">
+                  <div class="erfc-summary__num erfc-summary__num--reject">1</div>
+                  <div class="erfc-summary__lbl">거절</div>
+                </div>
+              </div>
+
+              <div class="erfc-sec erfc-sec--approve">승인 <span class="erfc-sec__count">3건</span></div>
+              <div class="erfc-card">
+                <div class="erfc-card__avatar">김</div>
+                <div class="erfc-card__body">
+                  <div class="erfc-card__row">
+                    <div class="erfc-card__name">김민지</div>
+                    <div class="erfc-card__group">여성 그룹</div>
+                  </div>
+                  <div class="erfc-card__sub">여 · 1996-03-12</div>
+                </div>
+                <div class="erfc-card__edit">수정</div>
+              </div>
+              <div class="erfc-card">
+                <div class="erfc-card__avatar">정</div>
+                <div class="erfc-card__body">
+                  <div class="erfc-card__row">
+                    <div class="erfc-card__name">정유진</div>
+                    <div class="erfc-card__group">여성 그룹</div>
+                  </div>
+                  <div class="erfc-card__sub">여 · 1995-07-08</div>
+                </div>
+                <div class="erfc-card__edit">수정</div>
+              </div>
+              <div class="erfc-card">
+                <div class="erfc-card__avatar">한</div>
+                <div class="erfc-card__body">
+                  <div class="erfc-card__row">
+                    <div class="erfc-card__name">한승우</div>
+                    <div class="erfc-card__group">남성 그룹</div>
+                  </div>
+                  <div class="erfc-card__sub">남 · 1994-11-22</div>
+                </div>
+                <div class="erfc-card__edit">수정</div>
+              </div>
+
+              <div class="erfc-sec erfc-sec--reject">거절 <span class="erfc-sec__count">1건</span></div>
+              <div class="erfc-card">
+                <div class="erfc-card__avatar">박</div>
+                <div class="erfc-card__body">
+                  <div class="erfc-card__row">
+                    <div class="erfc-card__name">박지호</div>
+                    <div class="erfc-card__group">남성 그룹</div>
+                  </div>
+                  <div class="erfc-card__sub">남 · 1992-08-04</div>
+                  <div class="erfc-card__reason">인증 정보 부족 — 신분증 사진이 너무 흐려서 본인 확인이 어렵습니다.</div>
+                </div>
+                <div class="erfc-card__edit">수정</div>
+              </div>
+            </div>
+            <div class="erfc-cta">
+              <div class="erfc-cta__btn">확정 (총 4건)</div>
+            </div>
+          </div></td>
+          <td class="state-mini__aspect">조건</td>
+          <td>마킹된 신청 ≥1건 + 승인/거절 둘 다 존재. capacity skip / error 없음. 확정 버튼 활성.</td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">사용자 액션</td>
+          <td>
+            · <strong>카드 탭</strong> → carousel 단일 사용자 push (수정 모드) → 결정 후 본 화면으로 자동 복귀<br>
+            · <strong>확정 버튼 탭</strong> → unified bulk review API 호출 → loading state(State 4) → 성공 시 리스트로 pop + 마킹 캐시 invalidate / capacity skip이면 State 3 / 에러면 State 5<br>
+            · <strong>back / 뒤로가기</strong> → 리스트로 pop, 마킹 캐시 보존 (다시 carousel/confirm 진입 가능)
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">에지케이스</td><td>· 거절 사유 텍스트는 max 2줄 + ellipsis (긴 사유는 잘림)<br>· 사용자가 속한 입장그룹 chip을 카드에 작게 노출(컨텍스트 보강)<br>· 같은 입장그룹의 사용자들이 인접하도록 정렬(승인 섹션 안에서 그룹별 묶음 — 정렬만, sub-section은 X)<br>· 마킹 0건이면 이론상 도달 X (carousel이 큐 비었을 때만 confirm push, 큐 비면 진입 자체 X)</td></tr>
+        <tr>
+          <td class="state-mini__aspect">컴포넌트</td>
+          <td>
+            <code>Scaffold</code> · <code>AppBar</code> · <code>SingleChildScrollView</code> · <code>_Summary</code>(2-cell row) · <code>_SectionHeader</code>(approve/reject 톤) · <code>_MarkCard</code>(avatar + body + 사유 preview + edit affordance) · <code>FilledButton</code>(sticky 확정) · <code>SafeArea</code>
+          </td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">토큰</td>
+          <td>
+            <code>color-primary</code>(partner — avatar bg @ 15% / edit affordance / 확정 버튼) · <code>color-text-primary</code>(이름 / 카드 제목) · <code>color-text-secondary</code>(서브 / 그룹 chip / count) · #15803d(승인 톤 — summary 숫자 / 섹션 헤더) · <code>color-error</code>(거절 톤 — summary 숫자 / 섹션 헤더 / 사유 텍스트 + 8% bg) · <code>color-divider</code>(카드 border / 그룹 chip bg) · <code>radius-card</code> · <code>radius-small</code>(사유 bg) · 999(그룹 chip) · typography 22px w700 (summary 숫자) / 14px w600 (이름) / 13px w700 (섹션) / 12px (사유 / 서브) / 11px (count / edit affordance / summary 라벨) / 10px (그룹 chip) / 15px w700 (CTA)
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">노트</td><td>📝 baseline. 운영자가 carousel에서 빠르게 결정한 내용을 한 화면에 요약해 보여줘 의도를 한 번 더 확인할 기회를 제공.</td></tr>
+      </tbody>
+    </table>
+
+    <!-- =================================================
+         STATE 2 — 한쪽만 (승인만)
+         ================================================= -->
+    <table class="ref state-mini">
+      <thead><tr><th colspan="3"><strong>State 2 · 한쪽만</strong> <span class="tag tag--mute">single-side</span> · <small>승인만 또는 거절만</small></th></tr></thead>
+      <tbody>
+        <tr>
+          <td rowspan="3" class="state-mini__mock"><div class="viewport">
+            <div class="erfc-appbar">
+              <div class="erfc-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg></div>
+              <div class="erfc-appbar__title">최종 확인</div>
+            </div>
+            <div class="erfc-body">
+              <div class="erfc-summary">
+                <div class="erfc-summary__cell">
+                  <div class="erfc-summary__num erfc-summary__num--approve">3</div>
+                  <div class="erfc-summary__lbl">승인</div>
+                </div>
+                <div class="erfc-summary__cell">
+                  <div class="erfc-summary__num erfc-summary__num--reject">0</div>
+                  <div class="erfc-summary__lbl">거절</div>
+                </div>
+              </div>
+              <div class="erfc-sec erfc-sec--approve">승인 <span class="erfc-sec__count">3건</span></div>
+              <div class="erfc-card">
+                <div class="erfc-card__avatar">김</div>
+                <div class="erfc-card__body">
+                  <div class="erfc-card__row">
+                    <div class="erfc-card__name">김민지</div>
+                    <div class="erfc-card__group">여성 그룹</div>
+                  </div>
+                  <div class="erfc-card__sub">여 · 1996-03-12</div>
+                </div>
+                <div class="erfc-card__edit">수정</div>
+              </div>
+              <div class="erfc-card">
+                <div class="erfc-card__avatar">정</div>
+                <div class="erfc-card__body">
+                  <div class="erfc-card__row">
+                    <div class="erfc-card__name">정유진</div>
+                    <div class="erfc-card__group">여성 그룹</div>
+                  </div>
+                  <div class="erfc-card__sub">여 · 1995-07-08</div>
+                </div>
+                <div class="erfc-card__edit">수정</div>
+              </div>
+            </div>
+            <div class="erfc-cta">
+              <div class="erfc-cta__btn">확정 (총 3건)</div>
+            </div>
+          </div></td>
+          <td class="state-mini__aspect">조건</td>
+          <td>한쪽만 마킹된 케이스 (예: 승인만 3건). summary는 두 cell 모두 노출하되 비어있는 쪽은 0으로 표시. 거절 섹션 헤더 + 카드 모두 렌더 X.</td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">사용자 액션</td>
+          <td>State 1과 동일. 운영자가 거절을 추가로 마킹하고 싶으면 back → 리스트로 가서 그 사용자 카드를 탭(아직 처리 완료 그룹에 없으니 심사 대기에 남아있음)해 carousel 진입 후 거절. 다시 confirm으로 도달.</td>
+        </tr>
+        <tr><td class="state-mini__aspect">노트</td><td>📝 가장 흔한 케이스 — 거절은 드물기 때문에 보통 승인만 있는 화면을 자주 본다.</td></tr>
+      </tbody>
+    </table>
+
+    <!-- =================================================
+         STATE 3 — Capacity skip 결과
+         ================================================= -->
+    <table class="ref state-mini">
+      <thead><tr><th colspan="3"><strong>State 3 · Capacity skip 결과</strong> <span class="tag tag--mute">capacity-skip</span></th></tr></thead>
+      <tbody>
+        <tr>
+          <td rowspan="3" class="state-mini__mock"><div class="viewport">
+            <div class="erfc-appbar">
+              <div class="erfc-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg></div>
+              <div class="erfc-appbar__title">최종 확인</div>
+            </div>
+            <div class="erfc-body">
+              <div class="erfc-warn">
+                <div class="erfc-warn__title">정원 초과로 일부 보류</div>
+                <div class="erfc-warn__sub">총 3건 중 1건이 정원 초과로 처리되지 않았습니다. 보류된 신청은 그대로 마킹이 남아있어 다음 시도에서 다시 확정할 수 있습니다.</div>
+              </div>
+              <div class="erfc-summary">
+                <div class="erfc-summary__cell">
+                  <div class="erfc-summary__num erfc-summary__num--approve">1</div>
+                  <div class="erfc-summary__lbl">승인 보류</div>
+                </div>
+                <div class="erfc-summary__cell">
+                  <div class="erfc-summary__num erfc-summary__num--reject">0</div>
+                  <div class="erfc-summary__lbl">거절</div>
+                </div>
+              </div>
+              <div class="erfc-sec erfc-sec--approve">승인 <span class="erfc-sec__count">1건 (보류)</span></div>
+              <div class="erfc-card">
+                <div class="erfc-card__avatar">한</div>
+                <div class="erfc-card__body">
+                  <div class="erfc-card__row">
+                    <div class="erfc-card__name">한승우</div>
+                    <div class="erfc-card__group">남성 그룹</div>
+                  </div>
+                  <div class="erfc-card__sub">남 · 1994-11-22</div>
+                  <div class="erfc-card__cap">⚠ 정원 초과로 다음 시도에서 보류됨</div>
+                </div>
+                <div class="erfc-card__edit">수정</div>
+              </div>
+            </div>
+            <div class="erfc-cta">
+              <div class="erfc-cta__btn">다시 확정 (1건)</div>
+            </div>
+          </div></td>
+          <td class="state-mini__aspect">조건</td>
+          <td>직전 확정 시도에서 백엔드가 일부 신청을 capacity 초과로 skip한 결과. 처리된 건은 마킹 캐시에서 제거되고 보류된 건만 화면에 남아있다. 상단 warn banner + 카드별 cap 시그널.</td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">사용자 액션</td>
+          <td>
+            · <strong>다시 확정 탭</strong> → 보류된 마킹만 다시 unified API에 전송 (capacity가 비어있을 때만 통과)<br>
+            · <strong>카드 탭</strong> → carousel 수정 모드 — 거절로 변경하거나 마킹 해제(미정 처리)<br>
+            · <strong>back</strong> → 리스트로 pop. 보류된 마킹은 캐시에 남아 다음 carousel/confirm 진입 시 그대로 보임.<br>
+            · <strong>마킹 해제 흐름</strong> — 사용자가 capacity skip을 보고 결정을 내려놓고 싶다면 carousel 수정에서 거절로 바꾸거나 마킹 자체를 제거할 수 있어야 함 (carousel 수정 모드에 "마킹 해제" 옵션 추가 — 후속 spec 보강).
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">노트</td><td>⚠ capacity skip 시그널은 운영자에게 명확히 — 단순 빈 결과로 보이면 혼란. banner + 카드별 cap 시그널 이중화로 의도를 강조.</td></tr>
+      </tbody>
+    </table>
+
+    <!-- =================================================
+         STATE 4 — Submitting (loading)
+         ================================================= -->
+    <table class="ref state-mini">
+      <thead><tr><th colspan="3"><strong>State 4 · 제출 중</strong> <span class="tag tag--mute">loading</span></th></tr></thead>
+      <tbody>
+        <tr>
+          <td rowspan="3" class="state-mini__mock"><div class="viewport">
+            <div class="erfc-appbar">
+              <div class="erfc-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg></div>
+              <div class="erfc-appbar__title">최종 확인</div>
+            </div>
+            <div class="erfc-body" style="opacity:0.5;pointer-events:none;">
+              <div class="erfc-summary">
+                <div class="erfc-summary__cell">
+                  <div class="erfc-summary__num erfc-summary__num--approve">3</div>
+                  <div class="erfc-summary__lbl">승인</div>
+                </div>
+                <div class="erfc-summary__cell">
+                  <div class="erfc-summary__num erfc-summary__num--reject">1</div>
+                  <div class="erfc-summary__lbl">거절</div>
+                </div>
+              </div>
+              <div class="erfc-sec erfc-sec--approve">승인 <span class="erfc-sec__count">3건</span></div>
+              <div class="erfc-card">
+                <div class="erfc-card__avatar">김</div>
+                <div class="erfc-card__body">
+                  <div class="erfc-card__row">
+                    <div class="erfc-card__name">김민지</div>
+                    <div class="erfc-card__group">여성 그룹</div>
+                  </div>
+                  <div class="erfc-card__sub">여 · 1996-03-12</div>
+                </div>
+                <div class="erfc-card__edit">수정</div>
+              </div>
+            </div>
+            <div class="erfc-cta">
+              <div class="erfc-cta__btn erfc-cta__btn--loading">⟳ 확정 중...</div>
+            </div>
+          </div></td>
+          <td class="state-mini__aspect">조건</td>
+          <td>확정 버튼 탭 직후, unified bulk review API 응답 대기 중. 본문은 50% opacity로 가라앉히고 pointer-events 차단. CTA 버튼은 spinner + 라벨 변경 + 70% bg.</td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">사용자 액션</td>
+          <td>
+            · 모든 인터랙션 차단 (back 버튼 포함 — 시스템 back은 무시)<br>
+            · API 응답에 따라 자동 전환:
+              <ul>
+                <li>전체 성공 → 성공 SnackBar + 리스트로 pop + 마킹 캐시 invalidate</li>
+                <li>일부 capacity skip → State 3로 전환</li>
+                <li>네트워크/서버 에러 → State 5로 전환 (마킹 보존)</li>
+              </ul>
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">노트</td><td>📝 호출 시간은 일반적으로 1~3초. 5초 넘으면 timeout 처리 (State 5).</td></tr>
+      </tbody>
+    </table>
+
+    <!-- =================================================
+         STATE 5 — Error
+         ================================================= -->
+    <table class="ref state-mini">
+      <thead><tr><th colspan="3"><strong>State 5 · 에러</strong> <span class="tag tag--mute">error</span></th></tr></thead>
+      <tbody>
+        <tr>
+          <td rowspan="3" class="state-mini__mock"><div class="viewport">
+            <div class="erfc-appbar">
+              <div class="erfc-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg></div>
+              <div class="erfc-appbar__title">최종 확인</div>
+            </div>
+            <div class="erfc-body">
+              <div class="erfc-err">
+                <div class="erfc-err__title">확정 실패 — 네트워크 오류</div>
+                <div class="erfc-err__sub">서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요. 마킹은 그대로 보존됩니다.</div>
+              </div>
+              <div class="erfc-summary">
+                <div class="erfc-summary__cell">
+                  <div class="erfc-summary__num erfc-summary__num--approve">3</div>
+                  <div class="erfc-summary__lbl">승인</div>
+                </div>
+                <div class="erfc-summary__cell">
+                  <div class="erfc-summary__num erfc-summary__num--reject">1</div>
+                  <div class="erfc-summary__lbl">거절</div>
+                </div>
+              </div>
+              <div class="erfc-sec erfc-sec--approve">승인 <span class="erfc-sec__count">3건</span></div>
+              <div class="erfc-card">
+                <div class="erfc-card__avatar">김</div>
+                <div class="erfc-card__body">
+                  <div class="erfc-card__row">
+                    <div class="erfc-card__name">김민지</div>
+                    <div class="erfc-card__group">여성 그룹</div>
+                  </div>
+                  <div class="erfc-card__sub">여 · 1996-03-12</div>
+                </div>
+                <div class="erfc-card__edit">수정</div>
+              </div>
+            </div>
+            <div class="erfc-cta">
+              <div class="erfc-cta__btn">다시 시도 (총 4건)</div>
+            </div>
+          </div></td>
+          <td class="state-mini__aspect">조건</td>
+          <td>API 호출 실패 (네트워크 / 서버 / timeout / 권한). 마킹은 모두 보존되고 본문 상단에 error banner 노출. 확정 버튼 라벨은 '다시 시도'로 변경.</td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">사용자 액션</td>
+          <td>
+            · <strong>다시 시도 탭</strong> → State 4로 전환 후 재호출<br>
+            · <strong>back</strong> → 리스트로 pop, 마킹 캐시 보존 (다음 진입 시 confirm으로 다시 도달 가능)<br>
+            · <strong>카드 탭</strong> → carousel 수정 모드 (에러 상태에서도 가능)<br>
+            · 같은 에러가 3회 이상 반복되면 banner 카피를 더 구체적으로 — '서버 점검 중일 수 있습니다. 잠시 후 다시 시도해주세요.'
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">노트</td><td>⚠ 에러 발생 시 마킹 보존이 최우선 — 절대 자동 invalidate 금지. 운영자가 다시 시도할 수 있는 경로를 명시.</td></tr>
+      </tbody>
+    </table>
+  </section>
+</div>
+
+<!-- ============================================================
+     GLOBAL BEHAVIOR
+     ============================================================ -->
+<div class="perspective" id="behavior">
+  <div class="perspective__header">
+    <span class="glyph">🔄</span>
+    <h2>Global Behavior</h2>
+    <span class="lede">모든 state에 동일하게 적용되는 동작.</span>
+  </div>
+
+  <section class="doc">
+    <h2>커밋 트랜잭션 정책</h2>
+    <ul>
+      <li>확정 버튼 → unified bulk review EF(<a href="https://github.com/Mark-Yun/minglit/issues/2101">#2101</a>) 호출 — 승인 + 거절을 단일 트랜잭션으로 처리.</li>
+      <li>응답 분기:
+        <ul>
+          <li><strong>전체 성공</strong>: <code>{ approved: [...], rejected: [...], skipped_due_to_capacity: [] }</code> → 성공 SnackBar + 리스트로 pop + 마킹 캐시 invalidate</li>
+          <li><strong>부분 capacity skip</strong>: <code>skipped_due_to_capacity</code> 비어있지 않음 → State 3로 전환, 처리된 건만 캐시에서 제거하고 보류된 건은 유지</li>
+          <li><strong>전체 실패</strong>: 네트워크/서버 에러 → State 5, 마킹 캐시 전체 보존</li>
+        </ul>
+      </li>
+      <li>API가 부재하거나 미가용 시 fallback: 기존 single approve / single reject EF를 순차 호출 — 성공한 건은 캐시에서 제거, 실패한 건은 보존. (트랜잭션성은 보장 안 됨, 사용자에게 명시.)</li>
+    </ul>
+  </section>
+
+  <section class="doc">
+    <h2>수정 진입 → 자동 복귀 흐름</h2>
+    <ul>
+      <li>본 화면 카드 탭 → <code>CarouselRoute</code>를 single-user mode로 push (기존 carousel 큐와는 별개의 페이지로 진입).</li>
+      <li>carousel은 진입 모드 = modify로 인식하고 사용자 헤더 아래 _MarkPill 노출(현재 마킹 시그널). 결정 후 자동 advance 대신 confirm 화면으로 즉시 pop.</li>
+      <li>마킹 해제 옵션 — 사용자가 결정을 보류하고 싶을 때 carousel 수정 모드 안에 "마킹 해제" 동작 제공 (구체 UI는 carousel spec 후속 보강).</li>
+    </ul>
+  </section>
+
+  <section class="doc">
+    <h2>마킹 정렬 정책</h2>
+    <ul>
+      <li>승인 섹션 — 입장그룹별로 인접하도록 정렬(같은 그룹의 사용자가 모여 있도록). sub-section 헤더는 사용하지 않음 — 가벼운 정렬만.</li>
+      <li>거절 섹션 — 거절 사유별 분류 없이 마킹 시각 순서 (carousel에서 결정한 순서) 유지.</li>
+      <li>그룹 chip을 카드 안에 작게 노출해 컨텍스트는 보존.</li>
+    </ul>
+  </section>
+
+  <section class="doc">
+    <h2>back 동작</h2>
+    <ul>
+      <li>appbar back 또는 시스템 back → 리스트로 pop. 마킹 캐시는 보존되어 리스트에서 다시 carousel 진입 가능.</li>
+      <li>State 4(loading) 중에는 back 무시 — API 응답 도착 후 자동 전환되도록.</li>
+      <li>State 5(error) 중에는 back 허용 — 에러 회복은 다음 진입에서 재시도 가능.</li>
+    </ul>
+  </section>
+</div>
+
+<!-- ============================================================
+     REFERENCE
+     ============================================================ -->
+<div class="perspective" id="reference">
+  <div class="perspective__header">
+    <span class="glyph">🔗</span>
+    <h2>Reference</h2>
+    <span class="lede">관련 라우트 · 화면 · 구현 소스.</span>
+  </div>
+
+  <section class="doc">
+    <h2>Implementation source</h2>
+    <table class="ref">
+      <tbody>
+        <tr><td style="width: 160px;"><strong>Route</strong></td><td><code>EventApplicationReviewConfirmRoute</code></td></tr>
+        <tr><td><strong>Path</strong></td><td><code>/more/parties/:partyId/events/:eventId/applications/review/confirm</code></td></tr>
+        <tr><td><strong>Widget class</strong></td><td><code>EventApplicationReviewConfirmPage</code> (+ <code>_Summary</code> · <code>_SectionHeader</code> · <code>_MarkCard</code> · <code>_Banner</code>)</td></tr>
+        <tr><td><strong>App</strong></td><td><code>app_partner</code></td></tr>
+        <tr><td><strong>Source (예상)</strong></td><td><code>apps/app_partner/lib/src/features/event/applications/review/event_application_review_confirm_page.dart</code></td></tr>
+        <tr><td><strong>Marking state</strong></td><td>carousel과 같은 in-memory 마킹 컨테이너 공유</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Backend dependency</h2>
+    <table class="ref">
+      <tbody>
+        <tr><td style="width: 200px;"><strong>Primary</strong></td><td>Unified bulk review EF — <a href="https://github.com/Mark-Yun/minglit/issues/2101">#2101</a>. 승인 + 거절을 단일 트랜잭션 처리, capacity skip 결과를 명시적으로 반환.</td></tr>
+        <tr><td><strong>Fallback (if unified API not available)</strong></td><td>기존 EF 순차 호출:
+          <ul>
+            <li><code>partner-approve-application</code> action=approve (single)</li>
+            <li><code>partner-reject-application</code> single</li>
+          </ul>
+          트랜잭션성 보장 안 됨, 부분 실패 가능.
+        </td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Related screens</h2>
+    <table class="ref">
+      <thead><tr><th style="width: 280px;">Spec</th><th>관계</th></tr></thead>
+      <tbody>
+        <tr><td><a href="/specs/event_application_review_carousel_page.html"><code>EventApplicationReviewCarouselPage</code></a></td><td>Parent (replace) — 큐 종료 시 본 화면으로 pushReplacement. 카드 탭 수정 시 본 화면에서 carousel 단일 사용자 모드로 push.</td></tr>
+        <tr><td><a href="/specs/event_application_list_page.html"><code>EventApplicationListPage</code></a></td><td>Grandparent — 확정 성공 또는 back 시 본 화면이 pop되면 도달. 자동 invalidate로 처리된 신청이 처리 완료 그룹으로 이동.</td></tr>
+        <tr><td><a href="/specs/event_application_detail_page.html"><code>EventApplicationDetailPage</code></a></td><td>Sibling — 처리 완료된 신청 회고는 detail로 (read-only).</td></tr>
+      </tbody>
+    </table>
+  </section>
+</div>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **event_application_list_page.html** (v2 redesign) — 심사 대기 그룹을 입장그룹별 sub-section으로 묶고, 카드 탭 라우팅을 carousel(심사 대기) / detail(처리 완료)로 분기. bottom sticky '심사 시작' CTA 추가.
- **event_application_review_carousel_page.html** (신규) — 풀스크린 단일 사용자 심사 화면. 듀얼 CTA + 거절 사유 bottom sheet(predefined 5종 + free input). 자동 advance + 큐 끝 confirm replace.
- **event_application_review_confirm_page.html** (신규) — 마킹 요약 + 카드 탭 수정 + unified bulk review API(#2101) 단일 트랜잭션 커밋. capacity skip / error 회복 흐름 포함.

Closes #2103

## Design decisions

- **Deferred batch 패턴**: 마킹은 로컬 캐시(eventId 키), 페이지 이탈 시 invalidate. 백엔드 커밋은 confirm 단계에서 한 번만.
- **큐 정의**: carousel queue = 전체 pending across 입장그룹, `created_at ASC`. 입장그룹별 batch가 아니라 자연 정렬 순회.
- **거절 사유**: 강제하지 않되, predefined chip + 자유 입력 조합으로 사유 명시를 한 발짝 늦춤. "기타" chip은 자유 입력 필수.
- **수정 흐름**: confirm 카드 탭 → carousel single-user mode → 결정 후 confirm으로 즉시 pop (자동 advance 안 함).

## Related issues

- #2101 — Backend: Unified bulk review EF (carousel/confirm 동작의 백엔드 의존성)
- #2102 — Backend: Ticket → EntryGroup 1:1 enforcement (입장그룹 sub-grouping의 정합성 전제)
- #2103 — Spec: 본 PR

## Test plan

- [ ] localhost:3003/specs/event_application_list_page.html — 4 states 시각 확인 (default / 단일 그룹 / 처리완료만 / 빈상태)
- [ ] localhost:3003/specs/event_application_review_carousel_page.html — 4 states 시각 확인 (review / 사유 sheet / 수정 모드 / 큐 종료)
- [ ] localhost:3003/specs/event_application_review_confirm_page.html — 5 states 시각 확인 (default / 한쪽만 / capacity skip / loading / error)
- [ ] dark mode 토글 시 모든 토큰 정상 전환
- [ ] cross-link 동작 — 각 spec의 hierarchy / related screens 링크 클릭 시 정상 이동

🤖 Generated with [Claude Code](https://claude.com/claude-code)