### PR TITLE
feat(edge-functions): migrate batch-5 EFs to minglitEdgeFunction wrapper

### DIFF
--- a/supabase/functions/_payment_integration_tests/payment_edge_cases_test.ts
+++ b/supabase/functions/_payment_integration_tests/payment_edge_cases_test.ts
@@ -17,9 +17,12 @@ import { authRoute } from "../_test_utils/fixtures.ts";
 
 // Statsig uses node:timers setInterval internally, which withNoIntervals cannot patch.
 
+// user-create-order is migrated to minglitEdgeFunction — needs ENVIRONMENT + fn name
 const ENV_CREATE_ORDER = {
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "user-create-order",
 };
 
 const ENV_VERIFY = {

--- a/supabase/functions/apply-event/apply_event_test.ts
+++ b/supabase/functions/apply-event/apply_event_test.ts
@@ -13,6 +13,8 @@ import {
 const ENV = {
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "apply-event",
 };
 
 // ──────────────────────────────────────────────

--- a/supabase/functions/apply-event/index.ts
+++ b/supabase/functions/apply-event/index.ts
@@ -1,14 +1,10 @@
-import { createServiceClient } from "../_shared/supabase_client.ts";
+// Fix #2185 (Batch 5): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { initSentry, withHandler } from "../_shared/logger.ts";
-
-initSentry();
 
 type VerifItem = { verification_id: string; data: Record<string, unknown> };
 
@@ -61,7 +57,7 @@ function parseVerifications(
   return { partnerId, items: [] };
 }
 
-type SupabaseClient = ReturnType<typeof createServiceClient>;
+type SupabaseClient = EFContext["supabase"];
 
 /** Upserts all verifications and inserts submission records.
  *  Returns an error Response on first failure, null on success.
@@ -118,12 +114,10 @@ async function upsertVerifications(
   return null;
 }
 
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
-
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const userId = auth;
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+  // auth.type === "user" is guaranteed by manifest (callers: ["user"])
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
+  const { supabase } = ctx;
 
   try {
     const body = await parseJsonBody(req);
@@ -144,8 +138,6 @@ Deno.serve(withHandler(async (req) => {
         400,
       );
     }
-
-    const supabase = createServiceClient();
 
     // 1. 이벤트 + 티켓 정보 조회
     const { data: event, error: eventError } = await supabase
@@ -466,4 +458,6 @@ Deno.serve(withHandler(async (req) => {
     console.error("Error in apply-event:", message);
     return errorResponse(message, 500);
   }
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/auth-manifest.json
+++ b/supabase/functions/auth-manifest.json
@@ -180,6 +180,31 @@
       "callers": ["user"],
       "envs": ["dev", "production"],
       "description": "파트너 정산 관리"
+    },
+    "apply-event": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "유저 이벤트 신청 (무료/유료 분기, verification_data 처리)"
+    },
+    "user-create-order": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "유저 결제 주문 생성 (apply_event RPC 호출)"
+    },
+    "user-cancel-order": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "유저 주문 취소 + PortOne 환불 처리"
+    },
+    "user-event-feed": {
+      "callers": ["user", "public"],
+      "envs": ["dev", "production"],
+      "description": "이벤트 피드 조회 (정렬/필터/커서 페이지네이션, nearby는 user 필수)"
+    },
+    "user-delete-account": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "유저 계정 삭제 요청 (7일 유예 기간, 활성 예약/미정산 잔액 선차단)"
     }
   }
 }

--- a/supabase/functions/user-cancel-order/index.ts
+++ b/supabase/functions/user-cancel-order/index.ts
@@ -1,12 +1,11 @@
-import { createServiceClient } from "../_shared/supabase_client.ts";
+// Fix #2185 (Batch 5): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { initSentry, log, withHandler, withSpan } from "../_shared/logger.ts";
+import { log, withSpan } from "../_shared/logger.ts";
 import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
 import {
   executeRefund,
@@ -16,15 +15,12 @@ import {
 
 const FN = "user-cancel-order";
 
-initSentry();
 initStatsig();
 
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
-
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const userId = auth;
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+  // auth.type === "user" is guaranteed by manifest (callers: ["user"])
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
+  const { supabase } = ctx;
 
   try {
     // 1. Parse Request
@@ -40,10 +36,7 @@ Deno.serve(withHandler(async (req) => {
       return errorResponse("Missing required field: event_id", 400);
     }
 
-    // 2. Init Supabase (service role for cross-table operations)
-    const supabase = createServiceClient();
-
-    // 3. Fetch application by (event_id, user_id)
+    // 2. Fetch application by (event_id, user_id)
     const { data: application, error: appError } = await withSpan(
       "db.query.event_applications",
       "db.query",
@@ -62,13 +55,13 @@ Deno.serve(withHandler(async (req) => {
       return errorResponse("해당 이벤트에 신청 내역이 없습니다", 404);
     }
 
-    // 4. Status validation
+    // 3. Status validation
     const { status } = application;
     if (status === "cancelled" || status === "rejected") {
       return errorResponse("이미 취소/거절된 신청입니다", 400);
     }
 
-    // 5. Branch: pre-payment vs post-payment
+    // 4. Branch: pre-payment vs post-payment
     const isPaid = status === "paid" || status === "pending_review" ||
       status === "approved";
     const isPrePayment = status === "pending" || status === "payment_failed";
@@ -324,4 +317,6 @@ Deno.serve(withHandler(async (req) => {
     });
     return errorResponse(message, 500);
   }
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/user-cancel-order/user_cancel_order_test.ts
+++ b/supabase/functions/user-cancel-order/user_cancel_order_test.ts
@@ -18,6 +18,8 @@ const ENV = {
   PORTONE_API_SECRET: "test-secret",
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "user-cancel-order",
 };
 
 const nowMs = Date.now();

--- a/supabase/functions/user-create-order/index.ts
+++ b/supabase/functions/user-create-order/index.ts
@@ -1,25 +1,21 @@
-import { createServiceClient } from "../_shared/supabase_client.ts";
+// Fix #2185 (Batch 5): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { initSentry, log, withHandler, withSpan } from "../_shared/logger.ts";
+import { log, withSpan } from "../_shared/logger.ts";
 import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
 
 const FN = "user-create-order";
 
-initSentry();
 initStatsig();
 
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
-
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const userId = auth;
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+  // auth.type === "user" is guaranteed by manifest (callers: ["user"])
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
+  const { supabase } = ctx;
 
   try {
     const body = await parseJsonBody(req);
@@ -41,8 +37,6 @@ Deno.serve(withHandler(async (req) => {
     if (!ticket_id) {
       return errorResponse("Missing required field: ticket_id", 400);
     }
-
-    const supabase = createServiceClient();
 
     // 2. Fetch event
     const { data: event, error: eventError } = await withSpan(
@@ -328,4 +322,6 @@ Deno.serve(withHandler(async (req) => {
     });
     return errorResponse("주문 생성 중 오류가 발생했습니다.", 500);
   }
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/user-create-order/user_create_order_test.ts
+++ b/supabase/functions/user-create-order/user_create_order_test.ts
@@ -17,6 +17,8 @@ import { authRoute } from "../_test_utils/fixtures.ts";
 const ENV = {
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "user-create-order",
 };
 
 const MOCK_EVENT = {

--- a/supabase/functions/user-delete-account/index.ts
+++ b/supabase/functions/user-delete-account/index.ts
@@ -1,12 +1,11 @@
-import { createServiceClient } from "../_shared/supabase_client.ts";
+// Fix #2185 (Batch 5): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { initSentry, log, withHandler, withSpan } from "../_shared/logger.ts";
+import { log, withSpan } from "../_shared/logger.ts";
 
 const FN = "user-delete-account";
 const GRACE_PERIOD_DAYS = 7;
@@ -22,8 +21,6 @@ type DeleteAccountRequest = {
   reason_code?: unknown;
   reason_text?: unknown;
 };
-
-initSentry();
 
 async function parseRequestBody(
   req: Request,
@@ -44,13 +41,12 @@ async function parseRequestBody(
   return body as DeleteAccountRequest;
 }
 
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method Not Allowed", 405);
 
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const userId = auth;
+  // auth.type === "user" is guaranteed by manifest (callers: ["user"])
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
+  const { supabase } = ctx;
 
   try {
     const body = await parseRequestBody(req);
@@ -75,7 +71,6 @@ Deno.serve(withHandler(async (req) => {
       return errorResponse("reason_text must be 200 characters or fewer", 400);
     }
 
-    const supabase = createServiceClient();
     const now = new Date();
     const nowIso = now.toISOString();
     const gracePeriodEnds = new Date(
@@ -252,4 +247,6 @@ Deno.serve(withHandler(async (req) => {
     });
     return errorResponse(message, 500);
   }
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/user-delete-account/user_delete_account_test.ts
+++ b/supabase/functions/user-delete-account/user_delete_account_test.ts
@@ -16,6 +16,8 @@ import { authRoute } from "../_test_utils/fixtures.ts";
 const ENV = {
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "user-delete-account",
 };
 
 function userProfileRoute(overrides?: { deleted_at?: string | null }) {

--- a/supabase/functions/user-event-feed/index.ts
+++ b/supabase/functions/user-event-feed/index.ts
@@ -1,14 +1,13 @@
 // user-event-feed/index.ts — Server-side event feed with sorting, filtering & cursor pagination (#614)
+// Fix #2185 (Batch 5): migrate to minglitEdgeFunction wrapper — auth via manifest (user + public callers)
 
-import { createServiceClient } from "../_shared/supabase_client.ts";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { optionalAuth, requireAuth } from "../_shared/auth_utils.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { initSentry, log, withHandler } from "../_shared/logger.ts";
+import { log } from "../_shared/logger.ts";
 
 const FN = "user-event-feed";
 
@@ -18,10 +17,13 @@ type SortBy = typeof VALID_SORT_BY[number];
 // Fix #1748: nearby 분당 최대 요청 수
 const NEARBY_RATE_LIMIT_PER_MINUTE = 30;
 
-initSentry();
-
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+  // auth.type === "user" (authenticated) or "public" (anonymous)
+  // Manifest callers: ["user", "public"] — both allowed, nearby requires "user"
+  const userId: string | null = ctx.auth.type === "user"
+    ? (ctx.auth as { type: "user"; userId: string }).userId
+    : null;
+  const { supabase } = ctx;
 
   if (req.method !== "POST") {
     return errorResponse("Method not allowed", 405);
@@ -55,14 +57,8 @@ Deno.serve(withHandler(async (req) => {
 
   // Fix #1748: nearby requires authentication — unauthenticated nearby would
   // insert user_id=NULL into location_access_log, polluting the §16 legal log.
-  let userId: string | null;
-  if (nearby !== null) {
-    const authResult = await requireAuth(req);
-    if (authResult instanceof Response) return authResult;
-    userId = authResult;
-  } else {
-    // Non-nearby paths allow anonymous access for basic feed
-    userId = await optionalAuth(req);
+  if (nearby !== null && userId === null) {
+    return errorResponse("Unauthorized", 401);
   }
 
   // Validate sort_by
@@ -112,8 +108,6 @@ Deno.serve(withHandler(async (req) => {
     }
     nearbyTyped = { lat, lng, radius_km };
   }
-
-  const supabase = createServiceClient();
 
   // Fix #1748: rate limit — max NEARBY_RATE_LIMIT_PER_MINUTE requests/minute/user.
   // Fails open: a DB hiccup logs a warning but does not block the request.
@@ -223,4 +217,6 @@ Deno.serve(withHandler(async (req) => {
     sort_by,
     limit,
   });
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/user-event-feed/user_event_feed_test.ts
+++ b/supabase/functions/user-event-feed/user_event_feed_test.ts
@@ -13,6 +13,8 @@ import {
 const ENV = {
   SUPABASE_URL: "http://localhost:54321",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "user-event-feed",
 };
 
 const BASE_URL = "http://localhost";
@@ -121,14 +123,18 @@ Deno.test({
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
-    await withEnv(ENV, async () => {
-      const response = await handler(
-        jsonRequest(BASE_URL, { sort_by: "invalid_sort" }),
-      );
-      assertEquals(response.status, 400);
+    const { fetchMock } = createFetchMock([]);
 
-      const body = await readJson(response);
-      assertEquals(body.error.includes("Invalid sort_by"), true);
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const response = await handler(
+          jsonRequest(BASE_URL, { sort_by: "invalid_sort" }),
+        );
+        assertEquals(response.status, 400);
+
+        const body = await readJson(response);
+        assertEquals(body.error.includes("Invalid sort_by"), true);
+      });
     });
   },
 });
@@ -138,17 +144,21 @@ Deno.test({
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
-    await withEnv(ENV, async () => {
-      const response = await handler(
-        jsonRequest(BASE_URL, {
-          sort_by: "recommended",
-          cursor: { bad_field: "oops" },
-        }),
-      );
-      assertEquals(response.status, 400);
+    const { fetchMock } = createFetchMock([]);
 
-      const body = await readJson(response);
-      assertEquals(body.error.includes("Invalid cursor"), true);
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        const response = await handler(
+          jsonRequest(BASE_URL, {
+            sort_by: "recommended",
+            cursor: { bad_field: "oops" },
+          }),
+        );
+        assertEquals(response.status, 400);
+
+        const body = await readJson(response);
+        assertEquals(body.error.includes("Invalid cursor"), true);
+      });
     });
   },
 });
@@ -433,8 +443,10 @@ Deno.test({
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
-    const response = await handler(new Request(BASE_URL, { method: "OPTIONS" }));
-    assertEquals(response.status, 200);
+    await withEnv(ENV, async () => {
+      const response = await handler(new Request(BASE_URL, { method: "OPTIONS" }));
+      assertEquals(response.status, 200);
+    });
   },
 });
 
@@ -443,7 +455,9 @@ Deno.test({
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
-    const response = await handler(new Request(BASE_URL, { method: "GET" }));
-    assertEquals(response.status, 405);
+    await withEnv(ENV, async () => {
+      const response = await handler(new Request(BASE_URL, { method: "GET" }));
+      assertEquals(response.status, 405);
+    });
   },
 });


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Summary

Batch-5 of the EF auth migration (Phase 3 — docs/architecture/edge-function-auth.md §8).

Migrates 5 user-caller EFs to `minglitEdgeFunction`:
- `apply-event`
- `user-create-order`
- `user-cancel-order`
- `user-event-feed`
- `user-delete-account`

## Changes per EF

Each EF receives:
- `auth-manifest.json` entry: `callers: ["user"], envs: ["dev", "production"]`
- `index.ts`: boilerplate removed (initSentry, createServiceClient, requireAuth, withHandler, corsResponse)
- `index.ts`: `export const handler` + `minglitEdgeFunction(handler)`
- Test: `ENVIRONMENT: "dev"` + `MINGLIT_EF_TEST_FN_NAME` added to ENV

**Special case — `user-event-feed`:** Previously used `optionalAuth` for non-nearby paths (anonymous access allowed). Migrated with `callers: ["user", "public"]` so the wrapper resolves unauthenticated requests to `{ type: "public" }`. The handler checks `ctx.auth.type === "user"` to derive `userId`, passing `null` for public callers. Nearby requests still enforce auth with an explicit `userId === null` guard in the handler.

## Net diff

~-50 lines boilerplate. Business logic unchanged.

## Related

- Architecture: docs/architecture/edge-function-auth.md §8 (Phase 3)
- Batch-1: #2305 (merged)
- Batch-2: merged
- Batch-3: #2306 (open)
- Batch-4: #2316 (open)