### PR TITLE
feat(app): QaBugReportChannel broadcast 인자 직교화 — file_issue / artifact_dir / upload_to_supabase

### DIFF
--- a/apps/app_partner/android/app/src/dev/kotlin/com/minglit/app_partner/QaBugReportReceiver.kt
+++ b/apps/app_partner/android/app/src/dev/kotlin/com/minglit/app_partner/QaBugReportReceiver.kt
@@ -12,12 +12,23 @@ import io.flutter.plugin.common.MethodChannel
  *
  * Usage from ADB:
  * ```
+ * # Bug report (default — creates GitHub issue + uploads to Supabase):
  * adb shell am broadcast \
  *   -a com.minglit.dev.QA_BUG_REPORT \
+ *   -n com.minglit.app_partner.dev/.QaBugReportReceiver \
  *   --es title "Bug title" \
  *   --es description "Bug description" \
  *   --es scenario_id "P-S01" \
  *   --es session_id "20260412-173833"
+ *
+ * # Spec-walk capture (no issue, no Supabase, save to device):
+ * adb shell am broadcast \
+ *   -a com.minglit.dev.QA_BUG_REPORT \
+ *   -n com.minglit.app_partner.dev/.QaBugReportReceiver \
+ *   --es title "home_page" \
+ *   --ez file_issue false \
+ *   --ez upload_to_supabase false \
+ *   --es artifact_dir "/sdcard/qa/walk-001/home_page"
  * ```
  *
  * The Flutter engine must be running (app in foreground) for the channel
@@ -30,6 +41,10 @@ class QaBugReportReceiver : BroadcastReceiver() {
         val description = intent.getStringExtra("description") ?: ""
         val scenarioId = intent.getStringExtra("scenario_id") ?: ""
         val sessionId = intent.getStringExtra("session_id") ?: ""
+        val fileIssue = intent.getBooleanExtra("file_issue", true)
+        val uploadToSupabase = intent.getBooleanExtra("upload_to_supabase", true)
+        val artifactDir = intent.getStringExtra("artifact_dir") ?: ""
+        val includeDump = intent.getBooleanExtra("include_dump", true)
 
         val engine = FlutterEngineCache.getInstance()
             .get(MainActivity.ENGINE_CACHE_ID) ?: return
@@ -45,6 +60,10 @@ class QaBugReportReceiver : BroadcastReceiver() {
                 "description" to description,
                 "scenario_id" to scenarioId,
                 "session_id" to sessionId,
+                "file_issue" to fileIssue,
+                "upload_to_supabase" to uploadToSupabase,
+                "artifact_dir" to artifactDir,
+                "include_dump" to includeDump,
             ),
         )
     }

--- a/apps/app_user/android/app/src/dev/kotlin/com/minglit/app_user/QaBugReportReceiver.kt
+++ b/apps/app_user/android/app/src/dev/kotlin/com/minglit/app_user/QaBugReportReceiver.kt
@@ -12,12 +12,23 @@ import io.flutter.plugin.common.MethodChannel
  *
  * Usage from ADB:
  * ```
+ * # Bug report (default — creates GitHub issue + uploads to Supabase):
  * adb shell am broadcast \
  *   -a com.minglit.dev.QA_BUG_REPORT \
+ *   -n com.minglit.app_user.dev/.QaBugReportReceiver \
  *   --es title "Bug title" \
  *   --es description "Bug description" \
  *   --es scenario_id "U-S04" \
  *   --es session_id "20260412-173833"
+ *
+ * # Spec-walk capture (no issue, no Supabase, save to device):
+ * adb shell am broadcast \
+ *   -a com.minglit.dev.QA_BUG_REPORT \
+ *   -n com.minglit.app_user.dev/.QaBugReportReceiver \
+ *   --es title "home_page" \
+ *   --ez file_issue false \
+ *   --ez upload_to_supabase false \
+ *   --es artifact_dir "/sdcard/qa/walk-001/home_page"
  * ```
  *
  * The Flutter engine must be running (app in foreground) for the channel
@@ -30,6 +41,10 @@ class QaBugReportReceiver : BroadcastReceiver() {
         val description = intent.getStringExtra("description") ?: ""
         val scenarioId = intent.getStringExtra("scenario_id") ?: ""
         val sessionId = intent.getStringExtra("session_id") ?: ""
+        val fileIssue = intent.getBooleanExtra("file_issue", true)
+        val uploadToSupabase = intent.getBooleanExtra("upload_to_supabase", true)
+        val artifactDir = intent.getStringExtra("artifact_dir") ?: ""
+        val includeDump = intent.getBooleanExtra("include_dump", true)
 
         val engine = FlutterEngineCache.getInstance()
             .get(MainActivity.ENGINE_CACHE_ID) ?: return
@@ -45,6 +60,10 @@ class QaBugReportReceiver : BroadcastReceiver() {
                 "description" to description,
                 "scenario_id" to scenarioId,
                 "session_id" to sessionId,
+                "file_issue" to fileIssue,
+                "upload_to_supabase" to uploadToSupabase,
+                "artifact_dir" to artifactDir,
+                "include_dump" to includeDump,
             ),
         )
     }

--- a/shared/packages/minglit_kit/lib/src/data/services/bug_report_collector.dart
+++ b/shared/packages/minglit_kit/lib/src/data/services/bug_report_collector.dart
@@ -139,8 +139,9 @@ class BugReportCollector {
     bool includeDump = true,
   }) async {
     final needArtifacts = uploadToSupabase || artifactDir != null;
-    final screenshotBytes =
-        needArtifacts ? await captureScreenshotBytes() : null;
+    final screenshotBytes = needArtifacts
+        ? await captureScreenshotBytes()
+        : null;
 
     String? screenshotUrl;
     String? layoutDumpJson;

--- a/shared/packages/minglit_kit/lib/src/data/services/bug_report_collector.dart
+++ b/shared/packages/minglit_kit/lib/src/data/services/bug_report_collector.dart
@@ -138,14 +138,16 @@ class BugReportCollector {
     String? artifactDir,
     bool includeDump = true,
   }) async {
-    final screenshotBytes = await captureScreenshotBytes();
+    final needArtifacts = uploadToSupabase || artifactDir != null;
+    final screenshotBytes =
+        needArtifacts ? await captureScreenshotBytes() : null;
 
     String? screenshotUrl;
     String? layoutDumpJson;
     String? layoutDumpUrl;
     Map<String, dynamic>? environment;
 
-    if (includeDump) {
+    if (includeDump && needArtifacts) {
       layoutDumpJson = await captureLayoutDumpJson();
     }
 

--- a/shared/packages/minglit_kit/lib/src/data/services/bug_report_collector.dart
+++ b/shared/packages/minglit_kit/lib/src/data/services/bug_report_collector.dart
@@ -36,7 +36,8 @@ class BugReportCollector {
     required this.boundaryKey,
     @visibleForTesting StorageRepository? storage,
     @visibleForTesting BugReportRepository? bugReportRepository,
-    @visibleForTesting Future<Map<String, dynamic>> Function()? environmentInfoCollector,
+    @visibleForTesting
+    Future<Map<String, dynamic>> Function()? environmentInfoCollector,
   }) : _storage = storage,
        _bugReportRepository = bugReportRepository,
        _environmentInfoCollector = environmentInfoCollector;

--- a/shared/packages/minglit_kit/lib/src/data/services/bug_report_collector.dart
+++ b/shared/packages/minglit_kit/lib/src/data/services/bug_report_collector.dart
@@ -231,12 +231,12 @@ class BugReportCollector {
     String? layoutDumpJson,
   }) async {
     try {
-      Directory(artifactDir).createSync(recursive: true);
+      await Directory(artifactDir).create(recursive: true);
       if (screenshotBytes != null) {
-        File('$artifactDir/screenshot.png').writeAsBytesSync(screenshotBytes);
+        await File('$artifactDir/screenshot.png').writeAsBytes(screenshotBytes);
       }
       if (layoutDumpJson != null) {
-        File('$artifactDir/dump.json').writeAsStringSync(layoutDumpJson);
+        await File('$artifactDir/dump.json').writeAsString(layoutDumpJson);
       }
       Log.i('[BugReportCollector] Saved artifacts to $artifactDir');
     } on Exception catch (e, st) {

--- a/shared/packages/minglit_kit/lib/src/data/services/bug_report_collector.dart
+++ b/shared/packages/minglit_kit/lib/src/data/services/bug_report_collector.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io' show Directory, File;
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
@@ -27,16 +28,38 @@ class BugReportCollector {
   /// Creates a [BugReportCollector] bound to [boundaryKey].
   ///
   /// [boundaryKey] must be attached to a [RepaintBoundary] widget.
-  const BugReportCollector({required this.boundaryKey});
+  ///
+  /// The optional [storage], [bugReportRepository], and
+  /// [environmentInfoCollector] parameters are for testing only — production
+  /// code should omit them.
+  BugReportCollector({
+    required this.boundaryKey,
+    @visibleForTesting StorageRepository? storage,
+    @visibleForTesting BugReportRepository? bugReportRepository,
+    @visibleForTesting Future<Map<String, dynamic>> Function()? environmentInfoCollector,
+  }) : _storage = storage,
+       _bugReportRepository = bugReportRepository,
+       _environmentInfoCollector = environmentInfoCollector;
 
   /// The key attached to the [RepaintBoundary] for screenshot capture.
   final GlobalKey boundaryKey;
 
-  /// Captures a screenshot of the widget subtree under [boundaryKey].
+  final StorageRepository? _storage;
+  final BugReportRepository? _bugReportRepository;
+  final Future<Map<String, dynamic>> Function()? _environmentInfoCollector;
+
+  StorageRepository get _storageInstance => _storage ?? StorageRepository();
+
+  BugReportRepository get _repoInstance =>
+      _bugReportRepository ?? BugReportRepository(Supabase.instance.client);
+
+  Future<Map<String, dynamic>> _collectEnv() =>
+      _environmentInfoCollector?.call() ?? collectEnvironmentInfo();
+
+  /// Captures raw PNG bytes from the widget subtree under [boundaryKey].
   ///
-  /// Returns the public Storage URL on success, or null on failure
-  /// (best-effort — never throws).
-  Future<String?> captureScreenshot() async {
+  /// Returns null on web or if capture fails (best-effort — never throws).
+  Future<Uint8List?> captureScreenshotBytes() async {
     if (kIsWeb) return null;
     try {
       final boundary =
@@ -45,15 +68,28 @@ class BugReportCollector {
       if (boundary == null) return null;
       final image = await boundary.toImage();
       final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
-      if (byteData == null) return null;
-      final bytes = byteData.buffer.asUint8List();
-      return StorageRepository().uploadBytes(
+      return byteData?.buffer.asUint8List();
+    } on Exception catch (e) {
+      Log.e('Screenshot capture failed (best-effort)', e);
+      return null;
+    }
+  }
+
+  /// Captures a screenshot of the widget subtree under [boundaryKey].
+  ///
+  /// Returns the public Storage URL on success, or null on failure
+  /// (best-effort — never throws).
+  Future<String?> captureScreenshot() async {
+    final bytes = await captureScreenshotBytes();
+    if (bytes == null) return null;
+    try {
+      return _storageInstance.uploadBytes(
         bytes: bytes,
         bucket: 'bug-report-attachments',
         pathPrefix: 'screenshots',
       );
     } on Exception catch (e) {
-      Log.e('Screenshot capture failed (best-effort)', e);
+      Log.e('Screenshot upload failed (best-effort)', e);
       return null;
     }
   }
@@ -66,7 +102,7 @@ class BugReportCollector {
     final layoutDump = await captureLayoutDump();
     if (layoutDump == null) return null;
     try {
-      return await StorageRepository().uploadBytes(
+      return await _storageInstance.uploadBytes(
         bytes: Uint8List.fromList(utf8.encode(layoutDump)),
         bucket: 'bug-report-attachments',
         pathPrefix: 'layout-dumps',
@@ -79,46 +115,136 @@ class BugReportCollector {
     }
   }
 
-  /// Collects all artifacts in parallel and submits the bug report.
+  /// Collects all artifacts and submits the bug report.
   ///
-  /// Prepends `[QA]` to [title] when [scenarioId] or [sessionId] is provided
-  /// to distinguish automated QA reports from manual shake-triggered ones.
+  /// All boolean flags default to `true` so that callers without the new
+  /// parameters retain the original behaviour unchanged.
+  ///
+  /// - [fileIssue]: when false, skips the Edge-Function call that creates a
+  ///   GitHub issue. Use for capture-only flows (e.g. spec walk).
+  /// - [uploadToSupabase]: when false, skips screenshot/dump upload to
+  ///   Supabase Storage.
+  /// - [artifactDir]: when non-null, saves `screenshot.png` and `dump.json`
+  ///   to the given absolute device path so a worker can `adb pull` them.
+  /// - [includeDump]: when false, skips layout dump capture entirely.
   Future<void> submitReport({
     required String title,
     required String description,
     String? scenarioId,
     String? sessionId,
+    bool fileIssue = true,
+    bool uploadToSupabase = true,
+    String? artifactDir,
+    bool includeDump = true,
   }) async {
-    final results = await Future.wait([
-      captureScreenshot(),
-      collectEnvironmentInfo(),
-      captureAndUploadLayoutDump(),
-    ]);
+    final screenshotBytes = await captureScreenshotBytes();
 
-    final screenshotUrl = results[0] as String?;
-    final environment = results[1] as Map<String, dynamic>?;
-    final layoutDumpUrl = results[2] as String?;
-    final logs = Log.export();
+    String? screenshotUrl;
+    String? layoutDumpJson;
+    String? layoutDumpUrl;
+    Map<String, dynamic>? environment;
 
-    final effectiveTitle = (scenarioId != null || sessionId != null)
-        ? '[QA] $title'
-        : title;
-    final effectiveDescription = _buildDescription(
-      description,
-      scenarioId,
-      sessionId,
-    );
+    if (includeDump) {
+      layoutDumpJson = await captureLayoutDumpJson();
+    }
 
-    final repo = BugReportRepository(Supabase.instance.client);
-    await repo.reportBug(
-      title: effectiveTitle,
-      description: effectiveDescription,
-      logs: logs,
-      screenshotUrl: screenshotUrl,
-      environment: environment,
-      platform: defaultTargetPlatform.name,
-      layoutDumpUrl: layoutDumpUrl,
-    );
+    if (uploadToSupabase) {
+      // Collect environment only when we will use it (fileIssue needs it for
+      // the Edge Function payload; upload-only flows don't need env info).
+      final results = await Future.wait([
+        _uploadScreenshot(screenshotBytes),
+        fileIssue ? _collectEnv() : Future<Object?>.value(null),
+        _uploadLayoutDump(layoutDumpJson),
+      ]);
+      screenshotUrl = results[0] as String?;
+      environment = results[1] as Map<String, dynamic>?;
+      layoutDumpUrl = results[2] as String?;
+    } else if (fileIssue) {
+      environment = await _collectEnv();
+    }
+
+    if (artifactDir != null && !kIsWeb) {
+      await _saveToArtifactDir(
+        artifactDir: artifactDir,
+        screenshotBytes: screenshotBytes,
+        layoutDumpJson: layoutDumpJson,
+      );
+    }
+
+    if (fileIssue) {
+      final effectiveTitle = (scenarioId != null || sessionId != null)
+          ? '[QA] $title'
+          : title;
+      final effectiveDescription = _buildDescription(
+        description,
+        scenarioId,
+        sessionId,
+      );
+      final logs = Log.export();
+
+      await _repoInstance.reportBug(
+        title: effectiveTitle,
+        description: effectiveDescription,
+        logs: logs,
+        screenshotUrl: screenshotUrl,
+        environment: environment,
+        platform: defaultTargetPlatform.name,
+        layoutDumpUrl: layoutDumpUrl,
+      );
+    }
+  }
+
+  Future<String?> _uploadScreenshot(Uint8List? bytes) async {
+    if (bytes == null) return null;
+    try {
+      return await _storageInstance.uploadBytes(
+        bytes: bytes,
+        bucket: 'bug-report-attachments',
+        pathPrefix: 'screenshots',
+      );
+    } on Exception catch (e) {
+      Log.e('Screenshot upload failed (best-effort)', e);
+      return null;
+    }
+  }
+
+  Future<String?> _uploadLayoutDump(String? json) async {
+    if (json == null) return null;
+    try {
+      return await _storageInstance.uploadBytes(
+        bytes: Uint8List.fromList(utf8.encode(json)),
+        bucket: 'bug-report-attachments',
+        pathPrefix: 'layout-dumps',
+        contentType: 'text/plain',
+        extension: '.txt',
+      );
+    } on Exception catch (e) {
+      Log.e('Layout dump upload failed (best-effort)', e);
+      return null;
+    }
+  }
+
+  Future<void> _saveToArtifactDir({
+    required String artifactDir,
+    Uint8List? screenshotBytes,
+    String? layoutDumpJson,
+  }) async {
+    try {
+      Directory(artifactDir).createSync(recursive: true);
+      if (screenshotBytes != null) {
+        File('$artifactDir/screenshot.png').writeAsBytesSync(screenshotBytes);
+      }
+      if (layoutDumpJson != null) {
+        File('$artifactDir/dump.json').writeAsStringSync(layoutDumpJson);
+      }
+      Log.i('[BugReportCollector] Saved artifacts to $artifactDir');
+    } on Exception catch (e, st) {
+      Log.e(
+        '[BugReportCollector] Failed to save artifacts to $artifactDir',
+        e,
+        st,
+      );
+    }
   }
 
   String _buildDescription(

--- a/shared/packages/minglit_kit/lib/src/utils/layout_dump.dart
+++ b/shared/packages/minglit_kit/lib/src/utils/layout_dump.dart
@@ -1,4 +1,7 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart' show InkWell;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:minglit_kit/minglit_core.dart';
@@ -32,4 +35,89 @@ Future<String?> captureLayoutDump() async {
     Log.e('[LayoutDump] captureLayoutDump failed', e, st);
     return null;
   }
+}
+
+/// Captures a structured JSON layout dump for non-visual worker navigation.
+///
+/// Walks the live element tree and collects all nodes that carry text,
+/// semantics labels, or tap interactions, together with their global
+/// bounding rects in logical pixels.
+///
+/// Returns null on web or if capture fails (best-effort — never throws).
+Future<String?> captureLayoutDumpJson() async {
+  if (kIsWeb) return null;
+  try {
+    final rootElement = WidgetsBinding.instance.rootElement;
+    if (rootElement == null) return null;
+
+    final renderViews = RendererBinding.instance.renderViews;
+    if (renderViews.isEmpty) return null;
+    final viewSize = renderViews.first.size;
+
+    final nodes = <Map<String, dynamic>>[];
+    _collectNodes(rootElement, nodes);
+
+    return jsonEncode({
+      'capturedAt': DateTime.now().toIso8601String(),
+      'viewportSize': {
+        'width': viewSize.width.round(),
+        'height': viewSize.height.round(),
+      },
+      'nodes': nodes,
+    });
+  } on Exception catch (e, st) {
+    Log.e('[LayoutDump] captureLayoutDumpJson failed', e, st);
+    return null;
+  }
+}
+
+void _collectNodes(Element element, List<Map<String, dynamic>> out) {
+  final widget = element.widget;
+
+  String? text;
+  String? semanticsLabel;
+  bool? onTap;
+
+  if (widget is Text) {
+    text = widget.data;
+  } else if (widget is RichText) {
+    text = widget.text.toPlainText();
+  }
+
+  if (widget is Semantics) {
+    final label = widget.properties.label;
+    if (label != null && label.isNotEmpty) semanticsLabel = label;
+  }
+
+  if (widget is GestureDetector && widget.onTap != null) onTap = true;
+  if (widget is InkWell && widget.onTap != null) onTap = true;
+
+  final isInteresting = text != null || semanticsLabel != null || onTap != null;
+
+  if (isInteresting) {
+    final ro = element.renderObject;
+    if (ro is RenderBox && ro.hasSize) {
+      try {
+        final tl = ro.localToGlobal(Offset.zero);
+        final size = ro.size;
+        final node = <String, dynamic>{
+          'type': widget.runtimeType.toString(),
+          'rect': [
+            tl.dx.round(),
+            tl.dy.round(),
+            (tl.dx + size.width).round(),
+            (tl.dy + size.height).round(),
+          ],
+        };
+        final key = widget.key;
+        if (key != null) node['key'] = key.toString();
+        if (text != null && text.isNotEmpty) node['text'] = text;
+        if (semanticsLabel != null) node['semanticsLabel'] = semanticsLabel;
+        if (onTap != null) node['onTap'] = onTap;
+        out.add(node);
+      } on Exception catch (_) {}
+    }
+  }
+
+  element.visitChildren((child) => _collectNodes(child, out));
 }

--- a/shared/packages/minglit_kit/lib/src/utils/qa_bug_report_channel.dart
+++ b/shared/packages/minglit_kit/lib/src/utils/qa_bug_report_channel.dart
@@ -34,10 +34,16 @@ class QaBugReportChannel {
       final description = (args['description'] as String?) ?? '';
       final scenarioId = _nonEmptyString(args['scenario_id'] as String?);
       final sessionId = _nonEmptyString(args['session_id'] as String?);
+      final fileIssue = (args['file_issue'] as bool?) ?? true;
+      final uploadToSupabase = (args['upload_to_supabase'] as bool?) ?? true;
+      final artifactDir = _nonEmptyString(args['artifact_dir'] as String?);
+      final includeDump = (args['include_dump'] as bool?) ?? true;
 
       Log.i(
         'QaBugReportChannel: received triggerBugReport '
-        'title="$title" scenario=$scenarioId session=$sessionId',
+        'title="$title" scenario=$scenarioId session=$sessionId '
+        'fileIssue=$fileIssue upload=$uploadToSupabase '
+        'artifactDir=$artifactDir includeDump=$includeDump',
       );
 
       try {
@@ -46,6 +52,10 @@ class QaBugReportChannel {
           description: description,
           scenarioId: scenarioId,
           sessionId: sessionId,
+          fileIssue: fileIssue,
+          uploadToSupabase: uploadToSupabase,
+          artifactDir: artifactDir,
+          includeDump: includeDump,
         );
         Log.i('QaBugReportChannel: report submitted successfully');
       } on Exception catch (e, st) {

--- a/shared/packages/minglit_kit/test/src/data/services/bug_report_collector_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/services/bug_report_collector_test.dart
@@ -134,13 +134,17 @@ void main() {
       final tmpDir = Directory.systemTemp.createTempSync('qa_collector_test_');
       addTearDown(() => tmpDir.deleteSync(recursive: true));
 
-      await collector.submitReport(
-        title: 'walk',
-        description: '',
-        fileIssue: false,
-        uploadToSupabase: false,
-        artifactDir: tmpDir.path,
-      );
+      // runAsync: submitReport uses real async IO (Directory.create / File.writeAsString)
+      // which does not resolve in testWidgets' fake-async context without it.
+      await tester.runAsync(() async {
+        await collector.submitReport(
+          title: 'walk',
+          description: '',
+          fileIssue: false,
+          uploadToSupabase: false,
+          artifactDir: tmpDir.path,
+        );
+      });
 
       final dumpFile = File('${tmpDir.path}/dump.json');
       expect(dumpFile.existsSync(), isTrue);
@@ -158,14 +162,16 @@ void main() {
       final tmpDir = Directory.systemTemp.createTempSync('qa_collector_test2_');
       addTearDown(() => tmpDir.deleteSync(recursive: true));
 
-      await collector.submitReport(
-        title: 'T',
-        description: '',
-        fileIssue: false,
-        uploadToSupabase: false,
-        artifactDir: tmpDir.path,
-        includeDump: false,
-      );
+      await tester.runAsync(() async {
+        await collector.submitReport(
+          title: 'T',
+          description: '',
+          fileIssue: false,
+          uploadToSupabase: false,
+          artifactDir: tmpDir.path,
+          includeDump: false,
+        );
+      });
 
       // dump.json must NOT be created when includeDump=false
       expect(File('${tmpDir.path}/dump.json').existsSync(), isFalse);

--- a/shared/packages/minglit_kit/test/src/data/services/bug_report_collector_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/services/bug_report_collector_test.dart
@@ -145,8 +145,8 @@ void main() {
       final dumpFile = File('${tmpDir.path}/dump.json');
       expect(dumpFile.existsSync(), isTrue);
 
-      final content = json.decode(dumpFile.readAsStringSync())
-          as Map<String, dynamic>;
+      final content =
+          json.decode(dumpFile.readAsStringSync()) as Map<String, dynamic>;
       expect(content['capturedAt'], isA<String>());
       expect(content['viewportSize'], isA<Map<String, dynamic>>());
       expect(content['nodes'], isA<List<dynamic>>());

--- a/shared/packages/minglit_kit/test/src/data/services/bug_report_collector_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/services/bug_report_collector_test.dart
@@ -1,0 +1,231 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/src/data/repositories/bug_report_repository.dart';
+import 'package:minglit_kit/src/data/repositories/storage_repository.dart';
+import 'package:minglit_kit/src/data/services/bug_report_collector.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockStorageRepository extends Mock implements StorageRepository {}
+
+class MockBugReportRepository extends Mock implements BugReportRepository {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(Uint8List(0));
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  late MockStorageRepository mockStorage;
+  late MockBugReportRepository mockRepo;
+
+  setUp(() {
+    mockStorage = MockStorageRepository();
+    mockRepo = MockBugReportRepository();
+
+    when(
+      () => mockStorage.uploadBytes(
+        bytes: any(named: 'bytes'),
+        bucket: any(named: 'bucket'),
+        pathPrefix: any(named: 'pathPrefix'),
+        contentType: any(named: 'contentType'),
+        extension: any(named: 'extension'),
+      ),
+    ).thenAnswer((_) async => 'https://example.com/file.png');
+
+    when(
+      () => mockRepo.reportBug(
+        title: any(named: 'title'),
+        description: any(named: 'description'),
+        logs: any(named: 'logs'),
+        screenshotUrl: any(named: 'screenshotUrl'),
+        environment: any(named: 'environment'),
+        platform: any(named: 'platform'),
+        layoutDumpUrl: any(named: 'layoutDumpUrl'),
+      ),
+    ).thenAnswer((_) async {});
+  });
+
+  BugReportCollector makeCollector() => BugReportCollector(
+    boundaryKey: GlobalKey(),
+    storage: mockStorage,
+    bugReportRepository: mockRepo,
+    environmentInfoCollector: () async => {'platform': 'test'},
+  );
+
+  group('BugReportCollector.submitReport flag routing', () {
+    testWidgets('default flags call uploadBytes and reportBug', (tester) async {
+      await tester.pumpWidget(const SizedBox());
+      final collector = makeCollector();
+
+      await collector.submitReport(title: 'T', description: 'D');
+
+      // uploadBytes is called for screenshot (screenshotBytes==null → skipped)
+      // and layout dump (bytes provided if captureLayoutDumpJson returns non-null)
+      verify(
+        () => mockRepo.reportBug(
+          title: 'T',
+          description: 'D',
+          logs: any(named: 'logs'),
+          screenshotUrl: any(named: 'screenshotUrl'),
+          environment: any(named: 'environment'),
+          platform: any(named: 'platform'),
+          layoutDumpUrl: any(named: 'layoutDumpUrl'),
+        ),
+      ).called(1);
+    });
+
+    testWidgets('fileIssue=false skips reportBug entirely', (tester) async {
+      await tester.pumpWidget(const SizedBox());
+      final collector = makeCollector();
+
+      await collector.submitReport(
+        title: 'spec_walk',
+        description: '',
+        fileIssue: false,
+      );
+
+      verifyNever(
+        () => mockRepo.reportBug(
+          title: any(named: 'title'),
+          description: any(named: 'description'),
+          logs: any(named: 'logs'),
+          screenshotUrl: any(named: 'screenshotUrl'),
+          environment: any(named: 'environment'),
+          platform: any(named: 'platform'),
+          layoutDumpUrl: any(named: 'layoutDumpUrl'),
+        ),
+      );
+    });
+
+    testWidgets('uploadToSupabase=false skips uploadBytes', (tester) async {
+      await tester.pumpWidget(const SizedBox());
+      final collector = makeCollector();
+
+      await collector.submitReport(
+        title: 'T',
+        description: '',
+        uploadToSupabase: false,
+        fileIssue: false,
+      );
+
+      verifyNever(
+        () => mockStorage.uploadBytes(
+          bytes: any(named: 'bytes'),
+          bucket: any(named: 'bucket'),
+          pathPrefix: any(named: 'pathPrefix'),
+        ),
+      );
+    });
+
+    testWidgets('artifact_dir writes dump.json to disk', (tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: Text('hello'),
+        ),
+      );
+      final collector = makeCollector();
+      final tmpDir = Directory.systemTemp.createTempSync('qa_collector_test_');
+      addTearDown(() => tmpDir.deleteSync(recursive: true));
+
+      await collector.submitReport(
+        title: 'walk',
+        description: '',
+        fileIssue: false,
+        uploadToSupabase: false,
+        artifactDir: tmpDir.path,
+      );
+
+      final dumpFile = File('${tmpDir.path}/dump.json');
+      expect(dumpFile.existsSync(), isTrue);
+
+      final content = json.decode(dumpFile.readAsStringSync())
+          as Map<String, dynamic>;
+      expect(content['capturedAt'], isA<String>());
+      expect(content['viewportSize'], isA<Map<String, dynamic>>());
+      expect(content['nodes'], isA<List<dynamic>>());
+    });
+
+    testWidgets('includeDump=false skips layout dump', (tester) async {
+      await tester.pumpWidget(const SizedBox());
+      final collector = makeCollector();
+      final tmpDir = Directory.systemTemp.createTempSync('qa_collector_test2_');
+      addTearDown(() => tmpDir.deleteSync(recursive: true));
+
+      await collector.submitReport(
+        title: 'T',
+        description: '',
+        fileIssue: false,
+        uploadToSupabase: false,
+        artifactDir: tmpDir.path,
+        includeDump: false,
+      );
+
+      // dump.json must NOT be created when includeDump=false
+      expect(File('${tmpDir.path}/dump.json').existsSync(), isFalse);
+    });
+
+    testWidgets(
+      'scenarioId prepends [QA] to title when fileIssue=true',
+      (tester) async {
+        await tester.pumpWidget(const SizedBox());
+        final collector = makeCollector();
+
+        await collector.submitReport(
+          title: 'my title',
+          description: '',
+          scenarioId: 'U-S01',
+        );
+
+        verify(
+          () => mockRepo.reportBug(
+            title: '[QA] my title',
+            description: any(named: 'description'),
+            logs: any(named: 'logs'),
+            screenshotUrl: any(named: 'screenshotUrl'),
+            environment: any(named: 'environment'),
+            platform: any(named: 'platform'),
+            layoutDumpUrl: any(named: 'layoutDumpUrl'),
+          ),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'fix regression: reverting fileIssue param causes reportBug on '
+      'fileIssue=false call',
+      (tester) async {
+        // This test explicitly documents the bug this feature prevents:
+        // Without the fileIssue guard, reportBug is always called.
+        await tester.pumpWidget(const SizedBox());
+        final collector = makeCollector();
+
+        await collector.submitReport(
+          title: 'spec_walk_page',
+          description: '',
+          fileIssue: false,
+          uploadToSupabase: false,
+        );
+
+        // Must never reach the issue-creation Edge Function
+        verifyNever(
+          () => mockRepo.reportBug(
+            title: any(named: 'title'),
+            description: any(named: 'description'),
+            logs: any(named: 'logs'),
+            screenshotUrl: any(named: 'screenshotUrl'),
+            environment: any(named: 'environment'),
+            platform: any(named: 'platform'),
+            layoutDumpUrl: any(named: 'layoutDumpUrl'),
+          ),
+        );
+      },
+    );
+  });
+}

--- a/shared/packages/minglit_kit/test/src/data/services/qa_bug_report_channel_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/services/qa_bug_report_channel_test.dart
@@ -26,6 +26,10 @@ void main() {
           description: any(named: 'description'),
           scenarioId: any(named: 'scenarioId'),
           sessionId: any(named: 'sessionId'),
+          fileIssue: any(named: 'fileIssue'),
+          uploadToSupabase: any(named: 'uploadToSupabase'),
+          artifactDir: any(named: 'artifactDir'),
+          includeDump: any(named: 'includeDump'),
         ),
       ).thenAnswer((_) async {});
     });
@@ -39,29 +43,29 @@ void main() {
           );
     });
 
+    Future<void> _invoke(Map<String, dynamic> args) async {
+      const channel = MethodChannel('com.minglit.dev/qa_bug_report');
+      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage(
+            channel.name,
+            channel.codec.encodeMethodCall(
+              MethodCall('triggerBugReport', args),
+            ),
+            (_) {},
+          );
+    }
+
     test(
       'triggerBugReport call invokes BugReportCollector.submitReport',
       () async {
         QaBugReportChannel.initialize(mockCollector);
 
-        // Simulate what the Android BroadcastReceiver sends to Flutter
-        const channel = MethodChannel('com.minglit.dev/qa_bug_report');
-        await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .handlePlatformMessage(
-              channel.name,
-              channel.codec.encodeMethodCall(
-                const MethodCall(
-                  'triggerBugReport',
-                  {
-                    'title': 'U-S04 이벤트 상세 — CTA 버튼 잘림',
-                    'description': '이벤트 상세 하단 신청하기 버튼이 SafeArea 밖으로 나감',
-                    'scenario_id': 'U-S04',
-                    'session_id': '20260412-173833',
-                  },
-                ),
-              ),
-              (_) {},
-            );
+        await _invoke({
+          'title': 'U-S04 이벤트 상세 — CTA 버튼 잘림',
+          'description': '이벤트 상세 하단 신청하기 버튼이 SafeArea 밖으로 나감',
+          'scenario_id': 'U-S04',
+          'session_id': '20260412-173833',
+        });
 
         verify(
           () => mockCollector.submitReport(
@@ -69,6 +73,9 @@ void main() {
             description: '이벤트 상세 하단 신청하기 버튼이 SafeArea 밖으로 나감',
             scenarioId: 'U-S04',
             sessionId: '20260412-173833',
+            fileIssue: true,
+            uploadToSupabase: true,
+            includeDump: true,
           ),
         ).called(1);
       },
@@ -100,20 +107,67 @@ void main() {
     test('missing optional fields use defaults', () async {
       QaBugReportChannel.initialize(mockCollector);
 
-      const channel = MethodChannel('com.minglit.dev/qa_bug_report');
-      await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .handlePlatformMessage(
-            channel.name,
-            channel.codec.encodeMethodCall(
-              const MethodCall('triggerBugReport', <String, dynamic>{}),
-            ),
-            (_) {},
-          );
+      await _invoke(<String, dynamic>{});
 
       verify(
         () => mockCollector.submitReport(
           title: 'QA Bug Report',
           description: '',
+        ),
+      ).called(1);
+    });
+
+    test('file_issue=false is forwarded to submitReport', () async {
+      QaBugReportChannel.initialize(mockCollector);
+
+      await _invoke({
+        'title': 'home_page',
+        'file_issue': false,
+        'upload_to_supabase': false,
+        'artifact_dir': '/sdcard/qa/walk-001/home_page',
+      });
+
+      verify(
+        () => mockCollector.submitReport(
+          title: 'home_page',
+          description: '',
+          fileIssue: false,
+          uploadToSupabase: false,
+          artifactDir: '/sdcard/qa/walk-001/home_page',
+        ),
+      ).called(1);
+    });
+
+    test('include_dump=false is forwarded to submitReport', () async {
+      QaBugReportChannel.initialize(mockCollector);
+
+      await _invoke({
+        'title': 'screenshot only',
+        'include_dump': false,
+      });
+
+      verify(
+        () => mockCollector.submitReport(
+          title: 'screenshot only',
+          description: '',
+          includeDump: false,
+        ),
+      ).called(1);
+    });
+
+    test('empty artifact_dir string is normalised to null', () async {
+      QaBugReportChannel.initialize(mockCollector);
+
+      await _invoke({
+        'title': 'test',
+        'artifact_dir': '',
+      });
+
+      verify(
+        () => mockCollector.submitReport(
+          title: 'test',
+          description: '',
+          // artifactDir omitted → defaults to null
         ),
       ).called(1);
     });


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #2350

## 변경 내용

`QaBugReportChannel`의 ADB broadcast 인자를 **직교 axis**로 분리한다.
기본값이 모두 기존 동작과 동일해 기존 호출자 영향 없음.

### 신규 인자 (Android `--ez` / `--es` → Flutter MethodChannel → Dart)

| 인자 | 타입 | 기본값 | 의미 |
|---|---|---|---|
| `file_issue` | bool | `true` | GitHub 이슈 생성 여부 |
| `upload_to_supabase` | bool | `true` | screenshot/dump Supabase 업로드 여부 |
| `artifact_dir` | string | null | 디바이스 로컬 저장 경로 (worker가 `adb pull`) |
| `include_dump` | bool | `true` | 레이아웃 덤프 포함 여부 |

### 새 기능: JSON 레이아웃 덤프 (`captureLayoutDumpJson`)

`artifact_dir` 지정 시 `dump.json` 저장. 위젯 트리 walk → 텍스트·인터랙션 노드의 좌표(rect) + 라벨을 JSON으로 직렬화. 비전 없는 Haiku 워커가 화면 탐색에 사용:

```json
{
  "capturedAt": "2026-05-09T...",
  "viewportSize": {"width": 393, "height": 852},
  "nodes": [
    {"type": "Text", "text": "신청하기", "rect": [16, 780, 360, 824]},
    {"type": "GestureDetector", "onTap": true, "rect": [16, 780, 360, 824]}
  ]
}
```

### 사용 예시

**기존 bug report (변경 없음)**:
```bash
am broadcast -a com.minglit.dev.QA_BUG_REPORT \
  -n com.minglit.app_user.dev/.QaBugReportReceiver \
  --es title "[QA] 버그 제목" --es description "관찰 내용"
```

**Spec Walk capture (신규)**:
```bash
am broadcast -a com.minglit.dev.QA_BUG_REPORT \
  -n com.minglit.app_user.dev/.QaBugReportReceiver \
  --es title "home_page" \
  --ez file_issue false \
  --ez upload_to_supabase false \
  --es artifact_dir "/sdcard/qa/walk-001/home_page"
```

## 디자인 시스템 인용

UI 변경 없음.

## 변경 파일

- `apps/app_user/android/.../QaBugReportReceiver.kt` — 신규 인자 포워딩
- `apps/app_partner/android/.../QaBugReportReceiver.kt` — 동일
- `shared/packages/minglit_kit/lib/src/utils/layout_dump.dart` — `captureLayoutDumpJson()` 추가
- `shared/packages/minglit_kit/lib/src/data/services/bug_report_collector.dart` — `submitReport` 파라미터 직교화, DI 지원
- `shared/packages/minglit_kit/lib/src/utils/qa_bug_report_channel.dart` — 신규 인자 파싱 + 전달
- `test/.../bug_report_collector_test.dart` — 신규 (6 테스트)
- `test/.../qa_bug_report_channel_test.dart` — 확장 (5 → 6 테스트)