### PR TITLE
fix(test): refund_policy_v2 [1-1] [5-2] — SnackBar Timer drain

### DIFF
--- a/apps/app_user/integration_test/cuj/event/refund_policy_v2_test.dart
+++ b/apps/app_user/integration_test/cuj/event/refund_policy_v2_test.dart
@@ -198,6 +198,15 @@ void main() {
             reason: any(named: 'reason'),
           ),
         ).called(1);
+
+        // Fix #2589 dev-blocker: onSuccess() 의 showMinglitSuccess SnackBar 는
+        // 3 초 후 자동 dismiss Timer 가 있다. pumpAndSettle 은 Timer 를 drain 하지
+        // 않으므로 test body 종료 후 Timer 가 발화 → flutter_test binding 의
+        // 'inTest: is not true' assertion. test 끝나기 전에 명시적으로 clear.
+        ScaffoldMessenger.of(
+          t.element(find.byType(MaterialApp)),
+        ).clearSnackBars();
+        await t.pumpAndSettle();
       },
     );
 
@@ -363,6 +372,13 @@ void main() {
             reason: any(named: 'reason'),
           ),
         ).called(1);
+
+        // Fix #2589 dev-blocker: SnackBar 3 초 자동 dismiss Timer drain
+        // (1-1 happy 동일 패턴 참고).
+        ScaffoldMessenger.of(
+          t.element(find.byType(MaterialApp)),
+        ).clearSnackBars();
+        await t.pumpAndSettle();
       },
     );
 


### PR DESCRIPTION
Scheduler: swe-opus-1

Refs #2589 (parent cuj-coverage tracking).

## 문제

#2668 머지로 `예매 취소` 버튼 ensureVisible fix 가 적용된 후, cancelOrder flow 가 정상 진행되어 다음 stage 의 실패가 노출됨:

```
❌ [1-1] grace period(3시간) 내 자동 환불 happy:
   결제 확인 다이얼로그 → 취소하기 → cancelOrder 호출 (failed)
'package:flutter_test/src/binding.dart': Failed assertion:
  line 2696 pos 12: 'inTest': is not true.

❌ [5-2] 무료 이벤트 취소 happy:
   무료 취소 확인 다이얼로그 → 취소하기 → cancelOrder 호출 (failed)
(same assertion)
```

## 원인

`PurchaseHistoryDetailPage._runCancel` 의 `onSuccess` 가 `cancelOrder` 후 `context.showMinglitSuccess(...)` 호출 → `MinglitFeedbackUI.buildSnackBar` 는 default `Duration(seconds: 3)` 자동 dismiss Timer 보유.

`pumpAndSettle()` 은 animation 만 settle 하고 Timer.delayed 는 drain 하지 않음 (integration_test = LiveTestBinding = 실제 wall-clock Timer). 따라서 test body 종료 직후, 3 초 후 Timer 가 발화 → SnackBar dismiss 시도 → test binding 의 \`inTest: true\` assertion 실패.

## 수정

\`verify(...)\` 직후 ScaffoldMessenger 로 pending SnackBar 명시적 clear:

\`\`\`dart
ScaffoldMessenger.of(
  t.element(find.byType(MaterialApp)),
).clearSnackBars();
await t.pumpAndSettle();
\`\`\`

- \`MaterialApp\` 은 cuj_test.dart scaffold 의 root → 항상 존재.
- \`clearSnackBars()\` 은 SnackBar Timer 까지 cancel.
- \`pumpAndSettle()\` 은 dismiss animation drain.

다른 test ([1-1] edge, [1-2] happy, [1-3] happy, [5-2] edge) 는 \`cancelOrder\` 호출 없어 SnackBar 미발생 → 영향 없음.

## 영향

\`cuj-integration-user\` 다시 통과 → 11+ APPROVED PR (#2664, #2596, #2575, #2618, #2617, #2616, #2612, #2662, #2663, #2665, #2667) 의 머지 게이트 해소.