### PR TITLE
feat(edge-functions): migrate batch-9 EFs to minglitEdgeFunction wrapper

### DIFF
--- a/supabase/functions/_contract_tests/contract_test.ts
+++ b/supabase/functions/_contract_tests/contract_test.ts
@@ -136,7 +136,7 @@ Deno.test("contract: payment-verify response matches schema", async () => {
 Deno.test("contract: identity-verify response matches schema", async () => {
   const schema = await loadSchema("identity_verify");
 
-  await withEnv(COMMON_ENV, async () => {
+  await withEnv({ ...COMMON_ENV, MINGLIT_EF_TEST_FN_NAME: "identity-verify" }, async () => {
     const handler = await captureServeHandler(
       new URL("../identity-verify/index.ts", import.meta.url),
     );

--- a/supabase/functions/auth-manifest.json
+++ b/supabase/functions/auth-manifest.json
@@ -230,6 +230,31 @@
       "callers": ["user"],
       "envs": ["dev", "production"],
       "description": "결제 취소 및 환불 처리"
+    },
+    "identity-verify": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "PortOne V2 본인인증 → 유저 프로필 업데이트 (CI/DI 암호화 저장)"
+    },
+    "bug-report": {
+      "callers": ["user"],
+      "envs": ["dev", "production"],
+      "description": "유저 버그 리포트 제출 → GitHub 이슈 생성"
+    },
+    "dev-mock-portone": {
+      "callers": ["public"],
+      "envs": ["local", "development", "dev"],
+      "description": "PortOne API 모킹 (dev/local 전용 — users/getToken, payments)"
+    },
+    "dev-seed": {
+      "callers": ["public"],
+      "envs": ["local", "development", "dev"],
+      "description": "Dev 시딩 — 이미지 업로드 전용 (seed.dev.sql로 데이터 시딩)"
+    },
+    "dev-session-switch": {
+      "callers": ["public"],
+      "envs": ["local", "development", "dev"],
+      "description": "Dev 세션 전환 — 유저 목록 조회 (테스트용)"
     }
   }
 }

--- a/supabase/functions/bug-report/bug_report_test.ts
+++ b/supabase/functions/bug-report/bug_report_test.ts
@@ -19,6 +19,8 @@ const BASE_ENV = {
   GITHUB_ACCESS_TOKEN: "test-token",
   SUPABASE_URL: "https://test.supabase.co",
   SUPABASE_SERVICE_ROLE_KEY: "test-service-key",
+  ENVIRONMENT: "dev",
+  MINGLIT_EF_TEST_FN_NAME: "bug-report",
 };
 
 const SUPABASE_AUTH_ROUTE = {

--- a/supabase/functions/bug-report/index.ts
+++ b/supabase/functions/bug-report/index.ts
@@ -1,26 +1,18 @@
+// Fix #2184 (Batch 9): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
 import {
-  corsResponse,
   errorResponse,
   successResponse,
 } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { initSentry, log, withHandler } from "../_shared/logger.ts";
+import { log } from "../_shared/logger.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 
 const FN = "bug-report";
 
 const GITHUB_TOKEN = Deno.env.get("GITHUB_ACCESS_TOKEN");
 const GITHUB_REPO = "Mark-Yun/minglit";
 
-initSentry();
-
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
-
-  // Verify JWT (ES256-compatible, via Auth server)
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-
+export const handler = async (req: Request, _ctx: EFContext): Promise<Response> => {
   try {
     const body = await parseJsonBody(req);
     if (body instanceof Response) return body;
@@ -140,4 +132,6 @@ ${screenshotSection}${environmentSection}${layoutDumpSection}`;
     });
     return errorResponse(message, 500);
   }
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/dev-mock-portone/dev_mock_portone_test.ts
+++ b/supabase/functions/dev-mock-portone/dev_mock_portone_test.ts
@@ -10,11 +10,11 @@ Deno.test({
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
-    await withEnv({ ENVIRONMENT: "production" }, async () => {
+    await withEnv({ ENVIRONMENT: "production", MINGLIT_EF_TEST_FN_NAME: "dev-mock-portone" }, async () => {
       const response = await handler(new Request("http://localhost/users/getToken", { method: "POST" }));
       assertEquals(response.status, 403);
       const body = await readJson(response);
-      assertEquals(body.error, "Dev-only function. Blocked in production.");
+      assertEquals(body.error, "Function disabled in production");
     });
   },
 });
@@ -24,7 +24,7 @@ Deno.test({
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
-    await withEnv({ ENVIRONMENT: "local" }, async () => {
+    await withEnv({ ENVIRONMENT: "local", MINGLIT_EF_TEST_FN_NAME: "dev-mock-portone" }, async () => {
       const response = await handler(
         new Request("http://localhost/users/getToken", {
           method: "POST",
@@ -45,7 +45,7 @@ Deno.test({
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
-    await withEnv({ ENVIRONMENT: "development" }, async () => {
+    await withEnv({ ENVIRONMENT: "development", MINGLIT_EF_TEST_FN_NAME: "dev-mock-portone" }, async () => {
       const response = await handler(
         new Request("http://localhost/payments/imp_test_123", {
           method: "GET",
@@ -68,7 +68,7 @@ Deno.test({
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
-    await withEnv({ ENVIRONMENT: "local" }, async () => {
+    await withEnv({ ENVIRONMENT: "local", MINGLIT_EF_TEST_FN_NAME: "dev-mock-portone" }, async () => {
       const response = await handler(
         new Request("http://localhost/payments/imp_fail_abc", {
           method: "GET",
@@ -88,7 +88,7 @@ Deno.test({
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
-    await withEnv({ ENVIRONMENT: "local" }, async () => {
+    await withEnv({ ENVIRONMENT: "local", MINGLIT_EF_TEST_FN_NAME: "dev-mock-portone" }, async () => {
       const response = await handler(
         new Request("http://localhost/payments/cancel", {
           method: "POST",
@@ -114,7 +114,7 @@ Deno.test({
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
-    await withEnv({ ENVIRONMENT: "local" }, async () => {
+    await withEnv({ ENVIRONMENT: "local", MINGLIT_EF_TEST_FN_NAME: "dev-mock-portone" }, async () => {
       const response = await handler(
         new Request("http://localhost/unknown/path", { method: "GET" }),
       );

--- a/supabase/functions/dev-mock-portone/index.ts
+++ b/supabase/functions/dev-mock-portone/index.ts
@@ -1,7 +1,6 @@
-import { initSentry, withHandler } from "../_shared/logger.ts";
+// Fix #2184 (Batch 9): migrate to minglitEdgeFunction wrapper — public caller, dev-only
 import { parseJsonBody } from "../_shared/request_utils.ts";
-
-initSentry();
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -17,19 +16,7 @@ function json(body: unknown, status = 200): Response {
   });
 }
 
-Deno.serve(withHandler(async (req) => {
-  // Handle CORS preflight
-  if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
-  }
-
-  // Dev-only guard
-  const env = Deno.env.get("ENVIRONMENT");
-  // Fix #1614: "dev" = Supabase dev project (set by supabase-deploy.yml secrets)
-  if (env !== "local" && env !== "development" && env !== "dev") {
-    return json({ error: "Dev-only function. Blocked in production." }, 403);
-  }
-
+export const handler = async (req: Request, _ctx: EFContext): Promise<Response> => {
   const url = new URL(req.url);
   const path = url.pathname;
 
@@ -78,4 +65,6 @@ Deno.serve(withHandler(async (req) => {
   }
 
   return json({ error: "Not found" }, 404);
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/dev-seed/dev_seed_test.ts
+++ b/supabase/functions/dev-seed/dev_seed_test.ts
@@ -17,11 +17,11 @@ Deno.test({
       new URL("./index.ts", import.meta.url),
     );
 
-    await withEnv({ ENVIRONMENT: "production" }, async () => {
+    await withEnv({ ENVIRONMENT: "production", MINGLIT_EF_TEST_FN_NAME: "dev-seed" }, async () => {
       const response = await handler(new Request("http://localhost"));
       assertEquals(response.status, 403);
       const body = await readJson(response);
-      assertEquals(body.error, "Dev-only function. Blocked in production.");
+      assertEquals(body.error, "Function disabled in production");
     });
   },
 });
@@ -34,9 +34,10 @@ Deno.test({
       new URL("./index.ts", import.meta.url),
     );
 
-    await withEnv({ ENVIRONMENT: undefined }, async () => {
+    // wrapper init fails when ENVIRONMENT is unset → returns 500 on request
+    await withEnv({ ENVIRONMENT: undefined, MINGLIT_EF_TEST_FN_NAME: "dev-seed" }, async () => {
       const response = await handler(new Request("http://localhost"));
-      assertEquals(response.status, 403);
+      assertEquals(response.status, 500);
     });
   },
 });
@@ -71,6 +72,7 @@ Deno.test({
       ENVIRONMENT: "dev",
       SUPABASE_URL: "http://localhost:54321",
       SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+      MINGLIT_EF_TEST_FN_NAME: "dev-seed",
     }, async () => {
       await withMockedFetch(fetchMock, async () => {
         const response = await handler(
@@ -115,6 +117,7 @@ Deno.test({
       ENVIRONMENT: "development",
       SUPABASE_URL: "http://localhost:54321",
       SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+      MINGLIT_EF_TEST_FN_NAME: "dev-seed",
     }, async () => {
       await withMockedFetch(fetchMock, async () => {
         const response = await handler(
@@ -158,6 +161,7 @@ Deno.test({
       ENVIRONMENT: "development",
       SUPABASE_URL: "http://localhost:54321",
       SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+      MINGLIT_EF_TEST_FN_NAME: "dev-seed",
     }, async () => {
       await withMockedFetch(fetchMock, async () => {
         // No ?mode param — should default to images-only
@@ -181,6 +185,7 @@ Deno.test({
       ENVIRONMENT: "development",
       SUPABASE_URL: "http://localhost:54321",
       SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+      MINGLIT_EF_TEST_FN_NAME: "dev-seed",
     }, async () => {
       const response = await handler(
         new Request("http://localhost?mode=static"),
@@ -203,6 +208,7 @@ Deno.test({
       ENVIRONMENT: "development",
       SUPABASE_URL: "http://localhost:54321",
       SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+      MINGLIT_EF_TEST_FN_NAME: "dev-seed",
     }, async () => {
       const response = await handler(
         new Request("http://localhost?mode=full"),
@@ -228,6 +234,7 @@ Deno.test({
       ENVIRONMENT: "development",
       SUPABASE_URL: undefined,
       SUPABASE_SERVICE_ROLE_KEY: undefined,
+      MINGLIT_EF_TEST_FN_NAME: "dev-seed",
     }, async () => {
       const response = await handler(
         new Request("http://localhost?mode=images-only"),

--- a/supabase/functions/dev-seed/index.ts
+++ b/supabase/functions/dev-seed/index.ts
@@ -1,19 +1,12 @@
 // Fix #1413: dev-seed EF는 이미지 업로드만 담당.
 // 유저/파트너 시딩은 seed.dev.sql + psql 직접 실행으로 전환됨.
+// Fix #2184 (Batch 9): migrate to minglitEdgeFunction wrapper — public caller, dev-only
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
-import { createServiceClient } from "../_shared/supabase_client.ts";
 import { errorResponse, successResponse } from "../_shared/response_utils.ts";
-import { initSentry, withHandler, log } from "../_shared/logger.ts";
+import { log } from "../_shared/logger.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 
 const FN = "dev-seed";
-
-initSentry();
-
-function isProduction(): boolean {
-  const env = Deno.env.get("ENVIRONMENT");
-  // Fix #1614: "dev" = Supabase dev project (set by supabase-deploy.yml secrets)
-  return env !== "local" && env !== "development" && env !== "dev";
-}
 
 // Partner owner that already exists via seed.dev.sql (used for authed storage upload)
 const SEED_IMAGE_OWNER_EMAIL = "partner_owner_1@test.com";
@@ -98,24 +91,7 @@ async function uploadSeedImages(supabase: SupabaseClient): Promise<string[]> {
   return urls;
 }
 
-Deno.serve(withHandler(async (req) => {
-  // Handle CORS preflight before any auth/env checks
-  if (req.method === "OPTIONS") {
-    return new Response(null, {
-      status: 204,
-      headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Headers":
-          "authorization, x-client-info, apikey, content-type",
-        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-      },
-    });
-  }
-
-  if (isProduction()) {
-    return errorResponse("Dev-only function. Blocked in production.", 403);
-  }
-
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
   const url = new URL(req.url);
   const mode = url.searchParams.get("mode") ?? "images-only";
 
@@ -127,10 +103,11 @@ Deno.serve(withHandler(async (req) => {
   }
 
   try {
-    const supabase = createServiceClient();
-    const imageUrls = await uploadSeedImages(supabase);
+    const imageUrls = await uploadSeedImages(ctx.supabase);
     return successResponse({ mode, image_urls: imageUrls });
   } catch (err) {
     return errorResponse((err as Error).message, 500);
   }
-}));
+};
+
+minglitEdgeFunction(handler);

--- a/supabase/functions/dev-session-switch/dev_session_switch_test.ts
+++ b/supabase/functions/dev-session-switch/dev_session_switch_test.ts
@@ -12,12 +12,12 @@ Deno.test({
   name: "dev-session-switch - blocks in production (ENVIRONMENT=production)",
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-    
-    await withEnv({ ENVIRONMENT: "production" }, async () => {
+
+    await withEnv({ ENVIRONMENT: "production", MINGLIT_EF_TEST_FN_NAME: "dev-session-switch" }, async () => {
       const response = await handler(new Request("http://localhost"));
       assertEquals(response.status, 403);
       const body = await readJson(response);
-      assertEquals(body.error, "Dev-only function. Blocked in production.");
+      assertEquals(body.error, "Function disabled in production");
     });
   },
 });
@@ -26,23 +26,24 @@ Deno.test({
   name: "dev-session-switch - returns user profiles in local env",
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-    
+
     const mockUsers = [
       { id: "1", name: "Test User", username: "user_25_m_ok" },
       { id: "2", name: "Test User 2", username: "user_30_f_ok" },
     ];
-    
+
     const { fetchMock } = createFetchMock([
       {
         matcher: /user_profiles/,
         handler: () => jsonResponse(mockUsers),
       },
     ]);
-    
+
     await withEnv({
       ENVIRONMENT: "local",
       SUPABASE_URL: "http://localhost:54321",
       SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+      MINGLIT_EF_TEST_FN_NAME: "dev-session-switch",
     }, async () => {
       await withMockedFetch(fetchMock, async () => {
         const response = await handler(new Request("http://localhost"));
@@ -59,18 +60,19 @@ Deno.test({
   name: "dev-session-switch - handles Supabase error",
   fn: async () => {
     const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
-    
+
     const { fetchMock } = createFetchMock([
       {
         matcher: /user_profiles/,
         handler: () => jsonResponse({ message: "Database connection failed" }, { status: 500 }),
       },
     ]);
-    
+
     await withEnv({
       ENVIRONMENT: "development",
       SUPABASE_URL: "http://localhost:54321",
       SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+      MINGLIT_EF_TEST_FN_NAME: "dev-session-switch",
     }, async () => {
       await withMockedFetch(fetchMock, async () => {
         const response = await handler(new Request("http://localhost"));

--- a/supabase/functions/dev-session-switch/index.ts
+++ b/supabase/functions/dev-session-switch/index.ts
@@ -1,53 +1,18 @@
-import { createServiceClient } from '../_shared/supabase_client.ts'
-import { initSentry, withHandler } from '../_shared/logger.ts'
+// Fix #2184 (Batch 9): migrate to minglitEdgeFunction wrapper — public caller, dev-only
+import { successResponse, errorResponse } from '../_shared/response_utils.ts'
+import { minglitEdgeFunction, type EFContext } from '../_shared/edge_function.ts'
 
+export const handler = async (_req: Request, ctx: EFContext): Promise<Response> => {
+  const { data, error } = await ctx.supabase
+    .from('user_profiles')
+    .select('id, name, username')
+    .order('username', { ascending: true })
 
-initSentry();
+  if (error) {
+    return errorResponse(error.message, 500)
+  }
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  return successResponse({ users: data })
 }
 
-Deno.serve(withHandler(async (req) => {
-  // Handle CORS preflight
-  if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: corsHeaders })
-  }
-
-  const env = Deno.env.get('ENVIRONMENT')
-  // Fix #1614: "dev" = Supabase dev project (set by supabase-deploy.yml secrets)
-  if (env !== 'local' && env !== 'development' && env !== 'dev') {
-    return new Response(
-      JSON.stringify({ error: 'Dev-only function. Blocked in production.' }),
-      { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
-    )
-  }
-
-  try {
-    const supabase = createServiceClient()
-
-    const { data, error } = await supabase
-      .from('user_profiles')
-      .select('id, name, username')
-      .order('username', { ascending: true })
-
-    if (error) {
-      return new Response(
-        JSON.stringify({ error: error.message }),
-        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
-      )
-    }
-
-    return new Response(
-      JSON.stringify({ users: data }),
-      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
-    )
-  } catch (err) {
-    return new Response(
-      JSON.stringify({ error: (err as Error).message }),
-      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
-    )
-  }
-}));
+minglitEdgeFunction(handler)

--- a/supabase/functions/identity-verify/identity_verify_test.ts
+++ b/supabase/functions/identity-verify/identity_verify_test.ts
@@ -19,6 +19,8 @@ Deno.test("identity-verify - happy path updates profile", async () => {
       PORTONE_V2_API_KEY: "test-key",
       SUPABASE_URL: "https://supabase.test",
       SUPABASE_SERVICE_ROLE_KEY: "service-key",
+      ENVIRONMENT: "dev",
+      MINGLIT_EF_TEST_FN_NAME: "identity-verify",
     },
     async () => {
       const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
@@ -62,6 +64,8 @@ Deno.test("identity-verify - missing id returns 400", async () => {
       PORTONE_V2_API_KEY: "test-key",
       SUPABASE_URL: "https://supabase.test",
       SUPABASE_SERVICE_ROLE_KEY: "service-key",
+      ENVIRONMENT: "dev",
+      MINGLIT_EF_TEST_FN_NAME: "identity-verify",
     },
     async () => {
       const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
@@ -87,6 +91,8 @@ Deno.test("identity-verify - external API error returns status", async () => {
       PORTONE_V2_API_KEY: "test-key",
       SUPABASE_URL: "https://supabase.test",
       SUPABASE_SERVICE_ROLE_KEY: "service-key",
+      ENVIRONMENT: "dev",
+      MINGLIT_EF_TEST_FN_NAME: "identity-verify",
     },
     async () => {
       const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
@@ -120,6 +126,8 @@ Deno.test("identity-verify - unauthorized returns 401", async () => {
       PORTONE_V2_API_KEY: "test-key",
       SUPABASE_URL: "https://supabase.test",
       SUPABASE_SERVICE_ROLE_KEY: "service-key",
+      ENVIRONMENT: "dev",
+      MINGLIT_EF_TEST_FN_NAME: "identity-verify",
     },
     async () => {
       const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
@@ -156,6 +164,8 @@ Deno.test("identity-verify - malformed JSON returns 400", async () => {
       PORTONE_V2_API_KEY: "test-key",
       SUPABASE_URL: "https://supabase.test",
       SUPABASE_SERVICE_ROLE_KEY: "service-key",
+      ENVIRONMENT: "dev",
+      MINGLIT_EF_TEST_FN_NAME: "identity-verify",
     },
     async () => {
       const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));

--- a/supabase/functions/identity-verify/index.ts
+++ b/supabase/functions/identity-verify/index.ts
@@ -1,24 +1,18 @@
 // Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
-import { createServiceClient } from "../_shared/supabase_client.ts";
+// Fix #2184 (Batch 9): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
 import { getPortoneClient } from "../_shared/portone_client.ts";
-import { successResponse, errorResponse, corsResponse } from "../_shared/response_utils.ts";
-import { requireAuth } from "../_shared/auth_utils.ts";
+import { successResponse, errorResponse } from "../_shared/response_utils.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { initSentry, log, withHandler } from "../_shared/logger.ts";
+import { log } from "../_shared/logger.ts";
 // Fix #763: Portone 에러 응답에 PII 포함 가능 — JSON 문자열 내 PII 마스킹
 import { maskJsonString } from "../_shared/pii_masker.ts";
+import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
 
 const FN = "identity-verify";
 
-
-initSentry();
-
-Deno.serve(withHandler(async (req) => {
-  if (req.method === "OPTIONS") return corsResponse();
-
-  const auth = await requireAuth(req);
-  if (auth instanceof Response) return auth;
-  const userId = auth;
+export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+  // wrapper guarantees type === "user" per auth-manifest callers: ["user"]
+  const userId = (ctx.auth as { type: "user"; userId: string }).userId;
   try {
     const body = await parseJsonBody(req);
     if (body instanceof Response) return body;
@@ -68,13 +62,11 @@ Deno.serve(withHandler(async (req) => {
 
     // 3. Supabase DB 업데이트 — update_user_identity RPC로 암호화 저장
     // Fix #809: ci/di 평문 컬럼 제거 후 ci_encrypted/di_encrypted/di_hash로 전환
-    const supabase = createServiceClient();
-
     const gender = typeof customer.gender === "string"
       ? customer.gender.toLowerCase()
       : undefined;
 
-    const { error: updateError } = await supabase.rpc("update_user_identity", {
+    const { error: updateError } = await ctx.supabase.rpc("update_user_identity", {
       p_user_id: userId,
       p_ci: customer.ci as string,
       p_di: customer.di as string,
@@ -105,4 +97,6 @@ Deno.serve(withHandler(async (req) => {
     });
     return errorResponse(message, 500);
   }
-}));
+};
+
+minglitEdgeFunction(handler);


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 개요

EF 인증/인가 래퍼 마이그레이션 batch-9 (이슈 #2184 TBD-2 진행).

## 변경 EF (5개)

| EF | Callers | Envs |
|---|---|---|
| identity-verify | user | dev, production |
| bug-report | user | dev, production |
| dev-mock-portone | public | local, development, dev |
| dev-seed | public | local, development, dev |
| dev-session-switch | public | local, development, dev |

## 변경 내용

- `initSentry()` + `withHandler()` + `requireAuth()` 제거 → `minglitEdgeFunction(handler)` 단일 진입점
- `auth-manifest.json`에 5개 entry 추가
- 각 test ENV에 `ENVIRONMENT` + `MINGLIT_EF_TEST_FN_NAME` 추가
- `dev-*` EF: 환경 차단 에러 메시지 업데이트 (wrapper의 `"Function disabled in {env}"`)
- `dev-seed`: ENVIRONMENT 미설정 시 500 반환 (wrapper init 실패 — fail-safe 유지)

## 관련 이슈

이슈 #2184: 옛 auth 헬퍼 deprecation + 제거 (TBD-2 completion에 필요)