### PR TITLE
ci: add soak status writer workflows

### DIFF
--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -58,4 +58,4 @@
 - [CLAUDE.md](../../CLAUDE.md) `## PR Conventions` — branch별 required check / auto-merge 흐름
 
 ---
-_Reviewed: 2026-05-24 16:30_
+_Reviewed: 2026-05-24 16:31_

--- a/.github/workflows/set-dev-soak-status.yml
+++ b/.github/workflows/set-dev-soak-status.yml
@@ -1,0 +1,140 @@
+name: set-dev-soak-status
+
+on:
+  workflow_call:
+    inputs:
+      signal:
+        type: string
+        required: true
+        description: 'Dev soak signal. Allowed: backend-simulator, real-device, app-ai-review.'
+      state:
+        type: string
+        required: true
+        description: 'Commit status state. Allowed: failure, pending, success.'
+      sha:
+        type: string
+        required: true
+        description: 'Full dev commit SHA to attach the status to.'
+      target_url:
+        type: string
+        required: false
+        default: ''
+        description: 'Optional run, artifact, screenshot, or review URL.'
+      description:
+        type: string
+        required: false
+        default: ''
+        description: 'Optional short status description.'
+    outputs:
+      context:
+        description: 'Mapped commit status context.'
+        value: ${{ jobs.map-dev-soak-status.outputs.context }}
+    secrets:
+      MINGLIT_RELEASE_BOT_APP_ID:
+        required: false
+        description: 'Fallback GitHub App ID for minglit-release-bot.'
+      MINGLIT_RELEASE_BOT_PRIVATE_KEY:
+        required: false
+        description: 'Fallback GitHub App private key for minglit-release-bot.'
+  workflow_dispatch:
+    inputs:
+      signal:
+        description: Dev soak signal.
+        required: true
+        type: choice
+        options:
+          - backend-simulator
+          - real-device
+          - app-ai-review
+      state:
+        description: Commit status state.
+        required: true
+        type: choice
+        options:
+          - failure
+          - pending
+          - success
+      sha:
+        description: Full dev commit SHA to attach the status to.
+        required: true
+        type: string
+      target_url:
+        description: Optional run, artifact, screenshot, or review URL.
+        required: false
+        type: string
+      description:
+        description: Optional short status description.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  statuses: write
+
+jobs:
+  map-dev-soak-status:
+    name: map-dev-soak-status
+    runs-on: ubuntu-latest
+    outputs:
+      context: ${{ steps.map.outputs.context }}
+      description: ${{ steps.map.outputs.description }}
+      target_url: ${{ steps.map.outputs.target_url }}
+    steps:
+      - name: Map dev soak signal to status context
+        id: map
+        env:
+          INPUT_SIGNAL: ${{ inputs.signal }}
+          INPUT_STATE: ${{ inputs.state }}
+          INPUT_TARGET_URL: ${{ inputs.target_url || '' }}
+          INPUT_DESCRIPTION: ${{ inputs.description || '' }}
+        run: |
+          set -euo pipefail
+
+          case "${INPUT_SIGNAL}" in
+            backend-simulator) CONTEXT="dev-soak/backend-simulator" ;;
+            real-device) CONTEXT="dev-soak/real-device" ;;
+            app-ai-review) CONTEXT="dev-soak/app-ai-review" ;;
+            *)
+              echo "::error::signal must be one of: backend-simulator, real-device, app-ai-review."
+              exit 1
+              ;;
+          esac
+
+          case "${INPUT_STATE}" in
+            failure|pending|success) ;;
+            *)
+              echo "::error::state must be one of: failure, pending, success."
+              exit 1
+              ;;
+          esac
+
+          DESCRIPTION="${INPUT_DESCRIPTION}"
+          if [ -z "${DESCRIPTION}" ]; then
+            DESCRIPTION="${CONTEXT}: ${INPUT_STATE}"
+          fi
+          DESCRIPTION="${DESCRIPTION//$'\r'/ }"
+          DESCRIPTION="${DESCRIPTION//$'\n'/ }"
+
+          TARGET_URL="${INPUT_TARGET_URL}"
+          if [ -z "${TARGET_URL}" ]; then
+            TARGET_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          fi
+
+          echo "context=${CONTEXT}" >> "${GITHUB_OUTPUT}"
+          echo "description=${DESCRIPTION}" >> "${GITHUB_OUTPUT}"
+          echo "target_url=${TARGET_URL}" >> "${GITHUB_OUTPUT}"
+
+  write-dev-soak-status:
+    name: write-dev-soak-status
+    needs: map-dev-soak-status
+    uses: ./.github/workflows/shared-set-commit-status.yml
+    permissions:
+      contents: read
+      statuses: write
+    secrets: inherit
+    with:
+      sha: ${{ inputs.sha }}
+      context: ${{ needs.map-dev-soak-status.outputs.context }}
+      state: ${{ inputs.state }}
+      target_url: ${{ needs.map-dev-soak-status.outputs.target_url }}
+      description: ${{ needs.map-dev-soak-status.outputs.description }}

--- a/.github/workflows/set-rc-soak-status.yml
+++ b/.github/workflows/set-rc-soak-status.yml
@@ -1,0 +1,140 @@
+name: set-rc-soak-status
+
+on:
+  workflow_call:
+    inputs:
+      signal:
+        type: string
+        required: true
+        description: 'RC soak signal. Allowed: backend-simulator, real-device, dogfooding.'
+      state:
+        type: string
+        required: true
+        description: 'Commit status state. Allowed: failure, pending, success.'
+      sha:
+        type: string
+        required: true
+        description: 'Full RC commit SHA to attach the status to.'
+      target_url:
+        type: string
+        required: false
+        default: ''
+        description: 'Optional run, artifact, screenshot, or review URL.'
+      description:
+        type: string
+        required: false
+        default: ''
+        description: 'Optional short status description.'
+    outputs:
+      context:
+        description: 'Mapped commit status context.'
+        value: ${{ jobs.map-rc-soak-status.outputs.context }}
+    secrets:
+      MINGLIT_RELEASE_BOT_APP_ID:
+        required: false
+        description: 'Fallback GitHub App ID for minglit-release-bot.'
+      MINGLIT_RELEASE_BOT_PRIVATE_KEY:
+        required: false
+        description: 'Fallback GitHub App private key for minglit-release-bot.'
+  workflow_dispatch:
+    inputs:
+      signal:
+        description: RC soak signal.
+        required: true
+        type: choice
+        options:
+          - backend-simulator
+          - real-device
+          - dogfooding
+      state:
+        description: Commit status state.
+        required: true
+        type: choice
+        options:
+          - failure
+          - pending
+          - success
+      sha:
+        description: Full RC commit SHA to attach the status to.
+        required: true
+        type: string
+      target_url:
+        description: Optional run, artifact, screenshot, or review URL.
+        required: false
+        type: string
+      description:
+        description: Optional short status description.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  statuses: write
+
+jobs:
+  map-rc-soak-status:
+    name: map-rc-soak-status
+    runs-on: ubuntu-latest
+    outputs:
+      context: ${{ steps.map.outputs.context }}
+      description: ${{ steps.map.outputs.description }}
+      target_url: ${{ steps.map.outputs.target_url }}
+    steps:
+      - name: Map RC soak signal to status context
+        id: map
+        env:
+          INPUT_SIGNAL: ${{ inputs.signal }}
+          INPUT_STATE: ${{ inputs.state }}
+          INPUT_TARGET_URL: ${{ inputs.target_url || '' }}
+          INPUT_DESCRIPTION: ${{ inputs.description || '' }}
+        run: |
+          set -euo pipefail
+
+          case "${INPUT_SIGNAL}" in
+            backend-simulator) CONTEXT="rc-soak/backend-simulator" ;;
+            real-device) CONTEXT="rc-soak/real-device" ;;
+            dogfooding) CONTEXT="rc-soak/dogfooding" ;;
+            *)
+              echo "::error::signal must be one of: backend-simulator, real-device, dogfooding."
+              exit 1
+              ;;
+          esac
+
+          case "${INPUT_STATE}" in
+            failure|pending|success) ;;
+            *)
+              echo "::error::state must be one of: failure, pending, success."
+              exit 1
+              ;;
+          esac
+
+          DESCRIPTION="${INPUT_DESCRIPTION}"
+          if [ -z "${DESCRIPTION}" ]; then
+            DESCRIPTION="${CONTEXT}: ${INPUT_STATE}"
+          fi
+          DESCRIPTION="${DESCRIPTION//$'\r'/ }"
+          DESCRIPTION="${DESCRIPTION//$'\n'/ }"
+
+          TARGET_URL="${INPUT_TARGET_URL}"
+          if [ -z "${TARGET_URL}" ]; then
+            TARGET_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          fi
+
+          echo "context=${CONTEXT}" >> "${GITHUB_OUTPUT}"
+          echo "description=${DESCRIPTION}" >> "${GITHUB_OUTPUT}"
+          echo "target_url=${TARGET_URL}" >> "${GITHUB_OUTPUT}"
+
+  write-rc-soak-status:
+    name: write-rc-soak-status
+    needs: map-rc-soak-status
+    uses: ./.github/workflows/shared-set-commit-status.yml
+    permissions:
+      contents: read
+      statuses: write
+    secrets: inherit
+    with:
+      sha: ${{ inputs.sha }}
+      context: ${{ needs.map-rc-soak-status.outputs.context }}
+      state: ${{ inputs.state }}
+      target_url: ${{ needs.map-rc-soak-status.outputs.target_url }}
+      description: ${{ needs.map-rc-soak-status.outputs.description }}

--- a/.github/workflows/shared-set-commit-status.yml
+++ b/.github/workflows/shared-set-commit-status.yml
@@ -1,0 +1,103 @@
+name: shared-set-commit-status
+
+on:
+  workflow_call:
+    inputs:
+      sha:
+        type: string
+        required: true
+        description: 'Full commit SHA to attach the status to.'
+      context:
+        type: string
+        required: true
+        description: 'Commit status context, e.g. dev-soak/backend-simulator.'
+      state:
+        type: string
+        required: true
+        description: 'Commit status state. Allowed: failure, pending, success.'
+      target_url:
+        type: string
+        required: false
+        default: ''
+        description: 'Optional run, artifact, screenshot, or review URL.'
+      description:
+        type: string
+        required: false
+        default: ''
+        description: 'Optional short status description.'
+    secrets:
+      MINGLIT_RELEASE_BOT_APP_ID:
+        required: false
+        description: 'Fallback GitHub App ID for minglit-release-bot.'
+      MINGLIT_RELEASE_BOT_PRIVATE_KEY:
+        required: false
+        description: 'Fallback GitHub App private key for minglit-release-bot.'
+
+permissions:
+  contents: read
+  statuses: write
+
+jobs:
+  set-commit-status:
+    name: set-commit-status
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Generate release bot token
+        id: release-bot
+        uses: ./.github/actions/release-bot-token
+        with:
+          fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
+          fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Validate inputs and write commit status
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          INPUT_SHA: ${{ inputs.sha }}
+          INPUT_CONTEXT: ${{ inputs.context }}
+          INPUT_STATE: ${{ inputs.state }}
+          INPUT_TARGET_URL: ${{ inputs.target_url }}
+          INPUT_DESCRIPTION: ${{ inputs.description }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${INPUT_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::sha must be a full 40-character commit SHA."
+            exit 1
+          fi
+
+          if [ -z "${INPUT_CONTEXT}" ]; then
+            echo "::error::context is required."
+            exit 1
+          fi
+
+          case "${INPUT_STATE}" in
+            failure|pending|success) ;;
+            *)
+              echo "::error::state must be one of: failure, pending, success."
+              exit 1
+              ;;
+          esac
+
+          TARGET_URL="${INPUT_TARGET_URL}"
+          if [ -z "${TARGET_URL}" ]; then
+            TARGET_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          fi
+
+          DESCRIPTION="${INPUT_DESCRIPTION}"
+          if [ -z "${DESCRIPTION}" ]; then
+            DESCRIPTION="${INPUT_CONTEXT}: ${INPUT_STATE}"
+          fi
+          DESCRIPTION="${DESCRIPTION//$'\r'/ }"
+          DESCRIPTION="${DESCRIPTION//$'\n'/ }"
+          DESCRIPTION="${DESCRIPTION:0:140}"
+
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${INPUT_SHA}" \
+            --method POST \
+            -f state="${INPUT_STATE}" \
+            -f context="${INPUT_CONTEXT}" \
+            -f description="${DESCRIPTION}" \
+            -f target_url="${TARGET_URL}"


### PR DESCRIPTION
## Summary
- Add shared-set-commit-status reusable workflow using the minglit-release-bot token
- Add set-dev-soak-status public API mapping backend-simulator, real-device, app-ai-review to dev-soak/* contexts
- Add set-rc-soak-status public API mapping backend-simulator, real-device, dogfooding to rc-soak/* contexts

## Validation
- Parsed all .github/workflows/*.yml with python yaml.safe_load
- BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh
- git diff --check