### PR TITLE
fix(ci): pin Flutter to 3.41.9 — flutter_quill 11.5.0 incompatible with 3.44.0

### DIFF
--- a/.github/workflows/monitor-cuj-coverage.yml
+++ b/.github/workflows/monitor-cuj-coverage.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          flutter-version: '3.41.9'  # Fix #2640: flutter_quill 11.5.0 incompatible with Flutter 3.44.0
           cache: true
 
       - name: Run coverage report (JSON)

--- a/.github/workflows/monitor-mds-render-coverage.yml
+++ b/.github/workflows/monitor-mds-render-coverage.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          flutter-version: '3.41.9'  # Fix #2640: flutter_quill 11.5.0 incompatible with Flutter 3.44.0
           cache: true
 
       - name: Run coverage report (JSON)

--- a/.github/workflows/monitor-patrol-e2e.yml
+++ b/.github/workflows/monitor-patrol-e2e.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          flutter-version: '3.41.9'  # Fix #2640: flutter_quill 11.5.0 incompatible with Flutter 3.44.0
           cache: true
 
       - name: Install patrol_cli

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -241,7 +241,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         with:
-          channel: 'stable'
+          flutter-version: '3.41.9'  # Fix #2640: flutter_quill 11.5.0 incompatible with Flutter 3.44.0
           cache: true
       - name: Cache pub packages
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
@@ -446,7 +446,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          flutter-version: '3.41.9'  # Fix #2640: flutter_quill 11.5.0 incompatible with Flutter 3.44.0
           cache: true
       - uses: actions/cache@v5
         with:
@@ -486,7 +486,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          flutter-version: '3.41.9'  # Fix #2640: flutter_quill 11.5.0 incompatible with Flutter 3.44.0
           cache: true
       # Wipe any volume left by a prior run on this host so `supabase start`
       # initializes a fresh DB and auto-applies all migrations from scratch.
@@ -696,7 +696,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
       - uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          flutter-version: '3.41.9'  # Fix #2640: flutter_quill 11.5.0 incompatible with Flutter 3.44.0
           cache: true
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/shared-android-deploy.yml
+++ b/.github/workflows/shared-android-deploy.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          flutter-version: '3.41.9'  # Fix #2640: flutter_quill 11.5.0 incompatible with Flutter 3.44.0
           cache: true
 
       - name: Cache Gradle

--- a/.github/workflows/shared-cuj-integration.yml
+++ b/.github/workflows/shared-cuj-integration.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          flutter-version: '3.41.9'  # Fix #2640: flutter_quill 11.5.0 incompatible with Flutter 3.44.0
           cache: true
 
       # Self-hosted runner: Flutter SDK cache dir 가 다른 user 소유 → git 거부.

--- a/.github/workflows/sync-test-coverage.yml
+++ b/.github/workflows/sync-test-coverage.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         with:
-          channel: 'stable'
+          flutter-version: '3.41.9'  # Fix #2640: flutter_quill 11.5.0 incompatible with Flutter 3.44.0
           cache: true
 
       - name: Install dependencies


### PR DESCRIPTION
Scheduler: swe-sonnet-1

## Summary

Flutter 3.44.0이 \`TextInputClient.onFocusReceived()\`를 추가했으나 flutter_quill 11.5.0이 구현하지 않아, 모든 Flutter 앱 PR CI가 실패 중입니다.

**Root cause**: Flutter 3.44.0 added \`bool onFocusReceived() => false;\` to \`TextInputClient\`, requiring all \`TextInputClient\` implementors to implement it. flutter_quill's \`RawEditorStateTextInputClientMixin\` does not implement this method.

**Fix**: Pin Flutter to 3.41.9 (last stable before 3.44.0). flutter_quill 11.5.0 works correctly with 3.41.9.

**Upstream tracking**: singerdmx/flutter-quill#2726 (open PR adding the method)

## 영향 범위

7개 workflow 파일, 10곳 변경:
- `pr-gate.yml` (4곳)
- `shared-cuj-integration.yml` (1곳)  
- `shared-android-deploy.yml` (1곳)
- `monitor-patrol-e2e.yml` (1곳)
- `sync-test-coverage.yml` (1곳)
- `monitor-mds-render-coverage.yml` (1곳)
- `monitor-cuj-coverage.yml` (1곳)

## 검증 방법

- Flutter 3.41.9에서 \`onFocusReceived\` 미존재 확인: `curl -s "https://raw.githubusercontent.com/flutter/flutter/3.41.9/packages/flutter/lib/src/services/text_input.dart" | grep onFocusReceived` → 결과 없음
- Flutter 3.44.0에서 존재 확인: 1401번 줄에 \`bool onFocusReceived() => false;\`

## Rollback 계획

flutter_quill 11.5.x 이상에서 fix가 배포되면:
1. 이 PR과 반대 방향으로 \`flutter-version: '3.41.9'\`를 \`channel: 'stable'\`로 되돌림
2. singerdmx/flutter-quill#2726 머지 모니터링

Closes #2640