### PR TITLE
ci: add branch promotion flow workflows

### DIFF
--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -20,19 +20,20 @@
 | `post-merge` | dev push 직후 follow-up 자동화의 단일 entry point (5 reusable orchestrator) | `post-merge` |
 | `tool-` | (수동으로 부를 때만 도는 도구) | (현재 없음 — 새 수동 도구 추가 시 prefix) |
 | `shared-` | (다른 워크플로우의 부품 — 단독 실행 X) | `shared-notify`, `shared-android-deploy` |
-| branch-strategy stage name | branch-strategy 문서의 stage entry workflow | `dev-staging-post-merge-sync`, `nightly-cut`, `rc-gate`, `dev-deploy`, `rc-cut`, `rc-deploy`, `main-cut`, `main-deploy` |
+| branch-strategy stage name | branch-strategy 문서의 stage entry workflow | `dev-staging-pr-gate`, `dev-staging-dev-cut-gate`, `dev-staging-dev-cut`, `dev-pr-gate`, `dev-rc-cut-gate`, `dev-rc-cut`, `rc-pr-gate`, `rc-main-cut-gate`, `rc-main-cut`, `main-pr-gate` |
 | reusable no-prefix | `workflow_call` 로만 호출되는 domain reusable | `version-bump` |
 
 ## Reusable Gates
 
 - `pr-gate.yml` 은 기존 `push`/`pull_request`/`merge_group` 진입점을 유지하면서 `workflow_call` 도 지원한다.
-- 호출자는 `stage` (`dev`, `dev-staging`, `nightly`, `rc`, `main`) 와 `base_ref` 를 넘겨 동일한 CI 코어를 stage 별 gate 로 재사용한다.
+- 호출자는 `stage` (`dev-staging`, `dev`, `rc`, `main`) 와 `base_ref` 를 넘겨 동일한 CI 코어를 stage 별 gate 로 재사용한다.
 - 기존 required check 는 아직 `ci-result` 그대로 유지한다. stage 별 required check 전환은 branch-strategy Phase 4 에서 Ruleset 과 함께 적용한다.
-- `dev-staging-post-merge-sync` 가 dev-staging 의 PR-number CalVer bump/tag 를 담당한다. `sync-version` 은 legacy main release bump 만 담당하며, `dev` promotion 은 `nightly-cut` 에서 version 변경 없이 처리한다.
-- `rc-gate` 는 dev push 후 user/partner CUJ integration 을 직접 실행하고, 통과한 commit 에만 `rc-gate-pass` status 를 찍는다. backend/EF/Test Lab 을 포함한 full `rc-gate-suite` matrix 는 후속 확장이다.
-- `rc-cut` 은 latest `rc-gate-pass` dev commit 에서 `rc/YYYY-Wxx` branch 를 만들고 `version-bump` 로 `v*-rc-01` + `promo/rc-*` tag 를 생성한다.
-- `main-cut` 은 5일 soak 를 통과한 `rc/*` 를 `main` PR 로 promote 한다.
-- deploy entry 는 `[branch]-deploy` 로 통일한다 (`dev-deploy`, `rc-deploy`, `main-deploy`). `monitor-event-flow-*` 는 deploy 가 아니라 지속 batch signal 이다.
+- `dev-staging-pr-gate`, `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 는 얇은 wrapper 로 시작한다. 현재는 `pr-gate.yml` 의 `ci-result` 를 재사용하고, branch ruleset 전환 시 이 wrapper job 이름을 required check 로 사용한다.
+- `dev-staging-dev-cut-gate` 가 dev-staging 의 PR-number CalVer bump/tag 를 담당한다. `sync-version` 은 legacy main release bump 만 담당하며, `dev` promotion 은 `dev-staging-dev-cut` 에서 version 변경 없이 처리한다.
+- `dev-rc-cut-gate` 는 dev push 후 user/partner CUJ integration 을 직접 실행하고, 통과한 commit 에만 `dev-rc-cut-pass` status 를 찍는다. backend/EF/Test Lab 을 포함한 full `dev-rc-cut-gate-suite` matrix 는 후속 확장이다.
+- `dev-rc-cut` 은 latest `dev-rc-cut-pass` dev commit 에서 `rc/YYYY-Wxx` branch 를 만들고 `version-bump` 로 `v*-rc-01` + `promo/rc-*` tag 를 생성한다.
+- `rc-main-cut-gate` 는 5일 soak 를 통과한 `rc/*` 에 `rc-main-cut-pass` 를 찍고, `rc-main-cut` 은 그 marker 를 소비해 `main` PR 을 만든다.
+- deploy entry 는 후속 단계에서 `[branch]-deploy` 로 통일한다 (`dev-deploy`, `rc-deploy`, `main-deploy`). `monitor-event-flow-*` 는 deploy 가 아니라 지속 batch signal 이다.
 - protected branch/tag 에 직접 push 하는 workflow 는 `minglit-release-bot` GitHub App token 을 사용한다. App credential 은 `minglit_env/{stage}/github.env` 파일에서 먼저 읽고, 공통 token mint 는 `.github/actions/release-bot-token` 에서 처리한다.
 
 ## 컨벤션

--- a/.github/workflows/dev-pr-gate.yml
+++ b/.github/workflows/dev-pr-gate.yml
@@ -1,0 +1,36 @@
+name: dev-pr-gate
+
+on:
+  pull_request:
+    branches: [dev]
+
+permissions:
+  contents: write
+  pull-requests: read
+  checks: write
+  issues: write
+
+concurrency:
+  group: dev-pr-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr-gate-core:
+    uses: ./.github/workflows/pr-gate.yml
+    with:
+      stage: dev
+      base_ref: dev
+    secrets: inherit
+
+  dev-pr-gate:
+    needs: [pr-gate-core]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish branch gate result
+        run: |
+          if [ "${{ needs.pr-gate-core.result }}" != "success" ]; then
+            echo "::error::pr-gate-core result: ${{ needs.pr-gate-core.result }}"
+            exit 1
+          fi
+          echo "dev-pr-gate passed"

--- a/.github/workflows/dev-rc-cut-gate.yml
+++ b/.github/workflows/dev-rc-cut-gate.yml
@@ -1,4 +1,4 @@
-name: rc-gate
+name: dev-rc-cut-gate
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: rc-gate-${{ github.ref }}
+  group: dev-rc-cut-gate-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -29,8 +29,8 @@ jobs:
       app-name: partner
     secrets: inherit
 
-  set-rc-gate-status:
-    name: set-rc-gate-status
+  set-dev-rc-cut-status:
+    name: set-dev-rc-cut-status
     needs: [cuj-integration-user, cuj-integration-partner]
     if: always()
     runs-on: ubuntu-latest
@@ -44,20 +44,20 @@ jobs:
           gh api "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
             --method POST \
             -f state=success \
-            -f context=rc-gate-pass \
-            -f description="rc-gate passed; this dev commit can be cut to RC" \
+            -f context=dev-rc-cut-pass \
+            -f description="dev-rc-cut-gate passed; this dev commit can be cut to RC" \
             -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
-      - name: Fail rc-gate without publishing rc-gate-pass
+      - name: Fail dev-rc-cut-gate without publishing dev-rc-cut-pass
         if: ${{ needs.cuj-integration-user.result != 'success' || needs.cuj-integration-partner.result != 'success' }}
         run: |
-          echo "::error::rc-gate failed; rc-gate-pass status was not set."
+          echo "::error::dev-rc-cut-gate failed; dev-rc-cut-pass status was not set."
           echo "cuj-integration-user=${{ needs.cuj-integration-user.result }}"
           echo "cuj-integration-partner=${{ needs.cuj-integration-partner.result }}"
           exit 1
 
   notify-failure:
-    needs: [cuj-integration-user, cuj-integration-partner, set-rc-gate-status]
+    needs: [cuj-integration-user, cuj-integration-partner, set-dev-rc-cut-status]
     if: always()
     permissions:
       issues: write
@@ -67,7 +67,7 @@ jobs:
         ${{
           needs.cuj-integration-user.result == 'success' &&
           needs.cuj-integration-partner.result == 'success' &&
-          needs.set-rc-gate-status.result == 'success'
+          needs.set-dev-rc-cut-status.result == 'success'
         }}
-      workflow_name: 'RC Gate'
-      job_results: '{"cuj-integration-user":"${{ needs.cuj-integration-user.result }}","cuj-integration-partner":"${{ needs.cuj-integration-partner.result }}","set-rc-gate-status":"${{ needs.set-rc-gate-status.result }}"}'
+      workflow_name: 'Dev RC Cut Gate'
+      job_results: '{"cuj-integration-user":"${{ needs.cuj-integration-user.result }}","cuj-integration-partner":"${{ needs.cuj-integration-partner.result }}","set-dev-rc-cut-status":"${{ needs.set-dev-rc-cut-status.result }}"}'

--- a/.github/workflows/dev-rc-cut.yml
+++ b/.github/workflows/dev-rc-cut.yml
@@ -1,4 +1,4 @@
-name: rc-cut
+name: dev-rc-cut
 
 on:
   schedule:
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       source_sha:
-        description: Optional dev commit SHA to cut instead of the latest rc-gate-pass commit.
+        description: Optional dev commit SHA to cut instead of the latest dev-rc-cut-pass commit.
         required: false
         type: string
       rc_week:
@@ -21,7 +21,7 @@ on:
         default: false
 
 concurrency:
-  group: rc-cut
+  group: dev-rc-cut
   cancel-in-progress: false
 
 permissions:
@@ -84,7 +84,7 @@ jobs:
 
           ACTIVE_RC="$(git ls-remote --heads origin 'rc/*' | awk '{print $2}' | sed 's#refs/heads/##' | sort | xargs || true)"
           if [ -n "${ACTIVE_RC}" ] && [ "${ALLOW_ACTIVE_RC}" != "true" ]; then
-            echo "Active RC branch exists (${ACTIVE_RC}); skipping rc-cut."
+            echo "Active RC branch exists (${ACTIVE_RC}); skipping dev-rc-cut."
             echo "skipped=true" >> "$GITHUB_OUTPUT"
             echo "rc_week=${RC_WEEK}" >> "$GITHUB_OUTPUT"
             echo "rc_branch=${RC_BRANCH}" >> "$GITHUB_OUTPUT"
@@ -109,7 +109,7 @@ jobs:
           else
             for sha in $(git rev-list --first-parent -n 200 origin/dev); do
               state="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${sha}/status" \
-                --jq '[.statuses[] | select(.context == "rc-gate-pass")][0].state // empty' || true)"
+                --jq '[.statuses[] | select(.context == "dev-rc-cut-pass")][0].state // empty' || true)"
               if [ "${state}" = "success" ]; then
                 SOURCE_SHA="${sha}"
                 break
@@ -118,7 +118,7 @@ jobs:
           fi
 
           if [ -z "${SOURCE_SHA}" ]; then
-            echo "::warning::No origin/dev commit with successful rc-gate-pass status found in the latest 200 first-parent commits; skipping rc-cut."
+            echo "::warning::No origin/dev commit with successful dev-rc-cut-pass status found in the latest 200 first-parent commits; skipping dev-rc-cut."
             echo "skipped=true" >> "$GITHUB_OUTPUT"
             echo "rc_week=${RC_WEEK}" >> "$GITHUB_OUTPUT"
             echo "rc_branch=${RC_BRANCH}" >> "$GITHUB_OUTPUT"
@@ -216,5 +216,5 @@ jobs:
             needs.tag-promo.result == 'success'
           )
         }}
-      workflow_name: 'RC Cut'
+      workflow_name: 'Dev RC Cut'
       job_results: '{"plan":"${{ needs.plan.result }}","bump":"${{ needs.bump.result }}","tag-promo":"${{ needs.tag-promo.result }}"}'

--- a/.github/workflows/dev-staging-dev-cut-gate.yml
+++ b/.github/workflows/dev-staging-dev-cut-gate.yml
@@ -1,4 +1,4 @@
-name: dev-staging-post-merge-sync
+name: dev-staging-dev-cut-gate
 
 on:
   push:
@@ -11,7 +11,7 @@ on:
         type: string
 
 concurrency:
-  group: dev-staging-post-merge-sync
+  group: dev-staging-dev-cut-gate
   cancel-in-progress: false
 
 permissions:
@@ -94,5 +94,5 @@ jobs:
           (needs.calculate-version.result == 'success' || needs.calculate-version.result == 'skipped') &&
           (needs.bump.result == 'success' || needs.bump.result == 'skipped')
         }}
-      workflow_name: 'Dev-Staging Post-Merge Sync'
+      workflow_name: 'Dev-Staging Dev Cut Gate'
       job_results: '{"calculate-version":"${{ needs.calculate-version.result }}","bump":"${{ needs.bump.result }}"}'

--- a/.github/workflows/dev-staging-dev-cut.yml
+++ b/.github/workflows/dev-staging-dev-cut.yml
@@ -1,4 +1,4 @@
-name: nightly-cut
+name: dev-staging-dev-cut
 
 on:
   schedule:
@@ -12,7 +12,7 @@ on:
         type: string
 
 concurrency:
-  group: nightly-cut
+  group: dev-staging-dev-cut
   cancel-in-progress: false
 
 permissions:
@@ -21,7 +21,7 @@ permissions:
   issues: write
 
 jobs:
-  create-nightly-pr:
+  create-dev-cut-pr:
     runs-on: ubuntu-latest
     outputs:
       skipped: ${{ steps.plan.outputs.skipped }}
@@ -42,7 +42,7 @@ jobs:
           fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
           fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
 
-      - name: Plan nightly promotion
+      - name: Plan dev promotion
         id: plan
         env:
           GH_TOKEN: ${{ github.token }}
@@ -58,9 +58,9 @@ jobs:
             --base dev \
             --state open \
             --json number,headRefName \
-            --jq '[.[] | select(.headRefName | startswith("nightly/"))][0].number // empty')"
+            --jq '[.[] | select((.headRefName | startswith("cut/dev-staging-dev/")) or (.headRefName | startswith("nightly/")))][0].number // empty')"
           if [ -n "${OPEN_PR}" ]; then
-            echo "Nightly PR #${OPEN_PR} is already open; skipping."
+            echo "dev-staging-dev-cut PR #${OPEN_PR} is already open; skipping."
             echo "skipped=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -98,7 +98,7 @@ jobs:
 
           RUN_DATE="$(TZ=Asia/Seoul date +%Y-%m-%d)"
           SHORT_SHA="${TAG_SHA:0:8}"
-          BRANCH_NAME="nightly/${RUN_DATE}-${SHORT_SHA}"
+          BRANCH_NAME="cut/dev-staging-dev/${RUN_DATE}-${SHORT_SHA}"
           if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" >/dev/null 2>&1; then
             BRANCH_NAME="${BRANCH_NAME}-${GITHUB_RUN_ID}"
           fi
@@ -108,7 +108,7 @@ jobs:
           echo "tag_sha=${TAG_SHA}" >> "$GITHUB_OUTPUT"
           echo "branch_name=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
 
-      - name: Push nightly branch
+      - name: Push dev promotion branch
         if: steps.plan.outputs.skipped != 'true'
         env:
           RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
@@ -120,7 +120,7 @@ jobs:
           git push origin "${TAG_SHA}:refs/heads/${BRANCH_NAME}"
           git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
 
-      - name: Create nightly PR and enable auto-merge
+      - name: Create dev promotion PR and enable auto-merge
         id: pr
         if: steps.plan.outputs.skipped != 'true'
         env:
@@ -142,7 +142,7 @@ jobs:
           PR_URL="$(gh pr create \
             --base dev \
             --head "${BRANCH_NAME}" \
-            --title "ci(nightly-cut): promote ${TAG_NAME} to dev" \
+            --title "ci(dev-staging-dev-cut): promote ${TAG_NAME} to dev" \
             --body "${BODY}")"
           PR_NUMBER="${PR_URL##*/}"
 
@@ -150,12 +150,12 @@ jobs:
           echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
   notify-failure:
-    needs: [create-nightly-pr]
+    needs: [create-dev-cut-pr]
     if: always()
     permissions:
       issues: write
     uses: ./.github/workflows/shared-notify.yml
     with:
-      success: ${{ needs.create-nightly-pr.result == 'success' || needs.create-nightly-pr.result == 'skipped' }}
-      workflow_name: 'Nightly Cut'
-      job_results: '{"create-nightly-pr":"${{ needs.create-nightly-pr.result }}"}'
+      success: ${{ needs.create-dev-cut-pr.result == 'success' || needs.create-dev-cut-pr.result == 'skipped' }}
+      workflow_name: 'Dev-Staging Dev Cut'
+      job_results: '{"create-dev-cut-pr":"${{ needs.create-dev-cut-pr.result }}"}'

--- a/.github/workflows/dev-staging-pr-gate.yml
+++ b/.github/workflows/dev-staging-pr-gate.yml
@@ -1,0 +1,36 @@
+name: dev-staging-pr-gate
+
+on:
+  pull_request:
+    branches: [dev-staging]
+
+permissions:
+  contents: write
+  pull-requests: read
+  checks: write
+  issues: write
+
+concurrency:
+  group: dev-staging-pr-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr-gate-core:
+    uses: ./.github/workflows/pr-gate.yml
+    with:
+      stage: dev-staging
+      base_ref: dev-staging
+    secrets: inherit
+
+  dev-staging-pr-gate:
+    needs: [pr-gate-core]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish branch gate result
+        run: |
+          if [ "${{ needs.pr-gate-core.result }}" != "success" ]; then
+            echo "::error::pr-gate-core result: ${{ needs.pr-gate-core.result }}"
+            exit 1
+          fi
+          echo "dev-staging-pr-gate passed"

--- a/.github/workflows/main-pr-gate.yml
+++ b/.github/workflows/main-pr-gate.yml
@@ -1,0 +1,36 @@
+name: main-pr-gate
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+  checks: write
+  issues: write
+
+concurrency:
+  group: main-pr-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr-gate-core:
+    uses: ./.github/workflows/pr-gate.yml
+    with:
+      stage: main
+      base_ref: main
+    secrets: inherit
+
+  main-pr-gate:
+    needs: [pr-gate-core]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish branch gate result
+        run: |
+          if [ "${{ needs.pr-gate-core.result }}" != "success" ]; then
+            echo "::error::pr-gate-core result: ${{ needs.pr-gate-core.result }}"
+            exit 1
+          fi
+          echo "main-pr-gate passed"

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       stage:
-        description: 'Logical gate stage: dev, dev-staging, nightly, rc, or main'
+        description: 'Logical gate stage: dev-staging, dev, rc, or main'
         required: false
         type: string
         default: 'dev'

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -22,7 +22,7 @@ on:
 concurrency:
   # merge_group 이벤트는 절대 cancel 금지 — 큐 전체가 thrash됨.
   # PR 단계(pull_request)에서만 새 푸시 시 이전 run cancel.
-  group: pr-gate-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
+  group: pr-gate-${{ inputs.stage || github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/rc-main-cut-gate.yml
+++ b/.github/workflows/rc-main-cut-gate.yml
@@ -1,0 +1,125 @@
+name: rc-main-cut-gate
+
+on:
+  schedule:
+    # 09:00 KST daily.
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      rc_branch:
+        description: Optional rc branch, e.g. rc/2026-W22. Defaults to latest rc/*.
+        required: false
+        type: string
+      min_soak_days:
+        description: Minimum days since the latest RC commit.
+        required: false
+        type: string
+        default: '5'
+
+concurrency:
+  group: rc-main-cut-gate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  statuses: write
+  issues: write
+
+jobs:
+  mark-main-cut-eligible:
+    runs-on: ubuntu-latest
+    outputs:
+      skipped: ${{ steps.plan.outputs.skipped }}
+      rc_branch: ${{ steps.plan.outputs.rc_branch }}
+      rc_sha: ${{ steps.plan.outputs.rc_sha }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Select RC branch and check soak window
+        id: plan
+        env:
+          REQUESTED_RC_BRANCH: ${{ inputs.rc_branch || '' }}
+          MIN_SOAK_DAYS: ${{ inputs.min_soak_days || '5' }}
+        run: |
+          set -euo pipefail
+
+          if ! [[ "${MIN_SOAK_DAYS}" =~ ^[0-9]+$ ]]; then
+            echo "::error::min_soak_days must be a non-negative integer"
+            exit 1
+          fi
+
+          if ! git ls-remote --exit-code --heads origin 'rc/*' >/dev/null 2>&1; then
+            echo "No rc/* branch exists; skipping."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch origin '+refs/heads/rc/*:refs/remotes/origin/rc/*' --force
+
+          RC_BRANCH="${REQUESTED_RC_BRANCH}"
+          if [ -z "${RC_BRANCH}" ]; then
+            RC_BRANCH="$(git for-each-ref \
+              --sort=-committerdate \
+              --format='%(refname:short)' \
+              refs/remotes/origin/rc | sed 's#^origin/##' | head -n 1)"
+          fi
+
+          if [ -z "${RC_BRANCH}" ]; then
+            echo "No rc/* branch exists; skipping."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! [[ "${RC_BRANCH}" =~ ^rc/[0-9]{4}-W[0-9]{2}$ ]]; then
+            echo "::error::Invalid rc_branch: ${RC_BRANCH}. Expected rc/YYYY-Www."
+            exit 1
+          fi
+
+          RC_REF="origin/${RC_BRANCH}"
+          if ! git rev-parse -q --verify "${RC_REF}^{commit}" >/dev/null; then
+            echo "::error::RC branch ${RC_BRANCH} not found on origin."
+            exit 1
+          fi
+
+          RC_SHA="$(git rev-parse "${RC_REF}")"
+          COMMIT_TS="$(git show -s --format=%ct "${RC_SHA}")"
+          NOW_TS="$(date +%s)"
+          AGE_DAYS="$(( (NOW_TS - COMMIT_TS) / 86400 ))"
+
+          if [ "${AGE_DAYS}" -lt "${MIN_SOAK_DAYS}" ]; then
+            echo "RC ${RC_BRANCH} is ${AGE_DAYS}d old; needs ${MIN_SOAK_DAYS}d. Skipping."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            echo "rc_branch=${RC_BRANCH}" >> "$GITHUB_OUTPUT"
+            echo "rc_sha=${RC_SHA}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+          echo "rc_branch=${RC_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "rc_sha=${RC_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Mark RC as main cut eligible
+        if: steps.plan.outputs.skipped != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RC_SHA: ${{ steps.plan.outputs.rc_sha }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${RC_SHA}" \
+            --method POST \
+            -f state=success \
+            -f context=rc-main-cut-pass \
+            -f description="rc-main-cut-gate passed; this RC can be promoted to main" \
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+  notify-failure:
+    needs: [mark-main-cut-eligible]
+    if: always()
+    permissions:
+      issues: write
+    uses: ./.github/workflows/shared-notify.yml
+    with:
+      success: ${{ needs.mark-main-cut-eligible.result == 'success' || needs.mark-main-cut-eligible.outputs.skipped == 'true' }}
+      workflow_name: 'RC Main Cut Gate'
+      job_results: '{"mark-main-cut-eligible":"${{ needs.mark-main-cut-eligible.result }}"}'

--- a/.github/workflows/rc-main-cut.yml
+++ b/.github/workflows/rc-main-cut.yml
@@ -1,0 +1,162 @@
+name: rc-main-cut
+
+on:
+  schedule:
+    # 09:15 KST daily, after rc-main-cut-gate.
+    - cron: '15 0 * * *'
+  workflow_dispatch:
+    inputs:
+      rc_branch:
+        description: Optional rc branch, e.g. rc/2026-W22. Defaults to latest rc-main-cut-pass.
+        required: false
+        type: string
+
+concurrency:
+  group: rc-main-cut
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  statuses: read
+  issues: write
+
+jobs:
+  create-main-pr:
+    runs-on: ubuntu-latest
+    outputs:
+      skipped: ${{ steps.plan.outputs.skipped }}
+      pr_number: ${{ steps.pr.outputs.pr_number }}
+      rc_branch: ${{ steps.plan.outputs.rc_branch }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Generate release bot token
+        id: release-bot
+        uses: ./.github/actions/release-bot-token
+        with:
+          fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
+          fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Plan main promotion
+        id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_RC_BRANCH: ${{ inputs.rc_branch || '' }}
+        run: |
+          set -euo pipefail
+
+          git fetch origin main --tags --force
+          if ! git ls-remote --exit-code --heads origin 'rc/*' >/dev/null 2>&1; then
+            echo "No rc/* branch exists; skipping."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch origin '+refs/heads/rc/*:refs/remotes/origin/rc/*' --force
+
+          OPEN_PR="$(gh pr list \
+            --base main \
+            --state open \
+            --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("rc/"))][0].number // empty')"
+          if [ -n "${OPEN_PR}" ]; then
+            echo "rc-main-cut PR #${OPEN_PR} is already open; skipping."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          RC_BRANCH="${REQUESTED_RC_BRANCH}"
+          if [ -z "${RC_BRANCH}" ]; then
+            while read -r candidate; do
+              [ -n "${candidate}" ] || continue
+              sha="$(git rev-parse "origin/${candidate}")"
+              state="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${sha}/status" \
+                --jq '[.statuses[] | select(.context == "rc-main-cut-pass")][0].state // empty' || true)"
+              if [ "${state}" = "success" ]; then
+                RC_BRANCH="${candidate}"
+                break
+              fi
+            done < <(git for-each-ref --sort=-committerdate --format='%(refname:short)' refs/remotes/origin/rc | sed 's#^origin/##')
+          fi
+
+          if [ -z "${RC_BRANCH}" ]; then
+            echo "No rc/* branch with rc-main-cut-pass exists; skipping."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! [[ "${RC_BRANCH}" =~ ^rc/[0-9]{4}-W[0-9]{2}$ ]]; then
+            echo "::error::Invalid rc_branch: ${RC_BRANCH}. Expected rc/YYYY-Www."
+            exit 1
+          fi
+
+          RC_SHA="$(git rev-parse "origin/${RC_BRANCH}")"
+          state="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RC_SHA}/status" \
+            --jq '[.statuses[] | select(.context == "rc-main-cut-pass")][0].state // empty' || true)"
+          if [ "${state}" != "success" ]; then
+            echo "RC ${RC_BRANCH} does not have rc-main-cut-pass; skipping."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            echo "rc_branch=${RC_BRANCH}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git merge-base --is-ancestor "${RC_SHA}" origin/main; then
+            echo "origin/main already contains ${RC_BRANCH}; skipping."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            echo "rc_branch=${RC_BRANCH}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+          echo "rc_branch=${RC_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "rc_sha=${RC_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Create main promotion PR and enable auto-merge
+        id: pr
+        if: steps.plan.outputs.skipped != 'true'
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          RC_BRANCH: ${{ steps.plan.outputs.rc_branch }}
+          RC_SHA: ${{ steps.plan.outputs.rc_sha }}
+        run: |
+          set -euo pipefail
+
+          gh label create rc-main-cut-pass \
+            --description "RC passed rc-main-cut-gate" \
+            --color 0E8A16 \
+            --force
+
+          BODY="$(cat <<EOF
+          Promotes \`${RC_BRANCH}\` to \`main\`.
+
+          - Source branch: ${RC_BRANCH}
+          - Source SHA: ${RC_SHA}
+          - Required marker: rc-main-cut-pass
+          - Merge mode: rebase, because main requires linear history.
+          EOF
+          )"
+
+          PR_URL="$(gh pr create \
+            --base main \
+            --head "${RC_BRANCH}" \
+            --title "ci(rc-main-cut): promote ${RC_BRANCH} to main" \
+            --body "${BODY}" \
+            --label rc-main-cut-pass)"
+          PR_NUMBER="${PR_URL##*/}"
+
+          gh pr merge "${PR_NUMBER}" --auto --rebase --delete-branch
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+  notify-failure:
+    needs: [create-main-pr]
+    if: always()
+    permissions:
+      issues: write
+    uses: ./.github/workflows/shared-notify.yml
+    with:
+      success: ${{ needs.create-main-pr.result == 'success' || needs.create-main-pr.outputs.skipped == 'true' }}
+      workflow_name: 'RC Main Cut'
+      job_results: '{"create-main-pr":"${{ needs.create-main-pr.result }}"}'

--- a/.github/workflows/rc-pr-gate.yml
+++ b/.github/workflows/rc-pr-gate.yml
@@ -1,0 +1,36 @@
+name: rc-pr-gate
+
+on:
+  pull_request:
+    branches: ['rc/**']
+
+permissions:
+  contents: write
+  pull-requests: read
+  checks: write
+  issues: write
+
+concurrency:
+  group: rc-pr-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr-gate-core:
+    uses: ./.github/workflows/pr-gate.yml
+    with:
+      stage: rc
+      base_ref: ${{ github.base_ref }}
+    secrets: inherit
+
+  rc-pr-gate:
+    needs: [pr-gate-core]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish branch gate result
+        run: |
+          if [ "${{ needs.pr-gate-core.result }}" != "success" ]; then
+            echo "::error::pr-gate-core result: ${{ needs.pr-gate-core.result }}"
+            exit 1
+          fi
+          echo "rc-pr-gate passed"

--- a/docs/infra/branch-strategy/BLUEDOC.md
+++ b/docs/infra/branch-strategy/BLUEDOC.md
@@ -1,6 +1,6 @@
 # Branch Strategy
 
-4-stage (`dev-staging → dev → rc → main`) + 일반 PR/auto-merge + nightly snapshot + `rc-gate` green build picking + feature flag + 3가지 safety net. AI agent 가 dev-staging 에 PR, `rc-gate-pass` commit 에서 RC 를 cut 하고, main 머지에서 backend + mobile 모두 prod 로 deploy 한다 (hotfix 없으면 weekly). 이벤트 플로우 시뮬레이터는 release promotion 과 별개인 batch monitor 로 계속 돈다.
+4-stage (`dev-staging → dev → rc → main`) + 일반 PR/auto-merge + cut-gate/cut SRP + feature flag + 3가지 safety net. AI agent 가 dev-staging 에 PR, `dev-rc-cut-pass` commit 에서 RC 를 cut 하고, `rc-main-cut-pass` RC 에서 main PR 을 cut 한다. main 머지에서 backend + mobile 모두 prod 로 deploy 한다 (hotfix 없으면 weekly). 이벤트 플로우 시뮬레이터는 release promotion 과 별개인 batch monitor 로 계속 돈다.
 
 ## Workflow Overview
 
@@ -8,17 +8,17 @@
 flowchart LR
   agent[Agent / Human PR] --> dsg[dev-staging-pr-gate]
   dsg --> ds[dev-staging]
-  ds --> dss[dev-staging-post-merge-sync]
+  ds --> dss[dev-staging-dev-cut-gate]
   dss --> dstag["v*-dev-staging tag"]
 
-  dstag --> nc[nightly-cut]
-  nc --> npg[nightly-pr-gate]
+  dstag --> nc[dev-staging-dev-cut]
+  nc --> npg[dev-pr-gate]
   npg --> dev[dev]
 
-  dev --> rg[rc-gate]
-  rg -->|pass| rgp["rc-gate-pass status"]
+  dev --> rg[dev-rc-cut-gate]
+  rg -->|pass| rgp["dev-rc-cut-pass status"]
   rg -->|fail| issue[auto issue + fix via dev-staging]
-  rgp --> rcut[rc-cut]
+  rgp --> rcut[dev-rc-cut]
   rcut --> rc["rc/YYYY-Wxx"]
 
   rc --> rpg[rc-pr-gate]
@@ -28,7 +28,10 @@ flowchart LR
   rbp --> ds
 
   rc --> rcd[rc-deploy]
-  rc --> mcut[main-cut]
+  rc --> rmcg[rc-main-cut-gate]
+  rcd --> rmcg
+  rmcg -->|pass| rmcp["rc-main-cut-pass marker"]
+  rmcp --> mcut[rc-main-cut]
   mcut --> mpg[main-pr-gate]
   mpg --> main[main]
   main --> md[main-deploy]
@@ -43,14 +46,15 @@ flowchart LR
 | 단계 | Entry workflow | 역할 |
 |------|----------------|------|
 | dev-staging PR | `dev-staging-pr-gate` | feature/agent PR 의 빠른 CI gate |
-| dev-staging post-merge | `dev-staging-post-merge-sync` | `v*-dev-staging` version/tag 생성 |
-| dev promotion | `nightly-cut` + `nightly-pr-gate` | coherent dev-staging snapshot 을 dev 로 promote |
-| dev post-merge | `rc-gate` | RC 후보 검증 후 `rc-gate-pass` status 부여 |
+| dev-staging → dev cut gate | `dev-staging-dev-cut-gate` | dev 로 promote 할 coherent dev-staging snapshot 을 `v*-dev-staging` tag 로 선별 |
+| dev-staging → dev cut | `dev-staging-dev-cut` + `dev-pr-gate` | gate 가 선별한 snapshot 을 dev PR 로 promote |
+| dev → rc cut gate | `dev-rc-cut-gate` | RC 후보 검증 후 `dev-rc-cut-pass` status 부여 |
 | dev deploy/validation | `dev-deploy` | dev 환경 deploy/validation orchestrator. 이벤트 플로우 시뮬레이터는 `monitor-event-flow-*` batch 로 별도 운영 |
-| rc creation | `rc-cut` | latest `rc-gate-pass` commit 에서 `rc/YYYY-Wxx` 생성 |
+| dev → rc cut | `dev-rc-cut` | latest `dev-rc-cut-pass` commit 에서 `rc/YYYY-Wxx` 생성 |
 | rc hotfix | `rc-pr-gate` + `rc-post-merge-sync` + `rc-hotfix-backport` | RC hotfix 검증, RC version bump, dev-staging backport |
 | rc deploy/validation | `rc-deploy` | Supabase branching 기반 RC 검증 환경 구성 + pre-main validation |
-| main promotion | `main-cut` + `main-pr-gate` | soak 완료 RC 를 main PR 로 promote |
+| rc → main cut gate | `rc-main-cut-gate` | soak/pre-main validation 통과 RC 에 `rc-main-cut-pass` marker 부여 |
+| rc → main cut | `rc-main-cut` + `main-pr-gate` | gate 가 선별한 RC 를 main PR 로 promote |
 | prod deploy | `main-deploy` | final version/tag, prod backend/mobile deploy, RC cleanup |
 
 ## 4-stage 모델
@@ -58,8 +62,8 @@ flowchart LR
 | 단계 | 역할 | 진입 방식 |
 |------|------|-----------|
 | `dev-staging` | AI agent commit zone | 일반 PR + auto-merge + 가벼운 `pr-gate` |
-| `dev` | nightly-validated trunk | daily `nightly-cut` → post-merge `rc-gate` |
-| `rc/YYYY-Wxx` | mobile RC, 5일 soak | weekly cut from latest rc-gate-pass |
+| `dev` | cut-gate validated trunk | daily `dev-staging-dev-cut` → post-merge `dev-rc-cut-gate` |
+| `rc/YYYY-Wxx` | mobile RC, 5일 soak | weekly cut from latest dev-rc-cut-pass |
 | `main` | mobile-stable snapshot | rc → main 머지 (soak 통과 시) |
 
 ## Safety Nets 3종
@@ -78,8 +82,8 @@ flowchart LR
 | [test-strategy.md](./test-strategy.md) | per-stage gates |
 | [error-detection.md](./error-detection.md) | detection layers |
 | [dev-staging-pipeline.md](./dev-staging-pipeline.md) | 일반 PR/auto-merge + pr-gate + safety net CI |
-| [dev-pipeline.md](./dev-pipeline.md) | nightly-cut + rc-gate + auto-deploy chain |
-| [rc-promotion.md](./rc-promotion.md) | rc-cut + soak + hotfix + backport |
+| [dev-pipeline.md](./dev-pipeline.md) | dev-staging-dev-cut + dev-rc-cut-gate + auto-deploy chain |
+| [rc-promotion.md](./rc-promotion.md) | dev-rc-cut + soak + hotfix + backport |
 | [main-promotion.md](./main-promotion.md) | rc → main + main-deploy + min-version |
 | [life-of-flag.md](./life-of-flag.md) | flag lifecycle |
 | [versioning.md](./versioning.md) | CalVer + tag |
@@ -92,6 +96,7 @@ flowchart LR
 ## 핵심 컨벤션
 
 - 코드 promotion = 한 방향 PR, 기능 promotion = flag flip
+- `*-cut-gate` = 다음 브랜치로 promote 할 source artifact 선별/마킹, `*-cut` = 그 artifact 로 PR/branch 생성. 검증과 promotion 을 같은 workflow 에 섞지 않는다
 - 모든 branch linear ON — dev-staging: squash, dev/rc/main: rebase
 - Protected branch 직접 push 는 human 금지. version bump/tag/promotion 처리는 `minglit-release-bot` 전용 token + Ruleset bypass 로만 허용
 - `monitor-event-flow-*` 는 release promotion 과 독립적인 batch signal. dev 에서 계속 돌고, RC 에서는 main 배포 전 검증 signal 로 사용한다
@@ -105,14 +110,14 @@ Promotion PR 제목은 workflow 이름과 source artifact 를 앞에 둔다. PR 
 
 | 단계 | 제목 형식 |
 |------|-----------|
-| dev-staging → dev | `ci(nightly-cut): promote v26.05.2722-dev-staging to dev` |
-| dev → rc | `ci(rc-cut): cut rc/2026-W22 from <source>` |
-| rc → main | `ci(main-cut): promote rc/2026-W22 to main` |
+| dev-staging → dev | `ci(dev-staging-dev-cut): promote v26.05.2722-dev-staging to dev` |
+| dev → rc | `ci(dev-rc-cut): cut rc/2026-W22 from <source>` |
+| rc → main | `ci(rc-main-cut): promote rc/2026-W22 to main` |
 | rc hotfix backport | `ci(rc-backport): backport rc hotfix #1234 to dev-staging` |
 
 ### RC Eligibility Marker
 
-RC cut 의 source-of-truth status 이름은 **`rc-gate-pass`** 이다. `rc-eligible` 은 현재 구현된 workflow/status 명칭이 아니며, 새 이름으로 바꾸려면 `rc-gate`, `rc-cut`, `main-pr-gate`, 문서 전체를 같은 PR 에서 일괄 변경한다.
+RC cut 의 source-of-truth status 이름은 **`dev-rc-cut-pass`** 이다. `rc-eligible` 은 현재 구현된 workflow/status 명칭이 아니며, 새 이름으로 바꾸려면 `dev-rc-cut-gate`, `dev-rc-cut`, `main-pr-gate`, 문서 전체를 같은 PR 에서 일괄 변경한다.
 
 ---
 _Reviewed: 2026-05-24 10:24_

--- a/docs/infra/branch-strategy/branch-flow.md
+++ b/docs/infra/branch-strategy/branch-flow.md
@@ -7,21 +7,21 @@
 ```
   agents ──PR + auto-merge──▶ dev-staging
                               │
-                              └─daily nightly-cut linear snapshot PR──▶ dev
+                              └─daily dev-staging-dev-cut linear snapshot PR──▶ dev
                                                               │
-                                                              ├─▶ rc-gate (post-merge 자동)
+                                                              ├─▶ dev-rc-cut-gate (post-merge 자동)
                                                               │      │
-                                                              │      ├─ pass: status rc-gate-pass
+                                                              │      ├─ pass: status dev-rc-cut-pass
                                                               │      │         │
                                                               │      │         └─▶ monitor-event-flow-* batch signal keeps running
                                                               │      │
                                                               │      └─ fail: 자동 이슈 + AI agent fix via dev-staging (no auto-revert)
                                                               │
-                                                              └─weekly rc-cut (최신 rc-gate-pass commit)──▶ rc/YYYY-Wxx
+                                                              └─weekly dev-rc-cut (최신 dev-rc-cut-pass commit)──▶ rc/YYYY-Wxx
                                                                                                               │
                                                                                                               ├─▶ rc-deploy (Supabase branching + pre-main validation)
                                                                                                               │
-                                                                                                              └─5일 soak (hotfix 시 시계 리셋)──▶ main-cut
+                                                                                                              └─5일 soak (hotfix 시 시계 리셋)──▶ rc-main-cut
                                                                                                                                                     │
                                                                                                                                                     └─main-deploy (prod deploy chain)
                                                                                                                                                               │
@@ -46,35 +46,35 @@ rc/* hotfix 머지 ──auto cherry-pick──▶ backport-branch ──PR─�
 | 머지 방향 | base ← head | 트리거 | 머지 방식 | 요구 체크 |
 |-----------|-------------|--------|-----------|-----------|
 | feature/agent → dev-staging | `dev-staging` ← `feat/*`, `fix/*`, `chore/*`, `docs/*` | PR + auto-merge | **squash** | `dev-staging-pr-gate` |
-| dev-staging → dev | `dev` ← `nightly/YYYY-MM-DD-{sha8}` at latest `v*-dev-staging` tag | daily cron `nightly-cut` | rebase (linear snapshot) | `nightly-pr-gate` |
+| dev-staging → dev | `dev` ← `cut/dev-staging-dev/YYYY-MM-DD-{sha8}` at latest `v*-dev-staging` tag | daily cron `dev-staging-dev-cut` | rebase (linear snapshot) | `dev-pr-gate` |
 | hotfix → rc | `rc/YYYY-Wxx` ← hotfix branch | hotfix only | rebase | `rc-pr-gate` |
-| rc → main | `main` ← `rc/YYYY-Wxx` | `main-cut` 이 5일 무커밋 시 PR 생성 + auto-merge | rebase + ff | `main-pr-gate` |
+| rc → main | `main` ← `rc/YYYY-Wxx` | `rc-main-cut` 이 5일 무커밋 시 PR 생성 + auto-merge | rebase + ff | `main-pr-gate` |
 
 ## Branch Protection 설정
 
 | 브랜치 | direct push | linear | required check | merge 종류 |
 |--------|-------------|--------|----------------|------------|
 | `dev-staging` | 금지 (release bot 예외) | **ON** | `dev-staging-pr-gate` | squash |
-| `dev` | 금지 | **ON** | `nightly-pr-gate` | rebase (linear snapshot) |
+| `dev` | 금지 | **ON** | `dev-pr-gate` | rebase (linear snapshot) |
 | `rc/YYYY-Wxx` | 금지 | **ON** | `rc-pr-gate` | rebase |
 | `main` | 금지 (release bot 예외) | **ON** | `main-pr-gate` | rebase |
 
-Hybrid linear history 금지 — 각 branch 내 일관 (squash or rebase 한 가지). `dev` 는 active ruleset 의 linear history 와 맞추기 위해 nightly promotion 도 rebase 를 사용한다. Protected branch 직접 push 는 `minglit-release-bot` 의 version bump/tag/promotion commit 에만 Ruleset bypass 로 허용한다.
+Hybrid linear history 금지 — 각 branch 내 일관 (squash or rebase 한 가지). `dev` 는 active ruleset 의 linear history 와 맞추기 위해 `dev-staging-dev-cut` promotion 도 rebase 를 사용한다. Protected branch 직접 push 는 `minglit-release-bot` 의 version bump/tag/promotion commit 에만 Ruleset bypass 로 허용한다.
 
 ## Promotion Tag 컨벤션
 
 | Tag / Status | 시점 | 예시 | 부여자 |
 |--------------|------|------|--------|
-| `v{ver}-dev-staging` (tag) | dev-staging-post-merge-sync | `v26.05.2572-dev-staging` | workflow |
-| `rc-gate-pass` (commit status) | rc-gate green 시 dev commit 에 | (status only, tag 없음) | workflow |
-| `promo/rc-YYYY-Wxx` (tag) | rc-cut 직후 | `promo/rc-2026-W20` | workflow |
-| `v{ver}-rc-NN` (tag) | rc-cut + hotfix | `v26.05.2572-rc-01`, `v26.05.2585-rc-02` | workflow |
+| `v{ver}-dev-staging` (tag) | dev-staging-dev-cut-gate | `v26.05.2572-dev-staging` | workflow |
+| `dev-rc-cut-pass` (commit status) | dev-rc-cut-gate green 시 dev commit 에 | (status only, tag 없음) | workflow |
+| `promo/rc-YYYY-Wxx` (tag) | dev-rc-cut 직후 | `promo/rc-2026-W20` | workflow |
+| `v{ver}-rc-NN` (tag) | dev-rc-cut + hotfix | `v26.05.2572-rc-01`, `v26.05.2585-rc-02` | workflow |
 | `promo/main-YYYY-Wxx` (tag) | main 머지 직후 | `promo/main-2026-W20` | workflow |
 | `v{ver}` (tag) | main 머지 직후 (동시) | `v26.05.2585` | workflow |
 
 > **Tag naming regex 는 [`RELEASE.md`](../../../RELEASE.md) lock** (TODO). 외부 도구 (Sentry, Statsig, Vercel, App Store, Play Console) 가 pin → rename = 모든 dashboard 깨짐.
 
-조회: `git tag -l 'v*'`, `git tag -l 'promo/main-*'`, `gh api repos/.../commits/{sha}/status` (rc-gate-pass)
+조회: `git tag -l 'v*'`, `git tag -l 'promo/main-*'`, `gh api repos/.../commits/{sha}/status` (dev-rc-cut-pass)
 
 ## Auto-deploy Chain
 
@@ -115,7 +115,7 @@ main-deploy (on push to main):
 
 ## 결정해야 할 것
 
-- 주간 rc-cut 요일
+- 주간 dev-rc-cut 요일
 - Fastlane / store upload 설정
 - `RELEASE.md` 작성
 

--- a/docs/infra/branch-strategy/dev-pipeline.md
+++ b/docs/infra/branch-strategy/dev-pipeline.md
@@ -1,15 +1,15 @@
 # Dev Pipeline
 
-`dev` 브랜치가 trunk 역할: dev-staging 의 daily snapshot 을 받고, post-merge 로 full integration suite (`rc-gate`) 를 돌린다. RC 는 `rc-gate-pass` status 를 보고 cut 한다. 이벤트 플로우 시뮬레이터는 `monitor-event-flow-*` batch 로 계속 돌며, backend prod deploy 는 main 머지 후 `main-deploy` 에서 수행한다.
+`dev` 브랜치가 trunk 역할: dev-staging 의 daily snapshot 을 받고, post-merge 로 full integration suite (`dev-rc-cut-gate`) 를 돌린다. RC 는 `dev-rc-cut-pass` status 를 보고 cut 한다. 이벤트 플로우 시뮬레이터는 `monitor-event-flow-*` batch 로 계속 돌며, backend prod deploy 는 main 머지 후 `main-deploy` 에서 수행한다.
 
 ## 4가지 workflow
 
-1. **`nightly-cut`** — daily cron, dev-staging tip 의 snapshot 으로 PR 생성
-2. **`nightly-pr-gate`** — snapshot PR 머지 전 검증 (defensive)
-3. **`rc-gate`** — dev 머지 후 자동 발동, full integration suite, 통과 시 status `rc-gate-pass` set
+1. **`dev-staging-dev-cut`** — daily cron, dev-staging tip 의 snapshot 으로 PR 생성
+2. **`dev-pr-gate`** — snapshot PR 머지 전 검증 (defensive)
+3. **`dev-rc-cut-gate`** — dev 머지 후 자동 발동, full integration suite, 통과 시 status `dev-rc-cut-pass` set
 4. **`dev-deploy` / monitor jobs** — dev 환경 deploy/smoke 가 필요할 때만 수행. 이벤트 플로우 시뮬레이터는 `monitor-event-flow-*` 로 별도 운영
 
-## `nightly-cut`
+## `dev-staging-dev-cut`
 
 ### 트리거 / 동작
 
@@ -17,32 +17,32 @@
 - **manual**: `workflow_dispatch`
 - 동작:
   1. 가장 최근 `v*-dev-staging` 태그 (dev-staging 의 latest coherent snapshot) 찾기
-  2. PR 생성: `ci(nightly-cut): promote v26.05.2722-dev-staging to dev` (base=dev, head=`nightly/YYYY-MM-DD-{sha8}` at that tag)
-  3. `nightly-pr-gate` 자동 발동
+  2. PR 생성: `ci(dev-staging-dev-cut): promote v26.05.2722-dev-staging to dev` (base=dev, head=`cut/dev-staging-dev/YYYY-MM-DD-{sha8}` at that tag)
+  3. `dev-pr-gate` 자동 발동
   4. 통과 시 auto-merge (rebase — active `dev` ruleset 의 linear history 와 호환)
 
 ### 슬립 처리
 
 - 이미 dev 가 최신 dev-staging 과 동기화돼 있으면 (= 새 commit 없음) skip
-- 이전 nightly-cut 이 still in progress (드물) → 이번 cron skip + Slack 알림
+- 이전 dev-staging-dev-cut 이 still in progress (드물) → 이번 cron skip + Slack 알림
 
-## `nightly-pr-gate`
+## `dev-pr-gate`
 
 `dev-staging-pr-gate` 와 **동일한 test suite**. 환경 차이 회귀만 잡는 defensive 검증. 대부분 통과.
 
 (상세는 [dev-staging-pipeline.md](./dev-staging-pipeline.md))
 
-## `rc-gate` — Heavy Integration
+## `dev-rc-cut-gate` — Heavy Integration
 
 dev 머지 후 자동 발동. 통과 = "이 commit 은 RC cut source 로 사용할 수 있음".
 
-> **Current implementation**: first operational version runs user/partner CUJ integration directly and sets `rc-gate-pass` on success. Backend simulation/Test Lab 확장은 후속이다.
+> **Current implementation**: first operational version runs user/partner CUJ integration directly and sets `dev-rc-cut-pass` on success. Backend simulation/Test Lab 확장은 후속이다.
 
 ### 무엇을 도는가
 
-매트릭스 병렬. 하나라도 실패 = rc-gate 전체 실패.
+매트릭스 병렬. 하나라도 실패 = dev-rc-cut-gate 전체 실패.
 
-매트릭스 (app × scenario) 병렬. 하나라도 실패 = rc-gate 전체 실패.
+매트릭스 (app × scenario) 병렬. 하나라도 실패 = dev-rc-cut-gate 전체 실패.
 
 | job | 대상 | 비고 |
 |-----|------|------|
@@ -52,24 +52,24 @@ dev 머지 후 자동 발동. 통과 = "이 commit 은 RC cut source 로 사용�
 | `integration-edge-functions` | `tests/ef_integration/**` | EF 통합 시나리오 |
 | `test-lab-smoke` | Firebase Test Lab — 실 디바이스 4종 | 디바이스 다양성 보강 |
 
-### 통과 시 (rc-gate-pass)
+### 통과 시 (dev-rc-cut-pass)
 
 ```
-1. dev HEAD commit 에 GitHub commit status `rc-gate-pass` set
-2. `rc-cut` 이 이 status 를 source-of-truth 로 사용
+1. dev HEAD commit 에 GitHub commit status `dev-rc-cut-pass` set
+2. `dev-rc-cut` 이 이 status 를 source-of-truth 로 사용
 3. 이벤트 플로우 시뮬레이터는 `monitor-event-flow-*` batch 로 계속 별도 관찰
 4. Mobile + backend prod 은 main 머지 후 `main-deploy` 에서 처리
 ```
 
-> **사용자 서버 영향 X** — `rc-gate-pass` 는 prod deploy 가 아니라 RC 후보 marker 다. prod 는 main 머지에서만 배포한다.
+> **사용자 서버 영향 X** — `dev-rc-cut-pass` 는 prod deploy 가 아니라 RC 후보 marker 다. prod 는 main 머지에서만 배포한다.
 
 ### 실패 시
 
 Snapshot 모델 — **auto-revert 없음**. dev 가 broken 상태로 잠시 머묾, AI agent 가 fix PR 을 normal flow 로 처리.
 
-- Status 미부여 (`rc-gate-pass` 없음 → rc-cut 이 이 commit 안 골라잡음)
-- 자동 이슈 + `P1-high` 라벨 + 직전 `rc-gate-pass` 이후 머지된 PR 작성자들 assignee (AI agent 포함)
-- AI agent 가 fix PR 을 dev-staging 으로 작성 → dev-staging-pr-gate → 다음 nightly-cut → 다음 rc-gate 가 검증
+- Status 미부여 (`dev-rc-cut-pass` 없음 → dev-rc-cut 이 이 commit 안 골라잡음)
+- 자동 이슈 + `P1-high` 라벨 + 직전 `dev-rc-cut-pass` 이후 머지된 PR 작성자들 assignee (AI agent 포함)
+- AI agent 가 fix PR 을 dev-staging 으로 작성 → dev-staging-pr-gate → 다음 dev-staging-dev-cut → 다음 dev-rc-cut-gate 가 검증
 - dev 는 *broken integration 상태* 지만 `pr-gate-core` 가 compile/unit 잡아주니 다른 PR 진입 자체는 OK
 
 ### 60분 비용 예산
@@ -78,15 +78,15 @@ Snapshot 모델 — **auto-revert 없음**. dev 가 broken 상태로 잠시 머�
 
 ## Error-Backoff 정책
 
-**Workflow infra 실패** (`rc-gate` script 에러, runner 다운 등) → **P0 이슈 자동 생성** + on-call. 아래는 *rc-gate test* 실패 escalation.
+**Workflow infra 실패** (`dev-rc-cut-gate` script 에러, runner 다운 등) → **P0 이슈 자동 생성** + on-call. 아래는 *dev-rc-cut-gate test* 실패 escalation.
 
 | 연속 실패 | 동작 |
 |----------|------|
 | 1회 | 자동 이슈 + Slack `#nightly` + AI agent assignee |
 | 2회 (같은 area) | 기존 이슈 댓글 누적, assignee reminder, 영역 owner 추가 알림 |
-| 3회 (같은 area) | `rc-gate-degraded` label + **rc-cut workflow 자동 차단** (다음 weekly cut PR 생성 안 함) + Slack `#release` |
+| 3회 (같은 area) | `dev-rc-cut-gate-degraded` label + **dev-rc-cut workflow 자동 차단** (다음 weekly cut PR 생성 안 함) + Slack `#release` |
 
-**Recovery**: 다음 rc-gate green → 자동 차단 해제, 누적 이슈 verify 코멘트.
+**Recovery**: 다음 dev-rc-cut-gate green → 자동 차단 해제, 누적 이슈 verify 코멘트.
 
 ## Dev Validation / Monitor
 
@@ -102,23 +102,23 @@ Snapshot 모델 — **auto-revert 없음**. dev 가 broken 상태로 잠시 머�
 
 ## Artifact / 보존
 
-- 실패한 rc-gate: 30일 (스크린샷, 로그, APK)
+- 실패한 dev-rc-cut-gate: 30일 (스크린샷, 로그, APK)
 - 성공: 7일
 
 ## 결정해야 할 것
 
-- nightly-cut cron 시각
+- dev-staging-dev-cut cron 시각
 - backoff 임계 (3회 차단이 적정한가)
 - CUJ chaos 시나리오 정의 (현재 미정의)
 - Supabase RC branch TTL / seed data 정책
-- rc-gate selective run 도입 시점
+- dev-rc-cut-gate selective run 도입 시점
 
 ## 관련
 
 - [dev-staging-pipeline.md](./dev-staging-pipeline.md) — dev-staging 의 pr-gate + safety net
-- [rc-promotion.md](./rc-promotion.md) — rc-gate-pass 가 rc-cut 의 source
+- [rc-promotion.md](./rc-promotion.md) — dev-rc-cut-pass 가 dev-rc-cut 의 source
 - [main-promotion.md](./main-promotion.md) — main-deploy 와 prod deploy failure handling
-- [test-strategy.md](./test-strategy.md) — rc-gate 의 단계별 위치
+- [test-strategy.md](./test-strategy.md) — dev-rc-cut-gate 의 단계별 위치
 - [branch-flow.md](./branch-flow.md) — workflow chain 그림
 
 ---

--- a/docs/infra/branch-strategy/dev-staging-pipeline.md
+++ b/docs/infra/branch-strategy/dev-staging-pipeline.md
@@ -1,11 +1,11 @@
 # Dev-Staging Pipeline
 
-AI agent 와 feature/fix/chore PR 이 `dev-staging` 브랜치로 들어오는 진입점. 일반 PR + auto-merge 로 처리하고, `dev-staging-pr-gate` 가 가벼운 검증, 머지 후 `dev-staging-post-merge-sync` 가 release bot 권한으로 version bump.
+AI agent 와 feature/fix/chore PR 이 `dev-staging` 브랜치로 들어오는 진입점. 일반 PR + auto-merge 로 처리하고, `dev-staging-pr-gate` 가 가벼운 검증, 머지 후 `dev-staging-dev-cut-gate` 가 release bot 권한으로 version bump.
 
 ## 두 가지 workflow
 
 1. **`dev-staging-pr-gate`** — PR 머지 전
-2. **`dev-staging-post-merge-sync`** — PR 머지 직후 (version bump + tag)
+2. **`dev-staging-dev-cut-gate`** — PR 머지 직후 (version bump + tag)
 
 ## PR + Auto-Merge
 
@@ -22,7 +22,7 @@ AI agent 와 feature/fix/chore PR 이 `dev-staging` 브랜치로 들어오는 �
     ↓
 [통과 시 squash merge to dev-staging]
     ↓
-[dev-staging-post-merge-sync 자동 발동]
+[dev-staging-dev-cut-gate 자동 발동]
 ```
 
 ### 왜 merge queue 를 보류하나
@@ -81,7 +81,7 @@ AI agent 와 feature/fix/chore PR 이 `dev-staging` 브랜치로 들어오는 �
 
 **현재 상태**: TODO — AST 검출 로직 + 예외 라벨 운영 룰 + 분기별 우회 통계.
 
-## `dev-staging-post-merge-sync`
+## `dev-staging-dev-cut-gate`
 
 PR 머지 직후 자동 발동. 운영 복구용으로 `workflow_dispatch` 도 제공하며, 수동 실행 시 version 에 사용할 PR 번호를 입력한다.
 
@@ -94,9 +94,9 @@ PR 머지 직후 자동 발동. 운영 복구용으로 `workflow_dispatch` 도 �
 
 `git push` 는 human 권한이 아니라 `minglit-release-bot` 전용 token 으로 실행한다. Ruleset bypass 는 이 bot actor 에만 부여하고, workflow permission 은 `contents: write` 및 tag/status 갱신에 필요한 최소 권한으로 제한한다.
 
-Tag `v{ver}-dev-staging` 는 다음 단계의 `nightly-cut` workflow 가 query 해서 "가장 최근 dev-staging 의 coherent snapshot" 찾는 데 사용.
+Tag `v{ver}-dev-staging` 는 다음 단계의 `dev-staging-dev-cut` workflow 가 query 해서 "가장 최근 dev-staging 의 coherent snapshot" 찾는 데 사용.
 
-> **구현 결정**: bump 커밋은 PR squash commit 과 분리한다. release bot 전용 커밋으로 남겨 branch/tag write 권한과 human PR 변경을 분리한다. `[skip ci]` 는 쓰지 않는다. nightly PR 의 HEAD 가 이 bump 커밋이므로 `[skip ci]` 를 넣으면 required check 가 생성되지 않는다. 루프 방지는 `dev-staging-post-merge-sync` 의 commit message guard 로 처리한다.
+> **구현 결정**: bump 커밋은 PR squash commit 과 분리한다. release bot 전용 커밋으로 남겨 branch/tag write 권한과 human PR 변경을 분리한다. `[skip ci]` 는 쓰지 않는다. nightly PR 의 HEAD 가 이 bump 커밋이므로 `[skip ci]` 를 넣으면 required check 가 생성되지 않는다. 루프 방지는 `dev-staging-dev-cut-gate` 의 commit message guard 로 처리한다.
 
 ## Error-Backoff
 

--- a/docs/infra/branch-strategy/error-detection.md
+++ b/docs/infra/branch-strategy/error-detection.md
@@ -8,8 +8,8 @@
 |-------|----------------|----------|---------|
 | 개발자 로컬 | LSP, analyze, unit | 컴파일/타입/단위 | 초~분 |
 | dev-staging PR gate | `dev-staging-pr-gate` (unit, lint, pgTAP, EF, migration, `expand-migrate-contract`, `flag-registration`, gitleaks) | PR 회귀, 보안, migration 충돌, flag 미등록, contract 위반 | < 10분 |
-| nightly-cut PR | `nightly-pr-gate` (defensive) | 환경 차이 회귀 | < 10분 |
-| dev 머지 후 (자동) | `rc-gate` (CUJ matrix happy/unhappy/chaos, integration, e2e, Test Lab) | 통합 회귀, 시나리오, 외부 의존, 디바이스 | 30-60분 |
+| dev-staging-dev-cut PR | `dev-pr-gate` (defensive) | 환경 차이 회귀 | < 10분 |
+| dev 머지 후 (자동) | `dev-rc-cut-gate` (CUJ matrix happy/unhappy/chaos, integration, e2e, Test Lab) | 통합 회귀, 시나리오, 외부 의존, 디바이스 | 30-60분 |
 | Backend/Web auto-deploy | post-deploy smoke, Sentry release marker | deploy infra 회귀 | 분 |
 | rc soak (5일) | rc 의 nightly 재실행 + 내부 dogfooding | 누적 회귀, real-data 이슈 | 일 단위 |
 | main 머지 후 (auto-deploy) | smoke + Sentry/Crashlytics 알람 임계 | prod 회귀 | 분 |
@@ -32,7 +32,7 @@
 
 ### Firebase Test Lab
 - 실 디바이스 farm 에서 CUJ/smoke
-- `rc-gate` 의 mobile 부분 일부 위임
+- `dev-rc-cut-gate` 의 mobile 부분 일부 위임
 - 상세: [../firebase/BLUEDOC.md](../firebase/BLUEDOC.md)
 
 ### Statsig
@@ -45,7 +45,7 @@
 - 참고: `docs/operations/edge-functions.md`
 
 ### GitHub Actions
-- pr-gate / rc-gate / promotion workflow 의 자동 이슈 생성
+- pr-gate / dev-rc-cut-gate / promotion workflow 의 자동 이슈 생성
 - **workflow infra 실패 → P0**, test 실패 → P1-high
 
 ## Detection → Action 책임
@@ -53,8 +53,8 @@
 | Detection 신호 | 누가 받음 | 어디서 | Action |
 |---------------|----------|--------|--------|
 | pr-gate 실패 (어느 단계든) | PR 작성자 | GitHub PR | 본인 fix → re-push → auto-merge 재대기 |
-| `rc-gate` 실패 (dev 머지 후) | 직전 rc-gate-pass 이후 머지된 PR 작성자들 + AI agent | GitHub issue + Slack `#nightly` | AI agent fix PR via dev-staging — dev keeps moving ([dev-pipeline.md](./dev-pipeline.md)) |
-| Backend/web staging deploy 실패 (dev rc-gate-pass) | on-call | Slack `#release` | retry → P0 이슈, RC 진행 차단 (staging 도달 못함) |
+| `dev-rc-cut-gate` 실패 (dev 머지 후) | 직전 dev-rc-cut-pass 이후 머지된 PR 작성자들 + AI agent | GitHub issue + Slack `#nightly` | AI agent fix PR via dev-staging — dev keeps moving ([dev-pipeline.md](./dev-pipeline.md)) |
+| Backend/web staging deploy 실패 (dev dev-rc-cut-pass) | on-call | Slack `#release` | retry → P0 이슈, RC 진행 차단 (staging 도달 못함) |
 | Backend/web/mobile prod deploy 실패 (main 머지) | on-call | Slack `#release` | retry → rollback ([main-promotion.md](./main-promotion.md) error-backoff) |
 | rc soak 중 회귀 | RC owner | Slack `#release` | hotfix PR → rc | 
 | deploy-android-*, deploy-ios-* 실패 | mobile 팀 | GitHub issue + Slack | retry + auto-issue ([main-promotion.md](./main-promotion.md) error-backoff) |
@@ -80,7 +80,7 @@
 ## 관련
 
 - [test-strategy.md](./test-strategy.md) — 어떤 테스트
-- [dev-pipeline.md](./dev-pipeline.md) — rc-gate detection → backoff
+- [dev-pipeline.md](./dev-pipeline.md) — dev-rc-cut-gate detection → backoff
 - [main-promotion.md](./main-promotion.md) — deploy detection → rollback
 - [life-of-flag.md](./life-of-flag.md) — flag 메트릭 → flip
 - [../firebase/BLUEDOC.md](../firebase/BLUEDOC.md), [../statsig/BLUEDOC.md](../statsig/BLUEDOC.md)

--- a/docs/infra/branch-strategy/life-of-flag.md
+++ b/docs/infra/branch-strategy/life-of-flag.md
@@ -80,7 +80,7 @@ Feature flag (Statsig + Firebase Remote Config) 의 생성·soak·rollout·**자
 
 | Stage | Cohort | 기간 | Exit |
 |-------|--------|------|------|
-| 1. dev | 개발자 (Statsig env=dev / RC condition) | **1주** | rc-gate green + 코드 dev 진입 |
+| 1. dev | 개발자 (Statsig env=dev / RC condition) | **1주** | dev-rc-cut-gate green + 코드 dev 진입 |
 | 2. prod allowlist | 내부 직원 user_id allowlist | **2주** | 카나리 메트릭 OK |
 | 3a. backend staged | prod backend 5% → 25% → 100% | 48h → 72h → 7일 | error rate < baseline +X% |
 | 3b. backend soak | - | 1주 | 무이슈 (mobile 활성화 게이트) |
@@ -173,7 +173,7 @@ Feature flag (Statsig + Firebase Remote Config) 의 생성·soak·rollout·**자
 - [branch-flow.md](./branch-flow.md) — 코드 promotion 의 그림
 - [main-promotion.md](./main-promotion.md) — min-version + expand-migrate-contract
 - [dev-staging-pipeline.md](./dev-staging-pipeline.md) — flag-registration CI
-- [dev-pipeline.md](./dev-pipeline.md) — rc-gate-pass marker 와 dev validation
+- [dev-pipeline.md](./dev-pipeline.md) — dev-rc-cut-pass marker 와 dev validation
 - [test-strategy.md](./test-strategy.md) — flag staged rollout 의 게이트
 - [error-detection.md](./error-detection.md) — flag 메트릭의 detection layer
 - [../firebase/BLUEDOC.md](../firebase/BLUEDOC.md), [../statsig/BLUEDOC.md](../statsig/BLUEDOC.md)

--- a/docs/infra/branch-strategy/main-promotion.md
+++ b/docs/infra/branch-strategy/main-promotion.md
@@ -4,21 +4,21 @@
 
 ## 두 가지 이벤트
 
-1. **rc → main 머지** — `main-cut` 이 자동 PR 생성 + 모든 check 통과 시 workflow auto-merge
+1. **rc → main 머지** — `rc-main-cut` 이 자동 PR 생성 + 모든 check 통과 시 workflow auto-merge
 2. **main push → prod deploy chain** — `main-deploy` 가 backend, web, mobile prod deploy 를 orchestrate. store review + staged rollout 은 store-side
 
 ## `main-pr-gate`
 
-`main-cut` 이 자동 생성한 promotion PR 에 적용:
+`rc-main-cut` 이 자동 생성한 promotion PR 에 적용:
 
 | Check | 내용 |
 |-------|------|
 | `pr-gate` 재실행 | dev-staging-pr-gate 와 동일 — defensive 검증 |
 | `expand-migrate-contract` (재검증) | RC 5일 동안 dev 가 더 나갔을 수 있음. 재확인 |
-| RC HEAD 의 `rc-gate-pass` status 확인 | 마지막 hotfix 이 rc-gate 통과했는지 |
-| `rc-soak-passed` 자동 마커 | main-cut 이 5일 무커밋 확인 후 부여 |
+| RC HEAD 의 `dev-rc-cut-pass` status 확인 | 마지막 hotfix 이 dev-rc-cut-gate 통과했는지 |
+| `rc-main-cut-pass` 자동 마커 | `rc-main-cut-gate` 가 5일 무커밋 + pre-main signal 확인 후 부여 |
 
-GitHub Ruleset 의 required check 는 `main-pr-gate` 하나로 둔다. `rc-gate-pass`, `expand-migrate-contract`, `rc-soak-passed` 는 PR head SHA 와 별도 commit/label 상태가 섞일 수 있으므로 `main-pr-gate` 내부 검증으로 처리한다. 모든 check 통과 시 workflow 가 auto-merge (rebase + fast-forward) 한다. 어느 하나라도 실패 시 PR hold + Slack 알림 → human 개입 (edge case).
+GitHub Ruleset 의 required check 는 `main-pr-gate` 하나로 둔다. `dev-rc-cut-pass`, `expand-migrate-contract`, `rc-main-cut-pass` 는 PR head SHA 와 별도 commit/label 상태가 섞일 수 있으므로 `main-pr-gate` 내부 검증으로 처리한다. 모든 check 통과 시 workflow 가 auto-merge (rebase + fast-forward) 한다. 어느 하나라도 실패 시 PR hold + Slack 알림 → human 개입 (edge case).
 
 ## `main-deploy`
 
@@ -131,7 +131,7 @@ main push trigger 로 자동 발동되는 기존 workflows:
 
 | 조건 | 동작 |
 |------|------|
-| `rc-gate-degraded` (dev-pipeline backoff) | rc → main PR 자동 close + 코멘트 ("recovery 후 재시도") |
+| `dev-rc-cut-gate-degraded` (dev-pipeline backoff) | rc → main PR 자동 close + 코멘트 ("recovery 후 재시도") |
 | `expand-migrate-contract` 검사 실패 | PR 자동 close |
 
 ### Mobile deploy (`deploy-android-*` / `deploy-ios-*`) 실패
@@ -158,11 +158,11 @@ main push trigger 로 자동 발동되는 기존 workflows:
 
 ## 관련
 
-- [dev-pipeline.md](./dev-pipeline.md) — rc-gate-pass marker 와 dev validation 위치
+- [dev-pipeline.md](./dev-pipeline.md) — dev-rc-cut-pass marker 와 dev validation 위치
 - [rc-promotion.md](./rc-promotion.md) — rc → main PR 의 생성
 - [life-of-flag.md](./life-of-flag.md) — flag rollout 은 main 머지와 별도
 - [branch-flow.md](./branch-flow.md) — tag 컨벤션 + protection
-- [specs/workflow-spec.md](./specs/workflow-spec.md) — main-cut/main-deploy workflow 계약
+- [specs/workflow-spec.md](./specs/workflow-spec.md) — rc-main-cut/main-deploy workflow 계약
 
 ---
 _Reviewed: 2026-05-24 10:24_

--- a/docs/infra/branch-strategy/rc-promotion.md
+++ b/docs/infra/branch-strategy/rc-promotion.md
@@ -1,25 +1,25 @@
 # RC Promotion
 
-`rc/YYYY-Wxx` 브랜치의 lifecycle: weekly cut from dev 의 `rc-gate-pass` commit, RC 전용 Supabase branch 생성, 5일 soak (hotfix 시 시계 리셋), soak 통과 시 main 으로 머지 후 RC branch 정리.
+`rc/YYYY-Wxx` 브랜치의 lifecycle: weekly cut from dev 의 `dev-rc-cut-pass` commit, RC 전용 Supabase branch 생성, 5일 soak (hotfix 시 시계 리셋), soak 통과 시 main 으로 머지 후 RC branch 정리.
 
 ## 4가지 workflow
 
-1. **`rc-cut`** — weekly cron, dev 의 latest `rc-gate-pass` commit 에서 branch out
+1. **`dev-rc-cut`** — weekly cron, dev 의 latest `dev-rc-cut-pass` commit 에서 branch out
 2. **`rc-pr-gate`** — hotfix PR 머지 전 검증
 3. **`rc-post-merge-sync`** — hotfix 머지 직후 (`_rc-NN` bump)
 4. **`rc-deploy`** — RC Supabase branch 에 migration/EF 적용 + pre-main validation
-5. **`main-cut`** — daily cron, RC HEAD commit 의 committer date 가 5일 이전이면 rc → main PR 자동 생성
+5. **`rc-main-cut`** — daily cron, RC HEAD commit 의 committer date 가 5일 이전이면 rc → main PR 자동 생성
 
-## `rc-cut`
+## `dev-rc-cut`
 
 ### 트리거 / 동작
 
 - **cron**: 매주 X 요일 KST 10:00 (TBD)
 - **manual**: `workflow_dispatch` (긴급 cut)
-- **현재 구현**: 매주 월요일 KST 10:00. 수동 실행은 `source_sha`, `rc_week`, `allow_active_rc` 입력을 지원한다. `rc-gate-pass` commit 이 아직 없으면 실패 알림 없이 skip 한다.
+- **현재 구현**: 매주 월요일 KST 10:00. 수동 실행은 `source_sha`, `rc_week`, `allow_active_rc` 입력을 지원한다. `dev-rc-cut-pass` commit 이 아직 없으면 실패 알림 없이 skip 한다.
 - 동작:
   1. **active RC marker 확인** → 있으면 skip + Slack `#release` 알림 (이전 RC 가 hotfix 로 길어지는 중)
-  2. 없으면 dev 의 최신 `rc-gate-pass` status 부여된 commit 찾기 (GitHub API: `GET /repos/.../commits/{sha}/status`)
+  2. 없으면 dev 의 최신 `dev-rc-cut-pass` status 부여된 commit 찾기 (GitHub API: `GET /repos/.../commits/{sha}/status`)
   3. 못 찾으면 cut 보류 (현재 구현은 초기 no-pass 상태를 skip, 3일+ green 없음 alert 는 후속 PR)
   4. 찾았으면 그 commit 에서 `rc/YYYY-Wxx` branch cut
   5. Supabase branch 생성/검증은 `rc-deploy` 에 위임 (후속 PR)
@@ -30,7 +30,7 @@
 ### Cron 슬립 처리
 
 - "active RC marker 있음" → skip + 다음 주 cron 까지 대기
-- "rc-gate-pass commit 없음 (3일+)" → cut 보류 + alert (운영자 개입 필요)
+- "dev-rc-cut-pass commit 없음 (3일+)" → cut 보류 + alert (운영자 개입 필요)
 
 `rc/*` git branch 는 릴리즈 이력 보존 수단이 아니다. RC 종료 후 삭제할 수 있으며, 이력은 `promo/rc-*`, `v*-rc-*`, `promo/main-*` protected tag 로 보존한다.
 
@@ -55,7 +55,7 @@ Hotfix PR 머지 직후 자동:
 5. RC Supabase branch 에 migration/EF 재적용
 ```
 
-**Soak 시계 자동 리셋** — 새 commit 의 committer date 가 최신이므로 `main-cut` 이 자연스럽게 카운트 다시 시작.
+**Soak 시계 자동 리셋** — 새 commit 의 committer date 가 최신이므로 `rc-main-cut` 이 자연스럽게 카운트 다시 시작.
 
 ### Hotfix 카운트 결정
 
@@ -72,19 +72,23 @@ RC branch push 마다 RC 검증 환경을 구성한다. RC 는 계속 유지되�
 | smoke | RC env smoke + backend contract 확인 |
 | batch signal | `monitor-event-flow-*` 결과를 main 배포 전 검증 signal 로 사용 |
 
-## `main-cut`
+## `rc-main-cut-gate` → `rc-main-cut`
 
 ### 트리거 / 동작
 
-- **cron**: daily KST 09:00 (TBD)
-- 동작:
+- **gate cron**: daily KST 09:00 (TBD)
+- **cut cron**: daily KST 09:15 (TBD, gate 직후)
+- `rc-main-cut-gate` 동작:
   1. 현재 `rc/*` 가 있는지 확인 → 없으면 종료
   2. RC HEAD commit 의 `committer date` 조회
   3. `committer date` 가 5일 이전 (= 5일 동안 새 commit 없음) 이면:
-     - PR 자동 생성: `release(main): RC YYYY-Wxx → main` (base=main, head=rc/YYYY-Wxx)
-     - PR 에 `rc-soak-passed` 마커 부여
-     - `main-pr-gate` 통과 시 workflow 가 auto-merge ([main-promotion.md](./main-promotion.md))
+     - pre-main validation / event-flow signal 확인
+     - RC HEAD 에 `rc-main-cut-pass` 마커 부여
   4. 5일 이전 아니면 → 다음날 cron 까지 대기
+- `rc-main-cut` 동작:
+  1. `rc-main-cut-pass` 마커가 있는 active RC 확인
+  2. PR 자동 생성: `ci(rc-main-cut): promote rc/YYYY-Wxx to main` (base=main, head=rc/YYYY-Wxx)
+  3. `main-pr-gate` 통과 시 workflow 가 auto-merge ([main-promotion.md](./main-promotion.md))
 
 ### Slip 자연스러움
 
@@ -112,7 +116,7 @@ Mark 님 직감대로 hotfix loop 으로 RC lifecycle 이 길어지는 게 일�
             │
             ├─▶ [rc-post-merge-sync: _rc-NN bump]
             │
-            └─▶ [main-cut 이 다음날부터 새 committer date 인식 → 5일 다시 측정]
+            └─▶ [rc-main-cut 이 다음날부터 새 committer date 인식 → 5일 다시 측정]
 ```
 
 ## Hotfix Backport to dev-staging
@@ -161,7 +165,7 @@ Mobile 은 release branch 없음 (main 머지 마다 `deploy-android-*, deploy-i
 | rc → main 완료 | prod deploy 후 RC Supabase branch 삭제 |
 | RC abandon | RC Supabase branch 삭제 + active RC marker 제거 |
 
-`rc-gate-pass` 는 deploy marker 가 아니라 RC cut source marker 다. RC soak 는 `rc-YYYY-Wxx` Supabase branch 를 사용하므로 dev 의 후속 green commit 과 섞이지 않는다.
+`dev-rc-cut-pass` 는 deploy marker 가 아니라 RC cut source marker 다. RC soak 는 `rc-YYYY-Wxx` Supabase branch 를 사용하므로 dev 의 후속 green commit 과 섞이지 않는다.
 
 ### 결정해야 할 것
 
@@ -170,7 +174,7 @@ Mobile 은 release branch 없음 (main 머지 마다 `deploy-android-*, deploy-i
 
 ## Error-Backoff 정책
 
-**Workflow infra 실패** (rc-cut / rc-pr-gate / rc-deploy / main-cut workflow 자체 실패) → **P0 이슈** + on-call.
+**Workflow infra 실패** (dev-rc-cut / rc-pr-gate / rc-deploy / rc-main-cut workflow 자체 실패) → **P0 이슈** + on-call.
 
 **Soak 중 사용자 발견 회귀**:
 
@@ -182,16 +186,16 @@ Mobile 은 release branch 없음 (main 머지 마다 `deploy-android-*, deploy-i
 
 ## 결정해야 할 것
 
-- weekly rc-cut 요일
-- main-cut daily cron 시각
+- weekly dev-rc-cut 요일
+- rc-main-cut daily cron 시각
 - RC 자체 nightly 별도 schedule 여부
 - Supabase RC branch TTL / seed data 정책
 - RC abandon 의 명확한 기준
 
 ## 관련
 
-- [dev-pipeline.md](./dev-pipeline.md) — rc-gate-pass status 가 rc-cut 의 source
-- [main-promotion.md](./main-promotion.md) — main-cut + main-deploy + mobile deploy
+- [dev-pipeline.md](./dev-pipeline.md) — dev-rc-cut-pass status 가 dev-rc-cut 의 source
+- [main-promotion.md](./main-promotion.md) — rc-main-cut + main-deploy + mobile deploy
 - [test-strategy.md](./test-strategy.md) — rc-pr-gate 와 mobile smoke 위치
 - [branch-flow.md](./branch-flow.md) — tag 컨벤션 + protection
 

--- a/docs/infra/branch-strategy/specs/branch-spec.md
+++ b/docs/infra/branch-strategy/specs/branch-spec.md
@@ -44,14 +44,14 @@
 | Direct push | 금지 |
 | Force push | 금지 |
 | Branch deletion | 금지 |
-| Required status checks | `nightly-pr-gate` (dev-staging 의 snapshot PR 에 대해) |
+| Required status checks | `dev-pr-gate` (dev-staging 의 snapshot PR 에 대해) |
 | Required reviewers | 0 |
 | Require conversation resolution | yes |
 | Require linear history | **yes** (nightly snapshot PR 만 들어옴, snapshot 자체가 linear) |
 | Allowed merge methods | merge commit (snapshot 보존용) |
 | Bypass roles | `minglit-release-bot` only for promotion/version metadata push |
 
-> dev 는 사람이 직접 PR 안 만듦. `nightly-cut` workflow 만 PR 생성. branch protection 이 사실상 workflow 만 허용하는 효과.
+> dev 는 사람이 직접 PR 안 만듦. `dev-staging-dev-cut` workflow 만 PR 생성. branch protection 이 사실상 workflow 만 허용하는 효과.
 
 ### `main`
 
@@ -61,8 +61,8 @@
 | Direct push | 금지 |
 | Force push | 금지 |
 | Branch deletion | 금지 |
-| Required status checks | `main-pr-gate` (RC HEAD 의 `rc-gate-pass`, `expand-migrate-contract`, `rc-soak-passed` marker 를 내부 검증) |
-| Required PR labels | GitHub Ruleset 직접 요구 없음. `main-pr-gate` 가 `rc-soak-passed` marker 를 검증 |
+| Required status checks | `main-pr-gate` (RC HEAD 의 `dev-rc-cut-pass`, `expand-migrate-contract`, `rc-main-cut-pass` marker 를 내부 검증) |
+| Required PR labels | GitHub Ruleset 직접 요구 없음. `main-pr-gate` 가 `rc-main-cut-pass` marker 를 검증 |
 | Required reviewers | 0 (workflow auto-merge) |
 | Require conversation resolution | yes |
 | Require linear history | **yes** |
@@ -70,7 +70,7 @@
 | Auto-delete head branch on merge | yes (`rc/*` branch 는 main merge 후 삭제, 이력은 protected tag 로 보존) |
 | Bypass roles | `minglit-release-bot` for final version/tag push, release manager only for catastrophic incident response |
 
-> rc → main PR 만 받음. GitHub Ruleset 은 `main-pr-gate` 하나만 required 로 두고, `main-pr-gate` 내부에서 RC HEAD status, soak marker, contract 재검증을 수행한다. PR head SHA 와 dev commit status 가 다를 수 있으므로 `rc-gate-pass` 를 branch protection 의 독립 required check 로 걸지 않는다.
+> rc → main PR 만 받음. GitHub Ruleset 은 `main-pr-gate` 하나만 required 로 두고, `main-pr-gate` 내부에서 RC HEAD status, soak marker, contract 재검증을 수행한다. PR head SHA 와 dev commit status 가 다를 수 있으므로 `dev-rc-cut-pass` 를 branch protection 의 독립 required check 로 걸지 않는다.
 
 ## Pattern Branch 설정
 
@@ -89,7 +89,7 @@
 | Auto-delete head branch on merge | yes (hotfix branch 자동 삭제) |
 | Bypass roles | `minglit-release-bot` only for RC version bump/tag push and RC branch cleanup |
 
-> `rc-cut` workflow 가 branch 생성 후 이 protection ruleset 을 REST API 로 활성화. RC 종료 후 `minglit-release-bot` 이 branch 를 삭제하고, 릴리즈 이력은 `promo/rc-*`, `v*-rc-*`, `promo/main-*` protected tag 로 보존한다.
+> `dev-rc-cut` workflow 가 branch 생성 후 이 protection ruleset 을 REST API 로 활성화. RC 종료 후 `minglit-release-bot` 이 branch 를 삭제하고, 릴리즈 이력은 `promo/rc-*`, `v*-rc-*`, `promo/main-*` protected tag 로 보존한다.
 
 ### `feat/*`, `fix/*`, `chore/*`, `docs/*`, `hotfix/*`
 
@@ -146,7 +146,7 @@ Bypass: 없음 (catastrophic 한 경우만 admin 명시 승인).
 
 | Pattern | 생성 권한 |
 |---------|----------|
-| `rc/YYYY-Wxx` | `rc-cut` workflow (GitHub Actions bot) only — human 직접 생성 금지 |
+| `rc/YYYY-Wxx` | `dev-rc-cut` workflow (GitHub Actions bot) only — human 직접 생성 금지 |
 | `release/**` | (현재 사용 안 함, 향후 추가 시 정의) |
 | `backport/**` | `rc-hotfix-backport` workflow only |
 
@@ -160,7 +160,7 @@ Protected branch 에 대한 direct push 는 human 에게 허용하지 않는다.
 |------|----|
 | Actor | `minglit-release-bot` (GitHub App 권장, 대안: fine-grained PAT 전용 bot account) |
 | Token source | GitHub App installation token minted from `minglit_env/{stage}/github.env` (`MINGLIT_RELEASE_BOT_APP_ID` + `MINGLIT_RELEASE_BOT_PRIVATE_KEY_BASE64`) |
-| 사용 workflow | `dev-staging-post-merge-sync`, `nightly-cut`, `rc-cut`, `rc-post-merge-sync`, `main-cut`, `rc-hotfix-backport`, `main-deploy` |
+| 사용 workflow | `dev-staging-dev-cut-gate`, `dev-staging-dev-cut`, `dev-rc-cut`, `rc-post-merge-sync`, `rc-main-cut`, `rc-hotfix-backport`, `main-deploy` |
 | Ruleset bypass | `dev-staging`, `dev`, `rc/**`, `main`, protected tag push (`v*`, `promo/**`) |
 | Human 사용 | 금지. 로컬/수동 CLI 에서 token 사용 금지 |
 | Audit | 모든 bot push 는 workflow run URL, actor, target ref, tag 목록을 PR/issue 또는 job summary 에 남김 |
@@ -172,8 +172,8 @@ GitHub App 기준 권장 permission:
 | Permission | Level | 이유 |
 |------------|-------|------|
 | Contents | Read/write | version bump commit, branch 생성/삭제, tag push |
-| Pull requests | Read/write | nightly/promotion/backport PR 생성, auto-merge enable |
-| Commit statuses | Read/write | `rc-gate-pass` status set |
+| Pull requests | Read/write | promotion/backport PR 생성, auto-merge enable |
+| Commit statuses | Read/write | `dev-rc-cut-pass` status set |
 | Checks | Read | gate 상태 조회 |
 | Issues | Read/write | auto-issue 생성/댓글 |
 | Metadata | Read | GitHub App 기본 권한 |
@@ -186,7 +186,7 @@ Deploy 권한·secret 격리·required reviewer 등은 GitHub Environment 단위
 
 | Environment | 용도 | 설정 |
 |-------------|------|------|
-| `dev` | dev 의 rc-gate-pass commit 으로 backend/web 자동 deploy | 자동 (no reviewer), Firebase service-account 등 dev secret |
+| `dev` | dev 의 dev-rc-cut-pass commit 으로 backend/web 자동 deploy | 자동 (no reviewer), Firebase service-account 등 dev secret |
 | `production` | main push 로 mobile build + store upload | **required reviewer (release manager)** — store upload 직전에 사람 1 명 승인. Apple/Google secret 격리. Sentry production project token |
 | `staging` (옵션) | RC Supabase branch 관리와 staging secret 격리 | TBD |
 
@@ -224,7 +224,7 @@ CODEOWNERS 가 required reviewer 와 결합하면 자동으로 review 요청 + �
 | version bump/tag push | `minglit-release-bot` | Ruleset bypass, workflow 내부에서만 |
 | nightly red 인데 main 핫픽스 필요 | release manager | `--admin` bypass + 명시 승인 (CLAUDE.md 룰) |
 | catastrophic incident (Tier 2b hard kill) | release manager / on-call | branch 변경 아님 (admin page 로 RC 콘솔 변경) |
-| RC abandon (TBD 시나리오) | RC owner | rc branch 삭제 + workflow_dispatch 로 새 rc-cut |
+| RC abandon (TBD 시나리오) | RC owner | rc branch 삭제 + workflow_dispatch 로 새 dev-rc-cut |
 
 ## 결정해야 할 것
 

--- a/docs/infra/branch-strategy/specs/execution-plan.md
+++ b/docs/infra/branch-strategy/specs/execution-plan.md
@@ -23,16 +23,16 @@
 |---------------|----------|----------|
 | `pr-gate-core` (reusable) | `pr-gate` 의 step 들을 reusable workflow_call 로 추출 + stage parameter 추가 | **refactor** |
 | `version-bump` (reusable) | `sync-version` 의 핵심 로직 → reusable 분리 | **refactor** |
-| `rc-gate-suite` (reusable) | 기존 `monitor-patrol-e2e`, `monitor-cuj-coverage` 등을 통합해 reusable suite 구성 | **신규 (조합)** |
+| `dev-rc-cut-gate-suite` (reusable) | 기존 `monitor-patrol-e2e`, `monitor-cuj-coverage` 등을 통합해 reusable suite 구성 | **신규 (조합)** |
 | `auto-issue` (reusable) | (없음) | **신규** |
 | `backport-pr` (reusable) | (없음) | **신규** |
 | `dev-staging-pr-gate` | `pr-gate` 를 dev-staging base 로 재사용 (stage=dev-staging) | **신규 (얇은 wrapper)** |
-| `dev-staging-post-merge-sync` | `post-merge` + `sync-version` orchestration | **신규 (조합)** |
-| `nightly-cut` | (없음) | **신규** |
-| `nightly-pr-gate` | `dev-staging-pr-gate` 와 동일 (stage=nightly) | **신규 (얇은 wrapper)** |
-| `rc-gate` | (없음) — rc-gate-suite 호출 + status set | **신규** |
+| `dev-staging-dev-cut-gate` | `post-merge` + `sync-version` orchestration | **신규 (조합)** |
+| `dev-staging-dev-cut` | (없음) | **신규** |
+| `dev-pr-gate` | `dev-staging-pr-gate` 와 동일 (stage=dev) | **신규 (얇은 wrapper)** |
+| `dev-rc-cut-gate` | 기존 `rc-gate` rename + `dev-rc-cut-pass` status set. full suite 는 후속 gate 확장 | **rename/refactor** |
 | `dev-deploy` | dev deploy/smoke entrypoint (범위 TBD), event-flow 는 monitor 로 유지 | **신규/선택** |
-| `rc-cut`, `rc-pr-gate`, `rc-post-merge-sync`, `rc-deploy`, `main-cut`, `rc-hotfix-backport` | (모두 없음) | **신규** |
+| `dev-rc-cut`, `rc-pr-gate`, `rc-post-merge-sync`, `rc-deploy`, `rc-main-cut-gate`, `rc-main-cut`, `rc-hotfix-backport` | 기존 `rc-cut` rename + 신규 wrapper/cut flow | **신규/rename** |
 | `main-pr-gate`, `main-deploy` | (없음, 부분적으로 `sync-version` / `deploy-*`) | **신규 + refactor** |
 | backend prod deploy | `deploy-supabase` 로직을 `main-deploy` 하위 job/reusable 로 흡수 | **refactor** |
 | web deploy | Vercel native build 로 전환 | **external config** |
@@ -60,9 +60,9 @@
 
 - 어느 시점에 default branch 를 dev-staging 으로 바꿀지 (Phase 4 까지 dev 유지)
 
-## Phase 2: Workflow refactor
+## Phase 2: CI flow / PR flow
 
-**위험도**: 중간. 기존 PR 흐름에 영향 가능.
+**위험도**: 중간. 기존 PR 흐름에 영향 가능. 목표는 gate 조건을 깊게 채우기 전에 PR 이 올바른 브랜치로 흐르는 entry workflow 를 먼저 만드는 것이다.
 
 ### Steps (순차)
 
@@ -74,8 +74,6 @@
 | 2d | `minglit-release-bot` 생성 + App ID/private key 등록 + workflow permission 최소화 | protected branch/tag push 를 human 대신 bot 으로 수행 |
 | 2e | `auto-issue` reusable 추가 | 신규 — 기존 영향 없음 |
 | 2f | **`ci-result` 폐기** — 현 branch protection 의 required check `ci-result` 를 각 branch 의 `pr-gate` 로 변경 (Phase 4 에서 실제 적용) | 본 step 은 workflow 측 준비, 실제 protection 변경은 4 |
-| 2g | backend deploy 로직을 `main-deploy` 하위 job/reusable 로 정리. dev 에서는 prod backend deploy 하지 않음 | prod deploy 의 단일 진입점 확정 |
-| 2h | **`deploy-vercel` 폐기** — 자체 빌드 워크플로우 제거. **Vercel native build 로 전환** (Vercel-GitHub 연결, Vercel-side: main=production) | Vercel-side 설정 필요, workflow 측 작업 없음 |
 
 ### Rollback
 
@@ -87,7 +85,21 @@
 - 기존 `pr-gate.yml` 파일을 그대로 두고 reusable 내부 사용 vs `pr-gate-core.yml` 신규 파일 (기존 파일은 trigger 만 정의)
 - 2c 의 sync-version 도 그대로 두고 reusable 호출 vs 완전 흡수
 
-## Phase 3: Workflow 신규 구현
+## Phase 3: Branch CD flow
+
+**위험도**: 중간. CI/promotion entrypoint 가 안정된 뒤 branch별 deploy entrypoint 를 정리한다.
+
+### Steps
+
+| Step | 작업 | 의존 |
+|------|------|------|
+| 3a | `dev-deploy` entrypoint: dev 환경 backend deploy/smoke. event-flow simulator 는 `monitor-event-flow-*` batch 로 유지 | Phase 2 |
+| 3b | `rc-deploy` entrypoint: Supabase branching 기반 RC branch 생성/적용/검증 | Phase 2 + Supabase branching 설정 |
+| 3c | `main-deploy` entrypoint: final version/tag + backend prod deploy. mobile deploy workflows 는 기존 `deploy-android-*`, `deploy-ios-*` 재사용 | Phase 2 |
+| 3d | backend deploy 로직을 `main-deploy` 하위 job/reusable 로 정리. dev 에서는 prod backend deploy 하지 않음 | 3c |
+| 3e | **`deploy-vercel` 폐기** — 자체 빌드 워크플로우 제거. **Vercel native build 로 전환** (Vercel-GitHub 연결, Vercel-side: main=production) | Vercel-side 설정 필요 |
+
+## Phase 4: Gate fill-in
 
 **위험도**: 중간~높음. 새 흐름 도입.
 
@@ -95,13 +107,10 @@
 
 | Step | 작업 | 의존 |
 |------|------|------|
-| 3a | `dev-staging-pr-gate`, `dev-staging-post-merge-sync` | 2a, 2b, 2c, 2d |
-| 3b | `nightly-cut`, `nightly-pr-gate` | 3a + dev-staging branch 존재 (Phase 1) |
-| 3c | `rc-gate-suite` reusable 조립 (CUJ × matrix + integration + Test Lab) | 2a |
-| 3d | `rc-gate` (호출 + status set) | 3c + 2f |
-| 3e | `rc-cut`, `rc-pr-gate`, `rc-post-merge-sync`, `rc-deploy`, `main-cut` | 3d + rc/* branch 패턴 확정 + Supabase branching 설정 |
-| 3f | `backport-pr` reusable, `rc-hotfix-backport` | 2a |
-| 3g | `main-pr-gate`, `main-deploy` | 3d (rc-gate-pass status 필요) |
+| 4a | `dev-rc-cut-gate-suite` reusable 조립 (CUJ × matrix + integration + Test Lab) | Phase 2 |
+| 4b | `dev-rc-cut-gate` 에 full suite 연결 + failure auto-issue/backoff | 4a |
+| 4c | `main-pr-gate` 에 RC lineage / `rc-main-cut-pass` / contract 재검증 추가 | Phase 2 |
+| 4d | `backport-pr` reusable, `rc-hotfix-backport` | Phase 2 |
 
 ### Verification 단계
 
@@ -117,11 +126,11 @@
 
 ### 결정
 
-- 신규 workflow 도입 순서가 정확히 위 순서 맞는지 (3a-3g)
+- 신규 workflow 도입 순서가 정확히 위 순서 맞는지
 - 각 verification 기간 (1주 vs 더 짧게/길게)
 - 운영 중 issue 발견 시 다음 step 진행 여부
 
-## Phase 4: Branch rule 적용
+## Phase 5: Branch rule 적용
 
 **위험도**: 가장 높음. required check 잘못 지정 시 모든 PR 머지 차단.
 
@@ -129,39 +138,39 @@
 
 | Step | 작업 | Pre-condition |
 |------|------|---------------|
-| 4a | `dev-staging` Ruleset 적용 (required: `dev-staging-pr-gate`) | 3a 1주 운영 |
-| 4b | `dev` Ruleset 갱신 (required: `nightly-pr-gate`) | 3b 1주 |
-| 4c | `rc/**` pattern Ruleset 적용 (required: `rc-pr-gate`) | 3e 1주 |
-| 4d | `main` Ruleset 갱신 — **기존 `ci-result` required check 제거** + 추가: `main-pr-gate` 단일 required check (`rc-gate-pass`, `expand-migrate-contract`, `rc-soak-passed` 는 내부 검증) | 3g 1주 + 3d 안정 |
-| 4e | Tag protection Ruleset (`v*`, `promo/**`) + release bot tag bypass | 4d 안정 (release 가 도는 게 확인된 후) |
-| 4f | Branch creation 제한 (`rc/**` → bot only) | 4c 안정 |
-| 4g | GitHub Environment `production` 생성 + required reviewer 설정 | 3g 1주 |
-| 4h | **Default branch 변경**: `dev` → `dev-staging` | 모든 위 단계 안정 |
+| 5a | `dev-staging` Ruleset 적용 (required: `dev-staging-pr-gate`) | Phase 2 1주 운영 |
+| 5b | `dev` Ruleset 갱신 (required: `dev-pr-gate`) | Phase 2 1주 |
+| 5c | `rc/**` pattern Ruleset 적용 (required: `rc-pr-gate`) | Phase 2 + RC flow 1주 |
+| 5d | `main` Ruleset 갱신 — **기존 `ci-result` required check 제거** + 추가: `main-pr-gate` 단일 required check (`dev-rc-cut-pass`, `expand-migrate-contract`, `rc-main-cut-pass` 는 내부 검증) | Phase 4 gate fill-in 안정 |
+| 5e | Tag protection Ruleset (`v*`, `promo/**`) + release bot tag bypass | 5d 안정 (release 가 도는 게 확인된 후) |
+| 5f | Branch creation 제한 (`rc/**` → bot only) | 5c 안정 |
+| 5g | GitHub Environment `production` 생성 + required reviewer 설정 | Phase 3 1주 |
+| 5h | **Default branch 변경**: `dev` → `dev-staging` | 모든 위 단계 안정 |
 
 ### Rollback
 
 - 각 Ruleset 은 GitHub 콘솔에서 즉시 disable 가능
 - Default branch 변경은 rollback 가능 (수동)
-- 가장 위험: 4d (main 의 required check) — 잘못 적용 시 모든 release 차단. **항상 단계별로 우선 *warn-only* 모드로 적용 후 *enforced* 전환**
+- 가장 위험: 5d (main 의 required check) — 잘못 적용 시 모든 release 차단. **항상 단계별로 우선 *warn-only* 모드로 적용 후 *enforced* 전환**
 
 ### 결정
 
 - 각 Ruleset 의 bypass list (admin / release manager)
-- 4h 시점 (Phase 4 끝일까, 운영 1개월 후일까)
+- 5h 시점 (Phase 5 끝일까, 운영 1개월 후일까)
 
 ## 우선순위 / Critical Path
 
 가장 critical 한 path (block 면 전체 멈춤):
 
 ```
-Phase 1 (skeletal) → Phase 2a-2c (pr-gate refactor) → Phase 3a (dev-staging workflow)
-    → Phase 3d (rc-gate, 가장 큰 신규) → Phase 4a (첫 protection 적용)
+Phase 1 (skeletal) → Phase 2 (CI/PR flow) → Phase 3 (branch CD)
+    → Phase 4 (gate fill-in) → Phase 5a (첫 protection 적용)
 ```
 
 비-critical (병렬 가능):
 - Phase 2e (`auto-issue` reusable) — 신규, 의존 없음
-- Phase 2f/2g (deploy trigger refactor) — Phase 3 이전에 끝나면 OK
-- 3c (rc-gate-suite) — 3d 이전에만 끝나면 OK
+- Phase 3 (deploy trigger refactor) — Phase 5 이전에 끝나면 OK
+- Phase 4a (dev-rc-cut-gate-suite) — Phase 4b 이전에만 끝나면 OK
 
 ## Secret Management 정리 (별도 작업, user 와 함께)
 
@@ -206,7 +215,7 @@ Phase 1 (skeletal) → Phase 2a-2c (pr-gate refactor) → Phase 3a (dev-staging 
 
 1. **CI 실패가 release 차단**: pr-gate 의 stage parameter 가 정확히 매칭돼야 함. *required check 이름 한 글자라도 다르면 차단*. 특히 `ci-result` → stage pr-gate 전환 시 cutover 타이밍 중요
 2. **trigger 변경**: cron → push 변경 시 *겹치는 기간* 발생할 수 있음 — 한쪽 비활성화 후 다른쪽 활성화. 부분 적용 금지
-3. **status check naming**: `rc-gate-pass` 같은 commit status 의 이름이 spec 과 workflow 에서 일치해야 함. branch protection 에는 직접 required 로 걸지 않고 `main-pr-gate` 내부에서 검증
+3. **status check naming**: `dev-rc-cut-pass` 같은 commit status 의 이름이 spec 과 workflow 에서 일치해야 함. branch protection 에는 직접 required 로 걸지 않고 `main-pr-gate` 내부에서 검증
 4. **AI agent 의 PR 동시성**: merge queue 없으니 race condition 발생 시 수동 conflict resolve 필요 (또는 merge queue 도입 검토)
 5. **Release bot token 실패**: GitHub App ID/private key 누락 또는 App 권한 부족이면 version bump/tag/promotion workflow 가 막힘. 최초 도입 시 dry-run branch 로 push/tag/delete까지 검증
 6. **Secret 마이그레이션 중 workflow 실패**: file 기반과 GH secret 참조가 섞이는 transition 기간 — env 변수 누락 시 즉시 발견 (CI 통과 못함)
@@ -215,17 +224,17 @@ Phase 1 (skeletal) → Phase 2a-2c (pr-gate refactor) → Phase 3a (dev-staging 
 
 내부 검토 결과 — **현재 순서 (3a → 3b → 3c → 3d → 3e → 3f → 3g) OK**, 단 다음 minor 개선:
 
-- **3a / 3b 병렬 가능**: dev-staging-pr-gate (3a) 와 nightly-cut (3b) 는 서로 의존이 약함. 단 version bump/tag push 검증에는 release bot 준비가 선행되어야 함
-- **3c → 3d 사이 verification 불필요**: rc-gate-suite (3c) 는 reusable, 호출은 rc-gate (3d) 에서. 3c 자체로는 동작 없음 → 3d 와 동일 PR 또는 직후 PR 가능
+- **3a / 3b 병렬 가능**: dev-staging-pr-gate (3a) 와 dev-staging-dev-cut (3b) 는 서로 의존이 약함. 단 version bump/tag push 검증에는 release bot 준비가 선행되어야 함
+- **3c → 3d 사이 verification 불필요**: dev-rc-cut-gate-suite (3c) 는 reusable, 호출은 dev-rc-cut-gate (3d) 에서. 3c 자체로는 동작 없음 → 3d 와 동일 PR 또는 직후 PR 가능
 - **3f 는 3e 와 같이**: rc-hotfix-backport 가 rc-promotion 흐름의 일부라 같은 시점에 도입이 자연스러움
-- **가장 critical**: 3d (rc-gate) — 첫 verification 기간 1주 이상 추천 (다른 stage 와 달리 60분 비용 + 통합 시나리오 복잡)
+- **가장 critical**: 3d (dev-rc-cut-gate) — 첫 verification 기간 1주 이상 추천 (다른 stage 와 달리 60분 비용 + 통합 시나리오 복잡)
 
 권장 변경 없음. 위 순서 그대로 진행.
 
 ## TBD (구현 중 결정)
 
 - `auto-issue` 의 P0/P1/P2 라벨 컨벤션 표준 (현재 minglit 의 `P0-critical` 등 따름)
-- `rc-gate-suite` 매트릭스 분할 (60분 예산 안에 들어오게)
+- `dev-rc-cut-gate-suite` 매트릭스 분할 (60분 예산 안에 들어오게)
 - 4d 의 main protection 적용을 *warn-only* → *enforced* 전환 일자
 - Vercel native build 전환 시점 + Vercel-GitHub 연결 설정 (Vercel-side 작업)
 - Secret 마이그레이션 timing (user 와 함께 — Phase 2/3 와 별도)

--- a/docs/infra/branch-strategy/specs/release-bot.md
+++ b/docs/infra/branch-strategy/specs/release-bot.md
@@ -19,8 +19,8 @@ GitHub App permission 은 아래만 부여한다.
 | Permission | Level | 이유 |
 |------------|-------|------|
 | Contents | Read/write | version bump commit, branch 생성/삭제, tag push, release asset/source 접근 |
-| Pull requests | Read/write | nightly/promotion/backport PR 생성, auto-merge enable |
-| Commit statuses | Read/write | `rc-gate-pass` 같은 commit status 설정 |
+| Pull requests | Read/write | promotion/backport PR 생성, auto-merge enable |
+| Commit statuses | Read/write | `dev-rc-cut-pass` 같은 commit status 설정 |
 | Checks | Read | required check / gate 상태 조회 |
 | Issues | Read/write | release 자동 이슈 생성, failure comment |
 | Metadata | Read | GitHub App 기본 권한 |
@@ -84,11 +84,11 @@ git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
 | Workflow | 사용 이유 |
 |----------|-----------|
 | `sync-version` | dev/main version bump commit, main release tag |
-| `dev-staging-post-merge-sync` | dev-staging version bump/tag |
-| `nightly-cut` | immutable nightly branch 생성, dev PR 생성 |
-| `rc-cut` | `rc/YYYY-Wxx` branch 생성, RC tag |
+| `dev-staging-dev-cut-gate` | dev-staging version bump/tag |
+| `dev-staging-dev-cut` | immutable nightly branch 생성, dev PR 생성 |
+| `dev-rc-cut` | `rc/YYYY-Wxx` branch 생성, RC tag |
 | `rc-post-merge-sync` | RC hotfix version bump/tag |
-| `main-cut` | rc → main promotion PR 생성/auto-merge |
+| `rc-main-cut` | rc → main promotion PR 생성/auto-merge |
 | `rc-hotfix-backport` | backport branch/PR 생성 |
 | `main-deploy` | final version/tag/release marker, prod deploy, RC branch cleanup |
 
@@ -99,7 +99,7 @@ Ruleset bypass actor 는 `minglit-release-bot` App installation 으로 제한한
 | Target | 허용 작업 |
 |--------|-----------|
 | `dev-staging` | version bump commit, `v*-dev-staging` tag |
-| `dev` | nightly promotion/version metadata push |
+| `dev` | dev-staging-dev-cut promotion/version metadata push |
 | `rc/**` | RC branch 생성/삭제, RC hotfix version bump |
 | `main` | final version bump/tag/promotion commit |
 | `v*`, `promo/**` | protected tag 생성 |

--- a/docs/infra/branch-strategy/specs/secret-migration-plan.md
+++ b/docs/infra/branch-strategy/specs/secret-migration-plan.md
@@ -27,7 +27,7 @@ minglit_env/
 └── README.md           # 컨벤션 + 변수 카탈로그
 ```
 
-> **RC env 의 역할**: `rc-deploy` 가 Supabase branching 으로 `rc-YYYY-Wxx` 임시 branch 를 만들고 main 배포 전 backend 검증에 사용한다. `rc-gate-pass` 는 deploy trigger 가 아니라 RC cut source marker 다.
+> **RC env 의 역할**: `rc-deploy` 가 Supabase branching 으로 `rc-YYYY-Wxx` 임시 branch 를 만들고 main 배포 전 backend 검증에 사용한다. `dev-rc-cut-pass` 는 deploy trigger 가 아니라 RC cut source marker 다.
 
 기존 도메인별 파일 (`flutter.env`, `supabase.env`, `nextjs.env`, `metabase.env`) 은 통합 후 폐기.
 

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -4,10 +4,13 @@
 
 ## 명명 컨벤션
 
-- **Entry workflow**: `<stage>-<action>` 패턴 (예: `dev-staging-pr-gate`, `rc-cut`, `main-deploy`)
+- **Entry workflow**: `<stage>-<action>` 패턴 (예: `dev-staging-pr-gate`, `dev-rc-cut`, `main-deploy`)
 - **Reusable workflow** (`workflow_call`): 명사·동사형 (예: `pr-gate-core`, `version-bump`)
 - File 이름 = workflow 이름 + `.yml`
-- Stage prefix: `dev-staging-` · `nightly-` · `rc-` · `main-`
+- Stage prefix: `dev-staging-` · `dev-` · `rc-` · `main-`
+- `*-cut-gate`: 다음 브랜치로 promote 할 source artifact 를 검증/선별하고 marker 를 남긴다
+- `*-cut`: gate 가 남긴 marker 를 소비해서 실제 promotion PR 또는 branch 를 만든다
+- Branch PR gate 는 `<branch>-pr-gate` 로만 부른다: `dev-staging-pr-gate`, `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate`
 - Reusable 은 prefix 없음
 - Deploy entry workflow 는 `[branch]-deploy` 로 통일한다: `dev-deploy`, `rc-deploy`, `main-deploy`
 - 기존 domain deploy workflow (`deploy-supabase`, `deploy-android-user` 등) 는 entrypoint 가 아니라 하위 구현/재사용 대상이다
@@ -22,10 +25,10 @@
 | 항목 | 값 |
 |------|----|
 | Trigger | `workflow_call` |
-| Inputs | `stage`: dev-staging\|nightly\|rc\|main / `ref`: branch ref / `extra_steps`: array (optional) |
+| Inputs | `stage`: dev-staging\|dev\|rc\|main / `ref`: branch ref / `extra_steps`: array (optional) |
 | Outputs | `status`: pass\|fail / `report_url` |
 | 핵심 steps | test-flutter-apps (matrix) · lint-landing-* · test-supabase (pgTAP) · test-edge-functions (Deno) · check-migration-versions · `expand-migrate-contract` · `flag-registration-check` · gitleaks · CodeRabbit (≤30분 wait) |
-| Called by | `dev-staging-pr-gate`, `nightly-pr-gate`, `rc-pr-gate`, `main-pr-gate` |
+| Called by | `dev-staging-pr-gate`, `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` |
 
 ### `version-bump`
 
@@ -37,9 +40,9 @@
 | Inputs | `version`: YY.MM.PR# / `suffix`: ""\|`-dev-staging`\|`-rc-NN` / `commit_message`: string |
 | Outputs | `commit_sha`, `tag_name` |
 | 핵심 steps | `bash scripts/bump-version.sh {version}{suffix}` · commit (`skip_ci` option) · `git tag v{version}{suffix}` · push |
-| Called by | `dev-staging-post-merge-sync`, `rc-cut`, `rc-post-merge-sync`, `main-deploy` |
+| Called by | `dev-staging-dev-cut-gate`, `dev-rc-cut`, `rc-post-merge-sync`, `main-deploy` |
 
-### `rc-gate-suite`
+### `dev-rc-cut-gate-suite`
 
 Heavy integration test suite. 60분 예산.
 
@@ -49,7 +52,7 @@ Heavy integration test suite. 60분 예산.
 | Inputs | `ref`: dev commit SHA |
 | Outputs | `status`: pass\|fail / `failed_jobs`: array |
 | Matrix | (app × scenario): `cuj-app-user × {happy, unhappy, chaos}` + `cuj-app-partner × {happy, unhappy, chaos}` + `integration-backend` + `integration-edge-functions` + `test-lab-smoke` |
-| Called by | `rc-gate` |
+| Called by | `dev-rc-cut-gate` |
 
 > chaos 시나리오 미정의면 CUJ 로 추후 정의 (TBD).
 
@@ -90,7 +93,7 @@ Cross-branch cherry-pick PR 자동 생성.
 | Steps | calls `pr-gate-core` (stage=dev-staging) |
 | Required for | dev-staging PR merge |
 
-#### `dev-staging-post-merge-sync`
+#### `dev-staging-dev-cut-gate`
 
 | 항목 | 값 |
 |------|----|
@@ -99,37 +102,37 @@ Cross-branch cherry-pick PR 자동 생성.
 | Outputs | tag `v{YY.MM.PR#}-dev-staging` |
 | Steps | calls `version-bump` (suffix=`-dev-staging`, version=`{YY.MM.PR#}`) using release bot GitHub App token |
 
-### nightly (dev 진입)
+### dev-staging → dev
 
-#### `nightly-cut`
+#### `dev-staging-dev-cut`
 
 | 항목 | 값 |
 |------|----|
 | Trigger | `schedule` (daily KST 02:00 TBD) + `workflow_dispatch` |
 | Inputs | optional `tag_name` (`v*-dev-staging`) |
 | Outputs | PR number (dev-staging → dev) or skip |
-| PR title | `ci(nightly-cut): promote {tag_name} to dev` |
-| Steps | (1) 이전 `nightly-cut` PR open 이면 skip + Slack (2) 가장 최근 `v*-dev-staging` tag SHA 조회, 또는 입력 `tag_name` 사용 (3) dev 가 그 SHA 를 이미 포함하면 skip ("no new commits") (4) `nightly/YYYY-MM-DD-{sha8}` promotion branch 를 tag SHA 에서 생성 (5) `gh pr create` (base=dev, head=nightly/YYYY-MM-DD-{sha8}) + auto-merge 활성화 (`rebase`, active dev ruleset 의 linear history 와 호환) |
+| PR title | `ci(dev-staging-dev-cut): promote {tag_name} to dev` |
+| Steps | (1) 이전 `dev-staging-dev-cut` PR open 이면 skip + Slack (2) 가장 최근 `v*-dev-staging` tag SHA 조회, 또는 입력 `tag_name` 사용 (3) dev 가 그 SHA 를 이미 포함하면 skip ("no new commits") (4) `cut/dev-staging-dev/YYYY-MM-DD-{sha8}` promotion branch 를 tag SHA 에서 생성 (5) `gh pr create` (base=dev, head=`cut/dev-staging-dev/YYYY-MM-DD-{sha8}`) + auto-merge 활성화 (`rebase`, active dev ruleset 의 linear history 와 호환) |
 
-#### `nightly-pr-gate`
+#### `dev-pr-gate`
 
 | 항목 | 값 |
 |------|----|
 | Trigger | `pull_request` (base: `dev`) |
-| Steps | calls `pr-gate-core` (stage=nightly) |
+| Steps | calls `pr-gate-core` (stage=dev) |
 | Required for | dev branch protection |
 
-#### `rc-gate`
+#### `dev-rc-cut-gate`
 
 | 항목 | 값 |
 |------|----|
-| Trigger | `push` to `dev` (= nightly-cut PR merge 직후) |
-| Outputs | commit status `rc-gate-pass` (success only) |
-| Steps | (1) calls `rc-gate-suite` (2) **success**: set commit status `rc-gate-pass` (3) **failure**: `auto-issue` (P1, label `rc-gate-failure`, assignee=직전 rc-gate-pass 이후 머지된 PR 작성자들). dev 는 broken 상태로 잠시 머묾, AI agent 가 fix PR 을 dev-staging 으로 normal flow 로 작성 → 다음 nightly-cut → 다음 rc-gate 가 검증 |
-| Backoff | 같은 area 3회 연속 실패 시 `rc-cut` 자동 차단 (다음 weekly cut PR 안 만듦) |
+| Trigger | `push` to `dev` (= dev-staging-dev-cut PR merge 직후) |
+| Outputs | commit status `dev-rc-cut-pass` (success only) |
+| Steps | (1) calls `dev-rc-cut-gate-suite` (2) **success**: set commit status `dev-rc-cut-pass` (3) **failure**: `auto-issue` (P1, label `dev-rc-cut-gate-failure`, assignee=직전 dev-rc-cut-pass 이후 머지된 PR 작성자들). dev 는 broken 상태로 잠시 머묾, AI agent 가 fix PR 을 dev-staging 으로 normal flow 로 작성 → 다음 dev-staging-dev-cut → 다음 dev-rc-cut-gate 가 검증 |
+| Backoff | 같은 area 3회 연속 실패 시 `dev-rc-cut` 자동 차단 (다음 weekly cut PR 안 만듦) |
 
-> **No auto-revert** — snapshot 모델: 실패 = no tag, dev keeps moving, 새 fix 가 자연스럽게 다음 rc-gate 에서 검증됨.
-> **Naming** — `rc-gate-pass` 가 canonical RC eligibility marker 이다. `rc-eligible` 은 현재 workflow/status 명칭이 아니다.
+> **No auto-revert** — snapshot 모델: 실패 = no tag, dev keeps moving, 새 fix 가 자연스럽게 다음 dev-rc-cut-gate 에서 검증됨.
+> **Naming** — `dev-rc-cut-pass` 가 canonical RC eligibility marker 이다. `rc-eligible` 은 현재 workflow/status 명칭이 아니다.
 
 #### `dev-deploy`
 
@@ -151,13 +154,13 @@ Cross-branch cherry-pick PR 자동 생성.
 
 ### rc
 
-#### `rc-cut`
+#### `dev-rc-cut`
 
 | 항목 | 값 |
 |------|----|
 | Trigger | `schedule` (weekly KST TBD) + `workflow_dispatch` |
 | Outputs | branch `rc/YYYY-Wxx` + tag `v{ver}-rc-01` + tag `promo/rc-YYYY-Wxx` |
-| Steps | (1) active RC marker 가 있으면 skip + Slack `#release` (hotfix 로 길어지는 중) (2) dev 의 최신 `rc-gate-pass` status SHA query (`gh api`) (3) 없으면 cut 보류 (4) `git branch rc/YYYY-Wxx <SHA>` + push using release bot (5) calls `version-bump` (suffix=`-rc-01`) (6) `git tag promo/rc-YYYY-Wxx` + push (7) branch protection 활성화 (8) Slack `#release` 알림 |
+| Steps | (1) active RC marker 가 있으면 skip + Slack `#release` (hotfix 로 길어지는 중) (2) dev 의 최신 `dev-rc-cut-pass` status SHA query (`gh api`) (3) 없으면 cut 보류 (4) `git branch rc/YYYY-Wxx <SHA>` + push using release bot (5) calls `version-bump` (suffix=`-rc-01`) (6) `git tag promo/rc-YYYY-Wxx` + push (7) branch protection 활성화 (8) Slack `#release` 알림 |
 
 #### `rc-pr-gate`
 
@@ -184,13 +187,24 @@ Cross-branch cherry-pick PR 자동 생성.
 | Steps | (1) Supabase branch `rc-YYYY-Wxx` 생성/확인 (2) migration/EF apply to RC branch (3) RC env smoke (4) event-flow simulation signal 확인 (5) 실패 시 `auto-issue` |
 | Note | RC 는 계속 유지되는 장기 branch 가 아니라 Supabase branching 기반의 임시 검증 환경이다 |
 
-#### `main-cut`
+#### `rc-main-cut-gate`
 
 | 항목 | 값 |
 |------|----|
-| Trigger | `schedule` (daily KST TBD) |
-| Outputs | rc → main PR (5일 무커밋 시) or skip |
-| Steps | (1) `rc/*` 존재 확인 → 없으면 종료 (2) rc HEAD 의 `committer date` 조회 (3) committer date 가 5일 이전이면: `gh pr create base=main head=rc/YYYY-Wxx` + label `rc-soak-passed` + auto-merge 활성화 |
+| Trigger | `schedule` (daily KST TBD) + `workflow_dispatch` |
+| Outputs | marker `rc-main-cut-pass` on current RC head, or skip/fail |
+| Steps | (1) active `rc/*` 확인 → 없으면 종료 (2) rc HEAD 의 `committer date` 가 5일 이전인지 확인 (3) `rc-deploy`/pre-main validation/event-flow signal green 확인 (4) main promotion 차단 조건(`dev-rc-cut-gate-degraded`, P0/P1 blocker 등) 확인 (5) 통과 시 RC HEAD/active marker 에 `rc-main-cut-pass` 부여 |
+| Note | promotion PR 을 만들지 않는다. main 으로 보낼 RC 를 선별하는 gate 전용 workflow 다 |
+
+#### `rc-main-cut`
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `schedule` (daily KST TBD, after `rc-main-cut-gate`) + `workflow_dispatch` |
+| Outputs | rc → main PR or skip |
+| PR title | `ci(rc-main-cut): promote rc/YYYY-Wxx to main` |
+| Steps | (1) `rc-main-cut-pass` marker 가 있는 active `rc/*` 확인 → 없으면 종료 (2) 이미 open rc → main PR 이 있으면 skip (3) `gh pr create base=main head=rc/YYYY-Wxx` + label `rc-main-cut-pass` + auto-merge 활성화 |
+| Note | soak/validation 판단은 `rc-main-cut-gate` 책임이다. `rc-main-cut` 은 marker 소비와 PR 생성만 담당한다 |
 
 #### `rc-hotfix-backport`
 
@@ -207,7 +221,7 @@ Cross-branch cherry-pick PR 자동 생성.
 | 항목 | 값 |
 |------|----|
 | Trigger | `pull_request` (base: `main`) |
-| Steps | (1) calls `pr-gate-core` (stage=main) (2) RC HEAD 의 `rc-gate-pass` commit status 확인 (3) PR 의 `rc-soak-passed` label 확인 |
+| Steps | (1) calls `pr-gate-core` (stage=main) (2) RC lineage 의 `dev-rc-cut-pass` commit status 확인 (3) PR 의 `rc-main-cut-pass` label/marker 확인 |
 | Required for | main branch protection |
 
 #### `main-deploy`
@@ -233,23 +247,23 @@ Cross-branch cherry-pick PR 자동 생성.
        ↓
 [dev-staging-pr-gate] ──auto-merge──▶ dev-staging push
                                                 ↓
-                                         [dev-staging-post-merge-sync]
+                                         [dev-staging-dev-cut-gate]
                                                 ↓ tag v{ver}-dev-staging
 
 [daily KST 02:00]
     ↓
-[nightly-cut] ──PR created──▶ [nightly-pr-gate] ──auto-merge──▶ dev push
+[dev-staging-dev-cut] ──PR created──▶ [dev-pr-gate] ──auto-merge──▶ dev push
                                                                     ↓
-                                                              [rc-gate]
-                                                              ├ success ─▶ status rc-gate-pass
+                                                              [dev-rc-cut-gate]
+                                                              ├ success ─▶ status dev-rc-cut-pass
                                                               │              ↓ monitor-event-flow-* continuous signal
                                                               │
                                                               └ failure ─▶ [auto-issue P1] (AI agent assignee → dev-staging fix PR)
-                                                                          (no auto-revert — dev 잠시 broken, 다음 fix 가 다음 rc-gate 에서 검증)
+                                                                          (no auto-revert — dev 잠시 broken, 다음 fix 가 다음 dev-rc-cut-gate 에서 검증)
 
 [weekly cron]
     ↓
-[rc-cut] ──branch out from latest rc-gate-pass commit──▶ rc/YYYY-Wxx (+ v{ver}-rc-01)
+[dev-rc-cut] ──branch out from latest dev-rc-cut-pass commit──▶ rc/YYYY-Wxx (+ v{ver}-rc-01)
                                                                 ↓ (soak, hotfix 가능)
                                                                 │
                                                           [rc-pr-gate] (hotfix PR)
@@ -257,15 +271,17 @@ Cross-branch cherry-pick PR 자동 생성.
                                                                 ↓ (parallel)
                                                           [rc-post-merge-sync] ──▶ v{ver}-rc-NN
                                                           [rc-hotfix-backport]  ──▶ backport PR to dev-staging
-                                                          [rc-deploy]           ──▶ Supabase branch + pre-main validation
+[rc-deploy]           ──▶ Supabase branch + pre-main validation
 
 [daily cron, rc 존재 시]
     ↓
-[main-cut] ──5일 무커밋──▶ rc → main PR (label rc-soak-passed)
-                                       ↓ [main-pr-gate] → auto-merge
-                                       ↓ main push
-                                       ↓
-                                 [main-deploy]
+[rc-main-cut-gate] ──5일 무커밋 + pre-main signal green──▶ marker rc-main-cut-pass
+                                                                  ↓
+                                                           [rc-main-cut] ──▶ rc → main PR
+                                                                  ↓ [main-pr-gate] → auto-merge
+                                                                  ↓ main push
+                                                                  ↓
+                                                            [main-deploy]
                                        ↓ tag v{ver} + promo/main-Wxx + Sentry release
                                        ↓ Firebase RC `latest_version` = v{ver}
                                        ↓ (parallel)
@@ -281,7 +297,7 @@ Cross-branch cherry-pick PR 자동 생성.
 
 - `pr-gate-core` 의 stage 별 `extra_steps` 명세
 - `version-bump` 의 commit 방식 (별도 commit vs squash inline)
-- `rc-gate-suite` matrix 분할 (60분 예산)
+- `dev-rc-cut-gate-suite` matrix 분할 (60분 예산)
 - `dev-deploy` 가 실제로 맡을 dev deploy/smoke 범위
 - `rc-deploy` 의 Supabase branch seed data 와 event-flow simulation contract
 - CUJ chaos 시나리오 정의 (현재 미정의)
@@ -293,7 +309,7 @@ Cross-branch cherry-pick PR 자동 생성.
 ## 관련
 
 - [../branch-flow.md](../branch-flow.md) — workflow 가 흘러가는 branch 그림
-- [../test-strategy.md](../test-strategy.md) — pr-gate-core 와 rc-gate-suite 의 test 내용
+- [../test-strategy.md](../test-strategy.md) — pr-gate-core 와 dev-rc-cut-gate-suite 의 test 내용
 - [../error-detection.md](../error-detection.md) — auto-issue 의 priority 와 채널
 - [../life-of-flag.md](../life-of-flag.md) — flag lifecycle
 - [../versioning.md](../versioning.md) — version-bump 의 suffix 진행

--- a/docs/infra/branch-strategy/test-strategy.md
+++ b/docs/infra/branch-strategy/test-strategy.md
@@ -1,16 +1,16 @@
 # Test Strategy
 
-4-stage 모델 (`dev-staging → dev → rc → main`) + flag staged rollout 환경에서, *어떤 테스트가 어느 단계에서 도는가* 의 단일 source. 빠른 검사 = `pr-gate` (각 단계), 무거운 검사 = `rc-gate` (dev 의 post-merge), 프로덕션 검증 = `deploy-android-*, deploy-ios-*` smoke + flag staged.
+4-stage 모델 (`dev-staging → dev → rc → main`) + flag staged rollout 환경에서, *어떤 테스트가 어느 단계에서 도는가* 의 단일 source. 빠른 검사 = `pr-gate` (각 단계), 무거운 검사 = `dev-rc-cut-gate` (dev 의 post-merge), 프로덕션 검증 = `deploy-android-*, deploy-ios-*` smoke + flag staged.
 
 ## 단계별 게이트
 
 | 단계 | 게이트 | 소요 | 실패 시 |
 |------|--------|------|---------|
 | dev-staging 머지 전 | `dev-staging-pr-gate` (unit · lint · analyze · pgTAP · EF test · migration check · `expand-migrate-contract` · `flag-registration` · gitleaks) | < 10분 | auto-merge 보류 |
-| dev 머지 전 | `nightly-pr-gate` (dev-staging-pr-gate 와 동일 — defensive) | < 10분 | nightly-cut PR drop |
-| dev 머지 후 (자동) | `rc-gate` (CUJ matrix happy/unhappy/chaos · integration · e2e · Test Lab smoke) | 30-60분 | 자동 이슈 + AI fix flow via dev-staging. `rc-gate-pass` 미부여 |
+| dev 머지 전 | `dev-pr-gate` (dev-staging-pr-gate 와 동일 — defensive) | < 10분 | dev-staging-dev-cut PR drop |
+| dev 머지 후 (자동) | `dev-rc-cut-gate` (CUJ matrix happy/unhappy/chaos · integration · e2e · Test Lab smoke) | 30-60분 | 자동 이슈 + AI fix flow via dev-staging. `dev-rc-cut-pass` 미부여 |
 | rc 머지 전 (hotfix) | `rc-pr-gate` (pr-gate + mobile smoke) | < 15분 | hotfix PR drop |
-| main 머지 전 (rc → main) | `main-pr-gate` (pr-gate + `expand-migrate-contract` 재검증 + RC HEAD 의 `rc-gate-pass` 확인 + `rc-soak-passed` marker 확인) | 분 | promotion PR 보류 |
+| main 머지 전 (rc → main) | `main-pr-gate` (pr-gate + `expand-migrate-contract` 재검증 + RC HEAD 의 `dev-rc-cut-pass` 확인 + `rc-main-cut-pass` marker 확인) | 분 | promotion PR 보류 |
 | rc → main PR | workflow auto-merge (모든 check 통과 시) | 분 | check 실패 시 PR hold + alert |
 | Backend/Web auto-deploy 후 | post-deploy smoke + Sentry/Crashlytics 알람 임계 | 분 | auto-rollback ([main-promotion.md](./main-promotion.md)) |
 | deploy-android-*, deploy-ios-* 후 | mobile build smoke (Fastlane upload 검증) | 시간 | retry 1회 → auto-issue + mobile 팀 |
@@ -33,15 +33,15 @@
 - `gitleaks`
 - CodeRabbit 리뷰 (최대 30분 대기)
 
-룰: 10분 넘으면 `rc-gate` 로 이동.
+룰: 10분 넘으면 `dev-rc-cut-gate` 로 이동.
 
-### nightly-pr-gate
+### dev-pr-gate
 
 `dev-staging-pr-gate` 와 동일한 test suite. 환경 차이로 인한 회귀만 잡는 defensive 검증. 대부분 통과.
 
-### rc-gate — Heavy Integration
+### dev-rc-cut-gate — Heavy Integration
 
-dev 머지 후 자동 발동. 통과 시 commit 에 GitHub status `rc-gate-pass` set + `backend-auto-deploy` + `web-auto-deploy` chain.
+dev 머지 후 자동 발동. 통과 시 commit 에 GitHub status `dev-rc-cut-pass` set + `backend-auto-deploy` + `web-auto-deploy` chain.
 
 - CUJ (app_user, app_partner)
 - Integration tests (backend, edge functions)
@@ -57,10 +57,10 @@ RC 의 hotfix 만 받음. `pr-gate` + 추가 mobile smoke. 머지 시 `rc-post-m
 
 ### main-pr-gate
 
-`main-cut` 이 자동 생성한 promotion PR 에 적용:
+`rc-main-cut` 이 자동 생성한 promotion PR 에 적용:
 - pr-gate 재실행
 - `expand-migrate-contract` 다시 검증 (RC 5일 동안 dev 가 더 나갔을 수 있음)
-- RC HEAD 의 `rc-gate-pass` status 확인 (마지막 hotfix 이 rc-gate 통과했는지)
+- RC HEAD 의 `dev-rc-cut-pass` status 확인 (마지막 hotfix 이 dev-rc-cut-gate 통과했는지)
 
 모든 check 통과 시 workflow auto-merge (rebase + ff).
 
@@ -78,11 +78,11 @@ RC 의 hotfix 만 받음. `pr-gate` + 추가 mobile smoke. 머지 시 `rc-post-m
 | 테스트 성격 | 배치 위치 | 이유 |
 |-------------|-----------|------|
 | 결정론적, < 10분 | `dev-staging-pr-gate` | PR 사이클 안 막음 |
-| flaky 또는 느림 (10분+) | `rc-gate` | PR 머지 게이트의 신뢰도 보호 |
-| 외부 의존성 (실 결제 등) | `rc-gate` + flag canary | 비용·side effect 통제 |
-| 부하/성능 | `rc-gate` (주 1회) or staged rollout 메트릭 | 매일 무거움 |
+| flaky 또는 느림 (10분+) | `dev-rc-cut-gate` | PR 머지 게이트의 신뢰도 보호 |
+| 외부 의존성 (실 결제 등) | `dev-rc-cut-gate` + flag canary | 비용·side effect 통제 |
+| 부하/성능 | `dev-rc-cut-gate` (주 1회) or staged rollout 메트릭 | 매일 무거움 |
 | backend ↔ mobile 계약 호환 | `expand-migrate-contract` CI + flag canary 메트릭 | 다층 안전망 |
-| 실 디바이스 다양성 | `rc-gate` 의 Firebase Test Lab | 시뮬레이터 한계 보완 |
+| 실 디바이스 다양성 | `dev-rc-cut-gate` 의 Firebase Test Lab | 시뮬레이터 한계 보완 |
 | Mobile 회귀 (deploy 직후) | `deploy-android-*, deploy-ios-*` 의 build smoke | store upload 전 마지막 |
 
 ## 결정해야 할 것

--- a/docs/infra/branch-strategy/versioning.md
+++ b/docs/infra/branch-strategy/versioning.md
@@ -19,7 +19,7 @@
 | Stage | Suffix | 예시 |
 |-------|--------|------|
 | dev-staging | `-dev-staging` | `26.05.2572-dev-staging` |
-| dev (nightly-cut snapshot) | (동일 suffix 유지, 새 bump 없음) | `26.05.2572-dev-staging` |
+| dev (dev-staging-dev-cut snapshot) | (동일 suffix 유지, 새 bump 없음) | `26.05.2572-dev-staging` |
 | rc (cut) | `-rc-NN` (N = 1) | `26.05.2572-rc-01` |
 | rc (hotfix) | `-rc-NN` (N 증가) | `26.05.2585-rc-02` |
 | main (final) | (없음) | `26.05.2585` |
@@ -30,9 +30,9 @@
 
 | Workflow | When | What |
 |----------|------|------|
-| `dev-staging-post-merge-sync` | dev-staging PR 머지 직후 | `bump-version.sh {PR#}-dev-staging` |
-| `nightly-cut` | daily snapshot 생성 시 | version 변경 없음 (dev-staging 의 그대로 가져감, legacy `sync-version` dev trigger 비활성화) |
-| `rc-cut` | RC 브랜치 생성 시 | `bump-version.sh {ver}-rc-01` |
+| `dev-staging-dev-cut-gate` | dev-staging PR 머지 직후 | `bump-version.sh {PR#}-dev-staging` |
+| `dev-staging-dev-cut` | daily snapshot 생성 시 | version 변경 없음 (dev-staging 의 그대로 가져감, legacy `sync-version` dev trigger 비활성화) |
+| `dev-rc-cut` | RC 브랜치 생성 시 | `bump-version.sh {ver}-rc-01` |
 | `rc-post-merge-sync` | RC hotfix 머지 직후 | `bump-version.sh {PR#}-rc-NN` (N 증가) |
 | `main-deploy` | rc → main 머지 직후 | `bump-version.sh {ver}` (suffix 제거) |
 
@@ -41,9 +41,9 @@
 | Tag / Status | 시점 | 예시 | 부여자 |
 |--------------|------|------|--------|
 | `v{ver}-dev-staging` (tag) | dev-staging post-merge | `v26.05.2572-dev-staging` | workflow |
-| `rc-gate-pass` (commit status) | dev 머지 후 rc-gate green | (status only, tag 없음) | workflow |
-| `v{ver}-rc-NN` (tag) | rc-cut + hotfix | `v26.05.2572-rc-01`, `v26.05.2585-rc-02` | workflow |
-| `promo/rc-YYYY-Wxx` (tag) | rc-cut 직후 | `promo/rc-2026-W20` | workflow |
+| `dev-rc-cut-pass` (commit status) | dev 머지 후 dev-rc-cut-gate green | (status only, tag 없음) | workflow |
+| `v{ver}-rc-NN` (tag) | dev-rc-cut + hotfix | `v26.05.2572-rc-01`, `v26.05.2585-rc-02` | workflow |
+| `promo/rc-YYYY-Wxx` (tag) | dev-rc-cut 직후 | `promo/rc-2026-W20` | workflow |
 | `v{ver}` (tag) | main 머지 직후 | `v26.05.2585` | workflow |
 | `promo/main-YYYY-Wxx` (tag) | main 머지 직후 (동시) | `promo/main-2026-W20` | workflow |
 
@@ -55,14 +55,14 @@
 - `git tag -l 'v*'` (모든 release version)
 - `git tag -l 'promo/main-*'` (weekly main promotion event)
 - `git log --first-parent main` (main 의 promotion 이벤트, rebase 라 사실상 linear)
-- `gh api repos/.../commits/{sha}/status` (rc-gate-pass 확인)
+- `gh api repos/.../commits/{sha}/status` (dev-rc-cut-pass 확인)
 
 ## 동일 PR# 가 여러 단계 등장하는 의미
 
 | 상태 | 의미 |
 |------|------|
 | `26.05.2572-dev-staging` | dev-staging 에 PR# 2572 머지된 시점 |
-| `26.05.2572-rc-01` | 그 commit 이 rc 로 cut 된 시점 (rc-gate 통과 후) |
+| `26.05.2572-rc-01` | 그 commit 이 rc 로 cut 된 시점 (dev-rc-cut-gate 통과 후) |
 | `26.05.2585-rc-02` | RC 에 hotfix PR# 2585 가 머지된 시점 |
 | `26.05.2585` | rc → main 머지 시 final version (RC 의 최종 hotfix version) |
 


### PR DESCRIPTION
## Summary
- Add branch-specific PR gate wrapper workflows: dev-staging, dev, rc, main.
- Rename legacy promotion workflows to the official cut/cut-gate names and update marker context to dev-rc-cut-pass.
- Add rc-main-cut-gate and rc-main-cut flow so RC eligibility marking is separated from main promotion PR creation.
- Update branch strategy docs to reflect CI/PR flow first, branch CD next, gate fill-in last.

## Validation
- Parsed all .github/workflows/*.yml with Python YAML loader.
- Ran git diff --check.

## Notes
- Existing pr-gate direct trigger remains in place, so current ci-result-based protection is not cut over in this PR.
- Branch-level CD workflows are intentionally deferred to the next phase.