### PR TITLE
fix(app_user): defer initConsentItems out of build phase — fix Riverpod exception on consent step (#2343)

### DIFF
--- a/apps/app_user/lib/src/features/event/admission/wizard_consent_step.dart
+++ b/apps/app_user/lib/src/features/event/admission/wizard_consent_step.dart
@@ -13,11 +13,16 @@ class _ConsentStepState extends ConsumerState<_ConsentStep> {
   @override
   void initState() {
     super.initState();
-    // Initialise per-item checkbox state in the controller so that
-    // navigating back restores the previously-agreed state visually.
-    ref
-        .read(eventApplicationControllerProvider(widget.event).notifier)
-        .initConsentItems(_consentItems.length);
+    // Fix #2343: defer state modification to post-frame to avoid
+    // "Tried to modify a provider while the widget tree was building".
+    // initState is called synchronously during the parent's build phase,
+    // so any state mutation must be deferred.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ref
+          .read(eventApplicationControllerProvider(widget.event).notifier)
+          .initConsentItems(_consentItems.length);
+    });
   }
 
   @override

--- a/apps/app_user/test/src/features/event/ui/event_application_wizard_smoke_test.dart
+++ b/apps/app_user/test/src/features/event/ui/event_application_wizard_smoke_test.dart
@@ -117,6 +117,33 @@ void main() {
 
       expect(find.text('참여 신청'), findsOneWidget);
     });
+
+    // Regression: Fix #2343 — initConsentItems was called in initState,
+    // triggering "Tried to modify a provider while the widget tree was
+    // building" on Step 1 → consent step transition.
+    testWidgets(
+      'consent 단계 진입 시 Riverpod 예외 없이 렌더링된다 (Fix #2343)',
+      (tester) async {
+        await tester.pumpWidget(
+          buildWidget(
+            appState: const EventApplicationState(
+              step: EventApplicationStep.consent,
+              status: EventApplicationStatus.initial,
+              identityCompleted: true,
+              partnerVerifications: [],
+              consentGranted: false,
+              // consentCheckedItems is intentionally empty (length=0) so
+              // initConsentItems modifies state on first mount — the exact
+              // condition that triggered the exception before the fix.
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('참여 신청'), findsOneWidget);
+        expect(find.text('개인정보 및 심사 동의'), findsOneWidget);
+      },
+    );
   });
 }
 

--- a/apps/app_user/test/src/features/event/ui/event_application_wizard_smoke_test.dart
+++ b/apps/app_user/test/src/features/event/ui/event_application_wizard_smoke_test.dart
@@ -118,9 +118,7 @@ void main() {
       expect(find.text('참여 신청'), findsOneWidget);
     });
 
-    // Regression: Fix #2343 — initConsentItems was called in initState,
-    // triggering "Tried to modify a provider while the widget tree was
-    // building" on Step 1 → consent step transition.
+    // Fix #2343: initConsentItems called in initState causing provider modification during widget build
     testWidgets(
       'consent 단계 진입 시 Riverpod 예외 없이 렌더링된다 (Fix #2343)',
       (tester) async {


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #2343

## Root Cause

`_ConsentStepState.initState()` called `ref.read(...).notifier.initConsentItems()` synchronously, which modifies Riverpod provider state during the parent widget's build phase. Flutter forbids state mutation during the build cycle, triggering:

```
Tried to modify a provider while the widget tree was building
```

**Trigger path**: EventApplicationWizard Step 1 (identity) → Step 2 (consent). When the parent `_WizardBodyState.build()` switches `step` to `consent`, Flutter creates `_ConsentStep` and calls `initState()` — still inside the parent's build frame.

## Fix

`wizard_consent_step.dart` — wrap the `initConsentItems` call in `WidgetsBinding.instance.addPostFrameCallback` so the state mutation is deferred until after the current frame's build/layout/paint cycle.

```dart
// Before
void initState() {
  super.initState();
  ref.read(...).initConsentItems(_consentItems.length);  // ❌ modifies state in build phase
}

// After
void initState() {
  super.initState();
  WidgetsBinding.instance.addPostFrameCallback((_) {
    if (!mounted) return;
    ref.read(...).initConsentItems(_consentItems.length);  // ✅ deferred to post-frame
  });
}
```

## Regression Test

Added to `event_application_wizard_smoke_test.dart`:
- Mounts the wizard directly at consent step with uninitialised `consentCheckedItems` (length=0, triggering `initConsentItems` on first mount)
- Verifies no exception is thrown and the consent UI renders correctly
- Before the fix: throws `"Tried to modify a provider while the widget tree was building"`; after: passes