### PR TITLE
feat(security): Phase 2 (partner-side partial) — route updateEventStatus/Metadata via EF — Fix #2393

### DIFF
--- a/shared/packages/minglit_kit/lib/src/data/repositories/party_event_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/party_event_repository.dart
@@ -84,13 +84,24 @@ mixin _PartyEventRepository on _SupabasePartyContext {
   }
 
   /// Updates only the status of an event.
+  // Fix #2393: route through partner-manage-event EF.
   Future<void> updateEventStatus(String eventId, String status) async {
     Log.d('updateEventStatus called | eventId: $eventId, status: $status');
     try {
-      await supabaseClient
-          .from('events')
-          .update({'status': status})
-          .eq('id', eventId);
+      final response = await supabaseClient.functions.invoke(
+        'partner-manage-event',
+        body: {
+          'action': 'update_status',
+          'event_id': eventId,
+          'status': status,
+        },
+      );
+      if (response.status != 200) {
+        final error = response.data is Map
+            ? (response.data as Map)['error'] ?? 'Failed to update event status'
+            : 'Failed to update event status';
+        throw Exception(error);
+      }
       Log.d('updateEventStatus success');
     } catch (e, st) {
       Log.e('❌ [PartyRepo] updateEventStatus Error', e, st);
@@ -99,15 +110,27 @@ mixin _PartyEventRepository on _SupabasePartyContext {
   }
 
   /// Updates the metadata of an event.
+  // Fix #2393: route through partner-manage-event EF.
   Future<void> updateEventMetadata(
     String eventId,
     Map<String, dynamic> metadata,
   ) async {
     try {
-      await supabaseClient
-          .from('events')
-          .update({'metadata': metadata})
-          .eq('id', eventId);
+      final response = await supabaseClient.functions.invoke(
+        'partner-manage-event',
+        body: {
+          'action': 'update',
+          'event_id': eventId,
+          'event': {'metadata': metadata},
+        },
+      );
+      if (response.status != 200) {
+        final error = response.data is Map
+            ? (response.data as Map)['error'] ??
+                'Failed to update event metadata'
+            : 'Failed to update event metadata';
+        throw Exception(error);
+      }
       Log.d('updateEventMetadata success');
     } catch (e, st) {
       Log.e('❌ [PartyRepo] updateEventMetadata Error', e, st);

--- a/shared/packages/minglit_kit/test/src/data/repositories/party_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/party_repository_test.dart
@@ -675,31 +675,72 @@ void main() {
       });
     });
 
+    // Fix #2393: updateEventStatus/Metadata now route through partner-manage-event EF.
     group('updateEventStatus', () {
-      test('completes without error', () async {
-        unawaited(mockTable(mockClient, 'events'));
+      test('invokes EF with update_status action', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-event',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true},
+          ),
+        );
 
         await expectLater(
-          repository.updateEventStatus('event_1', 'active'),
+          repository.updateEventStatus('event_1', 'cancelled'),
           completes,
         );
+
+        final captured = verify(
+          () => mockFunctions.invoke(
+            'partner-manage-event',
+            body: captureAny(named: 'body'),
+          ),
+        ).captured;
+
+        final body = captured.first as Map<String, dynamic>;
+        expect(body['action'], 'update_status');
+        expect(body['event_id'], 'event_1');
+        expect(body['status'], 'cancelled');
       });
 
-      test('throws on error', () async {
-        unawaited(
-          mockTable(mockClient, 'events', shouldThrow: Exception('error')),
+      test('throws on EF error', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-event',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 400,
+            data: {'error': 'Invalid status'},
+          ),
         );
 
         await expectLater(
-          repository.updateEventStatus('event_1', 'active'),
+          repository.updateEventStatus('event_1', 'cancelled'),
           throwsA(anything),
         );
       });
     });
 
     group('updateEventMetadata', () {
-      test('completes without error', () async {
-        unawaited(mockTable(mockClient, 'events'));
+      test('invokes EF with update action and metadata', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-event',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 200,
+            data: {'success': true},
+          ),
+        );
 
         await expectLater(
           repository.updateEventMetadata(
@@ -708,11 +749,31 @@ void main() {
           ),
           completes,
         );
+
+        final captured = verify(
+          () => mockFunctions.invoke(
+            'partner-manage-event',
+            body: captureAny(named: 'body'),
+          ),
+        ).captured;
+
+        final body = captured.first as Map<String, dynamic>;
+        expect(body['action'], 'update');
+        expect(body['event_id'], 'event_1');
+        expect((body['event'] as Map)['metadata'], {'theme': 'dark', 'capacity': 50});
       });
 
-      test('throws on error', () async {
-        unawaited(
-          mockTable(mockClient, 'events', shouldThrow: Exception('error')),
+      test('throws on EF error', () async {
+        when(
+          () => mockFunctions.invoke(
+            'partner-manage-event',
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) async => FunctionResponse(
+            status: 500,
+            data: {'error': 'Server error'},
+          ),
         );
 
         await expectLater(


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

(Continuation of #2487, now merged)

## 변경 내용

**Issue #2393 Phase 2** 파트너 사이드 일부 마이그레이션.

### 대상

| Repository | 메서드 | 기존 | 변경 |
|-----------|--------|------|------|
| `party_event_repository.dart` | `updateEventStatus` | `events` UPDATE | `partner-manage-event` EF `update_status` |
| `party_event_repository.dart` | `updateEventMetadata` | `events` UPDATE | `partner-manage-event` EF `update` |

### 미처리 항목 (별도 작업 필요)

파트너 사이드 나머지 항목은 EF 인터페이스와 Dart 코드 간 포맷 불일치로 별도 분석 필요:
- `createEvent` — EF는 template refs 기대, Dart는 full object 전송 (포맷 불일치)
- `updateEvent` — 반환값 처리 차이 (`Event` vs `{success: true}`)
- `location_repository.dart` 2개 writes — `partner-manage-party` EF 인터페이스 확인 필요
- `ticket_repository.dart` 5개 writes — 일부 신규 EF 필요 (Group B/C)

## 테스트

```
flutter test test/src/data/repositories/party_repository_test.dart
→ 36 tests passed
```