### PR TITLE
ci: route workflow failures through shared notify

### DIFF
--- a/.github/workflows/deploy-dev-seed.yml
+++ b/.github/workflows/deploy-dev-seed.yml
@@ -62,8 +62,12 @@ jobs:
     needs: [seed]
     if: ${{ always() && needs.seed.result == 'failure' }}
     permissions:
+      actions: read
+      contents: read
       issues: write
+      statuses: write
     uses: ./.github/workflows/shared-notify.yml
     with:
-      success: ${{ needs.seed.result == 'success' }}
+      failed: ${{ needs.seed.result != 'success' }}
       workflow_name: 'Seed Dev'
+      severity: 'P0-critical'

--- a/.github/workflows/deploy-ios-partner.yml
+++ b/.github/workflows/deploy-ios-partner.yml
@@ -54,9 +54,13 @@ jobs:
     needs: [ios-deploy]
     if: always()
     permissions:
+      actions: read
+      contents: read
       issues: write
+      statuses: write
     uses: ./.github/workflows/shared-notify.yml
     with:
-      success: ${{ needs.ios-deploy.result == 'success' }}
+      failed: ${{ needs.ios-deploy.result != 'success' }}
       workflow_name: 'iOS Deploy Partner'
+      severity: 'P0-critical'
       job_results: '{"ios-deploy":"${{ needs.ios-deploy.result }}"}'

--- a/.github/workflows/deploy-ios-user.yml
+++ b/.github/workflows/deploy-ios-user.yml
@@ -53,9 +53,13 @@ jobs:
     needs: [ios-deploy]
     if: always()
     permissions:
+      actions: read
+      contents: read
       issues: write
+      statuses: write
     uses: ./.github/workflows/shared-notify.yml
     with:
-      success: ${{ needs.ios-deploy.result == 'success' }}
+      failed: ${{ needs.ios-deploy.result != 'success' }}
       workflow_name: 'iOS Deploy User'
+      severity: 'P0-critical'
       job_results: '{"ios-deploy":"${{ needs.ios-deploy.result }}"}'

--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -353,9 +353,13 @@ jobs:
     needs: [deploy]
     if: always()
     permissions:
+      actions: read
+      contents: read
       issues: write
+      statuses: write
     uses: ./.github/workflows/shared-notify.yml
     with:
-      success: ${{ needs.deploy.result == 'success' }}
+      failed: ${{ needs.deploy.result != 'success' }}
       workflow_name: 'Deploy Supabase Migrations'
+      severity: 'P0-critical'
       job_results: '{"deploy":"${{ needs.deploy.result }}"}'

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -221,8 +221,12 @@ jobs:
     needs: [deploy-app_user, deploy-landing_user, deploy-landing_partner, deploy-app_partner, deploy-mds_docs, smoke-test]
     if: always()
     permissions:
+      actions: read
+      contents: read
       issues: write
+      statuses: write
     uses: ./.github/workflows/shared-notify.yml
     with:
-      success: ${{ !contains(needs.*.result, 'failure') }}
+      failed: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
       workflow_name: 'Vercel Deploy'
+      severity: 'P0-critical'

--- a/.github/workflows/dev-rc-cut-gate.yml
+++ b/.github/workflows/dev-rc-cut-gate.yml
@@ -60,14 +60,20 @@ jobs:
     needs: [cuj-integration-user, cuj-integration-partner, set-dev-rc-cut-status]
     if: always()
     permissions:
+      actions: read
+      contents: read
       issues: write
+      statuses: write
     uses: ./.github/workflows/shared-notify.yml
     with:
-      success: >-
+      failed: >-
         ${{
-          needs.cuj-integration-user.result == 'success' &&
-          needs.cuj-integration-partner.result == 'success' &&
-          needs.set-dev-rc-cut-status.result == 'success'
+          (
+            needs.cuj-integration-user.result != 'success' ||
+            needs.cuj-integration-partner.result != 'success' ||
+            needs.set-dev-rc-cut-status.result != 'success'
+          )
         }}
       workflow_name: 'Dev RC Cut Gate'
+      severity: 'P1-high'
       job_results: '{"cuj-integration-user":"${{ needs.cuj-integration-user.result }}","cuj-integration-partner":"${{ needs.cuj-integration-partner.result }}","set-dev-rc-cut-status":"${{ needs.set-dev-rc-cut-status.result }}"}'

--- a/.github/workflows/dev-rc-cut.yml
+++ b/.github/workflows/dev-rc-cut.yml
@@ -204,17 +204,21 @@ jobs:
     needs: [plan, bump, tag-promo]
     if: always()
     permissions:
+      actions: read
+      contents: read
       issues: write
+      statuses: write
     uses: ./.github/workflows/shared-notify.yml
     with:
-      success: >-
+      failed: >-
         ${{
-          needs.plan.outputs.skipped == 'true' ||
+          needs.plan.outputs.skipped != 'true' &&
           (
-            needs.plan.result == 'success' &&
-            needs.bump.result == 'success' &&
-            needs.tag-promo.result == 'success'
+            needs.plan.result != 'success' ||
+            needs.bump.result != 'success' ||
+            needs.tag-promo.result != 'success'
           )
         }}
       workflow_name: 'Dev RC Cut'
+      severity: 'P1-high'
       job_results: '{"plan":"${{ needs.plan.result }}","bump":"${{ needs.bump.result }}","tag-promo":"${{ needs.tag-promo.result }}"}'

--- a/.github/workflows/dev-staging-dev-cut-gate.yml
+++ b/.github/workflows/dev-staging-dev-cut-gate.yml
@@ -86,13 +86,19 @@ jobs:
     needs: [calculate-version, bump]
     if: always()
     permissions:
+      actions: read
+      contents: read
       issues: write
+      statuses: write
     uses: ./.github/workflows/shared-notify.yml
     with:
-      success: >-
+      failed: >-
         ${{
-          (needs.calculate-version.result == 'success' || needs.calculate-version.result == 'skipped') &&
-          (needs.bump.result == 'success' || needs.bump.result == 'skipped')
+          (
+            (needs.calculate-version.result != 'success' && needs.calculate-version.result != 'skipped') ||
+            (needs.bump.result != 'success' && needs.bump.result != 'skipped')
+          )
         }}
       workflow_name: 'Dev-Staging Dev Cut Gate'
+      severity: 'P1-high'
       job_results: '{"calculate-version":"${{ needs.calculate-version.result }}","bump":"${{ needs.bump.result }}"}'

--- a/.github/workflows/dev-staging-dev-cut.yml
+++ b/.github/workflows/dev-staging-dev-cut.yml
@@ -153,9 +153,13 @@ jobs:
     needs: [create-dev-cut-pr]
     if: always()
     permissions:
+      actions: read
+      contents: read
       issues: write
+      statuses: write
     uses: ./.github/workflows/shared-notify.yml
     with:
-      success: ${{ needs.create-dev-cut-pr.result == 'success' || needs.create-dev-cut-pr.result == 'skipped' }}
+      failed: ${{ needs.create-dev-cut-pr.result != 'success' && needs.create-dev-cut-pr.result != 'skipped' }}
       workflow_name: 'Dev-Staging Dev Cut'
+      severity: 'P1-high'
       job_results: '{"create-dev-cut-pr":"${{ needs.create-dev-cut-pr.result }}"}'

--- a/.github/workflows/monitor-event-flow-daily.yml
+++ b/.github/workflows/monitor-event-flow-daily.yml
@@ -14,8 +14,27 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  resolve-dev-sha:
+    name: Resolve current dev HEAD
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      dev_sha: ${{ steps.resolve.outputs.dev_sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Resolve origin/dev
+        id: resolve
+        run: |
+          set -euo pipefail
+          git fetch origin dev --depth=1
+          echo "dev_sha=$(git rev-parse origin/dev)" >> "${GITHUB_OUTPUT}"
+
   seed-and-simulate:
     name: Seed + event-flow cascade (daily)
+    needs: [resolve-dev-sha]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -69,12 +88,22 @@ jobs:
           jq -e '.success == true' /tmp/sim_response.json
 
   notify-failure:
-    needs: [seed-and-simulate]
+    needs: [resolve-dev-sha, seed-and-simulate]
     if: always()
     permissions:
+      actions: read
+      contents: read
       issues: write
+      statuses: write
     uses: ./.github/workflows/shared-notify.yml
     with:
-      success: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+      failed: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
       workflow_name: 'monitor-event-flow-daily'
+      severity: 'P1-high'
+      job_results: '{"resolve-dev-sha":"${{ needs.resolve-dev-sha.result }}","seed-and-simulate":"${{ needs.seed-and-simulate.result }}"}'
+      stage: 'dev-soak'
+      signal: 'backend-simulator'
+      blocks_rc_cut: true
+      commit_sha: ${{ needs.resolve-dev-sha.outputs.dev_sha }}
+      status_description: 'monitor-event-flow-daily failed'
     secrets: inherit

--- a/.github/workflows/monitor-event-flow-hourly.yml
+++ b/.github/workflows/monitor-event-flow-hourly.yml
@@ -13,8 +13,27 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  resolve-dev-sha:
+    name: Resolve current dev HEAD
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      dev_sha: ${{ steps.resolve.outputs.dev_sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - name: Resolve origin/dev
+        id: resolve
+        run: |
+          set -euo pipefail
+          git fetch origin dev --depth=1
+          echo "dev_sha=$(git rev-parse origin/dev)" >> "${GITHUB_OUTPUT}"
+
   simulate:
     name: Run event-flow cascade (hourly smoke)
+    needs: [resolve-dev-sha]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -37,12 +56,22 @@ jobs:
           jq -e '.success == true' /tmp/sim_response.json
 
   notify-failure:
-    needs: [simulate]
+    needs: [resolve-dev-sha, simulate]
     if: always()
     permissions:
+      actions: read
+      contents: read
       issues: write
+      statuses: write
     uses: ./.github/workflows/shared-notify.yml
     with:
-      success: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+      failed: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
       workflow_name: 'monitor-event-flow-hourly'
+      severity: 'P1-high'
+      job_results: '{"resolve-dev-sha":"${{ needs.resolve-dev-sha.result }}","simulate":"${{ needs.simulate.result }}"}'
+      stage: 'dev-soak'
+      signal: 'backend-simulator'
+      blocks_rc_cut: true
+      commit_sha: ${{ needs.resolve-dev-sha.outputs.dev_sha }}
+      status_description: 'monitor-event-flow-hourly failed'
     secrets: inherit

--- a/.github/workflows/monitor-security-advisor.yml
+++ b/.github/workflows/monitor-security-advisor.yml
@@ -202,9 +202,13 @@ jobs:
     needs: [audit]
     if: always() && needs.audit.result == 'failure'
     permissions:
+      actions: read
+      contents: read
       issues: write
+      statuses: write
     uses: ./.github/workflows/shared-notify.yml
     with:
-      success: false
+      failed: true
       workflow_name: 'Supabase Security/Performance Advisor Audit'
+      severity: 'P1-high'
       job_results: '{"audit":"${{ needs.audit.result }}"}'

--- a/.github/workflows/rc-main-cut-gate.yml
+++ b/.github/workflows/rc-main-cut-gate.yml
@@ -117,9 +117,13 @@ jobs:
     needs: [mark-main-cut-eligible]
     if: always()
     permissions:
+      actions: read
+      contents: read
       issues: write
+      statuses: write
     uses: ./.github/workflows/shared-notify.yml
     with:
-      success: ${{ needs.mark-main-cut-eligible.result == 'success' || needs.mark-main-cut-eligible.outputs.skipped == 'true' }}
+      failed: ${{ needs.mark-main-cut-eligible.result != 'success' && needs.mark-main-cut-eligible.outputs.skipped != 'true' }}
       workflow_name: 'RC Main Cut Gate'
+      severity: 'P1-high'
       job_results: '{"mark-main-cut-eligible":"${{ needs.mark-main-cut-eligible.result }}"}'

--- a/.github/workflows/rc-main-cut.yml
+++ b/.github/workflows/rc-main-cut.yml
@@ -154,9 +154,13 @@ jobs:
     needs: [create-main-pr]
     if: always()
     permissions:
+      actions: read
+      contents: read
       issues: write
+      statuses: write
     uses: ./.github/workflows/shared-notify.yml
     with:
-      success: ${{ needs.create-main-pr.result == 'success' || needs.create-main-pr.outputs.skipped == 'true' }}
+      failed: ${{ needs.create-main-pr.result != 'success' && needs.create-main-pr.outputs.skipped != 'true' }}
       workflow_name: 'RC Main Cut'
+      severity: 'P1-high'
       job_results: '{"create-main-pr":"${{ needs.create-main-pr.result }}"}'

--- a/.github/workflows/shared-android-deploy.yml
+++ b/.github/workflows/shared-android-deploy.yml
@@ -242,8 +242,12 @@ jobs:
     needs: [build]
     if: always()
     permissions:
+      actions: read
+      contents: read
       issues: write
+      statuses: write
     uses: ./.github/workflows/shared-notify.yml
     with:
-      success: ${{ needs.build.result == 'success' }}
+      failed: ${{ needs.build.result != 'success' }}
       workflow_name: ${{ inputs.notify-workflow-name }}
+      severity: 'P0-critical'

--- a/.github/workflows/shared-notify.yml
+++ b/.github/workflows/shared-notify.yml
@@ -3,79 +3,200 @@ name: shared-notify
 on:
   workflow_call:
     inputs:
-      success:
+      failed:
         type: boolean
         required: true
-        description: Whether the workflow succeeded
+        description: 'Whether the caller workflow failed.'
       workflow_name:
         type: string
         required: true
-        description: Name of the workflow that ran
+        description: 'Name of the workflow that ran.'
+      severity:
+        type: string
+        required: true
+        description: 'Issue priority label, e.g. P0-critical or P1-high.'
       job_results:
         type: string
         required: false
         default: ''
-        description: 'JSON string of job results, e.g. {"build":"success","test":"failure"}'
-      create_issue:
+        description: 'JSON string of job results, e.g. {"build":"success","test":"failure"}.'
+      stage:
+        type: string
+        required: false
+        default: ''
+        description: 'Optional release signal stage, e.g. dev-soak.'
+      signal:
+        type: string
+        required: false
+        default: ''
+        description: 'Optional release signal name, e.g. backend-simulator.'
+      blocks_rc_cut:
         type: boolean
         required: false
-        default: true
-        description: 'Whether to create/comment a GitHub issue on failure. Set false for PR-triggered workflows to avoid noise.'
+        default: false
+        description: 'If true, write a dev-soak failure status for the target commit.'
+      commit_sha:
+        type: string
+        required: false
+        default: ''
+        description: 'Target commit SHA for release signal status. Defaults to github.sha.'
+      target_url:
+        type: string
+        required: false
+        default: ''
+        description: 'Optional status target URL. Defaults to this workflow run.'
+      status_description:
+        type: string
+        required: false
+        default: ''
+        description: 'Optional commit status description.'
 
 jobs:
+  set-dev-soak-failure:
+    if: ${{ inputs.failed && inputs.blocks_rc_cut && inputs.stage == 'dev-soak' }}
+    uses: ./.github/workflows/set-dev-soak-status.yml
+    permissions:
+      contents: read
+      statuses: write
+    secrets: inherit
+    with:
+      signal: ${{ inputs.signal }}
+      state: failure
+      sha: ${{ inputs.commit_sha || github.sha }}
+      target_url: ${{ inputs.target_url || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
+      description: ${{ inputs.status_description || format('{0} failed', inputs.workflow_name) }}
+
   notify:
+    needs: [set-dev-soak-failure]
+    if: always()
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       issues: write
     steps:
-      - name: Create or comment on issue for CI failure
+      - name: Create or update failure issue
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JOB_RESULTS: ${{ inputs.job_results }}
-        continue-on-error: true
+          GH_TOKEN: ${{ github.token }}
+          INPUT_FAILED: ${{ inputs.failed }}
+          INPUT_WORKFLOW_NAME: ${{ inputs.workflow_name }}
+          INPUT_SEVERITY: ${{ inputs.severity }}
+          INPUT_JOB_RESULTS: ${{ inputs.job_results }}
+          INPUT_STAGE: ${{ inputs.stage }}
+          INPUT_SIGNAL: ${{ inputs.signal }}
+          INPUT_BLOCKS_RC_CUT: ${{ inputs.blocks_rc_cut }}
+          INPUT_COMMIT_SHA: ${{ inputs.commit_sha || github.sha }}
+          INPUT_TARGET_URL: ${{ inputs.target_url || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
+          PR_NUMBER: ${{ github.event.pull_request.number || '' }}
+          PR_TITLE: ${{ github.event.pull_request.title || '' }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
+          BASE_REF: ${{ github.event.pull_request.base.ref || '' }}
         run: |
-          TITLE="🚨 ${{ inputs.workflow_name }} failed on ${{ github.ref_name }}"
-          BODY="**Workflow**: ${{ inputs.workflow_name }}
-          **Branch**: ${{ github.ref_name }}
-          **Commit**: ${{ github.sha }}
-          **Run**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          **Triggered by**: ${{ github.event.head_commit.message || github.event.pull_request.title || 'N/A' }}
-          **Actor**: ${{ github.actor }}"
+          set -euo pipefail
 
-          if [ -n "$JOB_RESULTS" ]; then
-            JOB_LOG=$(echo "$JOB_RESULTS" | python3 -c "
-          import sys, json
+          if [ "${INPUT_FAILED}" != "true" ]; then
+            echo "Caller did not fail; skipping notification."
+            exit 0
+          fi
+
+          TITLE="[${INPUT_SEVERITY}] ${INPUT_WORKFLOW_NAME} failed on ${{ github.ref_name }}"
+          if [ -n "${INPUT_STAGE}" ] && [ -n "${INPUT_SIGNAL}" ]; then
+            TITLE="[${INPUT_SEVERITY}] ${INPUT_STAGE}/${INPUT_SIGNAL}: ${INPUT_WORKFLOW_NAME} failed on ${{ github.ref_name }}"
+          fi
+
+          JOB_LOG="(not provided)"
+          if [ -n "${INPUT_JOB_RESULTS}" ]; then
+            JOB_LOG="$(echo "${INPUT_JOB_RESULTS}" | python3 -c "
+          import json, sys
           try:
-            data = json.load(sys.stdin)
-            for k, v in data.items():
-              icon = '✅' if v == 'success' else '⏭️' if v == 'skipped' else '❌'
-              print(f'  {icon} {k}: {v}')
-          except: pass
-          " 2>/dev/null || echo "  (parse error)")
-            BODY="${BODY}
-
-          **Job Results**:
-          ${JOB_LOG}"
+              data = json.load(sys.stdin)
+              for key, value in data.items():
+                  icon = 'PASS' if value == 'success' else 'SKIP' if value == 'skipped' else 'FAIL'
+                  print(f'- {icon} {key}: {value}')
+          except Exception as exc:
+              print(f'- parse error: {exc}')
+          " 2>/dev/null || echo "- parse error")"
           fi
 
-          if [ "${{ inputs.success }}" = "true" ]; then
-            echo "✅ Workflow succeeded, no issue needed."
-            exit 0
+          LOG_TAIL_FILE="$(mktemp)"
+          if gh run view "${GITHUB_RUN_ID}" --log-failed > "${LOG_TAIL_FILE}" 2>/tmp/shared-notify-log-error; then
+            FAILED_LOG_TAIL="$(tail -n 200 "${LOG_TAIL_FILE}")"
+          else
+            FAILED_LOG_TAIL="Failed log tail unavailable. $(cat /tmp/shared-notify-log-error 2>/dev/null || true)"
           fi
 
-          if [ "${{ inputs.create_issue }}" = "false" ]; then
-            echo "ℹ️ create_issue=false — skipping issue creation for PR-triggered workflow."
-            exit 0
-          fi
+          BODY_FILE="$(mktemp)"
+          {
+            echo "## Failure"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Workflow | ${INPUT_WORKFLOW_NAME} |"
+            echo "| Branch | ${{ github.ref_name }} |"
+            echo "| Commit | ${INPUT_COMMIT_SHA} |"
+            echo "| Run | ${INPUT_TARGET_URL} |"
+            echo "| Actor | ${{ github.actor }} |"
+            if [ -n "${PR_NUMBER}" ]; then
+              echo "| PR | #${PR_NUMBER} ${PR_TITLE} |"
+              echo "| PR refs | ${HEAD_REF} -> ${BASE_REF} |"
+            fi
+            if [ -n "${INPUT_STAGE}" ] || [ -n "${INPUT_SIGNAL}" ]; then
+              echo "| Release signal | ${INPUT_STAGE}/${INPUT_SIGNAL} |"
+              echo "| Blocks RC cut | ${INPUT_BLOCKS_RC_CUT} |"
+            fi
+            echo ""
+            echo "## Job Results"
+            echo ""
+            echo "${JOB_LOG}"
 
-          echo "::warning::Workflow failed. Creating/updating issue."
+            if [ -n "${INPUT_STAGE}" ] || [ -n "${INPUT_SIGNAL}" ]; then
+              echo ""
+              echo "<!-- minglit-release-signal"
+              echo "stage: ${INPUT_STAGE}"
+              echo "signal: ${INPUT_SIGNAL}"
+              echo "workflow: ${INPUT_WORKFLOW_NAME}"
+              echo "branch: ${{ github.ref_name }}"
+              echo "commit: ${INPUT_COMMIT_SHA}"
+              echo "run_id: ${GITHUB_RUN_ID}"
+              echo "severity: ${INPUT_SEVERITY}"
+              echo "blocks_rc_cut: ${INPUT_BLOCKS_RC_CUT}"
+              echo "-->"
+            fi
+
+            echo ""
+            echo "## Failed Log Tail"
+            echo ""
+            echo '```text'
+            echo "${FAILED_LOG_TAIL}"
+            echo '```'
+          } > "${BODY_FILE}"
 
           REPO="${{ github.repository }}"
-          EXISTING=$(gh issue list --repo "$REPO" --search "\"${TITLE}\" in:title" --state open --label ci-failure --json number --jq '.[0].number' 2>/dev/null || echo "")
-          if [ -n "$EXISTING" ]; then
-            echo "🔁 Found existing issue #$EXISTING, adding comment..."
-            gh issue comment "$EXISTING" --repo "$REPO" --body "$BODY"
+          EXISTING="$(gh issue list \
+            --repo "${REPO}" \
+            --search "\"${TITLE}\" in:title" \
+            --state open \
+            --label ci-failure \
+            --json number \
+            --jq '.[0].number' 2>/dev/null || true)"
+
+          if [ -n "${EXISTING}" ]; then
+            echo "Found existing issue #${EXISTING}; adding comment."
+            gh issue comment "${EXISTING}" --repo "${REPO}" --body-file "${BODY_FILE}"
+            ISSUE_NUMBER="${EXISTING}"
           else
-            echo "🆕 Creating new issue..."
-            gh issue create --repo "$REPO" --title "$TITLE" --body "$BODY" --label "ci-failure" --label "P0-critical"
+            echo "Creating new issue."
+            ISSUE_URL="$(gh issue create \
+              --repo "${REPO}" \
+              --title "${TITLE}" \
+              --body-file "${BODY_FILE}" \
+              --label ci-failure \
+              --label "${INPUT_SEVERITY}")"
+            ISSUE_NUMBER="${ISSUE_URL##*/}"
+          fi
+
+          if [ -n "${INPUT_STAGE}" ]; then
+            gh issue edit "${ISSUE_NUMBER}" --repo "${REPO}" --add-label "${INPUT_STAGE}" || true
+          fi
+          if [ -n "${INPUT_SIGNAL}" ]; then
+            gh issue edit "${ISSUE_NUMBER}" --repo "${REPO}" --add-label "${INPUT_SIGNAL}" || true
           fi

--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -65,13 +65,19 @@ jobs:
     needs: [calculate-version, bump]
     if: always()
     permissions:
+      actions: read
+      contents: read
       issues: write
+      statuses: write
     uses: ./.github/workflows/shared-notify.yml
     with:
-      success: >-
+      failed: >-
         ${{
-          (needs.calculate-version.result == 'success' || needs.calculate-version.result == 'skipped') &&
-          (needs.bump.result == 'success' || needs.bump.result == 'skipped')
+          (
+            (needs.calculate-version.result != 'success' && needs.calculate-version.result != 'skipped') ||
+            (needs.bump.result != 'success' && needs.bump.result != 'skipped')
+          )
         }}
       workflow_name: 'Version Bump'
+      severity: 'P1-high'
       job_results: '{"calculate-version":"${{ needs.calculate-version.result }}","bump":"${{ needs.bump.result }}"}'


### PR DESCRIPTION
## Summary
- Replace shared-notify success/create_issue contract with failure-first failed/severity inputs
- Update all shared-notify callers to the new contract
- Add richer failure issues with PR/run/commit metadata and failed log tail
- Wire monitor-event-flow-hourly/daily failures to dev-soak/backend-simulator commit status on latest dev HEAD

## Validation
- Parsed all .github/workflows/*.yml with python yaml.safe_load
- BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh
- git diff --check