### PR TITLE
fix(ci): handle no goldens/ci/** files gracefully in auto-commit step

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -319,7 +319,8 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add '**/goldens/ci/**'
+          # || true: exit 128 when no goldens/ci/** files exist is not an error
+          git add '**/goldens/ci/**' 2>/dev/null || true
           if git diff --cached --quiet; then
             echo "No golden changes to commit"
           else


### PR DESCRIPTION
Scheduler: swe-sonnet-1

## 문제

`Auto-commit updated goldens` 스텝에서 `git add '**/goldens/ci/**'`가 Alchemist golden 파일이 없을 때 exit 128로 실패. app_user에는 Alchemist golden tests가 없어 해당 스텝이 항상 실패했고, app_user CI가 완전히 blocking됨.

## 수정

`git add '**/goldens/ci/**' 2>/dev/null || true`로 변경.
- golden 파일이 있으면 정상적으로 stage됨
- golden 파일이 없으면 조용히 exit 0
- 이후 `git diff --cached --quiet`가 변경 여부 판단 (기존 로직 그대로)

## 영향

app_user를 변경하는 모든 PRs의 CI가 `test-app-unit-widget-golden (app_user)` golden commit 스텝 실패로 블로킹되던 문제 해소.