### PR TITLE
docs(infra): 4-stage branch strategy + 3-tier kill switch (draft)

### DIFF
--- a/docs/infra/branch-strategy/BLUEDOC.md
+++ b/docs/infra/branch-strategy/BLUEDOC.md
@@ -1,0 +1,49 @@
+# Branch Strategy
+
+4-stage (`dev-staging → dev → rc → main`) + merge queue + nightly snapshot + `rc-gate` green build picking + feature flag + 3가지 safety net. AI agent 가 dev-staging commit, backend/web 은 dev rc-gate-pass commit 마다 continuous deploy (Spotify 식), mobile 은 main 에서 월 1회 cut. 모든 cadence = target, slip 자연스러움.
+
+## 4-stage 모델
+
+| 단계 | 역할 | 진입 방식 |
+|------|------|-----------|
+| `dev-staging` | AI agent commit zone | merge queue + 가벼운 `pr-gate` |
+| `dev` | nightly-validated trunk | daily `nightly-cut` → post-merge `rc-gate` |
+| `rc/YYYY-Wxx` | mobile RC, 5일 soak | weekly cut from latest rc-gate-pass |
+| `main` | mobile-stable snapshot | rc → main 머지 (soak 통과 시) |
+
+## Safety Nets 3종
+
+| Safety Net | 정책 / 명세 |
+|------------|-------------|
+| Version kill switch (Tier 2a soft + 2b hard) | 6개월 backward compat, Firebase RC source / [main-promotion.md](./main-promotion.md) |
+| Expand-Migrate-Contract CI | 6개월 DB schema, Option C / [dev-staging-pipeline.md](./dev-staging-pipeline.md) |
+| Flag-registration CI | unflagged 코드 차단 / [dev-staging-pipeline.md](./dev-staging-pipeline.md) |
+
+## 이정표
+
+| 문서 | 내용 |
+|------|------|
+| [branch-flow.md](./branch-flow.md) | flow + protection + tag + backport |
+| [test-strategy.md](./test-strategy.md) | per-stage gates |
+| [error-detection.md](./error-detection.md) | detection layers |
+| [dev-staging-pipeline.md](./dev-staging-pipeline.md) | merge queue + pr-gate + safety net CI |
+| [dev-pipeline.md](./dev-pipeline.md) | nightly-cut + rc-gate + auto-deploy chain |
+| [rc-promotion.md](./rc-promotion.md) | rc-cut + soak + hotfix + backport |
+| [main-promotion.md](./main-promotion.md) | rc → main + mobile-cut + min-version |
+| [life-of-flag.md](./life-of-flag.md) | flag lifecycle |
+| [versioning.md](./versioning.md) | CalVer + tag |
+
+## 역할 (workflow 가 처리 못하는 edge case 만)
+
+**release manager** 비상 min-version bump · workflow-blocked promotion 수동 처리 / **on-call** workflow 자동 복구 실패한 P0 / **feature owner** flag 정책 결정 · cleanup PR review / **RC owner** abandon 판단 (TBD)
+
+## 핵심 컨벤션
+
+- 코드 promotion = 한 방향 PR, 기능 promotion = flag flip
+- 모든 branch linear ON — dev-staging: squash, dev/rc/main: rebase
+- dev rc-gate-pass = backend/web continuous deploy (Spotify 식); mobile = main 에서 월 1회 cut + cherry-pick 자동화 (TBD)
+- **Hotfix 는 rc 에서, dev-staging 으로 자동 backport** ([rc-promotion.md](./rc-promotion.md))
+- Tag regex 는 `RELEASE.md` lock (TODO)
+
+---
+_Reviewed: 2026-05-19 09:47_

--- a/docs/infra/branch-strategy/branch-flow.md
+++ b/docs/infra/branch-strategy/branch-flow.md
@@ -1,0 +1,108 @@
+# Branch Flow
+
+`dev-staging → dev → rc → main` 4-stage 모델의 머지 방향, branch protection, promotion tag, auto-deploy chain.
+
+## 흐름 다이어그램
+
+```
+  agents ──merge queue──▶ dev-staging
+                              │
+                              └─daily nightly-cut snapshot──▶ dev
+                                                              │
+                                                              ├─▶ rc-gate (post-merge 자동)
+                                                              │      │
+                                                              │      ├─ pass: status rc-gate-pass
+                                                              │      │         │
+                                                              │      │         ├─▶ backend-auto-deploy (EF + migration)
+                                                              │      │         └─▶ web-auto-deploy (Vercel 4앱)
+                                                              │      │
+                                                              │      └─ fail: bot 자동 이슈 + AI fix PR 경로
+                                                              │
+                                                              └─weekly rc-cut (최신 rc-gate-pass commit)──▶ rc/YYYY-Wxx
+                                                                                                              │
+                                                                                                              └─5일 soak (hotfix 시 시계 리셋)──▶ main
+                                                                                                                                                    │
+                                                                                                                                                    └─monthly mobile-cut──▶ release/mobile-YYYY-MM
+                                                                                                                                                                                  │
+                                                                                                                                                                                  └─ App Store
+```
+
+**Hotfix backport 흐름** (rc → dev-staging):
+
+```
+rc/* hotfix 머지 ──auto cherry-pick──▶ backport-branch ──PR──▶ dev-staging
+```
+
+상세는 [rc-promotion.md](./rc-promotion.md). Mobile cherry-pick 은 backport 불필요 (main 에서 cherry-pick 한 commit 은 이미 dev-staging 에 존재).
+
+## 단계별 PR 룰
+
+| 머지 방향 | base ← head | 트리거 | 머지 방식 | 요구 체크 |
+|-----------|-------------|--------|-----------|-----------|
+| feature/agent → dev-staging | `dev-staging` ← `feat/*`, `fix/*`, `chore/*`, `docs/*` | merge queue enqueue | **squash** (queue) | `dev-staging-pr-gate` |
+| dev-staging → dev | `dev` ← `dev-staging` | daily cron `nightly-cut` | merge (snapshot) | `nightly-pr-gate` |
+| feature → rc | `rc/YYYY-Wxx` ← hotfix branch | hotfix only | rebase | `rc-pr-gate` |
+| rc → main | `main` ← `rc/YYYY-Wxx` | `rc-soak-check` 가 5일 무커밋 시 PR 생성 + auto-merge | rebase + ff | `main-pr-gate` + `rc-soak-passed` |
+| main → release/mobile-YYYY-MM | branch cut | monthly cron `mobile-cut` | branch 신규 생성 | mobile smoke |
+
+## Branch Protection 설정
+
+| 브랜치 | direct push | linear | required check | merge 종류 |
+|--------|-------------|--------|----------------|------------|
+| `dev-staging` | 금지 | **ON** | `dev-staging-pr-gate` + merge queue | squash |
+| `dev` | 금지 | **ON** | `nightly-pr-gate` | merge (snapshot) |
+| `rc/YYYY-Wxx` | 금지 | **ON** | `rc-pr-gate` | rebase |
+| `main` | 금지 | **ON** | `main-pr-gate` + `rc-gate-pass` (RC HEAD) + `expand-migrate-contract` + `rc-soak-passed` | rebase |
+| `release/mobile-*` | 금지 | ON | mobile smoke | rebase (cherry-pick) |
+
+Hybrid linear history 금지 — 각 branch 내 일관 (squash or rebase 한 가지).
+
+## Promotion Tag 컨벤션
+
+| Tag / Status | 시점 | 예시 | 부여자 |
+|--------------|------|------|--------|
+| `v{ver}-dev-staging` (tag) | dev-staging-post-merge-sync | `v26.05.2572-dev-staging` | workflow |
+| `rc-gate-pass` (commit status) | rc-gate green 시 dev commit 에 | (status only, tag 없음) | workflow |
+| `promo/rc-YYYY-Wxx` (tag) | rc-cut 직후 | `promo/rc-2026-W20` | workflow |
+| `v{ver}-rc-NN` (tag) | rc-cut + hotfix | `v26.05.2572-rc-01`, `v26.05.2585-rc-02` | workflow |
+| `promo/main-YYYY-Wxx` (tag) | main 머지 직후 | `promo/main-2026-W20` | workflow |
+| `v{ver}` (tag) | main 머지 직후 (동시) | `v26.05.2585` | workflow |
+| `release/mobile-YYYY-MM` (branch) | mobile-cut | `release/mobile-2026-05` | workflow |
+
+> **Tag naming regex 는 [`RELEASE.md`](../../../RELEASE.md) lock** (TODO). 외부 도구 (Sentry, Statsig, Vercel) 가 pin → rename = 모든 dashboard 깨짐.
+
+조회: `git tag -l 'v*'`, `git tag -l 'promo/main-*'`, `gh api repos/.../commits/{sha}/status` (rc-gate-pass)
+
+## Auto-deploy Chain
+
+dev 의 `rc-gate-pass` status 가 set 되는 즉시 `rc-gate` workflow 가 `workflow_call` 로 호출:
+
+```yaml
+# 개념
+trigger-deploys:
+  needs: rc-gate (green)
+  parallel:
+    - uses: ./.github/workflows/backend-auto-deploy.yml  # EF + migration
+    - uses: ./.github/workflows/web-auto-deploy.yml      # Vercel 4앱
+```
+
+Mobile 은 별도 cadence — main 에서 monthly cut.
+
+## Safety Nets 위치
+
+| Safety Net | 실행 위치 |
+|------------|-----------|
+| min-version endpoint | server-side, `mobile-cut` 시점에 monthly auto-bump ([main-promotion.md](./main-promotion.md)) |
+| expand-migrate-contract CI | `dev-staging-pr-gate` (destructive op 탐지) + `main-pr-gate` (재검증) |
+| flag-registration CI | `dev-staging-pr-gate` |
+
+## 결정해야 할 것
+
+- 주간 rc-cut 요일
+- monthly mobile-cut 날짜
+- merge queue 모드 (concurrent vs serial)
+- cherry-pick 자동화 도구 선정 (Runway/Xray/자체)
+- `RELEASE.md` 작성
+
+---
+_Reviewed: 2026-05-19 09:47_

--- a/docs/infra/branch-strategy/dev-pipeline.md
+++ b/docs/infra/branch-strategy/dev-pipeline.md
@@ -1,0 +1,148 @@
+# Dev Pipeline
+
+`dev` 브랜치가 trunk 역할: dev-staging 의 daily snapshot 을 받고, post-merge 로 full integration suite (`rc-gate`) 를 돌려, 통과한 commit 마다 backend/web auto-deploy. RC 는 이 status 를 보고 cut.
+
+## 4가지 workflow
+
+1. **`nightly-cut`** — daily cron, dev-staging tip 의 snapshot 으로 PR 생성
+2. **`nightly-pr-gate`** — snapshot PR 머지 전 검증 (defensive)
+3. **`rc-gate`** — dev 머지 후 자동 발동, full integration suite, 통과 시 status `rc-gate-pass` set
+4. **Auto-deploy chain** — `rc-gate-pass` 시점에 `backend-auto-deploy` + `web-auto-deploy` 동시 trigger
+
+## `nightly-cut`
+
+### 트리거 / 동작
+
+- **cron**: 매일 KST 02:00 (TBD)
+- **manual**: `workflow_dispatch`
+- 동작:
+  1. 가장 최근 `v*-dev-staging` 태그 (dev-staging 의 latest coherent snapshot) 찾기
+  2. PR 생성: `chore(promo): dev-staging → dev YYYY-MM-DD` (base=dev, head=dev-staging at that tag)
+  3. `nightly-pr-gate` 자동 발동
+  4. 통과 시 auto-merge (merge — snapshot 보존)
+
+### 슬립 처리
+
+- 이미 dev 가 최신 dev-staging 과 동기화돼 있으면 (= 새 commit 없음) skip
+- 이전 nightly-cut 이 still in progress (드물) → 이번 cron skip + Slack 알림
+
+## `nightly-pr-gate`
+
+`dev-staging-pr-gate` 와 **동일한 test suite**. 환경 차이 회귀만 잡는 defensive 검증. 대부분 통과.
+
+(상세는 [dev-staging-pipeline.md](./dev-staging-pipeline.md))
+
+## `rc-gate` — Heavy Integration
+
+dev 머지 후 자동 발동. 통과 = "이 commit 은 RC 가능 + backend/web prod 배포 가능".
+
+### 무엇을 도는가
+
+매트릭스 병렬. 하나라도 실패 = rc-gate 전체 실패.
+
+| job | 대상 | 비고 |
+|-----|------|------|
+| `cuj-app-user` | `apps/app_user/patrol_test/cuj/*` | `--flavor dev --dart-define-from-file=.../dev/flutter.env` 필수 |
+| `cuj-app-partner` | `apps/app_partner/patrol_test/cuj/*` | 같음 |
+| `integration-backend` | `tests/backend_integration/**` | Supabase staging or ephemeral branch |
+| `integration-edge-functions` | `tests/ef_integration/**` | EF 통합 시나리오 |
+| `simulator-happy` | `tests/simulator/scenarios/happy/*` | cascade prob 0.85~0.95 |
+| `simulator-chaos` | `tests/simulator/scenarios/chaos/*` | chaos mode, 회복 검증 |
+| `test-lab-smoke` | Firebase Test Lab — 실 디바이스 4종 | 디바이스 다양성 보강 |
+
+### 통과 시 (rc-gate-pass)
+
+```
+1. dev HEAD commit 에 GitHub commit status `rc-gate-pass` set
+2. Auto-deploy chain workflow_call:
+   - backend-auto-deploy (EF + migration apply)
+   - web-auto-deploy (Vercel hooks 4앱)
+3. (Mobile 은 deploy 없음 — main 의 monthly cut 에서 처리)
+```
+
+### 실패 시
+
+- Status 미부여 (`rc-gate-pass` 없음 → rc-cut 이 이 commit 안 골라잡음)
+- 자동 이슈 + `P1-high` 라벨 + 직전 `rc-gate-pass` 이후 머지된 PR 작성자들 assignee
+- Bot auto-revert + AI fix flow (다음 섹션)
+
+### 60분 비용 예산
+
+전체 60분 안에. 넘으면: 매트릭스 분할, selective run, weekly 로 이동. macOS matrix 필요 시 ubuntu-latest 와 병행.
+
+## Auto-revert + AI Fix Flow
+
+`rc-gate` 실패 시 정상 cadence 유지를 위한 자동화:
+
+```
+[rc-gate fail on dev commit C]
+        │
+        ├─▶ [봇이 culprit 추정]
+        │       - 휴리스틱: 실패한 test area + 그 area 변경한 PR
+        │       - AI agent 분석 (rc-gate log + diff 컨텍스트)
+        │       - 신뢰도 낮으면 직전 rc-gate-pass 이후 PR 들 모두 후보
+        │
+        ├─▶ [봇이 revert PR 자동 생성] (dev-staging 에 PR 머지)
+        │       └─ 다음 nightly-cut 에서 자동으로 dev 로 promote → 다음 rc-gate
+        │
+        └─▶ [이슈 자동 파일링]
+                  body: revert SHA + rc-gate log + 추정 원인
+                  assignee: 원래 PR 작성자 (AI agent)
+                        │
+                        └─▶ AI 가 fix PR 작성 (revert 된 코드의 forward-fix)
+                              │
+                              └─▶ dev-staging-pr-gate → 정상 flow → 다음 rc-gate 검증
+```
+
+**핵심**: revert 와 fix 는 *경쟁* 아니라 *순차*. revert = stabilization (즉시 dev 회복), fix = resolution (async AI 작업).
+
+## Error-Backoff 정책
+
+**Workflow infra 실패** (`rc-gate` script 에러, runner 다운, deploy hook 실패 등) → **P0 이슈 자동 생성** + on-call. 아래는 *rc-gate test* 실패 escalation.
+
+| 연속 실패 | 동작 |
+|----------|------|
+| 1회 | 자동 revert + 이슈 + Slack `#nightly` |
+| 2회 (같은 area) | 기존 이슈 댓글 누적, assignee reminder, 영역 owner 추가 알림 |
+| 3회 (같은 area) | `rc-gate-degraded` label + **rc-cut workflow 자동 차단** (다음 weekly cut PR 생성 안 함) + Slack `#release` |
+
+**Recovery**: 다음 rc-gate green → 자동 차단 해제, 누적 이슈 verify 코멘트.
+
+## Auto-deploy 워크플로우
+
+### backend-auto-deploy
+
+- Supabase EF 배포 (deno deploy)
+- Migration apply (Supabase CLI)
+- Sentry release marker 부여 (`v{ver}-dev` 형식)
+- 실패 시: retry 1회 → 실패 시 P0 이슈 + on-call
+
+### web-auto-deploy
+
+- Vercel deploy hooks 4앱 (app_user, app_partner, landing_user, landing_partner)
+- 현재 cron 2시간 → push-event 기반으로 교체
+- 실패 시: retry 1회 → 실패 시 P0 이슈
+
+## Artifact / 보존
+
+- 실패한 rc-gate: 30일 (스크린샷, 로그, APK)
+- 성공: 7일
+
+## 결정해야 할 것
+
+- nightly-cut cron 시각
+- AI culprit 식별 도구 (Claude Code agent / 자체 휴리스틱)
+- backoff 임계 (3회 차단이 적정한가)
+- ephemeral Supabase branch (RC 마다 새로 vs 단일 공유)
+- rc-gate selective run 도입 시점
+
+## 관련
+
+- [dev-staging-pipeline.md](./dev-staging-pipeline.md) — dev-staging 의 pr-gate + safety net
+- [rc-promotion.md](./rc-promotion.md) — rc-gate-pass 가 rc-cut 의 source
+- [main-promotion.md](./main-promotion.md) — auto-deploy 실패 시 rollback
+- [test-strategy.md](./test-strategy.md) — rc-gate 의 단계별 위치
+- [branch-flow.md](./branch-flow.md) — auto-deploy chain 그림
+
+---
+_Reviewed: 2026-05-19 09:47_

--- a/docs/infra/branch-strategy/dev-staging-pipeline.md
+++ b/docs/infra/branch-strategy/dev-staging-pipeline.md
@@ -1,0 +1,127 @@
+# Dev-Staging Pipeline
+
+AI agent 와 feature/fix/chore PR 이 `dev-staging` 브랜치로 들어오는 진입점. merge queue 가 직렬 처리하고, `dev-staging-pr-gate` 가 가벼운 검증, 머지 후 `dev-staging-post-merge-sync` 가 version bump.
+
+## 두 가지 workflow
+
+1. **`dev-staging-pr-gate`** — PR 머지 전 (merge queue 가 각 PR rebase 후 실행)
+2. **`dev-staging-post-merge-sync`** — PR 머지 직후 (version bump + tag)
+
+## Merge Queue
+
+GitHub merge queue 가 `dev-staging` 의 PR 을 직렬 처리:
+
+```
+[PR enqueue]
+    ↓
+[PR base 를 최신 dev-staging HEAD 로 rebase]
+    ↓
+[dev-staging-pr-gate 재실행 (rebased state)]
+    ↓
+[통과 시 squash merge to dev-staging]
+    ↓
+[dev-staging-post-merge-sync 자동 발동]
+    ↓
+[다음 PR 처리]
+```
+
+### 왜 merge queue
+
+- Master-green 유지 (Uber Submit Queue: 99%+)
+- Drift / conflict accumulation 회피
+- AI agent 가 동시 다발 PR 작성해도 안전하게 직렬 처리
+- "Update branch" 수동 작업 제거
+
+### 결정해야 할 것
+
+- 모드 (concurrent vs serial)
+- queue stuck 시 escalation
+- 도입 단계 (전체 vs 점진)
+
+## `dev-staging-pr-gate`
+
+빠른 PR 게이트. 10분 안에 끝나는 검사만.
+
+| Check | 도구 | 비고 |
+|-------|------|------|
+| `test-flutter-apps` | Flutter test (matrix: app_user, app_partner) | unit + widget test |
+| `lint-landing-user` | npm lint + build | |
+| `lint-landing-partner` | npm lint + build | |
+| `test-supabase` | pgTAP | DB function test |
+| `test-edge-functions` | Deno test | EF unit test |
+| `check-migration-versions` | shell script | duplicate / gap 검사 |
+| **`expand-migrate-contract`** | shell + 패턴 매칭 (Safety Net) | destructive op 탐지 |
+| **`flag-registration-check`** | AST 분석 (Safety Net) | 새 코드 path 가 flag SDK 참조 |
+| `gitleaks` | secret scanning | |
+| CodeRabbit | AI review | 최대 30분 대기 |
+
+### Safety Net: `expand-migrate-contract`
+
+**정책**: 6개월 backward compat (6 mobile releases). DB schema 만 검증 (Option C — API contract test 는 TBD).
+
+| 탐지 | Bypass |
+|------|--------|
+| `DROP COLUMN`, `DROP TABLE`, `ALTER COLUMN TYPE` 등 destructive SQL pattern | `-- migration-phase: contract` 주석 + 라벨 `migration-contract-justified` + min-version 변경 확인 + 별도 reviewer |
+
+**구현**: `supabase/migrations/*.sql` 파일 grep + AST. 초기엔 정규식 기반 (false positive 가능 → bypass label 자주 쓰임 → 점진 개선).
+
+**현재 상태**: TODO — CI script 작성 + destructive pattern list + 6-month-old client schema 어디 보관할지.
+
+### Safety Net: `flag-registration-check`
+
+새 코드 path 가 flag SDK 를 reference 하지 않으면 PR fail.
+
+| 영역 | 검출 패턴 |
+|------|----------|
+| Backend (EF) | 새 request handler 가 `Statsig.checkGate` or `RemoteConfig.getValue` 미참조 |
+| Mobile (Flutter) | 새 화면/feature widget 같음 (mobile SDK) |
+| Web (landing) | 새 endpoint 같음 |
+
+| Bypass | 조건 |
+|--------|------|
+| `// no-flag: reason` 주석 + 라벨 `unflagged-justified` + 별도 reviewer | infra / security / bug-fix 에 한정 |
+
+**현재 상태**: TODO — AST 검출 로직 + 예외 라벨 운영 룰 + 분기별 우회 통계.
+
+## `dev-staging-post-merge-sync`
+
+PR 머지 직후 자동 발동.
+
+```
+1. bump-version.sh {PR번호}-dev-staging  # 8개 파일 version 일괄 업데이트
+2. git commit -m "chore: bump version to v{ver}-dev-staging [skip ci]"
+3. git tag v{ver}-dev-staging
+4. git push (tag + commit)
+```
+
+Tag `v{ver}-dev-staging` 는 다음 단계의 `nightly-cut` workflow 가 query 해서 "가장 최근 dev-staging 의 coherent snapshot" 찾는 데 사용.
+
+> **구현 디테일**: bump 커밋이 별도로 만들어지는 게 깔끔 vs squash 커밋에 inline 시키는 게 깔끔 — workflow 디자인 결정 (TBD).
+
+## Error-Backoff
+
+**Workflow infra 실패** (merge queue 다운, runner 다운, script 에러) → **P0 이슈** + on-call.
+
+**Test 실패** (PR 단위) → queue 가 PR drop + 작성자 알림. 작성자 fix → re-queue.
+
+### `expand-migrate-contract` false positive
+
+destructive pattern 검출이 too aggressive 한 경우:
+- 우선 bypass label 부여 + reviewer 확인
+- 분기별 retrospective 에서 검출 룰 개선
+
+## 결정해야 할 것
+
+- merge queue 모드 (concurrent / serial)
+- `expand-migrate-contract` 의 6-month-old schema 보관 위치
+- `flag-registration` AST 도구 (analyzer / 자체 / Semgrep?)
+- version bump commit 별도 vs inline
+
+## 관련
+
+- [dev-pipeline.md](./dev-pipeline.md) — dev-staging 의 snapshot 이 dev 로 어떻게 promote
+- [test-strategy.md](./test-strategy.md) — 단계별 게이트 큰 그림
+- [branch-flow.md](./branch-flow.md) — protection + tag
+
+---
+_Reviewed: 2026-05-19 09:47_

--- a/docs/infra/branch-strategy/error-detection.md
+++ b/docs/infra/branch-strategy/error-detection.md
@@ -1,0 +1,88 @@
+# Error Detection
+
+각 단계에서 에러를 어떻게 *detect* 하고, detection → action 까지 얼마나 빨리 가는지. *어떤 테스트* 는 [test-strategy.md](./test-strategy.md), *detect 후 무엇* 은 각 promotion 의 error-backoff 섹션, **이 문서는 detection layer**.
+
+## Layered Detection
+
+| Stage | Detection 도구 | 잡는 에러 | Latency |
+|-------|----------------|----------|---------|
+| 개발자 로컬 | LSP, analyze, unit | 컴파일/타입/단위 | 초~분 |
+| dev-staging merge queue | `dev-staging-pr-gate` (unit, lint, pgTAP, EF, migration, `expand-migrate-contract`, `flag-registration`, gitleaks) | PR 회귀, 보안, migration 충돌, flag 미등록, contract 위반 | < 10분 |
+| nightly-cut PR | `nightly-pr-gate` (defensive) | 환경 차이 회귀 | < 10분 |
+| dev 머지 후 (자동) | `rc-gate` (CUJ, integration, e2e, simulator, Test Lab) | 통합 회귀, 시나리오, 외부 의존, 디바이스 | 30-60분 |
+| Backend/Web auto-deploy | post-deploy smoke, Sentry release marker | deploy infra 회귀 | 분 |
+| rc soak (5일) | rc 의 nightly 재실행 + 내부 dogfooding | 누적 회귀, real-data 이슈 | 일 단위 |
+| main 머지 후 (auto-deploy) | smoke + Sentry/Crashlytics 알람 임계 | prod 회귀 | 분 |
+| mobile-cut 후 | mobile-specific smoke + Test Lab | mobile build 회귀 | 시간 |
+| flag canary (allowlist) | Statsig metric (error rate, crash-free) | 실사용자 회귀 (canary) | 분~시간 |
+| flag staged 5/25/100% | 위 + cohort 비교 | 새 cohort 회귀 | 분~시간 |
+| 100% 운영 | uptime, on-call | infra-level, 장기 회귀 | 분~일 |
+
+## 도구 별 책임
+
+### Sentry
+- Backend / mobile / web 의 unhandled exception, error log
+- Release tagging (`v{ver}` 마커) → "이 commit 부터 새 에러" 추적
+- Alert: error rate spike, new issue
+
+### Firebase Crashlytics
+- Mobile crash (native crash, isolate crash)
+- Crash-free rate — **mobile 가장 신뢰성 높은 신호**
+- 상세: [../firebase/BLUEDOC.md](../firebase/BLUEDOC.md)
+
+### Firebase Test Lab
+- 실 디바이스 farm 에서 CUJ/smoke
+- `rc-gate` 의 mobile 부분 일부 위임
+- 상세: [../firebase/BLUEDOC.md](../firebase/BLUEDOC.md)
+
+### Statsig
+- Flag staged rollout 메트릭 게이트 (one-sided sequential testing)
+- A/B holdout 분석
+- 상세: [../statsig/BLUEDOC.md](../statsig/BLUEDOC.md)
+
+### Axiom / Supabase logs
+- Backend (EF) 로그 수집
+- 참고: `docs/operations/edge-functions.md`
+
+### GitHub Actions
+- pr-gate / rc-gate / promotion workflow 의 자동 이슈 생성
+- **workflow infra 실패 → P0**, test 실패 → P1-high
+
+## Detection → Action 책임
+
+| Detection 신호 | 누가 받음 | 어디서 | Action |
+|---------------|----------|--------|--------|
+| pr-gate 실패 (어느 단계든) | PR 작성자 | GitHub PR | 본인 fix → re-push → re-queue |
+| `rc-gate` 실패 (dev 머지 후) | 직전 rc-gate-pass 이후 머지된 PR 작성자들 | GitHub issue + Slack `#nightly` | bot auto-revert + AI fix PR ([dev-pipeline.md](./dev-pipeline.md)) |
+| Backend/web auto-deploy 실패 | on-call | Slack `#release` | retry → rollback ([main-promotion.md](./main-promotion.md) error-backoff) |
+| rc soak 중 회귀 | RC owner | Slack `#release` | hotfix PR → rc | 
+| mobile-cut smoke 실패 | mobile 팀 | GitHub issue | cut 차단, 직전 main commit 시도 |
+| Sentry alert (error spike) | 영역 owner | Sentry → Slack | 영역 별 on-call 판단 |
+| Crashlytics velocity alert | mobile 팀 | Firebase → Slack | flag flip OFF 우선 |
+| Statsig metric gate | flag owner | Statsig dashboard | flag rollback ([life-of-flag.md](./life-of-flag.md)) |
+| Workflow infra 실패 (P0) | on-call | GitHub issue + PagerDuty | 즉시 |
+
+## Detection Gap 방지
+
+- 신규 EF / 새 화면: Sentry release tag + Crashlytics dSYM 등록 필수
+- 신규 flag: 메트릭 게이트 정의 강제 (Statsig 콘솔 metric 미연결 = warning)
+- 새 코드 path: flag SDK reference 강제 (`flag-registration` CI)
+- alert silence: owner + 이유 + 재활성 일자 명시
+
+## 결정해야 할 것
+
+- alert 채널 통합 vs 분리 (Slack 구조)
+- on-call rotation 정의
+- alert 임계치 (error rate baseline 측정)
+- Crashlytics + Sentry 양쪽 vs 한쪽 통일
+
+## 관련
+
+- [test-strategy.md](./test-strategy.md) — 어떤 테스트
+- [dev-pipeline.md](./dev-pipeline.md) — rc-gate detection → backoff
+- [main-promotion.md](./main-promotion.md) — deploy detection → rollback
+- [life-of-flag.md](./life-of-flag.md) — flag 메트릭 → flip
+- [../firebase/BLUEDOC.md](../firebase/BLUEDOC.md), [../statsig/BLUEDOC.md](../statsig/BLUEDOC.md)
+
+---
+_Reviewed: 2026-05-19 09:47_

--- a/docs/infra/branch-strategy/life-of-flag.md
+++ b/docs/infra/branch-strategy/life-of-flag.md
@@ -1,0 +1,182 @@
+# Life of a Flag
+
+Feature flag (Statsig + Firebase Remote Config) 의 생성·soak·rollout·**자동 cleanup** lifecycle. 코드 release (branch promotion) 와 분리된 *기능 release* 의 단일 문서. literature 기반 7개 운영 룰 반영.
+
+## Statsig vs Firebase Remote Config 역할 분담
+
+| 도구 | 용도 | 예시 |
+|------|------|------|
+| **Statsig** | 실험·gate·layered config·dependent gate | A/B 실험, 권한 gate, staged rollout |
+| **Firebase Remote Config** | 단순 config·즉시 kill switch | API base URL, 임계치, cold start fetch, **min-version endpoint** |
+
+**선택 룰**:
+- 사용자 cohort 분기 / 메트릭 비교 → Statsig
+- 단순 on/off, 값 변경, 빠른 kill switch → Firebase RC
+- 둘 다 가능하면 → Statsig
+- **둘 다 필요 (kill switch + 실험)**: 결정 트리 명시 필요 (TBD)
+
+**Statsig 사용 룰** (literature gotchas):
+- layered experiment → **반드시 `getLayer` API** (`getExperiment` 는 layered 에서 비직관적)
+- holdout cohort 의 layer default 는 일반 사용자와 다름을 인지
+- **dependent gate depth ≤ 2** (6중 nested = 64 code paths, 테스트 cover 불가)
+
+**Firebase RC 사용 룰** (literature gotchas):
+- 기본 fetch interval = 12시간. kill switch 용은 short interval + quota risk 수용
+- **cold-start default = 안전 상태 강제** — 첫 cold start 에 server fetch 실패해도 사용자가 신기능 미노출 (default OFF)
+- iOS pre-6.3.0 throttle (5 fetches / 60min). `lastFetchStatus` 체크 필수
+
+상세: [../firebase/BLUEDOC.md](../firebase/BLUEDOC.md), [../statsig/BLUEDOC.md](../statsig/BLUEDOC.md)
+
+## Platform 별 Flag 분리
+
+**통합 기능 (backend + mobile 양쪽)** 은 platform 별 별도 flag, **backend 100% prod + 1주 soak 후 mobile 활성화**.
+
+### 명명 컨벤션
+
+```
+{area}_{feature}_be    # backend (EF, server-side gating)
+{area}_{feature}_mu    # mobile app_user
+{area}_{feature}_mp    # mobile app_partner
+{area}_{feature}_web   # web (landing) — 있으면
+```
+
+### 의존성
+
+- `*_mu`, `*_mp`, `*_web` 는 `*_be` 가 prod 100% + 1주 soak 후에만 5% rollout 시작
+- Statsig dependent gate 로 강제
+
+### 4-flag-as-1-Unit Tooling (필수)
+
+**경고**: 4개 flag 를 독립 cleanup 하면 `_be` 만 정리되고 `_mu` 가 영구 50% 고착 (LaunchDarkly 데이터). 다음 tooling 동시 도입:
+
+- flag 생성 시 4개 자동 생성 + sibling hash metadata 로 연결
+- cleanup 시 4개 모두 100% & soak 통과 확인 후 일괄 PR 생성
+- 4개 중 일부만 stale 한 상태 = monitoring alert
+- 월간 sibling 불일치 flag 리스트
+
+**현재 상태**: TODO — tooling spec.
+
+## Flag Lifecycle
+
+```
+[0] flag 등록 (4-flag-as-1 tool 이 4개 자동 생성)
+    ↓
+[1] dev 환경 ON (개발자만, ~1주)
+    ↓
+[2] prod 카나리 — backend 먼저 (내부 직원 allowlist, ~2주)
+    ↓
+[3a] backend staged (5% → 25% → 100%, ~1~2주)
+    ↓
+[3b] backend 100% + 1주 안정 → mobile/web 활성화 게이트 해제
+    ↓
+[4] mobile/web 카나리 (allowlist, ~2주) → staged (5/25/100%)
+    ↓
+[5] 전 platform 100% + 1주 안정
+    ↓
+[6] **30일 후 auto codemod cleanup PR** (4개 flag + 분기 코드 통째 삭제)
+```
+
+## Stage 상세
+
+| Stage | Cohort | 기간 | Exit |
+|-------|--------|------|------|
+| 1. dev | 개발자 (Statsig env=dev / RC condition) | **1주** | rc-gate green + 코드 dev 진입 |
+| 2. prod allowlist | 내부 직원 user_id allowlist | **2주** | 카나리 메트릭 OK |
+| 3a. backend staged | prod backend 5% → 25% → 100% | 48h → 72h → 7일 | error rate < baseline +X% |
+| 3b. backend soak | - | 1주 | 무이슈 (mobile 활성화 게이트) |
+| 4. mobile/web | allowlist 2주 → staged 5/25/100% (48h/72h/7일) | ~3~4주 | 동일 룰 |
+| 5. 전체 soak | prod 전체 | 1주 | 무이슈 |
+| 6. cleanup | - | 30일 후 자동 | codemod PR 자동 생성 |
+
+**왜 dev soak 가 짧고 prod allowlist 가 긴가**: Slack May 2020 outage 처럼 *prod load 와 실 데이터* 에서만 잡히는 버그 다수. dev soak 길이는 효과 약함 (literature).
+
+## 메트릭 게이트
+
+각 staged rollout 단계에서:
+
+- **error rate**: Sentry, baseline +X% 이내 (one-sided sequential testing)
+- **crash-free rate**: Firebase Crashlytics, 99.X% 이상 — mobile 가장 신뢰성 높은 신호
+- **latency p95**: backend 영향 받는 flag 추가
+- **business metric** (결제 성공률 등): 5% 에선 noise 크니 *trip wire* 만, gate X
+- **계약 호환 알람**: mobile 활성화 직후 contract mismatch 모니터링
+
+자동 disable 임계: error rate > 5%, p95 > 2s
+
+## Error-Backoff
+
+| 상황 | 동작 |
+|------|------|
+| canary 메트릭 1회 alert | 자동 hold (다음 단계 차단) + owner 알림 |
+| canary 메트릭 2회 연속 | flag flip OFF + 이슈 (`flag-degraded`) |
+| staged 5% alert | 자동 rollback (5% → 0%) + owner |
+| staged 25% alert | 즉시 rollback to 5% → 0% + on-call |
+| staged 100% alert | 즉시 rollback (마지막 안정 단계) + post-mortem |
+| mobile 활성화 직후 contract 에러 | mobile flag 즉시 OFF, backend 유지 |
+
+## Cleanup — 가장 critical
+
+**73% 의 "temporary" flag 가 영구화** (Featureflip). 이슈 ping 으론 부족. **codemod-driven auto-PR 필수**.
+
+### 자동 cleanup Flow
+
+```
+[100% rollout 통과] → [+30일] → [4-flag-as-1 tool 이 cleanup PR 자동 생성]
+                                  ↓
+                                  PR 내용:
+                                  - 4개 flag 의 Statsig/RC entry archive 표시
+                                  - 코드의 flag 분기 통째 제거 (dead branch 까지)
+                                  - 관련 test mock 제거
+                                  ↓
+                                [owner review → merge to dev-staging]
+                                  ↓
+                                [merge 후 자동으로 Statsig/RC 콘솔 entry 삭제]
+```
+
+### Dead Branch 통째 삭제 룰
+
+**Knight Capital ($460M, 45분)**: flag entry 만 지우고 dead branch 코드 남기면 시한폭탄. cleanup PR 은 반드시:
+- flag 체크 if/else 의 양쪽 branch 중 사용 안 하는 쪽 **통째 삭제**
+- 관련 import / dead function / unused enum 까지 정리
+- "혹시 모르니 남겨두자" 금지
+
+### Cleanup 강제
+
+- 30일 auto PR 이 60일까지 머지 안 되면 → `flag-debt` 라벨 + owner manager escalation
+- 분기별 flag debt 리뷰 (removed/created ratio, DevCycle 0.8 기준)
+
+## Flag 메타데이터
+
+필수: owner, 생성일, 예상 cleanup 일 (생성일 + 60일), 관련 PR, 관련 metric, sibling flags
+
+## 코드 release vs 기능 release
+
+| 항목 | 코드 release | 기능 release |
+|------|--------------|--------------|
+| 트리거 | backend/web: dev rc-gate-pass / mobile: monthly cut | flag ON 조작 |
+| cadence | backend/web: 시간 단위 / mobile: 월 1회 | feature 별 비동기 |
+| rollback | redeploy 이전 commit (분) | flag flip (즉시) |
+| 통제 권한 | 릴리즈 매니저 | feature owner |
+
+**원칙**: 새 기능은 flag 뒤에. unflagged 변경은 refactor·infra·security 등 *기능이 아닌 것* 에만. **CI 강제** ([dev-staging-pipeline.md](./dev-staging-pipeline.md) 의 flag-registration).
+
+## 결정해야 할 것
+
+- 카나리 cohort 정의 (내부 직원 group 구체)
+- staged rollout 자동 진행 vs 수동 promote
+- 메트릭 모니터링 도구 (Statsig 자체 / Grafana / Sentry alert)
+- **4-flag-as-1 tooling 구현** (가장 critical TBD)
+- RC + Statsig 둘 다 필요 case 결정 트리
+- min-version endpoint 와의 연동 (특정 flag 가 min-version bump 요구하는 경우)
+
+## 관련
+
+- [branch-flow.md](./branch-flow.md) — 코드 promotion 의 그림
+- [main-promotion.md](./main-promotion.md) — min-version + expand-migrate-contract
+- [dev-staging-pipeline.md](./dev-staging-pipeline.md) — flag-registration CI
+- [dev-pipeline.md](./dev-pipeline.md) — backend/web auto-deploy
+- [test-strategy.md](./test-strategy.md) — flag staged rollout 의 게이트
+- [error-detection.md](./error-detection.md) — flag 메트릭의 detection layer
+- [../firebase/BLUEDOC.md](../firebase/BLUEDOC.md), [../statsig/BLUEDOC.md](../statsig/BLUEDOC.md)
+
+---
+_Reviewed: 2026-05-19 09:47_

--- a/docs/infra/branch-strategy/main-promotion.md
+++ b/docs/infra/branch-strategy/main-promotion.md
@@ -1,0 +1,181 @@
+# Main Promotion
+
+`rc/YYYY-Wxx` 의 soak 통과 시 `main` 으로 머지, 그리고 main 에서 월 1회 `mobile-cut`. Backend/web 의 auto-deploy 는 dev 의 rc-gate-pass 에서 이미 일어남 ([dev-pipeline.md](./dev-pipeline.md)) — main 은 **mobile-stable snapshot** 역할.
+
+## 두 가지 이벤트
+
+1. **rc → main weekly 머지** — `rc-soak-check` 가 자동 PR 생성 + 모든 check 통과 시 workflow auto-merge
+2. **mobile-cut** — 월 1회 main 에서 `release/mobile-YYYY-MM` branch cut
+
+## `main-pr-gate`
+
+`rc-soak-check` 가 자동 생성한 promotion PR 에 적용:
+
+| Check | 내용 |
+|-------|------|
+| `pr-gate` 재실행 | dev-staging-pr-gate 와 동일 — defensive 검증 |
+| `expand-migrate-contract` (재검증) | RC 5일 동안 dev 가 더 나갔을 수 있음. 재확인 |
+| RC HEAD 의 `rc-gate-pass` status 확인 | 마지막 hotfix 이 rc-gate 통과했는지 |
+| `rc-soak-passed` 자동 마커 | rc-soak-check 가 5일 무커밋 확인 후 부여 |
+
+**모든 check 통과 시 workflow 가 auto-merge** (rebase + fast-forward). 어느 하나라도 실패 시 PR hold + Slack 알림 → human 개입 (edge case 만).
+
+## `main-post-merge-promote`
+
+auto-merge 직후 자동:
+
+```
+1. bump-version.sh {ver}  (suffix 제거 — main 은 final version)
+2. git commit -m "chore: bump version to v{ver} [skip ci]"
+3. git tag v{ver}
+4. git tag promo/main-YYYY-Wxx
+5. git push (tags + commit)
+6. Sentry release marker 부여 (v{ver})
+```
+
+**Backend/web deploy 는 main 에서 하지 않음** — dev 의 rc-gate-pass 에서 이미 prod 반영됨. main 은 mobile 의 stable snapshot.
+
+## `mobile-cut` (월 1회)
+
+### 트리거 / 동작
+
+- **cron**: 매월 X 일 KST 09:00 (TBD)
+- **manual**: `workflow_dispatch` (긴급 mobile release)
+- 동작:
+  1. 그 시점 main HEAD 에서 `release/mobile-YYYY-MM` 브랜치 cut
+  2. Branch protection 활성화 (direct push 금지, cherry-pick PR 만)
+  3. mobile-specific smoke (build + Test Lab 회귀)
+  4. **`min-version` default 자동 bump** (Safety Net 1 — 아래)
+  5. 안내 issue 생성 (build/upload assignee)
+
+### Release branch lifecycle
+
+- cut 후 ~수일: build, internal QA, app store 업로드 (TestFlight, Internal Track)
+- store 리뷰 ~수일: 필요 시 main 에서 cherry-pick PR (**자동화 도구 필수** — Runway/Xray/자체)
+- store 출시 후: 다음 cut 까지 cherry-pick 핫픽스만
+- 다음 month cut 시 archive 결정 (보존 vs 삭제 — TBD)
+
+## Safety Net 1: Version Kill Switch (Soft + Hard Tier)
+
+**정책**: 6개월 backward compat (마지막 6개 mobile release 지원). 분기별 retrospective 에서 update rate 데이터 보고 조정.
+
+**Source of truth**: Firebase RC parameter (client + server 양쪽이 동일 source 에서 fetch).
+
+### 두 Tier
+
+| Tier | 메커니즘 | 사용 case |
+|------|----------|----------|
+| **2a. Soft kill** | client 가 `min_version_soft` (RC) + *app store 의 새 버전 가용성* 양쪽 확인 후 force-update screen | 빠른 update 유도. store rollout 중이라 일부만 새 버전 받을 수 있을 때 안전 (못 받는 사용자는 그대로 사용) |
+| **2b. Hard kill** | EF middleware 가 `kill_list_hard` (RC) + `X-App-Version` header 비교 → HTTP 426 reject | catastrophic (데이터 유출, 결제 사고, 보안). 매우 드묾 |
+
+### Tier 2a: Soft Kill 흐름
+
+```
+[client cold start]
+        ↓
+[Firebase RC fetch: min_version_soft]
+        ↓
+[내 version < min_version_soft?]
+        │
+        ├─ no → 정상 사용
+        │
+        └─ yes → [app store check (Play In-App Update / iOS StoreKit) → 새 버전 사용 가능?]
+                        │
+                        ├─ yes → force-update screen + 앱스토어 deep-link
+                        │
+                        └─ no → 정상 사용 (UX 사고 방지)
+```
+
+`min_version_soft` default = 6개월 전 mobile release version. `mobile-cut` 이 매월 자동 bump.
+
+### Tier 2b: Hard Kill 흐름 (EF middleware)
+
+```
+[incoming request to any EF]
+        ↓
+[Firebase Admin SDK 로 RC fetch (캐시 5분)]
+        ↓
+[request.headers['X-App-Version'] ∈ kill_list_hard?]
+        │
+        ├─ yes → HTTP 426 Upgrade Required + update 안내
+        │
+        └─ no → 정상 처리 (다음 middleware)
+```
+
+`kill_list_hard` default = `[]` (안전 상태).
+
+### Auto-bump (PR label 컨벤션)
+
+| PR Label | Tier | `main-post-merge-promote` 동작 |
+|----------|------|--------------------------------|
+| (없음) | - | 변경 없음 (mobile-cut 의 monthly soft auto-bump 만) |
+| `force-update` | 2a | RC `min_version_soft` 즉시 bump to 이 PR 의 `v{ver}` |
+| `force-update-hard` | 2b | RC `kill_list_hard` 에 현 store-live version 추가 + Slack `#release` + on-call 호출 |
+
+**Single source of truth = Firebase RC**. Client cold start fetch, Server EF Admin SDK fetch + 5분 캐시. RC 콘솔이 운영 dashboard.
+
+### 결정해야 할 것
+
+- App store check API 선택 (Play In-App Update / iOS StoreKit 직접 query)
+- EF middleware 의 RC cache TTL (5분 vs 1분)
+- `force-update-hard` label 부여 권한 (release manager / on-call)
+- Firebase App Check 도입 여부 (별개 — 인증 layer, 버전 kill 과 무관, 보안 강화 후속 PR)
+
+**현재 상태**: TODO. EF middleware + mobile dual check + RC parameter 셋업 + Firebase Admin SDK 인증.
+
+## Safety Net 2: Expand-Migrate-Contract (재검증)
+
+`main-pr-gate` 에서도 `expand-migrate-contract` CI 재실행 (RC 5일 사이 dev 가 더 나갔을 수 있음). 정책 + 구현 상세는 [dev-staging-pipeline.md](./dev-staging-pipeline.md) 참고.
+
+**Policy 요약**:
+- N = 6 mobile releases (= 6개월)
+- Option C: DB schema 만 검증 (API contract test 는 TBD)
+- Destructive op (DROP COLUMN/TABLE, ALTER TYPE) 탐지 + bypass label
+
+## Cherry-pick 자동화 도구
+
+Squarespace 데이터: 자동화 도구 도입 시 핫픽스 **many/월 → 5/년**. 단순 convention 으론 부족.
+
+후보: Runway / Xray / 자체 GitHub Action
+
+**현재 상태**: TODO — 도구 평가 + 도입 결정. (mobile 핵심 ROI 안전망)
+
+## Error-Backoff 정책
+
+**Workflow infra 실패** (main-pr-gate / main-post-merge-promote / mobile-cut workflow 자체 실패) → **P0 이슈** + on-call.
+
+### rc → main 머지 차단
+
+| 조건 | 동작 |
+|------|------|
+| `rc-gate-degraded` (dev-pipeline backoff) | rc → main PR 자동 close + 코멘트 ("nightly recovery 후 재시도") |
+| `expand-migrate-contract` 검사 실패 | PR 자동 close |
+
+### mobile-cut 실패
+
+| 상황 | 동작 |
+|------|------|
+| smoke test 실패 | cut 차단 + 이슈, 직전 main commit cut 시도 (수동) |
+| min-version bump 실패 | cut 진행 가능, alert 알림 (수동 bump) |
+| Store reject | hotfix PR → cherry-pick → re-submit. release branch 유지 |
+
+### Backend/web auto-deploy 실패 (참고 — 상세는 dev-pipeline)
+
+main 머지와 무관 (이미 dev 에서 deploy 됐음). dev-pipeline 의 error-backoff 참고.
+
+## 결정해야 할 것
+
+- mobile-cut 매월 X 일 (1일 / 첫째 월요일)
+- mobile release branch 보존 정책 (영구 / archive 후 삭제)
+- cherry-pick 자동화 도구 선정
+- mobile build/upload 워크플로우 (Fastlane 자동 vs 수동 단계)
+
+## 관련
+
+- [dev-pipeline.md](./dev-pipeline.md) — auto-deploy 의 진짜 위치
+- [rc-promotion.md](./rc-promotion.md) — rc → main PR 의 생성
+- [life-of-flag.md](./life-of-flag.md) — flag rollout 은 main 머지와 별도
+- [branch-flow.md](./branch-flow.md) — tag 컨벤션 + protection
+
+---
+_Reviewed: 2026-05-19 09:47_

--- a/docs/infra/branch-strategy/rc-promotion.md
+++ b/docs/infra/branch-strategy/rc-promotion.md
@@ -1,0 +1,177 @@
+# RC Promotion
+
+`rc/YYYY-Wxx` 브랜치의 lifecycle: weekly cut from dev 의 `rc-gate-pass` commit, 5일 soak (hotfix 시 시계 리셋), soak 통과 시 main 으로 머지.
+
+## 4가지 workflow
+
+1. **`rc-cut`** — weekly cron, dev 의 latest `rc-gate-pass` commit 에서 branch out
+2. **`rc-pr-gate`** — hotfix PR 머지 전 검증
+3. **`rc-post-merge-sync`** — hotfix 머지 직후 (`_rc-NN` bump)
+4. **`rc-soak-check`** — daily cron, RC HEAD commit 의 committer date 가 5일 이전이면 rc → main PR 자동 생성
+
+## `rc-cut`
+
+### 트리거 / 동작
+
+- **cron**: 매주 X 요일 KST 10:00 (TBD)
+- **manual**: `workflow_dispatch` (긴급 cut)
+- 동작:
+  1. **현재 `rc/*` 살아있는지 확인** → 있으면 skip + Slack `#release` 알림 (이전 RC 가 hotfix 로 길어지는 중)
+  2. 없으면 dev 의 최신 `rc-gate-pass` status 부여된 commit 찾기 (GitHub API: `GET /repos/.../commits/{sha}/status`)
+  3. 못 찾으면 (3일+ green 없음) → alert + cut 보류
+  4. 찾았으면 그 commit 에서 `rc/YYYY-Wxx` branch cut
+  5. `bump-version.sh {ver}-rc-01` 실행 → tag `v{ver}-rc-01` + `promo/rc-YYYY-Wxx`
+  6. Branch protection 활성화 (direct push 금지, cherry-pick PR 만)
+  7. Slack `#release` 알림 + soak 시작
+
+### Cron 슬립 처리
+
+- "현재 `rc/*` 살아있음" → skip + 다음 주 cron 까지 대기
+- "rc-gate-pass commit 없음 (3일+)" → cut 보류 + alert (운영자 개입 필요)
+
+## `rc-pr-gate`
+
+RC 브랜치는 hotfix PR 만 받음. `dev-staging-pr-gate` 와 동일 + 추가 mobile smoke (RC 가 mobile 의 source 가 될 가능성 높음).
+
+| Check | 내용 |
+|-------|------|
+| (dev-staging-pr-gate 와 동일) | unit, lint, pgTAP, EF, migration, expand-migrate-contract, flag-registration, gitleaks |
+| `rc-mobile-smoke` (추가) | mobile build 가능성 + 기본 navigation 동작 | 
+
+## `rc-post-merge-sync`
+
+Hotfix PR 머지 직후 자동:
+
+```
+1. bump-version.sh {PR번호}-rc-NN  (NN = 현재 RC 의 hotfix 카운트 + 1)
+2. git commit -m "chore: bump RC version [skip ci]"
+3. git tag v{ver}-rc-NN
+4. git push
+```
+
+**Soak 시계 자동 리셋** — 새 commit 의 committer date 가 최신이므로 `rc-soak-check` 가 자연스럽게 카운트 다시 시작.
+
+### Hotfix 카운트 결정
+
+`bump-version.sh` 가 현재 RC 의 가장 최근 `v*-rc-NN` 태그 찾아 N + 1 로 bump. 첫 cut 이 `_rc-01`, 첫 hotfix 가 `_rc-02`.
+
+## `rc-soak-check`
+
+### 트리거 / 동작
+
+- **cron**: daily KST 09:00 (TBD)
+- 동작:
+  1. 현재 `rc/*` 가 있는지 확인 → 없으면 종료
+  2. RC HEAD commit 의 `committer date` 조회
+  3. `committer date` 가 5일 이전 (= 5일 동안 새 commit 없음) 이면:
+     - PR 자동 생성: `release(main): RC YYYY-Wxx → main` (base=main, head=rc/YYYY-Wxx)
+     - PR 에 `rc-soak-passed` 마커 부여
+     - `main-pr-gate` 통과 시 workflow 가 auto-merge ([main-promotion.md](./main-promotion.md))
+  4. 5일 이전 아니면 → 다음날 cron 까지 대기
+
+### Slip 자연스러움
+
+Mark 님 직감대로 hotfix loop 으로 RC lifecycle 이 길어지는 게 일반적. 5일 시계 리셋이 자정 압박 ("PR 잘 만들기"). 평균 cycle time 은 운영하면서 metric 으로 추적.
+
+## Soak 5일 동안 무엇이 검증되나
+
+| 검증 | 도구 |
+|------|------|
+| 누적 회귀 | rc 의 nightly 재실행 (선택 — RC 별도 nightly schedule TBD) |
+| 내부 dogfooding | 내부 직원 cohort 가 `_rc-NN` 빌드 사용 |
+| Real-data 이슈 | rc 의 supabase staging branch (단일 공유 branch, 5일 후 reset) |
+| 외부 의존성 동작 (실 결제, 실 메시지) | 내부 사용자가 실제로 사용해보며 검증 |
+
+## Hotfix 경로
+
+```
+[soak 중 issue 발견]
+    │
+    └─▶ [hotfix PR 작성: feat/fix branch → rc/YYYY-Wxx]
+            │
+            ├─▶ [rc-pr-gate]
+            │
+            ├─▶ [merge to rc (rebase)]
+            │
+            ├─▶ [rc-post-merge-sync: _rc-NN bump]
+            │
+            └─▶ [rc-soak-check 가 다음날부터 새 committer date 인식 → 5일 다시 측정]
+```
+
+## Hotfix Backport to dev-staging
+
+RC 의 hotfix 는 RC 에 머지 후 **반드시 dev-staging 으로 backport**. 안 하면 다음 RC cut 에 같은 버그 재출현.
+
+### `rc-hotfix-backport` workflow
+
+```
+[hotfix PR merged on rc/YYYY-Wxx]
+        ↓
+[`rc-hotfix-backport` 자동 발동]
+        ↓
+[bot 이 cherry-pick 으로 backport-branch 생성 (base: dev-staging)]
+        ↓
+[PR 자동 생성: backport-branch → dev-staging]
+        ↓
+[`dev-staging-pr-gate` 통과 시 auto-merge]
+[충돌 / 테스트 실패 시: AI agent assignee, 수동 resolve]
+```
+
+### Backport 충돌
+
+RC 는 dev-staging 에서 cut 됐지만 RC 가 사는 동안 dev-staging 이 앞서가서 충돌 가능:
+- bot 이 충돌 PR 생성 + 이슈 + AI agent assignee
+- AI 가 resolve 후 push
+- pr-gate 통과 시 머지
+
+### Mobile cherry-pick 의 backport?
+
+Mobile release branch (`release/mobile-YYYY-MM`) 의 cherry-pick PR 은 main commit 에서 cherry-pick = dev-staging 에 이미 존재 → **backport 불필요**.
+
+긴급 mobile 직접 hotfix (release/mobile-* 에 새 PR — drop-down 룰 위반 case) → dev-staging backport 필요. 드문 case, 발생 시 수동 처리 (TBD: 자동화 여부).
+
+## Supabase Staging Branch (RC 의 backend 검증용)
+
+**전략**: 단일 영구 supabase staging branch 를 모든 RC 가 공유 (RC merge to main 시점에 reset).
+
+- 비용 절감 (RC 마다 새 branch 안 만듬)
+- 복잡도 낮음 (sync 디테일 단순)
+- expand-migrate-contract CI 가 PR 시점에 destructive 검증 → 5일 소크 시점 추가 보호
+
+이전: RC 마다 ephemeral branch — runtime 가격 누적, 복잡.
+지금: 1 branch 영구 운영. RC merge to main → DB reset → 다음 RC 가 깨끗한 상태에서 시작.
+
+### 결정해야 할 것
+
+- staging branch reset 시점 정확화 (main 머지 직후 / 다음 rc-cut 직전)
+- staging branch 의 seed data 정책
+
+## Error-Backoff 정책
+
+**Workflow infra 실패** (rc-cut / rc-pr-gate / rc-soak-check workflow 자체 실패) → **P0 이슈** + on-call.
+
+**Soak 중 사용자 발견 회귀**:
+
+| 심각도 | 동작 |
+|--------|------|
+| Minor (UI, edge case) | hotfix PR → rc-post-merge-sync → soak 시계 리셋 |
+| Critical (crash, data loss) | flag 로 즉시 OFF (코드 release 와 분리 — life-of-flag 참고) + hotfix PR 병행 |
+| Catastrophic (전체 깨짐) | RC abandon — branch 삭제, 다음 weekly cut 새로 시작 (작업 손실) |
+
+## 결정해야 할 것
+
+- weekly rc-cut 요일
+- rc-soak-check daily cron 시각
+- RC 자체 nightly 별도 schedule 여부
+- staging supabase branch reset 정책
+- RC abandon 의 명확한 기준
+
+## 관련
+
+- [dev-pipeline.md](./dev-pipeline.md) — rc-gate-pass status 가 rc-cut 의 source
+- [main-promotion.md](./main-promotion.md) — rc → main 머지 + 그 후 mobile-cut
+- [test-strategy.md](./test-strategy.md) — rc-pr-gate 와 mobile smoke 위치
+- [branch-flow.md](./branch-flow.md) — tag 컨벤션 + protection
+
+---
+_Reviewed: 2026-05-19 09:47_

--- a/docs/infra/branch-strategy/test-strategy.md
+++ b/docs/infra/branch-strategy/test-strategy.md
@@ -1,0 +1,97 @@
+# Test Strategy
+
+4-stage 모델 (`dev-staging → dev → rc → main`) + flag staged rollout 환경에서, *어떤 테스트가 어느 단계에서 도는가* 의 단일 source. 빠른 검사 = `pr-gate` (각 단계), 무거운 검사 = `rc-gate` (dev 의 post-merge), 프로덕션 검증 = `mobile-cut` + flag staged.
+
+## 단계별 게이트
+
+| 단계 | 게이트 | 소요 | 실패 시 |
+|------|--------|------|---------|
+| dev-staging 머지 전 | `dev-staging-pr-gate` (unit · lint · analyze · pgTAP · EF test · migration check · `expand-migrate-contract` · `flag-registration` · gitleaks) | < 10분 | merge queue PR drop |
+| dev 머지 전 | `nightly-pr-gate` (dev-staging-pr-gate 와 동일 — defensive) | < 10분 | nightly-cut PR drop |
+| dev 머지 후 (자동) | `rc-gate` (full: CUJ · integration · e2e · simulator · Test Lab smoke) | 30-60분 | 자동 이슈 + AI fix flow. status 미부여 |
+| rc 머지 전 (hotfix) | `rc-pr-gate` (pr-gate + mobile smoke) | < 15분 | hotfix PR drop |
+| main 머지 전 (rc → main) | `main-pr-gate` (pr-gate + `expand-migrate-contract` 재검증 + RC HEAD 의 `rc-gate-pass` 확인) | 분 | promotion PR 보류 |
+| rc → main PR | workflow auto-merge (모든 check 통과 시) | 분 | check 실패 시 PR hold + alert |
+| Backend/Web auto-deploy 후 | post-deploy smoke + Sentry/Crashlytics 알람 임계 | 분 | auto-rollback ([main-promotion.md](./main-promotion.md)) |
+| mobile-cut 후 | mobile-specific smoke (build + Test Lab 회귀) | 시간 | cut 차단, 직전 main commit 시도 |
+| Flag canary (allowlist) | Statsig metric gates | 며칠 | flag flip OFF |
+| Flag staged (5/25/100%) | Statsig one-sided sequential | 48h/72h/7일 | hold or rollback |
+
+## Stage 별 상세
+
+### dev-staging-pr-gate — 빠른 머지 게이트
+
+merge queue 가 직렬 처리. 각 PR 이 rebase 후 재실행.
+
+- `test-flutter-apps` (matrix: app_user, app_partner)
+- `lint-landing-user`, `lint-landing-partner`
+- `test-supabase` (pgTAP)
+- `test-edge-functions` (Deno)
+- `check-migration-versions`
+- **`expand-migrate-contract`** (safety net — DB schema 6-month 호환)
+- **`flag-registration-check`** (safety net — 새 코드 path 가 flag SDK 참조)
+- `gitleaks`
+- CodeRabbit 리뷰 (최대 30분 대기)
+
+룰: 10분 넘으면 `rc-gate` 로 이동.
+
+### nightly-pr-gate
+
+`dev-staging-pr-gate` 와 동일한 test suite. 환경 차이로 인한 회귀만 잡는 defensive 검증. 대부분 통과.
+
+### rc-gate — Heavy Integration
+
+dev 머지 후 자동 발동. 통과 시 commit 에 GitHub status `rc-gate-pass` set + `backend-auto-deploy` + `web-auto-deploy` chain.
+
+- CUJ (app_user, app_partner)
+- Integration tests (backend, edge functions)
+- Simulator happy/chaos 시나리오
+- 풀 e2e
+- Firebase Test Lab smoke (실 디바이스 다양성)
+
+상세: [dev-pipeline.md](./dev-pipeline.md)
+
+### rc-pr-gate
+
+RC 의 hotfix 만 받음. `pr-gate` + 추가 mobile smoke. 머지 시 `rc-post-merge-sync` 가 `_rc-NN` bump.
+
+### main-pr-gate
+
+`rc-soak-check` 가 자동 생성한 promotion PR 에 적용:
+- pr-gate 재실행
+- `expand-migrate-contract` 다시 검증 (RC 5일 동안 dev 가 더 나갔을 수 있음)
+- RC HEAD 의 `rc-gate-pass` status 확인 (마지막 hotfix 이 rc-gate 통과했는지)
+
+모든 check 통과 시 workflow auto-merge (rebase + ff).
+
+### Flag staged rollout 메트릭 게이트
+
+- error rate (Sentry, baseline +X% 이내)
+- crash-free rate (Crashlytics, mobile 가장 신뢰성 높은 신호)
+- latency p95 (backend 영향 받는 flag)
+- business metric (5% 단계에선 trip wire 만, gate X)
+
+상세: [life-of-flag.md](./life-of-flag.md)
+
+## 어디에 어떤 테스트를 두나
+
+| 테스트 성격 | 배치 위치 | 이유 |
+|-------------|-----------|------|
+| 결정론적, < 10분 | `dev-staging-pr-gate` | PR 사이클 안 막음 |
+| flaky 또는 느림 (10분+) | `rc-gate` | merge queue 신뢰도 보호 |
+| 외부 의존성 (실 결제 등) | `rc-gate` + flag canary | 비용·side effect 통제 |
+| 부하/성능 | `rc-gate` (주 1회) or staged rollout 메트릭 | 매일 무거움 |
+| backend ↔ mobile 계약 호환 | `expand-migrate-contract` CI + flag canary 메트릭 | 다층 안전망 |
+| 실 디바이스 다양성 | `rc-gate` 의 Firebase Test Lab | 시뮬레이터 한계 보완 |
+| Mobile 회귀 (cut 직후) | `mobile-cut` 의 mobile-specific smoke | app store 업로드 전 마지막 |
+
+## 결정해야 할 것
+
+- nightly cron 시각
+- 부하 테스트 도구 (k6 / Artillery / 자체)
+- mobile smoke 5개 핵심 경로 정의
+- 카나리 cohort 정의 (내부 직원 group)
+- `expand-migrate-contract` 구현 디테일 (Option C: DB schema only)
+
+---
+_Reviewed: 2026-05-19 09:47_

--- a/docs/infra/branch-strategy/versioning.md
+++ b/docs/infra/branch-strategy/versioning.md
@@ -1,0 +1,92 @@
+# Versioning & Tags
+
+4-stage 모델 (`dev-staging → dev → rc → main`) 위에서의 CalVer (`YY.MM.PR#`) 적용 + tag 컨벤션. 기존 CLAUDE.md 의 "Versioning Conventions" 를 4-stage + flag 모델에 맞게 보강.
+
+## 기본 형식 (기존 유지)
+
+| 구성요소 | 설명 | 예시 |
+|----------|------|------|
+| `YY` | 연도 2자리 | `26` |
+| `MM` | 월 2자리 | `05` |
+| `PR#` | 머지된 PR 번호 (cumulative across repo) | `2572` |
+
+- mobile versionCode: `YYMM * 10000 + PR#` — 예: `26052572`
+
+> CLAUDE.md 의 "새 월이면 .1 시작" 은 `scripts/bump-version.sh` 와 불일치 — 실제론 PR# 가 cumulative. CLAUDE.md 정정 PR 별도 권장.
+
+## 단계별 Suffix
+
+| Stage | Suffix | 예시 |
+|-------|--------|------|
+| dev-staging | `-dev-staging` | `26.05.2572-dev-staging` |
+| dev (nightly-cut snapshot) | (동일 suffix 유지, 새 bump 없음) | `26.05.2572-dev-staging` |
+| rc (cut) | `-rc-NN` (N = 1) | `26.05.2572-rc-01` |
+| rc (hotfix) | `-rc-NN` (N 증가) | `26.05.2585-rc-02` |
+| main (final) | (없음) | `26.05.2585` |
+
+**원칙**: PR# 은 dev-staging 머지 시점에 부여, 모든 stage 에서 동일 PR# 유지. RC hotfix 시 새 PR# (hotfix PR 의 번호) + `_rc-NN` 증가.
+
+## Version Bump 위치
+
+| Workflow | When | What |
+|----------|------|------|
+| `dev-staging-post-merge-sync` | dev-staging PR 머지 직후 | `bump-version.sh {PR#}-dev-staging` |
+| `nightly-cut` | daily snapshot 생성 시 | version 변경 없음 (dev-staging 의 그대로 가져감) |
+| `rc-cut` | RC 브랜치 생성 시 | `bump-version.sh {ver}-rc-01` |
+| `rc-post-merge-sync` | RC hotfix 머지 직후 | `bump-version.sh {PR#}-rc-NN` (N 증가) |
+| `main-post-merge-promote` | rc → main 머지 직후 | `bump-version.sh {ver}` (suffix 제거) |
+
+## Tag 컨벤션
+
+| Tag / Status | 시점 | 예시 | 부여자 |
+|--------------|------|------|--------|
+| `v{ver}-dev-staging` (tag) | dev-staging post-merge | `v26.05.2572-dev-staging` | workflow |
+| `rc-gate-pass` (commit status) | dev 머지 후 rc-gate green | (status only, tag 없음) | workflow |
+| `v{ver}-rc-NN` (tag) | rc-cut + hotfix | `v26.05.2572-rc-01`, `v26.05.2585-rc-02` | workflow |
+| `promo/rc-YYYY-Wxx` (tag) | rc-cut 직후 | `promo/rc-2026-W20` | workflow |
+| `v{ver}` (tag) | main 머지 직후 | `v26.05.2585` | workflow |
+| `promo/main-YYYY-Wxx` (tag) | main 머지 직후 (동시) | `promo/main-2026-W20` | workflow |
+| `release/mobile-YYYY-MM` (branch) | mobile-cut | `release/mobile-2026-05` | workflow |
+
+`Wxx` = ISO week number (예: 2026-W20 = 2026년 20주차).
+
+> **Tag naming regex 는 [`RELEASE.md`](../../../RELEASE.md) lock** (TODO). Sentry, Statsig, Vercel, App Store 가 모두 pin. rename = 모든 dashboard 깨짐.
+
+조회:
+- `git tag -l 'v*'` (모든 release version)
+- `git tag -l 'promo/main-*'` (weekly main promotion event)
+- `git log --first-parent main` (main 의 promotion 이벤트, rebase 라 사실상 linear)
+- `gh api repos/.../commits/{sha}/status` (rc-gate-pass 확인)
+
+## 동일 PR# 가 여러 단계 등장하는 의미
+
+| 상태 | 의미 |
+|------|------|
+| `26.05.2572-dev-staging` | dev-staging 에 PR# 2572 머지된 시점 |
+| `26.05.2572-rc-01` | 그 commit 이 rc 로 cut 된 시점 (rc-gate 통과 후) |
+| `26.05.2585-rc-02` | RC 에 hotfix PR# 2585 가 머지된 시점 |
+| `26.05.2585` | rc → main 머지 시 final version (RC 의 최종 hotfix version) |
+
+PR# 가 dev-staging 에서 부여되고 같은 PR# 가 후속 단계에서 suffix 만 바뀌어 등장. 헷갈리지 않게 *suffix 가 stage 표시* 라는 룰 명확.
+
+## 버전 관리 제외 대상 (기존 유지)
+
+- `tests/test_data_seeder`
+- `tests/backend_integration`
+- `apps/integration_scenario_tester`
+
+## 결정해야 할 것
+
+- mobile release branch hotfix 의 PR# 출처 (cherry-pick PR# 인가 새 PR# 인가)
+- main 비-promotion 변경의 version bump 룰 (긴급 hotfix 직접 push 시)
+- `RELEASE.md` 작성 (tag regex single source)
+- merge queue 가 squash commit 에 `bump-version.sh` 결과를 inline 시킬지 별도 commit 으로 둘지
+
+## 관련
+
+- [branch-flow.md](./branch-flow.md) — promotion tag 사용 맥락
+- [dev-staging-pipeline.md](./dev-staging-pipeline.md), [rc-promotion.md](./rc-promotion.md), [main-promotion.md](./main-promotion.md) — 각 stage 의 bump trigger
+- 기존 [CLAUDE.md "Versioning Conventions"](../../../CLAUDE.md#versioning-conventions) — 원본
+
+---
+_Reviewed: 2026-05-19 09:47_

--- a/docs/infra/firebase/BLUEDOC.md
+++ b/docs/infra/firebase/BLUEDOC.md
@@ -1,0 +1,46 @@
+# Firebase
+
+minglit 의 Firebase 컴포넌트 진입점. mobile 의 crash 분석, 디바이스 farm, 원격 config, push notification.
+
+## 사용 컴포넌트
+
+| 컴포넌트 | 용도 | 상세 |
+|----------|------|------|
+| **Crashlytics** | mobile crash, crash-free rate (가장 신뢰성 높은 신호) | TBD |
+| **Test Lab** | 실 디바이스 farm — `rc-gate` 일부 위임 | TBD |
+| **Remote Config** | 단순 kill switch, **version kill source (Tier 2a soft `min_version_soft` + Tier 2b hard `kill_list_hard`)** | TBD |
+| **App Check** (TBD 도입) | request 인증 (App Attest / Play Integrity / reCAPTCHA) — 버전 kill 과 무관, 별개 보안 layer | TBD |
+| **Cloud Messaging (FCM)** | push notification | 기존 mobile 문서 |
+| **Analytics** | 사용자 행동 (보조) | TBD |
+| **App Distribution** | internal track 배포 | TBD |
+
+## Statsig 와의 경계
+
+- **Statsig**: 실험·gate·layered·dependent
+- **Firebase RC**: 단순 on/off, kill switch, cold start fetch, min-version
+- 상세: [../branch-strategy/life-of-flag.md](../branch-strategy/life-of-flag.md)
+
+## Remote Config 운영 룰 (literature gotchas)
+
+- **기본 fetch interval = 12시간** ([Firebase docs](https://firebase.google.com/docs/remote-config/loading)). kill switch 용은 short interval + quota 수용
+- **cold-start default = 안전 상태** — 첫 cold start fetch 실패해도 사용자 미노출
+- **iOS pre-6.3.0 throttle** (5 fetches / 60min). `lastFetchStatus` 체크 필수
+- **flicker**: `fetchAndActivate()` async → bootstrap with cached values
+- **Min-version endpoint**: 6개월 backward compat, `mobile-cut` 이 매월 자동 bump ([../branch-strategy/main-promotion.md](../branch-strategy/main-promotion.md))
+
+## 핵심 컨벤션
+
+- mobile crash = Crashlytics 1차, Sentry = backend / unhandled exception
+- Test Lab 은 `rc-gate` 의 mobile job 일부 위임
+- RC parameter description 에 owner / cleanup 일 명시
+- 신규 mobile release 시 Crashlytics 에 dSYM (iOS) / mapping (Android) 등록
+
+## 관련
+
+- [../branch-strategy/error-detection.md](../branch-strategy/error-detection.md)
+- [../branch-strategy/life-of-flag.md](../branch-strategy/life-of-flag.md)
+- [../branch-strategy/main-promotion.md](../branch-strategy/main-promotion.md) — min-version
+- [../statsig/BLUEDOC.md](../statsig/BLUEDOC.md)
+
+---
+_Reviewed: 2026-05-19 09:47_

--- a/docs/infra/statsig/BLUEDOC.md
+++ b/docs/infra/statsig/BLUEDOC.md
@@ -1,0 +1,43 @@
+# Statsig
+
+minglit 프로젝트가 사용하는 Statsig 컴포넌트의 진입점. Feature gate, 실험, staged rollout, 메트릭 모니터링.
+
+## 사용 컴포넌트
+
+| 컴포넌트 | 용도 | 상세 |
+|----------|------|------|
+| **Feature Gates** | platform 별 flag, dependent gate, cohort 분기 — **Tier 1 feature kill 의 primary 도구** | TBD (`gates.md` 예정) |
+| **Experiments** | A/B 실험, layer 기반 트래픽 분배 | TBD (`experiments.md` 예정) |
+| **Dynamic Config** | layered 값 config | TBD |
+| **Metrics** | flag rollout 메트릭 게이트 (one-sided sequential testing) | TBD |
+| **Holdouts** | 통계적 회귀 검증 (장기 holdout cohort) | TBD |
+
+## Firebase Remote Config 와의 경계
+
+- **Statsig**: cohort 분기, 메트릭 비교, staged rollout, dependent gate
+- **Firebase RC**: 단순 on/off, kill switch, cold start fetch, min-version endpoint
+- 상세: [../branch-strategy/life-of-flag.md](../branch-strategy/life-of-flag.md)
+
+## API 사용 룰 (literature gotchas)
+
+- **layered experiment 에는 `getLayer` 만** ([Statsig 공식 docs](https://docs.statsig.com/layers/)). `getExperiment` 는 비직관적 동작
+- **Holdout + Layer interaction**: holdout cohort 의 layer default 가 일반 사용자와 다름 ([Statsig 공식 docs](https://docs.statsig.com/holdouts/))
+- **Nested dependent gate depth ≤ 2**: 6중 nested = 64 code paths (Featureflip), 테스트 cover 불가
+
+## 핵심 컨벤션
+
+- **Platform 별 flag 분리** — `{area}_{feature}_be / _mu / _mp / _web`
+- **Backend 100% + 1주 soak 후 mobile/web 5% 진입** (dependent gate 강제)
+- **4-flag-as-1 tooling** — 4개 flag cleanup 을 묶음 단위로 (안 그러면 `_be` 만 cleanup, `_mu` 50% 영구 고착)
+- 메타데이터 (owner, cleanup 일, sibling flags, 관련 metric) 콘솔 description 필수
+- staged rollout 메트릭 가드: error rate, crash-free, latency p95 (business metric 은 trip wire 만)
+
+## 관련
+
+- [../branch-strategy/life-of-flag.md](../branch-strategy/life-of-flag.md) — 전체 lifecycle
+- [../branch-strategy/error-detection.md](../branch-strategy/error-detection.md) — Statsig 메트릭의 detection layer 위치
+- [../firebase/BLUEDOC.md](../firebase/BLUEDOC.md)
+- [BLUEDOC convention](../bluedoc/BLUEDOC.md)
+
+---
+_Reviewed: 2026-05-19 09:47_


### PR DESCRIPTION
## Summary

`docs/infra/branch-strategy/` 신규 폴더 (10 docs) + `docs/infra/firebase/`, `docs/infra/statsig/` 진입점 BLUEDOC. release pipeline 의 4-stage 모델 + 3-tier kill switch + safety net 3종 설계 문서화. **구현 없음 — 문서만**.

## 모델 한눈에

```
agents → dev-staging → daily nightly-cut → dev → weekly rc-cut → rc/Wxx → 5d soak → main
                       (merge queue)          (rc-gate post-merge)            (auto-merge)
                                              │
                                              └─▶ rc-gate-pass commit 마다
                                                  backend/web auto-deploy (Spotify 식 trunk)

main → monthly mobile-cut → release/mobile-YYYY-MM → app store
```

## 주요 결정

- **AI agent 가 dev-staging 에 commit** (Spotify 의 trunk 와 다른 우리만의 정당화 — quarantine lane)
- **Backend/web continuous deploy from dev** (mobile 의 monthly cadence 가 backend 발 묶이지 않게)
- **3-tier kill switch**:
  - Tier 1 (feature): Statsig flag flip
  - Tier 2a (version soft): Firebase RC `min_version_soft` + client dual check (store 가용성)
  - Tier 2b (version hard): Firebase RC `kill_list_hard` + EF middleware `X-App-Version` reject
- **Safety nets 3종**: min-version (6개월 backward compat) / expand-migrate-contract CI / flag-registration CI
- **Workflow 우선 자동화** — human roles 은 edge case 핸들러 (release manager, on-call, feature owner, RC owner)
- **`force-update` / `force-update-hard` PR label** 컨벤션 → workflow 자동 RC update
- **CalVer 진행**: `_dev-staging` → `_rc-NN` → `v{ver}` (모든 stage workflow 가 자동 bump)

## Literature 기반

Spotify (engineering blog), Shopify (mobile shipit + API versioning 9개월 overlap), Squarespace (Unfold release engineering), Uber (Submit Queue / iOS monorepo), Featureflip (flag debt 73%), Knight Capital ($460M post-mortem), Google June 2025 outage (unflagged path) 등 22개 source 종합.

## TBD (후속 PR 필요)

- 모든 workflow 구현 (12개 stage-prefixed workflows)
- EF middleware 의 Tier 2b hard kill enforcement
- mobile dual-check SDK 통합 (Play In-App Update / iOS StoreKit)
- `expand-migrate-contract` CI script
- `flag-registration` AST 검출
- cherry-pick 자동화 도구 (Runway / Xray / 자체)
- `RELEASE.md` (tag regex single source)
- `incident-rollback.md` (flag 로 해결 안 되는 hotfix)
- merge queue 도입 (점진 vs 전체)
- nightly cron 시각 / rc-cut 요일 / mobile-cut 날짜 등 cadence 디테일

## Test plan

- [ ] BLUEDOC freshness 검사 통과 (BLUEDOC 3개 모두 ≤50 줄 + Reviewed 필드)
- [ ] 문서 cross-link 확인 (broken link 없음)
- [ ] CodeRabbit 리뷰 통과

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)