### PR TITLE
feat(mds-render): app_partner account screens catalog 등록 — Refs #2587

### DIFF
--- a/apps/app_partner/BLUEDOC.md
+++ b/apps/app_partner/BLUEDOC.md
@@ -11,7 +11,8 @@ Minglit 의 **파트너 사장님 Flutter 앱**. 매장 관리·멤버 초대·�
 | [`lib/src/routing/`](./lib/src/routing/) | `app_router` (auth + 권한 + 온보딩 redirect) + `app_routes` (Type-safe) |
 | [`lib/src/logic/`](./lib/src/logic/) | 앱-레벨 Provider (`current_partner_provider`, `onboarding_state_provider`, `event_application_logic`, `dashboard_refresh_notifier`) |
 | `lib/src/ui/` · `widgets/` · `utils/` · `l10n/` | 파트너 전용 UI (shell, widgets) · 공용 위젯 · 헬퍼 · 다국어 |
-| [`integration_test/`](./integration_test/) | 통합 테스트 / CUJ ([BLUEDOC](./integration_test/cuj/BLUEDOC.md)) |
+| [`integration_test/cuj/`](./integration_test/cuj/) | CUJ 통합 테스트 ([BLUEDOC](./integration_test/cuj/BLUEDOC.md)) |
+| [`integration_test/mds-emulator-render/`](./integration_test/mds-emulator-render/) | MDS 에뮬레이터 렌더 catalog ([BLUEDOC](./integration_test/mds-emulator-render/BLUEDOC.md)) |
 | [`architecture.md`](./architecture.md) | 파트너 앱 고유 아키텍처 (권한 기반 라우팅 redirect) |
 | [`README.md`](./README.md) | 빌드·실행 명령 |
 
@@ -48,6 +49,7 @@ Minglit 의 **파트너 사장님 Flutter 앱**. 매장 관리·멤버 초대·�
 - [minglit_kit/BLUEDOC.md](../../shared/packages/minglit_kit/BLUEDOC.md) — 공용 패키지
 - [README.md](./README.md) — 빌드·실행 명령
 - [integration_test/cuj/BLUEDOC.md](./integration_test/cuj/BLUEDOC.md) — CUJ 통합 테스트
+- [integration_test/mds-emulator-render/BLUEDOC.md](./integration_test/mds-emulator-render/BLUEDOC.md) — MDS 에뮬레이터 렌더 catalog
 
 ---
-_Reviewed: 2026-05-17 22:32_
+_Reviewed: 2026-05-20 00:20_

--- a/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
@@ -21,8 +21,11 @@ flutter drive \
 
 | 화면 | states |
 |------|--------|
+| `bank_account_page` | loading · no-account · with-account · dark |
 | `checkin_placeholder_page` | loading · error · empty · selection · selection-dark |
+| `create_verification_page` | empty · with-fields · dark |
 | `recurrence_management_screen` | active · paused · cancelled · no-rule · action-loading · loading · active-dark |
+| `verification_manage_page` | loading · active-empty · active-with-items · archived-with-items · dark |
 
 ## 구조
 
@@ -36,14 +39,23 @@ mds-emulator-render/
 │   ├── runner.dart
 │   └── manifest.dart
 ├── _mocks/
-│   └── data.dart           # mockPartner(), mockRecurrenceRule(), mockEvents()
+│   └── data.dart           # mockPartner(), mockVerification(), mockBankAccount(), mockRecurrenceRule(), mockEvents()
 ├── _registry.dart          # 등록된 모든 catalog (알파벳 순)
+├── bank_account_page/
+│   ├── builder.dart
+│   └── bank_account_page_test.dart
 ├── checkin_placeholder_page/
 │   ├── builder.dart
 │   └── checkin_placeholder_page_test.dart
-└── recurrence_management_screen/
+├── create_verification_page/
+│   ├── builder.dart
+│   └── create_verification_page_test.dart
+├── recurrence_management_screen/
+│   ├── builder.dart
+│   └── recurrence_management_screen_test.dart
+└── verification_manage_page/
     ├── builder.dart
-    └── recurrence_management_screen_test.dart
+    └── verification_manage_page_test.dart
 ```
 
 ## 관련
@@ -51,4 +63,4 @@ mds-emulator-render/
 - [app_user mds-emulator-render](../../../app_user/integration_test/mds-emulator-render/BLUEDOC.md)
 - [architecture.md](../../../app_user/integration_test/mds-emulator-render/architecture.md)
 
-_Reviewed: 2026-05-20 00:00_
+_Reviewed: 2026-05-20 08:00_

--- a/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
@@ -1,0 +1,54 @@
+# mds-emulator-render (app_partner)
+
+MDS spec 의 각 화면을 실제 Flutter 앱으로 에뮬레이터에서 렌더링하여 PNG 캡처. 결과는 `docs/infra/mds-emulator-render/<screen>/state-*.png` 로, MDS HTML 디자인과 1:1 비교 대상.
+
+app_user 의 동일 인프라(`apps/app_user/integration_test/mds-emulator-render/`)를 app_partner 용으로 미러링. 엔진 코드는 동일, mock 및 builder 는 app_partner 전용.
+
+## 빠른 실행 (단일 화면)
+
+```bash
+cd apps/app_partner
+export JAVA_HOME="$(/usr/libexec/java_home -v 17)"
+flutter drive \
+  --driver=test_driver/mds_emulator_render_driver.dart \
+  --target=integration_test/mds-emulator-render/<screen>/<screen>_test.dart \
+  --flavor dev \
+  --dart-define-from-file=../../minglit_env/dev/flutter.env \
+  -d <device>
+```
+
+## 등록된 화면 (카탈로그 완료)
+
+| 화면 | states |
+|------|--------|
+| `checkin_placeholder_page` | loading · error · empty · selection · selection-dark |
+| `recurrence_management_screen` | active · paused · cancelled · no-rule · action-loading · loading · active-dark |
+
+## 구조
+
+```
+mds-emulator-render/
+├── BLUEDOC.md              # ← 본 문서
+├── _engine/                # 공통 framework (app_user 와 동일)
+│   ├── builder.dart
+│   ├── catalog.dart
+│   ├── state.dart
+│   ├── runner.dart
+│   └── manifest.dart
+├── _mocks/
+│   └── data.dart           # mockPartner(), mockRecurrenceRule(), mockEvents()
+├── _registry.dart          # 등록된 모든 catalog (알파벳 순)
+├── checkin_placeholder_page/
+│   ├── builder.dart
+│   └── checkin_placeholder_page_test.dart
+└── recurrence_management_screen/
+    ├── builder.dart
+    └── recurrence_management_screen_test.dart
+```
+
+## 관련
+
+- [app_user mds-emulator-render](../../../app_user/integration_test/mds-emulator-render/BLUEDOC.md)
+- [architecture.md](../../../app_user/integration_test/mds-emulator-render/architecture.md)
+
+_Reviewed: 2026-05-20 00:00_

--- a/apps/app_partner/integration_test/mds-emulator-render/_engine/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_engine/builder.dart
@@ -1,0 +1,91 @@
+// MdsScreenBuilder<W> — 화면별 fluent API base.
+//
+// 각 화면은 본 클래스를 extend 하여 자기 특화 메서드를 fluent 로 제공.
+// 예: HomePageBuilder().withEvents(3).dark()
+//
+// build() 호출 시 ProviderScope + MaterialApp 로 wrap 된 위젯 반환.
+// 모든 화면 공통 override (currentUser, authStateChanges, notificationInitializer)
+// 는 _commonRootOverrides() 가 자동 주입.
+
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+// NOTE: List<dynamic> + .cast() 패턴은 의도된 선택 (style choice 아님).
+// Riverpod 3.x 의 `Override` 와 `ProviderListenable` 는 sealed class /
+// internal interface 로 public export 가 없어, 외부 코드가 직접 type 으로
+// 사용 불가. ProviderScope.overrides 가 받는 type 자체가 internal `Override`.
+// alchemist 의 GoldenPageWrapper 도 동일 우회 (List<dynamic>).
+// 런타임 동작은 strict type 과 동일 — cast 가 실패 시 즉시 throw.
+//
+// ⚠ 함정 — provider override 중복:
+// Riverpod 는 같은 provider 가 두 번 override 되면 build 시점에 throw
+// ("Tried to override a provider twice"). 같은 provider 를 set 하는 fluent
+// 메서드가 2개라면 (예: `empty()` 와 `withEvents()`) state setup 에서 한쪽만
+// 호출하도록 author 가 책임진다. base 에 mutable provider 를 두지 않는 것이
+// 안전한 default (모든 state 가 명시적 호출).
+
+/// 모든 화면이 공유하는 root level override.
+List<dynamic> _commonRootOverrides() => [
+  currentUserProvider.overrideWith((_) => null),
+  authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+  notificationInitializerProvider.overrideWith((_) {}),
+];
+
+/// 화면별 builder 의 base class.
+///
+/// 화면 특화 builder 는 본 클래스를 extend 하고 fluent 메서드를 추가:
+/// ```dart
+/// class HomePageBuilder extends MdsScreenBuilder<HomePage> {
+///   HomePageBuilder() : super(
+///     page: const HomePage(),
+///     base: [
+///       homeCoordinatorProvider.overrideWith((_) => MockHomeCoordinator()),
+///     ],
+///   );
+///
+///   HomePageBuilder withEvents(int n) {
+///     addOverride(recommendationFeedProvider.overrideWith(...));
+///     return this;
+///   }
+/// }
+/// ```
+abstract class MdsScreenBuilder<W extends Widget> {
+  MdsScreenBuilder({
+    required this.page,
+    List<dynamic> base = const [],
+  }) : _base = List.unmodifiable(base);
+
+  final W page;
+  final List<dynamic> _base;
+  final List<dynamic> _stateOverrides = [];
+  Brightness _brightness = Brightness.light;
+
+  /// state 전용 override 추가. 화면 특화 builder 의 fluent 메서드에서 사용.
+  @protected
+  void addOverride(dynamic o) => _stateOverrides.add(o);
+
+  /// 다크 모드 토글. 모든 builder 가 공통으로 가짐.
+  void useDarkTheme() {
+    _brightness = Brightness.dark;
+  }
+
+  /// 최종 위젯 트리 생성.
+  /// `commonRoot + base + state` 순으로 override 적용.
+  /// 같은 provider 가 여러 번 override 되면 후순위가 이김.
+  Widget build() {
+    return ProviderScope(
+      overrides: [
+        ..._commonRootOverrides().cast(),
+        ..._base.cast(),
+        ..._stateOverrides.cast(),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: _brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
+        home: page,
+      ),
+    );
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/_engine/catalog.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_engine/catalog.dart
@@ -1,0 +1,30 @@
+// MdsCatalog — 한 화면의 모든 state 를 묶는 컨테이너.
+//
+// runner 가 본 카탈로그를 받아 testWidgets 를 자동 생성하고 PNG 캡처.
+
+import 'builder.dart';
+import 'state.dart';
+
+class MdsCatalog<B extends MdsScreenBuilder<dynamic>> {
+  const MdsCatalog({
+    required this.screen,
+    required this.mdsSpec,
+    required this.builder,
+    required this.states,
+  });
+
+  /// MDS spec 디렉토리명과 동일. snake_case.
+  /// 예: 'home_page', 'event_application_detail_page'.
+  final String screen;
+
+  /// MDS spec 디렉토리 경로 (참고용). 인스펙션 워크플로우의 페어링 단서.
+  /// 예: 'apps/mds/docs/public/specs/home_page/'
+  final String mdsSpec;
+
+  /// 새 builder 인스턴스 생성 함수.
+  /// 각 state 마다 fresh builder 가 만들어져야 override 누적 방지.
+  final B Function() builder;
+
+  /// 이 화면의 모든 state.
+  final List<MdsState<B>> states;
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/_engine/manifest.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_engine/manifest.dart
@@ -1,0 +1,55 @@
+// _manifest.yaml 데이터 모델 + YAML 직렬화.
+//
+// 인스펙션 워크플로우가 MDS state index ↔ 캡처 PNG 페어링 시 사용.
+//
+// 출력 위치: docs/infra/mds-emulator-render/<screen>/_manifest.yaml
+//
+// 작성 주체: host 측 `scripts/mds_render_coverage.dart` 가 registry 의
+// 모든 catalog 를 import 한 뒤 본 클래스로 직렬화 → 파일 쓰기.
+// (driver 측 emulator 환경에서 작성 안 함 — catalog 메타데이터 접근 어려움)
+
+/// 한 state 의 manifest entry.
+class MdsManifestState {
+  const MdsManifestState({
+    required this.name,
+    required this.mdsIndex,
+    required this.tags,
+  });
+
+  final String name;
+  final int? mdsIndex;
+  final List<String> tags;
+}
+
+/// 한 화면 manifest.
+class MdsManifest {
+  const MdsManifest({
+    required this.screen,
+    required this.mdsSpec,
+    required this.states,
+  });
+
+  final String screen;
+  final String mdsSpec;
+  final List<MdsManifestState> states;
+
+  /// YAML 직렬화 (단순 — 외부 yaml 패키지 의존 없이).
+  String toYaml({DateTime? generatedAt}) {
+    final ts = (generatedAt ?? DateTime.now().toUtc()).toIso8601String();
+    final buf = StringBuffer()
+      ..writeln('schema: 1')
+      ..writeln('screen: $screen')
+      ..writeln('mds_spec: $mdsSpec')
+      ..writeln('generated_at: $ts')
+      ..writeln('states:');
+    for (final s in states) {
+      buf.writeln('  - name: ${s.name}');
+      if (s.mdsIndex != null) buf.writeln('    mds_index: ${s.mdsIndex}');
+      buf.writeln('    file: ${s.name}.png');
+      if (s.tags.isNotEmpty) {
+        buf.writeln('    tags: [${s.tags.join(', ')}]');
+      }
+    }
+    return buf.toString();
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/_engine/runner.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_engine/runner.dart
@@ -1,0 +1,50 @@
+// MdsRenderEngine — catalog 를 받아 testWidgets 자동 생성 + 캡처.
+//
+// 각 state 마다 독립 testWidgets (실패 격리). screenshot name 컨벤션:
+//   <screen>__<state>
+// driver 의 onScreenshot 콜백이 이 name 을 split 해서 출력 경로 결정.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'builder.dart';
+import 'catalog.dart';
+
+class MdsRenderEngine {
+  /// 카탈로그의 모든 state 를 testWidgets 로 실행 + PNG 캡처.
+  static void run<B extends MdsScreenBuilder<dynamic>>(MdsCatalog<B> catalog) {
+    final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+    setUpAll(() async {
+      SharedPreferences.setMockInitialValues({});
+      await initializeDateFormatting('ko_KR');
+    });
+
+    for (final state in catalog.states) {
+      testWidgets(state.name, (tester) async {
+        final builder = state.setup(catalog.builder());
+        await tester.pumpWidget(builder.build());
+        // Fix #2590: repeat() 애니메이션은 pumpAndSettle이 timeout — 고정 pump 사용.
+        if (state.infiniteAnimation) {
+          // pulse 1회분(MinglitAnimation.medium ≈ 300ms) — 시작 직후 visible 상태 캡처.
+          await tester.pump(const Duration(milliseconds: 300));
+        } else {
+          await tester.pumpAndSettle();
+        }
+
+        // Android: Flutter surface → image 변환 후 캡처 필요.
+        await binding.convertFlutterSurfaceToImage();
+        if (state.infiniteAnimation) {
+          // surface 변환 후 추가 프레임 — 렌더링 파이프라인 완료 보장.
+          await tester.pump(const Duration(milliseconds: 100));
+        } else {
+          await tester.pumpAndSettle();
+        }
+
+        await binding.takeScreenshot('${catalog.screen}__${state.name}');
+      });
+    }
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/_engine/state.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_engine/state.dart
@@ -1,0 +1,45 @@
+// MdsState — 선언적 state 정의.
+//
+// catalog 의 states list 에 등록되는 단위. setup 함수가 builder 에 적용되어
+// 그 state 의 렌더링 결과를 만든다.
+
+import 'builder.dart';
+
+/// builder 에 state 셋업을 적용하는 함수.
+typedef MdsStateSetup<B extends MdsScreenBuilder<dynamic>> =
+    B Function(
+      B builder,
+    );
+
+/// 한 화면의 한 state.
+///
+/// 예:
+/// ```dart
+/// MdsState('state-empty', (b) => b.empty(), mdsIndex: 1)
+/// MdsState('state-with-events', (b) => b.withEvents(3), mdsIndex: 2)
+/// MdsState('state-dark', (b) => b.dark())   // mdsIndex null = orphan
+/// MdsState('state-pulse', (b) => b.pulse(), infiniteAnimation: true)
+/// ```
+///
+/// - [name]: kebab-case, `state-<label>` 권장. screenshot name 의 후반부.
+/// - [setup]: builder fluent 호출 chain. 반드시 builder 반환.
+/// - [mdsIndex]: 페어되는 MDS `state_N.png` 의 N. orphan (디자인 없음) 이면 null.
+/// - [tags]: 필터링 / 분류용. 예: `['smoke', 'edge', 'a11y']`.
+/// - [infiniteAnimation]: true이면 runner가 `pumpAndSettle()` 대신 고정 pump를
+///   사용한다. `repeat()` 애니메이션처럼 settle되지 않는 state에 필수.
+class MdsState<B extends MdsScreenBuilder<dynamic>> {
+  const MdsState(
+    this.name,
+    this.setup, {
+    this.mdsIndex,
+    this.tags = const [],
+    this.infiniteAnimation = false,
+  });
+
+  final String name;
+  final MdsStateSetup<B> setup;
+  final int? mdsIndex;
+  final List<String> tags;
+  // Fix #2590: pumpAndSettle이 settle하지 않는 무한 반복 애니메이션 state용.
+  final bool infiniteAnimation;
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/_mocks/data.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_mocks/data.dart
@@ -31,6 +31,47 @@ List<Event> mockEvents({int count = 2, DateTime? now}) {
   );
 }
 
+/// MDS render 용 mock Verification (partner custom 인증).
+Verification mockVerification({
+  String id = 'mock-verification-1',
+  String displayName = '골프 핸디캡 인증',
+  String internalName = 'golf_handicap',
+  VerificationCategory category = VerificationCategory.etc,
+  bool isActive = true,
+}) => Verification(
+  id: id,
+  displayName: displayName,
+  internalName: internalName,
+  category: category,
+  partnerId: 'mock-partner-1',
+  description: '골프 핸디캡을 인증하는 용도입니다.',
+  isActive: isActive,
+  formSchema: [
+    const VerificationFormField(
+      type: 'text',
+      label: '핸디캡 수치',
+      key: 'handicap_value',
+    ),
+    const VerificationFormField(
+      type: 'file',
+      label: '증빙 파일',
+      key: 'proof_file',
+      required: false,
+    ),
+  ],
+);
+
+/// MDS render 용 mock bank account data.
+Map<String, dynamic> mockBankAccount({
+  String bankName = '국민은행',
+  String accountHolder = '밍글릿 파트너',
+  String accountNumber = '12345678901234',
+}) => {
+  'bank_name': bankName,
+  'account_holder': accountHolder,
+  'account_number': accountNumber,
+};
+
 /// MDS render 용 mock RecurrenceRule (활성 상태, 매주 월요일).
 RecurrenceRule mockRecurrenceRule({
   String id = 'mock-rule-1',

--- a/apps/app_partner/integration_test/mds-emulator-render/_mocks/data.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_mocks/data.dart
@@ -1,0 +1,51 @@
+// Mock 데이터 팩토리. builder fluent 메서드들이 사용.
+//
+// 시간 의존 데이터는 고정값 사용 — PNG 캡처 시 결정적 결과 보장.
+
+import 'package:minglit_kit/minglit_kit.dart';
+
+/// 결정적 캡처를 위한 기준 시간.
+final DateTime mockBaseTime = DateTime.utc(2026, 5, 17, 19);
+
+/// MDS render 용 mock Partner.
+Partner mockPartner({
+  String id = 'mock-partner-1',
+  String name = '밍글릿 파트너',
+}) => Partner(id: id, name: name);
+
+/// MDS render 용 mock Event 목록.
+List<Event> mockEvents({int count = 2, DateTime? now}) {
+  final base = now ?? mockBaseTime;
+  return List.generate(
+    count,
+    (i) => Event(
+      id: 'mock-event-$i',
+      partyId: 'mock-party-1',
+      startTime: base.add(Duration(minutes: 30 + i * 60)),
+      endTime: base.add(Duration(hours: 2 + i)),
+      createdAt: base,
+      updatedAt: base,
+      title: 'Mock 이벤트 ${i + 1}',
+      currentParticipants: (i + 1) * 5,
+    ),
+  );
+}
+
+/// MDS render 용 mock RecurrenceRule (활성 상태, 매주 월요일).
+RecurrenceRule mockRecurrenceRule({
+  String id = 'mock-rule-1',
+  String partyId = 'mock-party-1',
+  RecurrencePattern pattern = RecurrencePattern.weekly,
+  RecurrenceStatus status = RecurrenceStatus.active,
+  List<int> daysOfWeek = const [1],
+}) => RecurrenceRule(
+  id: id,
+  partyId: partyId,
+  pattern: pattern,
+  startTime: '20:00',
+  endTime: '22:00',
+  createdAt: mockBaseTime,
+  updatedAt: mockBaseTime,
+  daysOfWeek: daysOfWeek,
+  status: status,
+);

--- a/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
@@ -1,0 +1,15 @@
+// MDS render catalog registry — app_partner.
+//
+// 등록된 catalog 목록. 알파벳 순서 유지.
+// 새 screen 추가 시 아래 import + catalog 변수 참조 추가.
+
+import 'checkin_placeholder_page/checkin_placeholder_page_test.dart'
+    as checkin_placeholder_page;
+import 'recurrence_management_screen/recurrence_management_screen_test.dart'
+    as recurrence_management_screen;
+
+/// 모든 등록된 catalog.
+final List<Object> catalogs = [
+  checkin_placeholder_page.catalog,
+  recurrence_management_screen.catalog,
+];

--- a/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
@@ -3,13 +3,21 @@
 // 등록된 catalog 목록. 알파벳 순서 유지.
 // 새 screen 추가 시 아래 import + catalog 변수 참조 추가.
 
+import 'bank_account_page/bank_account_page_test.dart' as bank_account_page;
 import 'checkin_placeholder_page/checkin_placeholder_page_test.dart'
     as checkin_placeholder_page;
+import 'create_verification_page/create_verification_page_test.dart'
+    as create_verification_page;
 import 'recurrence_management_screen/recurrence_management_screen_test.dart'
     as recurrence_management_screen;
+import 'verification_manage_page/verification_manage_page_test.dart'
+    as verification_manage_page;
 
 /// 모든 등록된 catalog.
 final List<Object> catalogs = [
+  bank_account_page.catalog,
   checkin_placeholder_page.catalog,
+  create_verification_page.catalog,
   recurrence_management_screen.catalog,
+  verification_manage_page.catalog,
 ];

--- a/apps/app_partner/integration_test/mds-emulator-render/bank_account_page/bank_account_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/bank_account_page/bank_account_page_test.dart
@@ -1,0 +1,32 @@
+// MDS screen: bank_account_page (app_partner)
+// 대응 MDS: apps/mds/docs/public/specs/bank_account_page/
+//
+// 출력: docs/infra/mds-emulator-render/bank_account_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<BankAccountPageBuilder>(
+  screen: 'bank_account_page',
+  mdsSpec: 'apps/mds/docs/public/specs/bank_account_page/',
+  builder: BankAccountPageBuilder.new,
+  states: [
+    // Loading — partner 정보 로딩 중 스피너
+    MdsState(
+      'state-loading',
+      (b) => b.loading(),
+      mdsIndex: 1,
+      infiniteAnimation: true,
+    ),
+    // No account — 등록된 계좌 없음
+    MdsState('state-no-account', (b) => b.withNoAccount(), mdsIndex: 2),
+    // With account — 계좌 정보 표시
+    MdsState('state-with-account', (b) => b.withAccount(), mdsIndex: 3),
+    // Dark variant
+    MdsState('state-dark', (b) => b.withAccount().dark()),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);

--- a/apps/app_partner/integration_test/mds-emulator-render/bank_account_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/bank_account_page/builder.dart
@@ -1,0 +1,141 @@
+// BankAccountPageBuilder — bank_account_page 전용 fluent API.
+//
+// BankAccountPage 는 ConsumerStatefulWidget 으로, initState() 에서
+// currentPartnerInfoProvider.future 와 settlementRepositoryProvider 를 직접 read.
+// - loading: currentPartnerInfoProvider 를 무한 지연으로 override
+// - no-account: partner 있음 + getBankAccount null 반환
+// - with-account: partner 있음 + getBankAccount mock 데이터 반환
+
+import 'package:app_partner/src/features/settlement/bank_account_page.dart';
+import 'package:app_partner/src/logic/current_partner_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+import '../_mocks/data.dart';
+
+/// _FakeSettlementRepository — Supabase 없이 결정적 데이터 반환.
+class _FakeSettlementRepository implements SettlementRepository {
+  _FakeSettlementRepository({this.bankAccountData});
+
+  final Map<String, dynamic>? bankAccountData;
+
+  @override
+  Future<Map<String, dynamic>?> getBankAccount(String partnerId) async =>
+      bankAccountData;
+
+  @override
+  Future<void> upsertBankAccount({
+    required String partnerId,
+    required String bankName,
+    required String accountHolder,
+    required String accountNumber,
+  }) async {}
+
+  @override
+  Future<List<SettlementItemDetail>> getSettlementItems({
+    required String partnerId,
+    String? status,
+    DateTime? dateStart,
+    DateTime? dateEnd,
+    int limit = 20,
+    int offset = 0,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<SettlementItemDetail?> getSettlementItemDetail(String itemId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<Map<String, dynamic>> getSettlementDashboard({
+    required String partnerId,
+    DateTime? periodStart,
+    DateTime? periodEnd,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<Map<String, dynamic>?> getEventInfo(String eventId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<Map<String, dynamic>?> getPartnerSettlementInfo(
+    String partnerId,
+  ) => throw UnimplementedError();
+
+  @override
+  Future<Map<String, dynamic>> retryPayout({
+    required String payoutId,
+    required String partnerId,
+  }) => throw UnimplementedError();
+}
+
+class BankAccountPageBuilder extends MdsScreenBuilder<BankAccountPage> {
+  BankAccountPageBuilder() : super(page: const BankAccountPage());
+
+  bool _isLoading = false;
+  Map<String, dynamic>? _bankAccountData;
+  Partner? _partner;
+  Brightness _brightness = Brightness.light;
+
+  /// loading 상태 — partner 정보 로딩 중, spinner 표시.
+  BankAccountPageBuilder loading() {
+    _isLoading = true;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// partner 있음, 등록된 계좌 없음.
+  BankAccountPageBuilder withNoAccount() {
+    _partner = mockPartner();
+    _bankAccountData = null;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// partner 있음, 계좌 정보 있음.
+  BankAccountPageBuilder withAccount() {
+    _partner = mockPartner();
+    _bankAccountData = mockBankAccount();
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// 다크 모드.
+  BankAccountPageBuilder dark() {
+    _brightness = Brightness.dark;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  @override
+  Widget build() {
+    final isLoading = _isLoading;
+    final partner = _partner;
+    final bankAccountData = _bankAccountData;
+
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => null),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+        currentPartnerInfoProvider.overrideWith((ref) async {
+          if (isLoading) {
+            await Future<void>.delayed(const Duration(days: 1));
+          }
+          return partner;
+        }),
+        if (partner != null)
+          settlementRepositoryProvider.overrideWith(
+            (_) => _FakeSettlementRepository(bankAccountData: bankAccountData),
+          ),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: _brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
+        home: const BankAccountPage(),
+      ),
+    );
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/checkin_placeholder_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/checkin_placeholder_page/builder.dart
@@ -16,8 +16,7 @@ import '../_mocks/data.dart';
 
 class CheckinPlaceholderPageBuilder
     extends MdsScreenBuilder<CheckinPlaceholderPage> {
-  CheckinPlaceholderPageBuilder()
-    : super(page: const CheckinPlaceholderPage());
+  CheckinPlaceholderPageBuilder() : super(page: const CheckinPlaceholderPage());
 
   Partner? _partner;
   bool _isLoading = false;

--- a/apps/app_partner/integration_test/mds-emulator-render/checkin_placeholder_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/checkin_placeholder_page/builder.dart
@@ -1,0 +1,100 @@
+// CheckinPlaceholderPageBuilder — checkin_placeholder_page 전용 fluent API.
+//
+// CheckinPlaceholderPage 는 currentPartnerInfoProvider (Partner?) 와
+// todayEventsProvider(partnerId) (List<Event>) 를 watch 한다.
+//
+// build() 직접 override 로 currentPartnerInfoProvider 중복 override 방지
+// (_commonRootOverrides() 내 currentUserProvider 와 충돌 없이 독립 구성).
+
+import 'package:app_partner/src/features/checkin/checkin_placeholder_page.dart';
+import 'package:app_partner/src/logic/current_partner_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+import '../_mocks/data.dart';
+
+class CheckinPlaceholderPageBuilder
+    extends MdsScreenBuilder<CheckinPlaceholderPage> {
+  CheckinPlaceholderPageBuilder()
+    : super(page: const CheckinPlaceholderPage());
+
+  Partner? _partner;
+  bool _isLoading = false;
+  bool _partnerLoadError = false;
+  List<Event> _events = [];
+  Brightness _brightness = Brightness.light;
+
+  /// loading 상태 — partner 정보 로딩 중.
+  CheckinPlaceholderPageBuilder loading() {
+    _isLoading = true;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// error 상태 — partner 정보 로드 실패.
+  CheckinPlaceholderPageBuilder error() {
+    _partnerLoadError = true;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// partner 정보 있음 + 오늘 이벤트 0개.
+  CheckinPlaceholderPageBuilder withNoEvents() {
+    _partner = mockPartner();
+    _events = [];
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// partner 정보 있음 + 오늘 이벤트 2+개 (선택 목록 표시).
+  CheckinPlaceholderPageBuilder withMultipleEvents(int count) {
+    _partner = mockPartner();
+    _events = mockEvents(count: count);
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// 다크 모드.
+  CheckinPlaceholderPageBuilder dark() {
+    _brightness = Brightness.dark;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  @override
+  Widget build() {
+    final partner = _partner;
+    final isLoading = _isLoading;
+    final hasError = _partnerLoadError;
+    final events = _events;
+
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => null),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+        currentPartnerInfoProvider.overrideWith((ref) async {
+          if (isLoading) {
+            await Future<void>.delayed(const Duration(days: 1));
+          }
+          if (hasError) {
+            throw Exception('파트너 정보를 불러올 수 없습니다');
+          }
+          return partner;
+        }),
+        if (partner != null)
+          todayEventsProvider.overrideWith(
+            (ref, partnerId) async => events,
+          ),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: _brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
+        home: const CheckinPlaceholderPage(),
+      ),
+    );
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/checkin_placeholder_page/checkin_placeholder_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/checkin_placeholder_page/checkin_placeholder_page_test.dart
@@ -1,0 +1,31 @@
+// MDS screen: checkin_placeholder_page (app_partner)
+// 대응 MDS: apps/mds/docs/public/specs/checkin_placeholder_page/
+//
+// 출력: docs/infra/mds-emulator-render/checkin_placeholder_page/state-*.png
+//
+// state_4 (direct-scan 1event) 는 mobile_scanner (카메라) 의존 → 캡처 제외.
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<CheckinPlaceholderPageBuilder>(
+  screen: 'checkin_placeholder_page',
+  mdsSpec: 'apps/mds/docs/public/specs/checkin_placeholder_page/',
+  builder: CheckinPlaceholderPageBuilder.new,
+  states: [
+    // Loading — partner 정보 로딩 중 스피너
+    MdsState('state-loading', (b) => b.loading(), mdsIndex: 1),
+    // Error — partner 정보 로드 실패
+    MdsState('state-error', (b) => b.error(), mdsIndex: 2),
+    // Empty — 오늘 이벤트 없음
+    MdsState('state-empty', (b) => b.withNoEvents(), mdsIndex: 3),
+    // Selection — 오늘 이벤트 2+개 (선택 목록)
+    MdsState('state-selection', (b) => b.withMultipleEvents(2), mdsIndex: 5),
+    // Dark variant
+    MdsState('state-selection-dark', (b) => b.withMultipleEvents(2).dark()),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);

--- a/apps/app_partner/integration_test/mds-emulator-render/checkin_placeholder_page/checkin_placeholder_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/checkin_placeholder_page/checkin_placeholder_page_test.dart
@@ -16,7 +16,12 @@ final catalog = MdsCatalog<CheckinPlaceholderPageBuilder>(
   builder: CheckinPlaceholderPageBuilder.new,
   states: [
     // Loading — partner 정보 로딩 중 스피너
-    MdsState('state-loading', (b) => b.loading(), mdsIndex: 1, infiniteAnimation: true),
+    MdsState(
+      'state-loading',
+      (b) => b.loading(),
+      mdsIndex: 1,
+      infiniteAnimation: true,
+    ),
     // Error — partner 정보 로드 실패
     MdsState('state-error', (b) => b.error(), mdsIndex: 2),
     // Empty — 오늘 이벤트 없음

--- a/apps/app_partner/integration_test/mds-emulator-render/checkin_placeholder_page/checkin_placeholder_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/checkin_placeholder_page/checkin_placeholder_page_test.dart
@@ -16,7 +16,7 @@ final catalog = MdsCatalog<CheckinPlaceholderPageBuilder>(
   builder: CheckinPlaceholderPageBuilder.new,
   states: [
     // Loading — partner 정보 로딩 중 스피너
-    MdsState('state-loading', (b) => b.loading(), mdsIndex: 1),
+    MdsState('state-loading', (b) => b.loading(), mdsIndex: 1, infiniteAnimation: true),
     // Error — partner 정보 로드 실패
     MdsState('state-error', (b) => b.error(), mdsIndex: 2),
     // Empty — 오늘 이벤트 없음

--- a/apps/app_partner/integration_test/mds-emulator-render/create_verification_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/create_verification_page/builder.dart
@@ -1,0 +1,92 @@
+// CreateVerificationPageBuilder — create_verification_page 전용 fluent API.
+//
+// CreateVerificationPage 는 createVerificationControllerProvider (순수 로컬 상태)
+// 를 watch. 외부 async 의존성 없음 — controller fake 로 초기 state 주입.
+
+import 'dart:async';
+
+import 'package:app_partner/src/features/verification/create/create_verification_controller.dart';
+import 'package:app_partner/src/features/verification/create/create_verification_page.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+
+/// 고정 state 를 반환하는 fake controller.
+class _FakeCreateVerificationController extends CreateVerificationController {
+  _FakeCreateVerificationController({required this.initialState});
+
+  final CreateVerificationState initialState;
+
+  @override
+  CreateVerificationState build() => initialState;
+}
+
+class CreateVerificationPageBuilder
+    extends MdsScreenBuilder<CreateVerificationPage> {
+  CreateVerificationPageBuilder() : super(page: const CreateVerificationPage());
+
+  CreateVerificationState _state = const CreateVerificationState();
+  Brightness _brightness = Brightness.light;
+
+  /// 필드 없는 빈 폼 상태 (기본값).
+  CreateVerificationPageBuilder empty() {
+    _state = const CreateVerificationState();
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// 텍스트 + 파일 필드가 추가된 상태.
+  CreateVerificationPageBuilder withFields() {
+    _state = const CreateVerificationState(
+      displayName: '골프 핸디캡 인증',
+      internalName: 'golf_handicap_2026',
+      description: '핸디캡 증빙 서류를 제출해 주세요.',
+      fields: [
+        VerificationFormField(
+          type: 'text',
+          label: '핸디캡 수치',
+          key: 'handicap_value',
+        ),
+        VerificationFormField(
+          type: 'file',
+          label: '증빙 파일',
+          key: 'proof_file',
+          required: false,
+        ),
+      ],
+    );
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// 다크 모드.
+  CreateVerificationPageBuilder dark() {
+    _brightness = Brightness.dark;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  @override
+  Widget build() {
+    final state = _state;
+
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => null),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+        createVerificationControllerProvider.overrideWith(
+          () => _FakeCreateVerificationController(initialState: state),
+        ),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: _brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
+        home: const CreateVerificationPage(),
+      ),
+    );
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/create_verification_page/create_verification_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/create_verification_page/create_verification_page_test.dart
@@ -1,0 +1,25 @@
+// MDS screen: create_verification_page (app_partner)
+// 대응 MDS: apps/mds/docs/public/specs/create_verification_page/
+//
+// 출력: docs/infra/mds-emulator-render/create_verification_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<CreateVerificationPageBuilder>(
+  screen: 'create_verification_page',
+  mdsSpec: 'apps/mds/docs/public/specs/create_verification_page/',
+  builder: CreateVerificationPageBuilder.new,
+  states: [
+    // Empty — 필드 없는 빈 폼
+    MdsState('state-empty', (b) => b.empty(), mdsIndex: 1),
+    // With fields — 텍스트 + 파일 필드 2개 추가된 상태
+    MdsState('state-with-fields', (b) => b.withFields(), mdsIndex: 2),
+    // Dark variant
+    MdsState('state-dark', (b) => b.dark()),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);

--- a/apps/app_partner/integration_test/mds-emulator-render/recurrence_management_screen/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/recurrence_management_screen/builder.dart
@@ -1,0 +1,133 @@
+// RecurrenceManagementScreenBuilder — recurrence_management_screen 전용 builder.
+//
+// RecurrenceManagementScreen 은 partyRecurrenceRuleProvider(partyId) 와
+// recurrenceManagementControllerProvider 를 watch 한다.
+
+import 'dart:async';
+
+import 'package:app_partner/src/features/party/recurrence/recurrence_management_controller.dart';
+import 'package:app_partner/src/features/party/recurrence/recurrence_management_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+import '../_mocks/data.dart';
+
+const _mockPartyId = 'mock-party-1';
+
+/// Fake controller that returns a fixed state without network calls.
+class _FakeRecurrenceManagementController
+    extends RecurrenceManagementController {
+  _FakeRecurrenceManagementController({required this.loading});
+
+  final bool loading;
+
+  @override
+  FutureOr<void> build() {
+    if (loading) return Future<void>.delayed(const Duration(days: 1));
+  }
+}
+
+class RecurrenceManagementScreenBuilder
+    extends MdsScreenBuilder<RecurrenceManagementScreen> {
+  RecurrenceManagementScreenBuilder()
+    : super(
+        page: const RecurrenceManagementScreen(partyId: _mockPartyId),
+      );
+
+  RecurrenceRule? _rule;
+  bool _ruleLoadError = false;
+  bool _loadingState = false;
+  bool _actionLoading = false;
+  Brightness _brightness = Brightness.light;
+
+  /// 활성 규칙 (매주 월요일, 운영 중).
+  RecurrenceManagementScreenBuilder withActiveRule() {
+    _rule = mockRecurrenceRule();
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// 일시 정지된 규칙.
+  RecurrenceManagementScreenBuilder withPausedRule() {
+    _rule = mockRecurrenceRule(status: RecurrenceStatus.paused);
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// 취소된 규칙.
+  RecurrenceManagementScreenBuilder withCancelledRule() {
+    _rule = mockRecurrenceRule(status: RecurrenceStatus.cancelled);
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// 규칙 없음 (null).
+  RecurrenceManagementScreenBuilder withNoRule() {
+    _rule = null;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// 로드 에러.
+  RecurrenceManagementScreenBuilder withLoadError() {
+    _ruleLoadError = true;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// 로딩 중 — provider AsyncLoading (fetch in progress).
+  RecurrenceManagementScreenBuilder loading() {
+    _loadingState = true;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// 액션 진행 중 (버튼 disabled).
+  RecurrenceManagementScreenBuilder withActionLoading() {
+    _rule = mockRecurrenceRule();
+    _actionLoading = true;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// 다크 모드.
+  RecurrenceManagementScreenBuilder dark() {
+    _brightness = Brightness.dark;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  @override
+  Widget build() {
+    final rule = _rule;
+    final loadingState = _loadingState;
+    final ruleLoadError = _ruleLoadError;
+    final actionLoading = _actionLoading;
+
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => null),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+        partyRecurrenceRuleProvider(_mockPartyId).overrideWith((ref) async {
+          if (ruleLoadError) throw Exception('규칙을 불러올 수 없습니다');
+          if (loadingState) {
+            await Future<void>.delayed(const Duration(days: 1));
+          }
+          return rule;
+        }),
+        recurrenceManagementControllerProvider.overrideWith(
+          () => _FakeRecurrenceManagementController(loading: actionLoading),
+        ),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: _brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
+        home: const RecurrenceManagementScreen(partyId: _mockPartyId),
+      ),
+    );
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/recurrence_management_screen/recurrence_management_screen_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/recurrence_management_screen/recurrence_management_screen_test.dart
@@ -27,7 +27,7 @@ final catalog = MdsCatalog<RecurrenceManagementScreenBuilder>(
     // Action loading — 버튼 disabled
     MdsState('state-action-loading', (b) => b.withActionLoading(), mdsIndex: 6),
     // Loading (fetch) — AsyncValueWidget 로딩
-    MdsState('state-loading', (b) => b.loading(), mdsIndex: 8),
+    MdsState('state-loading', (b) => b.loading(), mdsIndex: 8, infiniteAnimation: true),
     // Dark variant
     MdsState('state-active-dark', (b) => b.withActiveRule().dark()),
   ],

--- a/apps/app_partner/integration_test/mds-emulator-render/recurrence_management_screen/recurrence_management_screen_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/recurrence_management_screen/recurrence_management_screen_test.dart
@@ -1,0 +1,36 @@
+// MDS screen: recurrence_management_screen (app_partner)
+// 대응 MDS: apps/mds/docs/public/specs/recurrence_management_screen/
+//
+// 출력: docs/infra/mds-emulator-render/recurrence_management_screen/state-*.png
+//
+// state_5 (confirm dialog overlay), state_7 (success snackbar) 는
+// 실제 유저 액션 트리거 필요 → 카탈로그 외 UI test 에서 검증.
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<RecurrenceManagementScreenBuilder>(
+  screen: 'recurrence_management_screen',
+  mdsSpec: 'apps/mds/docs/public/specs/recurrence_management_screen/',
+  builder: RecurrenceManagementScreenBuilder.new,
+  states: [
+    // Default/Active — 보라 '활성' 칩 + [일시정지 | 취소] 액션바
+    MdsState('state-active', (b) => b.withActiveRule(), mdsIndex: 1),
+    // Paused — tertiary '일시 정지' 칩 + [취소 | 재개] 액션바
+    MdsState('state-paused', (b) => b.withPausedRule(), mdsIndex: 2),
+    // Cancelled — error '취소됨' 칩 + 안내문 + 액션바 hidden
+    MdsState('state-cancelled', (b) => b.withCancelledRule(), mdsIndex: 3),
+    // No rule — '설정된 반복 규칙이 없습니다.' 중앙 텍스트
+    MdsState('state-no-rule', (b) => b.withNoRule(), mdsIndex: 4),
+    // Action loading — 버튼 disabled
+    MdsState('state-action-loading', (b) => b.withActionLoading(), mdsIndex: 6),
+    // Loading (fetch) — AsyncValueWidget 로딩
+    MdsState('state-loading', (b) => b.loading(), mdsIndex: 8),
+    // Dark variant
+    MdsState('state-active-dark', (b) => b.withActiveRule().dark()),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);

--- a/apps/app_partner/integration_test/mds-emulator-render/recurrence_management_screen/recurrence_management_screen_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/recurrence_management_screen/recurrence_management_screen_test.dart
@@ -27,7 +27,12 @@ final catalog = MdsCatalog<RecurrenceManagementScreenBuilder>(
     // Action loading — 버튼 disabled
     MdsState('state-action-loading', (b) => b.withActionLoading(), mdsIndex: 6),
     // Loading (fetch) — AsyncValueWidget 로딩
-    MdsState('state-loading', (b) => b.loading(), mdsIndex: 8, infiniteAnimation: true),
+    MdsState(
+      'state-loading',
+      (b) => b.loading(),
+      mdsIndex: 8,
+      infiniteAnimation: true,
+    ),
     // Dark variant
     MdsState('state-active-dark', (b) => b.withActiveRule().dark()),
   ],

--- a/apps/app_partner/integration_test/mds-emulator-render/verification_manage_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/verification_manage_page/builder.dart
@@ -1,0 +1,134 @@
+// VerificationManagePageBuilder — verification_manage_page 전용 fluent API.
+//
+// VerificationManagePage 는 verificationManageControllerProvider (async) 와
+// verificationCoordinatorProvider 를 watch/read 한다.
+// - controller: FutureOr<VerificationManageState> 반환 fake 사용
+// - coordinator: no-op (navigation action 무시)
+
+import 'dart:async';
+
+import 'package:app_partner/src/features/verification/manage/verification_manage_controller.dart';
+import 'package:app_partner/src/features/verification/manage/verification_manage_page.dart';
+import 'package:app_partner/src/features/verification/verification_coordinator.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+import '../_mocks/data.dart';
+
+/// 고정 state 를 반환하는 fake controller.
+class _FakeVerificationManageController extends VerificationManageController {
+  _FakeVerificationManageController({this.fixedState});
+
+  // null → AsyncLoading (지연 반환으로 구현)
+  final VerificationManageState? fixedState;
+
+  @override
+  FutureOr<VerificationManageState> build() {
+    final s = fixedState;
+    if (s == null) {
+      return Future<VerificationManageState>.delayed(
+        const Duration(days: 1),
+      );
+    }
+    return s;
+  }
+}
+
+/// No-op coordinator — 화면 내 navigation 탭 없이 render 가능하게.
+class _NoOpVerificationCoordinator extends VerificationCoordinator {
+  @override
+  void build() {}
+
+  @override
+  void pushVerificationManage() {}
+
+  @override
+  void pushCreateVerification({String? partnerId}) {}
+}
+
+class VerificationManagePageBuilder
+    extends MdsScreenBuilder<VerificationManagePage> {
+  VerificationManagePageBuilder() : super(page: const VerificationManagePage());
+
+  VerificationManageState? _state; // null → loading
+  Brightness _brightness = Brightness.light;
+
+  /// loading 상태 — MinglitAsyncValueWidget 로딩 스피너.
+  VerificationManagePageBuilder loading() {
+    _state = null;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// active list 비어 있음.
+  VerificationManagePageBuilder withActiveEmpty() {
+    _state = const VerificationManageState();
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// active list 에 인증 2개.
+  VerificationManagePageBuilder withActiveItems() {
+    _state = VerificationManageState(
+      active: [
+        mockVerification(),
+        mockVerification(
+          id: 'mock-verification-2',
+          displayName: '테니스 레이팅 인증',
+          internalName: 'tennis_rating',
+        ),
+      ],
+    );
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// archived list 에 인증 1개 (active 비어있음).
+  VerificationManagePageBuilder withArchivedItems() {
+    _state = VerificationManageState(
+      archived: [
+        mockVerification(
+          id: 'mock-verification-archived-1',
+          displayName: '아카이브된 인증',
+          isActive: false,
+        ),
+      ],
+    );
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// 다크 모드.
+  VerificationManagePageBuilder dark() {
+    _brightness = Brightness.dark;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  @override
+  Widget build() {
+    final state = _state;
+
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => null),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+        verificationManageControllerProvider.overrideWith(
+          () => _FakeVerificationManageController(fixedState: state),
+        ),
+        verificationCoordinatorProvider.overrideWith(
+          _NoOpVerificationCoordinator.new,
+        ),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: _brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
+        home: const VerificationManagePage(),
+      ),
+    );
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/verification_manage_page/verification_manage_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/verification_manage_page/verification_manage_page_test.dart
@@ -1,0 +1,42 @@
+// MDS screen: verification_manage_page (app_partner)
+// 대응 MDS: apps/mds/docs/public/specs/verification_manage_page/
+//
+// 출력: docs/infra/mds-emulator-render/verification_manage_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<VerificationManagePageBuilder>(
+  screen: 'verification_manage_page',
+  mdsSpec: 'apps/mds/docs/public/specs/verification_manage_page/',
+  builder: VerificationManagePageBuilder.new,
+  states: [
+    // Loading — MinglitAsyncValueWidget 로딩 스피너
+    MdsState(
+      'state-loading',
+      (b) => b.loading(),
+      mdsIndex: 1,
+      infiniteAnimation: true,
+    ),
+    // Active empty — "생성된 인증이 없습니다" empty state
+    MdsState('state-active-empty', (b) => b.withActiveEmpty(), mdsIndex: 2),
+    // Active with items — 인증 목록 2개
+    MdsState(
+      'state-active-with-items',
+      (b) => b.withActiveItems(),
+      mdsIndex: 3,
+    ),
+    // Archived with items — 보관됨 탭
+    MdsState(
+      'state-archived-with-items',
+      (b) => b.withArchivedItems(),
+      mdsIndex: 4,
+    ),
+    // Dark variant
+    MdsState('state-dark', (b) => b.withActiveItems().dark()),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);

--- a/apps/app_partner/test_driver/mds_emulator_render_driver.dart
+++ b/apps/app_partner/test_driver/mds_emulator_render_driver.dart
@@ -1,0 +1,77 @@
+// mds-emulator-render driver
+//
+// `integration_test/mds-emulator-render/<screen>/<screen>_test.dart` 의
+// `binding.takeScreenshot('<screen>__<state>')` 호출을 받아
+// `docs/infra/mds-emulator-render/<screen>/<state>.png` 에 저장.
+//
+// 이름 컨벤션 `<screen>__<state>` 사용 이유: Android 가 takeScreenshot 의
+// args 파라미터 미지원 (`_callback_io.dart`: 'args == null' assertion).
+//
+// MDS 의 `apps/mds/docs/public/specs/<screen>/state_*.png` 와 1:1 비교 대상.
+//
+// 출력 경로 가정:
+//   - flutter drive 의 cwd 는 `apps/app_partner/` (`flutter drive` 실행 위치).
+//   - `../../` 로 minglit 루트, 거기서 `docs/infra/mds-emulator-render/` 로 저장.
+//   - 다른 cwd 에서 호출 시 misroute 가능 — `pwd` 확인 필수.
+//
+// 실행:
+//   cd apps/app_partner                            # ← 필수
+//   flutter drive \
+//     --driver=test_driver/mds_emulator_render_driver.dart \
+//     --target=integration_test/mds-emulator-render/<screen>/<screen>_test.dart \
+//     --flavor dev \
+//     --dart-define-from-file=../../minglit_env/dev/flutter.env \
+//     -d <device>
+
+import 'dart:io';
+
+import 'package:integration_test/integration_test_driver_extended.dart';
+
+const _outputRoot = '../../docs/infra/mds-emulator-render';
+
+/// 같은 (screen, state) 쌍이 한 run 안에서 중복 캡처되면 경고.
+/// (테스트 코드 author 실수 감지 — 같은 이름 두 번 testWidgets 등.)
+final Set<String> _seenNames = <String>{};
+
+void _logErr(String msg) {
+  stderr.writeln('[mds-emulator-render] $msg');
+}
+
+Future<void> main() => integrationDriver(
+  onScreenshot:
+      (
+        String name,
+        List<int> bytes, [
+        Map<String, Object?>? args,
+      ]) async {
+        try {
+          // name 컨벤션: <screen>__<state> (double underscore separator)
+          final parts = name.split('__');
+          if (parts.length != 2 || parts.any((p) => p.isEmpty)) {
+            _logErr(
+              'invalid name "$name" — expected "<screen>__<state>" format. skipped.',
+            );
+            return false;
+          }
+          final screen = parts[0];
+          final stateName = parts[1];
+          final outputPath = '$_outputRoot/$screen/$stateName.png';
+
+          if (!_seenNames.add(name)) {
+            _logErr('duplicate capture name "$name" — overwriting $outputPath');
+          }
+
+          final file = File(outputPath);
+          await file.create(recursive: true);
+          await file.writeAsBytes(bytes);
+
+          stderr.writeln(
+            '[mds-emulator-render] saved → $outputPath (${bytes.length} bytes)',
+          );
+          return true;
+        } catch (e, st) {
+          _logErr('failed to save "$name": $e\n$st');
+          return false;
+        }
+      },
+);

--- a/scripts/mds_render_coverage.dart
+++ b/scripts/mds_render_coverage.dart
@@ -4,6 +4,7 @@
 // 파일시스템만 스캔 (Flutter SDK / dart import 의존 없음):
 //   - MDS spec: apps/mds/docs/public/specs/<screen>/state_*.png
 //   - Cataloged: apps/app_user/integration_test/mds-emulator-render/<screen>/
+//              + apps/app_partner/integration_test/mds-emulator-render/<screen>/
 //   - Captured: docs/infra/mds-emulator-render/<screen>/state-*.png
 //
 // 사용:
@@ -22,8 +23,10 @@ import 'dart:convert';
 import 'dart:io';
 
 const _mdsSpecsRoot = 'apps/mds/docs/public/specs';
-const _catalogRoot =
-    'apps/app_user/integration_test/mds-emulator-render';
+const _catalogRoots = [
+  'apps/app_user/integration_test/mds-emulator-render',
+  'apps/app_partner/integration_test/mds-emulator-render',
+];
 const _renderRoot = 'docs/infra/mds-emulator-render';
 
 void main(List<String> args) {
@@ -36,9 +39,16 @@ void main(List<String> args) {
         .where((d) => !d.startsWith('_'))
         .where((d) => _countPngs('$_mdsSpecsRoot/$d', 'state_') > 0)
         .toList();
-    final cataloged = _listDirs(_catalogRoot)
-        .where((d) => !d.startsWith('_')) // _engine, _mocks 등 제외
-        .toList();
+    // app_user + app_partner catalog 병합 (union). 같은 화면이 두 앱에 있어도
+    // 한 번만 카운트. _engine, _mocks 등 internal 디렉토리 제외.
+    final cataloged = _catalogRoots
+        .expand(
+          (root) =>
+              _listDirs(root).where((d) => !d.startsWith('_')),
+        )
+        .toSet()
+        .toList()
+      ..sort();
 
     final uncovered = mdsScreens.where((s) => !cataloged.contains(s)).toList();
     final orphan = cataloged.where((c) => !mdsScreens.contains(c)).toList();


### PR DESCRIPTION
Scheduler: swe-sonnet-1

## 개요

PR #2662 (app_partner mds-emulator-render 인프라) 에 이어, account 카테고리 3개 화면을 추가 등록합니다.

Refs #2587

## 추가된 catalog

| 화면 | states | 주요 구현 |
|------|--------|-----------|
| `bank_account_page` | loading · no-account · with-account · dark | `_FakeSettlementRepository implements SettlementRepository` |
| `create_verification_page` | empty · with-fields · dark | `_FakeCreateVerificationController` (pure local state) |
| `verification_manage_page` | loading · active-empty · active-with-items · archived-with-items · dark | `_FakeVerificationManageController` + `_NoOpVerificationCoordinator` |

## 검증

- `flutter analyze integration_test/mds-emulator-render/` → No issues found
- `dart format` 적용

## 의존성

본 PR 은 PR #2662 (app_partner mds-emulator-render 인프라) 를 기반으로 합니다.
PR #2662 머지 후 base 가 dev 와 일치하면 diff 가 자동 줄어듭니다.

## 잔여 미커버 account 화면

- `identity_verification_screen` (minglit_kit) — iamport 외부 서비스 의존, 별도 분석 필요