### PR TITLE
test(mds-render): add my_tickets_page catalog

### DIFF
--- a/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
@@ -43,6 +43,7 @@ Phase 2 (TODO, follow-up PR) — `_manifest.yaml`, coverage report, scaffold 결
 | `deletion_verify_page` | email-user · social-user · dark |
 | `home_page` | default · guest · loading · feed-empty · error |
 | `login_page` | 기본 |
+| `my_tickets_page` | active-banners · empty · logged-out |
 | `notification_list_screen` | loaded · empty |
 | `notification_settings_screen` | default |
 | `privacy_page` | loading · loaded · dark |
@@ -66,4 +67,4 @@ MDS spec 디렉토리명과 동일 (per-screen, snake_case). 화면당 `builder.
 - [상위 BLUEDOC](../BLUEDOC.md) · 페어 워크플로우: `sync-mds-mockups.yml` (디자인 PNG)
 
 ---
-_Reviewed: 2026-05-21 07:00_
+_Reviewed: 2026-05-27 14:40_

--- a/apps/app_user/integration_test/mds-emulator-render/_mocks/coordinators.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_mocks/coordinators.dart
@@ -3,6 +3,7 @@
 import 'package:app_user/src/features/home/logic/home_coordinator.dart';
 import 'package:app_user/src/features/search/logic/search_coordinator.dart';
 import 'package:app_user/src/logic/auth_coordinator.dart';
+import 'package:app_user/src/routing/app_coordinator.dart';
 import 'package:mocktail/mocktail.dart';
 
 class MockHomeCoordinator extends Mock implements HomeCoordinator {}
@@ -10,3 +11,5 @@ class MockHomeCoordinator extends Mock implements HomeCoordinator {}
 class MockAuthCoordinator extends Mock implements AuthCoordinator {}
 
 class MockSearchCoordinator extends Mock implements SearchCoordinator {}
+
+class MockAppCoordinator extends Mock implements AppCoordinator {}

--- a/apps/app_user/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_registry.dart
@@ -8,8 +8,6 @@ import '_engine/builder.dart';
 import '_engine/catalog.dart';
 import 'account_management_page/account_management_page_test.dart'
     as account_management_page;
-import 'event_bottom_ticket_bar/event_bottom_ticket_bar_test.dart'
-    as event_bottom_ticket_bar;
 import 'auth_callback_page/auth_callback_page_test.dart' as auth_callback_page;
 import 'blocked_partners_page/blocked_partners_page_test.dart'
     as blocked_partners_page;
@@ -20,12 +18,15 @@ import 'deletion_reason_page/deletion_reason_page_test.dart'
     as deletion_reason_page;
 import 'deletion_verify_page/deletion_verify_page_test.dart'
     as deletion_verify_page;
+import 'event_bottom_ticket_bar/event_bottom_ticket_bar_test.dart'
+    as event_bottom_ticket_bar;
 import 'event_now_bar/event_now_bar_test.dart' as event_now_bar;
 import 'event_ongoing_banner/event_ongoing_banner_test.dart'
     as event_ongoing_banner;
 import 'home_page/home_page_test.dart' as home_page;
 import 'login_page/login_page_test.dart' as login_page;
 import 'my_page/my_page_test.dart' as my_page;
+import 'my_tickets_page/my_tickets_page_test.dart' as my_tickets_page;
 import 'notification_list_screen/notification_list_screen_test.dart'
     as notification_list_screen;
 import 'notification_settings_screen/notification_settings_screen_test.dart'
@@ -51,6 +52,7 @@ final List<MdsCatalog<MdsScreenBuilder<dynamic>>> allCatalogs = [
   event_ongoing_banner.catalog,
   home_page.catalog,
   login_page.catalog,
+  my_tickets_page.catalog,
   my_page.catalog,
   notification_list_screen.catalog,
   notification_settings_screen.catalog,

--- a/apps/app_user/integration_test/mds-emulator-render/my_tickets_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/my_tickets_page/builder.dart
@@ -1,0 +1,92 @@
+// MyTicketsPageBuilder — my_tickets_page 전용 fluent API.
+
+import 'package:app_user/src/features/tickets/active_event_banners_provider.dart';
+import 'package:app_user/src/features/tickets/my_tickets_page.dart';
+import 'package:app_user/src/routing/app_coordinator.dart';
+import 'package:minglit_demo/minglit_demo.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+import '../_mocks/coordinators.dart';
+
+EventApplication _mockApplication({
+  required String id,
+  required String title,
+  required DateTime startTime,
+}) {
+  final event = Event(
+    id: 'event-$id',
+    partyId: 'party-$id',
+    title: title,
+    startTime: startTime,
+    endTime: startTime.add(const Duration(hours: 2)),
+    createdAt: DemoWorld.now,
+    updatedAt: DemoWorld.now,
+    currentParticipants: 24,
+  );
+
+  return EventApplication(
+    id: id,
+    eventId: event.id,
+    ticketId: 'ticket-$id',
+    userId: 'user-render-1',
+    status: 'approved',
+    createdAt: DemoWorld.now,
+    updatedAt: DemoWorld.now,
+    event: event,
+  );
+}
+
+class MyTicketsPageBuilder extends MdsScreenBuilder<MyTicketsPage> {
+  MyTicketsPageBuilder()
+    : super(
+        page: const MyTicketsPage(),
+        base: [
+          appCoordinatorProvider.overrideWithValue(MockAppCoordinator()),
+        ],
+      );
+
+  /// 기본 상태: 활성 이벤트 banner 2개.
+  MyTicketsPageBuilder withActiveBanners() {
+    final now = DemoWorld.now;
+    final items = <ActiveEventBannerItem>[
+      (
+        application: _mockApplication(
+          id: 'app-1',
+          title: '강남 밍릿파티',
+          startTime: now.add(const Duration(hours: 1)),
+        ),
+        phase: EventLifecyclePhase.checkInReady,
+      ),
+      (
+        application: _mockApplication(
+          id: 'app-2',
+          title: '홍대 밍글나잇',
+          startTime: now.add(const Duration(hours: 3)),
+        ),
+        phase: EventLifecyclePhase.waiting,
+      ),
+    ];
+    addOverride(
+      activeEventBannersProvider.overrideWith((_) async => items),
+    );
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  /// 활성 이벤트 없음 (empty state).
+  MyTicketsPageBuilder empty() {
+    addOverride(
+      activeEventBannersProvider.overrideWith((_) async => const []),
+    );
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  /// 다크 모드.
+  MyTicketsPageBuilder dark() {
+    useDarkTheme();
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+}

--- a/apps/app_user/integration_test/mds-emulator-render/my_tickets_page/my_tickets_page_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/my_tickets_page/my_tickets_page_test.dart
@@ -1,0 +1,32 @@
+// MDS screen: my_tickets_page
+// 대응 MDS: apps/mds/docs/public/specs/my_tickets_page/
+//
+// 출력: docs/infra/mds-emulator-render/my_tickets_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<MyTicketsPageBuilder>(
+  screen: 'my_tickets_page',
+  mdsSpec: 'apps/mds/docs/public/specs/my_tickets_page/',
+  builder: MyTicketsPageBuilder.new,
+  states: [
+    MdsState(
+      'state-active-banners',
+      (b) => b.withActiveBanners(),
+      mdsIndex: 1,
+    ),
+    MdsState('state-empty', (b) => b.empty(), mdsIndex: 2),
+    // 현재 구현에는 별도 auth guard UI가 없어 logged-out은 empty 표현으로 캡처.
+    MdsState(
+      'state-logged-out',
+      (b) => b.empty(),
+      mdsIndex: 3,
+    ),
+    MdsState('state-dark-empty', (b) => b.empty().dark()),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- Added `my_tickets_page` render catalog (`builder.dart`, `my_tickets_page_test.dart`) under app_user mds-emulator-render.
- Registered the new catalog in `_registry.dart` and added `MockAppCoordinator` for render-time coordinator override.
- Updated `apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md` screen table and Reviewed timestamp.

## Why
- Issue #2819 tracks uncovered MDS render screens. This PR removes `my_tickets_page` from uncovered catalogs and raises screen coverage (39.4% -> 40.9% in local script output).

## Verification
- `flutter analyze apps/app_user/integration_test/mds-emulator-render/my_tickets_page`
- `flutter analyze apps/app_user/integration_test/mds-emulator-render/my_tickets_page apps/app_user/integration_test/mds-emulator-render/_mocks/coordinators.dart apps/app_user/integration_test/mds-emulator-render/_registry.dart`
- `dart run scripts/mds_render_coverage.dart --json` (confirmed `my_tickets_page` removed from `uncovered_screens`)

## Issue linkage
- Refs #2819 (partial progress: one uncovered screen cataloged; remaining uncovered/incomplete screens are follow-up work).
