### PR TITLE
fix(retention): storage_bucket cleanup 가 sub-directory 안 들여다 봐서 0 deleted (#2204)

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
-# Graph Report - /Users/mark/workspace/minglit-worker-runtime/repos/minglit/.claude/worktrees/fix-2124-match-results-viewed-at  (2026-05-05)
+# Graph Report - /private/tmp/minglit-storage-fix  (2026-05-05)
 
 ## Corpus Check
-- 1175 files · ~1,561,662 words
+- 1182 files · ~1,569,030 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 3662 nodes · 5079 edges · 326 communities detected
-- Extraction: 90% EXTRACTED · 10% INFERRED · 0% AMBIGUOUS · INFERRED: 522 edges (avg confidence: 0.8)
+- 3803 nodes · 5181 edges · 329 communities detected
+- Extraction: 90% EXTRACTED · 10% INFERRED · 0% AMBIGUOUS · INFERRED: 504 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Community Hubs (Navigation)
@@ -336,28 +336,31 @@
 - [[_COMMUNITY_Community 323|Community 323]]
 - [[_COMMUNITY_Community 324|Community 324]]
 - [[_COMMUNITY_Community 325|Community 325]]
+- [[_COMMUNITY_Community 326|Community 326]]
+- [[_COMMUNITY_Community 327|Community 327]]
+- [[_COMMUNITY_Community 328|Community 328]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `package:flutter/material.dart` - 104 edges
-2. `package:minglit_kit/minglit_kit.dart` - 71 edges
-3. `package:flutter_test/flutter_test.dart` - 64 edges
-4. `dart:async` - 51 edges
-5. `_shared/logger` - 44 edges
-6. `package:mocktail/mocktail.dart` - 42 edges
-7. `_shared/response_utils` - 41 edges
-8. `_shared/supabase_client` - 40 edges
-9. `_shared/auth_utils` - 39 edges
-10. `AppRouter / goRouterProvider` - 37 edges
+1. `package:flutter/material.dart` - 114 edges
+2. `package:minglit_kit/minglit_kit.dart` - 83 edges
+3. `package:flutter_test/flutter_test.dart` - 75 edges
+4. `dart:async` - 57 edges
+5. `package:mocktail/mocktail.dart` - 47 edges
+6. `_shared/response_utils` - 40 edges
+7. `_shared/supabase_client` - 39 edges
+8. `_shared/request_utils` - 33 edges
+9. `AppRouter / goRouterProvider` - 32 edges
+10. `package:mds/src/theme/minglit_theme.dart` - 31 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `minglit_kit Package` --references--> `Flutter & Riverpod 3.0 Standard`  [INFERRED]
   /Users/mark/workspace/minglit-graphify-init/apps/app_user/test/alchemist/scenarios/screenshot_scenario.dart → /Users/mark/workspace/minglit-graphify-init/docs/standards/flutter-riverpod-3.0.md
 - `PartyDetailController` --semantically_similar_to--> `PartyListController`  [INFERRED] [semantically similar]
   /Users/mark/workspace/minglit-graphify-init/apps/app_partner/lib/src/features/party/detail/party_detail_controller.dart → /Users/mark/workspace/minglit-graphify-init/apps/app_partner/lib/src/features/party/list/party_list_controller.dart
+- `Worker: audit-legal` --semantically_similar_to--> `Privacy Retention Map (선언-구현 매핑)`  [INFERRED] [semantically similar]
+  /Users/mark/workspace/minglit-graphify-init/docs/features/worker-prompt-v2/spec.md → /Users/mark/workspace/minglit-graphify-init/docs/legal/retention-map.md
 - `authControllerProvider` --semantically_similar_to--> `auth_provider_utils`  [INFERRED] [semantically similar]
   /Users/mark/workspace/minglit-graphify-init/shared/packages/minglit_kit/lib/src/features/auth/logic/auth_controller.dart → /Users/mark/workspace/minglit-graphify-init/shared/packages/minglit_kit/lib/src/utils/auth_provider_utils.dart
-- `UserSettings` --semantically_similar_to--> `UserConsent`  [INFERRED] [semantically similar]
-  /Users/mark/workspace/minglit-graphify-init/shared/packages/minglit_kit/lib/src/data/models/user_settings.dart → /Users/mark/workspace/minglit-graphify-init/shared/packages/minglit_kit/lib/src/data/models/user_consent.dart
 - `partnerEventsProvider` --semantically_similar_to--> `TagProviders`  [INFERRED] [semantically similar]
   /Users/mark/workspace/minglit-graphify-init/shared/packages/minglit_kit/lib/src/logic/providers/event_feed_provider.dart → /Users/mark/workspace/minglit-graphify-init/shared/packages/minglit_kit/lib/src/logic/providers/tag_providers.dart
 
@@ -702,147 +705,147 @@
 
 ### Community 0 - "Community 0"
 Cohesion: 0.01
-Nodes (338): dart:async, dart:io, dart:js_interop, dart:js_interop_unsafe, package:app_partner/firebase_options.dart, package:app_partner/src/features/application/event_application_manage_page.dart, package:app_partner/src/features/checkin/qr_scanner_screen.dart, package:app_partner/src/features/home/partner_dashboard_controller.dart (+330 more)
+Nodes (309): dart:convert, dart:io, ../../../helpers/mocks.dart, ../../../helpers/supabase_mock_helpers.dart, ../../../helpers/test_utils.dart, mocks.dart, package:app_partner/firebase_options.dart, package:app_partner/src/features/home/partner_dashboard_controller.dart (+301 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.01
-Nodes (302): dart:convert, ../../../helpers/mocks.dart, ../../../helpers/supabase_mock_helpers.dart, ../../../helpers/test_utils.dart, mocks.dart, package:app_partner/src/features/checkin/stats/checkin_stats_controller.dart, package:app_partner/src/features/checkin/stats/entry_group_checkin_stats_controller.dart, package:app_partner/src/features/party/detail/party_detail_controller.dart (+294 more)
+Nodes (254): dart:async, dart:js_interop, dart:js_interop_unsafe, package:app_partner/src/features/onboarding/partner_apply_status_page.dart, package:app_partner/src/features/party/event/detail/event_application_controller.dart, package:app_partner/src/features/party/widgets/party_status_edit_sheet.dart, package:app_partner/src/logic/onboarding_state_provider.dart, package:app_user/src/common/event_ticket_token_provider.dart (+246 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.02
-Nodes (174): AccountManagementPage, AccountManagementPageTest, AddActionCard, BugReportCollector, BugReportRepository, BugReporterWrapper Widget, BugReporterWrapper Widget Test Suite, MinglitIamportCertification (mobile) (+166 more)
+Nodes (190): account_deletion_golden_test, activeFiltersProvider (ExploreFilters state), ActivePartySummaryScroll, ActivePartySummaryScroll Test, AdmissionActionHandler (extension), UserScenarios (All), AppleSignInTest (emulator), ApprovalWaitingCard (+182 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.02
-Nodes (171): account_deletion_golden_test, activeFiltersProvider (ExploreFilters state), AdmissionActionHandler (extension), UserScenarios (All), AppleSignInTest (emulator), AuthCallbackPage, AuthCoordinator, AuthGuard (+163 more)
+Nodes (189): ActionRunner, Admin Dashboard Spec, Admin Dashboard Wireframe, apply-event Edge Function, backend-simulator E2E Tests, backend-simulator Edge Function (main handler), bug-report Edge Function, bug-report Tests (+181 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.02
-Nodes (162): ActivePartySummaryScroll, ActivePartySummaryScroll Test, AddressSearchDialog, AddressSearchDialog Test, AppLocalizations, AppLocalizationsKo, AppRouter / goRouterProvider, AppRouter Redirect Logic Test (+154 more)
+Nodes (136): package:app_partner/src/features/application/event_application_manage_page.dart, package:app_user/src/features/account_deletion/ui/deletion_complete_page.dart, package:app_user/src/features/account_deletion/ui/deletion_info_page.dart, package:app_user/src/features/account_deletion/ui/deletion_reason_page.dart, package:app_user/src/features/account_deletion/ui/deletion_verify_page.dart, package:app_user/src/features/auth/login_page.dart, package:app_user/src/features/auth/ui/auth_callback_page.dart, package:app_user/src/features/consent/ui/signup_consent_page.dart (+128 more)
 
 ### Community 5 - "Community 5"
-Cohesion: 0.03
-Nodes (151): apply-event Edge Function, bug-report Edge Function, bug-report Tests, cleanup-blocked-dis Edge Function, cleanup-blocked-dis Tests, cleanup-retention Edge Function, cleanup-retention Tests, Event Capacity Guard (DB-serialized approval) (+143 more)
+Cohesion: 0.01
+Nodes (111): package:mds/src/theme/minglit_theme.dart, package:mds/src/ui/widgets/common/minglit_horizontal_scroll_group.dart, package:mds/src/ui/widgets/common/minglit_section_divider.dart, build, ClipRRect, _ContinuousBar, MinglitCapacityBar, Row (+103 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.02
-Nodes (104): package:mds/src/theme/minglit_theme.dart, package:mds/src/ui/widgets/common/minglit_horizontal_scroll_group.dart, package:mds/src/ui/widgets/common/minglit_section_divider.dart, AlertDialog, build, MinglitAlert, build, Center (+96 more)
+Nodes (109): AddressSearchDialog, AddressSearchDialog Test, Alchemist goldenTest, EventApplicationManagePage Smoke Test, CheckinController, CheckinController Unit Test, CheckinParticipant, CheckinParticipant Data Class Unit Test (+101 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.02
-Nodes (95): Alchemist goldenTest, EventApplicationManagePage Smoke Test, CheckinController, CheckinController Unit Test, CheckinParticipant, CheckinParticipant Data Class Unit Test, CheckinPlaceholderPage, CheckinPlaceholderPage Widget Test (+87 more)
+Nodes (115): AI 기본법, AI-First Operating Principle, AI Worker Operating Model, Application (event_applications), Minglit Architecture Overview, Brand Anti-patterns — 외모 품평/익명성/결혼 압박 금지, Brand Identity — minglit voice + visual, Brand Visual — MZ 틱 세련됨 + 보라 그라디언트 (+107 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.02
-Nodes (93): package:app_user/src/common/event_ticket_token_provider.dart, package:app_user/src/common/widgets/matching_vote_content.dart, package:app_user/src/common/widgets/ticket_qr_viewer.dart, package:app_user/src/features/event/matching/matching_vote_controller.dart, package:app_user/src/features/home/home_page.dart, package:app_user/src/features/home/widgets/event_now_bar_controller.dart, package:app_user/src/features/home/widgets/event_now_bar.dart, package:app_user/src/features/home/widgets/event_now_bottom_sheet.dart (+85 more)
+Nodes (93): package:app_user/src/features/account_deletion/logic/account_deletion_coordinator.dart, package:app_user/src/features/home/logic/home_coordinator.dart, package:app_user/src/features/my_tickets/logic/my_tickets_controller.dart, package:app_user/src/features/my_tickets/ui/my_ticket_card.dart, package:app_user/src/features/my_tickets/ui/my_tickets_page.dart, package:app_user/src/features/partner/detail/partner_detail_page.dart, package:app_user/src/features/partner/logic/partner_coordinator.dart, package:app_user/src/features/ticket/ui/model/ticket_event_meta.dart (+85 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.03
-Nodes (96): AI 기본법, Partner App Smoke Test Cases, User App Smoke Test Cases, 25 Cross-Feature Import Violations (issue #452), Cross-Feature Coupling Violations (issue #436), Automation Test Guide (7-Layer), CI/DI Encrypted Storage, cleanup-retention Edge Function (+88 more)
+Cohesion: 0.02
+Nodes (100): package:app_partner/src/features/checkin/qr_scanner_screen.dart, package:app_partner/src/features/home/widgets/event_action_card.dart, package:app_partner/src/features/home/widgets/location_guide_banner.dart, package:app_partner/src/features/home/widgets/onboarding_step_guide.dart, package:app_partner/src/features/home/widgets/todo_summary_chips.dart, package:app_partner/src/features/settlement/widgets/download_bottom_sheet.dart, package:app_partner/src/features/settlement/widgets/settlement_card.dart, package:app_partner/src/features/settlement/widgets/settlement_status_badge.dart (+92 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.03
-Nodes (83): package:app_partner/main.dart, package:app_partner/src/features/onboarding/onboarding_coordinator.dart, package:app_partner/src/features/onboarding/partner_apply_controller.dart, package:app_partner/src/features/onboarding/partner_apply_page.dart, package:app_partner/src/features/onboarding/steps/step1_basic_info.dart, package:app_partner/src/features/onboarding/steps/step2_biz_info.dart, package:app_partner/src/features/onboarding/steps/step3_contact_settlement.dart, package:app_partner/src/features/onboarding/steps/step4_documents.dart (+75 more)
+Nodes (106): BugReportCollector, BugReportRepository, BugReporterWrapper Widget, BugReporterWrapper Widget Test Suite, MinglitIamportCertification (mobile), MinglitIamportCertification (stub), MinglitIamportCertification (web), minglitUrlConfigProvider (+98 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.02
-Nodes (81): package:app_user/src/common/widgets/consent_detail_sheet.dart, package:app_user/src/common/widgets/match_results_content.dart, package:app_user/src/features/account_deletion/logic/account_deletion_coordinator.dart, package:app_user/src/features/auth/logic/auth_coordinator.dart, package:app_user/src/features/home/logic/home_coordinator.dart, package:app_user/src/features/my_tickets/logic/my_tickets_controller.dart, package:app_user/src/features/my_tickets/ui/my_ticket_card.dart, package:app_user/src/features/my_tickets/ui/my_tickets_page.dart (+73 more)
+Cohesion: 0.04
+Nodes (91): AccountDeletionController, AccountDeletionControllerTest, AccountDeletionCoordinator, accountDeletionCoordinatorProvider, AccountDeletionCoordinator Unit Test, AccountDeletionReasonOption, AccountDeletionScenarios, AccountRepository (+83 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.03
-Nodes (85): AI-First Operating Principle, AI Worker Operating Model, Application (event_applications), Minglit Architecture Overview, Brand Anti-patterns — 외모 품평/익명성/결혼 압박 금지, Brand Identity — minglit voice + visual, Brand Visual — MZ 틱 세련됨 + 보라 그라디언트, Brand Voice — 존댓말 정중 + 무겁지 않음 (+77 more)
+Nodes (92): AppLocalizations, AppLocalizationsKo, AppRouter / goRouterProvider, AppRouter Redirect Logic Test, AppRoutes, AppRoutesTest (partner), CreateVerificationPage, CUJ PartnerApply Wizard Integration Test (+84 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.04
-Nodes (82): AccountDeletionController, AccountDeletionControllerTest, AccountDeletionCoordinator, accountDeletionCoordinatorProvider, AccountDeletionCoordinator Unit Test, AccountDeletionReasonOption, AccountDeletionScenarios, AccountManagementRoute (/my/account) (+74 more)
+Cohesion: 0.02
+Nodes (86): dart:math, package:app_partner/src/features/checkin/checkin_controller.dart, package:app_user/src/features/ticket/logic/boarding_pass_status.dart, package:flutter/services.dart, package:mobile_scanner/mobile_scanner.dart, package:qr_flutter/qr_flutter.dart, build, MinglitTextField (+78 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.03
-Nodes (64): package:app_partner/src/features/checkin/checkin_controller.dart, package:app_partner/src/features/checkin/manual/checkin_participant.dart, package:app_partner/src/features/checkin/manual/manual_checkin_controller.dart, package:app_partner/src/features/checkin/manual/manual_checkin_sheet.dart, package:flutter/services.dart, package:mobile_scanner/mobile_scanner.dart, build, Center (+56 more)
+Nodes (83): AccountManagementPage, AccountManagementPageTest, AddActionCard, DevScreenItem, DevScreenList, EntryGroupDetail, EntryGroup Model, EntryGroupTemplate model (+75 more)
 
 ### Community 15 - "Community 15"
 Cohesion: 0.04
-Nodes (69): CUJ Recurring Event Integration Test (IT-P09), DB Table: recurrence_rules, Edge Function: recurrence-rules, EntryGroupEditorScreen, EventBasicInfoSummary, EventCapacitySummary, EventContactSummary, EventCreateCoordinator (+61 more)
+Nodes (37): optionalAuth(), requireAuth(), requireServiceRole(), handleCreate(), checkExternalAuth(), verifyAuth(), IamportClient, IamportClientTest (+29 more)
 
 ### Community 16 - "Community 16"
+Cohesion: 0.04
+Nodes (68): CUJ Recurring Event Integration Test (IT-P09), DB Table: recurrence_rules, Edge Function: recurrence-rules, EntryGroupEditorScreen, EventBasicInfoSummary, EventCapacitySummary, EventContactSummary, EventCreateCoordinator (+60 more)
+
+### Community 17 - "Community 17"
+Cohesion: 0.04
+Nodes (66): Partner App Smoke Test Cases, User App Smoke Test Cases, 25 Cross-Feature Import Violations (issue #452), Cross-Feature Coupling Violations (issue #436), Automation Test Guide (7-Layer), Partner CUJ Test Scenarios, CUJ-P01: Partner Onboarding → Event Creation, CUJ-P02: Application Review (Approve/Reject) (+58 more)
+
+### Community 18 - "Community 18"
 Cohesion: 0.05
 Nodes (64): Admin Dashboard Feature (PRD + Wireframe), Dark Pattern Regulation Compliance, Event Now Bar Feature, Feature Maturity Matrix (PM 추적 도구), Flutter + UIautomator 비호환 (bounds=[0,0][0,0]), JUSO_CONFIRM_KEY 환경변수 누락 패턴, Legal Compliance (F1~F8 retention policies), MVP Feature Maturity Tracking (+56 more)
 
-### Community 17 - "Community 17"
+### Community 19 - "Community 19"
 Cohesion: 0.03
 Nodes (54): package:flutter_quill/flutter_quill.dart, package:flutter_svg/flutter_svg.dart, package:mds/src/theme/minglit_text_theme_extension.dart, package:mds/src/ui/widgets/common/minglit_chip.dart, package:mds/src/ui/widgets/common/minglit_empty_state.dart, package:mds/src/ui/widgets/common/minglit_image.dart, package:mds/src/ui/widgets/common/minglit_skeleton.dart, package:mds_tokens/mds_tokens.dart (+46 more)
 
-### Community 18 - "Community 18"
+### Community 20 - "Community 20"
 Cohesion: 0.04
 Nodes (58): ADB Device Connection — wireless adb pair 요구사항, ADR-001: Supabase as Backend Platform, ADR-002: PGroonga for Korean Full-Text Search, ADR-003: pgvector for Recommendation Embeddings, ADR-004: PGMQ for Async Event Pipeline, ADR-005: Coordinator + Repository Pattern (Flutter), ADR-006: Ed25519 for QR Ticket Signing, ADR-007: PortOne Multi-PG Abstraction (+50 more)
 
-### Community 19 - "Community 19"
-Cohesion: 0.09
-Nodes (44): ActionRunner, Admin Dashboard Spec, Admin Dashboard Wireframe, backend-simulator E2E Tests, backend-simulator Edge Function (main handler), DB Table: partner_verified_users, EF: apply-event, EF: event-checkin (+36 more)
+### Community 21 - "Community 21"
+Cohesion: 0.04
+Nodes (51): package:app_partner/src/features/checkin/manual/checkin_participant.dart, package:app_partner/src/features/checkin/manual/manual_checkin_controller.dart, package:app_partner/src/features/checkin/manual/manual_checkin_sheet.dart, package:app_partner/src/features/checkin/stats/checkin_stats_controller.dart, package:app_partner/src/features/checkin/stats/entry_group_checkin_stats_controller.dart, package:flutter_riverpod/flutter_riverpod.dart, package:mds/src/ui/widgets/common/loading_indicator.dart, package:minglit_kit/src/logic/providers/supabase_provider.dart (+43 more)
 
-### Community 20 - "Community 20"
+### Community 22 - "Community 22"
+Cohesion: 0.04
+Nodes (47): package:app_partner/main.dart, package:app_partner/src/features/party/create/party_create_wizard_controller.dart, package:app_partner/src/features/party/create/steps/step1_basic_info.dart, package:app_partner/src/features/party/create/steps/step2_location.dart, package:app_partner/src/features/party/create/steps/step3_capacity_contact.dart, package:app_partner/src/features/party/create/steps/step4_entry_rules.dart, package:app_partner/src/features/party/create/steps/step5_tickets.dart, package:app_partner/src/features/party/create/steps/step6_review.dart (+39 more)
+
+### Community 23 - "Community 23"
+Cohesion: 0.04
+Nodes (45): package:app_user/src/features/event/admission/event_application_controller.dart, package:app_user/src/features/event/admission/event_application_wizard_page.dart, package:app_user/src/features/event/admission/payment_success_screen.dart, package:app_user/src/features/event/logic/event_coordinator.dart, package:app_user/src/features/event/logic/event_detail_controller.dart, package:file_picker/file_picker.dart, package:flutter/widgets.dart, build (+37 more)
+
+### Community 24 - "Community 24"
 Cohesion: 0.05
 Nodes (33): package:analyzer/dart/ast/ast.dart, package:analyzer/error/listener.dart, package:custom_lint_builder/custom_lint_builder.dart, package:minglit_lints/src/no_cross_feature_imports_rule.dart, package:minglit_lints/src/no_hardcoded_colors_rule.dart, package:minglit_lints/src/no_hardcoded_padding_rule.dart, package:minglit_lints/src/no_hardcoded_text_style_rule.dart, package:minglit_lints/src/use_minglit_async_value_widget_rule.dart (+25 more)
 
-### Community 21 - "Community 21"
+### Community 25 - "Community 25"
 Cohesion: 0.06
 Nodes (33): fixtures/mock_events.dart, package:mds/mds.dart, package:widgetbook/widgetbook.dart, build, _ColorsStory, _ColorSwatch, _DarkColorsStory, _FilterChipStory (+25 more)
 
-### Community 22 - "Community 22"
+### Community 26 - "Community 26"
 Cohesion: 0.07
-Nodes (32): package:app_user/src/features/account_deletion/ui/deletion_complete_page.dart, package:app_user/src/features/account_deletion/ui/deletion_info_page.dart, package:app_user/src/features/account_deletion/ui/deletion_reason_page.dart, package:app_user/src/features/account_deletion/ui/deletion_verify_page.dart, package:app_user/src/features/auth/login_page.dart, package:app_user/src/features/home/my_page.dart, package:app_user/src/features/payment/ui/purchase_history_page.dart, package:plugin_platform_interface/plugin_platform_interface.dart (+24 more)
+Nodes (29): package:app_partner/src/features/onboarding/onboarding_coordinator.dart, package:app_partner/src/features/onboarding/steps/step2_biz_info.dart, package:app_partner/src/features/onboarding/steps/step3_contact_settlement.dart, package:app_partner/src/features/onboarding/steps/step4_documents.dart, package:app_partner/src/utils/l10n_ext.dart, build, dispose, _getStepTitle (+21 more)
 
-### Community 23 - "Community 23"
-Cohesion: 0.06
-Nodes (31): dart:math, package:app_user/src/features/ticket/logic/boarding_pass_status.dart, package:qr_flutter/qr_flutter.dart, BoardingPassCard, _BoardingPassCardState, boardingPassStatus, build, _computeStatus (+23 more)
-
-### Community 24 - "Community 24"
-Cohesion: 0.1
-Nodes (13): handleCreate(), requirePartnerPermission, PartnerPermissionsTest, parseAction, parseJsonBody, RequestUtilsTest, errorResponse, successResponse (+5 more)
-
-### Community 25 - "Community 25"
+### Community 27 - "Community 27"
 Cohesion: 0.09
 Nodes (30): CheckinResult State Machine, Domain Probe (Observability Interface), Design System 07 — Accessibility Guide, Design System 02 — Component Themes, Design System 01 — Foundation Tokens, Design System 05 — Motion Guide, Design System 04 — Navigation Guide, Design System 03 — UI Patterns (+22 more)
 
-### Community 26 - "Community 26"
+### Community 28 - "Community 28"
 Cohesion: 0.12
 Nodes (28): Breach Notification Runbook, Breach Response Process, Dark Mode Contrast / Accessibility Issue, Minglit Design Token System, Golden Test Coverage Tracking, notification-worker Edge Function, sensitive_access_log Audit Table, Deno 2.0 & Edge Functions Standard (+20 more)
 
-### Community 27 - "Community 27"
-Cohesion: 0.11
-Nodes (24): handleMinglitError, MinglitAuthException, MinglitException, MinglitSystemException, MinglitUserException, MinglitFeedbackX, getAccessToken(), getAffectedUserId() (+16 more)
-
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.18
 Nodes (25): Architecture Audit #1003 — 2026-04-04, Architecture Audit #1092 — 2026-04-06, Architecture Audit #536 — 2026-03-28, Code Quality Audit #541 — 2026-03-28, Architecture Audit #601 — 2026-03-28 (cross-import), Architecture Audit #648 — 2026-03-28, Architecture Audit #678 — 2026-03-29, Architecture Audit #686 — 2026-03-29 (+17 more)
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.1
 Nodes (0): 
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.19
 Nodes (20): DeletionStatus model (account deletion grace period), EnvKeyStore (compile-time env var validation), EventApplication model (user join application), Event model (party instance with scheduling/capacity), EventFeedType enum (nearest, newArrivals, closingSoon, earlyBird, aiRecommended), EventParticipant model (confirmed attendance record), IamportConfig / iamportConfigProvider (PortOne payment config), MatchRule / MatchVote / MatchPair models (+12 more)
 
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.15
 Nodes (8): deriveSpecBasename(), designUrlFor(), extractRoutes(), getRoutesByApp(), hasDesignFor(), widgetNameFor(), withWidgetLabels(), Add()
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.11
 Nodes (17): _boardingBadge, build, Container, _DashLinePainter, _formatTicketNo, _MetaLabel, _NotchCircle, paint (+9 more)
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.11
 Nodes (17): build, ColoredBox, dispose, Divider, _EventDetailContent, _EventDetailContentState, Function, initState (+9 more)
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.11
 Nodes (18): Event Now Bar Spec, Event Now Bar Test Plan, Event Now Bar Wireframe, Event State Machine Extension Plan, Golden Test Coverage Plan, Location Consent Plan, My Tickets Plan, My Tickets Spec (+10 more)
-
-### Community 35 - "Community 35"
-Cohesion: 0.14
-Nodes (17): IamportClient, IamportClientTest, initSentry, LoggerTest, withHandler, EXCLUDED_KEYS, maskJsonString, maskMetadata (+9 more)
 
 ### Community 36 - "Community 36"
 Cohesion: 0.2
@@ -933,48 +936,48 @@ Cohesion: 0.33
 Nodes (0): 
 
 ### Community 58 - "Community 58"
+Cohesion: 0.53
+Nodes (6): EXCLUDED_KEYS, maskJsonString, maskMetadata, maskPii, maskValue, PiiMaskerTest
+
+### Community 59 - "Community 59"
 Cohesion: 0.33
 Nodes (0): 
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.4
 Nodes (6): AdminCoordinator, AdminCoordinator Unit Test, PartnerApplicationDetailPage, PartnerApplicationListPage, partnerApplicationProvider, partnerApplicationsProvider
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.4
 Nodes (6): CI/CD Deploy Pipeline Test Cases, Edge Function Environment Variables, Flutter Environment Variables, GitHub Secrets Configuration, Environment Variable Reference, JUSO_CONFIRM_KEY Required/Optional Mismatch Issue
 
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.53
 Nodes (6): Alert #1433: iOS Deploy Partner Failed, Alert #1434: Android Deploy Partner Failed, Alert #1484: iOS Deploy User Failed, Alert #1509: iOS Deploy Partner Failed, App Store Connect Agreement Expiry (FORBIDDEN.REQUIRED_AGREEMENTS_MISSING_OR_EXPIRED), JUSO_CONFIRM_KEY GitHub Actions Secret
-
-### Community 62 - "Community 62"
-Cohesion: 0.33
-Nodes (6): Flutter SDK Availability in Runtime QA Environment, minglit_env Git Submodule (flutter.env), PortOne API Key Env Vars Missing from Edge Functions, Incident #1575: Missing EF Env Vars After Deploy, Incident #1606: Hard Block — Missing minglit_env/dev/flutter.env, Incident #1713: Hard Block — Flutter SDK Missing in Runtime Environment
 
 ### Community 63 - "Community 63"
 Cohesion: 0.4
 Nodes (6): Audit Worker SESSION_TIMEOUT Unbound Variable Crash, Issue Worker needs-dev Label Gate Bug, Incident #672: Issue Worker Activity Check, Incident #675: Issue Worker Restart Required, Incident #679: Worker Reschedule After Dev Pull-Rebase, Incident #681: Issue Worker Scheduling Only
 
 ### Community 64 - "Community 64"
-Cohesion: 0.4
-Nodes (4): allure_report Dart Package, AutoLabelAllureReporter, MinglitException Test Suite, MinglitException (exceptions.dart)
+Cohesion: 0.33
+Nodes (6): Flutter SDK Availability in Runtime QA Environment, minglit_env Git Submodule (flutter.env), PortOne API Key Env Vars Missing from Edge Functions, Incident #1575: Missing EF Env Vars After Deploy, Incident #1606: Hard Block — Missing minglit_env/dev/flutter.env, Incident #1713: Hard Block — Flutter SDK Missing in Runtime Environment
 
 ### Community 65 - "Community 65"
 Cohesion: 0.4
-Nodes (5): MinglitFilePickerImagePreview, MinglitFilePickerPreviewList, MinglitFilePicker, MinglitFilePickerUploadButton, StorageRepository
+Nodes (4): allure_report Dart Package, AutoLabelAllureReporter, MinglitException Test Suite, MinglitException (exceptions.dart)
 
 ### Community 66 - "Community 66"
 Cohesion: 0.4
-Nodes (4): AgeUtil, calculateKoreanAge, calculateManAge, calculateManAgeFromDate
+Nodes (5): MinglitFilePickerImagePreview, MinglitFilePickerPreviewList, MinglitFilePicker, MinglitFilePickerUploadButton, StorageRepository
 
 ### Community 67 - "Community 67"
-Cohesion: 0.7
-Nodes (4): checkAuth(), checkDatabase(), checkStorage(), withTimeout()
+Cohesion: 0.4
+Nodes (4): AgeUtil, calculateKoreanAge, calculateManAge, calculateManAgeFromDate
 
 ### Community 68 - "Community 68"
-Cohesion: 0.4
-Nodes (0): 
+Cohesion: 0.7
+Nodes (4): checkAuth(), checkDatabase(), checkStorage(), withTimeout()
 
 ### Community 69 - "Community 69"
 Cohesion: 0.4
@@ -982,51 +985,51 @@ Nodes (0):
 
 ### Community 70 - "Community 70"
 Cohesion: 0.4
-Nodes (5): Tag Discovery Technical Design Plan, Tag Discovery Feature Spec, Tag Discovery Test Plan, Tag Discovery Wireframe, Tag Stats Usage Policy
+Nodes (0): 
 
 ### Community 71 - "Community 71"
+Cohesion: 0.4
+Nodes (5): Tag Discovery Technical Design Plan, Tag Discovery Feature Spec, Tag Discovery Test Plan, Tag Discovery Wireframe, Tag Stats Usage Policy
+
+### Community 72 - "Community 72"
 Cohesion: 0.6
 Nodes (5): Signup Consent Technical Design Plan, Signup Consent Feature Spec, Signup Consent Test Plan, Signup Consent Wireframe (Original), Signup Consent Wireframe v2 (Redesign)
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.4
 Nodes (5): Account Deletion Technical Design Plan, Account Deletion Feature Spec, Account Deletion Test Plan, Account Deletion Wireframe, Account Management Sub-page Wireframe
 
-### Community 73 - "Community 73"
+### Community 74 - "Community 74"
 Cohesion: 0.5
 Nodes (5): Patrol 도입 기술 설계, 반복 이벤트 기술 설계, 반복 이벤트 스펙, 반복 이벤트 테스트 계획, 반복 이벤트 와이어프레임
 
-### Community 74 - "Community 74"
+### Community 75 - "Community 75"
 Cohesion: 0.5
 Nodes (5): TPM Report — CI Failure 40 Issues/Week, Deploy Workflow Stability, TPM Report — iOS Deploy 100% Failure + Issue Digest Rate Drop, TPM Report — iOS Deploy Continued Failure + CI Failure 45 Issues/Week, TPM Report — iOS Deploy Failure Recurrence Week 3, TPM Report — iOS Deploy Workflow Failure 8/7 Days
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.5
 Nodes (5): android-emulator-runner Shell Compatibility Issue, Ops Alert #1128 — Daily Backend Simulation Failed (2026-04-06), Ops Alert #1238 — Deploy Supabase Migrations Failed (2026-04-10), Ops Alert #916 — Daily Backend Simulation Failed (2026-03-30), Ops Alert #950 — Daily CUJ Test 5-day ADB Failure
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.5
 Nodes (4): MinglitBadge, MinglitBadgeTest, MinglitTag, MinglitTagTest
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.5
 Nodes (4): MatchPair Model, MatchRule Model, MatchVote Model, Matching Model Test
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.67
 Nodes (2): toCamel(), toPascal()
 
-### Community 79 - "Community 79"
-Cohesion: 0.5
-Nodes (0): 
-
 ### Community 80 - "Community 80"
 Cohesion: 0.5
-Nodes (4): checkStatsigGate, initStatsig, logStatsigEvent, StatsigUtilsTest
+Nodes (0): 
 
 ### Community 81 - "Community 81"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (4): checkStatsigGate, initStatsig, logStatsigEvent, StatsigUtilsTest
 
 ### Community 82 - "Community 82"
 Cohesion: 0.5
@@ -1037,44 +1040,44 @@ Cohesion: 0.5
 Nodes (0): 
 
 ### Community 84 - "Community 84"
-Cohesion: 0.67
-Nodes (4): eventMatchRulesProvider, MatchingController, MatchingController Test, MatchingSettingsScreen
+Cohesion: 0.5
+Nodes (0): 
 
 ### Community 85 - "Community 85"
 Cohesion: 0.67
 Nodes (4): StatsigAnalyticsProvider (Partner), RootLayout (landing_user), StatsigAnalyticsProvider (User), @statsig/react-bindings StatsigProvider
 
 ### Community 86 - "Community 86"
-Cohesion: 0.83
-Nodes (4): 파트너 QR 체크인 UX 강화 스펙, 파트너 QR 체크인 UX 강화 테스트 계획, 파트너 QR 체크인 UI/UX 디자인, 파트너 QR 체크인 와이어프레임
+Cohesion: 0.5
+Nodes (3): AdmissionButtonConfig, AdmissionState, _checkEligibility
 
 ### Community 87 - "Community 87"
 Cohesion: 0.67
-Nodes (4): ai-embed EF 에러 핸들링 갭 — DB 쿼리 에러 미검증, vectorization 에러 삼킴, 결제 full-cycle 통합 테스트 부재 — create-order→webhook→apply→cancel→refund 경로 미커버, Issue #1409: 결제하기 진입 시 Type Cast Error (applyEvent null cast), Issue #1440: QA Audit Report — ai-embed 에러 핸들링 갭 + 결제 통합 테스트 전략
+Nodes (4): eventMatchRulesProvider, MatchingController, MatchingController Test, MatchingSettingsScreen
 
 ### Community 88 - "Community 88"
-Cohesion: 0.67
-Nodes (3): GlobalLoadingController, GlobalLoadingState, MinglitGlobalLoadingOverlay
+Cohesion: 0.83
+Nodes (4): 파트너 QR 체크인 UX 강화 스펙, 파트너 QR 체크인 UX 강화 테스트 계획, 파트너 QR 체크인 UI/UX 디자인, 파트너 QR 체크인 와이어프레임
 
 ### Community 89 - "Community 89"
 Cohesion: 0.67
-Nodes (3): platform_utils (conditional export), isLocalhost (IO), isLocalhost (Web)
+Nodes (4): ai-embed EF 에러 핸들링 갭 — DB 쿼리 에러 미검증, vectorization 에러 삼킴, 결제 full-cycle 통합 테스트 부재 — create-order→webhook→apply→cancel→refund 경로 미커버, Issue #1409: 결제하기 진입 시 Type Cast Error (applyEvent null cast), Issue #1440: QA Audit Report — ai-embed 에러 핸들링 갭 + 결제 통합 테스트 전략
 
 ### Community 90 - "Community 90"
 Cohesion: 0.67
-Nodes (2): _EventRepositoryFeedQueries, Exception
+Nodes (3): GlobalLoadingController, GlobalLoadingState, MinglitGlobalLoadingOverlay
 
 ### Community 91 - "Community 91"
 Cohesion: 0.67
-Nodes (2): _EventRepositoryCheckinQueries, FormatException
+Nodes (3): platform_utils (conditional export), isLocalhost (IO), isLocalhost (Web)
 
 ### Community 92 - "Community 92"
 Cohesion: 0.67
-Nodes (3): Axiom Structured Logger, Axiom Logger Test Suite, PII Masker (maskMetadata)
+Nodes (2): _EventRepositoryFeedQueries, Exception
 
 ### Community 93 - "Community 93"
 Cohesion: 0.67
-Nodes (3): Auth Utils (requireAuth / optionalAuth / requireServiceRole), Response Utils (errorResponse), Supabase Service Client (createServiceClient)
+Nodes (2): _EventRepositoryCheckinQueries, FormatException
 
 ### Community 94 - "Community 94"
 Cohesion: 0.67
@@ -1082,7 +1085,7 @@ Nodes (0):
 
 ### Community 95 - "Community 95"
 Cohesion: 0.67
-Nodes (0): 
+Nodes (3): Axiom Structured Logger, Axiom Logger Test Suite, PII Masker (maskMetadata)
 
 ### Community 96 - "Community 96"
 Cohesion: 0.67
@@ -1102,115 +1105,115 @@ Nodes (0):
 
 ### Community 100 - "Community 100"
 Cohesion: 0.67
-Nodes (3): PartnerTermsPage, LocationTermsPage, TermsPage (landing_user)
+Nodes (0): 
 
 ### Community 101 - "Community 101"
-Cohesion: 1.0
-Nodes (3): EventNowMultiStack, EventNowMultiStack Widget Test, sortActiveEvents
+Cohesion: 0.67
+Nodes (0): 
 
 ### Community 102 - "Community 102"
 Cohesion: 0.67
-Nodes (3): ConsentCoordinator Unit Test, IdentityVerificationConsentSheet Test, SignupConsentPage Test
+Nodes (3): PartnerTermsPage, LocationTermsPage, TermsPage (landing_user)
 
 ### Community 103 - "Community 103"
-Cohesion: 0.67
-Nodes (3): Event Edit and Cancel Spec, Event Edit and Cancel Test Plan, Event Edit and Cancel Wireframe
+Cohesion: 1.0
+Nodes (3): EventNowMultiStack, EventNowMultiStack Widget Test, sortActiveEvents
 
 ### Community 104 - "Community 104"
 Cohesion: 0.67
-Nodes (3): Ticket QR Boarding Pass Redesign Spec, Ticket QR Boarding Pass Test Plan, Ticket QR Boarding Pass Wireframe
+Nodes (3): ConsentCoordinator Unit Test, IdentityVerificationConsentSheet Test, SignupConsentPage Test
 
 ### Community 105 - "Community 105"
-Cohesion: 1.0
-Nodes (3): TICKET_SIGNING_PRIVATE_KEY_JWK 미설정 — dev 환경 QR/티켓 토큰 생성 불가, Issue #1653: CUJ-U02 QR 생성 실패 — Ticket signing key not configured (500), Issue #1657: 티켓 조회 500 에러 — TICKET_SIGNING_PRIVATE_KEY_JWK 미설정
+Cohesion: 0.67
+Nodes (2): _PartnerApplyDraft, saveDraft
 
 ### Community 106 - "Community 106"
 Cohesion: 0.67
-Nodes (3): settlement_histories.created_at 컬럼 없음 — 올바른 컬럼은 event_at, Issue #1566: P-S12 정산 상세 PostgrestException — settlement_histories.created_at 없음, Issue #1568: P-S11 계좌 관리 진입 경로 미발견 (settlement/bank-account)
+Nodes (3): Event Edit and Cancel Spec, Event Edit and Cancel Test Plan, Event Edit and Cancel Wireframe
 
 ### Community 107 - "Community 107"
 Cohesion: 0.67
-Nodes (3): PartyCurationPage 고아 코드 — UI 진입점 없이 라우트/코디네이터만 존재 (6주 방치), Issue #1293: PartyCurationPage 진입 경로 부재 (U-S02), Issue #1296: PartyCurationPage 진입 경로 미발견 (중복 #1293)
+Nodes (3): Ticket QR Boarding Pass Redesign Spec, Ticket QR Boarding Pass Test Plan, Ticket QR Boarding Pass Wireframe
 
 ### Community 108 - "Community 108"
 Cohesion: 1.0
-Nodes (3): Runtime QA Scheduler System, Incident #1765: Flutter SDK Missing in Runtime Environment, Incident #1850: Testing Device Disconnected - Pixel 7a
+Nodes (3): TICKET_SIGNING_PRIVATE_KEY_JWK 미설정 — dev 환경 QR/티켓 토큰 생성 불가, Issue #1653: CUJ-U02 QR 생성 실패 — Ticket signing key not configured (500), Issue #1657: 티켓 조회 500 에러 — TICKET_SIGNING_PRIVATE_KEY_JWK 미설정
 
 ### Community 109 - "Community 109"
 Cohesion: 0.67
-Nodes (3): Safe Area Bottom Padding Fix (#1830), Ticket Header Bad Wrap Fix (#1831), UI Polish Q1 2026 Wireframe — Partner App (#1830 #1824 #1831)
+Nodes (3): settlement_histories.created_at 컬럼 없음 — 올바른 컬럼은 event_at, Issue #1566: P-S12 정산 상세 PostgrestException — settlement_histories.created_at 없음, Issue #1568: P-S11 계좌 관리 진입 경로 미발견 (settlement/bank-account)
 
 ### Community 110 - "Community 110"
-Cohesion: 1.0
-Nodes (2): MinglitFilePicker Widget, MinglitFilePicker Widget Test Suite
+Cohesion: 0.67
+Nodes (3): PartyCurationPage 고아 코드 — UI 진입점 없이 라우트/코디네이터만 존재 (6주 방치), Issue #1293: PartyCurationPage 진입 경로 부재 (U-S02), Issue #1296: PartyCurationPage 진입 경로 미발견 (중복 #1293)
 
 ### Community 111 - "Community 111"
 Cohesion: 1.0
-Nodes (2): LocationService, LocationService Test
+Nodes (3): Runtime QA Scheduler System, Incident #1765: Flutter SDK Missing in Runtime Environment, Incident #1850: Testing Device Disconnected - Pixel 7a
 
 ### Community 112 - "Community 112"
-Cohesion: 1.0
-Nodes (2): MinglitContentCard, MinglitContentCardTest
+Cohesion: 0.67
+Nodes (3): Safe Area Bottom Padding Fix (#1830), Ticket Header Bad Wrap Fix (#1831), UI Polish Q1 2026 Wireframe — Partner App (#1830 #1824 #1831)
 
 ### Community 113 - "Community 113"
 Cohesion: 1.0
-Nodes (2): MinglitKeyValueRow, MinglitKeyValueRowTest
+Nodes (2): MinglitFilePicker Widget, MinglitFilePicker Widget Test Suite
 
 ### Community 114 - "Community 114"
 Cohesion: 1.0
-Nodes (2): MinglitBottomSheet, MinglitBottomSheetTest
+Nodes (2): LocationService, LocationService Test
 
 ### Community 115 - "Community 115"
 Cohesion: 1.0
-Nodes (2): MinglitTextField, MinglitTextFieldTest
+Nodes (2): MinglitContentCard, MinglitContentCardTest
 
 ### Community 116 - "Community 116"
 Cohesion: 1.0
-Nodes (2): MinglitButton, MinglitButtonTest
+Nodes (2): MinglitKeyValueRow, MinglitKeyValueRowTest
 
 ### Community 117 - "Community 117"
 Cohesion: 1.0
-Nodes (2): Env Keystore (validateEnv / requireEnv), EnvKeyStore Test
+Nodes (2): MinglitBottomSheet, MinglitBottomSheetTest
 
 ### Community 118 - "Community 118"
 Cohesion: 1.0
-Nodes (2): ThemeController, ThemeSettingsTile
+Nodes (2): MinglitTextField, MinglitTextFieldTest
 
 ### Community 119 - "Community 119"
 Cohesion: 1.0
-Nodes (1): supabaseImageUrl
+Nodes (2): MinglitButton, MinglitButtonTest
 
 ### Community 120 - "Community 120"
 Cohesion: 1.0
-Nodes (2): ImageUtils (stripExifAndReencode), stripExifAndReencode Test Suite
+Nodes (2): Env Keystore (validateEnv / requireEnv), EnvKeyStore Test
 
 ### Community 121 - "Community 121"
 Cohesion: 1.0
-Nodes (1): _EventRepositoryPartnerQueries
+Nodes (2): ThemeController, ThemeSettingsTile
 
 ### Community 122 - "Community 122"
 Cohesion: 1.0
-Nodes (1): _EventRepositoryApplicationQueries
+Nodes (1): supabaseImageUrl
 
 ### Community 123 - "Community 123"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): ImageUtils (stripExifAndReencode), stripExifAndReencode Test Suite
 
 ### Community 124 - "Community 124"
 Cohesion: 1.0
-Nodes (2): notification-worker loop_worker Tests, notification-worker loop_worker
+Nodes (1): _EventRepositoryPartnerQueries
 
 ### Community 125 - "Community 125"
 Cohesion: 1.0
-Nodes (2): nowUnix, WorkerUtils
+Nodes (1): _EventRepositoryApplicationQueries
 
 ### Community 126 - "Community 126"
 Cohesion: 1.0
-Nodes (1): MockEvent
+Nodes (0): 
 
 ### Community 127 - "Community 127"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): notification-worker loop_worker Tests, notification-worker loop_worker
 
 ### Community 128 - "Community 128"
 Cohesion: 1.0
@@ -1218,11 +1221,11 @@ Nodes (0):
 
 ### Community 129 - "Community 129"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (2): nowUnix, WorkerUtils
 
 ### Community 130 - "Community 130"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): MockEvent
 
 ### Community 131 - "Community 131"
 Cohesion: 1.0
@@ -1278,7 +1281,7 @@ Nodes (0):
 
 ### Community 144 - "Community 144"
 Cohesion: 1.0
-Nodes (2): validateBuildEnv, landing_user Next.js Config
+Nodes (0): 
 
 ### Community 145 - "Community 145"
 Cohesion: 1.0
@@ -1286,227 +1289,227 @@ Nodes (0):
 
 ### Community 146 - "Community 146"
 Cohesion: 1.0
-Nodes (2): BrandPage, MingleSymbol SVG Component
+Nodes (0): 
 
 ### Community 147 - "Community 147"
 Cohesion: 1.0
-Nodes (2): VisualQaTester Extension, VisualQaTester Test
+Nodes (0): 
 
 ### Community 148 - "Community 148"
 Cohesion: 1.0
-Nodes (2): AdmissionButtonConfig Test, AdmissionState Edge Cases Test
+Nodes (2): validateBuildEnv, landing_user Next.js Config
 
 ### Community 149 - "Community 149"
 Cohesion: 1.0
-Nodes (1): _ConsentDefinition
+Nodes (0): 
 
 ### Community 150 - "Community 150"
 Cohesion: 1.0
-Nodes (2): boardingPassStatus Function, BoardingPassStatus Test
+Nodes (2): BrandPage, MingleSymbol SVG Component
 
 ### Community 151 - "Community 151"
 Cohesion: 1.0
-Nodes (2): SettlementStatusBadge Test, SettlementStatusBadge / SettlementStatus
+Nodes (2): VisualQaTester Extension, VisualQaTester Test
 
 ### Community 152 - "Community 152"
 Cohesion: 1.0
-Nodes (2): StatusFilterChips Widget Test, StatusFilterChips Widget
+Nodes (2): AdmissionButtonConfig Test, AdmissionState Edge Cases Test
 
 ### Community 153 - "Community 153"
 Cohesion: 1.0
-Nodes (2): PartyListItem, PartyListPage
+Nodes (1): _ConsentDefinition
 
 ### Community 154 - "Community 154"
 Cohesion: 1.0
-Nodes (2): partyTicketsProvider, TicketManageScreen
+Nodes (2): boardingPassStatus Function, BoardingPassStatus Test
 
 ### Community 155 - "Community 155"
 Cohesion: 1.0
-Nodes (2): Landing Partner Env Validator, Landing Partner Next.js Config
+Nodes (2): StatusFilterChips Widget Test, StatusFilterChips Widget
 
 ### Community 156 - "Community 156"
 Cohesion: 1.0
-Nodes (2): 개인정보 보호 인증 열람 권한 관리 UI/UX, 개인정보 보호 와이어프레임
+Nodes (2): SettlementStatusBadge Test, SettlementStatusBadge / SettlementStatus
 
 ### Community 157 - "Community 157"
 Cohesion: 1.0
-Nodes (2): Metabase BI Dashboard, Statistics & Analytics Tools Spec
+Nodes (2): PartyListItem, PartyListPage
 
 ### Community 158 - "Community 158"
 Cohesion: 1.0
-Nodes (2): Simulator Edge Function Migration Plan, Simulator Lifecycle Fix Plan
+Nodes (2): partyTicketsProvider, TicketManageScreen
 
 ### Community 159 - "Community 159"
 Cohesion: 1.0
-Nodes (2): Settings UI Redesign UX Design, Settings UI Redesign Wireframe
+Nodes (2): Landing Partner Env Validator, Landing Partner Next.js Config
 
 ### Community 160 - "Community 160"
 Cohesion: 1.0
-Nodes (2): Refund Policy v2 Wireframe (Original), Refund Policy v2 Wireframe (UX Review)
+Nodes (2): 개인정보 보호 인증 열람 권한 관리 UI/UX, 개인정보 보호 와이어프레임
 
 ### Community 161 - "Community 161"
 Cohesion: 1.0
-Nodes (2): Pretendard Font Migration Typography Review, Login Dark Theme Wireframe
+Nodes (2): Metabase BI Dashboard, Statistics & Analytics Tools Spec
 
 ### Community 162 - "Community 162"
 Cohesion: 1.0
-Nodes (2): Trust Badge System Spec, Trust Badge UI/UX Design
+Nodes (2): Simulator Edge Function Migration Plan, Simulator Lifecycle Fix Plan
 
 ### Community 163 - "Community 163"
 Cohesion: 1.0
-Nodes (2): TPM Report — dev Branch Protection Change Blocks All PR Merges, TPM Report — review-presence Workflow Defect Blocking P0 PR #903
+Nodes (2): Pretendard Font Migration Typography Review, Login Dark Theme Wireframe
 
 ### Community 164 - "Community 164"
 Cohesion: 1.0
-Nodes (2): TPM Report — needs-dev Backlog Surge 30 Issues, 10% Digest Rate, TPM Report — Duplicate Issue Creation Pattern
+Nodes (2): Settings UI Redesign UX Design, Settings UI Redesign Wireframe
 
 ### Community 165 - "Community 165"
 Cohesion: 1.0
-Nodes (2): Refund Policy: Terms of Service Page, TPM Report — Refund Policy Terms-Code Mismatch
+Nodes (2): Refund Policy v2 Wireframe (Original), Refund Policy v2 Wireframe (UX Review)
 
 ### Community 166 - "Community 166"
 Cohesion: 1.0
-Nodes (2): Bug: BugReport FAB overlaps MyPage navigation button (PR #1268 regression), Runtime QA Bug #1285: BugReport FAB Blocks MyPage Button Touch Area
+Nodes (2): Trust Badge System Spec, Trust Badge UI/UX Design
 
 ### Community 167 - "Community 167"
 Cohesion: 1.0
-Nodes (2): Bug: Refund button not shown for free ticket (paymentId null canCancel logic), Runtime QA Bug #1652: CUJ-U03 Refund Button Not Shown in Purchase History
+Nodes (2): TPM Report — dev Branch Protection Change Blocks All PR Merges, TPM Report — review-presence Workflow Defect Blocking P0 PR #903
 
 ### Community 168 - "Community 168"
 Cohesion: 1.0
-Nodes (2): Bug: Hot Tags section shows 0-event tags — conceptual contradiction, Runtime QA Bug #1286: Hot Tags Section Shows 0-Event Tags
+Nodes (2): TPM Report — needs-dev Backlog Surge 30 Issues, 10% Digest Rate, TPM Report — Duplicate Issue Creation Pattern
 
 ### Community 169 - "Community 169"
 Cohesion: 1.0
-Nodes (2): CI Issue: Vercel Deploy Cascading Cancel (cron + concurrency), TPM Report #1091: Vercel Deploy 20h+ Cascading Failure — Cron Concurrency
+Nodes (2): Refund Policy: Terms of Service Page, TPM Report — Refund Policy Terms-Code Mismatch
 
 ### Community 170 - "Community 170"
 Cohesion: 1.0
-Nodes (2): Bug Report — CUJ-P03 QR Scanner Summary Card and Entry Group Stats Missing, Bug Report — CUJ-P01 Party Create Wizard Step 3 Next Uncertain
+Nodes (2): Bug: BugReport FAB overlaps MyPage navigation button (PR #1268 regression), Runtime QA Bug #1285: BugReport FAB Blocks MyPage Button Touch Area
 
 ### Community 171 - "Community 171"
 Cohesion: 1.0
-Nodes (2): 이벤트 수정/취소 기능 미구현 — EventEditRoute/cancelEvent 없음, Issue #1338: app_partner 이벤트 수정/취소 통합 테스트 추가 (blocked)
+Nodes (2): Bug: Refund button not shown for free ticket (paymentId null canCancel logic), Runtime QA Bug #1652: CUJ-U03 Refund Button Not Shown in Purchase History
 
 ### Community 172 - "Community 172"
 Cohesion: 1.0
-Nodes (2): UIautomator × Flutter 호환성 한계 — 단일 FlutterSurfaceView로 좌표 탭 부정확, Issue #1291: 이벤트 상세 파트너명 탭 시 파트너 상세 이동 안 됨 (U-S05)
+Nodes (2): Bug: Hot Tags section shows 0-event tags — conceptual contradiction, Runtime QA Bug #1286: Hot Tags Section Shows 0-Event Tags
 
 ### Community 173 - "Community 173"
 Cohesion: 1.0
-Nodes (2): Alert #1506: Version Bump Failed, Version Bump Push Race Condition
+Nodes (2): CI Issue: Vercel Deploy Cascading Cancel (cron + concurrency), TPM Report #1091: Vercel Deploy 20h+ Cascading Failure — Cron Concurrency
 
 ### Community 174 - "Community 174"
 Cohesion: 1.0
-Nodes (2): Backend Simulator Edge Function Timeout Issue, Ops Alert #703 — Daily Backend Simulation Failed (2026-03-28)
+Nodes (2): Bug Report — CUJ-P03 QR Scanner Summary Card and Entry Group Stats Missing, Bug Report — CUJ-P01 Party Create Wizard Step 3 Next Uncertain
 
 ### Community 175 - "Community 175"
 Cohesion: 1.0
-Nodes (2): Duplicate MainActivity in Android Source Sets (src/main + src/dev), Incident #1322: Hard Block — MainActivity Redeclaration on Dev Branch
+Nodes (2): 이벤트 수정/취소 기능 미구현 — EventEditRoute/cancelEvent 없음, Issue #1338: app_partner 이벤트 수정/취소 통합 테스트 추가 (blocked)
 
 ### Community 176 - "Community 176"
 Cohesion: 1.0
-Nodes (1): _RefundRow Widget
+Nodes (2): UIautomator × Flutter 호환성 한계 — 단일 FlutterSurfaceView로 좌표 탭 부정확, Issue #1291: 이벤트 상세 파트너명 탭 시 파트너 상세 이동 안 됨 (U-S05)
 
 ### Community 177 - "Community 177"
 Cohesion: 1.0
-Nodes (1): reporter (AutoLabelAllureReporter)
+Nodes (2): Alert #1506: Version Bump Failed, Version Bump Push Race Condition
 
 ### Community 178 - "Community 178"
 Cohesion: 1.0
-Nodes (1): MinglitListTile Widget Test Suite
+Nodes (2): Backend Simulator Edge Function Timeout Issue, Ops Alert #703 — Daily Backend Simulation Failed (2026-03-28)
 
 ### Community 179 - "Community 179"
 Cohesion: 1.0
-Nodes (1): MinglitContentLayout Widget Test Suite
+Nodes (2): Duplicate MainActivity in Android Source Sets (src/main + src/dev), Incident #1322: Hard Block — MainActivity Redeclaration on Dev Branch
 
 ### Community 180 - "Community 180"
 Cohesion: 1.0
-Nodes (1): MinglitBottomCTA Widget Test Suite
+Nodes (1): _RefundRow Widget
 
 ### Community 181 - "Community 181"
 Cohesion: 1.0
-Nodes (1): MinglitImageCarousel Widget Test Suite
+Nodes (1): reporter (AutoLabelAllureReporter)
 
 ### Community 182 - "Community 182"
 Cohesion: 1.0
-Nodes (1): MinglitImage Widget Test Suite
+Nodes (1): MinglitListTile Widget Test Suite
 
 ### Community 183 - "Community 183"
 Cohesion: 1.0
-Nodes (1): MockSupabaseClient
+Nodes (1): MinglitContentLayout Widget Test Suite
 
 ### Community 184 - "Community 184"
 Cohesion: 1.0
-Nodes (1): minglit_dev.dart (barrel: dev/debug tools)
+Nodes (1): MinglitBottomCTA Widget Test Suite
 
 ### Community 185 - "Community 185"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): MinglitImageCarousel Widget Test Suite
 
 ### Community 186 - "Community 186"
 Cohesion: 1.0
-Nodes (1): TicketCrypto
+Nodes (1): MinglitImage Widget Test Suite
 
 ### Community 187 - "Community 187"
 Cohesion: 1.0
-Nodes (1): Tag model
+Nodes (1): MockSupabaseClient
 
 ### Community 188 - "Community 188"
 Cohesion: 1.0
-Nodes (1): EventFeedType
+Nodes (1): minglit_dev.dart (barrel: dev/debug tools)
 
 ### Community 189 - "Community 189"
 Cohesion: 1.0
-Nodes (1): ConditionKey Enum
+Nodes (0): 
 
 ### Community 190 - "Community 190"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): TicketCrypto
 
 ### Community 191 - "Community 191"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): Tag model
 
 ### Community 192 - "Community 192"
 Cohesion: 1.0
-Nodes (1): recurrence-cron Test Suite
+Nodes (1): EventFeedType
 
 ### Community 193 - "Community 193"
 Cohesion: 1.0
-Nodes (1): payment-verify Test Suite
+Nodes (1): ConditionKey Enum
 
 ### Community 194 - "Community 194"
 Cohesion: 1.0
-Nodes (1): recurrence-rules Test Suite
+Nodes (0): 
 
 ### Community 195 - "Community 195"
 Cohesion: 1.0
-Nodes (1): payout-sync Test Suite
+Nodes (0): 
 
 ### Community 196 - "Community 196"
 Cohesion: 1.0
-Nodes (1): reconciliation-daily Test Suite
+Nodes (1): recurrence-cron Test Suite
 
 ### Community 197 - "Community 197"
 Cohesion: 1.0
-Nodes (1): settlement-query Test Suite
+Nodes (1): payment-verify Test Suite
 
 ### Community 198 - "Community 198"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): recurrence-rules Test Suite
 
 ### Community 199 - "Community 199"
 Cohesion: 1.0
-Nodes (1): Std Server Stub
+Nodes (1): payout-sync Test Suite
 
 ### Community 200 - "Community 200"
 Cohesion: 1.0
-Nodes (1): Mock Supabase Client
+Nodes (1): reconciliation-daily Test Suite
 
 ### Community 201 - "Community 201"
 Cohesion: 1.0
-Nodes (1): Schema Validator
+Nodes (1): settlement-query Test Suite
 
 ### Community 202 - "Community 202"
 Cohesion: 1.0
@@ -1514,19 +1517,19 @@ Nodes (0):
 
 ### Community 203 - "Community 203"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): Std Server Stub
 
 ### Community 204 - "Community 204"
 Cohesion: 1.0
-Nodes (1): process-pending-deletions Test Suite
+Nodes (1): Mock Supabase Client
 
 ### Community 205 - "Community 205"
 Cohesion: 1.0
-Nodes (1): DB: match_votes (via RPC cast_match_vote)
+Nodes (1): Schema Validator
 
 ### Community 206 - "Community 206"
 Cohesion: 1.0
-Nodes (1): settlement-register-transfers Test Suite
+Nodes (0): 
 
 ### Community 207 - "Community 207"
 Cohesion: 1.0
@@ -1534,103 +1537,103 @@ Nodes (0):
 
 ### Community 208 - "Community 208"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): process-pending-deletions Test Suite
 
 ### Community 209 - "Community 209"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): DB: match_votes (via RPC cast_match_vote)
 
 ### Community 210 - "Community 210"
 Cohesion: 1.0
-Nodes (1): user-cancel-deletion Test Suite
+Nodes (1): settlement-register-transfers Test Suite
 
 ### Community 211 - "Community 211"
 Cohesion: 1.0
-Nodes (1): corsResponse
+Nodes (0): 
 
 ### Community 212 - "Community 212"
 Cohesion: 1.0
-Nodes (1): createServiceClient
+Nodes (0): 
 
 ### Community 213 - "Community 213"
 Cohesion: 1.0
-Nodes (1): nowISO
+Nodes (0): 
 
 ### Community 214 - "Community 214"
 Cohesion: 1.0
-Nodes (1): isoToUnix
+Nodes (1): user-cancel-deletion Test Suite
 
 ### Community 215 - "Community 215"
 Cohesion: 1.0
-Nodes (1): fetchPartnerPortoneId
+Nodes (1): Response Utils (errorResponse)
 
 ### Community 216 - "Community 216"
 Cohesion: 1.0
-Nodes (1): requireNonEmpty
+Nodes (1): corsResponse
 
 ### Community 217 - "Community 217"
 Cohesion: 1.0
-Nodes (1): validateBizType
+Nodes (1): Supabase Service Client (createServiceClient)
 
 ### Community 218 - "Community 218"
 Cohesion: 1.0
-Nodes (1): validateBizNumber
+Nodes (1): nowISO
 
 ### Community 219 - "Community 219"
 Cohesion: 1.0
-Nodes (1): validatePhone
+Nodes (1): isoToUnix
 
 ### Community 220 - "Community 220"
 Cohesion: 1.0
-Nodes (1): validateEmail
+Nodes (1): fetchPartnerPortoneId
 
 ### Community 221 - "Community 221"
 Cohesion: 1.0
-Nodes (1): withSpan
+Nodes (1): requireNonEmpty
 
 ### Community 222 - "Community 222"
 Cohesion: 1.0
-Nodes (1): captureException
+Nodes (1): validateBizType
 
 ### Community 223 - "Community 223"
 Cohesion: 1.0
-Nodes (1): IamportPayment
+Nodes (1): validateBizNumber
 
 ### Community 224 - "Community 224"
 Cohesion: 1.0
-Nodes (1): PartnerPermission
+Nodes (1): validatePhone
 
 ### Community 225 - "Community 225"
 Cohesion: 1.0
-Nodes (1): _shared/env_keystore
+Nodes (1): validateEmail
 
 ### Community 226 - "Community 226"
 Cohesion: 1.0
-Nodes (1): _shared/worker_utils
+Nodes (1): IamportPayment
 
 ### Community 227 - "Community 227"
 Cohesion: 1.0
-Nodes (1): EmbeddingAdapter
+Nodes (1): PartnerPermission
 
 ### Community 228 - "Community 228"
 Cohesion: 1.0
-Nodes (1): Apply Event Integration Test
+Nodes (1): _shared/env_keystore
 
 ### Community 229 - "Community 229"
 Cohesion: 1.0
-Nodes (1): settlement-transfer Test Suite
+Nodes (1): _shared/worker_utils
 
 ### Community 230 - "Community 230"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): EmbeddingAdapter
 
 ### Community 231 - "Community 231"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): Apply Event Integration Test
 
 ### Community 232 - "Community 232"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): settlement-transfer Test Suite
 
 ### Community 233 - "Community 233"
 Cohesion: 1.0
@@ -1718,289 +1721,301 @@ Nodes (0):
 
 ### Community 254 - "Community 254"
 Cohesion: 1.0
-Nodes (1): landing_user ESLint Config
+Nodes (0): 
 
 ### Community 255 - "Community 255"
 Cohesion: 1.0
-Nodes (1): LandingUserPage
+Nodes (0): 
 
 ### Community 256 - "Community 256"
 Cohesion: 1.0
-Nodes (1): Integration Test Driver
+Nodes (0): 
 
 ### Community 257 - "Community 257"
 Cohesion: 1.0
-Nodes (1): reporter.dart (AutoLabelAllureReporter)
+Nodes (1): landing_user ESLint Config
 
 ### Community 258 - "Community 258"
 Cohesion: 1.0
-Nodes (1): Alchemist Package
+Nodes (1): LandingUserPage
 
 ### Community 259 - "Community 259"
 Cohesion: 1.0
-Nodes (1): AuthCoordinator Unit Test
+Nodes (1): Integration Test Driver
 
 ### Community 260 - "Community 260"
 Cohesion: 1.0
-Nodes (1): DeletionCompletePage Test
+Nodes (1): reporter.dart (AutoLabelAllureReporter)
 
 ### Community 261 - "Community 261"
 Cohesion: 1.0
-Nodes (1): StatusBadge Widget Test
+Nodes (1): Alchemist Package
 
 ### Community 262 - "Community 262"
 Cohesion: 1.0
-Nodes (1): permission_grant_test (patrol, skipped)
+Nodes (1): AuthCoordinator Unit Test
 
 ### Community 263 - "Community 263"
 Cohesion: 1.0
-Nodes (1): payment_pg_test (patrol, skipped)
+Nodes (1): DeletionCompletePage Test
 
 ### Community 264 - "Community 264"
 Cohesion: 1.0
-Nodes (1): kakao_login_test (patrol, skipped)
+Nodes (1): StatusBadge Widget Test
 
 ### Community 265 - "Community 265"
 Cohesion: 1.0
-Nodes (0): 
+Nodes (1): permission_grant_test (patrol, skipped)
 
 ### Community 266 - "Community 266"
 Cohesion: 1.0
-Nodes (1): _StepIndicator / _Footer (wizard parts)
+Nodes (1): payment_pg_test (patrol, skipped)
 
 ### Community 267 - "Community 267"
 Cohesion: 1.0
-Nodes (1): app_user AppRoutes (app_routes.dart)
+Nodes (1): kakao_login_test (patrol, skipped)
 
 ### Community 268 - "Community 268"
 Cohesion: 1.0
-Nodes (1): app_user AppRouter (app_router.dart)
+Nodes (0): 
 
 ### Community 269 - "Community 269"
 Cohesion: 1.0
-Nodes (1): DownloadBottomSheet CSV Test
+Nodes (1): _StepIndicator / _Footer (wizard parts)
 
 ### Community 270 - "Community 270"
 Cohesion: 1.0
-Nodes (1): ReviewVerificationScreen snapshot_data Type Guard Test
+Nodes (1): ShareUtils
 
 ### Community 271 - "Community 271"
 Cohesion: 1.0
-Nodes (1): AccountDeletion Flow Logic Unit Test
+Nodes (1): app_user AppRouter (app_router.dart)
 
 ### Community 272 - "Community 272"
 Cohesion: 1.0
-Nodes (1): DefaultFirebaseOptions
+Nodes (1): DownloadBottomSheet CSV Test
 
 ### Community 273 - "Community 273"
 Cohesion: 1.0
-Nodes (1): MinglitEditableSection
+Nodes (1): ReviewVerificationScreen snapshot_data Type Guard Test
 
 ### Community 274 - "Community 274"
 Cohesion: 1.0
-Nodes (1): TodayPartyCard
+Nodes (1): AccountDeletion Flow Logic Unit Test
 
 ### Community 275 - "Community 275"
 Cohesion: 1.0
-Nodes (1): SettlementListShimmer
+Nodes (1): DefaultFirebaseOptions
 
 ### Community 276 - "Community 276"
 Cohesion: 1.0
-Nodes (1): EventCard
+Nodes (1): MinglitEditableSection
 
 ### Community 277 - "Community 277"
 Cohesion: 1.0
-Nodes (1): PartyImageEditor
+Nodes (1): TodayPartyCard
 
 ### Community 278 - "Community 278"
 Cohesion: 1.0
-Nodes (1): PartyStatusEditSheet
+Nodes (1): SettlementListShimmer
 
 ### Community 279 - "Community 279"
 Cohesion: 1.0
-Nodes (1): PartyVerificationInput
+Nodes (1): EventCard
 
 ### Community 280 - "Community 280"
 Cohesion: 1.0
-Nodes (1): app_partner AppRoutes (app_routes.dart)
+Nodes (1): PartyImageEditor
 
 ### Community 281 - "Community 281"
 Cohesion: 1.0
-Nodes (1): app_partner AppRouter (app_router.dart)
+Nodes (1): PartyStatusEditSheet
 
 ### Community 282 - "Community 282"
 Cohesion: 1.0
-Nodes (1): Landing Partner PostCSS Config
+Nodes (1): PartyVerificationInput
 
 ### Community 283 - "Community 283"
 Cohesion: 1.0
-Nodes (1): Landing Partner ESLint Config
+Nodes (1): app_partner AppRoutes (app_routes.dart)
 
 ### Community 284 - "Community 284"
 Cohesion: 1.0
-Nodes (1): Landing Partner Home Page
+Nodes (1): app_partner AppRouter (app_router.dart)
 
 ### Community 285 - "Community 285"
 Cohesion: 1.0
-Nodes (1): Landing Partner Privacy Policy Page
+Nodes (1): Landing Partner PostCSS Config
 
 ### Community 286 - "Community 286"
 Cohesion: 1.0
-Nodes (1): AppUser README
+Nodes (1): Landing Partner ESLint Config
 
 ### Community 287 - "Community 287"
 Cohesion: 1.0
-Nodes (1): App Partner README
+Nodes (1): Landing Partner Home Page
 
 ### Community 288 - "Community 288"
 Cohesion: 1.0
-Nodes (1): landing_user README
+Nodes (1): Landing Partner Privacy Policy Page
 
 ### Community 289 - "Community 289"
 Cohesion: 1.0
-Nodes (1): Landing Partner README
+Nodes (1): AppUser README
 
 ### Community 290 - "Community 290"
 Cohesion: 1.0
-Nodes (1): minglit_kit CHANGELOG
+Nodes (1): App Partner README
 
 ### Community 291 - "Community 291"
 Cohesion: 1.0
-Nodes (1): minglit_kit README
+Nodes (1): landing_user README
 
 ### Community 292 - "Community 292"
 Cohesion: 1.0
-Nodes (1): Pretendard Font OFL License
+Nodes (1): Landing Partner README
 
 ### Community 293 - "Community 293"
 Cohesion: 1.0
-Nodes (1): 구매 내역 색상 위계 리디자인 와이어프레임
+Nodes (1): minglit_kit CHANGELOG
 
 ### Community 294 - "Community 294"
 Cohesion: 1.0
-Nodes (1): My Tickets Test Plan
+Nodes (1): minglit_kit README
 
 ### Community 295 - "Community 295"
 Cohesion: 1.0
-Nodes (1): Partner Detail Event Card Wireframe
+Nodes (1): Pretendard Font OFL License
 
 ### Community 296 - "Community 296"
 Cohesion: 1.0
-Nodes (1): MinglitEmptyState Variants Wireframe
+Nodes (1): 구매 내역 색상 위계 리디자인 와이어프레임
 
 ### Community 297 - "Community 297"
 Cohesion: 1.0
-Nodes (1): 파트너 정산 어드민 UI/UX 설계
+Nodes (1): My Tickets Test Plan
 
 ### Community 298 - "Community 298"
 Cohesion: 1.0
-Nodes (1): Event Now Bar Technical Plan
+Nodes (1): Partner Detail Event Card Wireframe
 
 ### Community 299 - "Community 299"
 Cohesion: 1.0
-Nodes (1): Security Audit Report — Tag Discovery Phase 1
+Nodes (1): MinglitEmptyState Variants Wireframe
 
 ### Community 300 - "Community 300"
 Cohesion: 1.0
-Nodes (1): Runtime QA Bug — app_partner DevUserSwitchScreen Non-functional + am force-stop Auto-login Failure
+Nodes (1): 파트너 정산 어드민 UI/UX 설계
 
 ### Community 301 - "Community 301"
 Cohesion: 1.0
-Nodes (1): Issue #1542: Login 페이지 다크 테마 일관성 (P3-low)
+Nodes (1): Event Now Bar Technical Plan
 
 ### Community 302 - "Community 302"
 Cohesion: 1.0
-Nodes (1): Bug Report — P-S31 /dev Deeplink 404
+Nodes (1): Security Audit Report — Tag Discovery Phase 1
 
 ### Community 303 - "Community 303"
 Cohesion: 1.0
-Nodes (1): Runtime QA — CUJ-U03 Refund Button Label Mismatch
+Nodes (1): Runtime QA Bug — app_partner DevUserSwitchScreen Non-functional + am force-stop Auto-login Failure
 
 ### Community 304 - "Community 304"
 Cohesion: 1.0
-Nodes (1): Runtime QA Bug — Build Server Disk Full (98%)
+Nodes (1): Issue #1542: Login 페이지 다크 테마 일관성 (P3-low)
 
 ### Community 305 - "Community 305"
 Cohesion: 1.0
-Nodes (1): Runtime QA Bug — Pixel 7a ADB Wireless Session Disconnect
+Nodes (1): Bug Report — P-S31 /dev Deeplink 404
 
 ### Community 306 - "Community 306"
 Cohesion: 1.0
-Nodes (1): Ops Alert #990 — Dependabot CI Actions Update (actions/checkout v4->v6)
+Nodes (1): Runtime QA — CUJ-U03 Refund Button Label Mismatch
 
 ### Community 307 - "Community 307"
 Cohesion: 1.0
-Nodes (1): App logo: purple gradient speech bubble with white 'm', orange sparkle accent
+Nodes (1): Runtime QA Bug — Build Server Disk Full (98%)
 
 ### Community 308 - "Community 308"
 Cohesion: 1.0
-Nodes (1): App splash icon: purple gradient chat bubble with white 'm' and orange sparkle
+Nodes (1): Runtime QA Bug — Pixel 7a ADB Wireless Session Disconnect
 
 ### Community 309 - "Community 309"
 Cohesion: 1.0
-Nodes (1): Minglit app splash icon: purple chat bubble with white 'm' and orange sparkle
+Nodes (1): Ops Alert #990 — Dependabot CI Actions Update (actions/checkout v4->v6)
 
 ### Community 310 - "Community 310"
 Cohesion: 1.0
-Nodes (1): App icon foreground: purple chat bubble with white 'm' and orange sparkle
+Nodes (1): App logo: purple gradient speech bubble with white 'm', orange sparkle accent
 
 ### Community 311 - "Community 311"
 Cohesion: 1.0
-Nodes (1): Purple-blue gradient background image for app_partner icon
+Nodes (1): App splash icon: purple gradient chat bubble with white 'm' and orange sparkle
 
 ### Community 312 - "Community 312"
 Cohesion: 1.0
-Nodes (1): Minglit inverted logo: white wordmark with cyan and orange shadow layers on transparent background
+Nodes (1): Minglit app splash icon: purple chat bubble with white 'm' and orange sparkle
 
 ### Community 313 - "Community 313"
 Cohesion: 1.0
-Nodes (1): Minglit wordmark logo SVG with transparent background, cyan/orange layered text
+Nodes (1): App icon foreground: purple chat bubble with white 'm' and orange sparkle
 
 ### Community 314 - "Community 314"
 Cohesion: 1.0
-Nodes (1): Minglit app bar logo — bold italic 'Minglit' text in purple with cyan and orange shadow layers
+Nodes (1): Purple-blue gradient background image for app_partner icon
 
 ### Community 315 - "Community 315"
 Cohesion: 1.0
-Nodes (1): Upscale lounge/restaurant interior with bar, green velvet chairs, Asian art, warm lighting
+Nodes (1): Minglit inverted logo: white wordmark with cyan and orange shadow layers on transparent background
 
 ### Community 316 - "Community 316"
 Cohesion: 1.0
-Nodes (1): Bright minimalist Korean cafe interior with numbered wooden tables, plants, string lights, and coffee bar
+Nodes (1): Minglit wordmark logo SVG with transparent background, cyan/orange layered text
 
 ### Community 317 - "Community 317"
 Cohesion: 1.0
-Nodes (1): Warm sunlit cafe interior with wood furniture, plants, string lights, and menu board
+Nodes (1): Minglit app bar logo — bold italic 'Minglit' text in purple with cyan and orange shadow layers
 
 ### Community 318 - "Community 318"
 Cohesion: 1.0
-Nodes (1): Participation status redesign (after) — not-logged-in state with counts and login prompt
+Nodes (1): Upscale lounge/restaurant interior with bar, green velvet chairs, Asian art, warm lighting
 
 ### Community 319 - "Community 319"
 Cohesion: 1.0
-Nodes (1): Dark theme participation status redesign, 2-group male/female layout with progress bars
+Nodes (1): Bright minimalist Korean cafe interior with numbered wooden tables, plants, string lights, and coffee bar
 
 ### Community 320 - "Community 320"
 Cohesion: 1.0
-Nodes (1): Participation status redesign after-state with 4 groups showing 12/40 total and per-group cards
+Nodes (1): Warm sunlit cafe interior with wood furniture, plants, string lights, and menu board
 
 ### Community 321 - "Community 321"
 Cohesion: 1.0
-Nodes (1): Empty participation status UI: 0/20 total, 0/10 male/female, empty state message
+Nodes (1): Participation status redesign (after) — not-logged-in state with counts and login prompt
 
 ### Community 322 - "Community 322"
 Cohesion: 1.0
-Nodes (1): Participation status redesign after variant: 2-group (male/female) split with progress bars
+Nodes (1): Dark theme participation status redesign, 2-group male/female layout with progress bars
 
 ### Community 323 - "Community 323"
 Cohesion: 1.0
-Nodes (1): Participation status redesign: 2-group (male/female) expanded view with counts and age breakdowns
+Nodes (1): Participation status redesign after-state with 4 groups showing 12/40 total and per-group cards
 
 ### Community 324 - "Community 324"
 Cohesion: 1.0
-Nodes (1): Before state: participation status UI with male/female groups, 2/10 capacity each
+Nodes (1): Empty participation status UI: 0/20 total, 0/10 male/female, empty state message
 
 ### Community 325 - "Community 325"
+Cohesion: 1.0
+Nodes (1): Participation status redesign after variant: 2-group (male/female) split with progress bars
+
+### Community 326 - "Community 326"
+Cohesion: 1.0
+Nodes (1): Participation status redesign: 2-group (male/female) expanded view with counts and age breakdowns
+
+### Community 327 - "Community 327"
+Cohesion: 1.0
+Nodes (1): Before state: participation status UI with male/female groups, 2/10 capacity each
+
+### Community 328 - "Community 328"
 Cohesion: 1.0
 Nodes (1): user_profiles Table
 
@@ -2011,439 +2026,439 @@ Nodes (1): user_profiles Table
   /Users/mark/workspace/minglit-graphify-init/docs/reports/architecture/2026-04-05-issue1092-architect-audit-report-architecture-audit.md · relation: conceptually_related_to
 
 ## Knowledge Gaps
-- **1937 isolated node(s):** `reporter (AutoLabelAllureReporter)`, `BugReporterWrapper Widget Test Suite`, `MinglitListTile Widget Test Suite`, `MinglitHorizontalScrollGroup Widget Test Suite`, `MinglitContentLayout Widget Test Suite` (+1932 more)
+- **2040 isolated node(s):** `reporter (AutoLabelAllureReporter)`, `BugReporterWrapper Widget Test Suite`, `MinglitListTile Widget Test Suite`, `MinglitHorizontalScrollGroup Widget Test Suite`, `MinglitContentLayout Widget Test Suite` (+2035 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 110`** (2 nodes): `MinglitFilePicker Widget`, `MinglitFilePicker Widget Test Suite`
+- **Thin community `Community 113`** (2 nodes): `MinglitFilePicker Widget`, `MinglitFilePicker Widget Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 111`** (2 nodes): `LocationService`, `LocationService Test`
+- **Thin community `Community 114`** (2 nodes): `LocationService`, `LocationService Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 112`** (2 nodes): `MinglitContentCard`, `MinglitContentCardTest`
+- **Thin community `Community 115`** (2 nodes): `MinglitContentCard`, `MinglitContentCardTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 113`** (2 nodes): `MinglitKeyValueRow`, `MinglitKeyValueRowTest`
+- **Thin community `Community 116`** (2 nodes): `MinglitKeyValueRow`, `MinglitKeyValueRowTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 114`** (2 nodes): `MinglitBottomSheet`, `MinglitBottomSheetTest`
+- **Thin community `Community 117`** (2 nodes): `MinglitBottomSheet`, `MinglitBottomSheetTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 115`** (2 nodes): `MinglitTextField`, `MinglitTextFieldTest`
+- **Thin community `Community 118`** (2 nodes): `MinglitTextField`, `MinglitTextFieldTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 116`** (2 nodes): `MinglitButton`, `MinglitButtonTest`
+- **Thin community `Community 119`** (2 nodes): `MinglitButton`, `MinglitButtonTest`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 117`** (2 nodes): `Env Keystore (validateEnv / requireEnv)`, `EnvKeyStore Test`
+- **Thin community `Community 120`** (2 nodes): `Env Keystore (validateEnv / requireEnv)`, `EnvKeyStore Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 118`** (2 nodes): `ThemeController`, `ThemeSettingsTile`
+- **Thin community `Community 121`** (2 nodes): `ThemeController`, `ThemeSettingsTile`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 119`** (2 nodes): `supabase_image_url.dart`, `supabaseImageUrl`
+- **Thin community `Community 122`** (2 nodes): `supabase_image_url.dart`, `supabaseImageUrl`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 120`** (2 nodes): `ImageUtils (stripExifAndReencode)`, `stripExifAndReencode Test Suite`
+- **Thin community `Community 123`** (2 nodes): `ImageUtils (stripExifAndReencode)`, `stripExifAndReencode Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 121`** (2 nodes): `event_repository_partner_queries.dart`, `_EventRepositoryPartnerQueries`
+- **Thin community `Community 124`** (2 nodes): `event_repository_partner_queries.dart`, `_EventRepositoryPartnerQueries`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 122`** (2 nodes): `event_repository_application_queries.dart`, `_EventRepositoryApplicationQueries`
+- **Thin community `Community 125`** (2 nodes): `event_repository_application_queries.dart`, `_EventRepositoryApplicationQueries`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 123`** (2 nodes): `noop()`, `sim_settle_test.ts`
+- **Thin community `Community 126`** (2 nodes): `noop()`, `sim_settle_test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 124`** (2 nodes): `notification-worker loop_worker Tests`, `notification-worker loop_worker`
+- **Thin community `Community 127`** (2 nodes): `notification-worker loop_worker Tests`, `notification-worker loop_worker`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 125`** (2 nodes): `nowUnix`, `WorkerUtils`
+- **Thin community `Community 128`** (2 nodes): `postRequest()`, `index_test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 126`** (2 nodes): `mock_events.dart`, `MockEvent`
+- **Thin community `Community 129`** (2 nodes): `nowUnix`, `WorkerUtils`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 127`** (2 nodes): `RootLayout()`, `layout.tsx`
+- **Thin community `Community 130`** (2 nodes): `mock_events.dart`, `MockEvent`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 128`** (2 nodes): `ScreensPage()`, `page.tsx`
+- **Thin community `Community 131`** (2 nodes): `RootLayout()`, `layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 129`** (2 nodes): `getIcons()`, `page.tsx`
+- **Thin community `Community 132`** (2 nodes): `ScreensPage()`, `page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 130`** (2 nodes): `MermaidDiagram()`, `MermaidDiagram.tsx`
+- **Thin community `Community 133`** (2 nodes): `getIcons()`, `page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 131`** (2 nodes): `SubComponentRow()`, `RouteScreenIndex.tsx`
+- **Thin community `Community 134`** (2 nodes): `MermaidDiagram()`, `MermaidDiagram.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 132`** (2 nodes): `DialogStyles()`, `MinglitDialogSpec.tsx`
+- **Thin community `Community 135`** (2 nodes): `SubComponentRow()`, `RouteScreenIndex.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 133`** (2 nodes): `OverlayStyles()`, `MinglitAlertSpec.tsx`
+- **Thin community `Community 136`** (2 nodes): `DialogStyles()`, `MinglitDialogSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 134`** (2 nodes): `CircleSpinner()`, `MinglitAsyncValueWidgetSpec.tsx`
+- **Thin community `Community 137`** (2 nodes): `OverlayStyles()`, `MinglitAlertSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 135`** (2 nodes): `SegmentedBar()`, `MinglitCapacityBarSpec.tsx`
+- **Thin community `Community 138`** (2 nodes): `CircleSpinner()`, `MinglitAsyncValueWidgetSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 136`** (2 nodes): `ChipStub()`, `MinglitHorizontalScrollGroupSpec.tsx`
+- **Thin community `Community 139`** (2 nodes): `SegmentedBar()`, `MinglitCapacityBarSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 137`** (2 nodes): `DividerDemo()`, `MinglitSectionDividerSpec.tsx`
+- **Thin community `Community 140`** (2 nodes): `ChipStub()`, `MinglitHorizontalScrollGroupSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 138`** (2 nodes): `Btn()`, `MinglitButtonSpec.tsx`
+- **Thin community `Community 141`** (2 nodes): `DividerDemo()`, `MinglitSectionDividerSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 139`** (2 nodes): `ContentCardDemo()`, `MinglitContentCardSpec.tsx`
+- **Thin community `Community 142`** (2 nodes): `Btn()`, `MinglitButtonSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 140`** (2 nodes): `FooDemo()`, `_template.tsx`
+- **Thin community `Community 143`** (2 nodes): `ContentCardDemo()`, `MinglitContentCardSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 141`** (2 nodes): `Badge()`, `MinglitListTileSpec.tsx`
+- **Thin community `Community 144`** (2 nodes): `FooDemo()`, `_template.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 142`** (2 nodes): `SheetStyles()`, `MinglitBottomSheetSpec.tsx`
+- **Thin community `Community 145`** (2 nodes): `Badge()`, `MinglitListTileSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 143`** (2 nodes): `SkeletonBlock()`, `MinglitSkeletonSpec.tsx`
+- **Thin community `Community 146`** (2 nodes): `SheetStyles()`, `MinglitBottomSheetSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 144`** (2 nodes): `validateBuildEnv`, `landing_user Next.js Config`
+- **Thin community `Community 147`** (2 nodes): `SkeletonBlock()`, `MinglitSkeletonSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 145`** (2 nodes): `PrivacyPage()`, `page.tsx`
+- **Thin community `Community 148`** (2 nodes): `validateBuildEnv`, `landing_user Next.js Config`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 146`** (2 nodes): `BrandPage`, `MingleSymbol SVG Component`
+- **Thin community `Community 149`** (2 nodes): `PrivacyPage()`, `page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 147`** (2 nodes): `VisualQaTester Extension`, `VisualQaTester Test`
+- **Thin community `Community 150`** (2 nodes): `BrandPage`, `MingleSymbol SVG Component`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 148`** (2 nodes): `AdmissionButtonConfig Test`, `AdmissionState Edge Cases Test`
+- **Thin community `Community 151`** (2 nodes): `VisualQaTester Extension`, `VisualQaTester Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 149`** (2 nodes): `signup_consent_definitions.dart`, `_ConsentDefinition`
+- **Thin community `Community 152`** (2 nodes): `AdmissionButtonConfig Test`, `AdmissionState Edge Cases Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 150`** (2 nodes): `boardingPassStatus Function`, `BoardingPassStatus Test`
+- **Thin community `Community 153`** (2 nodes): `signup_consent_definitions.dart`, `_ConsentDefinition`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 151`** (2 nodes): `SettlementStatusBadge Test`, `SettlementStatusBadge / SettlementStatus`
+- **Thin community `Community 154`** (2 nodes): `boardingPassStatus Function`, `BoardingPassStatus Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 152`** (2 nodes): `StatusFilterChips Widget Test`, `StatusFilterChips Widget`
+- **Thin community `Community 155`** (2 nodes): `StatusFilterChips Widget Test`, `StatusFilterChips Widget`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 153`** (2 nodes): `PartyListItem`, `PartyListPage`
+- **Thin community `Community 156`** (2 nodes): `SettlementStatusBadge Test`, `SettlementStatusBadge / SettlementStatus`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 154`** (2 nodes): `partyTicketsProvider`, `TicketManageScreen`
+- **Thin community `Community 157`** (2 nodes): `PartyListItem`, `PartyListPage`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 155`** (2 nodes): `Landing Partner Env Validator`, `Landing Partner Next.js Config`
+- **Thin community `Community 158`** (2 nodes): `partyTicketsProvider`, `TicketManageScreen`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 156`** (2 nodes): `개인정보 보호 인증 열람 권한 관리 UI/UX`, `개인정보 보호 와이어프레임`
+- **Thin community `Community 159`** (2 nodes): `Landing Partner Env Validator`, `Landing Partner Next.js Config`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 157`** (2 nodes): `Metabase BI Dashboard`, `Statistics & Analytics Tools Spec`
+- **Thin community `Community 160`** (2 nodes): `개인정보 보호 인증 열람 권한 관리 UI/UX`, `개인정보 보호 와이어프레임`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 158`** (2 nodes): `Simulator Edge Function Migration Plan`, `Simulator Lifecycle Fix Plan`
+- **Thin community `Community 161`** (2 nodes): `Metabase BI Dashboard`, `Statistics & Analytics Tools Spec`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 159`** (2 nodes): `Settings UI Redesign UX Design`, `Settings UI Redesign Wireframe`
+- **Thin community `Community 162`** (2 nodes): `Simulator Edge Function Migration Plan`, `Simulator Lifecycle Fix Plan`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 160`** (2 nodes): `Refund Policy v2 Wireframe (Original)`, `Refund Policy v2 Wireframe (UX Review)`
+- **Thin community `Community 163`** (2 nodes): `Pretendard Font Migration Typography Review`, `Login Dark Theme Wireframe`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 161`** (2 nodes): `Pretendard Font Migration Typography Review`, `Login Dark Theme Wireframe`
+- **Thin community `Community 164`** (2 nodes): `Settings UI Redesign UX Design`, `Settings UI Redesign Wireframe`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 162`** (2 nodes): `Trust Badge System Spec`, `Trust Badge UI/UX Design`
+- **Thin community `Community 165`** (2 nodes): `Refund Policy v2 Wireframe (Original)`, `Refund Policy v2 Wireframe (UX Review)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 163`** (2 nodes): `TPM Report — dev Branch Protection Change Blocks All PR Merges`, `TPM Report — review-presence Workflow Defect Blocking P0 PR #903`
+- **Thin community `Community 166`** (2 nodes): `Trust Badge System Spec`, `Trust Badge UI/UX Design`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 164`** (2 nodes): `TPM Report — needs-dev Backlog Surge 30 Issues, 10% Digest Rate`, `TPM Report — Duplicate Issue Creation Pattern`
+- **Thin community `Community 167`** (2 nodes): `TPM Report — dev Branch Protection Change Blocks All PR Merges`, `TPM Report — review-presence Workflow Defect Blocking P0 PR #903`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 165`** (2 nodes): `Refund Policy: Terms of Service Page`, `TPM Report — Refund Policy Terms-Code Mismatch`
+- **Thin community `Community 168`** (2 nodes): `TPM Report — needs-dev Backlog Surge 30 Issues, 10% Digest Rate`, `TPM Report — Duplicate Issue Creation Pattern`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 166`** (2 nodes): `Bug: BugReport FAB overlaps MyPage navigation button (PR #1268 regression)`, `Runtime QA Bug #1285: BugReport FAB Blocks MyPage Button Touch Area`
+- **Thin community `Community 169`** (2 nodes): `Refund Policy: Terms of Service Page`, `TPM Report — Refund Policy Terms-Code Mismatch`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 167`** (2 nodes): `Bug: Refund button not shown for free ticket (paymentId null canCancel logic)`, `Runtime QA Bug #1652: CUJ-U03 Refund Button Not Shown in Purchase History`
+- **Thin community `Community 170`** (2 nodes): `Bug: BugReport FAB overlaps MyPage navigation button (PR #1268 regression)`, `Runtime QA Bug #1285: BugReport FAB Blocks MyPage Button Touch Area`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 168`** (2 nodes): `Bug: Hot Tags section shows 0-event tags — conceptual contradiction`, `Runtime QA Bug #1286: Hot Tags Section Shows 0-Event Tags`
+- **Thin community `Community 171`** (2 nodes): `Bug: Refund button not shown for free ticket (paymentId null canCancel logic)`, `Runtime QA Bug #1652: CUJ-U03 Refund Button Not Shown in Purchase History`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 169`** (2 nodes): `CI Issue: Vercel Deploy Cascading Cancel (cron + concurrency)`, `TPM Report #1091: Vercel Deploy 20h+ Cascading Failure — Cron Concurrency`
+- **Thin community `Community 172`** (2 nodes): `Bug: Hot Tags section shows 0-event tags — conceptual contradiction`, `Runtime QA Bug #1286: Hot Tags Section Shows 0-Event Tags`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 170`** (2 nodes): `Bug Report — CUJ-P03 QR Scanner Summary Card and Entry Group Stats Missing`, `Bug Report — CUJ-P01 Party Create Wizard Step 3 Next Uncertain`
+- **Thin community `Community 173`** (2 nodes): `CI Issue: Vercel Deploy Cascading Cancel (cron + concurrency)`, `TPM Report #1091: Vercel Deploy 20h+ Cascading Failure — Cron Concurrency`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 171`** (2 nodes): `이벤트 수정/취소 기능 미구현 — EventEditRoute/cancelEvent 없음`, `Issue #1338: app_partner 이벤트 수정/취소 통합 테스트 추가 (blocked)`
+- **Thin community `Community 174`** (2 nodes): `Bug Report — CUJ-P03 QR Scanner Summary Card and Entry Group Stats Missing`, `Bug Report — CUJ-P01 Party Create Wizard Step 3 Next Uncertain`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 172`** (2 nodes): `UIautomator × Flutter 호환성 한계 — 단일 FlutterSurfaceView로 좌표 탭 부정확`, `Issue #1291: 이벤트 상세 파트너명 탭 시 파트너 상세 이동 안 됨 (U-S05)`
+- **Thin community `Community 175`** (2 nodes): `이벤트 수정/취소 기능 미구현 — EventEditRoute/cancelEvent 없음`, `Issue #1338: app_partner 이벤트 수정/취소 통합 테스트 추가 (blocked)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 173`** (2 nodes): `Alert #1506: Version Bump Failed`, `Version Bump Push Race Condition`
+- **Thin community `Community 176`** (2 nodes): `UIautomator × Flutter 호환성 한계 — 단일 FlutterSurfaceView로 좌표 탭 부정확`, `Issue #1291: 이벤트 상세 파트너명 탭 시 파트너 상세 이동 안 됨 (U-S05)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 174`** (2 nodes): `Backend Simulator Edge Function Timeout Issue`, `Ops Alert #703 — Daily Backend Simulation Failed (2026-03-28)`
+- **Thin community `Community 177`** (2 nodes): `Alert #1506: Version Bump Failed`, `Version Bump Push Race Condition`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 175`** (2 nodes): `Duplicate MainActivity in Android Source Sets (src/main + src/dev)`, `Incident #1322: Hard Block — MainActivity Redeclaration on Dev Branch`
+- **Thin community `Community 178`** (2 nodes): `Backend Simulator Edge Function Timeout Issue`, `Ops Alert #703 — Daily Backend Simulation Failed (2026-03-28)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 176`** (1 nodes): `_RefundRow Widget`
+- **Thin community `Community 179`** (2 nodes): `Duplicate MainActivity in Android Source Sets (src/main + src/dev)`, `Incident #1322: Hard Block — MainActivity Redeclaration on Dev Branch`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 177`** (1 nodes): `reporter (AutoLabelAllureReporter)`
+- **Thin community `Community 180`** (1 nodes): `_RefundRow Widget`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 178`** (1 nodes): `MinglitListTile Widget Test Suite`
+- **Thin community `Community 181`** (1 nodes): `reporter (AutoLabelAllureReporter)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 179`** (1 nodes): `MinglitContentLayout Widget Test Suite`
+- **Thin community `Community 182`** (1 nodes): `MinglitListTile Widget Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 180`** (1 nodes): `MinglitBottomCTA Widget Test Suite`
+- **Thin community `Community 183`** (1 nodes): `MinglitContentLayout Widget Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 181`** (1 nodes): `MinglitImageCarousel Widget Test Suite`
+- **Thin community `Community 184`** (1 nodes): `MinglitBottomCTA Widget Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 182`** (1 nodes): `MinglitImage Widget Test Suite`
+- **Thin community `Community 185`** (1 nodes): `MinglitImageCarousel Widget Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 183`** (1 nodes): `MockSupabaseClient`
+- **Thin community `Community 186`** (1 nodes): `MinglitImage Widget Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 184`** (1 nodes): `minglit_dev.dart (barrel: dev/debug tools)`
+- **Thin community `Community 187`** (1 nodes): `MockSupabaseClient`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 185`** (1 nodes): `iamport.dart`
+- **Thin community `Community 188`** (1 nodes): `minglit_dev.dart (barrel: dev/debug tools)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 186`** (1 nodes): `TicketCrypto`
+- **Thin community `Community 189`** (1 nodes): `iamport.dart`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 187`** (1 nodes): `Tag model`
+- **Thin community `Community 190`** (1 nodes): `TicketCrypto`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 188`** (1 nodes): `EventFeedType`
+- **Thin community `Community 191`** (1 nodes): `Tag model`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 189`** (1 nodes): `ConditionKey Enum`
+- **Thin community `Community 192`** (1 nodes): `EventFeedType`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 190`** (1 nodes): `mds.dart`
+- **Thin community `Community 193`** (1 nodes): `ConditionKey Enum`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 191`** (1 nodes): `mds_icons.dart`
+- **Thin community `Community 194`** (1 nodes): `mds.dart`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 192`** (1 nodes): `recurrence-cron Test Suite`
+- **Thin community `Community 195`** (1 nodes): `mds_icons.dart`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 193`** (1 nodes): `payment-verify Test Suite`
+- **Thin community `Community 196`** (1 nodes): `recurrence-cron Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 194`** (1 nodes): `recurrence-rules Test Suite`
+- **Thin community `Community 197`** (1 nodes): `payment-verify Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 195`** (1 nodes): `payout-sync Test Suite`
+- **Thin community `Community 198`** (1 nodes): `recurrence-rules Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 196`** (1 nodes): `reconciliation-daily Test Suite`
+- **Thin community `Community 199`** (1 nodes): `payout-sync Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 197`** (1 nodes): `settlement-query Test Suite`
+- **Thin community `Community 200`** (1 nodes): `reconciliation-daily Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 198`** (1 nodes): `health_test.ts`
+- **Thin community `Community 201`** (1 nodes): `settlement-query Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 199`** (1 nodes): `Std Server Stub`
+- **Thin community `Community 202`** (1 nodes): `health_test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 200`** (1 nodes): `Mock Supabase Client`
+- **Thin community `Community 203`** (1 nodes): `Std Server Stub`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 201`** (1 nodes): `Schema Validator`
+- **Thin community `Community 204`** (1 nodes): `Mock Supabase Client`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 202`** (1 nodes): `sim_assertions_test.ts`
+- **Thin community `Community 205`** (1 nodes): `Schema Validator`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 203`** (1 nodes): `sim_reporter_test.ts`
+- **Thin community `Community 206`** (1 nodes): `sim_assertions_test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 204`** (1 nodes): `process-pending-deletions Test Suite`
+- **Thin community `Community 207`** (1 nodes): `sim_reporter_test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 205`** (1 nodes): `DB: match_votes (via RPC cast_match_vote)`
+- **Thin community `Community 208`** (1 nodes): `process-pending-deletions Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 206`** (1 nodes): `settlement-register-transfers Test Suite`
+- **Thin community `Community 209`** (1 nodes): `DB: match_votes (via RPC cast_match_vote)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 207`** (1 nodes): `payment_webhook_test.ts`
+- **Thin community `Community 210`** (1 nodes): `settlement-register-transfers Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 208`** (1 nodes): `index.ts`
+- **Thin community `Community 211`** (1 nodes): `payment_webhook_test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 209`** (1 nodes): `index.ts`
+- **Thin community `Community 212`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 210`** (1 nodes): `user-cancel-deletion Test Suite`
+- **Thin community `Community 213`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 211`** (1 nodes): `corsResponse`
+- **Thin community `Community 214`** (1 nodes): `user-cancel-deletion Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 212`** (1 nodes): `createServiceClient`
+- **Thin community `Community 215`** (1 nodes): `Response Utils (errorResponse)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 213`** (1 nodes): `nowISO`
+- **Thin community `Community 216`** (1 nodes): `corsResponse`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 214`** (1 nodes): `isoToUnix`
+- **Thin community `Community 217`** (1 nodes): `Supabase Service Client (createServiceClient)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 215`** (1 nodes): `fetchPartnerPortoneId`
+- **Thin community `Community 218`** (1 nodes): `nowISO`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 216`** (1 nodes): `requireNonEmpty`
+- **Thin community `Community 219`** (1 nodes): `isoToUnix`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 217`** (1 nodes): `validateBizType`
+- **Thin community `Community 220`** (1 nodes): `fetchPartnerPortoneId`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 218`** (1 nodes): `validateBizNumber`
+- **Thin community `Community 221`** (1 nodes): `requireNonEmpty`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 219`** (1 nodes): `validatePhone`
+- **Thin community `Community 222`** (1 nodes): `validateBizType`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 220`** (1 nodes): `validateEmail`
+- **Thin community `Community 223`** (1 nodes): `validateBizNumber`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 221`** (1 nodes): `withSpan`
+- **Thin community `Community 224`** (1 nodes): `validatePhone`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 222`** (1 nodes): `captureException`
+- **Thin community `Community 225`** (1 nodes): `validateEmail`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 223`** (1 nodes): `IamportPayment`
+- **Thin community `Community 226`** (1 nodes): `IamportPayment`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 224`** (1 nodes): `PartnerPermission`
+- **Thin community `Community 227`** (1 nodes): `PartnerPermission`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 225`** (1 nodes): `_shared/env_keystore`
+- **Thin community `Community 228`** (1 nodes): `_shared/env_keystore`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (1 nodes): `_shared/worker_utils`
+- **Thin community `Community 229`** (1 nodes): `_shared/worker_utils`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 227`** (1 nodes): `EmbeddingAdapter`
+- **Thin community `Community 230`** (1 nodes): `EmbeddingAdapter`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (1 nodes): `Apply Event Integration Test`
+- **Thin community `Community 231`** (1 nodes): `Apply Event Integration Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 229`** (1 nodes): `settlement-transfer Test Suite`
+- **Thin community `Community 232`** (1 nodes): `settlement-transfer Test Suite`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 230`** (1 nodes): `postcss.config.mjs`
+- **Thin community `Community 233`** (1 nodes): `postcss.config.mjs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 231`** (1 nodes): `tailwind.config.ts`
+- **Thin community `Community 234`** (1 nodes): `tailwind.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 232`** (1 nodes): `eslint.config.mjs`
+- **Thin community `Community 235`** (1 nodes): `eslint.config.mjs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 233`** (1 nodes): `next.config.ts`
+- **Thin community `Community 236`** (1 nodes): `next.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 234`** (1 nodes): `page.tsx`
+- **Thin community `Community 237`** (1 nodes): `page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 235`** (1 nodes): `page.tsx`
+- **Thin community `Community 238`** (1 nodes): `page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 236`** (1 nodes): `page.tsx`
+- **Thin community `Community 239`** (1 nodes): `page.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 237`** (1 nodes): `Sidebar.tsx`
+- **Thin community `Community 240`** (1 nodes): `Sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 238`** (1 nodes): `MinglitSettingsTileSpec.tsx`
+- **Thin community `Community 241`** (1 nodes): `MinglitSettingsTileSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 239`** (1 nodes): `MinglitKeyValueRowSpec.tsx`
+- **Thin community `Community 242`** (1 nodes): `MinglitKeyValueRowSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 240`** (1 nodes): `MinglitErrorStateSpec.tsx`
+- **Thin community `Community 243`** (1 nodes): `MinglitErrorStateSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 241`** (1 nodes): `LoadingIndicatorSpec.tsx`
+- **Thin community `Community 244`** (1 nodes): `LoadingIndicatorSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 242`** (1 nodes): `MinglitSettingsGroupSpec.tsx`
+- **Thin community `Community 245`** (1 nodes): `MinglitSettingsGroupSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 243`** (1 nodes): `MinglitTextFieldSpec.tsx`
+- **Thin community `Community 246`** (1 nodes): `MinglitTextFieldSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 244`** (1 nodes): `NumberStepperInputSpec.tsx`
+- **Thin community `Community 247`** (1 nodes): `NumberStepperInputSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 245`** (1 nodes): `MinglitChipSpec.tsx`
+- **Thin community `Community 248`** (1 nodes): `MinglitChipSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 246`** (1 nodes): `MinglitTimelineSpec.tsx`
+- **Thin community `Community 249`** (1 nodes): `MinglitTimelineSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 247`** (1 nodes): `MinglitChipGroupSpec.tsx`
+- **Thin community `Community 250`** (1 nodes): `MinglitChipGroupSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 248`** (1 nodes): `MinglitContentLayoutSpec.tsx`
+- **Thin community `Community 251`** (1 nodes): `MinglitContentLayoutSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 249`** (1 nodes): `MinglitBadgeSpec.tsx`
+- **Thin community `Community 252`** (1 nodes): `MinglitBadgeSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 250`** (1 nodes): `MinglitFilterChipSpec.tsx`
+- **Thin community `Community 253`** (1 nodes): `MinglitFilterChipSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 251`** (1 nodes): `MinglitSectionSpec.tsx`
+- **Thin community `Community 254`** (1 nodes): `MinglitSectionSpec.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 252`** (1 nodes): `mds-icons-react.ts`
+- **Thin community `Community 255`** (1 nodes): `mds-icons-react.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 253`** (1 nodes): `postcss.config.mjs`
+- **Thin community `Community 256`** (1 nodes): `postcss.config.mjs`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 254`** (1 nodes): `landing_user ESLint Config`
+- **Thin community `Community 257`** (1 nodes): `landing_user ESLint Config`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 255`** (1 nodes): `LandingUserPage`
+- **Thin community `Community 258`** (1 nodes): `LandingUserPage`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 256`** (1 nodes): `Integration Test Driver`
+- **Thin community `Community 259`** (1 nodes): `Integration Test Driver`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 257`** (1 nodes): `reporter.dart (AutoLabelAllureReporter)`
+- **Thin community `Community 260`** (1 nodes): `reporter.dart (AutoLabelAllureReporter)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 258`** (1 nodes): `Alchemist Package`
+- **Thin community `Community 261`** (1 nodes): `Alchemist Package`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 259`** (1 nodes): `AuthCoordinator Unit Test`
+- **Thin community `Community 262`** (1 nodes): `AuthCoordinator Unit Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 260`** (1 nodes): `DeletionCompletePage Test`
+- **Thin community `Community 263`** (1 nodes): `DeletionCompletePage Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 261`** (1 nodes): `StatusBadge Widget Test`
+- **Thin community `Community 264`** (1 nodes): `StatusBadge Widget Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 262`** (1 nodes): `permission_grant_test (patrol, skipped)`
+- **Thin community `Community 265`** (1 nodes): `permission_grant_test (patrol, skipped)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 263`** (1 nodes): `payment_pg_test (patrol, skipped)`
+- **Thin community `Community 266`** (1 nodes): `payment_pg_test (patrol, skipped)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 264`** (1 nodes): `kakao_login_test (patrol, skipped)`
+- **Thin community `Community 267`** (1 nodes): `kakao_login_test (patrol, skipped)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 265`** (1 nodes): `consent_detail_sheet.dart`
+- **Thin community `Community 268`** (1 nodes): `consent_detail_sheet.dart`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 266`** (1 nodes): `_StepIndicator / _Footer (wizard parts)`
+- **Thin community `Community 269`** (1 nodes): `_StepIndicator / _Footer (wizard parts)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 267`** (1 nodes): `app_user AppRoutes (app_routes.dart)`
+- **Thin community `Community 270`** (1 nodes): `ShareUtils`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 268`** (1 nodes): `app_user AppRouter (app_router.dart)`
+- **Thin community `Community 271`** (1 nodes): `app_user AppRouter (app_router.dart)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 269`** (1 nodes): `DownloadBottomSheet CSV Test`
+- **Thin community `Community 272`** (1 nodes): `DownloadBottomSheet CSV Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 270`** (1 nodes): `ReviewVerificationScreen snapshot_data Type Guard Test`
+- **Thin community `Community 273`** (1 nodes): `ReviewVerificationScreen snapshot_data Type Guard Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 271`** (1 nodes): `AccountDeletion Flow Logic Unit Test`
+- **Thin community `Community 274`** (1 nodes): `AccountDeletion Flow Logic Unit Test`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 272`** (1 nodes): `DefaultFirebaseOptions`
+- **Thin community `Community 275`** (1 nodes): `DefaultFirebaseOptions`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 273`** (1 nodes): `MinglitEditableSection`
+- **Thin community `Community 276`** (1 nodes): `MinglitEditableSection`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 274`** (1 nodes): `TodayPartyCard`
+- **Thin community `Community 277`** (1 nodes): `TodayPartyCard`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 275`** (1 nodes): `SettlementListShimmer`
+- **Thin community `Community 278`** (1 nodes): `SettlementListShimmer`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 276`** (1 nodes): `EventCard`
+- **Thin community `Community 279`** (1 nodes): `EventCard`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 277`** (1 nodes): `PartyImageEditor`
+- **Thin community `Community 280`** (1 nodes): `PartyImageEditor`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 278`** (1 nodes): `PartyStatusEditSheet`
+- **Thin community `Community 281`** (1 nodes): `PartyStatusEditSheet`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 279`** (1 nodes): `PartyVerificationInput`
+- **Thin community `Community 282`** (1 nodes): `PartyVerificationInput`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 280`** (1 nodes): `app_partner AppRoutes (app_routes.dart)`
+- **Thin community `Community 283`** (1 nodes): `app_partner AppRoutes (app_routes.dart)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 281`** (1 nodes): `app_partner AppRouter (app_router.dart)`
+- **Thin community `Community 284`** (1 nodes): `app_partner AppRouter (app_router.dart)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 282`** (1 nodes): `Landing Partner PostCSS Config`
+- **Thin community `Community 285`** (1 nodes): `Landing Partner PostCSS Config`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 283`** (1 nodes): `Landing Partner ESLint Config`
+- **Thin community `Community 286`** (1 nodes): `Landing Partner ESLint Config`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 284`** (1 nodes): `Landing Partner Home Page`
+- **Thin community `Community 287`** (1 nodes): `Landing Partner Home Page`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 285`** (1 nodes): `Landing Partner Privacy Policy Page`
+- **Thin community `Community 288`** (1 nodes): `Landing Partner Privacy Policy Page`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 286`** (1 nodes): `AppUser README`
+- **Thin community `Community 289`** (1 nodes): `AppUser README`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 287`** (1 nodes): `App Partner README`
+- **Thin community `Community 290`** (1 nodes): `App Partner README`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 288`** (1 nodes): `landing_user README`
+- **Thin community `Community 291`** (1 nodes): `landing_user README`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 289`** (1 nodes): `Landing Partner README`
+- **Thin community `Community 292`** (1 nodes): `Landing Partner README`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 290`** (1 nodes): `minglit_kit CHANGELOG`
+- **Thin community `Community 293`** (1 nodes): `minglit_kit CHANGELOG`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 291`** (1 nodes): `minglit_kit README`
+- **Thin community `Community 294`** (1 nodes): `minglit_kit README`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 292`** (1 nodes): `Pretendard Font OFL License`
+- **Thin community `Community 295`** (1 nodes): `Pretendard Font OFL License`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 293`** (1 nodes): `구매 내역 색상 위계 리디자인 와이어프레임`
+- **Thin community `Community 296`** (1 nodes): `구매 내역 색상 위계 리디자인 와이어프레임`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 294`** (1 nodes): `My Tickets Test Plan`
+- **Thin community `Community 297`** (1 nodes): `My Tickets Test Plan`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 295`** (1 nodes): `Partner Detail Event Card Wireframe`
+- **Thin community `Community 298`** (1 nodes): `Partner Detail Event Card Wireframe`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 296`** (1 nodes): `MinglitEmptyState Variants Wireframe`
+- **Thin community `Community 299`** (1 nodes): `MinglitEmptyState Variants Wireframe`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 297`** (1 nodes): `파트너 정산 어드민 UI/UX 설계`
+- **Thin community `Community 300`** (1 nodes): `파트너 정산 어드민 UI/UX 설계`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 298`** (1 nodes): `Event Now Bar Technical Plan`
+- **Thin community `Community 301`** (1 nodes): `Event Now Bar Technical Plan`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 299`** (1 nodes): `Security Audit Report — Tag Discovery Phase 1`
+- **Thin community `Community 302`** (1 nodes): `Security Audit Report — Tag Discovery Phase 1`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 300`** (1 nodes): `Runtime QA Bug — app_partner DevUserSwitchScreen Non-functional + am force-stop Auto-login Failure`
+- **Thin community `Community 303`** (1 nodes): `Runtime QA Bug — app_partner DevUserSwitchScreen Non-functional + am force-stop Auto-login Failure`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 301`** (1 nodes): `Issue #1542: Login 페이지 다크 테마 일관성 (P3-low)`
+- **Thin community `Community 304`** (1 nodes): `Issue #1542: Login 페이지 다크 테마 일관성 (P3-low)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 302`** (1 nodes): `Bug Report — P-S31 /dev Deeplink 404`
+- **Thin community `Community 305`** (1 nodes): `Bug Report — P-S31 /dev Deeplink 404`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 303`** (1 nodes): `Runtime QA — CUJ-U03 Refund Button Label Mismatch`
+- **Thin community `Community 306`** (1 nodes): `Runtime QA — CUJ-U03 Refund Button Label Mismatch`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 304`** (1 nodes): `Runtime QA Bug — Build Server Disk Full (98%)`
+- **Thin community `Community 307`** (1 nodes): `Runtime QA Bug — Build Server Disk Full (98%)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 305`** (1 nodes): `Runtime QA Bug — Pixel 7a ADB Wireless Session Disconnect`
+- **Thin community `Community 308`** (1 nodes): `Runtime QA Bug — Pixel 7a ADB Wireless Session Disconnect`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 306`** (1 nodes): `Ops Alert #990 — Dependabot CI Actions Update (actions/checkout v4->v6)`
+- **Thin community `Community 309`** (1 nodes): `Ops Alert #990 — Dependabot CI Actions Update (actions/checkout v4->v6)`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 307`** (1 nodes): `App logo: purple gradient speech bubble with white 'm', orange sparkle accent`
+- **Thin community `Community 310`** (1 nodes): `App logo: purple gradient speech bubble with white 'm', orange sparkle accent`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 308`** (1 nodes): `App splash icon: purple gradient chat bubble with white 'm' and orange sparkle`
+- **Thin community `Community 311`** (1 nodes): `App splash icon: purple gradient chat bubble with white 'm' and orange sparkle`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 309`** (1 nodes): `Minglit app splash icon: purple chat bubble with white 'm' and orange sparkle`
+- **Thin community `Community 312`** (1 nodes): `Minglit app splash icon: purple chat bubble with white 'm' and orange sparkle`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 310`** (1 nodes): `App icon foreground: purple chat bubble with white 'm' and orange sparkle`
+- **Thin community `Community 313`** (1 nodes): `App icon foreground: purple chat bubble with white 'm' and orange sparkle`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 311`** (1 nodes): `Purple-blue gradient background image for app_partner icon`
+- **Thin community `Community 314`** (1 nodes): `Purple-blue gradient background image for app_partner icon`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 312`** (1 nodes): `Minglit inverted logo: white wordmark with cyan and orange shadow layers on transparent background`
+- **Thin community `Community 315`** (1 nodes): `Minglit inverted logo: white wordmark with cyan and orange shadow layers on transparent background`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 313`** (1 nodes): `Minglit wordmark logo SVG with transparent background, cyan/orange layered text`
+- **Thin community `Community 316`** (1 nodes): `Minglit wordmark logo SVG with transparent background, cyan/orange layered text`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 314`** (1 nodes): `Minglit app bar logo — bold italic 'Minglit' text in purple with cyan and orange shadow layers`
+- **Thin community `Community 317`** (1 nodes): `Minglit app bar logo — bold italic 'Minglit' text in purple with cyan and orange shadow layers`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 315`** (1 nodes): `Upscale lounge/restaurant interior with bar, green velvet chairs, Asian art, warm lighting`
+- **Thin community `Community 318`** (1 nodes): `Upscale lounge/restaurant interior with bar, green velvet chairs, Asian art, warm lighting`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 316`** (1 nodes): `Bright minimalist Korean cafe interior with numbered wooden tables, plants, string lights, and coffee bar`
+- **Thin community `Community 319`** (1 nodes): `Bright minimalist Korean cafe interior with numbered wooden tables, plants, string lights, and coffee bar`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 317`** (1 nodes): `Warm sunlit cafe interior with wood furniture, plants, string lights, and menu board`
+- **Thin community `Community 320`** (1 nodes): `Warm sunlit cafe interior with wood furniture, plants, string lights, and menu board`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 318`** (1 nodes): `Participation status redesign (after) — not-logged-in state with counts and login prompt`
+- **Thin community `Community 321`** (1 nodes): `Participation status redesign (after) — not-logged-in state with counts and login prompt`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 319`** (1 nodes): `Dark theme participation status redesign, 2-group male/female layout with progress bars`
+- **Thin community `Community 322`** (1 nodes): `Dark theme participation status redesign, 2-group male/female layout with progress bars`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 320`** (1 nodes): `Participation status redesign after-state with 4 groups showing 12/40 total and per-group cards`
+- **Thin community `Community 323`** (1 nodes): `Participation status redesign after-state with 4 groups showing 12/40 total and per-group cards`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 321`** (1 nodes): `Empty participation status UI: 0/20 total, 0/10 male/female, empty state message`
+- **Thin community `Community 324`** (1 nodes): `Empty participation status UI: 0/20 total, 0/10 male/female, empty state message`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 322`** (1 nodes): `Participation status redesign after variant: 2-group (male/female) split with progress bars`
+- **Thin community `Community 325`** (1 nodes): `Participation status redesign after variant: 2-group (male/female) split with progress bars`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 323`** (1 nodes): `Participation status redesign: 2-group (male/female) expanded view with counts and age breakdowns`
+- **Thin community `Community 326`** (1 nodes): `Participation status redesign: 2-group (male/female) expanded view with counts and age breakdowns`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 324`** (1 nodes): `Before state: participation status UI with male/female groups, 2/10 capacity each`
+- **Thin community `Community 327`** (1 nodes): `Before state: participation status UI with male/female groups, 2/10 capacity each`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 325`** (1 nodes): `user_profiles Table`
+- **Thin community `Community 328`** (1 nodes): `user_profiles Table`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -2453,12 +2468,12 @@ _Questions this graph is uniquely positioned to answer:_
   _Edge tagged AMBIGUOUS (relation: calls) - confidence is low._
 - **What is the exact relationship between `Architecture Audit #1092 — 2026-04-06` and `AI Basic Law Compliance (Korea 2026)`?**
   _Edge tagged AMBIGUOUS (relation: conceptually_related_to) - confidence is low._
-- **Why does `Text` connect `Community 27` to `Community 10`?**
-  _High betweenness centrality (0.199) - this node is a cross-community bridge._
-- **Why does `Log` connect `Community 27` to `Community 2`?**
-  _High betweenness centrality (0.198) - this node is a cross-community bridge._
+- **Why does `Log` connect `Community 14` to `Community 10`?**
+  _High betweenness centrality (0.179) - this node is a cross-community bridge._
+- **Why does `Text` connect `Community 14` to `Community 26`?**
+  _High betweenness centrality (0.178) - this node is a cross-community bridge._
 - **What connects `reporter (AutoLabelAllureReporter)`, `BugReporterWrapper Widget Test Suite`, `MinglitListTile Widget Test Suite` to the rest of the system?**
-  _1937 weakly-connected nodes found - possible documentation gaps or missing edges._
+  _2040 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.01 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**

--- a/supabase/functions/cleanup-retention/index.ts
+++ b/supabase/functions/cleanup-retention/index.ts
@@ -49,36 +49,41 @@ async function runStorageBucketCleanup(
   supabase: SupabaseClient,
   policy: RetentionPolicy,
 ): Promise<{ rows_deleted: number }> {
+  // Fix #2204: 옛 패턴 (supabase.storage.from(b).list(prefix)) 은 sub-directory 안 들여다 봄.
+  // 모든 파일이 sub-dir 에 있으면 stale=0 으로 잘못 판단. admin.find_stale_storage_objects()
+  // 가 storage.objects 직접 query 로 평면화된 모든 stale 파일 반환 → 재귀 무관.
   const { bucket_id, path_prefix = "" } = policy.target;
-  const cutoff = new Date(Date.now() - policy.retention_days * 86400 * 1000);
+  const REMOVE_BATCH = 100;  // Supabase storage remove API batch limit
+  const QUERY_BATCH = 10000;  // admin function 의 LIMIT
 
   let deleted = 0;
-  const BATCH = 1000;
 
-  // Always list from offset=0 to avoid skipping files shifted by prior deletes.
-  // Stop when no stale files found in a batch (oldest files are listed first).
   while (true) {
-    const { data: files, error: listError } = await supabase.storage
-      .from(bucket_id)
-      .list(path_prefix || undefined, {
-        limit: BATCH,
-        offset: 0,
-        sortBy: { column: "created_at", order: "asc" },
+    const { data: staleFiles, error: queryError } = await supabase
+      .schema("admin")
+      .rpc("find_stale_storage_objects", {
+        p_bucket_id: bucket_id,
+        p_path_prefix: path_prefix,
+        p_cutoff_days: policy.retention_days,
+        p_limit: QUERY_BATCH,
       });
-    if (listError) throw new Error(listError.message);
-    if (!files || files.length === 0) break;
+    if (queryError) throw new Error(queryError.message);
+    if (!staleFiles || staleFiles.length === 0) break;
 
-    const stale = files
-      .filter((f) => f.created_at && new Date(f.created_at) < cutoff)
-      .map((f) => (path_prefix ? `${path_prefix}/${f.name}` : f.name));
+    const names = (staleFiles as Array<{ name: string }>).map((f) => f.name);
 
-    if (stale.length === 0) break;
+    // Storage API batch 단위로 삭제 (한번에 너무 많이 보내면 timeout)
+    for (let i = 0; i < names.length; i += REMOVE_BATCH) {
+      const batch = names.slice(i, i + REMOVE_BATCH);
+      const { error: removeError } = await supabase.storage
+        .from(bucket_id)
+        .remove(batch);
+      if (removeError) throw new Error(removeError.message);
+      deleted += batch.length;
+    }
 
-    const { error: removeError } = await supabase.storage
-      .from(bucket_id)
-      .remove(stale);
-    if (removeError) throw new Error(removeError.message);
-    deleted += stale.length;
+    // 한 번에 QUERY_BATCH 미만 받으면 더 없는 거 — 종료
+    if (staleFiles.length < QUERY_BATCH) break;
   }
 
   return { rows_deleted: deleted };

--- a/supabase/functions/cleanup-retention/index_test.ts
+++ b/supabase/functions/cleanup-retention/index_test.ts
@@ -181,15 +181,12 @@ Deno.test({
 });
 
 Deno.test({
-  name: "cleanup-retention - storage_bucket cleanup stops when no stale files",
+  name: "cleanup-retention - storage_bucket deletes stale files in sub-directories (Fix #2204 regression guard)",
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
-    // All files are recent (created_at = now)
-    const recentFiles = [
-      { name: "recent1.png", created_at: new Date().toISOString() },
-      { name: "recent2.png", created_at: new Date().toISOString() },
-    ];
+    let removeCalled = false;
+    let removedNames: string[] = [];
 
     const { fetchMock } = createFetchMock([
       {
@@ -204,9 +201,75 @@ Deno.test({
             },
           ]),
       },
+      // Fix #2204: admin RPC 가 sub-directory 파일 포함 평면화된 list 반환
       {
-        matcher: "/storage/v1/object/list/bug-report-attachments",
-        handler: () => jsonResponse(recentFiles),
+        matcher: "/rest/v1/rpc/find_stale_storage_objects",
+        handler: () =>
+          jsonResponse([
+            { name: "screenshots/old1.png" },
+            { name: "screenshots/old2.png" },
+            { name: "layout-dumps/old1.json" },
+          ]),
+      },
+      // Storage remove API
+      {
+        matcher: "/storage/v1/object/bug-report-attachments",
+        handler: async (req) => {
+          removeCalled = true;
+          const body = await req.json();
+          removedNames = body.prefixes;
+          return jsonResponse([{ name: removedNames[0] }]);
+        },
+      },
+      {
+        matcher: POLICIES_URL,
+        handler: () => jsonResponse({}),
+      },
+      {
+        matcher: AUDIT_URL,
+        handler: () => jsonResponse({}),
+      },
+    ]);
+
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const response = await handler(postRequest());
+        assertEquals(response.status, 200);
+        const body = await readJson(response);
+        assertEquals(body.results[0].status, "success");
+        assertEquals(body.results[0].rows_deleted, 3);
+      });
+    });
+
+    assertEquals(removeCalled, true, "supabase.storage.remove must be called for stale files");
+    assertEquals(removedNames.length, 3);
+    assertEquals(removedNames[0].startsWith("screenshots/") || removedNames[0].startsWith("layout-dumps/"), true,
+      "removed names must include sub-directory paths (Fix #2204)");
+  },
+});
+
+Deno.test({
+  name: "cleanup-retention - storage_bucket returns 0 when no stale files (Fix #2204)",
+  fn: async () => {
+    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
+    const { fetchMock } = createFetchMock([
+      {
+        matcher: POLICIES_URL,
+        handler: () =>
+          jsonResponse([
+            {
+              id: "storage_bug_reports",
+              kind: "storage_bucket",
+              retention_days: 30,
+              target: { bucket_id: "bug-report-attachments", path_prefix: "" },
+            },
+          ]),
+      },
+      // Fix #2204: 새 패턴 — admin.find_stale_storage_objects RPC. 빈 array 반환
+      {
+        matcher: "/rest/v1/rpc/find_stale_storage_objects",
+        handler: () => jsonResponse([]),
       },
       {
         matcher: POLICIES_URL,

--- a/supabase/migrations/20260505000007_admin_find_stale_storage_objects_fn.sql
+++ b/supabase/migrations/20260505000007_admin_find_stale_storage_objects_fn.sql
@@ -1,0 +1,37 @@
+-- Fix #2204: storage_bucket retention cleanup 가 sub-directory 안 들여다 봐서 0 deleted.
+--
+-- 원인: cleanup-retention/index.ts 의 runStorageBucketCleanup 가 supabase.storage.from(b).list("")
+--      만 호출 → bucket 루트만 listing. 실제 파일은 sub-directory (screenshots/, layout-dumps/) 안.
+--      결과: bug-report-attachments bucket 에 57일 된 파일 있는데 0 deleted.
+--
+-- 수정: admin.find_stale_storage_objects() 함수 추가. storage.objects 테이블 직접 query (재귀 무관 — 모든
+--      파일이 한 row 로 평면화돼있음). created_at 기준 stale 파일 list 반환.
+--      EF 가 이 list 를 받아 supabase.storage.from(b).remove(names) 로 일괄 삭제.
+--
+-- Security: SECURITY DEFINER + REVOKE FROM PUBLIC + GRANT TO service_role — service_role 만 호출 가능.
+
+CREATE OR REPLACE FUNCTION admin.find_stale_storage_objects(
+  p_bucket_id    text,
+  p_path_prefix  text,
+  p_cutoff_days  int,
+  p_limit        int DEFAULT 10000
+)
+RETURNS TABLE (name text)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT o.name
+  FROM storage.objects o
+  WHERE o.bucket_id = p_bucket_id
+    AND o.created_at < now() - p_cutoff_days * interval '1 day'
+    AND (p_path_prefix = '' OR o.name LIKE p_path_prefix || '/%')
+  ORDER BY o.created_at ASC
+  LIMIT p_limit;
+$$;
+
+REVOKE ALL ON FUNCTION admin.find_stale_storage_objects(text, text, int, int) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION admin.find_stale_storage_objects(text, text, int, int) TO service_role;
+
+COMMENT ON FUNCTION admin.find_stale_storage_objects(text, text, int, int) IS
+  'Fix #2204: cleanup-retention storage_bucket 정책에서 사용. storage.objects 직접 query 로 sub-directory 포함 모든 stale 파일 반환. SECURITY DEFINER 라 RLS 우회 (service_role 전용).';


### PR DESCRIPTION
## Summary

cleanup-retention 의 `runStorageBucketCleanup` 가 supabase storage list API 가 재귀 listing 안 하는 점 간과 → bucket 루트만 listing → sub-dir (screenshots/, layout-dumps/) 안 파일 못 봄 → 0 deleted.

bug-report-attachments 501MB / 436 파일 (57일 누적) — 모두 sub-dir 안에 있어서 cleanup 못 받음.

Closes #2204

## Fix

- **Migration**: `admin.find_stale_storage_objects(bucket_id, path_prefix, cutoff_days, limit)` 함수 추가
  - `storage.objects` 직접 query (재귀 무관 — 모든 파일 한 row 평면화)
  - SECURITY DEFINER + service_role 전용
- **EF**: `runStorageBucketCleanup` 가 RPC 호출 → 평면 list 받아 storage.remove() 일괄 삭제
  - 10000개씩 query batch, 100개씩 remove batch
- **Test**: regression guard 추가 — sub-dir 파일 삭제 검증

## Test plan

- [x] deno test 16/16 통과
- [ ] 머지 후 deploy → cleanup-retention 수동 invoke
- [ ] bug-report-attachments 501MB → 30일 이내 데이터만 (~수십MB) 회수 확인
- [ ] retention_policies last_run_rows_deleted 가 ~400+ 으로 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)