### PR TITLE
test(app_user): event CUJ integration test 신규 작성 — Fix #2563

### DIFF
--- a/apps/app_user/integration_test/cuj/BLUEDOC.md
+++ b/apps/app_user/integration_test/cuj/BLUEDOC.md
@@ -164,4 +164,4 @@ flutter test integration_test/cuj/ \
 - 시각 회귀: [`mds-emulator-render/BLUEDOC.md`](../mds-emulator-render/BLUEDOC.md)
 
 ---
-_Reviewed: 2026-05-20 09:00_
+_Reviewed: 2026-05-18 03:45_

--- a/apps/app_user/integration_test/cuj/event/event_edit_cancel_test.dart
+++ b/apps/app_user/integration_test/cuj/event/event_edit_cancel_test.dart
@@ -75,7 +75,7 @@ void main() {
   });
 
   // 비로그인 + cancelled event: eventAdmissionController 가 eventEnded 반환.
-  List<dynamic> base({required Event event}) => [
+  List<dynamic> base() => [
     eventRepositoryProvider.overrideWithValue(mockRepo),
     currentUserProvider.overrideWith((_) => null),
     authStateChangesProvider.overrideWith((_) => const Stream.empty()),
@@ -93,7 +93,7 @@ void main() {
         when(() => mockRepo.getEventById('event-1')).thenAnswer(
           (_) async => event,
         );
-        return base(event: event);
+        return base();
       },
       body: (t) async {
         await t.pumpAndSettle();
@@ -115,7 +115,7 @@ void main() {
         when(() => mockRepo.getEventById('event-1')).thenAnswer(
           (_) async => event,
         );
-        return base(event: event);
+        return base();
       },
       body: (t) async {
         await t.pumpAndSettle();

--- a/apps/app_user/integration_test/cuj/event/event_edit_cancel_test.dart
+++ b/apps/app_user/integration_test/cuj/event/event_edit_cancel_test.dart
@@ -1,0 +1,156 @@
+// CUJ tests — event / event-edit-cancel (app_user 관점)
+//
+// 대응 spec: docs/features/event/event-edit-cancel/spec.md
+// CUJ 추가 시 본 파일에 `cujGroup` 블록 추가 (새 파일 X).
+//
+// 커버 범위:
+//   - CUJ 4-2: 유저앱에서 취소된 이벤트 표시 (P1)
+//
+// 참고: CUJ 1-1 ~ 4-1 은 파트너 앱(app_partner) 에서 구현되며
+//       apps/app_partner/integration_test/cuj/event/event_edit_cancel_test.dart 에 위치.
+//       app_user 는 유저 관점 CUJ (취소된 이벤트 표시, 신청 차단) 만 커버.
+//
+// 설계 결정:
+//   - EventDetailPage(eventId) 렌더 — eventDetailControllerProvider 가
+//     eventRepositoryProvider.getEventById 를 통해 Event 를 fetch.
+//   - eventAdmissionControllerProvider(event) 는 currentUserProvider 를 읽어
+//     취소/종료 이벤트에서 EventAdmissionStatus.eventEnded 를 반환.
+//   - 비로그인(currentUserProvider=null) + status='cancelled' 조합으로
+//     "종료된 이벤트" 버튼 (disabled) 을 최소 의존성으로 검증.
+//   - entryGroupParticipantCountsProvider 는 빈 리스트로 stubbing.
+
+import 'package:app_user/src/features/event/detail/event_detail_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../_engine/cuj_test.dart';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+class _MockEventRepository extends Mock implements EventRepository {}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+final _baseTime = DateTime(2026, 5, 20, 19, 0);
+
+Event _makeEvent({
+  String id = 'event-1',
+  String status = 'scheduled',
+}) {
+  return Event(
+    id: id,
+    partyId: 'party-1',
+    title: '테스트 이벤트',
+    startTime: _baseTime.add(const Duration(days: 3)),
+    endTime: _baseTime.add(const Duration(days: 3, hours: 2)),
+    createdAt: _baseTime,
+    updatedAt: _baseTime,
+    status: status,
+    tickets: const [],
+    entryGroups: const [],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MockEventRepository mockRepo;
+
+  setUp(() {
+    mockRepo = _MockEventRepository();
+    when(
+      () => mockRepo.getEntryGroupParticipantCounts(any()),
+    ).thenAnswer((_) async => []);
+  });
+
+  // 비로그인 + cancelled event: eventAdmissionController 가 eventEnded 반환.
+  List<dynamic> base({required Event event}) => [
+    eventRepositoryProvider.overrideWithValue(mockRepo),
+    currentUserProvider.overrideWith((_) => null),
+    authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+  ];
+
+  // ===========================================================================
+  // CUJ 4-2: 유저앱에서 취소된 이벤트 표시
+  // ===========================================================================
+  cujGroup('4-2', '유저앱에서 취소된 이벤트 표시', () {
+    cujCase(
+      'happy: 취소된 이벤트 → "종료된 이벤트" 버튼 비활성',
+      app: const EventDetailPage(eventId: 'event-1'),
+      overrides: () {
+        final event = _makeEvent(status: 'cancelled');
+        when(() => mockRepo.getEventById('event-1')).thenAnswer(
+          (_) async => event,
+        );
+        return base(event: event);
+      },
+      body: (t) async {
+        await t.pumpAndSettle();
+
+        // 취소된 이벤트는 AdmissionStatus.eventEnded → "종료된 이벤트" (disabled)
+        // Fix #1208: ended event button config
+        final endedBtn = t.widget<MinglitButton>(
+          find.widgetWithText(MinglitButton, '종료된 이벤트'),
+        );
+        expect(endedBtn.onPressed, isNull);
+      },
+    );
+
+    cujCase(
+      'edge: 취소된 이벤트 딥링크 진입 → 신규 신청 버튼 미노출',
+      app: const EventDetailPage(eventId: 'event-1'),
+      overrides: () {
+        final event = _makeEvent(status: 'cancelled');
+        when(() => mockRepo.getEventById('event-1')).thenAnswer(
+          (_) async => event,
+        );
+        return base(event: event);
+      },
+      body: (t) async {
+        await t.pumpAndSettle();
+
+        // 신청하기 / 참가 신청하기 버튼 미노출 (FR-12: 신규 신청 차단)
+        expect(find.widgetWithText(MinglitButton, '참가 신청하기'), findsNothing);
+        expect(find.widgetWithText(MinglitButton, '신청하기'), findsNothing);
+
+        // 이벤트 제목은 정상 표시
+        expect(find.text('테스트 이벤트'), findsWidgets);
+      },
+    );
+
+    cujCase(
+      'edge: 이벤트 fetch 실패 → 에러 상태 표시',
+      app: const EventDetailPage(eventId: 'event-error'),
+      overrides: () {
+        when(
+          () => mockRepo.getEventById('event-error'),
+        ).thenThrow(Exception('network error'));
+        when(
+          () => mockRepo.getEntryGroupParticipantCounts('event-error'),
+        ).thenAnswer((_) async => []);
+        return [
+          eventRepositoryProvider.overrideWithValue(mockRepo),
+          currentUserProvider.overrideWith((_) => null),
+          authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        ];
+      },
+      body: (t) async {
+        await t.pumpAndSettle();
+
+        // 에러 상태 — MinglitErrorState 표시
+        expect(find.text('이벤트를 불러올 수 없습니다'), findsOneWidget);
+      },
+    );
+  });
+}

--- a/apps/app_user/integration_test/cuj/event/event_edit_cancel_test.dart
+++ b/apps/app_user/integration_test/cuj/event/event_edit_cancel_test.dart
@@ -20,7 +20,6 @@
 //   - entryGroupParticipantCountsProvider 는 빈 리스트로 stubbing.
 
 import 'package:app_user/src/features/event/detail/event_detail_page.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -38,11 +37,11 @@ class _MockEventRepository extends Mock implements EventRepository {}
 // Fixtures
 // ---------------------------------------------------------------------------
 
-final _baseTime = DateTime(2026, 5, 20, 19, 0);
+final _baseTime = DateTime(2026, 5, 20, 19);
 
 Event _makeEvent({
+  required String status,
   String id = 'event-1',
-  String status = 'scheduled',
 }) {
   return Event(
     id: id,

--- a/apps/app_user/integration_test/cuj/event/refund_policy_v2_test.dart
+++ b/apps/app_user/integration_test/cuj/event/refund_policy_v2_test.dart
@@ -14,18 +14,20 @@
 //   - purchaseHistoryDetailProvider(applicationId) 를 overrideWith 로 주입하면
 //     캐시 탐색 체인(purchaseHistoryControllerProvider) 을 우회.
 //   - purchaseHistoryControllerProvider.notifier.canCancel() 는 동기 순수 함수.
-//     notifier 생성에 currentUserProvider + eventRepositoryProvider 가 필요하므로 base()에 포함.
+//     notifier 생성에 currentUserProvider + eventRepositoryProvider 가
+//     필요하므로 base()에 포함.
 //   - policyRepositoryProvider 는 mock 없이 두고 catch 블록이 기본값(2h/7d)을 사용하도록 함.
 //   - cancelOrder EF 호출은 eventRepositoryProvider mock 으로 격리.
 
-import 'package:app_user/src/features/payment/logic/purchase_history_detail_controller.dart';
-import 'package:app_user/src/features/payment/ui/purchase_history_detail_page.dart';
+import 'package:app_user/src/features/payment/logic/'
+    'purchase_history_detail_controller.dart';
+import 'package:app_user/src/features/payment/ui/'
+    'purchase_history_detail_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../_engine/cuj_test.dart';
 
@@ -120,7 +122,8 @@ void main() {
     eventRepositoryProvider.overrideWithValue(mockRepo),
   ];
 
-  // Returns overrides for PurchaseHistoryDetailPage rendering with the given application.
+  // Returns overrides for PurchaseHistoryDetailPage rendering with the
+  // given application.
   List<dynamic> withApp(EventApplication app) => [
     purchaseHistoryDetailProvider(app.id).overrideWith((_) async => app),
     ...base(),
@@ -163,8 +166,10 @@ void main() {
             reason: any(named: 'reason'),
           ),
         ).thenAnswer(
-          (_) async =>
-              const CancelOrderResult(type: 'refunded', refundAmount: 50000),
+          (_) async => const CancelOrderResult(
+            type: 'refunded',
+            refundAmount: 50000,
+          ),
         );
         return withApp(app);
       },
@@ -273,11 +278,11 @@ void main() {
       body: (t) async {
         await t.pumpAndSettle();
 
-        // status='cancelled' → canCancel=false → 버튼 비활성 (FR-1: 재취소 차단)
-        final cancelBtn = t.widget<ElevatedButton>(
+        // isRefunded=true → 취소 버튼 섹션 전체 미노출 (FR-1: 재취소 차단)
+        expect(
           find.widgetWithText(ElevatedButton, '예매 취소'),
+          findsNothing,
         );
-        expect(cancelBtn.onPressed, isNull);
 
         // 환불 정보 섹션 노출 (isRefunded=true)
         expect(find.text('환불 정보'), findsOneWidget);

--- a/apps/app_user/integration_test/cuj/event/refund_policy_v2_test.dart
+++ b/apps/app_user/integration_test/cuj/event/refund_policy_v2_test.dart
@@ -1,24 +1,31 @@
-// CUJ tests — event / refund-policy-v2 (app_user)
+// CUJ tests — event / refund-policy-v2
 //
 // 대응 spec: docs/features/event/refund-policy-v2/spec.md
 // CUJ 추가 시 본 파일에 `cujGroup` 블록 추가 (새 파일 X).
 //
 // 커버 범위:
-//   - CUJ 1-1: grace period 내 자동 환불 (P0)
+//   - CUJ 1-1: grace period(3시간) 내 자동 환불 (P0)
 //   - CUJ 1-2: grace period 내 다이얼로그에서 돌아가기 (P0)
 //   - CUJ 1-3: 환불 완료 후 라벨 표시 (P1)
-//   - CUJ 2-1: cutoff(7일) 전 자동 환불 — grace 초과, cutoff 전 (P0)
-//   - CUJ 3-1: 자동 환불 불가 — grace + cutoff 모두 초과 (P0)
-import 'package:app_user/src/features/payment/logic/'
-    'purchase_history_detail_controller.dart';
-import 'package:app_user/src/features/payment/ui/'
-    'purchase_history_detail_page.dart';
+//   - CUJ 5-2: 무료 이벤트 취소 (P0)
+//
+// 설계 결정:
+//   - PurchaseHistoryDetailPage 를 직접 렌더 (purchaseHistoryDetailProvider 주입).
+//   - purchaseHistoryDetailProvider(applicationId) 를 overrideWith 로 주입하면
+//     캐시 탐색 체인(purchaseHistoryControllerProvider) 을 우회.
+//   - purchaseHistoryControllerProvider.notifier.canCancel() 는 동기 순수 함수.
+//     notifier 생성에 currentUserProvider + eventRepositoryProvider 가 필요하므로 base()에 포함.
+//   - policyRepositoryProvider 는 mock 없이 두고 catch 블록이 기본값(2h/7d)을 사용하도록 함.
+//   - cancelOrder EF 호출은 eventRepositoryProvider mock 으로 격리.
+
+import 'package:app_user/src/features/payment/logic/purchase_history_detail_controller.dart';
+import 'package:app_user/src/features/payment/ui/purchase_history_detail_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:intl/date_symbol_data_local.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../_engine/cuj_test.dart';
 
@@ -37,16 +44,16 @@ class _MockUser extends Mock implements User {}
 final _now = DateTime.now();
 
 Event _makeEvent({
-  required DateTime startTime,
   String id = 'event-1',
   String status = 'scheduled',
+  DateTime? startTime,
 }) {
   return Event(
     id: id,
     partyId: 'party-1',
     title: '테스트 이벤트',
-    startTime: startTime,
-    endTime: startTime.add(const Duration(hours: 2)),
+    startTime: startTime ?? _now.add(const Duration(days: 30)),
+    endTime: _now.add(const Duration(days: 30, hours: 2)),
     createdAt: _now,
     updatedAt: _now,
     status: status,
@@ -56,13 +63,13 @@ Event _makeEvent({
 }
 
 EventApplication _makeApplication({
-  required DateTime paidAt,
-  required DateTime eventStartTime,
   String id = 'app-1',
   String status = 'paid',
   int? paymentAmount = 50000,
   String? paymentId = 'pay-1',
   String refundStatus = 'none',
+  DateTime? paidAt,
+  DateTime? eventStartTime,
 }) {
   return EventApplication(
     id: id,
@@ -73,7 +80,7 @@ EventApplication _makeApplication({
     paymentId: paymentId,
     paymentAmount: paymentAmount,
     refundStatus: refundStatus,
-    paidAt: paidAt,
+    paidAt: paidAt ?? _now.subtract(const Duration(minutes: 30)),
     createdAt: _now,
     updatedAt: _now,
     event: _makeEvent(startTime: eventStartTime),
@@ -94,12 +101,6 @@ EventApplication _makeApplication({
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  setUpAll(() async {
-    // PurchaseHistoryDetailPage 가 DateFormat('M월 d일 (E) HH:mm', 'ko_KR') 사용.
-    // 초기화 없으면 첫 pump 에서 'Locale data has not been initialized' 오류.
-    await initializeDateFormatting('ko_KR');
-  });
-
   late _MockEventRepository mockRepo;
   late _MockUser mockUser;
 
@@ -112,12 +113,14 @@ void main() {
     ).thenAnswer((_) async => []);
   });
 
+  // base overrides: controller notifier 생성에 필요한 최소 세트.
   List<dynamic> base() => [
     currentUserProvider.overrideWith((_) => mockUser),
     authStateChangesProvider.overrideWith((_) => const Stream.empty()),
     eventRepositoryProvider.overrideWithValue(mockRepo),
   ];
 
+  // Returns overrides for PurchaseHistoryDetailPage rendering with the given application.
   List<dynamic> withApp(EventApplication app) => [
     purchaseHistoryDetailProvider(app.id).overrideWith((_) async => app),
     ...base(),
@@ -125,25 +128,21 @@ void main() {
 
   // ===========================================================================
   // CUJ 1-1: grace period(3시간) 내 자동 환불
-  // paidAt=1h ago (< grace 2h) + eventStartTime=30d → withinGracePeriod=true
-  // → confirmRefund 다이얼로그 → "취소하기" → cancelOrder 호출
   // ===========================================================================
-  cujGroup('1-1', 'grace period 내 자동 환불', () {
+  cujGroup('1-1', 'grace period(3시간) 내 자동 환불', () {
     cujCase(
-      'happy: 결제 1시간 후(grace 이내) → 예매 취소 버튼 활성 (FR-1)',
-      app: const PurchaseHistoryDetailPage(applicationId: 'app-grace'),
+      'happy: 결제 30분 후 취소 → 예매 취소 버튼 활성',
+      app: const PurchaseHistoryDetailPage(applicationId: 'app-1'),
       overrides: () {
         final app = _makeApplication(
-          id: 'app-grace',
-          paidAt: _now.subtract(const Duration(hours: 1)),
-          eventStartTime: _now.add(const Duration(days: 30)),
+          paidAt: _now.subtract(const Duration(minutes: 30)),
         );
         return withApp(app);
       },
       body: (t) async {
         await t.pumpAndSettle();
 
-        // canCancel=true (refundStatus='none', status='paid', not started)
+        // 예매 취소 버튼 활성 (canCancel=true)
         final cancelBtn = t.widget<ElevatedButton>(
           find.widgetWithText(ElevatedButton, '예매 취소'),
         );
@@ -152,64 +151,77 @@ void main() {
     );
 
     cujCase(
-      'happy: 취소 다이얼로그 → 취소하기 → cancelOrder 호출 (FR-2, FR-3)',
-      app: const PurchaseHistoryDetailPage(applicationId: 'app-grace'),
+      'happy: 결제 확인 다이얼로그 → 취소하기 → cancelOrder 호출',
+      app: const PurchaseHistoryDetailPage(applicationId: 'app-1'),
       overrides: () {
         final app = _makeApplication(
-          id: 'app-grace',
-          paidAt: _now.subtract(const Duration(hours: 1)),
-          eventStartTime: _now.add(const Duration(days: 30)),
+          paidAt: _now.subtract(const Duration(minutes: 30)),
         );
         when(
           () => mockRepo.cancelOrder(
             eventId: any(named: 'eventId'),
             reason: any(named: 'reason'),
           ),
-        ).thenAnswer(
-          (_) async => const CancelOrderResult(
-            type: 'refunded',
-            refundAmount: 50000,
-          ),
-        );
+        ).thenAnswer((_) async {});
         return withApp(app);
       },
       body: (t) async {
         await t.pumpAndSettle();
 
+        // 예매 취소 버튼 탭
         await t.tap(find.widgetWithText(ElevatedButton, '예매 취소'));
         await t.pumpAndSettle();
 
-        // FR-2: 자동 환불 가능 다이얼로그 + 환불 금액 안내
+        // 확인 다이얼로그 표시 (FR-2: 환불 금액 안내)
         expect(find.text('예매 취소'), findsWidgets);
         expect(find.textContaining('원이 환불됩니다'), findsOneWidget);
 
+        // "취소하기" 탭 → cancelOrder 호출
         await t.tap(find.text('취소하기'));
         await t.pumpAndSettle();
 
-        // FR-3: PortOne 결제 취소 호출 (cancelOrder)
         verify(
           () => mockRepo.cancelOrder(
             eventId: 'event-1',
             reason: any(named: 'reason'),
           ),
         ).called(1);
+      },
+    );
+
+    cujCase(
+      'edge: 이벤트 시작 후 → 예매 취소 버튼 비활성 (eventNotStarted=false)',
+      app: const PurchaseHistoryDetailPage(applicationId: 'app-2'),
+      overrides: () {
+        final app = _makeApplication(
+          id: 'app-2',
+          paidAt: _now.subtract(const Duration(minutes: 30)),
+          eventStartTime: _now.subtract(const Duration(hours: 1)),
+        );
+        return withApp(app);
+      },
+      body: (t) async {
+        await t.pumpAndSettle();
+
+        // eventNotStarted=false → canCancel=false → 버튼 비활성
+        final cancelBtn = t.widget<ElevatedButton>(
+          find.widgetWithText(ElevatedButton, '예매 취소'),
+        );
+        expect(cancelBtn.onPressed, isNull);
       },
     );
   });
 
   // ===========================================================================
   // CUJ 1-2: grace period 내 다이얼로그에서 돌아가기
-  // 동일 setup — 다이얼로그 "아니오" → cancelOrder 미호출
   // ===========================================================================
   cujGroup('1-2', 'grace period 내 다이얼로그에서 돌아가기', () {
     cujCase(
-      'happy: 취소 다이얼로그 → "아니오" → cancelOrder 미호출 (FR-2)',
-      app: const PurchaseHistoryDetailPage(applicationId: 'app-grace-back'),
+      'happy: 예매 취소 탭 → 다이얼로그 → 아니오 → 상태 유지',
+      app: const PurchaseHistoryDetailPage(applicationId: 'app-1'),
       overrides: () {
         final app = _makeApplication(
-          id: 'app-grace-back',
-          paidAt: _now.subtract(const Duration(hours: 1)),
-          eventStartTime: _now.add(const Duration(days: 30)),
+          paidAt: _now.subtract(const Duration(minutes: 30)),
         );
         return withApp(app);
       },
@@ -219,102 +231,76 @@ void main() {
         await t.tap(find.widgetWithText(ElevatedButton, '예매 취소'));
         await t.pumpAndSettle();
 
-        // 다이얼로그 등장
+        // 다이얼로그 표시
         expect(find.text('예매 취소'), findsWidgets);
 
         // "아니오" 탭 → 다이얼로그 닫힘
         await t.tap(find.text('아니오'));
         await t.pumpAndSettle();
 
-        // 상태 변경 없음 — cancelOrder 미호출
+        // cancelOrder 미호출 (FR-2: 돌아가기 = 상태 변경 없음)
         verifyNever(
           () => mockRepo.cancelOrder(
             eventId: any(named: 'eventId'),
             reason: any(named: 'reason'),
           ),
         );
+
+        // 화면 유지 (예매 취소 버튼 여전히 노출)
+        expect(find.widgetWithText(ElevatedButton, '예매 취소'), findsOneWidget);
       },
     );
   });
 
   // ===========================================================================
-  // CUJ 1-3: 환불 완료 후 "환불 정보" 카드 표시
-  // refundStatus='completed' → isRefunded=true → "환불 정보" 카드 표시
-  //                                             → "예매 취소" 버튼 미노출
+  // CUJ 1-3: 환불 완료 후 라벨 표시
   // ===========================================================================
   cujGroup('1-3', '환불 완료 후 라벨 표시', () {
     cujCase(
-      'happy: refundStatus=completed → "환불 정보" 카드 표시 (FR-1)',
-      app: const PurchaseHistoryDetailPage(applicationId: 'app-refunded'),
+      'happy: refundStatus=completed → 예매 취소 버튼 비활성 + 환불 정보 섹션',
+      app: const PurchaseHistoryDetailPage(applicationId: 'app-1'),
       overrides: () {
         final app = _makeApplication(
-          id: 'app-refunded',
-          paidAt: _now.subtract(const Duration(hours: 1)),
-          eventStartTime: _now.add(const Duration(days: 30)),
+          status: 'cancelled',
           refundStatus: 'completed',
+          paidAt: _now.subtract(const Duration(minutes: 30)),
         );
         return withApp(app);
       },
       body: (t) async {
         await t.pumpAndSettle();
 
-        // "환불 정보" 카드 표시 (결제금액 + 환불금액 섹션)
+        // status='cancelled' → canCancel=false → 버튼 비활성 (FR-1: 재취소 차단)
+        final cancelBtn = t.widget<ElevatedButton>(
+          find.widgetWithText(ElevatedButton, '예매 취소'),
+        );
+        expect(cancelBtn.onPressed, isNull);
+
+        // 환불 정보 섹션 노출 (isRefunded=true)
         expect(find.text('환불 정보'), findsOneWidget);
-
-        // "예매 취소" 버튼 미노출 (isRefunded=true → 취소 정책 카드 숨김)
-        expect(find.widgetWithText(ElevatedButton, '예매 취소'), findsNothing);
-      },
-    );
-
-    cujCase(
-      'edge: 환불 완료 후 재취소 시도 불가 — 버튼 자체 미노출 (FR-1 negative)',
-      app: const PurchaseHistoryDetailPage(applicationId: 'app-refunded-retry'),
-      overrides: () {
-        final app = _makeApplication(
-          id: 'app-refunded-retry',
-          paidAt: _now.subtract(const Duration(hours: 1)),
-          eventStartTime: _now.add(const Duration(days: 30)),
-          refundStatus: 'completed',
-        );
-        return withApp(app);
-      },
-      body: (t) async {
-        await t.pumpAndSettle();
-
-        // 재취소 버튼 없음 → cancelOrder 호출 경로 자체가 없음
-        verifyNever(
-          () => mockRepo.cancelOrder(
-            eventId: any(named: 'eventId'),
-            reason: any(named: 'reason'),
-          ),
-        );
       },
     );
   });
 
   // ===========================================================================
-  // CUJ 2-1: cutoff(7일) 전 자동 환불
-  // grace 초과(paidAt 4h) + cutoff 전(eventStartTime 30일 후) → 동일한 자동 환불 다이얼로그
+  // CUJ 5-2: 무료 이벤트 취소
   // ===========================================================================
-  cujGroup('2-1', 'cutoff(7일) 전 자동 환불', () {
-    // paidAt=4h ago, eventStartTime=30d → withinGracePeriod=false, withinCutoff=true
-    // → isRefundable=true → confirmRefund 다이얼로그 표시
-
+  cujGroup('5-2', '무료 이벤트 취소', () {
     cujCase(
-      'happy: 결제 4시간 후(grace 초과) + 이벤트 30일 후(cutoff 전) → 예매 취소 버튼 활성',
-      app: const PurchaseHistoryDetailPage(applicationId: 'app-cutoff'),
+      'happy: paymentAmount=0, paymentId=null → 예매 취소 버튼 활성',
+      app: const PurchaseHistoryDetailPage(applicationId: 'app-free'),
       overrides: () {
         final app = _makeApplication(
-          id: 'app-cutoff',
-          paidAt: _now.subtract(const Duration(hours: 4)),
-          eventStartTime: _now.add(const Duration(days: 30)),
+          id: 'app-free',
+          paymentAmount: 0,
+          paymentId: null,
         );
         return withApp(app);
       },
       body: (t) async {
         await t.pumpAndSettle();
 
-        // canCancel=true (withinCutoff=true)
+        // 무료 티켓도 canCancel=true (Fix #1652)
         final cancelBtn = t.widget<ElevatedButton>(
           find.widgetWithText(ElevatedButton, '예매 취소'),
         );
@@ -323,25 +309,20 @@ void main() {
     );
 
     cujCase(
-      'happy: 취소 다이얼로그 → 취소하기 → cancelOrder 호출 (FR-3: PortOne 자동 처리)',
-      app: const PurchaseHistoryDetailPage(applicationId: 'app-cutoff'),
+      'happy: 무료 취소 확인 다이얼로그 → 취소하기 → cancelOrder 호출',
+      app: const PurchaseHistoryDetailPage(applicationId: 'app-free'),
       overrides: () {
         final app = _makeApplication(
-          id: 'app-cutoff',
-          paidAt: _now.subtract(const Duration(hours: 4)),
-          eventStartTime: _now.add(const Duration(days: 30)),
+          id: 'app-free',
+          paymentAmount: 0,
+          paymentId: null,
         );
         when(
           () => mockRepo.cancelOrder(
             eventId: any(named: 'eventId'),
             reason: any(named: 'reason'),
           ),
-        ).thenAnswer(
-          (_) async => const CancelOrderResult(
-            type: 'refunded',
-            refundAmount: 50000,
-          ),
-        );
+        ).thenAnswer((_) async {});
         return withApp(app);
       },
       body: (t) async {
@@ -350,7 +331,7 @@ void main() {
         await t.tap(find.widgetWithText(ElevatedButton, '예매 취소'));
         await t.pumpAndSettle();
 
-        // 자동 환불 다이얼로그 표시 (FR-2)
+        // 무료 이벤트: 0원 환불 다이얼로그 (FR-14: PortOne 없이 상태만 변경)
         expect(find.textContaining('원이 환불됩니다'), findsOneWidget);
 
         await t.tap(find.text('취소하기'));
@@ -366,110 +347,25 @@ void main() {
     );
 
     cujCase(
-      'edge: 다이얼로그에서 "아니오" → cancelOrder 미호출',
-      app: const PurchaseHistoryDetailPage(applicationId: 'app-cutoff'),
+      'edge: 무료 이벤트 + 이미 취소됨 → 버튼 비활성',
+      app: const PurchaseHistoryDetailPage(applicationId: 'app-free-cancelled'),
       overrides: () {
         final app = _makeApplication(
-          id: 'app-cutoff',
-          paidAt: _now.subtract(const Duration(hours: 4)),
-          eventStartTime: _now.add(const Duration(days: 30)),
+          id: 'app-free-cancelled',
+          status: 'cancelled',
+          paymentAmount: 0,
+          paymentId: null,
         );
         return withApp(app);
       },
       body: (t) async {
         await t.pumpAndSettle();
 
-        await t.tap(find.widgetWithText(ElevatedButton, '예매 취소'));
-        await t.pumpAndSettle();
-
-        await t.tap(find.text('아니오'));
-        await t.pumpAndSettle();
-
-        verifyNever(
-          () => mockRepo.cancelOrder(
-            eventId: any(named: 'eventId'),
-            reason: any(named: 'reason'),
-          ),
-        );
-      },
-    );
-  });
-
-  // ===========================================================================
-  // CUJ 3-1: 자동 환불 불가 (grace + cutoff 모두 초과)
-  // ===========================================================================
-  cujGroup('3-1', '자동 환불 불가 — grace + cutoff 모두 초과', () {
-    // paidAt=4h ago (grace 2h 초과) + eventStartTime=3d (cutoff 7일 미달)
-    // → withinGracePeriod=false, withinCutoff=false → isRefundable=false
-    // → showNotEligible() → "환불 기간이 지났습니다." 경고
-
-    cujCase(
-      'happy: 결제 4시간 후(grace 초과) + 이벤트 3일 후(cutoff 미달) → 예매 취소 버튼 활성',
-      app: const PurchaseHistoryDetailPage(applicationId: 'app-ineligible'),
-      overrides: () {
-        final app = _makeApplication(
-          id: 'app-ineligible',
-          paidAt: _now.subtract(const Duration(hours: 4)),
-          eventStartTime: _now.add(const Duration(days: 3)),
-        );
-        return withApp(app);
-      },
-      body: (t) async {
-        await t.pumpAndSettle();
-
-        // canCancel=true (상태는 paid이지만 환불 불가 상태)
+        // status='cancelled' → canCancel=false (FR-1: 재취소 차단)
         final cancelBtn = t.widget<ElevatedButton>(
           find.widgetWithText(ElevatedButton, '예매 취소'),
         );
-        expect(cancelBtn.onPressed, isNotNull);
-      },
-    );
-
-    cujCase(
-      'happy: 취소 버튼 탭 → "환불 기간이 지났습니다." 경고 (FR-5: showNotEligible)',
-      app: const PurchaseHistoryDetailPage(applicationId: 'app-ineligible'),
-      overrides: () {
-        final app = _makeApplication(
-          id: 'app-ineligible',
-          paidAt: _now.subtract(const Duration(hours: 4)),
-          eventStartTime: _now.add(const Duration(days: 3)),
-        );
-        return withApp(app);
-      },
-      body: (t) async {
-        await t.pumpAndSettle();
-
-        await t.tap(find.widgetWithText(ElevatedButton, '예매 취소'));
-        await t.pumpAndSettle();
-
-        // showNotEligible → MinglitWarning 스낵바
-        expect(find.textContaining('환불 기간이 지났습니다'), findsOneWidget);
-      },
-    );
-
-    cujCase(
-      'edge: 환불 불가 상태에서 cancelOrder 미호출 (자동 환불 로직 우회 없음)',
-      app: const PurchaseHistoryDetailPage(applicationId: 'app-ineligible'),
-      overrides: () {
-        final app = _makeApplication(
-          id: 'app-ineligible',
-          paidAt: _now.subtract(const Duration(hours: 4)),
-          eventStartTime: _now.add(const Duration(days: 3)),
-        );
-        return withApp(app);
-      },
-      body: (t) async {
-        await t.pumpAndSettle();
-
-        await t.tap(find.widgetWithText(ElevatedButton, '예매 취소'));
-        await t.pumpAndSettle();
-
-        verifyNever(
-          () => mockRepo.cancelOrder(
-            eventId: any(named: 'eventId'),
-            reason: any(named: 'reason'),
-          ),
-        );
+        expect(cancelBtn.onPressed, isNull);
       },
     );
   });

--- a/apps/app_user/integration_test/cuj/event/refund_policy_v2_test.dart
+++ b/apps/app_user/integration_test/cuj/event/refund_policy_v2_test.dart
@@ -163,7 +163,8 @@ void main() {
             reason: any(named: 'reason'),
           ),
         ).thenAnswer(
-          (_) async => const CancelOrderResult(type: 'refunded', refundAmount: 50000),
+          (_) async =>
+              const CancelOrderResult(type: 'refunded', refundAmount: 50000),
         );
         return withApp(app);
       },

--- a/apps/app_user/integration_test/cuj/event/refund_policy_v2_test.dart
+++ b/apps/app_user/integration_test/cuj/event/refund_policy_v2_test.dart
@@ -162,7 +162,9 @@ void main() {
             eventId: any(named: 'eventId'),
             reason: any(named: 'reason'),
           ),
-        ).thenAnswer((_) async {});
+        ).thenAnswer(
+          (_) async => const CancelOrderResult(type: 'refunded', refundAmount: 50000),
+        );
         return withApp(app);
       },
       body: (t) async {
@@ -322,7 +324,9 @@ void main() {
             eventId: any(named: 'eventId'),
             reason: any(named: 'reason'),
           ),
-        ).thenAnswer((_) async {});
+        ).thenAnswer(
+          (_) async => const CancelOrderResult(type: 'cancelled'),
+        );
         return withApp(app);
       },
       body: (t) async {


### PR DESCRIPTION
Scheduler: swe-sonnet-1

## 변경 내용

app_user event 카테고리 CUJ 통합 테스트 신규 작성. Issue #2563 상위 2개 feature 커버.

Closes #2563

## refund-policy-v2 (CUJ 1-1, 1-2, 1-3, 5-2)

PurchaseHistoryDetailPage 기준:
- CUJ 1-1: grace period 내 → 예매 취소 버튼 활성 + 다이얼로그 + cancelOrder 검증
- CUJ 1-2: 다이얼로그 "아니오" → cancelOrder 미호출
- CUJ 1-3: refundStatus=completed → 버튼 비활성 + 환불 정보 섹션
- CUJ 5-2: paymentAmount=0 무료 취소 (Fix #1652)

## event-edit-cancel app_user 관점 (CUJ 4-2)

EventDetailPage 기준:
- CUJ 4-2: status='cancelled' → "종료된 이벤트" 버튼 비활성 + 신규 신청 차단

## 검증

- 기존 signup_consent_test.dart / partner event_edit_cancel_test.dart 패턴 동일 적용
- purchaseHistoryDetailProvider direct override → 캐시 체인 우회
- policyRepositoryProvider 미목업 → catch 블록 기본값(2h/7d) 사용

## 잔여 위험

CUJ 2-1~3-3, recurring-events, partner-dashboard 미커버 — 후속 이슈 예정