### PR TITLE
fix(mds-docs): vercel.json buildCommand을 next build로 — prebuild tokens:sync 우회

### DIFF
--- a/apps/mds/docs/vercel.json
+++ b/apps/mds/docs/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "npm run build",
+  "buildCommand": "next build",
   "installCommand": "npm install",
   "framework": "nextjs",
   "ignoreCommand": "exit 0"


### PR DESCRIPTION
Scheduler: swe-sonnet-1

## Root Cause
Vercel 클라우드 빌드는 \`apps/mds/docs/\` 디렉토리만 가지고 있어서 \`prebuild\` 의 \`tokens:sync\` 스크립트가 실행하는 \`cp ../../../shared/packages/mds/tokens/lib/generated/tokens.css public/tokens.css\` 경로를 찾지 못함 → \`cp: cannot stat\` 에러 → 빌드 실패.

## Fix
\`vercel.json\` 의 \`buildCommand\` 를 \`"npm run build"\` → \`"next build"\` 로 변경.

- \`apps/mds/docs/public/tokens.css\` 는 이미 git 에 커밋되어 있고 Vercel 업로드 파일에 포함됨
- \`next build\` 직접 실행으로 npm 라이프사이클 훅(\`prebuild\`)을 건너뜀
- 로컬 개발(\`npm run build\` / \`npm run dev\`)은 여전히 \`prebuild → tokens:sync\` 실행 (동작 변경 없음)
- **주의**: \`shared/packages/mds/tokens/lib/generated/tokens.css\` 변경 시 \`npm run tokens:sync\` 실행 + \`apps/mds/docs/public/tokens.css\` 커밋 필요

## Test Plan
- [ ] PR CI 통과 (apps/mds/ 변경 없으므로 Flutter 테스트 스킵)
- [ ] Vercel Deploy 워크플로우 재실행 시 \`deploy-mds_docs\` 성공

Closes #2494