### PR TITLE
feat(mds-render): signup_consent_page render catalog 등록 — Refs #2587

### DIFF
--- a/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
@@ -42,6 +42,7 @@ Phase 2 (TODO, follow-up PR) — `_manifest.yaml`, coverage report, scaffold 결
 | `search_page` | idle · results · empty |
 | `event_now_bar` | waiting · check-in-ready · checked-in · matching · results · ended · offline |
 | `event_ongoing_banner` | 8 phases + dark |
+| `signup_consent_page` | loading · default · required-only · all · dark |
 | `ticket_qr_screen` | with-token · not-found · dark |
 
 ## 폴더 컨벤션
@@ -58,4 +59,4 @@ MDS spec 디렉토리명과 동일 (per-screen, snake_case). 화면당 `builder.
 - [상위 BLUEDOC](../BLUEDOC.md) · 페어 워크플로우: `sync-mds-mockups.yml` (디자인 PNG)
 
 ---
-_Reviewed: 2026-05-20 22:50_
+_Reviewed: 2026-05-20 23:00_

--- a/apps/app_user/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_registry.dart
@@ -23,6 +23,8 @@ import 'notification_list_screen/notification_list_screen_test.dart'
 import 'notification_settings_screen/notification_settings_screen_test.dart'
     as notification_settings_screen;
 import 'search_page/search_page_test.dart' as search_page;
+import 'signup_consent_page/signup_consent_page_test.dart'
+    as signup_consent_page;
 import 'ticket_qr_screen/ticket_qr_screen_test.dart' as ticket_qr_screen;
 
 /// 모든 cataloged 화면의 명시적 list. 새 화면 추가 시 본 list 에 추가.
@@ -39,5 +41,6 @@ final List<MdsCatalog<MdsScreenBuilder<dynamic>>> allCatalogs = [
   notification_list_screen.catalog,
   notification_settings_screen.catalog,
   search_page.catalog,
+  signup_consent_page.catalog,
   ticket_qr_screen.catalog,
 ];

--- a/apps/app_user/integration_test/mds-emulator-render/signup_consent_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/signup_consent_page/builder.dart
@@ -54,8 +54,7 @@ class _AllConsentController extends ConsentController {
 /// 미완료 future — isInitialLoading=true 유지 (스피너 표시).
 class _LoadingConsentController extends ConsentController {
   @override
-  FutureOr<List<UserConsent>> build() =>
-      Completer<List<UserConsent>>().future;
+  FutureOr<List<UserConsent>> build() => Completer<List<UserConsent>>().future;
 }
 
 UserConsent _consent(ConsentType type) => UserConsent(

--- a/apps/app_user/integration_test/mds-emulator-render/signup_consent_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/signup_consent_page/builder.dart
@@ -1,0 +1,119 @@
+// SignupConsentPageBuilder — signup_consent_page 전용 fluent API.
+//
+// SignupConsentPage 는 consentControllerProvider 를 listen 해
+// 저장된 동의 항목으로 checkbox 를 hydrate 한다 (_didHydrate = true 이후).
+//
+// 모든 state 는 명시적 override 필요:
+//  noneSelected()  — [] 동기 반환 → 체크박스 없음 (State 1)
+//  requiredOnly()  — 필수 3개 checked (State 2)
+//  allSelected()   — 전체 7개 checked (State 3)
+//  loading()       — Completer 미완료 → 스피너 (infiniteAnimation 필수)
+//
+// State 4 (Submitting) / State 5 (Error) 는 사용자 액션 또는
+// 에러 스낵바 의존으로 정적 캡처 제외.
+
+import 'dart:async';
+
+import 'package:app_user/src/features/consent/ui/signup_consent_page.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+
+// ── Fake ConsentControllers ──────────────────────────────────────────────────
+
+/// [] 동기 반환 — loading 상태 없이 즉시 hydrate (체크박스 없음).
+class _DefaultConsentController extends ConsentController {
+  @override
+  FutureOr<List<UserConsent>> build() => [];
+}
+
+/// 필수 3개 동기 반환 — hydrate 후 required 체크박스 3개 checked.
+class _RequiredOnlyConsentController extends ConsentController {
+  @override
+  FutureOr<List<UserConsent>> build() => [
+    _consent(ConsentType.termsOfService),
+    _consent(ConsentType.privacyCollection),
+    _consent(ConsentType.ageConfirmation),
+  ];
+}
+
+/// 전체 7개 동기 반환 — hydrate 후 모든 체크박스 checked.
+class _AllConsentController extends ConsentController {
+  @override
+  FutureOr<List<UserConsent>> build() => [
+    _consent(ConsentType.termsOfService),
+    _consent(ConsentType.privacyCollection),
+    _consent(ConsentType.ageConfirmation),
+    _consent(ConsentType.thirdPartyProvision),
+    _consent(ConsentType.locationConsent),
+    _consent(ConsentType.identityVerification),
+    _consent(ConsentType.marketingConsent),
+  ];
+}
+
+/// 미완료 future — isInitialLoading=true 유지 (스피너 표시).
+class _LoadingConsentController extends ConsentController {
+  @override
+  FutureOr<List<UserConsent>> build() =>
+      Completer<List<UserConsent>>().future;
+}
+
+UserConsent _consent(ConsentType type) => UserConsent(
+  id: 'consent-${type.name}',
+  userId: 'mock-user-1',
+  consentKey: type,
+  consented: true,
+  consentedAt: DateTime.utc(2026),
+  createdAt: DateTime.utc(2026),
+);
+
+// ── Builder ─────────────────────────────────────────────────────────────────
+
+class SignupConsentPageBuilder extends MdsScreenBuilder<SignupConsentPage> {
+  SignupConsentPageBuilder() : super(page: const SignupConsentPage());
+
+  /// 로딩 상태 — consentControllerProvider 미완료 (infiniteAnimation 필수).
+  SignupConsentPageBuilder loading() {
+    addOverride(
+      consentControllerProvider.overrideWith(_LoadingConsentController.new),
+    );
+    // ignore: avoid_returning_this, fluent builder
+    return this;
+  }
+
+  /// 체크박스 없음 (none selected) — CTA 비활성 (State 1 baseline).
+  SignupConsentPageBuilder noneSelected() {
+    addOverride(
+      consentControllerProvider.overrideWith(_DefaultConsentController.new),
+    );
+    // ignore: avoid_returning_this, fluent builder
+    return this;
+  }
+
+  /// 필수 3개 checked — CTA 활성 (State 2).
+  SignupConsentPageBuilder requiredOnly() {
+    addOverride(
+      consentControllerProvider.overrideWith(
+        _RequiredOnlyConsentController.new,
+      ),
+    );
+    // ignore: avoid_returning_this, fluent builder
+    return this;
+  }
+
+  /// 전체 7개 checked (State 3).
+  SignupConsentPageBuilder allSelected() {
+    addOverride(
+      consentControllerProvider.overrideWith(_AllConsentController.new),
+    );
+    // ignore: avoid_returning_this, fluent builder
+    return this;
+  }
+
+  /// 다크 모드 토글.
+  SignupConsentPageBuilder dark() {
+    useDarkTheme();
+    // ignore: avoid_returning_this, fluent builder
+    return this;
+  }
+}

--- a/apps/app_user/integration_test/mds-emulator-render/signup_consent_page/signup_consent_page_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/signup_consent_page/signup_consent_page_test.dart
@@ -1,0 +1,36 @@
+// MDS screen: signup_consent_page
+// 대응 MDS: apps/mds/docs/public/specs/signup_consent_page/
+//
+// 출력: docs/infra/mds-emulator-render/signup_consent_page/state-*.png
+//
+// State 4 (Submitting) — _isSubmitting 은 로컬 state, 버튼 tap 필요 → 제외.
+// State 5 (Error) — showMinglitError snackbar 의존 → 제외.
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<SignupConsentPageBuilder>(
+  screen: 'signup_consent_page',
+  mdsSpec: 'apps/mds/docs/public/specs/signup_consent_page/',
+  builder: SignupConsentPageBuilder.new,
+  states: [
+    // Loading on entry — 동의 정보 로딩 중 스피너
+    MdsState(
+      'state-loading',
+      (b) => b.loading(),
+      infiniteAnimation: true,
+    ),
+    // State 1 — Default: 체크박스 없음, CTA 비활성
+    MdsState('state-default', (b) => b.noneSelected(), mdsIndex: 1),
+    // State 2 — 필수만 토글: CTA 활성
+    MdsState('state-required-only', (b) => b.requiredOnly(), mdsIndex: 2),
+    // State 3 — 전체 토글: 모든 체크박스 checked
+    MdsState('state-all', (b) => b.allSelected(), mdsIndex: 3),
+    // Dark variant
+    MdsState('state-dark', (b) => b.noneSelected().dark()),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-sonnet-1

## 개요

이슈 #2587 (account 카테고리 mds-render 미등록) 의 후속 작업. signup_consent_page MDS render catalog 5 states 등록.

## 변경 사항

### 신규 파일
- signup_consent_page/builder.dart — fluent API builder + fake ConsentController 4개
- signup_consent_page/signup_consent_page_test.dart — MdsCatalog 5 states

### 기존 파일 수정
- _registry.dart — allCatalogs 에 signup_consent_page 추가
- BLUEDOC.md — 신규 화면 이정표 추가 + _Reviewed 날짜 bump

## States

| State | 설명 | mdsIndex |
|-------|------|----------|
| state-loading | Completer 미완료 → 스피너 (infiniteAnimation: true) | null |
| state-default | 체크박스 없음, CTA 비활성 | 1 |
| state-required-only | 필수 3개 checked, CTA 활성 | 2 |
| state-all | 전체 7개 checked | 3 |
| state-dark | 다크 모드 (none selected) | null |

## 설계 결정

ConsentController.build()가 async 함수로 null 유저에도 Future<[]>를 반환 → 초기 AsyncLoading → pumpAndSettle 타임아웃. 각 state는 동기 반환 Controller override로 loading 상태를 건너뜀.

State 4 (Submitting): _isSubmitting은 로컬 state, 버튼 tap 트리거 필요 → 정적 캡처 제외.
State 5 (Error): showMinglitError snackbar 의존 → 정적 캡처 제외.

## 검증

flutter analyze integration_test/mds-emulator-render/signup_consent_page/ --no-fatal-infos
→ No issues found!

Refs #2587