### PR TITLE
ci: use version-bump PR build numbers

### DIFF
--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -34,7 +34,7 @@
 - `dev-staging-pr-gate`, `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 는 얇은 wrapper 로 시작한다. 내부에서는 `pr-gate.yml` reusable core 를 호출하고, wrapper job 이 최종 required check context 를 제공한다.
 - `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 는 `shared-pr-source-guard` 로 직접 PR 을 차단한다. 정상 진입점은 `dev-staging` 이고, 예외는 branch별 approved hotfix 뿐이다.
 - `monitor-dev-staging-health` 는 required check 가 아니다. 6시간마다 `dev-staging` HEAD 에서 EF unit/integration + user/partner CUJ 를 돌려 nightly 전에 회귀를 발견하고, 결과를 `dev-staging-health/*` commit status 로 남긴다.
-- `dev-staging-dev-cut-gate` 가 dev-staging 의 PR-number CalVer bump/tag 를 담당한다. `dev`/`rc`/`main` promotion 은 source-controlled version 변경 없이 처리한다.
+- `dev-staging-dev-cut-gate` 가 날짜 기반 dev-staging version-bump PR 을 만들고, 그 PR 번호를 mobile build number 로 사용한다. merge 후 `vYY.MM.DD+BUILD_PR-dev-staging` tag 를 생성한다. `dev`/`rc`/`main` promotion 은 source-controlled version 변경 없이 처리한다.
 - `dev-rc-cut-gate` 는 cut 직전 evaluator 다. 내부에서 `shared-soak-gate` 를 호출해 `dev-soak/*` status 와 `monitor-event-flow-distributed` candidate 이후 run history 를 확인하고, 통과한 commit 에만 `dev-rc-cut-pass` status 를 찍는다.
 - Release gate 는 true evidence 기반이다. required success status/run history/git lineage 가 없으면 `unknown` 이며, failure issue 가 없다는 이유만으로 `dev-rc-cut-pass` 또는 `rc-main-cut-pass` 를 쓰지 않는다.
 - `dev-rc-cut` 은 latest `dev-rc-cut-pass` dev commit 에서 `rc/YYYY-Wxx` branch 를 만들고 `promo/rc-*` tag 를 생성한다. RC branch 에 version bump commit 을 만들지 않는다.
@@ -53,7 +53,7 @@
 - deploy entry 는 후속 단계에서 `[branch]-deploy` 로 통일한다 (`dev-deploy`, `rc-deploy`, `main-deploy`). `monitor-event-flow-*` 는 deploy 가 아니라 지속 batch signal 이다.
 - `set-dev-soak-status` / `set-rc-soak-status` 는 workflow 와 AI agent 가 사용하는 공개 status write API 다. 내부에서는 `shared-set-commit-status` 를 호출한다.
 - protected branch/tag 에 직접 push 하는 workflow 는 `minglit-release-bot` GitHub App token 을 사용한다. App credential 은 `minglit_env/{stage}/github.env` 파일에서 먼저 읽고, 공통 token mint 는 `.github/actions/release-bot-token` 에서 처리한다.
-- `version-bump` 는 source-controlled version file 변경용 reusable 이며 현재 일반 promotion 중에서는 `dev-staging-dev-cut-gate` 만 사용한다. 앱 deploy version 은 `shared-version-metadata` 가 계산해 Android/iOS build command 에 주입한다.
+- `version-bump` 는 source-controlled version file 변경용 reusable 이며 현재 일반 promotion 중에서는 `dev-staging-dev-cut-gate` 의 version-bump PR 안에서만 사용한다. 앱 deploy version 은 `shared-version-metadata` 가 latest version-bump PR number 를 찾아 Android/iOS build command 에 주입한다.
 
 ## 컨벤션
 

--- a/.github/workflows/dev-pr-gate.yml
+++ b/.github/workflows/dev-pr-gate.yml
@@ -29,6 +29,7 @@ jobs:
     with:
       stage: dev
       base_ref: dev
+      run_cuj_integration: true
     secrets: inherit
 
   dev-pr-gate:

--- a/.github/workflows/dev-staging-dev-cut-gate.yml
+++ b/.github/workflows/dev-staging-dev-cut-gate.yml
@@ -5,9 +5,9 @@ on:
     branches: [dev-staging]
   workflow_dispatch:
     inputs:
-      pr_number:
-        description: PR number to use for the dev-staging CalVer revision.
-        required: true
+      snapshot_sha:
+        description: Optional dev-staging snapshot SHA to version. Defaults to the workflow ref.
+        required: false
         type: string
 
 concurrency:
@@ -19,75 +19,231 @@ permissions:
   pull-requests: write
 
 jobs:
-  calculate-version:
+  create-version-bump-pr:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      !startsWith(github.event.head_commit.message || '', 'chore: bump version')
+      (
+        !startsWith(github.event.head_commit.message || '', 'chore: bump version') &&
+        !startsWith(github.event.head_commit.message || '', 'chore(graphify): auto-update') &&
+        !contains(github.event.head_commit.message || '', '[skip ci]')
+      )
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.version.outputs.new }}
-      release_version: ${{ steps.version.outputs.base }}
-      tag_name: ${{ steps.version.outputs.tag }}
-      source_pr_number: ${{ steps.version.outputs.source_pr_number }}
-      source_pr_url: ${{ steps.version.outputs.source_pr_url }}
+      pr_number: ${{ steps.bump-pr.outputs.pr_number }}
+      version: ${{ steps.bump-pr.outputs.version }}
+      tag_name: ${{ steps.bump-pr.outputs.tag_name }}
 
     steps:
-      - name: Calculate dev-staging CalVer version
-        id: version
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.snapshot_sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Generate release bot token
+        id: release-bot
+        uses: ./.github/actions/release-bot-token
+        with:
+          fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
+          fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Create version bump PR
+        id: bump-pr
         env:
-          GH_TOKEN: ${{ github.token }}
-          MANUAL_PR_NUMBER: ${{ inputs.pr_number || '' }}
-          HEAD_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
+          RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
+          SNAPSHOT_SHA_INPUT: ${{ inputs.snapshot_sha || '' }}
           HEAD_MESSAGE: ${{ github.event.head_commit.message || '' }}
         run: |
           set -euo pipefail
 
-          if [ -n "${MANUAL_PR_NUMBER}" ]; then
-            PR_NUM="${MANUAL_PR_NUMBER}"
-          else
-            PR_NUM="$(gh api \
-              "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              --jq '.[0].number // empty')"
-
-            if [ -z "${PR_NUM}" ]; then
-              PR_NUM="$(printf '%s\n' "${HEAD_MESSAGE}" | sed -nE 's/.*\(#([0-9]+)\).*/\1/p' | head -n 1)"
-            fi
+          SNAPSHOT_SHA="$(git rev-parse HEAD)"
+          VERSION_DATE="$(TZ=Asia/Seoul date +%y.%m.%d)"
+          VERSION="${VERSION_DATE}-dev-staging"
+          RUN_DATE="$(TZ=Asia/Seoul date +%Y-%m-%d)"
+          SHORT_SHA="${SNAPSHOT_SHA:0:8}"
+          BRANCH_NAME="version-bump/dev-staging/${RUN_DATE}-${SHORT_SHA}"
+          if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" >/dev/null 2>&1; then
+            BRANCH_NAME="${BRANCH_NAME}-${GITHUB_RUN_ID}"
           fi
 
-          if ! [[ "${PR_NUM}" =~ ^[0-9]+$ ]]; then
-            echo "::error::Unable to determine merged PR number for dev-staging version bump."
+          SOURCE_PR_NUM="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/commits/${SNAPSHOT_SHA}/pulls" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              --jq '.[0].number // empty' || true)"
+
+          if [ -z "${SOURCE_PR_NUM}" ]; then
+            SOURCE_PR_NUM="$(printf '%s\n' "${HEAD_MESSAGE}" | sed -nE 's/.*\(#([0-9]+)\).*/\1/p' | head -n 1)"
+          fi
+
+          PREVIOUS_TAG="$(git for-each-ref \
+            --sort=-creatordate \
+            --format='%(refname:short)' \
+            'refs/tags/v*-dev-staging' | head -n 1)"
+
+          INCLUDED_PRS=""
+          if [ -n "${PREVIOUS_TAG}" ]; then
+            INCLUDED_PRS="$(git log --first-parent --format=%s "${PREVIOUS_TAG}..HEAD" \
+              | sed -nE 's/.*\(#([0-9]+)\).*/#\1/p' \
+              | sort -u \
+              | awk 'BEGIN { first = 1 } { if (!first) printf ", "; printf "%s", $0; first = 0 } END { if (!first) print "" }')"
+          fi
+          if [ -z "${INCLUDED_PRS}" ] && [[ "${SOURCE_PR_NUM}" =~ ^[0-9]+$ ]]; then
+            INCLUDED_PRS="#${SOURCE_PR_NUM}"
+          fi
+          if [ -z "${INCLUDED_PRS}" ]; then
+            INCLUDED_PRS="none detected"
+          fi
+
+          OPEN_PRS="$(gh pr list \
+            --base dev-staging \
+            --state open \
+            --json number,headRefName \
+            --jq '.[] | select(.headRefName | startswith("version-bump/dev-staging/")) | .number')"
+          for pr in ${OPEN_PRS}; do
+            echo "Closing stale version bump PR #${pr}"
+            gh pr close "${pr}" \
+              --comment "Superseded by snapshot ${SNAPSHOT_SHA}; dev-staging moved before this bump merged." \
+              --delete-branch || true
+          done
+
+          git config user.name "minglit-release-bot"
+          git config user.email "minglit-release-bot@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          # Create a temporary diff so GitHub can allocate the bump PR number.
+          bash scripts/bump-version.sh "${VERSION}" 1
+          git add -A
+          git commit -m "chore: prepare version bump for v${VERSION}"
+          git push origin "HEAD:refs/heads/${BRANCH_NAME}"
+
+          PR_BODY="$(cat <<EOF
+          Bumps dev-staging source version for the snapshot at \`${SNAPSHOT_SHA}\`.
+
+          - Version name: \`${VERSION}\`
+          - Build number: assigned from this version-bump PR number
+          - Snapshot SHA: \`${SNAPSHOT_SHA}\`
+          - Previous snapshot tag: \`${PREVIOUS_TAG:-none}\`
+          - Included PRs: ${INCLUDED_PRS}
+          - Source PR from triggering commit: ${SOURCE_PR_NUM:+#${SOURCE_PR_NUM}}
+
+          After this PR is created, the workflow amends this branch so Flutter build numbers equal this PR number.
+          EOF
+          )"
+
+          PR_URL="$(gh pr create \
+            --base dev-staging \
+            --head "${BRANCH_NAME}" \
+            --title "chore: bump version to v${VERSION}" \
+            --body "${PR_BODY}")"
+          PR_NUMBER="${PR_URL##*/}"
+          TAG_NAME="v${VERSION_DATE}+${PR_NUMBER}-dev-staging"
+
+          bash scripts/bump-version.sh "${VERSION}" "${PR_NUMBER}"
+          git add -A
+          git commit --amend -m "chore: bump version to ${TAG_NAME}"
+          git push --force-with-lease origin "HEAD:refs/heads/${BRANCH_NAME}"
+
+          UPDATED_BODY="$(cat <<EOF
+          Bumps dev-staging source version for the snapshot at \`${SNAPSHOT_SHA}\`.
+
+          - Version name: \`${VERSION}\`
+          - Build number: \`${PR_NUMBER}\` (this version-bump PR)
+          - Tag after merge: \`${TAG_NAME}\`
+          - Snapshot SHA: \`${SNAPSHOT_SHA}\`
+          - Previous snapshot tag: \`${PREVIOUS_TAG:-none}\`
+          - Included PRs: ${INCLUDED_PRS}
+          - Source PR from triggering commit: ${SOURCE_PR_NUM:+#${SOURCE_PR_NUM}}
+
+          The tag is created after this PR merges to \`dev-staging\`.
+          EOF
+          )"
+
+          gh pr edit "${PR_NUMBER}" \
+            --title "chore: bump version to ${TAG_NAME}" \
+            --body "${UPDATED_BODY}"
+          gh pr merge "${PR_NUMBER}" --auto --squash --delete-branch
+
+          {
+            echo "pr_number=${PR_NUMBER}"
+            echo "version=${VERSION}"
+            echo "tag_name=${TAG_NAME}"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## dev-staging version bump PR"
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| snapshot_sha | ${SNAPSHOT_SHA} |"
+            echo "| version | ${VERSION} |"
+            echo "| build_number | ${PR_NUMBER} |"
+            echo "| tag_name | ${TAG_NAME} |"
+            echo "| pr | #${PR_NUMBER} |"
+            echo "| included_prs | ${INCLUDED_PRS} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  tag-version-bump:
+    if: >-
+      github.event_name == 'push' &&
+      startsWith(github.event.head_commit.message || '', 'chore: bump version to v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Generate release bot token
+        id: release-bot
+        uses: ./.github/actions/release-bot-token
+        with:
+          fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
+          fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Tag merged version bump
+        env:
+          RELEASE_BOT_TOKEN: ${{ steps.release-bot.outputs.token }}
+          HEAD_MESSAGE: ${{ github.event.head_commit.message || '' }}
+        run: |
+          set -euo pipefail
+
+          VERSION="$(python3 - <<'PY'
+          import json
+          with open('package.json') as f:
+              print(json.load(f)['version'])
+          PY
+          )"
+          BUILD_NUMBER="$(printf '%s\n' "${HEAD_MESSAGE}" | sed -nE 's/.*\+#?([0-9]+)-dev-staging.*/\1/p' | head -n 1)"
+          if [ -z "${BUILD_NUMBER}" ]; then
+            BUILD_NUMBER="$(printf '%s\n' "${HEAD_MESSAGE}" | sed -nE 's/.*\(#([0-9]+)\).*/\1/p' | head -n 1)"
+          fi
+          if ! [[ "${BUILD_NUMBER}" =~ ^[0-9]+$ ]]; then
+            echo "::error::Unable to determine version-bump PR number from merge commit."
+            exit 1
+          fi
+          if [[ "${VERSION}" != *-dev-staging ]]; then
+            echo "::error::Expected package.json version to end with -dev-staging, got ${VERSION}."
             exit 1
           fi
 
-          NOW_YY="$(date -u +%y)"
-          NOW_MM="$(date -u +%m)"
-          BASE="${NOW_YY}.${NOW_MM}.${PR_NUM}"
-          NEW_VERSION="${BASE}-dev-staging"
-          TAG_NAME="v${NEW_VERSION}"
-          SOURCE_PR_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUM}"
+          BASE_VERSION="${VERSION%-dev-staging}"
+          TAG_NAME="v${BASE_VERSION}+${BUILD_NUMBER}-dev-staging"
 
-          echo "new=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "base=${BASE}" >> "$GITHUB_OUTPUT"
-          echo "tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
-          echo "source_pr_number=${PR_NUM}" >> "$GITHUB_OUTPUT"
-          echo "source_pr_url=${SOURCE_PR_URL}" >> "$GITHUB_OUTPUT"
-          echo "Bumping dev-staging to ${NEW_VERSION}"
+          git remote set-url origin "https://x-access-token:${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG_NAME}" >/dev/null 2>&1; then
+            echo "Tag ${TAG_NAME} already exists; skipping."
+            exit 0
+          fi
 
-  bump:
-    needs: [calculate-version]
-    uses: ./.github/workflows/version-bump.yml
-    with:
-      target_ref: dev-staging
-      version: ${{ needs.calculate-version.outputs.version }}
-      release_version: ${{ needs.calculate-version.outputs.release_version }}
-      tag_name: ${{ needs.calculate-version.outputs.tag_name }}
-      skip_ci: false
-    secrets: inherit
+          git tag "${TAG_NAME}" "${GITHUB_SHA}"
+          git push origin "refs/tags/${TAG_NAME}"
+          echo "Tagged ${GITHUB_SHA} as ${TAG_NAME}"
 
   notify-failure:
-    needs: [calculate-version, bump]
+    needs: [create-version-bump-pr, tag-version-bump]
     if: always()
     permissions:
       actions: read
@@ -99,10 +255,10 @@ jobs:
       failed: >-
         ${{
           (
-            (needs.calculate-version.result != 'success' && needs.calculate-version.result != 'skipped') ||
-            (needs.bump.result != 'success' && needs.bump.result != 'skipped')
+            (needs.create-version-bump-pr.result != 'success' && needs.create-version-bump-pr.result != 'skipped') ||
+            (needs.tag-version-bump.result != 'success' && needs.tag-version-bump.result != 'skipped')
           )
         }}
       workflow_name: 'Dev-Staging Dev Cut Gate'
       severity: 'P1-high'
-      job_results: '{"calculate-version":"${{ needs.calculate-version.result }}","bump":"${{ needs.bump.result }}"}'
+      job_results: '{"create-version-bump-pr":"${{ needs.create-version-bump-pr.result }}","tag-version-bump":"${{ needs.tag-version-bump.result }}"}'

--- a/.github/workflows/dev-staging-pr-gate.yml
+++ b/.github/workflows/dev-staging-pr-gate.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       stage: dev-staging
       base_ref: dev-staging
+      run_cuj_integration: false
     secrets: inherit
 
   dev-staging-pr-gate:

--- a/.github/workflows/main-pr-gate.yml
+++ b/.github/workflows/main-pr-gate.yml
@@ -31,6 +31,7 @@ jobs:
     with:
       stage: main
       base_ref: main
+      run_cuj_integration: true
     secrets: inherit
 
   validate-rc-promotion:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -395,6 +395,33 @@ jobs:
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' && (matrix.app == 'app_user' || matrix.app == 'app_partner') }}
         run: flutter test test/integration/
         working-directory: ${{ matrix.directory }}
+      - name: Golden Test (comparison)
+        id: golden_compare
+        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
+        continue-on-error: true
+        run: |
+          # Alchemist CI mode: compare against committed CI goldens (Ahem font).
+          # Exit 79 = no tests matched the tag.
+          set +e
+          flutter test --dart-define=CI=true --tags golden
+          rc=$?
+          set -e
+          if [ "$rc" -eq 79 ]; then exit 0; fi
+          exit "$rc"
+        working-directory: ${{ matrix.directory }}
+      - name: Upload golden failures
+        if: ${{ steps.golden_compare.outcome == 'failure' }}
+        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        with:
+          name: golden-failures-${{ matrix.app }}
+          path: ${{ matrix.directory }}/test/**/failures/
+          retention-days: 14
+      - name: Fail if golden comparison detected mismatch
+        if: ${{ steps.golden_compare.outcome == 'failure' }}
+        run: |
+          echo "Golden comparison step detected mismatches."
+          exit 1
       - name: Test Report
         uses: dorny/test-reporter@v3
         if: ${{ (success() || failure()) && needs.changes.outputs[matrix.change_key] == 'true' }}

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -395,33 +395,6 @@ jobs:
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' && (matrix.app == 'app_user' || matrix.app == 'app_partner') }}
         run: flutter test test/integration/
         working-directory: ${{ matrix.directory }}
-      - name: Golden Test (comparison)
-        id: golden_compare
-        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
-        continue-on-error: true
-        run: |
-          # Alchemist CI mode: compare against committed CI goldens (Ahem font).
-          # Exit 79 = no tests matched the tag.
-          set +e
-          flutter test --dart-define=CI=true --tags golden
-          rc=$?
-          set -e
-          if [ "$rc" -eq 79 ]; then exit 0; fi
-          exit "$rc"
-        working-directory: ${{ matrix.directory }}
-      - name: Upload golden failures
-        if: ${{ steps.golden_compare.outcome == 'failure' }}
-        uses: actions/upload-artifact@v7
-        continue-on-error: true
-        with:
-          name: golden-failures-${{ matrix.app }}
-          path: ${{ matrix.directory }}/test/**/failures/
-          retention-days: 14
-      - name: Fail if golden comparison detected mismatch
-        if: ${{ steps.golden_compare.outcome == 'failure' }}
-        run: |
-          echo "Golden comparison step detected mismatches."
-          exit 1
       - name: Test Report
         uses: dorny/test-reporter@v3
         if: ${{ (success() || failure()) && needs.changes.outputs[matrix.change_key] == 'true' }}

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: 'dev'
+      run_cuj_integration:
+        description: 'Run emulator CUJ integration jobs when app/kit paths changed'
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
   # Branch-specific wrappers own the user-facing required check name.
@@ -302,12 +307,12 @@ jobs:
 
   # App CI (User + Partner)
   test-flutter-apps:
-    name: test-app-unit-widget-golden
+    name: test-app-unit-widget-integration
     needs: changes
     if: ${{ needs.changes.outputs.app_user == 'true' || needs.changes.outputs.app_partner == 'true' || needs.changes.outputs.minglit_kit == 'true' || needs.changes.outputs.mds_core == 'true' }}
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       checks: write
     strategy:
       fail-fast: false
@@ -390,68 +395,6 @@ jobs:
         if: ${{ needs.changes.outputs[matrix.change_key] == 'true' && (matrix.app == 'app_user' || matrix.app == 'app_partner') }}
         run: flutter test test/integration/
         working-directory: ${{ matrix.directory }}
-      - name: Golden Test (comparison)
-        id: golden_compare
-        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
-        continue-on-error: true
-        run: |
-          # Alchemist CI mode: compare against committed CI goldens (Ahem font).
-          # Exit 79 = no tests matched the tag.
-          set +e
-          flutter test --dart-define=CI=true --tags golden
-          rc=$?
-          set -e
-          if [ "$rc" -eq 79 ]; then exit 0; fi
-          exit "$rc"
-        working-directory: ${{ matrix.directory }}
-      - name: Upload golden failures
-        if: ${{ steps.golden_compare.outcome == 'failure' }}
-        uses: actions/upload-artifact@v7
-        continue-on-error: true
-        with:
-          name: golden-failures-${{ matrix.app }}
-          path: ${{ matrix.directory }}/test/**/failures/
-          retention-days: 14
-      - name: Regenerate goldens
-        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' }}
-        run: |
-          set +e
-          flutter test --dart-define=CI=true --tags golden --update-goldens
-          rc=$?
-          set -e
-          if [ "$rc" -eq 79 ]; then exit 0; fi
-          exit "$rc"
-        working-directory: ${{ matrix.directory }}
-      - name: Auto-commit updated goldens
-        if: ${{ needs.changes.outputs[matrix.change_key] == 'true' && github.event_name == 'pull_request' }}
-        env:
-          PR_BRANCH: ${{ github.head_ref }}
-          # PAT injected only here, not during pub get/analyze/test above.
-          GH_PAT: ${{ secrets.GH_PAT_VERSION_BUMP }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          # || true: exit 128 when no goldens/ci/** files exist is not an error
-          git add '**/goldens/ci/**' 2>/dev/null || true
-          if git diff --cached --quiet; then
-            echo "No golden changes to commit"
-          else
-            git commit -m "chore(golden): update CI goldens on Linux runner [skip ci]"
-            git remote set-url origin "https://x-access-token:${GH_PAT}@github.com/${GITHUB_REPOSITORY}.git"
-            for i in 1 2 3; do
-              git pull --rebase origin "${PR_BRANCH}" 2>/dev/null || true
-              git push origin "HEAD:${PR_BRANCH}" && break
-              echo "Push attempt $i failed, retrying in 5s..."
-              sleep 5
-            done
-            git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          fi
-      - name: Fail if golden comparison detected mismatch
-        if: ${{ steps.golden_compare.outcome == 'failure' }}
-        run: |
-          echo "Golden comparison step detected mismatches."
-          echo "Updated goldens have been auto-committed for review."
-          exit 1
       - name: Test Report
         uses: dorny/test-reporter@v3
         if: ${{ (success() || failure()) && needs.changes.outputs[matrix.change_key] == 'true' }}
@@ -1105,7 +1048,7 @@ jobs:
   test-integration-app-user-cuj:
     name: cuj-integration-user
     needs: changes
-    if: needs.changes.outputs.app_user_or_kit == 'true'
+    if: inputs.run_cuj_integration && needs.changes.outputs.app_user_or_kit == 'true'
     uses: ./.github/workflows/shared-cuj-integration.yml
     with:
       app-name: user
@@ -1114,7 +1057,7 @@ jobs:
   test-integration-app-partner-cuj:
     name: cuj-integration-partner
     needs: changes
-    if: needs.changes.outputs.app_partner_or_kit == 'true'
+    if: inputs.run_cuj_integration && needs.changes.outputs.app_partner_or_kit == 'true'
     uses: ./.github/workflows/shared-cuj-integration.yml
     with:
       app-name: partner

--- a/.github/workflows/rc-pr-gate.yml
+++ b/.github/workflows/rc-pr-gate.yml
@@ -29,6 +29,7 @@ jobs:
     with:
       stage: rc
       base_ref: ${{ github.base_ref }}
+      run_cuj_integration: true
     secrets: inherit
 
   rc-pr-gate:

--- a/.github/workflows/shared-version-metadata.yml
+++ b/.github/workflows/shared-version-metadata.yml
@@ -28,7 +28,7 @@ on:
         description: GitHub Release title suffix.
         value: ${{ jobs.metadata.outputs.release_name }}
       pr_number:
-        description: Revision PR number.
+        description: Version-bump PR number used as the monotonic build number.
         value: ${{ jobs.metadata.outputs.pr_number }}
       source_sha:
         description: Resolved source SHA.
@@ -72,69 +72,70 @@ jobs:
           esac
 
           SOURCE_SHA="$(git rev-parse HEAD)"
-          PR_NUM=""
+          ROOT_VERSION="$(python3 - <<'PY'
+          import json
+          with open('package.json') as f:
+              print(json.load(f)['version'])
+          PY
+          )"
+          BASE_VERSION="${ROOT_VERSION%-dev-staging}"
+          BUMP_PR_NUM=""
           REVISION_SHA=""
 
           for sha in $(git rev-list --first-parent -n 80 HEAD); do
-            candidate="$(gh api \
-              "repos/${GITHUB_REPOSITORY}/commits/${sha}/pulls" \
-              -H "Accept: application/vnd.github+json" \
-              -H "X-GitHub-Api-Version: 2022-11-28" \
-              --jq '.[0].number // empty' || true)"
-
-            if [ -z "${candidate}" ]; then
-              candidate="$(git log -1 --format=%B "${sha}" | sed -nE 's/.*\(#([0-9]+)\).*/\1/p' | head -n 1)"
-            fi
+            message="$(git log -1 --format=%B "${sha}")"
+            candidate="$(printf '%s\n' "${message}" | sed -nE 's/.*chore: bump version to v[0-9]{2}\.[0-9]{2}\.[0-9]{2}\+([0-9]+)-dev-staging.*/\1/p' | head -n 1)"
 
             if [[ "${candidate}" =~ ^[0-9]+$ ]]; then
-              PR_NUM="${candidate}"
+              BUMP_PR_NUM="${candidate}"
               REVISION_SHA="${sha}"
               break
             fi
           done
 
-          if ! [[ "${PR_NUM}" =~ ^[0-9]+$ ]]; then
-            echo "::error::Unable to determine revision PR number for ${SOURCE_SHA} (${SOURCE_REF})."
+          # Backward compatibility for builds cut before version-bump PR numbers
+          # were embedded in the squash title.
+          if [ -z "${BUMP_PR_NUM}" ]; then
+            for sha in $(git rev-list --first-parent -n 80 HEAD); do
+              candidate="$(gh api \
+                "repos/${GITHUB_REPOSITORY}/commits/${sha}/pulls" \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                --jq '.[0].number // empty' || true)"
+
+              if [ -z "${candidate}" ]; then
+                candidate="$(git log -1 --format=%B "${sha}" | sed -nE 's/.*\(#([0-9]+)\).*/\1/p' | head -n 1)"
+              fi
+
+              if [[ "${candidate}" =~ ^[0-9]+$ ]]; then
+                BUMP_PR_NUM="${candidate}"
+                REVISION_SHA="${sha}"
+                break
+              fi
+            done
+          fi
+
+          if ! [[ "${BUMP_PR_NUM}" =~ ^[0-9]+$ ]]; then
+            echo "::error::Unable to determine version-bump PR number for ${SOURCE_SHA} (${SOURCE_REF})."
             exit 1
           fi
 
-          YEAR="$(date -u +%Y)"
-          MONTH="$(date -u +%-m)"
-          BASE_VERSION="${YEAR}.${MONTH}.${PR_NUM}"
           if [ "${CHANNEL}" = "main" ]; then
             VERSION_NAME="${BASE_VERSION}"
           else
             VERSION_NAME="${BASE_VERSION}-${CHANNEL}"
           fi
 
-          PR_NUMBER_INT=$((10#${PR_NUM}))
-          BUILD_NUMBER="${PR_NUM}"
-          BUILD_NUMBER_RULE="pr_number"
-          LEGACY_SEED=""
-
-          # Main channel keeps compatibility with legacy YYMM#### Android/iOS build numbers
-          # so first deploy after switching to PR-based naming cannot go backwards.
-          if [ "${CHANNEL}" = "main" ]; then
-            YY="$(date -u +%y)"
-            MM="$(date -u +%m)"
-            LEGACY_SEED=$((10#${YY} * 1000000 + 10#${MM} * 10000))
-            BUILD_NUMBER=$((LEGACY_SEED + PR_NUMBER_INT))
-            BUILD_NUMBER_RULE="legacy_compat_main_YYMM0000_plus_PR"
-
-            # Contract guard: main build number must stay above raw PR number.
-            if [ "${BUILD_NUMBER}" -le "${PR_NUMBER_INT}" ]; then
-              echo "::error::Main build_number must be monotonic and greater than PR number."
-              exit 1
-            fi
-          fi
+          BUILD_NUMBER="${BUMP_PR_NUM}"
+          BUILD_NUMBER_RULE="version_bump_pr_number"
 
           {
             echo "base_version=${BASE_VERSION}"
             echo "version_name=${VERSION_NAME}"
             echo "build_number=${BUILD_NUMBER}"
-            echo "release_tag=build-${CHANNEL}-v${VERSION_NAME}"
-            echo "release_name=${CHANNEL} v${VERSION_NAME}"
-            echo "pr_number=${PR_NUM}"
+            echo "release_tag=build-${CHANNEL}-v${VERSION_NAME}+${BUILD_NUMBER}"
+            echo "release_name=${CHANNEL} v${VERSION_NAME} (${BUILD_NUMBER})"
+            echo "pr_number=${BUMP_PR_NUM}"
             echo "source_sha=${SOURCE_SHA}"
           } >> "$GITHUB_OUTPUT"
 
@@ -147,12 +148,9 @@ jobs:
             echo "| source_ref | ${SOURCE_REF} |"
             echo "| source_sha | ${SOURCE_SHA} |"
             echo "| revision_sha | ${REVISION_SHA} |"
-            echo "| pr_number | ${PR_NUM} |"
+            echo "| version_bump_pr | #${BUMP_PR_NUM} |"
             echo "| base_version | ${BASE_VERSION} |"
             echo "| version_name | ${VERSION_NAME} |"
             echo "| build_number | ${BUILD_NUMBER} |"
             echo "| build_number_rule | ${BUILD_NUMBER_RULE} |"
-            if [ "${CHANNEL}" = "main" ]; then
-              echo "| legacy_seed | ${LEGACY_SEED} |"
-            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/shared-version-metadata.yml
+++ b/.github/workflows/shared-version-metadata.yml
@@ -120,14 +120,32 @@ jobs:
             exit 1
           fi
 
-          if [ "${CHANNEL}" = "main" ]; then
-            VERSION_NAME="${BASE_VERSION}"
-          else
-            VERSION_NAME="${BASE_VERSION}-${CHANNEL}"
+          PR_NUMBER_INT="${BUMP_PR_NUM}"
+          if ! [[ "${PR_NUMBER_INT}" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid version-bump PR number '${PR_NUMBER_INT}'."
+            exit 1
           fi
 
-          BUILD_NUMBER="${BUMP_PR_NUM}"
-          BUILD_NUMBER_RULE="version_bump_pr_number"
+          if [ "${CHANNEL}" = "main" ]; then
+            VERSION_NAME="${BASE_VERSION}"
+            YY="$(printf '%s' "${BASE_VERSION}" | cut -d. -f1)"
+            MM="$(printf '%s' "${BASE_VERSION}" | cut -d. -f2)"
+            if ! [[ "${YY}" =~ ^[0-9]{2}$ && "${MM}" =~ ^[0-9]{2}$ ]]; then
+              echo "::error::BASE_VERSION '${BASE_VERSION}' must start with YY.MM for main channel."
+              exit 1
+            fi
+            LEGACY_SEED=$((10#${YY} * 1000000 + 10#${MM} * 10000))
+            BUILD_NUMBER=$((LEGACY_SEED + PR_NUMBER_INT))
+            if [ "${BUILD_NUMBER}" -le "${PR_NUMBER_INT}" ]; then
+              echo "::error::Computed main build_number must exceed PR number (${PR_NUMBER_INT})."
+              exit 1
+            fi
+            BUILD_NUMBER_RULE="legacy_seed_plus_version_bump_pr"
+          else
+            VERSION_NAME="${BASE_VERSION}-${CHANNEL}"
+            BUILD_NUMBER="${PR_NUMBER_INT}"
+            BUILD_NUMBER_RULE="version_bump_pr_number"
+          fi
 
           {
             echo "base_version=${BASE_VERSION}"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -11,6 +11,11 @@ on:
         description: Full version passed to scripts/bump-version.sh.
         required: true
         type: string
+      build_number:
+        description: Optional Flutter/Android/iOS build number.
+        required: false
+        type: string
+        default: ''
       release_version:
         description: Release version without stage suffix, used for GitHub release tags.
         required: false
@@ -68,7 +73,7 @@ jobs:
           fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Run bump-version.sh
-        run: bash scripts/bump-version.sh "${{ inputs.version }}"
+        run: bash scripts/bump-version.sh "${{ inputs.version }}" "${{ inputs.build_number }}"
 
       - name: Commit and push version bump
         id: commit

--- a/apps/app_partner/BLUEDOC.md
+++ b/apps/app_partner/BLUEDOC.md
@@ -48,4 +48,4 @@ Minglit 의 **파트너 사장님 Flutter 앱**. 매장 관리·멤버 초대·�
 - [README.md](./README.md) — 빌드·실행 / [integration_test/cuj](./integration_test/cuj/BLUEDOC.md) — CUJ
 
 ---
-_Reviewed: 2026-05-24 16:30_
+_Reviewed: 2026-05-27 22:20_

--- a/apps/app_partner/README.md
+++ b/apps/app_partner/README.md
@@ -32,7 +32,6 @@ flutter build apk --flavor dev --release --dart-define-from-file=../../minglit_e
 flutter pub get
 flutter analyze --no-fatal-infos
 flutter test                       # unit + widget
-flutter test --tags golden         # golden
 flutter test test/integration/     # integration
 dart format .
 ```

--- a/apps/app_partner/dart_test.yaml
+++ b/apps/app_partner/dart_test.yaml
@@ -1,3 +1,0 @@
-tags:
-  golden:
-    description: "Golden (snapshot) tests — pixel comparison for visual regression."

--- a/apps/app_partner/integration_test/mds-emulator-render/_engine/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_engine/builder.dart
@@ -14,7 +14,7 @@ import 'package:minglit_kit/minglit_kit.dart';
 // Riverpod 3.x 의 `Override` 와 `ProviderListenable` 는 sealed class /
 // internal interface 로 public export 가 없어, 외부 코드가 직접 type 으로
 // 사용 불가. ProviderScope.overrides 가 받는 type 자체가 internal `Override`.
-// alchemist 의 GoldenPageWrapper 도 동일 우회 (List<dynamic>).
+// MDS emulator render builders use the same List<dynamic> boundary.
 // 런타임 동작은 strict type 과 동일 — cast 가 실패 시 즉시 throw.
 //
 // ⚠ 함정 — provider override 중복:

--- a/apps/app_partner/test/BLUEDOC.md
+++ b/apps/app_partner/test/BLUEDOC.md
@@ -1,6 +1,6 @@
 # app_partner/test — 테스트
 
-`app_partner` 의 unit · widget · integration · golden 테스트. `lib/src/` 구조를 그대로 미러링.
+`app_partner` 의 unit · widget · integration 테스트. `lib/src/` 구조를 그대로 미러링.
 
 ## 이정표
 
@@ -8,7 +8,6 @@
 |---|---|
 | [`src/`](./src/) | unit + widget 테스트 (lib/src/ 미러링) |
 | [`integration/`](./integration/) | Integration 테스트 (CI 의 `pr-gate.test-integration-app-partner-cuj` 실행) |
-| [`alchemist/`](./alchemist/) | Alchemist golden 설정·고정 골든 |
 | [`visual_qa/`](./visual_qa/) | 시각 QA 캡처 |
 | [`utils/`](./utils/) | 테스트 헬퍼 (mocks, utils, reporter integration) |
 | [`widget_test.dart`](./widget_test.dart) | 레거시 widget test |
@@ -19,7 +18,6 @@
 
 - **Unit/widget 테스트는 `src/<sub>/<feature>_test.dart` 패턴** — `lib/src/` 미러링.
 - **권한 분기 테스트는 router redirect 레벨에서** — feature 안에 권한 체크 없으므로 권한 시나리오는 [`integration_test/`](../integration_test/cuj/) 의 router context 로 검증.
-- **Golden 은 `--tags golden`** — Alchemist 가 처리.
 - **공용 mock/util 은 [`utils/`](./utils/)**.
 
 ## 실행
@@ -28,7 +26,6 @@
 flutter test                       # unit + widget
 flutter test test/src/features/member/   # 특정 feature
 flutter test --coverage             # 커버리지 → coverage/lcov.info
-flutter test --tags golden          # Alchemist golden
 ```
 
 CI 자동 실행: `pr-gate.test-flutter-apps` matrix. 커버리지 dev 자동 갱신: [`sync-test-coverage`](../../../.github/workflows/sync-test-coverage.yml) → [`tests/_coverage/app_partner/`](../../../tests/_coverage/app_partner/).

--- a/apps/app_user/BLUEDOC.md
+++ b/apps/app_user/BLUEDOC.md
@@ -48,4 +48,4 @@ Minglit 의 **일반 사용자 Flutter 앱**. 파티 탐색·참여 신청·결�
 - [README.md](./README.md) — 빌드·실행 / [integration_test](./integration_test/BLUEDOC.md) — 통합 테스트
 
 ---
-_Reviewed: 2026-05-24 16:30_
+_Reviewed: 2026-05-27 22:20_

--- a/apps/app_user/README.md
+++ b/apps/app_user/README.md
@@ -38,13 +38,12 @@ adb -s adb-R3CX803P2ND-8btuuD._adb-tls-connect._tcp install -r build/app/outputs
 flutter pub get
 flutter analyze --no-fatal-infos
 flutter test                                    # unit + widget
-flutter test --tags golden                      # golden (Alchemist)
 flutter test test/integration/                  # integration
 dart format .
 ```
 
 ## CI 에서 자동으로 도는 것
 
-- `pr-gate`: analyze + test + golden + gitleaks (required check)
+- `pr-gate`: analyze + test + gitleaks (required check)
 - `pr-setup-format`: PR push 마다 `dart fix --apply` + `dart format` 자동 적용 후 commit
 - 자세한 워크플로우는 [`.github/workflows/BLUEDOC.md`](../../.github/workflows/BLUEDOC.md)

--- a/apps/app_user/dart_test.yaml
+++ b/apps/app_user/dart_test.yaml
@@ -1,3 +1,0 @@
-tags:
-  golden:
-    description: "Golden (snapshot) tests — pixel comparison for visual regression."

--- a/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
@@ -4,7 +4,7 @@ MDS spec 의 각 화면을 실제 Flutter 앱으로 에뮬레이터에서 렌더
 
 ## 왜 있나
 
-이전 alchemist 골든 테스트가 실제 UI defect 를 못 잡았다 (블록 폰트, 실 viewport 부재, 실제 navigation 누락). 에뮬레이터 위 mock 주입 렌더링이 동일 결정성을 유지하면서 실 폰트·viewport·전환을 모두 잡는다.
+이전 위젯 단위 스냅샷 테스트가 실제 UI defect 를 못 잡았다 (블록 폰트, 실 viewport 부재, 실제 navigation 누락). 에뮬레이터 위 mock 주입 렌더링이 동일 결정성을 유지하면서 실 폰트·viewport·전환을 모두 잡는다.
 
 ## 트리거
 

--- a/apps/app_user/integration_test/mds-emulator-render/_engine/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_engine/builder.dart
@@ -15,7 +15,7 @@ import 'package:minglit_kit/minglit_kit.dart';
 // Riverpod 3.x 의 `Override` 와 `ProviderListenable` 는 sealed class /
 // internal interface 로 public export 가 없어, 외부 코드가 직접 type 으로
 // 사용 불가. ProviderScope.overrides 가 받는 type 자체가 internal `Override`.
-// alchemist 의 GoldenPageWrapper 도 동일 우회 (List<dynamic>).
+// MDS emulator render builders use the same List<dynamic> boundary.
 // 런타임 동작은 strict type 과 동일 — cast 가 실패 시 즉시 throw.
 //
 // ⚠ 함정 — provider override 중복:

--- a/apps/app_user/test/BLUEDOC.md
+++ b/apps/app_user/test/BLUEDOC.md
@@ -1,6 +1,6 @@
 # app_user/test — 테스트
 
-`app_user` 의 unit · widget · integration · golden 테스트. `lib/src/` 구조를 그대로 미러링.
+`app_user` 의 unit · widget · integration 테스트. `lib/src/` 구조를 그대로 미러링.
 
 ## 이정표
 
@@ -19,7 +19,6 @@
 
 - **Unit/widget 테스트는 `src/<sub>/<feature>_test.dart` 패턴** — `lib/src/` 의 구조 미러링.
 - **Integration 테스트는 `integration_test/` 사용** (CUJ 패턴) — `test/integration/` 은 일반 통합, `integration_test/cuj/` 는 emulator 기반 CUJ.
-- **Golden 테스트는 `--tags golden`** — Alchemist 가 처리, CI 에서 별도 step.
 - **공용 mock/util 은 [`utils/`](./utils/)** — feature 별로 흩뿌리지 않음.
 
 ## 실행
@@ -28,7 +27,6 @@
 flutter test                       # unit + widget (전체)
 flutter test test/src/features/auth/   # 특정 feature
 flutter test --coverage             # 커버리지 측정 → coverage/lcov.info
-flutter test --tags golden          # Alchemist golden
 ```
 
 CI 자동 실행은 `pr-gate.test-flutter-apps` (matrix). 커버리지 dev 자동 갱신은 [`sync-test-coverage`](../../../.github/workflows/sync-test-coverage.yml) → [`tests/_coverage/app_user/`](../../../tests/_coverage/app_user/).

--- a/docs/infra/branch-strategy/BLUEDOC.md
+++ b/docs/infra/branch-strategy/BLUEDOC.md
@@ -106,7 +106,7 @@ flowchart LR
 - Protected branch 직접 push 는 human 금지. dev-staging version bump, promotion branch/tag, RC cleanup 은 `minglit-release-bot` 전용 token + Ruleset bypass 로만 허용
 - `monitor-event-flow-*` 는 release promotion 과 독립적인 batch signal. target 은 dev 5분 distributed tick 이고, RC 에서는 main 배포 전 검증 signal 로 사용한다
 - main 머지 = backend + mobile 모두 prod deploy. backend prod deploy 는 `main-deploy` 에서 한 번에 수행한다
-- 소스 파일 version bump 는 `dev-staging-dev-cut-gate` 에만 남긴다. `dev`/`rc`/`main` 은 branch state 를 바꾸지 않고 deploy workflow 가 `YYYY.M.PR#[-channel]` metadata 를 build-time 에 주입한다
+- 소스 파일 version bump 는 `dev-staging-dev-cut-gate` 가 만든 version-bump PR 에만 남긴다. 날짜 버전(`YY.MM.DD`) + version-bump PR 번호 build number 를 사용하고, `dev`/`rc`/`main` 은 branch state 를 바꾸지 않고 deploy workflow 가 metadata 를 build-time 에 주입한다
 - `main-deploy` 는 prod deploy execution 을 담당한다. main push 에서 version bump commit 을 만들지 않고, release asset/tag/marker 는 deploy metadata 를 기준으로 생성한다
 - 모바일 배포 산출물(APK/AAB/IPA)은 GitHub Release asset 이 canonical archive 다. Actions artifact 는 테스트 리포트/스크린샷/로그 같은 단기 디버깅 산출물에만 사용한다
 - 일반 PR 은 `dev-staging` 으로만 진입한다. `dev`, `rc/*`, `main` 직접 PR 은 promotion 또는 승인된 hotfix 만 허용한다 ([hotfix-policy.md](./hotfix-policy.md))
@@ -119,7 +119,7 @@ Promotion PR 제목은 workflow 이름과 source artifact 를 앞에 둔다. PR 
 
 | 단계 | 제목 형식 |
 |------|-----------|
-| dev-staging → dev | `ci(dev-staging-dev-cut): promote v26.05.2722-dev-staging to dev` |
+| dev-staging → dev | `ci(dev-staging-dev-cut): promote v26.05.27+2832-dev-staging to dev` |
 | dev → rc | `ci(dev-rc-cut): cut rc/2026-W22 from <source>` |
 | rc → main | `ci(rc-main-cut): promote rc/2026-W22 to main` |
 | rc hotfix apply | `ci(rc-hotfix-apply): apply dev-staging fix #1234 to rc/2026-W22` |

--- a/docs/infra/branch-strategy/branch-flow.md
+++ b/docs/infra/branch-strategy/branch-flow.md
@@ -71,11 +71,11 @@ Hybrid linear history 금지 — 각 branch 내 일관 (squash or rebase 한 가
 
 | Tag / Status | 시점 | 예시 | 부여자 |
 |--------------|------|------|--------|
-| `v{ver}-dev-staging` (tag) | dev-staging-dev-cut-gate | `v26.05.2572-dev-staging` | workflow |
+| `v{ver}+{build}-dev-staging` (tag) | dev-staging-dev-cut-gate | `v26.05.27+2832-dev-staging` | workflow |
 | `dev-rc-cut-pass` (commit status) | dev-rc-cut-gate green 시 dev commit 에 | (status only, tag 없음) | workflow |
 | `promo/rc-YYYY-Wxx` (tag) | dev-rc-cut 직후 | `promo/rc-2026-W20` | workflow |
 | `promo/main-YYYY-Wxx` (tag) | main 머지 직후 | `promo/main-2026-W20` | workflow |
-| `build-{channel}-v{version}` (GitHub Release) | deploy artifact archive | `build-dev-v2026.5.2572-dev` | deploy workflow |
+| `build-{channel}-v{version}+{build}` (GitHub Release) | deploy artifact archive | `build-dev-v26.05.27-dev+2832` | deploy workflow |
 
 > **Tag naming regex 는 [`RELEASE.md`](../../../RELEASE.md) lock** (TODO). 외부 도구 (Sentry, Statsig, Vercel, App Store, Play Console) 가 pin → rename = 모든 dashboard 깨짐.
 
@@ -104,7 +104,7 @@ monitor-dev-staging-health:
 # 개념 — backend + mobile 모두 prod
 main-deploy (on push to main):
   steps:
-    - compute deploy-time version metadata: YYYY.M.PR#
+    - compute deploy-time version metadata: YY.MM.DD + version-bump PR build number
     - tag promo/main-Wxx + Sentry marker
     - Firebase RC `latest_version` = computed version 자동 update
   parallel:

--- a/docs/infra/branch-strategy/dev-pipeline.md
+++ b/docs/infra/branch-strategy/dev-pipeline.md
@@ -17,7 +17,7 @@
 - **manual**: `workflow_dispatch`
 - 동작:
   1. 가장 최근 `v*-dev-staging` 태그 (dev-staging 의 latest coherent snapshot) 찾기
-  2. PR 생성: `ci(dev-staging-dev-cut): promote v26.05.2722-dev-staging to dev` (base=dev, head=`cut/dev-staging-dev/YYYY-MM-DD-{sha8}` at that tag)
+  2. PR 생성: `ci(dev-staging-dev-cut): promote v26.05.27+2832-dev-staging to dev` (base=dev, head=`cut/dev-staging-dev/YYYY-MM-DD-{sha8}` at that tag)
   3. `dev-pr-gate` 자동 발동
   4. 통과 시 auto-merge (rebase — active `dev` ruleset 의 linear history 와 호환)
 

--- a/docs/infra/branch-strategy/dev-staging-pipeline.md
+++ b/docs/infra/branch-strategy/dev-staging-pipeline.md
@@ -1,11 +1,11 @@
 # Dev-Staging Pipeline
 
-AI agent 와 feature/fix/chore PR 이 `dev-staging` 브랜치로 들어오는 진입점. 일반 PR + auto-merge 로 처리하고, `dev-staging-pr-gate` 가 가벼운 검증, 머지 후 `dev-staging-dev-cut-gate` 가 release bot 권한으로 version bump.
+AI agent 와 feature/fix/chore PR 이 `dev-staging` 브랜치로 들어오는 진입점. 일반 PR + auto-merge 로 처리하고, `dev-staging-pr-gate` 가 가벼운 검증, 머지 후 `dev-staging-dev-cut-gate` 가 version-bump PR 을 생성한다.
 
 ## 두 가지 workflow
 
 1. **`dev-staging-pr-gate`** — PR 머지 전
-2. **`dev-staging-dev-cut-gate`** — PR 머지 직후 (version bump + tag)
+2. **`dev-staging-dev-cut-gate`** — PR 머지 직후 (version-bump PR 생성, merge 후 tag)
 
 ## PR + Auto-Merge
 
@@ -83,20 +83,22 @@ AI agent 와 feature/fix/chore PR 이 `dev-staging` 브랜치로 들어오는 �
 
 ## `dev-staging-dev-cut-gate`
 
-PR 머지 직후 자동 발동. 운영 복구용으로 `workflow_dispatch` 도 제공하며, 수동 실행 시 version 에 사용할 PR 번호를 입력한다.
+PR 머지 직후 자동 발동. 운영 복구용으로 `workflow_dispatch` 도 제공하며, 수동 실행 시 version 을 찍을 snapshot SHA 를 입력할 수 있다.
 
 ```
-1. `version-bump` reusable 호출: `bump-version.sh YY.MM.{PR번호}-dev-staging`
-2. git commit -m "chore: bump version to v{ver}-dev-staging"
-3. git tag v{ver}-dev-staging
-4. git push (tag + commit)
+1. KST 기준 날짜로 versionName 계산: `YY.MM.DD-dev-staging`
+2. 기존 open `version-bump/dev-staging/*` PR 이 있으면 stale 로 close
+3. 임시 version bump branch 생성 후 PR 생성
+4. 생성된 version-bump PR 번호를 build number 로 사용해 branch commit amend
+5. `dev-staging-pr-gate` 통과 시 auto-merge
+6. merge commit 에 tag `vYY.MM.DD+{version-bump PR#}-dev-staging` 생성
 ```
 
-`git push` 는 human 권한이 아니라 `minglit-release-bot` 전용 token 으로 실행한다. Ruleset bypass 는 이 bot actor 에만 부여하고, workflow permission 은 `contents: write` 및 tag/status 갱신에 필요한 최소 권한으로 제한한다.
+Protected `dev-staging` 에 직접 bump commit 을 push 하지 않는다. release bot 은 version-bump branch push, PR 생성/auto-merge, tag push 에만 사용한다.
 
-Tag `v{ver}-dev-staging` 는 다음 단계의 `dev-staging-dev-cut` workflow 가 query 해서 "가장 최근 dev-staging 의 coherent snapshot" 찾는 데 사용.
+Tag `vYY.MM.DD+{build}-dev-staging` 는 다음 단계의 `dev-staging-dev-cut` workflow 가 query 해서 "가장 최근 dev-staging 의 coherent snapshot" 찾는 데 사용.
 
-> **구현 결정**: bump 커밋은 PR squash commit 과 분리한다. release bot 전용 커밋으로 남겨 branch/tag write 권한과 human PR 변경을 분리한다. `[skip ci]` 는 쓰지 않는다. nightly PR 의 HEAD 가 이 bump 커밋이므로 `[skip ci]` 를 넣으면 required check 가 생성되지 않는다. 루프 방지는 `dev-staging-dev-cut-gate` 의 commit message guard 로 처리한다.
+> **구현 결정**: source PR 번호는 build number 로 쓰지 않는다. GitHub PR 번호는 생성 순서라 merge 순서를 보장하지 않기 때문이다. version-bump PR 번호만 build number 로 사용한다.
 
 ## Error-Backoff
 

--- a/docs/infra/branch-strategy/rc-promotion.md
+++ b/docs/infra/branch-strategy/rc-promotion.md
@@ -54,7 +54,7 @@ Hotfix PR 머지 직후에는 RC branch 에 version bump commit 을 추가하지
 4. 새 RC HEAD 기준으로 5일 soak clock 이 다시 시작
 ```
 
-RC artifact version 은 `shared-version-metadata(channel=rc)` 가 latest RC HEAD 의 PR 번호로 계산한다.
+RC artifact version 은 `shared-version-metadata(channel=rc)` 가 latest RC HEAD 의 version-bump PR 번호로 계산한다.
 
 ## `rc-deploy`
 
@@ -98,7 +98,7 @@ Mark 님 직감대로 hotfix loop 으로 RC lifecycle 이 길어지는 게 일�
 | 검증 | 도구 |
 |------|------|
 | 누적 회귀 | rc 의 nightly 재실행 (선택 — RC 별도 nightly schedule TBD) |
-| 내부 dogfooding | 내부 직원 cohort 가 `YYYY.M.PR#-rc` 빌드 사용 |
+| 내부 dogfooding | 내부 직원 cohort 가 `YY.MM.DD-rc+BUILD_PR#` 빌드 사용 |
 | Real-data 이슈 | RC 전용 Supabase branch (`rc-YYYY-Wxx`) |
 | 외부 의존성 동작 (실 결제, 실 메시지) | 내부 사용자가 실제로 사용해보며 검증 |
 

--- a/docs/infra/branch-strategy/specs/branch-spec.md
+++ b/docs/infra/branch-strategy/specs/branch-spec.md
@@ -134,7 +134,7 @@ Rulesets 의 장점 (legacy 대비):
 
 | Tag pattern | 보호 |
 |-------------|------|
-| `v*` (예: `v26.05.2572`, `v26.05.2572-rc-01`) | 삭제 금지, force-push 금지 |
+| `v*` (예: `v26.05.27+2832-dev-staging`) | 삭제 금지, force-push 금지 |
 | `promo/**` (예: `promo/main-2026-W20`) | 삭제 금지, force-push 금지 |
 | `mobile-released/**` (있다면) | 삭제 금지 |
 

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -32,14 +32,14 @@
 
 ### `version-bump`
 
-`bump-version.sh` 실행 + commit + tag.
+`bump-version.sh` 실행 + commit. dev-staging 에서는 direct push 하지 않고 version-bump PR 안에서 사용한다.
 
 | 항목 | 값 |
 |------|----|
 | Trigger | `workflow_call` |
-| Inputs | `version`: YY.MM.PR# / `suffix`: `-dev-staging` / `commit_message`: string |
+| Inputs | `version`: YY.MM.DD[-stage], optional `build_number`: version-bump PR number |
 | Outputs | `commit_sha`, `tag_name` |
-| 핵심 steps | `bash scripts/bump-version.sh {version}{suffix}` · commit (`skip_ci` option) · `git tag v{version}{suffix}` · push |
+| 핵심 steps | `bash scripts/bump-version.sh {version} {build_number}` · commit |
 | Called by | `dev-staging-dev-cut-gate` |
 
 `dev`/`rc`/`main` promotion 은 version bump commit 을 만들지 않는다. 앱/스토어/릴리즈 에셋에 노출되는 version 은 deploy workflow 가 `shared-version-metadata` 로 계산해 build command 에 주입한다.
@@ -53,10 +53,10 @@ Deploy artifact version metadata 를 계산하는 reusable workflow.
 | Trigger | `workflow_call` |
 | Inputs | `channel`: dev\|rc\|main, `source-ref`: ref/SHA |
 | Outputs | `base_version`, `version_name`, `build_number`, `release_tag`, `release_name`, `pr_number`, `source_sha` |
-| 규칙 | `version_name = YYYY.M.PR#[-channel]`, `build_number = PR#` |
+| 규칙 | `version_name = YY.MM.DD[-channel]`, `build_number = version-bump PR number` |
 | Called by | `shared-android-deploy`, `shared-ios-deploy`, 후속 `rc-deploy` |
 
-source-ref HEAD 가 graphify/coverage 같은 자동 commit 이면 first-parent history 를 거슬러 실제 PR 번호를 찾는다.
+source-ref 의 first-parent history 에서 latest version-bump squash commit 을 찾고, commit title/tag 에 포함된 version-bump PR number 를 build number 로 사용한다. source PR 번호는 release note/trace metadata 로만 사용한다.
 
 ### `shared-set-commit-status`
 
@@ -167,8 +167,8 @@ Cross-branch cherry-pick PR 자동 생성.
 |------|----|
 | Trigger | `push` to `dev-staging` (PR squash merge 후) |
 | Inputs | (from event) PR number, merged SHA |
-| Outputs | tag `v{YY.MM.PR#}-dev-staging` |
-| Steps | calls `version-bump` (suffix=`-dev-staging`, version=`{YY.MM.PR#}`) using release bot GitHub App token |
+| Outputs | version-bump PR + tag `v{YY.MM.DD}+{BUILD_PR#}-dev-staging` after merge |
+| Steps | (1) skip generated bump/graphify commits (2) close stale open `version-bump/dev-staging/*` PRs (3) create version-bump PR from current snapshot (4) amend bump commit so Flutter build number equals that PR number (5) enable auto-merge (6) on bump PR merge, create dev-staging snapshot tag |
 
 `dev-staging-dev-cut-gate` 는 dev-staging merge 마다 실행되므로 cut tracking issue 를 만들지 않는다. 하루 1회 실제 promotion 을 만드는 `dev-staging-dev-cut` 이 tracking issue 를 `status/promoting` 으로 생성/갱신한다.
 
@@ -246,7 +246,7 @@ Cross-branch cherry-pick PR 자동 생성.
 
 #### RC hotfix post-merge behavior
 
-RC branch 에 version bump commit/tag 를 만들던 이전 설계. 최신 정책에서는 RC hotfix merge 후에도 branch state 를 바꾸지 않는다. RC deploy artifact version 은 `shared-version-metadata(channel=rc)` 가 source commit 의 PR 번호로 계산한다.
+RC branch 에 version bump commit/tag 를 만들던 이전 설계. 최신 정책에서는 RC hotfix merge 후에도 branch state 를 바꾸지 않는다. RC deploy artifact version 은 `shared-version-metadata(channel=rc)` 가 latest version-bump PR number 로 계산한다.
 
 #### `rc-deploy`
 
@@ -321,7 +321,7 @@ RC branch 에 version bump commit/tag 를 만들던 이전 설계. 최신 정책
 [dev-staging-pr-gate] ──auto-merge──▶ dev-staging push
                                                 ↓
                                          [dev-staging-dev-cut-gate]
-                                                ↓ tag v{ver}-dev-staging
+                                                ↓ tag v{YY.MM.DD}+{BUILD_PR#}-dev-staging
 
 [daily KST 02:00]
     ↓

--- a/docs/infra/branch-strategy/versioning.md
+++ b/docs/infra/branch-strategy/versioning.md
@@ -6,43 +6,45 @@
 
 | 구성요소 | 설명 | 예시 |
 |----------|------|------|
-| `YYYY` | 연도 4자리 | `2026` |
-| `M` | 월 번호 | `5` |
-| `PR#` | 머지된 PR 번호 (cumulative across repo) | `2572` |
+| `YY` | 연도 2자리 | `26` |
+| `MM` | 월 2자리 | `05` |
+| `DD` | KST 기준 snapshot 날짜 | `27` |
+| `BUILD_PR#` | version-bump PR 번호 | `2832` |
 
-- deploy artifact versionName: `YYYY.M.PR#[-channel]` — 예: `2026.5.2572-dev`, `2026.5.2572-rc`, `2026.5.2572`
-- mobile build number / Android versionCode: `PR#` — 예: `2572`
+- deploy artifact versionName: `YY.MM.DD[-channel]` — 예: `26.05.27-dev`, `26.05.27-rc`, `26.05.27`
+- mobile build number / Android versionCode: `BUILD_PR#` — 예: `2832`
+- full identity/tag: `vYY.MM.DD+BUILD_PR#[-channel]` — 예: `v26.05.27+2832-dev-staging`
 
-> Store 에 이미 더 높은 Android versionCode 가 올라간 경우 PR# 단독 versionCode 는 migration rule 이 필요하다. 신규 업로드 전 Play Console 의 latest versionCode 를 확인한다.
+`BUILD_PR#` 는 source PR 번호가 아니라 **version-bump PR 번호**다. GitHub source PR 번호는 생성 순서라 merge 순서를 보장하지 않으므로 build number 로 쓰지 않는다.
 
 ## 단계별 채널 suffix
 
 | Stage | Suffix | 예시 |
 |-------|--------|------|
-| dev-staging source snapshot | `-dev-staging` | `26.05.2572-dev-staging` (source file only) |
-| dev artifact | `-dev` | `2026.5.2572-dev` |
-| rc artifact | `-rc` | `2026.5.2572-rc` |
-| main artifact | 없음 | `2026.5.2572` |
+| dev-staging source snapshot | `-dev-staging` | `26.05.27-dev-staging+2832` (Flutter), `26.05.27-dev-staging` (packages) |
+| dev artifact | `-dev` | `26.05.27-dev+2832` |
+| rc artifact | `-rc` | `26.05.27-rc+2832` |
+| main artifact | 없음 | `26.05.27+2832` |
 
-**원칙**: PR# 은 실제 source revision 을 설명하는 값이다. `dev`/`rc`/`main` branch 에는 version bump commit 을 만들지 않고, deploy workflow 가 source commit 에서 PR# 를 역추적해 build metadata 로 주입한다.
+**원칙**: 날짜는 snapshot 을 설명하고, build number 는 version-bump PR 을 설명한다. 포함된 source PR 목록과 snapshot SHA 는 version-bump PR body/tag 로 추적한다.
 
 ## Version Bump 위치
 
 | Workflow | When | What |
 |----------|------|------|
-| `dev-staging-dev-cut-gate` | dev-staging PR 머지 직후 | `bump-version.sh {YY.MM.PR#}-dev-staging` + `v{YY.MM.PR#}-dev-staging` tag |
+| `dev-staging-dev-cut-gate` | dev-staging PR 머지 직후 | version-bump PR 생성. PR 번호를 build number 로 사용하고 merge 후 `v{YY.MM.DD}+{BUILD_PR#}-dev-staging` tag |
 | `dev-staging-dev-cut` | daily snapshot 생성 시 | version 변경 없음 |
 | `dev-rc-cut` | RC 브랜치 생성 시 | version 변경 없음. `rc/YYYY-Wxx` branch + `promo/rc-YYYY-Wxx` tag 만 생성 |
-| RC hotfix merge | RC hotfix 머지 직후 | version 변경 없음. RC deploy metadata 가 최신 PR# 를 사용 |
+| RC hotfix merge | RC hotfix 머지 직후 | version 변경 없음. RC deploy metadata 가 latest version-bump PR number 를 사용 |
 | `main-deploy` | main push 직후 | version 변경 없음. deploy-time metadata + release asset/tag/marker 생성 |
 
-`version-bump` reusable 은 현재 `dev-staging-dev-cut-gate` 전용으로 남긴다. `dev`/`rc`/`main` 에 자동 version commit 을 만들지 않는다.
+`dev-staging-dev-cut-gate` 는 protected branch 에 직접 bump commit 을 push 하지 않는다. version-bump PR 을 만들고 `dev-staging-pr-gate` + auto-merge 를 통과시킨다. `dev`/`rc`/`main` 에 자동 version commit 을 만들지 않는다.
 
 ## Tag 컨벤션
 
 | Tag / Status | 시점 | 예시 | 부여자 |
 |--------------|------|------|--------|
-| `v{ver}-dev-staging` (tag) | dev-staging post-merge | `v26.05.2572-dev-staging` | workflow |
+| `v{ver}+{build}-dev-staging` (tag) | version-bump PR merge 후 | `v26.05.27+2832-dev-staging` | workflow |
 | `dev-rc-cut-pass` (commit status) | dev 머지 후 dev-rc-cut-gate green | (status only, tag 없음) | workflow |
 | `promo/rc-YYYY-Wxx` (tag) | dev-rc-cut 직후 | `promo/rc-2026-W20` | workflow |
 | `promo/main-YYYY-Wxx` (tag) | main 머지 직후 (동시) | `promo/main-2026-W20` | workflow |
@@ -57,16 +59,16 @@
 - `git log --first-parent main` (main 의 promotion 이벤트, rebase 라 사실상 linear)
 - `gh api repos/.../commits/{sha}/status` (dev-rc-cut-pass 확인)
 
-## 동일 PR# 가 여러 단계 등장하는 의미
+## 동일 build number 가 여러 단계 등장하는 의미
 
 | 상태 | 의미 |
 |------|------|
-| `26.05.2572-dev-staging` | dev-staging source snapshot version/tag |
-| `2026.5.2572-dev` | dev branch deploy artifact version |
-| `2026.5.2572-rc` | rc branch deploy artifact version |
-| `2026.5.2572` | main branch deploy artifact version |
+| `26.05.27-dev-staging+2832` | dev-staging source snapshot version/tag |
+| `26.05.27-dev+2832` | dev branch deploy artifact version |
+| `26.05.27-rc+2832` | rc branch deploy artifact version |
+| `26.05.27+2832` | main branch deploy artifact version |
 
-source-controlled `26.05.*-dev-staging` 과 deploy artifact `2026.5.*` 는 목적이 다르다. 전자는 coherent snapshot marker, 후자는 사용자/스토어/릴리즈 에셋에 노출되는 build metadata 다.
+source-controlled `26.05.DD-dev-staging` 과 deploy artifact `26.05.DD[-channel]` 는 같은 snapshot date 를 공유한다. build number 는 version-bump PR number 로 고정된다.
 
 ## 버전 관리 제외 대상 (기존 유지)
 
@@ -76,9 +78,8 @@ source-controlled `26.05.*-dev-staging` 과 deploy artifact `2026.5.*` 는 목�
 
 ## 결정해야 할 것
 
-- mobile release branch hotfix 의 PR# 출처 (cherry-pick PR# 인가 새 PR# 인가)
 - `RELEASE.md` 작성 (tag regex single source)
-- Android Play Console 기존 versionCode 가 PR# 단독 값보다 큰 경우 migration rule
+- Android Play Console 기존 versionCode 가 version-bump PR number 보다 큰 경우 migration rule
 
 ## 관련
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # bump-version.sh - Update version across all project files
-# Usage: bash scripts/bump-version.sh <version>
+# Usage: bash scripts/bump-version.sh <version> [build_number]
 # Examples:
 #   bash scripts/bump-version.sh 26.03.1
 #   bash scripts/bump-version.sh 26.03.1-dev
@@ -17,9 +17,9 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 # Validate input
-if [ $# -ne 1 ]; then
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
     echo -e "${RED}Error: Missing version argument${NC}"
-    echo "Usage: bash scripts/bump-version.sh <version>"
+    echo "Usage: bash scripts/bump-version.sh <version> [build_number]"
     echo "Examples:"
     echo "  bash scripts/bump-version.sh 26.03.1"
     echo "  bash scripts/bump-version.sh 26.03.1-dev"
@@ -29,28 +29,29 @@ if [ $# -ne 1 ]; then
 fi
 
 VERSION_INPUT="$1"
+BUILD_NUMBER_INPUT="${2:-}"
 
-# Regex validation: YY.MM.PR#[-stage]
-# Format: 26.03.1, 26.03.1-dev, 26.03.1-dev-staging, or 26.03.1-rc-01
+# Regex validation: YY.MM.REVISION[-stage]
+# Format: 26.03.1, 26.03.27-dev, 26.03.27-dev-staging, or 26.03.27-rc-01
 # Month must be 01-12
 if ! [[ "$VERSION_INPUT" =~ ^[0-9]{2}\.(0[1-9]|1[0-2])\.[0-9]+(-(dev|dev-staging|rc-[0-9]{2}))?$ ]]; then
     echo -e "${RED}Error: Invalid version format: $VERSION_INPUT${NC}"
-    echo "Expected format: YY.MM.PR#, YY.MM.PR#-dev, YY.MM.PR#-dev-staging, or YY.MM.PR#-rc-NN"
+    echo "Expected format: YY.MM.REVISION, YY.MM.REVISION-dev, YY.MM.REVISION-dev-staging, or YY.MM.REVISION-rc-NN"
     echo "Examples: 26.03.1, 26.03.1-dev, 26.03.1-dev-staging, 26.03.1-rc-01, 26.12.99"
     exit 1
 fi
 
-# Extract YY, MM, PR# from version
+# Extract YY, MM, revision from version
 YY=$(echo "$VERSION_INPUT" | cut -d. -f1)
 MM=$(echo "$VERSION_INPUT" | cut -d. -f2)
 PR_AND_SUFFIX=$(echo "$VERSION_INPUT" | cut -d. -f3)
 
-# Extract PR# (remove stage suffix if present)
+# Extract revision (remove stage suffix if present)
 PR=$(echo "$PR_AND_SUFFIX" | sed -E 's/-(dev|dev-staging|rc-[0-9]{2})$//')
 
-# Validate PR# (must be >= 1)
+# Validate revision (must be >= 1)
 if [ "$((10#$PR))" -lt 1 ]; then
-    echo -e "${RED}Error: Invalid PR#: $PR (must be >= 1)${NC}"
+    echo -e "${RED}Error: Invalid revision: $PR (must be >= 1)${NC}"
     exit 1
 fi
 
@@ -65,14 +66,23 @@ if [ "$MM_DEC" -lt 1 ] || [ "$MM_DEC" -gt 12 ]; then
     exit 1
 fi
 
-# Calculate versionCode: YYMM * 10000 + PR#
-VERSION_CODE=$(( (YY_DEC * 100 + MM_DEC) * 10000 + PR_DEC ))
+# Calculate versionCode. New release automation passes the version-bump PR
+# number explicitly so mobile build numbers stay monotonic by bump PR order.
+if [ -n "$BUILD_NUMBER_INPUT" ]; then
+    if ! [[ "$BUILD_NUMBER_INPUT" =~ ^[0-9]+$ ]] || [ "$((10#$BUILD_NUMBER_INPUT))" -lt 1 ]; then
+        echo -e "${RED}Error: Invalid build_number: $BUILD_NUMBER_INPUT (must be >= 1)${NC}"
+        exit 1
+    fi
+    VERSION_CODE=$((10#$BUILD_NUMBER_INPUT))
+else
+    VERSION_CODE=$(( (YY_DEC * 100 + MM_DEC) * 10000 + PR_DEC ))
+fi
 
 # Extract base version (without stage suffix)
 BASE_VERSION=$(echo "$VERSION_INPUT" | sed -E 's/-(dev|dev-staging|rc-[0-9]{2})$//')
 
 echo -e "${YELLOW}Bumping version to: $VERSION_INPUT${NC}"
-echo "  YY=$YY, MM=$MM, PR#=$PR"
+echo "  YY=$YY, MM=$MM, revision=$PR"
 echo "  versionCode=$VERSION_CODE"
 echo "  baseVersion=$BASE_VERSION"
 echo ""

--- a/shared/packages/minglit_kit/README.md
+++ b/shared/packages/minglit_kit/README.md
@@ -8,7 +8,6 @@
 flutter pub get
 flutter analyze --no-fatal-infos
 flutter test                           # unit + widget
-flutter test --tags golden             # golden (kit 의 공용 위젯)
 dart format .
 ```
 

--- a/shared/packages/minglit_kit/test/BLUEDOC.md
+++ b/shared/packages/minglit_kit/test/BLUEDOC.md
@@ -1,6 +1,6 @@
 # minglit_kit/test — 테스트
 
-`minglit_kit` 공용 패키지의 unit · widget · golden · contract 테스트. `lib/src/` 구조 미러링 + Repository 계약 테스트.
+`minglit_kit` 공용 패키지의 unit · widget · contract 테스트. `lib/src/` 구조 미러링 + Repository 계약 테스트.
 
 ## 이정표
 
@@ -8,7 +8,6 @@
 |---|---|
 | [`src/`](./src/) | unit + widget 테스트 (lib/src/ 미러링: bootstrap/components/config/data/features/logic/theme/ui/utils) |
 | [`contract/`](./contract/) | Repository 계약 테스트 — Supabase schema 와의 동기화 검증 |
-| [`goldens/`](./goldens/) | Golden 테스트 (Alchemist) — 공용 위젯 시각 회귀 |
 | [`logic/`](./logic/) | 글로벌 logic 테스트 (auth, provider 등) |
 | [`services/`](./services/) | 외부 SDK 래퍼 테스트 |
 | [`ui/`](./ui/) | UI / Design System 테스트 |
@@ -23,15 +22,12 @@
 
 - **계약 테스트 (`contract/`)** — Repository 가 wrapping 하는 Supabase 테이블/RPC 의 schema 가 변경되면 즉시 fail. 백엔드와 클라이언트 동기화 보장.
 - **`lib/src/` 의 모든 폴더는 대응 `test/src/` 폴더를 가진다.**
-- **Golden 은 Alchemist 사용** — `apps/app_user`/`app_partner` 와 동일.
-
 ## 실행
 
 ```bash
 flutter test                       # 전체
 flutter test test/contract/        # 계약 테스트만
 flutter test --coverage             # 커버리지 → coverage/lcov.info
-flutter test --tags golden          # Alchemist golden
 ```
 
 CI 자동 실행: `pr-gate.test-flutter-apps` matrix (minglit_kit 변경 시). 커버리지 dev 자동 갱신: [`sync-test-coverage`](../../../../.github/workflows/sync-test-coverage.yml) → [`tests/_coverage/minglit_kit/`](../../../../tests/_coverage/minglit_kit/).


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- Change dev-staging versioning to date-based versions plus version-bump PR build numbers.
- Create version-bump PRs instead of direct pushing bump commits to dev-staging.
- Tag merged bump snapshots as `vYY.MM.DD+BUILD_PR-dev-staging`.
- Update deploy metadata to read the latest version-bump PR number.
- Make CUJ execution explicit per PR-gate wrapper: `dev-staging-pr-gate` disables emulator CUJ, while `dev-pr-gate` / `rc-pr-gate` / `main-pr-gate` keep it enabled.
- Remove obsolete Alchemist golden merge-gate steps and stale `dart_test.yaml` golden tag declarations.

## Gate Scope / Cutover Notes
- `dev-staging-pr-gate` is intentionally a fast deterministic merge gate. It runs static checks, path-filtered app/kit analyze + unit/widget/integration tests, demo Android builds, artifact secret scan, landing builds, gitleaks, and workflow contract checks.
- Emulator CUJ is not a dev-staging PR merge blocker. The replacement guard for that failure mode is `monitor-dev-staging-health`, which runs EF unit/integration + user/partner CUJ on dev-staging on the scheduled health lane and records `dev-staging-health/*` commit statuses for promotion gating.
- The removed golden gate was Alchemist-based. Alchemist has been removed from the project, so keeping `flutter test --tags golden` would provide a stale/no-op or false-confidence gate rather than real visual regression coverage.
- Visual regression ownership is moved out of this PR gate. MDS screen-level visual validation is handled by the MDS emulator-render lane/coverage workflow, which uses real app rendering instead of legacy widget snapshot goldens.

## Validation
- `bash -n scripts/bump-version.sh`
- YAML parse for `dev-staging-dev-cut-gate`, `shared-version-metadata`, `version-bump`, branch PR gates, and `pr-gate`
- `git diff --check`
- temp-copy bump-version smoke: `26.05.27-dev-staging` + build `2832`
- PR CI: CUJ jobs are present but skipped for `dev-staging-pr-gate`; app/kit tests and demo builds are running/passing on this PR

No linked issue: CI versioning pipeline contract migration PR created directly from operational workflow sync.
