### PR TITLE
docs(features): discovery 카테고리 feature audit 완료 — Fix #2548

### DIFF
--- a/docs/features/discovery/FRESH_DOC
+++ b/docs/features/discovery/FRESH_DOC
@@ -1,6 +1,6 @@
 cycle: 14d
 priority: P3-low
-last_verified: 2026-05-16
+last_verified: 2026-05-18
 refresh_method: |
   본 카테고리 (discovery) 인스펙션 → feature_audit_report.md 갱신 + Action Items 마다 GitHub Issue 1건 파일링.
   절차: docs/features/feature_audit_report_template.md 의 "AI 실행 절차" 섹션 (6 step + 명령어) 참조.

--- a/docs/features/discovery/feature_audit_report.md
+++ b/docs/features/discovery/feature_audit_report.md
@@ -1,0 +1,63 @@
+# Feature Audit Report — `discovery` · `2026-05-18`
+
+> 인스펙션 리포트. FRESH_DOC cycle 트리거로 에이전트가 본 절차를 수행하고 발견 사항을 GitHub Issue 로 파일링한다.
+
+## Summary
+
+`discovery` 카테고리 (feature 2개) 인스펙션 결과:
+
+| Severity | Count | Issues |
+|---|---|---|
+| P0 — Critical | 0 | — |
+| P1 — Defect / Gap | 0 | — |
+| P2 — Improvement | 1 | #2561 |
+| P3 — Low | 0 | — |
+
+## Action Items by Priority
+
+### P2 — Improvement
+
+- [ ] **#2561** `[3-1]` `discovery/tag-discovery` + `discovery/trust-badge` — CUJ integration test 전무. 26 CUJs (P0 8개 포함) 미검증. widget test는 tag-discovery 6개 존재. **Action**: `apps/app_user/integration_test/cuj/discovery/` 신규 작성. **Evidence**: `apps/app_user/integration_test/cuj/` — discovery 디렉토리 없음.
+
+## 1. Spec 점검
+
+### 1-1. PRD / spec.md 완성도
+
+| Feature | prd.md | spec.md | CUJ 수 | FR/NFR |
+|---------|--------|---------|--------|--------|
+| tag-discovery | ✓ | ✓ (5섹션) | 15개 | 13 FR, 5 NFR |
+| trust-badge | ✓ | ✓ (5섹션) | 11개 | 16 FR, 4 NFR |
+
+### 1-3. MDS 트레이스
+
+| 화면 | MDS spec |
+|------|----------|
+| `tag_event_list_page` | ✓ |
+| `home_page`, `search_page` | ✓ |
+| `verification_manage_page`, `identity_verification_screen`, `create_verification_page` | ✓ |
+| `trust_badge` / `trust_sheet` 위젯 | 디자인 TODO (spec에 명시됨) |
+
+## 3. 테스트 현황
+
+### 3-1. app_user
+
+| Layer | 결과 |
+|-------|------|
+| Widget (tag-discovery) | ✓ 6개 (chip_bar, trending, providers×2, controller, list_page) |
+| CUJ integration | 없음 ❌ (discovery 디렉토리 미존재) |
+
+### 3-3. Backend pgTAP
+
+`60_tag_discovery_schema_test.sql`, `63_tag_sensitive_filter_test.sql`, `66_tag_usage_retention_test.sql`, `67_tag_monthly_rls_test.sql`, `70_ai_extract_tags_migration_test.sql` — 5개 ✓
+
+## Findings
+
+| ID | 분류 | 설명 | Severity |
+|----|------|------|----------|
+| #2561 | 3-1 | discovery CUJ integration test 전무 (26 CUJs) | P2 |
+
+## Run Metadata
+
+- Agent: swe-sonnet-1
+- Cycle: 14d (next: 2026-06-01)
+- Template version: c6bd89a1e


### PR DESCRIPTION
Scheduler: swe-sonnet-1

## 무엇이 변경됐는가

- docs/features/discovery/feature_audit_report.md 신규 작성
- docs/features/discovery/FRESH_DOC last_verified 갱신

## 왜

Closes #2548

## 결과

- tag-discovery, trust-badge 양쪽 prd.md + spec.md 5섹션 완성 확인
- #2561 (P2): CUJ integration test 전무 (26 CUJs) 파일링
- pgTAP 5개 (tag schema) ✓, widget test 6개 ✓