### PR TITLE
fix(app_user): 예매 취소 후 구매 목록 상태 갱신 안됨 — Fix #2345

### DIFF
--- a/apps/app_user/lib/src/features/payment/ui/purchase_history_detail_page.dart
+++ b/apps/app_user/lib/src/features/payment/ui/purchase_history_detail_page.dart
@@ -399,6 +399,11 @@ class _PurchaseDetailBody extends ConsumerWidget {
       },
       onSuccess: () async {
         if (context.mounted) {
+          // Fix #2345: invalidate before pop. The notifier-level invalidate in
+          // _requestRefund fires after Navigator.pop schedules route removal —
+          // at that point the widget-tree transition absorbs the Riverpod
+          // notification and PurchaseHistoryPage never re-fetches.
+          ref.invalidate(purchaseHistoryControllerProvider);
           context.showMinglitSuccess('예매가 취소되었습니다.');
           Navigator.pop(context);
         }

--- a/apps/app_user/test/src/features/payment/ui/purchase_history_detail_page_test.dart
+++ b/apps/app_user/test/src/features/payment/ui/purchase_history_detail_page_test.dart
@@ -71,6 +71,110 @@ void main() {
     );
   }
 
+  // Fix #2345: regression — successful cancel must re-fetch purchase history list.
+  // Uses an external ProviderContainer listener to simulate PurchaseHistoryPage
+  // watching purchaseHistoryControllerProvider, then verifies a post-cancel
+  // re-fetch happens — which only occurs if ref.invalidate is called in onSuccess.
+  group('PurchaseHistoryDetailPage cancel refresh — Fix #2345', () {
+    testWidgets(
+      'successful cancel triggers purchaseHistoryController re-fetch',
+      (tester) async {
+        var historyFetchCount = 0;
+        final now = DateTime.now();
+
+        final futureEvent = Event(
+          id: 'event1',
+          partyId: 'party1',
+          startTime: now.add(const Duration(days: 1)),
+          endTime: now.add(const Duration(days: 1, hours: 2)),
+          createdAt: now,
+          updatedAt: now,
+          title: 'Free Cancel Event',
+        );
+
+        final freeApp = EventApplication(
+          id: 'app1',
+          eventId: 'event1',
+          ticketId: 'ticket1',
+          userId: 'user1',
+          status: 'approved',
+          paymentAmount: 0,
+          paymentId: null,
+          refundStatus: 'none',
+          createdAt: now,
+          updatedAt: now,
+          event: futureEvent,
+        );
+
+        when(
+          () => mockEventRepository.getMyPurchaseHistory('user1'),
+        ).thenAnswer((_) async {
+          historyFetchCount++;
+          return [freeApp];
+        });
+        when(
+          () => mockEventRepository.cancelOrder(
+            eventId: any(named: 'eventId'),
+            reason: any(named: 'reason'),
+          ),
+        ).thenAnswer(
+          (_) async => const CancelOrderResult(type: 'cancelled'),
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              currentUserProvider.overrideWith((ref) => mockUser),
+              eventRepositoryProvider.overrideWithValue(mockEventRepository),
+              // Override detail provider so it returns freeApp directly,
+              // bypassing getPurchaseHistoryDetailById. The external listener
+              // below independently detects the post-cancel re-fetch.
+              purchaseHistoryDetailProvider('app1').overrideWith(
+                (ref) async => freeApp,
+              ),
+            ],
+            child: const MaterialApp(
+              home: PurchaseHistoryDetailPage(applicationId: 'app1'),
+            ),
+          ),
+        );
+
+        // Attach a listener via ProviderScope.containerOf to simulate
+        // PurchaseHistoryPage keeping the list controller alive across
+        // the navigation pop — mirrors the real app's base-route watcher.
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(PurchaseHistoryDetailPage)),
+        );
+        final sub = container.listen(
+          purchaseHistoryControllerProvider,
+          (_, _) {},
+        );
+        addTearDown(sub.close);
+
+        await tester.pumpAndSettle();
+        final fetchCountAfterLoad = historyFetchCount;
+        expect(fetchCountAfterLoad, greaterThan(0));
+
+        // Cancel button must be enabled (approved free ticket, future event).
+        // The button is inside a SingleChildScrollView — scroll it into view.
+        final cancelBtn = find.widgetWithText(ElevatedButton, '예매 취소');
+        expect(tester.widget<ElevatedButton>(cancelBtn).onPressed, isNotNull);
+        await tester.ensureVisible(cancelBtn);
+        await tester.pumpAndSettle();
+        await tester.tap(cancelBtn);
+        await tester.pumpAndSettle();
+
+        // Confirm cancel in dialog
+        await tester.tap(find.text('취소하기'));
+        await tester.pumpAndSettle();
+
+        // Removing ref.invalidate from onSuccess (the Fix #2345 change) must
+        // make this assertion fail.
+        expect(historyFetchCount, greaterThan(fetchCountAfterLoad));
+      },
+    );
+  });
+
   group('PurchaseHistoryDetailPage — #2095', () {
     testWidgets('shows event title and payment info', (tester) async {
       await tester.pumpWidget(createTestWidget(baseApplication));


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 요약

예매 취소 성공 후 구매 내역 목록으로 돌아와도 상태가 'Approved'로 남아있는 P1 버그 수정.

## 근본 원인

`_requestRefund` (Notifier 레벨)에서 `ref.invalidate(purchaseHistoryControllerProvider)`를 `Navigator.pop` 이후에 호출했기 때문에, 위젯 트리 전환 중 Riverpod 알림이 `PurchaseHistoryPage`까지 도달하지 못함.

## 변경 내용

- `purchase_history_detail_page.dart` `onSuccess` 콜백에서 `Navigator.pop` **전에** `ref.invalidate(purchaseHistoryControllerProvider)` 호출 — context가 mounted임이 보장되고 위젯 트리가 안정된 시점에서 invalidate 수행
- Notifier 레벨 invalidate(`_requestRefund`)는 safety net으로 유지

## 회귀 테스트

- 외부 `ProviderContainer` 리스너(PurchaseHistoryPage의 프로바이더 구독을 시뮬레이션)를 사용하는 위젯 테스트 추가
- 무료 티켓 취소 성공 후 `getMyPurchaseHistory`가 재호출되는지 검증
- 픽스를 revert하면 테스트 실패 확인됨

## 참고

TPM 트리아지 분석: #2345 코멘트

Closes #2345