### PR TITLE
fix(db): tighten user notifications insert RLS

### DIFF
--- a/supabase/BLUEDOC.md
+++ b/supabase/BLUEDOC.md
@@ -31,4 +31,4 @@ Minglit 의 **백엔드 구현 루트**. DB migration, Edge Functions, seed, bac
 - [docs/infra/bluedoc/BLUEDOC.md](../docs/infra/bluedoc/BLUEDOC.md) — BLUEDOC 컨벤션
 
 ---
-_Reviewed: 2026-05-25 00:34_
+_Reviewed: 2026-05-25 16:37_

--- a/supabase/migrations/20260524000007_tighten_user_notifications_insert_rls.sql
+++ b/supabase/migrations/20260524000007_tighten_user_notifications_insert_rls.sql
@@ -1,0 +1,12 @@
+-- Fix #2755: remove always-true INSERT RLS for user_notifications.
+-- Notification writes are service-role only through notification-worker/EF paths.
+
+DROP POLICY IF EXISTS "Service role can insert notifications" ON public.user_notifications;
+
+CREATE POLICY "Service role can insert notifications"
+  ON public.user_notifications
+  FOR INSERT
+  WITH CHECK (auth.role() = 'service_role');
+
+REVOKE INSERT ON public.user_notifications FROM PUBLIC, anon, authenticated;
+GRANT INSERT ON public.user_notifications TO service_role;

--- a/supabase/tests/database/11_notifications_rls_test.sql
+++ b/supabase/tests/database/11_notifications_rls_test.sql
@@ -1,5 +1,5 @@
 BEGIN;
-SELECT plan(6);
+SELECT plan(9);
 
 SELECT tests.create_supabase_user('user_a', 'a@test.com');
 SELECT tests.create_supabase_user('user_b', 'b@test.com');
@@ -29,6 +29,51 @@ WITH notif_b AS (
   RETURNING id
 )
 SELECT set_config('tests.notif_b', id::text, true) FROM notif_b;
+
+SELECT lives_ok(
+  format(
+    $$
+      INSERT INTO public.user_notifications (user_id, title, body, category)
+      VALUES ('%s', 'Service insert', 'Service body', 'service')
+    $$,
+    tests.get_supabase_uid('user_a')
+  ),
+  'service_role can insert notifications'
+);
+
+SELECT tests.clear_authentication();
+
+SAVEPOINT before_anon_notification_insert;
+SELECT throws_ok(
+  format(
+    $$
+      INSERT INTO public.user_notifications (user_id, title, body, category)
+      VALUES ('%s', 'Anon insert', 'Anon body', 'service')
+    $$,
+    tests.get_supabase_uid('user_a')
+  ),
+  NULL,
+  NULL,
+  'anon cannot insert arbitrary notifications'
+);
+ROLLBACK TO SAVEPOINT before_anon_notification_insert;
+
+SELECT tests.authenticate_as('user_a');
+
+SAVEPOINT before_authenticated_notification_insert;
+SELECT throws_ok(
+  format(
+    $$
+      INSERT INTO public.user_notifications (user_id, title, body, category)
+      VALUES ('%s', 'Authenticated insert', 'Authenticated body', 'service')
+    $$,
+    tests.get_supabase_uid('user_a')
+  ),
+  NULL,
+  NULL,
+  'authenticated users cannot insert arbitrary notifications'
+);
+ROLLBACK TO SAVEPOINT before_authenticated_notification_insert;
 
 SELECT tests.clear_authentication();
 SELECT is_empty(


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-high-1

## What changed

Tightens `public.user_notifications` INSERT RLS so the policy is no longer `WITH CHECK (true)`:

- Recreates `Service role can insert notifications` with `WITH CHECK (auth.role() = 'service_role')`.
- Explicitly revokes INSERT from `PUBLIC`, `anon`, and `authenticated`.
- Explicitly grants INSERT to `service_role`.
- Extends notification RLS pgTAP coverage for service-role insert success and anon/authenticated insert denial.

## Why

Refs #2755. Supabase Security Advisor flagged the previous always-true INSERT policy as `rls_policy_always_true`. Notification writes are service/system-owned through the notification worker, not a client direct-write contract.

## Verification

- `BASE_REF=origin/dev-staging bash .github/scripts/check-bluedoc-freshness.sh`
- `git diff --cached --check`
- migration version duplicate check
- `supabase start`
- `supabase test db` — PASS, 118 files / 2181 tests
- local catalog check: `user_notifications` INSERT policy now checks `auth.role() = 'service_role'`; INSERT grant exists only for `postgres` and `service_role`

## Residual risk

Next Supabase Security Advisor run still needs to confirm the `rls_policy_always_true` WARN disappears in dev. Runtime blast radius is low because authenticated clients previously had no INSERT grant and tests now guard anon/authenticated insert denial.