### PR TITLE
feat(edge-functions): migrate batch-6 EFs to minglitEdgeFunction wrapper

### DIFF
--- a/supabase/functions/auth-manifest.json
+++ b/supabase/functions/auth-manifest.json
@@ -150,6 +150,36 @@
       "callers": ["user"],
       "envs": ["dev", "production"],
       "description": "파트너 신청 — save_draft/submit/update, 서버사이드 검증 포함 (Issue #311)"
+    },
+    "event-checkin": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "이벤트 체크인 처리"
+    },
+    "commit-match-likes": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "매치 좋아요 확정 제출"
+    },
+    "partner-manage-event": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "파트너 이벤트 관리 (생성/수정/삭제/상태변경)"
+    },
+    "partner-manage-match": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "파트너 매치 결과 관리"
+    },
+    "partner-manage-member": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "파트너 멤버 관리"
+    },
+    "partner-manage-settlement": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "파트너 정산 관리"
     }
   }
 }

--- a/supabase/functions/commit-match-likes/commit_match_likes_test.ts
+++ b/supabase/functions/commit-match-likes/commit_match_likes_test.ts
@@ -8,11 +8,14 @@ import {
   readJson,
   withEnv,
   withMockedFetch,
+  withNoIntervals,
 } from "../_test_utils/mock_http.ts";
 
 const ENV = {
   SUPABASE_URL: "http://localhost:54321",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "commit-match-likes",
 };
 
 const TEST_EVENT_ID = "event-001";
@@ -135,22 +138,24 @@ function happyPathRoutes(): FetchRoute[] {
 Deno.test({
   name: "returns 400 when voter_id is in candidate_ids (self-like)",
   fn: async () => {
-    const handler = await captureServeHandler(
-      new URL("./index.ts", import.meta.url),
-    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const res = await handler(
-          authenticatedJsonRequest("http://localhost", {
-            event_id: TEST_EVENT_ID,
-            candidate_ids: [TEST_VOTER_ID],
-          }),
-        );
-        assertEquals(res.status, 400);
-        const body = await readJson(res);
-        assertEquals(body.error, "자기 자신에게 좋아요를 보낼 수 없습니다");
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
+          const res = await handler(
+            authenticatedJsonRequest("http://localhost", {
+              event_id: TEST_EVENT_ID,
+              candidate_ids: [TEST_VOTER_ID],
+            }),
+          );
+          assertEquals(res.status, 400);
+          const body = await readJson(res);
+          assertEquals(body.error, "자기 자신에게 좋아요를 보낼 수 없습니다");
+        });
       });
     });
   },
@@ -159,22 +164,24 @@ Deno.test({
 Deno.test({
   name: "returns 400 when candidate_ids exceed max 3",
   fn: async () => {
-    const handler = await captureServeHandler(
-      new URL("./index.ts", import.meta.url),
-    );
     const { fetchMock } = createFetchMock([authRoute()]);
 
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const res = await handler(
-          authenticatedJsonRequest("http://localhost", {
-            event_id: TEST_EVENT_ID,
-            candidate_ids: ["u1", "u2", "u3", "u4"],
-          }),
-        );
-        assertEquals(res.status, 400);
-        const body = await readJson(res);
-        assertEquals(body.error, "좋아요는 최대 3명까지 보낼 수 있습니다");
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
+          const res = await handler(
+            authenticatedJsonRequest("http://localhost", {
+              event_id: TEST_EVENT_ID,
+              candidate_ids: ["u1", "u2", "u3", "u4"],
+            }),
+          );
+          assertEquals(res.status, 400);
+          const body = await readJson(res);
+          assertEquals(body.error, "좋아요는 최대 3명까지 보낼 수 있습니다");
+        });
       });
     });
   },
@@ -184,9 +191,6 @@ Deno.test({
   name:
     "returns structured phase mismatch when event is outside matching window",
   fn: async () => {
-    const handler = await captureServeHandler(
-      new URL("./index.ts", import.meta.url),
-    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       eventRoute({ status: "completed", vote_end_at: "2000-01-02T00:00:00Z" }),
@@ -194,16 +198,21 @@ Deno.test({
 
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const res = await handler(
-          authenticatedJsonRequest("http://localhost", {
-            event_id: TEST_EVENT_ID,
-            candidate_ids: TEST_CANDIDATE_IDS,
-          }),
-        );
-        assertEquals(res.status, 409);
-        const body = await readJson(res);
-        assertEquals(body.error, "매칭 선택 가능 시간이 아니에요");
-        assertEquals(body.details.code, "phase_mismatch");
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
+          const res = await handler(
+            authenticatedJsonRequest("http://localhost", {
+              event_id: TEST_EVENT_ID,
+              candidate_ids: TEST_CANDIDATE_IDS,
+            }),
+          );
+          assertEquals(res.status, 409);
+          const body = await readJson(res);
+          assertEquals(body.error, "매칭 선택 가능 시간이 아니에요");
+          assertEquals(body.details.code, "phase_mismatch");
+        });
       });
     });
   },
@@ -212,9 +221,6 @@ Deno.test({
 Deno.test({
   name: "returns idempotent counts when duplicate likes are submitted again",
   fn: async () => {
-    const handler = await captureServeHandler(
-      new URL("./index.ts", import.meta.url),
-    );
     const { fetchMock } = createFetchMock([
       authRoute(),
       eventRoute(),
@@ -228,16 +234,21 @@ Deno.test({
 
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const res = await handler(
-          authenticatedJsonRequest("http://localhost", {
-            event_id: TEST_EVENT_ID,
-            candidate_ids: TEST_CANDIDATE_IDS,
-          }),
-        );
-        assertEquals(res.status, 200);
-        const body = await readJson(res);
-        assertEquals(body.inserted_count, 0);
-        assertEquals(body.duplicate_count, 2);
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
+          const res = await handler(
+            authenticatedJsonRequest("http://localhost", {
+              event_id: TEST_EVENT_ID,
+              candidate_ids: TEST_CANDIDATE_IDS,
+            }),
+          );
+          assertEquals(res.status, 200);
+          const body = await readJson(res);
+          assertEquals(body.inserted_count, 0);
+          assertEquals(body.duplicate_count, 2);
+        });
       });
     });
   },
@@ -246,20 +257,22 @@ Deno.test({
 Deno.test({
   name: "commits likes in one batch mutation",
   fn: async () => {
-    const handler = await captureServeHandler(
-      new URL("./index.ts", import.meta.url),
-    );
     const { fetchMock, calls } = createFetchMock(happyPathRoutes());
 
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const res = await handler(
-          authenticatedJsonRequest("http://localhost", {
-            event_id: TEST_EVENT_ID,
-            candidate_ids: TEST_CANDIDATE_IDS,
-          }),
-        );
-        assertEquals(res.status, 200);
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(
+            new URL("./index.ts", import.meta.url),
+          );
+          const res = await handler(
+            authenticatedJsonRequest("http://localhost", {
+              event_id: TEST_EVENT_ID,
+              candidate_ids: TEST_CANDIDATE_IDS,
+            }),
+          );
+          assertEquals(res.status, 200);
+        });
       });
     });
 

--- a/supabase/functions/commit-match-likes/index.ts
+++ b/supabase/functions/commit-match-likes/index.ts
@@ -1,23 +1,16 @@
-import { requireAuth } from "../_shared/auth_utils.ts";
-import { initSentry, withHandler } from "../_shared/logger.ts";
+// Fix #2185 (Batch 6): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { createServiceClient } from "../_shared/supabase_client.ts";
-
-initSentry();
 
 const MAX_LIKES_PER_COMMIT = 3;
 
-Deno.serve(withHandler(async (req: Request): Promise<Response> => {
-  if (req.method === "OPTIONS") return corsResponse();
-
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const voterId = auth;
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+  const { supabase } = ctx;
+  const voterId = (ctx.auth as { type: "user"; userId: string }).userId;
 
   const body = await parseJsonBody(req);
   if (body instanceof Response) return body;
@@ -46,8 +39,6 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
   if (normalizedCandidateIds.includes(voterId)) {
     return errorResponse("자기 자신에게 좋아요를 보낼 수 없습니다", 400);
   }
-
-  const supabase = createServiceClient();
 
   const { data: event, error: eventError } = await supabase
     .from("events")
@@ -223,4 +214,6 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
     "inserted_count": result["inserted_count"] ?? 0,
     "duplicate_count": result["duplicate_count"] ?? 0,
   });
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/event-checkin/event_checkin_test.ts
+++ b/supabase/functions/event-checkin/event_checkin_test.ts
@@ -7,11 +7,14 @@ import {
   readJson,
   withEnv,
   withMockedFetch,
+  withNoIntervals,
 } from "../_test_utils/mock_http.ts";
 
 const BASE_ENV = {
   SUPABASE_URL: "http://localhost:54321",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "event-checkin",
 };
 
 const BASE_URL = "http://localhost";
@@ -82,8 +85,6 @@ Deno.test({
       TICKET_SIGNING_PUBLIC_KEY_JWK: JSON.stringify(publicKeyJwk),
     };
 
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
     const { fetchMock } = createFetchMock([
       {
         matcher: "/auth/v1/user",
@@ -105,19 +106,22 @@ Deno.test({
 
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const response = await handler(
-          authenticatedJsonRequest(BASE_URL, {
-            event_id: "evt-1",
-            participant_id: "part-1",
-            signature,
-            expires_at: expiresAt,
-          }),
-        );
-        assertEquals(response.status, 200);
-        const body = await readJson(response);
-        assertEquals(body.success, true);
-        assertEquals(body.status, "checked_in");
-        assertEquals(body.participant_id, "part-1");
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const response = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              event_id: "evt-1",
+              participant_id: "part-1",
+              signature,
+              expires_at: expiresAt,
+            }),
+          );
+          assertEquals(response.status, 200);
+          const body = await readJson(response);
+          assertEquals(body.success, true);
+          assertEquals(body.status, "checked_in");
+          assertEquals(body.participant_id, "part-1");
+        });
       });
     });
   },
@@ -126,8 +130,6 @@ Deno.test({
 Deno.test({
   name: "event-checkin - returns 400 when missing event_id/participant_id",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
     const { fetchMock } = createFetchMock([
       {
         matcher: "/auth/v1/user",
@@ -137,12 +139,15 @@ Deno.test({
 
     await withEnv(BASE_ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const response = await handler(
-          authenticatedJsonRequest(BASE_URL, { event_id: "evt-1" }),
-        );
-        assertEquals(response.status, 400);
-        const body = await readJson(response);
-        assertEquals(body.error, "Missing required parameters: event_id, participant_id");
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const response = await handler(
+            authenticatedJsonRequest(BASE_URL, { event_id: "evt-1" }),
+          );
+          assertEquals(response.status, 400);
+          const body = await readJson(response);
+          assertEquals(body.error, "Missing required parameters: event_id, participant_id");
+        });
       });
     });
   },
@@ -151,8 +156,6 @@ Deno.test({
 Deno.test({
   name: "event-checkin - returns 400 when missing signature/expires_at",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
     const { fetchMock } = createFetchMock([
       {
         matcher: "/auth/v1/user",
@@ -162,15 +165,18 @@ Deno.test({
 
     await withEnv(BASE_ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const response = await handler(
-          authenticatedJsonRequest(BASE_URL, {
-            event_id: "evt-1",
-            participant_id: "part-1",
-          }),
-        );
-        assertEquals(response.status, 400);
-        const body = await readJson(response);
-        assertEquals(body.error, "Missing required parameters: signature, expires_at");
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const response = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              event_id: "evt-1",
+              participant_id: "part-1",
+            }),
+          );
+          assertEquals(response.status, 400);
+          const body = await readJson(response);
+          assertEquals(body.error, "Missing required parameters: signature, expires_at");
+        });
       });
     });
   },
@@ -179,8 +185,6 @@ Deno.test({
 Deno.test({
   name: "event-checkin - returns 400 when QR token is expired",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
     const { fetchMock } = createFetchMock([
       {
         matcher: "/auth/v1/user",
@@ -192,17 +196,20 @@ Deno.test({
 
     await withEnv(BASE_ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const response = await handler(
-          authenticatedJsonRequest(BASE_URL, {
-            event_id: "evt-1",
-            participant_id: "part-1",
-            signature: "any-sig",
-            expires_at: expiredAt,
-          }),
-        );
-        assertEquals(response.status, 400);
-        const body = await readJson(response);
-        assertEquals(body.error, "QR token expired");
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const response = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              event_id: "evt-1",
+              participant_id: "part-1",
+              signature: "any-sig",
+              expires_at: expiredAt,
+            }),
+          );
+          assertEquals(response.status, 400);
+          const body = await readJson(response);
+          assertEquals(body.error, "QR token expired");
+        });
       });
     });
   },
@@ -211,7 +218,6 @@ Deno.test({
 Deno.test({
   name: "event-checkin - returns 404 when participant not found",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const futureExpiry = new Date(Date.now() + 3600000).toISOString();
 
     const { fetchMock } = createFetchMock([
@@ -227,17 +233,20 @@ Deno.test({
 
     await withEnv(BASE_ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const response = await handler(
-          authenticatedJsonRequest(BASE_URL, {
-            event_id: "evt-1",
-            participant_id: "nonexistent",
-            signature: "dummy-sig",
-            expires_at: futureExpiry,
-          }),
-        );
-        assertEquals(response.status, 404);
-        const body = await readJson(response);
-        assertEquals(body.error, "Participant not found");
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const response = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              event_id: "evt-1",
+              participant_id: "nonexistent",
+              signature: "dummy-sig",
+              expires_at: futureExpiry,
+            }),
+          );
+          assertEquals(response.status, 404);
+          const body = await readJson(response);
+          assertEquals(body.error, "Participant not found");
+        });
       });
     });
   },
@@ -246,7 +255,6 @@ Deno.test({
 Deno.test({
   name: "event-checkin - returns 403 when caller is not the participant",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const futureExpiry = new Date(Date.now() + 3600000).toISOString();
 
     const { fetchMock } = createFetchMock([
@@ -262,17 +270,20 @@ Deno.test({
 
     await withEnv(BASE_ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const response = await handler(
-          authenticatedJsonRequest(BASE_URL, {
-            event_id: "evt-1",
-            participant_id: "part-1",
-            signature: "dummy-sig",
-            expires_at: futureExpiry,
-          }),
-        );
-        assertEquals(response.status, 403);
-        const body = await readJson(response);
-        assertEquals(body.error, "Forbidden: caller is not the participant's user");
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const response = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              event_id: "evt-1",
+              participant_id: "part-1",
+              signature: "dummy-sig",
+              expires_at: futureExpiry,
+            }),
+          );
+          assertEquals(response.status, 403);
+          const body = await readJson(response);
+          assertEquals(body.error, "Forbidden: caller is not the participant's user");
+        });
       });
     });
   },
@@ -289,8 +300,6 @@ Deno.test({
       TICKET_SIGNING_PUBLIC_KEY_JWK: JSON.stringify(publicKeyJwk),
     };
 
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
     const { fetchMock } = createFetchMock([
       {
         matcher: "/auth/v1/user",
@@ -304,17 +313,20 @@ Deno.test({
 
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const response = await handler(
-          authenticatedJsonRequest(BASE_URL, {
-            event_id: "evt-1",
-            participant_id: "part-1",
-            signature: "aW52YWxpZC1zaWduYXR1cmU", // invalid base64url
-            expires_at: expiresAt,
-          }),
-        );
-        assertEquals(response.status, 403);
-        const body = await readJson(response);
-        assertEquals(body.error, "Invalid QR signature");
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const response = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              event_id: "evt-1",
+              participant_id: "part-1",
+              signature: "aW52YWxpZC1zaWduYXR1cmU", // invalid base64url
+              expires_at: expiresAt,
+            }),
+          );
+          assertEquals(response.status, 403);
+          const body = await readJson(response);
+          assertEquals(body.error, "Invalid QR signature");
+        });
       });
     });
   },
@@ -331,8 +343,6 @@ Deno.test({
       ...BASE_ENV,
       TICKET_SIGNING_PUBLIC_KEY_JWK: JSON.stringify(publicKeyJwk),
     };
-
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
     const { fetchMock } = createFetchMock([
       {
@@ -351,17 +361,20 @@ Deno.test({
 
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const response = await handler(
-          authenticatedJsonRequest(BASE_URL, {
-            event_id: "evt-1",
-            participant_id: "part-1",
-            signature,
-            expires_at: expiresAt,
-          }),
-        );
-        assertEquals(response.status, 409);
-        const body = await readJson(response);
-        assertEquals(body.error, "Participant already checked in");
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const response = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              event_id: "evt-1",
+              participant_id: "part-1",
+              signature,
+              expires_at: expiresAt,
+            }),
+          );
+          assertEquals(response.status, 409);
+          const body = await readJson(response);
+          assertEquals(body.error, "Participant already checked in");
+        });
       });
     });
   },
@@ -378,8 +391,6 @@ Deno.test({
       ...BASE_ENV,
       TICKET_SIGNING_PUBLIC_KEY_JWK: JSON.stringify(publicKeyJwk),
     };
-
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
     const { fetchMock } = createFetchMock([
       {
@@ -398,17 +409,20 @@ Deno.test({
 
     await withEnv(ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const response = await handler(
-          authenticatedJsonRequest(BASE_URL, {
-            event_id: "evt-1",
-            participant_id: "part-1",
-            signature,
-            expires_at: expiresAt,
-          }),
-        );
-        assertEquals(response.status, 400);
-        const body = await readJson(response);
-        assertEquals(body.error, "Cannot check in participant with status 'cancelled'");
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const response = await handler(
+            authenticatedJsonRequest(BASE_URL, {
+              event_id: "evt-1",
+              participant_id: "part-1",
+              signature,
+              expires_at: expiresAt,
+            }),
+          );
+          assertEquals(response.status, 400);
+          const body = await readJson(response);
+          assertEquals(body.error, "Cannot check in participant with status 'cancelled'");
+        });
       });
     });
   },
@@ -417,20 +431,21 @@ Deno.test({
 Deno.test({
   name: "event-checkin - returns 401 without auth token",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-
     const { fetchMock } = createFetchMock([]);
 
     await withEnv(BASE_ENV, async () => {
       await withMockedFetch(fetchMock, async () => {
-        const request = new Request(BASE_URL, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ event_id: "evt-1", participant_id: "part-1" }),
-        });
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const request = new Request(BASE_URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ event_id: "evt-1", participant_id: "part-1" }),
+          });
 
-        const response = await handler(request);
-        assertEquals(response.status, 401);
+          const response = await handler(request);
+          assertEquals(response.status, 401);
+        });
       });
     });
   },
@@ -439,9 +454,16 @@ Deno.test({
 Deno.test({
   name: "event-checkin - OPTIONS returns CORS response",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+    const { fetchMock } = createFetchMock([]);
 
-    const response = await handler(new Request(BASE_URL, { method: "OPTIONS" }));
-    assertEquals(response.status, 200);
+    await withEnv(BASE_ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const response = await handler(new Request(BASE_URL, { method: "OPTIONS" }));
+          assertEquals(response.status, 200);
+        });
+      });
+    });
   },
 });

--- a/supabase/functions/event-checkin/event_checkin_test.ts
+++ b/supabase/functions/event-checkin/event_checkin_test.ts
@@ -462,6 +462,9 @@ Deno.test({
           const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
           const response = await handler(new Request(BASE_URL, { method: "OPTIONS" }));
           assertEquals(response.status, 200);
+          assertEquals(response.headers.get("Access-Control-Allow-Origin"), "*");
+          assertEquals(response.headers.get("Access-Control-Allow-Methods"), "GET, POST, OPTIONS");
+          assertEquals(response.headers.has("Access-Control-Allow-Headers"), true);
         });
       });
     });

--- a/supabase/functions/event-checkin/index.ts
+++ b/supabase/functions/event-checkin/index.ts
@@ -1,18 +1,15 @@
 // event-checkin/index.ts — Check-in a participant for an event
+// Fix #2185 (Batch 6): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
 
-import { createServiceClient } from "../_shared/supabase_client.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { initSentry, log, withHandler } from "../_shared/logger.ts";
+import { log } from "../_shared/logger.ts";
 
 const FN = "event-checkin";
-
-initSentry();
 
 // Fix #1491: base64url 디코딩 — Ed25519 서명 바이트 복원
 function base64UrlDecode(str: string): Uint8Array {
@@ -27,11 +24,9 @@ function base64UrlDecode(str: string): Uint8Array {
   return bytes;
 }
 
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
-
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+  const { supabase } = ctx;
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
 
   const body = await parseJsonBody(req);
   if (body instanceof Response) return body;
@@ -64,8 +59,6 @@ Deno.serve(withHandler(async (req) => {
     return errorResponse("QR token expired", 400);
   }
 
-  const supabase = createServiceClient();
-
   // Fetch the participant row to validate ownership and current status
   const { data: participant, error: fetchErr } = await supabase
     .from("event_participants")
@@ -89,7 +82,7 @@ Deno.serve(withHandler(async (req) => {
   }
 
   // Validate caller is the participant's user
-  if ((participant as { user_id: string }).user_id !== auth) {
+  if ((participant as { user_id: string }).user_id !== userId) {
     return errorResponse(
       "Forbidden: caller is not the participant's user",
       403,
@@ -117,8 +110,8 @@ Deno.serve(withHandler(async (req) => {
     );
 
     const ticketId = (participant as { ticket_id: string }).ticket_id;
-    const userId = (participant as { user_id: string }).user_id;
-    const payload = `${ticketId}|${event_id}|${userId}|${expires_at}`;
+    const participantUserId = (participant as { user_id: string }).user_id;
+    const payload = `${ticketId}|${event_id}|${participantUserId}|${expires_at}`;
     const message = new TextEncoder().encode(payload);
     const sigBytes = base64UrlDecode(signature);
 
@@ -225,4 +218,6 @@ Deno.serve(withHandler(async (req) => {
     participant_id,
     status: "checked_in",
   });
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/partner-manage-event/index.ts
+++ b/supabase/functions/partner-manage-event/index.ts
@@ -1,19 +1,15 @@
 // partner-manage-event — Event/ticket/entry-group CRUD for partners
 // Issue #317: RLS write strategy 전환 — 이벤트/티켓 CRUD
+// Fix #2185 (Batch 6): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
 
-import { createServiceClient } from "../_shared/supabase_client.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
 import { parseAction } from "../_shared/request_utils.ts";
-import { initSentry, withHandler } from "../_shared/logger.ts";
-
-initSentry();
 
 const VALID_EVENT_STATUSES = ["scheduled", "cancelled", "completed"];
 const _VALID_GENDERS = ["male", "female"];
@@ -40,34 +36,28 @@ const TICKET_UPDATE_FIELDS = [
   "quantity",
 ] as const;
 
-Deno.serve(withHandler(async (req: Request): Promise<Response> => {
-  if (req.method === "OPTIONS") return corsResponse();
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
+  const { supabase } = ctx;
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
+
   try {
-    return await handleRequest(req);
+    return await handleRequest(supabase, userId, req);
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
     return errorResponse(message, 500);
   }
-}));
+};
 
-async function handleRequest(req: Request): Promise<Response> {
-  // 1. Environment check (handled by createServiceClient)
+minglitEdgeFunction(handler);
 
-  // 2. Auth
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const userId = auth;
-
-  // 3. Parse body
+async function handleRequest(supabase: SupabaseClient, userId: string, req: Request): Promise<Response> {
+  // Parse body
   const result = await parseAction(req);
   if (result instanceof Response) return result;
   const { action, body } = result;
   if (!action) return errorResponse("Missing action", 400);
-
-  // 4. Supabase client (service role)
-  const supabase = createServiceClient();
 
   // ─── create ───
   if (action === "create") {

--- a/supabase/functions/partner-manage-event/partner_manage_event_test.ts
+++ b/supabase/functions/partner-manage-event/partner_manage_event_test.ts
@@ -8,6 +8,7 @@ import {
   readJson,
   withEnv,
   withMockedFetch,
+  withNoIntervals,
   type FetchRoute,
 } from "../_test_utils/mock_http.ts";
 
@@ -23,6 +24,8 @@ const TEST_TEMPLATE_ID_2 = "tpl-002";
 const ENV = {
   SUPABASE_URL: "http://localhost:54321",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "partner-manage-event",
 };
 
 const FUTURE_START = new Date(Date.now() + 86400000).toISOString(); // +1 day
@@ -216,20 +219,35 @@ function updateTicketRoute(): FetchRoute {
 Deno.test({
   name: "OPTIONS returns CORS preflight",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-    const req = new Request("http://localhost", { method: "OPTIONS" });
-    const res = await handler(req);
-    assertEquals(res.status, 200);
+    await withEnv(ENV, async () => {
+      await withNoIntervals(async () => {
+        const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+        const req = new Request("http://localhost", { method: "OPTIONS" });
+        const res = await handler(req);
+        assertEquals(res.status, 200);
+      });
+    });
   },
 });
 
 Deno.test({
   name: "GET returns 405",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-    const req = new Request("http://localhost", { method: "GET" });
-    const res = await handler(req);
-    assertEquals(res.status, 405);
+    // minglitEdgeFunction runs auth before handler; authenticated GET reaches handler → 405
+    const { fetchMock } = createFetchMock([authRoute()]);
+    await withEnv(ENV, async () => {
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const req = new Request("http://localhost", {
+            method: "GET",
+            headers: { Authorization: "Bearer test-token" },
+          });
+          const res = await handler(req);
+          assertEquals(res.status, 405);
+        });
+      });
+    });
   },
 });
 

--- a/supabase/functions/partner-manage-match/index.ts
+++ b/supabase/functions/partner-manage-match/index.ts
@@ -1,18 +1,14 @@
 // partner-manage-match — Manage match rules for events (set_rules, clear_rules)
 // Issue #305: RLS write strategy 전환 + vote_count 지원
+// Fix #2185 (Batch 6): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
 
-import { createServiceClient } from "../_shared/supabase_client.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
 import { parseAction } from "../_shared/request_utils.ts";
-import { initSentry, withHandler } from "../_shared/logger.ts";
-
-initSentry();
 
 interface RuleInput {
   source_group_id: string;
@@ -20,16 +16,14 @@ interface RuleInput {
   vote_count?: number;
 }
 
-Deno.serve(withHandler(async (req: Request): Promise<Response> => {
-  if (req.method === "OPTIONS") return corsResponse();
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
-  // 1. Auth
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const userId = auth;
+  const { supabase } = ctx;
+  // wrapper guarantees type === "user" per auth-manifest callers: ["user"]
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
 
-  // 3. Parse body
+  // Parse body
   const result = await parseAction(req);
   if (result instanceof Response) return result;
   const { action, body } = result;
@@ -40,10 +34,7 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
     return errorResponse("Missing event_id", 400);
   }
 
-  // 4. Supabase client (service role)
-  const supabase = createServiceClient();
-
-  // 5. Verify ownership: event → party → partner
+  // Verify ownership: event → party → partner
   const { data: event, error: eventError } = await supabase
     .from("events")
     .select("id, status, party:party_id(id, partner_id)")
@@ -169,4 +160,6 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
   }
 
   return errorResponse(`Unknown action: ${action}`, 400);
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/partner-manage-match/partner_manage_match_test.ts
+++ b/supabase/functions/partner-manage-match/partner_manage_match_test.ts
@@ -20,6 +20,8 @@ const GROUP_FEMALE = "group-female";
 const ENV = {
   SUPABASE_URL: "http://localhost:54321",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "partner-manage-match",
 };
 
 function authRoute(): FetchRoute {

--- a/supabase/functions/partner-manage-member/index.ts
+++ b/supabase/functions/partner-manage-member/index.ts
@@ -1,20 +1,17 @@
 // partner-manage-member — Manage partner member roles and permissions
 // Issue #313: RLS write strategy 전환
+// Fix #2185 (Batch 6): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
 
-import { createServiceClient } from "../_shared/supabase_client.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
 import { parseAction } from "../_shared/request_utils.ts";
-import { initSentry, withHandler, log } from "../_shared/logger.ts";
+import { log } from "../_shared/logger.ts";
 
 const FN = "partner-manage-member";
-
-initSentry();
 
 // Fix #313: role 화이트리스트 — partner_role enum과 일치
 const VALID_ROLES = ["owner", "manager", "staff"] as const;
@@ -32,24 +29,19 @@ const VALID_PERMISSIONS = [
   "COMMENT_MANAGE",
 ] as const;
 
-Deno.serve(withHandler(async (req: Request): Promise<Response> => {
-  if (req.method === "OPTIONS") return corsResponse();
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
-  try {
-    // 1. Auth
-    const auth = await requireAuth(req);
-    if (auth instanceof Response) return auth;
-    const userId = auth;
+  const { supabase } = ctx;
+  // wrapper guarantees type === "user" per auth-manifest callers: ["user"]
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
 
-    // 2. Parse body
+  try {
+    // Parse body
     const result = await parseAction(req);
     if (result instanceof Response) return result;
     const { action, body } = result;
     if (!action) return errorResponse("Missing action", 400);
-
-    // 3. Supabase client (service role)
-    const supabase = createServiceClient();
 
     // ─── update_role ───
     if (action === "update_role") {
@@ -160,4 +152,6 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
       500,
     );
   }
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/partner-manage-member/partner_manage_member_test.ts
+++ b/supabase/functions/partner-manage-member/partner_manage_member_test.ts
@@ -17,6 +17,8 @@ const TEST_PARTNER_ID = "partner-001";
 const ENV = {
   SUPABASE_URL: "http://localhost:54321",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "partner-manage-member",
 };
 
 function authRoute(): FetchRoute {

--- a/supabase/functions/partner-manage-settlement/index.ts
+++ b/supabase/functions/partner-manage-settlement/index.ts
@@ -1,20 +1,17 @@
 // partner-manage-settlement — Manage partner settlement bank account
 // Issue #312: RLS write strategy 전환
+// Fix #2185 (Batch 6): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
 
-import { createServiceClient } from "../_shared/supabase_client.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
 import { parseAction } from "../_shared/request_utils.ts";
-import { initSentry, withHandler, log } from "../_shared/logger.ts";
+import { log } from "../_shared/logger.ts";
 
 const FN = "partner-manage-settlement";
-
-initSentry();
 
 // Fields allowed in upsert_bank_account action
 const UPSERT_FIELDS = [
@@ -26,24 +23,19 @@ const UPSERT_FIELDS = [
 // Fix #312: 계좌번호 형식 검증 — 하이픈/공백 제거 후 숫자 6~20자리
 const ACCOUNT_NUMBER_RE = /^[0-9]{6,20}$/;
 
-Deno.serve(withHandler(async (req: Request): Promise<Response> => {
-  if (req.method === "OPTIONS") return corsResponse();
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
-  try {
-    // 1. Auth
-    const auth = await requireAuth(req);
-    if (auth instanceof Response) return auth;
-    const userId = auth;
+  const { supabase } = ctx;
+  // wrapper guarantees type === "user" per auth-manifest callers: ["user"]
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
 
-    // 2. Parse body
+  try {
+    // Parse body
     const result = await parseAction(req);
     if (result instanceof Response) return result;
     const { action, body } = result;
     if (!action) return errorResponse("Missing action", 400);
-
-    // 3. Supabase client (service role)
-    const supabase = createServiceClient();
 
     // ─── upsert_bank_account ───
     if (action === "upsert_bank_account") {
@@ -120,4 +112,6 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
     });
     return errorResponse("Internal server error", 500);
   }
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/partner-manage-settlement/partner_manage_settlement_test.ts
+++ b/supabase/functions/partner-manage-settlement/partner_manage_settlement_test.ts
@@ -16,6 +16,8 @@ const TEST_PARTNER_ID = "partner-001";
 const ENV = {
   SUPABASE_URL: "http://localhost:54321",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "partner-manage-settlement",
 };
 
 function authRoute(): FetchRoute {


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Summary

Batch-6 of the EF auth migration (Phase 3 — docs/architecture/edge-function-auth.md §8).

Migrates 6 user-caller EFs to `minglitEdgeFunction`:
- `event-checkin`
- `commit-match-likes`
- `partner-manage-event`
- `partner-manage-match`
- `partner-manage-member`
- `partner-manage-settlement`

## Changes per EF

Each EF receives:
- `auth-manifest.json` entry: `callers: ["user"], envs: ["dev", "production"]`
- `index.ts`: boilerplate removed (initSentry, createServiceClient, requireAuth, withHandler, corsResponse)
- `index.ts`: `export const handler` + `minglitEdgeFunction(handler)`

`requirePartnerPermission()` calls are **business logic**, not auth boilerplate — kept intact in handlers.

## Test file updates

`event-checkin` and `commit-match-likes` had existing test files. Updated to:
- Add `ENVIRONMENT: "dev"` and `MINGLIT_EF_TEST_FN_NAME` to ENV
- Wrap `captureServeHandler` calls in `withNoIntervals` (required by minglitEdgeFunction wrapper)
- Move handler capture inside `withEnv` / `withMockedFetch` / `withNoIntervals` nesting

## Net diff

~-60 lines boilerplate. Business logic unchanged.

## Related

- Architecture: docs/architecture/edge-function-auth.md §8 (Phase 3)
- Batch-1: #2305 (merged)
- Batch-3: #2306 (open)
- Batch-4: #2316 (open)
- Batch-5: #2317 (open)