### PR TITLE
docs(ci): add BLUEDOCs for .github/, actions/, scripts/

### DIFF
--- a/.github/BLUEDOC.md
+++ b/.github/BLUEDOC.md
@@ -1,0 +1,24 @@
+# .github/
+
+GitHub 통합 폴더 — CI/CD 워크플로우, composite actions, shell scripts, 의존성 자동화, 릴리스 노트 설정.
+
+## 이정표
+
+| 항목 | 무엇 |
+|---|---|
+| [`workflows/`](./workflows/BLUEDOC.md) | GitHub Actions 워크플로우 (`pr-gate`, `pr-setup`, `pr-review-setup`, `deploy`, `monitor`, `sync`, `triage`, `tool`, `shared` prefix) |
+| [`actions/`](./actions/BLUEDOC.md) | 워크플로우가 `uses:` 로 호출하는 composite actions (deploy-flutter-app, deploy-nextjs-app, ios-deploy) |
+| [`scripts/`](./scripts/BLUEDOC.md) | 워크플로우가 `bash` 로 실행하는 shell 헬퍼 (env 파일 생성, CUJ 실행 등) |
+| [`dependabot.yml`](./dependabot.yml) | dependabot 의존성 자동 업데이트 설정 (npm + GitHub Actions 그룹화, weekly) |
+| [`release.yml`](./release.yml) | GitHub Release notes 자동 생성 카테고리 (Features/Bug Fixes/Refactor/Docs) |
+
+## 핵심 컨벤션
+
+- **워크플로우는 9 prefix 중 하나** (pr-gate / pr-setup / pr-review-setup / deploy / monitor / sync / triage / tool / shared) — [`workflows/BLUEDOC.md`](./workflows/BLUEDOC.md) 참고.
+- **재사용 가능한 step 묶음은 `actions/` composite 로 분리**, 단순 명령 묶음은 `scripts/` 로.
+- **dependabot 은 patch/minor 자동 머지** (pr-review-setup 의 dependabot 분기), major 는 수동.
+
+## 관련
+
+- [CLAUDE.md](../CLAUDE.md) — PR Conventions, Branch Protection, Auto-Merge 흐름
+- [BLUEDOC 컨벤션](../docs/infra/bluedoc/BLUEDOC.md)

--- a/.github/actions/BLUEDOC.md
+++ b/.github/actions/BLUEDOC.md
@@ -1,0 +1,25 @@
+# .github/actions/
+
+워크플로우가 `uses: ./.github/actions/<name>` 로 호출하는 **composite actions**. 여러 step 을 묶어 워크플로우 파일의 중복 제거.
+
+## 이정표
+
+| Action | 역할 | 호출자 |
+|---|---|---|
+| [`deploy-flutter-app/`](./deploy-flutter-app/) | Flutter web 앱 → Vercel 배포 (build + alias + smoke) | `deploy-vercel` (app_user, app_partner) |
+| [`deploy-nextjs-app/`](./deploy-nextjs-app/) | Next.js 앱 → Vercel 배포 (env-manifest 복사 + node 설치 + vercel CLI) | `deploy-vercel` (landing_user, landing_partner, mds_docs) |
+| [`ios-deploy/`](./ios-deploy/) | iOS 앱 → TestFlight 배포 (signing cert / provisioning profile + xcodebuild + altool) | `deploy-ios-user`, `deploy-ios-partner` |
+
+각 action 의 inputs/outputs 는 해당 폴더의 `action.yml` 참고.
+
+## 핵심 컨벤션
+
+- **`runs: using: "composite"`** — Docker 액션 X, JavaScript 액션 X. 모든 자체 action 은 shell step 묶음 composite.
+- **여러 워크플로우에서 같은 step 체인을 반복할 때만 composite 로 추출** — 단발성 외부 액션 호출 (checkout, setup-node 등) 은 워크플로우에서 직접 `uses:` OK. 중복 / 멀티-step orchestration 만 composite.
+- **action 변경 시 호출자 워크플로우 회귀 검증** — 한 PR 에서 action.yml 만 바뀌어도 호출하는 deploy-* 워크플로우 다음 cron 까지 영향.
+- **secrets 는 action 의 input 으로 전달** — action.yml 안에서 `${{ secrets.* }}` 직접 참조 금지 (calling workflow 의 책임).
+
+## 관련
+
+- [workflows/BLUEDOC.md](../workflows/BLUEDOC.md) — 어느 워크플로우가 어느 action 호출하는지
+- [.github/BLUEDOC.md](../BLUEDOC.md) — 상위 진입점

--- a/.github/scripts/BLUEDOC.md
+++ b/.github/scripts/BLUEDOC.md
@@ -1,0 +1,25 @@
+# .github/scripts/
+
+워크플로우가 `bash .github/scripts/<name>.sh` 로 실행하는 **shell 헬퍼**. composite action 을 만들 만큼 무겁지 않은 명령 묶음.
+
+## 이정표
+
+| Script | 역할 | 호출자 |
+|---|---|---|
+| [`create-dev-flutter-env.sh`](./create-dev-flutter-env.sh) | Actions secrets → `minglit_env/dev/flutter.env` 재생성 (CI 가 private submodule `minglit_env/` 를 받지 못해서 필요, Fix #1169) | `shared-cuj-integration`, `monitor-patrol-e2e` |
+| [`run-user-cuj.sh`](./run-user-cuj.sh) | `apps/app_user/integration_test/cuj/` 의 CUJ 테스트 실행 (emulator) | `shared-cuj-integration` (app-name=user 일 때) |
+| [`run-partner-cuj.sh`](./run-partner-cuj.sh) | `apps/app_partner/integration_test/cuj/` CUJ 실행 | `shared-cuj-integration` (app-name=partner 일 때) |
+
+## 핵심 컨벤션
+
+- **`set -euo pipefail`** — 모든 스크립트가 명시. 한 step 의 실패가 다음 step 에 새지 않도록.
+- **필수 env 는 시작부에 `: "${VAR:?msg}"` 로 검증** — secret 누락 시 즉시 명확히 fail.
+- **secrets 는 환경변수로 받기만** — script 안에 secret 값·경로 하드코드 금지.
+- **`cd apps/<app>` 같은 작업 디렉토리 전제는 명시** — 호출 워크플로우의 `working-directory:` 와 일치.
+- **무거워지면 composite action 으로 승격** — script 가 외부 액션 chain 을 만들기 시작하면 [`actions/`](../actions/BLUEDOC.md) 로.
+
+## 관련
+
+- [workflows/BLUEDOC.md](../workflows/BLUEDOC.md) — 호출하는 워크플로우 컨벤션
+- [actions/BLUEDOC.md](../actions/BLUEDOC.md) — script 가 자라면 composite 로 승격
+- [.github/BLUEDOC.md](../BLUEDOC.md) — 상위 진입점

--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -4,7 +4,7 @@
 
 ## 배경
 
-기존 파일명·`name:` 규칙이 제각각이었다 (`auto-format.yml`, `Deploy to Vercel`, `Hourly: DB Invariant Monitor`, ...). PR Checks 화면에서 *"이게 머지를 막는 건지 / 배포인지 / 단순 자동화인지"* 한눈에 안 잡힘. **"빨갛게 뜨면 무슨 일이 일어나나"** 를 축으로 8 개 prefix 로 통일했다.
+기존 파일명·`name:` 규칙이 제각각이었다 (`auto-format.yml`, `Deploy to Vercel`, `Hourly: DB Invariant Monitor`, ...). PR Checks 화면에서 *"이게 머지를 막는 건지 / 배포인지 / 단순 자동화인지"* 한눈에 안 잡힘. **"빨갛게 뜨면 무슨 일이 일어나나"** 를 축으로 9 개 prefix 로 통일했다.
 
 ## Prefix
 
@@ -24,7 +24,7 @@
 
 - **파일명 = workflow `name:` 필드** (소문자 kebab, 확장자 제외). 예: `deploy-vercel.yml` 의 `name: deploy-vercel`.
 - prefix 다음은 *대상*만 적는다. 액션 동사는 prefix 가 이미 함의함 (`deploy-vercel` ◯ / `deploy-to-vercel` ✗).
-- 새 워크플로우는 위 8 prefix 중 하나에 반드시 속해야 한다. 어디에도 안 맞으면 새 prefix 추가 PR 을 먼저 낸다.
+- 새 워크플로우는 위 9 prefix 중 하나에 반드시 속해야 한다. 어디에도 안 맞으면 새 prefix 추가 PR 을 먼저 낸다.
 - `pr-setup-` vs `pr-review-setup-` vs `sync-` vs `triage-` 의 기준:
   - `pr-setup-` = PR push 마다 PR 브랜치를 mutate (현재는 `pr-setup-format` 만 — dart format + commit push)
   - `pr-review-setup-` = PR 의 "리뷰 준비 단계" 자동화 (auto-merge enable, `needs-review` 라벨 부여)


### PR DESCRIPTION
## Summary

워크플로우는 `.github/workflows/BLUEDOC.md` 가 이미 있었지만, 그 옆의 composite actions / shell scripts / dependabot / release 설정에 진입점이 없어서 *"이 action 어디서 쓰이지"* 역방향 추적이 어려웠음. 3 개 BLUEDOC 추가.

| 파일 | 라인 | 역할 |
|---|---|---|
| `.github/BLUEDOC.md` | 24 | `.github/` 폴더 진입점 (workflows/actions/scripts + dependabot.yml/release.yml 이정표) |
| `.github/actions/BLUEDOC.md` | 25 | 3 composite actions + 호출자 워크플로우 매핑 |
| `.github/scripts/BLUEDOC.md` | 25 | 3 shell scripts + 호출자 매핑 + composite 승격 기준 |

각 BLUEDOC 의 이정표 표에 **호출자 워크플로우 명시** — action/script 가 어디서 쓰이는지 한 줄로 보임.

## Self-review (2 pass)

**Pass 1 (사실 검증)** 에서 발견 + 수정:
- `.github/BLUEDOC.md` 의 "8 prefix 컨벤션" → 실제 9 개 (pr-gate/pr-setup/pr-review-setup/deploy/monitor/sync/triage/tool/shared). 수치 명시 → prefix 나열로 변경.
- `.github/workflows/BLUEDOC.md` 본문·컨벤션의 "8 개 prefix" 표현 (pre-existing) — 9 개로 갱신.
- `.github/actions/BLUEDOC.md` "외부 액션은 직접 `uses:` 하지 않고 composite 안으로 래핑" 단정 → 실제로는 워크플로우들이 actions/checkout, subosito/flutter-action, setup-node 등 직접 호출 빈번. 컨벤션 표현 완화 ("멀티-step orchestration · 중복 체인만 composite").

**Pass 2 (컨벤션 준수)**: 모두 ≤25 줄 (50 줄 한도 안), signpost-only (스펙·디테일 없음), 형식 일관.

## Test plan
- [ ] 모든 상대경로 링크 유효
- [ ] BLUEDOC ≤ 50 줄 (로컬 확인 ✓)
- [ ] 호출자 매핑 정확 (deploy-flutter-app/deploy-nextjs-app → deploy-vercel, ios-deploy → deploy-ios-*, create-dev-flutter-env → shared-cuj-integration/monitor-patrol-e2e, run-*-cuj → shared-cuj-integration) — 로컬 grep 검증 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)