### PR TITLE
ci: harden nightly cut checkout

### DIFF
--- a/.github/workflows/nightly-cut.yml
+++ b/.github/workflows/nightly-cut.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
 
       - name: Generate release bot token
@@ -46,10 +46,12 @@ jobs:
         id: plan
         env:
           GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
           REQUESTED_TAG: ${{ inputs.tag_name || '' }}
         run: |
           set -euo pipefail
 
+          git remote set-url origin "https://x-access-token:${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git fetch origin dev dev-staging --tags --force
 
           OPEN_PR="$(gh pr list \


### PR DESCRIPTION
## Summary
- make nightly-cut initial checkout shallow so actions/checkout does not fetch every branch/tag with GITHUB_TOKEN
- fetch dev/dev-staging/tags explicitly after minting the release bot token

## Why
Manual nightly-cut reproduced the checkout auth failure seen earlier when checkout@v6 tried to fetch all refs. The workflow needs a release-bot-authenticated fetch for refs/tags anyway.

## Verification
- YAML parse for nightly-cut
- git diff --check