### PR TITLE
fix(app_partner): VerificationManagePage — route via coordinator not context.push (#2281)

### DIFF
--- a/apps/app_partner/lib/src/features/verification/manage/verification_manage_page.dart
+++ b/apps/app_partner/lib/src/features/verification/manage/verification_manage_page.dart
@@ -1,5 +1,5 @@
 import 'package:app_partner/src/features/verification/manage/verification_manage_controller.dart';
-import 'package:app_partner/src/routing/app_routes.dart';
+import 'package:app_partner/src/features/verification/verification_coordinator.dart';
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
@@ -41,6 +41,11 @@ class VerificationManagePage extends ConsumerWidget {
               // 1. Active List
               _ActiveList(
                 verifications: state.active,
+                // Fix #2281: use coordinator (goRouterProvider) instead of context.push,
+                // which fails silently inside StatefulShellRoute branch navigators
+                onCreate: () => ref
+                    .read(verificationCoordinatorProvider.notifier)
+                    .pushCreateVerification(),
                 onArchive: (id) => _confirmArchive(context, ref, id),
               ),
               // 2. Archived List
@@ -100,9 +105,14 @@ class VerificationManagePage extends ConsumerWidget {
 }
 
 class _ActiveList extends StatelessWidget {
-  const _ActiveList({required this.verifications, required this.onArchive});
+  const _ActiveList({
+    required this.verifications,
+    required this.onCreate,
+    required this.onArchive,
+  });
 
   final List<Verification> verifications;
+  final VoidCallback onCreate;
   final void Function(Verification) onArchive;
 
   @override
@@ -115,7 +125,9 @@ class _ActiveList extends StatelessWidget {
           AddActionCard(
             title: '새로운 인증 만들기',
             subtitle: '우리 가게만의 특별한 입장 조건을 만들어보세요.',
-            onTap: () => const CreateVerificationRoute().push<void>(context),
+            // Fix #2281: use onCreate (coordinator-based) instead of context.push,
+            // which fails silently inside StatefulShellRoute branch navigators
+            onTap: onCreate,
           ),
           const SizedBox(height: MinglitSpacing.medium),
           if (verifications.isEmpty)

--- a/apps/app_partner/test/src/features/verification/verification_manage_page_test.dart
+++ b/apps/app_partner/test/src/features/verification/verification_manage_page_test.dart
@@ -1,0 +1,65 @@
+import 'package:app_partner/src/features/verification/manage/verification_manage_controller.dart';
+import 'package:app_partner/src/features/verification/manage/verification_manage_page.dart';
+import 'package:app_partner/src/routing/app_router.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../utils/mocks.dart';
+
+void main() {
+  late MockGoRouter mockRouter;
+
+  setUp(() {
+    mockRouter = MockGoRouter();
+    when(() => mockRouter.push(any())).thenAnswer((_) async => null);
+  });
+
+  Widget buildSubject({
+    VerificationManageState state = const VerificationManageState(),
+  }) {
+    return ProviderScope(
+      overrides: [
+        verificationManageControllerProvider.overrideWith(
+          () => _StubVerificationManageController(state),
+        ),
+        goRouterProvider.overrideWithValue(mockRouter),
+      ],
+      child: MaterialApp(
+        theme: MinglitTheme.materialTheme,
+        home: const VerificationManagePage(),
+      ),
+    );
+  }
+
+  // Fix #2281: regression test — "새로운 인증 만들기" must navigate via goRouterProvider,
+  // not context.push, which fails silently in StatefulShellRoute branch navigators.
+  testWidgets(
+    '새로운 인증 만들기 tap navigates via goRouter (not context.push)',
+    (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('새로운 인증 만들기'));
+      await tester.pump();
+
+      verify(() => mockRouter.push(any())).called(1);
+    },
+  );
+}
+
+class _StubVerificationManageController extends VerificationManageController {
+  _StubVerificationManageController(this._state);
+
+  final VerificationManageState _state;
+
+  @override
+  Future<VerificationManageState> build() async => _state;
+
+  @override
+  Future<void> archiveVerification(String id) async {}
+
+  @override
+  Future<void> restoreVerification(String id) async {}
+}


### PR DESCRIPTION
## Summary

- `VerificationManagePage`의 "새로운 인증 만들기" `AddActionCard`가 `context.push()` 를 직접 호출하고 있었음
- `StatefulShellRoute` branch navigator 내부에서 `context.push()` 는 루트 `GoRouter` 대신 branch navigator context를 사용하여 **silently 실패** (Fix #1834과 동일한 버그 클래스)
- `_ActiveList`에 `onCreate: VoidCallback` 파라미터를 추가하고, `VerificationManagePage`에서 `VerificationCoordinator.pushCreateVerification()` (→ `ref.read(goRouterProvider).push()`) 로 연결
- 회귀 방지 위젯 테스트 추가: `goRouterProvider`를 mock하여 tap 시 `router.push()` 가 실제로 호출됨을 검증

## Test plan

- [x] `flutter test apps/app_partner/test/src/features/verification/verification_manage_page_test.dart` 통과
- [x] "새로운 인증 만들기" 탭 → `CreateVerificationRoute` 로 정상 이동 확인

Closes #2281

🤖 Generated with [Claude Code](https://claude.com/claude-code)