### PR TITLE
fix(app_user): add PopScope back-navigation guard to EventApplicationWizardPage (#2314)

### DIFF
--- a/apps/app_user/lib/src/features/event/admission/event_application_wizard_page.dart
+++ b/apps/app_user/lib/src/features/event/admission/event_application_wizard_page.dart
@@ -14,7 +14,7 @@ part 'wizard_payment_step.dart';
 part 'wizard_verification_step.dart';
 part 'wizard_widgets.dart';
 
-class EventApplicationWizardPage extends ConsumerWidget {
+class EventApplicationWizardPage extends ConsumerStatefulWidget {
   const EventApplicationWizardPage({
     required this.eventId,
     this.ticketId,
@@ -25,14 +25,62 @@ class EventApplicationWizardPage extends ConsumerWidget {
   final String? ticketId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final eventAsync = ref.watch(eventDetailControllerProvider(eventId));
+  ConsumerState<EventApplicationWizardPage> createState() =>
+      _EventApplicationWizardPageState();
+}
 
-    return Scaffold(
-      appBar: AppBar(title: const Text('참여 신청'), leading: const CloseButton()),
-      body: MinglitAsyncValueWidget(
-        value: eventAsync,
-        data: (event) => _WizardBody(event: event, initialTicketId: ticketId),
+class _EventApplicationWizardPageState
+    extends ConsumerState<EventApplicationWizardPage> {
+  // Fix #2314: show confirmation dialog on back navigation — wizard state is
+  // lost on pop and there is no auto-save, so guard every exit attempt.
+  void _onPopInvoked(bool didPop, Object? result) {
+    if (didPop) return;
+    unawaited(_confirmExit());
+  }
+
+  Future<void> _confirmExit() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => AlertDialog(
+        title: const Text('신청을 중단할까요?'),
+        content: const Text('지금 나가면 입력한 내용이 모두 사라집니다.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('계속하기'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('나가기'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true && mounted) {
+      Navigator.pop(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final eventAsync = ref.watch(eventDetailControllerProvider(widget.eventId));
+
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: _onPopInvoked,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('참여 신청'),
+          // Fix #2314: custom onPressed routes through the same confirmation
+          // dialog as the Android back gesture, preventing silent state loss.
+          leading: CloseButton(onPressed: () => unawaited(_confirmExit())),
+        ),
+        body: MinglitAsyncValueWidget(
+          value: eventAsync,
+          data: (event) =>
+              _WizardBody(event: event, initialTicketId: widget.ticketId),
+        ),
       ),
     );
   }

--- a/apps/app_user/lib/src/features/event/admission/event_application_wizard_page.dart
+++ b/apps/app_user/lib/src/features/event/admission/event_application_wizard_page.dart
@@ -31,8 +31,7 @@ class EventApplicationWizardPage extends ConsumerStatefulWidget {
 
 class _EventApplicationWizardPageState
     extends ConsumerState<EventApplicationWizardPage> {
-  // Fix #2314: show confirmation dialog on back navigation — wizard state is
-  // lost on pop and there is no auto-save, so guard every exit attempt.
+  // Fix #2314: show confirmation dialog on back navigation
   void _onPopInvoked(bool didPop, Object? result) {
     if (didPop) return;
     unawaited(_confirmExit());
@@ -72,8 +71,7 @@ class _EventApplicationWizardPageState
       child: Scaffold(
         appBar: AppBar(
           title: const Text('참여 신청'),
-          // Fix #2314: custom onPressed routes through the same confirmation
-          // dialog as the Android back gesture, preventing silent state loss.
+          // Fix #2314: CloseButton routes through the same dialog as Android back
           leading: CloseButton(onPressed: () => unawaited(_confirmExit())),
         ),
         body: MinglitAsyncValueWidget(

--- a/apps/app_user/test/src/features/event/ui/event_application_wizard_back_nav_test.dart
+++ b/apps/app_user/test/src/features/event/ui/event_application_wizard_back_nav_test.dart
@@ -84,6 +84,16 @@ void main() {
   }
 
   group('EventApplicationWizardPage — 뒤로가기 가드', () {
+    testWidgets('Android 시스템 백키 입력 시 확인 다이얼로그가 표시된다', (tester) async {
+      // Fix #2314: PopScope(canPop: false)가 시스템 백을 가로채고 다이얼로그를 보여야 함
+      await openWizard(tester);
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      expect(find.text('신청을 중단할까요?'), findsOneWidget);
+    });
+
     testWidgets('CloseButton 탭 시 확인 다이얼로그가 표시된다', (tester) async {
       // Fix #2314: CloseButton이 이전처럼 즉시 pop하지 않고 다이얼로그를 보여야 함
       await openWizard(tester);

--- a/apps/app_user/test/src/features/event/ui/event_application_wizard_back_nav_test.dart
+++ b/apps/app_user/test/src/features/event/ui/event_application_wizard_back_nav_test.dart
@@ -1,0 +1,146 @@
+// Fix #2314: 위저드 뒤로가기 내비게이션 가드 회귀 방지 테스트
+//
+// 위저드 진행 중 CloseButton/Android 백키 입력 시:
+//   - 확인 다이얼로그가 표시되어야 한다
+//   - '계속하기' 선택 시 위저드에 머물러야 한다
+//   - '나가기' 선택 시 위저드가 닫혀야 한다
+import 'dart:async';
+
+import 'package:app_user/src/features/event/admission/event_application_controller.dart';
+import 'package:app_user/src/features/event/admission/event_application_wizard_page.dart';
+import 'package:app_user/src/features/event/logic/event_detail_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+void main() {
+  final now = DateTime(2026, 4, 5, 15);
+
+  final testTicket = Ticket(
+    id: 'ticket-1',
+    name: '일반 티켓',
+    price: 25000,
+    createdAt: now,
+    updatedAt: now,
+  );
+
+  final testEvent = Event(
+    id: 'event-1',
+    partyId: 'party-1',
+    title: '소개팅 파티',
+    startTime: now.add(const Duration(days: 1)),
+    endTime: now.add(const Duration(days: 1, hours: 3)),
+    createdAt: now,
+    updatedAt: now,
+    tickets: [testTicket],
+    entryGroups: [],
+  );
+
+  // Wrap with a navigator so we can verify pop behaviour.
+  Widget buildWidget() {
+    return ProviderScope(
+      overrides: [
+        eventDetailControllerProvider(
+          testEvent.id,
+        ).overrideWith(() => _FakeEventDetailController(testEvent)),
+        eventApplicationControllerProvider(
+          testEvent,
+        ).overrideWith(
+          () => _FakeEventApplicationController(
+            const EventApplicationState(
+              step: EventApplicationStep.identity,
+              status: EventApplicationStatus.initial,
+              identityCompleted: false,
+              partnerVerifications: [],
+              consentGranted: false,
+            ),
+          ),
+        ),
+      ],
+      child: MaterialApp(
+        home: Builder(
+          builder: (ctx) => Scaffold(
+            body: ElevatedButton(
+              onPressed: () => Navigator.push(
+                ctx,
+                MaterialPageRoute<void>(
+                  builder: (_) =>
+                      EventApplicationWizardPage(eventId: testEvent.id),
+                ),
+              ),
+              child: const Text('open wizard'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> openWizard(WidgetTester tester) async {
+    await tester.pumpWidget(buildWidget());
+    await tester.tap(find.text('open wizard'));
+    await tester.pumpAndSettle();
+    expect(find.text('참여 신청'), findsOneWidget);
+  }
+
+  group('EventApplicationWizardPage — 뒤로가기 가드', () {
+    testWidgets('CloseButton 탭 시 확인 다이얼로그가 표시된다', (tester) async {
+      // Fix #2314: CloseButton이 이전처럼 즉시 pop하지 않고 다이얼로그를 보여야 함
+      await openWizard(tester);
+
+      await tester.tap(find.byType(CloseButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('신청을 중단할까요?'), findsOneWidget);
+    });
+
+    testWidgets('다이얼로그에서 "계속하기" 선택 시 위저드가 유지된다', (tester) async {
+      await openWizard(tester);
+
+      await tester.tap(find.byType(CloseButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('계속하기'));
+      await tester.pumpAndSettle();
+
+      // 위저드 화면이 아직 보여야 한다
+      expect(find.text('참여 신청'), findsOneWidget);
+      expect(find.text('신청을 중단할까요?'), findsNothing);
+    });
+
+    testWidgets('다이얼로그에서 "나가기" 선택 시 위저드가 닫힌다', (tester) async {
+      await openWizard(tester);
+
+      await tester.tap(find.byType(CloseButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('나가기'));
+      await tester.pumpAndSettle();
+
+      // 위저드가 닫히고 이전 화면으로 돌아온다
+      expect(find.text('참여 신청'), findsNothing);
+      expect(find.text('open wizard'), findsOneWidget);
+    });
+  });
+}
+
+class _FakeEventApplicationController extends EventApplicationController {
+  _FakeEventApplicationController(this._initialState);
+
+  final EventApplicationState _initialState;
+
+  @override
+  EventApplicationState build(Event event) => _initialState;
+
+  @override
+  Future<void> selectTicket(Ticket ticket) async {
+    state = state.copyWith(selectedTicket: ticket);
+  }
+}
+
+class _FakeEventDetailController extends EventDetailController {
+  _FakeEventDetailController(this._event);
+
+  final Event _event;
+
+  @override
+  Future<Event> build(String id) async => _event;
+}


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 원인

`EventApplicationWizardPage`에 back navigation guard가 없었음.

위저드 진행 중 Android 백키 또는 CloseButton을 누르면 확인 다이얼로그 없이 즉시 위저드가 닫혀, 사용자가 입력한 티켓 선택/인증/동의 내용이 모두 유실됨.

## 수정 내용

### `event_application_wizard_page.dart`

- `EventApplicationWizardPage`: `ConsumerWidget` → `ConsumerStatefulWidget`으로 전환
- `PopScope(canPop: false, onPopInvokedWithResult: _onPopInvoked)` 추가
- `_confirmExit()`: "신청을 중단할까요?" AlertDialog 표시
  - "계속하기" → 위저드 유지
  - "나가기" → `Navigator.pop(context)` 실행
- `CloseButton.onPressed`도 동일한 `_confirmExit()` 경로로 라우팅 (Android 백키와 통일된 UX)

### `event_application_wizard_back_nav_test.dart` (신규)

| 테스트 | 내용 |
|--------|------|
| Test 1 | CloseButton 탭 시 확인 다이얼로그가 표시됨 |
| Test 2 | "계속하기" 선택 시 위저드가 유지됨 |
| Test 3 | "나가기" 선택 시 위저드가 닫힘 |

픽스를 revert하면 Test 1 즉시 실패 (다이얼로그가 표시되지 않음).

## 영향 범위

- `apps/app_user/lib/src/features/event/admission/event_application_wizard_page.dart`
- `apps/app_user/test/src/features/event/ui/event_application_wizard_back_nav_test.dart` (신규)
- 기존 스모크 테스트 6개 전부 통과 확인

Closes #2314