### PR TITLE
ci: allow dev-staging bump checks

### DIFF
--- a/.github/workflows/dev-staging-post-merge-sync.yml
+++ b/.github/workflows/dev-staging-post-merge-sync.yml
@@ -79,6 +79,7 @@ jobs:
       version: ${{ needs.calculate-version.outputs.version }}
       release_version: ${{ needs.calculate-version.outputs.release_version }}
       tag_name: ${{ needs.calculate-version.outputs.tag_name }}
+      skip_ci: false
     secrets: inherit
 
   notify-failure:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: string
         default: ''
+      skip_ci:
+        description: Whether to append [skip ci] to the bump commit message.
+        required: false
+        type: boolean
+        default: true
       env_file:
         description: minglit_env file for release bot credentials.
         required: false
@@ -69,9 +74,14 @@ jobs:
         id: commit
         env:
           RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
+          SKIP_CI: ${{ inputs.skip_ci }}
         run: |
           NEW_VERSION="${{ inputs.version }}"
           BRANCH="${{ inputs.target_ref }}"
+          SKIP_CI_SUFFIX=""
+          if [ "${SKIP_CI}" = "true" ]; then
+            SKIP_CI_SUFFIX=" [skip ci]"
+          fi
 
           git config user.name "minglit-release-bot"
           git config user.email "minglit-release-bot@users.noreply.github.com"
@@ -84,7 +94,7 @@ jobs:
             exit 0
           fi
 
-          git commit -m "chore: bump version to v${NEW_VERSION} [skip ci]"
+          git commit -m "chore: bump version to v${NEW_VERSION}${SKIP_CI_SUFFIX}"
 
           # Fix #1506: push race — target ref may advance via another workflow.
           MAX_ATTEMPTS=5

--- a/docs/infra/branch-strategy/dev-staging-pipeline.md
+++ b/docs/infra/branch-strategy/dev-staging-pipeline.md
@@ -87,7 +87,7 @@ PR 머지 직후 자동 발동.
 
 ```
 1. `version-bump` reusable 호출: `bump-version.sh YY.MM.{PR번호}-dev-staging`
-2. git commit -m "chore: bump version to v{ver}-dev-staging [skip ci]"
+2. git commit -m "chore: bump version to v{ver}-dev-staging"
 3. git tag v{ver}-dev-staging
 4. git push (tag + commit)
 ```
@@ -96,7 +96,7 @@ PR 머지 직후 자동 발동.
 
 Tag `v{ver}-dev-staging` 는 다음 단계의 `nightly-cut` workflow 가 query 해서 "가장 최근 dev-staging 의 coherent snapshot" 찾는 데 사용.
 
-> **구현 결정**: bump 커밋은 PR squash commit 과 분리한다. release bot 전용 커밋으로 남겨 branch/tag write 권한과 human PR 변경을 분리한다.
+> **구현 결정**: bump 커밋은 PR squash commit 과 분리한다. release bot 전용 커밋으로 남겨 branch/tag write 권한과 human PR 변경을 분리한다. `[skip ci]` 는 쓰지 않는다. nightly PR 의 HEAD 가 이 bump 커밋이므로 `[skip ci]` 를 넣으면 required check 가 생성되지 않는다. 루프 방지는 `dev-staging-post-merge-sync` 의 commit message guard 로 처리한다.
 
 ## Error-Backoff
 

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -34,7 +34,7 @@
 | Trigger | `workflow_call` |
 | Inputs | `version`: YY.MM.PR# / `suffix`: ""\|`-dev-staging`\|`-rc-NN` / `commit_message`: string |
 | Outputs | `commit_sha`, `tag_name` |
-| 핵심 steps | `bash scripts/bump-version.sh {version}{suffix}` · commit (with `[skip ci]`) · `git tag v{version}{suffix}` · push |
+| 핵심 steps | `bash scripts/bump-version.sh {version}{suffix}` · commit (`skip_ci` option) · `git tag v{version}{suffix}` · push |
 | Called by | `dev-staging-post-merge-sync`, `rc-cut`, `rc-post-merge-sync`, `main-post-merge-promote` |
 
 ### `rc-gate-suite`


### PR DESCRIPTION
## Summary
- add skip_ci input to reusable version-bump
- set dev-staging-post-merge-sync to create bump commits without [skip ci]
- document why dev-staging bump commits must allow PR checks for nightly promotion

## Why
nightly-cut creates dev PRs from the latest v*-dev-staging tag. If that tag points to a [skip ci] bump commit, GitHub does not create the required ci-result check and the nightly PR is permanently blocked.

## Verification
- YAML parse for version-bump and dev-staging-post-merge-sync
- git diff --check