### PR TITLE
fix(sim): exclude completed events from user app limit — Fix #2410

### DIFF
--- a/supabase/functions/backend-simulator/tick/factories/user_action_factory.ts
+++ b/supabase/functions/backend-simulator/tick/factories/user_action_factory.ts
@@ -47,9 +47,14 @@ export class UserActionFactory {
     if (myAppsError) throw new Error(`Failed to fetch applications: ${myAppsError.message}`);
 
     const appliedIds = new Set((myApps ?? []).map((a) => a.event_id as string));
-    let activeAppCount = (myApps ?? []).filter(
-      (a) => (a.status as string) !== "cancelled",
-    ).length;
+    // Fix #2410: exclude completed events from activeAppCount — accumulated completed
+    // events were blocking new applications by maxing out maxAppsPerUser.
+    let activeAppCount = (myApps ?? []).filter((a) => {
+      if ((a.status as string) === "cancelled") return false;
+      const ev = a.events as unknown as { status: string } | null;
+      if (ev?.status === "completed") return false;
+      return true;
+    }).length;
 
     // 3. Apply to un-applied events from feed (up to maxAppsPerUser)
     for (const event of feedEvents) {


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 원인

`UserActionFactory`에서 `activeAppCount`를 계산할 때 `status: 'completed'` 이벤트의 신청도 카운트에 포함.

축적된 2,700개+ completed [E2E] 이벤트 때문에 시드 유저 대부분이 `maxAppsPerUser` (기본: 3)에 도달 → 새 이벤트 신청 불가 → `total_actions: 0` stale loop.

## 수정

`activeAppCount` 필터에 event status 조건 추가:
- `status === 'cancelled'` 제외 (기존)
- `events.status === 'completed'` 제외 (추가)

이미 `events(status, start_time)` join이 있으므로 추가 DB 쿼리 불필요.

Closes #2410