### PR TITLE
chore(ci): migrate all self-hosted runners to GitHub-hosted (ubuntu-latest)

### DIFF
--- a/.github/workflows/deploy-dev-seed.yml
+++ b/.github/workflows/deploy-dev-seed.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   seed:
     name: Run Seeder
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     # Safety Guard 1: Only run on dev branch, or if manually triggered.
     # Also ensures the triggering workflow (migrations) was successful.
     if: >

--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   deploy-app_user:
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' && 'production' || 'preview' }}
     outputs:
       accessible-url: ${{ steps.deploy.outputs.accessible-url }}
@@ -51,7 +51,7 @@ jobs:
           STATSIG_CLIENT_KEY: ${{ secrets.STATSIG_CLIENT_KEY }}
 
   deploy-landing_user:
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' && 'production' || 'preview' }}
     outputs:
       accessible-url: ${{ steps.deploy.outputs.accessible-url }}
@@ -71,7 +71,7 @@ jobs:
           deploy-branch: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name }}
 
   deploy-landing_partner:
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' && 'production' || 'preview' }}
     outputs:
       accessible-url: ${{ steps.deploy.outputs.accessible-url }}
@@ -91,7 +91,7 @@ jobs:
           deploy-branch: ${{ (github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name }}
 
   deploy-app_partner:
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' && 'production' || 'preview' }}
     outputs:
       accessible-url: ${{ steps.deploy.outputs.accessible-url }}
@@ -125,7 +125,7 @@ jobs:
   # 3. Add GitHub Actions secret: VERCEL_MDS_DOCS_PROJECT_ID = <project-id>
   # The VERCEL_TOKEN and VERCEL_ORG_ID secrets are already shared.
   deploy-mds_docs:
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' && 'production' || 'preview' }}
     outputs:
       accessible-url: ${{ steps.deploy.outputs.accessible-url }}
@@ -147,7 +147,7 @@ jobs:
   smoke-test:
     needs: [deploy-app_user, deploy-landing_user, deploy-landing_partner, deploy-app_partner, deploy-mds_docs]
     if: success()
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     env:
       IS_PROD: ${{ ((github.event_name == 'workflow_dispatch' && inputs.branch) || github.ref_name) == 'main' }}
     steps:

--- a/.github/workflows/doc-freshness.yml
+++ b/.github/workflows/doc-freshness.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   scan:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/monitor-allure.yml
+++ b/.github/workflows/monitor-allure.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   generate-report:
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:

--- a/.github/workflows/monitor-cuj-coverage.yml
+++ b/.github/workflows/monitor-cuj-coverage.yml
@@ -18,13 +18,14 @@ permissions:
 
 jobs:
   coverage:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          cache: true
 
       - name: Run coverage report (JSON)
         id: cov

--- a/.github/workflows/monitor-db-invariants.yml
+++ b/.github/workflows/monitor-db-invariants.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   check:
     name: Run DB invariant checks
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/monitor-deno-coverage.yml
+++ b/.github/workflows/monitor-deno-coverage.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   coverage:
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: write

--- a/.github/workflows/monitor-event-flow-daily.yml
+++ b/.github/workflows/monitor-event-flow-daily.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   seed-and-simulate:
     name: Seed + event-flow cascade (daily)
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/monitor-event-flow-hourly.yml
+++ b/.github/workflows/monitor-event-flow-hourly.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   simulate:
     name: Run event-flow cascade (hourly smoke)
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Invoke event-flow-simulator

--- a/.github/workflows/monitor-mds-render-coverage.yml
+++ b/.github/workflows/monitor-mds-render-coverage.yml
@@ -18,13 +18,14 @@ permissions:
 
 jobs:
   coverage:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          cache: true
 
       - name: Run coverage report (JSON)
         id: cov

--- a/.github/workflows/monitor-patrol-e2e.yml
+++ b/.github/workflows/monitor-patrol-e2e.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   patrol-e2e-app-user:
-    runs-on: [self-hosted, android]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -56,6 +56,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          cache: true
 
       - name: Install patrol_cli
         run: dart pub global activate patrol_cli

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -193,7 +193,7 @@ jobs:
     name: test-app-unit-widget-golden
     needs: changes
     if: ${{ needs.changes.outputs.app_user == 'true' || needs.changes.outputs.app_partner == 'true' || needs.changes.outputs.minglit_kit == 'true' || needs.changes.outputs.mds_core == 'true' }}
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       checks: write
@@ -238,14 +238,19 @@ jobs:
           # persist-credentials: false keeps the PAT out of git config during pub get,
           # analyze, and test steps; the PAT is injected only in the push step below.
           persist-credentials: false
-      # Flutter SDK + pub-cache come from a host bind volume on the
-      # self-hosted runner (toolcache + .pub-cache mounts in
-      # minglit-github-workflow-runner). The action's `cache: true` and
-      # the explicit actions/cache@v5 for ~/.pub-cache are redundant.
       - uses: subosito/flutter-action@v2
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         with:
           channel: 'stable'
+          cache: true
+      - name: Cache pub packages
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
+        uses: actions/cache@v5
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
       - name: Install dependencies
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         run: flutter pub get
@@ -472,7 +477,7 @@ jobs:
     name: test-pgtap
     needs: changes
     if: ${{ needs.changes.outputs.supabase == 'true' }}
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: supabase/setup-cli@v2
@@ -482,6 +487,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          cache: true
       # Wipe any volume left by a prior run on this host so `supabase start`
       # initializes a fresh DB and auto-applies all migrations from scratch.
       # Required on shared self-hosted runners — otherwise the next start
@@ -612,7 +618,7 @@ jobs:
     name: test-ef-integration
     needs: changes
     if: ${{ needs.changes.outputs.supabase == 'true' }}
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr-review-setup.yml
+++ b/.github/workflows/pr-review-setup.yml
@@ -29,7 +29,7 @@ jobs:
     if: >-
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.fork == false
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     steps:
       - name: Enable squash auto-merge
         env:

--- a/.github/workflows/shared-android-deploy.yml
+++ b/.github/workflows/shared-android-deploy.yml
@@ -61,7 +61,7 @@ on:
 
 jobs:
   build:
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
     defaults:
       run:
@@ -82,6 +82,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          cache: true
 
       - name: Cache Gradle
         uses: actions/cache@v5

--- a/.github/workflows/shared-cuj-integration.yml
+++ b/.github/workflows/shared-cuj-integration.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   cuj-integration:
-    runs-on: [self-hosted, android]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -57,6 +57,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          cache: true
 
       # Self-hosted runner: Flutter SDK cache dir 가 다른 user 소유 → git 거부.
       # safe.directory를 '*'로 열지 않고 Flutter SDK 경로만 허용 (Fix #2499).

--- a/.github/workflows/shared-notify.yml
+++ b/.github/workflows/shared-notify.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   notify:
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     permissions:
       issues: write
     steps:

--- a/.github/workflows/sync-graphify.yml
+++ b/.github/workflows/sync-graphify.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   update:
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/sync-mds-mockups.yml
+++ b/.github/workflows/sync-mds-mockups.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   render:
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/sync-pr-branches.yml
+++ b/.github/workflows/sync-pr-branches.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   update-branches:
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     # Fix #1972: job-level permissions — only what update-branch needs
     permissions:
       contents: write

--- a/.github/workflows/sync-test-coverage.yml
+++ b/.github/workflows/sync-test-coverage.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
@@ -51,7 +51,7 @@ jobs:
 
   coverage:
     needs: changes
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     strategy:
@@ -83,6 +83,7 @@ jobs:
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         with:
           channel: 'stable'
+          cache: true
 
       - name: Install dependencies
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}

--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -18,7 +18,7 @@ jobs:
     if: >-
       github.event.pull_request.merged == true &&
       !startsWith(github.event.pull_request.title, 'chore: bump version')
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/triage-mds-issue.yml
+++ b/.github/workflows/triage-mds-issue.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   file-issue:
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/triage-slash.yml
+++ b/.github/workflows/triage-slash.yml
@@ -13,7 +13,7 @@ jobs:
       github.event.issue.pull_request == null &&
       contains(github.event.comment.body, '/needs-') &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-    runs-on: [self-hosted, ephemeral]
+    runs-on: ubuntu-latest
     concurrency:
       group: triage-slash-issue-${{ github.event.issue.number }}
       cancel-in-progress: false


### PR DESCRIPTION
## Summary

Move every `runs-on: self-hosted*` job to `runs-on: ubuntu-latest`. The self-hosted pool stopped accepting registrations after the `Mark-Yun` → `team-minglit` org transfer (POST `/actions/runner-registration` returns 404 because GitHub does not redirect that endpoint), and the repo is now public so GitHub Actions minutes are free.

## Changes

**Squashed two patches:**

1. **Revert #2607** (`perf(ci): drop redundant Flutter/pub cache on self-hosted`) — restores `cache: true` on every `subosito/flutter-action@v2` and the explicit `actions/cache@v5` for `~/.pub-cache`. Removed because the self-hosted pool had a host-bind toolcache; GitHub-hosted runners are fresh per run, so caching is needed again.
2. **runs-on swap** — 32 jobs across 24 workflow files:
   - `[self-hosted, ephemeral]` (25 jobs) → `ubuntu-latest`
   - `[self-hosted, android]` (2 jobs) → `ubuntu-latest`
   - `self-hosted` (5 jobs) → `ubuntu-latest`

`macos-15` jobs (iOS deploys) left alone.

## Conflict resolutions

- `pr-setup-format.yml` was deleted by #2627 — revert's edit to that file was discarded.
- `pr-gate.yml lint-mds-icons` had a later-added `actions/cache@v5` step (from #2623); kept HEAD's version.

## Why this works without further changes

The codebase already has dual-environment scaffolding for the trickiest jobs:
- `shared-cuj-integration.yml` and `monitor-patrol-e2e.yml` gate their KVM-enablement step on `runner.environment == 'github-hosted'` (added in #2558). The Android emulator step uses `reactivecircus/android-emulator-runner@v2`, which works on both environments. After this PR, ubuntu-latest → environment is `'github-hosted'` → KVM setup fires correctly.
- Self-hosted-only steps (`Reset stale Supabase state`, `Allow git access to Flutter SDK dir`) are no-ops on github-hosted (`supabase stop || true`, idempotent safe.directory add).

## Performance expectations

GitHub-hosted ubuntu-latest doesn't have the baked Flutter SDK that the self-hosted pool had. With `cache: true` restored:
- Cold cache: ~60-80s Flutter download per fresh runner
- Warm cache: ~5-10s (action detects cache hit)

Android emulator on GitHub-hosted with KVM: comparable speed to self-hosted with KVM passthrough. CUJ integration jobs run 8-15 min in either environment.

## Operational notes

- **Self-hosted decommission:** the runner pool can stay dead. Workflows no longer depend on it.
- **18 stuck queued runs** (waiting for self-hosted, never going to run) were cancelled via API before opening this PR — they were noise.
- **Self-hosted runner repo** (`minglit-github-workflow-runner`) is unchanged; you can leave it as-is or wind it down at your own pace.

## Test plan

- [ ] PR opens → pr-gate completes on ubuntu-latest, ci-result passes
- [ ] format-check fires only when .dart files change (no regression from #2627)
- [ ] static-checks completes in one job (no regression from #2628)
- [ ] post-merge.yml fires correctly on push to dev after merge (no regression from #2626)
- [ ] After merge, an Android CUJ-touching PR successfully runs shared-cuj-integration on ubuntu-latest with `reactivecircus/android-emulator-runner@v2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)