### PR TITLE
fix(mds): remove settings divider indent

### DIFF
--- a/apps/mds/docs/public/specs/more_page/index.html
+++ b/apps/mds/docs/public/specs/more_page/index.html
@@ -48,7 +48,7 @@ body.dark-mode .viewport {
 /* MinglitSettingsGroup — padded card (16 horizontal margin · NOT edge-to-edge).
    Header is OUTSIDE the card (uppercase labelMedium · letter-spacing 0.5).
    Card bg = surfaceContainerLowest (≈ ColorScheme.surface = #ffffff).
-   Internal dividers between tiles use indent: 52px (= 16 + 20 + 16). */
+   Internal dividers between tiles are full-width inside the card. */
 .more-group { padding: 0 var(--spacing-medium); }
 .more-group + .more-group { margin-top: var(--spacing-large); }
 .more-group__header {
@@ -82,7 +82,7 @@ body.dark-mode .more-group__card { background: var(--color-dark-surface); }
   content: '';
   position: absolute;
   top: 0;
-  left: 52px;  /* 16 (pad) + 20 (icon) + 16 (gap) */
+  left: 0;
   right: 0;
   height: 0.5px;
   background: var(--color-divider);
@@ -288,7 +288,7 @@ body.dark-mode .more-group__card { background: var(--color-dark-surface); }
     <h2>Blueprint &amp; tree</h2>
     <p class="intro">
       Scaffold + <code>MinglitTheme.simpleAppBar(title: '더보기', showBackButton: false)</code> + SafeArea wrap + ListView로 5 그룹 + body padding (top: medium · bottom: xxxlarge — home bar 가림 방지).
-      각 그룹은 <em>padded card</em>: 좌우 16 margin · radius-card 라운드 · 내부 tile 사이 0.5px divider (indent 52).
+      각 그룹은 <em>padded card</em>: 좌우 16 margin · radius-card 라운드 · 내부 tile 사이 0.5px full-width divider.
       그룹 헤더는 카드 <em>바깥</em> 위에 UPPERCASE labelMedium으로 노출.
     </p>
     <div class="layout-grid">
@@ -369,7 +369,7 @@ body.dark-mode .more-group__card { background: var(--color-dark-surface); }
         <tr><td>②</td><td>ProfileGroup</td><td>header 없음 · 단일 _ProfileTile (custom · 48px 보다 큼)</td><td>card h-margin: 16 · _ProfileTile padding: medium all (16) · row gap: medium · MinglitAvatarImage radius 24 (= 48px)</td></tr>
         <tr><td>③–⑥</td><td>SettingsGroup × 4</td><td>header (외부 · UPPERCASE) + tile list (carded)</td><td>그룹 사이: <code>spacing-large (24)</code> · 카드 h-margin: <code>spacing-medium (16)</code> · header v-padding: <code>spacing-small (8)</code> 하단 + <code>spacing-xsmall (4)</code> 좌측 · 카드 radius: <code>radius-card (16)</code></td></tr>
         <tr><td>—</td><td>tile (MinglitSettingsTile)</td><td>row · icon + title-stack + trailing</td><td>height 고정 48 · h-padding: <code>spacing-medium</code> · icon → title gap: <code>spacing-medium (16)</code> · trailing gap: <code>spacing-small (8)</code> · icon size: 20 (<code>MinglitIconSize.small</code>)</td></tr>
-        <tr><td>—</td><td>tile-tile divider</td><td>indent 52 (16+20+16)</td><td>height/thickness 0.5 · color <code>outlineVariant</code></td></tr>
+        <tr><td>—</td><td>tile-tile divider</td><td>들여쓰기 없이 카드 내부 전체 폭</td><td>height/thickness 0.5 · color <code>outlineVariant</code></td></tr>
       </tbody>
     </table>
   </section>
@@ -602,7 +602,7 @@ body.dark-mode .more-group__card { background: var(--color-dark-surface); }
         <tr>
           <td class="state-mini__aspect">토큰</td>
           <td>
-            · color: <code>color-surface</code> (scaffold + AppBar gray), <code>color-background</code> (group card white = surfaceContainerLowest), <code>color-text-primary</code> (title · name), <code>color-text-secondary</code> (subtitle · header · email · icon · chevron = onSurfaceVariant), <code>color-divider</code> (= outlineVariant · 0.5px tile divider · indent 52), <code>color-partner-primary</code> (avatar bg @ 22% · scoped to viewport), <code>color-error</code> (로그아웃 destructive)<br>
+            · color: <code>color-surface</code> (scaffold + AppBar gray), <code>color-background</code> (group card white = surfaceContainerLowest), <code>color-text-primary</code> (title · name), <code>color-text-secondary</code> (subtitle · header · email · icon · chevron = onSurfaceVariant), <code>color-divider</code> (= outlineVariant · 0.5px full-width tile divider), <code>color-partner-primary</code> (avatar bg @ 22% · scoped to viewport), <code>color-error</code> (로그아웃 destructive)<br>
             · spacing: <code>spacing-medium (16)</code> (body top · group h-margin · tile h-padding · row gap), <code>spacing-large (24)</code> (그룹 사이), <code>spacing-small (8)</code> (header bottom · trailing gap), <code>spacing-xsmall (4)</code> (header left), <code>spacing-xxxlarge</code> (body bottom safeArea)<br>
             · radius: <code>radius-card (16)</code> (group card)<br>
             · typography: appBarTitle (18/600), bodyMedium (16 · tile title), bodySmall (13 · subtitle · email), titleMedium (16/700 · profile name), labelMedium (12/500 · UPPERCASE group header · letter-spacing 0.5)<br>
@@ -845,7 +845,7 @@ body.dark-mode .more-group__card { background: var(--color-dark-surface); }
         <tr><th>Route</th><td><code>MoreRoute</code> · <code>/more</code> · <code>MoreBranch</code> (StatefulShell branch 5) · <a href="https://github.com/Mark-Yun/minglit/blob/dev/apps/app_partner/lib/src/routing/app_routes.dart"><code>app_routes.dart</code></a></td></tr>
         <tr><th>Coordinator</th><td><code>moreCoordinatorProvider</code> · <code>more_coordinator.dart</code> — pushPartyList / pushVerificationManage / pushBankAccountManagement / pushMemberList / pushNotificationSettings / pushAccountManagement.</td></tr>
         <tr><th>Auth / Permission gates</th><td>· <code>currentPartnerInfoProvider</code> — async partner profile (loading / error / data / null 분기)<br>· <code>currentMemberPermissionsProvider</code> — owner 폴백 시 <code>['SETTLEMENT_VIEW','SETTLEMENT_EDIT']</code> 자동 부여 (Fix #1568 · Fix #1533 · Fix #1217)<br>· <code>canEditSettlement = permissions.contains('SETTLEMENT_EDIT')</code> — false면 "계좌 관리" tile 미렌더</td></tr>
-        <tr><th>SettingsGroup atom</th><td><a href="/components#MinglitSettingsGroup"><code>MinglitSettingsGroup</code></a> — padded card (h-margin 16) · radius-card · header 외부 UPPERCASE labelMedium · 내부 0.5px divider (indent 52)</td></tr>
+        <tr><th>SettingsGroup atom</th><td><a href="/components#MinglitSettingsGroup"><code>MinglitSettingsGroup</code></a> — padded card (h-margin 16) · radius-card · header 외부 UPPERCASE labelMedium · 내부 0.5px full-width divider</td></tr>
         <tr><th>SettingsTile atom</th><td><a href="/components#MinglitSettingsTile"><code>MinglitSettingsTile</code></a> — height 48 · icon 20 (<code>MinglitIconSize.small</code>) · title + optional subtitle (Column) · trailing: <code>navigation</code>(chevron) / <code>toggle</code> / <code>value</code> / <code>none</code> · destructive (color-error)</td></tr>
         <tr><th>ThemeSettingsTile</th><td>kit-shared widget — 테마 모드 (system / light / dark) 분기 · subtitle = 현재 모드 · icon = 현재 effective brightness 반영 · <a href="https://github.com/Mark-Yun/minglit/blob/dev/shared/packages/minglit_kit/lib/src/features/theme/theme_settings_tile.dart"><code>theme_settings_tile.dart</code></a></td></tr>
         <tr><th>_ProfileTile</th><td>private widget · MinglitAvatarImage(radius:24 · Icons.store fallback · primaryContainer bg) · name (titleMedium/bold) · email (bodySmall/onSurfaceVariant) · chevron — Fix #2069 (캐싱 + 에러 폴백)</td></tr>

--- a/apps/mds/docs/public/specs/more_page/index.md
+++ b/apps/mds/docs/public/specs/more_page/index.md
@@ -34,7 +34,7 @@ simpleAppBar + ListView body의 ProfileGroup + 4 SettingsGroup. 그룹 사이 sp
 
 ## Blueprint & tree
 
-Scaffold + `MinglitTheme.simpleAppBar(title: '더보기', showBackButton: false)` + SafeArea wrap + ListView로 5 그룹 + body padding (top: medium · bottom: xxxlarge — home bar 가림 방지). 각 그룹은 _padded card_: 좌우 16 margin · radius-card 라운드 · 내부 tile 사이 0.5px divider (indent 52). 그룹 헤더는 카드 _바깥_ 위에 UPPERCASE labelMedium으로 노출.
+Scaffold + `MinglitTheme.simpleAppBar(title: '더보기', showBackButton: false)` + SafeArea wrap + ListView로 5 그룹 + body padding (top: medium · bottom: xxxlarge — home bar 가림 방지). 각 그룹은 _padded card_: 좌우 16 margin · radius-card 라운드 · 내부 tile 사이 0.5px full-width divider. 그룹 헤더는 카드 _바깥_ 위에 UPPERCASE labelMedium으로 노출.
 
 ![blueprint](blueprint.png)
 
@@ -47,7 +47,7 @@ Scaffold + `MinglitTheme.simpleAppBar(title: '더보기', showBackButton: false)
 | ② | ProfileGroup | header 없음 · 단일 _ProfileTile (custom · 48px 보다 큼) | card h-margin: 16 · _ProfileTile padding: medium all (16) · row gap: medium · MinglitAvatarImage radius 24 (= 48px) |
 | ③–⑥ | SettingsGroup × 4 | header (외부 · UPPERCASE) + tile list (carded) | 그룹 사이: spacing-large (24) · 카드 h-margin: spacing-medium (16) · header v-padding: spacing-small (8) 하단 + spacing-xsmall (4) 좌측 · 카드 radius: radius-card (16) |
 | — | tile (MinglitSettingsTile) | row · icon + title-stack + trailing | height 고정 48 · h-padding: spacing-medium · icon → title gap: spacing-medium (16) · trailing gap: spacing-small (8) · icon size: 20 (MinglitIconSize.small) |
-| — | tile-tile divider | indent 52 (16+20+16) | height/thickness 0.5 · color outlineVariant |
+| — | tile-tile divider | 들여쓰기 없이 카드 내부 전체 폭 | height/thickness 0.5 · color outlineVariant |
 
 ## SettingsGroup sub-anatomy (per group)
 
@@ -102,7 +102,7 @@ Scaffold + `MinglitTheme.simpleAppBar(title: '더보기', showBackButton: false)
 | 사용자 액션 | ① 프로필 영역 탭 — 계정 관리 화면으로 이동.② 비즈니스 관리 항목 탭 (파티 · 인증 · 계좌 · 멤버) — 각각의 관리 화면으로 이동.③ 알림 설정 / 테마 항목 탭 — 알림 설정 화면으로 이동, 또는 테마 선택 다이얼로그 노출.④ 로그아웃 탭 — 위험 강조 톤의 확인 다이얼로그를 거쳐 로그아웃이 진행됨.⑤ 약관 / 정보 항목 탭 — 외부 브라우저에서 해당 약관 페이지가 열림.⑥ 스크롤 — 화면 아래쪽의 약관·정보 그룹이 노출. |
 | 에지케이스 | · 파트너 정보가 아직 도착하지 않은 동안 멤버 관리 항목을 탭하면 "파트너 정보를 불러오는 중입니다" 안내 메시지가 잠깐 노출됨.· 앱 버전 항목은 탭해도 반응이 없음 — 정보 표시 전용.· 프로필 영역은 다음 세 가지 형태로 변할 수 있음: – 정보를 가져오는 중: 로딩 인디케이터 – 정보 가져오기 실패: 비활성 프로필 영역 + "정보를 불러올 수 없습니다" 안내, 화살표 미노출 – 파트너 정보가 비어있는 경우: 비활성 프로필 영역 + "파트너 정보를 불러올 수 없습니다" 안내 |
 | 컴포넌트 | · MinglitTheme.simpleAppBar(title: '더보기', showBackButton: false)· SafeArea + ListView(EdgeInsets.only top: medium · bottom: xxxlarge) — Fix #1824 / #1803 (home bar 가림 방지)· MinglitSettingsGroup × 5 (header optional · 외부 위치 · padded card)· MinglitSettingsTile × 11 (icon + title-stack + chevron · destructive 분기 · trailing 옵션)· _ProfileTile (private widget · MinglitAvatarImage radius 24 + Icons.store fallback · displayName · email · chevron) — Fix #2069· ThemeSettingsTile (kit-shared · 동적 icon + subtitle · SimpleDialog 라디오)· FutureBuilder<PackageInfo> (앱 버전 tile · package_info_plus)· MinglitAlert.showConfirm (로그아웃 destructive) · launchUrl (약관 외부) |
-| 토큰 | · color: color-surface (scaffold + AppBar gray), color-background (group card white = surfaceContainerLowest), color-text-primary (title · name), color-text-secondary (subtitle · header · email · icon · chevron = onSurfaceVariant), color-divider (= outlineVariant · 0.5px tile divider · indent 52), color-partner-primary (avatar bg @ 22% · scoped to viewport), color-error (로그아웃 destructive)· spacing: spacing-medium (16) (body top · group h-margin · tile h-padding · row gap), spacing-large (24) (그룹 사이), spacing-small (8) (header bottom · trailing gap), spacing-xsmall (4) (header left), spacing-xxxlarge (body bottom safeArea)· radius: radius-card (16) (group card)· typography: appBarTitle (18/600), bodyMedium (16 · tile title), bodySmall (13 · subtitle · email), titleMedium (16/700 · profile name), labelMedium (12/500 · UPPERCASE group header · letter-spacing 0.5)· icon: MinglitIconSize.small (20) |
+| 토큰 | · color: color-surface (scaffold + AppBar gray), color-background (group card white = surfaceContainerLowest), color-text-primary (title · name), color-text-secondary (subtitle · header · email · icon · chevron = onSurfaceVariant), color-divider (= outlineVariant · 0.5px full-width tile divider), color-partner-primary (avatar bg @ 22% · scoped to viewport), color-error (로그아웃 destructive)· spacing: spacing-medium (16) (body top · group h-margin · tile h-padding · row gap), spacing-large (24) (그룹 사이), spacing-small (8) (header bottom · trailing gap), spacing-xsmall (4) (header left), spacing-xxxlarge (body bottom safeArea)· radius: radius-card (16) (group card)· typography: appBarTitle (18/600), bodyMedium (16 · tile title), bodySmall (13 · subtitle · email), titleMedium (16/700 · profile name), labelMedium (12/500 · UPPERCASE group header · letter-spacing 0.5)· icon: MinglitIconSize.small (20) |
 | 노트 | 📝 위 mockup은 5개 그룹을 한 화면에 모두 노출했지만 실제로는 한 번의 스크롤로 마지막 그룹까지 도달함. 라벨은 "정산 계좌 관리" 대신 "계좌 관리"로 통일됨 — 정산 메뉴와 동일한 표기. |
 
 ### Limited permissions · 정산 권한 없는 멤버 비즈니스 관리 그룹에서 "계좌 관리" 한 줄이 빠진 형태
@@ -167,7 +167,7 @@ implementation source + 인접 화면.
 | Route | MoreRoute · /more · MoreBranch (StatefulShell branch 5) · app_routes.dart |
 | Coordinator | moreCoordinatorProvider · more_coordinator.dart — pushPartyList / pushVerificationManage / pushBankAccountManagement / pushMemberList / pushNotificationSettings / pushAccountManagement. |
 | Auth / Permission gates | · currentPartnerInfoProvider — async partner profile (loading / error / data / null 분기)· currentMemberPermissionsProvider — owner 폴백 시 ['SETTLEMENT_VIEW','SETTLEMENT_EDIT'] 자동 부여 (Fix #1568 · Fix #1533 · Fix #1217)· canEditSettlement = permissions.contains('SETTLEMENT_EDIT') — false면 "계좌 관리" tile 미렌더 |
-| SettingsGroup atom | MinglitSettingsGroup — padded card (h-margin 16) · radius-card · header 외부 UPPERCASE labelMedium · 내부 0.5px divider (indent 52) |
+| SettingsGroup atom | MinglitSettingsGroup — padded card (h-margin 16) · radius-card · header 외부 UPPERCASE labelMedium · 내부 0.5px full-width divider |
 | SettingsTile atom | MinglitSettingsTile — height 48 · icon 20 (MinglitIconSize.small) · title + optional subtitle (Column) · trailing: navigation(chevron) / toggle / value / none · destructive (color-error) |
 | ThemeSettingsTile | kit-shared widget — 테마 모드 (system / light / dark) 분기 · subtitle = 현재 모드 · icon = 현재 effective brightness 반영 · theme_settings_tile.dart |
 | _ProfileTile | private widget · MinglitAvatarImage(radius:24 · Icons.store fallback · primaryContainer bg) · name (titleMedium/bold) · email (bodySmall/onSurfaceVariant) · chevron — Fix #2069 (캐싱 + 에러 폴백) |

--- a/apps/mds/docs/public/specs/my_page/index.html
+++ b/apps/mds/docs/public/specs/my_page/index.html
@@ -36,7 +36,7 @@
 /* MinglitSettingsGroup — card with horizontal padding, NOT edge-to-edge.
    Header sits OUTSIDE the card (uppercase labelMedium · letter-spacing 0.5).
    Card bg = surfaceContainerLowest (≈ ColorScheme.surface = #ffffff).
-   Internal dividers between tiles use indent: 52px (= 16 + 20 + 16). */
+   Internal dividers between tiles are full-width inside the card. */
 .my-group {
   padding: 0 var(--spacing-medium);
 }
@@ -77,7 +77,7 @@ body.dark-mode .my-group__card { background: var(--color-dark-surface); }
   content: '';
   position: absolute;
   top: 0;
-  left: 52px;  /* 16 (pad) + 20 (icon) + 16 (gap) */
+  left: 0;
   right: 0;
   height: 0.5px;
   background: var(--color-divider);
@@ -403,7 +403,7 @@ body.dark-mode .my-group__card { background: var(--color-dark-surface); }
         <tr><td>①</td><td>AppBar</td><td>title center · showBackButton: false · scaffold bg · border 없음</td><td>height: 56 · gray bg · <code>surfaceTintColor: transparent</code> · elevation 0</td></tr>
         <tr><td>②</td><td>ProfileGroup</td><td>headerless · 1 tile (_ProfileTile · avatar 48 + name/email + chevron)</td><td>card bg <code>color-background</code> · radius <code>radius-card</code> · h-padding <code>spacing-medium</code> · 탭 영역 전체에 ripple — 탭 시 계정 관리 화면으로 이동</td></tr>
         <tr><td>③–⑥</td><td>SettingsGroup × 4</td><td>헤더 + tile list (그룹 카드)</td><td>그룹 사이: <code>spacing-large (24)</code> · header h-padding: <code>spacing-xsmall</code> · header v-padding: <code>spacing-small (8)</code> · tile h-padding: <code>spacing-medium</code> · tile height: 48 (subtitle 있을 시 56+ 자동)</td></tr>
-        <tr><td>—</td><td>tile-tile divider</td><td>두 번째 tile부터 top hairline 0.5px · indent 52(= padding 16 + icon 20 + gap 16)</td><td><code>color-divider</code> · per-tile</td></tr>
+        <tr><td>—</td><td>tile-tile divider</td><td>두 번째 tile부터 top hairline 0.5px · 들여쓰기 없이 카드 내부 전체 폭</td><td><code>color-divider</code> · per-tile</td></tr>
       </tbody>
     </table>
   </section>
@@ -524,7 +524,7 @@ body.dark-mode .my-group__card { background: var(--color-dark-surface); }
         <tr>
           <td class="state-mini__aspect">토큰</td>
           <td>
-            · color: <code>color-surface</code> (scaffold bg), <code>color-background</code> (그룹 카드 surface), <code>color-text-primary</code> (tile title · profile name), <code>color-text-secondary</code> (subtitle · email · 그룹 헤더 · chevron · leading icon), <code>color-divider</code> (tile 사이 indent hairline), <code>color-primary</code> (avatar bg)<br>
+            · color: <code>color-surface</code> (scaffold bg), <code>color-background</code> (그룹 카드 surface), <code>color-text-primary</code> (tile title · profile name), <code>color-text-secondary</code> (subtitle · email · 그룹 헤더 · chevron · leading icon), <code>color-divider</code> (tile 사이 full-width hairline), <code>color-primary</code> (avatar bg)<br>
             · spacing: <code>spacing-medium</code> (16 · body v-padding · 그룹 h-padding · tile h-padding · icon ↔ title gap), <code>spacing-large</code> (24 · 그룹 사이 gap), <code>spacing-small</code> (8 · 헤더 v-padding · subtitle tile padding), <code>spacing-xsmall</code> (헤더 h-padding)<br>
             · radius: <code>radius-card</code> (그룹 카드 corner)<br>
             · typography: appBarTitle (18/600), 그룹 헤더(13 · 500 · uppercase · letter-spacing 0.5), tile title (14), tile subtitle (12), profile name (16/700), profile email (12)

--- a/apps/mds/docs/public/specs/my_page/index.md
+++ b/apps/mds/docs/public/specs/my_page/index.md
@@ -47,7 +47,7 @@ Scaffold + AppBar (간단 title only · "마이페이지") + ListView 또는 Sin
 | ① | AppBar | title center · showBackButton: false · scaffold bg · border 없음 | height: 56 · gray bg · surfaceTintColor: transparent · elevation 0 |
 | ② | ProfileGroup | headerless · 1 tile (_ProfileTile · avatar 48 + name/email + chevron) | card bg color-background · radius radius-card · h-padding spacing-medium · 탭 영역 전체에 ripple — 탭 시 계정 관리 화면으로 이동 |
 | ③–⑥ | SettingsGroup × 4 | 헤더 + tile list (그룹 카드) | 그룹 사이: spacing-large (24) · header h-padding: spacing-xsmall · header v-padding: spacing-small (8) · tile h-padding: spacing-medium · tile height: 48 (subtitle 있을 시 56+ 자동) |
-| — | tile-tile divider | 두 번째 tile부터 top hairline 0.5px · indent 52(= padding 16 + icon 20 + gap 16) | color-divider · per-tile |
+| — | tile-tile divider | 두 번째 tile부터 top hairline 0.5px · 들여쓰기 없이 카드 내부 전체 폭 | color-divider · per-tile |
 
 🎨
 
@@ -67,7 +67,7 @@ Scaffold + AppBar (간단 title only · "마이페이지") + ListView 또는 Sin
 | 사용자 액션 | ① 프로필 영역 탭 — 계정 관리 화면으로 이동(본인인증 · 파트너 프로필 · 로그아웃 · 회원 탈퇴는 그 안에서).② 각 settings tile 탭 — 해당 하위 settings 화면으로 이동.③ 스크롤 — 화면 아래쪽의 약관·정보 그룹이 노출.④ 뒤로 가기 — 홈으로 복귀. |
 | 에지케이스 | · 앱 버전 tile은 탭해도 반응이 없음 — 정보 표시 전용.· 아직 준비되지 않은 일부 tile은 탭 시 "구현 준비 중" 안내 메시지가 잠깐 나타남.· 계정 관리 / 로그아웃 / 회원 탈퇴는 마이페이지에 별도 tile로 노출되지 않음 — 상단 프로필 영역 탭으로만 진입. |
 | 컴포넌트 | · MinglitTheme.simpleAppBar(title: '마이페이지', showBackButton: false)· ListView + EdgeInsets.symmetric(vertical: MinglitSpacing.medium)· _ProfileTile (private widget · CircleAvatar radius 24 + Icons.person fallback · displayName · email · Icons.chevron_right · 탭 시 계정 관리 화면으로 push)· MinglitSettingsGroup × 6 (1 ProfileGroup + 5 SettingsGroup · header + tile list · 그룹 카드)· MinglitSettingsTile (leading icon + title + optional subtitle + chevron · destructive variant · trailing 옵션)· ThemeSettingsTile (별도 widget · 테마 설정 tile — 시스템/dark/light 분기)· FutureBuilder<PackageInfo> (앱 버전 tile — packageInfoFromPlatform)· PopScope (시스템 back → homeCoordinator.goToHome()) |
-| 토큰 | · color: color-surface (scaffold bg), color-background (그룹 카드 surface), color-text-primary (tile title · profile name), color-text-secondary (subtitle · email · 그룹 헤더 · chevron · leading icon), color-divider (tile 사이 indent hairline), color-primary (avatar bg)· spacing: spacing-medium (16 · body v-padding · 그룹 h-padding · tile h-padding · icon ↔ title gap), spacing-large (24 · 그룹 사이 gap), spacing-small (8 · 헤더 v-padding · subtitle tile padding), spacing-xsmall (헤더 h-padding)· radius: radius-card (그룹 카드 corner)· typography: appBarTitle (18/600), 그룹 헤더(13 · 500 · uppercase · letter-spacing 0.5), tile title (14), tile subtitle (12), profile name (16/700), profile email (12) |
+| 토큰 | · color: color-surface (scaffold bg), color-background (그룹 카드 surface), color-text-primary (tile title · profile name), color-text-secondary (subtitle · email · 그룹 헤더 · chevron · leading icon), color-divider (tile 사이 full-width hairline), color-primary (avatar bg)· spacing: spacing-medium (16 · body v-padding · 그룹 h-padding · tile h-padding · icon ↔ title gap), spacing-large (24 · 그룹 사이 gap), spacing-small (8 · 헤더 v-padding · subtitle tile padding), spacing-xsmall (헤더 h-padding)· radius: radius-card (그룹 카드 corner)· typography: appBarTitle (18/600), 그룹 헤더(13 · 500 · uppercase · letter-spacing 0.5), tile title (14), tile subtitle (12), profile name (16/700), profile email (12) |
 | 노트 | 📝 위 mockup은 프로필 ~ 개인정보·보안 그룹까지만 보임. 실제 화면에서는 약관·정보 그룹은 스크롤로 확인 가능. 계정 관리는 별도 그룹이 아닌 상단 프로필 영역 탭으로 진입. |
 
 ### Logged out · 비로그인 로그인이 필요한 안내 화면이 노출되는 상태

--- a/apps/mds/docs/src/components/specs/MinglitSettingsGroupSpec.tsx
+++ b/apps/mds/docs/src/components/specs/MinglitSettingsGroupSpec.tsx
@@ -9,7 +9,7 @@
  *   - 카드 좌우 horizontal padding (medium = 16) — scaffold edge에서 떨어진 모양
  *   - radius-card (16) · surfaceContainerLowest 배경 (라이트모드 흰색)
  *   - 카드 위에 헤더 라벨 (uppercase · letter-spacing 0.5 · 회색)
- *   - 카드 안의 행 사이에 0.5px 얇은 선 (좌측 indent 52 = 16 padding + 20 icon + 16 gap)
+ *   - 카드 안의 행 사이에 0.5px 얇은 선 (들여쓰기 없이 카드 내부 전체 폭)
  *   - 카드의 둥근 모서리 안쪽으로 콘텐츠가 깔끔히 잘림
  */
 
@@ -129,7 +129,6 @@ function SettingsGroupDemo({
               <div
                 style={{
                   height: 0.5,
-                  marginLeft: 52,
                   background: 'var(--color-divider)',
                 }}
               />
@@ -181,7 +180,7 @@ export default function MinglitSettingsGroupSpec() {
           { text: 'spacing-medium → 카드 좌우 padding (16)', style: { top: 12, left: '50%', transform: 'translateX(-50%)' } },
           { text: 'header (uppercase · 회색 · letter-spacing 0.5)', style: { top: 60, right: 8 } },
           { text: 'radius-card (16) · 카드 모서리', style: { bottom: 80, right: 8 } },
-          { text: 'divider 0.5px · indent 52 (icon 폭만큼 들여쓰기)', style: { bottom: 12, left: 8 } },
+          { text: 'divider 0.5px · full-width', style: { bottom: 12, left: 8 } },
         ]}
       />
 

--- a/shared/packages/mds/core/lib/src/ui/widgets/common/minglit_settings_group.dart
+++ b/shared/packages/mds/core/lib/src/ui/widgets/common/minglit_settings_group.dart
@@ -64,7 +64,6 @@ class MinglitSettingsGroup extends StatelessWidget {
                     Divider(
                       height: 0.5,
                       thickness: 0.5,
-                      indent: 52, // 16 (pad) + 20 (icon) + 16 (gap)
                       color: colorScheme.outlineVariant,
                     ),
                 ],


### PR DESCRIPTION
## Summary
- remove the 52px left indent from MinglitSettingsGroup internal dividers
- update MDS SettingsGroup, MyPage, and MorePage specs to define full-width dividers
- keep generated public spec HTML aligned with markdown specs

## Verification
- dart format shared/packages/mds/core/lib/src/ui/widgets/common/minglit_settings_group.dart
- flutter test (shared/packages/mds/core)
- graphify update .

## Notes
- npm --prefix apps/mds/docs run lint could not run locally because eslint is not installed in node_modules.