### PR TITLE
test(mds-render): add partner_login_page catalog

### DIFF
--- a/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
@@ -26,6 +26,7 @@ flutter drive \
 | `create_verification_page` | empty · with-fields · dark |
 | `location_guide_page` | default · loading |
 | `more_page` | default · limited-permissions |
+| `partner_login_page` | default-ios · default-android · loading · auth-error |
 | `recurrence_management_screen` | active · paused · cancelled · no-rule · action-loading · loading · active-dark |
 | `verification_manage_page` | loading · active-empty · active-with-items · archived-with-items · dark |
 
@@ -58,6 +59,9 @@ mds-emulator-render/
 ├── more_page/
 │   ├── builder.dart
 │   └── more_page_test.dart
+├── partner_login_page/
+│   ├── builder.dart
+│   └── partner_login_page_test.dart
 ├── recurrence_management_screen/
 │   ├── builder.dart
 │   └── recurrence_management_screen_test.dart
@@ -71,4 +75,4 @@ mds-emulator-render/
 - [app_user mds-emulator-render](../../../app_user/integration_test/mds-emulator-render/BLUEDOC.md)
 - [architecture.md](../../../app_user/integration_test/mds-emulator-render/architecture.md)
 
-_Reviewed: 2026-05-26 17:12_
+_Reviewed: 2026-05-27 19:36_

--- a/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
@@ -11,6 +11,7 @@ import 'create_verification_page/create_verification_page_test.dart'
 import 'location_guide_page/location_guide_page_test.dart'
     as location_guide_page;
 import 'more_page/more_page_test.dart' as more_page;
+import 'partner_login_page/partner_login_page_test.dart' as partner_login_page;
 import 'recurrence_management_screen/recurrence_management_screen_test.dart'
     as recurrence_management_screen;
 import 'verification_manage_page/verification_manage_page_test.dart'
@@ -23,6 +24,7 @@ final List<Object> catalogs = [
   create_verification_page.catalog,
   location_guide_page.catalog,
   more_page.catalog,
+  partner_login_page.catalog,
   recurrence_management_screen.catalog,
   verification_manage_page.catalog,
 ];

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_login_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_login_page/builder.dart
@@ -1,0 +1,110 @@
+// PartnerLoginPageBuilder — partner_login_page 전용 fluent API.
+//
+// PartnerLoginPage 는 authControllerProvider 상태와 platform 분기(iOS/Android)에
+// 따라 버튼 구성이 달라진다. MDS render에서는 auth 동작을 no-op으로 고정하고
+// 상태별 UI만 deterministic 하게 재현한다.
+
+import 'dart:async';
+
+import 'package:app_partner/src/features/auth/partner_login_page.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+
+class _IdleAuthController extends AuthController {
+  @override
+  FutureOr<void> build() {}
+
+  @override
+  Future<void> signInWithGoogle({String? redirectTo}) async {}
+
+  @override
+  Future<void> signInWithApple({String? redirectTo}) async {}
+
+  @override
+  Future<void> signInWithKakao({String? redirectTo}) async {}
+}
+
+class _LoadingAuthController extends AuthController {
+  @override
+  Future<void> build() => Completer<void>().future;
+}
+
+class _ErrorAuthController extends AuthController {
+  @override
+  Future<void> build() async {
+    throw Exception('render: forced auth error');
+  }
+}
+
+class PartnerLoginPageBuilder extends MdsScreenBuilder<PartnerLoginPage> {
+  PartnerLoginPageBuilder() : super(page: const PartnerLoginPage());
+
+  bool _isDevEnv = false;
+  TargetPlatform _platform = TargetPlatform.iOS;
+  AuthController Function() _controllerFactory = _IdleAuthController.new;
+
+  /// iOS/macOS/Web 대응 상태: Apple 버튼 포함 baseline.
+  PartnerLoginPageBuilder iosDefault() {
+    _platform = TargetPlatform.iOS;
+    _controllerFactory = _IdleAuthController.new;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// Android 대응 상태: Apple 버튼 미노출.
+  PartnerLoginPageBuilder androidDefault() {
+    _platform = TargetPlatform.android;
+    _controllerFactory = _IdleAuthController.new;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// 인증 진행 중 전체 로딩 상태.
+  PartnerLoginPageBuilder loading() {
+    _platform = TargetPlatform.iOS;
+    _controllerFactory = _LoadingAuthController.new;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// 인증 에러 상태.
+  PartnerLoginPageBuilder error() {
+    _platform = TargetPlatform.iOS;
+    _controllerFactory = _ErrorAuthController.new;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  /// Dev trigger 노출 여부.
+  PartnerLoginPageBuilder devEnv({bool enabled = true}) {
+    _isDevEnv = enabled;
+    // ignore: avoid_returning_this, fluent builder — callers chain methods
+    return this;
+  }
+
+  @override
+  Widget build() {
+    // PartnerLoginPage 내부 Apple 노출 분기에서 읽는 platform 고정.
+    debugDefaultTargetPlatformOverride = _platform;
+
+    final controllerFactory = _controllerFactory;
+    final isDevEnv = _isDevEnv;
+
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => null),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+        authControllerProvider.overrideWith(controllerFactory),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: MinglitTheme.materialTheme,
+        home: PartnerLoginPage(isDevEnvOverride: isDevEnv),
+      ),
+    );
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_login_page/partner_login_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_login_page/partner_login_page_test.dart
@@ -1,0 +1,27 @@
+// MDS screen: partner_login_page (app_partner)
+// 대응 MDS: apps/mds/docs/public/specs/partner_login_page/
+//
+// 출력: docs/infra/mds-emulator-render/partner_login_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<PartnerLoginPageBuilder>(
+  screen: 'partner_login_page',
+  mdsSpec: 'apps/mds/docs/public/specs/partner_login_page/',
+  builder: PartnerLoginPageBuilder.new,
+  states: [
+    // Default iOS/macOS/Web variant — Apple 버튼 포함 baseline.
+    MdsState('state-default-ios', (b) => b.iosDefault(), mdsIndex: 1),
+    // Default Android variant — Apple 버튼 미노출.
+    MdsState('state-default-android', (b) => b.androidDefault(), mdsIndex: 2),
+    // Loading — OAuth 처리 중 스피너 노출.
+    MdsState('state-loading', (b) => b.loading(), mdsIndex: 3),
+    // Auth Error — 인증 실패 후 에러 처리 상태.
+    MdsState('state-auth-error', (b) => b.error(), mdsIndex: 4),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- `apps/app_partner/integration_test/mds-emulator-render/partner_login_page/` 카탈로그를 추가했습니다.
- `PartnerLoginPageBuilder`에 iOS 기본 / Android 기본 / loading / auth-error 상태를 추가해 spec state 4개를 매핑했습니다.
- `apps/app_partner/integration_test/mds-emulator-render/_registry.dart`에 등록하고 BLUEDOC 등록 화면/구조/Reviewed를 갱신했습니다.

## Why
- MDS render coverage 이슈(#2819)에서 `partner_login_page`가 uncovered screen으로 남아 있어 screen coverage를 높이기 위한 독립 슬라이스입니다.

## Verification
- `flutter analyze integration_test/mds-emulator-render/partner_login_page` (in `apps/app_partner`)
- `dart run scripts/mds_render_coverage.dart --json`
  - `cataloged_screens: 29`
  - `screen_coverage_pct: 43.9`
  - `uncovered_screens`에서 `partner_login_page` 제거 확인

## Risk
- `state-auth-error`는 provider error state를 강제로 만들어 에러 처리 경로를 렌더링합니다. 실제 디바이스 캡처에서 다이얼로그 타이밍 차이가 있을 수 있어 후속 캡처 결과를 확인해야 합니다.

Refs #2819
(aggregate coverage tracker 이슈라 단일 화면 슬라이스 완료만으로는 close하지 않음)