### PR TITLE
fix(cuj): allow git access to Flutter SDK in pr-gate CUJ jobs

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -576,6 +576,10 @@ jobs:
           channel: 'stable'
           cache: true
 
+      # Fix self-hosted runner: Flutter SDK cache dir owned by different user → git refuses ops.
+      - name: Allow git access to Flutter SDK dir
+        run: git config --global --add safe.directory '*'
+
       - name: Install dependencies
         run: flutter pub get
         working-directory: apps/app_user
@@ -639,6 +643,10 @@ jobs:
         with:
           channel: 'stable'
           cache: true
+
+      # Fix self-hosted runner: Flutter SDK cache dir owned by different user → git refuses ops.
+      - name: Allow git access to Flutter SDK dir
+        run: git config --global --add safe.directory '*'
 
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -538,143 +538,26 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml
 
-  # CUJ integration tests on emulator — pattern: integration_test/cuj/<category>/<feature>_test.dart
+  # CUJ integration tests on emulator — reusable workflow.
   # Engine + BLUEDOC: apps/<app>/integration_test/cuj/BLUEDOC.md
+  # Manual debug: `gh workflow run shared-cuj-integration.yml -f app-name=user --ref <branch>`
   test-integration-app-user-cuj:
     name: cuj-integration-user
     needs: changes
     if: needs.changes.outputs.app_user_or_kit == 'true'
-    runs-on: [self-hosted, android]
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Create dev Flutter env file
-        env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_DEV_URL }}
-          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }}
-          ENVIRONMENT: development
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN_FLUTTER }}
-          STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
-          GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_DEV_WEB_CLIENT_ID }}
-          KAKAO_LOCAL_REST_API_KEY: ${{ secrets.KAKAO_LOCAL_REST_API_KEY }}
-          KAKAO_MAP_JAVASCRIPT_KEY: ${{ secrets.KAKAO_MAP_JAVASCRIPT_KEY }}
-          JUSO_CONFIRM_KEY: ${{ secrets.JUSO_CONFIRM_KEY }}
-          IAMPORT_USER_CODE: ${{ secrets.IAMPORT_USER_CODE }}
-          MOBILE_REDIRECT_SCHEME: ${{ secrets.MOBILE_REDIRECT_SCHEME }}
-        run: bash .github/scripts/create-dev-flutter-env.sh
-
-      - name: Set up Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 17
-
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: 'stable'
-          cache: true
-
-      # Fix self-hosted runner: Flutter SDK cache dir owned by different user → git refuses ops.
-      - name: Allow git access to Flutter SDK dir
-        run: git config --global --add safe.directory '*'
-
-      - name: Install dependencies
-        run: flutter pub get
-        working-directory: apps/app_user
-
-      - name: Enable KVM acceleration
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules && sudo udevadm trigger --name-match=kvm
-
-      - name: Run CUJ tests on Android emulator
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 34
-          arch: x86_64
-          profile: pixel_6
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
-          disable-animations: true
-          script: bash .github/scripts/run-user-cuj.sh
-
-      - name: Upload test artifacts on failure
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: cuj-integration-app-user-${{ github.run_id }}
-          path: apps/app_user/build/app/outputs/
-          retention-days: 14
+    uses: ./.github/workflows/shared-cuj-integration.yml
+    with:
+      app-name: user
+    secrets: inherit
 
   test-integration-app-partner-cuj:
     name: cuj-integration-partner
     needs: changes
     if: needs.changes.outputs.app_partner_or_kit == 'true'
-    runs-on: [self-hosted, android]
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Create dev Flutter env file
-        env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_DEV_URL }}
-          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }}
-          ENVIRONMENT: development
-          SENTRY_DSN: ${{ secrets.SENTRY_DSN_FLUTTER }}
-          STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
-          GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_DEV_WEB_CLIENT_ID }}
-          KAKAO_LOCAL_REST_API_KEY: ${{ secrets.KAKAO_LOCAL_REST_API_KEY }}
-          KAKAO_MAP_JAVASCRIPT_KEY: ${{ secrets.KAKAO_MAP_JAVASCRIPT_KEY }}
-          JUSO_CONFIRM_KEY: ${{ secrets.JUSO_CONFIRM_KEY }}
-          IAMPORT_USER_CODE: ${{ secrets.IAMPORT_USER_CODE }}
-          MOBILE_REDIRECT_SCHEME: ${{ secrets.MOBILE_REDIRECT_SCHEME }}
-        run: bash .github/scripts/create-dev-flutter-env.sh
-
-      - name: Set up Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 17
-
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: 'stable'
-          cache: true
-
-      # Fix self-hosted runner: Flutter SDK cache dir owned by different user → git refuses ops.
-      - name: Allow git access to Flutter SDK dir
-        run: git config --global --add safe.directory '*'
-
-      - name: Install dependencies
-        run: flutter pub get
-        working-directory: apps/app_partner
-
-      - name: Enable KVM acceleration
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules && sudo udevadm trigger --name-match=kvm
-
-      - name: Run CUJ tests on Android emulator
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 34
-          arch: x86_64
-          profile: pixel_6
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
-          disable-animations: true
-          script: bash .github/scripts/run-partner-cuj.sh
-
-      - name: Upload test artifacts on failure
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: cuj-integration-app-partner-${{ github.run_id }}
-          path: apps/app_partner/build/app/outputs/
-          retention-days: 14
+    uses: ./.github/workflows/shared-cuj-integration.yml
+    with:
+      app-name: partner
+    secrets: inherit
 
   ci-result:
     needs: [check-migration-versions, check-env-manifest-sync, check-workflow-yaml, check-android-test-deps, check-cross-feature-imports, gitleaks, test-flutter-apps, test-integration-app-user-cuj, test-integration-app-partner-cuj, lint-landing-user, lint-landing-partner, lint-mds-docs, lint-mds-icons, test-supabase, test-edge-functions]

--- a/.github/workflows/shared-cuj-integration.yml
+++ b/.github/workflows/shared-cuj-integration.yml
@@ -72,6 +72,7 @@ jobs:
 
       - name: Enable KVM acceleration
         run: |
+          sudo mkdir -p /etc/udev/rules.d
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules && sudo udevadm trigger --name-match=kvm
 

--- a/.github/workflows/shared-cuj-integration.yml
+++ b/.github/workflows/shared-cuj-integration.yml
@@ -60,8 +60,11 @@ jobs:
           cache: true
 
       # Self-hosted runner: Flutter SDK cache dir 가 다른 user 소유 → git 거부.
+      # safe.directory를 '*'로 열지 않고 Flutter SDK 경로만 허용 (Fix #2499).
       - name: Allow git access to Flutter SDK dir
-        run: git config --global --add safe.directory '*'
+        run: |
+          FLUTTER_SDK="$(dirname "$(dirname "$(command -v flutter)")")"
+          git config --global --add safe.directory "$FLUTTER_SDK"
 
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/shared-cuj-integration.yml
+++ b/.github/workflows/shared-cuj-integration.yml
@@ -1,0 +1,92 @@
+name: shared-cuj-integration
+
+# CUJ integration tests on Android emulator — 재사용 워크플로우.
+#
+# pr-gate.yml 에서 path filter 통과 시 `uses:` 로 호출되고,
+# workflow_dispatch 로 수동 트리거도 가능 (디버깅/검증용).
+#
+# 대응 BLUEDOC: apps/<app>/integration_test/cuj/BLUEDOC.md
+
+on:
+  workflow_call:
+    inputs:
+      app-name:
+        description: 'App name (user or partner)'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      app-name:
+        description: 'App name'
+        required: true
+        type: choice
+        options:
+          - user
+          - partner
+        default: user
+
+jobs:
+  cuj-integration:
+    runs-on: [self-hosted, android]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Create dev Flutter env file
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_DEV_URL }}
+          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }}
+          ENVIRONMENT: development
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN_FLUTTER }}
+          STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
+          GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_DEV_WEB_CLIENT_ID }}
+          KAKAO_LOCAL_REST_API_KEY: ${{ secrets.KAKAO_LOCAL_REST_API_KEY }}
+          KAKAO_MAP_JAVASCRIPT_KEY: ${{ secrets.KAKAO_MAP_JAVASCRIPT_KEY }}
+          JUSO_CONFIRM_KEY: ${{ secrets.JUSO_CONFIRM_KEY }}
+          IAMPORT_USER_CODE: ${{ secrets.IAMPORT_USER_CODE }}
+          MOBILE_REDIRECT_SCHEME: ${{ secrets.MOBILE_REDIRECT_SCHEME }}
+        run: bash .github/scripts/create-dev-flutter-env.sh
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      # Self-hosted runner: Flutter SDK cache dir 가 다른 user 소유 → git 거부.
+      - name: Allow git access to Flutter SDK dir
+        run: git config --global --add safe.directory '*'
+
+      - name: Install dependencies
+        run: flutter pub get
+        working-directory: apps/app_${{ inputs.app-name }}
+
+      - name: Enable KVM acceleration
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules && sudo udevadm trigger --name-match=kvm
+
+      - name: Run CUJ tests on Android emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          profile: pixel_6
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          disable-animations: true
+          script: bash .github/scripts/run-${{ inputs.app-name }}-cuj.sh
+
+      - name: Upload test artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: cuj-integration-app-${{ inputs.app-name }}-${{ github.run_id }}
+          path: apps/app_${{ inputs.app-name }}/build/app/outputs/
+          retention-days: 14

--- a/apps/app_partner/integration_test/cuj/account/partner_account_deletion_test.dart
+++ b/apps/app_partner/integration_test/cuj/account/partner_account_deletion_test.dart
@@ -31,11 +31,12 @@ void main() {
   });
 
   List<dynamic> base() => [
-        accountDeletionCoordinatorProvider.overrideWithValue(coordinator),
-      ];
+    accountDeletionCoordinatorProvider.overrideWithValue(coordinator),
+  ];
 
   cujGroup('1-1', '탈퇴 사유 선택 후 다음 단계 진입', () {
-    cujCase('happy: 사유 선택 → 다음 → pushInfo(reason: ...)',
+    cujCase(
+      'happy: 사유 선택 → 다음 → pushInfo(reason: ...)',
       app: const DeletionReasonPage(),
       overrides: base,
       body: (t) async {
@@ -51,12 +52,14 @@ void main() {
         await t.tap(find.text('다음'));
         await t.pumpAndSettle();
 
-        verify(() => coordinator.pushInfo(reason: any(named: 'reason')))
-            .called(1);
+        verify(
+          () => coordinator.pushInfo(reason: any(named: 'reason')),
+        ).called(1);
       },
     );
 
-    cujCase('happy: 선택 없이 계속하기 → pushInfo(reason: null)',
+    cujCase(
+      'happy: 선택 없이 계속하기 → pushInfo(reason: null)',
       app: const DeletionReasonPage(),
       overrides: base,
       body: (t) async {
@@ -68,7 +71,8 @@ void main() {
       },
     );
 
-    cujCase('edge: 사유 미선택 → 다음 비활성',
+    cujCase(
+      'edge: 사유 미선택 → 다음 비활성',
       app: const DeletionReasonPage(),
       overrides: base,
       body: (t) async {

--- a/apps/app_user/integration_test/cuj/account/signup_consent_test.dart
+++ b/apps/app_user/integration_test/cuj/account/signup_consent_test.dart
@@ -44,14 +44,15 @@ void main() {
   });
 
   List<dynamic> base() => [
-        currentUserProvider.overrideWith((_) => user),
-        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
-        consentRepositoryProvider.overrideWith((_) => repo),
-        consentCoordinatorProvider.overrideWith((_) => coordinator),
-      ];
+    currentUserProvider.overrideWith((_) => user),
+    authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+    consentRepositoryProvider.overrideWith((_) => repo),
+    consentCoordinatorProvider.overrideWith((_) => coordinator),
+  ];
 
   cujGroup('1-1', '필수 동의 3종 체크 후 가입', () {
-    cujCase('happy: 정상 가입',
+    cujCase(
+      'happy: 정상 가입',
       app: const SignupConsentPage(),
       overrides: base,
       body: (t) async {
@@ -78,12 +79,14 @@ void main() {
         expect(keys, equals(ConsentType.requiredTypes.toSet()));
 
         // FR-12: 가입 완료 후 HomePage 진입 (coordinator 위임)
-        verify(() => coordinator.completeSignup(from: any(named: 'from')))
-            .called(1);
+        verify(
+          () => coordinator.completeSignup(from: any(named: 'from')),
+        ).called(1);
       },
     );
 
-    cujCase('edge: 14세 미체크 → CTA 비활성',
+    cujCase(
+      'edge: 14세 미체크 → CTA 비활성',
       app: const SignupConsentPage(),
       overrides: base,
       body: (t) async {
@@ -100,12 +103,14 @@ void main() {
       },
     );
 
-    cujCase('edge: 저장 실패 → coordinator 미호출',
+    cujCase(
+      'edge: 저장 실패 → coordinator 미호출',
       app: const SignupConsentPage(),
       overrides: base,
       body: (t) async {
-        when(() => repo.saveConsents(any(), any()))
-            .thenThrow(Exception('network'));
+        when(
+          () => repo.saveConsents(any(), any()),
+        ).thenThrow(Exception('network'));
 
         await t.tap(find.text('서비스 이용약관'));
         await t.tap(find.text('개인정보 수집·이용 동의'));

--- a/apps/app_user/integration_test/mds-emulator-render/_engine/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_engine/builder.dart
@@ -27,10 +27,10 @@ import 'package:minglit_kit/minglit_kit.dart';
 
 /// 모든 화면이 공유하는 root level override.
 List<dynamic> _commonRootOverrides() => [
-      currentUserProvider.overrideWith((_) => null),
-      authStateChangesProvider.overrideWith((_) => const Stream.empty()),
-      notificationInitializerProvider.overrideWith((_) {}),
-    ];
+  currentUserProvider.overrideWith((_) => null),
+  authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+  notificationInitializerProvider.overrideWith((_) {}),
+];
 
 /// 화면별 builder 의 base class.
 ///

--- a/apps/app_user/integration_test/mds-emulator-render/_engine/state.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_engine/state.dart
@@ -6,9 +6,10 @@
 import 'builder.dart';
 
 /// builder 에 state 셋업을 적용하는 함수.
-typedef MdsStateSetup<B extends MdsScreenBuilder<dynamic>> = B Function(
-  B builder,
-);
+typedef MdsStateSetup<B extends MdsScreenBuilder<dynamic>> =
+    B Function(
+      B builder,
+    );
 
 /// 한 화면의 한 state.
 ///

--- a/apps/app_user/integration_test/mds-emulator-render/_mocks/notifiers.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_mocks/notifiers.dart
@@ -28,8 +28,8 @@ class StaticRecommendationFeedNotifier extends RecommendationFeedNotifier {
 
   @override
   Future<RecommendationFeedState> build() async => RecommendationFeedState(
-        events: _events,
-        serverOffset: _events.length,
-        hasMore: false,
-      );
+    events: _events,
+    serverOffset: _events.length,
+    hasMore: false,
+  );
 }

--- a/apps/app_user/integration_test/mds-emulator-render/home_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/home_page/builder.dart
@@ -17,21 +17,22 @@ import '../_mocks/notifiers.dart';
 
 class HomePageBuilder extends MdsScreenBuilder<HomePage> {
   HomePageBuilder()
-      : super(
-          page: const HomePage(),
-          base: [
-            // 모든 state 에 공통인 것만. provider 충돌 방지 위해 state 별로
-            // 달라질 수 있는 것 (feed 등) 은 fluent 메서드가 명시적으로 추가.
-            homeCoordinatorProvider.overrideWithValue(MockHomeCoordinator()),
-            activeFiltersProvider.overrideWith(NoFiltersNotifier.new),
-          ],
-        );
+    : super(
+        page: const HomePage(),
+        base: [
+          // 모든 state 에 공통인 것만. provider 충돌 방지 위해 state 별로
+          // 달라질 수 있는 것 (feed 등) 은 fluent 메서드가 명시적으로 추가.
+          homeCoordinatorProvider.overrideWithValue(MockHomeCoordinator()),
+          activeFiltersProvider.overrideWith(NoFiltersNotifier.new),
+        ],
+      );
 
   /// 빈 추천 피드.
   HomePageBuilder empty() {
     addOverride(
-      recommendationFeedProvider
-          .overrideWith(EmptyRecommendationFeedNotifier.new),
+      recommendationFeedProvider.overrideWith(
+        EmptyRecommendationFeedNotifier.new,
+      ),
     );
     return this;
   }

--- a/apps/app_user/test/src/features/search/search_page_a11y_test.dart
+++ b/apps/app_user/test/src/features/search/search_page_a11y_test.dart
@@ -35,7 +35,9 @@ Widget _buildTestWidget({List<Override> extraOverrides = const []}) {
 
 void main() {
   group('SearchPage a11y — Fix #2390', () {
-    testWidgets('TextField has Semantics label for screen readers', (tester) async {
+    testWidgets('TextField has Semantics label for screen readers', (
+      tester,
+    ) async {
       await tester.pumpWidget(_buildTestWidget());
       await tester.pump();
 
@@ -46,7 +48,9 @@ void main() {
       expect(semanticsFinder, findsOneWidget);
     });
 
-    testWidgets('clear button has tooltip when text is present', (tester) async {
+    testWidgets('clear button has tooltip when text is present', (
+      tester,
+    ) async {
       await tester.pumpWidget(_buildTestWidget());
       await tester.pump();
 
@@ -62,7 +66,9 @@ void main() {
       expect(iconButton.tooltip, '입력 지우기');
     });
 
-    testWidgets('clear button is absent when text field is empty', (tester) async {
+    testWidgets('clear button is absent when text field is empty', (
+      tester,
+    ) async {
       await tester.pumpWidget(_buildTestWidget());
       await tester.pump();
 

--- a/apps/app_user/test_driver/mds_emulator_render_driver.dart
+++ b/apps/app_user/test_driver/mds_emulator_render_driver.dart
@@ -36,7 +36,8 @@ void _logErr(String msg) {
 }
 
 Future<void> main() => integrationDriver(
-      onScreenshot: (
+  onScreenshot:
+      (
         String name,
         List<int> bytes, [
         Map<String, Object?>? args,
@@ -71,4 +72,4 @@ Future<void> main() => integrationDriver(
           return false;
         }
       },
-    );
+);

--- a/shared/packages/minglit_kit/lib/src/data/repositories/party_event_repository.dart
+++ b/shared/packages/minglit_kit/lib/src/data/repositories/party_event_repository.dart
@@ -129,7 +129,7 @@ mixin _PartyEventRepository on _SupabasePartyContext {
       if (response.status != 200) {
         final error = response.data is Map
             ? (response.data as Map)['error'] ??
-                'Failed to update event metadata'
+                  'Failed to update event metadata'
             : 'Failed to update event metadata';
         throw Exception(error);
       }

--- a/shared/packages/minglit_kit/test/src/data/repositories/event_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/event_repository_test.dart
@@ -217,21 +217,24 @@ void main() {
         );
       });
 
-      test('throws MinglitUserException when response.data is not a Map', () async {
-        when(
-          () => mockFunctions.invoke(
-            'user-cancel-order',
-            body: any(named: 'body'),
-          ),
-        ).thenAnswer(
-          (_) async => FunctionResponse(status: 200, data: 'ok'),
-        );
+      test(
+        'throws MinglitUserException when response.data is not a Map',
+        () async {
+          when(
+            () => mockFunctions.invoke(
+              'user-cancel-order',
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer(
+            (_) async => FunctionResponse(status: 200, data: 'ok'),
+          );
 
-        await expectLater(
-          repository.cancelOrder(eventId: 'event_1'),
-          throwsA(isA<MinglitUserException>()),
-        );
-      });
+          await expectLater(
+            repository.cancelOrder(eventId: 'event_1'),
+            throwsA(isA<MinglitUserException>()),
+          );
+        },
+      );
 
       test('returns refunded result with refundAmount', () async {
         when(
@@ -242,7 +245,10 @@ void main() {
         ).thenAnswer(
           (_) async => FunctionResponse(
             status: 200,
-            data: {'type': 'refunded', 'data': {'refund_amount': 30000}},
+            data: {
+              'type': 'refunded',
+              'data': {'refund_amount': 30000},
+            },
           ),
         );
 

--- a/shared/packages/minglit_kit/test/src/data/repositories/party_repository_test.dart
+++ b/shared/packages/minglit_kit/test/src/data/repositories/party_repository_test.dart
@@ -760,7 +760,10 @@ void main() {
         final body = captured.first as Map<String, dynamic>;
         expect(body['action'], 'update');
         expect(body['event_id'], 'event_1');
-        expect((body['event'] as Map)['metadata'], {'theme': 'dark', 'capacity': 50});
+        expect((body['event'] as Map)['metadata'], {
+          'theme': 'dark',
+          'capacity': 50,
+        });
       });
 
       test('throws on EF error', () async {


### PR DESCRIPTION
## Summary

PR #2496 실 검증에서 `test-integration-app-{user,partner}-cuj` 둘 다 fail:

```
fatal: detected dubious ownership in repository at
'/opt/hostedtoolcache/flutter/stable-3.41.9-x64/flutter'
##[error]Process completed with exit code 128.
```

`[self-hosted, android]` runner 의 Flutter SDK cache 가 다른 user 소유 → `flutter pub get` 가 호출하는 git ops 가 거부됨. `safe.directory '*'` 로 우회.

## Test plan

- [ ] **이번에는 머지 전에 ci-result 끝까지 대기** — `test-integration-app-{user,partner}-cuj` 둘 다 success 확인
- [ ] 통과하면 머지

🤖 Generated with [Claude Code](https://claude.com/claude-code)