### PR TITLE
feat(mds-render): account-deletion render catalog 등록 — Refs #2587

### DIFF
--- a/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
@@ -57,4 +57,4 @@ MDS spec 디렉토리명과 동일 (per-screen, snake_case). 화면당 `builder.
 - [상위 BLUEDOC](../BLUEDOC.md) · 페어 워크플로우: `sync-mds-mockups.yml` (디자인 PNG)
 
 ---
-_Reviewed: 2026-05-19 14:00_
+_Reviewed: 2026-05-20 09:00_

--- a/apps/app_user/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_registry.dart
@@ -6,6 +6,13 @@
 
 import '_engine/builder.dart';
 import '_engine/catalog.dart';
+import 'deletion_complete_page/deletion_complete_page_test.dart'
+    as deletion_complete_page;
+import 'deletion_info_page/deletion_info_page_test.dart' as deletion_info_page;
+import 'deletion_reason_page/deletion_reason_page_test.dart'
+    as deletion_reason_page;
+import 'deletion_verify_page/deletion_verify_page_test.dart'
+    as deletion_verify_page;
 import 'event_now_bar/event_now_bar_test.dart' as event_now_bar;
 import 'event_ongoing_banner/event_ongoing_banner_test.dart'
     as event_ongoing_banner;
@@ -19,6 +26,10 @@ import 'search_page/search_page_test.dart' as search_page;
 
 /// 모든 cataloged 화면의 명시적 list. 새 화면 추가 시 본 list 에 추가.
 final List<MdsCatalog<MdsScreenBuilder<dynamic>>> allCatalogs = [
+  deletion_complete_page.catalog,
+  deletion_info_page.catalog,
+  deletion_reason_page.catalog,
+  deletion_verify_page.catalog,
   event_now_bar.catalog,
   event_ongoing_banner.catalog,
   home_page.catalog,

--- a/apps/app_user/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_registry.dart
@@ -28,6 +28,7 @@ import 'search_page/search_page_test.dart' as search_page;
 final List<MdsCatalog<MdsScreenBuilder<dynamic>>> allCatalogs = [
   deletion_complete_page.catalog,
   deletion_info_page.catalog,
+  deletion_info_page.catalogWithReason,
   deletion_reason_page.catalog,
   deletion_verify_page.catalog,
   event_now_bar.catalog,

--- a/apps/app_user/integration_test/mds-emulator-render/deletion_complete_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/deletion_complete_page/builder.dart
@@ -1,0 +1,21 @@
+// DeletionCompletePageBuilder — deletion_complete_page 전용 fluent API.
+//
+// DeletionCompletePage 는 build() 에서 provider 를 watch 하지 않는다.
+// 버튼 tap 시 authControllerProvider / appCoordinatorProvider 를 read 하지만
+// 렌더 catalog 에서는 상호작용 없이 초기 UI 만 캡처하므로 별도 override 불필요.
+
+import 'package:app_user/src/features/account_deletion/ui/deletion_complete_page.dart';
+
+import '../_engine/builder.dart';
+
+class DeletionCompletePageBuilder
+    extends MdsScreenBuilder<DeletionCompletePage> {
+  DeletionCompletePageBuilder()
+    : super(page: const DeletionCompletePage());
+
+  /// 다크 모드 토글.
+  DeletionCompletePageBuilder dark() {
+    useDarkTheme();
+    return this;
+  }
+}

--- a/apps/app_user/integration_test/mds-emulator-render/deletion_complete_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/deletion_complete_page/builder.dart
@@ -10,8 +10,7 @@ import '../_engine/builder.dart';
 
 class DeletionCompletePageBuilder
     extends MdsScreenBuilder<DeletionCompletePage> {
-  DeletionCompletePageBuilder()
-    : super(page: const DeletionCompletePage());
+  DeletionCompletePageBuilder() : super(page: const DeletionCompletePage());
 
   /// 다크 모드 토글.
   DeletionCompletePageBuilder dark() {

--- a/apps/app_user/integration_test/mds-emulator-render/deletion_complete_page/deletion_complete_page_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/deletion_complete_page/deletion_complete_page_test.dart
@@ -1,0 +1,21 @@
+// MDS screen: deletion_complete_page
+// 대응 MDS: apps/mds/docs/public/specs/deletion_complete_page/
+//
+// 출력: docs/infra/mds-emulator-render/deletion_complete_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<DeletionCompletePageBuilder>(
+  screen: 'deletion_complete_page',
+  mdsSpec: 'apps/mds/docs/public/specs/deletion_complete_page/',
+  builder: DeletionCompletePageBuilder.new,
+  states: [
+    MdsState('state-default', (b) => b, mdsIndex: 1),
+    MdsState('state-dark', (b) => b.dark()),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);

--- a/apps/app_user/integration_test/mds-emulator-render/deletion_info_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/deletion_info_page/builder.dart
@@ -1,0 +1,64 @@
+// DeletionInfoPageBuilder — deletion_info_page 전용 fluent API.
+//
+// DeletionInfoPage 는 reasonCode/reasonText 를 생성자 파라미터로 받으므로
+// 사유 유무에 따른 state 는 별도 named constructor 로 분기한다.
+// (Riverpod provider override 로 주입 불가 — page 생성자 파라미터)
+
+import 'package:app_user/src/features/account_deletion/logic/account_deletion_coordinator.dart';
+import 'package:app_user/src/features/account_deletion/ui/deletion_info_page.dart';
+import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
+
+import '../_engine/builder.dart';
+
+class _FakeDeletionCoordinator extends AccountDeletionCoordinator {
+  _FakeDeletionCoordinator()
+    : super(
+        GoRouter(
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) => const SizedBox.shrink(),
+            ),
+          ],
+        ),
+      );
+}
+
+/// deletion_info_page 의 기본 상태 builder (탈퇴 사유 없이 진입).
+class DeletionInfoPageBuilder extends MdsScreenBuilder<DeletionInfoPage> {
+  DeletionInfoPageBuilder()
+    : super(
+        page: const DeletionInfoPage(),
+        base: [
+          accountDeletionCoordinatorProvider.overrideWithValue(
+            _FakeDeletionCoordinator(),
+          ),
+        ],
+      );
+
+  /// 다크 모드 토글.
+  DeletionInfoPageBuilder dark() {
+    useDarkTheme();
+    return this;
+  }
+}
+
+/// deletion_info_page 의 사유 포함 상태 builder (privacy_concern 사유 선택 후 진입).
+class DeletionInfoWithReasonBuilder extends MdsScreenBuilder<DeletionInfoPage> {
+  DeletionInfoWithReasonBuilder()
+    : super(
+        page: const DeletionInfoPage(reasonCode: 'privacy_concern'),
+        base: [
+          accountDeletionCoordinatorProvider.overrideWithValue(
+            _FakeDeletionCoordinator(),
+          ),
+        ],
+      );
+
+  /// 다크 모드 토글.
+  DeletionInfoWithReasonBuilder dark() {
+    useDarkTheme();
+    return this;
+  }
+}

--- a/apps/app_user/integration_test/mds-emulator-render/deletion_info_page/deletion_info_page_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/deletion_info_page/deletion_info_page_test.dart
@@ -24,7 +24,7 @@ final catalog = MdsCatalog<DeletionInfoPageBuilder>(
 );
 
 /// 탈퇴 사유를 선택하고 진입하는 상태들.
-final _catalogWithReason = MdsCatalog<DeletionInfoWithReasonBuilder>(
+final catalogWithReason = MdsCatalog<DeletionInfoWithReasonBuilder>(
   screen: 'deletion_info_page',
   mdsSpec: 'apps/mds/docs/public/specs/deletion_info_page/',
   builder: DeletionInfoWithReasonBuilder.new,
@@ -36,5 +36,5 @@ final _catalogWithReason = MdsCatalog<DeletionInfoWithReasonBuilder>(
 
 void main() {
   MdsRenderEngine.run(catalog);
-  MdsRenderEngine.run(_catalogWithReason);
+  MdsRenderEngine.run(catalogWithReason);
 }

--- a/apps/app_user/integration_test/mds-emulator-render/deletion_info_page/deletion_info_page_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/deletion_info_page/deletion_info_page_test.dart
@@ -1,0 +1,40 @@
+// MDS screen: deletion_info_page
+// 대응 MDS: apps/mds/docs/public/specs/deletion_info_page/
+//
+// 출력: docs/infra/mds-emulator-render/deletion_info_page/state-*.png
+//
+// state 분류:
+//   - state-no-reason*  : 탈퇴 사유를 건너뛰고 진입
+//   - state-with-reason*: 탈퇴 사유(privacy_concern) 를 선택하고 진입
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+/// 탈퇴 사유 없이 진입하는 상태들.
+final catalog = MdsCatalog<DeletionInfoPageBuilder>(
+  screen: 'deletion_info_page',
+  mdsSpec: 'apps/mds/docs/public/specs/deletion_info_page/',
+  builder: DeletionInfoPageBuilder.new,
+  states: [
+    MdsState('state-no-reason', (b) => b, mdsIndex: 1),
+    MdsState('state-no-reason-dark', (b) => b.dark()),
+  ],
+);
+
+/// 탈퇴 사유를 선택하고 진입하는 상태들.
+final _catalogWithReason = MdsCatalog<DeletionInfoWithReasonBuilder>(
+  screen: 'deletion_info_page',
+  mdsSpec: 'apps/mds/docs/public/specs/deletion_info_page/',
+  builder: DeletionInfoWithReasonBuilder.new,
+  states: [
+    MdsState('state-with-reason', (b) => b, mdsIndex: 2),
+    MdsState('state-with-reason-dark', (b) => b.dark()),
+  ],
+);
+
+void main() {
+  MdsRenderEngine.run(catalog);
+  MdsRenderEngine.run(_catalogWithReason);
+}

--- a/apps/app_user/integration_test/mds-emulator-render/deletion_reason_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/deletion_reason_page/builder.dart
@@ -25,8 +25,7 @@ class _FakeDeletionCoordinator extends AccountDeletionCoordinator {
       );
 }
 
-class DeletionReasonPageBuilder
-    extends MdsScreenBuilder<DeletionReasonPage> {
+class DeletionReasonPageBuilder extends MdsScreenBuilder<DeletionReasonPage> {
   DeletionReasonPageBuilder()
     : super(
         page: const DeletionReasonPage(),

--- a/apps/app_user/integration_test/mds-emulator-render/deletion_reason_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/deletion_reason_page/builder.dart
@@ -1,0 +1,45 @@
+// DeletionReasonPageBuilder — deletion_reason_page 전용 fluent API.
+//
+// DeletionReasonPage 는 ConsumerStatefulWidget 이며 내부 state 로
+// 라디오 선택 및 텍스트 입력을 관리한다.
+// 렌더 catalog 는 초기(미선택) 상태만 캡처한다.
+
+import 'package:app_user/src/features/account_deletion/logic/account_deletion_coordinator.dart';
+import 'package:app_user/src/features/account_deletion/ui/deletion_reason_page.dart';
+import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
+
+import '../_engine/builder.dart';
+
+class _FakeDeletionCoordinator extends AccountDeletionCoordinator {
+  _FakeDeletionCoordinator()
+    : super(
+        GoRouter(
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) => const SizedBox.shrink(),
+            ),
+          ],
+        ),
+      );
+}
+
+class DeletionReasonPageBuilder
+    extends MdsScreenBuilder<DeletionReasonPage> {
+  DeletionReasonPageBuilder()
+    : super(
+        page: const DeletionReasonPage(),
+        base: [
+          accountDeletionCoordinatorProvider.overrideWithValue(
+            _FakeDeletionCoordinator(),
+          ),
+        ],
+      );
+
+  /// 다크 모드 토글.
+  DeletionReasonPageBuilder dark() {
+    useDarkTheme();
+    return this;
+  }
+}

--- a/apps/app_user/integration_test/mds-emulator-render/deletion_reason_page/deletion_reason_page_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/deletion_reason_page/deletion_reason_page_test.dart
@@ -1,0 +1,21 @@
+// MDS screen: deletion_reason_page
+// 대응 MDS: apps/mds/docs/public/specs/deletion_reason_page/
+//
+// 출력: docs/infra/mds-emulator-render/deletion_reason_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<DeletionReasonPageBuilder>(
+  screen: 'deletion_reason_page',
+  mdsSpec: 'apps/mds/docs/public/specs/deletion_reason_page/',
+  builder: DeletionReasonPageBuilder.new,
+  states: [
+    MdsState('state-default', (b) => b, mdsIndex: 1),
+    MdsState('state-dark', (b) => b.dark()),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);

--- a/apps/app_user/integration_test/mds-emulator-render/deletion_verify_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/deletion_verify_page/builder.dart
@@ -4,10 +4,11 @@
 // 를 watch 한다. currentUserProvider 가 null 이면 SizedBox.shrink() 를 반환하므로
 // 렌더 catalog 에서는 반드시 mock User 를 주입한다.
 //
-// _commonRootOverrides() 의 currentUserProvider(null) 은 state override 에서
-// 덮어쓴다 (Riverpod: 뒤에 오는 override 가 우선).
+// _commonRootOverrides() 의 currentUserProvider 중복 override 방지를 위해
+// build() 를 직접 override 함 (AccountManagementPageBuilder 패턴).
 
 import 'package:app_user/src/features/account_deletion/ui/deletion_verify_page.dart';
+import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -48,24 +49,20 @@ User _makeSocialUser() {
 
 class DeletionVerifyPageBuilder extends MdsScreenBuilder<DeletionVerifyPage> {
   DeletionVerifyPageBuilder()
-    : super(
-        page: const DeletionVerifyPage(reasonCode: 'privacy_concern'),
-        base: [
-          accountRepositoryProvider.overrideWithValue(
-            _FakeAccountRepository(),
-          ),
-        ],
-      );
+    : super(page: const DeletionVerifyPage(reasonCode: 'privacy_concern'));
+
+  User? _user;
+  Brightness _brightness = Brightness.light;
 
   /// 이메일(비밀번호) 로그인 유저 — 비밀번호 입력 필드 노출.
   DeletionVerifyPageBuilder asEmailUser() {
-    addOverride(currentUserProvider.overrideWith((_) => _makeEmailUser()));
+    _user = _makeEmailUser();
     return this;
   }
 
   /// 소셜 로그인 유저 — 재인증 안내 카드 노출.
   DeletionVerifyPageBuilder asSocialUser() {
-    addOverride(currentUserProvider.overrideWith((_) => _makeSocialUser()));
+    _user = _makeSocialUser();
     return this;
   }
 
@@ -77,6 +74,26 @@ class DeletionVerifyPageBuilder extends MdsScreenBuilder<DeletionVerifyPage> {
   /// 다크 모드 토글.
   DeletionVerifyPageBuilder dark() {
     useDarkTheme();
+    _brightness = Brightness.dark;
     return this;
+  }
+
+  @override
+  Widget build() {
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => _user),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+        accountRepositoryProvider.overrideWithValue(_FakeAccountRepository()),
+      ].cast(),
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: _brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
+        home: page,
+      ),
+    );
   }
 }

--- a/apps/app_user/integration_test/mds-emulator-render/deletion_verify_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/deletion_verify_page/builder.dart
@@ -1,0 +1,83 @@
+// DeletionVerifyPageBuilder — deletion_verify_page 전용 fluent API.
+//
+// DeletionVerifyPage 는 currentUserProvider 와 accountDeletionControllerProvider
+// 를 watch 한다. currentUserProvider 가 null 이면 SizedBox.shrink() 를 반환하므로
+// 렌더 catalog 에서는 반드시 mock User 를 주입한다.
+//
+// _commonRootOverrides() 의 currentUserProvider(null) 은 state override 에서
+// 덮어쓴다 (Riverpod: 뒤에 오는 override 가 우선).
+
+import 'package:app_user/src/features/account_deletion/ui/deletion_verify_page.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../_engine/builder.dart';
+
+class _MockUser extends Mock implements User {}
+
+class _MockSupabaseClient extends Mock implements SupabaseClient {}
+
+class _FakeAccountRepository extends AccountRepository {
+  _FakeAccountRepository() : super(_MockSupabaseClient());
+
+  @override
+  Future<DeletionStatus?> getDeletionStatus() async => null;
+
+  @override
+  Future<void> reauthenticate(String? password) async {}
+
+  @override
+  Future<DeletionStatus> deleteAccount(WithdrawalReason? reason) async =>
+      DeletionStatus.fromDeletedAt(DateTime(2026, 3, 31));
+}
+
+User _makeEmailUser() {
+  final user = _MockUser();
+  when(() => user.appMetadata).thenReturn(const {'provider': 'email'});
+  when(() => user.identities).thenReturn(const []);
+  return user;
+}
+
+User _makeSocialUser() {
+  final user = _MockUser();
+  when(() => user.appMetadata).thenReturn(const {'provider': 'google'});
+  when(() => user.identities).thenReturn(const []);
+  return user;
+}
+
+class DeletionVerifyPageBuilder
+    extends MdsScreenBuilder<DeletionVerifyPage> {
+  DeletionVerifyPageBuilder()
+    : super(
+        page: const DeletionVerifyPage(reasonCode: 'privacy_concern'),
+        base: [
+          accountRepositoryProvider.overrideWithValue(
+            _FakeAccountRepository(),
+          ),
+        ],
+      );
+
+  /// 이메일(비밀번호) 로그인 유저 — 비밀번호 입력 필드 노출.
+  DeletionVerifyPageBuilder asEmailUser() {
+    addOverride(currentUserProvider.overrideWith((_) => _makeEmailUser()));
+    return this;
+  }
+
+  /// 소셜 로그인 유저 — 재인증 안내 카드 노출.
+  DeletionVerifyPageBuilder asSocialUser() {
+    addOverride(currentUserProvider.overrideWith((_) => _makeSocialUser()));
+    return this;
+  }
+
+  /// 탈퇴 사유 없이 진입.
+  DeletionVerifyPageBuilder withNoReason() {
+    return this;
+  }
+
+  /// 다크 모드 토글.
+  DeletionVerifyPageBuilder dark() {
+    useDarkTheme();
+    return this;
+  }
+}

--- a/apps/app_user/integration_test/mds-emulator-render/deletion_verify_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/deletion_verify_page/builder.dart
@@ -46,8 +46,7 @@ User _makeSocialUser() {
   return user;
 }
 
-class DeletionVerifyPageBuilder
-    extends MdsScreenBuilder<DeletionVerifyPage> {
+class DeletionVerifyPageBuilder extends MdsScreenBuilder<DeletionVerifyPage> {
   DeletionVerifyPageBuilder()
     : super(
         page: const DeletionVerifyPage(reasonCode: 'privacy_concern'),

--- a/apps/app_user/integration_test/mds-emulator-render/deletion_verify_page/deletion_verify_page_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/deletion_verify_page/deletion_verify_page_test.dart
@@ -1,0 +1,24 @@
+// MDS screen: deletion_verify_page
+// 대응 MDS: apps/mds/docs/public/specs/deletion_verify_page/
+//
+// 출력: docs/infra/mds-emulator-render/deletion_verify_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<DeletionVerifyPageBuilder>(
+  screen: 'deletion_verify_page',
+  mdsSpec: 'apps/mds/docs/public/specs/deletion_verify_page/',
+  builder: DeletionVerifyPageBuilder.new,
+  states: [
+    // 이메일 유저: 비밀번호 입력 필드 노출
+    MdsState('state-email-user', (b) => b.asEmailUser(), mdsIndex: 1),
+    // 소셜 유저: 재인증 안내 카드 노출
+    MdsState('state-social-user', (b) => b.asSocialUser(), mdsIndex: 2),
+    MdsState('state-email-user-dark', (b) => b.asEmailUser().dark()),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-sonnet-1

## Summary

account 카테고리 deletion 4개 화면의 MDS render catalog 신규 등록.

| Screen | States | 비고 |
|--------|--------|------|
| `deletion_complete_page` | default, dark | 외부 provider 불필요 |
| `deletion_info_page` | no-reason, no-reason-dark, with-reason, with-reason-dark | reason이 생성자 파라미터이므로 2개 builder |
| `deletion_reason_page` | default, dark | `accountDeletionCoordinatorProvider` fake |
| `deletion_verify_page` | email-user, social-user, email-user-dark | `currentUserProvider` + `accountRepositoryProvider` override |

`_registry.dart` 에 4개 화면 등록 완료.

## 검증

- `dart analyze apps/app_user/integration_test/mds-emulator-render/` — exit 0

Refs #2587

🤖 Generated with [Claude Code](https://claude.com/claude-code)