### PR TITLE
fix(ci): iOS deploy 러너 macos-15 고정 — Xcode 16+ SDK 보장

### DIFF
--- a/.github/workflows/ios-deploy-partner.yml
+++ b/.github/workflows/ios-deploy-partner.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   ios-deploy:
-    runs-on: macos-latest
+    runs-on: macos-15  # Fix #2371: connectivity_plus 7.1.1 requires NWPath.isUltraConstrained (iOS 18 SDK / Xcode 16+)
     timeout-minutes: 60
     environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
     steps:

--- a/.github/workflows/ios-deploy-user.yml
+++ b/.github/workflows/ios-deploy-user.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   ios-deploy:
-    runs-on: macos-latest
+    runs-on: macos-15  # Fix #2371: connectivity_plus 7.1.1 requires NWPath.isUltraConstrained (iOS 18 SDK / Xcode 16+)
     timeout-minutes: 60
     environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
     steps:


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 문제

`connectivity_plus 7.1.1`이 `NWPath.isUltraConstrained` API를 사용하는데, 이 API는 iOS 18 SDK / Xcode 16+에서 도입됐다. `macos-latest` 러너가 macOS 14 (Xcode 15.x)를 가리키고 있어 Swift compile 단계에서 실패.

```
Swift Compiler Error: Value of type 'NWPath' has no member 'isUltraConstrained'
/connectivity_plus-7.1.1/ios/.../PathMonitorConnectivityProvider.swift:28:39
```

## 수정

`.github/workflows/ios-deploy-{user,partner}.yml`의 `runs-on: macos-latest` → `runs-on: macos-15`

`macos-15` 런너는 Xcode 16+를 포함하여 iOS 18 SDK를 지원한다.

## 검증 방법

PR 머지 후 `workflow_dispatch`로 수동 실행 → build success 확인

Closes #2371
Closes #2049
Closes #2061