### PR TITLE
chore(workflows): add pr-setup- prefix for PR housekeeping

### DIFF
--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -4,17 +4,18 @@
 
 ## 배경
 
-기존 파일명·`name:` 규칙이 제각각이었다 (`auto-format.yml`, `Deploy to Vercel`, `Hourly: DB Invariant Monitor`, ...). PR Checks 화면에서 *"이게 머지를 막는 건지 / 배포인지 / 단순 자동화인지"* 한눈에 안 잡힘. **"빨갛게 뜨면 무슨 일이 일어나나"** 를 축으로 7 개 prefix 로 통일했다.
+기존 파일명·`name:` 규칙이 제각각이었다 (`auto-format.yml`, `Deploy to Vercel`, `Hourly: DB Invariant Monitor`, ...). PR Checks 화면에서 *"이게 머지를 막는 건지 / 배포인지 / 단순 자동화인지"* 한눈에 안 잡힘. **"빨갛게 뜨면 무슨 일이 일어나나"** 를 축으로 8 개 prefix 로 통일했다.
 
 ## Prefix
 
 | Prefix | 빨갛게 뜨면 = | 예시 파일 |
 |---|---|---|
 | `pr-gate-` | **머지 못 함** (required check) | `pr-gate.yml` |
+| `pr-setup-` | PR 받자마자 도는 자동 셋업 (포맷·라벨·시크릿 검사·dependabot auto-merge) | `pr-setup-format`, `pr-setup-label`, `pr-setup-secret-scan`, `pr-setup-dependabot` |
 | `deploy-` | 사용자·dev 환경에 코드·스키마·시드가 안 갔음 | `deploy-vercel`, `deploy-supabase`, `deploy-android-user`, `deploy-ios-user`, `deploy-dev-seed` |
-| `monitor-` | 운영·테스트 시스템 헬스 이상 (스케줄) | `monitor-db-invariants`, `monitor-tick-user`, `monitor-daily-lifecycle`, `monitor-allure` |
-| `sync-` | repo 에 자동 commit/push 가 실패함 | `sync-format`, `sync-version`, `sync-graphify`, `sync-mds-mockups`, `sync-pr-branches` |
-| `triage-` | PR·이슈 라벨·머지·검증 자동화 실패 (commit 없음) | `triage-label`, `triage-secret-scan`, `triage-review`, `triage-dependabot`, `triage-mds-issue` |
+| `monitor-` | 운영·테스트 시스템 헬스 이상 (스케줄) | `monitor-db-invariants`, `monitor-event-flow-hourly`, `monitor-event-flow-daily`, `monitor-mds-render-coverage`, `monitor-patrol-e2e`, `monitor-allure` |
+| `sync-` | repo 에 자동 commit/push 가 실패함 (dev push 또는 merge 기반) | `sync-version`, `sync-graphify`, `sync-mds-mockups`, `sync-pr-branches` |
+| `triage-` | PR·이슈 검증·이슈 생성·슬래시 명령 (commit 없음) | `triage-review`, `triage-mds-issue`, `triage-slash` |
 | `tool-` | (수동으로 부를 때만 도는 도구) | (현재 없음 — 새 수동 도구 추가 시 prefix) |
 | `shared-` | (다른 워크플로우의 부품 — 단독 실행 X) | `shared-notify`, `shared-android-deploy` |
 
@@ -22,8 +23,11 @@
 
 - **파일명 = workflow `name:` 필드** (소문자 kebab, 확장자 제외). 예: `deploy-vercel.yml` 의 `name: deploy-vercel`.
 - prefix 다음은 *대상*만 적는다. 액션 동사는 prefix 가 이미 함의함 (`deploy-vercel` ◯ / `deploy-to-vercel` ✗).
-- 새 워크플로우는 위 7 prefix 중 하나에 반드시 속해야 한다. 어디에도 안 맞으면 새 prefix 추가 PR 을 먼저 낸다.
-- `sync-` vs `triage-` 의 기준: **repo 에 commit 이 들어가나** = `sync-`, 라벨·이슈·검증만 = `triage-`.
+- 새 워크플로우는 위 8 prefix 중 하나에 반드시 속해야 한다. 어디에도 안 맞으면 새 prefix 추가 PR 을 먼저 낸다.
+- `pr-setup-` vs `sync-` vs `triage-` 의 기준:
+  - `pr-setup-` = PR 라이프사이클 초기에 자동으로 도는 셋업 (포맷·라벨·검사·머지 자동화)
+  - `sync-` = dev push 또는 merge 기반으로 repo 에 commit 을 자동 push
+  - `triage-` = 검증·이슈 생성·슬래시 명령 (commit 없음, PR 외 컨텍스트에서도 동작)
 
 ## 관련
 

--- a/.github/workflows/pr-setup-dependabot.yml
+++ b/.github/workflows/pr-setup-dependabot.yml
@@ -1,4 +1,4 @@
-name: triage-dependabot
+name: pr-setup-dependabot
 
 on:
   pull_request:

--- a/.github/workflows/pr-setup-format.yml
+++ b/.github/workflows/pr-setup-format.yml
@@ -1,4 +1,4 @@
-name: sync-format
+name: pr-setup-format
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize, reopened]
 
 concurrency:
-  group: sync-format-${{ github.event.pull_request.number }}
+  group: pr-setup-format-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:
@@ -78,6 +78,6 @@ jobs:
     uses: ./.github/workflows/shared-notify.yml
     with:
       success: false
-      workflow_name: 'Auto Format'
+      workflow_name: 'pr-setup-format'
       # Fix #976: PR-triggered workflows should not create P0 noise issues
       create_issue: false

--- a/.github/workflows/pr-setup-label.yml
+++ b/.github/workflows/pr-setup-label.yml
@@ -1,4 +1,4 @@
-name: triage-label
+name: pr-setup-label
 
 on:
   pull_request:

--- a/.github/workflows/pr-setup-secret-scan.yml
+++ b/.github/workflows/pr-setup-secret-scan.yml
@@ -1,11 +1,11 @@
-name: triage-secret-scan
+name: pr-setup-secret-scan
 
 on:
   pull_request:
     branches: [ "main", "dev" ]
 
 concurrency:
-  group: triage-secret-scan-${{ github.event.pull_request.number || github.ref }}
+  group: pr-setup-secret-scan-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -33,6 +33,6 @@ jobs:
     uses: ./.github/workflows/shared-notify.yml
     with:
       success: false
-      workflow_name: 'PR: Gitleaks Secret Scan'
+      workflow_name: 'pr-setup-secret-scan'
       # Fix #976: PR-triggered workflows should not create P0 noise issues
       create_issue: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,8 +168,8 @@ adb -s adb-R3CX803P2ND-8btuuD._adb-tls-connect._tcp install -r build/app/outputs
 | CodeRabbit 리뷰 | PR only | `ci-result` job 내에서 최대 30분 대기 |
 
 별도 워크플로우 (required check 아님, 참고용):
-- **`sync-format`**: PR 시 `dart fix --apply` + `dart format` 자동 적용. 포맷 변경이 있으면 자동 커밋.
-- **`triage-secret-scan`**: PR 시 Gitleaks로 시크릿 유출 검사.
+- **`pr-setup-format`**: PR 시 `dart fix --apply` + `dart format` 자동 적용. 포맷 변경이 있으면 자동 커밋.
+- **`pr-setup-secret-scan`**: PR 시 Gitleaks로 시크릿 유출 검사.
 
 → 전체 워크플로우 prefix 컨벤션은 [`.github/workflows/BLUEDOC.md`](.github/workflows/BLUEDOC.md) 참고.
 

--- a/docs/qa/test-strategy.md
+++ b/docs/qa/test-strategy.md
@@ -44,7 +44,7 @@
 
 | 항목 | 위치 | 성격 |
 |------|------|------|
-| Secret scan | `.github/workflows/triage-secret-scan.yml` | 보안 |
+| Secret scan | `.github/workflows/pr-setup-secret-scan.yml` | 보안 |
 | Migration version check | `pr-gate.yml` job | Pre-test gate |
 | Env manifest sync | `pr-gate.yml` job | 환경변수 정합성 |
 | Landing lint/build | `pr-gate.yml` job | Next.js 빌드 |


### PR DESCRIPTION
## Summary

PR opened/sync 시 자동으로 도는 4 개 워크플로우를 `sync-`/`triage-` 에서 분리해 `pr-setup-` prefix 로 묶음. PR Checks UI 에서 "PR 받자마자 도는 자동 셋업" 한 묶음으로 보이게.

| 현재 | → | 새 이름 |
|---|---|---|
| `sync-format.yml` | → | `pr-setup-format.yml` |
| `triage-label.yml` | → | `pr-setup-label.yml` |
| `triage-secret-scan.yml` | → | `pr-setup-secret-scan.yml` |
| `triage-dependabot.yml` | → | `pr-setup-dependabot.yml` |

잔여 `sync-`/`triage-` 의미가 더 또렷해짐:
- `sync-` = dev push / merge 기반 자동 commit (4 개: version, graphify, mds-mockups, pr-branches)
- `triage-` = 검증·이슈 생성·슬래시 (3 개: review, mds-issue, slash) — commit 없음

추가 정리:
- `BLUEDOC.md`: `pr-setup-` 행 추가 + `monitor-` 예시가 #2490 이후 stale 이었던 부분 (tick-user / daily-lifecycle → event-flow-hourly/daily, mds-render-coverage 추가) 도 같이 정정
- `CLAUDE.md`, `docs/qa/test-strategy.md` 의 옛 파일명 참조 갱신

## Test plan
- [ ] `pr-gate` → `check-workflow-yaml` 통과 (27 파일 YAML 파싱 ✓ 로컬 확인)
- [ ] 4 개 워크플로우가 새 이름으로 PR 트리거에 발화 (이 PR 자체로 확인)
- [ ] cross-ref 0 건 (다른 워크플로우의 `uses:`, `workflow_run.workflows` 에 옛 이름 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)