### PR TITLE
fix(simulator): accept 'approved' for free-event apply assertions

### DIFF
--- a/supabase/functions/backend-simulator/tick/actions/user_action_apply.ts
+++ b/supabase/functions/backend-simulator/tick/actions/user_action_apply.ts
@@ -75,12 +75,15 @@ export class UserActionApplyEvent extends SimAction {
         };
       }
 
-      const validStatuses = ["paid", "pending_review"];
+      // Fix #1660: apply-event EF 가 무료 이벤트(price=0) + 검증 없음 케이스에서
+      // status를 'approved'로 박음 (paid 가 아님 — payment_id NULL). 검증 있는 무료/유료는
+      // 'pending_review'/'paid'. 세 상태 모두 정상 apply 결과로 인정.
+      const validStatuses = ["paid", "pending_review", "approved"];
       if (!validStatuses.includes(data.status as string)) {
         return {
           passed: false,
           name: "apply_db_status",
-          details: `expected status in (paid, pending_review), got '${data.status}'`,
+          details: `expected status in (paid, pending_review, approved), got '${data.status}'`,
         };
       }
 

--- a/supabase/functions/backend-simulator/tick/actions/user_action_apply_test.ts
+++ b/supabase/functions/backend-simulator/tick/actions/user_action_apply_test.ts
@@ -122,6 +122,18 @@ Deno.test({
 });
 
 Deno.test({
+  // Fix #1660: apply-event EF 가 무료 이벤트(price=0) + 검증 없음 케이스에서 status='approved' 로
+  // application 생성 (payment_id NULL). 정상 apply 결과로 인정해야 함.
+  name: "UserActionApplyEvent.assertDBState - passes when row exists with status=approved (free event path)",
+  fn: async () => {
+    const mock = mockWithApplication({ id: "app-1", status: "approved" });
+    const result = await newAction().assertDBState(mock as unknown as SupabaseClient);
+    assertEquals(result.passed, true);
+    assertEquals(result.details.includes("approved"), true);
+  },
+});
+
+Deno.test({
   name: "UserActionApplyEvent.assertDBState - fails when application row missing",
   fn: async () => {
     const mock = mockWithApplication(null);
@@ -134,7 +146,8 @@ Deno.test({
 Deno.test({
   name: "UserActionApplyEvent.assertDBState - fails on unexpected application status",
   fn: async () => {
-    for (const status of ["cancelled", "refunded", "rejected", "approved"]) {
+    // 'approved' 는 Fix #1660 으로 유효 상태에 포함됨 — 본 케이스에서 제외
+    for (const status of ["cancelled", "refunded", "rejected"]) {
       const mock = mockWithApplication({ id: "app-1", status });
       const result = await newAction().assertDBState(mock as unknown as SupabaseClient);
       assertEquals(result.passed, false, `status=${status} must fail apply assertion`);


### PR DESCRIPTION
## Summary

`tick/actions/user_action_apply.ts:78` 의 `validStatuses` 가 `["paid", "pending_review"]` 만 인정해서 **무료 이벤트(price=0) + 검증 없음** 케이스에 EF 가 생성한 `'approved'` 상태 application 을 fail 로 분류.

`apply-event` EF L364 (Fix #1660) 에 명시:
```ts
// free re-applications use 'approved' (not 'paid') — payment_id is null for free events
const newStatus = verifItems.length > 0 ? "pending_review" : "approved";
```

즉 simulator 는 Fix #1660 이후 contract drift 상태였음.

## 증상

PR #2456 (RPC 수정) 머지 후 첫 tick run 에서 발견:
- run_id: `1acb22b3-9c81-4da4-ae40-2ef4c048b078` (2026-05-17 14:59)
- 5/5 Apply 액션이 EF 200 + DB row 생성 성공
- 그런데 SUT 가 모두 fail 처리:
  ```
  expected status in (paid, pending_review), got 'approved'
  ```
- workflow fail → 자동 이슈 #2459 생성

## 변경

- `user_action_apply.ts`: `validStatuses` 에 `'approved'` 추가, error message 갱신, Fix #1660 참조 주석
- `user_action_apply_test.ts`:
  - `'approved'` happy path 케이스 신규 추가 (free event path 명시)
  - 기존 'unexpected status' 루프에서 `'approved'` 제거 (이제 유효)

## Test plan

### 정적
- [x] 로컬 deno 테스트 12/12 통과 (1 신규 + 기존 11)
- [ ] CI `test-edge-functions` 통과

### 동적 (머지 후 dev)
- [ ] 다음 :30 hourly-tick-simulator 자동 실행 → response `success: true, failed: 0`
- [ ] axiom `backend-simulator` completed 로그의 `metadata.status` 가 200 (이전 500)
- [ ] 자동 GH 이슈 (`[E2E-SIM] N failures`) 생성되지 않음

## Constraint / Risk

- `apply-event` EF 가 4가지 상태 분기(`paid`/`payment_pending`/`pending_review`/`approved`). 본 SUT 는 apply 직후 시점 검증이라 `payment_pending` 은 의도적 제외 (결제 confirm 시 `paid` 로 갱신되는 흐름)
- `payment_pending` race: ActionRunner 가 EF 200 즉시 DB assert 하므로 payment_confirm 이 async 라면 `paid` 갱신 전 검사 가능. 현재는 동기 처리라 영향 없음 — 추후 async 전환 시 재검토

## Related

- #2456 — RPC fix (tick 을 0 actions 에서 살려낸 직전 PR — 이 PR 머지 결과로 drift 가 드러남)
- #2459 — 본 drift 로 인해 자동 생성된 실패 리포트 (본 PR 머지 후 다음 tick 에서 자동 해소 예상)
- Fix #1660 — EF 쪽 free-event approved 도입 시점

🤖 Generated with [Claude Code](https://claude.com/claude-code)