### PR TITLE
perf(ci): drop redundant Flutter/pub cache on self-hosted runners

### DIFF
--- a/.github/workflows/monitor-cuj-coverage.yml
+++ b/.github/workflows/monitor-cuj-coverage.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          cache: true
 
       - name: Run coverage report (JSON)
         id: cov

--- a/.github/workflows/monitor-mds-render-coverage.yml
+++ b/.github/workflows/monitor-mds-render-coverage.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          cache: true
 
       - name: Run coverage report (JSON)
         id: cov

--- a/.github/workflows/monitor-patrol-e2e.yml
+++ b/.github/workflows/monitor-patrol-e2e.yml
@@ -56,7 +56,6 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          cache: true
 
       - name: Install patrol_cli
         run: dart pub global activate patrol_cli

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -154,19 +154,14 @@ jobs:
           # persist-credentials: false keeps the PAT out of git config during pub get,
           # analyze, and test steps; the PAT is injected only in the push step below.
           persist-credentials: false
+      # Flutter SDK + pub-cache come from a host bind volume on the
+      # self-hosted runner (toolcache + .pub-cache mounts in
+      # minglit-github-workflow-runner). The action's `cache: true` and
+      # the explicit actions/cache@v5 for ~/.pub-cache are redundant.
       - uses: subosito/flutter-action@v2
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         with:
           channel: 'stable'
-          cache: true
-      - name: Cache pub packages
-        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
-        uses: actions/cache@v5
-        with:
-          path: ~/.pub-cache
-          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pub-
       - name: Install dependencies
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         run: flutter pub get
@@ -363,7 +358,6 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          cache: true
       - uses: actions/setup-node@v6
         with:
           node-version: '20'
@@ -396,7 +390,6 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          cache: true
       # Wipe any volume left by a prior run on this host so `supabase start`
       # initializes a fresh DB and auto-applies all migrations from scratch.
       # Required on shared self-hosted runners — otherwise the next start

--- a/.github/workflows/pr-setup-format.yml
+++ b/.github/workflows/pr-setup-format.yml
@@ -24,18 +24,15 @@ jobs:
           # pub get and dart fix/format steps; injected only in the push step.
           persist-credentials: false
 
+      # Flutter SDK + pub-cache come from a host bind volume on the
+      # self-hosted runner (see minglit-github-workflow-runner:
+      # systemd/minglit-runner@.service), so the action's own
+      # `cache: true` and the explicit actions/cache@v5 for ~/.pub-cache
+      # are redundant and add round-trip latency. Default `cache: false`
+      # lets the action detect the existing toolcache and skip download.
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          cache: true
-
-      - name: Cache pub packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.pub-cache
-          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pub-
 
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/shared-android-deploy.yml
+++ b/.github/workflows/shared-android-deploy.yml
@@ -82,7 +82,6 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          cache: true
 
       - name: Cache Gradle
         uses: actions/cache@v5

--- a/.github/workflows/shared-cuj-integration.yml
+++ b/.github/workflows/shared-cuj-integration.yml
@@ -57,7 +57,6 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          cache: true
 
       # Self-hosted runner: Flutter SDK cache dir 가 다른 user 소유 → git 거부.
       # safe.directory를 '*'로 열지 않고 Flutter SDK 경로만 허용 (Fix #2499).

--- a/.github/workflows/sync-test-coverage.yml
+++ b/.github/workflows/sync-test-coverage.yml
@@ -91,7 +91,6 @@ jobs:
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         with:
           channel: 'stable'
-          cache: true
 
       - name: Install dependencies
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}


### PR DESCRIPTION
## Summary
Remove `cache: true` from every `subosito/flutter-action@v2` invocation and the explicit `actions/cache@v5` for `~/.pub-cache` in pr-gate / pr-setup-format. All affected jobs run on the self-hosted pool, which now has host-side bind mounts at `/opt/hostedtoolcache` and `/root/.pub-cache` (configured in `minglit-github-workflow-runner: systemd/minglit-runner@.service`).

## Why
Two cache layers now compete:

1. **`cache: true` on flutter-action** — internally calls `actions/cache@v5` to push/pull the Flutter SDK to/from the GitHub-side cache. The SDK is already on the host bind, so the action skips the download — but the cache round-trip still runs. Measured: subosito step went from ~51s (no host bind, with `cache: true`) to ~110s (host bind + `cache: true`), because the second layer now contends with the first.

2. **Explicit `actions/cache@v5` for `~/.pub-cache`** in pr-setup-format and pr-gate. The `/root/.pub-cache` bind already persists pub deps across runs, so the GitHub round-trip adds ~20s with no benefit.

Removing both lets the action detect the existing toolcache and skip download entirely.

## Files
- monitor-cuj-coverage.yml, monitor-mds-render-coverage.yml, monitor-patrol-e2e.yml
- pr-gate.yml (3 sites in the test-app-unit-widget-golden matrix)
- pr-setup-format.yml
- shared-android-deploy.yml, shared-cuj-integration.yml
- sync-test-coverage.yml

## Expected effect (warm cache)
- auto-format: ~178s → ~70-90s (5 recent samples)
- test-app-unit-widget-golden (×4 matrix): ~100s × 4 saved per PR
- deploy-app_user/_partner: ~100s per main push
- Aggregate across last 24h volume: ~1.5h wall-time saved/day

## Scope
Self-hosted only. No ubuntu-hosted job uses `subosito/flutter-action`, so this doesn't touch GitHub-hosted runners.

## Test plan
- [ ] This PR's own auto-format completes in <90s (warm cache).
- [ ] No regression in pr-gate test-app-unit-widget-golden / test-pgtap (both use flutter-action without the explicit pub-cache step now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)