### PR TITLE
fix(ci): run iOS deploy build on non-main branches

### DIFF
--- a/.github/actions/ios-deploy/action.yml
+++ b/.github/actions/ios-deploy/action.yml
@@ -123,7 +123,7 @@ runs:
       run: pod install
 
     - name: Set Dev Bundle ID
-      if: ${{ inputs.git-ref == 'refs/heads/dev' }}
+      if: ${{ inputs.git-ref != 'refs/heads/main' }}
       shell: bash
       working-directory: ./${{ inputs.app-directory }}
       run: |
@@ -133,7 +133,7 @@ runs:
     # prod Info.plist에는 이 scheme이 존재하지 않음을 보장
     # app_user 전용 — partner 앱에는 minglit-dev:// scheme 불필요
     - name: Add Dev URL Scheme
-      if: ${{ inputs.git-ref == 'refs/heads/dev' && inputs.app-directory == 'apps/app_user' }}
+      if: ${{ inputs.git-ref != 'refs/heads/main' && inputs.app-directory == 'apps/app_user' }}
       shell: bash
       working-directory: ./${{ inputs.app-directory }}
       run: |
@@ -150,7 +150,7 @@ runs:
         /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:${IDX}:CFBundleURLSchemes array" "$PLIST"
         /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:${IDX}:CFBundleURLSchemes:0 string minglit-dev" "$PLIST"
         # Note: feature 브랜치 빌드에는 이 scheme을 포함하지 않는다.
-        # dev flavor 딥링크는 dev 브랜치 CI 빌드에서만 필요하며,
+        # dev flavor 딥링크는 non-main CI 빌드에서만 필요하며,
         # 로컬 개발은 adb/flutter run으로 직접 접근 가능하다.
 
     - name: Generate keychain password
@@ -194,7 +194,7 @@ runs:
         GIT_REF: ${{ inputs.git-ref }}
       run: |
         mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-        if [ "$GIT_REF" = "refs/heads/dev" ]; then
+        if [ "$GIT_REF" != "refs/heads/main" ]; then
           PROFILE_B64="$APPLE_PROVISION_PROFILE_DEV_BASE64"
         else
           PROFILE_B64="$APPLE_PROVISION_PROFILE_PROD_BASE64"
@@ -230,7 +230,7 @@ runs:
         sed -i '' '/PROVISIONING_PROFILE_SPECIFIER/d' "$PBXPROJ"
 
         # Select provisioning profile specifier based on branch
-        if [ "$GIT_REF" = "refs/heads/dev" ]; then
+        if [ "$GIT_REF" != "refs/heads/main" ]; then
           PROFILE_SPECIFIER="${{ inputs.provisioning-profile-dev-specifier }}"
         else
           PROFILE_SPECIFIER="${{ inputs.provisioning-profile-prod-specifier }}"
@@ -254,7 +254,7 @@ runs:
         cat ios/CI.xcconfig
 
     - name: Build IPA (Dev)
-      if: ${{ inputs.git-ref == 'refs/heads/dev' }}
+      if: ${{ inputs.git-ref != 'refs/heads/main' }}
       shell: bash
       working-directory: ./${{ inputs.app-directory }}
       run: |

--- a/.github/scripts/BLUEDOC.md
+++ b/.github/scripts/BLUEDOC.md
@@ -10,6 +10,7 @@
 | [`run-user-cuj.sh`](./run-user-cuj.sh) | `apps/app_user/integration_test/cuj/` 의 CUJ 테스트 실행 (emulator) | `shared-cuj-integration` (app-name=user 일 때) |
 | [`run-partner-cuj.sh`](./run-partner-cuj.sh) | `apps/app_partner/integration_test/cuj/` CUJ 실행 | `shared-cuj-integration` (app-name=partner 일 때) |
 | [`check-bluedoc-freshness.sh`](./check-bluedoc-freshness.sh) | PR 에서 새/삭제 파일에 대해 가장 가까운 ancestor BLUEDOC.md 갱신 강제. 통과: 이정표 표 갱신 또는 BLUEDOC 의 `_Reviewed_` 날짜 bump. + 모든 BLUEDOC.md 의 Reviewed 형식 검증 | `pr-gate.check-bluedoc-freshness` (required check) |
+| [`check-ios-deploy-branch-conditions.sh`](./check-ios-deploy-branch-conditions.sh) | `ios-deploy` action 의 브랜치 분기(`main` vs `non-main`) 회귀 검증 | 수동 실행 (`bash .github/scripts/check-ios-deploy-branch-conditions.sh`) |
 
 ## 핵심 컨벤션
 
@@ -26,4 +27,4 @@
 - [.github/BLUEDOC.md](../BLUEDOC.md) — 상위 진입점
 
 ---
-_Reviewed: 2026-05-17 22:50_
+_Reviewed: 2026-05-24 21:30_

--- a/.github/scripts/check-ios-deploy-branch-conditions.sh
+++ b/.github/scripts/check-ios-deploy-branch-conditions.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION_FILE=".github/actions/ios-deploy/action.yml"
+
+if [[ ! -f "$ACTION_FILE" ]]; then
+  echo "ERROR: Missing $ACTION_FILE"
+  exit 1
+fi
+
+# Regression guard: dev-staging (and any non-main branch) must go through
+# development build/signing path, not be silently skipped.
+if rg -n "refs/heads/dev" "$ACTION_FILE" >/dev/null; then
+  echo "ERROR: Found legacy refs/heads/dev checks in $ACTION_FILE"
+  rg -n "refs/heads/dev" "$ACTION_FILE"
+  exit 1
+fi
+
+required_patterns=(
+  "inputs.git-ref != 'refs/heads/main'"
+  '[ "$GIT_REF" != "refs/heads/main" ]'
+)
+
+for pattern in "${required_patterns[@]}"; do
+  if ! rg -F "$pattern" "$ACTION_FILE" >/dev/null; then
+    echo "ERROR: Missing required branch condition pattern: $pattern"
+    exit 1
+  fi
+done
+
+echo "OK: iOS deploy branch conditions validated (main vs non-main)"


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- fix `ios-deploy` branch gating from `dev/main` split to `main` vs `non-main`
- ensure non-main branches (including `dev-staging`) run DEV signing/profile + DEV IPA build path
- add regression guard script: `.github/scripts/check-ios-deploy-branch-conditions.sh`

## Why
- P0 incidents #2758 and #2759 failed on `dev-staging` because `Build IPA (Dev)` step was skipped.
- skipped build caused `build/ios/ipa/*.ipa` missing in release publish step.

## Verification
- `bash .github/scripts/check-ios-deploy-branch-conditions.sh`
- `python3 -c "import yaml; yaml.safe_load(open('.github/actions/ios-deploy/action.yml'))"`

## Risks
- Branch classification is now explicit: only `main` is production build path; all others are development path.

Closes #2758
Closes #2759
