### PR TITLE
chore(workflows): 7-prefix naming convention

### DIFF
--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -1,0 +1,31 @@
+# GitHub Workflows
+
+`.github/workflows/` 의 진입점. 워크플로우를 추가하거나 수정하기 전에 이 파일을 먼저 읽고 prefix 컨벤션을 따른다.
+
+## 배경
+
+기존 파일명·`name:` 규칙이 제각각이었다 (`auto-format.yml`, `Deploy to Vercel`, `Hourly: DB Invariant Monitor`, ...). PR Checks 화면에서 *"이게 머지를 막는 건지 / 배포인지 / 단순 자동화인지"* 한눈에 안 잡힘. **"빨갛게 뜨면 무슨 일이 일어나나"** 를 축으로 7 개 prefix 로 통일했다.
+
+## Prefix
+
+| Prefix | 빨갛게 뜨면 = | 예시 파일 |
+|---|---|---|
+| `pr-gate-` | **머지 못 함** (required check) | `pr-gate.yml` |
+| `deploy-` | 사용자·dev 환경에 코드·스키마·시드가 안 갔음 | `deploy-vercel`, `deploy-supabase`, `deploy-android-user`, `deploy-ios-user`, `deploy-dev-seed` |
+| `monitor-` | 운영·테스트 시스템 헬스 이상 (스케줄) | `monitor-db-invariants`, `monitor-tick-user`, `monitor-daily-lifecycle`, `monitor-allure` |
+| `sync-` | repo 에 자동 commit/push 가 실패함 | `sync-format`, `sync-version`, `sync-graphify`, `sync-mds-mockups`, `sync-pr-branches` |
+| `triage-` | PR·이슈 라벨·머지·검증 자동화 실패 (commit 없음) | `triage-label`, `triage-secret-scan`, `triage-review`, `triage-dependabot`, `triage-mds-issue` |
+| `tool-` | (수동으로 부를 때만 도는 도구) | (현재 없음 — 새 수동 도구 추가 시 prefix) |
+| `shared-` | (다른 워크플로우의 부품 — 단독 실행 X) | `shared-notify`, `shared-android-deploy` |
+
+## 컨벤션
+
+- **파일명 = workflow `name:` 필드** (소문자 kebab, 확장자 제외). 예: `deploy-vercel.yml` 의 `name: deploy-vercel`.
+- prefix 다음은 *대상*만 적는다. 액션 동사는 prefix 가 이미 함의함 (`deploy-vercel` ◯ / `deploy-to-vercel` ✗).
+- 새 워크플로우는 위 7 prefix 중 하나에 반드시 속해야 한다. 어디에도 안 맞으면 새 prefix 추가 PR 을 먼저 낸다.
+- `sync-` vs `triage-` 의 기준: **repo 에 commit 이 들어가나** = `sync-`, 라벨·이슈·검증만 = `triage-`.
+
+## 관련
+
+- [BLUEDOC](../../docs/infra/bluedoc/BLUEDOC.md) — 본 파일이 따르는 진입점 컨벤션
+- [CLAUDE.md](../../CLAUDE.md) `## PR Conventions` — required check (`ci-result` job = `pr-gate.yml` 내부) / auto-merge 흐름

--- a/.github/workflows/deploy-android-partner.yml
+++ b/.github/workflows/deploy-android-partner.yml
@@ -1,4 +1,4 @@
-name: Android Build & Deploy (Partner)
+name: deploy-android-partner
 
 on:
   push:
@@ -12,12 +12,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: android-partner-${{ github.ref }}
+  group: deploy-android-partner-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   deploy:
-    uses: ./.github/workflows/android-deploy-reusable.yml
+    uses: ./.github/workflows/shared-android-deploy.yml
     with:
       app-name: partner
       app-directory: apps/app_partner

--- a/.github/workflows/deploy-android-user.yml
+++ b/.github/workflows/deploy-android-user.yml
@@ -1,4 +1,4 @@
-name: Android Build & Deploy (User)
+name: deploy-android-user
 
 on:
   push:
@@ -12,12 +12,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: android-user-${{ github.ref }}
+  group: deploy-android-user-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   deploy:
-    uses: ./.github/workflows/android-deploy-reusable.yml
+    uses: ./.github/workflows/shared-android-deploy.yml
     with:
       app-name: user
       app-directory: apps/app_user

--- a/.github/workflows/deploy-dev-seed.yml
+++ b/.github/workflows/deploy-dev-seed.yml
@@ -1,9 +1,9 @@
-name: Seed Dev Database
+name: deploy-dev-seed
 
 on:
   workflow_dispatch: # Manual trigger
   workflow_run:      # Auto-trigger after migration
-    workflows: ["Deploy Supabase Migrations"]
+    workflows: ["deploy-supabase"]
     types:
       - completed
     branches:
@@ -63,7 +63,7 @@ jobs:
     if: ${{ always() && needs.seed.result == 'failure' }}
     permissions:
       issues: write
-    uses: ./.github/workflows/notify-failure.yml
+    uses: ./.github/workflows/shared-notify.yml
     with:
       success: ${{ needs.seed.result == 'success' }}
       workflow_name: 'Seed Dev'

--- a/.github/workflows/deploy-ios-partner.yml
+++ b/.github/workflows/deploy-ios-partner.yml
@@ -1,4 +1,4 @@
-name: iOS Partner App Deploy
+name: deploy-ios-partner
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ios-partner-${{ github.ref }}
+  group: deploy-ios-partner-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -54,7 +54,7 @@ jobs:
     if: always()
     permissions:
       issues: write
-    uses: ./.github/workflows/notify-failure.yml
+    uses: ./.github/workflows/shared-notify.yml
     with:
       success: ${{ needs.ios-deploy.result == 'success' }}
       workflow_name: 'iOS Deploy Partner'

--- a/.github/workflows/deploy-ios-user.yml
+++ b/.github/workflows/deploy-ios-user.yml
@@ -1,4 +1,4 @@
-name: iOS User App Deploy
+name: deploy-ios-user
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ios-user-${{ github.ref }}
+  group: deploy-ios-user-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -53,7 +53,7 @@ jobs:
     if: always()
     permissions:
       issues: write
-    uses: ./.github/workflows/notify-failure.yml
+    uses: ./.github/workflows/shared-notify.yml
     with:
       success: ${{ needs.ios-deploy.result == 'success' }}
       workflow_name: 'iOS Deploy User'

--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -1,4 +1,4 @@
-name: Deploy Supabase Migrations
+name: deploy-supabase
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: supabase-${{ github.ref }}
+  group: deploy-supabase-${{ github.ref }}
   cancel-in-progress: false   # DB 마이그레이션 보호 — 부분 적용 방지
 
 jobs:
@@ -354,7 +354,7 @@ jobs:
     if: always()
     permissions:
       issues: write
-    uses: ./.github/workflows/notify-failure.yml
+    uses: ./.github/workflows/shared-notify.yml
     with:
       success: ${{ needs.deploy.result == 'success' }}
       workflow_name: 'Deploy Supabase Migrations'

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -1,4 +1,4 @@
-name: Deploy to Vercel
+name: deploy-vercel
 
 # NOTE: Consider adding status badges to README.
 
@@ -17,7 +17,7 @@ on:
           - main
 
 concurrency:
-  group: vercel-${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name }}
+  group: deploy-vercel-${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -222,7 +222,7 @@ jobs:
     if: always()
     permissions:
       issues: write
-    uses: ./.github/workflows/notify-failure.yml
+    uses: ./.github/workflows/shared-notify.yml
     with:
       success: ${{ !contains(needs.*.result, 'failure') }}
       workflow_name: 'Vercel Deploy'

--- a/.github/workflows/monitor-allure.yml
+++ b/.github/workflows/monitor-allure.yml
@@ -1,4 +1,4 @@
-name: "Daily: Allure Test Report Aggregation"
+name: monitor-allure
 
 on:
   schedule:
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: allure-report
+  group: monitor-allure
   cancel-in-progress: true
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
       - name: Download Allure Results (app_user)
         uses: dawidd6/action-download-artifact@v21
         with:
-          workflow: ci.yml
+          workflow: pr-gate.yml
           name: allure-results-app_user
           path: allure-results/
           if_no_artifact_found: warn
@@ -33,7 +33,7 @@ jobs:
       - name: Download Allure Results (app_partner)
         uses: dawidd6/action-download-artifact@v21
         with:
-          workflow: ci.yml
+          workflow: pr-gate.yml
           name: allure-results-app_partner
           path: allure-results/
           if_no_artifact_found: warn
@@ -42,7 +42,7 @@ jobs:
       - name: Download Allure Results (minglit_kit)
         uses: dawidd6/action-download-artifact@v21
         with:
-          workflow: ci.yml
+          workflow: pr-gate.yml
           name: allure-results-minglit_kit
           path: allure-results/
           if_no_artifact_found: warn
@@ -52,7 +52,7 @@ jobs:
       - name: Download Coverage (app_user)
         uses: dawidd6/action-download-artifact@v21
         with:
-          workflow: ci.yml
+          workflow: pr-gate.yml
           name: app-user-coverage
           path: coverage/app_user/
           if_no_artifact_found: warn
@@ -61,7 +61,7 @@ jobs:
       - name: Download Coverage (app_partner)
         uses: dawidd6/action-download-artifact@v21
         with:
-          workflow: ci.yml
+          workflow: pr-gate.yml
           name: app-partner-coverage
           path: coverage/app_partner/
           if_no_artifact_found: warn
@@ -70,7 +70,7 @@ jobs:
       - name: Download Coverage (minglit_kit)
         uses: dawidd6/action-download-artifact@v21
         with:
-          workflow: ci.yml
+          workflow: pr-gate.yml
           name: minglit-kit-coverage
           path: coverage/minglit_kit/
           if_no_artifact_found: warn

--- a/.github/workflows/monitor-daily-lifecycle.yml
+++ b/.github/workflows/monitor-daily-lifecycle.yml
@@ -1,4 +1,4 @@
-name: "Daily: Tick Simulator Pipeline + Emulator CUJ"
+name: monitor-daily-lifecycle
 
 on:
   schedule:
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: supabase-dev-simulation
+  group: monitor-supabase-dev-sim
   cancel-in-progress: false
 
 jobs:
@@ -187,7 +187,7 @@ jobs:
     if: always()
     permissions:
       issues: write
-    uses: ./.github/workflows/notify-failure.yml
+    uses: ./.github/workflows/shared-notify.yml
     with:
       success: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
       workflow_name: 'Daily: Tick Simulator Pipeline + Emulator CUJ'

--- a/.github/workflows/monitor-db-invariants.yml
+++ b/.github/workflows/monitor-db-invariants.yml
@@ -1,4 +1,4 @@
-name: "Hourly: DB Invariant Monitor"
+name: monitor-db-invariants
 
 on:
   schedule:
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: db-invariant-monitor
+  group: monitor-db-invariants
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/monitor-patrol-e2e.yml
+++ b/.github/workflows/monitor-patrol-e2e.yml
@@ -9,7 +9,7 @@
 #
 # Fix #1673: patrol_cli 4.x requires patrol_test/ directory — moved tests from integration_test/
 
-name: "Weekly: Emulator Test (Patrol native surface)"
+name: monitor-patrol-e2e
 
 on:
   schedule:
@@ -18,7 +18,7 @@ on:
 
 # Fix #1457: schedule + manual 실행 겹침 시 병렬 실행 방지
 concurrency:
-  group: patrol-e2e
+  group: monitor-patrol-e2e
   cancel-in-progress: false
 
 jobs:
@@ -30,7 +30,7 @@ jobs:
 
       # Fix: CI checkout does not include the private minglit_env submodule.
       # Rebuild the dev Flutter env file from Actions secrets before running Patrol.
-      # Same pattern as daily-backend-simulation.yml (Fix #1169).
+      # Same pattern as monitor-daily-lifecycle.yml (Fix #1169).
       - name: Create dev Flutter env file
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_DEV_URL }}

--- a/.github/workflows/monitor-tick-user.yml
+++ b/.github/workflows/monitor-tick-user.yml
@@ -1,4 +1,4 @@
-name: "Hourly: Tick Simulator (user activity mode)"
+name: monitor-tick-user
 
 on:
   schedule:
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: supabase-dev-simulation
+  group: monitor-supabase-dev-sim
   cancel-in-progress: false
 
 jobs:
@@ -29,7 +29,7 @@ jobs:
     if: always()
     permissions:
       issues: write
-    uses: ./.github/workflows/notify-failure.yml
+    uses: ./.github/workflows/shared-notify.yml
     with:
       success: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
       workflow_name: 'Hourly Tick Simulator (user activity mode)'

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,4 +1,4 @@
-name: "CI: Unit + Widget + Golden + pgTAP + Deno EF + Landing Lint"
+name: pr-gate
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
   merge_group:
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.ref }}
+  group: pr-gate-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/shared-android-deploy.yml
+++ b/.github/workflows/shared-android-deploy.yml
@@ -1,4 +1,4 @@
-name: Android Build & Deploy (Reusable)
+name: shared-android-deploy
 
 on:
   workflow_call:
@@ -170,7 +170,7 @@ jobs:
     if: always()
     permissions:
       issues: write
-    uses: ./.github/workflows/notify-failure.yml
+    uses: ./.github/workflows/shared-notify.yml
     with:
       success: ${{ needs.build.result == 'success' }}
       workflow_name: ${{ inputs.notify-workflow-name }}

--- a/.github/workflows/shared-notify.yml
+++ b/.github/workflows/shared-notify.yml
@@ -1,4 +1,4 @@
-name: Notify CI Failure
+name: shared-notify
 
 on:
   workflow_call:

--- a/.github/workflows/sync-format.yml
+++ b/.github/workflows/sync-format.yml
@@ -1,4 +1,4 @@
-name: Auto Format PR
+name: sync-format
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize, reopened]
 
 concurrency:
-  group: auto-format-${{ github.event.pull_request.number }}
+  group: sync-format-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:
@@ -75,7 +75,7 @@ jobs:
     if: ${{ always() && needs.auto-format.result == 'failure' }}
     permissions:
       issues: write
-    uses: ./.github/workflows/notify-failure.yml
+    uses: ./.github/workflows/shared-notify.yml
     with:
       success: false
       workflow_name: 'Auto Format'

--- a/.github/workflows/sync-graphify.yml
+++ b/.github/workflows/sync-graphify.yml
@@ -1,4 +1,4 @@
-name: Graphify Auto-Update
+name: sync-graphify
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: graphify-update
+  group: sync-graphify
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/sync-mds-mockups.yml
+++ b/.github/workflows/sync-mds-mockups.yml
@@ -1,4 +1,4 @@
-name: Render MDS spec mockups
+name: sync-mds-mockups
 
 on:
   push:
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: render-spec-mockups
+  group: sync-mds-mockups
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/sync-pr-branches.yml
+++ b/.github/workflows/sync-pr-branches.yml
@@ -1,4 +1,4 @@
-name: Auto-update PR branches
+name: sync-pr-branches
 
 on:
   push:

--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -1,4 +1,4 @@
-name: Version Bump
+name: sync-version
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
     branches: [dev, main]
 
 concurrency:
-  group: version-bump-${{ github.base_ref }}
+  group: sync-version-${{ github.base_ref }}
   cancel-in-progress: false
 
 permissions:
@@ -108,7 +108,7 @@ jobs:
     if: always()
     permissions:
       issues: write
-    uses: ./.github/workflows/notify-failure.yml
+    uses: ./.github/workflows/shared-notify.yml
     with:
       success: ${{ needs.bump.result == 'success' || needs.bump.result == 'skipped' }}
       workflow_name: 'Version Bump'

--- a/.github/workflows/triage-dependabot.yml
+++ b/.github/workflows/triage-dependabot.yml
@@ -1,4 +1,4 @@
-name: Dependabot Auto-Merge
+name: triage-dependabot
 
 on:
   pull_request:

--- a/.github/workflows/triage-label.yml
+++ b/.github/workflows/triage-label.yml
@@ -1,4 +1,4 @@
-name: Auto Label PR
+name: triage-label
 
 on:
   pull_request:

--- a/.github/workflows/triage-mds-issue.yml
+++ b/.github/workflows/triage-mds-issue.yml
@@ -1,4 +1,4 @@
-name: MDS Spec Change → Issue
+name: triage-mds-issue
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
       - 'apps/mds/docs/src/components/specs/**'
 
 concurrency:
-  group: mds-spec-change-issue-${{ github.ref }}
+  group: triage-mds-issue-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/triage-review.yml
+++ b/.github/workflows/triage-review.yml
@@ -1,4 +1,4 @@
-name: review-presence
+name: triage-review
 
 on:
   pull_request:

--- a/.github/workflows/triage-secret-scan.yml
+++ b/.github/workflows/triage-secret-scan.yml
@@ -1,11 +1,11 @@
-name: "PR: Gitleaks Secret Scan"
+name: triage-secret-scan
 
 on:
   pull_request:
     branches: [ "main", "dev" ]
 
 concurrency:
-  group: secret-scan-${{ github.event.pull_request.number || github.ref }}
+  group: triage-secret-scan-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -30,7 +30,7 @@ jobs:
     if: ${{ always() && needs.gitleaks.result == 'failure' }}
     permissions:
       issues: write
-    uses: ./.github/workflows/notify-failure.yml
+    uses: ./.github/workflows/shared-notify.yml
     with:
       success: false
       workflow_name: 'PR: Gitleaks Secret Scan'

--- a/.github/workflows/triage-slash.yml
+++ b/.github/workflows/triage-slash.yml
@@ -1,4 +1,4 @@
-name: Slash Label Command
+name: triage-slash
 
 on:
   issue_comment:
@@ -15,7 +15,7 @@ jobs:
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: self-hosted
     concurrency:
-      group: slash-label-issue-${{ github.event.issue.number }}
+      group: triage-slash-issue-${{ github.event.issue.number }}
       cancel-in-progress: false
     steps:
       - name: Extract and apply label

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,7 +264,7 @@ git push
 
 - Vercel 배포는 cron (2시간마다) + 수동(`workflow_dispatch`)으로 실행된다.
 - PR/push 시 Vercel auto-deploy는 `ignoreCommand`로 차단되어 있다.
-- 즉시 배포가 필요하면: GitHub Actions → Deploy to Vercel → Run workflow → branch 선택 → 실행.
+- 즉시 배포가 필요하면: GitHub Actions → `deploy-vercel` → Run workflow → branch 선택 → 실행.
 - 4개 앱(app_user, app_partner, landing_user, landing_partner) 모두 매 cron마다 deploy된다.
 
 ## Bug Fix Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ adb -s adb-R3CX803P2ND-8btuuD._adb-tls-connect._tcp install -r build/app/outputs
 ## Branch Rebase Rules
 
 - `shared/packages/**`를 수정하는 PR을 생성하기 전에 반드시 `git rebase origin/dev`를 수행한다.
-  ci.yml의 paths filter가 업데이트될 수 있으며, stale branch에서는 새 패키지가 CI 트리거에서 누락될 수 있다.
+  pr-gate.yml의 paths filter가 업데이트될 수 있으며, stale branch에서는 새 패키지가 CI 트리거에서 누락될 수 있다.
 
 ## Branch Protection
 
@@ -168,8 +168,10 @@ adb -s adb-R3CX803P2ND-8btuuD._adb-tls-connect._tcp install -r build/app/outputs
 | CodeRabbit 리뷰 | PR only | `ci-result` job 내에서 최대 30분 대기 |
 
 별도 워크플로우 (required check 아님, 참고용):
-- **Auto Format PR**: PR 시 `dart fix --apply` + `dart format` 자동 적용. 포맷 변경이 있으면 자동 커밋.
-- **Secret Scanning**: PR 시 Gitleaks로 시크릿 유출 검사.
+- **`sync-format`**: PR 시 `dart fix --apply` + `dart format` 자동 적용. 포맷 변경이 있으면 자동 커밋.
+- **`triage-secret-scan`**: PR 시 Gitleaks로 시크릿 유출 검사.
+
+→ 전체 워크플로우 prefix 컨벤션은 [`.github/workflows/BLUEDOC.md`](.github/workflows/BLUEDOC.md) 참고.
 
 ### PR 케어 (생성 → 머지 완료까지)
 
@@ -235,7 +237,7 @@ git push
 
 - Vercel 배포는 cron (2시간마다) + 수동(`workflow_dispatch`)으로 실행된다.
 - PR/push 시 Vercel auto-deploy는 `ignoreCommand`로 차단되어 있다.
-- 즉시 배포가 필요하면: GitHub Actions → Deploy to Vercel → Run workflow → branch 선택 → 실행.
+- 즉시 배포가 필요하면: GitHub Actions → `deploy-vercel` → Run workflow → branch 선택 → 실행.
 - 4개 앱(app_user, app_partner, landing_user, landing_partner) 모두 매 cron마다 deploy된다.
 
 ## Bug Fix Conventions

--- a/docs/architecture/edge-function-auth.md
+++ b/docs/architecture/edge-function-auth.md
@@ -42,8 +42,8 @@ Minglit의 모든 Edge Function (EF) 인증/인가 모델을 기술한다.
 
 ```
 GH Secret (SUPABASE_*_SECRET_KEY)
-  ├─→ EF env (Supabase 플랫폼 자동 주입 — supabase-deploy.yml 의 supabase secrets set 안 거침)
-  └─→ Vault (CI sync — supabase-deploy.yml 의 Sync Vault secrets step)
+  ├─→ EF env (Supabase 플랫폼 자동 주입 — deploy-supabase.yml 의 supabase secrets set 안 거침)
+  └─→ Vault (CI sync — deploy-supabase.yml 의 Sync Vault secrets step)
         └─→ cron 이 SELECT 하여 Bearer 헤더에 사용
 ```
 
@@ -579,7 +579,7 @@ EFContext
     # done
 ```
 
-`ci.yml` 의 `test-edge-functions` job 에 dependency 추가하여 `ci-result` 게이트 합류.
+`pr-gate.yml` 의 `test-edge-functions` job 에 dependency 추가하여 `ci-result` 게이트 합류.
 
 `#3` 활성화 시점: Phase 4 (모든 EF 마이그레이션 완료 후).
 `#4` 활성화 시점: Phase 5 (옛 헬퍼 제거 후).

--- a/docs/infra/fresh-doc/schema-validator.md
+++ b/docs/infra/fresh-doc/schema-validator.md
@@ -49,7 +49,7 @@ docs/standards/FRESH_DOC: FRESH (cycle 90d, 45d elapsed)
 
 ## CI 통합
 
-`.github/workflows/ci.yml` 에 job 추가:
+`.github/workflows/pr-gate.yml` 에 job 추가:
 
 - 트리거: `docs/**/FRESH_DOC` 또는 `scripts/fresh-doc-lint.ts` 변경
 - 단계: validator 실행. 1·2 단계 실패 시 CI fail.

--- a/docs/infra/graphify/github-workflow.md
+++ b/docs/infra/graphify/github-workflow.md
@@ -1,6 +1,6 @@
 # Graphify 자동 갱신 워크플로우
 
-`.github/workflows/graphify-update.yml` 이 `graphify-out/` 을 자동으로 갱신한다. 로컬 hook 을 대체한다.
+`.github/workflows/sync-graphify.yml` 이 `graphify-out/` 을 자동으로 갱신한다. 로컬 hook 을 대체한다.
 
 ## 트리거
 
@@ -32,7 +32,7 @@
 ## 권한
 
 - `contents: write` — graphify-out 갱신 커밋용
-- `GH_PAT_VERSION_BUMP` 시크릿 — 보호된 `dev` 에 직접 push (version-bump.yml 과 동일 패턴)
+- `GH_PAT_VERSION_BUMP` 시크릿 — 보호된 `dev` 에 직접 push (sync-version.yml 과 동일 패턴)
 
 ## 실패 시 동작
 

--- a/docs/operations/edge-functions.md
+++ b/docs/operations/edge-functions.md
@@ -114,7 +114,7 @@ supabase functions list --project-ref <project-ref>
 Edge Function 배포는 CI를 통해서만 한다 (직접 `supabase functions deploy` 금지).
 
 ```
-feature branch → PR → dev 머지 → supabase-deploy.yml 자동 실행
+feature branch → PR → dev 머지 → deploy-supabase.yml 자동 실행
 ```
 
 `supabase/functions/**` 경로 변경 시 자동 트리거.
@@ -230,7 +230,7 @@ Assertion 실패 시 GitHub 이슈가 자동 생성되며, 이슈에 Axiom 쿼�
 
 ### Edge Function 배포가 안 될 때
 
-1. CI 워크플로우 확인: `gh run list --workflow=supabase-deploy.yml`
+1. CI 워크플로우 확인: `gh run list --workflow=deploy-supabase.yml`
 2. `supabase/functions/**` 경로 변경이 포함되었는지 확인
 3. `workflow_dispatch`로 수동 트리거 가능
 

--- a/docs/qa/automation-test-guide.md
+++ b/docs/qa/automation-test-guide.md
@@ -261,7 +261,7 @@ cd apps/app_user && flutter test test/integration/cuj_signup_to_apply_test.dart
 # Layer 3 (Patrol) — 로컬 emulator 필요
 cd apps/app_user && patrol test --target patrol_test/permission_grant_test.dart
 # 여러 파일: --target 반복 또는 --targets 콤마 구분
-# CI 에서는 patrol-e2e.yml 워크플로우
+# CI 에서는 monitor-patrol-e2e.yml 워크플로우
 
 # Layer 4 pgTAP
 supabase test db
@@ -274,7 +274,7 @@ deno test --allow-all supabase/functions/payment-verify/
 psql -c "SELECT * FROM check_db_invariants();"
 
 # Layer 7 — workflow_dispatch 로 수동 trigger
-gh workflow run daily-backend-simulation.yml --ref dev
+gh workflow run monitor-daily-lifecycle.yml --ref dev
 ```
 
 ---
@@ -301,7 +301,7 @@ gh workflow run daily-backend-simulation.yml --ref dev
 
 ## 8. CI 파이프라인 연동
 
-`.github/workflows/ci.yml` 이 PR 마다 Layer 1 / 2a / 2b / 4 / 5 를 실행.
+`.github/workflows/pr-gate.yml` 이 PR 마다 Layer 1 / 2a / 2b / 4 / 5 를 실행.
 
 | 변경 영역 | 실행 Layer |
 |----------|-----------|
@@ -312,9 +312,9 @@ gh workflow run daily-backend-simulation.yml --ref dev
 | `apps/landing_*/**` | npm lint + build |
 
 추가 워크플로우:
-- `patrol-e2e.yml` — Layer 3 (주 1회 예정, 현재 런 0건)
-- `db-invariants.yml` — Layer 6 (매시간)
-- `daily-backend-simulation.yml` / `hourly-user-activity.yml` — Layer 7
+- `monitor-patrol-e2e.yml` — Layer 3 (주 1회 예정, 현재 런 0건)
+- `monitor-db-invariants.yml` — Layer 6 (매시간)
+- `monitor-daily-lifecycle.yml` / `hourly-user-activity.yml` — Layer 7
 
 ---
 

--- a/docs/qa/screenshot-capture-points.md
+++ b/docs/qa/screenshot-capture-points.md
@@ -21,8 +21,8 @@
 | 2. `GoldenCapture` 유틸 실행 | CI headless 환경에서 동작 | **런타임 skip** (PR #1539) | headless hang 방지를 위한 임시 조치 — 대체 구현 미완 |
 | 3. CUJ 테스트 실행 경로 | `apps/app_user/test/integration/` 순회 | `run-client-cuj.sh` / `run-partner-cuj.sh` 모두 `test/integration/*_test.dart` 순회 — **경로 수정 완료** (#1557) | 차단 없음 |
 | 4. 상위 파이프라인 (`client-cuj-test`, `partner-cuj-test` job) | 매일 실행 | **skip 지속** | `needs: seed-and-simulate` 의존 — #1553 (CLOSED) / PR #1556 (MERGED 2026-04-18) 으로 선결 해소. 재가동 확인 필요 |
-| 5. Patrol E2E (`patrol-e2e.yml`) | weekly cron | **run 이력 0건** | 한 번도 trigger되지 않음. 수동 실행도 없음 |
-| 6. 아티팩트 업로드 | 생성된 png 보존 | `patrol-e2e.yml:66`은 `if: failure()` + build outputs만 업로드 (스크린샷 아님). `ci.yml`은 golden 실패 / coverage / allure만 업로드 | Tier B 용 retention 경로 미구축 |
+| 5. Patrol E2E (`monitor-patrol-e2e.yml`) | weekly cron | **run 이력 0건** | 한 번도 trigger되지 않음. 수동 실행도 없음 |
+| 6. 아티팩트 업로드 | 생성된 png 보존 | `monitor-patrol-e2e.yml:66`은 `if: failure()` + build outputs만 업로드 (스크린샷 아님). `pr-gate.yml`은 golden 실패 / coverage / allure만 업로드 | Tier B 용 retention 경로 미구축 |
 
 ### 3-Tier 스크린샷 아키텍처
 
@@ -60,7 +60,7 @@
 
 - **캡처는 "비교"가 아니라 "증거 사진"** — Tier C AI agent 의 semantic 리뷰 입력용.
 - 따라서 아티팩트 저장 요구사항이 Tier A (골든 픽셀 비교) 와 다름:
-  - ❌ PR 실패 시에만 업로드 (현재 `patrol-e2e.yml:66` 패턴)
+  - ❌ PR 실패 시에만 업로드 (현재 `monitor-patrol-e2e.yml:66` 패턴)
   - ✅ **매일 성공 run 에서도 전량 저장**, retention 14 일 이상, Tier C agent 가 접근 가능한 경로
 - 따라서 이 문서의 매핑은 "픽셀 고정"이 아니라 **"뭘 촬영할지"** 를 정의하는 쇼트 리스트로 해석.
 

--- a/docs/qa/test-cases/ci-deploy-tests.md
+++ b/docs/qa/test-cases/ci-deploy-tests.md
@@ -9,9 +9,9 @@
 
 ## 1. 배포 워크플로우별 필수 Secret 매트릭스
 
-### 1.1 Android 배포 (Reusable: `android-deploy-reusable.yml`)
+### 1.1 Android 배포 (Reusable: `shared-android-deploy.yml`)
 
-| Secret | User (`android-deploy.yml`) | Partner (`android-deploy-partner.yml`) | 용도 |
+| Secret | User (`deploy-android-user.yml`) | Partner (`deploy-android-partner.yml`) | 용도 |
 |--------|:---:|:---:|------|
 | `ANDROID_KEYSTORE_BASE64` | **필수** | **필수** | 서명용 keystore (base64) |
 | `ANDROID_KEYSTORE_PASSWORD` | **필수** | **필수** | keystore 비밀번호 |
@@ -31,7 +31,7 @@
 
 ### 1.2 iOS 배포 (Action: `.github/actions/ios-deploy/`)
 
-| Secret | User (`ios-deploy-user.yml`) | Partner (`ios-deploy-partner.yml`) | 용도 |
+| Secret | User (`deploy-ios-user.yml`) | Partner (`deploy-ios-partner.yml`) | 용도 |
 |--------|:---:|:---:|------|
 | `APPLE_CERTIFICATE_BASE64` | **필수** | **필수** | Apple 서명 인증서 |
 | `APPLE_CERTIFICATE_PASSWORD` | **필수** | **필수** | 인증서 비밀번호 |
@@ -67,9 +67,9 @@ Secret 추가/변경 시 아래 체크리스트로 검증한다:
 
 | # | 워크플로우 | 스텝 | 트리거 조건 | 기대 동작 | 실패 시 |
 |---|-----------|------|-----------|-----------|---------|
-| CD-V01 | `android-deploy-reusable.yml` | `Validate JUSO key for partner` | `app-name == 'partner'` | `JUSO_CONFIRM_KEY` 비어있으면 exit 1 | 빌드 중단 + 에러 메시지 |
+| CD-V01 | `shared-android-deploy.yml` | `Validate JUSO key for partner` | `app-name == 'partner'` | `JUSO_CONFIRM_KEY` 비어있으면 exit 1 | 빌드 중단 + 에러 메시지 |
 | CD-V02 | `.github/actions/ios-deploy/` | `Validate JUSO key for partner` | `app-name == 'partner'` | 동일 | 빌드 중단 + 에러 메시지 |
-| CD-V03 | `android-deploy-reusable.yml` | `Decode Keystore` | 항상 | keystore base64 디코딩 성공 | 서명 실패 → 빌드 에러 |
+| CD-V03 | `shared-android-deploy.yml` | `Decode Keystore` | 항상 | keystore base64 디코딩 성공 | 서명 실패 → 빌드 에러 |
 | CD-V04 | `ios-deploy` action | `Import signing certificate` | 항상 | 인증서 임포트 성공 | codesign 실패 |
 | CD-V05 | `ios-deploy` action | `Install provisioning profile` | 항상 | UUID 추출 + 설치 성공 | 아카이브 실패 |
 
@@ -77,8 +77,8 @@ Secret 추가/변경 시 아래 체크리스트로 검증한다:
 
 | # | 시나리오 | 트리거 | 기대 결과 |
 |---|----------|--------|-----------|
-| CD-N01 | Android Partner 빌드 실패 | `build` job 실패 | `notify-failure.yml` → 이슈 자동 생성 |
-| CD-N02 | iOS Partner 빌드 실패 | `ios-deploy` job 실패 | `notify-failure.yml` → 이슈 자동 생성 |
+| CD-N01 | Android Partner 빌드 실패 | `build` job 실패 | `shared-notify.yml` → 이슈 자동 생성 |
+| CD-N02 | iOS Partner 빌드 실패 | `ios-deploy` job 실패 | `shared-notify.yml` → 이슈 자동 생성 |
 | CD-N03 | Android User 빌드 성공 | `build` job 성공 | 알림 이슈 미생성 |
 | CD-N04 | iOS User 빌드 성공 | `ios-deploy` job 성공 | 알림 이슈 미생성 |
 
@@ -140,7 +140,7 @@ Secret 추가/변경 시 아래 체크리스트로 검증한다:
 | # | 취약점 | 영향 | 제안 |
 |---|--------|------|------|
 | CD-I01 | `JUSO_CONFIRM_KEY`가 reusable workflow에서 `required: false` | Partner 빌드 시 런타임 실패 (빌드 스텝까지 가야 발견) | `required: true`로 변경하거나, partner workflow에서 전달 전 검증 |
-| CD-I02 | User 앱에 `JUSO_CONFIRM_KEY` 전달 안 됨 (android-deploy.yml) | User 앱에서 주소 검색 기능 사용 시 빈 값 → 런타임 에러 가능 | User 앱에서 JUSO API 사용 여부 확인 후 필요 시 추가 |
+| CD-I02 | User 앱에 `JUSO_CONFIRM_KEY` 전달 안 됨 (deploy-android-user.yml) | User 앱에서 주소 검색 기능 사용 시 빈 값 → 런타임 에러 가능 | User 앱에서 JUSO API 사용 여부 확인 후 필요 시 추가 |
 | CD-I03 | Secret 만료 모니터링 없음 | Apple 인증서/프로비저닝 만료 시 배포 중단 | 인증서 만료일 체크 워크플로우 추가 (월 1회 cron) |
 
 ---

--- a/docs/qa/test-strategy.md
+++ b/docs/qa/test-strategy.md
@@ -37,19 +37,19 @@
 |---|-------|------|------|-----------|------|
 | 4 | **pgTAP** | DB 스키마 / 트리거 / RPC / RLS 계약 | `supabase/tests/database/` | pgTAP | PR 마다 |
 | 5 | **Deno EF test** | Edge Function TypeScript 로직 단위 | `supabase/functions/**/*_test.ts` | `deno test` | PR 마다 |
-| 6 | **DB monitor** | Runtime invariant 감시 | `check_db_invariants()` RPC + `.github/workflows/db-invariants.yml` | SQL | 매시간 cron |
-| 7 | **Tick simulator** | 서버 pipeline 관통 시뮬 (시간 전진 + 파이프라인 부하) | `backend-simulator` EF + `.github/workflows/daily-backend-simulation.yml` + `hourly-user-activity.yml` | EF + HTTP | 매시간 + 매일 |
+| 6 | **DB monitor** | Runtime invariant 감시 | `check_db_invariants()` RPC + `.github/workflows/monitor-db-invariants.yml` | SQL | 매시간 cron |
+| 7 | **Tick simulator** | 서버 pipeline 관통 시뮬 (시간 전진 + 파이프라인 부하) | `backend-simulator` EF + `.github/workflows/monitor-daily-lifecycle.yml` + `hourly-user-activity.yml` | EF + HTTP | 매시간 + 매일 |
 
 ### 보조 (taxonomy 밖, 유지)
 
 | 항목 | 위치 | 성격 |
 |------|------|------|
-| Secret scan | `.github/workflows/secret-scan.yml` | 보안 |
-| Migration version check | `ci.yml` job | Pre-test gate |
-| Env manifest sync | `ci.yml` job | 환경변수 정합성 |
-| Landing lint/build | `ci.yml` job | Next.js 빌드 |
-| Allure report | `allure-report.yml` | 결과 집계 |
-| Update goldens | `update-goldens.yml` | Layer 2b 유지보수 |
+| Secret scan | `.github/workflows/triage-secret-scan.yml` | 보안 |
+| Migration version check | `pr-gate.yml` job | Pre-test gate |
+| Env manifest sync | `pr-gate.yml` job | 환경변수 정합성 |
+| Landing lint/build | `pr-gate.yml` job | Next.js 빌드 |
+| Allure report | `monitor-allure.yml` | 결과 집계 |
+| Update goldens | `tool-update-goldens.yml` | Layer 2b 유지보수 |
 
 ---
 
@@ -173,7 +173,7 @@
 | app_user | `apps/app_user/emulator_test/` | 1 | `apple_sign_in` — IntegrationTestWidgetsFlutterBinding |
 | app_partner | — | 0 | Layer 3 테스트 없음. `scenario_screenshots_test.dart` 이 PR에서 삭제됨. |
 
-**Layer 3 런타임 상태**: `patrol-e2e.yml` 복구 완료 (#1673). `app_partner` Layer 3 테스트 0건. 재가동 계획은 §6 로드맵 및 #1586 Phase D-2 참고.
+**Layer 3 런타임 상태**: `monitor-patrol-e2e.yml` 복구 완료 (#1673). `app_partner` Layer 3 테스트 0건. 재가동 계획은 §6 로드맵 및 #1586 Phase D-2 참고.
 
 ### Layer 4 — pgTAP
 
@@ -187,14 +187,14 @@
 ### Layer 6 — DB monitor
 
 - RPC: `check_db_invariants()` (supabase/migrations 에서 정의)
-- 워크플로우: `.github/workflows/db-invariants.yml` — 매시간 cron
+- 워크플로우: `.github/workflows/monitor-db-invariants.yml` — 매시간 cron
 - 상태: **구현 존재. 2026-04-15 이슈 #1549 로 재등록 확인.**
 
 ### Layer 7 — Tick simulator
 
 - EF: `supabase/functions/backend-simulator/`
 - 워크플로우:
-  - `daily-backend-simulation.yml` — 매일 (PR #1584 로 pg_cron 에서 GH Actions 로 이관)
+  - `monitor-daily-lifecycle.yml` — 매일 (PR #1584 로 pg_cron 에서 GH Actions 로 이관)
   - `hourly-user-activity.yml` — 매시간
 - 상태: **정상 동작.**
 
@@ -272,7 +272,7 @@
 
 ### 6.4 CI 연동
 
-- `patrol-e2e.yml`에 통합 (주 1회 또는 매일)
+- `monitor-patrol-e2e.yml`에 통합 (주 1회 또는 매일)
 - 스크린샷 아티팩트 업로드 → Layer 3 agent의 semantic 리뷰 입력으로 활용 (픽셀 비교 아님 — §6.0 참고)
 - 네이티브 E2E (카카오 로그인, PG 결제, 권한)는 실물 디바이스에서만 실행
 
@@ -362,7 +362,7 @@ Flutter 앱은 Skia/Impeller 엔진으로 단일 `FlutterSurfaceView` 위에 렌
 
 - **4개 배포 워크플로우** (Android/iOS × User/Partner)의 필수 Secret을 매트릭스로 정리
 - Partner 전용 Secret (`JUSO_CONFIRM_KEY`)의 `required: false` 선언 불일치 식별 → 개선 제안 포함
-- 배포 실패 알림(`notify-failure.yml`) 동작 검증 케이스 포함
+- 배포 실패 알림(`shared-notify.yml`) 동작 검증 케이스 포함
 
 ---
 
@@ -386,7 +386,7 @@ Flutter 앱은 Skia/Impeller 엔진으로 단일 `FlutterSurfaceView` 위에 렌
 
 - D-2 PoC: 2-3 CUJ Patrol 변환 + CI 돌아감 + 스크린샷 생성 (2026-04)
 - D-2 전량: CUJ 5-10 개 단위로 쪼갠 PR 병합 (15-23일 FTE 예상)
-- D-3-a: `patrol-e2e.yml` 수동 trigger 성공 1회 확인
+- D-3-a: `monitor-patrol-e2e.yml` 수동 trigger 성공 1회 확인
 - D-3-b: matrix shard 6-8 → wall-clock < 20min 달성
 - D-4: 스크린샷 git commit 파이프라인 (또는 auto-PR) 가동
 

--- a/docs/reports/ops/alerts/2026-04-06-issue1128-daily-backend-simulation-failed-on-dev.md
+++ b/docs/reports/ops/alerts/2026-04-06-issue1128-daily-backend-simulation-failed-on-dev.md
@@ -38,7 +38,7 @@ CI 로그:
 /usr/bin/sh: 1: Syntax error: end of file unexpected (expecting "done")
 ```
 
-워크플로우 파일 자체는 정상 (`daily-backend-simulation.yml:110-117`). `android-emulator-runner@v2`의 script 실행 방식 문제.
+워크플로우 파일 자체는 정상 (`monitor-daily-lifecycle.yml:110-117`). `android-emulator-runner@v2`의 script 실행 방식 문제.
 
 ## 영향
 
@@ -67,7 +67,7 @@ PR #1131 생성했습니다: https://github.com/Mark-Yun/minglit/pull/1131
 
 - `.github/scripts/run-client-cuj.sh` 신규 추가
 - `.github/scripts/run-partner-cuj.sh` 신규 추가
-- `daily-backend-simulation.yml` — multi-line `script:` 블록을 단일 라인 bash 파일 호출로 교체
+- `monitor-daily-lifecycle.yml` — multi-line `script:` 블록을 단일 라인 bash 파일 호출로 교체
 
 auto-merge 활성화 완료. `ci-result` 통과 시 자동 squash merge.
 

--- a/docs/reports/ops/alerts/2026-04-16-issue1499-deploy-supabase-migrations-failed-on-dev.md
+++ b/docs/reports/ops/alerts/2026-04-16-issue1499-deploy-supabase-migrations-failed-on-dev.md
@@ -93,6 +93,6 @@ Co-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.
 - 증거: 에러 로그 `ENOTFOUND tenant/user postgres.***`, 대시보드 Connection pooling 표기, `supabase/.temp/pooler-url` CLI 생성 값 모두 `aws-1` 일치
 
 ### 해결
-`.github/workflows/supabase-deploy.yml:132` 한 줄 수정 + 하드코딩 제거 장기안은 #1553 참고.
+`.github/workflows/deploy-supabase.yml:132` 한 줄 수정 + 하드코딩 제거 장기안은 #1553 참고.
 
 실행 추적은 #1553으로 이관되었으므로 이 자동 생성 ci-failure 이슈는 close합니다.

--- a/docs/reports/ops/alerts/2026-04-16-issue1506-version-bump-failed-on-dev.md
+++ b/docs/reports/ops/alerts/2026-04-16-issue1506-version-bump-failed-on-dev.md
@@ -77,6 +77,6 @@ title: "🚨 Version Bump failed on dev"
 - 최근 10 run은 전부 success — 현상은 자연 해소됐으나 **race window는 그대로 남아 재발 보장**
 
 ### 해결
-`.github/workflows/version-bump.yml` push step에 pull-rebase + retry loop 추가 (#1554에 정확한 diff 포함).
+`.github/workflows/sync-version.yml` push step에 pull-rebase + retry loop 추가 (#1554에 정확한 diff 포함).
 
 실행 추적은 #1554로 이관되었으므로 이 자동 생성 ci-failure 이슈는 close합니다.

--- a/docs/reports/ops/alerts/2026-04-16-issue1516-hourly-user-activity-failed-on-dev.md
+++ b/docs/reports/ops/alerts/2026-04-16-issue1516-hourly-user-activity-failed-on-dev.md
@@ -35,7 +35,7 @@ title: "🚨 Hourly User Activity failed on dev"
 `backend-simulator` EF의 **tick mode가 `SIM_USER_PASSWORD` 환경변수 미설정으로 즉시 throw** → \`curl\` exit 22 (HTTP 5xx). `hourly-user-activity.yml:20`에서 `{\"mode\":\"tick\"}` POST 호출이 실패한 것.
 
 ### 영구 fix (대기 중)
-커밋 **`f2032dd3e` (\"fix(ci): SIM_USER_PASSWORD secret 추가 — tick simulator 500 해소\")** 가 \`supabase-deploy.yml\`에 \`supabase secrets set SIM_USER_PASSWORD=...\` 한 줄을 추가하여 deploy 시 자동 주입.
+커밋 **`f2032dd3e` (\"fix(ci): SIM_USER_PASSWORD secret 추가 — tick simulator 500 해소\")** 가 \`deploy-supabase.yml\`에 \`supabase secrets set SIM_USER_PASSWORD=...\` 한 줄을 추가하여 deploy 시 자동 주입.
 
 - 현재 브랜치 `fix/deploy-seed-cli`에 존재, **dev 미머지**
 - 이 fix가 실제 효과 보려면 **#1553 (pooler host 수정)으로 Deploy Supabase Migrations가 먼저 성공해야 함** — deploy 자체가 깨져있는 동안에는 secret이 EF에 push되지 않음

--- a/docs/reports/ops/alerts/2026-04-16-issue1517-daily-backend-simulation-failed-on-dev.md
+++ b/docs/reports/ops/alerts/2026-04-16-issue1517-daily-backend-simulation-failed-on-dev.md
@@ -41,11 +41,11 @@ title: "🚨 Daily Backend Simulation failed on dev"
 
 ### 요약
 - 에러: \`psql ... FATAL: (ENOTFOUND) tenant/user postgres.*** not found\` — host \`aws-0-ap-northeast-2.pooler.supabase.com\`
-- \`.github/workflows/daily-backend-simulation.yml:29\` 에 pooler host가 옛 \`aws-0\`로 하드코딩됨
+- \`.github/workflows/monitor-daily-lifecycle.yml:29\` 에 pooler host가 옛 \`aws-0\`로 하드코딩됨
 - **#1499/#1553과 완전히 동일한 원인** (Supabase pooler 인프라 `aws-0` → `aws-1` 이전 미대응)
 - 영향: 2026-04-10부터 매일 scheduled run 10일 연속 실패
 
 ### 조치
-#1553의 스코프를 `supabase-deploy.yml` + `daily-backend-simulation.yml` 두 파일로 확장했습니다. 하나의 fix(`aws-0` → `aws-1`) + 하드코딩 제거 장기안으로 양쪽 동시 해소됩니다.
+#1553의 스코프를 `deploy-supabase.yml` + `monitor-daily-lifecycle.yml` 두 파일로 확장했습니다. 하나의 fix(`aws-0` → `aws-1`) + 하드코딩 제거 장기안으로 양쪽 동시 해소됩니다.
 
 실행 추적은 #1553으로 이관되었으므로 이 자동 생성 ci-failure 이슈는 close합니다.

--- a/docs/reports/ops/incidents/2026-04-18-issue1575-missing-env-vars-after-deploy-on-dev.md
+++ b/docs/reports/ops/incidents/2026-04-18-issue1575-missing-env-vars-after-deploy-on-dev.md
@@ -226,11 +226,11 @@ reconciliation-daily: PORTONE_V2_API_KEY
 
 ## 근본 원인 + Fix 이슈로 이관
 
-4일간 auto-recreate 되던 원인 확정 — \`supabase-deploy.yml\` 의 EF secret 주입 블록에 **PortOne key 만 누락**.
+4일간 auto-recreate 되던 원인 확정 — \`deploy-supabase.yml\` 의 EF secret 주입 블록에 **PortOne key 만 누락**.
 
 ### 원인
 - EF 코드: \`Deno.env.get("PORTONE_API_KEY")\` 등으로 9개 EF 가 PortOne env 읽음 (Vault 아님)
-- \`supabase-deploy.yml:66-88\` 에서 OPENAI, SENTRY, AXIOM 등은 \`supabase secrets set\` 으로 주입 중
+- \`deploy-supabase.yml:66-88\` 에서 OPENAI, SENTRY, AXIOM 등은 \`supabase secrets set\` 으로 주입 중
 - PortOne 만 이 리스트에서 빠져있어 EF 환경에 영원히 없음
 - \`Verify Edge Function env vars\` step 이 health 엔드포인트로 누락 감지 → 자동 이슈 생성/코멘트
 
@@ -239,7 +239,7 @@ reconciliation-daily: PORTONE_V2_API_KEY
 - GitHub Actions secrets 등록: \`PORTONE_DEV_API_KEY\`, \`PORTONE_DEV_API_SECRET\`, \`PORTONE_DEV_V2_API_KEY\`, \`PORTONE_DEV_V2_WEBHOOK_SECRET\` (minglit_env/dev/supabase.env 에서 가져와 주입)
 
 #### 이관
-- **#1683** 에서 \`supabase-deploy.yml\` 수정으로 자동 주입 블록 추가 추적. dev/main 환경별 분기 + 구체 diff 포함. needs-swe P0.
+- **#1683** 에서 \`deploy-supabase.yml\` 수정으로 자동 주입 블록 추가 추적. dev/main 환경별 분기 + 구체 diff 포함. needs-swe P0.
 
 ### Main 환경 주의
 dev 는 위 4개 secrets 등록으로 해소되지만, **main 은 \`PORTONE_MAIN_*\` 별도 등록 필요** — PortOne production credentials 입력은 관리자(너)가 해야. #1683 Phase 2 에 명시.

--- a/docs/reports/qa/2026-04-19-issue1616-runtime-qa-bug-dev-session-switcher-403-blocked-in-productio.md
+++ b/docs/reports/qa/2026-04-19-issue1616-runtime-qa-bug-dev-session-switcher-403-blocked-in-productio.md
@@ -60,7 +60,7 @@ Supabase Edge Function에서 서버 사이드로 production 체크를 하고 있
 이 버그는 이미 커밋 `dd08f6bda`에서 수정되었습니다.
 
 **근본 원인**: `dev-session-switch`의 dev-only guard가 `"local" | "development"`만 허용하고 `"dev"`를 차단함.
-`supabase-deploy.yml`이 Supabase dev 프로젝트에 `ENVIRONMENT=dev`를 설정하므로, 배포된 dev 환경에서 호출 시 403 반환.
+`deploy-supabase.yml`이 Supabase dev 프로젝트에 `ENVIRONMENT=dev`를 설정하므로, 배포된 dev 환경에서 호출 시 403 반환.
 
 **수정 내용** (`supabase/functions/dev-session-switch/index.ts`):
 ```

--- a/docs/reports/tpm/2026-03-27-issue0488-tpm-report-ios-deploy-100-failure-issue.md
+++ b/docs/reports/tpm/2026-03-27-issue0488-tpm-report-ios-deploy-100-failure-issue.md
@@ -86,10 +86,10 @@ title: "⚠️ TPM Report — 2026-03-27: iOS deploy 100% 실패 + 이슈 소화
 
 ### 실제 iOS 빌드는 정상
 
-caller 워크플로우(`ios-deploy-user.yml`, `ios-deploy-partner.yml`)는 schedule(매일 KST 19:00)로 정상 실행 중:
+caller 워크플로우(`deploy-ios-user.yml`, `deploy-ios-partner.yml`)는 schedule(매일 KST 19:00)로 정상 실행 중:
 
 ```
-# ios-deploy-user.yml (실제 빌드)
+# deploy-ios-user.yml (실제 빌드)
 23590169924 success event=schedule branch=dev
 23536855113 success event=schedule branch=dev
 23485345999 success event=schedule branch=dev

--- a/docs/reports/tpm/2026-03-27-issue0545-tpm-report-ios-deploy-failure-ci-failure-issue-weekly-45.md
+++ b/docs/reports/tpm/2026-03-27-issue0545-tpm-report-ios-deploy-failure-ci-failure-issue-weekly-45.md
@@ -78,7 +78,7 @@ title: "⚠️ TPM Report — 2026-03-28: iOS deploy 지속 실패 + ci-failure 
 ### 1. iOS deploy 100% 실패 → phantom run (실제 문제 아님)
 
 #488 분석과 동일. `ios-deploy-reusable.yml`이 push 이벤트에 phantom run 생성.
-- 실제 caller(`ios-deploy-user.yml`, `ios-deploy-partner.yml`)는 schedule로 **정상 실행 중**
+- 실제 caller(`deploy-ios-user.yml`, `deploy-ios-partner.yml`)는 schedule로 **정상 실행 중**
 - 근본 해결: #550 (composite action 전환)에서 처리 예정
 
 ### 2. Daily Backend Simulation 실패 → 수정 완료

--- a/docs/reports/tpm/2026-03-29-issue0706-tpm-report-ios-deploy-workflow-failure-8-7.md
+++ b/docs/reports/tpm/2026-03-29-issue0706-tpm-report-ios-deploy-workflow-failure-8-7.md
@@ -22,7 +22,7 @@ title: "⚠️ TPM Report — 2026-03-29: iOS 배포 워크플로우 연속 실�
 ## 분석
 
 ### 트리거
-- `ios-deploy-user.yml` / `ios-deploy-partner.yml`이 **매일 cron (UTC 10:00, KST 19:00)**으로 default branch(dev)에서 실행
+- `deploy-ios-user.yml` / `deploy-ios-partner.yml`이 **매일 cron (UTC 10:00, KST 19:00)**으로 default branch(dev)에서 실행
 - push to main (경로 필터) 및 workflow_dispatch도 트리거 가능
 
 ### 실패 패턴

--- a/docs/reports/tpm/2026-04-04-issue1019-tpm-report-deploy-supabase-migrations-ipv6-100-failure-10.md
+++ b/docs/reports/tpm/2026-04-04-issue1019-tpm-report-deploy-supabase-migrations-ipv6-100-failure-10.md
@@ -74,11 +74,11 @@ port 5432 failed: Network is unreachable
 
 ### 왜 gai.conf 수정이 안 먹히는가
 
-`supabase-deploy.yml:96`에서 `gai.conf`에 IPv4 우선 설정을 추가하지만, `psql`이 내부적으로 `getaddrinfo()`를 호출할 때 이미 resolve된 IPv6 주소를 먼저 시도하는 경우가 있음. GitHub Actions ubuntu-latest 러너에서 `/etc/gai.conf` 변경이 즉시 반영되지 않는 환경 이슈.
+`deploy-supabase.yml:96`에서 `gai.conf`에 IPv4 우선 설정을 추가하지만, `psql`이 내부적으로 `getaddrinfo()`를 호출할 때 이미 resolve된 IPv6 주소를 먼저 시도하는 경우가 있음. GitHub Actions ubuntu-latest 러너에서 `/etc/gai.conf` 변경이 즉시 반영되지 않는 환경 이슈.
 
 ### 수정 방안 (옵션 A 구현)
 
-`supabase-deploy.yml`의 "Verify vault secrets" step에서 DNS hostname 대신 IPv4 주소를 직접 resolve하여 사용:
+`deploy-supabase.yml`의 "Verify vault secrets" step에서 DNS hostname 대신 IPv4 주소를 직접 resolve하여 사용:
 
 ```bash
 # Before (IPv6로 연결 시도 → 실패)
@@ -99,7 +99,7 @@ PGPASSWORD="${DB_PASSWORD}" psql \
 
 ### 영향 범위
 
-`supabase-deploy.yml` 1파일, "Verify vault secrets" step만 수정.
+`deploy-supabase.yml` 1파일, "Verify vault secrets" step만 수정.
 
 ### 관련
 - #669 (최초 보고, gai.conf 시도)

--- a/docs/reports/tpm/2026-04-05-issue1091-tpm-report-vercel-deploy-20-cascading-failure-cron-concurren.md
+++ b/docs/reports/tpm/2026-04-05-issue1091-tpm-report-vercel-deploy-20-cascading-failure-cron-concurren.md
@@ -41,7 +41,7 @@ Vercel Deploy 워크플로우가 **20시간+** 연속으로 성공하지 못하�
 
 ## 근본 원인 분석
 
-`deploy.yml`의 `concurrency.cancel-in-progress: true` + 2시간 cron 간격에서 deploy 시간이 2시간을 초과하면:
+`deploy-vercel.yml`의 `concurrency.cancel-in-progress: true` + 2시간 cron 간격에서 deploy 시간이 2시간을 초과하면:
 1. cron이 새 run을 시작
 2. concurrency 설정이 이전 run을 cancel
 3. 새 run도 2시간 내 완료 못함

--- a/docs/reports/tpm/2026-04-13-issue1373-tpm-report-supabase-deploy-10-failure-dependabot-pr-view.md
+++ b/docs/reports/tpm/2026-04-13-issue1373-tpm-report-supabase-deploy-10-failure-dependabot-pr-view.md
@@ -44,7 +44,7 @@ and not in import map from ".../supabase/functions/_shared/supabase_client.ts"
 - `db push` (마이그레이션)는 성공 추정 — `functions deploy`에서 실패
 
 **권장 조치**:
-- [ ] `version: latest` → 직전 성공 버전으로 pin (`.github/workflows/supabase-deploy.yml` L29)
+- [ ] `version: latest` → 직전 성공 버전으로 pin (`.github/workflows/deploy-supabase.yml` L29)
 - [ ] 또는 Supabase CLI changelog 확인 후 import map 형식 업데이트
 
 **판단 요청**: `version: latest` 정책을 pin으로 전환하는 것이 적절한지 확인 부탁드립니다. SWE가 바로 수정 가능하도록 #1357에 needs-swe 라우팅 완료.
@@ -90,7 +90,7 @@ and not in import map from ".../supabase/functions/_shared/supabase_client.ts"
 
 ### Supabase Deploy 10연속 실패
 이미 진단 완료 + 수정 이슈 존재:
-- **#1228** — \`supabase-deploy.yml\` verification 스텝을 pooler 엔드포인트로 전환
+- **#1228** — \`deploy-supabase.yml\` verification 스텝을 pooler 엔드포인트로 전환
 - **Root cause**: \`db.{ref}.supabase.co\`의 A(IPv4) 레코드 제거됨 → GitHub runner에서 DNS 해석 불가
 - **실제 migration 배포는 정상** — \`supabase db push\`(CLI)는 내부적으로 pooler 사용하므로 성공. verification 스텝만 실패해서 workflow red 표시
 - \`supabase migration list --linked\`로 dev DB에 모든 migration 반영 확인됨

--- a/docs/reports/tpm/2026-04-23-issue1768-tpm-report-review-presence-required-check-recurrence-approve.md
+++ b/docs/reports/tpm/2026-04-23-issue1768-tpm-report-review-presence-required-check-recurrence-approve.md
@@ -59,7 +59,7 @@ Branch protection required check `review-presence`가 **여전히 활성화되�
 
 **추천: B (근본 수정)**.
 
-`review-presence.yml` 의 check 로직 (formalReviews 또는 reviewer completion comment 검사)을 `ci-result.yml` 의 한 step으로 이식하고, `review-presence` 워크플로우는 삭제하거나 informational로 강등. 이후 branch protection에서 `review-presence` required 제거 (Admin 권한 필요).
+`triage-review.yml` 의 check 로직 (formalReviews 또는 reviewer completion comment 검사)을 `ci-result.yml` 의 한 step으로 이식하고, `review-presence` 워크플로우는 삭제하거나 informational로 강등. 이후 branch protection에서 `review-presence` required 제거 (Admin 권한 필요).
 
 **즉시 조치**: 현재 BLOCKED 상태의 approved PR이 또 있으면 TPM이 주기적으로 `gh run rerun` 실행. (오늘 #1767, #1766, #1764 에 대해 조치 완료 → #1767, #1764 머지됨)
 


### PR DESCRIPTION
## Summary
- 27→26 워크플로우 파일을 **7개 purpose prefix** 로 통일: `pr-gate-` / `deploy-` / `monitor-` / `sync-` / `triage-` / `tool-` / `shared-`
- 파일명 = workflow `name:` = `concurrency.group:` prefix 일치
- 컨벤션 진입점: `.github/workflows/BLUEDOC.md` (신규, 31줄)
- cross-ref (`uses:`, `workflow_run.workflows`, allure `workflow:`), CLAUDE.md / AGENTS.md / docs/ 일괄 정리

세부 분류 기준 — *"빨갛게 뜨면 무슨 일이 일어나나"*:
- `pr-gate-`: 머지 차단 (required check)
- `deploy-`: 사용자/dev 배포 실패
- `monitor-`: 운영·테스트 헬스 이상 (스케줄)
- `sync-`: repo 에 자동 commit/push 실패
- `triage-`: PR·이슈 라벨·머지·검증 자동화 실패 (commit 없음)
- `tool-`: 수동 도구 (현재 0건 — alchemist deprecation 으로 `update-goldens` 삭제됨)
- `shared-`: 재사용 부품 (workflow_call)

## Test plan
- [ ] `check-workflow-yaml` job 통과 (26 파일 YAML 파싱 ✓ 로컬 확인 완료)
- [ ] `ci-result` job 이름 보존 → branch protection required check 무영향
- [ ] `shared-notify` / `shared-android-deploy` workflow_call 체인 동작 (실제 self-hosted 실행 시 검증)
- [ ] `monitor-allure` 의 `workflow: pr-gate.yml` artifact 참조 (다음 cron 시 검증)
- [ ] `deploy-dev-seed` 의 `workflow_run: workflows: ["deploy-supabase"]` 매칭 (다음 supabase deploy 시 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)