### PR TITLE
test(cuj): event-now-bar CUJ 2-2, 2-3 — Refs #2589

### DIFF
--- a/apps/app_user/integration_test/cuj/BLUEDOC.md
+++ b/apps/app_user/integration_test/cuj/BLUEDOC.md
@@ -164,4 +164,4 @@ flutter test integration_test/cuj/ \
 - 시각 회귀: [`mds-emulator-render/BLUEDOC.md`](../mds-emulator-render/BLUEDOC.md)
 
 ---
-_Reviewed: 2026-05-21 03:00_
+_Reviewed: 2026-05-21 06:00_

--- a/apps/app_user/integration_test/cuj/event-operation/event_now_bar_test.dart
+++ b/apps/app_user/integration_test/cuj/event-operation/event_now_bar_test.dart
@@ -4,7 +4,7 @@
 // CUJ 추가 시 본 파일에 `cujGroup` 블록 추가 (새 파일 X).
 //
 // Fix #2564: event-operation 카테고리 CUJ integration test 전무 해소 (event-now-bar)
-// Refs #2589: 추가 CUJ 커버 (1-2 ~ 2-1)
+// Refs #2589: 추가 CUJ 커버 (1-2 ~ 2-1, 2-2, 2-3)
 
 import 'dart:async';
 
@@ -465,6 +465,161 @@ void main() {
         await t.pumpAndSettle();
 
         expect(find.text('3'), findsOneWidget);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 2-2: 드롭다운 탭 → 이벤트 목록 시트 (FR-15)
+  // ---------------------------------------------------------------------------
+
+  cujGroup('2-2', '드롭다운 탭 → 이벤트 목록 시트 오픈', () {
+    final e1 = _makeActiveEvent();
+    final e2 = _makeActiveEvent2();
+
+    cujCase(
+      'happy: 멀티 이벤트에서 드롭다운 탭 → 시트 헤더 노출',
+      app: Scaffold(
+        body: EventNowMultiStack(events: [e1, e2]),
+      ),
+      overrides: () => [
+        eventNowBarStateProvider(e1).overrideWith(
+          () => _FakeEventNowBarStateNotifier(EventNowBarState.waiting),
+        ),
+        eventNowBarStateProvider(e2).overrideWith(
+          () => _FakeEventNowBarStateNotifier(EventNowBarState.waiting),
+        ),
+        eventRealtimeProvider(e1.event.id).overrideWith(
+          _FakeEventRealtime.new,
+        ),
+        eventRealtimeProvider(e2.event.id).overrideWith(
+          _FakeEventRealtime.new,
+        ),
+      ],
+      body: (t) async {
+        await t.pump();
+        await t.pumpAndSettle();
+
+        // 초기 상태: 시트는 닫혀 있음
+        expect(find.text('진행 중인 이벤트'), findsNothing);
+
+        // 드롭다운 아이콘 탭 → modal bottom sheet 오픈
+        await t.tap(find.byIcon(Icons.expand_more));
+        await t.pumpAndSettle();
+
+        // 시트 헤더 노출
+        expect(find.text('진행 중인 이벤트'), findsOneWidget);
+      },
+    );
+
+    cujCase(
+      'edge: 시트에서 다른 이벤트 선택 → 시트 닫힘',
+      app: Scaffold(
+        body: EventNowMultiStack(events: [e1, e2]),
+      ),
+      overrides: () => [
+        eventNowBarStateProvider(e1).overrideWith(
+          () => _FakeEventNowBarStateNotifier(EventNowBarState.waiting),
+        ),
+        eventNowBarStateProvider(e2).overrideWith(
+          () => _FakeEventNowBarStateNotifier(EventNowBarState.waiting),
+        ),
+        eventRealtimeProvider(e1.event.id).overrideWith(
+          _FakeEventRealtime.new,
+        ),
+        eventRealtimeProvider(e2.event.id).overrideWith(
+          _FakeEventRealtime.new,
+        ),
+      ],
+      body: (t) async {
+        await t.pump();
+        await t.pumpAndSettle();
+
+        // 시트 오픈
+        await t.tap(find.byIcon(Icons.expand_more));
+        await t.pumpAndSettle();
+        expect(find.text('진행 중인 이벤트'), findsOneWidget);
+
+        // 첫 번째 tile 선택 → 시트 닫힘 (onSelect 가 Navigator.pop 호출)
+        // _EventListTile 의 InkWell 중 하나를 탭 (시트 안의 첫 tile)
+        final tileFinder = find.descendant(
+          of: find.byType(BottomSheet),
+          matching: find.byType(InkWell),
+        );
+        expect(tileFinder, findsWidgets);
+        await t.tap(tileFinder.first);
+        await t.pumpAndSettle();
+
+        // 시트 닫힘 → 헤더 사라짐
+        expect(find.text('진행 중인 이벤트'), findsNothing);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 2-3: 한 이벤트 종료 → 자동으로 다음 이벤트 상단 (FR-14, FR-16)
+  // ---------------------------------------------------------------------------
+
+  cujGroup('2-3', '한 이벤트 종료 → 다음 활성 이벤트가 상단', () {
+    final e1 = _makeActiveEvent();
+    final e2 = _makeActiveEvent2();
+
+    cujCase(
+      'happy: ENDED + WAITING 혼합 → 바는 WAITING 이벤트 상태 표시',
+      app: Scaffold(
+        body: EventNowMultiStack(events: [e1, e2]),
+      ),
+      overrides: () => [
+        // e1 = ENDED (priority 2 → 하단), e2 = WAITING (priority 1 → 상단)
+        eventNowBarStateProvider(e1).overrideWith(
+          () => _FakeEventNowBarStateNotifier(EventNowBarState.ended),
+        ),
+        eventNowBarStateProvider(e2).overrideWith(
+          () => _FakeEventNowBarStateNotifier(EventNowBarState.waiting),
+        ),
+        eventRealtimeProvider(e1.event.id).overrideWith(
+          _FakeEventRealtime.new,
+        ),
+        eventRealtimeProvider(e2.event.id).overrideWith(
+          _FakeEventRealtime.new,
+        ),
+      ],
+      body: (t) async {
+        await t.pump();
+        await t.pumpAndSettle();
+
+        // sortActiveEvents 가 ENDED 를 하단, WAITING 을 상단 → 바는 WAITING
+        // 의 status text '곧 시작' 표시 (단일 instance — 바는 1 개)
+        expect(find.text('곧 시작'), findsOneWidget);
+      },
+    );
+
+    cujCase(
+      'edge: ACTIVE (CHECK_IN_READY, priority 0) + WAITING → 바는 ACTIVE 표시',
+      app: Scaffold(
+        body: EventNowMultiStack(events: [e1, e2]),
+      ),
+      overrides: () => [
+        // e1 = WAITING (priority 1), e2 = CHECK_IN_READY (priority 0 → 최상위)
+        eventNowBarStateProvider(e1).overrideWith(
+          () => _FakeEventNowBarStateNotifier(EventNowBarState.waiting),
+        ),
+        eventNowBarStateProvider(e2).overrideWith(
+          () => _FakeEventNowBarStateNotifier(EventNowBarState.checkInReady),
+        ),
+        eventRealtimeProvider(e1.event.id).overrideWith(
+          _FakeEventRealtime.new,
+        ),
+        eventRealtimeProvider(e2.event.id).overrideWith(
+          _FakeEventRealtime.new,
+        ),
+      ],
+      body: (t) async {
+        await t.pump();
+        await t.pumpAndSettle();
+
+        // CHECK_IN_READY 가 priority 0 으로 상단 → 바는 '체크인하세요' 표시
+        expect(find.text('체크인하세요'), findsOneWidget);
       },
     );
   });

--- a/apps/app_user/integration_test/cuj/event-operation/event_now_bar_test.dart
+++ b/apps/app_user/integration_test/cuj/event-operation/event_now_bar_test.dart
@@ -41,10 +41,10 @@ class _FakeEventRealtime extends EventRealtime {
 // Helpers
 // ---------------------------------------------------------------------------
 
-Event _makeEvent({String id = 'evt-1'}) => Event(
+Event _makeEvent({String id = 'evt-1', String title = 'Test Event'}) => Event(
   id: id,
   partyId: 'party-1',
-  title: 'Test Event',
+  title: title,
   startTime: DateTime(2026, 5, 18, 18),
   endTime: DateTime(2026, 5, 18, 20),
   createdAt: DateTime(2026),
@@ -57,14 +57,50 @@ TodayActiveEvent _makeActiveEvent() => TodayActiveEvent(
 );
 
 TodayActiveEvent _makeActiveEvent2() => TodayActiveEvent(
-  event: _makeEvent(id: 'evt-2'),
+  event: _makeEvent(id: 'evt-2', title: 'Test Event 2'),
   participantStatus: 'ticket_issued',
 );
 
 TodayActiveEvent _makeActiveEvent3() => TodayActiveEvent(
-  event: _makeEvent(id: 'evt-3'),
+  event: _makeEvent(id: 'evt-3', title: 'Test Event 3'),
   participantStatus: 'ticket_issued',
 );
+
+/// Test harness that wraps [EventNowMultiStack] with an `onEventTap`
+/// callback that records the last tapped event for assertions.
+///
+/// Captures into a static so CUJ tests (which pass `app:` as a const-ish
+/// widget) can verify the callback fired with the expected event without
+/// plumbing closures through the cuj engine API.
+class _OnEventTapHarness extends StatefulWidget {
+  const _OnEventTapHarness({required this.events});
+
+  final List<TodayActiveEvent> events;
+
+  static TodayActiveEvent? lastTapped;
+
+  @override
+  State<_OnEventTapHarness> createState() => _OnEventTapHarnessState();
+}
+
+class _OnEventTapHarnessState extends State<_OnEventTapHarness> {
+  @override
+  void initState() {
+    super.initState();
+    // Reset between cujCases to avoid cross-test contamination.
+    _OnEventTapHarness.lastTapped = null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: EventNowMultiStack(
+        events: widget.events,
+        onEventTap: (event) => _OnEventTapHarness.lastTapped = event,
+      ),
+    );
+  }
+}
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -512,11 +548,13 @@ void main() {
       },
     );
 
+    // Initial _selectedIndex = 0 → first tile is already selected (e1).
+    // To verify CUJ 2-2 / FR-15 (선택한 이벤트로 전환) we must tap the
+    // *second* tile (e2) and assert both the onEventTap callback receives e2
+    // AND the bar re-renders with e2's distinct title.
     cujCase(
-      'edge: 시트에서 다른 이벤트 선택 → 시트 닫힘',
-      app: Scaffold(
-        body: EventNowMultiStack(events: [e1, e2]),
-      ),
+      'edge: 시트에서 다른 이벤트(e2) 선택 → 시트 닫힘 + 바가 e2로 전환',
+      app: _OnEventTapHarness(events: [e1, e2]),
       overrides: () => [
         eventNowBarStateProvider(e1).overrideWith(
           () => _FakeEventNowBarStateNotifier(EventNowBarState.waiting),
@@ -535,23 +573,37 @@ void main() {
         await t.pump();
         await t.pumpAndSettle();
 
+        // 초기 바: e1 (선택 인덱스 0) → 'Test Event' 표시, e2 title 부재
+        expect(find.text('Test Event'), findsOneWidget);
+        expect(find.text('Test Event 2'), findsNothing);
+
         // 시트 오픈
         await t.tap(find.byIcon(Icons.expand_more));
         await t.pumpAndSettle();
         expect(find.text('진행 중인 이벤트'), findsOneWidget);
 
-        // 첫 번째 tile 선택 → 시트 닫힘 (onSelect 가 Navigator.pop 호출)
-        // _EventListTile 의 InkWell 중 하나를 탭 (시트 안의 첫 tile)
+        // 시트 안 두 번째 tile (e2) 탭 — 실제 "다른 이벤트" 선택
         final tileFinder = find.descendant(
           of: find.byType(BottomSheet),
           matching: find.byType(InkWell),
         );
-        expect(tileFinder, findsWidgets);
-        await t.tap(tileFinder.first);
+        expect(tileFinder, findsNWidgets(2));
+        await t.tap(tileFinder.at(1));
         await t.pumpAndSettle();
 
-        // 시트 닫힘 → 헤더 사라짐
+        // 1) 시트 닫힘 → 헤더 사라짐
         expect(find.text('진행 중인 이벤트'), findsNothing);
+
+        // 2) onEventTap 콜백이 e2 를 받았는지 확인 (식별자로 검증)
+        final tapped = _OnEventTapHarness.lastTapped;
+        expect(tapped, isNotNull);
+        expect(tapped!.event.id, 'evt-2');
+
+        // 3) 바가 실제로 e2 로 전환되어 'Test Event 2' 타이틀 표시 — e1
+        //    title 은 사라짐. selectedIndex 가 갱신되지 않거나 잘못된
+        //    인덱스로 갱신되는 회귀(예: 항상 .first 탭) 를 막는 핵심 assert.
+        expect(find.text('Test Event 2'), findsOneWidget);
+        expect(find.text('Test Event'), findsNothing);
       },
     );
   });


### PR DESCRIPTION
Scheduler: swe-opus-1

## Summary

event-operation/event-now-bar 의 testable uncovered CUJ 2건 추가.

- **CUJ 2-2**: 드롭다운 탭 → 이벤트 목록 시트 오픈 (FR-15)
- **CUJ 2-3**: 한 이벤트 종료 → 다음 활성 이벤트가 상단 (FR-14, FR-16)

## 변경

| 파일 | 변경 |
|------|------|
| `apps/app_user/integration_test/cuj/event-operation/event_now_bar_test.dart` | cujGroup 2-2 (happy + edge), 2-3 (happy + edge) 4 케이스 추가 |
| `apps/app_user/integration_test/cuj/BLUEDOC.md` | _Reviewed timestamp bump |

## 커버리지

| 항목 | Before | After |
|------|--------|-------|
| event-now-bar | 10/14 | 12/14 |
| 전체 CUJ | 138/276 (50.0%) | 140/276 (50.7%) |

미커버 잔류 (3-1 백그라운드 복귀, 3-3 앱 킬 재시작) 는 appLifecycle / process restart 의존으로 현재 integration test 프레임워크 범위 밖.

## 검증

- dart analyze: No issues found
- dart run scripts/cuj_coverage.dart: event-now-bar 12/14 확인
- Local emulator 실행 불가 → pr-gate cuj-integration-user CI 에 위임

## Spec 인용

- docs/features/event-operation/event-now-bar/spec.md CUJ 2-2 / 2-3
  - FR-14, FR-15, FR-16 의 멀티 이벤트 정렬 + 시트 오픈 동작
- 구현 참조: apps/app_user/lib/src/features/home/widgets/event_now_multi_stack.dart
  - sortActiveEvents priority (active 0 > waiting 1 > ended 2)
  - _showEventListSheet (Icons.expand_more 탭)

Refs #2589