### PR TITLE
feat(mds-render): auth_callback + blocked_partners + privacy_page catalog 등록 — Refs #2587

### DIFF
--- a/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
@@ -35,10 +35,17 @@ Phase 2 (TODO, follow-up PR) — `_manifest.yaml`, coverage report, scaffold 결
 
 | 화면 | states |
 |------|--------|
+| `auth_callback_page` | loading · loading-dark |
+| `blocked_partners_page` | loading · empty · with-partners · dark |
+| `deletion_complete_page` | default · dark |
+| `deletion_info_page` | no-reason · with-reason |
+| `deletion_reason_page` | initial · dark |
+| `deletion_verify_page` | email-user · social-user · dark |
 | `home_page` | default · guest · loading · feed-empty · error |
 | `login_page` | 기본 |
 | `notification_list_screen` | loaded · empty |
 | `notification_settings_screen` | default |
+| `privacy_page` | loading · loaded · dark |
 | `search_page` | idle · results · empty |
 | `event_now_bar` | waiting · check-in-ready · checked-in · matching · results · ended · offline |
 | `event_ongoing_banner` | 8 phases + dark |
@@ -58,4 +65,4 @@ MDS spec 디렉토리명과 동일 (per-screen, snake_case). 화면당 `builder.
 - [상위 BLUEDOC](../BLUEDOC.md) · 페어 워크플로우: `sync-mds-mockups.yml` (디자인 PNG)
 
 ---
-_Reviewed: 2026-05-20 22:50_
+_Reviewed: 2026-05-20 23:00_

--- a/apps/app_user/integration_test/mds-emulator-render/_mocks/notifiers.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_mocks/notifiers.dart
@@ -5,6 +5,30 @@ import 'dart:async';
 import 'package:app_user/src/logic/feed_state_provider.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 
+// ── Consent ──────────────────────────────────────────────────────────────────
+
+/// 동의 목록 로드 완료 (필수 3 + 선택 2 동의됨).
+class LoadedConsentController extends ConsentController {
+  @override
+  FutureOr<List<UserConsent>> build() async => [
+    _consent(ConsentType.termsOfService),
+    _consent(ConsentType.privacyCollection),
+    _consent(ConsentType.ageConfirmation),
+    _consent(ConsentType.thirdPartyProvision),
+    _consent(ConsentType.marketingConsent, consented: false),
+    _consent(ConsentType.locationConsent, consented: false),
+  ];
+
+  UserConsent _consent(ConsentType type, {bool consented = true}) => UserConsent(
+    id: 'consent-${type.name}',
+    userId: 'mock-user-1',
+    consentKey: type,
+    consented: consented,
+    consentedAt: DateTime.utc(2026, 1, 1),
+    createdAt: DateTime.utc(2026, 1, 1),
+  );
+}
+
 // ── Auth ─────────────────────────────────────────────────────────────────────
 
 /// 인증 대기 (idle) 상태 — 로그인 폼 표시.

--- a/apps/app_user/integration_test/mds-emulator-render/_mocks/notifiers.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_mocks/notifiers.dart
@@ -19,14 +19,15 @@ class LoadedConsentController extends ConsentController {
     _consent(ConsentType.locationConsent, consented: false),
   ];
 
-  UserConsent _consent(ConsentType type, {bool consented = true}) => UserConsent(
-    id: 'consent-${type.name}',
-    userId: 'mock-user-1',
-    consentKey: type,
-    consented: consented,
-    consentedAt: DateTime.utc(2026, 1, 1),
-    createdAt: DateTime.utc(2026, 1, 1),
-  );
+  UserConsent _consent(ConsentType type, {bool consented = true}) =>
+      UserConsent(
+        id: 'consent-${type.name}',
+        userId: 'mock-user-1',
+        consentKey: type,
+        consented: consented,
+        consentedAt: DateTime.utc(2026, 1, 1),
+        createdAt: DateTime.utc(2026, 1, 1),
+      );
 }
 
 // ── Auth ─────────────────────────────────────────────────────────────────────

--- a/apps/app_user/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_registry.dart
@@ -6,6 +6,9 @@
 
 import '_engine/builder.dart';
 import '_engine/catalog.dart';
+import 'auth_callback_page/auth_callback_page_test.dart' as auth_callback_page;
+import 'blocked_partners_page/blocked_partners_page_test.dart'
+    as blocked_partners_page;
 import 'deletion_complete_page/deletion_complete_page_test.dart'
     as deletion_complete_page;
 import 'deletion_info_page/deletion_info_page_test.dart' as deletion_info_page;
@@ -22,11 +25,14 @@ import 'notification_list_screen/notification_list_screen_test.dart'
     as notification_list_screen;
 import 'notification_settings_screen/notification_settings_screen_test.dart'
     as notification_settings_screen;
+import 'privacy_page/privacy_page_test.dart' as privacy_page;
 import 'search_page/search_page_test.dart' as search_page;
 import 'ticket_qr_screen/ticket_qr_screen_test.dart' as ticket_qr_screen;
 
 /// 모든 cataloged 화면의 명시적 list. 새 화면 추가 시 본 list 에 추가.
 final List<MdsCatalog<MdsScreenBuilder<dynamic>>> allCatalogs = [
+  auth_callback_page.catalog,
+  blocked_partners_page.catalog,
   deletion_complete_page.catalog,
   deletion_info_page.catalog,
   deletion_info_page.catalogWithReason,
@@ -38,6 +44,7 @@ final List<MdsCatalog<MdsScreenBuilder<dynamic>>> allCatalogs = [
   login_page.catalog,
   notification_list_screen.catalog,
   notification_settings_screen.catalog,
+  privacy_page.catalog,
   search_page.catalog,
   ticket_qr_screen.catalog,
 ];

--- a/apps/app_user/integration_test/mds-emulator-render/auth_callback_page/auth_callback_page_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/auth_callback_page/auth_callback_page_test.dart
@@ -1,0 +1,36 @@
+// MDS screen: auth_callback_page
+// 대응 MDS: apps/mds/docs/public/specs/auth_callback_page/
+//
+// 출력: docs/infra/mds-emulator-render/auth_callback_page/state-*.png
+//
+// state_1 = 로딩 중 (스피너 + "로그인 처리 중입니다...")
+//   infiniteAnimation: true 로 10초 타이머 발동 방지.
+// state_2, state_3 = 타이머 발동 후 타임아웃 에러 / 다크 — 별도 PR 예정
+//   (타이머 발동은 pumpAndSettle fake-time 진행 10초 필요 → 별도 처리 필요).
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<AuthCallbackPageBuilder>(
+  screen: 'auth_callback_page',
+  mdsSpec: 'apps/mds/docs/public/specs/auth_callback_page/',
+  builder: AuthCallbackPageBuilder.new,
+  states: [
+    MdsState(
+      'state-loading',
+      (b) => b,
+      mdsIndex: 1,
+      // 10초 타이머 발동 전에 캡처하도록 infiniteAnimation 플래그 사용.
+      infiniteAnimation: true,
+    ),
+    MdsState(
+      'state-loading-dark',
+      (b) => b.dark(),
+      infiniteAnimation: true,
+    ),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);

--- a/apps/app_user/integration_test/mds-emulator-render/auth_callback_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/auth_callback_page/builder.dart
@@ -1,0 +1,43 @@
+// AuthCallbackPageBuilder — auth_callback_page 전용 fluent API.
+//
+// AuthCallbackPage 는 ConsumerStatefulWidget — initState 에서 10초 타이머를
+// 설정한다. 렌더 catalog 에서는 타이머가 발동하기 전 초기 로딩 UI 만 캡처.
+// pumpAndSettle 이 fake-time 을 10초 진행하기 전에 infiniteAnimation 플래그로
+// 고정 pump 를 사용해 타이머 발동을 방지한다.
+//
+// currentUserProvider 가 null 이면 (공통 override) redirect 없이 로딩 상태 유지.
+
+import 'package:app_user/src/features/auth/ui/auth_callback_page.dart';
+import 'package:app_user/src/logic/auth_coordinator.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../_engine/builder.dart';
+import '../_mocks/coordinators.dart';
+
+class AuthCallbackPageBuilder extends MdsScreenBuilder<AuthCallbackPage> {
+  AuthCallbackPageBuilder()
+    : super(
+        page: const AuthCallbackPage(),
+        base: [
+          // authCoordinatorProvider 를 mock 으로 교체 — 리디렉션 방지.
+          authCoordinatorProvider.overrideWithValue(
+            _createNoOpAuthCoordinator(),
+          ),
+        ],
+      );
+
+  /// 다크 모드 토글.
+  AuthCallbackPageBuilder dark() {
+    useDarkTheme();
+    // ignore: avoid_returning_this, fluent builder
+    return this;
+  }
+}
+
+/// 모든 메서드가 no-op 인 AuthCoordinator mock.
+MockAuthCoordinator _createNoOpAuthCoordinator() {
+  final mock = MockAuthCoordinator();
+  when(mock.goToLogin).thenReturn(null);
+  when(() => mock.goToReturnLocation(any())).thenReturn(null);
+  return mock;
+}

--- a/apps/app_user/integration_test/mds-emulator-render/blocked_partners_page/blocked_partners_page_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/blocked_partners_page/blocked_partners_page_test.dart
@@ -13,7 +13,12 @@ final catalog = MdsCatalog<BlockedPartnersPageBuilder>(
   mdsSpec: 'apps/mds/docs/public/specs/blocked_partners_page/',
   builder: BlockedPartnersPageBuilder.new,
   states: [
-    MdsState('state-loading', (b) => b.loading(), mdsIndex: 1, infiniteAnimation: true),
+    MdsState(
+      'state-loading',
+      (b) => b.loading(),
+      mdsIndex: 1,
+      infiniteAnimation: true,
+    ),
     MdsState('state-empty', (b) => b.empty(), mdsIndex: 2),
     MdsState('state-with-partners', (b) => b.withPartners(), mdsIndex: 3),
     MdsState('state-dark', (b) => b.withPartners().dark()),

--- a/apps/app_user/integration_test/mds-emulator-render/blocked_partners_page/blocked_partners_page_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/blocked_partners_page/blocked_partners_page_test.dart
@@ -1,0 +1,23 @@
+// MDS screen: blocked_partners_page
+// 대응 MDS: apps/mds/docs/public/specs/blocked_partners_page/
+//
+// 출력: docs/infra/mds-emulator-render/blocked_partners_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<BlockedPartnersPageBuilder>(
+  screen: 'blocked_partners_page',
+  mdsSpec: 'apps/mds/docs/public/specs/blocked_partners_page/',
+  builder: BlockedPartnersPageBuilder.new,
+  states: [
+    MdsState('state-loading', (b) => b.loading(), mdsIndex: 1),
+    MdsState('state-empty', (b) => b.empty(), mdsIndex: 2),
+    MdsState('state-with-partners', (b) => b.withPartners(), mdsIndex: 3),
+    MdsState('state-dark', (b) => b.withPartners().dark()),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);

--- a/apps/app_user/integration_test/mds-emulator-render/blocked_partners_page/blocked_partners_page_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/blocked_partners_page/blocked_partners_page_test.dart
@@ -13,7 +13,7 @@ final catalog = MdsCatalog<BlockedPartnersPageBuilder>(
   mdsSpec: 'apps/mds/docs/public/specs/blocked_partners_page/',
   builder: BlockedPartnersPageBuilder.new,
   states: [
-    MdsState('state-loading', (b) => b.loading(), mdsIndex: 1),
+    MdsState('state-loading', (b) => b.loading(), mdsIndex: 1, infiniteAnimation: true),
     MdsState('state-empty', (b) => b.empty(), mdsIndex: 2),
     MdsState('state-with-partners', (b) => b.withPartners(), mdsIndex: 3),
     MdsState('state-dark', (b) => b.withPartners().dark()),

--- a/apps/app_user/integration_test/mds-emulator-render/blocked_partners_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/blocked_partners_page/builder.dart
@@ -25,8 +25,7 @@ const List<Map<String, Object?>> _mockPartners = [
   },
 ];
 
-class BlockedPartnersPageBuilder
-    extends MdsScreenBuilder<BlockedPartnersPage> {
+class BlockedPartnersPageBuilder extends MdsScreenBuilder<BlockedPartnersPage> {
   BlockedPartnersPageBuilder() : super(page: const BlockedPartnersPage());
 
   /// 로딩 중 (future 미완료).

--- a/apps/app_user/integration_test/mds-emulator-render/blocked_partners_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/blocked_partners_page/builder.dart
@@ -1,0 +1,65 @@
+// BlockedPartnersPageBuilder — blocked_partners_page 전용 fluent API.
+//
+// blockedPartnersProvider (FutureProvider.autoDispose) 를 직접 override 해
+// loading / empty / with-partners 상태를 렌더링.
+// BlockedPartnersPage 의 unblock 버튼은 상호작용이 필요하므로
+// 렌더 catalog 에서는 초기 UI(목록 표시)만 캡처.
+
+import 'dart:async';
+
+import 'package:app_user/src/features/settings/blocked_partners_page.dart';
+
+import '../_engine/builder.dart';
+
+/// mock partner 2건.
+const List<Map<String, Object?>> _mockPartners = [
+  {
+    'id': 'partner-1',
+    'name': '카페 밍릿',
+    'profile_image_url': null,
+  },
+  {
+    'id': 'partner-2',
+    'name': '밍릿 하우스',
+    'profile_image_url': null,
+  },
+];
+
+class BlockedPartnersPageBuilder
+    extends MdsScreenBuilder<BlockedPartnersPage> {
+  BlockedPartnersPageBuilder() : super(page: const BlockedPartnersPage());
+
+  /// 로딩 중 (future 미완료).
+  BlockedPartnersPageBuilder loading() {
+    addOverride(
+      blockedPartnersProvider.overrideWith(
+        (_) => Completer<List<Map<String, dynamic>>>().future,
+      ),
+    );
+    // ignore: avoid_returning_this, fluent builder
+    return this;
+  }
+
+  /// 차단 목록 없음 (빈 상태).
+  BlockedPartnersPageBuilder empty() {
+    addOverride(blockedPartnersProvider.overrideWith((_) async => []));
+    // ignore: avoid_returning_this, fluent builder
+    return this;
+  }
+
+  /// 차단된 파트너 2건 표시.
+  BlockedPartnersPageBuilder withPartners() {
+    addOverride(
+      blockedPartnersProvider.overrideWith((_) async => _mockPartners),
+    );
+    // ignore: avoid_returning_this, fluent builder
+    return this;
+  }
+
+  /// 다크 모드 토글.
+  BlockedPartnersPageBuilder dark() {
+    useDarkTheme();
+    // ignore: avoid_returning_this, fluent builder
+    return this;
+  }
+}

--- a/apps/app_user/integration_test/mds-emulator-render/privacy_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/privacy_page/builder.dart
@@ -1,0 +1,30 @@
+// PrivacyPageBuilder — privacy_page 전용 fluent API.
+//
+// PrivacyPage 는 consentControllerProvider 를 watch 한다.
+// LoadedConsentController override 로 동의 목록을 주입.
+
+import 'package:app_user/src/features/settings/privacy_page.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+import '../_mocks/notifiers.dart';
+
+class PrivacyPageBuilder extends MdsScreenBuilder<PrivacyPage> {
+  PrivacyPageBuilder() : super(page: const PrivacyPage());
+
+  /// 동의 목록 로드 완료 (필수 동의 + 선택 일부).
+  PrivacyPageBuilder loaded() {
+    addOverride(
+      consentControllerProvider.overrideWith(LoadedConsentController.new),
+    );
+    // ignore: avoid_returning_this, fluent builder
+    return this;
+  }
+
+  /// 다크 모드 토글.
+  PrivacyPageBuilder dark() {
+    useDarkTheme();
+    // ignore: avoid_returning_this, fluent builder
+    return this;
+  }
+}

--- a/apps/app_user/integration_test/mds-emulator-render/privacy_page/privacy_page_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/privacy_page/privacy_page_test.dart
@@ -1,0 +1,27 @@
+// MDS screen: privacy_page
+// 대응 MDS: apps/mds/docs/public/specs/privacy_page/
+//
+// 출력: docs/infra/mds-emulator-render/privacy_page/state-*.png
+//
+// state_1 = 로딩 (consentControllerProvider AsyncLoading)
+// state_2 = 동의 목록 표시 (loaded)
+// state_3 = 다크 모드
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<PrivacyPageBuilder>(
+  screen: 'privacy_page',
+  mdsSpec: 'apps/mds/docs/public/specs/privacy_page/',
+  builder: PrivacyPageBuilder.new,
+  states: [
+    // 기본 state 는 consentControllerProvider AsyncLoading (override 없음).
+    MdsState('state-loading', (b) => b, mdsIndex: 1),
+    MdsState('state-loaded', (b) => b.loaded(), mdsIndex: 2),
+    MdsState('state-dark', (b) => b.loaded().dark(), mdsIndex: 3),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);

--- a/apps/app_user/integration_test/mds-emulator-render/privacy_page/privacy_page_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/privacy_page/privacy_page_test.dart
@@ -18,7 +18,7 @@ final catalog = MdsCatalog<PrivacyPageBuilder>(
   builder: PrivacyPageBuilder.new,
   states: [
     // 기본 state 는 consentControllerProvider AsyncLoading (override 없음).
-    MdsState('state-loading', (b) => b, mdsIndex: 1),
+    MdsState('state-loading', (b) => b, mdsIndex: 1, infiniteAnimation: true),
     MdsState('state-loaded', (b) => b.loaded(), mdsIndex: 2),
     MdsState('state-dark', (b) => b.loaded().dark(), mdsIndex: 3),
   ],


### PR DESCRIPTION
Scheduler: swe-sonnet-1

## 변경 내용

app_user mds-emulator-render catalog 3개 신규 등록. Refs #2587 (account 카테고리 잔여 uncovered screens 추적).

### 신규 catalog

| 화면 | states | 비고 |
|------|--------|------|
| `auth_callback_page` | state-loading · state-loading-dark | `infiniteAnimation: true` — 10초 타이머 발동 방지 |
| `blocked_partners_page` | state-loading · state-empty · state-with-partners · state-dark | `blockedPartnersProvider` FutureProvider override |
| `privacy_page` | state-loading · state-loaded · state-dark | `LoadedConsentController` override (필수 3 + 선택 3) |

### 신규 mock

- `_mocks/notifiers.dart`: `LoadedConsentController` (ConsentController 서브클래스, 동의 6개 반환)
- `_registry.dart`: 3개 catalog 알파벳 순 등록

## 검증

- `flutter analyze integration_test/mds-emulator-render/{auth_callback_page,blocked_partners_page,privacy_page}/ --no-fatal-infos` → No issues found

## 잔여 account 카테고리 미등록 화면

- `auth_callback_page` state-timeout (10초 타이머 발동 필요, 별도 처리 예정)
- `bank_account_page` (app_partner 화면)
- `create_verification_page` / `identity_verification_screen` (complex provider 의존)
- `signup_consent_page` (ConsumerStatefulWidget local state)