### PR TITLE
ci: extract reusable version bump workflow

### DIFF
--- a/.github/BLUEDOC.md
+++ b/.github/BLUEDOC.md
@@ -14,7 +14,7 @@ GitHub 통합 폴더 — CI/CD 워크플로우, composite actions, shell scripts
 
 ## 핵심 컨벤션
 
-- **워크플로우는 9 prefix 중 하나** (pr-gate / pr-setup / pr-review-setup / deploy / monitor / sync / triage / tool / shared) — [`workflows/BLUEDOC.md`](./workflows/BLUEDOC.md) 참고.
+- **entry 워크플로우는 9 prefix 중 하나** (pr-gate / pr-setup / pr-review-setup / deploy / monitor / sync / triage / tool / shared), `workflow_call` 전용 reusable 은 domain name 허용 — [`workflows/BLUEDOC.md`](./workflows/BLUEDOC.md) 참고.
 - **재사용 가능한 step 묶음은 `actions/` composite 로 분리**, 단순 명령 묶음은 `scripts/` 로.
 - **dependabot 은 patch/minor 자동 머지** (pr-review-setup 의 dependabot 분기), major 는 수동.
 
@@ -24,4 +24,4 @@ GitHub 통합 폴더 — CI/CD 워크플로우, composite actions, shell scripts
 - [BLUEDOC 컨벤션](../docs/infra/bluedoc/BLUEDOC.md)
 
 ---
-_Reviewed: 2026-05-17 22:32_
+_Reviewed: 2026-05-23 16:05_

--- a/.github/actions/release-bot-token/action.yml
+++ b/.github/actions/release-bot-token/action.yml
@@ -41,18 +41,18 @@ runs:
   steps:
     - name: Generate minglit_env checkout token
       id: env-token
-      if: ${{ inputs.minglit-env-pat == '' && inputs.fallback-app-id != '' && inputs.fallback-private-key != '' }}
+      if: ${{ inputs['minglit-env-pat'] == '' && inputs['fallback-app-id'] != '' && inputs['fallback-private-key'] != '' }}
       uses: actions/create-github-app-token@v2
       with:
-        app-id: ${{ inputs.fallback-app-id }}
-        private-key: ${{ inputs.fallback-private-key }}
+        app-id: ${{ inputs['fallback-app-id'] }}
+        private-key: ${{ inputs['fallback-private-key'] }}
         owner: ${{ inputs.owner }}
-        repositories: ${{ inputs.env-repository }}
+        repositories: ${{ inputs['env-repository'] }}
 
     - name: Checkout minglit_env submodule
       shell: bash
       env:
-        MINGLIT_ENV_TOKEN: ${{ inputs.minglit-env-pat || steps.env-token.outputs.token }}
+        MINGLIT_ENV_TOKEN: ${{ inputs['minglit-env-pat'] || steps.env-token.outputs.token }}
       run: |
         set -euo pipefail
         if [ -z "${MINGLIT_ENV_TOKEN:-}" ]; then
@@ -67,9 +67,9 @@ runs:
       id: credentials
       shell: bash
       env:
-        ENV_FILE: ${{ inputs.env-file }}
-        FALLBACK_APP_ID: ${{ inputs.fallback-app-id }}
-        FALLBACK_PRIVATE_KEY: ${{ inputs.fallback-private-key }}
+        ENV_FILE: ${{ inputs['env-file'] }}
+        FALLBACK_APP_ID: ${{ inputs['fallback-app-id'] }}
+        FALLBACK_PRIVATE_KEY: ${{ inputs['fallback-private-key'] }}
         DEFAULT_OWNER: ${{ inputs.owner }}
         DEFAULT_REPOSITORIES: ${{ inputs.repositories }}
       run: |

--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -20,6 +20,7 @@
 | `post-merge` | dev push 직후 follow-up 자동화의 단일 entry point (5 reusable orchestrator) | `post-merge` |
 | `tool-` | (수동으로 부를 때만 도는 도구) | (현재 없음 — 새 수동 도구 추가 시 prefix) |
 | `shared-` | (다른 워크플로우의 부품 — 단독 실행 X) | `shared-notify`, `shared-android-deploy` |
+| reusable no-prefix | `workflow_call` 로만 호출되는 domain reusable | `version-bump` |
 
 ## Reusable Gates
 
@@ -32,7 +33,7 @@
 
 - **파일명 = workflow `name:` 필드** (소문자 kebab, 확장자 제외). 예: `deploy-vercel.yml` 의 `name: deploy-vercel`.
 - prefix 다음은 *대상*만 적는다. 액션 동사는 prefix 가 이미 함의함 (`deploy-vercel` ◯ / `deploy-to-vercel` ✗).
-- 새 워크플로우는 위 9 prefix 중 하나에 반드시 속해야 한다. 어디에도 안 맞으면 새 prefix 추가 PR 을 먼저 낸다.
+- 새 entry workflow 는 위 9 prefix 중 하나에 반드시 속해야 한다. `workflow_call` 전용 reusable 은 domain name no-prefix 를 허용한다.
 - `pr-setup-` vs `pr-review-setup-` vs `sync-` vs `triage-` 의 기준:
   - `pr-setup-` = PR push 마다 PR 브랜치를 mutate (#2627 이후 인스턴스 없음 — auto-format 은 `pr-gate` 의 `format-check` 잡으로 대체)
   - `pr-review-setup-` = PR 의 "리뷰 준비 단계" 자동화 (auto-merge enable, `needs-review` 라벨 부여)
@@ -45,4 +46,4 @@
 - [CLAUDE.md](../../CLAUDE.md) `## PR Conventions` — required check (`ci-result` job = `pr-gate.yml` 내부) / auto-merge 흐름
 
 ---
-_Reviewed: 2026-05-20 09:15_
+_Reviewed: 2026-05-23 16:05_

--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -14,31 +14,20 @@ permissions:
   pull-requests: write
 
 jobs:
-  bump:
+  calculate-version:
     if: >-
       github.event.pull_request.merged == true &&
       !startsWith(github.event.pull_request.title, 'chore: bump version')
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.new }}
+      release_version: ${{ steps.version.outputs.base }}
 
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.base_ref }}
           fetch-depth: 0
-          persist-credentials: false
-
-      - name: Generate release bot token
-        id: release-bot
-        uses: ./.github/actions/release-bot-token
-        with:
-          env-file: minglit_env/dev/github.env
-          fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
-          fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.x'
 
       - name: Calculate next CalVer version
         id: version
@@ -66,62 +55,27 @@ jobs:
           echo "base=$BASE" >> "$GITHUB_OUTPUT"
           echo "Bumping $CURRENT → $NEW_VERSION"
 
-      - name: Run bump-version.sh
-        run: bash scripts/bump-version.sh "${{ steps.version.outputs.new }}"
-
-      - name: Commit and push version bump
-        env:
-          RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
-        run: |
-          NEW_VERSION="${{ steps.version.outputs.new }}"
-          BRANCH="${{ github.base_ref }}"
-
-          git config user.name "minglit-release-bot"
-          git config user.email "minglit-release-bot@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-
-          git add -A
-          git diff --cached --quiet && { echo "No version changes to commit."; exit 0; }
-          git commit -m "chore: bump version to v${NEW_VERSION} [skip ci]"
-
-          # Fix #1506: push race — dev가 다른 경로로 전진할 수 있어 pull --rebase + retry
-          MAX_ATTEMPTS=5
-          ATTEMPT=0
-          until git push origin HEAD:${BRANCH}; do
-            ATTEMPT=$((ATTEMPT+1))
-            if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
-              echo "::error::push failed after $MAX_ATTEMPTS attempts"
-              exit 1
-            fi
-            echo "::warning::push rejected (attempt $ATTEMPT/$MAX_ATTEMPTS), rebasing on origin/${BRANCH} and retrying..."
-            git fetch origin ${BRANCH}
-            git rebase origin/${BRANCH} || {
-              echo "::error::rebase failed — manual resolution required"
-              exit 1
-            }
-            # linear backoff: 2s, 4s, 6s, 8s
-            sleep $((2 * ATTEMPT))
-          done
-          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
-
-      - name: Create GitHub release (main only)
-        if: github.base_ref == 'main'
-        env:
-          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
-        run: |
-          VERSION="${{ steps.version.outputs.base }}"
-          gh release create "v${VERSION}" \
-            --generate-notes \
-            --target main \
-            --title "v${VERSION}"
+  bump:
+    needs: [calculate-version]
+    uses: ./.github/workflows/version-bump.yml
+    with:
+      target_ref: ${{ github.base_ref }}
+      version: ${{ needs.calculate-version.outputs.version }}
+      release_version: ${{ needs.calculate-version.outputs.release_version }}
+      create_release: ${{ github.base_ref == 'main' }}
+    secrets: inherit
 
   notify-failure:
-    needs: [bump]
+    needs: [calculate-version, bump]
     if: always()
     permissions:
       issues: write
     uses: ./.github/workflows/shared-notify.yml
     with:
-      success: ${{ needs.bump.result == 'success' || needs.bump.result == 'skipped' }}
+      success: >-
+        ${{
+          (needs.calculate-version.result == 'success' || needs.calculate-version.result == 'skipped') &&
+          (needs.bump.result == 'success' || needs.bump.result == 'skipped')
+        }}
       workflow_name: 'Version Bump'
-      job_results: '{"bump":"${{ needs.bump.result }}"}'
+      job_results: '{"calculate-version":"${{ needs.calculate-version.result }}","bump":"${{ needs.bump.result }}"}'

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,114 @@
+name: version-bump
+
+on:
+  workflow_call:
+    inputs:
+      target_ref:
+        description: Branch/ref to bump and push.
+        required: true
+        type: string
+      version:
+        description: Full version passed to scripts/bump-version.sh.
+        required: true
+        type: string
+      release_version:
+        description: Release version without stage suffix, used for GitHub release tags.
+        required: false
+        type: string
+        default: ''
+      create_release:
+        description: Whether to create a GitHub Release after bumping.
+        required: false
+        type: boolean
+        default: false
+      env_file:
+        description: minglit_env file for release bot credentials.
+        required: false
+        type: string
+        default: minglit_env/dev/github.env
+
+    outputs:
+      commit_sha:
+        description: Commit SHA after the bump job.
+        value: ${{ jobs.bump.outputs.commit_sha }}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    outputs:
+      commit_sha: ${{ steps.commit.outputs.commit_sha }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.target_ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Generate release bot token
+        id: release-bot
+        uses: ./.github/actions/release-bot-token
+        with:
+          env-file: ${{ inputs.env_file }}
+          fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
+          fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Run bump-version.sh
+        run: bash scripts/bump-version.sh "${{ inputs.version }}"
+
+      - name: Commit and push version bump
+        id: commit
+        env:
+          RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
+        run: |
+          NEW_VERSION="${{ inputs.version }}"
+          BRANCH="${{ inputs.target_ref }}"
+
+          git config user.name "minglit-release-bot"
+          git config user.email "minglit-release-bot@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No version changes to commit."
+            echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git commit -m "chore: bump version to v${NEW_VERSION} [skip ci]"
+
+          # Fix #1506: push race — target ref may advance via another workflow.
+          MAX_ATTEMPTS=5
+          ATTEMPT=0
+          until git push origin HEAD:${BRANCH}; do
+            ATTEMPT=$((ATTEMPT+1))
+            if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then
+              echo "::error::push failed after $MAX_ATTEMPTS attempts"
+              exit 1
+            fi
+            echo "::warning::push rejected (attempt $ATTEMPT/$MAX_ATTEMPTS), rebasing on origin/${BRANCH} and retrying..."
+            git fetch origin "${BRANCH}"
+            git rebase "origin/${BRANCH}" || {
+              echo "::error::rebase failed — manual resolution required"
+              exit 1
+            }
+            sleep $((2 * ATTEMPT))
+          done
+
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub release
+        if: ${{ inputs.create_release }}
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+        run: |
+          VERSION="${{ inputs.release_version || inputs.version }}"
+          gh release create "v${VERSION}" \
+            --generate-notes \
+            --target "${{ inputs.target_ref }}" \
+            --title "v${VERSION}"


### PR DESCRIPTION
## Summary
- add reusable version-bump workflow for bump-version, release bot push, and optional GitHub release creation
- refactor sync-version to calculate CalVer and call version-bump
- update workflow BLUEDOCs for no-prefix workflow_call reusable workflows
- harden release-bot-token input expressions with bracket notation

## Verification
- ruby YAML parse for release-bot-token, sync-version, version-bump
- git diff --check