### PR TITLE
fix(ci): skip CodeRabbit wait for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,8 +531,8 @@ jobs:
           fi
           echo "✅ CI jobs passed"
 
-          # 2. Wait for CodeRabbit review (PR only)
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          # 2. Wait for CodeRabbit review (PR only, skip for dependabot)
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.actor }}" != "dependabot[bot]" ]; then
             SHA="${{ github.event.pull_request.head.sha }}"
             echo ""
             echo "Waiting for CodeRabbit review on $SHA ..."


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 요약

dependabot PRs (#2048, #2133, #2134)의 `ci-result`가 매번 30분 타임아웃으로 실패하는 근본 원인을 수정합니다.

## 근본 원인

`ci-result` job이 CodeRabbit의 commit status를 기다리는데, CodeRabbit은 `dependabot[bot]`이 생성한 PR에는 commit status를 posting하지 않습니다.

```bash
STATE=$(gh api repos/.../commits/$SHA/status \
  --jq '[.statuses[] | select(.context=="CodeRabbit") | .state][0] // ""')
# dependabot PR에서는 항상 "" (empty) → 30분 후 timeout
```

## 수정 내용

`dependabot[bot]` actor가 연 PR에서는 CodeRabbit 대기 루프를 건너뜁니다:

```diff
-if [ "${{ github.event_name }}" = "pull_request" ]; then
+if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.actor }}" != "dependabot[bot]" ]; then
```

CodeRabbit은 사람이 작성한 PR은 그대로 리뷰합니다. dependabot PR은 `onlyhyeok-cmd`가 수동 검토합니다.

## 영향

- dependabot PR CI: `ci-result` 30분 대기 제거 → CI 통과 속도 대폭 향상
- 사람 작성 PR: 변경 없음 (CodeRabbit 리뷰 대기 유지)

Closes #2149