### PR TITLE
docs(mds): event_detail_page _InfoTile subtitle 코드-spec 동기화

### DIFF
--- a/apps/mds/docs/public/specs/event_detail_page/index.html
+++ b/apps/mds/docs/public/specs/event_detail_page/index.html
@@ -740,7 +740,7 @@
       ├─ <em>InfoTile #1 — 날짜·시간</em>                       ← ㉢
       │  └─ <b>_InfoTile</b>(icon: calendar_today_outlined,
       │                     title: 'M월 d일 (E) HH:mm',
-      │                     subtitle: '<code>{durationHours}</code>시간')
+      │                     subtitle: '<code>{durationHours}</code>시간 진행')
       ├─ Gap: <i>spacing-small (8)</i>
       │
       ├─ <em>InfoTile #2 — 장소</em>                            ← ㉣
@@ -1318,7 +1318,7 @@
                 <div class="detail-info-tile__icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/></svg></div>
                 <div class="detail-info-tile__text">
                   <div class="detail-info-tile__title">4월 30일 (화) 19:30</div>
-                  <div class="detail-info-tile__sub">3시간</div>
+                  <div class="detail-info-tile__sub">3시간 진행</div>
                 </div>
               </div>
               <div class="detail-info-tile">


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 변경 내용

코드(`event_detail_content.dart:341`)는 `'{durationHours}시간 진행'`으로 배포 중이나 spec은 `'{durationHours}시간'`만 표기하여 불일치.

**디자인 시스템 spec 인용**: `apps/mds/docs/public/specs/event_detail_page/index.html` line 743 (anatomy) + line 1321 (mock)

| 위치 | 변경 |
|------|------|
| line 743 (anatomy) | `{durationHours}시간` → `{durationHours}시간 진행` |
| line 1321 (mock) | `3시간` → `3시간 진행` |

코드 변경 없음. spec-only sync.

Closes #2376