### PR TITLE
ci: cut over to branch pr gates

### DIFF
--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -25,10 +25,10 @@
 
 ## Reusable Gates
 
-- `pr-gate.yml` 은 기존 `push`/`pull_request`/`merge_group` 진입점을 유지하면서 `workflow_call` 도 지원한다.
+- `pr-gate.yml` 은 `workflow_call` 전용 reusable CI core 다. 직접 `push`/`pull_request`/`merge_group` 로 실행하지 않는다.
 - 호출자는 `stage` (`dev-staging`, `dev`, `rc`, `main`) 와 `base_ref` 를 넘겨 동일한 CI 코어를 stage 별 gate 로 재사용한다.
-- 기존 required check 는 아직 `ci-result` 그대로 유지한다. stage 별 required check 전환은 branch-strategy Phase 4 에서 Ruleset 과 함께 적용한다.
-- `dev-staging-pr-gate`, `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 는 얇은 wrapper 로 시작한다. 현재는 `pr-gate.yml` 의 `ci-result` 를 재사용하고, branch ruleset 전환 시 이 wrapper job 이름을 required check 로 사용한다.
+- Branch ruleset 의 required check 는 `dev-staging-pr-gate`, `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 같은 branch별 wrapper job 이름을 사용한다. `ci-result` summary job 은 폐기한다.
+- `dev-staging-pr-gate`, `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 는 얇은 wrapper 로 시작한다. 내부에서는 `pr-gate.yml` reusable core 를 호출하고, wrapper job 이 최종 required check context 를 제공한다.
 - `dev-staging-dev-cut-gate` 가 dev-staging 의 PR-number CalVer bump/tag 를 담당한다. `sync-version` 은 legacy main release bump 만 담당하며, `dev` promotion 은 `dev-staging-dev-cut` 에서 version 변경 없이 처리한다.
 - `dev-rc-cut-gate` 는 dev push 후 user/partner CUJ integration 을 직접 실행하고, 통과한 commit 에만 `dev-rc-cut-pass` status 를 찍는다. backend/EF/Test Lab 을 포함한 full `dev-rc-cut-gate-suite` matrix 는 후속 확장이다.
 - `dev-rc-cut` 은 latest `dev-rc-cut-pass` dev commit 에서 `rc/YYYY-Wxx` branch 를 만들고 `version-bump` 로 `v*-rc-01` + `promo/rc-*` tag 를 생성한다.
@@ -51,7 +51,7 @@
 ## 관련
 
 - [BLUEDOC](../../docs/infra/bluedoc/BLUEDOC.md) — 본 파일이 따르는 진입점 컨벤션
-- [CLAUDE.md](../../CLAUDE.md) `## PR Conventions` — required check (`ci-result` job = `pr-gate.yml` 내부) / auto-merge 흐름
+- [CLAUDE.md](../../CLAUDE.md) `## PR Conventions` — branch별 required check / auto-merge 흐름
 
 ---
 _Reviewed: 2026-05-24 10:24_

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -13,16 +13,11 @@ on:
         required: false
         type: string
         default: 'dev'
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main", "dev", "dev-staging" ]
-  merge_group:
 
 concurrency:
-  # merge_group 이벤트는 절대 cancel 금지 — 큐 전체가 thrash됨.
-  # PR 단계(pull_request)에서만 새 푸시 시 이전 run cancel.
-  group: pr-gate-${{ inputs.stage || github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
+  # Branch-specific wrappers own the user-facing required check name.
+  # This reusable core only needs to avoid duplicate runs for the same caller/ref.
+  group: pr-gate-core-${{ inputs.stage }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -861,38 +856,3 @@ jobs:
     with:
       app-name: partner
     secrets: inherit
-
-  ci-result:
-    needs: [static-checks, auto-format, gitleaks, test-flutter-apps, test-integration-app-user-cuj, test-integration-app-partner-cuj, lint-landing-user, lint-landing-partner, lint-mds-docs, lint-mds-icons, test-supabase, test-edge-functions, test-ef-integration]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Gate context
-        run: |
-          echo "event=${{ github.event_name }}"
-          echo "stage=${{ inputs.stage || 'dev' }}"
-          echo "base_ref=${{ inputs.base_ref || github.event.pull_request.base.ref || github.event.merge_group.base_ref || github.ref_name }}"
-      - name: Check CI results
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # 1. Check CI job results
-          results='${{ toJSON(needs.*.result) }}'
-          echo "Job results: $results"
-          if echo "$results" | grep -Eq '"(failure|cancelled)"'; then
-            echo ""
-            echo '${{ toJSON(needs) }}' | jq -r 'to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | "❌ \(.key): \(.value.result)"'
-            exit 1
-          fi
-          echo "✅ CI jobs passed"
-
-          # CodeRabbit review wait was here. Removed: required-reviewer
-          # branch protection already gates merge on human APPROVED review,
-          # so the bot-review wait was duplicate enforcement that held a
-          # self-hosted runner slot for up to 30 minutes per PR — under
-          # cascade merges, that's the single biggest source of queue backlog.
-          # CodeRabbit still posts its review as a status (visible on the PR);
-          # we just stop blocking on it here.
-
-          echo ""
-          echo "✅ All checks passed"

--- a/docs/infra/branch-strategy/specs/execution-plan.md
+++ b/docs/infra/branch-strategy/specs/execution-plan.md
@@ -73,7 +73,7 @@
 | 2c | `version-bump` reusable extract (sync-version 의 핵심 로직) | sync-version 의 caller 가 reusable 호출하게 변경 |
 | 2d | `minglit-release-bot` 생성 + App ID/private key 등록 + workflow permission 최소화 | protected branch/tag push 를 human 대신 bot 으로 수행 |
 | 2e | `auto-issue` reusable 추가 | 신규 — 기존 영향 없음 |
-| 2f | **`ci-result` 폐기** — 현 branch protection 의 required check `ci-result` 를 각 branch 의 `pr-gate` 로 변경 (Phase 4 에서 실제 적용) | 본 step 은 workflow 측 준비, 실제 protection 변경은 4 |
+| 2f | **`ci-result` 폐기** — branch protection 의 required check 를 각 branch 의 `*-pr-gate` 로 변경 | `dev-staging` 부터 적용, dev/rc/main 은 해당 workflow 가 각 branch 에 도달한 뒤 적용 |
 
 ### Rollback
 
@@ -141,7 +141,7 @@
 | 5a | `dev-staging` Ruleset 적용 (required: `dev-staging-pr-gate`) | Phase 2 1주 운영 |
 | 5b | `dev` Ruleset 갱신 (required: `dev-pr-gate`) | Phase 2 1주 |
 | 5c | `rc/**` pattern Ruleset 적용 (required: `rc-pr-gate`) | Phase 2 + RC flow 1주 |
-| 5d | `main` Ruleset 갱신 — **기존 `ci-result` required check 제거** + 추가: `main-pr-gate` 단일 required check (`dev-rc-cut-pass`, `expand-migrate-contract`, `rc-main-cut-pass` 는 내부 검증) | Phase 4 gate fill-in 안정 |
+| 5d | `main` Ruleset 갱신 — `main-pr-gate` 단일 required check (`dev-rc-cut-pass`, `expand-migrate-contract`, `rc-main-cut-pass` 는 내부 검증) | Phase 4 gate fill-in 안정 |
 | 5e | Tag protection Ruleset (`v*`, `promo/**`) + release bot tag bypass | 5d 안정 (release 가 도는 게 확인된 후) |
 | 5f | Branch creation 제한 (`rc/**` → bot only) | 5c 안정 |
 | 5g | GitHub Environment `production` 생성 + required reviewer 설정 | Phase 3 1주 |
@@ -213,7 +213,7 @@ Phase 1 (skeletal) → Phase 2 (CI/PR flow) → Phase 3 (branch CD)
 
 ## 운영 중 주의사항
 
-1. **CI 실패가 release 차단**: pr-gate 의 stage parameter 가 정확히 매칭돼야 함. *required check 이름 한 글자라도 다르면 차단*. 특히 `ci-result` → stage pr-gate 전환 시 cutover 타이밍 중요
+1. **CI 실패가 release 차단**: pr-gate 의 stage parameter 가 정확히 매칭돼야 함. *required check 이름 한 글자라도 다르면 차단*. branch ruleset 의 required check 는 각 branch 의 `*-pr-gate` 이름과 정확히 일치해야 한다
 2. **trigger 변경**: cron → push 변경 시 *겹치는 기간* 발생할 수 있음 — 한쪽 비활성화 후 다른쪽 활성화. 부분 적용 금지
 3. **status check naming**: `dev-rc-cut-pass` 같은 commit status 의 이름이 spec 과 workflow 에서 일치해야 함. branch protection 에는 직접 required 로 걸지 않고 `main-pr-gate` 내부에서 검증
 4. **AI agent 의 PR 동시성**: merge queue 없으니 race condition 발생 시 수동 conflict resolve 필요 (또는 merge queue 도입 검토)


### PR DESCRIPTION
## Summary
- Make pr-gate.yml workflow_call-only so branch-specific wrappers own PR gate entrypoints.
- Remove the obsolete ci-result summary job.
- Update workflow docs/execution plan to document branch-specific required checks.

## Ruleset change already applied
- dev-staging-rules required check: ci-result -> dev-staging-pr-gate.
- dev-rules remains on ci-result until the branch gate workflows are promoted to dev.

## Validation
- Parsed all .github/workflows/*.yml with Python YAML loader.
- Ran git diff --check.