### PR TITLE
fix(db): restrict internal security definer grants

### DIFF
--- a/supabase/BLUEDOC.md
+++ b/supabase/BLUEDOC.md
@@ -31,4 +31,4 @@ Minglit 의 **백엔드 구현 루트**. DB migration, Edge Functions, seed, bac
 - [docs/infra/bluedoc/BLUEDOC.md](../docs/infra/bluedoc/BLUEDOC.md) — BLUEDOC 컨벤션
 
 ---
-_Reviewed: 2026-05-24 20:35_
+_Reviewed: 2026-05-24 21:12_

--- a/supabase/migrations/20260524000006_restrict_internal_security_definer_execute.sql
+++ b/supabase/migrations/20260524000006_restrict_internal_security_definer_execute.sql
@@ -1,0 +1,84 @@
+-- Issue #2752: restrict direct client execution of internal SECURITY DEFINER helpers.
+--
+-- These functions are cron/trigger/service-role implementation details. Client
+-- RPCs and RLS predicate helpers are intentionally left for separate review.
+
+revoke all on function public.calculate_settlement_amounts(bigint, numeric, numeric, numeric)
+  from public, anon, authenticated;
+grant execute on function public.calculate_settlement_amounts(bigint, numeric, numeric, numeric)
+  to service_role;
+
+revoke all on function public.calculate_settlement_checksum(uuid, date, date, character, bigint, numeric, numeric, numeric, bigint, bigint, bigint, bigint)
+  from public, anon, authenticated;
+grant execute on function public.calculate_settlement_checksum(uuid, date, date, character, bigint, numeric, numeric, numeric, bigint, bigint, bigint, bigint)
+  to service_role;
+
+revoke all on function public.transition_settlement_status(uuid, integer, text, text, text, text, text, text, text, text, jsonb, text)
+  from public, anon, authenticated;
+grant execute on function public.transition_settlement_status(uuid, integer, text, text, text, text, text, text, text, text, jsonb, text)
+  to service_role;
+
+revoke all on function public.create_settlement_on_event_completion()
+  from public, anon, authenticated;
+grant execute on function public.create_settlement_on_event_completion()
+  to service_role;
+
+revoke all on function public.update_settlement_ready_status()
+  from public, anon, authenticated;
+grant execute on function public.update_settlement_ready_status()
+  to service_role;
+
+revoke all on function public.check_stuck_processing_settlements()
+  from public, anon, authenticated;
+grant execute on function public.check_stuck_processing_settlements()
+  to service_role;
+
+revoke all on function public.calculate_next_retry_at(integer)
+  from public, anon, authenticated;
+grant execute on function public.calculate_next_retry_at(integer)
+  to service_role;
+
+revoke all on function public.assemble_payouts()
+  from public, anon, authenticated;
+grant execute on function public.assemble_payouts()
+  to service_role;
+
+revoke all on function public.retry_failed_settlements()
+  from public, anon, authenticated;
+grant execute on function public.retry_failed_settlements()
+  to service_role;
+
+revoke all on function public.calculate_scheduled_at(date, time without time zone)
+  from public, anon, authenticated;
+grant execute on function public.calculate_scheduled_at(date, time without time zone)
+  to service_role;
+
+revoke all on function public.classify_reconciliation_mismatch(bigint, bigint, date, date, text, text)
+  from public, anon, authenticated;
+grant execute on function public.classify_reconciliation_mismatch(bigint, bigint, date, date, text, text)
+  to service_role;
+
+revoke all on function public.force_fail_processing_on_kill_switch()
+  from public, anon, authenticated;
+grant execute on function public.force_fail_processing_on_kill_switch()
+  to service_role;
+
+revoke all on function public.toggle_settlement_kill_switch(boolean, text)
+  from public, anon, authenticated;
+grant execute on function public.toggle_settlement_kill_switch(boolean, text)
+  to service_role;
+
+revoke all on function public.check_settlement_alarms()
+  from public, anon, authenticated;
+grant execute on function public.check_settlement_alarms()
+  to service_role;
+
+revoke all on function public.check_db_invariants()
+  from public, anon, authenticated;
+grant execute on function public.check_db_invariants()
+  to service_role;
+
+revoke all on function public.upsert_github_daily_stat(date, text, integer)
+  from public, anon, authenticated;
+grant execute on function public.upsert_github_daily_stat(date, text, integer)
+  to service_role;

--- a/supabase/tests/database/103_internal_security_definer_execute_grants_test.sql
+++ b/supabase/tests/database/103_internal_security_definer_execute_grants_test.sql
@@ -1,0 +1,98 @@
+BEGIN;
+
+SELECT plan(3);
+
+-- Issue #2752: internal SECURITY DEFINER helpers should not be directly
+-- executable by client roles. They remain callable by service_role Edge
+-- Functions, cron jobs, and trigger-owned flows.
+
+SELECT is_empty(
+  $$
+  WITH target(function_signature) AS (
+    VALUES
+      ('public.calculate_settlement_amounts(bigint, numeric, numeric, numeric)'),
+      ('public.calculate_settlement_checksum(uuid, date, date, character, bigint, numeric, numeric, numeric, bigint, bigint, bigint, bigint)'),
+      ('public.transition_settlement_status(uuid, integer, text, text, text, text, text, text, text, text, jsonb, text)'),
+      ('public.create_settlement_on_event_completion()'),
+      ('public.update_settlement_ready_status()'),
+      ('public.check_stuck_processing_settlements()'),
+      ('public.calculate_next_retry_at(integer)'),
+      ('public.assemble_payouts()'),
+      ('public.retry_failed_settlements()'),
+      ('public.calculate_scheduled_at(date, time without time zone)'),
+      ('public.classify_reconciliation_mismatch(bigint, bigint, date, date, text, text)'),
+      ('public.force_fail_processing_on_kill_switch()'),
+      ('public.toggle_settlement_kill_switch(boolean, text)'),
+      ('public.check_settlement_alarms()'),
+      ('public.check_db_invariants()'),
+      ('public.upsert_github_daily_stat(date, text, integer)')
+  )
+  SELECT function_signature
+  FROM target
+  WHERE has_function_privilege('anon', function_signature, 'EXECUTE')
+  ORDER BY function_signature
+  $$,
+  'anon cannot EXECUTE internal SECURITY DEFINER helpers'
+);
+
+SELECT is_empty(
+  $$
+  WITH target(function_signature) AS (
+    VALUES
+      ('public.calculate_settlement_amounts(bigint, numeric, numeric, numeric)'),
+      ('public.calculate_settlement_checksum(uuid, date, date, character, bigint, numeric, numeric, numeric, bigint, bigint, bigint, bigint)'),
+      ('public.transition_settlement_status(uuid, integer, text, text, text, text, text, text, text, text, jsonb, text)'),
+      ('public.create_settlement_on_event_completion()'),
+      ('public.update_settlement_ready_status()'),
+      ('public.check_stuck_processing_settlements()'),
+      ('public.calculate_next_retry_at(integer)'),
+      ('public.assemble_payouts()'),
+      ('public.retry_failed_settlements()'),
+      ('public.calculate_scheduled_at(date, time without time zone)'),
+      ('public.classify_reconciliation_mismatch(bigint, bigint, date, date, text, text)'),
+      ('public.force_fail_processing_on_kill_switch()'),
+      ('public.toggle_settlement_kill_switch(boolean, text)'),
+      ('public.check_settlement_alarms()'),
+      ('public.check_db_invariants()'),
+      ('public.upsert_github_daily_stat(date, text, integer)')
+  )
+  SELECT function_signature
+  FROM target
+  WHERE has_function_privilege('authenticated', function_signature, 'EXECUTE')
+  ORDER BY function_signature
+  $$,
+  'authenticated cannot EXECUTE internal SECURITY DEFINER helpers'
+);
+
+SELECT is_empty(
+  $$
+  WITH target(function_signature) AS (
+    VALUES
+      ('public.calculate_settlement_amounts(bigint, numeric, numeric, numeric)'),
+      ('public.calculate_settlement_checksum(uuid, date, date, character, bigint, numeric, numeric, numeric, bigint, bigint, bigint, bigint)'),
+      ('public.transition_settlement_status(uuid, integer, text, text, text, text, text, text, text, text, jsonb, text)'),
+      ('public.create_settlement_on_event_completion()'),
+      ('public.update_settlement_ready_status()'),
+      ('public.check_stuck_processing_settlements()'),
+      ('public.calculate_next_retry_at(integer)'),
+      ('public.assemble_payouts()'),
+      ('public.retry_failed_settlements()'),
+      ('public.calculate_scheduled_at(date, time without time zone)'),
+      ('public.classify_reconciliation_mismatch(bigint, bigint, date, date, text, text)'),
+      ('public.force_fail_processing_on_kill_switch()'),
+      ('public.toggle_settlement_kill_switch(boolean, text)'),
+      ('public.check_settlement_alarms()'),
+      ('public.check_db_invariants()'),
+      ('public.upsert_github_daily_stat(date, text, integer)')
+  )
+  SELECT function_signature
+  FROM target
+  WHERE NOT has_function_privilege('service_role', function_signature, 'EXECUTE')
+  ORDER BY function_signature
+  $$,
+  'service_role can EXECUTE internal SECURITY DEFINER helpers'
+);
+
+SELECT * FROM finish();
+
+ROLLBACK;


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-high-1

## What changed

Restricts the first low-blast subset of internal SECURITY DEFINER helpers from direct client execution. The migration revokes EXECUTE from `PUBLIC`, `anon`, and `authenticated` for 16 cron/trigger/service-role implementation functions, then grants EXECUTE back to `service_role`.

Adds pgTAP coverage that verifies:
- `anon` cannot execute the selected internal helpers
- `authenticated` cannot execute the selected internal helpers
- `service_role` retains execute permission

## Why

Refs #2752. This reduces the Supabase advisor SECURITY DEFINER executable WARN family without touching client-facing RPCs or RLS predicate helpers in the same PR.

## Verification

- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`
- `git diff --check origin/dev-staging...HEAD`
- migration version duplicate check
- `supabase start`
- `supabase test db` — PASS, 118 files / 2178 tests

## Residual risk

This intentionally handles only the internal-helper subset. Remaining SECURITY DEFINER RPC grants still need separate audit/remediation so client-facing read/search/checkin/feed/application functions are not broken by a broad revoke.