### PR TITLE
fix(app_user): _TagChip GestureDetector HitTestBehavior.opaque — Fix #2349

### DIFF
--- a/apps/app_user/lib/src/features/home/widgets/featured_tag_chip_bar.dart
+++ b/apps/app_user/lib/src/features/home/widgets/featured_tag_chip_bar.dart
@@ -58,7 +58,10 @@ class _TagChip extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
+    // Fix #2349: GestureDetector deferToChild → opaque so the chip's entire
+    // rendered area accepts hits without relying on RenderParagraph.hitTestSelf.
     return GestureDetector(
+      behavior: HitTestBehavior.opaque,
       onTap: onTap,
       child: Container(
         padding: const EdgeInsets.symmetric(

--- a/apps/app_user/test/src/features/home/widgets/featured_tag_chip_bar_test.dart
+++ b/apps/app_user/test/src/features/home/widgets/featured_tag_chip_bar_test.dart
@@ -121,5 +121,36 @@ void main() {
         expect(fakeCoordinator.calls.first.$2, '클럽');
       },
     );
+
+    // Fix #2349: GestureDetector.behavior = opaque 회귀 방지.
+    // deferToChild로 되돌리면 RenderDecoratedBox.hitTestSelf()가 false를 반환하므로
+    // padding 영역 탭이 실패한다. 여기서는 GestureDetector 설정을 직접 단언한다.
+    testWidgets(
+      '_TagChip GestureDetector — HitTestBehavior.opaque 설정 확인',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubject(
+            stub: () => when(
+              () => mockTagRepo.getFeaturedTags(),
+            ).thenAnswer((_) async => [makeTag('클럽')]),
+          ),
+        );
+        await tester.pump();
+
+        // FeaturedTagChipBar 내부의 GestureDetector를 찾는다.
+        // _TagChip이 최하위에 있으므로 마지막 GestureDetector가 칩의 것.
+        final chipGestureDetector = tester.widget<GestureDetector>(
+          find
+              .descendant(
+                of: find.byType(FeaturedTagChipBar),
+                matching: find.byType(GestureDetector),
+              )
+              .last,
+        );
+
+        // behavior: deferToChild로 되돌리면 이 단언이 깨진다.
+        expect(chipGestureDetector.behavior, equals(HitTestBehavior.opaque));
+      },
+    );
   });
 }


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #2349

## 분석 요약

QA 리포트 #2349에서 홈 화면 FeaturedTagChipBar의 태그 칩(`_TagChip`)이 터치에 반응하지 않는 이슈가 보고됐다.

### Root Cause

`_TagChip.GestureDetector`의 `behavior`가 기본값 `deferToChild`로 설정되어 있었다:

```dart
// Before (취약)
GestureDetector(
  onTap: onTap,
  child: Container(decoration: BoxDecoration(...), child: Text(...)),
)
```

`behavior: deferToChild`이면 hit-test를 자식 위젯에 위임한다. 자식 트리 `DecoratedBox → Padding → Text(RenderParagraph)`:
- `RenderParagraph.hitTestSelf() = true`이지만
- `RenderBox.hitTest()`는 먼저 `size.contains(position)` 체크를 수행
- Padding 영역(텍스트 bounds 밖)으로 tap이 들어오면 `RenderParagraph.hitTest()`가 `false` 반환
- `GestureDetector(deferToChild)`의 tap recognizer가 gesture arena에 진입하지 못해 callback 미발

### Fix

```dart
// After (명시적 opaque)
GestureDetector(
  behavior: HitTestBehavior.opaque,  // ← 추가
  onTap: onTap,
  child: Container(...)
)
```

`HitTestBehavior.opaque`이면 GestureDetector의 render area 전체에서 hit-test를 수신하므로 padding 영역 탭에서도 안정적으로 callback이 호출된다.

### 이슈 #2348 (profile icon)에 대해

#2348 (프로필 아이콘 탭 미작동)은 별도 분석에서 AppBar `IconButton` 코드가 정상임을 확인했다:
- 모든 unit 테스트 통과 (`home_page_app_bar_test.dart` 18건)
- `InkWell`에 tap gesture 등록됨 (레이아웃 덤프 확인)
- `homeCoordinator.pushMyPage` tear-off은 null이 될 수 없음

레이아웃 덤프에서 "disabled, disabled" 표시는 덤프 캡처 시점의 diagnostic format 차이로 보이며, 실제 렌더 트리에는 gesture handler가 정상 등록되어 있음. QA 자동화의 타이밍/interaction 방식 검토가 필요한 별도 이슈로 분리.

## 변경 파일

- `apps/app_user/lib/src/features/home/widgets/featured_tag_chip_bar.dart` — `_TagChip.GestureDetector`에 `behavior: HitTestBehavior.opaque` 추가
- `apps/app_user/test/src/features/home/widgets/featured_tag_chip_bar_test.dart` — GestureDetector.behavior 직접 단언 회귀 테스트 추가

## 테스트

```
flutter test test/src/features/home/ — 122건 통과
```

회귀 테스트 검증:
- fix 적용: `_TagChip GestureDetector — HitTestBehavior.opaque 설정 확인` 통과 ✅
- fix 제거: 동 테스트 실패 (Expected: <HitTestBehavior.opaque>) ✅