### PR TITLE
ci: route self-hosted workflows to ephemeral/android runner pools

### DIFF
--- a/.github/workflows/deploy-dev-seed.yml
+++ b/.github/workflows/deploy-dev-seed.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   seed:
     name: Run Seeder
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     # Safety Guard 1: Only run on dev branch, or if manually triggered.
     # Also ensures the triggering workflow (migrations) was successful.
     if: >

--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   deploy-app_user:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' && 'production' || 'preview' }}
     outputs:
       accessible-url: ${{ steps.deploy.outputs.accessible-url }}
@@ -51,7 +51,7 @@ jobs:
           STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
 
   deploy-landing_user:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' && 'production' || 'preview' }}
     outputs:
       accessible-url: ${{ steps.deploy.outputs.accessible-url }}
@@ -71,7 +71,7 @@ jobs:
           deploy-branch: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name }}
 
   deploy-landing_partner:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' && 'production' || 'preview' }}
     outputs:
       accessible-url: ${{ steps.deploy.outputs.accessible-url }}
@@ -91,7 +91,7 @@ jobs:
           deploy-branch: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name }}
 
   deploy-app_partner:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' && 'production' || 'preview' }}
     outputs:
       accessible-url: ${{ steps.deploy.outputs.accessible-url }}
@@ -125,7 +125,7 @@ jobs:
   # 3. Add GitHub Actions secret: VERCEL_MDS_DOCS_PROJECT_ID = <project-id>
   # The VERCEL_TOKEN and VERCEL_ORG_ID secrets are already shared.
   deploy-mds_docs:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' && 'production' || 'preview' }}
     outputs:
       accessible-url: ${{ steps.deploy.outputs.accessible-url }}
@@ -147,7 +147,7 @@ jobs:
   smoke-test:
     needs: [deploy-app_user, deploy-landing_user, deploy-landing_partner, deploy-app_partner, deploy-mds_docs]
     if: success()
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     env:
       IS_PROD: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' }}
     steps:

--- a/.github/workflows/monitor-allure.yml
+++ b/.github/workflows/monitor-allure.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   generate-report:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     permissions:
       contents: write
     steps:

--- a/.github/workflows/monitor-daily-lifecycle.yml
+++ b/.github/workflows/monitor-daily-lifecycle.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   seed-and-simulate:
     name: Seed and Simulate
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -84,7 +84,7 @@ jobs:
 
   client-cuj-test:
     needs: seed-and-simulate
-    runs-on: self-hosted
+    runs-on: [self-hosted, android]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -134,7 +134,7 @@ jobs:
 
   partner-cuj-test:
     needs: seed-and-simulate
-    runs-on: self-hosted
+    runs-on: [self-hosted, android]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/monitor-db-invariants.yml
+++ b/.github/workflows/monitor-db-invariants.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   check:
     name: Run DB invariant checks
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/monitor-patrol-e2e.yml
+++ b/.github/workflows/monitor-patrol-e2e.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   patrol-e2e-app-user:
-    runs-on: self-hosted
+    runs-on: [self-hosted, android]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/monitor-tick-user.yml
+++ b/.github/workflows/monitor-tick-user.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   simulate:
     name: Run User Activity Simulation
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     timeout-minutes: 10
     steps:
       - name: Run user activity simulation

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   # Migration version 중복 검사 (항상 실행 — path filter 없음)
   check-migration-versions:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     steps:
       - uses: actions/checkout@v6
       - name: Check duplicate migration versions
@@ -48,7 +48,7 @@ jobs:
 
   # env-manifest.json ↔ EnvKeyStore drift 검사 (항상 실행 — path filter 없음)
   check-env-manifest-sync:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     steps:
       - uses: actions/checkout@v6
       - name: Check env-manifest.json / EnvKeyStore sync
@@ -56,7 +56,7 @@ jobs:
 
   # 변경 사항 감지 Job
   changes:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     permissions:
       contents: read
       pull-requests: read
@@ -109,7 +109,7 @@ jobs:
     name: test-app-unit-widget-golden
     needs: changes
     if: ${{ needs.changes.outputs.app_user == 'true' || needs.changes.outputs.app_partner == 'true' || needs.changes.outputs.minglit_kit == 'true' || needs.changes.outputs.mds_core == 'true' }}
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     permissions:
       contents: write
       checks: write
@@ -290,7 +290,7 @@ jobs:
     name: lint-and-build-landing-user
     needs: changes
     if: ${{ needs.changes.outputs.landing_user == 'true' }}
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     defaults:
       run:
         working-directory: ./apps/landing_user
@@ -311,7 +311,7 @@ jobs:
     name: lint-and-build-landing-partner
     needs: changes
     if: ${{ needs.changes.outputs.landing_partner == 'true' }}
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     defaults:
       run:
         working-directory: ./apps/landing_partner
@@ -332,7 +332,7 @@ jobs:
     name: lint-and-build-mds-docs
     needs: changes
     if: ${{ needs.changes.outputs.mds_docs == 'true' || needs.changes.outputs.mds_tokens == 'true' || needs.changes.outputs.mds_icons == 'true' }}
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     defaults:
       run:
         working-directory: ./apps/mds/docs
@@ -354,7 +354,7 @@ jobs:
     name: lint-mds-icons
     needs: changes
     if: ${{ needs.changes.outputs.mds_icons == 'true' }}
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     defaults:
       run:
         working-directory: ./shared/packages/mds/icons
@@ -386,7 +386,7 @@ jobs:
     name: test-pgtap
     needs: changes
     if: ${{ needs.changes.outputs.supabase == 'true' }}
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     steps:
       - uses: actions/checkout@v6
       - uses: supabase/setup-cli@v2
@@ -415,7 +415,7 @@ jobs:
     name: test-deno-ef
     needs: changes
     if: ${{ needs.changes.outputs.supabase == 'true' }}
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     steps:
       - uses: actions/checkout@v6
       - uses: denoland/setup-deno@v2
@@ -468,7 +468,7 @@ jobs:
 
   # Workflow YAML 파싱 검증 (항상 실행 — db-invariants #1593 회귀 방지)
   check-workflow-yaml:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     steps:
       - uses: actions/checkout@v6
       - name: Validate all workflow YAML files
@@ -493,7 +493,7 @@ jobs:
   # runner와 orchestrator는 동일 major.minor 계열이어야 함 (1.5.x↔1.5.x, 1.6.x↔1.6.x)
   # Gradle consistent resolution이 혼용 시 빌드 실패를 발생시키므로 PR 단계에서 사전 차단.
   check-android-test-deps:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     steps:
       - uses: actions/checkout@v6
       - name: Verify androidx.test runner/orchestrator version alignment
@@ -518,7 +518,7 @@ jobs:
 
   # Fix #1872: block new cross-feature imports; existing violations are grandfathered in baseline
   check-cross-feature-imports:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     steps:
       - uses: actions/checkout@v6
       - name: Check cross-feature imports
@@ -527,7 +527,7 @@ jobs:
   ci-result:
     needs: [check-migration-versions, check-env-manifest-sync, check-workflow-yaml, check-android-test-deps, check-cross-feature-imports, test-flutter-apps, lint-landing-user, lint-landing-partner, lint-mds-docs, lint-mds-icons, test-supabase, test-edge-functions]
     if: always()
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     steps:
       - name: Check CI results
         env:

--- a/.github/workflows/shared-android-deploy.yml
+++ b/.github/workflows/shared-android-deploy.yml
@@ -61,7 +61,7 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
     defaults:
       run:

--- a/.github/workflows/shared-notify.yml
+++ b/.github/workflows/shared-notify.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   notify:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     permissions:
       issues: write
     steps:

--- a/.github/workflows/sync-format.yml
+++ b/.github/workflows/sync-format.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   auto-format:
     if: ${{ github.event.pull_request.head.repo.fork == false }}
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/sync-graphify.yml
+++ b/.github/workflows/sync-graphify.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   update:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/sync-mds-mockups.yml
+++ b/.github/workflows/sync-mds-mockups.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   render:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/sync-pr-branches.yml
+++ b/.github/workflows/sync-pr-branches.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   update-branches:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     # Fix #1972: job-level permissions — only what update-branch needs
     permissions:
       contents: write

--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -18,7 +18,7 @@ jobs:
     if: >-
       github.event.pull_request.merged == true &&
       !startsWith(github.event.pull_request.title, 'chore: bump version')
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/triage-dependabot.yml
+++ b/.github/workflows/triage-dependabot.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]'
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     steps:
       - name: Fetch Dependabot metadata
         id: metadata

--- a/.github/workflows/triage-label.yml
+++ b/.github/workflows/triage-label.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   add-needs-review:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     steps:
       - name: Add needs-review label
         env:

--- a/.github/workflows/triage-mds-issue.yml
+++ b/.github/workflows/triage-mds-issue.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   file-issue:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/triage-review.yml
+++ b/.github/workflows/triage-review.yml
@@ -30,7 +30,7 @@ jobs:
     if: >
       github.event_name != 'issue_comment' ||
       github.event.issue.pull_request != null
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     steps:
       - name: Check review presence
         uses: actions/github-script@v9

--- a/.github/workflows/triage-secret-scan.yml
+++ b/.github/workflows/triage-secret-scan.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   gitleaks:
     name: Gitleaks Secret Scan
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/triage-slash.yml
+++ b/.github/workflows/triage-slash.yml
@@ -13,7 +13,7 @@ jobs:
       github.event.issue.pull_request == null &&
       contains(github.event.comment.body, '/needs-') &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-    runs-on: self-hosted
+    runs-on: [self-hosted, ephemeral]
     concurrency:
       group: triage-slash-issue-${{ github.event.issue.number }}
       cancel-in-progress: false


### PR DESCRIPTION
## Summary

- Replace `runs-on: self-hosted` with explicit label sets (`[self-hosted, ephemeral]` or `[self-hosted, android]`) so jobs land on the right pool.
- 39 jobs across 22 workflows → `[self-hosted, ephemeral]` (lint/test/deploy/triage/sync).
- 3 emulator jobs → `[self-hosted, android]`: `monitor-patrol-e2e.patrol-e2e-app-user`, `monitor-daily-lifecycle.client-cuj-test`, `monitor-daily-lifecycle.partner-cuj-test`.

## Why

We split the self-hosted runner fleet into two pools:

- **Ephemeral** — light job per container, 4 GB / 3 CPU cap, no KVM, fresh state every job.
- **Android** — persistent runner, 8 GB / 4 CPU cap, `/dev/kvm` device, ANDROID_HOME / Gradle / pub cache on named volumes, EPHEMERAL=false to amortize AVD+SDK setup.

Both pools carry the `self-hosted` label, so a bare `runs-on: self-hosted` would non-deterministically pick either — risking emulator jobs on a 4 GB runner without KVM, or lint jobs occupying the heavier persistent runner. Explicit labels make routing predictable.

Runner infra (compose, KVM passthrough, `RUNNER_WORKDIR` path matching for docker-using actions) lives in [Mark-Yun/minglit-github-workflow-runner](https://github.com/Mark-Yun/minglit-github-workflow-runner).

## Test plan

- [ ] PR-triggered workflows (`pr-gate`, `triage-*`, `sync-*`) pick up on `minglit-runner-1` or `minglit-runner-2` (ephemeral pool).
- [ ] On next scheduled cycle, `monitor-patrol-e2e` and `monitor-daily-lifecycle` (CUJ jobs) run on `minglit-android-runner`.
- [ ] `monitor-daily-lifecycle.seed-and-simulate` (no emulator) still routes to ephemeral.
- [ ] No workflow stalls in `queued` state due to label mismatch (would indicate a missed runs-on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)