### PR TITLE
ci: convert dev rc gate to soak evaluator

### DIFF
--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -20,7 +20,7 @@
 | `triage-` | 이슈 생성·슬래시 명령 (commit 없음) | `triage-mds-issue`, `triage-slash` |
 | `post-merge` | dev push 직후 follow-up 자동화의 단일 entry point (5 reusable orchestrator) | `post-merge` |
 | `tool-` | (수동으로 부를 때만 도는 도구) | (현재 없음 — 새 수동 도구 추가 시 prefix) |
-| `shared-` | (다른 워크플로우의 부품 — 단독 실행 X) | `shared-notify`, `shared-android-deploy`, `shared-set-commit-status` |
+| `shared-` | (다른 워크플로우의 부품 — 단독 실행 X) | `shared-notify`, `shared-android-deploy`, `shared-set-commit-status`, `shared-soak-gate` |
 | branch-strategy stage name | branch-strategy 문서의 stage entry workflow | `dev-staging-pr-gate`, `dev-staging-dev-cut-gate`, `dev-staging-dev-cut`, `dev-pr-gate`, `dev-rc-cut-gate`, `dev-rc-cut`, `rc-pr-gate`, `rc-main-cut-gate`, `rc-main-cut`, `main-pr-gate` |
 | reusable no-prefix | `workflow_call` 로만 호출되는 domain reusable | `version-bump` |
 
@@ -32,7 +32,7 @@
 - Branch ruleset 의 required check 는 `dev-staging-pr-gate`, `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 같은 branch별 wrapper job 이름을 사용한다. `ci-result` summary job 은 폐기한다.
 - `dev-staging-pr-gate`, `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 는 얇은 wrapper 로 시작한다. 내부에서는 `pr-gate.yml` reusable core 를 호출하고, wrapper job 이 최종 required check context 를 제공한다.
 - `dev-staging-dev-cut-gate` 가 dev-staging 의 PR-number CalVer bump/tag 를 담당한다. `sync-version` 은 legacy main release bump 만 담당하며, `dev` promotion 은 `dev-staging-dev-cut` 에서 version 변경 없이 처리한다.
-- `dev-rc-cut-gate` 는 cut 직전 evaluator 다. `set-dev-soak-status` 로 기록된 `dev-soak/*` status 와 monitor run history 를 확인하고, 통과한 commit 에만 `dev-rc-cut-pass` status 를 찍는다.
+- `dev-rc-cut-gate` 는 cut 직전 evaluator 다. 내부에서 `shared-soak-gate` 를 호출해 `dev-soak/*` status 와 monitor run history 를 확인하고, 통과한 commit 에만 `dev-rc-cut-pass` status 를 찍는다.
 - `dev-rc-cut` 은 latest `dev-rc-cut-pass` dev commit 에서 `rc/YYYY-Wxx` branch 를 만들고 `version-bump` 로 `v*-rc-01` + `promo/rc-*` tag 를 생성한다.
 - `rc-main-cut-gate` 는 5일 soak 를 통과한 `rc/*` 에 `rc-main-cut-pass` 를 찍고, `rc-main-cut` 은 그 marker 를 소비해 `main` PR 을 만든다.
 - deploy entry 는 후속 단계에서 `[branch]-deploy` 로 통일한다 (`dev-deploy`, `rc-deploy`, `main-deploy`). `monitor-event-flow-*` 는 deploy 가 아니라 지속 batch signal 이다.
@@ -58,4 +58,4 @@
 - [CLAUDE.md](../../CLAUDE.md) `## PR Conventions` — branch별 required check / auto-merge 흐름
 
 ---
-_Reviewed: 2026-05-24 16:31_
+_Reviewed: 2026-05-24 16:45_

--- a/.github/workflows/dev-rc-cut-gate.yml
+++ b/.github/workflows/dev-rc-cut-gate.yml
@@ -1,63 +1,54 @@
 name: dev-rc-cut-gate
 
 on:
-  push:
-    branches: [ "dev" ]
+  schedule:
+    # 01:30 KST daily, before dev-rc-cut.
+    - cron: '30 16 * * *'
   workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: Optional full dev candidate SHA. Defaults to latest origin/dev.
+        required: false
+        type: string
+      min_soak_hours:
+        description: Minimum candidate age in hours.
+        required: false
+        type: string
+        default: '24'
 
 concurrency:
-  group: dev-rc-cut-gate-${{ github.ref }}
+  group: dev-rc-cut-gate
   cancel-in-progress: false
 
 permissions:
+  actions: read
   contents: read
-  statuses: write
   issues: write
+  statuses: write
 
 jobs:
-  cuj-integration-user:
-    name: cuj-integration-user
-    uses: ./.github/workflows/shared-cuj-integration.yml
+  evaluate-dev-soak:
+    name: evaluate-dev-soak
+    uses: ./.github/workflows/shared-soak-gate.yml
     with:
-      app-name: user
+      candidate_ref: dev
+      candidate_sha: ${{ inputs.candidate_sha || '' }}
+      min_soak_hours: ${{ inputs.min_soak_hours || '24' }}
+      required_runs_json: >-
+        [
+          {"workflow":"monitor-event-flow-hourly.yml","branch":"dev-staging","min_success":20},
+          {"workflow":"monitor-event-flow-daily.yml","branch":"dev-staging","min_success":1}
+        ]
+      failure_contexts: |
+        dev-soak/backend-simulator
+      success_contexts: |
+        dev-soak/backend-simulator
+      pass_context: dev-rc-cut-pass
+      pass_description: 'dev-rc-cut-gate passed; this dev commit can be cut to RC'
     secrets: inherit
-
-  cuj-integration-partner:
-    name: cuj-integration-partner
-    uses: ./.github/workflows/shared-cuj-integration.yml
-    with:
-      app-name: partner
-    secrets: inherit
-
-  set-dev-rc-cut-status:
-    name: set-dev-rc-cut-status
-    needs: [cuj-integration-user, cuj-integration-partner]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Mark commit as RC eligible
-        if: ${{ needs.cuj-integration-user.result == 'success' && needs.cuj-integration-partner.result == 'success' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          gh api "repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}" \
-            --method POST \
-            -f state=success \
-            -f context=dev-rc-cut-pass \
-            -f description="dev-rc-cut-gate passed; this dev commit can be cut to RC" \
-            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-
-      - name: Fail dev-rc-cut-gate without publishing dev-rc-cut-pass
-        if: ${{ needs.cuj-integration-user.result != 'success' || needs.cuj-integration-partner.result != 'success' }}
-        run: |
-          echo "::error::dev-rc-cut-gate failed; dev-rc-cut-pass status was not set."
-          echo "cuj-integration-user=${{ needs.cuj-integration-user.result }}"
-          echo "cuj-integration-partner=${{ needs.cuj-integration-partner.result }}"
-          exit 1
 
   notify-failure:
-    needs: [cuj-integration-user, cuj-integration-partner, set-dev-rc-cut-status]
+    needs: [evaluate-dev-soak]
     if: always()
     permissions:
       actions: read
@@ -66,14 +57,8 @@ jobs:
       statuses: write
     uses: ./.github/workflows/shared-notify.yml
     with:
-      failed: >-
-        ${{
-          (
-            needs.cuj-integration-user.result != 'success' ||
-            needs.cuj-integration-partner.result != 'success' ||
-            needs.set-dev-rc-cut-status.result != 'success'
-          )
-        }}
+      failed: ${{ needs.evaluate-dev-soak.result != 'success' }}
       workflow_name: 'Dev RC Cut Gate'
       severity: 'P1-high'
-      job_results: '{"cuj-integration-user":"${{ needs.cuj-integration-user.result }}","cuj-integration-partner":"${{ needs.cuj-integration-partner.result }}","set-dev-rc-cut-status":"${{ needs.set-dev-rc-cut-status.result }}"}'
+      job_results: '{"evaluate-dev-soak":"${{ needs.evaluate-dev-soak.result }}","skipped":"${{ needs.evaluate-dev-soak.outputs.skipped }}","reason":"${{ needs.evaluate-dev-soak.outputs.reason }}","candidate_sha":"${{ needs.evaluate-dev-soak.outputs.candidate_sha }}"}'
+    secrets: inherit

--- a/.github/workflows/shared-notify.yml
+++ b/.github/workflows/shared-notify.yml
@@ -3,6 +3,7 @@ name: shared-notify
 on:
   workflow_call:
     inputs:
+      # Failure-first contract: callers pass `failed=true` only when notification is needed.
       failed:
         type: boolean
         required: true

--- a/.github/workflows/shared-soak-gate.yml
+++ b/.github/workflows/shared-soak-gate.yml
@@ -1,0 +1,226 @@
+name: shared-soak-gate
+
+on:
+  workflow_call:
+    inputs:
+      candidate_ref:
+        type: string
+        required: true
+        description: 'Remote branch/ref to evaluate when candidate_sha is empty, e.g. dev or rc/2026-W22.'
+      candidate_sha:
+        type: string
+        required: false
+        default: ''
+        description: 'Optional full candidate SHA. If empty, origin/{candidate_ref} is used.'
+      min_soak_hours:
+        type: string
+        required: true
+        description: 'Minimum candidate age in hours.'
+      required_runs_json:
+        type: string
+        required: false
+        default: '[]'
+        description: 'JSON array of workflow run requirements.'
+      failure_contexts:
+        type: string
+        required: false
+        default: ''
+        description: 'Newline-separated commit status contexts that must not be failure.'
+      success_contexts:
+        type: string
+        required: false
+        default: ''
+        description: 'Newline-separated commit status contexts to mark success when eligible.'
+      pass_context:
+        type: string
+        required: true
+        description: 'Final pass marker context, e.g. dev-rc-cut-pass.'
+      pass_description:
+        type: string
+        required: true
+        description: 'Description for the final pass marker.'
+    outputs:
+      skipped:
+        description: 'true when candidate is not eligible yet.'
+        value: ${{ jobs.evaluate.outputs.skipped }}
+      reason:
+        description: 'Human-readable skip/pass reason.'
+        value: ${{ jobs.evaluate.outputs.reason }}
+      candidate_sha:
+        description: 'Evaluated candidate SHA.'
+        value: ${{ jobs.evaluate.outputs.candidate_sha }}
+    secrets:
+      MINGLIT_RELEASE_BOT_APP_ID:
+        required: false
+        description: 'Fallback GitHub App ID for minglit-release-bot.'
+      MINGLIT_RELEASE_BOT_PRIVATE_KEY:
+        required: false
+        description: 'Fallback GitHub App private key for minglit-release-bot.'
+
+permissions:
+  actions: read
+  contents: read
+  statuses: write
+
+jobs:
+  evaluate:
+    name: evaluate
+    runs-on: ubuntu-latest
+    outputs:
+      skipped: ${{ steps.evaluate.outputs.skipped }}
+      reason: ${{ steps.evaluate.outputs.reason }}
+      candidate_sha: ${{ steps.evaluate.outputs.candidate_sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Generate release bot token
+        id: release-bot
+        uses: ./.github/actions/release-bot-token
+        with:
+          fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
+          fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Evaluate soak gate and write pass markers
+        id: evaluate
+        env:
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          INPUT_CANDIDATE_REF: ${{ inputs.candidate_ref }}
+          INPUT_CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          INPUT_MIN_SOAK_HOURS: ${{ inputs.min_soak_hours }}
+          INPUT_REQUIRED_RUNS_JSON: ${{ inputs.required_runs_json }}
+          INPUT_FAILURE_CONTEXTS: ${{ inputs.failure_contexts }}
+          INPUT_SUCCESS_CONTEXTS: ${{ inputs.success_contexts }}
+          INPUT_PASS_CONTEXT: ${{ inputs.pass_context }}
+          INPUT_PASS_DESCRIPTION: ${{ inputs.pass_description }}
+        run: |
+          set -euo pipefail
+
+          skip() {
+            echo "skipped=true" >> "${GITHUB_OUTPUT}"
+            echo "reason=$1" >> "${GITHUB_OUTPUT}"
+            echo "::notice::$1"
+            exit 0
+          }
+
+          if ! [[ "${INPUT_MIN_SOAK_HOURS}" =~ ^[0-9]+$ ]]; then
+            echo "::error::min_soak_hours must be a non-negative integer."
+            exit 1
+          fi
+          if [ -z "${INPUT_PASS_CONTEXT}" ]; then
+            echo "::error::pass_context is required."
+            exit 1
+          fi
+
+          CANDIDATE_SHA="${INPUT_CANDIDATE_SHA}"
+          if [ -z "${CANDIDATE_SHA}" ]; then
+            git fetch origin "${INPUT_CANDIDATE_REF}" --depth=200
+            CANDIDATE_SHA="$(git rev-parse "origin/${INPUT_CANDIDATE_REF}")"
+          fi
+          if ! [[ "${CANDIDATE_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::candidate_sha must be a full 40-character commit SHA."
+            exit 1
+          fi
+
+          echo "candidate_sha=${CANDIDATE_SHA}" >> "${GITHUB_OUTPUT}"
+          if ! git cat-file -e "${CANDIDATE_SHA}^{commit}" 2>/dev/null; then
+            git fetch origin '+refs/heads/*:refs/remotes/origin/*' --depth=200
+          fi
+          if ! git cat-file -e "${CANDIDATE_SHA}^{commit}" 2>/dev/null; then
+            echo "::error::candidate_sha is not reachable from fetched refs: ${CANDIDATE_SHA}"
+            exit 1
+          fi
+
+          COMMIT_TS="$(git show -s --format=%ct "${CANDIDATE_SHA}")"
+          COMMIT_ISO="$(date -u -d "@${COMMIT_TS}" +%Y-%m-%dT%H:%M:%SZ)"
+          NOW_TS="$(date +%s)"
+          AGE_HOURS="$(( (NOW_TS - COMMIT_TS) / 3600 ))"
+          if [ "${AGE_HOURS}" -lt "${INPUT_MIN_SOAK_HOURS}" ]; then
+            skip "candidate ${CANDIDATE_SHA} age ${AGE_HOURS}h < ${INPUT_MIN_SOAK_HOURS}h"
+          fi
+
+          python3 - <<'PY' > /tmp/run_requirements.tsv
+          import json
+          import os
+          import sys
+
+          raw = os.environ["INPUT_REQUIRED_RUNS_JSON"].strip() or "[]"
+          try:
+              items = json.loads(raw)
+          except Exception as exc:
+              print(f"::error::required_runs_json is invalid JSON: {exc}", file=sys.stderr)
+              sys.exit(1)
+          if not isinstance(items, list):
+              print("::error::required_runs_json must be a JSON array.", file=sys.stderr)
+              sys.exit(1)
+          for item in items:
+              if not isinstance(item, dict):
+                  print("::error::each run requirement must be an object.", file=sys.stderr)
+                  sys.exit(1)
+              workflow = str(item.get("workflow", "")).strip()
+              branch = str(item.get("branch", "")).strip()
+              min_success = int(item.get("min_success", 0))
+              match_head_sha = bool(item.get("match_head_sha", False))
+              if not workflow or not branch or min_success < 0:
+                  print("::error::run requirement needs workflow, branch, min_success.", file=sys.stderr)
+                  sys.exit(1)
+              print(f"{workflow}\t{branch}\t{min_success}\t{str(match_head_sha).lower()}")
+          PY
+
+          while IFS=$'\t' read -r workflow branch min_success match_head_sha; do
+            [ -z "${workflow}" ] && continue
+            runs_json="$(gh run list \
+              --workflow "${workflow}" \
+              --branch "${branch}" \
+              --limit 100 \
+              --json conclusion,createdAt,headSha)"
+            if [ "${match_head_sha}" = "true" ]; then
+              run_count="$(jq \
+                --arg since "${COMMIT_ISO}" \
+                --arg sha "${CANDIDATE_SHA}" \
+                '[.[] | select(.conclusion == "success" and .createdAt >= $since and .headSha == $sha)] | length' \
+                <<< "${runs_json}")"
+            else
+              run_count="$(jq \
+                --arg since "${COMMIT_ISO}" \
+                '[.[] | select(.conclusion == "success" and .createdAt >= $since)] | length' \
+                <<< "${runs_json}")"
+            fi
+            if [ "${run_count}" -lt "${min_success}" ]; then
+              skip "${workflow} has ${run_count}/${min_success} success runs since ${COMMIT_ISO}"
+            fi
+          done < /tmp/run_requirements.tsv
+
+          STATUS_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${CANDIDATE_SHA}/status")"
+          while IFS= read -r context; do
+            [ -z "${context}" ] && continue
+            state="$(jq -r --arg context "${context}" '.statuses[]? | select(.context == $context) | .state' <<< "${STATUS_JSON}" | head -n 1)"
+            if [ "${state}" = "failure" ]; then
+              skip "${context} is failure on ${CANDIDATE_SHA}"
+            fi
+          done <<< "${INPUT_FAILURE_CONTEXTS}"
+
+          TARGET_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          write_status() {
+            local context="$1"
+            local description="$2"
+            [ -z "${context}" ] && return 0
+            gh api "repos/${GITHUB_REPOSITORY}/statuses/${CANDIDATE_SHA}" \
+              --method POST \
+              -f state=success \
+              -f context="${context}" \
+              -f description="${description:0:140}" \
+              -f target_url="${TARGET_URL}"
+          }
+
+          while IFS= read -r context; do
+            [ -z "${context}" ] && continue
+            write_status "${context}" "${context}: soak confirmed"
+          done <<< "${INPUT_SUCCESS_CONTEXTS}"
+
+          write_status "${INPUT_PASS_CONTEXT}" "${INPUT_PASS_DESCRIPTION}"
+
+          echo "skipped=false" >> "${GITHUB_OUTPUT}"
+          echo "reason=passed" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/shared-soak-gate.yml
+++ b/.github/workflows/shared-soak-gate.yml
@@ -116,7 +116,7 @@ jobs:
 
           CANDIDATE_SHA="${INPUT_CANDIDATE_SHA}"
           if [ -z "${CANDIDATE_SHA}" ]; then
-            git fetch origin "${INPUT_CANDIDATE_REF}" --depth=200
+            git fetch origin "${INPUT_CANDIDATE_REF}:refs/remotes/origin/${INPUT_CANDIDATE_REF}" --depth=200
             CANDIDATE_SHA="$(git rev-parse "origin/${INPUT_CANDIDATE_REF}")"
           fi
           if ! [[ "${CANDIDATE_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -81,6 +81,19 @@ RC soak status write API. dev 와 signal set 이 다를 수 있으므로 별도 
 
 Issue 는 audit/log surface 이며 gate 판정 source-of-truth 가 아니다.
 
+### `shared-soak-gate`
+
+Soak window, workflow run history, commit status failure context 를 평가하고 통과 시 success marker 를 쓰는 reusable evaluator. Stage-specific promotion 의미는 갖지 않는다.
+
+| 항목 | 값 |
+|------|----|
+| Trigger | `workflow_call` |
+| Inputs | `candidate_ref`, `candidate_sha`, `min_soak_hours`, `required_runs_json`, `failure_contexts`, `success_contexts`, `pass_context`, `pass_description` |
+| Outputs | `skipped`, `reason`, `candidate_sha` |
+| Called by | `dev-rc-cut-gate`, later `rc-main-cut-gate` |
+
+`required_runs_json` 은 workflow run history 조건을 담는다. 기본은 candidate commit 이후의 성공 run 수를 세며, 필요 시 `match_head_sha=true` 로 head SHA 일치를 강제할 수 있다.
+
 ### `auto-issue`
 
 GitHub issue 자동 생성 + Slack 알림.
@@ -154,7 +167,7 @@ Cross-branch cherry-pick PR 자동 생성.
 | Trigger | `schedule` (cut 직전, TBD) + `workflow_dispatch` |
 | Inputs | optional `candidate_sha` (default: latest `origin/dev` HEAD) |
 | Outputs | commit status `dev-rc-cut-pass` (success only) + `dev-soak/*` success confirmations |
-| Steps | (1) latest `origin/dev` HEAD 를 candidate 로 선택 (2) candidate age >= 24h 확인 (3) `monitor-event-flow-hourly` success run >= 20, `monitor-event-flow-daily` success run >= 1 확인 (4) candidate 의 최신 `dev-soak/backend-simulator`, `dev-soak/real-device`, `dev-soak/app-ai-review` status 가 failure 가 아닌지 확인 (5) real-device/app AI review pass signal 확인 (6) 통과 시 `set-dev-soak-status` 로 `dev-soak/*` success 작성 + `shared-set-commit-status` 로 `dev-rc-cut-pass` success set |
+| Steps | calls `shared-soak-gate` with candidate=`origin/dev`, min_soak_hours=24, required runs=`monitor-event-flow-hourly>=20` + `monitor-event-flow-daily>=1`, failure context=`dev-soak/backend-simulator`, success context=`dev-soak/backend-simulator`, pass context=`dev-rc-cut-pass` |
 | Failure path | 조건 미충족이면 `dev-rc-cut-pass` 를 쓰지 않는다. 실패를 발견한 monitor/AI agent 가 이미 `dev-soak/*` failure 를 쓴다 |
 
 > **No auto-revert** — snapshot 모델: 실패 = no `dev-rc-cut-pass`, dev keeps moving, 새 fix 가 자연스럽게 다음 dev-staging-dev-cut 후 새 candidate 로 검증됨.
@@ -346,4 +359,4 @@ Cross-branch cherry-pick PR 자동 생성.
 - `execution-plan.md` (예정) — 기존 workflow refactor + 구현 순서
 
 ---
-_Reviewed: 2026-05-24 10:24_
+_Reviewed: 2026-05-24 16:45_


### PR DESCRIPTION
## Summary
- Add shared-soak-gate reusable evaluator for soak window, workflow run history, and commit status checks
- Convert dev-rc-cut-gate from push-triggered CUJ runner to schedule/manual soak evaluator
- Mark dev-soak/backend-simulator and dev-rc-cut-pass success only when the evaluator passes
- Document shared-soak-gate in workflow/branch strategy docs

## Validation
- Parsed all .github/workflows/*.yml with python yaml.safe_load
- BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh
- git diff --check

## Notes
- Auto-merge is intentionally not enabled. This PR needs review approval.
- real-device and app-ai-review remain soft/TBD; this first evaluator enforces backend-simulator only.