### PR TITLE
ci(secret-scan): grant pull-requests:write to gitleaks job

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Add `pull-requests: write` to the gitleaks job's permissions block so `gitleaks/gitleaks-action@v2` can post its PR comment.

## Why
With only `contents: read`, the action's PR-summary call fails with `Resource not accessible by integration` and the scan job goes red even when no secrets were detected. This surfaced on the self-hosted-fork variant of this workflow (`triage-secret-scan.yml`) on a recent PR; main's `secret-scan.yml` has the same permission gap and is preemptively fixed here.

## Test plan
- [ ] Wait for this PR's own Gitleaks Secret Scan check to run with the new permissions — should pass without `Resource not accessible by integration`.
- [ ] Confirm no other workflow regresses.

Context: branched off the infra issue cleanup referenced in #2491 (now closed by the self-hosted runner ephemerality fix in `minglit-github-workflow-runner`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)