### PR TITLE
fix(settlement): use MinglitEmptyState for dashboard error state — Fix #2415

### DIFF
--- a/apps/app_partner/lib/src/features/settlement/_settlement_dashboard_tab.dart
+++ b/apps/app_partner/lib/src/features/settlement/_settlement_dashboard_tab.dart
@@ -31,30 +31,17 @@ class _DashboardTab extends ConsumerWidget {
                 _StatusSummaryGrid(data: dashState.dashboardData),
               ],
               loading: () => [const Center(child: CircularProgressIndicator())],
-              error: (error, _) => [
-                Center(
-                  child: Column(
-                    children: [
-                      Text(
-                        '오류가 발생했습니다',
-                        style: Theme.of(context).textTheme.bodyMedium,
-                      ),
-                      const SizedBox(height: MinglitSpacing.small),
-                      Text(
-                        error.toString(),
-                        style: Theme.of(context).textTheme.bodySmall,
-                      ),
-                      const SizedBox(height: MinglitSpacing.medium),
-                      FilledButton(
-                        onPressed: () => ref
-                            .read(
-                              settlementDashboardControllerProvider.notifier,
-                            )
-                            .loadDashboard(),
-                        child: const Text('다시 시도'),
-                      ),
-                    ],
-                  ),
+              // Fix #2415: replace inline Column+Text with MinglitEmptyState — aligns with
+              // list tab's canonical error pattern; removes raw error.toString() from UI.
+              error: (_, _) => [
+                MinglitEmptyState(
+                  icon: Icons.error_outline,
+                  title: '대시보드를 불러오지 못했습니다',
+                  subtitle: '잠시 후 다시 시도해 주세요.',
+                  actionLabel: '다시 시도',
+                  onAction: () => ref
+                      .read(settlementDashboardControllerProvider.notifier)
+                      .loadDashboard(),
                 ),
               ],
             ),

--- a/apps/app_partner/test/src/features/settlement/settlement_page_test.dart
+++ b/apps/app_partner/test/src/features/settlement/settlement_page_test.dart
@@ -28,6 +28,15 @@ class _FakeSettlementDashboardController extends SettlementDashboardController {
   );
 }
 
+// Fix #2415: error state fake — returns AsyncError so the UI renders the error branch
+class _FakeErrorDashboardController extends SettlementDashboardController {
+  @override
+  SettlementDashboardState build() => SettlementDashboardState(
+    selectedMonth: DateTime(2026, 4),
+    status: AsyncValue.error(Exception('서버 오류'), StackTrace.empty),
+  );
+}
+
 class _FakeSettlementListController extends SettlementListController {
   @override
   SettlementListState build() => const SettlementListState();
@@ -156,6 +165,44 @@ void main() {
 
         expect(permissions, contains('SETTLEMENT_EDIT'));
         expect(permissions, contains('SETTLEMENT_VIEW'));
+      },
+    );
+  });
+
+  // Fix #2415 regression guard: dashboard error state must use MinglitEmptyState,
+  // not inline Column+Text — and must NOT expose raw error.toString() to users.
+  group('SettlementPage — Fix #2415: dashboard error state', () {
+    testWidgets(
+      '대시보드 오류 시 MinglitEmptyState가 표시된다',
+      (tester) async {
+        final mockRouter = MockGoRouter();
+        when(() => mockRouter.push(any())).thenAnswer((_) => Future.value());
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              currentMemberPermissionsProvider.overrideWith(
+                (ref) async => ['SETTLEMENT_VIEW'],
+              ),
+              currentPartnerInfoProvider.overrideWith(
+                (ref) async => const Partner(id: 'p1', name: 'Test'),
+              ),
+              settlementDashboardControllerProvider.overrideWith(
+                _FakeErrorDashboardController.new,
+              ),
+              settlementListControllerProvider.overrideWith(
+                _FakeSettlementListController.new,
+              ),
+              goRouterProvider.overrideWithValue(mockRouter),
+            ],
+            child: const MaterialApp(home: SettlementPage()),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.byType(MinglitEmptyState), findsOneWidget);
+        // Fix #2415: raw error.toString() must NOT be shown to users
+        expect(find.textContaining('Exception'), findsNothing);
       },
     );
   });


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Design System Reference

spec: `apps/mds/docs/public/specs/settlement_page/index.md:210,229`

해당 spec lines가 Dashboard error 상태의 "후속 통일 후보"를 명시하고 있음. 이번 PR로 해소.

## 원인

`_settlement_dashboard_tab.dart`의 error 분기가 `MinglitEmptyState` 미사용 인라인 `Center+Column+Text+FilledButton` 패턴 사용:
- 같은 화면 List tab과 시각적 결 불일치
- `error.toString()` raw 메시지 사용자에게 노출
- 아이콘 없음

## 수정 내용

**`apps/app_partner/lib/src/features/settlement/_settlement_dashboard_tab.dart`**
- error 분기 → `MinglitEmptyState(icon: Icons.error_outline, title: '대시보드를 불러오지 못했습니다', ...)` 로 교체
- List tab과 동일한 패턴 → 시각적 일관성 확보
- `error.toString()` 제거 → 민감 정보 미노출

## 회귀 방지 테스트

**`test/src/features/settlement/settlement_page_test.dart`** (기존 파일에 추가)
- `AsyncValue.error` 상태에서 `MinglitEmptyState` 렌더링 검증
- `find.textContaining('Exception')` → `findsNothing` 검증

Closes #2415