### PR TITLE
docs(mds): party_list_page Global Behavior info 아이콘 탭 동작 수정

### DIFF
--- a/apps/mds/docs/public/specs/party_list_page/index.html
+++ b/apps/mds/docs/public/specs/party_list_page/index.html
@@ -1575,7 +1575,7 @@ body.dark-mode .viewport {
         </tr>
         <tr>
           <td>AppBar info 아이콘 탭</td>
-          <td>체크인 화면으로 이동. 같은 위치는 하단 탭의 체크인과 동일 도착지지만 별도의 스택으로 열림.</td>
+          <td>도움말 bottom sheet 노출 (<code>showMinglitHelpSheet</code> 호출 — State 5). 체크인 화면으로 이동하지 않음 (v1 구동작 → v2에서 도움말 패턴으로 대체).</td>
         </tr>
         <tr>
           <td>다음 이벤트 row 탭</td>


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 문제

party_list_page.html Global Behavior 인터랙션 표의 AppBar info 아이콘 탭 설명이 구 동작("체크인 화면으로 이동")으로 남아 있어 spec 내부가 self-contradictory 상태.

- Layout tree (line 696): `IconButton(info_outline) → showMinglitHelpSheet(...)`
- AppBar sub-anatomy (line 882): `탭 시 도움말 bottom sheet 진입 (State 5)`
- State 5: Help bottom sheet
- **Global Behavior 표 (line 1577)**: ~~체크인 화면으로 이동~~ ← 여기만 구 동작

## 수정

Global Behavior 인터랙션 표를 `showMinglitHelpSheet` 호출로 수정. spec 내부 일관성 복원.

**디자인 시스템 spec 인용**:
- `apps/mds/docs/public/specs/party_list_page/index.html` line 1577 (Global Behavior 표)

Closes #2268