### PR TITLE
feat(edge-functions): migrate batch-7 EFs to minglitEdgeFunction wrapper

### DIFF
--- a/supabase/functions/_contract_tests/contract_test.ts
+++ b/supabase/functions/_contract_tests/contract_test.ts
@@ -173,7 +173,8 @@ Deno.test("contract: payment-cancel response matches schema", async () => {
   const eligiblePaidAt = new Date(nowMs - 1 * 60 * 60 * 1000).toISOString();
   const farFutureEvent = new Date(nowMs + 10 * 24 * 60 * 60 * 1000).toISOString();
 
-  await withEnv(COMMON_ENV, async () => {
+  // payment-cancel is migrated to minglitEdgeFunction — needs ENVIRONMENT + fn name
+  await withEnv({ ...COMMON_ENV, ENVIRONMENT: "dev", MINGLIT_EF_TEST_FN_NAME: "payment-cancel" }, async () => {
     const handler = await captureServeHandler(
       new URL("../payment-cancel/index.ts", import.meta.url),
     );

--- a/supabase/functions/_payment_integration_tests/payment_integration_test.ts
+++ b/supabase/functions/_payment_integration_tests/payment_integration_test.ts
@@ -167,7 +167,8 @@ Deno.test("integration - approved payment: cancel within grace period → refund
   const eligiblePaidAt = new Date(nowMs - 30 * 60 * 1000).toISOString(); // 30분 전 결제
   const farFutureEvent = new Date(nowMs + 10 * 24 * 60 * 60 * 1000).toISOString(); // 10일 후
 
-  await withEnv(ENV, async () => {
+  // payment-cancel is migrated to minglitEdgeFunction — needs ENVIRONMENT + fn name
+  await withEnv({ ...ENV, ENVIRONMENT: "dev", MINGLIT_EF_TEST_FN_NAME: "payment-cancel" }, async () => {
     const handler = await captureServeHandler(
       new URL("../payment-cancel/index.ts", import.meta.url),
     );

--- a/supabase/functions/auth-manifest.json
+++ b/supabase/functions/auth-manifest.json
@@ -205,6 +205,31 @@
       "callers": ["user"],
       "envs": ["dev", "production"],
       "description": "유저 계정 삭제 요청 (7일 유예 기간, 활성 예약/미정산 잔액 선차단)"
+    },
+    "partner-manage-verification": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "파트너 인증 항목 관리 (KYC 카테고리 정의)"
+    },
+    "partner-review-submission": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "파트너 인증 심사 (승인/거부)"
+    },
+    "partner-sync": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "파트너 정보 PortOne 동기화"
+    },
+    "recurrence-rules": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "반복 이벤트 규칙 생성/수정/일시정지/재개/취소"
+    },
+    "payment-cancel": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "결제 취소 및 환불 처리"
     }
   }
 }

--- a/supabase/functions/partner-manage-verification/index.ts
+++ b/supabase/functions/partner-manage-verification/index.ts
@@ -1,18 +1,14 @@
 // partner-manage-verification — Manage verification definitions (create, update)
 // Issue #308: RLS write strategy 전환
+// Fix #2185 (Batch 7): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
 
-import { createServiceClient } from "../_shared/supabase_client.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
 import { parseAction } from "../_shared/request_utils.ts";
-import { initSentry, withHandler } from "../_shared/logger.ts";
-
-initSentry();
 
 const VALID_CATEGORIES = [
   "career",
@@ -44,25 +40,20 @@ const UPDATE_FIELDS = [
   "is_active",
 ] as const;
 
-Deno.serve(withHandler(async (req: Request): Promise<Response> => {
-  if (req.method === "OPTIONS") return corsResponse();
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
   // 1. Environment check (handled by createServiceClient)
 
   // 2. Auth
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const userId = auth;
+  const { supabase } = ctx;
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
 
   // 3. Parse body
   const result = await parseAction(req);
   if (result instanceof Response) return result;
   const { action, body } = result;
   if (!action) return errorResponse("Missing action", 400);
-
-  // 4. Supabase client (service role)
-  const supabase = createServiceClient();
 
   // ─── create ───
   if (action === "create") {
@@ -178,4 +169,6 @@ Deno.serve(withHandler(async (req: Request): Promise<Response> => {
   }
 
   return errorResponse(`Unknown action: ${action}`, 400);
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/partner-manage-verification/partner_manage_verification_test.ts
+++ b/supabase/functions/partner-manage-verification/partner_manage_verification_test.ts
@@ -17,6 +17,8 @@ const TEST_VERIFICATION_ID = "ver-001";
 const ENV = {
   SUPABASE_URL: "http://localhost:54321",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "partner-manage-verification",
 };
 
 function authRoute(): FetchRoute {

--- a/supabase/functions/partner-review-submission/index.ts
+++ b/supabase/functions/partner-review-submission/index.ts
@@ -1,49 +1,29 @@
 // partner-review-submission — Review verification submissions (approve/reject + comment)
 // Issue #309: RLS write strategy 전환
+// Fix #2185 (Batch 7): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
 
-import { createServiceClient } from "../_shared/supabase_client.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
 import { parseAction } from "../_shared/request_utils.ts";
-import { initSentry, withHandler } from "../_shared/logger.ts";
-
-initSentry();
 
 const VALID_RESULTS = ["approved", "rejected"];
 
-Deno.serve(withHandler(async (req: Request): Promise<Response> => {
-  if (req.method === "OPTIONS") return corsResponse();
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
-  try {
-    return await handleRequest(req);
-  } catch (e) {
-    const message = e instanceof Error ? e.message : String(e);
-    return errorResponse(message, 500);
-  }
-}));
+  const { supabase } = ctx;
+  // wrapper guarantees type === "user" per auth-manifest callers: ["user"]
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
 
-async function handleRequest(req: Request): Promise<Response> {
-  // 1. Environment check (handled by createServiceClient)
-
-  // 2. Auth
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const userId = auth;
-
-  // 3. Parse body
+  // Parse body
   const result = await parseAction(req);
   if (result instanceof Response) return result;
   const { action, body } = result;
   if (!action) return errorResponse("Missing action", 400);
-
-  // 4. Supabase client (service role)
-  const supabase = createServiceClient();
 
   // ─── review ───
   if (action === "review") {
@@ -203,4 +183,6 @@ async function handleRequest(req: Request): Promise<Response> {
   }
 
   return errorResponse(`Unknown action: ${action}`, 400);
-}
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/partner-review-submission/partner_review_submission_test.ts
+++ b/supabase/functions/partner-review-submission/partner_review_submission_test.ts
@@ -17,6 +17,8 @@ const TEST_SUBMISSION_ID = "sub-001";
 const ENV = {
   SUPABASE_URL: "http://localhost:54321",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "partner-review-submission",
 };
 
 const SNAPSHOT_DATA = [

--- a/supabase/functions/partner-sync/index.ts
+++ b/supabase/functions/partner-sync/index.ts
@@ -1,21 +1,15 @@
 // Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
-import { createServiceClient } from "../_shared/supabase_client.ts";
+// Fix #2185 (Batch 7): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import { getPortoneClient } from "../_shared/portone_client.ts";
-import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
+import { successResponse, errorResponse } from "../_shared/response_utils.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { initSentry, log, withHandler } from "../_shared/logger.ts";
+import { log } from "../_shared/logger.ts";
 
 const FN = "partner-sync";
 
-
-initSentry();
-
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
-
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+  const { supabase } = ctx;
   try {
     const body = await parseJsonBody(req);
     if (body instanceof Response) return body;
@@ -24,8 +18,6 @@ Deno.serve(withHandler(async (req) => {
     if (!partner_id) {
       return errorResponse("Missing partner_id", 400);
     }
-
-    const supabase = createServiceClient();
 
     const { data: partner, error: partnerError } = await supabase
       .from("partners")
@@ -92,4 +84,6 @@ Deno.serve(withHandler(async (req) => {
     });
     return errorResponse(message, 500);
   }
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/partner-sync/partner_sync_test.ts
+++ b/supabase/functions/partner-sync/partner_sync_test.ts
@@ -15,6 +15,8 @@ const ENV = {
   PORTONE_V2_API_KEY: "test-v2-key",
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "partner-sync",
 };
 
 Deno.test("partner-sync - new partner creates PortOne partner and saves ID", async () => {

--- a/supabase/functions/payment-cancel/index.ts
+++ b/supabase/functions/payment-cancel/index.ts
@@ -1,14 +1,13 @@
 // Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
-import { createServiceClient } from "../_shared/supabase_client.ts";
+// Fix #2185 (Batch 7): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import { nowISO } from "../_shared/temporal_utils.ts";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { initSentry, log, withHandler } from "../_shared/logger.ts";
+import { log } from "../_shared/logger.ts";
 // Fix #299: 환불 로직을 shared 모듈로 추출 — user-cancel-order와 공유
 import {
   executeRefund,
@@ -18,13 +17,11 @@ import {
 
 const FN = "payment-cancel";
 
-initSentry();
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+  const { supabase } = ctx;
+  // wrapper guarantees type === "user" per auth-manifest callers: ["user"]
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
 
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
-
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
   try {
     // 1. Parse Request
     const body = await parseJsonBody(req);
@@ -40,9 +37,6 @@ Deno.serve(withHandler(async (req) => {
       return errorResponse("Missing payment_id", 400);
     }
 
-    // 1.5 Init Supabase (reused throughout)
-    const supabase = createServiceClient();
-
     // 1.5a Fetch application for eligibility check
     const { data: application, error: appError } = await supabase
       .from("event_applications")
@@ -55,7 +49,7 @@ Deno.serve(withHandler(async (req) => {
     }
 
     // Fix #133: 호출자가 신청자 본인인지 검증 — service role은 RLS를 우회하므로 명시적 확인 필요
-    if (application.user_id !== auth) {
+    if (application.user_id !== userId) {
       return errorResponse("Forbidden", 403);
     }
 
@@ -173,4 +167,6 @@ Deno.serve(withHandler(async (req) => {
     });
     return errorResponse(message, 500);
   }
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/payment-cancel/payment_cancel_test.ts
+++ b/supabase/functions/payment-cancel/payment_cancel_test.ts
@@ -17,6 +17,8 @@ const ENV = {
   PORTONE_API_SECRET: "test-secret",
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "payment-cancel",
 };
 
 const nowMs = Date.now();

--- a/supabase/functions/recurrence-rules/index.ts
+++ b/supabase/functions/recurrence-rules/index.ts
@@ -1,22 +1,18 @@
 // recurrence-rules — Manage recurring event rules for parties
 // Issue #1034: 반복 이벤트 규칙 CRUD + 자동 이벤트 생성
+// Fix #2185 (Batch 7): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
 
-import { createServiceClient } from "../_shared/supabase_client.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import {
-  corsResponse,
   errorResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { parseAction } from "../_shared/request_utils.ts";
-import { initSentry, withHandler } from "../_shared/logger.ts";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { handleCreate } from "./_handlers/create.ts";
 import { handleUpdate } from "./_handlers/update.ts";
 import { handlePause } from "./_handlers/pause.ts";
 import { handleResume } from "./_handlers/resume.ts";
 import { handleCancel } from "./_handlers/cancel.ts";
-
-initSentry();
 
 type ActionHandler = (
   body: Record<string, unknown>,
@@ -32,26 +28,21 @@ const DISPATCH: Record<string, ActionHandler> = {
   cancel: handleCancel,
 };
 
-Deno.serve(withHandler(async (req: Request): Promise<Response> => {
-  if (req.method === "OPTIONS") return corsResponse();
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
 
-  try {
-    const auth = await requireAuth(req);
-    if (auth instanceof Response) return auth;
-    const userId = auth;
+  const { supabase } = ctx;
+  // wrapper guarantees type === "user" per auth-manifest callers: ["user"]
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
 
-    const result = await parseAction(req);
-    if (result instanceof Response) return result;
-    const { action, body } = result;
-    if (!action) return errorResponse("Missing action", 400);
+  const result = await parseAction(req);
+  if (result instanceof Response) return result;
+  const { action, body } = result;
+  if (!action) return errorResponse("Missing action", 400);
 
-    const supabase = createServiceClient();
-    const handler = DISPATCH[action];
-    if (!handler) return errorResponse(`Unknown action: ${action}`, 400);
-    return handler(body, supabase, userId);
-  } catch (e) {
-    const message = e instanceof Error ? e.message : String(e);
-    return errorResponse(message, 500);
-  }
-}));
+  const actionHandler = DISPATCH[action];
+  if (!actionHandler) return errorResponse(`Unknown action: ${action}`, 400);
+  return actionHandler(body, supabase, userId);
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/recurrence-rules/recurrence-rules_test.ts
+++ b/supabase/functions/recurrence-rules/recurrence-rules_test.ts
@@ -19,6 +19,8 @@ const TEST_RULE_ID = "rule-001";
 const ENV = {
   SUPABASE_URL: "http://localhost:54321",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "recurrence-rules",
 };
 
 // ─── Route helpers ───
@@ -189,20 +191,24 @@ function insertTicketsRoute(): FetchRoute {
 Deno.test({
   name: "OPTIONS returns CORS preflight",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-    const req = new Request("http://localhost", { method: "OPTIONS" });
-    const res = await handler(req);
-    assertEquals(res.status, 200);
+    await withEnv(ENV, async () => {
+      const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+      const req = new Request("http://localhost", { method: "OPTIONS" });
+      const res = await handler(req);
+      assertEquals(res.status, 200);
+    });
   },
 });
 
 Deno.test({
   name: "GET returns 405",
   fn: async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-    const req = new Request("http://localhost", { method: "GET" });
-    const res = await handler(req);
-    assertEquals(res.status, 405);
+    await withEnv(ENV, async () => {
+      const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+      const req = new Request("http://localhost", { method: "GET" });
+      const res = await handler(req);
+      assertEquals(res.status, 405);
+    });
   },
 });
 

--- a/supabase/functions/recurrence-rules/recurrence-rules_test.ts
+++ b/supabase/functions/recurrence-rules/recurrence-rules_test.ts
@@ -8,6 +8,7 @@ import {
   readJson,
   withEnv,
   withMockedFetch,
+  withNoIntervals,
   type FetchRoute,
 } from "../_test_utils/mock_http.ts";
 
@@ -203,11 +204,20 @@ Deno.test({
 Deno.test({
   name: "GET returns 405",
   fn: async () => {
+    // minglitEdgeFunction runs auth before handler; authenticated GET reaches handler → 405
+    const { fetchMock } = createFetchMock([authRoute()]);
     await withEnv(ENV, async () => {
-      const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-      const req = new Request("http://localhost", { method: "GET" });
-      const res = await handler(req);
-      assertEquals(res.status, 405);
+      await withMockedFetch(fetchMock, async () => {
+        await withNoIntervals(async () => {
+          const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
+          const req = new Request("http://localhost", {
+            method: "GET",
+            headers: { Authorization: "Bearer test-token" },
+          });
+          const res = await handler(req);
+          assertEquals(res.status, 405);
+        });
+      });
     });
   },
 });


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Summary

Batch-7 of the EF auth migration (Phase 3 — docs/architecture/edge-function-auth.md §8).

Migrates 5 user-caller EFs to `minglitEdgeFunction`:
- `partner-manage-verification`
- `partner-review-submission`
- `partner-sync`
- `recurrence-rules`
- `payment-cancel`

## Changes per EF

Each EF receives:
- `auth-manifest.json` entry: `callers: ["user"], envs: ["dev", "production"]`
- `index.ts`: boilerplate removed (initSentry, createServiceClient, requireAuth, withHandler, corsResponse)
- `index.ts`: `export const handler` + `minglitEdgeFunction(handler)`
- test: `ENVIRONMENT: "dev"` + `MINGLIT_EF_TEST_FN_NAME` added to ENV fixture

`requirePartnerPermission()` calls are **business logic** — kept intact.

## Net diff

~-50 lines boilerplate. Business logic unchanged.

## Related

- Architecture: docs/architecture/edge-function-auth.md §8 (Phase 3)
- Batch-5: #2317 (open)
- Batch-6: #2319 (open)