### PR TITLE
fix(integration-tests): suite() env var 누락 시 disabled ctx 반환으로 coverage 실패 수정

### DIFF
--- a/supabase/functions/_integration_tests/_framework/cuj_test.ts
+++ b/supabase/functions/_integration_tests/_framework/cuj_test.ts
@@ -19,6 +19,8 @@ export function cujTest(
 ): void {
   Deno.test({
     name: `[CUJ ${id}] (scenario=${scenario})`,
+    // Fix: env vars 없는 coverage 환경에서 uncaught error 대신 ignore 처리
+    ignore: ctx.disabled,
     async fn() {
       await applyScenario(scenario, ctx.db);
       try {

--- a/supabase/functions/_integration_tests/_framework/suite.ts
+++ b/supabase/functions/_integration_tests/_framework/suite.ts
@@ -4,6 +4,7 @@ import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { createActor, type Actor } from "./actor.ts";
 
 export interface Ctx {
+  readonly disabled: boolean;          // true → env vars 없음, cujTest 가 ignore 처리
   readonly url: string;
   readonly anonKey: string;
   readonly db: SupabaseClient;        // service role — RLS 우회 (assertion + seed 용)
@@ -13,12 +14,27 @@ export interface Ctx {
   };
 }
 
+// coverage 실행 환경처럼 Supabase 없이 deno test 가 호출될 때 throw 대신 반환
+const _DISABLED_CTX: Ctx = {
+  disabled: true,
+  url: "",
+  anonKey: "",
+  db: null as unknown as SupabaseClient,
+  actAs: {
+    user: () => Promise.reject(new Error("disabled")),
+    partner: () => Promise.reject(new Error("disabled")),
+  },
+};
+
 let _ctx: Ctx | null = null;
 
 /**
  * suite("category/feature") — 파일 단위 setup.
  * 첫 호출 시 env 에서 SUPABASE_URL / SERVICE_ROLE_KEY / ANON_KEY 캡처.
  * 같은 process 안에서 동일 ctx 재사용 (테스트 간 client 재생성 비용 회피).
+ *
+ * env vars 없으면 disabled ctx 반환 → cujTest 가 해당 테스트를 ignore 처리.
+ * (coverage-only 실행 시 uncaught error 방지)
  */
 export function suite(_featureKey: string): Ctx {
   if (_ctx) return _ctx;
@@ -28,10 +44,7 @@ export function suite(_featureKey: string): Ctx {
   const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
 
   if (!url || !serviceKey || !anonKey) {
-    throw new Error(
-      "suite() requires SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY / SUPABASE_ANON_KEY env vars. " +
-        "Run `supabase start` and export from `supabase status -o env`.",
-    );
+    return _DISABLED_CTX;
   }
 
   const db = createClient(url, serviceKey, {
@@ -39,6 +52,7 @@ export function suite(_featureKey: string): Ctx {
   });
 
   _ctx = {
+    disabled: false,
     url,
     anonKey,
     db,


### PR DESCRIPTION
Scheduler: swe-sonnet-1

## Summary
- `suite()` 가 Supabase env vars 없을 때 throw 하던 문제를 disabled ctx 반환으로 수정
- `monitor-deno-coverage` 워크플로우에서 `_integration_tests` 파일이 uncaught error 없이 실행됨
- env vars 있을 때는 기존과 동일하게 실 Supabase 연결 후 테스트 실행

## Root Cause
`event_feed_test.ts` 가 module top-level 에서 `suite()` 를 호출하는데, `monitor-deno-coverage` 는 Supabase 없이 `deno test --coverage functions/` 실행 → `suite()` throw → uncaught error → test runner 실패 (exit code 1).

failed run: https://github.com/Mark-Yun/minglit/actions/runs/25988576735

## Changes
- `_framework/suite.ts`: `Ctx.disabled` 필드 추가, `_DISABLED_CTX` sentinel, env vars 없으면 throw 대신 반환
- `_framework/cuj_test.ts`: `ignore: ctx.disabled` 추가

## Test Plan
- [ ] PR CI `test-edge-functions` 통과 (Supabase 있으므로 disabled=false, 정상 실행)
- [ ] `monitor-deno-coverage` 재실행 시 849+N passed, CUJ tests ignored (no failure)

Closes #2512