### PR TITLE
fix(mds-docs): vendor mds-icons-generated.tsx — Fix #2518

### DIFF
--- a/apps/mds/docs/package.json
+++ b/apps/mds/docs/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "tokens:sync": "cp ../../../shared/packages/mds/tokens/lib/generated/tokens.css public/tokens.css",
+    "icons:sync": "cp ../../../shared/packages/mds/icons/react/src/generated/index.tsx src/lib/mds-icons-generated.tsx",
     "predev": "npm run tokens:sync",
     "prebuild": "npm run tokens:sync",
     "dev": "next dev -p 3003",

--- a/apps/mds/docs/src/lib/mds-icons-generated.tsx
+++ b/apps/mds/docs/src/lib/mds-icons-generated.tsx
@@ -1,0 +1,167 @@
+// VENDORED — synced from shared/packages/mds/icons/react/src/generated/index.tsx
+// Update by running: npm run icons:sync (inside apps/mds/docs/)
+// Do NOT edit manually — re-sync from source when icons change.
+
+import * as React from 'react';
+
+export interface MdsIconProps extends React.SVGProps<SVGSVGElement> {
+  size?: number | string;
+}
+
+/** add icon. Inherits color via currentColor. */
+export const Add: React.FC<MdsIconProps> = ({ size = 24, ...props }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    {...props}
+  >
+    <path d="M5 12h14M12 5v14"/>
+  </svg>
+);
+
+/** check icon. Inherits color via currentColor. */
+export const Check: React.FC<MdsIconProps> = ({ size = 24, ...props }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    {...props}
+  >
+    <path d="M20 6 9 17l-5-5"/>
+  </svg>
+);
+
+/** chevron_right icon. Inherits color via currentColor. */
+export const ChevronRight: React.FC<MdsIconProps> = ({ size = 24, ...props }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    {...props}
+  >
+    <path d="m9 18 6-6-6-6"/>
+  </svg>
+);
+
+/** close icon. Inherits color via currentColor. */
+export const Close: React.FC<MdsIconProps> = ({ size = 24, ...props }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    {...props}
+  >
+    <path d="M18 6 6 18M6 6l12 12"/>
+  </svg>
+);
+
+/** more_vert icon. Inherits color via currentColor. */
+export const MoreVert: React.FC<MdsIconProps> = ({ size = 24, ...props }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    {...props}
+  >
+    <circle cx="12" cy="12" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="19" r="1"/>
+  </svg>
+);
+
+/** notifications icon. Inherits color via currentColor. */
+export const Notifications: React.FC<MdsIconProps> = ({ size = 24, ...props }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    {...props}
+  >
+    <path d="M10.268 21a2 2 0 0 0 3.464 0M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8A6 6 0 0 0 6 8c0 4.499-1.411 5.956-2.738 7.326"/>
+  </svg>
+);
+
+/** person icon. Inherits color via currentColor. */
+export const Person: React.FC<MdsIconProps> = ({ size = 24, ...props }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    {...props}
+  >
+    <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/>
+  </svg>
+);
+
+/** search icon. Inherits color via currentColor. */
+export const Search: React.FC<MdsIconProps> = ({ size = 24, ...props }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    {...props}
+  >
+    <path d="m21 21-4.34-4.34"/><circle cx="11" cy="11" r="8"/>
+  </svg>
+);
+
+/** Registry of all icons keyed by snake_case name. */
+export const MdsIcons = {
+  'add': Add,
+  'check': Check,
+  'chevron_right': ChevronRight,
+  'close': Close,
+  'more_vert': MoreVert,
+  'notifications': Notifications,
+  'person': Person,
+  'search': Search,
+} as const;
+
+export type MdsIconName = keyof typeof MdsIcons;

--- a/apps/mds/docs/src/lib/mds-icons-react.ts
+++ b/apps/mds/docs/src/lib/mds-icons-react.ts
@@ -1,3 +1,4 @@
-// Re-export from the mds_icons React codegen output.
-// Source: shared/packages/mds/icons/react/src/generated/index.tsx
-export * from '../../../../../shared/packages/mds/icons/react/src/generated';
+// Re-export from vendored copy of shared/packages/mds/icons/react/src/generated/index.tsx.
+// Vendored because Vercel build only has access to apps/mds/docs/ — shared/ is out of scope.
+// Update by running: npm run icons:sync (inside apps/mds/docs/)
+export * from './mds-icons-generated';

--- a/apps/mds/docs/tsconfig.json
+++ b/apps/mds/docs/tsconfig.json
@@ -21,7 +21,7 @@
     "paths": {
       "@/*": ["./src/*"],
       "@mds/icons-react": [
-        "../../../shared/packages/mds/icons/react/src/generated/index.tsx"
+        "./src/lib/mds-icons-generated.tsx"
       ]
     }
   },


### PR DESCRIPTION
Scheduler: swe-sonnet-1

## Root Cause

Vercel 클라우드 빌드는 `apps/mds/docs/` 디렉토리만 업로드하므로 `shared/` 디렉토리에 접근 불가.

두 가지 경로가 Vercel 빌드에서 실패:
1. `apps/mds/docs/tsconfig.json`의 `@mds/icons-react` 앨리어스 → `../../../shared/packages/mds/icons/react/src/generated/index.tsx`
2. `apps/mds/docs/src/lib/mds-icons-react.ts`의 re-export → `'../../../../../shared/packages/mds/icons/react/src/generated'`

두 경로 모두 Vercel 빌드 컨텍스트에서 `shared/`에 접근 불가 → `Module not found: Can't resolve '@mds/icons-react'` + `Export MdsIcons doesn't exist in target module` → 빌드 실패.

## Fix

PR #2514(`tokens.css` 벤더)와 동일한 패턴:

| 변경 | 내용 |
|------|------|
| `src/lib/mds-icons-generated.tsx` (신규) | `shared/.../generated/index.tsx` 벤더 복사 — Vercel 업로드에 포함됨 |
| `src/lib/mds-icons-react.ts` | `shared/` 상대 경로 → `./mds-icons-generated` 로컬 참조 |
| `tsconfig.json` | `@mds/icons-react` 앨리어스 → `./src/lib/mds-icons-generated.tsx` |
| `package.json` | `icons:sync` 스크립트 추가 (아이콘 변경 시 동기화용) |

> **주의**: `shared/packages/mds/icons/react/src/generated/index.tsx` 변경 시
> `npm run icons:sync` 실행 + `apps/mds/docs/src/lib/mds-icons-generated.tsx` 커밋 필요

## Design System Gate (적용 없음)

순수 빌드 인프라 수정. UI 화면/위젯 변경 없음.

## Test Plan
- [ ] Vercel Deploy 워크플로우 재실행 시 `deploy-mds_docs` 성공
- [ ] CI `ci-result` 통과

Closes #2518