### PR TITLE
fix(ci): gitleaks in pr-gate missing pull-requests:write + SARIF upload error

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -529,6 +529,7 @@ jobs:
     runs-on: [self-hosted, ephemeral]
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -537,6 +538,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml
+          # Self-hosted ephemeral runners execute as root (HOME=/root) which
+          # doesn't share a parent with GITHUB_WORKSPACE. Disable SARIF artifact
+          # upload to avoid the rootDirectory/file mismatch error.
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"
 
   # CUJ integration tests on emulator — pattern: integration_test/cuj/<category>/<feature>_test.dart
   # Engine + BLUEDOC: apps/<app>/integration_test/cuj/BLUEDOC.md


### PR DESCRIPTION
Scheduler: needs-swe-sonnet-1

## Summary

PR #2503이 gitleaks를 pr-gate에 흡수했지만 두 가지 문제가 남았습니다:

1. **pull-requests: write 누락**: gitleaks-action@v2가 PR 요약 코멘트를 포스팅하기 위해 `pull-requests: write` 필요. `contents: read`만 있어 403 발생.
2. **SARIF 업로드 에러**: self-hosted ephemeral runner가 root 계정(HOME=/root)으로 실행되어 GITHUB_WORKSPACE와 루트가 달라 `results.sarif` 업로드 실패.

## Changes

- `gitleaks` job에 `pull-requests: write` 권한 추가
- `GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"` 설정으로 SARIF 업로드 비활성화

## Test plan
- [ ] PR 머지 후 다음 pr-gate 실행에서 gitleaks 잡이 성공해야 함
- [ ] gitleaks가 secret 감지 시 PR 코멘트 정상 포스팅 확인

## Context

동일한 픽스가 PR #2502에서 `pr-setup-secret-scan.yml`에도 적용됨 (gitleaks의 이전 위치). 해당 파일은 이제 pr-gate가 required check를 맡으므로 별도 실행은 non-required임.