### PR TITLE
fix(monitor-mds-render-coverage): drop obsolete flutter pub get step

### DIFF
--- a/.github/workflows/monitor-mds-render-coverage.yml
+++ b/.github/workflows/monitor-mds-render-coverage.yml
@@ -27,10 +27,6 @@ jobs:
           channel: 'stable'
           cache: true
 
-      - name: Get pub deps (registry import 해결용)
-        working-directory: apps/app_user
-        run: flutter pub get
-
       - name: Run coverage report (JSON)
         id: cov
         run: |


### PR DESCRIPTION
## Summary
이전 PR (#2471) 의 워크플로우 첫 실행 (run #25978827530) 이 \`flutter pub get\` 단계에서 fail:

\`\`\`
fatal: detected dubious ownership in repository at '/opt/hostedtoolcache/flutter/...'
\`\`\`

근본 원인: 그 단계는 coverage script 가 \`_registry.dart\` 를 import 하던 시절의 잔재. 스크립트는 filesystem-only scan 으로 전환됐는데 워크플로우만 안 갱신.

## 변경
- \`.github/workflows/monitor-mds-render-coverage.yml\`: \`Get pub deps (registry import 해결용)\` step 제거 (4 줄)

\`flutter SDK\` setup (subosito/flutter-action) 자체는 유지 — dart runtime 사용을 위해 필요.

## Test plan
- [x] script 가 dart 표준 라이브러리만 사용 (Flutter framework 호출 없음)
- [ ] 머지 후 워크플로우 재실행하여 fail 해소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)