### PR TITLE
fix(pgtap): replace col_is_nullable with col_is_null — CI unblock

### DIFF
--- a/supabase/tests/database/03_partners_schema_test.sql
+++ b/supabase/tests/database/03_partners_schema_test.sql
@@ -47,10 +47,10 @@ SELECT col_is_fk('partner_settlements', 'partner_id');
 SELECT col_not_null('partner_settlements', 'partner_id');
 SELECT col_type_is('partner_settlements', 'biz_type', 'business_type');
 -- Fix #2322: biz 정보 컬럼 nullable 허용 — 은행 계좌만 먼저 upsert 가능
-SELECT col_is_nullable('partner_settlements', 'biz_type');
-SELECT col_is_nullable('partner_settlements', 'biz_name');
-SELECT col_is_nullable('partner_settlements', 'biz_number');
-SELECT col_is_nullable('partner_settlements', 'representative_name');
+SELECT col_is_null('partner_settlements', 'biz_type');
+SELECT col_is_null('partner_settlements', 'biz_name');
+SELECT col_is_null('partner_settlements', 'biz_number');
+SELECT col_is_null('partner_settlements', 'representative_name');
 SELECT col_not_null('partner_settlements', 'bank_name');
 SELECT col_not_null('partner_settlements', 'account_number');
 SELECT col_not_null('partner_settlements', 'account_holder');


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Summary

- PR #2327 (`fix(db)`) 이후 `03_partners_schema_test.sql`에 존재하지 않는 pgTAP 함수 `col_is_nullable()` 호출 4개가 추가되어 `supabase/**` 변경 포함 모든 PR의 `test-pgtap`이 차단됨.
- `col_is_null(table, column)` 이 올바른 pgTAP 함수명임 (참조: `05_commerce_schema_test.sql` 에서 동일 패턴 사용 중).
- PR #2332, #2333 등 관련 없는 EF PR도 이 오류로 CI 실패 상태.

## Test plan
- [x] `supabase/tests/database/03_partners_schema_test.sql` — 4개 `col_is_nullable` → `col_is_null` 교체
- [x] `05_commerce_schema_test.sql`에서 `col_is_null` 2-arg 형식이 정상 동작함을 확인