### PR TITLE
fix(db): pin search paths for advisor functions

### DIFF
--- a/supabase/BLUEDOC.md
+++ b/supabase/BLUEDOC.md
@@ -31,4 +31,4 @@ Minglit 의 **백엔드 구현 루트**. DB migration, Edge Functions, seed, bac
 - [docs/infra/bluedoc/BLUEDOC.md](../docs/infra/bluedoc/BLUEDOC.md) — BLUEDOC 컨벤션
 
 ---
-_Reviewed: 2026-05-24 19:17_
+_Reviewed: 2026-05-24 19:49_

--- a/supabase/migrations/20260524000003_fix_function_search_paths.sql
+++ b/supabase/migrations/20260524000003_fix_function_search_paths.sql
@@ -1,0 +1,82 @@
+-- Issue #2744: fix Security Advisor function_search_path_mutable WARNs.
+--
+-- Keep function bodies, grants, volatility, and SECURITY DEFINER/INVOKER flags
+-- unchanged. This migration only pins each function's runtime search_path.
+
+ALTER FUNCTION admin.validate_retention_policy_legal_min()
+  SET search_path = pg_catalog, admin, public;
+
+ALTER FUNCTION public.cast_match_vote(uuid, uuid, uuid, integer)
+  SET search_path = public;
+
+ALTER FUNCTION public.check_party_tags_limit()
+  SET search_path = public;
+
+ALTER FUNCTION public.check_tag_name_sensitivity()
+  SET search_path = public;
+
+ALTER FUNCTION public.check_user_interest_tags_limit()
+  SET search_path = public;
+
+ALTER FUNCTION public.commit_match_likes(uuid, uuid, uuid[], integer)
+  SET search_path = public;
+
+ALTER FUNCTION public.fn_clear_recurrence_date_on_rule_delete()
+  SET search_path = public;
+
+ALTER FUNCTION public.get_matched_user_contact(uuid, uuid)
+  SET search_path = public;
+
+ALTER FUNCTION public.handle_event_reschedule()
+  SET search_path = public;
+
+ALTER FUNCTION public.handle_fcm_token_update()
+  SET search_path = public;
+
+ALTER FUNCTION public.handle_new_application_files()
+  SET search_path = public;
+
+ALTER FUNCTION public.handle_new_match_vote()
+  SET search_path = public;
+
+ALTER FUNCTION public.handle_new_user_settings()
+  SET search_path = public;
+
+ALTER FUNCTION public.handle_new_user()
+  SET search_path = public;
+
+ALTER FUNCTION public.handle_storage_object_created()
+  SET search_path = public;
+
+ALTER FUNCTION public.handle_updated_at()
+  SET search_path = public;
+
+ALTER FUNCTION public.has_partner_permission(uuid, text)
+  SET search_path = public;
+
+ALTER FUNCTION public.is_super_admin()
+  SET search_path = public;
+
+ALTER FUNCTION public.normalize_for_filter(text)
+  SET search_path = public;
+
+ALTER FUNCTION public.search_events_pgroonga(text)
+  SET search_path = public, extensions;
+
+ALTER FUNCTION public.search_parties_pgroonga(text)
+  SET search_path = public, extensions;
+
+ALTER FUNCTION public.sync_max_participants()
+  SET search_path = public;
+
+ALTER FUNCTION public.sync_partner_member_permissions()
+  SET search_path = public;
+
+ALTER FUNCTION public.update_event_participation_stats()
+  SET search_path = public;
+
+ALTER FUNCTION public.update_single_settlement_ready_status(uuid)
+  SET search_path = public;
+
+ALTER FUNCTION public.update_tag_usage_count()
+  SET search_path = public;

--- a/supabase/tests/database/99_security_definer_search_path_test.sql
+++ b/supabase/tests/database/99_security_definer_search_path_test.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(7);
+SELECT plan(8);
 
 -- Fix #1954: Verify all SECURITY DEFINER functions have SET search_path
 -- to prevent schema injection attacks.
@@ -62,6 +62,52 @@ SELECT ok(
    JOIN pg_namespace n ON n.oid = p.pronamespace
    WHERE n.nspname = 'public' AND p.proname = 'replace_match_rules'),
   'replace_match_rules has SET search_path = public'
+);
+
+WITH expected_functions(schema_name, function_name, identity_arguments, expected_search_path) AS (
+  VALUES
+    ('admin', 'validate_retention_policy_legal_min', '', 'search_path=pg_catalog, admin, public'),
+    ('public', 'cast_match_vote', 'p_event_id uuid, p_voter_id uuid, p_candidate_id uuid, p_max_vote_count integer', 'search_path=public'),
+    ('public', 'check_party_tags_limit', '', 'search_path=public'),
+    ('public', 'check_tag_name_sensitivity', '', 'search_path=public'),
+    ('public', 'check_user_interest_tags_limit', '', 'search_path=public'),
+    ('public', 'commit_match_likes', 'p_event_id uuid, p_voter_id uuid, p_candidate_ids uuid[], p_max_vote_count integer', 'search_path=public'),
+    ('public', 'fn_clear_recurrence_date_on_rule_delete', '', 'search_path=public'),
+    ('public', 'get_matched_user_contact', 'target_user_id uuid, target_event_id uuid', 'search_path=public'),
+    ('public', 'handle_event_reschedule', '', 'search_path=public'),
+    ('public', 'handle_fcm_token_update', '', 'search_path=public'),
+    ('public', 'handle_new_application_files', '', 'search_path=public'),
+    ('public', 'handle_new_match_vote', '', 'search_path=public'),
+    ('public', 'handle_new_user_settings', '', 'search_path=public'),
+    ('public', 'handle_new_user', '', 'search_path=public'),
+    ('public', 'handle_storage_object_created', '', 'search_path=public'),
+    ('public', 'handle_updated_at', '', 'search_path=public'),
+    ('public', 'has_partner_permission', 'p_id uuid, p_key text', 'search_path=public'),
+    ('public', 'is_super_admin', '', 'search_path=public'),
+    ('public', 'normalize_for_filter', 'input text', 'search_path=public'),
+    ('public', 'search_events_pgroonga', 'query text', 'search_path=public, extensions'),
+    ('public', 'search_parties_pgroonga', 'query text', 'search_path=public, extensions'),
+    ('public', 'sync_max_participants', '', 'search_path=public'),
+    ('public', 'sync_partner_member_permissions', '', 'search_path=public'),
+    ('public', 'update_event_participation_stats', '', 'search_path=public'),
+    ('public', 'update_single_settlement_ready_status', 'p_settlement_id uuid', 'search_path=public'),
+    ('public', 'update_tag_usage_count', '', 'search_path=public')
+),
+missing AS (
+  SELECT e.schema_name, e.function_name, e.identity_arguments, e.expected_search_path
+  FROM expected_functions e
+  LEFT JOIN pg_namespace n ON n.nspname = e.schema_name
+  LEFT JOIN pg_proc p
+    ON p.pronamespace = n.oid
+   AND p.proname = e.function_name
+   AND pg_get_function_identity_arguments(p.oid) = e.identity_arguments
+  WHERE p.oid IS NULL
+     OR NOT COALESCE(p.proconfig::text[] @> ARRAY[e.expected_search_path], false)
+)
+SELECT is(
+  (SELECT count(*) FROM missing),
+  0::bigint,
+  'Issue #2744 function_search_path_mutable targets have pinned search_path'
 );
 
 SELECT * FROM finish();


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-high-1

## What changed

- Added an append-only migration that pins function-level `search_path` for the 26 `function_search_path_mutable` Security Advisor WARN targets from #2744.
- Extended `99_security_definer_search_path_test.sql` with a regression query covering all 26 targeted functions and their expected `proconfig` search paths.
- Kept function bodies, grants, volatility, and SECURITY DEFINER/INVOKER settings unchanged.

## Why

Refs #2744. This handles the lowest-blast WARN family first, as recommended in the issue, without mixing in SECURITY DEFINER grant audits, extension moves, storage policy changes, or dashboard-only Auth settings.

## Verification

- `git diff --check`
- `BASE_REF=origin/dev bash .github/scripts/check-bluedoc-freshness.sh`
- migration version duplicate check: no duplicate timestamp prefix
- `supabase test db` could not run because local Postgres was not listening on `127.0.0.1:54322`
- `supabase start` could not run because this worker lacks Docker socket permission

## Residual risk

- CI `test-pgtap` is the first executable DB sensor for the new migration/test.
- Remaining #2744 WARN families are intentionally left for separate follow-up: SECURITY DEFINER grants, extension placement, storage bucket listing policies, `user_notifications` always-true service policy, and Supabase Auth leaked-password protection.