### PR TITLE
feat(edge-functions): migrate batch-4 EFs to minglitEdgeFunction wrapper

### DIFF
--- a/supabase/functions/auth-manifest.json
+++ b/supabase/functions/auth-manifest.json
@@ -125,6 +125,31 @@
         "ips": ["52.78.100.19", "52.78.48.223", "52.78.17.128"]
       },
       "description": "PortOne V1 결제 웹훅 수신"
+    },
+    "user-manage-settings": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "FCM 토큰 및 사용자 설정 관리 — upsert/delete_token, update_settings (Fix #2040)"
+    },
+    "partner-reject-application": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "파트너 신청 거절 — 단건, compare-and-set 상태 보호 (Issue #517)"
+    },
+    "partner-approve-application": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "파트너 신청 승인 — 단건/일괄, DB 용량 가드 포함 (Fix #1219)"
+    },
+    "partner-manage-party": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "파티/장소/템플릿 CRUD — create/update/update_status (Issue #316)"
+    },
+    "partner-register": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "파트너 신청 — save_draft/submit/update, 서버사이드 검증 포함 (Issue #311)"
     }
   }
 }

--- a/supabase/functions/partner-approve-application/index.ts
+++ b/supabase/functions/partner-approve-application/index.ts
@@ -1,65 +1,30 @@
 // partner-approve-application — Approve event applications (single + bulk)
 // Issue #517: 파트너 대시보드 리디자인 — 신청 승인 API
 
-import { createServiceClient } from "../_shared/supabase_client.ts";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
 import { parseAction } from "../_shared/request_utils.ts";
-import { initSentry, withHandler, log } from "../_shared/logger.ts";
-
-const FN = "partner-approve-application";
-
-initSentry();
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 // Fix #1219: keep approval status filtering aligned with the capacity guard paths.
 const APPROVABLE_STATUSES = ["pending", "pending_review"] as const;
 
-Deno.serve(withHandler(async (req: Request): Promise<Response> => {
-  if (req.method === "OPTIONS") return corsResponse();
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
-  try {
-    return await handleRequest(req);
-  } catch (e) {
-    const detail = e instanceof Error ? e.message : String(e);
-    log({
-      function: FN,
-      level: "error",
-      message: "partner-approve-application error",
-      metadata: { detail },
-    });
-    const env = Deno.env.get("ENVIRONMENT");
-    const exposeDetail = env === "local" || env === "development";
-    return errorResponse(
-      exposeDetail ? `${FN}: ${detail}` : "Internal server error",
-      500,
-    );
-  }
-}));
+  const { supabase } = ctx;
+  // wrapper guarantees type === "user" per auth-manifest callers: ["user"]
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
 
-async function handleRequest(req: Request): Promise<Response> {
-  // 1. Auth
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const userId = auth;
-
-  // 2. Parse body
   const result = await parseAction(req);
   if (result instanceof Response) return result;
   const { action, body } = result;
-  if (!action) {
-    return errorResponse("Missing action", 400);
-  }
-
-  const supabase = createServiceClient();
 
   // ─── approve (single) ───
   if (action === "approve") {
@@ -72,7 +37,7 @@ async function handleRequest(req: Request): Promise<Response> {
   }
 
   return errorResponse(`Unknown action: ${action}`, 400);
-}
+};
 
 // ── Single approve ──
 async function handleApprove(
@@ -226,3 +191,5 @@ async function handleBulkApprove(
     remaining_slots_before_approval: remainingSlotsBeforeApproval,
   });
 }
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/partner-approve-application/partner_approve_application_test.ts
+++ b/supabase/functions/partner-approve-application/partner_approve_application_test.ts
@@ -3,11 +3,12 @@ import {
   authenticatedJsonRequest,
   captureServeHandler,
   createFetchMock,
+  type FetchRoute,
   jsonResponse,
   readJson,
   withEnv,
   withMockedFetch,
-  type FetchRoute,
+  withNoIntervals,
 } from "../_test_utils/mock_http.ts";
 
 const TEST_USER_ID = "user-partner-owner";
@@ -18,6 +19,8 @@ const TEST_EVENT_ID = "00000000-0000-1000-8000-000000000002";
 const ENV = {
   SUPABASE_URL: "http://localhost:54321",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "partner-approve-application",
 };
 
 const BASE_URL = "http://localhost:54321/functions/v1/partner-approve-application";
@@ -165,36 +168,54 @@ function bulkApproveRpcRoute(
 Deno.test({
   name: "OPTIONS returns CORS preflight",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-    const req = new Request(BASE_URL, { method: "OPTIONS" });
-    const res = await handler(req);
-    assertEquals(res.status, 200);
+    const { fetchMock } = createFetchMock([]);
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const res = await handler(new Request(BASE_URL, { method: "OPTIONS" }));
+          assertEquals(res.status, 200);
+        });
+      });
+    });
   },
 });
 
 Deno.test({
-  name: "GET returns 405",
+  name: "GET returns 405 (requires auth — wrapper checks auth before handler checks method)",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-    const req = new Request(BASE_URL, { method: "GET" });
-    const res = await handler(req);
-    assertEquals(res.status, 405);
+    const { fetchMock } = createFetchMock([authRoute()]);
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const res = await handler(
+            new Request(BASE_URL, {
+              method: "GET",
+              headers: { Authorization: "Bearer user-token" },
+            }),
+          );
+          assertEquals(res.status, 405);
+        });
+      });
+    });
   },
 });
 
 Deno.test({
   name: "Missing action returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const req = authenticatedJsonRequest(BASE_URL, {});
-        const res = await handler(req);
-        assertEquals(res.status, 400);
-        const json = await readJson(res);
-        assertEquals(json.error, "Missing or invalid \"action\" field");
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const req = authenticatedJsonRequest(BASE_URL, {});
+          const res = await handler(req);
+          assertEquals(res.status, 400);
+          const json = await readJson(res);
+          assertEquals(json.error, 'Missing or invalid "action" field');
+        });
       });
     });
   },
@@ -203,24 +224,25 @@ Deno.test({
 Deno.test({
   name: "approve: single approve success returns 200 with approved:1",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
       appRoute("pending"),
       permRoute("owner"),
       approveRpcRoute(),
     ]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const req = authenticatedJsonRequest(BASE_URL, {
-          action: "approve",
-          application_id: TEST_APP_ID,
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const req = authenticatedJsonRequest(BASE_URL, {
+            action: "approve",
+            application_id: TEST_APP_ID,
+          });
+          const res = await handler(req);
+          assertEquals(res.status, 200);
+          const json = await readJson(res);
+          assertEquals(json.approved, 1);
         });
-        const res = await handler(req);
-        assertEquals(res.status, 200);
-        const json = await readJson(res);
-        assertEquals(json.approved, 1);
       });
     });
   },
@@ -229,20 +251,21 @@ Deno.test({
 Deno.test({
   name: "approve: application not found returns 404",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
       appNotFoundRoute(),
     ]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const req = authenticatedJsonRequest(BASE_URL, {
-          action: "approve",
-          application_id: "00000000-0000-1000-8000-999999999999",
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const req = authenticatedJsonRequest(BASE_URL, {
+            action: "approve",
+            application_id: "00000000-0000-1000-8000-999999999999",
+          });
+          const res = await handler(req);
+          assertEquals(res.status, 404);
         });
-        const res = await handler(req);
-        assertEquals(res.status, 404);
       });
     });
   },
@@ -251,21 +274,22 @@ Deno.test({
 Deno.test({
   name: "approve: already approved status returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
       appRoute("approved"),
       permRoute("owner"),
     ]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const req = authenticatedJsonRequest(BASE_URL, {
-          action: "approve",
-          application_id: TEST_APP_ID,
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const req = authenticatedJsonRequest(BASE_URL, {
+            action: "approve",
+            application_id: TEST_APP_ID,
+          });
+          const res = await handler(req);
+          assertEquals(res.status, 400);
         });
-        const res = await handler(req);
-        assertEquals(res.status, 400);
       });
     });
   },
@@ -274,17 +298,18 @@ Deno.test({
 Deno.test({
   name: "approve: unauthorized (no auth) returns 401",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authFailRoute()]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const req = authenticatedJsonRequest(BASE_URL, {
-          action: "approve",
-          application_id: TEST_APP_ID,
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const req = authenticatedJsonRequest(BASE_URL, {
+            action: "approve",
+            application_id: TEST_APP_ID,
+          });
+          const res = await handler(req);
+          assertEquals(res.status, 401);
         });
-        const res = await handler(req);
-        assertEquals(res.status, 401);
       });
     });
   },
@@ -293,21 +318,22 @@ Deno.test({
 Deno.test({
   name: "approve: forbidden (insufficient permissions) returns 403",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
       appRoute("pending"),
       permForbiddenRoute(),
     ]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const req = authenticatedJsonRequest(BASE_URL, {
-          action: "approve",
-          application_id: TEST_APP_ID,
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const req = authenticatedJsonRequest(BASE_URL, {
+            action: "approve",
+            application_id: TEST_APP_ID,
+          });
+          const res = await handler(req);
+          assertEquals(res.status, 403);
         });
-        const res = await handler(req);
-        assertEquals(res.status, 403);
       });
     });
   },
@@ -316,7 +342,6 @@ Deno.test({
 Deno.test({
   name: "approve: owner role bypasses permissions check returns 200",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
       appRoute("pending"),
@@ -327,17 +352,19 @@ Deno.test({
       },
       approveRpcRoute(),
     ]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const req = authenticatedJsonRequest(BASE_URL, {
-          action: "approve",
-          application_id: TEST_APP_ID,
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const req = authenticatedJsonRequest(BASE_URL, {
+            action: "approve",
+            application_id: TEST_APP_ID,
+          });
+          const res = await handler(req);
+          assertEquals(res.status, 200);
+          const json = await readJson(res);
+          assertEquals(json.approved, 1);
         });
-        const res = await handler(req);
-        assertEquals(res.status, 200);
-        const json = await readJson(res);
-        assertEquals(json.approved, 1);
       });
     });
   },
@@ -346,22 +373,23 @@ Deno.test({
 Deno.test({
   name: "approve: already processed (compare-and-set returns empty) returns 409",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
       appRoute("pending"),
       permRoute("owner"),
       approveRpcRoute("already_processed", 0),
     ]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const req = authenticatedJsonRequest(BASE_URL, {
-          action: "approve",
-          application_id: TEST_APP_ID,
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const req = authenticatedJsonRequest(BASE_URL, {
+            action: "approve",
+            application_id: TEST_APP_ID,
+          });
+          const res = await handler(req);
+          assertEquals(res.status, 409);
         });
-        const res = await handler(req);
-        assertEquals(res.status, 409);
       });
     });
   },
@@ -370,24 +398,25 @@ Deno.test({
 Deno.test({
   name: "approve: returns 409 when event is already full",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
       appRoute("pending"),
       permRoute("owner"),
       approveRpcRoute("event_full", 0),
     ]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const req = authenticatedJsonRequest(BASE_URL, {
-          action: "approve",
-          application_id: TEST_APP_ID,
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const req = authenticatedJsonRequest(BASE_URL, {
+            action: "approve",
+            application_id: TEST_APP_ID,
+          });
+          const res = await handler(req);
+          assertEquals(res.status, 409);
+          const json = await readJson(res);
+          assertEquals(json.error, "정원이 초과되었습니다.");
         });
-        const res = await handler(req);
-        assertEquals(res.status, 409);
-        const json = await readJson(res);
-        assertEquals(json.error, "정원이 초과되었습니다.");
       });
     });
   },
@@ -396,24 +425,25 @@ Deno.test({
 Deno.test({
   name: "approve: returns 500 when capacity data is invalid",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
       appRoute("pending"),
       permRoute("owner"),
       approveRpcRoute("invalid_capacity", 0),
     ]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const req = authenticatedJsonRequest(BASE_URL, {
-          action: "approve",
-          application_id: TEST_APP_ID,
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const req = authenticatedJsonRequest(BASE_URL, {
+            action: "approve",
+            application_id: TEST_APP_ID,
+          });
+          const res = await handler(req);
+          assertEquals(res.status, 500);
+          const json = await readJson(res);
+          assertEquals(json.error, "Event capacity data is invalid");
         });
-        const res = await handler(req);
-        assertEquals(res.status, 500);
-        const json = await readJson(res);
-        assertEquals(json.error, "Event capacity data is invalid");
       });
     });
   },
@@ -422,24 +452,25 @@ Deno.test({
 Deno.test({
   name: "bulk_approve: success returns 200 with approved count",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
       eventRoute(),
       permRoute("owner"),
       bulkApproveRpcRoute(),
     ]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const req = authenticatedJsonRequest(BASE_URL, {
-          action: "bulk_approve",
-          event_id: TEST_EVENT_ID,
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const req = authenticatedJsonRequest(BASE_URL, {
+            action: "bulk_approve",
+            event_id: TEST_EVENT_ID,
+          });
+          const res = await handler(req);
+          assertEquals(res.status, 200);
+          const json = await readJson(res);
+          assertEquals(json.approved, 2);
         });
-        const res = await handler(req);
-        assertEquals(res.status, 200);
-        const json = await readJson(res);
-        assertEquals(json.approved, 2);
       });
     });
   },
@@ -448,7 +479,6 @@ Deno.test({
 Deno.test({
   name: "bulk_approve: only approves up to remaining capacity",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
       eventRoute(),
@@ -459,19 +489,21 @@ Deno.test({
         remainingSlotsBeforeApproval: 2,
       }),
     ]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const req = authenticatedJsonRequest(BASE_URL, {
-          action: "bulk_approve",
-          event_id: TEST_EVENT_ID,
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const req = authenticatedJsonRequest(BASE_URL, {
+            action: "bulk_approve",
+            event_id: TEST_EVENT_ID,
+          });
+          const res = await handler(req);
+          assertEquals(res.status, 200);
+          const json = await readJson(res);
+          assertEquals(json.approved, 2);
+          assertEquals(json.skipped_due_to_capacity, 1);
+          assertEquals(json.remaining_slots_before_approval, 2);
         });
-        const res = await handler(req);
-        assertEquals(res.status, 200);
-        const json = await readJson(res);
-        assertEquals(json.approved, 2);
-        assertEquals(json.skipped_due_to_capacity, 1);
-        assertEquals(json.remaining_slots_before_approval, 2);
       });
     });
   },
@@ -480,7 +512,6 @@ Deno.test({
 Deno.test({
   name: "bulk_approve: returns 500 when capacity data is invalid",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
       eventRoute(),
@@ -492,17 +523,19 @@ Deno.test({
         remainingSlotsBeforeApproval: 0,
       }),
     ]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const req = authenticatedJsonRequest(BASE_URL, {
-          action: "bulk_approve",
-          event_id: TEST_EVENT_ID,
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const req = authenticatedJsonRequest(BASE_URL, {
+            action: "bulk_approve",
+            event_id: TEST_EVENT_ID,
+          });
+          const res = await handler(req);
+          assertEquals(res.status, 500);
+          const json = await readJson(res);
+          assertEquals(json.error, "Event capacity data is invalid");
         });
-        const res = await handler(req);
-        assertEquals(res.status, 500);
-        const json = await readJson(res);
-        assertEquals(json.error, "Event capacity data is invalid");
       });
     });
   },
@@ -511,7 +544,6 @@ Deno.test({
 Deno.test({
   name: "bulk_approve: no pending apps returns 200 with approved:0",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
       eventRoute(),
@@ -523,17 +555,19 @@ Deno.test({
         remainingSlotsBeforeApproval: 15,
       }),
     ]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const req = authenticatedJsonRequest(BASE_URL, {
-          action: "bulk_approve",
-          event_id: TEST_EVENT_ID,
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const req = authenticatedJsonRequest(BASE_URL, {
+            action: "bulk_approve",
+            event_id: TEST_EVENT_ID,
+          });
+          const res = await handler(req);
+          assertEquals(res.status, 200);
+          const json = await readJson(res);
+          assertEquals(json.approved, 0);
         });
-        const res = await handler(req);
-        assertEquals(res.status, 200);
-        const json = await readJson(res);
-        assertEquals(json.approved, 0);
       });
     });
   },

--- a/supabase/functions/partner-manage-party/index.ts
+++ b/supabase/functions/partner-manage-party/index.ts
@@ -1,20 +1,15 @@
 // partner-manage-party — Party/location/template CRUD for partners
 // Issue #316: RLS write strategy 전환
 
-import { createServiceClient } from "../_shared/supabase_client.ts";
 import {
-  corsResponse,
   errorResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { parseAction } from "../_shared/request_utils.ts";
-import { initSentry, withHandler } from "../_shared/logger.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { handleCreate } from "./_handlers/create.ts";
 import { handleUpdate } from "./_handlers/update.ts";
 import { handleUpdateStatus } from "./_handlers/update_status.ts";
-
-initSentry();
 
 type ActionHandler = (
   body: Record<string, unknown>,
@@ -28,26 +23,20 @@ const DISPATCH: Record<string, ActionHandler> = {
   update_status: handleUpdateStatus,
 };
 
-Deno.serve(withHandler(async (req: Request): Promise<Response> => {
-  if (req.method === "OPTIONS") return corsResponse();
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
-  try {
-    const auth = await requireAuth(req);
-    if (auth instanceof Response) return auth;
-    const userId = auth;
+  const { supabase } = ctx;
+  // wrapper guarantees type === "user" per auth-manifest callers: ["user"]
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
 
-    const result = await parseAction(req);
-    if (result instanceof Response) return result;
-    const { action, body } = result;
-    if (!action) return errorResponse("Missing action", 400);
+  const result = await parseAction(req);
+  if (result instanceof Response) return result;
+  const { action, body } = result;
 
-    const supabase = createServiceClient();
-    const handler = DISPATCH[action];
-    if (!handler) return errorResponse(`Unknown action: ${action}`, 400);
-    return handler(body, supabase, userId);
-  } catch (e) {
-    const message = e instanceof Error ? e.message : String(e);
-    return errorResponse(message, 500);
-  }
-}));
+  const actionHandler = DISPATCH[action];
+  if (!actionHandler) return errorResponse(`Unknown action: ${action}`, 400);
+  return actionHandler(body, supabase, userId);
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/partner-manage-party/partner_manage_party_test.ts
+++ b/supabase/functions/partner-manage-party/partner_manage_party_test.ts
@@ -9,6 +9,7 @@ import {
   readJson,
   withEnv,
   withMockedFetch,
+  withNoIntervals,
 } from "../_test_utils/mock_http.ts";
 
 const TEST_USER_ID = "user-partner-owner";
@@ -19,6 +20,8 @@ const TEST_LOCATION_ID = "loc-001";
 const ENV = {
   SUPABASE_URL: "http://localhost:54321",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "partner-manage-party",
 };
 
 // ─── Route helpers ───
@@ -253,24 +256,41 @@ function insertTicketTemplatesRoute(): FetchRoute {
 Deno.test({
   name: "OPTIONS returns CORS preflight",
   fn: async () => {
-    const handler = await captureServeHandler(
-      new URL("./index.ts", import.meta.url),
-    );
-    const req = new Request("http://localhost", { method: "OPTIONS" });
-    const res = await handler(req);
-    assertEquals(res.status, 200);
+    const { fetchMock } = createFetchMock([]);
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
+          const req = new Request("http://localhost", { method: "OPTIONS" });
+          const res = await handler(req);
+          assertEquals(res.status, 200);
+        });
+      });
+    });
   },
 });
 
 Deno.test({
-  name: "GET returns 405",
+  name: "GET returns 405 (requires auth — wrapper checks auth before handler checks method)",
   fn: async () => {
-    const handler = await captureServeHandler(
-      new URL("./index.ts", import.meta.url),
-    );
-    const req = new Request("http://localhost", { method: "GET" });
-    const res = await handler(req);
-    assertEquals(res.status, 405);
+    const { fetchMock } = createFetchMock([authRoute()]);
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
+          const req = new Request("http://localhost", {
+            method: "GET",
+            headers: { Authorization: "Bearer user-token" },
+          });
+          const res = await handler(req);
+          assertEquals(res.status, 405);
+        });
+      });
+    });
   },
 });
 

--- a/supabase/functions/partner-register/index.ts
+++ b/supabase/functions/partner-register/index.ts
@@ -1,17 +1,12 @@
 // partner-register — Partner application (save draft, submit, update)
 // Issue #311: RLS write strategy 전환
 
-import { createServiceClient } from "../_shared/supabase_client.ts";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { parseAction } from "../_shared/request_utils.ts";
-import { initSentry, withHandler } from "../_shared/logger.ts";
-
-initSentry();
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import {
   requireNonEmpty,
   validateBizNumber,
@@ -50,34 +45,16 @@ const CLEARABLE_FIELDS: ReadonlySet<string> = new Set([
   "profile_image_path",
 ]);
 
-Deno.serve(withHandler(async (req: Request): Promise<Response> => {
-  if (req.method === "OPTIONS") return corsResponse();
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
-  try {
-    return await handleRequest(req);
-  } catch (e) {
-    const message = e instanceof Error ? e.message : String(e);
-    return errorResponse(message, 500);
-  }
-}));
+  const { supabase } = ctx;
+  // wrapper guarantees type === "user" per auth-manifest callers: ["user"]
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
 
-async function handleRequest(req: Request): Promise<Response> {
-  // 1. Environment check (handled by createServiceClient)
-
-  // 2. Auth
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const userId = auth;
-
-  // 3. Parse body
   const result = await parseAction(req);
   if (result instanceof Response) return result;
   const { action, body } = result;
-  if (!action) return errorResponse("Missing action", 400);
-
-  // 4. Supabase client (service role)
-  const supabase = createServiceClient();
 
   // ─── save_draft ───
   if (action === "save_draft") {
@@ -120,7 +97,7 @@ async function handleRequest(req: Request): Promise<Response> {
       }
 
       // Fix #311: 상태 조건을 UPDATE WHERE에 포함하여 원자적 검사
-      const { error: updateError, count: _count } = await supabase
+      const { error: updateError } = await supabase
         .from("partner_applications")
         .update(record)
         .eq("id", applicationId)
@@ -353,4 +330,6 @@ async function handleRequest(req: Request): Promise<Response> {
   }
 
   return errorResponse(`Unknown action: ${action}`, 400);
-}
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/partner-register/partner_register_test.ts
+++ b/supabase/functions/partner-register/partner_register_test.ts
@@ -17,6 +17,8 @@ const TEST_APP_ID = "app-001";
 const ENV = {
   SUPABASE_URL: "http://localhost:54321",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "partner-register",
 };
 
 // Valid complete application data for submit tests

--- a/supabase/functions/partner-reject-application/index.ts
+++ b/supabase/functions/partner-reject-application/index.ts
@@ -1,52 +1,26 @@
 // partner-reject-application — Reject event applications with reason
 // Issue #517: 파트너 대시보드 리디자인 — 신청 거절 API
 
-import { createServiceClient } from "../_shared/supabase_client.ts";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { initSentry, withHandler, log } from "../_shared/logger.ts";
-
-const FN = "partner-reject-application";
-
-initSentry();
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-Deno.serve(withHandler(async (req: Request): Promise<Response> => {
-  if (req.method === "OPTIONS") return corsResponse();
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
-  try {
-    return await handleRequest(req);
-  } catch (e) {
-    log({
-      function: FN,
-      level: "error",
-      message: "partner-reject-application error",
-      metadata: { detail: e instanceof Error ? e.message : String(e) },
-    });
-    return errorResponse("Internal server error", 500);
-  }
-}));
+  const { supabase } = ctx;
+  // wrapper guarantees type === "user" per auth-manifest callers: ["user"]
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
 
-async function handleRequest(req: Request): Promise<Response> {
-  // 1. Auth
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const userId = auth;
-
-  // 2. Parse body
   const body = await parseJsonBody(req);
   if (body instanceof Response) return body;
-
-  const supabase = createServiceClient();
 
   const applicationId = body.application_id;
   if (typeof applicationId !== "string" || !applicationId) {
@@ -110,4 +84,6 @@ async function handleRequest(req: Request): Promise<Response> {
     rejected: 1,
     application_id: applicationId,
   });
-}
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/partner-reject-application/partner_reject_application_test.ts
+++ b/supabase/functions/partner-reject-application/partner_reject_application_test.ts
@@ -7,6 +7,7 @@ import {
   readJson,
   withEnv,
   withMockedFetch,
+  withNoIntervals,
   type FetchRoute,
 } from "../_test_utils/mock_http.ts";
 
@@ -18,6 +19,8 @@ const TEST_EVENT_ID = "00000000-0000-1000-8000-000000000002";
 const ENV = {
   SUPABASE_URL: "http://localhost:54321",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "partner-reject-application",
 };
 
 const BASE_URL = "http://localhost:54321/functions/v1/partner-reject-application";
@@ -102,29 +105,36 @@ function updateRoute(updated = [{ id: TEST_APP_ID }]): FetchRoute {
 Deno.test({
   name: "OPTIONS returns CORS",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const res = await handler(new Request(BASE_URL, { method: "OPTIONS" }));
-        assertEquals(res.status, 200);
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const res = await handler(new Request(BASE_URL, { method: "OPTIONS" }));
+          assertEquals(res.status, 200);
+        });
       });
     });
   },
 });
 
-// ─── GET: 405 ───
+// ─── GET: 405 (requires auth — wrapper checks auth before handler checks method) ───
 Deno.test({
   name: "GET returns 405",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-    const { fetchMock } = createFetchMock([]);
-
+    const { fetchMock } = createFetchMock([authRoute()]);
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const res = await handler(new Request(BASE_URL, { method: "GET" }));
-        assertEquals(res.status, 405);
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const res = await handler(
+            new Request(BASE_URL, {
+              method: "GET",
+              headers: { Authorization: "Bearer user-token" },
+            }),
+          );
+          assertEquals(res.status, 405);
+        });
       });
     });
   },
@@ -134,17 +144,18 @@ Deno.test({
 Deno.test({
   name: "Missing application_id returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const res = await handler(
-          authenticatedJsonRequest(BASE_URL, { reason: "Not a good fit" }),
-        );
-        assertEquals(res.status, 400);
-        const json = await readJson(res);
-        assertEquals(json.error, "Missing application_id");
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const res = await handler(
+            authenticatedJsonRequest(BASE_URL, { reason: "Not a good fit" }),
+          );
+          assertEquals(res.status, 400);
+          const json = await readJson(res);
+          assertEquals(json.error, "Missing application_id");
+        });
       });
     });
   },
@@ -154,17 +165,18 @@ Deno.test({
 Deno.test({
   name: "Missing reason returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authRoute()]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const res = await handler(
-          authenticatedJsonRequest(BASE_URL, { application_id: TEST_APP_ID }),
-        );
-        assertEquals(res.status, 400);
-        const json = await readJson(res);
-        assertEquals(json.error, "Missing or empty rejection reason");
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const res = await handler(
+            authenticatedJsonRequest(BASE_URL, { application_id: TEST_APP_ID }),
+          );
+          assertEquals(res.status, 400);
+          const json = await readJson(res);
+          assertEquals(json.error, "Missing or empty rejection reason");
+        });
       });
     });
   },
@@ -174,25 +186,26 @@ Deno.test({
 Deno.test({
   name: "Reject success returns 200 with rejected count",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
       appRoute("pending"),
       permRoute(),
       updateRoute(),
     ]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const res = await handler(
-          authenticatedJsonRequest(BASE_URL, {
-            application_id: TEST_APP_ID,
-            reason: "Not a good fit",
-          }),
-        );
-        assertEquals(res.status, 200);
-        const json = await readJson(res);
-        assertEquals(json.rejected, 1);
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const res = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              application_id: TEST_APP_ID,
+              reason: "Not a good fit",
+            }),
+          );
+          assertEquals(res.status, 200);
+          const json = await readJson(res);
+          assertEquals(json.rejected, 1);
+        });
       });
     });
   },
@@ -202,23 +215,24 @@ Deno.test({
 Deno.test({
   name: "Application not found returns 404",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
       appNotFoundRoute(),
     ]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const res = await handler(
-          authenticatedJsonRequest(BASE_URL, {
-            application_id: "00000000-0000-1000-8000-999999999999",
-            reason: "Not a good fit",
-          }),
-        );
-        assertEquals(res.status, 404);
-        const json = await readJson(res);
-        assertEquals(json.error, "Application not found");
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const res = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              application_id: "00000000-0000-1000-8000-999999999999",
+              reason: "Not a good fit",
+            }),
+          );
+          assertEquals(res.status, 404);
+          const json = await readJson(res);
+          assertEquals(json.error, "Application not found");
+        });
       });
     });
   },
@@ -228,24 +242,24 @@ Deno.test({
 Deno.test({
   name: "Already rejected status returns 400",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
       appRoute("rejected"),
-      permRoute("owner"),
     ]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const res = await handler(
-          authenticatedJsonRequest(BASE_URL, {
-            application_id: TEST_APP_ID,
-            reason: "Not a good fit",
-          }),
-        );
-        assertEquals(res.status, 400);
-        const json = await readJson(res);
-        assertEquals(json.error, "Cannot reject application with status 'rejected'");
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const res = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              application_id: TEST_APP_ID,
+              reason: "Not a good fit",
+            }),
+          );
+          assertEquals(res.status, 400);
+          const json = await readJson(res);
+          assertEquals(json.error, "Cannot reject application with status 'rejected'");
+        });
       });
     });
   },
@@ -255,18 +269,19 @@ Deno.test({
 Deno.test({
   name: "Unauthorized returns 401",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([authFailRoute()]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const res = await handler(
-          authenticatedJsonRequest(BASE_URL, {
-            application_id: TEST_APP_ID,
-            reason: "Not a good fit",
-          }),
-        );
-        assertEquals(res.status, 401);
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const res = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              application_id: TEST_APP_ID,
+              reason: "Not a good fit",
+            }),
+          );
+          assertEquals(res.status, 401);
+        });
       });
     });
   },
@@ -276,24 +291,25 @@ Deno.test({
 Deno.test({
   name: "Forbidden (insufficient permissions) returns 403",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
       appRoute("pending"),
       permForbiddenRoute(),
     ]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const res = await handler(
-          authenticatedJsonRequest(BASE_URL, {
-            application_id: TEST_APP_ID,
-            reason: "Not a good fit",
-          }),
-        );
-        assertEquals(res.status, 403);
-        const json = await readJson(res);
-        assertEquals(json.error, "Forbidden: insufficient partner permissions");
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const res = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              application_id: TEST_APP_ID,
+              reason: "Not a good fit",
+            }),
+          );
+          assertEquals(res.status, 403);
+          const json = await readJson(res);
+          assertEquals(json.error, "Forbidden: insufficient partner permissions");
+        });
       });
     });
   },
@@ -303,7 +319,6 @@ Deno.test({
 Deno.test({
   name: "Owner role bypasses permissions check",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
       appRoute("pending"),
@@ -313,18 +328,20 @@ Deno.test({
       },
       updateRoute(),
     ]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const res = await handler(
-          authenticatedJsonRequest(BASE_URL, {
-            application_id: TEST_APP_ID,
-            reason: "Not a good fit",
-          }),
-        );
-        assertEquals(res.status, 200);
-        const json = await readJson(res);
-        assertEquals(json.rejected, 1);
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const res = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              application_id: TEST_APP_ID,
+              reason: "Not a good fit",
+            }),
+          );
+          assertEquals(res.status, 200);
+          const json = await readJson(res);
+          assertEquals(json.rejected, 1);
+        });
       });
     });
   },
@@ -334,25 +351,26 @@ Deno.test({
 Deno.test({
   name: "Already processed (compare-and-set returns empty) returns 409",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([
       authRoute(),
       appRoute("pending"),
       permRoute(),
       updateRoute([]),
     ]);
-
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const res = await handler(
-          authenticatedJsonRequest(BASE_URL, {
-            application_id: TEST_APP_ID,
-            reason: "Not a good fit",
-          }),
-        );
-        assertEquals(res.status, 409);
-        const json = await readJson(res);
-        assertEquals(json.error, "Application already processed");
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const res = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              application_id: TEST_APP_ID,
+              reason: "Not a good fit",
+            }),
+          );
+          assertEquals(res.status, 409);
+          const json = await readJson(res);
+          assertEquals(json.error, "Application already processed");
+        });
       });
     });
   },

--- a/supabase/functions/user-manage-settings/index.ts
+++ b/supabase/functions/user-manage-settings/index.ts
@@ -1,12 +1,13 @@
-import { createServiceClient } from "../_shared/supabase_client.ts";
+// user-manage-settings — FCM token registration and user settings management
+// Issue #2040: atomic upsert for user_settings + user_consents via RPC
+
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { parseAction } from "../_shared/request_utils.ts";
-import { initSentry, log, withHandler, withSpan } from "../_shared/logger.ts";
+import { log, withSpan } from "../_shared/logger.ts";
 import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
 
 const FN = "user-manage-settings";
@@ -14,28 +15,19 @@ const FN = "user-manage-settings";
 const ALLOWED_SETTINGS_FIELDS = ["marketing_consent", "service_notification"];
 const VALID_DEVICE_TYPES = ["android", "ios", "web"];
 
-initSentry();
 initStatsig();
 
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+  if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const userId = auth;
+  // wrapper guarantees type === "user" per auth-manifest callers: ["user"]
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
+  const { supabase } = ctx;
 
   try {
-    // 1. Parse Request
     const result = await parseAction(req);
     if (result instanceof Response) return result;
     const { action, body } = result;
-
-    if (!action) {
-      return errorResponse("Missing required field: action", 400);
-    }
-
-    // 2. Init Supabase (service role)
-    const supabase = createServiceClient();
 
     switch (action) {
       case "upsert_token": {
@@ -49,9 +41,7 @@ Deno.serve(withHandler(async (req) => {
         }
         if (!device_type || !VALID_DEVICE_TYPES.includes(device_type)) {
           return errorResponse(
-            `Invalid device_type. Must be one of: ${
-              VALID_DEVICE_TYPES.join(", ")
-            }`,
+            `Invalid device_type. Must be one of: ${VALID_DEVICE_TYPES.join(", ")}`,
             400,
           );
         }
@@ -145,9 +135,7 @@ Deno.serve(withHandler(async (req) => {
 
         if (Object.keys(sanitized).length === 0) {
           return errorResponse(
-            `No valid settings fields. Allowed: ${
-              ALLOWED_SETTINGS_FIELDS.join(", ")
-            }`,
+            `No valid settings fields. Allowed: ${ALLOWED_SETTINGS_FIELDS.join(", ")}`,
             400,
           );
         }
@@ -202,4 +190,6 @@ Deno.serve(withHandler(async (req) => {
     });
     return errorResponse(message, 500);
   }
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/user-manage-settings/user_manage_settings_test.ts
+++ b/supabase/functions/user-manage-settings/user_manage_settings_test.ts
@@ -16,6 +16,8 @@ import { authRoute } from "../_test_utils/fixtures.ts";
 const ENV = {
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "user-manage-settings",
 };
 
 // --- Route helpers ---
@@ -51,8 +53,6 @@ function dbUpsertSettingsRpcRoute(overrides?: Record<string, unknown>) {
 // ===== upsert_token tests =====
 
 Deno.test("upsert_token — 정상 등록", async () => {
-  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
   const { fetchMock, calls } = createFetchMock([
     authRoute,
     dbUpsertTokenRoute,
@@ -61,6 +61,8 @@ Deno.test("upsert_token — 정상 등록", async () => {
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
+        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
         const request = authenticatedJsonRequest("http://localhost", {
           action: "upsert_token",
           token: "fcm_token_abc",
@@ -86,8 +88,6 @@ Deno.test("upsert_token — 정상 등록", async () => {
 });
 
 Deno.test("upsert_token — 같은 토큰 재등록 → last_updated_at 갱신", async () => {
-  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
   const { fetchMock, calls } = createFetchMock([
     authRoute,
     dbUpsertTokenRoute,
@@ -96,6 +96,8 @@ Deno.test("upsert_token — 같은 토큰 재등록 → last_updated_at 갱신",
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
+        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
         const request = authenticatedJsonRequest("http://localhost", {
           action: "upsert_token",
           token: "existing_token",
@@ -118,13 +120,13 @@ Deno.test("upsert_token — 같은 토큰 재등록 → last_updated_at 갱신",
 });
 
 Deno.test("upsert_token — token 누락 → 400", async () => {
-  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
   const { fetchMock } = createFetchMock([authRoute]);
 
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
+        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
         const request = authenticatedJsonRequest("http://localhost", {
           action: "upsert_token",
           device_type: "android",
@@ -140,13 +142,13 @@ Deno.test("upsert_token — token 누락 → 400", async () => {
 });
 
 Deno.test("upsert_token — 잘못된 device_type → 400", async () => {
-  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
   const { fetchMock } = createFetchMock([authRoute]);
 
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
+        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
         const request = authenticatedJsonRequest("http://localhost", {
           action: "upsert_token",
           token: "fcm_token",
@@ -168,8 +170,6 @@ Deno.test("upsert_token — 잘못된 device_type → 400", async () => {
 // ===== delete_token tests =====
 
 Deno.test("delete_token — 정상 삭제", async () => {
-  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
   const { fetchMock, calls } = createFetchMock([
     authRoute,
     dbDeleteTokenRoute,
@@ -178,6 +178,8 @@ Deno.test("delete_token — 정상 삭제", async () => {
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
+        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
         const request = authenticatedJsonRequest("http://localhost", {
           action: "delete_token",
           token: "fcm_token_abc",
@@ -198,8 +200,6 @@ Deno.test("delete_token — 정상 삭제", async () => {
 });
 
 Deno.test("delete_token — 존재하지 않는 토큰 → 에러 없이 성공", async () => {
-  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
   const { fetchMock } = createFetchMock([
     authRoute,
     dbDeleteTokenRoute,
@@ -208,6 +208,8 @@ Deno.test("delete_token — 존재하지 않는 토큰 → 에러 없이 성공"
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
+        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
         const request = authenticatedJsonRequest("http://localhost", {
           action: "delete_token",
           token: "nonexistent_token",
@@ -223,13 +225,13 @@ Deno.test("delete_token — 존재하지 않는 토큰 → 에러 없이 성공"
 });
 
 Deno.test("delete_token — token 누락 → 400", async () => {
-  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
   const { fetchMock } = createFetchMock([authRoute]);
 
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
+        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
         const request = authenticatedJsonRequest("http://localhost", {
           action: "delete_token",
         });
@@ -246,8 +248,6 @@ Deno.test("delete_token — token 누락 → 400", async () => {
 // ===== update_settings tests =====
 
 Deno.test("update_settings — marketing_consent 변경 → user_settings + user_consents 동시 반영", async () => {
-  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
   const { fetchMock, calls } = createFetchMock([
     authRoute,
     dbUpsertSettingsRpcRoute({ marketing_consent: true }),
@@ -256,6 +256,8 @@ Deno.test("update_settings — marketing_consent 변경 → user_settings + user
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
+        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
         const request = authenticatedJsonRequest("http://localhost", {
           action: "update_settings",
           settings: { marketing_consent: true },
@@ -283,8 +285,6 @@ Deno.test("update_settings — marketing_consent 변경 → user_settings + user
 });
 
 Deno.test("update_settings — marketing_consent false → user_consents withdrawn_at 설정 (Regression #2040)", async () => {
-  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
   const { fetchMock, calls } = createFetchMock([
     authRoute,
     dbUpsertSettingsRpcRoute({ marketing_consent: false }),
@@ -293,6 +293,8 @@ Deno.test("update_settings — marketing_consent false → user_consents withdra
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
+        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
         const request = authenticatedJsonRequest("http://localhost", {
           action: "update_settings",
           settings: { marketing_consent: false },
@@ -314,8 +316,6 @@ Deno.test("update_settings — marketing_consent false → user_consents withdra
 });
 
 Deno.test("update_settings — service_notification 변경", async () => {
-  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
   const { fetchMock } = createFetchMock([
     authRoute,
     dbUpsertSettingsRpcRoute({ service_notification: false }),
@@ -324,6 +324,8 @@ Deno.test("update_settings — service_notification 변경", async () => {
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
+        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
         const request = authenticatedJsonRequest("http://localhost", {
           action: "update_settings",
           settings: { service_notification: false },
@@ -340,13 +342,13 @@ Deno.test("update_settings — service_notification 변경", async () => {
 });
 
 Deno.test("update_settings — 허용되지 않은 필드만 → 400", async () => {
-  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
   const { fetchMock } = createFetchMock([authRoute]);
 
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
+        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
         const request = authenticatedJsonRequest("http://localhost", {
           action: "update_settings",
           settings: { theme: "dark", language: "ko" },
@@ -365,13 +367,13 @@ Deno.test("update_settings — 허용되지 않은 필드만 → 400", async () 
 });
 
 Deno.test("update_settings — boolean이 아닌 값 → 400", async () => {
-  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
   const { fetchMock } = createFetchMock([authRoute]);
 
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
+        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
         const request = authenticatedJsonRequest("http://localhost", {
           action: "update_settings",
           settings: { marketing_consent: "yes" },
@@ -387,13 +389,13 @@ Deno.test("update_settings — boolean이 아닌 값 → 400", async () => {
 });
 
 Deno.test("update_settings — settings 누락 → 400", async () => {
-  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
   const { fetchMock } = createFetchMock([authRoute]);
 
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
+        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
         const request = authenticatedJsonRequest("http://localhost", {
           action: "update_settings",
         });
@@ -410,8 +412,6 @@ Deno.test("update_settings — settings 누락 → 400", async () => {
 // ===== Auth & Edge cases =====
 
 Deno.test("인증 없이 호출 → 401", async () => {
-  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
   const { fetchMock } = createFetchMock([
     {
       matcher: (req: Request) => req.url.includes("/auth/v1/user"),
@@ -422,6 +422,8 @@ Deno.test("인증 없이 호출 → 401", async () => {
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
+        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
         const request = authenticatedJsonRequest("http://localhost", {
           action: "upsert_token",
           token: "test",
@@ -436,13 +438,13 @@ Deno.test("인증 없이 호출 → 401", async () => {
 });
 
 Deno.test("잘못된 action → 400", async () => {
-  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
   const { fetchMock } = createFetchMock([authRoute]);
 
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
+        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
         const request = authenticatedJsonRequest("http://localhost", {
           action: "invalid_action",
         });
@@ -457,13 +459,13 @@ Deno.test("잘못된 action → 400", async () => {
 });
 
 Deno.test("action 누락 → 400", async () => {
-  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
   const { fetchMock } = createFetchMock([authRoute]);
 
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
+        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
         const request = authenticatedJsonRequest("http://localhost", {
           token: "test",
         });
@@ -471,20 +473,20 @@ Deno.test("action 누락 → 400", async () => {
         const payload = await readJson(response);
 
         assertEquals(response.status, 400);
-        assertEquals(payload.error, "Missing or invalid \"action\" field");
+        assertEquals(payload.error, 'Missing or invalid "action" field');
       });
     });
   });
 });
 
 Deno.test("malformed JSON → 400", async () => {
-  const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
   const { fetchMock } = createFetchMock([authRoute]);
 
   await withEnv(ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
       await withNoIntervals(async () => {
+        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+
         const request = textRequest("http://localhost", "{invalid-json", {
           headers: { Authorization: "Bearer test-token" },
         });


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Summary

Migrates 5 edge functions to the unified `minglitEdgeFunction` wrapper as part of the ongoing TBD-2 EF migration (prerequisite for #2184, #2186, #2187, #2188).

**Migrated EFs:**
- `user-manage-settings` — FCM token registration/deletion + user settings (marketing consent, notifications)
- `partner-reject-application` — Single application rejection with compare-and-set status guard
- `partner-approve-application` — Single/bulk approval with DB capacity guard (Fix #1219)
- `partner-manage-party` — Party/location/template CRUD via handler dispatch pattern
- `partner-register` — Partner application save_draft/submit/update with server-side validation

**Changes per EF:**
- Replaced `Deno.serve(withHandler(...))` → `export const handler + minglitEdgeFunction(handler)`
- Auth: `requireAuth(req)` → `ctx.auth` (type guaranteed by manifest callers: ["user"])
- Supabase client: `createServiceClient()` → `ctx.supabase`
- Removed: manual `initSentry()`, `corsResponse()` handling (wrapper handles both)
- Retained: `withSpan`, `log`, `initStatsig`, `logStatsigEvent` where used

**Test updates:**
- Added `ENVIRONMENT: "dev"` and `MINGLIT_EF_TEST_FN_NAME` to all ENV objects
- Moved `captureServeHandler` inside `withEnv`/`withMockedFetch`/`withNoIntervals` where handler was called without ENV set
- Fixed OPTIONS/GET 405 tests: OPTIONS needs ENV (wrapper checks auth before handler, CORS preflight handled post-init), GET 405 needs auth header (wrapper does auth before method check)

**auth-manifest.json:** Added 5 new entries with `callers: ["user"]`, `envs: ["dev", "production"]`.

## Migration progress (after this PR)
- Migrated: 13 (dev) + 6 (PR #2306 in review) + 5 (this PR) = 24/57 EFs

## Test plan
- [ ] `test-deno-ef` CI passes — Deno unit tests for all 5 migrated EFs
- [ ] `test-pgtap` CI passes — no DB migration changes
- [ ] Verify contract tests unaffected