### PR TITLE
docs(features): redesign FEATURE_REPORT_TEMPLATE as inspection report

### DIFF
--- a/docs/features/FEATURE_REPORT_TEMPLATE.md
+++ b/docs/features/FEATURE_REPORT_TEMPLATE.md
@@ -1,41 +1,82 @@
-# Feature Report — <카테고리 이름>
+# Feature Report — `<category>` · `<YYYY-MM-DD>`
 
-> 마지막 갱신: `<YYYY-MM-DD>`
-> 다음 갱신 예정: `<YYYY-MM-DD>` (FRESH_DOC cycle 기반)
-> 갱신 주체: 자동 워크플로우 또는 카테고리 오너
+> 인스펙션 리포트. `FRESH_DOC` cycle 트리거로 에이전트가 본 절차를 수행하고 발견 사항을 GitHub Issue 로 파일링한다. 본 문서는 **감사 추적(audit trail)** 이며, 직접 편집하지 않는다.
 
-본 리포트는 카테고리 내 피쳐들의 상태를 한눈에 보여주기 위한 자동 갱신 문서다. 직접 편집보다는 \`spec.md\` 의 frontmatter 와 GitHub 활동을 기반으로 워크플로우가 재생성하는 방식을 권장한다.
+## Summary
 
-## 1. 카테고리 요약
+`<카테고리>` 카테고리 인스펙션 결과 P1 결함 `<N>` 건, 탐지 룰 보강 `<M>` 건, P2 개선 제안 `<K>` 건 파일링.
 
-<카테고리 한두 줄 설명. 어떤 도메인을 다루는지, user/partner 어느 쪽에 어떻게 노출되는지.>
+| Severity | Count | Issues |
+|---|---|---|
+| P1 — Defect | `<N>` | `<#aaa> <#bbb>` |
+| P1 — Detection gap | `<M>` | `<#ccc> <#ddd>` |
+| P2 — Improvement | `<K>` | `<#eee> <#fff>` |
 
-## 2. 피쳐 상태 표
+---
 
-| Feature | Phase | Owner | Last Audit | 최근 활동 | 비고 |
-|---------|-------|-------|------------|----------|------|
-| `<feature-name>` | planning / active / shipped / deprecated | `@user` | `YYYY-MM-DD` | 이슈/PR 활동 요약 | |
+## P1 — Defects
 
-**Phase 정의**
-- `planning` — spec 작성 중, 구현 시작 전
-- `active` — 개발 진행 중
-- `shipped` — 사용자에게 배포 완료
-- `deprecated` — 제거 예정 또는 후속 feature 로 대체됨
+**Method**. `docs/spec-walker/screenshot/<flow>/` 의 step PNG 와 `apps/mds/docs/public/specs/<screen>/state_*.png` 를 짝지어 시각/동작 drift 점검. 동시에 최근 CI 실행에서 본 카테고리 코드 경로의 실패/플레이키 검토.
 
-## 3. 도메인 헬스
+**Findings**.
 
-- 열린 이슈: `<count>` (라벨: `feature/<category>` 또는 개별 feature 라벨)
-- 최근 30일 PR 활동: `<count>` 머지됨
-- 알려진 문제 / 드리프트: <list>
+- `<#issue>` — `<one-line finding>`. Evidence: `<spec-walk path 또는 MDS state png 또는 test name>`.
+- `<#issue>` — ...
 
-## 4. 다음 액션
+**Coverage taken**.
 
-카테고리 오너가 다음 갱신 전까지 처리할 항목.
+| 비교한 spec-walk step | 매칭된 MDS state PNG | drift 발견 |
+|---|---|---|
+| `<N>` | `<M>` | `<K>` |
 
-- [ ] <action item>
+---
 
-## 5. 변경 이력
+## P1 — Detection Gaps
 
-리포트 내용의 주요 변화 (피쳐 추가/제거/phase 변경 등).
+**Method**. 본 카테고리 spec.md 가 다루는 화면/상호작용을 enumerate 하고, (a) spec-walker `flows/` 에 매핑이 없는 항목, (b) 코드 변경 빈도 대비 단위/widget/E2E 테스트가 부족한 영역 식별. 이런 누락은 P1 인스펙션 자체의 신뢰도를 낮추므로 P1 으로 다룬다.
 
-- `YYYY-MM-DD`: <변경 내용>
+**Findings**.
+
+- `<#issue>` — `<누락된 spec-walk flow 또는 테스트 영역>`. Why it matters: `<없으면 다음 cycle 에 어떤 결함을 놓치는지>`.
+- `<#issue>` — ...
+
+**Coverage taken**.
+
+| 누락된 spec-walk path | 테스트 보강 권고 영역 |
+|---|---|
+| `<N>` | `<M>` |
+
+---
+
+## P2 — Improvements
+
+**Method**. 최근 30일의 본 카테고리 관련 이슈/PR 트렌드, 리뷰 코멘트 테마, 코드 hot spot, 워크플로우 비효율 지점에서 (a) production UX 개선, (b) 개발 리소스 효율화, (c) 워크플로우 자동화 강화 제안 도출.
+
+**Findings**.
+
+- `<#issue>` — `<제안 한 줄>`. Impact: `<low/med/high>`. Effort: `<S/M/L>`.
+- `<#issue>` — ...
+
+---
+
+## Inputs Consulted
+
+- **spec-walk**: `docs/spec-walker/screenshot/{<flows>}/` — `<N>` flow × `<M>` step (latest walk: `<YYYY-MM-DD>`)
+- **MDS specs**: `apps/mds/docs/public/specs/{<screens>}/` — `<N>` screen / `<M>` state PNG
+- **Tests reviewed**:
+  - Flutter unit/widget/golden — `apps/app_{user,partner}/test/` (golden via alchemist)
+  - Flutter integration — `apps/app_user/test/integration/`
+  - Patrol E2E (weekly) — `patrol_test/`, last run `<YYYY-MM-DD>`: `<status>`
+  - pgTAP — `supabase/tests/database/`, `<count>` tests
+  - Edge functions (Deno) — `supabase/functions/*/*_test.ts`, `<count>` tests
+- **카테고리 spec**: `docs/features/<category>/<feature>/spec.md` × `<N>`
+- **Recent activity**: 최근 30일 본 카테고리 관련 이슈 `<count>` / PR `<count>`
+
+---
+
+## Run Metadata
+
+- Agent: `<runner id>`
+- Duration: `<HH:MM>`
+- Cycle: `<Nd>` (next: `<YYYY-MM-DD>`)
+- Template version: `<git sha>`


### PR DESCRIPTION
## Summary
이전 \`FEATURE_REPORT_TEMPLATE.md\` 는 양식에 가까웠다. **인스펙션 리포트** 형식으로 재작성:
- 결과 우선 (Summary 테이블이 lead)
- Method / Findings / Coverage 패턴으로 3개 섹션 통일
- 이슈 파일링이 1차 산출물, 리포트는 **audit trail**

## 3개 섹션

| 섹션 | 입력 | 처리 |
|------|------|------|
| P1 Defects | spec-walk PNG ↔ MDS state PNG, 최근 CI 실패 | 시각 / 동작 drift, 테스트 실패 → 이슈 |
| P1 Detection Gaps | spec.md 가 다루는 화면 / 테스트 커버리지 | spec-walk 누락 + 테스트 부족 → 이슈 (다음 cycle 신뢰도 보장) |
| P2 Improvements | 최근 30일 이슈 / PR 트렌드, 코드 hot spot | UX / 리소스 / 자동화 제안 → 이슈 |

## 실제 자원 명시
- spec-walk: \`docs/spec-walker/screenshot/<flow>/\`
- MDS state PNG: \`apps/mds/docs/public/specs/<screen>/state_*.png\`
- 테스트: Flutter unit/widget/golden(alchemist), integration, Patrol E2E (weekly), pgTAP, Deno EF tests

## Test plan
- [x] 템플릿 placeholder 가 워크플로우 구현 시 채워질 수 있는 형태인지 검토
- [x] 카테고리 generic 유지 (카테고리별 차이는 FRESH_DOC \`refresh_method\` 에서)

🤖 Generated with [Claude Code](https://claude.com/claude-code)