### PR TITLE
fix(ef-runtime): config.toml ENVIRONMENT 누락 — 모든 EF init 500 fix (Fix #2650)

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -373,6 +373,10 @@ deno_version = 2
 
 [edge_runtime.secrets]
 OPENAI_API_KEY = "env(OPENAI_API_KEY)"
+# Fix #2650: ENVIRONMENT 가 없으면 minglitEdgeFunction wrapper init 이 throw 하여
+# 모든 EF 가 500 'Init failed' 반환. 로컬/CI 는 dev 환경과 동일한 manifest gate 를
+# 사용하므로 'dev' 하드코딩. production 배포는 `supabase secrets set ENVIRONMENT=production` 으로 override.
+ENVIRONMENT = "dev"
 
 [analytics]
 enabled = true

--- a/supabase/functions/_integration_tests/cuj/discovery/event_feed_test.ts
+++ b/supabase/functions/_integration_tests/cuj/discovery/event_feed_test.ts
@@ -12,10 +12,9 @@ import { cujTest } from "../../_framework/cuj_test.ts";
 
 const ctx = suite("discovery/event-feed");
 
-// Fix #2641: user-event-feed RPC 가 empty DB 에서 500 반환 — dev-side 별개 버그로
-// 추적 필요. 이 테스트는 #2497 머지 후 한번도 실제 실행된 적 없음 (nodeModulesDir
-// 누락으로 framework 가 import 실패 → 모든 테스트 skip). nodeModulesDir 픽스로
-// framework 가 살아나면서 이 RPC bug 가 처음 노출됨. 픽스는 별도 PR 로 분리.
+// Fix #2650: 원래 RPC 500 으로 추측됐던 실패는 supabase/config.toml [edge_runtime.secrets]
+// 의 ENVIRONMENT 누락이 root cause 였음 (minglitEdgeFunction init throw → 모든 EF 500).
+// config.toml 픽스로 EF runtime 정상화 — empty DB 케이스 정상 처리 가능, skip 해제.
 cujTest(ctx, "1-1 user-event-feed returns empty array when no events exist", "single-user", async (ctx) => {
   const user = await ctx.actAs.user("user_test1");
   const res = await user.invoke("user-event-feed", { limit: 20 });
@@ -24,7 +23,7 @@ cujTest(ctx, "1-1 user-event-feed returns empty array when no events exist", "si
   const data = res.data as { events?: unknown[] };
   assert(Array.isArray(data.events), `events must be array, got ${typeof data.events}`);
   assertEquals(data.events!.length, 0, "fresh DB should yield 0 events");
-}, { skip: true });
+});
 
 cujTest(ctx, "1-2 user-event-feed rejects invalid sort_by", "single-user", async (ctx) => {
   const user = await ctx.actAs.user("user_test1");

--- a/supabase/functions/_integration_tests/cuj/event/refund_policy_v2_test.ts
+++ b/supabase/functions/_integration_tests/cuj/event/refund_policy_v2_test.ts
@@ -126,11 +126,14 @@ async function seedPartnerEvent(
     .single();
   if (tmplErr || !tmpl) throw new Error(`seedPartnerEvent ticket_template: ${tmplErr?.message}`);
 
+  // Fix #2650: tickets 테이블에는 template_id 컬럼이 없음 — schema 상 tickets 는
+  // event-level 인스턴스로 ticket_templates 와 직접 FK 없음 (20260301000003).
+  // ticket_templates INSERT 자체는 sync_max_participants trigger 가 parties.max_participants
+  // 를 동기화하기 위해 필요하므로 유지.
   const { data: ticket, error: ticketErr } = await db
     .from("tickets")
     .insert({
       event_id: eventId,
-      template_id: (tmpl as { id: string }).id,
       name: "General",
       price: opts.paymentAmount,
       quantity: 10,


### PR DESCRIPTION
Scheduler: swe-opus-1

## Summary

- `supabase/config.toml [edge_runtime.secrets]` 에 `ENVIRONMENT = \"dev\"` 추가
- CI 로그 (actions/runs/26108609508) 분석 결과 #2650 의 root cause 는 SQL RPC bug 가 아니라 EF wrapper init 실패
- `event_feed_test.ts` CUJ 1-1 skip 해제 + `refund_policy_v2_test.ts` 의 \`tickets.template_id\` 스키마 mismatch fix

## Root cause

\`\`\`
\"error\":\"Init failed: [minglitEdgeFunction] ENVIRONMENT env var not set.
Required for env gate. Check supabase secrets set ENVIRONMENT=...\"
\`\`\`

\`supabase start\` 가 띄우는 local EF runtime 이 ENVIRONMENT 를 받지 못해 \`readEnvironment()\` 가 throw → \`_initError\` 가 set 되고 모든 request 가 500. PR #2641 가 nodeModulesDir 픽스로 framework 를 살리면서 처음 노출됨.

CUJ 1-2 (invalid sort_by) 가 4xx/5xx 모두 허용해서 우연 통과했고, CUJ 1-1 (strict 200) 이 fail 하여 SQL bug 으로 잘못 추정됨.

## 변경 파일

| 파일 | 변경 |
|---|---|
| \`supabase/config.toml\` | \`[edge_runtime.secrets]\` 에 \`ENVIRONMENT = \"dev\"\` 추가 |
| \`event_feed_test.ts\` | CUJ 1-1 \`{ skip: true }\` 제거 + 주석 갱신 |
| \`refund_policy_v2_test.ts\` | seedPartnerEvent: tickets INSERT 에서 \`template_id\` 제거 (schema 부재, 다른 케이스는 PORTONE 설정 필요로 skip 유지) |

## 영향

- 본 PR 머지 후 모든 minglitEdgeFunction wrapper EF 가 local/CI 에서 정상 init
- test-ef-integration job 이 framework 의 실 시나리오 검증을 시작 (이전에는 1-2 만 우연 통과)
- production 배포 흐름은 영향 없음 (`supabase secrets set ENVIRONMENT=production` 이 config.toml 값을 override)

## Test plan

- [ ] test-ef-integration job pass — event_feed CUJ 1-1 통과
- [ ] 기타 EF unit/integration test 회귀 없음
- [ ] static-checks pass

Closes #2650