### PR TITLE
ci: fail summary gate on cancelled jobs

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -877,9 +877,9 @@ jobs:
           # 1. Check CI job results
           results='${{ toJSON(needs.*.result) }}'
           echo "Job results: $results"
-          if echo "$results" | grep -q '"failure"'; then
+          if echo "$results" | grep -Eq '"(failure|cancelled)"'; then
             echo ""
-            echo '${{ toJSON(needs) }}' | jq -r 'to_entries[] | select(.value.result == "failure") | "❌ \(.key)"'
+            echo '${{ toJSON(needs) }}' | jq -r 'to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | "❌ \(.key): \(.value.result)"'
             exit 1
           fi
           echo "✅ CI jobs passed"


### PR DESCRIPTION
## Summary
- Treat cancelled dependency jobs as failures in ci-result.
- Print the failed/cancelled job name and result for faster diagnosis.

## Context
Nightly promotion PR #2711 exposed that a CUJ timeout produced a cancelled reusable-workflow result while ci-result only checked for failure, so the summary gate passed incorrectly.

## Test
- git diff --check