### PR TITLE
docs(qa): wizard pattern checklist 등재 + U-S20 DEPRECATED 정리 (#2176)

### DIFF
--- a/docs/qa/test-cases/app-user-smoke.md
+++ b/docs/qa/test-cases/app-user-smoke.md
@@ -56,7 +56,6 @@
 
 | # | 화면 | 경로 | Page 클래스 | GUEST | AUTH | VERIFIED | 비고 |
 |---|------|------|------------|-------|------|----------|------|
-| U-S20 | ~~개발 도구~~ | ~~`/dev`~~ | ~~`UserDevMap`~~ | — | — | — | **DEPRECATED** — PR #274 (2026-03-22)로 데브맵 제거. 로그인 화면 5클릭 히든 제스처가 `/dev/switch`로 직접 이동 |
 | U-S21 | 유저 전환 | `/dev/switch` | `DevUserSwitchScreen` | OK | OK | OK | dev flavor만 접근 가능. 로그인 화면 로고 5클릭으로도 진입 가능 |
 
 ---

--- a/docs/qa/test-strategy.md
+++ b/docs/qa/test-strategy.md
@@ -75,6 +75,19 @@
 | 로그인 상태별 분기 렌더링 | PG/WebView 등 네이티브 브릿지 (→ 3) |
 | 딥링크 파라미터 처리 | |
 
+#### Wizard flow 패턴 — 필수 위젯 테스트 체크리스트
+
+다단계 wizard(2 step 이상) 신규 추가 시 다음 위젯 테스트 필수:
+
+1. 각 step에서 "다음" 버튼이 `validateStep(currentStep)` false일 때 disabled (`onPressed == null`)
+2. 각 step에서 "이전" 버튼이 step > 0일 때 enabled
+3. 마지막 step "신청하기/제출" 버튼이 `validateAll()` false일 때 disabled
+4. Draft 복원 시 `PageView`가 `currentStep`으로 즉시(`jumpToPage`) 이동
+
+**배경**: 2026-05-04 partner onboarding wizard에서 동일 영역 P1 4건이 하루에 동시 보고됨 (#2130, #2161, #2162, #2163). PR #2165가 8개 위젯 테스트로 한꺼번에 픽스. 미래의 wizard flow (signup-consent, event-edit 등)에서 동일 갭 재발 방지 위해 등재.
+
+**레퍼런스 구현**: `apps/app_partner/test/src/features/onboarding/cuj_partner_apply_wizard_test.dart` (TC-P01-001/002/003/004) + PR #2165.
+
 ### Layer 2b — Golden image
 
 | ✅ 책임 | ❌ 비책임 |

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
-# Graph Report - /Users/mark/workspace/minglit-worker-runtime/workspace/needs-qa-claude-1  (2026-05-05)
+# Graph Report - /Users/mark/workspace/minglit-worker-runtime/workspace/needs-qa-claude-1/.claude/worktrees/qa-2176  (2026-05-05)
 
 ## Corpus Check
-- 1176 files · ~1,794,021 words
+- 1176 files · ~1,803,096 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
@@ -2474,9 +2474,9 @@ _Questions this graph is uniquely positioned to answer:_
 - **What is the exact relationship between `Architecture Audit #1092 — 2026-04-06` and `AI Basic Law Compliance (Korea 2026)`?**
   _Edge tagged AMBIGUOUS (relation: conceptually_related_to) - confidence is low._
 - **Why does `Text` connect `Community 10` to `Community 1`?**
-  _High betweenness centrality (0.224) - this node is a cross-community bridge._
+  _High betweenness centrality (0.206) - this node is a cross-community bridge._
 - **Why does `Log` connect `Community 10` to `Community 9`?**
-  _High betweenness centrality (0.222) - this node is a cross-community bridge._
+  _High betweenness centrality (0.205) - this node is a cross-community bridge._
 - **What connects `reporter (AutoLabelAllureReporter)`, `BugReporterWrapper Widget Test Suite`, `MinglitListTile Widget Test Suite` to the rest of the system?**
   _2011 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**


### PR DESCRIPTION
Scheduler: needs-qa-claude-1

Closes #2176

## Summary

QA audit #2167의 두 항목 묶음 처리. 모두 \`docs/qa/\` SSOT 정리.

### 작업 1 — \`docs/qa/test-strategy.md\` Wizard 패턴 체크리스트 등재

Layer 2a — Widget flow 섹션 안에 \`#### Wizard flow 패턴 — 필수 위젯 테스트 체크리스트\` 서브섹션 추가.

**배경**: 2026-05-04 partner onboarding wizard에서 P1 4건이 하루에 동시 보고 (#2130, #2161, #2162, #2163). PR #2165가 8개 위젯 테스트로 한꺼번에 픽스. 미래의 wizard flow (signup-consent, event-edit 등)에서 동일 갭 재발 방지 위해 패턴을 등재.

**체크리스트 4항목**:
1. 각 step에서 "다음" 버튼이 \`validateStep(currentStep)\` false일 때 disabled
2. 각 step에서 "이전" 버튼이 step > 0일 때 enabled
3. 마지막 step "신청하기/제출" 버튼이 \`validateAll()\` false일 때 disabled
4. Draft 복원 시 \`PageView\`가 \`currentStep\`으로 즉시(\`jumpToPage\`) 이동

레퍼런스: \`apps/app_partner/test/src/features/onboarding/cuj_partner_apply_wizard_test.dart\` (TC-P01-001/002/003/004) + PR #2165.

### 작업 2 — \`docs/qa/test-cases/app-user-smoke.md\` U-S20 DEPRECATED 행 제거

옵션 A 채택 — 행 자체 삭제.

**배경**: U-S20은 strikethrough(\`~~\`) markup만으로 DEPRECATED 표시되어 있어 runtime-qa 워커가 트립 → #2138 P3 노이즈 false-positive 버그 발생. closed 상태이지만 같은 패턴의 미래 deprecation에서 재발 가능.

PR #274 (2026-03-22)로 \`/dev\` 데브맵 폐기. U-S21 (\`/dev/switch\`)이 후속이므로 U-S20 행만 제거. DEPRECATED 사실은 git history(이 commit)에 보존.

## Test plan

- [x] \`docs/qa/test-strategy.md\` 렌더링 확인 — Layer 2a 안 \`####\` 서브섹션으로 자연스럽게 통합 (Layer 2b 직전)
- [x] \`docs/qa/test-cases/app-user-smoke.md\` 렌더링 확인 — 2.4 Dev Only 표가 U-S21 한 행으로 정리됨, 표 무결성 유지
- [x] U-S20 다른 docs 참조 없음 (grep 검증)
- [ ] 다음 사이클 runtime-qa 워커가 \`/dev\` 경로를 false-positive 트립하지 않는지 모니터링 (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)