### PR TITLE
feat(edge-functions): migrate batch-8 EFs to minglitEdgeFunction wrapper

### DIFF
--- a/supabase/functions/_contract_tests/contract_test.ts
+++ b/supabase/functions/_contract_tests/contract_test.ts
@@ -88,12 +88,13 @@ const COMMON_ENV = {
   PORTONE_V2_API_KEY: "test-v2-key",
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
+  ENVIRONMENT: "dev",
 };
 
 Deno.test("contract: payment-verify response matches schema", async () => {
   const schema = await loadSchema("payment_verify");
 
-  await withEnv(COMMON_ENV, async () => {
+  await withEnv({ ...COMMON_ENV, MINGLIT_EF_TEST_FN_NAME: "payment-verify" }, async () => {
     const handler = await captureServeHandler(
       new URL("../payment-verify/index.ts", import.meta.url),
     );
@@ -275,7 +276,7 @@ Deno.test("contract: settlement-query response matches schema", async () => {
 Deno.test("contract: payment-verify error matches error schema", async () => {
   const schema = await loadSchema("error");
 
-  await withEnv(COMMON_ENV, async () => {
+  await withEnv({ ...COMMON_ENV, MINGLIT_EF_TEST_FN_NAME: "payment-verify" }, async () => {
     const handler = await captureServeHandler(
       new URL("../payment-verify/index.ts", import.meta.url),
     );

--- a/supabase/functions/_payment_integration_tests/payment_edge_cases_test.ts
+++ b/supabase/functions/_payment_integration_tests/payment_edge_cases_test.ts
@@ -27,6 +27,8 @@ const ENV_VERIFY = {
   PORTONE_API_SECRET: "test-secret",
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "payment-verify",
 };
 
 // --- Shared fixtures ---

--- a/supabase/functions/_payment_integration_tests/payment_integration_test.ts
+++ b/supabase/functions/_payment_integration_tests/payment_integration_test.ts
@@ -28,6 +28,8 @@ const ENV = {
   PORTONE_API_SECRET: "test-secret",
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "payment-verify",
 };
 
 // ─── 시나리오 1: 유료 이벤트 신청 → PG 결제 → 결제 검증 → 티켓 발급 ────────────

--- a/supabase/functions/auth-manifest.json
+++ b/supabase/functions/auth-manifest.json
@@ -66,6 +66,35 @@
       "callers": ["system"],
       "envs": ["dev", "production"],
       "description": "이벤트 체크인 참가자 매치 페어 생성 (Fix #592)"
+    },
+    "notification-worker": {
+      "callers": ["system"],
+      "envs": ["dev", "production"],
+      "description": "알림 발송 워커 (cron 트리거)"
+    },
+    "payment-verify": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "결제 완료 검증 (PortOne V1)"
+    },
+    "user-submit-verification": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "유저 인증 데이터 제출"
+    },
+    "user-update-verification": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "유저 인증 폼 데이터 저장/수정"
+    },
+    "payment-webhook": {
+      "callers": ["external"],
+      "envs": ["dev", "production"],
+      "external_auth": {
+        "type": "ip_allowlist",
+        "ips": ["52.78.100.19", "52.78.48.223", "52.78.17.128"]
+      },
+      "description": "PortOne V1 결제 웹훅 수신"
     }
   }
 }

--- a/supabase/functions/notification-worker/index.ts
+++ b/supabase/functions/notification-worker/index.ts
@@ -1,11 +1,12 @@
+// Fix #2185 (Batch 8): migrate to minglitEdgeFunction wrapper — auth via manifest
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import { createServiceClient } from '../_shared/supabase_client.ts'
 import { requireEnv } from '../_shared/env_keystore.ts'
 import { runWorkerLoop } from './loop_worker.ts'
 import { WorkerUtils } from '../_shared/worker_utils.ts'
 import { isoToUnix } from '../_shared/temporal_utils.ts'
 import * as jose from 'jose'
-import { initSentry, withHandler, log } from '../_shared/logger.ts'
-import { requireServiceRole } from '../_shared/auth_utils.ts'
+import { log } from '../_shared/logger.ts'
 import { isNightTimeKST, secondsUntilKST8AM } from './marketing_guards.ts'
 
 const FN = "notification-worker";
@@ -239,13 +240,8 @@ async function sendToAllParticipants(
   }
 }
 
-
-initSentry();
-
-Deno.serve(withHandler(async (req) => {
-  // Fix #1489: 시스템 전용 EF — service_role만 허용
-  const auth = requireServiceRole(req);
-  if (auth instanceof Response) return auth;
+export const handler = async (_req: Request, ctx: EFContext): Promise<Response> => {
+  const { supabase } = ctx;
   // env-manifest: validate all required env vars for this function
   const envErr = requireEnv("notification-worker");
   if (envErr) return envErr;
@@ -257,7 +253,6 @@ Deno.serve(withHandler(async (req) => {
         throw new Error("Missing environment variable: FIREBASE_SERVICE_ACCOUNT");
     }
 
-    const supabase = createServiceClient()
     const utils = new WorkerUtils(supabase, 'q_notifications')
 
     log({ function: FN, level: "info", message: "Notification Worker v2 Started" });
@@ -504,4 +499,6 @@ Deno.serve(withHandler(async (req) => {
       headers: { "Content-Type": "application/json" }
     })
   }
-}))
+}
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/notification-worker/notification_worker_test.ts
+++ b/supabase/functions/notification-worker/notification_worker_test.ts
@@ -290,15 +290,15 @@ Deno.test({
 });
 
 Deno.test({
-  name: "notification-worker - missing env returns 500",
+  name: "notification-worker - missing FIREBASE_SERVICE_ACCOUNT returns 500",
   fn: async () => {
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
   const { fetchMock } = createFetchMock([]);
 
   await withEnv(
     {
-      SUPABASE_URL: undefined,
-      SUPABASE_SERVICE_ROLE_KEY: undefined,
+      SUPABASE_URL: "https://supabase.test",
+      SUPABASE_SERVICE_ROLE_KEY: "service-key",
       FIREBASE_SERVICE_ACCOUNT: undefined,
       ENVIRONMENT: "dev",
       MINGLIT_EF_TEST_FN_NAME: "notification-worker",
@@ -307,7 +307,9 @@ Deno.test({
       await withMockedFetch(fetchMock, async () => {
         await withNoIntervals(async () => {
           await withFastTimers(async () => {
-            const response = await handler(new Request("http://localhost"));
+            // Auth passes (Bearer service-key matches SUPABASE_SERVICE_ROLE_KEY)
+            // but FIREBASE_SERVICE_ACCOUNT missing → handler throws → 500
+            const response = await handler(new Request("http://localhost", { headers: { "Authorization": "Bearer service-key" } }));
             const payload = await readJson(response);
 
             assertEquals(response.status, 500);

--- a/supabase/functions/notification-worker/notification_worker_test.ts
+++ b/supabase/functions/notification-worker/notification_worker_test.ts
@@ -132,6 +132,8 @@ Deno.test({
         SUPABASE_URL: "https://supabase.test",
         SUPABASE_SERVICE_ROLE_KEY: "service-key",
         FIREBASE_SERVICE_ACCOUNT: firebaseServiceAccountJson,
+        ENVIRONMENT: "dev",
+        MINGLIT_EF_TEST_FN_NAME: "notification-worker",
       },
       async () => {
         await withMockedFetch(fetchMock, async () => {
@@ -202,6 +204,8 @@ Deno.test({
         SUPABASE_URL: "https://supabase.test",
         SUPABASE_SERVICE_ROLE_KEY: "service-key",
         FIREBASE_SERVICE_ACCOUNT: firebaseServiceAccountJson,
+        ENVIRONMENT: "dev",
+        MINGLIT_EF_TEST_FN_NAME: "notification-worker",
       },
       async () => {
         await withMockedFetch(fetchMock, async () => {
@@ -238,6 +242,8 @@ Deno.test({
       SUPABASE_URL: "https://supabase.test",
       SUPABASE_SERVICE_ROLE_KEY: "service-key",
       FIREBASE_SERVICE_ACCOUNT: firebaseServiceAccountJson,
+      ENVIRONMENT: "dev",
+      MINGLIT_EF_TEST_FN_NAME: "notification-worker",
     },
     async () => {
       await withMockedFetch(fetchMock, async () => {
@@ -264,6 +270,8 @@ Deno.test({
       SUPABASE_URL: "https://supabase.test",
       SUPABASE_SERVICE_ROLE_KEY: "service-key",
       FIREBASE_SERVICE_ACCOUNT: firebaseServiceAccountJson,
+      ENVIRONMENT: "dev",
+      MINGLIT_EF_TEST_FN_NAME: "notification-worker",
     },
     async () => {
       await withMockedFetch(fetchMock, async () => {
@@ -292,6 +300,8 @@ Deno.test({
       SUPABASE_URL: undefined,
       SUPABASE_SERVICE_ROLE_KEY: undefined,
       FIREBASE_SERVICE_ACCOUNT: undefined,
+      ENVIRONMENT: "dev",
+      MINGLIT_EF_TEST_FN_NAME: "notification-worker",
     },
     async () => {
       await withMockedFetch(fetchMock, async () => {
@@ -375,6 +385,8 @@ Deno.test({
         SUPABASE_URL: "https://supabase.test",
         SUPABASE_SERVICE_ROLE_KEY: "service-key",
         FIREBASE_SERVICE_ACCOUNT: firebaseServiceAccountJson,
+        ENVIRONMENT: "dev",
+        MINGLIT_EF_TEST_FN_NAME: "notification-worker",
       },
       async () => {
         await withMockedFetch(fetchMock, async () => {
@@ -430,6 +442,8 @@ Deno.test({
         SUPABASE_URL: "https://supabase.test",
         SUPABASE_SERVICE_ROLE_KEY: "service-key",
         FIREBASE_SERVICE_ACCOUNT: firebaseServiceAccountJson,
+        ENVIRONMENT: "dev",
+        MINGLIT_EF_TEST_FN_NAME: "notification-worker",
       },
       async () => {
         await withMockedFetch(fetchMock, async () => {
@@ -508,6 +522,8 @@ Deno.test({
         SUPABASE_URL: "https://supabase.test",
         SUPABASE_SERVICE_ROLE_KEY: "service-key",
         FIREBASE_SERVICE_ACCOUNT: firebaseServiceAccountJson,
+        ENVIRONMENT: "dev",
+        MINGLIT_EF_TEST_FN_NAME: "notification-worker",
       },
       async () => {
         await withMockedFetch(fetchMock, async () => {
@@ -562,6 +578,8 @@ Deno.test({
         SUPABASE_URL: "https://supabase.test",
         SUPABASE_SERVICE_ROLE_KEY: "service-key",
         FIREBASE_SERVICE_ACCOUNT: firebaseServiceAccountJson,
+        ENVIRONMENT: "dev",
+        MINGLIT_EF_TEST_FN_NAME: "notification-worker",
       },
       async () => {
         await withMockedFetch(fetchMock, async () => {
@@ -620,6 +638,8 @@ Deno.test({
         SUPABASE_URL: "https://supabase.test",
         SUPABASE_SERVICE_ROLE_KEY: "service-key",
         FIREBASE_SERVICE_ACCOUNT: firebaseServiceAccountJson,
+        ENVIRONMENT: "dev",
+        MINGLIT_EF_TEST_FN_NAME: "notification-worker",
       },
       async () => {
         await withMockedFetch(fetchMock, async () => {
@@ -686,6 +706,8 @@ Deno.test({
         SUPABASE_URL: "https://supabase.test",
         SUPABASE_SERVICE_ROLE_KEY: "service-key",
         FIREBASE_SERVICE_ACCOUNT: firebaseServiceAccountJson,
+        ENVIRONMENT: "dev",
+        MINGLIT_EF_TEST_FN_NAME: "notification-worker",
       },
       async () => {
         await withMockedFetch(fetchMock, async () => {

--- a/supabase/functions/payment-verify/index.ts
+++ b/supabase/functions/payment-verify/index.ts
@@ -1,15 +1,14 @@
+// Fix #2185 (Batch 8): migrate to minglitEdgeFunction wrapper — auth via manifest
 // Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
-import { createServiceClient } from "../_shared/supabase_client.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import { nowISO } from "../_shared/temporal_utils.ts";
 import { IamportClient } from "../_shared/iamport_client.ts";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { initSentry, log, withHandler, withSpan } from "../_shared/logger.ts";
+import { log, withSpan } from "../_shared/logger.ts";
 
 const FN = "payment-verify";
 import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
@@ -23,14 +22,12 @@ if (!IMP_KEY || !IMP_SECRET) {
   );
 }
 
-initSentry();
 initStatsig();
 
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+  const { supabase } = ctx;
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
 
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
   try {
     const body = await parseJsonBody(req);
     if (body instanceof Response) return body;
@@ -42,9 +39,6 @@ Deno.serve(withHandler(async (req) => {
     if (!imp_uid || !merchant_uid) {
       return errorResponse("Missing required parameters", 400);
     }
-
-    // 0. Supabase Client 초기화
-    const supabase = createServiceClient();
 
     // 1. DB에서 주문 정보 조회 (금액 확인)
     const { data: order, error: orderError } = await withSpan(
@@ -63,7 +57,7 @@ Deno.serve(withHandler(async (req) => {
     }
 
     // Fix #1490: 호출자가 신청자 본인인지 검증 — service role은 RLS를 우회하므로 명시적 확인 필요
-    if (order.user_id !== auth) {
+    if (order.user_id !== userId) {
       return errorResponse("Forbidden", 403);
     }
 
@@ -78,7 +72,7 @@ Deno.serve(withHandler(async (req) => {
 
     // 3. 결제 상태 및 금액 검증
     if (payment.status !== "paid") {
-      logStatsigEvent(auth, "payment_failed", undefined, {
+      logStatsigEvent(userId, "payment_failed", undefined, {
         reason: "payment_not_completed",
         imp_uid,
       }).catch(() => {});
@@ -99,7 +93,7 @@ Deno.serve(withHandler(async (req) => {
           });
         },
       );
-      logStatsigEvent(auth, "payment_failed", undefined, {
+      logStatsigEvent(userId, "payment_failed", undefined, {
         reason: "amount_mismatch",
         imp_uid,
       }).catch(() => {});
@@ -137,14 +131,14 @@ Deno.serve(withHandler(async (req) => {
         message: "DB Update Error",
         metadata: { detail: updateError },
       });
-      logStatsigEvent(auth, "payment_failed", undefined, {
+      logStatsigEvent(userId, "payment_failed", undefined, {
         reason: "db_update_error",
         imp_uid,
       }).catch(() => {});
       return errorResponse("Failed to update order status", 500);
     }
 
-    logStatsigEvent(auth, "payment_completed", payment.amount, {
+    logStatsigEvent(userId, "payment_completed", payment.amount, {
       imp_uid,
       merchant_uid,
     }).catch(() => {});
@@ -159,4 +153,6 @@ Deno.serve(withHandler(async (req) => {
     });
     return errorResponse(message, 500);
   }
-}));
+}
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/payment-verify/payment_verify_test.ts
+++ b/supabase/functions/payment-verify/payment_verify_test.ts
@@ -20,6 +20,8 @@ const ENV = {
   PORTONE_API_SECRET: "test-secret",
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "payment-verify",
 };
 
 Deno.test("payment-verify - happy path approves order", async () => {

--- a/supabase/functions/payment-webhook/index.ts
+++ b/supabase/functions/payment-webhook/index.ts
@@ -1,9 +1,9 @@
-// Fix #1892: 호출자 검증 강화 (H1 — 127.0.0.1 prod 제거, H2 — XFF 파싱 개선)
-// V1은 HMAC 미지원이므로 IP whitelist + Portone cross-check가 방어선. V2 마이그레이션 시 HMAC 추가 가능.
+// Fix #2185 (Batch 8): migrate to minglitEdgeFunction wrapper — auth via manifest
+// IP allowlist now handled by wrapper via external_auth in auth-manifest.json
 // Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
-import { createServiceClient } from "../_shared/supabase_client.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import { IamportClient } from "../_shared/iamport_client.ts";
-import { initSentry, withHandler, log } from "../_shared/logger.ts";
+import { log } from "../_shared/logger.ts";
 import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
 import { nowISO } from "../_shared/temporal_utils.ts";
 
@@ -16,37 +16,13 @@ if (!IMP_KEY || !IMP_SECRET) {
   throw new Error("Missing required environment variables: PORTONE_API_KEY, PORTONE_API_SECRET");
 }
 
-// Portone (Iamport V1) Webhook IP Whitelist
-// Fix #1892 H1: 127.0.0.1은 dev 환경에서만 허용 — production에서 localhost를 허용하면
-// X-Forwarded-For 스푸핑으로 IP 게이트가 무력화될 수 있음
-const _IS_DEV_ENV = Deno.env.get("ENVIRONMENT") === "dev";
-const ALLOWED_IPS = _IS_DEV_ENV
-  ? ["52.78.100.19", "52.78.48.223", "52.78.17.128", "127.0.0.1"]
-  : ["52.78.100.19", "52.78.48.223", "52.78.17.128"];
-
-initSentry();
 initStatsig();
 
-Deno.serve(withHandler(async (req) => {
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+  const { supabase } = ctx;
+
   try {
     const rawBody = await req.text();
-
-    // 1. IP Validation (Primary Security Layer for V1 — V1 has no HMAC signing)
-    // Fix #1892 H2: 우선순위 — edge/CDN이 주입하는 헤더를 신뢰, 클라이언트가 조작 가능한 leftmost XFF 금지.
-    //   1) x-real-ip: Supabase Edge/CDN이 실제 연결 IP로 설정
-    //   2) cf-connecting-ip: Cloudflare가 설정하는 클라이언트 IP (Supabase가 CF 인프라 사용 시)
-    //   3) XFF rightmost fallback: CDN이 XFF에 연결 IP를 append하는 구조에서의 안전한 fallback.
-    //      leftmost는 클라이언트가 임의 조작 가능하므로 사용하지 않음.
-    const clientIp =
-      req.headers.get("x-real-ip")?.trim() ||
-      req.headers.get("cf-connecting-ip")?.trim() ||
-      req.headers.get("x-forwarded-for")?.split(",").map((s) => s.trim()).filter(Boolean).pop() ||
-      "";
-
-    if (!clientIp || !ALLOWED_IPS.includes(clientIp)) {
-      log({ function: FN, level: "warn", message: `Blocked Webhook Request from unauthorized IP: ${clientIp || "(empty)"}` });
-      return new Response("Unauthorized IP", { status: 403 });
-    }
 
     let body: Record<string, unknown>;
     try {
@@ -65,7 +41,6 @@ Deno.serve(withHandler(async (req) => {
     // Fix #1949: Idempotency check — reject replayed webhooks before hitting PortOne API.
     // SELECT-first is intentional: INSERT-first would consume the key on transient failures,
     // blocking PortOne retries. We insert only after a successful DB update below.
-    const supabase = createServiceClient();
     const { data: existingLog } = await supabase
       .from("webhook_imp_uid_log")
       .select("imp_uid")
@@ -180,4 +155,6 @@ Deno.serve(withHandler(async (req) => {
     log({ function: FN, level: "error", message: `Webhook Error: ${errorMessage}` });
     return new Response(errorMessage, { status: 500 });
   }
-}));
+}
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/payment-webhook/payment_webhook_test.ts
+++ b/supabase/functions/payment-webhook/payment_webhook_test.ts
@@ -15,11 +15,11 @@ const ENV = {
   PORTONE_API_SECRET: "test-secret",
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "payment-webhook",
 };
 
-const DEV_ENV = { ...ENV, ENVIRONMENT: "dev" };
-
-// Real Portone webhook IP (used in non-dev tests to pass IP gate)
+// Real Portone webhook IP (used to pass IP allowlist gate in auth-manifest)
 const PORTONE_IP = "52.78.100.19";
 
 Deno.test("payment-webhook - happy path updates status", async () => {
@@ -64,7 +64,7 @@ Deno.test("payment-webhook - happy path updates status", async () => {
   });
 });
 
-Deno.test("payment-webhook - unauthorized IP returns 403", async () => {
+Deno.test("payment-webhook - unauthorized IP returns 401", async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([]);
@@ -77,15 +77,17 @@ Deno.test("payment-webhook - unauthorized IP returns 403", async () => {
           { headers: { "x-forwarded-for": "10.0.0.1" } },
         );
         const response = await handler(request);
-        assertEquals(response.status, 403);
-        assertEquals(await response.text(), "Unauthorized IP");
+        // Fix #2185 (Batch 8): IP check now via wrapper manifest; returns 401 JSON (not 403 text)
+        assertEquals(response.status, 401);
+        const body = await response.json();
+        assertEquals(body.error, "Unauthorized");
       });
     });
   });
 });
 
-// Fix #1892 H1: 127.0.0.1은 production에서 차단되어야 함
-Deno.test("payment-webhook - localhost IP blocked in production", async () => {
+// Fix #2185 (Batch 8): 127.0.0.1 is not in manifest ips — always blocked (manifest-enforced, not env-specific)
+Deno.test("payment-webhook - localhost IP always blocked (not in manifest allowlist)", async () => {
   await withEnv(ENV, async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
     const { fetchMock } = createFetchMock([]);
@@ -98,49 +100,10 @@ Deno.test("payment-webhook - localhost IP blocked in production", async () => {
           { headers: { "x-forwarded-for": "127.0.0.1" } },
         );
         const response = await handler(request);
-        assertEquals(response.status, 403);
-        assertEquals(await response.text(), "Unauthorized IP");
-      });
-    });
-  });
-});
-
-// Fix #1892 H1: ENVIRONMENT=dev에서는 127.0.0.1 허용
-Deno.test("payment-webhook - localhost IP allowed in dev env", async () => {
-  await withEnv(DEV_ENV, async () => {
-    const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-    const { fetchMock } = createFetchMock([
-      {
-        matcher: (req) => req.url.includes("/rest/v1/webhook_imp_uid_log") && req.method === "GET",
-        handler: () => new Response("null", { status: 200, headers: { "Content-Type": "application/json" } }),
-      },
-      {
-        matcher: (req) => req.url.includes("/rest/v1/webhook_imp_uid_log") && req.method === "POST",
-        handler: () => jsonResponse({}),
-      },
-      {
-        matcher: "https://api.iamport.kr/users/getToken",
-        handler: () => jsonResponse({ code: 0, response: { access_token: "token" } }),
-      },
-      {
-        matcher: "https://api.iamport.kr/payments/imp_dev",
-        handler: () => jsonResponse({ code: 0, response: { merchant_uid: "order-dev", status: "paid" } }),
-      },
-      {
-        matcher: (req) => req.url.includes("/rest/v1/event_applications") && req.method === "PATCH",
-        handler: () => jsonResponse({}),
-      },
-    ]);
-
-    await withMockedFetch(fetchMock, async () => {
-      await withNoIntervals(async () => {
-        const request = jsonRequest(
-          "http://localhost",
-          { imp_uid: "imp_dev", merchant_uid: "order-dev", status: "paid" },
-          { headers: { "x-forwarded-for": "127.0.0.1" } },
-        );
-        const response = await handler(request);
-        assertEquals(response.status, 200);
+        // IP allowlist declared in auth-manifest.json (3 Portone IPs, no 127.0.0.1)
+        assertEquals(response.status, 401);
+        const body = await response.json();
+        assertEquals(body.error, "Unauthorized");
       });
     });
   });
@@ -161,9 +124,10 @@ Deno.test("payment-webhook - spoofed XFF first hop blocked", async () => {
           { headers: { "x-forwarded-for": `${PORTONE_IP}, evil.example.com` } },
         );
         const response = await handler(request);
-        // rightmost(evil.example.com)가 선택되므로 403
-        assertEquals(response.status, 403);
-        assertEquals(await response.text(), "Unauthorized IP");
+        // rightmost(evil.example.com)가 선택되므로 401 (Fix #2185: wrapper returns JSON 401)
+        assertEquals(response.status, 401);
+        const body = await response.json();
+        assertEquals(body.error, "Unauthorized");
       });
     });
   });

--- a/supabase/functions/user-submit-verification/index.ts
+++ b/supabase/functions/user-submit-verification/index.ts
@@ -1,25 +1,20 @@
-import { createServiceClient } from "../_shared/supabase_client.ts";
+// Fix #2185 (Batch 8): migrate to minglitEdgeFunction wrapper — auth via manifest
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { parseAction } from "../_shared/request_utils.ts";
-import { initSentry, log, withHandler, withSpan } from "../_shared/logger.ts";
+import { log, withSpan } from "../_shared/logger.ts";
 import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
 
 const FN = "user-submit-verification";
 
-initSentry();
 initStatsig();
 
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
-
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const userId = auth;
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+  const { supabase } = ctx;
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
 
   try {
     const result = await parseAction(req);
@@ -28,8 +23,6 @@ Deno.serve(withHandler(async (req) => {
     if (!action) {
       return errorResponse("Missing required field: action", 400);
     }
-
-    const supabase = createServiceClient();
 
     switch (action) {
       case "submit": {
@@ -288,4 +281,6 @@ Deno.serve(withHandler(async (req) => {
     });
     return errorResponse(message, 500);
   }
-}));
+}
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/user-submit-verification/user_submit_verification_test.ts
+++ b/supabase/functions/user-submit-verification/user_submit_verification_test.ts
@@ -16,6 +16,8 @@ import { authRoute } from "../_test_utils/fixtures.ts";
 const ENV = {
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "user-submit-verification",
 };
 
 // --- Route helpers ---

--- a/supabase/functions/user-update-verification/index.ts
+++ b/supabase/functions/user-update-verification/index.ts
@@ -1,25 +1,20 @@
-import { createServiceClient } from "../_shared/supabase_client.ts";
+// Fix #2185 (Batch 8): migrate to minglitEdgeFunction wrapper — auth via manifest
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { initSentry, log, withHandler, withSpan } from "../_shared/logger.ts";
+import { log, withSpan } from "../_shared/logger.ts";
 import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
 
 const FN = "user-update-verification";
 
-initSentry();
 initStatsig();
 
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
-
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const userId = auth;
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+  const { supabase } = ctx;
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
 
   try {
     const body = await parseJsonBody(req);
@@ -36,8 +31,6 @@ Deno.serve(withHandler(async (req) => {
     if (!data || typeof data !== "object") {
       return errorResponse("Missing required field: data", 400);
     }
-
-    const supabase = createServiceClient();
 
     // Verify that the verification definition exists
     const { data: verification, error: verificationError } = await withSpan(
@@ -107,4 +100,6 @@ Deno.serve(withHandler(async (req) => {
     });
     return errorResponse(message, 500);
   }
-}));
+}
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/user-update-verification/user_update_verification_test.ts
+++ b/supabase/functions/user-update-verification/user_update_verification_test.ts
@@ -16,6 +16,8 @@ import { authRoute } from "../_test_utils/fixtures.ts";
 const ENV = {
   SUPABASE_URL: "https://supabase.test",
   SUPABASE_SERVICE_ROLE_KEY: "service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "user-update-verification",
 };
 
 // --- Route helpers ---


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Summary

Batch-8 of the EF auth migration (Phase 3 — docs/architecture/edge-function-auth.md §8).

Migrates 5 EFs to `minglitEdgeFunction`:
- `notification-worker` — system caller
- `payment-verify` — user caller (Statsig preserved)
- `user-submit-verification` — user caller (Statsig preserved)
- `user-update-verification` — user caller (Statsig preserved)
- `payment-webhook` — external caller (PortOne IP allowlist via manifest)

## Key notes

- `initStatsig()` kept at module level for Statsig-using functions (global init pattern, compatible with wrapper)
- `payment-webhook`: manual `ALLOWED_IPS` check removed — now declared in `external_auth.ips` in manifest
- `payment-webhook` tests updated: IP-blocked responses now return 401 JSON (wrapper standard) instead of 403 text; "localhost allowed in dev" test removed as wrapper enforces manifest ips uniformly across envs

## Related

- Architecture: docs/architecture/edge-function-auth.md §8 (Phase 3)
- Batch-5: #2317 (open)
- Batch-6: #2319 (open)
- Batch-7: #2320 (open)