### PR TITLE
feat(infra): replace graphify post-commit hook with GitHub workflow

### DIFF
--- a/.github/workflows/graphify-update.yml
+++ b/.github/workflows/graphify-update.yml
@@ -1,0 +1,56 @@
+name: Graphify Auto-Update
+
+on:
+  push:
+    branches: [dev]
+    paths-ignore:
+      - 'graphify-out/**'
+  schedule:
+    - cron: '0 4 * * *'  # 04:00 UTC = 13:00 KST, daily safety net
+  workflow_dispatch:
+
+concurrency:
+  group: graphify-update
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT_VERSION_BUMP }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Cache pip
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-graphifyy-0.4.23
+
+      - name: Install graphify
+        run: pip install graphifyy==0.4.23
+
+      - name: Update graph
+        run: graphify update . --no-viz
+
+      - name: Commit & push if changed
+        run: |
+          if [[ -n "$(git status --porcelain graphify-out/)" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add graphify-out/
+            git commit -m "chore(graphify): auto-update [skip ci]"
+            git push origin dev
+          else
+            echo "No graph changes"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,12 +259,12 @@ git push
 
 ## graphify
 
-This project has a graphify knowledge graph at graphify-out/.
+This project has a graphify knowledge graph at graphify-out/. 자동 갱신은 `.github/workflows/graphify-update.yml` 워크플로우가 담당한다 (상세: `docs/infra/graphify/`).
 
 Rules:
 - Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
 - If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
 - For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
-- After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
-- `graphify-out/` 안 파일이 commit/checkout/merge 직후 dirty 로 남으면 post-commit hook 부산물 — 사용자 작업이 아님. `git checkout HEAD -- graphify-out/` 또는 `git stash` 로 자유롭게 정리 가능 (별도 승인 불필요). 새 commit 에 포함 필요한 변경(코드 수정으로 인한 그래프 변화)이면 `git add graphify-out/` 로 묶어 커밋
-- 머지 충돌이 `graphify-out/` 파일에서만 발생하면 `git checkout --theirs graphify-out/` + `graphify update .` 로 재생성하여 해결 (사용자 작업이 아닌 hook 산출물이므로 어느 쪽이든 안전)
+- 로컬에서 수동으로 `graphify update .` 하거나 `graphify-out/` 을 커밋할 필요 없다. GitHub Actions 가 dev push 와 daily schedule 로 자동 갱신한다.
+- 옛 `post-commit` hook 이 설치되어 있다면 제거한다 (`graphify hook uninstall` 또는 `rm .git/hooks/post-commit`). 상세: `docs/infra/graphify/local-setup.md`.
+- 머지 충돌이 `graphify-out/` 파일에서만 발생하면 `git checkout --theirs graphify-out/` 로 해결한다 (자동화 산출물이라 어느 쪽을 택해도 안전, 다음 워크플로우 실행에서 재계산됨).

--- a/docs/infra/graphify/BLUEDOC.md
+++ b/docs/infra/graphify/BLUEDOC.md
@@ -1,0 +1,16 @@
+# Graphify
+
+레포 코드와 문서를 분석하여 지식 그래프 (`graphify-out/`) 를 생성/갱신하는 도구. AST 추출 기반으로 LLM 비용 없이 동작하며, 아키텍처 / 코드베이스 질문에 답할 때 god node 와 community 구조를 참조한다.
+
+## 배경
+
+이전에는 `graphify hook install` 로 설치된 로컬 `post-commit` hook 이 매 커밋 후 그래프를 재빌드했다. 매 커밋마다 1270 파일 AST 추출 (수십초), 자주 viz size limit 으로 rebuild 실패, dirty 상태로 working tree 오염 등의 문제로 인해 GitHub Actions 워크플로우로 이관했다. 로컬 hook 은 더 이상 사용하지 않는다.
+
+## 문서
+
+- [github-workflow.md](./github-workflow.md) — 자동 갱신 워크플로우 동작
+- [local-setup.md](./local-setup.md) — 로컬 환경에서 옛 hook 제거 방법
+
+## 관련 컨벤션
+
+- [BLUEDOC](../bluedoc/BLUEDOC.md) — 본 폴더가 따르는 진입점 컨벤션

--- a/docs/infra/graphify/github-workflow.md
+++ b/docs/infra/graphify/github-workflow.md
@@ -1,0 +1,48 @@
+# Graphify 자동 갱신 워크플로우
+
+`.github/workflows/graphify-update.yml` 이 `graphify-out/` 을 자동으로 갱신한다. 로컬 hook 을 대체한다.
+
+## 트리거
+
+세 가지 경로로 실행된다.
+
+| 트리거 | 조건 | 용도 |
+|--------|------|------|
+| `push` | `dev` 브랜치, `graphify-out/**` 외 변경 | PR 머지 직후 즉시 갱신 |
+| `schedule` | 매일 04:00 UTC (13:00 KST) | 누락 보정용 안전망 |
+| `workflow_dispatch` | 수동 | 디버깅 / 강제 갱신 |
+
+`paths-ignore: ['graphify-out/**']` 로 자기 자신의 push 가 워크플로우를 재트리거하는 무한 루프를 막는다.
+
+## 실행 단계
+
+1. `dev` 브랜치 checkout (`GH_PAT_VERSION_BUMP` 시크릿 사용 — 보호된 브랜치에 직접 push 가능)
+2. Python 3 환경 설정
+3. `pip install graphifyy==0.4.23` (버전 핀)
+4. `graphify update . --no-viz` 실행 (viz 단계는 노드 수 5000+ 에서 실패하므로 건너뜀)
+5. `graphify-out/` 에 변경이 있으면:
+   - `chore(graphify): auto-update [skip ci]` 커밋
+   - `dev` 에 직접 push (CI 재실행 방지 위해 `[skip ci]`)
+6. 변경 없으면 종료
+
+## 동시 실행 방지
+
+`concurrency.group: graphify-update` 로 동일 그룹의 워크플로우가 동시에 돌지 않게 한다. 푸시가 빠르게 연속되면 큐잉되어 순차 실행된다. `cancel-in-progress: false` — 이미 시작된 갱신을 중간에 끊지 않는다.
+
+## 권한
+
+- `contents: write` — graphify-out 갱신 커밋용
+- `GH_PAT_VERSION_BUMP` 시크릿 — 보호된 `dev` 에 직접 push (version-bump.yml 과 동일 패턴)
+
+## 실패 시 동작
+
+- `pip install` 실패: 워크플로우 fail. 다음 push 또는 daily schedule 에서 재시도
+- `graphify update` 실패: 워크플로우 fail. `[skip ci]` 없이 종료되므로 graphify-out 갱신 안 됨 → 다음 트리거에서 재시도
+- `git push` 실패 (race condition): 워크플로우 fail. 다음 schedule 에서 재시도
+
+영구 실패 알림은 별도로 두지 않는다. daily schedule 이 safety net 역할.
+
+## 비용
+
+- AST 추출 only (LLM 호출 없음) → CI 분당 비용 ~30초 ~ 1분 수준
+- 매 dev push 마다 실행되므로 트래픽 많은 날 ~10회 실행 추정

--- a/docs/infra/graphify/local-setup.md
+++ b/docs/infra/graphify/local-setup.md
@@ -1,0 +1,49 @@
+# 로컬 환경 — 옛 hook 제거
+
+GitHub Actions 워크플로우가 `graphify-out/` 을 자동 갱신하므로, 로컬에 설치된 `post-commit` hook 은 더 이상 필요하지 않다. 오히려 다음 문제를 일으킨다.
+
+- 매 커밋마다 1270 파일 AST 추출 (수십초 지연)
+- `graphify-out/` 이 매번 dirty 로 남음 → `git pull` abort, working tree 오염
+- 노드 수 5000+ 에서 viz rebuild 실패가 매번 발생
+
+## 제거 방법
+
+### 방법 1: graphify CLI
+
+```bash
+graphify hook uninstall
+```
+
+`graphify hook install` 로 설치했다면 동일 도구로 제거 가능하다.
+
+### 방법 2: 수동 삭제
+
+```bash
+rm .git/hooks/post-commit
+rm .git/hooks/post-checkout   # graphify 가 같이 설치한 경우
+```
+
+`.git/hooks/` 는 로컬 디렉토리이므로 안전하게 삭제 가능하다 (커밋 대상 아님).
+
+### 확인
+
+```bash
+ls .git/hooks/ | grep -v sample
+```
+
+비어있거나 graphify 와 무관한 hook 만 남으면 완료.
+
+## 그래도 로컬에서 graph 를 보고 싶다면
+
+이슈 진단 등으로 즉시 최신 graph 가 필요하면 수동으로 실행한다.
+
+```bash
+graphify update . --no-viz
+```
+
+이후 커밋하지 말고 (워크플로우가 dev 에서 갱신하므로) 변경분은 버린다.
+
+```bash
+git checkout HEAD -- graphify-out/
+git clean -fd graphify-out/
+```


### PR DESCRIPTION
## Summary
- 로컬 post-commit hook 이 매 커밋마다 AST 추출 (수십초) + dirty working tree 오염 등 문제 발생 → GitHub Actions 로 이관
- 워크플로우는 \`dev\` push + daily schedule + manual dispatch 로 trigger, \`graphify-out/\` 만 갱신하여 dev 에 직접 commit
- \`docs/infra/graphify/\` 토픽 폴더에 컨벤션 명세 추가
- CLAUDE.md graphify 섹션 업데이트 (수동 갱신 불필요 명시)

## 파일

| 파일 | 역할 |
|------|------|
| \`.github/workflows/graphify-update.yml\` | 자동 갱신 워크플로우 |
| \`docs/infra/graphify/BLUEDOC.md\` | 토픽 진입점 |
| \`docs/infra/graphify/github-workflow.md\` | 워크플로우 동작 명세 |
| \`docs/infra/graphify/local-setup.md\` | 로컬 hook 제거 가이드 |
| \`CLAUDE.md\` | graphify 섹션 갱신 |

## 워크플로우 동작

- **Trigger**: \`push\` to dev (\`paths-ignore: graphify-out/**\`) + daily 04:00 UTC + \`workflow_dispatch\`
- **Auth**: \`GH_PAT_VERSION_BUMP\` 시크릿 (version-bump.yml 과 동일 패턴, 보호된 dev 직접 push)
- **Concurrency**: \`graphify-update\` group, 순차 실행
- **Install**: \`pip install graphifyy==0.4.23\` (버전 핀)
- **Push**: \`chore(graphify): auto-update [skip ci]\` 로 CI 재실행 방지

## 머지 후 사용자 액션

각 개발자가 로컬에서 옛 hook 제거 (1회):
\`\`\`bash
graphify hook uninstall
# 또는
rm .git/hooks/post-commit
\`\`\`

상세는 \`docs/infra/graphify/local-setup.md\` 참고.

## Test plan
- [x] 워크플로우 syntax 검증 (yaml)
- [x] \`GH_PAT_VERSION_BUMP\` 시크릿 존재 확인 (version-bump.yml 이 동일 시크릿 사용 중)
- [x] CLAUDE.md 의 graphify 규칙 모순 없음
- [ ] 머지 후 \`workflow_dispatch\` 로 1회 수동 실행하여 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)