### PR TITLE
docs: update branch strategy release flow

### DIFF
--- a/docs/infra/branch-strategy/BLUEDOC.md
+++ b/docs/infra/branch-strategy/BLUEDOC.md
@@ -1,12 +1,12 @@
 # Branch Strategy
 
-4-stage (`dev-staging → dev → rc → main`) + merge queue + nightly snapshot + `rc-gate` green build picking + feature flag + 3가지 safety net. AI agent 가 dev-staging commit, **dev rc-gate-pass 는 main-staging env (staging Supabase) 로 deploy**, main 머지에서 backend + mobile 모두 prod 로 deploy (hotfix 없으면 weekly). 모든 cadence = target, slip 자연스러움.
+4-stage (`dev-staging → dev → rc → main`) + 일반 PR/auto-merge + nightly snapshot + `rc-gate` green build picking + feature flag + 3가지 safety net. AI agent 가 dev-staging 에 PR, **dev rc-gate-pass 는 main-staging env (staging Supabase) 로 deploy**, main 머지에서 backend + mobile 모두 prod 로 deploy (hotfix 없으면 weekly). 모든 cadence = target, slip 자연스러움.
 
 ## 4-stage 모델
 
 | 단계 | 역할 | 진입 방식 |
 |------|------|-----------|
-| `dev-staging` | AI agent commit zone | merge queue + 가벼운 `pr-gate` |
+| `dev-staging` | AI agent commit zone | 일반 PR + auto-merge + 가벼운 `pr-gate` |
 | `dev` | nightly-validated trunk | daily `nightly-cut` → post-merge `rc-gate` |
 | `rc/YYYY-Wxx` | mobile RC, 5일 soak | weekly cut from latest rc-gate-pass |
 | `main` | mobile-stable snapshot | rc → main 머지 (soak 통과 시) |
@@ -26,7 +26,7 @@
 | [branch-flow.md](./branch-flow.md) | flow + protection + tag + backport |
 | [test-strategy.md](./test-strategy.md) | per-stage gates |
 | [error-detection.md](./error-detection.md) | detection layers |
-| [dev-staging-pipeline.md](./dev-staging-pipeline.md) | merge queue + pr-gate + safety net CI |
+| [dev-staging-pipeline.md](./dev-staging-pipeline.md) | 일반 PR/auto-merge + pr-gate + safety net CI |
 | [dev-pipeline.md](./dev-pipeline.md) | nightly-cut + rc-gate + auto-deploy chain |
 | [rc-promotion.md](./rc-promotion.md) | rc-cut + soak + hotfix + backport |
 | [main-promotion.md](./main-promotion.md) | rc → main + deploy-android-*, deploy-ios-* + min-version |
@@ -42,6 +42,7 @@
 
 - 코드 promotion = 한 방향 PR, 기능 promotion = flag flip
 - 모든 branch linear ON — dev-staging: squash, dev/rc/main: rebase
+- Protected branch 직접 push 는 human 금지. version bump/tag/promotion 처리는 `minglit-release-bot` 전용 token + Ruleset bypass 로만 허용
 - dev rc-gate-pass = backend/web → **main-staging env** deploy (사용자 서버 영향 X); main 머지 = backend + mobile 모두 prod deploy
 - **Hotfix 는 rc 에서, dev-staging 으로 자동 backport** ([rc-promotion.md](./rc-promotion.md))
 - Tag regex 는 `RELEASE.md` lock (TODO)

--- a/docs/infra/branch-strategy/branch-flow.md
+++ b/docs/infra/branch-strategy/branch-flow.md
@@ -5,7 +5,7 @@
 ## 흐름 다이어그램
 
 ```
-  agents ──merge queue──▶ dev-staging
+  agents ──PR + auto-merge──▶ dev-staging
                               │
                               └─daily nightly-cut snapshot──▶ dev
                                                               │
@@ -44,21 +44,21 @@ rc/* hotfix 머지 ──auto cherry-pick──▶ backport-branch ──PR─�
 
 | 머지 방향 | base ← head | 트리거 | 머지 방식 | 요구 체크 |
 |-----------|-------------|--------|-----------|-----------|
-| feature/agent → dev-staging | `dev-staging` ← `feat/*`, `fix/*`, `chore/*`, `docs/*` | merge queue enqueue | **squash** (queue) | `dev-staging-pr-gate` |
+| feature/agent → dev-staging | `dev-staging` ← `feat/*`, `fix/*`, `chore/*`, `docs/*` | PR + auto-merge | **squash** | `dev-staging-pr-gate` |
 | dev-staging → dev | `dev` ← `dev-staging` | daily cron `nightly-cut` | merge (snapshot) | `nightly-pr-gate` |
 | hotfix → rc | `rc/YYYY-Wxx` ← hotfix branch | hotfix only | rebase | `rc-pr-gate` |
-| rc → main | `main` ← `rc/YYYY-Wxx` | `rc-soak-check` 가 5일 무커밋 시 PR 생성 + auto-merge | rebase + ff | `main-pr-gate` + `rc-soak-passed` |
+| rc → main | `main` ← `rc/YYYY-Wxx` | `rc-soak-check` 가 5일 무커밋 시 PR 생성 + auto-merge | rebase + ff | `main-pr-gate` |
 
 ## Branch Protection 설정
 
 | 브랜치 | direct push | linear | required check | merge 종류 |
 |--------|-------------|--------|----------------|------------|
-| `dev-staging` | 금지 | **ON** | `dev-staging-pr-gate` + merge queue | squash |
+| `dev-staging` | 금지 (release bot 예외) | **ON** | `dev-staging-pr-gate` | squash |
 | `dev` | 금지 | **ON** | `nightly-pr-gate` | merge (snapshot) |
 | `rc/YYYY-Wxx` | 금지 | **ON** | `rc-pr-gate` | rebase |
-| `main` | 금지 | **ON** | `main-pr-gate` + `rc-gate-pass` (RC HEAD) + `expand-migrate-contract` + `rc-soak-passed` | rebase |
+| `main` | 금지 (release bot 예외) | **ON** | `main-pr-gate` | rebase |
 
-Hybrid linear history 금지 — 각 branch 내 일관 (squash or rebase 한 가지).
+Hybrid linear history 금지 — 각 branch 내 일관 (squash or rebase 한 가지). Protected branch 직접 push 는 `minglit-release-bot` 의 version bump/tag/promotion commit 에만 Ruleset bypass 로 허용한다.
 
 ## Promotion Tag 컨벤션
 
@@ -116,7 +116,6 @@ main-post-merge-promote (on push to main):
 ## 결정해야 할 것
 
 - 주간 rc-cut 요일
-- merge queue 모드 (concurrent vs serial)
 - Fastlane / store upload 설정
 - `RELEASE.md` 작성
 

--- a/docs/infra/branch-strategy/dev-pipeline.md
+++ b/docs/infra/branch-strategy/dev-pipeline.md
@@ -98,8 +98,8 @@ Snapshot 모델 — **auto-revert 없음**. dev 가 broken 상태로 잠시 머�
 
 ### `deploy-vercel`
 
-- Vercel deploy hooks 4앱 (app_user, app_partner, landing_user, landing_partner)
-- 현재 cron 2시간 → push-event 기반으로 교체
+- Vercel native build 사용. `dev` 는 preview deployment, `main` 은 production deployment
+- 기존 cron/deploy hook 워크플로우는 전환 완료 후 폐기
 - 실패 시: retry 1회 → 실패 시 P0 이슈
 
 ## Artifact / 보존
@@ -112,7 +112,7 @@ Snapshot 모델 — **auto-revert 없음**. dev 가 broken 상태로 잠시 머�
 - nightly-cut cron 시각
 - backoff 임계 (3회 차단이 적정한가)
 - CUJ chaos 시나리오 정의 (현재 미정의)
-- ephemeral Supabase branch (RC 마다 새로 vs 단일 공유)
+- Supabase RC branch TTL / seed data 정책
 - rc-gate selective run 도입 시점
 
 ## 관련

--- a/docs/infra/branch-strategy/dev-staging-pipeline.md
+++ b/docs/infra/branch-strategy/dev-staging-pipeline.md
@@ -1,42 +1,40 @@
 # Dev-Staging Pipeline
 
-AI agent 와 feature/fix/chore PR 이 `dev-staging` 브랜치로 들어오는 진입점. merge queue 가 직렬 처리하고, `dev-staging-pr-gate` 가 가벼운 검증, 머지 후 `dev-staging-post-merge-sync` 가 version bump.
+AI agent 와 feature/fix/chore PR 이 `dev-staging` 브랜치로 들어오는 진입점. 일반 PR + auto-merge 로 처리하고, `dev-staging-pr-gate` 가 가벼운 검증, 머지 후 `dev-staging-post-merge-sync` 가 release bot 권한으로 version bump.
 
 ## 두 가지 workflow
 
-1. **`dev-staging-pr-gate`** — PR 머지 전 (merge queue 가 각 PR rebase 후 실행)
+1. **`dev-staging-pr-gate`** — PR 머지 전
 2. **`dev-staging-post-merge-sync`** — PR 머지 직후 (version bump + tag)
 
-## Merge Queue
+## PR + Auto-Merge
 
-GitHub merge queue 가 `dev-staging` 의 PR 을 직렬 처리:
+초기 모델에서는 merge queue 를 쓰지 않는다. PR 은 `dev-staging-pr-gate` 통과 후 auto-merge 로 squash merge 된다. base drift 는 strict status checks 와 자동 branch update 로 처리한다.
 
 ```
-[PR enqueue]
+[PR open]
     ↓
-[PR base 를 최신 dev-staging HEAD 로 rebase]
+[dev-staging-pr-gate]
     ↓
-[dev-staging-pr-gate 재실행 (rebased state)]
+[auto-merge 대기]
+    ↓
+[base drift 발생 시 branch update 후 gate 재실행]
     ↓
 [통과 시 squash merge to dev-staging]
     ↓
 [dev-staging-post-merge-sync 자동 발동]
-    ↓
-[다음 PR 처리]
 ```
 
-### 왜 merge queue
+### 왜 merge queue 를 보류하나
 
-- Master-green 유지 (Uber Submit Queue: 99%+)
-- Drift / conflict accumulation 회피
-- AI agent 가 동시 다발 PR 작성해도 안전하게 직렬 처리
-- "Update branch" 수동 작업 제거
+- 현재 PR 동시성/충돌 빈도 데이터를 먼저 본다
+- 운영 복잡도를 낮추고 기존 GitHub auto-merge 흐름을 재사용한다
+- 필요해지면 `dev-staging` 에만 merge queue 를 후속 도입한다
 
 ### 결정해야 할 것
 
-- 모드 (concurrent vs serial)
-- queue stuck 시 escalation
-- 도입 단계 (전체 vs 점진)
+- branch update 자동화 방식 (`gh api update-branch` vs 기존 sync-pr-branches 재사용)
+- merge queue 도입 기준 (동시 PR 수, conflict 빈도, stale 재실행 비용)
 
 ## `dev-staging-pr-gate`
 
@@ -94,15 +92,17 @@ PR 머지 직후 자동 발동.
 4. git push (tag + commit)
 ```
 
+`git push` 는 human 권한이 아니라 `minglit-release-bot` 전용 token 으로 실행한다. Ruleset bypass 는 이 bot actor 에만 부여하고, workflow permission 은 `contents: write` 및 tag/status 갱신에 필요한 최소 권한으로 제한한다.
+
 Tag `v{ver}-dev-staging` 는 다음 단계의 `nightly-cut` workflow 가 query 해서 "가장 최근 dev-staging 의 coherent snapshot" 찾는 데 사용.
 
 > **구현 디테일**: bump 커밋이 별도로 만들어지는 게 깔끔 vs squash 커밋에 inline 시키는 게 깔끔 — workflow 디자인 결정 (TBD).
 
 ## Error-Backoff
 
-**Workflow infra 실패** (merge queue 다운, runner 다운, script 에러) → **P0 이슈** + on-call.
+**Workflow infra 실패** (runner 다운, script 에러, release bot push 실패) → **P0 이슈** + on-call.
 
-**Test 실패** (PR 단위) → queue 가 PR drop + 작성자 알림. 작성자 fix → re-queue.
+**Test 실패** (PR 단위) → auto-merge 보류 + 작성자 알림. 작성자 fix → re-run.
 
 ### `expand-migrate-contract` false positive
 
@@ -112,7 +112,7 @@ destructive pattern 검출이 too aggressive 한 경우:
 
 ## 결정해야 할 것
 
-- merge queue 모드 (concurrent / serial)
+- branch update 자동화 방식
 - `expand-migrate-contract` 의 6-month-old schema 보관 위치
 - `flag-registration` AST 도구 (analyzer / 자체 / Semgrep?)
 - version bump commit 별도 vs inline

--- a/docs/infra/branch-strategy/error-detection.md
+++ b/docs/infra/branch-strategy/error-detection.md
@@ -7,7 +7,7 @@
 | Stage | Detection 도구 | 잡는 에러 | Latency |
 |-------|----------------|----------|---------|
 | 개발자 로컬 | LSP, analyze, unit | 컴파일/타입/단위 | 초~분 |
-| dev-staging merge queue | `dev-staging-pr-gate` (unit, lint, pgTAP, EF, migration, `expand-migrate-contract`, `flag-registration`, gitleaks) | PR 회귀, 보안, migration 충돌, flag 미등록, contract 위반 | < 10분 |
+| dev-staging PR gate | `dev-staging-pr-gate` (unit, lint, pgTAP, EF, migration, `expand-migrate-contract`, `flag-registration`, gitleaks) | PR 회귀, 보안, migration 충돌, flag 미등록, contract 위반 | < 10분 |
 | nightly-cut PR | `nightly-pr-gate` (defensive) | 환경 차이 회귀 | < 10분 |
 | dev 머지 후 (자동) | `rc-gate` (CUJ matrix happy/unhappy/chaos, integration, e2e, Test Lab) | 통합 회귀, 시나리오, 외부 의존, 디바이스 | 30-60분 |
 | Backend/Web auto-deploy | post-deploy smoke, Sentry release marker | deploy infra 회귀 | 분 |
@@ -52,7 +52,7 @@
 
 | Detection 신호 | 누가 받음 | 어디서 | Action |
 |---------------|----------|--------|--------|
-| pr-gate 실패 (어느 단계든) | PR 작성자 | GitHub PR | 본인 fix → re-push → re-queue |
+| pr-gate 실패 (어느 단계든) | PR 작성자 | GitHub PR | 본인 fix → re-push → auto-merge 재대기 |
 | `rc-gate` 실패 (dev 머지 후) | 직전 rc-gate-pass 이후 머지된 PR 작성자들 + AI agent | GitHub issue + Slack `#nightly` | AI agent fix PR via dev-staging — dev keeps moving ([dev-pipeline.md](./dev-pipeline.md)) |
 | Backend/web staging deploy 실패 (dev rc-gate-pass) | on-call | Slack `#release` | retry → P0 이슈, RC 진행 차단 (staging 도달 못함) |
 | Backend/web/mobile prod deploy 실패 (main 머지) | on-call | Slack `#release` | retry → rollback ([main-promotion.md](./main-promotion.md) error-backoff) |

--- a/docs/infra/branch-strategy/main-promotion.md
+++ b/docs/infra/branch-strategy/main-promotion.md
@@ -18,7 +18,7 @@
 | RC HEAD 의 `rc-gate-pass` status 확인 | 마지막 hotfix 이 rc-gate 통과했는지 |
 | `rc-soak-passed` 자동 마커 | rc-soak-check 가 5일 무커밋 확인 후 부여 |
 
-**모든 check 통과 시 workflow 가 auto-merge** (rebase + fast-forward). 어느 하나라도 실패 시 PR hold + Slack 알림 → human 개입 (edge case).
+GitHub Ruleset 의 required check 는 `main-pr-gate` 하나로 둔다. `rc-gate-pass`, `expand-migrate-contract`, `rc-soak-passed` 는 PR head SHA 와 별도 commit/label 상태가 섞일 수 있으므로 `main-pr-gate` 내부 검증으로 처리한다. 모든 check 통과 시 workflow 가 auto-merge (rebase + fast-forward) 한다. 어느 하나라도 실패 시 PR hold + Slack 알림 → human 개입 (edge case).
 
 ## `main-post-merge-promote`
 
@@ -37,9 +37,10 @@ auto-merge 직후 자동 (promote + prod deploy chain):
    - deploy-android-{user,partner}
    - deploy-ios-{user,partner}
    - (Vercel: native build 가 main push 자동 감지)
+9. RC Supabase branch 삭제 + active RC marker 제거
 ```
 
-> Backend/web deploy 는 main 에서 안 함 — dev 의 rc-gate-pass 에서 이미 prod 반영됨. Mobile deploy 는 별도 workflow.
+> Backend/web staging deploy 는 dev 의 rc-gate-pass 에서 수행되고, backend/web prod deploy 는 main 머지 후 수행한다. Mobile deploy 는 main push 이후 별도 workflow 로 수행한다.
 
 ## 기존 Mobile Deploy Workflows (재사용)
 

--- a/docs/infra/branch-strategy/rc-promotion.md
+++ b/docs/infra/branch-strategy/rc-promotion.md
@@ -1,6 +1,6 @@
 # RC Promotion
 
-`rc/YYYY-Wxx` 브랜치의 lifecycle: weekly cut from dev 의 `rc-gate-pass` commit, 5일 soak (hotfix 시 시계 리셋), soak 통과 시 main 으로 머지.
+`rc/YYYY-Wxx` 브랜치의 lifecycle: weekly cut from dev 의 `rc-gate-pass` commit, RC 전용 Supabase branch 생성, 5일 soak (hotfix 시 시계 리셋), soak 통과 시 main 으로 머지 후 RC branch 정리.
 
 ## 4가지 workflow
 
@@ -16,18 +16,21 @@
 - **cron**: 매주 X 요일 KST 10:00 (TBD)
 - **manual**: `workflow_dispatch` (긴급 cut)
 - 동작:
-  1. **현재 `rc/*` 살아있는지 확인** → 있으면 skip + Slack `#release` 알림 (이전 RC 가 hotfix 로 길어지는 중)
+  1. **active RC marker 확인** → 있으면 skip + Slack `#release` 알림 (이전 RC 가 hotfix 로 길어지는 중)
   2. 없으면 dev 의 최신 `rc-gate-pass` status 부여된 commit 찾기 (GitHub API: `GET /repos/.../commits/{sha}/status`)
   3. 못 찾으면 (3일+ green 없음) → alert + cut 보류
   4. 찾았으면 그 commit 에서 `rc/YYYY-Wxx` branch cut
-  5. `bump-version.sh {ver}-rc-01` 실행 → tag `v{ver}-rc-01` + `promo/rc-YYYY-Wxx`
-  6. Branch protection 활성화 (direct push 금지, cherry-pick PR 만)
-  7. Slack `#release` 알림 + soak 시작
+  5. Supabase branch 생성 (`rc-YYYY-Wxx`) + RC env 에 migration/EF deploy
+  6. `bump-version.sh {ver}-rc-01` 실행 → tag `v{ver}-rc-01` + `promo/rc-YYYY-Wxx`
+  7. Branch protection 활성화 (direct push 금지, hotfix PR 만)
+  8. active RC marker 기록 + Slack `#release` 알림 + soak 시작
 
 ### Cron 슬립 처리
 
-- "현재 `rc/*` 살아있음" → skip + 다음 주 cron 까지 대기
+- "active RC marker 있음" → skip + 다음 주 cron 까지 대기
 - "rc-gate-pass commit 없음 (3일+)" → cut 보류 + alert (운영자 개입 필요)
+
+`rc/*` git branch 는 릴리즈 이력 보존 수단이 아니다. RC 종료 후 삭제할 수 있으며, 이력은 `promo/rc-*`, `v*-rc-*`, `promo/main-*` protected tag 로 보존한다.
 
 ## `rc-pr-gate`
 
@@ -47,6 +50,7 @@ Hotfix PR 머지 직후 자동:
 2. git commit -m "chore: bump RC version [skip ci]"
 3. git tag v{ver}-rc-NN
 4. git push
+5. RC Supabase branch 에 migration/EF 재적용
 ```
 
 **Soak 시계 자동 리셋** — 새 commit 의 committer date 가 최신이므로 `rc-soak-check` 가 자연스럽게 카운트 다시 시작.
@@ -79,7 +83,7 @@ Mark 님 직감대로 hotfix loop 으로 RC lifecycle 이 길어지는 게 일�
 |------|------|
 | 누적 회귀 | rc 의 nightly 재실행 (선택 — RC 별도 nightly schedule TBD) |
 | 내부 dogfooding | 내부 직원 cohort 가 `_rc-NN` 빌드 사용 |
-| Real-data 이슈 | rc 의 supabase staging branch (단일 공유 branch, 5일 후 reset) |
+| Real-data 이슈 | RC 전용 Supabase branch (`rc-YYYY-Wxx`) |
 | 외부 의존성 동작 (실 결제, 실 메시지) | 내부 사용자가 실제로 사용해보며 검증 |
 
 ## Hotfix 경로
@@ -124,24 +128,31 @@ RC 는 dev-staging 에서 cut 됐지만 RC 가 사는 동안 dev-staging 이 앞
 - AI 가 resolve 후 push
 - pr-gate 통과 시 머지
 
+`rc-hotfix-backport` 는 hotfix PR 의 merged commits 만 cherry-pick 한다. `rc-post-merge-sync` 가 만든 version bump commit 은 backport 대상에서 제외한다.
+
 ### Mobile 의 backport 불필요
 
 Mobile 은 release branch 없음 (main 머지 마다 `deploy-android-*, deploy-ios-*` 가 직접 build + store upload). 따라서 mobile-specific backport 흐름 없음. mobile 의 모든 hotfix 는 dev-staging → ... → rc → main 의 정상 흐름을 따라 다음 main push 시 mobile deploy workflow 들이 자동 반영.
 
-## Supabase Staging Branch (RC 의 backend 검증용)
+## Supabase Branching (RC 의 backend 검증용)
 
-**전략**: 단일 영구 supabase staging branch 를 모든 RC 가 공유 (RC merge to main 시점에 reset).
+**전략**: RC 마다 Supabase branch 를 생성하고, RC 종료 시 삭제한다. 단일 공유 staging branch 는 RC soak 와 dev continuous deploy 가 서로 오염될 수 있으므로 사용하지 않는다.
 
-- 비용 절감 (RC 마다 새 branch 안 만듬)
-- 복잡도 낮음 (sync 디테일 단순)
-- expand-migrate-contract CI 가 PR 시점에 destructive 검증 → 5일 소크 시점 추가 보호
+### Lifecycle
 
-이전: RC 마다 ephemeral branch — runtime 가격 누적, 복잡.
-지금: 1 branch 영구 운영. RC merge to main → DB reset → 다음 RC 가 깨끗한 상태에서 시작.
+| 시점 | 동작 |
+|------|------|
+| `rc-cut` | Supabase branch `rc-YYYY-Wxx` 생성, RC SHA 기준 migration/EF deploy |
+| RC soak | 내부 dogfooding 과 real-data 검증은 해당 RC branch 로만 수행 |
+| hotfix merge | 같은 RC Supabase branch 에 migration/EF 재적용 |
+| rc → main 완료 | prod deploy 후 RC Supabase branch 삭제 |
+| RC abandon | RC Supabase branch 삭제 + active RC marker 제거 |
+
+dev 의 `rc-gate-pass` 는 계속 `main-staging` env 로 deploy 된다. RC soak 는 `rc-YYYY-Wxx` branch 를 사용하므로 dev 의 후속 green commit 과 섞이지 않는다.
 
 ### 결정해야 할 것
 
-- staging branch reset 시점 정확화 (main 머지 직후 / 다음 rc-cut 직전)
+- Supabase branch TTL / 비용 알림
 - staging branch 의 seed data 정책
 
 ## Error-Backoff 정책
@@ -154,14 +165,14 @@ Mobile 은 release branch 없음 (main 머지 마다 `deploy-android-*, deploy-i
 |--------|------|
 | Minor (UI, edge case) | hotfix PR → rc-post-merge-sync → soak 시계 리셋 |
 | Critical (crash, data loss) | flag 로 즉시 OFF (코드 release 와 분리 — life-of-flag 참고) + hotfix PR 병행 |
-| Catastrophic (전체 깨짐) | RC abandon — branch 삭제, 다음 weekly cut 새로 시작 (작업 손실) |
+| Catastrophic (전체 깨짐) | RC abandon — git rc branch + Supabase branch 삭제, active marker 제거, 다음 weekly cut 새로 시작 |
 
 ## 결정해야 할 것
 
 - weekly rc-cut 요일
 - rc-soak-check daily cron 시각
 - RC 자체 nightly 별도 schedule 여부
-- staging supabase branch reset 정책
+- Supabase RC branch TTL / seed data 정책
 - RC abandon 의 명확한 기준
 
 ## 관련

--- a/docs/infra/branch-strategy/specs/BLUEDOC.md
+++ b/docs/infra/branch-strategy/specs/BLUEDOC.md
@@ -11,7 +11,7 @@ design 문서는 운영자 관점 (cadence, role, policy). spec 문서는 구현
 | 문서 | 내용 |
 |------|------|
 | [workflow-spec.md](./workflow-spec.md) | `.github/workflows/` 의 reusable + entry workflow 의 trigger / input / output / steps / call chain |
-| [branch-spec.md](./branch-spec.md) | 각 branch 의 protection rule, required check, merge method, merge queue 구현 설정값 |
+| [branch-spec.md](./branch-spec.md) | 각 branch 의 protection rule, required check, merge method, release bot bypass 설정값 |
 | [execution-plan.md](./execution-plan.md) | 현재 workflow 인벤토리, refactor / 신규 / 폐기, Phase 1~4 적용 순서 |
 | [secret-migration-plan.md](./secret-migration-plan.md) | GH secrets → minglit_env/{stage}/.env 단일 파일 통합 plan |
 

--- a/docs/infra/branch-strategy/specs/branch-spec.md
+++ b/docs/infra/branch-strategy/specs/branch-spec.md
@@ -1,6 +1,6 @@
 # Branch Spec
 
-각 branch 의 protection rule, required status check, merge method, merge queue 설정의 구현 명세. GitHub Branch Protection / Ruleset API 로 직접 매핑 가능한 구체 값. [workflow-spec.md](./workflow-spec.md) 와 cross-reference.
+각 branch 의 protection rule, required status check, merge method, release bot bypass 설정의 구현 명세. GitHub Branch Protection / Ruleset API 로 직접 매핑 가능한 구체 값. [workflow-spec.md](./workflow-spec.md) 와 cross-reference.
 
 ## 명명 컨벤션
 
@@ -8,7 +8,7 @@
 |------------------|------|------|
 | `dev-staging` | 영구 | yes |
 | `dev` | 영구 | yes |
-| `rc/YYYY-Wxx` | 임시 (weekly cut, RC → main 머지 후 archive) | yes (pattern protection) |
+| `rc/YYYY-Wxx` | 임시 (weekly cut, RC → main 머지 후 삭제, 이력은 tag 보존) | yes (pattern protection) |
 | `main` | 영구 | yes (가장 강함) |
 | `feat/*`, `fix/*`, `chore/*`, `docs/*`, `hotfix/*` | 임시 (PR 머지 후 자동 삭제) | no |
 | `backport/*` | 자동 생성 (rc-hotfix-backport) | no |
@@ -32,9 +32,9 @@
 | Require linear history | **yes** (squash merge 강제) |
 | Allowed merge methods | **squash only** |
 | Require signed commits | no (현재 minglit 컨벤션 따름) |
-| Merge queue | **사용 안 함** (단발 PR 흐름으로 시작. 필요 시 후속 도입 — TBD) |
+| Merge queue | **사용 안 함** (일반 PR + auto-merge 흐름으로 시작. 필요 시 후속 도입 — TBD) |
 | Auto-delete head branch on merge | yes |
-| Bypass roles | none (단 인시던트 시 `--admin` 사용자 명시 승인 가능) |
+| Bypass roles | `minglit-release-bot` only for version bump/tag push. 인시던트 시 `--admin` 은 사용자 명시 승인 필요 |
 
 ### `dev`
 
@@ -47,9 +47,9 @@
 | Required status checks | `nightly-pr-gate` (dev-staging 의 snapshot PR 에 대해) |
 | Required reviewers | 0 |
 | Require conversation resolution | yes |
-| Require linear history | **yes** (merge queue 통과 snapshot 만 들어옴, snapshot 자체가 linear) |
+| Require linear history | **yes** (nightly snapshot PR 만 들어옴, snapshot 자체가 linear) |
 | Allowed merge methods | merge commit (snapshot 보존용) |
-| Bypass roles | none |
+| Bypass roles | `minglit-release-bot` only for promotion/version metadata push |
 
 > dev 는 사람이 직접 PR 안 만듦. `nightly-cut` workflow 만 PR 생성. branch protection 이 사실상 workflow 만 허용하는 효과.
 
@@ -61,16 +61,16 @@
 | Direct push | 금지 |
 | Force push | 금지 |
 | Branch deletion | 금지 |
-| Required status checks | `main-pr-gate` (전체) + `rc-gate-pass` (RC HEAD commit 의 GitHub commit status) + `expand-migrate-contract` (재실행) |
-| Required PR labels | `rc-soak-passed` (rc-soak-check 가 부여) |
+| Required status checks | `main-pr-gate` (RC HEAD 의 `rc-gate-pass`, `expand-migrate-contract`, `rc-soak-passed` marker 를 내부 검증) |
+| Required PR labels | GitHub Ruleset 직접 요구 없음. `main-pr-gate` 가 `rc-soak-passed` marker 를 검증 |
 | Required reviewers | 0 (workflow auto-merge) |
 | Require conversation resolution | yes |
 | Require linear history | **yes** |
 | Allowed merge methods | **rebase only** (rebase + fast-forward) |
-| Auto-delete head branch on merge | no (rc/* branch 는 archive 정책 따로 — TBD) |
-| Bypass roles | release manager (catastrophic incident response 시) |
+| Auto-delete head branch on merge | yes (`rc/*` branch 는 main merge 후 삭제, 이력은 protected tag 로 보존) |
+| Bypass roles | `minglit-release-bot` for final version/tag push, release manager only for catastrophic incident response |
 
-> rc → main PR 만 받음. `main-pr-gate` 가 RC HEAD 의 status 등을 검증하는 게이트.
+> rc → main PR 만 받음. GitHub Ruleset 은 `main-pr-gate` 하나만 required 로 두고, `main-pr-gate` 내부에서 RC HEAD status, soak marker, contract 재검증을 수행한다. PR head SHA 와 dev commit status 가 다를 수 있으므로 `rc-gate-pass` 를 branch protection 의 독립 required check 로 걸지 않는다.
 
 ## Pattern Branch 설정
 
@@ -80,16 +80,16 @@
 |------|----|
 | Direct push | 금지 |
 | Force push | 금지 |
-| Branch deletion | 금지 (머지 후에도 archive 보존 — release history marker 역할) |
+| Branch deletion | 허용 대상 제한 (`minglit-release-bot` 만 RC 종료/abandon 시 삭제). human 삭제 금지 |
 | Required status checks | `rc-pr-gate` (hotfix PR 에 대해) |
 | Required reviewers | 0 |
 | Require conversation resolution | yes |
 | Require linear history | yes |
 | Allowed merge methods | rebase only |
 | Auto-delete head branch on merge | yes (hotfix branch 자동 삭제) |
-| Bypass roles | none |
+| Bypass roles | `minglit-release-bot` only for RC version bump/tag push and RC branch cleanup |
 
-> `rc-cut` workflow 가 branch 생성 후 이 protection ruleset 을 REST API 로 활성화.
+> `rc-cut` workflow 가 branch 생성 후 이 protection ruleset 을 REST API 로 활성화. RC 종료 후 `minglit-release-bot` 이 branch 를 삭제하고, 릴리즈 이력은 `promo/rc-*`, `v*-rc-*`, `promo/main-*` protected tag 로 보존한다.
 
 ### `feat/*`, `fix/*`, `chore/*`, `docs/*`, `hotfix/*`
 
@@ -113,10 +113,10 @@ GitHub 의 **Rulesets** 채택 (legacy Branch Protection 아님). 패턴 기반�
 
 | Ruleset | Target | 규칙 |
 |---------|--------|------|
-| `dev-staging-rules` | `dev-staging` | 위 영구 branch 표 그대로 |
-| `dev-rules` | `dev` | 위 |
-| `main-rules` | `main` | 위 |
-| `rc-pattern-rules` | `rc/**` | 위 pattern 표 |
+| `dev-staging-rules` | `dev-staging` | 위 영구 branch 표 그대로 + `minglit-release-bot` bypass |
+| `dev-rules` | `dev` | 위 + `minglit-release-bot` bypass |
+| `main-rules` | `main` | 위 + `minglit-release-bot` bypass |
+| `rc-pattern-rules` | `rc/**` | 위 pattern 표 + `minglit-release-bot` bypass |
 | `auto-delete-temp` | `feat/**`, `fix/**`, `chore/**`, `docs/**`, `hotfix/**`, `backport/**` | auto-delete only |
 | `tag-protection` | `v*`, `promo/**`, `mobile-released/**` | 아래 Tag Protection 표 |
 | `branch-creation` | `rc/**`, `release/**` | 아래 Branch Creation 표 |
@@ -152,6 +152,34 @@ Bypass: 없음 (catastrophic 한 경우만 admin 명시 승인).
 
 Bypass: release manager (긴급 RC 새 cut 시).
 
+## Release Bot
+
+Protected branch 에 대한 direct push 는 human 에게 허용하지 않는다. version bump commit, tag push, RC branch 생성/삭제처럼 workflow 가 branch state 를 변경해야 하는 경우만 전용 bot actor 를 사용한다.
+
+| 항목 | 값 |
+|------|----|
+| Actor | `minglit-release-bot` (GitHub App 권장, 대안: fine-grained PAT 전용 bot account) |
+| Token secret | `MINGLIT_RELEASE_BOT_TOKEN` |
+| 사용 workflow | `dev-staging-post-merge-sync`, `nightly-cut`, `rc-cut`, `rc-post-merge-sync`, `rc-soak-check`, `rc-hotfix-backport`, `main-post-merge-promote` |
+| Ruleset bypass | `dev-staging`, `dev`, `rc/**`, `main`, protected tag push (`v*`, `promo/**`) |
+| Human 사용 | 금지. 로컬/수동 CLI 에서 token 사용 금지 |
+| Audit | 모든 bot push 는 workflow run URL, actor, target ref, tag 목록을 PR/issue 또는 job summary 에 남김 |
+
+### 최소 권한
+
+GitHub App 기준 권장 permission:
+
+| Permission | Level | 이유 |
+|------------|-------|------|
+| Contents | Read/write | version bump commit, branch 생성/삭제, tag push |
+| Pull requests | Read/write | nightly/promotion/backport PR 생성, auto-merge enable |
+| Commit statuses | Read/write | `rc-gate-pass` status set |
+| Checks | Read | gate 상태 조회 |
+| Issues | Read/write | auto-issue 생성/댓글 |
+| Metadata | Read | GitHub App 기본 권한 |
+
+`Actions`, `Administration`, `Secrets` 권한은 기본적으로 부여하지 않는다. Ruleset 수정/생성은 초기 설정 또는 별도 infra workflow 에서만 수행하며, release bot 의 상시 권한에서 제외한다.
+
 ## GitHub Environment Protection
 
 Deploy 권한·secret 격리·required reviewer 등은 GitHub Environment 단위로:
@@ -160,7 +188,7 @@ Deploy 권한·secret 격리·required reviewer 등은 GitHub Environment 단위
 |-------------|------|------|
 | `dev` | dev 의 rc-gate-pass commit 으로 backend/web 자동 deploy | 자동 (no reviewer), Firebase service-account 등 dev secret |
 | `production` | main push 로 mobile build + store upload | **required reviewer (release manager)** — store upload 직전에 사람 1 명 승인. Apple/Google secret 격리. Sentry production project token |
-| `staging` (옵션) | RC soak 용 ephemeral Supabase branch 등 | TBD |
+| `staging` (옵션) | RC Supabase branch 관리와 staging secret 격리 | TBD |
 
 **중요**: production environment 의 required reviewer = workflow 자동 흐름에 한 번의 human approval 삽입. catastrophic 사고 방지의 마지막 안전망.
 
@@ -192,7 +220,8 @@ CODEOWNERS 가 required reviewer 와 결합하면 자동으로 review 요청 + �
 
 | 시나리오 | 누가 | 우회 방법 |
 |----------|------|----------|
-| 정상 작업 | AI agent / 개발자 | merge queue + auto-merge (우회 없음) |
+| 정상 작업 | AI agent / 개발자 | PR + auto-merge (우회 없음) |
+| version bump/tag push | `minglit-release-bot` | Ruleset bypass, workflow 내부에서만 |
 | nightly red 인데 main 핫픽스 필요 | release manager | `--admin` bypass + 명시 승인 (CLAUDE.md 룰) |
 | catastrophic incident (Tier 2b hard kill) | release manager / on-call | branch 변경 아님 (admin page 로 RC 콘솔 변경) |
 | RC abandon (TBD 시나리오) | RC owner | rc branch 삭제 + workflow_dispatch 로 새 rc-cut |
@@ -200,6 +229,7 @@ CODEOWNERS 가 required reviewer 와 결합하면 자동으로 review 요청 + �
 ## 결정해야 할 것
 
 - merge queue 도입 시점 (PR 동시성·conflict 데이터 쌓이면)
+- `minglit-release-bot` 을 GitHub App 으로 만들지, fine-grained PAT bot account 로 시작할지
 - `--admin` bypass 의 audit log 자동 분석 (분기별 사용 패턴 검토)
 - `signed commits` 요구 여부 (현재 미요구, 향후 SLSA 컴플라이언스 고려)
 - `production` environment 의 required reviewer 명단 (release manager — 누가?)

--- a/docs/infra/branch-strategy/specs/execution-plan.md
+++ b/docs/infra/branch-strategy/specs/execution-plan.md
@@ -70,10 +70,11 @@
 | 2a | `pr-gate.yml` 단일 파일 유지하면서 내부 jobs 를 `workflow_call` 받게 변경 + stage parameter 추가. `pr-gate-core` 별도 파일 아님 | PR 흐름 동일, 내부 jobs reusable 化 |
 | 2b | stage 별 `extra_steps` 지원 (dev-staging / rc / main) | 기존 동작 동일 |
 | 2c | `version-bump` reusable extract (sync-version 의 핵심 로직) | sync-version 의 caller 가 reusable 호출하게 변경 |
-| 2d | `auto-issue` reusable 추가 | 신규 — 기존 영향 없음 |
-| 2e | **`ci-result` 폐기** — 현 branch protection 의 required check `ci-result` 를 각 branch 의 `pr-gate` 로 변경 (Phase 4 에서 실제 적용) | 본 step 은 workflow 측 준비, 실제 protection 변경은 4 |
-| 2f | `deploy-supabase` 의 trigger refactor — push:dev 부분을 rc-gate-pass workflow_call **with target=main-staging** 로 변경, push:main 은 main-post-merge-promote 의 workflow_call **with target=main** | staging deploy 와 prod deploy 분리. 사용자 서버 영향 X |
-| 2g | **`deploy-vercel` 폐기** — 자체 빌드 워크플로우 제거. **Vercel native build 로 전환** (Vercel-GitHub 연결, Vercel-side: main=production, dev=preview) | Vercel-side 설정 필요, workflow 측 작업 없음 |
+| 2d | `minglit-release-bot` 생성 + `MINGLIT_RELEASE_BOT_TOKEN` 등록 + workflow permission 최소화 | protected branch/tag push 를 human 대신 bot 으로 수행 |
+| 2e | `auto-issue` reusable 추가 | 신규 — 기존 영향 없음 |
+| 2f | **`ci-result` 폐기** — 현 branch protection 의 required check `ci-result` 를 각 branch 의 `pr-gate` 로 변경 (Phase 4 에서 실제 적용) | 본 step 은 workflow 측 준비, 실제 protection 변경은 4 |
+| 2g | `deploy-supabase` 의 trigger refactor — push:dev 부분을 rc-gate-pass workflow_call **with target=main-staging** 로 변경, push:main 은 main-post-merge-promote 의 workflow_call **with target=main** | staging deploy 와 prod deploy 분리. 사용자 서버 영향 X |
+| 2h | **`deploy-vercel` 폐기** — 자체 빌드 워크플로우 제거. **Vercel native build 로 전환** (Vercel-GitHub 연결, Vercel-side: main=production, dev=preview) | Vercel-side 설정 필요, workflow 측 작업 없음 |
 
 ### Rollback
 
@@ -93,11 +94,11 @@
 
 | Step | 작업 | 의존 |
 |------|------|------|
-| 3a | `dev-staging-pr-gate`, `dev-staging-post-merge-sync` | 2a, 2b, 2c |
+| 3a | `dev-staging-pr-gate`, `dev-staging-post-merge-sync` | 2a, 2b, 2c, 2d |
 | 3b | `nightly-cut`, `nightly-pr-gate` | 3a + dev-staging branch 존재 (Phase 1) |
 | 3c | `rc-gate-suite` reusable 조립 (CUJ × matrix + integration + Test Lab) | 2a |
-| 3d | `rc-gate` (호출 + status set + deploy chain trigger) | 3c + 2e/2f |
-| 3e | `rc-cut`, `rc-pr-gate`, `rc-post-merge-sync`, `rc-soak-check` | 3d + rc/* branch 패턴 확정 |
+| 3d | `rc-gate` (호출 + status set + deploy chain trigger) | 3c + 2f/2g |
+| 3e | `rc-cut`, `rc-pr-gate`, `rc-post-merge-sync`, `rc-soak-check` | 3d + rc/* branch 패턴 확정 + Supabase branching 설정 |
 | 3f | `backport-pr` reusable, `rc-hotfix-backport` | 2a |
 | 3g | `main-pr-gate`, `main-post-merge-promote` | 3d (rc-gate-pass status 필요) |
 
@@ -130,8 +131,8 @@
 | 4a | `dev-staging` Ruleset 적용 (required: `dev-staging-pr-gate`) | 3a 1주 운영 |
 | 4b | `dev` Ruleset 갱신 (required: `nightly-pr-gate`) | 3b 1주 |
 | 4c | `rc/**` pattern Ruleset 적용 (required: `rc-pr-gate`) | 3e 1주 |
-| 4d | `main` Ruleset 갱신 — **기존 `ci-result` required check 제거** + 추가: `main-pr-gate` + `rc-gate-pass` + `expand-migrate-contract` + label `rc-soak-passed` | 3g 1주 + 3d 안정 |
-| 4e | Tag protection Ruleset (`v*`, `promo/**`) | 4d 안정 (release 가 도는 게 확인된 후) |
+| 4d | `main` Ruleset 갱신 — **기존 `ci-result` required check 제거** + 추가: `main-pr-gate` 단일 required check (`rc-gate-pass`, `expand-migrate-contract`, `rc-soak-passed` 는 내부 검증) | 3g 1주 + 3d 안정 |
+| 4e | Tag protection Ruleset (`v*`, `promo/**`) + release bot tag bypass | 4d 안정 (release 가 도는 게 확인된 후) |
 | 4f | Branch creation 제한 (`rc/**` → bot only) | 4c 안정 |
 | 4g | GitHub Environment `production` 생성 + required reviewer 설정 | 3g 1주 |
 | 4h | **Default branch 변경**: `dev` → `dev-staging` | 모든 위 단계 안정 |
@@ -157,8 +158,8 @@ Phase 1 (skeletal) → Phase 2a-2c (pr-gate refactor) → Phase 3a (dev-staging 
 ```
 
 비-critical (병렬 가능):
-- Phase 2d (`auto-issue` reusable) — 신규, 의존 없음
-- Phase 2e/2f (deploy trigger refactor) — Phase 3 이전에 끝나면 OK
+- Phase 2e (`auto-issue` reusable) — 신규, 의존 없음
+- Phase 2f/2g (deploy trigger refactor) — Phase 3 이전에 끝나면 OK
 - 3c (rc-gate-suite) — 3d 이전에만 끝나면 OK
 
 ## Secret Management 정리 (별도 작업, user 와 함께)
@@ -204,15 +205,16 @@ Phase 1 (skeletal) → Phase 2a-2c (pr-gate refactor) → Phase 3a (dev-staging 
 
 1. **CI 실패가 release 차단**: pr-gate 의 stage parameter 가 정확히 매칭돼야 함. *required check 이름 한 글자라도 다르면 차단*. 특히 `ci-result` → stage pr-gate 전환 시 cutover 타이밍 중요
 2. **trigger 변경**: cron → push 변경 시 *겹치는 기간* 발생할 수 있음 — 한쪽 비활성화 후 다른쪽 활성화. 부분 적용 금지
-3. **status check naming**: `rc-gate-pass` 같은 commit status 의 이름이 spec, workflow, branch protection 셋 모두에서 일치해야 함
+3. **status check naming**: `rc-gate-pass` 같은 commit status 의 이름이 spec 과 workflow 에서 일치해야 함. branch protection 에는 직접 required 로 걸지 않고 `main-pr-gate` 내부에서 검증
 4. **AI agent 의 PR 동시성**: merge queue 없으니 race condition 발생 시 수동 conflict resolve 필요 (또는 merge queue 도입 검토)
-5. **Secret 마이그레이션 중 workflow 실패**: file 기반과 GH secret 참조가 섞이는 transition 기간 — env 변수 누락 시 즉시 발견 (CI 통과 못함)
+5. **Release bot token 실패**: `MINGLIT_RELEASE_BOT_TOKEN` 권한 부족이면 version bump/tag/promotion workflow 가 막힘. 최초 도입 시 dry-run branch 로 push/tag/delete까지 검증
+6. **Secret 마이그레이션 중 workflow 실패**: file 기반과 GH secret 참조가 섞이는 transition 기간 — env 변수 누락 시 즉시 발견 (CI 통과 못함)
 
 ## Self-review: Phase 3 ordering
 
 내부 검토 결과 — **현재 순서 (3a → 3b → 3c → 3d → 3e → 3f → 3g) OK**, 단 다음 minor 개선:
 
-- **3a / 3b 병렬 가능**: dev-staging-pr-gate (3a) 와 nightly-cut (3b) 는 서로 의존 없음. 다른 PR 로 병렬 진행 가능
+- **3a / 3b 병렬 가능**: dev-staging-pr-gate (3a) 와 nightly-cut (3b) 는 서로 의존이 약함. 단 version bump/tag push 검증에는 release bot 준비가 선행되어야 함
 - **3c → 3d 사이 verification 불필요**: rc-gate-suite (3c) 는 reusable, 호출은 rc-gate (3d) 에서. 3c 자체로는 동작 없음 → 3d 와 동일 PR 또는 직후 PR 가능
 - **3f 는 3e 와 같이**: rc-hotfix-backport 가 rc-promotion 흐름의 일부라 같은 시점에 도입이 자연스러움
 - **가장 critical**: 3d (rc-gate) — 첫 verification 기간 1주 이상 추천 (다른 stage 와 달리 60분 비용 + 통합 시나리오 복잡)

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -83,19 +83,19 @@ Cross-branch cherry-pick PR 자동 생성.
 
 | 항목 | 값 |
 |------|----|
-| Trigger | `pull_request` (base: `dev-staging`) + `merge_group` (GitHub merge queue) |
+| Trigger | `pull_request` (base: `dev-staging`) |
 | Outputs | required status check |
 | Steps | calls `pr-gate-core` (stage=dev-staging) |
-| Required for | dev-staging merge queue + PR merge |
+| Required for | dev-staging PR merge |
 
 #### `dev-staging-post-merge-sync`
 
 | 항목 | 값 |
 |------|----|
-| Trigger | `push` to `dev-staging` (merge queue 통과 후) |
+| Trigger | `push` to `dev-staging` (PR squash merge 후) |
 | Inputs | (from event) PR number, merged SHA |
 | Outputs | tag `v{YY.MM.PR#}-dev-staging` |
-| Steps | calls `version-bump` (suffix=`-dev-staging`, version=`{YY.MM.PR#}`) |
+| Steps | calls `version-bump` (suffix=`-dev-staging`, version=`{YY.MM.PR#}`) using `MINGLIT_RELEASE_BOT_TOKEN` |
 
 ### nightly (dev 진입)
 
@@ -106,7 +106,7 @@ Cross-branch cherry-pick PR 자동 생성.
 | Trigger | `schedule` (daily KST 02:00 TBD) + `workflow_dispatch` |
 | Inputs | (none, or optional ref override) |
 | Outputs | PR number (dev-staging → dev) or skip |
-| Steps | (1) 이전 `nightly-cut` PR open 이면 skip + Slack (2) 가장 최근 `v*-dev-staging` tag SHA 조회 (3) dev HEAD == 그 SHA 이면 skip ("no new commits") (4) 아니면 `gh pr create` (base=dev, head=dev-staging) + auto-merge 활성화 |
+| Steps | (1) 이전 `nightly-cut` PR open 이면 skip + Slack (2) 가장 최근 `v*-dev-staging` tag SHA 조회 (3) dev HEAD == 그 SHA 이면 skip ("no new commits") (4) `nightly/YYYY-MM-DD` promotion branch 를 tag SHA 에서 생성 (5) `gh pr create` (base=dev, head=nightly/YYYY-MM-DD) + auto-merge 활성화 |
 
 #### `nightly-pr-gate`
 
@@ -157,7 +157,7 @@ Vercel native 가 자체 trigger 및 build 처리. workflow 측 작업 없음.
 |------|----|
 | Trigger | `schedule` (weekly KST TBD) + `workflow_dispatch` |
 | Outputs | branch `rc/YYYY-Wxx` + tag `v{ver}-rc-01` + tag `promo/rc-YYYY-Wxx` |
-| Steps | (1) 현재 `rc/*` 살아있는지 확인 → 있으면 skip + Slack `#release` (hotfix 로 길어지는 중) (2) dev 의 최신 `rc-gate-pass` status SHA query (`gh api`) (3) 없으면 (3일+ green 없음) alert + abort (4) `git branch rc/YYYY-Wxx <SHA>` + push (5) calls `version-bump` (suffix=`-rc-01`) (6) `git tag promo/rc-YYYY-Wxx` + push (7) branch protection 활성화 (8) Slack `#release` 알림 |
+| Steps | (1) active RC marker 가 있으면 skip + Slack `#release` (hotfix 로 길어지는 중) (2) dev 의 최신 `rc-gate-pass` status SHA query (`gh api`) (3) 없으면 (3일+ green 없음) alert + abort (4) `git branch rc/YYYY-Wxx <SHA>` + push using release bot (5) Supabase branch 생성 + RC env deploy (6) calls `version-bump` (suffix=`-rc-01`) (7) `git tag promo/rc-YYYY-Wxx` + push (8) branch protection 활성화 (9) Slack `#release` 알림 |
 
 #### `rc-pr-gate`
 
@@ -173,7 +173,7 @@ Vercel native 가 자체 trigger 및 build 처리. workflow 측 작업 없음.
 |------|----|
 | Trigger | `push` to `rc/*` (hotfix merge 후) |
 | Outputs | tag `v{ver}-rc-NN` (NN+1) |
-| Steps | (1) 현 rc 의 마지막 `v*-rc-*` tag 의 NN 파싱 (2) calls `version-bump` (suffix=`-rc-{NN+1}`) |
+| Steps | (1) 현 rc 의 마지막 `v*-rc-*` tag 의 NN 파싱 (2) calls `version-bump` (suffix=`-rc-{NN+1}`) using release bot (3) RC Supabase branch 에 migration/EF 재적용 |
 
 #### `rc-soak-check`
 
@@ -187,9 +187,9 @@ Vercel native 가 자체 trigger 및 build 처리. workflow 측 작업 없음.
 
 | 항목 | 값 |
 |------|----|
-| Trigger | `push` to `rc/*` (rc-post-merge-sync 와 parallel) |
+| Trigger | `pull_request` closed/merged (base: `rc/*`) |
 | Outputs | backport PR (rc/* → dev-staging) |
-| Steps | calls `backport-pr` (source=`rc/*`, target=dev-staging, commits=[새 hotfix SHA]) · 충돌 시 `auto-issue` (P1, AI agent assignee) |
+| Steps | calls `backport-pr` (source=`rc/*`, target=dev-staging, commits=[merged PR commits only]) · 충돌 시 `auto-issue` (P1, AI agent assignee). `rc-post-merge-sync` 의 version bump commit 은 backport 대상에서 제외 |
 
 ### main
 
@@ -207,7 +207,7 @@ Vercel native 가 자체 trigger 및 build 처리. workflow 측 작업 없음.
 |------|----|
 | Trigger | `push` to `main` (rc → main auto-merge 직후) |
 | Outputs | tag `v{ver}` + tag `promo/main-YYYY-Wxx` + Sentry marker + Firebase RC `latest_version` update + parallel deploy chain |
-| Steps | (1) calls `version-bump` (suffix="") (2) `git tag promo/main-YYYY-Wxx` + push (3) Sentry release marker `v{ver}` (4) Firebase RC `latest_version` = `v{ver}` (Admin SDK) (5) **parallel deploy chain** (모두 target=main env): `deploy-supabase`, mobile deploy workflows |
+| Steps | (1) calls `version-bump` (suffix="") using release bot (2) `git tag promo/main-YYYY-Wxx` + push (3) Sentry release marker `v{ver}` (4) Firebase RC `latest_version` = `v{ver}` (Admin SDK) (5) **parallel deploy chain** (모두 target=main env): `deploy-supabase`, mobile deploy workflows (6) RC Supabase branch 삭제 |
 
 > main push 후 자동 발동되는 deploy workflows (병렬):
 > - `deploy-supabase` (target=main, prod Supabase project) — EF + migration
@@ -222,7 +222,7 @@ Vercel native 가 자체 trigger 및 build 처리. workflow 측 작업 없음.
 ```
 [agent PR opens to dev-staging]
        ↓
-[dev-staging-pr-gate] ──merge queue 통과──▶ dev-staging push
+[dev-staging-pr-gate] ──auto-merge──▶ dev-staging push
                                                 ↓
                                          [dev-staging-post-merge-sync]
                                                 ↓ tag v{ver}-dev-staging

--- a/docs/infra/branch-strategy/test-strategy.md
+++ b/docs/infra/branch-strategy/test-strategy.md
@@ -6,11 +6,11 @@
 
 | 단계 | 게이트 | 소요 | 실패 시 |
 |------|--------|------|---------|
-| dev-staging 머지 전 | `dev-staging-pr-gate` (unit · lint · analyze · pgTAP · EF test · migration check · `expand-migrate-contract` · `flag-registration` · gitleaks) | < 10분 | merge queue PR drop |
+| dev-staging 머지 전 | `dev-staging-pr-gate` (unit · lint · analyze · pgTAP · EF test · migration check · `expand-migrate-contract` · `flag-registration` · gitleaks) | < 10분 | auto-merge 보류 |
 | dev 머지 전 | `nightly-pr-gate` (dev-staging-pr-gate 와 동일 — defensive) | < 10분 | nightly-cut PR drop |
 | dev 머지 후 (자동) | `rc-gate` (CUJ matrix happy/unhappy/chaos · integration · e2e · Test Lab smoke) | 30-60분 | 자동 이슈 + AI fix flow via dev-staging. `rc-gate-pass` 미부여 |
 | rc 머지 전 (hotfix) | `rc-pr-gate` (pr-gate + mobile smoke) | < 15분 | hotfix PR drop |
-| main 머지 전 (rc → main) | `main-pr-gate` (pr-gate + `expand-migrate-contract` 재검증 + RC HEAD 의 `rc-gate-pass` 확인) | 분 | promotion PR 보류 |
+| main 머지 전 (rc → main) | `main-pr-gate` (pr-gate + `expand-migrate-contract` 재검증 + RC HEAD 의 `rc-gate-pass` 확인 + `rc-soak-passed` marker 확인) | 분 | promotion PR 보류 |
 | rc → main PR | workflow auto-merge (모든 check 통과 시) | 분 | check 실패 시 PR hold + alert |
 | Backend/Web auto-deploy 후 | post-deploy smoke + Sentry/Crashlytics 알람 임계 | 분 | auto-rollback ([main-promotion.md](./main-promotion.md)) |
 | deploy-android-*, deploy-ios-* 후 | mobile build smoke (Fastlane upload 검증) | 시간 | retry 1회 → auto-issue + mobile 팀 |
@@ -21,7 +21,7 @@
 
 ### dev-staging-pr-gate — 빠른 머지 게이트
 
-merge queue 가 직렬 처리. 각 PR 이 rebase 후 재실행.
+일반 PR + auto-merge 로 처리한다. base drift 가 생기면 branch update 후 gate 를 재실행한다.
 
 - `test-flutter-apps` (matrix: app_user, app_partner)
 - `lint-landing-user`, `lint-landing-partner`
@@ -78,7 +78,7 @@ RC 의 hotfix 만 받음. `pr-gate` + 추가 mobile smoke. 머지 시 `rc-post-m
 | 테스트 성격 | 배치 위치 | 이유 |
 |-------------|-----------|------|
 | 결정론적, < 10분 | `dev-staging-pr-gate` | PR 사이클 안 막음 |
-| flaky 또는 느림 (10분+) | `rc-gate` | merge queue 신뢰도 보호 |
+| flaky 또는 느림 (10분+) | `rc-gate` | PR 머지 게이트의 신뢰도 보호 |
 | 외부 의존성 (실 결제 등) | `rc-gate` + flag canary | 비용·side effect 통제 |
 | 부하/성능 | `rc-gate` (주 1회) or staged rollout 메트릭 | 매일 무거움 |
 | backend ↔ mobile 계약 호환 | `expand-migrate-contract` CI + flag canary 메트릭 | 다층 안전망 |

--- a/docs/infra/branch-strategy/versioning.md
+++ b/docs/infra/branch-strategy/versioning.md
@@ -79,7 +79,7 @@ PR# 가 dev-staging 에서 부여되고 같은 PR# 가 후속 단계에서 suffi
 - mobile release branch hotfix 의 PR# 출처 (cherry-pick PR# 인가 새 PR# 인가)
 - main 비-promotion 변경의 version bump 룰 (긴급 hotfix 직접 push 시)
 - `RELEASE.md` 작성 (tag regex single source)
-- merge queue 가 squash commit 에 `bump-version.sh` 결과를 inline 시킬지 별도 commit 으로 둘지
+- `bump-version.sh` 결과를 squash commit 에 inline 시킬지 release bot 별도 commit 으로 둘지
 
 ## 관련
 


### PR DESCRIPTION
## Summary
- document dev-staging as PR + auto-merge without merge queue for the initial rollout
- specify release-bot-only protected branch/tag writes via MINGLIT_RELEASE_BOT_TOKEN and Ruleset bypass
- clarify rc lifecycle with per-RC Supabase branching, temporary RC cleanup, and hotfix backport behavior
- consolidate main protection around a single main-pr-gate required check with internal rc-gate/soak/contract validation

## Verification
- rg scan for merge queue / bypass / rc-gate / Supabase branch policy terms
- graphify update . attempted; output was not committed because local graphify regenerated a smaller 13,390-node graph and would downgrade current dev graphify output
- markdownlint not run locally: command not installed