### PR TITLE
ci: improve dev cut gate traceability

### DIFF
--- a/.github/workflows/dev-staging-dev-cut-gate.yml
+++ b/.github/workflows/dev-staging-dev-cut-gate.yml
@@ -29,6 +29,8 @@ jobs:
       version: ${{ steps.version.outputs.new }}
       release_version: ${{ steps.version.outputs.base }}
       tag_name: ${{ steps.version.outputs.tag }}
+      source_pr_number: ${{ steps.version.outputs.source_pr_number }}
+      source_pr_url: ${{ steps.version.outputs.source_pr_url }}
 
     steps:
       - name: Calculate dev-staging CalVer version
@@ -65,10 +67,13 @@ jobs:
           BASE="${NOW_YY}.${NOW_MM}.${PR_NUM}"
           NEW_VERSION="${BASE}-dev-staging"
           TAG_NAME="v${NEW_VERSION}"
+          SOURCE_PR_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUM}"
 
           echo "new=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
           echo "base=${BASE}" >> "$GITHUB_OUTPUT"
           echo "tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+          echo "source_pr_number=${PR_NUM}" >> "$GITHUB_OUTPUT"
+          echo "source_pr_url=${SOURCE_PR_URL}" >> "$GITHUB_OUTPUT"
           echo "Bumping dev-staging to ${NEW_VERSION}"
 
   bump:
@@ -105,7 +110,10 @@ jobs:
             - Version: `${{ needs.calculate-version.outputs.version }}`
             - Release version: `${{ needs.calculate-version.outputs.release_version }}`
             - Tag: `${{ needs.calculate-version.outputs.tag_name }}`
+            - Source PR: [#${{ needs.calculate-version.outputs.source_pr_number }}](${{ needs.calculate-version.outputs.source_pr_url }})
+            - Target branch: `dev`
             - Next workflow: `dev-staging-dev-cut`
+            - Deploy after merge: `dev-deploy` on `push` to `dev`
 
   notify-failure:
     needs: [calculate-version, bump, track-cut-gate]

--- a/.github/workflows/dev-staging-dev-cut.yml
+++ b/.github/workflows/dev-staging-dev-cut.yml
@@ -154,6 +154,8 @@ jobs:
             - Source tag: `${{ steps.plan.outputs.tag_name }}`
             - Source SHA: `${{ steps.plan.outputs.tag_sha }}`
             - Promotion branch: `${{ steps.plan.outputs.branch_name }}`
+            - Target branch: `dev`
+            - Deploy after merge: `dev-deploy` on `push` to `dev`
             - Dry run: `${{ inputs.dry_run || false }}`
 
       - name: Create dev promotion PR and enable auto-merge
@@ -165,13 +167,16 @@ jobs:
           TAG_SHA: ${{ steps.plan.outputs.tag_sha }}
           BRANCH_NAME: ${{ steps.plan.outputs.branch_name }}
           CUT_ISSUE_NUMBER: ${{ steps.cut-issue.outputs.issue-number }}
+          CUT_ISSUE_URL: ${{ steps.cut-issue.outputs.issue-url }}
         run: |
           set -euo pipefail
           CUT_ISSUE_CLOSER=""
           CUT_ISSUE_MARKER=""
+          CUT_ISSUE_LINE="- Tracking issue: none"
           if [ -n "${CUT_ISSUE_NUMBER}" ]; then
             CUT_ISSUE_CLOSER="Closes #${CUT_ISSUE_NUMBER}"
             CUT_ISSUE_MARKER="<!-- minglit:cut-issue-number:${CUT_ISSUE_NUMBER} -->"
+            CUT_ISSUE_LINE="- Tracking issue: #${CUT_ISSUE_NUMBER} (${CUT_ISSUE_URL})"
           fi
 
           BODY="$(cat <<EOF
@@ -179,6 +184,9 @@ jobs:
 
           - Source tag: ${TAG_NAME}
           - Source SHA: ${TAG_SHA}
+          - Target branch: dev
+          - Deploy after merge: dev-deploy on push to dev
+          ${CUT_ISSUE_LINE}
           - Merge mode: rebase, because the active dev ruleset requires linear history.
 
           ${CUT_ISSUE_CLOSER}


### PR DESCRIPTION
## Summary
- add source PR and target/deploy context to dev-staging-dev cut gate issues
- keep promotion PR tracking in the PR body via Closes marker instead of writing promotion PR links back into the issue
- include tracking issue, target branch, and dev-deploy trigger in dev promotion PR bodies

## Test
- python3 YAML parse for changed workflows
- git diff --check