### PR TITLE
fix(supabase): wrap RLS auth helpers for initplans

### DIFF
--- a/supabase/BLUEDOC.md
+++ b/supabase/BLUEDOC.md
@@ -32,4 +32,4 @@ Minglit 의 **백엔드 구현 루트**. DB migration, Edge Functions, seed, bac
 - [docs/infra/bluedoc/BLUEDOC.md](../docs/infra/bluedoc/BLUEDOC.md) — BLUEDOC 컨벤션
 
 ---
-_Reviewed: 2026-05-25 16:37_
+_Reviewed: 2026-05-25 22:00_

--- a/supabase/migrations/20260525000001_rls_auth_initplan.sql
+++ b/supabase/migrations/20260525000001_rls_auth_initplan.sql
@@ -1,0 +1,268 @@
+-- Issue #2797: wrap RLS auth helper calls in scalar subqueries so Postgres
+-- can evaluate them as initplans instead of per-row expressions.
+
+-- service_role-only system/retention tables
+DROP POLICY IF EXISTS "service_role_only" ON public.archived_records;
+CREATE POLICY "service_role_only" ON public.archived_records
+  FOR ALL USING ((SELECT auth.role()) = 'service_role');
+
+DROP POLICY IF EXISTS "service_role_only" ON public.blocked_dis;
+CREATE POLICY "service_role_only" ON public.blocked_dis
+  FOR ALL USING ((SELECT auth.role()) = 'service_role');
+
+DROP POLICY IF EXISTS "business_calendar_write_service_role" ON public.business_calendar;
+CREATE POLICY "business_calendar_write_service_role"
+  ON public.business_calendar FOR ALL
+  USING ((SELECT auth.role()) = 'service_role');
+
+DROP POLICY IF EXISTS "service_role_only" ON public.dead_letter_queue;
+CREATE POLICY "service_role_only" ON public.dead_letter_queue
+  FOR ALL USING ((SELECT auth.role()) = 'service_role');
+
+DROP POLICY IF EXISTS "service_role_all" ON public.debug_logs;
+CREATE POLICY "service_role_all" ON public.debug_logs
+  FOR ALL
+  USING ((SELECT auth.role()) = 'service_role')
+  WITH CHECK ((SELECT auth.role()) = 'service_role');
+
+DROP POLICY IF EXISTS "service_role_only" ON public.event_routes;
+CREATE POLICY "service_role_only" ON public.event_routes
+  FOR ALL USING ((SELECT auth.role()) = 'service_role');
+
+DROP POLICY IF EXISTS "service_role_only" ON public.processed_events;
+CREATE POLICY "service_role_only" ON public.processed_events
+  FOR ALL USING ((SELECT auth.role()) = 'service_role');
+
+DROP POLICY IF EXISTS "reconciliation_results_service_role_only" ON public.reconciliation_results;
+CREATE POLICY "reconciliation_results_service_role_only"
+  ON public.reconciliation_results
+  USING ((SELECT auth.role()) = 'service_role');
+
+DROP POLICY IF EXISTS "reconciliation_runs_service_role_only" ON public.reconciliation_runs;
+CREATE POLICY "reconciliation_runs_service_role_only"
+  ON public.reconciliation_runs
+  USING ((SELECT auth.role()) = 'service_role');
+
+DROP POLICY IF EXISTS "settlement_alarm_results_service_role_only" ON public.settlement_alarm_results;
+CREATE POLICY "settlement_alarm_results_service_role_only"
+  ON public.settlement_alarm_results
+  USING ((SELECT auth.role()) = 'service_role');
+
+DROP POLICY IF EXISTS "system_settings_service_role_only" ON public.system_settings;
+CREATE POLICY "system_settings_service_role_only"
+  ON public.system_settings
+  USING ((SELECT auth.role()) = 'service_role');
+
+DROP POLICY IF EXISTS "service_role_only" ON public.withdrawal_reasons;
+CREATE POLICY "service_role_only" ON public.withdrawal_reasons
+  FOR ALL USING ((SELECT auth.role()) = 'service_role');
+
+-- User/application ownership policies
+DROP POLICY IF EXISTS "Users can read own applications" ON public.event_applications;
+CREATE POLICY "Users can read own applications" ON public.event_applications
+  FOR SELECT
+  USING ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can create own applications" ON public.event_applications;
+CREATE POLICY "Users can create own applications" ON public.event_applications
+  FOR INSERT
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can update own applications" ON public.event_applications;
+CREATE POLICY "Users can update own applications" ON public.event_applications
+  FOR UPDATE
+  USING ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "partner_read_own_event_change_logs" ON public.event_change_logs;
+CREATE POLICY "partner_read_own_event_change_logs"
+  ON public.event_change_logs
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.events e
+      JOIN public.parties p ON p.id = e.party_id
+      WHERE e.id = event_change_logs.event_id
+        AND p.partner_id = (SELECT auth.uid())
+    )
+  );
+
+DROP POLICY IF EXISTS "Authenticated users can read visible participants" ON public.event_participants;
+CREATE POLICY "Authenticated users can read visible participants"
+  ON public.event_participants
+  FOR SELECT
+  USING (
+    (SELECT auth.role()) = 'authenticated'
+    AND (
+      (SELECT auth.uid()) = user_id
+      OR public.is_visible_user_profile(user_id)
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can view their own FCM tokens" ON public.fcm_tokens;
+CREATE POLICY "Users can view their own FCM tokens" ON public.fcm_tokens
+  FOR SELECT
+  USING ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Viewers can see their grants" ON public.file_access_grants;
+CREATE POLICY "Viewers can see their grants" ON public.file_access_grants
+  FOR SELECT
+  USING (viewer_id = (SELECT auth.uid()));
+
+DROP POLICY IF EXISTS "users read own logs" ON public.location_access_log;
+CREATE POLICY "users read own logs"
+  ON public.location_access_log
+  FOR SELECT TO authenticated
+  USING (user_id = (SELECT auth.uid()));
+
+DROP POLICY IF EXISTS "Users can see own matches" ON public.match_pairs;
+CREATE POLICY "Users can see own matches" ON public.match_pairs
+  FOR SELECT
+  USING ((SELECT auth.uid()) = user_lower_id OR (SELECT auth.uid()) = user_higher_id);
+
+DROP POLICY IF EXISTS "Users can cast votes" ON public.match_votes;
+CREATE POLICY "Users can cast votes" ON public.match_votes
+  FOR INSERT
+  WITH CHECK ((SELECT auth.uid()) = voter_id);
+
+DROP POLICY IF EXISTS "Users can read own votes" ON public.match_votes;
+CREATE POLICY "Users can read own votes" ON public.match_votes
+  FOR SELECT
+  USING ((SELECT auth.uid()) = voter_id);
+
+DROP POLICY IF EXISTS "Users can view granted files" ON public.minglit_files;
+CREATE POLICY "Users can view granted files" ON public.minglit_files
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.file_access_grants
+      WHERE file_id = minglit_files.id
+        AND viewer_id = (SELECT auth.uid())
+        AND (expires_at IS NULL OR expires_at > now())
+    )
+  );
+
+DROP POLICY IF EXISTS "Users can view own files" ON public.minglit_files;
+CREATE POLICY "Users can view own files" ON public.minglit_files
+  FOR SELECT
+  USING ((SELECT auth.uid()) = owner_id);
+
+DROP POLICY IF EXISTS "Users can read own applications" ON public.partner_applications;
+CREATE POLICY "Users can read own applications" ON public.partner_applications
+  FOR SELECT
+  USING ((SELECT auth.uid()) = user_id OR public.is_super_admin());
+
+DROP POLICY IF EXISTS "authenticated_can_apply" ON public.partner_applications;
+CREATE POLICY "authenticated_can_apply" ON public.partner_applications
+  FOR INSERT TO authenticated
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can read own permissions" ON public.partner_member_permissions;
+CREATE POLICY "Users can read own permissions" ON public.partner_member_permissions
+  FOR SELECT
+  USING (
+    (SELECT auth.uid()) = user_id
+    OR public.is_super_admin()
+    OR public.has_partner_permission(partner_id, 'MEMBER_MANAGE')
+  );
+
+DROP POLICY IF EXISTS "Users can read own verified status" ON public.partner_verified_users;
+CREATE POLICY "Users can read own verified status" ON public.partner_verified_users
+  FOR SELECT
+  USING ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can insert own reports" ON public.report_details;
+CREATE POLICY "Users can insert own reports" ON public.report_details
+  FOR INSERT TO authenticated
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can view own reports" ON public.report_details;
+CREATE POLICY "Users can view own reports" ON public.report_details
+  FOR SELECT TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can manage own interactions" ON public.social_interactions;
+CREATE POLICY "Users can manage own interactions" ON public.social_interactions
+  FOR ALL
+  USING ((SELECT auth.uid()) = user_id)
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can view own interactions" ON public.social_interactions;
+CREATE POLICY "Users can view own interactions" ON public.social_interactions
+  FOR SELECT
+  USING ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "user_read_own_consents" ON public.user_consents;
+CREATE POLICY "user_read_own_consents" ON public.user_consents
+  FOR SELECT TO authenticated
+  USING ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "user_interest_tags_read_own" ON public.user_interest_tags;
+CREATE POLICY "user_interest_tags_read_own" ON public.user_interest_tags
+  FOR SELECT
+  USING ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can update their own notifications" ON public.user_notifications;
+CREATE POLICY "Users can update their own notifications" ON public.user_notifications
+  FOR UPDATE
+  USING ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can view their own notifications" ON public.user_notifications;
+CREATE POLICY "Users can view their own notifications" ON public.user_notifications
+  FOR SELECT
+  USING ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can read own profile" ON public.user_profiles;
+CREATE POLICY "Users can read own profile" ON public.user_profiles
+  FOR SELECT
+  USING ((SELECT auth.uid()) = id);
+
+DROP POLICY IF EXISTS "Users can update own profile" ON public.user_profiles;
+CREATE POLICY "Users can update own profile" ON public.user_profiles
+  FOR UPDATE
+  USING ((SELECT auth.uid()) = id);
+
+DROP POLICY IF EXISTS "Users can view their own settings" ON public.user_settings;
+CREATE POLICY "Users can view their own settings" ON public.user_settings
+  FOR SELECT
+  USING ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can read own verifications" ON public.user_verifications;
+CREATE POLICY "Users can read own verifications" ON public.user_verifications
+  FOR SELECT
+  USING ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can create own submissions" ON public.verification_submissions;
+CREATE POLICY "Users can create own submissions" ON public.verification_submissions
+  FOR INSERT
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Users can read own submissions" ON public.verification_submissions;
+CREATE POLICY "Users can read own submissions" ON public.verification_submissions
+  FOR SELECT
+  USING ((SELECT auth.uid()) = user_id);
+
+-- Policy store and tag usage service policies
+DROP POLICY IF EXISTS "authenticated_read_policies" ON public.policies;
+CREATE POLICY "authenticated_read_policies" ON public.policies
+  FOR SELECT
+  USING ((SELECT auth.uid()) IS NOT NULL);
+
+DROP POLICY IF EXISTS "service_role_all_policies" ON public.policies;
+CREATE POLICY "service_role_all_policies" ON public.policies
+  FOR ALL
+  USING ((SELECT auth.role()) = 'service_role');
+
+DROP POLICY IF EXISTS party_tags_service ON public.party_tags;
+CREATE POLICY party_tags_service ON public.party_tags
+  FOR ALL
+  USING ((SELECT auth.role()) = 'service_role');
+
+DROP POLICY IF EXISTS tag_usage_daily_service ON public.tag_usage_daily;
+CREATE POLICY tag_usage_daily_service ON public.tag_usage_daily
+  FOR ALL
+  USING ((SELECT auth.role()) = 'service_role');
+
+DROP POLICY IF EXISTS tag_usage_monthly_service ON public.tag_usage_monthly;
+CREATE POLICY tag_usage_monthly_service ON public.tag_usage_monthly
+  FOR ALL
+  USING ((SELECT auth.role()) = 'service_role');

--- a/supabase/tests/database/104_rls_auth_initplan_advisor_test.sql
+++ b/supabase/tests/database/104_rls_auth_initplan_advisor_test.sql
@@ -1,0 +1,103 @@
+-- Issue #2797: Supabase Performance Advisor auth_rls_initplan regression.
+-- The affected policies should use scalar subqueries around auth helpers.
+BEGIN;
+
+SELECT plan(2);
+
+CREATE TEMP TABLE expected_auth_initplan_policies (
+  schemaname text NOT NULL,
+  tablename text NOT NULL,
+  policyname text NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO expected_auth_initplan_policies
+  (schemaname, tablename, policyname)
+VALUES
+  ('public', 'archived_records', 'service_role_only'),
+  ('public', 'blocked_dis', 'service_role_only'),
+  ('public', 'business_calendar', 'business_calendar_write_service_role'),
+  ('public', 'dead_letter_queue', 'service_role_only'),
+  ('public', 'debug_logs', 'service_role_all'),
+  ('public', 'event_applications', 'Users can create own applications'),
+  ('public', 'event_applications', 'Users can read own applications'),
+  ('public', 'event_applications', 'Users can update own applications'),
+  ('public', 'event_change_logs', 'partner_read_own_event_change_logs'),
+  ('public', 'event_participants', 'Authenticated users can read visible participants'),
+  ('public', 'event_routes', 'service_role_only'),
+  ('public', 'fcm_tokens', 'Users can view their own FCM tokens'),
+  ('public', 'file_access_grants', 'Viewers can see their grants'),
+  ('public', 'location_access_log', 'users read own logs'),
+  ('public', 'match_pairs', 'Users can see own matches'),
+  ('public', 'match_votes', 'Users can cast votes'),
+  ('public', 'match_votes', 'Users can read own votes'),
+  ('public', 'minglit_files', 'Users can view granted files'),
+  ('public', 'minglit_files', 'Users can view own files'),
+  ('public', 'partner_applications', 'Users can read own applications'),
+  ('public', 'partner_applications', 'authenticated_can_apply'),
+  ('public', 'partner_member_permissions', 'Users can read own permissions'),
+  ('public', 'partner_verified_users', 'Users can read own verified status'),
+  ('public', 'party_tags', 'party_tags_service'),
+  ('public', 'policies', 'authenticated_read_policies'),
+  ('public', 'policies', 'service_role_all_policies'),
+  ('public', 'processed_events', 'service_role_only'),
+  ('public', 'reconciliation_results', 'reconciliation_results_service_role_only'),
+  ('public', 'reconciliation_runs', 'reconciliation_runs_service_role_only'),
+  ('public', 'report_details', 'Users can insert own reports'),
+  ('public', 'report_details', 'Users can view own reports'),
+  ('public', 'settlement_alarm_results', 'settlement_alarm_results_service_role_only'),
+  ('public', 'social_interactions', 'Users can manage own interactions'),
+  ('public', 'social_interactions', 'Users can view own interactions'),
+  ('public', 'system_settings', 'system_settings_service_role_only'),
+  ('public', 'tag_usage_daily', 'tag_usage_daily_service'),
+  ('public', 'tag_usage_monthly', 'tag_usage_monthly_service'),
+  ('public', 'user_consents', 'user_read_own_consents'),
+  ('public', 'user_interest_tags', 'user_interest_tags_read_own'),
+  ('public', 'user_notifications', 'Users can update their own notifications'),
+  ('public', 'user_notifications', 'Users can view their own notifications'),
+  ('public', 'user_profiles', 'Users can read own profile'),
+  ('public', 'user_profiles', 'Users can update own profile'),
+  ('public', 'user_settings', 'Users can view their own settings'),
+  ('public', 'user_verifications', 'Users can read own verifications'),
+  ('public', 'verification_submissions', 'Users can create own submissions'),
+  ('public', 'verification_submissions', 'Users can read own submissions'),
+  ('public', 'withdrawal_reasons', 'service_role_only');
+
+SELECT is_empty(
+  $$
+    SELECT e.*
+    FROM expected_auth_initplan_policies e
+    LEFT JOIN pg_policies p
+      ON p.schemaname = e.schemaname
+     AND p.tablename = e.tablename
+     AND p.policyname = e.policyname
+    WHERE p.policyname IS NULL
+  $$,
+  'all auth_rls_initplan advisor policies still exist'
+);
+
+SELECT is_empty(
+  $$
+    WITH expressions AS (
+      SELECT
+        p.schemaname,
+        p.tablename,
+        p.policyname,
+        lower(coalesce(p.qual, '') || ' ' || coalesce(p.with_check, '')) AS expr
+      FROM pg_policies p
+      JOIN expected_auth_initplan_policies e
+        ON e.schemaname = p.schemaname
+       AND e.tablename = p.tablename
+       AND e.policyname = p.policyname
+    )
+    SELECT schemaname, tablename, policyname, expr
+    FROM expressions
+    WHERE expr ~ 'auth\.uid\(\)\s*(=|is)'
+       OR expr ~ '=\s*auth\.uid\(\)'
+       OR expr ~ 'auth\.role\(\)\s*='
+       OR expr ~ 'current_setting\([^)]*\)\s*='
+  $$,
+  'affected policies do not contain unwrapped auth helper calls'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-high-1

## Goal

Resolve the Supabase Performance Advisor `auth_rls_initplan` findings from #2797 by wrapping affected RLS `auth.uid()` / `auth.role()` calls in scalar subqueries while preserving the existing access model.

Refs #2797
Refs #2688

This does not close #2797 automatically because the final advisor rerun on dev still needs to confirm the WARN count is cleared after deployment.

## Changes

- Added append-only migration `20260525000001_rls_auth_initplan.sql`.
- Dropped/recreated the 48 affected policies only, preserving policy commands, target roles, `USING`, and `WITH CHECK` semantics.
- Replaced per-row auth helper calls with initplan forms like `(SELECT auth.uid())` / `(SELECT auth.role())`.
- Added pgTAP catalog regression coverage for the exact advisor policy set.

## Verification

- `supabase db reset`
- `supabase test db supabase/tests/database/104_rls_auth_initplan_advisor_test.sql`
- `supabase test db supabase/tests/database/00_setup.sql supabase/tests/database/06_rls_missing_tables_test.sql supabase/tests/database/07_social_rls_test.sql supabase/tests/database/52_policies_test.sql supabase/tests/database/54_pgmq_system_rls_test.sql supabase/tests/database/56_user_consents_test.sql supabase/tests/database/57_account_deletion_foundation_test.sql supabase/tests/database/61_tag_discovery_rls_test.sql supabase/tests/database/66_tag_security_hardening_test.sql supabase/tests/database/67_tag_monthly_rls_test.sql supabase/tests/database/85_location_access_log_test.sql supabase/tests/database/104_rls_auth_initplan_advisor_test.sql`

## Residual Risk

- Dev Supabase advisor must be rerun after this migration reaches dev to confirm the hosted warning count is cleared.
- `debug_logs.service_role_all` moves from older `current_setting('role')` style to the project-standard `auth.role()` service-role guard, wrapped as an initplan.
