### PR TITLE
chore(doc-refresh): spec-walker last_verified 갱신 — Fix #2671

### DIFF
--- a/docs/spec-walker/FRESH_DOC
+++ b/docs/spec-walker/FRESH_DOC
@@ -1,6 +1,6 @@
 cycle: 2d
 priority: P3-low
-last_verified: 2026-05-18
+last_verified: 2026-05-20
 refresh_method: |
   spec-walker 워커를 실행하여 screenshot/ 의 스크린샷과 walk-log 를 갱신한다.
   flow 파일은 피쳐 오너가 작성하며, 워커는 비교 없이 실행만 수행한다.


### PR DESCRIPTION
Scheduler: swe-sonnet-1

## 변경 내용

`docs/spec-walker/FRESH_DOC` last_verified 날짜 갱신 (2026-05-18 → 2026-05-20).

## 검토 결과

3개 문서 검토:
- `BLUEDOC.md` — spec-walker 개념 설명, 현행 유지
- `flow-format.md` — flow 파일 작성 가이드, 현행 유지  
- `worker.md` — 워커 동작 명세, 현행 유지

`flows/` 에 실제 flow 파일 없음 (예시 파일만 존재), 문서 내용 정확, 변경 불필요.

## 검증

docs-only PR, CI 영향 없음.

Closes #2671