### PR TITLE
ci: load release bot credentials from env files

### DIFF
--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -26,7 +26,7 @@
 - `pr-gate.yml` 은 기존 `push`/`pull_request`/`merge_group` 진입점을 유지하면서 `workflow_call` 도 지원한다.
 - 호출자는 `stage` (`dev`, `dev-staging`, `nightly`, `rc`, `main`) 와 `base_ref` 를 넘겨 동일한 CI 코어를 stage 별 gate 로 재사용한다.
 - 기존 required check 는 아직 `ci-result` 그대로 유지한다. stage 별 required check 전환은 branch-strategy Phase 4 에서 Ruleset 과 함께 적용한다.
-- protected branch/tag 에 직접 push 하는 workflow 는 `minglit-release-bot` GitHub App token 을 사용한다. 공통 token mint 는 `.github/actions/release-bot-token` 에서 처리한다.
+- protected branch/tag 에 직접 push 하는 workflow 는 `minglit-release-bot` GitHub App token 을 사용한다. App credential 은 `minglit_env/{stage}/github.env` 파일에서 먼저 읽고, 공통 token mint 는 `.github/actions/release-bot-token` 에서 처리한다.
 
 ## 컨벤션
 

--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -27,14 +27,77 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Checkout minglit_env submodule
+        env:
+          MINGLIT_ENV_PAT: ${{ secrets.MINGLIT_ENV_PAT }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MINGLIT_ENV_PAT:-}" ]; then
+            echo "::warning::MINGLIT_ENV_PAT is not configured; falling back to GitHub Actions secrets for release bot credentials."
+            exit 0
+          fi
+
+          git -c "url.https://x-access-token:${MINGLIT_ENV_PAT}@github.com/.insteadOf=https://github.com/" \
+            submodule update --init --recursive minglit_env
+
+      - name: Load release bot credentials
+        env:
+          FALLBACK_APP_ID: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
+          FALLBACK_PRIVATE_KEY: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          env_file="minglit_env/dev/github.env"
+
+          if [ -f "${env_file}" ]; then
+            set -a
+            # shellcheck disable=SC1090
+            . "${env_file}"
+            set +a
+          else
+            echo "::warning::${env_file} not found; using GitHub Actions secrets fallback."
+          fi
+
+          MINGLIT_RELEASE_BOT_APP_ID="${MINGLIT_RELEASE_BOT_APP_ID:-${FALLBACK_APP_ID:-}}"
+          MINGLIT_RELEASE_BOT_OWNER="${MINGLIT_RELEASE_BOT_OWNER:-Mark-Yun}"
+          MINGLIT_RELEASE_BOT_REPOSITORIES="${MINGLIT_RELEASE_BOT_REPOSITORIES:-minglit}"
+
+          if [ -n "${MINGLIT_RELEASE_BOT_PRIVATE_KEY_BASE64:-}" ]; then
+            {
+              echo "MINGLIT_RELEASE_BOT_PRIVATE_KEY<<EOF"
+              printf '%s' "${MINGLIT_RELEASE_BOT_PRIVATE_KEY_BASE64}" | base64 --decode
+              echo
+              echo "EOF"
+            } >> "${GITHUB_ENV}"
+          elif [ -n "${FALLBACK_PRIVATE_KEY:-}" ]; then
+            {
+              echo "MINGLIT_RELEASE_BOT_PRIVATE_KEY<<EOF"
+              printf '%s\n' "${FALLBACK_PRIVATE_KEY}"
+              echo "EOF"
+            } >> "${GITHUB_ENV}"
+          else
+            echo "::error::Missing release bot private key. Configure minglit_env/dev/github.env or MINGLIT_RELEASE_BOT_PRIVATE_KEY."
+            exit 1
+          fi
+
+          if [ -z "${MINGLIT_RELEASE_BOT_APP_ID}" ]; then
+            echo "::error::Missing release bot app ID. Configure minglit_env/dev/github.env or MINGLIT_RELEASE_BOT_APP_ID."
+            exit 1
+          fi
+
+          {
+            echo "MINGLIT_RELEASE_BOT_APP_ID=${MINGLIT_RELEASE_BOT_APP_ID}"
+            echo "MINGLIT_RELEASE_BOT_OWNER=${MINGLIT_RELEASE_BOT_OWNER}"
+            echo "MINGLIT_RELEASE_BOT_REPOSITORIES=${MINGLIT_RELEASE_BOT_REPOSITORIES}"
+          } >> "${GITHUB_ENV}"
+
       - name: Generate release bot token
         id: release-bot
         uses: ./.github/actions/release-bot-token
         with:
-          app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
-          private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
-          owner: ${{ vars.MINGLIT_RELEASE_BOT_OWNER || 'team-minglit' }}
-          repositories: ${{ vars.MINGLIT_RELEASE_BOT_REPOSITORIES || 'minglit' }}
+          app-id: ${{ env.MINGLIT_RELEASE_BOT_APP_ID }}
+          private-key: ${{ env.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ env.MINGLIT_RELEASE_BOT_OWNER }}
+          repositories: ${{ env.MINGLIT_RELEASE_BOT_REPOSITORIES }}
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,12 +313,12 @@ deno test --allow-all supabase/functions/{function_name}/
 
 ## graphify
 
-This project has a graphify knowledge graph at graphify-out/.
+This project has a graphify knowledge graph at graphify-out/. 자동 갱신은 `.github/workflows/sync-graphify.yml` 워크플로우가 담당한다.
 
 Rules:
 - Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
 - If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
 - For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
-- After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
-- `graphify-out/` 안 파일이 commit/checkout/merge 직후 dirty 로 남으면 post-commit hook 부산물 — 사용자 작업이 아님. `git checkout HEAD -- graphify-out/` 또는 `git stash` 로 자유롭게 정리 가능 (별도 승인 불필요). 새 commit 에 포함 필요한 변경(코드 수정으로 인한 그래프 변화)이면 `git add graphify-out/` 로 묶어 커밋
-- 머지 충돌이 `graphify-out/` 파일에서만 발생하면 `git checkout --theirs graphify-out/` + `graphify update .` 로 재생성하여 해결 (사용자 작업이 아닌 hook 산출물이므로 어느 쪽이든 안전)
+- 로컬에서 수동으로 `graphify update .` 하거나 `graphify-out/` 을 커밋할 필요 없다. GitHub Actions 가 dev push 와 daily schedule 로 자동 갱신한다.
+- `graphify-out/` 안 파일이 commit/checkout/merge 직후 dirty 로 남으면 자동화 산출물로 보고 `git checkout HEAD -- graphify-out/` 또는 `git clean -fd graphify-out/` 로 정리한다.
+- 머지 충돌이 `graphify-out/` 파일에서만 발생하면 `git checkout --theirs graphify-out/` 로 해결한다. 다음 워크플로우 실행에서 재계산된다.

--- a/docs/infra/branch-strategy/specs/branch-spec.md
+++ b/docs/infra/branch-strategy/specs/branch-spec.md
@@ -159,7 +159,7 @@ Protected branch 에 대한 direct push 는 human 에게 허용하지 않는다.
 | 항목 | 값 |
 |------|----|
 | Actor | `minglit-release-bot` (GitHub App 권장, 대안: fine-grained PAT 전용 bot account) |
-| Token source | GitHub App installation token minted from `MINGLIT_RELEASE_BOT_APP_ID` + `MINGLIT_RELEASE_BOT_PRIVATE_KEY` |
+| Token source | GitHub App installation token minted from `minglit_env/{stage}/github.env` (`MINGLIT_RELEASE_BOT_APP_ID` + `MINGLIT_RELEASE_BOT_PRIVATE_KEY_BASE64`) |
 | 사용 workflow | `dev-staging-post-merge-sync`, `nightly-cut`, `rc-cut`, `rc-post-merge-sync`, `rc-soak-check`, `rc-hotfix-backport`, `main-post-merge-promote` |
 | Ruleset bypass | `dev-staging`, `dev`, `rc/**`, `main`, protected tag push (`v*`, `promo/**`) |
 | Human 사용 | 금지. 로컬/수동 CLI 에서 token 사용 금지 |

--- a/docs/infra/branch-strategy/specs/release-bot.md
+++ b/docs/infra/branch-strategy/specs/release-bot.md
@@ -9,7 +9,7 @@
 | App name | `minglit-release-bot` |
 | Owner | 개인 계정 또는 `team-minglit` org |
 | Visibility | **Any account** 권장 — 개인 계정에서 만든 App 을 org repo 에 설치하려면 필요 |
-| Installation target | `team-minglit/minglit` selected repository |
+| Installation target | `Mark-Yun/minglit` selected repository |
 | Webhook | 불필요. Active 해제 가능 |
 
 ## Permissions
@@ -36,16 +36,17 @@ GitHub App permission 은 아래만 부여한다.
 
 ## Secrets / Env
 
-Workflow 에는 장기 PAT 를 저장하지 않는다. App private key 로 매 run 마다 1시간짜리 installation token 을 mint 한다.
+Workflow 에 release bot 장기 PAT 를 저장하지 않는다. App private key 로 매 run 마다 1시간짜리 installation token 을 mint 한다.
 
 | 이름 | 위치 | 내용 |
 |------|------|------|
-| `MINGLIT_RELEASE_BOT_APP_ID` | GitHub Actions secret 또는 `minglit_env/{stage}` | GitHub App ID |
-| `MINGLIT_RELEASE_BOT_PRIVATE_KEY` | GitHub Actions secret 권장 | GitHub App private key PEM |
-| `MINGLIT_RELEASE_BOT_OWNER` | `minglit_env/{stage}` 또는 workflow env | `team-minglit` |
-| `MINGLIT_RELEASE_BOT_REPOSITORIES` | `minglit_env/{stage}` 또는 workflow env | `minglit` |
+| `MINGLIT_RELEASE_BOT_APP_ID` | `minglit_env/{stage}/github.env` | GitHub App ID |
+| `MINGLIT_RELEASE_BOT_PRIVATE_KEY_BASE64` | `minglit_env/{stage}/github.env` | GitHub App private key PEM 을 base64 단일 라인으로 저장 |
+| `MINGLIT_RELEASE_BOT_OWNER` | `minglit_env/{stage}/github.env` | `Mark-Yun` |
+| `MINGLIT_RELEASE_BOT_REPOSITORIES` | `minglit_env/{stage}/github.env` | `minglit` |
+| `MINGLIT_ENV_PAT` | GitHub Actions secret | private `minglit_env` submodule checkout 용 read-only token |
 
-비밀이 아닌 `owner`, `repositories` 는 env 파일에 둘 수 있다. `private-key` 는 줄바꿈이 포함된 PEM 이라 GitHub Actions secret 으로 두는 것을 기본값으로 한다.
+`sync-version` 은 파일 기반 값을 우선 사용한다. `MINGLIT_ENV_PAT` 이 아직 없거나 submodule checkout 이 실패하는 transition 기간에는 기존 `MINGLIT_RELEASE_BOT_APP_ID` / `MINGLIT_RELEASE_BOT_PRIVATE_KEY` GitHub Actions secret 을 fallback 으로 사용할 수 있다.
 
 ## Workflow 사용법
 
@@ -56,10 +57,10 @@ Workflow 에는 장기 PAT 를 저장하지 않는다. App private key 로 매 r
   id: release-bot
   uses: ./.github/actions/release-bot-token
   with:
-    app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
-    private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
-    owner: ${{ vars.MINGLIT_RELEASE_BOT_OWNER || 'team-minglit' }}
-    repositories: ${{ vars.MINGLIT_RELEASE_BOT_REPOSITORIES || 'minglit' }}
+    app-id: ${{ env.MINGLIT_RELEASE_BOT_APP_ID }}
+    private-key: ${{ env.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
+    owner: ${{ env.MINGLIT_RELEASE_BOT_OWNER }}
+    repositories: ${{ env.MINGLIT_RELEASE_BOT_REPOSITORIES }}
 ```
 
 생성된 token 은 같은 job 에서만 사용한다.


### PR DESCRIPTION
## Summary
- load release bot GitHub App credentials from minglit_env/dev/github.env when available
- keep existing GitHub Actions secrets as a transition fallback
- document file-based release bot env and remove local graphify update instruction from AGENTS.md

## Verification
- ruby YAML parse for sync-version and release-bot-token
- git diff --check