### PR TITLE
fix(pgtap): 94_cron_service_role_key_test stale backend-simulation 어설션 제거 — Fix #2647

### DIFF
--- a/supabase/tests/database/94_cron_service_role_key_test.sql
+++ b/supabase/tests/database/94_cron_service_role_key_test.sql
@@ -2,7 +2,9 @@
 -- publishable_key(anon JWT) 사용 시 requireServiceRole() 가드에서 401 반환
 
 BEGIN;
-SELECT plan(8);
+-- Fix #2640-followup: plan(8) → plan(7) — backend-simulation cron 제거됨
+-- (20260517000002_rename_backend_simulator_to_event_flow_simulator.sql)
+SELECT plan(7);
 
 -- Helper: 특정 cron job의 Authorization 헤더가 service_role_key를 참조하는지 확인
 CREATE OR REPLACE FUNCTION _check_cron_uses_service_role(p_jobname text)
@@ -19,49 +21,43 @@ BEGIN
 END;
 $$;
 
--- 1. backend-simulation: service_role_key 사용
-SELECT ok(
-  _check_cron_uses_service_role('backend-simulation'),
-  'backend-simulation cron uses service_role_key (not publishable_key)'
-);
-
--- 2. process-notifications: service_role_key 사용
+-- 1. process-notifications: service_role_key 사용
 SELECT ok(
   _check_cron_uses_service_role('process-notifications'),
   'process-notifications cron uses service_role_key (not publishable_key)'
 );
 
--- 3. settlement-reconciliation-daily: service_role_key 사용
+-- 2. settlement-reconciliation-daily: service_role_key 사용
 SELECT ok(
   _check_cron_uses_service_role('settlement-reconciliation-daily'),
   'settlement-reconciliation-daily cron uses service_role_key (not publishable_key)'
 );
 
--- 4. settlement-register-transfers: service_role_key 사용
+-- 3. settlement-register-transfers: service_role_key 사용
 SELECT ok(
   _check_cron_uses_service_role('settlement-register-transfers'),
   'settlement-register-transfers cron uses service_role_key (not publishable_key)'
 );
 
--- 5. settlement-payout-sync: service_role_key 사용
+-- 4. settlement-payout-sync: service_role_key 사용
 SELECT ok(
   _check_cron_uses_service_role('settlement-payout-sync'),
   'settlement-payout-sync cron uses service_role_key (not publishable_key)'
 );
 
--- 6. settlement-alarm-check: service_role_key 사용
+-- 5. settlement-alarm-check: service_role_key 사용
 SELECT ok(
   _check_cron_uses_service_role('settlement-alarm-check'),
   'settlement-alarm-check cron uses service_role_key (not publishable_key)'
 );
 
--- 7. ai-extract-tags: service_role_key 사용
+-- 6. ai-extract-tags: service_role_key 사용
 SELECT ok(
   _check_cron_uses_service_role('ai-extract-tags'),
   'ai-extract-tags cron uses service_role_key (not publishable_key)'
 );
 
--- 8. sync_github_stats: service_role_key 사용
+-- 7. sync_github_stats: service_role_key 사용
 SELECT ok(
   _check_cron_uses_service_role('sync_github_stats'),
   'sync_github_stats cron uses service_role_key (not publishable_key)'

--- a/supabase/tests/database/94_cron_service_role_key_test.sql
+++ b/supabase/tests/database/94_cron_service_role_key_test.sql
@@ -2,7 +2,7 @@
 -- publishable_key(anon JWT) 사용 시 requireServiceRole() 가드에서 401 반환
 
 BEGIN;
--- Fix #2640-followup: plan(8) → plan(7) — backend-simulation cron 제거됨
+-- Fix #2647: plan(8) → plan(7) — backend-simulation cron 제거됨
 -- (20260517000002_rename_backend_simulator_to_event_flow_simulator.sql)
 SELECT plan(7);
 


### PR DESCRIPTION
Scheduler: swe-opus-1

## Summary

`94_cron_service_role_key_test.sql`이 dev에서 unschedule된 `backend-simulation` cron을 여전히 검사 → 1 fail → 모든 supabase PR의 `test-pgtap` job fail.

`backend-simulation` cron 제거 이력:
- `20260418000001_remove_backend_simulation_cron.sql`
- `20260517000002_rename_backend_simulator_to_event_flow_simulator.sql` (재차 정리)

테스트의 stale assertion만 제거 (`plan(8) → plan(7)`, 어설션 1 삭제).

## Test plan

- [ ] CI test-pgtap 통과 — 이전 1/8 fail → 7/7 pass
- [ ] supabase 변경 PR의 ci-result에 test-pgtap fail 사라짐 확인

Closes #2647