### PR TITLE
Refactor core Edge Function business policies

### DIFF
--- a/supabase/functions/BLUEDOC.md
+++ b/supabase/functions/BLUEDOC.md
@@ -1,51 +1,40 @@
 # Supabase Edge Functions
 
-minglit 의 backend API 진입점. 60+ EF (user / partner / system / public) + 5 underscore-prefix 공용 디렉토리.
+minglit 의 backend API 진입점. 60+ EF 와 공용 `_shared/`, 테스트 유틸을
+포함한다.
 
-## 디렉토리 분류
+## 이정표
 
-### 공용 (`_` prefix — EF 아님)
+| 항목                                                                   | 역할                                                             |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| [architecture.md](architecture.md)                                     | EF 표준 레이어 (`index/input/service/domain/RPC`) 와 테스트 전략 |
+| [auth-manifest.json](auth-manifest.json)                               | EF 별 env/caller 선언. wrapper 가 런타임 가드                    |
+| [_shared/](./_shared/BLUEDOC.md)                                       | wrapper, HTTP, DB client, logger, pure domain core               |
+| [_test_utils/](./_test_utils/BLUEDOC.md)                               | HTTP mock, fixture, schema validator                             |
+| [_contract_tests/](./_contract_tests/BLUEDOC.md)                       | EF 응답 JSON schema contract                                     |
+| [_integration_tests/](./_integration_tests/BLUEDOC.md)                 | local Supabase + 외부 mock integration/CUJ                       |
+| [_payment_integration_tests/](./_payment_integration_tests/BLUEDOC.md) | 결제 chaining 시뮬. 추후 `_integration_tests/` 흡수              |
+| [event-flow-simulator/](./event-flow-simulator/BLUEDOC.md)             | 이벤트 lifecycle funnel 시뮬레이터                               |
+| [user-create-order/](./user-create-order/BLUEDOC.md)                   | 이벤트 신청/주문 생성 EF                                         |
 
-| 디렉토리 | 역할 |
-|---|---|
-| [_shared/](./_shared/BLUEDOC.md) | 모든 EF 가 import 하는 공용 라이브러리 (wrapper / logger / HTTP / DB / 외부 client / 도메인 helper) |
-| [_test_utils/](./_test_utils/BLUEDOC.md) | 테스트 공용 mock 및 fixture (mock_supabase / mock_http / schema_validator 등) |
-| [_payment_integration_tests/](./_payment_integration_tests/BLUEDOC.md) | 결제 도메인 EF chaining 시뮬 (in-process, mock 전체). 추후 `_integration_tests/` 로 흡수 예정 |
-| [_contract_tests/](./_contract_tests/BLUEDOC.md) | EF 응답 ↔ shared JSON schema 일치 가드 |
-| [_integration_tests/](./_integration_tests/BLUEDOC.md) | 빈 local Supabase + 외부 mock 으로 실 schema/trigger/RLS contract 검증 (Layer 5.5) |
+## 핵심 컨벤션
 
-### EF (60+)
+- 신규/핵심 EF 는 `minglitEdgeFunction` + `auth-manifest.json` 를 반드시
+  사용한다.
+- 복잡한 EF 는 `index.ts` 를 얇게 두고 `input.ts` / `service.ts` 로 분리한다.
+- 비즈니스 규칙은 `_shared/domains/<domain>` 의 pure 함수와 mock 없는 unit test
+  로 검증한다.
+- 원자성이 필요한 write 는 EF service 가 아니라 Postgres RPC boundary 로 옮긴다.
+- 모든 신규 EF 는 `<ef-name>_test.ts` 또는 `index_test.ts`, 필요 시 response
+  contract 를 추가한다.
 
-도메인별 (auth-manifest.json 의 `callers` 기준):
+## 관련
 
-| 카테고리 | 예 |
-|---|---|
-| **user** (33) — JWT 인증, 유저/파트너 호출 | apply-event, payment-verify, partner-manage-party, user-event-feed ... |
-| **system** (15) — pg_cron / worker 호출 | notification-worker, settlement-register-transfers, recurrence-cron ... |
-| **public** (4) — 인증 없음 (dev 전용 + health) | event-flow-simulator, dev-mock-portone, dev-seed, health |
-| **external** (1) — 외부 콜백 | payment-webhook (PortOne) |
-
-특수 EF: [event-flow-simulator/](./event-flow-simulator/BLUEDOC.md) — 이벤트 라이프사이클 funnel 시뮬레이터 (Stochastic Cascade 모델).
-
-## auth-manifest.json
-
-각 EF 의 `envs` (어느 환경에서 동작) + `callers` (누가 호출) + 설명 선언. `_shared/edge_function.ts` 의 `minglitEdgeFunction` wrapper 가 호출 시 manifest 기반 가드 적용. 상세: [docs/architecture/edge-function-auth.md](../../docs/architecture/edge-function-auth.md).
-
-## 신규 EF 추가 절차
-
-1. `<ef-name>/index.ts` + `deno.json` 생성
-2. `minglitEdgeFunction` wrapper 사용 (`_shared/edge_function.ts`)
-3. `auth-manifest.json` 에 entry 추가 (envs / callers / description)
-4. `<ef-name>/<ef_name>_test.ts` 단위 테스트 (`_test_utils/` 활용)
-5. `supabase/config.toml` 의 `[functions.<ef-name>]` 자동 생성 또는 수동 등록
-6. (선택) `shared/schemas/responses/<ef>.json` + `_contract_tests` 항목 추가
-
-## 관련 컨벤션
-
+- [edge-function-auth.md](../../docs/architecture/edge-function-auth.md)
+- [edge-functions.md](../../docs/operations/edge-functions.md)
+- [test-strategy.md](../../docs/qa/test-strategy.md)
 - [BLUEDOC convention](../../docs/infra/bluedoc/BLUEDOC.md)
-- [edge-function-auth.md](../../docs/architecture/edge-function-auth.md) — minglitEdgeFunction wrapper + manifest
-- [edge-functions.md](../../docs/operations/edge-functions.md) — 디버깅 / Axiom / Sentry
-- [test-strategy.md](../../docs/qa/test-strategy.md) — 7-Layer test taxonomy
 
 ---
-_Reviewed: 2026-05-18 21:00_
+
+_Reviewed: 2026-05-24 00:00_

--- a/supabase/functions/BLUEDOC.md
+++ b/supabase/functions/BLUEDOC.md
@@ -16,6 +16,7 @@ minglit 의 backend API 진입점. 60+ EF 와 공용 `_shared/`, 테스트 유�
 | [_payment_integration_tests/](./_payment_integration_tests/BLUEDOC.md) | 결제 chaining 시뮬. 추후 `_integration_tests/` 흡수              |
 | [event-flow-simulator/](./event-flow-simulator/BLUEDOC.md)             | 이벤트 lifecycle funnel 시뮬레이터                               |
 | [user-create-order/](./user-create-order/BLUEDOC.md)                   | 이벤트 신청/주문 생성 EF                                         |
+| [payment-verify/](./payment-verify/BLUEDOC.md)                         | PortOne 결제 검증/승인 EF                                        |
 
 ## 핵심 컨벤션
 

--- a/supabase/functions/BLUEDOC.md
+++ b/supabase/functions/BLUEDOC.md
@@ -17,6 +17,7 @@ minglit 의 backend API 진입점. 60+ EF 와 공용 `_shared/`, 테스트 유�
 | [event-flow-simulator/](./event-flow-simulator/BLUEDOC.md)             | 이벤트 lifecycle funnel 시뮬레이터                               |
 | [user-create-order/](./user-create-order/BLUEDOC.md)                   | 이벤트 신청/주문 생성 EF                                         |
 | [payment-verify/](./payment-verify/BLUEDOC.md)                         | PortOne 결제 검증/승인 EF                                        |
+| [user-cancel-order/](./user-cancel-order/BLUEDOC.md)                   | 유저 신청 취소/환불 EF                                           |
 
 ## 핵심 컨벤션
 

--- a/supabase/functions/BLUEDOC.md
+++ b/supabase/functions/BLUEDOC.md
@@ -5,19 +5,20 @@ minglit 의 backend API 진입점. 60+ EF 와 공용 `_shared/`, 테스트 유�
 
 ## 이정표
 
-| 항목                                                                   | 역할                                                             |
-| ---------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| [architecture.md](architecture.md)                                     | EF 표준 레이어 (`index/input/service/domain/RPC`) 와 테스트 전략 |
-| [auth-manifest.json](auth-manifest.json)                               | EF 별 env/caller 선언. wrapper 가 런타임 가드                    |
-| [_shared/](./_shared/BLUEDOC.md)                                       | wrapper, HTTP, DB client, logger, pure domain core               |
-| [_test_utils/](./_test_utils/BLUEDOC.md)                               | HTTP mock, fixture, schema validator                             |
-| [_contract_tests/](./_contract_tests/BLUEDOC.md)                       | EF 응답 JSON schema contract                                     |
-| [_integration_tests/](./_integration_tests/BLUEDOC.md)                 | local Supabase + 외부 mock integration/CUJ                       |
-| [_payment_integration_tests/](./_payment_integration_tests/BLUEDOC.md) | 결제 chaining 시뮬. 추후 `_integration_tests/` 흡수              |
-| [event-flow-simulator/](./event-flow-simulator/BLUEDOC.md)             | 이벤트 lifecycle funnel 시뮬레이터                               |
-| [user-create-order/](./user-create-order/BLUEDOC.md)                   | 이벤트 신청/주문 생성 EF                                         |
-| [payment-verify/](./payment-verify/BLUEDOC.md)                         | PortOne 결제 검증/승인 EF                                        |
-| [user-cancel-order/](./user-cancel-order/BLUEDOC.md)                   | 유저 신청 취소/환불 EF                                           |
+| 항목                                                                     | 역할                                                             |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------- |
+| [architecture.md](architecture.md)                                       | EF 표준 레이어 (`index/input/service/domain/RPC`) 와 테스트 전략 |
+| [auth-manifest.json](auth-manifest.json)                                 | EF 별 env/caller 선언. wrapper 가 런타임 가드                    |
+| [_shared/](./_shared/BLUEDOC.md)                                         | wrapper, HTTP, DB client, logger, pure domain core               |
+| [_test_utils/](./_test_utils/BLUEDOC.md)                                 | HTTP mock, fixture, schema validator                             |
+| [_contract_tests/](./_contract_tests/BLUEDOC.md)                         | EF 응답 JSON schema contract                                     |
+| [_integration_tests/](./_integration_tests/BLUEDOC.md)                   | local Supabase + 외부 mock integration/CUJ                       |
+| [_payment_integration_tests/](./_payment_integration_tests/BLUEDOC.md)   | 결제 chaining 시뮬. 추후 `_integration_tests/` 흡수              |
+| [event-flow-simulator/](./event-flow-simulator/BLUEDOC.md)               | 이벤트 lifecycle funnel 시뮬레이터                               |
+| [user-create-order/](./user-create-order/BLUEDOC.md)                     | 이벤트 신청/주문 생성 EF                                         |
+| [payment-verify/](./payment-verify/BLUEDOC.md)                           | PortOne 결제 검증/승인 EF                                        |
+| [user-cancel-order/](./user-cancel-order/BLUEDOC.md)                     | 유저 신청 취소/환불 EF                                           |
+| [partner-approve-application/](./partner-approve-application/BLUEDOC.md) | 파트너 신청 승인 EF                                              |
 
 ## 핵심 컨벤션
 

--- a/supabase/functions/_shared/BLUEDOC.md
+++ b/supabase/functions/_shared/BLUEDOC.md
@@ -1,60 +1,36 @@
 # _shared
 
-모든 Edge Function 이 import 하는 공용 라이브러리. EF 아님 (`_` prefix). 변경 시 영향 큼.
+모든 Edge Function 이 import 하는 공용 라이브러리. `_` prefix 라 EF entrypoint 아님.
 
-## 파일 그룹
+## 이정표
 
-### Wrapper / Auth (EF 진입점 표준)
-- `edge_function.ts` — `minglitEdgeFunction(handler)` wrapper. auth-manifest 기반 envs/role 가드 + logger / sentry 통합. **모든 신규 EF 가 사용해야 함**
-- `env_keystore.ts` — env-manifest 기반 환경변수 typed 접근
+| 항목 | 역할 |
+|---|---|
+| `edge_function.ts` | `minglitEdgeFunction(handler)` wrapper. manifest env/caller 가드 + logging/Sentry |
+| `env_keystore.ts` | env-manifest 기반 환경변수 typed 접근 |
+| `request_utils.ts` / `response_utils.ts` | request body parsing, CORS/success/error response |
+| `supabase_client.ts` | service/user Supabase client 생성 |
+| `logger.ts` / `axiom_logger.ts` / `statsig_utils.ts` | local/Axiom/Statsig observability |
+| `iamport_client.ts` / `portone_client.ts` | 결제 외부 client |
+| `partner_permissions.ts` / `refund_utils.ts` / `worker_utils.ts` | IO 포함 공용 helper |
+| `validation_utils.ts` / `temporal_utils.ts` | 입력/시간 helper |
+| [domains/](domains/BLUEDOC.md) | pure business rule core (`event`, `payment`, `order`) |
+| [_testing/](_testing/BLUEDOC.md) | L3 handler unit test (`fakeSupabase`, fixtures, `makeCtx`) |
+| [ai/](ai/) | AI adapter abstraction |
 
-### Logging / Observability
-- `logger.ts` — 콘솔 logger (local 전용)
-- `axiom_logger.ts` — Axiom 구조화 로깅 (dev/prod). withHandler 가 자동 호출
-- `statsig_utils.ts` — Statsig 이벤트 logging (no-op when key missing)
-- `pii_masker.ts` — 로그 출력 시 PII 마스킹
+## 핵심 컨벤션
 
-### HTTP
-- `request_utils.ts` — request body 파싱 helper
-- `response_utils.ts` — corsResponse / errorResponse / successResponse
-
-### DB
-- `supabase_client.ts` — `createServiceClient()` / `createUserClient(token)`
-
-### 외부 client
-- `iamport_client.ts` — Iamport (구) PortOne v1 client
-- `portone_client.ts` — PortOne v2 client
-
-### 도메인 helper (IO 포함)
-- `partner_permissions.ts` — partner_members role 검증
-- `refund_utils.ts` — PortOne 환불 IO (`executeRefund`, `RefundError`). 정책은 `domains/payment/refund_policy.ts` 로 이동
-- `temporal_utils.ts` — 시간/timezone 유틸
-- `validation_utils.ts` — 입력 검증
-- `worker_utils.ts` — PGMQ worker 패턴
-
-### Pure 도메인 코어
-- `domains/` — 도메인별 pure 비즈니스 로직 (IO 없음). [domains/BLUEDOC.md](domains/BLUEDOC.md)
-  - `domains/payment/` — application status 분류, 환불 정책
-  - `domains/event/` — event status / capacity / 시작 시각 / participant
-
-### AI
-- `ai/` — AI 어댑터 추상화 (OpenAI embedding / LLM)
-
-### Test 인프라
-- `_testing/` — L3 EF handler unit test (`fakeSupabase` + `makeCtx` + fixtures). [_testing/BLUEDOC.md](_testing/BLUEDOC.md)
-
-### Tests
-각 `*.ts` 의 `*_test.ts` 동반.
-
-## 변경 정책
-
-breaking change → 모든 EF 영향, 전수 회귀 필요. 신규 utility → 자유. deprecation → 단계적 (legacy 유지 → 마이그 PR → 삭제).
+- 신규 EF 는 `edge_function.ts` wrapper 와 `auth-manifest.json` 을 사용한다.
+- business rule 은 가능하면 `domains/` 로 분리하고 IO helper 와 섞지 않는다.
+- `_shared` breaking change 는 모든 EF 영향이므로 전수 회귀가 필요하다.
+- 신규 utility 는 동반 `*_test.ts` 를 기본으로 둔다.
 
 ## 관련
 
-- [edge-function-auth.md](../../../docs/architecture/edge-function-auth.md) — minglitEdgeFunction wrapper 상세
-- [edge-functions.md](../../../docs/operations/edge-functions.md) — axiom / sentry 디버깅
-- [functions/BLUEDOC.md](../BLUEDOC.md) — EF 디렉토리 진입점
+- [functions/architecture.md](../architecture.md) — EF 레이어 표준
+- [edge-function-auth.md](../../../docs/architecture/edge-function-auth.md)
+- [edge-functions.md](../../../docs/operations/edge-functions.md)
+- [functions/BLUEDOC.md](../BLUEDOC.md)
 
 ---
-_Reviewed: 2026-05-17 22:32_
+_Reviewed: 2026-05-24 00:00_

--- a/supabase/functions/_shared/domains/BLUEDOC.md
+++ b/supabase/functions/_shared/domains/BLUEDOC.md
@@ -1,23 +1,29 @@
 # _shared/domains
 
-도메인별 **순수 비즈니스 로직** 모음. IO (DB / 외부 API / HTTP / env / Date.now) 없음.
+도메인별 **순수 비즈니스 로직** 모음. IO (DB / 외부 API / HTTP / env / Date.now)
+없음.
 
 ## 왜 `_shared/domains/`?
 
-Hexagonal 의 도메인 코어는 보통 EF 안 nested 폴더에 두지만, Supabase CLI 는 nested EF entrypoint 를 인식 못 함 ([Issue #3676](https://github.com/supabase/cli/issues/3676)). 차선책으로 `_shared/` 안에 도메인별 grouping. EF 폴더는 flat 유지.
+Hexagonal 의 도메인 코어는 보통 EF 안 nested 폴더에 두지만, Supabase CLI 는
+nested EF entrypoint 를 인식 못 함
+([Issue #3676](https://github.com/supabase/cli/issues/3676)). 차선책으로
+`_shared/` 안에 도메인별 grouping. EF 폴더는 flat 유지.
 
 ## 현재 도메인
 
-| 도메인 | 설명 | BLUEDOC |
-|---|---|---|
-| `payment/` | application status 분류, 환불 정책 (grace period + cutoff), 정책 파싱 | [payment/BLUEDOC.md](payment/BLUEDOC.md) |
-| `event/` | event status 가드 (신청 가능 / 편집 가능), capacity, 시작 시각, participant (`isCheckedIn`) | [event/BLUEDOC.md](event/BLUEDOC.md) |
+| 도메인     | 설명                                                                                        | BLUEDOC                                  |
+| ---------- | ------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `payment/` | application status 분류, 환불 정책 (grace period + cutoff), 정책 파싱                       | [payment/BLUEDOC.md](payment/BLUEDOC.md) |
+| `event/`   | event status 가드 (신청 가능 / 편집 가능), capacity, 시작 시각, participant (`isCheckedIn`) | [event/BLUEDOC.md](event/BLUEDOC.md)     |
+| `order/`   | 주문 생성/신청 eligibility, 결제 필요 여부, 재신청 정책                                     | [order/BLUEDOC.md](order/BLUEDOC.md)     |
 
 ## 새 도메인 추가 가이드
 
 1. EF 들이 동일한 분류 / 계산 / 분기 로직을 인라인으로 중복 구현 → 추출 신호
 2. `_shared/domains/<domain>/` 폴더 생성
-3. pure 함수만 — IO 가 필요하면 인자로 주입 (예: `now: Date`, `policyRaw: unknown`)
+3. pure 함수만 — IO 가 필요하면 인자로 주입 (예: `now: Date`,
+   `policyRaw: unknown`)
 4. `<file>.ts` + `<file>_test.ts` 동반 작성, mock 0 / IO 0
 5. `BLUEDOC.md` 추가 — 파일 목록 + 사용 패턴 + 변경 정책
 6. 본 entry 점에 도메인 등록
@@ -32,7 +38,9 @@ Hexagonal 의 도메인 코어는 보통 EF 안 nested 폴더에 두지만, Supa
 
 - [_shared/BLUEDOC.md](../BLUEDOC.md) — `_shared/` 전체 entry
 - [functions/BLUEDOC.md](../../BLUEDOC.md) — EF 디렉토리 entry
-- [Issue #3676](https://github.com/supabase/cli/issues/3676) — nested entrypoint 미지원 (본 구조 선택 이유)
+- [Issue #3676](https://github.com/supabase/cli/issues/3676) — nested entrypoint
+  미지원 (본 구조 선택 이유)
 
 ---
-_Reviewed: 2026-05-18 03:45_
+
+_Reviewed: 2026-05-24 00:00_

--- a/supabase/functions/_shared/domains/event/BLUEDOC.md
+++ b/supabase/functions/_shared/domains/event/BLUEDOC.md
@@ -1,56 +1,35 @@
 # _shared/domains/event
 
-이벤트 도메인의 **순수 비즈니스 로직**. IO 없음. event status / capacity 가드 + 시간 비교.
+이벤트 도메인의 **순수 비즈니스 로직**. IO 없음.
 
-## 파일
+## 이정표
 
-| 파일 | 역할 |
-|---|---|
-| `availability.ts` | event status (`isEventOpenForApplication` / `isEventEditableByPartner`), capacity (`isEventFull` / `isTicketSoldOut`), 시작 시각 (`isEventStarted`) |
-| `availability_test.ts` | pure unit tests (mock 0) |
-| `participant.ts` | event_participants 분류 (`isCheckedIn`). 매칭 / 투표 EF 의 자격 가드 |
-| `participant_test.ts` | pure unit tests (mock 0) |
+| 파일                             | 역할                                                            |
+| -------------------------------- | --------------------------------------------------------------- |
+| `availability.ts`                | 신청/편집 가능 status, capacity, 시작 시각, 티켓 매진 predicate |
+| `application_approval_policy.ts` | partner approval 가능 status + capacity guard RPC 결과 mapping  |
+| `participant.ts`                 | event_participants check-in 분류                                |
+| `*_test.ts`                      | 각 policy 의 mock 없는 unit tests                               |
 
-## 두 status predicate 의 의미 차이 (중요)
+## 핵심 컨벤션
 
-| Predicate | scheduled | active | 그 외 | 의미 |
-|---|---|---|---|---|
-| `isEventOpenForApplication` | ✅ | ✅ | ❌ | 유저가 신청 시도 가능 — Fix #998 |
-| `isEventEditableByPartner`  | ✅ | ❌ | ❌ | 파트너가 취소/규칙 변경 가능 — state machine 가드 |
-
-`active` 에서 갈림: 진행 중 이벤트에 유저는 신청 가능하지만 파트너는 편집 불가.
-
-## 사용 패턴
-
-```ts
-// user-create-order
-import { isEventOpenForApplication, isEventStarted, isEventFull, isTicketSoldOut }
-  from "../_shared/domains/event/availability.ts";
-
-if (!isEventOpenForApplication(event.status)) return errorResponse(...);
-if (isEventStarted(event.start_time)) return errorResponse(...);
-if (isEventFull(event.current_participants, event.max_participants)) ...
-if (isTicketSoldOut(ticket.sold_count, ticket.quantity)) ...
-
-// partner-manage-event (cancel 분기)
-import { isEventEditableByPartner } from "../_shared/domains/event/availability.ts";
-if (!isEventEditableByPartner(event.status)) return errorResponse(...);
-```
-
-## 변경 정책
-
-- pure 만 — IO 필요 시 인자로 주입 (`now: Date`)
-- breaking change → user-create-order / apply-event / partner-manage-event / partner-manage-match 전부 영향, unit test 가 자동 가드
-- 신규 predicate 추가 자유
+- `isEventOpenForApplication`: scheduled / active 신청 가능.
+- `isEventEditableByPartner`: scheduled 만 편집 가능.
+- 시간 비교는 `now: Date` 를 주입할 수 있게 둔다.
+- capacity 원자성은 EF policy 가 아니라 Postgres RPC guard 책임이다.
+- breaking change 는 user-create-order / apply-event / partner-manage-event /
+  approval EF 영향.
 
 ## 알려진 정합성 이슈
 
-- `apply-event/index.ts` 의 status 가드는 `scheduled only` (active 거부) — Fix #998 의 `user-create-order` 와 불일치. 별도 이슈로 관리.
+- `apply-event/index.ts` 의 status 가드는 `scheduled only` 로 Fix #998 의
+  user-create-order 와 불일치. 별도 이슈로 관리.
 
 ## 관련
 
-- [_shared/domains/BLUEDOC.md](../BLUEDOC.md)
-- [payment/BLUEDOC.md](../payment/BLUEDOC.md) — paid 후 처리 흐름
+- [../BLUEDOC.md](../BLUEDOC.md)
+- [payment/BLUEDOC.md](../payment/BLUEDOC.md)
 
 ---
-_Reviewed: 2026-05-18 03:45_
+
+_Reviewed: 2026-05-24 00:00_

--- a/supabase/functions/_shared/domains/event/application_approval_policy.ts
+++ b/supabase/functions/_shared/domains/event/application_approval_policy.ts
@@ -1,0 +1,105 @@
+export const APPROVABLE_APPLICATION_STATUSES = [
+  "pending",
+  "pending_review",
+] as const;
+
+export interface ApprovalFailure {
+  ok: false;
+  status: number;
+  message: string;
+  details?: unknown;
+}
+
+export type SingleApprovalPolicyResult =
+  | { ok: true; approved: 1 }
+  | ApprovalFailure;
+
+export type BulkApprovalPolicyResult =
+  | {
+    ok: true;
+    approved: number;
+    skippedDueToCapacity: number;
+    remainingSlotsBeforeApproval: number;
+  }
+  | ApprovalFailure;
+
+export function isApplicationApprovableForPartnerApproval(
+  status: string,
+): boolean {
+  return APPROVABLE_APPLICATION_STATUSES.includes(
+    status as typeof APPROVABLE_APPLICATION_STATUSES[number],
+  );
+}
+
+export function mapSingleApprovalRpcResult(
+  rawResult: unknown,
+): SingleApprovalPolicyResult {
+  const result = firstResult(rawResult);
+  const resultStatus = typeof result.result_status === "string"
+    ? result.result_status
+    : undefined;
+
+  if (resultStatus === "approved") {
+    return { ok: true, approved: 1 };
+  }
+  if (resultStatus === "event_full") {
+    return fail(409, "정원이 초과되었습니다.", { code: "EVENT_FULL" });
+  }
+  if (resultStatus === "already_processed") {
+    return fail(409, "Application already processed");
+  }
+  if (resultStatus === "not_found") {
+    return fail(404, "Application not found");
+  }
+
+  return fail(500, "Event capacity data is invalid", {
+    code: "INVALID_EVENT_CAPACITY",
+  });
+}
+
+export function mapBulkApprovalRpcResult(
+  rawResult: unknown,
+): BulkApprovalPolicyResult {
+  const result = firstResult(rawResult);
+  const resultStatus = typeof result.result_status === "string"
+    ? result.result_status
+    : undefined;
+
+  if (resultStatus === "invalid_capacity") {
+    return fail(500, "Event capacity data is invalid", {
+      code: "INVALID_EVENT_CAPACITY",
+    });
+  }
+  if (resultStatus === "not_found") {
+    return fail(404, "Event not found");
+  }
+
+  return {
+    ok: true,
+    approved: numberOrZero(result.approved_count),
+    skippedDueToCapacity: numberOrZero(result.skipped_due_to_capacity),
+    remainingSlotsBeforeApproval: numberOrZero(
+      result.remaining_slots_before_approval,
+    ),
+  };
+}
+
+function firstResult(rawResult: unknown): Record<string, unknown> {
+  const value = Array.isArray(rawResult) ? rawResult[0] : rawResult;
+  return typeof value === "object" && value !== null
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === "number" ? value : 0;
+}
+
+function fail(
+  status: number,
+  message: string,
+  details?: unknown,
+): ApprovalFailure {
+  if (details === undefined) return { ok: false, status, message };
+  return { ok: false, status, message, details };
+}

--- a/supabase/functions/_shared/domains/event/application_approval_policy_test.ts
+++ b/supabase/functions/_shared/domains/event/application_approval_policy_test.ts
@@ -1,0 +1,92 @@
+import { assertEquals } from "@std/assert";
+import {
+  isApplicationApprovableForPartnerApproval,
+  mapBulkApprovalRpcResult,
+  mapSingleApprovalRpcResult,
+} from "./application_approval_policy.ts";
+
+Deno.test("isApplicationApprovableForPartnerApproval — pending statuses only", () => {
+  assertEquals(isApplicationApprovableForPartnerApproval("pending"), true);
+  assertEquals(
+    isApplicationApprovableForPartnerApproval("pending_review"),
+    true,
+  );
+  for (const status of ["approved", "paid", "cancelled", "rejected"]) {
+    assertEquals(isApplicationApprovableForPartnerApproval(status), false);
+  }
+});
+
+Deno.test("mapSingleApprovalRpcResult — approved passes", () => {
+  assertEquals(mapSingleApprovalRpcResult([{ result_status: "approved" }]), {
+    ok: true,
+    approved: 1,
+  });
+});
+
+Deno.test("mapSingleApprovalRpcResult — event_full/already/not_found/errors map to stable responses", () => {
+  assertEquals(mapSingleApprovalRpcResult({ result_status: "event_full" }), {
+    ok: false,
+    status: 409,
+    message: "정원이 초과되었습니다.",
+    details: { code: "EVENT_FULL" },
+  });
+  assertEquals(
+    mapSingleApprovalRpcResult({ result_status: "already_processed" }),
+    {
+      ok: false,
+      status: 409,
+      message: "Application already processed",
+    },
+  );
+  assertEquals(mapSingleApprovalRpcResult({ result_status: "not_found" }), {
+    ok: false,
+    status: 404,
+    message: "Application not found",
+  });
+  assertEquals(mapSingleApprovalRpcResult({ result_status: "weird" }), {
+    ok: false,
+    status: 500,
+    message: "Event capacity data is invalid",
+    details: { code: "INVALID_EVENT_CAPACITY" },
+  });
+});
+
+Deno.test("mapBulkApprovalRpcResult — invalid/not_found map to errors", () => {
+  assertEquals(
+    mapBulkApprovalRpcResult({ result_status: "invalid_capacity" }),
+    {
+      ok: false,
+      status: 500,
+      message: "Event capacity data is invalid",
+      details: { code: "INVALID_EVENT_CAPACITY" },
+    },
+  );
+  assertEquals(mapBulkApprovalRpcResult({ result_status: "not_found" }), {
+    ok: false,
+    status: 404,
+    message: "Event not found",
+  });
+});
+
+Deno.test("mapBulkApprovalRpcResult — counts default to zero", () => {
+  assertEquals(
+    mapBulkApprovalRpcResult([{
+      result_status: "ok",
+      approved_count: 5,
+      skipped_due_to_capacity: 2,
+      remaining_slots_before_approval: 7,
+    }]),
+    {
+      ok: true,
+      approved: 5,
+      skippedDueToCapacity: 2,
+      remainingSlotsBeforeApproval: 7,
+    },
+  );
+  assertEquals(mapBulkApprovalRpcResult({ result_status: "no_pending" }), {
+    ok: true,
+    approved: 0,
+    skippedDueToCapacity: 0,
+    remainingSlotsBeforeApproval: 0,
+  });
+});

--- a/supabase/functions/_shared/domains/order/BLUEDOC.md
+++ b/supabase/functions/_shared/domains/order/BLUEDOC.md
@@ -1,0 +1,28 @@
+# order domain
+
+이벤트 신청/주문 생성의 **pure business policy**.
+DB/RPC/HTTP/logger/env/timer/random 없음.
+
+## 이정표
+
+| 파일                                                       | 역할                                                        |
+| ---------------------------------------------------------- | ----------------------------------------------------------- |
+| [create_order_policy.ts](create_order_policy.ts)           | event/ticket/profile/entry group/reapplication/payment 정책 |
+| [create_order_policy_test.ts](create_order_policy_test.ts) | mock 없는 business-rule unit test                           |
+
+## 핵심 컨벤션
+
+- 입력은 EF service 가 이미 load 한 record snapshot 만 받는다.
+- 실패는 `{ ok: false, status, message, code? }` 형태로 반환해 handler/service
+  mapping 을 단순화한다.
+- 현재 시각은 호출자가 `now` 로 주입한다.
+- 원자성, DB lock, 재고 차감은 Postgres RPC 책임이다.
+
+## 관련
+
+- [../BLUEDOC.md](../BLUEDOC.md) — pure domain 가이드
+- [../../architecture.md](../../architecture.md) — EF 레이어 표준
+
+---
+
+_Reviewed: 2026-05-24 00:00_

--- a/supabase/functions/_shared/domains/order/create_order_policy.ts
+++ b/supabase/functions/_shared/domains/order/create_order_policy.ts
@@ -1,0 +1,198 @@
+import {
+  isEventFull,
+  isEventOpenForApplication,
+  isEventStarted,
+  isTicketSoldOut,
+} from "../event/availability.ts";
+import { blocksReapplication } from "../payment/application_status.ts";
+
+export type CreateOrderErrorCode =
+  | "EVENT_CLOSED"
+  | "EVENT_NOT_SCHEDULED"
+  | "TICKET_SOLD_OUT"
+  | "EVENT_FULL"
+  | "IDENTITY_REQUIRED"
+  | "GENDER_MISMATCH"
+  | "AGE_MISMATCH"
+  | "VERIFICATION_REQUIRED"
+  | "BALANCE_LIMIT"
+  | "ALREADY_APPLIED";
+
+export type CreateOrderPolicyResult =
+  | { ok: true }
+  | { ok: false; status: number; message: string; code?: CreateOrderErrorCode };
+
+export interface CreateOrderEventSnapshot {
+  status: string;
+  start_time: string | Date;
+  max_participants: number;
+  current_participants: number;
+}
+
+export interface CreateOrderTicketSnapshot {
+  event_id: string;
+  price: number;
+  quantity: number;
+  sold_count: number;
+}
+
+export interface CreateOrderUserProfileSnapshot {
+  is_verified: boolean;
+  gender?: string | null;
+  birth_date?: string | null;
+}
+
+export interface CreateOrderEntryGroupSnapshot {
+  gender?: string | null;
+  birth_year_min?: number | null;
+  birth_year_max?: number | null;
+  required_verification_ids?: string[] | null;
+}
+
+export interface CreateOrderExistingApplicationSnapshot {
+  status: string;
+}
+
+export interface CreateOrderVerificationData {
+  verification_id: string;
+  data: Record<string, unknown>;
+}
+
+export interface CreateOrderPaymentPlan {
+  amount: number;
+  requiresPayment: boolean;
+  initialStatus: "pending" | "paid";
+}
+
+export function evaluateEventAvailability(
+  event: CreateOrderEventSnapshot,
+  now: Date,
+): CreateOrderPolicyResult {
+  const windowResult = evaluateEventApplicationWindow(event, now);
+  if (!windowResult.ok) return windowResult;
+  return evaluateEventCapacity(event);
+}
+
+export function evaluateEventApplicationWindow(
+  event: Pick<CreateOrderEventSnapshot, "status" | "start_time">,
+  now: Date,
+): CreateOrderPolicyResult {
+  if (!isEventOpenForApplication(event.status)) {
+    return reject("이벤트가 마감되었습니다.", "EVENT_CLOSED");
+  }
+  if (isEventStarted(event.start_time, now)) {
+    return reject("이벤트가 마감되었습니다.", "EVENT_NOT_SCHEDULED");
+  }
+  return { ok: true };
+}
+
+export function evaluateEventCapacity(
+  event: Pick<
+    CreateOrderEventSnapshot,
+    "current_participants" | "max_participants"
+  >,
+): CreateOrderPolicyResult {
+  if (isEventFull(event.current_participants, event.max_participants)) {
+    return reject("정원이 초과되었습니다.", "EVENT_FULL");
+  }
+  return { ok: true };
+}
+
+export function evaluateTicketAvailability(
+  ticket: CreateOrderTicketSnapshot,
+  eventId: string,
+): CreateOrderPolicyResult {
+  if (ticket.event_id !== eventId) {
+    return { ok: false, status: 404, message: "티켓을 찾을 수 없습니다." };
+  }
+  if (isTicketSoldOut(ticket.sold_count, ticket.quantity)) {
+    return reject("티켓이 매진되었습니다.", "TICKET_SOLD_OUT");
+  }
+  return { ok: true };
+}
+
+export function evaluateIdentity(
+  profile: CreateOrderUserProfileSnapshot,
+): CreateOrderPolicyResult {
+  if (!profile.is_verified) {
+    return reject("본인인증이 필요합니다.", "IDENTITY_REQUIRED");
+  }
+  return { ok: true };
+}
+
+export function evaluateEntryGroupEligibility(args: {
+  profile: CreateOrderUserProfileSnapshot;
+  entryGroups: CreateOrderEntryGroupSnapshot[];
+  verificationData?: CreateOrderVerificationData;
+}): CreateOrderPolicyResult {
+  const { profile, entryGroups, verificationData } = args;
+  if (entryGroups.length === 0) return { ok: true };
+
+  const primaryGroup = entryGroups[0];
+  if (
+    primaryGroup.gender && profile.gender &&
+    primaryGroup.gender !== profile.gender
+  ) {
+    return reject("성별 조건이 맞지 않습니다.", "GENDER_MISMATCH");
+  }
+
+  if (profile.birth_date) {
+    const birthYear = new Date(profile.birth_date).getFullYear();
+    if (
+      primaryGroup.birth_year_min && birthYear < primaryGroup.birth_year_min
+    ) {
+      return reject("나이 조건이 맞지 않습니다.", "AGE_MISMATCH");
+    }
+    if (
+      primaryGroup.birth_year_max && birthYear > primaryGroup.birth_year_max
+    ) {
+      return reject("나이 조건이 맞지 않습니다.", "AGE_MISMATCH");
+    }
+  }
+
+  const requiredIds = entryGroups.flatMap((g) =>
+    g.required_verification_ids ?? []
+  );
+  if (requiredIds.length > 0 && !verificationData) {
+    return reject("자격 인증 정보가 필요합니다.", "VERIFICATION_REQUIRED");
+  }
+
+  return { ok: true };
+}
+
+export function evaluatePartyBalance(
+  balanceResult: { allowed?: boolean } | null,
+): CreateOrderPolicyResult {
+  if (balanceResult?.allowed === false) {
+    return reject("성비 균형 제한입니다.", "BALANCE_LIMIT");
+  }
+  return { ok: true };
+}
+
+export function evaluateReapplication(
+  existingApp: CreateOrderExistingApplicationSnapshot | null,
+): CreateOrderPolicyResult {
+  if (existingApp && blocksReapplication(existingApp.status)) {
+    return reject("이미 신청한 이벤트입니다.", "ALREADY_APPLIED");
+  }
+  return { ok: true };
+}
+
+export function decideCreateOrderPaymentPlan(
+  ticket: Pick<CreateOrderTicketSnapshot, "price">,
+): CreateOrderPaymentPlan {
+  const amount = ticket.price;
+  const requiresPayment = amount > 0;
+  return {
+    amount,
+    requiresPayment,
+    initialStatus: requiresPayment ? "pending" : "paid",
+  };
+}
+
+function reject(
+  message: string,
+  code: CreateOrderErrorCode,
+): CreateOrderPolicyResult {
+  return { ok: false, status: 400, message, code };
+}

--- a/supabase/functions/_shared/domains/order/create_order_policy_test.ts
+++ b/supabase/functions/_shared/domains/order/create_order_policy_test.ts
@@ -1,0 +1,233 @@
+import { assertEquals } from "@std/assert";
+import {
+  type CreateOrderEntryGroupSnapshot,
+  type CreateOrderEventSnapshot,
+  type CreateOrderTicketSnapshot,
+  type CreateOrderUserProfileSnapshot,
+  decideCreateOrderPaymentPlan,
+  evaluateEntryGroupEligibility,
+  evaluateEventAvailability,
+  evaluateEventCapacity,
+  evaluateIdentity,
+  evaluatePartyBalance,
+  evaluateReapplication,
+  evaluateTicketAvailability,
+} from "./create_order_policy.ts";
+
+const NOW = new Date("2026-01-01T12:00:00Z");
+
+function event(
+  overrides: Partial<CreateOrderEventSnapshot> = {},
+): CreateOrderEventSnapshot {
+  return {
+    status: "scheduled",
+    start_time: "2026-01-02T12:00:00Z",
+    max_participants: 20,
+    current_participants: 5,
+    ...overrides,
+  };
+}
+
+function ticket(
+  overrides: Partial<CreateOrderTicketSnapshot> = {},
+): CreateOrderTicketSnapshot {
+  return {
+    event_id: "ev-1",
+    price: 15000,
+    quantity: 10,
+    sold_count: 3,
+    ...overrides,
+  };
+}
+
+function profile(
+  overrides: Partial<CreateOrderUserProfileSnapshot> = {},
+): CreateOrderUserProfileSnapshot {
+  return {
+    is_verified: true,
+    gender: "male",
+    birth_date: "1995-06-15",
+    ...overrides,
+  };
+}
+
+function group(
+  overrides: Partial<CreateOrderEntryGroupSnapshot> = {},
+): CreateOrderEntryGroupSnapshot {
+  return {
+    gender: "male",
+    birth_year_min: 1990,
+    birth_year_max: 2000,
+    required_verification_ids: [],
+    ...overrides,
+  };
+}
+
+Deno.test("evaluateEventAvailability — closed status rejects", () => {
+  const result = evaluateEventAvailability(event({ status: "cancelled" }), NOW);
+  assertEquals(result, {
+    ok: false,
+    status: 400,
+    message: "이벤트가 마감되었습니다.",
+    code: "EVENT_CLOSED",
+  });
+});
+
+Deno.test("evaluateEventAvailability — already started rejects", () => {
+  const result = evaluateEventAvailability(event({ start_time: NOW }), NOW);
+  assertEquals(result, {
+    ok: false,
+    status: 400,
+    message: "이벤트가 마감되었습니다.",
+    code: "EVENT_NOT_SCHEDULED",
+  });
+});
+
+Deno.test("evaluateEventAvailability — full event rejects", () => {
+  const result = evaluateEventAvailability(
+    event({ current_participants: 20, max_participants: 20 }),
+    NOW,
+  );
+  assertEquals(result, {
+    ok: false,
+    status: 400,
+    message: "정원이 초과되었습니다.",
+    code: "EVENT_FULL",
+  });
+});
+
+Deno.test("evaluateEventCapacity — capacity check can run after ticket validation", () => {
+  const result = evaluateEventCapacity(
+    event({ current_participants: 20, max_participants: 20 }),
+  );
+  assertEquals(result, {
+    ok: false,
+    status: 400,
+    message: "정원이 초과되었습니다.",
+    code: "EVENT_FULL",
+  });
+});
+
+Deno.test("evaluateTicketAvailability — ticket from different event maps to 404", () => {
+  const result = evaluateTicketAvailability(
+    ticket({ event_id: "ev-other" }),
+    "ev-1",
+  );
+  assertEquals(result, {
+    ok: false,
+    status: 404,
+    message: "티켓을 찾을 수 없습니다.",
+  });
+});
+
+Deno.test("evaluateTicketAvailability — sold out rejects", () => {
+  const result = evaluateTicketAvailability(
+    ticket({ sold_count: 10, quantity: 10 }),
+    "ev-1",
+  );
+  assertEquals(result, {
+    ok: false,
+    status: 400,
+    message: "티켓이 매진되었습니다.",
+    code: "TICKET_SOLD_OUT",
+  });
+});
+
+Deno.test("evaluateIdentity — unverified user rejects", () => {
+  const result = evaluateIdentity(profile({ is_verified: false }));
+  assertEquals(result, {
+    ok: false,
+    status: 400,
+    message: "본인인증이 필요합니다.",
+    code: "IDENTITY_REQUIRED",
+  });
+});
+
+Deno.test("evaluateEntryGroupEligibility — gender mismatch rejects", () => {
+  const result = evaluateEntryGroupEligibility({
+    profile: profile({ gender: "female" }),
+    entryGroups: [group({ gender: "male" })],
+  });
+  assertEquals(result, {
+    ok: false,
+    status: 400,
+    message: "성별 조건이 맞지 않습니다.",
+    code: "GENDER_MISMATCH",
+  });
+});
+
+Deno.test("evaluateEntryGroupEligibility — birth year min/max rejects", () => {
+  assertEquals(
+    evaluateEntryGroupEligibility({
+      profile: profile({ birth_date: "1989-01-01" }),
+      entryGroups: [group({ birth_year_min: 1990 })],
+    }),
+    {
+      ok: false,
+      status: 400,
+      message: "나이 조건이 맞지 않습니다.",
+      code: "AGE_MISMATCH",
+    },
+  );
+  assertEquals(
+    evaluateEntryGroupEligibility({
+      profile: profile({ birth_date: "2001-01-01" }),
+      entryGroups: [group({ birth_year_max: 2000 })],
+    }),
+    {
+      ok: false,
+      status: 400,
+      message: "나이 조건이 맞지 않습니다.",
+      code: "AGE_MISMATCH",
+    },
+  );
+});
+
+Deno.test("evaluateEntryGroupEligibility — required verification rejects missing verification data", () => {
+  const result = evaluateEntryGroupEligibility({
+    profile: profile(),
+    entryGroups: [group({ required_verification_ids: ["student-id"] })],
+  });
+  assertEquals(result, {
+    ok: false,
+    status: 400,
+    message: "자격 인증 정보가 필요합니다.",
+    code: "VERIFICATION_REQUIRED",
+  });
+});
+
+Deno.test("evaluatePartyBalance — allowed=false rejects", () => {
+  const result = evaluatePartyBalance({ allowed: false });
+  assertEquals(result, {
+    ok: false,
+    status: 400,
+    message: "성비 균형 제한입니다.",
+    code: "BALANCE_LIMIT",
+  });
+});
+
+Deno.test("evaluateReapplication — cancelled/payment_failed allowed, paid blocked", () => {
+  assertEquals(evaluateReapplication({ status: "cancelled" }), { ok: true });
+  assertEquals(evaluateReapplication({ status: "payment_failed" }), {
+    ok: true,
+  });
+  assertEquals(evaluateReapplication({ status: "paid" }), {
+    ok: false,
+    status: 400,
+    message: "이미 신청한 이벤트입니다.",
+    code: "ALREADY_APPLIED",
+  });
+});
+
+Deno.test("decideCreateOrderPaymentPlan — paid ticket pending, free ticket paid", () => {
+  assertEquals(decideCreateOrderPaymentPlan(ticket({ price: 15000 })), {
+    amount: 15000,
+    requiresPayment: true,
+    initialStatus: "pending",
+  });
+  assertEquals(decideCreateOrderPaymentPlan(ticket({ price: 0 })), {
+    amount: 0,
+    requiresPayment: false,
+    initialStatus: "paid",
+  });
+});

--- a/supabase/functions/_shared/domains/payment/BLUEDOC.md
+++ b/supabase/functions/_shared/domains/payment/BLUEDOC.md
@@ -1,51 +1,31 @@
 # _shared/domains/payment
 
-결제 / 환불 도메인의 **순수 비즈니스 로직** 모음. IO (DB / 외부 API / HTTP)
-없음. 모든 payment-* EF 가 import.
+결제/환불 도메인의 **순수 비즈니스 로직**. IO (DB / 외부 API / HTTP) 없음.
 
-## 위치 — Supabase 제약 반영
+## 이정표
 
-Hexagonal 의 도메인 코어를 nested EF 폴더에 못 둠 (Supabase CLI Issue #3676 —
-nested entrypoint 미지원). 차선: `_shared/` 안 도메인별 grouping. EF 폴더는 flat
-유지.
+| 파일                             | 역할                                             |
+| -------------------------------- | ------------------------------------------------ |
+| `application_status.ts`          | application status 분류, 무료 여부, 재신청 차단  |
+| `cancel_order_policy.ts`         | user-cancel-order 취소 경로 결정                 |
+| `payment_verification_policy.ts` | payment-verify 소유자/멱등성/결제 상태/금액 검증 |
+| `refund_policy.ts`               | grace period + cutoff + 이벤트 시작 가드         |
+| `*_test.ts`                      | 각 policy 의 mock 없는 unit tests                |
 
-## 파일
+## 핵심 컨벤션
 
-| 파일                                                  | 역할                                                                                                                                                            |
-| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `application_status.ts`                               | application status 분류 (`isPaid` / `isPrePayment` / `isFinal`) + `isFreeApplication` + `blocksReapplication` (중복 신청 가드). 모든 payment / apply EF 가 사용 |
-| `application_status_test.ts`                          | pure unit tests (mock 0)                                                                                                                                        |
-| `payment_verification_policy.ts`                      | payment-verify 의 소유자/멱등성/결제 상태/금액 검증 policy                                                                                                      |
-| `payment_verification_policy_test.ts`                 | payment verification pure unit tests                                                                                                                            |
-| (관련 도메인) `_shared/domains/event/availability.ts` | `isEventStarted` (refund cutoff 등에서 사용)                                                                                                                    |
-| `refund_policy.ts`                                    | `verifyRefundEligibility` — grace period + cutoff + 이벤트 시작 가드 (Fix #1235)                                                                                |
-| `refund_policy_test.ts`                               | pure unit tests (mock 0)                                                                                                                                        |
-| (예정) `refund_amount.ts`                             | 환불 금액 계산 (Fix #2131 후속)                                                                                                                                 |
-
-## 사용 패턴
-
-```ts
-// payment EF index.ts
-import { classifyApplicationStatus } from "../_shared/domains/payment/application_status.ts";
-
-const { isPaid, isPrePayment } = classifyApplicationStatus(application.status);
-if (isPrePayment) { /* pre-payment 분기 */ }
-if (isPaid) { /* paid 분기 */ }
-```
-
-## 변경 정책
-
-- pure 함수만 — IO / Deno API / Date.now() 호출 시 인자로 받음 (testable)
-- breaking change → 모든 payment EF 영향 → 전수 unit test 가 자동 가드
-- 새 함수 추가 자유 (사용 안 하면 cost 0)
+- pure 함수만 둔다. IO / Deno API / Date.now() 필요 시 인자로 받는다.
+- payment-* EF 는 handler/service 에서 record 를 load 한 뒤 policy 에 snapshot
+  을 넘긴다.
+- 환불/승인/정산 같은 write 원자성은 EF policy 가 아니라 Postgres RPC 책임이다.
+- breaking change 는 모든 payment EF 영향 → domain unit test + EF
+  service/handler test 를 함께 확인한다.
 
 ## 관련
 
-- [_shared/BLUEDOC.md](../../BLUEDOC.md) — _shared 전체
-- [EF 아키텍처 RFC](../../../../../docs/architecture/) (예정) — 갈래 A 의 도입
-  배경
-- [Issue #3676](https://github.com/supabase/cli/issues/3676) — nested entrypoint
-  미지원 (본 구조 선택 이유)
+- [../BLUEDOC.md](../BLUEDOC.md)
+- [../../architecture.md](../../architecture.md)
+- [Issue #3676](https://github.com/supabase/cli/issues/3676)
 
 ---
 

--- a/supabase/functions/_shared/domains/payment/BLUEDOC.md
+++ b/supabase/functions/_shared/domains/payment/BLUEDOC.md
@@ -1,21 +1,26 @@
 # _shared/domains/payment
 
-결제 / 환불 도메인의 **순수 비즈니스 로직** 모음. IO (DB / 외부 API / HTTP) 없음. 모든 payment-* EF 가 import.
+결제 / 환불 도메인의 **순수 비즈니스 로직** 모음. IO (DB / 외부 API / HTTP)
+없음. 모든 payment-* EF 가 import.
 
 ## 위치 — Supabase 제약 반영
 
-Hexagonal 의 도메인 코어를 nested EF 폴더에 못 둠 (Supabase CLI Issue #3676 — nested entrypoint 미지원). 차선: `_shared/` 안 도메인별 grouping. EF 폴더는 flat 유지.
+Hexagonal 의 도메인 코어를 nested EF 폴더에 못 둠 (Supabase CLI Issue #3676 —
+nested entrypoint 미지원). 차선: `_shared/` 안 도메인별 grouping. EF 폴더는 flat
+유지.
 
 ## 파일
 
-| 파일 | 역할 |
-|---|---|
-| `application_status.ts` | application status 분류 (`isPaid` / `isPrePayment` / `isFinal`) + `isFreeApplication` + `blocksReapplication` (중복 신청 가드). 모든 payment / apply EF 가 사용 |
-| `application_status_test.ts` | pure unit tests (mock 0) |
-| (관련 도메인) `_shared/domains/event/availability.ts` | `isEventStarted` (refund cutoff 등에서 사용) |
-| `refund_policy.ts` | `verifyRefundEligibility` — grace period + cutoff + 이벤트 시작 가드 (Fix #1235) |
-| `refund_policy_test.ts` | pure unit tests (mock 0) |
-| (예정) `refund_amount.ts` | 환불 금액 계산 (Fix #2131 후속) |
+| 파일                                                  | 역할                                                                                                                                                            |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `application_status.ts`                               | application status 분류 (`isPaid` / `isPrePayment` / `isFinal`) + `isFreeApplication` + `blocksReapplication` (중복 신청 가드). 모든 payment / apply EF 가 사용 |
+| `application_status_test.ts`                          | pure unit tests (mock 0)                                                                                                                                        |
+| `payment_verification_policy.ts`                      | payment-verify 의 소유자/멱등성/결제 상태/금액 검증 policy                                                                                                      |
+| `payment_verification_policy_test.ts`                 | payment verification pure unit tests                                                                                                                            |
+| (관련 도메인) `_shared/domains/event/availability.ts` | `isEventStarted` (refund cutoff 등에서 사용)                                                                                                                    |
+| `refund_policy.ts`                                    | `verifyRefundEligibility` — grace period + cutoff + 이벤트 시작 가드 (Fix #1235)                                                                                |
+| `refund_policy_test.ts`                               | pure unit tests (mock 0)                                                                                                                                        |
+| (예정) `refund_amount.ts`                             | 환불 금액 계산 (Fix #2131 후속)                                                                                                                                 |
 
 ## 사용 패턴
 
@@ -37,8 +42,11 @@ if (isPaid) { /* paid 분기 */ }
 ## 관련
 
 - [_shared/BLUEDOC.md](../../BLUEDOC.md) — _shared 전체
-- [EF 아키텍처 RFC](../../../../../docs/architecture/) (예정) — 갈래 A 의 도입 배경
-- [Issue #3676](https://github.com/supabase/cli/issues/3676) — nested entrypoint 미지원 (본 구조 선택 이유)
+- [EF 아키텍처 RFC](../../../../../docs/architecture/) (예정) — 갈래 A 의 도입
+  배경
+- [Issue #3676](https://github.com/supabase/cli/issues/3676) — nested entrypoint
+  미지원 (본 구조 선택 이유)
 
 ---
-_Reviewed: 2026-05-18 03:45_
+
+_Reviewed: 2026-05-24 00:00_

--- a/supabase/functions/_shared/domains/payment/cancel_order_policy.ts
+++ b/supabase/functions/_shared/domains/payment/cancel_order_policy.ts
@@ -1,0 +1,78 @@
+import {
+  classifyApplicationStatus,
+  isFreeApplication,
+} from "./application_status.ts";
+import { isEventStarted } from "../event/availability.ts";
+
+export type CancelOrderPath =
+  | { ok: true; type: "pre_payment" }
+  | { ok: true; type: "free" }
+  | { ok: true; type: "paid_refund"; amount: number }
+  | { ok: false; status: number; message: string; details?: unknown };
+
+export interface CancelOrderApplicationSnapshot {
+  status: string;
+  payment_amount: number | null;
+  refund_status?: string | null;
+}
+
+export function decideCancelOrderPath(
+  application: CancelOrderApplicationSnapshot,
+): CancelOrderPath {
+  const { isPaid, isPrePayment, isFinal } = classifyApplicationStatus(
+    application.status,
+  );
+
+  if (isFinal) {
+    return reject(400, "이미 취소/거절된 신청입니다");
+  }
+
+  if (isPrePayment) {
+    return { ok: true, type: "pre_payment" };
+  }
+
+  if (!isPaid) {
+    return reject(400, "지원하지 않는 신청 상태입니다");
+  }
+
+  if (application.payment_amount === null) {
+    return reject(400, "결제 정보가 손상된 신청입니다");
+  }
+
+  if (isFreeApplication(application.payment_amount)) {
+    return { ok: true, type: "free" };
+  }
+
+  if (application.refund_status !== "none") {
+    return reject(400, "already_refunded", {
+      reason: "Refund already processed",
+    });
+  }
+
+  return {
+    ok: true,
+    type: "paid_refund",
+    amount: application.payment_amount,
+  };
+}
+
+export function evaluateFreeCancellationWindow(
+  eventStartTime: string | Date,
+  now: Date,
+): CancelOrderPath {
+  if (isEventStarted(eventStartTime, now)) {
+    return reject(400, "refund_not_eligible", {
+      reason: "event_already_started",
+    });
+  }
+  return { ok: true, type: "free" };
+}
+
+function reject(
+  status: number,
+  message: string,
+  details?: unknown,
+): CancelOrderPath {
+  if (details === undefined) return { ok: false, status, message };
+  return { ok: false, status, message, details };
+}

--- a/supabase/functions/_shared/domains/payment/cancel_order_policy_test.ts
+++ b/supabase/functions/_shared/domains/payment/cancel_order_policy_test.ts
@@ -1,0 +1,106 @@
+import { assertEquals } from "@std/assert";
+import {
+  decideCancelOrderPath,
+  evaluateFreeCancellationWindow,
+} from "./cancel_order_policy.ts";
+
+Deno.test("decideCancelOrderPath — final statuses reject", () => {
+  for (const status of ["cancelled", "rejected"]) {
+    assertEquals(
+      decideCancelOrderPath({
+        status,
+        payment_amount: 30000,
+        refund_status: "none",
+      }),
+      { ok: false, status: 400, message: "이미 취소/거절된 신청입니다" },
+    );
+  }
+});
+
+Deno.test("decideCancelOrderPath — pre-payment statuses delete application", () => {
+  assertEquals(
+    decideCancelOrderPath({
+      status: "pending",
+      payment_amount: 30000,
+      refund_status: "none",
+    }),
+    { ok: true, type: "pre_payment" },
+  );
+  assertEquals(
+    decideCancelOrderPath({
+      status: "payment_failed",
+      payment_amount: 30000,
+      refund_status: "none",
+    }),
+    { ok: true, type: "pre_payment" },
+  );
+});
+
+Deno.test("decideCancelOrderPath — paid with null amount rejects damaged data", () => {
+  assertEquals(
+    decideCancelOrderPath({
+      status: "paid",
+      payment_amount: null,
+      refund_status: "none",
+    }),
+    { ok: false, status: 400, message: "결제 정보가 손상된 신청입니다" },
+  );
+});
+
+Deno.test("decideCancelOrderPath — free paid application uses free cancel path", () => {
+  assertEquals(
+    decideCancelOrderPath({
+      status: "paid",
+      payment_amount: 0,
+      refund_status: "none",
+    }),
+    { ok: true, type: "free" },
+  );
+});
+
+Deno.test("decideCancelOrderPath — paid refund rejects already refunded", () => {
+  assertEquals(
+    decideCancelOrderPath({
+      status: "paid",
+      payment_amount: 30000,
+      refund_status: "completed",
+    }),
+    {
+      ok: false,
+      status: 400,
+      message: "already_refunded",
+      details: { reason: "Refund already processed" },
+    },
+  );
+});
+
+Deno.test("decideCancelOrderPath — paid/pending_review/approved require refund", () => {
+  for (const status of ["paid", "pending_review", "approved"]) {
+    assertEquals(
+      decideCancelOrderPath({
+        status,
+        payment_amount: 30000,
+        refund_status: "none",
+      }),
+      { ok: true, type: "paid_refund", amount: 30000 },
+    );
+  }
+});
+
+Deno.test("evaluateFreeCancellationWindow — event already started rejects", () => {
+  const now = new Date("2026-01-01T12:00:00Z");
+  assertEquals(evaluateFreeCancellationWindow(now, now), {
+    ok: false,
+    status: 400,
+    message: "refund_not_eligible",
+    details: { reason: "event_already_started" },
+  });
+});
+
+Deno.test("evaluateFreeCancellationWindow — future event passes", () => {
+  const now = new Date("2026-01-01T12:00:00Z");
+  assertEquals(
+    evaluateFreeCancellationWindow("2026-01-01T12:00:01Z", now),
+    { ok: true, type: "free" },
+  );
+});

--- a/supabase/functions/_shared/domains/payment/payment_verification_policy.ts
+++ b/supabase/functions/_shared/domains/payment/payment_verification_policy.ts
@@ -1,0 +1,68 @@
+export type PaymentVerificationReason =
+  | "payment_not_completed"
+  | "amount_mismatch";
+
+export type PaymentVerificationResult =
+  | { ok: true }
+  | {
+    ok: false;
+    status: number;
+    message: string;
+    reason: PaymentVerificationReason;
+    details: Record<string, unknown>;
+  };
+
+export interface PaymentVerificationOrderSnapshot {
+  payment_amount: number;
+  status: string;
+  user_id: string;
+}
+
+export interface PaymentGatewaySnapshot {
+  status: string;
+  amount: number;
+  paid_at?: number | null;
+}
+
+export function isPaymentVerifyAlreadyProcessed(status: string): boolean {
+  return status === "approved" || status === "paid";
+}
+
+export function isOrderOwner(
+  order: Pick<PaymentVerificationOrderSnapshot, "user_id">,
+  userId: string,
+): boolean {
+  return order.user_id === userId;
+}
+
+export function evaluateGatewayPayment(
+  payment: PaymentGatewaySnapshot,
+  expectedAmount: number,
+): PaymentVerificationResult {
+  if (payment.status !== "paid") {
+    return {
+      ok: false,
+      status: 400,
+      message: "Payment not completed",
+      reason: "payment_not_completed",
+      details: { status: payment.status },
+    };
+  }
+
+  if (payment.amount !== expectedAmount) {
+    return {
+      ok: false,
+      status: 400,
+      message: "Amount mismatch",
+      reason: "amount_mismatch",
+      details: { expected: expectedAmount, actual: payment.amount },
+    };
+  }
+
+  return { ok: true };
+}
+
+export function paidAtToIso(paidAt: number | null | undefined): string | null {
+  if (!paidAt || paidAt <= 0) return null;
+  return new Date(paidAt * 1000).toISOString().replace(".000Z", "Z");
+}

--- a/supabase/functions/_shared/domains/payment/payment_verification_policy_test.ts
+++ b/supabase/functions/_shared/domains/payment/payment_verification_policy_test.ts
@@ -1,0 +1,61 @@
+import { assertEquals } from "@std/assert";
+import {
+  evaluateGatewayPayment,
+  isOrderOwner,
+  isPaymentVerifyAlreadyProcessed,
+  paidAtToIso,
+} from "./payment_verification_policy.ts";
+
+Deno.test("isPaymentVerifyAlreadyProcessed — approved/paid are idempotent success", () => {
+  assertEquals(isPaymentVerifyAlreadyProcessed("approved"), true);
+  assertEquals(isPaymentVerifyAlreadyProcessed("paid"), true);
+  for (
+    const status of ["pending", "payment_failed", "pending_review", "rejected"]
+  ) {
+    assertEquals(isPaymentVerifyAlreadyProcessed(status), false);
+  }
+});
+
+Deno.test("isOrderOwner — authenticated user must match application owner", () => {
+  assertEquals(isOrderOwner({ user_id: "u-1" }, "u-1"), true);
+  assertEquals(isOrderOwner({ user_id: "u-2" }, "u-1"), false);
+});
+
+Deno.test("evaluateGatewayPayment — non-paid status rejects", () => {
+  assertEquals(
+    evaluateGatewayPayment({ status: "ready", amount: 10000 }, 10000),
+    {
+      ok: false,
+      status: 400,
+      message: "Payment not completed",
+      reason: "payment_not_completed",
+      details: { status: "ready" },
+    },
+  );
+});
+
+Deno.test("evaluateGatewayPayment — amount mismatch rejects with expected/actual", () => {
+  assertEquals(evaluateGatewayPayment({ status: "paid", amount: 999 }, 10000), {
+    ok: false,
+    status: 400,
+    message: "Amount mismatch",
+    reason: "amount_mismatch",
+    details: { expected: 10000, actual: 999 },
+  });
+});
+
+Deno.test("evaluateGatewayPayment — paid and exact amount passes", () => {
+  assertEquals(
+    evaluateGatewayPayment({ status: "paid", amount: 10000 }, 10000),
+    {
+      ok: true,
+    },
+  );
+});
+
+Deno.test("paidAtToIso — epoch seconds convert to ISO, missing values stay null", () => {
+  assertEquals(paidAtToIso(1700000000), "2023-11-14T22:13:20Z");
+  assertEquals(paidAtToIso(null), null);
+  assertEquals(paidAtToIso(0), null);
+  assertEquals(paidAtToIso(undefined), null);
+});

--- a/supabase/functions/_test_utils/mock_http.ts
+++ b/supabase/functions/_test_utils/mock_http.ts
@@ -3,7 +3,10 @@ import { getCapturedHandler, resetCapturedHandler } from "./std_server_stub.ts";
 
 export type RequestHandler = (req: Request) => Response | Promise<Response>;
 
-export type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+export type FetchLike = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
 
 export type FetchRoute = {
   matcher: string | RegExp | ((req: Request) => boolean | Promise<boolean>);
@@ -26,7 +29,11 @@ export function textResponse(body: string, init: ResponseInit = {}): Response {
   return new Response(body, { ...init, headers });
 }
 
-export function jsonRequest(url: string, body: unknown, init: RequestInit = {}): Request {
+export function jsonRequest(
+  url: string,
+  body: unknown,
+  init: RequestInit = {},
+): Request {
   const headers = new Headers(init.headers);
   headers.set("Content-Type", "application/json");
   return new Request(url, {
@@ -37,7 +44,11 @@ export function jsonRequest(url: string, body: unknown, init: RequestInit = {}):
   });
 }
 
-export function textRequest(url: string, body: string, init: RequestInit = {}): Request {
+export function textRequest(
+  url: string,
+  body: string,
+  init: RequestInit = {},
+): Request {
   return new Request(url, {
     ...init,
     method: init.method ?? "POST",
@@ -45,7 +56,11 @@ export function textRequest(url: string, body: string, init: RequestInit = {}): 
   });
 }
 
-export function authenticatedJsonRequest(url: string, body: unknown, init: RequestInit = {}): Request {
+export function authenticatedJsonRequest(
+  url: string,
+  body: unknown,
+  init: RequestInit = {},
+): Request {
   const headers = new Headers(init.headers);
   if (!headers.has("Authorization")) {
     headers.set("Authorization", "Bearer test-token");
@@ -69,7 +84,10 @@ export function createFetchMock(
 ) {
   const calls: Array<{ url: string; method: string; body: string | null }> = [];
 
-  const fetchMock: FetchLike = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const fetchMock: FetchLike = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
     const req = new Request(input, init);
     let bodyText: string | null = null;
     try {
@@ -80,12 +98,11 @@ export function createFetchMock(
     calls.push({ url: req.url, method: req.method, body: bodyText });
 
     for (const route of routes) {
-      const match =
-        typeof route.matcher === "string"
-          ? req.url.includes(route.matcher)
-          : route.matcher instanceof RegExp
-          ? route.matcher.test(req.url)
-          : await Promise.resolve(route.matcher(req));
+      const match = typeof route.matcher === "string"
+        ? req.url.includes(route.matcher)
+        : route.matcher instanceof RegExp
+        ? route.matcher.test(req.url)
+        : await Promise.resolve(route.matcher(req));
       if (match) {
         return await route.handler(req);
       }
@@ -100,7 +117,10 @@ export function createFetchMock(
   return { fetchMock, calls };
 }
 
-export async function withMockedFetch<T>(fetchMock: FetchLike, fn: () => Promise<T>) {
+export async function withMockedFetch<T>(
+  fetchMock: FetchLike,
+  fn: () => Promise<T>,
+) {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = fetchMock as typeof fetch;
   try {
@@ -155,7 +175,44 @@ export async function withEnv<T>(
   }
 }
 
-export async function captureServeHandler(moduleUrl: string | URL): Promise<RequestHandler> {
+export async function importHandlerWithStubbedServe<T>(
+  moduleUrl: string | URL,
+): Promise<T> {
+  const serveOwner = Deno as unknown as {
+    serve: (...args: unknown[]) => Deno.HttpServer;
+  };
+
+  const originalSetInterval = globalThis.setInterval;
+  const originalClearInterval = globalThis.clearInterval;
+  globalThis.setInterval =
+    ((_callback: () => void) =>
+      0 as unknown as ReturnType<
+        typeof setInterval
+      >) as unknown as typeof setInterval;
+  globalThis.clearInterval =
+    ((_id?: ReturnType<typeof setInterval>) => {}) as typeof clearInterval;
+
+  const serveStub = stub(serveOwner, "serve", () => ({
+    shutdown() {},
+    finished: Promise.resolve(),
+  } as Deno.HttpServer));
+
+  try {
+    const specifier = typeof moduleUrl === "string"
+      ? moduleUrl
+      : moduleUrl.toString();
+    const mod = await import(`${specifier}?unit=${crypto.randomUUID()}`);
+    return mod.handler as T;
+  } finally {
+    serveStub.restore();
+    globalThis.setInterval = originalSetInterval;
+    globalThis.clearInterval = originalClearInterval;
+  }
+}
+
+export async function captureServeHandler(
+  moduleUrl: string | URL,
+): Promise<RequestHandler> {
   let captured: RequestHandler | undefined;
 
   resetCapturedHandler();
@@ -172,28 +229,33 @@ export async function captureServeHandler(moduleUrl: string | URL): Promise<Requ
   }) as unknown as typeof setInterval;
   globalThis.clearInterval = ((_id?: number) => {}) as typeof clearInterval;
 
-  const serveStub = stub(serveOwner, "serve", (arg1: unknown, arg2?: unknown) => {
-    const handler =
-      typeof arg1 === "function"
+  const serveStub = stub(
+    serveOwner,
+    "serve",
+    (arg1: unknown, arg2?: unknown) => {
+      const handler = typeof arg1 === "function"
         ? (arg1 as RequestHandler)
         : (arg1 as { handler?: RequestHandler })?.handler ??
           (typeof arg2 === "function" ? (arg2 as RequestHandler) : undefined);
 
-    if (!handler) {
-      throw new Error("No handler provided to Deno.serve");
-    }
-    if (!captured) {
-      captured = handler;
-    }
+      if (!handler) {
+        throw new Error("No handler provided to Deno.serve");
+      }
+      if (!captured) {
+        captured = handler;
+      }
 
-    return {
-      shutdown() {},
-      finished: Promise.resolve(),
-    } as Deno.HttpServer;
-  });
+      return {
+        shutdown() {},
+        finished: Promise.resolve(),
+      } as Deno.HttpServer;
+    },
+  );
 
   try {
-    const specifier = typeof moduleUrl === "string" ? moduleUrl : moduleUrl.toString();
+    const specifier = typeof moduleUrl === "string"
+      ? moduleUrl
+      : moduleUrl.toString();
     await import(`${specifier}?test=${crypto.randomUUID()}`);
   } finally {
     serveStub.restore();

--- a/supabase/functions/_test_utils/mock_http.ts
+++ b/supabase/functions/_test_utils/mock_http.ts
@@ -117,7 +117,7 @@ export async function withNoIntervals<T>(fn: () => Promise<T>) {
   globalThis.setInterval = ((callback: () => void) => {
     callback();
     return 0 as unknown as number;
-  }) as typeof setInterval;
+  }) as unknown as typeof setInterval;
   globalThis.clearInterval = ((_id?: number) => {}) as typeof clearInterval;
 
   try {
@@ -169,7 +169,7 @@ export async function captureServeHandler(moduleUrl: string | URL): Promise<Requ
   globalThis.setInterval = ((callback: () => void) => {
     callback();
     return 0 as unknown as number;
-  }) as typeof setInterval;
+  }) as unknown as typeof setInterval;
   globalThis.clearInterval = ((_id?: number) => {}) as typeof clearInterval;
 
   const serveStub = stub(serveOwner, "serve", (arg1: unknown, arg2?: unknown) => {

--- a/supabase/functions/apply-event/index_test.ts
+++ b/supabase/functions/apply-event/index_test.ts
@@ -4,6 +4,7 @@
 // a real HTTP server from being started (same pattern as payment-webhook/index_test.ts).
 
 import { assertEquals } from "jsr:@std/assert@1";
+import { stub } from "@std/testing/mock";
 import {
   buildApplication,
   buildEvent,
@@ -18,9 +19,11 @@ import {
 let _handler: Handler | null = null;
 async function getHandler(): Promise<Handler> {
   if (_handler) return _handler;
-  const denoAsAny = Deno as unknown as { serve: (...args: unknown[]) => Deno.HttpServer };
-  const origServe = denoAsAny.serve;
-  denoAsAny.serve = () => ({ shutdown() {}, finished: Promise.resolve() } as Deno.HttpServer);
+  const serveOwner = Deno as unknown as { serve: (...args: unknown[]) => Deno.HttpServer };
+  const serveStub = stub(serveOwner, "serve", () => ({
+    shutdown() {},
+    finished: Promise.resolve(),
+  } as Deno.HttpServer));
   const origSetInterval = globalThis.setInterval;
   const origClearInterval = globalThis.clearInterval;
   globalThis.setInterval = ((_cb: () => void) => 0 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
@@ -28,7 +31,7 @@ async function getHandler(): Promise<Handler> {
   try {
     _handler = (await import(`./index.ts?unit=${crypto.randomUUID()}`)).handler as Handler;
   } finally {
-    denoAsAny.serve = origServe;
+    serveStub.restore();
     globalThis.setInterval = origSetInterval;
     globalThis.clearInterval = origClearInterval;
   }

--- a/supabase/functions/apply-event/index_test.ts
+++ b/supabase/functions/apply-event/index_test.ts
@@ -3,38 +3,25 @@
 // Lazy-loads the handler via dynamic import with Deno.serve stubbed to prevent
 // a real HTTP server from being started (same pattern as payment-webhook/index_test.ts).
 
-import { assertEquals } from "jsr:@std/assert@1";
-import { stub } from "@std/testing/mock";
+import { assertEquals } from "@std/assert";
 import {
   buildApplication,
   buildEvent,
   buildTicket,
   fakeSupabase,
+  type Handler,
   makeCtx,
   readJson,
   runHandler,
-  type Handler,
 } from "../_shared/_testing/mod.ts";
+import { importHandlerWithStubbedServe } from "../_test_utils/mock_http.ts";
 
 let _handler: Handler | null = null;
 async function getHandler(): Promise<Handler> {
   if (_handler) return _handler;
-  const serveOwner = Deno as unknown as { serve: (...args: unknown[]) => Deno.HttpServer };
-  const serveStub = stub(serveOwner, "serve", () => ({
-    shutdown() {},
-    finished: Promise.resolve(),
-  } as Deno.HttpServer));
-  const origSetInterval = globalThis.setInterval;
-  const origClearInterval = globalThis.clearInterval;
-  globalThis.setInterval = ((_cb: () => void) => 0 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
-  globalThis.clearInterval = ((_id?: ReturnType<typeof setInterval>) => {}) as typeof clearInterval;
-  try {
-    _handler = (await import(`./index.ts?unit=${crypto.randomUUID()}`)).handler as Handler;
-  } finally {
-    serveStub.restore();
-    globalThis.setInterval = origSetInterval;
-    globalThis.clearInterval = origClearInterval;
-  }
+  _handler = await importHandlerWithStubbedServe<Handler>(
+    new URL("./index.ts", import.meta.url),
+  );
   return _handler!;
 }
 
@@ -128,7 +115,9 @@ Deno.test("apply-event :: ticket not found → 404", async () => {
   const handler = await getHandler();
   const sb = fakeSupabase()
     .on("events", "select", { data: buildEvent() })
-    .on("tickets", "select", { error: { message: "no rows", code: "PGRST116" } });
+    .on("tickets", "select", {
+      error: { message: "no rows", code: "PGRST116" },
+    });
   const res = await runHandler(handler, {
     body: BASE_BODY,
     ctx: makeCtx({ supabase: sb, userId: "u-1" }),
@@ -198,7 +187,11 @@ Deno.test("apply-event :: duplicate application (status=pending) → 409 ALREADY
     .on("events", "select", { data: buildEvent() })
     .on("tickets", "select", { data: buildTicket() })
     .on("event_applications", "select", {
-      data: buildApplication({ status: "pending", event_id: "ev-1", user_id: "u-1" }),
+      data: buildApplication({
+        status: "pending",
+        event_id: "ev-1",
+        user_id: "u-1",
+      }),
     });
   const res = await runHandler(handler, {
     body: BASE_BODY,
@@ -225,7 +218,9 @@ Deno.test("apply-event :: verification requirements not met → 403", async () =
     ctx: makeCtx({ supabase: sb, userId: "u-1" }),
   });
   assertEquals(res.status, 403);
-  const body = await readJson<{ error: string; details: { missing_verification_ids: string[] } }>(res);
+  const body = await readJson<
+    { error: string; details: { missing_verification_ids: string[] } }
+  >(res);
   assertEquals(body.error, "Eligibility requirements not met");
   assertEquals(body.details.missing_verification_ids, ["verif-A"]);
 });
@@ -305,7 +300,12 @@ Deno.test("apply-event :: free ticket, cancelled re-application → 200 + update
     .on("events", "select", { data: buildEvent() })
     .on("tickets", "select", { data: buildTicket({ price: 0 }) })
     .on("event_applications", "select", {
-      data: buildApplication({ id: "app-old", status: "cancelled", event_id: "ev-1", user_id: "u-1" }),
+      data: buildApplication({
+        id: "app-old",
+        status: "cancelled",
+        event_id: "ev-1",
+        user_id: "u-1",
+      }),
     })
     .on("check_party_balance", "rpc", { data: { allowed: true, reason: null } })
     .on("event_applications", "update", { error: null });

--- a/supabase/functions/architecture.md
+++ b/supabase/functions/architecture.md
@@ -1,0 +1,68 @@
+# Edge Function Architecture
+
+Edge Functions use one wrapper, thin HTTP handlers, typed inputs, service
+orchestration, pure domain policy, and Postgres RPC for atomic writes.
+
+## Standard Layers
+
+```text
+<ef-name>/
+  BLUEDOC.md        # only when the EF has local structure worth mapping
+  index.ts          # HTTP/auth/input/response only
+  input.ts          # request body validation and typed DTOs
+  service.ts        # use-case orchestration, DB/RPC/external IO
+  service_test.ts   # fakeSupabase/service-level behavior
+  index_test.ts     # auth, invalid input, response mapping
+  deno.json
+
+_shared/domains/<domain>/
+  BLUEDOC.md
+  *.ts              # pure business rules only
+  *_test.ts         # dense policy tests, no mocks
+```
+
+Action-router EFs may use `_handlers/` and `_lib/` when one public EF exposes
+multiple actions. Small EFs may stay as `index.ts` only.
+
+## Responsibilities
+
+`index.ts` owns HTTP concerns: `minglitEdgeFunction`, caller type checks,
+`parseJsonBody`, input validation, service invocation, and response mapping.
+
+`input.ts` owns request shape. It should reject invalid field types before DB
+queries. Missing-field error strings remain stable for clients and tests.
+
+`service.ts` owns orchestration: Supabase queries, RPC calls, external clients,
+logging, Statsig, Sentry breadcrumbs, and use-case result mapping. It should be
+small enough that each business branch is visible without reading HTTP code.
+
+`_shared/domains/*` owns pure policy. No DB, HTTP, env, logger, timers, random
+IDs, or `Date.now()`. Pass `now`, raw policy, or loaded records as arguments.
+
+Postgres RPC owns atomic writes for inventory, application/order creation,
+payment verification, approval, refund, settlement, and other state transitions
+that must not partially succeed.
+
+## Extraction Signals
+
+- Two or more request fields with validation rules: add `input.ts`.
+- Two or more DB/RPC steps: add `service.ts`.
+- A business rule needs many cases or is reused: add `_shared/domains/<domain>`.
+- Three or more actions in one EF: use `_handlers/`.
+- A write path updates more than one consistency boundary: move it into RPC.
+
+## Test Strategy
+
+Domain policy tests are the primary business-rule guard. They should be fast,
+mock-free, and exhaustive over boundary cases.
+
+Service tests verify orchestration with fake Supabase: query/RPC branches,
+fail-open/fail-closed policy, update errors, and event emission behavior.
+
+Handler tests stay thin: auth errors, invalid JSON, invalid input, and response
+mapping. Integration/CUJ tests prove schema/RLS/RPC wiring and key happy paths,
+not every business-rule combination.
+
+---
+
+_Reviewed: 2026-05-24 00:00_

--- a/supabase/functions/notification-worker/notification_worker_test.ts
+++ b/supabase/functions/notification-worker/notification_worker_test.ts
@@ -93,9 +93,9 @@ Deno.test({
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const stubs = [
-    stub(WorkerUtils.prototype, "isProcessed", async () => false),
-    stub(WorkerUtils.prototype, "markProcessed", async () => {}),
-    stub(WorkerUtils.prototype, "moveToDLQ", async () => {}),
+    stub(WorkerUtils.prototype, "isProcessed", () => Promise.resolve(false)),
+    stub(WorkerUtils.prototype, "markProcessed", () => Promise.resolve()),
+    stub(WorkerUtils.prototype, "moveToDLQ", () => Promise.resolve()),
     stub(WorkerUtils.prototype, "logTimeLag", () => {}),
   ];
 
@@ -161,9 +161,9 @@ Deno.test({
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const stubs = [
-    stub(WorkerUtils.prototype, "isProcessed", async () => false),
-    stub(WorkerUtils.prototype, "markProcessed", async () => {}),
-    stub(WorkerUtils.prototype, "moveToDLQ", async () => {}),
+    stub(WorkerUtils.prototype, "isProcessed", () => Promise.resolve(false)),
+    stub(WorkerUtils.prototype, "markProcessed", () => Promise.resolve()),
+    stub(WorkerUtils.prototype, "moveToDLQ", () => Promise.resolve()),
     stub(WorkerUtils.prototype, "logTimeLag", () => {}),
   ];
 
@@ -359,9 +359,9 @@ Deno.test({
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const stubs = [
-    stub(WorkerUtils.prototype, "isProcessed", async () => false),
-    stub(WorkerUtils.prototype, "markProcessed", async () => {}),
-    stub(WorkerUtils.prototype, "moveToDLQ", async () => {}),
+    stub(WorkerUtils.prototype, "isProcessed", () => Promise.resolve(false)),
+    stub(WorkerUtils.prototype, "markProcessed", () => Promise.resolve()),
+    stub(WorkerUtils.prototype, "moveToDLQ", () => Promise.resolve()),
     stub(WorkerUtils.prototype, "logTimeLag", () => {}),
   ];
 
@@ -416,9 +416,9 @@ Deno.test({
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const stubs = [
-    stub(WorkerUtils.prototype, "isProcessed", async () => false),
-    stub(WorkerUtils.prototype, "markProcessed", async () => {}),
-    stub(WorkerUtils.prototype, "moveToDLQ", async () => {}),
+    stub(WorkerUtils.prototype, "isProcessed", () => Promise.resolve(false)),
+    stub(WorkerUtils.prototype, "markProcessed", () => Promise.resolve()),
+    stub(WorkerUtils.prototype, "moveToDLQ", () => Promise.resolve()),
     stub(WorkerUtils.prototype, "logTimeLag", () => {}),
   ];
 
@@ -450,7 +450,9 @@ Deno.test({
       async () => {
         await withMockedFetch(fetchMock, async () => {
           await withNoIntervals(async () => {
-            await handler(new Request("http://localhost", { headers: { "Authorization": "Bearer service-key" } }));
+            await withFastTimers(async () => {
+              await handler(new Request("http://localhost", { headers: { "Authorization": "Bearer service-key" } }));
+            });
           });
         });
       },
@@ -473,9 +475,9 @@ Deno.test({
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const stubs = [
-    stub(WorkerUtils.prototype, "isProcessed", async () => false),
-    stub(WorkerUtils.prototype, "markProcessed", async () => {}),
-    stub(WorkerUtils.prototype, "moveToDLQ", async () => {}),
+    stub(WorkerUtils.prototype, "isProcessed", () => Promise.resolve(false)),
+    stub(WorkerUtils.prototype, "markProcessed", () => Promise.resolve()),
+    stub(WorkerUtils.prototype, "moveToDLQ", () => Promise.resolve()),
     stub(WorkerUtils.prototype, "logTimeLag", () => {}),
   ];
 
@@ -553,9 +555,9 @@ Deno.test({
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const stubs = [
-    stub(WorkerUtils.prototype, "isProcessed", async () => false),
-    stub(WorkerUtils.prototype, "markProcessed", async () => {}),
-    stub(WorkerUtils.prototype, "moveToDLQ", async () => {}),
+    stub(WorkerUtils.prototype, "isProcessed", () => Promise.resolve(false)),
+    stub(WorkerUtils.prototype, "markProcessed", () => Promise.resolve()),
+    stub(WorkerUtils.prototype, "moveToDLQ", () => Promise.resolve()),
     stub(WorkerUtils.prototype, "logTimeLag", () => {}),
   ];
 
@@ -613,9 +615,9 @@ Deno.test({
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const stubs = [
-    stub(WorkerUtils.prototype, "isProcessed", async () => false),
-    stub(WorkerUtils.prototype, "markProcessed", async () => {}),
-    stub(WorkerUtils.prototype, "moveToDLQ", async () => {}),
+    stub(WorkerUtils.prototype, "isProcessed", () => Promise.resolve(false)),
+    stub(WorkerUtils.prototype, "markProcessed", () => Promise.resolve()),
+    stub(WorkerUtils.prototype, "moveToDLQ", () => Promise.resolve()),
     stub(WorkerUtils.prototype, "logTimeLag", () => {}),
   ];
 
@@ -646,7 +648,9 @@ Deno.test({
       async () => {
         await withMockedFetch(fetchMock, async () => {
           await withNoIntervals(async () => {
-            await handler(new Request("http://localhost", { headers: { "Authorization": "Bearer service-key" } }));
+            await withFastTimers(async () => {
+              await handler(new Request("http://localhost", { headers: { "Authorization": "Bearer service-key" } }));
+            });
           });
         });
       },
@@ -669,9 +673,9 @@ Deno.test({
   const handler = await captureServeHandler(new URL("./index.ts", import.meta.url));
 
   const stubs = [
-    stub(WorkerUtils.prototype, "isProcessed", async () => false),
-    stub(WorkerUtils.prototype, "markProcessed", async () => {}),
-    stub(WorkerUtils.prototype, "moveToDLQ", async () => {}),
+    stub(WorkerUtils.prototype, "isProcessed", () => Promise.resolve(false)),
+    stub(WorkerUtils.prototype, "markProcessed", () => Promise.resolve()),
+    stub(WorkerUtils.prototype, "moveToDLQ", () => Promise.resolve()),
     stub(WorkerUtils.prototype, "logTimeLag", () => {}),
   ];
 

--- a/supabase/functions/notification-worker/notification_worker_test.ts
+++ b/supabase/functions/notification-worker/notification_worker_test.ts
@@ -29,7 +29,7 @@ async function withNightTimers(fn: () => Promise<void>) {
   globalThis.setTimeout = ((callback: () => void) => {
     callback();
     return 0;
-  }) as typeof setTimeout;
+  }) as unknown as typeof setTimeout;
 
   try {
     await fn();
@@ -55,7 +55,7 @@ async function withDayTimers(fn: () => Promise<void>) {
   globalThis.setTimeout = ((callback: () => void) => {
     callback();
     return 0;
-  }) as typeof setTimeout;
+  }) as unknown as typeof setTimeout;
 
   try {
     await fn();
@@ -77,7 +77,7 @@ async function withFastTimers(fn: () => Promise<void>) {
   globalThis.setTimeout = ((callback: () => void) => {
     callback();
     return 0;
-  }) as typeof setTimeout;
+  }) as unknown as typeof setTimeout;
 
   try {
     await fn();

--- a/supabase/functions/partner-approve-application/BLUEDOC.md
+++ b/supabase/functions/partner-approve-application/BLUEDOC.md
@@ -1,0 +1,30 @@
+# partner-approve-application
+
+파트너가 이벤트 신청을 단건/일괄 승인하는 EF. capacity 정합성은 DB RPC guard 로
+보장한다.
+
+## 이정표
+
+| 파일                                                                       | 역할                                                                 |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| [index.ts](index.ts)                                                       | method/auth/action parse, service 호출, HTTP response mapping        |
+| [input.ts](input.ts)                                                       | approve/bulk_approve action body validation                          |
+| [approve_application_service.ts](approve_application_service.ts)           | permission check, application/event 조회, approval RPC orchestration |
+| [index_test.ts](index_test.ts)                                             | L3 handler unit test (`fakeSupabase`)                                |
+| [partner_approve_application_test.ts](partner_approve_application_test.ts) | HTTP wrapper/integration-style test                                  |
+
+## 핵심 컨벤션
+
+- 승인 가능 status / RPC 결과 mapping 은
+  `_shared/domains/event/application_approval_policy.ts`.
+- 권한 확인은 application 상태 검증보다 먼저 실행해 state leak 을 줄인다.
+- capacity 초과/동시성은 `*_with_capacity_guard` Postgres RPC 에 맡긴다.
+
+## 관련
+
+- [../architecture.md](../architecture.md)
+- [../_shared/domains/event/BLUEDOC.md](../_shared/domains/event/BLUEDOC.md)
+
+---
+
+_Reviewed: 2026-05-24 00:00_

--- a/supabase/functions/partner-approve-application/approve_application_service.ts
+++ b/supabase/functions/partner-approve-application/approve_application_service.ts
@@ -1,0 +1,140 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
+import {
+  isApplicationApprovableForPartnerApproval,
+  mapBulkApprovalRpcResult,
+  mapSingleApprovalRpcResult,
+} from "../_shared/domains/event/application_approval_policy.ts";
+import type { PartnerApproveInput } from "./input.ts";
+
+export type PartnerApproveServiceResult =
+  | { ok: true; type: "approve"; approved: 1; applicationId: string }
+  | {
+    ok: true;
+    type: "bulk_approve";
+    approved: number;
+    eventId: string;
+    skippedDueToCapacity: number;
+    remainingSlotsBeforeApproval: number;
+  }
+  | { ok: false; status: number; message: string; details?: unknown };
+
+export function approveApplication(args: {
+  supabase: SupabaseClient;
+  input: PartnerApproveInput;
+  userId: string;
+}): Promise<PartnerApproveServiceResult | Response> {
+  if (args.input.action === "approve") {
+    return approveSingle(args.supabase, args.input.applicationId, args.userId);
+  }
+  return approveBulk(args.supabase, args.input.eventId, args.userId);
+}
+
+async function approveSingle(
+  supabase: SupabaseClient,
+  applicationId: string,
+  userId: string,
+): Promise<PartnerApproveServiceResult | Response> {
+  const { data: app, error: fetchError } = await supabase
+    .from("event_applications")
+    .select(
+      "id, status, event_id, events!inner(party_id, parties!inner(partner_id))",
+    )
+    .eq("id", applicationId)
+    .maybeSingle();
+
+  if (fetchError) return fail(500, "Failed to load application");
+  if (!app) return fail(404, "Application not found");
+
+  const partnerId = extractApplicationPartnerId(app as Record<string, unknown>);
+  const permCheck = await requirePartnerPermission(
+    supabase,
+    partnerId,
+    userId,
+    [
+      "EVENT_MANAGE",
+      "APPLICATION_MANAGE",
+    ],
+  );
+  if (permCheck) return permCheck;
+
+  const status = String((app as { status?: unknown }).status);
+  if (!isApplicationApprovableForPartnerApproval(status)) {
+    return fail(400, `Cannot approve application with status '${status}'`);
+  }
+
+  const { data: approvalResult, error: approvalError } = await supabase
+    .rpc("approve_event_application_with_capacity_guard", {
+      p_application_id: applicationId,
+    });
+
+  if (approvalError) return fail(500, "Failed to approve application");
+
+  const mapped = mapSingleApprovalRpcResult(approvalResult);
+  if (!mapped.ok) return fail(mapped.status, mapped.message, mapped.details);
+  return { ok: true, type: "approve", approved: 1, applicationId };
+}
+
+async function approveBulk(
+  supabase: SupabaseClient,
+  eventId: string,
+  userId: string,
+): Promise<PartnerApproveServiceResult | Response> {
+  const { data: event, error: eventError } = await supabase
+    .from("events")
+    .select("id, party_id, parties!inner(partner_id)")
+    .eq("id", eventId)
+    .maybeSingle();
+
+  if (eventError) return fail(500, "Failed to load event");
+  if (!event) return fail(404, "Event not found");
+
+  const partnerId = extractEventPartnerId(event as Record<string, unknown>);
+  const permCheck = await requirePartnerPermission(
+    supabase,
+    partnerId,
+    userId,
+    [
+      "EVENT_MANAGE",
+      "APPLICATION_MANAGE",
+    ],
+  );
+  if (permCheck) return permCheck;
+
+  const { data: bulkApprovalResult, error: bulkApprovalError } = await supabase
+    .rpc("bulk_approve_event_applications_with_capacity_guard", {
+      p_event_id: eventId,
+    });
+
+  if (bulkApprovalError) return fail(500, "Failed to bulk approve");
+
+  const mapped = mapBulkApprovalRpcResult(bulkApprovalResult);
+  if (!mapped.ok) return fail(mapped.status, mapped.message, mapped.details);
+  return {
+    ok: true,
+    type: "bulk_approve",
+    approved: mapped.approved,
+    eventId,
+    skippedDueToCapacity: mapped.skippedDueToCapacity,
+    remainingSlotsBeforeApproval: mapped.remainingSlotsBeforeApproval,
+  };
+}
+
+function extractApplicationPartnerId(app: Record<string, unknown>): string {
+  const event = app.events as Record<string, unknown>;
+  return extractEventPartnerId(event);
+}
+
+function extractEventPartnerId(event: Record<string, unknown>): string {
+  const party = event.parties as Record<string, unknown>;
+  return party.partner_id as string;
+}
+
+function fail(
+  status: number,
+  message: string,
+  details?: unknown,
+): Extract<PartnerApproveServiceResult, { ok: false }> {
+  if (details === undefined) return { ok: false, status, message };
+  return { ok: false, status, message, details };
+}

--- a/supabase/functions/partner-approve-application/index.ts
+++ b/supabase/functions/partner-approve-application/index.ts
@@ -1,195 +1,55 @@
 // partner-approve-application — Approve event applications (single + bulk)
 // Issue #517: 파트너 대시보드 리디자인 — 신청 승인 API
 
-import type { SupabaseClient } from "@supabase/supabase-js";
-import {
-  errorResponse,
-  successResponse,
-} from "../_shared/response_utils.ts";
-import { requirePartnerPermission } from "../_shared/partner_permissions.ts";
+import { errorResponse, successResponse } from "../_shared/response_utils.ts";
 import { parseAction } from "../_shared/request_utils.ts";
-import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
+import {
+  type EFContext,
+  minglitEdgeFunction,
+} from "../_shared/edge_function.ts";
+import { approveApplication } from "./approve_application_service.ts";
+import { parsePartnerApproveInput } from "./input.ts";
 
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-// Fix #1219: keep approval status filtering aligned with the capacity guard paths.
-const APPROVABLE_STATUSES = ["pending", "pending_review"] as const;
-
-export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
+export const handler = async (
+  req: Request,
+  ctx: EFContext,
+): Promise<Response> => {
   if (req.method !== "POST") return errorResponse("Method not allowed", 405);
-
-  const { supabase } = ctx;
-  if (ctx.auth.type !== "user") return errorResponse("Unexpected auth type", 500);
-  const userId = ctx.auth.userId;
-
-  const result = await parseAction(req);
-  if (result instanceof Response) return result;
-  const { action, body } = result;
-
-  // ─── approve (single) ───
-  if (action === "approve") {
-    return handleApprove(supabase, body, userId);
+  if (ctx.auth.type !== "user") {
+    return errorResponse("Unexpected auth type", 500);
   }
 
-  // ─── bulk_approve ───
-  if (action === "bulk_approve") {
-    return handleBulkApprove(supabase, body, userId);
-  }
+  const parsed = await parseAction(req);
+  if (parsed instanceof Response) return parsed;
 
-  return errorResponse(`Unknown action: ${action}`, 400);
-};
+  const input = parsePartnerApproveInput(parsed.action, parsed.body);
+  if (input instanceof Response) return input;
 
-// ── Single approve ──
-async function handleApprove(
-  supabase: SupabaseClient,
-  body: Record<string, unknown>,
-  userId: string,
-): Promise<Response> {
-  const applicationId = body.application_id;
-  if (typeof applicationId !== "string" || !applicationId) {
-    return errorResponse("Missing application_id", 400);
-  }
-  if (!UUID_RE.test(applicationId)) {
-    return errorResponse("Invalid application_id", 400);
-  }
-
-  // Fix #1219: load event capacity with the application so single approval can reject full events.
-  const { data: app, error: fetchError } = await supabase
-    .from("event_applications")
-    .select(
-      "id, status, event_id, events!inner(party_id, parties!inner(partner_id))",
-    )
-    .eq("id", applicationId)
-    .maybeSingle();
-
-  if (fetchError) return errorResponse("Failed to load application", 500);
-  if (!app) return errorResponse("Application not found", 404);
-
-  // Check partner permission first to avoid leaking application state
-  const event = app.events as Record<string, unknown>;
-  const party = event.parties as Record<string, unknown>;
-  const partnerId = party.partner_id as string;
-
-  const permCheck = await requirePartnerPermission(supabase, partnerId, userId, ["EVENT_MANAGE", "APPLICATION_MANAGE"]);
-  if (permCheck) return permCheck;
-
-  // Verify status is approvable (after permission check)
-  if (
-    !APPROVABLE_STATUSES.includes(
-      app.status as typeof APPROVABLE_STATUSES[number],
-    )
-  ) {
-    return errorResponse(
-      `Cannot approve application with status '${app.status}'`,
-      400,
-    );
-  }
-
-  // Fix #1219: route single approval through the DB capacity guard so the status flip is serialized per event.
-  const { data: approvalResult, error: approvalError } = await supabase
-    .rpc("approve_event_application_with_capacity_guard", {
-      p_application_id: applicationId,
-    });
-
-  if (approvalError) return errorResponse("Failed to approve application", 500);
-
-  const result = Array.isArray(approvalResult)
-    ? approvalResult[0]
-    : approvalResult;
-  const resultStatus = result?.result_status as string | undefined;
-
-  if (resultStatus === "approved") {
-    return successResponse({ approved: 1, application_id: applicationId });
-  }
-
-  if (resultStatus === "event_full") {
-    return errorResponse("정원이 초과되었습니다.", 409, { code: "EVENT_FULL" });
-  }
-
-  if (resultStatus === "already_processed") {
-    return errorResponse("Application already processed", 409);
-  }
-
-  if (resultStatus === "not_found") {
-    return errorResponse("Application not found", 404);
-  }
-
-  return errorResponse("Event capacity data is invalid", 500, {
-    code: "INVALID_EVENT_CAPACITY",
+  const result = await approveApplication({
+    supabase: ctx.supabase,
+    input,
+    userId: ctx.auth.userId,
   });
-}
 
-// ── Bulk approve ──
-async function handleBulkApprove(
-  supabase: SupabaseClient,
-  body: Record<string, unknown>,
-  userId: string,
-): Promise<Response> {
-  const eventId = body.event_id;
-  if (typeof eventId !== "string" || !eventId) {
-    return errorResponse("Missing event_id", 400);
-  }
-  if (!UUID_RE.test(eventId)) {
-    return errorResponse("Invalid event_id", 400);
+  if (result instanceof Response) return result;
+
+  if (!result.ok) {
+    return errorResponse(result.message, result.status, result.details);
   }
 
-  // Fix #1219: load event capacity so bulk approval can cap approvals at remaining slots.
-  const { data: event, error: eventError } = await supabase
-    .from("events")
-    .select("id, party_id, parties!inner(partner_id)")
-    .eq("id", eventId)
-    .maybeSingle();
-
-  if (eventError) return errorResponse("Failed to load event", 500);
-  if (!event) return errorResponse("Event not found", 404);
-
-  const party = event.parties as Record<string, unknown>;
-  const partnerId = party.partner_id as string;
-
-  const permCheck = await requirePartnerPermission(supabase, partnerId, userId, ["EVENT_MANAGE", "APPLICATION_MANAGE"]);
-  if (permCheck) return permCheck;
-
-  // Fix #1219: route bulk approval through the DB capacity guard so oldest rows are approved under one event lock.
-  const { data: bulkApprovalResult, error: bulkApprovalError } = await supabase
-    .rpc("bulk_approve_event_applications_with_capacity_guard", {
-      p_event_id: eventId,
-    });
-
-  if (bulkApprovalError) return errorResponse("Failed to bulk approve", 500);
-
-  const result = Array.isArray(bulkApprovalResult)
-    ? bulkApprovalResult[0]
-    : bulkApprovalResult;
-  const resultStatus = result?.result_status as string | undefined;
-
-  if (resultStatus === "invalid_capacity") {
-    return errorResponse("Event capacity data is invalid", 500, {
-      code: "INVALID_EVENT_CAPACITY",
+  if (result.type === "approve") {
+    return successResponse({
+      approved: result.approved,
+      application_id: result.applicationId,
     });
   }
-
-  if (resultStatus === "not_found") {
-    return errorResponse("Event not found", 404);
-  }
-
-  const approvedCount = typeof result?.approved_count === "number"
-    ? result.approved_count
-    : 0;
-  const skippedDueToCapacity =
-    typeof result?.skipped_due_to_capacity === "number"
-      ? result.skipped_due_to_capacity
-      : 0;
-  const remainingSlotsBeforeApproval =
-    typeof result?.remaining_slots_before_approval === "number"
-      ? result.remaining_slots_before_approval
-      : 0;
 
   return successResponse({
-    approved: approvedCount,
-    event_id: eventId,
-    skipped_due_to_capacity: skippedDueToCapacity,
-    remaining_slots_before_approval: remainingSlotsBeforeApproval,
+    approved: result.approved,
+    event_id: result.eventId,
+    skipped_due_to_capacity: result.skippedDueToCapacity,
+    remaining_slots_before_approval: result.remainingSlotsBeforeApproval,
   });
-}
+};
 
 minglitEdgeFunction(handler);

--- a/supabase/functions/partner-approve-application/index_test.ts
+++ b/supabase/functions/partner-approve-application/index_test.ts
@@ -4,7 +4,6 @@
 // a real HTTP server from being started (same pattern as payment-webhook/index_test.ts).
 
 import { assertEquals } from "@std/assert";
-import { stub } from "@std/testing/mock";
 import {
   buildApplication,
   fakeSupabase,
@@ -13,32 +12,14 @@ import {
   readJson,
   runHandler,
 } from "../_shared/_testing/mod.ts";
+import { importHandlerWithStubbedServe } from "../_test_utils/mock_http.ts";
 
 let _handler: Handler | null = null;
 async function getHandler(): Promise<Handler> {
   if (_handler) return _handler;
-  const serveOwner = Deno as unknown as {
-    serve: (...args: unknown[]) => Deno.HttpServer;
-  };
-  const serveStub = stub(serveOwner, "serve", () => ({
-    shutdown() {},
-    finished: Promise.resolve(),
-  } as Deno.HttpServer));
-  const origSetInterval = globalThis.setInterval;
-  const origClearInterval = globalThis.clearInterval;
-  globalThis.setInterval =
-    ((_cb: () => void) =>
-      0 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
-  globalThis.clearInterval =
-    ((_id?: ReturnType<typeof setInterval>) => {}) as typeof clearInterval;
-  try {
-    _handler = (await import(`./index.ts?unit=${crypto.randomUUID()}`))
-      .handler as Handler;
-  } finally {
-    serveStub.restore();
-    globalThis.setInterval = origSetInterval;
-    globalThis.clearInterval = origClearInterval;
-  }
+  _handler = await importHandlerWithStubbedServe<Handler>(
+    new URL("./index.ts", import.meta.url),
+  );
   return _handler!;
 }
 

--- a/supabase/functions/partner-approve-application/index_test.ts
+++ b/supabase/functions/partner-approve-application/index_test.ts
@@ -3,28 +3,35 @@
 // Lazy-loads the handler via dynamic import with Deno.serve stubbed to prevent
 // a real HTTP server from being started (same pattern as payment-webhook/index_test.ts).
 
-import { assertEquals } from "jsr:@std/assert@1";
+import { assertEquals } from "@std/assert";
 import {
   buildApplication,
   fakeSupabase,
+  type Handler,
   makeCtx,
   readJson,
   runHandler,
-  type Handler,
 } from "../_shared/_testing/mod.ts";
 
 let _handler: Handler | null = null;
 async function getHandler(): Promise<Handler> {
   if (_handler) return _handler;
-  const denoAsAny = Deno as unknown as { serve: (...args: unknown[]) => Deno.HttpServer };
+  const denoAsAny = Deno as unknown as {
+    serve: (...args: unknown[]) => Deno.HttpServer;
+  };
   const origServe = denoAsAny.serve;
-  denoAsAny.serve = () => ({ shutdown() {}, finished: Promise.resolve() } as Deno.HttpServer);
+  denoAsAny.serve =
+    () => ({ shutdown() {}, finished: Promise.resolve() } as Deno.HttpServer);
   const origSetInterval = globalThis.setInterval;
   const origClearInterval = globalThis.clearInterval;
-  globalThis.setInterval = ((_cb: () => void) => 0 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
-  globalThis.clearInterval = ((_id?: ReturnType<typeof setInterval>) => {}) as typeof clearInterval;
+  globalThis.setInterval =
+    ((_cb: () => void) =>
+      0 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
+  globalThis.clearInterval =
+    ((_id?: ReturnType<typeof setInterval>) => {}) as typeof clearInterval;
   try {
-    _handler = (await import(`./index.ts?unit=${crypto.randomUUID()}`)).handler as Handler;
+    _handler = (await import(`./index.ts?unit=${crypto.randomUUID()}`))
+      .handler as Handler;
   } finally {
     denoAsAny.serve = origServe;
     globalThis.setInterval = origSetInterval;
@@ -42,7 +49,11 @@ const PARTNER_ID = "p1b2c3d4-e5f6-1234-89ab-000000000003";
 /** application row with nested events+parties join (as handler expects). */
 function buildAppRow(overrides: { status?: string } = {}) {
   return {
-    ...buildApplication({ id: VALID_APP_ID, event_id: VALID_EVENT_ID, status: overrides.status ?? "pending_review" }),
+    ...buildApplication({
+      id: VALID_APP_ID,
+      event_id: VALID_EVENT_ID,
+      status: overrides.status ?? "pending_review",
+    }),
     events: {
       party_id: "party-1",
       parties: { partner_id: PARTNER_ID },
@@ -150,7 +161,9 @@ Deno.test("partner-approve-application :: approve :: partner permission denied (
 Deno.test("partner-approve-application :: approve :: non-approvable status (cancelled) → 400", async () => {
   const handler = await getHandler();
   const sb = fakeSupabase()
-    .on("event_applications", "select", { data: buildAppRow({ status: "cancelled" }) })
+    .on("event_applications", "select", {
+      data: buildAppRow({ status: "cancelled" }),
+    })
     .on("partner_member_permissions", "select", {
       data: { role: "owner", permissions: [] },
     });
@@ -160,7 +173,10 @@ Deno.test("partner-approve-application :: approve :: non-approvable status (canc
   });
   assertEquals(res.status, 400);
   const body = await readJson<{ error: string }>(res);
-  assertEquals(body.error.startsWith("Cannot approve application with status"), true);
+  assertEquals(
+    body.error.startsWith("Cannot approve application with status"),
+    true,
+  );
 });
 
 Deno.test("partner-approve-application :: approve :: event_full → 409 EVENT_FULL", async () => {
@@ -208,7 +224,9 @@ Deno.test("partner-approve-application :: approve :: happy path → 200 + approv
     ctx: makeCtx({ supabase: sb, userId: "u-1" }),
   });
   assertEquals(res.status, 200);
-  const body = await readJson<{ approved: number; application_id: string }>(res);
+  const body = await readJson<{ approved: number; application_id: string }>(
+    res,
+  );
   assertEquals(body.approved, 1);
   assertEquals(body.application_id, VALID_APP_ID);
 });
@@ -243,11 +261,20 @@ Deno.test("partner-approve-application :: bulk_approve :: happy path → 200 + a
   const handler = await getHandler();
   const sb = fakeSupabase()
     .on("events", "select", {
-      data: { id: VALID_EVENT_ID, party_id: "party-1", parties: { partner_id: PARTNER_ID } },
+      data: {
+        id: VALID_EVENT_ID,
+        party_id: "party-1",
+        parties: { partner_id: PARTNER_ID },
+      },
     });
   ownerPermScript(sb);
   sb.on("bulk_approve_event_applications_with_capacity_guard", "rpc", {
-    data: [{ result_status: "ok", approved_count: 5, skipped_due_to_capacity: 2, remaining_slots_before_approval: 7 }],
+    data: [{
+      result_status: "ok",
+      approved_count: 5,
+      skipped_due_to_capacity: 2,
+      remaining_slots_before_approval: 7,
+    }],
   });
   const res = await runHandler(handler, {
     body: { action: "bulk_approve", event_id: VALID_EVENT_ID },

--- a/supabase/functions/partner-approve-application/index_test.ts
+++ b/supabase/functions/partner-approve-application/index_test.ts
@@ -4,6 +4,7 @@
 // a real HTTP server from being started (same pattern as payment-webhook/index_test.ts).
 
 import { assertEquals } from "@std/assert";
+import { stub } from "@std/testing/mock";
 import {
   buildApplication,
   fakeSupabase,
@@ -16,12 +17,13 @@ import {
 let _handler: Handler | null = null;
 async function getHandler(): Promise<Handler> {
   if (_handler) return _handler;
-  const denoAsAny = Deno as unknown as {
+  const serveOwner = Deno as unknown as {
     serve: (...args: unknown[]) => Deno.HttpServer;
   };
-  const origServe = denoAsAny.serve;
-  denoAsAny.serve =
-    () => ({ shutdown() {}, finished: Promise.resolve() } as Deno.HttpServer);
+  const serveStub = stub(serveOwner, "serve", () => ({
+    shutdown() {},
+    finished: Promise.resolve(),
+  } as Deno.HttpServer));
   const origSetInterval = globalThis.setInterval;
   const origClearInterval = globalThis.clearInterval;
   globalThis.setInterval =
@@ -33,7 +35,7 @@ async function getHandler(): Promise<Handler> {
     _handler = (await import(`./index.ts?unit=${crypto.randomUUID()}`))
       .handler as Handler;
   } finally {
-    denoAsAny.serve = origServe;
+    serveStub.restore();
     globalThis.setInterval = origSetInterval;
     globalThis.clearInterval = origClearInterval;
   }

--- a/supabase/functions/partner-approve-application/input.ts
+++ b/supabase/functions/partner-approve-application/input.ts
@@ -1,0 +1,37 @@
+import { errorResponse } from "../_shared/response_utils.ts";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export type PartnerApproveInput =
+  | { action: "approve"; applicationId: string }
+  | { action: "bulk_approve"; eventId: string };
+
+export function parsePartnerApproveInput(
+  action: string,
+  body: Record<string, unknown>,
+): PartnerApproveInput | Response {
+  if (action === "approve") {
+    const applicationId = body.application_id;
+    if (typeof applicationId !== "string" || !applicationId) {
+      return errorResponse("Missing application_id", 400);
+    }
+    if (!UUID_RE.test(applicationId)) {
+      return errorResponse("Invalid application_id", 400);
+    }
+    return { action, applicationId };
+  }
+
+  if (action === "bulk_approve") {
+    const eventId = body.event_id;
+    if (typeof eventId !== "string" || !eventId) {
+      return errorResponse("Missing event_id", 400);
+    }
+    if (!UUID_RE.test(eventId)) {
+      return errorResponse("Invalid event_id", 400);
+    }
+    return { action, eventId };
+  }
+
+  return errorResponse(`Unknown action: ${action}`, 400);
+}

--- a/supabase/functions/partner-reject-application/index_test.ts
+++ b/supabase/functions/partner-reject-application/index_test.ts
@@ -4,6 +4,7 @@
 // a real HTTP server from being started (same pattern as payment-webhook/index_test.ts).
 
 import { assertEquals } from "jsr:@std/assert@1";
+import { stub } from "@std/testing/mock";
 import {
   buildApplication,
   fakeSupabase,
@@ -16,9 +17,11 @@ import {
 let _handler: Handler | null = null;
 async function getHandler(): Promise<Handler> {
   if (_handler) return _handler;
-  const denoAsAny = Deno as unknown as { serve: (...args: unknown[]) => Deno.HttpServer };
-  const origServe = denoAsAny.serve;
-  denoAsAny.serve = () => ({ shutdown() {}, finished: Promise.resolve() } as Deno.HttpServer);
+  const serveOwner = Deno as unknown as { serve: (...args: unknown[]) => Deno.HttpServer };
+  const serveStub = stub(serveOwner, "serve", () => ({
+    shutdown() {},
+    finished: Promise.resolve(),
+  } as Deno.HttpServer));
   const origSetInterval = globalThis.setInterval;
   const origClearInterval = globalThis.clearInterval;
   globalThis.setInterval = ((_cb: () => void) => 0 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
@@ -26,7 +29,7 @@ async function getHandler(): Promise<Handler> {
   try {
     _handler = (await import(`./index.ts?unit=${crypto.randomUUID()}`)).handler as Handler;
   } finally {
-    denoAsAny.serve = origServe;
+    serveStub.restore();
     globalThis.setInterval = origSetInterval;
     globalThis.clearInterval = origClearInterval;
   }

--- a/supabase/functions/partner-reject-application/index_test.ts
+++ b/supabase/functions/partner-reject-application/index_test.ts
@@ -3,36 +3,23 @@
 // Lazy-loads the handler via dynamic import with Deno.serve stubbed to prevent
 // a real HTTP server from being started (same pattern as payment-webhook/index_test.ts).
 
-import { assertEquals } from "jsr:@std/assert@1";
-import { stub } from "@std/testing/mock";
+import { assertEquals } from "@std/assert";
 import {
   buildApplication,
   fakeSupabase,
+  type Handler,
   makeCtx,
   readJson,
   runHandler,
-  type Handler,
 } from "../_shared/_testing/mod.ts";
+import { importHandlerWithStubbedServe } from "../_test_utils/mock_http.ts";
 
 let _handler: Handler | null = null;
 async function getHandler(): Promise<Handler> {
   if (_handler) return _handler;
-  const serveOwner = Deno as unknown as { serve: (...args: unknown[]) => Deno.HttpServer };
-  const serveStub = stub(serveOwner, "serve", () => ({
-    shutdown() {},
-    finished: Promise.resolve(),
-  } as Deno.HttpServer));
-  const origSetInterval = globalThis.setInterval;
-  const origClearInterval = globalThis.clearInterval;
-  globalThis.setInterval = ((_cb: () => void) => 0 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
-  globalThis.clearInterval = ((_id?: ReturnType<typeof setInterval>) => {}) as typeof clearInterval;
-  try {
-    _handler = (await import(`./index.ts?unit=${crypto.randomUUID()}`)).handler as Handler;
-  } finally {
-    serveStub.restore();
-    globalThis.setInterval = origSetInterval;
-    globalThis.clearInterval = origClearInterval;
-  }
+  _handler = await importHandlerWithStubbedServe<Handler>(
+    new URL("./index.ts", import.meta.url),
+  );
   return _handler!;
 }
 
@@ -152,7 +139,10 @@ Deno.test("partner-reject-application :: status=paid (non-rejectable) → 400", 
   });
   assertEquals(res.status, 400);
   const body = await readJson<{ error: string }>(res);
-  assertEquals(body.error.startsWith("Cannot reject application with status"), true);
+  assertEquals(
+    body.error.startsWith("Cannot reject application with status"),
+    true,
+  );
 });
 
 Deno.test("partner-reject-application :: status=rejected (already rejected) → 400", async () => {
@@ -207,7 +197,9 @@ Deno.test("partner-reject-application :: DB error on update → 500", async () =
   const sb = fakeSupabase()
     .on("event_applications", "select", { data: buildAppRow("pending") })
     .on("partner_member_permissions", "select", { data: OWNER_PERM })
-    .on("event_applications", "update", { error: { message: "deadlock", code: "40P01" } });
+    .on("event_applications", "update", {
+      error: { message: "deadlock", code: "40P01" },
+    });
   const res = await runHandler(handler, {
     body: { application_id: APP_ID, reason: "Not a fit" },
     ctx: makeCtx({ supabase: sb, userId: "u-partner" }),
@@ -230,7 +222,9 @@ Deno.test("partner-reject-application :: status=pending + owner role → 200", a
     ctx: makeCtx({ supabase: sb, userId: "u-partner" }),
   });
   assertEquals(res.status, 200);
-  const body = await readJson<{ rejected: number; application_id: string }>(res);
+  const body = await readJson<{ rejected: number; application_id: string }>(
+    res,
+  );
   assertEquals(body.rejected, 1);
   assertEquals(body.application_id, APP_ID);
 

--- a/supabase/functions/payment-cancel/index_test.ts
+++ b/supabase/functions/payment-cancel/index_test.ts
@@ -10,13 +10,14 @@
 import { assertEquals } from "@std/assert";
 import {
   fakeSupabase,
+  type Handler,
   makeCtx,
   readJson,
   runHandler,
-  type Handler,
 } from "../_shared/_testing/mod.ts";
 import {
   createFetchMock,
+  importHandlerWithStubbedServe,
   jsonResponse,
   withEnv,
   withMockedFetch,
@@ -25,20 +26,9 @@ import {
 let _handler: Handler | null = null;
 async function getHandler(): Promise<Handler> {
   if (_handler) return _handler;
-  const denoAsAny = Deno as unknown as { serve: (...args: unknown[]) => Deno.HttpServer };
-  const origServe = denoAsAny.serve;
-  denoAsAny.serve = () => ({ shutdown() {}, finished: Promise.resolve() } as Deno.HttpServer);
-  const origSetInterval = globalThis.setInterval;
-  const origClearInterval = globalThis.clearInterval;
-  globalThis.setInterval = ((_cb: () => void) => 0 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
-  globalThis.clearInterval = ((_id?: ReturnType<typeof setInterval>) => {}) as typeof clearInterval;
-  try {
-    _handler = (await import(`./index.ts?unit=${crypto.randomUUID()}`)).handler as Handler;
-  } finally {
-    denoAsAny.serve = origServe;
-    globalThis.setInterval = origSetInterval;
-    globalThis.clearInterval = origClearInterval;
-  }
+  _handler = await importHandlerWithStubbedServe<Handler>(
+    new URL("./index.ts", import.meta.url),
+  );
   return _handler!;
 }
 
@@ -46,8 +36,10 @@ async function getHandler(): Promise<Handler> {
 const nowMs = Date.now();
 const ELIGIBLE_PAID_AT = new Date(nowMs - 1 * 60 * 60 * 1000).toISOString(); // 1h ago — within 2h grace
 const INELIGIBLE_PAID_AT = new Date(nowMs - 3 * 60 * 60 * 1000).toISOString(); // 3h ago — outside grace
-const FAR_FUTURE_EVENT = new Date(nowMs + 10 * 24 * 60 * 60 * 1000).toISOString(); // 10d → within cutoff
-const NEAR_FUTURE_EVENT = new Date(nowMs + 3 * 24 * 60 * 60 * 1000).toISOString(); // 3d → outside 7d cutoff
+const FAR_FUTURE_EVENT = new Date(nowMs + 10 * 24 * 60 * 60 * 1000)
+  .toISOString(); // 10d → within cutoff
+const NEAR_FUTURE_EVENT = new Date(nowMs + 3 * 24 * 60 * 60 * 1000)
+  .toISOString(); // 3d → outside 7d cutoff
 const PAST_EVENT = new Date(nowMs - 60 * 60 * 1000).toISOString(); // already started
 
 // ── Shared env required by executeRefund ─────────────────────────────────────
@@ -64,13 +56,16 @@ const portoneTokenRoute = {
 
 const portoneCancelRoute = {
   matcher: "https://api.iamport.kr/payments/cancel",
-  handler: () => jsonResponse({ code: 0, response: { status: "cancelled", amount: 15000 } }),
+  handler: () =>
+    jsonResponse({ code: 0, response: { status: "cancelled", amount: 15000 } }),
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /** Standard application row returned from event_applications select */
-function makeApp(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+function makeApp(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
   return {
     paid_at: ELIGIBLE_PAID_AT,
     event_id: "ev-1",
@@ -146,7 +141,9 @@ Deno.test("payment-cancel :: event fetch error → 500", async () => {
   const sb = fakeSupabase()
     .on("event_applications", "select", { data: makeApp() })
     .on("events", "select", { error: { message: "connection timeout" } })
-    .on("get_current_policy", "rpc", { data: { grace_period_hours: 2, cutoff_days: 7 } });
+    .on("get_current_policy", "rpc", {
+      data: { grace_period_hours: 2, cutoff_days: 7 },
+    });
 
   const res = await runHandler(handler, {
     body: { payment_id: "imp_123" },
@@ -182,14 +179,18 @@ Deno.test("payment-cancel :: event already started → 400 refund_not_eligible",
       data: makeApp({ paid_at: ELIGIBLE_PAID_AT }),
     })
     .on("events", "select", { data: { start_time: PAST_EVENT } })
-    .on("get_current_policy", "rpc", { data: { grace_period_hours: 2, cutoff_days: 7 } });
+    .on("get_current_policy", "rpc", {
+      data: { grace_period_hours: 2, cutoff_days: 7 },
+    });
 
   const res = await runHandler(handler, {
     body: { payment_id: "imp_123" },
     ctx: makeCtx({ supabase: sb, userId: "u-1" }),
   });
   assertEquals(res.status, 400);
-  const body = await readJson<{ error: string; details?: { reason?: string } }>(res);
+  const body = await readJson<{ error: string; details?: { reason?: string } }>(
+    res,
+  );
   assertEquals(body.error, "refund_not_eligible");
 });
 
@@ -201,7 +202,9 @@ Deno.test("payment-cancel :: outside grace and cutoff window → 400 refund_not_
       data: makeApp({ paid_at: INELIGIBLE_PAID_AT }), // 3h ago — outside 2h grace
     })
     .on("events", "select", { data: { start_time: NEAR_FUTURE_EVENT } }) // 3d — outside 7d cutoff
-    .on("get_current_policy", "rpc", { data: { grace_period_hours: 2, cutoff_days: 7 } });
+    .on("get_current_policy", "rpc", {
+      data: { grace_period_hours: 2, cutoff_days: 7 },
+    });
 
   const res = await runHandler(handler, {
     body: { payment_id: "imp_123" },
@@ -218,7 +221,9 @@ Deno.test("payment-cancel :: missing portone credentials → 500", async () => {
   const sb = fakeSupabase()
     .on("event_applications", "select", { data: makeApp() })
     .on("events", "select", { data: { start_time: FAR_FUTURE_EVENT } })
-    .on("get_current_policy", "rpc", { data: { grace_period_hours: 2, cutoff_days: 7 } });
+    .on("get_current_policy", "rpc", {
+      data: { grace_period_hours: 2, cutoff_days: 7 },
+    });
 
   // Explicitly unset credentials so executeRefund throws RefundError("Server configuration error", 500)
   await withEnv(
@@ -243,10 +248,15 @@ Deno.test("payment-cancel :: happy path (within grace) → 200 + refund_status=c
       data: makeApp({ paid_at: ELIGIBLE_PAID_AT }),
     })
     .on("events", "select", { data: { start_time: NEAR_FUTURE_EVENT } })
-    .on("get_current_policy", "rpc", { data: { grace_period_hours: 2, cutoff_days: 7 } })
+    .on("get_current_policy", "rpc", {
+      data: { grace_period_hours: 2, cutoff_days: 7 },
+    })
     .on("event_applications", "update", { error: null });
 
-  const { fetchMock } = createFetchMock([portoneTokenRoute, portoneCancelRoute]);
+  const { fetchMock } = createFetchMock([
+    portoneTokenRoute,
+    portoneCancelRoute,
+  ]);
 
   await withEnv(PORTONE_ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
@@ -277,10 +287,15 @@ Deno.test("payment-cancel :: paidAt=null + within cutoff → 200", async () => {
       data: makeApp({ paid_at: null }),
     })
     .on("events", "select", { data: { start_time: FAR_FUTURE_EVENT } }) // 10d → within 7d cutoff
-    .on("get_current_policy", "rpc", { data: { grace_period_hours: 2, cutoff_days: 7 } })
+    .on("get_current_policy", "rpc", {
+      data: { grace_period_hours: 2, cutoff_days: 7 },
+    })
     .on("event_applications", "update", { error: null });
 
-  const { fetchMock } = createFetchMock([portoneTokenRoute, portoneCancelRoute]);
+  const { fetchMock } = createFetchMock([
+    portoneTokenRoute,
+    portoneCancelRoute,
+  ]);
 
   await withEnv(PORTONE_ENV, async () => {
     await withMockedFetch(fetchMock, async () => {
@@ -299,7 +314,9 @@ Deno.test("payment-cancel :: portone token failure → 502", async () => {
   const sb = fakeSupabase()
     .on("event_applications", "select", { data: makeApp() })
     .on("events", "select", { data: { start_time: FAR_FUTURE_EVENT } })
-    .on("get_current_policy", "rpc", { data: { grace_period_hours: 2, cutoff_days: 7 } });
+    .on("get_current_policy", "rpc", {
+      data: { grace_period_hours: 2, cutoff_days: 7 },
+    });
 
   const { fetchMock } = createFetchMock([
     {
@@ -327,10 +344,17 @@ Deno.test("payment-cancel :: DB update error is non-fatal → 200", async () => 
   const sb = fakeSupabase()
     .on("event_applications", "select", { data: makeApp() })
     .on("events", "select", { data: { start_time: FAR_FUTURE_EVENT } })
-    .on("get_current_policy", "rpc", { data: { grace_period_hours: 2, cutoff_days: 7 } })
-    .on("event_applications", "update", { error: { message: "DB error", code: "XXXXX" } });
+    .on("get_current_policy", "rpc", {
+      data: { grace_period_hours: 2, cutoff_days: 7 },
+    })
+    .on("event_applications", "update", {
+      error: { message: "DB error", code: "XXXXX" },
+    });
 
-  const { fetchMock } = createFetchMock([portoneTokenRoute, portoneCancelRoute]);
+  const { fetchMock } = createFetchMock([
+    portoneTokenRoute,
+    portoneCancelRoute,
+  ]);
 
   await withEnv(PORTONE_ENV, async () => {
     await withMockedFetch(fetchMock, async () => {

--- a/supabase/functions/payment-verify/BLUEDOC.md
+++ b/supabase/functions/payment-verify/BLUEDOC.md
@@ -1,0 +1,30 @@
+# payment-verify
+
+유저 결제 완료 후 PortOne/Iamport 결제를 검증하고 application 상태를 승인
+처리하는 EF.
+
+## 이정표
+
+| 파일                                                   | 역할                                                               |
+| ------------------------------------------------------ | ------------------------------------------------------------------ |
+| [index.ts](index.ts)                                   | user auth 확인, request parse, service 호출, HTTP response mapping |
+| [input.ts](input.ts)                                   | `imp_uid` / `merchant_uid` request validation                      |
+| [verify_payment_service.ts](verify_payment_service.ts) | order 조회, PortOne 조회/취소, DB update, Statsig orchestration    |
+| [index_test.ts](index_test.ts)                         | L3 handler unit test (`fakeSupabase` + fetch mock)                 |
+| [payment_verify_test.ts](payment_verify_test.ts)       | HTTP wrapper/integration-style test                                |
+
+## 핵심 컨벤션
+
+- 결제 상태/금액/멱등성 policy 는 `_shared/domains/payment` 에 둔다.
+- `merchant_uid` 는 `event_applications.id` 이며 owner check 를 service_role EF
+  에서 명시한다.
+- 금액 mismatch 는 자동 취소를 시도하고 실패해도 검증 요청은 400 으로 종료한다.
+
+## 관련
+
+- [../architecture.md](../architecture.md)
+- [../_shared/domains/payment/BLUEDOC.md](../_shared/domains/payment/BLUEDOC.md)
+
+---
+
+_Reviewed: 2026-05-24 00:00_

--- a/supabase/functions/payment-verify/index.ts
+++ b/supabase/functions/payment-verify/index.ts
@@ -1,17 +1,18 @@
 // Fix #2185 (Batch 8): migrate to minglitEdgeFunction wrapper — auth via manifest
 // Fix #179: esm.sh 직접 URL → deno.json import map 기반으로 통일
-import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
-import { nowISO } from "../_shared/temporal_utils.ts";
-import { IamportClient } from "../_shared/iamport_client.ts";
 import {
-  errorResponse,
-  successResponse,
-} from "../_shared/response_utils.ts";
+  type EFContext,
+  minglitEdgeFunction,
+} from "../_shared/edge_function.ts";
+import { IamportClient } from "../_shared/iamport_client.ts";
+import { errorResponse, successResponse } from "../_shared/response_utils.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { log, withSpan } from "../_shared/logger.ts";
+import { log } from "../_shared/logger.ts";
+import { initStatsig } from "../_shared/statsig_utils.ts";
+import { parsePaymentVerifyInput } from "./input.ts";
+import { verifyPayment } from "./verify_payment_service.ts";
 
 const FN = "payment-verify";
-import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
 
 const IMP_KEY = Deno.env.get("PORTONE_API_KEY");
 const IMP_SECRET = Deno.env.get("PORTONE_API_SECRET");
@@ -24,126 +25,37 @@ if (!IMP_KEY || !IMP_SECRET) {
 
 initStatsig();
 
-export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
-  const { supabase } = ctx;
-  if (ctx.auth.type !== "user") return errorResponse("Unexpected auth type", 500);
-  const userId = ctx.auth.userId;
+export const handler = async (
+  req: Request,
+  ctx: EFContext,
+): Promise<Response> => {
+  if (ctx.auth.type !== "user") {
+    return errorResponse("Unexpected auth type", 500);
+  }
 
   try {
     const body = await parseJsonBody(req);
     if (body instanceof Response) return body;
-    const { imp_uid, merchant_uid } = body as {
-      imp_uid?: string;
-      merchant_uid?: string;
-    };
 
-    if (!imp_uid || !merchant_uid) {
-      return errorResponse("Missing required parameters", 400);
+    const input = parsePaymentVerifyInput(body);
+    if (input instanceof Response) return input;
+
+    const result = await verifyPayment({
+      supabase: ctx.supabase,
+      userId: ctx.auth.userId,
+      input,
+      iamportClient: new IamportClient(IMP_KEY, IMP_SECRET),
+    });
+
+    if (!result.ok) {
+      return errorResponse(result.message, result.status, result.details);
     }
 
-    // 1. DB에서 주문 정보 조회 (금액 확인)
-    const { data: order, error: orderError } = await withSpan(
-      "db.query.event_applications",
-      "db.query",
-      async () =>
-        supabase
-          .from("event_applications")
-          .select("payment_amount, status, user_id")
-          .eq("id", merchant_uid)
-          .single(),
-    );
-
-    if (orderError || !order) {
-      return errorResponse("Order not found", 404);
-    }
-
-    // Fix #1490: 호출자가 신청자 본인인지 검증 — service role은 RLS를 우회하므로 명시적 확인 필요
-    if (order.user_id !== userId) {
-      return errorResponse("Forbidden", 403);
-    }
-
-    // 이미 처리된 주문인지 확인
-    if (order.status === "approved" || order.status === "paid") {
+    if (result.alreadyProcessed) {
       return successResponse({ success: true, message: "Already processed" });
     }
 
-    // 2. Iamport V1 API 조회
-    const client = new IamportClient(IMP_KEY, IMP_SECRET);
-    const payment = await client.getPayment(imp_uid);
-
-    // 3. 결제 상태 및 금액 검증
-    if (payment.status !== "paid") {
-      logStatsigEvent(userId, "payment_failed", undefined, {
-        reason: "payment_not_completed",
-        imp_uid,
-      }).catch(() => {});
-      return errorResponse("Payment not completed", 400, {
-        status: payment.status,
-      });
-    }
-
-    if (payment.amount !== order.payment_amount) {
-      await client.cancelPayment(imp_uid, "결제 금액 위변조로 자동 취소").catch(
-        (e: unknown) => {
-          const msg = e instanceof Error ? e.message : String(e);
-          log({
-            function: FN,
-            level: "error",
-            message: "Cancel on mismatch failed",
-            metadata: { detail: msg },
-          });
-        },
-      );
-      logStatsigEvent(userId, "payment_failed", undefined, {
-        reason: "amount_mismatch",
-        imp_uid,
-      }).catch(() => {});
-      return errorResponse("Amount mismatch", 400, {
-        expected: order.payment_amount,
-        actual: payment.amount,
-      });
-    }
-
-    // Fix #133: paid_at 없을 때 now 폴백하면 재시도마다 값이 밀려 멱등성 깨짐 — payment-webhook과 동일하게 null 처리
-    const paidAtIso = payment.paid_at && payment.paid_at > 0
-      ? Temporal.Instant.fromEpochMilliseconds(payment.paid_at * 1000)
-        .toString()
-      : null;
-
-    const { error: updateError } = await withSpan(
-      "db.update.event_applications",
-      "db.update",
-      async () =>
-        supabase
-          .from("event_applications")
-          .update({
-            status: "approved",
-            payment_id: imp_uid,
-            ...(paidAtIso ? { paid_at: paidAtIso } : {}),
-            updated_at: nowISO(),
-          })
-          .eq("id", merchant_uid),
-    );
-
-    if (updateError) {
-      log({
-        function: FN,
-        level: "error",
-        message: "DB Update Error",
-        metadata: { detail: updateError },
-      });
-      logStatsigEvent(userId, "payment_failed", undefined, {
-        reason: "db_update_error",
-        imp_uid,
-      }).catch(() => {});
-      return errorResponse("Failed to update order status", 500);
-    }
-
-    logStatsigEvent(userId, "payment_completed", payment.amount, {
-      imp_uid,
-      merchant_uid,
-    }).catch(() => {});
-    return successResponse({ success: true, imp_uid });
+    return successResponse({ success: true, imp_uid: result.impUid });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     log({
@@ -154,6 +66,6 @@ export const handler = async (req: Request, ctx: EFContext): Promise<Response> =
     });
     return errorResponse(message, 500);
   }
-}
+};
 
 minglitEdgeFunction(handler);

--- a/supabase/functions/payment-verify/index_test.ts
+++ b/supabase/functions/payment-verify/index_test.ts
@@ -15,7 +15,10 @@ import {
   readJson,
   runHandler,
 } from "../_shared/_testing/mod.ts";
-import { withEnv } from "../_test_utils/mock_http.ts";
+import {
+  importHandlerWithStubbedServe,
+  withEnv,
+} from "../_test_utils/mock_http.ts";
 
 const PORTONE_ENV = {
   PORTONE_API_KEY: "test-key",
@@ -25,29 +28,13 @@ const PORTONE_ENV = {
 let _handler: Handler | null = null;
 async function getHandler(): Promise<Handler> {
   if (_handler) return _handler;
-  const denoAsAny = Deno as unknown as {
-    serve: (...args: unknown[]) => Deno.HttpServer;
-  };
-  const origServe = denoAsAny.serve;
-  denoAsAny.serve =
-    () => ({ shutdown() {}, finished: Promise.resolve() } as Deno.HttpServer);
-  const origSetInterval = globalThis.setInterval;
-  const origClearInterval = globalThis.clearInterval;
-  globalThis.setInterval =
-    ((_cb: () => void) =>
-      0 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
-  globalThis.clearInterval =
-    ((_id?: ReturnType<typeof setInterval>) => {}) as typeof clearInterval;
-  try {
-    _handler = await withEnv(PORTONE_ENV, async () => {
-      const mod = await import(`./index.ts?unit=${crypto.randomUUID()}`);
-      return mod.handler as Handler;
-    });
-  } finally {
-    denoAsAny.serve = origServe;
-    globalThis.setInterval = origSetInterval;
-    globalThis.clearInterval = origClearInterval;
-  }
+  _handler = await withEnv(
+    PORTONE_ENV,
+    () =>
+      importHandlerWithStubbedServe<Handler>(
+        new URL("./index.ts", import.meta.url),
+      ),
+  );
   return _handler!;
 }
 

--- a/supabase/functions/payment-verify/index_test.ts
+++ b/supabase/functions/payment-verify/index_test.ts
@@ -7,13 +7,13 @@
 // 격리: env 는 withEnv 로 import 시점에만 set + 복원. top-level Deno.env.set 절대 금지
 // (Fix #2526: 다른 EF 의 wrapper 가 stale MINGLIT_EF_TEST_FN_NAME 읽어 wrong policy 로딩).
 
-import { assertEquals } from "jsr:@std/assert@1";
+import { assertEquals } from "@std/assert";
 import {
   fakeSupabase,
+  type Handler,
   makeCtx,
   readJson,
   runHandler,
-  type Handler,
 } from "../_shared/_testing/mod.ts";
 import { withEnv } from "../_test_utils/mock_http.ts";
 
@@ -25,13 +25,19 @@ const PORTONE_ENV = {
 let _handler: Handler | null = null;
 async function getHandler(): Promise<Handler> {
   if (_handler) return _handler;
-  const denoAsAny = Deno as unknown as { serve: (...args: unknown[]) => Deno.HttpServer };
+  const denoAsAny = Deno as unknown as {
+    serve: (...args: unknown[]) => Deno.HttpServer;
+  };
   const origServe = denoAsAny.serve;
-  denoAsAny.serve = () => ({ shutdown() {}, finished: Promise.resolve() } as Deno.HttpServer);
+  denoAsAny.serve =
+    () => ({ shutdown() {}, finished: Promise.resolve() } as Deno.HttpServer);
   const origSetInterval = globalThis.setInterval;
   const origClearInterval = globalThis.clearInterval;
-  globalThis.setInterval = ((_cb: () => void) => 0 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
-  globalThis.clearInterval = ((_id?: ReturnType<typeof setInterval>) => {}) as typeof clearInterval;
+  globalThis.setInterval =
+    ((_cb: () => void) =>
+      0 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
+  globalThis.clearInterval =
+    ((_id?: ReturnType<typeof setInterval>) => {}) as typeof clearInterval;
   try {
     _handler = await withEnv(PORTONE_ENV, async () => {
       const mod = await import(`./index.ts?unit=${crypto.randomUUID()}`);
@@ -71,16 +77,26 @@ function makePortOneFetch(paymentOverrides: Record<string, unknown> = {}) {
     ...paymentOverrides,
   };
 
-  return (input: string | URL | Request, _init?: RequestInit): Promise<Response> => {
-    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+  return (
+    input: string | URL | Request,
+    _init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+      ? input.href
+      : input.url;
 
     // Token endpoint
     if (url.includes("/users/getToken")) {
       return Promise.resolve(
-        new Response(JSON.stringify({ code: 0, response: { access_token: "tok-test" } }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
+        new Response(
+          JSON.stringify({ code: 0, response: { access_token: "tok-test" } }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
       );
     }
     // Payment lookup
@@ -101,7 +117,9 @@ function makePortOneFetch(paymentOverrides: Record<string, unknown> = {}) {
         }),
       );
     }
-    return Promise.resolve(new Response("unexpected fetch: " + url, { status: 500 }));
+    return Promise.resolve(
+      new Response("unexpected fetch: " + url, { status: 500 }),
+    );
   };
 }
 
@@ -213,7 +231,10 @@ Deno.test("payment-verify :: PortOne amount mismatch → 400 (cancel triggered)"
   const handler = await getHandler();
   const origFetch = globalThis.fetch;
   // PortOne returns amount=999 but order expects 10000
-  globalThis.fetch = makePortOneFetch({ status: "paid", amount: 999 }) as typeof fetch;
+  globalThis.fetch = makePortOneFetch({
+    status: "paid",
+    amount: 999,
+  }) as typeof fetch;
   try {
     const sb = fakeSupabase().on("event_applications", "select", {
       data: buildOrder({ status: "pending", payment_amount: 10000 }),
@@ -223,7 +244,9 @@ Deno.test("payment-verify :: PortOne amount mismatch → 400 (cancel triggered)"
       ctx: makeCtx({ supabase: sb, userId: USER_ID }),
     });
     assertEquals(res.status, 400);
-    const body = await readJson<{ error: string; details: { expected: number; actual: number } }>(res);
+    const body = await readJson<
+      { error: string; details: { expected: number; actual: number } }
+    >(res);
     assertEquals(body.error, "Amount mismatch");
     assertEquals(body.details.expected, 10000);
     assertEquals(body.details.actual, 999);
@@ -238,7 +261,9 @@ Deno.test("payment-verify :: happy path → 200 + DB updated to approved", async
   globalThis.fetch = makePortOneFetch() as typeof fetch;
   try {
     const sb = fakeSupabase()
-      .on("event_applications", "select", { data: buildOrder({ status: "pending" }) })
+      .on("event_applications", "select", {
+        data: buildOrder({ status: "pending" }),
+      })
       .on("event_applications", "update", { error: null });
 
     const res = await runHandler(handler, {
@@ -267,7 +292,9 @@ Deno.test("payment-verify :: happy path with paid_at=null → approved with no p
   globalThis.fetch = makePortOneFetch({ paid_at: null }) as typeof fetch;
   try {
     const sb = fakeSupabase()
-      .on("event_applications", "select", { data: buildOrder({ status: "pending" }) })
+      .on("event_applications", "select", {
+        data: buildOrder({ status: "pending" }),
+      })
       .on("event_applications", "update", { error: null });
 
     const res = await runHandler(handler, {
@@ -292,7 +319,9 @@ Deno.test("payment-verify :: DB update fails after payment verified → 500", as
   globalThis.fetch = makePortOneFetch() as typeof fetch;
   try {
     const sb = fakeSupabase()
-      .on("event_applications", "select", { data: buildOrder({ status: "pending" }) })
+      .on("event_applications", "select", {
+        data: buildOrder({ status: "pending" }),
+      })
       .on("event_applications", "update", {
         error: { message: "db error", code: "23000" },
       });

--- a/supabase/functions/payment-verify/input.ts
+++ b/supabase/functions/payment-verify/input.ts
@@ -1,0 +1,24 @@
+import { errorResponse } from "../_shared/response_utils.ts";
+
+export interface PaymentVerifyInput {
+  imp_uid: string;
+  merchant_uid: string;
+}
+
+export function parsePaymentVerifyInput(
+  body: Record<string, unknown>,
+): PaymentVerifyInput | Response {
+  const impUid = body.imp_uid;
+  const merchantUid = body.merchant_uid;
+
+  if (
+    typeof impUid !== "string" ||
+    impUid.length === 0 ||
+    typeof merchantUid !== "string" ||
+    merchantUid.length === 0
+  ) {
+    return errorResponse("Missing required parameters", 400);
+  }
+
+  return { imp_uid: impUid, merchant_uid: merchantUid };
+}

--- a/supabase/functions/payment-verify/verify_payment_service.ts
+++ b/supabase/functions/payment-verify/verify_payment_service.ts
@@ -1,0 +1,139 @@
+import type { EFContext } from "../_shared/edge_function.ts";
+import type { IamportClient } from "../_shared/iamport_client.ts";
+import { log, withSpan } from "../_shared/logger.ts";
+import { logStatsigEvent } from "../_shared/statsig_utils.ts";
+import {
+  evaluateGatewayPayment,
+  isOrderOwner,
+  isPaymentVerifyAlreadyProcessed,
+  paidAtToIso,
+  type PaymentVerificationOrderSnapshot,
+} from "../_shared/domains/payment/payment_verification_policy.ts";
+import type { PaymentVerifyInput } from "./input.ts";
+
+const FN = "payment-verify";
+
+export type VerifyPaymentServiceResult =
+  | { ok: true; alreadyProcessed: true }
+  | { ok: true; alreadyProcessed: false; impUid: string }
+  | VerifyPaymentServiceFailure;
+
+export interface VerifyPaymentServiceFailure {
+  ok: false;
+  status: number;
+  message: string;
+  details?: unknown;
+}
+
+export async function verifyPayment(args: {
+  supabase: EFContext["supabase"];
+  userId: string;
+  input: PaymentVerifyInput;
+  iamportClient: Pick<IamportClient, "getPayment" | "cancelPayment">;
+}): Promise<VerifyPaymentServiceResult> {
+  const { supabase, userId, input, iamportClient } = args;
+
+  const { data: order, error: orderError } = await withSpan(
+    "db.query.event_applications",
+    "db.query",
+    () =>
+      supabase
+        .from("event_applications")
+        .select("payment_amount, status, user_id")
+        .eq("id", input.merchant_uid)
+        .single(),
+  );
+
+  if (orderError || !order) {
+    return fail(404, "Order not found");
+  }
+
+  const typedOrder = order as PaymentVerificationOrderSnapshot;
+  if (!isOrderOwner(typedOrder, userId)) {
+    return fail(403, "Forbidden");
+  }
+
+  if (isPaymentVerifyAlreadyProcessed(typedOrder.status)) {
+    return { ok: true, alreadyProcessed: true };
+  }
+
+  const payment = await iamportClient.getPayment(input.imp_uid);
+  const paymentPolicy = evaluateGatewayPayment(
+    payment,
+    typedOrder.payment_amount,
+  );
+
+  if (!paymentPolicy.ok) {
+    if (paymentPolicy.reason === "amount_mismatch") {
+      await iamportClient
+        .cancelPayment(input.imp_uid, "결제 금액 위변조로 자동 취소")
+        .catch((error: unknown) => {
+          const message = error instanceof Error
+            ? error.message
+            : String(error);
+          log({
+            function: FN,
+            level: "error",
+            message: "Cancel on mismatch failed",
+            metadata: { detail: message },
+          });
+        });
+    }
+
+    logStatsigEvent(userId, "payment_failed", undefined, {
+      reason: paymentPolicy.reason,
+      imp_uid: input.imp_uid,
+    }).catch(() => {});
+
+    return fail(
+      paymentPolicy.status,
+      paymentPolicy.message,
+      paymentPolicy.details,
+    );
+  }
+
+  const paidAtIso = paidAtToIso(payment.paid_at);
+  const { error: updateError } = await withSpan(
+    "db.update.event_applications",
+    "db.update",
+    () =>
+      supabase
+        .from("event_applications")
+        .update({
+          status: "approved",
+          payment_id: input.imp_uid,
+          ...(paidAtIso ? { paid_at: paidAtIso } : {}),
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", input.merchant_uid),
+  );
+
+  if (updateError) {
+    log({
+      function: FN,
+      level: "error",
+      message: "DB Update Error",
+      metadata: { detail: updateError },
+    });
+    logStatsigEvent(userId, "payment_failed", undefined, {
+      reason: "db_update_error",
+      imp_uid: input.imp_uid,
+    }).catch(() => {});
+    return fail(500, "Failed to update order status");
+  }
+
+  logStatsigEvent(userId, "payment_completed", payment.amount, {
+    imp_uid: input.imp_uid,
+    merchant_uid: input.merchant_uid,
+  }).catch(() => {});
+
+  return { ok: true, alreadyProcessed: false, impUid: input.imp_uid };
+}
+
+function fail(
+  status: number,
+  message: string,
+  details?: unknown,
+): VerifyPaymentServiceFailure {
+  return { ok: false, status, message, details };
+}

--- a/supabase/functions/payment-webhook/index_test.ts
+++ b/supabase/functions/payment-webhook/index_test.ts
@@ -19,11 +19,16 @@
 import { assertEquals } from "@std/assert";
 import {
   fakeSupabase,
+  type Handler,
   makeCtx,
   runHandler,
-  type Handler,
 } from "../_shared/_testing/mod.ts";
-import { createFetchMock, withEnv, withMockedFetch } from "../_test_utils/mock_http.ts";
+import {
+  createFetchMock,
+  importHandlerWithStubbedServe,
+  withEnv,
+  withMockedFetch,
+} from "../_test_utils/mock_http.ts";
 
 const PORTONE_ENV = {
   PORTONE_API_KEY: "test-key",
@@ -40,27 +45,13 @@ let _handler: Handler | null = null;
 async function getHandler(): Promise<Handler> {
   if (_handler) return _handler;
 
-  // Stub Deno.serve to prevent a real HTTP server from being started.
-  const denoAsAny = Deno as unknown as { serve: (...args: unknown[]) => Deno.HttpServer };
-  const originalServe = denoAsAny.serve;
-  denoAsAny.serve = () => ({ shutdown() {}, finished: Promise.resolve() } as Deno.HttpServer);
-
-  // Stub setInterval to prevent background timers (e.g. Statsig flush).
-  const originalSetInterval = globalThis.setInterval;
-  const originalClearInterval = globalThis.clearInterval;
-  globalThis.setInterval = ((_cb: () => void) => 0 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
-  globalThis.clearInterval = ((_id?: ReturnType<typeof setInterval>) => {}) as typeof clearInterval;
-
-  try {
-    _handler = await withEnv(PORTONE_ENV, async () => {
-      const mod = await import(`./index.ts?unit=${crypto.randomUUID()}`);
-      return mod.handler as Handler;
-    });
-  } finally {
-    denoAsAny.serve = originalServe;
-    globalThis.setInterval = originalSetInterval;
-    globalThis.clearInterval = originalClearInterval;
-  }
+  _handler = await withEnv(
+    PORTONE_ENV,
+    () =>
+      importHandlerWithStubbedServe<Handler>(
+        new URL("./index.ts", import.meta.url),
+      ),
+  );
 
   return _handler!;
 }
@@ -125,8 +116,7 @@ Deno.test("payment-webhook :: malformed JSON body → 400", async () => {
       body: "not-json{{{",
       headers: { "content-type": "text/plain" },
       ctx: sysCtx(sb),
-    })
-  );
+    }));
   assertEquals(res.status, 400);
   assertEquals(await res.text(), "Bad Request");
 });
@@ -142,8 +132,7 @@ Deno.test("payment-webhook :: missing imp_uid → 400", async () => {
     runHandler(h, {
       body: { merchant_uid: "order-1", status: "paid" },
       ctx: sysCtx(sb),
-    })
-  );
+    }));
   assertEquals(res.status, 400);
   assertEquals(await res.text(), "Missing parameters");
 });
@@ -159,8 +148,7 @@ Deno.test("payment-webhook :: missing merchant_uid → 400", async () => {
     runHandler(h, {
       body: { imp_uid: "imp-1", status: "paid" },
       ctx: sysCtx(sb),
-    })
-  );
+    }));
   assertEquals(res.status, 400);
   assertEquals(await res.text(), "Missing parameters");
 });
@@ -176,7 +164,10 @@ Deno.test("payment-webhook :: duplicate imp_uid (already processed) → 200 earl
   let portoneCallCount = 0;
   const { fetchMock } = createFetchMock([
     {
-      matcher: () => { portoneCallCount++; return false; },
+      matcher: () => {
+        portoneCallCount++;
+        return false;
+      },
       handler: () => new Response("should not reach", { status: 500 }),
     },
   ]);
@@ -185,8 +176,7 @@ Deno.test("payment-webhook :: duplicate imp_uid (already processed) → 200 earl
     runHandler(h, {
       body: { imp_uid: "imp-dup", merchant_uid: "order-dup", status: "paid" },
       ctx: sysCtx(sb),
-    })
-  );
+    }));
   assertEquals(res.status, 200);
   assertEquals(await res.text(), "OK");
   assertEquals(sb.callsFor("event_applications", "update").length, 0);
@@ -207,8 +197,7 @@ Deno.test("payment-webhook :: merchant_uid mismatch → 400", async () => {
     runHandler(h, {
       body: { imp_uid: "imp-1", merchant_uid: "order-1", status: "paid" },
       ctx: sysCtx(sb),
-    })
-  );
+    }));
   assertEquals(res.status, 400);
   assertEquals(await res.text(), "Merchant UID mismatch");
   assertEquals(sb.callsFor("event_applications", "update").length, 0);
@@ -228,14 +217,15 @@ Deno.test("payment-webhook :: paid → dbStatus=approved, notification enqueued 
     })
     .on("pgmq_send", "rpc", { data: null, error: null });
 
-  const fetchMock = portoneOkFetch("imp-paid", "order-paid", "paid", { paid_at: 1700000000 });
+  const fetchMock = portoneOkFetch("imp-paid", "order-paid", "paid", {
+    paid_at: 1700000000,
+  });
 
   const res = await withMockedFetch(fetchMock, () =>
     runHandler(h, {
       body: { imp_uid: "imp-paid", merchant_uid: "order-paid", status: "paid" },
       ctx: sysCtx(sb),
-    })
-  );
+    }));
   assertEquals(res.status, 200);
 
   const [updateCall] = sb.callsFor("event_applications", "update");
@@ -264,14 +254,19 @@ Deno.test("payment-webhook :: paid but paid_at=null → paid_at omitted from upd
     })
     .on("pgmq_send", "rpc", { data: null, error: null });
 
-  const fetchMock = portoneOkFetch("imp-nopaidat", "order-nopaidat", "paid", { paid_at: null });
+  const fetchMock = portoneOkFetch("imp-nopaidat", "order-nopaidat", "paid", {
+    paid_at: null,
+  });
 
   const res = await withMockedFetch(fetchMock, () =>
     runHandler(h, {
-      body: { imp_uid: "imp-nopaidat", merchant_uid: "order-nopaidat", status: "paid" },
+      body: {
+        imp_uid: "imp-nopaidat",
+        merchant_uid: "order-nopaidat",
+        status: "paid",
+      },
       ctx: sysCtx(sb),
-    })
-  );
+    }));
   assertEquals(res.status, 200);
   const [updateCall] = sb.callsFor("event_applications", "update");
   const patch = updateCall.payload as Record<string, unknown>;
@@ -294,10 +289,13 @@ Deno.test("payment-webhook :: cancelled → dbStatus=cancelled + refund_status=c
 
   const res = await withMockedFetch(fetchMock, () =>
     runHandler(h, {
-      body: { imp_uid: "imp-cancel", merchant_uid: "order-cancel", status: "cancelled" },
+      body: {
+        imp_uid: "imp-cancel",
+        merchant_uid: "order-cancel",
+        status: "cancelled",
+      },
       ctx: sysCtx(sb),
-    })
-  );
+    }));
   assertEquals(res.status, 200);
 
   const [updateCall] = sb.callsFor("event_applications", "update");
@@ -320,14 +318,20 @@ Deno.test("payment-webhook :: failed → dbStatus=payment_failed, no notificatio
 
   const res = await withMockedFetch(fetchMock, () =>
     runHandler(h, {
-      body: { imp_uid: "imp-fail", merchant_uid: "order-fail", status: "failed" },
+      body: {
+        imp_uid: "imp-fail",
+        merchant_uid: "order-fail",
+        status: "failed",
+      },
       ctx: sysCtx(sb),
-    })
-  );
+    }));
   assertEquals(res.status, 200);
 
   const [updateCall] = sb.callsFor("event_applications", "update");
-  assertEquals((updateCall.payload as Record<string, unknown>).status, "payment_failed");
+  assertEquals(
+    (updateCall.payload as Record<string, unknown>).status,
+    "payment_failed",
+  );
   // No pgmq_send for failed payments (only for paid)
   assertEquals(sb.callsFor("pgmq_send", "rpc").length, 0);
 });
@@ -346,14 +350,20 @@ Deno.test("payment-webhook :: ready (가상계좌) → dbStatus=payment_pending 
 
   const res = await withMockedFetch(fetchMock, () =>
     runHandler(h, {
-      body: { imp_uid: "imp-ready", merchant_uid: "order-ready", status: "ready" },
+      body: {
+        imp_uid: "imp-ready",
+        merchant_uid: "order-ready",
+        status: "ready",
+      },
       ctx: sysCtx(sb),
-    })
-  );
+    }));
   assertEquals(res.status, 200);
 
   const [updateCall] = sb.callsFor("event_applications", "update");
-  assertEquals((updateCall.payload as Record<string, unknown>).status, "payment_pending");
+  assertEquals(
+    (updateCall.payload as Record<string, unknown>).status,
+    "payment_pending",
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -366,14 +376,21 @@ Deno.test("payment-webhook :: unknown status → dbStatus=unknown_<value> → 20
     .on("event_applications", "update", { error: null })
     .on("webhook_imp_uid_log", "insert", { error: null });
 
-  const fetchMock = portoneOkFetch("imp-unk", "order-unk", "awaiting_something");
+  const fetchMock = portoneOkFetch(
+    "imp-unk",
+    "order-unk",
+    "awaiting_something",
+  );
 
   const res = await withMockedFetch(fetchMock, () =>
     runHandler(h, {
-      body: { imp_uid: "imp-unk", merchant_uid: "order-unk", status: "awaiting_something" },
+      body: {
+        imp_uid: "imp-unk",
+        merchant_uid: "order-unk",
+        status: "awaiting_something",
+      },
       ctx: sysCtx(sb),
-    })
-  );
+    }));
   assertEquals(res.status, 200);
 
   const [updateCall] = sb.callsFor("event_applications", "update");
@@ -398,10 +415,13 @@ Deno.test("payment-webhook :: DB update error → 500", async () => {
 
   const res = await withMockedFetch(fetchMock, () =>
     runHandler(h, {
-      body: { imp_uid: "imp-dberr", merchant_uid: "order-dberr", status: "paid" },
+      body: {
+        imp_uid: "imp-dberr",
+        merchant_uid: "order-dberr",
+        status: "paid",
+      },
       ctx: sysCtx(sb),
-    })
-  );
+    }));
   assertEquals(res.status, 500);
   assertEquals(await res.text(), "DB Error");
 });
@@ -423,10 +443,13 @@ Deno.test("payment-webhook :: PortOne getToken failure → 500", async () => {
 
   const res = await withMockedFetch(fetchMock, () =>
     runHandler(h, {
-      body: { imp_uid: "imp-pgfail", merchant_uid: "order-pgfail", status: "paid" },
+      body: {
+        imp_uid: "imp-pgfail",
+        merchant_uid: "order-pgfail",
+        status: "paid",
+      },
       ctx: sysCtx(sb),
-    })
-  );
+    }));
   assertEquals(res.status, 500);
   assertEquals(sb.callsFor("event_applications", "update").length, 0);
 });
@@ -449,8 +472,7 @@ Deno.test("payment-webhook :: paid → webhook_imp_uid_log inserted after succes
     runHandler(h, {
       body: { imp_uid: "imp-log", merchant_uid: "order-log", status: "paid" },
       ctx: sysCtx(sb),
-    })
-  );
+    }));
   assertEquals(res.status, 200);
 
   const insertCalls = sb.callsFor("webhook_imp_uid_log", "insert");

--- a/supabase/functions/user-cancel-order/BLUEDOC.md
+++ b/supabase/functions/user-cancel-order/BLUEDOC.md
@@ -1,0 +1,29 @@
+# user-cancel-order
+
+유저가 이벤트 신청/order 를 취소하고, 필요 시 PortOne 환불을 실행하는 EF.
+
+## 이정표
+
+| 파일                                                   | 역할                                                               |
+| ------------------------------------------------------ | ------------------------------------------------------------------ |
+| [index.ts](index.ts)                                   | user auth 확인, request parse, service 호출, HTTP response mapping |
+| [input.ts](input.ts)                                   | `event_id` / optional `reason` request validation                  |
+| [cancel_order_service.ts](cancel_order_service.ts)     | application 조회, 삭제/취소/update, refund orchestration           |
+| [index_test.ts](index_test.ts)                         | L3 handler unit test (`fakeSupabase`)                              |
+| [user_cancel_order_test.ts](user_cancel_order_test.ts) | HTTP wrapper/integration-style test                                |
+
+## 핵심 컨벤션
+
+- 취소 경로 결정은 `_shared/domains/payment/cancel_order_policy.ts` 에 둔다.
+- pre-payment 는 application/verification submission 삭제, paid 는 refund 후
+  cancel update.
+- 환불 성공 후 DB update 실패는 기존 정책대로 non-fatal 로 유지한다.
+
+## 관련
+
+- [../architecture.md](../architecture.md)
+- [../_shared/domains/payment/BLUEDOC.md](../_shared/domains/payment/BLUEDOC.md)
+
+---
+
+_Reviewed: 2026-05-24 00:00_

--- a/supabase/functions/user-cancel-order/cancel_order_service.ts
+++ b/supabase/functions/user-cancel-order/cancel_order_service.ts
@@ -1,0 +1,336 @@
+import type { EFContext } from "../_shared/edge_function.ts";
+import { log, withSpan } from "../_shared/logger.ts";
+import { executeRefund, RefundError } from "../_shared/refund_utils.ts";
+import { logStatsigEvent } from "../_shared/statsig_utils.ts";
+import {
+  parseRefundPolicy,
+  verifyRefundEligibility,
+} from "../_shared/domains/payment/refund_policy.ts";
+import {
+  type CancelOrderApplicationSnapshot,
+  decideCancelOrderPath,
+  evaluateFreeCancellationWindow,
+} from "../_shared/domains/payment/cancel_order_policy.ts";
+import type { CancelOrderInput } from "./input.ts";
+
+const FN = "user-cancel-order";
+
+export type CancelOrderServiceResult =
+  | { ok: true; type: "cancelled" }
+  | { ok: true; type: "refunded"; refundAmount: number | undefined }
+  | { ok: false; status: number; message: string; details?: unknown };
+
+export async function cancelOrder(args: {
+  supabase: EFContext["supabase"];
+  userId: string;
+  input: CancelOrderInput;
+  now?: Date;
+}): Promise<CancelOrderServiceResult> {
+  const { supabase, userId, input } = args;
+  const now = args.now ?? new Date();
+
+  const { data: application, error: appError } = await withSpan(
+    "db.query.event_applications",
+    "db.query",
+    () =>
+      supabase
+        .from("event_applications")
+        .select(
+          "id, status, payment_id, payment_amount, paid_at, refund_status, event_id, user_id",
+        )
+        .eq("event_id", input.event_id)
+        .eq("user_id", userId)
+        .single(),
+  );
+
+  if (appError || !application) {
+    return fail(404, "해당 이벤트에 신청 내역이 없습니다");
+  }
+
+  const typedApplication = application as CancelOrderApplicationSnapshot & {
+    id: string;
+    payment_id: string | null;
+    paid_at: string | null;
+  };
+  const path = decideCancelOrderPath(typedApplication);
+
+  if (!path.ok) {
+    if (path.message === "결제 정보가 손상된 신청입니다") {
+      log({
+        function: FN,
+        level: "error",
+        message: "Damaged data: payment_amount=null on paid application",
+        metadata: { application_id: typedApplication.id },
+      });
+    } else if (path.message === "지원하지 않는 신청 상태입니다") {
+      log({
+        function: FN,
+        level: "error",
+        message: `Unhandled status: ${typedApplication.status}`,
+        metadata: { application_id: typedApplication.id },
+      });
+    }
+    return fail(path.status, path.message, path.details);
+  }
+
+  if (path.type === "pre_payment") {
+    return cancelPrePayment({
+      supabase,
+      userId,
+      eventId: input.event_id,
+      applicationId: typedApplication.id,
+      previousStatus: typedApplication.status,
+    });
+  }
+
+  if (path.type === "free") {
+    return cancelFreeApplication({
+      supabase,
+      userId,
+      eventId: input.event_id,
+      applicationId: typedApplication.id,
+      previousStatus: typedApplication.status,
+      now,
+    });
+  }
+
+  return refundPaidApplication({
+    supabase,
+    userId,
+    input,
+    application: typedApplication,
+    amount: path.amount,
+  });
+}
+
+async function cancelPrePayment(args: {
+  supabase: EFContext["supabase"];
+  userId: string;
+  eventId: string;
+  applicationId: string;
+  previousStatus: string;
+}): Promise<CancelOrderServiceResult> {
+  await withSpan(
+    "db.delete.verification_submissions",
+    "db.delete",
+    () =>
+      args.supabase
+        .from("verification_submissions")
+        .delete()
+        .eq("application_id", args.applicationId)
+        .eq("status", "pending"),
+  );
+
+  await withSpan(
+    "db.delete.event_applications",
+    "db.delete",
+    () =>
+      args.supabase
+        .from("event_applications")
+        .delete()
+        .eq("id", args.applicationId),
+  );
+
+  logStatsigEvent(args.userId, "order_cancelled", undefined, {
+    event_id: args.eventId,
+    type: "pre_payment",
+    previous_status: args.previousStatus,
+  }).catch(() => {});
+
+  return { ok: true, type: "cancelled" };
+}
+
+async function cancelFreeApplication(args: {
+  supabase: EFContext["supabase"];
+  userId: string;
+  eventId: string;
+  applicationId: string;
+  previousStatus: string;
+  now: Date;
+}): Promise<CancelOrderServiceResult> {
+  const { data: eventData, error: eventError } = await withSpan(
+    "db.query.events.free_cancel",
+    "db.query",
+    () =>
+      args.supabase
+        .from("events")
+        .select("start_time")
+        .eq("id", args.eventId)
+        .single(),
+  );
+
+  if (eventError || !eventData) {
+    log({
+      function: FN,
+      level: "error",
+      message: "Failed to fetch event for free cancel",
+      metadata: { detail: eventError },
+    });
+    return fail(500, "이벤트 정보를 가져올 수 없습니다");
+  }
+
+  const windowResult = evaluateFreeCancellationWindow(
+    (eventData as { start_time: string }).start_time,
+    args.now,
+  );
+  if (!windowResult.ok) {
+    return fail(
+      windowResult.status,
+      windowResult.message,
+      windowResult.details,
+    );
+  }
+
+  const { error: updateError } = await withSpan(
+    "db.update.event_applications.cancel",
+    "db.update",
+    () =>
+      args.supabase
+        .from("event_applications")
+        .update({
+          status: "cancelled",
+          cancellation_reason: "user_requested",
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", args.applicationId),
+  );
+
+  if (updateError) {
+    log({
+      function: FN,
+      level: "error",
+      message: "DB Update Error (free cancel)",
+      metadata: { detail: updateError },
+    });
+  }
+
+  logStatsigEvent(args.userId, "order_cancelled", undefined, {
+    event_id: args.eventId,
+    type: "free_cancelled",
+    previous_status: args.previousStatus,
+  }).catch(() => {});
+
+  return { ok: true, type: "cancelled" };
+}
+
+async function refundPaidApplication(args: {
+  supabase: EFContext["supabase"];
+  userId: string;
+  input: CancelOrderInput;
+  application: CancelOrderApplicationSnapshot & {
+    id: string;
+    payment_id: string | null;
+    paid_at: string | null;
+  };
+  amount: number;
+}): Promise<CancelOrderServiceResult> {
+  const [eventResult, policyResult] = await Promise.all([
+    withSpan("db.query.events", "db.query", () =>
+      args.supabase
+        .from("events")
+        .select("start_time")
+        .eq("id", args.input.event_id)
+        .single()),
+    withSpan(
+      "db.rpc.get_current_policy",
+      "db.rpc",
+      () => args.supabase.rpc("get_current_policy", { p_key: "refund" }),
+    ),
+  ]);
+
+  if (eventResult.error || !eventResult.data) {
+    log({
+      function: FN,
+      level: "error",
+      message: "Failed to fetch event",
+      metadata: { detail: eventResult.error },
+    });
+    return fail(500, "Failed to verify refund eligibility");
+  }
+
+  if (policyResult.error || !policyResult.data) {
+    log({
+      function: FN,
+      level: "error",
+      message: "Failed to fetch policy",
+      metadata: { detail: policyResult.error },
+    });
+    return fail(500, "Failed to verify refund eligibility");
+  }
+
+  const policy = parseRefundPolicy(policyResult.data);
+  const eligibility = verifyRefundEligibility({
+    paidAt: args.application.paid_at,
+    eventStartTime: (eventResult.data as { start_time: string }).start_time,
+    ...policy,
+  });
+
+  if (!eligibility.eligible) {
+    return fail(400, "refund_not_eligible", { reason: eligibility.reason });
+  }
+
+  let cancelResponse: Record<string, unknown>;
+  try {
+    cancelResponse = await executeRefund({
+      paymentId: args.application.payment_id as string,
+      reason: args.input.reason || "사용자 예매 취소",
+      amount: args.amount,
+      checksum: args.amount,
+      fnName: FN,
+    });
+  } catch (error) {
+    if (error instanceof RefundError) {
+      return fail(error.status, error.message);
+    }
+    throw error;
+  }
+
+  const refundAmount = args.amount ??
+    (cancelResponse.amount as number | undefined);
+  const nowIso = new Date().toISOString();
+  const updatePayload: Record<string, unknown> = {
+    status: "cancelled",
+    refund_status: "completed",
+    refunded_at: nowIso,
+    cancellation_reason: "user_requested",
+    updated_at: nowIso,
+  };
+  if (refundAmount !== undefined) {
+    updatePayload.refund_amount = refundAmount;
+  }
+
+  const { error: dbError } = await withSpan(
+    "db.update.event_applications.refund",
+    "db.update",
+    () =>
+      args.supabase
+        .from("event_applications")
+        .update(updatePayload)
+        .eq("id", args.application.id),
+  );
+
+  if (dbError) {
+    log({
+      function: FN,
+      level: "error",
+      message: "DB Update Error",
+      metadata: { detail: dbError },
+    });
+  }
+
+  logStatsigEvent(args.userId, "order_cancelled", refundAmount, {
+    event_id: args.input.event_id,
+    type: "refunded",
+    previous_status: args.application.status,
+  }).catch(() => {});
+
+  return { ok: true, type: "refunded", refundAmount };
+}
+
+function fail(
+  status: number,
+  message: string,
+  details?: unknown,
+): Extract<CancelOrderServiceResult, { ok: false }> {
+  return { ok: false, status, message, details };
+}

--- a/supabase/functions/user-cancel-order/deno.json
+++ b/supabase/functions/user-cancel-order/deno.json
@@ -1,5 +1,7 @@
 {
   "imports": {
+    "@std/assert": "jsr:@std/assert@1",
+    "@std/testing/mock": "jsr:@std/testing@1/mock",
     "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
   }
 }

--- a/supabase/functions/user-cancel-order/index.ts
+++ b/supabase/functions/user-cancel-order/index.ts
@@ -1,312 +1,55 @@
 // Fix #2185 (Batch 5): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
+import { errorResponse, successResponse } from "../_shared/response_utils.ts";
 import {
-  errorResponse,
-  successResponse,
-} from "../_shared/response_utils.ts";
-import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
+  type EFContext,
+  minglitEdgeFunction,
+} from "../_shared/edge_function.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { log, withSpan } from "../_shared/logger.ts";
-import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
-import { executeRefund, RefundError } from "../_shared/refund_utils.ts";
-import {
-  classifyApplicationStatus,
-  isFreeApplication,
-} from "../_shared/domains/payment/application_status.ts";
-import {
-  parseRefundPolicy,
-  verifyRefundEligibility,
-} from "../_shared/domains/payment/refund_policy.ts";
-import { isEventStarted } from "../_shared/domains/event/availability.ts";
+import { log } from "../_shared/logger.ts";
+import { initStatsig } from "../_shared/statsig_utils.ts";
+import { cancelOrder } from "./cancel_order_service.ts";
+import { parseCancelOrderInput } from "./input.ts";
 
 const FN = "user-cancel-order";
 
 initStatsig();
 
-export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
-  if (ctx.auth.type !== "user") return errorResponse("Unexpected auth type", 500);
-  const userId = ctx.auth.userId;
-  const { supabase } = ctx;
+export const handler = async (
+  req: Request,
+  ctx: EFContext,
+): Promise<Response> => {
+  if (ctx.auth.type !== "user") {
+    return errorResponse("Unexpected auth type", 500);
+  }
 
   try {
-    // 1. Parse Request
     const body = await parseJsonBody(req);
     if (body instanceof Response) return body;
 
-    const { event_id, reason } = body as {
-      event_id?: string;
-      reason?: string;
-    };
+    const input = parseCancelOrderInput(body);
+    if (input instanceof Response) return input;
 
-    if (!event_id) {
-      return errorResponse("Missing required field: event_id", 400);
+    const result = await cancelOrder({
+      supabase: ctx.supabase,
+      userId: ctx.auth.userId,
+      input,
+    });
+
+    if (!result.ok) {
+      return errorResponse(result.message, result.status, result.details);
     }
 
-    // 2. Fetch application by (event_id, user_id)
-    const { data: application, error: appError } = await withSpan(
-      "db.query.event_applications",
-      "db.query",
-      () =>
-        supabase
-          .from("event_applications")
-          .select(
-            "id, status, payment_id, payment_amount, paid_at, refund_status, event_id, user_id",
-          )
-          .eq("event_id", event_id)
-          .eq("user_id", userId)
-          .single(),
-    );
-
-    if (appError || !application) {
-      return errorResponse("해당 이벤트에 신청 내역이 없습니다", 404);
-    }
-
-    // 3. Status validation + classify
-    const { status } = application;
-    const { isPaid, isPrePayment, isFinal } = classifyApplicationStatus(status);
-    if (isFinal) {
-      return errorResponse("이미 취소/거절된 신청입니다", 400);
-    }
-
-    if (isPrePayment) {
-      // Pre-payment cancellation: delete verification_submissions + delete application
-      await withSpan(
-        "db.delete.verification_submissions",
-        "db.delete",
-        () =>
-          supabase
-            .from("verification_submissions")
-            .delete()
-            .eq("application_id", application.id)
-            .eq("status", "pending"),
-      );
-
-      await withSpan(
-        "db.delete.event_applications",
-        "db.delete",
-        () =>
-          supabase
-            .from("event_applications")
-            .delete()
-            .eq("id", application.id),
-      );
-
-      logStatsigEvent(userId, "order_cancelled", undefined, {
-        event_id,
-        type: "pre_payment",
-        previous_status: status,
-      }).catch(() => {});
-
-      return successResponse({ success: true, type: "cancelled" });
-    }
-
-    if (isPaid) {
-      const paymentAmount = application.payment_amount as number | null;
-
-      // Fix #1652: payment_amount=null means damaged data — reject, do not treat as free.
-      if (paymentAmount === null) {
-        log({
-          function: FN,
-          level: "error",
-          message: "Damaged data: payment_amount=null on paid application",
-          metadata: { application_id: application.id },
-        });
-        return errorResponse("결제 정보가 손상된 신청입니다", 400);
-      }
-
-      // Free event (payment_amount === 0): verify event hasn't started, then cancel.
-      if (isFreeApplication(paymentAmount)) {
-        const { data: eventData, error: eventError } = await withSpan(
-          "db.query.events.free_cancel",
-          "db.query",
-          () =>
-            supabase
-              .from("events")
-              .select("start_time")
-              .eq("id", event_id)
-              .single(),
-        );
-
-        if (eventError || !eventData) {
-          log({
-            function: FN,
-            level: "error",
-            message: "Failed to fetch event for free cancel",
-            metadata: { detail: eventError },
-          });
-          return errorResponse("이벤트 정보를 가져올 수 없습니다", 500);
-        }
-
-        if (isEventStarted(eventData.start_time)) {
-          return errorResponse("refund_not_eligible", 400, {
-            reason: "event_already_started",
-          });
-        }
-
-        const { error: updateError } = await withSpan(
-          "db.update.event_applications.cancel",
-          "db.update",
-          () =>
-            supabase
-              .from("event_applications")
-              .update({
-                status: "cancelled",
-                // Fix #2099: 취소 사유 기록 — system vs user 구분
-                cancellation_reason: "user_requested",
-                updated_at: new Date().toISOString(),
-              })
-              .eq("id", application.id),
-        );
-
-        if (updateError) {
-          log({
-            function: FN,
-            level: "error",
-            message: "DB Update Error (free cancel)",
-            metadata: { detail: updateError },
-          });
-        }
-
-        logStatsigEvent(userId, "order_cancelled", undefined, {
-          event_id,
-          type: "free_cancelled",
-          previous_status: status,
-        }).catch(() => {});
-
-        return successResponse({ success: true, type: "cancelled" });
-      }
-
-      // Paid event: check refund eligibility
-      if (application.refund_status !== "none") {
-        return errorResponse("already_refunded", 400, {
-          reason: "Refund already processed",
-        });
-      }
-
-      // Fetch event + refund policy
-      const [eventResult, policyResult] = await Promise.all([
-        withSpan("db.query.events", "db.query", () =>
-          supabase
-            .from("events")
-            .select("start_time")
-            .eq("id", event_id)
-            .single()),
-        withSpan(
-          "db.rpc.get_current_policy",
-          "db.rpc",
-          () => supabase.rpc("get_current_policy", { p_key: "refund" }),
-        ),
-      ]);
-
-      if (eventResult.error || !eventResult.data) {
-        log({
-          function: FN,
-          level: "error",
-          message: "Failed to fetch event",
-          metadata: { detail: eventResult.error },
-        });
-        return errorResponse("Failed to verify refund eligibility", 500);
-      }
-
-      if (policyResult.error || !policyResult.data) {
-        log({
-          function: FN,
-          level: "error",
-          message: "Failed to fetch policy",
-          metadata: { detail: policyResult.error },
-        });
-        return errorResponse("Failed to verify refund eligibility", 500);
-      }
-
-      const policy = parseRefundPolicy(policyResult.data);
-      const eligibility = verifyRefundEligibility({
-        paidAt: application.paid_at as string | null,
-        eventStartTime: eventResult.data.start_time,
-        ...policy,
-      });
-
-      if (!eligibility.eligible) {
-        return errorResponse("refund_not_eligible", 400, {
-          reason: eligibility.reason,
-        });
-      }
-
-      // Execute refund via PortOne
-      let cancelResponse: Record<string, unknown>;
-      try {
-        cancelResponse = await executeRefund({
-          paymentId: application.payment_id as string,
-          reason: reason || "사용자 예매 취소",
-          amount: paymentAmount,
-          checksum: paymentAmount,
-          fnName: FN,
-        });
-      } catch (e) {
-        if (e instanceof RefundError) {
-          return errorResponse(e.message, e.status);
-        }
-        throw e;
-      }
-
-      // Update DB: status=cancelled + refund_status + refund_amount
-      // Fix #1515: Set status='cancelled' so on_application_cancel trigger removes event_participants
-      const refundAmount = paymentAmount ??
-        (cancelResponse.amount as number | undefined);
-      const nowISO = new Date().toISOString();
-      const updatePayload: Record<string, unknown> = {
-        status: "cancelled",
-        refund_status: "completed",
-        // Fix #2099: 환불 처리 시점 + 취소 사유 기록
-        refunded_at: nowISO,
-        cancellation_reason: "user_requested",
-        updated_at: nowISO,
-      };
-      if (refundAmount !== undefined) {
-        updatePayload.refund_amount = refundAmount;
-      }
-
-      const { error: dbError } = await withSpan(
-        "db.update.event_applications.refund",
-        "db.update",
-        () =>
-          supabase
-            .from("event_applications")
-            .update(updatePayload)
-            .eq("id", application.id),
-      );
-
-      if (dbError) {
-        log({
-          function: FN,
-          level: "error",
-          message: "DB Update Error",
-          metadata: { detail: dbError },
-        });
-        // Non-fatal: payment was already refunded
-      }
-
-      logStatsigEvent(userId, "order_cancelled", refundAmount, {
-        event_id,
-        type: "refunded",
-        previous_status: status,
-      }).catch(() => {});
-
+    if (result.type === "refunded") {
       return successResponse({
         success: true,
         type: "refunded",
-        data: { refund_amount: refundAmount },
+        data: { refund_amount: result.refundAmount },
       });
     }
 
-    // Unhandled status
-    log({
-      function: FN,
-      level: "error",
-      message: `Unhandled status: ${status}`,
-      metadata: { application_id: application.id },
-    });
-    return errorResponse("지원하지 않는 신청 상태입니다", 400);
-  } catch (e) {
-    const message = e instanceof Error ? e.message : String(e);
+    return successResponse({ success: true, type: "cancelled" });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
     log({
       function: FN,
       level: "error",

--- a/supabase/functions/user-cancel-order/index_test.ts
+++ b/supabase/functions/user-cancel-order/index_test.ts
@@ -3,28 +3,35 @@
 // Lazy-loads the handler via dynamic import with Deno.serve stubbed to prevent
 // a real HTTP server from being started (same pattern as payment-webhook/index_test.ts).
 
-import { assertEquals } from "jsr:@std/assert@1";
+import { assertEquals } from "@std/assert";
 import {
   buildApplication,
   fakeSupabase,
+  type Handler,
   makeCtx,
   readJson,
   runHandler,
-  type Handler,
 } from "../_shared/_testing/mod.ts";
 
 let _handler: Handler | null = null;
 async function getHandler(): Promise<Handler> {
   if (_handler) return _handler;
-  const denoAsAny = Deno as unknown as { serve: (...args: unknown[]) => Deno.HttpServer };
+  const denoAsAny = Deno as unknown as {
+    serve: (...args: unknown[]) => Deno.HttpServer;
+  };
   const origServe = denoAsAny.serve;
-  denoAsAny.serve = () => ({ shutdown() {}, finished: Promise.resolve() } as Deno.HttpServer);
+  denoAsAny.serve =
+    () => ({ shutdown() {}, finished: Promise.resolve() } as Deno.HttpServer);
   const origSetInterval = globalThis.setInterval;
   const origClearInterval = globalThis.clearInterval;
-  globalThis.setInterval = ((_cb: () => void) => 0 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
-  globalThis.clearInterval = ((_id?: ReturnType<typeof setInterval>) => {}) as typeof clearInterval;
+  globalThis.setInterval =
+    ((_cb: () => void) =>
+      0 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
+  globalThis.clearInterval =
+    ((_id?: ReturnType<typeof setInterval>) => {}) as typeof clearInterval;
   try {
-    _handler = (await import(`./index.ts?unit=${crypto.randomUUID()}`)).handler as Handler;
+    _handler = (await import(`./index.ts?unit=${crypto.randomUUID()}`))
+      .handler as Handler;
   } finally {
     denoAsAny.serve = origServe;
     globalThis.setInterval = origSetInterval;
@@ -70,7 +77,9 @@ Deno.test("user-cancel-order :: status=cancelled (final) → 400", async () => {
 Deno.test("user-cancel-order :: status=pending (pre-payment) → 200 + 2 deletes", async () => {
   const handler = await getHandler();
   const sb = fakeSupabase()
-    .on("event_applications", "select", { data: buildApplication({ status: "pending" }) })
+    .on("event_applications", "select", {
+      data: buildApplication({ status: "pending" }),
+    })
     .on("verification_submissions", "delete", { error: null })
     .on("event_applications", "delete", { error: null });
   const res = await runHandler(handler, {
@@ -126,7 +135,9 @@ Deno.test("user-cancel-order :: free event but 이벤트 이미 시작 → 400 (
     ctx: makeCtx({ supabase: sb, userId: "u-1" }),
   });
   assertEquals(res.status, 400);
-  const body = await readJson<{ error: string; details?: { reason?: string } }>(res);
+  const body = await readJson<{ error: string; details?: { reason?: string } }>(
+    res,
+  );
   assertEquals(body.error, "refund_not_eligible");
   assertEquals(body.details?.reason, "event_already_started");
 });

--- a/supabase/functions/user-cancel-order/index_test.ts
+++ b/supabase/functions/user-cancel-order/index_test.ts
@@ -12,31 +12,14 @@ import {
   readJson,
   runHandler,
 } from "../_shared/_testing/mod.ts";
+import { importHandlerWithStubbedServe } from "../_test_utils/mock_http.ts";
 
 let _handler: Handler | null = null;
 async function getHandler(): Promise<Handler> {
   if (_handler) return _handler;
-  const denoAsAny = Deno as unknown as {
-    serve: (...args: unknown[]) => Deno.HttpServer;
-  };
-  const origServe = denoAsAny.serve;
-  denoAsAny.serve =
-    () => ({ shutdown() {}, finished: Promise.resolve() } as Deno.HttpServer);
-  const origSetInterval = globalThis.setInterval;
-  const origClearInterval = globalThis.clearInterval;
-  globalThis.setInterval =
-    ((_cb: () => void) =>
-      0 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
-  globalThis.clearInterval =
-    ((_id?: ReturnType<typeof setInterval>) => {}) as typeof clearInterval;
-  try {
-    _handler = (await import(`./index.ts?unit=${crypto.randomUUID()}`))
-      .handler as Handler;
-  } finally {
-    denoAsAny.serve = origServe;
-    globalThis.setInterval = origSetInterval;
-    globalThis.clearInterval = origClearInterval;
-  }
+  _handler = await importHandlerWithStubbedServe<Handler>(
+    new URL("./index.ts", import.meta.url),
+  );
   return _handler!;
 }
 

--- a/supabase/functions/user-cancel-order/input.ts
+++ b/supabase/functions/user-cancel-order/input.ts
@@ -1,0 +1,24 @@
+import { errorResponse } from "../_shared/response_utils.ts";
+
+export interface CancelOrderInput {
+  event_id: string;
+  reason?: string;
+}
+
+export function parseCancelOrderInput(
+  body: Record<string, unknown>,
+): CancelOrderInput | Response {
+  const eventId = body.event_id;
+  if (typeof eventId !== "string" || eventId.length === 0) {
+    return errorResponse("Missing required field: event_id", 400);
+  }
+
+  const reason = body.reason;
+  if (reason !== undefined && typeof reason !== "string") {
+    return errorResponse("Invalid field: reason", 400);
+  }
+
+  return reason === undefined
+    ? { event_id: eventId }
+    : { event_id: eventId, reason };
+}

--- a/supabase/functions/user-create-order/BLUEDOC.md
+++ b/supabase/functions/user-create-order/BLUEDOC.md
@@ -1,0 +1,30 @@
+# user-create-order
+
+유저가 이벤트 티켓으로 신청/order 를 생성하는 Edge Function. 결제 전 핵심
+business rule 을 검증한다.
+
+## 이정표
+
+| 파일                                                   | 역할                                                                     |
+| ------------------------------------------------------ | ------------------------------------------------------------------------ |
+| [index.ts](index.ts)                                   | user auth 확인, request parse, service 호출, HTTP response mapping       |
+| [input.ts](input.ts)                                   | request body schema/type validation                                      |
+| [create_order_service.ts](create_order_service.ts)     | event/ticket/profile 조회, policy 적용, RPC/update/Statsig orchestration |
+| [index_test.ts](index_test.ts)                         | L3 handler unit test (`fakeSupabase`)                                    |
+| [user_create_order_test.ts](user_create_order_test.ts) | HTTP wrapper/integration-style test                                      |
+
+## 핵심 컨벤션
+
+- business rule 은 `_shared/domains/order/create_order_policy.ts` 에 먼저
+  추가한다.
+- DB/RPC 순서와 fail-open/fail-closed 결정은 service test 로 고정한다.
+- application/order write 원자성은 최종적으로 Postgres RPC 로 이동한다.
+
+## 관련
+
+- [../architecture.md](../architecture.md) — EF 표준 레이어
+- [../_shared/domains/order/BLUEDOC.md](../_shared/domains/order/BLUEDOC.md)
+
+---
+
+_Reviewed: 2026-05-24 00:00_

--- a/supabase/functions/user-create-order/create_order_service.ts
+++ b/supabase/functions/user-create-order/create_order_service.ts
@@ -1,0 +1,280 @@
+import type { EFContext } from "../_shared/edge_function.ts";
+import { log, withSpan } from "../_shared/logger.ts";
+import { logStatsigEvent } from "../_shared/statsig_utils.ts";
+import {
+  type CreateOrderEntryGroupSnapshot,
+  type CreateOrderEventSnapshot,
+  type CreateOrderExistingApplicationSnapshot,
+  type CreateOrderPolicyResult,
+  type CreateOrderTicketSnapshot,
+  type CreateOrderUserProfileSnapshot,
+  decideCreateOrderPaymentPlan,
+  evaluateEntryGroupEligibility,
+  evaluateEventApplicationWindow,
+  evaluateEventCapacity,
+  evaluateIdentity,
+  evaluatePartyBalance,
+  evaluateReapplication,
+  evaluateTicketAvailability,
+} from "../_shared/domains/order/create_order_policy.ts";
+import type { CreateOrderInput } from "./input.ts";
+
+const FN = "user-create-order";
+
+export type CreateOrderServiceResult =
+  | {
+    ok: true;
+    applicationId: string;
+    amount: number;
+    requiresPayment: boolean;
+    ticketName: string;
+  }
+  | CreateOrderServiceFailure;
+
+export interface CreateOrderServiceFailure {
+  ok: false;
+  status: number;
+  message: string;
+  code?: string;
+}
+
+export async function createApplicationOrder(args: {
+  supabase: EFContext["supabase"];
+  userId: string;
+  input: CreateOrderInput;
+  now?: Date;
+}): Promise<CreateOrderServiceResult> {
+  const { supabase, userId, input } = args;
+  const now = args.now ?? new Date();
+
+  const { data: event, error: eventError } = await withSpan(
+    "db.query.events",
+    "db.query",
+    () =>
+      supabase
+        .from("events")
+        .select(
+          "id, party_id, status, start_time, max_participants, current_participants",
+        )
+        .eq("id", input.event_id)
+        .single(),
+  );
+
+  if (eventError || !event) {
+    return fail(404, "이벤트를 찾을 수 없습니다.");
+  }
+
+  const eventPolicy = evaluateEventApplicationWindow(
+    event as CreateOrderEventSnapshot,
+    now,
+  );
+  if (!eventPolicy.ok) return fromPolicy(eventPolicy);
+
+  const { data: ticket, error: ticketError } = await withSpan(
+    "db.query.tickets",
+    "db.query",
+    () =>
+      supabase
+        .from("tickets")
+        .select(
+          "id, event_id, name, price, quantity, sold_count, target_entry_group_ids",
+        )
+        .eq("id", input.ticket_id)
+        .single(),
+  );
+
+  if (ticketError || !ticket) {
+    return fail(404, "티켓을 찾을 수 없습니다.");
+  }
+
+  const ticketPolicy = evaluateTicketAvailability(
+    ticket as CreateOrderTicketSnapshot,
+    input.event_id,
+  );
+  if (!ticketPolicy.ok) return fromPolicy(ticketPolicy);
+
+  const capacityPolicy = evaluateEventCapacity(
+    event as CreateOrderEventSnapshot,
+  );
+  if (!capacityPolicy.ok) return fromPolicy(capacityPolicy);
+
+  const { data: userProfile, error: profileError } = await withSpan(
+    "db.query.user_profiles",
+    "db.query",
+    () =>
+      supabase
+        .from("user_profiles")
+        .select("id, is_verified, gender, birth_date")
+        .eq("id", userId)
+        .single(),
+  );
+
+  if (profileError || !userProfile) {
+    return fail(404, "사용자 프로필을 찾을 수 없습니다.");
+  }
+
+  const profile = userProfile as CreateOrderUserProfileSnapshot;
+  const identityPolicy = evaluateIdentity(profile);
+  if (!identityPolicy.ok) return fromPolicy(identityPolicy);
+
+  const targetGroupIds: string[] = Array.isArray(ticket.target_entry_group_ids)
+    ? ticket.target_entry_group_ids
+    : [];
+  if (targetGroupIds.length > 0) {
+    const { data: entryGroups } = await withSpan(
+      "db.query.entry_groups",
+      "db.query",
+      () =>
+        supabase
+          .from("entry_groups")
+          .select(
+            "id, gender, birth_year_min, birth_year_max, required_verification_ids",
+          )
+          .eq("event_id", input.event_id)
+          .in("id", targetGroupIds),
+    );
+
+    const eligibilityPolicy = evaluateEntryGroupEligibility({
+      profile,
+      entryGroups: Array.isArray(entryGroups)
+        ? entryGroups as CreateOrderEntryGroupSnapshot[]
+        : [],
+      verificationData: input.verification_data,
+    });
+    if (!eligibilityPolicy.ok) return fromPolicy(eligibilityPolicy);
+  }
+
+  const { data: balanceResult, error: balanceError } = await withSpan(
+    "db.rpc.check_party_balance",
+    "db.rpc",
+    () =>
+      supabase.rpc("check_party_balance", {
+        p_event_id: input.event_id,
+        p_ticket_id: input.ticket_id,
+      }),
+  );
+
+  if (balanceError) {
+    log({
+      function: FN,
+      level: "error",
+      message: "check_party_balance error",
+      metadata: { detail: balanceError },
+    });
+  }
+
+  const balancePolicy = evaluatePartyBalance(
+    isRecord(balanceResult) ? balanceResult as { allowed?: boolean } : null,
+  );
+  if (!balancePolicy.ok) return fromPolicy(balancePolicy);
+
+  const { data: existingApp } = await withSpan(
+    "db.query.existing_application",
+    "db.query",
+    () =>
+      supabase
+        .from("event_applications")
+        .select("id, status")
+        .eq("event_id", input.event_id)
+        .eq("user_id", userId)
+        .single(),
+  );
+
+  const existingApplication = isRecord(existingApp)
+    ? existingApp as CreateOrderExistingApplicationSnapshot & { id?: string }
+    : null;
+  const reapplicationPolicy = evaluateReapplication(existingApplication);
+  if (!reapplicationPolicy.ok) return fromPolicy(reapplicationPolicy);
+
+  const paymentPlan = decideCreateOrderPaymentPlan(
+    ticket as CreateOrderTicketSnapshot,
+  );
+  const pendingPaymentId = `PENDING_${crypto.randomUUID()}`;
+
+  const { data: appId, error: applyError } = await withSpan(
+    "db.rpc.apply_event",
+    "db.rpc",
+    () =>
+      supabase.rpc("apply_event", {
+        p_event_id: input.event_id,
+        p_ticket_id: input.ticket_id,
+        p_user_id: userId,
+        p_payment_id: pendingPaymentId,
+        p_payment_amount: paymentPlan.amount,
+        p_verification_data: input.verification_data ?? null,
+      }),
+  );
+
+  if (applyError) {
+    log({
+      function: FN,
+      level: "error",
+      message: "apply_event error",
+      metadata: { detail: applyError },
+    });
+    return fail(500, "주문 생성 중 오류가 발생했습니다.");
+  }
+
+  const applicationId = String(appId);
+  const updatePayload: Record<string, unknown> = {
+    status: paymentPlan.initialStatus,
+    payment_id: pendingPaymentId,
+    payment_amount: paymentPlan.amount,
+    updated_at: now.toISOString(),
+  };
+  if (existingApplication) {
+    updatePayload.ticket_id = input.ticket_id;
+  }
+
+  const { error: updateError } = await withSpan(
+    existingApplication
+      ? "db.update.event_applications"
+      : "db.update.event_applications.status",
+    "db.update",
+    () =>
+      supabase
+        .from("event_applications")
+        .update(updatePayload)
+        .eq("id", applicationId),
+  );
+
+  if (updateError) {
+    log({
+      function: FN,
+      level: "error",
+      message: "event_applications update error",
+      metadata: { detail: updateError },
+    });
+    return fail(500, "주문 생성 중 오류가 발생했습니다.");
+  }
+
+  logStatsigEvent(userId, "order_created", paymentPlan.amount, {
+    event_id: input.event_id,
+    ticket_id: input.ticket_id,
+    requires_payment: String(paymentPlan.requiresPayment),
+  }).catch(() => {});
+
+  return {
+    ok: true,
+    applicationId,
+    amount: paymentPlan.amount,
+    requiresPayment: paymentPlan.requiresPayment,
+    ticketName: String((ticket as { name?: unknown }).name ?? ""),
+  };
+}
+
+function fromPolicy(result: Exclude<CreateOrderPolicyResult, { ok: true }>) {
+  return fail(result.status, result.message, result.code);
+}
+
+function fail(
+  status: number,
+  message: string,
+  code?: string,
+): CreateOrderServiceFailure {
+  return { ok: false, status, message, code };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/supabase/functions/user-create-order/index.ts
+++ b/supabase/functions/user-create-order/index.ts
@@ -1,320 +1,54 @@
 // Fix #2185 (Batch 5): migrate to minglitEdgeFunction wrapper — auth via manifest (user caller)
+import { errorResponse, successResponse } from "../_shared/response_utils.ts";
 import {
-  errorResponse,
-  successResponse,
-} from "../_shared/response_utils.ts";
-import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
+  type EFContext,
+  minglitEdgeFunction,
+} from "../_shared/edge_function.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
-import { log, withSpan } from "../_shared/logger.ts";
-import { initStatsig, logStatsigEvent } from "../_shared/statsig_utils.ts";
-import {
-  isEventFull,
-  isEventOpenForApplication,
-  isEventStarted,
-  isTicketSoldOut,
-} from "../_shared/domains/event/availability.ts";
-import { blocksReapplication } from "../_shared/domains/payment/application_status.ts";
+import { log } from "../_shared/logger.ts";
+import { initStatsig } from "../_shared/statsig_utils.ts";
+import { createApplicationOrder } from "./create_order_service.ts";
+import { parseCreateOrderInput } from "./input.ts";
 
 const FN = "user-create-order";
 
 initStatsig();
 
-export const handler = async (req: Request, ctx: EFContext): Promise<Response> => {
-  if (ctx.auth.type !== "user") return errorResponse("Unexpected auth type", 500);
-  const userId = ctx.auth.userId;
-  const { supabase } = ctx;
+export const handler = async (
+  req: Request,
+  ctx: EFContext,
+): Promise<Response> => {
+  if (ctx.auth.type !== "user") {
+    return errorResponse("Unexpected auth type", 500);
+  }
 
   try {
     const body = await parseJsonBody(req);
     if (body instanceof Response) return body;
 
-    const { event_id, ticket_id, verification_data } = body as {
-      event_id?: string;
-      ticket_id?: string;
-      verification_data?: {
-        verification_id: string;
-        data: Record<string, unknown>;
-      };
-    };
+    const input = parseCreateOrderInput(body);
+    if (input instanceof Response) return input;
 
-    // 1. Input validation
-    if (!event_id) {
-      return errorResponse("Missing required field: event_id", 400);
-    }
-    if (!ticket_id) {
-      return errorResponse("Missing required field: ticket_id", 400);
-    }
+    const result = await createApplicationOrder({
+      supabase: ctx.supabase,
+      userId: ctx.auth.userId,
+      input,
+    });
 
-    // 2. Fetch event
-    const { data: event, error: eventError } = await withSpan(
-      "db.query.events",
-      "db.query",
-      () =>
-        supabase
-          .from("events")
-          .select(
-            "id, party_id, status, start_time, max_participants, current_participants",
-          )
-          .eq("id", event_id)
-          .single(),
-    );
-
-    if (eventError || !event) {
-      return errorResponse("이벤트를 찾을 수 없습니다.", 404);
-    }
-
-    // Fix #998: active 상태 이벤트도 신청 허용
-    if (!isEventOpenForApplication(event.status)) {
-      return errorResponse("이벤트가 마감되었습니다.", 400, {
-        code: "EVENT_CLOSED",
-      });
-    }
-
-    if (isEventStarted(event.start_time)) {
-      return errorResponse("이벤트가 마감되었습니다.", 400, {
-        code: "EVENT_NOT_SCHEDULED",
-      });
-    }
-
-    // 3. Fetch ticket and verify it belongs to the event
-    const { data: ticket, error: ticketError } = await withSpan(
-      "db.query.tickets",
-      "db.query",
-      () =>
-        supabase
-          .from("tickets")
-          .select(
-            "id, event_id, name, price, quantity, sold_count, target_entry_group_ids",
-          )
-          .eq("id", ticket_id)
-          .single(),
-    );
-
-    if (ticketError || !ticket) {
-      return errorResponse("티켓을 찾을 수 없습니다.", 404);
-    }
-
-    if (ticket.event_id !== event_id) {
-      return errorResponse("티켓을 찾을 수 없습니다.", 404);
-    }
-
-    // 4. Check ticket availability
-    if (isTicketSoldOut(ticket.sold_count, ticket.quantity)) {
-      return errorResponse("티켓이 매진되었습니다.", 400, {
-        code: "TICKET_SOLD_OUT",
-      });
-    }
-
-    // 5. Check event capacity
-    if (isEventFull(event.current_participants, event.max_participants)) {
-      return errorResponse("정원이 초과되었습니다.", 400, {
-        code: "EVENT_FULL",
-      });
-    }
-
-    // 6. Fetch user profile
-    const { data: userProfile, error: profileError } = await withSpan(
-      "db.query.user_profiles",
-      "db.query",
-      () =>
-        supabase
-          .from("user_profiles")
-          .select("id, is_verified, gender, birth_date")
-          .eq("id", userId)
-          .single(),
-    );
-
-    if (profileError || !userProfile) {
-      return errorResponse("사용자 프로필을 찾을 수 없습니다.", 404);
-    }
-
-    // 7. Check identity verification
-    if (!userProfile.is_verified) {
-      return errorResponse("본인인증이 필요합니다.", 400, {
-        code: "IDENTITY_REQUIRED",
-      });
-    }
-
-    // 8. Check entry group eligibility (gender/age)
-    const targetGroupIds: string[] = ticket.target_entry_group_ids ?? [];
-    if (targetGroupIds.length > 0) {
-      const { data: entryGroups } = await withSpan(
-        "db.query.entry_groups",
-        "db.query",
-        () =>
-          supabase
-            .from("entry_groups")
-            .select(
-              "id, gender, birth_year_min, birth_year_max, required_verification_ids",
-            )
-            .eq("event_id", event_id)
-            .in("id", targetGroupIds),
-      );
-
-      if (entryGroups && entryGroups.length > 0) {
-        const group = entryGroups[0];
-
-        // Gender check
-        if (
-          group.gender && userProfile.gender &&
-          group.gender !== userProfile.gender
-        ) {
-          return errorResponse("성별 조건이 맞지 않습니다.", 400, {
-            code: "GENDER_MISMATCH",
-          });
-        }
-
-        // Age check
-        if (userProfile.birth_date) {
-          const birthYear = new Date(userProfile.birth_date).getFullYear();
-          if (group.birth_year_min && birthYear < group.birth_year_min) {
-            return errorResponse("나이 조건이 맞지 않습니다.", 400, {
-              code: "AGE_MISMATCH",
-            });
-          }
-          if (group.birth_year_max && birthYear > group.birth_year_max) {
-            return errorResponse("나이 조건이 맞지 않습니다.", 400, {
-              code: "AGE_MISMATCH",
-            });
-          }
-        }
-
-        // Required verification check
-        const requiredIds: string[] = entryGroups
-          .flatMap((g: { required_verification_ids?: string[] }) =>
-            g.required_verification_ids ?? []
-          );
-        if (requiredIds.length > 0 && !verification_data) {
-          return errorResponse("자격 인증 정보가 필요합니다.", 400, {
-            code: "VERIFICATION_REQUIRED",
-          });
-        }
-      }
-    }
-
-    // 9. Check party balance (gender balance)
-    const { data: balanceResult, error: balanceError } = await withSpan(
-      "db.rpc.check_party_balance",
-      "db.rpc",
-      () =>
-        supabase.rpc("check_party_balance", {
-          p_event_id: event_id,
-          p_ticket_id: ticket_id,
-        }),
-    );
-
-    if (balanceError) {
-      log({
-        function: FN,
-        level: "error",
-        message: "check_party_balance error",
-        metadata: { detail: balanceError },
-      });
-    }
-
-    if (balanceResult && balanceResult.allowed === false) {
-      return errorResponse("성비 균형 제한입니다.", 400, {
-        code: "BALANCE_LIMIT",
-      });
-    }
-
-    // 10. Check duplicate application
-    const { data: existingApp } = await withSpan(
-      "db.query.existing_application",
-      "db.query",
-      () =>
-        supabase
-          .from("event_applications")
-          .select("id, status")
-          .eq("event_id", event_id)
-          .eq("user_id", userId)
-          .single(),
-    );
-
-    if (existingApp && blocksReapplication(existingApp.status)) {
-      return errorResponse("이미 신청한 이벤트입니다.", 400, {
-        code: "ALREADY_APPLIED",
-      });
-    }
-
-    // 11. Determine status based on price
-    const amount = ticket.price;
-    const requiresPayment = amount > 0;
-    const pendingPaymentId = `PENDING_${Date.now()}`;
-    const initialStatus = requiresPayment ? "pending" : "paid";
-
-    // 12. Create or update application via apply_event RPC
-    const { data: appId, error: applyError } = await withSpan(
-      "db.rpc.apply_event",
-      "db.rpc",
-      () =>
-        supabase.rpc("apply_event", {
-          p_event_id: event_id,
-          p_ticket_id: ticket_id,
-          p_user_id: userId,
-          p_payment_id: pendingPaymentId,
-          p_payment_amount: amount,
-          p_verification_data: verification_data ?? null,
-        }),
-    );
-
-    if (applyError) {
-      log({
-        function: FN,
-        level: "error",
-        message: "apply_event error",
-        metadata: { detail: applyError },
-      });
-      return errorResponse("주문 생성 중 오류가 발생했습니다.", 500);
-    }
-
-    // If existing cancelled/failed app was reused, update it
-    if (existingApp) {
-      await withSpan(
-        "db.update.event_applications",
-        "db.update",
-        () =>
-          supabase
-            .from("event_applications")
-            .update({
-              status: initialStatus,
-              payment_id: pendingPaymentId,
-              ticket_id: ticket_id,
-              payment_amount: amount,
-              updated_at: new Date().toISOString(),
-            })
-            .eq("id", appId),
-      );
-    } else {
-      // Set status to pending (for paid) or paid (for free)
-      await withSpan(
-        "db.update.event_applications.status",
-        "db.update",
-        () =>
-          supabase
-            .from("event_applications")
-            .update({
-              status: initialStatus,
-              payment_id: pendingPaymentId,
-              payment_amount: amount,
-              updated_at: new Date().toISOString(),
-            })
-            .eq("id", appId),
+    if (!result.ok) {
+      return errorResponse(
+        result.message,
+        result.status,
+        result.code ? { code: result.code } : undefined,
       );
     }
-
-    logStatsigEvent(userId, "order_created", amount, {
-      event_id,
-      ticket_id,
-      requires_payment: String(requiresPayment),
-    }).catch(() => {});
 
     return successResponse({
       success: true,
-      application_id: appId,
-      amount,
-      requires_payment: requiresPayment,
-      ticket_name: ticket.name,
+      application_id: result.applicationId,
+      amount: result.amount,
+      requires_payment: result.requiresPayment,
+      ticket_name: result.ticketName,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/supabase/functions/user-create-order/index_test.ts
+++ b/supabase/functions/user-create-order/index_test.ts
@@ -3,31 +3,38 @@
 // Lazy-loads the handler via dynamic import with Deno.serve stubbed to prevent
 // a real HTTP server from being started (same pattern as payment-webhook/index_test.ts).
 
-import { assertEquals } from "jsr:@std/assert@1";
+import { assertEquals } from "@std/assert";
 import {
   buildApplication,
   buildEvent,
   buildTicket,
   buildUserProfile,
   fakeSupabase,
+  type Handler,
   makeCtx,
   readJson,
   runHandler,
-  type Handler,
 } from "../_shared/_testing/mod.ts";
 
 let _handler: Handler | null = null;
 async function getHandler(): Promise<Handler> {
   if (_handler) return _handler;
-  const denoAsAny = Deno as unknown as { serve: (...args: unknown[]) => Deno.HttpServer };
+  const denoAsAny = Deno as unknown as {
+    serve: (...args: unknown[]) => Deno.HttpServer;
+  };
   const origServe = denoAsAny.serve;
-  denoAsAny.serve = () => ({ shutdown() {}, finished: Promise.resolve() } as Deno.HttpServer);
+  denoAsAny.serve =
+    () => ({ shutdown() {}, finished: Promise.resolve() } as Deno.HttpServer);
   const origSetInterval = globalThis.setInterval;
   const origClearInterval = globalThis.clearInterval;
-  globalThis.setInterval = ((_cb: () => void) => 0 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
-  globalThis.clearInterval = ((_id?: ReturnType<typeof setInterval>) => {}) as typeof clearInterval;
+  globalThis.setInterval =
+    ((_cb: () => void) =>
+      0 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
+  globalThis.clearInterval =
+    ((_id?: ReturnType<typeof setInterval>) => {}) as typeof clearInterval;
   try {
-    _handler = (await import(`./index.ts?unit=${crypto.randomUUID()}`)).handler as Handler;
+    _handler = (await import(`./index.ts?unit=${crypto.randomUUID()}`))
+      .handler as Handler;
   } finally {
     denoAsAny.serve = origServe;
     globalThis.setInterval = origSetInterval;
@@ -47,9 +54,13 @@ function happyPathFake(overrides: {
   return fakeSupabase()
     .on("events", "select", { data: buildEvent(overrides.event) })
     .on("tickets", "select", { data: buildTicket(overrides.ticket) })
-    .on("user_profiles", "select", { data: buildUserProfile(overrides.profile) })
+    .on("user_profiles", "select", {
+      data: buildUserProfile(overrides.profile),
+    })
     .on("check_party_balance", "rpc", { data: { allowed: true } })
-    .on("event_applications", "select", { error: { message: "no rows", code: "PGRST116" } })
+    .on("event_applications", "select", {
+      error: { message: "no rows", code: "PGRST116" },
+    })
     .on("apply_event", "rpc", { data: "app-new-1" })
     .on("event_applications", "update", { error: null });
 }
@@ -78,6 +89,32 @@ Deno.test("user-create-order :: missing ticket_id → 400", async () => {
   assertEquals(res.status, 400);
   const body = await readJson<{ error: string }>(res);
   assertEquals(body.error.toLowerCase().includes("ticket_id"), true);
+});
+
+Deno.test("user-create-order :: non-string event_id → 400 before DB access", async () => {
+  const handler = await getHandler();
+  const sb = fakeSupabase();
+  const res = await runHandler(handler, {
+    body: { event_id: 123, ticket_id: "tk-1" },
+    ctx: makeCtx({ supabase: sb, userId: "u-1" }),
+  });
+  assertEquals(res.status, 400);
+  assertEquals(sb.getCalls().length, 0);
+});
+
+Deno.test("user-create-order :: invalid verification_data shape → 400 before DB access", async () => {
+  const handler = await getHandler();
+  const sb = fakeSupabase();
+  const res = await runHandler(handler, {
+    body: {
+      event_id: "ev-1",
+      ticket_id: "tk-1",
+      verification_data: { verification_id: 123, data: {} },
+    },
+    ctx: makeCtx({ supabase: sb, userId: "u-1" }),
+  });
+  assertEquals(res.status, 400);
+  assertEquals(sb.getCalls().length, 0);
 });
 
 // ── event checks ───────────────────────────────────────────────────────────────
@@ -111,7 +148,10 @@ Deno.test("user-create-order :: event status=cancelled → 400 EVENT_CLOSED", as
 Deno.test("user-create-order :: event already started → 400 EVENT_NOT_SCHEDULED", async () => {
   const handler = await getHandler();
   const sb = fakeSupabase().on("events", "select", {
-    data: buildEvent({ status: "scheduled", start_time: "2020-01-01T00:00:00Z" }),
+    data: buildEvent({
+      status: "scheduled",
+      start_time: "2020-01-01T00:00:00Z",
+    }),
   });
   const res = await runHandler(handler, {
     body: { event_id: "ev-1", ticket_id: "tk-1" },
@@ -128,7 +168,9 @@ Deno.test("user-create-order :: ticket not found → 404", async () => {
   const handler = await getHandler();
   const sb = fakeSupabase()
     .on("events", "select", { data: buildEvent() })
-    .on("tickets", "select", { error: { message: "no rows", code: "PGRST116" } });
+    .on("tickets", "select", {
+      error: { message: "no rows", code: "PGRST116" },
+    });
   const res = await runHandler(handler, {
     body: { event_id: "ev-1", ticket_id: "tk-1" },
     ctx: makeCtx({ supabase: sb, userId: "u-1" }),
@@ -152,7 +194,9 @@ Deno.test("user-create-order :: ticket sold out → 400 TICKET_SOLD_OUT", async 
   const handler = await getHandler();
   const sb = fakeSupabase()
     .on("events", "select", { data: buildEvent() })
-    .on("tickets", "select", { data: buildTicket({ sold_count: 30, quantity: 30 }) });
+    .on("tickets", "select", {
+      data: buildTicket({ sold_count: 30, quantity: 30 }),
+    });
   const res = await runHandler(handler, {
     body: { event_id: "ev-1", ticket_id: "tk-1" },
     ctx: makeCtx({ supabase: sb, userId: "u-1" }),
@@ -185,7 +229,9 @@ Deno.test("user-create-order :: user profile not found → 404", async () => {
   const sb = fakeSupabase()
     .on("events", "select", { data: buildEvent() })
     .on("tickets", "select", { data: buildTicket() })
-    .on("user_profiles", "select", { error: { message: "no rows", code: "PGRST116" } });
+    .on("user_profiles", "select", {
+      error: { message: "no rows", code: "PGRST116" },
+    });
   const res = await runHandler(handler, {
     body: { event_id: "ev-1", ticket_id: "tk-1" },
     ctx: makeCtx({ supabase: sb, userId: "u-1" }),
@@ -198,7 +244,9 @@ Deno.test("user-create-order :: user not verified → 400 IDENTITY_REQUIRED", as
   const sb = fakeSupabase()
     .on("events", "select", { data: buildEvent() })
     .on("tickets", "select", { data: buildTicket() })
-    .on("user_profiles", "select", { data: buildUserProfile({ is_verified: false }) });
+    .on("user_profiles", "select", {
+      data: buildUserProfile({ is_verified: false }),
+    });
   const res = await runHandler(handler, {
     body: { event_id: "ev-1", ticket_id: "tk-1" },
     ctx: makeCtx({ supabase: sb, userId: "u-1" }),
@@ -246,7 +294,9 @@ Deno.test("user-create-order :: existing application (cancelled) → reapplicati
     ctx: makeCtx({ supabase: sb, userId: "u-1" }),
   });
   assertEquals(res.status, 200);
-  const body = await readJson<{ success: boolean; application_id: string }>(res);
+  const body = await readJson<{ success: boolean; application_id: string }>(
+    res,
+  );
   assertEquals(body.success, true);
   assertEquals(body.application_id, "app-reused-1");
   // update path for existing app was taken
@@ -318,8 +368,33 @@ Deno.test("user-create-order :: apply_event RPC error → 500", async () => {
     .on("tickets", "select", { data: buildTicket() })
     .on("user_profiles", "select", { data: buildUserProfile() })
     .on("check_party_balance", "rpc", { data: { allowed: true } })
-    .on("event_applications", "select", { error: { message: "no rows", code: "PGRST116" } })
-    .on("apply_event", "rpc", { error: { message: "constraint violation", code: "23505" } });
+    .on("event_applications", "select", {
+      error: { message: "no rows", code: "PGRST116" },
+    })
+    .on("apply_event", "rpc", {
+      error: { message: "constraint violation", code: "23505" },
+    });
+  const res = await runHandler(handler, {
+    body: { event_id: "ev-1", ticket_id: "tk-1" },
+    ctx: makeCtx({ supabase: sb, userId: "u-1" }),
+  });
+  assertEquals(res.status, 500);
+});
+
+Deno.test("user-create-order :: application update error after RPC → 500", async () => {
+  const handler = await getHandler();
+  const sb = fakeSupabase()
+    .on("events", "select", { data: buildEvent() })
+    .on("tickets", "select", { data: buildTicket() })
+    .on("user_profiles", "select", { data: buildUserProfile() })
+    .on("check_party_balance", "rpc", { data: { allowed: true } })
+    .on("event_applications", "select", {
+      error: { message: "no rows", code: "PGRST116" },
+    })
+    .on("apply_event", "rpc", { data: "app-new-1" })
+    .on("event_applications", "update", {
+      error: { message: "update failed", code: "XX000" },
+    });
   const res = await runHandler(handler, {
     body: { event_id: "ev-1", ticket_id: "tk-1" },
     ctx: makeCtx({ supabase: sb, userId: "u-1" }),

--- a/supabase/functions/user-create-order/index_test.ts
+++ b/supabase/functions/user-create-order/index_test.ts
@@ -15,31 +15,14 @@ import {
   readJson,
   runHandler,
 } from "../_shared/_testing/mod.ts";
+import { importHandlerWithStubbedServe } from "../_test_utils/mock_http.ts";
 
 let _handler: Handler | null = null;
 async function getHandler(): Promise<Handler> {
   if (_handler) return _handler;
-  const denoAsAny = Deno as unknown as {
-    serve: (...args: unknown[]) => Deno.HttpServer;
-  };
-  const origServe = denoAsAny.serve;
-  denoAsAny.serve =
-    () => ({ shutdown() {}, finished: Promise.resolve() } as Deno.HttpServer);
-  const origSetInterval = globalThis.setInterval;
-  const origClearInterval = globalThis.clearInterval;
-  globalThis.setInterval =
-    ((_cb: () => void) =>
-      0 as unknown as ReturnType<typeof setInterval>) as typeof setInterval;
-  globalThis.clearInterval =
-    ((_id?: ReturnType<typeof setInterval>) => {}) as typeof clearInterval;
-  try {
-    _handler = (await import(`./index.ts?unit=${crypto.randomUUID()}`))
-      .handler as Handler;
-  } finally {
-    denoAsAny.serve = origServe;
-    globalThis.setInterval = origSetInterval;
-    globalThis.clearInterval = origClearInterval;
-  }
+  _handler = await importHandlerWithStubbedServe<Handler>(
+    new URL("./index.ts", import.meta.url),
+  );
   return _handler!;
 }
 

--- a/supabase/functions/user-create-order/input.ts
+++ b/supabase/functions/user-create-order/input.ts
@@ -1,0 +1,51 @@
+import { errorResponse } from "../_shared/response_utils.ts";
+import type { CreateOrderVerificationData } from "../_shared/domains/order/create_order_policy.ts";
+
+export interface CreateOrderInput {
+  event_id: string;
+  ticket_id: string;
+  verification_data?: CreateOrderVerificationData;
+}
+
+export function parseCreateOrderInput(
+  body: Record<string, unknown>,
+): CreateOrderInput | Response {
+  const eventId = body.event_id;
+  if (typeof eventId !== "string" || eventId.length === 0) {
+    return errorResponse("Missing required field: event_id", 400);
+  }
+
+  const ticketId = body.ticket_id;
+  if (typeof ticketId !== "string" || ticketId.length === 0) {
+    return errorResponse("Missing required field: ticket_id", 400);
+  }
+
+  const verificationData = body.verification_data;
+  if (verificationData === undefined) {
+    return { event_id: eventId, ticket_id: ticketId };
+  }
+
+  if (!isVerificationData(verificationData)) {
+    return errorResponse("Invalid field: verification_data", 400);
+  }
+
+  return {
+    event_id: eventId,
+    ticket_id: ticketId,
+    verification_data: verificationData,
+  };
+}
+
+function isVerificationData(
+  value: unknown,
+): value is CreateOrderVerificationData {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  const data = record.data;
+  return typeof record.verification_id === "string" &&
+    typeof data === "object" &&
+    data !== null &&
+    !Array.isArray(data);
+}


### PR DESCRIPTION
## Summary
- document the Edge Function layer standard for index/input/service/domain/RPC boundaries
- split user-create-order, payment-verify, user-cancel-order, and partner-approve-application into thin handlers plus typed inputs/services
- add pure domain policy tests for order creation, payment verification, cancellation, and partner approval result mapping
- add BLUEDOC files for new EF/domain folders

## Tests
- deno lint for all touched EF/domain files
- deno test user-create-order domain/handler/wrapper tests
- deno test payment-verify domain/handler/wrapper tests
- deno test user-cancel-order domain/handler/wrapper tests
- deno test partner-approve-application domain/handler/wrapper tests
- BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh
- git diff --check