### PR TITLE
ci: stop dev promotion version sync

### DIFF
--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -28,6 +28,7 @@
 - `pr-gate.yml` 은 기존 `push`/`pull_request`/`merge_group` 진입점을 유지하면서 `workflow_call` 도 지원한다.
 - 호출자는 `stage` (`dev`, `dev-staging`, `nightly`, `rc`, `main`) 와 `base_ref` 를 넘겨 동일한 CI 코어를 stage 별 gate 로 재사용한다.
 - 기존 required check 는 아직 `ci-result` 그대로 유지한다. stage 별 required check 전환은 branch-strategy Phase 4 에서 Ruleset 과 함께 적용한다.
+- `dev-staging-post-merge-sync` 가 dev-staging 의 PR-number CalVer bump/tag 를 담당한다. `sync-version` 은 legacy main release bump 만 담당하며, `dev` promotion 은 `nightly-cut` 에서 version 변경 없이 처리한다.
 - protected branch/tag 에 직접 push 하는 workflow 는 `minglit-release-bot` GitHub App token 을 사용한다. App credential 은 `minglit_env/{stage}/github.env` 파일에서 먼저 읽고, 공통 token mint 는 `.github/actions/release-bot-token` 에서 처리한다.
 
 ## 컨벤션
@@ -48,4 +49,4 @@
 - [CLAUDE.md](../../CLAUDE.md) `## PR Conventions` — required check (`ci-result` job = `pr-gate.yml` 내부) / auto-merge 흐름
 
 ---
-_Reviewed: 2026-05-23 16:31_
+_Reviewed: 2026-05-23 16:39_

--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -3,7 +3,7 @@ name: sync-version
 on:
   pull_request:
     types: [closed]
-    branches: [dev, main]
+    branches: [main]
 
 concurrency:
   group: sync-version-${{ github.base_ref }}
@@ -45,11 +45,7 @@ jobs:
 
           BASE="${NOW_YY}.${NOW_MM}.${PR_NUM}"
 
-          if [ "$BRANCH" = "dev" ]; then
-            NEW_VERSION="${BASE}-dev"
-          else
-            NEW_VERSION="${BASE}"
-          fi
+          NEW_VERSION="${BASE}"
 
           echo "new=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           echo "base=$BASE" >> "$GITHUB_OUTPUT"

--- a/docs/infra/branch-strategy/versioning.md
+++ b/docs/infra/branch-strategy/versioning.md
@@ -31,7 +31,7 @@
 | Workflow | When | What |
 |----------|------|------|
 | `dev-staging-post-merge-sync` | dev-staging PR 머지 직후 | `bump-version.sh {PR#}-dev-staging` |
-| `nightly-cut` | daily snapshot 생성 시 | version 변경 없음 (dev-staging 의 그대로 가져감) |
+| `nightly-cut` | daily snapshot 생성 시 | version 변경 없음 (dev-staging 의 그대로 가져감, legacy `sync-version` dev trigger 비활성화) |
 | `rc-cut` | RC 브랜치 생성 시 | `bump-version.sh {ver}-rc-01` |
 | `rc-post-merge-sync` | RC hotfix 머지 직후 | `bump-version.sh {PR#}-rc-NN` (N 증가) |
 | `main-post-merge-promote` | rc → main 머지 직후 | `bump-version.sh {ver}` (suffix 제거) |


### PR DESCRIPTION
## Summary
- remove dev from legacy sync-version trigger
- keep sync-version scoped to main release bump only
- document that dev promotion keeps the dev-staging version unchanged

## Why
nightly-cut promotes a tagged dev-staging snapshot into dev. The existing sync-version dev trigger would immediately rewrite that version to *-dev after merge, conflicting with the branch-strategy versioning model.

## Verification
- YAML parse for sync-version/nightly-cut/version-bump
- git diff --check