### PR TITLE
test(cuj): add account-management CUJ integration tests — Refs #2589

### DIFF
--- a/apps/app_partner/integration_test/cuj/BLUEDOC.md
+++ b/apps/app_partner/integration_test/cuj/BLUEDOC.md
@@ -58,4 +58,4 @@ integration_test/cuj/
 Flutter 범위 외 CUJ (landing_partner 웹 기능 또는 미구현): 1-2, 1-3, 2-2~2-4, 3-1~3-2.
 
 ---
-_Reviewed: 2026-05-21 03:00_
+_Reviewed: 2026-05-20 07:50_

--- a/apps/app_partner/integration_test/cuj/account/account_management_test.dart
+++ b/apps/app_partner/integration_test/cuj/account/account_management_test.dart
@@ -70,9 +70,11 @@ void main() {
         expect(find.text('준비 중입니다.'), findsOneWidget);
 
         // Fix #2676: SnackBar Timer drain before test teardown
-        t.state<ScaffoldMessengerState>(
-          find.byType(ScaffoldMessenger),
-        ).clearSnackBars();
+        t
+            .state<ScaffoldMessengerState>(
+              find.byType(ScaffoldMessenger),
+            )
+            .clearSnackBars();
         await t.pumpAndSettle();
       },
     );
@@ -97,9 +99,11 @@ void main() {
         await t.pumpAndSettle();
 
         // Fix #2676: SnackBar Timer drain before test teardown
-        t.state<ScaffoldMessengerState>(
-          find.byType(ScaffoldMessenger),
-        ).clearSnackBars();
+        t
+            .state<ScaffoldMessengerState>(
+              find.byType(ScaffoldMessenger),
+            )
+            .clearSnackBars();
         await t.pumpAndSettle();
       },
     );

--- a/apps/app_partner/integration_test/cuj/account/account_management_test.dart
+++ b/apps/app_partner/integration_test/cuj/account/account_management_test.dart
@@ -1,0 +1,98 @@
+// CUJ tests — account / account-management (app_partner)
+//
+// 대응 spec: docs/features/account/account-management/spec.md
+// CUJ 추가 시 본 파일에 `cujGroup` 블록 추가 (새 파일 X).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/cuj_test.dart';
+
+// CUJ 2-2: wrapper that replicates the route's onPartnerProfile SnackBar logic.
+class _PartnerAccountManagementWrapper extends StatelessWidget {
+  const _PartnerAccountManagementWrapper();
+
+  @override
+  Widget build(BuildContext context) {
+    return AccountManagementPage(
+      onPartnerProfile: () => ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('준비 중입니다.')),
+      ),
+      onLogout: () {},
+      onDeleteAccount: () {},
+    );
+  }
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  // ---------------------------------------------------------------------------
+  // CUJ 2-1: (partner) 더보기 → 계정 관리 진입
+  // ---------------------------------------------------------------------------
+
+  cujGroup('2-1', '(partner) 파트너 모드 계정 관리 진입', () {
+    cujCase(
+      'happy: 파트너 프로필 타일 노출, 본인인증 타일 미노출 (FR-1, FR-5)',
+      app: const AccountManagementPage(
+        onPartnerProfile: _noop,
+        onLogout: _noop,
+        onDeleteAccount: _noop,
+      ),
+      body: (t) async {
+        // 파트너 프로필 타일 노출 (partner only — FR-5)
+        expect(find.text('파트너 프로필'), findsOneWidget);
+
+        // 본인인증 타일 미노출 (user only — FR-1)
+        expect(find.text('본인인증'), findsNothing);
+
+        // 로그아웃 / 회원 탈퇴 공통 타일 노출
+        expect(find.text('로그아웃'), findsOneWidget);
+        expect(find.text('회원 탈퇴'), findsOneWidget);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 2-2: (partner) 파트너 프로필 타일 탭 → SnackBar
+  // ---------------------------------------------------------------------------
+
+  cujGroup('2-2', '(partner) 파트너 프로필 타일 탭 → SnackBar', () {
+    cujCase(
+      'happy: 파트너 프로필 탭 → "준비 중입니다." SnackBar 노출 (FR-6)',
+      app: const _PartnerAccountManagementWrapper(),
+      body: (t) async {
+        await t.tap(find.text('파트너 프로필'));
+        await t.pumpAndSettle();
+
+        expect(find.text('준비 중입니다.'), findsOneWidget);
+      },
+    );
+
+    cujCase(
+      'edge: SnackBar 표시 중 다른 타일 탭 가능 (비차단 — NFR-3)',
+      app: const _PartnerAccountManagementWrapper(),
+      body: (t) async {
+        await t.tap(find.text('파트너 프로필'));
+        await t.pumpAndSettle();
+
+        // SnackBar 표시 중에도 로그아웃 타일 탭 가능
+        expect(find.text('준비 중입니다.'), findsOneWidget);
+        await t.tap(find.text('로그아웃'));
+        await t.pumpAndSettle();
+
+        // 로그아웃 confirm 다이얼로그 — 비차단 확인
+        expect(find.text('로그아웃 하시겠어요?'), findsOneWidget);
+
+        // 취소로 닫기
+        await t.tap(find.widgetWithText(TextButton, '취소'));
+        await t.pumpAndSettle();
+      },
+    );
+  });
+}
+
+// Const-compatible no-op callback for const widget declarations.
+void _noop() {}

--- a/apps/app_partner/integration_test/cuj/account/account_management_test.dart
+++ b/apps/app_partner/integration_test/cuj/account/account_management_test.dart
@@ -68,6 +68,12 @@ void main() {
         await t.pumpAndSettle();
 
         expect(find.text('준비 중입니다.'), findsOneWidget);
+
+        // Fix #2676: SnackBar Timer drain before test teardown
+        t.state<ScaffoldMessengerState>(
+          find.byType(ScaffoldMessenger),
+        ).clearSnackBars();
+        await t.pumpAndSettle();
       },
     );
 
@@ -88,6 +94,12 @@ void main() {
 
         // 취소로 닫기
         await t.tap(find.widgetWithText(TextButton, '취소'));
+        await t.pumpAndSettle();
+
+        // Fix #2676: SnackBar Timer drain before test teardown
+        t.state<ScaffoldMessengerState>(
+          find.byType(ScaffoldMessenger),
+        ).clearSnackBars();
         await t.pumpAndSettle();
       },
     );

--- a/apps/app_user/integration_test/cuj/BLUEDOC.md
+++ b/apps/app_user/integration_test/cuj/BLUEDOC.md
@@ -164,4 +164,4 @@ flutter test integration_test/cuj/ \
 - 시각 회귀: [`mds-emulator-render/BLUEDOC.md`](../mds-emulator-render/BLUEDOC.md)
 
 ---
-_Reviewed: 2026-05-20 09:00_
+_Reviewed: 2026-05-24 09:04_

--- a/apps/app_user/integration_test/cuj/account/account_management_test.dart
+++ b/apps/app_user/integration_test/cuj/account/account_management_test.dart
@@ -1,0 +1,305 @@
+// CUJ tests — account / account-management (app_user)
+//
+// 대응 spec: docs/features/account/account-management/spec.md
+// CUJ 추가 시 본 파일에 `cujGroup` 블록 추가 (새 파일 X).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/cuj_test.dart';
+
+// CUJ 1-3: StatefulWidget for simulating external isVerified change.
+class _VerifiedWrapper extends StatefulWidget {
+  const _VerifiedWrapper();
+
+  @override
+  State<_VerifiedWrapper> createState() => _VerifiedWrapperState();
+}
+
+class _VerifiedWrapperState extends State<_VerifiedWrapper> {
+  bool _isVerified = false;
+
+  void setVerified({required bool value}) {
+    setState(() => _isVerified = value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AccountManagementPage(
+      isVerified: _isVerified,
+      onCertification: () {},
+      onLogout: () {},
+      onDeleteAccount: () {},
+    );
+  }
+}
+
+// CUJ 4-2: Wrapper that pushes AccountManagementPage onto Navigator stack.
+class _PushWrapper extends StatelessWidget {
+  const _PushWrapper();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: TextButton(
+          onPressed: () => Navigator.push<void>(
+            context,
+            MaterialPageRoute<void>(
+              builder: (_) => AccountManagementPage(
+                onCertification: () {},
+                onLogout: () {},
+                onDeleteAccount: () {},
+              ),
+            ),
+          ),
+          child: const Text('열기'),
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  // ---------------------------------------------------------------------------
+  // CUJ 1-1: (user) 본인인증 미완 상태에서 진입
+  // ---------------------------------------------------------------------------
+
+  cujGroup('1-1', '(user) 본인인증 미완 상태에서 진입', () {
+    var onCertCalled = false;
+
+    cujCase(
+      'happy: 본인인증 타일 "인증하기" subtitle 노출, 탭 → onCertification 호출',
+      app: AccountManagementPage(
+        onCertification: () => onCertCalled = true,
+        onLogout: () {},
+        onDeleteAccount: () {},
+      ),
+      body: (t) async {
+        onCertCalled = false;
+
+        expect(find.text('본인인증'), findsOneWidget);
+        expect(find.text('인증하기'), findsOneWidget);
+
+        await t.tap(find.text('본인인증'));
+        await t.pumpAndSettle();
+
+        expect(onCertCalled, isTrue);
+      },
+    );
+
+    cujCase(
+      'edge: isVerified 기본값(false) → 인증하기 표시',
+      app: const AccountManagementPage(
+        onCertification: _noop,
+        onLogout: _noop,
+        onDeleteAccount: _noop,
+      ),
+      body: (t) async {
+        expect(find.text('인증하기'), findsOneWidget);
+        expect(find.text('인증 완료'), findsNothing);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 1-2: (user) 본인인증 완료 상태에서 진입
+  // ---------------------------------------------------------------------------
+
+  cujGroup('1-2', '(user) 본인인증 완료 상태에서 진입', () {
+    var onCertCalled = false;
+
+    cujCase(
+      'happy: 본인인증 타일 "인증 완료" subtitle 노출 + 탭 가능',
+      app: AccountManagementPage(
+        isVerified: true,
+        onCertification: () => onCertCalled = true,
+        onLogout: () {},
+        onDeleteAccount: () {},
+      ),
+      body: (t) async {
+        onCertCalled = false;
+
+        expect(find.text('본인인증'), findsOneWidget);
+        expect(find.text('인증 완료'), findsOneWidget);
+
+        // Fix #1861: 인증 완료 후도 탭 가능 (다시 들어가도 막지 않음)
+        await t.tap(find.text('본인인증'));
+        await t.pumpAndSettle();
+
+        expect(onCertCalled, isTrue);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 1-3: (user) 본인인증 상태 외부 변경 즉시 반영
+  // ---------------------------------------------------------------------------
+
+  cujGroup('1-3', '(user) 본인인증 상태 외부 변경 즉시 반영', () {
+    cujCase(
+      'happy: isVerified false→true → success 톤 즉시 교체 (깜빡임 X)',
+      app: const _VerifiedWrapper(),
+      body: (t) async {
+        // 초기 미인증 상태 확인
+        expect(find.text('인증하기'), findsOneWidget);
+        expect(find.text('인증 완료'), findsNothing);
+
+        // 외부에서 인증 완료 시뮬레이션 (provider rebuild → setState 동일 효과)
+        t
+            .state<_VerifiedWrapperState>(find.byType(_VerifiedWrapper))
+            .setVerified(value: true);
+        await t.pump();
+
+        // UI 즉시 업데이트 확인 (깜빡임 없이 교체)
+        expect(find.text('인증 완료'), findsOneWidget);
+        expect(find.text('인증하기'), findsNothing);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 3-1: 로그아웃 confirm 후 로그인 화면 복귀
+  // ---------------------------------------------------------------------------
+
+  cujGroup('3-1', '로그아웃 confirm 후 로그인 화면 복귀', () {
+    var logoutCalled = false;
+
+    cujCase(
+      'happy: "로그아웃" 타일 탭 → confirm 다이얼로그 → "로그아웃" → onLogout 호출',
+      app: AccountManagementPage(
+        onCertification: () {},
+        onLogout: () => logoutCalled = true,
+        onDeleteAccount: () {},
+      ),
+      body: (t) async {
+        logoutCalled = false;
+
+        // 로그아웃 타일 탭
+        await t.tap(find.text('로그아웃'));
+        await t.pumpAndSettle();
+
+        // MinglitAlert.showConfirm 다이얼로그 노출 확인 (FR-8)
+        expect(find.text('로그아웃 하시겠어요?'), findsOneWidget);
+
+        // 다이얼로그의 "로그아웃" 확인 버튼 탭
+        await t.tap(find.widgetWithText(TextButton, '로그아웃'));
+        await t.pumpAndSettle();
+
+        expect(logoutCalled, isTrue);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 3-2: 로그아웃 confirm 취소
+  // ---------------------------------------------------------------------------
+
+  cujGroup('3-2', '로그아웃 confirm 취소', () {
+    var logoutCalled = false;
+
+    cujCase(
+      'happy: "취소" 탭 → 다이얼로그 닫힘, onLogout 미호출',
+      app: AccountManagementPage(
+        onCertification: () {},
+        onLogout: () => logoutCalled = true,
+        onDeleteAccount: () {},
+      ),
+      body: (t) async {
+        logoutCalled = false;
+
+        await t.tap(find.text('로그아웃'));
+        await t.pumpAndSettle();
+
+        expect(find.text('로그아웃 하시겠어요?'), findsOneWidget);
+
+        await t.tap(find.widgetWithText(TextButton, '취소'));
+        await t.pumpAndSettle();
+
+        expect(logoutCalled, isFalse);
+        expect(find.text('로그아웃 하시겠어요?'), findsNothing);
+      },
+    );
+
+    cujCase(
+      'edge: scrim 탭 → 다이얼로그 닫힘, onLogout 미호출',
+      app: AccountManagementPage(
+        onCertification: () {},
+        onLogout: () => logoutCalled = true,
+        onDeleteAccount: () {},
+      ),
+      body: (t) async {
+        logoutCalled = false;
+
+        await t.tap(find.text('로그아웃'));
+        await t.pumpAndSettle();
+
+        // scrim 탭 — dialog 외부 좌상단 모서리
+        await t.tapAt(const Offset(10, 10));
+        await t.pumpAndSettle();
+
+        expect(logoutCalled, isFalse);
+        expect(find.text('로그아웃 하시겠어요?'), findsNothing);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 4-1: 회원 탈퇴 진입 (추가 confirm 없이)
+  // ---------------------------------------------------------------------------
+
+  cujGroup('4-1', '회원 탈퇴 진입 (추가 confirm 없이)', () {
+    var deleteAccountCalled = false;
+
+    cujCase(
+      'happy: 회원 탈퇴 탭 → onDeleteAccount 즉시 호출 (FR-10)',
+      app: AccountManagementPage(
+        onCertification: () {},
+        onLogout: () {},
+        onDeleteAccount: () => deleteAccountCalled = true,
+      ),
+      body: (t) async {
+        deleteAccountCalled = false;
+
+        await t.tap(find.text('회원 탈퇴'));
+        await t.pumpAndSettle();
+
+        // 추가 confirm dialog 없이 즉시 호출 확인 (FR-10)
+        expect(deleteAccountCalled, isTrue);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 4-2: 뒤로 가기 → 부모 페이지 복귀
+  // ---------------------------------------------------------------------------
+
+  cujGroup('4-2', '뒤로 가기 → 부모 페이지 복귀', () {
+    cujCase(
+      'happy: AppBar 뒤로 가기 → Navigator.pop → 이전 화면 복귀',
+      app: const _PushWrapper(),
+      body: (t) async {
+        // AccountManagementPage 진입
+        await t.tap(find.text('열기'));
+        await t.pumpAndSettle();
+
+        expect(find.text('계정 관리'), findsOneWidget);
+
+        // AppBar 뒤로 가기
+        await t.tap(find.byType(BackButton));
+        await t.pumpAndSettle();
+
+        // 부모 페이지 복귀 확인
+        expect(find.text('열기'), findsOneWidget);
+        expect(find.text('계정 관리'), findsNothing);
+      },
+    );
+  });
+}
+
+// Const-compatible no-op callback for const widget declarations.
+void _noop() {}

--- a/apps/app_user/integration_test/cuj/account/account_management_test.dart
+++ b/apps/app_user/integration_test/cuj/account/account_management_test.dart
@@ -287,7 +287,10 @@ void main() {
         await t.tap(find.text('열기'));
         await t.pumpAndSettle();
 
-        expect(find.text('계정 관리'), findsOneWidget);
+        // Fix #2659: AccountManagementPage는 AppBar 제목 + settings group 헤더 양쪽에
+        // '계정 관리' 텍스트가 있어 findsOneWidget 대신 '로그아웃' 로 페이지 진입 검증.
+        expect(find.text('로그아웃'), findsOneWidget);
+        expect(find.byType(BackButton), findsOneWidget);
 
         // AppBar 뒤로 가기
         await t.tap(find.byType(BackButton));


### PR DESCRIPTION
Scheduler: swe-sonnet-1

## 변경 내용

\`account/account-management\` feature 9개 CUJ 전체 커버 (0/9 → 9/9)

**app_user** (\`apps/app_user/integration_test/cuj/account/account_management_test.dart\`):
- CUJ 1-1: 본인인증 미완 — '인증하기' subtitle + onCertification 호출 (happy + edge)
- CUJ 1-2: 본인인증 완료 — '인증 완료' subtitle + 탭 가능 확인
- CUJ 1-3: 외부 상태 변경 즉시 반영 — StatefulWrapper setState로 isVerified 변경 → UI 즉시 교체
- CUJ 3-1: 로그아웃 confirm → onLogout 호출
- CUJ 3-2: 로그아웃 cancel → onLogout 미호출 (취소 버튼 + scrim 탭 edge case)
- CUJ 4-1: 회원 탈퇴 → onDeleteAccount 즉시 호출 (추가 confirm 없음)
- CUJ 4-2: AppBar 뒤로 가기 → Navigator.pop → 부모 페이지 복귀

**app_partner** (\`apps/app_partner/integration_test/cuj/account/account_management_test.dart\`):
- CUJ 2-1: 파트너 모드 — 파트너 프로필 타일 노출, 본인인증 타일 미노출
- CUJ 2-2: 파트너 프로필 탭 → '준비 중입니다.' SnackBar (비차단 edge case 포함)

## 검증

- \`dart run scripts/cuj_coverage.dart\`: account/account-management 9/9 ✓, 전체 50.7% → 54.0%
- \`dart analyze --no-fatal-infos\`: 두 파일 모두 No issues found ✓
- \`dart format\`: 변경 없음 ✓

## 잔여 위험

- 실 기기/에뮬레이터 실행 없음 — CI \`cuj-integration-{user,partner}\` 에서 검증 예정

Refs #2589