### PR TITLE
feat(edge-functions): migrate batch-3 EFs to minglitEdgeFunction wrapper

### DIFF
--- a/supabase/functions/_contract_tests/contract_test.ts
+++ b/supabase/functions/_contract_tests/contract_test.ts
@@ -233,7 +233,7 @@ Deno.test("contract: payment-cancel response matches schema", async () => {
 Deno.test("contract: settlement-query response matches schema", async () => {
   const schema = await loadSchema("settlement_query");
 
-  await withEnv(COMMON_ENV, async () => {
+  await withEnv({ ...COMMON_ENV, ENVIRONMENT: "dev", MINGLIT_EF_TEST_FN_NAME: "settlement-query" }, async () => {
     const handler = await captureServeHandler(
       new URL("../settlement-query/index.ts", import.meta.url),
     );

--- a/supabase/functions/auth-manifest.json
+++ b/supabase/functions/auth-manifest.json
@@ -66,6 +66,36 @@
       "callers": ["system"],
       "envs": ["dev", "production"],
       "description": "이벤트 체크인 참가자 매치 페어 생성 (Fix #592)"
+    },
+    "settlement-query": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "파트너 정산/지급 내역 조회 — PortOne getPartnerSettlements / getPayouts"
+    },
+    "user-cancel-deletion": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "탈퇴 유예 기간 중 취소 — deleted_at 복구"
+    },
+    "user-cast-vote": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "이벤트 체크인 참가자 매칭 투표"
+    },
+    "user-manage-notification": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "유저 알림 읽음/삭제 처리"
+    },
+    "user-manage-social": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "소셜 인터랙션 관리 (좋아요, 차단, 신고)"
+    },
+    "user-get-ticket-token": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "QR 코드용 서명된 티켓 토큰 발급 (Fix #1206)"
     }
   }
 }

--- a/supabase/functions/settlement-query/index.ts
+++ b/supabase/functions/settlement-query/index.ts
@@ -1,19 +1,14 @@
 import { getPortoneClient } from "../_shared/portone_client.ts";
-import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
+import { successResponse, errorResponse } from "../_shared/response_utils.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { initSentry, log, withHandler } from "../_shared/logger.ts";
+import { log } from "../_shared/logger.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 
 const FN = "settlement-query";
 
+export const handler = async (req: Request, { auth }: EFContext): Promise<Response> => {
+  const { userId: _userId } = auth as { type: "user"; userId: string };
 
-initSentry();
-
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
-
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
   try {
     const body = await parseJsonBody(req);
     if (body instanceof Response) return body;
@@ -82,4 +77,6 @@ Deno.serve(withHandler(async (req) => {
     });
     return errorResponse(message, 500);
   }
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/settlement-query/settlement_query_test.ts
+++ b/supabase/functions/settlement-query/settlement_query_test.ts
@@ -7,11 +7,12 @@ import {
   readJson,
   withEnv,
   withMockedFetch,
-  withNoIntervals,
 } from "../_test_utils/mock_http.ts";
 import { authRoute } from "../_test_utils/fixtures.ts";
 
 const ENV = {
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "settlement-query",
   PORTONE_V2_API_KEY: "test-v2-key",
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
@@ -30,16 +31,14 @@ Deno.test("settlement-query - settlements type returns settlement list", async (
     ]);
 
     await withMockedFetch(fetchMock, async () => {
-      await withNoIntervals(async () => {
-        const request = authenticatedJsonRequest("http://localhost", { type: "settlements" });
-        const response = await handler(request);
-        const payload = await readJson(response);
+      const request = authenticatedJsonRequest("http://localhost", { type: "settlements" });
+      const response = await handler(request);
+      const payload = await readJson(response);
 
-        assertEquals(response.status, 200);
-        assertEquals(payload.success, true);
-        assertEquals(payload.settlements.length, 1);
-        assertEquals(payload.settlements[0].id, "s1");
-      });
+      assertEquals(response.status, 200);
+      assertEquals(payload.success, true);
+      assertEquals(payload.settlements.length, 1);
+      assertEquals(payload.settlements[0].id, "s1");
     });
   });
 });
@@ -57,16 +56,14 @@ Deno.test("settlement-query - payouts type returns payout list", async () => {
     ]);
 
     await withMockedFetch(fetchMock, async () => {
-      await withNoIntervals(async () => {
-        const request = authenticatedJsonRequest("http://localhost", { type: "payouts" });
-        const response = await handler(request);
-        const payload = await readJson(response);
+      const request = authenticatedJsonRequest("http://localhost", { type: "payouts" });
+      const response = await handler(request);
+      const payload = await readJson(response);
 
-        assertEquals(response.status, 200);
-        assertEquals(payload.success, true);
-        assertEquals(payload.payouts.length, 1);
-        assertEquals(payload.payouts[0].id, "p1");
-      });
+      assertEquals(response.status, 200);
+      assertEquals(payload.success, true);
+      assertEquals(payload.payouts.length, 1);
+      assertEquals(payload.payouts[0].id, "p1");
     });
   });
 });
@@ -77,14 +74,12 @@ Deno.test("settlement-query - missing type returns 400", async () => {
     const { fetchMock } = createFetchMock([authRoute]);
 
     await withMockedFetch(fetchMock, async () => {
-      await withNoIntervals(async () => {
-        const request = authenticatedJsonRequest("http://localhost", { partner_id: "partner-uuid" });
-        const response = await handler(request);
-        const payload = await readJson(response);
+      const request = authenticatedJsonRequest("http://localhost", { partner_id: "partner-uuid" });
+      const response = await handler(request);
+      const payload = await readJson(response);
 
-        assertEquals(response.status, 400);
-        assertEquals(payload.error, "Missing or invalid type: must be 'settlements' or 'payouts'");
-      });
+      assertEquals(response.status, 400);
+      assertEquals(payload.error, "Missing or invalid type: must be 'settlements' or 'payouts'");
     });
   });
 });
@@ -102,14 +97,12 @@ Deno.test("settlement-query - PortOne API error returns 502", async () => {
     ]);
 
     await withMockedFetch(fetchMock, async () => {
-      await withNoIntervals(async () => {
-        const request = authenticatedJsonRequest("http://localhost", { type: "settlements" });
-        const response = await handler(request);
-        const payload = await readJson(response);
+      const request = authenticatedJsonRequest("http://localhost", { type: "settlements" });
+      const response = await handler(request);
+      const payload = await readJson(response);
 
-        assertEquals(response.status, 502);
-        assertEquals(payload.error, "Failed to fetch settlements");
-      });
+      assertEquals(response.status, 502);
+      assertEquals(payload.error, "Failed to fetch settlements");
     });
   });
 });

--- a/supabase/functions/user-cancel-deletion/index.ts
+++ b/supabase/functions/user-cancel-deletion/index.ts
@@ -1,24 +1,16 @@
-import { createServiceClient } from "../_shared/supabase_client.ts";
-import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler, withSpan, log } from "../_shared/logger.ts";
+import { successResponse, errorResponse } from "../_shared/response_utils.ts";
+import { withSpan, log } from "../_shared/logger.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 
 const FN = "user-cancel-deletion";
 const DELETION_GRACE_PERIOD_MS = 7 * 24 * 60 * 60 * 1000;
 
-initSentry();
-
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
+export const handler = async (req: Request, { auth, supabase }: EFContext): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const userId = auth;
+  const { userId } = auth as { type: "user"; userId: string };
 
   try {
-    const supabase = createServiceClient();
-
     const { data: profile, error: profileError } = await withSpan(
       "db.query.user_profiles",
       "db.query",
@@ -91,4 +83,6 @@ Deno.serve(withHandler(async (req) => {
     });
     return errorResponse("Internal server error", 500);
   }
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/user-cancel-deletion/user-cancel-deletion_test.ts
+++ b/supabase/functions/user-cancel-deletion/user-cancel-deletion_test.ts
@@ -7,12 +7,13 @@ import {
   readJson,
   withEnv,
   withMockedFetch,
-  withNoIntervals,
 } from "../_test_utils/mock_http.ts";
 import { authRoute } from "../_test_utils/fixtures.ts";
 
 
 const ENV = {
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "user-cancel-deletion",
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
 };
@@ -38,13 +39,11 @@ Deno.test("인증 없는 요청 → 401", async () => {
 
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
-      await withNoIntervals(async () => {
-        const response = await handler(new Request("http://localhost", { method: "POST" }));
-        const payload = await readJson(response);
+      const response = await handler(new Request("http://localhost", { method: "POST" }));
+      const payload = await readJson(response);
 
-        assertEquals(response.status, 401);
-        assertEquals(payload.error, "Missing or invalid Authorization header");
-      });
+      assertEquals(response.status, 401);
+      assertEquals(payload.error, "Unauthorized");
     });
   });
 });
@@ -61,19 +60,17 @@ Deno.test("유예 기간 중 취소 → deleted_at 복구", async () => {
 
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
-      await withNoIntervals(async () => {
-        const response = await handler(authenticatedJsonRequest("http://localhost", {}));
-        const payload = await readJson(response);
+      const response = await handler(authenticatedJsonRequest("http://localhost", {}));
+      const payload = await readJson(response);
 
-        assertEquals(response.status, 200);
-        assertEquals(payload.success, true);
+      assertEquals(response.status, 200);
+      assertEquals(payload.success, true);
 
-        const restoreCall = calls.find(
-          (call) => call.url.includes("/rest/v1/user_profiles") && call.method === "PATCH",
-        );
-        assertEquals(restoreCall !== undefined, true);
-        assertEquals(JSON.parse(restoreCall!.body ?? "{}").deleted_at, null);
-      });
+      const restoreCall = calls.find(
+        (call) => call.url.includes("/rest/v1/user_profiles") && call.method === "PATCH",
+      );
+      assertEquals(restoreCall !== undefined, true);
+      assertEquals(JSON.parse(restoreCall!.body ?? "{}").deleted_at, null);
     });
   });
 });
@@ -88,13 +85,11 @@ Deno.test("deleted_at 이 null인 유저 → 404", async () => {
 
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
-      await withNoIntervals(async () => {
-        const response = await handler(authenticatedJsonRequest("http://localhost", {}));
-        const payload = await readJson(response);
+      const response = await handler(authenticatedJsonRequest("http://localhost", {}));
+      const payload = await readJson(response);
 
-        assertEquals(response.status, 404);
-        assertEquals(payload.error, "탈퇴 진행 중인 계정이 아닙니다");
-      });
+      assertEquals(response.status, 404);
+      assertEquals(payload.error, "탈퇴 진행 중인 계정이 아닙니다");
     });
   });
 });
@@ -110,18 +105,16 @@ Deno.test("유예 기간 초과 → 400", async () => {
 
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
-      await withNoIntervals(async () => {
-        const response = await handler(authenticatedJsonRequest("http://localhost", {}));
-        const payload = await readJson(response);
+      const response = await handler(authenticatedJsonRequest("http://localhost", {}));
+      const payload = await readJson(response);
 
-        assertEquals(response.status, 400);
-        assertEquals(payload.error, "탈퇴 유예 기간이 만료되었습니다");
+      assertEquals(response.status, 400);
+      assertEquals(payload.error, "탈퇴 유예 기간이 만료되었습니다");
 
-        const restoreCall = calls.find(
-          (call) => call.url.includes("/rest/v1/user_profiles") && call.method === "PATCH",
-        );
-        assertEquals(restoreCall, undefined);
-      });
+      const restoreCall = calls.find(
+        (call) => call.url.includes("/rest/v1/user_profiles") && call.method === "PATCH",
+      );
+      assertEquals(restoreCall, undefined);
     });
   });
 });

--- a/supabase/functions/user-cast-vote/index.ts
+++ b/supabase/functions/user-cast-vote/index.ts
@@ -1,26 +1,15 @@
 // user-cast-vote — Cast a matching vote for a candidate in an event
 // Replaces direct client writes to match_votes (RLS write → EF)
 
-import { createServiceClient } from "../_shared/supabase_client.ts";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { initSentry, withHandler } from "../_shared/logger.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 
-initSentry();
-
-Deno.serve(withHandler(async (req: Request): Promise<Response> => {
-  if (req.method === "OPTIONS") return corsResponse();
-
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const voterId = auth;
-
-  const supabase = createServiceClient();
+export const handler = async (req: Request, { auth, supabase }: EFContext): Promise<Response> => {
+  const { userId: voterId } = auth as { type: "user"; userId: string };
 
   const body = await parseJsonBody(req);
   if (body instanceof Response) return body;
@@ -164,4 +153,6 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
   }
 
   return successResponse({ success: true });
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/user-cast-vote/user_cast_vote_test.ts
+++ b/supabase/functions/user-cast-vote/user_cast_vote_test.ts
@@ -19,6 +19,8 @@ const GROUP_MALE = "group-male";
 const GROUP_FEMALE = "group-female";
 
 const ENV = {
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "user-cast-vote",
   SUPABASE_URL: "http://localhost:54321",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
 };
@@ -138,24 +140,6 @@ function happyPathRoutes(): FetchRoute[] {
     rpcCastVoteRoute(),
   ];
 }
-
-// ─── CORS preflight ───
-Deno.test({
-  name: "handles OPTIONS preflight request",
-  fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-    const { fetchMock } = createFetchMock([]);
-
-    await withEnv(ENV, async () => {
-      await withMockedFetch(fetchMock, async () => {
-        const res = await handler(
-          new Request("http://localhost", { method: "OPTIONS" }),
-        );
-        assertEquals(res.status, 200);
-      });
-    });
-  },
-});
 
 // ─── 401: no auth ───
 Deno.test({

--- a/supabase/functions/user-get-ticket-token/index.ts
+++ b/supabase/functions/user-get-ticket-token/index.ts
@@ -1,19 +1,15 @@
 // user-get-ticket-token/index.ts — Issue a signed ticket token for QR display
 // Fix #1206: QR screen now fetches token from Edge Function if not in local wallet
 
-import { createServiceClient } from "../_shared/supabase_client.ts";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { initSentry, log, withHandler } from "../_shared/logger.ts";
+import { log } from "../_shared/logger.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 
 const FN = "user-get-ticket-token";
-
-initSentry();
 
 function base64UrlEncode(bytes: Uint8Array): string {
   let binary = "";
@@ -23,12 +19,8 @@ function base64UrlEncode(bytes: Uint8Array): string {
   return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
 }
 
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
-
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const authUid = auth;
+export const handler = async (req: Request, { auth, supabase }: EFContext): Promise<Response> => {
+  const { userId: authUid } = auth as { type: "user"; userId: string };
 
   const body = await parseJsonBody(req);
   if (body instanceof Response) return body;
@@ -38,8 +30,6 @@ Deno.serve(withHandler(async (req) => {
   if (!ticket_id) {
     return errorResponse("Missing required parameter: ticket_id", 400);
   }
-
-  const supabase = createServiceClient();
 
   // Verify the user has a paid/approved application for this ticket
   const { data: application, error: appErr } = await supabase
@@ -130,4 +120,6 @@ Deno.serve(withHandler(async (req) => {
     signature,
     expires_at: expiresAt.toISOString(),
   });
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/user-get-ticket-token/user_get_ticket_token_test.ts
+++ b/supabase/functions/user-get-ticket-token/user_get_ticket_token_test.ts
@@ -10,6 +10,8 @@ import {
 } from "../_test_utils/mock_http.ts";
 
 const ENV = {
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "user-get-ticket-token",
   SUPABASE_URL: "http://localhost:54321",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
   // Valid Ed25519 test private key JWK (for testing only — not used in production)
@@ -22,6 +24,8 @@ const ENV = {
 };
 
 const ENV_NO_KEY = {
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "user-get-ticket-token",
   SUPABASE_URL: "http://localhost:54321",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
 };
@@ -187,12 +191,3 @@ Deno.test({
   },
 });
 
-Deno.test({
-  name: "user-get-ticket-token - OPTIONS returns CORS response",
-  fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
-    const response = await handler(new Request(BASE_URL, { method: "OPTIONS" }));
-    assertEquals(response.status, 200);
-  },
-});

--- a/supabase/functions/user-manage-notification/index.ts
+++ b/supabase/functions/user-manage-notification/index.ts
@@ -1,21 +1,12 @@
-import { createServiceClient } from "../_shared/supabase_client.ts";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { parseAction } from "../_shared/request_utils.ts";
-import { initSentry, withHandler } from "../_shared/logger.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 
-initSentry();
-
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
-
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const userId = auth;
+export const handler = async (req: Request, { auth, supabase }: EFContext): Promise<Response> => {
+  const { userId } = auth as { type: "user"; userId: string };
 
   const result = await parseAction(req);
   if (result instanceof Response) return result;
@@ -26,8 +17,6 @@ Deno.serve(withHandler(async (req) => {
   if (!action) {
     return errorResponse("Missing required parameter: action", 400);
   }
-
-  const supabase = createServiceClient();
 
   if (action === "mark_read") {
     if (!notification_id) {
@@ -91,4 +80,6 @@ Deno.serve(withHandler(async (req) => {
   }
 
   return errorResponse(`Unknown action: ${action}`, 400);
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/user-manage-notification/user_manage_notification_test.ts
+++ b/supabase/functions/user-manage-notification/user_manage_notification_test.ts
@@ -5,12 +5,13 @@ import {
   jsonRequest,
   jsonResponse,
   readJson,
-  withNoIntervals,
   withEnv,
   withMockedFetch,
 } from "../_test_utils/mock_http.ts";
 
 const ENV = {
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "user-manage-notification",
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
 };
@@ -40,18 +41,16 @@ Deno.test({
       ]);
 
       await withMockedFetch(fetchMock, async () => {
-        await withNoIntervals(async () => {
-          const request = jsonRequest(
-            "http://localhost",
-            { action: "mark_read", notification_id: "notif-1" },
-            { headers: AUTH_HEADER },
-          );
-          const response = await handler(request);
-          const payload = await readJson(response);
+        const request = jsonRequest(
+          "http://localhost",
+          { action: "mark_read", notification_id: "notif-1" },
+          { headers: AUTH_HEADER },
+        );
+        const response = await handler(request);
+        const payload = await readJson(response);
 
-          assertEquals(response.status, 200);
-          assertEquals(payload.success, true);
-        });
+        assertEquals(response.status, 200);
+        assertEquals(payload.success, true);
       });
     });
   },
@@ -72,18 +71,16 @@ Deno.test({
       ]);
 
       await withMockedFetch(fetchMock, async () => {
-        await withNoIntervals(async () => {
-          const request = jsonRequest(
-            "http://localhost",
-            { action: "mark_read", notification_id: "notif-999" },
-            { headers: AUTH_HEADER },
-          );
-          const response = await handler(request);
-          const payload = await readJson(response);
+        const request = jsonRequest(
+          "http://localhost",
+          { action: "mark_read", notification_id: "notif-999" },
+          { headers: AUTH_HEADER },
+        );
+        const response = await handler(request);
+        const payload = await readJson(response);
 
-          assertEquals(response.status, 404);
-          assertEquals(payload.error, "Notification not found");
-        });
+        assertEquals(response.status, 404);
+        assertEquals(payload.error, "Notification not found");
       });
     });
   },
@@ -97,18 +94,16 @@ Deno.test({
       const { fetchMock } = createFetchMock([mockGetUser()]);
 
       await withMockedFetch(fetchMock, async () => {
-        await withNoIntervals(async () => {
-          const request = jsonRequest(
-            "http://localhost",
-            { action: "mark_read" },
-            { headers: AUTH_HEADER },
-          );
-          const response = await handler(request);
-          const payload = await readJson(response);
+        const request = jsonRequest(
+          "http://localhost",
+          { action: "mark_read" },
+          { headers: AUTH_HEADER },
+        );
+        const response = await handler(request);
+        const payload = await readJson(response);
 
-          assertEquals(response.status, 400);
-          assertEquals(payload.error, "Missing required parameter: notification_id");
-        });
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "Missing required parameter: notification_id");
       });
     });
   },
@@ -129,19 +124,17 @@ Deno.test({
       ]);
 
       await withMockedFetch(fetchMock, async () => {
-        await withNoIntervals(async () => {
-          const request = jsonRequest(
-            "http://localhost",
-            { action: "mark_all_read" },
-            { headers: AUTH_HEADER },
-          );
-          const response = await handler(request);
-          const payload = await readJson(response);
+        const request = jsonRequest(
+          "http://localhost",
+          { action: "mark_all_read" },
+          { headers: AUTH_HEADER },
+        );
+        const response = await handler(request);
+        const payload = await readJson(response);
 
-          assertEquals(response.status, 200);
-          assertEquals(payload.success, true);
-          assertEquals(payload.count, 2);
-        });
+        assertEquals(response.status, 200);
+        assertEquals(payload.success, true);
+        assertEquals(payload.count, 2);
       });
     });
   },
@@ -162,19 +155,17 @@ Deno.test({
       ]);
 
       await withMockedFetch(fetchMock, async () => {
-        await withNoIntervals(async () => {
-          const request = jsonRequest(
-            "http://localhost",
-            { action: "mark_all_read" },
-            { headers: AUTH_HEADER },
-          );
-          const response = await handler(request);
-          const payload = await readJson(response);
+        const request = jsonRequest(
+          "http://localhost",
+          { action: "mark_all_read" },
+          { headers: AUTH_HEADER },
+        );
+        const response = await handler(request);
+        const payload = await readJson(response);
 
-          assertEquals(response.status, 200);
-          assertEquals(payload.success, true);
-          assertEquals(payload.count, 0);
-        });
+        assertEquals(response.status, 200);
+        assertEquals(payload.success, true);
+        assertEquals(payload.count, 0);
       });
     });
   },
@@ -195,18 +186,16 @@ Deno.test({
       ]);
 
       await withMockedFetch(fetchMock, async () => {
-        await withNoIntervals(async () => {
-          const request = jsonRequest(
-            "http://localhost",
-            { action: "delete", notification_id: "notif-1" },
-            { headers: AUTH_HEADER },
-          );
-          const response = await handler(request);
-          const payload = await readJson(response);
+        const request = jsonRequest(
+          "http://localhost",
+          { action: "delete", notification_id: "notif-1" },
+          { headers: AUTH_HEADER },
+        );
+        const response = await handler(request);
+        const payload = await readJson(response);
 
-          assertEquals(response.status, 200);
-          assertEquals(payload.success, true);
-        });
+        assertEquals(response.status, 200);
+        assertEquals(payload.success, true);
       });
     });
   },
@@ -227,18 +216,16 @@ Deno.test({
       ]);
 
       await withMockedFetch(fetchMock, async () => {
-        await withNoIntervals(async () => {
-          const request = jsonRequest(
-            "http://localhost",
-            { action: "delete", notification_id: "notif-999" },
-            { headers: AUTH_HEADER },
-          );
-          const response = await handler(request);
-          const payload = await readJson(response);
+        const request = jsonRequest(
+          "http://localhost",
+          { action: "delete", notification_id: "notif-999" },
+          { headers: AUTH_HEADER },
+        );
+        const response = await handler(request);
+        const payload = await readJson(response);
 
-          assertEquals(response.status, 404);
-          assertEquals(payload.error, "Notification not found");
-        });
+        assertEquals(response.status, 404);
+        assertEquals(payload.error, "Notification not found");
       });
     });
   },
@@ -252,17 +239,15 @@ Deno.test({
       const { fetchMock } = createFetchMock([]);
 
       await withMockedFetch(fetchMock, async () => {
-        await withNoIntervals(async () => {
-          const request = jsonRequest("http://localhost", {
-            action: "mark_read",
-            notification_id: "notif-1",
-          });
-          const response = await handler(request);
-          const payload = await readJson(response);
-
-          assertEquals(response.status, 401);
-          assertEquals(typeof payload.error, "string");
+        const request = jsonRequest("http://localhost", {
+          action: "mark_read",
+          notification_id: "notif-1",
         });
+        const response = await handler(request);
+        const payload = await readJson(response);
+
+        assertEquals(response.status, 401);
+        assertEquals(typeof payload.error, "string");
       });
     });
   },
@@ -276,38 +261,16 @@ Deno.test({
       const { fetchMock } = createFetchMock([mockGetUser()]);
 
       await withMockedFetch(fetchMock, async () => {
-        await withNoIntervals(async () => {
-          const request = jsonRequest(
-            "http://localhost",
-            { action: "invalid_action" },
-            { headers: AUTH_HEADER },
-          );
-          const response = await handler(request);
-          const payload = await readJson(response);
+        const request = jsonRequest(
+          "http://localhost",
+          { action: "invalid_action" },
+          { headers: AUTH_HEADER },
+        );
+        const response = await handler(request);
+        const payload = await readJson(response);
 
-          assertEquals(response.status, 400);
-          assertEquals(payload.error, "Unknown action: invalid_action");
-        });
-      });
-    });
-  },
-});
-
-Deno.test({
-  name: "user-manage-notification - OPTIONS returns CORS response",
-  fn: async () => {
-    await withEnv(ENV, async () => {
-      const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-      const { fetchMock } = createFetchMock([]);
-
-      await withMockedFetch(fetchMock, async () => {
-        await withNoIntervals(async () => {
-          const request = new Request("http://localhost", { method: "OPTIONS" });
-          const response = await handler(request);
-
-          assertEquals(response.status, 200);
-          assertEquals(response.headers.get("Access-Control-Allow-Origin"), "*");
-        });
+        assertEquals(response.status, 400);
+        assertEquals(payload.error, "Unknown action: invalid_action");
       });
     });
   },

--- a/supabase/functions/user-manage-social/index.ts
+++ b/supabase/functions/user-manage-social/index.ts
@@ -1,17 +1,12 @@
 // user-manage-social — Manage social interactions (like, block, report)
 // Replaces direct client writes to social_interactions + report_details
 
-import { createServiceClient } from "../_shared/supabase_client.ts";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { parseAction } from "../_shared/request_utils.ts";
-import { initSentry, withHandler } from "../_shared/logger.ts";
-
-initSentry();
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 
 const VALID_INTERACTION_TYPES = ["like", "dislike", "subscribe", "bookmark"];
 const VALID_TARGET_TYPES = ["party", "partner", "review", "comment"];
@@ -23,14 +18,8 @@ const VALID_REPORT_REASONS = [
   "other",
 ];
 
-Deno.serve(withHandler(async (req: Request): Promise<Response> => {
-  if (req.method === "OPTIONS") return corsResponse();
-
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const userId = auth;
-
-  const supabase = createServiceClient();
+export const handler = async (req: Request, { auth, supabase }: EFContext): Promise<Response> => {
+  const { userId } = auth as { type: "user"; userId: string };
 
   const result = await parseAction(req);
   if (result instanceof Response) return result;
@@ -181,4 +170,6 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
   }
 
   return errorResponse(`Unknown action: ${action}`, 400);
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/user-manage-social/user_manage_social_test.ts
+++ b/supabase/functions/user-manage-social/user_manage_social_test.ts
@@ -12,6 +12,8 @@ import {
 const TEST_USER_ID = "user-111";
 const TEST_TARGET_ID = "partner-222";
 const ENV = {
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "user-manage-social",
   SUPABASE_URL: "http://localhost:54321",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
 };
@@ -300,12 +302,3 @@ Deno.test({
   },
 });
 
-Deno.test({
-  name: "returns CORS headers for OPTIONS",
-  fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-    const res = await handler(new Request("http://localhost", { method: "OPTIONS" }));
-    assertEquals(res.status, 200);
-    assertEquals(res.headers.get("Access-Control-Allow-Origin"), "*");
-  },
-});


### PR DESCRIPTION
## Summary

Batch 3 of EF migration epic #2185 — migrates 6 user-caller edge functions to the `minglitEdgeFunction` wrapper.

**Note**: Built on `feat/2185-ef-migration-batch2` (PR #2305). Will rebase on `dev` after batches 1+2 merge.

### Migrated Functions

| Function | Caller | Description |
|---|---|---|
| `settlement-query` | user | PortOne 정산/지급 내역 조회 |
| `user-cancel-deletion` | user | 탈퇴 유예 기간 중 취소 |
| `user-cast-vote` | user | 이벤트 매칭 투표 |
| `user-manage-notification` | user | 알림 읽음/삭제 |
| `user-manage-social` | user | 소셜 인터랙션 (좋아요, 차단, 신고) |
| `user-get-ticket-token` | user | QR 코드용 서명된 티켓 토큰 발급 |

### Changes Per Function

- `index.ts`: removed `createServiceClient`, `requireAuth`, `corsResponse`, `initSentry`, `withHandler` → added `minglitEdgeFunction` + `EFContext`
- `userId` extracted from `auth` as `{ type: "user"; userId: string }` (manifest guarantees user-only callers)
- Tests: added `ENVIRONMENT: "dev"` and `MINGLIT_EF_TEST_FN_NAME`, removed `withNoIntervals`, removed OPTIONS tests (wrapper handles preflight)

### auth-manifest.json

Added 6 new user-caller entries.

Closes #2185