### PR TITLE
chore(reports): add TPM exec report for #2148

### DIFF
--- a/docs/reports/tpm/2026-05-04-issue2148-audit-2135-actionable-split-payment-p1-orphan-triage.md
+++ b/docs/reports/tpm/2026-05-04-issue2148-audit-2135-actionable-split-payment-p1-orphan-triage.md
@@ -1,0 +1,150 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2148
+captured_at: 2026-05-04
+issue_number: 2148
+state: open
+labels: [report-exec]
+author: Mark-Yun
+title: "⚠️ TPM Report — 2026-05-04: audit #2135 처리(5건 분할) + 신규 P1 결제 버튼 + 미아 26건 트리아지 + 인프라 P0 5~7일 무진전"
+---
+
+# ⚠️ TPM Report — 2026-05-04: audit #2135 처리(5건 분할) + 신규 P1 결제 버튼 + 미아 26건 트리아지 + 인프라 P0 5~7일 무진전
+
+> Issue #2148 · open · created 2026-05-04 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2148
+
+## Body
+
+Scheduler: tpm-exec-report-claude-subagents
+
+## Headline
+
+- **Architect Audit #2135 처리 완료** — 6/8 후속조치 해소(좋은 트랙) + 신규 5건 actionable 생성 (#2143 docs / #2144 lint rule / #2145 cross-feature cleanup / #2146 god widget split / #2147 recurrence-rules 모듈화).
+- **신규 P1 버그 2건**: #2106 PaymentSuccessScreen 버튼 미동작(결제 플로우) / #2130 Partner registration state corruption — runtime-qa CUJ에서 발견. 이번 사이클에 라우팅됨.
+- **iOS Deploy 양쪽 + Vercel Deploy P0 추가 +24h 무진전** (총 누적 4~7일).
+- **신규 트리아지 26건** — 미아 이슈 일제 정리(needs-* 라우팅 부재). 어제 6건 → 오늘 26건. 백로그 라벨 갭 해소.
+- **PR 8건 머지** (Mark가 docs(mds) spec 작성 + ci hook 8건 — 정상 활동).
+- **신규 P0 #2132 (Tick Sim) auto-recovered** — 단발 실패 후 5연속 success → close.
+- **메인 CI on dev 견고** — Hourly Tick(both) / DB Invariant 100% success.
+
+## 1. 사람 판단 필요 사항 (반복 escalate)
+
+### A. iOS Deploy 양쪽 P0 — 누적 ~96~98h (#2049, #2061)
+
+| 이슈 | 워크플로 | 첫 발생 | 누적 | 최근 fail |
+|------|----------|---------|------|-----------|
+| #2049 | iOS User App Deploy | 2026-04-29 11:34Z | ~98h | 2026-05-03 10:45 |
+| #2061 | iOS Partner App Deploy | 2026-04-30 11:32Z | ~98h | 2026-05-03 10:48 |
+
+- 양쪽 동시 실패 + 코드 회귀 가능성 낮음 → **Apple 자격증명 만료** 의심 지속
+- 어제 추가 코멘트/액션 없음
+- **swe 자체 해결 불가** — Mark의 Apple Developer 계정 직접 점검 필요 (Apple Developer 계정 / 인증서 / 프로비저닝 / App Store Connect API key / Fastlane Match)
+
+### B. Vercel Deploy P0 — 누적 ~7일 (#1917)
+
+- 오늘 24h cron 3회 실행 모두 failure (마지막 22:50, 20:52, 19:07)
+- 누적 코멘트 61개 — 매 cron 실패 통지만 쌓임. Mark의 직접 점검 0회
+- 환경변수 / Vercel 토큰 / 빌드 명령어 회귀 의심
+- swe 해결 불가 가능성 — Mark가 Vercel 대시보드 또는 빌드 로그 직접 확인 필요
+
+### C. runtime-qa 디스크 공간 부족 (#2075) — 4일째
+
+- 2026-05-01 23:50 첫 보고 → 어제·오늘 변동 없음 (OPEN)
+- `~/.gradle/caches` 18G 점유 / 가용 ~3.8GiB
+- 매뉴얼 명령어는 어제 코멘트로 안내됨. 실행 미수행
+
+## 2. 이번 사이클 트리아지 (총 26건)
+
+### 2.1 audit #2135 → 5건 actionable 분할
+
+| 이슈 | 제목 | 라벨 | 우선순위 |
+|------|------|------|----------|
+| #2143 | docs(arch): backend.md cleanup-retention 등재 + client.md MDS spec SSOT | needs-arch | P2 |
+| #2144 | lints: no_cross_feature_imports 신규 룰 | needs-swe | P2 |
+| #2145 | refactor: cross-feature import 8건 정리 (depends on #2144) | needs-swe | P3 |
+| #2146 | refactor: god 위젯 4건 분리 (event_card / settlement_page / ...) | needs-swe | P3 |
+| #2147 | refactor: recurrence-rules EF 모듈화 (partner-manage-party 패턴) | needs-swe | P3 |
+
+audit 권고 7건 모두 실제 코드/문서 검증 → skip 0건.
+
+### 2.2 신규 P1 버그 2건
+
+| 이슈 | 제목 | 근거 |
+|------|------|------|
+| #2106 | CUJ-U01 PaymentSuccessScreen 버튼 미동작 | 결제 플로우 핵심 기능 — 무료 이벤트 결제 완료 후 '내 티켓 보기'/'닫기' 모두 미반응. 앱 재시작 필요 |
+| #2130 | CUJ-P01 Partner registration state corruption | 화면 title=Final Confirmation, 내용=Step 3 — state 일관성 깨짐 |
+
+### 2.3 P2 버그 6건
+
+#2107 (CUJ-U05 nav drift), #2137 (U-S05 Partner Events redirect), #2128 (CUJ-P02 dashboard "-"), #2118 (EventApplication 이름 표시), #2129 (#2128 dup), #2138 (P3 — /dev route 404)
+
+### 2.4 신규 P2 백엔드/플러터 follow-up 7건 → needs-swe
+
+#2127, #2126, #2117, #2102, #2101, #2099, #2095, #2096 — 모두 PR #2094/#2125 후속 작업 (이미 P2/P3 라벨 보유, needs-* 부족).
+
+### 2.5 needs-uiux 2건
+
+#2098 (Spec PartnerDetailPage), #2097 (Spec PurchaseHistoryPage) — Mark의 spec 작업 후속.
+
+### 2.6 mds-change auto-file 5건 → needs-swe
+
+#2116, #2115, #2113, #2105, #2100 — 디자인 시스템 spec 변경 후 코드 반영 검토 대상.
+
+### 2.7 기타
+
+- #2131 E2E-SIM 1 failure → needs-qa P2 (자동화 테스트 분석)
+- #2142 ReviewVerificationScreen orphan → needs-swe P3 (delete vs restore 판단)
+- #2129 → #2128 통합 권고 코멘트
+- #2132 Tick Sim P0 → 자동 회복 후 close
+- #2135 audit 리포트 → 5건 분할 후 close
+
+## 3. 메트릭 (24h, 2026-05-03 ~ 04 KST 기준)
+
+| 지표 | 수치 | 추세 |
+|------|------|------|
+| 신규 이슈 (24h) | ~25건 | 어제 0 → 오늘 다수 (runtime-qa CUJ + audit + mds) |
+| 미아 이슈 (no needs-*) | 0건 | 어제 6 → 트리아지 후 0 (정리 완료) |
+| 메인 CI on dev | hourly 24/24 | 견고 (Tick x2, DB Invariant) |
+| Vercel Deploy | 0/3 | ~7일 100% 실패 |
+| iOS Deploy User | 0/1 | 5일째 (#2049) |
+| iOS Deploy Partner | 0/1 | 4일째 (#2061) |
+| 머지된 PR | 8 | 어제 0 → 오늘 8 (Mark의 docs(mds) spec 작업 + ci hook) |
+| audit 리포트 처리 | 1건 close | 6/8 후속조치 해소, 5건 actionable 분할 |
+
+## 4. report-exec 백로그 누적 (10건)
+
+| 이슈 | 생성일 | 종류 | 누적일 |
+|------|--------|------|--------|
+| #1338 | 04-12 | test enhancement (P2) | **22일** — P2 test enh가 report-exec 부적절. 라벨 정리 필요 (별건) |
+| #1768 | 04-23 | TPM Report — review-presence | 11일 |
+| #1774 | 04-23 | PM Report | 11일 |
+| #1917 | 04-27 | Vercel Deploy P0 | 7일 |
+| #2042 | 04-28 | TPM Report — runtime-qa ADB | 6일 |
+| #2046 | 04-29 | TPM Report — audit + dependabot | 5일 |
+| #2049 | 04-29 | iOS Deploy User P0 | 5일 |
+| #2059 | 04-30 | PM Report | 4일 |
+| #2061 | 04-30 | iOS Deploy Partner P0 | 4일 |
+| #2070 | 05-01 | TPM Report — iOS+SD | 3일 |
+| #2075 | 05-01 | runtime-qa hard block | 3일 |
+| #2076 | 05-01 | CUJ-U03 영수증 (P2) | 3일 |
+| #2083 | 05-02 | TPM Report — submodule | 2일 |
+| #2086 | 05-02 | dependabot file_picker (P1) | 2일 |
+| #2089 | 05-03 | TPM Report — iOS+Vercel | 1일 |
+
+총 15건 (P1 1건 + P0 인프라 3건 포함).
+
+## 5. 결론
+
+- **P0 인프라 3건 + #2075 disk hard block 여전히 Mark 액션 대기** — 자동 회복 신호 없음. 누적 4~7일.
+- **architect 팀 위생 좋다** — audit #2135 후속조치 6/8 해소, SWE 모듈화 패턴(`partner-manage-party`) 잘 정착됨.
+- **신규 P1 #2106 (결제 버튼 미동작)** — runtime-qa가 결제 플로우 회귀를 잡았다. swe 우선 처리 필요.
+- **백로그 라벨 갭 해소** — 미아 이슈 26건 모두 needs-* 부여 완료.
+- **Mark의 spec 작업 활발** — 8 PR 머지(주로 docs/mds) + audit 리포트 분석. Mark side에서 product/design은 정상 동력.
+
+**Mark에게 우선 요청 (어제 + 동일 + 변동 없음)**:
+1. **Apple Developer 계정 점검** — iOS Deploy 양쪽 (#2049, #2061) — **누적 5일째**
+2. **Vercel 빌드 로그 점검** — Vercel Deploy (#1917) — **누적 7일째**
+3. **Gradle 캐시 정리** — runtime-qa 디스크 (#2075) — **누적 3일째**
+4. (선택) #1338 (P2 test enh) 라벨 정리 — `report-exec` 부적절
+
+(어제와 변동 없음 — 인프라 P0 누적이 점진 증가, 액션 0)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
-# Graph Report - /Users/mark/workspace/minglit-worker-runtime/workspace/needs-qa-claude-1-work  (2026-05-04)
+# Graph Report - /private/tmp/tpm-report-2148  (2026-05-04)
 
 ## Corpus Check
-- 1173 files · ~1,789,854 words
+- 1173 files · ~1,558,706 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
@@ -2445,11 +2445,11 @@ _Questions this graph is uniquely positioned to answer:_
 - **What is the exact relationship between `Architecture Audit #1092 — 2026-04-06` and `AI Basic Law Compliance (Korea 2026)`?**
   _Edge tagged AMBIGUOUS (relation: conceptually_related_to) - confidence is low._
 - **Why does `package:flutter/material.dart` connect `Community 0` to `Community 1`, `Community 2`, `Community 6`, `Community 7`, `Community 10`, `Community 19`, `Community 20`, `Community 21`, `Community 26`?**
-  _High betweenness centrality (0.066) - this node is a cross-community bridge._
+  _High betweenness centrality (0.069) - this node is a cross-community bridge._
 - **Why does `package:minglit_kit/minglit_kit.dart` connect `Community 6` to `Community 0`, `Community 1`, `Community 2`, `Community 37`, `Community 7`, `Community 10`, `Community 19`, `Community 21`, `Community 26`?**
-  _High betweenness centrality (0.033) - this node is a cross-community bridge._
-- **Why does `package:flutter_test/flutter_test.dart` connect `Community 1` to `Community 2`, `Community 6`, `Community 7`, `Community 10`, `Community 19`, `Community 21`, `Community 26`?**
-  _High betweenness centrality (0.017) - this node is a cross-community bridge._
+  _High betweenness centrality (0.028) - this node is a cross-community bridge._
+- **Why does `dart:async` connect `Community 1` to `Community 0`, `Community 2`, `Community 6`, `Community 7`, `Community 10`, `Community 19`, `Community 21`, `Community 26`?**
+  _High betweenness centrality (0.021) - this node is a cross-community bridge._
 - **What connects `reporter (AutoLabelAllureReporter)`, `BugReporterWrapper Widget Test Suite`, `MinglitListTile Widget Test Suite` to the rest of the system?**
   _1861 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
 # Graph Report - /private/tmp/tpm-report-2148  (2026-05-04)
 
 ## Corpus Check
-- 1173 files · ~1,558,706 words
+- 1173 files · ~1,791,098 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
@@ -2445,10 +2445,10 @@ _Questions this graph is uniquely positioned to answer:_
 - **What is the exact relationship between `Architecture Audit #1092 — 2026-04-06` and `AI Basic Law Compliance (Korea 2026)`?**
   _Edge tagged AMBIGUOUS (relation: conceptually_related_to) - confidence is low._
 - **Why does `package:flutter/material.dart` connect `Community 0` to `Community 1`, `Community 2`, `Community 6`, `Community 7`, `Community 10`, `Community 19`, `Community 20`, `Community 21`, `Community 26`?**
-  _High betweenness centrality (0.069) - this node is a cross-community bridge._
+  _High betweenness centrality (0.075) - this node is a cross-community bridge._
 - **Why does `package:minglit_kit/minglit_kit.dart` connect `Community 6` to `Community 0`, `Community 1`, `Community 2`, `Community 37`, `Community 7`, `Community 10`, `Community 19`, `Community 21`, `Community 26`?**
-  _High betweenness centrality (0.028) - this node is a cross-community bridge._
-- **Why does `dart:async` connect `Community 1` to `Community 0`, `Community 2`, `Community 6`, `Community 7`, `Community 10`, `Community 19`, `Community 21`, `Community 26`?**
+  _High betweenness centrality (0.025) - this node is a cross-community bridge._
+- **Why does `minglit_kit Package` connect `Community 11` to `Community 25`, `Community 3`, `Community 13`?**
   _High betweenness centrality (0.021) - this node is a cross-community bridge._
 - **What connects `reporter (AutoLabelAllureReporter)`, `BugReporterWrapper Widget Test Suite`, `MinglitListTile Widget Test Suite` to the rest of the system?**
   _1861 weakly-connected nodes found - possible documentation gaps or missing edges._


### PR DESCRIPTION
Scheduler: tpm-exec-report-claude-subagents

## Summary
- audit-arch #2135 처리(5건 분할: #2143~#2147) + 신규 P1 결제 버튼(#2106) + 미아 26건 트리아지 + 인프라 P0 5~7일 무진전을 다룬 TPM 리포트 #2148을 docs/reports/tpm/에 동기화.
- graphify 그래프 동기화 (1 commit).

## Test plan
- [x] 파일 경로/네이밍 컨벤션 (`YYYY-MM-DD-issueNNNN-<slug>.md`) 일치
- [x] 본문 = 이슈 #2148 verbatim + YAML 프론트매터
- [x] graphify-out/ 갱신 동반