### PR TITLE
fix(ci): check PR author instead of actor for dependabot CodeRabbit skip (#2149)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,7 +555,10 @@ jobs:
           echo "✅ CI jobs passed"
 
           # 2. Wait for CodeRabbit review (PR only, skip for dependabot)
-          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.actor }}" != "dependabot[bot]" ]; then
+          # Fix #2149: check PR author (user.login), not github.actor — when a human
+          # updates a dependabot branch (merge/rebase), actor becomes that human but
+          # CodeRabbit still doesn't review dependabot PRs → 30-minute timeout.
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.user.login }}" != "dependabot[bot]" ]; then
             SHA="${{ github.event.pull_request.head.sha }}"
             echo ""
             echo "Waiting for CodeRabbit review on $SHA ..."


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 원인

PR #2311에서 `github.actor != "dependabot[bot]"` 조건으로 dependabot PR의 CodeRabbit wait을 skip하도록 수정했지만, 사람이 dependabot 브랜치를 업데이트(merge/rebase)하면 `github.actor`가 그 사람으로 변경되어 skip 조건이 작동하지 않음.

확인된 증거:
```json
{
  "actor": "Mark-Yun",
  "triggering_actor": "Mark-Yun",
  "event": "pull_request",
  "head_commit": "Merge branch 'dev' into dependabot/github_actions/..."
}
```

Mark-Yun이 dependabot 브랜치를 업데이트하면 `github.actor = "Mark-Yun"` → CodeRabbit wait 실행 → CodeRabbit은 dependabot PR을 리뷰하지 않음 → 30분 타임아웃.

## 수정 내용

```diff
- if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.actor }}" != "dependabot[bot]" ]; then
+ if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.user.login }}" != "dependabot[bot]" ]; then
```

`github.event.pull_request.user.login`은 **PR 작성자** — dependabot이 열면 항상 `"dependabot[bot]"`, 누가 CI를 트리거하든 변하지 않음.

Closes #2149