### PR TITLE
fix(app_user): Kotlin 2.3.0 업그레이드 + kotlinOptions → compilerOptions — Fix #2362

### DIFF
--- a/apps/app_user/android/app/build.gradle.kts
+++ b/apps/app_user/android/app/build.gradle.kts
@@ -25,8 +25,11 @@ android {
         targetCompatibility = JavaVersion.VERSION_11
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+    // Fix #2362: kotlinOptions는 Kotlin 2.3.0+에서 deprecated — compilerOptions DSL로 이전
+    kotlin {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
+        }
     }
 
     defaultConfig {

--- a/apps/app_user/android/settings.gradle.kts
+++ b/apps/app_user/android/settings.gradle.kts
@@ -19,7 +19,8 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.9.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    // Fix #2362: screen_brightness_android 컴파일 오류 — Kotlin 2.3.0으로 상향
+    id("org.jetbrains.kotlin.android") version "2.3.0" apply false
 }
 
 rootProject.name = "app_user_android"


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #2362

## 문제

`screen_brightness_android` 플러그인이 Kotlin 2.1.0과 컴파일 충돌:
```
Execution failed for task ':screen_brightness_android:compileDebugKotlin'.
> Internal compiler error
```

## 변경 내용

**`apps/app_user/android/settings.gradle.kts`**
- Kotlin 플러그인 버전: `2.1.0` → `2.3.0`

**`apps/app_user/android/app/build.gradle.kts`**
- `kotlinOptions { jvmTarget = ... }` → `kotlin { compilerOptions { jvmTarget.set(JVM_11) } }` (Kotlin 2.3.0+ deprecated API 이전)

## 검증

- needs-runtime-qa-gemini-1 워커가 동일 수정 후 `assembleDevDebug` 빌드 정상 통과 확인 (#2362 코멘트)
- `app_partner`는 `screen_brightness` 미사용 — 변경 불필요