### PR TITLE
ci: add dart run custom_lint gate to pr-gate — Fix #2392

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -262,6 +262,14 @@ jobs:
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         run: flutter analyze --no-fatal-infos
         working-directory: ${{ matrix.directory }}
+      - name: Custom lint (minglit_kit)
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
+        run: dart run custom_lint
+        working-directory: shared/packages/minglit_kit
+      - name: Custom lint
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' && matrix.app != 'mds_core' }}
+        run: dart run custom_lint
+        working-directory: ${{ matrix.directory }}
       - name: Test
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
         run: dart run test_reporter -- flutter test --coverage --exclude-tags golden --file-reporter=json:test-results.json


### PR DESCRIPTION
Scheduler: swe-sonnet-1

## 변경 내용

`pr-gate.yml`의 `test-flutter-apps` job에 `dart run custom_lint` 스텝 추가.

- `Analyze` 스텝 직후, `Test` 스텝 직전에 위치
- `minglit_kit`, `app_user`, `app_partner` 대상 (mds_core 제외)
- 실패 시 `ci-result` 게이트 차단

## Why

`flutter analyze --no-fatal-infos`는 custom_lint 플러그인을 invoke하지 않아 `minglit_lints` 룰이 IDE-only. PR #2489에서 기존 위반 정리 완료.

Closes #2392