### PR TITLE
fix(event-repo): guard cancelOrder against null/non-Map response.data — Fix #2394

### DIFF
--- a/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_commands.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/event_repository_commands.dart
@@ -73,8 +73,13 @@ mixin _EventRepositoryCommands on _SupabaseEventContext {
         throw MinglitUserException(errorMsg);
       }
 
-      final data = response.data as Map<String, dynamic>;
-      final type = data['type'] as String;
+      // Fix #2394: response.data가 null이거나 Map이 아닐 때 CastError로 크래시.
+      final rawData = response.data;
+      if (rawData is! Map) {
+        throw const MinglitUserException('취소 요청에 실패했습니다.');
+      }
+      final data = Map<String, dynamic>.from(rawData);
+      final type = (data['type'] as String?) ?? 'cancelled';
       int? refundAmount;
       if (type == 'refunded') {
         final refundData = data['data'] as Map<String, dynamic>?;

--- a/shared/packages/minglit_kit/test/src/data/repositories/event_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/event_repository_test.dart
@@ -199,6 +199,57 @@ void main() {
           throwsA(anything),
         );
       });
+
+      // Fix #2394: response.data가 null이면 CastError로 크래시 발생했던 버그 재발 방지
+      test('throws MinglitUserException when response.data is null', () async {
+        when(
+          () => mockFunctions.invoke(
+            'user-cancel-order',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(status: 200, data: null),
+        );
+
+        await expectLater(
+          repository.cancelOrder(eventId: 'event_1'),
+          throwsA(isA<MinglitUserException>()),
+        );
+      });
+
+      test('throws MinglitUserException when response.data is not a Map', () async {
+        when(
+          () => mockFunctions.invoke(
+            'user-cancel-order',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(status: 200, data: 'ok'),
+        );
+
+        await expectLater(
+          repository.cancelOrder(eventId: 'event_1'),
+          throwsA(isA<MinglitUserException>()),
+        );
+      });
+
+      test('returns refunded result with refundAmount', () async {
+        when(
+          () => mockFunctions.invoke(
+            'user-cancel-order',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'type': 'refunded', 'data': {'refund_amount': 30000}},
+          ),
+        );
+
+        final result = await repository.cancelOrder(eventId: 'event_1');
+        expect(result.type, 'refunded');
+        expect(result.refundAmount, 30000);
+      });
     });
 
     group('confirmPayment', () {


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 원인

`cancelOrder`에서 `response.data as Map<String, dynamic>` (line 76) 가 null이거나 Map이 아닐 때 `CastError`로 크래시.

로그 패턴: `cancelOrder called | event: ...` 직후 앱 종료 (layout dump: native FrameLayout만 남음).

## 수정 내용

**`shared/packages/minglit_kit/lib/src/data/repositories/event_repository_commands.dart`**
- `response.data as Map<String, dynamic>` → 명시적 타입 가드 추가
- null 또는 비-Map이면 `MinglitUserException('취소 요청에 실패했습니다.')` throw

## Design System

해당 없음 (비-UI 버그 수정)

## 회귀 방지 테스트

**`shared/packages/minglit_kit/test/src/data/repositories/event_repository_test.dart`**
- `response.data is null` → `MinglitUserException` throw
- `response.data is String` → `MinglitUserException` throw
- `type == 'refunded'` → `refundAmount` 정상 파싱
- fix를 revert하면 테스트 실패 확인됨

```
flutter test test/src/data/repositories/event_repository_test.dart --name "cancelOrder"
00:00 +5: All tests passed!
```

Closes #2394