### PR TITLE
chore(reports): sync 3 audit-uiux/차이 reports — AppBar info icon drift (#2380 fallout)

### DIFF
--- a/docs/reports/uiux/2026-05-10-issue2417-partner-home-appbar-info-icon-missing.md
+++ b/docs/reports/uiux/2026-05-10-issue2417-partner-home-appbar-info-icon-missing.md
@@ -1,0 +1,92 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2417
+captured_at: 2026-05-10
+issue_number: 2417
+state: open
+labels: []
+author: Mark-Yun
+title: "[audit-uiux/차이] partner_home_page — AppBar info_outline icon 누락 (PR #2380 spec sync 후 코드 미반영)"
+---
+
+# [audit-uiux/차이] partner_home_page — AppBar info_outline icon 누락 (PR #2380 spec sync 후 코드 미반영)
+
+> Issue #2417 · open · created 2026-05-10 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2417
+
+## Body
+
+Scheduler: needs-uiux-claude-1
+
+## 발견 위치
+
+- code: `apps/app_partner/lib/src/features/home/partner_home_page.dart:38-82` (AppBar `actions` 배열)
+- spec: `apps/mds/docs/public/specs/partner_home_page/index.html`
+  - Layout tree: line 1057 — `IconButton(info_outline) → showMinglitHelpSheet(...)`
+  - AppBar sub-anatomy: line 1122 — `② Info action (1st trailing) · info_outline 22×22 · 탭 시 도움말 bottom sheet 진입 (State 8). 파트너 앱 모든 화면에 동일 패턴 적용.`
+- canonical 구현 reference: `apps/app_partner/lib/src/features/party/list/party_list_page.dart:8-55` (Fix #2200, PR #2243)
+
+## 현재 / 권장
+
+### 현재 (drift)
+
+PR #2380 (commit `e1cc82a55`)이 3개 spec 에 `AppBar info_outline → showMinglitHelpSheet` 패턴을 동기화했지만, **partner_home_page 코드에는 info_outline icon 자체가 없음**. spec 은 "info → bug → 알림" 순서(line 1057)를 명시하지만 코드는 "bug → 알림"만 존재.
+
+```dart
+// partner_home_page.dart:44-81 — 현재
+actions: [
+  const BugReportAction(),                     // ① spec 기준 ③번 위치
+  Stack(...IconButton(notifications_outlined)) // ② spec 기준 ④번 위치
+  // info_outline 누락
+],
+```
+
+PR #2380 본문은 *"코드는 PR #2243에서 결정·배포됨. Mark 지시로 spec 단순 sync."*라고 명시했지만, PR #2243은 `party_list_page` 1개 화면만 구현했고 partner_home_page 등 나머지 3개 화면은 미구현 상태였다 → spec ↔ code drift.
+
+### 권장 (Mark 결정 시 swe 라우팅)
+
+canonical 패턴(party_list_page) 그대로 첫 trailing action 으로 info_outline 추가:
+
+```dart
+const _kPartnerHomeHelpSections = [
+  HelpSection(
+    title: '...',
+    body: '...',
+  ),
+  // PR #2380 본문: "도움말 콘텐츠(Q&A sections)는 화면별 정의 미완 — placeholder로 표시. 추후 별도 이슈로 확정."
+  // → 콘텐츠는 Mark 가 별도 정의 후 채움
+];
+
+actions: [
+  IconButton(
+    icon: const Icon(Icons.info_outline),
+    iconSize: 22,
+    tooltip: '도움말',
+    onPressed: () => showMinglitHelpSheet(
+      context: context,
+      title: '파트너 홈 가이드',
+      sections: _kPartnerHomeHelpSections,
+    ),
+  ),
+  const BugReportAction(),
+  Stack(...notifications_outlined...),
+],
+```
+
+## 영향
+
+- spec State 8 "도움말 bottom sheet" 가 spec 에만 존재 + 코드에서는 진입점 부재 → 파트너가 앱에서 컨텍스트 도움말에 접근 불가.
+- spec 은 "파트너 앱 모든 화면에 동일 패턴 적용" 을 명시하지만 실제로는 party_list_page 1개 화면만 적용. 패턴 일관성 위반.
+- audit / spec walk 가 이 화면을 "spec 동기화됨" 으로 잘못 판정할 위험.
+
+## reference
+
+- canonical 구현: `apps/app_partner/lib/src/features/party/list/party_list_page.dart:8-55` (Fix #2200 — `_kPartyHelpSections` const list + IconButton(info_outline) + showMinglitHelpSheet)
+- helper 위치: `shared/packages/mds/core/lib/src/ui/widgets/common/minglit_help_sheet.dart:42-63` (`showMinglitHelpSheet` + `HelpSection` 구조체 — minglit_kit re-export)
+- spec sync PR: #2380 (commit e1cc82a55, closes #2261/#2265, also-closes #2268-2271)
+- 자매 issue: partner_home_page 외 같은 root cause 로 settlement_page / event_application_manage_page 도 별도 파일링 예정.
+
+## 카테고리
+
+`[audit-uiux/차이]` — 코드 ↔ 단일 진실(spec) drift. spec 만 sync 되고 코드 미반영. tpm 이 트리아지로 `needs-swe` 부여 (코드 픽스 영역 — Help sheet sections 콘텐츠 결정은 Mark, IconButton 추가 + showMinglitHelpSheet 호출 wiring 은 swe).
+
+— needs-uiux-claude-1

--- a/docs/reports/uiux/2026-05-10-issue2418-settlement-appbar-info-icon-missing.md
+++ b/docs/reports/uiux/2026-05-10-issue2418-settlement-appbar-info-icon-missing.md
@@ -1,0 +1,109 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2418
+captured_at: 2026-05-10
+issue_number: 2418
+state: open
+labels: []
+author: Mark-Yun
+title: "[audit-uiux/차이] settlement_page — AppBar info_outline icon 누락 (PR #2380 spec sync 후 코드 미반영)"
+---
+
+# [audit-uiux/차이] settlement_page — AppBar info_outline icon 누락 (PR #2380 spec sync 후 코드 미반영)
+
+> Issue #2418 · open · created 2026-05-10 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2418
+
+## Body
+
+Scheduler: needs-uiux-claude-1
+
+## 발견 위치
+
+- code: `apps/app_partner/lib/src/features/settlement/settlement_page.dart:51-72` (AppBar `actions` 배열)
+- spec: `apps/mds/docs/public/specs/settlement_page/index.html`
+  - Layout tree: line 500 — `IconButton(info_outline) → showMinglitHelpSheet(...)` (info → wallet 순서)
+  - AppBar sub-anatomy: line 567 — `② Info action (1st trailing) · info_outline 22×22 · 탭 시 도움말 bottom sheet 진입 (State 7). 파트너 앱 모든 화면에 동일 패턴 적용.`
+- canonical 구현 reference: `apps/app_partner/lib/src/features/party/list/party_list_page.dart:8-55` (Fix #2200, PR #2243)
+
+## 현재 / 권장
+
+### 현재 (drift)
+
+PR #2380 (commit `e1cc82a55`)이 spec 에 "info → wallet" actions 순서를 동기화했지만, **settlement_page 코드에는 info_outline icon 자체가 없음**. wallet icon (계좌 관리) 만 존재 (그것도 SETTLEMENT_EDIT permission gated — Fix #1568).
+
+```dart
+// settlement_page.dart:52-64 — 현재
+appBar: AppBar(
+  title: const Text('정산'),
+  actions: [
+    if (canEditSettlement)
+      IconButton(
+        icon: const Icon(Icons.account_balance_wallet_outlined),
+        tooltip: '계좌 관리',
+        ...
+      ),
+    // info_outline 누락
+  ],
+  bottom: TabBar(...),
+),
+```
+
+PR #2380 본문은 *"코드는 PR #2243에서 결정·배포됨. Mark 지시로 spec 단순 sync."*라고 명시했지만, PR #2243은 `party_list_page` 1개 화면만 구현했고 settlement_page 등 나머지 3개 화면은 미구현 상태였다 → spec ↔ code drift.
+
+### 권장 (Mark 결정 시 swe 라우팅)
+
+canonical 패턴(party_list_page) 그대로 첫 trailing action 으로 info_outline 추가 (permission 게이트 무관 — 도움말은 모든 멤버에게 노출):
+
+```dart
+const _kSettlementHelpSections = [
+  HelpSection(
+    title: '...',
+    body: '...',
+  ),
+  // PR #2380 본문: "도움말 콘텐츠(Q&A sections)는 화면별 정의 미완 — placeholder로 표시. 추후 별도 이슈로 확정."
+  // → 콘텐츠는 Mark 가 별도 정의 후 채움
+];
+
+appBar: AppBar(
+  title: const Text('정산'),
+  actions: [
+    IconButton(
+      icon: const Icon(Icons.info_outline),
+      iconSize: 22,
+      tooltip: '도움말',
+      onPressed: () => showMinglitHelpSheet(
+        context: context,
+        title: '정산 가이드',
+        sections: _kSettlementHelpSections,
+      ),
+    ),
+    if (canEditSettlement)
+      IconButton(
+        key: const Key('bankAccountButton'),
+        icon: const Icon(Icons.account_balance_wallet_outlined),
+        tooltip: '계좌 관리',
+        ...
+      ),
+  ],
+  bottom: TabBar(...),
+),
+```
+
+## 영향
+
+- spec State 7 "도움말 bottom sheet" 가 spec 에만 존재 + 코드에서는 진입점 부재 → 파트너가 정산 정책(수수료/지급주기/세금 처리 등) 컨텍스트 도움말에 접근 불가. **정산 도메인 특성상 도움말 부재가 가장 큰 친화도 손실 영역 중 하나** (정산 관련 CS 부담 직결).
+- spec 은 "파트너 앱 모든 화면에 동일 패턴 적용" 을 명시하지만 실제로는 party_list_page 1개 화면만 적용. 패턴 일관성 위반.
+- audit / spec walk 가 이 화면을 "spec 동기화됨" 으로 잘못 판정할 위험.
+
+## reference
+
+- canonical 구현: `apps/app_partner/lib/src/features/party/list/party_list_page.dart:8-55` (Fix #2200 — `_kPartyHelpSections` const list + IconButton(info_outline) + showMinglitHelpSheet)
+- helper 위치: `shared/packages/mds/core/lib/src/ui/widgets/common/minglit_help_sheet.dart:42-63` (`showMinglitHelpSheet` + `HelpSection` 구조체 — minglit_kit re-export)
+- spec sync PR: #2380 (commit e1cc82a55, closes #2261/#2265, also-closes #2268-2271)
+- 자매 issue: settlement_page 외 같은 root cause 로 partner_home_page (#2417) / event_application_manage_page 도 별도 파일링 예정.
+
+## 카테고리
+
+`[audit-uiux/차이]` — 코드 ↔ 단일 진실(spec) drift. spec 만 sync 되고 코드 미반영. tpm 이 트리아지로 `needs-swe` 부여.
+
+— needs-uiux-claude-1

--- a/docs/reports/uiux/2026-05-10-issue2419-event-application-manage-appbar-info-icon-missing.md
+++ b/docs/reports/uiux/2026-05-10-issue2419-event-application-manage-appbar-info-icon-missing.md
@@ -1,0 +1,108 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2419
+captured_at: 2026-05-10
+issue_number: 2419
+state: open
+labels: []
+author: Mark-Yun
+title: "[audit-uiux/차이] event_application_manage_page — AppBar info_outline icon 누락 (PR #2380 spec sync 후 코드 미반영)"
+---
+
+# [audit-uiux/차이] event_application_manage_page — AppBar info_outline icon 누락 (PR #2380 spec sync 후 코드 미반영)
+
+> Issue #2419 · open · created 2026-05-10 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2419
+
+## Body
+
+Scheduler: needs-uiux-claude-1
+
+## 발견 위치
+
+- code: `apps/app_partner/lib/src/features/application/event_application_manage_page.dart:43-55` (AppBar — `actions` 배열 자체 없음)
+- spec: `apps/mds/docs/public/specs/event_application_manage_page/index.html`
+  - Layout tree: line 446 — `IconButton(info_outline) → showMinglitHelpSheet(...)`
+  - AppBar sub-anatomy: line 512 — `② Info action (trailing) · info_outline 22×22 · 탭 시 도움말 bottom sheet 진입 (State 7). 파트너 앱 모든 화면에 동일 패턴 적용 — 각 화면별 컨텍스트 도움말 콘텐츠는 호출 측에서 정의.`
+- canonical 구현 reference: `apps/app_partner/lib/src/features/party/list/party_list_page.dart:8-55` (Fix #2200, PR #2243)
+
+## 현재 / 권장
+
+### 현재 (drift)
+
+PR #2380 (commit `e1cc82a55`)이 spec 에 `AppBar info_outline → showMinglitHelpSheet` 패턴을 동기화했지만, **event_application_manage_page 코드에는 actions 배열 자체가 없다** — 3개 자매 화면 중 가장 심한 drift.
+
+```dart
+// event_application_manage_page.dart:43-55 — 현재
+appBar: AppBar(
+  title: const Text('신청관리'),
+  centerTitle: true,
+  // actions 배열 없음
+  bottom: TabBar(
+    controller: _tabController,
+    tabs: const [
+      Tab(text: '대기중'),
+      Tab(text: '승인됨'),
+      Tab(text: '거절됨'),
+    ],
+  ),
+),
+```
+
+PR #2380 본문은 *"코드는 PR #2243에서 결정·배포됨. Mark 지시로 spec 단순 sync."*라고 명시했지만, PR #2243은 `party_list_page` 1개 화면만 구현했고 event_application_manage_page 등 나머지 3개 화면은 미구현 상태였다 → spec ↔ code drift.
+
+### 권장 (Mark 결정 시 swe 라우팅)
+
+canonical 패턴(party_list_page) 그대로 신청관리 컨텍스트 도움말로 actions 배열 신설:
+
+```dart
+const _kApplicationManageHelpSections = [
+  HelpSection(
+    title: '신청 승인/거절은 어떻게 하나요?',
+    body: '...',
+  ),
+  HelpSection(
+    title: '거절된 신청을 되돌릴 수 있나요?',
+    body: '...',
+  ),
+  // PR #2380 본문: "도움말 콘텐츠(Q&A sections)는 화면별 정의 미완 — placeholder로 표시. 추후 별도 이슈로 확정."
+  // → 콘텐츠는 Mark 가 별도 정의 후 채움
+];
+
+appBar: AppBar(
+  title: const Text('신청관리'),
+  centerTitle: true,
+  actions: [
+    IconButton(
+      icon: const Icon(Icons.info_outline),
+      iconSize: 22,
+      tooltip: '도움말',
+      onPressed: () => showMinglitHelpSheet(
+        context: context,
+        title: '신청관리 가이드',
+        sections: _kApplicationManageHelpSections,
+      ),
+    ),
+  ],
+  bottom: TabBar(...),
+),
+```
+
+## 영향
+
+- spec State 7 "도움말 bottom sheet" 가 spec 에만 존재 + 코드에서는 진입점 부재 → 파트너가 신청 처리 정책(자동 승인 조건 / 환불 영향 / 거절 정책) 컨텍스트 도움말에 접근 불가.
+- 신청관리는 파티/이벤트 운영의 **결제 직전 게이트** — 도움말 부재가 잘못된 승인/거절 결정 → CS 폭발 / 환불 분쟁의 vector 가 될 가능성.
+- spec 은 "파트너 앱 모든 화면에 동일 패턴 적용" 을 명시하지만 실제로는 party_list_page 1개 화면만 적용. 패턴 일관성 위반.
+- audit / spec walk 가 이 화면을 "spec 동기화됨" 으로 잘못 판정할 위험.
+
+## reference
+
+- canonical 구현: `apps/app_partner/lib/src/features/party/list/party_list_page.dart:8-55` (Fix #2200 — `_kPartyHelpSections` const list + IconButton(info_outline) + showMinglitHelpSheet)
+- helper 위치: `shared/packages/mds/core/lib/src/ui/widgets/common/minglit_help_sheet.dart:42-63` (`showMinglitHelpSheet` + `HelpSection` 구조체 — minglit_kit re-export)
+- spec sync PR: #2380 (commit e1cc82a55, closes #2261/#2265, also-closes #2268-2271)
+- 자매 issue: event_application_manage_page 외 같은 root cause 로 partner_home_page (#2417) / settlement_page (#2418) 도 별도 파일링.
+
+## 카테고리
+
+`[audit-uiux/차이]` — 코드 ↔ 단일 진실(spec) drift. spec 만 sync 되고 코드 미반영. tpm 이 트리아지로 `needs-swe` 부여.
+
+— needs-uiux-claude-1


### PR DESCRIPTION
Scheduler: needs-uiux-claude-1

## 변경 내용

audit-uiux 사이클(2026-05-10 후속)에서 발견한 3개 이슈 본문을 `docs/reports/uiux/`에 동기화. PR #2380 (commit `e1cc82a55`)이 spec 만 sync 하고 코드는 미반영된 채로 dev 에 머지된 drift 발견.

| Issue | Screen | drift 요약 |
|---|---|---|
| #2417 | partner_home_page | actions[BugReport, Notifications] — info_outline 누락 |
| #2418 | settlement_page | actions[wallet] — info_outline 누락 (정산 도움말 부재) |
| #2419 | event_application_manage_page | actions 배열 자체 없음 (가장 심한 drift) |

3개 모두 canonical 구현(`apps/app_partner/lib/src/features/party/list/party_list_page.dart:8-55`, Fix #2200/PR #2243) 패턴으로 픽스 가능.

## 배경

`audit-report-work.txt`의 `docs/reports/{category}/` 동기화 룰은 audit-uiux 두 카테고리(개선/차이) 모두에 적용된다. 3개 이슈는 이번 사이클에서 새로 파일링 → 동기화 누락 방지를 위해 같은 사이클에서 sync.

PR #2380 본문은 *"코드는 PR #2243에서 결정·배포됨. Mark 지시로 spec 단순 sync."*라고 명시했으나, PR #2243은 `party_list_page` 1개 화면만 구현했고 나머지 3개 화면은 미구현 상태였다 → spec ↔ code drift 의 root cause.

## reference

- policy: `config/prompts/work/audit-report-work.txt` (lines 31-97) — uiux 카테고리 동기화 룰
- 카테고리 결정: worker name `needs-uiux-claude-1` → `uiux`
- 파일명 규칙: `YYYY-MM-DD-issueNNNN-<slug>.md` (이슈 createdAt 기준)
- 본문: 이슈 body verbatim + YAML frontmatter (코멘트 제외)
- spec sync PR (root cause): #2380 (commit e1cc82a55)
- canonical 구현: party_list_page (Fix #2200, PR #2243)
- helper: `shared/packages/mds/core/lib/src/ui/widgets/common/minglit_help_sheet.dart:42-63`

## 테스트 / 검증

- 3개 파일 모두 `docs/reports/uiux/` 디렉토리에 정상 생성
- frontmatter YAML 형식 일관 (source_url / captured_at / issue_number / state / labels / author / title) — 직전 PR #2416 와 동일 포맷
- 파일명 slug 영문 키워드: `partner-home-appbar-info-icon-missing` / `settlement-appbar-info-icon-missing` / `event-application-manage-appbar-info-icon-missing`
- 이슈 본문에 backslash-escaped quote 없음 (post-create sed 픽스 후 captured)