### PR TITLE
fix(ios): cap connectivity_plus below Xcode 26 requirement

### DIFF
--- a/.github/scripts/BLUEDOC.md
+++ b/.github/scripts/BLUEDOC.md
@@ -12,6 +12,7 @@
 | [`check-bluedoc-freshness.sh`](./check-bluedoc-freshness.sh) | PR 에서 새/삭제 파일에 대해 가장 가까운 ancestor BLUEDOC.md 갱신 강제. 통과: 이정표 표 갱신 또는 BLUEDOC 의 `_Reviewed_` 날짜 bump. + 모든 BLUEDOC.md 의 Reviewed 형식 검증 | `pr-gate.check-bluedoc-freshness` (required check) |
 | [`check-ios-deploy-branch-conditions.sh`](./check-ios-deploy-branch-conditions.sh) | `ios-deploy` action 의 브랜치 분기(`main` vs `non-main`) 회귀 검증 | 수동 실행 (`bash .github/scripts/check-ios-deploy-branch-conditions.sh`) |
 | [`check-android-deploy-workflow-contract.py`](./check-android-deploy-workflow-contract.py) | Android deploy release archive 가 `github.token` + `contents: write` 를 사용하고 PAT caller 계약을 요구하지 않는지 검증 | `pr-gate.static-checks` |
+| [`check-ios-connectivity-plus-cap.sh`](./check-ios-connectivity-plus-cap.sh) | iOS deploy runner 가 지원할 때까지 `connectivity_plus <7.1.0` resolution 강제 | `pr-gate.guard-ios-connectivity-plus-cap` |
 | [`scan-build-artifact-secrets.py`](./scan-build-artifact-secrets.py) | APK/AAB/`.next` 등 빌드 산출물에서 Supabase service-role secret 패턴을 redacted summary 로 검사 | `pr-gate.scan-build-artifact-secrets` |
 
 ## 핵심 컨벤션

--- a/.github/scripts/check-ios-connectivity-plus-cap.sh
+++ b/.github/scripts/check-ios-connectivity-plus-cap.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MAX_EXCLUSIVE="${CONNECTIVITY_PLUS_MAX_EXCLUSIVE:-7.1.0}"
+
+if [ "$#" -gt 0 ]; then
+  PACKAGE_DIRS=("$@")
+else
+  PACKAGE_DIRS=(
+    "apps/app_user"
+    "apps/app_partner"
+    "shared/packages/minglit_kit"
+  )
+fi
+
+for package_dir in "${PACKAGE_DIRS[@]}"; do
+  if [ ! -f "$package_dir/pubspec.yaml" ]; then
+    echo "::error file=${package_dir}/pubspec.yaml::pubspec.yaml not found"
+    exit 1
+  fi
+
+  deps_json="$(mktemp)"
+  (cd "$package_dir" && dart pub deps --json) > "$deps_json"
+
+  python3 - "$package_dir" "$MAX_EXCLUSIVE" "$deps_json" <<'PY'
+import json
+import sys
+
+package_dir, max_exclusive, deps_json_path = sys.argv[1:]
+
+
+def version_tuple(value: str) -> tuple[int, int, int]:
+    core = value.split("-", 1)[0].split("+", 1)[0]
+    parts = [int(part) for part in core.split(".")]
+    return tuple((parts + [0, 0, 0])[:3])
+
+
+with open(deps_json_path, encoding="utf-8") as deps_file:
+    deps = json.load(deps_file)
+
+package = next(
+    (item for item in deps.get("packages", []) if item.get("name") == "connectivity_plus"),
+    None,
+)
+if package is None:
+    print(
+        f"::error file={package_dir}/pubspec.yaml::connectivity_plus is not resolved; "
+        "the iOS deploy guard cannot verify the dependency cap"
+    )
+    sys.exit(1)
+
+version = package.get("version", "")
+if version_tuple(version) >= version_tuple(max_exclusive):
+    print(
+        f"::error file={package_dir}/pubspec.yaml::connectivity_plus resolved to "
+        f"{version}; keep it below {max_exclusive} until iOS deploy runners support "
+        "the newer Network framework API used by 7.1.x"
+    )
+    sys.exit(1)
+
+print(f"{package_dir}: connectivity_plus {version} < {max_exclusive}")
+PY
+  rm -f "$deps_json"
+done

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -155,6 +155,7 @@ jobs:
       app_user: ${{ steps.filter.outputs.app_user }}
       app_partner: ${{ steps.filter.outputs.app_partner }}
       minglit_kit: ${{ steps.filter.outputs.minglit_kit }}
+      ios_connectivity_plus_cap: ${{ steps.filter.outputs.ios_connectivity_plus_cap }}
       demo_android: ${{ steps.filter.outputs.demo_android }}
       mds_core: ${{ steps.filter.outputs.mds_core }}
       app_user_or_kit: ${{ steps.filter.outputs.app_user == 'true' || steps.filter.outputs.minglit_kit == 'true' || steps.filter.outputs.mds_core == 'true' }}
@@ -193,6 +194,14 @@ jobs:
           minglit_kit:
             - 'shared/packages/minglit_kit/**'
             - 'shared/packages/**'
+          ios_connectivity_plus_cap:
+            - 'pubspec.yaml'
+            - 'pubspec.lock'
+            - 'apps/app_user/pubspec.yaml'
+            - 'apps/app_partner/pubspec.yaml'
+            - 'shared/packages/minglit_kit/pubspec.yaml'
+            - '.github/scripts/check-ios-connectivity-plus-cap.sh'
+            - '.github/workflows/pr-gate.yml'
           demo_android:
             - '.github/workflows/pr-gate.yml'
             - 'pubspec.yaml'
@@ -248,6 +257,33 @@ jobs:
             - 'supabase/functions/**/*.json'
             - 'supabase/functions/**/.npmrc'
             - 'supabase/deno.json'
+
+  guard-ios-connectivity-plus-cap:
+    name: guard-ios-connectivity-plus-cap
+    needs: changes
+    if: ${{ needs.changes.outputs.ios_connectivity_plus_cap == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.41.9'  # Fix #2640: flutter_quill 11.5.0 incompatible with Flutter 3.44.0
+          cache: true
+      - name: Cache pub packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-ios-connectivity-plus-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Guard iOS connectivity_plus cap
+        run: bash .github/scripts/check-ios-connectivity-plus-cap.sh
 
   # App CI (User + Partner)
   test-flutter-apps:

--- a/shared/packages/minglit_kit/pubspec.yaml
+++ b/shared/packages/minglit_kit/pubspec.yaml
@@ -11,7 +11,8 @@ dependencies:
   app_settings: ^7.0.0
   async: ^2.13.0
   battery_plus: ^7.0.0
-  connectivity_plus: ^7.1.1
+  # Fix #2777/#2778: connectivity_plus 7.1.x requires Xcode 26.1.1 for NWPath.isUltraConstrained.
+  connectivity_plus: ">=7.0.0 <7.1.0"
   crypto: ^3.0.5
   cryptography: ^2.9.0
   # Fix #1111: device_info_plus 12.4.0 uses isiOSAppOnVision (iOS 16+ SDK) without availability guard — cap below 12.4.0


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-high-1

## Goal

Closes #2777. Closes #2778. Restore dev iOS deploy builds on the current `macos-15` GitHub runner image. Both iOS Partner and iOS User failed in run `26389702248` with the same `connectivity_plus 7.1.1` compiler error.

## Changes

- Cap `connectivity_plus` in `minglit_kit` to `>=7.0.0 <7.1.0`.
- Document the cap reason: 7.1.x references `NWPath.isUltraConstrained`, and the 7.1.1 changelog documents the newer Xcode 26.1.1 requirement.
- Add `pr-gate.guard-ios-connectivity-plus-cap`, which runs after `flutter pub get` and fails CI if `apps/app_user`, `apps/app_partner`, or `shared/packages/minglit_kit` resolve `connectivity_plus >= 7.1.0`.

## Verification

- `flutter pub get` from repo root resolved `connectivity_plus 7.0.0 (7.1.1 available)`.
- `bash .github/scripts/check-ios-connectivity-plus-cap.sh` passed for app_user, app_partner, and minglit_kit with `connectivity_plus 7.0.0 < 7.1.0`.
- `CONNECTIVITY_PLUS_MAX_EXCLUSIVE=7.0.0 bash .github/scripts/check-ios-connectivity-plus-cap.sh apps/app_user` failed as expected, proving the guard blocks an out-of-range resolution.
- `python3` YAML parse check passed for `.github/workflows/pr-gate.yml` and `.github/workflows/dev-staging-pr-gate.yml`.
- `bash .github/scripts/check-bluedoc-freshness.sh origin/dev-staging` passed.
- `flutter test test/src/utils/environment_info_test.dart` in `shared/packages/minglit_kit` passed.
- `git diff --check` passed.

## Residual Risk

Low for dev deploy recovery. This intentionally defers the satellite connectivity result added by `connectivity_plus 7.1.0` until the iOS deploy runner can build with an Xcode 26.1.1-compatible SDK. `flutter analyze` was also run earlier and failed on existing info-level lint debt unrelated to this change (229 infos, including pre-existing pubspec dependency sorting).