### PR TITLE
ci: mint release bot token from github app

### DIFF
--- a/.github/actions/BLUEDOC.md
+++ b/.github/actions/BLUEDOC.md
@@ -1,28 +1,21 @@
-# .github/actions/
+# GitHub Actions
 
-워크플로우가 `uses: ./.github/actions/<name>` 로 호출하는 **composite actions**. 여러 step 을 묶어 워크플로우 파일의 중복 제거.
+`.github/actions/` 는 workflow 에서 재사용하는 local action 의 진입점이다. 새 action 을 추가할 때는 이 파일의 이정표를 갱신한다.
 
 ## 이정표
 
-| Action | 역할 | 호출자 |
-|---|---|---|
-| [`deploy-flutter-app/`](./deploy-flutter-app/) | Flutter web 앱 → Vercel 배포 (build + alias + smoke) | `deploy-vercel` (app_user, app_partner) |
-| [`deploy-nextjs-app/`](./deploy-nextjs-app/) | Next.js 앱 → Vercel 배포 (env-manifest 복사 + node 설치 + vercel CLI) | `deploy-vercel` (landing_user, landing_partner, mds_docs) |
-| [`ios-deploy/`](./ios-deploy/) | iOS 앱 → TestFlight 배포 (signing cert / provisioning profile + xcodebuild + altool) | `deploy-ios-user`, `deploy-ios-partner` |
+| Action | 내용 |
+|--------|------|
+| [deploy-flutter-app](./deploy-flutter-app/action.yml) | Flutter app deploy 공통 action |
+| [deploy-nextjs-app](./deploy-nextjs-app/action.yml) | Next.js app deploy 공통 action |
+| [ios-deploy](./ios-deploy/action.yml) | iOS deploy 공통 action |
+| [release-bot-token](./release-bot-token/action.yml) | `minglit-release-bot` GitHub App installation token mint |
 
-각 action 의 inputs/outputs 는 해당 폴더의 `action.yml` 참고.
+## 컨벤션
 
-## 핵심 컨벤션
-
-- **`runs: using: "composite"`** — Docker 액션 X, JavaScript 액션 X. 모든 자체 action 은 shell step 묶음 composite.
-- **여러 워크플로우에서 같은 step 체인을 반복할 때만 composite 로 추출** — 단발성 외부 액션 호출 (checkout, setup-node 등) 은 워크플로우에서 직접 `uses:` OK. 중복 / 멀티-step orchestration 만 composite.
-- **action 변경 시 호출자 워크플로우 회귀 검증** — 한 PR 에서 action.yml 만 바뀌어도 호출하는 deploy-* 워크플로우 다음 cron 까지 영향.
-- **secrets 는 action 의 input 으로 전달** — action.yml 안에서 `${{ secrets.* }}` 직접 참조 금지 (calling workflow 의 책임).
-
-## 관련
-
-- [workflows/BLUEDOC.md](../workflows/BLUEDOC.md) — 어느 워크플로우가 어느 action 호출하는지
-- [.github/BLUEDOC.md](../BLUEDOC.md) — 상위 진입점
+- Local action 은 workflow 내부 반복을 줄일 때만 추가한다.
+- Secret 은 action 안에서 직접 참조하지 않고 input 으로 받는다.
+- Protected branch/tag write 용 token 은 `release-bot-token` 을 통해 mint 한다.
 
 ---
-_Reviewed: 2026-05-17 22:32_
+_Reviewed: 2026-05-23 10:00_

--- a/.github/actions/release-bot-token/action.yml
+++ b/.github/actions/release-bot-token/action.yml
@@ -1,0 +1,33 @@
+name: release-bot-token
+description: Mint a short-lived GitHub App installation token for minglit-release-bot.
+
+inputs:
+  app-id:
+    description: GitHub App ID for minglit-release-bot.
+    required: true
+  private-key:
+    description: GitHub App private key for minglit-release-bot.
+    required: true
+  owner:
+    description: Account or organization where the app is installed.
+    required: true
+  repositories:
+    description: Repository list to scope the installation token to.
+    required: true
+
+outputs:
+  token:
+    description: Short-lived installation token.
+    value: ${{ steps.app-token.outputs.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Generate release bot token
+      id: app-token
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
+        owner: ${{ inputs.owner }}
+        repositories: ${{ inputs.repositories }}

--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -26,7 +26,7 @@
 - `pr-gate.yml` 은 기존 `push`/`pull_request`/`merge_group` 진입점을 유지하면서 `workflow_call` 도 지원한다.
 - 호출자는 `stage` (`dev`, `dev-staging`, `nightly`, `rc`, `main`) 와 `base_ref` 를 넘겨 동일한 CI 코어를 stage 별 gate 로 재사용한다.
 - 기존 required check 는 아직 `ci-result` 그대로 유지한다. stage 별 required check 전환은 branch-strategy Phase 4 에서 Ruleset 과 함께 적용한다.
-- protected branch/tag 에 직접 push 하는 workflow 는 `MINGLIT_RELEASE_BOT_TOKEN` 을 사용한다. `sync-version.yml` 의 dev/main version bump 도 여기에 포함된다.
+- protected branch/tag 에 직접 push 하는 workflow 는 `minglit-release-bot` GitHub App token 을 사용한다. 공통 token mint 는 `.github/actions/release-bot-token` 에서 처리한다.
 
 ## 컨벤션
 

--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -27,14 +27,14 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Validate release bot token
-        env:
-          MINGLIT_RELEASE_BOT_TOKEN: ${{ secrets.MINGLIT_RELEASE_BOT_TOKEN }}
-        run: |
-          if [ -z "${MINGLIT_RELEASE_BOT_TOKEN}" ]; then
-            echo "::error::MINGLIT_RELEASE_BOT_TOKEN is required for protected branch version bump pushes"
-            exit 1
-          fi
+      - name: Generate release bot token
+        id: release-bot
+        uses: ./.github/actions/release-bot-token
+        with:
+          app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ vars.MINGLIT_RELEASE_BOT_OWNER || 'team-minglit' }}
+          repositories: ${{ vars.MINGLIT_RELEASE_BOT_REPOSITORIES || 'minglit' }}
 
       - name: Setup Python
         uses: actions/setup-python@v6
@@ -72,14 +72,14 @@ jobs:
 
       - name: Commit and push version bump
         env:
-          MINGLIT_RELEASE_BOT_TOKEN: ${{ secrets.MINGLIT_RELEASE_BOT_TOKEN }}
+          RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
         run: |
           NEW_VERSION="${{ steps.version.outputs.new }}"
           BRANCH="${{ github.base_ref }}"
 
           git config user.name "minglit-release-bot"
           git config user.email "minglit-release-bot@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${MINGLIT_RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
           git add -A
           git diff --cached --quiet && { echo "No version changes to commit."; exit 0; }
@@ -108,7 +108,7 @@ jobs:
       - name: Create GitHub release (main only)
         if: github.base_ref == 'main'
         env:
-          GH_TOKEN: ${{ secrets.MINGLIT_RELEASE_BOT_TOKEN }}
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
         run: |
           VERSION="${{ steps.version.outputs.base }}"
           gh release create "v${VERSION}" \

--- a/docs/infra/branch-strategy/specs/BLUEDOC.md
+++ b/docs/infra/branch-strategy/specs/BLUEDOC.md
@@ -12,6 +12,7 @@ design 문서는 운영자 관점 (cadence, role, policy). spec 문서는 구현
 |------|------|
 | [workflow-spec.md](./workflow-spec.md) | `.github/workflows/` 의 reusable + entry workflow 의 trigger / input / output / steps / call chain |
 | [branch-spec.md](./branch-spec.md) | 각 branch 의 protection rule, required check, merge method, release bot bypass 설정값 |
+| [release-bot.md](./release-bot.md) | `minglit-release-bot` GitHub App 권한, secret/env, Ruleset bypass, workflow 사용법 |
 | [execution-plan.md](./execution-plan.md) | 현재 workflow 인벤토리, refactor / 신규 / 폐기, Phase 1~4 적용 순서 |
 | [secret-migration-plan.md](./secret-migration-plan.md) | GH secrets → minglit_env/{stage}/.env 단일 파일 통합 plan |
 

--- a/docs/infra/branch-strategy/specs/branch-spec.md
+++ b/docs/infra/branch-strategy/specs/branch-spec.md
@@ -159,7 +159,7 @@ Protected branch 에 대한 direct push 는 human 에게 허용하지 않는다.
 | 항목 | 값 |
 |------|----|
 | Actor | `minglit-release-bot` (GitHub App 권장, 대안: fine-grained PAT 전용 bot account) |
-| Token secret | `MINGLIT_RELEASE_BOT_TOKEN` |
+| Token source | GitHub App installation token minted from `MINGLIT_RELEASE_BOT_APP_ID` + `MINGLIT_RELEASE_BOT_PRIVATE_KEY` |
 | 사용 workflow | `dev-staging-post-merge-sync`, `nightly-cut`, `rc-cut`, `rc-post-merge-sync`, `rc-soak-check`, `rc-hotfix-backport`, `main-post-merge-promote` |
 | Ruleset bypass | `dev-staging`, `dev`, `rc/**`, `main`, protected tag push (`v*`, `promo/**`) |
 | Human 사용 | 금지. 로컬/수동 CLI 에서 token 사용 금지 |

--- a/docs/infra/branch-strategy/specs/execution-plan.md
+++ b/docs/infra/branch-strategy/specs/execution-plan.md
@@ -70,7 +70,7 @@
 | 2a | `pr-gate.yml` 단일 파일 유지하면서 내부 jobs 를 `workflow_call` 받게 변경 + stage parameter 추가. `pr-gate-core` 별도 파일 아님 | PR 흐름 동일, 내부 jobs reusable 化 |
 | 2b | stage 별 `extra_steps` 지원 (dev-staging / rc / main) | 기존 동작 동일 |
 | 2c | `version-bump` reusable extract (sync-version 의 핵심 로직) | sync-version 의 caller 가 reusable 호출하게 변경 |
-| 2d | `minglit-release-bot` 생성 + `MINGLIT_RELEASE_BOT_TOKEN` 등록 + workflow permission 최소화 | protected branch/tag push 를 human 대신 bot 으로 수행 |
+| 2d | `minglit-release-bot` 생성 + App ID/private key 등록 + workflow permission 최소화 | protected branch/tag push 를 human 대신 bot 으로 수행 |
 | 2e | `auto-issue` reusable 추가 | 신규 — 기존 영향 없음 |
 | 2f | **`ci-result` 폐기** — 현 branch protection 의 required check `ci-result` 를 각 branch 의 `pr-gate` 로 변경 (Phase 4 에서 실제 적용) | 본 step 은 workflow 측 준비, 실제 protection 변경은 4 |
 | 2g | `deploy-supabase` 의 trigger refactor — push:dev 부분을 rc-gate-pass workflow_call **with target=main-staging** 로 변경, push:main 은 main-post-merge-promote 의 workflow_call **with target=main** | staging deploy 와 prod deploy 분리. 사용자 서버 영향 X |
@@ -207,7 +207,7 @@ Phase 1 (skeletal) → Phase 2a-2c (pr-gate refactor) → Phase 3a (dev-staging 
 2. **trigger 변경**: cron → push 변경 시 *겹치는 기간* 발생할 수 있음 — 한쪽 비활성화 후 다른쪽 활성화. 부분 적용 금지
 3. **status check naming**: `rc-gate-pass` 같은 commit status 의 이름이 spec 과 workflow 에서 일치해야 함. branch protection 에는 직접 required 로 걸지 않고 `main-pr-gate` 내부에서 검증
 4. **AI agent 의 PR 동시성**: merge queue 없으니 race condition 발생 시 수동 conflict resolve 필요 (또는 merge queue 도입 검토)
-5. **Release bot token 실패**: `MINGLIT_RELEASE_BOT_TOKEN` 권한 부족이면 version bump/tag/promotion workflow 가 막힘. 최초 도입 시 dry-run branch 로 push/tag/delete까지 검증
+5. **Release bot token 실패**: GitHub App ID/private key 누락 또는 App 권한 부족이면 version bump/tag/promotion workflow 가 막힘. 최초 도입 시 dry-run branch 로 push/tag/delete까지 검증
 6. **Secret 마이그레이션 중 workflow 실패**: file 기반과 GH secret 참조가 섞이는 transition 기간 — env 변수 누락 시 즉시 발견 (CI 통과 못함)
 
 ## Self-review: Phase 3 ordering

--- a/docs/infra/branch-strategy/specs/release-bot.md
+++ b/docs/infra/branch-strategy/specs/release-bot.md
@@ -1,0 +1,119 @@
+# Release Bot
+
+`minglit-release-bot` 은 protected branch/tag/release 를 workflow 가 변경해야 할 때만 사용하는 GitHub App identity 다. Human direct push 를 대체하되, 일반 PR automation 과 release 권한을 분리한다.
+
+## GitHub App 설정
+
+| 항목 | 값 |
+|------|----|
+| App name | `minglit-release-bot` |
+| Owner | 개인 계정 또는 `team-minglit` org |
+| Visibility | **Any account** 권장 — 개인 계정에서 만든 App 을 org repo 에 설치하려면 필요 |
+| Installation target | `team-minglit/minglit` selected repository |
+| Webhook | 불필요. Active 해제 가능 |
+
+## Permissions
+
+GitHub App permission 은 아래만 부여한다.
+
+| Permission | Level | 이유 |
+|------------|-------|------|
+| Contents | Read/write | version bump commit, branch 생성/삭제, tag push, release asset/source 접근 |
+| Pull requests | Read/write | nightly/promotion/backport PR 생성, auto-merge enable |
+| Commit statuses | Read/write | `rc-gate-pass` 같은 commit status 설정 |
+| Checks | Read | required check / gate 상태 조회 |
+| Issues | Read/write | release 자동 이슈 생성, failure comment |
+| Metadata | Read | GitHub App 기본 권한 |
+
+부여하지 않는 권한:
+
+| Permission | 이유 |
+|------------|------|
+| Administration | Ruleset 수정은 초기 수동 설정 또는 별도 infra workflow 에서만 수행 |
+| Actions | workflow 실행/수정 권한은 상시 release path 에 불필요 |
+| Secrets | secret 조회/수정 금지 |
+| Members / Organization administration | repo release automation 범위 초과 |
+
+## Secrets / Env
+
+Workflow 에는 장기 PAT 를 저장하지 않는다. App private key 로 매 run 마다 1시간짜리 installation token 을 mint 한다.
+
+| 이름 | 위치 | 내용 |
+|------|------|------|
+| `MINGLIT_RELEASE_BOT_APP_ID` | GitHub Actions secret 또는 `minglit_env/{stage}` | GitHub App ID |
+| `MINGLIT_RELEASE_BOT_PRIVATE_KEY` | GitHub Actions secret 권장 | GitHub App private key PEM |
+| `MINGLIT_RELEASE_BOT_OWNER` | `minglit_env/{stage}` 또는 workflow env | `team-minglit` |
+| `MINGLIT_RELEASE_BOT_REPOSITORIES` | `minglit_env/{stage}` 또는 workflow env | `minglit` |
+
+비밀이 아닌 `owner`, `repositories` 는 env 파일에 둘 수 있다. `private-key` 는 줄바꿈이 포함된 PEM 이라 GitHub Actions secret 으로 두는 것을 기본값으로 한다.
+
+## Workflow 사용법
+
+공통 token mint 는 composite action 으로 제공한다.
+
+```yaml
+- name: Generate release bot token
+  id: release-bot
+  uses: ./.github/actions/release-bot-token
+  with:
+    app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
+    private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
+    owner: ${{ vars.MINGLIT_RELEASE_BOT_OWNER || 'team-minglit' }}
+    repositories: ${{ vars.MINGLIT_RELEASE_BOT_REPOSITORIES || 'minglit' }}
+```
+
+생성된 token 은 같은 job 에서만 사용한다.
+
+```yaml
+- uses: actions/checkout@v6
+  with:
+    token: ${{ steps.release-bot.outputs.token }}
+```
+
+또는 push 직전에 remote URL 에 주입한다.
+
+```bash
+git remote set-url origin "https://x-access-token:${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+git push origin HEAD:dev
+git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+```
+
+## 사용 workflow
+
+| Workflow | 사용 이유 |
+|----------|-----------|
+| `sync-version` | dev/main version bump commit, main release tag |
+| `dev-staging-post-merge-sync` | dev-staging version bump/tag |
+| `nightly-cut` | immutable nightly branch 생성, dev PR 생성 |
+| `rc-cut` | `rc/YYYY-Wxx` branch 생성, RC tag |
+| `rc-post-merge-sync` | RC hotfix version bump/tag |
+| `rc-soak-check` | rc → main promotion PR 생성/auto-merge |
+| `rc-hotfix-backport` | backport branch/PR 생성 |
+| `main-post-merge-promote` | final version/tag/release marker, RC branch cleanup |
+
+## Ruleset Bypass
+
+Ruleset bypass actor 는 `minglit-release-bot` App installation 으로 제한한다.
+
+| Target | 허용 작업 |
+|--------|-----------|
+| `dev-staging` | version bump commit, `v*-dev-staging` tag |
+| `dev` | nightly promotion/version metadata push |
+| `rc/**` | RC branch 생성/삭제, RC hotfix version bump |
+| `main` | final version bump/tag/promotion commit |
+| `v*`, `promo/**` | protected tag 생성 |
+
+Human 은 release bot private key/token 을 로컬에서 사용하지 않는다. 모든 bot write 는 workflow run URL, target ref, pushed tag/commit 을 job summary 에 남긴다.
+
+## 검증
+
+초기 설정 후 dry-run workflow 로 다음을 순서대로 확인한다.
+
+1. selected repo token mint 성공
+2. 임시 branch 생성/push/delete 성공
+3. 임시 tag 생성/delete 성공
+4. protected branch Ruleset bypass 성공
+5. 권한 부족 시 실패 메시지가 명확한지 확인
+
+---
+_Reviewed: 2026-05-23 09:40_

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -95,7 +95,7 @@ Cross-branch cherry-pick PR 자동 생성.
 | Trigger | `push` to `dev-staging` (PR squash merge 후) |
 | Inputs | (from event) PR number, merged SHA |
 | Outputs | tag `v{YY.MM.PR#}-dev-staging` |
-| Steps | calls `version-bump` (suffix=`-dev-staging`, version=`{YY.MM.PR#}`) using `MINGLIT_RELEASE_BOT_TOKEN` |
+| Steps | calls `version-bump` (suffix=`-dev-staging`, version=`{YY.MM.PR#}`) using release bot GitHub App token |
 
 ### nightly (dev 진입)
 


### PR DESCRIPTION
## Summary
- add a reusable composite action for minting minglit-release-bot GitHub App installation tokens
- switch sync-version from a long-lived MINGLIT_RELEASE_BOT_TOKEN to App ID/private-key based token minting
- document release bot permissions, denied permissions, Ruleset bypass targets, and dry-run validation steps
- add minglit_env dev metadata for release bot owner/repository/app-id placeholder via submodule update

## Verification
- python3 YAML parse over all .github/workflows/*.yml and .github/actions/*/action.yml
- git diff --check
- graphify update . attempted; output excluded because local graphify regenerated the smaller 13,390-node graph and would downgrade current dev graphify output

## Required Setup
- Create GitHub App: minglit-release-bot
- Add Actions secrets: MINGLIT_RELEASE_BOT_APP_ID, MINGLIT_RELEASE_BOT_PRIVATE_KEY
- Add repo variables or keep defaults: MINGLIT_RELEASE_BOT_OWNER=team-minglit, MINGLIT_RELEASE_BOT_REPOSITORIES=minglit
- Grant release bot Ruleset bypass for protected release refs before relying on sync-version.