### PR TITLE
perf(ci): only run auto-format on PRs touching .dart files

### DIFF
--- a/.github/workflows/pr-setup-format.yml
+++ b/.github/workflows/pr-setup-format.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches: ["main", "dev"]
     types: [opened, synchronize, reopened]
+    # auto-format only runs `dart format` on apps/* and shared/packages/minglit_kit.
+    # PRs that don't touch .dart files (docs, workflow YAML, mds-render specs,
+    # graphify output, migration SQL, ...) had nothing to format and were
+    # spending ~3min on Flutter setup + pub get + zero-diff format. Filter
+    # at the trigger level so we skip the runner entirely.
+    paths:
+      - '**/*.dart'
 
 concurrency:
   group: pr-setup-format-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
Add `paths: ['**/*.dart']` to `pr-setup-format.yml`'s `pull_request` trigger so PRs that don't touch any Dart file skip the workflow entirely.

## Why
auto-format only runs `dart format .` on apps/* + minglit_kit. PRs that touch only docs / mds-render specs / workflow YAML / graphify output / migration SQL / supabase config had nothing to format but were spending ~3 minutes per run on Flutter SDK setup + `flutter pub get` + zero-diff format.

Of the last 24h's 32 auto-format runs, a large fraction were doc/spec/workflow-only PRs — skipping them saves ~50 min wall-time/day and frees ephemeral runner slots for PRs that actually have dart changes.

## Scope
- `**/*.dart` is the only pattern that matters — `analysis_options.yaml` / `pubspec.yaml` don't affect `dart format` output. Those are read by `flutter analyze` and `dart fix`, neither of which this workflow runs.

## Test plan
- [ ] Open a docs-only PR after merge: auto-format should not appear in the checks list.
- [ ] Open a PR touching any .dart file: auto-format triggers and runs as before.
- [ ] PRs in flight at merge time keep their existing checks (path filter only affects future runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)