### PR TITLE
fix(search): add a11y labels to TextField and clear button — Fix #2390

### DIFF
--- a/apps/app_user/lib/src/features/search/search_page.dart
+++ b/apps/app_user/lib/src/features/search/search_page.dart
@@ -54,24 +54,32 @@ class _SearchPageState extends ConsumerState<SearchPage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: TextField(
-          controller: _controller,
-          autofocus: true,
-          onChanged: _onSearchChanged,
-          decoration: InputDecoration(
-            hintText: '이벤트 검색',
-            border: InputBorder.none,
-            suffixIcon: ValueListenableBuilder<TextEditingValue>(
-              valueListenable: _controller,
-              builder: (_, value, _) => value.text.isNotEmpty
-                  ? IconButton(
-                      icon: const Icon(Icons.clear),
-                      onPressed: () {
-                        _controller.clear();
-                        ref.read(searchQueryProvider.notifier).clear();
-                      },
-                    )
-                  : const SizedBox.shrink(),
+        // Fix #2390: Wrap with Semantics so Android contentDescription is set
+        // for the TextField (hintText alone leaves content-desc="" → NAF=true).
+        title: Semantics(
+          label: '이벤트 검색 입력',
+          textField: true,
+          child: TextField(
+            controller: _controller,
+            autofocus: true,
+            onChanged: _onSearchChanged,
+            decoration: InputDecoration(
+              hintText: '이벤트 검색',
+              border: InputBorder.none,
+              suffixIcon: ValueListenableBuilder<TextEditingValue>(
+                valueListenable: _controller,
+                builder: (_, value, _) => value.text.isNotEmpty
+                    ? IconButton(
+                        icon: const Icon(Icons.clear),
+                        // Fix #2390: tooltip sets Android contentDescription → NAF 해소
+                        tooltip: '입력 지우기',
+                        onPressed: () {
+                          _controller.clear();
+                          ref.read(searchQueryProvider.notifier).clear();
+                        },
+                      )
+                    : const SizedBox.shrink(),
+              ),
             ),
           ),
         ),

--- a/apps/app_user/test/src/features/search/search_page_a11y_test.dart
+++ b/apps/app_user/test/src/features/search/search_page_a11y_test.dart
@@ -1,0 +1,73 @@
+// Fix #2390: Regression tests for search page accessibility labels.
+// Verifies that NAF=true (Not Accessibility Friendly) issues are resolved.
+import 'package:app_user/src/features/search/logic/search_coordinator.dart';
+import 'package:app_user/src/features/search/search_page.dart';
+import 'package:app_user/src/logic/feed_state_provider.dart';
+import 'package:app_user/src/routing/app_router.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockGoRouter extends Mock implements GoRouter {}
+
+Widget _buildTestWidget({List<Override> extraOverrides = const []}) {
+  final mockRouter = _MockGoRouter();
+  when(() => mockRouter.push(any())).thenAnswer((_) async => null);
+
+  return ProviderScope(
+    overrides: [
+      searchResultsProvider.overrideWith((_) => const AsyncValue.data([])),
+      goRouterProvider.overrideWithValue(mockRouter),
+      searchCoordinatorProvider.overrideWith(
+        (ref) => SearchCoordinator(ref.read(goRouterProvider)),
+      ),
+      ...extraOverrides,
+    ],
+    child: MaterialApp(
+      home: const SearchPage(),
+    ),
+  );
+}
+
+void main() {
+  group('SearchPage a11y — Fix #2390', () {
+    testWidgets('TextField has Semantics label for screen readers', (tester) async {
+      await tester.pumpWidget(_buildTestWidget());
+      await tester.pump();
+
+      // The Semantics wrapper must exist with the correct label
+      final semanticsFinder = find.byWidgetPredicate(
+        (w) => w is Semantics && w.properties.label == '이벤트 검색 입력',
+      );
+      expect(semanticsFinder, findsOneWidget);
+    });
+
+    testWidgets('clear button has tooltip when text is present', (tester) async {
+      await tester.pumpWidget(_buildTestWidget());
+      await tester.pump();
+
+      // Enter text to make the clear button appear
+      await tester.enterText(find.byType(TextField), '스포츠');
+      await tester.pump();
+
+      // Clear button (IconButton) must have tooltip set — tooltip drives Android contentDescription
+      final clearButton = find.widgetWithIcon(IconButton, Icons.clear);
+      expect(clearButton, findsOneWidget);
+
+      final iconButton = tester.widget<IconButton>(clearButton);
+      expect(iconButton.tooltip, '입력 지우기');
+    });
+
+    testWidgets('clear button is absent when text field is empty', (tester) async {
+      await tester.pumpWidget(_buildTestWidget());
+      await tester.pump();
+
+      // No text → no clear button
+      expect(find.widgetWithIcon(IconButton, Icons.clear), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 원인

`search_page.dart`의 검색 TextField와 suffixIcon clear 버튼이 Android 접근성 트리에서 NAF=true (content-desc="") 반환.

Flutter `TextField`의 `hintText`는 visual placeholder이며 Android contentDescription을 채우지 않음 → 스크린리더 사용자에게 정보 미전달.

## Design System Reference

spec: `apps/mds/docs/public/specs/search_page/index.md` → AppBar / Blueprint & tree (suffixIcon: IconButton(Icons.clear))
MDS 패턴: AppBar의 모든 IconButton은 tooltip 부여 (home_page spec 참조)

이 수정은 순수 접근성 버그 수정으로 시각적 변화 없음.

## 수정 내용

**`apps/app_user/lib/src/features/search/search_page.dart`**
- `TextField`를 `Semantics(label: '이벤트 검색 입력', textField: true, child: ...)`로 감쌈 → Android contentDescription 부여
- suffixIcon `IconButton`에 `tooltip: '입력 지우기'` 추가 → tooltip이 contentDescription으로 변환되어 NAF 해소

## 회귀 방지 테스트

**`test/src/features/search/search_page_a11y_test.dart`** (신규)
1. TextField에 Semantics label `'이벤트 검색 입력'` 존재 검증
2. 텍스트 입력 후 clear 버튼의 tooltip `'입력 지우기'` 검증
3. 빈 상태에서 clear 버튼 미표시 검증

Closes #2390