### PR TITLE
fix(ci): prevent false tag ancestry failures in dev cut

### DIFF
--- a/.github/scripts/BLUEDOC.md
+++ b/.github/scripts/BLUEDOC.md
@@ -14,6 +14,7 @@
 | [`check-ios-deploy-branch-conditions.sh`](./check-ios-deploy-branch-conditions.sh) | `ios-deploy` action 의 브랜치 분기(`main` vs `non-main`) 회귀 검증 | 수동 실행 (`bash .github/scripts/check-ios-deploy-branch-conditions.sh`) |
 | [`check-android-deploy-workflow-contract.py`](./check-android-deploy-workflow-contract.py) | Android deploy release archive 가 `github.token` + `contents: write` 를 사용하고 PAT caller 계약을 요구하지 않는지 검증 | `pr-gate.static-checks` |
 | [`check-dev-soak-workflow-contract.py`](./check-dev-soak-workflow-contract.py) | `monitor-event-flow-distributed` + `dev-rc-cut-gate` + `shared-soak-gate` 의 run-history 판정 계약 검증 | `pr-gate.static-checks` |
+| [`check-dev-cut-workflow-contract.py`](./check-dev-cut-workflow-contract.py) | `dev-staging-dev-cut` 의 full-history checkout(`fetch-depth: 0`)과 `shared-notify` 의 `gh run view --repo` 컨텍스트 계약을 검증 | `pr-gate.static-checks` |
 | [`check-ios-connectivity-plus-cap.sh`](./check-ios-connectivity-plus-cap.sh) | iOS deploy runner 가 지원할 때까지 `connectivity_plus <7.1.0` resolution 강제 | `pr-gate.guard-ios-connectivity-plus-cap` |
 | [`scan-build-artifact-secrets.py`](./scan-build-artifact-secrets.py) | APK/AAB/`.next` 등 빌드 산출물에서 Supabase service-role secret 패턴을 redacted summary 로 검사 | `pr-gate.scan-build-artifact-secrets` |
 
@@ -32,4 +33,4 @@
 - [.github/BLUEDOC.md](../BLUEDOC.md) — 상위 진입점
 
 ---
-_Reviewed: 2026-05-25 12:00_
+_Reviewed: 2026-05-26 04:47_

--- a/.github/scripts/check-dev-cut-workflow-contract.py
+++ b/.github/scripts/check-dev-cut-workflow-contract.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Validate dev-staging-dev-cut and shared-notify workflow contracts."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEV_STAGING_DEV_CUT = ROOT / ".github/workflows/dev-staging-dev-cut.yml"
+SHARED_NOTIFY = ROOT / ".github/workflows/shared-notify.yml"
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_workflow(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as file:
+        data = yaml.safe_load(file)
+    if not isinstance(data, dict):
+        fail(f"{path} did not parse as a mapping")
+    return data
+
+
+def jobs_config(workflow: dict[str, Any], path: Path) -> dict[str, Any]:
+    jobs = workflow.get("jobs", {})
+    if not isinstance(jobs, dict):
+        fail(f"{path} jobs block did not parse as a mapping")
+    return jobs
+
+
+def assert_dev_staging_dev_cut_contract() -> None:
+    workflow = load_workflow(DEV_STAGING_DEV_CUT)
+    jobs = jobs_config(workflow, DEV_STAGING_DEV_CUT)
+    create_dev_cut_pr = jobs.get("create-dev-cut-pr", {})
+    if not isinstance(create_dev_cut_pr, dict):
+        fail("dev-staging-dev-cut must define create-dev-cut-pr job")
+
+    steps = create_dev_cut_pr.get("steps", [])
+    if not isinstance(steps, list):
+        fail("dev-staging-dev-cut create-dev-cut-pr steps did not parse as a list")
+    if not steps:
+        fail("dev-staging-dev-cut create-dev-cut-pr must have steps")
+
+    checkout = steps[0]
+    if not isinstance(checkout, dict):
+        fail("dev-staging-dev-cut first step must be a mapping")
+    if checkout.get("uses") != "actions/checkout@v6":
+        fail("dev-staging-dev-cut first step must use actions/checkout@v6")
+
+    with_config = checkout.get("with", {})
+    if not isinstance(with_config, dict):
+        fail("dev-staging-dev-cut checkout with block did not parse as a mapping")
+    if str(with_config.get("fetch-depth")) != "0":
+        fail("dev-staging-dev-cut checkout fetch-depth must be 0")
+
+
+def assert_shared_notify_contract() -> None:
+    text = SHARED_NOTIFY.read_text(encoding="utf-8")
+    expected = 'gh run view "${GITHUB_RUN_ID}" --repo "${GITHUB_REPOSITORY}" --log-failed'
+    if expected not in text:
+        fail("shared-notify must call gh run view with explicit --repo context")
+
+
+def main() -> None:
+    assert_dev_staging_dev_cut_contract()
+    assert_shared_notify_contract()
+    print("Dev cut workflow contract OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/dev-staging-dev-cut.yml
+++ b/.github/workflows/dev-staging-dev-cut.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Generate release bot token

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -114,6 +114,10 @@ jobs:
         if: ${{ !cancelled() }}
         run: python3 .github/scripts/check-dev-soak-workflow-contract.py
 
+      - name: Check dev cut workflow contract
+        if: ${{ !cancelled() }}
+        run: python3 .github/scripts/check-dev-cut-workflow-contract.py
+
       - name: Verify androidx.test runner/orchestrator version alignment
         if: ${{ !cancelled() }}
         # Fix #1780: runner와 orchestrator는 동일 major.minor 계열이어야 함 — Gradle

--- a/.github/workflows/shared-notify.yml
+++ b/.github/workflows/shared-notify.yml
@@ -133,7 +133,7 @@ jobs:
           fi
 
           LOG_TAIL_FILE="$(mktemp)"
-          if gh run view "${GITHUB_RUN_ID}" --log-failed > "${LOG_TAIL_FILE}" 2>/tmp/shared-notify-log-error; then
+          if gh run view "${GITHUB_RUN_ID}" --repo "${GITHUB_REPOSITORY}" --log-failed > "${LOG_TAIL_FILE}" 2>/tmp/shared-notify-log-error; then
             FAILED_LOG_TAIL="$(tail -n 200 "${LOG_TAIL_FILE}")"
           else
             FAILED_LOG_TAIL="Failed log tail unavailable. $(cat /tmp/shared-notify-log-error 2>/dev/null || true)"


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

Fixes #2804

## What Changed
- `.github/workflows/dev-staging-dev-cut.yml`
  - `actions/checkout` depth를 `1 -> 0`으로 변경해 full history를 확보했습니다.
  - `git merge-base --is-ancestor <tag_sha> origin/dev-staging` 검증이 shallow clone 경계에 걸려 false negative가 나는 문제를 방지합니다.
- `.github/workflows/shared-notify.yml`
  - `gh run view --log-failed`에 `--repo "${GITHUB_REPOSITORY}"`를 추가해 checkout 없는 notify job에서도 실패 로그 tail을 조회하도록 보강했습니다.

## Why
- 실제 실패 로그 기준 원인은 `Tag ... is not reachable from origin/dev-staging`였고, 이는 shallow checkout에서 ancestry 판정이 틀릴 수 있는 패턴과 일치했습니다.
- 기존 실패 이슈 본문의 "failed log tail unavailable" 메시지는 notify 단계의 repo 컨텍스트 누락으로 2차 실패가 섞인 상태였습니다.

## Verification
- 로컬 재현 스크립트로 shallow/full-history 비교:
  - shallow fetch 환경: `git merge-base --is-ancestor` 실패 재현
  - unshallow/full history 후: 동일 ancestry 체크 성공 확인
- 변경 파일 diff self-review 완료

## Residual Risk
- full history fetch로 네트워크 전송량이 증가할 수 있으나 daily 단일 workflow라 영향은 제한적입니다.
