### PR TITLE
feat(mds-render): event_bottom_ticket_bar render catalog 등록 — Refs #2588

### DIFF
--- a/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
@@ -66,4 +66,4 @@ MDS spec 디렉토리명과 동일 (per-screen, snake_case). 화면당 `builder.
 - [상위 BLUEDOC](../BLUEDOC.md) · 페어 워크플로우: `sync-mds-mockups.yml` (디자인 PNG)
 
 ---
-_Reviewed: 2026-05-21 06:00_
+_Reviewed: 2026-05-21 07:00_

--- a/apps/app_user/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_registry.dart
@@ -8,6 +8,8 @@ import '_engine/builder.dart';
 import '_engine/catalog.dart';
 import 'account_management_page/account_management_page_test.dart'
     as account_management_page;
+import 'event_bottom_ticket_bar/event_bottom_ticket_bar_test.dart'
+    as event_bottom_ticket_bar;
 import 'auth_callback_page/auth_callback_page_test.dart' as auth_callback_page;
 import 'blocked_partners_page/blocked_partners_page_test.dart'
     as blocked_partners_page;
@@ -44,6 +46,7 @@ final List<MdsCatalog<MdsScreenBuilder<dynamic>>> allCatalogs = [
   deletion_info_page.catalogWithReason,
   deletion_reason_page.catalog,
   deletion_verify_page.catalog,
+  event_bottom_ticket_bar.catalog,
   event_now_bar.catalog,
   event_ongoing_banner.catalog,
   home_page.catalog,

--- a/apps/app_user/integration_test/mds-emulator-render/event_bottom_ticket_bar/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/event_bottom_ticket_bar/builder.dart
@@ -72,8 +72,7 @@ final _renderEvent = Event(
 // Builder
 // ---------------------------------------------------------------------------
 
-class EventBottomTicketBarBuilder
-    extends MdsScreenBuilder<Scaffold> {
+class EventBottomTicketBarBuilder extends MdsScreenBuilder<Scaffold> {
   EventBottomTicketBarBuilder()
     : super(
         page: Scaffold(
@@ -93,66 +92,66 @@ class EventBottomTicketBarBuilder
 
   /// CUJ 메인 — 구매 가능 상태 ("참가 신청하기").
   void eligible() => _applyAdmission(
-        AdmissionState(status: EventAdmissionStatus.eligible),
-      );
+    AdmissionState(status: EventAdmissionStatus.eligible),
+  );
 
   /// 비로그인 상태 ("로그인하고 신청하기").
   void guest() => _applyAdmission(
-        AdmissionState(status: EventAdmissionStatus.guest),
-      );
+    AdmissionState(status: EventAdmissionStatus.guest),
+  );
 
   /// 본인인증 필요 상태 ("본인인증 후 신청하기").
   void identityRequired() => _applyAdmission(
-        AdmissionState(status: EventAdmissionStatus.identityRequired),
-      );
+    AdmissionState(status: EventAdmissionStatus.identityRequired),
+  );
 
   /// 파트너 심사 필요 상태 ("신청하기").
   void qualificationRequired() => _applyAdmission(
-        AdmissionState(status: EventAdmissionStatus.qualificationRequired),
-      );
+    AdmissionState(status: EventAdmissionStatus.qualificationRequired),
+  );
 
   /// 참여 조건 미달 상태 ("성별 조건이 맞지 않습니다.").
   void notEligible() => _applyAdmission(
-        AdmissionState(
-          status: EventAdmissionStatus.notEligible,
-          ineligibleReason: '성별 조건이 맞지 않습니다.',
-        ),
-      );
+    AdmissionState(
+      status: EventAdmissionStatus.notEligible,
+      ineligibleReason: '성별 조건이 맞지 않습니다.',
+    ),
+  );
 
   /// 정원 마감 / 매진 상태 ("마감된 이벤트").
   void soldOut() => _applyAdmission(
-        AdmissionState(status: EventAdmissionStatus.fullOrSoldOut),
-      );
+    AdmissionState(status: EventAdmissionStatus.fullOrSoldOut),
+  );
 
   /// 결제 미완료 — 이어하기 상태 ("결제 계속하기").
   void pendingPayment() => _applyAdmission(
-        AdmissionState(status: EventAdmissionStatus.pendingPayment),
-      );
+    AdmissionState(status: EventAdmissionStatus.pendingPayment),
+  );
 
   /// 이미 신청 완료 상태 ("이미 신청한 이벤트").
   void applied() => _applyAdmission(
-        AdmissionState(status: EventAdmissionStatus.applied),
-      );
+    AdmissionState(status: EventAdmissionStatus.applied),
+  );
 
   /// 심사 반려 상태 — destructive 버튼.
   void rejected() => _applyAdmission(
-        AdmissionState(status: EventAdmissionStatus.rejected),
-      );
+    AdmissionState(status: EventAdmissionStatus.rejected),
+  );
 
   /// 이벤트 종료 + 미참여 상태 ("종료된 이벤트").
   void eventEnded() => _applyAdmission(
-        AdmissionState(status: EventAdmissionStatus.eventEnded),
-      );
+    AdmissionState(status: EventAdmissionStatus.eventEnded),
+  );
 
   /// 이벤트 종료 + 매칭 결과 도착 ("매칭 결과 보기").
   void eventEndedWithResults() => _applyAdmission(
-        AdmissionState(status: EventAdmissionStatus.eventEndedWithResults),
-      );
+    AdmissionState(status: EventAdmissionStatus.eventEndedWithResults),
+  );
 
   /// 이벤트 종료 + 참여 완료 ("참여 완료").
   void eventEndedParticipated() => _applyAdmission(
-        AdmissionState(status: EventAdmissionStatus.eventEndedParticipated),
-      );
+    AdmissionState(status: EventAdmissionStatus.eventEndedParticipated),
+  );
 
   /// admission 로딩 중 — 스피너 표시.
   void loading() {

--- a/apps/app_user/integration_test/mds-emulator-render/event_bottom_ticket_bar/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/event_bottom_ticket_bar/builder.dart
@@ -1,0 +1,177 @@
+// EventBottomTicketBarBuilder — event_bottom_ticket_bar 전용 fluent API.
+//
+// EventDetailPage 하단에 고정되는 admission CTA bar.
+// Scaffold bottomSheet 으로 마운트하여 실제 사용 환경을 재현한다.
+//
+// Refs #2588: mds-render-coverage event-operation 카탈로그 등록
+
+import 'dart:async';
+
+import 'package:app_user/src/features/event/admission/event_admission_controller.dart';
+import 'package:app_user/src/features/event/detail/event_bottom_ticket_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+
+// ---------------------------------------------------------------------------
+// Fake controller — no Supabase / network in render context
+// ---------------------------------------------------------------------------
+
+class _FixedAdmissionController extends EventAdmissionController {
+  _FixedAdmissionController(this._state);
+  final AdmissionState _state;
+
+  @override
+  FutureOr<AdmissionState> build(Event event) => _state;
+}
+
+// Never completes — simulates async loading state.
+class _LoadingAdmissionController extends EventAdmissionController {
+  @override
+  FutureOr<AdmissionState> build(Event event) =>
+      Completer<AdmissionState>().future;
+}
+
+// Throws immediately — simulates async error state.
+class _ErrorAdmissionController extends EventAdmissionController {
+  @override
+  FutureOr<AdmissionState> build(Event event) =>
+      throw Exception('render: forced error');
+}
+
+// ---------------------------------------------------------------------------
+// Fixed render event
+// ---------------------------------------------------------------------------
+
+final _base = DateTime(2026, 5, 18, 18);
+
+final _renderEvent = Event(
+  id: 'render-event-1',
+  partyId: 'render-party-1',
+  title: '강남 밍릿파티',
+  startTime: _base,
+  endTime: _base.add(const Duration(hours: 2)),
+  createdAt: _base,
+  updatedAt: _base,
+  tickets: [
+    Ticket(
+      id: 'ticket-1',
+      eventId: 'render-event-1',
+      name: '일반 입장권',
+      price: 20000,
+      quantity: 100,
+      soldCount: 0,
+      createdAt: _base,
+      updatedAt: _base,
+    ),
+  ],
+);
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+class EventBottomTicketBarBuilder
+    extends MdsScreenBuilder<Scaffold> {
+  EventBottomTicketBarBuilder()
+    : super(
+        page: Scaffold(
+          body: const SizedBox.expand(),
+          bottomSheet: EventBottomTicketBar(event: _renderEvent),
+        ),
+        base: [],
+      );
+
+  void _applyAdmission(AdmissionState state) {
+    addOverride(
+      eventAdmissionControllerProvider(_renderEvent).overrideWith(
+        () => _FixedAdmissionController(state),
+      ),
+    );
+  }
+
+  /// CUJ 메인 — 구매 가능 상태 ("참가 신청하기").
+  void eligible() => _applyAdmission(
+        AdmissionState(status: EventAdmissionStatus.eligible),
+      );
+
+  /// 비로그인 상태 ("로그인하고 신청하기").
+  void guest() => _applyAdmission(
+        AdmissionState(status: EventAdmissionStatus.guest),
+      );
+
+  /// 본인인증 필요 상태 ("본인인증 후 신청하기").
+  void identityRequired() => _applyAdmission(
+        AdmissionState(status: EventAdmissionStatus.identityRequired),
+      );
+
+  /// 파트너 심사 필요 상태 ("신청하기").
+  void qualificationRequired() => _applyAdmission(
+        AdmissionState(status: EventAdmissionStatus.qualificationRequired),
+      );
+
+  /// 참여 조건 미달 상태 ("성별 조건이 맞지 않습니다.").
+  void notEligible() => _applyAdmission(
+        AdmissionState(
+          status: EventAdmissionStatus.notEligible,
+          ineligibleReason: '성별 조건이 맞지 않습니다.',
+        ),
+      );
+
+  /// 정원 마감 / 매진 상태 ("마감된 이벤트").
+  void soldOut() => _applyAdmission(
+        AdmissionState(status: EventAdmissionStatus.fullOrSoldOut),
+      );
+
+  /// 결제 미완료 — 이어하기 상태 ("결제 계속하기").
+  void pendingPayment() => _applyAdmission(
+        AdmissionState(status: EventAdmissionStatus.pendingPayment),
+      );
+
+  /// 이미 신청 완료 상태 ("이미 신청한 이벤트").
+  void applied() => _applyAdmission(
+        AdmissionState(status: EventAdmissionStatus.applied),
+      );
+
+  /// 심사 반려 상태 — destructive 버튼.
+  void rejected() => _applyAdmission(
+        AdmissionState(status: EventAdmissionStatus.rejected),
+      );
+
+  /// 이벤트 종료 + 미참여 상태 ("종료된 이벤트").
+  void eventEnded() => _applyAdmission(
+        AdmissionState(status: EventAdmissionStatus.eventEnded),
+      );
+
+  /// 이벤트 종료 + 매칭 결과 도착 ("매칭 결과 보기").
+  void eventEndedWithResults() => _applyAdmission(
+        AdmissionState(status: EventAdmissionStatus.eventEndedWithResults),
+      );
+
+  /// 이벤트 종료 + 참여 완료 ("참여 완료").
+  void eventEndedParticipated() => _applyAdmission(
+        AdmissionState(status: EventAdmissionStatus.eventEndedParticipated),
+      );
+
+  /// admission 로딩 중 — 스피너 표시.
+  void loading() {
+    addOverride(
+      eventAdmissionControllerProvider(_renderEvent).overrideWith(
+        _LoadingAdmissionController.new,
+      ),
+    );
+  }
+
+  /// admission 조회 실패 — "오류 발생" errorContainer.
+  void error() {
+    addOverride(
+      eventAdmissionControllerProvider(_renderEvent).overrideWith(
+        _ErrorAdmissionController.new,
+      ),
+    );
+  }
+
+  /// 다크 모드 토글.
+  void dark() => useDarkTheme();
+}

--- a/apps/app_user/integration_test/mds-emulator-render/event_bottom_ticket_bar/event_bottom_ticket_bar_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/event_bottom_ticket_bar/event_bottom_ticket_bar_test.dart
@@ -1,0 +1,61 @@
+// MDS screen: event_bottom_ticket_bar
+// 대응 MDS: apps/mds/docs/public/specs/event_bottom_ticket_bar/
+//
+// 출력: docs/infra/mds-emulator-render/event_bottom_ticket_bar/state-*.png
+//
+// Refs #2588: mds-render-coverage event-operation 카탈로그 등록
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<EventBottomTicketBarBuilder>(
+  screen: 'event_bottom_ticket_bar',
+  mdsSpec: 'apps/mds/docs/public/specs/event_bottom_ticket_bar/',
+  builder: EventBottomTicketBarBuilder.new,
+  states: [
+    // 12 admission states
+    MdsState('state-eligible', (b) => b..eligible(), mdsIndex: 4),
+    MdsState('state-guest', (b) => b..guest(), mdsIndex: 1),
+    MdsState('state-identity-required', (b) => b..identityRequired(), mdsIndex: 2),
+    MdsState(
+      'state-qualification-required',
+      (b) => b..qualificationRequired(),
+      mdsIndex: 3,
+    ),
+    MdsState('state-not-eligible', (b) => b..notEligible(), mdsIndex: 5),
+    MdsState('state-sold-out', (b) => b..soldOut(), mdsIndex: 6),
+    MdsState('state-pending-payment', (b) => b..pendingPayment(), mdsIndex: 7),
+    MdsState('state-applied', (b) => b..applied(), mdsIndex: 8),
+    MdsState('state-rejected', (b) => b..rejected(), mdsIndex: 9),
+    MdsState('state-event-ended', (b) => b..eventEnded(), mdsIndex: 10),
+    MdsState(
+      'state-event-ended-with-results',
+      (b) => b..eventEndedWithResults(),
+      mdsIndex: 11,
+    ),
+    MdsState(
+      'state-event-ended-participated',
+      (b) => b..eventEndedParticipated(),
+      mdsIndex: 12,
+    ),
+    // Async states
+    MdsState(
+      'state-loading',
+      (b) => b..loading(),
+      mdsIndex: 13,
+      infiniteAnimation: true,
+    ),
+    MdsState('state-error', (b) => b..error(), mdsIndex: 14),
+    // Dark mode variant (메인 케이스)
+    MdsState(
+      'state-eligible-dark',
+      (b) => b
+        ..eligible()
+        ..dark(),
+    ),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);

--- a/apps/app_user/integration_test/mds-emulator-render/event_bottom_ticket_bar/event_bottom_ticket_bar_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/event_bottom_ticket_bar/event_bottom_ticket_bar_test.dart
@@ -18,7 +18,11 @@ final catalog = MdsCatalog<EventBottomTicketBarBuilder>(
     // 12 admission states
     MdsState('state-eligible', (b) => b..eligible(), mdsIndex: 4),
     MdsState('state-guest', (b) => b..guest(), mdsIndex: 1),
-    MdsState('state-identity-required', (b) => b..identityRequired(), mdsIndex: 2),
+    MdsState(
+      'state-identity-required',
+      (b) => b..identityRequired(),
+      mdsIndex: 2,
+    ),
     MdsState(
       'state-qualification-required',
       (b) => b..qualificationRequired(),

--- a/apps/app_user/lib/src/features/event/detail/event_bottom_ticket_bar.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_bottom_ticket_bar.dart
@@ -1,7 +1,12 @@
-part of 'event_detail_page.dart';
+// Refs #2588: extracted from part-of to public for mds-render catalog
+import 'package:app_user/src/features/event/admission/event_admission_controller.dart';
+import 'package:app_user/src/logic/event_coordinator.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:minglit_kit/minglit_kit.dart';
 
-class _BottomTicketBar extends ConsumerWidget {
-  const _BottomTicketBar({required this.event});
+class EventBottomTicketBar extends ConsumerWidget {
+  const EventBottomTicketBar({required this.event, super.key});
 
   final Event event;
 
@@ -119,8 +124,8 @@ class _BottomTicketBar extends ConsumerWidget {
   }
 }
 
-class _BottomTicketBarSkeleton extends StatelessWidget {
-  const _BottomTicketBarSkeleton();
+class EventBottomTicketBarSkeleton extends StatelessWidget {
+  const EventBottomTicketBarSkeleton({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/apps/app_user/lib/src/features/event/detail/event_detail_page.dart
+++ b/apps/app_user/lib/src/features/event/detail/event_detail_page.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:app_user/src/features/event/admission/event_admission_controller.dart';
+import 'package:app_user/src/features/event/detail/event_bottom_ticket_bar.dart';
 import 'package:app_user/src/features/event/detail/event_detail_now_provider.dart';
 import 'package:app_user/src/features/event/detail/open_in_app_dialog.dart';
 import 'package:app_user/src/features/event/detail/report_bottom_sheet.dart';
@@ -15,7 +15,6 @@ import 'package:minglit_kit/minglit_kit.dart';
 
 export 'package:app_user/src/features/event/detail/event_detail_now_provider.dart';
 
-part 'event_bottom_ticket_bar.dart';
 part 'event_detail_content.dart';
 part 'event_detail_content_skeleton.dart';
 part 'event_detail_tab_bar_delegate.dart';
@@ -72,8 +71,8 @@ class EventDetailPage extends ConsumerWidget {
             ),
           ),
           eventAsync.when(
-            data: (event) => _BottomTicketBar(event: event),
-            loading: () => const _BottomTicketBarSkeleton(),
+            data: (event) => EventBottomTicketBar(event: event),
+            loading: () => const EventBottomTicketBarSkeleton(),
             error: (_, _) => const SizedBox.shrink(),
           ),
         ],


### PR DESCRIPTION
Scheduler: swe-sonnet-1

Refs #2588

## 변경 내용

이슈 #2588의 마지막 미등록 화면 `event_bottom_ticket_bar` MDS render catalog 등록.

### 구조 변경

| 파일 | 변경 내용 |
|------|-----------|
| `event_bottom_ticket_bar.dart` | `part of` → standalone public 클래스 추출 (`EventBottomTicketBar`, `EventBottomTicketBarSkeleton`) |
| `event_detail_page.dart` | `part 'event_bottom_ticket_bar.dart'` → `import` 전환, 클래스명 업데이트 |

### 카탈로그 states (15개)

| State | 설명 |
|-------|------|
| state-eligible (mdsIndex:4) | 메인 케이스 — "참가 신청하기" |
| state-guest (mdsIndex:1) | 비로그인 — "로그인하고 신청하기" |
| state-identity-required (mdsIndex:2) | 본인인증 필요 — "본인인증 후 신청하기" |
| state-qualification-required (mdsIndex:3) | 심사 필요 — "신청하기" |
| state-not-eligible (mdsIndex:5) | 조건 미달 — "성별 조건이 맞지 않습니다." |
| state-sold-out (mdsIndex:6) | 마감 — "마감된 이벤트" |
| state-pending-payment (mdsIndex:7) | 결제 중단 — "결제 계속하기" |
| state-applied (mdsIndex:8) | 신청 완료 — "이미 신청한 이벤트" |
| state-rejected (mdsIndex:9) | 심사 반려 — destructive 버튼 |
| state-event-ended (mdsIndex:10) | 종료 — "종료된 이벤트" |
| state-event-ended-with-results (mdsIndex:11) | 종료+결과 — "매칭 결과 보기" |
| state-event-ended-participated (mdsIndex:12) | 종료+참여 — "참여 완료" |
| state-loading (mdsIndex:13) | 로딩 스피너 (infiniteAnimation) |
| state-error (mdsIndex:14) | 오류 — "오류 발생" errorContainer |
| state-eligible-dark | 메인 케이스 다크 모드 |

## 검증

- `flutter analyze`: 0 errors (351 info/warning — 기존 pre-existing)
- `part-of` 추출 후 `EventBottomTicketBar` 공개 클래스 — 기능 변경 없음

## 잔여 위험

- `state-loading` 은 Completer never-completes 패턴 — 다른 catalog(event_now_bar state-results)에서도 사용 중인 검증된 패턴
- `_FixedAdmissionController._ErrorAdmissionController`: `build()` 에서 throw → Riverpod이 async error로 변환하는 패턴