### PR TITLE
fix(db): add INSERT RLS policy for partner_settlements + relax biz NOT NULL (#2322)

### DIFF
--- a/supabase/migrations/20260509000001_fix_partner_settlements_insert_rls.sql
+++ b/supabase/migrations/20260509000001_fix_partner_settlements_insert_rls.sql
@@ -1,0 +1,23 @@
+-- Fix #2322: partner_settlements RLS 위반 — INSERT 정책 누락 + NOT NULL 제약 완화
+--
+-- Root cause:
+--   1. partner_settlements에 INSERT RLS 정책이 없어 upsertBankAccount() 첫 실행 시 42501 오류
+--   2. biz_type/biz_name/biz_number/representative_name NOT NULL 제약이 은행 계좌만 upsert 시 차단
+--
+-- Fix:
+--   1. INSERT 정책 추가 — SETTLEMENT_EDIT 권한 보유자만 자기 파트너 레코드 INSERT 가능
+--   2. 비즈니스 정보 컬럼 nullable 허용 — 승인 트리거가 전체 정보를 채우지만,
+--      계좌 정보만 먼저 저장하는 경우(예: 테스트/시드 파트너)도 허용
+
+-- 1. INSERT 정책 추가
+CREATE POLICY "settlement_insert"
+  ON public.partner_settlements
+  FOR INSERT
+  WITH CHECK (public.has_partner_permission(partner_id, 'SETTLEMENT_EDIT'));
+
+-- 2. biz 정보 컬럼 nullable — 승인 트리거는 항상 값을 채우므로 프로덕션 영향 없음
+ALTER TABLE public.partner_settlements
+  ALTER COLUMN biz_type   DROP NOT NULL,
+  ALTER COLUMN biz_name   DROP NOT NULL,
+  ALTER COLUMN biz_number DROP NOT NULL,
+  ALTER COLUMN representative_name DROP NOT NULL;

--- a/supabase/tests/database/03_partners_schema_test.sql
+++ b/supabase/tests/database/03_partners_schema_test.sql
@@ -46,10 +46,11 @@ SELECT col_is_pk('partner_settlements', 'partner_id');
 SELECT col_is_fk('partner_settlements', 'partner_id');
 SELECT col_not_null('partner_settlements', 'partner_id');
 SELECT col_type_is('partner_settlements', 'biz_type', 'business_type');
-SELECT col_not_null('partner_settlements', 'biz_type');
-SELECT col_not_null('partner_settlements', 'biz_name');
-SELECT col_not_null('partner_settlements', 'biz_number');
-SELECT col_not_null('partner_settlements', 'representative_name');
+-- Fix #2322: biz 정보 컬럼 nullable 허용 — 은행 계좌만 먼저 upsert 가능
+SELECT col_is_nullable('partner_settlements', 'biz_type');
+SELECT col_is_nullable('partner_settlements', 'biz_name');
+SELECT col_is_nullable('partner_settlements', 'biz_number');
+SELECT col_is_nullable('partner_settlements', 'representative_name');
 SELECT col_not_null('partner_settlements', 'bank_name');
 SELECT col_not_null('partner_settlements', 'account_number');
 SELECT col_not_null('partner_settlements', 'account_holder');

--- a/supabase/tests/database/74_partner_settlements_insert_rls_test.sql
+++ b/supabase/tests/database/74_partner_settlements_insert_rls_test.sql
@@ -1,0 +1,81 @@
+-- Fix #2322: partner_settlements INSERT RLS 회귀 방지 테스트
+-- upsertBankAccount() 경로 — SETTLEMENT_EDIT 권한 보유자만 INSERT 가능
+BEGIN;
+SELECT plan(4);
+
+SELECT tests.create_supabase_user('owner_user', 'settlement_insert_owner@test.com');
+SELECT tests.create_supabase_user('outsider_user', 'settlement_insert_outsider@test.com');
+
+SELECT tests.authenticate_as_service_role();
+
+WITH partner AS (
+  INSERT INTO public.partners (name, introduction)
+  VALUES ('Settlement Insert Test Partner', 'Test')
+  RETURNING id
+)
+SELECT set_config('tests.partner_id', id::text, true) FROM partner;
+
+-- owner 권한 부여 (sync_partner_member_permissions 트리거가 SETTLEMENT_EDIT 포함 권한 배열 설정)
+INSERT INTO public.partner_member_permissions (partner_id, user_id, role)
+VALUES (
+  current_setting('tests.partner_id')::uuid,
+  tests.get_supabase_uid('owner_user'),
+  'owner'
+);
+
+-- Test 1: owner (SETTLEMENT_EDIT) — bank-only upsert INSERT 성공
+-- Fix #2322: INSERT 정책이 없으면 이 테스트가 실패함
+SELECT tests.authenticate_as('owner_user');
+SELECT lives_ok(
+  format(
+    $$INSERT INTO public.partner_settlements (partner_id, bank_name, account_number, account_holder)
+      VALUES (%L, 'Kakaobank', '111-222-333', 'Test Owner')
+      ON CONFLICT (partner_id) DO UPDATE
+        SET bank_name      = EXCLUDED.bank_name,
+            account_number = EXCLUDED.account_number,
+            account_holder = EXCLUDED.account_holder$$,
+    current_setting('tests.partner_id')
+  ),
+  'owner with SETTLEMENT_EDIT can upsert (INSERT path) bank account into partner_settlements'
+);
+
+-- Test 2: upsert UPDATE 경로도 성공 (레코드가 이미 존재하므로 ON CONFLICT 동작)
+SELECT lives_ok(
+  format(
+    $$INSERT INTO public.partner_settlements (partner_id, bank_name, account_number, account_holder)
+      VALUES (%L, 'Kookmin', '444-555-666', 'Test Owner Updated')
+      ON CONFLICT (partner_id) DO UPDATE
+        SET bank_name      = EXCLUDED.bank_name,
+            account_number = EXCLUDED.account_number,
+            account_holder = EXCLUDED.account_holder$$,
+    current_setting('tests.partner_id')
+  ),
+  'owner with SETTLEMENT_EDIT can upsert (UPDATE path) bank account into partner_settlements'
+);
+
+-- Test 3: INSERT 후 SELECT로 저장 확인
+SELECT results_eq(
+  format(
+    $$SELECT bank_name FROM public.partner_settlements
+      WHERE partner_id = %L$$,
+    current_setting('tests.partner_id')
+  ),
+  $$VALUES ('Kookmin')$$,
+  'upserted bank_name is persisted and readable by owner'
+);
+
+-- Test 4: outsider (파트너 멤버 아님) — INSERT 차단
+SELECT tests.authenticate_as('outsider_user');
+SELECT throws_ok(
+  format(
+    $$INSERT INTO public.partner_settlements (partner_id, bank_name, account_number, account_holder)
+      VALUES (%L, 'Hana', '777-888-999', 'Outsider')$$,
+    current_setting('tests.partner_id')
+  ),
+  '42501',
+  NULL,
+  'outsider cannot insert into partner_settlements'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 원인

`partner_settlements` 테이블에 **INSERT RLS 정책이 없었음**.

파트너가 처음으로 정산 계좌를 저장할 때 `upsertBankAccount()`가 PostgREST upsert(INSERT ON CONFLICT UPDATE)를 호출하는데, 기존 레코드가 없으면 INSERT 경로로 진입 → INSERT 정책이 없어 `PostgrestException(code: 42501)`으로 차단.

기존 RLS 정책:
- SELECT: `SETTLEMENT_VIEW`
- UPDATE: `SETTLEMENT_EDIT`
- DELETE: `is_super_admin()`
- **INSERT: 없음** ← 버그

## 수정 내용

### Migration `20260509000001`

1. **INSERT 정책 추가** (`settlement_insert`): `SETTLEMENT_EDIT` 권한 보유자만 자기 파트너 레코드 INSERT 가능
2. **biz 정보 컬럼 nullable 완화** (`biz_type`, `biz_name`, `biz_number`, `representative_name`):
   - `upsertBankAccount()`는 은행 계좌 정보만 전송 → INSERT 시 NOT NULL 위반 방지
   - 파트너 승인 트리거(`handle_partner_application_approved`)는 항상 전체 값을 SECURITY DEFINER로 채움 → 프로덕션 동작 무변

### pgTAP test `74_partner_settlements_insert_rls_test.sql`

| 테스트 | 내용 |
|--------|------|
| Test 1 | owner (SETTLEMENT_EDIT) — INSERT 경로 upsert 성공 |
| Test 2 | owner — UPDATE 경로 upsert 성공 |
| Test 3 | upserted 값이 SELECT로 확인 가능 |
| Test 4 | outsider — INSERT 차단 (42501) |

픽스를 revert하면 Test 1이 즉시 실패 (회귀 방지 보장됨).

## 영향 범위

- `supabase/migrations/20260509000001_fix_partner_settlements_insert_rls.sql` (신규)
- `supabase/tests/database/74_partner_settlements_insert_rls_test.sql` (신규)
- Dart 코드 변경 없음

Closes #2322