### PR TITLE
fix(ci): re-enable gitleaks with raw binary + PR-diff scoping — Fix #2541

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -732,24 +732,64 @@ jobs:
           fi
 
   # Gitleaks secret scan — formerly pr-setup-secret-scan.yml, absorbed into pr-gate as a required check.
-  # Disabled 2026-05-19: post-org-transfer (Mark-Yun → team-minglit), gitleaks-action@v2 requires a
-  # paid license for org repos. ci-result aggregates on "failure" only, so a "skipped" job here does
-  # not block the required check. Re-enable by removing `if: false` once a GITLEAKS_LICENSE secret
-  # is provisioned, or by switching to the raw `gitleaks` binary (no license required).
+  # Re-enabled 2026-05-20 (Fix #2541): swapped gitleaks/gitleaks-action@v2 (paid license for org repos)
+  # → raw `gitleaks` binary from upstream release. Same `.gitleaks.toml` config, same exit-code semantics.
+  # Scope: scans only the commits introduced by the PR (or merge-group / pushed range), NOT the full
+  # repo history — historical leaks that were since removed (e.g. dev_main.dart in 2025-12) stay out
+  # of the gate, while any new leak in the PR diff fails CI.
   gitleaks:
-    if: false
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+    env:
+      GITLEAKS_VERSION: '8.21.2'
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - name: Install gitleaks
+        run: |
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+      - name: Determine scan scope
+        id: scope
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_CONFIG: .gitleaks.toml
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          MERGE_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            pull_request)
+              log_opts="origin/${BASE_REF}..HEAD"
+              ;;
+            merge_group)
+              log_opts="${MERGE_BASE_SHA}..HEAD"
+              ;;
+            push)
+              if [[ -z "${BEFORE_SHA:-}" || "$BEFORE_SHA" == "0000000000000000000000000000000000000000" ]]; then
+                log_opts="HEAD~1..HEAD"
+              else
+                log_opts="${BEFORE_SHA}..HEAD"
+              fi
+              ;;
+            *)
+              log_opts="HEAD~1..HEAD"
+              ;;
+          esac
+          echo "log_opts=${log_opts}" >> "$GITHUB_OUTPUT"
+          echo "::notice::gitleaks scanning commits ${log_opts}"
+      - name: Run gitleaks
+        run: |
+          gitleaks detect \
+            --config .gitleaks.toml \
+            --source . \
+            --log-opts="${{ steps.scope.outputs.log_opts }}" \
+            --no-banner \
+            --redact \
+            --verbose
 
   # check-bluedoc-freshness consolidated into `static-checks` job at top of this file.
 

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -6,7 +6,11 @@ title = "Minglit Gitleaks Configuration"
     '''\.env$''',
     '''\.env\.local$''',
     '''\.env\.example$''',
-    '''iamport_\w+\.g\.dart$''',
+    # Dart code-generation outputs (riverpod/freezed/json_serializable etc.) contain
+    # provider/state hashes that look like hex/base64 secrets but are deterministic
+    # derivatives of source — never real keys.
+    '''\.g\.dart$''',
+    '''\.freezed\.dart$''',
     '''_test\.ts$''',
     '''_test\.dart$''',
     '''_test_utils/''',
@@ -44,6 +48,14 @@ title = "Minglit Gitleaks Configuration"
   regex = '''[A-Za-z0-9+/]{40,}'''
   path = '''portone|iamport|verify-payment|verify-identity'''
   tags = ["key", "payment"]
+  [rules.allowlist]
+    description = "Dart package import paths and Deno/JSR imports trip the broad base64 regex"
+    regexTarget = "line"
+    regexes = [
+      '''^\s*import\s+['"]''',
+      '''^\s*export\s+['"]''',
+      '''part\s+['"][a-zA-Z0-9_/]+\.dart['"]''',
+    ]
 
 [[rules]]
   id = "kakao-api-key"


### PR DESCRIPTION
Scheduler: swe-opus-1

Closes part of #2541 (§작업 범위 1).

## 요약

2026-05-19 이후 disabled 상태이던 gitleaks job 을 재활성화한다. `gitleaks/gitleaks-action@v2` 가 org repo 에서 유료 라이선스를 요구하는 것이 disable 이유였는데, 라이선스 없이 동작하는 raw `gitleaks` binary 로 swap.

## 변경

### `.github/workflows/pr-gate.yml` — gitleaks job

- `gitleaks/gitleaks-action@v2` → 공식 release 의 \`gitleaks\` binary v8.21.2 직접 설치 + 실행
- \`if: false\` 제거
- **scan scope 를 PR diff 로 제한** (\`--log-opts\` 사용):
  - \`pull_request\`: \`origin/\${BASE_REF}..HEAD\`
  - \`merge_group\`: \`\${MERGE_BASE_SHA}..HEAD\`
  - \`push\` to main: \`\${BEFORE_SHA}..HEAD\` (또는 첫 푸시면 \`HEAD~1..HEAD\`)
- 효과: 과거에 한 번 커밋되었다가 후속 정리에서 제거된 secret (예: \`apps/{app_user,app_partner}/lib/dev_main.dart\` 의 \`sb_secret_*\` from 2025-12) 가 모든 PR 을 막지 않으면서, PR diff 에 새로 들어가는 leak 은 그대로 차단한다.

### \`.gitleaks.toml\` — false-positive 제거

현재 dev tree 에 대해 \`gitleaks detect --no-git\` 실행 시 3 건 false positive 발견 → allowlist 보강:

| Finding | Rule | 원인 | 조치 |
|---|---|---|---|
| \`shared/packages/minglit_kit/.../kakao_location_repository.g.dart:62\` | kakao-api-key | riverpod 생성 hash (\`r'5533...84229c19'\` — 32+ hex) 가 kakao path 필터에 걸림 | \`\\.g\\.dart$\` / \`\\.freezed\\.dart$\` 를 allowlist paths 에 추가 (code-gen 산출물은 source 의 deterministic 파생물) |
| \`shared/packages/minglit_kit/.../iamport_controller.dart:3-4\` | portone-imp-secret | Dart \`import 'package:minglit_kit/src/.../iamport/.../iamport_repository.dart';\` 가 40+ char \`[A-Za-z0-9+/]\` regex 와 \`iamport\` path 필터에 동시 매치 | rule-local allowlist 에 \`regexTarget = \"line\"\` 로 \`import\`/\`export\`/\`part\` 라인 패턴 추가 |

## 검증

로컬에서 gitleaks 8.21.2 로 4 종 시나리오 실행:

1. **\`--no-git\` 현재 tree scan**: 0 leaks (allowlist 적용 전 3 false positive → 0)
2. **\`HEAD~5..HEAD\` 최근 5 commits**: 0 leaks
3. **\`c0bbcbde4^..c0bbcbde4\` (sb_secret_ 도입 commit)**: 2 leaks ✅ — rule 이 실제 secret 은 그대로 잡음
4. **임의 fake \`sb_secret_aBcDeF...\` 주입 file**: 1 leak ✅

## scope 외 (별도 PR 예정)

이슈 #2541 의 §작업 범위 2 (Flutter APK / iOS bundle build-artifact scan) 와 §3 (Next.js \`.next/\` artifact scan) 은 새 CI job 신설이 필요하여 본 PR 에서 분리한다. 본 PR 머지로 §1 (gitleaks 룰 강화 + job 활성화) 가 실제 효과 발생.

## 잔여 위험

- raw binary 모드는 PR-summary 코멘트를 생성하지 않음 (gitleaks-action 의 value-add 였음). leak 발견 시 CI 실패 + job 로그로만 surface — required check 차단은 동일하게 작동.
- gitleaks 버전 pin (\`8.21.2\`): upstream 새 버전이 새 룰을 추가해도 자동 반영 X. 명시적 bump 필요.