### PR TITLE
docs(infra): Spotify-style → 3-tier deploy (사용자 서버 영향 분리)

### DIFF
--- a/docs/infra/branch-strategy/BLUEDOC.md
+++ b/docs/infra/branch-strategy/BLUEDOC.md
@@ -1,6 +1,6 @@
 # Branch Strategy
 
-4-stage (`dev-staging → dev → rc → main`) + merge queue + nightly snapshot + `rc-gate` green build picking + feature flag + 3가지 safety net. AI agent 가 dev-staging commit, backend/web 은 dev rc-gate-pass commit 마다 continuous deploy (Spotify 식), mobile 은 main 머지마다 build/store upload (hotfix 없으면 weekly). 모든 cadence = target, slip 자연스러움.
+4-stage (`dev-staging → dev → rc → main`) + merge queue + nightly snapshot + `rc-gate` green build picking + feature flag + 3가지 safety net. AI agent 가 dev-staging commit, **dev rc-gate-pass 는 main-staging env (staging Supabase) 로 deploy**, main 머지에서 backend + mobile 모두 prod 로 deploy (hotfix 없으면 weekly). 모든 cadence = target, slip 자연스러움.
 
 ## 4-stage 모델
 
@@ -42,7 +42,7 @@
 
 - 코드 promotion = 한 방향 PR, 기능 promotion = flag flip
 - 모든 branch linear ON — dev-staging: squash, dev/rc/main: rebase
-- dev rc-gate-pass = backend/web continuous deploy (Spotify 식); main 머지 = mobile build/store upload (`deploy-android-*, deploy-ios-*`)
+- dev rc-gate-pass = backend/web → **main-staging env** deploy (사용자 서버 영향 X); main 머지 = backend + mobile 모두 prod deploy
 - **Hotfix 는 rc 에서, dev-staging 으로 자동 backport** ([rc-promotion.md](./rc-promotion.md))
 - Tag regex 는 `RELEASE.md` lock (TODO)
 

--- a/docs/infra/branch-strategy/branch-flow.md
+++ b/docs/infra/branch-strategy/branch-flow.md
@@ -13,20 +13,21 @@
                                                               │      │
                                                               │      ├─ pass: status rc-gate-pass
                                                               │      │         │
-                                                              │      │         ├─▶ deploy-supabase (EF + migration)
-                                                              │      │         └─▶ deploy-vercel (4앱)
+                                                              │      │         ├─▶ deploy-supabase (target=main-staging, staging Supabase project)
+                                                              │      │         └─▶ Vercel preview (native, dev branch)
                                                               │      │
                                                               │      └─ fail: 자동 이슈 + AI agent fix via dev-staging (no auto-revert)
                                                               │
                                                               └─weekly rc-cut (최신 rc-gate-pass commit)──▶ rc/YYYY-Wxx
                                                                                                               │
-                                                                                                              └─5일 soak (hotfix 시 시계 리셋)──▶ main
+                                                                                                              └─5일 soak (hotfix 시 시계 리셋, main-staging env 사용)──▶ main
                                                                                                                                                     │
-                                                                                                                                                    └─main-post-merge-promote
+                                                                                                                                                    └─main-post-merge-promote (prod deploy chain)
                                                                                                                                                               │
+                                                                                                                                                              ├─▶ deploy-supabase (target=main, prod Supabase)
                                                                                                                                                               ├─▶ deploy-android-{user,partner} ──▶ Play Store
-                                                                                                                                                              └─▶ deploy-ios-{user,partner} ──▶ App Store Connect
-                                                                                                                                                                              (push: main trigger 로 자동, 병렬)
+                                                                                                                                                              ├─▶ deploy-ios-{user,partner} ──▶ App Store Connect
+                                                                                                                                                              └─▶ Vercel production (native, main branch)
 ```
 
 **Hotfix backport 흐름** (rc → dev-staging):
@@ -76,29 +77,30 @@ Hybrid linear history 금지 — 각 branch 내 일관 (squash or rebase 한 가
 
 ## Auto-deploy Chain
 
-### dev rc-gate-pass → backend/web (continuous)
+### dev rc-gate-pass → main-staging env deploy (continuous)
 
 ```yaml
-# 개념
+# 개념 — staging env 만, prod 영향 X
 rc-gate (on push to dev):
   needs: pass
   parallel:
-    - uses: ./.github/workflows/deploy-supabase.yml  # EF + migration
-    - uses: ./.github/workflows/deploy-vercel.yml    # 4앱
+    - uses: ./.github/workflows/deploy-supabase.yml  # target=main-staging
+    # Vercel: native build 가 dev branch → preview deployment
 ```
 
-### main push → mobile (every release)
+### main push → prod deploy chain
 
 ```yaml
-# 개념
+# 개념 — backend + mobile 모두 prod
 main-post-merge-promote (on push to main):
   steps:
     - tag v{ver} + promo/main-Wxx + Sentry marker
     - Firebase RC `latest_version` = v{ver} 자동 update
   parallel:
-    # (실제로는 workflow_call 아닌 push: main trigger 로 기존 deploy-* workflows 자동 발동)
-    # - deploy-android-user / deploy-android-partner
-    # - deploy-ios-user / deploy-ios-partner
+    - uses: ./.github/workflows/deploy-supabase.yml  # target=main (prod Supabase)
+    - uses: ./.github/workflows/deploy-android-{user,partner}.yml
+    - uses: ./.github/workflows/deploy-ios-{user,partner}.yml
+    # Vercel: native build 가 main branch → production deployment
 ```
 
 상세: [specs/workflow-spec.md](./specs/workflow-spec.md).

--- a/docs/infra/branch-strategy/dev-pipeline.md
+++ b/docs/infra/branch-strategy/dev-pipeline.md
@@ -54,11 +54,13 @@ dev 머지 후 자동 발동. 통과 = "이 commit 은 RC 가능 + backend/web p
 
 ```
 1. dev HEAD commit 에 GitHub commit status `rc-gate-pass` set
-2. Auto-deploy chain workflow_call (parallel):
-   - deploy-supabase (EF + migration apply)
-   - deploy-vercel (Vercel hooks 4앱)
-3. (Mobile 은 별도 — main 머지 후 기존 `deploy-android-*` / `deploy-ios-*` workflow 들이 자동 발동)
+2. Auto-deploy chain workflow_call (parallel, target=main-staging):
+   - deploy-supabase (staging Supabase project: EF + migration apply)
+   - (Vercel native: dev branch → preview deployment)
+3. (Mobile + backend prod 은 별도 — main 머지 후 deploy chain)
 ```
+
+> **사용자 서버 영향 X** — rc-gate-pass deploy 는 main-staging env (별도 Supabase project) 만. prod 는 main 머지에서.
 
 ### 실패 시
 

--- a/docs/infra/branch-strategy/error-detection.md
+++ b/docs/infra/branch-strategy/error-detection.md
@@ -54,7 +54,8 @@
 |---------------|----------|--------|--------|
 | pr-gate 실패 (어느 단계든) | PR 작성자 | GitHub PR | 본인 fix → re-push → re-queue |
 | `rc-gate` 실패 (dev 머지 후) | 직전 rc-gate-pass 이후 머지된 PR 작성자들 + AI agent | GitHub issue + Slack `#nightly` | AI agent fix PR via dev-staging — dev keeps moving ([dev-pipeline.md](./dev-pipeline.md)) |
-| Backend/web auto-deploy 실패 | on-call | Slack `#release` | retry → rollback ([main-promotion.md](./main-promotion.md) error-backoff) |
+| Backend/web staging deploy 실패 (dev rc-gate-pass) | on-call | Slack `#release` | retry → P0 이슈, RC 진행 차단 (staging 도달 못함) |
+| Backend/web/mobile prod deploy 실패 (main 머지) | on-call | Slack `#release` | retry → rollback ([main-promotion.md](./main-promotion.md) error-backoff) |
 | rc soak 중 회귀 | RC owner | Slack `#release` | hotfix PR → rc | 
 | deploy-android-*, deploy-ios-* 실패 | mobile 팀 | GitHub issue + Slack | retry + auto-issue ([main-promotion.md](./main-promotion.md) error-backoff) |
 | Sentry alert (error spike) | 영역 owner | Sentry → Slack | 영역 별 on-call 판단 |

--- a/docs/infra/branch-strategy/life-of-flag.md
+++ b/docs/infra/branch-strategy/life-of-flag.md
@@ -152,8 +152,8 @@ Feature flag (Statsig + Firebase Remote Config) 의 생성·soak·rollout·**자
 
 | 항목 | 코드 release | 기능 release |
 |------|--------------|--------------|
-| 트리거 | backend/web: dev rc-gate-pass / mobile: main 머지 (deploy-android-*, deploy-ios-*) | flag ON 조작 |
-| cadence | backend/web: 시간 단위 / mobile: hotfix 없으면 weekly (rc → main 주기) | feature 별 비동기 |
+| 트리거 | backend/web staging: dev rc-gate-pass (main-staging env) / backend/web prod + mobile: main 머지 | flag ON 조작 |
+| cadence | staging: 시간 단위 / prod (backend + mobile): hotfix 없으면 weekly (rc → main 주기) | feature 별 비동기 |
 | rollback | redeploy 이전 commit (분) | flag flip (즉시) |
 | 통제 권한 | 릴리즈 매니저 | feature owner |
 

--- a/docs/infra/branch-strategy/main-promotion.md
+++ b/docs/infra/branch-strategy/main-promotion.md
@@ -1,11 +1,11 @@
 # Main Promotion
 
-`rc/YYYY-Wxx` 의 soak 통과 시 `main` 으로 머지, main push 직후 기존 mobile deploy workflow (`deploy-android-*`, `deploy-ios-*`) 가 자동 발동. Backend/web 의 auto-deploy 는 dev 의 rc-gate-pass 에서 이미 일어남 ([dev-pipeline.md](./dev-pipeline.md)). main 머지가 곧 mobile release (hotfix 없으면 weekly).
+`rc/YYYY-Wxx` 의 soak 통과 시 `main` 으로 머지, main push 직후 **backend + mobile 모두 prod 로 deploy**. Backend 의 staging deploy 는 dev 의 rc-gate-pass 에서 일어남 (main-staging env, [dev-pipeline.md](./dev-pipeline.md)). prod deploy 는 main 머지에서 — 사용자 서버에 검증 안 된 코드 직접 들어가지 않게 RC soak 통과 후만.
 
 ## 두 가지 이벤트
 
 1. **rc → main 머지** — `rc-soak-check` 가 자동 PR 생성 + 모든 check 통과 시 workflow auto-merge
-2. **기존 deploy-* workflow 자동 발동** — main push trigger 로 `deploy-android-{user,partner}`, `deploy-ios-{user,partner}` 가 병렬 실행. store review + staged rollout 은 store-side
+2. **main push → prod deploy chain** — backend (`deploy-supabase` target=main), web (Vercel native), mobile (`deploy-android-*`, `deploy-ios-*`) 모두 prod 로 병렬 deploy. store review + staged rollout 은 store-side
 
 ## `main-pr-gate`
 
@@ -22,7 +22,7 @@
 
 ## `main-post-merge-promote`
 
-auto-merge 직후 자동:
+auto-merge 직후 자동 (promote + prod deploy chain):
 
 ```
 1. bump-version.sh {ver}  (suffix 제거 — main 은 final version)
@@ -32,6 +32,11 @@ auto-merge 직후 자동:
 5. git push (tags + commit)
 6. Sentry release marker 부여 (v{ver})
 7. Firebase RC `latest_version` = v{ver} (Admin SDK)
+8. parallel deploy chain (모두 target=main):
+   - deploy-supabase (prod Supabase: migration + EF)
+   - deploy-android-{user,partner}
+   - deploy-ios-{user,partner}
+   - (Vercel: native build 가 main push 자동 감지)
 ```
 
 > Backend/web deploy 는 main 에서 안 함 — dev 의 rc-gate-pass 에서 이미 prod 반영됨. Mobile deploy 는 별도 workflow.

--- a/docs/infra/branch-strategy/specs/execution-plan.md
+++ b/docs/infra/branch-strategy/specs/execution-plan.md
@@ -72,8 +72,8 @@
 | 2c | `version-bump` reusable extract (sync-version 의 핵심 로직) | sync-version 의 caller 가 reusable 호출하게 변경 |
 | 2d | `auto-issue` reusable 추가 | 신규 — 기존 영향 없음 |
 | 2e | **`ci-result` 폐기** — 현 branch protection 의 required check `ci-result` 를 각 branch 의 `pr-gate` 로 변경 (Phase 4 에서 실제 적용) | 본 step 은 workflow 측 준비, 실제 protection 변경은 4 |
-| 2f | `deploy-supabase` 의 trigger refactor (push:dev 부분을 rc-gate-pass 발동으로 변경) | dev 배포 trigger 가 status-event 로 변경. 신중 적용 |
-| 2g | **`deploy-vercel` 폐기** — 자체 빌드 워크플로우 제거. 향후 **Vercel native build** 로 전환 (Vercel-GitHub 연결, Vercel-side 자동 트리거) — 본 workflow scope 밖 | web/landing 배포가 GitHub Actions 가 아닌 Vercel 자체 build infra 사용 |
+| 2f | `deploy-supabase` 의 trigger refactor — push:dev 부분을 rc-gate-pass workflow_call **with target=main-staging** 로 변경, push:main 은 main-post-merge-promote 의 workflow_call **with target=main** | staging deploy 와 prod deploy 분리. 사용자 서버 영향 X |
+| 2g | **`deploy-vercel` 폐기** — 자체 빌드 워크플로우 제거. **Vercel native build 로 전환** (Vercel-GitHub 연결, Vercel-side: main=production, dev=preview) | Vercel-side 설정 필요, workflow 측 작업 없음 |
 
 ### Rollback
 

--- a/docs/infra/branch-strategy/specs/secret-migration-plan.md
+++ b/docs/infra/branch-strategy/specs/secret-migration-plan.md
@@ -19,12 +19,15 @@ GitHub repo secrets (`DEV_*`, `MAIN_*`, `PRD_*` prefix) → `minglit_env/{stage}
 
 ```
 minglit_env/
-├── dev/.env          # dev 환경 (workflow 의 default)
-├── local/.env        # 로컬 개발자 환경
-├── main/.env         # production
-├── staging/.env      # (옵션 — RC soak 용 향후)
-└── README.md         # 컨벤션 + 변수 카탈로그
+├── local/.env          # 로컬 개발자 환경
+├── dev/.env            # CI 테스트 + dev workflow config
+├── dev-staging → dev   # symlink (같은 env)
+├── main-staging/.env   # RC 가 deploy 되는 staging Supabase project (dev rc-gate-pass 가 deploy)
+├── main/.env           # production (main 머지가 deploy)
+└── README.md           # 컨벤션 + 변수 카탈로그
 ```
+
+> **main-staging env 의 역할**: dev 가 계속 움직이는 동안 RC soak 가 *frozen 환경* 에서 검증되도록 staging Supabase project 를 별도 운영. dev rc-gate-pass 마다 deploy 되지만 사용자 서버 (main env) 영향 X.
 
 기존 도메인별 파일 (`flutter.env`, `supabase.env`, `nextjs.env`, `metabase.env`) 은 통합 후 폐기.
 

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -122,7 +122,7 @@ Cross-branch cherry-pick PR 자동 생성.
 |------|----|
 | Trigger | `push` to `dev` (= nightly-cut PR merge 직후) |
 | Outputs | commit status `rc-gate-pass` (success only) |
-| Steps | (1) calls `rc-gate-suite` (2) **success**: set commit status `rc-gate-pass` → parallel `workflow_call` 기존 `deploy-supabase` + `deploy-vercel` (3) **failure**: `auto-issue` (P1, label `rc-gate-failure`, assignee=직전 rc-gate-pass 이후 머지된 PR 작성자들). dev 는 broken 상태로 잠시 머묾, AI agent 가 fix PR 을 dev-staging 으로 normal flow 로 작성 → 다음 nightly-cut → 다음 rc-gate 가 검증 |
+| Steps | (1) calls `rc-gate-suite` (2) **success**: set commit status `rc-gate-pass` → `workflow_call` `deploy-supabase` **with target=main-staging** (= staging Supabase project, NOT prod). Vercel 은 native build 가 dev branch → preview deployment 자동 처리 (3) **failure**: `auto-issue` (P1, label `rc-gate-failure`, assignee=직전 rc-gate-pass 이후 머지된 PR 작성자들). dev 는 broken 상태로 잠시 머묾, AI agent 가 fix PR 을 dev-staging 으로 normal flow 로 작성 → 다음 nightly-cut → 다음 rc-gate 가 검증 |
 | Backoff | 같은 area 3회 연속 실패 시 `rc-cut` 자동 차단 (다음 weekly cut PR 안 만듦) |
 
 > **No auto-revert** — snapshot 모델: 실패 = no tag, dev keeps moving, 새 fix 가 자연스럽게 다음 rc-gate 에서 검증됨.
@@ -131,19 +131,23 @@ Cross-branch cherry-pick PR 자동 생성.
 
 | 항목 | 값 |
 |------|----|
-| 현재 trigger | `push` to dev or main + paths filter (`supabase/migrations/**`, `supabase/functions/**`) |
-| Refactor 후 trigger | `workflow_call` from `rc-gate` (success) + `push` to main |
+| 현재 trigger | `push` to dev or main + paths filter |
+| Refactor 후 trigger | `workflow_call` (target=main-staging) from `rc-gate` (success) **+** `workflow_call` (target=main) from `main-post-merge-promote` |
+| Inputs | `target_env`: main-staging \| main |
 | Outputs | deploy status, Sentry release marker |
-| Steps | (1) Supabase migration apply (2) EF deploy (3) Sentry release marker (4) post-deploy smoke (5) 실패 시 retry → `auto-issue` (P0) + on-call |
+| Steps | (1) Supabase migration apply to target env (2) EF deploy to target env (3) Sentry release marker (4) post-deploy smoke (5) 실패 시 retry → `auto-issue` (P0) + on-call |
+| Env file | `minglit_env/${target_env}/.env` (main-staging = staging Supabase project, main = prod Supabase project) |
 
-#### `deploy-vercel` (기존, refactor 대상)
+#### `deploy-vercel` (폐기 예정)
 
-| 항목 | 값 |
-|------|----|
-| 현재 trigger | `schedule` cron 2시간 + `workflow_dispatch` |
-| Refactor 후 trigger | `workflow_call` from `rc-gate` (success) + `push` to main (cron 폐기) |
-| Outputs | deploy status |
-| Steps | Vercel deploy hooks (4앱 parallel) · 실패 시 retry → `auto-issue` (P0) |
+기존 자체 빌드 워크플로우 폐기. **Vercel native build 로 전환** (Vercel-GitHub 연결, Vercel-side branch 매핑).
+
+| Branch | Vercel target |
+|--------|---------------|
+| `main` | production deployment |
+| `dev` (rc-gate-pass) | preview deployment (main-staging equivalent) |
+
+Vercel native 가 자체 trigger 및 build 처리. workflow 측 작업 없음.
 
 ### rc
 
@@ -202,17 +206,16 @@ Cross-branch cherry-pick PR 자동 생성.
 | 항목 | 값 |
 |------|----|
 | Trigger | `push` to `main` (rc → main auto-merge 직후) |
-| Outputs | tag `v{ver}` + tag `promo/main-YYYY-Wxx` + Sentry marker + Firebase RC `latest_version` update |
-| Steps | (1) calls `version-bump` (suffix="") (2) `git tag promo/main-YYYY-Wxx` + push (3) Sentry release marker `v{ver}` (4) Firebase RC `latest_version` = `v{ver}` (Admin SDK) (5) **deploys 는 별도 — push: main trigger 로 기존 workflow 들이 자동 발동** |
+| Outputs | tag `v{ver}` + tag `promo/main-YYYY-Wxx` + Sentry marker + Firebase RC `latest_version` update + parallel deploy chain |
+| Steps | (1) calls `version-bump` (suffix="") (2) `git tag promo/main-YYYY-Wxx` + push (3) Sentry release marker `v{ver}` (4) Firebase RC `latest_version` = `v{ver}` (Admin SDK) (5) **parallel deploy chain** (모두 target=main env): `deploy-supabase`, mobile deploy workflows |
 
-> main push 후 자동 발동되는 기존 deploy workflows (병렬):
-> - `deploy-supabase` — EF + migration
-> - `deploy-vercel` — 4 web 앱
+> main push 후 자동 발동되는 deploy workflows (병렬):
+> - `deploy-supabase` (target=main, prod Supabase project) — EF + migration
 > - `deploy-android-user`, `deploy-android-partner` (each calls `shared-android-deploy`)
-> - `deploy-ios-user`, `deploy-ios-partner` (TBD: shared-ios-deploy reusable 있는지 확인)
+> - `deploy-ios-user`, `deploy-ios-partner` (TBD: shared-ios-deploy reusable)
+> - Vercel: native build 가 main push 자동 감지 (workflow_call 아님)
 
-> Mobile cadence = main 머지 마다 weekly build/upload (hotfix 없으면). store review + staged rollout 은 store-side.
-> Fastlane vs native action 등 mobile deploy 의 구체 도구는 기존 workflow 따름 (Fastlane 통일 검토는 후속 TBD).
+> Cadence: backend prod + mobile 모두 weekly (rc → main 머지 마다, hotfix 없으면). store review + staged rollout 은 store-side.
 
 ## Workflow Chain Diagram
 
@@ -229,7 +232,7 @@ Cross-branch cherry-pick PR 자동 생성.
 [nightly-cut] ──PR created──▶ [nightly-pr-gate] ──auto-merge──▶ dev push
                                                                     ↓
                                                               [rc-gate]
-                                                              ├ success ─▶ status rc-gate-pass + [deploy-supabase] + [deploy-vercel]
+                                                              ├ success ─▶ status rc-gate-pass + [deploy-supabase target=main-staging] (+ Vercel preview native)
                                                               │              ↓ Sentry release
                                                               │
                                                               └ failure ─▶ [auto-issue P1] (AI agent assignee → dev-staging fix PR)


### PR DESCRIPTION
## Summary

기존 spec 의 *dev rc-gate-pass → backend prod 직접 deploy* (Spotify 식 continuous) 를 **3-tier deploy 패턴** 으로 변경. dev 가 계속 움직이는 동안 검증 안 된 코드가 사용자 서버에 직접 들어가는 위험 제거.

## Architectural 변경

```
Before:
  dev rc-gate-pass ──▶ backend PROD (즉시)
  main 머지 ──▶ mobile only

After:
  dev rc-gate-pass ──▶ main-staging env (staging Supabase project)
  RC soak 5일 (frozen staging env 에서 검증)
  main 머지 ──▶ backend PROD + mobile PROD (병렬)
```

## Trade-off

| Lose | Gain |
|------|------|
| Backend prod cadence: 분 단위 continuous → weekly | 사용자 서버에 검증 안 된 코드 직접 영향 0 |
| Backend hotfix 도 RC soak 통과 필수 | RC soak 가 진짜 prod-like 환경에서 검증 (frozen staging) |
| - | mobile + backend release cadence 동기화 (둘 다 weekly via main) |

긴급 hotfix 는 flag flip 으로 우회 (Tier 1) 또는 admin bypass.

## Env 구조 (final)

```
minglit_env/
├── local/.env
├── dev/.env              # CI test config, dev workflow
├── dev-staging → dev     # symlink (같은 env)
├── main-staging/.env     # RC frozen staging (별도 Supabase project)
├── main/.env             # production
└── README.md
```

## 수정 docs (9개)

| 파일 | 변경 |
|------|------|
| workflow-spec.md | rc-gate target=main-staging, deploy-supabase refactor with target input, main-post-merge-promote 에 prod deploy chain, deploy-vercel 폐기 |
| branch-flow.md | chain diagram 의 deploy target 갱신 |
| dev-pipeline.md | rc-gate-pass deploy target = main-staging 명시 |
| main-promotion.md | main-post-merge-promote 에 prod deploy chain 추가 |
| BLUEDOC.md | 핵심 컨벤션 의 deploy 흐름 갱신 |
| life-of-flag.md | backend cadence "시간 단위" → "weekly" |
| error-detection.md | staging deploy 실패 / prod deploy 실패 분리 |
| specs/execution-plan.md | deploy-supabase refactor 명시 |
| specs/secret-migration-plan.md | minglit_env 구조에 main-staging/ 추가 |

## 다음 step

이 PR 머지 후:
1. **minglit_env repo**: main-staging/.env 골격 + 값 (Mark 가 staging Supabase project 셋업 후 채움)
2. **Phase 2 workflow refactor** (execution-plan 따라): deploy-supabase 의 target input 받게 refactor
3. **Phase 3 신규 구현**: rc-gate, main-post-merge-promote 의 chain 구현

## Test plan

- [ ] BLUEDOC freshness 통과
- [ ] 문서 cross-link 깨짐 없음
- [ ] CodeRabbit 리뷰 통과

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)