### PR TITLE
ci: require issue lifecycle intent in dev-staging PRs

### DIFF
--- a/.github/scripts/BLUEDOC.md
+++ b/.github/scripts/BLUEDOC.md
@@ -10,6 +10,7 @@
 | [`run-user-cuj.sh`](./run-user-cuj.sh) | `apps/app_user/integration_test/cuj/` 의 CUJ 테스트 실행 (emulator) | `shared-cuj-integration` (app-name=user 일 때) |
 | [`run-partner-cuj.sh`](./run-partner-cuj.sh) | `apps/app_partner/integration_test/cuj/` CUJ 실행 | `shared-cuj-integration` (app-name=partner 일 때) |
 | [`check-bluedoc-freshness.sh`](./check-bluedoc-freshness.sh) | PR 에서 새/삭제 파일에 대해 가장 가까운 ancestor BLUEDOC.md 갱신 강제. 통과: 이정표 표 갱신 또는 BLUEDOC 의 `_Reviewed_` 날짜 bump. + 모든 BLUEDOC.md 의 Reviewed 형식 검증 | `pr-gate.check-bluedoc-freshness` (required check) |
+| [`check-pr-issue-reference.sh`](./check-pr-issue-reference.sh) | dev-staging PR 본문에 이슈 종료 의도(`Closes/Fixes/Resolves`) 또는 명시적 비종료 사유(`Refs` + 이유 / `No linked issue`)가 있는지 검사 | `pr-gate.static-checks` |
 | [`check-ios-deploy-branch-conditions.sh`](./check-ios-deploy-branch-conditions.sh) | `ios-deploy` action 의 브랜치 분기(`main` vs `non-main`) 회귀 검증 | 수동 실행 (`bash .github/scripts/check-ios-deploy-branch-conditions.sh`) |
 | [`check-android-deploy-workflow-contract.py`](./check-android-deploy-workflow-contract.py) | Android deploy release archive 가 `github.token` + `contents: write` 를 사용하고 PAT caller 계약을 요구하지 않는지 검증 | `pr-gate.static-checks` |
 | [`scan-build-artifact-secrets.py`](./scan-build-artifact-secrets.py) | APK/AAB/`.next` 등 빌드 산출물에서 Supabase service-role secret 패턴을 redacted summary 로 검사 | `pr-gate.scan-build-artifact-secrets` |
@@ -29,4 +30,4 @@
 - [.github/BLUEDOC.md](../BLUEDOC.md) — 상위 진입점
 
 ---
-_Reviewed: 2026-05-24 21:30_
+_Reviewed: 2026-05-25 12:00_

--- a/.github/scripts/check-pr-issue-reference.sh
+++ b/.github/scripts/check-pr-issue-reference.sh
@@ -40,18 +40,21 @@ case "$author" in
     ;;
 esac
 
-if printf '%s\n' "$title" | grep -Eiq '^(backport|release)(\(|:)|^ci\(dev-staging-dev-cut\):'; then
-  echo "Release/backport PR title; skipping PR issue reference check."
+if printf '%s\n' "$title" | grep -Eiq '^ci\(rc-backport\): backport rc hotfix #[0-9]+ to dev-staging$'; then
+  echo "Release-bot RC hotfix backport PR title; skipping PR issue reference check."
   exit 0
 fi
 
-if printf '%s\n' "$body" | grep -Eiq '(^|[^[:alnum:]_-])(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+((#[0-9]+)|([[:alnum:]_.-]+/[[:alnum:]_.-]+#[0-9]+)|(https://github[.]com/[^[:space:]]+/issues/[0-9]+))'; then
+issue_ref='((#[0-9]+)|([[:alnum:]_.-]+/[[:alnum:]_.-]+#[0-9]+)|(https://github[.]com/[^[:space:]]+/issues/[0-9]+))'
+keyword_separator='([[:space:]]+|[[:space:]]*:[[:space:]]*)'
+
+if printf '%s\n' "$body" | grep -Eiq "(^|[^[:alnum:]_-])(close[sd]?|fix(e[sd])?|resolve[sd]?)${keyword_separator}${issue_ref}"; then
   echo "PR body contains a closing issue keyword."
   exit 0
 fi
 
 has_refs=false
-if printf '%s\n' "$body" | grep -Eiq '(^|[^[:alnum:]_-])(refs?|references?)[[:space:]]+((#[0-9]+)|([[:alnum:]_.-]+/[[:alnum:]_.-]+#[0-9]+)|(https://github[.]com/[^[:space:]]+/issues/[0-9]+))'; then
+if printf '%s\n' "$body" | grep -Eiq "(^|[^[:alnum:]_-])(refs?|references?)${keyword_separator}${issue_ref}"; then
   has_refs=true
 fi
 

--- a/.github/scripts/check-pr-issue-reference.sh
+++ b/.github/scripts/check-pr-issue-reference.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+stage="${PR_GATE_STAGE:-}"
+if [ "$stage" != "dev-staging" ]; then
+  echo "Stage is '${stage:-unset}', not dev-staging; skipping PR issue reference check."
+  exit 0
+fi
+
+if [ -z "${GITHUB_EVENT_PATH:-}" ] || [ ! -f "$GITHUB_EVENT_PATH" ]; then
+  echo "GITHUB_EVENT_PATH is unavailable; skipping PR issue reference check."
+  exit 0
+fi
+
+if ! jq -e '.pull_request.number' "$GITHUB_EVENT_PATH" >/dev/null 2>&1; then
+  echo "Not a pull_request payload; skipping PR issue reference check."
+  exit 0
+fi
+
+base_ref=$(jq -r '.pull_request.base.ref // ""' "$GITHUB_EVENT_PATH")
+if [ "$base_ref" != "dev-staging" ]; then
+  echo "PR base is '$base_ref', not dev-staging; skipping PR issue reference check."
+  exit 0
+fi
+
+draft=$(jq -r '.pull_request.draft // false' "$GITHUB_EVENT_PATH")
+if [ "$draft" = "true" ]; then
+  echo "Draft PR; skipping PR issue reference check until ready for review."
+  exit 0
+fi
+
+author=$(jq -r '.pull_request.user.login // ""' "$GITHUB_EVENT_PATH")
+title=$(jq -r '.pull_request.title // ""' "$GITHUB_EVENT_PATH")
+body=$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")
+
+case "$author" in
+  dependabot[bot]|minglit-release-bot[bot])
+    echo "Bot-authored PR by $author; skipping PR issue reference check."
+    exit 0
+    ;;
+esac
+
+if printf '%s\n' "$title" | grep -Eiq '^(backport|release)(\(|:)|^ci\(dev-staging-dev-cut\):'; then
+  echo "Release/backport PR title; skipping PR issue reference check."
+  exit 0
+fi
+
+if printf '%s\n' "$body" | grep -Eiq '(^|[^[:alnum:]_-])(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+((#[0-9]+)|([[:alnum:]_.-]+/[[:alnum:]_.-]+#[0-9]+)|(https://github[.]com/[^[:space:]]+/issues/[0-9]+))'; then
+  echo "PR body contains a closing issue keyword."
+  exit 0
+fi
+
+has_refs=false
+if printf '%s\n' "$body" | grep -Eiq '(^|[^[:alnum:]_-])(refs?|references?)[[:space:]]+((#[0-9]+)|([[:alnum:]_.-]+/[[:alnum:]_.-]+#[0-9]+)|(https://github[.]com/[^[:space:]]+/issues/[0-9]+))'; then
+  has_refs=true
+fi
+
+has_nonclosing_reason=false
+if printf '%s\n' "$body" | grep -Eiq '(partial|partially|follow-?up|umbrella|parent|tracking|one feature per PR|not close|no close|close[[:space:]]+금지|닫지[[:space:]]*않|부분|일부|후속|상위|추적)'; then
+  has_nonclosing_reason=true
+fi
+
+if [ "$has_refs" = "true" ] && [ "$has_nonclosing_reason" = "true" ]; then
+  echo "PR body uses Refs with an explicit non-closing reason."
+  exit 0
+fi
+
+if printf '%s\n' "$body" | grep -Eiq '(^|[[:space:]])No linked issue:[[:space:]].{10,}'; then
+  echo "PR body declares an explicit no-linked-issue reason."
+  exit 0
+fi
+
+cat <<'MSG'
+::error::dev-staging PR body must declare issue lifecycle intent.
+
+Add one of:
+- `Closes #123` / `Fixes #123` / `Resolves #123` when this PR fully resolves the issue.
+- `Refs #123` plus a clear non-closing reason when this is partial work, an umbrella issue, or a follow-up tracker.
+- `No linked issue: <reason>` only for exceptional PRs that genuinely have no issue.
+
+This prevents agent PRs from merging without closing the issue they completed.
+MSG
+exit 1

--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -10,7 +10,7 @@
 
 | Prefix | 빨갛게 뜨면 = | 예시 파일 |
 |---|---|---|
-| `pr-gate-` | **머지 못 함** (required check — Gitleaks 시크릿 검사 포함) | `pr-gate.yml`, `pr-gate-fresh-doc.yml` |
+| `pr-gate-` | **머지 못 함** (required check — static PR 메시지 검사 + Gitleaks 시크릿 검사 포함) | `pr-gate.yml`, `pr-gate-fresh-doc.yml` |
 | `pr-setup-` | PR push 마다 PR 브랜치를 mutate 하는 자동화 (포맷 등) | (현재 없음 — `pr-setup-format` 은 #2627 에서 `pr-gate-format-check` 잡으로 대체) |
 | `pr-review-setup-` | PR 의 "리뷰 준비" 자동화 — auto-merge enable + 조건 충족 시 `needs-review` 라벨 부여 | `pr-review-setup` |
 | `deploy-` | 사용자·dev 환경에 코드·스키마·시드가 안 갔음 | `dev-deploy`, `main-deploy`, `deploy-vercel`, `deploy-supabase`, `deploy-android-user`, `deploy-ios-user`, `deploy-dev-seed` |
@@ -69,4 +69,4 @@
 - [CLAUDE.md](../../CLAUDE.md) `## PR Conventions` — branch별 required check / auto-merge 흐름
 
 ---
-_Reviewed: 2026-05-24 16:45_
+_Reviewed: 2026-05-25 12:00_

--- a/.github/workflows/dev-pr-gate.yml
+++ b/.github/workflows/dev-pr-gate.yml
@@ -33,7 +33,7 @@ jobs:
 
   dev-pr-gate:
     needs: [source-guard, pr-gate-core]
-    if: always()
+    if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Publish branch gate result

--- a/.github/workflows/dev-staging-pr-gate.yml
+++ b/.github/workflows/dev-staging-pr-gate.yml
@@ -25,7 +25,7 @@ jobs:
 
   dev-staging-pr-gate:
     needs: [pr-gate-core]
-    if: always()
+    if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Publish branch gate result

--- a/.github/workflows/dev-staging-pr-gate.yml
+++ b/.github/workflows/dev-staging-pr-gate.yml
@@ -3,6 +3,7 @@ name: dev-staging-pr-gate
 on:
   pull_request:
     branches: [dev-staging]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
 
 permissions:
   contents: write

--- a/.github/workflows/main-pr-gate.yml
+++ b/.github/workflows/main-pr-gate.yml
@@ -105,7 +105,7 @@ jobs:
 
   main-pr-gate:
     needs: [source-guard, pr-gate-core, validate-rc-promotion]
-    if: always()
+    if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Publish branch gate result

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -21,11 +21,11 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Consolidated fast read-only static checks: 6 verifications that previously each
+  # Consolidated fast read-only static checks: 7 verifications that previously each
   # ran in its own ubuntu-latest job (migration version uniqueness + same-day gap
   # warning, env-manifest ↔ EnvKeyStore drift, workflow YAML parse validity,
   # androidx.test runner/orchestrator version alignment, cross-feature import
-  # baseline, BLUEDOC freshness).
+  # baseline, BLUEDOC freshness, dev-staging PR issue lifecycle intent).
   #
   # Why merge: each separate job paid runner startup + actions/checkout overhead
   # (~10-15s × 6 = ~70s of Actions minutes per PR). Combined into one job with a
@@ -43,6 +43,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # BLUEDOC freshness needs history for base-ref diff
+
+      - name: Check PR issue reference
+        if: ${{ !cancelled() }}
+        env:
+          PR_GATE_STAGE: ${{ inputs.stage }}
+        run: bash .github/scripts/check-pr-issue-reference.sh
 
       - name: Check duplicate migration versions
         if: ${{ !cancelled() }}

--- a/.github/workflows/rc-pr-gate.yml
+++ b/.github/workflows/rc-pr-gate.yml
@@ -33,7 +33,7 @@ jobs:
 
   rc-pr-gate:
     needs: [source-guard, pr-gate-core]
-    if: always()
+    if: ${{ always() && !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Publish branch gate result


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-high-1

No linked issue: operational CI guard requested during agent PR lifecycle cleanup.

## What
- Adds a static pr-gate check for dev-staging PR issue lifecycle intent.
- Requires `Closes`/`Fixes`/`Resolves` for fully resolved issues.
- Allows `Refs` only when paired with an explicit non-closing reason, plus an exceptional `No linked issue:` escape hatch.
- Accepts GitHub's valid colon lifecycle syntax such as `Closes: #123`, `Fixes: #123`, and `Refs: #123`.
- Narrows title-based bypasses to the concrete release-bot RC hotfix backport PR format only.
- Reruns the dev-staging PR gate on `ready_for_review` and `edited` events so draft or body-edit paths cannot keep a stale successful check.
- Prevents cancelled superseded branch-gate wrapper runs from publishing stale failed required checks.

## Verification
- `bash -n .github/scripts/check-pr-issue-reference.sh`
- `python3` YAML parse for `.github/workflows/dev-staging-pr-gate.yml`, `.github/workflows/dev-pr-gate.yml`, `.github/workflows/rc-pr-gate.yml`, `.github/workflows/main-pr-gate.yml`, and `.github/workflows/pr-gate.yml`
- Local sample payload checks for:
  - `Closes #123` pass
  - `Closes: #123` pass
  - `Fixes: Mark-Yun/minglit#123` pass
  - `Refs: #123` plus partial/follow-up reason pass
  - concrete `ci(rc-backport): backport rc hotfix #1234 to dev-staging` title pass
  - generic `release: refactor ci logs` title fail
  - missing lifecycle intent fail
- Static check that `dev-staging-pr-gate.yml` includes `opened`, `synchronize`, `reopened`, `ready_for_review`, and `edited` pull_request activity types
- Static check that branch gate wrappers use `always() && !cancelled()` for result publishing
- `git diff --check`

## Residual Risk
- GitHub Actions cancellation semantics are verified by the live PR gate after this push.