### PR TITLE
test(mds-render): add event_card catalog

### DIFF
--- a/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
@@ -41,6 +41,7 @@ Phase 2 (TODO, follow-up PR) — `_manifest.yaml`, coverage report, scaffold 결
 | `deletion_info_page` | no-reason · with-reason |
 | `deletion_reason_page` | initial · dark |
 | `deletion_verify_page` | email-user · social-user · dark |
+| `event_card` | normal · today · sold-out · ended |
 | `home_page` | default · guest · loading · feed-empty · error |
 | `login_page` | 기본 |
 | `my_tickets_page` | active-banners · empty · logged-out |
@@ -68,4 +69,4 @@ MDS spec 디렉토리명과 동일 (per-screen, snake_case). 화면당 `builder.
 - [상위 BLUEDOC](../BLUEDOC.md) · 페어 워크플로우: `sync-mds-mockups.yml` (디자인 PNG)
 
 ---
-_Reviewed: 2026-05-27 18:06_
+_Reviewed: 2026-05-27 21:05_

--- a/apps/app_user/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_registry.dart
@@ -18,6 +18,7 @@ import 'deletion_reason_page/deletion_reason_page_test.dart'
     as deletion_reason_page;
 import 'deletion_verify_page/deletion_verify_page_test.dart'
     as deletion_verify_page;
+import 'event_card/event_card_test.dart' as event_card;
 import 'event_bottom_ticket_bar/event_bottom_ticket_bar_test.dart'
     as event_bottom_ticket_bar;
 import 'event_now_bar/event_now_bar_test.dart' as event_now_bar;
@@ -49,6 +50,7 @@ final List<MdsCatalog<MdsScreenBuilder<dynamic>>> allCatalogs = [
   deletion_info_page.catalogWithReason,
   deletion_reason_page.catalog,
   deletion_verify_page.catalog,
+  event_card.catalog,
   event_bottom_ticket_bar.catalog,
   event_now_bar.catalog,
   event_ongoing_banner.catalog,

--- a/apps/app_user/integration_test/mds-emulator-render/event_card/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/event_card/builder.dart
@@ -53,8 +53,9 @@ final _EventCardRenderConfig _endedConfig = _EventCardRenderConfig(
   currentTime: _endedNow,
 );
 
-final _eventCardRenderConfigProvider =
-    Provider<_EventCardRenderConfig>((_) => _normalConfig);
+final _eventCardRenderConfigProvider = Provider<_EventCardRenderConfig>(
+  (_) => _normalConfig,
+);
 
 class _EventCardRenderPage extends ConsumerWidget {
   const _EventCardRenderPage();

--- a/apps/app_user/integration_test/mds-emulator-render/event_card/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/event_card/builder.dart
@@ -1,0 +1,103 @@
+// EventCardBuilder — event_card 전용 fluent API.
+//
+// MDS child spec(4 visible states: normal/today/soldOut/ended)를
+// deterministic fixture(demoEvents)로 재현한다.
+
+import 'package:flutter/material.dart';
+import 'package:minglit_demo/minglit_demo.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+
+final Event _baseEvent = demoEvents.first;
+
+class _EventCardRenderConfig {
+  const _EventCardRenderConfig({
+    required this.event,
+    required this.currentTime,
+  });
+
+  final Event event;
+  final DateTime currentTime;
+}
+
+final DateTime _normalNow = DemoWorld.now;
+
+final DateTime _todayNow = DateTime(
+  _baseEvent.startTime.year,
+  _baseEvent.startTime.month,
+  _baseEvent.startTime.day,
+  _baseEvent.startTime.hour,
+  _baseEvent.startTime.minute,
+);
+
+final DateTime _endedNow = _baseEvent.startTime.add(const Duration(days: 1));
+
+final _EventCardRenderConfig _normalConfig = _EventCardRenderConfig(
+  event: _baseEvent,
+  currentTime: _normalNow,
+);
+
+final _EventCardRenderConfig _todayConfig = _EventCardRenderConfig(
+  event: _baseEvent,
+  currentTime: _todayNow,
+);
+
+final _EventCardRenderConfig _soldOutConfig = _EventCardRenderConfig(
+  event: _baseEvent.copyWith(currentParticipants: _baseEvent.maxParticipants),
+  currentTime: _normalNow,
+);
+
+final _EventCardRenderConfig _endedConfig = _EventCardRenderConfig(
+  event: _baseEvent,
+  currentTime: _endedNow,
+);
+
+final _eventCardRenderConfigProvider =
+    Provider<_EventCardRenderConfig>((_) => _normalConfig);
+
+class _EventCardRenderPage extends ConsumerWidget {
+  const _EventCardRenderPage();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final config = ref.watch(_eventCardRenderConfigProvider);
+
+    return Scaffold(
+      body: Center(
+        child: SizedBox(
+          width: 343,
+          child: MinglitEventCard(
+            event: config.event,
+            currentTime: config.currentTime,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class EventCardBuilder extends MdsScreenBuilder<_EventCardRenderPage> {
+  EventCardBuilder() : super(page: const _EventCardRenderPage());
+
+  void _apply(_EventCardRenderConfig config) {
+    addOverride(
+      _eventCardRenderConfigProvider.overrideWith((_) => config),
+    );
+  }
+
+  /// 기본 상태: 미래 이벤트 + 수용 인원 여유.
+  void normal() => _apply(_normalConfig);
+
+  /// 당일 상태: D-Day label 이 "오늘"로 바뀌는 케이스.
+  void today() => _apply(_todayConfig);
+
+  /// 마감 상태: currentParticipants >= maxParticipants.
+  void soldOut() => _apply(_soldOutConfig);
+
+  /// 종료 상태: currentTime 이 startTime 이후.
+  void ended() => _apply(_endedConfig);
+
+  /// 다크 모드.
+  void dark() => useDarkTheme();
+}

--- a/apps/app_user/integration_test/mds-emulator-render/event_card/event_card_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/event_card/event_card_test.dart
@@ -1,0 +1,23 @@
+// MDS screen: event_card
+// 대응 MDS: apps/mds/docs/public/specs/event_card/
+//
+// 출력: docs/infra/mds-emulator-render/event_card/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<EventCardBuilder>(
+  screen: 'event_card',
+  mdsSpec: 'apps/mds/docs/public/specs/event_card/',
+  builder: EventCardBuilder.new,
+  states: [
+    MdsState('state-normal', (b) => b..normal(), mdsIndex: 1),
+    MdsState('state-today', (b) => b..today(), mdsIndex: 2),
+    MdsState('state-sold-out', (b) => b..soldOut(), mdsIndex: 3),
+    MdsState('state-ended', (b) => b..ended(), mdsIndex: 4),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- add `event_card` MDS emulator catalog under `apps/app_user/integration_test/mds-emulator-render/event_card/`
- implement deterministic builder states for `MinglitEventCard` (normal, today, sold-out, ended)
- register catalog in `_registry.dart` and update app_user mds-render BLUEDOC index/reviewed timestamp

## Why
- Refs #2819
- partial work for the monitoring backlog; this PR covers one screen slice and does **not close** the umbrella issue
- monitor issue still had `event_card` in `uncovered_screens`; this adds a self-contained screen slice to raise screen coverage

## Verification
- `flutter analyze apps/app_user/integration_test/mds-emulator-render/event_card`
- `dart run scripts/mds_render_coverage.dart --json` (confirmed `event_card` is removed from `uncovered_screens`, `cataloged_screens: 30`, `screen_coverage_pct: 45.5`)

## Residual Risk
- this PR adds catalog/test definitions only; PNG capture output remains 0 until emulator render workflow runs and assets are generated