### PR TITLE
fix(seed): qa_fresh 이메일 qa_fresh@test.com으로 수정 (Fix #2279)

### DIFF
--- a/supabase/seed.dev.sql
+++ b/supabase/seed.dev.sql
@@ -757,7 +757,13 @@ DECLARE
 BEGIN
   pwd_hash := extensions.crypt('password1234!', extensions.gen_salt('bf'));
 
-  SELECT id INTO existing_id FROM auth.users WHERE email = 'user_qa_fresh@test.com';
+  -- Fix #2279: email must match username@test.com pattern (DevUserSwitch constructs email as '$username@test.com')
+  -- username=qa_fresh → email must be qa_fresh@test.com, not user_qa_fresh@test.com
+  SELECT id INTO existing_id FROM auth.users WHERE email = 'qa_fresh@test.com';
+  IF NOT FOUND THEN
+    -- backfill: also check old incorrect email and delete it so re-seed is idempotent
+    DELETE FROM auth.users WHERE email = 'user_qa_fresh@test.com';
+  END IF;
   IF existing_id IS NULL THEN
     -- Fix #2256: add qa_fresh user with empty application history for U-S19 smoke test
     INSERT INTO auth.users (
@@ -771,7 +777,7 @@ BEGIN
     ) VALUES (
       '00000000-0000-0000-0000-000000000000',
       gen_random_uuid(), 'authenticated', 'authenticated',
-      'user_qa_fresh@test.com', pwd_hash, now(),
+      'qa_fresh@test.com', pwd_hash, now(),
       '{"provider":"email","providers":["email"],"has_password":true}'::jsonb,
       '{"name":"[QA] 신청 테스트 유저","username":"qa_fresh","gender":"female","birth_date":"2000-01-01","phone_number":"010-0099-0000","is_verified":true}'::jsonb,
       now(), now(), '', '',


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Root Cause

`DevUserSwitchScreen`(line 136)에서 이메일을 `$username@test.com` 패턴으로 구성합니다.  
username=`qa_fresh` → 로그인 시도 이메일: `qa_fresh@test.com`

그러나 `supabase/seed.dev.sql`에는 `user_qa_fresh@test.com`으로 등록되어 있어 매번 `invalid_credentials` 발생.

## Fix

seed.dev.sql에서 auth email: `user_qa_fresh@test.com` → `qa_fresh@test.com`

- 구 이메일(`user_qa_fresh@test.com`) 있으면 삭제 후 신규 삽입 (re-seed idempotency 유지)
- username, password, 프로필은 그대로 유지

## Constraint

`DevUserSwitchScreen:136`의 이메일 구성 패턴: `'$username@test.com'` — seed auth email은 반드시 이 패턴을 따라야 함.

Closes #2279