### PR TITLE
fix(mds-docs): route-pages.json에 5개 누락 라우트 등록 — Fix #2403

### DIFF
--- a/apps/mds/docs/src/lib/route-pages.json
+++ b/apps/mds/docs/src/lib/route-pages.json
@@ -99,6 +99,22 @@
     "TagEventListRoute": {
       "widget": "TagEventListPage",
       "file": "apps/app_user/lib/src/features/tag/ui/tag_event_list_page.dart"
+    },
+    "EventMatchingRoute": {
+      "widget": "EventMatchingScreen",
+      "file": "apps/app_user/lib/src/features/event/matching/ui/event_matching_screen.dart"
+    },
+    "EventApplicationConfirmationRoute": {
+      "widget": "MinglitConfirmationPage",
+      "file": "shared/packages/minglit_kit/lib/src/components/feedback/minglit_confirmation_page.dart"
+    },
+    "PurchaseHistoryDetailRoute": {
+      "widget": "PurchaseHistoryDetailPage",
+      "file": "apps/app_user/lib/src/features/payment/ui/purchase_history_detail_page.dart"
+    },
+    "EventApplicationReviewRoute": {
+      "widget": "EventApplicationReviewPage",
+      "file": "apps/app_user/lib/src/features/payment/ui/event_application_review_page.dart"
     }
   },
   "partner": {
@@ -245,6 +261,10 @@
     "PartnerAccountManagementRoute": {
       "widget": "AccountManagementPage",
       "file": "shared/packages/minglit_kit/lib/src/ui/pages/account_management_page.dart"
+    },
+    "VerificationReviewRoute": {
+      "widget": "ReviewVerificationScreen",
+      "file": "apps/app_partner/lib/src/features/verification/review/review_verification_screen.dart"
     }
   }
 }


### PR DESCRIPTION
Scheduler: swe-sonnet-1

## Summary

Closes #2403

`app_routes.dart`에 `@TypedGoRoute`로 등록됐으나 `route-pages.json`에 누락된 5개 라우트를 추가합니다.

`route-pages.json`은 `flow-data.ts` / spec walk / back-link 생성기가 참조하는 manifest로, 누락 시 flow chart와 spec 카탈로그에서 해당 화면이 빠집니다.

## Changes

| 앱 | Route | Widget | File |
|----|-------|--------|------|
| user | `EventMatchingRoute` | `EventMatchingScreen` | `apps/app_user/.../event/matching/ui/event_matching_screen.dart` |
| user | `EventApplicationConfirmationRoute` | `MinglitConfirmationPage` | `shared/packages/minglit_kit/.../feedback/minglit_confirmation_page.dart` |
| user | `PurchaseHistoryDetailRoute` | `PurchaseHistoryDetailPage` | `apps/app_user/.../payment/ui/purchase_history_detail_page.dart` |
| user | `EventApplicationReviewRoute` | `EventApplicationReviewPage` | `apps/app_user/.../payment/ui/event_application_review_page.dart` |
| partner | `VerificationReviewRoute` | `ReviewVerificationScreen` | `apps/app_partner/.../verification/review/review_verification_screen.dart` |

`EventApplicationConfirmationRoute`는 kit 합성 라우트 — `MinglitConfirmationPage`(공용 컴포넌트)를 빌더에서 직접 인스턴스화. `file`은 kit 컴포넌트 위치를 가리킴.

## How Verified

- JSON syntax valid (`python3 -c "import json; json.load(...)"`)
- 5개 위젯 파일 모두 `origin/dev`에 존재 확인
- `route-pages.json` 포맷: 기존 항목과 동일한 `{ "widget": "...", "file": "..." }` 구조

## Remaining Risk

없음. JSON manifest 파일만 변경.