### PR TITLE
feat(app_user): PurchaseHistoryDetailPage + EventApplicationReviewPage

### DIFF
--- a/apps/app_user/lib/main.g.dart
+++ b/apps/app_user/lib/main.g.dart
@@ -40,4 +40,4 @@ final class AppStartupProvider
   }
 }
 
-String _$appStartupHash() => r'20139d156771b14e48bc4b3e8bf79a9e61444cd1';
+String _$appStartupHash() => r'69ded5e4b59911a75b980f877e28d2d8f7ec1303';

--- a/apps/app_user/lib/src/features/event/admission/event_admission_controller.g.dart
+++ b/apps/app_user/lib/src/features/event/admission/event_admission_controller.g.dart
@@ -52,7 +52,7 @@ final class EventAdmissionControllerProvider
 }
 
 String _$eventAdmissionControllerHash() =>
-    r'6e7a7c160852751ce4d67bad0258ff8149851ff0';
+    r'685821193130b28844681aca4cb52af7a1a9e277';
 
 final class EventAdmissionControllerFamily extends $Family
     with

--- a/apps/app_user/lib/src/features/event/admission/event_application_controller.g.dart
+++ b/apps/app_user/lib/src/features/event/admission/event_application_controller.g.dart
@@ -61,7 +61,7 @@ final class EventApplicationControllerProvider
 }
 
 String _$eventApplicationControllerHash() =>
-    r'dfc366005e0cc61d8b0ee94ff2be2df9689d52b1';
+    r'7d763c161dede121cd5c60591fe509ac8594eafb';
 
 final class EventApplicationControllerFamily extends $Family
     with

--- a/apps/app_user/lib/src/features/event/matching/logic/commit_match_likes_controller.g.dart
+++ b/apps/app_user/lib/src/features/event/matching/logic/commit_match_likes_controller.g.dart
@@ -35,7 +35,7 @@ final class CommitMatchLikesControllerProvider
 }
 
 String _$commitMatchLikesControllerHash() =>
-    r'303aa4caf6cdfa6dca60377f8f4d06e6979f8194';
+    r'8666aded9cae3e8f97a6f3b7b665cfaaf95ebf0d';
 
 abstract class _$CommitMatchLikesController extends $AsyncNotifier<void> {
   FutureOr<void> build();

--- a/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.g.dart
+++ b/apps/app_user/lib/src/features/home/widgets/event_now_bar_controller.g.dart
@@ -31,6 +31,11 @@ final class ClockProvider
           DateTime Function()
         >
     with $Provider<DateTime Function()> {
+  /// Returns a clock function that produces the current [DateTime].
+  ///
+  /// The provider returns `() => DateTime.now()` so each call site gets a fresh
+  /// timestamp instead of a cached value. Override in tests with
+  /// `() => fixedNow` to make state transitions deterministic.
   const ClockProvider._()
     : super(
         from: null,
@@ -65,7 +70,7 @@ final class ClockProvider
   }
 }
 
-String _$clockHash() => r'clock_provider_fixed_time_injection';
+String _$clockHash() => r'3b571c5a0c08b7391c0eed04391003191bab6ccf';
 
 /// Fetches today's active events for the current user.
 ///
@@ -187,7 +192,7 @@ final class EventNowBarStateNotifierProvider
 }
 
 String _$eventNowBarStateNotifierHash() =>
-    r'182e06cee3fcad5002f20d2b59dcab8659ce4c09';
+    r'2d523ace9700f6f67018e4c9e6e86dfbfe32fa37';
 
 /// Computes the [EventNowBarState] for a given event.
 ///

--- a/apps/app_user/lib/src/features/payment/logic/purchase_history_controller.g.dart
+++ b/apps/app_user/lib/src/features/payment/logic/purchase_history_controller.g.dart
@@ -50,7 +50,7 @@ final class PurchaseHistoryControllerProvider
 }
 
 String _$purchaseHistoryControllerHash() =>
-    r'8ee98ad8d5a728fa61269fbb946e733ba84118ec';
+    r'45abf463fae796d8b63f6d96a484b9cd70ca71f8';
 
 /// **Purchase History Controller**
 ///

--- a/apps/app_user/lib/src/features/payment/logic/purchase_history_detail_controller.dart
+++ b/apps/app_user/lib/src/features/payment/logic/purchase_history_detail_controller.dart
@@ -1,0 +1,29 @@
+import 'package:app_user/src/features/payment/logic/purchase_history_controller.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'purchase_history_detail_controller.g.dart';
+
+/// Fetches a single application with full event+ticket data for the detail
+/// page. Tries the cached list first to avoid an extra round-trip when the
+/// user navigates from PurchaseHistoryPage.
+@riverpod
+Future<EventApplication?> purchaseHistoryDetail(
+  Ref ref,
+  String applicationId,
+) async {
+  // Prefer cached list so the detail screen opens instantly.
+  final cached = switch (ref.watch(purchaseHistoryControllerProvider)) {
+    AsyncData(:final value) => value,
+    _ => null,
+  };
+  if (cached != null) {
+    final found = cached
+        .where((EventApplication a) => a.id == applicationId)
+        .firstOrNull;
+    if (found != null) return found;
+  }
+
+  final repository = ref.watch(eventRepositoryProvider);
+  return repository.getPurchaseHistoryDetailById(applicationId);
+}

--- a/apps/app_user/lib/src/features/payment/logic/purchase_history_detail_controller.g.dart
+++ b/apps/app_user/lib/src/features/payment/logic/purchase_history_detail_controller.g.dart
@@ -1,0 +1,106 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'purchase_history_detail_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// Fetches a single application with full event+ticket data for the detail
+/// page. Tries the cached list first to avoid an extra round-trip when the
+/// user navigates from PurchaseHistoryPage.
+
+@ProviderFor(purchaseHistoryDetail)
+const purchaseHistoryDetailProvider = PurchaseHistoryDetailFamily._();
+
+/// Fetches a single application with full event+ticket data for the detail
+/// page. Tries the cached list first to avoid an extra round-trip when the
+/// user navigates from PurchaseHistoryPage.
+
+final class PurchaseHistoryDetailProvider
+    extends
+        $FunctionalProvider<
+          AsyncValue<EventApplication?>,
+          EventApplication?,
+          FutureOr<EventApplication?>
+        >
+    with
+        $FutureModifier<EventApplication?>,
+        $FutureProvider<EventApplication?> {
+  /// Fetches a single application with full event+ticket data for the detail
+  /// page. Tries the cached list first to avoid an extra round-trip when the
+  /// user navigates from PurchaseHistoryPage.
+  const PurchaseHistoryDetailProvider._({
+    required PurchaseHistoryDetailFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'purchaseHistoryDetailProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$purchaseHistoryDetailHash();
+
+  @override
+  String toString() {
+    return r'purchaseHistoryDetailProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $FutureProviderElement<EventApplication?> $createElement(
+    $ProviderPointer pointer,
+  ) => $FutureProviderElement(pointer);
+
+  @override
+  FutureOr<EventApplication?> create(Ref ref) {
+    final argument = this.argument as String;
+    return purchaseHistoryDetail(ref, argument);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is PurchaseHistoryDetailProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$purchaseHistoryDetailHash() =>
+    r'd38e0c544b2b47090b27201322362764e4e148af';
+
+/// Fetches a single application with full event+ticket data for the detail
+/// page. Tries the cached list first to avoid an extra round-trip when the
+/// user navigates from PurchaseHistoryPage.
+
+final class PurchaseHistoryDetailFamily extends $Family
+    with $FunctionalFamilyOverride<FutureOr<EventApplication?>, String> {
+  const PurchaseHistoryDetailFamily._()
+    : super(
+        retry: null,
+        name: r'purchaseHistoryDetailProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Fetches a single application with full event+ticket data for the detail
+  /// page. Tries the cached list first to avoid an extra round-trip when the
+  /// user navigates from PurchaseHistoryPage.
+
+  PurchaseHistoryDetailProvider call(String applicationId) =>
+      PurchaseHistoryDetailProvider._(argument: applicationId, from: this);
+
+  @override
+  String toString() => r'purchaseHistoryDetailProvider';
+}

--- a/apps/app_user/lib/src/features/payment/ui/event_application_review_page.dart
+++ b/apps/app_user/lib/src/features/payment/ui/event_application_review_page.dart
@@ -1,0 +1,393 @@
+import 'package:app_user/src/features/payment/logic/purchase_history_detail_controller.dart';
+import 'package:app_user/src/routing/app_routes.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+class EventApplicationReviewPage extends ConsumerWidget {
+  const EventApplicationReviewPage({required this.applicationId, super.key});
+
+  final String applicationId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final appAsync = ref.watch(purchaseHistoryDetailProvider(applicationId));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('심사 상태'),
+        centerTitle: false,
+      ),
+      body: MinglitAsyncValueWidget(
+        value: appAsync,
+        data: (application) {
+          if (application == null) {
+            return const Center(child: Text('신청 내역을 찾을 수 없습니다.'));
+          }
+          return _ReviewBody(application: application);
+        },
+      ),
+    );
+  }
+}
+
+class _ReviewBody extends StatelessWidget {
+  const _ReviewBody({required this.application});
+
+  final EventApplication application;
+
+  @override
+  Widget build(BuildContext context) {
+    final event = application.event;
+    final party = event?.party;
+    final eventName = event?.title ?? party?.title ?? '제목 없음';
+    final theme = Theme.of(context);
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 1. Hero card
+          _ReviewCard(
+            child: InkWell(
+              onTap: event != null
+                  ? () => EventDetailRoute(eventId: event.id).push<void>(context)
+                  : null,
+              borderRadius: BorderRadius.circular(MinglitRadius.card),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(MinglitRadius.small),
+                    child: SizedBox(
+                      width: 72,
+                      height: 72,
+                      child: MinglitImage(
+                        path: event?.imageUrl ?? '',
+                        fit: BoxFit.cover,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: MinglitSpacing.medium),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          eventName,
+                          style: theme.textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        if (event != null) ...[
+                          const SizedBox(height: MinglitSpacing.xxsmall),
+                          Text(
+                            DateFormat('M월 d일 (E)', 'ko_KR')
+                                .format(event.startTime),
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                  Icon(
+                    Icons.chevron_right,
+                    size: 18,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: MinglitSpacing.medium),
+
+          // 2. Timeline card
+          _ReviewCard(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '심사 타임라인',
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: MinglitSpacing.medium),
+                _ApplicationTimeline(application: application),
+              ],
+            ),
+          ),
+
+          // Reapply CTA
+          if (_canReapply(application.status)) ...[
+            const SizedBox(height: MinglitSpacing.medium),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: event != null
+                    ? () => EventDetailRoute(eventId: event.id).push<void>(context)
+                    : null,
+                icon: const Icon(Icons.refresh),
+                label: const Text('다시 신청하기'),
+              ),
+            ),
+          ],
+
+          const SizedBox(height: MinglitSpacing.medium),
+        ],
+      ),
+    );
+  }
+
+  bool _canReapply(String status) =>
+      status == 'rejected' || status == 'payment_failed';
+}
+
+class _ApplicationTimeline extends StatelessWidget {
+  const _ApplicationTimeline({required this.application});
+
+  final EventApplication application;
+
+  @override
+  Widget build(BuildContext context) {
+    final steps = _buildSteps();
+
+    return Column(
+      children: [
+        for (var i = 0; i < steps.length; i++) ...[
+          _TimelineStep(
+            step: steps[i],
+            isLast: i == steps.length - 1,
+          ),
+        ],
+      ],
+    );
+  }
+
+  List<_StepData> _buildSteps() {
+    final steps = <_StepData>[];
+
+    // Step 1: 신청
+    steps.add(
+      _StepData(
+        label: '신청',
+        subtitle: DateFormat('yyyy.MM.dd HH:mm').format(
+          application.createdAt.toLocal(),
+        ),
+        icon: Icons.edit_note,
+        state: _StepState.done,
+      ),
+    );
+
+    // Step 2: 결제
+    if (application.status == 'pending') {
+      steps.add(
+        _StepData(
+          label: '결제 대기 중',
+          subtitle: '결제가 완료되면 심사가 시작됩니다.',
+          icon: Icons.payment,
+          state: _StepState.active,
+        ),
+      );
+      return steps;
+    }
+    if (application.status == 'payment_failed') {
+      steps.add(
+        _StepData(
+          label: '결제 실패',
+          subtitle: '결제가 처리되지 않았습니다.',
+          icon: Icons.payment,
+          state: _StepState.failed,
+        ),
+      );
+      return steps;
+    }
+    steps.add(
+      _StepData(
+        label: '결제 완료',
+        subtitle: application.paidAt != null
+            ? DateFormat('yyyy.MM.dd HH:mm').format(
+                application.paidAt!.toLocal(),
+              )
+            : null,
+        icon: Icons.payment,
+        state: _StepState.done,
+      ),
+    );
+
+    // Step 3: 심사 진행 / 결과
+    switch (application.status) {
+      case 'pending_review':
+        steps.add(
+          _StepData(
+            label: '심사 진행 중',
+            subtitle: '파트너가 신청을 검토하고 있습니다.',
+            icon: Icons.hourglass_top,
+            state: _StepState.active,
+          ),
+        );
+      case 'approved':
+        steps.add(
+          _StepData(
+            label: '승인됨',
+            subtitle: application.rejectionReason,
+            icon: Icons.check_circle,
+            state: _StepState.done,
+          ),
+        );
+      case 'paid':
+        steps.add(
+          _StepData(
+            label: '예매 완료',
+            subtitle: '이벤트 당일 체크인하세요.',
+            icon: Icons.check_circle,
+            state: _StepState.done,
+          ),
+        );
+      case 'rejected':
+        steps.add(
+          _StepData(
+            label: '반려됨',
+            subtitle: application.rejectionReason,
+            icon: Icons.cancel,
+            state: _StepState.failed,
+          ),
+        );
+      case 'cancelled':
+        steps.add(
+          _StepData(
+            label: '취소됨',
+            subtitle: null,
+            icon: Icons.cancel,
+            state: _StepState.neutral,
+          ),
+        );
+    }
+
+    return steps;
+  }
+}
+
+enum _StepState { done, active, failed, neutral }
+
+class _StepData {
+  const _StepData({
+    required this.label,
+    required this.icon,
+    required this.state,
+    this.subtitle,
+  });
+
+  final String label;
+  final String? subtitle;
+  final IconData icon;
+  final _StepState state;
+}
+
+class _TimelineStep extends StatelessWidget {
+  const _TimelineStep({required this.step, required this.isLast});
+
+  final _StepData step;
+  final bool isLast;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    Color dotColor;
+    switch (step.state) {
+      case _StepState.done:
+        dotColor = theme.colorScheme.primary;
+      case _StepState.active:
+        dotColor = theme.colorScheme.tertiary;
+      case _StepState.failed:
+        dotColor = theme.colorScheme.error;
+      case _StepState.neutral:
+        dotColor = theme.colorScheme.onSurfaceVariant;
+    }
+
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 28,
+            child: Column(
+              children: [
+                Container(
+                  width: 28,
+                  height: 28,
+                  decoration: BoxDecoration(
+                    color: dotColor.withValues(alpha: 0.15),
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(step.icon, size: 16, color: dotColor),
+                ),
+                if (!isLast)
+                  Expanded(
+                    child: Container(
+                      width: 2,
+                      color: theme.colorScheme.outlineVariant,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          const SizedBox(width: MinglitSpacing.small),
+          Expanded(
+            child: Padding(
+              padding: EdgeInsets.only(
+                bottom: isLast ? 0 : MinglitSpacing.medium,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    step.label,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  if (step.subtitle != null && step.subtitle!.isNotEmpty) ...[
+                    const SizedBox(height: MinglitSpacing.xxsmall),
+                    Text(
+                      step.subtitle!,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ReviewCard extends StatelessWidget {
+  const _ReviewCard({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        borderRadius: BorderRadius.circular(MinglitRadius.card),
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+      ),
+      child: child,
+    );
+  }
+}

--- a/apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart
+++ b/apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart
@@ -28,7 +28,12 @@ class PurchaseHistoryCard extends ConsumerWidget {
 
     final canCancel = controller.canCancel(application);
 
-    return Container(
+    return InkWell(
+      onTap: () => PurchaseHistoryDetailRoute(
+        applicationId: application.id,
+      ).push<void>(context),
+      borderRadius: BorderRadius.circular(MinglitRadius.card),
+      child: Container(
       padding: const EdgeInsets.all(MinglitSpacing.medium),
       decoration: BoxDecoration(
         color: theme.colorScheme.surface,
@@ -240,6 +245,7 @@ class PurchaseHistoryCard extends ConsumerWidget {
           ),
         ],
       ),
+    ),
     );
   }
 

--- a/apps/app_user/lib/src/features/payment/ui/purchase_history_detail_page.dart
+++ b/apps/app_user/lib/src/features/payment/ui/purchase_history_detail_page.dart
@@ -1,0 +1,533 @@
+import 'package:app_user/src/common/widgets/status_badge.dart';
+import 'package:app_user/src/features/payment/logic/purchase_history_controller.dart';
+import 'package:app_user/src/features/payment/logic/purchase_history_detail_controller.dart';
+import 'package:app_user/src/routing/app_routes.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class PurchaseHistoryDetailPage extends ConsumerWidget {
+  const PurchaseHistoryDetailPage({required this.applicationId, super.key});
+
+  final String applicationId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final appAsync = ref.watch(purchaseHistoryDetailProvider(applicationId));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('구매 상세'),
+        centerTitle: false,
+      ),
+      body: MinglitAsyncValueWidget(
+        value: appAsync,
+        data: (application) {
+          if (application == null) {
+            return const Center(child: Text('구매 내역을 찾을 수 없습니다.'));
+          }
+          return _PurchaseDetailBody(application: application);
+        },
+      ),
+    );
+  }
+}
+
+class _PurchaseDetailBody extends ConsumerWidget {
+  const _PurchaseDetailBody({required this.application});
+
+  final EventApplication application;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = ref.read(purchaseHistoryControllerProvider.notifier);
+    final event = application.event;
+    final ticket = application.ticket;
+    final party = event?.party;
+    final location = event?.location ?? party?.location;
+    final eventName = event?.title ?? party?.title ?? '제목 없음';
+    final paymentId = application.paymentId;
+    final paymentAmount = application.paymentAmount ?? 0;
+    final canCancel = controller.canCancel(application);
+    final isRefunded = application.refundStatus == 'completed';
+    final theme = Theme.of(context);
+    final formatter = NumberFormat('#,###');
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 1. Hero card
+          _DetailCard(
+            child: InkWell(
+              onTap: event != null
+                  ? () => EventDetailRoute(eventId: event.id).push<void>(context)
+                  : null,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  AspectRatio(
+                    aspectRatio: 2,
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(MinglitRadius.small),
+                      child: MinglitImage(
+                        path: event?.imageUrl ?? '',
+                        fit: BoxFit.cover,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: MinglitSpacing.medium),
+                  Text(
+                    eventName,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  if (event != null) ...[
+                    const SizedBox(height: MinglitSpacing.xsmall),
+                    Row(
+                      children: [
+                        Icon(
+                          Icons.calendar_today_outlined,
+                          size: 14,
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                        const SizedBox(width: MinglitSpacing.xxsmall),
+                        Text(
+                          DateFormat('M월 d일 (E) HH:mm', 'ko_KR')
+                              .format(event.startTime),
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                  if (location != null) ...[
+                    const SizedBox(height: MinglitSpacing.xxsmall),
+                    Row(
+                      children: [
+                        Icon(
+                          Icons.location_on_outlined,
+                          size: 14,
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                        const SizedBox(width: MinglitSpacing.xxsmall),
+                        Expanded(
+                          child: Text(
+                            location.name,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: MinglitSpacing.medium),
+
+          // 2. Review status row (tappable → review timeline)
+          _DetailCard(
+            child: InkWell(
+              onTap: () => EventApplicationReviewRoute(
+                applicationId: applicationId,
+              ).push<void>(context),
+              borderRadius: BorderRadius.circular(MinglitRadius.card),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  vertical: MinglitSpacing.xsmall,
+                ),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '심사 상태',
+                            style: theme.textTheme.labelMedium?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                          const SizedBox(height: MinglitSpacing.xxsmall),
+                          Row(
+                            children: [
+                              StatusBadge(status: application.status),
+                              if (isRefunded) ...[
+                                const SizedBox(width: MinglitSpacing.xsmall),
+                                _RefundBadge(),
+                              ],
+                            ],
+                          ),
+                          const SizedBox(height: MinglitSpacing.xxsmall),
+                          Text(
+                            DateFormat('yyyy.MM.dd HH:mm').format(
+                              application.updatedAt.toLocal(),
+                            ),
+                            style: theme.textTheme.labelSmall?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Icon(
+                      Icons.chevron_right,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: MinglitSpacing.medium),
+
+          // 3. Payment info card
+          if (!isRefunded) ...[
+            _DetailCard(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '결제 정보',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: MinglitSpacing.medium),
+                  _KeyValueRow(
+                    label: '결제일',
+                    value: DateFormat('yyyy.MM.dd').format(
+                      (application.paidAt ?? application.createdAt).toLocal(),
+                    ),
+                  ),
+                  const SizedBox(height: MinglitSpacing.xsmall),
+                  _KeyValueRow(
+                    label: '티켓',
+                    value: ticket?.name ?? '티켓 정보 없음',
+                  ),
+                  const SizedBox(height: MinglitSpacing.xsmall),
+                  _KeyValueRow(
+                    label: '결제금액',
+                    value: '${formatter.format(paymentAmount)}원',
+                    isHighlight: true,
+                  ),
+                  if (paymentId != null || paymentAmount == 0) ...[
+                    const SizedBox(height: MinglitSpacing.medium),
+                    OutlinedButton.icon(
+                      onPressed: () async {
+                        if (paymentId != null && paymentId.isNotEmpty) {
+                          final url = Uri.parse(
+                            'https://service.iamport.kr/payments/detail/$paymentId',
+                          );
+                          final launched = await launchUrl(
+                            url,
+                            mode: LaunchMode.externalApplication,
+                          );
+                          if (!launched && context.mounted) {
+                            context.showMinglitWarning(
+                              '영수증 페이지를 열 수 없습니다.',
+                            );
+                          }
+                        } else {
+                          context.showMinglitInfo('무료 티켓 — 결제 영수증이 없습니다.');
+                        }
+                      },
+                      icon: const Icon(Icons.receipt_outlined, size: 18),
+                      label: const Text('영수증 보기'),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            const SizedBox(height: MinglitSpacing.medium),
+          ],
+
+          // Refund info card (shows instead of payment info when refunded)
+          if (isRefunded) ...[
+            _DetailCard(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '환불 정보',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: MinglitSpacing.medium),
+                  _KeyValueRow(
+                    label: '결제금액',
+                    value: '${formatter.format(paymentAmount)}원',
+                  ),
+                  const SizedBox(height: MinglitSpacing.xsmall),
+                  _KeyValueRow(
+                    label: '환불금액',
+                    value: '${formatter.format(paymentAmount)}원',
+                    isHighlight: true,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: MinglitSpacing.medium),
+          ],
+
+          // 4. Refund policy card with cancel button
+          if (!isRefunded) ...[
+            _DetailCard(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '취소 및 환불 정책',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: MinglitSpacing.small),
+                  Text(
+                    '이벤트 시작 전까지 취소 가능합니다. 환불 정책은 결제 시 안내된 내용을 따릅니다.',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  const SizedBox(height: MinglitSpacing.medium),
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: canCancel
+                          ? () => _runCancel(context, ref, event)
+                          : null,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: canCancel
+                            ? Theme.of(context).colorScheme.errorContainer
+                            : null,
+                        foregroundColor: canCancel
+                            ? Theme.of(context).colorScheme.onErrorContainer
+                            : null,
+                      ),
+                      child: const Text('예매 취소'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: MinglitSpacing.medium),
+          ],
+
+          // 5. Partner info card
+          if (party != null) ...[
+            _PartnerInfoCard(party: party),
+            const SizedBox(height: MinglitSpacing.medium),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String get applicationId => application.id;
+
+  Future<void> _runCancel(
+    BuildContext context,
+    WidgetRef ref,
+    Event? event,
+  ) async {
+    if (event == null) return;
+    final controller = ref.read(purchaseHistoryControllerProvider.notifier);
+    await controller.runRefundFlow(
+      eventId: event.id,
+      paymentId: application.paymentId,
+      paymentAmount: application.paymentAmount,
+      eventStartTime: event.startTime,
+      paidAt: application.paidAt,
+      showMissingInfo: () async {
+        if (context.mounted) context.showMinglitWarning('취소에 필요한 정보가 부족합니다.');
+      },
+      showNotEligible: () async {
+        if (context.mounted) context.showMinglitWarning('환불 기간이 지났습니다.');
+      },
+      confirmRefund: (calculation) async {
+        if (!context.mounted) return false;
+        return await showDialog<bool>(
+              context: context,
+              builder: (_) => AlertDialog(
+                title: const Text('예매 취소'),
+                content: Text(
+                  '${NumberFormat('#,###').format(calculation.refundAmount)}원이 환불됩니다. 취소하시겠습니까?',
+                ),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(context, false),
+                    child: const Text('아니오'),
+                  ),
+                  TextButton(
+                    onPressed: () => Navigator.pop(context, true),
+                    child: const Text('취소하기'),
+                  ),
+                ],
+              ),
+            ) ??
+            false;
+      },
+      showError: (message) async {
+        if (!context.mounted) return false;
+        await showDialog<void>(
+          context: context,
+          builder: (_) => AlertDialog(
+            title: const Text('취소 실패'),
+            content: Text(message),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: const Text('확인'),
+              ),
+            ],
+          ),
+        );
+        return false;
+      },
+      onSuccess: () async {
+        if (context.mounted) {
+          context.showMinglitSuccess('예매가 취소되었습니다.');
+          Navigator.pop(context);
+        }
+      },
+    );
+  }
+}
+
+class _PartnerInfoCard extends StatelessWidget {
+  const _PartnerInfoCard({required this.party});
+
+  final Party party;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return _DetailCard(
+      child: InkWell(
+        onTap: () => PartnerDetailRoute(partnerId: party.partnerId).push<void>(
+          context,
+        ),
+        borderRadius: BorderRadius.circular(MinglitRadius.card),
+        child: Row(
+          children: [
+            CircleAvatar(
+              radius: 24,
+              backgroundColor: theme.colorScheme.surfaceContainerHighest,
+              backgroundImage: party.imageUrl != null
+                  ? NetworkImage(party.imageUrl!)
+                  : null,
+              child: party.imageUrl == null
+                  ? Icon(Icons.store, color: theme.colorScheme.onSurfaceVariant)
+                  : null,
+            ),
+            const SizedBox(width: MinglitSpacing.medium),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    party.title,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Icon(Icons.chevron_right, color: theme.colorScheme.onSurfaceVariant),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DetailCard extends StatelessWidget {
+  const _DetailCard({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        borderRadius: BorderRadius.circular(MinglitRadius.card),
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+      ),
+      child: child,
+    );
+  }
+}
+
+class _KeyValueRow extends StatelessWidget {
+  const _KeyValueRow({
+    required this.label,
+    required this.value,
+    this.isHighlight = false,
+  });
+
+  final String label;
+  final String value;
+  final bool isHighlight;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        Text(
+          value,
+          style: isHighlight
+              ? theme.textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                )
+              : theme.textTheme.bodyMedium,
+        ),
+      ],
+    );
+  }
+}
+
+class _RefundBadge extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: MinglitSpacing.xsmall,
+        vertical: MinglitSpacing.xxsmall,
+      ),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(MinglitRadius.chip),
+      ),
+      child: Text(
+        '환불완료',
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onErrorContainer,
+        ),
+      ),
+    );
+  }
+}

--- a/apps/app_user/lib/src/features/payment/ui/purchase_history_page.dart
+++ b/apps/app_user/lib/src/features/payment/ui/purchase_history_page.dart
@@ -1,5 +1,6 @@
 import 'package:app_user/src/common/widgets/status_badge.dart';
 import 'package:app_user/src/features/payment/logic/purchase_history_controller.dart';
+import 'package:app_user/src/routing/app_routes.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:minglit_kit/minglit_kit.dart';

--- a/apps/app_user/lib/src/logic/feed_state_provider.g.dart
+++ b/apps/app_user/lib/src/logic/feed_state_provider.g.dart
@@ -93,7 +93,7 @@ final class ActiveFiltersProvider
   }
 }
 
-String _$activeFiltersHash() => r'1993d5e37e4b5d2a9f5cd1926fe7898bf17c757f';
+String _$activeFiltersHash() => r'b87e6e1f1f91c04b6190cc1bf4e570f29b6d14b6';
 
 abstract class _$ActiveFilters extends $Notifier<ExploreFilters> {
   ExploreFilters build();
@@ -190,7 +190,7 @@ final class SearchResultsProvider
   }
 }
 
-String _$searchResultsHash() => r'1e0ac41dea7e827a16504833246fcec7a0728f68';
+String _$searchResultsHash() => r'f736aef74b0ebf915c7fa0a4d6c33af7cb13b459';
 
 /// Fetches bulk eligibility data (user profile + verified status).
 
@@ -440,8 +440,8 @@ abstract class _$RecommendationFeedNotifier
 /// - closingSoon → closingSoon
 /// - nearestDate → nearest
 ///
-// TODO: migrate to [recommendationEventsFromEf] once the user-event-feed EF
-// is validated in production.
+// TODO(#1891): migrate to [recommendationEventsFromEf] once the user-event-feed
+// EF is validated in production.
 
 @ProviderFor(recommendationEvents)
 const recommendationEventsProvider = RecommendationEventsProvider._();
@@ -453,8 +453,8 @@ const recommendationEventsProvider = RecommendationEventsProvider._();
 /// - closingSoon → closingSoon
 /// - nearestDate → nearest
 ///
-// TODO: migrate to [recommendationEventsFromEf] once the user-event-feed EF
-// is validated in production.
+// TODO(#1891): migrate to [recommendationEventsFromEf] once the user-event-feed
+// EF is validated in production.
 
 final class RecommendationEventsProvider
     extends
@@ -471,8 +471,8 @@ final class RecommendationEventsProvider
   /// - closingSoon → closingSoon
   /// - nearestDate → nearest
   ///
-  // TODO: migrate to [recommendationEventsFromEf] once the user-event-feed EF
-  // is validated in production.
+  // TODO(#1891): migrate to [recommendationEventsFromEf] once the user-event-feed
+  // EF is validated in production.
   const RecommendationEventsProvider._()
     : super(
         from: null,
@@ -508,8 +508,8 @@ String _$recommendationEventsHash() =>
 /// and cursor pagination are handled by the DB function, so no
 /// client-side post-processing is needed.
 ///
-// TODO: wire this into the explore UI behind a feature flag, then remove the
-// legacy [recommendationEvents] path.
+// TODO(#1891): wire this into the explore UI behind a feature flag, then
+// remove the legacy [recommendationEvents] path.
 
 @ProviderFor(recommendationEventsFromEf)
 const recommendationEventsFromEfProvider =
@@ -521,8 +521,8 @@ const recommendationEventsFromEfProvider =
 /// and cursor pagination are handled by the DB function, so no
 /// client-side post-processing is needed.
 ///
-// TODO: wire this into the explore UI behind a feature flag, then remove the
-// legacy [recommendationEvents] path.
+// TODO(#1891): wire this into the explore UI behind a feature flag, then
+// remove the legacy [recommendationEvents] path.
 
 final class RecommendationEventsFromEfProvider
     extends
@@ -540,8 +540,8 @@ final class RecommendationEventsFromEfProvider
   /// and cursor pagination are handled by the DB function, so no
   /// client-side post-processing is needed.
   ///
-  // TODO: wire this into the explore UI behind a feature flag, then remove the
-  // legacy [recommendationEvents] path.
+  // TODO(#1891): wire this into the explore UI behind a feature flag, then
+  // remove the legacy [recommendationEvents] path.
   const RecommendationEventsFromEfProvider._()
     : super(
         from: null,

--- a/apps/app_user/lib/src/routing/app_router.g.dart
+++ b/apps/app_user/lib/src/routing/app_router.g.dart
@@ -48,4 +48,4 @@ final class GoRouterProvider
   }
 }
 
-String _$goRouterHash() => r'8db8469bad2f3983a3373a47afe3546e36e04847';
+String _$goRouterHash() => r'37880c82783df89a0b2fbda0dc021ecd7f92cb84';

--- a/apps/app_user/lib/src/routing/app_routes.dart
+++ b/apps/app_user/lib/src/routing/app_routes.dart
@@ -17,6 +17,8 @@ import 'package:app_user/src/features/home/my_page.dart';
 import 'package:app_user/src/features/my_tickets/ui/my_tickets_page.dart';
 import 'package:app_user/src/features/partner/detail/partner_detail_page.dart';
 import 'package:app_user/src/features/partner/detail/partner_events_page.dart';
+import 'package:app_user/src/features/payment/ui/event_application_review_page.dart';
+import 'package:app_user/src/features/payment/ui/purchase_history_detail_page.dart';
 import 'package:app_user/src/features/payment/ui/purchase_history_page.dart';
 import 'package:app_user/src/features/search/search_page.dart';
 import 'package:app_user/src/features/settings/blocked_partners_page.dart';
@@ -260,6 +262,38 @@ class PurchaseHistoryRoute extends GoRouteData with $PurchaseHistoryRoute {
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       const PurchaseHistoryPage();
+}
+
+/// **Purchase History Detail Route**
+/// Path: `/purchase-history/:applicationId`
+@TypedGoRoute<PurchaseHistoryDetailRoute>(
+  path: '/purchase-history/:applicationId',
+)
+class PurchaseHistoryDetailRoute extends GoRouteData
+    with $PurchaseHistoryDetailRoute {
+  const PurchaseHistoryDetailRoute({required this.applicationId});
+
+  final String applicationId;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      PurchaseHistoryDetailPage(applicationId: applicationId);
+}
+
+/// **Event Application Review Route**
+/// Path: `/purchase-history/:applicationId/review`
+@TypedGoRoute<EventApplicationReviewRoute>(
+  path: '/purchase-history/:applicationId/review',
+)
+class EventApplicationReviewRoute extends GoRouteData
+    with $EventApplicationReviewRoute {
+  const EventApplicationReviewRoute({required this.applicationId});
+
+  final String applicationId;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      EventApplicationReviewPage(applicationId: applicationId);
 }
 
 /// **Notification Center Route**

--- a/apps/app_user/lib/src/routing/app_routes.g.dart
+++ b/apps/app_user/lib/src/routing/app_routes.g.dart
@@ -22,6 +22,8 @@ List<RouteBase> get $appRoutes => [
   $myTicketsRoute,
   $ticketQRRoute,
   $purchaseHistoryRoute,
+  $purchaseHistoryDetailRoute,
+  $eventApplicationReviewRoute,
   $notificationCenterRoute,
   $notificationSettingsRoute,
   $accountManagementRoute,
@@ -462,6 +464,70 @@ mixin $PurchaseHistoryRoute on GoRouteData {
 
   @override
   String get location => GoRouteData.$location('/purchase-history');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $purchaseHistoryDetailRoute => GoRouteData.$route(
+  path: '/purchase-history/:applicationId',
+  factory: $PurchaseHistoryDetailRoute._fromState,
+);
+
+mixin $PurchaseHistoryDetailRoute on GoRouteData {
+  static PurchaseHistoryDetailRoute _fromState(GoRouterState state) =>
+      PurchaseHistoryDetailRoute(
+        applicationId: state.pathParameters['applicationId']!,
+      );
+
+  PurchaseHistoryDetailRoute get _self => this as PurchaseHistoryDetailRoute;
+
+  @override
+  String get location => GoRouteData.$location(
+    '/purchase-history/${Uri.encodeComponent(_self.applicationId)}',
+  );
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+RouteBase get $eventApplicationReviewRoute => GoRouteData.$route(
+  path: '/purchase-history/:applicationId/review',
+  factory: $EventApplicationReviewRoute._fromState,
+);
+
+mixin $EventApplicationReviewRoute on GoRouteData {
+  static EventApplicationReviewRoute _fromState(GoRouterState state) =>
+      EventApplicationReviewRoute(
+        applicationId: state.pathParameters['applicationId']!,
+      );
+
+  EventApplicationReviewRoute get _self => this as EventApplicationReviewRoute;
+
+  @override
+  String get location => GoRouteData.$location(
+    '/purchase-history/${Uri.encodeComponent(_self.applicationId)}/review',
+  );
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/apps/app_user/test/src/features/payment/ui/event_application_review_page_test.dart
+++ b/apps/app_user/test/src/features/payment/ui/event_application_review_page_test.dart
@@ -1,0 +1,122 @@
+import 'package:app_user/src/features/payment/logic/purchase_history_detail_controller.dart';
+import 'package:app_user/src/features/payment/ui/event_application_review_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../utils/mocks.dart';
+
+void main() {
+  setUpAll(() async {
+    await initializeDateFormatting('ko_KR');
+  });
+
+  late MockEventRepository mockEventRepository;
+  late MockUser mockUser;
+
+  final baseEvent = Event(
+    id: 'event1',
+    partyId: 'party1',
+    startTime: DateTime(2026, 6, 1, 19),
+    endTime: DateTime(2026, 6, 1, 21),
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+    title: 'Review Event',
+  );
+
+  setUp(() {
+    mockEventRepository = MockEventRepository();
+    mockUser = MockUser();
+    when(() => mockUser.id).thenReturn('user1');
+  });
+
+  Widget createTestWidget(EventApplication application) {
+    return ProviderScope(
+      overrides: [
+        eventRepositoryProvider.overrideWithValue(mockEventRepository),
+        purchaseHistoryDetailProvider('app1').overrideWith(
+          (ref) async => application,
+        ),
+      ],
+      child: const MaterialApp(
+        home: EventApplicationReviewPage(applicationId: 'app1'),
+      ),
+    );
+  }
+
+  EventApplication makeApp(String status) => EventApplication(
+        id: 'app1',
+        eventId: 'event1',
+        ticketId: 'ticket1',
+        userId: 'user1',
+        status: status,
+        createdAt: DateTime(2026, 5, 1),
+        updatedAt: DateTime(2026, 5, 1),
+        event: baseEvent,
+      );
+
+  group('EventApplicationReviewPage — #2095', () {
+    testWidgets('shows timeline for paid status', (tester) async {
+      await tester.pumpWidget(createTestWidget(makeApp('paid')));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('심사 타임라인'), findsOneWidget);
+      expect(find.text('예매 완료'), findsOneWidget);
+      expect(find.text('다시 신청하기'), findsNothing);
+    });
+
+    testWidgets('shows 다시 신청하기 when rejected', (tester) async {
+      await tester.pumpWidget(createTestWidget(makeApp('rejected')));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('반려됨'), findsOneWidget);
+      expect(find.text('다시 신청하기'), findsOneWidget);
+    });
+
+    testWidgets('shows 다시 신청하기 when payment_failed', (tester) async {
+      await tester.pumpWidget(createTestWidget(makeApp('payment_failed')));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('결제 실패'), findsOneWidget);
+      expect(find.text('다시 신청하기'), findsOneWidget);
+    });
+
+    testWidgets('shows pending_review state with hourglass step', (
+      tester,
+    ) async {
+      await tester.pumpWidget(createTestWidget(makeApp('pending_review')));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('심사 진행 중'), findsOneWidget);
+      expect(find.text('다시 신청하기'), findsNothing);
+    });
+
+    testWidgets('shows null state message when application is null', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            eventRepositoryProvider.overrideWithValue(mockEventRepository),
+            purchaseHistoryDetailProvider('app1').overrideWith(
+              (ref) async => null,
+            ),
+          ],
+          child: const MaterialApp(
+            home: EventApplicationReviewPage(applicationId: 'app1'),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('신청 내역을 찾을 수 없습니다.'), findsOneWidget);
+    });
+  });
+}

--- a/apps/app_user/test/src/features/payment/ui/purchase_history_detail_page_test.dart
+++ b/apps/app_user/test/src/features/payment/ui/purchase_history_detail_page_test.dart
@@ -1,0 +1,151 @@
+import 'package:app_user/src/features/payment/logic/purchase_history_controller.dart';
+import 'package:app_user/src/features/payment/logic/purchase_history_detail_controller.dart';
+import 'package:app_user/src/features/payment/ui/purchase_history_detail_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../utils/mocks.dart';
+
+void main() {
+  setUpAll(() async {
+    await initializeDateFormatting('ko_KR');
+  });
+
+  late MockEventRepository mockEventRepository;
+  late MockUser mockUser;
+
+  final baseEvent = Event(
+    id: 'event1',
+    partyId: 'party1',
+    startTime: DateTime(2026, 6, 1, 19),
+    endTime: DateTime(2026, 6, 1, 21),
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+    title: 'Test Event',
+  );
+
+  final baseApplication = EventApplication(
+    id: 'app1',
+    eventId: 'event1',
+    ticketId: 'ticket1',
+    userId: 'user1',
+    status: 'paid',
+    paymentAmount: 50000,
+    paymentId: 'imp_test123',
+    createdAt: DateTime(2026, 5, 1),
+    updatedAt: DateTime(2026, 5, 1),
+    paidAt: DateTime(2026, 5, 1),
+    event: baseEvent,
+    ticket: Ticket(
+      id: 'ticket1',
+      name: 'General',
+      createdAt: DateTime(2026, 1, 1),
+      updatedAt: DateTime(2026, 1, 1),
+    ),
+  );
+
+  setUp(() {
+    mockEventRepository = MockEventRepository();
+    mockUser = MockUser();
+    when(() => mockUser.id).thenReturn('user1');
+  });
+
+  Widget createTestWidget(EventApplication application) {
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((ref) => mockUser),
+        eventRepositoryProvider.overrideWithValue(mockEventRepository),
+        purchaseHistoryControllerProvider.overrideWith(
+          () => PurchaseHistoryController(),
+        ),
+        purchaseHistoryDetailProvider('app1').overrideWith(
+          (ref) async => application,
+        ),
+      ],
+      child: const MaterialApp(
+        home: PurchaseHistoryDetailPage(applicationId: 'app1'),
+      ),
+    );
+  }
+
+  group('PurchaseHistoryDetailPage — #2095', () {
+    testWidgets('shows event title and payment info', (tester) async {
+      await tester.pumpWidget(createTestWidget(baseApplication));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('Test Event'), findsOneWidget);
+      expect(find.text('50,000원'), findsOneWidget);
+      expect(find.text('General'), findsOneWidget);
+    });
+
+    testWidgets('shows refund info card when refund completed', (tester) async {
+      final refundedApp = baseApplication.copyWith(
+        refundStatus: 'completed',
+      );
+      await tester.pumpWidget(createTestWidget(refundedApp));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('환불 정보'), findsOneWidget);
+      expect(find.text('결제 정보'), findsNothing);
+    });
+
+    testWidgets('shows payment info card when not refunded', (tester) async {
+      await tester.pumpWidget(createTestWidget(baseApplication));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('결제 정보'), findsOneWidget);
+      expect(find.text('환불 정보'), findsNothing);
+    });
+
+    testWidgets('cancel button is disabled when canCancel is false', (
+      tester,
+    ) async {
+      final pastApp = baseApplication.copyWith(
+        event: baseEvent.copyWith(
+          startTime: DateTime(2020, 1, 1),
+          endTime: DateTime(2020, 1, 1, 2),
+        ),
+      );
+      await tester.pumpWidget(createTestWidget(pastApp));
+      await tester.pump();
+      await tester.pump();
+
+      final cancelBtn = find.widgetWithText(ElevatedButton, '예매 취소');
+      expect(cancelBtn, findsOneWidget);
+      final btn = tester.widget<ElevatedButton>(cancelBtn);
+      expect(btn.onPressed, isNull);
+    });
+
+    testWidgets('shows null state message when application is null', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            currentUserProvider.overrideWith((ref) => mockUser),
+            eventRepositoryProvider.overrideWithValue(mockEventRepository),
+            purchaseHistoryControllerProvider.overrideWith(
+              () => PurchaseHistoryController(),
+            ),
+            purchaseHistoryDetailProvider('app1').overrideWith(
+              (ref) async => null,
+            ),
+          ],
+          child: const MaterialApp(
+            home: PurchaseHistoryDetailPage(applicationId: 'app1'),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('구매 내역을 찾을 수 없습니다.'), findsOneWidget);
+    });
+  });
+}

--- a/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_application_queries.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_application_queries.dart
@@ -92,6 +92,30 @@ mixin _EventRepositoryApplicationQueries on _SupabaseEventContext {
     }
   }
 
+  /// Fetches a single application with full event, ticket, and submission data
+  /// for the purchase history detail page.
+  Future<EventApplication?> getPurchaseHistoryDetailById(
+    String applicationId,
+  ) async {
+    Log.d('getPurchaseHistoryDetailById called | id: $applicationId');
+    try {
+      final response = await supabaseClient
+          .from('event_applications')
+          .select(
+            '*, '
+            'event:events(*, party:parties(*, location:locations(*))), '
+            'ticket:tickets(*)',
+          )
+          .eq('id', applicationId)
+          .maybeSingle();
+      if (response == null) return null;
+      return EventApplication.fromJson(response);
+    } catch (e, st) {
+      Log.e('❌ [EventRepo] getPurchaseHistoryDetailById Error', e, st);
+      rethrow;
+    }
+  }
+
   /// Fetches the application record for a specific user and event.
   Future<EventApplication?> getApplication({
     required String eventId,


### PR DESCRIPTION
## Summary

- `PurchaseHistoryDetailPage`: 5-section detail view (hero card → review status → payment info → refund policy/cancel → partner info)
- `EventApplicationReviewPage`: step-by-step timeline showing application lifecycle (신청 → 결제 → 심사) with 다시 신청하기 CTA for rejected/payment_failed states
- `purchaseHistoryDetailProvider`: cache-first (avoids extra round-trip when navigating from list), falls back to `getPurchaseHistoryDetailById` query
- `PurchaseHistoryCard` wrapped in `InkWell` → taps navigate to detail page
- 10 new widget tests covering key render paths and null states

## Test plan
- [x] `flutter analyze` — 0 errors, 0 warnings in lib/src
- [x] 10 widget tests pass (`purchase_history_detail_page_test.dart`, `event_application_review_page_test.dart`)
- [ ] CI `test-flutter-apps` passes

Closes #2095

🤖 Generated with [Claude Code](https://claude.com/claude-code)