### PR TITLE
ci: use github token for nightly PR lookup

### DIFF
--- a/.github/workflows/nightly-cut.yml
+++ b/.github/workflows/nightly-cut.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Plan nightly promotion
         id: plan
         env:
-          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
           REQUESTED_TAG: ${{ inputs.tag_name || '' }}
         run: |


### PR DESCRIPTION
## Summary
- use the workflow token for the read-only open nightly PR lookup
- keep the release bot token for git writes and PR creation

## Verification
- YAML parse for nightly-cut
- git diff --check