### PR TITLE
chore(ci): pr-setup-format / pr-review-setup GitHub-hosted 이전

### DIFF
--- a/.github/workflows/pr-review-setup.yml
+++ b/.github/workflows/pr-review-setup.yml
@@ -29,7 +29,7 @@ jobs:
     if: >-
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.fork == false
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     steps:
       - name: Enable squash auto-merge
         env:

--- a/.github/workflows/pr-setup-format.yml
+++ b/.github/workflows/pr-setup-format.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   auto-format:
     if: ${{ github.event.pull_request.head.repo.fork == false }}
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
@@ -31,15 +31,16 @@ jobs:
           # pub get and dart fix/format steps; injected only in the push step.
           persist-credentials: false
 
-      # Flutter SDK + pub-cache come from a host bind volume on the
-      # self-hosted runner (see minglit-github-workflow-runner:
-      # systemd/minglit-runner@.service), so the action's own
-      # `cache: true` and the explicit actions/cache@v5 for ~/.pub-cache
-      # are redundant and add round-trip latency. Default `cache: false`
-      # lets the action detect the existing toolcache and skip download.
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          cache: true
+
+      - uses: actions/cache@v5
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-format-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: ${{ runner.os }}-pub-format-
 
       - name: Install dependencies
         run: flutter pub get


### PR DESCRIPTION
## Summary

pr-gate 14개 잡 이전(#2623)의 후속. 나머지 PR-trigger 워크플로 2개도 \`ubuntu-latest\` 로 이전해 self-hosted 풀(3대) 부담 추가 완화.

## 변경

### \`pr-setup-format.yml\`
- runs-on \`ubuntu-latest\`
- subosito/flutter-action \`cache: true\` 추가 (Flutter SDK 캐시)
- actions/cache for \`~/.pub-cache\` 추가
- self-hosted host bind volume 가정 주석 제거

### \`pr-review-setup.yml\`
- runs-on \`ubuntu-latest\`
- gh CLI 만 사용해 의존성 없음 → 캐시 불필요

## Test plan

- [x] YAML 문법 검증
- [ ] 머지 후 다음 PR open 시 pr-setup-format / pr-review-setup ubuntu 정상 통과 확인
- [ ] Flutter SDK + pub-cache 캐시 hit 확인 (2번째 실행부터)

## 후속 PR 후보

- monitor-/deploy-/sync-/triage-/shared- 워크플로 24개 self-hosted 검토
- test-flutter-apps / test-supabase ubuntu 이전 (개별 검증 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)