### PR TITLE
fix(ci): add setup-node to Vercel deploy actions — Fix #2382

### DIFF
--- a/.github/actions/deploy-flutter-app/action.yml
+++ b/.github/actions/deploy-flutter-app/action.yml
@@ -77,6 +77,11 @@ runs:
           cp -r ${{ inputs.working-directory }}/api/. ${{ inputs.working-directory }}/build/web/api/
         fi
 
+    # Fix #2382: self-hosted ephemeral runners don't have Node.js pre-installed
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
     - name: Deploy to Vercel
       id: vercel-deploy
       shell: bash

--- a/.github/actions/deploy-nextjs-app/action.yml
+++ b/.github/actions/deploy-nextjs-app/action.yml
@@ -29,6 +29,11 @@ runs:
       shell: bash
       run: cp -- env-manifest.json "${{ inputs.working-directory }}/env-manifest.json"
 
+    # Fix #2382: self-hosted ephemeral runners don't have Node.js pre-installed
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
     - name: Deploy to Vercel
       id: deploy
       shell: bash


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 원인

PR #2457로 GitHub-hosted runner(`ubuntu-latest`)에서 self-hosted ephemeral runner로 마이그레이션한 이후 Vercel 배포가 연속 실패.

GitHub-hosted runner는 Node.js가 pre-installed되어 있어 `npx`가 바로 동작했지만, self-hosted ephemeral 컨테이너에는 Node.js가 없어 exit code 127 (command not found) 발생.

- `deploy-nextjs-app`: `npx --yes vercel@latest` → exit 127
- `deploy-flutter-app`: `npx vercel` → exit 128

## 수정 내용

`actions/setup-node@v4`(Node.js 20)를 두 composite action에 추가:
- `.github/actions/deploy-nextjs-app/action.yml` — "Copy env-manifest" 다음, "Deploy to Vercel" 이전
- `.github/actions/deploy-flutter-app/action.yml` — "Copy vercel.json" 다음, "Deploy to Vercel" 이전

Flutter 빌드는 Node.js 불필요 → flutter 빌드 완료 후 setup-node 배치.

## 검증

CI 통과 후 Vercel deploy workflow를 `workflow_dispatch`로 수동 트리거하면 배포 성공 여부 확인 가능.

Closes #2382