### PR TITLE
ci: add demo Android build gate

### DIFF
--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -27,6 +27,7 @@
 
 - `pr-gate.yml` 은 `workflow_call` 전용 reusable CI core 다. 직접 `push`/`pull_request`/`merge_group` 로 실행하지 않는다.
 - 호출자는 `stage` (`dev-staging`, `dev`, `rc`, `main`) 와 `base_ref` 를 넘겨 동일한 CI 코어를 stage 별 gate 로 재사용한다.
+- `pr-gate.yml` 의 `build-demo-android` 잡은 `minglit_demo`, `main_demo.dart`, Android demo flavor 변경 시 양 앱 demo debug APK 빌드를 검증한다.
 - Branch ruleset 의 required check 는 `dev-staging-pr-gate`, `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 같은 branch별 wrapper job 이름을 사용한다. `ci-result` summary job 은 폐기한다.
 - `dev-staging-pr-gate`, `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 는 얇은 wrapper 로 시작한다. 내부에서는 `pr-gate.yml` reusable core 를 호출하고, wrapper job 이 최종 required check context 를 제공한다.
 - `dev-staging-dev-cut-gate` 가 dev-staging 의 PR-number CalVer bump/tag 를 담당한다. `sync-version` 은 legacy main release bump 만 담당하며, `dev` promotion 은 `dev-staging-dev-cut` 에서 version 변경 없이 처리한다.
@@ -54,4 +55,4 @@
 - [CLAUDE.md](../../CLAUDE.md) `## PR Conventions` — branch별 required check / auto-merge 흐름
 
 ---
-_Reviewed: 2026-05-24 10:24_
+_Reviewed: 2026-05-24 16:30_

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -147,6 +147,7 @@ jobs:
       app_user: ${{ steps.filter.outputs.app_user }}
       app_partner: ${{ steps.filter.outputs.app_partner }}
       minglit_kit: ${{ steps.filter.outputs.minglit_kit }}
+      demo_android: ${{ steps.filter.outputs.demo_android }}
       mds_core: ${{ steps.filter.outputs.mds_core }}
       app_user_or_kit: ${{ steps.filter.outputs.app_user == 'true' || steps.filter.outputs.minglit_kit == 'true' || steps.filter.outputs.mds_core == 'true' }}
       app_partner_or_kit: ${{ steps.filter.outputs.app_partner == 'true' || steps.filter.outputs.minglit_kit == 'true' || steps.filter.outputs.mds_core == 'true' }}
@@ -183,6 +184,19 @@ jobs:
           minglit_kit:
             - 'shared/packages/minglit_kit/**'
             - 'shared/packages/**'
+          demo_android:
+            - '.github/workflows/pr-gate.yml'
+            - 'pubspec.yaml'
+            - 'pubspec.lock'
+            - 'shared/packages/minglit_demo/**'
+            - 'apps/app_user/lib/main_demo.dart'
+            - 'apps/app_partner/lib/main_demo.dart'
+            - 'apps/app_user/pubspec.yaml'
+            - 'apps/app_partner/pubspec.yaml'
+            - 'apps/app_user/android/app/build.gradle.kts'
+            - 'apps/app_partner/android/app/build.gradle.kts'
+            - 'apps/app_user/android/app/src/demo/**'
+            - 'apps/app_partner/android/app/src/demo/**'
           mds_core:
             - 'shared/packages/mds/core/**'
           landing_user:
@@ -411,6 +425,45 @@ jobs:
           flags: ${{ matrix.coverage_flag_logic }}
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+
+  build-demo-android:
+    name: build-demo-android
+    needs: changes
+    if: ${{ needs.changes.outputs.demo_android == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - app: app_user
+            directory: apps/app_user
+          - app: app_partner
+            directory: apps/app_partner
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.41.9'
+          cache: true
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Build demo debug APK
+        run: >
+          flutter build apk
+          --debug
+          --flavor demo
+          --target lib/main_demo.dart
+          --dart-define=ENVIRONMENT=demo
+          --dart-define=IS_DEMO=true
+          --dart-define=SUPABASE_URL=https://demo.invalid
+          --dart-define=SUPABASE_PUBLISHABLE_KEY=demo-publishable-key-not-used
+        working-directory: ${{ matrix.directory }}
 
   # Landing User CI
   lint-landing-user:

--- a/apps/app_partner/BLUEDOC.md
+++ b/apps/app_partner/BLUEDOC.md
@@ -6,7 +6,7 @@ Minglit 의 **파트너 사장님 Flutter 앱**. 매장 관리·멤버 초대·�
 
 | 항목 | 무엇 |
 |---|---|
-| `lib/main.dart` / `lib/main_demo.dart` | 프로덕션 / demo flavor 엔트리포인트 |
+| `lib/main.dart` / `lib/main_demo.dart` | 프로덕션 / demo flavor 엔트리포인트 (`main_demo.dart` 는 `minglit_demo` fixtures + Android `demo` flavor 사용) |
 | [`lib/src/features/`](./lib/src/features/) | 기능별 모듈 (아래 표) |
 | [`lib/src/routing/`](./lib/src/routing/) | `app_router` (auth + 권한 + 온보딩 redirect) + `app_routes` (Type-safe) |
 | [`lib/src/logic/`](./lib/src/logic/) | 앱-레벨 Provider (`current_partner_provider`, `onboarding_state_provider` 등) |
@@ -39,6 +39,7 @@ Minglit 의 **파트너 사장님 Flutter 앱**. 매장 관리·멤버 초대·�
 - **Cross-feature import 금지** — `pr-gate.check-cross-feature-imports` 가 차단.
 - **권한 분기는 router redirect 에서** — feature 안에 권한 체크 흩뿌리지 않음.
 - **공통 Flutter 아키텍처는 [`apps/architecture.md`](../architecture.md)** — Tech Stack, Coordinator/Routing/Repository pattern.
+- **demo flavor 는 서버 0 연결** — `main_demo.dart` + `android/app/src/demo/google-services.json` + `minglit_env/demo/flutter.env` 조합으로 빌드.
 
 ## 관련
 
@@ -47,4 +48,4 @@ Minglit 의 **파트너 사장님 Flutter 앱**. 매장 관리·멤버 초대·�
 - [README.md](./README.md) — 빌드·실행 / [integration_test/cuj](./integration_test/cuj/BLUEDOC.md) — CUJ
 
 ---
-_Reviewed: 2026-05-23 00:00_
+_Reviewed: 2026-05-24 16:30_

--- a/apps/app_partner/android/app/src/demo/google-services.json
+++ b/apps/app_partner/android/app/src/demo/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "000000000000",
+    "project_id": "minglit-demo-local",
+    "storage_bucket": "minglit-demo-local.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:1111111111111111111111",
+        "android_client_info": {
+          "package_name": "com.minglit.app_partner.demo"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "demo-api-key-not-used"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/apps/app_user/BLUEDOC.md
+++ b/apps/app_user/BLUEDOC.md
@@ -6,7 +6,7 @@ Minglit 의 **일반 사용자 Flutter 앱**. 파티 탐색·참여 신청·결�
 
 | 항목 | 무엇 |
 |---|---|
-| `lib/main.dart` / `lib/main_demo.dart` | 프로덕션 / demo flavor 엔트리포인트 |
+| `lib/main.dart` / `lib/main_demo.dart` | 프로덕션 / demo flavor 엔트리포인트 (`main_demo.dart` 는 `minglit_demo` fixtures + Android `demo` flavor 사용) |
 | [`lib/src/features/`](./lib/src/features/) | 기능별 모듈 (아래 표) |
 | [`lib/src/routing/`](./lib/src/routing/) | `app_router` (GoRouter) + `app_routes` (Type-safe) + `app_coordinator` |
 | [`lib/src/logic/`](./lib/src/logic/) | 앱-레벨 Coordinator / Provider (`event_coordinator`, `auth_coordinator`, `feed_state_provider`) |
@@ -39,6 +39,7 @@ Minglit 의 **일반 사용자 Flutter 앱**. 파티 탐색·참여 신청·결�
 - **Cross-feature import 금지** — `pr-gate.check-cross-feature-imports` 가 차단.
 - **화면 이동은 Coordinator 경유** — UI 가 `context.push` 직접 호출 X.
 - **공통 아키텍처는 [`apps/architecture.md`](../architecture.md) 참고** — Tech Stack, Coordinator/Routing/Repository pattern.
+- **demo flavor 는 서버 0 연결** — `main_demo.dart` + `android/app/src/demo/google-services.json` + `minglit_env/demo/flutter.env` 조합으로 빌드.
 
 ## 관련
 
@@ -47,4 +48,4 @@ Minglit 의 **일반 사용자 Flutter 앱**. 파티 탐색·참여 신청·결�
 - [README.md](./README.md) — 빌드·실행 / [integration_test](./integration_test/BLUEDOC.md) — 통합 테스트
 
 ---
-_Reviewed: 2026-05-23 00:00_
+_Reviewed: 2026-05-24 16:30_

--- a/apps/app_user/android/app/src/demo/google-services.json
+++ b/apps/app_user/android/app/src/demo/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "000000000000",
+    "project_id": "minglit-demo-local",
+    "storage_bucket": "minglit-demo-local.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+        "android_client_info": {
+          "package_name": "com.minglit.app_user.demo"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "demo-api-key-not-used"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/docs/infra/app_demo/BLUEDOC.md
+++ b/docs/infra/app_demo/BLUEDOC.md
@@ -12,17 +12,20 @@
 |---|---|
 | [`architecture.md`](./architecture.md) | 설계 — 패키지 레이아웃, override 전략, 라우터·뷰 재활용 표, drift 방지 규칙 |
 | [`plan.md`](./plan.md) | 단계별 작업 (P0-P8) 체크리스트 + acceptance criteria |
-| `shared/packages/minglit_demo/` *(P1 산출, 예정)* | fixture + ProviderScope override 빌더 |
-| `apps/app_user/lib/main_demo.dart` *(P4 산출, 예정)* | 사용자 앱 데모 entry |
-| `apps/app_partner/lib/main_demo.dart` *(P4 산출, 예정)* | 파트너 앱 데모 entry |
+| [`shared/packages/minglit_demo/`](../../../shared/packages/minglit_demo/) | fixture + ProviderScope override 빌더 |
+| [`apps/app_user/lib/main_demo.dart`](../../../apps/app_user/lib/main_demo.dart) | 사용자 앱 데모 entry |
+| [`apps/app_partner/lib/main_demo.dart`](../../../apps/app_partner/lib/main_demo.dart) | 파트너 앱 데모 entry |
+| `apps/*/android/app/src/demo/google-services.json` | demo Android variant 빌드용 non-secret Firebase placeholder |
+| `minglit_env/demo/flutter.env` | demo compile-time env (`IS_DEMO=true`, placeholder keys) |
+| [`.github/workflows/pr-gate.yml`](../../../.github/workflows/pr-gate.yml) | demo Android debug APK 빌드 gate |
 
 ## 핵심 컨벤션
 
 - **데모 ≠ 시나리오 선택 화면**: 실제 라우터 그대로, 자동 로그인된 데모 유저로 부팅. 사용자는 평범하게 네비게이션
 - **fixture SSoT**: `shared/packages/minglit_demo/lib/fixtures/` 한 곳. unit test·emulator-render·데모 앱 모두 여기서 import
 - **prod 격리**: `Supabase.instance.client` 직접 호출 금지 → `dart-custom-lint` 룰로 강제 (P0)
-- **외부 SDK init 가드**: `appStartup()` 안의 모든 network SDK init 은 `kIsDemo` 분기 안에서 skip 가능해야 함
-- **별도 ApplicationId**: `com.minglit.demo.user`, `com.minglit.demo.partner` → 실 앱과 나란히 설치
+- **외부 SDK init 가드**: `EnvKeyStore.isDemo` 분기에서 network SDK init 을 skip
+- **별도 ApplicationId**: `com.minglit.app_user.demo`, `com.minglit.app_partner.demo` → 실 앱과 나란히 설치
 
 ## 관련
 
@@ -33,4 +36,4 @@
 - [apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md](../../../apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md) — fixture 패키지 공동 소비자
 
 ---
-_Reviewed: 2026-05-18 19:30_
+_Reviewed: 2026-05-24 16:30_


### PR DESCRIPTION
## Summary
- add demo Android google-services placeholders for app_user and app_partner
- wire pr-gate build-demo-android for demo-related changes
- update app_demo/app BLUEDOC pointers and advance minglit_env to include demo/flutter.env

## Verification
- python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-gate.yml')); print('yaml ok')"
- git diff --check
- flutter build apk --debug --flavor demo --target lib/main_demo.dart --dart-define-from-file=../../minglit_env/demo/flutter.env (apps/app_user)
- flutter build apk --debug --flavor demo --target lib/main_demo.dart --dart-define-from-file=../../minglit_env/demo/flutter.env (apps/app_partner)

Depends on merged env PR: https://github.com/Mark-Yun/minglit_env/pull/1