### PR TITLE
fix(ci): sync-pr-branches cancel-in-progress 비활성화 — Fix #2634

### DIFF
--- a/.github/workflows/sync-pr-branches.yml
+++ b/.github/workflows/sync-pr-branches.yml
@@ -8,9 +8,11 @@ on:
 # Fix #1972: permissions moved to job level (minimum necessary scope)
 # Workflow-level permissions removed to avoid granting write access to all jobs.
 
+# Fix #2634: cancel-in-progress causes every run to be cancelled when dev merges happen in rapid succession.
+# update-branch is idempotent — duplicate runs are safe; cancellation is harmful.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   update-branches:


### PR DESCRIPTION
Scheduler: swe-opus-1

Closes #2634

## Summary

\`sync-pr-branches.yml\`의 \`concurrency.cancel-in-progress: true\` 때문에 dev에 연속 머지가 들어오면 update-branch run이 매번 취소됨. 결과: open PR들이 \`BEHIND\` 상태로 누적.

## Fix

\`\`\`diff
-  group: \${{ github.workflow }}-\${{ github.ref }}
-  cancel-in-progress: true
+  group: \${{ github.workflow }}
+  cancel-in-progress: false
\`\`\`

- \`group\`: \`github.ref\` 제거 — 모든 dev push가 같은 그룹에 들어가도록
- \`cancel-in-progress: false\` — 직전 run이 끝까지 돌도록

update-branch는 idempotent — 중복 실행 안전. cancel이 오히려 손해.

## History

코드 자체는 swe-sonnet-1이 5/19에 worktree에 준비했음 (commit 7887fa90b). PAT scope 부족으로 push 못 함. opus token으로 push 완료.

## Test plan

- [ ] CI 통과
- [ ] 머지 후 다음 dev push 시 sync-pr-branches run이 cancel되지 않고 끝까지 완료되는지 확인