### PR TITLE
chore(tickets): add spec reference comment for 44px button height — Fix #2285 #2286

### DIFF
--- a/apps/app_user/lib/src/features/tickets/widgets/event_ongoing_banner.dart
+++ b/apps/app_user/lib/src/features/tickets/widgets/event_ongoing_banner.dart
@@ -279,6 +279,8 @@ class _DisabledFooterButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Fix #2285: height 44 is spec-specified; no MinglitButtonSize token exists
+    // for this value (small=36, medium=48). Awaiting MDS token addition.
     return SizedBox(
       width: double.infinity,
       height: 44,


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## 상황

`MinglitButtonSize`에 40px(#2286), 44px(#2285) 토큰이 없음 (small=36, medium=48).
두 값 모두 spec이 명시한 수치 — 새 토큰은 Mark의 MDS 영역.

## 수정 내용

**event_ongoing_banner.dart (#2285)**: `height: 44` 위에 spec 참조 주석 추가 — 하드코딩 이유 명시.

**my_tickets_page.dart (#2286)**: 이미 `// spec: my_tickets_page.html#empty-state — height 40 each` 주석 존재 → 추가 변경 없음.

## 후속 필요

MDS `MinglitButtonSize`에 `compact` (44px) 또는 `small2` (40px) 토큰 추가 필요 — Mark의 영역.

Closes #2285
Closes #2286