### PR TITLE
ci: add nightly cut workflow

### DIFF
--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -20,7 +20,7 @@
 | `post-merge` | dev push 직후 follow-up 자동화의 단일 entry point (5 reusable orchestrator) | `post-merge` |
 | `tool-` | (수동으로 부를 때만 도는 도구) | (현재 없음 — 새 수동 도구 추가 시 prefix) |
 | `shared-` | (다른 워크플로우의 부품 — 단독 실행 X) | `shared-notify`, `shared-android-deploy` |
-| branch-strategy stage name | branch-strategy 문서의 stage entry workflow | `dev-staging-post-merge-sync` |
+| branch-strategy stage name | branch-strategy 문서의 stage entry workflow | `dev-staging-post-merge-sync`, `nightly-cut` |
 | reusable no-prefix | `workflow_call` 로만 호출되는 domain reusable | `version-bump` |
 
 ## Reusable Gates
@@ -48,4 +48,4 @@
 - [CLAUDE.md](../../CLAUDE.md) `## PR Conventions` — required check (`ci-result` job = `pr-gate.yml` 내부) / auto-merge 흐름
 
 ---
-_Reviewed: 2026-05-23 16:18_
+_Reviewed: 2026-05-23 16:31_

--- a/.github/workflows/nightly-cut.yml
+++ b/.github/workflows/nightly-cut.yml
@@ -1,0 +1,160 @@
+name: nightly-cut
+
+on:
+  schedule:
+    # 02:00 KST daily.
+    - cron: '0 17 * * *'
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Optional v*-dev-staging tag to promote instead of the latest one.
+        required: false
+        type: string
+
+concurrency:
+  group: nightly-cut
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  create-nightly-pr:
+    runs-on: ubuntu-latest
+    outputs:
+      skipped: ${{ steps.plan.outputs.skipped }}
+      pr_number: ${{ steps.pr.outputs.pr_number }}
+      tag_name: ${{ steps.plan.outputs.tag_name }}
+      branch_name: ${{ steps.plan.outputs.branch_name }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Generate release bot token
+        id: release-bot
+        uses: ./.github/actions/release-bot-token
+        with:
+          fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
+          fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Plan nightly promotion
+        id: plan
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          REQUESTED_TAG: ${{ inputs.tag_name || '' }}
+        run: |
+          set -euo pipefail
+
+          git fetch origin dev dev-staging --tags --force
+
+          OPEN_PR="$(gh pr list \
+            --base dev \
+            --state open \
+            --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("nightly/"))][0].number // empty')"
+          if [ -n "${OPEN_PR}" ]; then
+            echo "Nightly PR #${OPEN_PR} is already open; skipping."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -n "${REQUESTED_TAG}" ]; then
+            TAG_NAME="${REQUESTED_TAG}"
+          else
+            TAG_NAME="$(git for-each-ref \
+              --sort=-creatordate \
+              --format='%(refname:short)' \
+              'refs/tags/v*-dev-staging' | head -n 1)"
+          fi
+
+          if [ -z "${TAG_NAME}" ]; then
+            echo "::error::No v*-dev-staging tag found to promote."
+            exit 1
+          fi
+          if ! git rev-parse -q --verify "refs/tags/${TAG_NAME}" >/dev/null; then
+            echo "::error::Tag ${TAG_NAME} does not exist."
+            exit 1
+          fi
+
+          TAG_SHA="$(git rev-list -n 1 "${TAG_NAME}")"
+          if ! git merge-base --is-ancestor "${TAG_SHA}" origin/dev-staging; then
+            echo "::error::Tag ${TAG_NAME} (${TAG_SHA}) is not reachable from origin/dev-staging."
+            exit 1
+          fi
+
+          if git merge-base --is-ancestor "${TAG_SHA}" origin/dev; then
+            echo "origin/dev already contains ${TAG_NAME}; skipping."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            echo "tag_name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          RUN_DATE="$(TZ=Asia/Seoul date +%Y-%m-%d)"
+          SHORT_SHA="${TAG_SHA:0:8}"
+          BRANCH_NAME="nightly/${RUN_DATE}-${SHORT_SHA}"
+          if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" >/dev/null 2>&1; then
+            BRANCH_NAME="${BRANCH_NAME}-${GITHUB_RUN_ID}"
+          fi
+
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+          echo "tag_name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+          echo "tag_sha=${TAG_SHA}" >> "$GITHUB_OUTPUT"
+          echo "branch_name=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Push nightly branch
+        if: steps.plan.outputs.skipped != 'true'
+        env:
+          RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
+          TAG_SHA: ${{ steps.plan.outputs.tag_sha }}
+          BRANCH_NAME: ${{ steps.plan.outputs.branch_name }}
+        run: |
+          set -euo pipefail
+          git remote set-url origin "https://x-access-token:${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push origin "${TAG_SHA}:refs/heads/${BRANCH_NAME}"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+
+      - name: Create nightly PR and enable auto-merge
+        id: pr
+        if: steps.plan.outputs.skipped != 'true'
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          TAG_NAME: ${{ steps.plan.outputs.tag_name }}
+          TAG_SHA: ${{ steps.plan.outputs.tag_sha }}
+          BRANCH_NAME: ${{ steps.plan.outputs.branch_name }}
+        run: |
+          set -euo pipefail
+          RUN_DATE="$(TZ=Asia/Seoul date +%Y-%m-%d)"
+          BODY="$(cat <<EOF
+          Promotes the latest coherent dev-staging snapshot to dev.
+
+          - Source tag: ${TAG_NAME}
+          - Source SHA: ${TAG_SHA}
+          - Merge mode: rebase, because the active dev ruleset requires linear history.
+          EOF
+          )"
+
+          PR_URL="$(gh pr create \
+            --base dev \
+            --head "${BRANCH_NAME}" \
+            --title "chore(promo): dev-staging to dev ${RUN_DATE}" \
+            --body "${BODY}")"
+          PR_NUMBER="${PR_URL##*/}"
+
+          gh pr merge "${PR_NUMBER}" --auto --rebase --delete-branch
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+  notify-failure:
+    needs: [create-nightly-pr]
+    if: always()
+    permissions:
+      issues: write
+    uses: ./.github/workflows/shared-notify.yml
+    with:
+      success: ${{ needs.create-nightly-pr.result == 'success' || needs.create-nightly-pr.result == 'skipped' }}
+      workflow_name: 'Nightly Cut'
+      job_results: '{"create-nightly-pr":"${{ needs.create-nightly-pr.result }}"}'

--- a/docs/infra/branch-strategy/branch-flow.md
+++ b/docs/infra/branch-strategy/branch-flow.md
@@ -7,7 +7,7 @@
 ```
   agents ──PR + auto-merge──▶ dev-staging
                               │
-                              └─daily nightly-cut snapshot──▶ dev
+                              └─daily nightly-cut linear snapshot PR──▶ dev
                                                               │
                                                               ├─▶ rc-gate (post-merge 자동)
                                                               │      │
@@ -45,7 +45,7 @@ rc/* hotfix 머지 ──auto cherry-pick──▶ backport-branch ──PR─�
 | 머지 방향 | base ← head | 트리거 | 머지 방식 | 요구 체크 |
 |-----------|-------------|--------|-----------|-----------|
 | feature/agent → dev-staging | `dev-staging` ← `feat/*`, `fix/*`, `chore/*`, `docs/*` | PR + auto-merge | **squash** | `dev-staging-pr-gate` |
-| dev-staging → dev | `dev` ← `dev-staging` | daily cron `nightly-cut` | merge (snapshot) | `nightly-pr-gate` |
+| dev-staging → dev | `dev` ← `nightly/YYYY-MM-DD-{sha8}` at latest `v*-dev-staging` tag | daily cron `nightly-cut` | rebase (linear snapshot) | `nightly-pr-gate` |
 | hotfix → rc | `rc/YYYY-Wxx` ← hotfix branch | hotfix only | rebase | `rc-pr-gate` |
 | rc → main | `main` ← `rc/YYYY-Wxx` | `rc-soak-check` 가 5일 무커밋 시 PR 생성 + auto-merge | rebase + ff | `main-pr-gate` |
 
@@ -54,11 +54,11 @@ rc/* hotfix 머지 ──auto cherry-pick──▶ backport-branch ──PR─�
 | 브랜치 | direct push | linear | required check | merge 종류 |
 |--------|-------------|--------|----------------|------------|
 | `dev-staging` | 금지 (release bot 예외) | **ON** | `dev-staging-pr-gate` | squash |
-| `dev` | 금지 | **ON** | `nightly-pr-gate` | merge (snapshot) |
+| `dev` | 금지 | **ON** | `nightly-pr-gate` | rebase (linear snapshot) |
 | `rc/YYYY-Wxx` | 금지 | **ON** | `rc-pr-gate` | rebase |
 | `main` | 금지 (release bot 예외) | **ON** | `main-pr-gate` | rebase |
 
-Hybrid linear history 금지 — 각 branch 내 일관 (squash or rebase 한 가지). Protected branch 직접 push 는 `minglit-release-bot` 의 version bump/tag/promotion commit 에만 Ruleset bypass 로 허용한다.
+Hybrid linear history 금지 — 각 branch 내 일관 (squash or rebase 한 가지). `dev` 는 active ruleset 의 linear history 와 맞추기 위해 nightly promotion 도 rebase 를 사용한다. Protected branch 직접 push 는 `minglit-release-bot` 의 version bump/tag/promotion commit 에만 Ruleset bypass 로 허용한다.
 
 ## Promotion Tag 컨벤션
 
@@ -120,4 +120,4 @@ main-post-merge-promote (on push to main):
 - `RELEASE.md` 작성
 
 ---
-_Reviewed: 2026-05-19 09:47_
+_Reviewed: 2026-05-23 16:31_

--- a/docs/infra/branch-strategy/dev-pipeline.md
+++ b/docs/infra/branch-strategy/dev-pipeline.md
@@ -17,9 +17,9 @@
 - **manual**: `workflow_dispatch`
 - 동작:
   1. 가장 최근 `v*-dev-staging` 태그 (dev-staging 의 latest coherent snapshot) 찾기
-  2. PR 생성: `chore(promo): dev-staging → dev YYYY-MM-DD` (base=dev, head=dev-staging at that tag)
+  2. PR 생성: `chore(promo): dev-staging → dev YYYY-MM-DD` (base=dev, head=`nightly/YYYY-MM-DD-{sha8}` at that tag)
   3. `nightly-pr-gate` 자동 발동
-  4. 통과 시 auto-merge (merge — snapshot 보존)
+  4. 통과 시 auto-merge (rebase — active `dev` ruleset 의 linear history 와 호환)
 
 ### 슬립 처리
 
@@ -124,4 +124,4 @@ Snapshot 모델 — **auto-revert 없음**. dev 가 broken 상태로 잠시 머�
 - [branch-flow.md](./branch-flow.md) — auto-deploy chain 그림
 
 ---
-_Reviewed: 2026-05-19 09:47_
+_Reviewed: 2026-05-23 16:31_

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -106,7 +106,7 @@ Cross-branch cherry-pick PR 자동 생성.
 | Trigger | `schedule` (daily KST 02:00 TBD) + `workflow_dispatch` |
 | Inputs | (none, or optional ref override) |
 | Outputs | PR number (dev-staging → dev) or skip |
-| Steps | (1) 이전 `nightly-cut` PR open 이면 skip + Slack (2) 가장 최근 `v*-dev-staging` tag SHA 조회 (3) dev HEAD == 그 SHA 이면 skip ("no new commits") (4) `nightly/YYYY-MM-DD` promotion branch 를 tag SHA 에서 생성 (5) `gh pr create` (base=dev, head=nightly/YYYY-MM-DD) + auto-merge 활성화 |
+| Steps | (1) 이전 `nightly-cut` PR open 이면 skip + Slack (2) 가장 최근 `v*-dev-staging` tag SHA 조회 (3) dev 가 그 SHA 를 이미 포함하면 skip ("no new commits") (4) `nightly/YYYY-MM-DD-{sha8}` promotion branch 를 tag SHA 에서 생성 (5) `gh pr create` (base=dev, head=nightly/YYYY-MM-DD-{sha8}) + auto-merge 활성화 (`rebase`, active dev ruleset 의 linear history 와 호환) |
 
 #### `nightly-pr-gate`
 


### PR DESCRIPTION
## Summary
- add nightly-cut workflow to promote latest v*-dev-staging tag into a dev PR
- use release bot for nightly branch/PR creation and auto-enable rebase auto-merge
- update branch-strategy docs for the active dev linear-history ruleset

## Note
The branch-strategy doc previously said dev promotion should use a merge commit, but the active dev ruleset requires linear history. This implements rebase promotion so the workflow can actually merge under the current rules.

## Verification
- YAML parse for changed workflow files
- git diff --check
- checked latest dev-staging tag is reachable from dev-staging and not yet in dev