### PR TITLE
ci: use release bot for version sync

### DIFF
--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -26,6 +26,7 @@
 - `pr-gate.yml` 은 기존 `push`/`pull_request`/`merge_group` 진입점을 유지하면서 `workflow_call` 도 지원한다.
 - 호출자는 `stage` (`dev`, `dev-staging`, `nightly`, `rc`, `main`) 와 `base_ref` 를 넘겨 동일한 CI 코어를 stage 별 gate 로 재사용한다.
 - 기존 required check 는 아직 `ci-result` 그대로 유지한다. stage 별 required check 전환은 branch-strategy Phase 4 에서 Ruleset 과 함께 적용한다.
+- protected branch/tag 에 직접 push 하는 workflow 는 `MINGLIT_RELEASE_BOT_TOKEN` 을 사용한다. `sync-version.yml` 의 dev/main version bump 도 여기에 포함된다.
 
 ## 컨벤션
 

--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -25,7 +25,16 @@ jobs:
         with:
           ref: ${{ github.base_ref }}
           fetch-depth: 0
-          token: ${{ secrets.GH_PAT_VERSION_BUMP }}
+          persist-credentials: false
+
+      - name: Validate release bot token
+        env:
+          MINGLIT_RELEASE_BOT_TOKEN: ${{ secrets.MINGLIT_RELEASE_BOT_TOKEN }}
+        run: |
+          if [ -z "${MINGLIT_RELEASE_BOT_TOKEN}" ]; then
+            echo "::error::MINGLIT_RELEASE_BOT_TOKEN is required for protected branch version bump pushes"
+            exit 1
+          fi
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -62,12 +71,15 @@ jobs:
         run: bash scripts/bump-version.sh "${{ steps.version.outputs.new }}"
 
       - name: Commit and push version bump
+        env:
+          MINGLIT_RELEASE_BOT_TOKEN: ${{ secrets.MINGLIT_RELEASE_BOT_TOKEN }}
         run: |
           NEW_VERSION="${{ steps.version.outputs.new }}"
           BRANCH="${{ github.base_ref }}"
 
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "minglit-release-bot"
+          git config user.email "minglit-release-bot@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${MINGLIT_RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
           git add -A
           git diff --cached --quiet && { echo "No version changes to commit."; exit 0; }
@@ -91,11 +103,12 @@ jobs:
             # linear backoff: 2s, 4s, 6s, 8s
             sleep $((2 * ATTEMPT))
           done
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Create GitHub release (main only)
         if: github.base_ref == 'main'
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_VERSION_BUMP }}
+          GH_TOKEN: ${{ secrets.MINGLIT_RELEASE_BOT_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.base }}"
           gh release create "v${VERSION}" \


### PR DESCRIPTION
## Summary
- switch sync-version protected branch pushes from GH_PAT_VERSION_BUMP to MINGLIT_RELEASE_BOT_TOKEN
- validate the release bot token before attempting version bump writes
- attribute version bump commits to minglit-release-bot and use the same token for main releases
- document that protected branch/tag write workflows require MINGLIT_RELEASE_BOT_TOKEN

## Verification
- python3 YAML parse over all .github/workflows/*.yml
- git diff --check
- graphify update . attempted; output excluded because local graphify regenerated the smaller 13,390-node graph and would downgrade current dev graphify output

## Operational Note
- Repo secret MINGLIT_RELEASE_BOT_TOKEN must exist and the bot actor must have Ruleset bypass for dev/main protected writes before the next sync-version run can succeed.