### PR TITLE
feat(mds): MinglitCapacityBar — segmented/continuous capacity visualisation

### DIFF
--- a/apps/app_user/test/src/common/widgets/minglit_capacity_bar_test.dart
+++ b/apps/app_user/test/src/common/widgets/minglit_capacity_bar_test.dart
@@ -3,13 +3,15 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
 Widget _wrap(Widget child) => MaterialApp(
-      theme: MinglitTheme.materialTheme,
-      home: Scaffold(body: SizedBox(width: 300, child: child)),
-    );
+  theme: MinglitTheme.materialTheme,
+  home: Scaffold(body: SizedBox(width: 300, child: child)),
+);
 
 void main() {
   group('MinglitCapacityBar', () {
-    testWidgets('renders segmented mode when total <= threshold', (tester) async {
+    testWidgets('renders segmented mode when total <= threshold', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         _wrap(
           const MinglitCapacityBar(total: 8, filled: 4, pending: 2),
@@ -19,7 +21,9 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
-    testWidgets('renders continuous mode when total > threshold', (tester) async {
+    testWidgets('renders continuous mode when total > threshold', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         _wrap(
           const MinglitCapacityBar(total: 100, filled: 60, pending: 20),
@@ -29,7 +33,9 @@ void main() {
       expect(tester.takeException(), isNull);
     });
 
-    testWidgets('clamps filled and pending to total without overflow', (tester) async {
+    testWidgets('clamps filled and pending to total without overflow', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         _wrap(
           const MinglitCapacityBar(total: 5, filled: 10, pending: 10),

--- a/apps/app_user/test/src/common/widgets/minglit_capacity_bar_test.dart
+++ b/apps/app_user/test/src/common/widgets/minglit_capacity_bar_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+      theme: MinglitTheme.materialTheme,
+      home: Scaffold(body: SizedBox(width: 300, child: child)),
+    );
+
+void main() {
+  group('MinglitCapacityBar', () {
+    testWidgets('renders segmented mode when total <= threshold', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const MinglitCapacityBar(total: 8, filled: 4, pending: 2),
+        ),
+      );
+      expect(find.byType(MinglitCapacityBar), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('renders continuous mode when total > threshold', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const MinglitCapacityBar(total: 100, filled: 60, pending: 20),
+        ),
+      );
+      expect(find.byType(MinglitCapacityBar), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('clamps filled and pending to total without overflow', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const MinglitCapacityBar(total: 5, filled: 10, pending: 10),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('zero filled and pending renders track only', (tester) async {
+      await tester.pumpWidget(
+        _wrap(const MinglitCapacityBar(total: 8, filled: 0)),
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('total=0 renders empty without crash', (tester) async {
+      await tester.pumpWidget(
+        _wrap(const MinglitCapacityBar(total: 0, filled: 0)),
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('custom segmentThreshold overrides default', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const MinglitCapacityBar(
+            total: 50,
+            filled: 25,
+            segmentThreshold: 60,
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('custom color and height accepted', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const MinglitCapacityBar(
+            total: 10,
+            filled: 5,
+            height: 4,
+            color: Color(0xFF0000FF),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/shared/packages/mds/core/lib/mds.dart
+++ b/shared/packages/mds/core/lib/mds.dart
@@ -37,4 +37,5 @@ export 'src/ui/widgets/common/minglit_settings_tile.dart';
 export 'src/ui/widgets/common/minglit_skeleton.dart';
 export 'src/ui/widgets/common/minglit_tag.dart';
 export 'src/ui/widgets/common/minglit_text_field.dart';
+export 'src/ui/widgets/common/minglit_capacity_bar.dart';
 export 'src/ui/widgets/common/number_stepper_input.dart';

--- a/shared/packages/mds/core/lib/src/ui/widgets/common/minglit_capacity_bar.dart
+++ b/shared/packages/mds/core/lib/src/ui/widgets/common/minglit_capacity_bar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:mds/src/theme/minglit_theme.dart';
 
 /// Visualises event capacity — confirmed (filled) and pending (waiting) against total.

--- a/shared/packages/mds/core/lib/src/ui/widgets/common/minglit_capacity_bar.dart
+++ b/shared/packages/mds/core/lib/src/ui/widgets/common/minglit_capacity_bar.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/widgets.dart';
+import 'package:mds/src/theme/minglit_theme.dart';
+
+/// Visualises event capacity — confirmed (filled) and pending (waiting) against total.
+///
+/// Automatically switches between:
+/// - **segmented**: one slot per person (total ≤ [segmentThreshold], default 30)
+/// - **continuous**: linear bar overlay (total > [segmentThreshold])
+class MinglitCapacityBar extends StatelessWidget {
+  const MinglitCapacityBar({
+    required this.total,
+    required this.filled,
+    this.pending = 0,
+    this.segmentThreshold = 30,
+    this.height,
+    this.segmentGap = 2,
+    this.color,
+    this.pendingColor,
+    this.trackColor,
+    this.radius,
+    super.key,
+  }) : assert(total >= 0),
+       assert(filled >= 0),
+       assert(pending >= 0);
+
+  final int total;
+  final int filled;
+  final int pending;
+  final int segmentThreshold;
+  final double? height;
+  final double segmentGap;
+  final Color? color;
+  final Color? pendingColor;
+  final Color? trackColor;
+  final double? radius;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final baseColor = color ?? (isDark ? MinglitColorsDark.primary : MinglitColors.primary);
+    final baseTrackColor = trackColor ?? (isDark ? MinglitColorsDark.divider : MinglitColors.divider);
+    final basePendingColor = pendingColor ?? baseColor.withOpacity(0.3);
+
+    if (total <= 0) return const SizedBox.shrink();
+
+    if (total <= segmentThreshold) {
+      return _SegmentedBar(
+        total: total,
+        filled: filled,
+        pending: pending,
+        height: height ?? 8,
+        segmentGap: segmentGap,
+        filledColor: baseColor,
+        pendingColor: basePendingColor,
+        trackColor: baseTrackColor,
+        radius: radius ?? 2,
+      );
+    }
+
+    return _ContinuousBar(
+      total: total,
+      filled: filled,
+      pending: pending,
+      height: height ?? 6,
+      filledColor: baseColor,
+      pendingColor: basePendingColor,
+      trackColor: baseTrackColor,
+      radius: radius ?? 3,
+    );
+  }
+}
+
+class _SegmentedBar extends StatelessWidget {
+  const _SegmentedBar({
+    required this.total,
+    required this.filled,
+    required this.pending,
+    required this.height,
+    required this.segmentGap,
+    required this.filledColor,
+    required this.pendingColor,
+    required this.trackColor,
+    required this.radius,
+  });
+
+  final int total;
+  final int filled;
+  final int pending;
+  final double height;
+  final double segmentGap;
+  final Color filledColor;
+  final Color pendingColor;
+  final Color trackColor;
+  final double radius;
+
+  @override
+  Widget build(BuildContext context) {
+    final safeFilled = filled.clamp(0, total);
+    final safePending = pending.clamp(0, total - safeFilled);
+
+    return Row(
+      children: [
+        for (int i = 0; i < total; i++) ...[
+          if (i > 0) SizedBox(width: segmentGap),
+          Expanded(
+            child: Container(
+              height: height,
+              decoration: BoxDecoration(
+                color: i < safeFilled
+                    ? filledColor
+                    : i < safeFilled + safePending
+                        ? pendingColor
+                        : trackColor,
+                borderRadius: BorderRadius.circular(radius),
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _ContinuousBar extends StatelessWidget {
+  const _ContinuousBar({
+    required this.total,
+    required this.filled,
+    required this.pending,
+    required this.height,
+    required this.filledColor,
+    required this.pendingColor,
+    required this.trackColor,
+    required this.radius,
+  });
+
+  final int total;
+  final int filled;
+  final int pending;
+  final double height;
+  final Color filledColor;
+  final Color pendingColor;
+  final Color trackColor;
+  final double radius;
+
+  @override
+  Widget build(BuildContext context) {
+    final safeFilled = filled.clamp(0, total);
+    final safePending = pending.clamp(0, total - safeFilled);
+    final filledFraction = safeFilled / total;
+    final pendingFraction = safePending / total;
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(radius),
+      child: SizedBox(
+        height: height,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final totalWidth = constraints.maxWidth;
+            final filledWidth = totalWidth * filledFraction;
+            final pendingWidth = totalWidth * pendingFraction;
+
+            return Stack(
+              children: [
+                Container(width: totalWidth, color: trackColor),
+                if (pendingFraction > 0)
+                  Positioned(
+                    left: filledWidth,
+                    top: 0,
+                    bottom: 0,
+                    width: pendingWidth,
+                    child: Container(color: pendingColor),
+                  ),
+                if (filledFraction > 0)
+                  Positioned(
+                    left: 0,
+                    top: 0,
+                    bottom: 0,
+                    width: filledWidth,
+                    child: Container(color: filledColor),
+                  ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- New `MinglitCapacityBar` widget in `shared/packages/mds/core`
- Auto-switches between segmented (total ≤ 30) and continuous (total > 30) mode
- Props: `total`, `filled`, `pending`, `segmentThreshold`, `height`, `segmentGap`, `color`, `pendingColor`, `trackColor`, `radius`
- Clamps `filled+pending ≤ total` gracefully (no crash on overflow input)
- Uses theme-resolved primary + divider color tokens; `pendingColor` defaults to primary @ 30% opacity

## Design System Reference

- `apps/mds/docs/src/components/specs/MinglitCapacityBarSpec.tsx` (PR #2108)
- `apps/mds/docs/src/lib/components.ts` — MinglitCapacityBar entry

## Test plan

- [ ] 7 widget tests in `minglit_capacity_bar_test.dart`: segmented/continuous/clamp/zero/custom threshold/height/color
- [ ] `test-app-unit-widget-golden` CI job

Closes #2111

🤖 Generated with [Claude Code](https://claude.com/claude-code)