### PR TITLE
docs: define dev soak status model

### DIFF
--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -4,7 +4,7 @@
 
 ## 배경
 
-기존 파일명·`name:` 규칙이 제각각이었다 (`auto-format.yml`, `Deploy to Vercel`, `Hourly: DB Invariant Monitor`, ...). PR Checks 화면에서 *"이게 머지를 막는 건지 / 배포인지 / 단순 자동화인지"* 한눈에 안 잡힘. **"빨갛게 뜨면 무슨 일이 일어나나"** 를 축으로 9 개 prefix 로 통일했다.
+기존 파일명·`name:` 규칙이 제각각이었다 (`auto-format.yml`, `Deploy to Vercel`, `Hourly: DB Invariant Monitor`, ...). PR Checks 화면에서 *"이게 머지를 막는 건지 / 배포인지 / 단순 자동화인지"* 한눈에 안 잡힘. **"빨갛게 뜨면 무슨 일이 일어나나"** 를 축으로 prefix 를 통일했다.
 
 ## Prefix
 
@@ -16,10 +16,11 @@
 | `deploy-` | 사용자·dev 환경에 코드·스키마·시드가 안 갔음 | `deploy-vercel`, `deploy-supabase`, `deploy-android-user`, `deploy-ios-user`, `deploy-dev-seed` |
 | `monitor-` | 운영·테스트 시스템 헬스 이상 / 스케줄 유지보수 | `monitor-db-invariants`, `monitor-event-flow-hourly`, `monitor-event-flow-daily`, `monitor-mds-render-coverage`, `monitor-patrol-e2e`, `monitor-allure`, `monitor-build-retention`, `monitor-security-advisor`, `monitor-doc-freshness` |
 | `sync-` | repo 에 자동 commit/push 가 실패함 (dev push 또는 merge 기반) | `sync-version`, `sync-graphify`, `sync-mds-mockups`, `sync-pr-branches`, `sync-test-coverage` |
+| `set-` | GitHub status/metadata 를 쓰는 수동·자동 API entrypoint 실패 | `set-dev-soak-status`, `set-rc-soak-status` |
 | `triage-` | 이슈 생성·슬래시 명령 (commit 없음) | `triage-mds-issue`, `triage-slash` |
 | `post-merge` | dev push 직후 follow-up 자동화의 단일 entry point (5 reusable orchestrator) | `post-merge` |
 | `tool-` | (수동으로 부를 때만 도는 도구) | (현재 없음 — 새 수동 도구 추가 시 prefix) |
-| `shared-` | (다른 워크플로우의 부품 — 단독 실행 X) | `shared-notify`, `shared-android-deploy` |
+| `shared-` | (다른 워크플로우의 부품 — 단독 실행 X) | `shared-notify`, `shared-android-deploy`, `shared-set-commit-status` |
 | branch-strategy stage name | branch-strategy 문서의 stage entry workflow | `dev-staging-pr-gate`, `dev-staging-dev-cut-gate`, `dev-staging-dev-cut`, `dev-pr-gate`, `dev-rc-cut-gate`, `dev-rc-cut`, `rc-pr-gate`, `rc-main-cut-gate`, `rc-main-cut`, `main-pr-gate` |
 | reusable no-prefix | `workflow_call` 로만 호출되는 domain reusable | `version-bump` |
 
@@ -30,18 +31,20 @@
 - Branch ruleset 의 required check 는 `dev-staging-pr-gate`, `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 같은 branch별 wrapper job 이름을 사용한다. `ci-result` summary job 은 폐기한다.
 - `dev-staging-pr-gate`, `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 는 얇은 wrapper 로 시작한다. 내부에서는 `pr-gate.yml` reusable core 를 호출하고, wrapper job 이 최종 required check context 를 제공한다.
 - `dev-staging-dev-cut-gate` 가 dev-staging 의 PR-number CalVer bump/tag 를 담당한다. `sync-version` 은 legacy main release bump 만 담당하며, `dev` promotion 은 `dev-staging-dev-cut` 에서 version 변경 없이 처리한다.
-- `dev-rc-cut-gate` 는 dev push 후 user/partner CUJ integration 을 직접 실행하고, 통과한 commit 에만 `dev-rc-cut-pass` status 를 찍는다. backend/EF/Test Lab 을 포함한 full `dev-rc-cut-gate-suite` matrix 는 후속 확장이다.
+- `dev-rc-cut-gate` 는 cut 직전 evaluator 다. `set-dev-soak-status` 로 기록된 `dev-soak/*` status 와 monitor run history 를 확인하고, 통과한 commit 에만 `dev-rc-cut-pass` status 를 찍는다.
 - `dev-rc-cut` 은 latest `dev-rc-cut-pass` dev commit 에서 `rc/YYYY-Wxx` branch 를 만들고 `version-bump` 로 `v*-rc-01` + `promo/rc-*` tag 를 생성한다.
 - `rc-main-cut-gate` 는 5일 soak 를 통과한 `rc/*` 에 `rc-main-cut-pass` 를 찍고, `rc-main-cut` 은 그 marker 를 소비해 `main` PR 을 만든다.
 - deploy entry 는 후속 단계에서 `[branch]-deploy` 로 통일한다 (`dev-deploy`, `rc-deploy`, `main-deploy`). `monitor-event-flow-*` 는 deploy 가 아니라 지속 batch signal 이다.
+- `set-dev-soak-status` / `set-rc-soak-status` 는 workflow 와 AI agent 가 사용하는 공개 status write API 다. 내부에서는 `shared-set-commit-status` 를 호출한다.
 - protected branch/tag 에 직접 push 하는 workflow 는 `minglit-release-bot` GitHub App token 을 사용한다. App credential 은 `minglit_env/{stage}/github.env` 파일에서 먼저 읽고, 공통 token mint 는 `.github/actions/release-bot-token` 에서 처리한다.
 
 ## 컨벤션
 
 - **파일명 = workflow `name:` 필드** (소문자 kebab, 확장자 제외). 예: `deploy-vercel.yml` 의 `name: deploy-vercel`.
 - prefix 다음은 *대상*만 적는다. 액션 동사는 prefix 가 이미 함의함 (`deploy-vercel` ◯ / `deploy-to-vercel` ✗).
-- 새 entry workflow 는 위 9 prefix 중 하나에 반드시 속해야 한다. 단, branch-strategy 문서에서 고정한 stage entry workflow 는 문서명과 같은 이름을 허용한다.
+- 새 entry workflow 는 위 prefix 중 하나에 반드시 속해야 한다. 단, branch-strategy 문서에서 고정한 stage entry workflow 는 문서명과 같은 이름을 허용한다.
 - `workflow_call` 전용 reusable 은 domain name no-prefix 를 허용한다.
+- `shared-` reusable 은 사람이 직접 실행하지 않는다. 수동 실행이 필요하면 `set-`/`tool-` entry workflow 를 따로 둔다.
 - `pr-setup-` vs `pr-review-setup-` vs `sync-` vs `triage-` 의 기준:
   - `pr-setup-` = PR push 마다 PR 브랜치를 mutate (#2627 이후 인스턴스 없음 — auto-format 은 `pr-gate` 의 `format-check` 잡으로 대체)
   - `pr-review-setup-` = PR 의 "리뷰 준비 단계" 자동화 (auto-merge enable, `needs-review` 라벨 부여)

--- a/docs/infra/branch-strategy/BLUEDOC.md
+++ b/docs/infra/branch-strategy/BLUEDOC.md
@@ -15,9 +15,11 @@ flowchart LR
   nc --> npg[dev-pr-gate]
   npg --> dev[dev]
 
-  dev --> rg[dev-rc-cut-gate]
+  dev -. 24h soak .-> rg[dev-rc-cut-gate]
+  monitor["monitor-event-flow-* batch"] -. dev-soak/backend-simulator .-> dev
+  ai["AI app soak / real-device"] -. dev-soak/app-ai-review .-> dev
   rg -->|pass| rgp["dev-rc-cut-pass status"]
-  rg -->|fail| issue[auto issue + fix via dev-staging]
+  rg -->|blocked| issue[status failure + issue/audit]
   rgp --> rcut[dev-rc-cut]
   rcut --> rc["rc/YYYY-Wxx"]
 
@@ -37,7 +39,6 @@ flowchart LR
   main --> md[main-deploy]
   md --> prod[(Production)]
 
-  monitor["monitor-event-flow-* batch"] -. continuous signal .- dev
   monitor -. pre-main signal .- rc
 ```
 
@@ -48,7 +49,7 @@ flowchart LR
 | dev-staging PR | `dev-staging-pr-gate` | feature/agent PR 의 빠른 CI gate |
 | dev-staging → dev cut gate | `dev-staging-dev-cut-gate` | dev 로 promote 할 coherent dev-staging snapshot 을 `v*-dev-staging` tag 로 선별 |
 | dev-staging → dev cut | `dev-staging-dev-cut` + `dev-pr-gate` | gate 가 선별한 snapshot 을 dev PR 로 promote |
-| dev → rc cut gate | `dev-rc-cut-gate` | RC 후보 검증 후 `dev-rc-cut-pass` status 부여 |
+| dev → rc cut gate | `dev-rc-cut-gate` | 24h dev soak status/run history 확인 후 `dev-rc-cut-pass` status 부여 |
 | dev deploy/validation | `dev-deploy` | dev 환경 deploy/validation orchestrator. 이벤트 플로우 시뮬레이터는 `monitor-event-flow-*` batch 로 별도 운영 |
 | dev → rc cut | `dev-rc-cut` | latest `dev-rc-cut-pass` commit 에서 `rc/YYYY-Wxx` 생성 |
 | rc hotfix | `rc-pr-gate` + `rc-post-merge-sync` + `rc-hotfix-backport` | RC hotfix 검증, RC version bump, dev-staging backport |
@@ -62,7 +63,7 @@ flowchart LR
 | 단계 | 역할 | 진입 방식 |
 |------|------|-----------|
 | `dev-staging` | AI agent commit zone | 일반 PR + auto-merge + 가벼운 `pr-gate` |
-| `dev` | cut-gate validated trunk | daily `dev-staging-dev-cut` → post-merge `dev-rc-cut-gate` |
+| `dev` | soak-validated trunk | daily `dev-staging-dev-cut` → 24h soak → `dev-rc-cut-gate` |
 | `rc/YYYY-Wxx` | mobile RC, 5일 soak | weekly cut from latest dev-rc-cut-pass |
 | `main` | mobile-stable snapshot | rc → main 머지 (soak 통과 시) |
 
@@ -83,6 +84,7 @@ flowchart LR
 | [error-detection.md](./error-detection.md) | detection layers |
 | [dev-staging-pipeline.md](./dev-staging-pipeline.md) | 일반 PR/auto-merge + pr-gate + safety net CI |
 | [dev-pipeline.md](./dev-pipeline.md) | dev-staging-dev-cut + dev-rc-cut-gate + auto-deploy chain |
+| [dev-soak-status-model.md](./dev-soak-status-model.md) | dev soak commit status contexts + run history based `dev-rc-cut-gate` 판정 |
 | [rc-promotion.md](./rc-promotion.md) | dev-rc-cut + soak + hotfix + backport |
 | [main-promotion.md](./main-promotion.md) | rc → main + main-deploy + min-version |
 | [life-of-flag.md](./life-of-flag.md) | flag lifecycle |
@@ -97,6 +99,7 @@ flowchart LR
 
 - 코드 promotion = 한 방향 PR, 기능 promotion = flag flip
 - `*-cut-gate` = 다음 브랜치로 promote 할 source artifact 선별/마킹, `*-cut` = 그 artifact 로 PR/branch 생성. 검증과 promotion 을 같은 workflow 에 섞지 않는다
+- dev soak 판정의 source-of-truth 는 GitHub Issue/label 이 아니라 commit status context + workflow run history 다 ([dev-soak-status-model.md](./dev-soak-status-model.md))
 - 모든 branch linear ON — dev-staging: squash, dev/rc/main: rebase
 - Protected branch 직접 push 는 human 금지. version bump/tag/promotion 처리는 `minglit-release-bot` 전용 token + Ruleset bypass 로만 허용
 - `monitor-event-flow-*` 는 release promotion 과 독립적인 batch signal. dev 에서 계속 돌고, RC 에서는 main 배포 전 검증 signal 로 사용한다

--- a/docs/infra/branch-strategy/dev-pipeline.md
+++ b/docs/infra/branch-strategy/dev-pipeline.md
@@ -1,12 +1,12 @@
 # Dev Pipeline
 
-`dev` 브랜치가 trunk 역할: dev-staging 의 daily snapshot 을 받고, post-merge 로 full integration suite (`dev-rc-cut-gate`) 를 돌린다. RC 는 `dev-rc-cut-pass` status 를 보고 cut 한다. 이벤트 플로우 시뮬레이터는 `monitor-event-flow-*` batch 로 계속 돌며, backend prod deploy 는 main 머지 후 `main-deploy` 에서 수행한다.
+`dev` 브랜치가 trunk 역할: dev-staging 의 daily snapshot 을 받고, 24h soak 후 `dev-rc-cut-gate` 가 commit status 와 monitor run history 를 평가한다. RC 는 `dev-rc-cut-pass` status 를 보고 cut 한다. 이벤트 플로우 시뮬레이터는 `monitor-event-flow-*` batch 로 계속 돌며, backend prod deploy 는 main 머지 후 `main-deploy` 에서 수행한다.
 
 ## 4가지 workflow
 
 1. **`dev-staging-dev-cut`** — daily cron, dev-staging tip 의 snapshot 으로 PR 생성
 2. **`dev-pr-gate`** — snapshot PR 머지 전 검증 (defensive)
-3. **`dev-rc-cut-gate`** — dev 머지 후 자동 발동, full integration suite, 통과 시 status `dev-rc-cut-pass` set
+3. **`dev-rc-cut-gate`** — cut 직전 evaluator. 24h soak + commit status + run history 확인 후 `dev-rc-cut-pass` set
 4. **`dev-deploy` / monitor jobs** — dev 환경 deploy/smoke 가 필요할 때만 수행. 이벤트 플로우 시뮬레이터는 `monitor-event-flow-*` 로 별도 운영
 
 ## `dev-staging-dev-cut`
@@ -32,32 +32,44 @@
 
 (상세는 [dev-staging-pipeline.md](./dev-staging-pipeline.md))
 
-## `dev-rc-cut-gate` — Heavy Integration
+## `dev-rc-cut-gate` — Soak Evaluator
 
-dev 머지 후 자동 발동. 통과 = "이 commit 은 RC cut source 로 사용할 수 있음".
+cut 직전 schedule/manual 로 실행된다. 통과 = "이 dev HEAD commit 은 RC cut source 로 사용할 수 있음".
 
-> **Current implementation**: first operational version runs user/partner CUJ integration directly and sets `dev-rc-cut-pass` on success. Backend simulation/Test Lab 확장은 후속이다.
+> **정책 변경**: `dev-rc-cut-gate` 는 heavy test runner 가 아니라 evaluator 다. 테스트/모니터는 별도 workflow 또는 AI agent 가 돌고, 실패 즉시 commit status 를 남긴다. `dev-rc-cut-gate` 는 24h soak 가 실제로 돌았는지 확인한 뒤 성공 status 를 확정한다.
 
-### 무엇을 도는가
+### Source of truth
 
-매트릭스 병렬. 하나라도 실패 = dev-rc-cut-gate 전체 실패.
+GitHub Issue 는 source-of-truth 가 아니다. Gate 판정은 commit status context 와 GitHub Actions run history 를 사용한다.
 
-매트릭스 (app × scenario) 병렬. 하나라도 실패 = dev-rc-cut-gate 전체 실패.
+| Context | failure 작성자 | success 작성자 |
+|---------|---------------|----------------|
+| `dev-soak/backend-simulator` | `monitor-event-flow-*` 실패 path (`shared-notify`) | `dev-rc-cut-gate` |
+| `dev-soak/real-device` | real-device/Test Lab workflow 또는 AI agent | `dev-rc-cut-gate` |
+| `dev-soak/app-ai-review` | AI agent | `dev-rc-cut-gate` |
+| `dev-rc-cut-pass` | 없음 | `dev-rc-cut-gate` |
 
-| job | 대상 | 비고 |
-|-----|------|------|
-| `cuj-app-user` × {happy, unhappy, chaos} | `apps/app_user/patrol_test/cuj/*` | `--flavor dev --dart-define-from-file=.../dev/flutter.env`. scenario 별 sub-suite. chaos 미정의 시 후속 정의 (TBD) |
-| `cuj-app-partner` × {happy, unhappy, chaos} | `apps/app_partner/patrol_test/cuj/*` | 동일 |
-| `integration-backend` | `tests/backend_integration/**` | Supabase staging or ephemeral branch |
-| `integration-edge-functions` | `tests/ef_integration/**` | EF 통합 시나리오 |
-| `test-lab-smoke` | Firebase Test Lab — 실 디바이스 4종 | 디바이스 다양성 보강 |
+상세 status model 은 [dev-soak-status-model.md](./dev-soak-status-model.md) 를 따른다.
+
+### 무엇을 확인하는가
+
+`dev-rc-cut-gate` 는 latest `origin/dev` HEAD 만 평가한다. dev 에 새 commit 이 들어오면 candidate 와 24h soak clock 은 reset 된다.
+
+| 검증 | 조건 |
+|------|------|
+| Soak duration | candidate age >= 24h |
+| Hourly backend simulator | `candidate_since` 이후 `monitor-event-flow-hourly` success run >= 20 |
+| Daily backend simulator | `candidate_since` 이후 `monitor-event-flow-daily` success run >= 1 |
+| Real device | candidate 기준 required real-device signal success >= 1 (workflow TBD) |
+| App AI review | AI agent 가 candidate 기준 app-soak pass signal 제공 (입력 방식 TBD) |
+| Failure status | `dev-soak/*` context 의 최신 state 가 `failure` 가 아니어야 함 |
 
 ### 통과 시 (dev-rc-cut-pass)
 
 ```
 1. dev HEAD commit 에 GitHub commit status `dev-rc-cut-pass` set
-2. `dev-rc-cut` 이 이 status 를 source-of-truth 로 사용
-3. 이벤트 플로우 시뮬레이터는 `monitor-event-flow-*` batch 로 계속 별도 관찰
+2. `dev-soak/backend-simulator`, `dev-soak/real-device`, `dev-soak/app-ai-review` 도 evaluator 가 success 로 확정
+3. `dev-rc-cut` 이 `dev-rc-cut-pass` 를 source-of-truth 로 사용
 4. Mobile + backend prod 은 main 머지 후 `main-deploy` 에서 처리
 ```
 
@@ -68,6 +80,8 @@ dev 머지 후 자동 발동. 통과 = "이 commit 은 RC cut source 로 사용�
 Snapshot 모델 — **auto-revert 없음**. dev 가 broken 상태로 잠시 머묾, AI agent 가 fix PR 을 normal flow 로 처리.
 
 - Status 미부여 (`dev-rc-cut-pass` 없음 → dev-rc-cut 이 이 commit 안 골라잡음)
+- 실패를 발견한 monitor/AI agent 가 `dev-soak/*` failure status 를 즉시 작성
+- `shared-notify` 가 release-blocker issue 를 생성/갱신하되, issue 상태는 gate 판정 source-of-truth 로 쓰지 않음
 - 자동 이슈 + `P1-high` 라벨 + 직전 `dev-rc-cut-pass` 이후 머지된 PR 작성자들 assignee (AI agent 포함)
 - AI agent 가 fix PR 을 dev-staging 으로 작성 → dev-staging-pr-gate → 다음 dev-staging-dev-cut → 다음 dev-rc-cut-gate 가 검증
 - dev 는 *broken integration 상태* 지만 `pr-gate-core` 가 compile/unit 잡아주니 다른 PR 진입 자체는 OK
@@ -102,16 +116,16 @@ Snapshot 모델 — **auto-revert 없음**. dev 가 broken 상태로 잠시 머�
 
 ## Artifact / 보존
 
-- 실패한 dev-rc-cut-gate: 30일 (스크린샷, 로그, APK)
-- 성공: 7일
+- 실패한 monitor/soak workflow: 30일 (스크린샷, 로그, APK)
+- 성공한 `dev-rc-cut-gate` evaluator run: 7일
 
 ## 결정해야 할 것
 
 - dev-staging-dev-cut cron 시각
 - backoff 임계 (3회 차단이 적정한가)
-- CUJ chaos 시나리오 정의 (현재 미정의)
+- real-device/app AI review status writer 구현 방식
+- `shared-notify` 의 release signal metadata/log tail 확장
 - Supabase RC branch TTL / seed data 정책
-- dev-rc-cut-gate selective run 도입 시점
 
 ## 관련
 

--- a/docs/infra/branch-strategy/dev-soak-status-model.md
+++ b/docs/infra/branch-strategy/dev-soak-status-model.md
@@ -1,0 +1,197 @@
+# Dev Soak Status Model
+
+`dev-rc-cut-gate` 는 테스트를 직접 실행하는 workflow 가 아니라, dev HEAD 가 RC cut source 로 충분히 안정적인지 판정하는 evaluator 다. 판정의 source-of-truth 는 GitHub Issue 가 아니라 **commit status context** 와 workflow run history 다. Issue 는 사람이 보는 incident/audit surface 로만 사용한다.
+
+## Source Of Truth
+
+| 데이터 | 역할 | SSOT 여부 |
+|--------|------|-----------|
+| Commit status | soak failure/pass marker. `dev-rc-cut-gate` 가 직접 판정에 사용 | yes |
+| Workflow run history | monitor 가 실제로 충분히 돌았는지 확인 | yes |
+| GitHub Issue | 로그, 담당, 원인, 후속 조치 기록 | no |
+| GitHub label | 사람이 보는 분류/필터 | no |
+
+SHA, PR number, run id, version 은 label 로 만들지 않는다. Label 은 repo-wide category 로만 유지한다.
+
+## Status Write API
+
+Workflow 와 AI agent 는 commit status context 를 직접 하드코딩하지 않고 stage별 status write workflow 를 사용한다.
+
+| Workflow | 공개 범위 | 역할 |
+|----------|----------|------|
+| `shared-set-commit-status` | internal reusable | `sha`, `context`, `state`, `description`, `target_url` 를 받아 GitHub commit status 를 작성 |
+| `set-dev-soak-status` | public API (`workflow_call` + `workflow_dispatch`) | `signal` 을 `dev-soak/*` context 로 매핑한 뒤 `shared-set-commit-status` 호출 |
+| `set-rc-soak-status` | public API (`workflow_call` + `workflow_dispatch`) | `signal` 을 `rc-soak/*` context 로 매핑한 뒤 `shared-set-commit-status` 호출 |
+
+외부 consumer 는 `shared-set-commit-status` 를 직접 호출하지 않는다. 공통 writer 는 context 를 검증하지 않는 low-level primitive 이므로, 사람이 직접 쓰면 stage/signal naming 을 우회할 수 있다.
+
+### `set-dev-soak-status`
+
+입력:
+
+| Input | 값 |
+|-------|----|
+| `signal` | `backend-simulator` \| `real-device` \| `app-ai-review` |
+| `state` | `failure` \| `success` \| `pending` |
+| `sha` | status 를 붙일 commit SHA |
+| `target_url` | workflow run, artifact, screenshot, AI review 결과 URL |
+| `description` | status 설명 (GitHub UI 에 노출) |
+
+Signal mapping:
+
+| Signal | Context |
+|--------|---------|
+| `backend-simulator` | `dev-soak/backend-simulator` |
+| `real-device` | `dev-soak/real-device` |
+| `app-ai-review` | `dev-soak/app-ai-review` |
+
+사용 예:
+
+```bash
+gh workflow run set-dev-soak-status.yml \
+  -f signal=app-ai-review \
+  -f state=failure \
+  -f sha=<dev-commit-sha> \
+  -f description="settings screen layout regression"
+```
+
+### `set-rc-soak-status`
+
+RC soak 는 dev soak 와 signal set 이 달라질 수 있으므로 별도 entry workflow 로 둔다.
+
+초기 signal mapping:
+
+| Signal | Context |
+|--------|---------|
+| `backend-simulator` | `rc-soak/backend-simulator` |
+| `real-device` | `rc-soak/real-device` |
+| `dogfooding` | `rc-soak/dogfooding` |
+
+`rc-main-cut-gate` 는 나중에 `rc-soak/*` status 와 RC run history 를 읽어 `rc-main-cut-pass` 를 판정한다.
+
+## Commit Status Contexts
+
+| Context | 작성자 | 실패 시점 | 성공 시점 | 의미 |
+|---------|--------|-----------|-----------|------|
+| `dev-soak/backend-simulator` | `set-dev-soak-status` via `monitor-event-flow-*` / `dev-rc-cut-gate` | event-flow simulator 실패 즉시 `failure` | `dev-rc-cut-gate` 가 24h run history 를 확인한 뒤 `success` | backend/event-flow soak signal |
+| `dev-soak/real-device` | `set-dev-soak-status` via real-device workflow / `dev-rc-cut-gate` | Firebase Test Lab 또는 실디바이스 smoke 실패 즉시 `failure` | `dev-rc-cut-gate` 가 required run/signal 을 확인한 뒤 `success` | 실제 디바이스 안정성 signal |
+| `dev-soak/app-ai-review` | `set-dev-soak-status` via AI agent / `dev-rc-cut-gate` | AI/human 앱 소킹 중 blocker 발견 즉시 `failure` | `dev-rc-cut-gate` 가 AI review pass signal 을 확인한 뒤 `success` | screenshot/UX/manual-ish app soak signal |
+| `dev-rc-cut-pass` | `dev-rc-cut-gate` | 작성하지 않음 | 모든 dev soak 조건 통과 시 `success` | RC cut source marker |
+
+실패 status 는 발견 즉시 찍는다. 성공 status 는 각 monitor 가 매번 찍지 않고, cut 직전 evaluator 인 `dev-rc-cut-gate` 가 검증 완료 후 찍는다.
+
+## Labels
+
+Issue label 은 분류용이다. Gate 판정에는 사용하지 않는다.
+
+| Label | 용도 |
+|-------|------|
+| `release-blocker` | release 관련 blocker incident |
+| `dev-soak` | dev soak window 에서 발견 |
+| `backend-simulator` | event-flow/backend simulator 계열 |
+| `real-device` | Firebase Test Lab/실디바이스 계열 |
+| `app-soak` | AI/human 앱 소킹 계열 |
+| `P0-critical`, `P1-high` | 우선순위 |
+
+금지: `candidate-sha-*`, `commit-*`, `run-*`, `pr-*` 같은 동적 label.
+
+## Soak Window
+
+기본 정책은 **latest `origin/dev` HEAD 만 평가**한다.
+
+1. `candidate_sha = origin/dev HEAD`
+2. `candidate_since = candidate_sha` 가 dev 에 들어온 시각
+3. `now - candidate_since >= 24h`
+4. candidate 이후 dev 에 새 commit 이 들어오면 candidate 와 soak clock 은 reset
+
+여러 candidate 를 동시에 추적하지 않는다. Snapshot model 이므로 최신 dev HEAD 만 RC source 후보가 된다.
+
+## Run History Verification
+
+`dev-rc-cut-gate` 는 GitHub Actions run history 로 "soak 이 실제로 돌았는지" 검증한다.
+
+| Signal | 최소 조건 |
+|--------|-----------|
+| `monitor-event-flow-hourly` | `candidate_since` 이후 `success` run >= 20 |
+| `monitor-event-flow-daily` | `candidate_since` 이후 `success` run >= 1 |
+| real-device smoke | candidate 기준 required run/signal success >= 1 (workflow 이름 TBD) |
+| app AI review | AI agent 가 candidate 기준 pass signal 제공 (workflow/status 입력 방식 TBD) |
+
+예시 조회:
+
+```bash
+gh run list \
+  --workflow monitor-event-flow-hourly.yml \
+  --branch dev \
+  --created ">=2026-05-24T00:00:00Z" \
+  --json databaseId,status,conclusion,createdAt,headSha
+```
+
+Scheduled workflow 의 `headSha` 는 실행 시점의 `dev` HEAD 다. 따라서 run 의 `headSha` 가 candidate 와 다르면 latest candidate 가 바뀐 것으로 보고 그 run 은 현재 candidate 의 soak 증거로 쓰지 않는다.
+
+## Failure Recording
+
+`shared-notify` 는 실패를 발견한 workflow 의 공통 issue/log recorder 로 확장한다. Commit status 는 `set-dev-soak-status` 를 통해 기록한다.
+
+필요 입력:
+
+| Input | 예시 | 용도 |
+|-------|------|------|
+| `stage` | `dev-soak` | issue 제목/metadata |
+| `signal` | `backend-simulator` | status context suffix |
+| `severity` | `P1-high` | label/제목 |
+| `blocks_rc_cut` | `true` | commit status failure 작성 여부 |
+| `commit_sha` | `${{ github.sha }}` | status target |
+
+실패 시 동작:
+
+1. `set-dev-soak-status` 를 호출해 status context `dev-soak/{signal}` 을 `failure` 로 설정
+2. Issue 생성/갱신 (`release-blocker`, `dev-soak`, signal label, severity label)
+3. Issue body 에 workflow/run/commit/PR 정보와 failed log tail 을 첨부
+
+Issue body 에는 machine-readable metadata 를 남긴다. 단, gate 판정은 이 metadata 를 SSOT 로 사용하지 않는다.
+
+```md
+<!-- minglit-release-signal
+stage: dev-soak
+signal: backend-simulator
+workflow: monitor-event-flow-hourly
+branch: dev
+commit: abc123...
+run_id: 263...
+severity: P1-high
+blocks_rc_cut: true
+-->
+```
+
+## `dev-rc-cut-gate` Evaluation
+
+`dev-rc-cut-gate` 는 schedule 또는 manual dispatch 로 동작한다. `push to dev` 직후 즉시 pass 를 찍지 않는다.
+
+평가 순서:
+
+1. `candidate_sha = origin/dev HEAD`
+2. candidate age 가 24h 이상인지 확인
+3. required monitor run history 가 candidate 기준으로 충분한지 확인
+4. candidate 의 최신 commit status 중 아래 context 가 `failure` 인지 확인:
+   - `dev-soak/backend-simulator`
+   - `dev-soak/real-device`
+   - `dev-soak/app-ai-review`
+5. 모두 통과하면 각 `dev-soak/*` status 를 `success` 로 찍고 `dev-rc-cut-pass` 를 `success` 로 찍는다
+
+실패 또는 미충족 시 `dev-rc-cut-pass` 는 쓰지 않는다.
+
+## Permissions
+
+Commit status 를 직접 관리하는 actor 는 GitHub App token 을 사용한다.
+
+| Actor | 필요 권한 |
+|-------|-----------|
+| `shared-notify` / monitor workflows | Commit statuses: read/write, Issues: read/write |
+| AI agent status writer | Commit statuses: read/write, Issues: read/write |
+| `dev-rc-cut-gate` | Commit statuses: read/write, Actions: read, Contents: read |
+
+Human 은 로컬에서 release bot token 을 사용하지 않는다. AI agent 가 app soak failure/pass 를 기록할 때도 같은 status context naming 을 따라야 한다.
+
+---
+_Reviewed: 2026-05-24 13:05_

--- a/docs/infra/branch-strategy/error-detection.md
+++ b/docs/infra/branch-strategy/error-detection.md
@@ -9,8 +9,9 @@
 | 개발자 로컬 | LSP, analyze, unit | 컴파일/타입/단위 | 초~분 |
 | dev-staging PR gate | `dev-staging-pr-gate` (unit, lint, pgTAP, EF, migration, `expand-migrate-contract`, `flag-registration`, gitleaks) | PR 회귀, 보안, migration 충돌, flag 미등록, contract 위반 | < 10분 |
 | dev-staging-dev-cut PR | `dev-pr-gate` (defensive) | 환경 차이 회귀 | < 10분 |
-| dev 머지 후 (자동) | `dev-rc-cut-gate` (CUJ matrix happy/unhappy/chaos, integration, e2e, Test Lab) | 통합 회귀, 시나리오, 외부 의존, 디바이스 | 30-60분 |
-| Backend/Web auto-deploy | post-deploy smoke, Sentry release marker | deploy infra 회귀 | 분 |
+| dev soak | `monitor-event-flow-*`, real-device workflow, AI app soak status writer via `set-dev-soak-status` | backend simulator, 외부 의존, 디바이스, UX/blocker | 즉시~24h |
+| RC cut 직전 | `dev-rc-cut-gate` evaluator | 24h soak 미충족, `dev-soak/*` failure status, monitor 미실행 | 분 |
+| Backend/Web deploy validation | post-deploy smoke, Sentry release marker | deploy infra 회귀 | 분 |
 | rc soak (5일) | rc 의 nightly 재실행 + 내부 dogfooding | 누적 회귀, real-data 이슈 | 일 단위 |
 | main 머지 후 (auto-deploy) | smoke + Sentry/Crashlytics 알람 임계 | prod 회귀 | 분 |
 | deploy-android-*, deploy-ios-* 후 | mobile build smoke + Crashlytics dSYM/mapping 등록 | mobile build 회귀, sign 실패 | 시간 |
@@ -32,7 +33,7 @@
 
 ### Firebase Test Lab
 - 실 디바이스 farm 에서 CUJ/smoke
-- `dev-rc-cut-gate` 의 mobile 부분 일부 위임
+- 실패 즉시 `dev-soak/real-device` commit status 를 failure 로 기록
 - 상세: [../firebase/BLUEDOC.md](../firebase/BLUEDOC.md)
 
 ### Statsig
@@ -45,16 +46,18 @@
 - 참고: `docs/operations/edge-functions.md`
 
 ### GitHub Actions
-- pr-gate / dev-rc-cut-gate / promotion workflow 의 자동 이슈 생성
-- **workflow infra 실패 → P0**, test 실패 → P1-high
+- pr-gate / monitor / promotion workflow 의 자동 이슈 생성
+- `shared-notify` 는 release blocker incident 를 issue 로 남기고, gate 판정용 commit status 를 기록
+- **workflow infra 실패 → P0**, test/soak 실패 → P1-high
 
 ## Detection → Action 책임
 
 | Detection 신호 | 누가 받음 | 어디서 | Action |
 |---------------|----------|--------|--------|
 | pr-gate 실패 (어느 단계든) | PR 작성자 | GitHub PR | 본인 fix → re-push → auto-merge 재대기 |
-| `dev-rc-cut-gate` 실패 (dev 머지 후) | 직전 dev-rc-cut-pass 이후 머지된 PR 작성자들 + AI agent | GitHub issue + Slack `#nightly` | AI agent fix PR via dev-staging — dev keeps moving ([dev-pipeline.md](./dev-pipeline.md)) |
-| Backend/web staging deploy 실패 (dev dev-rc-cut-pass) | on-call | Slack `#release` | retry → P0 이슈, RC 진행 차단 (staging 도달 못함) |
+| `dev-soak/*` failure status | 직전 dev-rc-cut-pass 이후 머지된 PR 작성자들 + AI agent | commit status + GitHub issue + Slack `#nightly` | AI agent fix PR via dev-staging — dev keeps moving ([dev-pipeline.md](./dev-pipeline.md)) |
+| `dev-rc-cut-gate` evaluator 미충족 | release manager / AI agent | GitHub Actions run summary | RC cut 보류. failure status 또는 monitor run history 부족 원인 확인 |
+| Backend/web deploy validation 실패 | on-call | Slack `#release` | retry → P0 이슈, 해당 promotion/deploy 진행 차단 |
 | Backend/web/mobile prod deploy 실패 (main 머지) | on-call | Slack `#release` | retry → rollback ([main-promotion.md](./main-promotion.md) error-backoff) |
 | rc soak 중 회귀 | RC owner | Slack `#release` | hotfix PR → rc | 
 | deploy-android-*, deploy-ios-* 실패 | mobile 팀 | GitHub issue + Slack | retry + auto-issue ([main-promotion.md](./main-promotion.md) error-backoff) |

--- a/docs/infra/branch-strategy/specs/execution-plan.md
+++ b/docs/infra/branch-strategy/specs/execution-plan.md
@@ -23,7 +23,9 @@
 |---------------|----------|----------|
 | `pr-gate-core` (reusable) | `pr-gate` 의 step 들을 reusable workflow_call 로 추출 + stage parameter 추가 | **refactor** |
 | `version-bump` (reusable) | `sync-version` 의 핵심 로직 → reusable 분리 | **refactor** |
-| `dev-rc-cut-gate-suite` (reusable) | 기존 `monitor-patrol-e2e`, `monitor-cuj-coverage` 등을 통합해 reusable suite 구성 | **신규 (조합)** |
+| `shared-set-commit-status` | commit status write 공통 reusable | **신규** |
+| `set-dev-soak-status`, `set-rc-soak-status` | stage별 soak status write API (`workflow_call` + `workflow_dispatch`) | **신규** |
+| dev soak monitor/status model | 기존 `monitor-event-flow-*`, real-device workflow, AI agent signal 을 `dev-soak/*` commit status 로 통합 | **신규 (조합)** |
 | `auto-issue` (reusable) | (없음) | **신규** |
 | `backport-pr` (reusable) | (없음) | **신규** |
 | `dev-staging-pr-gate` | `pr-gate` 를 dev-staging base 로 재사용 (stage=dev-staging) | **신규 (얇은 wrapper)** |
@@ -107,10 +109,11 @@
 
 | Step | 작업 | 의존 |
 |------|------|------|
-| 4a | `dev-rc-cut-gate-suite` reusable 조립 (CUJ × matrix + integration + Test Lab) | Phase 2 |
-| 4b | `dev-rc-cut-gate` 에 full suite 연결 + failure auto-issue/backoff | 4a |
-| 4c | `main-pr-gate` 에 RC lineage / `rc-main-cut-pass` / contract 재검증 추가 | Phase 2 |
-| 4d | `backport-pr` reusable, `rc-hotfix-backport` | Phase 2 |
+| 4a | `shared-set-commit-status`, `set-dev-soak-status`, `set-rc-soak-status` 구현 | Phase 2 |
+| 4b | `shared-notify` 가 실패 시 `set-dev-soak-status` 호출 + issue title/body/log tail 개선 | 4a |
+| 4c | `dev-rc-cut-gate` 를 24h soak evaluator 로 변경 (run history + `dev-soak/*` status 확인) | 4a, 4b |
+| 4d | `main-pr-gate` 에 RC lineage / `rc-main-cut-pass` / contract 재검증 추가 | Phase 2 |
+| 4e | `backport-pr` reusable, `rc-hotfix-backport` | Phase 2 |
 
 ### Verification 단계
 
@@ -170,7 +173,7 @@ Phase 1 (skeletal) → Phase 2 (CI/PR flow) → Phase 3 (branch CD)
 비-critical (병렬 가능):
 - Phase 2e (`auto-issue` reusable) — 신규, 의존 없음
 - Phase 3 (deploy trigger refactor) — Phase 5 이전에 끝나면 OK
-- Phase 4a (dev-rc-cut-gate-suite) — Phase 4b 이전에만 끝나면 OK
+- Phase 4a (status write API) — Phase 4b/4c 이전에만 끝나면 OK
 
 ## Secret Management 정리 (별도 작업, user 와 함께)
 
@@ -220,21 +223,21 @@ Phase 1 (skeletal) → Phase 2 (CI/PR flow) → Phase 3 (branch CD)
 5. **Release bot token 실패**: GitHub App ID/private key 누락 또는 App 권한 부족이면 version bump/tag/promotion workflow 가 막힘. 최초 도입 시 dry-run branch 로 push/tag/delete까지 검증
 6. **Secret 마이그레이션 중 workflow 실패**: file 기반과 GH secret 참조가 섞이는 transition 기간 — env 변수 누락 시 즉시 발견 (CI 통과 못함)
 
-## Self-review: Phase 3 ordering
+## Self-review: Phase 4 ordering
 
-내부 검토 결과 — **현재 순서 (3a → 3b → 3c → 3d → 3e → 3f → 3g) OK**, 단 다음 minor 개선:
+내부 검토 결과 — **현재 순서 (4a → 4b → 4c → 4d → 4e) OK**, 단 다음 minor 개선:
 
-- **3a / 3b 병렬 가능**: dev-staging-pr-gate (3a) 와 dev-staging-dev-cut (3b) 는 서로 의존이 약함. 단 version bump/tag push 검증에는 release bot 준비가 선행되어야 함
-- **3c → 3d 사이 verification 불필요**: dev-rc-cut-gate-suite (3c) 는 reusable, 호출은 dev-rc-cut-gate (3d) 에서. 3c 자체로는 동작 없음 → 3d 와 동일 PR 또는 직후 PR 가능
-- **3f 는 3e 와 같이**: rc-hotfix-backport 가 rc-promotion 흐름의 일부라 같은 시점에 도입이 자연스러움
-- **가장 critical**: 3d (dev-rc-cut-gate) — 첫 verification 기간 1주 이상 추천 (다른 stage 와 달리 60분 비용 + 통합 시나리오 복잡)
+- **4a / 4b 는 같은 PR 가능**: `shared-set-commit-status` 와 `shared-notify` 연동은 API contract 가 작아서 같이 검증 가능하다. 단 `set-dev-soak-status` 수동 dispatch dry-run 은 먼저 통과해야 한다
+- **status write API → evaluator 사이 verification 필요**: `set-dev-soak-status` 는 AI agent/monitor 가 직접 쓰는 public API 이므로 context mapping, 권한, target SHA 를 먼저 검증한다
+- **4e 는 4d 와 독립 가능**: rc-hotfix-backport 는 rc promotion 흐름의 일부지만 main protection 적용과 직접 의존하지 않는다
+- **가장 critical**: `dev-rc-cut-gate` evaluator — 첫 verification 기간 1주 이상 추천 (24h soak/run history/status context 판정이 release cut 을 직접 막음)
 
 권장 변경 없음. 위 순서 그대로 진행.
 
 ## TBD (구현 중 결정)
 
 - `auto-issue` 의 P0/P1/P2 라벨 컨벤션 표준 (현재 minglit 의 `P0-critical` 등 따름)
-- `dev-rc-cut-gate-suite` 매트릭스 분할 (60분 예산 안에 들어오게)
+- real-device/app AI review 의 `set-dev-soak-status` pass/failure 입력 방식
 - 4d 의 main protection 적용을 *warn-only* → *enforced* 전환 일자
 - Vercel native build 전환 시점 + Vercel-GitHub 연결 설정 (Vercel-side 작업)
 - Secret 마이그레이션 timing (user 와 함께 — Phase 2/3 와 별도)
@@ -247,4 +250,4 @@ Phase 1 (skeletal) → Phase 2 (CI/PR flow) → Phase 3 (branch CD)
 - 기존 [`.github/workflows/BLUEDOC.md`](../../../../.github/workflows/BLUEDOC.md) — 현재 workflow 의 인벤토리 진입점
 
 ---
-_Reviewed: 2026-05-19 09:47_
+_Reviewed: 2026-05-24 13:05_

--- a/docs/infra/branch-strategy/specs/release-bot.md
+++ b/docs/infra/branch-strategy/specs/release-bot.md
@@ -20,8 +20,9 @@ GitHub App permission 은 아래만 부여한다.
 |------------|-------|------|
 | Contents | Read/write | version bump commit, branch 생성/삭제, tag push, release asset/source 접근 |
 | Pull requests | Read/write | promotion/backport PR 생성, auto-merge enable |
-| Commit statuses | Read/write | `dev-rc-cut-pass` 같은 commit status 설정 |
+| Commit statuses | Read/write | `dev-soak/*`, `dev-rc-cut-pass`, `rc-main-cut-pass` 같은 gate marker 설정 |
 | Checks | Read | required check / gate 상태 조회 |
+| Actions | Read | `dev-rc-cut-gate` 가 monitor workflow run history 를 조회 |
 | Issues | Read/write | release 자동 이슈 생성, failure comment |
 | Metadata | Read | GitHub App 기본 권한 |
 
@@ -30,7 +31,7 @@ GitHub App permission 은 아래만 부여한다.
 | Permission | 이유 |
 |------------|------|
 | Administration | Ruleset 수정은 초기 수동 설정 또는 별도 infra workflow 에서만 수행 |
-| Actions | workflow 실행/수정 권한은 상시 release path 에 불필요 |
+| Actions write | workflow 실행/수정 권한은 상시 release path 에 불필요. run history 조회용 read 만 허용 |
 | Secrets | secret 조회/수정 금지 |
 | Members / Organization administration | repo release automation 범위 초과 |
 
@@ -86,6 +87,12 @@ git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
 | `sync-version` | dev/main version bump commit, main release tag |
 | `dev-staging-dev-cut-gate` | dev-staging version bump/tag |
 | `dev-staging-dev-cut` | immutable nightly branch 생성, dev PR 생성 |
+| `shared-set-commit-status` | commit status 를 쓰는 low-level reusable |
+| `set-dev-soak-status` | dev soak signal 을 `dev-soak/*` context 로 매핑 |
+| `set-rc-soak-status` | rc soak signal 을 `rc-soak/*` context 로 매핑 |
+| `monitor-event-flow-*` / `shared-notify` | backend simulator 실패 시 `set-dev-soak-status` 로 failure status + issue 기록 |
+| AI app soak status writer | 앱 소킹/실디바이스 이상 발견 시 `set-dev-soak-status` 로 failure status 기록 |
+| `dev-rc-cut-gate` | 24h soak run history 확인 후 `set-dev-soak-status` 로 `dev-soak/*` success + `dev-rc-cut-pass` status 기록 |
 | `dev-rc-cut` | `rc/YYYY-Wxx` branch 생성, RC tag |
 | `rc-post-merge-sync` | RC hotfix version bump/tag |
 | `rc-main-cut` | rc → main promotion PR 생성/auto-merge |

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -42,19 +42,44 @@
 | 핵심 steps | `bash scripts/bump-version.sh {version}{suffix}` · commit (`skip_ci` option) · `git tag v{version}{suffix}` · push |
 | Called by | `dev-staging-dev-cut-gate`, `dev-rc-cut`, `rc-post-merge-sync`, `main-deploy` |
 
-### `dev-rc-cut-gate-suite`
+### `shared-set-commit-status`
 
-Heavy integration test suite. 60분 예산.
+GitHub commit status 를 쓰는 low-level reusable workflow. Stage/signal mapping 은 하지 않는다.
 
 | 항목 | 값 |
 |------|----|
 | Trigger | `workflow_call` |
-| Inputs | `ref`: dev commit SHA |
-| Outputs | `status`: pass\|fail / `failed_jobs`: array |
-| Matrix | (app × scenario): `cuj-app-user × {happy, unhappy, chaos}` + `cuj-app-partner × {happy, unhappy, chaos}` + `integration-backend` + `integration-edge-functions` + `test-lab-smoke` |
-| Called by | `dev-rc-cut-gate` |
+| Inputs | `sha`, `context`, `state`: failure\|success\|pending, `target_url`, `description` |
+| Outputs | GitHub commit status |
+| Called by | `set-dev-soak-status`, `set-rc-soak-status`, cut-gate evaluators |
 
-> chaos 시나리오 미정의면 CUJ 로 추후 정의 (TBD).
+외부 workflow/AI agent 는 직접 호출하지 않는다. Public API 는 stage별 `set-*-soak-status` entry workflow 다.
+
+### `set-dev-soak-status`
+
+Dev soak status write API. `workflow_call` 과 `workflow_dispatch` 를 모두 지원한다.
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `workflow_call` + `workflow_dispatch` |
+| Inputs | `signal`: backend-simulator\|real-device\|app-ai-review, `state`, `sha`, `target_url`, `description` |
+| Mapping | `backend-simulator` → `dev-soak/backend-simulator`; `real-device` → `dev-soak/real-device`; `app-ai-review` → `dev-soak/app-ai-review` |
+| Steps | validate signal/state → context mapping → calls `shared-set-commit-status` |
+| Called by | `monitor-event-flow-*`, real-device workflow, AI agent, `dev-rc-cut-gate` |
+
+### `set-rc-soak-status`
+
+RC soak status write API. dev 와 signal set 이 다를 수 있으므로 별도 entry 로 둔다.
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `workflow_call` + `workflow_dispatch` |
+| Inputs | `signal`: backend-simulator\|real-device\|dogfooding, `state`, `sha`, `target_url`, `description` |
+| Mapping | `backend-simulator` → `rc-soak/backend-simulator`; `real-device` → `rc-soak/real-device`; `dogfooding` → `rc-soak/dogfooding` |
+| Steps | validate signal/state → context mapping → calls `shared-set-commit-status` |
+| Called by | `rc-deploy`, real-device workflow, AI agent, `rc-main-cut-gate` |
+
+Issue 는 audit/log surface 이며 gate 판정 source-of-truth 가 아니다.
 
 ### `auto-issue`
 
@@ -126,13 +151,15 @@ Cross-branch cherry-pick PR 자동 생성.
 
 | 항목 | 값 |
 |------|----|
-| Trigger | `push` to `dev` (= dev-staging-dev-cut PR merge 직후) |
-| Outputs | commit status `dev-rc-cut-pass` (success only) |
-| Steps | (1) calls `dev-rc-cut-gate-suite` (2) **success**: set commit status `dev-rc-cut-pass` (3) **failure**: `auto-issue` (P1, label `dev-rc-cut-gate-failure`, assignee=직전 dev-rc-cut-pass 이후 머지된 PR 작성자들). dev 는 broken 상태로 잠시 머묾, AI agent 가 fix PR 을 dev-staging 으로 normal flow 로 작성 → 다음 dev-staging-dev-cut → 다음 dev-rc-cut-gate 가 검증 |
-| Backoff | 같은 area 3회 연속 실패 시 `dev-rc-cut` 자동 차단 (다음 weekly cut PR 안 만듦) |
+| Trigger | `schedule` (cut 직전, TBD) + `workflow_dispatch` |
+| Inputs | optional `candidate_sha` (default: latest `origin/dev` HEAD) |
+| Outputs | commit status `dev-rc-cut-pass` (success only) + `dev-soak/*` success confirmations |
+| Steps | (1) latest `origin/dev` HEAD 를 candidate 로 선택 (2) candidate age >= 24h 확인 (3) `monitor-event-flow-hourly` success run >= 20, `monitor-event-flow-daily` success run >= 1 확인 (4) candidate 의 최신 `dev-soak/backend-simulator`, `dev-soak/real-device`, `dev-soak/app-ai-review` status 가 failure 가 아닌지 확인 (5) real-device/app AI review pass signal 확인 (6) 통과 시 `set-dev-soak-status` 로 `dev-soak/*` success 작성 + `shared-set-commit-status` 로 `dev-rc-cut-pass` success set |
+| Failure path | 조건 미충족이면 `dev-rc-cut-pass` 를 쓰지 않는다. 실패를 발견한 monitor/AI agent 가 이미 `dev-soak/*` failure 를 쓴다 |
 
-> **No auto-revert** — snapshot 모델: 실패 = no tag, dev keeps moving, 새 fix 가 자연스럽게 다음 dev-rc-cut-gate 에서 검증됨.
+> **No auto-revert** — snapshot 모델: 실패 = no `dev-rc-cut-pass`, dev keeps moving, 새 fix 가 자연스럽게 다음 dev-staging-dev-cut 후 새 candidate 로 검증됨.
 > **Naming** — `dev-rc-cut-pass` 가 canonical RC eligibility marker 이다. `rc-eligible` 은 현재 workflow/status 명칭이 아니다.
+> **SSOT** — dev soak 판정은 [../dev-soak-status-model.md](../dev-soak-status-model.md) 의 commit status + run history 를 따른다. GitHub Issue 는 사람이 보는 incident/audit surface 다.
 
 #### `dev-deploy`
 
@@ -149,7 +176,7 @@ Cross-branch cherry-pick PR 자동 생성.
 |------|----|
 | Trigger | schedule (`monitor-event-flow-hourly`, `monitor-event-flow-daily`) |
 | Branch/env | dev 를 계속 관찰. RC cut 후에는 RC env/Supabase branch 도 pre-main 검증 signal 로 사용 |
-| Outputs | event-flow simulation signal, issue/alert |
+| Outputs | event-flow simulation signal, `set-dev-soak-status(signal=backend-simulator,state=failure)`, issue/alert |
 | Note | promotion gate 자체가 아니라 지속 신호다. main deploy 를 대신하지 않는다 |
 
 ### rc
@@ -297,7 +324,8 @@ Cross-branch cherry-pick PR 자동 생성.
 
 - `pr-gate-core` 의 stage 별 `extra_steps` 명세
 - `version-bump` 의 commit 방식 (별도 commit vs squash inline)
-- `dev-rc-cut-gate-suite` matrix 분할 (60분 예산)
+- `set-dev-soak-status` / `set-rc-soak-status` 의 signal set 확정
+- real-device / app AI review 가 어떤 workflow 또는 agent 에서 pass/failure status 를 쓸지 확정
 - `dev-deploy` 가 실제로 맡을 dev deploy/smoke 범위
 - `rc-deploy` 의 Supabase branch seed data 와 event-flow simulation contract
 - CUJ chaos 시나리오 정의 (현재 미정의)
@@ -309,7 +337,8 @@ Cross-branch cherry-pick PR 자동 생성.
 ## 관련
 
 - [../branch-flow.md](../branch-flow.md) — workflow 가 흘러가는 branch 그림
-- [../test-strategy.md](../test-strategy.md) — pr-gate-core 와 dev-rc-cut-gate-suite 의 test 내용
+- [../test-strategy.md](../test-strategy.md) — pr-gate-core 와 dev soak signal 배치
+- [../dev-soak-status-model.md](../dev-soak-status-model.md) — dev soak commit status / run history SSOT
 - [../error-detection.md](../error-detection.md) — auto-issue 의 priority 와 채널
 - [../life-of-flag.md](../life-of-flag.md) — flag lifecycle
 - [../versioning.md](../versioning.md) — version-bump 의 suffix 진행

--- a/docs/infra/branch-strategy/test-strategy.md
+++ b/docs/infra/branch-strategy/test-strategy.md
@@ -1,6 +1,6 @@
 # Test Strategy
 
-4-stage 모델 (`dev-staging → dev → rc → main`) + flag staged rollout 환경에서, *어떤 테스트가 어느 단계에서 도는가* 의 단일 source. 빠른 검사 = `pr-gate` (각 단계), 무거운 검사 = `dev-rc-cut-gate` (dev 의 post-merge), 프로덕션 검증 = `deploy-android-*, deploy-ios-*` smoke + flag staged.
+4-stage 모델 (`dev-staging → dev → rc → main`) + flag staged rollout 환경에서, *어떤 테스트가 어느 단계에서 도는가* 의 단일 source. 빠른 검사 = branch별 `*-pr-gate`, 지속 소킹 = `monitor-event-flow-*`/real-device/app AI review, RC 후보 판정 = `dev-rc-cut-gate`, 프로덕션 검증 = `deploy-android-*, deploy-ios-*` smoke + flag staged.
 
 ## 단계별 게이트
 
@@ -8,11 +8,12 @@
 |------|--------|------|---------|
 | dev-staging 머지 전 | `dev-staging-pr-gate` (unit · lint · analyze · pgTAP · EF test · migration check · `expand-migrate-contract` · `flag-registration` · gitleaks) | < 10분 | auto-merge 보류 |
 | dev 머지 전 | `dev-pr-gate` (dev-staging-pr-gate 와 동일 — defensive) | < 10분 | dev-staging-dev-cut PR drop |
-| dev 머지 후 (자동) | `dev-rc-cut-gate` (CUJ matrix happy/unhappy/chaos · integration · e2e · Test Lab smoke) | 30-60분 | 자동 이슈 + AI fix flow via dev-staging. `dev-rc-cut-pass` 미부여 |
+| dev 머지 후 24h soak | `monitor-event-flow-*` + real-device/app AI review status writer | 24h | 실패 즉시 `dev-soak/*` failure status + release-blocker issue |
+| RC cut 직전 | `dev-rc-cut-gate` evaluator (24h run history + `dev-soak/*` status 확인) | 분 | `dev-rc-cut-pass` 미부여 |
 | rc 머지 전 (hotfix) | `rc-pr-gate` (pr-gate + mobile smoke) | < 15분 | hotfix PR drop |
 | main 머지 전 (rc → main) | `main-pr-gate` (pr-gate + `expand-migrate-contract` 재검증 + RC HEAD 의 `dev-rc-cut-pass` 확인 + `rc-main-cut-pass` marker 확인) | 분 | promotion PR 보류 |
 | rc → main PR | workflow auto-merge (모든 check 통과 시) | 분 | check 실패 시 PR hold + alert |
-| Backend/Web auto-deploy 후 | post-deploy smoke + Sentry/Crashlytics 알람 임계 | 분 | auto-rollback ([main-promotion.md](./main-promotion.md)) |
+| main deploy 후 | backend/web/mobile smoke + Sentry/Crashlytics 알람 임계 | 분 | rollback ([main-promotion.md](./main-promotion.md)) |
 | deploy-android-*, deploy-ios-* 후 | mobile build smoke (Fastlane upload 검증) | 시간 | retry 1회 → auto-issue + mobile 팀 |
 | Flag canary (allowlist) | Statsig metric gates | 며칠 | flag flip OFF |
 | Flag staged (5/25/100%) | Statsig one-sided sequential | 48h/72h/7일 | hold or rollback |
@@ -39,15 +40,25 @@
 
 `dev-staging-pr-gate` 와 동일한 test suite. 환경 차이로 인한 회귀만 잡는 defensive 검증. 대부분 통과.
 
-### dev-rc-cut-gate — Heavy Integration
+### dev soak signals
 
-dev 머지 후 자동 발동. 통과 시 commit 에 GitHub status `dev-rc-cut-pass` set + `backend-auto-deploy` + `web-auto-deploy` chain.
+dev 에 들어간 latest HEAD 만 RC candidate 로 평가한다. 새 dev commit 이 들어오면 candidate 와 24h soak clock 은 reset 된다.
 
-- CUJ (app_user, app_partner)
-- Integration tests (backend, edge functions)
-- Simulator happy/chaos 시나리오
-- 풀 e2e
-- Firebase Test Lab smoke (실 디바이스 다양성)
+| Signal | 실행자 | 실패 status | 성공 status |
+|--------|--------|-------------|-------------|
+| backend simulator | `monitor-event-flow-hourly`, `monitor-event-flow-daily` | `dev-soak/backend-simulator` failure 즉시 | `dev-rc-cut-gate` 가 run history 확인 후 success |
+| real device | Test Lab/실디바이스 workflow | `dev-soak/real-device` failure 즉시 | `dev-rc-cut-gate` 가 required signal 확인 후 success |
+| app AI review | AI agent | `dev-soak/app-ai-review` failure 즉시 | `dev-rc-cut-gate` 가 pass signal 확인 후 success |
+
+### dev-rc-cut-gate — Evaluator
+
+cut 직전 schedule/manual 로 실행한다. 통과 시 commit 에 GitHub status `dev-rc-cut-pass` 를 set 한다.
+
+- candidate age >= 24h
+- `monitor-event-flow-hourly` success run >= 20 since candidate
+- `monitor-event-flow-daily` success run >= 1 since candidate
+- candidate 의 최신 `dev-soak/*` status 가 failure 가 아님
+- real-device/app AI review required signal 충족
 
 상세: [dev-pipeline.md](./dev-pipeline.md)
 
@@ -78,18 +89,19 @@ RC 의 hotfix 만 받음. `pr-gate` + 추가 mobile smoke. 머지 시 `rc-post-m
 | 테스트 성격 | 배치 위치 | 이유 |
 |-------------|-----------|------|
 | 결정론적, < 10분 | `dev-staging-pr-gate` | PR 사이클 안 막음 |
-| flaky 또는 느림 (10분+) | `dev-rc-cut-gate` | PR 머지 게이트의 신뢰도 보호 |
-| 외부 의존성 (실 결제 등) | `dev-rc-cut-gate` + flag canary | 비용·side effect 통제 |
-| 부하/성능 | `dev-rc-cut-gate` (주 1회) or staged rollout 메트릭 | 매일 무거움 |
+| flaky 또는 느림 (10분+) | dev soak monitor / real-device workflow | PR 머지 게이트의 신뢰도 보호 |
+| 외부 의존성 (실 결제 등) | dev soak + flag canary | 비용·side effect 통제 |
+| 부하/성능 | scheduled monitor or staged rollout 메트릭 | 매일 무거움 |
 | backend ↔ mobile 계약 호환 | `expand-migrate-contract` CI + flag canary 메트릭 | 다층 안전망 |
-| 실 디바이스 다양성 | `dev-rc-cut-gate` 의 Firebase Test Lab | 시뮬레이터 한계 보완 |
+| 실 디바이스 다양성 | real-device workflow + `dev-soak/real-device` status | 시뮬레이터 한계 보완 |
 | Mobile 회귀 (deploy 직후) | `deploy-android-*, deploy-ios-*` 의 build smoke | store upload 전 마지막 |
 
 ## 결정해야 할 것
 
 - nightly cron 시각
 - 부하 테스트 도구 (k6 / Artillery / 자체)
-- mobile smoke 5개 핵심 경로 정의
+- mobile smoke 5개 핵심 경로 정의 + `dev-soak/real-device` status writer
+- AI app soak pass/fail status writer 구현
 - 카나리 cohort 정의 (내부 직원 group)
 - `expand-migrate-contract` 구현 디테일 (Option C: DB schema only)
 


### PR DESCRIPTION
## Summary
- Document dev soak as commit status + workflow run history, not GitHub issue/label SSOT
- Define shared-set-commit-status plus set-dev-soak-status / set-rc-soak-status workflow API contracts
- Update branch strategy, workflow, release bot, error detection, and test strategy docs to match the evaluator model

## Validation
- git diff --check
- stale terminology search for old dev-rc-cut-gate-suite / backend-auto-deploy wording