### PR TITLE
fix(app_user): 동의 스텝 CheckboxListTile contentPadding 복원 — Fix #2346

### DIFF
--- a/apps/app_user/lib/src/features/event/admission/wizard_consent_step.dart
+++ b/apps/app_user/lib/src/features/event/admission/wizard_consent_step.dart
@@ -62,9 +62,9 @@ class _ConsentStepState extends ConsumerState<_ConsentStep> {
             ...List.generate(
               _consentItems.length,
               // Fix #2346: contentPadding: zero로 인해 체크박스가 카드 내부 edge에
-            // 붙어 좌표 기반 자동화의 예상 위치와 달랐음. 기본 패딩으로 복원해
-            // 표준 터치 타겟 위치 확보.
-            (index) => CheckboxListTile(
+              // 붙어 좌표 기반 자동화의 예상 위치와 달랐음. 기본 패딩으로 복원해
+              // 표준 터치 타겟 위치 확보.
+              (index) => CheckboxListTile(
                 value: checked[index],
                 onChanged: (value) {
                   ref

--- a/apps/app_user/lib/src/features/event/admission/wizard_consent_step.dart
+++ b/apps/app_user/lib/src/features/event/admission/wizard_consent_step.dart
@@ -61,8 +61,10 @@ class _ConsentStepState extends ConsumerState<_ConsentStep> {
           if (checked.isNotEmpty)
             ...List.generate(
               _consentItems.length,
-              (index) => CheckboxListTile(
-                contentPadding: EdgeInsets.zero,
+              // Fix #2346: contentPadding: zero로 인해 체크박스가 카드 내부 edge에
+            // 붙어 좌표 기반 자동화의 예상 위치와 달랐음. 기본 패딩으로 복원해
+            // 표준 터치 타겟 위치 확보.
+            (index) => CheckboxListTile(
                 value: checked[index],
                 onChanged: (value) {
                   ref

--- a/apps/app_user/test/src/features/event/ui/event_application_wizard_smoke_test.dart
+++ b/apps/app_user/test/src/features/event/ui/event_application_wizard_smoke_test.dart
@@ -118,6 +118,36 @@ void main() {
       expect(find.text('참여 신청'), findsOneWidget);
     });
 
+    // Fix #2346: contentPadding: EdgeInsets.zero 회귀 방지.
+    // contentPadding zero이면 체크박스가 카드 내부 좌측 edge에 붙어
+    // 좌표 기반 자동화의 예상 좌표와 어긋난다.
+    testWidgets(
+      'consent 단계 체크박스 — contentPadding이 EdgeInsets.zero가 아님 (Fix #2346)',
+      (tester) async {
+        await tester.pumpWidget(
+          buildWidget(
+            appState: const EventApplicationState(
+              step: EventApplicationStep.consent,
+              status: EventApplicationStatus.initial,
+              identityCompleted: true,
+              partnerVerifications: [],
+              consentGranted: false,
+              consentCheckedItems: [false, false, false],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CheckboxListTile), findsNWidgets(3));
+
+        // contentPadding: EdgeInsets.zero로 되돌리면 이 단언이 깨진다.
+        final tile = tester.widget<CheckboxListTile>(
+          find.byType(CheckboxListTile).first,
+        );
+        expect(tile.contentPadding, isNot(equals(EdgeInsets.zero)));
+      },
+    );
+
     // Fix #2343: initConsentItems called in initState causing provider modification during widget build
     testWidgets(
       'consent 단계 진입 시 Riverpod 예외 없이 렌더링된다 (Fix #2343)',


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #2346

## 문제

신청 위저드 동의 스텝의 `CheckboxListTile`에 `contentPadding: EdgeInsets.zero`가 설정되어 있어 체크박스가 카드 내부 좌측 edge에 붙어 있었다.

`CheckboxListTile` 기본 `contentPadding`은 `EdgeInsets.symmetric(horizontal: 16)`이다. `EdgeInsets.zero`로 설정하면 체크박스가 x=0 (카드 inner padding 직후)에 위치하게 되어 Material 표준 좌표(x=16)를 가정하는 QA 자동화 스크립트가 정확한 위치를 찾지 못한다.

## Fix

```dart
// Before
CheckboxListTile(
  contentPadding: EdgeInsets.zero,  // ← 제거
  ...
)

// After
CheckboxListTile(
  // default contentPadding: EdgeInsets.symmetric(horizontal: 16)
  ...
)
```

## 테스트

```
flutter test test/src/features/event/ui/event_application_wizard_smoke_test.dart — 8건 통과
```

회귀 방지 테스트 추가:
- `contentPadding: EdgeInsets.zero로 되돌리면 단언 실패` ✅