### PR TITLE
ci: scan build artifacts for service-role secrets

### DIFF
--- a/.github/scripts/BLUEDOC.md
+++ b/.github/scripts/BLUEDOC.md
@@ -1,6 +1,6 @@
 # .github/scripts/
 
-워크플로우가 `bash .github/scripts/<name>.sh` 로 실행하는 **shell 헬퍼**. composite action 을 만들 만큼 무겁지 않은 명령 묶음.
+워크플로우가 `.github/scripts/<name>` 로 실행하는 **가벼운 스크립트 헬퍼**. composite action 을 만들 만큼 무겁지 않은 명령 묶음.
 
 ## 이정표
 
@@ -10,6 +10,7 @@
 | [`run-user-cuj.sh`](./run-user-cuj.sh) | `apps/app_user/integration_test/cuj/` 의 CUJ 테스트 실행 (emulator) | `shared-cuj-integration` (app-name=user 일 때) |
 | [`run-partner-cuj.sh`](./run-partner-cuj.sh) | `apps/app_partner/integration_test/cuj/` CUJ 실행 | `shared-cuj-integration` (app-name=partner 일 때) |
 | [`check-bluedoc-freshness.sh`](./check-bluedoc-freshness.sh) | PR 에서 새/삭제 파일에 대해 가장 가까운 ancestor BLUEDOC.md 갱신 강제. 통과: 이정표 표 갱신 또는 BLUEDOC 의 `_Reviewed_` 날짜 bump. + 모든 BLUEDOC.md 의 Reviewed 형식 검증 | `pr-gate.check-bluedoc-freshness` (required check) |
+| [`scan-build-artifact-secrets.py`](./scan-build-artifact-secrets.py) | APK/AAB/`.next` 등 빌드 산출물에서 Supabase service-role secret 패턴을 redacted summary 로 검사 | `pr-gate.scan-build-artifact-secrets` |
 
 ## 핵심 컨벤션
 

--- a/.github/scripts/scan-build-artifact-secrets.py
+++ b/.github/scripts/scan-build-artifact-secrets.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Scan generated build artifacts for server-side Supabase secrets.
+
+The script intentionally reports only rule ids and artifact locations. It never
+prints the matched token, so CI logs stay useful without becoming a new leak.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Rule:
+    rule_id: str
+    description: str
+    pattern: re.Pattern[bytes]
+
+
+@dataclass(frozen=True)
+class Finding:
+    rule_id: str
+    location: str
+
+
+RULES: tuple[Rule, ...] = (
+    Rule(
+        "supabase-service-role-secret",
+        "Supabase sb_secret service-role key",
+        re.compile(rb"sb_secret_[A-Za-z0-9_-]+"),
+    ),
+    Rule(
+        "supabase-legacy-jwt",
+        "Supabase legacy JWT",
+        re.compile(
+            rb"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\."
+            rb"[A-Za-z0-9_-]{60,}\.[A-Za-z0-9_-]{40,}"
+        ),
+    ),
+)
+
+
+def iter_files(paths: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for path in paths:
+        if not path.exists():
+            raise FileNotFoundError(f"scan target does not exist: {path}")
+        if path.is_file():
+            files.append(path)
+            continue
+        for root, _, names in os.walk(path):
+            for name in names:
+                candidate = Path(root) / name
+                if candidate.is_file() and not candidate.is_symlink():
+                    files.append(candidate)
+    return files
+
+
+def scan_bytes(data: bytes, location: str) -> list[Finding]:
+    findings: list[Finding] = []
+    for rule in RULES:
+        if rule.pattern.search(data):
+            findings.append(Finding(rule.rule_id, location))
+    return findings
+
+
+def scan_file(path: Path) -> list[Finding]:
+    if zipfile.is_zipfile(path):
+        return scan_zip(path)
+    try:
+        return scan_bytes(path.read_bytes(), str(path))
+    except OSError as exc:
+        raise RuntimeError(f"failed to read {path}: {exc}") from exc
+
+
+def scan_zip(path: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    try:
+        with zipfile.ZipFile(path) as archive:
+            for info in archive.infolist():
+                if info.is_dir():
+                    continue
+                with archive.open(info) as member:
+                    data = member.read()
+                findings.extend(scan_bytes(data, f"{path}!{info.filename}"))
+    except zipfile.BadZipFile as exc:
+        raise RuntimeError(f"failed to inspect zip artifact {path}: {exc}") from exc
+    return findings
+
+
+def scan_paths(paths: list[Path]) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in iter_files(paths):
+        findings.extend(scan_file(path))
+    return findings
+
+
+def github_escape(value: str) -> str:
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def report_findings(findings: list[Finding]) -> None:
+    if not findings:
+        print("Build artifact secret scan passed.")
+        return
+
+    print(f"Build artifact secret scan found {len(findings)} finding(s).")
+    for finding in findings:
+        location = github_escape(finding.location)
+        rule_id = github_escape(finding.rule_id)
+        print(
+            "::error title=Build artifact secret detected::"
+            f"{rule_id} matched in {location}; token redacted"
+        )
+
+
+def run_self_test() -> int:
+    fake_jwt = (
+        b"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+        + b"A" * 60
+        + b"."
+        + b"B" * 40
+    )
+    fake_secret = b"sb_" + b"secret_FAKE_ARTIFACT_SCAN_SHOULD_FAIL_1234567890"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        plain = root / "plain.txt"
+        plain.write_bytes(b"prefix " + fake_secret + b" suffix")
+
+        archive = root / "app.apk"
+        with zipfile.ZipFile(archive, "w") as zf:
+            zf.writestr("assets/config.txt", b"jwt=" + fake_jwt)
+
+        clean = root / "clean.next"
+        clean.mkdir()
+        (clean / "chunk.js").write_text("console.log('no server secrets here');")
+
+        findings = scan_paths([plain, archive, clean])
+        rule_ids = {finding.rule_id for finding in findings}
+        if rule_ids != {"supabase-service-role-secret", "supabase-legacy-jwt"}:
+            print(f"self-test failed: unexpected findings {findings}", file=sys.stderr)
+            return 1
+
+    print("Build artifact secret scan self-test passed.")
+    return 0
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Scan build artifacts for Supabase service-role secrets."
+    )
+    parser.add_argument("paths", nargs="*", type=Path, help="Files or directories to scan.")
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Run the built-in fake secret fixture test.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if args.self_test:
+        return run_self_test()
+    if not args.paths:
+        print("at least one scan path is required", file=sys.stderr)
+        return 2
+
+    findings = scan_paths(args.paths)
+    report_findings(findings)
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -137,6 +137,10 @@ jobs:
           git fetch origin "${BASE_REF#origin/}" --depth=50 || true
           bash .github/scripts/check-bluedoc-freshness.sh
 
+      - name: Build artifact secret scan self-test
+        if: ${{ !cancelled() }}
+        run: python3 .github/scripts/scan-build-artifact-secrets.py --self-test
+
   # 변경 사항 감지 Job
   changes:
     runs-on: ubuntu-latest
@@ -158,6 +162,7 @@ jobs:
       mds_icons: ${{ steps.filter.outputs.mds_icons }}
       supabase: ${{ steps.filter.outputs.supabase }}
       dart_files: ${{ steps.filter.outputs.dart_files }}
+      artifact_secret_scan: ${{ steps.filter.outputs.artifact_secret_scan }}
       # 세분화 — 잡별 의존성에 맞춰 분리 (false positive 트리거 회피)
       supabase_migrations: ${{ steps.filter.outputs.supabase_migrations }}
       supabase_tests: ${{ steps.filter.outputs.supabase_tests }}
@@ -201,6 +206,10 @@ jobs:
             - 'supabase/**'
           dart_files:
             - '**/*.dart'
+          artifact_secret_scan:
+            - '.github/scripts/scan-build-artifact-secrets.py'
+            - '.github/scripts/BLUEDOC.md'
+            - '.github/workflows/pr-gate.yml'
           # migrations + seed + config — pgTAP / ef-integration 트리거
           supabase_migrations:
             - 'supabase/migrations/**'
@@ -416,7 +425,7 @@ jobs:
   lint-landing-user:
     name: lint-and-build-landing-user
     needs: changes
-    if: ${{ needs.changes.outputs.landing_user == 'true' }}
+    if: ${{ needs.changes.outputs.landing_user == 'true' || needs.changes.outputs.artifact_secret_scan == 'true' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -432,12 +441,14 @@ jobs:
       - run: npm audit --audit-level=high
       - run: npm run lint
       - run: npm run build
+      - name: Scan Next.js build artifact secrets
+        run: python3 ../../.github/scripts/scan-build-artifact-secrets.py .next
 
   # Landing Partner CI
   lint-landing-partner:
     name: lint-and-build-landing-partner
     needs: changes
-    if: ${{ needs.changes.outputs.landing_partner == 'true' }}
+    if: ${{ needs.changes.outputs.landing_partner == 'true' || needs.changes.outputs.artifact_secret_scan == 'true' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -453,6 +464,131 @@ jobs:
       - run: npm audit --audit-level=high
       - run: npm run lint
       - run: npm run build
+      - name: Scan Next.js build artifact secrets
+        run: python3 ../../.github/scripts/scan-build-artifact-secrets.py .next
+
+  # Flutter release artifact secret scan (Android first; iOS requires macOS/signing deploy context).
+  scan-flutter-artifact-secrets:
+    name: scan-build-artifact-secrets
+    needs: changes
+    if: ${{ needs.changes.outputs.app_user == 'true' || needs.changes.outputs.app_partner == 'true' || needs.changes.outputs.artifact_secret_scan == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - app: app_user
+            change_key: app_user
+            directory: apps/app_user
+          - app: app_partner
+            change_key: app_partner
+            directory: apps/app_partner
+    defaults:
+      run:
+        working-directory: ./${{ matrix.directory }}
+    steps:
+      - uses: actions/checkout@v6
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' || needs.changes.outputs.artifact_secret_scan == 'true' }}
+
+      - name: Set up JDK 17
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' || needs.changes.outputs.artifact_secret_scan == 'true' }}
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+          cache-dependency-path: ${{ matrix.directory }}/android/build.gradle.kts
+
+      - uses: subosito/flutter-action@v2
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' || needs.changes.outputs.artifact_secret_scan == 'true' }}
+        with:
+          flutter-version: '3.41.9'  # Fix #2640: flutter_quill 11.5.0 incompatible with Flutter 3.44.0
+          cache: true
+
+      - name: Cache Gradle
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' || needs.changes.outputs.artifact_secret_scan == 'true' }}
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ${{ matrix.directory }}/android/.gradle
+          key: ${{ runner.os }}-artifact-secret-scan-${{ matrix.app }}-${{ hashFiles(format('{0}/android/**/*.gradle.kts', matrix.directory), format('{0}/android/gradle/wrapper/gradle-wrapper.properties', matrix.directory)) }}
+          restore-keys: |
+            ${{ runner.os }}-artifact-secret-scan-${{ matrix.app }}-
+
+      - name: Get dependencies
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' || needs.changes.outputs.artifact_secret_scan == 'true' }}
+        run: flutter pub get
+
+      - name: Decode Keystore
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' || needs.changes.outputs.artifact_secret_scan == 'true' }}
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          : "${ANDROID_KEYSTORE_BASE64:?ANDROID_KEYSTORE_BASE64 is required for release artifact scan}"
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > android/app/upload-keystore.jks
+
+      - name: Create key.properties
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' || needs.changes.outputs.artifact_secret_scan == 'true' }}
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
+          : "${ANDROID_KEYSTORE_PASSWORD:?ANDROID_KEYSTORE_PASSWORD is required for release artifact scan}"
+          : "${ANDROID_KEY_PASSWORD:?ANDROID_KEY_PASSWORD is required for release artifact scan}"
+          : "${ANDROID_KEY_ALIAS:?ANDROID_KEY_ALIAS is required for release artifact scan}"
+          {
+            echo "storePassword=$ANDROID_KEYSTORE_PASSWORD"
+            echo "keyPassword=$ANDROID_KEY_PASSWORD"
+            echo "keyAlias=$ANDROID_KEY_ALIAS"
+            echo "storeFile=upload-keystore.jks"
+          } > android/key.properties
+
+      - name: Build dev release APK
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' || needs.changes.outputs.artifact_secret_scan == 'true' }}
+        env:
+          SUPABASE_DEV_URL: ${{ secrets.SUPABASE_DEV_URL }}
+          SUPABASE_DEV_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }}
+          SENTRY_DSN_FLUTTER: ${{ secrets.SENTRY_DSN_FLUTTER }}
+          JUSO_CONFIRM_KEY: ${{ secrets.JUSO_CONFIRM_KEY }}
+        run: |
+          flutter build apk \
+            --flavor dev \
+            --release \
+            --build-number=${{ github.run_number }} \
+            --dart-define=SUPABASE_URL="$SUPABASE_DEV_URL" \
+            --dart-define=SUPABASE_PUBLISHABLE_KEY="$SUPABASE_DEV_PUBLISHABLE_KEY" \
+            --dart-define=SENTRY_DSN="$SENTRY_DSN_FLUTTER" \
+            --dart-define=ENVIRONMENT=development \
+            --dart-define=JUSO_CONFIRM_KEY="$JUSO_CONFIRM_KEY"
+
+      - name: Build dev release AAB
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' || needs.changes.outputs.artifact_secret_scan == 'true' }}
+        env:
+          SUPABASE_DEV_URL: ${{ secrets.SUPABASE_DEV_URL }}
+          SUPABASE_DEV_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_DEV_PUBLISHABLE_KEY }}
+          SENTRY_DSN_FLUTTER: ${{ secrets.SENTRY_DSN_FLUTTER }}
+          JUSO_CONFIRM_KEY: ${{ secrets.JUSO_CONFIRM_KEY }}
+        run: |
+          flutter build appbundle \
+            --flavor dev \
+            --release \
+            --build-number=${{ github.run_number }} \
+            --dart-define=SUPABASE_URL="$SUPABASE_DEV_URL" \
+            --dart-define=SUPABASE_PUBLISHABLE_KEY="$SUPABASE_DEV_PUBLISHABLE_KEY" \
+            --dart-define=SENTRY_DSN="$SENTRY_DSN_FLUTTER" \
+            --dart-define=ENVIRONMENT=development \
+            --dart-define=JUSO_CONFIRM_KEY="$JUSO_CONFIRM_KEY"
+
+      - name: Scan Flutter build artifact secrets
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' || needs.changes.outputs.artifact_secret_scan == 'true' }}
+        working-directory: .
+        run: |
+          python3 .github/scripts/scan-build-artifact-secrets.py \
+            "${{ matrix.directory }}/build/app/outputs/flutter-apk" \
+            "${{ matrix.directory }}/build/app/outputs/bundle"
 
   # MDS Docs CI
   lint-mds-docs:


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-high-1

## Summary
- Added `.github/scripts/scan-build-artifact-secrets.py` to scan directories, files, APKs, and AABs for Supabase service-role secret patterns without printing matched tokens.
- Wired the scanner into `pr-gate.yml`:
  - static self-test with harmless fake fixtures
  - Next.js `.next/` artifact scan after landing builds
  - Android dev release APK/AAB build + artifact scan for `app_user` and `app_partner`
- Updated `.github/scripts/BLUEDOC.md` for the new workflow helper.

## Why
Refs #2729, parent #2396 / #2541. Source gitleaks is already active, but generated Flutter/Next.js artifacts were not separately checked for leaked `sb_secret_...` or legacy Supabase JWT service-role tokens.

## Verification
- `python3 .github/scripts/scan-build-artifact-secrets.py --self-test`
- redaction check with a fake `sb_secret_...` fixture: scanner failed as expected and did not print the fake token
- `python3 .github/scripts/scan-build-artifact-secrets.py .github/scripts`
- `python3 - <<'PY' ... yaml.safe_load(.github/workflows/*.yml) ... PY`
- `git diff --check`
- `BASE_REF=origin/dev bash .github/scripts/check-bluedoc-freshness.sh`
- `CI=true npm run build && python3 ../../.github/scripts/scan-build-artifact-secrets.py .next` in `apps/landing_user`
- `CI=true npm run build && python3 ../../.github/scripts/scan-build-artifact-secrets.py .next` in `apps/landing_partner`

## Risks / Notes
- Flutter Android release artifact builds require CI Android signing secrets, so local verification stopped at script/YAML/Next.js artifact scans. PR gate will validate the Android APK/AAB jobs.
- iOS bundle scanning is intentionally left out because it requires macOS/signing deploy context; Android APK/AAB and Next.js artifacts are covered in this PR.