### PR TITLE
test(mds-render): add tag_event_list_page catalog

### DIFF
--- a/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
@@ -51,6 +51,7 @@ Phase 2 (TODO, follow-up PR) — `_manifest.yaml`, coverage report, scaffold 결
 | `event_now_bar` | waiting · check-in-ready · checked-in · matching · results · ended · offline |
 | `event_ongoing_banner` | 8 phases + dark |
 | `signup_consent_page` | loading · default · required-only · all · dark |
+| `tag_event_list_page` | default · empty · loading · error |
 | `ticket_qr_screen` | with-token · not-found · dark |
 
 ## 폴더 컨벤션
@@ -67,4 +68,4 @@ MDS spec 디렉토리명과 동일 (per-screen, snake_case). 화면당 `builder.
 - [상위 BLUEDOC](../BLUEDOC.md) · 페어 워크플로우: `sync-mds-mockups.yml` (디자인 PNG)
 
 ---
-_Reviewed: 2026-05-27 14:40_
+_Reviewed: 2026-05-27 18:06_

--- a/apps/app_user/integration_test/mds-emulator-render/_mocks/coordinators.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_mocks/coordinators.dart
@@ -3,6 +3,7 @@
 import 'package:app_user/src/features/home/logic/home_coordinator.dart';
 import 'package:app_user/src/features/search/logic/search_coordinator.dart';
 import 'package:app_user/src/logic/auth_coordinator.dart';
+import 'package:app_user/src/logic/event_coordinator.dart';
 import 'package:app_user/src/routing/app_coordinator.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -11,5 +12,7 @@ class MockHomeCoordinator extends Mock implements HomeCoordinator {}
 class MockAuthCoordinator extends Mock implements AuthCoordinator {}
 
 class MockSearchCoordinator extends Mock implements SearchCoordinator {}
+
+class MockEventCoordinator extends Mock implements EventCoordinator {}
 
 class MockAppCoordinator extends Mock implements AppCoordinator {}

--- a/apps/app_user/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_registry.dart
@@ -35,6 +35,8 @@ import 'privacy_page/privacy_page_test.dart' as privacy_page;
 import 'search_page/search_page_test.dart' as search_page;
 import 'signup_consent_page/signup_consent_page_test.dart'
     as signup_consent_page;
+import 'tag_event_list_page/tag_event_list_page_test.dart'
+    as tag_event_list_page;
 import 'ticket_qr_screen/ticket_qr_screen_test.dart' as ticket_qr_screen;
 
 /// 모든 cataloged 화면의 명시적 list. 새 화면 추가 시 본 list 에 추가.
@@ -59,5 +61,6 @@ final List<MdsCatalog<MdsScreenBuilder<dynamic>>> allCatalogs = [
   privacy_page.catalog,
   search_page.catalog,
   signup_consent_page.catalog,
+  tag_event_list_page.catalog,
   ticket_qr_screen.catalog,
 ];

--- a/apps/app_user/integration_test/mds-emulator-render/tag_event_list_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/tag_event_list_page/builder.dart
@@ -1,0 +1,122 @@
+// TagEventListPageBuilder — tag_event_list_page 전용 fluent API.
+
+import 'dart:async';
+
+import 'package:app_user/src/features/tag/logic/tag_event_list_controller.dart';
+import 'package:app_user/src/features/tag/ui/tag_event_list_page.dart';
+import 'package:app_user/src/logic/event_coordinator.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+import '../_mocks/coordinators.dart';
+
+class _FixedTagEventListController extends TagEventListController {
+  _FixedTagEventListController(this._state);
+  final TagEventListState _state;
+
+  @override
+  Future<TagEventListState> build(String tagId) async => _state;
+}
+
+class _LoadingTagEventListController extends TagEventListController {
+  @override
+  Future<TagEventListState> build(String tagId) =>
+      Completer<TagEventListState>().future;
+}
+
+class _ErrorTagEventListController extends TagEventListController {
+  @override
+  Future<TagEventListState> build(String tagId) async =>
+      throw Exception('render: forced error');
+}
+
+final _base = DateTime(2026, 5, 18, 18);
+const _tagId = 'tag-wine';
+
+Event _event({
+  required String id,
+  required String title,
+  required DateTime start,
+}) {
+  return Event(
+    id: id,
+    partyId: 'party-$id',
+    title: title,
+    startTime: start,
+    endTime: start.add(const Duration(hours: 2)),
+    createdAt: _base,
+    updatedAt: _base,
+  );
+}
+
+final _events = <Event>[
+  _event(
+    id: 'event-1',
+    title: '와인 소셜 나이트',
+    start: _base.add(const Duration(days: 1)),
+  ),
+  _event(
+    id: 'event-2',
+    title: '강남 밍글 라운지',
+    start: _base.add(const Duration(days: 2)),
+  ),
+  _event(
+    id: 'event-3',
+    title: '홍대 위켄드 믹서',
+    start: _base.add(const Duration(days: 3)),
+  ),
+];
+
+class TagEventListPageBuilder extends MdsScreenBuilder<TagEventListPage> {
+  TagEventListPageBuilder()
+    : super(
+        page: const TagEventListPage(tagId: _tagId, tagName: '와인'),
+        base: [
+          eventCoordinatorProvider.overrideWithValue(MockEventCoordinator()),
+        ],
+      );
+
+  /// 기본 상태: 이벤트 목록이 로드되어 카드가 렌더됨.
+  void withDefaultList() {
+    addOverride(
+      tagEventListControllerProvider(_tagId).overrideWith(
+        () => _FixedTagEventListController(
+          TagEventListState(
+            events: _events,
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// 빈 상태.
+  void withEmpty() {
+    addOverride(
+      tagEventListControllerProvider(_tagId).overrideWith(
+        () => _FixedTagEventListController(
+          const TagEventListState(
+            hasMore: false,
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// 로딩 상태.
+  void withLoading() {
+    addOverride(
+      tagEventListControllerProvider(_tagId).overrideWith(
+        _LoadingTagEventListController.new,
+      ),
+    );
+  }
+
+  /// 에러 상태.
+  void withError() {
+    addOverride(
+      tagEventListControllerProvider(_tagId).overrideWith(
+        _ErrorTagEventListController.new,
+      ),
+    );
+  }
+}

--- a/apps/app_user/integration_test/mds-emulator-render/tag_event_list_page/tag_event_list_page_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/tag_event_list_page/tag_event_list_page_test.dart
@@ -1,0 +1,52 @@
+// MDS screen: tag_event_list_page
+// 대응 MDS: apps/mds/docs/public/specs/tag_event_list_page/
+//
+// 출력: docs/infra/mds-emulator-render/tag_event_list_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<TagEventListPageBuilder>(
+  screen: 'tag_event_list_page',
+  mdsSpec: 'apps/mds/docs/public/specs/tag_event_list_page/',
+  builder: TagEventListPageBuilder.new,
+  states: [
+    MdsState(
+      'state-default',
+      (b) {
+        b.withDefaultList();
+        return b;
+      },
+      mdsIndex: 1,
+    ),
+    MdsState(
+      'state-empty',
+      (b) {
+        b.withEmpty();
+        return b;
+      },
+      mdsIndex: 2,
+    ),
+    MdsState(
+      'state-loading',
+      (b) {
+        b.withLoading();
+        return b;
+      },
+      mdsIndex: 3,
+      infiniteAnimation: true,
+    ),
+    MdsState(
+      'state-error',
+      (b) {
+        b.withError();
+        return b;
+      },
+      mdsIndex: 4,
+    ),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- Added a new MDS emulator render catalog for `tag_event_list_page` with deterministic `Default`, `Empty`, `Loading`, and `Error` states.
- Registered the catalog in `mds-emulator-render/_registry.dart`.
- Added `MockEventCoordinator` for render-only coordinator override.
- Updated `mds-emulator-render/BLUEDOC.md` registered-screen list and Reviewed timestamp.

## Why
- Issue #2819 tracks uncovered MDS render screens.
- `tag_event_list_page` was in `uncovered_screens`; this PR catalogs it so the screen is now covered.

## Verification
- `flutter analyze apps/app_user/integration_test/mds-emulator-render/tag_event_list_page`
- `dart run scripts/mds_render_coverage.dart --json` (confirmed `tag_event_list_page` is no longer in `uncovered_screens`)

## Risk
- This change only affects integration test render catalog code and does not modify runtime app behavior.

Refs #2819

Non-closing reason: partial coverage work for an umbrella tracker; remaining follow-up coverage in #2819.