### PR TITLE
feat(monitor-mds-render-coverage): include state-level coverage + incomplete screens

### DIFF
--- a/.github/workflows/monitor-mds-render-coverage.yml
+++ b/.github/workflows/monitor-mds-render-coverage.yml
@@ -44,9 +44,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # cov.json 파싱
-          PCT=$(jq -r '.screen_coverage_pct' /tmp/cov.json)
+          SCREEN_PCT=$(jq -r '.screen_coverage_pct' /tmp/cov.json)
+          STATE_PCT=$(jq -r '.state_coverage_pct' /tmp/cov.json)
+          CATALOGED=$(jq -r '.cataloged_screens' /tmp/cov.json)
+          MDS_SCREENS=$(jq -r '.mds_screens' /tmp/cov.json)
+          CAPTURED_STATES=$(jq -r '.captured_states' /tmp/cov.json)
+          MDS_STATES=$(jq -r '.mds_states' /tmp/cov.json)
           UNCOVERED=$(jq -r '.uncovered_screens | length' /tmp/cov.json)
           ORPHAN=$(jq -r '.orphan_catalogs | length' /tmp/cov.json)
+          INCOMPLETE=$(jq -r '.incomplete_screens | length' /tmp/cov.json)
 
           ISSUE_TITLE_PREFIX="[mds-render-coverage]"
 
@@ -73,16 +79,23 @@ jobs:
           > 자동 갱신: $(date -u +%Y-%m-%dT%H:%M:%SZ) by monitor-mds-render-coverage
 
           ## Summary
-          - 화면 커버리지: **${PCT}%** ($(jq -r '.cataloged_screens' /tmp/cov.json)/$(jq -r '.mds_screens' /tmp/cov.json))
+          - 화면 커버리지: **${SCREEN_PCT}%** (${CATALOGED}/${MDS_SCREENS})
+          - State 커버리지: **${STATE_PCT}%** (${CAPTURED_STATES}/${MDS_STATES})
           - Uncovered MDS screens: **${UNCOVERED}**
+          - Incomplete screens (state 부족): **${INCOMPLETE}**
           - Orphan catalogs (MDS 에 없음): **${ORPHAN}**
 
-          ## Uncovered screens
+          ## Uncovered screens (전혀 cataloged 안 됨)
           \`\`\`
           $(jq -r '.uncovered_screens | .[]' /tmp/cov.json)
           \`\`\`
 
-          ## Orphan catalogs
+          ## Incomplete screens (cataloged 됐지만 state 부족)
+          \`\`\`
+          $(jq -r '.incomplete_screens[] | "\(.screen): captured \(.captured) / mds \(.mds) (missing \(.missing))"' /tmp/cov.json)
+          \`\`\`
+
+          ## Orphan catalogs (MDS 에 대응 spec 없음 — 컴포넌트 dir 일 가능성)
           \`\`\`
           $(jq -r '.orphan_catalogs | .[]' /tmp/cov.json)
           \`\`\`
@@ -94,6 +107,7 @@ jobs:
 
           ## 다음 액션
           - 새 화면 추가: \`apps/app_user/integration_test/mds-emulator-render/home_page/\` 패턴 복제
+          - state 추가: 해당 화면의 \`<screen>_test.dart\` 의 catalog states list 에 entry 추가
           - 상세: \`apps/app_user/integration_test/mds-emulator-render/architecture.md\`
           EOF
           )
@@ -103,7 +117,7 @@ jobs:
             echo "updated issue #$EXISTING"
           else
             gh issue create \
-              --title "$ISSUE_TITLE_PREFIX ${UNCOVERED} screens uncovered (${PCT}%)" \
+              --title "$ISSUE_TITLE_PREFIX ${UNCOVERED} screens + ${INCOMPLETE} incomplete (${STATE_PCT}% states)" \
               --label "docs,P3-low" \
               --body "$BODY"
           fi

--- a/scripts/mds_render_coverage.dart
+++ b/scripts/mds_render_coverage.dart
@@ -43,16 +43,34 @@ void main(List<String> args) {
     final uncovered = mdsScreens.where((s) => !cataloged.contains(s)).toList();
     final orphan = cataloged.where((c) => !mdsScreens.contains(c)).toList();
 
+    // 전체 MDS state 합산 (cataloged 여부와 무관) — 진짜 state 커버리지 분모.
+    var totalMdsStates = 0;
+    for (final screen in mdsScreens) {
+      totalMdsStates += _countPngs('$_mdsSpecsRoot/$screen', 'state_');
+    }
+
     final perScreen = <Map<String, dynamic>>[];
+    var totalCapturedStates = 0;
+    final incompleteScreens = <Map<String, dynamic>>[];
     for (final screen in cataloged) {
       final mdsStateCount = _countPngs('$_mdsSpecsRoot/$screen', 'state_');
       final capturedCount = _countPngs('$_renderRoot/$screen', 'state-');
+      final complete = capturedCount >= mdsStateCount && mdsStateCount > 0;
       perScreen.add({
         'screen': screen,
         'mds_state_pngs': mdsStateCount,
         'captured_pngs': capturedCount,
-        'complete': capturedCount >= mdsStateCount && mdsStateCount > 0,
+        'complete': complete,
       });
+      totalCapturedStates += capturedCount;
+      if (!complete && mdsStateCount > 0) {
+        incompleteScreens.add({
+          'screen': screen,
+          'captured': capturedCount,
+          'mds': mdsStateCount,
+          'missing': mdsStateCount - capturedCount,
+        });
+      }
     }
 
     final screenPct = mdsScreens.isEmpty
@@ -60,13 +78,20 @@ void main(List<String> args) {
         : (cataloged.toSet().intersection(mdsScreens.toSet()).length /
                 mdsScreens.length) *
             100;
+    final statePct = totalMdsStates == 0
+        ? 100.0
+        : (totalCapturedStates / totalMdsStates) * 100;
 
     final summary = {
       'mds_screens': mdsScreens.length,
       'cataloged_screens': cataloged.length,
       'screen_coverage_pct': screenPct.toStringAsFixed(1),
+      'mds_states': totalMdsStates,
+      'captured_states': totalCapturedStates,
+      'state_coverage_pct': statePct.toStringAsFixed(1),
       'uncovered_screens': uncovered..sort(),
       'orphan_catalogs': orphan..sort(),
+      'incomplete_screens': incompleteScreens,
       'per_screen': perScreen,
     };
 
@@ -76,7 +101,12 @@ void main(List<String> args) {
       _printHuman(summary);
     }
 
-    exit(uncovered.isEmpty && orphan.isEmpty ? 0 : 1);
+    // 성공 조건: 모든 MDS screen cataloged + orphan 없음 + 모든 cataloged
+    // screen 의 state 가 MDS state 수 이상 captured.
+    final pass = uncovered.isEmpty &&
+        orphan.isEmpty &&
+        incompleteScreens.isEmpty;
+    exit(pass ? 0 : 1);
   } catch (e, st) {
     stderr.writeln('[coverage] error: $e\n$st');
     exit(2);
@@ -113,9 +143,8 @@ void _printHuman(Map<String, dynamic> s) {
   print('═' * 60);
   print('  MDS Render Coverage');
   print('═' * 60);
-  print('  Total MDS screens     : ${s['mds_screens']}');
-  print('  Cataloged screens     : ${s['cataloged_screens']}');
-  print('  Screen coverage       : ${s['screen_coverage_pct']}%');
+  print('  MDS screens           : ${s['cataloged_screens']}/${s['mds_screens']} (${s['screen_coverage_pct']}%)');
+  print('  MDS states            : ${s['captured_states']}/${s['mds_states']} (${s['state_coverage_pct']}%)');
   print('');
   print('─── Per-screen ──────────────────────────────────────────');
   for (final p in s['per_screen'] as List) {


### PR DESCRIPTION
screen + state 두 메트릭 모두 100% 일 때만 통과. incomplete_screens (cataloged 됐지만 state 부족) 도 이슈에 포함.

검증:
- MDS screens: 1/66 (1.5%) + state 4/369 (1.1%)
- home_page incomplete (4/5) 정확히 검출
- exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)