### PR TITLE
fix(test): consent CUJ 2-1/2-2/2-3 happy — afterPump pump(500ms)로 timeout 회피

### DIFF
--- a/apps/app_user/integration_test/cuj/account/signup_consent_test.dart
+++ b/apps/app_user/integration_test/cuj/account/signup_consent_test.dart
@@ -397,6 +397,9 @@ void main() {
       'happy: identity_verification 동의 없음 → 동의 시트 자동 표시',
       app: const IdentityVerificationScreen(),
       overrides: verificationBase,
+      // Fix #2589 dev-blocker: IdentityVerificationScreen 의 무한 CircularProgressIndicator(_isLoading=true) 가
+      // 시트가 열려있는 동안 백그라운드에서 계속 회전 → pumpAndSettle 가 settle 안 되고 10min timeout.
+      afterPump: (t) => t.pump(const Duration(milliseconds: 500)),
       body: (t) async {
         // IdentityVerificationScreen 진입 시 동의 미완료면 시트 자동 표시 (FR-7)
         expect(find.text('본인확인정보 수집·이용 동의'), findsOneWidget);
@@ -440,6 +443,8 @@ void main() {
       'happy: 동의 → consent 저장 → 인증 플로우 진입',
       app: const IdentityVerificationScreen(),
       overrides: verificationBase,
+      // Fix #2589 dev-blocker: 무한 CircularProgressIndicator 회피 (CUJ 2-1 참고)
+      afterPump: (t) => t.pump(const Duration(milliseconds: 500)),
       body: (t) async {
         // 시트 자동 표시됨 (CUJ 2-1과 동일 전제)
         expect(find.text('동의하고 인증'), findsOneWidget);
@@ -470,6 +475,8 @@ void main() {
       'happy: 취소 탭 → 동의 미저장, 시트 닫힘',
       app: const IdentityVerificationScreen(),
       overrides: verificationBase,
+      // Fix #2589 dev-blocker: 무한 CircularProgressIndicator 회피 (CUJ 2-1 참고)
+      afterPump: (t) => t.pump(const Duration(milliseconds: 500)),
       body: (t) async {
         // 시트 자동 표시됨
         expect(find.text('취소'), findsOneWidget);

--- a/apps/app_user/integration_test/cuj/account/signup_consent_test.dart
+++ b/apps/app_user/integration_test/cuj/account/signup_consent_test.dart
@@ -449,6 +449,11 @@ void main() {
         // 시트 자동 표시됨 (CUJ 2-1과 동일 전제)
         expect(find.text('동의하고 인증'), findsOneWidget);
 
+        // Fix #2589 dev-blocker: bottom sheet content
+        // (SingleChildScrollView)가 viewport(866px)보다 커서 버튼이 off-screen
+        // → tap miss. ensureVisible로 스크롤 후 탭.
+        await t.ensureVisible(find.text('동의하고 인증'));
+        await t.pump();
         await t.tap(find.text('동의하고 인증'));
         // FR-8: 동의 후 toggleConsent(identityVerification, consented: true) 저장
         // mock async 완료 대기 (Portone SDK 외부 호출 전)
@@ -481,8 +486,14 @@ void main() {
         // 시트 자동 표시됨
         expect(find.text('취소'), findsOneWidget);
 
+        // Fix #2589 dev-blocker: bottom sheet content
+        // (SingleChildScrollView)가 viewport(866px)보다 커서 버튼이 off-screen
+        // → tap miss. ensureVisible로 스크롤 후 탭.
+        await t.ensureVisible(find.text('취소'));
+        await t.pump();
         await t.tap(find.text('취소'));
-        await t.pumpAndSettle();
+        // 무한 spinner 회피 — pumpAndSettle 대신 고정 pump (CUJ 2-1 참고)
+        await t.pump(const Duration(milliseconds: 500));
 
         // FR-7: 취소 시 동의 미저장
         verifyNever(() => repo.saveConsents(any(), any()));

--- a/apps/app_user/integration_test/cuj/account/signup_consent_test.dart
+++ b/apps/app_user/integration_test/cuj/account/signup_consent_test.dart
@@ -264,7 +264,20 @@ void main() {
       app: const SignupConsentPage(),
       overrides: base,
       body: (t) async {
-        await t.tap(find.text('보기 ›').at(1));
+        // Fix #2589 dev-blocker: `.at(1)` 은 두 번째 보기 › → 개인정보 항목.
+        // 제3자 항목은 ageConfirmation(보기 › 없음) 다음이라 위치 변동 위험 큼.
+        // 1-3 첫 케이스(서비스 이용약관)와 동일하게 descendant 패턴으로 안정화.
+        await t.tap(
+          find
+              .descendant(
+                of: find.ancestor(
+                  of: find.text('제3자 제공 동의'),
+                  matching: find.byType(InkWell),
+                ),
+                matching: find.text('보기 ›'),
+              )
+              .first,
+        );
         await t.pumpAndSettle();
 
         // 제3자 제공 동의 전문 (FR-5)


### PR DESCRIPTION
Scheduler: swe-opus-1

## 문제

3 PR (#2596 / #2575 / #2618) 의 `cuj-integration-user` job 이 일제히 **30분 timeout** 으로 실패.

실패 로그 (PR #2596 기준):
\`\`\`
❌ [2-1] 본인인증 전 CI/DI 동의 happy: identity_verification 동의 없음 → 동의 시트 자동 표시
   pumpAndSettle timed out
✅ [2-1] 본인인증 전 CI/DI 동의 edge: identity_verification 이미 동의 → 시트 미표시
❌ [2-2] CI/DI 동의 후 Portone 호출 happy: 동의 → consent 저장 → 인증 플로우 진입
   pumpAndSettle timed out
\`\`\`

## Root cause

`IdentityVerificationScreen` (`shared/packages/minglit_kit/lib/src/features/verification/ui/identity_verification_screen.dart`) 는 진입 시 `_isLoading = true` 로 시작하여 `MinglitCircularProgressIndicator` (무한 회전 spinner) 를 표시한다.

flow:
1. `initState` → `addPostFrameCallback` 으로 `_startVerificationFlow()` 시동
2. `_ensureIdentityVerificationConsent()` 이 await — consent 없으면 `showIdentityVerificationConsentSheet()` 호출 → 모달 bottom sheet 가 사용자 입력 대기
3. 이 동안 background 의 spinner 는 계속 회전 → **pumpAndSettle 가 settle 안 됨 → 10min timeout**

edge case (이미 동의 있음 / Portone throw) 들은 `catch → finally` 에서 `_isLoading=false` 로 spinner 가 멎어 통과.

## 수정

`apps/app_user/integration_test/cuj/account/signup_consent_test.dart` 의 happy 3개 (2-1/2-2/2-3) 에 `afterPump` 명시:

\`\`\`dart
afterPump: (t) => t.pump(const Duration(milliseconds: 500)),
\`\`\`

이는 `apps/app_user/integration_test/cuj/event-operation/ticket_qr_improvement_test.dart` 등에서 이미 사용 중인 established pattern (무한 애니메이션이 있는 위젯의 cuj_test 엔진 사용 가이드: `apps/app_user/integration_test/cuj/_engine/cuj_test.dart:80`).

500ms 면 postFrameCallback + `getConsents()` mock async + `showModalBottomSheet` enter animation (250ms) 까지 충분.

## 영향 (unblock)

세 PR 의 `cuj-integration-user` 가 unblock 됨:
- #2596 (event-now-bar CUJ)
- #2575 (event-operation CUJ)
- #2618 (app_demo flavor)

## 검증 방법

PR 의 `cuj-integration-user` job 이 통과하면 fix 가 작동한다.

Refs #2589