### PR TITLE
fix(mds): resolve token JSON path in Vercel builds

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -675,6 +675,9 @@ jobs:
         continue-on-error: true
       - run: npm run lint
       - run: npm run build
+      - name: Build from repo root
+        working-directory: .
+        run: ./apps/mds/docs/node_modules/.bin/next build apps/mds/docs
 
   # MDS Icons CI — flutter analyze + npm build (codegen)
   lint-mds-icons:

--- a/apps/mds/docs/src/lib/tokens.ts
+++ b/apps/mds/docs/src/lib/tokens.ts
@@ -79,12 +79,27 @@ function flattenTokens(
 }
 
 // ---------------------------------------------------------------------------
-// Token directory — resolved relative to repo root from mds/docs
+// Token directory — local Next builds run from apps/mds/docs, while Vercel
+// deploy builds may run from the repo root.
 // ---------------------------------------------------------------------------
-const TOKEN_DIR = path.resolve(
-  process.cwd(),
-  '../../../shared/packages/mds/tokens/tokens',
-);
+const TOKEN_DIR_CANDIDATES = [
+  path.resolve(process.cwd(), '../../../shared/packages/mds/tokens/tokens'),
+  path.resolve(process.cwd(), 'shared/packages/mds/tokens/tokens'),
+];
+
+function resolveTokenDir(): string {
+  for (const candidate of TOKEN_DIR_CANDIDATES) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    `Unable to locate MDS token JSON directory. Tried: ${TOKEN_DIR_CANDIDATES.join(', ')}`,
+  );
+}
+
+const TOKEN_DIR = resolveTokenDir();
 
 function readTokenFile(filename: string): TokenGroup {
   const filePath = path.join(TOKEN_DIR, filename);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8918,6 +8918,126 @@
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       }
+    },
+    "apps/mds/docs/node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
+      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/mds/docs/node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
+      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/mds/docs/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
+      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/mds/docs/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
+      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/mds/docs/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
+      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/mds/docs/node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
+      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/mds/docs/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
+      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "apps/mds/docs/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
+      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-high-1

## Goal

Closes #2776. Restore dev Vercel deploy for MDS docs by fixing the `/tokens` prerender failure.

## Changes

- Resolve MDS token JSON from either `apps/mds/docs` cwd or repo-root cwd so local Next builds and Vercel deploy builds both find `shared/packages/mds/tokens/tokens/*.json`.
- Commit the Next-generated `@next/swc` optional dependency lockfile entries so docs builds do not patch the root lockfile at build time.
- Add a `lint-and-build-mds-docs` CI step that runs `next build apps/mds/docs` from the repo root, locking the Vercel cwd regression path.

## Verification

- `npm run lint` in `apps/mds/docs` (passes with existing warning in `src/lib/flow-data.ts`).
- `npm run build` in `apps/mds/docs`.
- `./apps/mds/docs/node_modules/.bin/next build apps/mds/docs` from repo root to match the Vercel cwd failure mode.
- `python3` PyYAML parse for `.github/workflows/pr-gate.yml`.
- `git diff --check`.

## Residual Risk

Low. The fix keeps the existing filesystem loader and only broadens token directory resolution for deploy cwd differences. Build still emits an existing Turbopack NFT warning about filesystem tracing, but `/tokens` prerender completes and the repo-root build path is now part of PR gate.