### PR TITLE
fix(db): remove public view security definer findings

### DIFF
--- a/supabase/BLUEDOC.md
+++ b/supabase/BLUEDOC.md
@@ -31,4 +31,4 @@ Minglit 의 **백엔드 구현 루트**. DB migration, Edge Functions, seed, bac
 - [docs/infra/bluedoc/BLUEDOC.md](../docs/infra/bluedoc/BLUEDOC.md) — BLUEDOC 컨벤션
 
 ---
-_Reviewed: 2026-05-24 18:40_
+_Reviewed: 2026-05-24 19:17_

--- a/supabase/migrations/20260524000002_public_views_security_invoker.sql
+++ b/supabase/migrations/20260524000002_public_views_security_invoker.sql
@@ -1,0 +1,19 @@
+-- Issue #2743: remove Security Advisor security_definer_view findings.
+--
+-- Postgres views run with the view owner's privileges by default. These
+-- Minglit runtime views should evaluate with the invoking role so underlying
+-- table grants and RLS remain authoritative.
+
+ALTER VIEW public.locations_view SET (security_invoker = true);
+ALTER VIEW public.partner_revenue_stats SET (security_invoker = true);
+ALTER VIEW public.partner_monthly_revenue SET (security_invoker = true);
+ALTER VIEW public.my_matches_view SET (security_invoker = true);
+ALTER VIEW public.settlement_metrics SET (security_invoker = true);
+
+-- The advisor artifact also listed three public v_* views from the same
+-- Metabase residue family handled by #2742. They are not part of the Minglit
+-- runtime schema and should not remain exposed in public.
+DROP VIEW IF EXISTS
+  public.v_audit_log,
+  public.v_dashboardcard,
+  public.v_task_runs;

--- a/supabase/tests/database/102_public_views_security_invoker_test.sql
+++ b/supabase/tests/database/102_public_views_security_invoker_test.sql
@@ -1,0 +1,106 @@
+BEGIN;
+
+SELECT plan(19);
+
+-- Runtime view contracts remain present.
+SELECT has_view('public', 'locations_view', 'locations_view exists');
+SELECT has_view('public', 'partner_revenue_stats', 'partner_revenue_stats exists');
+SELECT has_view('public', 'partner_monthly_revenue', 'partner_monthly_revenue exists');
+SELECT has_view('public', 'my_matches_view', 'my_matches_view exists');
+SELECT has_view('public', 'settlement_metrics', 'settlement_metrics exists');
+
+-- Security Advisor should no longer classify these views as SECURITY DEFINER.
+SELECT ok(
+  (
+    SELECT coalesce(c.reloptions, ARRAY[]::text[]) @> ARRAY['security_invoker=true']
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'v'
+      AND c.relname = 'locations_view'
+  ),
+  'locations_view is security_invoker'
+);
+
+SELECT ok(
+  (
+    SELECT coalesce(c.reloptions, ARRAY[]::text[]) @> ARRAY['security_invoker=true']
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'v'
+      AND c.relname = 'partner_revenue_stats'
+  ),
+  'partner_revenue_stats is security_invoker'
+);
+
+SELECT ok(
+  (
+    SELECT coalesce(c.reloptions, ARRAY[]::text[]) @> ARRAY['security_invoker=true']
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'v'
+      AND c.relname = 'partner_monthly_revenue'
+  ),
+  'partner_monthly_revenue is security_invoker'
+);
+
+SELECT ok(
+  (
+    SELECT coalesce(c.reloptions, ARRAY[]::text[]) @> ARRAY['security_invoker=true']
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'v'
+      AND c.relname = 'my_matches_view'
+  ),
+  'my_matches_view is security_invoker'
+);
+
+SELECT ok(
+  (
+    SELECT coalesce(c.reloptions, ARRAY[]::text[]) @> ARRAY['security_invoker=true']
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'v'
+      AND c.relname = 'settlement_metrics'
+  ),
+  'settlement_metrics is security_invoker'
+);
+
+-- Existing external contracts remain granted to the expected roles.
+SELECT ok(
+  has_table_privilege('anon', 'public.locations_view', 'SELECT'),
+  'anon keeps SELECT on locations_view'
+);
+SELECT ok(
+  has_table_privilege('authenticated', 'public.locations_view', 'SELECT'),
+  'authenticated keeps SELECT on locations_view'
+);
+SELECT ok(
+  has_table_privilege('authenticated', 'public.partner_revenue_stats', 'SELECT'),
+  'authenticated keeps SELECT on partner_revenue_stats'
+);
+SELECT ok(
+  has_table_privilege('authenticated', 'public.partner_monthly_revenue', 'SELECT'),
+  'authenticated keeps SELECT on partner_monthly_revenue'
+);
+SELECT ok(
+  has_table_privilege('authenticated', 'public.my_matches_view', 'SELECT'),
+  'authenticated keeps SELECT on my_matches_view'
+);
+SELECT ok(
+  has_table_privilege('service_role', 'public.settlement_metrics', 'SELECT'),
+  'service_role keeps SELECT on settlement_metrics'
+);
+
+-- Metabase residual views from the advisor artifact are not Minglit runtime
+-- schema and should not remain exposed in public.
+SELECT is(to_regclass('public.v_audit_log')::text, NULL::text, 'v_audit_log residual view is absent');
+SELECT is(to_regclass('public.v_dashboardcard')::text, NULL::text, 'v_dashboardcard residual view is absent');
+SELECT is(to_regclass('public.v_task_runs')::text, NULL::text, 'v_task_runs residual view is absent');
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-high-1

## What

- Sets `security_invoker=true` on the five Minglit runtime public views reported by Supabase Security Advisor: `locations_view`, `partner_revenue_stats`, `partner_monthly_revenue`, `my_matches_view`, `settlement_metrics`.
- Explicitly drops the three `v_*` Metabase residual views from the advisor artifact if they still exist: `v_audit_log`, `v_dashboardcard`, `v_task_runs`.
- Adds pgTAP coverage for view existence, expected SELECT grants, `security_invoker` reloptions, and residual view absence.
- Bumps `supabase/BLUEDOC.md` Reviewed timestamp for the new Supabase files.

## Why

Fixes #2743. These findings are part of #2687's `security_definer_view` ERROR family. Runtime views should use invoking-role permissions/RLS, while the `v_*` objects are not Minglit runtime schema and belong to the residual Metabase cleanup path from #2742.

## Verification

- `git diff --check origin/dev...HEAD`: passed.
- `BASE_REF=origin/dev bash .github/scripts/check-bluedoc-freshness.sh`: passed.
- `supabase test db`: not run successfully locally because Postgres was not running.
- `supabase start`: blocked by Docker socket permission (`/var/run/docker.sock: connect: permission denied`).

## Residual Risk

The `v_*` classification depends on repo search and #2742's residual Metabase inventory. If those views are reintroduced intentionally outside repo migrations, they should live outside the exposed `public` schema or be documented separately.