### PR TITLE
ci: migrate all workflows to self-hosted runner (except iOS)

### DIFF
--- a/.github/workflows/allure-report.yml
+++ b/.github/workflows/allure-report.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   generate-report:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: write
     steps:

--- a/.github/workflows/android-deploy-reusable.yml
+++ b/.github/workflows/android-deploy-reusable.yml
@@ -61,7 +61,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
     defaults:
       run:

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   auto-format:
     if: ${{ github.event.pull_request.head.repo.fork == false }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   add-needs-review:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Add needs-review label
         env:

--- a/.github/workflows/auto-update-branches.yml
+++ b/.github/workflows/auto-update-branches.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   update-branches:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     # Fix #1972: job-level permissions — only what update-branch needs
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   # Migration version 중복 검사 (항상 실행 — path filter 없음)
   check-migration-versions:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v6
       - name: Check duplicate migration versions
@@ -48,7 +48,7 @@ jobs:
 
   # env-manifest.json ↔ EnvKeyStore drift 검사 (항상 실행 — path filter 없음)
   check-env-manifest-sync:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v6
       - name: Check env-manifest.json / EnvKeyStore sync
@@ -56,7 +56,7 @@ jobs:
 
   # 변경 사항 감지 Job
   changes:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
       pull-requests: read
@@ -109,7 +109,7 @@ jobs:
     name: test-app-unit-widget-golden
     needs: changes
     if: ${{ needs.changes.outputs.app_user == 'true' || needs.changes.outputs.app_partner == 'true' || needs.changes.outputs.minglit_kit == 'true' || needs.changes.outputs.mds_core == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: write
       checks: write
@@ -290,7 +290,7 @@ jobs:
     name: lint-and-build-landing-user
     needs: changes
     if: ${{ needs.changes.outputs.landing_user == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     defaults:
       run:
         working-directory: ./apps/landing_user
@@ -311,7 +311,7 @@ jobs:
     name: lint-and-build-landing-partner
     needs: changes
     if: ${{ needs.changes.outputs.landing_partner == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     defaults:
       run:
         working-directory: ./apps/landing_partner
@@ -332,7 +332,7 @@ jobs:
     name: lint-and-build-mds-docs
     needs: changes
     if: ${{ needs.changes.outputs.mds_docs == 'true' || needs.changes.outputs.mds_tokens == 'true' || needs.changes.outputs.mds_icons == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     defaults:
       run:
         working-directory: ./apps/mds/docs
@@ -354,7 +354,7 @@ jobs:
     name: lint-mds-icons
     needs: changes
     if: ${{ needs.changes.outputs.mds_icons == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     defaults:
       run:
         working-directory: ./shared/packages/mds/icons
@@ -386,7 +386,7 @@ jobs:
     name: test-pgtap
     needs: changes
     if: ${{ needs.changes.outputs.supabase == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v6
       - uses: supabase/setup-cli@v2
@@ -415,7 +415,7 @@ jobs:
     name: test-deno-ef
     needs: changes
     if: ${{ needs.changes.outputs.supabase == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v6
       - uses: denoland/setup-deno@v2
@@ -468,7 +468,7 @@ jobs:
 
   # Workflow YAML 파싱 검증 (항상 실행 — db-invariants #1593 회귀 방지)
   check-workflow-yaml:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v6
       - name: Validate all workflow YAML files
@@ -493,7 +493,7 @@ jobs:
   # runner와 orchestrator는 동일 major.minor 계열이어야 함 (1.5.x↔1.5.x, 1.6.x↔1.6.x)
   # Gradle consistent resolution이 혼용 시 빌드 실패를 발생시키므로 PR 단계에서 사전 차단.
   check-android-test-deps:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v6
       - name: Verify androidx.test runner/orchestrator version alignment
@@ -518,7 +518,7 @@ jobs:
 
   # Fix #1872: block new cross-feature imports; existing violations are grandfathered in baseline
   check-cross-feature-imports:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v6
       - name: Check cross-feature imports
@@ -527,7 +527,7 @@ jobs:
   ci-result:
     needs: [check-migration-versions, check-env-manifest-sync, check-workflow-yaml, check-android-test-deps, check-cross-feature-imports, test-flutter-apps, lint-landing-user, lint-landing-partner, lint-mds-docs, lint-mds-icons, test-supabase, test-edge-functions]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Check CI results
         env:

--- a/.github/workflows/daily-backend-simulation.yml
+++ b/.github/workflows/daily-backend-simulation.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   seed-and-simulate:
     name: Seed and Simulate
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -84,7 +84,7 @@ jobs:
 
   client-cuj-test:
     needs: seed-and-simulate
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -134,7 +134,7 @@ jobs:
 
   partner-cuj-test:
     needs: seed-and-simulate
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/db-invariants.yml
+++ b/.github/workflows/db-invariants.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   check:
     name: Run DB invariant checks
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Fetch Dependabot metadata
         id: metadata

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   deploy-app_user:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' && 'production' || 'preview' }}
     outputs:
       accessible-url: ${{ steps.deploy.outputs.accessible-url }}
@@ -51,7 +51,7 @@ jobs:
           STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
 
   deploy-landing_user:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' && 'production' || 'preview' }}
     outputs:
       accessible-url: ${{ steps.deploy.outputs.accessible-url }}
@@ -71,7 +71,7 @@ jobs:
           deploy-branch: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name }}
 
   deploy-landing_partner:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' && 'production' || 'preview' }}
     outputs:
       accessible-url: ${{ steps.deploy.outputs.accessible-url }}
@@ -91,7 +91,7 @@ jobs:
           deploy-branch: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name }}
 
   deploy-app_partner:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' && 'production' || 'preview' }}
     outputs:
       accessible-url: ${{ steps.deploy.outputs.accessible-url }}
@@ -125,7 +125,7 @@ jobs:
   # 3. Add GitHub Actions secret: VERCEL_MDS_DOCS_PROJECT_ID = <project-id>
   # The VERCEL_TOKEN and VERCEL_ORG_ID secrets are already shared.
   deploy-mds_docs:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' && 'production' || 'preview' }}
     outputs:
       accessible-url: ${{ steps.deploy.outputs.accessible-url }}
@@ -147,7 +147,7 @@ jobs:
   smoke-test:
     needs: [deploy-app_user, deploy-landing_user, deploy-landing_partner, deploy-app_partner, deploy-mds_docs]
     if: success()
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       IS_PROD: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' }}
     steps:

--- a/.github/workflows/graphify-update.yml
+++ b/.github/workflows/graphify-update.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/hourly-tick-simulator.yml
+++ b/.github/workflows/hourly-tick-simulator.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   simulate:
     name: Run User Activity Simulation
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     steps:
       - name: Run user activity simulation

--- a/.github/workflows/mds-spec-change-issue.yml
+++ b/.github/workflows/mds-spec-change-issue.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   file-issue:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   notify:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       issues: write
     steps:

--- a/.github/workflows/patrol-e2e.yml
+++ b/.github/workflows/patrol-e2e.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   patrol-e2e-app-user:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/render-spec-mockups.yml
+++ b/.github/workflows/render-spec-mockups.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   render:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/review-presence.yml
+++ b/.github/workflows/review-presence.yml
@@ -30,7 +30,7 @@ jobs:
     if: >
       github.event_name != 'issue_comment' ||
       github.event.issue.pull_request != null
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Check review presence
         uses: actions/github-script@v9

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   gitleaks:
     name: Gitleaks Secret Scan
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
     steps:

--- a/.github/workflows/seed-dev.yml
+++ b/.github/workflows/seed-dev.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   seed:
     name: Run Seeder
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     # Safety Guard 1: Only run on dev branch, or if manually triggered.
     # Also ensures the triggering workflow (migrations) was successful.
     if: >

--- a/.github/workflows/slash-label.yml
+++ b/.github/workflows/slash-label.yml
@@ -13,7 +13,7 @@ jobs:
       github.event.issue.pull_request == null &&
       contains(github.event.comment.body, '/needs-') &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     concurrency:
       group: slash-label-issue-${{ github.event.issue.number }}
       cancel-in-progress: false

--- a/.github/workflows/supabase-deploy.yml
+++ b/.github/workflows/supabase-deploy.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/update-goldens.yml
+++ b/.github/workflows/update-goldens.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   update-goldens:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: write
     strategy:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -18,7 +18,7 @@ jobs:
     if: >-
       github.event.pull_request.merged == true &&
       !startsWith(github.event.pull_request.title, 'chore: bump version')
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

23개 워크플로우 파일의 `runs-on: ubuntu-latest` → `runs-on: self-hosted` 일괄 변경. `ios-deploy-user/partner.yml` 의 `macos-15` (Xcode 16+ 필수, Fix #2371) 는 그대로 유지.

## 변경 분포

| 파일 | 변경 건수 |
|---|---|
| `ci.yml` | 14 |
| `deploy.yml` | 6 |
| `daily-backend-simulation.yml` | 3 |
| 나머지 20개 워크플로우 | 각 1 |
| **합계** | **43건 (insertions=deletions)** |

## 배경 / 동기

- `supabase-deploy.yml` 이 5/13 부터 연속 실패 — hosted runner 가 GitHub Actions secrets API 호출 시 HTTP 403 (`Resource not accessible by integration`) 반환. PR #2456 의 `20260516000001` user_event_feed RPC 마이그가 dev 에 적용되지 못한 직접 원인.
- self-hosted 러너는 등록 시 부여된 자격증명으로 secrets API 직접 호출 가능 → 권한 문제 해소.
- 동시에 다른 워크플로우들도 일관된 실행 환경으로 통일.

## Test plan

### 정적 (CI)
- [ ] `check-workflow-yaml` — YAML 문법 통과
- [ ] `ci-result` — 본 PR 의 CI 자체가 self-hosted 에서 도는지 확인

### 동적 (머지 후)
- [ ] 다음 push to dev 시 자동으로 `supabase-deploy` 가 self-hosted 에서 실행 → success
- [ ] PR #2456 의 마이그 (`20260516000001`) 가 dev DB 에 적용됨 → `partners.status` reference 사라짐
- [ ] axiom 에서 `user-event-feed` 의 `column pr.status does not exist` 에러 멈춤
- [ ] 다음 `hourly-tick-simulator` :30 run 에서 `total_actions > 0` 회복

## Constraint / Risk

- iOS 빌드 (`ios-deploy-*.yml`) 는 macOS 필수 (#2371) → macos-15 유지
- **broad scope** — 모든 워크플로우의 실행 환경이 바뀜
- self-hosted 러너 오프라인 시 모든 자동 워크플로우가 queue 에 쌓임 (GHA 는 native fallback 없음). 러너 헬스 모니터링 필수
- 첫 트리거에서 각 워크플로우의 setup-* action / toolchain 가용성 검증 필요

## Rejected alternatives

- `dispatcher input + dynamic runs-on` (selectable per dispatch): 단순화 우선, self-hosted 등록된 지금 fallback 로직 불필요
- `사전 가용성 체크 후 동적 라우팅` (C2 패턴): 오버엔지니어링, 러너 헬스는 별도 모니터링이 맞음

## Related

- #2456 — user_event_feed RPC 수정 (deploy 가 self-hosted 로 가야 dev 적용)
- #2371 — Xcode 16+ 필수 (macos-15 유지 근거)

🤖 Generated with [Claude Code](https://claude.com/claude-code)