### PR TITLE
ci(branch): add rc-gate and rc-cut workflows

### DIFF
--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -20,7 +20,7 @@
 | `post-merge` | dev push 직후 follow-up 자동화의 단일 entry point (5 reusable orchestrator) | `post-merge` |
 | `tool-` | (수동으로 부를 때만 도는 도구) | (현재 없음 — 새 수동 도구 추가 시 prefix) |
 | `shared-` | (다른 워크플로우의 부품 — 단독 실행 X) | `shared-notify`, `shared-android-deploy` |
-| branch-strategy stage name | branch-strategy 문서의 stage entry workflow | `dev-staging-post-merge-sync`, `nightly-cut` |
+| branch-strategy stage name | branch-strategy 문서의 stage entry workflow | `dev-staging-post-merge-sync`, `nightly-cut`, `rc-gate`, `rc-cut` |
 | reusable no-prefix | `workflow_call` 로만 호출되는 domain reusable | `version-bump` |
 
 ## Reusable Gates
@@ -29,6 +29,8 @@
 - 호출자는 `stage` (`dev`, `dev-staging`, `nightly`, `rc`, `main`) 와 `base_ref` 를 넘겨 동일한 CI 코어를 stage 별 gate 로 재사용한다.
 - 기존 required check 는 아직 `ci-result` 그대로 유지한다. stage 별 required check 전환은 branch-strategy Phase 4 에서 Ruleset 과 함께 적용한다.
 - `dev-staging-post-merge-sync` 가 dev-staging 의 PR-number CalVer bump/tag 를 담당한다. `sync-version` 은 legacy main release bump 만 담당하며, `dev` promotion 은 `nightly-cut` 에서 version 변경 없이 처리한다.
+- `rc-gate` 는 dev push 후 user/partner CUJ integration 을 직접 실행하고, 통과한 commit 에만 `rc-gate-pass` status 를 찍는다. backend/EF/Test Lab 을 포함한 full `rc-gate-suite` matrix 는 후속 확장이다.
+- `rc-cut` 은 latest `rc-gate-pass` dev commit 에서 `rc/YYYY-Www` branch 를 만들고 `version-bump` 로 `v*-rc-01` + `promo/rc-*` tag 를 생성한다.
 - protected branch/tag 에 직접 push 하는 workflow 는 `minglit-release-bot` GitHub App token 을 사용한다. App credential 은 `minglit_env/{stage}/github.env` 파일에서 먼저 읽고, 공통 token mint 는 `.github/actions/release-bot-token` 에서 처리한다.
 
 ## 컨벤션
@@ -49,4 +51,4 @@
 - [CLAUDE.md](../../CLAUDE.md) `## PR Conventions` — required check (`ci-result` job = `pr-gate.yml` 내부) / auto-merge 흐름
 
 ---
-_Reviewed: 2026-05-23 16:39_
+_Reviewed: 2026-05-24 09:24_

--- a/.github/workflows/rc-cut.yml
+++ b/.github/workflows/rc-cut.yml
@@ -1,0 +1,220 @@
+name: rc-cut
+
+on:
+  schedule:
+    # 10:00 KST every Monday.
+    - cron: '0 1 * * 1'
+  workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Optional dev commit SHA to cut instead of the latest rc-gate-pass commit.
+        required: false
+        type: string
+      rc_week:
+        description: Optional ISO week, e.g. 2026-W22. Defaults to current KST week.
+        required: false
+        type: string
+      allow_active_rc:
+        description: Allow cutting while an rc/* branch already exists.
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: rc-cut
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  statuses: read
+  issues: write
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      skipped: ${{ steps.plan.outputs.skipped }}
+      rc_week: ${{ steps.plan.outputs.rc_week }}
+      rc_branch: ${{ steps.plan.outputs.rc_branch }}
+      source_sha: ${{ steps.plan.outputs.source_sha }}
+      version: ${{ steps.plan.outputs.version }}
+      release_version: ${{ steps.plan.outputs.release_version }}
+      tag_name: ${{ steps.plan.outputs.tag_name }}
+      promo_tag: ${{ steps.plan.outputs.promo_tag }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Generate release bot token
+        id: release-bot
+        uses: ./.github/actions/release-bot-token
+        with:
+          fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
+          fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Plan RC cut
+        id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
+          REQUESTED_SOURCE_SHA: ${{ inputs.source_sha || '' }}
+          REQUESTED_RC_WEEK: ${{ inputs.rc_week || '' }}
+          ALLOW_ACTIVE_RC: ${{ inputs.allow_active_rc || false }}
+        run: |
+          set -euo pipefail
+
+          git remote set-url origin "https://x-access-token:${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch origin dev --tags --force
+
+          RC_WEEK="${REQUESTED_RC_WEEK}"
+          if [ -z "${RC_WEEK}" ]; then
+            RC_WEEK="$(TZ=Asia/Seoul date +%G-W%V)"
+          fi
+          if ! [[ "${RC_WEEK}" =~ ^[0-9]{4}-W[0-9]{2}$ ]]; then
+            echo "::error::Invalid rc_week: ${RC_WEEK}. Expected YYYY-Www, e.g. 2026-W22."
+            exit 1
+          fi
+
+          RC_BRANCH="rc/${RC_WEEK}"
+          PROMO_TAG="promo/rc-${RC_WEEK}"
+
+          ACTIVE_RC="$(git ls-remote --heads origin 'rc/*' | awk '{print $2}' | sed 's#refs/heads/##' | sort | xargs || true)"
+          if [ -n "${ACTIVE_RC}" ] && [ "${ALLOW_ACTIVE_RC}" != "true" ]; then
+            echo "Active RC branch exists (${ACTIVE_RC}); skipping rc-cut."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            echo "rc_week=${RC_WEEK}" >> "$GITHUB_OUTPUT"
+            echo "rc_branch=${RC_BRANCH}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --heads origin "${RC_BRANCH}" >/dev/null 2>&1; then
+            echo "RC branch ${RC_BRANCH} already exists; skipping."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            echo "rc_week=${RC_WEEK}" >> "$GITHUB_OUTPUT"
+            echo "rc_branch=${RC_BRANCH}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          SOURCE_SHA="${REQUESTED_SOURCE_SHA}"
+          if [ -n "${SOURCE_SHA}" ]; then
+            SOURCE_SHA="$(git rev-parse "${SOURCE_SHA}^{commit}")"
+            if ! git merge-base --is-ancestor "${SOURCE_SHA}" origin/dev; then
+              echo "::error::Requested source_sha ${SOURCE_SHA} is not reachable from origin/dev."
+              exit 1
+            fi
+          else
+            for sha in $(git rev-list --first-parent -n 200 origin/dev); do
+              state="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${sha}/status" \
+                --jq '[.statuses[] | select(.context == "rc-gate-pass")][0].state // empty' || true)"
+              if [ "${state}" = "success" ]; then
+                SOURCE_SHA="${sha}"
+                break
+              fi
+            done
+          fi
+
+          if [ -z "${SOURCE_SHA}" ]; then
+            echo "::warning::No origin/dev commit with successful rc-gate-pass status found in the latest 200 first-parent commits; skipping rc-cut."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            echo "rc_week=${RC_WEEK}" >> "$GITHUB_OUTPUT"
+            echo "rc_branch=${RC_BRANCH}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CURRENT_VERSION="$(git show "${SOURCE_SHA}:apps/app_user/pubspec.yaml" | awk '/^version:/ {print $2; exit}' | sed 's/+.*//')"
+          RELEASE_VERSION="$(printf '%s' "${CURRENT_VERSION}" | sed -E 's/-(dev|dev-staging|rc-[0-9]{2})$//')"
+          VERSION="${RELEASE_VERSION}-rc-01"
+          TAG_NAME="v${VERSION}"
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG_NAME} already exists. Refusing to cut duplicate RC."
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/${PROMO_TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${PROMO_TAG} already exists. Refusing to cut duplicate RC."
+            exit 1
+          fi
+
+          git push origin "${SOURCE_SHA}:refs/heads/${RC_BRANCH}"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+          echo "rc_week=${RC_WEEK}" >> "$GITHUB_OUTPUT"
+          echo "rc_branch=${RC_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "source_sha=${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "release_version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag_name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+          echo "promo_tag=${PROMO_TAG}" >> "$GITHUB_OUTPUT"
+
+  bump:
+    needs: [plan]
+    if: needs.plan.outputs.skipped != 'true'
+    uses: ./.github/workflows/version-bump.yml
+    with:
+      target_ref: ${{ needs.plan.outputs.rc_branch }}
+      version: ${{ needs.plan.outputs.version }}
+      release_version: ${{ needs.plan.outputs.release_version }}
+      tag_name: ${{ needs.plan.outputs.tag_name }}
+      skip_ci: true
+    secrets: inherit
+
+  tag-promo:
+    needs: [plan, bump]
+    if: needs.plan.outputs.skipped != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.plan.outputs.rc_branch }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Generate release bot token
+        id: release-bot
+        uses: ./.github/actions/release-bot-token
+        with:
+          fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
+          fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Tag promotion marker
+        env:
+          RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
+          PROMO_TAG: ${{ needs.plan.outputs.promo_tag }}
+          COMMIT_SHA: ${{ needs.bump.outputs.commit_sha }}
+        run: |
+          set -euo pipefail
+          git remote set-url origin "https://x-access-token:${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch origin "${{ needs.plan.outputs.rc_branch }}" --tags --force
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${PROMO_TAG}" >/dev/null 2>&1; then
+            echo "Tag ${PROMO_TAG} already exists; skipping."
+            exit 0
+          fi
+
+          git tag "${PROMO_TAG}" "${COMMIT_SHA}"
+          git push origin "refs/tags/${PROMO_TAG}"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+
+  notify-failure:
+    needs: [plan, bump, tag-promo]
+    if: always()
+    permissions:
+      issues: write
+    uses: ./.github/workflows/shared-notify.yml
+    with:
+      success: >-
+        ${{
+          needs.plan.outputs.skipped == 'true' ||
+          (
+            needs.plan.result == 'success' &&
+            needs.bump.result == 'success' &&
+            needs.tag-promo.result == 'success'
+          )
+        }}
+      workflow_name: 'RC Cut'
+      job_results: '{"plan":"${{ needs.plan.result }}","bump":"${{ needs.bump.result }}","tag-promo":"${{ needs.tag-promo.result }}"}'

--- a/.github/workflows/rc-gate.yml
+++ b/.github/workflows/rc-gate.yml
@@ -1,0 +1,56 @@
+name: rc-gate
+
+on:
+  push:
+    branches: [ "dev" ]
+  workflow_dispatch:
+
+concurrency:
+  group: rc-gate-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  statuses: write
+
+jobs:
+  cuj-integration-user:
+    name: cuj-integration-user
+    uses: ./.github/workflows/shared-cuj-integration.yml
+    with:
+      app-name: user
+    secrets: inherit
+
+  cuj-integration-partner:
+    name: cuj-integration-partner
+    uses: ./.github/workflows/shared-cuj-integration.yml
+    with:
+      app-name: partner
+    secrets: inherit
+
+  set-rc-gate-status:
+    name: set-rc-gate-status
+    needs: [cuj-integration-user, cuj-integration-partner]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark commit as RC eligible
+        if: ${{ needs.cuj-integration-user.result == 'success' && needs.cuj-integration-partner.result == 'success' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
+            --method POST \
+            -f state=success \
+            -f context=rc-gate-pass \
+            -f description="rc-gate passed; this dev commit can be cut to RC" \
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+      - name: Fail rc-gate without publishing rc-gate-pass
+        if: ${{ needs.cuj-integration-user.result != 'success' || needs.cuj-integration-partner.result != 'success' }}
+        run: |
+          echo "::error::rc-gate failed; rc-gate-pass status was not set."
+          echo "cuj-integration-user=${{ needs.cuj-integration-user.result }}"
+          echo "cuj-integration-partner=${{ needs.cuj-integration-partner.result }}"
+          exit 1

--- a/docs/infra/branch-strategy/dev-pipeline.md
+++ b/docs/infra/branch-strategy/dev-pipeline.md
@@ -36,6 +36,8 @@
 
 dev 머지 후 자동 발동. 통과 = "이 commit 은 RC 가능 + backend/web prod 배포 가능".
 
+> **Current implementation**: first operational version runs user/partner CUJ integration directly and sets `rc-gate-pass` on success. Backend/EF/Test Lab and the deploy chain are follow-up expansions.
+
 ### 무엇을 도는가
 
 매트릭스 병렬. 하나라도 실패 = rc-gate 전체 실패.
@@ -124,4 +126,4 @@ Snapshot 모델 — **auto-revert 없음**. dev 가 broken 상태로 잠시 머�
 - [branch-flow.md](./branch-flow.md) — auto-deploy chain 그림
 
 ---
-_Reviewed: 2026-05-23 16:31_
+_Reviewed: 2026-05-24 09:24_

--- a/docs/infra/branch-strategy/rc-promotion.md
+++ b/docs/infra/branch-strategy/rc-promotion.md
@@ -15,12 +15,13 @@
 
 - **cron**: 매주 X 요일 KST 10:00 (TBD)
 - **manual**: `workflow_dispatch` (긴급 cut)
+- **현재 구현**: 매주 월요일 KST 10:00. 수동 실행은 `source_sha`, `rc_week`, `allow_active_rc` 입력을 지원한다.
 - 동작:
   1. **active RC marker 확인** → 있으면 skip + Slack `#release` 알림 (이전 RC 가 hotfix 로 길어지는 중)
   2. 없으면 dev 의 최신 `rc-gate-pass` status 부여된 commit 찾기 (GitHub API: `GET /repos/.../commits/{sha}/status`)
   3. 못 찾으면 (3일+ green 없음) → alert + cut 보류
   4. 찾았으면 그 commit 에서 `rc/YYYY-Wxx` branch cut
-  5. Supabase branch 생성 (`rc-YYYY-Wxx`) + RC env 에 migration/EF deploy
+  5. Supabase branch 생성 (`rc-YYYY-Wxx`) + RC env 에 migration/EF deploy (후속 PR)
   6. `bump-version.sh {ver}-rc-01` 실행 → tag `v{ver}-rc-01` + `promo/rc-YYYY-Wxx`
   7. Branch protection 활성화 (direct push 금지, hotfix PR 만)
   8. active RC marker 기록 + Slack `#release` 알림 + soak 시작
@@ -183,4 +184,4 @@ dev 의 `rc-gate-pass` 는 계속 `main-staging` env 로 deploy 된다. RC soak 
 - [branch-flow.md](./branch-flow.md) — tag 컨벤션 + protection
 
 ---
-_Reviewed: 2026-05-19 09:47_
+_Reviewed: 2026-05-24 09:24_


### PR DESCRIPTION
## Summary
- add rc-gate on dev push to run user/partner CUJ integration and set rc-gate-pass on success
- add rc-cut weekly/manual workflow to cut rc/YYYY-Www from latest rc-gate-pass commit
- document current implementation scope and follow-up backend/EF/Test Lab expansion

## Verification
- python3 YAML parse for all .github/workflows/*.yml