### PR TITLE
feat(ef-auth): implement external_auth HMAC and custom module patterns (#2186)

### DIFF
--- a/docs/architecture/edge-function-auth.md
+++ b/docs/architecture/edge-function-auth.md
@@ -144,14 +144,18 @@ EF 들과 같은 디렉토리 — wrapper 가 import 가능 + locality 좋음.
   "ips": ["52.78.100.19", "52.78.48.223", "52.78.17.128"]
 }
 
-// HMAC signature (미래 확장)
+// HMAC-SHA256 signature — PortOne V2 webhook 예시.
+// signature 형식: 헤더 값이 "sha256=<hex>" 또는 "<hex>" 모두 허용.
+// body는 req.clone()으로 읽어 원본 request를 보존한다.
 "external_auth": {
   "type": "hmac",
   "secret_env": "PORTONE_WEBHOOK_SECRET",
-  "header": "x-portone-signature"
+  "header": "x-portone-signature-v2"
 }
 
-// 임의 검증 (escape hatch, 미래 확장)
+// 임의 검증 (escape hatch — bespoke 인증 로직이 필요한 경우).
+// module은 EF 디렉토리 기준 상대 경로.
+// 해당 모듈은 `check(req: Request): Promise<{ok:true;reason:string}|{ok:false}>` 를 export해야 한다.
 "external_auth": {
   "type": "custom",
   "module": "./payment_webhook_auth.ts"
@@ -618,7 +622,7 @@ Phase 1~4 동안 **옛 헬퍼와 새 wrapper 가 공존**. 마이그레이션되
 | ~~TBD-1~~ | ~~manifest 누락 → startup throw 시나리오 검증~~ (완료: `_shared/edge_function_manifest_test.ts`, 실제 동작은 HTTP 500/request — deploy 성공) | ~~P2~~ |
 | TBD-2 | 60 EF 마이그레이션 진척 트래킹 (Phase 3 의 epic) | P2 |
 | TBD-3 | 옛 auth 헬퍼 deprecation timeline + 제거 (Phase 5) | P3 |
-| TBD-4 | `external_auth` HMAC / custom 패턴 실제 적용 (PortOne 등) | P3 |
+| ~~TBD-4~~ | ~~`external_auth` HMAC / custom 패턴 실제 적용 (PortOne 등)~~ (완료: `checkExternalAuth` — hmac/custom 모두 구현, issue #2186) | ~~P3~~ |
 | TBD-5 | rate limit / deprecation / audit 등 manifest 확장 | P3 |
 | TBD-6 | 신규 sb_secret_ 형식으로 service_role 마이그레이션 (verify_jwt=true cron-호출 EF 의 verify_jwt=false 전환 검토 포함) | P3 |
 

--- a/supabase/functions/_shared/edge_function.ts
+++ b/supabase/functions/_shared/edge_function.ts
@@ -39,9 +39,27 @@ export interface EFContext {
   readonly supabase: SupabaseClient;
 }
 
-export interface ExternalAuth {
-  type: "ip_allowlist";
-  ips: string[];
+// Discriminated union — manifest schema §3.4
+export type ExternalAuth =
+  | { type: "ip_allowlist"; ips: string[] }
+  | {
+      type: "hmac";
+      /** Deno env var name that holds the HMAC secret */
+      secret_env: string;
+      /** Request header carrying the signature (e.g. "x-portone-signature-v2") */
+      header: string;
+    }
+  | {
+      type: "custom";
+      /** Path to an auth checker module, relative to the EF directory.
+       *  The module must export `check(req: Request): Promise<{ok:true;reason:string}|{ok:false}>`.
+       */
+      module: string;
+    };
+
+/** Interface that a `custom` external_auth module must satisfy. */
+export interface CustomAuthChecker {
+  check(req: Request): Promise<{ ok: true; reason: string } | { ok: false }>;
 }
 
 export interface EFPolicy {
@@ -108,24 +126,75 @@ function readEnvironment(): Environment {
 // Per-request helpers
 // --------------------------------------------------------------------------
 
-function checkExternalAuth(req: Request, external: ExternalAuth): { ok: true; reason: string } | { ok: false } {
-  if (external.type === "ip_allowlist") {
-    // Fix #1892 H2 패턴: x-real-ip > cf-connecting-ip > x-forwarded-for rightmost
-    const realIp = req.headers.get("x-real-ip");
-    const cfIp = req.headers.get("cf-connecting-ip");
-    const xff = req.headers.get("x-forwarded-for");
-    const xffRightmost = xff ? xff.split(",").map(s => s.trim()).pop() : null;
-    const clientIp = realIp || cfIp || xffRightmost;
-    if (clientIp && external.ips.includes(clientIp)) {
-      return { ok: true, reason: `ip_allowlist:${clientIp}` };
+/**
+ * Verifies external caller auth per the manifest's `external_auth` policy.
+ * Exported for unit testing; not part of the stable public API.
+ *
+ * @param req     Incoming request (body is NOT consumed — uses req.clone() for HMAC).
+ * @param external Parsed external_auth entry from the manifest.
+ * @param fnName  EF name, used to resolve relative `custom` module paths.
+ */
+export async function checkExternalAuth(
+  req: Request,
+  external: ExternalAuth,
+  fnName: string,
+): Promise<{ ok: true; reason: string } | { ok: false }> {
+  switch (external.type) {
+    case "ip_allowlist": {
+      // Fix #1892 H2 패턴: x-real-ip > cf-connecting-ip > x-forwarded-for rightmost
+      const realIp = req.headers.get("x-real-ip");
+      const cfIp = req.headers.get("cf-connecting-ip");
+      const xff = req.headers.get("x-forwarded-for");
+      const xffRightmost = xff ? xff.split(",").map(s => s.trim()).pop() : null;
+      const clientIp = realIp || cfIp || xffRightmost;
+      if (clientIp && external.ips.includes(clientIp)) {
+        return { ok: true, reason: `ip_allowlist:${clientIp}` };
+      }
+      return { ok: false };
+    }
+
+    case "hmac": {
+      // Verify HMAC-SHA256 signature without consuming the original request body.
+      const signature = req.headers.get(external.header);
+      if (!signature) return { ok: false };
+
+      const secret = Deno.env.get(external.secret_env);
+      if (!secret) return { ok: false };
+
+      const body = await req.clone().text();
+      const key = await crypto.subtle.importKey(
+        "raw",
+        new TextEncoder().encode(secret),
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign"],
+      );
+      const mac = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body));
+      const computedHex = Array.from(new Uint8Array(mac))
+        .map(b => b.toString(16).padStart(2, "0"))
+        .join("");
+
+      // Accept both "<hex>" and "sha256=<hex>" formats (PortOne V2 uses the prefixed form).
+      const sigHex = signature.startsWith("sha256=") ? signature.slice(7) : signature;
+      if (computedHex === sigHex) {
+        return { ok: true, reason: `hmac:${external.header}` };
+      }
+      return { ok: false };
+    }
+
+    case "custom": {
+      // Resolve path relative to this EF's directory (escape hatch for bespoke auth).
+      const moduleUrl = new URL(external.module, new URL(`../${fnName}/`, import.meta.url));
+      const mod = await import(moduleUrl.href) as CustomAuthChecker;
+      return await mod.check(req);
     }
   }
-  return { ok: false };
 }
 
 async function verifyAuth(
   req: Request,
   policy: EFPolicy,
+  fnName: string,
 ): Promise<AuthContext | Response> {
   const allow = (c: Caller) => policy.callers.includes(c);
   const authHeader = req.headers.get("Authorization") ?? "";
@@ -153,7 +222,7 @@ async function verifyAuth(
     if (!policy.external_auth) {
       throw new Error(`[minglitEdgeFunction] policy.callers includes 'external' but external_auth missing`);
     }
-    const ext = checkExternalAuth(req, policy.external_auth);
+    const ext = await checkExternalAuth(req, policy.external_auth, fnName);
     if (ext.ok) return { type: "external", reason: ext.reason };
   }
 
@@ -230,7 +299,7 @@ export function minglitEdgeFunction(handler: EFHandler, opts: MinglitEFOptions =
       }
 
       // Auth 검증
-      const auth = await verifyAuth(req, policy);
+      const auth = await verifyAuth(req, policy, fnName);
       if (auth instanceof Response) return auth;
 
       // Context + handler 호출

--- a/supabase/functions/_shared/edge_function_external_auth_test.ts
+++ b/supabase/functions/_shared/edge_function_external_auth_test.ts
@@ -1,0 +1,205 @@
+// Tests for external_auth patterns: ip_allowlist, hmac, custom (#2186)
+import { assertEquals } from "@std/assert";
+import { checkExternalAuth } from "./edge_function.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(opts: {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}): Request {
+  return new Request("http://localhost/", {
+    method: opts.method ?? "POST",
+    headers: opts.headers,
+    body: opts.body,
+  });
+}
+
+async function computeHmac(secret: string, body: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const mac = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body));
+  return Array.from(new Uint8Array(mac))
+    .map(b => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+// ---------------------------------------------------------------------------
+// ip_allowlist (regression — existing behaviour must not change)
+// ---------------------------------------------------------------------------
+
+Deno.test("checkExternalAuth: ip_allowlist — matching x-real-ip passes", async () => {
+  const req = makeRequest({ headers: { "x-real-ip": "52.78.100.19" } });
+  const result = await checkExternalAuth(
+    req,
+    { type: "ip_allowlist", ips: ["52.78.100.19"] },
+    "test-fn",
+  );
+  assertEquals(result, { ok: true, reason: "ip_allowlist:52.78.100.19" });
+});
+
+Deno.test("checkExternalAuth: ip_allowlist — unlisted IP fails", async () => {
+  const req = makeRequest({ headers: { "x-real-ip": "1.2.3.4" } });
+  const result = await checkExternalAuth(
+    req,
+    { type: "ip_allowlist", ips: ["52.78.100.19"] },
+    "test-fn",
+  );
+  assertEquals(result, { ok: false });
+});
+
+// ---------------------------------------------------------------------------
+// hmac
+// ---------------------------------------------------------------------------
+
+Deno.test("checkExternalAuth: hmac — raw hex signature passes", async () => {
+  const secret = "test-secret";
+  const body = '{"imp_uid":"test123"}';
+  const sig = await computeHmac(secret, body);
+
+  Deno.env.set("TEST_WEBHOOK_SECRET", secret);
+  try {
+    const req = makeRequest({
+      body,
+      headers: { "x-webhook-signature": sig },
+    });
+    const result = await checkExternalAuth(
+      req,
+      { type: "hmac", secret_env: "TEST_WEBHOOK_SECRET", header: "x-webhook-signature" },
+      "test-fn",
+    );
+    assertEquals(result, { ok: true, reason: "hmac:x-webhook-signature" });
+  } finally {
+    Deno.env.delete("TEST_WEBHOOK_SECRET");
+  }
+});
+
+Deno.test("checkExternalAuth: hmac — sha256=<hex> prefixed signature passes (PortOne V2 format)", async () => {
+  const secret = "portone-secret";
+  const body = '{"status":"paid"}';
+  const hex = await computeHmac(secret, body);
+
+  Deno.env.set("TEST_WEBHOOK_SECRET", secret);
+  try {
+    const req = makeRequest({
+      body,
+      headers: { "x-portone-signature-v2": `sha256=${hex}` },
+    });
+    const result = await checkExternalAuth(
+      req,
+      { type: "hmac", secret_env: "TEST_WEBHOOK_SECRET", header: "x-portone-signature-v2" },
+      "test-fn",
+    );
+    assertEquals(result, { ok: true, reason: "hmac:x-portone-signature-v2" });
+  } finally {
+    Deno.env.delete("TEST_WEBHOOK_SECRET");
+  }
+});
+
+Deno.test("checkExternalAuth: hmac — wrong secret fails", async () => {
+  const body = '{"event":"payment"}';
+  const sig = await computeHmac("correct-secret", body);
+
+  Deno.env.set("TEST_WEBHOOK_SECRET", "wrong-secret");
+  try {
+    const req = makeRequest({
+      body,
+      headers: { "x-sig": sig },
+    });
+    const result = await checkExternalAuth(
+      req,
+      { type: "hmac", secret_env: "TEST_WEBHOOK_SECRET", header: "x-sig" },
+      "test-fn",
+    );
+    assertEquals(result, { ok: false });
+  } finally {
+    Deno.env.delete("TEST_WEBHOOK_SECRET");
+  }
+});
+
+Deno.test("checkExternalAuth: hmac — missing signature header fails", async () => {
+  Deno.env.set("TEST_WEBHOOK_SECRET", "some-secret");
+  try {
+    const req = makeRequest({ body: '{}' });
+    const result = await checkExternalAuth(
+      req,
+      { type: "hmac", secret_env: "TEST_WEBHOOK_SECRET", header: "x-sig" },
+      "test-fn",
+    );
+    assertEquals(result, { ok: false });
+  } finally {
+    Deno.env.delete("TEST_WEBHOOK_SECRET");
+  }
+});
+
+Deno.test("checkExternalAuth: hmac — env var not set fails", async () => {
+  Deno.env.delete("TEST_WEBHOOK_SECRET");
+  const req = makeRequest({
+    body: '{}',
+    headers: { "x-sig": "somehex" },
+  });
+  const result = await checkExternalAuth(
+    req,
+    { type: "hmac", secret_env: "TEST_WEBHOOK_SECRET", header: "x-sig" },
+    "test-fn",
+  );
+  assertEquals(result, { ok: false });
+});
+
+Deno.test("checkExternalAuth: hmac — original request body still readable after check", async () => {
+  const secret = "s3cr3t";
+  const body = '{"amount":9900}';
+  const sig = await computeHmac(secret, body);
+
+  Deno.env.set("TEST_WEBHOOK_SECRET", secret);
+  try {
+    const req = makeRequest({
+      body,
+      headers: { "x-sig": sig },
+    });
+    await checkExternalAuth(
+      req,
+      { type: "hmac", secret_env: "TEST_WEBHOOK_SECRET", header: "x-sig" },
+      "test-fn",
+    );
+    // Handler must still be able to read the body
+    const readBody = await req.text();
+    assertEquals(readBody, body);
+  } finally {
+    Deno.env.delete("TEST_WEBHOOK_SECRET");
+  }
+});
+
+// ---------------------------------------------------------------------------
+// custom
+// ---------------------------------------------------------------------------
+
+Deno.test("checkExternalAuth: custom — always-pass module returns ok:true", async () => {
+  const moduleUrl = new URL("../_test_utils/mock_custom_auth_pass.ts", import.meta.url).href;
+  const req = makeRequest({});
+  const result = await checkExternalAuth(
+    req,
+    { type: "custom", module: moduleUrl },
+    "test-fn",  // fnName unused when module is an absolute URL
+  );
+  assertEquals(result, { ok: true, reason: "mock:always-pass" });
+});
+
+Deno.test("checkExternalAuth: custom — always-fail module returns ok:false", async () => {
+  const moduleUrl = new URL("../_test_utils/mock_custom_auth_fail.ts", import.meta.url).href;
+  const req = makeRequest({});
+  const result = await checkExternalAuth(
+    req,
+    { type: "custom", module: moduleUrl },
+    "test-fn",
+  );
+  assertEquals(result, { ok: false });
+});

--- a/supabase/functions/_test_utils/mock_custom_auth_fail.ts
+++ b/supabase/functions/_test_utils/mock_custom_auth_fail.ts
@@ -1,0 +1,6 @@
+/** Test fixture: custom auth checker that always rejects. */
+export async function check(
+  _req: Request,
+): Promise<{ ok: true; reason: string } | { ok: false }> {
+  return { ok: false };
+}

--- a/supabase/functions/_test_utils/mock_custom_auth_pass.ts
+++ b/supabase/functions/_test_utils/mock_custom_auth_pass.ts
@@ -1,0 +1,6 @@
+/** Test fixture: custom auth checker that always approves. */
+export async function check(
+  _req: Request,
+): Promise<{ ok: true; reason: string } | { ok: false }> {
+  return { ok: true, reason: "mock:always-pass" };
+}


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Summary

- `ExternalAuth` 타입을 discriminated union으로 확장: `ip_allowlist` | `hmac` | `custom`
- **hmac**: HMAC-SHA256 서명 검증 구현. `req.clone()`으로 원본 body 보존 (핸들러가 재사용 가능). PortOne V2 `sha256=<hex>` prefix 및 raw hex 형식 모두 허용.
- **custom**: EF 디렉토리 기준 상대 경로의 모듈을 dynamic import. `CustomAuthChecker` 인터페이스 준수 (`check(req)` export 필요).
- `checkExternalAuth` 를 `async export` → 단위 테스트 직접 호출 가능.
- 아키텍처 문서(`edge-function-auth.md`) TBD-4 완료 표시 및 PortOne V2 예시 갱신.

## 회귀 방지 테스트

`supabase/functions/_shared/edge_function_external_auth_test.ts` — 9개 테스트:
- `ip_allowlist`: 매칭 IP 통과, 미등록 IP 차단 (기존 동작 회귀 방지)
- `hmac`: raw hex 서명 통과, sha256= prefix 형식 통과, wrong secret 차단, 헤더 누락 차단, env 미설정 차단, **원본 body 재사용 가능 확인**
- `custom`: always-pass 모듈 통과, always-fail 모듈 차단

## Test plan
- [x] `edge_function_external_auth_test.ts` 9개 테스트 (hmac/custom 패턴 포함)
- [x] 기존 `edge_function_manifest_test.ts` 영향 없음 (ExternalAuth 미사용)
- [x] 기존 `payment-webhook` manifest entry 변경 없음 (ip_allowlist 그대로)

Closes #2186