### PR TITLE
fix(accessibility): ticket_qr_screen BoardingPassCard semantic wiring

### DIFF
--- a/apps/app_user/lib/src/features/ticket/logic/boarding_pass_status.dart
+++ b/apps/app_user/lib/src/features/ticket/logic/boarding_pass_status.dart
@@ -9,7 +9,14 @@ enum BoardingPassStatus {
   confirmed,
 
   /// Event was in the past (started yesterday or earlier).
-  used,
+  used;
+
+  // Fix #2374: 스크린리더가 읽을 수 있는 한글 상태 레이블
+  String get semanticLabel => switch (this) {
+    BoardingPassStatus.boarding => '입장 가능',
+    BoardingPassStatus.confirmed => '예약 확정',
+    BoardingPassStatus.used => '사용 완료',
+  };
 }
 
 /// Determines the [BoardingPassStatus] for an event starting at

--- a/apps/app_user/lib/src/features/ticket/logic/boarding_pass_status.dart
+++ b/apps/app_user/lib/src/features/ticket/logic/boarding_pass_status.dart
@@ -9,7 +9,8 @@ enum BoardingPassStatus {
   confirmed,
 
   /// Event was in the past (started yesterday or earlier).
-  used;
+  used
+  ;
 
   // Fix #2374: 스크린리더가 읽을 수 있는 한글 상태 레이블
   String get semanticLabel => switch (this) {

--- a/apps/app_user/lib/src/features/ticket/ui/ticket_qr_screen.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/ticket_qr_screen.dart
@@ -121,26 +121,32 @@ class _TicketQRScreenState extends State<TicketQRScreen>
 
                     const SizedBox(height: MinglitSpacing.large),
 
-                    // Instruction text (below card)
-                    Text(
-                      '입장 시 파트너에게 이 화면을 보여주세요',
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
+                    // Fix #2374: 입장 안내 — 명시적 semantic label (스크린리더 접근성)
+                    Semantics(
+                      label: '입장 안내: 입장 시 파트너에게 이 화면을 보여주세요',
+                      child: Text(
+                        '입장 시 파트너에게 이 화면을 보여주세요',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                        textAlign: TextAlign.center,
                       ),
-                      textAlign: TextAlign.center,
                     ),
 
                     const SizedBox(height: MinglitSpacing.small),
 
-                    // Anti-fraud notice
-                    Text(
-                      '스크린샷은 입장에 사용할 수 없습니다',
-                      style: theme.textTheme.labelSmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant.withValues(
-                          alpha: MinglitOpacity.muted,
+                    // Fix #2374: 캡처 방지 안내 — 명시적 semantic label
+                    Semantics(
+                      label: '캡처 방지 안내: 스크린샷은 입장에 사용할 수 없습니다',
+                      child: Text(
+                        '스크린샷은 입장에 사용할 수 없습니다',
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant.withValues(
+                            alpha: MinglitOpacity.muted,
+                          ),
                         ),
+                        textAlign: TextAlign.center,
                       ),
-                      textAlign: TextAlign.center,
                     ),
                   ],
                 ),

--- a/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card_info.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card_info.dart
@@ -11,53 +11,58 @@ class _HeaderStrip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      height: 64,
-      decoration: const BoxDecoration(
-        gradient: LinearGradient(
-          colors: [MinglitColors.primary, MinglitColors.primaryDark],
+    // Fix #2374: header strip 전체를 단일 라벨로 — 장식적 요소(로고·"BOARDING PASS") 중복 읽기 방지
+    return Semantics(
+      label: 'Minglit 보딩패스 입장권',
+      excludeSemantics: true,
+      child: Container(
+        height: 64,
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [MinglitColors.primary, MinglitColors.primaryDark],
+          ),
         ),
-      ),
-      padding: const EdgeInsets.symmetric(
-        horizontal: MinglitSpacing.large,
-      ),
-      child: Row(
-        children: [
-          // White logo — ColorFiltered wraps the themed SVG
-          ColorFiltered(
-            colorFilter: const ColorFilter.mode(
-              MinglitColors.background,
-              BlendMode.srcIn,
+        padding: const EdgeInsets.symmetric(
+          horizontal: MinglitSpacing.large,
+        ),
+        child: Row(
+          children: [
+            // White logo — ColorFiltered wraps the themed SVG
+            ColorFiltered(
+              colorFilter: const ColorFilter.mode(
+                MinglitColors.background,
+                BlendMode.srcIn,
+              ),
+              child: MinglitTheme.appBarLogo(height: 24),
             ),
-            child: MinglitTheme.appBarLogo(height: 24),
-          ),
-          const Spacer(),
-          Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: [
-              const Text(
-                'BOARDING PASS',
-                style: TextStyle(
-                  color: MinglitColors.background,
-                  fontSize: 11,
-                  fontWeight: FontWeight.w700,
-                  letterSpacing: 2,
-                ),
-              ),
-              Text(
-                '입장권',
-                style: TextStyle(
-                  color: MinglitColors.background.withValues(
-                    alpha: MinglitOpacity.scrimDark,
+            const Spacer(),
+            Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                const Text(
+                  'BOARDING PASS',
+                  style: TextStyle(
+                    color: MinglitColors.background,
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 2,
                   ),
-                  fontSize: 10,
-                  fontWeight: FontWeight.w500,
                 ),
-              ),
-            ],
-          ),
-        ],
+                Text(
+                  '입장권',
+                  style: TextStyle(
+                    color: MinglitColors.background.withValues(
+                      alpha: MinglitOpacity.scrimDark,
+                    ),
+                    fontSize: 10,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -87,7 +92,18 @@ class _EventInfoSection extends StatelessWidget {
     final eventTitle = meta?.eventTitle ?? '—';
     final ticketName = meta?.ticketName;
 
-    return Container(
+    // Fix #2374: 이벤트 정보 섹션 전체를 하나의 semantic 노드로 병합
+    // 날짜/장소/이벤트명을 스크린리더가 한 번에 읽도록 label 제공
+    final semanticLabel = StringBuffer()
+      ..write('이벤트 정보. 날짜: $dateLabel $timeLabel. ')
+      ..write('장소: $venueLabel. ')
+      ..write('이벤트: $eventTitle');
+    if (ticketName != null) semanticLabel.write('. 티켓: $ticketName');
+
+    return Semantics(
+      label: semanticLabel.toString(),
+      excludeSemantics: true,
+      child: Container(
       color: MinglitColors.background,
       padding: const EdgeInsets.fromLTRB(
         MinglitSpacing.large,
@@ -203,7 +219,8 @@ class _EventInfoSection extends StatelessWidget {
           ],
         ],
       ),
-    );
+    ),
+  );
   }
 }
 

--- a/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card_info.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card_info.dart
@@ -104,123 +104,123 @@ class _EventInfoSection extends StatelessWidget {
       label: semanticLabel.toString(),
       excludeSemantics: true,
       child: Container(
-      color: MinglitColors.background,
-      padding: const EdgeInsets.fromLTRB(
-        MinglitSpacing.large,
-        MinglitSpacing.medium,
-        MinglitSpacing.large,
-        MinglitSpacing.medium,
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          // Flight-style info row: DATE → VENUE
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Left: DATE section
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const _FieldLabel('DATE'),
-                    const SizedBox(height: 2),
-                    Text(
-                      dateLabel,
-                      style: const TextStyle(
-                        color: MinglitColors.textPrimary,
-                        fontSize: 13,
-                        fontWeight: FontWeight.w700,
+        color: MinglitColors.background,
+        padding: const EdgeInsets.fromLTRB(
+          MinglitSpacing.large,
+          MinglitSpacing.medium,
+          MinglitSpacing.large,
+          MinglitSpacing.medium,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // Flight-style info row: DATE → VENUE
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Left: DATE section
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const _FieldLabel('DATE'),
+                      const SizedBox(height: 2),
+                      Text(
+                        dateLabel,
+                        style: const TextStyle(
+                          color: MinglitColors.textPrimary,
+                          fontSize: 13,
+                          fontWeight: FontWeight.w700,
+                        ),
                       ),
-                    ),
-                    Text(
-                      timeLabel,
-                      style: const TextStyle(
-                        color: MinglitColors.primary,
-                        fontSize: 22,
-                        fontWeight: FontWeight.w800,
-                        height: 1.1,
+                      Text(
+                        timeLabel,
+                        style: const TextStyle(
+                          color: MinglitColors.primary,
+                          fontSize: 22,
+                          fontWeight: FontWeight.w800,
+                          height: 1.1,
+                        ),
                       ),
-                    ),
-                  ],
-                ),
-              ),
-              // Center: arrow aligned to time row
-              const Padding(
-                padding: EdgeInsets.only(top: 30),
-                child: Text(
-                  '→',
-                  style: TextStyle(
-                    color: MinglitColors.textSecondary,
-                    fontSize: 18,
+                    ],
                   ),
                 ),
-              ),
-              // Right: VENUE section
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: [
-                    const _FieldLabel('VENUE', rightAligned: true),
-                    const SizedBox(height: 2),
-                    Text(
-                      venueLabel,
-                      style: const TextStyle(
-                        color: MinglitColors.textPrimary,
-                        fontSize: 13,
-                        fontWeight: FontWeight.w700,
-                      ),
-                      textAlign: TextAlign.right,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
+                // Center: arrow aligned to time row
+                const Padding(
+                  padding: EdgeInsets.only(top: 30),
+                  child: Text(
+                    '→',
+                    style: TextStyle(
+                      color: MinglitColors.textSecondary,
+                      fontSize: 18,
                     ),
-                  ],
+                  ),
                 ),
+                // Right: VENUE section
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      const _FieldLabel('VENUE', rightAligned: true),
+                      const SizedBox(height: 2),
+                      Text(
+                        venueLabel,
+                        style: const TextStyle(
+                          color: MinglitColors.textPrimary,
+                          fontSize: 13,
+                          fontWeight: FontWeight.w700,
+                        ),
+                        textAlign: TextAlign.right,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+
+            // Divider
+            // Fix #1931: use theme-aware color so divider renders correctly in dark mode
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: MinglitSpacing.sm),
+              child: Divider(
+                height: 1,
+                color: Theme.of(context).colorScheme.outlineVariant,
               ),
-            ],
-          ),
-
-          // Divider
-          // Fix #1931: use theme-aware color so divider renders correctly in dark mode
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: MinglitSpacing.sm),
-            child: Divider(
-              height: 1,
-              color: Theme.of(context).colorScheme.outlineVariant,
             ),
-          ),
 
-          // Event title (center aligned, 2-line ellipsis)
-          Text(
-            eventTitle,
-            style: const TextStyle(
-              color: MinglitColors.textPrimary,
-              fontSize: 16,
-              fontWeight: FontWeight.w700,
-            ),
-            textAlign: TextAlign.center,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-          ),
-
-          // Ticket type (optional)
-          if (ticketName != null) ...[
-            const SizedBox(height: MinglitSpacing.xsmall),
+            // Event title (center aligned, 2-line ellipsis)
             Text(
-              'TICKET · $ticketName',
+              eventTitle,
               style: const TextStyle(
-                color: MinglitColors.textSecondary,
-                fontSize: 11,
-                fontWeight: FontWeight.w500,
-                letterSpacing: 0.5,
+                color: MinglitColors.textPrimary,
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
               ),
               textAlign: TextAlign.center,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
             ),
+
+            // Ticket type (optional)
+            if (ticketName != null) ...[
+              const SizedBox(height: MinglitSpacing.xsmall),
+              Text(
+                'TICKET · $ticketName',
+                style: const TextStyle(
+                  color: MinglitColors.textSecondary,
+                  fontSize: 11,
+                  fontWeight: FontWeight.w500,
+                  letterSpacing: 0.5,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
           ],
-        ],
+        ),
       ),
-    ),
-  );
+    );
   }
 }
 

--- a/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card_qr.dart
+++ b/apps/app_user/lib/src/features/ticket/ui/widgets/boarding_pass_card_qr.dart
@@ -196,41 +196,46 @@ class _QRStubSection extends StatelessWidget {
 
           const SizedBox(height: MinglitSpacing.medium),
 
-          // TICKET NO. / STATUS row
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Left: ticket number
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const _MetaLabel('TICKET NO.'),
-                  const SizedBox(height: 2),
-                  Text(
-                    _formatTicketNo(token.ticketId),
-                    style: const TextStyle(
-                      color: MinglitColors.textPrimary,
-                      fontSize: 11,
-                      fontWeight: FontWeight.w600,
-                      letterSpacing: 0.5,
+          // Fix #2374: 티켓 번호 + 상태 행 — semantic label 병합 (장식적 TICKET NO./STATUS 라벨 제외)
+          Semantics(
+            label:
+                '티켓 번호: ${_formatTicketNo(token.ticketId)}. 상태: ${status.semanticLabel}',
+            excludeSemantics: true,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Left: ticket number
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const _MetaLabel('TICKET NO.'),
+                    const SizedBox(height: 2),
+                    Text(
+                      _formatTicketNo(token.ticketId),
+                      style: const TextStyle(
+                        color: MinglitColors.textPrimary,
+                        fontSize: 11,
+                        fontWeight: FontWeight.w600,
+                        letterSpacing: 0.5,
+                      ),
                     ),
-                  ),
-                ],
-              ),
-              const Spacer(),
-              // Right: status badge
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  const _MetaLabel('STATUS'),
-                  const SizedBox(height: 2),
-                  _StatusBadge(
-                    status: status,
-                    pulseAnimation: pulseAnimation,
-                  ),
-                ],
-              ),
-            ],
+                  ],
+                ),
+                const Spacer(),
+                // Right: status badge
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    const _MetaLabel('STATUS'),
+                    const SizedBox(height: 2),
+                    _StatusBadge(
+                      status: status,
+                      pulseAnimation: pulseAnimation,
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ),
         ],
       ),

--- a/apps/app_user/test/src/features/ticket/logic/boarding_pass_status_test.dart
+++ b/apps/app_user/test/src/features/ticket/logic/boarding_pass_status_test.dart
@@ -78,4 +78,19 @@ void main() {
       );
     });
   });
+
+  // Fix #2374 regression guard: semanticLabel 접근성 레이블 검증
+  group('BoardingPassStatus.semanticLabel', () {
+    test('boarding → "입장 가능"', () {
+      expect(BoardingPassStatus.boarding.semanticLabel, '입장 가능');
+    });
+
+    test('confirmed → "예약 확정"', () {
+      expect(BoardingPassStatus.confirmed.semanticLabel, '예약 확정');
+    });
+
+    test('used → "사용 완료"', () {
+      expect(BoardingPassStatus.used.semanticLabel, '사용 완료');
+    });
+  });
 }

--- a/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
+++ b/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
@@ -302,8 +302,7 @@ void main() {
 
       expect(
         find.byWidgetPredicate(
-          (w) =>
-              w is Semantics && w.properties.label == 'Minglit 보딩패스 입장권',
+          (w) => w is Semantics && w.properties.label == 'Minglit 보딩패스 입장권',
         ),
         findsOneWidget,
         reason: 'Fix #2374: _HeaderStrip에 semantic label 없으면 스크린리더가 헤더 인식 불가',
@@ -339,7 +338,10 @@ void main() {
         dateTime: DateTime.now().add(const Duration(days: 7)),
       );
       await tester.pumpWidget(
-        _wrap(token: _makeToken(ticketId: 'abcd1234'), eventMeta: futureMeta),
+        _wrap(
+          token: _makeToken(ticketId: 'abcd1234'),
+          eventMeta: futureMeta,
+        ),
       );
       await tester.pump();
 

--- a/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
+++ b/apps/app_user/test/src/features/ticket/ui/boarding_pass_card_test.dart
@@ -293,6 +293,69 @@ void main() {
       },
     );
 
+    // Fix #2374 regression guard: accessibility semantics wiring
+    testWidgets('헤더 스트립: semantic label "Minglit 보딩패스 입장권" 존재', (tester) async {
+      await tester.pumpWidget(
+        _wrap(token: _makeToken(), eventMeta: _makeMeta()),
+      );
+      await tester.pump();
+
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is Semantics && w.properties.label == 'Minglit 보딩패스 입장권',
+        ),
+        findsOneWidget,
+        reason: 'Fix #2374: _HeaderStrip에 semantic label 없으면 스크린리더가 헤더 인식 불가',
+      );
+    });
+
+    testWidgets('이벤트 정보: semantic label에 날짜·장소·이벤트명 포함', (tester) async {
+      final meta = _makeMeta(
+        title: '와인 테이스팅',
+        dateTime: DateTime(2026, 4, 15, 19),
+        venue: '강남 라운지',
+        ticketName: null,
+      );
+      await tester.pumpWidget(_wrap(token: _makeToken(), eventMeta: meta));
+      await tester.pump();
+
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is Semantics &&
+              w.properties.label != null &&
+              w.properties.label!.contains('이벤트 정보') &&
+              w.properties.label!.contains('강남 라운지') &&
+              w.properties.label!.contains('와인 테이스팅'),
+        ),
+        findsOneWidget,
+        reason: 'Fix #2374: _EventInfoSection semantic label 없으면 이벤트 정보 접근성 누락',
+      );
+    });
+
+    testWidgets('티켓 번호/상태 행: semantic label에 티켓번호·상태 포함', (tester) async {
+      final futureMeta = _makeMeta(
+        dateTime: DateTime.now().add(const Duration(days: 7)),
+      );
+      await tester.pumpWidget(
+        _wrap(token: _makeToken(ticketId: 'abcd1234'), eventMeta: futureMeta),
+      );
+      await tester.pump();
+
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is Semantics &&
+              w.properties.label != null &&
+              w.properties.label!.contains('티켓 번호') &&
+              w.properties.label!.contains('예약 확정'),
+        ),
+        findsOneWidget,
+        reason: 'Fix #2374: 티켓 번호+상태 행 semantic label 없으면 접근성 누락',
+      );
+    });
+
     // Fix #1931 regression guard: _NotchCircle must not use hardcoded
     // MinglitColors.surface in dark mode (causes bright circles on dark page).
     testWidgets(


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 문제

ticket_qr_screen 진입 시 uidump에 AppBar + 72×72 View 1개만 노출됨. BoardingPassCard 전체 콘텐츠(브랜드·이벤트 정보·QR·stub), 입장 안내, 캡처 방지 안내가 accessibility tree에 등장하지 않아 TalkBack 등 스크린리더가 화면 내용을 인식 불가.

## 수정 내용

| 위젯 | 변경 |
|------|------|
| `_HeaderStrip` | `Semantics(label: 'Minglit 보딩패스 입장권', excludeSemantics: true)` 래핑 |
| `_EventInfoSection` | 날짜/장소/이벤트명 합성 semantic label 제공 |
| `_QRStubSection` ticket row | 티켓번호+상태 semantic label 병합 (장식적 TICKET NO./STATUS 라벨 제외) |
| `BoardingPassStatus` | `semanticLabel` getter 추가 (한글 상태: 입장 가능/예약 확정/사용 완료) |
| `ticket_qr_screen` | 입장 안내 / 캡처 방지 안내 Text에 명시적 Semantics 추가 |

기존 QR 코드 Semantics (`label: '이벤트 입장 QR 코드'`)는 이미 올바르게 구현됨 — 변경 없음.

## 회귀 방지 테스트

- `_HeaderStrip` semantic label 검증
- `_EventInfoSection` semantic label 검증 (날짜/장소/이벤트명 포함 확인)
- 티켓번호+상태 행 semantic label 검증
- `BoardingPassStatus.semanticLabel` 단위 테스트 3개 (boarding/confirmed/used)

Closes #2374