### PR TITLE
docs(mds): QR 버튼 라벨 phase-dependent 정합

### DIFF
--- a/apps/mds/docs/public/specs/event_ongoing_banner/index.html
+++ b/apps/mds/docs/public/specs/event_ongoing_banner/index.html
@@ -471,7 +471,7 @@ body.dark-mode .viewport.ob-viewport { background: var(--color-dark-background);
             · <code>Thumb</code> 56×56 · <code>TitleColumn</code> (title · location · datetime)<br>
             · <code>ActionsStack</code> (vertical · gap 8)<br>
             ·   ├ <code>OutlineActionButton</code> ("길찾기" · primary 35% border · 외부 지도 앱 호출)<br>
-            ·   └ <code>FooterActionButton</code> (primary fill · "입장 QR 보기" + qr_code icon · 미리보기 sheet 호출)
+            ·   └ <code>FooterActionButton</code> (primary fill · "입장 QR 미리 보기" + qr_code icon · CheckInPreviewSheet 호출) — waiting phase. checkInReady phase에서는 "입장 QR 보기" + pulse + CheckInSheet.
           </td>
         </tr>
         <tr>

--- a/apps/mds/docs/public/specs/my_tickets_page/index.html
+++ b/apps/mds/docs/public/specs/my_tickets_page/index.html
@@ -488,7 +488,7 @@ body.dark-mode .ob-card { background: var(--color-dark-surface); }
                     </div>
                   </div>
                   <button class="ob-card__action ob-card__action--outline" style="margin-bottom: 8px;">길찾기</button>
-                  <button class="ob-card__action">입장 QR 보기</button>
+                  <button class="ob-card__action">입장 QR 미리 보기</button><!-- waiting phase: CheckInPreviewSheet 호출 (checkInReady phase에서는 "입장 QR 보기" + CheckInSheet) -->
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 변경 내용

waiting phase 컨텍스트에서 '입장 QR 보기' → '입장 QR 미리 보기'로 수정. 코드는 이미 phase-dependent로 동작 중이며 spec만 outdated.

**디자인 시스템 spec 인용**:
- `event_ongoing_banner/index.html` line 1165-1166 — phase 표 (source of truth, 변경 없음)

| 파일 | 위치 | 변경 |
|------|------|------|
| `my_tickets_page/index.html` | line 491 | waiting banner mockup: `입장 QR 보기` → `입장 QR 미리 보기` |
| `event_ongoing_banner/index.html` | line 474 | waiting phase 컴포넌트 설명 라벨 정정 |

Closes #2375