### PR TITLE
fix(search): apply spec styling to error state — Fix #2408

### DIFF
--- a/apps/app_user/lib/src/features/search/search_page.dart
+++ b/apps/app_user/lib/src/features/search/search_page.dart
@@ -208,8 +208,18 @@ class _SearchPageState extends ConsumerState<SearchPage> {
             loading: () => const Center(
               child: MinglitCircularProgressIndicator(),
             ),
-            error: (e, _) => const Center(
-              child: Text('검색 중 오류가 발생했습니다'),
+            // Fix #2408: spec — bodyMedium · onSurfaceVariant · padding-xlarge
+            error: (_, _) => Center(
+              child: Padding(
+                padding: const EdgeInsets.all(MinglitSpacing.xlarge),
+                child: Text(
+                  '검색 중 오류가 발생했습니다',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
             ),
           );
         },


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Design System Reference

spec: `apps/mds/docs/public/specs/search_page/index.md` → .search-error (bodyMedium · onSurfaceVariant · padding-xlarge)

## 수정 내용

`error` 분기에 spec이 명시한 스타일 적용:
- `Padding(EdgeInsets.all(MinglitSpacing.xlarge))` — viewport edge 여백 확보
- `TextStyle: bodyMedium + onSurfaceVariant color` — spec 컬러 토큰 준수
- `textAlign: TextAlign.center`

Closes #2408