### PR TITLE
ci: distribute event flow simulator runs

### DIFF
--- a/.github/scripts/BLUEDOC.md
+++ b/.github/scripts/BLUEDOC.md
@@ -13,6 +13,7 @@
 | [`check-pr-issue-reference.sh`](./check-pr-issue-reference.sh) | dev-staging PR 본문에 이슈 종료 의도(`Closes/Fixes/Resolves`) 또는 명시적 비종료 사유(`Refs` + 이유 / `No linked issue`)가 있는지 검사 | `pr-gate.static-checks` |
 | [`check-ios-deploy-branch-conditions.sh`](./check-ios-deploy-branch-conditions.sh) | `ios-deploy` action 의 브랜치 분기(`main` vs `non-main`) 회귀 검증 | 수동 실행 (`bash .github/scripts/check-ios-deploy-branch-conditions.sh`) |
 | [`check-android-deploy-workflow-contract.py`](./check-android-deploy-workflow-contract.py) | Android deploy release archive 가 `github.token` + `contents: write` 를 사용하고 PAT caller 계약을 요구하지 않는지 검증 | `pr-gate.static-checks` |
+| [`check-dev-soak-workflow-contract.py`](./check-dev-soak-workflow-contract.py) | `monitor-event-flow-distributed` + `dev-rc-cut-gate` + `shared-soak-gate` 의 run-history 판정 계약 검증 | `pr-gate.static-checks` |
 | [`check-ios-connectivity-plus-cap.sh`](./check-ios-connectivity-plus-cap.sh) | iOS deploy runner 가 지원할 때까지 `connectivity_plus <7.1.0` resolution 강제 | `pr-gate.guard-ios-connectivity-plus-cap` |
 | [`scan-build-artifact-secrets.py`](./scan-build-artifact-secrets.py) | APK/AAB/`.next` 등 빌드 산출물에서 Supabase service-role secret 패턴을 redacted summary 로 검사 | `pr-gate.scan-build-artifact-secrets` |
 

--- a/.github/scripts/check-dev-soak-workflow-contract.py
+++ b/.github/scripts/check-dev-soak-workflow-contract.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Validate dev soak monitor and RC cut gate workflow contracts."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MONITOR_DISTRIBUTED = ROOT / ".github/workflows/monitor-event-flow-distributed.yml"
+DEV_RC_CUT_GATE = ROOT / ".github/workflows/dev-rc-cut-gate.yml"
+SHARED_SOAK_GATE = ROOT / ".github/workflows/shared-soak-gate.yml"
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_workflow(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as file:
+        data = yaml.safe_load(file)
+    if not isinstance(data, dict):
+        fail(f"{path} did not parse as a mapping")
+    return data
+
+
+def on_config(workflow: dict[str, Any]) -> dict[str, Any]:
+    # PyYAML 1.1 treats the plain scalar key "on" as boolean True.
+    config = workflow.get("on", workflow.get(True, {}))
+    if not isinstance(config, dict):
+        fail("workflow 'on' block did not parse as a mapping")
+    return config
+
+
+def jobs_config(workflow: dict[str, Any], path: Path) -> dict[str, Any]:
+    jobs = workflow.get("jobs", {})
+    if not isinstance(jobs, dict):
+        fail(f"{path} jobs block did not parse as a mapping")
+    return jobs
+
+
+def run_block(job: dict[str, Any], step_name: str) -> str:
+    steps = job.get("steps", [])
+    if not isinstance(steps, list):
+        fail(f"{step_name} job steps did not parse as a list")
+    for step in steps:
+        if isinstance(step, dict) and step.get("name") == step_name:
+            script = step.get("run", "")
+            if not isinstance(script, str):
+                fail(f"{step_name} run block did not parse as text")
+            return script
+    fail(f"missing step: {step_name}")
+
+
+def assert_distributed_monitor_contract() -> None:
+    workflow = load_workflow(MONITOR_DISTRIBUTED)
+    config = on_config(workflow)
+
+    schedule = config.get("schedule", [])
+    if not isinstance(schedule, list) or not any(
+        isinstance(item, dict) and item.get("cron") == "*/5 * * * *"
+        for item in schedule
+    ):
+        fail("monitor-event-flow-distributed must run every 5 minutes")
+
+    dispatch = config.get("workflow_dispatch", {})
+    inputs = dispatch.get("inputs", {}) if isinstance(dispatch, dict) else {}
+    target_ref = inputs.get("target_ref", {}) if isinstance(inputs, dict) else {}
+    if not isinstance(target_ref, dict) or target_ref.get("default") != "dev":
+        fail("monitor-event-flow-distributed workflow_dispatch target_ref must default to dev")
+
+    jobs = jobs_config(workflow, MONITOR_DISTRIBUTED)
+    resolve_target = jobs.get("resolve-target", {})
+    if not isinstance(resolve_target, dict):
+        fail("monitor-event-flow-distributed must define resolve-target job")
+    script = run_block(resolve_target, "Resolve monitored ref")
+    if 'if [ "${EVENT_NAME}" = "schedule" ]; then' not in script or 'TARGET_REF="dev"' not in script:
+        fail("scheduled distributed monitor runs must force target_ref=dev")
+
+
+def assert_dev_rc_cut_gate_contract() -> None:
+    workflow = load_workflow(DEV_RC_CUT_GATE)
+    jobs = jobs_config(workflow, DEV_RC_CUT_GATE)
+    evaluate = jobs.get("evaluate-dev-soak", {})
+    if not isinstance(evaluate, dict):
+        fail("dev-rc-cut-gate must define evaluate-dev-soak job")
+    if evaluate.get("uses") != "./.github/workflows/shared-soak-gate.yml":
+        fail("dev-rc-cut-gate evaluate-dev-soak must call shared-soak-gate")
+
+    with_config = evaluate.get("with", {})
+    if not isinstance(with_config, dict):
+        fail("evaluate-dev-soak with block did not parse as a mapping")
+    if with_config.get("candidate_ref") != "dev":
+        fail("dev-rc-cut-gate must evaluate origin/dev")
+    min_soak_hours = str(with_config.get("min_soak_hours", ""))
+    if "24" not in min_soak_hours:
+        fail("dev-rc-cut-gate minimum soak must default to 24 hours")
+
+    raw_required_runs = str(with_config.get("required_runs_json", "")).strip()
+    try:
+        required_runs = json.loads(raw_required_runs)
+    except Exception as exc:  # noqa: BLE001 - contract failure should show parse detail.
+        fail(f"dev-rc-cut-gate required_runs_json is invalid JSON: {exc}")
+    if not isinstance(required_runs, list) or len(required_runs) != 1:
+        fail("dev-rc-cut-gate must define exactly one required run contract")
+    run = required_runs[0]
+    if not isinstance(run, dict):
+        fail("dev-rc-cut-gate required run contract must be an object")
+
+    expected = {
+        "workflow": "monitor-event-flow-distributed.yml",
+        "branch": "dev-staging",
+        "min_success": 250,
+    }
+    for key, value in expected.items():
+        if run.get(key) != value:
+            fail(f"dev-rc-cut-gate required run {key} must be {value!r}")
+    if int(run.get("run_limit", 0)) < int(run["min_success"]):
+        fail("dev-rc-cut-gate run_limit must be >= min_success")
+
+
+def assert_shared_soak_gate_contract() -> None:
+    workflow_text = SHARED_SOAK_GATE.read_text(encoding="utf-8")
+    required_fragments = [
+        "run_limit = int(item.get",
+        "run_limit < min_success",
+        '--created ">=${COMMIT_ISO}"',
+        '--limit "${run_limit}"',
+    ]
+    for fragment in required_fragments:
+        if fragment not in workflow_text:
+            fail(f"shared-soak-gate missing contract fragment: {fragment}")
+
+
+def main() -> None:
+    assert_distributed_monitor_contract()
+    assert_dev_rc_cut_gate_contract()
+    assert_shared_soak_gate_contract()
+    print("Dev soak workflow contract OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -14,7 +14,7 @@
 | `pr-setup-` | PR push 마다 PR 브랜치를 mutate 하는 자동화 (포맷 등) | (현재 없음 — `pr-setup-format` 은 #2627 에서 `pr-gate-format-check` 잡으로 대체) |
 | `pr-review-setup-` | PR 의 "리뷰 준비" 자동화 — auto-merge enable + 조건 충족 시 `needs-review` 라벨 부여 | `pr-review-setup` |
 | `deploy-` | 사용자·dev 환경에 코드·스키마·시드가 안 갔음 | `dev-deploy`, `main-deploy`, `deploy-vercel`, `deploy-supabase`, `deploy-android-user`, `deploy-ios-user`, `deploy-dev-seed` |
-| `monitor-` | 운영·테스트 시스템 헬스 이상 / 스케줄 유지보수 | `monitor-dev-staging-health`, `monitor-db-invariants`, `monitor-event-flow-hourly`, `monitor-event-flow-daily`, `monitor-mds-render-coverage`, `monitor-patrol-e2e`, `monitor-allure`, `monitor-build-retention`, `monitor-security-advisor`, `monitor-doc-freshness` |
+| `monitor-` | 운영·테스트 시스템 헬스 이상 / 스케줄 유지보수 | `monitor-dev-staging-health`, `monitor-db-invariants`, `monitor-event-flow-distributed`, `monitor-event-flow-hourly`, `monitor-event-flow-daily`, `monitor-mds-render-coverage`, `monitor-patrol-e2e`, `monitor-allure`, `monitor-build-retention`, `monitor-security-advisor`, `monitor-doc-freshness` |
 | `sync-` | repo 에 자동 commit/push 가 실패함 (dev push 또는 merge 기반) | `sync-version`, `sync-graphify`, `sync-mds-mockups`, `sync-pr-branches`, `sync-test-coverage` |
 | `set-` | GitHub status/metadata 를 쓰는 수동·자동 API entrypoint 실패 | `set-dev-soak-status`, `set-rc-soak-status` |
 | `triage-` | 이슈 생성·슬래시 명령 (commit 없음) | `triage-mds-issue`, `triage-slash` |
@@ -35,7 +35,7 @@
 - `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 는 `shared-pr-source-guard` 로 직접 PR 을 차단한다. 정상 진입점은 `dev-staging` 이고, 예외는 branch별 approved hotfix 뿐이다.
 - `monitor-dev-staging-health` 는 required check 가 아니다. 6시간마다 `dev-staging` HEAD 에서 EF unit/integration + user/partner CUJ 를 돌려 nightly 전에 회귀를 발견하고, 결과를 `dev-staging-health/*` commit status 로 남긴다.
 - `dev-staging-dev-cut-gate` 가 dev-staging 의 PR-number CalVer bump/tag 를 담당한다. `sync-version` 은 legacy main release bump 만 담당하며, `dev` promotion 은 `dev-staging-dev-cut` 에서 version 변경 없이 처리한다.
-- `dev-rc-cut-gate` 는 cut 직전 evaluator 다. 내부에서 `shared-soak-gate` 를 호출해 `dev-soak/*` status 와 monitor run history 를 확인하고, 통과한 commit 에만 `dev-rc-cut-pass` status 를 찍는다.
+- `dev-rc-cut-gate` 는 cut 직전 evaluator 다. 내부에서 `shared-soak-gate` 를 호출해 `dev-soak/*` status 와 `monitor-event-flow-distributed` run history 를 확인하고, 통과한 commit 에만 `dev-rc-cut-pass` status 를 찍는다.
 - `dev-rc-cut` 은 latest `dev-rc-cut-pass` dev commit 에서 `rc/YYYY-Wxx` branch 를 만들고 `version-bump` 로 `v*-rc-01` + `promo/rc-*` tag 를 생성한다.
 - `rc-main-cut-gate` 는 5일 soak 를 통과한 `rc/*` 에 `rc-main-cut-pass` 를 찍고, `rc-main-cut` 은 그 marker 를 소비해 `main` PR 을 만든다.
 - `.github/actions/cut-issue` 는 cut-gate tracking issue 를 생성/갱신/닫는 composite action 이다. Issue 는 운영자가 보는 추적 surface 이며 gate 판정 SSOT 는 commit status/workflow result 다.
@@ -43,6 +43,7 @@
 - `dev-deploy` 는 dev push 후 web + mobile dev 배포를 orchestrate 한다.
 - `main-deploy` 는 main push 후 prod 배포를 orchestrate 한다. RC promotion 이면 `version-bump` 로 final version/tag 를 만들고 `shared-promo-tag` 로 `promo/main-*` marker 를 만든다. 이미 final version 인 `main/hotfix/*` 머지는 version/tag finalization 없이 prod deploy 만 실행한다.
 - `shared-promo-tag` 는 `promo/rc-*`, `promo/main-*` tag 생성의 공통 release-bot 구현이다. Concrete workflow 는 target ref, tag name, commit SHA 만 넘긴다.
+- `monitor-event-flow-distributed` 는 schedule 에서 `origin/dev` 를 대상으로 5분 distributed tick 을 호출하고, 수동 실행은 `dev` 또는 `rc/YYYY-Www` 만 허용한다. `monitor-event-flow-hourly` / `monitor-event-flow-daily` 는 legacy manual smoke 다.
 - `deploy-android-*`, `deploy-ios-*`, `deploy-vercel` 은 branch-level deploy 에서 호출하는 concrete adapter 다. 직접 push/schedule 로 실행하지 않는다.
 - 실제 build/upload/notify 로직은 각각 `shared-android-deploy`, `shared-ios-deploy`, `shared-vercel-deploy` 에 둔다.
 - 모바일 배포 산출물(APK/AAB/IPA)은 GitHub Release asset 으로 보관한다. Actions artifact 는 테스트/디버깅 산출물용이며, deploy archive 의 source-of-truth 로 쓰지 않는다.

--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -35,7 +35,7 @@
 - `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 는 `shared-pr-source-guard` 로 직접 PR 을 차단한다. 정상 진입점은 `dev-staging` 이고, 예외는 branch별 approved hotfix 뿐이다.
 - `monitor-dev-staging-health` 는 required check 가 아니다. 6시간마다 `dev-staging` HEAD 에서 EF unit/integration + user/partner CUJ 를 돌려 nightly 전에 회귀를 발견하고, 결과를 `dev-staging-health/*` commit status 로 남긴다.
 - `dev-staging-dev-cut-gate` 가 dev-staging 의 PR-number CalVer bump/tag 를 담당한다. `sync-version` 은 legacy main release bump 만 담당하며, `dev` promotion 은 `dev-staging-dev-cut` 에서 version 변경 없이 처리한다.
-- `dev-rc-cut-gate` 는 cut 직전 evaluator 다. 내부에서 `shared-soak-gate` 를 호출해 `dev-soak/*` status 와 `monitor-event-flow-distributed` run history 를 확인하고, 통과한 commit 에만 `dev-rc-cut-pass` status 를 찍는다.
+- `dev-rc-cut-gate` 는 cut 직전 evaluator 다. 내부에서 `shared-soak-gate` 를 호출해 `dev-soak/*` status 와 `monitor-event-flow-distributed` candidate 이후 run history 를 확인하고, 통과한 commit 에만 `dev-rc-cut-pass` status 를 찍는다.
 - `dev-rc-cut` 은 latest `dev-rc-cut-pass` dev commit 에서 `rc/YYYY-Wxx` branch 를 만들고 `version-bump` 로 `v*-rc-01` + `promo/rc-*` tag 를 생성한다.
 - `rc-main-cut-gate` 는 5일 soak 를 통과한 `rc/*` 에 `rc-main-cut-pass` 를 찍고, `rc-main-cut` 은 그 marker 를 소비해 `main` PR 을 만든다.
 - `.github/actions/cut-issue` 는 cut-gate tracking issue 를 생성/갱신/닫는 composite action 이다. Issue 는 운영자가 보는 추적 surface 이며 gate 판정 SSOT 는 commit status/workflow result 다.

--- a/.github/workflows/dev-rc-cut-gate.yml
+++ b/.github/workflows/dev-rc-cut-gate.yml
@@ -41,7 +41,7 @@ jobs:
       min_soak_hours: ${{ inputs.min_soak_hours || '24' }}
       required_runs_json: >-
         [
-          {"workflow":"monitor-event-flow-distributed.yml","branch":"dev","min_success":250}
+          {"workflow":"monitor-event-flow-distributed.yml","branch":"dev-staging","min_success":250}
         ]
       failure_contexts: |
         dev-soak/backend-simulator

--- a/.github/workflows/dev-rc-cut-gate.yml
+++ b/.github/workflows/dev-rc-cut-gate.yml
@@ -41,7 +41,7 @@ jobs:
       min_soak_hours: ${{ inputs.min_soak_hours || '24' }}
       required_runs_json: >-
         [
-          {"workflow":"monitor-event-flow-distributed.yml","branch":"dev-staging","min_success":250}
+          {"workflow":"monitor-event-flow-distributed.yml","branch":"dev-staging","min_success":250,"run_limit":500}
         ]
       failure_contexts: |
         dev-soak/backend-simulator

--- a/.github/workflows/dev-rc-cut-gate.yml
+++ b/.github/workflows/dev-rc-cut-gate.yml
@@ -41,8 +41,7 @@ jobs:
       min_soak_hours: ${{ inputs.min_soak_hours || '24' }}
       required_runs_json: >-
         [
-          {"workflow":"monitor-event-flow-hourly.yml","branch":"dev-staging","min_success":20},
-          {"workflow":"monitor-event-flow-daily.yml","branch":"dev-staging","min_success":1}
+          {"workflow":"monitor-event-flow-distributed.yml","branch":"dev","min_success":250}
         ]
       failure_contexts: |
         dev-soak/backend-simulator

--- a/.github/workflows/monitor-event-flow-daily.yml
+++ b/.github/workflows/monitor-event-flow-daily.yml
@@ -1,12 +1,9 @@
 name: monitor-event-flow-daily
 
-# KST 07:00 매일 — SQL seed 초기화 후 긴 cascade 실행 (data 다양성 + 회귀 가드)
-# 1차 fixture 는 supabase/seed.dev.sql 로 박음 (Fix #1413 — EF 시딩 timeout 회피).
-# Patrol CUJ 테스트는 monitor-patrol-e2e.yml 이 별도 담당.
+# Legacy manual seed + long cascade. Scheduled execution moved to
+# monitor-event-flow-distributed.
 
 on:
-  schedule:
-    - cron: '0 22 * * *'    # UTC 22:00 = KST 07:00
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/monitor-event-flow-distributed.yml
+++ b/.github/workflows/monitor-event-flow-distributed.yml
@@ -1,0 +1,190 @@
+name: monitor-event-flow-distributed
+
+# Every 5 minutes — one small event-flow-simulator tick.
+# schedule always targets dev. Manual dispatch accepts dev or rc/YYYY-Www.
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: 'Target branch. Allowed: dev or rc/YYYY-Www.'
+        required: false
+        type: string
+        default: dev
+      ticks:
+        description: Cascade ticks per run.
+        required: false
+        type: string
+        default: '1'
+      users_per_tick:
+        description: Random seed users per run.
+        required: false
+        type: string
+        default: '5'
+      partners_per_tick:
+        description: Random seed partners per run.
+        required: false
+        type: string
+        default: '2'
+      delay_between_calls_ms:
+        description: Throttle between EF calls.
+        required: false
+        type: string
+        default: '400'
+
+concurrency:
+  group: monitor-event-flow-distributed-${{ inputs.target_ref || 'dev' }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  statuses: write
+
+jobs:
+  resolve-target:
+    name: Resolve target branch
+    runs-on: ubuntu-latest
+    outputs:
+      target_ref: ${{ steps.resolve.outputs.target_ref }}
+      target_sha: ${{ steps.resolve.outputs.target_sha }}
+      soak_stage: ${{ steps.resolve.outputs.soak_stage }}
+      supabase_stage: ${{ steps.resolve.outputs.supabase_stage }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Resolve monitored ref
+        id: resolve
+        env:
+          REQUESTED_TARGET_REF: ${{ inputs.target_ref || 'dev' }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          TARGET_REF="${REQUESTED_TARGET_REF}"
+          if [ "${EVENT_NAME}" = "schedule" ]; then
+            TARGET_REF="dev"
+          fi
+
+          case "${TARGET_REF}" in
+            dev)
+              SOAK_STAGE="dev-soak"
+              SUPABASE_STAGE="dev"
+              ;;
+            rc/[0-9][0-9][0-9][0-9]-W[0-9][0-9])
+              SOAK_STAGE="rc-soak"
+              SUPABASE_STAGE="rc"
+              ;;
+            *)
+              echo "::error::target_ref must be dev or rc/YYYY-Www. Got: ${TARGET_REF}"
+              exit 1
+              ;;
+          esac
+
+          git fetch origin "${TARGET_REF}" --depth=1
+          TARGET_SHA="$(git rev-parse "origin/${TARGET_REF}")"
+
+          echo "target_ref=${TARGET_REF}" >> "${GITHUB_OUTPUT}"
+          echo "target_sha=${TARGET_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "soak_stage=${SOAK_STAGE}" >> "${GITHUB_OUTPUT}"
+          echo "supabase_stage=${SUPABASE_STAGE}" >> "${GITHUB_OUTPUT}"
+
+  simulate:
+    name: Run distributed event-flow tick
+    needs: [resolve-target]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Invoke event-flow-simulator
+        env:
+          TARGET_REF: ${{ needs.resolve-target.outputs.target_ref }}
+          SUPABASE_STAGE: ${{ needs.resolve-target.outputs.supabase_stage }}
+          SUPABASE_DEV_URL: ${{ secrets.SUPABASE_DEV_URL }}
+          SUPABASE_DEV_SECRET_KEY: ${{ secrets.SUPABASE_DEV_SECRET_KEY }}
+          SUPABASE_RC_URL: ${{ secrets.SUPABASE_RC_URL }}
+          SUPABASE_RC_SECRET_KEY: ${{ secrets.SUPABASE_RC_SECRET_KEY }}
+          INPUT_TICKS: ${{ inputs.ticks || '1' }}
+          INPUT_USERS_PER_TICK: ${{ inputs.users_per_tick || '5' }}
+          INPUT_PARTNERS_PER_TICK: ${{ inputs.partners_per_tick || '2' }}
+          INPUT_DELAY_BETWEEN_CALLS_MS: ${{ inputs.delay_between_calls_ms || '400' }}
+        run: |
+          set -euo pipefail
+
+          require_uint() {
+            local name="$1"
+            local value="$2"
+            if ! [[ "${value}" =~ ^[0-9]+$ ]]; then
+              echo "::error::${name} must be a non-negative integer. Got: ${value}"
+              exit 1
+            fi
+          }
+
+          require_uint ticks "${INPUT_TICKS}"
+          require_uint users_per_tick "${INPUT_USERS_PER_TICK}"
+          require_uint partners_per_tick "${INPUT_PARTNERS_PER_TICK}"
+          require_uint delay_between_calls_ms "${INPUT_DELAY_BETWEEN_CALLS_MS}"
+
+          if [ "${SUPABASE_STAGE}" = "rc" ]; then
+            SUPABASE_URL="${SUPABASE_RC_URL}"
+            SUPABASE_SECRET_KEY="${SUPABASE_RC_SECRET_KEY}"
+          else
+            SUPABASE_URL="${SUPABASE_DEV_URL}"
+            SUPABASE_SECRET_KEY="${SUPABASE_DEV_SECRET_KEY}"
+          fi
+
+          if [ -z "${SUPABASE_URL}" ] || [ -z "${SUPABASE_SECRET_KEY}" ]; then
+            echo "::error::Missing Supabase ${SUPABASE_STAGE} simulator secrets."
+            exit 1
+          fi
+
+          SEED="$(date -u +%s)"
+          jq -n \
+            --argjson ticks "${INPUT_TICKS}" \
+            --argjson usersPerTick "${INPUT_USERS_PER_TICK}" \
+            --argjson partnersPerTick "${INPUT_PARTNERS_PER_TICK}" \
+            --argjson delayBetweenCallsMs "${INPUT_DELAY_BETWEEN_CALLS_MS}" \
+            --argjson seed "${SEED}" \
+            '{
+              ticks: $ticks,
+              usersPerTick: $usersPerTick,
+              partnersPerTick: $partnersPerTick,
+              delayBetweenCallsMs: $delayBetweenCallsMs,
+              seed: $seed
+            }' > /tmp/sim_payload.json
+
+          echo "target_ref=${TARGET_REF}"
+          cat /tmp/sim_payload.json
+
+          http_code=$(curl -s -o /tmp/sim_response.json -w "%{http_code}" -X POST \
+            "${SUPABASE_URL}/functions/v1/event-flow-simulator" \
+            -H "Authorization: Bearer ${SUPABASE_SECRET_KEY}" \
+            -H "Content-Type: application/json" \
+            -d @/tmp/sim_payload.json \
+            --max-time 240)
+          cat /tmp/sim_response.json
+          if [ "${http_code}" -lt 200 ] || [ "${http_code}" -ge 300 ]; then
+            echo "::error::event-flow-simulator returned HTTP ${http_code}"
+            exit 1
+          fi
+          jq -e '.success == true' /tmp/sim_response.json
+
+  notify-failure:
+    needs: [resolve-target, simulate]
+    if: always()
+    uses: ./.github/workflows/shared-notify.yml
+    with:
+      failed: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      workflow_name: 'monitor-event-flow-distributed'
+      severity: 'P1-high'
+      job_results: '{"resolve-target":"${{ needs.resolve-target.result }}","simulate":"${{ needs.simulate.result }}","target_ref":"${{ needs.resolve-target.outputs.target_ref }}","target_sha":"${{ needs.resolve-target.outputs.target_sha }}"}'
+      stage: ${{ needs.resolve-target.outputs.soak_stage }}
+      signal: 'backend-simulator'
+      blocks_rc_cut: true
+      commit_sha: ${{ needs.resolve-target.outputs.target_sha }}
+      status_description: 'monitor-event-flow-distributed failed'
+    secrets: inherit

--- a/.github/workflows/monitor-event-flow-hourly.yml
+++ b/.github/workflows/monitor-event-flow-hourly.yml
@@ -1,11 +1,8 @@
 name: monitor-event-flow-hourly
 
-# 매시 :30 — event-flow-simulator 짧은 cascade 실행 (스모크)
-# 길이가 긴 cascade + SQL seed 는 monitor-event-flow-daily 가 담당.
+# Legacy manual smoke. Scheduled execution moved to monitor-event-flow-distributed.
 
 on:
-  schedule:
-    - cron: '30 * * * *'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -21,11 +21,12 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Consolidated fast read-only static checks: 7 verifications that previously each
-  # ran in its own ubuntu-latest job (migration version uniqueness + same-day gap
-  # warning, env-manifest ↔ EnvKeyStore drift, workflow YAML parse validity,
-  # androidx.test runner/orchestrator version alignment, cross-feature import
-  # baseline, BLUEDOC freshness, dev-staging PR issue lifecycle intent).
+  # Consolidated fast read-only static checks that previously each ran in its own
+  # ubuntu-latest job: migration version uniqueness + same-day gap warning,
+  # env-manifest ↔ EnvKeyStore drift, workflow YAML parse validity, workflow
+  # contract checks, androidx.test runner/orchestrator version alignment,
+  # cross-feature import baseline, BLUEDOC freshness, and dev-staging PR issue
+  # lifecycle intent.
   #
   # Why merge: each separate job paid runner startup + actions/checkout overhead
   # (~10-15s × 6 = ~70s of Actions minutes per PR). Combined into one job with a
@@ -108,6 +109,10 @@ jobs:
       - name: Check Android deploy release archive contract
         if: ${{ !cancelled() }}
         run: python3 .github/scripts/check-android-deploy-workflow-contract.py
+
+      - name: Check dev soak workflow contract
+        if: ${{ !cancelled() }}
+        run: python3 .github/scripts/check-dev-soak-workflow-contract.py
 
       - name: Verify androidx.test runner/orchestrator version alignment
         if: ${{ !cancelled() }}

--- a/.github/workflows/shared-notify.yml
+++ b/.github/workflows/shared-notify.yml
@@ -35,7 +35,7 @@ on:
         type: boolean
         required: false
         default: false
-        description: 'If true, write a dev-soak failure status for the target commit.'
+        description: 'If true, write a soak failure status for the target commit.'
       commit_sha:
         type: string
         required: false
@@ -67,8 +67,22 @@ jobs:
       target_url: ${{ inputs.target_url || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
       description: ${{ inputs.status_description || format('{0} failed', inputs.workflow_name) }}
 
+  set-rc-soak-failure:
+    if: ${{ inputs.failed && inputs.blocks_rc_cut && inputs.stage == 'rc-soak' }}
+    uses: ./.github/workflows/set-rc-soak-status.yml
+    permissions:
+      contents: read
+      statuses: write
+    secrets: inherit
+    with:
+      signal: ${{ inputs.signal }}
+      state: failure
+      sha: ${{ inputs.commit_sha || github.sha }}
+      target_url: ${{ inputs.target_url || format('{0}/{1}/actions/runs/{2}', github.server_url, github.repository, github.run_id) }}
+      description: ${{ inputs.status_description || format('{0} failed', inputs.workflow_name) }}
+
   notify:
-    needs: [set-dev-soak-failure]
+    needs: [set-dev-soak-failure, set-rc-soak-failure]
     if: always()
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/shared-soak-gate.yml
+++ b/.github/workflows/shared-soak-gate.yml
@@ -169,18 +169,20 @@ jobs:
               branch = str(item.get("branch", "")).strip()
               min_success = int(item.get("min_success", 0))
               match_head_sha = bool(item.get("match_head_sha", False))
-              if not workflow or not branch or min_success < 0:
-                  print("::error::run requirement needs workflow, branch, min_success.", file=sys.stderr)
+              run_limit = int(item.get("run_limit", item.get("limit", max(100, min_success * 2))))
+              if not workflow or not branch or min_success < 0 or run_limit < min_success:
+                  print("::error::run requirement needs workflow, branch, min_success, and run_limit >= min_success.", file=sys.stderr)
                   sys.exit(1)
-              print(f"{workflow}\t{branch}\t{min_success}\t{str(match_head_sha).lower()}")
+              print(f"{workflow}\t{branch}\t{min_success}\t{str(match_head_sha).lower()}\t{run_limit}")
           PY
 
-          while IFS=$'\t' read -r workflow branch min_success match_head_sha; do
+          while IFS=$'\t' read -r workflow branch min_success match_head_sha run_limit; do
             [ -z "${workflow}" ] && continue
             runs_json="$(gh run list \
               --workflow "${workflow}" \
               --branch "${branch}" \
-              --limit 100 \
+              --created ">=${COMMIT_ISO}" \
+              --limit "${run_limit}" \
               --json conclusion,createdAt,headSha)"
             if [ "${match_head_sha}" = "true" ]; then
               run_count="$(jq \

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -260,7 +260,7 @@ Supabase Edge Functions는 Deno 런타임 기반이며, `supabase/functions/` �
 | `health` | System | 시스템 헬스 체크 |
 | `dev-seed` | Dev | 테스트 데이터 시딩 (dev only) |
 | `dev-session-switch` | Dev | 테스트 유저 전환 (dev only) |
-| `backend-simulator` | Dev | 백엔드 시뮬레이터 (dev only) |
+| `event-flow-simulator` | Dev | dev 5분 distributed backend flow 시뮬레이터 (dev only) |
 | `dev-mock-portone` | Dev | Portone 목업 서버 (dev only) |
 | `metrics-alert` | Monitoring | 정산 메트릭 알람 발송 |
 | `payout-sync` | Payment | 지급 상태 동기화 |

--- a/docs/guides/env-reference.md
+++ b/docs/guides/env-reference.md
@@ -114,11 +114,14 @@
 |-----|-------------|----------|
 | `GITHUB_ACCESS_TOKEN` | GitHub API (higher rate limit) | No |
 
-### backend-simulator
+### event-flow-simulator
 
 | Key | Description | Required |
 |-----|-------------|----------|
-| `ENVIRONMENT` | Dev guard (must be development) | Yes |
+| `ENVIRONMENT` | Dev guard (must be development/dev/local) | Yes |
+| `SUPABASE_ANON_KEY` | actor sign-in for simulated user/partner JWTs | Yes |
+| `SUPABASE_SERVICE_ROLE_KEY` | simulator service client | Yes |
+| `SIM_USER_PASSWORD` | dev seed actor password | Yes |
 
 ### ai-embed
 
@@ -155,8 +158,11 @@
 | `SUPABASE_ACCESS_TOKEN` | Supabase CLI auth | Yes |
 | `SUPABASE_DEV_DB_PASSWORD` | Dev DB password | Yes |
 | `SUPABASE_DEV_PROJECT_ID` | Dev project ref | Yes |
+| `SUPABASE_DEV_URL` | Dev Supabase URL | Yes |
 | `SUPABASE_DEV_PUBLISHABLE_KEY` | Dev publishable key | Yes |
 | `SUPABASE_DEV_SECRET_KEY` | Dev service role key | Yes |
+| `SUPABASE_RC_URL` | RC Supabase URL for manual simulator runs | No |
+| `SUPABASE_RC_SECRET_KEY` | RC service role key for manual simulator runs | No |
 | `SUPABASE_MAIN_DB_PASSWORD` | Main DB password | Yes |
 | `SUPABASE_MAIN_PROJECT_ID` | Main project ref | Yes |
 | `SUPABASE_MAIN_PUBLISHABLE_KEY` | Main publishable key | Yes |
@@ -166,7 +172,7 @@
 | `STATSIG_SERVER_KEY` | Statsig server | No |
 | `AXIOM_API_TOKEN` | Axiom logging | No |
 | `CODECOV_TOKEN` | Codecov upload | No |
-| `SIM_USER_PASSWORD` | Dev simulator user password (backend-simulator EF 전용) | No |
+| `SIM_USER_PASSWORD` | Dev simulator user password (`event-flow-simulator`) | No |
 
 ## Vault
 

--- a/docs/infra/branch-strategy/BLUEDOC.md
+++ b/docs/infra/branch-strategy/BLUEDOC.md
@@ -105,7 +105,7 @@ flowchart LR
 - cut-gate Issue 는 사람이 진행 상태를 추적하기 위한 projection 이다. 생성/갱신/닫기는 `.github/actions/cut-issue` 와 `close-cut-issue-on-pr-merge` 가 담당하며, promotion 판정 SSOT 로 사용하지 않는다
 - 모든 branch linear ON — dev-staging: squash, dev/rc/main: rebase
 - Protected branch 직접 push 는 human 금지. version bump/tag/promotion 처리는 `minglit-release-bot` 전용 token + Ruleset bypass 로만 허용
-- `monitor-event-flow-*` 는 release promotion 과 독립적인 batch signal. dev 에서 계속 돌고, RC 에서는 main 배포 전 검증 signal 로 사용한다
+- `monitor-event-flow-*` 는 release promotion 과 독립적인 batch signal. target 은 dev 5분 distributed tick 이고, RC 에서는 main 배포 전 검증 signal 로 사용한다
 - main 머지 = backend + mobile 모두 prod deploy. backend prod deploy 는 `main-deploy` 에서 한 번에 수행한다
 - `main-deploy` 는 version finalization 과 deploy execution 을 분리한다. RC promotion 은 final version/tag 를 만들고 deploy 하며, `main/hotfix/*` 처럼 이미 final version 인 main push 는 version bump 없이 prod deploy 만 실행한다
 - 모바일 배포 산출물(APK/AAB/IPA)은 GitHub Release asset 이 canonical archive 다. Actions artifact 는 테스트 리포트/스크린샷/로그 같은 단기 디버깅 산출물에만 사용한다
@@ -129,4 +129,4 @@ Promotion PR 제목은 workflow 이름과 source artifact 를 앞에 둔다. PR 
 RC cut 의 source-of-truth status 이름은 **`dev-rc-cut-pass`** 이다. `rc-eligible` 은 현재 구현된 workflow/status 명칭이 아니며, 새 이름으로 바꾸려면 `dev-rc-cut-gate`, `dev-rc-cut`, `main-pr-gate`, 문서 전체를 같은 PR 에서 일괄 변경한다.
 
 ---
-_Reviewed: 2026-05-24 10:24_
+_Reviewed: 2026-05-25 16:20_

--- a/docs/infra/branch-strategy/dev-pipeline.md
+++ b/docs/infra/branch-strategy/dev-pipeline.md
@@ -58,8 +58,8 @@ GitHub Issue 는 source-of-truth 가 아니다. Gate 판정은 commit status con
 | 검증 | 조건 |
 |------|------|
 | Soak duration | candidate age >= 24h |
-| Hourly backend simulator | `candidate_since` 이후 `monitor-event-flow-hourly` success run >= 20 |
-| Daily backend simulator | `candidate_since` 이후 `monitor-event-flow-daily` success run >= 1 |
+| Event-flow distributed simulator | `candidate_since` 이후 `monitor-event-flow-distributed` success run >= 250 |
+| Legacy hourly/daily simulator | 수동 smoke 전용. RC cut gate 조건에서 제외 |
 | Real device | candidate 기준 required real-device signal success >= 1 (workflow TBD) |
 | App AI review | AI agent 가 candidate 기준 app-soak pass signal 제공 (입력 방식 TBD) |
 | Failure status | `dev-soak/*` context 의 최신 state 가 `failure` 가 아니어야 함 |
@@ -110,7 +110,11 @@ Snapshot 모델 — **auto-revert 없음**. dev 가 broken 상태로 잠시 머�
 
 ### `monitor-event-flow-*`
 
-- 이벤트 플로우 시뮬레이터 batch (`monitor-event-flow-hourly`, `monitor-event-flow-daily`)
+- 이벤트 플로우 시뮬레이터 batch. target 은 `monitor-event-flow-distributed` 5분 주기 small tick
+- 시간은 고정 5분, 랜덤은 actor/user/partner/event sampling 에 적용한다
+- `seed.dev.sql` 은 계정/파트너 base 만 담당하고 party/event/ticket 은 EF 경유로 만든다
+- 유저 신청 대상은 DB prefix 필터가 아니라 `user-event-feed` 결과에서 선택한다
+- `monitor-event-flow-hourly` / `monitor-event-flow-daily` 는 legacy manual smoke
 - release promotion 과 독립적으로 계속 돈다
 - RC 에서는 main 배포 전 pre-main validation signal 로 사용한다
 

--- a/docs/infra/branch-strategy/dev-soak-status-model.md
+++ b/docs/infra/branch-strategy/dev-soak-status-model.md
@@ -112,8 +112,8 @@ Issue label 은 분류용이다. Gate 판정에는 사용하지 않는다.
 
 | Signal | 최소 조건 |
 |--------|-----------|
-| `monitor-event-flow-hourly` | `candidate_since` 이후 `success` run >= 20 |
-| `monitor-event-flow-daily` | `candidate_since` 이후 `success` run >= 1 |
+| `monitor-event-flow-distributed` | `candidate_since` 이후 `success` run >= 250 |
+| legacy `monitor-event-flow-hourly/daily` | 수동 smoke 전용. gate run requirement 에서 제외 |
 | real-device smoke | candidate 기준 required run/signal success >= 1 (workflow 이름 TBD) |
 | app AI review | AI agent 가 candidate 기준 pass signal 제공 (workflow/status 입력 방식 TBD) |
 
@@ -121,7 +121,7 @@ Issue label 은 분류용이다. Gate 판정에는 사용하지 않는다.
 
 ```bash
 gh run list \
-  --workflow monitor-event-flow-hourly.yml \
+  --workflow monitor-event-flow-distributed.yml \
   --branch dev \
   --created ">=2026-05-24T00:00:00Z" \
   --json databaseId,status,conclusion,createdAt,headSha
@@ -155,7 +155,7 @@ Issue body 에는 machine-readable metadata 를 남긴다. 단, gate 판정은 �
 <!-- minglit-release-signal
 stage: dev-soak
 signal: backend-simulator
-workflow: monitor-event-flow-hourly
+workflow: monitor-event-flow-distributed
 branch: dev
 commit: abc123...
 run_id: 263...

--- a/docs/infra/branch-strategy/dev-soak-status-model.md
+++ b/docs/infra/branch-strategy/dev-soak-status-model.md
@@ -124,10 +124,11 @@ gh run list \
   --workflow monitor-event-flow-distributed.yml \
   --branch dev-staging \
   --created ">=2026-05-24T00:00:00Z" \
+  --limit 500 \
   --json databaseId,status,conclusion,createdAt,headSha
 ```
 
-Scheduled workflow run 의 `headBranch` / `headSha` 는 default branch (`dev-staging`) 기준으로 기록된다. `monitor-event-flow-distributed` 내부에서 `origin/dev` 를 fetch 해 실제 simulator target 을 정하므로, gate run history 는 `--branch dev-staging` 으로 조회하고 candidate 이후 성공 run 수를 센다.
+Scheduled workflow run 의 `headBranch` / `headSha` 는 default branch (`dev-staging`) 기준으로 기록된다. `monitor-event-flow-distributed` 내부에서 `origin/dev` 를 fetch 해 실제 simulator target 을 정하므로, gate run history 는 `--branch dev-staging` 으로 조회한다. `shared-soak-gate` 는 `--created >= candidate_since` 와 `run_limit >= min_success` 로 candidate 이후 성공 run 수를 센다.
 
 ## Failure Recording
 

--- a/docs/infra/branch-strategy/dev-soak-status-model.md
+++ b/docs/infra/branch-strategy/dev-soak-status-model.md
@@ -122,12 +122,12 @@ Issue label 은 분류용이다. Gate 판정에는 사용하지 않는다.
 ```bash
 gh run list \
   --workflow monitor-event-flow-distributed.yml \
-  --branch dev \
+  --branch dev-staging \
   --created ">=2026-05-24T00:00:00Z" \
   --json databaseId,status,conclusion,createdAt,headSha
 ```
 
-Scheduled workflow 의 `headSha` 는 실행 시점의 `dev` HEAD 다. 따라서 run 의 `headSha` 가 candidate 와 다르면 latest candidate 가 바뀐 것으로 보고 그 run 은 현재 candidate 의 soak 증거로 쓰지 않는다.
+Scheduled workflow run 의 `headBranch` / `headSha` 는 default branch (`dev-staging`) 기준으로 기록된다. `monitor-event-flow-distributed` 내부에서 `origin/dev` 를 fetch 해 실제 simulator target 을 정하므로, gate run history 는 `--branch dev-staging` 으로 조회하고 candidate 이후 성공 run 수를 센다.
 
 ## Failure Recording
 

--- a/docs/infra/branch-strategy/specs/BLUEDOC.md
+++ b/docs/infra/branch-strategy/specs/BLUEDOC.md
@@ -29,4 +29,4 @@ design 문서는 운영자 관점 (cadence, role, policy). spec 문서는 구현
 - [BLUEDOC convention](../../bluedoc/BLUEDOC.md)
 
 ---
-_Reviewed: 2026-05-19 09:47_
+_Reviewed: 2026-05-25 16:20_

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -181,7 +181,7 @@ Cross-branch cherry-pick PR 자동 생성.
 | Trigger | `schedule` (cut 직전, TBD) + `workflow_dispatch` |
 | Inputs | optional `candidate_sha` (default: latest `origin/dev` HEAD) |
 | Outputs | commit status `dev-rc-cut-pass` (success only) + `dev-soak/*` success confirmations + cut issue `gate/dev-rc` |
-| Steps | calls `shared-soak-gate` with candidate=`origin/dev`, min_soak_hours=24, required runs=`monitor-event-flow-hourly>=20` + `monitor-event-flow-daily>=1`, failure context=`dev-soak/backend-simulator`, success context=`dev-soak/backend-simulator`, pass context=`dev-rc-cut-pass`; then upserts cut issue as `status/waiting` or `status/ready` |
+| Steps | calls `shared-soak-gate` with candidate=`origin/dev`, min_soak_hours=24, required runs=`monitor-event-flow-distributed>=250`, failure context=`dev-soak/backend-simulator`, success context=`dev-soak/backend-simulator`, pass context=`dev-rc-cut-pass`; then upserts cut issue as `status/waiting` or `status/ready` |
 | Failure path | 조건 미충족이면 `dev-rc-cut-pass` 를 쓰지 않는다. 실패를 발견한 monitor/AI agent 가 이미 `dev-soak/*` failure 를 쓴다 |
 
 > **No auto-revert** — snapshot 모델: 실패 = no `dev-rc-cut-pass`, dev keeps moving, 새 fix 가 자연스럽게 다음 dev-staging-dev-cut 후 새 candidate 로 검증됨.
@@ -195,16 +195,16 @@ Cross-branch cherry-pick PR 자동 생성.
 | Trigger | TBD (`push` to `dev` 또는 `workflow_dispatch`) |
 | Outputs | dev deploy/validation status |
 | Steps | dev 환경 배포 또는 smoke 가 필요할 때만 수행. backend prod deploy 는 여기서 하지 않고 `main-deploy` 에서 수행 |
-| Note | 이벤트 플로우 시뮬레이터는 `dev-deploy` 가 아니라 `monitor-event-flow-hourly` / `monitor-event-flow-daily` batch 로 계속 돈다 |
+| Note | 이벤트 플로우 시뮬레이터는 `dev-deploy` 가 아니라 `monitor-event-flow-distributed` batch 로 계속 돈다 |
 
 #### `monitor-event-flow-*` (release pipeline 외부 batch)
 
 | 항목 | 값 |
 |------|----|
-| Trigger | schedule (`monitor-event-flow-hourly`, `monitor-event-flow-daily`) |
+| Trigger | schedule (`monitor-event-flow-distributed`: `*/5 * * * *`; legacy hourly/daily 는 수동 smoke) |
 | Branch/env | dev 를 계속 관찰. RC cut 후에는 RC env/Supabase branch 도 pre-main 검증 signal 로 사용 |
 | Outputs | event-flow simulation signal, `set-dev-soak-status(signal=backend-simulator,state=failure)`, issue/alert |
-| Note | promotion gate 자체가 아니라 지속 신호다. main deploy 를 대신하지 않는다 |
+| Note | fixed-time small tick. actor/user/partner/event sampling 만 랜덤화하고, party/event 는 partner EF, 신청 대상은 `user-event-feed` 로 만든다 |
 
 ### rc
 

--- a/docs/infra/branch-strategy/test-strategy.md
+++ b/docs/infra/branch-strategy/test-strategy.md
@@ -58,7 +58,7 @@ dev 에 들어간 latest HEAD 만 RC candidate 로 평가한다. 새 dev commit 
 
 | Signal | 실행자 | 실패 status | 성공 status |
 |--------|--------|-------------|-------------|
-| backend simulator | `monitor-event-flow-hourly`, `monitor-event-flow-daily` | `dev-soak/backend-simulator` failure 즉시 | `dev-rc-cut-gate` 가 run history 확인 후 success |
+| backend simulator | `monitor-event-flow-distributed` (legacy hourly/daily 는 수동 smoke) | `dev-soak/backend-simulator` failure 즉시 | `dev-rc-cut-gate` 가 run history 확인 후 success |
 | real device | Test Lab/실디바이스 workflow | `dev-soak/real-device` failure 즉시 | `dev-rc-cut-gate` 가 required signal 확인 후 success |
 | app AI review | AI agent | `dev-soak/app-ai-review` failure 즉시 | `dev-rc-cut-gate` 가 pass signal 확인 후 success |
 
@@ -67,8 +67,8 @@ dev 에 들어간 latest HEAD 만 RC candidate 로 평가한다. 새 dev commit 
 cut 직전 schedule/manual 로 실행한다. 통과 시 commit 에 GitHub status `dev-rc-cut-pass` 를 set 한다.
 
 - candidate age >= 24h
-- `monitor-event-flow-hourly` success run >= 20 since candidate
-- `monitor-event-flow-daily` success run >= 1 since candidate
+- `monitor-event-flow-distributed` success run >= 250 since candidate
+- legacy hourly/daily 는 수동 smoke 로만 실행
 - candidate 의 최신 `dev-soak/*` status 가 failure 가 아님
 - real-device/app AI review required signal 충족
 

--- a/docs/operations/edge-functions.md
+++ b/docs/operations/edge-functions.md
@@ -104,13 +104,13 @@ curl -s ... | python3 -m json.tool
 curl -s -X POST "https://<project-ref>.supabase.co/functions/v1/<function-name>" \
   -H "Authorization: Bearer <SERVICE_ROLE_KEY>" \
   -H "Content-Type: application/json" \
-  -d '{"phase": "verify"}'
+  -d '{"key": "value"}'
 
 # sb_secret_ 형식은 Bearer가 아니라 apikey 헤더로 호출
 curl -s -X POST "https://<project-ref>.supabase.co/functions/v1/<function-name>" \
   -H "apikey: <SERVICE_ROLE_SECRET>" \
   -H "Content-Type: application/json" \
-  -d '{"phase": "verify"}'
+  -d '{"key": "value"}'
 ```
 
 환경 변수는 `minglit_env/dev/supabase.env`에서 확인.
@@ -208,18 +208,14 @@ deno test --allow-all --config supabase/deno.json supabase/functions/payment-ver
 ### 시나리오 테스트 (event-flow-simulator)
 
 ```bash
-# Dev 서버에서 전체 6-phase 시뮬레이션
+# Dev 서버에서 small distributed tick 1회
 curl -X POST ".../functions/v1/event-flow-simulator" \
   -H "Authorization: Bearer <SERVICE_ROLE_KEY>" \
-  -H "Content-Type: application/json"
-
-# 특정 phase만 실행
-curl -X POST "..." -d '{"phase": "verify"}'
-curl -X POST "..." -d '{"phase": "create"}'
-curl -X POST "..." -d '{"phase": "settle"}'
+  -H "Content-Type: application/json" \
+  -d '{"ticks":1,"usersPerTick":5,"partnersPerTick":2,"seed":202605250905}'
 ```
 
-Assertion 실패 시 GitHub 이슈가 자동 생성되며, 이슈에 Axiom 쿼리가 포함된다.
+시간은 5분 고정 schedule 이 담당하고, 랜덤성은 actor/user/partner/event sampling 에만 둔다. 유저 신청 대상은 DB prefix 가 아니라 `user-event-feed` 결과에서 고른다. Assertion 실패 시 GitHub 이슈가 자동 생성되며, 이슈에 Axiom 쿼리가 포함된다.
 
 ## 환경변수 참조
 

--- a/docs/qa/automation-test-guide.md
+++ b/docs/qa/automation-test-guide.md
@@ -23,7 +23,7 @@
 ├── 디자인 토큰 / 시각 회귀 감지?             → Layer 2b (Alchemist golden)
 ├── repository / controller / util / model?   → Layer 1 (unit)
 ├── 매시간 실 DB 데이터 이상 감시?            → Layer 6 (DB monitor RPC)
-└── 파이프라인 연쇄 동작 (tick) 감시?         → Layer 7 (event-flow-simulator)
+└── dev 환경에서 실제 EF flow 장시간 감시?    → Layer 7 (event-flow-simulator)
 ```
 
 **복수 Layer 필요 사례**:
@@ -210,7 +210,7 @@ void main() {
 ### MAY
 
 - [ ] **Layer 6 invariant** — 새 테이블이 "절대 N 초과하면 안 된다" 같은 런타임 제약을 가질 때
-- [ ] **Layer 7 tick** — 새 파이프라인 단계가 시간 기반 trigger 에 의존할 때
+- [ ] **Layer 7 event-flow** — 새 flow 가 여러 EF 를 거쳐 dev soak 에서 emerge 할 때
 
 ---
 
@@ -227,7 +227,7 @@ void main() {
 | 4 (pgTAP) | `supabase/tests/database/*.sql` | 80 |
 | 5 (Deno EF) | `supabase/functions/**/*_test.ts` | 75 |
 | 6 (DB monitor) | `check_db_invariants()` RPC | 1 RPC (매시간) |
-| 7 (tick simulator) | `event-flow-simulator` EF + 2 workflows | 매시간 + 매일 |
+| 7 (event-flow simulator) | `event-flow-simulator` EF + `monitor-event-flow-*` | 5분마다 + 24h soak |
 
 **핵심 갭**:
 - 🔴 **Layer 3 CUJ 이관 0%** — 37 widget flow 를 Patrol 로 전환 필요 (#1586 Phase D-2)
@@ -273,8 +273,11 @@ deno test --allow-all supabase/functions/payment-verify/
 # Layer 6 — 수동 실행
 psql -c "SELECT * FROM check_db_invariants();"
 
-# Layer 7 — workflow_dispatch 로 수동 trigger
-gh workflow run monitor-daily-lifecycle.yml --ref dev
+# Layer 7 — target workflow (구현 후) 수동 trigger
+gh workflow run monitor-event-flow-distributed.yml --ref dev
+
+# Legacy manual smoke
+gh workflow run monitor-event-flow-hourly.yml --ref dev
 ```
 
 ---
@@ -314,7 +317,7 @@ gh workflow run monitor-daily-lifecycle.yml --ref dev
 추가 워크플로우:
 - `monitor-patrol-e2e.yml` — Layer 3 (주 1회 예정, 현재 런 0건)
 - `monitor-db-invariants.yml` — Layer 6 (매시간)
-- `monitor-daily-lifecycle.yml` / `hourly-user-activity.yml` — Layer 7
+- `monitor-event-flow-*` — Layer 7
 
 ---
 

--- a/docs/qa/test-strategy.md
+++ b/docs/qa/test-strategy.md
@@ -2,7 +2,7 @@
 
 > 이 문서는 Minglit 모노레포의 테스트 계층 정의 **Single Source of Truth**.
 > 관련 이슈: #1586 (Phase A — 본 문서 재작성)
-> 최근 업데이트: 2026-04-18 (taxonomy 확정, 용어 통일)
+> 최근 업데이트: 2026-05-25 (Layer 7 를 dev distributed event-flow simulator 로 정렬)
 
 ---
 
@@ -38,7 +38,7 @@
 | 4 | **pgTAP** | DB 스키마 / 트리거 / RPC / RLS 계약 | `supabase/tests/database/` | pgTAP | PR 마다 |
 | 5 | **Deno EF test** | Edge Function TypeScript 로직 단위 | `supabase/functions/**/*_test.ts` | `deno test` | PR 마다 |
 | 6 | **DB monitor** | Runtime invariant 감시 | `check_db_invariants()` RPC + `.github/workflows/monitor-db-invariants.yml` | SQL | 매시간 cron |
-| 7 | **Tick simulator** | 서버 pipeline 관통 시뮬 (시간 전진 + 파이프라인 부하) | `event-flow-simulator` EF + `.github/workflows/monitor-daily-lifecycle.yml` + `hourly-user-activity.yml` | EF + HTTP | 매시간 + 매일 |
+| 7 | **Event-flow simulator** | dev 에 작은 실제 EF traffic 을 지속 주입해 backend flow 관통 검증 | `event-flow-simulator` EF + `monitor-event-flow-*` | EF + HTTP | 5분마다 + 24h soak |
 
 ### 보조 (taxonomy 밖, 유지)
 
@@ -129,13 +129,14 @@
 | 실 dev DB 데이터에 대한 실시간 검증 | 기능 테스트 (→ 1-5) |
 | alert 발송 | |
 
-### Layer 7 — Tick simulator
+### Layer 7 — Event-flow simulator
 
 | ✅ 책임 | ❌ 비책임 |
 |--------|----------|
-| 시간 전진 (시뮬레이션 tick) → 이벤트 생명주기 관통 | 단일 EF 단위 테스트 (→ 5) |
-| 매칭 / 결제 / 정산 파이프라인 연쇄 검증 | 앱 UI (→ 1-3) |
-| 매시간 user activity 시뮬 | 스키마 검증 (→ 4) |
+| dev Supabase 에 5분 단위 small tick 주입 | 단일 EF 단위 테스트 (→ 5) |
+| user-event-feed → 신청 → 결제/환불/승인/체크인 같은 실제 EF 경로 관통 | 앱 UI (→ 1-3) |
+| actor/user/partner/event seed 기반 랜덤 샘플링으로 24h 누적 커버리지 확보 | 스키마 검증 (→ 4) |
+| partner EF 로 party/event/ticket 생성 후 user feed 에 자연 노출 | 독립 deterministic test DB 검증 (→ `_integration_tests/`) |
 
 ---
 
@@ -190,13 +191,13 @@
 - 워크플로우: `.github/workflows/monitor-db-invariants.yml` — 매시간 cron
 - 상태: **구현 존재. 2026-04-15 이슈 #1549 로 재등록 확인.**
 
-### Layer 7 — Tick simulator
+### Layer 7 — Event-flow simulator
 
 - EF: `supabase/functions/event-flow-simulator/`
 - 워크플로우:
-  - `monitor-daily-lifecycle.yml` — 매일 (PR #1584 로 pg_cron 에서 GH Actions 로 이관)
-  - `hourly-user-activity.yml` — 매시간
-- 상태: **정상 동작.**
+  - target: `monitor-event-flow-distributed` — dev 에서 5분마다 small tick
+  - legacy: `monitor-event-flow-hourly` / `monitor-event-flow-daily` — 수동 smoke 전용
+- 상태: **설계 정렬 중.** large daily cascade 는 per-trace rate limit 에 취약하므로 제거/축소 대상.
 
 ---
 

--- a/supabase/BLUEDOC.md
+++ b/supabase/BLUEDOC.md
@@ -11,13 +11,14 @@ Minglit 의 **백엔드 구현 루트**. DB migration, Edge Functions, seed, bac
 | [`tests/`](./tests/) | pgTAP / backend integration 성격의 Supabase 테스트 |
 | [`config.toml`](./config.toml) | 로컬 Supabase project 설정과 function 등록 |
 | [`seed.sql`](./seed.sql) | 공통 seed 데이터 |
-| [`seed.dev.sql`](./seed.dev.sql) · [`seed.local.sql`](./seed.local.sql) | dev/local 환경 seed 데이터 |
+| [`seed.dev.sql`](./seed.dev.sql) · [`seed.local.sql`](./seed.local.sql) | dev/local actor/base seed 데이터 |
 | [`setup_local.sh`](./setup_local.sh) | 로컬 Supabase 초기화 보조 스크립트 |
 
 ## 핵심 컨벤션
 
 - **상세 백엔드 설계는 문서로 이동** — DB inventory 와 도메인 관계는 `docs/architecture/backend.md` 가 기준.
 - **쓰기 경로는 Edge Function 중심** — 클라이언트 직접 write 정책을 늘리지 않고 service_role EF 에서 검증한다.
+- **dev seed 는 actor/base 만** — user/partner/permission/verification 까지. party/event/ticket state 는 EF 경유로 만든다.
 - **migration 은 append-only** — 기존 migration 수정 대신 새 번호를 추가하고, 생성 전 `migrations/` 최신 번호를 확인한다.
 - **function 은 manifest/wrapper 경유** — `functions/auth-manifest.json` 과 `minglitEdgeFunction` 규칙을 따른다.
 

--- a/supabase/functions/BLUEDOC.md
+++ b/supabase/functions/BLUEDOC.md
@@ -14,7 +14,7 @@ minglit 의 backend API 진입점. 60+ EF 와 공용 `_shared/`, 테스트 유�
 | [_contract_tests/](./_contract_tests/BLUEDOC.md)                         | EF 응답 JSON schema contract                                     |
 | [_integration_tests/](./_integration_tests/BLUEDOC.md)                   | local Supabase + 외부 mock integration/CUJ                       |
 | [_payment_integration_tests/](./_payment_integration_tests/BLUEDOC.md)   | 결제 chaining 시뮬. 추후 `_integration_tests/` 흡수              |
-| [event-flow-simulator/](./event-flow-simulator/BLUEDOC.md)               | 이벤트 lifecycle funnel 시뮬레이터                               |
+| [event-flow-simulator/](./event-flow-simulator/BLUEDOC.md)               | dev 5분 distributed event-flow 시뮬레이터                        |
 | [user-create-order/](./user-create-order/BLUEDOC.md)                     | 이벤트 신청/주문 생성 EF                                         |
 | [payment-verify/](./payment-verify/BLUEDOC.md)                           | PortOne 결제 검증/승인 EF                                        |
 | [user-cancel-order/](./user-cancel-order/BLUEDOC.md)                     | 유저 신청 취소/환불 EF                                           |
@@ -40,4 +40,4 @@ minglit 의 backend API 진입점. 60+ EF 와 공용 `_shared/`, 테스트 유�
 
 ---
 
-_Reviewed: 2026-05-24 00:00_
+_Reviewed: 2026-05-25 16:20_

--- a/supabase/functions/event-flow-simulator/BLUEDOC.md
+++ b/supabase/functions/event-flow-simulator/BLUEDOC.md
@@ -1,10 +1,10 @@
 # event-flow-simulator
 
-유저·파트너 트래픽을 시뮬레이션해 dev EF/스키마/트리거를 자동 검증하는 Supabase Edge Function.
+유저·파트너 트래픽을 dev 에 5분 단위로 흘려 EF/스키마/트리거를 자동 검증하는 Supabase Edge Function.
 
 ## 단일 모드 — Stochastic Cascade
 
-옛 phase / tick 분기는 v2 cascade 로 통합 삭제. 매 호출 = cascade 1회 실행.
+옛 phase / tick 분기는 v2 cascade 로 통합 삭제. 매 호출 = 작은 cascade 1회 실행.
 
 ## 호출 예시
 
@@ -12,7 +12,7 @@
 curl -X POST "https://<project>.supabase.co/functions/v1/event-flow-simulator" \
   -H "Authorization: Bearer <SERVICE_ROLE_KEY>" \
   -H "Content-Type: application/json" \
-  -d '{"ticks": 3, "usersPerTick": 10}'
+  -d '{"ticks": 1, "usersPerTick": 5, "partnersPerTick": 2, "seed": 202605250905}'
 ```
 
 응답 = `{ success, run_id, actors, trace_summary, violations, github_issue_url }`. 실패 시 reporter 가 자동 GH 이슈 생성.
@@ -29,20 +29,22 @@ curl -X POST "https://<project>.supabase.co/functions/v1/event-flow-simulator" \
 
 ## 트리거 / 환경 가드
 
-- `monitor-tick-user.yml` 매시 :30 → `mode=tick` / `monitor-daily-lifecycle.yml` KST 07:00 → phase 6단계
+- target: `monitor-event-flow-distributed` 가 dev 에서 5분마다 작은 tick 실행 (하루 288회)
+- legacy: `monitor-event-flow-hourly` / `monitor-event-flow-daily` 는 수동 smoke 전용
 - **prod 차단**: auth-manifest `envs: ["dev","development","local"]` 가드, `minglitEdgeFunction` wrapper 가 enforce
 - 필수 env: `SIM_USER_PASSWORD` (Fix #1508), `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`
 
 ## 핵심 컨벤션
 
-- `[E2E]` prefix 파티 + `user_` prefix 유저만 시뮬 대상 (실데이터 격리)
-- 모든 쓰기 = EF 경유 (직접 DB DML 0건) — 실 트래픽 경로 충실 재현
+- 시간은 고정 5분, 랜덤은 actor/user/partner/event sampling 에만 적용
+- 유저는 `user-event-feed` EF 결과에서 신청 대상을 선택한다. 특정 party/event prefix 직접 필터 금지
+- party/event/ticket 생성은 seed SQL 이 아니라 partner EF 경유
+- `seed.dev.sql` 은 user / partner / permission / verification 같은 base actor 데이터만 담당
 - 액션 실패 시 `sim_reporter` 가 자동 GH 이슈 생성
 - 단위 테스트: `cd supabase/functions && deno test event-flow-simulator/`
 
 ## 한계 / 개선 계획
-
-v2 **Stochastic Cascade** 모델 (backend 를 확률적 funnel 로 모델링, invariant 1개로 N 시나리오 자동 가드) 도입 완료. 다만 실 invariant set 은 아직 미정의 — 진짜 minglit cross-EF 규칙 (money conservation, settlement coverage, match integrity 등) 은 별도 RFC 로 도입 예정. 상세는 [architecture.md](./architecture.md).
+v2 **Stochastic Cascade** 모델은 도입됐지만 현재 구현은 `[E2E]` prefix snapshot 과 large daily run 흔적이 남아 있다. 다음 단계는 5분 distributed tick, actor random sampling, feed-driven apply, partner-EF-driven party/event generation 으로 정렬한다. 상세는 [architecture.md](./architecture.md).
 
 ---
-_Reviewed: 2026-05-17 22:32_
+_Reviewed: 2026-05-25 16:20_

--- a/supabase/functions/event-flow-simulator/README.md
+++ b/supabase/functions/event-flow-simulator/README.md
@@ -1,6 +1,6 @@
 # event-flow-simulator
 
-Stochastic Cascade 모델 기반 백엔드 시뮬레이터. 진입점 / 모드 / 컨벤션은 [BLUEDOC.md](./BLUEDOC.md), 아키텍처 상세는 [architecture.md](./architecture.md).
+Stochastic Cascade 모델 기반 dev event-flow 시뮬레이터. 5분마다 작은 실제 EF traffic 을 흘리는 distributed soak signal 이다. 진입점 / 모드 / 컨벤션은 [BLUEDOC.md](./BLUEDOC.md), 아키텍처 상세는 [architecture.md](./architecture.md).
 
 ## 빠른 실행
 
@@ -12,8 +12,10 @@ deno test action/ core/ policy/ invariant/ --allow-all
 curl -X POST "https://<project>.supabase.co/functions/v1/event-flow-simulator" \
   -H "Authorization: Bearer <SERVICE_ROLE_KEY>" \
   -H "Content-Type: application/json" \
-  -d '{"ticks": 3, "usersPerTick": 10}'
+  -d '{"ticks": 1, "usersPerTick": 5, "partnersPerTick": 2, "seed": 202605250905}'
 ```
+
+시간은 schedule 이 고정 5분으로 관리한다. 랜덤성은 actor/user/partner/event sampling 에만 둔다. party/event/ticket 은 SQL seed 가 아니라 partner EF 로 만들고, user 는 `user-event-feed` 결과에서 신청 대상을 고른다.
 
 ## 폴더
 

--- a/supabase/functions/event-flow-simulator/action/partner_create_event.ts
+++ b/supabase/functions/event-flow-simulator/action/partner_create_event.ts
@@ -23,7 +23,8 @@ export const partnerCreateEventAction: ActionDef = {
     const myParties = (state.myParties as Array<unknown>) ?? [];
     // 파티 없거나 scheduled event 가 임계치 미만 → 신규 생성
     if (myParties.length === 0) return true;
-    const scheduledCount = myEvents.filter((e) => e.status === "scheduled").length;
+    const scheduledCount =
+      myEvents.filter((e) => e.status === "scheduled").length;
     return scheduledCount < MIN_SCHEDULED_EVENTS;
   },
 
@@ -35,8 +36,10 @@ export const partnerCreateEventAction: ActionDef = {
       action: "create",
       _imageFilenames: SEED_IMAGE_FILENAMES,
       party: {
-        title: `[E2E] Tick Party ${now}`,
-        description: { ops: [{ insert: "Auto-generated tick simulation party\n" }] },
+        title: `Event Flow Simulator Party ${now}`,
+        description: {
+          ops: [{ insert: "Auto-generated tick simulation party\n" }],
+        },
         required_verification_ids: [],
         min_confirmed_count: 4,
         max_participants: 20,
@@ -44,14 +47,24 @@ export const partnerCreateEventAction: ActionDef = {
         metadata: { show_participant_list: true, visibility: "public" },
       },
       location: {
-        name: "[E2E] 틱 시뮬레이션 장소",
+        name: "Event Flow Simulator Venue",
         address: "서울시 강남구",
         region_1: "서울",
         region_2: "강남구",
       },
       entry_group_templates: [
-        { label: "남성", gender: "male", birth_year_min: 1990, birth_year_max: 2005 },
-        { label: "여성", gender: "female", birth_year_min: 1990, birth_year_max: 2005 },
+        {
+          label: "남성",
+          gender: "male",
+          birth_year_min: 1990,
+          birth_year_max: 2005,
+        },
+        {
+          label: "여성",
+          gender: "female",
+          birth_year_min: 1990,
+          birth_year_max: 2005,
+        },
       ],
       ticket_templates: [{ name: "일반", price: 15000, quantity: 20 }],
     };

--- a/supabase/functions/event-flow-simulator/architecture.md
+++ b/supabase/functions/event-flow-simulator/architecture.md
@@ -7,7 +7,7 @@
 ## Part 1 — 목적 (What this simulator exists for)
 
 ### 1차 목적
-> **PR 머지 전에 backend 비즈니스 규칙 위반을 잡는다.**
+> **dev 환경에서 실제 EF 경로를 작은 트래픽으로 계속 흘려 backend 비즈니스 규칙 위반을 잡는다.**
 
 예: "결제 완료 (`event_applications.status='paid'`) 인데 대응 payment row 가 없는 경우" 같은 **여러 EF 호출이 엮여서 emerge 하는 정합 규칙**. 단일 EF 단위 테스트로는 잡히지 않고, production 에서야 발견되는 부류. (실 invariant set 정의는 Part 2.B 의 별도 RFC)
 
@@ -20,6 +20,31 @@
 - Production 시스템 (dev 전용 — `auth-manifest` envs 가드)
 - Load testing 도구 (latency 측정 ≠ correctness 검증)
 - UI 테스트 (Patrol/Alchemist 가 그 layer)
+- PR-time deterministic integration test (로컬 Supabase + 명시 scenario 는 `_integration_tests/` 책임)
+
+### Dev soak 운영 모델
+
+`event-flow-simulator` 는 독립 테스트 DB 가 아니라 **dev Supabase** 에서 계속 도는 soak signal 이다. RC 후보 판정은 24시간 동안 이 signal 이 안정적으로 흘렀는지를 본다.
+
+| 항목 | 정책 |
+|---|---|
+| 실행 주기 | 5분마다 1회 (`*/5 * * * *`) — 하루 288회 |
+| 호출 크기 | `ticks=1`, 작은 actor set (`usersPerTick` 3-8, `partnersPerTick` 1-2) |
+| 랜덤 위치 | 시간은 고정, actor/user/partner/event 선택만 seed 기반 랜덤 |
+| 환경 | dev 전용. `auth-manifest` env guard 로 prod 차단 |
+| 실패 처리 | 실패 즉시 `dev-soak/backend-simulator` status + release-blocker issue |
+
+큰 daily cascade 한 번(`ticks=3`, `usersPerTick=50`)으로 100개 이상의 nested EF 호출을 한 trace 에 몰아넣는 방식은 Supabase per-trace rate limit 에 취약하다. 총 커버리지는 24시간 누적으로 확보하고, 각 invocation 은 작게 유지한다.
+
+### Seed 책임 경계
+
+`seed.dev.sql` 은 **actor 와 최소 기준 데이터**만 만든다.
+
+- user / partner owner / partner applicant 계정
+- partner row, partner_member_permissions, location, verification
+- 로그인 가능한 dev password / auth identity backfill
+
+파티, 이벤트, 티켓, 신청, 결제, 승인, 체크인은 simulator 가 **각 도메인 EF 를 통해 생성/전이**해야 한다. SQL seed 로 party/event 를 직접 만들면 business flow 검증을 우회한다.
 
 ---
 
@@ -43,6 +68,27 @@
 ```
 
 각 화살표 = EF 호출 + 확률 게이트. cascade 가 funnel 자체를 모델링.
+
+### 실제 user flow 원칙
+
+유저 actor 가 신청할 이벤트를 고를 때 DB 에서 특정 prefix 의 party/event 를 직접 필터링하지 않는다. 실제 앱과 동일하게:
+
+```
+user actor JWT
+  → user-event-feed EF
+  → feed 결과에서 event 선택
+  → user-create-order / payment-verify / user-cancel-order / checkin / vote ...
+```
+
+파트너 측 데이터도 SQL seed 가 아니라 partner actor 가 EF 로 만든다.
+
+```
+partner actor JWT
+  → partner-manage-party / partner-manage-event / ticket EF
+  → user feed 에 자연 노출
+```
+
+`[E2E]` 같은 title prefix 는 이 simulator 의 개념명이 아니며, event-flow traffic 을 표현하지 못한다. 격리가 필요하면 `[SIM]` 같은 명확한 simulation marker 또는 metadata/cohort 필드를 사용하되, 유저의 event discovery 자체는 `user-event-feed` 를 통과해야 한다.
 
 ### 왜 이 추상화가 옳은가
 
@@ -122,12 +168,11 @@ event-flow-simulator/
 │   # participant ordering / event lifecycle / PGMQ DLQ
 │
 └── modes/                # 호출 패턴 — params × cascade depth 조합
-    ├── tick.ts           # hourly :30 — short cascade, default params
-    ├── pr-gate.ts        # PR CI — medium cascade, default params, 모든 invariant
+    ├── tick.ts           # 5분 distributed tick — small cascade, default params
+    ├── pr-gate.ts        # 로컬 Supabase deterministic test 를 호출할 때만 사용
     ├── stress.ts         # 야간/주말 — chaos params, invariant 위반 → 자동 issue
     └── seed.ts           # 수동 1회성 — large cascade, seed params로 dev DB 채움
-                          #   ⚠️ 초기 fixture (partners, base users) 는 SQL seed 가 박음.
-                          #   EF 직접 시딩은 과거 timeout 사건으로 금지 (Fix #1413).
+                          #   ⚠️ 계정/파트너 base 만 SQL seed. party/event 는 EF 경유.
 ```
 
 ### 옛 phase 모드 처리
@@ -144,9 +189,9 @@ event-flow-simulator/
 | 2 | 액션 마이그 | 기존 8 SimAction → `action/*.ts` 8 파일. 기존 *_test.ts 유지 | 1주 | 기존 deno test 통과 |
 | 3 | policy + params | `policy/user.ts`, `policy/partner.ts`, `params/default.ts` 작성 | 3-4일 | small cascade run → 액션 발생 검증 |
 | 4 | invariant 초기 set | 실 비즈니스 규칙 정의 RFC (후보: money conservation / settlement coverage / match integrity / participant ordering / event lifecycle / PGMQ DLQ) — 각 규칙은 실 코드/스키마 정합 확인 선행 필요. 가설 invariant 작성 금지 | 2-3주 | stress params 로 의도적 위반 → 잡히는지 검증 |
-| 5 | `modes/tick.ts` | 얇은 wrapper. 기존 hourly :30 cron 동작 보장 | 2일 | 1회 dispatch → 기존과 동등 결과 |
-| 6 | `modes/pr-gate.ts` + CI | PR 머지 전 cascade 실행 + invariant 위반 시 PR 차단 | 2-3일 | 의도된 회귀 PR 1개로 차단 검증 |
-| 7 | `modes/seed.ts` + phase 삭제 | dev DB 시딩 (단, 초기 fixture 는 SQL seed 사용 — EF 타임아웃 우회). 옛 phase 모드 5 파일 삭제 | 3-4일 | seed 1회 실행 후 dev 상태 다양성 측정 |
+| 5 | `modes/tick.ts` | 5분 distributed tick. actor random sample + small payload | 2일 | 24h run history 에서 rate limit 0건 |
+| 6 | user/partner discovery 경로 정렬 | 유저는 `user-event-feed`, 파트너/이벤트 생성은 partner EF 경유 | 1주 | SQL party/event seed 없이 feed→apply 가능 |
+| 7 | `modes/seed.ts` + phase 삭제 | 계정/파트너 base seed 와 EF-driven state generation 분리. 옛 phase 모드 5 파일 삭제 | 3-4일 | seed 1회 실행 후 dev 상태 다양성 측정 |
 | 8 | `modes/stress.ts` | chaos params + invariant 위반 → GH 이슈 자동 생성 | 3일 | 야간 stress run → 알림 도착 검증 |
 | 9 | shallow / deep 분리 | 흥미로운 tier 만 실 EF 호출 + 나머지 in-memory → 운영 트래픽급 규모 시뮬 가능 | 1주 | 시뮬 시간 / 비용 측정 |
 | 10 | 문서 + 마이그 가이드 | architecture.md 보강, 신규 EF 추가 가이드 | 2-3일 | — |

--- a/supabase/functions/event-flow-simulator/core/sampling.ts
+++ b/supabase/functions/event-flow-simulator/core/sampling.ts
@@ -1,0 +1,24 @@
+// core/sampling.ts — deterministic actor sampling helpers
+
+import type { PRNG } from "./types.ts";
+
+export function positiveInteger(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.max(0, Math.floor(value));
+}
+
+export function sampleDeterministic<T>(
+  items: readonly T[],
+  count: number,
+  rng: PRNG,
+): T[] {
+  const limit = Math.max(0, Math.min(Math.floor(count), items.length));
+  if (limit === 0) return [];
+
+  const copy = [...items];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(rng.next() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy.slice(0, limit);
+}

--- a/supabase/functions/event-flow-simulator/core/sampling_test.ts
+++ b/supabase/functions/event-flow-simulator/core/sampling_test.ts
@@ -1,0 +1,30 @@
+import { assertEquals } from "@std/assert";
+
+import { positiveInteger, sampleDeterministic } from "./sampling.ts";
+import { createPRNG } from "./types.ts";
+
+Deno.test("sampleDeterministic returns a stable bounded sample", () => {
+  const items = ["a", "b", "c", "d", "e"];
+
+  const first = sampleDeterministic(items, 3, createPRNG(123));
+  const second = sampleDeterministic(items, 3, createPRNG(123));
+
+  assertEquals(first, second);
+  assertEquals(first.length, 3);
+  assertEquals(new Set(first).size, 3);
+});
+
+Deno.test("sampleDeterministic clamps over-sized and zero counts", () => {
+  const items = ["a", "b"];
+
+  assertEquals(sampleDeterministic(items, 10, createPRNG(1)).length, 2);
+  assertEquals(sampleDeterministic(items, 0, createPRNG(1)), []);
+  assertEquals(items, ["a", "b"]);
+});
+
+Deno.test("positiveInteger accepts finite numbers only", () => {
+  assertEquals(positiveInteger(3.8, 1), 3);
+  assertEquals(positiveInteger(-4, 1), 0);
+  assertEquals(positiveInteger(Number.NaN, 7), 7);
+  assertEquals(positiveInteger("5", 7), 7);
+});

--- a/supabase/functions/event-flow-simulator/core/snapshot.ts
+++ b/supabase/functions/event-flow-simulator/core/snapshot.ts
@@ -2,17 +2,18 @@
 //
 // 실 운영: 단일 RPC sim_snapshot(actor_ids) 로 1 RT 채우는 게 이상 (architecture.md
 // Part 2.A — World Snapshot). PoC 단계: 다중 select 로 빌드 (RPC 신설은 후속 작업).
-// [E2E] prefix 가드로 시뮬 데이터만 격리.
+// dev/rc soak 에서는 실제 feed 대상 전체를 관찰한다. 격리는 workflow target
+// environment 로 맡긴다.
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { WorldSnapshot } from "./observable.ts";
 
-export async function buildSnapshot(supabase: SupabaseClient): Promise<WorldSnapshot> {
-  // [E2E] prefix party 만 시뮬 대상
+export async function buildSnapshot(
+  supabase: SupabaseClient,
+): Promise<WorldSnapshot> {
   const { data: partyRows } = await supabase
     .from("parties")
-    .select("id, partner_id, status")
-    .like("title", "[E2E]%");
+    .select("id, partner_id, status");
   const parties = (partyRows ?? []) as Array<{
     id: string;
     partner_id: string;
@@ -24,40 +25,64 @@ export async function buildSnapshot(supabase: SupabaseClient): Promise<WorldSnap
     return emptySnapshot();
   }
 
-  const [eventRows, ticketRows, appRows, partRows, voteRows, blockRows] = await Promise.all([
-    supabase
-      .from("events")
-      .select("id, party_id, status, start_time")
-      .in("party_id", partyIds),
-    supabase.from("tickets").select("id, event_id, price"),
-    supabase
-      .from("event_applications")
-      .select("id, user_id, event_id, status"),
-    supabase
-      .from("event_participants")
-      .select("id, user_id, event_id, status"),
-    supabase
-      .from("match_votes")
-      .select("event_id, voter_id, candidate_id"),
-    supabase
-      .from("social_interactions")
-      .select("user_id, target_id, target_type")
-      .eq("interaction_type", "block")
-      .eq("target_type", "partner"),
-  ]);
+  const { data: eventRows } = await supabase
+    .from("events")
+    .select("id, party_id, status, start_time")
+    .in("party_id", partyIds);
+  const events = (eventRows ?? []) as Array<{
+    id: string;
+    party_id: string;
+    status: string;
+    start_time: string;
+  }>;
+  const eventIds = events.map((e) => e.id);
+  const partnerIds = parties.map((p) => p.partner_id);
 
-  const events =
-    ((eventRows.data ?? []) as Array<{
-      id: string;
-      party_id: string;
-      status: string;
-      start_time: string;
-    }>);
-  const tickets =
-    ((ticketRows.data ?? []) as Array<{ id: string; event_id: string; price: number }>);
+  const [ticketRows, appRows, partRows, voteRows, blockRows] = await Promise
+    .all(
+      [
+        eventIds.length > 0
+          ? supabase.from("tickets").select("id, event_id, price").in(
+            "event_id",
+            eventIds,
+          )
+          : Promise.resolve({ data: [] }),
+        eventIds.length > 0
+          ? supabase
+            .from("event_applications")
+            .select("id, user_id, event_id, status")
+            .in("event_id", eventIds)
+          : Promise.resolve({ data: [] }),
+        eventIds.length > 0
+          ? supabase
+            .from("event_participants")
+            .select("id, user_id, event_id, status")
+            .in("event_id", eventIds)
+          : Promise.resolve({ data: [] }),
+        eventIds.length > 0
+          ? supabase
+            .from("match_votes")
+            .select("event_id, voter_id, candidate_id")
+            .in("event_id", eventIds)
+          : Promise.resolve({ data: [] }),
+        supabase
+          .from("social_interactions")
+          .select("user_id, target_id, target_type")
+          .eq("interaction_type", "block")
+          .eq("target_type", "partner")
+          .in("target_id", partnerIds),
+      ],
+    );
+
+  const tickets = (ticketRows.data ?? []) as Array<
+    { id: string; event_id: string; price: number }
+  >;
 
   // tickets 를 event 에 attach (observable 모델이 event.tickets 기대)
-  const ticketsByEvent = new Map<string, Array<{ id: string; price: number }>>();
+  const ticketsByEvent = new Map<
+    string,
+    Array<{ id: string; price: number }>
+  >();
   for (const t of tickets) {
     if (!ticketsByEvent.has(t.event_id)) ticketsByEvent.set(t.event_id, []);
     ticketsByEvent.get(t.event_id)!.push({ id: t.id, price: t.price });
@@ -70,32 +95,28 @@ export async function buildSnapshot(supabase: SupabaseClient): Promise<WorldSnap
   return {
     parties,
     events: eventsWithTickets,
-    applications:
-      ((appRows.data ?? []) as Array<{
-        id: string;
-        user_id: string;
-        event_id: string;
-        status: string;
-      }>),
-    participants:
-      ((partRows.data ?? []) as Array<{
-        id: string;
-        user_id: string;
-        event_id: string;
-        status: string;
-      }>),
-    votes:
-      ((voteRows.data ?? []) as Array<{
-        event_id: string;
-        voter_id: string;
-        candidate_id: string;
-      }>),
-    blocks:
-      ((blockRows.data ?? []) as Array<{
-        user_id: string;
-        target_id: string;
-        target_type: string;
-      }>),
+    applications: ((appRows.data ?? []) as Array<{
+      id: string;
+      user_id: string;
+      event_id: string;
+      status: string;
+    }>),
+    participants: ((partRows.data ?? []) as Array<{
+      id: string;
+      user_id: string;
+      event_id: string;
+      status: string;
+    }>),
+    votes: ((voteRows.data ?? []) as Array<{
+      event_id: string;
+      voter_id: string;
+      candidate_id: string;
+    }>),
+    blocks: ((blockRows.data ?? []) as Array<{
+      user_id: string;
+      target_id: string;
+      target_type: string;
+    }>),
   };
 }
 

--- a/supabase/functions/event-flow-simulator/index.ts
+++ b/supabase/functions/event-flow-simulator/index.ts
@@ -4,16 +4,24 @@
 // 상세: ./architecture.md (Stochastic Cascade 모델)
 
 import { createServiceClient } from "../_shared/supabase_client.ts";
-import { corsResponse, errorResponse, successResponse } from "../_shared/response_utils.ts";
+import {
+  corsResponse,
+  errorResponse,
+  successResponse,
+} from "../_shared/response_utils.ts";
 import { parseJsonBody } from "../_shared/request_utils.ts";
 import { flush, log } from "../_shared/axiom_logger.ts";
-import { minglitEdgeFunction, type EFContext } from "../_shared/edge_function.ts";
+import {
+  type EFContext,
+  minglitEdgeFunction,
+} from "../_shared/edge_function.ts";
 
 import { runCascade } from "./core/cascade.ts";
 import { createPRNG } from "./core/types.ts";
 import { EFTransport } from "./core/transport.ts";
 import { buildSnapshot } from "./core/snapshot.ts";
 import { reportFailure, summarizeTrace } from "./core/reporter.ts";
+import { positiveInteger, sampleDeterministic } from "./core/sampling.ts";
 import {
   getPartnerEmail,
   getSimPartnerToken,
@@ -30,20 +38,32 @@ import "./action/index.ts";
 
 const FN = "event-flow-simulator";
 
-export const handler = async (req: Request, _ctx: EFContext): Promise<Response> => {
+export const handler = async (
+  req: Request,
+  _ctx: EFContext,
+): Promise<Response> => {
   if (req.method === "OPTIONS") return corsResponse();
 
   const supabaseUrl = Deno.env.get("SUPABASE_URL");
   const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
   const simPassword = Deno.env.get("SIM_USER_PASSWORD");
   if (!supabaseUrl || !anonKey || !simPassword) {
-    return errorResponse("Missing required env vars (SUPABASE_URL / ANON_KEY / SIM_USER_PASSWORD)", 500);
+    return errorResponse(
+      "Missing required env vars (SUPABASE_URL / ANON_KEY / SIM_USER_PASSWORD)",
+      500,
+    );
   }
 
   const supabase = createServiceClient();
 
   // optional body params
-  let body: { ticks?: number; seed?: number; usersPerTick?: number; delayBetweenCallsMs?: number } = {};
+  let body: {
+    ticks?: number;
+    seed?: number;
+    usersPerTick?: number;
+    partnersPerTick?: number;
+    delayBetweenCallsMs?: number;
+  } = {};
   try {
     if (req.headers.get("content-type")?.includes("application/json")) {
       const parsed = await parseJsonBody(req);
@@ -54,35 +74,65 @@ export const handler = async (req: Request, _ctx: EFContext): Promise<Response> 
   }
 
   const runId = crypto.randomUUID();
-  const ticks = body.ticks ?? 1;
-  const seed = body.seed ?? Date.now();
-  const usersPerTick = body.usersPerTick ?? 10;
+  const ticks = positiveInteger(body.ticks, 1);
+  const seed = positiveInteger(body.seed, Date.now());
+  const usersPerTick = positiveInteger(body.usersPerTick, 10);
+  const partnersPerTick = positiveInteger(body.partnersPerTick, 2);
   // Fix #2545: 기본 300ms throttle — Supabase 의 per-trace rate limit 회피.
   // 0 으로 명시하면 disable (unit test / 빠른 dev 용).
-  const delayBetweenCallsMs = body.delayBetweenCallsMs ?? 300;
+  const delayBetweenCallsMs = positiveInteger(body.delayBetweenCallsMs, 300);
 
   log({
     function: FN,
     level: "info",
     message: "invoked",
-    metadata: { runId, ticks, seed, usersPerTick, delayBetweenCallsMs },
+    metadata: {
+      runId,
+      ticks,
+      seed,
+      usersPerTick,
+      partnersPerTick,
+      delayBetweenCallsMs,
+    },
   });
 
   try {
     // 1. 초기 snapshot 채움
     const initialSnapshot = await buildSnapshot(supabase);
+    const actorRng = createPRNG(seed).split();
 
     // 2. actor 발굴 + 토큰 prefetch
-    //    partner: 모든 [E2E] partner. user: seed user_ prefix 중 N명.
-    const partnerIds = [...new Set(initialSnapshot.parties.map((p) => p.partner_id))];
+    //    5분 distributed run 은 전체 seed cohort 중 일부만 랜덤 샘플링한다.
+    const snapshotPartnerIds = [
+      ...new Set(initialSnapshot.parties.map((p) => p.partner_id)),
+    ];
+    const { data: partnerRows } = await supabase
+      .from("partners")
+      .select("id")
+      .limit(200);
+    const allPartnerIds = [
+      ...new Set([
+        ...snapshotPartnerIds,
+        ...((partnerRows ?? []) as Array<{ id: string }>).map((p) => p.id),
+      ]),
+    ];
+    const partnerIds = sampleDeterministic(
+      allPartnerIds,
+      partnersPerTick,
+      actorRng.split(),
+    );
 
     const { data: userRows } = await supabase
       .from("user_profiles")
       .select("id, username")
       .like("username", "user\\_%")
       .not("username", "like", "partner\\_%")
-      .limit(usersPerTick);
-    const users = (userRows ?? []) as Array<{ id: string; username: string }>;
+      .limit(500);
+    const users = sampleDeterministic(
+      (userRows ?? []) as Array<{ id: string; username: string }>,
+      usersPerTick,
+      actorRng.split(),
+    );
 
     const tokenByActor = new Map<ActorId, string>();
     const actors: Actor[] = [];
@@ -91,12 +141,19 @@ export const handler = async (req: Request, _ctx: EFContext): Promise<Response> 
       try {
         const email = await getPartnerEmail(supabase, partnerId);
         if (!email) continue;
-        const token = await getSimPartnerToken(supabaseUrl, anonKey, email, simPassword);
+        const token = await getSimPartnerToken(
+          supabaseUrl,
+          anonKey,
+          email,
+          simPassword,
+        );
         tokenByActor.set(partnerId, token);
         actors.push({ id: partnerId, role: "partner" });
       } catch (e) {
         log({
-          function: FN, level: "warn", message: "partner_auth_skip",
+          function: FN,
+          level: "warn",
+          message: "partner_auth_skip",
           metadata: { partnerId, error: String(e) },
         });
       }
@@ -104,15 +161,24 @@ export const handler = async (req: Request, _ctx: EFContext): Promise<Response> 
 
     for (const user of users) {
       try {
-        const { data: authData } = await supabase.auth.admin.getUserById(user.id);
+        const { data: authData } = await supabase.auth.admin.getUserById(
+          user.id,
+        );
         const email = authData?.user?.email;
         if (!email) continue;
-        const token = await getSimUserToken(supabaseUrl, anonKey, email, simPassword);
+        const token = await getSimUserToken(
+          supabaseUrl,
+          anonKey,
+          email,
+          simPassword,
+        );
         tokenByActor.set(user.id, token);
         actors.push({ id: user.id, role: "user" });
       } catch (e) {
         log({
-          function: FN, level: "warn", message: "user_auth_skip",
+          function: FN,
+          level: "warn",
+          message: "user_auth_skip",
           metadata: { userId: user.id, error: String(e) },
         });
       }
@@ -147,6 +213,8 @@ export const handler = async (req: Request, _ctx: EFContext): Promise<Response> 
       metadata: {
         runId,
         actorsCount: actors.length,
+        usersPerTick,
+        partnersPerTick,
         traceTotal: summary.total,
         traceOk: summary.ok,
         traceFailed: summary.failed,


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-high-1

Closes #2767

## Summary
- add monitor-event-flow-distributed 5-minute workflow targeting dev by default and dev/rc only for manual dispatch
- make legacy hourly/daily simulator workflows manual-only and update soak gate requirements to distributed runs
- align dev-rc-cut-gate run-history lookup with GitHub scheduled workflow records on the default branch (`dev-staging`)
- add deterministic actor sampling to event-flow-simulator with partnersPerTick support and scoped snapshot queries
- update simulator/branch strategy docs and BLUEDOC pointers

## Tests
- deno test --allow-all --config supabase/functions/event-flow-simulator/deno.json supabase/functions/event-flow-simulator/
- ruby YAML parse for monitor-event-flow-*.yml, shared-notify.yml, dev-rc-cut-gate.yml (from original PR verification)
- python3 PyYAML parse for .github/workflows/dev-rc-cut-gate.yml
- python3 check that dev-rc-cut-gate requires monitor-event-flow-distributed runs on branch `dev-staging`
- git diff --check

## Residual Risk
- Low. The latest patch only changes the run-history branch filter and matching ops docs. It relies on the current repo default branch remaining `dev-staging`; if the default branch changes, this filter must change with it.