### PR TITLE
feat(partner): add AppBar info icon to 3 pages — Fix #2384

### DIFF
--- a/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
+++ b/apps/app_partner/lib/src/features/application/event_application_manage_page.dart
@@ -10,6 +10,22 @@ import 'package:riverpod/misc.dart';
 part 'event_application_manage_tab.dart';
 part 'event_application_manage_widgets.dart';
 
+// [mds-change] #2384: AppBar info icon 추가 — event_application_manage_page spec 동기화
+const _kApplicationHelpSections = [
+  HelpSection(
+    title: '신청 승인은 어떻게 하나요?',
+    body: '대기중 탭에서 신청자의 "승인" 버튼을 누르면 즉시 처리돼요. 승인된 참가자에게 티켓이 자동 발급됩니다.',
+  ),
+  HelpSection(
+    title: '거절하면 어떻게 되나요?',
+    body: '참가자에게 거절 알림이 전송되고 거절됨 탭으로 이동해요. 한번 거절한 신청은 되돌릴 수 없으니 신중하게 결정해 주세요.',
+  ),
+  HelpSection(
+    title: '신청 관리는 언제까지 가능한가요?',
+    body: '이벤트 시작 전까지 신청을 승인·거절할 수 있어요. 이벤트가 시작되면 더 이상 변경할 수 없습니다.',
+  ),
+];
+
 /// Event application management page — grouped by event with inline approve/reject.
 class EventApplicationManagePage extends ConsumerStatefulWidget {
   const EventApplicationManagePage({super.key});
@@ -44,6 +60,18 @@ class _EventApplicationManagePageState
       appBar: AppBar(
         title: const Text('신청관리'),
         centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.info_outline),
+            iconSize: 22,
+            tooltip: '도움말',
+            onPressed: () => showMinglitHelpSheet(
+              context: context,
+              title: '신청관리 가이드',
+              sections: _kApplicationHelpSections,
+            ),
+          ),
+        ],
         bottom: TabBar(
           controller: _tabController,
           tabs: const [

--- a/apps/app_partner/lib/src/features/home/partner_home_page.dart
+++ b/apps/app_partner/lib/src/features/home/partner_home_page.dart
@@ -16,6 +16,22 @@ import 'package:app_partner/src/routing/app_routes.dart';
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
+// [mds-change] #2384: AppBar info icon 추가 — partner_home_page spec 동기화
+const _kHomeHelpSections = [
+  HelpSection(
+    title: '대시보드에서 무엇을 할 수 있나요?',
+    body: '현재 진행 중인 이벤트, 모집 중인 이벤트, 임박한 일정을 한눈에 확인할 수 있어요.',
+  ),
+  HelpSection(
+    title: '이벤트는 어디서 만드나요?',
+    body: '하단 탭의 파티 관리에서 파티를 만든 뒤 이벤트를 추가할 수 있어요. 파티는 여러 이벤트를 묶는 단위예요.',
+  ),
+  HelpSection(
+    title: '신청자 관리는 어떻게 하나요?',
+    body: '하단 탭의 신청관리에서 대기 중인 신청을 승인하거나 거절할 수 있어요.',
+  ),
+];
+
 class PartnerHomePage extends ConsumerWidget {
   const PartnerHomePage({super.key});
 
@@ -42,6 +58,16 @@ class PartnerHomePage extends ConsumerWidget {
         centerTitle: false,
         surfaceTintColor: Colors.transparent,
         actions: [
+          IconButton(
+            icon: const Icon(Icons.info_outline),
+            iconSize: 22,
+            tooltip: '도움말',
+            onPressed: () => showMinglitHelpSheet(
+              context: context,
+              title: '파트너 홈 가이드',
+              sections: _kHomeHelpSections,
+            ),
+          ),
           const BugReportAction(),
           Stack(
             clipBehavior: Clip.none,

--- a/apps/app_partner/lib/src/features/settlement/settlement_page.dart
+++ b/apps/app_partner/lib/src/features/settlement/settlement_page.dart
@@ -12,6 +12,22 @@ import 'package:minglit_kit/minglit_kit.dart';
 part '_settlement_dashboard_tab.dart';
 part '_settlement_list_tab.dart';
 
+// [mds-change] #2384: AppBar info icon 추가 — settlement_page spec 동기화
+const _kSettlementHelpSections = [
+  HelpSection(
+    title: '정산은 어떻게 진행되나요?',
+    body: '이벤트 종료 후 매칭된 참가자 기준으로 정산 금액이 계산돼요. 영업일 기준 7일 내에 등록된 계좌로 입금됩니다.',
+  ),
+  HelpSection(
+    title: '정산 상태는 무엇을 의미하나요?',
+    body: '처리중: 정산 계산 중 / 지급대기: 입금 준비 완료 / 정산완료: 계좌 입금 완료를 의미해요.',
+  ),
+  HelpSection(
+    title: '계좌 정보는 어디서 변경하나요?',
+    body: '우측 상단 계좌 관리 버튼을 눌러 등록·변경할 수 있어요. 정산 전에 계좌 정보를 정확히 입력해 주세요.',
+  ),
+];
+
 class SettlementPage extends ConsumerStatefulWidget {
   const SettlementPage({super.key, this.initialIndex = 0});
 
@@ -52,6 +68,16 @@ class _SettlementPageState extends ConsumerState<SettlementPage>
       appBar: AppBar(
         title: const Text('정산'),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.info_outline),
+            iconSize: 22,
+            tooltip: '도움말',
+            onPressed: () => showMinglitHelpSheet(
+              context: context,
+              title: '정산 가이드',
+              sections: _kSettlementHelpSections,
+            ),
+          ),
           if (canEditSettlement)
             IconButton(
               key: const Key('bankAccountButton'),


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Design System Reference

spec: `apps/mds/docs/public/specs/event_application_manage_page/index.html` → AppBar sub-anatomy (② Info action trailing)
spec: `apps/mds/docs/public/specs/settlement_page/index.html` → AppBar sub-anatomy  
spec: `apps/mds/docs/public/specs/partner_home_page/index.html` → AppBar sub-anatomy

spec change: `e1cc82a` (PR #2380) — AppBar info 아이콘 패턴 3개 spec 동기화

## 수정 내용

MDS spec 동기화: 3개 파트너 앱 화면에 `info_outline` IconButton 추가.
기존 `party_list_page.dart`의 `showMinglitHelpSheet` 패턴을 따름 (Fix #2200).

- **`event_application_manage_page.dart`**: `actions: [IconButton(info_outline)]` 추가 → 신청관리 가이드 (Q&A 3개)
- **`settlement_page.dart`**: 계좌 관리 버튼 앞에 info icon 추가 → 정산 가이드 (Q&A 3개)
- **`partner_home_page.dart`**: BugReportAction 앞에 info icon 추가 → 파트너 홈 가이드 (Q&A 3개)

Closes #2384