### PR TITLE
fix(notification): use MinglitEmptyState for empty/error states — Fix #2413 #2414

### DIFF
--- a/shared/packages/minglit_kit/lib/src/features/notification/notification_list_screen.dart
+++ b/shared/packages/minglit_kit/lib/src/features/notification/notification_list_screen.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:mds/src/theme/minglit_theme.dart';
 import 'package:mds/src/ui/widgets/common/minglit_async_value_widget.dart';
+import 'package:mds/src/ui/widgets/common/minglit_empty_state.dart';
 import 'package:minglit_kit/src/features/notification/notification_list_controller.dart';
 
 /// Displays the list of user notifications.
@@ -37,8 +38,13 @@ class NotificationListScreen extends ConsumerWidget {
       body: MinglitAsyncValueWidget(
         value: notificationState,
         data: (notifications) {
+          // Fix #2414: replace plain Text with canonical MinglitEmptyState
           if (notifications.isEmpty) {
-            return const Center(child: Text('알림이 없습니다.'));
+            return const MinglitEmptyState(
+              icon: Icons.notifications_none_outlined,
+              title: '알림이 없습니다',
+              subtitle: '새 알림이 오면 여기에 표시됩니다.',
+            );
           }
 
           return RefreshIndicator(
@@ -134,7 +140,14 @@ class NotificationListScreen extends ConsumerWidget {
             ),
           );
         },
-        error: (err, stack) => Center(child: Text('에러: $err')),
+        // Fix #2413: remove raw err.toString() exposure; use canonical error UI
+        error: (_, _) => MinglitEmptyState(
+          icon: Icons.error_outline,
+          title: '알림을 불러오지 못했습니다',
+          subtitle: '잠시 후 다시 시도해 주세요.',
+          actionLabel: '다시 시도',
+          onAction: () => ref.invalidate(notificationListProvider),
+        ),
       ),
     );
   }


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Design System Reference

spec: `apps/mds/docs/public/specs/notification_list_screen/index.md:106,131`

## 수정 내용

**`shared/packages/minglit_kit/lib/src/features/notification/notification_list_screen.dart`**

Empty state (Fix #2414): `Center(child: Text('알림이 없습니다.'))` → `MinglitEmptyState(icon, title, subtitle)`
Error state (Fix #2413): `Center(child: Text('에러: $err'))` → `MinglitEmptyState` error 패턴 + '다시 시도' CTA + raw err.toString() 제거

Closes #2413
Closes #2414