### PR TITLE
fix(integration-test): refund_policy_v2_test parties.name → parties.title — Fix #2644

### DIFF
--- a/supabase/functions/_integration_tests/cuj/event/refund_policy_v2_test.ts
+++ b/supabase/functions/_integration_tests/cuj/event/refund_policy_v2_test.ts
@@ -82,7 +82,8 @@ async function seedPartnerEvent(
   // 2. Party
   const { data: party, error: partyErr } = await db
     .from("parties")
-    .insert({ partner_id: partnerId, name: "Test Party" })
+    // Fix #2640-followup: parties 테이블 컬럼은 title (name 아님) — schema cache PGRST204 차단
+    .insert({ partner_id: partnerId, title: "Test Party" })
     .select("id")
     .single();
   if (partyErr || !party) throw new Error(`seedPartnerEvent party: ${partyErr?.message}`);

--- a/supabase/functions/_integration_tests/cuj/event/refund_policy_v2_test.ts
+++ b/supabase/functions/_integration_tests/cuj/event/refund_policy_v2_test.ts
@@ -82,7 +82,7 @@ async function seedPartnerEvent(
   // 2. Party
   const { data: party, error: partyErr } = await db
     .from("parties")
-    // Fix #2640-followup: parties 테이블 컬럼은 title (name 아님) — schema cache PGRST204 차단
+    // Fix #2644: parties 테이블 컬럼은 title (name 아님) — schema cache PGRST204 차단
     .insert({ partner_id: partnerId, title: "Test Party" })
     .select("id")
     .single();


### PR DESCRIPTION
Scheduler: swe-opus-1

## Summary

`parties` 테이블 컬럼명 `title`인데 `refund_policy_v2_test.ts`의 `seedPartnerEvent` 헬퍼가 `name` 사용 → schema cache PGRST204 → 모든 supabase EF integration test job 실패.

1단어 변경 (`name: "Test Party"` → `title: "Test Party"`).

## Root cause

`supabase/migrations/20260301000003_03_schema_events.sql`:
```sql
create table public.parties (
  id uuid not null default gen_random_uuid(),
  partner_id uuid not null references public.partners(id) on delete cascade,
  ...
  title text not null,   -- ← 실제 컬럼명 (name 아님)
  ...
);
```

`#2520` 머지 시 들어온 dev-side 버그. 모든 후속 supabase PR을 blocking 중.

## Test plan

- [ ] CI test-ef-integration 통과 — 이전 8/9 CUJ fail → 모두 pass
- [ ] 다른 open supabase PR (#2641, #2595 등) rebase 후 동일 fail 사라짐 확인

Closes #2644