### PR TITLE
feat(mds-render): coverage monitor — daily cron + GitHub Issue alert

### DIFF
--- a/.github/workflows/monitor-mds-render-coverage.yml
+++ b/.github/workflows/monitor-mds-render-coverage.yml
@@ -1,0 +1,113 @@
+name: monitor-mds-render-coverage
+
+# MDS 77 화면 ↔ cataloged 화면 (apps/app_user/integration_test/mds-emulator-render/)
+# 차이를 매일 체크하여 100% 미만 시 GitHub Issue 생성/갱신.
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # UTC 자정 = KST 09:00
+  workflow_dispatch:
+
+concurrency:
+  group: monitor-mds-render-coverage
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  coverage:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Get pub deps (registry import 해결용)
+        working-directory: apps/app_user
+        run: flutter pub get
+
+      - name: Run coverage report (JSON)
+        id: cov
+        run: |
+          set +e
+          dart run scripts/mds_render_coverage.dart --json > /tmp/cov.json
+          EXIT=$?
+          set -e
+          cat /tmp/cov.json
+          echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"
+          # 사람 친화 출력도 로그에
+          dart run scripts/mds_render_coverage.dart || true
+
+      - name: Manage GitHub Issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # cov.json 파싱
+          PCT=$(jq -r '.screen_coverage_pct' /tmp/cov.json)
+          UNCOVERED=$(jq -r '.uncovered_screens | length' /tmp/cov.json)
+          ORPHAN=$(jq -r '.orphan_catalogs | length' /tmp/cov.json)
+
+          ISSUE_TITLE_PREFIX="[mds-render-coverage]"
+
+          # 기존 open 이슈 찾기
+          EXISTING=$(gh issue list \
+            --search "$ISSUE_TITLE_PREFIX in:title state:open" \
+            --json number,title \
+            --jq '.[0].number // empty')
+
+          if [ "${{ steps.cov.outputs.exit_code }}" = "0" ]; then
+            # 100% 달성 → 기존 이슈 close
+            if [ -n "$EXISTING" ]; then
+              gh issue close "$EXISTING" \
+                --comment "✅ Coverage 100% achieved on $(date -u +%Y-%m-%d). Auto-closed by monitor-mds-render-coverage."
+              echo "closed issue #$EXISTING"
+            else
+              echo "100% — no open issue to close"
+            fi
+            exit 0
+          fi
+
+          # 100% 미만 → 이슈 본문 생성
+          BODY=$(cat <<EOF
+          > 자동 갱신: $(date -u +%Y-%m-%dT%H:%M:%SZ) by monitor-mds-render-coverage
+
+          ## Summary
+          - 화면 커버리지: **${PCT}%** ($(jq -r '.cataloged_screens' /tmp/cov.json)/$(jq -r '.mds_screens' /tmp/cov.json))
+          - Uncovered MDS screens: **${UNCOVERED}**
+          - Orphan catalogs (MDS 에 없음): **${ORPHAN}**
+
+          ## Uncovered screens
+          \`\`\`
+          $(jq -r '.uncovered_screens | .[]' /tmp/cov.json)
+          \`\`\`
+
+          ## Orphan catalogs
+          \`\`\`
+          $(jq -r '.orphan_catalogs | .[]' /tmp/cov.json)
+          \`\`\`
+
+          ## Per-screen state count
+          \`\`\`
+          $(jq -r '.per_screen[] | "\(.screen): \(.captured_pngs)/\(.mds_state_pngs)"' /tmp/cov.json)
+          \`\`\`
+
+          ## 다음 액션
+          - 새 화면 추가: \`apps/app_user/integration_test/mds-emulator-render/home_page/\` 패턴 복제
+          - 상세: \`apps/app_user/integration_test/mds-emulator-render/architecture.md\`
+          EOF
+          )
+
+          if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" --body "$BODY"
+            echo "updated issue #$EXISTING"
+          else
+            gh issue create \
+              --title "$ISSUE_TITLE_PREFIX ${UNCOVERED} screens uncovered (${PCT}%)" \
+              --label "documentation,P3-low" \
+              --body "$BODY"
+          fi

--- a/apps/app_user/integration_test/mds-emulator-render/_engine/manifest.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_engine/manifest.dart
@@ -1,0 +1,55 @@
+// _manifest.yaml 데이터 모델 + YAML 직렬화.
+//
+// 인스펙션 워크플로우가 MDS state index ↔ 캡처 PNG 페어링 시 사용.
+//
+// 출력 위치: docs/infra/mds-emulator-render/<screen>/_manifest.yaml
+//
+// 작성 주체: host 측 `scripts/mds_render_coverage.dart` 가 registry 의
+// 모든 catalog 를 import 한 뒤 본 클래스로 직렬화 → 파일 쓰기.
+// (driver 측 emulator 환경에서 작성 안 함 — catalog 메타데이터 접근 어려움)
+
+/// 한 state 의 manifest entry.
+class MdsManifestState {
+  const MdsManifestState({
+    required this.name,
+    required this.mdsIndex,
+    required this.tags,
+  });
+
+  final String name;
+  final int? mdsIndex;
+  final List<String> tags;
+}
+
+/// 한 화면 manifest.
+class MdsManifest {
+  const MdsManifest({
+    required this.screen,
+    required this.mdsSpec,
+    required this.states,
+  });
+
+  final String screen;
+  final String mdsSpec;
+  final List<MdsManifestState> states;
+
+  /// YAML 직렬화 (단순 — 외부 yaml 패키지 의존 없이).
+  String toYaml({DateTime? generatedAt}) {
+    final ts = (generatedAt ?? DateTime.now().toUtc()).toIso8601String();
+    final buf = StringBuffer()
+      ..writeln('schema: 1')
+      ..writeln('screen: $screen')
+      ..writeln('mds_spec: $mdsSpec')
+      ..writeln('generated_at: $ts')
+      ..writeln('states:');
+    for (final s in states) {
+      buf.writeln('  - name: ${s.name}');
+      if (s.mdsIndex != null) buf.writeln('    mds_index: ${s.mdsIndex}');
+      buf.writeln('    file: ${s.name}.png');
+      if (s.tags.isNotEmpty) {
+        buf.writeln('    tags: [${s.tags.join(', ')}]');
+      }
+    }
+    return buf.toString();
+  }
+}

--- a/apps/app_user/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_registry.dart
@@ -1,0 +1,14 @@
+// Catalog registry — 모든 화면 catalog 의 명시적 import.
+//
+// 새 화면을 추가하면 본 파일에 import + allCatalogs list 에 등록한다.
+// (filesystem 자동 스캔 대신 explicit list 사용 — coverage script /
+// CI shard 가 빌드 없이 list 를 읽을 수 있도록.)
+
+import '_engine/catalog.dart';
+import '_engine/builder.dart';
+import 'home_page/home_page_test.dart' as home_page;
+
+/// 모든 cataloged 화면의 명시적 list. 새 화면 추가 시 본 list 에 추가.
+final List<MdsCatalog<MdsScreenBuilder<dynamic>>> allCatalogs = [
+  home_page.catalog,
+];

--- a/scripts/mds_render_coverage.dart
+++ b/scripts/mds_render_coverage.dart
@@ -1,0 +1,145 @@
+#!/usr/bin/env dart
+// MDS render coverage reconciler.
+//
+// 파일시스템만 스캔 (Flutter SDK / dart import 의존 없음):
+//   - MDS spec: apps/mds/docs/public/specs/<screen>/state_*.png
+//   - Cataloged: apps/app_user/integration_test/mds-emulator-render/<screen>/
+//   - Captured: docs/infra/mds-emulator-render/<screen>/state-*.png
+//
+// 사용:
+//   dart run scripts/mds_render_coverage.dart            # 사람 친화 출력
+//   dart run scripts/mds_render_coverage.dart --json     # JSON
+//
+// 종료 코드:
+//   0 — 100% 화면 커버리지 + orphan 0
+//   1 — 부족 (uncovered screens 또는 orphan catalogs 존재)
+//   2 — 스크립트 자체 에러
+//
+// 주의: catalog 메타 (mdsIndex 등) 는 본 스크립트에서 접근 안 함. manifest
+// 작성은 Phase 2b 에서 별도 메커니즘으로 처리.
+
+import 'dart:convert';
+import 'dart:io';
+
+const _mdsSpecsRoot = 'apps/mds/docs/public/specs';
+const _catalogRoot =
+    'apps/app_user/integration_test/mds-emulator-render';
+const _renderRoot = 'docs/infra/mds-emulator-render';
+
+void main(List<String> args) {
+  try {
+    final json = args.contains('--json');
+
+    // MDS screen = `state_*.png` 가 1개 이상 있는 dir 만.
+    // (components 같은 컴포넌트 폴더 / `_template`, `_authoring` 제외)
+    final mdsScreens = _listDirs(_mdsSpecsRoot)
+        .where((d) => !d.startsWith('_'))
+        .where((d) => _countPngs('$_mdsSpecsRoot/$d', 'state_') > 0)
+        .toList();
+    final cataloged = _listDirs(_catalogRoot)
+        .where((d) => !d.startsWith('_')) // _engine, _mocks 등 제외
+        .toList();
+
+    final uncovered = mdsScreens.where((s) => !cataloged.contains(s)).toList();
+    final orphan = cataloged.where((c) => !mdsScreens.contains(c)).toList();
+
+    final perScreen = <Map<String, dynamic>>[];
+    for (final screen in cataloged) {
+      final mdsStateCount = _countPngs('$_mdsSpecsRoot/$screen', 'state_');
+      final capturedCount = _countPngs('$_renderRoot/$screen', 'state-');
+      perScreen.add({
+        'screen': screen,
+        'mds_state_pngs': mdsStateCount,
+        'captured_pngs': capturedCount,
+        'complete': capturedCount >= mdsStateCount && mdsStateCount > 0,
+      });
+    }
+
+    final screenPct = mdsScreens.isEmpty
+        ? 100.0
+        : (cataloged.toSet().intersection(mdsScreens.toSet()).length /
+                mdsScreens.length) *
+            100;
+
+    final summary = {
+      'mds_screens': mdsScreens.length,
+      'cataloged_screens': cataloged.length,
+      'screen_coverage_pct': screenPct.toStringAsFixed(1),
+      'uncovered_screens': uncovered..sort(),
+      'orphan_catalogs': orphan..sort(),
+      'per_screen': perScreen,
+    };
+
+    if (json) {
+      print(const JsonEncoder.withIndent('  ').convert(summary));
+    } else {
+      _printHuman(summary);
+    }
+
+    exit(uncovered.isEmpty && orphan.isEmpty ? 0 : 1);
+  } catch (e, st) {
+    stderr.writeln('[coverage] error: $e\n$st');
+    exit(2);
+  }
+}
+
+/// [path] 안의 모든 디렉토리 이름 (basename).
+List<String> _listDirs(String path) {
+  final dir = Directory(path);
+  if (!dir.existsSync()) return [];
+  return dir
+      .listSync()
+      .whereType<Directory>()
+      .map((d) => d.uri.pathSegments.where((s) => s.isNotEmpty).last)
+      .toList()
+    ..sort();
+}
+
+/// [dirPath] 안의 `<prefix>*.png` 파일 개수.
+int _countPngs(String dirPath, String prefix) {
+  final dir = Directory(dirPath);
+  if (!dir.existsSync()) return 0;
+  return dir
+      .listSync()
+      .whereType<File>()
+      .where((f) {
+        final name = f.uri.pathSegments.last;
+        return name.startsWith(prefix) && name.endsWith('.png');
+      })
+      .length;
+}
+
+void _printHuman(Map<String, dynamic> s) {
+  print('═' * 60);
+  print('  MDS Render Coverage');
+  print('═' * 60);
+  print('  Total MDS screens     : ${s['mds_screens']}');
+  print('  Cataloged screens     : ${s['cataloged_screens']}');
+  print('  Screen coverage       : ${s['screen_coverage_pct']}%');
+  print('');
+  print('─── Per-screen ──────────────────────────────────────────');
+  for (final p in s['per_screen'] as List) {
+    final mark = p['complete'] as bool ? '✓' : '⚠';
+    print('  $mark ${p['screen']}: '
+        'tested ${p['captured_pngs']} / mds ${p['mds_state_pngs']}');
+  }
+  final uncovered = s['uncovered_screens'] as List;
+  if (uncovered.isNotEmpty) {
+    print('');
+    print('─── Uncovered MDS screens (${uncovered.length}) ──────────');
+    for (final name in uncovered.take(10)) {
+      print('  - $name');
+    }
+    if (uncovered.length > 10) {
+      print('  ... +${uncovered.length - 10} more');
+    }
+  }
+  final orphan = s['orphan_catalogs'] as List;
+  if (orphan.isNotEmpty) {
+    print('');
+    print('─── Orphan catalogs (MDS 에 없음) ─────────────────────');
+    for (final name in orphan) {
+      print('  - $name');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
\`mds-emulator-render\` 화면 커버리지가 100% 미만일 때 자동으로 GitHub Issue 생성/갱신, 100% 달성 시 자동 close.

## 변경 (4 파일)
- \`scripts/mds_render_coverage.dart\` — filesystem 기반 리포트 (Flutter SDK 의존 0)
- \`.github/workflows/monitor-mds-render-coverage.yml\` — daily cron + dedup
- \`apps/app_user/integration_test/mds-emulator-render/_engine/manifest.dart\` — \`_manifest.yaml\` 데이터 모델 (실제 사용 Phase 2b)
- \`apps/app_user/integration_test/mds-emulator-render/_registry.dart\` — 모든 catalog 명시적 list

## 검증 (로컬)

\`\`\`
$ dart run scripts/mds_render_coverage.dart
═════════════════════════════════════════════
  MDS Render Coverage
═════════════════════════════════════════════
  Total MDS screens     : 66
  Cataloged screens     : 1
  Screen coverage       : 1.5%

─── Per-screen ─────────────────────────────
  ⚠ home_page: tested 4 / mds 5

─── Uncovered MDS screens (65) ────────────
  - account_management_page
  - auth_callback_page
  ... +63 more

exit 1
\`\`\`

워크플로우 첫 실행 시 위 데이터로 이슈 자동 생성 예상.

## 이슈 dedup 로직
- 같은 \`[mds-render-coverage]\` prefix open 이슈 있으면 → body 만 update
- 없으면 신규 create
- 100% 달성 시 → 기존 이슈 close + 코멘트

## Phase 2b (별도 PR)
- runner 가 \`_manifest.yaml\` 자동 작성 (현재는 데이터 모델만)
- _registry.dart 기반 CI shard parallelization
- 후속 화면 catalog 추가 (event_detail_page 등)

🤖 Generated with [Claude Code](https://claude.com/claude-code)