### PR TITLE
chore(ci): disable gitleaks-action — org license required

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -636,8 +636,13 @@ jobs:
       - name: Check cross-feature imports
         run: bash scripts/check-cross-feature-imports.sh
 
-  # Gitleaks secret scan — formerly pr-setup-secret-scan.yml, absorbed into pr-gate as a required check
+  # Gitleaks secret scan — formerly pr-setup-secret-scan.yml, absorbed into pr-gate as a required check.
+  # Disabled 2026-05-19: post-org-transfer (Mark-Yun → team-minglit), gitleaks-action@v2 requires a
+  # paid license for org repos. ci-result aggregates on "failure" only, so a "skipped" job here does
+  # not block the required check. Re-enable by removing `if: false` once a GITLEAKS_LICENSE secret
+  # is provisioned, or by switching to the raw `gitleaks` binary (no license required).
   gitleaks:
+    if: false
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- repo transfer (`Mark-Yun` → `team-minglit`) triggered `gitleaks-action@v2`'s org-only paid-license requirement → PR checks fail with `[team-minglit] is an organization. License key is required.`
- add `if: false` to the `gitleaks` job in `pr-gate.yml` so it is skipped
- `ci-result` aggregates only on `"failure"`, so a `"skipped"` job here does **not** block the required check
- job definition kept (not deleted) for easy re-enable; comment explains the path back

## Re-enable options (later)

1. provision `GITLEAKS_LICENSE` secret in the org (paid), drop the `if: false`
2. switch to the raw `gitleaks` binary (no license required) — see https://github.com/gitleaks/gitleaks-action#-announcement

## Test plan

- [ ] PR opened — `ci-result` passes despite `gitleaks` showing as skipped
- [ ] no other workflow_run consumer references gitleaks job result (verified: only `monitor-allure` watches `pr-gate.yml` artifacts, which are unrelated to gitleaks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)