### PR TITLE
ci: bootstrap minglit env with release bot

### DIFF
--- a/.github/actions/release-bot-token/action.yml
+++ b/.github/actions/release-bot-token/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: Optional token for checking out the private minglit_env submodule.
     required: false
     default: ''
+  env-repository:
+    description: Repository that contains the private env submodule.
+    required: false
+    default: minglit_env
   fallback-app-id:
     description: Fallback GitHub App ID when env-file is unavailable.
     required: false
@@ -35,18 +39,28 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Generate minglit_env checkout token
+      id: env-token
+      if: ${{ inputs.minglit-env-pat == '' && inputs.fallback-app-id != '' && inputs.fallback-private-key != '' }}
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ inputs.fallback-app-id }}
+        private-key: ${{ inputs.fallback-private-key }}
+        owner: ${{ inputs.owner }}
+        repositories: ${{ inputs.env-repository }}
+
     - name: Checkout minglit_env submodule
       shell: bash
       env:
-        MINGLIT_ENV_PAT: ${{ inputs.minglit-env-pat }}
+        MINGLIT_ENV_TOKEN: ${{ inputs.minglit-env-pat || steps.env-token.outputs.token }}
       run: |
         set -euo pipefail
-        if [ -z "${MINGLIT_ENV_PAT:-}" ]; then
-          echo "::warning::MINGLIT_ENV_PAT is not configured; release bot credentials will use fallback inputs if env-file is unavailable."
+        if [ -z "${MINGLIT_ENV_TOKEN:-}" ]; then
+          echo "::warning::No minglit_env checkout token is available; release bot credentials will use fallback inputs if env-file is unavailable."
           exit 0
         fi
 
-        git -c "url.https://x-access-token:${MINGLIT_ENV_PAT}@github.com/.insteadOf=https://github.com/" \
+        git -c "url.https://x-access-token:${MINGLIT_ENV_TOKEN}@github.com/.insteadOf=https://github.com/" \
           submodule update --init --recursive minglit_env
 
     - name: Load release bot credentials

--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -32,7 +32,6 @@ jobs:
         uses: ./.github/actions/release-bot-token
         with:
           env-file: minglit_env/dev/github.env
-          minglit-env-pat: ${{ secrets.MINGLIT_ENV_PAT }}
           fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
           fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
 

--- a/docs/infra/branch-strategy/specs/release-bot.md
+++ b/docs/infra/branch-strategy/specs/release-bot.md
@@ -9,7 +9,7 @@
 | App name | `minglit-release-bot` |
 | Owner | 개인 계정 또는 `team-minglit` org |
 | Visibility | **Any account** 권장 — 개인 계정에서 만든 App 을 org repo 에 설치하려면 필요 |
-| Installation target | `Mark-Yun/minglit` selected repository |
+| Installation target | `Mark-Yun/minglit` + `Mark-Yun/minglit_env` selected repositories |
 | Webhook | 불필요. Active 해제 가능 |
 
 ## Permissions
@@ -44,9 +44,10 @@ Workflow 에 release bot 장기 PAT 를 저장하지 않는다. App private key 
 | `MINGLIT_RELEASE_BOT_PRIVATE_KEY_BASE64` | `minglit_env/{stage}/github.env` | GitHub App private key PEM 을 base64 단일 라인으로 저장 |
 | `MINGLIT_RELEASE_BOT_OWNER` | `minglit_env/{stage}/github.env` | `Mark-Yun` |
 | `MINGLIT_RELEASE_BOT_REPOSITORIES` | `minglit_env/{stage}/github.env` | `minglit` |
-| `MINGLIT_ENV_PAT` | GitHub Actions secret | private `minglit_env` submodule checkout 용 read-only token |
+| `MINGLIT_RELEASE_BOT_APP_ID` | GitHub Actions secret | `minglit_env` checkout bootstrap 용 GitHub App ID |
+| `MINGLIT_RELEASE_BOT_PRIVATE_KEY` | GitHub Actions secret | `minglit_env` checkout bootstrap 용 GitHub App private key PEM |
 
-`release-bot-token` composite action 은 파일 기반 값을 우선 사용한다. `MINGLIT_ENV_PAT` 이 아직 없거나 submodule checkout 이 실패하는 transition 기간에는 기존 `MINGLIT_RELEASE_BOT_APP_ID` / `MINGLIT_RELEASE_BOT_PRIVATE_KEY` GitHub Actions secret 을 fallback 으로 사용할 수 있다.
+`release-bot-token` composite action 은 GitHub Actions secret 의 App key 로 bootstrap token 을 만든 뒤 `minglit_env` 를 checkout 하고, 파일 기반 값을 우선 사용한다. `minglit_env` 를 읽을 수 없을 때만 기존 `MINGLIT_RELEASE_BOT_APP_ID` / `MINGLIT_RELEASE_BOT_PRIVATE_KEY` GitHub Actions secret 을 fallback 으로 사용한다.
 
 ## Workflow 사용법
 
@@ -58,7 +59,6 @@ Workflow 에 release bot 장기 PAT 를 저장하지 않는다. App private key 
   uses: ./.github/actions/release-bot-token
   with:
     env-file: minglit_env/dev/github.env
-    minglit-env-pat: ${{ secrets.MINGLIT_ENV_PAT }}
     fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
     fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
 ```


### PR DESCRIPTION
## Summary
- use the release bot GitHub App secret as the bootstrap credential for minglit_env checkout
- remove the MINGLIT_ENV_PAT requirement from sync-version
- keep minglit_env/dev/github.env as the preferred source for release bot App credentials

## Verification
- ruby YAML parse for release-bot-token and sync-version
- git diff --check