### PR TITLE
fix(db): PostgREST 에 admin schema expose — cleanup-retention 'Invalid schema: admin' 해결

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
-# Graph Report - /Users/mark/workspace/minglit-worker-runtime/workspace/needs-swe-sonnet-1  (2026-05-05)
+# Graph Report - /private/tmp/minglit-pgrst-admin  (2026-05-05)
 
 ## Corpus Check
-- 1181 files · ~1,808,995 words
+- 1178 files · ~1,567,587 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3809 nodes · 5187 edges · 329 communities detected
+- 3787 nodes · 5162 edges · 328 communities detected
 - Extraction: 90% EXTRACTED · 10% INFERRED · 0% AMBIGUOUS · INFERRED: 503 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
@@ -338,19 +338,18 @@
 - [[_COMMUNITY_Community 325|Community 325]]
 - [[_COMMUNITY_Community 326|Community 326]]
 - [[_COMMUNITY_Community 327|Community 327]]
-- [[_COMMUNITY_Community 328|Community 328]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `package:flutter/material.dart` - 114 edges
-2. `package:minglit_kit/minglit_kit.dart` - 83 edges
-3. `package:flutter_test/flutter_test.dart` - 75 edges
-4. `dart:async` - 58 edges
+1. `package:flutter/material.dart` - 112 edges
+2. `package:minglit_kit/minglit_kit.dart` - 82 edges
+3. `package:flutter_test/flutter_test.dart` - 74 edges
+4. `dart:async` - 57 edges
 5. `package:mocktail/mocktail.dart` - 47 edges
 6. `_shared/response_utils` - 40 edges
 7. `_shared/supabase_client` - 39 edges
 8. `_shared/request_utils` - 33 edges
 9. `AppRouter / goRouterProvider` - 32 edges
-10. `package:mds/src/theme/minglit_theme.dart` - 31 edges
+10. `MinglitTheme` - 30 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `minglit_kit Package` --references--> `Flutter & Riverpod 3.0 Standard`  [INFERRED]
@@ -705,55 +704,55 @@
 
 ### Community 0 - "Community 0"
 Cohesion: 0.01
-Nodes (312): dart:async, dart:io, dart:js_interop, dart:js_interop_unsafe, package:app_partner/firebase_options.dart, package:app_partner/main.dart, package:app_partner/src/features/more/more_coordinator.dart, package:app_partner/src/features/more/more_page.dart (+304 more)
+Nodes (297): dart:async, dart:io, dart:js_interop, dart:js_interop_unsafe, package:app_partner/firebase_options.dart, package:app_partner/src/features/more/more_coordinator.dart, package:app_partner/src/features/more/more_page.dart, package:app_partner/src/features/onboarding/partner_apply_status_page.dart (+289 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.01
-Nodes (189): dart:convert, ../../../helpers/mocks.dart, ../../../helpers/supabase_mock_helpers.dart, ../../../helpers/test_utils.dart, mocks.dart, package:app_partner/src/features/checkin/stats/checkin_stats_controller.dart, package:app_partner/src/features/checkin/stats/entry_group_checkin_stats_controller.dart, package:app_user/src/features/payment/logic/purchase_history_controller.dart (+181 more)
+Nodes (228): package:app_partner/src/features/application/event_application_manage_page.dart, package:app_user/src/features/account_deletion/logic/account_deletion_coordinator.dart, package:app_user/src/features/account_deletion/ui/deletion_complete_page.dart, package:app_user/src/features/account_deletion/ui/deletion_info_page.dart, package:app_user/src/features/account_deletion/ui/deletion_reason_page.dart, package:app_user/src/features/account_deletion/ui/deletion_verify_page.dart, package:app_user/src/features/auth/login_page.dart, package:app_user/src/features/auth/ui/auth_callback_page.dart (+220 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.02
-Nodes (184): account_deletion_golden_test, activeFiltersProvider (ExploreFilters state), ActivePartySummaryScroll, ActivePartySummaryScroll Test, AdmissionActionHandler (extension), Alchemist goldenTest, UserScenarios (All), AppleSignInTest (emulator) (+176 more)
+Cohesion: 0.01
+Nodes (209): dart:convert, ../../../helpers/mocks.dart, ../../../helpers/supabase_mock_helpers.dart, ../../../helpers/test_utils.dart, mocks.dart, package:app_partner/src/features/checkin/stats/checkin_stats_controller.dart, package:app_partner/src/features/checkin/stats/entry_group_checkin_stats_controller.dart, package:app_partner/src/features/party/event/detail/event_application_controller.dart (+201 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.02
-Nodes (193): ActionRunner, Admin Dashboard Spec, Admin Dashboard Wireframe, apply-event Edge Function, backend-simulator E2E Tests, backend-simulator Edge Function (main handler), bug-report Edge Function, bug-report Tests (+185 more)
+Nodes (190): ActionRunner, Admin Dashboard Spec, Admin Dashboard Wireframe, apply-event Edge Function, backend-simulator E2E Tests, backend-simulator Edge Function (main handler), bug-report Edge Function, bug-report Tests (+182 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.01
-Nodes (158): package:app_partner/src/features/checkin/qr_scanner_screen.dart, package:app_partner/src/features/home/partner_dashboard_controller.dart, package:app_partner/src/features/home/partner_home_coordinator.dart, package:app_partner/src/features/home/partner_home_page.dart, package:app_partner/src/features/home/widgets/event_action_card.dart, package:app_partner/src/features/home/widgets/location_guide_banner.dart, package:app_partner/src/features/home/widgets/onboarding_step_guide.dart, package:app_partner/src/features/home/widgets/todo_summary_chips.dart (+150 more)
+Nodes (176): package:app_partner/src/features/checkin/qr_scanner_screen.dart, package:app_partner/src/features/home/partner_dashboard_controller.dart, package:app_partner/src/features/home/partner_home_coordinator.dart, package:app_partner/src/features/home/partner_home_page.dart, package:app_partner/src/features/home/widgets/event_action_card.dart, package:app_partner/src/features/home/widgets/location_guide_banner.dart, package:app_partner/src/features/home/widgets/onboarding_step_guide.dart, package:app_partner/src/features/home/widgets/todo_summary_chips.dart (+168 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.02
-Nodes (136): package:app_partner/src/features/application/event_application_manage_page.dart, package:app_user/src/features/account_deletion/ui/deletion_complete_page.dart, package:app_user/src/features/account_deletion/ui/deletion_info_page.dart, package:app_user/src/features/account_deletion/ui/deletion_reason_page.dart, package:app_user/src/features/account_deletion/ui/deletion_verify_page.dart, package:app_user/src/features/auth/login_page.dart, package:app_user/src/features/auth/ui/auth_callback_page.dart, package:app_user/src/features/consent/ui/signup_consent_page.dart (+128 more)
+Nodes (177): account_deletion_golden_test, activeFiltersProvider (ExploreFilters state), ActivePartySummaryScroll, ActivePartySummaryScroll Test, AdmissionActionHandler (extension), UserScenarios (All), AppleSignInTest (emulator), ApprovalWaitingCard (+169 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.02
-Nodes (111): package:mds/src/theme/minglit_theme.dart, package:mds/src/ui/widgets/common/minglit_horizontal_scroll_group.dart, package:mds/src/ui/widgets/common/minglit_section_divider.dart, package:mds/src/ui/widgets/timeline/minglit_timeline_step.dart, AlertDialog, build, MinglitAlert, build (+103 more)
+Nodes (156): AccountManagementPage, AccountManagementPageTest, AddActionCard, BugReportCollector, BugReportRepository, BugReporterWrapper Widget, BugReporterWrapper Widget Test Suite, minglitUrlConfigProvider (+148 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.02
-Nodes (118): package:app_partner/src/features/onboarding/partner_apply_controller.dart, package:app_partner/src/features/party/detail/party_detail_controller.dart, package:app_partner/src/features/party/detail/party_detail_coordinator.dart, package:app_partner/src/features/party/event/create/event_create_controller.dart, package:app_partner/src/features/party/logic/recurrence_settings_controller.dart, package:app_user/src/common/widgets/matching_vote_content.dart, package:app_user/src/common/widgets/ticket_qr_viewer.dart, package:app_user/src/features/event/admission/event_admission_controller.dart (+110 more)
+Nodes (104): package:mds/src/theme/minglit_theme.dart, package:mds/src/ui/widgets/common/minglit_horizontal_scroll_group.dart, package:mds/src/ui/widgets/common/minglit_section_divider.dart, AlertDialog, build, MinglitAlert, build, Center (+96 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.03
-Nodes (120): BugReportCollector, BugReportRepository, BugReporterWrapper Widget, BugReporterWrapper Widget Test Suite, MinglitIamportCertification (mobile), MinglitIamportCertification (stub), MinglitIamportCertification (web), minglitUrlConfigProvider (+112 more)
+Cohesion: 0.02
+Nodes (94): dart:math, package:app_partner/src/features/checkin/checkin_controller.dart, package:app_partner/src/features/checkin/manual/checkin_participant.dart, package:app_partner/src/features/checkin/manual/manual_checkin_controller.dart, package:app_partner/src/features/checkin/manual/manual_checkin_sheet.dart, package:flutter/services.dart, package:mobile_scanner/mobile_scanner.dart, build (+86 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.02
-Nodes (93): package:app_user/src/features/account_deletion/logic/account_deletion_coordinator.dart, package:app_user/src/features/home/logic/home_coordinator.dart, package:app_user/src/features/my_tickets/logic/my_tickets_controller.dart, package:app_user/src/features/my_tickets/ui/my_ticket_card.dart, package:app_user/src/features/my_tickets/ui/my_tickets_page.dart, package:app_user/src/features/partner/detail/partner_detail_page.dart, package:app_user/src/features/partner/logic/partner_coordinator.dart, package:app_user/src/features/ticket/ui/model/ticket_event_meta.dart (+85 more)
+Cohesion: 0.03
+Nodes (79): AddressSearchDialog, AddressSearchDialog Test, Alchemist goldenTest, EventApplicationManagePage Smoke Test, ClosingSoonEventsCard, ClosingSoonEventsCard Test, createPartnerTestApp, CujApplicationActionTest (IT-P06) (+71 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.03
 Nodes (98): AI 기본법, AI-First Operating Principle, AI Worker Operating Model, Application (event_applications), Minglit Architecture Overview, Brand Anti-patterns — 외모 품평/익명성/결혼 압박 금지, Brand Identity — minglit voice + visual, Brand Visual — MZ 틱 세련됨 + 보라 그라디언트 (+90 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.03
-Nodes (83): AccountManagementPage, AccountManagementPageTest, AddActionCard, DevScreenItem, DevScreenList, EntryGroupDetail, EntryGroup Model, EntryGroupTemplate model (+75 more)
+Cohesion: 0.02
+Nodes (86): package:app_partner/main.dart, package:app_partner/src/features/onboarding/onboarding_coordinator.dart, package:app_partner/src/features/onboarding/partner_apply_controller.dart, package:app_partner/src/features/onboarding/partner_apply_page.dart, package:app_partner/src/features/onboarding/steps/step1_basic_info.dart, package:app_partner/src/features/onboarding/steps/step2_biz_info.dart, package:app_partner/src/features/onboarding/steps/step3_contact_settlement.dart, package:app_partner/src/features/onboarding/steps/step4_documents.dart (+78 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.04
-Nodes (85): AppLocalizations, AppLocalizationsKo, AppRouter / goRouterProvider, AppRouter Redirect Logic Test, AppRoutes, AppRoutesTest (partner), CreateVerificationPage, CUJ Settlement Integration Test (IT-P04) (+77 more)
+Cohesion: 0.03
+Nodes (90): AppLocalizations, AppLocalizationsKo, AppRouter / goRouterProvider, AppRouter Redirect Logic Test, AppRoutes, AppRoutesTest (partner), CreateVerificationPage, CUJ PartnerApply Wizard Integration Test (+82 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.03
@@ -764,96 +763,96 @@ Cohesion: 0.04
 Nodes (79): AccountDeletionController, AccountDeletionControllerTest, AccountDeletionCoordinator, accountDeletionCoordinatorProvider, AccountDeletionCoordinator Unit Test, AccountDeletionReasonOption, AccountDeletionScenarios, AccountRepository (+71 more)
 
 ### Community 15 - "Community 15"
-Cohesion: 0.03
-Nodes (70): dart:math, package:app_partner/src/features/checkin/checkin_controller.dart, package:app_user/src/features/ticket/logic/boarding_pass_status.dart, package:flutter/services.dart, package:mobile_scanner/mobile_scanner.dart, package:qr_flutter/qr_flutter.dart, build, MinglitTextField (+62 more)
-
-### Community 16 - "Community 16"
-Cohesion: 0.04
-Nodes (75): AddressSearchDialog, AddressSearchDialog Test, EventApplicationManagePage Smoke Test, createPartnerTestApp, CujApplicationActionTest (IT-P06), CujApplicationReviewTest (IT-P02), CujEventCreateWizardTest (IT-P15), CujOnboardingToEventTest (IT-P01) (+67 more)
-
-### Community 17 - "Community 17"
 Cohesion: 0.04
 Nodes (68): CUJ Recurring Event Integration Test (IT-P09), DB Table: recurrence_rules, Edge Function: recurrence-rules, EntryGroupEditorScreen, EventBasicInfoSummary, EventCapacitySummary, EventContactSummary, EventCreateCoordinator (+60 more)
 
-### Community 18 - "Community 18"
+### Community 16 - "Community 16"
 Cohesion: 0.04
 Nodes (37): optionalAuth(), requireAuth(), requireServiceRole(), handleCreate(), checkExternalAuth(), verifyAuth(), IamportClient, IamportClientTest (+29 more)
 
-### Community 19 - "Community 19"
+### Community 17 - "Community 17"
 Cohesion: 0.05
 Nodes (64): Admin Dashboard Feature (PRD + Wireframe), Dark Pattern Regulation Compliance, Event Now Bar Feature, Feature Maturity Matrix (PM 추적 도구), Flutter + UIautomator 비호환 (bounds=[0,0][0,0]), JUSO_CONFIRM_KEY 환경변수 누락 패턴, Legal Compliance (F1~F8 retention policies), MVP Feature Maturity Tracking (+56 more)
 
-### Community 20 - "Community 20"
+### Community 18 - "Community 18"
 Cohesion: 0.03
 Nodes (54): package:flutter_quill/flutter_quill.dart, package:flutter_svg/flutter_svg.dart, package:mds/src/theme/minglit_text_theme_extension.dart, package:mds/src/ui/widgets/common/minglit_chip.dart, package:mds/src/ui/widgets/common/minglit_empty_state.dart, package:mds/src/ui/widgets/common/minglit_image.dart, package:mds/src/ui/widgets/common/minglit_skeleton.dart, package:mds_tokens/mds_tokens.dart (+46 more)
 
-### Community 21 - "Community 21"
+### Community 19 - "Community 19"
 Cohesion: 0.04
 Nodes (58): ADB Device Connection — wireless adb pair 요구사항, ADR-001: Supabase as Backend Platform, ADR-002: PGroonga for Korean Full-Text Search, ADR-003: pgvector for Recommendation Embeddings, ADR-004: PGMQ for Async Event Pipeline, ADR-005: Coordinator + Repository Pattern (Flutter), ADR-006: Ed25519 for QR Ticket Signing, ADR-007: PortOne Multi-PG Abstraction (+50 more)
 
-### Community 22 - "Community 22"
+### Community 20 - "Community 20"
 Cohesion: 0.05
-Nodes (56): ApprovalWaitingCard, CheckinController, CheckinController Unit Test, CheckinParticipant, CheckinParticipant Data Class Unit Test, CheckinPlaceholderPage, CheckinPlaceholderPage Widget Test, CheckinRepository (+48 more)
+Nodes (51): CheckinController, CheckinController Unit Test, CheckinParticipant, CheckinParticipant Data Class Unit Test, CheckinPlaceholderPage, CheckinPlaceholderPage Widget Test, CheckinRepository, checkinRepositoryProvider (+43 more)
 
-### Community 23 - "Community 23"
+### Community 21 - "Community 21"
 Cohesion: 0.04
 Nodes (45): package:app_user/src/features/event/admission/event_application_controller.dart, package:app_user/src/features/event/admission/event_application_wizard_page.dart, package:app_user/src/features/event/admission/payment_success_screen.dart, package:app_user/src/features/event/logic/event_coordinator.dart, package:app_user/src/features/event/logic/event_detail_controller.dart, package:file_picker/file_picker.dart, package:flutter/widgets.dart, build (+37 more)
 
-### Community 24 - "Community 24"
+### Community 22 - "Community 22"
 Cohesion: 0.05
 Nodes (33): package:analyzer/dart/ast/ast.dart, package:analyzer/error/listener.dart, package:custom_lint_builder/custom_lint_builder.dart, package:minglit_lints/src/no_cross_feature_imports_rule.dart, package:minglit_lints/src/no_hardcoded_colors_rule.dart, package:minglit_lints/src/no_hardcoded_padding_rule.dart, package:minglit_lints/src/no_hardcoded_text_style_rule.dart, package:minglit_lints/src/use_minglit_async_value_widget_rule.dart (+25 more)
 
-### Community 25 - "Community 25"
+### Community 23 - "Community 23"
 Cohesion: 0.06
 Nodes (33): fixtures/mock_events.dart, package:mds/mds.dart, package:widgetbook/widgetbook.dart, build, _ColorsStory, _ColorSwatch, _DarkColorsStory, _FilterChipStory (+25 more)
 
-### Community 26 - "Community 26"
+### Community 24 - "Community 24"
 Cohesion: 0.09
 Nodes (30): CheckinResult State Machine, Domain Probe (Observability Interface), Design System 07 — Accessibility Guide, Design System 02 — Component Themes, Design System 01 — Foundation Tokens, Design System 05 — Motion Guide, Design System 04 — Navigation Guide, Design System 03 — UI Patterns (+22 more)
 
-### Community 27 - "Community 27"
+### Community 25 - "Community 25"
 Cohesion: 0.12
 Nodes (28): Breach Notification Runbook, Breach Response Process, Dark Mode Contrast / Accessibility Issue, Minglit Design Token System, Golden Test Coverage Tracking, notification-worker Edge Function, sensitive_access_log Audit Table, Deno 2.0 & Edge Functions Standard (+20 more)
 
-### Community 28 - "Community 28"
-Cohesion: 0.08
-Nodes (25): package:app_partner/src/features/checkin/manual/checkin_participant.dart, package:app_partner/src/features/checkin/manual/manual_checkin_controller.dart, package:app_partner/src/features/checkin/manual/manual_checkin_sheet.dart, build, Center, dispose, Divider, ListView (+17 more)
+### Community 26 - "Community 26"
+Cohesion: 0.11
+Nodes (24): handleMinglitError, MinglitAuthException, MinglitException, MinglitSystemException, MinglitUserException, MinglitFeedbackX, getAccessToken(), getAffectedUserId() (+16 more)
 
-### Community 29 - "Community 29"
+### Community 27 - "Community 27"
 Cohesion: 0.18
 Nodes (25): Architecture Audit #1003 — 2026-04-04, Architecture Audit #1092 — 2026-04-06, Architecture Audit #536 — 2026-03-28, Code Quality Audit #541 — 2026-03-28, Architecture Audit #601 — 2026-03-28 (cross-import), Architecture Audit #648 — 2026-03-28, Architecture Audit #678 — 2026-03-29, Architecture Audit #686 — 2026-03-29 (+17 more)
 
-### Community 30 - "Community 30"
+### Community 28 - "Community 28"
 Cohesion: 0.1
 Nodes (0): 
 
-### Community 31 - "Community 31"
+### Community 29 - "Community 29"
 Cohesion: 0.19
 Nodes (20): DeletionStatus model (account deletion grace period), EnvKeyStore (compile-time env var validation), EventApplication model (user join application), Event model (party instance with scheduling/capacity), EventFeedType enum (nearest, newArrivals, closingSoon, earlyBird, aiRecommended), EventParticipant model (confirmed attendance record), IamportConfig / iamportConfigProvider (PortOne payment config), MatchRule / MatchVote / MatchPair models (+12 more)
 
-### Community 32 - "Community 32"
+### Community 30 - "Community 30"
 Cohesion: 0.15
 Nodes (8): deriveSpecBasename(), designUrlFor(), extractRoutes(), getRoutesByApp(), hasDesignFor(), widgetNameFor(), withWidgetLabels(), Add()
 
-### Community 33 - "Community 33"
+### Community 31 - "Community 31"
 Cohesion: 0.11
 Nodes (17): _boardingBadge, build, Container, _DashLinePainter, _formatTicketNo, _MetaLabel, _NotchCircle, paint (+9 more)
 
-### Community 34 - "Community 34"
+### Community 32 - "Community 32"
 Cohesion: 0.11
 Nodes (17): build, ColoredBox, dispose, Divider, _EventDetailContent, _EventDetailContentState, Function, initState (+9 more)
 
-### Community 35 - "Community 35"
+### Community 33 - "Community 33"
 Cohesion: 0.11
 Nodes (18): Event Now Bar Spec, Event Now Bar Test Plan, Event Now Bar Wireframe, Event State Machine Extension Plan, Golden Test Coverage Plan, Location Consent Plan, My Tickets Plan, My Tickets Spec (+10 more)
 
-### Community 36 - "Community 36"
+### Community 34 - "Community 34"
 Cohesion: 0.2
 Nodes (16): HybridCalculator, AI Embed Edge Function, Party Serializer, Party Serializer Test, AI Embed Integration Test, Tag Extractor Helpers, Tag Extractor Unit Test, AI Extract Tags Edge Function (+8 more)
 
-### Community 37 - "Community 37"
+### Community 35 - "Community 35"
+Cohesion: 0.23
+Nodes (15): FeaturedTagChipBar, FeaturedTagChipBar Widget Test, Tag model, TagCoordinator, TagEventListController, TagEventListController Test, TagEventListPage, TagEventListPage Widget Test (+7 more)
+
+### Community 36 - "Community 36"
 Cohesion: 0.13
 Nodes (14): AlertDialog, _ApplicationItem, build, Column, Container, dispose, _EventGroupSection, _formatTimeAgo (+6 more)
+
+### Community 37 - "Community 37"
+Cohesion: 0.22
+Nodes (14): MinglitIamportCertification (mobile), MinglitIamportCertification (stub), MinglitIamportCertification (web), IamportController, IamportControllerTest, IamportHelper (conditional export), IamportHelperStub, IamportHelperWeb (dart:js interop) (+6 more)
 
 ### Community 38 - "Community 38"
 Cohesion: 0.14
@@ -1108,20 +1107,20 @@ Cohesion: 0.67
 Nodes (0): 
 
 ### Community 101 - "Community 101"
-Cohesion: 0.67
-Nodes (3): PartnerTermsPage, LocationTermsPage, TermsPage (landing_user)
-
-### Community 102 - "Community 102"
 Cohesion: 1.0
 Nodes (3): EventNowMultiStack, EventNowMultiStack Widget Test, sortActiveEvents
 
-### Community 103 - "Community 103"
+### Community 102 - "Community 102"
 Cohesion: 0.67
 Nodes (3): ConsentCoordinator Unit Test, IdentityVerificationConsentSheet Test, SignupConsentPage Test
 
-### Community 104 - "Community 104"
+### Community 103 - "Community 103"
 Cohesion: 0.67
 Nodes (2): _PartnerApplyDraft, saveDraft
+
+### Community 104 - "Community 104"
+Cohesion: 0.67
+Nodes (3): PartnerTermsPage, LocationTermsPage, TermsPage (landing_user)
 
 ### Community 105 - "Community 105"
 Cohesion: 0.67
@@ -1205,27 +1204,27 @@ Nodes (1): _EventRepositoryApplicationQueries
 
 ### Community 125 - "Community 125"
 Cohesion: 1.0
-Nodes (1): MinglitTimelineStep
+Nodes (0): 
 
 ### Community 126 - "Community 126"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): notification-worker loop_worker Tests, notification-worker loop_worker
 
 ### Community 127 - "Community 127"
 Cohesion: 1.0
-Nodes (2): notification-worker loop_worker Tests, notification-worker loop_worker
+Nodes (0): 
 
 ### Community 128 - "Community 128"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): nowUnix, WorkerUtils
 
 ### Community 129 - "Community 129"
 Cohesion: 1.0
-Nodes (2): nowUnix, WorkerUtils
+Nodes (1): MockEvent
 
 ### Community 130 - "Community 130"
 Cohesion: 1.0
-Nodes (1): MockEvent
+Nodes (0): 
 
 ### Community 131 - "Community 131"
 Cohesion: 1.0
@@ -1293,35 +1292,35 @@ Nodes (0):
 
 ### Community 147 - "Community 147"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): validateBuildEnv, landing_user Next.js Config
 
 ### Community 148 - "Community 148"
 Cohesion: 1.0
-Nodes (2): validateBuildEnv, landing_user Next.js Config
+Nodes (0): 
 
 ### Community 149 - "Community 149"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): BrandPage, MingleSymbol SVG Component
 
 ### Community 150 - "Community 150"
 Cohesion: 1.0
-Nodes (2): BrandPage, MingleSymbol SVG Component
+Nodes (2): VisualQaTester Extension, VisualQaTester Test
 
 ### Community 151 - "Community 151"
 Cohesion: 1.0
-Nodes (2): VisualQaTester Extension, VisualQaTester Test
+Nodes (2): AdmissionButtonConfig Test, AdmissionState Edge Cases Test
 
 ### Community 152 - "Community 152"
 Cohesion: 1.0
-Nodes (2): boardingPassStatus Function, BoardingPassStatus Test
+Nodes (1): _ConsentDefinition
 
 ### Community 153 - "Community 153"
 Cohesion: 1.0
-Nodes (2): AdmissionButtonConfig Test, AdmissionState Edge Cases Test
+Nodes (2): boardingPassStatus Function, BoardingPassStatus Test
 
 ### Community 154 - "Community 154"
 Cohesion: 1.0
-Nodes (1): _ConsentDefinition
+Nodes (2): StatusFilterChips Widget Test, StatusFilterChips Widget
 
 ### Community 155 - "Community 155"
 Cohesion: 1.0
@@ -1329,27 +1328,27 @@ Nodes (2): SettlementStatusBadge Test, SettlementStatusBadge / SettlementStatus
 
 ### Community 156 - "Community 156"
 Cohesion: 1.0
-Nodes (2): StatusFilterChips Widget Test, StatusFilterChips Widget
+Nodes (2): PartyListItem, PartyListPage
 
 ### Community 157 - "Community 157"
 Cohesion: 1.0
-Nodes (2): PartyListItem, PartyListPage
+Nodes (2): partyTicketsProvider, TicketManageScreen
 
 ### Community 158 - "Community 158"
 Cohesion: 1.0
-Nodes (2): partyTicketsProvider, TicketManageScreen
+Nodes (2): Landing Partner Env Validator, Landing Partner Next.js Config
 
 ### Community 159 - "Community 159"
 Cohesion: 1.0
-Nodes (2): Landing Partner Env Validator, Landing Partner Next.js Config
+Nodes (2): 개인정보 보호 인증 열람 권한 관리 UI/UX, 개인정보 보호 와이어프레임
 
 ### Community 160 - "Community 160"
 Cohesion: 1.0
-Nodes (2): 개인정보 보호 인증 열람 권한 관리 UI/UX, 개인정보 보호 와이어프레임
+Nodes (2): Metabase BI Dashboard, Statistics & Analytics Tools Spec
 
 ### Community 161 - "Community 161"
 Cohesion: 1.0
-Nodes (2): Metabase BI Dashboard, Statistics & Analytics Tools Spec
+Nodes (2): Simulator Edge Function Migration Plan, Simulator Lifecycle Fix Plan
 
 ### Community 162 - "Community 162"
 Cohesion: 1.0
@@ -1357,127 +1356,127 @@ Nodes (2): Pretendard Font Migration Typography Review, Login Dark Theme Wirefra
 
 ### Community 163 - "Community 163"
 Cohesion: 1.0
-Nodes (2): Simulator Edge Function Migration Plan, Simulator Lifecycle Fix Plan
+Nodes (2): Settings UI Redesign UX Design, Settings UI Redesign Wireframe
 
 ### Community 164 - "Community 164"
 Cohesion: 1.0
-Nodes (2): Settings UI Redesign UX Design, Settings UI Redesign Wireframe
+Nodes (2): Refund Policy v2 Wireframe (Original), Refund Policy v2 Wireframe (UX Review)
 
 ### Community 165 - "Community 165"
 Cohesion: 1.0
-Nodes (2): Refund Policy v2 Wireframe (Original), Refund Policy v2 Wireframe (UX Review)
+Nodes (2): Trust Badge System Spec, Trust Badge UI/UX Design
 
 ### Community 166 - "Community 166"
 Cohesion: 1.0
-Nodes (2): Trust Badge System Spec, Trust Badge UI/UX Design
+Nodes (2): Refund Policy: Terms of Service Page, TPM Report — Refund Policy Terms-Code Mismatch
 
 ### Community 167 - "Community 167"
 Cohesion: 1.0
-Nodes (2): TPM Report — dev Branch Protection Change Blocks All PR Merges, TPM Report — review-presence Workflow Defect Blocking P0 PR #903
+Nodes (2): Bug: BugReport FAB overlaps MyPage navigation button (PR #1268 regression), Runtime QA Bug #1285: BugReport FAB Blocks MyPage Button Touch Area
 
 ### Community 168 - "Community 168"
 Cohesion: 1.0
-Nodes (2): TPM Report — needs-dev Backlog Surge 30 Issues, 10% Digest Rate, TPM Report — Duplicate Issue Creation Pattern
+Nodes (2): Bug: Refund button not shown for free ticket (paymentId null canCancel logic), Runtime QA Bug #1652: CUJ-U03 Refund Button Not Shown in Purchase History
 
 ### Community 169 - "Community 169"
 Cohesion: 1.0
-Nodes (2): Refund Policy: Terms of Service Page, TPM Report — Refund Policy Terms-Code Mismatch
+Nodes (2): Bug: Hot Tags section shows 0-event tags — conceptual contradiction, Runtime QA Bug #1286: Hot Tags Section Shows 0-Event Tags
 
 ### Community 170 - "Community 170"
 Cohesion: 1.0
-Nodes (2): Bug: BugReport FAB overlaps MyPage navigation button (PR #1268 regression), Runtime QA Bug #1285: BugReport FAB Blocks MyPage Button Touch Area
+Nodes (2): TPM Report — needs-dev Backlog Surge 30 Issues, 10% Digest Rate, TPM Report — Duplicate Issue Creation Pattern
 
 ### Community 171 - "Community 171"
 Cohesion: 1.0
-Nodes (2): Bug: Refund button not shown for free ticket (paymentId null canCancel logic), Runtime QA Bug #1652: CUJ-U03 Refund Button Not Shown in Purchase History
+Nodes (2): CI Issue: Vercel Deploy Cascading Cancel (cron + concurrency), TPM Report #1091: Vercel Deploy 20h+ Cascading Failure — Cron Concurrency
 
 ### Community 172 - "Community 172"
 Cohesion: 1.0
-Nodes (2): Bug: Hot Tags section shows 0-event tags — conceptual contradiction, Runtime QA Bug #1286: Hot Tags Section Shows 0-Event Tags
+Nodes (2): TPM Report — dev Branch Protection Change Blocks All PR Merges, TPM Report — review-presence Workflow Defect Blocking P0 PR #903
 
 ### Community 173 - "Community 173"
 Cohesion: 1.0
-Nodes (2): CI Issue: Vercel Deploy Cascading Cancel (cron + concurrency), TPM Report #1091: Vercel Deploy 20h+ Cascading Failure — Cron Concurrency
+Nodes (2): Bug Report — CUJ-P03 QR Scanner Summary Card and Entry Group Stats Missing, Bug Report — CUJ-P01 Party Create Wizard Step 3 Next Uncertain
 
 ### Community 174 - "Community 174"
 Cohesion: 1.0
-Nodes (2): Bug Report — CUJ-P03 QR Scanner Summary Card and Entry Group Stats Missing, Bug Report — CUJ-P01 Party Create Wizard Step 3 Next Uncertain
+Nodes (2): 이벤트 수정/취소 기능 미구현 — EventEditRoute/cancelEvent 없음, Issue #1338: app_partner 이벤트 수정/취소 통합 테스트 추가 (blocked)
 
 ### Community 175 - "Community 175"
 Cohesion: 1.0
-Nodes (2): 이벤트 수정/취소 기능 미구현 — EventEditRoute/cancelEvent 없음, Issue #1338: app_partner 이벤트 수정/취소 통합 테스트 추가 (blocked)
+Nodes (2): UIautomator × Flutter 호환성 한계 — 단일 FlutterSurfaceView로 좌표 탭 부정확, Issue #1291: 이벤트 상세 파트너명 탭 시 파트너 상세 이동 안 됨 (U-S05)
 
 ### Community 176 - "Community 176"
 Cohesion: 1.0
-Nodes (2): UIautomator × Flutter 호환성 한계 — 단일 FlutterSurfaceView로 좌표 탭 부정확, Issue #1291: 이벤트 상세 파트너명 탭 시 파트너 상세 이동 안 됨 (U-S05)
+Nodes (2): Alert #1506: Version Bump Failed, Version Bump Push Race Condition
 
 ### Community 177 - "Community 177"
 Cohesion: 1.0
-Nodes (2): Alert #1506: Version Bump Failed, Version Bump Push Race Condition
+Nodes (2): Backend Simulator Edge Function Timeout Issue, Ops Alert #703 — Daily Backend Simulation Failed (2026-03-28)
 
 ### Community 178 - "Community 178"
 Cohesion: 1.0
-Nodes (2): Backend Simulator Edge Function Timeout Issue, Ops Alert #703 — Daily Backend Simulation Failed (2026-03-28)
+Nodes (2): Duplicate MainActivity in Android Source Sets (src/main + src/dev), Incident #1322: Hard Block — MainActivity Redeclaration on Dev Branch
 
 ### Community 179 - "Community 179"
 Cohesion: 1.0
-Nodes (2): Duplicate MainActivity in Android Source Sets (src/main + src/dev), Incident #1322: Hard Block — MainActivity Redeclaration on Dev Branch
+Nodes (1): _RefundRow Widget
 
 ### Community 180 - "Community 180"
 Cohesion: 1.0
-Nodes (1): _RefundRow Widget
+Nodes (1): reporter (AutoLabelAllureReporter)
 
 ### Community 181 - "Community 181"
 Cohesion: 1.0
-Nodes (1): reporter (AutoLabelAllureReporter)
+Nodes (1): MinglitListTile Widget Test Suite
 
 ### Community 182 - "Community 182"
 Cohesion: 1.0
-Nodes (1): MinglitListTile Widget Test Suite
+Nodes (1): MinglitContentLayout Widget Test Suite
 
 ### Community 183 - "Community 183"
 Cohesion: 1.0
-Nodes (1): MinglitContentLayout Widget Test Suite
+Nodes (1): MinglitBottomCTA Widget Test Suite
 
 ### Community 184 - "Community 184"
 Cohesion: 1.0
-Nodes (1): MinglitBottomCTA Widget Test Suite
+Nodes (1): MinglitImageCarousel Widget Test Suite
 
 ### Community 185 - "Community 185"
 Cohesion: 1.0
-Nodes (1): MinglitImageCarousel Widget Test Suite
+Nodes (1): MinglitImage Widget Test Suite
 
 ### Community 186 - "Community 186"
 Cohesion: 1.0
-Nodes (1): MinglitImage Widget Test Suite
+Nodes (1): MockSupabaseClient
 
 ### Community 187 - "Community 187"
 Cohesion: 1.0
-Nodes (1): MockSupabaseClient
+Nodes (1): minglit_dev.dart (barrel: dev/debug tools)
 
 ### Community 188 - "Community 188"
 Cohesion: 1.0
-Nodes (1): minglit_dev.dart (barrel: dev/debug tools)
+Nodes (0): 
 
 ### Community 189 - "Community 189"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): TicketCrypto
 
 ### Community 190 - "Community 190"
 Cohesion: 1.0
-Nodes (1): TicketCrypto
+Nodes (1): Tag model
 
 ### Community 191 - "Community 191"
 Cohesion: 1.0
-Nodes (1): Tag model
+Nodes (1): EventFeedType
 
 ### Community 192 - "Community 192"
 Cohesion: 1.0
-Nodes (1): EventFeedType
+Nodes (1): ConditionKey Enum
 
 ### Community 193 - "Community 193"
 Cohesion: 1.0
-Nodes (1): ConditionKey Enum
+Nodes (0): 
 
 ### Community 194 - "Community 194"
 Cohesion: 1.0
@@ -1485,47 +1484,47 @@ Nodes (0):
 
 ### Community 195 - "Community 195"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): recurrence-cron Test Suite
 
 ### Community 196 - "Community 196"
 Cohesion: 1.0
-Nodes (1): recurrence-cron Test Suite
+Nodes (1): payment-verify Test Suite
 
 ### Community 197 - "Community 197"
 Cohesion: 1.0
-Nodes (1): payment-verify Test Suite
+Nodes (1): recurrence-rules Test Suite
 
 ### Community 198 - "Community 198"
 Cohesion: 1.0
-Nodes (1): recurrence-rules Test Suite
+Nodes (1): payout-sync Test Suite
 
 ### Community 199 - "Community 199"
 Cohesion: 1.0
-Nodes (1): payout-sync Test Suite
+Nodes (1): reconciliation-daily Test Suite
 
 ### Community 200 - "Community 200"
 Cohesion: 1.0
-Nodes (1): reconciliation-daily Test Suite
+Nodes (1): settlement-query Test Suite
 
 ### Community 201 - "Community 201"
 Cohesion: 1.0
-Nodes (1): settlement-query Test Suite
+Nodes (0): 
 
 ### Community 202 - "Community 202"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): Std Server Stub
 
 ### Community 203 - "Community 203"
 Cohesion: 1.0
-Nodes (1): Std Server Stub
+Nodes (1): Mock Supabase Client
 
 ### Community 204 - "Community 204"
 Cohesion: 1.0
-Nodes (1): Mock Supabase Client
+Nodes (1): Schema Validator
 
 ### Community 205 - "Community 205"
 Cohesion: 1.0
-Nodes (1): Schema Validator
+Nodes (0): 
 
 ### Community 206 - "Community 206"
 Cohesion: 1.0
@@ -1533,19 +1532,19 @@ Nodes (0):
 
 ### Community 207 - "Community 207"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): process-pending-deletions Test Suite
 
 ### Community 208 - "Community 208"
 Cohesion: 1.0
-Nodes (1): process-pending-deletions Test Suite
+Nodes (1): DB: match_votes (via RPC cast_match_vote)
 
 ### Community 209 - "Community 209"
 Cohesion: 1.0
-Nodes (1): DB: match_votes (via RPC cast_match_vote)
+Nodes (1): settlement-register-transfers Test Suite
 
 ### Community 210 - "Community 210"
 Cohesion: 1.0
-Nodes (1): settlement-register-transfers Test Suite
+Nodes (0): 
 
 ### Community 211 - "Community 211"
 Cohesion: 1.0
@@ -1557,83 +1556,83 @@ Nodes (0):
 
 ### Community 213 - "Community 213"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): user-cancel-deletion Test Suite
 
 ### Community 214 - "Community 214"
 Cohesion: 1.0
-Nodes (1): user-cancel-deletion Test Suite
+Nodes (1): Response Utils (errorResponse)
 
 ### Community 215 - "Community 215"
 Cohesion: 1.0
-Nodes (1): Response Utils (errorResponse)
+Nodes (1): corsResponse
 
 ### Community 216 - "Community 216"
 Cohesion: 1.0
-Nodes (1): corsResponse
+Nodes (1): Supabase Service Client (createServiceClient)
 
 ### Community 217 - "Community 217"
 Cohesion: 1.0
-Nodes (1): Supabase Service Client (createServiceClient)
+Nodes (1): nowISO
 
 ### Community 218 - "Community 218"
 Cohesion: 1.0
-Nodes (1): nowISO
+Nodes (1): isoToUnix
 
 ### Community 219 - "Community 219"
 Cohesion: 1.0
-Nodes (1): isoToUnix
+Nodes (1): fetchPartnerPortoneId
 
 ### Community 220 - "Community 220"
 Cohesion: 1.0
-Nodes (1): fetchPartnerPortoneId
+Nodes (1): requireNonEmpty
 
 ### Community 221 - "Community 221"
 Cohesion: 1.0
-Nodes (1): requireNonEmpty
+Nodes (1): validateBizType
 
 ### Community 222 - "Community 222"
 Cohesion: 1.0
-Nodes (1): validateBizType
+Nodes (1): validateBizNumber
 
 ### Community 223 - "Community 223"
 Cohesion: 1.0
-Nodes (1): validateBizNumber
+Nodes (1): validatePhone
 
 ### Community 224 - "Community 224"
 Cohesion: 1.0
-Nodes (1): validatePhone
+Nodes (1): validateEmail
 
 ### Community 225 - "Community 225"
 Cohesion: 1.0
-Nodes (1): validateEmail
+Nodes (1): IamportPayment
 
 ### Community 226 - "Community 226"
 Cohesion: 1.0
-Nodes (1): IamportPayment
+Nodes (1): PartnerPermission
 
 ### Community 227 - "Community 227"
 Cohesion: 1.0
-Nodes (1): PartnerPermission
+Nodes (1): _shared/env_keystore
 
 ### Community 228 - "Community 228"
 Cohesion: 1.0
-Nodes (1): _shared/env_keystore
+Nodes (1): _shared/worker_utils
 
 ### Community 229 - "Community 229"
 Cohesion: 1.0
-Nodes (1): _shared/worker_utils
+Nodes (1): EmbeddingAdapter
 
 ### Community 230 - "Community 230"
 Cohesion: 1.0
-Nodes (1): EmbeddingAdapter
+Nodes (1): Apply Event Integration Test
 
 ### Community 231 - "Community 231"
 Cohesion: 1.0
-Nodes (1): Apply Event Integration Test
+Nodes (1): settlement-transfer Test Suite
 
 ### Community 232 - "Community 232"
 Cohesion: 1.0
-Nodes (1): settlement-transfer Test Suite
+Nodes (0): 
 
 ### Community 233 - "Community 233"
 Cohesion: 1.0
@@ -1729,293 +1728,289 @@ Nodes (0):
 
 ### Community 256 - "Community 256"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): landing_user ESLint Config
 
 ### Community 257 - "Community 257"
 Cohesion: 1.0
-Nodes (1): landing_user ESLint Config
+Nodes (1): LandingUserPage
 
 ### Community 258 - "Community 258"
 Cohesion: 1.0
-Nodes (1): LandingUserPage
+Nodes (1): Integration Test Driver
 
 ### Community 259 - "Community 259"
 Cohesion: 1.0
-Nodes (1): Integration Test Driver
+Nodes (1): reporter.dart (AutoLabelAllureReporter)
 
 ### Community 260 - "Community 260"
 Cohesion: 1.0
-Nodes (1): reporter.dart (AutoLabelAllureReporter)
+Nodes (1): Alchemist Package
 
 ### Community 261 - "Community 261"
 Cohesion: 1.0
-Nodes (1): Alchemist Package
+Nodes (1): AuthCoordinator Unit Test
 
 ### Community 262 - "Community 262"
 Cohesion: 1.0
-Nodes (1): AuthCoordinator Unit Test
+Nodes (1): DeletionCompletePage Test
 
 ### Community 263 - "Community 263"
 Cohesion: 1.0
-Nodes (1): DeletionCompletePage Test
+Nodes (1): StatusBadge Widget Test
 
 ### Community 264 - "Community 264"
 Cohesion: 1.0
-Nodes (1): StatusBadge Widget Test
+Nodes (1): permission_grant_test (patrol, skipped)
 
 ### Community 265 - "Community 265"
 Cohesion: 1.0
-Nodes (1): permission_grant_test (patrol, skipped)
+Nodes (1): payment_pg_test (patrol, skipped)
 
 ### Community 266 - "Community 266"
 Cohesion: 1.0
-Nodes (1): payment_pg_test (patrol, skipped)
+Nodes (1): kakao_login_test (patrol, skipped)
 
 ### Community 267 - "Community 267"
 Cohesion: 1.0
-Nodes (1): kakao_login_test (patrol, skipped)
+Nodes (0): 
 
 ### Community 268 - "Community 268"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): _StepIndicator / _Footer (wizard parts)
 
 ### Community 269 - "Community 269"
 Cohesion: 1.0
-Nodes (1): _StepIndicator / _Footer (wizard parts)
+Nodes (1): ShareUtils
 
 ### Community 270 - "Community 270"
 Cohesion: 1.0
-Nodes (1): ShareUtils
+Nodes (1): app_user AppRouter (app_router.dart)
 
 ### Community 271 - "Community 271"
 Cohesion: 1.0
-Nodes (1): app_user AppRouter (app_router.dart)
+Nodes (1): DownloadBottomSheet CSV Test
 
 ### Community 272 - "Community 272"
 Cohesion: 1.0
-Nodes (1): DownloadBottomSheet CSV Test
+Nodes (1): ReviewVerificationScreen snapshot_data Type Guard Test
 
 ### Community 273 - "Community 273"
 Cohesion: 1.0
-Nodes (1): ReviewVerificationScreen snapshot_data Type Guard Test
+Nodes (1): AccountDeletion Flow Logic Unit Test
 
 ### Community 274 - "Community 274"
 Cohesion: 1.0
-Nodes (1): AccountDeletion Flow Logic Unit Test
+Nodes (1): DefaultFirebaseOptions
 
 ### Community 275 - "Community 275"
 Cohesion: 1.0
-Nodes (1): DefaultFirebaseOptions
+Nodes (1): MinglitEditableSection
 
 ### Community 276 - "Community 276"
 Cohesion: 1.0
-Nodes (1): MinglitEditableSection
+Nodes (1): TodayPartyCard
 
 ### Community 277 - "Community 277"
 Cohesion: 1.0
-Nodes (1): TodayPartyCard
+Nodes (1): SettlementListShimmer
 
 ### Community 278 - "Community 278"
 Cohesion: 1.0
-Nodes (1): SettlementListShimmer
+Nodes (1): EventCard
 
 ### Community 279 - "Community 279"
 Cohesion: 1.0
-Nodes (1): EventCard
+Nodes (1): PartyImageEditor
 
 ### Community 280 - "Community 280"
 Cohesion: 1.0
-Nodes (1): PartyImageEditor
+Nodes (1): PartyStatusEditSheet
 
 ### Community 281 - "Community 281"
 Cohesion: 1.0
-Nodes (1): PartyStatusEditSheet
+Nodes (1): PartyVerificationInput
 
 ### Community 282 - "Community 282"
 Cohesion: 1.0
-Nodes (1): PartyVerificationInput
+Nodes (1): app_partner AppRoutes (app_routes.dart)
 
 ### Community 283 - "Community 283"
 Cohesion: 1.0
-Nodes (1): app_partner AppRoutes (app_routes.dart)
+Nodes (1): app_partner AppRouter (app_router.dart)
 
 ### Community 284 - "Community 284"
 Cohesion: 1.0
-Nodes (1): app_partner AppRouter (app_router.dart)
+Nodes (1): Landing Partner PostCSS Config
 
 ### Community 285 - "Community 285"
 Cohesion: 1.0
-Nodes (1): Landing Partner PostCSS Config
+Nodes (1): Landing Partner ESLint Config
 
 ### Community 286 - "Community 286"
 Cohesion: 1.0
-Nodes (1): Landing Partner ESLint Config
+Nodes (1): Landing Partner Home Page
 
 ### Community 287 - "Community 287"
 Cohesion: 1.0
-Nodes (1): Landing Partner Home Page
+Nodes (1): Landing Partner Privacy Policy Page
 
 ### Community 288 - "Community 288"
 Cohesion: 1.0
-Nodes (1): Landing Partner Privacy Policy Page
+Nodes (1): AppUser README
 
 ### Community 289 - "Community 289"
 Cohesion: 1.0
-Nodes (1): AppUser README
+Nodes (1): App Partner README
 
 ### Community 290 - "Community 290"
 Cohesion: 1.0
-Nodes (1): App Partner README
+Nodes (1): landing_user README
 
 ### Community 291 - "Community 291"
 Cohesion: 1.0
-Nodes (1): landing_user README
+Nodes (1): Landing Partner README
 
 ### Community 292 - "Community 292"
 Cohesion: 1.0
-Nodes (1): Landing Partner README
+Nodes (1): minglit_kit CHANGELOG
 
 ### Community 293 - "Community 293"
 Cohesion: 1.0
-Nodes (1): minglit_kit CHANGELOG
+Nodes (1): minglit_kit README
 
 ### Community 294 - "Community 294"
 Cohesion: 1.0
-Nodes (1): minglit_kit README
+Nodes (1): Pretendard Font OFL License
 
 ### Community 295 - "Community 295"
 Cohesion: 1.0
-Nodes (1): Pretendard Font OFL License
+Nodes (1): 구매 내역 색상 위계 리디자인 와이어프레임
 
 ### Community 296 - "Community 296"
 Cohesion: 1.0
-Nodes (1): 구매 내역 색상 위계 리디자인 와이어프레임
+Nodes (1): My Tickets Test Plan
 
 ### Community 297 - "Community 297"
 Cohesion: 1.0
-Nodes (1): My Tickets Test Plan
+Nodes (1): Partner Detail Event Card Wireframe
 
 ### Community 298 - "Community 298"
 Cohesion: 1.0
-Nodes (1): Partner Detail Event Card Wireframe
+Nodes (1): MinglitEmptyState Variants Wireframe
 
 ### Community 299 - "Community 299"
 Cohesion: 1.0
-Nodes (1): MinglitEmptyState Variants Wireframe
+Nodes (1): 파트너 정산 어드민 UI/UX 설계
 
 ### Community 300 - "Community 300"
 Cohesion: 1.0
-Nodes (1): 파트너 정산 어드민 UI/UX 설계
+Nodes (1): Event Now Bar Technical Plan
 
 ### Community 301 - "Community 301"
 Cohesion: 1.0
-Nodes (1): Event Now Bar Technical Plan
+Nodes (1): Security Audit Report — Tag Discovery Phase 1
 
 ### Community 302 - "Community 302"
 Cohesion: 1.0
-Nodes (1): Security Audit Report — Tag Discovery Phase 1
+Nodes (1): Runtime QA Bug — app_partner DevUserSwitchScreen Non-functional + am force-stop Auto-login Failure
 
 ### Community 303 - "Community 303"
 Cohesion: 1.0
-Nodes (1): Runtime QA Bug — app_partner DevUserSwitchScreen Non-functional + am force-stop Auto-login Failure
+Nodes (1): Issue #1542: Login 페이지 다크 테마 일관성 (P3-low)
 
 ### Community 304 - "Community 304"
 Cohesion: 1.0
-Nodes (1): Issue #1542: Login 페이지 다크 테마 일관성 (P3-low)
+Nodes (1): Bug Report — P-S31 /dev Deeplink 404
 
 ### Community 305 - "Community 305"
 Cohesion: 1.0
-Nodes (1): Bug Report — P-S31 /dev Deeplink 404
+Nodes (1): Runtime QA — CUJ-U03 Refund Button Label Mismatch
 
 ### Community 306 - "Community 306"
 Cohesion: 1.0
-Nodes (1): Runtime QA — CUJ-U03 Refund Button Label Mismatch
+Nodes (1): Runtime QA Bug — Build Server Disk Full (98%)
 
 ### Community 307 - "Community 307"
 Cohesion: 1.0
-Nodes (1): Runtime QA Bug — Build Server Disk Full (98%)
+Nodes (1): Runtime QA Bug — Pixel 7a ADB Wireless Session Disconnect
 
 ### Community 308 - "Community 308"
 Cohesion: 1.0
-Nodes (1): Runtime QA Bug — Pixel 7a ADB Wireless Session Disconnect
+Nodes (1): Ops Alert #990 — Dependabot CI Actions Update (actions/checkout v4->v6)
 
 ### Community 309 - "Community 309"
 Cohesion: 1.0
-Nodes (1): Ops Alert #990 — Dependabot CI Actions Update (actions/checkout v4->v6)
+Nodes (1): App logo: purple gradient speech bubble with white 'm', orange sparkle accent
 
 ### Community 310 - "Community 310"
 Cohesion: 1.0
-Nodes (1): App logo: purple gradient speech bubble with white 'm', orange sparkle accent
+Nodes (1): App splash icon: purple gradient chat bubble with white 'm' and orange sparkle
 
 ### Community 311 - "Community 311"
 Cohesion: 1.0
-Nodes (1): App splash icon: purple gradient chat bubble with white 'm' and orange sparkle
+Nodes (1): Minglit app splash icon: purple chat bubble with white 'm' and orange sparkle
 
 ### Community 312 - "Community 312"
 Cohesion: 1.0
-Nodes (1): Minglit app splash icon: purple chat bubble with white 'm' and orange sparkle
+Nodes (1): App icon foreground: purple chat bubble with white 'm' and orange sparkle
 
 ### Community 313 - "Community 313"
 Cohesion: 1.0
-Nodes (1): App icon foreground: purple chat bubble with white 'm' and orange sparkle
+Nodes (1): Purple-blue gradient background image for app_partner icon
 
 ### Community 314 - "Community 314"
 Cohesion: 1.0
-Nodes (1): Purple-blue gradient background image for app_partner icon
+Nodes (1): Minglit inverted logo: white wordmark with cyan and orange shadow layers on transparent background
 
 ### Community 315 - "Community 315"
 Cohesion: 1.0
-Nodes (1): Minglit inverted logo: white wordmark with cyan and orange shadow layers on transparent background
+Nodes (1): Minglit wordmark logo SVG with transparent background, cyan/orange layered text
 
 ### Community 316 - "Community 316"
 Cohesion: 1.0
-Nodes (1): Minglit wordmark logo SVG with transparent background, cyan/orange layered text
+Nodes (1): Minglit app bar logo — bold italic 'Minglit' text in purple with cyan and orange shadow layers
 
 ### Community 317 - "Community 317"
 Cohesion: 1.0
-Nodes (1): Minglit app bar logo — bold italic 'Minglit' text in purple with cyan and orange shadow layers
+Nodes (1): Upscale lounge/restaurant interior with bar, green velvet chairs, Asian art, warm lighting
 
 ### Community 318 - "Community 318"
 Cohesion: 1.0
-Nodes (1): Upscale lounge/restaurant interior with bar, green velvet chairs, Asian art, warm lighting
+Nodes (1): Bright minimalist Korean cafe interior with numbered wooden tables, plants, string lights, and coffee bar
 
 ### Community 319 - "Community 319"
 Cohesion: 1.0
-Nodes (1): Bright minimalist Korean cafe interior with numbered wooden tables, plants, string lights, and coffee bar
+Nodes (1): Warm sunlit cafe interior with wood furniture, plants, string lights, and menu board
 
 ### Community 320 - "Community 320"
 Cohesion: 1.0
-Nodes (1): Warm sunlit cafe interior with wood furniture, plants, string lights, and menu board
+Nodes (1): Participation status redesign (after) — not-logged-in state with counts and login prompt
 
 ### Community 321 - "Community 321"
 Cohesion: 1.0
-Nodes (1): Participation status redesign (after) — not-logged-in state with counts and login prompt
+Nodes (1): Dark theme participation status redesign, 2-group male/female layout with progress bars
 
 ### Community 322 - "Community 322"
 Cohesion: 1.0
-Nodes (1): Dark theme participation status redesign, 2-group male/female layout with progress bars
+Nodes (1): Participation status redesign after-state with 4 groups showing 12/40 total and per-group cards
 
 ### Community 323 - "Community 323"
 Cohesion: 1.0
-Nodes (1): Participation status redesign after-state with 4 groups showing 12/40 total and per-group cards
+Nodes (1): Empty participation status UI: 0/20 total, 0/10 male/female, empty state message
 
 ### Community 324 - "Community 324"
 Cohesion: 1.0
-Nodes (1): Empty participation status UI: 0/20 total, 0/10 male/female, empty state message
+Nodes (1): Participation status redesign after variant: 2-group (male/female) split with progress bars
 
 ### Community 325 - "Community 325"
 Cohesion: 1.0
-Nodes (1): Participation status redesign after variant: 2-group (male/female) split with progress bars
+Nodes (1): Participation status redesign: 2-group (male/female) expanded view with counts and age breakdowns
 
 ### Community 326 - "Community 326"
 Cohesion: 1.0
-Nodes (1): Participation status redesign: 2-group (male/female) expanded view with counts and age breakdowns
-
-### Community 327 - "Community 327"
-Cohesion: 1.0
 Nodes (1): Before state: participation status UI with male/female groups, 2/10 capacity each
 
-### Community 328 - "Community 328"
+### Community 327 - "Community 327"
 Cohesion: 1.0
 Nodes (1): user_profiles Table
 
@@ -2026,7 +2021,7 @@ Nodes (1): user_profiles Table
   /Users/mark/workspace/minglit-graphify-init/docs/reports/architecture/2026-04-05-issue1092-architect-audit-report-architecture-audit.md · relation: conceptually_related_to
 
 ## Knowledge Gaps
-- **2049 isolated node(s):** `reporter (AutoLabelAllureReporter)`, `BugReporterWrapper Widget Test Suite`, `MinglitListTile Widget Test Suite`, `MinglitHorizontalScrollGroup Widget Test Suite`, `MinglitContentLayout Widget Test Suite` (+2044 more)
+- **2030 isolated node(s):** `reporter (AutoLabelAllureReporter)`, `BugReporterWrapper Widget Test Suite`, `MinglitListTile Widget Test Suite`, `MinglitHorizontalScrollGroup Widget Test Suite`, `MinglitContentLayout Widget Test Suite` (+2025 more)
   These have ≤1 connection - possible missing edges or undocumented components.
 - **Thin community `Community 112`** (2 nodes): `MinglitFilePicker Widget`, `MinglitFilePicker Widget Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -2054,413 +2049,411 @@ Nodes (1): user_profiles Table
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 124`** (2 nodes): `event_repository_application_queries.dart`, `_EventRepositoryApplicationQueries`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 125`** (2 nodes): `minglit_timeline_step.dart`, `MinglitTimelineStep`
+- **Thin community `Community 125`** (2 nodes): `noop()`, `sim_settle_test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 126`** (2 nodes): `noop()`, `sim_settle_test.ts`
+- **Thin community `Community 126`** (2 nodes): `notification-worker loop_worker Tests`, `notification-worker loop_worker`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 127`** (2 nodes): `notification-worker loop_worker Tests`, `notification-worker loop_worker`
+- **Thin community `Community 127`** (2 nodes): `postRequest()`, `index_test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 128`** (2 nodes): `postRequest()`, `index_test.ts`
+- **Thin community `Community 128`** (2 nodes): `nowUnix`, `WorkerUtils`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 129`** (2 nodes): `nowUnix`, `WorkerUtils`
+- **Thin community `Community 129`** (2 nodes): `mock_events.dart`, `MockEvent`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 130`** (2 nodes): `mock_events.dart`, `MockEvent`
+- **Thin community `Community 130`** (2 nodes): `RootLayout()`, `layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 131`** (2 nodes): `RootLayout()`, `layout.tsx`
+- **Thin community `Community 131`** (2 nodes): `ScreensPage()`, `page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 132`** (2 nodes): `ScreensPage()`, `page.tsx`
+- **Thin community `Community 132`** (2 nodes): `getIcons()`, `page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 133`** (2 nodes): `getIcons()`, `page.tsx`
+- **Thin community `Community 133`** (2 nodes): `MermaidDiagram()`, `MermaidDiagram.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 134`** (2 nodes): `MermaidDiagram()`, `MermaidDiagram.tsx`
+- **Thin community `Community 134`** (2 nodes): `SubComponentRow()`, `RouteScreenIndex.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 135`** (2 nodes): `SubComponentRow()`, `RouteScreenIndex.tsx`
+- **Thin community `Community 135`** (2 nodes): `DialogStyles()`, `MinglitDialogSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 136`** (2 nodes): `DialogStyles()`, `MinglitDialogSpec.tsx`
+- **Thin community `Community 136`** (2 nodes): `OverlayStyles()`, `MinglitAlertSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 137`** (2 nodes): `OverlayStyles()`, `MinglitAlertSpec.tsx`
+- **Thin community `Community 137`** (2 nodes): `CircleSpinner()`, `MinglitAsyncValueWidgetSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 138`** (2 nodes): `CircleSpinner()`, `MinglitAsyncValueWidgetSpec.tsx`
+- **Thin community `Community 138`** (2 nodes): `SegmentedBar()`, `MinglitCapacityBarSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 139`** (2 nodes): `SegmentedBar()`, `MinglitCapacityBarSpec.tsx`
+- **Thin community `Community 139`** (2 nodes): `ChipStub()`, `MinglitHorizontalScrollGroupSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 140`** (2 nodes): `ChipStub()`, `MinglitHorizontalScrollGroupSpec.tsx`
+- **Thin community `Community 140`** (2 nodes): `DividerDemo()`, `MinglitSectionDividerSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 141`** (2 nodes): `DividerDemo()`, `MinglitSectionDividerSpec.tsx`
+- **Thin community `Community 141`** (2 nodes): `Btn()`, `MinglitButtonSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 142`** (2 nodes): `Btn()`, `MinglitButtonSpec.tsx`
+- **Thin community `Community 142`** (2 nodes): `ContentCardDemo()`, `MinglitContentCardSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 143`** (2 nodes): `ContentCardDemo()`, `MinglitContentCardSpec.tsx`
+- **Thin community `Community 143`** (2 nodes): `FooDemo()`, `_template.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 144`** (2 nodes): `FooDemo()`, `_template.tsx`
+- **Thin community `Community 144`** (2 nodes): `Badge()`, `MinglitListTileSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 145`** (2 nodes): `Badge()`, `MinglitListTileSpec.tsx`
+- **Thin community `Community 145`** (2 nodes): `SheetStyles()`, `MinglitBottomSheetSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 146`** (2 nodes): `SheetStyles()`, `MinglitBottomSheetSpec.tsx`
+- **Thin community `Community 146`** (2 nodes): `SkeletonBlock()`, `MinglitSkeletonSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 147`** (2 nodes): `SkeletonBlock()`, `MinglitSkeletonSpec.tsx`
+- **Thin community `Community 147`** (2 nodes): `validateBuildEnv`, `landing_user Next.js Config`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 148`** (2 nodes): `validateBuildEnv`, `landing_user Next.js Config`
+- **Thin community `Community 148`** (2 nodes): `PrivacyPage()`, `page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 149`** (2 nodes): `PrivacyPage()`, `page.tsx`
+- **Thin community `Community 149`** (2 nodes): `BrandPage`, `MingleSymbol SVG Component`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 150`** (2 nodes): `BrandPage`, `MingleSymbol SVG Component`
+- **Thin community `Community 150`** (2 nodes): `VisualQaTester Extension`, `VisualQaTester Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 151`** (2 nodes): `VisualQaTester Extension`, `VisualQaTester Test`
+- **Thin community `Community 151`** (2 nodes): `AdmissionButtonConfig Test`, `AdmissionState Edge Cases Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 152`** (2 nodes): `boardingPassStatus Function`, `BoardingPassStatus Test`
+- **Thin community `Community 152`** (2 nodes): `signup_consent_definitions.dart`, `_ConsentDefinition`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 153`** (2 nodes): `AdmissionButtonConfig Test`, `AdmissionState Edge Cases Test`
+- **Thin community `Community 153`** (2 nodes): `boardingPassStatus Function`, `BoardingPassStatus Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 154`** (2 nodes): `signup_consent_definitions.dart`, `_ConsentDefinition`
+- **Thin community `Community 154`** (2 nodes): `StatusFilterChips Widget Test`, `StatusFilterChips Widget`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 155`** (2 nodes): `SettlementStatusBadge Test`, `SettlementStatusBadge / SettlementStatus`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 156`** (2 nodes): `StatusFilterChips Widget Test`, `StatusFilterChips Widget`
+- **Thin community `Community 156`** (2 nodes): `PartyListItem`, `PartyListPage`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 157`** (2 nodes): `PartyListItem`, `PartyListPage`
+- **Thin community `Community 157`** (2 nodes): `partyTicketsProvider`, `TicketManageScreen`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 158`** (2 nodes): `partyTicketsProvider`, `TicketManageScreen`
+- **Thin community `Community 158`** (2 nodes): `Landing Partner Env Validator`, `Landing Partner Next.js Config`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 159`** (2 nodes): `Landing Partner Env Validator`, `Landing Partner Next.js Config`
+- **Thin community `Community 159`** (2 nodes): `개인정보 보호 인증 열람 권한 관리 UI/UX`, `개인정보 보호 와이어프레임`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 160`** (2 nodes): `개인정보 보호 인증 열람 권한 관리 UI/UX`, `개인정보 보호 와이어프레임`
+- **Thin community `Community 160`** (2 nodes): `Metabase BI Dashboard`, `Statistics & Analytics Tools Spec`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 161`** (2 nodes): `Metabase BI Dashboard`, `Statistics & Analytics Tools Spec`
+- **Thin community `Community 161`** (2 nodes): `Simulator Edge Function Migration Plan`, `Simulator Lifecycle Fix Plan`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 162`** (2 nodes): `Pretendard Font Migration Typography Review`, `Login Dark Theme Wireframe`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 163`** (2 nodes): `Simulator Edge Function Migration Plan`, `Simulator Lifecycle Fix Plan`
+- **Thin community `Community 163`** (2 nodes): `Settings UI Redesign UX Design`, `Settings UI Redesign Wireframe`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 164`** (2 nodes): `Settings UI Redesign UX Design`, `Settings UI Redesign Wireframe`
+- **Thin community `Community 164`** (2 nodes): `Refund Policy v2 Wireframe (Original)`, `Refund Policy v2 Wireframe (UX Review)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 165`** (2 nodes): `Refund Policy v2 Wireframe (Original)`, `Refund Policy v2 Wireframe (UX Review)`
+- **Thin community `Community 165`** (2 nodes): `Trust Badge System Spec`, `Trust Badge UI/UX Design`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 166`** (2 nodes): `Trust Badge System Spec`, `Trust Badge UI/UX Design`
+- **Thin community `Community 166`** (2 nodes): `Refund Policy: Terms of Service Page`, `TPM Report — Refund Policy Terms-Code Mismatch`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 167`** (2 nodes): `TPM Report — dev Branch Protection Change Blocks All PR Merges`, `TPM Report — review-presence Workflow Defect Blocking P0 PR #903`
+- **Thin community `Community 167`** (2 nodes): `Bug: BugReport FAB overlaps MyPage navigation button (PR #1268 regression)`, `Runtime QA Bug #1285: BugReport FAB Blocks MyPage Button Touch Area`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 168`** (2 nodes): `TPM Report — needs-dev Backlog Surge 30 Issues, 10% Digest Rate`, `TPM Report — Duplicate Issue Creation Pattern`
+- **Thin community `Community 168`** (2 nodes): `Bug: Refund button not shown for free ticket (paymentId null canCancel logic)`, `Runtime QA Bug #1652: CUJ-U03 Refund Button Not Shown in Purchase History`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 169`** (2 nodes): `Refund Policy: Terms of Service Page`, `TPM Report — Refund Policy Terms-Code Mismatch`
+- **Thin community `Community 169`** (2 nodes): `Bug: Hot Tags section shows 0-event tags — conceptual contradiction`, `Runtime QA Bug #1286: Hot Tags Section Shows 0-Event Tags`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 170`** (2 nodes): `Bug: BugReport FAB overlaps MyPage navigation button (PR #1268 regression)`, `Runtime QA Bug #1285: BugReport FAB Blocks MyPage Button Touch Area`
+- **Thin community `Community 170`** (2 nodes): `TPM Report — needs-dev Backlog Surge 30 Issues, 10% Digest Rate`, `TPM Report — Duplicate Issue Creation Pattern`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 171`** (2 nodes): `Bug: Refund button not shown for free ticket (paymentId null canCancel logic)`, `Runtime QA Bug #1652: CUJ-U03 Refund Button Not Shown in Purchase History`
+- **Thin community `Community 171`** (2 nodes): `CI Issue: Vercel Deploy Cascading Cancel (cron + concurrency)`, `TPM Report #1091: Vercel Deploy 20h+ Cascading Failure — Cron Concurrency`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 172`** (2 nodes): `Bug: Hot Tags section shows 0-event tags — conceptual contradiction`, `Runtime QA Bug #1286: Hot Tags Section Shows 0-Event Tags`
+- **Thin community `Community 172`** (2 nodes): `TPM Report — dev Branch Protection Change Blocks All PR Merges`, `TPM Report — review-presence Workflow Defect Blocking P0 PR #903`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 173`** (2 nodes): `CI Issue: Vercel Deploy Cascading Cancel (cron + concurrency)`, `TPM Report #1091: Vercel Deploy 20h+ Cascading Failure — Cron Concurrency`
+- **Thin community `Community 173`** (2 nodes): `Bug Report — CUJ-P03 QR Scanner Summary Card and Entry Group Stats Missing`, `Bug Report — CUJ-P01 Party Create Wizard Step 3 Next Uncertain`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 174`** (2 nodes): `Bug Report — CUJ-P03 QR Scanner Summary Card and Entry Group Stats Missing`, `Bug Report — CUJ-P01 Party Create Wizard Step 3 Next Uncertain`
+- **Thin community `Community 174`** (2 nodes): `이벤트 수정/취소 기능 미구현 — EventEditRoute/cancelEvent 없음`, `Issue #1338: app_partner 이벤트 수정/취소 통합 테스트 추가 (blocked)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 175`** (2 nodes): `이벤트 수정/취소 기능 미구현 — EventEditRoute/cancelEvent 없음`, `Issue #1338: app_partner 이벤트 수정/취소 통합 테스트 추가 (blocked)`
+- **Thin community `Community 175`** (2 nodes): `UIautomator × Flutter 호환성 한계 — 단일 FlutterSurfaceView로 좌표 탭 부정확`, `Issue #1291: 이벤트 상세 파트너명 탭 시 파트너 상세 이동 안 됨 (U-S05)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 176`** (2 nodes): `UIautomator × Flutter 호환성 한계 — 단일 FlutterSurfaceView로 좌표 탭 부정확`, `Issue #1291: 이벤트 상세 파트너명 탭 시 파트너 상세 이동 안 됨 (U-S05)`
+- **Thin community `Community 176`** (2 nodes): `Alert #1506: Version Bump Failed`, `Version Bump Push Race Condition`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 177`** (2 nodes): `Alert #1506: Version Bump Failed`, `Version Bump Push Race Condition`
+- **Thin community `Community 177`** (2 nodes): `Backend Simulator Edge Function Timeout Issue`, `Ops Alert #703 — Daily Backend Simulation Failed (2026-03-28)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 178`** (2 nodes): `Backend Simulator Edge Function Timeout Issue`, `Ops Alert #703 — Daily Backend Simulation Failed (2026-03-28)`
+- **Thin community `Community 178`** (2 nodes): `Duplicate MainActivity in Android Source Sets (src/main + src/dev)`, `Incident #1322: Hard Block — MainActivity Redeclaration on Dev Branch`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 179`** (2 nodes): `Duplicate MainActivity in Android Source Sets (src/main + src/dev)`, `Incident #1322: Hard Block — MainActivity Redeclaration on Dev Branch`
+- **Thin community `Community 179`** (1 nodes): `_RefundRow Widget`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 180`** (1 nodes): `_RefundRow Widget`
+- **Thin community `Community 180`** (1 nodes): `reporter (AutoLabelAllureReporter)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 181`** (1 nodes): `reporter (AutoLabelAllureReporter)`
+- **Thin community `Community 181`** (1 nodes): `MinglitListTile Widget Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 182`** (1 nodes): `MinglitListTile Widget Test Suite`
+- **Thin community `Community 182`** (1 nodes): `MinglitContentLayout Widget Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 183`** (1 nodes): `MinglitContentLayout Widget Test Suite`
+- **Thin community `Community 183`** (1 nodes): `MinglitBottomCTA Widget Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 184`** (1 nodes): `MinglitBottomCTA Widget Test Suite`
+- **Thin community `Community 184`** (1 nodes): `MinglitImageCarousel Widget Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 185`** (1 nodes): `MinglitImageCarousel Widget Test Suite`
+- **Thin community `Community 185`** (1 nodes): `MinglitImage Widget Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 186`** (1 nodes): `MinglitImage Widget Test Suite`
+- **Thin community `Community 186`** (1 nodes): `MockSupabaseClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 187`** (1 nodes): `MockSupabaseClient`
+- **Thin community `Community 187`** (1 nodes): `minglit_dev.dart (barrel: dev/debug tools)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 188`** (1 nodes): `minglit_dev.dart (barrel: dev/debug tools)`
+- **Thin community `Community 188`** (1 nodes): `iamport.dart`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 189`** (1 nodes): `iamport.dart`
+- **Thin community `Community 189`** (1 nodes): `TicketCrypto`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 190`** (1 nodes): `TicketCrypto`
+- **Thin community `Community 190`** (1 nodes): `Tag model`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 191`** (1 nodes): `Tag model`
+- **Thin community `Community 191`** (1 nodes): `EventFeedType`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 192`** (1 nodes): `EventFeedType`
+- **Thin community `Community 192`** (1 nodes): `ConditionKey Enum`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 193`** (1 nodes): `ConditionKey Enum`
+- **Thin community `Community 193`** (1 nodes): `mds.dart`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 194`** (1 nodes): `mds.dart`
+- **Thin community `Community 194`** (1 nodes): `mds_icons.dart`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 195`** (1 nodes): `mds_icons.dart`
+- **Thin community `Community 195`** (1 nodes): `recurrence-cron Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 196`** (1 nodes): `recurrence-cron Test Suite`
+- **Thin community `Community 196`** (1 nodes): `payment-verify Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 197`** (1 nodes): `payment-verify Test Suite`
+- **Thin community `Community 197`** (1 nodes): `recurrence-rules Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 198`** (1 nodes): `recurrence-rules Test Suite`
+- **Thin community `Community 198`** (1 nodes): `payout-sync Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 199`** (1 nodes): `payout-sync Test Suite`
+- **Thin community `Community 199`** (1 nodes): `reconciliation-daily Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 200`** (1 nodes): `reconciliation-daily Test Suite`
+- **Thin community `Community 200`** (1 nodes): `settlement-query Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 201`** (1 nodes): `settlement-query Test Suite`
+- **Thin community `Community 201`** (1 nodes): `health_test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 202`** (1 nodes): `health_test.ts`
+- **Thin community `Community 202`** (1 nodes): `Std Server Stub`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 203`** (1 nodes): `Std Server Stub`
+- **Thin community `Community 203`** (1 nodes): `Mock Supabase Client`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 204`** (1 nodes): `Mock Supabase Client`
+- **Thin community `Community 204`** (1 nodes): `Schema Validator`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 205`** (1 nodes): `Schema Validator`
+- **Thin community `Community 205`** (1 nodes): `sim_assertions_test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 206`** (1 nodes): `sim_assertions_test.ts`
+- **Thin community `Community 206`** (1 nodes): `sim_reporter_test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 207`** (1 nodes): `sim_reporter_test.ts`
+- **Thin community `Community 207`** (1 nodes): `process-pending-deletions Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 208`** (1 nodes): `process-pending-deletions Test Suite`
+- **Thin community `Community 208`** (1 nodes): `DB: match_votes (via RPC cast_match_vote)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 209`** (1 nodes): `DB: match_votes (via RPC cast_match_vote)`
+- **Thin community `Community 209`** (1 nodes): `settlement-register-transfers Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 210`** (1 nodes): `settlement-register-transfers Test Suite`
+- **Thin community `Community 210`** (1 nodes): `payment_webhook_test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 211`** (1 nodes): `payment_webhook_test.ts`
+- **Thin community `Community 211`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 212`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 213`** (1 nodes): `index.ts`
+- **Thin community `Community 213`** (1 nodes): `user-cancel-deletion Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 214`** (1 nodes): `user-cancel-deletion Test Suite`
+- **Thin community `Community 214`** (1 nodes): `Response Utils (errorResponse)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 215`** (1 nodes): `Response Utils (errorResponse)`
+- **Thin community `Community 215`** (1 nodes): `corsResponse`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 216`** (1 nodes): `corsResponse`
+- **Thin community `Community 216`** (1 nodes): `Supabase Service Client (createServiceClient)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 217`** (1 nodes): `Supabase Service Client (createServiceClient)`
+- **Thin community `Community 217`** (1 nodes): `nowISO`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 218`** (1 nodes): `nowISO`
+- **Thin community `Community 218`** (1 nodes): `isoToUnix`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 219`** (1 nodes): `isoToUnix`
+- **Thin community `Community 219`** (1 nodes): `fetchPartnerPortoneId`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 220`** (1 nodes): `fetchPartnerPortoneId`
+- **Thin community `Community 220`** (1 nodes): `requireNonEmpty`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 221`** (1 nodes): `requireNonEmpty`
+- **Thin community `Community 221`** (1 nodes): `validateBizType`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 222`** (1 nodes): `validateBizType`
+- **Thin community `Community 222`** (1 nodes): `validateBizNumber`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 223`** (1 nodes): `validateBizNumber`
+- **Thin community `Community 223`** (1 nodes): `validatePhone`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 224`** (1 nodes): `validatePhone`
+- **Thin community `Community 224`** (1 nodes): `validateEmail`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 225`** (1 nodes): `validateEmail`
+- **Thin community `Community 225`** (1 nodes): `IamportPayment`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (1 nodes): `IamportPayment`
+- **Thin community `Community 226`** (1 nodes): `PartnerPermission`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (1 nodes): `PartnerPermission`
+- **Thin community `Community 227`** (1 nodes): `_shared/env_keystore`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (1 nodes): `_shared/env_keystore`
+- **Thin community `Community 228`** (1 nodes): `_shared/worker_utils`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 229`** (1 nodes): `_shared/worker_utils`
+- **Thin community `Community 229`** (1 nodes): `EmbeddingAdapter`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (1 nodes): `EmbeddingAdapter`
+- **Thin community `Community 230`** (1 nodes): `Apply Event Integration Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 231`** (1 nodes): `Apply Event Integration Test`
+- **Thin community `Community 231`** (1 nodes): `settlement-transfer Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 232`** (1 nodes): `settlement-transfer Test Suite`
+- **Thin community `Community 232`** (1 nodes): `postcss.config.mjs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 233`** (1 nodes): `postcss.config.mjs`
+- **Thin community `Community 233`** (1 nodes): `tailwind.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 234`** (1 nodes): `tailwind.config.ts`
+- **Thin community `Community 234`** (1 nodes): `eslint.config.mjs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 235`** (1 nodes): `eslint.config.mjs`
+- **Thin community `Community 235`** (1 nodes): `next.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 236`** (1 nodes): `next.config.ts`
+- **Thin community `Community 236`** (1 nodes): `page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 237`** (1 nodes): `page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 238`** (1 nodes): `page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 239`** (1 nodes): `page.tsx`
+- **Thin community `Community 239`** (1 nodes): `Sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 240`** (1 nodes): `Sidebar.tsx`
+- **Thin community `Community 240`** (1 nodes): `MinglitSettingsTileSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 241`** (1 nodes): `MinglitSettingsTileSpec.tsx`
+- **Thin community `Community 241`** (1 nodes): `MinglitKeyValueRowSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 242`** (1 nodes): `MinglitKeyValueRowSpec.tsx`
+- **Thin community `Community 242`** (1 nodes): `MinglitErrorStateSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 243`** (1 nodes): `MinglitErrorStateSpec.tsx`
+- **Thin community `Community 243`** (1 nodes): `LoadingIndicatorSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 244`** (1 nodes): `LoadingIndicatorSpec.tsx`
+- **Thin community `Community 244`** (1 nodes): `MinglitSettingsGroupSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 245`** (1 nodes): `MinglitSettingsGroupSpec.tsx`
+- **Thin community `Community 245`** (1 nodes): `MinglitTextFieldSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 246`** (1 nodes): `MinglitTextFieldSpec.tsx`
+- **Thin community `Community 246`** (1 nodes): `NumberStepperInputSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 247`** (1 nodes): `NumberStepperInputSpec.tsx`
+- **Thin community `Community 247`** (1 nodes): `MinglitChipSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 248`** (1 nodes): `MinglitChipSpec.tsx`
+- **Thin community `Community 248`** (1 nodes): `MinglitTimelineSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 249`** (1 nodes): `MinglitTimelineSpec.tsx`
+- **Thin community `Community 249`** (1 nodes): `MinglitChipGroupSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 250`** (1 nodes): `MinglitChipGroupSpec.tsx`
+- **Thin community `Community 250`** (1 nodes): `MinglitContentLayoutSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 251`** (1 nodes): `MinglitContentLayoutSpec.tsx`
+- **Thin community `Community 251`** (1 nodes): `MinglitBadgeSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 252`** (1 nodes): `MinglitBadgeSpec.tsx`
+- **Thin community `Community 252`** (1 nodes): `MinglitFilterChipSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 253`** (1 nodes): `MinglitFilterChipSpec.tsx`
+- **Thin community `Community 253`** (1 nodes): `MinglitSectionSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 254`** (1 nodes): `MinglitSectionSpec.tsx`
+- **Thin community `Community 254`** (1 nodes): `mds-icons-react.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 255`** (1 nodes): `mds-icons-react.ts`
+- **Thin community `Community 255`** (1 nodes): `postcss.config.mjs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 256`** (1 nodes): `postcss.config.mjs`
+- **Thin community `Community 256`** (1 nodes): `landing_user ESLint Config`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 257`** (1 nodes): `landing_user ESLint Config`
+- **Thin community `Community 257`** (1 nodes): `LandingUserPage`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 258`** (1 nodes): `LandingUserPage`
+- **Thin community `Community 258`** (1 nodes): `Integration Test Driver`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 259`** (1 nodes): `Integration Test Driver`
+- **Thin community `Community 259`** (1 nodes): `reporter.dart (AutoLabelAllureReporter)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 260`** (1 nodes): `reporter.dart (AutoLabelAllureReporter)`
+- **Thin community `Community 260`** (1 nodes): `Alchemist Package`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 261`** (1 nodes): `Alchemist Package`
+- **Thin community `Community 261`** (1 nodes): `AuthCoordinator Unit Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 262`** (1 nodes): `AuthCoordinator Unit Test`
+- **Thin community `Community 262`** (1 nodes): `DeletionCompletePage Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 263`** (1 nodes): `DeletionCompletePage Test`
+- **Thin community `Community 263`** (1 nodes): `StatusBadge Widget Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 264`** (1 nodes): `StatusBadge Widget Test`
+- **Thin community `Community 264`** (1 nodes): `permission_grant_test (patrol, skipped)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 265`** (1 nodes): `permission_grant_test (patrol, skipped)`
+- **Thin community `Community 265`** (1 nodes): `payment_pg_test (patrol, skipped)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 266`** (1 nodes): `payment_pg_test (patrol, skipped)`
+- **Thin community `Community 266`** (1 nodes): `kakao_login_test (patrol, skipped)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 267`** (1 nodes): `kakao_login_test (patrol, skipped)`
+- **Thin community `Community 267`** (1 nodes): `consent_detail_sheet.dart`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 268`** (1 nodes): `consent_detail_sheet.dart`
+- **Thin community `Community 268`** (1 nodes): `_StepIndicator / _Footer (wizard parts)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 269`** (1 nodes): `_StepIndicator / _Footer (wizard parts)`
+- **Thin community `Community 269`** (1 nodes): `ShareUtils`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 270`** (1 nodes): `ShareUtils`
+- **Thin community `Community 270`** (1 nodes): `app_user AppRouter (app_router.dart)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 271`** (1 nodes): `app_user AppRouter (app_router.dart)`
+- **Thin community `Community 271`** (1 nodes): `DownloadBottomSheet CSV Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 272`** (1 nodes): `DownloadBottomSheet CSV Test`
+- **Thin community `Community 272`** (1 nodes): `ReviewVerificationScreen snapshot_data Type Guard Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 273`** (1 nodes): `ReviewVerificationScreen snapshot_data Type Guard Test`
+- **Thin community `Community 273`** (1 nodes): `AccountDeletion Flow Logic Unit Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 274`** (1 nodes): `AccountDeletion Flow Logic Unit Test`
+- **Thin community `Community 274`** (1 nodes): `DefaultFirebaseOptions`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 275`** (1 nodes): `DefaultFirebaseOptions`
+- **Thin community `Community 275`** (1 nodes): `MinglitEditableSection`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 276`** (1 nodes): `MinglitEditableSection`
+- **Thin community `Community 276`** (1 nodes): `TodayPartyCard`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 277`** (1 nodes): `TodayPartyCard`
+- **Thin community `Community 277`** (1 nodes): `SettlementListShimmer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 278`** (1 nodes): `SettlementListShimmer`
+- **Thin community `Community 278`** (1 nodes): `EventCard`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 279`** (1 nodes): `EventCard`
+- **Thin community `Community 279`** (1 nodes): `PartyImageEditor`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 280`** (1 nodes): `PartyImageEditor`
+- **Thin community `Community 280`** (1 nodes): `PartyStatusEditSheet`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 281`** (1 nodes): `PartyStatusEditSheet`
+- **Thin community `Community 281`** (1 nodes): `PartyVerificationInput`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 282`** (1 nodes): `PartyVerificationInput`
+- **Thin community `Community 282`** (1 nodes): `app_partner AppRoutes (app_routes.dart)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 283`** (1 nodes): `app_partner AppRoutes (app_routes.dart)`
+- **Thin community `Community 283`** (1 nodes): `app_partner AppRouter (app_router.dart)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 284`** (1 nodes): `app_partner AppRouter (app_router.dart)`
+- **Thin community `Community 284`** (1 nodes): `Landing Partner PostCSS Config`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 285`** (1 nodes): `Landing Partner PostCSS Config`
+- **Thin community `Community 285`** (1 nodes): `Landing Partner ESLint Config`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 286`** (1 nodes): `Landing Partner ESLint Config`
+- **Thin community `Community 286`** (1 nodes): `Landing Partner Home Page`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 287`** (1 nodes): `Landing Partner Home Page`
+- **Thin community `Community 287`** (1 nodes): `Landing Partner Privacy Policy Page`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 288`** (1 nodes): `Landing Partner Privacy Policy Page`
+- **Thin community `Community 288`** (1 nodes): `AppUser README`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 289`** (1 nodes): `AppUser README`
+- **Thin community `Community 289`** (1 nodes): `App Partner README`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 290`** (1 nodes): `App Partner README`
+- **Thin community `Community 290`** (1 nodes): `landing_user README`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 291`** (1 nodes): `landing_user README`
+- **Thin community `Community 291`** (1 nodes): `Landing Partner README`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 292`** (1 nodes): `Landing Partner README`
+- **Thin community `Community 292`** (1 nodes): `minglit_kit CHANGELOG`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 293`** (1 nodes): `minglit_kit CHANGELOG`
+- **Thin community `Community 293`** (1 nodes): `minglit_kit README`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 294`** (1 nodes): `minglit_kit README`
+- **Thin community `Community 294`** (1 nodes): `Pretendard Font OFL License`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 295`** (1 nodes): `Pretendard Font OFL License`
+- **Thin community `Community 295`** (1 nodes): `구매 내역 색상 위계 리디자인 와이어프레임`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 296`** (1 nodes): `구매 내역 색상 위계 리디자인 와이어프레임`
+- **Thin community `Community 296`** (1 nodes): `My Tickets Test Plan`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 297`** (1 nodes): `My Tickets Test Plan`
+- **Thin community `Community 297`** (1 nodes): `Partner Detail Event Card Wireframe`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 298`** (1 nodes): `Partner Detail Event Card Wireframe`
+- **Thin community `Community 298`** (1 nodes): `MinglitEmptyState Variants Wireframe`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 299`** (1 nodes): `MinglitEmptyState Variants Wireframe`
+- **Thin community `Community 299`** (1 nodes): `파트너 정산 어드민 UI/UX 설계`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (1 nodes): `파트너 정산 어드민 UI/UX 설계`
+- **Thin community `Community 300`** (1 nodes): `Event Now Bar Technical Plan`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (1 nodes): `Event Now Bar Technical Plan`
+- **Thin community `Community 301`** (1 nodes): `Security Audit Report — Tag Discovery Phase 1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (1 nodes): `Security Audit Report — Tag Discovery Phase 1`
+- **Thin community `Community 302`** (1 nodes): `Runtime QA Bug — app_partner DevUserSwitchScreen Non-functional + am force-stop Auto-login Failure`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (1 nodes): `Runtime QA Bug — app_partner DevUserSwitchScreen Non-functional + am force-stop Auto-login Failure`
+- **Thin community `Community 303`** (1 nodes): `Issue #1542: Login 페이지 다크 테마 일관성 (P3-low)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 304`** (1 nodes): `Issue #1542: Login 페이지 다크 테마 일관성 (P3-low)`
+- **Thin community `Community 304`** (1 nodes): `Bug Report — P-S31 /dev Deeplink 404`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 305`** (1 nodes): `Bug Report — P-S31 /dev Deeplink 404`
+- **Thin community `Community 305`** (1 nodes): `Runtime QA — CUJ-U03 Refund Button Label Mismatch`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 306`** (1 nodes): `Runtime QA — CUJ-U03 Refund Button Label Mismatch`
+- **Thin community `Community 306`** (1 nodes): `Runtime QA Bug — Build Server Disk Full (98%)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 307`** (1 nodes): `Runtime QA Bug — Build Server Disk Full (98%)`
+- **Thin community `Community 307`** (1 nodes): `Runtime QA Bug — Pixel 7a ADB Wireless Session Disconnect`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 308`** (1 nodes): `Runtime QA Bug — Pixel 7a ADB Wireless Session Disconnect`
+- **Thin community `Community 308`** (1 nodes): `Ops Alert #990 — Dependabot CI Actions Update (actions/checkout v4->v6)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 309`** (1 nodes): `Ops Alert #990 — Dependabot CI Actions Update (actions/checkout v4->v6)`
+- **Thin community `Community 309`** (1 nodes): `App logo: purple gradient speech bubble with white 'm', orange sparkle accent`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 310`** (1 nodes): `App logo: purple gradient speech bubble with white 'm', orange sparkle accent`
+- **Thin community `Community 310`** (1 nodes): `App splash icon: purple gradient chat bubble with white 'm' and orange sparkle`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 311`** (1 nodes): `App splash icon: purple gradient chat bubble with white 'm' and orange sparkle`
+- **Thin community `Community 311`** (1 nodes): `Minglit app splash icon: purple chat bubble with white 'm' and orange sparkle`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 312`** (1 nodes): `Minglit app splash icon: purple chat bubble with white 'm' and orange sparkle`
+- **Thin community `Community 312`** (1 nodes): `App icon foreground: purple chat bubble with white 'm' and orange sparkle`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 313`** (1 nodes): `App icon foreground: purple chat bubble with white 'm' and orange sparkle`
+- **Thin community `Community 313`** (1 nodes): `Purple-blue gradient background image for app_partner icon`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 314`** (1 nodes): `Purple-blue gradient background image for app_partner icon`
+- **Thin community `Community 314`** (1 nodes): `Minglit inverted logo: white wordmark with cyan and orange shadow layers on transparent background`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 315`** (1 nodes): `Minglit inverted logo: white wordmark with cyan and orange shadow layers on transparent background`
+- **Thin community `Community 315`** (1 nodes): `Minglit wordmark logo SVG with transparent background, cyan/orange layered text`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 316`** (1 nodes): `Minglit wordmark logo SVG with transparent background, cyan/orange layered text`
+- **Thin community `Community 316`** (1 nodes): `Minglit app bar logo — bold italic 'Minglit' text in purple with cyan and orange shadow layers`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 317`** (1 nodes): `Minglit app bar logo — bold italic 'Minglit' text in purple with cyan and orange shadow layers`
+- **Thin community `Community 317`** (1 nodes): `Upscale lounge/restaurant interior with bar, green velvet chairs, Asian art, warm lighting`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 318`** (1 nodes): `Upscale lounge/restaurant interior with bar, green velvet chairs, Asian art, warm lighting`
+- **Thin community `Community 318`** (1 nodes): `Bright minimalist Korean cafe interior with numbered wooden tables, plants, string lights, and coffee bar`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 319`** (1 nodes): `Bright minimalist Korean cafe interior with numbered wooden tables, plants, string lights, and coffee bar`
+- **Thin community `Community 319`** (1 nodes): `Warm sunlit cafe interior with wood furniture, plants, string lights, and menu board`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 320`** (1 nodes): `Warm sunlit cafe interior with wood furniture, plants, string lights, and menu board`
+- **Thin community `Community 320`** (1 nodes): `Participation status redesign (after) — not-logged-in state with counts and login prompt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 321`** (1 nodes): `Participation status redesign (after) — not-logged-in state with counts and login prompt`
+- **Thin community `Community 321`** (1 nodes): `Dark theme participation status redesign, 2-group male/female layout with progress bars`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 322`** (1 nodes): `Dark theme participation status redesign, 2-group male/female layout with progress bars`
+- **Thin community `Community 322`** (1 nodes): `Participation status redesign after-state with 4 groups showing 12/40 total and per-group cards`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 323`** (1 nodes): `Participation status redesign after-state with 4 groups showing 12/40 total and per-group cards`
+- **Thin community `Community 323`** (1 nodes): `Empty participation status UI: 0/20 total, 0/10 male/female, empty state message`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 324`** (1 nodes): `Empty participation status UI: 0/20 total, 0/10 male/female, empty state message`
+- **Thin community `Community 324`** (1 nodes): `Participation status redesign after variant: 2-group (male/female) split with progress bars`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 325`** (1 nodes): `Participation status redesign after variant: 2-group (male/female) split with progress bars`
+- **Thin community `Community 325`** (1 nodes): `Participation status redesign: 2-group (male/female) expanded view with counts and age breakdowns`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 326`** (1 nodes): `Participation status redesign: 2-group (male/female) expanded view with counts and age breakdowns`
+- **Thin community `Community 326`** (1 nodes): `Before state: participation status UI with male/female groups, 2/10 capacity each`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 327`** (1 nodes): `Before state: participation status UI with male/female groups, 2/10 capacity each`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 328`** (1 nodes): `user_profiles Table`
+- **Thin community `Community 327`** (1 nodes): `user_profiles Table`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -2470,12 +2463,12 @@ _Questions this graph is uniquely positioned to answer:_
   _Edge tagged AMBIGUOUS (relation: calls) - confidence is low._
 - **What is the exact relationship between `Architecture Audit #1092 — 2026-04-06` and `AI Basic Law Compliance (Korea 2026)`?**
   _Edge tagged AMBIGUOUS (relation: conceptually_related_to) - confidence is low._
-- **Why does `Log` connect `Community 11` to `Community 8`?**
-  _High betweenness centrality (0.190) - this node is a cross-community bridge._
-- **Why does `Text` connect `Community 11` to `Community 0`?**
-  _High betweenness centrality (0.188) - this node is a cross-community bridge._
+- **Why does `Log` connect `Community 26` to `Community 6`?**
+  _High betweenness centrality (0.215) - this node is a cross-community bridge._
+- **Why does `Text` connect `Community 26` to `Community 11`?**
+  _High betweenness centrality (0.214) - this node is a cross-community bridge._
 - **What connects `reporter (AutoLabelAllureReporter)`, `BugReporterWrapper Widget Test Suite`, `MinglitListTile Widget Test Suite` to the rest of the system?**
-  _2049 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _2030 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.01 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,7 +1,7 @@
 # Graph Report - /private/tmp/minglit-pgrst-admin  (2026-05-05)
 
 ## Corpus Check
-- 1178 files · ~1,567,587 words
+- 1178 files · ~1,808,852 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
@@ -2464,9 +2464,9 @@ _Questions this graph is uniquely positioned to answer:_
 - **What is the exact relationship between `Architecture Audit #1092 — 2026-04-06` and `AI Basic Law Compliance (Korea 2026)`?**
   _Edge tagged AMBIGUOUS (relation: conceptually_related_to) - confidence is low._
 - **Why does `Log` connect `Community 26` to `Community 6`?**
-  _High betweenness centrality (0.215) - this node is a cross-community bridge._
+  _High betweenness centrality (0.208) - this node is a cross-community bridge._
 - **Why does `Text` connect `Community 26` to `Community 11`?**
-  _High betweenness centrality (0.214) - this node is a cross-community bridge._
+  _High betweenness centrality (0.202) - this node is a cross-community bridge._
 - **What connects `reporter (AutoLabelAllureReporter)`, `BugReporterWrapper Widget Test Suite`, `MinglitListTile Widget Test Suite` to the rest of the system?**
   _2030 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**

--- a/supabase/migrations/20260505000002_postgrest_expose_admin_schema.sql
+++ b/supabase/migrations/20260505000002_postgrest_expose_admin_schema.sql
@@ -1,0 +1,39 @@
+-- Fix: PostgREST 가 admin 스키마를 expose 하지 않아 supabase-js 의 .schema("admin") 호출이
+--      "Invalid schema: admin" 으로 거부됨. cleanup-retention EF (및 admin 스키마 사용하는 모든
+--      EF) 가 동작 못 함.
+--
+-- 원인: admin 스키마 생성 PR (20260421000002_add_admin_schema_retention_policies.sql) 에서
+--      service_role 에 GRANT 만 하고 PostgREST 의 db_schemas 설정 누락. supabase/config.toml
+--      에는 schemas = ["public", "graphql_public", "admin"] 적혀있으나 이는 로컬 전용. 원격
+--      Supabase 프로젝트는 authenticator role 의 pgrst.db_schemas GUC 를 봄.
+--
+-- 영향: cleanup-retention 호출 시 500 "Invalid schema: admin" — cron 401 (vault 누락) 해결 후
+--      표면화. 그 외 admin 스키마 직접 사용하는 EF 도 동일.
+--
+-- 적용 후 NOTIFY pgrst, 'reload config' 로 PostgREST 가 즉시 새 설정 반영.
+
+-- 현재 값 확인용 주석 (실행 시 NOTICE):
+-- 기본 Supabase 프로젝트는 'public, graphql_public, storage' 가 노출됨.
+-- 본 변경은 'admin' 추가.
+DO $$
+DECLARE
+  current_schemas text;
+BEGIN
+  SELECT setting INTO current_schemas
+  FROM pg_db_role_setting drs
+  JOIN pg_roles r ON r.oid = drs.setrole
+  CROSS JOIN unnest(drs.setconfig) AS s(setting)
+  WHERE r.rolname = 'authenticator' AND s.setting LIKE 'pgrst.db_schemas=%'
+  LIMIT 1;
+
+  IF current_schemas IS NULL THEN
+    RAISE NOTICE 'pgrst.db_schemas not currently set on authenticator (Supabase platform default in use)';
+  ELSE
+    RAISE NOTICE 'pgrst.db_schemas was: %', current_schemas;
+  END IF;
+END $$;
+
+ALTER ROLE authenticator SET pgrst.db_schemas TO 'public, graphql_public, admin';
+
+-- PostgREST 즉시 리로드 (NOTIFY 채널은 PostgREST 가 listen 중)
+NOTIFY pgrst, 'reload config';

--- a/supabase/tests/database/95_postgrest_exposed_schemas_test.sql
+++ b/supabase/tests/database/95_postgrest_exposed_schemas_test.sql
@@ -1,0 +1,53 @@
+-- pgTAP tests for PostgREST exposed schemas (authenticator role pgrst.db_schemas GUC).
+-- migration: 20260505000002_postgrest_expose_admin_schema.sql
+--
+-- 의도: GUC 가 누락되거나 다른 migration 에서 덮어써질 때 즉시 fail 시키는 regression 가드.
+--      migration 적용 후 PostgREST 가 노출하는 스키마 목록을 실측 검증.
+
+BEGIN;
+
+SELECT plan(4);
+
+-- 헬퍼 view: authenticator role 의 pgrst.db_schemas 값 추출
+CREATE TEMP VIEW _exposed_schemas AS
+  SELECT trim(replace(s.setting, 'pgrst.db_schemas=', '')) AS value
+  FROM pg_db_role_setting drs
+  JOIN pg_roles r ON r.oid = drs.setrole
+  CROSS JOIN unnest(drs.setconfig) AS s(setting)
+  WHERE r.rolname = 'authenticator'
+    AND s.setting LIKE 'pgrst.db_schemas=%';
+
+-- 1. GUC 자체가 설정되어 있어야 함
+SELECT ok(
+  EXISTS (SELECT 1 FROM _exposed_schemas),
+  'authenticator role must have pgrst.db_schemas GUC set'
+);
+
+-- 2~4. 필수 스키마 각각 포함 확인
+-- Note: GUC value 형식은 "public, graphql_public, admin" — 공백 무관 contains 매칭
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM _exposed_schemas
+    WHERE position('public' IN value) > 0
+  ),
+  'pgrst.db_schemas must include ''public'' (Supabase default — RLS/RPC entry point)'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM _exposed_schemas
+    WHERE position('graphql_public' IN value) > 0
+  ),
+  'pgrst.db_schemas must include ''graphql_public'' (pg_graphql endpoint)'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM _exposed_schemas
+    WHERE position('admin' IN value) > 0
+  ),
+  'pgrst.db_schemas must include ''admin'' (cleanup-retention / process-pending-deletions EF supabase-js .schema(''admin'') 의존)'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary

cleanup-retention EF (#2189 머지로 auth 통과 후) handler 가 `supabase.schema('admin').from(...)` 호출 → `Invalid schema: admin` 500. PostgREST authenticator role 의 `pgrst.db_schemas` GUC 에 admin 미포함이 원인.

admin schema 생성 PR (#20260421000002) 의 누락 — GRANT 만 하고 PostgREST exposed schemas 업데이트 안 했음. config.toml 의 schemas config 는 로컬 전용.

## Migration

```sql
ALTER ROLE authenticator SET pgrst.db_schemas TO 'public, graphql_public, admin';
NOTIFY pgrst, 'reload config';
```

## Test plan

- [ ] 머지 후 dev deploy → migration 적용
- [ ] cleanup-retention 수동 invoke → 200 응답 확인
- [ ] retention_policies last_run_at 업데이트 확인 (현재 NULL)
- [ ] 03:00 UTC cron 자연 실행 시 succeeded + 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)