### PR TITLE
chore(ci): pr-gate merge_group 이벤트 호환성 보완

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -8,8 +8,10 @@ on:
   merge_group:
 
 concurrency:
-  group: pr-gate-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # merge_group 이벤트는 절대 cancel 금지 — 큐 전체가 thrash됨.
+  # PR 단계(pull_request)에서만 새 푸시 시 이전 run cancel.
+  group: pr-gate-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Migration version 중복 검사 (항상 실행 — path filter 없음)
@@ -79,6 +81,11 @@ jobs:
     - uses: dorny/paths-filter@v4
       id: filter
       with:
+        # merge_group 이벤트는 PR base 컨텍스트가 없어 paths-filter 가 비교 base 를
+        # 못 찾고 전체 파일을 changed 로 잡음 → 큐의 batch 효율이 무너짐.
+        # 명시적으로 큐의 base_ref(=dev) 와 비교하도록 지정.
+        # pull_request 이벤트일 때는 빈 값 → paths-filter 가 PR base 로 자동 fallback.
+        base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_ref || '' }}
         filters: |
           app_user:
             - 'apps/app_user/**'


### PR DESCRIPTION
## Summary

GitHub Merge Queue 도입 사전 작업. pr-gate.yml 은 이미 \`merge_group:\` 트리거를 가지고 있었으나, 두 곳이 merge_group 컨텍스트에서 깨질 수 있어 보완.

### 변경 (8라인)

1. **concurrency cancel 보호**
   - merge_group run 을 cancel 하면 큐 전체가 thrash → \`cancel-in-progress\` 를 \`pull_request\` 일 때만 true
   - concurrency group fallback 에 \`merge_group.head_sha\` 추가 (빈 group 방지)

2. **paths-filter base 명시**
   - merge_group 이벤트엔 PR base 컨텍스트가 없어 dorny/paths-filter@v4 가 전체 파일을 changed 로 잡음 → batch 효율 무너짐
   - \`merge_group\` 일 때만 \`base_ref\` 명시. \`pull_request\` 에선 빈 값 → 기존 자동 fallback 유지 (no-op)

## 배경 — quadratic CI thrash

현재 30+ open PR + strict branch protection 조합에서 dev 머지마다 모든 PR 이 BEHIND 가 됨. PR N 개 머지 시 update-branch 호출이 O(N²) — 50개면 1,225 회, 각 update 가 pr-gate fanout 을 새로 트리거.

Merge Queue 가 batch + speculative 로 이 quadratic 을 해소. minglit 워크플로는 트리거 측 준비가 이미 돼있어 이 PR 의 호환성 패치 후 branch protection 토글만 남음.

## Test plan

- [x] YAML 문법 검증 (\`python -c yaml.safe_load\`)
- [x] pull_request 이벤트에서 사실상 no-op 확인 (paths-filter base 가 빈 string → 기존 fallback)
- [ ] 머지 후 branch protection 에서 "Require merge queue" 토글
- [ ] 첫 큐 사이클에서 merge_group run 정상 발사 확인
- [ ] 며칠 운영 후 \`sync-pr-branches.yml\` 폐기 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)