### PR TITLE
test(mds-render): add app_partner location_guide_page catalog

### DIFF
--- a/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
@@ -24,6 +24,7 @@ flutter drive \
 | `bank_account_page` | loading · no-account · with-account · dark |
 | `checkin_placeholder_page` | loading · error · empty · selection · selection-dark |
 | `create_verification_page` | empty · with-fields · dark |
+| `location_guide_page` | default · loading |
 | `more_page` | default · limited-permissions |
 | `recurrence_management_screen` | active · paused · cancelled · no-rule · action-loading · loading · active-dark |
 | `verification_manage_page` | loading · active-empty · active-with-items · archived-with-items · dark |
@@ -51,6 +52,9 @@ mds-emulator-render/
 ├── create_verification_page/
 │   ├── builder.dart
 │   └── create_verification_page_test.dart
+├── location_guide_page/
+│   ├── builder.dart
+│   └── location_guide_page_test.dart
 ├── more_page/
 │   ├── builder.dart
 │   └── more_page_test.dart

--- a/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
@@ -8,6 +8,8 @@ import 'checkin_placeholder_page/checkin_placeholder_page_test.dart'
     as checkin_placeholder_page;
 import 'create_verification_page/create_verification_page_test.dart'
     as create_verification_page;
+import 'location_guide_page/location_guide_page_test.dart'
+    as location_guide_page;
 import 'more_page/more_page_test.dart' as more_page;
 import 'recurrence_management_screen/recurrence_management_screen_test.dart'
     as recurrence_management_screen;
@@ -19,6 +21,7 @@ final List<Object> catalogs = [
   bank_account_page.catalog,
   checkin_placeholder_page.catalog,
   create_verification_page.catalog,
+  location_guide_page.catalog,
   more_page.catalog,
   recurrence_management_screen.catalog,
   verification_manage_page.catalog,

--- a/apps/app_partner/integration_test/mds-emulator-render/location_guide_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/location_guide_page/builder.dart
@@ -1,7 +1,7 @@
 // LocationGuidePageBuilder — location_guide_page 전용 fluent API.
 //
 // LocationGuidePage 는 정적 안내 화면이므로 provider 의존 없이 렌더 가능.
-// spec state_2(loading) 재현을 위해 loading 모드에서 스피너 화면을 노출한다.
+// loading 모드에서도 기본 레이아웃(AppBar 포함)을 유지하고 스피너만 오버레이한다.
 
 import 'dart:async';
 
@@ -34,10 +34,17 @@ class LocationGuidePageBuilder extends MdsScreenBuilder<LocationGuidePage> {
   @override
   Widget build() {
     final home = _isLoading
-        ? const Scaffold(
-            body: Center(
-              child: MinglitCircularProgressIndicator(),
-            ),
+        ? const Stack(
+            children: [
+              LocationGuidePage(),
+              Positioned.fill(
+                child: IgnorePointer(
+                  child: Center(
+                    child: MinglitCircularProgressIndicator(),
+                  ),
+                ),
+              ),
+            ],
           )
         : const LocationGuidePage();
 

--- a/apps/app_partner/integration_test/mds-emulator-render/location_guide_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/location_guide_page/builder.dart
@@ -1,0 +1,59 @@
+// LocationGuidePageBuilder — location_guide_page 전용 fluent API.
+//
+// LocationGuidePage 는 정적 안내 화면이므로 provider 의존 없이 렌더 가능.
+// spec state_2(loading) 재현을 위해 loading 모드에서 스피너 화면을 노출한다.
+
+import 'dart:async';
+
+import 'package:app_partner/src/features/home/guide/location_guide_page.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+
+class LocationGuidePageBuilder extends MdsScreenBuilder<LocationGuidePage> {
+  LocationGuidePageBuilder() : super(page: const LocationGuidePage());
+
+  bool _isLoading = false;
+  Brightness _brightness = Brightness.light;
+
+  /// 로딩 상태.
+  LocationGuidePageBuilder loading() {
+    _isLoading = true;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// 다크 모드.
+  LocationGuidePageBuilder dark() {
+    _brightness = Brightness.dark;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  @override
+  Widget build() {
+    final home = _isLoading
+        ? const Scaffold(
+            body: Center(
+              child: MinglitCircularProgressIndicator(),
+            ),
+          )
+        : const LocationGuidePage();
+
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => null),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: _brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
+        home: home,
+      ),
+    );
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/location_guide_page/location_guide_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/location_guide_page/location_guide_page_test.dart
@@ -1,0 +1,28 @@
+// MDS screen: location_guide_page (app_partner)
+// 대응 MDS: apps/mds/docs/public/specs/location_guide_page/
+//
+// 출력: docs/infra/mds-emulator-render/location_guide_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<LocationGuidePageBuilder>(
+  screen: 'location_guide_page',
+  mdsSpec: 'apps/mds/docs/public/specs/location_guide_page/',
+  builder: LocationGuidePageBuilder.new,
+  states: [
+    // Default
+    MdsState('state-default', (b) => b, mdsIndex: 1),
+    // Loading
+    MdsState(
+      'state-loading',
+      (b) => b.loading(),
+      mdsIndex: 2,
+      infiniteAnimation: true,
+    ),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

Refs #2587

Issue lifecycle intent:
- Partial work only: this PR covers one uncovered screen from monitor issue #2587.
- The parent tracking issue remains open for follow-up uncovered screens; this PR does not close it.

## What Changed
- Added new app_partner MDS render catalog for `location_guide_page`
  - `builder.dart`: supports `state-default` and `state-loading`
  - `location_guide_page_test.dart`: catalog definitions mapped to MDS `state_1`, `state_2`
- Registered catalog in `apps/app_partner/integration_test/mds-emulator-render/_registry.dart`
- Updated `apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md`
  - added `location_guide_page` entry
  - updated structure map and `_Reviewed` timestamp

## Why
- `scripts/mds_render_coverage.dart` reported `location_guide_page` as uncovered.
- This PR reduces uncovered screens by 1 in the monitor baseline.

## Verification
- `dart run scripts/mds_render_coverage.dart --json`
  - `uncovered_screens`: `42 -> 41`
  - `location_guide_page` removed from uncovered list
- `flutter analyze integration_test/mds-emulator-render/location_guide_page integration_test/mds-emulator-render/_registry.dart` (in `apps/app_partner`) passed.

## Remaining Risk
- Integration screenshot test execution is blocked in this environment due missing Linux CMake runtime (`flutter test -d linux` failed before test run). CI/device runtime will validate execution path.
