### PR TITLE
feat(ef-auth): add manifest deprecated field — RFC 8594 Deprecation/Sunset headers (#2188)

### DIFF
--- a/docs/architecture/edge-function-auth.md
+++ b/docs/architecture/edge-function-auth.md
@@ -120,6 +120,7 @@ EF 들과 같은 디렉토리 — wrapper 가 import 가능 + locality 좋음.
       "callers": ["system" | "user" | "external" | "public"],
       "envs": ["local" | "development" | "dev" | "production"],
       "external_auth": { ... },     // optional, callers 에 "external" 있을 때
+      "deprecated": "YYYY-MM-DD",   // optional — 설정 시 모든 응답에 RFC 8594 Deprecation/Sunset 헤더 추가
       "description": "한 줄 요약"
     }
   }
@@ -133,6 +134,7 @@ EF 들과 같은 디렉토리 — wrapper 가 import 가능 + locality 좋음.
 | `callers` | `Caller[]` | ✅ | 허용 호출자 (OR) |
 | `envs` | `string[]` | ✅ | 동작 허용 환경 — 외 환경 호출 시 403 |
 | `external_auth` | `object` | callers 에 `external` 있으면 | 외부 인증 검증 정책 |
+| `deprecated` | `string` (ISO date) | 선택 | 설정 시 모든 응답에 RFC 8594 `Deprecation: @<date>` + `Sunset: <date>` 헤더 자동 추가. 클라이언트가 EOL을 감지해 마이그레이션 준비 가능. |
 | `description` | `string` | 권장 | 한 줄 한국어 설명 (audit 용) |
 
 ### 3.4 `external_auth` polymorphism
@@ -619,7 +621,7 @@ Phase 1~4 동안 **옛 헬퍼와 새 wrapper 가 공존**. 마이그레이션되
 | TBD-2 | 60 EF 마이그레이션 진척 트래킹 (Phase 3 의 epic) | P2 |
 | TBD-3 | 옛 auth 헬퍼 deprecation timeline + 제거 (Phase 5) | P3 |
 | TBD-4 | `external_auth` HMAC / custom 패턴 실제 적용 (PortOne 등) | P3 |
-| TBD-5 | rate limit / deprecation / audit 등 manifest 확장 | P3 |
+| TBD-5 | rate limit / deprecation / audit 등 manifest 확장 (`deprecated` 완료 #2188; rate_limit / audit / cors / required_role 후속) | P3 |
 | TBD-6 | 신규 sb_secret_ 형식으로 service_role 마이그레이션 (verify_jwt=true cron-호출 EF 의 verify_jwt=false 전환 검토 포함) | P3 |
 
 ---

--- a/supabase/functions/_shared/edge_function.ts
+++ b/supabase/functions/_shared/edge_function.ts
@@ -48,6 +48,12 @@ export interface EFPolicy {
   callers: Caller[];
   envs: Environment[];
   external_auth?: ExternalAuth;
+  /**
+   * ISO date string (e.g. "2026-12-01") — if set, every response from this EF
+   * will carry `Deprecation` and `Sunset` headers (RFC 8594) so clients can
+   * detect the upcoming EOL without reading documentation.
+   */
+  deprecated?: string;
   description?: string;
 }
 
@@ -107,6 +113,25 @@ function readEnvironment(): Environment {
 // --------------------------------------------------------------------------
 // Per-request helpers
 // --------------------------------------------------------------------------
+
+/**
+ * Injects RFC 8594 `Deprecation` and `Sunset` response headers.
+ * Exported for unit testing; not part of the stable public API.
+ *
+ * @param res        Original handler response.
+ * @param deprecated ISO date string from the manifest (e.g. "2026-12-01").
+ * @returns          New Response with the deprecation headers added.
+ */
+export function addDeprecationHeaders(res: Response, deprecated: string): Response {
+  const date = new Date(deprecated);
+  const httpDate = date.toUTCString();
+  const headers = new Headers(res.headers);
+  // RFC 8594 §2 — Deprecation header: date-tagged form "@<HTTP-date>"
+  headers.set("Deprecation", `@${httpDate}`);
+  // RFC 8594 §3 — Sunset header: the point at which the resource is removed
+  headers.set("Sunset", httpDate);
+  return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
+}
 
 function checkExternalAuth(req: Request, external: ExternalAuth): { ok: true; reason: string } | { ok: false } {
   if (external.type === "ip_allowlist") {
@@ -235,7 +260,8 @@ export function minglitEdgeFunction(handler: EFHandler, opts: MinglitEFOptions =
 
       // Context + handler 호출
       const ctx = makeContext({ auth, fnName, env, requestId });
-      const res = await handler(req, ctx);
+      let res = await handler(req, ctx);
+      if (policy.deprecated) res = addDeprecationHeaders(res, policy.deprecated);
       axiomLog({ function: fnName, level: "info", message: "completed", metadata: { status: res.status, requestId } });
       return res;
     } catch (e) {

--- a/supabase/functions/_shared/edge_function.ts
+++ b/supabase/functions/_shared/edge_function.ts
@@ -124,6 +124,7 @@ function readEnvironment(): Environment {
  */
 export function addDeprecationHeaders(res: Response, deprecated: string): Response {
   const date = new Date(deprecated);
+  if (Number.isNaN(date.getTime())) return res;
   const httpDate = date.toUTCString();
   const headers = new Headers(res.headers);
   // RFC 8594 §2 — Deprecation header: date-tagged form "@<HTTP-date>"

--- a/supabase/functions/_shared/edge_function_deprecated_test.ts
+++ b/supabase/functions/_shared/edge_function_deprecated_test.ts
@@ -1,5 +1,5 @@
 // Tests for manifest `deprecated` field — RFC 8594 Deprecation + Sunset headers (#2188)
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { addDeprecationHeaders } from "./edge_function.ts";
 
 function okResponse(body = "ok"): Response {
@@ -9,16 +9,15 @@ function okResponse(body = "ok"): Response {
 Deno.test("addDeprecationHeaders: adds Deprecation header in @<HTTP-date> format", () => {
   const res = addDeprecationHeaders(okResponse(), "2026-12-01");
   const deprecation = res.headers.get("Deprecation");
-  assertStringIncludes(deprecation ?? "", "@");
-  assertStringIncludes(deprecation ?? "", "2026");
+  const expected = new Date("2026-12-01").toUTCString();
+  assertEquals(deprecation, `@${expected}`);
 });
 
 Deno.test("addDeprecationHeaders: adds Sunset header as HTTP-date", () => {
   const res = addDeprecationHeaders(okResponse(), "2026-12-01");
   const sunset = res.headers.get("Sunset");
-  assertStringIncludes(sunset ?? "", "2026");
-  // Should be a valid HTTP-date (contains day-of-week abbreviation)
-  assertStringIncludes(sunset ?? "", "Dec");
+  const expected = new Date("2026-12-01").toUTCString();
+  assertEquals(sunset, expected);
 });
 
 Deno.test("addDeprecationHeaders: preserves original status and body", async () => {

--- a/supabase/functions/_shared/edge_function_deprecated_test.ts
+++ b/supabase/functions/_shared/edge_function_deprecated_test.ts
@@ -46,3 +46,10 @@ Deno.test("addDeprecationHeaders: Deprecation and Sunset reference the same date
   // Deprecation is "@<sunset>", so removing "@" prefix should equal Sunset
   assertEquals(deprecation, `@${sunset}`);
 });
+
+Deno.test("addDeprecationHeaders: returns original response unchanged for invalid date", () => {
+  const original = okResponse();
+  const res = addDeprecationHeaders(original, "not-a-date");
+  assertEquals(res.headers.has("Deprecation"), false);
+  assertEquals(res.headers.has("Sunset"), false);
+});

--- a/supabase/functions/_shared/edge_function_deprecated_test.ts
+++ b/supabase/functions/_shared/edge_function_deprecated_test.ts
@@ -1,0 +1,48 @@
+// Tests for manifest `deprecated` field — RFC 8594 Deprecation + Sunset headers (#2188)
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { addDeprecationHeaders } from "./edge_function.ts";
+
+function okResponse(body = "ok"): Response {
+  return new Response(body, { status: 200 });
+}
+
+Deno.test("addDeprecationHeaders: adds Deprecation header in @<HTTP-date> format", () => {
+  const res = addDeprecationHeaders(okResponse(), "2026-12-01");
+  const deprecation = res.headers.get("Deprecation");
+  assertStringIncludes(deprecation ?? "", "@");
+  assertStringIncludes(deprecation ?? "", "2026");
+});
+
+Deno.test("addDeprecationHeaders: adds Sunset header as HTTP-date", () => {
+  const res = addDeprecationHeaders(okResponse(), "2026-12-01");
+  const sunset = res.headers.get("Sunset");
+  assertStringIncludes(sunset ?? "", "2026");
+  // Should be a valid HTTP-date (contains day-of-week abbreviation)
+  assertStringIncludes(sunset ?? "", "Dec");
+});
+
+Deno.test("addDeprecationHeaders: preserves original status and body", async () => {
+  const original = new Response("hello", { status: 201 });
+  const res = addDeprecationHeaders(original, "2026-06-30");
+  assertEquals(res.status, 201);
+  assertEquals(await res.text(), "hello");
+});
+
+Deno.test("addDeprecationHeaders: preserves existing response headers", () => {
+  const original = new Response("ok", {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+  const res = addDeprecationHeaders(original, "2026-12-01");
+  assertEquals(res.headers.get("Content-Type"), "application/json");
+  assertEquals(res.headers.has("Deprecation"), true);
+  assertEquals(res.headers.has("Sunset"), true);
+});
+
+Deno.test("addDeprecationHeaders: Deprecation and Sunset reference the same date", () => {
+  const res = addDeprecationHeaders(okResponse(), "2027-03-15");
+  const deprecation = res.headers.get("Deprecation") ?? "";
+  const sunset = res.headers.get("Sunset") ?? "";
+  // Deprecation is "@<sunset>", so removing "@" prefix should equal Sunset
+  assertEquals(deprecation, `@${sunset}`);
+});


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Summary

- EFPolicy에 `deprecated?: string` 필드 추가 (ISO date, e.g. "2026-12-01")
- 설정 시 핸들러 응답마다 RFC 8594 헤더 자동 주입:
  - Deprecation: @<HTTP-date>
  - Sunset: <HTTP-date>
- addDeprecationHeaders() 내보내기로 단위 테스트 직접 가능

## Test plan
- [x] edge_function_deprecated_test.ts 5개 테스트

이슈 #2188 (TBD-5)의 deprecated 필드 구현 (1/N).
나머지 필드(rate_limit / audit / cors / required_role)는 사용 사례 발생 시 별도 PR.

Related to #2188