### PR TITLE
docs(mds): partner_event_detail 라이프사이클 정리 + EventEdit + MinglitCapacityBar

### DIFF
--- a/apps/mds/docs/public/specs/event_edit_page.html
+++ b/apps/mds/docs/public/specs/event_edit_page.html
@@ -1025,7 +1025,7 @@ body.dark-mode .viewport {
         <tr><td><strong>Path</strong></td><td><code>/more/parties/:partyId/events/:eventId/edit</code></td></tr>
         <tr><td><strong>Widget class</strong></td><td><code>EventEditPage</code> (+ <code>_LockBanner</code> · <code>_LockChip</code> · <code>_DateTimeField</code> · <code>_LocationField</code> · <code>_CapacityField</code> · <code>_PriceField</code> · <code>_TextField</code> internal widgets)</td></tr>
         <tr><td><strong>App</strong></td><td><code>app_partner</code></td></tr>
-        <tr><td><strong>Source (예상)</strong></td><td><code>apps/app_partner/lib/src/features/event/edit/event_edit_page.dart</code> + <code>apps/app_partner/lib/src/features/event/edit/widgets/*</code></td></tr>
+        <tr><td><strong>Source (예상)</strong></td><td><code>apps/app_partner/lib/src/features/party/event/edit/event_edit_page.dart</code> + <code>apps/app_partner/lib/src/features/party/event/edit/widgets/*</code></td></tr>
         <tr><td><strong>Provider</strong></td><td><code>eventDetailProvider(eventId)</code> 로 fresh fetch · 저장은 <code>eventEditCoordinator(eventId)</code> 통해 mutate + invalidate</td></tr>
       </tbody>
     </table>

--- a/apps/mds/docs/public/specs/event_edit_page.html
+++ b/apps/mds/docs/public/specs/event_edit_page.html
@@ -1,0 +1,1051 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<title>Spec — EventEditPage (app_partner · EventEditRoute)</title>
+<link rel="stylesheet" href="/specs/_spec.css">
+<style>
+/* ============================================================
+   EventEditPage-specific atoms.
+
+   Partner app theme:
+   - Page (Scaffold) bg = light gray (var(--color-surface))
+   - Cards / form rows = white (var(--color-background))
+   - AppBar matches scaffold (light gray, no border-bottom)
+   - Brand primary = MinglitPartnerColors.primary (#6c3ce1)
+     scoped via .viewport so docs chrome stays neutral.
+   ============================================================ */
+.viewport {
+  --color-primary: var(--color-partner-primary);
+  --spec-blueprint-rgb: 108, 60, 225;
+}
+body.dark-mode .viewport {
+  --color-primary: var(--color-partner-dark-primary);
+}
+
+/* --- App bar --- */
+.ee-appbar {
+  height: 56px;
+  display: flex;
+  align-items: center;
+  background: var(--color-surface);
+  position: relative;
+}
+.ee-appbar__back {
+  width: 40px; height: 40px;
+  display: flex; align-items: center; justify-content: center;
+  color: var(--color-text-primary);
+}
+.ee-appbar__back svg { width: 22px; height: 22px; }
+.ee-appbar__title {
+  flex: 1;
+  font-size: var(--typography-font-size-app-bar-title);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+/* --- Body (between appbar and submit bar) --- */
+.ee-body {
+  position: absolute;
+  top: 56px;
+  left: 0; right: 0; bottom: 80px;
+  overflow-y: auto;
+  scrollbar-width: none;
+  background: var(--color-surface);
+}
+.ee-body::-webkit-scrollbar { display: none; }
+
+/* --- Lock banner (확정자 ≥1명일 때 body 최상단) --- */
+.ee-lockbanner {
+  margin: var(--spacing-medium) var(--spacing-screen-edge) 0;
+  padding: var(--spacing-medium);
+  background: rgba(108, 60, 225, 0.08);
+  border: 1px solid rgba(108, 60, 225, 0.25);
+  border-radius: var(--radius-card);
+  display: flex;
+  gap: var(--spacing-small);
+  align-items: flex-start;
+}
+.ee-lockbanner svg {
+  width: 18px; height: 18px;
+  color: var(--color-partner-primary);
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+.ee-lockbanner__body { flex: 1; }
+.ee-lockbanner__title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin-bottom: 2px;
+}
+.ee-lockbanner__sub {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+}
+
+/* --- Section header --- */
+.ee-section-header {
+  font-size: var(--typography-font-size-body);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  padding: var(--spacing-medium) var(--spacing-screen-edge) var(--spacing-small);
+}
+
+/* --- Form field row --- */
+.ee-field {
+  margin: 0 var(--spacing-screen-edge) var(--spacing-small);
+  padding: var(--spacing-medium);
+  background: var(--color-background);
+  border-radius: var(--radius-card);
+  border: 1px solid var(--color-divider);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xsmall);
+}
+.ee-field__label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--color-text-secondary);
+  letter-spacing: 0.02em;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xsmall);
+}
+.ee-field__label svg {
+  width: 12px; height: 12px;
+  color: var(--color-text-secondary);
+}
+.ee-field__value {
+  font-size: 15px;
+  color: var(--color-text-primary);
+}
+.ee-field__hint {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  margin-top: 2px;
+}
+.ee-field__hint--warn {
+  color: var(--color-partner-primary);
+  font-weight: 500;
+}
+.ee-field__hint--error {
+  color: var(--color-error);
+  font-weight: 500;
+}
+.ee-field--locked {
+  opacity: 0.7;
+  background: var(--color-divider-faint, var(--color-surface));
+}
+.ee-field--locked .ee-field__value {
+  color: var(--color-text-secondary);
+}
+.ee-field--changed {
+  border-color: var(--color-partner-primary);
+  border-width: 1.5px;
+}
+
+/* --- Lock chip on a field --- */
+.ee-lockchip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 6px;
+  background: rgba(108, 60, 225, 0.12);
+  color: var(--color-partner-primary);
+  border-radius: var(--radius-small);
+  font-size: 10px;
+  font-weight: 600;
+  margin-left: auto;
+}
+.ee-lockchip svg { width: 10px; height: 10px; }
+
+/* --- Bottom submit bar --- */
+.ee-submitbar {
+  position: absolute;
+  bottom: 0; left: 0; right: 0;
+  height: 80px;
+  padding: var(--spacing-medium);
+  background: var(--color-surface);
+  box-shadow: 0 -4px 10px rgba(0,0,0,0.06);
+  box-sizing: border-box;
+}
+.ee-submit {
+  width: 100%;
+  height: 48px;
+  border-radius: var(--radius-button);
+  background: var(--color-partner-primary);
+  color: white;
+  display: flex; align-items: center; justify-content: center;
+  font-size: var(--typography-font-size-button);
+  font-weight: 600;
+  gap: var(--spacing-small);
+}
+.ee-submit--disabled {
+  background: var(--color-divider);
+  color: var(--color-text-secondary);
+}
+.ee-submit--loading { opacity: 0.85; }
+.btn-spinner {
+  width: 16px; height: 16px;
+  border: 2px solid rgba(255,255,255,0.4);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* --- Cancel link (이벤트 취소 진입) --- */
+.ee-cancel-link {
+  margin: var(--spacing-large) var(--spacing-screen-edge);
+  text-align: center;
+  font-size: 13px;
+  color: var(--color-error);
+  font-weight: 500;
+  padding: var(--spacing-small);
+}
+
+/* --- Reason dialog (일정·장소 변경 시) --- */
+.ee-dialog-overlay {
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0,0,0,0.45);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 5;
+}
+.ee-dialog {
+  width: 88%;
+  max-width: 320px;
+  background: var(--color-background);
+  border-radius: var(--radius-card);
+  padding: var(--spacing-large);
+  display: flex; flex-direction: column;
+  gap: var(--spacing-medium);
+}
+.ee-dialog__title {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+.ee-dialog__body {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+.ee-dialog__before-after {
+  display: flex; flex-direction: column;
+  gap: 4px;
+  padding: var(--spacing-small);
+  background: var(--color-surface);
+  border-radius: var(--radius-small);
+  font-size: 12px;
+}
+.ee-dialog__before { color: var(--color-text-secondary); }
+.ee-dialog__after { color: var(--color-partner-primary); font-weight: 600; }
+.ee-dialog__textarea {
+  border: 1px solid var(--color-divider);
+  border-radius: var(--radius-input);
+  padding: var(--spacing-small);
+  min-height: 56px;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+.ee-dialog__notice {
+  font-size: 11px;
+  color: var(--color-partner-primary);
+  background: rgba(108, 60, 225, 0.08);
+  padding: var(--spacing-small);
+  border-radius: var(--radius-small);
+  display: flex; gap: 6px; align-items: flex-start;
+}
+.ee-dialog__notice svg { width: 12px; height: 12px; flex-shrink: 0; margin-top: 1px; }
+.ee-dialog__actions {
+  display: flex; gap: var(--spacing-small);
+  justify-content: flex-end;
+}
+.ee-dialog__btn {
+  height: 36px;
+  padding: 0 var(--spacing-medium);
+  border-radius: var(--radius-button);
+  font-size: 13px;
+  font-weight: 600;
+  display: inline-flex; align-items: center;
+}
+.ee-dialog__btn--ghost { color: var(--color-text-secondary); }
+.ee-dialog__btn--primary {
+  background: var(--color-partner-primary);
+  color: white;
+}
+
+/* --- Snackbar --- */
+.snackbar {
+  position: absolute;
+  bottom: 96px; left: 16px; right: 16px;
+  background: #323232;
+  color: white;
+  border-radius: var(--radius-small);
+  padding: 12px 16px;
+  font-size: 13px;
+  display: flex; align-items: center; gap: 8px;
+}
+.snackbar svg { width: 18px; height: 18px; flex-shrink: 0; }
+.snackbar--success { background: #14532d; }
+.snackbar--success svg { color: #86efac; }
+.snackbar--error svg { color: var(--color-error); }
+</style>
+</head>
+<body>
+
+<div class="toolbar">
+  <label><input type="checkbox" id="spec-toggle"> Spec mode (annotations / callouts on)</label>
+  <label><input type="checkbox" id="dark-toggle"> Dark mode (viewports flip dark)</label>
+</div>
+
+<div class="page">
+
+<!-- ============================================================
+     HEADER
+     ============================================================ -->
+<header>
+  <h1>Event Edit</h1>
+</header>
+
+<!-- ============================================================
+     OVERVIEW
+     ============================================================ -->
+<section class="doc">
+  <h2>Overview</h2>
+  <table class="ref">
+    <tbody>
+      <tr>
+        <th style="width: 140px;">Status</th>
+        <td><strong>📝 신규작성</strong> <em style="color: var(--color-text-secondary);">— v1 초안 (확정자 0명 / ≥1명 / 변경 사유 다이얼로그 / 정원 감소 검증 / 저장 = 5 state)</em></td>
+      </tr>
+      <tr>
+        <th>App</th>
+        <td><code>app_partner</code></td>
+      </tr>
+      <tr>
+        <th>Category</th>
+        <td>party · event · edit (existing occurrence)</td>
+      </tr>
+      <tr>
+        <th>Route / Surface</th>
+        <td><code>EventEditRoute</code> · widget: <code>EventEditPage</code></td>
+      </tr>
+      <tr>
+        <th>Path</th>
+        <td><code>/more/parties/:partyId/events/:eventId/edit</code></td>
+      </tr>
+      <tr>
+        <th>Hierarchy</th>
+        <td>
+          <strong>Parent</strong>: <a href="/specs/partner_event_detail_page.html"><code>EventDetailPage</code></a> (운영 관리 탭의 Hero "일정" 영역 탭 시 진입)<br>
+          <strong>Children</strong>: <em>—</em> <em style="color: var(--color-text-secondary);">(이벤트 취소 진입 시 별도 destructive flow — 본 spec 범위 밖)</em>
+        </td>
+      </tr>
+      <tr>
+        <th>Purpose</th>
+        <td>
+          파트너가 기존 이벤트의 정보를 수정한다. 확정 참가자(<em>승인</em> 또는 <em>결제 완료</em>) 수에 따라 필드별 잠금 정책이 적용되며, 통지 의무가 있는 필드(일정·장소)는 변경 시 사유 입력 + 자동 알림 발송이 강제된다. 확정자 0명일 때는 모든 필드 자유 수정 가능.
+        </td>
+      </tr>
+      <tr>
+        <th>User journey</th>
+        <td>
+          <strong>Entry points</strong>: 이벤트 상세(<a href="/specs/partner_event_detail_page.html">EventDetailPage</a>)의 Hero "일정" 영역 탭.<br>
+          <strong>Exit points</strong>: 저장 성공 → 화면 닫히며 EventDetailPage로 복귀, 성공 snackbar 노출. 일정/장소 변경 시 → 알림 발송 안내 snackbar 추가.
+          뒤로가기 → 변경사항 있으면 confirm 다이얼로그 + "변경사항을 버리시겠습니까?", 없으면 즉시 닫힘.
+          이벤트 취소 → 본문 하단 "이벤트 취소하기" 텍스트 링크 → 별도 destructive flow.
+        </td>
+      </tr>
+      <tr>
+        <th>Background</th>
+        <td>
+          <code>EventCreateRoute</code>(신규 회차 생성)와 분리한 이유: 수정 흐름은 "확정 참가자 보호 + 통지 의무"라는 다른 도메인 규칙을 가진다. 가격 인상 시 신규 신청자만 새 가격이 적용되고 확정자는 원래 가격이 유지되는 등 DB 레벨 정책이 별도로 동작하며, UI는 이를 명시적으로 안내한다.
+          잠금 매트릭스의 단일 진실은 본 spec — 운영자 화면 / 이메일 안내 / SMS 알림이 모두 같은 정책을 참조한다.
+        </td>
+      </tr>
+      <tr>
+        <th>Frequency</th>
+        <td>이벤트당 평균 1~3회. 주 케이스: 만든 직후 오타·정보 보강(다수), 가격·정원 미세 조정(중), 확정자 발생 후 긴급 일정·장소 변경(소수, 통지 의무 발생).</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ============================================================
+     HISTORY
+     ============================================================ -->
+<section class="doc">
+  <h2>History</h2>
+  <p class="intro">
+    이 spec의 주요 변경 이력. 최신 항목 위.
+  </p>
+  <table class="ref">
+    <thead>
+      <tr>
+        <th style="width: 110px;">날짜</th>
+        <th style="width: 120px;">버전</th>
+        <th>변경 사항</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>2026-05-03</td>
+        <td>v1 (initial)</td>
+        <td>초안 작성. 확정자 0명/≥1명 두 모드 + 일정·장소 변경 사유 다이얼로그 + 정원 감소 검증(확정자 수 ≥ 새 정원이면 인라인 에러) + 가격 인상 시 "신규 신청자만 적용" 안내 + 저장 성공 시 EventDetailPage로 복귀.</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ============================================================
+     LAYOUT
+     ============================================================ -->
+<div class="perspective" id="layout">
+  <div class="perspective__header">
+    <span class="glyph">🧱</span>
+    <h2>Layout</h2>
+    <span class="lede">화면 구조 — 영역, 정렬, 간격 규칙. 색·타이포 무시.</span>
+  </div>
+
+  <section class="doc">
+    <h2>Blueprint &amp; tree</h2>
+    <p class="intro">
+      <code>Scaffold</code> — AppBar(title only, 좌측 정렬) + body(SingleChildScrollView with form sections) + bottom Container(SafeArea + ElevatedButton "저장"). TabBar 없음 — 단일 스크롤 폼.
+      확정자 ≥1명이면 body 최상단에 <strong>잠금 안내 배너</strong>가 추가되며 일정·정원·가격 필드에 lock chip이 붙는다.
+    </p>
+    <div class="layout-grid">
+      <div class="blueprint">
+        <div class="blueprint__region blueprint__region--full"></div>
+
+        <!-- AppBar -->
+        <div class="blueprint__region blueprint__region--shaded" style="top:0;left:0;right:0;height:56px;">
+          <span class="blueprint__region-label">① AppBar — back + '이벤트 수정' (left-aligned)</span>
+        </div>
+
+        <!-- Lock banner (확정자 ≥1명 only) -->
+        <div class="blueprint__region blueprint__region--shaded" style="top:72px;left:16px;right:16px;height:56px;">
+          <span class="blueprint__region-label" style="font-size:9px;">② Lock banner (확정자 ≥1명 only)<br>'확정 참가자 N명 — 일정·장소 변경 시 자동 알림'</span>
+        </div>
+
+        <!-- Form: 기본 정보 -->
+        <div class="blueprint__region" style="top:144px;left:0;right:0;height:140px;">
+          <span class="blueprint__region-label">③ 기본 정보 — 제목 / 설명 / 태그 (자유)</span>
+        </div>
+
+        <!-- Form: 일정 · 장소 -->
+        <div class="blueprint__region blueprint__region--shaded" style="top:300px;left:0;right:0;height:120px;">
+          <span class="blueprint__region-label">④ 일정 · 장소 — 통지 의무 필드<br>변경 시 사유 입력 다이얼로그 trigger</span>
+        </div>
+
+        <!-- Form: 가격 · 정원 -->
+        <div class="blueprint__region" style="top:436px;left:0;right:0;height:120px;">
+          <span class="blueprint__region-label">⑤ 가격 · 정원 — 정원 감소는 확정자 수 검증, 가격 인상은 신규에만 적용 안내</span>
+        </div>
+
+        <!-- Form: 추가 정보 -->
+        <div class="blueprint__region" style="top:572px;left:0;right:0;height:80px;">
+          <span class="blueprint__region-label">⑥ 추가 정보 — 이미지 · 호스트 · 카테고리 (자유)</span>
+        </div>
+
+        <!-- Cancel link -->
+        <div class="blueprint__region" style="top:668px;left:0;right:0;height:48px;border-style:dashed;border-color:rgba(255,80,80,0.5);">
+          <span class="blueprint__region-label" style="color:var(--color-error);">⑦ '이벤트 취소하기' 링크 (별도 destructive flow)</span>
+        </div>
+
+        <!-- Bottom submit -->
+        <div class="blueprint__region blueprint__region--shaded" style="bottom:0;left:0;right:0;height:80px;">
+          <span class="blueprint__region-label">⑧ Bottom submit — SafeArea + ElevatedButton('저장')<br>shadow Offset(0,-4)</span>
+        </div>
+
+        <div class="blueprint__align-marker" style="top:8px;right:8px;">screen-edge pad 16</div>
+      </div>
+
+      <div class="layout-tree"><b>Scaffold</b>
+├─ <b>appBar</b>: <b>AppBar</b>                                  ← ①
+│  ├─ leading: BackButton (auto · onPressed: confirm-if-dirty)
+│  └─ title: Text('이벤트 수정') · centerTitle: false
+├─ <b>body</b>: <code>MinglitAsyncValueWidget&lt;Event&gt;</code>
+│  ├─ loading: <code>MinglitCircularProgressIndicator</code>
+│  ├─ error:   Centered text ('이벤트 로드 실패')
+│  └─ data: <b>SingleChildScrollView</b>
+│     └─ Column [
+│        ├─ if confirmedCount &gt;= 1:                          ← ②
+│        │   <b>_LockBanner</b>(confirmedCount,
+│        │     locked: ['일정', '장소'],
+│        │     constrained: ['정원', '가격 인상'])
+│        ├─ <em>Section "기본 정보"</em>                         ← ③
+│        │  ├─ <b>_TextField</b>(label: '제목', maxLines: 1,
+│        │  │     unlocked: 항상)
+│        │  ├─ <b>_TextField</b>(label: '설명', maxLines: 6,
+│        │  │     unlocked: 항상)
+│        │  └─ <b>_TagsInput</b>(label: '태그', unlocked: 항상)
+│        ├─ <em>Section "일정 · 장소"</em>                       ← ④
+│        │  ├─ <b>_DateTimeField</b>(label: '일정',
+│        │  │     onChange: <em>if confirmed≥1 → showReasonDialog</em>)
+│        │  └─ <b>_LocationField</b>(label: '장소',
+│        │        onChange: <em>if confirmed≥1 → showReasonDialog</em>)
+│        ├─ <em>Section "가격 · 정원"</em>                       ← ⑤
+│        │  ├─ <b>_PriceField</b>(label: '가격',
+│        │  │     hint: '인상 시 신규 신청자만 적용')
+│        │  └─ <b>_CapacityField</b>(label: '정원',
+│        │        validator: <em>newCapacity &gt;= confirmedCount</em>)
+│        ├─ <em>Section "추가 정보"</em>                         ← ⑥
+│        │  ├─ <b>_ImagePicker</b>(unlocked: 항상)
+│        │  ├─ <b>_HostInfoFields</b>(unlocked: 항상)
+│        │  └─ <b>_CategoryDropdown</b>(unlocked: 항상)
+│        └─ <b>_CancelEventLink</b>('이벤트 취소하기')           ← ⑦
+│           · onTap: push EventCancelRoute (별도 flow)
+│     ]
+└─ <b>bottomNavigationBar</b>: <b>Container</b>(shadow -4)      ← ⑧
+   └─ <b>SafeArea</b>
+      └─ <b>ElevatedButton</b>(
+           onPressed: <em>!isDirty || isLoading ? null : _submit</em>,
+           child: isLoading ? '저장 중...' : '저장')</div>
+    </div>
+  </section>
+
+  <section class="doc">
+    <h2>Spacing &amp; alignment rules</h2>
+    <table class="ref">
+      <thead>
+        <tr>
+          <th style="width: 60px;">#</th>
+          <th style="width: 200px;">Region</th>
+          <th style="width: 220px;">Alignment</th>
+          <th>Spacing / tokens</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>①</td><td>AppBar</td><td>title left-aligned · 56px · back btn 좌측</td><td>centerTitle: false · h-pad <code>spacing-screen-edge</code> · bg <code>color-surface</code></td></tr>
+        <tr><td>②</td><td>Lock banner</td><td>full-width inside screen-edge · row(icon + body) crossAxis start</td><td>margin top <code>spacing-medium</code> · margin h <code>spacing-screen-edge</code> · padding <code>spacing-medium</code> all · bg <code>color-primary @ 8%</code> · border 1px <code>color-primary @ 25%</code> · radius <code>radius-card</code></td></tr>
+        <tr><td>③④⑤⑥</td><td>Form section</td><td>section header(좌측 라벨) + 카드 stack 수직 배치</td><td>섹션 헤더 padding: <code>spacing-medium</code> screen-edge / <code>spacing-small</code> bottom · 카드 사이 <code>spacing-small (8)</code> · 섹션 사이 <code>spacing-large (24)</code></td></tr>
+        <tr><td>—</td><td>Form field card</td><td>full-width with screen-edge h-margin · column(label / value / hint)</td><td>padding <code>spacing-medium</code> all · radius <code>radius-card</code> · border 1px <code>color-divider</code> · bg <code>color-background</code> · 잠금 시 opacity 0.7 + bg dim · 변경 감지 시 border <code>color-primary</code> 1.5px</td></tr>
+        <tr><td>—</td><td>Lock chip (필드 우측)</td><td>row trailing · label 같은 줄</td><td>padding 2px 6px · bg <code>color-primary @ 12%</code> · color <code>color-primary</code> · radius <code>radius-small</code> · font-size 10px w600 · gap 3px (icon + text)</td></tr>
+        <tr><td>⑦</td><td>Cancel link</td><td>centered · 단독 한 줄</td><td>margin top <code>spacing-large</code> / margin h <code>spacing-screen-edge</code> · color <code>color-error</code> · font-size 13px · w500 · padding <code>spacing-small</code></td></tr>
+        <tr><td>⑧</td><td>Bottom submit</td><td>SafeArea + Padding(<code>spacing-medium</code>) · button 풀폭</td><td>Container shadow Offset(0,-4) blur 10 alpha <code>tintFill</code> · button height 48 · radius <code>radius-button</code> · isDirty || isLoading 아닐 때 <code>color-divider</code> bg + secondary text (disabled tone)</td></tr>
+        <tr><td>—</td><td>Reason dialog</td><td>centered overlay · max-width 320 · column gap <code>spacing-medium</code></td><td>overlay bg rgba(0,0,0,0.45) · dialog padding <code>spacing-large</code> · radius <code>radius-card</code> · before/after row bg <code>color-surface</code> radius <code>radius-small</code> padding <code>spacing-small</code></td></tr>
+      </tbody>
+    </table>
+  </section>
+</div>
+
+<!-- ============================================================
+     STATES
+     ============================================================ -->
+<div class="perspective" id="states">
+  <div class="perspective__header">
+    <span class="glyph">🎨</span>
+    <h2>States</h2>
+    <span class="lede">시각 변형 5종. baseline = 확정자 0명, 나머지는 추가 조건 또는 사용자 액션에 따른 분기.</span>
+  </div>
+
+  <section class="doc">
+    <p class="intro">
+      <strong>State 식별 기준</strong>:
+      (1) 확정 참가자 수 — 0명이면 모든 필드 자유 수정, ≥1명이면 잠금 배너 + 일정·장소·정원 잠금 정책 발동.
+      (2) 사용자 액션 — 일정/장소 값 변경 시 사유 입력 다이얼로그 등장, 정원 감소 시 확정자 수 미달이면 인라인 에러, 저장 시 진행/성공/실패.
+      이 화면은 항상 <em>기존 이벤트 수정</em> 흐름이며 신규 생성 모드는 없다(<a href="/specs/event_create_page.html">EventCreatePage</a>가 별도 담당).
+    </p>
+
+    <!-- =================================================
+         STATE 1 — 확정자 0명 (baseline · 자유 수정)
+         ================================================= -->
+    <table class="ref state-mini">
+      <thead>
+        <tr><th colspan="3"><strong>State 1 · 확정자 0명 (baseline)</strong> 🎯 <span class="tag tag--mute">default</span> · <small>모든 필드 자유 수정</small></th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td rowspan="6" class="state-mini__mock"><div class="viewport">
+            <div class="ee-appbar">
+              <div class="ee-appbar__back">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+              </div>
+              <div class="ee-appbar__title">이벤트 수정</div>
+            </div>
+            <div class="ee-body">
+              <div class="ee-section-header">기본 정보</div>
+              <div class="ee-field">
+                <div class="ee-field__label">제목</div>
+                <div class="ee-field__value">금요일 와인 클래스</div>
+              </div>
+              <div class="ee-field">
+                <div class="ee-field__label">설명</div>
+                <div class="ee-field__value" style="font-size:13px;color:var(--color-text-secondary);line-height:1.4;">매주 금요일 저녁, 강남 와인바에서 진행되는 소셜 와인 클래스입니다...</div>
+              </div>
+
+              <div class="ee-section-header">일정 · 장소</div>
+              <div class="ee-field">
+                <div class="ee-field__label">📅 일정</div>
+                <div class="ee-field__value">2026.05.15 (금) 오후 7:30~9:30</div>
+              </div>
+              <div class="ee-field">
+                <div class="ee-field__label">📍 장소</div>
+                <div class="ee-field__value">강남 와인바 · 서울 강남구 ...</div>
+              </div>
+
+              <div class="ee-section-header">가격 · 정원</div>
+              <div class="ee-field">
+                <div class="ee-field__label">가격</div>
+                <div class="ee-field__value">35,000원</div>
+              </div>
+              <div class="ee-field">
+                <div class="ee-field__label">정원</div>
+                <div class="ee-field__value">20명</div>
+              </div>
+
+              <div class="ee-cancel-link">이벤트 취소하기</div>
+            </div>
+            <div class="ee-submitbar">
+              <div class="ee-submit ee-submit--disabled">저장</div>
+            </div>
+          </div></td>
+          <td class="state-mini__aspect">조건</td>
+          <td>이벤트 데이터 로드 완료 · 확정 참가자(approved 또는 paid) <strong>0명</strong> · 변경된 필드 없음.</td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">사용자 액션</td>
+          <td>
+            · <strong>모든 필드 자유 수정</strong> — 일정·장소·정원·가격 모두 잠금 배너 / lock chip 없이 직접 편집 가능<br>
+            · <strong>저장</strong> 버튼은 dirty(변경 감지) 전까지 disabled, 1개라도 변경되면 활성<br>
+            · <strong>저장 탭</strong> → API 성공 후 EventDetailPage로 복귀 + "이벤트 정보가 저장되었습니다" snackbar<br>
+            · <strong>뒤로가기</strong> → dirty 없으면 즉시 닫힘
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">에지케이스</td><td>· 이벤트 로드 실패 → body 자리에 에러 텍스트 + retry 버튼<br>· 동시에 다른 운영자가 같은 이벤트 수정 → 저장 시 충돌 감지 → 별도 안내 (재로드 권장)</td></tr>
+        <tr>
+          <td class="state-mini__aspect">컴포넌트</td>
+          <td>
+            <code>Scaffold</code> · <code>AppBar</code>(left title) · <code>SingleChildScrollView</code> · <code>MinglitAsyncValueWidget&lt;Event&gt;</code> · <code>_TextField</code> · <code>_DateTimeField</code> · <code>_LocationField</code> · <code>_PriceField</code> · <code>_CapacityField</code> · <code>_ImagePicker</code> · <code>_CancelEventLink</code> · 하단 <code>ElevatedButton</code>
+          </td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">토큰</td>
+          <td>
+            <code>color-primary</code>(partner #6c3ce1 — 저장 버튼 / 변경 감지 border) · <code>color-text-primary</code>(field value) · <code>color-text-secondary</code>(label / hint) · <code>color-divider</code>(field border) · <code>color-surface</code>(scaffold) · <code>color-background</code>(field card bg) · <code>color-error</code>(취소 링크) · <code>radius-card (16)</code> · <code>radius-button (12)</code> · <code>spacing-screen-edge (16)</code> · <code>spacing-medium (16)</code> · <code>spacing-small (8)</code> · typography 11px w700(label) / 15px(value) / 11px(hint)
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">노트</td><td>📝 가장 깔끔한 상태 — 신규 이벤트 직후 또는 신청자가 한 명도 없는 시점. 운영자는 이때 가능한 한 모든 정보를 마무리하는 게 권장된다.</td></tr>
+      </tbody>
+    </table>
+
+    <!-- =================================================
+         STATE 2 — 확정자 ≥1명 (잠금 배너 + lock chip)
+         ================================================= -->
+    <table class="ref state-mini">
+      <thead>
+        <tr><th colspan="3"><strong>State 2 · 확정자 ≥1명</strong> <span class="tag tag--mute">restricted</span> · <small>잠금 배너 + 일정·장소·정원·가격에 lock chip / 검증</small></th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td rowspan="6" class="state-mini__mock"><div class="viewport">
+            <div class="ee-appbar">
+              <div class="ee-appbar__back">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+              </div>
+              <div class="ee-appbar__title">이벤트 수정</div>
+            </div>
+            <div class="ee-body">
+              <div class="ee-lockbanner">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+                <div class="ee-lockbanner__body">
+                  <div class="ee-lockbanner__title">확정 참가자 8명</div>
+                  <div class="ee-lockbanner__sub">일정 / 장소 변경 시 자동 알림 발송. 정원은 확정자 수 이하로 줄일 수 없음. 가격 인상은 신규 신청자에게만 적용됨.</div>
+                </div>
+              </div>
+
+              <div class="ee-section-header">기본 정보</div>
+              <div class="ee-field">
+                <div class="ee-field__label">제목</div>
+                <div class="ee-field__value">금요일 와인 클래스</div>
+              </div>
+
+              <div class="ee-section-header">일정 · 장소</div>
+              <div class="ee-field">
+                <div class="ee-field__label">
+                  📅 일정
+                  <div class="ee-lockchip">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+                    변경 시 알림
+                  </div>
+                </div>
+                <div class="ee-field__value">2026.05.15 (금) 오후 7:30~9:30</div>
+                <div class="ee-field__hint ee-field__hint--warn">⚠️ 변경 시 사유 입력 + 8명에게 자동 알림</div>
+              </div>
+              <div class="ee-field">
+                <div class="ee-field__label">
+                  📍 장소
+                  <div class="ee-lockchip">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+                    변경 시 알림
+                  </div>
+                </div>
+                <div class="ee-field__value">강남 와인바 · 서울 강남구 ...</div>
+                <div class="ee-field__hint ee-field__hint--warn">⚠️ 변경 시 사유 입력 + 8명에게 자동 알림</div>
+              </div>
+
+              <div class="ee-section-header">가격 · 정원</div>
+              <div class="ee-field">
+                <div class="ee-field__label">가격</div>
+                <div class="ee-field__value">35,000원</div>
+                <div class="ee-field__hint">ℹ️ 인상 시 신규 신청자에게만 적용됨 (확정자 8명은 원래 가격 유지)</div>
+              </div>
+              <div class="ee-field">
+                <div class="ee-field__label">
+                  정원
+                  <div class="ee-lockchip">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+                    8명 이하 불가
+                  </div>
+                </div>
+                <div class="ee-field__value">20명</div>
+                <div class="ee-field__hint">ℹ️ 확정자 8명 이하로는 줄일 수 없음</div>
+              </div>
+            </div>
+            <div class="ee-submitbar">
+              <div class="ee-submit ee-submit--disabled">저장</div>
+            </div>
+          </div></td>
+          <td class="state-mini__aspect">조건</td>
+          <td>이벤트 데이터 로드 완료 · 확정 참가자(approved 또는 paid) <strong>≥1명</strong> · 아직 변경된 필드 없음.</td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">사용자 액션</td>
+          <td>
+            · <strong>제목 / 설명 / 태그 / 이미지 / 호스트 / 카테고리 수정</strong> → 자유 (잠금 표시 없음)<br>
+            · <strong>일정 또는 장소 변경 시도</strong> → State 3 (사유 입력 다이얼로그)로 이동<br>
+            · <strong>정원을 확정자 수 이하로 변경</strong> → State 4 (인라인 에러)<br>
+            · <strong>가격 인상</strong> → 자유 (단 hint 텍스트로 "신규 신청자만 적용" 안내)<br>
+            · <strong>저장</strong> → State 5 (성공 / 실패 처리)
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">에지케이스</td><td>· 잠금 배너 텍스트는 확정자 수에 따라 동적 ("확정 참가자 N명") · maxLines 2까지 줄바꿈<br>· lock chip은 라벨이 길어지면 라벨 ellipsis 후 chip은 그대로 우측 노출<br>· 이벤트 시작 24시간 전부터는 일정 변경 자체 차단 (banner 톤이 빨강으로 강조 — 별도 변형으로 추후 spec)</td></tr>
+        <tr>
+          <td class="state-mini__aspect">컴포넌트</td>
+          <td>
+            State 1 + <code>_LockBanner</code>(confirmedCount, locked, constrained) · <code>_LockChip</code>(label · variant: <em>'변경 시 알림' / 'N명 이하 불가'</em>) · <code>_FieldHint</code>(variant: <em>warn / info / error</em>)
+          </td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">토큰</td>
+          <td>
+            추가: <code>color-primary @ 8%</code>(banner bg) / <code>@ 25%</code>(banner border) / <code>@ 12%</code>(lock chip bg) · <code>radius-small (8)</code>(lock chip / hint pill) · 11px w500(hint warn) / 11px(hint info) · 10px w600(lock chip text)
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">노트</td><td>🔒 핵심 변형. 잠금 배너 + lock chip + hint 텍스트 3중으로 잠금 정책을 명시 — 운영자가 어떤 필드가 왜 제약되는지 읽지 않고도 알 수 있어야 함.</td></tr>
+      </tbody>
+    </table>
+
+    <!-- =================================================
+         STATE 3 — 일정/장소 변경 사유 입력 다이얼로그
+         ================================================= -->
+    <table class="ref state-mini">
+      <thead>
+        <tr><th colspan="3"><strong>State 3 · 변경 사유 입력 다이얼로그</strong> <span class="tag tag--mute">modal</span> · <small>일정 또는 장소 값 변경 직후 자동 등장</small></th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td rowspan="6" class="state-mini__mock"><div class="viewport" style="position: relative;">
+            <div class="ee-appbar">
+              <div class="ee-appbar__back">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+              </div>
+              <div class="ee-appbar__title">이벤트 수정</div>
+            </div>
+            <div class="ee-body" style="filter: blur(0.6px);">
+              <div class="ee-section-header">일정 · 장소</div>
+              <div class="ee-field ee-field--changed">
+                <div class="ee-field__label">📍 장소</div>
+                <div class="ee-field__value">신촌 와인바 · 서울 서대문구 ...</div>
+              </div>
+            </div>
+            <div class="ee-dialog-overlay">
+              <div class="ee-dialog">
+                <div class="ee-dialog__title">장소를 변경합니까?</div>
+                <div class="ee-dialog__before-after">
+                  <div class="ee-dialog__before">기존: 강남 와인바 · 서울 강남구 ...</div>
+                  <div class="ee-dialog__after">변경: 신촌 와인바 · 서울 서대문구 ...</div>
+                </div>
+                <div class="ee-dialog__textarea">변경 사유 (예: 원래 장소 폐업으로 인한 부득이한 이전)</div>
+                <div class="ee-dialog__notice">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+                  저장하면 확정 참가자 8명에게 변경 내용 + 사유가 자동 알림(앱 푸시 + SMS)으로 발송됩니다.
+                </div>
+                <div class="ee-dialog__actions">
+                  <div class="ee-dialog__btn ee-dialog__btn--ghost">취소</div>
+                  <div class="ee-dialog__btn ee-dialog__btn--primary">변경 확정</div>
+                </div>
+              </div>
+            </div>
+          </div></td>
+          <td class="state-mini__aspect">조건</td>
+          <td>State 2(확정자 ≥1명) · 사용자가 일정 또는 장소 필드를 새 값으로 바꾼 직후. 다이얼로그가 즉시 등장하며 다른 영역은 dim + blur 처리.</td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">사용자 액션</td>
+          <td>
+            · <strong>변경 사유 입력</strong> → 다이얼로그 textarea에 1~200자. 비어있으면 "변경 확정" disabled<br>
+            · <strong>변경 확정 탭</strong> → 다이얼로그 닫힘 + 필드는 변경 감지(border <code>color-primary</code>) 상태 유지 + 사유는 폼 state에 보관 (저장 시 함께 전송)<br>
+            · <strong>취소 탭</strong> → 다이얼로그 닫힘 + 필드 값 원래대로 롤백 + 변경 감지 해제<br>
+            · <strong>오버레이 외곽 탭</strong> → "취소"와 동일 동작
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">에지케이스</td><td>· 일정과 장소를 동시에 바꾸려는 경우 → 두 다이얼로그를 동시에 띄우지 않음. 첫 변경 후 닫힌 뒤 두 번째 필드 변경 시 두 번째 다이얼로그 등장 (순차 처리)<br>· 변경 후 다시 원래 값으로 되돌리면 → 다이얼로그 안 뜨고 변경 감지 해제<br>· 사유 입력 도중 키보드 dismiss 시 textarea 포커스만 해제 — 다이얼로그는 유지</td></tr>
+        <tr>
+          <td class="state-mini__aspect">컴포넌트</td>
+          <td>
+            <code>showDialog</code> · <code>AlertDialog</code> 또는 <code>Dialog</code> custom child · <code>_BeforeAfterRow</code> · <code>TextField</code>(maxLines: 3, maxLength: 200) · <code>_NoticeBanner</code>(앱 푸시 + SMS 안내) · 액션 row(취소 · 변경 확정)
+          </td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">토큰</td>
+          <td>
+            overlay bg <code>rgba(0,0,0,0.45)</code> · dialog bg <code>color-background</code> · radius <code>radius-card</code> · padding <code>spacing-large (24)</code> · before/after pill bg <code>color-surface</code> · 변경된 값 텍스트 <code>color-primary</code> w600 · notice banner bg <code>color-primary @ 8%</code> · primary action <code>color-primary</code>
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">노트</td><td>📣 통지 의무를 시각적으로 강제하는 핵심 다이얼로그. before/after를 명시해 운영자가 자기가 무엇을 바꿨는지 한 번 더 확인하도록 유도. 사유 텍스트는 알림 본문에 그대로 인용된다.</td></tr>
+      </tbody>
+    </table>
+
+    <!-- =================================================
+         STATE 4 — 정원 감소 시 확정자 수 미달 (인라인 에러)
+         ================================================= -->
+    <table class="ref state-mini">
+      <thead>
+        <tr><th colspan="3"><strong>State 4 · 정원 감소 검증 실패</strong> <span class="tag tag--mute">inline-error</span> · <small>정원을 확정자 수 이하로 입력 시</small></th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td rowspan="6" class="state-mini__mock"><div class="viewport">
+            <div class="ee-appbar">
+              <div class="ee-appbar__back">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+              </div>
+              <div class="ee-appbar__title">이벤트 수정</div>
+            </div>
+            <div class="ee-body">
+              <div class="ee-section-header">가격 · 정원</div>
+              <div class="ee-field">
+                <div class="ee-field__label">가격</div>
+                <div class="ee-field__value">35,000원</div>
+              </div>
+              <div class="ee-field ee-field--changed" style="border-color: var(--color-error);">
+                <div class="ee-field__label" style="color: var(--color-error);">정원</div>
+                <div class="ee-field__value" style="color: var(--color-error); font-weight: 600;">5명</div>
+                <div class="ee-field__hint ee-field__hint--error">❌ 확정 참가자 8명 이하로는 정원을 줄일 수 없습니다.</div>
+              </div>
+            </div>
+            <div class="ee-submitbar">
+              <div class="ee-submit ee-submit--disabled">저장</div>
+            </div>
+          </div></td>
+          <td class="state-mini__aspect">조건</td>
+          <td>State 2(확정자 ≥1명) · 사용자가 정원을 confirmedCount(예: 8) 이하 값으로 입력. 검증은 입력값 onChange 시 즉시 실행 (debounce 200ms).</td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">사용자 액션</td>
+          <td>
+            · <strong>정원을 confirmedCount 이상 값으로 정정</strong> → 인라인 에러 사라짐 + 변경 감지 색만 유지 + 저장 가능<br>
+            · <strong>정원을 원래 값(원본)으로 되돌림</strong> → 변경 감지 해제 (저장 disabled로 복귀)<br>
+            · <strong>저장 시도</strong> → 인라인 에러 있는 동안 저장 버튼은 disabled — 탭해도 동작 X<br>
+            · <strong>다른 필드 수정</strong> → 정원 검증과 무관하게 가능 (단, 저장은 모든 필드가 valid해야 활성)
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">에지케이스</td><td>· 확정자 수가 도중에 바뀌어도 (다른 운영자 승인 동시 진행) 폼 state는 진입 시점 confirmedCount 기준 — 저장 시 서버에서 재검증 + 충돌 시 안내<br>· 정원을 0으로 비우면 → "정원을 입력해주세요" 다른 톤 에러<br>· 숫자 외 문자 입력은 키보드 number-only로 차단</td></tr>
+        <tr>
+          <td class="state-mini__aspect">컴포넌트</td>
+          <td>
+            <code>_CapacityField</code>(confirmedCount, validator) · <code>_FieldHint</code>(variant: error) · field card border 색이 <code>color-error</code>로 전환 · 라벨 / 값 색도 동일 톤
+          </td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">토큰</td>
+          <td>
+            field error border <code>color-error</code> 1.5px · field error bg 그대로(<code>color-background</code>) · 라벨/값 <code>color-error</code> · hint <code>color-error</code> w500 11px · 저장 버튼은 <code>color-divider</code> bg + <code>color-text-secondary</code> 텍스트(disabled tone)
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">노트</td><td>⚠️ 클라이언트 검증은 빠른 피드백용. 서버 검증이 단일 진실 — race condition 가능성 때문에 저장 응답에서도 같은 검증을 반드시 수행하고 실패 시 snackbar로 안내한다.</td></tr>
+      </tbody>
+    </table>
+
+    <!-- =================================================
+         STATE 5 — 저장 진행 / 성공 (snackbar + 복귀)
+         ================================================= -->
+    <table class="ref state-mini">
+      <thead>
+        <tr><th colspan="3"><strong>State 5 · 저장 진행 → 성공</strong> <span class="tag tag--mute">submit</span> · <small>저장 버튼 탭 후 EventDetailPage 복귀까지</small></th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td rowspan="6" class="state-mini__mock"><div class="viewport">
+            <div class="ee-appbar">
+              <div class="ee-appbar__back">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+              </div>
+              <div class="ee-appbar__title">이벤트 수정</div>
+            </div>
+            <div class="ee-body">
+              <div class="ee-section-header">기본 정보</div>
+              <div class="ee-field ee-field--changed">
+                <div class="ee-field__label">제목</div>
+                <div class="ee-field__value">금요일 와인 클래스 (시즌 2)</div>
+              </div>
+            </div>
+            <div class="snackbar snackbar--success">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg>
+              <span>이벤트 정보가 저장되었습니다.<br><span style="font-size:11px;opacity:0.85;">확정 참가자 8명에게 변경 알림이 발송되었습니다.</span></span>
+            </div>
+            <div class="ee-submitbar">
+              <div class="ee-submit ee-submit--loading">
+                <div class="btn-spinner"></div>
+                저장 중...
+              </div>
+            </div>
+          </div></td>
+          <td class="state-mini__aspect">조건</td>
+          <td>저장 버튼 탭 → API 호출 진행. 일정/장소가 변경됐으면 사유 + 알림 발송 트리거 함께. 성공 응답 후 EventDetailPage로 복귀하면서 success snackbar 노출.</td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">사용자 액션</td>
+          <td>
+            · <strong>로딩 중</strong> → 저장 버튼이 spinner + "저장 중..." 으로 전환, 다른 필드는 read-only로 일시 잠김 (포커스 빠짐)<br>
+            · <strong>성공</strong> → 본 화면 자동 close + 부모(EventDetailPage)의 데이터 invalidate + success snackbar 3.5초 노출<br>
+            · &nbsp;&nbsp;일정/장소 변경 포함이면 snackbar 본문에 "확정 참가자 N명에게 알림 발송" 부가 텍스트 추가<br>
+            · <strong>실패</strong> → 화면 유지 + error snackbar (서버 메시지 그대로 또는 "저장에 실패했어요. 잠시 후 다시 시도해주세요.")<br>
+            · <strong>네트워크 끊김</strong> → 동일하게 실패 snackbar + 폼 state 유지 (재시도 가능)
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">에지케이스</td><td>· 저장 도중 뒤로가기 → 막힘 (loading 상태에선 back 무시 + 가벼운 진동 / 흔들림 hint)<br>· 서버 검증 실패(예: 정원 race condition) → snackbar에 사유 명시 + 폼은 유지 + 해당 필드에 인라인 에러 표시<br>· 알림 발송 자체는 서버 비동기 — 응답엔 "발송 큐에 적재됨"까지만 확인. snackbar 메시지는 그 가정 위에서 표현</td></tr>
+        <tr>
+          <td class="state-mini__aspect">컴포넌트</td>
+          <td>
+            <code>ElevatedButton</code>(loading variant) · <code>btn-spinner</code> · <code>SnackBar</code>(<code>showMinglitSuccess</code> / <code>showMinglitError</code>) · <code>ref.invalidate(eventDetailProvider(eventId))</code> · <code>Navigator.pop()</code>
+          </td>
+        </tr>
+        <tr>
+          <td class="state-mini__aspect">토큰</td>
+          <td>
+            success snackbar bg <code>#14532d</code> · check icon <code>#86efac</code> · 폰트 13px / 11px(부가 텍스트, opacity 0.85) · 위치 bottom 96 (submit bar 위) · radius <code>radius-small</code> · padding 12 / 16
+          </td>
+        </tr>
+        <tr><td class="state-mini__aspect">노트</td><td>✅ 사유 입력이 있었던 경우 snackbar 텍스트가 길어진다 → maxLines 2까지 허용. 알림 발송 결과 자체(성공/실패 N명)는 별도 운영자 활동 로그에서 확인 가능 (본 화면 책임 아님).</td></tr>
+      </tbody>
+    </table>
+  </section>
+</div>
+
+<!-- ============================================================
+     GLOBAL BEHAVIOR
+     ============================================================ -->
+<div class="perspective" id="behavior">
+  <div class="perspective__header">
+    <span class="glyph">🔄</span>
+    <h2>Global Behavior</h2>
+    <span class="lede">모든 state에 동일하게 적용되는 동작 — 잠금 매트릭스, 변경 감지, 알림 정책, 변경 이력.</span>
+  </div>
+
+  <section class="doc">
+    <h2>잠금 매트릭스 (필드별 정책)</h2>
+    <p class="intro">
+      이 매트릭스가 단일 진실. UI / 서버 검증 / 이메일·SMS 알림 모두 같은 정책을 참조.
+    </p>
+    <table class="ref">
+      <thead>
+        <tr>
+          <th style="width: 180px;">필드</th>
+          <th style="width: 180px;">확정자 0명</th>
+          <th>확정자 ≥1명</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>제목</td><td>자유</td><td>자유</td></tr>
+        <tr><td>설명 / 안내문</td><td>자유</td><td>자유</td></tr>
+        <tr><td>이미지 / 태그 / 카테고리</td><td>자유</td><td>자유</td></tr>
+        <tr><td>호스트 정보</td><td>자유</td><td>자유</td></tr>
+        <tr><td>가격 (인하)</td><td>자유</td><td>자유</td></tr>
+        <tr><td>가격 (인상)</td><td>자유</td><td>자유 — DB 레벨에서 신규 신청자만 새 가격 적용 / 확정자는 원래 가격 보호. UI에 hint 안내.</td></tr>
+        <tr><td>정원 (증가)</td><td>자유</td><td>자유</td></tr>
+        <tr><td>정원 (감소)</td><td>자유</td><td><strong>새 정원 ≥ 확정자 수</strong>여야 허용. 미달 시 인라인 에러 + 저장 disabled (State 4).</td></tr>
+        <tr><td><strong>일정 (날짜/시간)</strong></td><td>자유</td><td><strong>변경 사유 입력 다이얼로그 + 자동 알림</strong> (State 3). 사유는 알림 본문에 인용.</td></tr>
+        <tr><td><strong>장소</strong></td><td>자유</td><td>일정과 동일 — 사유 다이얼로그 + 알림.</td></tr>
+        <tr><td>이벤트 취소</td><td>자유 (소프트 삭제)</td><td><strong>별도 destructive flow</strong> — 본 spec 범위 밖. 일괄 환불 + 취소 안내 알림 발송.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>변경 감지 (dirty state)</h2>
+    <ul>
+      <li>각 필드 컨트롤러는 <em>원본 값</em>을 보관. 현재 값이 원본과 다르면 <strong>field card border가 <code>color-primary</code> 1.5px</strong>로 강조.</li>
+      <li>필드 1개 이상이 dirty이고 모든 검증이 valid이면 <strong>저장 버튼 활성</strong>.</li>
+      <li>뒤로가기 / 외곽 탭 시 dirty이면 "변경사항을 버리시겠습니까?" 확인 다이얼로그 (Material AlertDialog · 취소 / 버리기).</li>
+      <li>저장 성공 후 폼 state는 즉시 폐기되며 EventDetailPage로 복귀 — 다음 진입 시 서버 fresh fetch.</li>
+    </ul>
+  </section>
+
+  <section class="doc">
+    <h2>알림 발송 정책</h2>
+    <ul>
+      <li>일정 또는 장소 변경 + 확정자 ≥1명 → 저장 시 <strong>앱 푸시 + SMS 동시 발송</strong>. 본문은 <em>"[이벤트명] 변경 안내: {필드}이(가) {기존} → {변경}으로 변경되었습니다. 사유: {사유}"</em>.</li>
+      <li>발송은 서버 비동기 큐 — UI는 "발송 큐에 적재됨" 시점까지만 확인. 실제 전송 결과는 운영자 활동 로그에서 사후 확인.</li>
+      <li>같은 이벤트가 짧은 시간 내(예: 30분) 여러 번 변경되면 알림은 <strong>최신 변경 1건으로 합산</strong> — 운영자가 사유를 묶어서 입력하도록 권장.</li>
+      <li>알림 비용은 운영자 부담 — 변경 사유 다이얼로그에 "발송됨" 안내로 비용 발생을 인지하도록 설계.</li>
+    </ul>
+  </section>
+
+  <section class="doc">
+    <h2>변경 이력 로그</h2>
+    <ul>
+      <li>저장 성공 시 <code>event_change_log</code> 테이블에 <em>변경 필드 / 기존 값 / 새 값 / 사유 / 운영자 ID / 시각</em>을 기록.</li>
+      <li>이력은 운영자 측 별도 화면(향후 spec)에서 조회 가능. 분쟁 시 단일 진실 자료.</li>
+      <li>본 화면은 <em>이력 작성</em> 책임만 — 조회 / 노출은 다른 화면 책임.</li>
+    </ul>
+  </section>
+</div>
+
+<!-- ============================================================
+     REFERENCE
+     ============================================================ -->
+<div class="perspective" id="reference">
+  <div class="perspective__header">
+    <span class="glyph">🔗</span>
+    <h2>Reference</h2>
+    <span class="lede">관련 라우트 · 화면 · 구현 소스.</span>
+  </div>
+
+  <section class="doc">
+    <h2>Implementation source</h2>
+    <table class="ref">
+      <tbody>
+        <tr><td style="width: 160px;"><strong>Route</strong></td><td><code>EventEditRoute</code></td></tr>
+        <tr><td><strong>Path</strong></td><td><code>/more/parties/:partyId/events/:eventId/edit</code></td></tr>
+        <tr><td><strong>Widget class</strong></td><td><code>EventEditPage</code> (+ <code>_LockBanner</code> · <code>_LockChip</code> · <code>_DateTimeField</code> · <code>_LocationField</code> · <code>_CapacityField</code> · <code>_PriceField</code> · <code>_TextField</code> internal widgets)</td></tr>
+        <tr><td><strong>App</strong></td><td><code>app_partner</code></td></tr>
+        <tr><td><strong>Source (예상)</strong></td><td><code>apps/app_partner/lib/src/features/event/edit/event_edit_page.dart</code> + <code>apps/app_partner/lib/src/features/event/edit/widgets/*</code></td></tr>
+        <tr><td><strong>Provider</strong></td><td><code>eventDetailProvider(eventId)</code> 로 fresh fetch · 저장은 <code>eventEditCoordinator(eventId)</code> 통해 mutate + invalidate</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section class="doc">
+    <h2>Related screens</h2>
+    <table class="ref">
+      <thead><tr><th style="width: 220px;">Spec</th><th>관계</th></tr></thead>
+      <tbody>
+        <tr><td><a href="/specs/partner_event_detail_page.html"><code>EventDetailPage</code></a></td><td>Parent. Hero "일정" 영역 탭 → 본 화면 push. 저장 성공 시 본 화면 close + parent invalidate.</td></tr>
+        <tr><td><a href="/specs/event_create_page.html"><code>EventCreatePage</code></a></td><td>Sibling. 신규 회차 생성 흐름 — 본 화면(수정)과 별도. 잠금 정책 / 통지 의무 없음.</td></tr>
+        <tr><td><a href="/specs/ticket_edit_page.html"><code>TicketEditPage</code></a></td><td>Sibling. 동일 이벤트의 입장권 수정. 본 화면이 다루지 않는 티켓 도메인 — 별도 화면.</td></tr>
+        <tr><td><em>EventCancelRoute (예정)</em></td><td>Child of "이벤트 취소하기" 링크. 별도 destructive flow — 일괄 환불 + 취소 알림. 본 spec 범위 밖.</td></tr>
+        <tr><td><em>event_change_log (DB 테이블)</em></td><td>저장 시 변경 필드 / 사유 / 운영자 ID 기록. 분쟁 시 단일 진실.</td></tr>
+      </tbody>
+    </table>
+  </section>
+</div>
+
+</div>
+</body>
+</html>

--- a/apps/mds/docs/public/specs/partner_event_detail_page.html
+++ b/apps/mds/docs/public/specs/partner_event_detail_page.html
@@ -17,7 +17,7 @@ body.dark-mode .viewport {
   --color-primary: var(--color-partner-dark-primary); /* #9b7bec */
 }
 
-/* --- AppBar (partner — left-aligned title + bottom TabBar) --- */
+/* --- AppBar (partner — left-aligned title only — TabBar 폐기) --- */
 .ped-appbar {
   height: 56px;
   display: flex;
@@ -39,39 +39,10 @@ body.dark-mode .viewport {
   color: var(--color-text-primary);
 }
 
-/* --- TabBar (2 equal-flex tabs, primary underline) --- */
-.ped-tabbar {
-  height: 48px;
-  display: flex;
-  background: var(--color-background);
-  border-bottom: 1px solid var(--color-divider);
-}
-.ped-tab {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: var(--typography-font-size-body);
-  font-weight: 500;
-  color: var(--color-text-secondary);
-  position: relative;
-}
-.ped-tab--active {
-  color: var(--color-primary);
-  font-weight: 700;
-}
-.ped-tab--active::after {
-  content: "";
-  position: absolute;
-  left: 0; right: 0; bottom: 0;
-  height: 2px;
-  background: var(--color-primary);
-}
-
-/* --- Body container --- */
+/* --- Body container (단일 스크롤 — TabBar 폐기) --- */
 .ped-body {
   position: absolute;
-  top: 104px;          /* 56 appbar + 48 tabbar */
+  top: 56px;           /* AppBar only — TabBar 제거됨 */
   left: 0; right: 0; bottom: 0;
   overflow-y: auto;
   scrollbar-width: none;
@@ -80,24 +51,269 @@ body.dark-mode .viewport {
 }
 .ped-body::-webkit-scrollbar { display: none; }
 
-/* --- Event title block (Tab 1, top of MinglitContentLayout) --- */
+/* --- Title row: 이벤트 title 단독 (정보 수정 링크는 분리) --- */
+.ped-title-row {
+  display: flex;
+  align-items: baseline;
+  padding: 0 var(--spacing-screen-edge);
+  gap: var(--spacing-medium);
+  margin-top: var(--spacing-small);
+}
 .ped-title {
-  padding: var(--spacing-medium) var(--spacing-screen-edge) 0;
-  font-size: 22px;          /* headlineSmall */
-  font-weight: 700;
-  color: var(--color-primary);
+  flex: 1;
+  font-size: 20px;          /* titleLarge */
+  font-weight: 600;
+  color: var(--color-text-primary);
   line-height: 1.35;
 }
+/* 정보 수정 link row — chip line ↔ Hero 카드 사이, 우측 정렬 */
+.ped-edit-row {
+  display: flex;
+  justify-content: flex-end;
+  padding: var(--spacing-small) var(--spacing-screen-edge) 0;
+}
 
-/* --- Detail info card (5 DetailRow + 4 dividers) --- */
+/* 취소 안내 banner — title 밑, Hero 카드 위. warning tint */
+.ped-cancel-notice {
+  margin: var(--spacing-small) var(--spacing-screen-edge) 0;
+  padding: var(--spacing-small) var(--spacing-medium);
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: var(--radius-small);
+  font-size: 12px;
+  color: var(--color-text-primary);
+  line-height: 1.5;
+  display: flex;
+  gap: var(--spacing-xsmall);
+  align-items: flex-start;
+}
+.ped-cancel-notice svg {
+  width: 14px; height: 14px;
+  color: var(--color-error);
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+/* 완료 축하 banner — title 밑, Hero 카드 위. success tint + 인원수 highlight */
+.ped-celebrate-banner {
+  margin: var(--spacing-small) var(--spacing-screen-edge) 0;
+  padding: var(--spacing-small) var(--spacing-medium);
+  background: rgba(34, 197, 94, 0.1);
+  border-radius: var(--radius-small);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xsmall);
+}
+.ped-celebrate-banner__count {
+  color: #15803d;
+  font-weight: 700;
+}
+
+/* 완료 통계 카드 — 객단가 (전체 + 그룹별) */
+.ped-stats-card {
+  margin: 0 var(--spacing-screen-edge) var(--spacing-medium);
+  padding: var(--spacing-medium);
+  background: var(--color-surface);
+  border-radius: var(--radius-card);
+  display: flex; flex-direction: column;
+  gap: var(--spacing-small);
+}
+.ped-stats-row {
+  display: flex; align-items: baseline;
+  gap: var(--spacing-xsmall);
+}
+.ped-stats-row__label {
+  flex: 1;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+.ped-stats-row__value {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+.ped-stats-row__sub {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  margin-left: 2px;
+}
+.ped-stats-card__divider {
+  height: 1px;
+  background: var(--color-divider);
+  margin: var(--spacing-xsmall) 0;
+}
+
+/* 신청 트렌드 placeholder card — bar chart 시안 */
+.ped-trend-card {
+  margin: 0 var(--spacing-screen-edge) var(--spacing-medium);
+  padding: var(--spacing-medium);
+  background: var(--color-surface);
+  border-radius: var(--radius-card);
+}
+.ped-trend-chart {
+  height: 80px;
+  display: flex; align-items: flex-end;
+  gap: 3px;
+  padding-top: var(--spacing-small);
+}
+.ped-trend-chart__bar {
+  flex: 1;
+  background: var(--color-primary);
+  border-radius: 1px 1px 0 0;
+  opacity: 0.85;
+  position: relative;
+}
+.ped-trend-chart__bar--peak { opacity: 1; }
+/* 환불한 사람 — 그래프 위쪽에 회색 fill 오버레이 (filled type, neutral gray) */
+.ped-trend-chart__bar-refund {
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  background: var(--color-text-secondary);
+  opacity: 0.6;
+  border-radius: 1px 1px 0 0;
+}
+.ped-trend__legend {
+  display: flex; justify-content: space-between;
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  margin-top: var(--spacing-xsmall);
+}
+
+/* --- 메타 chip line — title 아래 (메타 강조: 모집/D-12/공개) --- */
+.ped-meta-chips {
+  display: flex;
+  gap: var(--spacing-xsmall);
+  flex-wrap: wrap;
+  padding: var(--spacing-small) var(--spacing-screen-edge) 0;  /* title ↔ chip 사이 breathing */
+}
+
+/* --- Hero 카드 신규 atoms (chip line / label-value rows / edit link) --- */
+.ped-chips {
+  display: flex;
+  gap: var(--spacing-xsmall);
+  flex-wrap: wrap;
+}
+.ped-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;                /* icon ↔ label */
+  padding: 3px 10px;
+  border-radius: var(--radius-small);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+/* Leading icon — visibility chip(globe / lock). 탭 시 설명 토스트 */
+.ped-chip__icon {
+  width: 11px; height: 11px;
+  flex-shrink: 0;
+}
+/* visibility chip은 인터랙티브 — 탭 시 토스트 (cursor pointer) */
+.ped-chip--visibility { cursor: pointer; }
+.ped-chip--accent  { background: rgba(108, 60, 225, 0.12); color: var(--color-primary); }   /* (현재 미사용 — 모집/완료 모두 success로 변경됨) */
+.ped-chip--success { background: rgba(34, 197, 94, 0.12);  color: #15803d; }                  /* 공개 (외부 노출) */
+.ped-chip--warning { background: rgba(255, 165, 0, 0.12);  color: #b85a00; }                  /* D-day (시간 임박) */
+.ped-chip--error   { background: rgba(239, 68, 68, 0.12);  color: var(--color-error); }     /* 취소 */
+.ped-chip--outline { background: var(--color-divider);     color: var(--color-text-secondary); } /* 비공개 / 완료 */
+
+.ped-info-rows {
+  display: flex; flex-direction: column;
+  gap: var(--spacing-medium);     /* 블록 사이 호흡 ↑ — was small */
+}
+/* Stacked block: caption(작은 라벨) → primary(큰 값) → secondary(보조)
+   value 위계가 명확해 운영자 시선이 큰 텍스트로 즉시 잡힘 */
+.ped-info-block {
+  display: flex; flex-direction: column;
+  gap: 2px;
+}
+.ped-info-block__caption {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  letter-spacing: 0.02em;
+}
+.ped-info-block__primary {
+  font-size: 16px;                    /* was 18px — 페이지 title(20px) 위계 유지 */
+  font-weight: 600;                   /* was 700 — title과 같은 weight */
+  color: var(--color-text-primary);
+  line-height: 1.3;
+}
+.ped-info-block__secondary {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+  margin-top: 1px;
+}
+
+/* Kakao Map thumb — 장소 block 안 시각 강조. SDK는 Flutter side에서 인라인 임베드,
+   탭 시 외부 맵 앱 deep-link(kakaomap://place?id= or maps:?q=) — 길 안내 진입.
+   spec mock에서는 grid 패턴 + 보라 핀으로 placeholder 표현 */
+.ped-map-thumb {
+  margin-top: var(--spacing-small);
+  height: 100px;
+  border-radius: var(--radius-input);
+  position: relative;
+  overflow: hidden;
+  background:
+    /* faint road grid */
+    linear-gradient(90deg, rgba(0,0,0,0.04) 1px, transparent 1px) 0 0 / 28px 28px,
+    linear-gradient(rgba(0,0,0,0.04) 1px, transparent 1px) 0 0 / 28px 28px,
+    linear-gradient(135deg, #e8edf5 0%, #f3f6fb 100%);
+  cursor: pointer;
+}
+.ped-map-thumb__pin {
+  position: absolute;
+  top: 50%; left: 50%;
+  width: 18px; height: 18px;
+  transform: translate(-50%, -100%);
+  color: var(--color-primary);
+}
+.ped-map-thumb__pin svg { width: 100%; height: 100%; filter: drop-shadow(0 1px 2px rgba(0,0,0,0.2)); }
+
+/* 오시는길 — 장소 block 안 sub-section. label + multiline 자유 텍스트
+   (도보 안내 / 입구 / 주차 / 랜드마크 등 운영자가 자유로 작성) */
+.ped-directions {
+  margin-top: var(--spacing-small);
+  display: flex; flex-direction: column;
+  gap: 3px;
+}
+.ped-directions__label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  letter-spacing: 0.04em;
+}
+.ped-directions__text {
+  font-size: 13px;
+  color: var(--color-text-primary);
+  line-height: 1.5;
+  white-space: pre-line;
+}
+
+.ped-edit-link {
+  display: inline-flex; align-items: center;
+  gap: 2px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-primary);
+  flex-shrink: 0;
+}
+.ped-edit-link svg { width: 14px; height: 14px; }
+
+/* --- Hero 카드 (chip line + 일정/장소/호스트 rows + 정보 수정 링크) --- */
 .ped-card {
   margin: var(--spacing-medium) var(--spacing-screen-edge);
   padding: var(--spacing-medium);
   background: var(--color-surface);
   border-radius: var(--radius-card);  /* 16 */
-  border: 1px solid var(--color-divider);
   display: flex;
   flex-direction: column;
+  gap: var(--spacing-medium);
 }
 .ped-row {
   display: flex;
@@ -111,63 +327,530 @@ body.dark-mode .viewport {
   margin-top: 2px;
 }
 .ped-row__icon svg { width: 18px; height: 18px; }
-.ped-row__label {
-  font-size: var(--typography-font-size-body);
-  font-weight: 700;
-  color: var(--color-text-secondary);
-  flex-shrink: 0;
-  max-width: 120px;
+
+/* Hero row — 일정 (차분한 톤, primary 강조 최소화) */
+.ped-row--hero {
+  align-items: flex-start;
+  gap: var(--spacing-small);
+  padding-bottom: var(--spacing-xsmall);
 }
-.ped-row__value {
+.ped-row--hero .ped-row__icon {
+  width: 18px; height: 18px;
+  margin-top: 2px;
+  color: var(--color-text-secondary);  /* primary X — 차분한 톤 */
+}
+.ped-row--hero .ped-row__icon svg { width: 18px; height: 18px; }
+.ped-row__hero-body {
+  display: flex; flex-direction: column;
+  gap: 2px;
   flex: 1;
-  text-align: right;
-  font-size: var(--typography-font-size-body);
+  min-width: 0;
+}
+.ped-row__hero-primary {
+  font-size: 16px;
+  font-weight: 600;        /* w700 → w600 톤 다운 */
   color: var(--color-text-primary);
+  line-height: 1.35;
 }
-.ped-row__value--accent {
-  color: var(--color-primary);
-  font-weight: 700;
-}
-.ped-row__value--error {
-  color: var(--color-error);
-  font-weight: 700;
-}
-.ped-row__value--muted {
+.ped-row__hero-secondary {
+  font-size: 13px;
   color: var(--color-text-secondary);
-  font-weight: 700;
+  line-height: 1.4;
 }
+/* D-day 우측 trail 배지 (일정 행 우측, primary 톤 — 유일한 강조) */
+.ped-row__hero-trail {
+  flex-shrink: 0;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--color-primary);
+  padding: 2px 8px;
+  background: rgba(108, 60, 225, 0.1);
+  border-radius: var(--radius-small);
+  margin-top: 1px;
+}
+
+/* Supporting (meta) rows — 참가 / 상태 / 공개 */
+.ped-row--meta {
+  gap: var(--spacing-small);
+  padding: 2px 0;
+}
+.ped-row__meta-body {
+  display: flex; flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  gap: 1px;
+}
+.ped-row__meta-label {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+.ped-row__meta-value {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  line-height: 1.35;
+}
+.ped-row__meta-value--accent { color: var(--color-primary); font-weight: 700; }
+.ped-row__meta-value--error { color: var(--color-error); font-weight: 700; }
+.ped-row__meta-value--muted { color: var(--color-text-secondary); font-weight: 600; }
+
 .ped-divider {
   height: 1px;
   background: var(--color-divider);
   margin: var(--spacing-small) 0;
 }
 
-/* --- MinglitSection header w/ trailing button --- */
+/* --- 전체 참가 현황 카드 (이벤트 통합 — 별도 섹션) --- */
+.ped-summary {
+  margin: 0 var(--spacing-screen-edge) var(--spacing-medium);
+  padding: var(--spacing-medium);    /* vertical 여유 */
+  background: var(--color-surface);
+  border-radius: var(--radius-card);
+  display: flex; flex-direction: column;
+  gap: var(--spacing-medium);                              /* gap 여유 — was small */
+}
+.ped-summary__head {
+  display: flex; align-items: baseline;
+  gap: var(--spacing-large);    /* 두 metric 그룹 사이 호흡 */
+  flex-wrap: wrap;
+}
+/* 한 metric = 큰 숫자 + 옆 라벨 (예: 6 / 12 확정, 4 심사대기) */
+.ped-summary__metric {
+  display: inline-flex; align-items: baseline;
+  gap: var(--spacing-xsmall);
+}
+/* stacked variant — 라벨이 위, 큰 숫자가 아래 (취소 환불 완료 카드 등 강조 케이스) */
+.ped-summary__metric--stacked {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+.ped-summary__metric--stacked .ped-summary__count-total {
+  order: -1;     /* 라벨을 위로 이동 (mock에서 순서 그대로 두고 CSS로 처리) */
+}
+.ped-summary__count {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  line-height: 1;
+}
+/* 심사대기 카운트 강조 — 운영자가 처리해야 할 액션 시그널 (≥1일 때만 적용) */
+.ped-summary__count--pulse {
+  color: var(--color-primary);
+  animation: ped-pulse 1.6s ease-in-out infinite;
+}
+@keyframes ped-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.5; }
+}
+/* 환불완료 metric 톤 다운 — 이미 끝난 정보, 액션 X */
+.ped-summary__metric--muted .ped-summary__count {
+  color: var(--color-text-secondary);
+  font-weight: 600;
+}
+.ped-summary__metric--muted .ped-summary__count-total {
+  color: var(--color-text-secondary);
+  opacity: 0.7;
+}
+.ped-summary__count-total {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+.ped-summary__breakdown {
+  display: flex;
+  gap: var(--spacing-medium);
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+.ped-summary__breakdown strong {
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+/* 심사 CTA — 대기 ≥1일 때 노출. CTA 버튼 스타일로 터치 영역 / 시인성 ↑ */
+.ped-summary__cta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 44px;
+  padding: 0 var(--spacing-medium);
+  background: var(--color-primary);
+  color: white;
+  border-radius: var(--radius-button);
+  font-size: 14px;
+  font-weight: 600;
+  gap: var(--spacing-xsmall);
+  box-sizing: border-box;
+}
+.ped-summary__cta svg { width: 16px; height: 16px; }
+/* outline variant — 보조 액션 (참가자 보기 등) — 같은 h44, primary border, transparent bg */
+.ped-summary__cta--outline {
+  background: transparent;
+  color: var(--color-primary);
+  border: 1px solid var(--color-primary);
+}
+/* CTA stack 컨테이너 — 두 버튼 사이 small gap */
+.ped-summary__actions {
+  display: flex; flex-direction: column;
+  gap: var(--spacing-small);
+  margin-top: var(--spacing-small);
+}
+
+/* --- 입장 그룹 리스트 컨테이너 (단일 카드 안에 그룹 N개 + divider) --- */
+.ped-group-list {
+  margin: 0 var(--spacing-screen-edge) var(--spacing-medium);
+  background: var(--color-surface);
+  border-radius: var(--radius-card);
+  display: flex; flex-direction: column;
+}
+
+/* --- 입장 그룹 (단일 카드 안의 섹션 — 자체 border/radius/margin 없음) --- */
+.ped-group {
+  /* vertical large — divider 위/아래 충분한 호흡 (카드 자체보다 여유 ↑)
+     가로는 medium 유지로 다른 카드와 통일 */
+  padding: var(--spacing-large) var(--spacing-medium);
+  display: flex; flex-direction: column;
+  gap: var(--spacing-medium);
+}
+/* 그룹 사이 divider — 카드 좌우 padding 안쪽으로 inset (full-width 안함) */
+.ped-group + .ped-group {
+  position: relative;
+}
+.ped-group + .ped-group::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: var(--spacing-medium);
+  right: var(--spacing-medium);
+  height: 1px;
+  background: var(--color-divider);
+}
+.ped-group__head {
+  display: flex; align-items: center; gap: var(--spacing-small);
+}
+.ped-group__name {
+  flex: 1;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+.ped-group__count {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+.ped-group__count-total {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  margin-left: 2px;
+}
+.ped-group__chevron { color: var(--color-text-secondary); flex-shrink: 0; }
+.ped-group__chevron svg { width: 14px; height: 14px; }
+/* MinglitCapacityBar — segmented (total ≤ 30) / continuous (> 30) */
+.mds-capbar {
+  height: 6px;
+  background: var(--color-divider);
+  border-radius: 3px;
+  overflow: hidden;
+  display: flex;
+}
+/* continuous mode children */
+.mds-capbar__fill {
+  height: 100%;
+  background: var(--color-primary);
+}
+.mds-capbar__pending {
+  height: 100%;
+  background: rgba(108, 60, 225, 0.3);
+}
+/* segmented mode (total ≤ segmentThreshold) — 칸 분리, 각 칸 = 1명 */
+.mds-capbar--segmented {
+  height: 8px;
+  background: transparent;        /* 빈 칸은 자식에서 표현 */
+  border-radius: 0;
+  overflow: visible;
+  gap: 2px;
+}
+.mds-capbar__seg {
+  flex: 1;
+  height: 100%;
+  background: var(--color-divider);  /* empty (남은 자리) */
+  border-radius: 2px;
+}
+.mds-capbar__seg--filled  { background: var(--color-primary); }
+.mds-capbar__seg--pending { background: rgba(108, 60, 225, 0.3); }
+
+/* 기존 alias 유지 (다른 mock에서 쓰면 segmented 지정) — 신규 사용 X */
+.ped-group__bar { display: none; }
+.ped-group__breakdown {
+  display: flex;
+  gap: var(--spacing-medium);
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+.ped-group__breakdown strong {
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+/* 환불 항목 톤 다운 — 끝난 정보 */
+.ped-group__breakdown-item--muted {
+  opacity: 0.65;
+}
+.ped-group__alert {
+  padding: var(--spacing-xsmall) var(--spacing-small);
+  background: rgba(255, 165, 0, 0.1);
+  border: 1px solid rgba(255, 165, 0, 0.25);
+  border-radius: var(--radius-small);
+  font-size: 12px;
+  color: var(--color-text-primary);
+  display: flex; align-items: center; gap: 6px;
+}
+.ped-group__alert svg { width: 12px; height: 12px; color: #b85a00; flex-shrink: 0; }
+.ped-group__alert strong { color: #b85a00; font-weight: 700; }
+/* Nest wrapper — 티켓 리스트 컨테이너. 보더는 각 티켓이 자체 보유 (티켓별 분리감) */
+.ped-group__nest {
+  display: flex; flex-direction: column;
+}
+.ped-group__tickets {
+  display: flex; flex-direction: column;
+  gap: var(--spacing-card-gap);   /* 12px — 티켓 카드 사이 호흡 (was small 8px) */
+}
+/* 각 티켓이 자체 좌측 bar 보유 — 티켓 1개여도 single ticket 느낌 명확
+   - 두께 4px (was 3px)
+   - 색: neutral gray rgba(0,0,0,0.15) — primary 톤(capbar 확정/대기)과 의미 충돌 회피
+   - border-radius 2px로 끝 부드럽게 */
+.ped-group__ticket {
+  display: flex; flex-direction: column;
+  padding: var(--spacing-small) 0 var(--spacing-small) var(--spacing-medium); /* 좌측 indent 16px */
+  gap: var(--spacing-small);
+  border-left: 4px solid rgba(0, 0, 0, 0.15);
+  border-radius: 2px;
+}
+.ped-group__ticket-row {
+  display: flex; align-items: center;
+  gap: var(--spacing-medium);
+}
+.ped-group__ticket-name {
+  flex: 1;
+  font-size: 14px;
+  font-weight: 600;        /* 굵게 — 티켓 이름과 메타 분리 명확 */
+  color: var(--color-text-primary);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.ped-group__ticket-sub {
+  font-size: 12px;
+  font-weight: 400;        /* 메타 — 가벼운 톤 */
+  color: var(--color-text-secondary);
+  margin-left: 0;          /* 한 행 → 두 줄 구조로 변경 */
+}
+.ped-group__ticket-price {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  white-space: nowrap;
+}
+.ped-group__ticket-chevron {
+  color: var(--color-text-secondary);
+  flex-shrink: 0;
+  margin-left: 4px;
+}
+.ped-group__ticket-chevron svg { width: 14px; height: 14px; }
+.ped-group__ticket-bar {
+  /* 판매 진행률 시각화 — MinglitCapacityBar mini variant (height 4px) */
+  margin-left: 0;
+}
+.ped-group__add {
+  /* margin-top 제거 — .ped-group__nest 의 gap(small)이 처리 */
+  height: 44px;                       /* 심사하기 CTA와 동일 — 보조 액션도 같은 터치 영역 */
+  padding: 0 var(--spacing-medium);
+  border: 1px dashed var(--color-primary);
+  border-radius: var(--radius-button);
+  color: var(--color-primary);
+  font-size: 14px;
+  font-weight: 600;
+  display: flex; align-items: center; justify-content: center;
+  gap: var(--spacing-xsmall);
+  box-sizing: border-box;
+}
+.ped-group__add svg { width: 16px; height: 16px; }
+
+/* --- (deprecated) 참가 현황 별도 카드 — 입장 그룹 카드 안으로 통합됨 --- */
+.ped-stats { display: none; }
+.ped-stats__head {
+  display: flex; align-items: center; gap: var(--spacing-small);
+}
+.ped-stats__title {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+.ped-stats__count {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  line-height: 1;
+}
+.ped-stats__count-total {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+}
+.ped-stats__chevron {
+  color: var(--color-text-secondary);
+  flex-shrink: 0;
+}
+.ped-stats__chevron svg { width: 16px; height: 16px; }
+.ped-stats__bar {
+  height: 6px;
+  background: var(--color-divider);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.ped-stats__bar-fill {
+  height: 100%;
+  background: var(--color-primary);
+  border-radius: 3px;
+}
+.ped-stats__breakdown {
+  display: flex;
+  gap: var(--spacing-medium);
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+.ped-stats__breakdown strong {
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+.ped-stats__alert {
+  margin-top: var(--spacing-xsmall);
+  padding: var(--spacing-small);
+  background: rgba(255, 165, 0, 0.1);
+  border: 1px solid rgba(255, 165, 0, 0.25);
+  border-radius: var(--radius-small);
+  font-size: 12px;
+  color: var(--color-text-primary);
+  display: flex; align-items: center; gap: 6px;
+}
+.ped-stats__alert svg {
+  width: 14px; height: 14px;
+  color: #b85a00;
+  flex-shrink: 0;
+}
+.ped-stats__alert strong { color: #b85a00; font-weight: 700; }
+
+/* --- 공개 설정 chip (제목 옆 — 상단 노출, 즉시 확인용) --- */
+.ped-vis-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-left: var(--spacing-small);
+  padding: 2px 8px;
+  background: var(--color-divider);
+  color: var(--color-text-secondary);
+  border-radius: var(--radius-small);
+  font-size: 11px;
+  font-weight: 500;
+  vertical-align: middle;
+}
+.ped-vis-chip svg { width: 11px; height: 11px; }
+
+/* --- 기대 매출 카드 (운영자 KPI 요약. 헤더는 카드 밖 .ped-section-header) --- */
+.ped-revenue {
+  margin: 0 var(--spacing-screen-edge) var(--spacing-medium);
+  padding: var(--spacing-medium);    /* vertical 여유 */
+  background: var(--color-surface);
+  border-radius: var(--radius-card);
+  display: flex; flex-direction: column;
+  gap: var(--spacing-medium);                              /* gap 여유 */
+}
+.ped-revenue__head {
+  display: flex; align-items: baseline; gap: var(--spacing-xsmall);
+  flex-wrap: wrap;
+}
+.ped-revenue__current {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  line-height: 1;
+}
+.ped-revenue__max {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+.ped-revenue__breakdown {
+  display: flex;
+  gap: var(--spacing-medium);
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  flex-wrap: wrap;
+}
+.ped-revenue__breakdown strong {
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+
+/* 그룹별 기대 매출 — 전체 매출 카드 안 sub-section */
+.ped-revenue__groups {
+  display: flex; flex-direction: column;
+  gap: var(--spacing-medium);
+  margin-top: var(--spacing-small);
+  padding-top: var(--spacing-medium);
+  border-top: 1px solid var(--color-divider);
+}
+.ped-revenue__group {
+  display: flex; flex-direction: column;
+  gap: var(--spacing-xsmall);
+}
+.ped-revenue__group-row {
+  display: flex; align-items: baseline;
+  gap: var(--spacing-xsmall);
+}
+.ped-revenue__group-name {
+  flex: 1;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  font-weight: 500;
+}
+.ped-revenue__group-amount {
+  font-size: 14px;
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+.ped-revenue__group-amount-max {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  font-weight: 400;
+}
+
+/* --- MinglitSection header (title only — trailing 없음) --- */
 .ped-section-header {
   display: flex;
   align-items: center;
-  padding: var(--spacing-small) var(--spacing-screen-edge) var(--spacing-xsmall);
+  /* vertical 여유: top large(섹션 사이 호흡), bottom small(헤더↔카드 거리) — was small/xsmall */
+  padding: var(--spacing-large) var(--spacing-screen-edge) var(--spacing-small);
 }
 .ped-section-header__title {
-  font-size: var(--typography-font-size-body);
+  font-size: var(--typography-font-size-button);  /* 16px — 섹션 위계 강조 (was body 14px) */
   font-weight: 700;
   color: var(--color-text-primary);
   flex: 1;
+  letter-spacing: -0.01em;
 }
-.ped-section-header__trailing {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-xsmall);
-  color: var(--color-primary);
-  font-size: var(--typography-font-size-body);
+/* 섹션 헤더 trailing 진입점 — title 옆 우측. 카드 안 CTA와 별개로 섹션 단위 진입 */
+.ped-section-header__link {
+  display: inline-flex; align-items: center;
+  gap: 2px;
+  font-size: 13px;
   font-weight: 600;
-  height: 32px;
-  padding: 0 var(--spacing-small);
-  cursor: pointer;
+  color: var(--color-primary);
+  flex-shrink: 0;
 }
-.ped-section-header__trailing svg {
-  width: 16px; height: 16px;
-}
+.ped-section-header__link svg { width: 14px; height: 14px; }
 
 /* --- Ticket list item card --- */
 .ped-ticket {
@@ -248,7 +931,7 @@ body.dark-mode .viewport {
   margin-top: var(--spacing-xxsmall);
 }
 
-/* --- Application list (Tab 2) --- */
+/* --- (deprecated) Application list — moved to event_application_list_page.html --- */
 .ped-app-section {
   padding: 0 var(--spacing-medium);
   margin-top: var(--spacing-small);
@@ -398,7 +1081,7 @@ body.dark-mode .viewport {
     <tbody>
       <tr>
         <th style="width: 140px;">Status</th>
-        <td><strong>✅ 디자인완료</strong> <em style="color: var(--color-text-secondary);">— 5 state · 파트너 이벤트 운영(티켓 관리 + 참가 신청 심사) 단일 진입점</em></td>
+        <td><strong>✅ 디자인완료</strong> <em style="color: var(--color-text-secondary);">— 6 state · 파트너 이벤트 운영(티켓 관리 + 참가 신청 심사) 단일 진입점</em></td>
       </tr>
       <tr>
         <th>App</th>
@@ -410,7 +1093,7 @@ body.dark-mode .viewport {
       </tr>
       <tr>
         <th>Route / Surface</th>
-        <td><code>EventDetailRoute</code> · widget: <code>EventDetailPage</code> (+ <code>_EventInfoTab</code> · <code>_DetailRow</code> internal widgets)</td>
+        <td><code>EventDetailRoute</code> · widget: <code>EventDetailPage</code> (+ <code>_EventInfoTab</code> · <code>_HeroDetailRow</code> / <code>_MetaDetailRow</code> internal widgets)</td>
       </tr>
       <tr>
         <th>Path</th>
@@ -420,7 +1103,7 @@ body.dark-mode .viewport {
         <th>Hierarchy</th>
         <td>
           <strong>Parent</strong>: <a href="/specs/party_detail_page.html"><code>PartyDetailPage</code></a> (이벤트 카드 탭 시 push)<br>
-          <strong>Children</strong>: <a href="/specs/ticket_create_page.html"><code>TicketCreateRoute</code></a> (티켓 만들기 버튼 / Add 카드 탭) · <a href="/specs/ticket_edit_page.html"><code>TicketEditRoute</code></a> (티켓 카드 탭) · <code>EventApplicationReviewDialog</code> (심사 대기 카드 탭 — 다이얼로그)
+          <strong>Children</strong>: <a href="/specs/event_edit_page.html"><code>EventEditRoute</code></a> (Hero "일정" 영역 탭 — 이벤트 정보 수정) · <a href="/specs/ticket_create_page.html"><code>TicketCreateRoute</code></a> (Add 카드 탭) · <a href="/specs/ticket_edit_page.html"><code>TicketEditRoute</code></a> (티켓 카드 탭) · <code>EventApplicationReviewDialog</code> (심사 대기 카드 탭 — 다이얼로그)
         </td>
       </tr>
       <tr>
@@ -433,7 +1116,7 @@ body.dark-mode .viewport {
         <th>User journey</th>
         <td>
           <strong>Entry points</strong>: <a href="/specs/party_detail_page.html">PartyDetailPage</a>의 이벤트 카드 탭 → 이 화면 진입 (운영 관리 탭이 기본).<br>
-          <strong>Exit points</strong>: AppBar back → 파티 상세 / "티켓 만들기" 또는 Add 카드 → <a href="/specs/ticket_create_page.html">TicketCreatePage</a> / 티켓 카드 탭 → <a href="/specs/ticket_edit_page.html">TicketEditPage</a> / 신청 카드(심사 대기) 탭 → 심사 다이얼로그 → 승인/거절 후 같은 화면 머무름 / "참가 신청" 탭 전환 → 같은 페이지 안에서 본문 교체.
+          <strong>Exit points</strong>: AppBar back → 파티 상세 / <strong>Hero "일정" 영역 탭 → <a href="/specs/event_edit_page.html">EventEditPage</a></strong> (이벤트 정보 수정) / Add 카드 (또는 빈 상태 카드) → <a href="/specs/ticket_create_page.html">TicketCreatePage</a> / 티켓 카드 탭 → <a href="/specs/ticket_edit_page.html">TicketEditPage</a> / 신청 카드(심사 대기) 탭 → 심사 다이얼로그 → 승인/거절 후 같은 화면 머무름 / "참가 신청" 탭 전환 → 같은 페이지 안에서 본문 교체.
         </td>
       </tr>
       <tr>
@@ -472,8 +1155,8 @@ body.dark-mode .viewport {
         <td>1.0</td>
         <td>mark-yun</td>
         <td>
-          v1.4 template으로 신규 작성. 파트너 brand color (<code>#6c3ce1</code>) viewport-scoped override. 5 state(Default 운영 관리 · Tab 2 신청 활성 · 신청 비어있음 · Loading · Error) → mini-table per state, additive diff.
-          5 sub-anatomy (AppBar+TabBar · Title block · Detail info card · Tickets section · Applications tab) + 2 visual zoom-in (AppBar+TabBar / Detail info card status별).
+          v1.4 template으로 신규 작성. 파트너 brand color (<code>#6c3ce1</code>) viewport-scoped override. 3 state(Default · Loading · Error) → mini-table per state, additive diff. Tab 구조 폐기 후 참가 신청은 별도 라우트(<a href="/specs/event_application_list_page.html"><code>EventApplicationListRoute</code></a>)로 분리.
+          4 sub-anatomy (AppBar · Title block · Detail info card · Tickets section) + 1 visual zoom-in (Detail info card 상태별 톤). 참가 신청 도메인은 별도 라우트(<a href="/specs/event_application_list_page.html"><code>EventApplicationListRoute</code></a>)로 분리.
         </td>
       </tr>
     </tbody>
@@ -501,7 +1184,11 @@ body.dark-mode .viewport {
   <section class="doc">
     <h2>Blueprint &amp; tree</h2>
     <p class="intro">
-      Scaffold = AppBar(title '이벤트 상세' + 2탭 TabBar) + body(이벤트 데이터 비동기 로드 → TabBarView 2 자식). 좌측 탭 "운영 관리"는 세로 스크롤 페이지로, 이벤트 제목 + 운영 메타 카드(5행) + 입장권 섹션이 차례로 쌓인다. 우측 탭 "참가 신청"은 들어온 신청을 심사 대기 / 처리 완료 두 그룹으로 분리한 리스트가 그대로 영역을 채운다. 하단 네비게이션 / CTA 바는 없다 — leaf route.
+      Scaffold = AppBar(title '이벤트 상세') + body(이벤트 데이터 비동기 로드 → 단일 스크롤 페이지). 본문은 세 섹션으로 명확히 분리된다:
+      (1) <strong>Hero 카드</strong> — 일정(D-day trail) + 상태 · 탭 → <a href="/specs/event_edit_page.html">EventEditRoute</a>.
+      (2) <strong>참가 현황 섹션</strong> — 이벤트 전체 분수(큰 22+px count) + 누적 CapacityBar(<a href="/components#MinglitCapacityBar">MinglitCapacityBar</a>) + breakdown + <em>심사 대기 ≥1일 때</em> "심사 대기 N건 처리하기 →" 링크(탭 → <a href="/specs/event_application_list_page.html">EventApplicationListRoute</a> · 그룹 필터 없음).
+      (3) <strong>입장 그룹별 현황 섹션</strong> — 입장 그룹 카드 × N(각 그룹: 이름 + 분수 + 누적 CapacityBar + breakdown + 그룹 티켓 row × N(<em>각 row에 발행률 mini CapacityBar</em>) + "이 그룹에 티켓 추가" 버튼 · 카드 자체 탭 → EventApplicationListRoute(groupId)).
+      그 아래 공개 설정 footer 마이크로 텍스트. TabBar / 하단 네비게이션 / CTA 바 없음 — leaf route. 참가 신청 도메인은 별도 라우트로 분리되며, 전체 진입(참가 현황 카드)과 그룹별 진입(그룹 카드) 모두 같은 EventApplicationListRoute로 라우팅 — 그룹별 진입 시만 groupId 파라미터로 필터.
     </p>
     <div class="layout-grid">
       <div class="blueprint">
@@ -509,85 +1196,164 @@ body.dark-mode .viewport {
 
         <!-- AppBar -->
         <div class="blueprint__region blueprint__region--shaded" style="top:0;left:0;right:0;height:56px;">
-          <span class="blueprint__region-label">① AppBar — back + '이벤트 상세' (left-aligned)</span>
+          <span class="blueprint__region-label">① AppBar — back + '이벤트 상세' (left-aligned, TabBar 없음)</span>
         </div>
-        <!-- TabBar -->
-        <div class="blueprint__region blueprint__region--shaded" style="top:56px;left:0;right:0;height:48px;">
-          <span class="blueprint__region-label">② TabBar — 운영 관리 · 참가 신청</span>
-        </div>
-        <!-- Title -->
-        <div class="blueprint__region blueprint__region--shaded" style="top:120px;left:16px;right:16px;height:32px;">
-          <span class="blueprint__region-label">③ Event title (headlineSmall · primary)</span>
+        <!-- Title + visibility chip -->
+        <div class="blueprint__region blueprint__region--shaded" style="top:72px;left:16px;right:16px;height:32px;">
+          <span class="blueprint__region-label">② Event title + 공개 설정 chip (title 우측 inline)</span>
         </div>
         <!-- Detail info card -->
-        <div class="blueprint__region blueprint__region--shaded" style="top:168px;left:16px;right:16px;height:200px;">
-          <span class="blueprint__region-label">④ Detail info card<br>날짜 / 시간 / 참가 현황 / 상태 / 공개 설정 (5 DetailRow + 4 dividers)</span>
+        <div class="blueprint__region blueprint__region--shaded" style="top:120px;left:16px;right:16px;height:110px;">
+          <span class="blueprint__region-label">③ Hero 카드<br>Hero 일정(D-day trail 배지) + 상태 supporting · 탭 → EventEditRoute</span>
         </div>
-        <!-- Tickets section -->
-        <div class="blueprint__region blueprint__region--shaded" style="top:384px;left:0;right:0;bottom:0;">
-          <span class="blueprint__region-label">⑤ Tickets section<br>섹션 헤더(+ '티켓 만들기' trailing) + status header + 입장권 카드 N개 + Add 카드</span>
+        <!-- Section header: 참가 현황 -->
+        <div class="blueprint__region blueprint__region--shaded" style="top:246px;left:16px;right:16px;height:28px;">
+          <span class="blueprint__region-label" style="font-size:9px;">④ '참가 현황' 섹션 헤더 (전체)</span>
+        </div>
+        <!-- Summary card -->
+        <div class="blueprint__region blueprint__region--shaded" style="top:282px;left:16px;right:16px;height:130px;">
+          <span class="blueprint__region-label" style="font-size:9px;">⑤ 참가 현황 카드 (전체)<br>큰 분수 + 누적 CapacityBar + breakdown + <em>심사 대기 ≥1일 때만</em> 심사 링크<br>탭 → EventApplicationListRoute (no group filter)</span>
+        </div>
+        <!-- Section header: 기대 매출 (전체 KPI — 그룹 디테일 위) -->
+        <div class="blueprint__region blueprint__region--shaded" style="top:422px;left:16px;right:16px;height:28px;">
+          <span class="blueprint__region-label" style="font-size:9px;">⑥ '기대 매출' 섹션 헤더</span>
+        </div>
+        <!-- Revenue summary card -->
+        <div class="blueprint__region blueprint__region--shaded" style="top:458px;left:16px;right:16px;height:100px;">
+          <span class="blueprint__region-label" style="font-size:9px;">⑦ 기대 매출 카드 — 현재/잠재(심사 승인 시)/최대 + continuous CapacityBar</span>
+        </div>
+        <!-- Section header: 입장 그룹별 현황 -->
+        <div class="blueprint__region blueprint__region--shaded" style="top:570px;left:16px;right:16px;height:28px;">
+          <span class="blueprint__region-label" style="font-size:9px;">⑧ '입장 그룹별 현황' 섹션 헤더</span>
+        </div>
+        <!-- Entry group cards -->
+        <div class="blueprint__region blueprint__region--shaded" style="bottom:0;left:16px;right:16px;height:120px;">
+          <span class="blueprint__region-label" style="font-size:9px;">⑨ 입장 그룹 리스트 (단일 카드 + 그룹 사이 divider)<br>각 그룹: 이름 + 분수 + CapacityBar + breakdown + 티켓 row(판매+대기/발행 mini CapacityBar) + 추가 버튼<br>그룹 영역 탭 → EventApplicationListRoute(groupId)</span>
         </div>
 
         <div class="blueprint__align-marker" style="top:8px;right:8px;">screen-edge pad 16</div>
       </div>
 
-      <div class="layout-tree"><b>DefaultTabController</b>(length: 2)
-└─ <b>Scaffold</b>
-   ├─ <b>appBar</b>: AppBar
-   │  ├─ leading: BackButton (auto)
-   │  ├─ title: Text('이벤트 상세') · centerTitle: false
-   │  └─ <b>bottom</b>: TabBar(length: 2)                       ← ②
-   │     ├─ Tab('운영 관리')
-   │     └─ Tab('참가 신청')
-   └─ <b>body</b>: <code>MinglitAsyncValueWidget&lt;Event&gt;</code>
-      ├─ loading: <code>MinglitCircularProgressIndicator</code>
-      ├─ error:   Centered text ('이벤트 로드 실패')
-      └─ data:    <b>TabBarView</b>
-         ├─ <b>_EventInfoTab</b> (운영 관리)                    ← ③④⑤
-         │  └─ SingleChildScrollView
-         │     └─ <code>MinglitContentLayout</code>(sections: [
-         │        ├─ Padding(<i>screenEdge h</i>) → Text(event.title) <i>headlineSmall · bold · primary</i>
-         │        ├─ Padding(<i>screenEdge h</i>) → Container(border + radius-card)
-         │        │  └─ Column [
-         │        │     ├─ <b>_DetailRow</b>(calendar_today, '일정 (날짜)', dateFormat)
-         │        │     ├─ Divider
-         │        │     ├─ <b>_DetailRow</b>(access_time, '시작 ~ 종료 시간', timeFormat)
-         │        │     ├─ Divider
-         │        │     ├─ <b>_DetailRow</b>(people_outline, '참가 현황',
-         │        │     │              '확정 N명 / 신청 M명 (대기 P)')
-         │        │     ├─ Divider
-         │        │     ├─ <b>_DetailRow</b>(info_outline, '상태',
-         │        │     │              status label, valueColor: status별)
-         │        │     ├─ Divider
-         │        │     └─ <b>_DetailRow</b>(visibility, '공개 설정',
-         │        │                    '공개' / '비공개' / '파티 설정 따라가기')
-         │        │  ]
-         │        └─ <code>MinglitSection</code>(title: '입장권 관리',
-         │             trailing: TextButton.icon(Icons.add, '티켓 만들기'))
-         │           └─ <code>MinglitAsyncValueWidget</code>(ticketsAsync)
-         │              └─ <code>TicketListView</code>
-         │                 ├─ if tickets.isEmpty + onCreate
-         │                 │  → <code>AddActionCard</code> ('새 티켓 만들기')
-         │                 └─ else
-         │                    ├─ <code>TicketStatusHeader</code>(totalIssued/maxParticipants)
-         │                    └─ ListView.separated [
-         │                       ├─ <b>TicketListItem</b>(ticket, entryGroups) × N
-         │                       │   · onTap → push <a href="/specs/ticket_edit_page.html">TicketEditRoute</a>
-         │                       └─ <code>AddActionCard</code> (작은 'add' 아이콘)
-         │                          · onTap → push <a href="/specs/ticket_create_page.html">TicketCreateRoute</a>
-         │                    ]
-         │     ])
+      <div class="layout-tree"><b>Scaffold</b>
+├─ <b>appBar</b>: AppBar                                  ← ①
+│  ├─ leading: BackButton (auto)
+│  └─ title: Text('이벤트 상세') · centerTitle: false (TabBar 없음 — 단일 스크롤)
+└─ <b>body</b>: <code>MinglitAsyncValueWidget&lt;Event&gt;</code>
+   ├─ loading: <code>MinglitCircularProgressIndicator</code>
+   ├─ error:   Centered text ('이벤트 로드 실패')
+   └─ data: <b>SingleChildScrollView</b>                  ← ②③④⑤⑥
+      └─ <code>MinglitContentLayout</code>(sections: [
+         ├─ <b>_TitleRow</b>(Row · padding small top + h-screen-edge) ← ②a title row
+         │  └─ Text(event.title) <i>· 20px w600 · color-text-primary</i>
          │
-         └─ <b>EventApplicationListView</b>(eventId)            ← Tab 2
-            └─ <code>MinglitAsyncValueWidget</code>(applicationsAsync)
-               ├─ if empty → 가운데 텍스트 ('신청 내역이 없습니다.')
-               └─ else → ListView(padding: medium)
-                  ├─ if pendingReviews.isNotEmpty
-                  │  ├─ Text('심사 대기 중 (N)') <i>titleMedium · bold</i>
-                  │  └─ <b>_ApplicationCard</b> × N (status: pending_review)
-                  └─ if others.isNotEmpty
-                     ├─ Text('처리 완료 (N)') <i>titleMedium · outline color</i>
-                     └─ <b>_ApplicationCard</b> × N (approved · paid · rejected)</div>
+         ├─ <b>_MetaChipLine</b>(Row · spacing-xsmall · padding small top + h-screen-edge · title 아래)  ← ②b chips
+         │  · <b>InkWell</b>(onTap: showToast(visibilityDescription))
+         │    └─ <b>MinglitChip</b>(label: '공개'/'비공개', tone: 공개→success / 비공개→outline,
+         │           leadingIcon: 공개→globe / 비공개→lock,
+         │           interactive: true)            /* 탭 시 설명 토스트 */
+         │  · <b>MinglitChip</b>(label: status, tone: scheduled→accent · cancelled→error · completed→outline)
+         │  · <b>MinglitChip</b>(label: 'D-N', tone: warning)             /* 시간 임박 — 주황 */
+         │
+         ├─ <b>_EditRow</b>(Row justify-end · padding small top + h-screen-edge)  ← ②c edit row
+         │  └─ <b>InkWell</b>(onTap: push <a href="/specs/event_edit_page.html">EventEditRoute</a>)
+         │     └─ Row('정보 수정 ›' · 13px w600 primary)                  /* Hero 카드 바로 위, 우측 */
+         │
+         ├─ Padding(<i>screenEdge h</i>) → Container(radius-card · borderless)  ← ③
+         │  └─ <b>_InfoBlocks</b>(Column · spacing-medium) [                /* stacked blocks */
+         │     ├─ <b>_InfoBlock</b>('일정')
+         │     │  ├─ caption 12px w500 secondary ('일정')
+         │     │  ├─ primary 16px w600 primary ('YYYY.MM.DD (E)')
+         │     │  └─ secondary 13px secondary ('오후 H:MM ~ H:MM')
+         │     └─ <b>_InfoBlock</b>('장소')
+         │        ├─ caption 12px w500 secondary ('장소')
+         │        ├─ primary 16px w600 primary (event.location.name)
+         │        ├─ secondary 13px secondary (event.location.address)
+         │        ├─ <b>_KakaoMapThumb</b>(height 100 · radius-input)      /* SDK 임베드 */
+         │        │  · static 또는 light interactive map · 핀 = event.location.geoPoint
+         │        │  · onTap → 외부 맵 앱 deep-link (kakaomap://place?id= or maps:?q=)
+         │        │  · spec mock에서는 grid + 보라 핀으로 placeholder 표현
+         │        └─ <b>_Directions</b>('오시는길')                          /* 자유 텍스트 */
+         │           ├─ label 11px w600 secondary ('오시는길')
+         │           └─ text 13px primary · multiline (도보·입구·주차·랜드마크)
+         │ ]
+         ├─ <code>MinglitSection</code>(title: '참가 현황')                  ← ④
+         │  └─ Padding(<i>screenEdge h</i>) → <b>EventApplicationStatsCard</b>(event)  ← ⑤
+         │     ├─ Row(spacing-large gap) [                                /* 메트릭 한 줄 통합 */
+         │     │    Metric(count event.confirmedCount '24px w700' + label '/ N 확정' '13px w500 secondary'),
+         │     │    Metric(count event.pendingCount + label '심사대기' · count에 pulse 강조 ≥1),
+         │     │    Metric(count event.refundedCount + label '환불완료' · 정적 — 액션 X)
+         │     │ ]  /* refundedCount = refund_status IN ('completed') */
+         │     ├─ <b>MinglitCapacityBar</b>(
+         │     │     total: event.totalCapacity,
+         │     │     filled: event.confirmedCount,
+         │     │     pending: event.pendingCount)
+         │     └─ <b>_Actions</b>(Column · spacing-small · margin-top small) [
+         │          if event.pendingCount &gt; 0:
+         │            <b>InkWell</b>(onTap: push EventApplicationListRoute(anchor: pending))
+         │            └─ <b>_ReviewCtaButton</b>('심사하기' · primary fill · h44 · radius-button)
+         │          /* 항상 노출 — 환불 요청 등 유저별 비정형 액션 진입 */
+         │          <b>InkWell</b>(onTap: push EventApplicationListRoute /* no filter */)
+         │          └─ <b>_ApplicantsCtaButton</b>('참가자 보기' · outline primary · h44 · radius-button)
+         │        ]
+         │
+         ├─ <code>MinglitSection</code>(title: '기대 매출')                  ← ⑥
+         │  └─ Padding(<i>screenEdge h</i>) → <b>_RevenueSummaryCard</b>(event)
+         │     ├─ <em>전체 매출</em>
+         │     │  ├─ Row(event.currentRevenue 22px w700 + '/ 최대 event.maxRevenue' 13px secondary)
+         │     │  ├─ <b>MinglitCapacityBar</b>(continuous,
+         │     │  │     total: maxRevenue, filled: currentRevenue, pending: pendingRevenue)
+         │     │  └─ Row(현재 KKK원 · 심사 승인 시 +KKK원)
+         │     └─ <em>그룹별 매출</em> (Divider · top-border · padding-top medium)
+         │        for each entryGroup in event.entryGroups:
+         │          Column(spacing-xsmall) [
+         │            Row(group.name 13px secondary, group.currentRevenue 14px w600 primary, '/ 최대 group.maxRevenue' 12px secondary)
+         │            <b>MinglitCapacityBar</b>(continuous · height 6,
+         │              total: group.maxRevenue, filled: group.currentRevenue, pending: group.pendingRevenue)
+         │          ]
+         │
+         └─ <code>MinglitSection</code>(title: '입장 그룹별 현황')             ← ⑦
+            └─ Padding(<i>screenEdge h</i>) → <b>EntryGroupListContainer</b>(border + radius)
+               for each entryGroup in event.entryGroups:                  ← ⑧
+                 if not first: Divider(full-width · color-divider)
+                 <b>InkWell</b>(onTap: push EventApplicationListRoute(groupId: g.id))
+                 └─ Padding(spacing-large v · spacing-medium h) → <b>EntryGroupSection</b>(group)
+                    ├─ Row(group.name + Row(count + '/ N 확정') + chevron)
+                    ├─ <b>MinglitCapacityBar</b>(
+                    │     total: group.capacity,
+                    │     filled: group.confirmedCount,
+                    │     pending: group.pendingCount)
+                    ├─ Row(확정 N · 대기 M · 환불 R)  /* 0인 항목은 노이즈, 표시 X */
+                    │  <em>(group-level alert 폐기 — 참가 현황 섹션이 대체)</em>
+                    ├─ <b>_NestContainer</b>(passthrough — 보더 각 티켓이 보유)
+                    │  └─ Column(spacing-small) [
+                    │       for each ticket in group.tickets:
+                    │         <b>InkWell</b>(onTap: push <a href="/specs/ticket_edit_page.html">TicketEditRoute</a>(ticketId))
+                    │         └─ Container(
+                    │              border-left: 3px neutral-gray @ 15%,  /* 티켓별 bar — primary 톤과 의미 분리 */
+                    │              padding: small v · medium left,        /* 16px indent */
+                    │              child: Column(spacing-small) [
+                    │                Row(
+                    │                  Column[ticket.name <i>(14px w600)</i>
+                    │                         + '판매 N · 대기 M / 발행 K장' <i>(12px secondary)</i>],
+                    │                  ticket.price <i>(14px w600)</i>,
+                    │                  chevron_right <i>(14 secondary)</i>      /* 탭 affordance */
+                    │                )
+                    │                <b>MinglitCapacityBar</b>(    /* mini · height 4 — 판매+대기/발행 */
+                    │                  total: ticket.issuedQuantity,
+                    │                  filled: ticket.soldQuantity,
+                    │                  pending: ticket.pendingQuantity)
+                    │              ])
+                    │         <em>탭 시 가격 / 발행수 수정 가능. 티켓별 분리된 좌측 bar로 single ticket도 명확한 티켓 단위 느낌</em>
+                    │     ]
+                    └─ <b>_GroupAddTicketButton</b>(group)              <em>nest 밖 — full-width</em>
+                       · dashed primary border · h44 · radius-button · '+ 이 그룹에 티켓 추가'
+                       · indent 없음 (그룹 본체와 같은 폭 — 그룹 자체에 속한 액션이라 들여쓰기 안 함)
+                       · onTap → push <a href="/specs/ticket_create_page.html">TicketCreateRoute</a>(groupId: g.id)
+            ]
+      ])
+※ 공개 설정 chip은 이벤트 title 우측에 inline (상단 즉시 확인) — footer 폐기.
+
+<em>티켓 정원 정책</em>: 티켓 발행 총수 ≥ 입장 그룹 정원. UI는 발행수가 정원 미만이면 안내(보강 권고). "남은 정원만큼 더 발행" 같은 cap 메시지 사용 X — 추가 발행은 항상 가능.</div>
     </div>
   </section>
 
@@ -604,99 +1370,15 @@ body.dark-mode .viewport {
       </thead>
       <tbody>
         <tr><td>①</td><td>AppBar</td><td>height 56 · row crossAxis center · 좌측 정렬 타이틀</td><td>back left: <code>spacing-xsmall (4)</code> · title↔back gap: 0 (BackButton width 흡수)</td></tr>
-        <tr><td>②</td><td>TabBar</td><td>height 48 · 2탭 flex equal</td><td>각 탭 row · indicator height 2 · 하단 1px <code>color-divider</code></td></tr>
-        <tr><td>③</td><td>Event title (Tab 1)</td><td>좌측 정렬 · multi-line</td><td>h-padding: <code>spacing-screen-edge (16)</code> · 위 <code>spacing-medium (16)</code></td></tr>
+                <tr><td>②</td><td>Event title</td><td>좌측 정렬 · multi-line</td><td>h-padding: <code>spacing-screen-edge (16)</code> · 위 <code>spacing-medium (16)</code></td></tr>
         <tr><td>④</td><td>Detail info card</td><td>풀폭 with screen-edge h-margin · column</td><td>h-margin: <code>spacing-screen-edge (16)</code> · padding: <code>spacing-medium (16)</code> all · radius: <code>radius-card (16)</code> · row 사이 divider top/bottom <code>spacing-small (8)</code></td></tr>
         <tr><td>⑤</td><td>Tickets section</td><td>풀폭 · column stretch</td><td>section header padding: <code>spacing-medium</code> top · 카드 사이 <code>spacing-small (8)</code> · 카드 h-margin: <code>spacing-screen-edge</code></td></tr>
-        <tr><td>—</td><td>Tab 2 list</td><td>list padding all <code>spacing-medium (16)</code></td><td>그룹 사이 <code>spacing-large (24)</code> · 카드 사이 <code>spacing-small (8)</code></td></tr>
-      </tbody>
+              </tbody>
     </table>
   </section>
 
   <section class="doc">
-    <h2>AppBar + TabBar anatomy (①②)</h2>
-    <p class="intro">
-      상단 56px AppBar + 48px TabBar로 묶인 한 덩어리. AppBar에는 좌측에 뒤로가기, 그 옆에 "이벤트 상세" 타이틀이 좌측 정렬로 붙는다(센터 타이틀 아님).
-      AppBar 바로 아래 TabBar는 화면 너비를 정확히 2등분한 두 탭(운영 관리 · 참가 신청) — 활성 탭은 라벨이 파트너 보라색으로 굵어지고 그 아래 2px 보라 언더라인이 그려진다.
-      탭은 탭하면 본문이 즉시 다른 탭의 내용으로 갈아끼워진다(같은 페이지 안 두 번째 화면 — 스크롤 위치는 탭별로 따로 보존되지 않음, 탭마다 자체 스크롤 영역).
-    </p>
-    <div class="layout-grid">
-      <div class="blueprint" style="width: 343px; height: 130px;">
-        <div class="blueprint__region blueprint__region--full"></div>
-
-        <!-- AppBar back -->
-        <div class="blueprint__region blueprint__region--shaded" style="top:8px;left:4px;width:40px;height:40px;">
-          <span class="blueprint__region-label" style="font-size:9px;">㉠ Back<br>40×40</span>
-        </div>
-        <!-- AppBar title -->
-        <div class="blueprint__region blueprint__region--shaded" style="top:14px;left:48px;width:160px;height:28px;">
-          <span class="blueprint__region-label" style="font-size:10px;">㉡ Title — '이벤트 상세' (left)</span>
-        </div>
-
-        <!-- TabBar tabs -->
-        <div class="blueprint__region blueprint__region--shaded" style="top:64px;left:0;width:170px;height:48px;">
-          <span class="blueprint__region-label" style="font-size:10px;">㉢ Tab #1 — '운영 관리' (active)</span>
-        </div>
-        <div class="blueprint__region" style="top:64px;left:170px;width:170px;height:48px;border-style:dashed;border-color:rgba(var(--spec-blueprint-rgb),0.3);">
-          <span class="blueprint__region-label" style="font-size:10px;">㉣ Tab #2 — '참가 신청'</span>
-        </div>
-        <!-- Active indicator -->
-        <div class="blueprint__region" style="top:110px;left:0;width:170px;height:2px;background:var(--color-primary);"></div>
-        <!-- Bottom divider -->
-        <div class="blueprint__region" style="bottom:8px;left:0;right:0;height:1px;background:var(--color-divider);"></div>
-
-        <div class="blueprint__align-marker" style="top:8px;right:8px;">left-aligned title</div>
-        <div class="blueprint__align-marker" style="bottom:14px;left:8px;">divider 하단 1px</div>
-      </div>
-
-      <div class="layout-tree"><b>AppBar</b>(height: 56, centerTitle: false)
-├─ leading: <b>BackButton</b>(width 40)                  ← ㉠
-│  · 좌측 가장자리 4px · 40×40 hit zone · onSurface
-│
-├─ title: <b>Text</b>('이벤트 상세')                     ← ㉡
-│  · 좌측 정렬 (centerTitle 미사용)
-│  · <i>titleMedium</i> 톤 / w700
-│
-└─ bottom: <b>TabBar</b>(length: 2)                      ← ㉢㉣
-   · height 48 · indicator weight 2
-   · 2탭 → 각 탭이 화면 너비의 정확히 1/2 흡수
-   ├─ Tab(text: '운영 관리')   <i>(default selected)</i>
-   └─ Tab(text: '참가 신청')
-
-<em>각 탭 내부:</em>
-· crossAxis center · 라벨 가운데 정렬
-· 비활성: <i>color-text-secondary · w500</i>
-· 활성: <i>color-primary (partner #6c3ce1) · w700</i>
-   · 활성 라벨 하단에 2px <i>color-primary</i> 언더라인 (탭 너비 전체)
-
-<em>탭 전환:</em>
-· 탭 탭 → 본문이 즉시 같은 페이지 안에서 다른 자식으로 슬라이드
-· DefaultTabController가 둘을 묶어 동기화
-· 본문은 탭별 자체 스크롤 영역 (위치 공유 안 됨)</div>
-    </div>
-
-    <table class="ref" style="margin-top: 16px;">
-      <thead>
-        <tr>
-          <th style="width: 60px;">#</th>
-          <th style="width: 200px;">Region</th>
-          <th style="width: 220px;">Alignment</th>
-          <th>Spacing / tokens</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr><td>—</td><td>AppBar 외부</td><td>height 56 · 풀폭</td><td>bg <code>color-background</code> · 자체 elevation 0 (TabBar divider가 분리 역할)</td></tr>
-        <tr><td>㉠</td><td>BackButton</td><td>좌상 정렬</td><td>40×40 hit zone · icon 22 · color <code>onSurface</code> · left margin: 4px</td></tr>
-        <tr><td>㉡</td><td>Title</td><td>BackButton 우측에 바로 이어 · 좌측 정렬</td><td>typography <code>titleMedium</code> w700 · color <code>color-text-primary</code></td></tr>
-        <tr><td>㉢㉣</td><td>각 Tab</td><td>flex equal (각 1/2) · row crossAxis center</td><td>height 48 · 라벨 <code>bodyMedium</code> · 비활성 w500/text-secondary · 활성 w700/primary</td></tr>
-        <tr><td>—</td><td>Active indicator</td><td>활성 탭 하단</td><td>height 2px · color <code>color-primary (partner)</code> · width = 탭 width</td></tr>
-        <tr><td>—</td><td>TabBar 하단 divider</td><td>풀폭</td><td>1px <code>color-divider</code> — body와 분리</td></tr>
-      </tbody>
-    </table>
-  </section>
-
-  <section class="doc">
-    <h2>Event title block anatomy (③)</h2>
+    <h2>Event title block anatomy (②)</h2>
     <p class="intro">
       운영 관리 탭의 첫 줄 — 이벤트 제목이 단독 블록으로 떠 있다. 화면 좌우 가장자리에서 16px 떨어져 있고, 한 줄에 안 들어가면 자연스럽게 줄바꿈되며 글자 크기가 줄지 않는다.
       파트너 보라색 + 굵은 헤드라인 톤으로 화면에서 가장 시각적 무게가 큰 요소 — 사용자가 "지금 운영 중인 이벤트가 무엇인지" 즉시 인지하게 하는 앵커.
@@ -744,14 +1426,21 @@ body.dark-mode .viewport {
   </section>
 
   <section class="doc">
-    <h2>Detail info card anatomy (④)</h2>
+    <h2>Hero 영역 anatomy (②③)</h2>
     <p class="intro">
-      운영에 필요한 핵심 메타 다섯 줄을 담은 라운드 카드. 좌우 가장자리에서 16px 떨어진 풀폭 블록이며, 안쪽은 16px 패딩이 둘러싼다. 행 하나하나는 좌측 아이콘 → 라벨(굵은 회색) → 값(우측 정렬)으로 같은 골격을 공유하고, 행 사이는 1px divider로 가볍게 끊는다.
-      값 영역은 행마다 톤이 달라질 수 있다 — 상태 행은 운영 단계에 따라 보라(예정) / 빨강(취소됨) / 회색(완료)으로 색이 바뀌고 두꺼워지며, 나머지 4행은 본문 톤 그대로다.
-      라벨이 길어지면 최대 2줄까지 줄바꿈되고 ellipsis로 잘리며, 값도 동일하게 2줄까지 허용 + ellipsis 처리.
+      페이지 최상단의 Hero 영역은 <strong>4단 구조</strong>로 분리:
+      <strong>(1) Title row</strong> — 이벤트 title(20px w600 · 일반 톤) 단독. AppBar 바로 아래 페이지 정체성을 명확히.
+      <strong>(2) Meta chip line</strong> — title 바로 아래에 <em>stable→dynamic 순서</em>로 <strong>공개 설정 chip</strong>(공개 → 🌐 globe icon + success 초록 / 비공개 → 🔒 lock icon + outline 회색 · set-once · <em>탭 시 설명 토스트</em>) → 상태 chip(모집 → success 초록 / 취소 → error 빨강 / 완료 → success 초록) → D-day chip(warning 주황 — 시간 임박 시그널). 도메인별 색 + 아이콘 차이로 메타 종류가 한눈에 구분. 공개 설정 chip은 인터랙티브 — 탭하면 토스트로 의미 안내(공개 → "외부에 공개되어 누구나 볼 수 있는 이벤트입니다." / 비공개 → "초대받은 사람만 볼 수 있는 비공개 이벤트입니다."). 다른 chip(상태·D-day)은 정적 노출만.
+      운영자가 화면 들어와 0.3초 안에 "공개됐어 / 어떤 상태야 / 며칠 남았어"를 확인.
+      <strong>(3) 정보 수정 row</strong> — Hero 카드 바로 위, 우측 정렬 "정보 수정 ›" 링크(13px w600 primary). 카드 밖 별도 row에 두어 편집 동작이 카드 콘텐츠와 시각적으로 분리 — 운영자가 정보를 읽다가 "수정해야지" 의도가 생겼을 때 손이 닿기 쉬운 위치. 탭 시 <a href="/specs/event_edit_page.html"><code>EventEditPage</code></a>로 push.
+      <strong>(4) Hero 카드 — stacked info blocks</strong>: '일정' / '장소' 각각 caption(12px w500 secondary · 카테고리) → primary(16px w600 primary · 값) → secondary(13px secondary · 보조). value 폰트는 title(20px)보다 작아 페이지 위계 유지 — Hero 카드의 무게는 stacked 구조와 caption-primary-secondary 위계에서 나옴.
+      <strong>장소 block</strong>은 추가로 <em>Kakao Map thumb</em>(100px · 핀 placement, 탭 시 외부 맵 앱 deep-link로 길 안내)과 <em>오시는길 sub-section</em>(label '오시는길' + 자유 텍스트 — 도보 안내 / 입구 / 주차 / 랜드마크 등 운영자가 작성)을 포함. 운영자뿐 아니라 외부 공유 시 참가자에게도 가치 있는 정보.
+      카드 자체는 borderless(<code>MinglitContentCard</code>의 <code>bordered: false</code> variant).
+      이전 Hero(아이콘 + 단일 일정 텍스트 + 상태 row + divider) → 현재 구조 전환 이유: (a) 정렬 — 아이콘과 multi-line 텍스트의 baseline 충돌 해소, (b) 정보 — 장소 추가 + 메타는 chip line으로 페이지 최상단 강조, (c) 액션 affordance — 카드 전체 탭보다 명시적 텍스트 링크가 의도 명료.
+      호스트 정보는 운영자 본인이 호스트인 경우가 대부분이라 본 영역에서는 생략(필요 시 EventEditPage에서 확인).
     </p>
     <div class="layout-grid">
-      <div class="blueprint" style="height: 240px;">
+      <div class="blueprint" style="height: 260px;">
         <div class="blueprint__region blueprint__region--full"></div>
 
         <!-- Card outer -->
@@ -759,27 +1448,30 @@ body.dark-mode .viewport {
           <span class="blueprint__region-label" style="font-size:9px;top:2px;">㉠ Card — radius 16 · border 1px · padding 16</span>
         </div>
 
-        <!-- Row 1 -->
-        <div class="blueprint__region" style="top:24px;left:32px;width:18px;height:18px;background:rgba(var(--spec-blueprint-rgb),0.3);">
+        <!-- Hero row (일정) -->
+        <div class="blueprint__region" style="top:24px;left:32px;width:22px;height:22px;background:rgba(var(--spec-blueprint-rgb),0.4);">
           <span class="blueprint__region-label" style="font-size:8px;">📅</span>
         </div>
-        <div class="blueprint__region" style="top:24px;left:60px;width:80px;height:18px;border-style:dashed;border-color:rgba(var(--spec-blueprint-rgb),0.3);">
-          <span class="blueprint__region-label" style="font-size:8px;">㉡ label</span>
+        <div class="blueprint__region" style="top:24px;left:64px;right:32px;height:14px;border-style:dashed;border-color:rgba(var(--spec-blueprint-rgb),0.3);">
+          <span class="blueprint__region-label" style="font-size:8px;">㉡ caption '일정' (11px · secondary)</span>
         </div>
-        <div class="blueprint__region" style="top:24px;right:32px;width:130px;height:18px;border-style:dashed;border-color:rgba(var(--spec-blueprint-rgb),0.3);">
-          <span class="blueprint__region-label" style="font-size:8px;">㉢ value (right)</span>
+        <div class="blueprint__region" style="top:42px;left:64px;right:32px;height:22px;border-style:dashed;border-color:rgba(var(--spec-blueprint-rgb),0.5);">
+          <span class="blueprint__region-label" style="font-size:8px;">㉣ primary '2026-05-15 (금)' (18px · w700 · primary)</span>
         </div>
-        <!-- Divider -->
-        <div class="blueprint__region" style="top:56px;left:32px;right:32px;height:1px;background:var(--color-divider);"></div>
+        <div class="blueprint__region" style="top:68px;left:64px;right:32px;height:18px;border-style:dashed;border-color:rgba(var(--spec-blueprint-rgb),0.3);">
+          <span class="blueprint__region-label" style="font-size:8px;">㉤ secondary '오후 7:30 ~ 오후 9:30' (14px · secondary)</span>
+        </div>
+        <!-- Divider after hero -->
+        <div class="blueprint__region" style="top:100px;left:32px;right:32px;height:1px;background:var(--color-divider);"></div>
 
-        <!-- Row 2 .. 5 stub markers -->
-        <div class="blueprint__align-marker" style="top:72px;left:32px;font-size:8px;">⏰ 시간 / value</div>
-        <div class="blueprint__region" style="top:96px;left:32px;right:32px;height:1px;background:var(--color-divider);"></div>
-        <div class="blueprint__align-marker" style="top:108px;left:32px;font-size:8px;">👥 참가 현황 / value</div>
-        <div class="blueprint__region" style="top:132px;left:32px;right:32px;height:1px;background:var(--color-divider);"></div>
-        <div class="blueprint__align-marker" style="top:144px;left:32px;font-size:8px;">ℹ️ 상태 / value (color-primary if scheduled)</div>
-        <div class="blueprint__region" style="top:168px;left:32px;right:32px;height:1px;background:var(--color-divider);"></div>
-        <div class="blueprint__align-marker" style="top:180px;left:32px;font-size:8px;">👁 공개 설정 / value</div>
+        <!-- Supporting row 1: 참가 현황 -->
+        <div class="blueprint__align-marker" style="top:116px;left:32px;font-size:8px;">㉦ [👥] 참가 현황 (12px label) / 확정 8명 ... (14px value · primary)</div>
+        <div class="blueprint__region" style="top:148px;left:32px;right:32px;height:1px;background:var(--color-divider);"></div>
+        <!-- Supporting row 2: 상태 -->
+        <div class="blueprint__align-marker" style="top:160px;left:32px;font-size:8px;">㉧ [ℹ️] 상태 / 모집 중 (color-primary if scheduled · w700)</div>
+        <div class="blueprint__region" style="top:192px;left:32px;right:32px;height:1px;background:var(--color-divider);"></div>
+        <!-- Supporting row 3: 공개 설정 -->
+        <div class="blueprint__align-marker" style="top:204px;left:32px;font-size:8px;">㉨ [👁] 공개 설정 / 공개</div>
 
         <div class="blueprint__align-marker" style="top:8px;right:8px;">h-margin: spacing-screen-edge (16)</div>
       </div>
@@ -791,35 +1483,42 @@ body.dark-mode .viewport {
    │   border: 1px <i>color-divider (outlineVariant)</i>,
    │   padding: <i>spacing-medium (16)</i> all)
    └─ <b>Column</b>
-      ├─ <b>_DetailRow</b>(calendar_today, '일정 (날짜)',    ← row #1
-      │     value: 'yyyy년 MM월 dd일 (E)')
+      ├─ <b>InkWell</b>(onTap: push <a href="/specs/event_edit_page.html">EventEditRoute</a>)
+      │  └─ <b>_HeroDetailRow</b>(calendar_today, '일정',   ← Hero row (탭 가능)
+      │       primary: 'yyyy년 MM월 dd일 (E)',
+      │       secondary: 'a h:mm ~ a h:mm')
       ├─ Divider(spacing-small v-padding 양쪽)
-      ├─ <b>_DetailRow</b>(access_time, '시간',              ← row #2
-      │     value: 'a h:mm ~ a h:mm')
-      ├─ Divider
-      ├─ <b>_DetailRow</b>(people_outline, '참가 현황',      ← row #3
+      ├─ <b>_MetaDetailRow</b>(people_outline, '참가 현황',  ← Supporting row
       │     value: '확정 N명 / 신청 M명 (대기 P)')
       ├─ Divider
-      ├─ <b>_DetailRow</b>(info_outline, '상태',             ← row #4
+      ├─ <b>_MetaDetailRow</b>(info_outline, '상태',         ← Supporting row
       │     value: status label,
       │     valueColor: <i>scheduled→primary · cancelled→error · completed→outline</i>)
       ├─ Divider
-      └─ <b>_DetailRow</b>(visibility, '공개 설정',          ← row #5
+      └─ <b>_MetaDetailRow</b>(visibility, '공개 설정',      ← Supporting row
             value: '공개' / '비공개' / '파티 설정 따라가기')
 
-<em>각 행(_DetailRow) 내부 구조:</em>
-└─ Row(crossAxis: start)
-   ├─ <b>Icon</b>(small · onSurfaceVariant)              ← ㉡ left
-   ├─ Gap: <i>spacing-small (8)</i>
-   ├─ Flexible <b>Text</b>(label)                        ← ㉡ label
-   │  · <i>bodyMedium · w700 · onSurfaceVariant</i>
-   │  · maxLines: 2 · ellipsis
-   ├─ Gap: <i>spacing-small (8)</i>
-   └─ Expanded <b>Text</b>(value)                        ← ㉢ value
-      · textAlign: right
-      · <i>bodyMedium</i>
-      · color/weight: valueColor 있으면 그 색 + bold, 없으면 기본
-      · maxLines: 2 · ellipsis</div>
+<em>Hero row (_HeroDetailRow) 내부 구조:</em>
+└─ Row(crossAxis: start, gap: spacing-small)
+   ├─ <b>Icon</b>(medium ≈22 · color-primary)           ← ㉡ left
+   └─ Expanded Column(gap: 2px)
+      ├─ <b>Text</b>(caption '일정')                     ← ㉡ caption
+      │  · 11px · w500 · color-text-secondary · letterSpacing 0.02em
+      ├─ <b>Text</b>(primary value)                     ← ㉣ primary
+      │  · 18px · w700 · color-text-primary · maxLines 2 · ellipsis
+      └─ <b>Text</b>(secondary value)                   ← ㉤ secondary
+         · 14px · color-text-secondary · maxLines 2 · ellipsis
+
+<em>Supporting row (_MetaDetailRow) 내부 구조:</em>
+└─ Row(crossAxis: start, gap: spacing-small, padding: 2px v)
+   ├─ <b>Icon</b>(small ≈18 · color-text-secondary)     ← ㉡ left
+   └─ Expanded Column(gap: 1px)
+      ├─ <b>Text</b>(label)                             ← ㉦㉧㉨ label
+      │  · 12px · w500 · color-text-secondary · maxLines 2 · ellipsis
+      └─ <b>Text</b>(value)                             ← ㉦㉧㉨ value
+         · 14px · w600 · color-text-primary (기본)
+         · 상태 행만 valueColor 적용 (primary/error/outline) + w700
+         · maxLines 2 · ellipsis</div>
     </div>
 
     <table class="ref" style="margin-top: 16px;">
@@ -833,30 +1532,33 @@ body.dark-mode .viewport {
       </thead>
       <tbody>
         <tr><td>㉠</td><td>Card 외곽</td><td>풀폭 with screen-edge h-margin</td><td>radius <code>radius-card (16)</code> · padding <code>spacing-medium (16)</code> all · border 1px <code>color-divider</code> · bg <code>color-surface</code></td></tr>
-        <tr><td>㉡</td><td>Label 영역 (각 행)</td><td>row leading · icon + label</td><td>icon <code>iconSize-small (≈18)</code> color <code>color-text-secondary</code> · gap <code>spacing-small (8)</code> · 라벨 <code>bodyMedium</code> w700 <code>color-text-secondary</code> · maxLines 2 · ellipsis</td></tr>
-        <tr><td>㉢</td><td>Value 영역 (각 행)</td><td>row trailing · 우측 정렬</td><td>typography <code>bodyMedium</code> · 기본은 <code>color-text-primary</code> · 상태 행은 <code>primary / error / outline</code> 중 하나 + <code>w700</code> · maxLines 2 · ellipsis</td></tr>
-        <tr><td>—</td><td>Divider (행 사이)</td><td>풀폭 · 행 사이</td><td>height 1px <code>color-divider</code> · 위/아래 padding <code>spacing-small (8)</code></td></tr>
+        <tr><td>㉡</td><td>Icon 영역 (모든 행)</td><td>row leading · 좌측 정렬 · 행 시작</td><td>Hero 행: <code>iconSize-medium (≈22)</code> · color <code>color-primary</code> · margin-top 2 / Supporting 행: <code>iconSize-small (≈18)</code> · color <code>color-text-secondary</code> · margin-top 0 · gap <code>spacing-small (8)</code></td></tr>
+        <tr><td>㉣</td><td>Hero primary (날짜)</td><td>좌측 정렬 · icon 우측</td><td>typography 18px <code>w700</code> · color <code>color-text-primary</code> · line-height 1.3 · maxLines 2 · ellipsis</td></tr>
+        <tr><td>㉤</td><td>Hero secondary (시간)</td><td>좌측 정렬 · primary 아래</td><td>typography 14px · color <code>color-text-secondary</code> · line-height 1.35 · maxLines 2 · ellipsis · 위 gap 2px</td></tr>
+        <tr><td>—</td><td>Hero caption ('일정')</td><td>좌측 정렬 · primary 위</td><td>typography 11px <code>w500</code> · color <code>color-text-secondary</code> · letterSpacing 0.02em · 아래 gap 2px</td></tr>
+        <tr><td>㉦㉧㉨</td><td>Supporting label</td><td>좌측 정렬 · 행 위쪽</td><td>typography 12px <code>w500</code> · color <code>color-text-secondary</code> · 아래 gap 1px · maxLines 2 · ellipsis</td></tr>
+        <tr><td>㉦㉧㉨</td><td>Supporting value</td><td>좌측 정렬 · label 아래</td><td>typography 14px <code>w600</code> · 기본 <code>color-text-primary</code> · 상태 행만 <code>primary / error / outline</code> 중 하나 + <code>w700</code> · maxLines 2 · ellipsis</td></tr>
+        <tr><td>—</td><td>Divider (행 사이)</td><td>풀폭 · hero ↔ supporting / supporting ↔ supporting</td><td>height 1px <code>color-divider</code> · 위/아래 margin <code>spacing-small (8)</code></td></tr>
       </tbody>
     </table>
   </section>
 
   <section class="doc">
-    <h2>Tickets section anatomy (⑤)</h2>
+    <h2>Entry group cards anatomy (⑤)</h2>
     <p class="intro">
-      카드 아래에 이어 붙는 입장권 관리 섹션. 헤더 한 줄(좌측 "입장권 관리" 타이틀 + 우측 "+ 티켓 만들기" 텍스트 버튼) 다음에 본문이 온다.
-      티켓이 하나라도 있으면 작은 상태 표시줄(현재 발행 수 vs 정원)이 위에 깔리고, 그 아래로 입장권 카드가 한 줄에 하나씩 쌓이며, 마지막 자리에는 늘 작은 "+ 추가" 카드가 붙어 새 티켓을 더 만들 수 있다.
-      티켓이 하나도 없으면 본문이 통째로 보라색 빈 상태 카드("새 티켓 만들기")로 바뀐다 — 헤더의 "+ 티켓 만들기" 버튼과 빈 상태 카드 어느 쪽을 탭해도 같은 화면(<a href="/specs/ticket_create_page.html">TicketCreatePage</a>)으로 이동한다.
+      섹션 헤더("참가 현황 / 입장권") 아래에 이어 붙는 <strong>입장 그룹별 카드 stack</strong>. 한 이벤트가 여러 입장 그룹(예: 일반 그룹 / VIP 그룹)을 가질 수 있으며, 각 그룹마다 카드 1개가 만들어져 그룹의 참가 현황 + 티켓 + 추가 버튼이 한 묶음으로 묶인다.
+      카드 안 구조는 위에서 아래로: 그룹 이름 + 분수(확정/정원) + chevron / <strong>누적 진행 바</strong>(확정 = 강한 primary, 대기 = 옅은 primary @ 30%) / breakdown(확정 N · 대기 M · 거절 P) / 심사 대기 alert (있을 때만) / divider / 그룹 티켓 row × N(이름 + 발행수 + 가격) / "+ 이 그룹에 티켓 추가" 버튼(dashed primary border).
+      <strong>카드 자체 탭 → <a href="/specs/event_application_list_page.html"><code>EventApplicationListRoute</code></a>(groupId)</strong> — 해당 그룹으로 필터된 신청 리스트로 이동. 티켓 row 탭 → <a href="/specs/ticket_edit_page.html"><code>TicketEditRoute</code></a>(ticketId), 추가 버튼 탭 → <a href="/specs/ticket_create_page.html"><code>TicketCreateRoute</code></a>(groupId 사전 선택).
+      <strong>티켓 정원 정책</strong>: 티켓 발행 총수 ≥ 그룹 정원이어야 함 (티켓이 정원보다 적으면 안내). "남은 정원만큼" 같은 cap 메시지 사용 X — 추가 발행은 항상 가능하며 운영자가 자유로 늘릴 수 있다.
+      입장 그룹이 0개면 본문 자리에 빈 상태 카드("입장 그룹을 먼저 만들어주세요" + 파티 상세 CTA), 그룹은 있는데 티켓이 0개면 카드 안 티켓 리스트 자리에 작은 안내 + 추가 버튼만.
     </p>
     <div class="layout-grid">
       <div class="blueprint" style="height: 280px;">
         <div class="blueprint__region blueprint__region--full"></div>
 
-        <!-- Section header -->
-        <div class="blueprint__region blueprint__region--shaded" style="top:16px;left:16px;width:120px;height:24px;">
-          <span class="blueprint__region-label" style="font-size:10px;">㉠ Section title — '입장권 관리'</span>
-        </div>
-        <div class="blueprint__region blueprint__region--shaded" style="top:12px;right:16px;width:120px;height:32px;">
-          <span class="blueprint__region-label" style="font-size:9px;">㉡ '+ 티켓 만들기' (TextButton)</span>
+        <!-- Section header (title only) -->
+        <div class="blueprint__region blueprint__region--shaded" style="top:16px;left:16px;right:16px;height:24px;">
+          <span class="blueprint__region-label" style="font-size:10px;">㉠ Section title — '입장권 관리' (trailing 없음)</span>
         </div>
 
         <!-- Status header -->
@@ -881,16 +1583,10 @@ body.dark-mode .viewport {
       </div>
 
       <div class="layout-tree"><code>MinglitSection</code>(title: '입장권 관리',
-   trailing: <b>TextButton.icon</b>(Icons.add, '티켓 만들기'),
    padding: EdgeInsets.zero,
    child: ...)
-├─ <em>Section header row</em>                          ← ㉠㉡
-│  ├─ Title: '입장권 관리' <i>· bodyMedium · w700</i>
-│  └─ Trailing: <b>TextButton.icon</b>
-│     · icon: Icons.add (size small ≈18)
-│     · label: '티켓 만들기'
-│     · color: <i>color-primary (partner)</i>
-│     · onPressed: push <a href="/specs/ticket_create_page.html">TicketCreateRoute</a>
+├─ <em>Section header row</em>                          ← ㉠
+│  └─ Title: '입장권 관리' <i>· bodyMedium · w700</i> (trailing 없음 — Add 카드가 단일 진입점)
 │
 └─ <code>MinglitAsyncValueWidget</code>(ticketsAsync)
    ├─ loading: small spinner
@@ -914,8 +1610,8 @@ body.dark-mode .viewport {
             │  · onTap → push <a href="/specs/ticket_edit_page.html">TicketEditRoute</a>(ticketId)
             │
             └─ <code>AddActionCard</code> (small + 아이콘) ← ㉥
-               · trailing 자리에 늘 한 칸 더 붙음
-               · onTap → TicketCreateRoute (헤더 버튼과 동일 행선지)</div>
+               · trailing 자리에 늘 한 칸 더 붙음 — 새 티켓 추가의 단일 진입점
+               · onTap → TicketCreateRoute</div>
     </div>
 
     <table class="ref" style="margin-top: 16px;">
@@ -928,8 +1624,7 @@ body.dark-mode .viewport {
         </tr>
       </thead>
       <tbody>
-        <tr><td>㉠</td><td>Section title</td><td>좌측 정렬</td><td>typography <code>bodyMedium</code> w700 · color <code>color-text-primary</code> · h-pad <code>spacing-screen-edge</code></td></tr>
-        <tr><td>㉡</td><td>Trailing button</td><td>우측 정렬 · row icon + label</td><td>height 32 · icon size <code>iconSize-small (≈18)</code> · color <code>color-primary</code> · gap <code>spacing-xsmall</code></td></tr>
+        <tr><td>㉠</td><td>Section title</td><td>좌측 정렬 · 풀폭 (trailing 없음)</td><td>typography <code>bodyMedium</code> w700 · color <code>color-text-primary</code> · h-pad <code>spacing-screen-edge</code></td></tr>
         <tr><td>㉢</td><td>TicketStatusHeader</td><td>row · icon + label + count(우측)</td><td>typography <code>labelMedium</code>(label) / <code>bodySmall</code>(count) · color <code>color-text-secondary</code> · v-pad <code>spacing-small</code></td></tr>
         <tr><td>㉣㉤</td><td>TicketListItem</td><td>풀폭 카드 · row 안</td><td>radius <code>radius-card</code> · border outlineVariant · padding <code>spacing-medium</code> · 카드 사이 <code>spacing-small (8)</code></td></tr>
         <tr><td>㉥</td><td>AddActionCard (trailing)</td><td>풀폭 · 항상 리스트 끝에</td><td>radius <code>radius-input</code> · 보라 dashed border · padding <code>spacing-medium</code> · top margin <code>spacing-xxsmall</code></td></tr>
@@ -938,115 +1633,6 @@ body.dark-mode .viewport {
     </table>
   </section>
 
-  <section class="doc">
-    <h2>Applications tab anatomy (Tab 2)</h2>
-    <p class="intro">
-      "참가 신청" 탭의 본문은 들어온 신청을 두 묶음으로 나눠 보여주는 리스트다 — 위쪽 "심사 대기 중 (N)" 그룹은 파트너의 즉시 액션이 필요한 신청만, 아래쪽 "처리 완료 (N)" 그룹은 이미 승인 / 거절 / 결제완료된 신청을 정리한 묶음이다.
-      각 신청 카드는 좌측 원형 아바타(이름 첫 글자) + 가운데 이름 / 성별·생년 + 우측에 작은 상태 뱃지로 구성된다.
-      심사 대기 카드만 탭 가능하고, 탭하면 같은 화면 위에 심사 다이얼로그가 뜬다 — 거기서 승인/거절을 누르면 다이얼로그가 닫히고 SnackBar가 잠깐 떴다 사라지면서 카드가 자동으로 "처리 완료" 그룹으로 옮겨간다.
-      신청이 하나도 없는 이벤트는 두 묶음 헤더 자체가 사라지고 가운데 한 줄짜리 안내 텍스트만 남는다.
-    </p>
-    <div class="layout-grid">
-      <div class="blueprint" style="height: 320px;">
-        <div class="blueprint__region blueprint__region--full"></div>
-
-        <!-- Pending group title -->
-        <div class="blueprint__region blueprint__region--shaded" style="top:16px;left:16px;width:160px;height:24px;">
-          <span class="blueprint__region-label" style="font-size:10px;">㉠ '심사 대기 중 (3)' — titleMedium · bold</span>
-        </div>
-        <!-- Pending cards -->
-        <div class="blueprint__region blueprint__region--shaded" style="top:48px;left:16px;right:16px;height:56px;">
-          <span class="blueprint__region-label" style="font-size:10px;">㉡ ApplicationCard #1 — 심사 대기 (탭 가능)</span>
-        </div>
-        <div class="blueprint__region blueprint__region--shaded" style="top:112px;left:16px;right:16px;height:56px;">
-          <span class="blueprint__region-label" style="font-size:10px;">㉢ ApplicationCard #2 — 심사 대기</span>
-        </div>
-
-        <!-- Group gap -->
-        <div class="blueprint__align-marker" style="top:184px;right:8px;">↕ spacing-large (24) — 그룹 사이</div>
-
-        <!-- Done group title -->
-        <div class="blueprint__region blueprint__region--shaded" style="top:200px;left:16px;width:130px;height:24px;">
-          <span class="blueprint__region-label" style="font-size:10px;">㉣ '처리 완료 (5)' — outline color</span>
-        </div>
-        <!-- Done card -->
-        <div class="blueprint__region blueprint__region--shaded" style="top:232px;left:16px;right:16px;height:56px;">
-          <span class="blueprint__region-label" style="font-size:10px;">㉤ ApplicationCard #3 — 결제완료 (탭 비활성)</span>
-        </div>
-
-        <div class="blueprint__align-marker" style="top:8px;right:8px;">list padding 16</div>
-      </div>
-
-      <div class="layout-tree"><b>EventApplicationListView</b>(eventId)
-└─ <code>MinglitAsyncValueWidget</code>(applicationsAsync)
-   ├─ loading: full-page spinner
-   ├─ error: full-page error state
-   └─ data:
-      ├─ <em>case A — 빈 상태</em>
-      │  └─ Center → Text('신청 내역이 없습니다.')
-      │
-      └─ <em>case B — 데이터 있음</em>
-         └─ ListView(padding: <i>spacing-medium (16)</i>)
-            ├─ <em>Pending group</em> (if pendingReviews.isNotEmpty)
-            │  ├─ Text('심사 대기 중 (N)')                  ← ㉠
-            │  │  · <i>titleMedium · w700 · text-primary</i>
-            │  ├─ SizedBox(<i>spacing-small (8)</i>)
-            │  ├─ <b>_ApplicationCard</b> × N             ← ㉡㉢
-            │  │  · onTap → <b>showDialog</b>(<code>EventApplicationReviewDialog</code>)
-            │  │  · 다이얼로그 결과 → 승인/거절 처리 → 카드가 다른 그룹으로 이동
-            │  └─ SizedBox(<i>spacing-large (24)</i>)
-            │
-            └─ <em>Completed group</em> (if others.isNotEmpty)
-               ├─ Text('처리 완료 (N)')                    ← ㉣
-               │  · <i>titleMedium · color outline (회색 톤)</i>
-               ├─ SizedBox(<i>spacing-small</i>)
-               └─ <b>_ApplicationCard</b> × N             ← ㉤
-                  · status: approved / paid / rejected
-                  · onTap: null (탭 무반응)
-
-<em>각 _ApplicationCard 내부:</em>
-└─ Card(margin bottom: spacing-small)
-   └─ ListTile
-      ├─ leading: <b>CircleAvatar</b>
-      │  · bg: primaryContainer
-      │  · child: 이름 첫 글자 (한 글자) — onPrimaryContainer
-      ├─ title: Text(user.name) <i>· bodyMedium</i>
-      ├─ subtitle: Text('남/여 · YYYY-MM-DD')
-      └─ trailing: <b>_StatusBadge</b>
-         · 박스 (radius-small · border 1px · padding small/xxsmall)
-         · 라벨 색·테두리: status별 매핑
-            · pending_review → '심사 중' · warning 톤
-            · approved       → '승인됨' · success 톤
-            · paid           → '결제완료' · primary 톤
-            · rejected       → '거절됨' · error 톤
-            · 그 외          → 원래 status string · outline 톤
-
-<em>심사 처리 후:</em>
-· 승인/거절 성공 → SnackBar('심사 처리가 완료되었습니다.') 노출
-· 신청 리스트 자동 새로고침 (해당 카드가 처리 완료 그룹으로 이동)
-· 실패 → 에러 처리 (공통 에러 핸들러로 위임)</div>
-    </div>
-
-    <table class="ref" style="margin-top: 16px;">
-      <thead>
-        <tr>
-          <th style="width: 60px;">#</th>
-          <th style="width: 200px;">Region</th>
-          <th style="width: 220px;">Alignment</th>
-          <th>Spacing / tokens</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr><td>—</td><td>List 외곽</td><td>풀폭 column · 자체 스크롤</td><td>padding all <code>spacing-medium (16)</code></td></tr>
-        <tr><td>㉠</td><td>Pending group title</td><td>좌측 정렬</td><td>typography <code>titleMedium</code> w700 <code>color-text-primary</code> · 하단 <code>spacing-small (8)</code></td></tr>
-        <tr><td>㉡㉢</td><td>Pending card</td><td>풀폭 Card · row(avatar/body/badge)</td><td>margin bottom <code>spacing-small</code> · ListTile 기본 padding · onTap 활성</td></tr>
-        <tr><td>—</td><td>그룹 사이 gap</td><td>—</td><td><code>spacing-large (24)</code></td></tr>
-        <tr><td>㉣</td><td>Completed group title</td><td>좌측 정렬</td><td>typography <code>titleMedium</code> · color <code>color-outline</code> (회색 톤) · 하단 <code>spacing-small</code></td></tr>
-        <tr><td>㉤</td><td>Completed card</td><td>풀폭 Card · 동일 골격</td><td>onTap: null (탭 비활성) · 그 외 동일</td></tr>
-        <tr><td>—</td><td>빈 상태</td><td>가운데 정렬 1줄</td><td>'신청 내역이 없습니다.' <code>bodyMedium</code> <code>color-text-secondary</code></td></tr>
-      </tbody>
-    </table>
-  </section>
 </div>
 
 <!-- ============================================================
@@ -1057,14 +1643,14 @@ body.dark-mode .viewport {
     <span class="glyph">🎨</span>
     <h2>States</h2>
     <span class="lede">
-      5 state (Default 운영 관리 · Tab 2 신청 활성 · 신청 비어있음 · Loading · Error). Default = baseline (운영 관리 탭 · 데이터 로드 완료 · 티켓 ≥ 1개 · 신청 ≥ 1개).
+      3 state (Default · Loading · Error). Default = baseline (데이터 로드 완료 · 티켓 ≥ 1개 · 신청 진행 중).
       각 state는 mini-table 6-row (조건/사용자액션/에지케이스/컴포넌트/토큰/노트). 나머지 state는 additive diff (<code>+</code> · <code>−</code> · <code>↔ X → Y</code> · <code>동일</code> · <code>—</code>).
     </span>
   </div>
 
   <section class="doc">
     <h2>State summary</h2>
-    <p class="intro">한눈에 5 state 비교. 자세한 사양은 아래 각 mini-table.</p>
+    <p class="intro">한눈에 6 state 비교. 자세한 사양은 아래 각 mini-table.</p>
     <table class="ref">
       <thead>
         <tr>
@@ -1075,11 +1661,12 @@ body.dark-mode .viewport {
         </tr>
       </thead>
       <tbody>
-        <tr class="is-baseline-tint"><td><strong>Default · 운영 관리</strong> 🎯</td><td>primary</td><td>Tab 1 활성 · 데이터 로드 · 티켓 ≥ 1</td><td>제목 + 메타 카드(5행) + 입장권 카드 N개 + Add 카드</td></tr>
-        <tr><td><strong>Tab 2 · 신청 활성</strong></td><td>tab-switched</td><td>Tab 2 활성 · 신청 ≥ 1</td><td>"심사 대기 중 (N)" + "처리 완료 (N)" 두 묶음 리스트, 카드별 상태 뱃지</td></tr>
-        <tr><td><strong>Tab 2 · 신청 비어있음</strong></td><td>empty</td><td>Tab 2 활성 · 신청 데이터 0건</td><td>가운데 안내 1줄만 (그룹 헤더 사라짐)</td></tr>
-        <tr><td><strong>Loading</strong></td><td>async</td><td>이벤트 데이터 로드 중</td><td>풀-스크린 spinner (AppBar+TabBar는 살아있음)</td></tr>
-        <tr><td><strong>Error</strong></td><td>network/server</td><td>이벤트 데이터 로드 실패</td><td>가운데 에러 안내 텍스트만 (탭 본문 미렌더)</td></tr>
+        <tr class="is-baseline-tint"><td><strong>Default · 모집</strong> 🎯</td><td>primary</td><td>이벤트 데이터 로드 · 상태 'scheduled' · 입장 그룹 ≥ 1 · 티켓 ≥ 1 · 신청 ≥ 1</td><td>제목 + chip(공개·모집·D-N) + Hero 일정/장소 + 참가 현황(심사하기·참가자 보기) + 기대 매출(전체+그룹별) + 입장 그룹별 카드 N개</td></tr>
+        <tr><td><strong>이벤트 취소됨</strong></td><td>cancelled</td><td>상태 'cancelled' (운영자 또는 시스템)</td><td>chip 모집 → 취소(error 빨강) + 정보 수정 / 심사하기 / 티켓 추가 / 티켓 row 탭 모두 숨김·비활성 · Hero ⚠️ 안내 · 매출 카드 라벨 '환불 완료' · 심사대기 metric은 운영자 모니터링용 유지</td></tr>
+        <tr><td><strong>이벤트 완료됨</strong></td><td>completed</td><td>상태 'completed' (cron auto-complete: end_time 도달)</td><td>chip 'outline 회색' + D+N · 정보 수정 / 심사하기 / 티켓 추가 / 티켓 row 탭 모두 숨김·비활성 · 매출 카드 라벨 '달성 매출' · 심사대기 metric 숨김 · '확정' → '참석' 라벨 전환</td></tr>
+        <tr><td><strong>신청 0건</strong></td><td>empty-applications</td><td>입장 그룹 ≥ 1 · 신청 데이터 0건</td><td>참가 현황 분수 0/N · capbar 빈 · 심사대기 metric 숨김 · 환불완료 metric 숨김 · 심사하기 CTA 숨김 · 참가자 보기 outline만</td></tr>
+        <tr><td><strong>Loading</strong></td><td>async</td><td>이벤트 데이터 로드 중</td><td>풀-스크린 spinner (AppBar는 살아있음)</td></tr>
+        <tr><td><strong>Error</strong></td><td>network/server</td><td>이벤트 데이터 로드 실패</td><td>가운데 에러 안내 텍스트 + retry (본문 미렌더)</td></tr>
       </tbody>
     </table>
   </section>
@@ -1087,7 +1674,7 @@ body.dark-mode .viewport {
   <section class="doc">
     <h2>States gallery</h2>
     <p class="intro">
-      각 state mini-table — mockup(rowspan=6) + 6 aspect rows. <strong>Default가 baseline</strong>; 나머지 4 states는 additive diff prefix 사용.
+      각 state mini-table — mockup(rowspan=6) + 6 aspect rows. <strong>Default · 모집이 baseline</strong>; 나머지 5 states는 additive diff prefix(↔ Default + ...) 사용.
     </p>
 
     <div class="visual-gallery" style="background: var(--color-surface); padding: 16px; border-radius: var(--radius-card); display: flex; flex-direction: column; gap: 16px;">
@@ -1102,293 +1689,752 @@ body.dark-mode .viewport {
         <tbody>
           <tr>
             <td rowspan="6" class="state-mini__mock"><div class="viewport">
-              <!-- AppBar -->
+              <!-- AppBar (TabBar 폐기 — 단일 스크롤) -->
               <div class="ped-appbar">
                 <div class="ped-appbar__back">
                   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
                 </div>
                 <div class="ped-appbar__title">이벤트 상세</div>
               </div>
-              <!-- TabBar -->
-              <div class="ped-tabbar">
-                <div class="ped-tab ped-tab--active">운영 관리</div>
-                <div class="ped-tab">참가 신청</div>
-              </div>
-              <!-- Body -->
+              <!-- Body (단일 스크롤) -->
               <div class="ped-body">
-                <!-- Title -->
-                <div class="ped-title">금요일 와인 클래스</div>
-                <!-- Detail info card -->
+                <!-- Title row: 이벤트 제목 단독 -->
+                <div class="ped-title-row">
+                  <div class="ped-title">금요일 와인 클래스</div>
+                </div>
+                <!-- Meta chips — title 아래, stable→dynamic 순 + 도메인별 색 -->
+                <div class="ped-meta-chips">
+                  <span class="ped-chip ped-chip--success ped-chip--visibility"><svg class="ped-chip__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>공개</span>
+                  <span class="ped-chip ped-chip--success">모집</span>
+                  <span class="ped-chip ped-chip--warning">D-12</span>
+                </div>
+                <!-- 정보 수정 link — Hero 카드 바로 위, 우측 정렬 -->
+                <div class="ped-edit-row">
+                  <a class="ped-edit-link">
+                    정보 수정
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+                  </a>
+                </div>
+                <!-- Hero 카드 (stacked blocks: caption / primary / secondary 위계) -->
                 <div class="ped-card">
-                  <div class="ped-row">
-                    <div class="ped-row__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></div>
-                    <div class="ped-row__label">일정 (날짜)</div>
-                    <div class="ped-row__value">2026년 05월 15일 (금)</div>
-                  </div>
-                  <div class="ped-divider"></div>
-                  <div class="ped-row">
-                    <div class="ped-row__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg></div>
-                    <div class="ped-row__label">시간</div>
-                    <div class="ped-row__value">오후 7:30 ~ 오후 9:30</div>
-                  </div>
-                  <div class="ped-divider"></div>
-                  <div class="ped-row">
-                    <div class="ped-row__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></div>
-                    <div class="ped-row__label">참가 현황</div>
-                    <div class="ped-row__value">확정 8명 / 신청 12명 (대기 4)</div>
-                  </div>
-                  <div class="ped-divider"></div>
-                  <div class="ped-row">
-                    <div class="ped-row__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg></div>
-                    <div class="ped-row__label">상태</div>
-                    <div class="ped-row__value ped-row__value--accent">예정됨</div>
-                  </div>
-                  <div class="ped-divider"></div>
-                  <div class="ped-row">
-                    <div class="ped-row__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></div>
-                    <div class="ped-row__label">공개 설정</div>
-                    <div class="ped-row__value">공개</div>
+                  <div class="ped-info-rows">
+                    <!-- 일정: 날짜(큰 강조) + 시간(보조) -->
+                    <div class="ped-info-block">
+                      <div class="ped-info-block__caption">일정</div>
+                      <div class="ped-info-block__primary">2026.05.15 (금)</div>
+                      <div class="ped-info-block__secondary">오후 7:30 ~ 9:30</div>
+                    </div>
+                    <!-- 장소: 이름 + 주소 + Kakao Map thumb (탭 → 외부 맵 앱 deep-link) -->
+                    <div class="ped-info-block">
+                      <div class="ped-info-block__caption">장소</div>
+                      <div class="ped-info-block__primary">강남 와인바</div>
+                      <div class="ped-info-block__secondary">서울 강남구 신사동 ...</div>
+                      <div class="ped-map-thumb" role="img" aria-label="강남 와인바 위치 미니맵 — 탭 시 외부 맵 앱으로 이동">
+                        <span class="ped-map-thumb__pin">
+                          <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5z"/></svg>
+                        </span>
+                      </div>
+                      <!-- 오시는길 — 도보·입구·주차·랜드마크 자유 텍스트 -->
+                      <div class="ped-directions">
+                        <div class="ped-directions__label">오시는길</div>
+                        <div class="ped-directions__text">강남역 3번 출구 도보 5분
+1층 카페 안쪽 와인바 입구 · 주차 가능</div>
+                      </div>
+                    </div>
                   </div>
                 </div>
-                <!-- Section header -->
+                <!-- Section header: 참가 현황 (link는 카드 안 actions로 이동) -->
                 <div class="ped-section-header">
-                  <div class="ped-section-header__title">입장권 관리</div>
-                  <div class="ped-section-header__trailing">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
-                    티켓 만들기
+                  <div class="ped-section-header__title">참가 현황</div>
+                </div>
+                <!-- Summary card — 이벤트 전체 정원/확정/심사대기 + 심사 CTA -->
+                <div class="ped-summary">
+                  <div class="ped-summary__head">
+                    <!-- Metric 1: 확정 분수 -->
+                    <span class="ped-summary__metric">
+                      <span class="ped-summary__count">6</span>
+                      <span class="ped-summary__count-total">/ 12 확정</span>
+                    </span>
+                    <!-- Metric 2: 심사대기 카운트 — pulse 강조 (≥1일 때만, 액션 시그널) -->
+                    <span class="ped-summary__metric">
+                      <span class="ped-summary__count ped-summary__count--pulse">4</span>
+                      <span class="ped-summary__count-total">심사대기</span>
+                    </span>
+                    <!-- Metric 3: 환불완료 — muted (이미 끝난 정보, 액션 X) -->
+                    <span class="ped-summary__metric ped-summary__metric--muted">
+                      <span class="ped-summary__count">3</span>
+                      <span class="ped-summary__count-total">환불완료</span>
+                    </span>
                   </div>
-                </div>
-                <!-- Status header -->
-                <div class="ped-ticket-stat">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
-                  <div class="ped-ticket-stat__label">총 발행 수량 / 정원</div>
-                  <div class="ped-ticket-stat__count">발행 18 / 정원 20</div>
-                </div>
-                <!-- Ticket cards -->
-                <div class="ped-ticket">
-                  <div class="ped-ticket__body">
-                    <div class="ped-ticket__name">얼리버드 입장권</div>
-                    <div class="ped-ticket__sub">
-                      <span>발행 8 / 8</span>
-                      <span>·</span>
-                      <span>일반 그룹</span>
+                  <!-- MinglitCapacityBar(total: 12, filled: 6, pending: 4) → segmented 12칸 (6 강 · 4 옅 · 2 빈) -->
+                  <div class="mds-capbar mds-capbar--segmented" role="progressbar" aria-label="정원 12명 중 확정 6명 · 대기 4명 · 남은 2명">
+                    <div class="mds-capbar__seg mds-capbar__seg--filled"></div>
+                    <div class="mds-capbar__seg mds-capbar__seg--filled"></div>
+                    <div class="mds-capbar__seg mds-capbar__seg--filled"></div>
+                    <div class="mds-capbar__seg mds-capbar__seg--filled"></div>
+                    <div class="mds-capbar__seg mds-capbar__seg--filled"></div>
+                    <div class="mds-capbar__seg mds-capbar__seg--filled"></div>
+                    <div class="mds-capbar__seg mds-capbar__seg--pending"></div>
+                    <div class="mds-capbar__seg mds-capbar__seg--pending"></div>
+                    <div class="mds-capbar__seg mds-capbar__seg--pending"></div>
+                    <div class="mds-capbar__seg mds-capbar__seg--pending"></div>
+                    <div class="mds-capbar__seg"></div>
+                    <div class="mds-capbar__seg"></div>
+                  </div>
+                  <!-- Actions: 심사하기 (primary CTA, 액션 시그널) + 참가자 보기 (outline, 보조 진입) -->
+                  <div class="ped-summary__actions">
+                    <!-- 심사하기 — 심사 대기 ≥1일 때만 primary fill로 강조 (그렇지 않으면 숨김) -->
+                    <div class="ped-summary__cta">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+                      <span>심사하기</span>
+                    </div>
+                    <!-- 참가자 보기 — 항상 노출, outline (환불 요청 등 유저별 처리 진입) -->
+                    <div class="ped-summary__cta ped-summary__cta--outline">
+                      <span>참가자 보기</span>
                     </div>
                   </div>
-                  <div class="ped-ticket__price">35,000원</div>
                 </div>
-                <div class="ped-ticket">
-                  <div class="ped-ticket__body">
-                    <div class="ped-ticket__name">정상가 입장권</div>
-                    <div class="ped-ticket__sub">
-                      <span>발행 10 / 12</span>
-                      <span>·</span>
-                      <span>일반 그룹</span>
+
+                <!-- Section header: 기대 매출 (다른 섹션과 동일한 패턴 — 카드 밖 헤더) -->
+                <div class="ped-section-header">
+                  <div class="ped-section-header__title">기대 매출</div>
+                </div>
+                <!-- 기대 매출 카드 (페이지 하단 — 운영자 KPI 요약) -->
+                <!-- 계산: 얼리버드 35,000×4=140,000 / 정상가 45,000×8=360,000 / VIP 120,000×4=480,000
+                     최대 매출 980,000원
+                     현재 (판매 결제완료): 35,000×3 + 45,000×1 + 120,000×2 = 390,000원
+                     대기 (승인 시 결제 잠재): 35,000×1 + 45,000×1 + 120,000×2 = 320,000원 -->
+                <div class="ped-revenue">
+                  <div class="ped-revenue__head">
+                    <span class="ped-revenue__current">390,000원</span>
+                    <span class="ped-revenue__max">/ 최대 980,000원</span>
+                  </div>
+                  <!-- MinglitCapacityBar(total: 980, filled: 390, pending: 320) — 980 > 30 → continuous fallback -->
+                  <div class="mds-capbar" role="progressbar" aria-label="최대 매출 980,000원 중 현재 390,000원 · 심사 승인 시 잠재 320,000원">
+                    <div class="mds-capbar__fill" style="width: 39.8%;"></div>
+                    <div class="mds-capbar__pending" style="width: 32.7%;"></div>
+                  </div>
+                  <div class="ped-revenue__breakdown">
+                    <span>현재 <strong>390,000원</strong></span>
+                    <span>심사 승인 시 <strong>+320,000원</strong></span>
+                  </div>
+                  <!-- 그룹별 기대 매출 — 전체 카드 안 sub-section -->
+                  <!-- 계산:
+                       일반 그룹 = 얼리버드(35,000×4=140,000) + 정상가(45,000×8=360,000) = 500,000원 max
+                                  현재(35,000×3 + 45,000×1) = 150,000원 / 대기 80,000원
+                       VIP 그룹  = 120,000×4 = 480,000원 max
+                                  현재 240,000원 / 대기 240,000원 -->
+                  <div class="ped-revenue__groups">
+                    <div class="ped-revenue__group">
+                      <div class="ped-revenue__group-row">
+                        <span class="ped-revenue__group-name">일반 그룹</span>
+                        <span class="ped-revenue__group-amount">150,000원</span>
+                        <span class="ped-revenue__group-amount-max">/ 최대 500,000원</span>
+                      </div>
+                      <!-- MinglitCapacityBar(total: 500000, filled: 150000, pending: 80000) — continuous (큰 숫자) -->
+                      <div class="mds-capbar" role="progressbar" aria-label="일반 그룹 최대 매출 500,000원 중 현재 150,000원 · 대기 80,000원">
+                        <div class="mds-capbar__fill" style="width: 30%;"></div>
+                        <div class="mds-capbar__pending" style="width: 16%;"></div>
+                      </div>
+                    </div>
+                    <div class="ped-revenue__group">
+                      <div class="ped-revenue__group-row">
+                        <span class="ped-revenue__group-name">VIP 그룹</span>
+                        <span class="ped-revenue__group-amount">240,000원</span>
+                        <span class="ped-revenue__group-amount-max">/ 최대 480,000원</span>
+                      </div>
+                      <!-- MinglitCapacityBar(total: 480000, filled: 240000, pending: 240000) — continuous -->
+                      <div class="mds-capbar" role="progressbar" aria-label="VIP 그룹 최대 매출 480,000원 중 현재 240,000원 · 대기 240,000원">
+                        <div class="mds-capbar__fill" style="width: 50%;"></div>
+                        <div class="mds-capbar__pending" style="width: 50%;"></div>
+                      </div>
                     </div>
                   </div>
-                  <div class="ped-ticket__price">45,000원</div>
                 </div>
-                <!-- Add card (trailing) -->
-                <div class="ped-add" style="margin-top:8px;">
-                  <div class="ped-add__icon">
+                <!-- Section header: 입장 그룹별 현황 -->
+                <div class="ped-section-header">
+                  <div class="ped-section-header__title">입장 그룹별 현황</div>
+                </div>
+                <!-- 입장 그룹들을 단일 카드로 묶고 그룹 사이는 divider 자동 (CSS .ped-group + .ped-group) -->
+                <div class="ped-group-list">
+                <!-- Entry group #1 — 일반 그룹 -->
+                <div class="ped-group">
+                  <div class="ped-group__head">
+                    <div class="ped-group__name">일반 그룹</div>
+                    <div>
+                      <span class="ped-group__count">4</span>
+                      <span class="ped-group__count-total">/ 8 확정</span>
+                    </div>
+                    <div class="ped-group__chevron">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+                    </div>
+                  </div>
+                  <!-- MinglitCapacityBar(total: 8, filled: 4, pending: 2) -->
+                  <div class="mds-capbar mds-capbar--segmented" role="progressbar" aria-label="정원 8명 중 확정 4명 · 대기 2명 · 남은 2명">
+                    <div class="mds-capbar__seg mds-capbar__seg--filled"></div>
+                    <div class="mds-capbar__seg mds-capbar__seg--filled"></div>
+                    <div class="mds-capbar__seg mds-capbar__seg--filled"></div>
+                    <div class="mds-capbar__seg mds-capbar__seg--filled"></div>
+                    <div class="mds-capbar__seg mds-capbar__seg--pending"></div>
+                    <div class="mds-capbar__seg mds-capbar__seg--pending"></div>
+                    <div class="mds-capbar__seg"></div>
+                    <div class="mds-capbar__seg"></div>
+                  </div>
+                  <div class="ped-group__breakdown">
+                    <span>확정 <strong>4</strong></span>
+                    <span>대기 <strong>2</strong></span>
+                    <span class="ped-group__breakdown-item--muted">환불 <strong>2</strong></span>
+                  </div>
+                  <div class="ped-group__nest">
+                    <div class="ped-group__tickets">
+                    <!-- Ticket row — 탭 시 TicketEditRoute. mini CapacityBar: 판매(강) + 대기(옅) + 빈 -->
+                    <!-- 얼리버드: 발행 4, 판매 3, 대기 1 → 그룹 확정 4 = 3+1(VIP의 1?) — 합산 검증: 일반 그룹 확정 4 = 얼리버드 3 + 정상가 1 ✓ / 대기 2 = 얼리버드 1 + 정상가 1 ✓ -->
+                    <div class="ped-group__ticket">
+                      <div class="ped-group__ticket-row">
+                        <div class="ped-group__ticket-name">
+                          얼리버드 입장권
+                          <span class="ped-group__ticket-sub">판매 3 · 대기 1 / 발행 4장</span>
+                        </div>
+                        <div class="ped-group__ticket-price">35,000원</div>
+                        <div class="ped-group__ticket-chevron">
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+                        </div>
+                      </div>
+                      <!-- MinglitCapacityBar(total: 4 발행, filled: 3 판매, pending: 1 대기) — 거의 마감 -->
+                      <div class="mds-capbar mds-capbar--segmented" style="height:4px;" role="progressbar" aria-label="발행 4장 중 판매 3장 · 대기 1장">
+                        <div class="mds-capbar__seg mds-capbar__seg--filled"></div>
+                        <div class="mds-capbar__seg mds-capbar__seg--filled"></div>
+                        <div class="mds-capbar__seg mds-capbar__seg--filled"></div>
+                        <div class="mds-capbar__seg mds-capbar__seg--pending"></div>
+                      </div>
+                    </div>
+                    <div class="ped-group__ticket">
+                      <div class="ped-group__ticket-row">
+                        <div class="ped-group__ticket-name">
+                          정상가 입장권
+                          <span class="ped-group__ticket-sub">판매 1 · 대기 1 / 발행 8장</span>
+                        </div>
+                        <div class="ped-group__ticket-price">45,000원</div>
+                        <div class="ped-group__ticket-chevron">
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+                        </div>
+                      </div>
+                      <!-- MinglitCapacityBar(total: 8 발행, filled: 1 판매, pending: 1 대기) — 신청 적음 -->
+                      <div class="mds-capbar mds-capbar--segmented" style="height:4px;" role="progressbar" aria-label="발행 8장 중 판매 1장 · 대기 1장">
+                        <div class="mds-capbar__seg mds-capbar__seg--filled"></div>
+                        <div class="mds-capbar__seg mds-capbar__seg--pending"></div>
+                        <div class="mds-capbar__seg"></div>
+                        <div class="mds-capbar__seg"></div>
+                        <div class="mds-capbar__seg"></div>
+                        <div class="mds-capbar__seg"></div>
+                        <div class="mds-capbar__seg"></div>
+                        <div class="mds-capbar__seg"></div>
+                      </div>
+                    </div>
+                    </div>
+                  </div>
+
+                  <div class="ped-group__add">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
-                  </div>
-                  <div class="ped-add__text">
-                    <div class="ped-add__title">티켓 추가</div>
-                    <div class="ped-add__sub">남은 정원만큼 더 만들 수 있어요.</div>
+                    이 그룹에 티켓 추가
                   </div>
                 </div>
+                <!-- Entry group card #2 — VIP 그룹 (alert 제거됨) -->
+                <div class="ped-group">
+                  <div class="ped-group__head">
+                    <div class="ped-group__name">VIP 그룹</div>
+                    <div>
+                      <span class="ped-group__count">2</span>
+                      <span class="ped-group__count-total">/ 4 확정</span>
+                    </div>
+                    <div class="ped-group__chevron">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+                    </div>
+                  </div>
+                  <!-- MinglitCapacityBar(total: 4, filled: 2, pending: 2) -->
+                  <div class="mds-capbar mds-capbar--segmented" role="progressbar" aria-label="정원 4명 중 확정 2명 · 대기 2명 · 남은 0명">
+                    <div class="mds-capbar__seg mds-capbar__seg--filled"></div>
+                    <div class="mds-capbar__seg mds-capbar__seg--filled"></div>
+                    <div class="mds-capbar__seg mds-capbar__seg--pending"></div>
+                    <div class="mds-capbar__seg mds-capbar__seg--pending"></div>
+                  </div>
+                  <div class="ped-group__breakdown">
+                    <span>확정 <strong>2</strong></span>
+                    <span>대기 <strong>2</strong></span>
+                    <span class="ped-group__breakdown-item--muted">환불 <strong>1</strong></span>
+                  </div>
+                  <div class="ped-group__nest">
+                    <div class="ped-group__tickets">
+                    <div class="ped-group__ticket">
+                      <div class="ped-group__ticket-row">
+                        <div class="ped-group__ticket-name">
+                          VIP 입장권
+                          <span class="ped-group__ticket-sub">판매 2 · 대기 2 / 발행 4장</span>
+                        </div>
+                        <div class="ped-group__ticket-price">120,000원</div>
+                        <div class="ped-group__ticket-chevron">
+                          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+                        </div>
+                      </div>
+                      <!-- MinglitCapacityBar(total: 4 발행, filled: 2 판매, pending: 2 대기) — 꽉참 -->
+                      <div class="mds-capbar mds-capbar--segmented" style="height:4px;" role="progressbar" aria-label="발행 4장 중 판매 2장 · 대기 2장 (꽉참)">
+                        <div class="mds-capbar__seg mds-capbar__seg--filled"></div>
+                        <div class="mds-capbar__seg mds-capbar__seg--filled"></div>
+                        <div class="mds-capbar__seg mds-capbar__seg--pending"></div>
+                        <div class="mds-capbar__seg mds-capbar__seg--pending"></div>
+                      </div>
+                    </div>
+                    </div>
+                  </div>
+
+                  <div class="ped-group__add">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                    이 그룹에 티켓 추가
+                  </div>
+                </div>
+                </div><!-- /.ped-group-list -->
               </div>
 
               <!-- Spec annotations -->
               <span class="annotation" style="top:14px;right:8px;">centerTitle: false</span>
-              <span class="annotation" style="top:60px;right:8px;">2탭 flex equal</span>
-              <span class="annotation" style="top:120px;left:8px;">title: headlineSmall · primary</span>
-              <span class="annotation" style="top:200px;right:8px;">card border + radius 16</span>
+              <span class="annotation" style="top:80px;left:8px;">title: headlineSmall · primary</span>
+              <span class="annotation" style="top:200px;right:8px;">Hero card · 탭 → EventEditRoute</span>
+              <span class="annotation" style="top:330px;right:8px;">참가 현황 카드 · 탭 → EventApplicationListRoute</span>
 
               <!-- Callouts -->
               <span class="callout" style="top:14px;left:8px;">ⓐ</span>
-              <span class="callout" style="top:60px;left:8px;">ⓑ</span>
+              <span class="callout" style="top:80px;left:8px;">ⓑ</span>
               <span class="callout" style="top:115px;left:8px;">ⓒ</span>
               <span class="callout" style="top:165px;right:8px;">ⓓ</span>
               <span class="callout" style="top:380px;left:8px;">ⓔ</span>
             </div></td>
             <td class="state-mini__aspect">조건</td>
-            <td>운영 관리(Tab 1) 활성 · 이벤트 데이터 로드 완료 · 티켓 1개 이상 발행됨 · 상태는 "예정됨"(scheduled).</td>
+            <td>이벤트 데이터 로드 완료 · 입장 그룹 ≥1개 (각 그룹은 정원·티켓·신청 메타 보유) · 상태 "모집 중"(scheduled) · D-N (이벤트 시작까지 남은 일수).</td>
           </tr>
           <tr>
             <td class="state-mini__aspect">사용자 액션</td>
             <td>
-              · <strong>탭 #2 ('참가 신청') 탭</strong> → 본문이 즉시 신청 리스트로 갈아끼워짐<br>
-              · <strong>"+ 티켓 만들기" 버튼 탭</strong> → <a href="/specs/ticket_create_page.html">TicketCreatePage</a>로 이동<br>
-              · <strong>입장권 카드 탭</strong> → <a href="/specs/ticket_edit_page.html">TicketEditPage</a>로 이동 (해당 티켓 선택 상태)<br>
-              · <strong>리스트 끝 "+ 추가" 카드 탭</strong> → "+ 티켓 만들기"와 동일한 화면으로 이동<br>
+              · <strong>공개/비공개 chip 탭</strong> → 설명 토스트 노출 (3초 자동 사라짐, MinglitToast)<br>
+              · <strong>Hero 카드 "정보 수정 ›" 링크 탭</strong> → <a href="/specs/event_edit_page.html">EventEditPage</a>로 이동 (확정 참가자 ≥1명이면 잠금 정책)<br>
+              · <strong>"심사하기" CTA 탭</strong> (대기 ≥1일 때만 노출, primary fill) → <a href="/specs/event_application_list_page.html">EventApplicationListPage</a>로 이동 (심사 대기 그룹 anchor)<br>
+              · <strong>"참가자 보기" 버튼 탭</strong> (항상 노출, outline) → 같은 EventApplicationListPage로 이동 (전체 — 환불 요청 / 유저별 액션 진입)<br>
+              · <strong>입장 그룹 카드 탭</strong> → EventApplicationListPage로 이동 (해당 그룹 필터)<br>
+              · <strong>티켓 행 탭</strong> → <a href="/specs/ticket_edit_page.html">TicketEditPage</a>로 이동 (해당 티켓 선택 — 가격·발행수 수정 가능)<br>
+              · <strong>"+ 이 그룹에 티켓 추가" 탭</strong> → <a href="/specs/ticket_create_page.html">TicketCreatePage</a>로 이동 (해당 그룹 사전 선택)<br>
               · <strong>뒤로가기</strong> → 파티 상세로 복귀
             </td>
           </tr>
-          <tr><td class="state-mini__aspect">에지케이스</td><td>· 라벨/값이 길어지면 2줄까지 줄바꿈 후 ellipsis<br>· 제목 비어있으면 제목 블록 통째로 사라짐 (카드가 위로 붙음)<br>· 정원이 정해지지 않은 이벤트는 status header가 사라지고 바로 카드부터 시작</td></tr>
+          <tr><td class="state-mini__aspect">에지케이스</td><td>· 그룹 안 티켓 0개면 티켓 리스트 자리에 작은 안내 텍스트 + 추가 버튼만<br>· <strong>참가 현황 카드 — 대기 0건이면 심사 링크 영역 숨김</strong> (분수 / CapacityBar / breakdown 유지)<br>· <strong>참가 현황 카드 — 신청 0건이면 분수 "0 / 정원", CapacityBar 빈 상태</strong>, 심사 링크 숨김<br>· 그룹 카드 — 신청 0건이면 분수 "0 / N", 빈 CapacityBar (alert는 본 spec에서 폐기)<br>· CapacityBar: 정원 ≤ segmentThreshold(30) → segmented · 초과 → continuous 자동 분기<br>· 제목 비어있으면 제목 블록 통째로 사라짐 (카드가 위로 붙음)<br>· 티켓 발행수가 정원 이상 (티켓 ≥ 정원 정책) — UI는 발행수가 정원 미만이면 안내</td></tr>
           <tr>
             <td class="state-mini__aspect">컴포넌트</td>
             <td>
-              <code>Scaffold</code> · <code>AppBar</code>(left-aligned title + bottom TabBar) · <code>DefaultTabController(length: 2)</code> · <code>TabBarView</code> · <code>MinglitAsyncValueWidget</code> · <code>SingleChildScrollView</code> · <code>MinglitContentLayout</code> · 운영 메타 카드(border container · 5 <code>_DetailRow</code> + Divider) · <code>MinglitSection</code>(title + trailing TextButton.icon) · <code>TicketListView</code> · <code>TicketStatusHeader</code> · <code>TicketListItem</code> × N · <code>AddActionCard</code>(trailing)
+              <code>Scaffold</code> · <code>AppBar</code>(left-aligned title only — TabBar 폐기) · <code>MinglitAsyncValueWidget</code> · <code>SingleChildScrollView</code> · <code>MinglitContentLayout</code> · 이벤트 title + <code>_VisibilityChip</code>(공개/비공개 — title 우측 inline) · 운영 메타 카드(<code>InkWell</code> → EventEditRoute · 1 <code>_HeroDetailRow</code>(D-day trail) + 1 Divider + 1 <code>_MetaDetailRow</code>(상태)) · <code>MinglitSection</code>(title '참가 현황') · <code>EventApplicationStatsCard</code>(전체 분수 + <code>MinglitCapacityBar</code>(확정+대기) + breakdown(확정·대기 — '거절 0'은 노이즈라 숨김, ≥1일 때만 노출) + 심사 대기 ≥1 시 <code>_ReviewCtaButton</code>('심사하기' · primary fill · h44 · radius-button) → EventApplicationListRoute) · <code>MinglitSection</code>(title '입장 그룹별 현황') · <code>EntryGroupCard</code> × N (분수 + <code>MinglitCapacityBar</code>(확정+대기) + breakdown + 티켓 row × N(<code>InkWell</code> → TicketEditRoute · Column[Row(이름 w600 + 'N · M / K장' sub / 가격 / chevron) + mini <code>MinglitCapacityBar</code>(판매+대기/발행)]) + "이 그룹에 티켓 추가" 버튼(dashed primary border · h44 · radius-button) / <code>InkWell</code> → EventApplicationListRoute(groupId)) · <code>_RevenueSummaryCard</code>(현재 매출 큰 숫자 + '/ 최대' suffix + continuous <code>MinglitCapacityBar</code>(현재 강 + 심사 승인 시 옅) + breakdown('현재 KKK원 · 심사 승인 시 +KKK원'))
             </td>
           </tr>
           <tr>
             <td class="state-mini__aspect">토큰</td>
             <td>
-              <code>color-primary</code> (partner #6c3ce1 — 제목 / 활성 탭 / 상태값(예정됨) / Add 카드 강조) · <code>color-text-primary</code> (값) · <code>color-text-secondary</code> (라벨 / sub) · <code>color-divider</code> (카드 border / divider) · <code>color-surface</code> (카드 bg) · <code>color-background</code> (scaffold) · <code>radius-card (16)</code> (메타 카드 / 티켓 카드) · <code>radius-input (12)</code> (Add 카드) · <code>radius-small (8)</code> (status badge) · <code>spacing-screen-edge (16)</code> · <code>spacing-medium (16)</code> · <code>spacing-small (8)</code> · <code>spacing-xsmall (4)</code> · <code>spacing-xxsmall (2)</code> · typography <code>titleMedium</code> w700 (AppBar title) · <code>headlineSmall</code> w700 (이벤트 title) · <code>bodyMedium</code> w700 (라벨) / 기본 (값) · <code>labelMedium</code> (status header) · <code>bodySmall</code> (count) · <code>bodyMedium</code> (탭 라벨) · iconSize <code>small (≈18)</code>
+              <code>color-primary</code> (partner #6c3ce1 — D-day trail / 상태값(모집 중) / 진행 바 확정 fill / "+ 그룹에 티켓 추가" border + label) · <code>color-primary @ 30%</code> (진행 바 대기 — 옅은 누적) · <code>color-primary @ 10%</code> (D-day trail bg) · <code>color-text-primary</code> (이벤트 title / Hero primary / Supporting value / 그룹 이름 / 그룹 count) · <code>color-text-secondary</code> (Hero icon / Hero secondary / Supporting label / 분수 분모 / breakdown / 티켓 sub / 공개 footer) · <code>color-divider</code> (카드 border / divider / 진행 바 track) · <code>color-surface</code> (카드 bg) · <code>color-warning</code> rgba 톤 (심사 대기 alert) · <code>radius-card (16)</code> (모든 카드) · <code>radius-input (12)</code> (티켓 추가 dashed border) · <code>radius-small (8)</code> (alert / D-day trail / 진행 바) · <code>spacing-screen-edge (16)</code> · <code>spacing-medium</code> · <code>spacing-small</code> · typography <strong>이벤트 title</strong>: 20px w600(<code>color-text-primary</code> — 일반 텍스트 톤) · <strong>Hero</strong>: 16px w600 / 13px secondary · <strong>D-day trail</strong>: 13px w700 primary · <strong>상태 row</strong>: 12px w500 (label) / 14px w700 + accent (value) · <strong>섹션 헤더</strong>: <code>bodyMedium</code> w700 · <strong>그룹 카드</strong>: 14px w600(이름/count) / 12px(분모/breakdown/alert) · <strong>티켓 row</strong>: 14px(이름) / 12px secondary(sub) / 14px w600(가격) · <strong>티켓 추가 버튼</strong>: 13px w600 primary · <strong>공개 footer</strong>: 11px secondary · iconSize: Hero <code>small (≈18)</code>
             </td>
           </tr>
-          <tr><td class="state-mini__aspect">노트</td><td>—</td></tr>
+          <tr><td class="state-mini__aspect">노트</td><td>🎨 톤 다운: 이벤트 title은 일반 텍스트(primary X). Hero 일정도 16px w600으로 차분하게. <strong>primary 강조 = D-day trail + 상태 accent + CapacityBar fill + 티켓 추가 dashed border (h44 CTA와 동일) + 심사 CTA fill</strong> — 두 액션 버튼 같은 typography/h44 통일. 정보 위계: <strong>이벤트 title(공개 chip 옆에) → Hero(일정/상태) → 참가 현황(전체 — 심사 CTA로 즉시 액션) → 입장 그룹별 현황(그룹 단위 책임 + 티켓 가격/발행수 수정) → 기대 매출(KPI 요약)</strong>. breakdown에서 "거절 0"은 표시 X (≥1일 때만 노출 — 노이즈 제거). 티켓 row는 InkWell + chevron으로 탭 affordance 명확화 — TicketEditRoute로 이동해 가격·발행수 수정. CapacityBar 의미 4계층: 전체(이벤트 정원/확정+대기 · segmented) · 그룹(그룹 정원/확정+대기 · segmented) · 티켓 mini(발행수/판매+대기 · segmented) · 매출(최대 매출/현재+잠재 · 큰 숫자라 자동 continuous). 모두 같은 컴포넌트, 의미만 도메인별로 다름.</td></tr>
         </tbody>
       </table>
 
       <!-- ===================================================
-           STATE 2 — Tab 2 신청 활성
+           STATE 2 — 이벤트 취소됨
            =================================================== -->
       <table class="ref state-mini">
         <thead>
-          <tr><th colspan="3"><strong>Tab 2 · 신청 활성</strong> <span class="tag tag--mute">tab-switched</span> · <small>신청 묶음 2개 (심사 대기 + 처리 완료)</small></th></tr>
+          <tr><th colspan="3"><strong>이벤트 취소됨</strong> <span class="tag tag--mute">cancelled</span></th></tr>
         </thead>
         <tbody>
           <tr>
             <td rowspan="6" class="state-mini__mock"><div class="viewport">
               <div class="ped-appbar">
-                <div class="ped-appbar__back">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
-                </div>
+                <div class="ped-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg></div>
                 <div class="ped-appbar__title">이벤트 상세</div>
               </div>
-              <div class="ped-tabbar">
-                <div class="ped-tab">운영 관리</div>
-                <div class="ped-tab ped-tab--active">참가 신청</div>
-              </div>
-              <div class="ped-body" style="padding-top:0;">
-                <div class="ped-app-section">
-                  <div class="ped-app-section__title">심사 대기 중 (3)</div>
-                  <!-- Pending card 1 -->
-                  <div class="ped-app-card">
-                    <div class="ped-app-card__avatar">김</div>
-                    <div class="ped-app-card__body">
-                      <div class="ped-app-card__name">김민지</div>
-                      <div class="ped-app-card__sub">여 · 1996-03-12</div>
+              <div class="ped-body">
+                <div class="ped-meta-chips">
+                  <span class="ped-chip ped-chip--success ped-chip--visibility"><svg class="ped-chip__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>공개</span>
+                  <span class="ped-chip ped-chip--error">취소</span>
+                  <span class="ped-chip ped-chip--outline">D-12</span>
+                </div>
+                <div class="ped-title-row">
+                  <div class="ped-title">금요일 와인 클래스</div>
+                </div>
+                <!-- 정보 수정 link 숨김 (취소 상태) -->
+                <!-- ⚠️ 취소 안내 banner — title 바로 밑 -->
+                <div class="ped-cancel-notice">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+                  <span>이벤트가 취소되었습니다 — 결제 사용자에게 환불이 자동 진행됩니다.</span>
+                </div>
+                <!-- Hero 카드 — 일정/장소 정상 (line-through X). 장소 block에 Kakao Map + 오시는길 -->
+                <div class="ped-card">
+                  <div class="ped-info-rows">
+                    <div class="ped-info-block">
+                      <div class="ped-info-block__caption">일정</div>
+                      <div class="ped-info-block__primary">2026.05.15 (금)</div>
+                      <div class="ped-info-block__secondary">오후 7:30 ~ 9:30</div>
                     </div>
-                    <div class="ped-app-card__badge ped-app-card__badge--pending">심사 중</div>
+                    <div class="ped-info-block">
+                      <div class="ped-info-block__caption">장소</div>
+                      <div class="ped-info-block__primary">강남 와인바</div>
+                      <div class="ped-info-block__secondary">서울 강남구 신사동 ...</div>
+                      <div class="ped-map-thumb" role="img" aria-label="강남 와인바 위치 미니맵">
+                        <span class="ped-map-thumb__pin"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5z"/></svg></span>
+                      </div>
+                      <div class="ped-directions">
+                        <div class="ped-directions__label">오시는길</div>
+                        <div class="ped-directions__text">강남역 3번 출구 도보 5분
+1층 카페 안쪽 와인바 입구 · 주차 가능</div>
+                      </div>
+                    </div>
                   </div>
-                  <!-- Pending card 2 -->
-                  <div class="ped-app-card">
-                    <div class="ped-app-card__avatar">박</div>
-                    <div class="ped-app-card__body">
-                      <div class="ped-app-card__name">박재훈</div>
-                      <div class="ped-app-card__sub">남 · 1990-07-04</div>
-                    </div>
-                    <div class="ped-app-card__badge ped-app-card__badge--pending">심사 중</div>
+                </div>
+                <!-- 참가 현황 섹션 삭제 (취소 상태에선 의미 X) -->
+                <div class="ped-section-header"><div class="ped-section-header__title">환불 완료</div></div>
+                <!-- 두 metric — stacked variant: 라벨 위 / 큰 숫자 아래 -->
+                <div class="ped-summary">
+                  <div class="ped-summary__head">
+                    <span class="ped-summary__metric ped-summary__metric--stacked">
+                      <span class="ped-summary__count">780,000원</span>
+                      <span class="ped-summary__count-total">환불액</span>
+                    </span>
+                    <span class="ped-summary__metric ped-summary__metric--stacked">
+                      <span class="ped-summary__count">9건</span>
+                      <span class="ped-summary__count-total">환불 건수</span>
+                    </span>
                   </div>
-                  <!-- Pending card 3 -->
-                  <div class="ped-app-card">
-                    <div class="ped-app-card__avatar">이</div>
-                    <div class="ped-app-card__body">
-                      <div class="ped-app-card__name">이서연</div>
-                      <div class="ped-app-card__sub">여 · 1998-11-29</div>
+                </div>
+                <div class="ped-section-header"><div class="ped-section-header__title">입장 그룹별 환불 정보</div></div>
+                <!-- 자발적/확정 구분 제거 — 환불 결과만. 티켓별 인원·금액 -->
+                <div class="ped-group-list">
+                  <div class="ped-group">
+                    <div class="ped-group__head">
+                      <div class="ped-group__name">일반 그룹</div>
+                      <div><span class="ped-group__count">6</span><span class="ped-group__count-total">명 환불</span></div>
                     </div>
-                    <div class="ped-app-card__badge ped-app-card__badge--pending">심사 중</div>
+                    <div class="ped-group__nest">
+                      <div class="ped-group__tickets">
+                        <div class="ped-group__ticket">
+                          <div class="ped-group__ticket-row">
+                            <div class="ped-group__ticket-name">얼리버드 입장권<span class="ped-group__ticket-sub">환불 4명 · 35,000원</span></div>
+                            <div class="ped-group__ticket-price">−140,000원</div>
+                          </div>
+                        </div>
+                        <div class="ped-group__ticket">
+                          <div class="ped-group__ticket-row">
+                            <div class="ped-group__ticket-name">정상가 입장권<span class="ped-group__ticket-sub">환불 2명 · 45,000원</span></div>
+                            <div class="ped-group__ticket-price">−90,000원</div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
                   </div>
-
-                  <div class="ped-app-section__title ped-app-section__title--muted">처리 완료 (5)</div>
-                  <div class="ped-app-card">
-                    <div class="ped-app-card__avatar">최</div>
-                    <div class="ped-app-card__body">
-                      <div class="ped-app-card__name">최수아</div>
-                      <div class="ped-app-card__sub">여 · 1995-02-18</div>
+                  <div class="ped-group">
+                    <div class="ped-group__head">
+                      <div class="ped-group__name">VIP 그룹</div>
+                      <div><span class="ped-group__count">3</span><span class="ped-group__count-total">명 환불</span></div>
                     </div>
-                    <div class="ped-app-card__badge ped-app-card__badge--paid">결제완료</div>
-                  </div>
-                  <div class="ped-app-card">
-                    <div class="ped-app-card__avatar">정</div>
-                    <div class="ped-app-card__body">
-                      <div class="ped-app-card__name">정도윤</div>
-                      <div class="ped-app-card__sub">남 · 1992-09-08</div>
+                    <div class="ped-group__nest">
+                      <div class="ped-group__tickets">
+                        <div class="ped-group__ticket">
+                          <div class="ped-group__ticket-row">
+                            <div class="ped-group__ticket-name">VIP 입장권<span class="ped-group__ticket-sub">환불 3명 · 120,000원</span></div>
+                            <div class="ped-group__ticket-price">−360,000원</div>
+                          </div>
+                        </div>
+                      </div>
                     </div>
-                    <div class="ped-app-card__badge ped-app-card__badge--rejected">거절됨</div>
                   </div>
                 </div>
               </div>
-
-              <span class="annotation" style="top:60px;right:8px;">tab #2 active · primary 강조</span>
-              <span class="annotation" style="top:120px;left:8px;">titleMedium · bold · 카운트 (3)</span>
-              <span class="annotation" style="bottom:160px;left:8px;">처리 완료 — outline 회색 톤</span>
             </div></td>
             <td class="state-mini__aspect">조건</td>
-            <td>참가 신청(Tab 2)으로 사용자가 전환 + 신청 데이터 1건 이상 도착. 위쪽 "심사 대기 중" 묶음에 즉시 액션 필요한 카드, 아래 "처리 완료" 묶음에 그 외.</td>
+            <td>이벤트 상태 'cancelled' (운영자 직접 취소 또는 시스템 자동). 결제완료(paid) 사용자는 자동 환불 트리거 → refund_status가 점진적으로 'completed'로 전환. 심사대기(pending_review) 사용자는 DB 자동 처리 X — 운영자가 별도 통보 필요.</td>
           </tr>
           <tr>
             <td class="state-mini__aspect">사용자 액션</td>
             <td>
-              · <strong>심사 대기 카드 탭</strong> → 같은 화면 위에 심사 다이얼로그 노출. 승인/거절 → 다이얼로그 닫힘 + SnackBar('심사 처리가 완료되었습니다.') + 카드가 자동으로 처리 완료 그룹으로 이동<br>
-              · <strong>처리 완료 카드 탭</strong> → 무반응 (탭 비활성)<br>
-              · <strong>탭 #1 ('운영 관리') 탭</strong> → 본문 즉시 운영 관리로 갈아끼워짐
+              · <strong>정보 수정 link 숨김</strong> — 취소된 이벤트의 정보 변경 의미 X<br>
+              · <strong>참가자 보기 outline 버튼만</strong> 노출 → <a href="/specs/event_application_list_page.html">EventApplicationListPage</a>로 이동 (환불 진행 모니터링 + 심사대기 사용자 통보 처리)<br>
+              · <strong>심사하기 CTA 숨김</strong> — 취소된 이벤트는 신규 심사 X<br>
+              · <strong>티켓 row 탭 비활성</strong> — chevron 숨김, 정보만 표시 (가격·발행수 수정 X)<br>
+              · <strong>"+ 이 그룹에 티켓 추가" 버튼 숨김</strong> — 추가 의미 X
             </td>
           </tr>
-          <tr><td class="state-mini__aspect">에지케이스</td><td>· 한쪽 묶음만 비어있으면 그 헤더 + 카드 자체가 사라지고 다른 묶음만 남음<br>· 심사 처리 실패 시 SnackBar 대신 공통 에러 처리 — 카드는 그대로 유지</td></tr>
+          <tr><td class="state-mini__aspect">에지케이스</td><td>· 취소 직후 환불 처리는 비동기 — 환불완료 카운트가 점진적 증가 (q_global_events → 환불 처리 Edge Function)<br>· 일부 환불 실패(refund_status: 'failed') 시 운영자 알림 + 수동 처리 안내 (별도 spec)<br>· 심사대기 사용자는 운영자 책임 — 통보 / 별도 환불 처리 (이벤트 취소 안내 등)<br>· 일정 텍스트는 line-through + secondary 톤 + ⚠️ 본문 안내</td></tr>
           <tr>
             <td class="state-mini__aspect">컴포넌트</td>
-            <td>↔ Default 본문 → <code>EventApplicationListView</code> · <code>ListView</code> + 그룹 헤더 Text × 2 + <code>_ApplicationCard</code>(<code>Card</code> + <code>ListTile</code>: <code>CircleAvatar</code> 좌 / 이름·성별·생년 가운데 / <code>_StatusBadge</code> 우) · <code>EventApplicationReviewDialog</code>(심사 대기 카드 탭 시) · <code>SnackBar</code>(심사 완료)</td>
+            <td>
+              ↔ Default 구조 + 다음 변형: chip 'error' (취소) · D-N chip은 outline tone (이벤트 의미 약화) · Hero 카드 일정 line-through + ⚠️ 안내 메시지 · <strong>정보 수정 row 숨김</strong> · 심사대기 metric은 그대로 (운영자 모니터링) · <strong>심사하기 CTA 숨김</strong> · 매출 카드 라벨 '환불 완료' (was '기대 매출') · 매출 본문은 환불액 차감 표시 · 그룹 티켓 row chevron 숨김 + InkWell 비활성 · "+ 티켓 추가" 버튼 숨김
+            </td>
           </tr>
           <tr>
             <td class="state-mini__aspect">토큰</td>
             <td>
-              + <code>color-primary-container</code> (CircleAvatar bg) / <code>color-on-primary-container</code> (이름 첫 글자) · <code>color-warning</code> (심사 중 뱃지) · <code>color-success</code> (승인됨 뱃지) · <code>color-primary</code> (결제완료 뱃지) · <code>color-error</code> (거절됨 뱃지) · <code>color-outline</code> (처리 완료 그룹 헤더 색) · typography <code>titleMedium</code> w700/normal (그룹 헤더) · <code>bodyMedium</code> (이름) · <code>bodyMedium</code>(subtitle, secondary) · <code>labelSmall</code> w700 (status badge)
+              + <code>color-error</code> (취소 chip · 라벨 톤) · <code>color-text-secondary</code> + line-through (취소된 일정) · 환불완료 metric muted tone (이미 끝난 정보)
             </td>
           </tr>
-          <tr><td class="state-mini__aspect">노트</td><td>📝 두 그룹 사이는 큰 여백(spacing-large)으로 시각 구분 — 심사 대기를 시선이 먼저 닿는 위치에 둔다.</td></tr>
+          <tr><td class="state-mini__aspect">노트</td><td>⚠️ 정보 수정 link 숨김 = "비활성 버튼은 보여줄 필요 없다" 정책. 사후 안내(취소 사유 등)는 EventApplicationListPage 또는 별도 알림 흐름에서 처리. 매출 카드 라벨이 '기대 매출' → '환불 완료'로 전환되어 운영자가 KPI 손실을 명확히 인지.</td></tr>
         </tbody>
       </table>
 
       <!-- ===================================================
-           STATE 3 — Tab 2 신청 비어있음
+           STATE 3 — 이벤트 완료됨
            =================================================== -->
       <table class="ref state-mini">
         <thead>
-          <tr><th colspan="3"><strong>Tab 2 · 신청 비어있음</strong> <span class="tag tag--mute">empty</span></th></tr>
+          <tr><th colspan="3"><strong>이벤트 완료됨</strong> <span class="tag tag--mute">completed</span></th></tr>
         </thead>
         <tbody>
           <tr>
             <td rowspan="6" class="state-mini__mock"><div class="viewport">
               <div class="ped-appbar">
-                <div class="ped-appbar__back">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
-                </div>
+                <div class="ped-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg></div>
                 <div class="ped-appbar__title">이벤트 상세</div>
               </div>
-              <div class="ped-tabbar">
-                <div class="ped-tab">운영 관리</div>
-                <div class="ped-tab ped-tab--active">참가 신청</div>
+              <div class="ped-body">
+                <div class="ped-meta-chips">
+                  <span class="ped-chip ped-chip--success ped-chip--visibility"><svg class="ped-chip__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>공개</span>
+                  <!-- 완료 chip — success 초록으로 (was outline) -->
+                  <span class="ped-chip ped-chip--success">완료</span>
+                  <span class="ped-chip ped-chip--outline">D+5</span>
+                </div>
+                <div class="ped-title-row">
+                  <div class="ped-title">금요일 와인 클래스</div>
+                </div>
+                <!-- 🎉 축하 banner — title 밑, Hero 카드 위 -->
+                <div class="ped-celebrate-banner">
+                  <span>🎉</span>
+                  <span><span class="ped-celebrate-banner__count">8명</span>과 함께한 이벤트가 완료됐어요</span>
+                </div>
+                <!-- Hero 카드 — 일정/장소 정상. 장소 block에 Kakao Map + 오시는길 -->
+                <div class="ped-card">
+                  <div class="ped-info-rows">
+                    <div class="ped-info-block">
+                      <div class="ped-info-block__caption">일정</div>
+                      <div class="ped-info-block__primary">2026.05.10 (일)</div>
+                      <div class="ped-info-block__secondary">오후 7:30 ~ 9:30</div>
+                    </div>
+                    <div class="ped-info-block">
+                      <div class="ped-info-block__caption">장소</div>
+                      <div class="ped-info-block__primary">강남 와인바</div>
+                      <div class="ped-info-block__secondary">서울 강남구 신사동 ...</div>
+                      <div class="ped-map-thumb" role="img" aria-label="강남 와인바 위치 미니맵">
+                        <span class="ped-map-thumb__pin"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5a2.5 2.5 0 1 1 0-5 2.5 2.5 0 0 1 0 5z"/></svg></span>
+                      </div>
+                      <div class="ped-directions">
+                        <div class="ped-directions__label">오시는길</div>
+                        <div class="ped-directions__text">강남역 3번 출구 도보 5분
+1층 카페 안쪽 와인바 입구 · 주차 가능</div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="ped-section-header"><div class="ped-section-header__title">참가 현황</div></div>
+                <div class="ped-summary">
+                  <div class="ped-summary__head">
+                    <span class="ped-summary__metric">
+                      <span class="ped-summary__count">8</span>
+                      <span class="ped-summary__count-total">/ 12 참석</span>
+                    </span>
+                    <!-- 심사대기 metric 숨김 (0건) -->
+                    <span class="ped-summary__metric ped-summary__metric--muted">
+                      <span class="ped-summary__count">3</span>
+                      <span class="ped-summary__count-total">환불완료</span>
+                    </span>
+                  </div>
+                  <div class="mds-capbar mds-capbar--segmented">
+                    <div class="mds-capbar__seg mds-capbar__seg--filled"></div><div class="mds-capbar__seg mds-capbar__seg--filled"></div><div class="mds-capbar__seg mds-capbar__seg--filled"></div><div class="mds-capbar__seg mds-capbar__seg--filled"></div><div class="mds-capbar__seg mds-capbar__seg--filled"></div><div class="mds-capbar__seg mds-capbar__seg--filled"></div><div class="mds-capbar__seg mds-capbar__seg--filled"></div><div class="mds-capbar__seg mds-capbar__seg--filled"></div><div class="mds-capbar__seg"></div><div class="mds-capbar__seg"></div><div class="mds-capbar__seg"></div><div class="mds-capbar__seg"></div>
+                  </div>
+                  <!-- 심사하기 CTA / 참가자 보기 모두 숨김 (완료 상태) -->
+                </div>
+                <div class="ped-section-header"><div class="ped-section-header__title">달성 매출</div></div>
+                <!-- 환불 차감 line 제거 — 깔끔한 큰 숫자 + bar -->
+                <div class="ped-revenue">
+                  <div class="ped-revenue__head">
+                    <span class="ped-revenue__current">630,000원</span>
+                    <span class="ped-revenue__max">/ 최대 980,000원</span>
+                  </div>
+                  <div class="mds-capbar" role="progressbar" aria-label="달성 매출 630,000원 (정원 대비 64%)">
+                    <div class="mds-capbar__fill" style="width: 64.3%;"></div>
+                  </div>
+                </div>
+                <div class="ped-section-header"><div class="ped-section-header__title">완료 통계</div></div>
+                <!-- 객단가 통계 카드 (전체 + 그룹별) -->
+                <div class="ped-stats-card">
+                  <div class="ped-stats-row">
+                    <span class="ped-stats-row__label">전체 객단가</span>
+                    <span class="ped-stats-row__value">78,750원</span>
+                    <span class="ped-stats-row__sub">(매출 630,000 ÷ 8명)</span>
+                  </div>
+                  <div class="ped-stats-card__divider"></div>
+                  <div class="ped-stats-row">
+                    <span class="ped-stats-row__label">일반 그룹</span>
+                    <span class="ped-stats-row__value">35,000원</span>
+                    <span class="ped-stats-row__sub">(6명 참석)</span>
+                  </div>
+                  <div class="ped-stats-row">
+                    <span class="ped-stats-row__label">VIP 그룹</span>
+                    <span class="ped-stats-row__value">120,000원</span>
+                    <span class="ped-stats-row__sub">(2명 참석)</span>
+                  </div>
+                </div>
+                <div class="ped-section-header"><div class="ped-section-header__title">신청 트렌드</div></div>
+                <!-- 신청 트렌드 — 게시일부터 당일까지 일별 신청 수 bar chart -->
+                <div class="ped-trend-card">
+                  <div class="ped-trend-chart" role="img" aria-label="게시일부터 당일까지 일별 신청 수 추이 (환불 상위 회색 표시)">
+                    <!-- 14일 일별 bar — primary fill = 활성 신청, top gray overlay = 환불됨 -->
+                    <div class="ped-trend-chart__bar ped-trend-chart__bar--peak" style="height:90%;"><div class="ped-trend-chart__bar-refund" style="height:22%;"></div></div>
+                    <div class="ped-trend-chart__bar" style="height:62%;"><div class="ped-trend-chart__bar-refund" style="height:18%;"></div></div>
+                    <div class="ped-trend-chart__bar" style="height:48%;"><div class="ped-trend-chart__bar-refund" style="height:25%;"></div></div>
+                    <div class="ped-trend-chart__bar" style="height:35%;"><div class="ped-trend-chart__bar-refund" style="height:20%;"></div></div>
+                    <div class="ped-trend-chart__bar" style="height:22%;"><div class="ped-trend-chart__bar-refund" style="height:15%;"></div></div>
+                    <div class="ped-trend-chart__bar" style="height:18%;"></div>
+                    <div class="ped-trend-chart__bar" style="height:14%;"></div>
+                    <div class="ped-trend-chart__bar" style="height:12%;"></div>
+                    <div class="ped-trend-chart__bar" style="height:16%;"></div>
+                    <div class="ped-trend-chart__bar" style="height:22%;"><div class="ped-trend-chart__bar-refund" style="height:10%;"></div></div>
+                    <div class="ped-trend-chart__bar" style="height:30%;"><div class="ped-trend-chart__bar-refund" style="height:14%;"></div></div>
+                    <div class="ped-trend-chart__bar" style="height:38%;"><div class="ped-trend-chart__bar-refund" style="height:18%;"></div></div>
+                    <div class="ped-trend-chart__bar" style="height:45%;"><div class="ped-trend-chart__bar-refund" style="height:22%;"></div></div>
+                    <div class="ped-trend-chart__bar" style="height:55%;"><div class="ped-trend-chart__bar-refund" style="height:25%;"></div></div>
+                  </div>
+                  <div class="ped-trend__legend">
+                    <span>게시 직후</span>
+                    <span>당일</span>
+                  </div>
+                </div>
+                <div class="ped-section-header"><div class="ped-section-header__title">입장 그룹별 현황</div></div>
+                <div class="ped-group-list">
+                  <div class="ped-group">
+                    <div class="ped-group__head">
+                      <div class="ped-group__name">일반 그룹</div>
+                      <div><span class="ped-group__count">6</span><span class="ped-group__count-total">/ 8 참석</span></div>
+                    </div>
+                    <div class="mds-capbar mds-capbar--segmented">
+                      <div class="mds-capbar__seg mds-capbar__seg--filled"></div><div class="mds-capbar__seg mds-capbar__seg--filled"></div><div class="mds-capbar__seg mds-capbar__seg--filled"></div><div class="mds-capbar__seg mds-capbar__seg--filled"></div><div class="mds-capbar__seg mds-capbar__seg--filled"></div><div class="mds-capbar__seg mds-capbar__seg--filled"></div><div class="mds-capbar__seg"></div><div class="mds-capbar__seg"></div>
+                    </div>
+                    <div class="ped-group__breakdown">
+                      <span>참석 <strong>6</strong></span>
+                      <span class="ped-group__breakdown-item--muted">환불 <strong>2</strong></span>
+                    </div>
+                    <div class="ped-group__nest">
+                      <div class="ped-group__tickets">
+                        <div class="ped-group__ticket">
+                          <div class="ped-group__ticket-row">
+                            <div class="ped-group__ticket-name">얼리버드 입장권<span class="ped-group__ticket-sub">판매 4 / 발행 4장</span></div>
+                            <div class="ped-group__ticket-price">35,000원</div>
+                            <!-- chevron 숨김 (탭 비활성) -->
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <!-- "+ 이 그룹에 티켓 추가" 버튼 숨김 -->
+                  </div>
+                </div>
               </div>
-              <div class="ped-empty" style="position:absolute;top:104px;left:0;right:0;bottom:0;">
-                신청 내역이 없습니다.
-              </div>
-              <span class="annotation" style="top:60px;right:8px;">tab #2 active</span>
-              <span class="annotation" style="top:240px;right:8px;">center align · single line</span>
             </div></td>
             <td class="state-mini__aspect">조건</td>
-            <td>참가 신청 탭 활성 + 신청 데이터 0건. 새 이벤트라 아직 아무도 신청하지 않은 시점.</td>
+            <td>이벤트 status 'completed' (cron auto-complete-past-events: end_time 도달 시 자동 전환). D-day가 음수(D+N) — N은 days_since_start. 모든 신청 lifecycle 종료, 매출은 실현 / 환불 차감 후 최종.</td>
           </tr>
           <tr>
             <td class="state-mini__aspect">사용자 액션</td>
             <td>
-              · 탭 #1로 다시 전환 → 운영 관리 본문 노출<br>
-              · 뒤로가기 → 파티 상세<br>
-              · (이 화면 자체에는 더 할 일이 없음)
+              · <strong>정보 수정 link 숨김</strong> — 끝난 이벤트의 정보 변경 의미 X (사후 메모는 별도 화면)<br>
+              · <strong>참가자 보기 outline 버튼만</strong> 노출 → EventApplicationListPage (참석 명단 / 후기 처리 / 환불 요청 검토)<br>
+              · <strong>심사하기 CTA 숨김</strong> — 신규 심사 X (심사대기 metric도 숨김 — 0건이거나 lifecycle 종료)<br>
+              · <strong>티켓 row 탭 비활성</strong> — chevron 숨김, 정보만 표시<br>
+              · <strong>"+ 이 그룹에 티켓 추가" 버튼 숨김</strong>
             </td>
           </tr>
-          <tr><td class="state-mini__aspect">에지케이스</td><td>—</td></tr>
-          <tr><td class="state-mini__aspect">컴포넌트</td><td>↔ State 2의 ListView+카드들 → 가운데 정렬된 단일 안내 텍스트(<code>Center</code> + <code>Text</code>)</td></tr>
-          <tr><td class="state-mini__aspect">토큰</td><td>− status badge 색상들<br>− primaryContainer 아바타<br>+ <code>color-text-secondary</code> 단독</td></tr>
-          <tr><td class="state-mini__aspect">노트</td><td>📝 빈 상태에서도 AppBar + TabBar 골격은 그대로 — 사용자가 다시 운영 관리로 돌아가는 길을 잃지 않음.</td></tr>
+          <tr><td class="state-mini__aspect">에지케이스</td><td>· 환불 요청 (refund_status: 'requested')은 완료 후에도 발생 가능 — 운영자 처리 진입은 EventApplicationListPage<br>· 정산 데이터는 별도 SettlementPage에서 (본 화면은 운영 hub 역할만)<br>· '확정' → '참석' 라벨 변환 (실제 참가한 사람 = checked-in)<br>· 후기 / 리뷰 진입은 별도 화면 (향후)</td></tr>
+          <tr>
+            <td class="state-mini__aspect">컴포넌트</td>
+            <td>
+              ↔ Default 구조 + 다음 변형: chip 'outline' (완료 + D+N) · <strong>정보 수정 row 숨김</strong> · 심사대기 metric 숨김 (0건) · <strong>심사하기 CTA 숨김</strong> · 매출 카드 라벨 '달성 매출' (was '기대 매출') · 매출 본문 = 실현 + 환불 차감 · '확정' → '참석' label 전환 · 그룹 티켓 row chevron 숨김 + InkWell 비활성 · "+ 티켓 추가" 버튼 숨김
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">토큰</td>
+            <td>
+              + <code>color-divider</code> bg + <code>color-text-secondary</code> (outline chip · D+N · '환불' breakdown) · 그 외는 Default와 동일
+            </td>
+          </tr>
+          <tr><td class="state-mini__aspect">노트</td><td>📋 완료 후 본 화면은 회고용 — 운영자 KPI 검토 + 후속 처리 진입. <strong>달성 매출</strong> 라벨이 가장 중요한 차이 — 더 이상 잠재(pending revenue)가 아닌 실현 매출. 향후 정산 페이지 / 리뷰 페이지 진입 link 추가 고려.</td></tr>
         </tbody>
       </table>
 
       <!-- ===================================================
-           STATE 4 — Loading
+           STATE 4 — 신청 0건
+           =================================================== -->
+      <table class="ref state-mini">
+        <thead>
+          <tr><th colspan="3"><strong>신청 0건</strong> <span class="tag tag--mute">empty-applications</span></th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td rowspan="6" class="state-mini__mock"><div class="viewport">
+              <div class="ped-appbar">
+                <div class="ped-appbar__back"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg></div>
+                <div class="ped-appbar__title">이벤트 상세</div>
+              </div>
+              <div class="ped-body">
+                <div class="ped-meta-chips">
+                  <span class="ped-chip ped-chip--success ped-chip--visibility"><svg class="ped-chip__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>공개</span>
+                  <span class="ped-chip ped-chip--success">모집</span>
+                  <span class="ped-chip ped-chip--warning">D-12</span>
+                </div>
+                <div class="ped-section-header" style="padding-top:var(--spacing-medium);"><div class="ped-section-header__title">참가 현황</div></div>
+                <div class="ped-summary">
+                  <div class="ped-summary__head">
+                    <span class="ped-summary__metric">
+                      <span class="ped-summary__count">0</span>
+                      <span class="ped-summary__count-total">/ 12 확정</span>
+                    </span>
+                  </div>
+                  <div class="mds-capbar mds-capbar--segmented" style="height:8px;">
+                    <div class="mds-capbar__seg"></div><div class="mds-capbar__seg"></div><div class="mds-capbar__seg"></div><div class="mds-capbar__seg"></div><div class="mds-capbar__seg"></div><div class="mds-capbar__seg"></div><div class="mds-capbar__seg"></div><div class="mds-capbar__seg"></div><div class="mds-capbar__seg"></div><div class="mds-capbar__seg"></div><div class="mds-capbar__seg"></div><div class="mds-capbar__seg"></div>
+                  </div>
+                  <div class="ped-summary__actions">
+                    <div class="ped-summary__cta ped-summary__cta--outline"><span>참가자 보기</span></div>
+                  </div>
+                </div>
+              </div>
+            </div></td>
+            <td class="state-mini__aspect">조건</td>
+            <td>입장 그룹 ≥ 1 · 신청 데이터 0건 (이벤트 직후 또는 노출 부족). 심사대기 / 환불완료 metric은 카운트가 0이라 노출 자체 X.</td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">사용자 액션</td>
+            <td>
+              · <strong>참가자 보기 탭</strong> → EventApplicationListPage 빈 상태 ("신청 내역이 없습니다.")<br>
+              · <strong>심사하기 CTA 숨김</strong> (대기 0)<br>
+              · 다른 액션(정보 수정 / 입장 그룹 / 티켓) 모두 평소와 동일
+            </td>
+          </tr>
+          <tr><td class="state-mini__aspect">에지케이스</td><td>· 0건일 때 metric은 "0 / N 확정"만 노출. 심사대기 / 환불완료는 ≥1일 때만 metric 노출<br>· capbar는 12칸 모두 빈(divider 톤) — 정원이 보이지만 채워진 게 없음<br>· "심사하기" CTA가 빠져 actions 영역에 "참가자 보기" outline 단독</td></tr>
+          <tr>
+            <td class="state-mini__aspect">컴포넌트</td>
+            <td>
+              ↔ Default − 심사대기 metric − 환불완료 metric − 심사하기 CTA · 참가자 보기 outline 버튼은 그대로 노출
+            </td>
+          </tr>
+          <tr>
+            <td class="state-mini__aspect">토큰</td>
+            <td>
+              ↔ Default와 동일 (단순 데이터 0 케이스)
+            </td>
+          </tr>
+          <tr><td class="state-mini__aspect">노트</td><td>📭 가이드 시그널이 약함 — 운영자에게 "노출 점검" 안내가 필요할 수도. 현재 spec에선 별도 안내 없음 — 향후 보강 가능 (예: "신청이 들어오지 않으면 외부 공유 / 가격 점검을 검토해보세요" hint).</td></tr>
+        </tbody>
+      </table>
+
+      <!-- ===================================================
+           STATE 5 — Loading
            =================================================== -->
       <table class="ref state-mini">
         <thead>
@@ -1403,18 +2449,14 @@ body.dark-mode .viewport {
                 </div>
                 <div class="ped-appbar__title">이벤트 상세</div>
               </div>
-              <div class="ped-tabbar">
-                <div class="ped-tab ped-tab--active">운영 관리</div>
-                <div class="ped-tab">참가 신청</div>
-              </div>
-              <div style="position:absolute;top:104px;left:0;right:0;bottom:0;">
+              <div style="position:absolute;top:56px;left:0;right:0;bottom:0;">
                 <div class="ped-spinner"></div>
               </div>
               <span class="annotation" style="top:60px;right:8px;">탭 동작 가능</span>
               <span class="annotation" style="top:260px;right:8px;">center spinner · primary 톤</span>
             </div></td>
             <td class="state-mini__aspect">조건</td>
-            <td>이벤트 데이터를 처음 받아오는 중. AppBar + TabBar는 이미 그려져 있고, 본문 영역만 비어있는 자리에 spinner가 도는 중.</td>
+            <td>이벤트 데이터를 처음 받아오는 중. AppBar는 이미 그려져 있고, 본문 영역에 풀-스크린 spinner가 도는 중.</td>
           </tr>
           <tr><td class="state-mini__aspect">사용자 액션</td><td>· 탭 전환은 가능 (다만 본문은 같은 spinner를 보여줌)<br>· 데이터가 도착하면 spinner가 사라지고 Default 본문으로 자동 전환</td></tr>
           <tr><td class="state-mini__aspect">에지케이스</td><td>로딩이 길어져도 spinner가 그대로 유지됨 (timeout 별도 처리 없음 — 실패 시 Error로 전환)</td></tr>
@@ -1425,7 +2467,7 @@ body.dark-mode .viewport {
       </table>
 
       <!-- ===================================================
-           STATE 5 — Error
+           STATE 6 — Error
            =================================================== -->
       <table class="ref state-mini">
         <thead>
@@ -1440,11 +2482,7 @@ body.dark-mode .viewport {
                 </div>
                 <div class="ped-appbar__title">이벤트 상세</div>
               </div>
-              <div class="ped-tabbar">
-                <div class="ped-tab ped-tab--active">운영 관리</div>
-                <div class="ped-tab">참가 신청</div>
-              </div>
-              <div class="ped-error" style="top:104px;">
+              <div class="ped-error" style="top:56px;">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
                 <div class="ped-error__msg">이벤트를 불러오지 못했습니다.<br>잠시 후 다시 시도해 주세요.</div>
               </div>
@@ -1473,51 +2511,63 @@ body.dark-mode .viewport {
   </section>
 
   <!-- ============================================================
-       Page-atom zoom-ins — AppBar+TabBar 전환 / Detail card status별
+       Page-atom zoom-ins — Detail card 상태별 톤
        ============================================================ -->
 
   <section class="doc">
-    <h2>AppBar + TabBar — visual</h2>
+    <h2>Meta chip — visual (도메인별 톤)</h2>
     <p class="intro">
-      두 탭 사이를 오갈 때 시선에 가장 먼저 들어오는 게 활성 탭의 색·굵기·언더라인 변화다. 비활성 탭은 옅은 회색 라벨이고, 활성 탭은 파트너 보라색 + 굵기 700 + 하단 2px 보라 언더라인이 동시에 들어온다.
-      AppBar 자체는 두 탭 모두에서 동일 — 좌측 정렬 "이벤트 상세" 타이틀 + 좌상 BackButton. 다크 모드에서도 같은 패턴이 다크 브랜드 톤으로 자동 반영된다.
+      페이지 최상단 chip line은 운영 단계 메타를 색으로 구분해 운영자가 0.3초 안에 인지하도록 한다. 도메인별 색 매핑이 단일 진실:
+      <strong>공개 설정</strong>(success / outline) · <strong>이벤트 상태</strong>(success / error / success) · <strong>D-day</strong>(warning · 시간 임박 시그널).
+      모든 chip은 동일 토큰(<code>radius-small</code> · 12px w600 · 3px 10px padding)을 공유하며 색만 variant로 분기.
     </p>
-    <div class="visual-gallery" style="background: var(--color-surface); padding: 24px; border-radius: var(--radius-card); display: flex; flex-direction: column; gap: 16px;">
+    <div class="visual-gallery" style="background: var(--color-surface); padding: 24px; border-radius: var(--radius-card); display: flex; flex-direction: column; gap: 20px;">
 
-      <!-- Variant 1: 운영 관리 탭 active -->
+      <!-- Group 1: 공개 설정 -->
       <div>
-        <div style="font-size:12px;color:var(--color-text-secondary);margin-bottom:8px;font-weight:600;">운영 관리(Tab 1) 활성</div>
-        <div style="display:flex;justify-content:center;">
-          <div style="width: 375px; background: var(--color-background); border: 1px solid var(--color-divider); border-radius: 8px; overflow: hidden;" class="viewport">
-            <div class="ped-appbar">
-              <div class="ped-appbar__back">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
-              </div>
-              <div class="ped-appbar__title">이벤트 상세</div>
-            </div>
-            <div class="ped-tabbar">
-              <div class="ped-tab ped-tab--active">운영 관리</div>
-              <div class="ped-tab">참가 신청</div>
-            </div>
+        <div style="font-size:12px;color:var(--color-text-secondary);margin-bottom:8px;font-weight:600;">공개 설정 (set-once)</div>
+        <div class="viewport" style="width:375px;padding:16px;">
+          <div class="ped-meta-chips" style="padding:0;">
+            <span class="ped-chip ped-chip--success ped-chip--visibility"><svg class="ped-chip__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>공개</span>
+            <span class="ped-chip ped-chip--outline ped-chip--visibility"><svg class="ped-chip__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>비공개</span>
           </div>
         </div>
       </div>
 
-      <!-- Variant 2: 참가 신청 탭 active -->
+      <!-- Group 2: 이벤트 상태 -->
       <div>
-        <div style="font-size:12px;color:var(--color-text-secondary);margin-bottom:8px;font-weight:600;">참가 신청(Tab 2) 활성</div>
-        <div style="display:flex;justify-content:center;">
-          <div style="width: 375px; background: var(--color-background); border: 1px solid var(--color-divider); border-radius: 8px; overflow: hidden;" class="viewport">
-            <div class="ped-appbar">
-              <div class="ped-appbar__back">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
-              </div>
-              <div class="ped-appbar__title">이벤트 상세</div>
-            </div>
-            <div class="ped-tabbar">
-              <div class="ped-tab">운영 관리</div>
-              <div class="ped-tab ped-tab--active">참가 신청</div>
-            </div>
+        <div style="font-size:12px;color:var(--color-text-secondary);margin-bottom:8px;font-weight:600;">이벤트 상태 (운영 단계)</div>
+        <div class="viewport" style="width:375px;padding:16px;">
+          <div class="ped-meta-chips" style="padding:0;">
+            <span class="ped-chip ped-chip--success">모집</span>
+            <span class="ped-chip ped-chip--error">취소</span>
+            <span class="ped-chip ped-chip--outline">완료</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Group 3: D-day -->
+      <div>
+        <div style="font-size:12px;color:var(--color-text-secondary);margin-bottom:8px;font-weight:600;">D-day (시간 임박)</div>
+        <div class="viewport" style="width:375px;padding:16px;">
+          <div class="ped-meta-chips" style="padding:0;">
+            <span class="ped-chip ped-chip--warning">D-30</span>
+            <span class="ped-chip ped-chip--warning">D-7</span>
+            <span class="ped-chip ped-chip--warning">D-1</span>
+            <span class="ped-chip ped-chip--warning">D-day</span>
+            <span class="ped-chip ped-chip--outline">D+1</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Group 4: 통합 (실제 페이지 chip line 예시) -->
+      <div>
+        <div style="font-size:12px;color:var(--color-text-secondary);margin-bottom:8px;font-weight:600;">실제 페이지 chip line — stable→dynamic 순서</div>
+        <div class="viewport" style="width:375px;padding:16px;">
+          <div class="ped-meta-chips" style="padding:0;">
+            <span class="ped-chip ped-chip--success ped-chip--visibility"><svg class="ped-chip__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>공개</span>
+            <span class="ped-chip ped-chip--success">모집</span>
+            <span class="ped-chip ped-chip--warning">D-12</span>
           </div>
         </div>
       </div>
@@ -1525,87 +2575,21 @@ body.dark-mode .viewport {
     </div>
     <table class="ref" style="margin-top: 16px;">
       <thead>
-        <tr><th style="width: 140px;">탭 라벨</th><th style="width: 200px;">색 / 굵기</th><th>하단 indicator</th></tr>
+        <tr><th style="width: 140px;">Chip 라벨</th><th style="width: 140px;">Variant / 색</th><th>의미 / 노출 조건</th></tr>
       </thead>
       <tbody>
-        <tr><td>비활성 탭</td><td><code>color-text-secondary</code> · w500</td><td>없음 (기본 divider 1px만)</td></tr>
-        <tr><td>활성 탭</td><td><code>color-primary (partner #6c3ce1)</code> · w700</td><td>2px <code>color-primary</code> · 탭 너비 전체</td></tr>
-        <tr><td>다크 모드 활성</td><td><code>color-partner-dark-primary (#9b7bec)</code> · w700</td><td>같은 색의 2px 라인 — 다크 톤 자동 반영</td></tr>
-        <tr><td>AppBar (모든 상태)</td><td>타이틀 <code>color-text-primary</code> · w700 · <code>titleMedium</code></td><td>해당 없음 (TabBar가 분리 역할)</td></tr>
-      </tbody>
-    </table>
-  </section>
-
-  <section class="doc">
-    <h2>Detail info card — visual (상태별 톤)</h2>
-    <p class="intro">
-      운영 메타 카드의 4번째 행("상태")은 운영 단계에 따라 값의 색이 바뀌는 유일한 행이다 — 다른 4행은 늘 같은 톤이고 이 행만 시그널 컬러를 가진다.
-      예정됨은 파트너 보라(앞으로 진행될 이벤트), 취소됨은 빨강(주의 — 환불 / 사후 안내 필요), 완료됨은 회색(이미 끝나 별도 액션 없음). 사용자가 카드 한 장 안에서 "지금 이 이벤트가 어떤 단계인지"를 색으로 즉시 파악할 수 있게 한다.
-    </p>
-    <div class="visual-gallery" style="background: var(--color-surface); padding: 24px; border-radius: var(--radius-card); display: flex; flex-direction: column; gap: 12px;">
-
-      <!-- Variant 1: scheduled (primary) -->
-      <div>
-        <div style="font-size:12px;color:var(--color-text-secondary);margin-bottom:6px;font-weight:600;">예정됨 — 보라 톤</div>
-        <div style="display:flex;justify-content:center;">
-          <div style="width: 375px;" class="viewport">
-            <div class="ped-card" style="margin:0;">
-              <div class="ped-row">
-                <div class="ped-row__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg></div>
-                <div class="ped-row__label">상태</div>
-                <div class="ped-row__value ped-row__value--accent">예정됨</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Variant 2: cancelled (error) -->
-      <div>
-        <div style="font-size:12px;color:var(--color-text-secondary);margin-bottom:6px;font-weight:600;">취소됨 — 빨강 톤</div>
-        <div style="display:flex;justify-content:center;">
-          <div style="width: 375px;" class="viewport">
-            <div class="ped-card" style="margin:0;">
-              <div class="ped-row">
-                <div class="ped-row__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg></div>
-                <div class="ped-row__label">상태</div>
-                <div class="ped-row__value ped-row__value--error">취소됨</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Variant 3: completed (outline / muted) -->
-      <div>
-        <div style="font-size:12px;color:var(--color-text-secondary);margin-bottom:6px;font-weight:600;">완료됨 — 회색 톤</div>
-        <div style="display:flex;justify-content:center;">
-          <div style="width: 375px;" class="viewport">
-            <div class="ped-card" style="margin:0;">
-              <div class="ped-row">
-                <div class="ped-row__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg></div>
-                <div class="ped-row__label">상태</div>
-                <div class="ped-row__value ped-row__value--muted">완료됨</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-    </div>
-    <table class="ref" style="margin-top: 16px;">
-      <thead>
-        <tr><th style="width: 140px;">상태</th><th style="width: 200px;">값 색 / 굵기</th><th>의미 / 신호</th></tr>
-      </thead>
-      <tbody>
-        <tr><td>예정됨 (scheduled)</td><td><code>color-primary</code> (partner) · w700</td><td>아직 진행 전 — 파트너의 운영 액션이 가장 활발한 단계</td></tr>
-        <tr><td>취소됨 (cancelled)</td><td><code>color-error</code> · w700</td><td>주의 — 환불 / 신청자 안내 등 사후 처리가 필요할 수 있음</td></tr>
-        <tr><td>완료됨 (completed)</td><td><code>color-outline</code> · w700</td><td>이벤트 종료 — 추가 운영 액션은 거의 없음, 정산/리뷰 단계로 이동</td></tr>
-        <tr><td>그 외 / null</td><td>기본 본문 톤 (color: 미지정 → bold도 미적용)</td><td>예외적 status 문자열 그대로 노출 — 별도 시그널 없음</td></tr>
+        <tr><td>공개</td><td><code>success</code> · 초록 #15803d</td><td>이벤트가 외부에 노출됨. set-once — 운영자가 거의 안 바꿈.</td></tr>
+        <tr><td>비공개</td><td><code>outline</code> · 회색</td><td>외부 노출 X. 초대 / draft 단계.</td></tr>
+        <tr><td>모집</td><td><code>success</code> · 초록 #15803d</td><td>이벤트 시작 전 — 신청 받는 활발한 단계. (공개 chip과 동일 톤이지만 도메인 다름 — visibility vs lifecycle)</td></tr>
+        <tr><td>취소</td><td><code>error</code> · 빨강</td><td>이벤트 취소됨 — 주의 (환불 / 사후 안내 필요).</td></tr>
+        <tr><td>완료</td><td><code>outline</code> · 회색</td><td>이벤트 종료 — 정산 / 리뷰 단계로 이동.</td></tr>
+        <tr><td>D-N (N&gt;0)</td><td><code>warning</code> · 주황 #b85a00</td><td>이벤트 시작까지 N일. 항상 동일 톤 (D-30 ~ D-1).</td></tr>
+        <tr><td>D-day</td><td><code>warning</code> · 주황</td><td>이벤트 당일. label만 'D-day'로 변경 (숫자 없음).</td></tr>
+        <tr><td>D+N (지남)</td><td><code>outline</code> · 회색</td><td>이벤트 시작 시간 지남. 보통 '완료' 상태와 함께 노출.</td></tr>
       </tbody>
     </table>
     <p class="intro" style="margin-top:12px;margin-bottom:0;">
-      ※ 다른 4행(일정 / 시간 / 참가 현황 / 공개 설정)은 상태와 무관하게 늘 본문 톤(<code>color-text-primary</code>)으로 표시 — 색 변화 없음.
+      ※ Chip 순서는 stable→dynamic — 공개 chip(set-once)이 가장 좌측, 상태 chip(occasional change), D-day chip(매일 변함)이 우측. 운영자 시선이 변하지 않는 메타 → 변하는 메타 순으로 흘러가도록 설계.
     </p>
   </section>
 </div>
@@ -1638,8 +2622,8 @@ body.dark-mode .viewport {
           <td>파티 상세로 복귀 — 모든 state에서 동일.</td>
         </tr>
         <tr>
-          <td>탭 전환 (Tab 1 ↔ Tab 2)</td>
-          <td>본문이 즉시 다른 탭의 내용으로 갈아끼워짐. AppBar / TabBar는 그대로 — 활성 indicator만 색·위치가 바뀐다. 탭별 스크롤 위치는 따로 보존되지 않고 각 탭의 자체 스크롤 영역이 항상 위에서 시작.</td>
+          <td>(deprecated) 탭 전환</td>
+          <td>(deprecated) Tab 구조 폐기 후 단일 스크롤로 전환. 참가 신청은 별도 라우트(EventApplicationListRoute)로 분리되어 push 네비게이션으로 이동.</td>
         </tr>
         <tr>
           <td>다른 화면에서 돌아옴 (TicketCreate / TicketEdit / 심사 다이얼로그)</td>
@@ -1672,7 +2656,7 @@ body.dark-mode .viewport {
       <tbody>
         <tr><td><code>MinglitAnimation.micro</code></td><td>100ms</td><td>탭 active indicator 슬라이드 (탭 → 다음 탭)</td></tr>
         <tr><td><code>MinglitAnimation.fast</code></td><td>200ms</td><td>심사 다이얼로그 scale fade-in/out</td></tr>
-        <tr><td><code>MinglitAnimation.medium</code></td><td>350ms</td><td>TabBarView 본문 슬라이드 (Tab 1 ↔ Tab 2) · loading → data 크로스페이드</td></tr>
+        <tr><td><code>MinglitAnimation.medium</code></td><td>350ms</td><td>loading → data 크로스페이드 · push 화면 전환</td></tr>
         <tr><td><em>(OS default)</em> SnackBar</td><td>~250ms 진입 / 4s 표시 / 200ms 퇴장</td><td>Material SnackBar 기본</td></tr>
       </tbody>
     </table>
@@ -1688,12 +2672,12 @@ body.dark-mode .viewport {
         <tr>
           <td>탭 전환 (본문 슬라이드)</td>
           <td><code>medium</code> (350ms)</td>
-          <td>TabBarView 기본 — easeInOut · 이전 탭 본문 사라지고 다음 탭 본문이 좌/우에서 슬라이드인</td>
+          <td>(deprecated — Tab 구조 폐기됨) push/pop은 Material 기본 슬라이드</td>
         </tr>
         <tr>
           <td>활성 indicator 이동</td>
           <td><code>micro</code> 근사 (~100ms)</td>
-          <td>TabBar indicator가 다음 탭 위치로 부드럽게 슬라이드</td>
+          <td>(deprecated — TabBar 폐기됨)</td>
         </tr>
         <tr>
           <td>이벤트 데이터 로드 (Loading → Default)</td>
@@ -1725,14 +2709,14 @@ body.dark-mode .viewport {
       화면 전반에 영향을 주는 edge case. state-specific edge case는 위 States section의 각 mini-table 에지케이스 행에.
     </p>
     <ul class="notes">
-      <li><strong>이벤트 제목이 비어있음</strong> — Tab 1 상단의 제목 블록 통째로 사라짐. 메타 카드가 곧바로 시작 위치로 올라간다.</li>
+      <li><strong>이벤트 제목이 비어있음</strong> — 본문 상단의 제목 블록 통째로 사라짐. Hero 카드가 곧바로 시작 위치로 올라간다.</li>
       <li><strong>참가 현황 / 신청 카운트가 0</strong> — 메타 카드의 "참가 현황" 행은 "확정 0명 / 신청 0명 (대기 0)"으로 노출 (행 자체는 사라지지 않음).</li>
-      <li><strong>티켓이 0개</strong> — 입장권 섹션 본문이 큰 보라 빈 상태 카드("새 티켓 만들기") 한 장으로 대체. 헤더의 "+ 티켓 만들기" 버튼은 그대로 노출.</li>
+      <li><strong>티켓이 0개</strong> — 입장권 섹션 본문이 큰 보라 빈 상태 카드("새 티켓 만들기") 한 장으로 대체. 섹션 헤더는 타이틀만 노출(trailing 버튼 없음).</li>
       <li><strong>정원(maxParticipants)이 정해지지 않음</strong> — 입장권 섹션의 status header(발행/정원 라인)가 사라지고 곧바로 카드부터 시작.</li>
       <li><strong>입장 그룹이 정의되지 않은 단순 이벤트</strong> — 티켓 카드 sub-라벨에서 "그룹" 정보가 빠지고 발행/정원 텍스트만 남는다.</li>
-      <li><strong>다크 모드</strong> — 활성 탭 / 이벤트 제목 / Add 카드의 partner primary 톤이 다크 브랜드 톤(#9b7bec)으로 자동 전환. 메타 카드 / 티켓 카드 / 신청 카드 / divider / status badge 모두 mds 다크 토큰 자동 반영. 상태값 색(예정/취소/완료)도 동일 매핑이 다크 컬러 셋으로 적용.</li>
-      <li><strong>접근성</strong> — TabBar는 Material 기본 a11y. 메타 카드의 라벨/값은 row 단위로 grouped. status badge 텍스트는 색 의존이 아니라 라벨 자체를 읽으면 의미가 전달되도록 작성. 심사 다이얼로그는 popup으로 키보드 nav 가능.</li>
-      <li><strong>네트워크 끊김 (재진입 전)</strong> — Loading이 길어지다 결국 Error state로 전환. AppBar + TabBar는 살아있어 사용자가 뒤로갈 수 있음.</li>
+      <li><strong>다크 모드</strong> — 활성 탭 / 이벤트 제목 / Add 카드의 partner primary 톤이 다크 브랜드 톤(#9b7bec)으로 자동 전환. 메타 카드 / 티켓 카드 / 신청 카드 / divider / status badge 모두 mds 다크 토큰 자동 반영. 상태값 색(모집/취소/완료)도 동일 매핑이 다크 컬러 셋으로 적용.</li>
+      <li><strong>접근성</strong> — Hero 카드 / 참가 현황 카드는 InkWell이라 Material 기본 a11y(스크린 리더 "버튼" 인식). 메타 카드의 라벨/값은 row 단위로 grouped. status badge 텍스트는 색 의존이 아니라 라벨 자체를 읽으면 의미가 전달되도록 작성. 심사 흐름은 별도 라우트(EventApplicationListRoute → EventApplicationDetailRoute)로 분리되어 키보드 nav 자연스럽게 가능.</li>
+      <li><strong>네트워크 끊김 (재진입 전)</strong> — Loading이 길어지다 결국 Error state로 전환. AppBar는 살아있어 사용자가 뒤로갈 수 있음.</li>
     </ul>
     <p class="intro" style="margin-top: 12px; margin-bottom: 0;">
       ※ <strong>티켓 / 심사 다이얼로그 자체의 edge</strong> (가격 미정 / 심사 거절 사유 미입력 등)는 각 child spec / 다이얼로그 내부 사양 참고.
@@ -1757,10 +2741,9 @@ body.dark-mode .viewport {
     <table class="ref">
       <thead><tr><th style="width: 200px;">항목</th><th>Path / Reference</th></tr></thead>
       <tbody>
-        <tr><td><strong>Widget class</strong></td><td><code>EventDetailPage</code> (+ <code>_EventInfoTab</code> · <code>_DetailRow</code> internal widgets)</td></tr>
+        <tr><td><strong>Widget class</strong></td><td><code>EventDetailPage</code> (+ <code>_EventInfoTab</code> · <code>_HeroDetailRow</code> / <code>_MetaDetailRow</code> internal widgets)</td></tr>
         <tr><td><strong>File path</strong></td><td><a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_partner/lib/src/features/party/event/detail/event_detail_page.dart"><code>apps/app_partner/lib/src/features/party/event/detail/event_detail_page.dart</code></a></td></tr>
-        <tr><td><strong>Tab 2 widget</strong></td><td><a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_partner/lib/src/features/party/event/widgets/event_application_list_view.dart"><code>event_application_list_view.dart</code></a> (<code>EventApplicationListView</code> + <code>_ApplicationCard</code> + <code>_StatusBadge</code>)</td></tr>
-        <tr><td><strong>Ticket list widget</strong></td><td><a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_partner/lib/src/features/party/event/widgets/ticket_list_item.dart"><code>ticket_list_item.dart</code></a> (<code>TicketListView</code> · <code>TicketListItem</code> · <code>TicketStatusHeader</code>)</td></tr>
+                <tr><td><strong>Ticket list widget</strong></td><td><a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_partner/lib/src/features/party/event/widgets/ticket_list_item.dart"><code>ticket_list_item.dart</code></a> (<code>TicketListView</code> · <code>TicketListItem</code> · <code>TicketStatusHeader</code>)</td></tr>
         <tr><td><strong>Controller / Provider</strong></td><td><code>eventDetailProvider(eventId)</code> · <code>eventTicketsProvider(eventId)</code> · <code>eventApplicationsProvider(eventId)</code> · <code>eventApplicationReviewControllerProvider</code> · <code>partyDetailProvider(partyId)</code></td></tr>
         <tr><td><strong>Review dialog</strong></td><td><code>EventApplicationReviewDialog</code> — 심사 대기 카드 탭 시 노출되는 승인/거절 다이얼로그</td></tr>
         <tr><td><strong>Route</strong></td><td><code>EventDetailRoute</code> · path: <code>/parties/:partyId/events/:eventId</code> · <code>app_partner/lib/src/routing/app_routes.dart</code></td></tr>
@@ -1774,9 +2757,10 @@ body.dark-mode .viewport {
       <thead><tr><th style="width: 240px;">Spec</th><th>Relation</th></tr></thead>
       <tbody>
         <tr><td><a href="/specs/party_detail_page.html"><code>PartyDetailPage</code></a></td><td>Parent — 이 화면으로 진입하는 주 경로 (이벤트 카드 탭).</td></tr>
-        <tr><td><a href="/specs/ticket_create_page.html"><code>TicketCreatePage</code></a></td><td>"+ 티켓 만들기" 버튼 / 빈 상태 카드 / 리스트 끝 Add 카드 → 모두 여기로 이동.</td></tr>
+        <tr><td><a href="/specs/event_edit_page.html"><code>EventEditPage</code></a></td><td>Hero "일정" 영역 탭 → 이벤트 정보 수정 화면. 확정 참가자 ≥1명이면 일정·장소 변경 시 사유 입력 + 자동 알림 정책 발동.</td></tr>
+        <tr><td><a href="/specs/ticket_create_page.html"><code>TicketCreatePage</code></a></td><td>빈 상태 카드(티켓 0개) / 리스트 끝 Add 카드 → 모두 여기로 이동 (단일 진입점).</td></tr>
         <tr><td><a href="/specs/ticket_edit_page.html"><code>TicketEditPage</code></a></td><td>입장권 카드 탭 → 해당 티켓을 선택한 상태로 이 화면으로 이동.</td></tr>
-        <tr><td><a href="/specs/event_application_manage_page.html"><code>EventApplicationManagePage</code></a></td><td>여러 이벤트의 신청을 한꺼번에 관리하는 화면 — 이 화면 Tab 2의 단일 이벤트 버전.</td></tr>
+        <tr><td><a href="/specs/event_application_manage_page.html"><code>EventApplicationManagePage</code></a></td><td>여러 이벤트의 신청을 한꺼번에 관리하는 화면 — 본 화면의 참가 현황 카드 → EventApplicationListRoute가 단일 이벤트 버전이고, 이 화면은 cross-event 버전.</td></tr>
         <tr><td><a href="/specs/event_application_detail_page.html"><code>EventApplicationDetailPage</code></a></td><td>개별 신청 상세 — 본 화면에서는 다이얼로그로 처리하지만, 더 깊은 정보가 필요할 때 이쪽으로 향한다.</td></tr>
         <tr><td><a href="/specs/event_create_page.html"><code>EventCreatePage</code></a></td><td>이 화면이 보여주는 이벤트를 처음 만든 화면 — 같은 event 데이터의 생성 단계.</td></tr>
         <tr><td><a href="/specs/event_detail_page.html"><code>EventDetailPage (user)</code></a></td><td>같은 이벤트의 user 측 화면 — 영업 톤(이미지 캐러셀 + CTA 바). 같은 데이터, 정반대 관점.</td></tr>
@@ -1794,14 +2778,14 @@ body.dark-mode .viewport {
     <li>✅ <strong>Header</strong> — Title (h1)만</li>
     <li>✅ <strong>Overview</strong> — Status (✅ 디자인완료) · App · Category · Route · Path · Hierarchy · Purpose · User journey · Background · Frequency 10행 모두 채움</li>
     <li>✅ <strong>History</strong> — v1.0 (2026-05-01) 초기 작성</li>
-    <li>✅ <strong>Layout — top blueprint</strong> — AppBar + TabBar + Title + Detail card + Tickets section 5블록 + tree</li>
-    <li>✅ <strong>Layout — Sub-anatomy 5종</strong> — AppBar+TabBar · Title block · Detail info card · Tickets section · Applications tab</li>
-    <li>✅ <strong>States — 5종</strong> — Default 운영 관리 · Tab 2 신청 활성 · Tab 2 신청 비어있음 · Loading · Error</li>
-    <li>✅ <strong>States — mini-table 6 rows</strong> — 5 state 모두 (조건/액션/에지/컴포넌트/토큰/노트)</li>
+    <li>✅ <strong>Layout — top blueprint</strong> — AppBar + Title + Detail card + Stats card + Tickets section + Visibility footer 6블록 + tree</li>
+    <li>✅ <strong>Layout — Sub-anatomy 3종</strong> — Title block · Detail info card · Tickets section (참가 신청은 EventApplicationListRoute 별도 spec)</li>
+    <li>✅ <strong>States — 6종</strong> — Default · 이벤트 취소됨 · 이벤트 완료됨 · 신청 0건 · Loading · Error</li>
+    <li>✅ <strong>States — mini-table 6 rows</strong> — 6 state 모두 (조건/액션/에지/컴포넌트/토큰/노트)</li>
     <li>✅ <strong>States — Default baseline 풀 리스트</strong> — 컴포넌트 + 토큰 풀 명시</li>
-    <li>✅ <strong>States — additive diff</strong> — 나머지 4 state는 ↔ / + / − prefix 사용</li>
-    <li>✅ <strong>State summary matrix</strong> — 5 state 한눈 비교</li>
-    <li>✅ <strong>Visual zoom-in 2종</strong> — AppBar+TabBar(active 변화) · Detail info card(상태별 톤)</li>
+    <li>✅ <strong>States — additive diff</strong> — 나머지 3 state는 ↔ / + / − prefix 사용</li>
+    <li>✅ <strong>State summary matrix</strong> — 6 state 한눈 비교</li>
+    <li>✅ <strong>Visual zoom-in 1종</strong> — Meta chip 도메인별 톤 (공개·상태·D-day 4 그룹 + 통합 예시)</li>
     <li>✅ <strong>Global Behavior — cross-cutting only</strong> — 뒤로가기 · 탭 전환 · 화면 복귀 시 새로고침 · 심사 처리 성공/실패</li>
     <li>✅ <strong>Global Behavior — Motion</strong> — MinglitAnimation token 매핑 표 + transitions 표</li>
     <li>✅ <strong>Global edge cases</strong> — 제목 빈/카운트 0/티켓 0/정원 미정/그룹 없음/다크모드/접근성/네트워크</li>

--- a/apps/mds/docs/src/components/specs/MinglitCapacityBarSpec.tsx
+++ b/apps/mds/docs/src/components/specs/MinglitCapacityBarSpec.tsx
@@ -1,0 +1,467 @@
+/**
+ * Inline visual spec for MinglitCapacityBar.
+ *
+ * Source of truth (Dart): shared/packages/mds/core/.../capacity_bar.dart
+ *   total ≤ segmentThreshold(default 30) → segmented (한 칸 = 1명)
+ *   total > segmentThreshold              → continuous bar
+ *
+ * Two exports:
+ *   default          — visual playground
+ *   GUIDELINE_RECIPES — keyed do/don't preview components
+ */
+
+import type { ComponentType, CSSProperties } from 'react';
+import {
+  PreviewTable,
+  SpecAnatomy,
+  SpecHero,
+  SpecRoot,
+  SpecSection,
+} from './_atoms';
+
+// ---------------------------------------------------------------------------
+// Atom — segmented (칸 분리) variant
+// ---------------------------------------------------------------------------
+function SegmentedBar({
+  total,
+  filled,
+  pending = 0,
+  height = 8,
+  gap = 2,
+  filledColor = 'var(--color-primary)',
+  pendingColor = 'rgba(108, 60, 225, 0.3)',
+  trackColor = 'var(--color-divider)',
+  radius = 2,
+}: {
+  total: number;
+  filled: number;
+  pending?: number;
+  height?: number;
+  gap?: number;
+  filledColor?: string;
+  pendingColor?: string;
+  trackColor?: string;
+  radius?: number;
+}) {
+  const safeFilled = Math.max(0, Math.min(filled, total));
+  const safePending = Math.max(0, Math.min(pending, total - safeFilled));
+  const empty = total - safeFilled - safePending;
+
+  const segs: Array<'filled' | 'pending' | 'empty'> = [
+    ...Array(safeFilled).fill('filled'),
+    ...Array(safePending).fill('pending'),
+    ...Array(empty).fill('empty'),
+  ];
+
+  return (
+    <div
+      role="progressbar"
+      aria-label={`정원 ${total}명 중 확정 ${safeFilled}명 · 대기 ${safePending}명 · 남은 ${empty}명`}
+      aria-valuemin={0}
+      aria-valuemax={total}
+      aria-valuenow={safeFilled}
+      style={{
+        display: 'flex',
+        gap: `${gap}px`,
+        width: '100%',
+        height: `${height}px`,
+      }}
+    >
+      {segs.map((kind, idx) => (
+        <div
+          key={idx}
+          style={{
+            flex: 1,
+            height: '100%',
+            background:
+              kind === 'filled' ? filledColor : kind === 'pending' ? pendingColor : trackColor,
+            borderRadius: `${radius}px`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Atom — continuous variant (total > segmentThreshold)
+// ---------------------------------------------------------------------------
+function ContinuousBar({
+  total,
+  filled,
+  pending = 0,
+  height = 6,
+  filledColor = 'var(--color-primary)',
+  pendingColor = 'rgba(108, 60, 225, 0.3)',
+  trackColor = 'var(--color-divider)',
+  radius = 3,
+}: {
+  total: number;
+  filled: number;
+  pending?: number;
+  height?: number;
+  filledColor?: string;
+  pendingColor?: string;
+  trackColor?: string;
+  radius?: number;
+}) {
+  const safeFilled = Math.max(0, Math.min(filled, total));
+  const safePending = Math.max(0, Math.min(pending, total - safeFilled));
+  const filledPct = (safeFilled / total) * 100;
+  const pendingPct = (safePending / total) * 100;
+
+  return (
+    <div
+      role="progressbar"
+      aria-label={`정원 ${total}명 중 확정 ${safeFilled}명 · 대기 ${safePending}명`}
+      aria-valuemin={0}
+      aria-valuemax={total}
+      aria-valuenow={safeFilled}
+      style={{
+        display: 'flex',
+        width: '100%',
+        height: `${height}px`,
+        background: trackColor,
+        borderRadius: `${radius}px`,
+        overflow: 'hidden',
+      }}
+    >
+      <div style={{ width: `${filledPct}%`, height: '100%', background: filledColor }} />
+      <div style={{ width: `${pendingPct}%`, height: '100%', background: pendingColor }} />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Composite atom — auto-switch based on segmentThreshold
+// ---------------------------------------------------------------------------
+function MinglitCapacityBarDemo({
+  total,
+  filled,
+  pending = 0,
+  segmentThreshold = 30,
+}: {
+  total: number;
+  filled: number;
+  pending?: number;
+  segmentThreshold?: number;
+}) {
+  if (total <= segmentThreshold) {
+    return <SegmentedBar total={total} filled={filled} pending={pending} />;
+  }
+  return <ContinuousBar total={total} filled={filled} pending={pending} />;
+}
+
+// Wrapper to give each demo a fixed-width context so they look natural in tables.
+function DemoWrap({ children, width = 280 }: { children: React.ReactNode; width?: number }) {
+  return (
+    <div style={{ width, padding: '8px 0' }}>
+      {children}
+    </div>
+  );
+}
+
+// Caption helper — small breakdown text below bars (도메인 패턴).
+function Caption({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        marginTop: 6,
+        fontSize: 12,
+        color: 'var(--color-text-secondary)',
+        display: 'flex',
+        gap: 12,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+const strongStyle: CSSProperties = {
+  color: 'var(--color-text-primary)',
+  fontWeight: 600,
+};
+
+// ---------------------------------------------------------------------------
+// Default export — visual playground
+// ---------------------------------------------------------------------------
+export default function MinglitCapacityBarSpec() {
+  return (
+    <SpecRoot>
+      {/* Hero — segmented 8칸 (운영자가 가장 자주 보는 케이스) */}
+      <SpecHero>
+        <DemoWrap width={320}>
+          <MinglitCapacityBarDemo total={8} filled={4} pending={2} />
+          <Caption>
+            <span>
+              확정 <span style={strongStyle}>4</span>
+            </span>
+            <span>
+              대기 <span style={strongStyle}>2</span>
+            </span>
+            <span>
+              남은 <span style={strongStyle}>2</span>
+            </span>
+          </Caption>
+        </DemoWrap>
+      </SpecHero>
+
+      {/* Anatomy — 한 칸 = 1명 단위 표시 */}
+      <SpecAnatomy
+        subject={
+          <DemoWrap width={320}>
+            <MinglitCapacityBarDemo total={8} filled={4} pending={2} />
+          </DemoWrap>
+        }
+        subjectClassName="mds-spec__anatomy-capbar"
+        labels={[
+          {
+            text: '확정 (color-primary · 강한 톤)',
+            style: { top: -22, left: 0 },
+          },
+          {
+            text: '대기 (color-primary @ 30% · 옅은 톤)',
+            style: { top: -22, left: '50%' },
+          },
+          {
+            text: '남은 자리 (color-divider)',
+            style: { bottom: -22, right: 0 },
+          },
+          {
+            text: 'segmentGap 2px',
+            style: { bottom: -22, left: 0 },
+          },
+        ]}
+      />
+
+      {/* Variants — segmented vs continuous + 채움 패턴 */}
+      <SpecSection title="Variants">
+        <PreviewTable
+          rows={[
+            {
+              name: 'segmented · partial',
+              preview: (
+                <DemoWrap>
+                  <MinglitCapacityBarDemo total={8} filled={4} pending={2} />
+                </DemoWrap>
+              ),
+              description:
+                'total ≤ 30 — 칸 분리. 4 강 · 2 옅 · 2 빈 — 한 칸 = 1명. 가장 일반적인 운영 케이스.',
+            },
+            {
+              name: 'segmented · full',
+              preview: (
+                <DemoWrap>
+                  <MinglitCapacityBarDemo total={4} filled={2} pending={2} />
+                </DemoWrap>
+              ),
+              description: '확정 + 대기가 정원에 도달 — 빈 칸 0. 추가 신청 받을 수 없는 직전 상태.',
+            },
+            {
+              name: 'segmented · filled-only',
+              preview: (
+                <DemoWrap>
+                  <MinglitCapacityBarDemo total={6} filled={6} />
+                </DemoWrap>
+              ),
+              description: '대기 0 · 확정만 정원 채움. 모든 신청이 결제까지 완료된 마감 직전 상태.',
+            },
+            {
+              name: 'segmented · empty',
+              preview: (
+                <DemoWrap>
+                  <MinglitCapacityBarDemo total={8} filled={0} />
+                </DemoWrap>
+              ),
+              description: '확정 0 · 대기 0 — 정원만 정의된 신규 그룹.',
+            },
+            {
+              name: 'continuous (total > 30)',
+              preview: (
+                <DemoWrap>
+                  <MinglitCapacityBarDemo total={200} filled={80} pending={30} />
+                </DemoWrap>
+              ),
+              description:
+                'total > segmentThreshold → continuous fallback. 0~40% 강 · 40~55% 옅 · 55~100% 빈.',
+            },
+            {
+              name: 'continuous · near full',
+              preview: (
+                <DemoWrap>
+                  <MinglitCapacityBarDemo total={150} filled={130} pending={15} />
+                </DemoWrap>
+              ),
+              description: '큰 이벤트 마감 직전 — 옅은 톤이 얇은 띠로 visible.',
+            },
+          ]}
+        />
+      </SpecSection>
+
+      {/* Threshold demo — 깨지는 한계 */}
+      <SpecSection title="segmentThreshold 임계값 (default 30)">
+        <PreviewTable
+          rows={[
+            {
+              name: 'total = 8',
+              preview: (
+                <DemoWrap>
+                  <SegmentedBar total={8} filled={4} pending={2} />
+                </DemoWrap>
+              ),
+              description: '여유롭게 칸이 보임 — 한 칸 폭 ≈ 30+px.',
+            },
+            {
+              name: 'total = 20',
+              preview: (
+                <DemoWrap>
+                  <SegmentedBar total={20} filled={12} pending={3} />
+                </DemoWrap>
+              ),
+              description: '한 칸 폭 ≈ 12px — 여전히 인지 가능.',
+            },
+            {
+              name: 'total = 30 (임계값)',
+              preview: (
+                <DemoWrap>
+                  <SegmentedBar total={30} filled={18} pending={5} />
+                </DemoWrap>
+              ),
+              description: '한 칸 폭 ≈ 8px — 모바일 360px 폭 기준 가독 한계. 이 이상은 continuous로 자동 fallback.',
+            },
+            {
+              name: 'total = 50 (over threshold → continuous)',
+              preview: (
+                <DemoWrap>
+                  <ContinuousBar total={50} filled={30} pending={10} />
+                </DemoWrap>
+              ),
+              description: 'segmented 시 칸 폭 < 5px로 깨짐 → continuous로 자동 전환.',
+            },
+          ]}
+        />
+      </SpecSection>
+
+      {/* Pattern contexts — group card composition */}
+      <SpecSection title="In group card (실사용 패턴)">
+        <PreviewTable
+          rows={[
+            {
+              name: 'with breakdown',
+              preview: (
+                <div
+                  style={{
+                    width: 320,
+                    padding: 16,
+                    background: 'var(--color-surface)',
+                    border: '1px solid var(--color-divider)',
+                    borderRadius: 16,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 8,
+                  }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <div style={{ flex: 1, fontSize: 14, fontWeight: 600 }}>일반 그룹</div>
+                    <div>
+                      <span style={{ fontSize: 14, fontWeight: 600 }}>4</span>
+                      <span style={{ fontSize: 12, color: 'var(--color-text-secondary)', marginLeft: 2 }}>
+                        / 8 확정
+                      </span>
+                    </div>
+                  </div>
+                  <SegmentedBar total={8} filled={4} pending={2} />
+                  <div style={{ display: 'flex', gap: 16, fontSize: 12, color: 'var(--color-text-secondary)' }}>
+                    <span>
+                      확정 <strong style={strongStyle}>4</strong>
+                    </span>
+                    <span>
+                      대기 <strong style={strongStyle}>2</strong>
+                    </span>
+                    <span>
+                      거절 <strong style={strongStyle}>0</strong>
+                    </span>
+                  </div>
+                </div>
+              ),
+              description:
+                '`partner_event_detail_page` 입장 그룹 카드 — 그룹 이름 + 분수 + bar + breakdown 한 묶음.',
+            },
+          ]}
+        />
+      </SpecSection>
+    </SpecRoot>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Recipes — short visual previews keyed to GuidelineEntry.recipeKey
+// ---------------------------------------------------------------------------
+function DoCapbarDomain() {
+  return (
+    <DemoWrap width={200}>
+      <SegmentedBar total={8} filled={4} pending={2} />
+    </DemoWrap>
+  );
+}
+
+function DoCapbarWithBreakdown() {
+  return (
+    <div style={{ width: 220 }}>
+      <SegmentedBar total={8} filled={4} pending={2} />
+      <div style={{ marginTop: 6, display: 'flex', gap: 12, fontSize: 12, color: 'var(--color-text-secondary)' }}>
+        <span>
+          확정 <strong style={strongStyle}>4</strong>
+        </span>
+        <span>
+          대기 <strong style={strongStyle}>2</strong>
+        </span>
+        <span>
+          거절 <strong style={strongStyle}>0</strong>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function DontCapbarShrinkThreshold() {
+  // Force segmented for a clearly broken total (e.g. 50) to show why threshold exists.
+  return (
+    <DemoWrap width={200}>
+      <SegmentedBar total={50} filled={30} pending={10} />
+    </DemoWrap>
+  );
+}
+
+function DontCapbarInvert() {
+  // Pending more emphasized than filled — wrong hierarchy.
+  return (
+    <DemoWrap width={200}>
+      <SegmentedBar
+        total={8}
+        filled={4}
+        pending={2}
+        filledColor="rgba(108, 60, 225, 0.3)"
+        pendingColor="var(--color-primary)"
+      />
+    </DemoWrap>
+  );
+}
+
+function DontCapbarGeneric() {
+  // Simulating a fake "70% upload" use case as if it were CapacityBar.
+  return (
+    <DemoWrap width={200}>
+      <ContinuousBar total={100} filled={70} />
+    </DemoWrap>
+  );
+}
+
+export const GUIDELINE_RECIPES: Record<string, ComponentType> = {
+  'do-capbar-domain': DoCapbarDomain,
+  'do-capbar-with-breakdown': DoCapbarWithBreakdown,
+  'dont-capbar-shrink-threshold': DontCapbarShrinkThreshold,
+  'dont-capbar-invert': DontCapbarInvert,
+  'dont-capbar-generic': DontCapbarGeneric,
+};

--- a/apps/mds/docs/src/components/specs/MinglitContentCardSpec.tsx
+++ b/apps/mds/docs/src/components/specs/MinglitContentCardSpec.tsx
@@ -28,13 +28,21 @@ function ContentCardDemo({
   children,
   highlighted = false,
   tappable = false,
+  bordered = true,
   width,
 }: {
   children: ReactNode;
   highlighted?: boolean;
   tappable?: boolean;
+  bordered?: boolean;
   width?: number | string;
 }) {
+  // highlighted 우선 (선택 강조). bordered=false일 때 보더 자체 제거.
+  const border = highlighted
+    ? '1px solid var(--color-primary)'
+    : bordered
+      ? '1px solid var(--color-divider)'
+      : 'none';
   return (
     <div
       style={{
@@ -42,9 +50,7 @@ function ContentCardDemo({
         padding: '16px 16px',
         background: 'white',
         borderRadius: 16,
-        border: highlighted
-          ? '1px solid var(--color-primary)'
-          : '1px solid var(--color-divider)',
+        border,
         cursor: tappable ? 'pointer' : 'default',
         transition: 'box-shadow 0.15s',
       }}
@@ -126,6 +132,21 @@ export default function MinglitContentCardSpec() {
               ),
               description: 'onTap이 연결된 카드. 탭 시 카드 내부에 잉크 리플 효과가 둥근 모서리 안쪽까지 표시.',
             },
+            {
+              name: 'borderless (bordered=false)',
+              preview: (
+                <div style={{ background: 'var(--color-surface)', padding: 12, borderRadius: 12 }}>
+                  <ContentCardDemo width={216} bordered={false}>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                      <span style={{ fontSize: 14, fontWeight: 600 }}>보더 없는 카드</span>
+                      <span style={{ fontSize: 12, color: 'var(--color-text-secondary)' }}>bg 대비로만 분리</span>
+                    </div>
+                  </ContentCardDemo>
+                </div>
+              ),
+              description:
+                '보더 제거 — 페이지 내 카드가 다수 쌓이고 섹션 헤더 + bg 대비로 위계가 충분히 명확할 때. 운영 hub 화면에서 정보 도메인이 같은 카드들을 가볍게 묶을 때 사용. 기본값(true) 유지가 일반적.',
+            },
           ]}
         />
       </SpecSection>
@@ -200,7 +221,47 @@ function DontStackedHighlights() {
   );
 }
 
+function DoBorderlessWhenHierarchyClear() {
+  // 운영 hub 패턴: 같은 정보 도메인 카드들을 섹션 헤더 + bg 대비로 묶음
+  return (
+    <div style={{ background: 'var(--color-background)', padding: 12, borderRadius: 12 }}>
+      <div style={{ fontSize: 12, fontWeight: 700, color: 'var(--color-text-primary)', marginBottom: 8 }}>
+        참가 현황
+      </div>
+      <ContentCardDemo width={200} bordered={false}>
+        <span style={{ fontSize: 13 }}>전체 분수 + 진행 바</span>
+      </ContentCardDemo>
+      <div style={{ height: 8 }} />
+      <div style={{ fontSize: 12, fontWeight: 700, color: 'var(--color-text-primary)', marginBottom: 8 }}>
+        기대 매출
+      </div>
+      <ContentCardDemo width={200} bordered={false}>
+        <span style={{ fontSize: 13 }}>현재 / 최대 매출</span>
+      </ContentCardDemo>
+    </div>
+  );
+}
+
+function DontMixBorderless() {
+  // 보더 있는 카드와 없는 카드 섞임 — 카드 경계 인식 어려움
+  return (
+    <div style={{ background: 'var(--color-background)', padding: 12, borderRadius: 12, display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <ContentCardDemo width={220}>
+        <span style={{ fontSize: 13 }}>이벤트 카드 (bordered)</span>
+      </ContentCardDemo>
+      <ContentCardDemo width={220} bordered={false}>
+        <span style={{ fontSize: 13 }}>알림 메시지 (borderless)</span>
+      </ContentCardDemo>
+      <ContentCardDemo width={220}>
+        <span style={{ fontSize: 13 }}>옵션 카드 (bordered)</span>
+      </ContentCardDemo>
+    </div>
+  );
+}
+
 export const GUIDELINE_RECIPES: Record<string, ComponentType> = {
   'do-highlight-selected': DoHighlightSelected,
   'dont-stacked-highlights': DontStackedHighlights,
+  'do-borderless-when-hierarchy-clear': DoBorderlessWhenHierarchyClear,
+  'dont-mix-borderless': DontMixBorderless,
 };

--- a/apps/mds/docs/src/lib/flow-data.ts
+++ b/apps/mds/docs/src/lib/flow-data.ts
@@ -117,6 +117,9 @@ const APP_PARTNER_MAIN_FLOW = `flowchart TB
   PartyDetailRoute -->|"edit party"| PartyEditRoute
   PartyDetailRoute -->|"create event"| EventCreateRoute
   PartyDetailRoute -->|"tap event"| EventDetailRoute
+  EventDetailRoute -->|"tap hero (일정)"| EventEditRoute
+  EventDetailRoute -->|"tap 참가 현황"| EventApplicationListRoute
+  EventApplicationListRoute -->|"tap application card"| EventApplicationDetailRoute
   EventDetailRoute -->|"create ticket"| TicketCreateRoute
   EventDetailRoute -->|"edit ticket"| TicketEditRoute
   PartyDetailRoute -->|"manage recurrence"| RecurrenceManagementRoute
@@ -276,8 +279,10 @@ const KNOWN_SPEC_FILES: { user: ReadonlySet<string>; partner: ReadonlySet<string
     'checkin_placeholder_page',
     'create_verification_page',
     'event_application_detail_page',
+    'event_application_list_page',
     'event_application_manage_page',
     'event_create_page',
+    'event_edit_page',
     'location_guide_page',
     'more_page',
     'notification_list_screen',

--- a/apps/mds/docs/src/lib/route-pages.json
+++ b/apps/mds/docs/src/lib/route-pages.json
@@ -178,14 +178,6 @@
       "widget": "EventDetailPage",
       "file": "apps/app_partner/lib/src/features/party/event/detail/event_detail_page.dart"
     },
-    "EventEditRoute": {
-      "widget": "EventEditPage",
-      "file": "apps/app_partner/lib/src/features/party/event/edit/event_edit_page.dart"
-    },
-    "EventApplicationListRoute": {
-      "widget": "EventApplicationListPage",
-      "file": "apps/app_partner/lib/src/features/event/applications/event_application_list_page.dart"
-    },
     "TicketCreateRoute": {
       "widget": "TicketCreatePage",
       "file": "apps/app_partner/lib/src/features/ticket/create/ticket_create_page.dart"

--- a/apps/mds/docs/src/lib/route-pages.json
+++ b/apps/mds/docs/src/lib/route-pages.json
@@ -178,6 +178,14 @@
       "widget": "EventDetailPage",
       "file": "apps/app_partner/lib/src/features/party/event/detail/event_detail_page.dart"
     },
+    "EventEditRoute": {
+      "widget": "EventEditPage",
+      "file": "apps/app_partner/lib/src/features/party/event/edit/event_edit_page.dart"
+    },
+    "EventApplicationListRoute": {
+      "widget": "EventApplicationListPage",
+      "file": "apps/app_partner/lib/src/features/event/applications/event_application_list_page.dart"
+    },
     "TicketCreateRoute": {
       "widget": "TicketCreatePage",
       "file": "apps/app_partner/lib/src/features/ticket/create/ticket_create_page.dart"


### PR DESCRIPTION
## Summary

- **partner_event_detail_page** 운영 단계(모집/취소/완료)별 섹션 정의 + 도메인 hub 패턴(Tab 폐기 → 단일 스크롤). 6 state 매트릭스(Default · 취소 · 완료 · 신청0 · Loading · Error)와 Hero/참가현황/매출/신청트렌드/그룹별 카드 lifecycle 분기 일괄 정리.
- **MinglitCapacityBar** 정원 단위 segmented/continuous 시각화 컴포넌트 spec 신설(확정 + 대기 overlay, 30 segmentThreshold).
- **EventEditPage** spec 신설(확정 참가자 ≥1명이면 수정 잠금 정책). flow-data + route-pages에 EventEditRoute / EventApplicationListRoute 엣지 추가. ContentCard `bordered=false` 변형 spec 추가.

## Notable design decisions

- **chip 시스템 도메인 분리**: visibility(공개/비공개 outline) · 상태(success 모집 / error 취소 / outline 완료) · D-day(warning). 비공개 chip 탭 시 설명 토스트.
- **장소 / 일정**은 모든 state Hero 카드 공통 노출 (카카오 맵 thumb + 오시는길).
- **취소 상태**: 참가 현황 → 환불 완료 카드(금액 · 건수 강조)로 대체. 자발적 환불 metric 제외 — 환불 결과만.
- **완료 상태**: 축하 배너 + 그룹별 객단가 통계. 환불 차감 breakdown은 노이즈라 제외.
- **신청 트렌드 차트**: 게시직후 / 당일 anchor + 환불은 회색 filled overlay (취소 신청도 분포 인지).

## Test plan

- [ ] `localhost:3003/specs/partner_event_detail_page.html` 6 state 미니 mock 시각 검수
- [ ] `localhost:3003/specs/event_edit_page.html` 잠금 정책 / 폼 레이아웃 검수
- [ ] `localhost:3003/components` MinglitCapacityBar / MinglitContentCard borderless variant preview 동작 확인
- [ ] flow map(`localhost:3003/flow`)에서 EventEditRoute / EventApplicationListRoute 새 엣지 시각화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)