### PR TITLE
ci: move release bot env loading into action

### DIFF
--- a/.github/actions/BLUEDOC.md
+++ b/.github/actions/BLUEDOC.md
@@ -9,7 +9,7 @@
 | [deploy-flutter-app](./deploy-flutter-app/action.yml) | Flutter app deploy 공통 action |
 | [deploy-nextjs-app](./deploy-nextjs-app/action.yml) | Next.js app deploy 공통 action |
 | [ios-deploy](./ios-deploy/action.yml) | iOS deploy 공통 action |
-| [release-bot-token](./release-bot-token/action.yml) | `minglit-release-bot` GitHub App installation token mint |
+| [release-bot-token](./release-bot-token/action.yml) | `minglit_env/{stage}/github.env` 우선 로드 + `minglit-release-bot` GitHub App installation token mint |
 
 ## 컨벤션
 

--- a/.github/actions/release-bot-token/action.yml
+++ b/.github/actions/release-bot-token/action.yml
@@ -2,18 +2,30 @@ name: release-bot-token
 description: Mint a short-lived GitHub App installation token for minglit-release-bot.
 
 inputs:
-  app-id:
-    description: GitHub App ID for minglit-release-bot.
-    required: true
-  private-key:
-    description: GitHub App private key for minglit-release-bot.
-    required: true
+  env-file:
+    description: Env file containing release bot GitHub App credentials.
+    required: false
+    default: minglit_env/dev/github.env
+  minglit-env-pat:
+    description: Optional token for checking out the private minglit_env submodule.
+    required: false
+    default: ''
+  fallback-app-id:
+    description: Fallback GitHub App ID when env-file is unavailable.
+    required: false
+    default: ''
+  fallback-private-key:
+    description: Fallback GitHub App private key PEM when env-file is unavailable.
+    required: false
+    default: ''
   owner:
-    description: Account or organization where the app is installed.
-    required: true
+    description: Default account or organization where the app is installed.
+    required: false
+    default: Mark-Yun
   repositories:
-    description: Repository list to scope the installation token to.
-    required: true
+    description: Default repository list to scope the installation token to.
+    required: false
+    default: minglit
 
 outputs:
   token:
@@ -23,11 +35,79 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Checkout minglit_env submodule
+      shell: bash
+      env:
+        MINGLIT_ENV_PAT: ${{ inputs.minglit-env-pat }}
+      run: |
+        set -euo pipefail
+        if [ -z "${MINGLIT_ENV_PAT:-}" ]; then
+          echo "::warning::MINGLIT_ENV_PAT is not configured; release bot credentials will use fallback inputs if env-file is unavailable."
+          exit 0
+        fi
+
+        git -c "url.https://x-access-token:${MINGLIT_ENV_PAT}@github.com/.insteadOf=https://github.com/" \
+          submodule update --init --recursive minglit_env
+
+    - name: Load release bot credentials
+      id: credentials
+      shell: bash
+      env:
+        ENV_FILE: ${{ inputs.env-file }}
+        FALLBACK_APP_ID: ${{ inputs.fallback-app-id }}
+        FALLBACK_PRIVATE_KEY: ${{ inputs.fallback-private-key }}
+        DEFAULT_OWNER: ${{ inputs.owner }}
+        DEFAULT_REPOSITORIES: ${{ inputs.repositories }}
+      run: |
+        set -euo pipefail
+
+        if [ -f "${ENV_FILE}" ]; then
+          set -a
+          # shellcheck disable=SC1090
+          . "${ENV_FILE}"
+          set +a
+        else
+          echo "::warning::${ENV_FILE} not found; using release bot fallback inputs."
+        fi
+
+        MINGLIT_RELEASE_BOT_APP_ID="${MINGLIT_RELEASE_BOT_APP_ID:-${FALLBACK_APP_ID:-}}"
+        MINGLIT_RELEASE_BOT_OWNER="${MINGLIT_RELEASE_BOT_OWNER:-${DEFAULT_OWNER}}"
+        MINGLIT_RELEASE_BOT_REPOSITORIES="${MINGLIT_RELEASE_BOT_REPOSITORIES:-${DEFAULT_REPOSITORIES}}"
+
+        if [ -z "${MINGLIT_RELEASE_BOT_APP_ID}" ]; then
+          echo "::error::Missing release bot app ID. Configure ${ENV_FILE} or fallback-app-id."
+          exit 1
+        fi
+
+        {
+          echo "app_id=${MINGLIT_RELEASE_BOT_APP_ID}"
+          echo "owner=${MINGLIT_RELEASE_BOT_OWNER}"
+          echo "repositories=${MINGLIT_RELEASE_BOT_REPOSITORIES}"
+        } >> "${GITHUB_OUTPUT}"
+
+        if [ -n "${MINGLIT_RELEASE_BOT_PRIVATE_KEY_BASE64:-}" ]; then
+          {
+            echo "private_key<<EOF"
+            printf '%s' "${MINGLIT_RELEASE_BOT_PRIVATE_KEY_BASE64}" | base64 --decode
+            echo
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+        elif [ -n "${FALLBACK_PRIVATE_KEY:-}" ]; then
+          {
+            echo "private_key<<EOF"
+            printf '%s\n' "${FALLBACK_PRIVATE_KEY}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+        else
+          echo "::error::Missing release bot private key. Configure ${ENV_FILE} or fallback-private-key."
+          exit 1
+        fi
+
     - name: Generate release bot token
       id: app-token
       uses: actions/create-github-app-token@v2
       with:
-        app-id: ${{ inputs.app-id }}
-        private-key: ${{ inputs.private-key }}
-        owner: ${{ inputs.owner }}
-        repositories: ${{ inputs.repositories }}
+        app-id: ${{ steps.credentials.outputs.app_id }}
+        private-key: ${{ steps.credentials.outputs.private_key }}
+        owner: ${{ steps.credentials.outputs.owner }}
+        repositories: ${{ steps.credentials.outputs.repositories }}

--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -27,77 +27,14 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Checkout minglit_env submodule
-        env:
-          MINGLIT_ENV_PAT: ${{ secrets.MINGLIT_ENV_PAT }}
-        run: |
-          set -euo pipefail
-          if [ -z "${MINGLIT_ENV_PAT:-}" ]; then
-            echo "::warning::MINGLIT_ENV_PAT is not configured; falling back to GitHub Actions secrets for release bot credentials."
-            exit 0
-          fi
-
-          git -c "url.https://x-access-token:${MINGLIT_ENV_PAT}@github.com/.insteadOf=https://github.com/" \
-            submodule update --init --recursive minglit_env
-
-      - name: Load release bot credentials
-        env:
-          FALLBACK_APP_ID: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
-          FALLBACK_PRIVATE_KEY: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
-        run: |
-          set -euo pipefail
-          env_file="minglit_env/dev/github.env"
-
-          if [ -f "${env_file}" ]; then
-            set -a
-            # shellcheck disable=SC1090
-            . "${env_file}"
-            set +a
-          else
-            echo "::warning::${env_file} not found; using GitHub Actions secrets fallback."
-          fi
-
-          MINGLIT_RELEASE_BOT_APP_ID="${MINGLIT_RELEASE_BOT_APP_ID:-${FALLBACK_APP_ID:-}}"
-          MINGLIT_RELEASE_BOT_OWNER="${MINGLIT_RELEASE_BOT_OWNER:-Mark-Yun}"
-          MINGLIT_RELEASE_BOT_REPOSITORIES="${MINGLIT_RELEASE_BOT_REPOSITORIES:-minglit}"
-
-          if [ -n "${MINGLIT_RELEASE_BOT_PRIVATE_KEY_BASE64:-}" ]; then
-            {
-              echo "MINGLIT_RELEASE_BOT_PRIVATE_KEY<<EOF"
-              printf '%s' "${MINGLIT_RELEASE_BOT_PRIVATE_KEY_BASE64}" | base64 --decode
-              echo
-              echo "EOF"
-            } >> "${GITHUB_ENV}"
-          elif [ -n "${FALLBACK_PRIVATE_KEY:-}" ]; then
-            {
-              echo "MINGLIT_RELEASE_BOT_PRIVATE_KEY<<EOF"
-              printf '%s\n' "${FALLBACK_PRIVATE_KEY}"
-              echo "EOF"
-            } >> "${GITHUB_ENV}"
-          else
-            echo "::error::Missing release bot private key. Configure minglit_env/dev/github.env or MINGLIT_RELEASE_BOT_PRIVATE_KEY."
-            exit 1
-          fi
-
-          if [ -z "${MINGLIT_RELEASE_BOT_APP_ID}" ]; then
-            echo "::error::Missing release bot app ID. Configure minglit_env/dev/github.env or MINGLIT_RELEASE_BOT_APP_ID."
-            exit 1
-          fi
-
-          {
-            echo "MINGLIT_RELEASE_BOT_APP_ID=${MINGLIT_RELEASE_BOT_APP_ID}"
-            echo "MINGLIT_RELEASE_BOT_OWNER=${MINGLIT_RELEASE_BOT_OWNER}"
-            echo "MINGLIT_RELEASE_BOT_REPOSITORIES=${MINGLIT_RELEASE_BOT_REPOSITORIES}"
-          } >> "${GITHUB_ENV}"
-
       - name: Generate release bot token
         id: release-bot
         uses: ./.github/actions/release-bot-token
         with:
-          app-id: ${{ env.MINGLIT_RELEASE_BOT_APP_ID }}
-          private-key: ${{ env.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
-          owner: ${{ env.MINGLIT_RELEASE_BOT_OWNER }}
-          repositories: ${{ env.MINGLIT_RELEASE_BOT_REPOSITORIES }}
+          env-file: minglit_env/dev/github.env
+          minglit-env-pat: ${{ secrets.MINGLIT_ENV_PAT }}
+          fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
+          fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/docs/infra/branch-strategy/specs/release-bot.md
+++ b/docs/infra/branch-strategy/specs/release-bot.md
@@ -46,7 +46,7 @@ Workflow 에 release bot 장기 PAT 를 저장하지 않는다. App private key 
 | `MINGLIT_RELEASE_BOT_REPOSITORIES` | `minglit_env/{stage}/github.env` | `minglit` |
 | `MINGLIT_ENV_PAT` | GitHub Actions secret | private `minglit_env` submodule checkout 용 read-only token |
 
-`sync-version` 은 파일 기반 값을 우선 사용한다. `MINGLIT_ENV_PAT` 이 아직 없거나 submodule checkout 이 실패하는 transition 기간에는 기존 `MINGLIT_RELEASE_BOT_APP_ID` / `MINGLIT_RELEASE_BOT_PRIVATE_KEY` GitHub Actions secret 을 fallback 으로 사용할 수 있다.
+`release-bot-token` composite action 은 파일 기반 값을 우선 사용한다. `MINGLIT_ENV_PAT` 이 아직 없거나 submodule checkout 이 실패하는 transition 기간에는 기존 `MINGLIT_RELEASE_BOT_APP_ID` / `MINGLIT_RELEASE_BOT_PRIVATE_KEY` GitHub Actions secret 을 fallback 으로 사용할 수 있다.
 
 ## Workflow 사용법
 
@@ -57,10 +57,10 @@ Workflow 에 release bot 장기 PAT 를 저장하지 않는다. App private key 
   id: release-bot
   uses: ./.github/actions/release-bot-token
   with:
-    app-id: ${{ env.MINGLIT_RELEASE_BOT_APP_ID }}
-    private-key: ${{ env.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
-    owner: ${{ env.MINGLIT_RELEASE_BOT_OWNER }}
-    repositories: ${{ env.MINGLIT_RELEASE_BOT_REPOSITORIES }}
+    env-file: minglit_env/dev/github.env
+    minglit-env-pat: ${{ secrets.MINGLIT_ENV_PAT }}
+    fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
+    fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
 ```
 
 생성된 token 은 같은 job 에서만 사용한다.


### PR DESCRIPTION
## Summary
- move minglit_env checkout and release bot credential loading into the release-bot-token composite action
- keep sync-version focused on version bump flow and token consumption
- keep existing GitHub secret fallback for the transition period

## Verification
- ruby YAML parse for sync-version and release-bot-token
- git diff --check