### PR TITLE
chore(ci): consolidate 6 static check jobs into one static-checks job

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -14,12 +14,31 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Migration version 중복 검사 (항상 실행 — path filter 없음)
-  check-migration-versions:
+  # Consolidated fast read-only static checks: 6 verifications that previously each
+  # ran in its own ubuntu-latest job (migration version uniqueness + same-day gap
+  # warning, env-manifest ↔ EnvKeyStore drift, workflow YAML parse validity,
+  # androidx.test runner/orchestrator version alignment, cross-feature import
+  # baseline, BLUEDOC freshness).
+  #
+  # Why merge: each separate job paid runner startup + actions/checkout overhead
+  # (~10-15s × 6 = ~70s of Actions minutes per PR). Combined into one job with a
+  # shared checkout, that overhead is paid once. Wall time increases (checks run
+  # sequentially instead of in parallel) by ~30-60s, but Actions minute usage and
+  # workflow file complexity both drop.
+  #
+  # `if: ${{ !cancelled() }}` on each step lets later checks run after earlier
+  # failures so the PR author sees the full failure list, not just the first one.
+  static-checks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # BLUEDOC freshness needs history for base-ref diff
+
       - name: Check duplicate migration versions
+        if: ${{ !cancelled() }}
         run: |
           VERSIONS=$(ls supabase/migrations/*.sql 2>/dev/null | xargs -n1 basename | cut -c1-14 | sort)
           DUPES=$(echo "$VERSIONS" | uniq -d)
@@ -29,7 +48,9 @@ jobs:
             exit 1
           fi
           echo "✅ All migration versions unique ($(echo "$VERSIONS" | wc -l | tr -d ' ') files checked)"
+
       - name: Warn on same-day sequence gaps
+        if: ${{ !cancelled() }}
         run: |
           GAP_FOUND=false
           for DATE in $(ls supabase/migrations/*.sql 2>/dev/null | xargs -n1 basename | sed 's/^\([0-9]\{8\}\).*/\1/' | sort -u); do
@@ -48,13 +69,66 @@ jobs:
           fi
           echo "✅ Sequence gap check complete"
 
-  # env-manifest.json ↔ EnvKeyStore drift 검사 (항상 실행 — path filter 없음)
-  check-env-manifest-sync:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
       - name: Check env-manifest.json / EnvKeyStore sync
+        if: ${{ !cancelled() }}
         run: bash scripts/check-env-manifest-sync.sh
+
+      - name: Validate all workflow YAML files
+        if: ${{ !cancelled() }}
+        run: |
+          FAILED=0
+          for f in .github/workflows/*.yml; do
+            if python3 -c "import yaml, sys; yaml.safe_load(open(sys.argv[1]))" "$f" 2>/dev/null; then
+              echo "✅ $f"
+            else
+              echo "❌ YAML parse error: $f"
+              FAILED=1
+            fi
+          done
+          if [ "$FAILED" = "1" ]; then
+            echo ""
+            echo "One or more workflow files failed YAML parsing."
+            exit 1
+          fi
+          echo "✅ All workflow YAML files are valid"
+
+      - name: Verify androidx.test runner/orchestrator version alignment
+        if: ${{ !cancelled() }}
+        # Fix #1780: runner와 orchestrator는 동일 major.minor 계열이어야 함 — Gradle
+        # consistent resolution이 혼용 시 빌드 실패를 발생시키므로 사전 차단.
+        run: |
+          GRADLE_FILE="apps/app_user/android/app/build.gradle.kts"
+          RUNNER=$(grep 'androidx\.test:runner:' "$GRADLE_FILE" | grep -oP '\d+\.\d+\.\d+' | head -1)
+          ORCHESTRATOR=$(grep 'androidx\.test:orchestrator:' "$GRADLE_FILE" | grep -oP '\d+\.\d+\.\d+' | head -1)
+          echo "runner: $RUNNER"
+          echo "orchestrator: $ORCHESTRATOR"
+          if [ -z "$RUNNER" ] || [ -z "$ORCHESTRATOR" ]; then
+            echo "❌ Could not parse runner or orchestrator version from $GRADLE_FILE"
+            exit 1
+          fi
+          RUNNER_MINOR=$(echo "$RUNNER" | cut -d. -f1,2)
+          ORCHESTRATOR_MINOR=$(echo "$ORCHESTRATOR" | cut -d. -f1,2)
+          if [ "$RUNNER_MINOR" != "$ORCHESTRATOR_MINOR" ]; then
+            echo "❌ Version mismatch: runner $RUNNER vs orchestrator $ORCHESTRATOR"
+            echo "Both must share the same major.minor series (e.g., both 1.5.x or both 1.6.x)"
+            exit 1
+          fi
+          echo "✅ runner $RUNNER and orchestrator $ORCHESTRATOR are compatible ($RUNNER_MINOR series)"
+
+      - name: Check cross-feature imports
+        if: ${{ !cancelled() }}
+        # Fix #1872: block new cross-feature imports; existing violations grandfathered in baseline.
+        run: bash scripts/check-cross-feature-imports.sh
+
+      - name: Check BLUEDOC freshness
+        if: ${{ !cancelled() }}
+        # 새 파일/폴더 추가 또는 파일 삭제 시 가장 가까운 ancestor BLUEDOC.md 갱신 강제.
+        # 통과: 이정표 표 갱신 또는 BLUEDOC 의 '_Reviewed_' 날짜 bump.
+        env:
+          BASE_REF: origin/${{ github.event.pull_request.base.ref || 'dev' }}
+        run: |
+          git fetch origin "${BASE_REF#origin/}" --depth=50 || true
+          bash .github/scripts/check-bluedoc-freshness.sh
 
   # 변경 사항 감지 Job
   changes:
@@ -578,63 +652,8 @@ jobs:
         if: always()
         run: supabase stop --no-backup || true
 
-  # Workflow YAML 파싱 검증 (항상 실행 — db-invariants #1593 회귀 방지)
-  check-workflow-yaml:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Validate all workflow YAML files
-        run: |
-          FAILED=0
-          for f in .github/workflows/*.yml; do
-            if python3 -c "import yaml, sys; yaml.safe_load(open(sys.argv[1]))" "$f" 2>/dev/null; then
-              echo "✅ $f"
-            else
-              echo "❌ YAML parse error: $f"
-              FAILED=1
-            fi
-          done
-          if [ "$FAILED" = "1" ]; then
-            echo ""
-            echo "One or more workflow files failed YAML parsing."
-            exit 1
-          fi
-          echo "✅ All workflow YAML files are valid"
-
-  # Fix #1780: androidx.test runner/orchestrator 버전 정합성 검증
-  # runner와 orchestrator는 동일 major.minor 계열이어야 함 (1.5.x↔1.5.x, 1.6.x↔1.6.x)
-  # Gradle consistent resolution이 혼용 시 빌드 실패를 발생시키므로 PR 단계에서 사전 차단.
-  check-android-test-deps:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Verify androidx.test runner/orchestrator version alignment
-        run: |
-          GRADLE_FILE="apps/app_user/android/app/build.gradle.kts"
-          RUNNER=$(grep 'androidx\.test:runner:' "$GRADLE_FILE" | grep -oP '\d+\.\d+\.\d+' | head -1)
-          ORCHESTRATOR=$(grep 'androidx\.test:orchestrator:' "$GRADLE_FILE" | grep -oP '\d+\.\d+\.\d+' | head -1)
-          echo "runner: $RUNNER"
-          echo "orchestrator: $ORCHESTRATOR"
-          if [ -z "$RUNNER" ] || [ -z "$ORCHESTRATOR" ]; then
-            echo "❌ Could not parse runner or orchestrator version from $GRADLE_FILE"
-            exit 1
-          fi
-          RUNNER_MINOR=$(echo "$RUNNER" | cut -d. -f1,2)
-          ORCHESTRATOR_MINOR=$(echo "$ORCHESTRATOR" | cut -d. -f1,2)
-          if [ "$RUNNER_MINOR" != "$ORCHESTRATOR_MINOR" ]; then
-            echo "❌ Version mismatch: runner $RUNNER vs orchestrator $ORCHESTRATOR"
-            echo "Both must share the same major.minor series (e.g., both 1.5.x or both 1.6.x)"
-            exit 1
-          fi
-          echo "✅ runner $RUNNER and orchestrator $ORCHESTRATOR are compatible ($RUNNER_MINOR series)"
-
-  # Fix #1872: block new cross-feature imports; existing violations are grandfathered in baseline
-  check-cross-feature-imports:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Check cross-feature imports
-        run: bash scripts/check-cross-feature-imports.sh
+  # check-workflow-yaml, check-android-test-deps, check-cross-feature-imports
+  # consolidated into `static-checks` job at top of this file.
 
   # Gitleaks secret scan — formerly pr-setup-secret-scan.yml, absorbed into pr-gate as a required check.
   # Disabled 2026-05-19: post-org-transfer (Mark-Yun → team-minglit), gitleaks-action@v2 requires a
@@ -656,23 +675,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml
 
-  # BLUEDOC freshness: 새 파일/폴더 추가 또는 파일 삭제 시 가장 가까운 ancestor BLUEDOC.md
-  # 갱신 강제. 통과: 이정표 표 갱신 또는 BLUEDOC 의 '_Reviewed_' 날짜 bump.
-  # Format: 모든 BLUEDOC.md 가 '_Reviewed: YYYY-MM-DD HH:MM_' 줄 포함.
-  check-bluedoc-freshness:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0  # diff 비교에 history 필요
-      - name: Run BLUEDOC freshness check
-        env:
-          BASE_REF: origin/${{ github.event.pull_request.base.ref || 'dev' }}
-        run: |
-          git fetch origin "${BASE_REF#origin/}" --depth=50 || true
-          bash .github/scripts/check-bluedoc-freshness.sh
+  # check-bluedoc-freshness consolidated into `static-checks` job at top of this file.
 
   # CUJ integration tests on emulator — reusable workflow.
   # Engine + BLUEDOC: apps/<app>/integration_test/cuj/BLUEDOC.md
@@ -696,7 +699,7 @@ jobs:
     secrets: inherit
 
   ci-result:
-    needs: [check-migration-versions, check-env-manifest-sync, check-workflow-yaml, check-android-test-deps, check-cross-feature-imports, gitleaks, check-bluedoc-freshness, test-flutter-apps, test-integration-app-user-cuj, test-integration-app-partner-cuj, lint-landing-user, lint-landing-partner, lint-mds-docs, lint-mds-icons, test-supabase, test-edge-functions, test-ef-integration]
+    needs: [static-checks, gitleaks, test-flutter-apps, test-integration-app-user-cuj, test-integration-app-partner-cuj, lint-landing-user, lint-landing-partner, lint-mds-docs, lint-mds-icons, test-supabase, test-edge-functions, test-ef-integration]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Merge 6 separate ubuntu-latest static-check jobs into a single `static-checks` job with each check as a named step. Each step uses `if: \${{ !cancelled() }}` so a failure in one does not skip later checks — the PR author sees the full list of issues at once.

## Changes

- **Removed jobs** (consolidated into `static-checks`):
  - `check-migration-versions`
  - `check-env-manifest-sync`
  - `check-workflow-yaml`
  - `check-android-test-deps`
  - `check-cross-feature-imports`
  - `check-bluedoc-freshness`
- **Added job**: `static-checks` (ubuntu-latest, single shared checkout with `fetch-depth: 0`, 7 named check steps)
- **`ci-result.needs`** simplified: 17 entries → 12 (static-checks replaces the 6 above)

## Trade-offs (intentional)

| | Before | After |
|---|---|---|
| Actions minutes per PR | ~6 × (startup + checkout) ≈ ~70s overhead | 1 × overhead ≈ ~12s |
| Wall time | max(check_1..check_6) ≈ ~30s | sum(check_1..check_6) ≈ ~60-90s |
| PR UI check count | 6 individual ✅/❌ | 1 ✅/❌ (drill into job log for per-step) |
| ubuntu-latest concurrent slots | 6 | 1 (frees 5 slots for lint-*/test-*) |

PR feedback latency goes up ~30-60s. In exchange the Actions-minute cost drops, the shared checkout removes 5 redundant clones, and 5 concurrent ubuntu-latest slots are freed for the heavier parallel jobs in the same workflow.

## Test plan

- [ ] static-checks job appears once in pr-gate workflow run
- [ ] All 7 check steps execute in order (visible in job log)
- [ ] When one step fails, subsequent steps still run
- [ ] Job overall fails if any step fails
- [ ] ci-result passes when static-checks passes (and all other jobs pass)
- [ ] BLUEDOC freshness still works (needs fetch-depth: 0 + base-ref fetch)

## Conflict note

Touches `ci-result.needs` (same line as #2625 and #2627). Whichever merges last needs a trivial conflict resolve to combine the needs arrays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)