### PR TITLE
fix(test): signup_consent CUJ 1-3 제3자 → descendant 패턴 안정화

### DIFF
--- a/apps/app_user/integration_test/cuj/account/signup_consent_test.dart
+++ b/apps/app_user/integration_test/cuj/account/signup_consent_test.dart
@@ -264,7 +264,20 @@ void main() {
       app: const SignupConsentPage(),
       overrides: base,
       body: (t) async {
-        await t.tap(find.text('보기 ›').at(1));
+        // Fix #2589 dev-blocker: `.at(1)` 은 두 번째 보기 › → 개인정보 항목.
+        // 제3자 항목은 ageConfirmation(보기 › 없음) 다음이라 위치 변동 위험 큼.
+        // 1-3 첫 케이스(서비스 이용약관)와 동일하게 descendant 패턴으로 안정화.
+        await t.tap(
+          find
+              .descendant(
+                of: find.ancestor(
+                  of: find.text('제3자 제공 동의'),
+                  matching: find.byType(InkWell),
+                ),
+                matching: find.text('보기 ›'),
+              )
+              .first,
+        );
         await t.pumpAndSettle();
 
         // 제3자 제공 동의 전문 (FR-5)


### PR DESCRIPTION
Scheduler: swe-opus-1

## What

`apps/app_user/integration_test/cuj/account/signup_consent_test.dart` 의
CUJ 1-3 두 번째 케이스 (`happy: 제3자 제공 동의 탭 → 바텀시트 열람`) 가
`find.text('보기 ›').at(1)` 을 사용하는데, 이는 두 번째 보기 › 인 **개인정보 수집·이용 동의**
항목을 탭한다. '제공받는 자' 는 제3자 항목 detail 에만 있으므로 `findsOneWidget` 실패.

| index | consent | 보기 › 존재 |
|---|---|---|
| 0 | 서비스 이용약관 | ✅ at(0) |
| 1 | 개인정보 수집·이용 동의 | ✅ at(1) ← 현재 잘못 탭 |
| 2 | 만 14세 이상 확인 | ❌ (detail 없음) |
| 3 | 제3자 제공 동의 | ✅ at(2) ← 원래 의도 |
| 4 | 위치정보 이용 동의 | ✅ |
| ... | ... | ... |

## Why

1-3 첫 케이스(서비스 이용약관)는 descendant + InkWell ancestor 패턴으로 robust 함.
같은 패턴으로 1-3 두 번째 케이스도 안정화 — index 변동에 영향 받지 않음.

`#2510` 에서 처음 추가될 때부터 잘못된 index. dev 에 머지되어 모든 app_user 변경
PR (`#2596`, `#2575` 등) 이 이 테스트 fail 로 BLOCKED 상태.

## How verified

- `flutter analyze` 통과
- descendant 패턴은 같은 파일 line 230-260 의 1-3 첫 케이스와 동일한 패턴

Refs #2589