### PR TITLE
fix(db): remove public storage listing policies

### DIFF
--- a/supabase/BLUEDOC.md
+++ b/supabase/BLUEDOC.md
@@ -31,4 +31,4 @@ Minglit 의 **백엔드 구현 루트**. DB migration, Edge Functions, seed, bac
 - [docs/infra/bluedoc/BLUEDOC.md](../docs/infra/bluedoc/BLUEDOC.md) — BLUEDOC 컨벤션
 
 ---
-_Reviewed: 2026-05-23 10:47_
+_Reviewed: 2026-05-24 20:35_

--- a/supabase/migrations/20260524000005_remove_public_bucket_listing_policies.sql
+++ b/supabase/migrations/20260524000005_remove_public_bucket_listing_policies.sql
@@ -1,0 +1,12 @@
+-- Fix #2753: public buckets can serve known object URLs without exposing
+-- storage.objects listing through broad SELECT policies.
+
+DROP POLICY IF EXISTS "Public read for bug report attachments"
+  ON storage.objects;
+
+DROP POLICY IF EXISTS "Public can view party assets"
+  ON storage.objects;
+
+UPDATE storage.buckets
+SET public = true
+WHERE id IN ('bug-report-attachments', 'party-assets');

--- a/supabase/tests/database/82_bug_report_storage_rls_test.sql
+++ b/supabase/tests/database/82_bug_report_storage_rls_test.sql
@@ -22,16 +22,17 @@ SELECT ok(
   'authenticated INSERT 정책이 storage.objects에 존재해야 함'
 );
 
--- SELECT 정책 존재 확인
+-- public bucket URL 접근은 storage.buckets.public 으로 유지하고,
+-- storage.objects SELECT 정책으로 bucket listing 을 열지 않는다.
 SELECT ok(
-  EXISTS (
+  NOT EXISTS (
     SELECT 1 FROM pg_policies
     WHERE schemaname = 'storage'
       AND tablename = 'objects'
       AND policyname = 'Public read for bug report attachments'
       AND cmd = 'SELECT'
   ),
-  'public SELECT 정책이 storage.objects에 존재해야 함'
+  'bug-report-attachments public SELECT/list 정책이 없어야 함'
 );
 
 -- anon 사용자는 bug-report-attachments에 INSERT 불가 (RLS 42501 exception 발생)

--- a/supabase/tests/database/99_public_storage_bucket_listing_policies_test.sql
+++ b/supabase/tests/database/99_public_storage_bucket_listing_policies_test.sql
@@ -1,0 +1,66 @@
+-- Fix #2753: public buckets keep known-object URL access without broad listing.
+BEGIN;
+SELECT plan(5);
+
+SET search_path TO storage, public, extensions;
+
+SELECT is(
+  (SELECT public FROM storage.buckets WHERE id = 'bug-report-attachments'),
+  true,
+  '#2753: bug-report-attachments remains a public bucket for known object URLs'
+);
+
+SELECT is(
+  (SELECT public FROM storage.buckets WHERE id = 'party-assets'),
+  true,
+  '#2753: party-assets remains a public bucket for known object URLs'
+);
+
+SELECT results_eq(
+  $$SELECT count(*)::int
+      FROM pg_policies
+     WHERE schemaname = 'storage'
+       AND tablename = 'objects'
+       AND cmd = 'SELECT'
+       AND policyname IN (
+         'Public read for bug report attachments',
+         'Public can view party assets'
+       )$$,
+  ARRAY[0],
+  '#2753: named broad public SELECT policies are removed'
+);
+
+SELECT results_eq(
+  $$SELECT count(*)::int
+      FROM pg_policies
+     WHERE schemaname = 'storage'
+       AND tablename = 'objects'
+       AND cmd = 'SELECT'
+       AND EXISTS (
+         SELECT 1
+         FROM unnest(roles) AS role_name
+         WHERE role_name::text IN ('public', 'anon', 'authenticated')
+       )
+       AND qual LIKE '%bug-report-attachments%'$$,
+  ARRAY[0],
+  '#2753: clients cannot list bug-report-attachments through storage.objects SELECT'
+);
+
+SELECT results_eq(
+  $$SELECT count(*)::int
+      FROM pg_policies
+     WHERE schemaname = 'storage'
+       AND tablename = 'objects'
+       AND cmd = 'SELECT'
+       AND EXISTS (
+         SELECT 1
+         FROM unnest(roles) AS role_name
+         WHERE role_name::text IN ('public', 'anon', 'authenticated')
+       )
+       AND qual LIKE '%party-assets%'$$,
+  ARRAY[0],
+  '#2753: clients cannot list party-assets through storage.objects SELECT'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-high-1

## What changed

- Dropped the broad `storage.objects` SELECT policies for public buckets `bug-report-attachments` and `party-assets`.
- Kept both buckets `public=true` so known object public URLs continue to work.
- Updated pgTAP coverage to assert the bug-report public SELECT policy is absent and added a regression test covering both buckets' client-visible listing policies.
- Bumped `supabase/BLUEDOC.md` freshness for the new migration.

## Why

Refs #2753. Supabase Security Advisor flagged `public_bucket_allows_listing` for these two bucket-wide SELECT policies. Supabase documents public buckets as serving known public URLs without requiring `storage.objects` permissions, while non-download operations such as listing still require storage policies:

- https://supabase.com/docs/guides/storage/buckets/fundamentals
- https://supabase.com/docs/reference/dart/storage-from-getpublicurl
- https://supabase.com/docs/guides/troubleshooting/why-cant-i-uploadlistetc-my-public-bucket-Z6CmGt

## Verification

- `git diff --check`
- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`
- migration timestamp duplicate check: no duplicate prefix
- `supabase db reset`
- `supabase test db` (117 files, 2175 tests, PASS)

## Residual risk

- CI `test-pgtap` previously hit self-hosted runner/local Supabase state failures before local reset/test passed; rerunning CI after cleanup.
- This assumes app/runtime paths use known object URLs (`getPublicUrl` or constructed public URLs), not bucket listing for these public buckets.