### PR TITLE
feat(ci): monitor-security-advisor — Supabase get_advisors 정기 audit (Fix #2540)

### DIFF
--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -14,7 +14,7 @@
 | `pr-setup-` | PR push 마다 PR 브랜치를 mutate 하는 자동화 (포맷 등) | (현재 없음 — `pr-setup-format` 은 #2627 에서 `pr-gate-format-check` 잡으로 대체) |
 | `pr-review-setup-` | PR 의 "리뷰 준비" 자동화 — auto-merge enable + 조건 충족 시 `needs-review` 라벨 부여 | `pr-review-setup` |
 | `deploy-` | 사용자·dev 환경에 코드·스키마·시드가 안 갔음 | `deploy-vercel`, `deploy-supabase`, `deploy-android-user`, `deploy-ios-user`, `deploy-dev-seed` |
-| `monitor-` | 운영·테스트 시스템 헬스 이상 / 스케줄 유지보수 | `monitor-db-invariants`, `monitor-event-flow-hourly`, `monitor-event-flow-daily`, `monitor-mds-render-coverage`, `monitor-patrol-e2e`, `monitor-allure`, `monitor-build-retention` |
+| `monitor-` | 운영·테스트 시스템 헬스 이상 / 스케줄 유지보수 | `monitor-db-invariants`, `monitor-event-flow-hourly`, `monitor-event-flow-daily`, `monitor-mds-render-coverage`, `monitor-patrol-e2e`, `monitor-allure`, `monitor-build-retention`, `monitor-security-advisor` |
 | `sync-` | repo 에 자동 commit/push 가 실패함 (dev push 또는 merge 기반) | `sync-version`, `sync-graphify`, `sync-mds-mockups`, `sync-pr-branches`, `sync-test-coverage` |
 | `triage-` | 이슈 생성·슬래시 명령 (commit 없음) | `triage-mds-issue`, `triage-slash` |
 | `post-merge` | dev push 직후 follow-up 자동화의 단일 entry point (5 reusable orchestrator) | `post-merge` |
@@ -38,4 +38,4 @@
 - [CLAUDE.md](../../CLAUDE.md) `## PR Conventions` — required check (`ci-result` job = `pr-gate.yml` 내부) / auto-merge 흐름
 
 ---
-_Reviewed: 2026-05-19 01:17_
+_Reviewed: 2026-05-19 20:39_

--- a/.github/workflows/monitor-security-advisor.yml
+++ b/.github/workflows/monitor-security-advisor.yml
@@ -1,0 +1,210 @@
+name: monitor-security-advisor
+
+# Refs #2540, #2396 (L3.5 — 3-Layer 보안 모델 Phase A)
+# Supabase get_advisors (Management API) 결과를 정기 audit 하여 보안/성능 회귀를 조기 감지.
+
+on:
+  schedule:
+    # 매일 18:00 UTC = 03:00 KST. monitor-db-invariants(:05) 와 시간 분리.
+    - cron: '0 18 * * *'
+  workflow_dispatch:
+    inputs:
+      env:
+        description: 'Target environment'
+        required: true
+        default: 'dev'
+        type: choice
+        options:
+          - dev
+          - main
+
+concurrency:
+  group: monitor-security-advisor-${{ inputs.env || 'dev' }}
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: Run Supabase advisor audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    strategy:
+      fail-fast: false
+      matrix:
+        type: [security, performance]
+    steps:
+      - name: Resolve target environment
+        id: env
+        run: |
+          ENV_INPUT="${{ inputs.env }}"
+          ENV="${ENV_INPUT:-dev}"
+          echo "ENV=$ENV" >> "$GITHUB_OUTPUT"
+          if [ "$ENV" = "main" ]; then
+            echo "PROJECT_ID=${{ secrets.SUPABASE_MAIN_PROJECT_ID }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "PROJECT_ID=${{ secrets.SUPABASE_DEV_PROJECT_ID }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Call Supabase advisor API
+        id: advisor
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          PROJECT_ID: ${{ steps.env.outputs.PROJECT_ID }}
+          TYPE: ${{ matrix.type }}
+        run: |
+          if [ -z "$PROJECT_ID" ]; then
+            echo "::error::PROJECT_ID is empty — register SUPABASE_${{ steps.env.outputs.ENV == 'main' && 'MAIN' || 'DEV' }}_PROJECT_ID"
+            exit 1
+          fi
+          if [ -z "$SUPABASE_ACCESS_TOKEN" ]; then
+            echo "::error::SUPABASE_ACCESS_TOKEN is empty"
+            exit 1
+          fi
+
+          # Management API advisor endpoint (database lints).
+          # Falls back to alt URL pattern if first 404s — endpoint name has varied across versions.
+          URL_PRIMARY="https://api.supabase.com/v1/projects/${PROJECT_ID}/advisors/${TYPE}"
+          URL_FALLBACK="https://api.supabase.com/v1/projects/${PROJECT_ID}/database/lints?type=${TYPE}"
+
+          fetch() {
+            curl -sS -w "\n%{http_code}" -X GET "$1" \
+              -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+              -H "Accept: application/json" \
+              --max-time 30
+          }
+
+          RESPONSE=$(fetch "$URL_PRIMARY")
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | sed '$d')
+
+          if [ "$HTTP_CODE" = "404" ] || [ "$HTTP_CODE" = "400" ]; then
+            echo "Primary endpoint returned $HTTP_CODE, trying fallback"
+            RESPONSE=$(fetch "$URL_FALLBACK")
+            HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+            BODY=$(echo "$RESPONSE" | sed '$d')
+          fi
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::advisor API failed: HTTP $HTTP_CODE"
+            echo "$BODY"
+            exit 1
+          fi
+
+          # Persist for downstream step
+          echo "$BODY" > advisor-${TYPE}.json
+          echo "Wrote advisor-${TYPE}.json ($(echo "$BODY" | wc -c) bytes)"
+
+          # Count by level — support both {lints:[...]} and bare [...] shapes.
+          ITEMS=$(echo "$BODY" | jq -c '
+            if type == "array" then .
+            elif .lints? then .lints
+            elif .data? then .data
+            else [] end
+          ')
+          ERRORS=$(echo "$ITEMS" | jq '[.[] | select((.level // .severity // "" | ascii_upcase) == "ERROR")] | length')
+          WARNS=$(echo "$ITEMS" | jq '[.[] | select((.level // .severity // "" | ascii_upcase) == "WARN")] | length')
+          TOTAL=$(echo "$ITEMS" | jq 'length')
+
+          echo "type=${TYPE}" >> "$GITHUB_OUTPUT"
+          echo "errors=$ERRORS" >> "$GITHUB_OUTPUT"
+          echo "warns=$WARNS" >> "$GITHUB_OUTPUT"
+          echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
+          echo "::notice::advisor=${TYPE} total=$TOTAL errors=$ERRORS warns=$WARNS"
+
+      - name: Create or update GitHub Issue on findings
+        if: steps.advisor.outputs.errors != '0' || steps.advisor.outputs.warns != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TYPE: ${{ matrix.type }}
+          ENV: ${{ steps.env.outputs.ENV }}
+          ERRORS: ${{ steps.advisor.outputs.errors }}
+          WARNS: ${{ steps.advisor.outputs.warns }}
+          TOTAL: ${{ steps.advisor.outputs.total }}
+        run: |
+          TITLE="[advisor-audit/${TYPE}] ${ENV} — ${ERRORS} ERROR / ${WARNS} WARN"
+
+          # Render top 20 findings (truncated for readability)
+          ITEMS=$(jq -c '
+            if type == "array" then .
+            elif .lints? then .lints
+            elif .data? then .data
+            else [] end
+          ' "advisor-${TYPE}.json")
+
+          TABLE=$(echo "$ITEMS" | jq -r '
+            [.[]
+             | { lvl: (.level // .severity // ""),
+                 name: (.name // .title // ""),
+                 desc: ((.description // .message // .detail // "") | tostring | gsub("\\|"; "/") | .[0:140]),
+                 cat: (.categories // [] | join(",")) }]
+            | sort_by(.lvl != "ERROR")
+            | .[0:20]
+            | map("| \(.lvl) | \(.name) | \(.cat) | \(.desc) |")
+            | join("\n")
+          ')
+
+          BODY=$(cat <<BODY_EOF
+          Scheduler: swe-opus-1 (auto-generated)
+
+          ## Supabase ${TYPE^} Advisor — ${ENV}
+
+          - **ERROR**: ${ERRORS}
+          - **WARN**: ${WARNS}
+          - **Total findings**: ${TOTAL}
+          - **Workflow**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          | Level | Name | Categories | Description |
+          |-------|------|------------|-------------|
+          ${TABLE}
+
+          ---
+
+          *Auto-generated by [monitor-security-advisor.yml](${{ github.server_url }}/${{ github.repository }}/blob/dev/.github/workflows/monitor-security-advisor.yml) — Refs #2540, #2396*
+          BODY_EOF
+          )
+
+          EXISTING=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --search "[advisor-audit/${TYPE}] ${ENV} in:title" \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" --repo "${{ github.repository }}" --title "$TITLE"
+            gh issue comment "$EXISTING" --repo "${{ github.repository }}" --body "$BODY"
+            echo "Updated existing issue #${EXISTING}"
+          else
+            # ERROR-level findings → P1, WARN-only → P2. Triage may re-prioritize.
+            if [ "$ERRORS" != "0" ]; then
+              LABEL="audit-report,P1-high"
+            else
+              LABEL="audit-report,P2-medium"
+            fi
+            gh issue create \
+              --repo "${{ github.repository }}" \
+              --title "$TITLE" \
+              --label "$LABEL" \
+              --body "$BODY"
+          fi
+
+      - name: Upload advisor raw artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: advisor-${{ matrix.type }}-${{ steps.env.outputs.ENV }}
+          path: advisor-${{ matrix.type }}.json
+          retention-days: 30
+          if-no-files-found: ignore
+
+  notify-failure:
+    needs: [audit]
+    if: always() && needs.audit.result == 'failure'
+    permissions:
+      issues: write
+    uses: ./.github/workflows/shared-notify.yml
+    with:
+      success: false
+      workflow_name: 'Supabase Security/Performance Advisor Audit'
+      job_results: '{"audit":"${{ needs.audit.result }}"}'


### PR DESCRIPTION
Scheduler: swe-opus-1

Closes #2540
Refs #2396 (3-Layer 보안 모델 Phase A — L3.5)

## Summary

- 새 workflow `monitor-security-advisor.yml` — 매일 03:00 KST 에 Supabase Management API `/v1/projects/{ref}/advisors/{type}` (404 시 `/database/lints?type=` 폴백) 호출
- ERROR / WARN advisor 발견 시 `audit-report` 라벨 이슈 자동 생성 (기존 같은 타이틀 있으면 코멘트 누적)
- matrix `[security, performance]` — fail-fast: false → 한 타입 실패가 다른 타입 차단 안 함
- workflow_dispatch 로 dev/main 환경 수동 실행

## 워커 token scope 검증

세션 97/100 의 hard evidence (push-reject) 와 달리, 이번 사이클의 `runtime-qa-smoke-user-gemini` 토큰은 workflow scope 가 부여되어 있어 push 통과. routing loop [#2532](https://github.com/Mark-Yun/minglit/issues/2532) 의 본질적 blocker 가 해소되었을 가능성.

## 필요한 secrets

- `SUPABASE_ACCESS_TOKEN` (Management API PAT) — 이미 다른 workflow 들이 참조 중
- `SUPABASE_DEV_PROJECT_ID`
- `SUPABASE_MAIN_PROJECT_ID`

> 위 secret 들이 미등록일 경우 첫 실행 시 `::error::PROJECT_ID is empty` 로 명시 실패 → `ci-failure` 이슈 자동 생성. 안전한 fast-fail 패턴.

## 가정 / 잔여 위험

- **Management API endpoint 불확실** — Supabase 가 advisor 엔드포인트를 문서에 정확히 노출하지 않음. 두 URL 폴백 (`/advisors/{type}` → `/database/lints?type=`) 패턴으로 대응. 첫 실행 후 artifact 다운로드하여 response shape (array / `{lints:[]}` / `{data:[]}`) 확정 후 jq path 정리 권장.
- `SUPABASE_ACCESS_TOKEN` PAT 만료 시 401 → `ci-failure` 이슈 자동 생성됨 (시스템이 알람).

## Test plan

- [ ] CI 통과 (pr-gate)
- [ ] 머지 후 매일 03:00 KST schedule 트리거 또는 수동 `workflow_dispatch` 로 실행 가능 확인
- [ ] 첫 실행 시 advisor API 응답이 정상 (200) 인지 → artifact 확인