### PR TITLE
docs(functions): add BLUEDOC for functions/ root + 4 underscore-prefix dirs

### DIFF
--- a/supabase/functions/BLUEDOC.md
+++ b/supabase/functions/BLUEDOC.md
@@ -1,0 +1,48 @@
+# Supabase Edge Functions
+
+minglit 의 backend API 진입점. 60+ EF (user / partner / system / public) + 5 underscore-prefix 공용 디렉토리.
+
+## 디렉토리 분류
+
+### 공용 (`_` prefix — EF 아님)
+
+| 디렉토리 | 역할 |
+|---|---|
+| [_shared/](./_shared/BLUEDOC.md) | 모든 EF 가 import 하는 공용 라이브러리 (wrapper / logger / HTTP / DB / 외부 client / 도메인 helper) |
+| [_test_utils/](./_test_utils/BLUEDOC.md) | 테스트 공용 mock 및 fixture (mock_supabase / mock_http / schema_validator 등) |
+| [_payment_integration_tests/](./_payment_integration_tests/BLUEDOC.md) | 결제 도메인 EF chaining 시뮬 (in-process, mock 전체). 추후 `_integration_tests/` 로 흡수 예정 |
+| [_contract_tests/](./_contract_tests/BLUEDOC.md) | EF 응답 ↔ shared JSON schema 일치 가드 |
+| [_integration_tests/](./_integration_tests/BLUEDOC.md) | 빈 local Supabase + 외부 mock 으로 실 schema/trigger/RLS contract 검증 (Layer 5.5) |
+
+### EF (60+)
+
+도메인별 (auth-manifest.json 의 `callers` 기준):
+
+| 카테고리 | 예 |
+|---|---|
+| **user** (33) — JWT 인증, 유저/파트너 호출 | apply-event, payment-verify, partner-manage-party, user-event-feed ... |
+| **system** (15) — pg_cron / worker 호출 | notification-worker, settlement-register-transfers, recurrence-cron ... |
+| **public** (4) — 인증 없음 (dev 전용 + health) | event-flow-simulator, dev-mock-portone, dev-seed, health |
+| **external** (1) — 외부 콜백 | payment-webhook (PortOne) |
+
+특수 EF: [event-flow-simulator/](./event-flow-simulator/BLUEDOC.md) — 이벤트 라이프사이클 funnel 시뮬레이터 (Stochastic Cascade 모델).
+
+## auth-manifest.json
+
+각 EF 의 `envs` (어느 환경에서 동작) + `callers` (누가 호출) + 설명 선언. `_shared/edge_function.ts` 의 `minglitEdgeFunction` wrapper 가 호출 시 manifest 기반 가드 적용. 상세: [docs/architecture/edge-function-auth.md](../../docs/architecture/edge-function-auth.md).
+
+## 신규 EF 추가 절차
+
+1. `<ef-name>/index.ts` + `deno.json` 생성
+2. `minglitEdgeFunction` wrapper 사용 (`_shared/edge_function.ts`)
+3. `auth-manifest.json` 에 entry 추가 (envs / callers / description)
+4. `<ef-name>/<ef_name>_test.ts` 단위 테스트 (`_test_utils/` 활용)
+5. `supabase/config.toml` 의 `[functions.<ef-name>]` 자동 생성 또는 수동 등록
+6. (선택) `shared/schemas/responses/<ef>.json` + `_contract_tests` 항목 추가
+
+## 관련 컨벤션
+
+- [BLUEDOC convention](../../docs/infra/bluedoc/BLUEDOC.md)
+- [edge-function-auth.md](../../docs/architecture/edge-function-auth.md) — minglitEdgeFunction wrapper + manifest
+- [edge-functions.md](../../docs/operations/edge-functions.md) — 디버깅 / Axiom / Sentry
+- [test-strategy.md](../../docs/qa/test-strategy.md) — 7-Layer test taxonomy

--- a/supabase/functions/_contract_tests/BLUEDOC.md
+++ b/supabase/functions/_contract_tests/BLUEDOC.md
@@ -1,0 +1,40 @@
+# _contract_tests
+
+Edge Function 응답이 shared JSON schema 와 일치하는지 검증. EF 가 응답 필드를 silently 변경하면 Flutter 클라가 깨지는 걸 PR 시점에 차단.
+
+## 파일
+
+- `contract_test.ts` — 모든 contract 검증을 1 파일에 모음 (Deno.test 블록 다수)
+
+## 검증 대상
+
+`shared/schemas/` 의 schema + sample 쌍:
+- `responses/<ef>.json` — JSON schema 정의
+- `samples/<ef>_<scenario>.json` — 그 EF 의 예시 응답
+
+테스트 2 종:
+1. **Sample ↔ Schema** — sample 파일이 schema 를 만족하는지 (schema 자체 정합성)
+2. **EF ↔ Sample/Schema** — EF 가 in-process 호출됐을 때 응답이 sample 과 동등 + schema 만족
+
+## 패턴
+
+```ts
+const schema = await loadSchema("payment_verify");
+const sample = await loadSample("payment_verify_success");
+assertMatchesSchema(sample, schema, "payment_verify_success sample");
+```
+
+EF 호출 시 `_test_utils/mock_http.ts` 의 `captureServeHandler` + `createFetchMock` 사용 (in-process). 실 DB 없음.
+
+## 신규 EF contract 추가 절차
+
+1. `shared/schemas/responses/<ef>.json` — schema 작성
+2. `shared/schemas/samples/<ef>_success.json` (등) — 예시 응답 작성
+3. `contract_test.ts` 에 `Deno.test("contract: sample <ef> matches schema", ...)` 추가
+4. (선택) EF in-process 호출 → 응답 검증 테스트 추가
+
+## 관련
+
+- `shared/schemas/` — schema / sample 저장소
+- [_test_utils/BLUEDOC.md](../_test_utils/BLUEDOC.md) — schema_validator / mock_http 사용
+- [functions/BLUEDOC.md](../BLUEDOC.md)

--- a/supabase/functions/_payment_integration_tests/BLUEDOC.md
+++ b/supabase/functions/_payment_integration_tests/BLUEDOC.md
@@ -1,0 +1,41 @@
+# _payment_integration_tests
+
+결제 도메인 EF chaining 시뮬레이션. 단일 EF unit test 가 못 잡는 **다단계 시나리오** (예: payment-verify → DB 업데이트 → refund) 를 in-process 로 검증.
+
+## 위치
+
+- **DB**: in-memory mock (실 Postgres 없음)
+- **EF**: real handler (in-process via `captureServeHandler`)
+- **외부 API (PortOne 등)**: route matcher mock
+
+## 파일
+
+- `payment_integration_test.ts` — 결제 happy / fail / refund 시퀀스 chaining
+- `payment_edge_cases_test.ts` — 무료 이벤트 / idempotent 결제 / amount 변조 등 edge case
+
+## 패턴
+
+```ts
+const handler = await captureServeHandler(new URL("../payment-verify/index.ts", ...));
+const { fetchMock } = createFetchMock([
+  authRoute,
+  { matcher: "...iamport.kr/payments/...", handler: () => jsonResponse(...) },
+  { matcher: req => req.url.includes("/rest/v1/event_applications") && req.method === "PATCH",
+    handler: async req => { capturedBody = await req.json(); return jsonResponse({}); } },
+]);
+await withMockedFetch(fetchMock, () => handler(authenticatedJsonRequest("http://localhost", { ... })));
+```
+
+상세 helper: [_test_utils/BLUEDOC.md](../_test_utils/BLUEDOC.md).
+
+## 향후 — `_integration_tests/` 로 흡수 예정
+
+본 디렉토리의 결제 chaining 시나리오는 추후 [`_integration_tests/`](../_integration_tests/BLUEDOC.md) (빈 local Supabase + 외부 mock) 의 cuj/payment/ 그룹으로 마이그 예정. 실 Postgres 사용 시 schema/trigger 회귀까지 가드 가능.
+
+마이그 후 본 디렉토리는 삭제. 그 전까지 두 layer 가 공존 (in-process = 빠름, local Supabase = 깊은 검증).
+
+## 관련
+
+- [_test_utils/BLUEDOC.md](../_test_utils/BLUEDOC.md) — mock_http / fixtures 사용
+- [_integration_tests/BLUEDOC.md](../_integration_tests/BLUEDOC.md) — 흡수 대상 layer
+- [functions/BLUEDOC.md](../BLUEDOC.md)

--- a/supabase/functions/_shared/BLUEDOC.md
+++ b/supabase/functions/_shared/BLUEDOC.md
@@ -1,0 +1,49 @@
+# _shared
+
+모든 Edge Function 이 import 하는 공용 라이브러리. EF 아님 (`_` prefix). 변경 시 영향 큼.
+
+## 파일 그룹
+
+### Wrapper / Auth (EF 진입점 표준)
+- `edge_function.ts` — `minglitEdgeFunction(handler)` wrapper. auth-manifest 기반 envs/role 가드 + logger / sentry 통합. **모든 신규 EF 가 사용해야 함**
+- `env_keystore.ts` — env-manifest 기반 환경변수 typed 접근
+
+### Logging / Observability
+- `logger.ts` — 콘솔 logger (local 전용)
+- `axiom_logger.ts` — Axiom 구조화 로깅 (dev/prod). withHandler 가 자동 호출
+- `statsig_utils.ts` — Statsig 이벤트 logging (no-op when key missing)
+- `pii_masker.ts` — 로그 출력 시 PII 마스킹
+
+### HTTP
+- `request_utils.ts` — request body 파싱 helper
+- `response_utils.ts` — corsResponse / errorResponse / successResponse
+
+### DB
+- `supabase_client.ts` — `createServiceClient()` / `createUserClient(token)`
+
+### 외부 client
+- `iamport_client.ts` — Iamport (구) PortOne v1 client
+- `portone_client.ts` — PortOne v2 client
+
+### 도메인 helper
+- `partner_permissions.ts` — partner_members role 검증
+- `refund_utils.ts` — 환불 정책 (#2131 cutoff 등)
+- `temporal_utils.ts` — 시간/timezone 유틸
+- `validation_utils.ts` — 입력 검증
+- `worker_utils.ts` — PGMQ worker 패턴
+
+### AI
+- `ai/` — AI 어댑터 추상화 (OpenAI embedding / LLM)
+
+### Tests
+각 `*.ts` 의 `*_test.ts` 동반.
+
+## 변경 정책
+
+breaking change → 모든 EF 영향, 전수 회귀 필요. 신규 utility → 자유. deprecation → 단계적 (legacy 유지 → 마이그 PR → 삭제).
+
+## 관련
+
+- [edge-function-auth.md](../../../docs/architecture/edge-function-auth.md) — minglitEdgeFunction wrapper 상세
+- [edge-functions.md](../../../docs/operations/edge-functions.md) — axiom / sentry 디버깅
+- [functions/BLUEDOC.md](../BLUEDOC.md) — EF 디렉토리 진입점

--- a/supabase/functions/_test_utils/BLUEDOC.md
+++ b/supabase/functions/_test_utils/BLUEDOC.md
@@ -1,0 +1,45 @@
+# _test_utils
+
+EF 단위 테스트 + in-process 통합 테스트가 사용하는 공용 mock / fixture / validator.
+
+## 파일
+
+| 파일 | 역할 |
+|---|---|
+| `mock_supabase_client.ts` | `createMockSupabaseClient(handlers)` — tables / rpcs / auth 응답 모킹. unit test 의 DB stub |
+| `mock_http.ts` | `captureServeHandler` + `createFetchMock` + `withMockedFetch` + `withEnv` + `withNoIntervals` — outbound fetch 차단 + EF handler in-process 실행 |
+| `mock_custom_auth_pass.ts` / `mock_custom_auth_fail.ts` | minglitEdgeFunction wrapper 의 custom auth fixture |
+| `fixtures.ts` | 공용 sample 페이로드 (mockPaidPayment, mockOrder, mockQueueUpdateMessage 등) |
+| `schema_validator.ts` | `assertMatchesSchema` — JSON schema 일치 가드 (`_contract_tests` 가 사용) |
+| `std_server_stub.ts` | Deno std http server 의 minimal stub (테스트 격리) |
+
+## 사용 패턴
+
+### Unit test (단일 EF)
+```ts
+import { createMockSupabaseClient } from "../_test_utils/mock_supabase_client.ts";
+const mock = createMockSupabaseClient({ tables: { event_applications: { select: () => ({ data: [...] }) } } });
+```
+
+### In-process chaining (`_payment_integration_tests/`)
+```ts
+import { captureServeHandler, createFetchMock, withMockedFetch } from "../_test_utils/mock_http.ts";
+const handler = await captureServeHandler(new URL("../<ef>/index.ts", import.meta.url));
+const { fetchMock } = createFetchMock([authRoute, { matcher: ..., handler: ... }]);
+await withMockedFetch(fetchMock, () => handler(request));
+```
+
+### Contract test (`_contract_tests/`)
+```ts
+import { assertMatchesSchema } from "../_test_utils/schema_validator.ts";
+assertMatchesSchema(sample, schema);
+```
+
+## 변경 정책
+
+각 EF 의 `*_test.ts` 가 import 함. signature 변경 시 모든 caller 영향 — `git grep` 으로 사용처 확인 후.
+
+## 관련
+
+- [functions/BLUEDOC.md](../BLUEDOC.md) — EF 진입점
+- 사용처: 각 EF 의 `*_test.ts`, `_payment_integration_tests/`, `_contract_tests/`


### PR DESCRIPTION
## Summary

`supabase/functions/` 에 외부 에이전트가 진입했을 때 디렉토리 분류 / 도메인별 EF / auth-manifest / 신규 EF 추가 절차를 한 진입점에서 발견하도록 BLUEDOC 5 파일 추가.

## 추가 파일 (5)

| 파일 | 내용 |
|---|---|
| `supabase/functions/BLUEDOC.md` | 최상위 진입점 — 5 공용 디렉토리 + EF 카테고리 (user/system/public/external) + auth-manifest + 신규 EF 추가 절차 |
| `_shared/BLUEDOC.md` | 공용 라이브러리 그룹 (wrapper / logger / HTTP / DB / 외부 client / 도메인 helper / AI) |
| `_test_utils/BLUEDOC.md` | mock_supabase / mock_http / fixtures / schema_validator 인벤토리 + 사용 패턴 |
| `_payment_integration_tests/BLUEDOC.md` | 결제 chaining 패턴 + **추후 `_integration_tests/` 흡수 예정 명시** |
| `_contract_tests/BLUEDOC.md` | EF 응답 ↔ JSON schema 가드 (shared/schemas/ 와 연동) 패턴 |

각 ≤50줄 (BLUEDOC convention).

## 이미 있는 BLUEDOC (참조)

- `_integration_tests/BLUEDOC.md` — PR #2497 (보류)
- `event-flow-simulator/BLUEDOC.md` — PR #2490 (머지)

본 PR 의 `functions/BLUEDOC.md` 가 두 BLUEDOC 모두 reference.

## 의도된 미작성

- 도메인별 EF sub-BLUEDOC (예: `functions/payment/BLUEDOC.md` 같은 grouping) — 본 PR scope 외. 각 EF 가 단독으로 자체 BLUEDOC 가질 가치는 적음 (자세한 spec 은 `docs/features/` 에 있음)

## Test plan

- [x] 5 BLUEDOC 모두 50줄 이내 (40-49줄)
- [ ] CI `check-workflow-yaml` 등 통과 (docs only — 영향 0)
- [ ] CodeRabbit 리뷰

## Related

- #2496 (Flutter CUJ framework) — `_payment_integration_tests/` 관계 재정리에 영향
- #2497 (보류) — `_integration_tests/` framework MVP, 본 PR 의 최상위 BLUEDOC 가 reference
- #2490 (머지) — event-flow-simulator, 동일

🤖 Generated with [Claude Code](https://claude.com/claude-code)