### PR TITLE
chore(ci): consolidate 5 push:dev workflows into post-merge.yml caller

### DIFF
--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -17,6 +17,7 @@
 | `monitor-` | 운영·테스트 시스템 헬스 이상 (스케줄) | `monitor-db-invariants`, `monitor-event-flow-hourly`, `monitor-event-flow-daily`, `monitor-mds-render-coverage`, `monitor-patrol-e2e`, `monitor-allure` |
 | `sync-` | repo 에 자동 commit/push 가 실패함 (dev push 또는 merge 기반) | `sync-version`, `sync-graphify`, `sync-mds-mockups`, `sync-pr-branches`, `sync-test-coverage` |
 | `triage-` | 이슈 생성·슬래시 명령 (commit 없음) | `triage-mds-issue`, `triage-slash` |
+| `post-merge` | dev push 직후 follow-up 자동화의 단일 entry point (5 reusable orchestrator) | `post-merge` |
 | `tool-` | (수동으로 부를 때만 도는 도구) | (현재 없음 — 새 수동 도구 추가 시 prefix) |
 | `shared-` | (다른 워크플로우의 부품 — 단독 실행 X) | `shared-notify`, `shared-android-deploy` |
 
@@ -37,4 +38,4 @@
 - [CLAUDE.md](../../CLAUDE.md) `## PR Conventions` — required check (`ci-result` job = `pr-gate.yml` 내부) / auto-merge 흐름
 
 ---
-_Reviewed: 2026-05-17 22:50_
+_Reviewed: 2026-05-19 01:13_

--- a/.github/workflows/monitor-deno-coverage.yml
+++ b/.github/workflows/monitor-deno-coverage.yml
@@ -4,12 +4,9 @@ name: monitor-deno-coverage
 # coverage.ts 자체는 제외 (self-loop 방지)
 # 같은 동작 PR 마다는 pr-gate 의 test-edge-functions 잡이 diff-cover 로 별도 처리
 
+# Invoked by post-merge.yml on push to dev (paths filter applied at caller level).
 on:
-  push:
-    branches: [dev]
-    paths:
-      - 'supabase/functions/**'
-      - '!supabase/functions/_coverage/**'
+  workflow_call:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,0 +1,99 @@
+# Post-merge orchestrator — single push:dev entry point for follow-up automation that
+# previously lived in 5 separate workflows (sync-pr-branches, triage-mds-issue,
+# sync-mds-mockups, monitor-deno-coverage, sync-test-coverage). Each is now reusable
+# (workflow_call) and gated here by a coarse dorny/paths-filter so unchanged areas
+# pay zero runner time. The reusables keep their workflow_dispatch trigger for manual
+# reruns; only their push:dev trigger moved here.
+#
+# sync-graphify (independent schedule) and sync-version (pull_request: closed) are
+# deliberately NOT consolidated — different trigger semantics.
+
+name: post-merge
+
+on:
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+# Union of permissions needed across all called reusables; each reusable still declares
+# its own narrower permissions at job level (those take precedence).
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      mds_specs: ${{ steps.filter.outputs.mds_specs }}
+      mds_mockups: ${{ steps.filter.outputs.mds_mockups }}
+      supabase_functions: ${{ steps.filter.outputs.supabase_functions }}
+      flutter: ${{ steps.filter.outputs.flutter }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          # On workflow_dispatch with no base, paths-filter treats all files as
+          # changed → every reusable runs. Intentional: manual rerun = "run all".
+          filters: |
+            mds_specs:
+              - 'apps/mds/docs/public/specs/**'
+              - 'apps/mds/docs/src/lib/components.ts'
+              - 'apps/mds/docs/src/components/specs/**'
+            mds_mockups:
+              - 'apps/mds/docs/public/specs/**/index.html'
+              - 'apps/mds/docs/public/specs/**.css'
+              - 'apps/mds/docs/scripts/render-spec-mockups.js'
+              - 'shared/packages/mds/tokens/lib/generated/tokens.css'
+            supabase_functions:
+              - 'supabase/functions/**'
+              - '!supabase/functions/_coverage/**'
+            flutter:
+              - 'apps/app_user/lib/**'
+              - 'apps/app_user/test/**'
+              - 'apps/app_user/pubspec.yaml'
+              - 'apps/app_partner/lib/**'
+              - 'apps/app_partner/test/**'
+              - 'apps/app_partner/pubspec.yaml'
+              - 'shared/packages/minglit_kit/lib/**'
+              - 'shared/packages/minglit_kit/test/**'
+              - 'shared/packages/minglit_kit/pubspec.yaml'
+
+  # No paths gate: previously fired on every push:dev regardless of files.
+  sync-pr-branches:
+    uses: ./.github/workflows/sync-pr-branches.yml
+    secrets: inherit
+
+  # Push-event-only: reusable consumes github.event.before for diff computation, which
+  # is unset under workflow_dispatch (would diff against full tree).
+  triage-mds-issue:
+    needs: changes
+    if: github.event_name == 'push' && needs.changes.outputs.mds_specs == 'true'
+    uses: ./.github/workflows/triage-mds-issue.yml
+    secrets: inherit
+
+  # workflow_dispatch fallback: dorny/paths-filter has no usable base on manual triggers
+  # (dev vs dev = empty diff), so its outputs would be 'false' and all jobs would skip.
+  # The OR makes "manual rerun" = "run everything", which matches the prior per-workflow
+  # workflow_dispatch behavior callers will expect.
+  sync-mds-mockups:
+    needs: changes
+    if: needs.changes.outputs.mds_mockups == 'true' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/sync-mds-mockups.yml
+    secrets: inherit
+
+  monitor-deno-coverage:
+    needs: changes
+    if: needs.changes.outputs.supabase_functions == 'true' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/monitor-deno-coverage.yml
+    secrets: inherit
+
+  sync-test-coverage:
+    needs: changes
+    if: needs.changes.outputs.flutter == 'true' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/sync-test-coverage.yml
+    secrets: inherit

--- a/.github/workflows/sync-mds-mockups.yml
+++ b/.github/workflows/sync-mds-mockups.yml
@@ -1,13 +1,8 @@
 name: sync-mds-mockups
 
+# Invoked by post-merge.yml on push to dev (paths filter applied at caller level).
 on:
-  push:
-    branches: [dev]
-    paths:
-      - 'apps/mds/docs/public/specs/**/index.html'
-      - 'apps/mds/docs/public/specs/**.css'
-      - 'apps/mds/docs/scripts/render-spec-mockups.js'
-      - 'shared/packages/mds/tokens/lib/generated/tokens.css'
+  workflow_call:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/sync-pr-branches.yml
+++ b/.github/workflows/sync-pr-branches.yml
@@ -1,8 +1,9 @@
 name: sync-pr-branches
 
+# Invoked by post-merge.yml on push to dev. workflow_dispatch retained for manual reruns.
 on:
-  push:
-    branches: [dev]
+  workflow_call:
+  workflow_dispatch:
 
 # Fix #1972: permissions moved to job level (minimum necessary scope)
 # Workflow-level permissions removed to avoid granting write access to all jobs.

--- a/.github/workflows/sync-test-coverage.yml
+++ b/.github/workflows/sync-test-coverage.yml
@@ -5,19 +5,11 @@ name: sync-test-coverage
 #
 # 매트릭스로 변경된 프로젝트만 측정해서 noise 줄임. 변경 없으면 commit skip.
 
+# Invoked by post-merge.yml on push to dev (paths filter applied at caller level).
+# Internal matrix still re-filters per-project via the nested `changes` job, so the outer
+# caller-level filter is intentionally coarse (any flutter file → call this workflow).
 on:
-  push:
-    branches: [dev]
-    paths:
-      - 'apps/app_user/lib/**'
-      - 'apps/app_user/test/**'
-      - 'apps/app_user/pubspec.yaml'
-      - 'apps/app_partner/lib/**'
-      - 'apps/app_partner/test/**'
-      - 'apps/app_partner/pubspec.yaml'
-      - 'shared/packages/minglit_kit/lib/**'
-      - 'shared/packages/minglit_kit/test/**'
-      - 'shared/packages/minglit_kit/pubspec.yaml'
+  workflow_call:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/triage-mds-issue.yml
+++ b/.github/workflows/triage-mds-issue.yml
@@ -1,12 +1,10 @@
 name: triage-mds-issue
 
+# Invoked by post-merge.yml on push to dev (paths filter applied at caller level).
+# Relies on github.event.before/head_commit; only safe under push context — caller gates with
+# `if: github.event_name == 'push'` so workflow_dispatch on the caller does not call this.
 on:
-  push:
-    branches: [dev]
-    paths:
-      - 'apps/mds/docs/public/specs/**'
-      - 'apps/mds/docs/src/lib/components.ts'
-      - 'apps/mds/docs/src/components/specs/**'
+  workflow_call:
 
 concurrency:
   group: triage-mds-issue-${{ github.ref }}


### PR DESCRIPTION
## Summary

5 independent `push: dev` workflows → 1 caller (`post-merge.yml`) + 5 reusable (`workflow_call`).

Consolidated:
- `sync-pr-branches`
- `triage-mds-issue`
- `sync-mds-mockups`
- `monitor-deno-coverage`
- `sync-test-coverage`

Not touched (different trigger semantics, defer):
- `sync-graphify` (independent schedule)
- `sync-version` (`pull_request: closed`)

## Mechanics

- Caller (`post-merge.yml`) has a single `changes` job using `dorny/paths-filter@v4` to compute which areas changed (mds_specs, mds_mockups, supabase_functions, flutter).
- Each reusable is gated by an `if:` on the matching output. Manual `workflow_dispatch` on the caller adds `|| github.event_name == 'workflow_dispatch'` to bypass the filter (matches the prior per-workflow dispatch UX).
- `sync-pr-branches` runs unconditionally (no paths filter), matching its prior behavior.
- `triage-mds-issue` is `push`-event-only because it consumes `github.event.before`; the caller gates it with `if: github.event_name == 'push' && ...`.
- Each reusable keeps its `workflow_dispatch` trigger where it had one — direct manual dispatch on the individual workflow still works.
- `permissions:` declared at caller level as the union of reusable needs (contents/pull-requests/issues: write); each reusable still declares its own narrower job-level permissions.

## Expected impact

- Single workflow run per `push: dev` instead of up to 5 → cleaner Actions UI, lower dispatch latency.
- Runner-time roughly equivalent (each gated job still consumes the same slots when its area changes).
- Concurrency groups using `${{ github.workflow }}` now resolve to `post-merge` for these jobs (was their individual workflow name); functionally equivalent serialization, just a different group label.

## Test plan

- [ ] Merge this PR → push to dev triggers `post-merge.yml` exactly once
- [ ] `changes` job correctly reports per-area outputs
- [ ] Gated reusables fire only when their area changed; `sync-pr-branches` fires every push
- [ ] Manual `workflow_dispatch` on `post-merge.yml` runs every reusable except `triage-mds-issue`
- [ ] Manual `workflow_dispatch` directly on `sync-mds-mockups.yml` / `monitor-deno-coverage.yml` / `sync-test-coverage.yml` / `sync-pr-branches.yml` still works (each reusable kept its own workflow_dispatch)
- [ ] No double-fire (the old per-workflow `push: dev` triggers were removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)