### PR TITLE
fix(app_user): IconButton tooltip 누락 수정 — Fix #2356, Fix #2358

### DIFF
--- a/apps/app_user/lib/src/features/home/home_page.dart
+++ b/apps/app_user/lib/src/features/home/home_page.dart
@@ -119,8 +119,10 @@ class _HomePageState extends ConsumerState<HomePage> {
                   onPressed: homeCoordinator.pushSearch,
                 ),
                 if (user != null) ...[
+                  // Fix #2356: tooltip 누락 — NAF="true" 회귀, spec: home_page.html L1244
                   IconButton(
                     icon: const Icon(Icons.notifications_outlined),
+                    tooltip: '알림',
                     onPressed: homeCoordinator.pushNotificationCenter,
                   ),
                   // Fix #141: Use IconButton for consistent touch target (48x48)

--- a/apps/app_user/lib/src/features/ticket/ui/ticket_selection_widgets.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/ticket_selection_widgets.dart
@@ -130,9 +130,11 @@ extension _TicketSelectionWidgets on _TicketSelectionSheetState {
       ),
       child: Row(
         children: [
+          // Fix #2358: tooltip 누락 — NAF="true" 회귀
           const IconButton(
             onPressed: null,
             icon: Icon(Icons.remove, size: MinglitIconSize.xsmall),
+            tooltip: '수량 감소',
             padding: EdgeInsets.zero,
             constraints: BoxConstraints(minWidth: 32, minHeight: 32),
           ),
@@ -146,6 +148,7 @@ extension _TicketSelectionWidgets on _TicketSelectionSheetState {
             onPressed: () =>
                 context.showMinglitInfo('친구와 함께 참가하기 기능은 준비 중입니다.'),
             icon: const Icon(Icons.add, size: MinglitIconSize.xsmall),
+            tooltip: '수량 증가',
             padding: EdgeInsets.zero,
             constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
           ),

--- a/apps/app_user/test/src/features/home/home_page_app_bar_test.dart
+++ b/apps/app_user/test/src/features/home/home_page_app_bar_test.dart
@@ -254,6 +254,25 @@ void main() {
       });
     });
 
+    // Fix #2356: 알림 버튼 — 접근성 라벨 회귀 가드 (NAF="true" 재발 방지)
+    group('Notification button tooltip — #2356 regression guard', () {
+      testWidgets('로그인 상태: 알림 버튼 tooltip이 존재한다', (tester) async {
+        final mockUser = _createMockUser(
+          id: 'user123',
+          email: 'test@example.com',
+        );
+
+        await tester.pumpWidget(
+          createTestWidget(
+            overrides: [currentUserProvider.overrideWith((_) => mockUser)],
+          ),
+        );
+        await tester.pump();
+
+        expect(find.byTooltip('알림'), findsOneWidget);
+      });
+    });
+
     // Fix #2339: 검색 버튼 — 접근성 라벨 + 내비게이션 회귀 가드
     // QA automation이 좌표 대신 시맨틱(tooltip)으로 버튼을 찾을 수 있는지 검증한다.
     group('Search button navigation — #2339 regression guard', () {

--- a/apps/app_user/test/src/features/ticket/ui/ticket_selection_sheet_test.dart
+++ b/apps/app_user/test/src/features/ticket/ui/ticket_selection_sheet_test.dart
@@ -1,0 +1,124 @@
+// Fix #2358: TicketSelectionSheet 수량 stepper IconButton tooltip 회귀 가드.
+//
+// buildQuantityStepper()의 − / + IconButton에 tooltip이 없으면
+// uidump에서 NAF="true" content-desc="" 로 캡처되어 스크린리더 접근 불가.
+import 'package:app_user/src/features/ticket/ui/ticket_selection_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../utils/mocks.dart';
+
+void main() {
+  setUpAll(() async {
+    await initializeDateFormatting('ko_KR');
+  });
+
+  late MockEventRepository mockEventRepo;
+  late MockUserRepository mockUserRepo;
+  late MockUser mockUser;
+
+  final now = DateTime.now();
+  final testTicket = Ticket(
+    id: 'ticket-1',
+    name: '일반',
+    price: 10000,
+    createdAt: now,
+    updatedAt: now,
+  );
+  final testEvent = Event(
+    id: 'event-1',
+    partyId: 'party-1',
+    title: 'Test Event',
+    startTime: now.add(const Duration(days: 1)),
+    endTime: now.add(const Duration(days: 1, hours: 2)),
+    createdAt: now,
+    updatedAt: now,
+    contactOptions: {},
+    tickets: [testTicket],
+    entryGroups: [],
+  );
+
+  setUp(() {
+    mockEventRepo = MockEventRepository();
+    mockUserRepo = MockUserRepository();
+    mockUser = MockUser();
+
+    when(() => mockUser.id).thenReturn('user-1');
+    when(() => mockUser.email).thenReturn('test@example.com');
+    when(() => mockUser.userMetadata).thenReturn({'full_name': 'Test User'});
+
+    when(
+      () => mockEventRepo.getTicketBalanceStatus(any()),
+    ).thenAnswer((_) async => <String, bool>{});
+
+    // isVerified=true → 티켓 자격 검사 통과 → 티켓 자동 선택 → 수량 stepper 노출
+    when(
+      () => mockUserRepo.getUserProfile(any()),
+    ).thenAnswer(
+      (_) async => const UserProfile(
+        id: 'user-1',
+        name: 'Test',
+        username: 'test',
+        isVerified: true,
+        gender: 'male',
+        birthYear: 1995,
+      ),
+    );
+
+    when(
+      () => mockUserRepo.getApprovedVerificationIds(any()),
+    ).thenAnswer((_) async => <String>[]);
+  });
+
+  Widget buildSheet() {
+    return ProviderScope(
+      overrides: [
+        // 로그인 상태 + verified profile → TicketRecommendationUtil이 티켓 선택
+        currentUserProvider.overrideWith((_) => mockUser),
+        eventRepositoryProvider.overrideWith((_) => mockEventRepo),
+        userRepositoryProvider.overrideWith((_) => mockUserRepo),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: TicketSelectionSheet(
+            event: testEvent,
+            onTicketSelected: (_, __) {},
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('TicketSelectionSheet quantity stepper', () {
+    testWidgets(
+      'Fix #2358: − 버튼에 tooltip "수량 감소"가 존재한다',
+      (tester) async {
+        await tester.pumpWidget(buildSheet());
+        await tester.pumpAndSettle();
+
+        expect(
+          find.byTooltip('수량 감소'),
+          findsOneWidget,
+          reason: '수량 감소 IconButton에 tooltip이 없으면 NAF="true" 회귀',
+        );
+      },
+    );
+
+    testWidgets(
+      'Fix #2358: + 버튼에 tooltip "수량 증가"가 존재한다',
+      (tester) async {
+        await tester.pumpWidget(buildSheet());
+        await tester.pumpAndSettle();
+
+        expect(
+          find.byTooltip('수량 증가'),
+          findsOneWidget,
+          reason: '수량 증가 IconButton에 tooltip이 없으면 NAF="true" 회귀',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #2356, closes #2358

## 문제

HomPage AppBar 알림 버튼과 TicketSelectionSheet 수량 stepper 버튼에 `tooltip`이 없어 uidump에서 `NAF="true"`, `content-desc=""`로 캡처됨.

스크린리더가 버튼을 "버튼" 외에 식별 불가 — a11y P2 회귀.

## 변경 내용

### spec 인용

**#2356** — `apps/mds/docs/public/specs/home_page.html` L1244: "MinglitAppBar (검색 · 알림 · 아바타 3개 액션 아이콘)"
- 검색·마이페이지에는 tooltip 있음, 알림만 누락

**#2358** — `apps/mds/docs/public/specs/event_application_wizard_page.html` 수량 stepper 섹션
- Fix #2107 / #2339 패턴(IconButton 전반 tooltip 의무화) 동일 회귀

### 구현

**`apps/app_user/lib/src/features/home/home_page.dart`** (Fix #2356)
- 알림 IconButton에 `tooltip: '알림'` 추가

**`apps/app_user/lib/src/features/ticket/ui/ticket_selection_widgets.dart`** (Fix #2358)
- `buildQuantityStepper()` 내 − / + IconButton에 `tooltip: '수량 감소'` / `'수량 증가'` 추가

## 테스트

**Fix #2356** — `home_page_app_bar_test.dart`
- `find.byTooltip('알림')` 로그인 상태 확인

**Fix #2358** — `ticket_selection_sheet_test.dart` (신규)
- `find.byTooltip('수량 감소')` / `find.byTooltip('수량 증가')` 확인
- 검증 완료: fix revert 시 fail

```
flutter test test/src/features/home/home_page_app_bar_test.dart
✓ 19 tests passed

flutter test test/src/features/ticket/ui/ticket_selection_sheet_test.dart  
✓ Fix #2358: − 버튼에 tooltip "수량 감소"가 존재한다
✓ Fix #2358: + 버튼에 tooltip "수량 증가"가 존재한다
✓ All tests passed!
```