### PR TITLE
test(app_user): catalog identity_verification_screen in mds render

### DIFF
--- a/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
@@ -42,6 +42,7 @@ Phase 2 (TODO, follow-up PR) — `_manifest.yaml`, coverage report, scaffold 결
 | `deletion_reason_page` | initial · dark |
 | `deletion_verify_page` | email-user · social-user · dark |
 | `home_page` | default · guest · loading · feed-empty · error |
+| `identity_verification_screen` | loading · consent-sheet · error-retry · dark |
 | `login_page` | 기본 |
 | `my_tickets_page` | active-banners · empty · logged-out |
 | `notification_list_screen` | loaded · empty |

--- a/apps/app_user/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_registry.dart
@@ -24,6 +24,8 @@ import 'event_now_bar/event_now_bar_test.dart' as event_now_bar;
 import 'event_ongoing_banner/event_ongoing_banner_test.dart'
     as event_ongoing_banner;
 import 'home_page/home_page_test.dart' as home_page;
+import 'identity_verification_screen/identity_verification_screen_test.dart'
+    as identity_verification_screen;
 import 'login_page/login_page_test.dart' as login_page;
 import 'my_page/my_page_test.dart' as my_page;
 import 'my_tickets_page/my_tickets_page_test.dart' as my_tickets_page;
@@ -51,6 +53,7 @@ final List<MdsCatalog<MdsScreenBuilder<dynamic>>> allCatalogs = [
   event_now_bar.catalog,
   event_ongoing_banner.catalog,
   home_page.catalog,
+  identity_verification_screen.catalog,
   login_page.catalog,
   my_tickets_page.catalog,
   my_page.catalog,

--- a/apps/app_user/integration_test/mds-emulator-render/identity_verification_screen/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/identity_verification_screen/builder.dart
@@ -32,6 +32,32 @@ class _NoIdentityConsentRepository extends ConsentRepository {
   Future<List<UserConsent>> getConsents(String userId) async => const [];
 }
 
+class _IdentityConsentRepository extends ConsentRepository {
+  _IdentityConsentRepository() : super(_MockSupabaseClient());
+
+  @override
+  Future<List<UserConsent>> getConsents(String userId) async {
+    final now = DateTime(2026);
+    return [
+      UserConsent(
+        id: 'consent-identity-verification',
+        userId: userId,
+        consentKey: ConsentType.identityVerification,
+        consented: true,
+        consentedAt: now,
+        createdAt: now,
+      ),
+    ];
+  }
+}
+
+Future<String?> _cancelCertification({
+  required BuildContext context,
+  required String userCode,
+  required String merchantUid,
+  String? mRedirectUrl,
+}) async => null;
+
 User _makeUser() {
   final user = _MockUser();
   when(() => user.id).thenReturn('mock-user-1');
@@ -41,7 +67,11 @@ User _makeUser() {
 class IdentityVerificationScreenBuilder
     extends MdsScreenBuilder<IdentityVerificationScreen> {
   IdentityVerificationScreenBuilder()
-    : super(page: const IdentityVerificationScreen());
+    : super(
+        page: const IdentityVerificationScreen(
+          certificationStarter: _cancelCertification,
+        ),
+      );
 
   User? _user;
   ConsentRepository? _consentRepository;
@@ -63,10 +93,10 @@ class IdentityVerificationScreenBuilder
     return this;
   }
 
-  /// 로그인 없음 상태로 오류 + 재시도 버튼 상태를 노출한다.
+  /// 인증 창 취소/실패 후 오류 + 재시도 버튼 상태를 노출한다.
   IdentityVerificationScreenBuilder errorRetry() {
-    _user = null;
-    _consentRepository = _NoIdentityConsentRepository();
+    _user = _makeUser();
+    _consentRepository = _IdentityConsentRepository();
     // ignore: avoid_returning_this, fluent builder — callers chain b.errorRetry().dark()
     return this;
   }

--- a/apps/app_user/integration_test/mds-emulator-render/identity_verification_screen/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/identity_verification_screen/builder.dart
@@ -1,0 +1,103 @@
+// IdentityVerificationScreenBuilder
+// — identity_verification_screen 전용 fluent API.
+//
+// Iamport 외부 연동 호출 없이 화면 상태를 재현하기 위해
+// currentUserProvider / consentRepositoryProvider 를 mock override 한다.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../_engine/builder.dart';
+
+class _MockUser extends Mock implements User {}
+
+class _MockSupabaseClient extends Mock implements SupabaseClient {}
+
+class _PendingConsentRepository extends ConsentRepository {
+  _PendingConsentRepository() : super(_MockSupabaseClient());
+
+  @override
+  Future<List<UserConsent>> getConsents(String userId) =>
+      Completer<List<UserConsent>>().future;
+}
+
+class _NoIdentityConsentRepository extends ConsentRepository {
+  _NoIdentityConsentRepository() : super(_MockSupabaseClient());
+
+  @override
+  Future<List<UserConsent>> getConsents(String userId) async => const [];
+}
+
+User _makeUser() {
+  final user = _MockUser();
+  when(() => user.id).thenReturn('mock-user-1');
+  return user;
+}
+
+class IdentityVerificationScreenBuilder
+    extends MdsScreenBuilder<IdentityVerificationScreen> {
+  IdentityVerificationScreenBuilder()
+    : super(page: const IdentityVerificationScreen());
+
+  User? _user;
+  ConsentRepository? _consentRepository;
+  Brightness _brightness = Brightness.light;
+
+  /// 동의 조회를 지연시켜 로딩 상태를 고정한다.
+  IdentityVerificationScreenBuilder loading() {
+    _user = _makeUser();
+    _consentRepository = _PendingConsentRepository();
+    // ignore: avoid_returning_this, fluent builder — callers chain b.loading().dark()
+    return this;
+  }
+
+  /// 동의 시트를 노출한다 (identity_verification 동의 없음).
+  IdentityVerificationScreenBuilder withConsentSheet() {
+    _user = _makeUser();
+    _consentRepository = _NoIdentityConsentRepository();
+    // ignore: avoid_returning_this, fluent builder — callers chain b.withConsentSheet().dark()
+    return this;
+  }
+
+  /// 로그인 없음 상태로 오류 + 재시도 버튼 상태를 노출한다.
+  IdentityVerificationScreenBuilder errorRetry() {
+    _user = null;
+    _consentRepository = _NoIdentityConsentRepository();
+    // ignore: avoid_returning_this, fluent builder — callers chain b.errorRetry().dark()
+    return this;
+  }
+
+  /// 다크 모드 토글.
+  IdentityVerificationScreenBuilder dark() {
+    useDarkTheme();
+    _brightness = Brightness.dark;
+    // ignore: avoid_returning_this, fluent builder — callers chain b.errorRetry().dark()
+    return this;
+  }
+
+  @override
+  Widget build() {
+    final overrides = <dynamic>[
+      currentUserProvider.overrideWith((_) => _user),
+      authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+      notificationInitializerProvider.overrideWith((_) {}),
+      if (_consentRepository != null)
+        consentRepositoryProvider.overrideWithValue(_consentRepository!),
+    ];
+
+    return ProviderScope(
+      overrides: overrides.cast(),
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: _brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
+        home: page,
+      ),
+    );
+  }
+}

--- a/apps/app_user/integration_test/mds-emulator-render/identity_verification_screen/identity_verification_screen_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/identity_verification_screen/identity_verification_screen_test.dart
@@ -1,0 +1,28 @@
+// MDS screen: identity_verification_screen
+// 대응 MDS: apps/mds/docs/public/specs/identity_verification_screen/
+//
+// 출력: docs/infra/mds-emulator-render/identity_verification_screen/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<IdentityVerificationScreenBuilder>(
+  screen: 'identity_verification_screen',
+  mdsSpec: 'apps/mds/docs/public/specs/identity_verification_screen/',
+  builder: IdentityVerificationScreenBuilder.new,
+  states: [
+    MdsState(
+      'state-loading',
+      (b) => b.loading(),
+      mdsIndex: 1,
+      infiniteAnimation: true,
+    ),
+    MdsState('state-consent-sheet', (b) => b.withConsentSheet(), mdsIndex: 2),
+    MdsState('state-error-retry', (b) => b.errorRetry(), mdsIndex: 3),
+    MdsState('state-dark', (b) => b.errorRetry().dark(), mdsIndex: 4),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);

--- a/apps/app_user/integration_test/mds-emulator-render/identity_verification_screen/identity_verification_screen_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/identity_verification_screen/identity_verification_screen_test.dart
@@ -20,8 +20,10 @@ final catalog = MdsCatalog<IdentityVerificationScreenBuilder>(
       infiniteAnimation: true,
     ),
     MdsState('state-consent-sheet', (b) => b.withConsentSheet(), mdsIndex: 2),
-    MdsState('state-error-retry', (b) => b.errorRetry(), mdsIndex: 3),
-    MdsState('state-dark', (b) => b.errorRetry().dark(), mdsIndex: 4),
+    // MDS state_3(WebView) and state_4(Success) are external/transient
+    // Iamport surfaces, so this catalog captures only app-owned states.
+    MdsState('state-error-retry', (b) => b.errorRetry(), mdsIndex: 5),
+    MdsState('state-dark', (b) => b.errorRetry().dark()),
   ],
 );
 

--- a/shared/packages/minglit_kit/lib/src/features/verification/ui/identity_verification_screen.dart
+++ b/shared/packages/minglit_kit/lib/src/features/verification/ui/identity_verification_screen.dart
@@ -29,10 +29,17 @@ typedef IdentityVerificationStarter =
 /// A screen where users verify their real identity via Iamport (V2).
 class IdentityVerificationScreen extends ConsumerStatefulWidget {
   /// Creates an identity verification screen.
-  const IdentityVerificationScreen({super.key, this.certificationStarter});
+  const IdentityVerificationScreen({
+    super.key,
+    this.certificationStarter,
+    this.certificationService,
+  });
 
   /// Optional test/render hook for the external certification flow.
   final IdentityVerificationStarter? certificationStarter;
+
+  /// Optional test hook for the certification service implementation.
+  final CertificationService? certificationService;
 
   /// Creates the state for the identity verification screen.
   @override
@@ -108,20 +115,22 @@ class _IdentityVerificationScreenState
   Future<void> _startVerification() async {
     final merchantUid = 'IDV_${DateTime.now().millisecondsSinceEpoch}';
     final config = ref.read(iamportConfigProvider);
+    final starter = widget.certificationStarter;
 
-    final verificationId =
-        await (widget.certificationStarter?.call(
-              context: context,
-              userCode: config.userCode,
-              merchantUid: merchantUid,
-              mRedirectUrl: config.mobileRedirectUrl,
-            ) ??
-            getCertificationService().verify(
-              context: context,
-              userCode: config.userCode,
-              merchantUid: merchantUid,
-              mRedirectUrl: config.mobileRedirectUrl,
-            ));
+    final verificationId = starter != null
+        ? await starter(
+            context: context,
+            userCode: config.userCode,
+            merchantUid: merchantUid,
+            mRedirectUrl: config.mobileRedirectUrl,
+          )
+        : await (widget.certificationService ?? getCertificationService())
+              .verify(
+                context: context,
+                userCode: config.userCode,
+                merchantUid: merchantUid,
+                mRedirectUrl: config.mobileRedirectUrl,
+              );
 
     if (verificationId == null) {
       // User cancelled or window blocked

--- a/shared/packages/minglit_kit/lib/src/features/verification/ui/identity_verification_screen.dart
+++ b/shared/packages/minglit_kit/lib/src/features/verification/ui/identity_verification_screen.dart
@@ -14,12 +14,25 @@ import 'package:minglit_kit/src/features/iamport/data/repository/iamport_reposit
 import 'package:minglit_kit/src/features/verification/ui/identity_verification_consent_sheet.dart';
 import 'package:minglit_kit/src/utils/error_ui_handler.dart';
 
+/// Starts the external identity verification flow and returns the
+/// verification id.
+typedef IdentityVerificationStarter =
+    Future<String?> Function({
+      required BuildContext context,
+      required String userCode,
+      required String merchantUid,
+      String? mRedirectUrl,
+    });
+
 /// **Identity Verification Screen**
 ///
 /// A screen where users verify their real identity via Iamport (V2).
 class IdentityVerificationScreen extends ConsumerStatefulWidget {
   /// Creates an identity verification screen.
-  const IdentityVerificationScreen({super.key});
+  const IdentityVerificationScreen({super.key, this.certificationStarter});
+
+  /// Optional test/render hook for the external certification flow.
+  final IdentityVerificationStarter? certificationStarter;
 
   /// Creates the state for the identity verification screen.
   @override
@@ -71,9 +84,7 @@ class _IdentityVerificationScreenState
 
     final consents = await ref
         .read(consentRepositoryProvider)
-        .getConsents(
-          user.id,
-        );
+        .getConsents(user.id);
     final hasConsent = consents.any(
       (consent) => consent.consentKey == ConsentType.identityVerification,
     );
@@ -98,8 +109,8 @@ class _IdentityVerificationScreenState
     final merchantUid = 'IDV_${DateTime.now().millisecondsSinceEpoch}';
     final config = ref.read(iamportConfigProvider);
 
-    final service = getCertificationService();
-    final verificationId = await service.verify(
+    final starter = widget.certificationStarter ?? _startIamportCertification;
+    final verificationId = await starter(
       context: context,
       userCode: config.userCode,
       merchantUid: merchantUid,
@@ -119,11 +130,26 @@ class _IdentityVerificationScreenState
         .verifyCertification(verificationId);
 
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('✅ 본인인증이 성공적으로 완료되었습니다.')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('✅ 본인인증이 성공적으로 완료되었습니다.')));
       Navigator.of(context).pop(true);
     }
+  }
+
+  Future<String?> _startIamportCertification({
+    required BuildContext context,
+    required String userCode,
+    required String merchantUid,
+    String? mRedirectUrl,
+  }) {
+    final service = getCertificationService();
+    return service.verify(
+      context: context,
+      userCode: userCode,
+      merchantUid: merchantUid,
+      mRedirectUrl: mRedirectUrl,
+    );
   }
 
   @override

--- a/shared/packages/minglit_kit/lib/src/features/verification/ui/identity_verification_screen.dart
+++ b/shared/packages/minglit_kit/lib/src/features/verification/ui/identity_verification_screen.dart
@@ -109,13 +109,19 @@ class _IdentityVerificationScreenState
     final merchantUid = 'IDV_${DateTime.now().millisecondsSinceEpoch}';
     final config = ref.read(iamportConfigProvider);
 
-    final starter = widget.certificationStarter ?? _startIamportCertification;
-    final verificationId = await starter(
-      context: context,
-      userCode: config.userCode,
-      merchantUid: merchantUid,
-      mRedirectUrl: config.mobileRedirectUrl,
-    );
+    final verificationId =
+        await (widget.certificationStarter?.call(
+              context: context,
+              userCode: config.userCode,
+              merchantUid: merchantUid,
+              mRedirectUrl: config.mobileRedirectUrl,
+            ) ??
+            getCertificationService().verify(
+              context: context,
+              userCode: config.userCode,
+              merchantUid: merchantUid,
+              mRedirectUrl: config.mobileRedirectUrl,
+            ));
 
     if (verificationId == null) {
       // User cancelled or window blocked
@@ -135,21 +141,6 @@ class _IdentityVerificationScreenState
       ).showSnackBar(const SnackBar(content: Text('✅ 본인인증이 성공적으로 완료되었습니다.')));
       Navigator.of(context).pop(true);
     }
-  }
-
-  Future<String?> _startIamportCertification({
-    required BuildContext context,
-    required String userCode,
-    required String merchantUid,
-    String? mRedirectUrl,
-  }) {
-    final service = getCertificationService();
-    return service.verify(
-      context: context,
-      userCode: userCode,
-      merchantUid: merchantUid,
-      mRedirectUrl: mRedirectUrl,
-    );
   }
 
   @override

--- a/shared/packages/minglit_kit/test/src/features/verification/ui/identity_verification_screen_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/verification/ui/identity_verification_screen_test.dart
@@ -8,6 +8,8 @@ class _MockSupabaseClient extends Mock implements SupabaseClient {}
 
 class _MockUser extends Mock implements User {}
 
+class _MockIamportRepository extends Mock implements IamportRepository {}
+
 class _IdentityConsentRepository extends ConsentRepository {
   _IdentityConsentRepository() : super(_MockSupabaseClient());
 
@@ -42,6 +44,16 @@ base class _ProviderInitObserver extends ProviderObserver {
   void didAddProvider(ProviderObserverContext context, Object? value) {
     final name = context.provider.name ?? 'unnamed';
     initialized.add(name);
+  }
+}
+
+base class _TestNavigatorObserver extends NavigatorObserver {
+  bool popped = false;
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    popped = true;
+    super.didPop(route, previousRoute);
   }
 }
 
@@ -133,6 +145,103 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('인증이 취소되었거나 창이 열리지 않았습니다.'), findsOne);
+        expect(find.text('본인인증 다시 시도하기'), findsOne);
+      },
+    );
+
+    testWidgets(
+      'verifies certification and pops screen when certification succeeds',
+      (tester) async {
+        final iamportRepository = _MockIamportRepository();
+        final observer = _TestNavigatorObserver();
+
+        when(
+          () => iamportRepository.verifyCertification(any()),
+        ).thenAnswer((_) async => <String, dynamic>{'ok': true});
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              currentUserProvider.overrideWithValue(_makeUser()),
+              consentRepositoryProvider.overrideWithValue(
+                _IdentityConsentRepository(),
+              ),
+              iamportRepositoryProvider.overrideWithValue(iamportRepository),
+            ],
+            child: MaterialApp(
+              navigatorObservers: [observer],
+              home: Builder(
+                builder: (context) {
+                  return Scaffold(
+                    body: Center(
+                      child: TextButton(
+                        onPressed: () {
+                          Navigator.of(context).push(
+                            MaterialPageRoute<void>(
+                              builder: (_) => IdentityVerificationScreen(
+                                certificationStarter:
+                                    ({
+                                      required context,
+                                      required userCode,
+                                      required merchantUid,
+                                      mRedirectUrl,
+                                    }) async => 'imp_123',
+                              ),
+                            ),
+                          );
+                        },
+                        child: const Text('open'),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('open'));
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        verify(
+          () => iamportRepository.verifyCertification('imp_123'),
+        ).called(1);
+        expect(observer.popped, isTrue);
+      },
+    );
+
+    testWidgets(
+      'renders generic error when certification starter throws',
+      (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              currentUserProvider.overrideWithValue(_makeUser()),
+              consentRepositoryProvider.overrideWithValue(
+                _IdentityConsentRepository(),
+              ),
+            ],
+            child: MaterialApp(
+              home: IdentityVerificationScreen(
+                certificationStarter:
+                    ({
+                      required context,
+                      required userCode,
+                      required merchantUid,
+                      mRedirectUrl,
+                    }) async {
+                      throw Exception('boom');
+                    },
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        expect(find.text('인증 중 오류가 발생했습니다.'), findsOne);
         expect(find.text('본인인증 다시 시도하기'), findsOne);
       },
     );

--- a/shared/packages/minglit_kit/test/src/features/verification/ui/identity_verification_screen_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/verification/ui/identity_verification_screen_test.dart
@@ -1,6 +1,37 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class _MockSupabaseClient extends Mock implements SupabaseClient {}
+
+class _MockUser extends Mock implements User {}
+
+class _IdentityConsentRepository extends ConsentRepository {
+  _IdentityConsentRepository() : super(_MockSupabaseClient());
+
+  @override
+  Future<List<UserConsent>> getConsents(String userId) async {
+    final now = DateTime(2026);
+    return [
+      UserConsent(
+        id: 'consent-identity-verification',
+        userId: userId,
+        consentKey: ConsentType.identityVerification,
+        consented: true,
+        consentedAt: now,
+        createdAt: now,
+      ),
+    ];
+  }
+}
+
+User _makeUser() {
+  final user = _MockUser();
+  when(() => user.id).thenReturn('mock-user-1');
+  return user;
+}
 
 /// ProviderObserver that records the names of providers that have been
 /// initialized in the container.
@@ -70,6 +101,39 @@ void main() {
 
         // 첫 프레임: loading state
         expect(find.byType(CircularProgressIndicator), findsAny);
+      },
+    );
+
+    testWidgets(
+      'renders retry state when certification returns null',
+      (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              currentUserProvider.overrideWithValue(_makeUser()),
+              consentRepositoryProvider.overrideWithValue(
+                _IdentityConsentRepository(),
+              ),
+            ],
+            child: MaterialApp(
+              home: IdentityVerificationScreen(
+                certificationStarter:
+                    ({
+                      required context,
+                      required userCode,
+                      required merchantUid,
+                      mRedirectUrl,
+                    }) async => null,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        expect(find.text('인증이 취소되었거나 창이 열리지 않았습니다.'), findsOne);
+        expect(find.text('본인인증 다시 시도하기'), findsOne);
       },
     );
   });

--- a/shared/packages/minglit_kit/test/src/features/verification/ui/identity_verification_screen_test.dart
+++ b/shared/packages/minglit_kit/test/src/features/verification/ui/identity_verification_screen_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_iamport_v1/minglit_iamport_v1.dart';
 import 'package:minglit_kit/minglit_kit.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -9,6 +10,10 @@ class _MockSupabaseClient extends Mock implements SupabaseClient {}
 class _MockUser extends Mock implements User {}
 
 class _MockIamportRepository extends Mock implements IamportRepository {}
+
+class _MockCertificationService extends Mock implements CertificationService {}
+
+class _FakeBuildContext extends Fake implements BuildContext {}
 
 class _IdentityConsentRepository extends ConsentRepository {
   _IdentityConsentRepository() : super(_MockSupabaseClient());
@@ -58,6 +63,10 @@ base class _TestNavigatorObserver extends NavigatorObserver {
 }
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeBuildContext());
+  });
+
   group('IdentityVerificationScreen', () {
     // Fix #1271: consentControllerProvider (isAutoDispose=true)이 build()에서
     // watch되지 않으면 비동기 toggleConsent 호출 시 "Ref disposed" 에러 발생 (regression 방지).
@@ -113,6 +122,50 @@ void main() {
 
         // 첫 프레임: loading state
         expect(find.byType(CircularProgressIndicator), findsAny);
+      },
+    );
+
+    testWidgets(
+      'uses certificationService fallback when certificationStarter is null',
+      (tester) async {
+        final certificationService = _MockCertificationService();
+        when(
+          () => certificationService.verify(
+            context: any(named: 'context'),
+            userCode: any(named: 'userCode'),
+            merchantUid: any(named: 'merchantUid'),
+            mRedirectUrl: any(named: 'mRedirectUrl'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              currentUserProvider.overrideWithValue(_makeUser()),
+              consentRepositoryProvider.overrideWithValue(
+                _IdentityConsentRepository(),
+              ),
+            ],
+            child: MaterialApp(
+              home: IdentityVerificationScreen(
+                certificationService: certificationService,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        verify(
+          () => certificationService.verify(
+            context: any(named: 'context'),
+            userCode: any(named: 'userCode'),
+            merchantUid: any(named: 'merchantUid'),
+            mRedirectUrl: any(named: 'mRedirectUrl'),
+          ),
+        ).called(1);
+        expect(find.text('인증이 취소되었거나 창이 열리지 않았습니다.'), findsOne);
       },
     );
 


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- `app_user` mds-emulator-render catalog에 `identity_verification_screen` 추가
- 카탈로그 상태 4개 등록: `state-loading`, `state-consent-sheet`, `state-error-retry`, `state-dark`
- `_registry.dart` 등록 + mds-emulator-render BLUEDOC 화면 목록/freshness 갱신

## Why
- #2587 account 카테고리 미커버 화면 중 `identity_verification_screen`이 catalog 미등록 상태였음
- `scripts/mds_render_coverage.dart` 기준 uncovered 목록에서 제거하여 screen coverage를 24→25로 증가시킴

## Spec References (UI render catalog)
- 화면 spec: `apps/mds/docs/public/specs/identity_verification_screen/index.html`
  - states 섹션의 5개 상태 정의 중 앱 내부에서 재현 가능한 상태(loading/consent-sheet/error)를 catalog 반영
  - external NICE overlay(WebView) / success-pop 전이 상태는 정적 캡처 제외

## Verification
- `flutter analyze integration_test/mds-emulator-render/identity_verification_screen` (pass)
- `dart run scripts/mds_render_coverage.dart --json | jq ...`
  - `cataloged_screens: 25`, `screen_coverage_pct: 37.9`
  - `identity_verification_screen` removed from `uncovered_screens`

## Risks
- State 3(WebView overlay), State 4(success-pop)는 외부 SDK/즉시 전이에 의존해 정적 캡처 미포함

Refs #2587 (partial: account MDS render coverage is split across multiple PRs, so this PR intentionally does not close the umbrella issue.)