### PR TITLE
feat(edge-functions): migrate batch-1 EFs to minglitEdgeFunction wrapper

### DIFF
--- a/supabase/functions/auth-manifest.json
+++ b/supabase/functions/auth-manifest.json
@@ -16,6 +16,36 @@
       "callers": ["user"],
       "envs": ["dev", "production"],
       "description": "파트너 일괄 심사 — approve + reject 단일 트랜잭션 처리 (issue #2101)"
+    },
+    "cleanup-blocked-dis": {
+      "callers": ["system"],
+      "envs": ["dev", "production"],
+      "description": "만료된 DI 블록 정리 (크론)"
+    },
+    "github-stats-sync": {
+      "callers": ["system"],
+      "envs": ["dev", "production"],
+      "description": "GitHub 이슈/PR 통계 수집 → analytics.github_daily_stats 저장 (pg_cron 트리거)"
+    },
+    "metrics-alert": {
+      "callers": ["system"],
+      "envs": ["dev", "production"],
+      "description": "메트릭 알람 → GitHub 이슈 생성/코멘트"
+    },
+    "payout-sync": {
+      "callers": ["system"],
+      "envs": ["dev", "production"],
+      "description": "지급 상태 동기화 (PortOne)"
+    },
+    "reconciliation-daily": {
+      "callers": ["system"],
+      "envs": ["dev", "production"],
+      "description": "일일 대사 (PG ↔ DB 불일치 검출)"
+    },
+    "recurrence-cron": {
+      "callers": ["system"],
+      "envs": ["dev", "production"],
+      "description": "반복 이벤트 자동 생성 (매일 UTC 00:00, 최대 30일 선행 생성)"
     }
   }
 }

--- a/supabase/functions/cleanup-blocked-dis/cleanup-blocked-dis_test.ts
+++ b/supabase/functions/cleanup-blocked-dis/cleanup-blocked-dis_test.ts
@@ -7,13 +7,14 @@ import {
   textRequest,
   withEnv,
   withMockedFetch,
-  withNoIntervals,
 } from "../_test_utils/mock_http.ts";
 
 
 const ENV = {
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "cleanup-blocked-dis",
 };
 
 function serviceRoleRequest() {
@@ -29,15 +30,13 @@ Deno.test("unauthorized request returns 401", async () => {
   );
 
   await withEnv(ENV, async () => {
-    await withNoIntervals(async () => {
-      const response = await handler(
-        textRequest("http://localhost", "{}", { method: "POST" }),
-      );
-      const payload = await readJson(response);
+    const response = await handler(
+      textRequest("http://localhost", "{}", { method: "POST" }),
+    );
+    const payload = await readJson(response);
 
-      assertEquals(response.status, 401);
-      assertEquals(payload.error, "Unauthorized");
-    });
+    assertEquals(response.status, 401);
+    assertEquals(payload.error, "Unauthorized");
   });
 });
 
@@ -54,21 +53,19 @@ Deno.test("expired blocked_dis rows are deleted", async () => {
 
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
-      await withNoIntervals(async () => {
-        const response = await handler(serviceRoleRequest());
-        const payload = await readJson(response);
+      const response = await handler(serviceRoleRequest());
+      const payload = await readJson(response);
 
-        assertEquals(response.status, 200);
-        assertEquals(payload.success, true);
-        assertEquals(payload.deleted_count, 2);
-        assertEquals(
-          calls.some((call) =>
-            call.url.includes("/rest/v1/blocked_dis") &&
-            call.method === "DELETE"
-          ),
-          true,
-        );
-      });
+      assertEquals(response.status, 200);
+      assertEquals(payload.success, true);
+      assertEquals(payload.deleted_count, 2);
+      assertEquals(
+        calls.some((call) =>
+          call.url.includes("/rest/v1/blocked_dis") &&
+          call.method === "DELETE"
+        ),
+        true,
+      );
     });
   });
 });

--- a/supabase/functions/cleanup-blocked-dis/index.ts
+++ b/supabase/functions/cleanup-blocked-dis/index.ts
@@ -1,62 +1,35 @@
-import { createServiceClient } from "../_shared/supabase_client.ts";
-import {
-  corsResponse,
-  errorResponse,
-  successResponse,
-} from "../_shared/response_utils.ts";
-import { initSentry, log, withHandler, withSpan } from "../_shared/logger.ts";
 // Fix #1784: 로컬 requireServiceRole 복사본 제거 → 공식 _shared/auth_utils.ts 사용
-import { requireServiceRole } from "../_shared/auth_utils.ts";
+import { errorResponse, successResponse } from "../_shared/response_utils.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
+import { withSpan } from "../_shared/logger.ts";
 
-const FN = "cleanup-blocked-dis";
-
-await initSentry();
-
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") {
-    return corsResponse();
-  }
+export const handler = async (req: Request, { supabase }: EFContext): Promise<Response> => {
   if (req.method !== "POST") {
     return errorResponse("Method Not Allowed", 405);
   }
 
-  const auth = requireServiceRole(req);
-  if (auth instanceof Response) {
-    return auth;
-  }
-
-  const supabase = createServiceClient();
   const nowIso = new Date().toISOString();
 
-  try {
-    const { data, error } = await withSpan(
-      "db.delete.expired_blocked_dis",
-      "db.delete",
-      () =>
-        supabase
-          .from("blocked_dis")
-          .delete()
-          .lt("blocked_until", nowIso)
-          .select("di_hash"),
-    );
+  const { data, error } = await withSpan(
+    "db.delete.expired_blocked_dis",
+    "db.delete",
+    () =>
+      supabase
+        .from("blocked_dis")
+        .delete()
+        .lt("blocked_until", nowIso)
+        .select("di_hash"),
+  );
 
-    if (error) {
-      throw new Error(`Failed to cleanup blocked_dis: ${error.message}`);
-    }
-
-    return successResponse({
-      success: true,
-      deleted_count: data?.length ?? 0,
-      executed_at: nowIso,
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    log({
-      function: FN,
-      level: "error",
-      message: "Unhandled error in cleanup-blocked-dis",
-      metadata: { detail: message },
-    });
-    return errorResponse(message, 500);
+  if (error) {
+    throw new Error(`Failed to cleanup blocked_dis: ${error.message}`);
   }
-}));
+
+  return successResponse({
+    success: true,
+    deleted_count: data?.length ?? 0,
+    executed_at: nowIso,
+  });
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/github-stats-sync/github_stats_sync_test.ts
+++ b/supabase/functions/github-stats-sync/github_stats_sync_test.ts
@@ -12,6 +12,8 @@ import {
 const ENV = {
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "valid-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "github-stats-sync",
 };
 
 Deno.test("github-stats-sync - unauthorized request returns 401", async () => {

--- a/supabase/functions/github-stats-sync/index.ts
+++ b/supabase/functions/github-stats-sync/index.ts
@@ -1,18 +1,10 @@
 // github-stats-sync — Fetch GitHub issue/PR stats and store in analytics.github_daily_stats
 // Triggered daily via pg_cron
 
-import { createServiceClient } from "../_shared/supabase_client.ts";
-import {
-  corsResponse,
-  errorResponse,
-  successResponse,
-} from "../_shared/response_utils.ts";
-import { requireServiceRole } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler, log } from "../_shared/logger.ts";
-
-const FN = "github-stats-sync";
-
-initSentry();
+import { errorResponse, successResponse } from "../_shared/response_utils.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
+// Fix #1121: requireServiceRole로 통일 (auth_utils 마이그레이션) → now handled by minglitEdgeFunction wrapper
+import { log } from "../_shared/logger.ts";
 
 const REPO = "Mark-Yun/minglit";
 const GITHUB_API = "https://api.github.com";
@@ -25,16 +17,12 @@ interface GitHubItem {
   pull_request?: { merged_at: string | null };
 }
 
-Deno.serve(withHandler(async (req: Request): Promise<Response> => {
-  if (req.method === "OPTIONS") return corsResponse();
+export const handler = async (req: Request, { supabase }: EFContext): Promise<Response> => {
+  if (req.method !== "POST") {
+    return errorResponse("Method Not Allowed", 405);
+  }
 
   const githubToken = Deno.env.get("GITHUB_ACCESS_TOKEN");
-
-  // Fix #1121: requireServiceRole로 통일 (auth_utils 마이그레이션)
-  const authResult = requireServiceRole(req);
-  if (authResult !== true) return authResult;
-
-  const supabase = createServiceClient();
 
   const headers: Record<string, string> = {
     Accept: "application/vnd.github.v3+json",
@@ -44,90 +32,87 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
     headers.Authorization = `Bearer ${githubToken}`;
   }
 
-  try {
-    // Fetch all issues (includes PRs) from last 90 days
-    const since = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
-    const items: GitHubItem[] = [];
-    let page = 1;
+  // Fetch all issues (includes PRs) from last 90 days
+  const since = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
+  const items: GitHubItem[] = [];
+  let page = 1;
 
-    while (page <= 10) {
-      const url = `${GITHUB_API}/repos/${REPO}/issues?state=all&since=${since}&per_page=100&page=${page}`;
-      const res = await fetch(url, { headers });
-      if (!res.ok) {
-        return errorResponse(`GitHub API error: ${res.status} ${res.statusText}`, 502);
-      }
-      const data = (await res.json()) as GitHubItem[];
-      if (data.length === 0) break;
-      items.push(...data);
-      page++;
+  while (page <= 10) {
+    const url = `${GITHUB_API}/repos/${REPO}/issues?state=all&since=${since}&per_page=100&page=${page}`;
+    const res = await fetch(url, { headers });
+    if (!res.ok) {
+      return errorResponse(`GitHub API error: ${res.status} ${res.statusText}`, 502);
     }
-
-    // Separate issues and PRs
-    const issues = items.filter((i) => !i.pull_request);
-    const prs = items.filter((i) => i.pull_request);
-
-    // Aggregate by date
-    const stats = new Map<string, Record<string, number>>();
-
-    const ensure = (date: string) => {
-      if (!stats.has(date)) {
-        stats.set(date, {
-          issues_opened: 0,
-          issues_closed: 0,
-          prs_opened: 0,
-          prs_merged: 0,
-        });
-      }
-      return stats.get(date)!;
-    };
-
-    for (const issue of issues) {
-      const created = issue.created_at.slice(0, 10);
-      ensure(created).issues_opened++;
-      if (issue.closed_at) {
-        const closed = issue.closed_at.slice(0, 10);
-        ensure(closed).issues_closed++;
-      }
-    }
-
-    for (const pr of prs) {
-      const created = pr.created_at.slice(0, 10);
-      ensure(created).prs_opened++;
-      if (pr.pull_request?.merged_at) {
-        const merged = pr.pull_request.merged_at.slice(0, 10);
-        ensure(merged).prs_merged++;
-      }
-    }
-
-    // Upsert into analytics.github_daily_stats
-    const rows: { date: string; metric: string; count: number }[] = [];
-    for (const [date, metrics] of stats) {
-      for (const [metric, count] of Object.entries(metrics)) {
-        rows.push({ date, metric, count });
-      }
-    }
-
-    // Batch upsert via RPC (analytics schema not exposed via REST)
-    // Use raw SQL via supabase.rpc or direct insert
-    for (const row of rows) {
-      const { error } = await supabase.rpc("upsert_github_daily_stat", {
-        p_date: row.date,
-        p_metric: row.metric,
-        p_count: row.count,
-      });
-      if (error) {
-        log({ function: FN, level: "error", message: `Failed to upsert ${row.date}/${row.metric}`, metadata: { detail: error.message } });
-      }
-    }
-
-    return successResponse({
-      success: true,
-      dates: stats.size,
-      total_rows: rows.length,
-      issues: issues.length,
-      prs: prs.length,
-    });
-  } catch (err) {
-    return errorResponse(`Unexpected error: ${(err as Error).message}`, 500);
+    const data = (await res.json()) as GitHubItem[];
+    if (data.length === 0) break;
+    items.push(...data);
+    page++;
   }
-}));
+
+  // Separate issues and PRs
+  const issues = items.filter((i) => !i.pull_request);
+  const prs = items.filter((i) => i.pull_request);
+
+  // Aggregate by date
+  const stats = new Map<string, Record<string, number>>();
+
+  const ensure = (date: string) => {
+    if (!stats.has(date)) {
+      stats.set(date, {
+        issues_opened: 0,
+        issues_closed: 0,
+        prs_opened: 0,
+        prs_merged: 0,
+      });
+    }
+    return stats.get(date)!;
+  };
+
+  for (const issue of issues) {
+    const created = issue.created_at.slice(0, 10);
+    ensure(created).issues_opened++;
+    if (issue.closed_at) {
+      const closed = issue.closed_at.slice(0, 10);
+      ensure(closed).issues_closed++;
+    }
+  }
+
+  for (const pr of prs) {
+    const created = pr.created_at.slice(0, 10);
+    ensure(created).prs_opened++;
+    if (pr.pull_request?.merged_at) {
+      const merged = pr.pull_request.merged_at.slice(0, 10);
+      ensure(merged).prs_merged++;
+    }
+  }
+
+  // Upsert into analytics.github_daily_stats
+  const rows: { date: string; metric: string; count: number }[] = [];
+  for (const [date, metrics] of stats) {
+    for (const [metric, count] of Object.entries(metrics)) {
+      rows.push({ date, metric, count });
+    }
+  }
+
+  // Batch upsert via RPC (analytics schema not exposed via REST)
+  for (const row of rows) {
+    const { error } = await supabase.rpc("upsert_github_daily_stat", {
+      p_date: row.date,
+      p_metric: row.metric,
+      p_count: row.count,
+    });
+    if (error) {
+      log({ function: "github-stats-sync", level: "error", message: `Failed to upsert ${row.date}/${row.metric}`, metadata: { detail: error.message } });
+    }
+  }
+
+  return successResponse({
+    success: true,
+    dates: stats.size,
+    total_rows: rows.length,
+    issues: issues.length,
+    prs: prs.length,
+  });
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/metrics-alert/index.ts
+++ b/supabase/functions/metrics-alert/index.ts
@@ -1,10 +1,6 @@
-import {
-  corsResponse,
-  errorResponse,
-  successResponse,
-} from "../_shared/response_utils.ts";
+import { errorResponse, successResponse } from "../_shared/response_utils.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { initSentry, withHandler } from "../_shared/logger.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 
 const GITHUB_TOKEN = Deno.env.get("GITHUB_ACCESS_TOKEN");
 const GITHUB_REPO = "Mark-Yun/minglit";
@@ -16,20 +12,7 @@ export const ALERT_LABELS: Record<string, string[]> = {
   report: ["metrics-alert", "auto-generated", "report"],
 };
 
-initSentry();
-
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
-
-  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-  if (!serviceRoleKey) {
-    return errorResponse("SUPABASE_SERVICE_ROLE_KEY not configured", 500);
-  }
-  const authHeader = req.headers.get("Authorization") ?? "";
-  if (authHeader !== `Bearer ${serviceRoleKey}`) {
-    return errorResponse("Unauthorized", 401);
-  }
-
+export const handler = async (req: Request, _ctx: EFContext): Promise<Response> => {
   const body = await parseJsonBody(req);
   if (body instanceof Response) return body;
 
@@ -121,4 +104,6 @@ Deno.serve(withHandler(async (req) => {
     issue_number: issue.number,
     url: issue.html_url,
   });
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/payout-sync/index.ts
+++ b/supabase/functions/payout-sync/index.ts
@@ -1,14 +1,9 @@
 // Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
-import { createServiceClient } from "../_shared/supabase_client.ts";
 import { getPortoneClient } from "../_shared/portone_client.ts";
-import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
-import { requireServiceRole } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler, log } from "../_shared/logger.ts";
-
-const FN = "payout-sync";
-
-
-initSentry();
+import { successResponse, errorResponse } from "../_shared/response_utils.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
+// Fix #593: service_role 전용으로 전환 — 벌크 금융 작업에 일반 유저 접근 차단 (now handled by minglitEdgeFunction wrapper)
+import { log } from "../_shared/logger.ts";
 
 const NON_RETRYABLE_ERRORS = new Set([
   "INVALID_BANK_ACCOUNT",
@@ -30,23 +25,17 @@ function classifyError(errorCode: string): { retryable: boolean } {
   return { retryable: true };
 }
 
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
-
-  // Fix #593: service_role 전용으로 전환 — 벌크 금융 작업에 일반 유저 접근 차단
-  const auth = requireServiceRole(req);
-  if (auth instanceof Response) return auth;
+export const handler = async (req: Request, { supabase }: EFContext): Promise<Response> => {
+  if (req.method !== "POST") return errorResponse("Method Not Allowed", 405);
 
   try {
-    const supabase = createServiceClient();
-
     const { data: activePayout, error: payoutFetchError } = await supabase
       .from("payouts")
       .select("id, partner_id, status, item_count")
       .in("status", ["CREATED", "READY", "PROCESSING"]);
 
     if (payoutFetchError) {
-      log({ function: FN, level: "error", message: `Failed to fetch active payouts: ${payoutFetchError.message}` });
+      log({ function: "payout-sync", level: "error", message: `Failed to fetch active payouts: ${payoutFetchError.message}` });
       return errorResponse("Failed to fetch payouts", 500);
     }
 
@@ -66,7 +55,7 @@ Deno.serve(withHandler(async (req) => {
           .single();
 
         if (partnerError || !partner?.portone_partner_id) {
-          log({ function: FN, level: "error", message: `Partner not found for payout ${payout.id}` });
+          log({ function: "payout-sync", level: "error", message: `Partner not found for payout ${payout.id}` });
           continue;
         }
 
@@ -76,7 +65,7 @@ Deno.serve(withHandler(async (req) => {
           portonePayouts = result.payouts ?? [];
         } catch (e) {
           const message = e instanceof Error ? e.message : String(e);
-          log({ function: FN, level: "error", message: `getPayouts failed for payout ${payout.id}: ${message}` });
+          log({ function: "payout-sync", level: "error", message: `getPayouts failed for payout ${payout.id}: ${message}` });
           continue;
         }
 
@@ -193,14 +182,16 @@ Deno.serve(withHandler(async (req) => {
         }
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e);
-        log({ function: FN, level: "error", message: `Error syncing payout ${payout.id}: ${message}` });
+        log({ function: "payout-sync", level: "error", message: `Error syncing payout ${payout.id}: ${message}` });
       }
     }
 
     return successResponse({ synced });
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    log({ function: FN, level: "error", message: `Error in payout-sync: ${message}` });
+    log({ function: "payout-sync", level: "error", message: `Error in payout-sync: ${message}` });
     return errorResponse(message, 500);
   }
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/payout-sync/payout_sync_test.ts
+++ b/supabase/functions/payout-sync/payout_sync_test.ts
@@ -7,13 +7,14 @@ import {
   readJson,
   withEnv,
   withMockedFetch,
-  withNoIntervals,
 } from "../_test_utils/mock_http.ts";
 
 const ENV = {
   PORTONE_V2_API_KEY: "test-v2-key",
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "payout-sync",
 };
 
 const NON_RETRYABLE_ERRORS = new Set([
@@ -69,16 +70,14 @@ Deno.test("payout-sync - 빈 목록: 비종결 payouts 없으면 synced=0 반환
     ]);
 
     await withMockedFetch(fetchMock, async () => {
-      await withNoIntervals(async () => {
-        const request = jsonRequest("http://localhost", {}, {
-          headers: { Authorization: "Bearer service-key" },
-        });
-        const response = await handler(request);
-        const payload = await readJson(response);
-
-        assertEquals(response.status, 200);
-        assertEquals(payload.synced, 0);
+      const request = jsonRequest("http://localhost", {}, {
+        headers: { Authorization: "Bearer service-key" },
       });
+      const response = await handler(request);
+      const payload = await readJson(response);
+
+      assertEquals(response.status, 200);
+      assertEquals(payload.synced, 0);
     });
   });
 });

--- a/supabase/functions/reconciliation-daily/index.ts
+++ b/supabase/functions/reconciliation-daily/index.ts
@@ -1,10 +1,7 @@
 // Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
-import { createServiceClient } from "../_shared/supabase_client.ts";
+// Fix #1116: 공통 유틸 사용 — env 미설정 시 빈 문자열 비교로 통과되던 취약점 제거 (now handled by minglitEdgeFunction wrapper)
 import { getPortoneClient, PortoneSettlement } from "../_shared/portone_client.ts";
-import { initSentry, withHandler } from "../_shared/logger.ts";
-import { requireServiceRole } from "../_shared/auth_utils.ts";
-
-await initSentry();
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 
 
 const CORS_HEADERS = {
@@ -81,16 +78,7 @@ function computeSourceHash(ledgerData: unknown[], portoneData: unknown[]): strin
   return Math.abs(hash).toString(16);
 }
 
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") {
-    return new Response(null, { status: 204, headers: CORS_HEADERS });
-  }
-
-  // Fix #1116: 공통 유틸 사용 — env 미설정 시 빈 문자열 비교로 통과되던 취약점 제거
-  const authResult = requireServiceRole(req);
-  if (authResult instanceof Response) return authResult;
-
-  const supabase = createServiceClient();
+export const handler = async (req: Request, { supabase }: EFContext): Promise<Response> => {
 
   const nowKst = new Date(Date.now() + 9 * 60 * 60 * 1000);
   const yesterdayKst = new Date(nowKst);
@@ -295,4 +283,6 @@ Deno.serve(withHandler(async (req) => {
       { status: 500, headers: { ...CORS_HEADERS, "Content-Type": "application/json" } },
     );
   }
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/reconciliation-daily/reconciliation_daily_test.ts
+++ b/supabase/functions/reconciliation-daily/reconciliation_daily_test.ts
@@ -70,12 +70,12 @@ Deno.test("reconciliation-daily - missing Authorization header returns 401", asy
   });
 });
 
-Deno.test("reconciliation-daily - OPTIONS preflight returns 204", async () => {
+Deno.test("reconciliation-daily - OPTIONS preflight returns 200", async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const request = new Request("http://localhost", { method: "OPTIONS" });
     const response = await handler(request);
-    assertEquals(response.status, 204);
+    assertEquals(response.status, 200);
   });
 });
 

--- a/supabase/functions/reconciliation-daily/reconciliation_daily_test.ts
+++ b/supabase/functions/reconciliation-daily/reconciliation_daily_test.ts
@@ -7,13 +7,14 @@ import {
   readJson,
   withEnv,
   withMockedFetch,
-  withNoIntervals,
 } from "../_test_utils/mock_http.ts";
 
 const ENV = {
   PORTONE_V2_API_KEY: "test-portone-key",
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "reconciliation-daily",
 };
 
 const RUN_ID = "aaaaaaaa-0000-0000-0000-000000000001";
@@ -121,18 +122,16 @@ Deno.test("reconciliation-daily - successful reconciliation with matched data", 
     ]);
 
     await withMockedFetch(fetchMock, async () => {
-      await withNoIntervals(async () => {
-        const request = jsonRequest("http://localhost", {}, {
-          headers: { Authorization: "Bearer test-service-key" },
-        });
-        const response = await handler(request);
-        const payload = await readJson(response);
-
-        assertEquals(response.status, 200);
-        assertEquals(payload.matched, 1);
-        assertEquals(payload.mismatched, 0);
-        assertEquals(payload.critical, 0);
+      const request = jsonRequest("http://localhost", {}, {
+        headers: { Authorization: "Bearer test-service-key" },
       });
+      const response = await handler(request);
+      const payload = await readJson(response);
+
+      assertEquals(response.status, 200);
+      assertEquals(payload.matched, 1);
+      assertEquals(payload.mismatched, 0);
+      assertEquals(payload.critical, 0);
     });
   });
 });
@@ -169,18 +168,16 @@ Deno.test("reconciliation-daily - MISSING_IN_PORTONE detection", async () => {
     ]);
 
     await withMockedFetch(fetchMock, async () => {
-      await withNoIntervals(async () => {
-        const request = jsonRequest("http://localhost", {}, {
-          headers: { Authorization: "Bearer test-service-key" },
-        });
-        const response = await handler(request);
-        const payload = await readJson(response);
-
-        assertEquals(response.status, 200);
-        assertEquals(payload.critical, 1);
-        assertEquals(payload.mismatched, 1);
-        assertEquals(payload.matched, 0);
+      const request = jsonRequest("http://localhost", {}, {
+        headers: { Authorization: "Bearer test-service-key" },
       });
+      const response = await handler(request);
+      const payload = await readJson(response);
+
+      assertEquals(response.status, 200);
+      assertEquals(payload.critical, 1);
+      assertEquals(payload.mismatched, 1);
+      assertEquals(payload.matched, 0);
     });
   });
 });
@@ -218,18 +215,16 @@ Deno.test("reconciliation-daily - MISSING_IN_LEDGER detection", async () => {
     ]);
 
     await withMockedFetch(fetchMock, async () => {
-      await withNoIntervals(async () => {
-        const request = jsonRequest("http://localhost", {}, {
-          headers: { Authorization: "Bearer test-service-key" },
-        });
-        const response = await handler(request);
-        const payload = await readJson(response);
-
-        assertEquals(response.status, 200);
-        assertEquals(payload.critical, 1);
-        assertEquals(payload.mismatched, 1);
-        assertEquals(payload.matched, 0);
+      const request = jsonRequest("http://localhost", {}, {
+        headers: { Authorization: "Bearer test-service-key" },
       });
+      const response = await handler(request);
+      const payload = await readJson(response);
+
+      assertEquals(response.status, 200);
+      assertEquals(payload.critical, 1);
+      assertEquals(payload.mismatched, 1);
+      assertEquals(payload.matched, 0);
     });
   });
 });
@@ -254,14 +249,12 @@ Deno.test("reconciliation-daily - PortOne API failure → FAILED run, no kill sw
     ]);
 
     await withMockedFetch(fetchMock, async () => {
-      await withNoIntervals(async () => {
-        const request = jsonRequest("http://localhost", {}, {
-          headers: { Authorization: "Bearer test-service-key" },
-        });
-        const response = await handler(request);
-
-        assertEquals(response.status, 500);
+      const request = jsonRequest("http://localhost", {}, {
+        headers: { Authorization: "Bearer test-service-key" },
       });
+      const response = await handler(request);
+
+      assertEquals(response.status, 500);
     });
   });
 });

--- a/supabase/functions/recurrence-cron/index.ts
+++ b/supabase/functions/recurrence-cron/index.ts
@@ -1,15 +1,7 @@
-import { createServiceClient } from "../_shared/supabase_client.ts";
-import {
-  corsResponse,
-  errorResponse,
-  successResponse,
-} from "../_shared/response_utils.ts";
-import { requireServiceRole } from "../_shared/auth_utils.ts";
-import { initSentry, log, withHandler } from "../_shared/logger.ts";
-
-await initSentry();
-
-const FN = "recurrence-cron";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { errorResponse, successResponse } from "../_shared/response_utils.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
+import { log } from "../_shared/logger.ts";
 const LOOKAHEAD_DAYS = 30;
 
 interface RecurrenceRule {
@@ -91,7 +83,7 @@ interface RuleProcessResult {
 }
 
 async function processRule(
-  supabase: ReturnType<typeof createServiceClient>,
+  supabase: SupabaseClient,
   rule: RecurrenceRule,
   today: Date,
   lookaheadEnd: Date,
@@ -135,7 +127,7 @@ async function processRule(
       ticketTemplatesResult.error?.message,
     ].filter(Boolean).join("; ");
     log({
-      function: FN,
+      function: "recurrence-cron",
       level: "error",
       message: "Failed to load templates",
       metadata: { rule_id: rule.id, party_id: rule.party_id, detail },
@@ -194,7 +186,7 @@ async function processRule(
         continue;
       }
       log({
-        function: FN,
+        function: "recurrence-cron",
         level: "error",
         message: "Failed to insert event",
         metadata: { rule_id: rule.id, date: dateStr, detail: eventError.message },
@@ -232,7 +224,7 @@ async function processRule(
 
       if (groupError) {
         log({
-          function: FN,
+          function: "recurrence-cron",
           level: "error",
           message: "Failed to insert entry_groups",
           metadata: { event_id: eventId, rule_id: rule.id, detail: groupError.message },
@@ -271,7 +263,7 @@ async function processRule(
 
       if (ticketError) {
         log({
-          function: FN,
+          function: "recurrence-cron",
           level: "error",
           message: "Failed to insert tickets",
           metadata: { event_id: eventId, rule_id: rule.id, detail: ticketError.message },
@@ -303,7 +295,7 @@ async function processRule(
 }
 
 async function processAllActiveRules(
-  supabase: ReturnType<typeof createServiceClient>,
+  supabase: SupabaseClient,
 ): Promise<RuleProcessResult[]> {
   const { data: rules, error } = await supabase
     .from("recurrence_rules")
@@ -331,7 +323,7 @@ async function processAllActiveRules(
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log({
-        function: FN,
+        function: "recurrence-cron",
         level: "error",
         message: "Unhandled error processing recurrence rule",
         metadata: { rule_id: rule.id, detail: message },
@@ -343,14 +335,8 @@ async function processAllActiveRules(
   return results;
 }
 
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
+export const handler = async (req: Request, { supabase }: EFContext): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method Not Allowed", 405);
-
-  const authCheck = requireServiceRole(req);
-  if (authCheck instanceof Response) return authCheck;
-
-  const supabase = createServiceClient();
 
   try {
     const results = await processAllActiveRules(supabase);
@@ -368,11 +354,13 @@ Deno.serve(withHandler(async (req) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log({
-      function: FN,
+      function: "recurrence-cron",
       level: "error",
       message: "Unhandled error in recurrence-cron",
       metadata: { detail: message },
     });
     return errorResponse(message, 500);
   }
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/recurrence-cron/recurrence-cron_test.ts
+++ b/supabase/functions/recurrence-cron/recurrence-cron_test.ts
@@ -7,7 +7,6 @@ import {
   readJson,
   withEnv,
   withMockedFetch,
-  withNoIntervals,
   type FetchRoute,
 } from "../_test_utils/mock_http.ts";
 
@@ -15,6 +14,8 @@ import {
 const ENV = {
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "recurrence-cron",
 };
 
 const TODAY = "2026-04-05";
@@ -118,11 +119,9 @@ Deno.test("recurrence-cron - missing auth returns 401", async () => {
     const handler = await captureServeHandler(
       new URL("./index.ts", import.meta.url),
     );
-    await withNoIntervals(async () => {
-      const req = new Request("http://localhost", { method: "POST" });
-      const res = await handler(req);
-      assertEquals(res.status, 401);
-    });
+    const req = new Request("http://localhost", { method: "POST" });
+    const res = await handler(req);
+    assertEquals(res.status, 401);
   });
 });
 
@@ -131,14 +130,12 @@ Deno.test("recurrence-cron - wrong service role key returns 401", async () => {
     const handler = await captureServeHandler(
       new URL("./index.ts", import.meta.url),
     );
-    await withNoIntervals(async () => {
-      const req = new Request("http://localhost", {
-        method: "POST",
-        headers: { Authorization: "Bearer wrong-key" },
-      });
-      const res = await handler(req);
-      assertEquals(res.status, 401);
+    const req = new Request("http://localhost", {
+      method: "POST",
+      headers: { Authorization: "Bearer wrong-key" },
     });
+    const res = await handler(req);
+    assertEquals(res.status, 401);
   });
 });
 
@@ -147,11 +144,9 @@ Deno.test("recurrence-cron - OPTIONS preflight returns 200", async () => {
     const handler = await captureServeHandler(
       new URL("./index.ts", import.meta.url),
     );
-    await withNoIntervals(async () => {
-      const req = new Request("http://localhost", { method: "OPTIONS" });
-      const res = await handler(req);
-      assertEquals(res.status, 200);
-    });
+    const req = new Request("http://localhost", { method: "OPTIONS" });
+    const res = await handler(req);
+    assertEquals(res.status, 200);
   });
 });
 
@@ -181,16 +176,14 @@ Deno.test(
       ]);
 
       await withMockedFetch(fetchMock, async () => {
-        await withNoIntervals(async () => {
-          const res = await handler(serviceRoleRequest());
-          const payload = await readJson(res);
+        const res = await handler(serviceRoleRequest());
+        const payload = await readJson(res);
 
-          assertEquals(res.status, 200);
-          assertEquals(payload.processed, 1);
-          // 30-day window with Mon+Fri: expect 8 or 9 events
-          const totalEvents = payload.total_events as number;
-          assertEquals(totalEvents >= 8 && totalEvents <= 9, true);
-        });
+        assertEquals(res.status, 200);
+        assertEquals(payload.processed, 1);
+        // 30-day window with Mon+Fri: expect 8 or 9 events
+        const totalEvents = payload.total_events as number;
+        assertEquals(totalEvents >= 8 && totalEvents <= 9, true);
       });
     });
   },
@@ -211,14 +204,12 @@ Deno.test(
       ]);
 
       await withMockedFetch(fetchMock, async () => {
-        await withNoIntervals(async () => {
-          const res = await handler(serviceRoleRequest());
-          const payload = await readJson(res);
+        const res = await handler(serviceRoleRequest());
+        const payload = await readJson(res);
 
-          assertEquals(res.status, 200);
-          assertEquals(payload.processed, 0);
-          assertEquals(payload.total_events, 0);
-        });
+        assertEquals(res.status, 200);
+        assertEquals(payload.processed, 0);
+        assertEquals(payload.total_events, 0);
       });
     });
   },
@@ -239,14 +230,12 @@ Deno.test(
       ]);
 
       await withMockedFetch(fetchMock, async () => {
-        await withNoIntervals(async () => {
-          const res = await handler(serviceRoleRequest());
-          const payload = await readJson(res);
+        const res = await handler(serviceRoleRequest());
+        const payload = await readJson(res);
 
-          assertEquals(res.status, 200);
-          assertEquals(payload.processed, 0);
-          assertEquals(payload.total_events, 0);
-        });
+        assertEquals(res.status, 200);
+        assertEquals(payload.processed, 0);
+        assertEquals(payload.total_events, 0);
       });
     });
   },
@@ -271,14 +260,12 @@ Deno.test(
       ]);
 
       await withMockedFetch(fetchMock, async () => {
-        await withNoIntervals(async () => {
-          const res = await handler(serviceRoleRequest());
-          const payload = await readJson(res);
+        const res = await handler(serviceRoleRequest());
+        const payload = await readJson(res);
 
-          assertEquals(res.status, 200);
-          assertEquals(payload.processed, 1);
-          assertEquals(payload.total_events, 0);
-        });
+        assertEquals(res.status, 200);
+        assertEquals(payload.processed, 1);
+        assertEquals(payload.total_events, 0);
       });
     });
   },
@@ -319,15 +306,13 @@ Deno.test(
       ]);
 
       await withMockedFetch(fetchMock, async () => {
-        await withNoIntervals(async () => {
-          const res = await handler(serviceRoleRequest());
-          const payload = await readJson(res);
+        const res = await handler(serviceRoleRequest());
+        const payload = await readJson(res);
 
-          assertEquals(res.status, 200);
-          assertEquals(payload.processed, 1);
-          // From today to today+10 inclusive = 11 days, all days of week → exactly 11 events
-          assertEquals(payload.total_events, 11);
-        });
+        assertEquals(res.status, 200);
+        assertEquals(payload.processed, 1);
+        // From today to today+10 inclusive = 11 days, all days of week → exactly 11 events
+        assertEquals(payload.total_events, 11);
       });
     });
   },
@@ -369,15 +354,13 @@ Deno.test(
         ]);
 
         await withMockedFetch(fetchMock, async () => {
-          await withNoIntervals(async () => {
-            const res = await handler(serviceRoleRequest());
-            const payload = await readJson(res);
+          const res = await handler(serviceRoleRequest());
+          const payload = await readJson(res);
 
-            assertEquals(res.status, 200);
-            assertEquals(payload.processed, 1);
-            // Frozen at 2026-04-05 → window [Apr 5, May 5] → month_day=15 → Apr 15 → 1 event
-            assertEquals(payload.total_events, 1);
-          });
+          assertEquals(res.status, 200);
+          assertEquals(payload.processed, 1);
+          // Frozen at 2026-04-05 → window [Apr 5, May 5] → month_day=15 → Apr 15 → 1 event
+          assertEquals(payload.total_events, 1);
         });
       });
     } finally {
@@ -414,16 +397,14 @@ Deno.test(
         ]);
 
         await withMockedFetch(fetchMock, async () => {
-          await withNoIntervals(async () => {
-            const res = await handler(serviceRoleRequest());
-            const payload = await readJson(res);
+          const res = await handler(serviceRoleRequest());
+          const payload = await readJson(res);
 
-            assertEquals(res.status, 200);
-            assertEquals(payload.processed, 1);
-            assertEquals(payload.total_events, 0);
-            assertEquals(payload.total_skipped, 1);
-            assertEquals(payload.total_errors, 0);
-          });
+          assertEquals(res.status, 200);
+          assertEquals(payload.processed, 1);
+          assertEquals(payload.total_events, 0);
+          assertEquals(payload.total_skipped, 1);
+          assertEquals(payload.total_errors, 0);
         });
       });
     } finally {
@@ -508,17 +489,15 @@ Deno.test(
       ]);
 
       await withMockedFetch(fetchMock, async () => {
-        await withNoIntervals(async () => {
-          const res = await handler(serviceRoleRequest());
-          const payload = await readJson(res);
+        const res = await handler(serviceRoleRequest());
+        const payload = await readJson(res);
 
-          assertEquals(res.status, 200);
-          assertEquals(payload.total_events, 1);
+        assertEquals(res.status, 200);
+        assertEquals(payload.total_events, 1);
 
-          // Ticket target_entry_group_ids should reference new group id, not template id
-          const ticketRows = ticketInsertBody as Array<{ target_entry_group_ids: string[] }>;
-          assertEquals(ticketRows[0].target_entry_group_ids[0], newGroupId);
-        });
+        // Ticket target_entry_group_ids should reference new group id, not template id
+        const ticketRows = ticketInsertBody as Array<{ target_entry_group_ids: string[] }>;
+        assertEquals(ticketRows[0].target_entry_group_ids[0], newGroupId);
       });
     });
     } finally {
@@ -565,10 +544,8 @@ Deno.test(
         ]);
 
         await withMockedFetch(fetchMock, async () => {
-          await withNoIntervals(async () => {
-            const res = await handler(serviceRoleRequest());
-            assertEquals(res.status, 200);
-          });
+          const res = await handler(serviceRoleRequest());
+          assertEquals(res.status, 200);
         });
 
         // start_time and end_time must carry KST offset, not Z
@@ -631,10 +608,8 @@ Deno.test(
         ]);
 
         await withMockedFetch(fetchMock, async () => {
-          await withNoIntervals(async () => {
-            const res = await handler(serviceRoleRequest());
-            assertEquals(res.status, 200);
-          });
+          const res = await handler(serviceRoleRequest());
+          assertEquals(res.status, 200);
         });
 
         assertExists(capturedBody, "POST /events must have been called");
@@ -671,14 +646,12 @@ Deno.test(
       ]);
 
       await withMockedFetch(fetchMock, async () => {
-        await withNoIntervals(async () => {
-          const res = await handler(serviceRoleRequest());
-          const payload = await readJson(res);
+        const res = await handler(serviceRoleRequest());
+        const payload = await readJson(res);
 
-          assertEquals(res.status, 200);
-          assertEquals(payload.processed, 0);
-          assertEquals(payload.total_events, 0);
-        });
+        assertEquals(res.status, 200);
+        assertEquals(payload.processed, 0);
+        assertEquals(payload.total_events, 0);
       });
     });
   },


### PR DESCRIPTION
## Summary

Closes #2185 (partial — batch 1 of 6 EFs)

Migrates 6 edge functions from the old `Deno.serve(withHandler(...))` pattern to the centralized `minglitEdgeFunction(handler)` wrapper:

- `cleanup-blocked-dis` — expired blocked_dis row deletion
- `github-stats-sync` — GitHub API → Supabase daily stats sync
- `metrics-alert` — GitHub issue creation/commenting for metric alerts
- `payout-sync` — PortOne payout status sync → settlement_items transitions
- `reconciliation-daily` — daily ledger ↔ PortOne settlement reconciliation
- `recurrence-cron` — recurring event generation from recurrence_rules

**Changes per function:**
- `index.ts`: replaced `createServiceClient()`, `requireServiceRole`, `initSentry()`, `withHandler`, `Deno.serve` boilerplate → `export const handler` + `minglitEdgeFunction(handler)`
- `auth-manifest.json`: added all 6 as `system` callers with `dev` + `production` envs
- `*_test.ts`: added `ENVIRONMENT: "dev"` and `MINGLIT_EF_TEST_FN_NAME` to test ENV; removed `withNoIntervals` (no longer needed post-migration)

**Note:** `reconciliation-daily` retains `CORS_HEADERS` const — its handler returns raw `new Response(...)` with custom CORS headers rather than `successResponse()`.

## Test plan

- [ ] `test-edge-functions` CI job covers all 6 migrated functions
- [ ] Verify auth 401 tests pass (minglitEdgeFunction wrapper enforces service role)
- [ ] Verify functional tests pass with mock fetch routes

🤖 Generated with [Claude Code](https://claude.ai/claude-code) — needs-swe-sonnet-1