### PR TITLE
docs: define branch workflow overview

### DIFF
--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -20,7 +20,7 @@
 | `post-merge` | dev push 직후 follow-up 자동화의 단일 entry point (5 reusable orchestrator) | `post-merge` |
 | `tool-` | (수동으로 부를 때만 도는 도구) | (현재 없음 — 새 수동 도구 추가 시 prefix) |
 | `shared-` | (다른 워크플로우의 부품 — 단독 실행 X) | `shared-notify`, `shared-android-deploy` |
-| branch-strategy stage name | branch-strategy 문서의 stage entry workflow | `dev-staging-post-merge-sync`, `nightly-cut`, `rc-gate`, `rc-cut` |
+| branch-strategy stage name | branch-strategy 문서의 stage entry workflow | `dev-staging-post-merge-sync`, `nightly-cut`, `rc-gate`, `dev-deploy`, `rc-cut`, `rc-deploy`, `main-cut`, `main-deploy` |
 | reusable no-prefix | `workflow_call` 로만 호출되는 domain reusable | `version-bump` |
 
 ## Reusable Gates
@@ -30,7 +30,9 @@
 - 기존 required check 는 아직 `ci-result` 그대로 유지한다. stage 별 required check 전환은 branch-strategy Phase 4 에서 Ruleset 과 함께 적용한다.
 - `dev-staging-post-merge-sync` 가 dev-staging 의 PR-number CalVer bump/tag 를 담당한다. `sync-version` 은 legacy main release bump 만 담당하며, `dev` promotion 은 `nightly-cut` 에서 version 변경 없이 처리한다.
 - `rc-gate` 는 dev push 후 user/partner CUJ integration 을 직접 실행하고, 통과한 commit 에만 `rc-gate-pass` status 를 찍는다. backend/EF/Test Lab 을 포함한 full `rc-gate-suite` matrix 는 후속 확장이다.
-- `rc-cut` 은 latest `rc-gate-pass` dev commit 에서 `rc/YYYY-Www` branch 를 만들고 `version-bump` 로 `v*-rc-01` + `promo/rc-*` tag 를 생성한다.
+- `rc-cut` 은 latest `rc-gate-pass` dev commit 에서 `rc/YYYY-Wxx` branch 를 만들고 `version-bump` 로 `v*-rc-01` + `promo/rc-*` tag 를 생성한다.
+- `main-cut` 은 5일 soak 를 통과한 `rc/*` 를 `main` PR 로 promote 한다.
+- deploy entry 는 `[branch]-deploy` 로 통일한다 (`dev-deploy`, `rc-deploy`, `main-deploy`). `monitor-event-flow-*` 는 deploy 가 아니라 지속 batch signal 이다.
 - protected branch/tag 에 직접 push 하는 workflow 는 `minglit-release-bot` GitHub App token 을 사용한다. App credential 은 `minglit_env/{stage}/github.env` 파일에서 먼저 읽고, 공통 token mint 는 `.github/actions/release-bot-token` 에서 처리한다.
 
 ## 컨벤션
@@ -51,4 +53,4 @@
 - [CLAUDE.md](../../CLAUDE.md) `## PR Conventions` — required check (`ci-result` job = `pr-gate.yml` 내부) / auto-merge 흐름
 
 ---
-_Reviewed: 2026-05-24 09:24_
+_Reviewed: 2026-05-24 10:24_

--- a/docs/infra/branch-strategy/BLUEDOC.md
+++ b/docs/infra/branch-strategy/BLUEDOC.md
@@ -1,6 +1,57 @@
 # Branch Strategy
 
-4-stage (`dev-staging → dev → rc → main`) + 일반 PR/auto-merge + nightly snapshot + `rc-gate` green build picking + feature flag + 3가지 safety net. AI agent 가 dev-staging 에 PR, **dev rc-gate-pass 는 main-staging env (staging Supabase) 로 deploy**, main 머지에서 backend + mobile 모두 prod 로 deploy (hotfix 없으면 weekly). 모든 cadence = target, slip 자연스러움.
+4-stage (`dev-staging → dev → rc → main`) + 일반 PR/auto-merge + nightly snapshot + `rc-gate` green build picking + feature flag + 3가지 safety net. AI agent 가 dev-staging 에 PR, `rc-gate-pass` commit 에서 RC 를 cut 하고, main 머지에서 backend + mobile 모두 prod 로 deploy 한다 (hotfix 없으면 weekly). 이벤트 플로우 시뮬레이터는 release promotion 과 별개인 batch monitor 로 계속 돈다.
+
+## Workflow Overview
+
+```mermaid
+flowchart LR
+  agent[Agent / Human PR] --> dsg[dev-staging-pr-gate]
+  dsg --> ds[dev-staging]
+  ds --> dss[dev-staging-post-merge-sync]
+  dss --> dstag["v*-dev-staging tag"]
+
+  dstag --> nc[nightly-cut]
+  nc --> npg[nightly-pr-gate]
+  npg --> dev[dev]
+
+  dev --> rg[rc-gate]
+  rg -->|pass| rgp["rc-gate-pass status"]
+  rg -->|fail| issue[auto issue + fix via dev-staging]
+  rgp --> rcut[rc-cut]
+  rcut --> rc["rc/YYYY-Wxx"]
+
+  rc --> rpg[rc-pr-gate]
+  rpg --> rps[rc-post-merge-sync]
+  rps --> rc
+  rps --> rbp[rc-hotfix-backport]
+  rbp --> ds
+
+  rc --> rcd[rc-deploy]
+  rc --> mcut[main-cut]
+  mcut --> mpg[main-pr-gate]
+  mpg --> main[main]
+  main --> md[main-deploy]
+  md --> prod[(Production)]
+
+  monitor["monitor-event-flow-* batch"] -. continuous signal .- dev
+  monitor -. pre-main signal .- rc
+```
+
+### Abstract Workflow Set
+
+| 단계 | Entry workflow | 역할 |
+|------|----------------|------|
+| dev-staging PR | `dev-staging-pr-gate` | feature/agent PR 의 빠른 CI gate |
+| dev-staging post-merge | `dev-staging-post-merge-sync` | `v*-dev-staging` version/tag 생성 |
+| dev promotion | `nightly-cut` + `nightly-pr-gate` | coherent dev-staging snapshot 을 dev 로 promote |
+| dev post-merge | `rc-gate` | RC 후보 검증 후 `rc-gate-pass` status 부여 |
+| dev deploy/validation | `dev-deploy` | dev 환경 deploy/validation orchestrator. 이벤트 플로우 시뮬레이터는 `monitor-event-flow-*` batch 로 별도 운영 |
+| rc creation | `rc-cut` | latest `rc-gate-pass` commit 에서 `rc/YYYY-Wxx` 생성 |
+| rc hotfix | `rc-pr-gate` + `rc-post-merge-sync` + `rc-hotfix-backport` | RC hotfix 검증, RC version bump, dev-staging backport |
+| rc deploy/validation | `rc-deploy` | Supabase branching 기반 RC 검증 환경 구성 + pre-main validation |
+| main promotion | `main-cut` + `main-pr-gate` | soak 완료 RC 를 main PR 로 promote |
+| prod deploy | `main-deploy` | final version/tag, prod backend/mobile deploy, RC cleanup |
 
 ## 4-stage 모델
 
@@ -29,7 +80,7 @@
 | [dev-staging-pipeline.md](./dev-staging-pipeline.md) | 일반 PR/auto-merge + pr-gate + safety net CI |
 | [dev-pipeline.md](./dev-pipeline.md) | nightly-cut + rc-gate + auto-deploy chain |
 | [rc-promotion.md](./rc-promotion.md) | rc-cut + soak + hotfix + backport |
-| [main-promotion.md](./main-promotion.md) | rc → main + deploy-android-*, deploy-ios-* + min-version |
+| [main-promotion.md](./main-promotion.md) | rc → main + main-deploy + min-version |
 | [life-of-flag.md](./life-of-flag.md) | flag lifecycle |
 | [versioning.md](./versioning.md) | CalVer + tag |
 | [specs/](./specs/BLUEDOC.md) | workflow spec, branch spec, execution plan (구현 계약) |
@@ -43,7 +94,8 @@
 - 코드 promotion = 한 방향 PR, 기능 promotion = flag flip
 - 모든 branch linear ON — dev-staging: squash, dev/rc/main: rebase
 - Protected branch 직접 push 는 human 금지. version bump/tag/promotion 처리는 `minglit-release-bot` 전용 token + Ruleset bypass 로만 허용
-- dev rc-gate-pass = backend/web → **main-staging env** deploy (사용자 서버 영향 X); main 머지 = backend + mobile 모두 prod deploy
+- `monitor-event-flow-*` 는 release promotion 과 독립적인 batch signal. dev 에서 계속 돌고, RC 에서는 main 배포 전 검증 signal 로 사용한다
+- main 머지 = backend + mobile 모두 prod deploy. backend prod deploy 는 `main-deploy` 에서 한 번에 수행한다
 - **Hotfix 는 rc 에서, dev-staging 으로 자동 backport** ([rc-promotion.md](./rc-promotion.md))
 - Tag regex 는 `RELEASE.md` lock (TODO)
 
@@ -55,7 +107,7 @@ Promotion PR 제목은 workflow 이름과 source artifact 를 앞에 둔다. PR 
 |------|-----------|
 | dev-staging → dev | `ci(nightly-cut): promote v26.05.2722-dev-staging to dev` |
 | dev → rc | `ci(rc-cut): cut rc/2026-W22 from <source>` |
-| rc → main | `ci(rc-soak): promote rc/2026-W22 to main` |
+| rc → main | `ci(main-cut): promote rc/2026-W22 to main` |
 | rc hotfix backport | `ci(rc-backport): backport rc hotfix #1234 to dev-staging` |
 
 ### RC Eligibility Marker
@@ -63,4 +115,4 @@ Promotion PR 제목은 workflow 이름과 source artifact 를 앞에 둔다. PR 
 RC cut 의 source-of-truth status 이름은 **`rc-gate-pass`** 이다. `rc-eligible` 은 현재 구현된 workflow/status 명칭이 아니며, 새 이름으로 바꾸려면 `rc-gate`, `rc-cut`, `main-pr-gate`, 문서 전체를 같은 PR 에서 일괄 변경한다.
 
 ---
-_Reviewed: 2026-05-19 09:47_
+_Reviewed: 2026-05-24 10:24_

--- a/docs/infra/branch-strategy/branch-flow.md
+++ b/docs/infra/branch-strategy/branch-flow.md
@@ -1,6 +1,6 @@
 # Branch Flow
 
-`dev-staging → dev → rc → main` 4-stage 모델의 머지 방향, branch protection, promotion tag, auto-deploy chain.
+`dev-staging → dev → rc → main` 4-stage 모델의 머지 방향, branch protection, promotion tag, deploy/validation chain.
 
 ## 흐름 다이어그램
 
@@ -13,18 +13,19 @@
                                                               │      │
                                                               │      ├─ pass: status rc-gate-pass
                                                               │      │         │
-                                                              │      │         ├─▶ deploy-supabase (target=main-staging, staging Supabase project)
-                                                              │      │         └─▶ Vercel preview (native, dev branch)
+                                                              │      │         └─▶ monitor-event-flow-* batch signal keeps running
                                                               │      │
                                                               │      └─ fail: 자동 이슈 + AI agent fix via dev-staging (no auto-revert)
                                                               │
                                                               └─weekly rc-cut (최신 rc-gate-pass commit)──▶ rc/YYYY-Wxx
                                                                                                               │
-                                                                                                              └─5일 soak (hotfix 시 시계 리셋, main-staging env 사용)──▶ main
+                                                                                                              ├─▶ rc-deploy (Supabase branching + pre-main validation)
+                                                                                                              │
+                                                                                                              └─5일 soak (hotfix 시 시계 리셋)──▶ main-cut
                                                                                                                                                     │
-                                                                                                                                                    └─main-post-merge-promote (prod deploy chain)
+                                                                                                                                                    └─main-deploy (prod deploy chain)
                                                                                                                                                               │
-                                                                                                                                                              ├─▶ deploy-supabase (target=main, prod Supabase)
+                                                                                                                                                              ├─▶ backend prod deploy (Supabase migration + EF)
                                                                                                                                                               ├─▶ deploy-android-{user,partner} ──▶ Play Store
                                                                                                                                                               ├─▶ deploy-ios-{user,partner} ──▶ App Store Connect
                                                                                                                                                               └─▶ Vercel production (native, main branch)
@@ -47,7 +48,7 @@ rc/* hotfix 머지 ──auto cherry-pick──▶ backport-branch ──PR─�
 | feature/agent → dev-staging | `dev-staging` ← `feat/*`, `fix/*`, `chore/*`, `docs/*` | PR + auto-merge | **squash** | `dev-staging-pr-gate` |
 | dev-staging → dev | `dev` ← `nightly/YYYY-MM-DD-{sha8}` at latest `v*-dev-staging` tag | daily cron `nightly-cut` | rebase (linear snapshot) | `nightly-pr-gate` |
 | hotfix → rc | `rc/YYYY-Wxx` ← hotfix branch | hotfix only | rebase | `rc-pr-gate` |
-| rc → main | `main` ← `rc/YYYY-Wxx` | `rc-soak-check` 가 5일 무커밋 시 PR 생성 + auto-merge | rebase + ff | `main-pr-gate` |
+| rc → main | `main` ← `rc/YYYY-Wxx` | `main-cut` 이 5일 무커밋 시 PR 생성 + auto-merge | rebase + ff | `main-pr-gate` |
 
 ## Branch Protection 설정
 
@@ -77,27 +78,26 @@ Hybrid linear history 금지 — 각 branch 내 일관 (squash or rebase 한 가
 
 ## Auto-deploy Chain
 
-### dev rc-gate-pass → main-staging env deploy (continuous)
+### dev validation signal
 
 ```yaml
-# 개념 — staging env 만, prod 영향 X
-rc-gate (on push to dev):
-  needs: pass
-  parallel:
-    - uses: ./.github/workflows/deploy-supabase.yml  # target=main-staging
-    # Vercel: native build 가 dev branch → preview deployment
+# 개념 — release promotion 과 독립적인 batch signal
+monitor-event-flow-*:
+  schedule: continuous
+  branch: dev
+  purpose: backend/event-flow simulation signal
 ```
 
 ### main push → prod deploy chain
 
 ```yaml
 # 개념 — backend + mobile 모두 prod
-main-post-merge-promote (on push to main):
+main-deploy (on push to main):
   steps:
     - tag v{ver} + promo/main-Wxx + Sentry marker
     - Firebase RC `latest_version` = v{ver} 자동 update
   parallel:
-    - uses: ./.github/workflows/deploy-supabase.yml  # target=main (prod Supabase)
+    - backend prod deploy  # Supabase migration + EF
     - uses: ./.github/workflows/deploy-android-{user,partner}.yml
     - uses: ./.github/workflows/deploy-ios-{user,partner}.yml
     # Vercel: native build 가 main branch → production deployment
@@ -109,7 +109,7 @@ main-post-merge-promote (on push to main):
 
 | Safety Net | 실행 위치 |
 |------------|-----------|
-| Version kill switch (soft/hard) | Firebase RC. soft `latest_version` = `main-post-merge-promote` 가 매 main 머지마다 자동 update / hard `kill_list_hard` = 내부 admin page manual (catastrophic only) |
+| Version kill switch (soft/hard) | Firebase RC. soft `latest_version` = `main-deploy` 가 매 main 머지마다 자동 update / hard `kill_list_hard` = 내부 admin page manual (catastrophic only) |
 | expand-migrate-contract CI | `dev-staging-pr-gate` (destructive op 탐지) + `main-pr-gate` (재검증) |
 | flag-registration CI | `dev-staging-pr-gate` |
 
@@ -120,4 +120,4 @@ main-post-merge-promote (on push to main):
 - `RELEASE.md` 작성
 
 ---
-_Reviewed: 2026-05-23 16:31_
+_Reviewed: 2026-05-24 10:24_

--- a/docs/infra/branch-strategy/dev-pipeline.md
+++ b/docs/infra/branch-strategy/dev-pipeline.md
@@ -1,13 +1,13 @@
 # Dev Pipeline
 
-`dev` 브랜치가 trunk 역할: dev-staging 의 daily snapshot 을 받고, post-merge 로 full integration suite (`rc-gate`) 를 돌려, 통과한 commit 마다 backend/web auto-deploy. RC 는 이 status 를 보고 cut.
+`dev` 브랜치가 trunk 역할: dev-staging 의 daily snapshot 을 받고, post-merge 로 full integration suite (`rc-gate`) 를 돌린다. RC 는 `rc-gate-pass` status 를 보고 cut 한다. 이벤트 플로우 시뮬레이터는 `monitor-event-flow-*` batch 로 계속 돌며, backend prod deploy 는 main 머지 후 `main-deploy` 에서 수행한다.
 
 ## 4가지 workflow
 
 1. **`nightly-cut`** — daily cron, dev-staging tip 의 snapshot 으로 PR 생성
 2. **`nightly-pr-gate`** — snapshot PR 머지 전 검증 (defensive)
 3. **`rc-gate`** — dev 머지 후 자동 발동, full integration suite, 통과 시 status `rc-gate-pass` set
-4. **Auto-deploy chain** — `rc-gate-pass` 시점에 `backend-auto-deploy` + `web-auto-deploy` 동시 trigger
+4. **`dev-deploy` / monitor jobs** — dev 환경 deploy/smoke 가 필요할 때만 수행. 이벤트 플로우 시뮬레이터는 `monitor-event-flow-*` 로 별도 운영
 
 ## `nightly-cut`
 
@@ -34,9 +34,9 @@
 
 ## `rc-gate` — Heavy Integration
 
-dev 머지 후 자동 발동. 통과 = "이 commit 은 RC 가능 + backend/web prod 배포 가능".
+dev 머지 후 자동 발동. 통과 = "이 commit 은 RC cut source 로 사용할 수 있음".
 
-> **Current implementation**: first operational version runs user/partner CUJ integration directly and sets `rc-gate-pass` on success. Backend/EF/Test Lab and the deploy chain are follow-up expansions.
+> **Current implementation**: first operational version runs user/partner CUJ integration directly and sets `rc-gate-pass` on success. Backend simulation/Test Lab 확장은 후속이다.
 
 ### 무엇을 도는가
 
@@ -56,13 +56,12 @@ dev 머지 후 자동 발동. 통과 = "이 commit 은 RC 가능 + backend/web p
 
 ```
 1. dev HEAD commit 에 GitHub commit status `rc-gate-pass` set
-2. Auto-deploy chain workflow_call (parallel, target=main-staging):
-   - deploy-supabase (staging Supabase project: EF + migration apply)
-   - (Vercel native: dev branch → preview deployment)
-3. (Mobile + backend prod 은 별도 — main 머지 후 deploy chain)
+2. `rc-cut` 이 이 status 를 source-of-truth 로 사용
+3. 이벤트 플로우 시뮬레이터는 `monitor-event-flow-*` batch 로 계속 별도 관찰
+4. Mobile + backend prod 은 main 머지 후 `main-deploy` 에서 처리
 ```
 
-> **사용자 서버 영향 X** — rc-gate-pass deploy 는 main-staging env (별도 Supabase project) 만. prod 는 main 머지에서.
+> **사용자 서버 영향 X** — `rc-gate-pass` 는 prod deploy 가 아니라 RC 후보 marker 다. prod 는 main 머지에서만 배포한다.
 
 ### 실패 시
 
@@ -79,7 +78,7 @@ Snapshot 모델 — **auto-revert 없음**. dev 가 broken 상태로 잠시 머�
 
 ## Error-Backoff 정책
 
-**Workflow infra 실패** (`rc-gate` script 에러, runner 다운, deploy hook 실패 등) → **P0 이슈 자동 생성** + on-call. 아래는 *rc-gate test* 실패 escalation.
+**Workflow infra 실패** (`rc-gate` script 에러, runner 다운 등) → **P0 이슈 자동 생성** + on-call. 아래는 *rc-gate test* 실패 escalation.
 
 | 연속 실패 | 동작 |
 |----------|------|
@@ -89,20 +88,17 @@ Snapshot 모델 — **auto-revert 없음**. dev 가 broken 상태로 잠시 머�
 
 **Recovery**: 다음 rc-gate green → 자동 차단 해제, 누적 이슈 verify 코멘트.
 
-## Auto-deploy 워크플로우
+## Dev Validation / Monitor
 
-### `deploy-supabase`
+### `dev-deploy`
 
-- Supabase EF 배포 (deno deploy)
-- Migration apply (Supabase CLI)
-- Sentry release marker 부여 (`v{ver}-dev` 형식)
-- 실패 시: retry 1회 → 실패 시 P0 이슈 + on-call
+`dev-deploy` 는 dev 환경 deploy/smoke 가 필요할 때의 branch-level entrypoint 다. 현재 release policy 에서는 backend prod deploy 를 여기서 하지 않는다.
 
-### `deploy-vercel`
+### `monitor-event-flow-*`
 
-- Vercel native build 사용. `dev` 는 preview deployment, `main` 은 production deployment
-- 기존 cron/deploy hook 워크플로우는 전환 완료 후 폐기
-- 실패 시: retry 1회 → 실패 시 P0 이슈
+- 이벤트 플로우 시뮬레이터 batch (`monitor-event-flow-hourly`, `monitor-event-flow-daily`)
+- release promotion 과 독립적으로 계속 돈다
+- RC 에서는 main 배포 전 pre-main validation signal 로 사용한다
 
 ## Artifact / 보존
 
@@ -121,9 +117,9 @@ Snapshot 모델 — **auto-revert 없음**. dev 가 broken 상태로 잠시 머�
 
 - [dev-staging-pipeline.md](./dev-staging-pipeline.md) — dev-staging 의 pr-gate + safety net
 - [rc-promotion.md](./rc-promotion.md) — rc-gate-pass 가 rc-cut 의 source
-- [main-promotion.md](./main-promotion.md) — auto-deploy 실패 시 rollback
+- [main-promotion.md](./main-promotion.md) — main-deploy 와 prod deploy failure handling
 - [test-strategy.md](./test-strategy.md) — rc-gate 의 단계별 위치
-- [branch-flow.md](./branch-flow.md) — auto-deploy chain 그림
+- [branch-flow.md](./branch-flow.md) — workflow chain 그림
 
 ---
-_Reviewed: 2026-05-24 09:24_
+_Reviewed: 2026-05-24 10:24_

--- a/docs/infra/branch-strategy/life-of-flag.md
+++ b/docs/infra/branch-strategy/life-of-flag.md
@@ -152,8 +152,8 @@ Feature flag (Statsig + Firebase Remote Config) 의 생성·soak·rollout·**자
 
 | 항목 | 코드 release | 기능 release |
 |------|--------------|--------------|
-| 트리거 | backend/web staging: dev rc-gate-pass (main-staging env) / backend/web prod + mobile: main 머지 | flag ON 조작 |
-| cadence | staging: 시간 단위 / prod (backend + mobile): hotfix 없으면 weekly (rc → main 주기) | feature 별 비동기 |
+| 트리거 | RC 검증: `rc-deploy` / backend prod + mobile: main 머지 후 `main-deploy` | flag ON 조작 |
+| cadence | RC: hotfix loop 에 따라 유동 / prod (backend + mobile): hotfix 없으면 weekly (rc → main 주기) | feature 별 비동기 |
 | rollback | redeploy 이전 commit (분) | flag flip (즉시) |
 | 통제 권한 | 릴리즈 매니저 | feature owner |
 
@@ -173,7 +173,7 @@ Feature flag (Statsig + Firebase Remote Config) 의 생성·soak·rollout·**자
 - [branch-flow.md](./branch-flow.md) — 코드 promotion 의 그림
 - [main-promotion.md](./main-promotion.md) — min-version + expand-migrate-contract
 - [dev-staging-pipeline.md](./dev-staging-pipeline.md) — flag-registration CI
-- [dev-pipeline.md](./dev-pipeline.md) — backend/web auto-deploy
+- [dev-pipeline.md](./dev-pipeline.md) — rc-gate-pass marker 와 dev validation
 - [test-strategy.md](./test-strategy.md) — flag staged rollout 의 게이트
 - [error-detection.md](./error-detection.md) — flag 메트릭의 detection layer
 - [../firebase/BLUEDOC.md](../firebase/BLUEDOC.md), [../statsig/BLUEDOC.md](../statsig/BLUEDOC.md)

--- a/docs/infra/branch-strategy/main-promotion.md
+++ b/docs/infra/branch-strategy/main-promotion.md
@@ -1,28 +1,28 @@
 # Main Promotion
 
-`rc/YYYY-Wxx` 의 soak 통과 시 `main` 으로 머지, main push 직후 **backend + mobile 모두 prod 로 deploy**. Backend 의 staging deploy 는 dev 의 rc-gate-pass 에서 일어남 (main-staging env, [dev-pipeline.md](./dev-pipeline.md)). prod deploy 는 main 머지에서 — 사용자 서버에 검증 안 된 코드 직접 들어가지 않게 RC soak 통과 후만.
+`rc/YYYY-Wxx` 의 soak 통과 시 `main` 으로 머지, main push 직후 **backend + mobile 모두 prod 로 deploy**. Backend prod deploy 는 `main-deploy` 에서 한 번에 수행한다. 이벤트 플로우 시뮬레이터는 별도 batch monitor 로 계속 돌며, RC 에서는 main 배포 전 검증 signal 로 사용한다.
 
 ## 두 가지 이벤트
 
-1. **rc → main 머지** — `rc-soak-check` 가 자동 PR 생성 + 모든 check 통과 시 workflow auto-merge
-2. **main push → prod deploy chain** — backend (`deploy-supabase` target=main), web (Vercel native), mobile (`deploy-android-*`, `deploy-ios-*`) 모두 prod 로 병렬 deploy. store review + staged rollout 은 store-side
+1. **rc → main 머지** — `main-cut` 이 자동 PR 생성 + 모든 check 통과 시 workflow auto-merge
+2. **main push → prod deploy chain** — `main-deploy` 가 backend, web, mobile prod deploy 를 orchestrate. store review + staged rollout 은 store-side
 
 ## `main-pr-gate`
 
-`rc-soak-check` 가 자동 생성한 promotion PR 에 적용:
+`main-cut` 이 자동 생성한 promotion PR 에 적용:
 
 | Check | 내용 |
 |-------|------|
 | `pr-gate` 재실행 | dev-staging-pr-gate 와 동일 — defensive 검증 |
 | `expand-migrate-contract` (재검증) | RC 5일 동안 dev 가 더 나갔을 수 있음. 재확인 |
 | RC HEAD 의 `rc-gate-pass` status 확인 | 마지막 hotfix 이 rc-gate 통과했는지 |
-| `rc-soak-passed` 자동 마커 | rc-soak-check 가 5일 무커밋 확인 후 부여 |
+| `rc-soak-passed` 자동 마커 | main-cut 이 5일 무커밋 확인 후 부여 |
 
 GitHub Ruleset 의 required check 는 `main-pr-gate` 하나로 둔다. `rc-gate-pass`, `expand-migrate-contract`, `rc-soak-passed` 는 PR head SHA 와 별도 commit/label 상태가 섞일 수 있으므로 `main-pr-gate` 내부 검증으로 처리한다. 모든 check 통과 시 workflow 가 auto-merge (rebase + fast-forward) 한다. 어느 하나라도 실패 시 PR hold + Slack 알림 → human 개입 (edge case).
 
-## `main-post-merge-promote`
+## `main-deploy`
 
-auto-merge 직후 자동 (promote + prod deploy chain):
+main push 직후 자동 (finalize + prod deploy chain):
 
 ```
 1. bump-version.sh {ver}  (suffix 제거 — main 은 final version)
@@ -33,14 +33,14 @@ auto-merge 직후 자동 (promote + prod deploy chain):
 6. Sentry release marker 부여 (v{ver})
 7. Firebase RC `latest_version` = v{ver} (Admin SDK)
 8. parallel deploy chain (모두 target=main):
-   - deploy-supabase (prod Supabase: migration + EF)
+   - backend prod deploy (Supabase migration + EF)
    - deploy-android-{user,partner}
    - deploy-ios-{user,partner}
    - (Vercel: native build 가 main push 자동 감지)
 9. RC Supabase branch 삭제 + active RC marker 제거
 ```
 
-> Backend/web staging deploy 는 dev 의 rc-gate-pass 에서 수행되고, backend/web prod deploy 는 main 머지 후 수행한다. Mobile deploy 는 main push 이후 별도 workflow 로 수행한다.
+> Backend prod deploy 는 main 머지 후 수행한다. Mobile deploy 는 main push 이후 별도 workflow 로 수행한다.
 
 ## 기존 Mobile Deploy Workflows (재사용)
 
@@ -65,7 +65,7 @@ main push trigger 로 자동 발동되는 기존 workflows:
 
 | Tier | 메커니즘 | RC param | Trigger |
 |------|----------|----------|---------|
-| **2a. Soft kill** | client 가 `latest_version` (RC) 와 자기 버전 비교 + app store 의 새 버전 가용성 확인 후 soft prompt | `latest_version` | `main-post-merge-promote` 가 매 main 머지마다 자동 update |
+| **2a. Soft kill** | client 가 `latest_version` (RC) 와 자기 버전 비교 + app store 의 새 버전 가용성 확인 후 soft prompt | `latest_version` | `main-deploy` 가 매 main 머지마다 자동 update |
 | **2b. Hard kill** | EF middleware 가 `kill_list_hard` (RC) + `X-App-Version` header 비교 → HTTP 426 reject | `kill_list_hard` | **내부 admin page manual** (catastrophic incident 시 release manager / on-call). 인증·audit log·role 권한·version dropdown 등이 RC 콘솔 직접 변경보다 안전. **admin page 구현은 본 docs scope 밖, 별도 작업 (TBD)** |
 
 ### Tier 2a: Soft Kill 흐름
@@ -125,7 +125,7 @@ main push trigger 로 자동 발동되는 기존 workflows:
 
 ## Error-Backoff 정책
 
-**Workflow infra 실패** (main-pr-gate / main-post-merge-promote / deploy-* workflow 자체 실패) → **P0 이슈** + on-call.
+**Workflow infra 실패** (main-pr-gate / main-deploy / deploy-* workflow 자체 실패) → **P0 이슈** + on-call.
 
 ### rc → main 머지 차단
 
@@ -143,9 +143,9 @@ main push trigger 로 자동 발동되는 기존 workflows:
 | Store upload 실패 (Fastlane) | retry 1회 → `auto-issue` (P1) |
 | Store 검수 reject | mobile 팀이 reject reason 확인 → fix PR via 정상 flow (dev-staging → ... → main → 다음 deploy 사이클) |
 
-### Backend/web auto-deploy 실패 (참고)
+### Backend/web deploy 실패
 
-main 머지와 무관 (이미 dev 에서 deploy). 상세는 [dev-pipeline.md](./dev-pipeline.md) error-backoff.
+`main-deploy` 의 backend prod deploy 실패는 P0/P1로 처리한다. 상세 detection layer 는 [error-detection.md](./error-detection.md) 를 따른다.
 
 ## 결정해야 할 것
 
@@ -158,11 +158,11 @@ main 머지와 무관 (이미 dev 에서 deploy). 상세는 [dev-pipeline.md](./
 
 ## 관련
 
-- [dev-pipeline.md](./dev-pipeline.md) — backend/web auto-deploy 의 실제 위치 (dev 의 rc-gate-pass)
+- [dev-pipeline.md](./dev-pipeline.md) — rc-gate-pass marker 와 dev validation 위치
 - [rc-promotion.md](./rc-promotion.md) — rc → main PR 의 생성
 - [life-of-flag.md](./life-of-flag.md) — flag rollout 은 main 머지와 별도
 - [branch-flow.md](./branch-flow.md) — tag 컨벤션 + protection
-- [specs/workflow-spec.md](./specs/workflow-spec.md) — 기존 deploy-* workflow 의 refactor 상세
+- [specs/workflow-spec.md](./specs/workflow-spec.md) — main-cut/main-deploy workflow 계약
 
 ---
-_Reviewed: 2026-05-19 09:47_
+_Reviewed: 2026-05-24 10:24_

--- a/docs/infra/branch-strategy/rc-promotion.md
+++ b/docs/infra/branch-strategy/rc-promotion.md
@@ -7,7 +7,8 @@
 1. **`rc-cut`** — weekly cron, dev 의 latest `rc-gate-pass` commit 에서 branch out
 2. **`rc-pr-gate`** — hotfix PR 머지 전 검증
 3. **`rc-post-merge-sync`** — hotfix 머지 직후 (`_rc-NN` bump)
-4. **`rc-soak-check`** — daily cron, RC HEAD commit 의 committer date 가 5일 이전이면 rc → main PR 자동 생성
+4. **`rc-deploy`** — RC Supabase branch 에 migration/EF 적용 + pre-main validation
+5. **`main-cut`** — daily cron, RC HEAD commit 의 committer date 가 5일 이전이면 rc → main PR 자동 생성
 
 ## `rc-cut`
 
@@ -21,7 +22,7 @@
   2. 없으면 dev 의 최신 `rc-gate-pass` status 부여된 commit 찾기 (GitHub API: `GET /repos/.../commits/{sha}/status`)
   3. 못 찾으면 cut 보류 (현재 구현은 초기 no-pass 상태를 skip, 3일+ green 없음 alert 는 후속 PR)
   4. 찾았으면 그 commit 에서 `rc/YYYY-Wxx` branch cut
-  5. Supabase branch 생성 (`rc-YYYY-Wxx`) + RC env 에 migration/EF deploy (후속 PR)
+  5. Supabase branch 생성/검증은 `rc-deploy` 에 위임 (후속 PR)
   6. `bump-version.sh {ver}-rc-01` 실행 → tag `v{ver}-rc-01` + `promo/rc-YYYY-Wxx`
   7. Branch protection 활성화 (direct push 금지, hotfix PR 만)
   8. active RC marker 기록 + Slack `#release` 알림 + soak 시작
@@ -54,13 +55,24 @@ Hotfix PR 머지 직후 자동:
 5. RC Supabase branch 에 migration/EF 재적용
 ```
 
-**Soak 시계 자동 리셋** — 새 commit 의 committer date 가 최신이므로 `rc-soak-check` 가 자연스럽게 카운트 다시 시작.
+**Soak 시계 자동 리셋** — 새 commit 의 committer date 가 최신이므로 `main-cut` 이 자연스럽게 카운트 다시 시작.
 
 ### Hotfix 카운트 결정
 
 `bump-version.sh` 가 현재 RC 의 가장 최근 `v*-rc-NN` 태그 찾아 N + 1 로 bump. 첫 cut 이 `_rc-01`, 첫 hotfix 가 `_rc-02`.
 
-## `rc-soak-check`
+## `rc-deploy`
+
+RC branch push 마다 RC 검증 환경을 구성한다. RC 는 계속 유지되는 장기 branch 가 아니라 Supabase branching 기반의 임시 검증 환경이다.
+
+| 단계 | 동작 |
+|------|------|
+| branch 준비 | Supabase branch `rc-YYYY-Wxx` 생성/확인 |
+| backend 적용 | RC branch 에 migration/EF apply |
+| smoke | RC env smoke + backend contract 확인 |
+| batch signal | `monitor-event-flow-*` 결과를 main 배포 전 검증 signal 로 사용 |
+
+## `main-cut`
 
 ### 트리거 / 동작
 
@@ -100,7 +112,7 @@ Mark 님 직감대로 hotfix loop 으로 RC lifecycle 이 길어지는 게 일�
             │
             ├─▶ [rc-post-merge-sync: _rc-NN bump]
             │
-            └─▶ [rc-soak-check 가 다음날부터 새 committer date 인식 → 5일 다시 측정]
+            └─▶ [main-cut 이 다음날부터 새 committer date 인식 → 5일 다시 측정]
 ```
 
 ## Hotfix Backport to dev-staging
@@ -143,22 +155,22 @@ Mobile 은 release branch 없음 (main 머지 마다 `deploy-android-*, deploy-i
 
 | 시점 | 동작 |
 |------|------|
-| `rc-cut` | Supabase branch `rc-YYYY-Wxx` 생성, RC SHA 기준 migration/EF deploy |
+| `rc-deploy` | Supabase branch `rc-YYYY-Wxx` 생성/확인, RC SHA 기준 migration/EF deploy |
 | RC soak | 내부 dogfooding 과 real-data 검증은 해당 RC branch 로만 수행 |
 | hotfix merge | 같은 RC Supabase branch 에 migration/EF 재적용 |
 | rc → main 완료 | prod deploy 후 RC Supabase branch 삭제 |
 | RC abandon | RC Supabase branch 삭제 + active RC marker 제거 |
 
-dev 의 `rc-gate-pass` 는 계속 `main-staging` env 로 deploy 된다. RC soak 는 `rc-YYYY-Wxx` branch 를 사용하므로 dev 의 후속 green commit 과 섞이지 않는다.
+`rc-gate-pass` 는 deploy marker 가 아니라 RC cut source marker 다. RC soak 는 `rc-YYYY-Wxx` Supabase branch 를 사용하므로 dev 의 후속 green commit 과 섞이지 않는다.
 
 ### 결정해야 할 것
 
 - Supabase branch TTL / 비용 알림
-- staging branch 의 seed data 정책
+- RC branch 의 seed data 정책
 
 ## Error-Backoff 정책
 
-**Workflow infra 실패** (rc-cut / rc-pr-gate / rc-soak-check workflow 자체 실패) → **P0 이슈** + on-call.
+**Workflow infra 실패** (rc-cut / rc-pr-gate / rc-deploy / main-cut workflow 자체 실패) → **P0 이슈** + on-call.
 
 **Soak 중 사용자 발견 회귀**:
 
@@ -171,7 +183,7 @@ dev 의 `rc-gate-pass` 는 계속 `main-staging` env 로 deploy 된다. RC soak 
 ## 결정해야 할 것
 
 - weekly rc-cut 요일
-- rc-soak-check daily cron 시각
+- main-cut daily cron 시각
 - RC 자체 nightly 별도 schedule 여부
 - Supabase RC branch TTL / seed data 정책
 - RC abandon 의 명확한 기준
@@ -179,7 +191,7 @@ dev 의 `rc-gate-pass` 는 계속 `main-staging` env 로 deploy 된다. RC soak 
 ## 관련
 
 - [dev-pipeline.md](./dev-pipeline.md) — rc-gate-pass status 가 rc-cut 의 source
-- [main-promotion.md](./main-promotion.md) — rc → main 머지 + deploy-android-*, deploy-ios-*
+- [main-promotion.md](./main-promotion.md) — main-cut + main-deploy + mobile deploy
 - [test-strategy.md](./test-strategy.md) — rc-pr-gate 와 mobile smoke 위치
 - [branch-flow.md](./branch-flow.md) — tag 컨벤션 + protection
 

--- a/docs/infra/branch-strategy/specs/branch-spec.md
+++ b/docs/infra/branch-strategy/specs/branch-spec.md
@@ -160,7 +160,7 @@ Protected branch 에 대한 direct push 는 human 에게 허용하지 않는다.
 |------|----|
 | Actor | `minglit-release-bot` (GitHub App 권장, 대안: fine-grained PAT 전용 bot account) |
 | Token source | GitHub App installation token minted from `minglit_env/{stage}/github.env` (`MINGLIT_RELEASE_BOT_APP_ID` + `MINGLIT_RELEASE_BOT_PRIVATE_KEY_BASE64`) |
-| 사용 workflow | `dev-staging-post-merge-sync`, `nightly-cut`, `rc-cut`, `rc-post-merge-sync`, `rc-soak-check`, `rc-hotfix-backport`, `main-post-merge-promote` |
+| 사용 workflow | `dev-staging-post-merge-sync`, `nightly-cut`, `rc-cut`, `rc-post-merge-sync`, `main-cut`, `rc-hotfix-backport`, `main-deploy` |
 | Ruleset bypass | `dev-staging`, `dev`, `rc/**`, `main`, protected tag push (`v*`, `promo/**`) |
 | Human 사용 | 금지. 로컬/수동 CLI 에서 token 사용 금지 |
 | Audit | 모든 bot push 는 workflow run URL, actor, target ref, tag 목록을 PR/issue 또는 job summary 에 남김 |

--- a/docs/infra/branch-strategy/specs/execution-plan.md
+++ b/docs/infra/branch-strategy/specs/execution-plan.md
@@ -8,7 +8,7 @@
 
 | 카테고리 | 파일 | 본 모델과의 관계 |
 |----------|------|------------------|
-| **Deploy** | `deploy-android-{user,partner}`, `deploy-ios-{user,partner}`, `deploy-supabase`, `deploy-vercel`, `deploy-dev-seed`, `shared-android-deploy` | spec 의 deploy 부분 — 재사용 + trigger refactor |
+| **Deploy** | `dev-deploy`, `rc-deploy`, `main-deploy`, `deploy-android-{user,partner}`, `deploy-ios-{user,partner}`, `deploy-dev-seed`, `shared-android-deploy` | branch-level deploy entrypoint + reusable/domain deploy jobs |
 | **PR / Review** | `pr-gate`, `pr-review-setup`, `doc-freshness` | spec 의 pr-gate-core 의 base — 추출·일반화 대상 |
 | **Post-merge** | `post-merge` (dev push orchestrator), `sync-version`, `sync-pr-branches`, `sync-test-coverage`, `sync-mds-mockups`, `sync-graphify` | spec 의 `*-post-merge-sync` 의 base — 부분 흡수 |
 | **Reusable** | `shared-android-deploy`, `shared-cuj-integration`, `shared-notify` | spec 의 reusable 패턴 — 추가 reusable extract 시 참고 |
@@ -30,11 +30,12 @@
 | `dev-staging-post-merge-sync` | `post-merge` + `sync-version` orchestration | **신규 (조합)** |
 | `nightly-cut` | (없음) | **신규** |
 | `nightly-pr-gate` | `dev-staging-pr-gate` 와 동일 (stage=nightly) | **신규 (얇은 wrapper)** |
-| `rc-gate` | (없음) — rc-gate-suite 호출 + status set + deploy chain | **신규** |
-| `rc-cut`, `rc-pr-gate`, `rc-post-merge-sync`, `rc-soak-check`, `rc-hotfix-backport` | (모두 없음) | **신규** |
-| `main-pr-gate`, `main-post-merge-promote` | (없음, 부분적으로 `sync-version`) | **신규 + refactor** |
-| `deploy-supabase` | 그대로 + trigger refactor (rc-gate-pass + push:main) | **trigger refactor** |
-| `deploy-vercel` | 그대로 + trigger refactor (cron 폐기 → rc-gate-pass + push:main) | **trigger refactor** |
+| `rc-gate` | (없음) — rc-gate-suite 호출 + status set | **신규** |
+| `dev-deploy` | dev deploy/smoke entrypoint (범위 TBD), event-flow 는 monitor 로 유지 | **신규/선택** |
+| `rc-cut`, `rc-pr-gate`, `rc-post-merge-sync`, `rc-deploy`, `main-cut`, `rc-hotfix-backport` | (모두 없음) | **신규** |
+| `main-pr-gate`, `main-deploy` | (없음, 부분적으로 `sync-version` / `deploy-*`) | **신규 + refactor** |
+| backend prod deploy | `deploy-supabase` 로직을 `main-deploy` 하위 job/reusable 로 흡수 | **refactor** |
+| web deploy | Vercel native build 로 전환 | **external config** |
 | `deploy-android-{user,partner}`, `deploy-ios-{user,partner}` | 그대로 (이미 push:main trigger) | **변경 없음** |
 | `deploy-dev-seed` | 본 spec scope 밖 (dev 환경 seeding) | **변경 없음** |
 
@@ -73,8 +74,8 @@
 | 2d | `minglit-release-bot` 생성 + App ID/private key 등록 + workflow permission 최소화 | protected branch/tag push 를 human 대신 bot 으로 수행 |
 | 2e | `auto-issue` reusable 추가 | 신규 — 기존 영향 없음 |
 | 2f | **`ci-result` 폐기** — 현 branch protection 의 required check `ci-result` 를 각 branch 의 `pr-gate` 로 변경 (Phase 4 에서 실제 적용) | 본 step 은 workflow 측 준비, 실제 protection 변경은 4 |
-| 2g | `deploy-supabase` 의 trigger refactor — push:dev 부분을 rc-gate-pass workflow_call **with target=main-staging** 로 변경, push:main 은 main-post-merge-promote 의 workflow_call **with target=main** | staging deploy 와 prod deploy 분리. 사용자 서버 영향 X |
-| 2h | **`deploy-vercel` 폐기** — 자체 빌드 워크플로우 제거. **Vercel native build 로 전환** (Vercel-GitHub 연결, Vercel-side: main=production, dev=preview) | Vercel-side 설정 필요, workflow 측 작업 없음 |
+| 2g | backend deploy 로직을 `main-deploy` 하위 job/reusable 로 정리. dev 에서는 prod backend deploy 하지 않음 | prod deploy 의 단일 진입점 확정 |
+| 2h | **`deploy-vercel` 폐기** — 자체 빌드 워크플로우 제거. **Vercel native build 로 전환** (Vercel-GitHub 연결, Vercel-side: main=production) | Vercel-side 설정 필요, workflow 측 작업 없음 |
 
 ### Rollback
 
@@ -97,10 +98,10 @@
 | 3a | `dev-staging-pr-gate`, `dev-staging-post-merge-sync` | 2a, 2b, 2c, 2d |
 | 3b | `nightly-cut`, `nightly-pr-gate` | 3a + dev-staging branch 존재 (Phase 1) |
 | 3c | `rc-gate-suite` reusable 조립 (CUJ × matrix + integration + Test Lab) | 2a |
-| 3d | `rc-gate` (호출 + status set + deploy chain trigger) | 3c + 2f/2g |
-| 3e | `rc-cut`, `rc-pr-gate`, `rc-post-merge-sync`, `rc-soak-check` | 3d + rc/* branch 패턴 확정 + Supabase branching 설정 |
+| 3d | `rc-gate` (호출 + status set) | 3c + 2f |
+| 3e | `rc-cut`, `rc-pr-gate`, `rc-post-merge-sync`, `rc-deploy`, `main-cut` | 3d + rc/* branch 패턴 확정 + Supabase branching 설정 |
 | 3f | `backport-pr` reusable, `rc-hotfix-backport` | 2a |
-| 3g | `main-pr-gate`, `main-post-merge-promote` | 3d (rc-gate-pass status 필요) |
+| 3g | `main-pr-gate`, `main-deploy` | 3d (rc-gate-pass status 필요) |
 
 ### Verification 단계
 

--- a/docs/infra/branch-strategy/specs/release-bot.md
+++ b/docs/infra/branch-strategy/specs/release-bot.md
@@ -88,9 +88,9 @@ git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
 | `nightly-cut` | immutable nightly branch 생성, dev PR 생성 |
 | `rc-cut` | `rc/YYYY-Wxx` branch 생성, RC tag |
 | `rc-post-merge-sync` | RC hotfix version bump/tag |
-| `rc-soak-check` | rc → main promotion PR 생성/auto-merge |
+| `main-cut` | rc → main promotion PR 생성/auto-merge |
 | `rc-hotfix-backport` | backport branch/PR 생성 |
-| `main-post-merge-promote` | final version/tag/release marker, RC branch cleanup |
+| `main-deploy` | final version/tag/release marker, prod deploy, RC branch cleanup |
 
 ## Ruleset Bypass
 

--- a/docs/infra/branch-strategy/specs/secret-migration-plan.md
+++ b/docs/infra/branch-strategy/specs/secret-migration-plan.md
@@ -22,12 +22,12 @@ minglit_env/
 ├── local/.env          # 로컬 개발자 환경
 ├── dev/.env            # CI 테스트 + dev workflow config
 ├── dev-staging → dev   # symlink (같은 env)
-├── main-staging/.env   # RC 가 deploy 되는 staging Supabase project (dev rc-gate-pass 가 deploy)
+├── rc/.env             # RC Supabase branching workflow config (ephemeral rc-YYYY-Wxx branches)
 ├── main/.env           # production (main 머지가 deploy)
 └── README.md           # 컨벤션 + 변수 카탈로그
 ```
 
-> **main-staging env 의 역할**: dev 가 계속 움직이는 동안 RC soak 가 *frozen 환경* 에서 검증되도록 staging Supabase project 를 별도 운영. dev rc-gate-pass 마다 deploy 되지만 사용자 서버 (main env) 영향 X.
+> **RC env 의 역할**: `rc-deploy` 가 Supabase branching 으로 `rc-YYYY-Wxx` 임시 branch 를 만들고 main 배포 전 backend 검증에 사용한다. `rc-gate-pass` 는 deploy trigger 가 아니라 RC cut source marker 다.
 
 기존 도메인별 파일 (`flutter.env`, `supabase.env`, `nextjs.env`, `metabase.env`) 은 통합 후 폐기.
 

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -4,12 +4,14 @@
 
 ## 명명 컨벤션
 
-- **Entry workflow**: `<stage>-<action>` 패턴 (예: `dev-staging-pr-gate`, `rc-cut`, `main-post-merge-promote`)
+- **Entry workflow**: `<stage>-<action>` 패턴 (예: `dev-staging-pr-gate`, `rc-cut`, `main-deploy`)
 - **Reusable workflow** (`workflow_call`): 명사·동사형 (예: `pr-gate-core`, `version-bump`)
 - File 이름 = workflow 이름 + `.yml`
 - Stage prefix: `dev-staging-` · `nightly-` · `rc-` · `main-`
 - Reusable 은 prefix 없음
-- **기존 deploy-* workflow 는 이름 유지** (예: `deploy-supabase`, `deploy-android-user`) — 재사용 + trigger 만 refactor
+- Deploy entry workflow 는 `[branch]-deploy` 로 통일한다: `dev-deploy`, `rc-deploy`, `main-deploy`
+- 기존 domain deploy workflow (`deploy-supabase`, `deploy-android-user` 등) 는 entrypoint 가 아니라 하위 구현/재사용 대상이다
+- 이벤트 플로우 시뮬레이터는 deploy workflow 가 아니라 `monitor-event-flow-*` batch job 이며, dev 에서 계속 돌고 RC 에서는 main 배포 전 검증 signal 로 사용한다
 
 ## Reusable Workflows (`workflow_call` building blocks)
 
@@ -35,7 +37,7 @@
 | Inputs | `version`: YY.MM.PR# / `suffix`: ""\|`-dev-staging`\|`-rc-NN` / `commit_message`: string |
 | Outputs | `commit_sha`, `tag_name` |
 | 핵심 steps | `bash scripts/bump-version.sh {version}{suffix}` · commit (`skip_ci` option) · `git tag v{version}{suffix}` · push |
-| Called by | `dev-staging-post-merge-sync`, `rc-cut`, `rc-post-merge-sync`, `main-post-merge-promote` |
+| Called by | `dev-staging-post-merge-sync`, `rc-cut`, `rc-post-merge-sync`, `main-deploy` |
 
 ### `rc-gate-suite`
 
@@ -123,33 +125,29 @@ Cross-branch cherry-pick PR 자동 생성.
 |------|----|
 | Trigger | `push` to `dev` (= nightly-cut PR merge 직후) |
 | Outputs | commit status `rc-gate-pass` (success only) |
-| Steps | (1) calls `rc-gate-suite` (2) **success**: set commit status `rc-gate-pass` → `workflow_call` `deploy-supabase` **with target=main-staging** (= staging Supabase project, NOT prod). Vercel 은 native build 가 dev branch → preview deployment 자동 처리 (3) **failure**: `auto-issue` (P1, label `rc-gate-failure`, assignee=직전 rc-gate-pass 이후 머지된 PR 작성자들). dev 는 broken 상태로 잠시 머묾, AI agent 가 fix PR 을 dev-staging 으로 normal flow 로 작성 → 다음 nightly-cut → 다음 rc-gate 가 검증 |
+| Steps | (1) calls `rc-gate-suite` (2) **success**: set commit status `rc-gate-pass` (3) **failure**: `auto-issue` (P1, label `rc-gate-failure`, assignee=직전 rc-gate-pass 이후 머지된 PR 작성자들). dev 는 broken 상태로 잠시 머묾, AI agent 가 fix PR 을 dev-staging 으로 normal flow 로 작성 → 다음 nightly-cut → 다음 rc-gate 가 검증 |
 | Backoff | 같은 area 3회 연속 실패 시 `rc-cut` 자동 차단 (다음 weekly cut PR 안 만듦) |
 
 > **No auto-revert** — snapshot 모델: 실패 = no tag, dev keeps moving, 새 fix 가 자연스럽게 다음 rc-gate 에서 검증됨.
 > **Naming** — `rc-gate-pass` 가 canonical RC eligibility marker 이다. `rc-eligible` 은 현재 workflow/status 명칭이 아니다.
 
-#### `deploy-supabase` (기존, refactor 대상)
+#### `dev-deploy`
 
 | 항목 | 값 |
 |------|----|
-| 현재 trigger | `push` to dev or main + paths filter |
-| Refactor 후 trigger | `workflow_call` (target=main-staging) from `rc-gate` (success) **+** `workflow_call` (target=main) from `main-post-merge-promote` |
-| Inputs | `target_env`: main-staging \| main |
-| Outputs | deploy status, Sentry release marker |
-| Steps | (1) Supabase migration apply to target env (2) EF deploy to target env (3) Sentry release marker (4) post-deploy smoke (5) 실패 시 retry → `auto-issue` (P0) + on-call |
-| Env file | `minglit_env/${target_env}/.env` (main-staging = staging Supabase project, main = prod Supabase project) |
+| Trigger | TBD (`push` to `dev` 또는 `workflow_dispatch`) |
+| Outputs | dev deploy/validation status |
+| Steps | dev 환경 배포 또는 smoke 가 필요할 때만 수행. backend prod deploy 는 여기서 하지 않고 `main-deploy` 에서 수행 |
+| Note | 이벤트 플로우 시뮬레이터는 `dev-deploy` 가 아니라 `monitor-event-flow-hourly` / `monitor-event-flow-daily` batch 로 계속 돈다 |
 
-#### `deploy-vercel` (폐기 예정)
+#### `monitor-event-flow-*` (release pipeline 외부 batch)
 
-기존 자체 빌드 워크플로우 폐기. **Vercel native build 로 전환** (Vercel-GitHub 연결, Vercel-side branch 매핑).
-
-| Branch | Vercel target |
-|--------|---------------|
-| `main` | production deployment |
-| `dev` (rc-gate-pass) | preview deployment (main-staging equivalent) |
-
-Vercel native 가 자체 trigger 및 build 처리. workflow 측 작업 없음.
+| 항목 | 값 |
+|------|----|
+| Trigger | schedule (`monitor-event-flow-hourly`, `monitor-event-flow-daily`) |
+| Branch/env | dev 를 계속 관찰. RC cut 후에는 RC env/Supabase branch 도 pre-main 검증 signal 로 사용 |
+| Outputs | event-flow simulation signal, issue/alert |
+| Note | promotion gate 자체가 아니라 지속 신호다. main deploy 를 대신하지 않는다 |
 
 ### rc
 
@@ -159,7 +157,7 @@ Vercel native 가 자체 trigger 및 build 처리. workflow 측 작업 없음.
 |------|----|
 | Trigger | `schedule` (weekly KST TBD) + `workflow_dispatch` |
 | Outputs | branch `rc/YYYY-Wxx` + tag `v{ver}-rc-01` + tag `promo/rc-YYYY-Wxx` |
-| Steps | (1) active RC marker 가 있으면 skip + Slack `#release` (hotfix 로 길어지는 중) (2) dev 의 최신 `rc-gate-pass` status SHA query (`gh api`) (3) 없으면 (3일+ green 없음) alert + abort (4) `git branch rc/YYYY-Wxx <SHA>` + push using release bot (5) Supabase branch 생성 + RC env deploy (6) calls `version-bump` (suffix=`-rc-01`) (7) `git tag promo/rc-YYYY-Wxx` + push (8) branch protection 활성화 (9) Slack `#release` 알림 |
+| Steps | (1) active RC marker 가 있으면 skip + Slack `#release` (hotfix 로 길어지는 중) (2) dev 의 최신 `rc-gate-pass` status SHA query (`gh api`) (3) 없으면 cut 보류 (4) `git branch rc/YYYY-Wxx <SHA>` + push using release bot (5) calls `version-bump` (suffix=`-rc-01`) (6) `git tag promo/rc-YYYY-Wxx` + push (7) branch protection 활성화 (8) Slack `#release` 알림 |
 
 #### `rc-pr-gate`
 
@@ -175,9 +173,18 @@ Vercel native 가 자체 trigger 및 build 처리. workflow 측 작업 없음.
 |------|----|
 | Trigger | `push` to `rc/*` (hotfix merge 후) |
 | Outputs | tag `v{ver}-rc-NN` (NN+1) |
-| Steps | (1) 현 rc 의 마지막 `v*-rc-*` tag 의 NN 파싱 (2) calls `version-bump` (suffix=`-rc-{NN+1}`) using release bot (3) RC Supabase branch 에 migration/EF 재적용 |
+| Steps | (1) 현 rc 의 마지막 `v*-rc-*` tag 의 NN 파싱 (2) calls `version-bump` (suffix=`-rc-{NN+1}`) using release bot |
 
-#### `rc-soak-check`
+#### `rc-deploy`
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `push` to `rc/*` + `workflow_dispatch` |
+| Outputs | RC env deploy/validation status |
+| Steps | (1) Supabase branch `rc-YYYY-Wxx` 생성/확인 (2) migration/EF apply to RC branch (3) RC env smoke (4) event-flow simulation signal 확인 (5) 실패 시 `auto-issue` |
+| Note | RC 는 계속 유지되는 장기 branch 가 아니라 Supabase branching 기반의 임시 검증 환경이다 |
+
+#### `main-cut`
 
 | 항목 | 값 |
 |------|----|
@@ -203,16 +210,16 @@ Vercel native 가 자체 trigger 및 build 처리. workflow 측 작업 없음.
 | Steps | (1) calls `pr-gate-core` (stage=main) (2) RC HEAD 의 `rc-gate-pass` commit status 확인 (3) PR 의 `rc-soak-passed` label 확인 |
 | Required for | main branch protection |
 
-#### `main-post-merge-promote`
+#### `main-deploy`
 
 | 항목 | 값 |
 |------|----|
 | Trigger | `push` to `main` (rc → main auto-merge 직후) |
 | Outputs | tag `v{ver}` + tag `promo/main-YYYY-Wxx` + Sentry marker + Firebase RC `latest_version` update + parallel deploy chain |
-| Steps | (1) calls `version-bump` (suffix="") using release bot (2) `git tag promo/main-YYYY-Wxx` + push (3) Sentry release marker `v{ver}` (4) Firebase RC `latest_version` = `v{ver}` (Admin SDK) (5) **parallel deploy chain** (모두 target=main env): `deploy-supabase`, mobile deploy workflows (6) RC Supabase branch 삭제 |
+| Steps | (1) calls `version-bump` (suffix="") using release bot (2) `git tag promo/main-YYYY-Wxx` + push (3) Sentry release marker `v{ver}` (4) Firebase RC `latest_version` = `v{ver}` (Admin SDK) (5) **parallel deploy chain** (모두 target=main env): backend prod deploy, mobile deploy workflows (6) RC Supabase branch 삭제 |
 
-> main push 후 자동 발동되는 deploy workflows (병렬):
-> - `deploy-supabase` (target=main, prod Supabase project) — EF + migration
+> `main-deploy` 내부 또는 하위 workflow 로 실행되는 deploy jobs:
+> - backend prod deploy (Supabase migration + EF)
 > - `deploy-android-user`, `deploy-android-partner` (each calls `shared-android-deploy`)
 > - `deploy-ios-user`, `deploy-ios-partner` (TBD: shared-ios-deploy reusable)
 > - Vercel: native build 가 main push 자동 감지 (workflow_call 아님)
@@ -234,8 +241,8 @@ Vercel native 가 자체 trigger 및 build 처리. workflow 측 작업 없음.
 [nightly-cut] ──PR created──▶ [nightly-pr-gate] ──auto-merge──▶ dev push
                                                                     ↓
                                                               [rc-gate]
-                                                              ├ success ─▶ status rc-gate-pass + [deploy-supabase target=main-staging] (+ Vercel preview native)
-                                                              │              ↓ Sentry release
+                                                              ├ success ─▶ status rc-gate-pass
+                                                              │              ↓ monitor-event-flow-* continuous signal
                                                               │
                                                               └ failure ─▶ [auto-issue P1] (AI agent assignee → dev-staging fix PR)
                                                                           (no auto-revert — dev 잠시 broken, 다음 fix 가 다음 rc-gate 에서 검증)
@@ -250,17 +257,19 @@ Vercel native 가 자체 trigger 및 build 처리. workflow 측 작업 없음.
                                                                 ↓ (parallel)
                                                           [rc-post-merge-sync] ──▶ v{ver}-rc-NN
                                                           [rc-hotfix-backport]  ──▶ backport PR to dev-staging
+                                                          [rc-deploy]           ──▶ Supabase branch + pre-main validation
 
 [daily cron, rc 존재 시]
     ↓
-[rc-soak-check] ──5일 무커밋──▶ rc → main PR (label rc-soak-passed)
+[main-cut] ──5일 무커밋──▶ rc → main PR (label rc-soak-passed)
                                        ↓ [main-pr-gate] → auto-merge
                                        ↓ main push
                                        ↓
-                                 [main-post-merge-promote]
+                                 [main-deploy]
                                        ↓ tag v{ver} + promo/main-Wxx + Sentry release
                                        ↓ Firebase RC `latest_version` = v{ver}
                                        ↓ (parallel)
+                                 [backend prod deploy] ──▶ Supabase main
                                  [deploy-android-user, deploy-android-partner] ──▶ Play Store
                                  [deploy-ios-user, deploy-ios-partner] ──▶ App Store Connect
                                  (각 workflow 가 push: main trigger 로 자동 발동, 병렬)
@@ -273,6 +282,8 @@ Vercel native 가 자체 trigger 및 build 처리. workflow 측 작업 없음.
 - `pr-gate-core` 의 stage 별 `extra_steps` 명세
 - `version-bump` 의 commit 방식 (별도 commit vs squash inline)
 - `rc-gate-suite` matrix 분할 (60분 예산)
+- `dev-deploy` 가 실제로 맡을 dev deploy/smoke 범위
+- `rc-deploy` 의 Supabase branch seed data 와 event-flow simulation contract
 - CUJ chaos 시나리오 정의 (현재 미정의)
 - Fastlane 설정 (Play `supply`, App Store `pilot`) + cert / keystore 관리
 - macOS runner 비용 (iOS build 비용)
@@ -290,4 +301,4 @@ Vercel native 가 자체 trigger 및 build 처리. workflow 측 작업 없음.
 - `execution-plan.md` (예정) — 기존 workflow refactor + 구현 순서
 
 ---
-_Reviewed: 2026-05-19 09:47_
+_Reviewed: 2026-05-24 10:24_

--- a/docs/infra/branch-strategy/test-strategy.md
+++ b/docs/infra/branch-strategy/test-strategy.md
@@ -57,7 +57,7 @@ RC 의 hotfix 만 받음. `pr-gate` + 추가 mobile smoke. 머지 시 `rc-post-m
 
 ### main-pr-gate
 
-`rc-soak-check` 가 자동 생성한 promotion PR 에 적용:
+`main-cut` 이 자동 생성한 promotion PR 에 적용:
 - pr-gate 재실행
 - `expand-migrate-contract` 다시 검증 (RC 5일 동안 dev 가 더 나갔을 수 있음)
 - RC HEAD 의 `rc-gate-pass` status 확인 (마지막 hotfix 이 rc-gate 통과했는지)

--- a/docs/infra/branch-strategy/versioning.md
+++ b/docs/infra/branch-strategy/versioning.md
@@ -34,7 +34,7 @@
 | `nightly-cut` | daily snapshot 생성 시 | version 변경 없음 (dev-staging 의 그대로 가져감, legacy `sync-version` dev trigger 비활성화) |
 | `rc-cut` | RC 브랜치 생성 시 | `bump-version.sh {ver}-rc-01` |
 | `rc-post-merge-sync` | RC hotfix 머지 직후 | `bump-version.sh {PR#}-rc-NN` (N 증가) |
-| `main-post-merge-promote` | rc → main 머지 직후 | `bump-version.sh {ver}` (suffix 제거) |
+| `main-deploy` | rc → main 머지 직후 | `bump-version.sh {ver}` (suffix 제거) |
 
 ## Tag 컨벤션
 
@@ -88,4 +88,4 @@ PR# 가 dev-staging 에서 부여되고 같은 PR# 가 후속 단계에서 suffi
 - 기존 [CLAUDE.md "Versioning Conventions"](../../../CLAUDE.md#versioning-conventions) — 원본
 
 ---
-_Reviewed: 2026-05-19 09:47_
+_Reviewed: 2026-05-24 10:24_


### PR DESCRIPTION
## Summary
- add Mermaid overview graph for the branch workflow model
- define the abstract entry workflow set, including `main-cut`, `rc-pr-gate`, `rc-deploy`, and `[branch]-deploy` naming
- document `monitor-event-flow-*` as a continuous batch signal, not a deploy workflow
- rename conceptual docs from `rc-soak-check`/`main-post-merge-promote` to `main-cut`/`main-deploy`

## Validation
- `git diff --check`
- searched for stale `rc-soak-check`, `main-post-merge-promote`, `main-staging` references
