### PR TITLE
docs(infra): workflow-spec + branch-strategy cleanup (snapshot model + 3-tier kill switch)

### DIFF
--- a/docs/infra/branch-strategy/BLUEDOC.md
+++ b/docs/infra/branch-strategy/BLUEDOC.md
@@ -1,6 +1,6 @@
 # Branch Strategy
 
-4-stage (`dev-staging → dev → rc → main`) + merge queue + nightly snapshot + `rc-gate` green build picking + feature flag + 3가지 safety net. AI agent 가 dev-staging commit, backend/web 은 dev rc-gate-pass commit 마다 continuous deploy (Spotify 식), mobile 은 main 에서 월 1회 cut. 모든 cadence = target, slip 자연스러움.
+4-stage (`dev-staging → dev → rc → main`) + merge queue + nightly snapshot + `rc-gate` green build picking + feature flag + 3가지 safety net. AI agent 가 dev-staging commit, backend/web 은 dev rc-gate-pass commit 마다 continuous deploy (Spotify 식), mobile 은 main 머지마다 build/store upload (hotfix 없으면 weekly). 모든 cadence = target, slip 자연스러움.
 
 ## 4-stage 모델
 
@@ -29,9 +29,10 @@
 | [dev-staging-pipeline.md](./dev-staging-pipeline.md) | merge queue + pr-gate + safety net CI |
 | [dev-pipeline.md](./dev-pipeline.md) | nightly-cut + rc-gate + auto-deploy chain |
 | [rc-promotion.md](./rc-promotion.md) | rc-cut + soak + hotfix + backport |
-| [main-promotion.md](./main-promotion.md) | rc → main + mobile-cut + min-version |
+| [main-promotion.md](./main-promotion.md) | rc → main + deploy-android-*, deploy-ios-* + min-version |
 | [life-of-flag.md](./life-of-flag.md) | flag lifecycle |
 | [versioning.md](./versioning.md) | CalVer + tag |
+| [specs/](./specs/BLUEDOC.md) | workflow spec, branch spec, execution plan (구현 계약) |
 
 ## 역할 (workflow 가 처리 못하는 edge case 만)
 
@@ -41,7 +42,7 @@
 
 - 코드 promotion = 한 방향 PR, 기능 promotion = flag flip
 - 모든 branch linear ON — dev-staging: squash, dev/rc/main: rebase
-- dev rc-gate-pass = backend/web continuous deploy (Spotify 식); mobile = main 에서 월 1회 cut + cherry-pick 자동화 (TBD)
+- dev rc-gate-pass = backend/web continuous deploy (Spotify 식); main 머지 = mobile build/store upload (`deploy-android-*, deploy-ios-*`)
 - **Hotfix 는 rc 에서, dev-staging 으로 자동 backport** ([rc-promotion.md](./rc-promotion.md))
 - Tag regex 는 `RELEASE.md` lock (TODO)
 

--- a/docs/infra/branch-strategy/branch-flow.md
+++ b/docs/infra/branch-strategy/branch-flow.md
@@ -13,18 +13,20 @@
                                                               │      │
                                                               │      ├─ pass: status rc-gate-pass
                                                               │      │         │
-                                                              │      │         ├─▶ backend-auto-deploy (EF + migration)
-                                                              │      │         └─▶ web-auto-deploy (Vercel 4앱)
+                                                              │      │         ├─▶ deploy-supabase (EF + migration)
+                                                              │      │         └─▶ deploy-vercel (4앱)
                                                               │      │
-                                                              │      └─ fail: bot 자동 이슈 + AI fix PR 경로
+                                                              │      └─ fail: 자동 이슈 + AI agent fix via dev-staging (no auto-revert)
                                                               │
                                                               └─weekly rc-cut (최신 rc-gate-pass commit)──▶ rc/YYYY-Wxx
                                                                                                               │
                                                                                                               └─5일 soak (hotfix 시 시계 리셋)──▶ main
                                                                                                                                                     │
-                                                                                                                                                    └─monthly mobile-cut──▶ release/mobile-YYYY-MM
-                                                                                                                                                                                  │
-                                                                                                                                                                                  └─ App Store
+                                                                                                                                                    └─main-post-merge-promote
+                                                                                                                                                              │
+                                                                                                                                                              ├─▶ deploy-android-{user,partner} ──▶ Play Store
+                                                                                                                                                              └─▶ deploy-ios-{user,partner} ──▶ App Store Connect
+                                                                                                                                                                              (push: main trigger 로 자동, 병렬)
 ```
 
 **Hotfix backport 흐름** (rc → dev-staging):
@@ -33,7 +35,9 @@
 rc/* hotfix 머지 ──auto cherry-pick──▶ backport-branch ──PR──▶ dev-staging
 ```
 
-상세는 [rc-promotion.md](./rc-promotion.md). Mobile cherry-pick 은 backport 불필요 (main 에서 cherry-pick 한 commit 은 이미 dev-staging 에 존재).
+상세는 [rc-promotion.md](./rc-promotion.md).
+
+> Mobile cadence = hotfix 없으면 weekly (rc → main 머지 마다 자동 build/deploy). store review + staged rollout 은 외부 (workflow 밖).
 
 ## 단계별 PR 룰
 
@@ -41,9 +45,8 @@ rc/* hotfix 머지 ──auto cherry-pick──▶ backport-branch ──PR─�
 |-----------|-------------|--------|-----------|-----------|
 | feature/agent → dev-staging | `dev-staging` ← `feat/*`, `fix/*`, `chore/*`, `docs/*` | merge queue enqueue | **squash** (queue) | `dev-staging-pr-gate` |
 | dev-staging → dev | `dev` ← `dev-staging` | daily cron `nightly-cut` | merge (snapshot) | `nightly-pr-gate` |
-| feature → rc | `rc/YYYY-Wxx` ← hotfix branch | hotfix only | rebase | `rc-pr-gate` |
+| hotfix → rc | `rc/YYYY-Wxx` ← hotfix branch | hotfix only | rebase | `rc-pr-gate` |
 | rc → main | `main` ← `rc/YYYY-Wxx` | `rc-soak-check` 가 5일 무커밋 시 PR 생성 + auto-merge | rebase + ff | `main-pr-gate` + `rc-soak-passed` |
-| main → release/mobile-YYYY-MM | branch cut | monthly cron `mobile-cut` | branch 신규 생성 | mobile smoke |
 
 ## Branch Protection 설정
 
@@ -53,7 +56,6 @@ rc/* hotfix 머지 ──auto cherry-pick──▶ backport-branch ──PR─�
 | `dev` | 금지 | **ON** | `nightly-pr-gate` | merge (snapshot) |
 | `rc/YYYY-Wxx` | 금지 | **ON** | `rc-pr-gate` | rebase |
 | `main` | 금지 | **ON** | `main-pr-gate` + `rc-gate-pass` (RC HEAD) + `expand-migrate-contract` + `rc-soak-passed` | rebase |
-| `release/mobile-*` | 금지 | ON | mobile smoke | rebase (cherry-pick) |
 
 Hybrid linear history 금지 — 각 branch 내 일관 (squash or rebase 한 가지).
 
@@ -67,41 +69,53 @@ Hybrid linear history 금지 — 각 branch 내 일관 (squash or rebase 한 가
 | `v{ver}-rc-NN` (tag) | rc-cut + hotfix | `v26.05.2572-rc-01`, `v26.05.2585-rc-02` | workflow |
 | `promo/main-YYYY-Wxx` (tag) | main 머지 직후 | `promo/main-2026-W20` | workflow |
 | `v{ver}` (tag) | main 머지 직후 (동시) | `v26.05.2585` | workflow |
-| `release/mobile-YYYY-MM` (branch) | mobile-cut | `release/mobile-2026-05` | workflow |
 
-> **Tag naming regex 는 [`RELEASE.md`](../../../RELEASE.md) lock** (TODO). 외부 도구 (Sentry, Statsig, Vercel) 가 pin → rename = 모든 dashboard 깨짐.
+> **Tag naming regex 는 [`RELEASE.md`](../../../RELEASE.md) lock** (TODO). 외부 도구 (Sentry, Statsig, Vercel, App Store, Play Console) 가 pin → rename = 모든 dashboard 깨짐.
 
 조회: `git tag -l 'v*'`, `git tag -l 'promo/main-*'`, `gh api repos/.../commits/{sha}/status` (rc-gate-pass)
 
 ## Auto-deploy Chain
 
-dev 의 `rc-gate-pass` status 가 set 되는 즉시 `rc-gate` workflow 가 `workflow_call` 로 호출:
+### dev rc-gate-pass → backend/web (continuous)
 
 ```yaml
 # 개념
-trigger-deploys:
-  needs: rc-gate (green)
+rc-gate (on push to dev):
+  needs: pass
   parallel:
-    - uses: ./.github/workflows/backend-auto-deploy.yml  # EF + migration
-    - uses: ./.github/workflows/web-auto-deploy.yml      # Vercel 4앱
+    - uses: ./.github/workflows/deploy-supabase.yml  # EF + migration
+    - uses: ./.github/workflows/deploy-vercel.yml    # 4앱
 ```
 
-Mobile 은 별도 cadence — main 에서 monthly cut.
+### main push → mobile (every release)
+
+```yaml
+# 개념
+main-post-merge-promote (on push to main):
+  steps:
+    - tag v{ver} + promo/main-Wxx + Sentry marker
+    - Firebase RC `latest_version` = v{ver} 자동 update
+  parallel:
+    # (실제로는 workflow_call 아닌 push: main trigger 로 기존 deploy-* workflows 자동 발동)
+    # - deploy-android-user / deploy-android-partner
+    # - deploy-ios-user / deploy-ios-partner
+```
+
+상세: [specs/workflow-spec.md](./specs/workflow-spec.md).
 
 ## Safety Nets 위치
 
 | Safety Net | 실행 위치 |
 |------------|-----------|
-| min-version endpoint | server-side, `mobile-cut` 시점에 monthly auto-bump ([main-promotion.md](./main-promotion.md)) |
+| Version kill switch (soft/hard) | Firebase RC. soft `latest_version` = `main-post-merge-promote` 가 매 main 머지마다 자동 update / hard `kill_list_hard` = 내부 admin page manual (catastrophic only) |
 | expand-migrate-contract CI | `dev-staging-pr-gate` (destructive op 탐지) + `main-pr-gate` (재검증) |
 | flag-registration CI | `dev-staging-pr-gate` |
 
 ## 결정해야 할 것
 
 - 주간 rc-cut 요일
-- monthly mobile-cut 날짜
 - merge queue 모드 (concurrent vs serial)
-- cherry-pick 자동화 도구 선정 (Runway/Xray/자체)
+- Fastlane / store upload 설정
 - `RELEASE.md` 작성
 
 ---

--- a/docs/infra/branch-strategy/dev-pipeline.md
+++ b/docs/infra/branch-strategy/dev-pipeline.md
@@ -40,61 +40,38 @@ dev 머지 후 자동 발동. 통과 = "이 commit 은 RC 가능 + backend/web p
 
 매트릭스 병렬. 하나라도 실패 = rc-gate 전체 실패.
 
+매트릭스 (app × scenario) 병렬. 하나라도 실패 = rc-gate 전체 실패.
+
 | job | 대상 | 비고 |
 |-----|------|------|
-| `cuj-app-user` | `apps/app_user/patrol_test/cuj/*` | `--flavor dev --dart-define-from-file=.../dev/flutter.env` 필수 |
-| `cuj-app-partner` | `apps/app_partner/patrol_test/cuj/*` | 같음 |
+| `cuj-app-user` × {happy, unhappy, chaos} | `apps/app_user/patrol_test/cuj/*` | `--flavor dev --dart-define-from-file=.../dev/flutter.env`. scenario 별 sub-suite. chaos 미정의 시 후속 정의 (TBD) |
+| `cuj-app-partner` × {happy, unhappy, chaos} | `apps/app_partner/patrol_test/cuj/*` | 동일 |
 | `integration-backend` | `tests/backend_integration/**` | Supabase staging or ephemeral branch |
 | `integration-edge-functions` | `tests/ef_integration/**` | EF 통합 시나리오 |
-| `simulator-happy` | `tests/simulator/scenarios/happy/*` | cascade prob 0.85~0.95 |
-| `simulator-chaos` | `tests/simulator/scenarios/chaos/*` | chaos mode, 회복 검증 |
 | `test-lab-smoke` | Firebase Test Lab — 실 디바이스 4종 | 디바이스 다양성 보강 |
 
 ### 통과 시 (rc-gate-pass)
 
 ```
 1. dev HEAD commit 에 GitHub commit status `rc-gate-pass` set
-2. Auto-deploy chain workflow_call:
-   - backend-auto-deploy (EF + migration apply)
-   - web-auto-deploy (Vercel hooks 4앱)
-3. (Mobile 은 deploy 없음 — main 의 monthly cut 에서 처리)
+2. Auto-deploy chain workflow_call (parallel):
+   - deploy-supabase (EF + migration apply)
+   - deploy-vercel (Vercel hooks 4앱)
+3. (Mobile 은 별도 — main 머지 후 기존 `deploy-android-*` / `deploy-ios-*` workflow 들이 자동 발동)
 ```
 
 ### 실패 시
 
+Snapshot 모델 — **auto-revert 없음**. dev 가 broken 상태로 잠시 머묾, AI agent 가 fix PR 을 normal flow 로 처리.
+
 - Status 미부여 (`rc-gate-pass` 없음 → rc-cut 이 이 commit 안 골라잡음)
-- 자동 이슈 + `P1-high` 라벨 + 직전 `rc-gate-pass` 이후 머지된 PR 작성자들 assignee
-- Bot auto-revert + AI fix flow (다음 섹션)
+- 자동 이슈 + `P1-high` 라벨 + 직전 `rc-gate-pass` 이후 머지된 PR 작성자들 assignee (AI agent 포함)
+- AI agent 가 fix PR 을 dev-staging 으로 작성 → dev-staging-pr-gate → 다음 nightly-cut → 다음 rc-gate 가 검증
+- dev 는 *broken integration 상태* 지만 `pr-gate-core` 가 compile/unit 잡아주니 다른 PR 진입 자체는 OK
 
 ### 60분 비용 예산
 
 전체 60분 안에. 넘으면: 매트릭스 분할, selective run, weekly 로 이동. macOS matrix 필요 시 ubuntu-latest 와 병행.
-
-## Auto-revert + AI Fix Flow
-
-`rc-gate` 실패 시 정상 cadence 유지를 위한 자동화:
-
-```
-[rc-gate fail on dev commit C]
-        │
-        ├─▶ [봇이 culprit 추정]
-        │       - 휴리스틱: 실패한 test area + 그 area 변경한 PR
-        │       - AI agent 분석 (rc-gate log + diff 컨텍스트)
-        │       - 신뢰도 낮으면 직전 rc-gate-pass 이후 PR 들 모두 후보
-        │
-        ├─▶ [봇이 revert PR 자동 생성] (dev-staging 에 PR 머지)
-        │       └─ 다음 nightly-cut 에서 자동으로 dev 로 promote → 다음 rc-gate
-        │
-        └─▶ [이슈 자동 파일링]
-                  body: revert SHA + rc-gate log + 추정 원인
-                  assignee: 원래 PR 작성자 (AI agent)
-                        │
-                        └─▶ AI 가 fix PR 작성 (revert 된 코드의 forward-fix)
-                              │
-                              └─▶ dev-staging-pr-gate → 정상 flow → 다음 rc-gate 검증
-```
-
-**핵심**: revert 와 fix 는 *경쟁* 아니라 *순차*. revert = stabilization (즉시 dev 회복), fix = resolution (async AI 작업).
 
 ## Error-Backoff 정책
 
@@ -102,7 +79,7 @@ dev 머지 후 자동 발동. 통과 = "이 commit 은 RC 가능 + backend/web p
 
 | 연속 실패 | 동작 |
 |----------|------|
-| 1회 | 자동 revert + 이슈 + Slack `#nightly` |
+| 1회 | 자동 이슈 + Slack `#nightly` + AI agent assignee |
 | 2회 (같은 area) | 기존 이슈 댓글 누적, assignee reminder, 영역 owner 추가 알림 |
 | 3회 (같은 area) | `rc-gate-degraded` label + **rc-cut workflow 자동 차단** (다음 weekly cut PR 생성 안 함) + Slack `#release` |
 
@@ -110,14 +87,14 @@ dev 머지 후 자동 발동. 통과 = "이 commit 은 RC 가능 + backend/web p
 
 ## Auto-deploy 워크플로우
 
-### backend-auto-deploy
+### `deploy-supabase`
 
 - Supabase EF 배포 (deno deploy)
 - Migration apply (Supabase CLI)
 - Sentry release marker 부여 (`v{ver}-dev` 형식)
 - 실패 시: retry 1회 → 실패 시 P0 이슈 + on-call
 
-### web-auto-deploy
+### `deploy-vercel`
 
 - Vercel deploy hooks 4앱 (app_user, app_partner, landing_user, landing_partner)
 - 현재 cron 2시간 → push-event 기반으로 교체
@@ -131,8 +108,8 @@ dev 머지 후 자동 발동. 통과 = "이 commit 은 RC 가능 + backend/web p
 ## 결정해야 할 것
 
 - nightly-cut cron 시각
-- AI culprit 식별 도구 (Claude Code agent / 자체 휴리스틱)
 - backoff 임계 (3회 차단이 적정한가)
+- CUJ chaos 시나리오 정의 (현재 미정의)
 - ephemeral Supabase branch (RC 마다 새로 vs 단일 공유)
 - rc-gate selective run 도입 시점
 

--- a/docs/infra/branch-strategy/error-detection.md
+++ b/docs/infra/branch-strategy/error-detection.md
@@ -9,11 +9,11 @@
 | 개발자 로컬 | LSP, analyze, unit | 컴파일/타입/단위 | 초~분 |
 | dev-staging merge queue | `dev-staging-pr-gate` (unit, lint, pgTAP, EF, migration, `expand-migrate-contract`, `flag-registration`, gitleaks) | PR 회귀, 보안, migration 충돌, flag 미등록, contract 위반 | < 10분 |
 | nightly-cut PR | `nightly-pr-gate` (defensive) | 환경 차이 회귀 | < 10분 |
-| dev 머지 후 (자동) | `rc-gate` (CUJ, integration, e2e, simulator, Test Lab) | 통합 회귀, 시나리오, 외부 의존, 디바이스 | 30-60분 |
+| dev 머지 후 (자동) | `rc-gate` (CUJ matrix happy/unhappy/chaos, integration, e2e, Test Lab) | 통합 회귀, 시나리오, 외부 의존, 디바이스 | 30-60분 |
 | Backend/Web auto-deploy | post-deploy smoke, Sentry release marker | deploy infra 회귀 | 분 |
 | rc soak (5일) | rc 의 nightly 재실행 + 내부 dogfooding | 누적 회귀, real-data 이슈 | 일 단위 |
 | main 머지 후 (auto-deploy) | smoke + Sentry/Crashlytics 알람 임계 | prod 회귀 | 분 |
-| mobile-cut 후 | mobile-specific smoke + Test Lab | mobile build 회귀 | 시간 |
+| deploy-android-*, deploy-ios-* 후 | mobile build smoke + Crashlytics dSYM/mapping 등록 | mobile build 회귀, sign 실패 | 시간 |
 | flag canary (allowlist) | Statsig metric (error rate, crash-free) | 실사용자 회귀 (canary) | 분~시간 |
 | flag staged 5/25/100% | 위 + cohort 비교 | 새 cohort 회귀 | 분~시간 |
 | 100% 운영 | uptime, on-call | infra-level, 장기 회귀 | 분~일 |
@@ -53,10 +53,10 @@
 | Detection 신호 | 누가 받음 | 어디서 | Action |
 |---------------|----------|--------|--------|
 | pr-gate 실패 (어느 단계든) | PR 작성자 | GitHub PR | 본인 fix → re-push → re-queue |
-| `rc-gate` 실패 (dev 머지 후) | 직전 rc-gate-pass 이후 머지된 PR 작성자들 | GitHub issue + Slack `#nightly` | bot auto-revert + AI fix PR ([dev-pipeline.md](./dev-pipeline.md)) |
+| `rc-gate` 실패 (dev 머지 후) | 직전 rc-gate-pass 이후 머지된 PR 작성자들 + AI agent | GitHub issue + Slack `#nightly` | AI agent fix PR via dev-staging — dev keeps moving ([dev-pipeline.md](./dev-pipeline.md)) |
 | Backend/web auto-deploy 실패 | on-call | Slack `#release` | retry → rollback ([main-promotion.md](./main-promotion.md) error-backoff) |
 | rc soak 중 회귀 | RC owner | Slack `#release` | hotfix PR → rc | 
-| mobile-cut smoke 실패 | mobile 팀 | GitHub issue | cut 차단, 직전 main commit 시도 |
+| deploy-android-*, deploy-ios-* 실패 | mobile 팀 | GitHub issue + Slack | retry + auto-issue ([main-promotion.md](./main-promotion.md) error-backoff) |
 | Sentry alert (error spike) | 영역 owner | Sentry → Slack | 영역 별 on-call 판단 |
 | Crashlytics velocity alert | mobile 팀 | Firebase → Slack | flag flip OFF 우선 |
 | Statsig metric gate | flag owner | Statsig dashboard | flag rollback ([life-of-flag.md](./life-of-flag.md)) |

--- a/docs/infra/branch-strategy/life-of-flag.md
+++ b/docs/infra/branch-strategy/life-of-flag.md
@@ -152,8 +152,8 @@ Feature flag (Statsig + Firebase Remote Config) 의 생성·soak·rollout·**자
 
 | 항목 | 코드 release | 기능 release |
 |------|--------------|--------------|
-| 트리거 | backend/web: dev rc-gate-pass / mobile: monthly cut | flag ON 조작 |
-| cadence | backend/web: 시간 단위 / mobile: 월 1회 | feature 별 비동기 |
+| 트리거 | backend/web: dev rc-gate-pass / mobile: main 머지 (deploy-android-*, deploy-ios-*) | flag ON 조작 |
+| cadence | backend/web: 시간 단위 / mobile: hotfix 없으면 weekly (rc → main 주기) | feature 별 비동기 |
 | rollback | redeploy 이전 commit (분) | flag flip (즉시) |
 | 통제 권한 | 릴리즈 매니저 | feature owner |
 

--- a/docs/infra/branch-strategy/main-promotion.md
+++ b/docs/infra/branch-strategy/main-promotion.md
@@ -1,11 +1,11 @@
 # Main Promotion
 
-`rc/YYYY-Wxx` 의 soak 통과 시 `main` 으로 머지, 그리고 main 에서 월 1회 `mobile-cut`. Backend/web 의 auto-deploy 는 dev 의 rc-gate-pass 에서 이미 일어남 ([dev-pipeline.md](./dev-pipeline.md)) — main 은 **mobile-stable snapshot** 역할.
+`rc/YYYY-Wxx` 의 soak 통과 시 `main` 으로 머지, main push 직후 기존 mobile deploy workflow (`deploy-android-*`, `deploy-ios-*`) 가 자동 발동. Backend/web 의 auto-deploy 는 dev 의 rc-gate-pass 에서 이미 일어남 ([dev-pipeline.md](./dev-pipeline.md)). main 머지가 곧 mobile release (hotfix 없으면 weekly).
 
 ## 두 가지 이벤트
 
-1. **rc → main weekly 머지** — `rc-soak-check` 가 자동 PR 생성 + 모든 check 통과 시 workflow auto-merge
-2. **mobile-cut** — 월 1회 main 에서 `release/mobile-YYYY-MM` branch cut
+1. **rc → main 머지** — `rc-soak-check` 가 자동 PR 생성 + 모든 check 통과 시 workflow auto-merge
+2. **기존 deploy-* workflow 자동 발동** — main push trigger 로 `deploy-android-{user,partner}`, `deploy-ios-{user,partner}` 가 병렬 실행. store review + staged rollout 은 store-side
 
 ## `main-pr-gate`
 
@@ -18,7 +18,7 @@
 | RC HEAD 의 `rc-gate-pass` status 확인 | 마지막 hotfix 이 rc-gate 통과했는지 |
 | `rc-soak-passed` 자동 마커 | rc-soak-check 가 5일 무커밋 확인 후 부여 |
 
-**모든 check 통과 시 workflow 가 auto-merge** (rebase + fast-forward). 어느 하나라도 실패 시 PR hold + Slack 알림 → human 개입 (edge case 만).
+**모든 check 통과 시 workflow 가 auto-merge** (rebase + fast-forward). 어느 하나라도 실패 시 PR hold + Slack 알림 → human 개입 (edge case).
 
 ## `main-post-merge-promote`
 
@@ -31,62 +31,56 @@ auto-merge 직후 자동:
 4. git tag promo/main-YYYY-Wxx
 5. git push (tags + commit)
 6. Sentry release marker 부여 (v{ver})
+7. Firebase RC `latest_version` = v{ver} (Admin SDK)
 ```
 
-**Backend/web deploy 는 main 에서 하지 않음** — dev 의 rc-gate-pass 에서 이미 prod 반영됨. main 은 mobile 의 stable snapshot.
+> Backend/web deploy 는 main 에서 안 함 — dev 의 rc-gate-pass 에서 이미 prod 반영됨. Mobile deploy 는 별도 workflow.
 
-## `mobile-cut` (월 1회)
+## 기존 Mobile Deploy Workflows (재사용)
 
-### 트리거 / 동작
+main push trigger 로 자동 발동되는 기존 workflows:
 
-- **cron**: 매월 X 일 KST 09:00 (TBD)
-- **manual**: `workflow_dispatch` (긴급 mobile release)
-- 동작:
-  1. 그 시점 main HEAD 에서 `release/mobile-YYYY-MM` 브랜치 cut
-  2. Branch protection 활성화 (direct push 금지, cherry-pick PR 만)
-  3. mobile-specific smoke (build + Test Lab 회귀)
-  4. **`min-version` default 자동 bump** (Safety Net 1 — 아래)
-  5. 안내 issue 생성 (build/upload assignee)
+| Workflow | 대상 | reusable 호출 |
+|----------|------|---------------|
+| `deploy-android-user` | Android (app_user) | `shared-android-deploy.yml` |
+| `deploy-android-partner` | Android (app_partner) | `shared-android-deploy.yml` |
+| `deploy-ios-user` | iOS (app_user) | shared-ios-deploy 가 있는지 확인 (TBD) |
+| `deploy-ios-partner` | iOS (app_partner) | 동일 |
 
-### Release branch lifecycle
+**현재 도구**: 기존 workflow 가 어떤 도구 (Fastlane / native CLI / GitHub Action) 쓰는지 그대로 사용. **Fastlane 통일은 후속 (TBD)**.
 
-- cut 후 ~수일: build, internal QA, app store 업로드 (TestFlight, Internal Track)
-- store 리뷰 ~수일: 필요 시 main 에서 cherry-pick PR (**자동화 도구 필수** — Runway/Xray/자체)
-- store 출시 후: 다음 cut 까지 cherry-pick 핫픽스만
-- 다음 month cut 시 archive 결정 (보존 vs 삭제 — TBD)
+> Mobile cadence = hotfix 없으면 weekly (rc → main 머지 마다). hotfix 로 RC 가 길어지면 자연스럽게 늦어짐.
 
 ## Safety Net 1: Version Kill Switch (Soft + Hard Tier)
-
-**정책**: 6개월 backward compat (마지막 6개 mobile release 지원). 분기별 retrospective 에서 update rate 데이터 보고 조정.
 
 **Source of truth**: Firebase RC parameter (client + server 양쪽이 동일 source 에서 fetch).
 
 ### 두 Tier
 
-| Tier | 메커니즘 | 사용 case |
-|------|----------|----------|
-| **2a. Soft kill** | client 가 `min_version_soft` (RC) + *app store 의 새 버전 가용성* 양쪽 확인 후 force-update screen | 빠른 update 유도. store rollout 중이라 일부만 새 버전 받을 수 있을 때 안전 (못 받는 사용자는 그대로 사용) |
-| **2b. Hard kill** | EF middleware 가 `kill_list_hard` (RC) + `X-App-Version` header 비교 → HTTP 426 reject | catastrophic (데이터 유출, 결제 사고, 보안). 매우 드묾 |
+| Tier | 메커니즘 | RC param | Trigger |
+|------|----------|----------|---------|
+| **2a. Soft kill** | client 가 `latest_version` (RC) 와 자기 버전 비교 + app store 의 새 버전 가용성 확인 후 soft prompt | `latest_version` | `main-post-merge-promote` 가 매 main 머지마다 자동 update |
+| **2b. Hard kill** | EF middleware 가 `kill_list_hard` (RC) + `X-App-Version` header 비교 → HTTP 426 reject | `kill_list_hard` | **내부 admin page manual** (catastrophic incident 시 release manager / on-call). 인증·audit log·role 권한·version dropdown 등이 RC 콘솔 직접 변경보다 안전. **admin page 구현은 본 docs scope 밖, 별도 작업 (TBD)** |
 
 ### Tier 2a: Soft Kill 흐름
 
 ```
 [client cold start]
         ↓
-[Firebase RC fetch: min_version_soft]
+[Firebase RC fetch: latest_version]
         ↓
-[내 version < min_version_soft?]
+[내 version != latest_version?]
         │
         ├─ no → 정상 사용
         │
         └─ yes → [app store check (Play In-App Update / iOS StoreKit) → 새 버전 사용 가능?]
                         │
-                        ├─ yes → force-update screen + 앱스토어 deep-link
+                        ├─ yes → soft update prompt + 앱스토어 deep-link
                         │
                         └─ no → 정상 사용 (UX 사고 방지)
 ```
 
-`min_version_soft` default = 6개월 전 mobile release version. `mobile-cut` 이 매월 자동 bump.
+`latest_version` 은 매 main 머지마다 자동 update. server 가 "최신이 뭐냐" 만 알리고, **누구를 force-update 할지 결정은 클라이언트 + store** (= update 가능한 사람만 prompt 받음).
 
 ### Tier 2b: Hard Kill 흐름 (EF middleware)
 
@@ -102,80 +96,67 @@ auto-merge 직후 자동:
         └─ no → 정상 처리 (다음 middleware)
 ```
 
-`kill_list_hard` default = `[]` (안전 상태).
-
-### Auto-bump (PR label 컨벤션)
-
-| PR Label | Tier | `main-post-merge-promote` 동작 |
-|----------|------|--------------------------------|
-| (없음) | - | 변경 없음 (mobile-cut 의 monthly soft auto-bump 만) |
-| `force-update` | 2a | RC `min_version_soft` 즉시 bump to 이 PR 의 `v{ver}` |
-| `force-update-hard` | 2b | RC `kill_list_hard` 에 현 store-live version 추가 + Slack `#release` + on-call 호출 |
-
-**Single source of truth = Firebase RC**. Client cold start fetch, Server EF Admin SDK fetch + 5분 캐시. RC 콘솔이 운영 dashboard.
+`kill_list_hard` default = `[]` (안전 상태). **변경은 내부 admin page 에서만** — workflow 없음, RC 콘솔 직접 변경도 지양. catastrophic 한 경우만 release manager / on-call 이 admin page 에서 list 추가 + post-mortem + audit log 자동 기록. admin page 의 인증·권한·UX 디테일은 별도 작업.
 
 ### 결정해야 할 것
 
 - App store check API 선택 (Play In-App Update / iOS StoreKit 직접 query)
 - EF middleware 의 RC cache TTL (5분 vs 1분)
-- `force-update-hard` label 부여 권한 (release manager / on-call)
-- Firebase App Check 도입 여부 (별개 — 인증 layer, 버전 kill 과 무관, 보안 강화 후속 PR)
+- admin page 의 `kill_list_hard` 변경 권한 (release manager only? on-call 포함?)
+- admin page 구현 위치 (landing_admin 신규 vs 기존 앱 내 admin 섹션)
+- Firebase App Check 도입 여부 (별개 보안 layer)
 
-**현재 상태**: TODO. EF middleware + mobile dual check + RC parameter 셋업 + Firebase Admin SDK 인증.
+**현재 상태**: TODO. EF middleware + mobile dual check + RC parameter 셋업 + Admin SDK 인증.
 
 ## Safety Net 2: Expand-Migrate-Contract (재검증)
 
-`main-pr-gate` 에서도 `expand-migrate-contract` CI 재실행 (RC 5일 사이 dev 가 더 나갔을 수 있음). 정책 + 구현 상세는 [dev-staging-pipeline.md](./dev-staging-pipeline.md) 참고.
+`main-pr-gate` 에서도 `expand-migrate-contract` CI 재실행 (RC 5일 사이 dev 가 더 나갔을 수 있음). 상세: [dev-staging-pipeline.md](./dev-staging-pipeline.md).
 
 **Policy 요약**:
 - N = 6 mobile releases (= 6개월)
 - Option C: DB schema 만 검증 (API contract test 는 TBD)
 - Destructive op (DROP COLUMN/TABLE, ALTER TYPE) 탐지 + bypass label
 
-## Cherry-pick 자동화 도구
-
-Squarespace 데이터: 자동화 도구 도입 시 핫픽스 **many/월 → 5/년**. 단순 convention 으론 부족.
-
-후보: Runway / Xray / 자체 GitHub Action
-
-**현재 상태**: TODO — 도구 평가 + 도입 결정. (mobile 핵심 ROI 안전망)
-
 ## Error-Backoff 정책
 
-**Workflow infra 실패** (main-pr-gate / main-post-merge-promote / mobile-cut workflow 자체 실패) → **P0 이슈** + on-call.
+**Workflow infra 실패** (main-pr-gate / main-post-merge-promote / deploy-* workflow 자체 실패) → **P0 이슈** + on-call.
 
 ### rc → main 머지 차단
 
 | 조건 | 동작 |
 |------|------|
-| `rc-gate-degraded` (dev-pipeline backoff) | rc → main PR 자동 close + 코멘트 ("nightly recovery 후 재시도") |
+| `rc-gate-degraded` (dev-pipeline backoff) | rc → main PR 자동 close + 코멘트 ("recovery 후 재시도") |
 | `expand-migrate-contract` 검사 실패 | PR 자동 close |
 
-### mobile-cut 실패
+### Mobile deploy (`deploy-android-*` / `deploy-ios-*`) 실패
 
 | 상황 | 동작 |
 |------|------|
-| smoke test 실패 | cut 차단 + 이슈, 직전 main commit cut 시도 (수동) |
-| min-version bump 실패 | cut 진행 가능, alert 알림 (수동 bump) |
-| Store reject | hotfix PR → cherry-pick → re-submit. release branch 유지 |
+| Flutter build 실패 | retry 1회 → `auto-issue` (P1) + mobile 팀 |
+| Sign 실패 (cert 만료 / keystore 문제) | `auto-issue` (P0) + mobile 팀 + on-call |
+| Store upload 실패 (Fastlane) | retry 1회 → `auto-issue` (P1) |
+| Store 검수 reject | mobile 팀이 reject reason 확인 → fix PR via 정상 flow (dev-staging → ... → main → 다음 deploy 사이클) |
 
-### Backend/web auto-deploy 실패 (참고 — 상세는 dev-pipeline)
+### Backend/web auto-deploy 실패 (참고)
 
-main 머지와 무관 (이미 dev 에서 deploy 됐음). dev-pipeline 의 error-backoff 참고.
+main 머지와 무관 (이미 dev 에서 deploy). 상세는 [dev-pipeline.md](./dev-pipeline.md) error-backoff.
 
 ## 결정해야 할 것
 
-- mobile-cut 매월 X 일 (1일 / 첫째 월요일)
-- mobile release branch 보존 정책 (영구 / archive 후 삭제)
-- cherry-pick 자동화 도구 선정
-- mobile build/upload 워크플로우 (Fastlane 자동 vs 수동 단계)
+- Fastlane 설정 (Play `supply`, App Store `pilot`)
+- macOS runner 비용 (iOS build 비용 — GitHub-hosted vs self-hosted)
+- Code signing cert / keystore 관리 (GitHub secret)
+- Crashlytics dSYM / mapping 자동 업로드 도구
+- store-side staged rollout 정책 (1%/5%/25%/100% Play 단계 / App Store phased release)
+- mobile build + Test Lab smoke 의 위치 (deploy workflow 안 vs 분리)
 
 ## 관련
 
-- [dev-pipeline.md](./dev-pipeline.md) — auto-deploy 의 진짜 위치
+- [dev-pipeline.md](./dev-pipeline.md) — backend/web auto-deploy 의 실제 위치 (dev 의 rc-gate-pass)
 - [rc-promotion.md](./rc-promotion.md) — rc → main PR 의 생성
 - [life-of-flag.md](./life-of-flag.md) — flag rollout 은 main 머지와 별도
 - [branch-flow.md](./branch-flow.md) — tag 컨벤션 + protection
+- [specs/workflow-spec.md](./specs/workflow-spec.md) — 기존 deploy-* workflow 의 refactor 상세
 
 ---
 _Reviewed: 2026-05-19 09:47_

--- a/docs/infra/branch-strategy/rc-promotion.md
+++ b/docs/infra/branch-strategy/rc-promotion.md
@@ -124,11 +124,9 @@ RC 는 dev-staging 에서 cut 됐지만 RC 가 사는 동안 dev-staging 이 앞
 - AI 가 resolve 후 push
 - pr-gate 통과 시 머지
 
-### Mobile cherry-pick 의 backport?
+### Mobile 의 backport 불필요
 
-Mobile release branch (`release/mobile-YYYY-MM`) 의 cherry-pick PR 은 main commit 에서 cherry-pick = dev-staging 에 이미 존재 → **backport 불필요**.
-
-긴급 mobile 직접 hotfix (release/mobile-* 에 새 PR — drop-down 룰 위반 case) → dev-staging backport 필요. 드문 case, 발생 시 수동 처리 (TBD: 자동화 여부).
+Mobile 은 release branch 없음 (main 머지 마다 `deploy-android-*, deploy-ios-*` 가 직접 build + store upload). 따라서 mobile-specific backport 흐름 없음. mobile 의 모든 hotfix 는 dev-staging → ... → rc → main 의 정상 흐름을 따라 다음 main push 시 mobile deploy workflow 들이 자동 반영.
 
 ## Supabase Staging Branch (RC 의 backend 검증용)
 
@@ -169,7 +167,7 @@ Mobile release branch (`release/mobile-YYYY-MM`) 의 cherry-pick PR 은 main com
 ## 관련
 
 - [dev-pipeline.md](./dev-pipeline.md) — rc-gate-pass status 가 rc-cut 의 source
-- [main-promotion.md](./main-promotion.md) — rc → main 머지 + 그 후 mobile-cut
+- [main-promotion.md](./main-promotion.md) — rc → main 머지 + deploy-android-*, deploy-ios-*
 - [test-strategy.md](./test-strategy.md) — rc-pr-gate 와 mobile smoke 위치
 - [branch-flow.md](./branch-flow.md) — tag 컨벤션 + protection
 

--- a/docs/infra/branch-strategy/specs/BLUEDOC.md
+++ b/docs/infra/branch-strategy/specs/BLUEDOC.md
@@ -1,0 +1,30 @@
+# Specs
+
+`docs/infra/branch-strategy/` 의 추상 명세 모음. 디자인 문서 (branch-flow / dev-pipeline / main-promotion 등) 가 *무엇* 을 어떻게 운영하는지 정의하고, 본 폴더가 그것의 *구현 계약* 을 정의한다. 실제 구현 (YAML, script) 은 별도 PR.
+
+## 배경
+
+design 문서는 운영자 관점 (cadence, role, policy). spec 문서는 구현자 관점 (workflow input/output, branch protection 설정값, refactor 순서). 둘이 섞이면 design 문서가 비대해지고 구현 변경 시 stale 되기 쉬워 분리.
+
+## 이정표
+
+| 문서 | 내용 |
+|------|------|
+| [workflow-spec.md](./workflow-spec.md) | `.github/workflows/` 의 reusable + entry workflow 의 trigger / input / output / steps / call chain |
+| `branch-spec.md` (예정) | 각 branch 의 protection rule, required check, merge method 의 구현 설정값 |
+| `execution-plan.md` (예정) | 기존 workflow refactor + 신규 구현 + branch 적용 순서 |
+
+## 핵심 컨벤션
+
+- Spec 은 *YAML 디테일 아님*, *계약 정의*. 구현 시 변경되어도 spec 의 의도는 유지
+- workflow naming = `<stage>-<action>` (entry) / 명사·동사형 (reusable)
+- 모든 reusable 은 `workflow_call` trigger
+- spec 변경 시 design 문서와 cross-link 일관 유지 필수
+
+## 관련
+
+- [../BLUEDOC.md](../BLUEDOC.md) — branch-strategy 전체 진입점
+- [BLUEDOC convention](../../bluedoc/BLUEDOC.md)
+
+---
+_Reviewed: 2026-05-19 09:47_

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -1,0 +1,288 @@
+# Workflow Spec
+
+`.github/workflows/` 의 모든 workflow 의 추상 명세. 4-stage branch model + 3-tier kill switch + safety net 의 구현 단일 source. *YAML 디테일 아님 — 의도·계약 정의.*
+
+## 명명 컨벤션
+
+- **Entry workflow**: `<stage>-<action>` 패턴 (예: `dev-staging-pr-gate`, `rc-cut`, `main-post-merge-promote`)
+- **Reusable workflow** (`workflow_call`): 명사·동사형 (예: `pr-gate-core`, `version-bump`)
+- File 이름 = workflow 이름 + `.yml`
+- Stage prefix: `dev-staging-` · `nightly-` · `rc-` · `main-`
+- Reusable 은 prefix 없음
+- **기존 deploy-* workflow 는 이름 유지** (예: `deploy-supabase`, `deploy-android-user`) — 재사용 + trigger 만 refactor
+
+## Reusable Workflows (`workflow_call` building blocks)
+
+### `pr-gate-core`
+
+모든 stage 의 PR 검증 공통 suite.
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `workflow_call` |
+| Inputs | `stage`: dev-staging\|nightly\|rc\|main / `ref`: branch ref / `extra_steps`: array (optional) |
+| Outputs | `status`: pass\|fail / `report_url` |
+| 핵심 steps | test-flutter-apps (matrix) · lint-landing-* · test-supabase (pgTAP) · test-edge-functions (Deno) · check-migration-versions · `expand-migrate-contract` · `flag-registration-check` · gitleaks · CodeRabbit (≤30분 wait) |
+| Called by | `dev-staging-pr-gate`, `nightly-pr-gate`, `rc-pr-gate`, `main-pr-gate` |
+
+### `version-bump`
+
+`bump-version.sh` 실행 + commit + tag.
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `workflow_call` |
+| Inputs | `version`: YY.MM.PR# / `suffix`: ""\|`-dev-staging`\|`-rc-NN` / `commit_message`: string |
+| Outputs | `commit_sha`, `tag_name` |
+| 핵심 steps | `bash scripts/bump-version.sh {version}{suffix}` · commit (with `[skip ci]`) · `git tag v{version}{suffix}` · push |
+| Called by | `dev-staging-post-merge-sync`, `rc-cut`, `rc-post-merge-sync`, `main-post-merge-promote` |
+
+### `rc-gate-suite`
+
+Heavy integration test suite. 60분 예산.
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `workflow_call` |
+| Inputs | `ref`: dev commit SHA |
+| Outputs | `status`: pass\|fail / `failed_jobs`: array |
+| Matrix | (app × scenario): `cuj-app-user × {happy, unhappy, chaos}` + `cuj-app-partner × {happy, unhappy, chaos}` + `integration-backend` + `integration-edge-functions` + `test-lab-smoke` |
+| Called by | `rc-gate` |
+
+> chaos 시나리오 미정의면 CUJ 로 추후 정의 (TBD).
+
+### `auto-issue`
+
+GitHub issue 자동 생성 + Slack 알림.
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `workflow_call` |
+| Inputs | `title`, `body`, `labels` (array), `assignees` (array), `priority`: P0\|P1\|P2\|P3, `slack_channel`: optional |
+| Outputs | `issue_number` |
+| 핵심 steps | `gh issue create` + Slack webhook fire (priority 별 채널) |
+| Called by | 모든 workflow 의 실패 path |
+
+### `backport-pr`
+
+Cross-branch cherry-pick PR 자동 생성.
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `workflow_call` |
+| Inputs | `source_branch`, `target_branch`, `commits`: SHA array |
+| Outputs | `pr_number`, `has_conflict`: bool |
+| 핵심 steps | `git cherry-pick` · 충돌 시 partial commit + label `backport-conflict` · push to `backport/{source}-{target}-{sha8}` · `gh pr create` |
+| Called by | `rc-hotfix-backport` |
+
+## Entry Workflows
+
+### dev-staging
+
+#### `dev-staging-pr-gate`
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `pull_request` (base: `dev-staging`) + `merge_group` (GitHub merge queue) |
+| Outputs | required status check |
+| Steps | calls `pr-gate-core` (stage=dev-staging) |
+| Required for | dev-staging merge queue + PR merge |
+
+#### `dev-staging-post-merge-sync`
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `push` to `dev-staging` (merge queue 통과 후) |
+| Inputs | (from event) PR number, merged SHA |
+| Outputs | tag `v{YY.MM.PR#}-dev-staging` |
+| Steps | calls `version-bump` (suffix=`-dev-staging`, version=`{YY.MM.PR#}`) |
+
+### nightly (dev 진입)
+
+#### `nightly-cut`
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `schedule` (daily KST 02:00 TBD) + `workflow_dispatch` |
+| Inputs | (none, or optional ref override) |
+| Outputs | PR number (dev-staging → dev) or skip |
+| Steps | (1) 이전 `nightly-cut` PR open 이면 skip + Slack (2) 가장 최근 `v*-dev-staging` tag SHA 조회 (3) dev HEAD == 그 SHA 이면 skip ("no new commits") (4) 아니면 `gh pr create` (base=dev, head=dev-staging) + auto-merge 활성화 |
+
+#### `nightly-pr-gate`
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `pull_request` (base: `dev`) |
+| Steps | calls `pr-gate-core` (stage=nightly) |
+| Required for | dev branch protection |
+
+#### `rc-gate`
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `push` to `dev` (= nightly-cut PR merge 직후) |
+| Outputs | commit status `rc-gate-pass` (success only) |
+| Steps | (1) calls `rc-gate-suite` (2) **success**: set commit status `rc-gate-pass` → parallel `workflow_call` 기존 `deploy-supabase` + `deploy-vercel` (3) **failure**: `auto-issue` (P1, label `rc-gate-failure`, assignee=직전 rc-gate-pass 이후 머지된 PR 작성자들). dev 는 broken 상태로 잠시 머묾, AI agent 가 fix PR 을 dev-staging 으로 normal flow 로 작성 → 다음 nightly-cut → 다음 rc-gate 가 검증 |
+| Backoff | 같은 area 3회 연속 실패 시 `rc-cut` 자동 차단 (다음 weekly cut PR 안 만듦) |
+
+> **No auto-revert** — snapshot 모델: 실패 = no tag, dev keeps moving, 새 fix 가 자연스럽게 다음 rc-gate 에서 검증됨.
+
+#### `deploy-supabase` (기존, refactor 대상)
+
+| 항목 | 값 |
+|------|----|
+| 현재 trigger | `push` to dev or main + paths filter (`supabase/migrations/**`, `supabase/functions/**`) |
+| Refactor 후 trigger | `workflow_call` from `rc-gate` (success) + `push` to main |
+| Outputs | deploy status, Sentry release marker |
+| Steps | (1) Supabase migration apply (2) EF deploy (3) Sentry release marker (4) post-deploy smoke (5) 실패 시 retry → `auto-issue` (P0) + on-call |
+
+#### `deploy-vercel` (기존, refactor 대상)
+
+| 항목 | 값 |
+|------|----|
+| 현재 trigger | `schedule` cron 2시간 + `workflow_dispatch` |
+| Refactor 후 trigger | `workflow_call` from `rc-gate` (success) + `push` to main (cron 폐기) |
+| Outputs | deploy status |
+| Steps | Vercel deploy hooks (4앱 parallel) · 실패 시 retry → `auto-issue` (P0) |
+
+### rc
+
+#### `rc-cut`
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `schedule` (weekly KST TBD) + `workflow_dispatch` |
+| Outputs | branch `rc/YYYY-Wxx` + tag `v{ver}-rc-01` + tag `promo/rc-YYYY-Wxx` |
+| Steps | (1) 현재 `rc/*` 살아있는지 확인 → 있으면 skip + Slack `#release` (hotfix 로 길어지는 중) (2) dev 의 최신 `rc-gate-pass` status SHA query (`gh api`) (3) 없으면 (3일+ green 없음) alert + abort (4) `git branch rc/YYYY-Wxx <SHA>` + push (5) calls `version-bump` (suffix=`-rc-01`) (6) `git tag promo/rc-YYYY-Wxx` + push (7) branch protection 활성화 (8) Slack `#release` 알림 |
+
+#### `rc-pr-gate`
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `pull_request` (base: `rc/*`) |
+| Steps | calls `pr-gate-core` (stage=rc) |
+| Required for | rc branch protection |
+
+#### `rc-post-merge-sync`
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `push` to `rc/*` (hotfix merge 후) |
+| Outputs | tag `v{ver}-rc-NN` (NN+1) |
+| Steps | (1) 현 rc 의 마지막 `v*-rc-*` tag 의 NN 파싱 (2) calls `version-bump` (suffix=`-rc-{NN+1}`) |
+
+#### `rc-soak-check`
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `schedule` (daily KST TBD) |
+| Outputs | rc → main PR (5일 무커밋 시) or skip |
+| Steps | (1) `rc/*` 존재 확인 → 없으면 종료 (2) rc HEAD 의 `committer date` 조회 (3) committer date 가 5일 이전이면: `gh pr create base=main head=rc/YYYY-Wxx` + label `rc-soak-passed` + auto-merge 활성화 |
+
+#### `rc-hotfix-backport`
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `push` to `rc/*` (rc-post-merge-sync 와 parallel) |
+| Outputs | backport PR (rc/* → dev-staging) |
+| Steps | calls `backport-pr` (source=`rc/*`, target=dev-staging, commits=[새 hotfix SHA]) · 충돌 시 `auto-issue` (P1, AI agent assignee) |
+
+### main
+
+#### `main-pr-gate`
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `pull_request` (base: `main`) |
+| Steps | (1) calls `pr-gate-core` (stage=main) (2) RC HEAD 의 `rc-gate-pass` commit status 확인 (3) PR 의 `rc-soak-passed` label 확인 |
+| Required for | main branch protection |
+
+#### `main-post-merge-promote`
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `push` to `main` (rc → main auto-merge 직후) |
+| Outputs | tag `v{ver}` + tag `promo/main-YYYY-Wxx` + Sentry marker + Firebase RC `latest_version` update |
+| Steps | (1) calls `version-bump` (suffix="") (2) `git tag promo/main-YYYY-Wxx` + push (3) Sentry release marker `v{ver}` (4) Firebase RC `latest_version` = `v{ver}` (Admin SDK) (5) **deploys 는 별도 — push: main trigger 로 기존 workflow 들이 자동 발동** |
+
+> main push 후 자동 발동되는 기존 deploy workflows (병렬):
+> - `deploy-supabase` — EF + migration
+> - `deploy-vercel` — 4 web 앱
+> - `deploy-android-user`, `deploy-android-partner` (each calls `shared-android-deploy`)
+> - `deploy-ios-user`, `deploy-ios-partner` (TBD: shared-ios-deploy reusable 있는지 확인)
+
+> Mobile cadence = main 머지 마다 weekly build/upload (hotfix 없으면). store review + staged rollout 은 store-side.
+> Fastlane vs native action 등 mobile deploy 의 구체 도구는 기존 workflow 따름 (Fastlane 통일 검토는 후속 TBD).
+
+## Workflow Chain Diagram
+
+```
+[agent PR opens to dev-staging]
+       ↓
+[dev-staging-pr-gate] ──merge queue 통과──▶ dev-staging push
+                                                ↓
+                                         [dev-staging-post-merge-sync]
+                                                ↓ tag v{ver}-dev-staging
+
+[daily KST 02:00]
+    ↓
+[nightly-cut] ──PR created──▶ [nightly-pr-gate] ──auto-merge──▶ dev push
+                                                                    ↓
+                                                              [rc-gate]
+                                                              ├ success ─▶ status rc-gate-pass + [deploy-supabase] + [deploy-vercel]
+                                                              │              ↓ Sentry release
+                                                              │
+                                                              └ failure ─▶ [auto-issue P1] (AI agent assignee → dev-staging fix PR)
+                                                                          (no auto-revert — dev 잠시 broken, 다음 fix 가 다음 rc-gate 에서 검증)
+
+[weekly cron]
+    ↓
+[rc-cut] ──branch out from latest rc-gate-pass commit──▶ rc/YYYY-Wxx (+ v{ver}-rc-01)
+                                                                ↓ (soak, hotfix 가능)
+                                                                │
+                                                          [rc-pr-gate] (hotfix PR)
+                                                                ↓ rc push
+                                                                ↓ (parallel)
+                                                          [rc-post-merge-sync] ──▶ v{ver}-rc-NN
+                                                          [rc-hotfix-backport]  ──▶ backport PR to dev-staging
+
+[daily cron, rc 존재 시]
+    ↓
+[rc-soak-check] ──5일 무커밋──▶ rc → main PR (label rc-soak-passed)
+                                       ↓ [main-pr-gate] → auto-merge
+                                       ↓ main push
+                                       ↓
+                                 [main-post-merge-promote]
+                                       ↓ tag v{ver} + promo/main-Wxx + Sentry release
+                                       ↓ Firebase RC `latest_version` = v{ver}
+                                       ↓ (parallel)
+                                 [deploy-android-user, deploy-android-partner] ──▶ Play Store
+                                 [deploy-ios-user, deploy-ios-partner] ──▶ App Store Connect
+                                 (각 workflow 가 push: main trigger 로 자동 발동, 병렬)
+
+(Tier 2b hard kill = 내부 admin page manual operation, workflow 없음 — catastrophic incident response 용. admin page 구현은 별도 작업)
+```
+
+## 결정해야 할 것
+
+- `pr-gate-core` 의 stage 별 `extra_steps` 명세
+- `version-bump` 의 commit 방식 (별도 commit vs squash inline)
+- `rc-gate-suite` matrix 분할 (60분 예산)
+- CUJ chaos 시나리오 정의 (현재 미정의)
+- Fastlane 설정 (Play `supply`, App Store `pilot`) + cert / keystore 관리
+- macOS runner 비용 (iOS build 비용)
+- Firebase Admin SDK 인증 (GitHub secret 으로 service account)
+- Slack webhook URL 관리 (`#nightly`, `#release` 별도 secret)
+
+## 관련
+
+- [../branch-flow.md](../branch-flow.md) — workflow 가 흘러가는 branch 그림
+- [../test-strategy.md](../test-strategy.md) — pr-gate-core 와 rc-gate-suite 의 test 내용
+- [../error-detection.md](../error-detection.md) — auto-issue 의 priority 와 채널
+- [../life-of-flag.md](../life-of-flag.md) — flag lifecycle
+- [../versioning.md](../versioning.md) — version-bump 의 suffix 진행
+- `branch-spec.md` (예정) — 각 entry workflow 가 어느 branch protection 의 required check 인지
+- `execution-plan.md` (예정) — 기존 workflow refactor + 구현 순서
+
+---
+_Reviewed: 2026-05-19 09:47_

--- a/docs/infra/branch-strategy/test-strategy.md
+++ b/docs/infra/branch-strategy/test-strategy.md
@@ -1,6 +1,6 @@
 # Test Strategy
 
-4-stage 모델 (`dev-staging → dev → rc → main`) + flag staged rollout 환경에서, *어떤 테스트가 어느 단계에서 도는가* 의 단일 source. 빠른 검사 = `pr-gate` (각 단계), 무거운 검사 = `rc-gate` (dev 의 post-merge), 프로덕션 검증 = `mobile-cut` + flag staged.
+4-stage 모델 (`dev-staging → dev → rc → main`) + flag staged rollout 환경에서, *어떤 테스트가 어느 단계에서 도는가* 의 단일 source. 빠른 검사 = `pr-gate` (각 단계), 무거운 검사 = `rc-gate` (dev 의 post-merge), 프로덕션 검증 = `deploy-android-*, deploy-ios-*` smoke + flag staged.
 
 ## 단계별 게이트
 
@@ -8,12 +8,12 @@
 |------|--------|------|---------|
 | dev-staging 머지 전 | `dev-staging-pr-gate` (unit · lint · analyze · pgTAP · EF test · migration check · `expand-migrate-contract` · `flag-registration` · gitleaks) | < 10분 | merge queue PR drop |
 | dev 머지 전 | `nightly-pr-gate` (dev-staging-pr-gate 와 동일 — defensive) | < 10분 | nightly-cut PR drop |
-| dev 머지 후 (자동) | `rc-gate` (full: CUJ · integration · e2e · simulator · Test Lab smoke) | 30-60분 | 자동 이슈 + AI fix flow. status 미부여 |
+| dev 머지 후 (자동) | `rc-gate` (CUJ matrix happy/unhappy/chaos · integration · e2e · Test Lab smoke) | 30-60분 | 자동 이슈 + AI fix flow via dev-staging. `rc-gate-pass` 미부여 |
 | rc 머지 전 (hotfix) | `rc-pr-gate` (pr-gate + mobile smoke) | < 15분 | hotfix PR drop |
 | main 머지 전 (rc → main) | `main-pr-gate` (pr-gate + `expand-migrate-contract` 재검증 + RC HEAD 의 `rc-gate-pass` 확인) | 분 | promotion PR 보류 |
 | rc → main PR | workflow auto-merge (모든 check 통과 시) | 분 | check 실패 시 PR hold + alert |
 | Backend/Web auto-deploy 후 | post-deploy smoke + Sentry/Crashlytics 알람 임계 | 분 | auto-rollback ([main-promotion.md](./main-promotion.md)) |
-| mobile-cut 후 | mobile-specific smoke (build + Test Lab 회귀) | 시간 | cut 차단, 직전 main commit 시도 |
+| deploy-android-*, deploy-ios-* 후 | mobile build smoke (Fastlane upload 검증) | 시간 | retry 1회 → auto-issue + mobile 팀 |
 | Flag canary (allowlist) | Statsig metric gates | 며칠 | flag flip OFF |
 | Flag staged (5/25/100%) | Statsig one-sided sequential | 48h/72h/7일 | hold or rollback |
 
@@ -83,7 +83,7 @@ RC 의 hotfix 만 받음. `pr-gate` + 추가 mobile smoke. 머지 시 `rc-post-m
 | 부하/성능 | `rc-gate` (주 1회) or staged rollout 메트릭 | 매일 무거움 |
 | backend ↔ mobile 계약 호환 | `expand-migrate-contract` CI + flag canary 메트릭 | 다층 안전망 |
 | 실 디바이스 다양성 | `rc-gate` 의 Firebase Test Lab | 시뮬레이터 한계 보완 |
-| Mobile 회귀 (cut 직후) | `mobile-cut` 의 mobile-specific smoke | app store 업로드 전 마지막 |
+| Mobile 회귀 (deploy 직후) | `deploy-android-*, deploy-ios-*` 의 build smoke | store upload 전 마지막 |
 
 ## 결정해야 할 것
 

--- a/docs/infra/branch-strategy/versioning.md
+++ b/docs/infra/branch-strategy/versioning.md
@@ -46,7 +46,6 @@
 | `promo/rc-YYYY-Wxx` (tag) | rc-cut 직후 | `promo/rc-2026-W20` | workflow |
 | `v{ver}` (tag) | main 머지 직후 | `v26.05.2585` | workflow |
 | `promo/main-YYYY-Wxx` (tag) | main 머지 직후 (동시) | `promo/main-2026-W20` | workflow |
-| `release/mobile-YYYY-MM` (branch) | mobile-cut | `release/mobile-2026-05` | workflow |
 
 `Wxx` = ISO week number (예: 2026-W20 = 2026년 20주차).
 

--- a/docs/infra/firebase/BLUEDOC.md
+++ b/docs/infra/firebase/BLUEDOC.md
@@ -8,7 +8,7 @@ minglit 의 Firebase 컴포넌트 진입점. mobile 의 crash 분석, 디바이�
 |----------|------|------|
 | **Crashlytics** | mobile crash, crash-free rate (가장 신뢰성 높은 신호) | TBD |
 | **Test Lab** | 실 디바이스 farm — `rc-gate` 일부 위임 | TBD |
-| **Remote Config** | 단순 kill switch, **version kill source (Tier 2a soft `min_version_soft` + Tier 2b hard `kill_list_hard`)** | TBD |
+| **Remote Config** | 단순 kill switch, **version kill source (Tier 2a soft `latest_version` + Tier 2b hard `kill_list_hard`)** | TBD |
 | **App Check** (TBD 도입) | request 인증 (App Attest / Play Integrity / reCAPTCHA) — 버전 kill 과 무관, 별개 보안 layer | TBD |
 | **Cloud Messaging (FCM)** | push notification | 기존 mobile 문서 |
 | **Analytics** | 사용자 행동 (보조) | TBD |


### PR DESCRIPTION
## Summary

- **신규**: `specs/workflow-spec.md` (288줄) + `specs/BLUEDOC.md` — workflow 구현 계약 명세 (reusable 5 + entry 14, trigger/input/output/steps)
- **정합성 수정**: 기존 branch-strategy docs 10개 + firebase BLUEDOC — snapshot 모델 일관성, mobile weekly cadence, kill switch 단순화

## 핵심 변경

### Snapshot 모델 일관성
- `rc-gate` 실패 시 **auto-revert 전체 제거**. dev 는 broken integration 상태로 잠시 머묾, AI agent 가 fix PR 을 dev-staging 으로 normal flow 작성 → 다음 nightly-cut → 다음 rc-gate 검증

### CUJ matrix
- `simulator-happy`/`simulator-chaos` 폐기 → `cuj-app-{user,partner} × {happy, unhappy, chaos}` matrix (chaos 시나리오 미정의면 후속 정의)

### Mobile cadence (월 1회 → weekly)
- `release/mobile-YYYY-MM` branch 폐기
- `mobile-cut`, `mobile-hotfix-pr-gate` 폐기
- 기존 `deploy-android-{user,partner}`, `deploy-ios-{user,partner}` 재사용 (main push trigger 자동 발동)
- mobile cadence = hotfix 없으면 weekly (rc → main 머지마다)

### Backend/web deploy
- 기존 `deploy-supabase`, `deploy-vercel` 재사용 (trigger refactor: cron → rc-gate-pass + push:main)
- 새 `rc-deploy-*` workflow 안 만듦

### Kill switch 단순화 (3-tier 유지, 메커니즘만 단순)
- `monthly-min-version-bump` workflow 폐기
- `force-update` / `force-update-hard` PR label 컨벤션 전체 폐기
- Tier 2a (soft): `latest_version` 단일 RC param + `main-post-merge-promote` 가 매 main 머지마다 자동 update
- Tier 2b (hard): `kill_list_hard` = **내부 admin page manual** (workflow 없음, catastrophic 응답은 자동화 부적합)

## 14개 doc 최종 구조

```
docs/infra/branch-strategy/
├── BLUEDOC.md (50줄)
├── branch-flow.md
├── test-strategy.md
├── error-detection.md
├── dev-staging-pipeline.md
├── dev-pipeline.md
├── rc-promotion.md
├── main-promotion.md
├── life-of-flag.md
├── versioning.md
└── specs/
    ├── BLUEDOC.md (30줄)
    ├── workflow-spec.md (288줄)  ← 신규
    ├── branch-spec.md (예정)
    └── execution-plan.md (예정)
docs/infra/firebase/BLUEDOC.md (소소한 RC param 이름 sync)
```

## TBD (다음 PR 들)

- `branch-spec.md`: branch 별 protection rule 구현 설정값
- `execution-plan.md`: 기존 workflow refactor + 신규 구현 순서
- 내부 admin page (Tier 2b hard kill UI)
- Fastlane 통일 검토
- `RELEASE.md` (tag regex single source)

## Test plan

- [ ] BLUEDOC freshness 검사 통과 (3개 BLUEDOC 모두 ≤50)
- [ ] 문서 cross-link 깨짐 없음
- [ ] CodeRabbit 리뷰 통과

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)