### PR TITLE
test(mds-render): add app_partner more_page catalog

### DIFF
--- a/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
@@ -24,6 +24,7 @@ flutter drive \
 | `bank_account_page` | loading · no-account · with-account · dark |
 | `checkin_placeholder_page` | loading · error · empty · selection · selection-dark |
 | `create_verification_page` | empty · with-fields · dark |
+| `more_page` | default · limited-permissions |
 | `recurrence_management_screen` | active · paused · cancelled · no-rule · action-loading · loading · active-dark |
 | `verification_manage_page` | loading · active-empty · active-with-items · archived-with-items · dark |
 
@@ -50,6 +51,9 @@ mds-emulator-render/
 ├── create_verification_page/
 │   ├── builder.dart
 │   └── create_verification_page_test.dart
+├── more_page/
+│   ├── builder.dart
+│   └── more_page_test.dart
 ├── recurrence_management_screen/
 │   ├── builder.dart
 │   └── recurrence_management_screen_test.dart
@@ -63,4 +67,4 @@ mds-emulator-render/
 - [app_user mds-emulator-render](../../../app_user/integration_test/mds-emulator-render/BLUEDOC.md)
 - [architecture.md](../../../app_user/integration_test/mds-emulator-render/architecture.md)
 
-_Reviewed: 2026-05-20 12:25_
+_Reviewed: 2026-05-26 17:12_

--- a/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
@@ -8,6 +8,7 @@ import 'checkin_placeholder_page/checkin_placeholder_page_test.dart'
     as checkin_placeholder_page;
 import 'create_verification_page/create_verification_page_test.dart'
     as create_verification_page;
+import 'more_page/more_page_test.dart' as more_page;
 import 'recurrence_management_screen/recurrence_management_screen_test.dart'
     as recurrence_management_screen;
 import 'verification_manage_page/verification_manage_page_test.dart'
@@ -18,6 +19,7 @@ final List<Object> catalogs = [
   bank_account_page.catalog,
   checkin_placeholder_page.catalog,
   create_verification_page.catalog,
+  more_page.catalog,
   recurrence_management_screen.catalog,
   verification_manage_page.catalog,
 ];

--- a/apps/app_partner/integration_test/mds-emulator-render/more_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/more_page/builder.dart
@@ -1,0 +1,138 @@
+// MorePageBuilder — more_page 전용 fluent API.
+//
+// MorePage 는 currentPartnerInfoProvider / currentMemberPermissionsProvider
+// / moreCoordinatorProvider / authControllerProvider 를 사용한다.
+// MDS render에서는 네비게이션/인증 액션을 no-op으로 고정하고,
+// 권한/프로필 state만 바꿔 2개 spec state를 재현한다.
+
+import 'dart:async';
+
+import 'package:app_partner/src/features/more/more_coordinator.dart';
+import 'package:app_partner/src/features/more/more_page.dart';
+import 'package:app_partner/src/logic/current_partner_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import '../_engine/builder.dart';
+
+class _NoOpMoreCoordinator implements MoreCoordinator {
+  @override
+  void goToHome() {}
+
+  @override
+  void pushAccountDeletion() {}
+
+  @override
+  void pushAccountManagement() {}
+
+  @override
+  void pushBankAccountManagement() {}
+
+  @override
+  void pushMemberList(String partnerId) {}
+
+  @override
+  void pushNotificationSettings() {}
+
+  @override
+  void pushPartyList() {}
+
+  @override
+  void pushVerificationManage() {}
+}
+
+class _NoOpAuthController extends AuthController {
+  @override
+  FutureOr<void> build() {}
+
+  @override
+  Future<void> signOut() async {}
+}
+
+class MorePageBuilder extends MdsScreenBuilder<MorePage> {
+  MorePageBuilder() : super(page: const MorePage());
+
+  Partner? _partner = const Partner(
+    id: 'mock-partner-1',
+    name: '밍글릿 파트너',
+    contactEmail: 'partner@example.com',
+  );
+  List<String> _permissions = const ['SETTLEMENT_EDIT'];
+  bool _isPartnerLoading = false;
+  bool _isPartnerError = false;
+
+  /// Baseline: 정산 권한이 있는 전권 파트너.
+  MorePageBuilder defaultState() {
+    _partner = const Partner(
+      id: 'mock-partner-1',
+      name: '밍글릿 파트너',
+      contactEmail: 'partner@example.com',
+    );
+    _permissions = const ['SETTLEMENT_EDIT'];
+    _isPartnerLoading = false;
+    _isPartnerError = false;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// 제한 권한: 정산 권한이 없는 멤버.
+  MorePageBuilder limitedPermissionsState() {
+    _partner = const Partner(
+      id: 'mock-partner-1',
+      name: '밍글릿 파트너',
+      contactEmail: 'staff@example.com',
+    );
+    _permissions = const [];
+    _isPartnerLoading = false;
+    _isPartnerError = false;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  @override
+  Widget build() {
+    final partner = _partner;
+    final permissions = _permissions;
+    final isPartnerLoading = _isPartnerLoading;
+    final isPartnerError = _isPartnerError;
+
+    PackageInfo.setMockInitialValues(
+      appName: 'Minglit Partner',
+      packageName: 'com.minglit.partner',
+      version: '26.04.1852-dev',
+      buildNumber: '1',
+      buildSignature: '',
+    );
+
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => null),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+        moreCoordinatorProvider.overrideWithValue(_NoOpMoreCoordinator()),
+        authControllerProvider.overrideWith(_NoOpAuthController.new),
+        minglitUrlConfigProvider.overrideWithValue(
+          const MinglitUrlConfig(MinglitDomains.production()),
+        ),
+        currentPartnerInfoProvider.overrideWith((ref) async {
+          if (isPartnerLoading) {
+            await Future<void>.delayed(const Duration(days: 1));
+          }
+          if (isPartnerError) {
+            throw Exception('정보를 불러올 수 없습니다');
+          }
+          return partner;
+        }),
+        currentMemberPermissionsProvider.overrideWith(
+          (ref) async => permissions,
+        ),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: MinglitTheme.materialTheme,
+        home: const MorePage(),
+      ),
+    );
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/more_page/more_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/more_page/more_page_test.dart
@@ -1,0 +1,27 @@
+// MDS screen: more_page (app_partner)
+// 대응 MDS: apps/mds/docs/public/specs/more_page/
+//
+// 출력: docs/infra/mds-emulator-render/more_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<MorePageBuilder>(
+  screen: 'more_page',
+  mdsSpec: 'apps/mds/docs/public/specs/more_page/',
+  builder: MorePageBuilder.new,
+  states: [
+    // Baseline: 전권 파트너 (정산 권한 있음)
+    MdsState('state-default', (b) => b.defaultState(), mdsIndex: 1),
+    // Limited permissions: 정산 권한 없음 (계좌 관리 tile 미노출)
+    MdsState(
+      'state-limited-permissions',
+      (b) => b.limitedPermissionsState(),
+      mdsIndex: 2,
+    ),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- Added `more_page` MDS emulator render catalog for `app_partner`.
- Added state builders for spec baseline states:
  - `state-default` (with `SETTLEMENT_EDIT`)
  - `state-limited-permissions` (without settlement permission)
- Registered the catalog in `_registry.dart` and updated `mds-emulator-render/BLUEDOC.md` (including Reviewed timestamp).

## Why
- `#2587` tracks remaining uncovered MDS render screens.
- `more_page` was uncovered in the monitor output and has self-contained spec states, so this PR adds a single screen-scoped catalog slice.

## Verification
- `cd apps/app_partner && flutter analyze integration_test/mds-emulator-render/more_page integration_test/mds-emulator-render/_registry.dart`
- `dart run scripts/mds_render_coverage.dart --json`
  - `more_page` is removed from `uncovered_screens` and now appears in `incomplete_screens` (expected until screenshots are captured).
- `cd apps/app_partner && flutter test integration_test/mds-emulator-render/more_page/more_page_test.dart -d linux`
  - Fails in this environment because Linux `cmake` is not installed.

## Residual Risk
- Screenshot capture (`captured_pngs`) is not produced locally in this environment; CI/device run is still required for final image artifacts.

Refs #2587

Issue lifecycle intent:
- Partial work only: this PR covers one remaining screen in monitor issue #2587.
- Follow-up tracker remains open for remaining uncovered screens; this PR does not close #2587.
