### PR TITLE
feat(mds-render): ticket_qr_screen render catalog 등록 — Refs #2588

### DIFF
--- a/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
@@ -42,6 +42,7 @@ Phase 2 (TODO, follow-up PR) — `_manifest.yaml`, coverage report, scaffold 결
 | `search_page` | idle · results · empty |
 | `event_now_bar` | waiting · check-in-ready · checked-in · matching · results · ended · offline |
 | `event_ongoing_banner` | 8 phases + dark |
+| `ticket_qr_screen` | with-token · not-found · dark |
 
 ## 폴더 컨벤션
 
@@ -57,4 +58,4 @@ MDS spec 디렉토리명과 동일 (per-screen, snake_case). 화면당 `builder.
 - [상위 BLUEDOC](../BLUEDOC.md) · 페어 워크플로우: `sync-mds-mockups.yml` (디자인 PNG)
 
 ---
-_Reviewed: 2026-05-20 09:00_
+_Reviewed: 2026-05-20 22:50_

--- a/apps/app_user/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_registry.dart
@@ -23,6 +23,7 @@ import 'notification_list_screen/notification_list_screen_test.dart'
 import 'notification_settings_screen/notification_settings_screen_test.dart'
     as notification_settings_screen;
 import 'search_page/search_page_test.dart' as search_page;
+import 'ticket_qr_screen/ticket_qr_screen_test.dart' as ticket_qr_screen;
 
 /// 모든 cataloged 화면의 명시적 list. 새 화면 추가 시 본 list 에 추가.
 final List<MdsCatalog<MdsScreenBuilder<dynamic>>> allCatalogs = [
@@ -38,4 +39,5 @@ final List<MdsCatalog<MdsScreenBuilder<dynamic>>> allCatalogs = [
   notification_list_screen.catalog,
   notification_settings_screen.catalog,
   search_page.catalog,
+  ticket_qr_screen.catalog,
 ];

--- a/apps/app_user/integration_test/mds-emulator-render/ticket_qr_screen/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/ticket_qr_screen/builder.dart
@@ -1,0 +1,45 @@
+import 'package:app_user/src/features/ticket/data/ticket_token_service.dart';
+import 'package:app_user/src/features/ticket/ui/ticket_qr_screen.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../_engine/builder.dart';
+
+class _MockTicketTokenService extends Mock implements TicketTokenService {}
+
+TicketToken _fakeToken() => TicketToken(
+  ticketId: 'ticket-render-001',
+  eventId: 'event-render-001',
+  userId: 'user-render-001',
+  signature: 'sig-render-test-ok',
+  expiresAt: DateTime(2099, 12, 31),
+);
+
+/// Builder for [TicketQRScreen] render catalog.
+///
+/// Default state: token present, no eventMeta (deep-link fallback path).
+/// [notFound]: token null — renders error message.
+class TicketQRScreenBuilder extends MdsScreenBuilder<TicketQRScreen> {
+  TicketQRScreenBuilder()
+    : _service = _MockTicketTokenService(),
+      super(
+        page: const TicketQRScreen(ticketId: 'ticket-render-001'),
+        base: [],
+      ) {
+    when(() => _service.getToken(any())).thenAnswer((_) async => _fakeToken());
+    addOverride(ticketTokenServiceProvider.overrideWith((_) => _service));
+  }
+
+  final _MockTicketTokenService _service;
+
+  // Fix #2588: token null → renders "티켓 정보를 찾을 수 없습니다" error state.
+  TicketQRScreenBuilder notFound() {
+    when(() => _service.getToken(any())).thenAnswer((_) async => null);
+    return this;
+  }
+
+  TicketQRScreenBuilder dark() {
+    useDarkTheme();
+    return this;
+  }
+}

--- a/apps/app_user/integration_test/mds-emulator-render/ticket_qr_screen/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/ticket_qr_screen/builder.dart
@@ -35,11 +35,11 @@ class TicketQRScreenBuilder extends MdsScreenBuilder<TicketQRScreen> {
   // Fix #2588: token null → renders "티켓 정보를 찾을 수 없습니다" error state.
   TicketQRScreenBuilder notFound() {
     when(() => _service.getToken(any())).thenAnswer((_) async => null);
-    return this;
+    return this; // ignore: avoid_returning_this
   }
 
   TicketQRScreenBuilder dark() {
     useDarkTheme();
-    return this;
+    return this; // ignore: avoid_returning_this
   }
 }

--- a/apps/app_user/integration_test/mds-emulator-render/ticket_qr_screen/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/ticket_qr_screen/builder.dart
@@ -35,11 +35,13 @@ class TicketQRScreenBuilder extends MdsScreenBuilder<TicketQRScreen> {
   // Fix #2588: token null → renders "티켓 정보를 찾을 수 없습니다" error state.
   TicketQRScreenBuilder notFound() {
     when(() => _service.getToken(any())).thenAnswer((_) async => null);
-    return this; // ignore: avoid_returning_this
+    // ignore: avoid_returning_this, fluent builder — callers chain b.notFound().dark()
+    return this;
   }
 
   TicketQRScreenBuilder dark() {
     useDarkTheme();
-    return this; // ignore: avoid_returning_this
+    // ignore: avoid_returning_this, fluent builder — callers chain b.notFound().dark()
+    return this;
   }
 }

--- a/apps/app_user/integration_test/mds-emulator-render/ticket_qr_screen/ticket_qr_screen_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/ticket_qr_screen/ticket_qr_screen_test.dart
@@ -1,0 +1,29 @@
+// MDS screen: ticket_qr_screen
+// 대응 MDS: apps/mds/docs/public/specs/ticket_qr_screen/
+//
+// 출력: docs/infra/mds-emulator-render/ticket_qr_screen/state-*.png
+//
+// 커버리지 (spec 5개 중 3개):
+//   mdsIndex 1 (no-meta): state-with-token — token 있음, eventMeta null (deep-link)
+//   mdsIndex 5 (not-found): state-not-found — token null
+//   ※ mdsIndex 2 (with-meta): TicketQRScreen.eventMeta 가 생성자 파라미터로 주입되어
+//      builder 패턴에서 fluent 변경 불가. eventMeta provider 화 시 커버 가능.
+//   ※ mdsIndex 3 (loading), 4 (error): FutureProvider 과도 상태 — 정적 캡처 대상 아님.
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<TicketQRScreenBuilder>(
+  screen: 'ticket_qr_screen',
+  mdsSpec: 'apps/mds/docs/public/specs/ticket_qr_screen/',
+  builder: TicketQRScreenBuilder.new,
+  states: [
+    MdsState('state-with-token', (b) => b, mdsIndex: 1),
+    MdsState('state-not-found', (b) => b.notFound(), mdsIndex: 5),
+    MdsState('state-dark', (b) => b.dark()),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);

--- a/apps/app_user/integration_test/mds-emulator-render/ticket_qr_screen/ticket_qr_screen_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/ticket_qr_screen/ticket_qr_screen_test.dart
@@ -4,7 +4,7 @@
 // 출력: docs/infra/mds-emulator-render/ticket_qr_screen/state-*.png
 //
 // 커버리지 (spec 5개 중 3개):
-//   mdsIndex 1 (no-meta): state-with-token — token 있음, eventMeta null (deep-link)
+//   mdsIndex 1 (no-meta): state-with-token — token 있음, eventMeta null
 //   mdsIndex 5 (not-found): state-not-found — token null
 //   ※ mdsIndex 2 (with-meta): TicketQRScreen.eventMeta 가 생성자 파라미터로 주입되어
 //      builder 패턴에서 fluent 변경 불가. eventMeta provider 화 시 커버 가능.


### PR DESCRIPTION
Scheduler: swe-sonnet-1

Refs #2588

## 변경 내용

`ticket_qr_screen` MDS render catalog 신규 등록.

| 파일 | 내용 |
|------|------|
| `ticket_qr_screen/builder.dart` | `TicketQRScreenBuilder` — `ticketTokenServiceProvider` mock으로 3가지 상태 |
| `ticket_qr_screen/ticket_qr_screen_test.dart` | 카탈로그 3개 state 정의 |
| `_registry.dart` | `allCatalogs`에 `ticket_qr_screen.catalog` 추가 |

## States

| State | mdsIndex | 설명 |
|-------|----------|------|
| `state-with-token` | 1 | token 있음, eventMeta null (deep-link 경로) |
| `state-not-found` | 5 | token null — "티켓 정보를 찾을 수 없습니다" 에러 |
| `state-dark` | — | 다크모드 |

## 미커버 states (제약 사유)

- **mdsIndex 2 (with-meta)**: `TicketQRScreen.eventMeta`가 생성자 파라미터 → builder 패턴에서 fluent 변경 불가. `eventMeta` provider화 시 커버 가능.
- **mdsIndex 3 (loading), 4 (error)**: `FutureProvider` 과도 상태 — 정적 render 캡처 대상 아님.

## 검증

- `dart analyze` 통과 예정 (기존 패턴과 동일)
- 런타임: `ScreenBrightness` plugin 실패 시 try-catch로 흡수

## 잔여 이슈 (#2588 나머지 screens)

- `event_check_in/checked_in_screen`: 앱 구현 미존재 → 불가
- `event_bottom_ticket_bar`: `_BottomTicketBar` private widget → 공개 접근 불가
- `checkin_placeholder_page`, `recurrence_management_screen`: app_partner에 mds-emulator-render 인프라 없음
- `event_now_bar`, `event_ongoing_banner`: PR #2590 처리 중 (APPROVED+BLOCKED)
