### PR TITLE
ci: add dev-staging post-merge sync

### DIFF
--- a/.github/BLUEDOC.md
+++ b/.github/BLUEDOC.md
@@ -14,7 +14,7 @@ GitHub 통합 폴더 — CI/CD 워크플로우, composite actions, shell scripts
 
 ## 핵심 컨벤션
 
-- **entry 워크플로우는 9 prefix 중 하나** (pr-gate / pr-setup / pr-review-setup / deploy / monitor / sync / triage / tool / shared), `workflow_call` 전용 reusable 은 domain name 허용 — [`workflows/BLUEDOC.md`](./workflows/BLUEDOC.md) 참고.
+- **entry 워크플로우는 9 prefix 중 하나** (pr-gate / pr-setup / pr-review-setup / deploy / monitor / sync / triage / tool / shared), branch-strategy stage workflow 와 `workflow_call` 전용 reusable 은 domain name 허용 — [`workflows/BLUEDOC.md`](./workflows/BLUEDOC.md) 참고.
 - **재사용 가능한 step 묶음은 `actions/` composite 로 분리**, 단순 명령 묶음은 `scripts/` 로.
 - **dependabot 은 patch/minor 자동 머지** (pr-review-setup 의 dependabot 분기), major 는 수동.
 
@@ -24,4 +24,4 @@ GitHub 통합 폴더 — CI/CD 워크플로우, composite actions, shell scripts
 - [BLUEDOC 컨벤션](../docs/infra/bluedoc/BLUEDOC.md)
 
 ---
-_Reviewed: 2026-05-23 16:05_
+_Reviewed: 2026-05-23 16:18_

--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -20,6 +20,7 @@
 | `post-merge` | dev push 직후 follow-up 자동화의 단일 entry point (5 reusable orchestrator) | `post-merge` |
 | `tool-` | (수동으로 부를 때만 도는 도구) | (현재 없음 — 새 수동 도구 추가 시 prefix) |
 | `shared-` | (다른 워크플로우의 부품 — 단독 실행 X) | `shared-notify`, `shared-android-deploy` |
+| branch-strategy stage name | branch-strategy 문서의 stage entry workflow | `dev-staging-post-merge-sync` |
 | reusable no-prefix | `workflow_call` 로만 호출되는 domain reusable | `version-bump` |
 
 ## Reusable Gates
@@ -33,7 +34,8 @@
 
 - **파일명 = workflow `name:` 필드** (소문자 kebab, 확장자 제외). 예: `deploy-vercel.yml` 의 `name: deploy-vercel`.
 - prefix 다음은 *대상*만 적는다. 액션 동사는 prefix 가 이미 함의함 (`deploy-vercel` ◯ / `deploy-to-vercel` ✗).
-- 새 entry workflow 는 위 9 prefix 중 하나에 반드시 속해야 한다. `workflow_call` 전용 reusable 은 domain name no-prefix 를 허용한다.
+- 새 entry workflow 는 위 9 prefix 중 하나에 반드시 속해야 한다. 단, branch-strategy 문서에서 고정한 stage entry workflow 는 문서명과 같은 이름을 허용한다.
+- `workflow_call` 전용 reusable 은 domain name no-prefix 를 허용한다.
 - `pr-setup-` vs `pr-review-setup-` vs `sync-` vs `triage-` 의 기준:
   - `pr-setup-` = PR push 마다 PR 브랜치를 mutate (#2627 이후 인스턴스 없음 — auto-format 은 `pr-gate` 의 `format-check` 잡으로 대체)
   - `pr-review-setup-` = PR 의 "리뷰 준비 단계" 자동화 (auto-merge enable, `needs-review` 라벨 부여)
@@ -46,4 +48,4 @@
 - [CLAUDE.md](../../CLAUDE.md) `## PR Conventions` — required check (`ci-result` job = `pr-gate.yml` 내부) / auto-merge 흐름
 
 ---
-_Reviewed: 2026-05-23 16:05_
+_Reviewed: 2026-05-23 16:18_

--- a/.github/workflows/dev-staging-post-merge-sync.yml
+++ b/.github/workflows/dev-staging-post-merge-sync.yml
@@ -1,0 +1,97 @@
+name: dev-staging-post-merge-sync
+
+on:
+  push:
+    branches: [dev-staging]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to use for the dev-staging CalVer revision.
+        required: true
+        type: string
+
+concurrency:
+  group: dev-staging-post-merge-sync
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  calculate-version:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      !startsWith(github.event.head_commit.message || '', 'chore: bump version')
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.new }}
+      release_version: ${{ steps.version.outputs.base }}
+      tag_name: ${{ steps.version.outputs.tag }}
+
+    steps:
+      - name: Calculate dev-staging CalVer version
+        id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MANUAL_PR_NUMBER: ${{ inputs.pr_number || '' }}
+          HEAD_SHA: ${{ github.sha }}
+          HEAD_MESSAGE: ${{ github.event.head_commit.message || '' }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${MANUAL_PR_NUMBER}" ]; then
+            PR_NUM="${MANUAL_PR_NUMBER}"
+          else
+            PR_NUM="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              --jq '.[0].number // empty')"
+
+            if [ -z "${PR_NUM}" ]; then
+              PR_NUM="$(printf '%s\n' "${HEAD_MESSAGE}" | sed -nE 's/.*\(#([0-9]+)\).*/\1/p' | head -n 1)"
+            fi
+          fi
+
+          if ! [[ "${PR_NUM}" =~ ^[0-9]+$ ]]; then
+            echo "::error::Unable to determine merged PR number for dev-staging version bump."
+            exit 1
+          fi
+
+          NOW_YY="$(date -u +%y)"
+          NOW_MM="$(date -u +%m)"
+          BASE="${NOW_YY}.${NOW_MM}.${PR_NUM}"
+          NEW_VERSION="${BASE}-dev-staging"
+          TAG_NAME="v${NEW_VERSION}"
+
+          echo "new=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "base=${BASE}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+          echo "Bumping dev-staging to ${NEW_VERSION}"
+
+  bump:
+    needs: [calculate-version]
+    uses: ./.github/workflows/version-bump.yml
+    with:
+      target_ref: dev-staging
+      version: ${{ needs.calculate-version.outputs.version }}
+      release_version: ${{ needs.calculate-version.outputs.release_version }}
+      tag_name: ${{ needs.calculate-version.outputs.tag_name }}
+    secrets: inherit
+
+  notify-failure:
+    needs: [calculate-version, bump]
+    if: always()
+    permissions:
+      issues: write
+    uses: ./.github/workflows/shared-notify.yml
+    with:
+      success: >-
+        ${{
+          (needs.calculate-version.result == 'success' || needs.calculate-version.result == 'skipped') &&
+          (needs.bump.result == 'success' || needs.bump.result == 'skipped')
+        }}
+      workflow_name: 'Dev-Staging Post-Merge Sync'
+      job_results: '{"calculate-version":"${{ needs.calculate-version.result }}","bump":"${{ needs.bump.result }}"}'

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -21,6 +21,11 @@ on:
         required: false
         type: boolean
         default: false
+      tag_name:
+        description: Optional git tag to create at the bumped commit.
+        required: false
+        type: string
+        default: ''
       env_file:
         description: minglit_env file for release bot credentials.
         required: false
@@ -101,6 +106,25 @@ jobs:
 
           git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
           echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Create git tag
+        if: ${{ inputs.tag_name != '' }}
+        env:
+          RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
+        run: |
+          TAG_NAME="${{ inputs.tag_name }}"
+
+          git remote set-url origin "https://x-access-token:${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists; skipping."
+            git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+            exit 0
+          fi
+
+          git tag "${TAG_NAME}" "$(git rev-parse HEAD)"
+          git push origin "refs/tags/${TAG_NAME}"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Create GitHub release
         if: ${{ inputs.create_release }}

--- a/docs/infra/branch-strategy/dev-staging-pipeline.md
+++ b/docs/infra/branch-strategy/dev-staging-pipeline.md
@@ -86,7 +86,7 @@ AI agent 와 feature/fix/chore PR 이 `dev-staging` 브랜치로 들어오는 �
 PR 머지 직후 자동 발동.
 
 ```
-1. bump-version.sh {PR번호}-dev-staging  # 8개 파일 version 일괄 업데이트
+1. `version-bump` reusable 호출: `bump-version.sh YY.MM.{PR번호}-dev-staging`
 2. git commit -m "chore: bump version to v{ver}-dev-staging [skip ci]"
 3. git tag v{ver}-dev-staging
 4. git push (tag + commit)
@@ -96,7 +96,7 @@ PR 머지 직후 자동 발동.
 
 Tag `v{ver}-dev-staging` 는 다음 단계의 `nightly-cut` workflow 가 query 해서 "가장 최근 dev-staging 의 coherent snapshot" 찾는 데 사용.
 
-> **구현 디테일**: bump 커밋이 별도로 만들어지는 게 깔끔 vs squash 커밋에 inline 시키는 게 깔끔 — workflow 디자인 결정 (TBD).
+> **구현 결정**: bump 커밋은 PR squash commit 과 분리한다. release bot 전용 커밋으로 남겨 branch/tag write 권한과 human PR 변경을 분리한다.
 
 ## Error-Backoff
 
@@ -124,4 +124,4 @@ destructive pattern 검출이 too aggressive 한 경우:
 - [branch-flow.md](./branch-flow.md) — protection + tag
 
 ---
-_Reviewed: 2026-05-19 09:47_
+_Reviewed: 2026-05-23 16:18_

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -5,6 +5,8 @@
 # Examples:
 #   bash scripts/bump-version.sh 26.03.1
 #   bash scripts/bump-version.sh 26.03.1-dev
+#   bash scripts/bump-version.sh 26.03.1-dev-staging
+#   bash scripts/bump-version.sh 26.03.1-rc-01
 
 set -e
 
@@ -21,18 +23,20 @@ if [ $# -ne 1 ]; then
     echo "Examples:"
     echo "  bash scripts/bump-version.sh 26.03.1"
     echo "  bash scripts/bump-version.sh 26.03.1-dev"
+    echo "  bash scripts/bump-version.sh 26.03.1-dev-staging"
+    echo "  bash scripts/bump-version.sh 26.03.1-rc-01"
     exit 1
 fi
 
 VERSION_INPUT="$1"
 
-# Regex validation: YY.MM.PR#[-dev]
-# Format: 26.03.1 or 26.03.1-dev
+# Regex validation: YY.MM.PR#[-stage]
+# Format: 26.03.1, 26.03.1-dev, 26.03.1-dev-staging, or 26.03.1-rc-01
 # Month must be 01-12
-if ! [[ "$VERSION_INPUT" =~ ^[0-9]{2}\.[0-9]{2}\.[0-9]+(-dev)?$ ]]; then
+if ! [[ "$VERSION_INPUT" =~ ^[0-9]{2}\.(0[1-9]|1[0-2])\.[0-9]+(-(dev|dev-staging|rc-[0-9]{2}))?$ ]]; then
     echo -e "${RED}Error: Invalid version format: $VERSION_INPUT${NC}"
-    echo "Expected format: YY.MM.PR# or YY.MM.PR#-dev"
-    echo "Examples: 26.03.1, 26.03.1-dev, 26.12.99"
+    echo "Expected format: YY.MM.PR#, YY.MM.PR#-dev, YY.MM.PR#-dev-staging, or YY.MM.PR#-rc-NN"
+    echo "Examples: 26.03.1, 26.03.1-dev, 26.03.1-dev-staging, 26.03.1-rc-01, 26.12.99"
     exit 1
 fi
 
@@ -41,8 +45,8 @@ YY=$(echo "$VERSION_INPUT" | cut -d. -f1)
 MM=$(echo "$VERSION_INPUT" | cut -d. -f2)
 PR_AND_SUFFIX=$(echo "$VERSION_INPUT" | cut -d. -f3)
 
-# Extract PR# (remove -dev suffix if present)
-PR=$(echo "$PR_AND_SUFFIX" | sed 's/-dev$//')
+# Extract PR# (remove stage suffix if present)
+PR=$(echo "$PR_AND_SUFFIX" | sed -E 's/-(dev|dev-staging|rc-[0-9]{2})$//')
 
 # Validate PR# (must be >= 1)
 if [ "$((10#$PR))" -lt 1 ]; then
@@ -64,8 +68,8 @@ fi
 # Calculate versionCode: YYMM * 10000 + PR#
 VERSION_CODE=$(( (YY_DEC * 100 + MM_DEC) * 10000 + PR_DEC ))
 
-# Extract base version (without -dev)
-BASE_VERSION=$(echo "$VERSION_INPUT" | sed 's/-dev$//')
+# Extract base version (without stage suffix)
+BASE_VERSION=$(echo "$VERSION_INPUT" | sed -E 's/-(dev|dev-staging|rc-[0-9]{2})$//')
 
 echo -e "${YELLOW}Bumping version to: $VERSION_INPUT${NC}"
 echo "  YY=$YY, MM=$MM, PR#=$PR"


### PR DESCRIPTION
## Summary
- add dev-staging-post-merge-sync workflow for PR-number CalVer bump and dev-staging tag creation
- extend version-bump reusable with optional git tag push
- allow bump-version.sh stage suffixes required by branch strategy

## Verification
- bash -n scripts/bump-version.sh
- YAML parse for changed workflow files
- git diff --check