### PR TITLE
docs: document promotion title conventions

### DIFF
--- a/docs/infra/branch-strategy/BLUEDOC.md
+++ b/docs/infra/branch-strategy/BLUEDOC.md
@@ -47,5 +47,20 @@
 - **Hotfix 는 rc 에서, dev-staging 으로 자동 backport** ([rc-promotion.md](./rc-promotion.md))
 - Tag regex 는 `RELEASE.md` lock (TODO)
 
+### Promotion PR Title
+
+Promotion PR 제목은 workflow 이름과 source artifact 를 앞에 둔다. PR list 와 git log 만 보고 어떤 workflow 가 무엇을 promote 했는지 알 수 있어야 한다.
+
+| 단계 | 제목 형식 |
+|------|-----------|
+| dev-staging → dev | `ci(nightly-cut): promote v26.05.2722-dev-staging to dev` |
+| dev → rc | `ci(rc-cut): cut rc/2026-W22 from <source>` |
+| rc → main | `ci(rc-soak): promote rc/2026-W22 to main` |
+| rc hotfix backport | `ci(rc-backport): backport rc hotfix #1234 to dev-staging` |
+
+### RC Eligibility Marker
+
+RC cut 의 source-of-truth status 이름은 **`rc-gate-pass`** 이다. `rc-eligible` 은 현재 구현된 workflow/status 명칭이 아니며, 새 이름으로 바꾸려면 `rc-gate`, `rc-cut`, `main-pr-gate`, 문서 전체를 같은 PR 에서 일괄 변경한다.
+
 ---
 _Reviewed: 2026-05-19 09:47_

--- a/docs/infra/branch-strategy/dev-pipeline.md
+++ b/docs/infra/branch-strategy/dev-pipeline.md
@@ -17,7 +17,7 @@
 - **manual**: `workflow_dispatch`
 - 동작:
   1. 가장 최근 `v*-dev-staging` 태그 (dev-staging 의 latest coherent snapshot) 찾기
-  2. PR 생성: `chore(promo): dev-staging → dev YYYY-MM-DD` (base=dev, head=`nightly/YYYY-MM-DD-{sha8}` at that tag)
+  2. PR 생성: `ci(nightly-cut): promote v26.05.2722-dev-staging to dev` (base=dev, head=`nightly/YYYY-MM-DD-{sha8}` at that tag)
   3. `nightly-pr-gate` 자동 발동
   4. 통과 시 auto-merge (rebase — active `dev` ruleset 의 linear history 와 호환)
 

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -104,9 +104,10 @@ Cross-branch cherry-pick PR 자동 생성.
 | 항목 | 값 |
 |------|----|
 | Trigger | `schedule` (daily KST 02:00 TBD) + `workflow_dispatch` |
-| Inputs | (none, or optional ref override) |
+| Inputs | optional `tag_name` (`v*-dev-staging`) |
 | Outputs | PR number (dev-staging → dev) or skip |
-| Steps | (1) 이전 `nightly-cut` PR open 이면 skip + Slack (2) 가장 최근 `v*-dev-staging` tag SHA 조회 (3) dev 가 그 SHA 를 이미 포함하면 skip ("no new commits") (4) `nightly/YYYY-MM-DD-{sha8}` promotion branch 를 tag SHA 에서 생성 (5) `gh pr create` (base=dev, head=nightly/YYYY-MM-DD-{sha8}) + auto-merge 활성화 (`rebase`, active dev ruleset 의 linear history 와 호환) |
+| PR title | `ci(nightly-cut): promote {tag_name} to dev` |
+| Steps | (1) 이전 `nightly-cut` PR open 이면 skip + Slack (2) 가장 최근 `v*-dev-staging` tag SHA 조회, 또는 입력 `tag_name` 사용 (3) dev 가 그 SHA 를 이미 포함하면 skip ("no new commits") (4) `nightly/YYYY-MM-DD-{sha8}` promotion branch 를 tag SHA 에서 생성 (5) `gh pr create` (base=dev, head=nightly/YYYY-MM-DD-{sha8}) + auto-merge 활성화 (`rebase`, active dev ruleset 의 linear history 와 호환) |
 
 #### `nightly-pr-gate`
 
@@ -126,6 +127,7 @@ Cross-branch cherry-pick PR 자동 생성.
 | Backoff | 같은 area 3회 연속 실패 시 `rc-cut` 자동 차단 (다음 weekly cut PR 안 만듦) |
 
 > **No auto-revert** — snapshot 모델: 실패 = no tag, dev keeps moving, 새 fix 가 자연스럽게 다음 rc-gate 에서 검증됨.
+> **Naming** — `rc-gate-pass` 가 canonical RC eligibility marker 이다. `rc-eligible` 은 현재 workflow/status 명칭이 아니다.
 
 #### `deploy-supabase` (기존, refactor 대상)
 


### PR DESCRIPTION
## Summary
- document promotion PR title conventions for nightly, rc, main, and backport flows
- update nightly-cut docs to match the implemented tag-based title
- clarify that the canonical RC eligibility marker is rc-gate-pass, not rc-eligible

## Validation
- git diff --check