### PR TITLE
fix(test): refund_policy_v2 — ensureVisible off-screen 예매 취소 버튼

### DIFF
--- a/apps/app_user/integration_test/cuj/event/refund_policy_v2_test.dart
+++ b/apps/app_user/integration_test/cuj/event/refund_policy_v2_test.dart
@@ -176,7 +176,11 @@ void main() {
       body: (t) async {
         await t.pumpAndSettle();
 
-        // 예매 취소 버튼 탭
+        // Fix #2589 dev-blocker: PurchaseHistoryDetailPage SingleChildScroll
+        // View 가 viewport(866px)보다 커서 예매 취소 버튼이 off-screen
+        // → tap miss (Offset Y=908 > 866). ensureVisible로 스크롤 후 탭.
+        await t.ensureVisible(find.widgetWithText(ElevatedButton, '예매 취소'));
+        await t.pump();
         await t.tap(find.widgetWithText(ElevatedButton, '예매 취소'));
         await t.pumpAndSettle();
 
@@ -236,6 +240,9 @@ void main() {
       body: (t) async {
         await t.pumpAndSettle();
 
+        // Fix #2589 dev-blocker: 예매 취소 버튼 off-screen → ensureVisible 후 탭.
+        await t.ensureVisible(find.widgetWithText(ElevatedButton, '예매 취소'));
+        await t.pump();
         await t.tap(find.widgetWithText(ElevatedButton, '예매 취소'));
         await t.pumpAndSettle();
 
@@ -338,6 +345,9 @@ void main() {
       body: (t) async {
         await t.pumpAndSettle();
 
+        // Fix #2589 dev-blocker: 예매 취소 버튼 off-screen → ensureVisible 후 탭.
+        await t.ensureVisible(find.widgetWithText(ElevatedButton, '예매 취소'));
+        await t.pump();
         await t.tap(find.widgetWithText(ElevatedButton, '예매 취소'));
         await t.pumpAndSettle();
 


### PR DESCRIPTION
Scheduler: swe-opus-1

Refs #2589 (parent cuj-coverage tracking).

## 문제

`cuj-integration-user` 가 dev 머지 후 3 케이스 실패. 11+ APPROVED PR 의 머지 게이트.

실패 케이스:
- [1-1] 결제 확인 다이얼로그 → 취소하기 → cancelOrder 호출
- [1-2] 예매 취소 탭 → 다이얼로그 → 아니오 → 상태 유지
- [5-2] 무료 취소 확인 다이얼로그 → 취소하기 → cancelOrder 호출

## 근본 원인

- `PurchaseHistoryDetailPage` 의 `SingleChildScrollView` 가 viewport(866px) 보다 큰 컨텐츠를 가짐
- `예매 취소` `ElevatedButton` 이 `Offset(205.7, 908.5)` 에 layout → **off-screen** (Y=908.5 > 866.3)
- `t.tap()` 이 hit miss → "could not find any matching widgets" / `verify` 실패

## 수정

3개 `cujCase` 의 `예매 취소` 버튼 탭 전에 `t.ensureVisible()` 추가.

```dart
await t.ensureVisible(find.widgetWithText(ElevatedButton, '예매 취소'));
await t.pump();
await t.tap(find.widgetWithText(ElevatedButton, '예매 취소'));
```

CUJ 2-2/2-3 (signup_consent) fix 와 동일 패턴.

## 검증

- `dart analyze`: 통과 (0 issues)
- 동일 패턴 fix (PR #2664) 가 signup_consent off-screen tap 문제를 해결한 전례

## 영향

이 PR 머지 후 `cuj-integration-user` 가 통과 → 다음 PR 들이 update-branch + auto-merge:
- #2664 (consent CUJ pumpsettle), #2596, #2575, #2618, #2617, #2616, #2612, #2662, #2663, #2665, #2667