### PR TITLE
feat(ef-auth): support sb_secret system apikey auth

### DIFF
--- a/docs/architecture/edge-function-auth.md
+++ b/docs/architecture/edge-function-auth.md
@@ -9,7 +9,7 @@ Minglit의 모든 Edge Function (EF) 인증/인가 모델을 기술한다.
 
 ### 1.1 현재 문제점 (이 설계 도입 전)
 
-47개 `verify_jwt = false` EF + 13개 `verify_jwt = true` EF (총 ~60개) 의 인증 보호가 **분산 관리** 되어 다음 문제 발생:
+다수의 Edge Function 인증 보호가 **분산 관리** 되어 다음 문제 발생:
 
 | 항목 | 현재 상태 |
 |---|---|
@@ -36,22 +36,28 @@ Minglit의 모든 Edge Function (EF) 인증/인가 모델을 기술한다.
 | EF 별 환경 가드 (dev-only / prod-only) | ❌ | ✅ 본 설계 |
 | Unprotected EF 자동 검출 | ❌ | ✅ CI lint |
 
-### 1.4 service_role 형식 일관성 요건 ⚠️
+### 1.4 system key 형식 일관성 요건 ⚠️
 
-`system` caller 검증은 cron 이 보낸 `Bearer <token>` 과 EF 내부 `Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")` 의 **exact string match** 다. 두 값의 출처:
+`system` caller 검증은 두 경로를 허용한다.
+
+1. legacy: `Authorization: Bearer <token>` 과 EF 내부 `Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")` 의 **exact string match**
+2. 신규 secret key: `apikey: <token>` 과 EF 내부 `Deno.env.get("SUPABASE_SERVICE_ROLE_SECRET")` 의 **exact string match**
+
+두 값의 출처:
 
 ```
-GH Secret (SUPABASE_*_SECRET_KEY)
-  ├─→ EF env (Supabase 플랫폼 자동 주입 — deploy-supabase.yml 의 supabase secrets set 안 거침)
-  └─→ Vault (CI sync — deploy-supabase.yml 의 Sync Vault secrets step)
-        └─→ cron 이 SELECT 하여 Bearer 헤더에 사용
+GH Secret / Supabase Secret
+  ├─→ EF env (SUPABASE_SERVICE_ROLE_KEY / SUPABASE_SERVICE_ROLE_SECRET)
+  └─→ Vault 또는 caller secret
+        └─→ cron/service caller 가 Authorization 또는 apikey 헤더에 사용
 ```
 
-두 경로가 같은 GH Secret 에서 나오므로 형식 일치는 자동. 단 **GH Secret 형식이 EF 게이트웨이의 verify_jwt 와 호환되어야** 함:
+형식별 gateway 호환성:
+
 - legacy JWT (`eyJ...`): verify_jwt=true / false 모두 호환
-- 신규 sb_secret_: verify_jwt=false 전용 (게이트웨이가 JWT 시그니처 검증 못함)
+- 신규 `sb_secret_...`: verify_jwt=false 전용. JWT가 아니므로 `Authorization: Bearer sb_secret_...` 로 보내면 gateway JWT 검증을 통과하지 못한다.
 
-**현재 정책**: legacy JWT 형식 사용. 신규 형식은 `verify_jwt=true` EF 가 cron 호출 받는 한 부적합 (별도 이슈에서 마이그레이션 검토).
+**현재 정책**: legacy JWT bearer 경로는 유지하고, `sb_secret_...` 전환 준비를 위해 `apikey` 경로를 추가한다. `system` caller EF 중 신규 secret key를 받을 수 있어야 하는 함수는 `verify_jwt=false` 로 전환하고 wrapper 내부 인증에 의존한다.
 
 ---
 
@@ -61,7 +67,7 @@ EF 가 받을 수 있는 호출자 분류. manifest 의 `callers` 배열에 명�
 
 | 타입 | 의미 | 검증 방법 |
 |---|---|---|
-| **`system`** | cron, 시스템 우회 | `Authorization: Bearer ${EF_ENV.SUPABASE_SERVICE_ROLE_KEY}` exact match (§1.4 의 EF env 값과 비교) |
+| **`system`** | cron, 시스템 우회 | legacy `Authorization: Bearer ${EF_ENV.SUPABASE_SERVICE_ROLE_KEY}` 또는 신규 `apikey: ${EF_ENV.SUPABASE_SERVICE_ROLE_SECRET}` exact match (§1.4) |
 | **`user`** | 인증된 사용자/파트너 | `supabase.auth.getUser(token)` 으로 decode + claims 추출 → `auth.userId` |
 | **`external`** | 외부 시스템 (webhook 등) | manifest 의 `external_auth` 정책에 따라 IP / HMAC / signature 검증. **Authorization 헤더 무관** |
 | **`public`** | 익명 OK | check 없음. 보통 `envs: ["dev"]` 와 결합하여 prod 노출 차단 |
@@ -78,23 +84,23 @@ EF 가 받을 수 있는 호출자 분류. manifest 의 `callers` 배열에 명�
 
 ### 2.2 caller 검증 우선순위 (성능 최적화)
 
-`Authorization` 헤더 형식과 manifest.callers 조합으로 분기. cheap check 먼저:
+`Authorization` / `apikey` 헤더와 manifest.callers 조합으로 분기. cheap check 먼저:
 
 ```
 0. (선결) Env 가드: ENVIRONMENT ∉ policy.envs → 403 (auth 검증 자체 skip)
 
-1. Authorization 헤더 있음 + Bearer 형식
-   ├─ Bearer == EF_ENV.SUPABASE_SERVICE_ROLE_KEY
-   │   └─ "system" ∈ callers → ✅ pass (cheap, env var 비교만)
-   │   └─ 아니면 → 403
-   └─ Else
-       ├─ "user" ∈ callers → supabase.auth.getUser() (expensive)
-       │   └─ success → ✅ pass + userId
-       │   └─ fail → 401
-       └─ "user" ∉ callers + "external" ∈ callers → external_auth 검증 (auth 헤더 무시, IP 등 다른 신호 사용)
-       └─ 둘 다 ∉ → 403
+1. "system" ∈ callers
+   ├─ Authorization Bearer == EF_ENV.SUPABASE_SERVICE_ROLE_KEY → ✅ pass (keyFormat=legacy)
+   ├─ apikey == EF_ENV.SUPABASE_SERVICE_ROLE_SECRET → ✅ pass (keyFormat=secret)
+   └─ Else → 다음 caller 검증으로 진행
 
-2. Authorization 헤더 없음 또는 Bearer 형식 아님
+2. Authorization 헤더 있음 + Bearer 형식
+   ├─ "user" ∈ callers → supabase.auth.getUser() (expensive)
+   │   └─ success → ✅ pass + userId
+   │   └─ fail → 401
+   └─ "user" ∉ callers + "external" ∈ callers → external_auth 검증 (auth 헤더 무시, IP 등 다른 신호 사용)
+
+3. Authorization 헤더 없음 또는 Bearer 형식 아님
    ├─ "external" ∈ callers → external_auth 검증
    ├─ "public" ∈ callers → ✅ pass (auth check 없음)
    └─ 둘 다 ∉ → 401
@@ -215,7 +221,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Logger } from "./logger.ts";
 
 export type AuthContext =
-  | { type: "system" }
+  | { type: "system"; keyFormat?: "legacy" | "secret" }
   | { type: "user"; userId: string }
   | { type: "external"; reason: string }   // e.g., "ip_allowlist:52.78.100.19"
   | { type: "public" };
@@ -429,7 +435,7 @@ sequenceDiagram
     participant Handler as EF Handler
     participant DB as Postgres
 
-    Caller->>Gateway: POST /functions/v1/<fn-name><br/>Authorization: Bearer <token>
+    Caller->>Gateway: POST /functions/v1/<fn-name><br/>Authorization: Bearer <JWT/legacy key><br/>or apikey: sb_secret_...
 
     alt verify_jwt = true (config.toml)
         Gateway->>Gateway: JWT 시그니처 검증
@@ -459,13 +465,13 @@ sequenceDiagram
 flowchart TD
     Req[Request 도착] --> EnvCheck{ENVIRONMENT<br/>∈ policy.envs?}
     EnvCheck -- No --> E403_env[403 Function disabled]
-    EnvCheck -- Yes --> AuthHeader{Authorization<br/>Bearer 있음?}
+    EnvCheck -- Yes --> SysAllow{'system'<br/>∈ callers?}
+    SysAllow -- Yes --> SysMatch{Legacy bearer<br/>or secret apikey<br/>matches EF env?}
+    SysMatch -- Yes --> Pass_sys[type=system]
+    SysMatch -- No --> AuthHeader{Authorization<br/>Bearer 있음?}
+    SysAllow -- No --> AuthHeader
 
-    AuthHeader -- Yes --> SysMatch{Bearer ==<br/>EF_ENV.<br/>SERVICE_ROLE_KEY?}
-    SysMatch -- Yes --> Sys{'system'<br/>∈ callers?}
-    Sys -- Yes --> Pass_sys[type=system]
-    Sys -- No --> E403_sys[403]
-    SysMatch -- No --> UserAllow{'user'<br/>∈ callers?}
+    AuthHeader -- Yes --> UserAllow{'user'<br/>∈ callers?}
     UserAllow -- Yes --> Decode[supabase.auth.getUser]
     Decode -- success --> Pass_user[type=user, userId]
     Decode -- fail --> E401_user[401]
@@ -588,7 +594,7 @@ EFContext
 
 ## 8. Migration Plan
 
-총 대상: **verify_jwt=false EF 47개 + verify_jwt=true EF 13개 = 약 60개**. 두 그룹 모두 wrapper 로 통합 (verify_jwt 설정은 config.toml 그대로 유지 — 게이트웨이 보호는 별도).
+총 대상: `supabase/config.toml` 에 등록된 EF 전체. 모든 함수는 wrapper 로 통합하고, `verify_jwt` 설정은 호출 방식에 맞춰 별도 관리한다.
 
 | Phase | 작업 | PR 단위 | 영향 |
 |---|---|---|---|

--- a/docs/guides/env-reference.md
+++ b/docs/guides/env-reference.md
@@ -25,6 +25,7 @@
 |-----|-------------|----------|
 | `SUPABASE_URL` | Supabase project URL (auto-injected) | Yes |
 | `SUPABASE_SERVICE_ROLE_KEY` | Service role JWT (auto-injected) | Yes |
+| `SUPABASE_SERVICE_ROLE_SECRET` | Supabase `sb_secret_...` key for system callers using the `apikey` header | No |
 | `SENTRY_DSN` | Sentry error tracking | No |
 | `AXIOM_API_TOKEN` | Axiom structured logging | No |
 | `AXIOM_DATASET` | Axiom dataset name | No |
@@ -173,4 +174,3 @@
 |-----|-------------|----------|
 | `publishable_key` | Legacy anon JWT for pg_cron -> EF auth | Yes |
 | `supabase_url` | Project URL for pg_cron -> EF calls | Yes |
-

--- a/docs/operations/edge-functions.md
+++ b/docs/operations/edge-functions.md
@@ -83,6 +83,12 @@ curl -s -X POST "http://localhost:54321/functions/v1/<function-name>" \
   -H "Content-Type: application/json" \
   -d '{"key": "value"}'
 
+# sb_secret_ 형식 secret key로 system caller 호출
+curl -s -X POST "http://localhost:54321/functions/v1/<function-name>" \
+  -H "apikey: <SUPABASE_SERVICE_ROLE_SECRET>" \
+  -H "Content-Type: application/json" \
+  -d '{"key": "value"}'
+
 # 응답 포맷팅
 curl -s ... | python3 -m json.tool
 ```
@@ -97,6 +103,12 @@ curl -s ... | python3 -m json.tool
 # Dev 서버 직접 호출
 curl -s -X POST "https://<project-ref>.supabase.co/functions/v1/<function-name>" \
   -H "Authorization: Bearer <SERVICE_ROLE_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"phase": "verify"}'
+
+# sb_secret_ 형식은 Bearer가 아니라 apikey 헤더로 호출
+curl -s -X POST "https://<project-ref>.supabase.co/functions/v1/<function-name>" \
+  -H "apikey: <SERVICE_ROLE_SECRET>" \
   -H "Content-Type: application/json" \
   -d '{"phase": "verify"}'
 ```
@@ -219,6 +231,7 @@ Assertion 실패 시 GitHub 이슈가 자동 생성되며, 이슈에 Axiom 쿼�
 | `SENTRY_DSN` | Sentry 에러 트래킹 | 미설정 (비활성) | 설정됨 | 설정됨 |
 | `SUPABASE_URL` | Supabase API URL | `http://localhost:54321` | `https://<ref>.supabase.co` | `https://<ref>.supabase.co` |
 | `SUPABASE_SERVICE_ROLE_KEY` | 관리자 키 | 로컬 키 | 시크릿 | 시크릿 |
+| `SUPABASE_SERVICE_ROLE_SECRET` | `sb_secret_...` system caller 키 | 선택 | 시크릿 | 시크릿 |
 
 ## 트러블슈팅
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -399,7 +399,7 @@ s3_secret_key = "env(S3_SECRET_KEY)"
 
 [functions.notification-worker]
 enabled = true
-verify_jwt = true
+verify_jwt = false  # system caller; wrapper accepts legacy bearer or sb_secret apikey
 import_map = "./deno.json"
 # Uncomment to specify a custom file path to the entrypoint.
 # Supported file extensions are: .ts, .js, .mjs, .jsx, .tsx
@@ -410,7 +410,7 @@ entrypoint = "./functions/notification-worker/index.ts"
 
 [functions.ai-embed]
 enabled = true
-verify_jwt = true
+verify_jwt = false  # system caller; wrapper accepts legacy bearer or sb_secret apikey
 import_map = "./deno.json"
 # Uncomment to specify a custom file path to the entrypoint.
 # Supported file extensions are: .ts, .js, .mjs, .jsx, .tsx
@@ -712,6 +712,6 @@ entrypoint = "./functions/cleanup-retention/index.ts"
 
 [functions.ai-extract-tags]
 enabled = true
-verify_jwt = true  # cron sends publishable_key (anon JWT); Supabase verifies at edge
+verify_jwt = false  # system caller; wrapper accepts legacy bearer or sb_secret apikey
 import_map = "./deno.json"
 entrypoint = "./functions/ai-extract-tags/index.ts"

--- a/supabase/functions/_shared/BLUEDOC.md
+++ b/supabase/functions/_shared/BLUEDOC.md
@@ -8,6 +8,7 @@
 | 항목                                                             | 역할                                                                              |
 | ---------------------------------------------------------------- | --------------------------------------------------------------------------------- |
 | `edge_function.ts`                                               | `minglitEdgeFunction(handler)` wrapper. manifest env/caller 가드 + logging/Sentry |
+| `edge_function_*_test.ts`                                        | wrapper auth/external/deprecation 회귀 테스트                                      |
 | `env_keystore.ts`                                                | env-manifest 기반 환경변수 typed 접근                                             |
 | `request_utils.ts` / `input_validation.ts` / `response_utils.ts` | request parsing, typed input field validation, CORS/success/error response        |
 | `supabase_client.ts`                                             | service/user Supabase client 생성                                                 |
@@ -35,4 +36,4 @@
 
 ---
 
-_Reviewed: 2026-05-24 00:00_
+_Reviewed: 2026-05-24 16:45_

--- a/supabase/functions/_shared/edge_function.ts
+++ b/supabase/functions/_shared/edge_function.ts
@@ -24,9 +24,10 @@ import authManifest from "../auth-manifest.json" with { type: "json" };
 
 export type Caller = "system" | "user" | "external" | "public";
 export type Environment = "local" | "development" | "dev" | "production";
+export type SystemKeyFormat = "legacy" | "secret";
 
 export type AuthContext =
-  | { type: "system" }
+  | { type: "system"; keyFormat?: SystemKeyFormat }
   | { type: "user"; userId: string }
   | { type: "external"; reason: string }
   | { type: "public" };
@@ -225,7 +226,37 @@ export async function checkExternalAuth(
   }
 }
 
-async function verifyAuth(
+/**
+ * Checks system caller credentials.
+ *
+ * Legacy service_role stays on `Authorization: Bearer <SUPABASE_SERVICE_ROLE_KEY>`.
+ * New Supabase secret keys (`sb_secret_...`) are not JWTs and must use `apikey`.
+ * Exported for unit testing; not part of the stable public API.
+ */
+export function checkSystemAuth(
+  req: Request,
+): { ok: true; keyFormat: SystemKeyFormat } | { ok: false } {
+  const authHeader = req.headers.get("Authorization") ?? "";
+  if (authHeader.startsWith("Bearer ")) {
+    const token = authHeader.slice(7);
+    const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+    if (serviceKey && token === serviceKey) {
+      return { ok: true, keyFormat: "legacy" };
+    }
+  }
+
+  const apiKey = req.headers.get("apikey") ?? "";
+  const serviceSecret = Deno.env.get("SUPABASE_SERVICE_ROLE_SECRET");
+  if (serviceSecret && apiKey === serviceSecret) {
+    return { ok: true, keyFormat: "secret" };
+  }
+
+  return { ok: false };
+}
+
+// Exported for unit testing; not part of the stable public API.
+export async function verifyAuth(
   req: Request,
   policy: EFPolicy,
   fnName: string,
@@ -233,14 +264,18 @@ async function verifyAuth(
   const allow = (c: Caller) => policy.callers.includes(c);
   const authHeader = req.headers.get("Authorization") ?? "";
 
-  // Bearer 형식 토큰이 있으면 우선 system → user 순으로 검증 (cheap → expensive)
+  // system auth is cheap and independent of JWT verification. Check it before
+  // user auth so service-to-service callers can use only `apikey`.
+  if (allow("system")) {
+    const system = checkSystemAuth(req);
+    if (system.ok) {
+      return { type: "system", keyFormat: system.keyFormat };
+    }
+  }
+
+  // Bearer 형식 토큰이 있으면 user JWT 검증 (expensive)
   if (authHeader.startsWith("Bearer ")) {
     const token = authHeader.slice(7);
-    const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-
-    if (allow("system") && serviceKey && token === serviceKey) {
-      return { type: "system" };
-    }
 
     if (allow("user")) {
       const supabase = createServiceClient();
@@ -335,6 +370,14 @@ export function minglitEdgeFunction(handler: EFHandler, opts: MinglitEFOptions =
       // Auth 검증
       const auth = await verifyAuth(req, policy, fnName);
       if (auth instanceof Response) return auth;
+      if (auth.type === "system") {
+        axiomLog({
+          function: fnName,
+          level: "info",
+          message: "system auth accepted",
+          metadata: { requestId, keyFormat: auth.keyFormat ?? "unknown" },
+        });
+      }
 
       // Context + handler 호출
       const ctx = makeContext({ auth, fnName, env, requestId });

--- a/supabase/functions/_shared/edge_function_system_auth_test.ts
+++ b/supabase/functions/_shared/edge_function_system_auth_test.ts
@@ -1,0 +1,112 @@
+import { assertEquals, assertInstanceOf } from "@std/assert";
+import { checkSystemAuth, type EFPolicy, verifyAuth } from "./edge_function.ts";
+import { withEnv } from "../_test_utils/mock_http.ts";
+
+const SYSTEM_POLICY: EFPolicy = {
+  callers: ["system"],
+  envs: ["dev"],
+};
+
+const AUTH_ENV = {
+  SUPABASE_SERVICE_ROLE_KEY: "legacy-service-role-jwt",
+  SUPABASE_SERVICE_ROLE_SECRET: "sb_secret_test_secret_key",
+};
+
+function request(headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost", { method: "POST", headers });
+}
+
+async function expectUnauthorized(req: Request): Promise<void> {
+  const result = await verifyAuth(req, SYSTEM_POLICY, "test-system-fn");
+  assertInstanceOf(result, Response);
+  assertEquals(result.status, 401);
+}
+
+Deno.test("checkSystemAuth: legacy bearer service_role key passes as legacy", async () => {
+  await withEnv(AUTH_ENV, () => {
+    const result = checkSystemAuth(request({
+      Authorization: "Bearer legacy-service-role-jwt",
+    }));
+    assertEquals(result, { ok: true, keyFormat: "legacy" });
+  });
+});
+
+Deno.test("checkSystemAuth: sb_secret apikey passes as secret", async () => {
+  await withEnv(AUTH_ENV, () => {
+    const result = checkSystemAuth(request({
+      apikey: "sb_secret_test_secret_key",
+    }));
+    assertEquals(result, { ok: true, keyFormat: "secret" });
+  });
+});
+
+Deno.test("verifyAuth: missing system credentials returns 401", async () => {
+  await withEnv(AUTH_ENV, async () => {
+    await expectUnauthorized(request());
+  });
+});
+
+Deno.test("verifyAuth: wrong bearer returns 401", async () => {
+  await withEnv(AUTH_ENV, async () => {
+    await expectUnauthorized(request({
+      Authorization: "Bearer wrong-key",
+    }));
+  });
+});
+
+Deno.test("verifyAuth: wrong apikey returns 401", async () => {
+  await withEnv(AUTH_ENV, async () => {
+    await expectUnauthorized(request({
+      apikey: "sb_secret_wrong_key",
+    }));
+  });
+});
+
+Deno.test("verifyAuth: user JWT bearer does not pass a system-only policy", async () => {
+  await withEnv(AUTH_ENV, async () => {
+    await expectUnauthorized(request({
+      Authorization: "Bearer user-jwt-token",
+    }));
+  });
+});
+
+Deno.test("verifyAuth: Authorization bearer sb_secret is not accepted", async () => {
+  await withEnv(AUTH_ENV, async () => {
+    await expectUnauthorized(request({
+      Authorization: "Bearer sb_secret_test_secret_key",
+    }));
+  });
+});
+
+Deno.test("verifyAuth: secret apikey system caller passes without Authorization", async () => {
+  await withEnv(AUTH_ENV, async () => {
+    const result = await verifyAuth(
+      request({ apikey: "sb_secret_test_secret_key" }),
+      SYSTEM_POLICY,
+      "test-system-fn",
+    );
+    assertEquals(result, { type: "system", keyFormat: "secret" });
+  });
+});
+
+Deno.test("verifyAuth: legacy bearer system caller still passes", async () => {
+  await withEnv(AUTH_ENV, async () => {
+    const result = await verifyAuth(
+      request({ Authorization: "Bearer legacy-service-role-jwt" }),
+      SYSTEM_POLICY,
+      "test-system-fn",
+    );
+    assertEquals(result, { type: "system", keyFormat: "legacy" });
+  });
+});
+
+Deno.test("verifyAuth: missing SUPABASE_SERVICE_ROLE_SECRET fails closed for apikey", async () => {
+  await withEnv(
+    { ...AUTH_ENV, SUPABASE_SERVICE_ROLE_SECRET: undefined },
+    async () => {
+      await expectUnauthorized(request({
+        apikey: "sb_secret_test_secret_key",
+      }));
+    },
+  );
+});


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-high-1

## Summary
- Added dual system caller auth in `minglitEdgeFunction`: legacy `Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY` plus new `apikey: $SUPABASE_SERVICE_ROLE_SECRET`.
- Kept `Authorization: Bearer sb_secret_...` rejected; Supabase secret keys are not JWTs and must use `apikey`.
- Switched `notification-worker`, `ai-embed`, and `ai-extract-tags` to `verify_jwt=false` so wrapper auth handles service-to-service calls.
- Updated EF auth/ops/env docs and added wrapper regression tests for missing/wrong credentials, user JWT denial, legacy success, secret apikey success, and fail-closed missing secret.

## Why
Refs #2728, parent #2187. This prepares system-only Edge Functions for Supabase `sb_secret_...` service-role migration while preserving current legacy service_role JWT callers.

Official docs checked:
- https://supabase.com/docs/guides/functions/auth-headers
- https://supabase.com/docs/guides/getting-started/api-keys

## Verification
- `/tmp/deno-install/bin/deno test --allow-all --config supabase/deno.json supabase/functions/_shared/edge_function_system_auth_test.ts`
- `/tmp/deno-install/bin/deno test --allow-all --config supabase/deno.json supabase/functions/_shared/edge_function_system_auth_test.ts supabase/functions/notification-worker/notification_worker_test.ts`
- `/tmp/deno-install/bin/deno test --allow-all --config supabase/deno.json supabase/functions/ai-embed/ai_embed_test.ts supabase/functions/ai-extract-tags/ai_extract_tags_test.ts`
- `python3 - <<'PY' ... tomllib.load('supabase/config.toml') ... PY`
- `git diff --check`

## Risks
- Mark still needs to create/inject `SUPABASE_SERVICE_ROLE_SECRET` before callers can use `sb_secret_...`.
- Existing callers continue using legacy bearer until Phase 4 migration, so legacy revoke must wait.