### PR TITLE
feat(lint): add no_supabase_writes_outside_ef custom_lint rule — Fix #2391

### DIFF
--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -392,6 +392,31 @@ protect_user_profile_fields() → trigger
 | `party-assets` | Yes | Authenticated | 전체 공개 |
 | `partner-proofs` | No | 본인 폴더만 | 본인 + 관리자 |
 
+### 5.4 Flutter Write Enforcement
+
+Flutter 앱(publishable key = anon/authenticated role)은 **READ 전용**이다.
+모든 write는 service_role을 사용하는 Edge Function 경유로만 허용한다.
+
+#### 강제 수단 (다층 방어)
+
+| 계층 | 수단 | 상태 |
+|------|------|------|
+| IDE | `no_supabase_writes_outside_ef` custom_lint 룰 | ✅ 운영 중 (`shared/packages/minglit_lints/`) |
+| CI | `dart run custom_lint` PR-gate 스텝 | 진행 중 (issue #2392) |
+| DB | `REVOKE INSERT/UPDATE/DELETE/TRUNCATE FROM anon, authenticated` | 진행 중 (issue #2393 Phase 3) |
+
+#### lint 룰: `no_supabase_writes_outside_ef`
+
+- **위치**: `shared/packages/minglit_lints/lib/src/no_supabase_writes_outside_ef_rule.dart`
+- **차단 패턴**: `.from('table').insert/update/delete/upsert(...)`
+- **허용 패턴**: `.from('table').select(...)`, `.functions.invoke(...)`, `.rpc(...)`
+- **억제 방법** (마이그레이션 과도기 한정):
+  ```dart
+  // minglit_lints: allow-supabase-write — reason: EF 마이그레이션 2026-07-01까지 예정
+  supabase.from('legacy_table').insert(data);
+  ```
+  `reason:` 필드 필수. 이유 없는 억제 주석은 lint error.
+
 ---
 
 ## 6. Key Triggers & Functions

--- a/shared/packages/minglit_lints/lib/minglit_lints.dart
+++ b/shared/packages/minglit_lints/lib/minglit_lints.dart
@@ -3,6 +3,7 @@ import 'package:minglit_lints/src/no_cross_feature_imports_rule.dart';
 import 'package:minglit_lints/src/no_hardcoded_colors_rule.dart';
 import 'package:minglit_lints/src/no_hardcoded_padding_rule.dart';
 import 'package:minglit_lints/src/no_hardcoded_text_style_rule.dart';
+import 'package:minglit_lints/src/no_supabase_writes_outside_ef_rule.dart';
 import 'package:minglit_lints/src/use_minglit_async_value_widget_rule.dart';
 import 'package:minglit_lints/src/use_minglit_progress_indicator_rule.dart';
 
@@ -17,5 +18,6 @@ class _MinglitLintsPlugin extends PluginBase {
         const UseMinglitProgressIndicatorRule(),
         const UseMinglitAsyncValueWidgetRule(),
         const NoCrossFeatureImportsRule(),
+        const NoSupabaseWritesOutsideEfRule(),
       ];
 }

--- a/shared/packages/minglit_lints/lib/src/no_supabase_writes_outside_ef_rule.dart
+++ b/shared/packages/minglit_lints/lib/src/no_supabase_writes_outside_ef_rule.dart
@@ -1,0 +1,100 @@
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/error/listener.dart';
+import 'package:custom_lint_builder/custom_lint_builder.dart';
+
+/// Flags direct Supabase write operations (insert/update/delete/upsert) in
+/// Flutter app code. All writes must go through Edge Functions (EF).
+///
+/// ## Forbidden
+/// ```dart
+/// supabase.from('events').insert({'name': 'Party'});
+/// supabase.from('tickets').update({'status': 'sold'}).eq('id', id);
+/// client.from('orders').delete().match({'user_id': uid});
+/// ```
+///
+/// ## Allowed
+/// ```dart
+/// // READ — always allowed
+/// supabase.from('events').select();
+///
+/// // EF invocation — always allowed
+/// supabase.functions.invoke('create-event', body: {...});
+///
+/// // Suppressed with mandatory reason
+/// // minglit_lints: allow-supabase-write — reason: EF migration pending until 2026-07-01
+/// supabase.from('legacy_table').insert(data);
+/// ```
+class NoSupabaseWritesOutsideEfRule extends DartLintRule {
+  const NoSupabaseWritesOutsideEfRule() : super(code: _code);
+
+  static const LintCode _code = LintCode(
+    name: 'no_supabase_writes_outside_ef',
+    problemMessage:
+        'Direct Supabase write operations are not allowed in Flutter apps. '
+        'All writes must go through Edge Functions.',
+    correctionMessage:
+        'Use supabase.functions.invoke() instead. '
+        'To suppress: add '
+        '"// minglit_lints: allow-supabase-write — reason: <reason>" '
+        'on the preceding line.',
+  );
+
+  static const _writeMethodNames = {'insert', 'update', 'delete', 'upsert'};
+
+  /// Returns true if [name] is one of the write method names to be flagged.
+  ///
+  /// Exposed as static for unit testing.
+  static bool isWriteMethodName(String name) =>
+      _writeMethodNames.contains(name);
+
+  /// Returns true if [commentText] is a valid allowlist suppression comment.
+  ///
+  /// Both the `allow-supabase-write` marker and a non-empty `reason:` value
+  /// are required. A comment without a reason is treated as a violation.
+  ///
+  /// Exposed as static for unit testing.
+  static bool matchesAllowlistComment(String commentText) {
+    if (!commentText.contains('minglit_lints: allow-supabase-write')) {
+      return false;
+    }
+    final reasonIdx = commentText.indexOf('reason:');
+    if (reasonIdx == -1) return false;
+    final reason = commentText.substring(reasonIdx + 7).trim();
+    return reason.isNotEmpty;
+  }
+
+  @override
+  void run(
+    CustomLintResolver resolver,
+    DiagnosticReporter reporter,
+    CustomLintContext context,
+  ) {
+    context.registry.addMethodInvocation((node) {
+      if (!isWriteMethodName(node.methodName.name)) return;
+
+      // The direct target must be a .from('table') invocation.
+      final target = node.target;
+      if (target is! MethodInvocation) return;
+      if (target.methodName.name != 'from') return;
+
+      if (_isSuppressed(node)) return;
+
+      reporter.atNode(node.methodName, _code);
+    });
+  }
+
+  // Checks preceding comment tokens attached to the first token of the entire
+  // method-chain expression (e.g. the `supabase` identifier in
+  // `supabase.from('t').insert({})`).
+  bool _isSuppressed(MethodInvocation node) {
+    // beginToken.precedingComments is a CommentToken linked list; using Token?
+    // to avoid the cast since CommentToken.next is exposed as Token?.
+    Token? comment = node.beginToken.precedingComments;
+    while (comment != null) {
+      if (matchesAllowlistComment(comment.lexeme)) return true;
+      comment = comment.next;
+    }
+    return false;
+  }
+}

--- a/shared/packages/minglit_lints/test/no_supabase_writes_outside_ef_test.dart
+++ b/shared/packages/minglit_lints/test/no_supabase_writes_outside_ef_test.dart
@@ -1,0 +1,123 @@
+import 'package:minglit_lints/src/no_supabase_writes_outside_ef_rule.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // ---------------------------------------------------------------------------
+  // isWriteMethodName
+  // ---------------------------------------------------------------------------
+  group('NoSupabaseWritesOutsideEfRule.isWriteMethodName', () {
+    group('positive: write method names', () {
+      test('insert', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('insert'), isTrue));
+      test('update', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('update'), isTrue));
+      test('delete', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('delete'), isTrue));
+      test('upsert', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('upsert'), isTrue));
+    });
+
+    group('negative: non-write method names', () {
+      test('select', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('select'), isFalse));
+      test('from', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('from'), isFalse));
+      test('invoke', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('invoke'), isFalse));
+      test('eq', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('eq'), isFalse));
+      test('filter', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('filter'), isFalse));
+      test('rpc', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName('rpc'), isFalse));
+      test('empty string', () => expect(NoSupabaseWritesOutsideEfRule.isWriteMethodName(''), isFalse));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // matchesAllowlistComment
+  // ---------------------------------------------------------------------------
+  group('NoSupabaseWritesOutsideEfRule.matchesAllowlistComment', () {
+    group('positive: valid suppression comments', () {
+      test('standard em-dash format with reason', () {
+        expect(
+          NoSupabaseWritesOutsideEfRule.matchesAllowlistComment(
+            '// minglit_lints: allow-supabase-write — reason: EF migration pending until 2026-07-01',
+          ),
+          isTrue,
+        );
+      });
+
+      test('reason with colon only (minimal)', () {
+        expect(
+          NoSupabaseWritesOutsideEfRule.matchesAllowlistComment(
+            '// minglit_lints: allow-supabase-write — reason: legacy write path',
+          ),
+          isTrue,
+        );
+      });
+
+      test('reason without em-dash separator is still matched', () {
+        expect(
+          NoSupabaseWritesOutsideEfRule.matchesAllowlistComment(
+            '// minglit_lints: allow-supabase-write reason: workaround for #1234',
+          ),
+          isTrue,
+        );
+      });
+    });
+
+    group('negative: invalid or missing suppression', () {
+      test('marker present but reason: key missing', () {
+        expect(
+          NoSupabaseWritesOutsideEfRule.matchesAllowlistComment(
+            '// minglit_lints: allow-supabase-write — migration in progress',
+          ),
+          isFalse,
+        );
+      });
+
+      test('marker present but reason value is empty', () {
+        expect(
+          NoSupabaseWritesOutsideEfRule.matchesAllowlistComment(
+            '// minglit_lints: allow-supabase-write — reason:',
+          ),
+          isFalse,
+        );
+      });
+
+      test('reason value is only whitespace', () {
+        expect(
+          NoSupabaseWritesOutsideEfRule.matchesAllowlistComment(
+            '// minglit_lints: allow-supabase-write — reason:   ',
+          ),
+          isFalse,
+        );
+      });
+
+      test('unrelated comment', () {
+        expect(
+          NoSupabaseWritesOutsideEfRule.matchesAllowlistComment(
+            '// TODO: migrate to EF',
+          ),
+          isFalse,
+        );
+      });
+
+      test('missing minglit_lints prefix', () {
+        expect(
+          NoSupabaseWritesOutsideEfRule.matchesAllowlistComment(
+            '// allow-supabase-write — reason: old code',
+          ),
+          isFalse,
+        );
+      });
+
+      test('empty string', () {
+        expect(
+          NoSupabaseWritesOutsideEfRule.matchesAllowlistComment(''),
+          isFalse,
+        );
+      });
+
+      test('ignore comment', () {
+        expect(
+          NoSupabaseWritesOutsideEfRule.matchesAllowlistComment(
+            '// ignore: no_supabase_writes_outside_ef',
+          ),
+          isFalse,
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #2391

## 변경 내용

`no_supabase_writes_outside_ef` custom_lint 룰 신규 추가.

Flutter 앱 코드에서 직접 Supabase write(`insert` / `update` / `delete` / `upsert`)를 호출하면 lint error를 발생시킨다. 모든 write는 Edge Function 경유로만 허용.

## 구현 세부

### 차단 패턴
```dart
// ❌ 모두 차단
supabase.from('events').insert({'name': 'Party'});
supabase.from('tickets').update({'status': 'sold'}).eq('id', id);
client.from('orders').delete().match({'user_id': uid});
```

### 허용 패턴
```dart
// ✅ READ
supabase.from('events').select();

// ✅ EF 호출
supabase.functions.invoke('create-event', body: {...});

// ✅ 억제 (이유 필수)
// minglit_lints: allow-supabase-write — reason: EF 마이그레이션 2026-07-01까지 예정
supabase.from('legacy_table').insert(data);
```

### 억제 메커니즘
- `// minglit_lints: allow-supabase-write — reason: <reason>` 주석 필요
- `reason:` 값이 비어 있으면 억제 무효 → lint error 유지

## 파일 변경

| 파일 | 변경 |
|------|------|
| `shared/packages/minglit_lints/lib/src/no_supabase_writes_outside_ef_rule.dart` | 신규 (룰 구현) |
| `shared/packages/minglit_lints/lib/minglit_lints.dart` | 룰 등록 |
| `shared/packages/minglit_lints/test/no_supabase_writes_outside_ef_test.dart` | 신규 (테스트 21개) |
| `docs/architecture/backend.md` | §5.4 Flutter Write Enforcement 섹션 추가 |

## 테스트

```
dart test — 33 tests passed (기존 12 + 신규 21)
dart analyze lib/ — No issues found
```

## 연관 이슈

- #2393 (RLS strict migration) Phase 3 전 lint 방어선 구축
- #2392 (CI 게이트 추가): 이 룰이 CI에서 강제되려면 #2392 필요 (workflow scope 블록 중)