### PR TITLE
feat(security): Phase 2 (user-side) EF migration — route social/notification writes via EF — Fix #2393

### DIFF
--- a/shared/packages/minglit_kit/lib/src/data/repositories/notification_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/notification_repository.dart
@@ -12,6 +12,9 @@ class NotificationRepository {
 
   static const _efName = 'user-manage-settings';
 
+  // Fix #2393: notification write operations routed through EF.
+  static const _efNotification = 'user-manage-notification';
+
   /// FCM 토큰을 서버에 등록하거나 갱신합니다.
   Future<void> upsertToken({
     required String userId,
@@ -72,13 +75,15 @@ class NotificationRepository {
   ///
   /// Fix #1955: swallows errors — read-state mutation failure must not
   /// crash the UI; logged for debuggability.
+  /// Fix #2393: routed through user-manage-notification EF.
   Future<void> markAsRead(String notificationId) async {
     try {
-      await _client
-          .from('user_notifications')
-          .update({'is_read': true})
-          .eq('id', notificationId);
-    } catch (e, st) {
+      final response = await _client.functions.invoke(
+        _efNotification,
+        body: {'action': 'mark_read', 'notification_id': notificationId},
+      );
+      _ensureSuccess(response);
+    } on Object catch (e, st) {
       Log.e('❌ [NotificationRepo] markAsRead Error', e, st);
     }
   }
@@ -87,13 +92,17 @@ class NotificationRepository {
   ///
   /// Fix #1955: swallows errors — read-state mutation failure must not
   /// crash the UI; logged for debuggability.
+  /// Fix #2393: routed through user-manage-notification EF.
+  /// [userId] is retained for API compatibility but not used in the EF call;
+  /// the EF derives the user from the JWT.
   Future<void> markAllAsRead(String userId) async {
     try {
-      await _client
-          .from('user_notifications')
-          .update({'is_read': true})
-          .eq('user_id', userId);
-    } catch (e, st) {
+      final response = await _client.functions.invoke(
+        _efNotification,
+        body: {'action': 'mark_all_read'},
+      );
+      _ensureSuccess(response);
+    } on Object catch (e, st) {
       Log.e('❌ [NotificationRepo] markAllAsRead Error', e, st);
     }
   }
@@ -102,13 +111,15 @@ class NotificationRepository {
   ///
   /// Fix #1955: swallows errors — delete failure must not crash the UI;
   /// logged for debuggability.
+  /// Fix #2393: routed through user-manage-notification EF.
   Future<void> deleteNotification(String notificationId) async {
     try {
-      await _client
-          .from('user_notifications')
-          .delete()
-          .eq('id', notificationId);
-    } catch (e, st) {
+      final response = await _client.functions.invoke(
+        _efNotification,
+        body: {'action': 'delete', 'notification_id': notificationId},
+      );
+      _ensureSuccess(response);
+    } on Object catch (e, st) {
       Log.e('❌ [NotificationRepo] deleteNotification Error', e, st);
     }
   }

--- a/shared/packages/minglit_kit/lib/src/data/repositories/social_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/social_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:minglit_kit/src/data/models/social_interaction.dart';
 import 'package:minglit_kit/src/utils/log.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -88,17 +90,17 @@ class SocialRepository {
     }
   }
 
+  // Fix #2393: Route block/unblock/report through EF to enforce write-via-EF rule.
+  static const _efSocial = 'user-manage-social';
+
   /// Blocks the given partner for the current user.
   Future<void> blockPartner(String partnerId) async {
-    final userId = _supabase.auth.currentUser?.id;
-    if (userId == null) throw Exception('User not authenticated');
     try {
-      await _supabase.from('social_interactions').upsert({
-        'user_id': userId,
-        'target_id': partnerId,
-        'target_type': SocialTargetType.partner.name,
-        'interaction_type': SocialInteractionType.block.name,
-      });
+      final response = await _supabase.functions.invoke(
+        _efSocial,
+        body: {'action': 'block', 'target_id': partnerId},
+      );
+      _ensureSuccess(response);
     } on Object catch (e, st) {
       Log.e('blockPartner Error', e, st);
       rethrow;
@@ -107,15 +109,12 @@ class SocialRepository {
 
   /// Unblocks a previously blocked partner.
   Future<void> unblockPartner(String partnerId) async {
-    final userId = _supabase.auth.currentUser?.id;
-    if (userId == null) throw Exception('User not authenticated');
     try {
-      await _supabase
-          .from('social_interactions')
-          .delete()
-          .eq('user_id', userId)
-          .eq('target_id', partnerId)
-          .eq('interaction_type', SocialInteractionType.block.name);
+      final response = await _supabase.functions.invoke(
+        _efSocial,
+        body: {'action': 'unblock', 'target_id': partnerId},
+      );
+      _ensureSuccess(response);
     } on Object catch (e, st) {
       Log.e('unblockPartner Error', e, st);
       rethrow;
@@ -123,31 +122,41 @@ class SocialRepository {
   }
 
   /// Reports a partner with a reason and optional description.
+  ///
+  /// Delegates to `user-manage-social` EF which atomically blocks the partner,
+  /// records the report interaction, and inserts report_details.
   Future<void> reportPartner({
     required String partnerId,
     required String reason,
     String? description,
   }) async {
-    final userId = _supabase.auth.currentUser?.id;
-    if (userId == null) throw Exception('User not authenticated');
     try {
-      await blockPartner(partnerId);
-      await _supabase.from('social_interactions').upsert({
-        'user_id': userId,
-        'target_id': partnerId,
-        'target_type': SocialTargetType.partner.name,
-        'interaction_type': SocialInteractionType.report.name,
-      });
-      await _supabase.from('report_details').insert({
-        'user_id': userId,
-        'target_id': partnerId,
-        'target_type': SocialTargetType.partner.name,
-        'reason': reason,
-        'description': ?description,
-      });
+      final response = await _supabase.functions.invoke(
+        _efSocial,
+        body: {
+          'action': 'report',
+          'target_id': partnerId,
+          'reason': reason,
+          if (description != null) 'description': description,
+        },
+      );
+      _ensureSuccess(response);
     } on Object catch (e, st) {
       Log.e('reportPartner Error', e, st);
       rethrow;
+    }
+  }
+
+  void _ensureSuccess(FunctionResponse response) {
+    if (response.status != 200) {
+      final body = response.data is String
+          ? response.data as String
+          : jsonEncode(response.data);
+      throw FunctionException(
+        status: response.status,
+        details: body,
+        reasonPhrase: 'Edge function error',
+      );
     }
   }
 

--- a/shared/packages/minglit_kit/test/src/data/repositories/notification_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/notification_repository_test.dart
@@ -168,78 +168,97 @@ void main() {
       });
     });
 
-    group('markAsRead', () {
-      test('completes without error', () async {
-        unawaited(mockTable(mockClient, 'user_notifications'));
+    // Helper: stub user-manage-notification EF with given status.
+    void stubNotifEf({int status = 200}) {
+      when(
+        () => mockFunctions.invoke(
+          'user-manage-notification',
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer(
+        (_) async => FunctionResponse(
+          status: status,
+          data: jsonEncode({'success': true}),
+        ),
+      );
+    }
 
-        await expectLater(
-          repository.markAsRead('notif_1'),
-          completes,
-        );
+    // Fix #2393: markAsRead now routes through user-manage-notification EF.
+    group('markAsRead', () {
+      test('invokes EF with mark_read action', () async {
+        stubNotifEf();
+
+        await expectLater(repository.markAsRead('notif_1'), completes);
+
+        final captured = verify(
+          () => mockFunctions.invoke(
+            'user-manage-notification',
+            body: captureAny(named: 'body'),
+          ),
+        ).captured;
+
+        final body = captured.first as Map<String, dynamic>;
+        expect(body['action'], 'mark_read');
+        expect(body['notification_id'], 'notif_1');
       });
 
       // Fix #1955: swallows error so read-state mutations don't crash the UI.
-      test('swallows error — does not throw on failure', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'user_notifications',
-            shouldThrow: Exception('db error'),
-          ),
-        );
-
+      test('swallows EF error — does not throw on failure', () async {
+        stubNotifEf(status: 500);
         await expectLater(repository.markAsRead('notif_1'), completes);
       });
     });
 
+    // Fix #2393: markAllAsRead now routes through user-manage-notification EF.
     group('markAllAsRead', () {
-      test('completes without error', () async {
-        unawaited(mockTable(mockClient, 'user_notifications'));
+      test('invokes EF with mark_all_read action', () async {
+        stubNotifEf();
 
-        await expectLater(
-          repository.markAllAsRead('user_1'),
-          completes,
-        );
+        await expectLater(repository.markAllAsRead('user_1'), completes);
+
+        final captured = verify(
+          () => mockFunctions.invoke(
+            'user-manage-notification',
+            body: captureAny(named: 'body'),
+          ),
+        ).captured;
+
+        final body = captured.first as Map<String, dynamic>;
+        expect(body['action'], 'mark_all_read');
+        // userId param is NOT forwarded to the EF — EF uses JWT.
+        expect(body.containsKey('user_id'), isFalse);
       });
 
       // Fix #1955: swallows error so read-state mutations don't crash the UI.
-      test('swallows error — does not throw on failure', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'user_notifications',
-            shouldThrow: Exception('db error'),
-          ),
-        );
-
+      test('swallows EF error — does not throw on failure', () async {
+        stubNotifEf(status: 500);
         await expectLater(repository.markAllAsRead('user_1'), completes);
       });
     });
 
+    // Fix #2393: deleteNotification now routes through user-manage-notification EF.
     group('deleteNotification', () {
-      test('completes without error', () async {
-        unawaited(mockTable(mockClient, 'user_notifications'));
+      test('invokes EF with delete action', () async {
+        stubNotifEf();
 
-        await expectLater(
-          repository.deleteNotification('notif_1'),
-          completes,
-        );
+        await expectLater(repository.deleteNotification('notif_1'), completes);
+
+        final captured = verify(
+          () => mockFunctions.invoke(
+            'user-manage-notification',
+            body: captureAny(named: 'body'),
+          ),
+        ).captured;
+
+        final body = captured.first as Map<String, dynamic>;
+        expect(body['action'], 'delete');
+        expect(body['notification_id'], 'notif_1');
       });
 
       // Fix #1955: swallows error so delete failures don't crash the UI.
-      test('swallows error — does not throw on failure', () async {
-        unawaited(
-          mockTable(
-            mockClient,
-            'user_notifications',
-            shouldThrow: Exception('db error'),
-          ),
-        );
-
-        await expectLater(
-          repository.deleteNotification('notif_1'),
-          completes,
-        );
+      test('swallows EF error — does not throw on failure', () async {
+        stubNotifEf(status: 500);
+        await expectLater(repository.deleteNotification('notif_1'), completes);
       });
     });
 

--- a/shared/packages/minglit_kit/test/src/data/repositories/social_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/social_repository_test.dart
@@ -1,14 +1,18 @@
 import 'dart:async' show unawaited;
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/src/data/models/social_interaction.dart';
 import 'package:minglit_kit/src/data/repositories/social_repository.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../../helpers/mocks.dart';
 import '../../../helpers/supabase_mock_helpers.dart';
 
 void main() {
   late MockSupabaseClient mockClient;
+  late MockFunctionsClient mockFunctions;
   late SocialRepository repository;
 
   final mockUser = MockUser();
@@ -22,8 +26,24 @@ void main() {
     ).thenAnswer((_) => FakeRpcBuilder<dynamic>(null));
   }
 
+  // Fix #2393: stub user-manage-social EF.
+  void stubSocialEf({int status = 200}) {
+    when(
+      () => mockFunctions.invoke(
+        'user-manage-social',
+        body: any(named: 'body'),
+      ),
+    ).thenAnswer(
+      (_) async => FunctionResponse(
+        status: status,
+        data: jsonEncode({'success': true}),
+      ),
+    );
+  }
+
   setUp(() {
     mockClient = createMockSupabase(currentUser: mockUser);
+    mockFunctions = mockClient.functions as MockFunctionsClient;
     when(() => mockUser.id).thenReturn('user_1');
     repository = SocialRepository(supabase: mockClient);
   });
@@ -148,6 +168,119 @@ void main() {
         );
 
         expect(result, isFalse);
+      });
+    });
+
+    // Fix #2393: block/unblock/report now route through user-manage-social EF.
+    group('blockPartner', () {
+      test('invokes EF with block action', () async {
+        stubSocialEf();
+
+        await expectLater(
+          repository.blockPartner('partner_1'),
+          completes,
+        );
+
+        final captured = verify(
+          () => mockFunctions.invoke(
+            'user-manage-social',
+            body: captureAny(named: 'body'),
+          ),
+        ).captured;
+
+        final body = captured.first as Map<String, dynamic>;
+        expect(body['action'], 'block');
+        expect(body['target_id'], 'partner_1');
+      });
+
+      test('throws on EF error', () async {
+        stubSocialEf(status: 500);
+
+        expect(
+          () => repository.blockPartner('partner_1'),
+          throwsA(isA<FunctionException>()),
+        );
+      });
+    });
+
+    group('unblockPartner', () {
+      test('invokes EF with unblock action', () async {
+        stubSocialEf();
+
+        await expectLater(
+          repository.unblockPartner('partner_1'),
+          completes,
+        );
+
+        final captured = verify(
+          () => mockFunctions.invoke(
+            'user-manage-social',
+            body: captureAny(named: 'body'),
+          ),
+        ).captured;
+
+        final body = captured.first as Map<String, dynamic>;
+        expect(body['action'], 'unblock');
+        expect(body['target_id'], 'partner_1');
+      });
+    });
+
+    group('reportPartner', () {
+      test('invokes EF with report action and reason', () async {
+        stubSocialEf();
+
+        await expectLater(
+          repository.reportPartner(
+            partnerId: 'partner_1',
+            reason: 'spam',
+          ),
+          completes,
+        );
+
+        final captured = verify(
+          () => mockFunctions.invoke(
+            'user-manage-social',
+            body: captureAny(named: 'body'),
+          ),
+        ).captured;
+
+        final body = captured.first as Map<String, dynamic>;
+        expect(body['action'], 'report');
+        expect(body['target_id'], 'partner_1');
+        expect(body['reason'], 'spam');
+        expect(body.containsKey('description'), isFalse);
+      });
+
+      test('includes description when provided', () async {
+        stubSocialEf();
+
+        await repository.reportPartner(
+          partnerId: 'partner_1',
+          reason: 'harassment',
+          description: 'Sent inappropriate messages',
+        );
+
+        final captured = verify(
+          () => mockFunctions.invoke(
+            'user-manage-social',
+            body: captureAny(named: 'body'),
+          ),
+        ).captured;
+
+        final body = captured.first as Map<String, dynamic>;
+        expect(body['description'], 'Sent inappropriate messages');
+      });
+
+      test('throws on EF error', () async {
+        stubSocialEf(status: 400);
+
+        expect(
+          () => repository.reportPartner(
+            partnerId: 'partner_1',
+            reason: 'spam',
+          ),
+          throwsA(isA<FunctionException>()),
+        );
       });
     });
 


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

Closes #2393 (partial — Phase 2 user-side complete; partner-side and Phase 3/4 to follow)

## 변경 내용

**Issue #2393 Phase 2** 중 user-side (Group A) 마이그레이션.

Flutter publishable key → Supabase 직접 write를 Edge Function 경유로 전환.

### 대상 Repository + 변경 내역

| Repository | 메서드 | 기존 | 변경 |
|-----------|--------|------|------|
| `social_repository.dart` | `blockPartner` | `social_interactions` UPSERT | `user-manage-social` EF `block` |
| `social_repository.dart` | `unblockPartner` | `social_interactions` DELETE | `user-manage-social` EF `unblock` |
| `social_repository.dart` | `reportPartner` | block + 2× write (3 DB calls) | `user-manage-social` EF `report` (atomic) |
| `notification_repository.dart` | `markAsRead` | `user_notifications` UPDATE | `user-manage-notification` EF `mark_read` |
| `notification_repository.dart` | `markAllAsRead` | `user_notifications` UPDATE | `user-manage-notification` EF `mark_all_read` |
| `notification_repository.dart` | `deleteNotification` | `user_notifications` DELETE | `user-manage-notification` EF `delete` |

### 부가 개선

- `reportPartner`: 기존 3개 직렬 DB 호출 → EF 단일 호출 (원자성 보장)
- `markAllAsRead(userId)`: `userId` 파라미터 보존 (API 호환성), EF는 JWT로 사용자 식별
- 보안: EF가 `user_id = jwt.sub` 조건을 강제하여 사용자 격리 보장

## 연관 컨텍스트

- `user-manage-social` / `user-manage-notification` EF는 이미 존재 (마이그레이션 전 검증 완료)
- 남은 작업: partner-side (party_event, location, ticket) + Phase 3 GRANT 회수

## 테스트

```
flutter test test/src/data/repositories/social_repository_test.dart
                test/src/data/repositories/notification_repository_test.dart
→ 31 tests passed
```

기존 테스트 업데이트: DB 테이블 mock → EF mock. EF body 검증 추가.