### PR TITLE
fix(event-flow-simulator): throttle 도입 (Fix #2545 — Supabase per-trace rate limit)

### DIFF
--- a/.github/workflows/monitor-event-flow-daily.yml
+++ b/.github/workflows/monitor-event-flow-daily.yml
@@ -52,12 +52,14 @@ jobs:
 
       - name: Run event-flow cascade (long)
         run: |
-          # daily 는 데이터 다양성 ↑ 위해 ticks/users 늘림
+          # daily 는 데이터 다양성 ↑ 위해 ticks/users 늘림.
+          # Fix #2545: usersPerTick=50 + delayBetweenCallsMs=400 — Supabase per-trace
+          # rate limit 회피하면서 데이터 다양성 ↑. 최대 (3×50 + partners) × 0.4 ≈ 1~2분.
           http_code=$(curl -s -o /tmp/sim_response.json -w "%{http_code}" -X POST \
             "${{ secrets.SUPABASE_DEV_URL }}/functions/v1/event-flow-simulator" \
             -H "Authorization: Bearer ${{ secrets.SUPABASE_DEV_SECRET_KEY }}" \
             -H "Content-Type: application/json" \
-            -d '{"ticks": 3, "usersPerTick": 20}' \
+            -d '{"ticks": 3, "usersPerTick": 50, "delayBetweenCallsMs": 400}' \
             --max-time 600)
           cat /tmp/sim_response.json
           if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then

--- a/.github/workflows/monitor-event-flow-hourly.yml
+++ b/.github/workflows/monitor-event-flow-hourly.yml
@@ -21,11 +21,13 @@ jobs:
       - name: Invoke event-flow-simulator
         run: |
           # Fix #1635: -s + 수동 status 검사 — error body 로깅 보장
+          # Fix #2545: usersPerTick=20 + delayBetweenCallsMs=300 — Supabase per-trace
+          # rate limit 회피. hourly 는 smoke 라 daily 보다 작은 payload.
           http_code=$(curl -s -o /tmp/sim_response.json -w "%{http_code}" -X POST \
             "${{ secrets.SUPABASE_DEV_URL }}/functions/v1/event-flow-simulator" \
             -H "Authorization: Bearer ${{ secrets.SUPABASE_DEV_SECRET_KEY }}" \
             -H "Content-Type: application/json" \
-            -d '{"ticks": 1, "usersPerTick": 10}' \
+            -d '{"ticks": 1, "usersPerTick": 20, "delayBetweenCallsMs": 300}' \
             --max-time 180)
           cat /tmp/sim_response.json
           if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then

--- a/supabase/functions/event-flow-simulator/core/cascade.ts
+++ b/supabase/functions/event-flow-simulator/core/cascade.ts
@@ -30,6 +30,8 @@ export interface CascadeConfig {
   ticks: number;
   /** 각 tick 후 snapshot 갱신 콜백 (실 운영: 재조회 RPC). 미제공 시 snapshot 변경 X */
   refreshSnapshot?: (current: WorldSnapshot, trace: Trace) => Promise<WorldSnapshot> | WorldSnapshot;
+  /** EF 호출 후 throttle delay (ms). Supabase 의 per-trace rate limit (Fix #2545) 회피용. 기본 0 = 즉시. 실 운영 권장 200~400ms */
+  delayBetweenCallsMs?: number;
 }
 
 export interface CascadeResult {
@@ -62,6 +64,11 @@ export async function runCascade(config: CascadeConfig): Promise<CascadeResult> 
       };
       if (result.error) entry.error = result.error;
       trace.push(entry);
+
+      // Fix #2545: Supabase per-trace rate limit 회피. EF 호출 후만 sleep (skip-action 시는 즉시 다음).
+      if (config.delayBetweenCallsMs && config.delayBetweenCallsMs > 0) {
+        await new Promise((r) => setTimeout(r, config.delayBetweenCallsMs));
+      }
     }
 
     if (config.refreshSnapshot) {

--- a/supabase/functions/event-flow-simulator/core/cascade_test.ts
+++ b/supabase/functions/event-flow-simulator/core/cascade_test.ts
@@ -173,3 +173,58 @@ Deno.test({
     assertEquals(trace1, trace2);
   },
 });
+
+// Fix #2545: throttle 동작 검증 — EF call 사이 delay 보장
+Deno.test({
+  name: "runCascade - delayBetweenCallsMs throttles between EF calls",
+  fn: async () => {
+    clearRegistry();
+    registerAction(applyAction);
+    const { transport, calls } = recordingTransport();
+    const start = performance.now();
+    await runCascade({
+      actors: [
+        { id: "user-1", role: "user" as const },
+        { id: "user-2", role: "user" as const },
+        { id: "user-3", role: "user" as const },
+      ],
+      initialSnapshot: snapshotWithOneEvent(),
+      rates: defaultRates,
+      transport,
+      rng: createPRNG(1),
+      ticks: 1,
+      delayBetweenCallsMs: 50,
+    });
+    const elapsed = performance.now() - start;
+    // 3 호출 사이 2 delay × 50ms = 100ms 최소 (모든 actor 가 action 발생 시)
+    // policy 가 일부 skip 해도 1 call 발생하면 +50ms 보장. 최소 50ms 확인 (느슨한 lower bound).
+    assertEquals(calls.length > 0, true, "at least one EF call expected");
+    assertEquals(elapsed >= 50, true, `elapsed (${elapsed}ms) should be >= 50ms with throttle`);
+  },
+});
+
+Deno.test({
+  name: "runCascade - delayBetweenCallsMs=0 (default) no throttle",
+  fn: async () => {
+    clearRegistry();
+    registerAction(applyAction);
+    const { transport, calls } = recordingTransport();
+    const start = performance.now();
+    await runCascade({
+      actors: [
+        { id: "user-1", role: "user" as const },
+        { id: "user-2", role: "user" as const },
+        { id: "user-3", role: "user" as const },
+      ],
+      initialSnapshot: snapshotWithOneEvent(),
+      rates: defaultRates,
+      transport,
+      rng: createPRNG(1),
+      ticks: 1,
+      // delayBetweenCallsMs omitted → undefined → no delay
+    });
+    const elapsed = performance.now() - start;
+    assertEquals(calls.length > 0, true);
+    assertEquals(elapsed < 50, true, `elapsed (${elapsed}ms) should be < 50ms without throttle`);
+  },
+});

--- a/supabase/functions/event-flow-simulator/index.ts
+++ b/supabase/functions/event-flow-simulator/index.ts
@@ -43,7 +43,7 @@ export const handler = async (req: Request, _ctx: EFContext): Promise<Response> 
   const supabase = createServiceClient();
 
   // optional body params
-  let body: { ticks?: number; seed?: number; usersPerTick?: number } = {};
+  let body: { ticks?: number; seed?: number; usersPerTick?: number; delayBetweenCallsMs?: number } = {};
   try {
     if (req.headers.get("content-type")?.includes("application/json")) {
       const parsed = await parseJsonBody(req);
@@ -57,12 +57,15 @@ export const handler = async (req: Request, _ctx: EFContext): Promise<Response> 
   const ticks = body.ticks ?? 1;
   const seed = body.seed ?? Date.now();
   const usersPerTick = body.usersPerTick ?? 10;
+  // Fix #2545: 기본 300ms throttle — Supabase 의 per-trace rate limit 회피.
+  // 0 으로 명시하면 disable (unit test / 빠른 dev 용).
+  const delayBetweenCallsMs = body.delayBetweenCallsMs ?? 300;
 
   log({
     function: FN,
     level: "info",
     message: "invoked",
-    metadata: { runId, ticks, seed, usersPerTick },
+    metadata: { runId, ticks, seed, usersPerTick, delayBetweenCallsMs },
   });
 
   try {
@@ -125,6 +128,7 @@ export const handler = async (req: Request, _ctx: EFContext): Promise<Response> 
       rng: createPRNG(seed),
       ticks,
       refreshSnapshot: () => buildSnapshot(supabase),
+      delayBetweenCallsMs,
     });
 
     // 4. invariant 검증


### PR DESCRIPTION
Closes #2545

## Summary

\`monitor-event-flow-daily\` 가 \`Rate limit exceeded for trace ... Retry after 19632ms\` 로 HTTP 500 → \`event-flow-simulator\` 가 한 parent trace 안에 60+ child EF call → Supabase trace-level rate limit 차단. cascade EF call 사이에 throttle delay 추가.

## Root cause

\`cascade.ts\` 는 actor 들을 순차 await 으로 EF 호출:
\`\`\`ts
for (const actor of actors) {
  const result = await transport.execute(action);  // ← child EF call
}
\`\`\`

daily 워크플로우: \`{"ticks": 3, "usersPerTick": 20}\` → ~60 EF call. Supabase 가 동일 trace 안의 child invocation 을 rate-limit (정확한 임계값 미공개, retry-after 로 ~20s window 추정).

## Fix

1. \`CascadeConfig.delayBetweenCallsMs\` — EF call 후만 sleep (action skip 시 즉시 다음)
2. \`event-flow-simulator/index.ts\` body 에 \`delayBetweenCallsMs\` 받음 (default 300ms)
3. daily workflow — \`usersPerTick: 50\` + \`delayBetweenCallsMs: 400\` (다양성 ↑ + 안전)
4. hourly workflow — \`usersPerTick: 20\` + \`delayBetweenCallsMs: 300\`
5. unit test 2개 — throttle 동작 + 미사용 시 즉시 동작

## 처리량 계산

| | 이전 | 변경 후 |
|---|---|---|
| daily | 60 call × 200ms = 12s (but trace limit hit) | 180 call × (200ms + 400ms) ≈ 108s, well under \`--max-time 600\` |
| hourly | 10 call × 200ms = 2s (smoke) | 20 call × (200ms + 300ms) ≈ 10s, well under \`--max-time 180\` |

## Test plan

- [x] \`deno test\` 8/8 pass (이전 6 + 새 throttle 2)
- [ ] dev 머지 후 다음 hourly run (KST 다음 :30) 통과 확인
- [ ] daily run (KST 07:00) 통과 확인

## 후속 (선택)

400ms 도 부족하면:
- 더 늘림 (500~700ms)
- 또는 cascade 내부에서 trace 를 batch 단위로 분리 (각 batch 가 새 root trace)
- 또는 직접 DB write 로 전환 (EF business logic 우회, 데이터 만족 목적만)

## 관련

- Issue #2545
- PR #2490 (Stochastic Cascade v2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)