### PR TITLE
fix(ef-auth): replace string === with crypto.subtle.verify for HMAC timing safety (#2336)

### DIFF
--- a/supabase/functions/_shared/edge_function.ts
+++ b/supabase/functions/_shared/edge_function.ts
@@ -200,8 +200,9 @@ export async function checkExternalAuth(
 
       // Accept both "<hex>" and "sha256=<hex>" formats (PortOne V2 uses the prefixed form).
       const sigHex = signature.startsWith("sha256=") ? signature.slice(7) : signature;
-      // Decode hex to bytes; odd-length hex is invalid.
-      if (sigHex.length % 2 !== 0) return { ok: false };
+      // Reject odd-length or non-hex chars before decoding. parseInt("aZ",16) silently
+      // stops at "Z" returning 10, so a regex guard is required to reject malformed input.
+      if (sigHex.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(sigHex)) return { ok: false };
       const sigBytes = new Uint8Array(sigHex.length / 2);
       for (let i = 0; i < sigHex.length; i += 2) {
         sigBytes[i / 2] = parseInt(sigHex.slice(i, i + 2), 16);

--- a/supabase/functions/_shared/edge_function.ts
+++ b/supabase/functions/_shared/edge_function.ts
@@ -188,21 +188,28 @@ export async function checkExternalAuth(
       if (!secret) return { ok: false };
 
       const body = await req.clone().text();
+      // Fix #2336: import key for "verify" to use crypto.subtle.verify — constant-time
+      // comparison (CWE-208: string === is not timing-safe).
       const key = await crypto.subtle.importKey(
         "raw",
         new TextEncoder().encode(secret),
         { name: "HMAC", hash: "SHA-256" },
         false,
-        ["sign"],
+        ["verify"],
       );
-      const mac = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body));
-      const computedHex = Array.from(new Uint8Array(mac))
-        .map(b => b.toString(16).padStart(2, "0"))
-        .join("");
 
       // Accept both "<hex>" and "sha256=<hex>" formats (PortOne V2 uses the prefixed form).
       const sigHex = signature.startsWith("sha256=") ? signature.slice(7) : signature;
-      if (computedHex === sigHex) {
+      // Decode hex to bytes; odd-length hex is invalid.
+      if (sigHex.length % 2 !== 0) return { ok: false };
+      const sigBytes = new Uint8Array(sigHex.length / 2);
+      for (let i = 0; i < sigHex.length; i += 2) {
+        sigBytes[i / 2] = parseInt(sigHex.slice(i, i + 2), 16);
+      }
+
+      // crypto.subtle.verify performs constant-time HMAC comparison internally.
+      const valid = await crypto.subtle.verify("HMAC", key, sigBytes, new TextEncoder().encode(body));
+      if (valid) {
         return { ok: true, reason: `hmac:${external.header}` };
       }
       return { ok: false };

--- a/supabase/functions/_shared/edge_function_external_auth_test.ts
+++ b/supabase/functions/_shared/edge_function_external_auth_test.ts
@@ -104,6 +104,53 @@ Deno.test("checkExternalAuth: hmac — sha256=<hex> prefixed signature passes (P
   }
 });
 
+// Fix #2336: verifies that a signature differing by one byte is rejected.
+// Regression guard for CWE-208 timing attack: string === would accept identical
+// prefixes if short-circuited; crypto.subtle.verify must reject partial matches.
+Deno.test("checkExternalAuth: hmac — signature with flipped last byte fails (timing-safe guard)", async () => {
+  const secret = "test-secret";
+  const body = '{"status":"paid"}';
+  const validHex = await computeHmac(secret, body);
+  // Flip the last byte of the valid hex signature.
+  const lastByte = parseInt(validHex.slice(-2), 16);
+  const flippedHex = validHex.slice(0, -2) + ((lastByte ^ 0xff) & 0xff).toString(16).padStart(2, "0");
+
+  Deno.env.set("TEST_WEBHOOK_SECRET", secret);
+  try {
+    const req = makeRequest({
+      body,
+      headers: { "x-sig": flippedHex },
+    });
+    const result = await checkExternalAuth(
+      req,
+      { type: "hmac", secret_env: "TEST_WEBHOOK_SECRET", header: "x-sig" },
+      "test-fn",
+    );
+    assertEquals(result, { ok: false });
+  } finally {
+    Deno.env.delete("TEST_WEBHOOK_SECRET");
+  }
+});
+
+// Fix #2336: odd-length hex is invalid and must fail before byte decoding.
+Deno.test("checkExternalAuth: hmac — odd-length hex signature fails", async () => {
+  Deno.env.set("TEST_WEBHOOK_SECRET", "some-secret");
+  try {
+    const req = makeRequest({
+      body: '{}',
+      headers: { "x-sig": "abc" },  // odd length
+    });
+    const result = await checkExternalAuth(
+      req,
+      { type: "hmac", secret_env: "TEST_WEBHOOK_SECRET", header: "x-sig" },
+      "test-fn",
+    );
+    assertEquals(result, { ok: false });
+  } finally {
+    Deno.env.delete("TEST_WEBHOOK_SECRET");
+  }
+});
+
 Deno.test("checkExternalAuth: hmac — wrong secret fails", async () => {
   const body = '{"event":"payment"}';
   const sig = await computeHmac("correct-secret", body);

--- a/supabase/functions/_shared/edge_function_external_auth_test.ts
+++ b/supabase/functions/_shared/edge_function_external_auth_test.ts
@@ -151,6 +151,26 @@ Deno.test("checkExternalAuth: hmac — odd-length hex signature fails", async ()
   }
 });
 
+// Fix #2336: even-length non-hex string must fail — parseInt("aZ",16)===10 silently
+// parses partial chars; regex guard is required to reject malformed input.
+Deno.test("checkExternalAuth: hmac — even-length non-hex signature fails", async () => {
+  Deno.env.set("TEST_WEBHOOK_SECRET", "some-secret");
+  try {
+    const req = makeRequest({
+      body: '{}',
+      headers: { "x-sig": "aZ" },  // even length but "Z" is not hex
+    });
+    const result = await checkExternalAuth(
+      req,
+      { type: "hmac", secret_env: "TEST_WEBHOOK_SECRET", header: "x-sig" },
+      "test-fn",
+    );
+    assertEquals(result, { ok: false });
+  } finally {
+    Deno.env.delete("TEST_WEBHOOK_SECRET");
+  }
+});
+
 Deno.test("checkExternalAuth: hmac — wrong secret fails", async () => {
   const body = '{"event":"payment"}';
   const sig = await computeHmac("correct-secret", body);


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Summary

- **Root cause**: `checkExternalAuth` hmac case used `computedHex === sigHex` (JavaScript string comparison), which is NOT constant-time — CWE-208 timing side-channel.
- **Attack path**: Attacker sends requests with progressively modified signatures and measures response time. Byte-by-byte inference of the correct HMAC → signature forgery → fake `paid` event injection without actual payment.
- **Fix**: Import HMAC key with `["verify"]` usage and call `crypto.subtle.verify()` which performs constant-time comparison internally (Web Crypto API standard). No `node:crypto` import needed.
- **Validation**: Added odd-length hex guard before byte decoding.

## Changes

- `supabase/functions/_shared/edge_function.ts` — hmac case: `["sign"]` → `["verify"]`, string comparison → `crypto.subtle.verify()`
- `supabase/functions/_shared/edge_function_external_auth_test.ts` — 2 new regression tests

## Test plan

- [x] "flipped last byte" test: valid sig with last byte XOR 0xff → `ok: false` (timing-safe regression guard)
- [x] "odd-length hex" test: malformed hex string → `ok: false` (boundary guard)
- [x] All 9 existing tests continue to pass (correct sig, sha256= prefix, wrong secret, missing header, missing env, body reuse, ip_allowlist, custom)

Closes #2336