### PR TITLE
feat(ef-integration-test): MVP framework + first CUJ + pr-gate job

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -466,6 +466,50 @@ jobs:
         run: deno test --allow-all functions/
         working-directory: supabase
 
+  # EF integration test — 빈 local Supabase + 외부 mock 으로 실 schema/trigger/RLS contract 검증
+  # 설계: supabase/functions/_integration_tests/architecture.md
+  test-ef-integration:
+    name: test-ef-integration
+    needs: changes
+    if: ${{ needs.changes.outputs.supabase == 'true' }}
+    runs-on: [self-hosted, ephemeral]
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: supabase/setup-cli@v2
+        with:
+          version: latest
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Start local Supabase
+        run: supabase start
+
+      - name: Apply migrations only (db reset --no-seed)
+        run: supabase db reset --no-seed
+
+      - name: Capture supabase env
+        id: env
+        run: |
+          {
+            echo "url=$(supabase status -o env | grep '^API_URL=' | cut -d= -f2-)"
+            echo "service_role_key=$(supabase status -o env | grep '^SERVICE_ROLE_KEY=' | cut -d= -f2-)"
+            echo "anon_key=$(supabase status -o env | grep '^ANON_KEY=' | cut -d= -f2-)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run integration tests
+        env:
+          SUPABASE_URL: ${{ steps.env.outputs.url }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ steps.env.outputs.service_role_key }}
+          SUPABASE_ANON_KEY: ${{ steps.env.outputs.anon_key }}
+          SIM_USER_PASSWORD: ${{ secrets.SIM_USER_PASSWORD }}
+        run: deno test --allow-all supabase/functions/_integration_tests/cuj/
+
+      - name: Stop Supabase
+        if: always()
+        run: supabase stop || true
+
   # Workflow YAML 파싱 검증 (항상 실행 — db-invariants #1593 회귀 방지)
   check-workflow-yaml:
     runs-on: [self-hosted, ephemeral]
@@ -565,7 +609,7 @@ jobs:
     secrets: inherit
 
   ci-result:
-    needs: [check-migration-versions, check-env-manifest-sync, check-workflow-yaml, check-android-test-deps, check-cross-feature-imports, gitleaks, test-flutter-apps, test-integration-app-user-cuj, test-integration-app-partner-cuj, lint-landing-user, lint-landing-partner, lint-mds-docs, lint-mds-icons, test-supabase, test-edge-functions]
+    needs: [check-migration-versions, check-env-manifest-sync, check-workflow-yaml, check-android-test-deps, check-cross-feature-imports, gitleaks, test-flutter-apps, test-integration-app-user-cuj, test-integration-app-partner-cuj, lint-landing-user, lint-landing-partner, lint-mds-docs, lint-mds-icons, test-supabase, test-edge-functions, test-ef-integration]
     if: always()
     runs-on: [self-hosted, ephemeral]
     steps:

--- a/supabase/functions/_integration_tests/BLUEDOC.md
+++ b/supabase/functions/_integration_tests/BLUEDOC.md
@@ -1,0 +1,48 @@
+# ef-integration-test
+
+빈 local Supabase + 외부 API mock 으로 EF 의 실 schema/trigger/RLS contract 를 PR-time 에 검증하는 통합 테스트 레이어.
+
+## 위치 — 기존 test layer 사이의 빈 칸
+
+| Layer | 무엇을 검증 | 비용 |
+|---|---|---|
+| 5 Deno unit (`*_test.ts` + mock supabase) | EF 내부 로직 | 빠름 |
+| **(신규) ef-integration-test** | **실 Postgres/trigger/RLS contract** | **중** |
+| 7 event-flow-simulator (cascade) | 확률 분포 cross-EF emerge (dev 환경) | 무거움 |
+
+## 폴더 구조
+
+```
+_integration_tests/
+├── BLUEDOC.md / README.md / architecture.md
+├── _framework/                  ← local_supabase / reset / seed / invoke / mock_external
+└── cuj/<category>/<feature>_test.ts
+    예: cuj/account/signup_consent_test.ts
+        cuj/event/refund_policy_v2_test.ts
+```
+
+- **1 feature = 1 파일**, 다수 CUJ 가 한 파일에 `Deno.test("<cuj-id> ...", ...)` 블록
+- 폴더명 dash → 파일명 underscore (`signup-consent` → `signup_consent_test.ts`)
+- CUJ ID 는 [features/BLUEDOC.md](../../../docs/features/BLUEDOC.md) 의 `<scenario>-<cuj>` 컨벤션 (예: `1-1`, `1-2`)
+
+## 핵심 원리
+
+1. **빈 local DB** — `supabase start` + `supabase db reset --no-seed` → 마이그만 적용된 깨끗한 Postgres
+2. **외부 API mock** — PortOne 은 `dev-mock-portone` 로 redirect, Statsig 은 key 미설정으로 no-op
+3. **실 EF runtime** — Supabase CLI 의 Edge Runtime → 실 schema/trigger/RLS 동작
+4. **CUJ ID 추적** — spec.md 의 CUJs 표 ID 를 Deno.test 이름에 prefix → coverage notification 가 매핑
+5. **CUJ binary 검증** — 각 cujTest = 1 CUJ 충족 여부 통과/실패. assertion 작성 자유 (helper 는 필요 시 자연 발생, tier 설계 X)
+
+## 인접 layer 와의 관계
+
+- `_payment_integration_tests/` — in-process EF 체이닝 + 전체 mock (실 DB 없음). 다른 layer, 공존
+- `event-flow-simulator/` — Layer 7 cascade. dev 환경 대상 long-running. 책임 분리
+
+## 형제 문서
+
+- [architecture.md](./architecture.md) — 설계 상세 / CI yaml / 외부 mock 전략 (예정)
+- [README.md](./README.md) — 로컬 실행 빠른 가이드 (예정)
+
+## 관련 컨벤션
+
+- [BLUEDOC](../../../docs/infra/bluedoc/BLUEDOC.md), [features/BLUEDOC.md](../../../docs/features/BLUEDOC.md) (PRD + spec.md + CUJ ID), [test-strategy.md](../../../docs/qa/test-strategy.md), [edge-functions.md](../../../docs/operations/edge-functions.md)

--- a/supabase/functions/_integration_tests/README.md
+++ b/supabase/functions/_integration_tests/README.md
@@ -1,0 +1,53 @@
+# ef-integration-test — 빠른 가이드
+
+설계는 [architecture.md](./architecture.md), 진입점은 [BLUEDOC.md](./BLUEDOC.md).
+
+## 로컬 실행
+
+```bash
+# 1. local Supabase 부팅 (Docker 필요)
+supabase start
+
+# 2. 마이그 적용 (db reset 은 모든 데이터 초기화)
+supabase db reset --no-seed
+
+# 3. env 캡처
+export SUPABASE_URL=$(supabase status -o env | grep API_URL | cut -d= -f2)
+export SUPABASE_SERVICE_ROLE_KEY=$(supabase status -o env | grep SERVICE_ROLE_KEY | cut -d= -f2)
+export SUPABASE_ANON_KEY=$(supabase status -o env | grep ANON_KEY | cut -d= -f2)
+export SIM_USER_PASSWORD=password1234!
+
+# 4. 테스트 실행
+cd supabase/functions/_integration_tests
+deno test --allow-all cuj/
+
+# 또는 task 사용
+deno task test
+```
+
+## 신규 CUJ test 추가
+
+1. spec.md 에 CUJ 가 정의돼 있어야 함 (예: `1-1`, `1-2`).
+2. `cuj/<category>/<feature>_test.ts` 파일 생성 (없으면).
+3. 시나리오가 필요하면 `_framework/scenario.ts` 에 키 추가.
+4. cujTest 블록 작성:
+
+```ts
+import { suite } from "../../_framework/suite.ts";
+import { cujTest } from "../../_framework/cuj_test.ts";
+
+const ctx = suite("category/feature");
+
+cujTest(ctx, "1-1 <한 줄 설명>", "scenario-name", async (ctx) => {
+  const user = await ctx.actAs.user("user_test1");
+  const res = await user.invoke("apply-event", { ... });
+  assertEquals(res.status, 200);
+  // ... assertion
+});
+```
+
+## 디버깅
+
+- 로컬 Supabase 로그: `supabase logs functions`
+- EF 별 로그 stream: `supabase logs functions <ef-name> --follow`
+- DB 확인: `psql postgresql://postgres:postgres@127.0.0.1:54322/postgres`

--- a/supabase/functions/_integration_tests/_framework/actor.ts
+++ b/supabase/functions/_integration_tests/_framework/actor.ts
@@ -1,0 +1,128 @@
+// _framework/actor.ts — JWT 발급 + EF invoke
+
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
+
+export interface Actor {
+  readonly id: string;
+  readonly role: "user" | "partner";
+  /** EF 호출 — JWT 자동 부착. status + parsed json 반환 */
+  invoke(efName: string, body: unknown): Promise<{ status: number; data: unknown }>;
+}
+
+// token cache: cacheKey → JWT (suite 수명 동안 재사용)
+const _tokenCache = new Map<string, string>();
+
+/**
+ * Actor 생성. 식별자는 username 또는 user_profiles.id 중 하나:
+ * - 36자 UUID 형식이면 id 로 간주, auth.admin.getUserById 로 email 조회
+ * - 그 외는 username 으로 간주, user_profiles → auth.users 매핑
+ *
+ * 비밀번호는 SIM_USER_PASSWORD env (기본 'password1234!') 사용.
+ */
+export async function createActor(
+  role: "user" | "partner",
+  identifier: string,
+  url: string,
+  anonKey: string,
+  db: SupabaseClient,
+): Promise<Actor> {
+  const cacheKey = `${role}:${identifier}`;
+  let token = _tokenCache.get(cacheKey);
+
+  if (!token) {
+    const password = Deno.env.get("SIM_USER_PASSWORD") ?? "password1234!";
+    const email = await resolveEmail(role, identifier, db);
+
+    const client = createClient(url, anonKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+    const { data, error } = await client.auth.signInWithPassword({ email, password });
+    if (error || !data.session?.access_token) {
+      throw new Error(`actor signIn failed for ${cacheKey} (${email}): ${error?.message ?? "no session"}`);
+    }
+    token = data.session.access_token;
+    _tokenCache.set(cacheKey, token);
+  }
+
+  const id = await resolveId(role, identifier, db);
+
+  return {
+    id,
+    role,
+    async invoke(efName, body) {
+      const res = await fetch(`${url}/functions/v1/${efName}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${token}`,
+        },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json().catch(() => null);
+      return { status: res.status, data };
+    },
+  };
+}
+
+async function resolveEmail(
+  role: "user" | "partner",
+  identifier: string,
+  db: SupabaseClient,
+): Promise<string> {
+  // UUID v4 모양이면 id 로 간주
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(identifier)) {
+    const { data, error } = await db.auth.admin.getUserById(identifier);
+    if (error || !data?.user?.email) {
+      throw new Error(`resolveEmail: cannot find ${role} by id=${identifier}: ${error?.message ?? "no user"}`);
+    }
+    return data.user.email;
+  }
+
+  // 그 외는 username 으로 간주 — user_profiles 또는 partner_members 경유
+  if (role === "user") {
+    const { data: profile, error } = await db
+      .from("user_profiles")
+      .select("id")
+      .eq("username", identifier)
+      .maybeSingle();
+    if (error || !profile) {
+      throw new Error(`resolveEmail user: profile not found for username=${identifier}`);
+    }
+    const { data: auth } = await db.auth.admin.getUserById(profile.id as string);
+    if (!auth?.user?.email) throw new Error(`resolveEmail user: auth.users missing for ${identifier}`);
+    return auth.user.email;
+  }
+
+  // partner: identifier = partner_id, 첫 멤버 email 사용
+  const { data: members, error } = await db
+    .from("partner_members")
+    .select("user_id")
+    .eq("partner_id", identifier)
+    .limit(1);
+  if (error || !members || members.length === 0) {
+    throw new Error(`resolveEmail partner: no member for partner_id=${identifier}`);
+  }
+  const { data: auth } = await db.auth.admin.getUserById((members[0] as { user_id: string }).user_id);
+  if (!auth?.user?.email) throw new Error(`resolveEmail partner: auth.users missing for ${identifier}`);
+  return auth.user.email;
+}
+
+async function resolveId(
+  role: "user" | "partner",
+  identifier: string,
+  db: SupabaseClient,
+): Promise<string> {
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(identifier)) {
+    return identifier;
+  }
+  if (role === "user") {
+    const { data } = await db.from("user_profiles").select("id").eq("username", identifier).single();
+    return (data as { id: string }).id;
+  }
+  return identifier; // partner — identifier 가 partner_id
+}
+
+/** 테스트 간 token 캐시 정리 (필요 시) */
+export function clearTokenCache(): void {
+  _tokenCache.clear();
+}

--- a/supabase/functions/_integration_tests/_framework/cuj_test.ts
+++ b/supabase/functions/_integration_tests/_framework/cuj_test.ts
@@ -1,0 +1,33 @@
+// _framework/cuj_test.ts — Deno.test wrapper
+
+import type { Ctx } from "./suite.ts";
+import { applyScenario } from "./scenario.ts";
+
+/**
+ * cujTest — Deno.test 래퍼. scenario 시드 + 실 EF 호출 + assertion.
+ *
+ * @param ctx        suite() 반환 ctx
+ * @param id         CUJ ID + 짧은 설명 (예: "1-1 user gets empty feed")
+ * @param scenario   _framework/scenario.ts 의 키 (예: "fresh", "single-user")
+ * @param fn         실제 테스트 본문 — (ctx) => Promise<void>
+ */
+export function cujTest(
+  ctx: Ctx,
+  id: string,
+  scenario: string,
+  fn: (ctx: Ctx) => Promise<void>,
+): void {
+  Deno.test({
+    name: `[CUJ ${id}] (scenario=${scenario})`,
+    async fn() {
+      await applyScenario(scenario, ctx.db);
+      try {
+        await fn(ctx);
+      } catch (err) {
+        // 실패 시 디버깅 도움 출력
+        console.error(`\n[CUJ ${id}] FAILED — scenario=${scenario}`);
+        throw err;
+      }
+    },
+  });
+}

--- a/supabase/functions/_integration_tests/_framework/scenario.ts
+++ b/supabase/functions/_integration_tests/_framework/scenario.ts
@@ -1,0 +1,51 @@
+// _framework/scenario.ts — 재사용 seed preset
+//
+// 각 scenario 는 cujTest 호출 직전에 실행됨.
+// "fresh" 외 모든 scenario 는 service role 로 직접 INSERT (RLS 우회).
+// 더 복잡한 시나리오는 본 파일에 키 추가.
+
+import type { SupabaseClient } from "npm:@supabase/supabase-js@2";
+
+export type ScenarioFn = (db: SupabaseClient) => Promise<void>;
+
+export const scenarios: Record<string, ScenarioFn> = {
+  /** No-op — db reset 만 적용된 상태 그대로 */
+  fresh: async () => {},
+
+  /**
+   * 1 user 만 생성 (auth.users + user_profiles).
+   * EF 호출에 user JWT 가 필요한 read-only 테스트용.
+   * username: user_test1
+   */
+  "single-user": async (db) => {
+    const password = Deno.env.get("SIM_USER_PASSWORD") ?? "password1234!";
+    const email = "user_test1@example.test";
+
+    // auth.users 생성 (이미 있으면 skip)
+    const { data: existing } = await db.auth.admin.listUsers();
+    let userId = existing?.users.find((u) => u.email === email)?.id;
+    if (!userId) {
+      const { data, error } = await db.auth.admin.createUser({
+        email,
+        password,
+        email_confirm: true,
+        user_metadata: { username: "user_test1" },
+      });
+      if (error) throw new Error(`scenario single-user createUser: ${error.message}`);
+      userId = data.user!.id;
+    }
+
+    // user_profiles upsert (trigger 가 만들 수도 있지만 안전하게 upsert)
+    const { error: profileErr } = await db.from("user_profiles").upsert(
+      { id: userId, username: "user_test1" },
+      { onConflict: "id" },
+    );
+    if (profileErr) throw new Error(`scenario single-user profile: ${profileErr.message}`);
+  },
+};
+
+export function applyScenario(name: string, db: SupabaseClient): Promise<void> {
+  const fn = scenarios[name];
+  if (!fn) throw new Error(`Unknown scenario: ${name}. Available: ${Object.keys(scenarios).join(", ")}`);
+  return fn(db);
+}

--- a/supabase/functions/_integration_tests/_framework/suite.ts
+++ b/supabase/functions/_integration_tests/_framework/suite.ts
@@ -1,0 +1,52 @@
+// _framework/suite.ts — local Supabase 연결 + ctx 생성
+
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
+import { createActor, type Actor } from "./actor.ts";
+
+export interface Ctx {
+  readonly url: string;
+  readonly anonKey: string;
+  readonly db: SupabaseClient;        // service role — RLS 우회 (assertion + seed 용)
+  readonly actAs: {
+    user(usernameOrId: string): Promise<Actor>;
+    partner(partnerNameOrId: string): Promise<Actor>;
+  };
+}
+
+let _ctx: Ctx | null = null;
+
+/**
+ * suite("category/feature") — 파일 단위 setup.
+ * 첫 호출 시 env 에서 SUPABASE_URL / SERVICE_ROLE_KEY / ANON_KEY 캡처.
+ * 같은 process 안에서 동일 ctx 재사용 (테스트 간 client 재생성 비용 회피).
+ */
+export function suite(_featureKey: string): Ctx {
+  if (_ctx) return _ctx;
+
+  const url = Deno.env.get("SUPABASE_URL");
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
+
+  if (!url || !serviceKey || !anonKey) {
+    throw new Error(
+      "suite() requires SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY / SUPABASE_ANON_KEY env vars. " +
+        "Run `supabase start` and export from `supabase status -o env`.",
+    );
+  }
+
+  const db = createClient(url, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  _ctx = {
+    url,
+    anonKey,
+    db,
+    actAs: {
+      user: (id) => createActor("user", id, url, anonKey, db),
+      partner: (id) => createActor("partner", id, url, anonKey, db),
+    },
+  };
+
+  return _ctx;
+}

--- a/supabase/functions/_integration_tests/architecture.md
+++ b/supabase/functions/_integration_tests/architecture.md
@@ -1,0 +1,237 @@
+# ef-integration-test Architecture
+
+본 문서는 ef-integration-test 의 **설계 원리**, **framework 구성요소**, **CI 통합**, **coverage notification** 을 담는다. 진입점은 [BLUEDOC.md](./BLUEDOC.md).
+
+---
+
+## Part 1 — 목적
+
+> **PR 머지 전에 EF 가 실 Postgres / trigger / RLS 와 만났을 때의 contract 위반을 잡는다.**
+
+기존 layer 들 사이의 빈 칸을 채움:
+
+- Layer 5 (Deno unit, mock supabase) — EF 내부 로직만. mock fetch 라 schema/trigger/RLS 가짜 동작 사용 → 실 DB 와 drift 발견 못 함
+- Layer 7 (event-flow-simulator cascade) — 확률 분포 기반 long-running. PR 시간 안 맞음. dev 환경 의존
+- **(신규) ef-integration-test** — 실 Postgres + 실 EF runtime + 외부 mock. deterministic. PR 마다 실행
+
+---
+
+## Part 2 — 단일 핵심 원칙
+
+> **각 cujTest = 1 CUJ 가 충족됐는지 binary 검증. 통과 = CUJ holds, 실패 = CUJ broken.**
+
+내부 assertion 구조는 자유. tier 시스템 / 정형 매처 강제 안 함. helper 는 반복 패턴이 5+ 발생 시 자연 추출.
+
+이유:
+- CUJ 자체가 검증 단위 — 추가 layer 가 의미 더하지 않음
+- 작성자 (사람 / agent) 가 CUJ 의 expected behavior 를 직접 코드로 명시 → 의도 명확
+- helper 사전 설계는 over-engineering — 실 사용 패턴이 나온 후 추출이 정확
+
+---
+
+## Part 3 — Framework 구성요소
+
+5 모듈 (`_framework/` 하위), 변경 빈도 낮음:
+
+### 3.1 `suite.ts` — local supabase + 파일 단위 lifecycle
+
+```ts
+export async function suite(featureKey: string): Promise<Ctx>
+```
+
+호출 시점에:
+- supabase URL/keys 캡처 (`supabase status -o env`)
+- admin client (service_role) 생성
+- 파일 시작 시 `supabase db reset --no-seed` 보장 (한 번만)
+- `Ctx` 반환 — actor / db / mock 진입점
+
+`Ctx` 구조:
+```ts
+type Ctx = {
+  db: AdminClient;                  // service_role, RLS 우회 (assertion 용)
+  actAs: { user(id), partner(id) }; // Actor 생성
+  // ... 내부 state
+};
+```
+
+### 3.2 `cuj_test.ts` — Deno.test wrapper
+
+```ts
+export function cujTest(
+  ctx: Ctx,
+  id: string,              // "1-1 user consents and signs up"
+  scenario: string,        // "fresh" | "user-with-paid-app" | ...
+  fn: (ctx: Ctx) => Promise<void>,
+): void
+```
+
+자동 처리:
+- 시나리오 시드 (`scenarios[scenario]` 호출)
+- 실패 시 `[CUJ <id>]` prefix 로 출력 — debugging trace
+- 실패 시 마지막 EF response + DB diff dump
+
+### 3.3 `actor.ts` — Actor 추상
+
+```ts
+class Actor {
+  invoke(efName: string, body: unknown): Promise<{ status, data }>
+  // JWT 토큰 캐싱, Authorization 헤더 자동
+}
+```
+
+`ctx.actAs.user("u1")` → JWT 발급 (캐시) → `actor.invoke("apply-event", ...)` → 실 HTTP call to local edge runtime.
+
+### 3.4 `scenario.ts` — 재사용 seed preset
+
+```ts
+export const scenarios = {
+  fresh: () => {},                          // no seed, db reset 만
+  "minimal-users": async (db) => { ... },  // 1 partner, 2 user
+  "user-with-pending-app": async (db) => { ... },
+  "user-with-paid-app": async (db) => { ... },
+  "user-blocked-partner": async (db) => { ... },
+  "checked-in-participants": async (db) => { ... },
+  // ... 점진 확장 (~20 시나리오 상한)
+};
+```
+
+각 CUJ test 가 골라 씀. cujTest 가 자동 호출.
+
+### 3.5 `mock_external.ts` — 외부 API redirect
+
+- **PortOne** — `PORTONE_API_URL` env 를 local `dev-mock-portone` EF 로 redirect
+- **Statsig** — `STATSIG_SERVER_KEY` 미설정 → `_shared/statsig_utils.ts` 가 no-op
+- **GitHub API** — event-flow CUJ 안 호출 (bug-report 도메인 외)
+
+신규 외부 의존 추가 시 본 모듈에 처리 패턴 추가.
+
+---
+
+## Part 4 — CI 워크플로우
+
+```yaml
+# .github/workflows/ci-ef-integration.yml (예정)
+name: ci-ef-integration
+
+on:
+  pull_request:
+    paths: ['supabase/functions/**', 'supabase/migrations/**']
+  workflow_dispatch:
+
+jobs:
+  integration:
+    runs-on: [self-hosted, ephemeral]
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: supabase/setup-cli@v2
+      - uses: denoland/setup-deno@v2
+
+      - run: supabase start                              # ~30-60s 1회
+      - run: supabase db reset --no-seed                 # 마이그 적용
+      - id: status
+        run: |
+          echo "service_role_key=$(supabase status -o env | grep SERVICE_ROLE_KEY | cut -d= -f2)" >> $GITHUB_OUTPUT
+
+      - run: deno test --allow-all --no-parallel supabase/functions/_integration_tests/cuj/
+        env:
+          SUPABASE_URL: http://127.0.0.1:54321
+          SUPABASE_SERVICE_ROLE_KEY: ${{ steps.status.outputs.service_role_key }}
+          PORTONE_API_URL: http://127.0.0.1:54321/functions/v1/dev-mock-portone
+
+      - name: CUJ coverage report
+        if: always()
+        run: deno run --allow-all supabase/functions/_integration_tests/_framework/coverage.ts > /tmp/coverage.md
+
+      - name: Post coverage as PR comment
+        if: github.event_name == 'pull_request' && always()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: /tmp/coverage.md
+          header: cuj-coverage
+
+      - if: always()
+        run: supabase stop
+```
+
+성능 추정:
+- supabase start: 30-60s
+- 마이그 reset: 5-10s
+- 테스트: ~2-3s/CUJ × 100 CUJ = 3-5분
+- **전체 PR run: ~4-7분**
+
+병렬화 가능 (`--parallel` + scenarios 격리) 한 장래 최적화.
+
+---
+
+## Part 5 — Coverage Notification
+
+### 5.1 측정 항목
+
+| 항목 | 출처 |
+|---|---|
+| **CUJ coverage** | `docs/features/<cat>/<feat>/spec.md` 의 CUJs 표 ID vs `cuj/<cat>/<feat>_test.ts` 의 Deno.test 이름 prefix |
+| **EF coverage** | test 파일 frontmatter `@efs` (선택) 또는 런타임 trace (axiom 로그) |
+| **Feature coverage** | feature 별 covered/missing CUJ 수 |
+
+### 5.2 출력 (PR sticky comment)
+
+```markdown
+# CUJ Integration Coverage
+
+| Feature | spec.md CUJs | Covered | Missing |
+|---|---|---|---|
+| account/signup-consent | 5 | 4 | `1-3` |
+| event/refund-policy-v2 | 7 | 7 | (all covered) |
+| event/event-edit-cancel | 4 | 0 | `1-1`, `1-2`, `2-1`, `2-2` |
+```
+
+### 5.3 gate 정책
+
+초기엔 **정보만 게시**. 운영 데이터 축적 후 strict (놓친 CUJ → PR fail) 단계 고려.
+
+---
+
+## Part 6 — 트레이드오프
+
+| 항목 | 결정 | 대안 |
+|---|---|---|
+| 격리 단위 | 파일 = suite, 테스트 = scenario | 매 테스트 reset (너무 느림) / transaction rollback (EF 가 HTTP 경계 넘으면 불가) |
+| 병렬 | serial (`--no-parallel`) | 병렬 → DB state 충돌. supabase 인스턴스 1개 한계 |
+| supabase 부팅 | 워크플로우 시작 시 1회 | 매 테스트 부팅 비현실적 |
+| assertion 구조 | 자유 (tier 없음) | helper tier — over-engineering |
+| 외부 mock 위치 | `_framework/mock_external.ts` 단일 | per-EF mock 분산 — 추적 어려움 |
+| Coverage gate | 정보만 (초기) | strict fail (놓친 CUJ) — 운영 후 고려 |
+
+---
+
+## Part 7 — 인접 layer 와의 관계
+
+| Layer | 책임 분리 |
+|---|---|
+| `_payment_integration_tests/` | in-process EF chaining + 전체 mock (실 DB 없음). 본 framework 와 다른 layer, 공존 |
+| `event-flow-simulator/` | Layer 7 cascade — 확률 분포, long-running, dev 환경. 본 framework 는 deterministic, PR-time |
+| Layer 5 (Deno unit) | EF 내부 로직 mock 테스트. 본 framework 는 실 schema/trigger/RLS contract |
+| Layer 4 (pgTAP) | DB schema/RPC/RLS 직접 검증. 본 framework 는 EF 경로 통과 시의 통합 동작 |
+
+---
+
+## Part 8 — 도입 단계 (예정)
+
+| # | 작업 | 기간 |
+|---|---|---|
+| 1 | `_framework/` 5 모듈 작성 + minimal scenarios 5개 | 1주 |
+| 2 | 첫 CUJ test 시범 — `cuj/account/signup_consent_test.ts` 1 파일 | 2-3일 |
+| 3 | CI 워크플로우 `ci-ef-integration.yml` 추가 (self-hosted Docker 안정화 선행) | 2-3일 |
+| 4 | coverage.ts + PR 코멘트 통합 | 2-3일 |
+| 5 | 점진 확장 — feature 별 cuj/<cat>/<feat>_test.ts 작성 | 지속 |
+
+---
+
+## 형제 문서
+
+- [BLUEDOC.md](./BLUEDOC.md) — 진입점
+- [README.md](./README.md) — 로컬 실행 빠른 가이드 (예정)
+- [features/BLUEDOC.md](../../../docs/features/BLUEDOC.md) — PRD / spec.md / CUJ ID 컨벤션
+- [edge-functions.md](../../../docs/operations/edge-functions.md) — EF 운영 / 디버깅
+- [event-flow-simulator/architecture.md](../event-flow-simulator/architecture.md) — Layer 7 cascade 모델

--- a/supabase/functions/_integration_tests/cuj/discovery/event_feed_test.ts
+++ b/supabase/functions/_integration_tests/cuj/discovery/event_feed_test.ts
@@ -1,0 +1,31 @@
+// cuj/discovery/event_feed_test.ts — user-event-feed EF 의 smoke 검증
+//
+// 본 파일은 framework PoC 첫 샘플. user-event-feed 가:
+// - 빈 DB 상태에서 200 + 빈 events 배열 반환
+// - 잘못된 sort_by 에 4xx 반환
+//
+// 더 의미 있는 CUJ 시나리오 (실 이벤트 신청/매칭 funnel) 는 후속 파일.
+
+import { assert, assertEquals } from "jsr:@std/assert@1";
+import { suite } from "../../_framework/suite.ts";
+import { cujTest } from "../../_framework/cuj_test.ts";
+
+const ctx = suite("discovery/event-feed");
+
+cujTest(ctx, "1-1 user-event-feed returns empty array when no events exist", "single-user", async (ctx) => {
+  const user = await ctx.actAs.user("user_test1");
+  const res = await user.invoke("user-event-feed", { limit: 20 });
+
+  assertEquals(res.status, 200, `expected 200, got ${res.status}: ${JSON.stringify(res.data)}`);
+  const data = res.data as { events?: unknown[] };
+  assert(Array.isArray(data.events), `events must be array, got ${typeof data.events}`);
+  assertEquals(data.events!.length, 0, "fresh DB should yield 0 events");
+});
+
+cujTest(ctx, "1-2 user-event-feed rejects invalid sort_by", "single-user", async (ctx) => {
+  const user = await ctx.actAs.user("user_test1");
+  const res = await user.invoke("user-event-feed", { limit: 20, sort_by: "bogus" });
+
+  // 400 또는 500 둘 다 허용 — RPC RAISE EXCEPTION 이 어떻게 직렬화되는지 EF 구현 의존
+  assert(res.status >= 400, `expected 4xx/5xx for invalid sort_by, got ${res.status}`);
+});

--- a/supabase/functions/_integration_tests/deno.json
+++ b/supabase/functions/_integration_tests/deno.json
@@ -1,0 +1,9 @@
+{
+  "tasks": {
+    "test": "deno test --allow-all cuj/"
+  },
+  "imports": {
+    "@std/assert": "jsr:@std/assert@1",
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2"
+  }
+}


### PR DESCRIPTION
## Summary

Stochastic Cascade (Layer 7) 와 별개의 **deterministic 통합 테스트 레이어 (Layer 5.5)**. 빈 local Supabase + 외부 mock 으로 EF 의 실 schema/trigger/RLS contract 를 PR-time 에 검증. PR #2490 에서 RFC (BLUEDOC + architecture) 만 머지됐고, 본 PR 이 MVP 구현 + CI 통합.

## 변경

### 문서 (PR #2490 squash 시 누락 재추가)
- `_integration_tests/BLUEDOC.md` — 진입점
- `_integration_tests/architecture.md` — 8 part 설계
- `_integration_tests/README.md` — 로컬 실행 가이드

### Framework (`_framework/` 4 파일)
- `suite.ts` — ctx 생성, env 캡처, admin client + actAs 진입점
- `actor.ts` — JWT 발급 (auth.signInWithPassword) + invoke() — username/id 자동 resolve + token cache
- `scenario.ts` — 재사용 seed preset (`fresh`, `single-user`)
- `cuj_test.ts` — Deno.test wrapper, scenario 자동 적용 + 실패 시 `[CUJ <id>]` prefix

### 샘플 test
- `cuj/discovery/event_feed_test.ts` — `user-event-feed` EF 2건:
  - `1-1` 빈 DB 상태 → 200 + 빈 events 배열
  - `1-2` invalid sort_by → 4xx/5xx

### CI
- `pr-gate.yml` 에 `test-ef-integration` 잡 신규 추가 (supabase start + db reset --no-seed + deno test)
- `ci-result` needs 에 `test-ef-integration` 추가 → 본 잡 fail 시 PR 차단

## Test plan

### 정적
- [x] 로컬 `deno check cuj/discovery/event_feed_test.ts` 통과
- [ ] CI `test-ef-integration` 잡이 self-hosted 에서 `supabase start` 성공
- [ ] `cuj/discovery/event_feed_test.ts` 2건 실 EF 호출 + assertion 통과
- [ ] `ci-result` 가 신규 잡 fail 반영

### 로컬 검증 미수행
본인 환경에 Docker 미설치 (OrbStack 삭제 직후). CI 가 첫 실 동작 검증.

## 알려진 제약

- `single-user` scenario 가 `user_profiles` trigger 의존 — trigger 없으면 upsert 가 보강
- `cuj_test` 가 file-level Ctx 공유 (suite 1회) → 같은 파일 테스트 순서 의존 가능. scenarios 가 멱등이라 OK 지만 추후 `reset_between_tests` 옵션 필요할 수도
- 외부 API mock (`mock_external.ts`) 는 첫 EF 가 외부 의존 없어서 미작성 — payment EF 추가 시 도입

## Follow-up (별도 PR)

- 더 많은 CUJ scenario (apply / pay / refund / approve / checkin / vote / match)
- `mock_external.ts` — PortOne → `dev-mock-portone` redirect
- `coverage.ts` — spec.md CUJ 표 ↔ test 매핑 + PR sticky comment
- Local Docker 환경 정리 후 framework 로컬 dev workflow 보강

## Related

- #2490 — Stochastic Cascade v2 + event-flow-simulator rename (본 framework 의 인접 layer)
- BLUEDOC + architecture 의 RFC 는 본 PR 에서 dev 에 처음 도달 (#2490 squash 시 타이밍상 누락)

🤖 Generated with [Claude Code](https://claude.com/claude-code)