### PR TITLE
chore(ci): auto-format push uses GitHub App token instead of PAT

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -677,13 +677,23 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Mint a fresh 1h installation token from the minglit-agent-code-review
+      # GitHub App. Replaces the prior GH_PAT_VERSION_BUMP PAT which 403'd after
+      # the team-minglit org transfer (org policy rejects user-scoped classic
+      # PATs for write ops). App credentials don't expire — only the per-run
+      # token does, and that's minted automatically. Pushes attributed to the
+      # App identity still trigger downstream workflows (unlike default
+      # GITHUB_TOKEN-authored pushes, which GitHub anti-loop-blocks).
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: '3672607'
+          private-key: ${{ secrets.REVIEWER_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
-          # persist-credentials: false keeps the default GITHUB_TOKEN out of
-          # git config; the explicit PAT is injected only in the push step so
-          # pub get / dart format don't see it.
-          persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
@@ -701,20 +711,13 @@ jobs:
         run: dart format .
         working-directory: apps/app_partner
       - name: Commit changes if needed
-        env:
-          # PAT triggers downstream workflow re-runs on the push commit;
-          # default GITHUB_TOKEN-authored pushes don't (anti-loop protection),
-          # so a real PAT is required to keep CI in sync with the formatted tree.
-          GH_PAT: ${{ secrets.GH_PAT_VERSION_BUMP }}
         run: |
           if [[ -n "$(git status --porcelain)" ]]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git config user.name "minglit-agent-code-review[bot]"
+            git config user.email "minglit-agent-code-review[bot]@users.noreply.github.com"
             git add -- '**/*.dart'
             git commit -m "chore: auto-format"
-            git remote set-url origin "https://x-access-token:${GH_PAT}@github.com/${GITHUB_REPOSITORY}.git"
             git push origin HEAD:"${GITHUB_HEAD_REF}"
-            git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
           else
             echo "No formatting changes needed"
           fi


### PR DESCRIPTION
## Summary

\`GH_PAT_VERSION_BUMP\` (Mark-Yun user-scoped classic PAT) 403's against \`team-minglit/minglit\` since the org transfer — org policy rejects classic user PATs for write ops. Every PR touching \`.dart\` files has been failing at the push-back step (\`dart format\` succeeds + local commit succeeds, but \`git push\` returns 403, so the formatted commit is lost and CI fails).

## Changes

\`pr-gate.yml\` auto-format job:
- New step: \`actions/create-github-app-token@v2\` mints a 1h installation token from the \`minglit-agent-code-review\` App (App ID \`3672607\`, repo secret \`REVIEWER_BOT_PRIVATE_KEY\`)
- \`actions/checkout@v6\` uses the App token directly (no more \`persist-credentials: false\` workaround)
- Push step drops the manual \`git remote set-url\` PAT dance — the checkout-installed credential just works
- Bot identity for the commit changed from \`github-actions[bot]\` to \`minglit-agent-code-review[bot]\` (consistent with reviewer bot)

## Why GitHub App over a new fine-grained PAT

| | PAT (fine-grained) | GitHub App (this PR) |
|---|---|---|
| Token expiry | 1y max, manual rotation | 1h auto-rotate, infra-managed |
| Rate limit | 5000/hr shared | 5000/hr per installation |
| Bot identity | user-attributed | distinct \`[bot]\` actor |
| Org seat | possible | none |

We already set this App up for the reviewer worker. It's the same one — just adding push capability.

## Test plan

- [ ] Merge → next .dart-touching PR: auto-format step posts \`chore: auto-format\` as \`minglit-agent-code-review[bot]\`, CI re-runs on the formatted commit
- [ ] Non-.dart PR: auto-format job skipped via \`dart_files == 'false'\` filter
- [ ] App token mint succeeds (verify in step output \`expires_at\`)

## Follow-up

- Once verified, \`GH_PAT_VERSION_BUMP\` can be revoked (\`gh secret delete\`) — \`sync-pr-branches.yml\` is the only other consumer; we can switch that too if/when we touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)