### PR TITLE
chore(reports): sync 12 audit-uiux reports for 2026-05-10 batch

### DIFF
--- a/docs/reports/uiux/2026-05-10-issue2402-review-verification-screen-spec-missing.md
+++ b/docs/reports/uiux/2026-05-10-issue2402-review-verification-screen-spec-missing.md
@@ -1,0 +1,36 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2402
+captured_at: 2026-05-10
+issue_number: 2402
+state: open
+labels: []
+author: Mark-Yun
+title: "[audit-uiux/차이] review_verification_screen — Flutter 구현 + 라우트 등록되어 있는데 mds spec 누락"
+---
+
+# [audit-uiux/차이] review_verification_screen — Flutter 구현 + 라우트 등록되어 있는데 mds spec 누락
+
+> Issue #2402 · open · created 2026-05-10 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2402
+
+## Body
+
+Scheduler: needs-uiux-claude-1
+
+## 발견 위치
+- Flutter widget: \`apps/app_partner/lib/src/features/verification/review/review_verification_screen.dart\`
+- Route 등록: \`apps/app_partner/lib/src/routing/app_routes.dart:204\` (\`VerificationReviewRoute\`, path \`/more/verifications/review\`, Fix #2142)
+- 누락: \`apps/mds/docs/public/specs/review_verification_screen/\` (디렉토리 없음)
+
+## 현재 / 권장
+- 현재: \`ReviewVerificationScreen\` 위젯이 완전 구현되어 있고(\`getMyManagedPartners\` → \`getPendingRequests\` → \`reviewRequest\` 흐름), \`/more/verifications/review\` 경로로 라우팅 가능. 그러나 mds 단일 진실 디렉토리에 spec이 없다.
+- 권장: 다른 \`*_screen\`/\`*_page\` 화면들과 동일하게 \`apps/mds/docs/public/specs/review_verification_screen/index.html\` (v1.4 template) + \`index.md\` + state PNG 세트를 갖춰야 한다. 화면이 mds 카탈로그(\`flow-data.ts\` / \`index\` 페이지)에서도 보이도록 \`route-pages.json\`에도 등록 필요.
+
+## 영향
+- 인증 심사 흐름(\`VerificationManagePage\` → \`CreateVerificationPage\` → \`ReviewVerificationScreen\`)의 마지막 단계가 mds 카탈로그에 누락 → audit / spec walk / 디자인 리뷰에서 chunk가 빠진다.
+- Fix #2142가 라우트 등록만 복구했고 spec 동기화가 후속으로 따라오지 못한 케이스.
+
+## reference
+- 라우트 등록 위치: \`apps/app_partner/lib/src/routing/app_routes.dart:201-205\` (\`VerificationManageRoute\` / \`CreateVerificationRoute\` / \`VerificationReviewRoute\` 3종 형제 라우트 — 앞 2개는 이미 spec 보유)
+- 형제 spec 참고: \`apps/mds/docs/public/specs/verification_manage_page/index.html\`, \`apps/mds/docs/public/specs/create_verification_page/index.html\`
+- 닫힌 이슈 #2142 (라우트 등록 복구)

--- a/docs/reports/uiux/2026-05-10-issue2403-route-pages-json-5-routes-missing.md
+++ b/docs/reports/uiux/2026-05-10-issue2403-route-pages-json-5-routes-missing.md
@@ -1,0 +1,54 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2403
+captured_at: 2026-05-10
+issue_number: 2403
+state: open
+labels: []
+author: Mark-Yun
+title: "[audit-uiux/차이] route-pages.json — 5개 등록 라우트 누락 (user 4 + partner 1)"
+---
+
+# [audit-uiux/차이] route-pages.json — 5개 등록 라우트 누락 (user 4 + partner 1)
+
+> Issue #2403 · open · created 2026-05-10 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2403
+
+## Body
+
+Scheduler: needs-uiux-claude-1
+
+## 발견 위치
+\`apps/mds/docs/src/lib/route-pages.json\`
+
+## 현재 / 권장
+
+\`app_routes.dart\`에 \`@TypedGoRoute\`로 등록된 라우트 중 \`route-pages.json\`에 누락된 항목:
+
+### app_user (4건)
+| Route | Path | Widget | Flutter 위치 | mds spec |
+|-------|------|--------|--------------|----------|
+| \`EventMatchingRoute\` | \`/events/:eventId/matching\` | \`EventMatchingScreen\` | \`apps/app_user/lib/src/features/event/matching/ui/event_matching_screen.dart\` | \`event_matching_screen\` ✅ |
+| \`EventApplicationConfirmationRoute\` | \`/events/:eventId/apply/confirmation\` | \`MinglitConfirmationPage\` (kit 컴포넌트) | \`apps/app_user/lib/src/routing/app_routes.dart:195-225\` | 없음 (composed page) |
+| \`PurchaseHistoryDetailRoute\` | \`/purchase-history/:applicationId\` | \`PurchaseHistoryDetailPage\` | \`apps/app_user/lib/src/features/payment/ui/purchase_history_detail_page.dart\` | \`purchase_history_detail_page\` ✅ |
+| \`EventApplicationReviewRoute\` | \`/purchase-history/:applicationId/review\` | \`EventApplicationReviewPage\` | \`apps/app_user/lib/src/features/payment/ui/event_application_review_page.dart\` | \`event_application_review_page\` ✅ |
+
+### app_partner (1건)
+| Route | Path | Widget | Flutter 위치 | mds spec |
+|-------|------|--------|--------------|----------|
+| \`VerificationReviewRoute\` | \`/more/verifications/review\` | \`ReviewVerificationScreen\` | \`apps/app_partner/lib/src/features/verification/review/review_verification_screen.dart\` | 없음 (issue #2402 별도) |
+
+### 권장
+- 위 5개 라우트를 \`route-pages.json\`의 \`user\` / \`partner\` 섹션에 등록 (\`{"<RouteName>": {"widget": "<WidgetName>", "file": "<path>"}}\` 형식)
+- \`MinglitConfirmationPage\`처럼 kit 컴포넌트로 합성된 라우트는 \`widget: null\` + 라우트 빌더 코드 위치를 \`file\`로 가리키는 방식 협의 필요
+
+## 영향
+- \`route-pages.json\`은 \`flow-data.ts\` / spec generator / spec walk 워커 등이 참조하는 manifest. drift 시:
+  - flow chart에서 빠진 라우트는 시각화되지 않음
+  - per-spec index.md 자동 생성에서 widget→spec back-link 끊김
+  - spec walk 카탈로그가 5개 화면을 빼먹을 가능성
+
+## reference
+- 라우트 정의: \`apps/app_user/lib/src/routing/app_routes.dart\` (line 175, 195, 272, 288)
+- 라우트 정의: \`apps/app_partner/lib/src/routing/app_routes.dart:204\` (\`VerificationReviewRoute\`, Fix #2142)
+- manifest: \`apps/mds/docs/src/lib/route-pages.json\`
+- spec generator 가이드: \`apps/mds/docs/src/lib/flow-data.ts\` 헤더 주석 ("When routes change, update both the Mermaid charts here AND regenerate route-pages.json")

--- a/docs/reports/uiux/2026-05-10-issue2404-event-application-review-page-spec-tbd-vs-implementation.md
+++ b/docs/reports/uiux/2026-05-10-issue2404-event-application-review-page-spec-tbd-vs-implementation.md
@@ -1,0 +1,39 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2404
+captured_at: 2026-05-10
+issue_number: 2404
+state: open
+labels: []
+author: Mark-Yun
+title: "[audit-uiux/차이] event_application_review_page spec — Widget 'TBD' 표기 vs 실제 구현 완료"
+---
+
+# [audit-uiux/차이] event_application_review_page spec — Widget 'TBD' 표기 vs 실제 구현 완료
+
+> Issue #2404 · open · created 2026-05-10 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2404
+
+## Body
+
+Scheduler: needs-uiux-claude-1
+
+## 발견 위치
+- spec: \`apps/mds/docs/public/specs/event_application_review_page/index.html\` (Header 'Route / Surface' row + 'Widget class' table cell)
+- 실제 위젯: \`apps/app_user/lib/src/features/payment/ui/event_application_review_page.dart\`
+- 라우트: \`apps/app_user/lib/src/routing/app_routes.dart:288-297\` (\`EventApplicationReviewRoute\`, path \`/purchase-history/:applicationId/review\`)
+
+## 현재 / 권장
+- 현재 (spec): 두 군데에서 widget을 'TBD'로 표시.
+  - \`<tr><th>Route / Surface</th><td><code>EventApplicationReviewRoute</code> · widget: <code>EventApplicationReviewPage</code> <em>(TBD)</em></td></tr>\`
+  - \`<tr><th>Widget class</th><td><code>EventApplicationReviewPage</code> · <code>TBD</code></td></tr>\`
+- 현재 (코드): \`EventApplicationReviewPage\` 위젯이 실제로 존재하고 라우트도 등록되어 있다 (\`final String applicationId\` 받아 build).
+- 권장: spec의 'TBD' 라벨을 제거하고 실제 구현 위치(\`apps/app_user/lib/src/features/payment/ui/event_application_review_page.dart\`)를 'Widget class' / 'Route / Surface' row에 명시. 추가로 spec이 언급하는 \`MinglitTimeline\` / \`MinglitTimelineStep\` 구현 상태도 재확인 필요(아직 mds_core에 없으면 별도 follow-up).
+
+## 영향
+- "TBD"라고 표시된 spec은 spec walk / audit / 디자인 리뷰에서 "구현 대기 중"으로 오해되어 실제 구현물 검증이 누락된다.
+- \`MinglitTimeline\` / \`MinglitTimelineStep\` 컴포넌트 의존이 spec에 명시되어 있지만 mds_core 추가 여부와 실제 위젯 사용 여부가 spec/코드 어느 쪽에서도 확정되지 않은 상태.
+
+## reference
+- spec: \`apps/mds/docs/public/specs/event_application_review_page/index.html\`
+- 코드: \`apps/app_user/lib/src/features/payment/ui/event_application_review_page.dart\`
+- 라우트: \`apps/app_user/lib/src/routing/app_routes.dart:288\`

--- a/docs/reports/uiux/2026-05-10-issue2405-purchase-history-page-spec-internal-conflict-inline-actions.md
+++ b/docs/reports/uiux/2026-05-10-issue2405-purchase-history-page-spec-internal-conflict-inline-actions.md
@@ -1,0 +1,77 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2405
+captured_at: 2026-05-10
+issue_number: 2405
+state: open
+labels: []
+author: Mark-Yun
+title: "[audit-uiux/개선] purchase_history_page spec 내부 충돌 — verbal '인라인 액션 없음' vs layout tree '영수증/문의하기/예매 취소' 버튼"
+---
+
+# [audit-uiux/개선] purchase_history_page spec 내부 충돌 — verbal '인라인 액션 없음' vs layout tree '영수증/문의하기/예매 취소' 버튼
+
+> Issue #2405 · open · created 2026-05-10 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2405
+
+## Body
+
+Scheduler: needs-uiux-claude-1
+
+## 발견 위치
+
+`apps/mds/docs/public/specs/purchase_history_page/index.html` 내부 self-contradictory.
+
+## 내부 충돌 요약
+
+같은 spec 안에서 v1.1 "책임 분리" intent와 layout tree / Fix #2076 history가 어긋나 있다.
+
+### A. v1.1 책임 분리 intent (verbal description)
+
+**line 348 (Versions table — 2026-05-05 v1.1)**
+> v1.1 책임 분리 정리 (PR #2094 후속). 카드의 **인라인 액션(영수증 / 문의하기 / 예매 취소) + 환불 confirm 다이얼로그 state를 상세 페이지로 위임**. ... 카드는 header / info / divider / pay-row **4 region**.
+
+**line 387-388 (Blueprint & tree intro)**
+> 카드는 모두 동일 높이 — **인라인 액션 없이 InkWell 전체가 탭되어 상세 페이지로 push**.
+
+→ 카드는 header / info / divider / pay-row 4 region, 인라인 액션 없음.
+
+### B. Layout tree / blueprint 실제 묘사
+
+**line 402 (Blueprint label)**
+> header(date · 상세 보기) / info(thumb · badge+title+meta) / divider / pay-row
+
+**line 432-441 (Layout tree)**
+\`\`\`
+PurchaseHistoryCard
+  ├─ 1. Header Row: paidAt ↔ StatusBadge
+  ├─ 2. Info Row: thumb + Column(title · date · location)
+  ├─ Divider
+  ├─ 3. Pay Row: ticket name ↔ amount
+  └─ 4. Actions Row (IntrinsicHeight + Row stretch)
+        ├─ TextButton "영수증" (flex 1)  // Fix #2076
+        ├─ TextButton "문의하기" (flex 1)
+        └─ if canCancel → ElevatedButton "예매 취소" (flex 2)
+\`\`\`
+
+**line 354-355 (Versions table — 2026-05-05)**
+> Fix #2076 — 무료 티켓 영수증 버튼 동작 변경. ... **항상 "영수증" 버튼 노출**
+
+→ Layout tree는 5 region이고 Actions Row가 명시. Fix #2076는 영수증 버튼이 살아있다는 전제.
+
+### C. 코드 현재 상태
+
+`apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart:155-237` — 영수증 / 문의하기 / 예매 취소 TextButton/ElevatedButton 3개 인라인 노출. 코드는 B를 따른다.
+
+## 현재 / 권장
+
+- **현재**: spec 내부에서 verbal intent (A)와 layout tree (B)가 모순. 코드는 B 구현. 신규 독자가 spec을 읽을 때 어느 쪽이 진실인지 판단 불가.
+- **권장**: Mark가 둘 중 하나로 정리.
+  - 옵션 1 — **버튼 유지(현행)**: line 348 / 387-388 verbal description을 갱신해 "인라인 액션 (영수증/문의하기/예매 취소) + InkWell 전체 탭 가능 — 카드 5 region"으로 일치시킨다. v1.1 책임 분리 history 항목은 "(부분 적용 — 환불 confirm 다이얼로그만 상세로 위임)"으로 정확히 표시.
+  - 옵션 2 — **v1.1 의도 완수**: 카드에서 Actions Row 제거 → 코드도 인라인 버튼 제거 → swe로 라우팅. layout tree / Fix #2076 항목 갱신.
+
+## reference
+
+- spec: `apps/mds/docs/public/specs/purchase_history_page/index.html` (lines 348, 387-388, 402, 432-441, 354-355)
+- 코드: `apps/app_user/lib/src/features/payment/ui/purchase_history_card.dart:31-237`
+- spec walk drift 발견: `docs/qa/walks/20260510-100059-user-sonnet/purchase_history_page/spec_diff.md` (PR #2372)
+- 관련 Fix: #2076 (영수증 버튼 항상 노출), #2094 (책임 분리 PR), #1234 (예매 취소 버튼 flex), #1820 (IntrinsicHeight 통일)

--- a/docs/reports/uiux/2026-05-10-issue2407-components-ts-visualspec-field-cleanup.md
+++ b/docs/reports/uiux/2026-05-10-issue2407-components-ts-visualspec-field-cleanup.md
@@ -1,0 +1,58 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2407
+captured_at: 2026-05-10
+issue_number: 2407
+state: open
+labels: [enhancement]
+author: Mark-Yun
+title: "[audit-uiux/개선] components.ts visualSpec 필드 — MinglitButton 1개만 사용 → legacy HTML spec 정리 필요"
+---
+
+# [audit-uiux/개선] components.ts visualSpec 필드 — MinglitButton 1개만 사용 → legacy HTML spec 정리 필요
+
+> Issue #2407 · open · created 2026-05-10 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2407
+
+## Body
+
+Scheduler: needs-uiux-claude-1
+
+## 발견 위치
+
+- `apps/mds/docs/src/lib/components.ts:213` — `MinglitButton` 컴포넌트만 `visualSpec: '/specs/components/minglit_button.html'` 필드를 갖고 있다
+- `apps/mds/docs/public/specs/components/minglit_button.html` (354줄) — `public/specs/components/` 디렉토리에 존재하는 **유일한** 정적 HTML 컴포넌트 spec page
+- `apps/mds/docs/src/components/specs/MinglitButtonSpec.tsx` (302줄) — 동일 컴포넌트의 React inline spec이 이미 별도로 존재
+
+## 현재 / 권장
+
+**현재 — 단일 컴포넌트만 이중 spec 보유**
+
+- `MDS_COMPONENTS` 매니페스트의 30개 컴포넌트 중 단 1개(`MinglitButton`)만 `visualSpec` 필드 사용
+- 나머지 29개 컴포넌트는 모두 React inline spec(`src/components/specs/<Name>Spec.tsx`)만 보유 — 일관된 패턴
+- `MinglitButton`은 정적 HTML spec(354줄) + React inline spec(302줄)을 **동시에** 보유 → 단일 진실(SSOT) 원칙 위반
+- 두 spec의 커버리지를 비교하면 거의 동일 (4 variants × 3 sizes × loading/disabled/icon 케이스 모두 양쪽에 중복 기재)
+- `components.ts:107-112`의 `visualSpec` typedef 주석: *"Optional — not all components need a visual spec yet"* — 1년 가까이 사용자 1명만 유지된 "yet"
+- `src/components/specs/README.md` 및 `components.ts` 매니페스트 헤더 주석에 안내된 컴포넌트 추가 워크플로우는 `.tsx` 인라인 스펙만 언급 — HTML spec 작성 단계는 없음 → React 인라인 스펙이 사실상 표준
+
+**권장 — 옵션 A 강하게 추천**
+
+| 옵션 | 작업 | 권장도 |
+|------|------|--------|
+| **A. legacy HTML 제거** | `public/specs/components/minglit_button.html` 삭제 + `components.ts:213` `visualSpec` 라인 제거 + `ComponentSpec` typedef에서 `visualSpec` 필드 제거 (사용처가 없어지므로) + 누락된 시각 케이스가 있다면 `MinglitButtonSpec.tsx`에 보강 | ★★★ |
+| B. 모든 컴포넌트 HTML spec 확장 | 29개 컴포넌트 각각 HTML spec 신규 작성 | ★ (React inline spec과 중복, 유지비 큼) |
+
+옵션 A의 경우, 작업 분량 추정:
+- 삭제: HTML 1개 파일 + `visualSpec` 라인 1줄 + typedef 5줄
+- React inline spec(`MinglitButtonSpec.tsx`)에 HTML 대비 누락된 시각 케이스가 있는지 1회 확인 (우리가 본 범위에선 거의 동일)
+
+## reference
+
+- `apps/mds/docs/src/lib/components.ts:107-112` — `visualSpec` typedef ("Optional ... yet")
+- `apps/mds/docs/src/lib/components.ts:151-220` — `MDS_COMPONENTS[0]` MinglitButton 항목 (유일한 `visualSpec` 사용처)
+- `apps/mds/docs/src/components/specs/README.md` — 컴포넌트 추가 워크플로우 (HTML 단계 없음)
+- 일관성 baseline: 나머지 29개 컴포넌트는 `.tsx` inline spec only
+
+## 카테고리
+
+[audit-uiux/개선] — 디자인 시스템 spec **자체**의 인터널 컨플릭/일관성. spec 변경(파일 삭제)이 필요하므로 Mark 영역.
+

--- a/docs/reports/uiux/2026-05-10-issue2408-search-page-error-state-text-style-missing.md
+++ b/docs/reports/uiux/2026-05-10-issue2408-search-page-error-state-text-style-missing.md
@@ -1,0 +1,67 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2408
+captured_at: 2026-05-10
+issue_number: 2408
+state: open
+labels: [bug]
+author: Mark-Yun
+title: "[audit-uiux/차이] search_page Error state — Text 위젯 명시 style 없음 (spec: bodyMedium · onSurfaceVariant · padding-xlarge)"
+---
+
+# [audit-uiux/차이] search_page Error state — Text 위젯 명시 style 없음 (spec: bodyMedium · onSurfaceVariant · padding-xlarge)
+
+> Issue #2408 · open · created 2026-05-10 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2408
+
+## Body
+
+Scheduler: needs-uiux-claude-1
+
+## 발견 위치
+
+`apps/app_user/lib/src/features/search/search_page.dart:203-205`
+
+```dart
+error: (e, _) => const Center(
+  child: Text('검색 중 오류가 발생했습니다'),
+),
+```
+
+## 현재 / 권장
+
+- **현재**: 명시적 `style` 없는 `Text` + `Center` (Padding 없음)
+  - 색상은 가까운 `DefaultTextStyle` / Theme의 `bodyMedium`을 따라가지만, 통상 `onSurface`(본문 진한 색)에 가깝다.
+  - 좌우 여백이 없어 긴 메시지가 viewport edge에 닿을 가능성.
+- **권장**: spec의 `.search-error` 정의와 동일하게 명시
+  ```dart
+  error: (e, _) => Center(
+    child: Padding(
+      padding: const EdgeInsets.all(MinglitSpacing.xlarge),
+      child: Text(
+        '검색 중 오류가 발생했습니다',
+        textAlign: TextAlign.center,
+        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+      ),
+    ),
+  ),
+  ```
+
+## reference
+
+- spec: `apps/mds/docs/public/specs/search_page/index.html#states` State 6 (Error)
+  - spec CSS `.search-error` (line 206-213):
+    ```css
+    padding: var(--spacing-xlarge);
+    font-size: 16px;
+    color: var(--color-text-secondary);
+    text-align: center;
+    ```
+  - spec mini-table 토큰 row (line 812):
+    > 메시지는 기본 Text 스타일 — bodyMedium · onSurfaceVariant
+- 비교: 같은 spec의 Empty/NoResult state는 코드에서 명시적으로 `Theme.textTheme.bodyMedium?.copyWith(color: onSurfaceVariant)` + `Padding(EdgeInsets.all(MinglitSpacing.xlarge))`를 사용 중 (line 84, 167-176). Error state만 누락.
+
+## 영향도
+
+P3 — 사용자가 자주 보는 화면은 아니지만 (네트워크 오류 시에만 노출), 같은 화면의 다른 빈 상태와 visual treatment가 어긋난다. 디자인 시스템 일관성 / 토큰 사용 관점의 작은 drift.

--- a/docs/reports/uiux/2026-05-10-issue2409-event-detail-section3-participation-caption-gauge-meaning-conflict.md
+++ b/docs/reports/uiux/2026-05-10-issue2409-event-detail-section3-participation-caption-gauge-meaning-conflict.md
@@ -1,0 +1,100 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2409
+captured_at: 2026-05-10
+issue_number: 2409
+state: open
+labels: []
+author: Mark-Yun
+title: "[audit-uiux/개선] event_detail §3 참가 현황 — \"N명 참여\" caption 과 gauge \"현재/정원\" 의미 충돌 (참여 인원 vs 티켓 판매)"
+---
+
+# [audit-uiux/개선] event_detail §3 참가 현황 — "N명 참여" caption 과 gauge "현재/정원" 의미 충돌 (참여 인원 vs 티켓 판매)
+
+> Issue #2409 · open · created 2026-05-10 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2409
+
+## Body
+
+Scheduler: needs-uiux-claude-1
+
+## 발견 위치
+
+- code: `apps/app_user/lib/src/features/event/detail/event_entry_conditions_section.dart:36-95`
+- spec: `apps/mds/docs/public/specs/event_detail_page/index.md` §3 참가 현황 sub-anatomy (lines 104-118)
+- visual: `apps/mds/docs/public/specs/event_detail_page/state_4.png`, `blueprint_5.png`
+
+## 문제 요약
+
+§3 참가 현황의 entry group card에는 같은 카드 row에 **두 카운트가 라벨 차별화 없이** 함께 노출된다:
+
+- 좌측 caption **"N명 참여"** — `participantCount = counts[group.id]` (entryGroupParticipantCountsProvider) → **실제 그룹 합류한 사용자 수**
+- 우측 gauge label **"현재/정원"** — `soldCount/totalQuantity` (matchingTickets fold) → **매칭 티켓의 판매량/capacity**
+
+state_4 mockup 재현:
+- 일반 참여 (남성) — `8명 참여` + `13/20`
+- 일반 참여 (여성) — `10명 참여` + `16/20`
+
+두 숫자는 **서로 다른 개념** (entry group join 카운트 vs ticket sold 카운트) 이지만, 동일 카드 안에 라벨 차별화 없이 배치되어 사용자는 "왜 8과 13이 다른가?" 를 즉시 의심한다. spec sub-anatomy(lines 110-118)도 의미 차이를 명시하지 않아 디자이너 / 구현자 / 사용자 셋 다 혼선이 발생한다.
+
+## 현재 / 권장
+
+### 현재 (drift)
+
+```dart
+// event_entry_conditions_section.dart:77 — caption (참여 인원)
+Text('$participantCount명 참여', ...)
+// event_entry_conditions_section.dart:89-92 — gauge (티켓 판매량)
+MinglitParticipantGauge(current: soldCount, max: totalQuantity)
+```
+
+spec sub-anatomy 본문 (lines 110-118):
+- `· _"N명 참여"_ (bodySmall · text-secondary)`
+- `· _"현재/정원"_ 라벨 (10 · w600 · text-secondary)`
+
+→ 두 숫자가 같은 카드에 있지만 라벨에서 의미 차이가 드러나지 않음. blueprint_5도 "name + count + gauge" 로 묶어 표기 — count 와 gauge 가 **같은 그룹의 같은 의미** 라는 인상을 준다.
+
+### 권장 (3가지 옵션 — Mark 판단)
+
+**Option A — 라벨 차별화 (변경 가장 작음)**
+- caption: `"참여 8명"` 유지
+- gauge label: `"티켓 13/20"` 으로 prefix 추가 → 두 숫자 의미를 명시
+
+**Option B — 단일 카운트로 통합 (정보 노이즈 ↓)** ⭐ 권장
+- caption "N명 참여" 제거, gauge label 만 노출 (`"신청 13/20"` 또는 `"참여 13/20"`)
+- 일반 사용자에게 entry group "join" 과 ticket "sold" 의 차이는 의미 없음 — 정보를 줄이는 것이 명료성 ↑.
+- 토스 / Airbnb / 당근 등 frontier 패턴은 모두 **단일 카운트** 노출.
+
+**Option C — 의미 차를 명시하는 부연 설명**
+- 참여 캡션 옆 info icon → 탭 시 "참여 = 그룹 합류, 신청 = 티켓 결제 완료" tooltip
+- 정보를 모두 보여주되 사용자가 필요 시에만 확인 — 가장 무거움.
+
+추천: **Option B**. 단일 진실(spec) 단순화 + 코드 line 76-81 caption 제거 + gauge label semantic 정리. spec §3 sub-anatomy 갱신이 필요 (Mark 영역).
+
+## reference
+
+- code: `apps/app_user/lib/src/features/event/detail/event_entry_conditions_section.dart`
+  - line 53: `participantCount = counts[group.id] ?? 0` (entry group join count)
+  - line 44-51: `soldCount / totalQuantity` fold (ticket sold count)
+  - line 76-81: caption render
+  - line 89-92: gauge render
+- spec: `apps/mds/docs/public/specs/event_detail_page/index.md`
+  - line 110-118: §3 sub-anatomy 본문 + 토큰 row
+- blueprint: `apps/mds/docs/public/specs/event_detail_page/blueprint_5.png` ("name + count + gauge" 묶음)
+- state mockup: `apps/mds/docs/public/specs/event_detail_page/state_4.png` (남성 8 vs 13/20, 여성 10 vs 16/20)
+
+### Frontier 비교
+
+| 앱 | 패턴 |
+|---|---|
+| 토스 이벤트 | 단일 "신청자 N명" |
+| Airbnb 숙소 | 단일 "남은 객실 N개" |
+| 당근마켓 모임 | 단일 "참여자 N/M명" |
+
+→ 모두 **단일 카운트** 노출. 듀얼 카운트는 frontier 패턴에서 발견되지 않음.
+
+## 노트
+
+- 이 발견은 단순 typography / token drift 가 아닌 **데이터 모델 노출 의도** 이슈. spec 과 코드 둘 다 "두 카운트 노출" 을 의도한 것으로 보이지만, frontier 사례와 비교하면 정보 줄임이 더 자연스럽다.
+- spec 변경 (sub-anatomy 정리) + 코드 변경 (caption 제거 또는 라벨 prefix) 양쪽 다 검토 필요.
+- 라우팅 의견: **Option 결정 → Mark / pm**, 결정 후 spec 정리 → Mark, 코드 픽스 → swe.
+

--- a/docs/reports/uiux/2026-05-10-issue2411-event-matching-results-screen-spec-tbd.md
+++ b/docs/reports/uiux/2026-05-10-issue2411-event-matching-results-screen-spec-tbd.md
@@ -1,0 +1,91 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2411
+captured_at: 2026-05-10
+issue_number: 2411
+state: open
+labels: []
+author: Mark-Yun
+title: "[audit-uiux/차이] event_matching_results_screen spec 'TBD' — MatchResultsContent 이미 완전 구현 + 출시 중 (route 가정도 어긋남)"
+---
+
+# [audit-uiux/차이] event_matching_results_screen spec 'TBD' — MatchResultsContent 이미 완전 구현 + 출시 중 (route 가정도 어긋남)
+
+> Issue #2411 · open · created 2026-05-10 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2411
+
+## Body
+
+Scheduler: needs-uiux-claude-1
+
+## 발견 위치
+
+- spec: `apps/mds/docs/public/specs/event_matching_results_screen/index.md`
+  - Status: `📝 TBD — 별도 디자인 라운드 예정` (line 7)
+  - Implementation source 표 4행 모두 `— (TBD)` (lines 55–59)
+  - Route 가정: `EventMatchingResultsRoute · /event/:id/matching/results (예정 · 확정 전)` (line 11)
+- code (이미 production 운영 중):
+  - `apps/app_user/lib/src/common/widgets/match_results_content.dart` (218 lines, `MatchResultsContent`)
+  - 사용처:
+    - `apps/app_user/lib/src/features/event/admission/event_admission_controller.dart:260` — `eventEndedWithResults` CTA → modal sheet 콘텐츠
+    - `apps/app_user/lib/src/features/home/widgets/event_now_phases/results_content.dart` — `EventNowBottomSheet` phase 6 콘텐츠 (re-export)
+
+## 현재 / 권장
+
+### 현재 (drift)
+
+spec은 `TBD` placeholder + 별도 route 가정인데, **코드는 이미 완전 구현 + 출시 중**. 게다가 구현 패턴이 spec 가정(`EventMatchingResultsRoute`)과 **다름** — 별도 route가 아니라 두 곳에서 쓰이는 **shared bottom sheet content widget**.
+
+구현된 anatomy:
+- DragHandle (width 40 · height 4 · radius 2 · textSecondary muted)
+- Hero badge: 64×64 primary 원형 + `Icons.favorite` 36px (background color)
+- Title `매칭 결과` titleLarge bold (gap medium)
+- Subtitle: event.title bodyMedium textSecondary center (gap xlarge)
+- Match list:
+  - Header: `${matches.length}명과 매칭되었어요!` titleSmall primary w600 (gap medium)
+  - Card per match (`_MatchResultCard`):
+    - padding `MinglitSpacing.medium`, radius `MinglitRadius.card`, surface bg, 1px primary muted border
+    - leading: `MinglitAvatarImage(radius: 24, url: partnerProfileImage)` — primary highlight bg + primary separator fallbackIconColor
+    - title: `match.partnerName` bodyLarge bold (fallback `'알 수 없음'`)
+    - subtitle: masked phone (`_maskPhone` Fix #1925 — `010-****-5678`) bodySmall textSecondary
+    - trailing: `Icons.favorite` primary small
+    - 카드 사이 gap small
+- Empty state (mutual 0건):
+  - `Icons.sentiment_neutral` 48px textSecondary strong
+  - `'이번엔 아쉽지만, 다음 기회에!'` bodyMedium textSecondary center
+- Loading: `MinglitCircularProgressIndicator` height 120 center
+- Error fallback → empty state 와 동일
+
+### 권장
+
+spec 갱신 (Mark 영역 — 본 이슈는 진단만):
+
+1. **Route 가정 정정** — `EventMatchingResultsRoute · /event/:id/matching/results (예정)` → 실제 패턴 명시:
+   - "단독 route 없음. `MatchResultsContent` shared widget 으로 ① `EventNowBottomSheet phase 6` (home) ② `event_admission_controller eventEndedWithResults CTA` modal sheet 두 surface 에서 렌더링."
+2. **Status: TBD → 'v1.0 (live)'** 또는 v1.0 — 코드가 이미 출시되어 단일 진실(spec)이 코드보다 stale.
+3. **Implementation source 표** 4행 채움:
+   - Widget class: `MatchResultsContent` (+ 내부 `_MatchResultCard` / `_DragHandle` private)
+   - File path: `apps/app_user/lib/src/common/widgets/match_results_content.dart`
+   - Provider: `myMatchesProvider(event.id)`
+   - Route: — (단독 라우트 없음. 두 surface 의 modal sheet content)
+4. **Layout / States 섹션 추가** — 위 anatomy 대로 채움 + 4 state (Default · Empty · Loading · Error) 명시.
+5. **Hierarchy 갱신**: parent 가 `MyTicketsPage 또는 EventMatchingScreen phase 전환` (line 12) → 실제는 `EventNowBottomSheet (home) + event_admission_controller (event/admission)`. 본 widget 이 reuse 대상이라는 점을 더 명확히.
+6. **Reference · Related screens** 에 `EventOngoingBanner` (lifecycle hub · phase 5 → 6 전환 시점) 외에 `EventNowBottomSheet` / `eventEndedWithResults CTA` 명시.
+
+코드 회귀 (구현 제거)는 권장하지 않음 — Fix #1925 (PII 마스킹), Fix #1934 (`results_content.dart` → `common/widgets/` 이관), Fix #1936 (`MinglitAvatarImage`) 누적된 정착물.
+
+## reference
+
+- spec (drift): `apps/mds/docs/public/specs/event_matching_results_screen/index.md` (lines 7, 11–14, 55–59, 64–67)
+- 인접 patterns:
+  - `MatchResultsContent` 재사용 패턴 export: `apps/app_user/lib/src/features/home/widgets/event_now_phases/results_content.dart:1-8` (`Fix #1934: widget moved to common/widgets/...`)
+  - PII 마스킹: `_maskPhone` (Fix #1925, line 184–202)
+  - 아바타: `MinglitAvatarImage` (Fix #1936, line 137–147) — `apps/mds/docs/public/specs/more_page/index.md` 의 canonical 패턴 참조
+- 유사한 TBD-vs-implemented 패턴 이슈:
+  - #2402 — `review_verification_screen` Flutter 구현 + 라우트 등록 vs spec 누락
+  - #2404 — `event_application_review_page` spec `'TBD'` vs 실제 구현 완료
+
+## 카테고리
+
+`[audit-uiux/차이]` — 코드 ↔ 단일 진실(spec) drift. spec 이 stale 한 케이스. tpm 이 트리아지로 `needs-uiux` 또는 `needs-tpm` 부여 후 Mark 가 spec 작성 / 갱신 수행.
+
+— needs-uiux-claude-1

--- a/docs/reports/uiux/2026-05-10-issue2412-ticket-selection-sheet-spec-missing.md
+++ b/docs/reports/uiux/2026-05-10-issue2412-ticket-selection-sheet-spec-missing.md
@@ -1,0 +1,98 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2412
+captured_at: 2026-05-10
+issue_number: 2412
+state: open
+labels: []
+author: Mark-Yun
+title: "[audit-uiux/차이] TicketSelectionSheet — 결제 진입 게이트 시트 코드 존재, spec 없음 (PR #2364 인용 spec 부재 root cause)"
+---
+
+# [audit-uiux/차이] TicketSelectionSheet — 결제 진입 게이트 시트 코드 존재, spec 없음 (PR #2364 인용 spec 부재 root cause)
+
+> Issue #2412 · open · created 2026-05-10 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2412
+
+## Body
+
+Scheduler: needs-uiux-claude-1
+
+## 발견 위치
+
+- code: `apps/app_user/lib/src/features/ticket/ui/ticket_selection_sheet.dart`
+- code (위젯): `apps/app_user/lib/src/features/ticket/ui/ticket_selection_widgets.dart`
+- 진입 경로: `apps/app_user/lib/src/logic/event_coordinator.dart`, `apps/app_user/lib/src/features/ticket/logic/ticket_coordinator.dart`
+- spec: **없음**
+- 인접 spec: `apps/mds/docs/public/specs/event_bottom_ticket_bar/index.md` (시트를 띄우는 트리거), `apps/mds/docs/public/specs/event_detail_page/index.md` (시트 진입 화면)
+
+## 현재 / 권장
+
+### 현재 (drift)
+
+`TicketSelectionSheet` 는 **결제 진입의 핵심 시트**:
+
+- 티켓 옵션 리스트 (selected/locked/recommended/ineligible 4-state)
+- 추천 자동 선택 (`TicketRecommendationResult` — 잔액 / 자격 / 가격 기준)
+- 수량 stepper (`buildQuantityStepper` — `−` / `+` IconButton, tooltip "수량 감소" / "수량 증가" — Fix #2358)
+- 잔액 상태 fetch / user verification fetch
+- CTA: 결제 진입
+
+이 시트는 **이벤트 → 결제** 메인 경로의 단일 게이트 — 모든 유료 이벤트 구매가 이 시트를 거친다. 그런데:
+
+1. `apps/mds/docs/public/specs/` 어디에도 `ticket_selection_sheet`(또는 유사) spec 폴더 없음.
+   ```
+   $ ls apps/mds/docs/public/specs/ | grep -i ticket
+   event_bottom_ticket_bar
+   my_tickets_page
+   ticket_create_page
+   ticket_edit_page
+   ticket_qr_screen
+   ```
+2. `apps/mds/docs/src/lib/flow-data.ts` 에 `ticket_selection` 관련 route 없음.
+3. PR #2364 (Fix #2358) 본문은 `event_application_wizard_page.html` 의 "수량 stepper 섹션"을 인용했지만 — `event_application_wizard_page/index.html` 와 `index.md` 모두 `tooltip` / `수량` / `stepper` / `quantity` 매치 0건. 즉 PR 인용이 사실상 부재한 spec 을 가리킴.
+
+### 권장
+
+`apps/mds/docs/public/specs/ticket_selection_sheet/` 신규 spec 작성 (Mark 영역). 최소 다음을 다뤄야 함:
+
+1. **Header / Overview** — 결제 진입 게이트 역할, event_detail_page → event_bottom_ticket_bar → 본 시트 → 결제 흐름 명시.
+2. **Layout / blueprint**
+   - 헤더 (이벤트 타이틀 / 닫기)
+   - 티켓 옵션 리스트 (Card row · 4-state visualization)
+   - 수량 stepper (− / + IconButton 24px · 가운데 숫자 · tooltip 의무)
+   - 가격 합계 row
+   - CTA 버튼 (full-width, primary, "결제하기")
+3. **Sub-anatomy**
+   - 티켓 옵션 카드: border / fill / opacity per state — `MinglitSpacing.medium` padding · `MinglitRadius.input` · selected outline 2px primary · locked opacity 0.5 · `MinglitOpacity.tintFill` selected fill
+   - Quantity stepper: `IconButton(remove, tooltip "수량 감소")` / 숫자 / `IconButton(add, tooltip "수량 증가")` · disabled rule
+   - 추천 배지 / 잠금 사유 텍스트 (`onSurfaceVariant`)
+4. **States**
+   - loading (잔액·유저 fetch 진행)
+   - all-locked (선택 가능 티켓 없음)
+   - selected + valid quantity
+   - selected + over-quantity (재고 한계)
+   - empty (티켓 0개) — 현재 코드 동작 확인 필요
+5. **Global Behavior**
+   - 자동 추천 선택 (`_hasAutoSelected` 가드)
+   - 수량 변경 시 잔액 재검증 트리거
+   - 잠긴 티켓 탭 시 무동작 + 사유 텍스트 인라인 표시
+6. **Reference**
+   - Implementation source 표: `TicketSelectionSheet` / `_TicketSelectionWidgets` / `TicketRecommendationUtil` / `TicketCoordinator` 매핑
+   - 진입 spec: `event_bottom_ticket_bar` · `event_detail_page`
+   - 다음 spec: `payment_*` (있다면)
+
+## reference
+
+- canonical 작성 톤: `apps/mds/docs/public/specs/event_bottom_ticket_bar/index.md` (시트 트리거 spec — 본 시트와 페어로 작성되면 단일 결제 진입 흐름 완성)
+- 트리거 PR: #2364 (Fix #2358) 가 spec 인용했지만 대상 섹션이 spec 에 부재 — root cause 는 시트 spec 자체 부재
+- 관련 refactor 이슈: #1519 (디자인 시스템 위젯 적용), #453 (event ↔ ticket 순환 참조)
+
+## 노트
+
+- 코드는 정상 동작 / 사용자 차단 없음. 다만 결제 메인 경로의 단일 게이트가 spec 없이 운영되는 건 audit / a11y / 디자인 일관성 측면에서 부채.
+- spec 변경은 Mark 영역 — ux-designer 워커는 진단 + 이슈 파일링까지.
+- 본 발견은 `2222 (TBD spec 일괄 — partner 측)` 와 별개의 user-side 시트 누락. 2222 와 묶지 말고 단독으로 처리 권장.
+- 후속 권장: spec 작성 후 #2364 의 "수량 stepper tooltip" 회귀 테스트가 spec 의 `tooltip "수량 감소"` / `tooltip "수량 증가"` 를 명시 인용하도록 PR 본문 보강.
+
+— needs-uiux-claude-1
+

--- a/docs/reports/uiux/2026-05-10-issue2413-notification-list-screen-error-state-inline-override.md
+++ b/docs/reports/uiux/2026-05-10-issue2413-notification-list-screen-error-state-inline-override.md
@@ -1,0 +1,101 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2413
+captured_at: 2026-05-10
+issue_number: 2413
+state: open
+labels: []
+author: Mark-Yun
+title: "[audit-uiux/차이] notification_list_screen Error state — inline override (raw err toString) vs canonical MinglitAsyncValueWidget _DefaultErrorView"
+---
+
+# [audit-uiux/차이] notification_list_screen Error state — inline override (raw err toString) vs canonical MinglitAsyncValueWidget _DefaultErrorView
+
+> Issue #2413 · open · created 2026-05-10 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2413
+
+## Body
+
+Scheduler: needs-uiux-claude-1
+
+## 발견 위치
+
+- code: `shared/packages/minglit_kit/lib/src/features/notification/notification_list_screen.dart:137`
+  ```dart
+  error: (err, stack) => Center(child: Text('에러: $err')),
+  ```
+- spec (acknowledged drift): `apps/mds/docs/public/specs/notification_list_screen/index.md`
+  - line 131: 후속 작업에서 표준 오류 화면(\"오류가 발생했습니다.\" + 다시 시도)으로 통일 권장
+  - line 132: 컴포넌트: `↔ list 전체 → Center + Text('에러: $err') (inline override). Default error UI 미적용.`
+  - line 134: 노트: 원본 오류 메시지가 그대로 노출되므로 민감 정보가 보일 위험이 있음
+
+## 현재 / 권장
+
+### 현재 (drift)
+
+`NotificationListScreen` 은 `MinglitAsyncValueWidget` 의 `error` 콜백을 inline override 해서 raw `err.toString()` 을 그대로 노출:
+
+```dart
+MinglitAsyncValueWidget(
+  value: notificationState,
+  data: (notifications) { ... },
+  error: (err, stack) => Center(child: Text('에러: $err')),  // ← override
+)
+```
+
+결과:
+- 본문 영역 가운데에 `에러: <raw err toString>` 평문 노출 — 아이콘 없음, MDS 토큰 미적용 (bodyMedium default).
+- `err` 가 Supabase / network exception 이면 stack-ish 메시지나 내부 식별자가 보일 수 있음 — 사용자 친화도 낮고 약한 정보 누출 가능성.
+
+### 캐노니컬 패턴 (sibling 참조)
+
+`MinglitAsyncValueWidget` 는 `error` 미지정 시 자동으로 `_DefaultErrorView` 를 그림:
+
+```
+Icon(Icons.error_outline · xlarge · color: error)
+SizedBox(spacing-medium)
+Text('오류가 발생했습니다.', titleMedium · bold)
+// showErrorDetails=false 가 default → raw err 노출 안 됨
+```
+
+같은 kit-shared 알림 패밀리의 sibling **`NotificationSettingsScreen`** 은 이미 default 사용 (override 없음, line 20-22):
+
+```dart
+MinglitAsyncValueWidget(
+  value: settingsAsync,
+  data: (settings) { ... },
+)  // ← error 생략 → _DefaultErrorView 자동 적용
+```
+
+→ 두 kit-shared 알림 화면이 같은 wrapper 를 다르게 쓰고 있음 = 인터널 컨플릭.
+
+### 권장 수정
+
+`error:` 콜백을 제거. spec 의 컴포넌트 row / 노트도 동기화 (별도 spec PR — Mark 영역).
+
+```diff
+ MinglitAsyncValueWidget(
+   value: notificationState,
+   data: (notifications) { ... },
+-  error: (err, stack) => Center(child: Text('에러: $err')),
+ )
+```
+
+부수 효과:
+- Error state 가 자동으로 `_DefaultErrorView` 로 전환 → spec 의 `notification_settings_screen` Error state 와 동일한 시각.
+- raw err 노출 제거 → 운영 환경 UX/보안 안정.
+- 코드 -1줄 (override 삭제만으로 충분).
+
+## reference
+
+- canonical 사례: `shared/packages/minglit_kit/lib/src/features/notification/notification_settings_screen.dart` (line 20-22) — same wrapper, default error 사용.
+- kit wrapper: `shared/packages/mds/core/lib/src/ui/widgets/common/minglit_async_value_widget.dart:38-51` — `error ?? (err, stack) => _DefaultErrorView(...)`.
+- `_DefaultErrorView` 구현: 같은 파일 line 54-101 (showErrorDetails default false → raw err 가려짐).
+- spec: `apps/mds/docs/public/specs/notification_list_screen/index.md` Error state section (line 122-134) — drift 를 명시적으로 인지하고 통일 권장.
+
+## 노트
+
+- 같은 kit-shared 패밀리(`notification_*`) 의 시각/패턴 통일 — design system 일관성 ROI 가 명확.
+- spec 변경 (Error state 컴포넌트 row 갱신) 은 Mark 영역. 본 이슈는 코드 fix (override 제거) + spec 동기화 후속 트리거 두 단계로 해결.
+- `notification_list_screen` 에 별도 추가 발견(Empty state 가 plain `Text` — `MinglitEmptyState` atom 미사용, spec line 106-108) 도 있지만 1 issue = 1 finding 정책에 따라 분리 검토 권장 (별도 이슈로 파일링 가능).
+
+— needs-uiux-claude-1

--- a/docs/reports/uiux/2026-05-10-issue2414-notification-list-screen-empty-state-plain-text.md
+++ b/docs/reports/uiux/2026-05-10-issue2414-notification-list-screen-empty-state-plain-text.md
@@ -1,0 +1,102 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2414
+captured_at: 2026-05-10
+issue_number: 2414
+state: open
+labels: []
+author: Mark-Yun
+title: "[audit-uiux/차이] notification_list_screen Empty state — plain Text vs canonical MinglitEmptyState atom"
+---
+
+# [audit-uiux/차이] notification_list_screen Empty state — plain Text vs canonical MinglitEmptyState atom
+
+> Issue #2414 · open · created 2026-05-10 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2414
+
+## Body
+
+Scheduler: needs-uiux-claude-1
+
+## 발견 위치
+
+- code: `shared/packages/minglit_kit/lib/src/features/notification/notification_list_screen.dart:40-41`
+  ```dart
+  if (notifications.isEmpty) {
+    return const Center(child: Text('알림이 없습니다.'));
+  }
+  ```
+- spec (acknowledged drift): `apps/mds/docs/public/specs/notification_list_screen/index.md`
+  - line 106: 컴포넌트 — `↔ ListView / RefreshIndicator → Center(child: Text('알림이 없습니다.')) 단일 — 전용 EmptyState atom 미사용 (plain Text)`
+  - line 108: 노트 — `다른 화면들의 표준 Empty 비주얼(아이콘 + 안내 + CTA) 대비 매우 빈약한 안내. 후속 작업에서 보강 검토 가치.`
+
+## 현재 / 권장
+
+### 현재 (drift)
+
+`MinglitEmptyState` atom 미사용 — 본문 가운데에 `Text('알림이 없습니다.')` 한 줄만 노출. 아이콘 / 부제 / CTA 모두 없음. MDS 토큰 미적용 (bodyMedium default).
+
+### 캐노니컬 패턴
+
+`MinglitEmptyState` (`shared/packages/mds/core/lib/src/ui/widgets/common/minglit_empty_state.dart`) — 디자인 시스템 표준 빈-상태 atom. `fullPage` variant 가 본 화면의 size 에 적합:
+
+```dart
+const MinglitEmptyState(
+  title: '아직 도착한 알림이 없어요',
+  subtitle: '서비스 알림이 도착하면 여기에서 확인할 수 있어요.',
+  icon: Icons.notifications_none_outlined,
+  // CTA 없음 — push 알림은 외부 트리거 기반이라 in-screen action 없음.
+)
+```
+
+`fullPage` variant 가 그리는 형태:
+- 48px outline-color icon
+- title (titleMedium · bold)
+- subtitle (bodyMedium · onSurfaceVariant)
+- 옵셔널 CTA — 본 화면은 미사용
+
+### 인접 사례 (이미 atom 채택)
+
+같은 디자인 시스템에서 다른 list/grid 화면들은 모두 `MinglitEmptyState` 사용:
+
+| 화면 | 사용 위치 |
+|---|---|
+| `my_tickets_page.dart` | 탭별 fullPage variant |
+| `event_matching_screen.dart` | fullPage |
+| `home_page.dart` | fullPage |
+| `_settlement_list_tab.dart` (partner) | fullPage |
+| `party_entry_group_management_screen.dart` (partner) | fullPage |
+
+→ 알림 list 만 plain Text 라 시각 인터널 컨플릭.
+
+### 권장 수정
+
+```diff
+ if (notifications.isEmpty) {
+-  return const Center(child: Text('알림이 없습니다.'));
++  return const MinglitEmptyState(
++    title: '아직 도착한 알림이 없어요',
++    subtitle: '서비스 알림이 도착하면 여기에서 확인할 수 있어요.',
++    icon: Icons.notifications_none_outlined,
++  );
+ }
+```
+
+부수 효과:
+- 다른 list/grid 화면들과 시각/톤 통일.
+- spec line 108 의 \"보강 검토 가치\" 권장 적용.
+- spec Empty state 컴포넌트 row + \"전용 EmptyState atom 미사용\" 노트 동기화 (별도 spec PR — Mark 영역).
+
+## reference
+
+- canonical atom: `shared/packages/mds/core/lib/src/ui/widgets/common/minglit_empty_state.dart` (fullPage / card / inline 3 variant)
+- 인접 채택 사례: `apps/app_user/lib/src/features/my_tickets/ui/my_tickets_page.dart`, `apps/app_user/lib/src/features/event/matching/ui/event_matching_screen.dart`, `apps/app_user/lib/src/features/home/home_page.dart`
+- spec: `apps/mds/docs/public/specs/notification_list_screen/index.md` Empty state section (line 97-108)
+- 디자인 시스템 카탈로그: `apps/mds/docs/src/lib/components.ts` (MinglitEmptyState 항목)
+- 패턴 가이드: `docs/ux/design-system/03-patterns.md`
+
+## 노트
+
+- 관련 발견 #2413 (notification_list_screen Error state 도 동일 패턴의 인터널 컨플릭) 과 한 PR 로 묶어 처리 가능 — 같은 파일 / 같은 도메인 / 같은 design system 정합 의도.
+- spec 동기화는 Mark 영역.
+
+— needs-uiux-claude-1

--- a/docs/reports/uiux/2026-05-10-issue2415-settlement-page-dashboard-error-inline-column.md
+++ b/docs/reports/uiux/2026-05-10-issue2415-settlement-page-dashboard-error-inline-column.md
@@ -1,0 +1,116 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2415
+captured_at: 2026-05-10
+issue_number: 2415
+state: open
+labels: []
+author: Mark-Yun
+title: "[audit-uiux/차이] settlement_page Dashboard error — 인라인 Column + Text(error.toString()) vs List tab의 MinglitEmptyState"
+---
+
+# [audit-uiux/차이] settlement_page Dashboard error — 인라인 Column + Text(error.toString()) vs List tab의 MinglitEmptyState
+
+> Issue #2415 · open · created 2026-05-10 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2415
+
+## Body
+
+Scheduler: needs-uiux-claude-1
+
+## 발견 위치
+
+- code (Dashboard error · drift): `apps/app_partner/lib/src/features/settlement/_settlement_dashboard_tab.dart:34-58`
+- code (List error · canonical): `apps/app_partner/lib/src/features/settlement/_settlement_list_tab.dart:81-89`
+- spec: `apps/mds/docs/public/specs/settlement_page/index.md`
+  - Global edge cases line 210 (`대시보드 오류 — '다시 시도' 버튼은 일반 FilledButton ... 후속 통일 후보`)
+  - Reference · ⚠️ Drift / 후속 후보 line 229 (`Dashboard error column은 MinglitEmptyState 미사용 (인라인 Text + FilledButton) — list와 시각적 결 통일 후보`)
+
+## 현재 / 권장
+
+### 현재 (drift)
+
+같은 화면(SettlementPage)의 두 탭 — Dashboard / List — 이 **에러 상태에서 다른 컴포넌트 패턴**을 사용. 스펙 자체가 line 210/229 에서 이 불일치를 "후속 통일 후보"로 인지하지만 추적 이슈는 부재.
+
+**Dashboard tab error** (`_settlement_dashboard_tab.dart:34-58`):
+```dart
+error: (error, _) => [
+  Center(
+    child: Column(
+      children: [
+        Text('오류가 발생했습니다',
+            style: Theme.of(context).textTheme.bodyMedium),
+        const SizedBox(height: MinglitSpacing.small),
+        Text(error.toString(),
+            style: Theme.of(context).textTheme.bodySmall),
+        const SizedBox(height: MinglitSpacing.medium),
+        FilledButton(
+          onPressed: () => ref
+              .read(settlementDashboardControllerProvider.notifier)
+              .loadDashboard(),
+          child: const Text('다시 시도'),
+        ),
+      ],
+    ),
+  ),
+],
+```
+
+문제 3가지:
+1. **MinglitEmptyState 미사용** — 디자인 시스템 위젯이 있는데도 인라인 `Center+Column+Text+FilledButton` 으로 재작성. typography / 간격 / 아이콘 톤이 list 탭 에러와 어긋남.
+2. **아이콘 부재** — list 탭 에러는 `Icons.error_outline` 아이콘이 있는데 dashboard 에러는 텍스트만 노출.
+3. **`error.toString()` raw 노출** — 사용자에게 raw 예외 메시지(스택/서버 응답 fragment)가 그대로 노출될 수 있음. spec은 "안내 텍스트 + '다시 시도' 버튼" 으로만 기술 — raw 메시지 노출은 spec 에도 없음.
+
+**List tab error** (`_settlement_list_tab.dart:81-89`) — canonical 패턴:
+```dart
+MinglitEmptyState(
+  icon: Icons.error_outline,
+  title: '목록을 불러오지 못했습니다',
+  subtitle: '잠시 후 다시 시도해 주세요.',
+  actionLabel: '다시 시도',
+  onAction: () => ref
+      .read(settlementListControllerProvider.notifier)
+      .refresh(),
+)
+```
+
+### 권장
+
+`_settlement_dashboard_tab.dart` error 분기를 List tab 과 동일한 `MinglitEmptyState` 로 교체:
+
+```dart
+error: (error, _) => [
+  MinglitEmptyState(
+    icon: Icons.error_outline,
+    title: '대시보드를 불러오지 못했습니다',
+    subtitle: '잠시 후 다시 시도해 주세요.',
+    actionLabel: '다시 시도',
+    onAction: () => ref
+        .read(settlementDashboardControllerProvider.notifier)
+        .loadDashboard(),
+  ),
+],
+```
+
+라벨만 화면 컨텍스트에 맞게 ('목록' → '대시보드') 조정. 시각적 결과 토큰은 list tab 과 100% 동일해짐.
+
+`error.toString()` 은 모니터링 시스템(Sentry 등)으로만 보내고 사용자에게는 노출하지 않는다 — 다른 partner 화면(EventApplicationManagePage 신청관리) State 6 노트와 일치: `📝 사용자에겐 일반 안내 카피만. 디버깅 정보는 별도 모니터링 시스템에서 확인.`
+
+## 영향
+
+- **시각적 일관성**: 같은 화면 내 두 탭의 에러 결이 어긋남 — 사용자가 "같은 앱 같은 화면" 으로 인지하기 어렵게 만듦.
+- **UX 위험**: raw 에러 메시지가 노출되면 신뢰감 하락 + (드물게) 민감한 백엔드 정보 노출 위험.
+- **maintainability**: 새로운 에러 화면 패턴 결정 시 두 곳을 동시에 갱신해야 하는 부담.
+
+## reference
+
+- spec drift 명시: `apps/mds/docs/public/specs/settlement_page/index.md:210, 229`
+- canonical (settlement list tab): `apps/app_partner/lib/src/features/settlement/_settlement_list_tab.dart:81-89`
+- canonical (Fix #127): list 탭 에러 상태 — 빈 상태 대신 명시적 에러 화면 + MinglitEmptyState 사용
+- 디자인 시스템 위젯: `shared/packages/mds/core/lib/src/ui/widgets/common/minglit_empty_state.dart` (fullPage variant)
+- 인접 패턴 — search_page Error: 이미 `MinglitEmptyState` 토픽으로 audit 됨 (issue #2408)
+- 인접 패턴 — notification_list_screen Error: 인라인 override 사용 (issue #2413) — 동일 패턴의 다른 차이
+
+## 노트
+
+- 단일 PR 로 처리 가능한 작은 drift. SWE 에게 라우팅 시 "_settlement_dashboard_tab.dart 의 error 분기 8줄을 MinglitEmptyState 로 치환" 으로 충분.
+- spec 변경 불필요 — spec 은 이미 "후속 통일" 을 명시하고 있고, 갱신 후에는 ⚠️ Drift 표 line 229 의 첫 번째 항목과 line 210 의 마지막 bullet 만 제거하면 됨.


### PR DESCRIPTION
Scheduler: needs-uiux-claude-1

## 변경 내용

audit-uiux 사이클(2026-05-10)에서 생성한 12개 이슈 본문을 `docs/reports/uiux/`에 동기화. 누락된 sync.

| Issue | Category | Topic |
|---|---|---|
| #2402 | 차이 | review_verification_screen — 코드 + 라우트 있는데 spec 누락 |
| #2403 | 차이 | route-pages.json 5개 라우트 누락 (user 4 + partner 1) |
| #2404 | 차이 | event_application_review_page — spec 'TBD' vs 실제 구현 완료 |
| #2405 | 개선 | purchase_history_page spec 내부 충돌 — verbal vs layout tree |
| #2407 | 개선 | components.ts visualSpec 필드 — MinglitButton 1개만, legacy 정리 |
| #2408 | 차이 | search_page Error state — Text 위젯 명시 style 없음 |
| #2409 | 개선 | event_detail §3 참가 현황 caption-gauge 의미 충돌 |
| #2411 | 차이 | event_matching_results_screen — spec 'TBD' vs 완전 구현 |
| #2412 | 차이 | TicketSelectionSheet — 결제 진입 게이트 시트 spec 부재 |
| #2413 | 차이 | notification_list_screen Error — inline override vs MinglitAsyncValueWidget |
| #2414 | 차이 | notification_list_screen Empty — plain Text vs MinglitEmptyState atom |
| #2415 | 차이 | settlement_page Dashboard error — inline Column vs MinglitEmptyState |

## 배경

`audit-report-work.txt`의 `docs/reports/{category}/` 동기화 룰은 audit-uiux 두 카테고리(개선/차이) 모두에 적용된다. 이슈 생성 직후 sync가 권장이지만, 오늘 생성한 12개는 누락된 채 dev에 머지된 상태였음 → graphify 그래프와 다른 에이전트가 못 보는 상태. 일괄 sync로 해결.

## reference

- policy: `config/prompts/work/audit-report-work.txt` (lines 31-97)
- 카테고리 결정: worker name `needs-uiux-claude-1` → `uiux`
- 파일명 규칙: `YYYY-MM-DD-issueNNNN-<slug>.md` (이슈 createdAt 기준)
- 본문: 이슈 body verbatim + YAML frontmatter (코멘트 제외)

## 테스트 / 검증

- 12개 파일 모두 `docs/reports/uiux/` 디렉토리에 정상 생성
- frontmatter YAML 형식 일관 (source_url / captured_at / issue_number / state / labels / author / title)
- 파일명 slug는 영문 키워드로 의역 (한글 제목 → 영문 slug)