### PR TITLE
fix(ci): supabase_functions filter — drop '!' negation (broken in paths-filter@v4) — Fix #2669

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -202,10 +202,16 @@ jobs:
           supabase_tests:
             - 'supabase/tests/**'
           # EF 소스 + deno config — deno-ef / ef-integration 트리거
-          # BLUEDOC.md / *.md 는 제외 (pure 문서, 동작 영향 0)
+          # NOTE: dorny/paths-filter@v4 의 '!' negation 은 .some() OR 평가로 인해
+          # filter 의도와 반대로 동작 (Fix #2669). negation 대신 explicit positive
+          # patterns 로 .ts/.json/.npmrc 만 매치 → BLUEDOC.md / *.md 는 자연스레 제외.
           supabase_functions:
-            - 'supabase/functions/**'
-            - '!supabase/functions/**/*.md'
+            - 'supabase/functions/**/*.ts'
+            - 'supabase/functions/**/*.tsx'
+            - 'supabase/functions/**/*.js'
+            - 'supabase/functions/**/*.mjs'
+            - 'supabase/functions/**/*.json'
+            - 'supabase/functions/**/.npmrc'
             - 'supabase/deno.json'
 
   # App CI (User + Partner)


### PR DESCRIPTION
Scheduler: swe-opus-1

Closes #2669

## Summary

\`dorny/paths-filter@v4\` 의 \`!\` negation 은 \`.some()\` OR 평가 + picomatch \`!pattern\` 의 positive-negation 시맨틱 때문에 의도와 반대 작동.

PR #2595 (\`538619a02\`) 가 추가한:
\`\`\`yaml
supabase_functions:
  - 'supabase/functions/**'
  - '!supabase/functions/**/*.md'   # ← 의도와 반대 동작
  - 'supabase/deno.json'
\`\`\`

→ \`supabase/functions/\` **밖**의 거의 모든 파일이 \`supabase_functions=true\` 매치 → 거의 모든 PR 이 self-hosted \`test-deno-ef\` + \`test-ef-integration\` 트리거 → 36h+ runner queue backlog.

## Fix

Negation 제거 + explicit positive patterns 로 \`.ts/.tsx/.js/.mjs/.json/.npmrc\` 만 매치:

\`\`\`yaml
supabase_functions:
  - 'supabase/functions/**/*.ts'
  - 'supabase/functions/**/*.tsx'
  - 'supabase/functions/**/*.js'
  - 'supabase/functions/**/*.mjs'
  - 'supabase/functions/**/*.json'
  - 'supabase/functions/**/.npmrc'
  - 'supabase/deno.json'
\`\`\`

## 커버리지 검증

\`supabase/functions/\` 의 실제 파일 분포:
- 236 \`.ts\` — 매치
- 60 \`.json\` — 매치
- 1 \`.npmrc\` — 매치
- 3 \`.jpg\` (test fixture, EF 런타임 동작 영향 0) — 제외 OK
- \`BLUEDOC.md\` / \`*.md\` — 제외 ✅ (원래 의도대로)

→ EF 트리거가 필요한 모든 source 파일 커버, BLUEDOC 만 깔끔히 제외.

## 회귀 안전망

- PR #2595 가 도입한 split (\`supabase_db_stack\` / \`supabase_ef_stack\`) 유지
- 다른 필터 (\`supabase_migrations\`, \`supabase_tests\`, \`supabase\`) 변경 없음
- \`!\` negation 사용처 0 — paths-filter@v4 의 broken 동작 의존 X

## 영향

이 PR merge 후:
- \`apps/**\` only PR → \`supabase_functions=false\` → \`test-deno-ef\` + \`test-ef-integration\` skip
- self-hosted runner 큐 정상화 → 12+ APPROVED PR 들 자동 merge 가능

## Test plan

- [x] YAML 문법 검증 (\`python3 -c "import yaml; yaml.safe_load(open(...))"\`)
- [x] supabase/functions/ 파일 분포 검증 (\`find ... | sed 's|.*\\.||' | sort -u\`)
- [ ] 이 PR 자체 CI: \`.github/workflows/**\` 변경이라 \`check-workflow-yaml\` 트리거 — pr-gate 통과 확인
- [ ] merge 후 다음 PR (예: app_user only) 가 \`changes\` job 로그에 \`supabase_functions=false\` 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)