### PR TITLE
chore(reports): sync 3 audit-uiux empty state cascade reports (#2422 #2423 #2425)

### DIFF
--- a/docs/reports/uiux/2026-05-10-issue2422-minglit-empty-state-fullpage-icon-size-conflict.md
+++ b/docs/reports/uiux/2026-05-10-issue2422-minglit-empty-state-fullpage-icon-size-conflict.md
@@ -1,0 +1,84 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2422
+captured_at: 2026-05-11
+issue_number: 2422
+state: open
+labels: []
+author: Mark-Yun
+title: "[audit-uiux/개선] MinglitEmptyState fullPage variant 아이콘 size 48 vs 3개 spec 64 충돌 — 캐노니컬 합리화 결정 필요"
+---
+
+# [audit-uiux/개선] MinglitEmptyState fullPage variant 아이콘 size 48 vs 3개 spec 64 충돌 — 캐노니컬 합리화 결정 필요
+
+> Issue #2422 · open · created 2026-05-10 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2422
+
+## Body
+
+Scheduler: needs-uiux-claude-1
+
+## 발견 위치
+
+`shared/packages/mds/core/lib/src/ui/widgets/common/minglit_empty_state.dart:103-105` — `MinglitEmptyState.fullPage` variant icon size = `MinglitIconSize.display` (48px).
+
+이 토큰 선택과 3개 화면 spec(`party_list_page` / `checkin_placeholder_page` / `event_application_manage_page`)이 명시한 **64×64** 사이에 충돌이 있어, 해당 화면들이 캐노니컬 위젯을 우회하고 raw `Column`으로 rolled-own empty state를 구현하고 있다.
+
+## 현재 / 권장
+
+### 현재 — 캐노니컬과 spec 불일치
+
+| Spec | Empty 아이콘 크기 | 캐노니컬 매칭? |
+|---|---|---|
+| `party_list_page` line 902 | smile_outline · **64×64** · `--color-divider` | ❌ |
+| `checkin_placeholder_page` line 332 | qr_code_scanner · **xlarge\*2 ≈ 64** | ❌ |
+| `event_application_manage_page` line 217 | 서류 outline · **width 64 height 64** opacity 0.5 | ❌ |
+| `event_matching_screen` line 239 | (people/lock outline) · **48×48** | ✅ matches `MinglitIconSize.display` |
+
+다수(3 of 4) full-page empty state spec이 **64px**를 명시 — 캐노니컬 fullPage variant(48px)와 불일치.
+
+### 캐스케이드 — 코드가 캐노니컬을 우회
+
+3개 화면이 `MinglitEmptyState`를 사용하지 않고 raw `Column`으로 직접 구현 (size 64 충족 위해):
+
+| 파일 | 라인 | 우회 사유 |
+|---|---|---|
+| `apps/app_partner/lib/src/features/checkin/checkin_placeholder_page.dart` | 122-138 | icon size `MinglitIconSize.xlarge * 2` (64) — 캐노니컬은 48 |
+| `apps/app_partner/lib/src/features/application/event_application_manage_tab.dart` | 46-65 | 동일 — `MinglitIconSize.xlarge * 2` |
+| `apps/app_partner/lib/src/features/party/list/party_list_page.dart` | 107-110 | 하드코딩 `size: 56` — 캐노니컬도 spec(64)도 둘 다 위반 |
+
+캐노니컬 위젯이 spec과 일치하지 않으니 SWE가 raw Column을 쓰는 게 자연스러운 분기 → 캐노니컬 합리화 / 일관성 확보 필요.
+
+### 권장 — 결정 옵션
+
+**옵션 A (권장)** — 캐노니컬을 64로 변경:
+```dart
+// minglit_empty_state.dart
+size: variant == MinglitEmptyStateVariant.card
+    ? MinglitIconSize.xlarge          // 32 (그대로)
+    : MinglitIconSize.xlarge * 2,     // 48 → 64
+```
+- 장점: 다수 spec(3/4)에 캐노니컬 정렬 / rolled-own 3개 화면 캐노니컬 회귀 가능 / 풀-페이지 hero 시그널 강화
+- 단점: `event_matching_screen` spec 1건은 48 → 64로 spec 업데이트 필요
+
+**옵션 B** — 캐노니컬 48 유지, 3개 spec 48로 업데이트:
+- 장점: 변경 표면 작음 (캐노니컬 위젯 무변)
+- 단점: 풀-페이지 hero icon이 시각적으로 약함 / 3개 spec 동시 변경 / event_application_manage spec line 903 "큰 아이콘 (서류 outline 형 · 64 · 보조 색)" 처럼 64라는 점이 시그널로 강조된 사례 → 의도 손상
+
+**옵션 C** — 새 variant `heroFullPage` (64) 신설, 기존 `fullPage` (48) 유지:
+- 장점: 두 톤 모두 보존 / 화면별 선택 가능
+- 단점: variant 종류 4개로 증가 / 어떤 화면이 어떤 variant 써야 하는지 가이드라인 추가 필요
+
+## reference
+
+- canonical: `shared/packages/mds/core/lib/src/ui/widgets/common/minglit_empty_state.dart:103-105`
+- token: `shared/packages/mds/core/lib/src/theme/minglit_design_tokens.dart:238-246` (`xlarge`=32 / `display`=48 — 64에 해당하는 토큰 없음 → `xlarge*2` 곱셈 패턴)
+- specs:
+  - `apps/mds/docs/public/specs/party_list_page/index.html:902` — empty state 64×64
+  - `apps/mds/docs/public/specs/checkin_placeholder_page/index.html:332` — `xlarge*2 ≈ 64`
+  - `apps/mds/docs/public/specs/event_application_manage_page/index.html:217` — width/height 64
+  - `apps/mds/docs/public/specs/event_matching_screen/index.html:239` — 48×48 (옵션 A 채택 시 spec 업데이트 대상)
+- M3/iOS HIG 비교: full-page empty state hero icon은 일반적으로 56–64dp (Material 3 Empty State guidance / iOS HIG NoContent placeholder). 48dp는 inline / list-empty 컨텍스트가 적합. 다수 spec이 64를 채택한 것이 frontier 톤에 더 가까움.
+
+## 카테고리
+
+[audit-uiux/개선] — 디자인 시스템 내부 충돌 (캐노니컬 위젯 ↔ 다수 spec). spec 직접 수정 / 위젯 직접 수정 모두 진행하지 않고 Mark 결정 대기.

--- a/docs/reports/uiux/2026-05-10-issue2423-party-list-empty-icon-size-spec-mismatch.md
+++ b/docs/reports/uiux/2026-05-10-issue2423-party-list-empty-icon-size-spec-mismatch.md
@@ -1,0 +1,54 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2423
+captured_at: 2026-05-11
+issue_number: 2423
+state: open
+labels: []
+author: Mark-Yun
+title: "[audit-uiux/차이] party_list_page _PartyListEmptyState — icon size 56 하드코딩 + spec 64 미일치 + Icons.celebration_outlined vs smile_outline"
+---
+
+# [audit-uiux/차이] party_list_page _PartyListEmptyState — icon size 56 하드코딩 + spec 64 미일치 + Icons.celebration_outlined vs smile_outline
+
+> Issue #2423 · open · created 2026-05-10 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2423
+
+## Body
+
+Scheduler: needs-uiux-claude-1
+
+## 발견 위치
+
+`apps/app_partner/lib/src/features/party/list/party_list_page.dart:107-110`
+
+```dart
+Icon(
+  Icons.celebration_outlined,   // ← spec: smile_outline
+  size: 56,                      // ← spec: 64 (하드코딩 + spec 미일치)
+  color: theme.colorScheme.outlineVariant,  // ← spec: --color-divider (= outlineVariant 매칭 OK)
+),
+```
+
+## 현재 / 권장
+
+| 항목 | 현재 코드 | spec |
+|---|---|---|
+| 아이콘 | `Icons.celebration_outlined` | `smile_outline` |
+| 크기 | `56` (하드코딩) | **64×64** |
+| 색 | `theme.colorScheme.outlineVariant` | `--color-divider` (= outlineVariant) ✅ |
+
+### 권장
+
+1. **size: 56 → 64** — spec과 정렬. 토큰화 (현재 `MinglitIconSize`에 64 토큰 없음 → `MinglitIconSize.xlarge * 2` 패턴이 다른 화면에서 사용 중. 단 #2422 결정 후 캐노니컬 / 토큰 변경 가능성 있음).
+2. **icon: celebration_outlined → smile_outline 계열** — spec 의도(`smile_outline`)와 비교 시 `Icons.sentiment_satisfied_outlined` 또는 `Icons.mood_outlined`가 자연스러운 매칭. 다만 "파티" 컨텍스트에서 celebration이 더 적합하다는 판단이 가능 → spec 측 업데이트가 더 합리적일 수 있음 (Mark 판단).
+
+## reference
+
+- code: `apps/app_partner/lib/src/features/party/list/party_list_page.dart:107-110`
+- spec: `apps/mds/docs/public/specs/party_list_page/index.html:902` ("smile_outline 64 · `--color-divider` 톤")
+- 관련 이슈: #2422 (`MinglitEmptyState` fullPage 48 vs spec 64 conflict — 캐노니컬 결정 후 본 이슈 size 토큰 결정도 동시에 따라감)
+- 캐노니컬: `shared/packages/mds/core/lib/src/ui/widgets/common/minglit_empty_state.dart` (현재는 fullPage 48 → 캐노니컬 채택 시 spec과도 어긋남 → rolled-own 유지 사유)
+
+## 카테고리
+
+[audit-uiux/차이] — 코드가 spec과 어긋남 (size 8px 차이 + icon 불일치 + 하드코딩 토큰 미사용). #2422 결정과 함께 처리하면 자연스럽게 캐노니컬 회귀 가능.

--- a/docs/reports/uiux/2026-05-10-issue2425-app-user-empty-state-cascade.md
+++ b/docs/reports/uiux/2026-05-10-issue2425-app-user-empty-state-cascade.md
@@ -1,0 +1,66 @@
+---
+source_url: https://github.com/Mark-Yun/minglit/issues/2425
+captured_at: 2026-05-11
+issue_number: 2425
+state: open
+labels: []
+author: Mark-Yun
+title: "[audit-uiux/차이] app_user 4개 화면 rolled-own empty state — #2422 cascade 확장 (search 2개 / my_page / auth_guard, 모두 size: 64 하드코딩)"
+---
+
+# [audit-uiux/차이] app_user 4개 화면 rolled-own empty state — #2422 cascade 확장 (search 2개 / my_page / auth_guard, 모두 size: 64 하드코딩)
+
+> Issue #2425 · open · created 2026-05-10 · author @Mark-Yun
+> https://github.com/Mark-Yun/minglit/issues/2425
+
+Scheduler: needs-uiux-claude-1
+
+## 발견 위치
+
+`#2422` (`MinglitEmptyState.fullPage` icon size = 48 vs 다수 spec 64) cascade 가 **app_partner 외에 app_user 4개 화면에서도 동일하게 발생** 중. 기존 audit 는 app_partner 만 확인 (3개) → 캐스케이드 총 **7+ 화면** 으로 확장.
+
+## 현재 / 권장
+
+### app_user rolled-own 인스턴스 (4건)
+
+| 파일 | 라인 | 아이콘 | 코드 크기 | spec 크기 | 일치? |
+|---|---|---|---|---|---|
+| `apps/app_user/lib/src/features/search/search_page.dart` | 90-94 | `Icons.search` | `size: 64` | search_page/index.html:107,391 — 64 | spec ✅ / 캐노니컬 ❌ |
+| `apps/app_user/lib/src/features/search/search_page.dart` | 150-154 | `Icons.search_off_outlined` | `size: 64` | search_page/index.html:402 — 64 | spec ✅ / 캐노니컬 ❌ |
+| `apps/app_user/lib/src/features/home/my_page.dart` | 28-32 | `Icons.person_outline` | `size: 64` | my_page/index.html:551,574 — 64 | spec ✅ / 캐노니컬 ❌ |
+| `apps/app_user/lib/src/features/auth/ui/auth_guard.dart` | 31-35 | `Icons.lock_outline` | `size: 64` | (공용 guard widget — 개별 spec 없음, 동일 톤 패턴) | 캐노니컬 ❌ |
+
+전부 raw `Column` + `Icon(... size: 64 ...)` + `Text(titleMedium)` + `Text(bodyMedium)` + 옵셔널 CTA 의 **동일 구조** — `MinglitEmptyState.fullPage` 캐노니컬 위젯의 거의 완전한 복제. 캐노니컬을 호출하지 않은 사유는 단 하나 — 캐노니컬이 size 48 을 강제하므로 spec 64 를 만족할 수 없음 (#2422).
+
+### 추가 드리프트 (참고)
+
+| 파일 | 라인 | 코드 크기 | spec 크기 | 비고 |
+|---|---|---|---|---|
+| `apps/app_user/lib/src/features/tickets/my_tickets_page.dart` | 31 | `MinglitIconSize.display` (=48) | my_tickets_page/index.html:380 — 64 | 캐노니컬 토큰 사용했으나 spec 미달 — #2422 캐노니컬 정렬되면 자동 해소 |
+
+(`apps/app_user/lib/src/features/my_tickets/ui/my_tickets_page.dart` 는 `MinglitEmptyState` 사용 — canonical compliant 이나 동일 size 48 vs spec 64 격차 보유)
+
+### 권장
+
+**본 발견은 #2422 의 결정에 종속.**
+
+- **#2422 옵션 A 채택 시** (캐노니컬 → 64) — 본 4개 + #2422 의 3개 + 캐노니컬 사용 my_tickets = **8개 화면이 자동 정렬**. 추가 대규모 변경 불필요.
+- **#2422 옵션 B 채택 시** (캐노니컬 48 유지, spec → 48) — 본 4개 화면도 코드 size 64 → 48 변경 + 캐노니컬 회귀 작업 추가. 변경 표면 가장 큼.
+- **#2422 옵션 C 채택 시** (`heroFullPage` 신설) — 본 4개 화면 모두 신 variant 적용 가이드라인 필요.
+
+**옵션 A 가 가장 효율적** — cascade 가 4 → 7 → 8개 화면으로 확장되며 다수 spec(이제 7+개 spec)이 64 를 명시하는 만큼, 캐노니컬을 64 로 정렬하면 자연스러운 회귀 경로 확보.
+
+## reference
+
+- root cause issue: #2422
+- 형제 cascade: #2423 (party_list_page, app_partner)
+- canonical: `shared/packages/mds/core/lib/src/ui/widgets/common/minglit_empty_state.dart:103-105`
+- specs (모두 64 명시):
+  - `apps/mds/docs/public/specs/search_page/index.html:107,391,402`
+  - `apps/mds/docs/public/specs/my_page/index.html:551,574`
+  - `apps/mds/docs/public/specs/my_tickets_page/index.html:380`
+- M3/iOS HIG: 풀-페이지 hero icon 56-64dp 권장 — frontier 톤 정렬
+
+## 카테고리
+
+[audit-uiux/차이] — 코드 ↔ 캐노니컬 위젯 우회 패턴 (4개 추가). #2422 결정과 묶어 처리하면 본 이슈 자동 해소.


### PR DESCRIPTION
Scheduler: needs-uiux-claude-1

## 변경 내용

audit-uiux 사이클(2026-05-11) 새 발견 3개 본문을 `docs/reports/uiux/`에 동기화.

| Issue | 카테고리 | 발견 |
|---|---|---|
| #2422 | [audit-uiux/개선] | `MinglitEmptyState.fullPage` 캐노니컬 icon size 48 vs 3개 spec 64 — 디자인 시스템 내부 충돌 |
| #2423 | [audit-uiux/차이] | `party_list_page _PartyListEmptyState` icon `size: 56` 하드코딩 + spec 64 미일치 + `Icons.celebration_outlined` vs spec `smile_outline` |
| #2425 | [audit-uiux/차이] | app_user 4개 화면(search 2 / my_page / auth_guard) rolled-own empty state size: 64 하드코딩 — #2422 cascade 확장 (총 7+화면) |

#2423 / #2425 는 #2422 결정에 따라가며, #2422 는 캐노니컬 위젯과 spec 사이의 root-cause 충돌. app_partner 3개 + app_user 4개 = **7개 화면**이 spec 64 요구를 캐노니컬(48)이 충족 못 해 raw `Column` 으로 우회 — 옵션 A(캐노니컬 → 64) 채택 시 8개 화면 자동 정렬.

## 배경

`config/prompts/work/audit-report-work.txt`의 `docs/reports/{category}/` 동기화 룰은 audit-uiux 두 카테고리(개선/차이) 모두에 적용. 같은 사이클의 새 이슈는 동일 PR 에 sync.

## reference

- policy: `config/prompts/work/audit-report-work.txt:31-97`
- 카테고리 결정: worker name `needs-uiux-claude-1` → `uiux`
- 파일명 규칙: `YYYY-MM-DD-issueNNNN-<slug>.md` (이슈 createdAt 기준)
- 본문: 이슈 body verbatim + YAML frontmatter
- 직전 PR: #2420 (3개 AppBar info icon drift) — 동일 패턴

## 테스트 / 검증

- 3개 파일 모두 `docs/reports/uiux/` 디렉토리에 정상 생성
- frontmatter YAML 형식 일관 — 직전 PR #2420 / #2416 동일 포맷
- 파일명 slug 영문 키워드: `minglit-empty-state-fullpage-icon-size-conflict` / `party-list-empty-icon-size-spec-mismatch` / `app-user-empty-state-cascade`
- 이슈 본문에 backslash-escaped quote 없음
