### PR TITLE
Move event-flow simulator to dev pg_cron

### DIFF
--- a/.github/scripts/BLUEDOC.md
+++ b/.github/scripts/BLUEDOC.md
@@ -13,10 +13,11 @@
 | [`check-pr-issue-reference.sh`](./check-pr-issue-reference.sh) | dev-staging PR 본문에 이슈 종료 의도(`Closes/Fixes/Resolves`) 또는 명시적 비종료 사유(`Refs` + 이유 / `No linked issue`)가 있는지 검사 | `pr-gate.static-checks` |
 | [`check-ios-deploy-branch-conditions.sh`](./check-ios-deploy-branch-conditions.sh) | `ios-deploy` action 의 브랜치 분기(`main` vs `non-main`) 회귀 검증 | 수동 실행 (`bash .github/scripts/check-ios-deploy-branch-conditions.sh`) |
 | [`check-android-deploy-workflow-contract.py`](./check-android-deploy-workflow-contract.py) | Android deploy release archive 가 `github.token` + `contents: write` 를 사용하고 PAT caller 계약을 요구하지 않는지 검증 | `pr-gate.static-checks` |
-| [`check-dev-soak-workflow-contract.py`](./check-dev-soak-workflow-contract.py) | `monitor-event-flow-distributed` + `dev-rc-cut-gate` + `shared-soak-gate` 의 run-history 판정 계약 검증 | `pr-gate.static-checks` |
+| [`check-dev-soak-workflow-contract.py`](./check-dev-soak-workflow-contract.py) | dev event-flow cron install + `dev-rc-cut-gate` + `shared-soak-gate` 판정 계약 검증 | `pr-gate.static-checks` |
 | [`check-dev-cut-workflow-contract.py`](./check-dev-cut-workflow-contract.py) | `dev-staging-dev-cut` 의 full-history checkout(`fetch-depth: 0`)과 `shared-notify` 의 `gh run view --repo` 컨텍스트 계약을 검증 | `pr-gate.static-checks` |
 | [`check-ios-connectivity-plus-cap.sh`](./check-ios-connectivity-plus-cap.sh) | iOS deploy runner 가 지원할 때까지 `connectivity_plus <7.1.0` resolution 강제 | `pr-gate.guard-ios-connectivity-plus-cap` |
 | [`scan-build-artifact-secrets.py`](./scan-build-artifact-secrets.py) | APK/AAB/`.next` 등 빌드 산출물에서 Supabase service-role secret 패턴을 redacted summary 로 검사 | `pr-gate.scan-build-artifact-secrets` |
+| [`install-dev-event-flow-cron.sh`](./install-dev-event-flow-cron.sh) | dev Supabase `dev-event-flow-simulator` pg_cron 설치/검증 | `deploy-dev-event-flow-cron` |
 
 ## 핵심 컨벤션
 

--- a/.github/scripts/check-dev-soak-workflow-contract.py
+++ b/.github/scripts/check-dev-soak-workflow-contract.py
@@ -106,6 +106,17 @@ def assert_dev_cron_deploy_contract() -> None:
         if fragment not in wait_script:
             fail(f"deploy-dev-event-flow-cron wait step missing fragment: {fragment}")
 
+    smoke_script = run_block(install, "Verify event-flow simulator tick")
+    required_smoke_fragments = [
+        "event-flow-simulator",
+        "targetRef: \"dev\"",
+        "targetSha: env.TARGET_SHA",
+        "jq -e '.success == true'",
+    ]
+    for fragment in required_smoke_fragments:
+        if fragment not in smoke_script:
+            fail(f"deploy-dev-event-flow-cron smoke step missing fragment: {fragment}")
+
     script_path = ROOT / ".github/scripts/install-dev-event-flow-cron.sh"
     script = script_path.read_text(encoding="utf-8")
     required_fragments = [

--- a/.github/scripts/check-dev-soak-workflow-contract.py
+++ b/.github/scripts/check-dev-soak-workflow-contract.py
@@ -111,6 +111,7 @@ def assert_dev_cron_deploy_contract() -> None:
     required_fragments = [
         "dev-event-flow-simulator",
         "*/5 * * * *",
+        "GITHUB_ACCESS_TOKEN is required for event-flow-simulator failure reporting",
         "'targetRef', 'dev'",
         "'targetSha', '${target_sha_esc}'",
         "public.ef_auth_manifest",

--- a/.github/scripts/check-dev-soak-workflow-contract.py
+++ b/.github/scripts/check-dev-soak-workflow-contract.py
@@ -13,6 +13,7 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 MONITOR_DISTRIBUTED = ROOT / ".github/workflows/monitor-event-flow-distributed.yml"
+DEPLOY_DEV_EVENT_FLOW_CRON = ROOT / ".github/workflows/deploy-dev-event-flow-cron.yml"
 DEV_RC_CUT_GATE = ROOT / ".github/workflows/dev-rc-cut-gate.yml"
 SHARED_SOAK_GATE = ROOT / ".github/workflows/shared-soak-gate.yml"
 
@@ -62,26 +63,50 @@ def assert_distributed_monitor_contract() -> None:
     workflow = load_workflow(MONITOR_DISTRIBUTED)
     config = on_config(workflow)
 
-    schedule = config.get("schedule", [])
-    if not isinstance(schedule, list) or not any(
-        isinstance(item, dict) and item.get("cron") == "*/5 * * * *"
-        for item in schedule
-    ):
-        fail("monitor-event-flow-distributed must run every 5 minutes")
+    if "schedule" in config:
+        fail("monitor-event-flow-distributed must not use GitHub schedule")
 
     dispatch = config.get("workflow_dispatch", {})
     inputs = dispatch.get("inputs", {}) if isinstance(dispatch, dict) else {}
-    target_ref = inputs.get("target_ref", {}) if isinstance(inputs, dict) else {}
-    if not isinstance(target_ref, dict) or target_ref.get("default") != "dev":
-        fail("monitor-event-flow-distributed workflow_dispatch target_ref must default to dev")
+    if "target_ref" in inputs:
+        fail("monitor-event-flow-distributed must not expose target_ref while rc cron is disabled")
 
     jobs = jobs_config(workflow, MONITOR_DISTRIBUTED)
     resolve_target = jobs.get("resolve-target", {})
     if not isinstance(resolve_target, dict):
         fail("monitor-event-flow-distributed must define resolve-target job")
-    script = run_block(resolve_target, "Resolve monitored ref")
-    if 'if [ "${EVENT_NAME}" = "schedule" ]; then' not in script or 'TARGET_REF="dev"' not in script:
-        fail("scheduled distributed monitor runs must force target_ref=dev")
+    script = run_block(resolve_target, "Resolve dev ref")
+    if 'GITHUB_REF' not in script or 'refs/heads/dev' not in script:
+        fail("manual distributed monitor must require --ref dev")
+
+
+def assert_dev_cron_deploy_contract() -> None:
+    workflow = load_workflow(DEPLOY_DEV_EVENT_FLOW_CRON)
+    config = on_config(workflow)
+    push = config.get("push", {})
+    branches = push.get("branches", []) if isinstance(push, dict) else []
+    if branches != ["dev"]:
+        fail("deploy-dev-event-flow-cron must run only on push to dev")
+
+    jobs = jobs_config(workflow, DEPLOY_DEV_EVENT_FLOW_CRON)
+    install = jobs.get("install", {})
+    if not isinstance(install, dict):
+        fail("deploy-dev-event-flow-cron must define install job")
+    if install.get("if") != "github.ref == 'refs/heads/dev'":
+        fail("deploy-dev-event-flow-cron install job must guard github.ref == refs/heads/dev")
+
+    script_path = ROOT / ".github/scripts/install-dev-event-flow-cron.sh"
+    script = script_path.read_text(encoding="utf-8")
+    required_fragments = [
+        "dev-event-flow-simulator",
+        "*/5 * * * *",
+        "'targetRef', 'dev'",
+        "'targetSha', '${target_sha_esc}'",
+        "public.ef_auth_manifest",
+    ]
+    for fragment in required_fragments:
+        if fragment not in script:
+            fail(f"install-dev-event-flow-cron.sh missing contract fragment: {fragment}")
 
 
 def assert_dev_rc_cut_gate_contract() -> None:
@@ -114,9 +139,10 @@ def assert_dev_rc_cut_gate_contract() -> None:
         fail("dev-rc-cut-gate required run contract must be an object")
 
     expected = {
-        "workflow": "monitor-event-flow-distributed.yml",
-        "branch": "dev-staging",
-        "min_success": 250,
+        "workflow": "deploy-dev-event-flow-cron.yml",
+        "branch": "dev",
+        "min_success": 1,
+        "match_head_sha": True,
     }
     for key, value in expected.items():
         if run.get(key) != value:
@@ -140,6 +166,7 @@ def assert_shared_soak_gate_contract() -> None:
 
 def main() -> None:
     assert_distributed_monitor_contract()
+    assert_dev_cron_deploy_contract()
     assert_dev_rc_cut_gate_contract()
     assert_shared_soak_gate_contract()
     print("Dev soak workflow contract OK")

--- a/.github/scripts/check-dev-soak-workflow-contract.py
+++ b/.github/scripts/check-dev-soak-workflow-contract.py
@@ -95,6 +95,17 @@ def assert_dev_cron_deploy_contract() -> None:
     if install.get("if") != "github.ref == 'refs/heads/dev'":
         fail("deploy-dev-event-flow-cron install job must guard github.ref == refs/heads/dev")
 
+    wait_script = run_block(install, "Wait for deploy-supabase on dev SHA")
+    required_wait_fragments = [
+        'wait_for_deploy="false"',
+        "changed_files=",
+        "supabase/(migrations|functions)",
+        "Skipping deploy-supabase wait.",
+    ]
+    for fragment in required_wait_fragments:
+        if fragment not in wait_script:
+            fail(f"deploy-dev-event-flow-cron wait step missing fragment: {fragment}")
+
     script_path = ROOT / ".github/scripts/install-dev-event-flow-cron.sh"
     script = script_path.read_text(encoding="utf-8")
     required_fragments = [

--- a/.github/scripts/install-dev-event-flow-cron.sh
+++ b/.github/scripts/install-dev-event-flow-cron.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${SUPABASE_DEV_PROJECT_ID:?SUPABASE_DEV_PROJECT_ID is required}"
+: "${SUPABASE_DEV_DB_PASSWORD:?SUPABASE_DEV_DB_PASSWORD is required}"
+: "${TARGET_REF:?TARGET_REF is required}"
+: "${TARGET_SHA:?TARGET_SHA is required}"
+: "${POOLER_HOST:=aws-1-ap-northeast-2.pooler.supabase.com}"
+
+if [ "${TARGET_REF}" != "dev" ]; then
+  echo "::error::event-flow simulator cron can only be installed for TARGET_REF=dev"
+  exit 1
+fi
+
+if ! [[ "${TARGET_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+  echo "::error::TARGET_SHA must be a full 40-character commit SHA"
+  exit 1
+fi
+
+sql_escape() {
+  printf '%s' "$1" | sed "s/'/''/g"
+}
+
+target_sha_esc="$(sql_escape "${TARGET_SHA}")"
+conn_url="postgresql://postgres.${SUPABASE_DEV_PROJECT_ID}@${POOLER_HOST}:5432/postgres?sslmode=require"
+
+PGPASSWORD="${SUPABASE_DEV_DB_PASSWORD}" psql "${conn_url}" -v ON_ERROR_STOP=1 <<SQL
+DO \$\$
+DECLARE
+  job_id bigint;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM vault.decrypted_secrets
+    WHERE name = 'supabase_url'
+      AND decrypted_secret IS NOT NULL
+      AND decrypted_secret <> ''
+  ) THEN
+    RAISE EXCEPTION 'vault secret supabase_url is required before installing dev-event-flow-simulator cron';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM vault.decrypted_secrets
+    WHERE name = 'service_role_key'
+      AND decrypted_secret IS NOT NULL
+      AND decrypted_secret <> ''
+  ) THEN
+    RAISE EXCEPTION 'vault secret service_role_key is required before installing dev-event-flow-simulator cron';
+  END IF;
+
+  FOR job_id IN
+    SELECT jobid
+    FROM cron.job
+    WHERE jobname IN (
+      'dev-event-flow-simulator',
+      'dev-event-flow-simulator-5m',
+      'dev_event_flow_simulator',
+      'dev_event_flow_simulator_5m',
+      'event-flow-simulator-5m',
+      'event_flow_simulator_5m'
+    )
+  LOOP
+    PERFORM cron.unschedule(job_id);
+  END LOOP;
+
+  INSERT INTO public.ef_auth_manifest (ef_name, required_auth, description)
+  VALUES (
+    'event-flow-simulator',
+    'service_role',
+    'Dev event-flow simulator - pg_cron distributed soak tick'
+  )
+  ON CONFLICT (ef_name) DO UPDATE
+    SET required_auth = EXCLUDED.required_auth,
+        description = EXCLUDED.description;
+END
+\$\$;
+
+SELECT cron.schedule(
+  'dev-event-flow-simulator',
+  '*/5 * * * *',
+  \$cron\$
+    SELECT net.http_post(
+      url := (
+        SELECT decrypted_secret FROM vault.decrypted_secrets
+        WHERE name = 'supabase_url' LIMIT 1
+      ) || '/functions/v1/event-flow-simulator',
+      headers := jsonb_build_object(
+        'Content-Type', 'application/json',
+        'Authorization', 'Bearer ' || (
+          SELECT decrypted_secret FROM vault.decrypted_secrets
+          WHERE name = 'service_role_key' LIMIT 1
+        )
+      ),
+      body := jsonb_build_object(
+        'ticks', 1,
+        'usersPerTick', 5,
+        'partnersPerTick', 2,
+        'delayBetweenCallsMs', 400,
+        'seed', extract(epoch from clock_timestamp())::bigint,
+        'targetRef', 'dev',
+        'targetSha', '${target_sha_esc}'
+      )
+    ) AS request_id;
+  \$cron\$
+);
+
+SELECT jobid, jobname, schedule, active
+FROM cron.job
+WHERE jobname = 'dev-event-flow-simulator';
+SQL

--- a/.github/scripts/install-dev-event-flow-cron.sh
+++ b/.github/scripts/install-dev-event-flow-cron.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 : "${SUPABASE_DEV_DB_PASSWORD:?SUPABASE_DEV_DB_PASSWORD is required}"
 : "${TARGET_REF:?TARGET_REF is required}"
 : "${TARGET_SHA:?TARGET_SHA is required}"
+: "${GITHUB_ACCESS_TOKEN:?GITHUB_ACCESS_TOKEN is required for event-flow-simulator failure reporting}"
 : "${POOLER_HOST:=aws-1-ap-northeast-2.pooler.supabase.com}"
 
 if [ "${TARGET_REF}" != "dev" ]; then

--- a/.github/workflows/BLUEDOC.md
+++ b/.github/workflows/BLUEDOC.md
@@ -13,7 +13,7 @@
 | `pr-gate-` | **머지 못 함** (required check — static PR 메시지 검사 + Gitleaks 시크릿 검사 포함) | `pr-gate.yml`, `pr-gate-fresh-doc.yml` |
 | `pr-setup-` | PR push 마다 PR 브랜치를 mutate 하는 자동화 (포맷 등) | (현재 없음 — `pr-setup-format` 은 #2627 에서 `pr-gate-format-check` 잡으로 대체) |
 | `pr-review-setup-` | PR 의 "리뷰 준비" 자동화 — auto-merge enable + 조건 충족 시 `needs-review` 라벨 부여 | `pr-review-setup` |
-| `deploy-` | 사용자·dev 환경에 코드·스키마·시드가 안 갔음 | `dev-deploy`, `main-deploy`, `deploy-vercel`, `deploy-supabase`, `deploy-android-user`, `deploy-ios-user`, `deploy-dev-seed` |
+| `deploy-` | 사용자·dev 환경에 코드·스키마·시드가 안 갔음 | `dev-deploy`, `main-deploy`, `deploy-vercel`, `deploy-supabase`, `deploy-dev-event-flow-cron`, `deploy-android-user`, `deploy-ios-user`, `deploy-dev-seed` |
 | `monitor-` | 운영·테스트 시스템 헬스 이상 / 스케줄 유지보수 | `monitor-dev-staging-health`, `monitor-db-invariants`, `monitor-event-flow-distributed`, `monitor-event-flow-hourly`, `monitor-event-flow-daily`, `monitor-mds-render-coverage`, `monitor-patrol-e2e`, `monitor-allure`, `monitor-build-retention`, `monitor-security-advisor`, `monitor-doc-freshness` |
 | `sync-` | repo 에 자동 commit/push 가 실패함 (dev-staging push 또는 merge 기반) | `sync-graphify`, `sync-mds-mockups`, `sync-pr-branches`, `sync-test-coverage` |
 | `set-` | GitHub status/metadata 를 쓰는 수동·자동 API entrypoint 실패 | `set-dev-soak-status`, `set-rc-soak-status` |
@@ -35,7 +35,7 @@
 - `dev-pr-gate`, `rc-pr-gate`, `main-pr-gate` 는 `shared-pr-source-guard` 로 직접 PR 을 차단한다. 정상 진입점은 `dev-staging` 이고, 예외는 branch별 approved hotfix 뿐이다.
 - `monitor-dev-staging-health` 는 required check 가 아니다. 6시간마다 `dev-staging` HEAD 에서 EF unit/integration + user/partner CUJ 를 돌려 nightly 전에 회귀를 발견하고, 결과를 `dev-staging-health/*` commit status 로 남긴다.
 - `dev-staging-dev-cut-gate` 가 날짜 기반 dev-staging version-bump PR 을 만들고, 그 PR 번호를 mobile build number 로 사용한다. merge 후 `vYY.MM.DD+BUILD_PR-dev-staging` tag 를 생성한다. `dev`/`rc`/`main` promotion 은 source-controlled version 변경 없이 처리한다.
-- `dev-rc-cut-gate` 는 cut 직전 evaluator 다. 내부에서 `shared-soak-gate` 를 호출해 `dev-soak/*` status 와 `monitor-event-flow-distributed` candidate 이후 run history 를 확인하고, 통과한 commit 에만 `dev-rc-cut-pass` status 를 찍는다.
+- `dev-rc-cut-gate` 는 cut 직전 evaluator 다. 내부에서 `shared-soak-gate` 를 호출해 `dev-soak/*` status 와 `deploy-dev-event-flow-cron` candidate install run 을 확인하고, 통과한 commit 에만 `dev-rc-cut-pass` status 를 찍는다.
 - Release gate 는 true evidence 기반이다. required success status/run history/git lineage 가 없으면 `unknown` 이며, failure issue 가 없다는 이유만으로 `dev-rc-cut-pass` 또는 `rc-main-cut-pass` 를 쓰지 않는다.
 - `dev-rc-cut` 은 latest `dev-rc-cut-pass` dev commit 에서 `rc/YYYY-Wxx` branch 를 만들고 `promo/rc-*` tag 를 생성한다. RC branch 에 version bump commit 을 만들지 않는다.
 - `dev-rc-cut` 은 active RC 가 있으면 기본 skip 한다. active RC 는 1개만 유지하고, 예외는 release-manager override 로만 허용한다.
@@ -46,7 +46,7 @@
 - `dev-deploy` 는 dev push 후 web + mobile dev 배포를 orchestrate 한다.
 - `main-deploy` 는 main push 후 prod 배포를 orchestrate 한다. version bump commit 없이 deploy-time metadata 를 계산하고 `shared-promo-tag` 로 `promo/main-*` marker 를 만든다.
 - `shared-promo-tag` 는 `promo/rc-*`, `promo/main-*` tag 생성의 공통 release-bot 구현이다. Concrete workflow 는 target ref, tag name, commit SHA 만 넘긴다.
-- `monitor-event-flow-distributed` 는 schedule 에서 `origin/dev` 를 대상으로 5분 distributed tick 을 호출하고, 수동 실행은 `dev` 또는 `rc/YYYY-Www` 만 허용한다. `monitor-event-flow-hourly` / `monitor-event-flow-daily` 는 legacy manual smoke 다.
+- `deploy-dev-event-flow-cron` 은 `dev` push 에서만 dev Supabase `dev-event-flow-simulator` pg_cron 을 설치한다. `monitor-event-flow-distributed` 는 `--ref dev` 수동 smoke 전용이고, hourly/daily 는 legacy manual smoke 다.
 - `deploy-android-*`, `deploy-ios-*`, `deploy-vercel` 은 branch-level deploy 에서 호출하는 concrete adapter 다. 직접 push/schedule 로 실행하지 않는다.
 - 실제 build/upload/notify 로직은 각각 `shared-android-deploy`, `shared-ios-deploy`, `shared-vercel-deploy` 에 둔다.
 - 모바일 배포 산출물(APK/AAB/IPA)은 GitHub Release asset 으로 보관한다. Actions artifact 는 테스트/디버깅 산출물용이며, deploy archive 의 source-of-truth 로 쓰지 않는다.

--- a/.github/workflows/deploy-dev-event-flow-cron.yml
+++ b/.github/workflows/deploy-dev-event-flow-cron.yml
@@ -118,6 +118,7 @@ jobs:
         env:
           SUPABASE_DEV_PROJECT_ID: ${{ secrets.SUPABASE_DEV_PROJECT_ID }}
           SUPABASE_DEV_DB_PASSWORD: ${{ secrets.SUPABASE_DEV_DB_PASSWORD }}
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GH_PAT_FOR_BUG_REPORT }}
           TARGET_REF: dev
           TARGET_SHA: ${{ github.sha }}
         run: bash .github/scripts/install-dev-event-flow-cron.sh

--- a/.github/workflows/deploy-dev-event-flow-cron.yml
+++ b/.github/workflows/deploy-dev-event-flow-cron.yml
@@ -1,0 +1,121 @@
+name: deploy-dev-event-flow-cron
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - '.github/scripts/install-dev-event-flow-cron.sh'
+      - '.github/workflows/deploy-dev-event-flow-cron.yml'
+      - 'supabase/functions/event-flow-simulator/**'
+      - 'supabase/functions/auth-manifest.json'
+  workflow_dispatch:
+    inputs:
+      wait_for_deploy_supabase:
+        description: Wait for deploy-supabase success on the same dev SHA before installing cron.
+        required: false
+        type: boolean
+        default: true
+
+concurrency:
+  group: deploy-dev-event-flow-cron
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  statuses: write
+
+jobs:
+  install:
+    name: Install dev event-flow cron
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/dev'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Wait for deploy-supabase on dev SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WAIT_FOR_DEPLOY_SUPABASE: ${{ github.event_name == 'push' || inputs.wait_for_deploy_supabase == true }}
+          TARGET_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ "${WAIT_FOR_DEPLOY_SUPABASE}" != "true" ]; then
+            echo "Skipping deploy-supabase wait."
+            exit 0
+          fi
+
+          for attempt in $(seq 1 60); do
+            run_json="$(gh run list \
+              --workflow deploy-supabase.yml \
+              --branch dev \
+              --limit 20 \
+              --json databaseId,headSha,status,conclusion,url \
+              --jq "[.[] | select(.headSha == \"${TARGET_SHA}\")][0] // {}")"
+            status="$(jq -r '.status // ""' <<< "${run_json}")"
+            conclusion="$(jq -r '.conclusion // ""' <<< "${run_json}")"
+            url="$(jq -r '.url // ""' <<< "${run_json}")"
+
+            if [ -z "${status}" ]; then
+              echo "deploy-supabase run for ${TARGET_SHA} not found yet (${attempt}/60)."
+              sleep 30
+              continue
+            fi
+
+            echo "deploy-supabase status=${status} conclusion=${conclusion} url=${url}"
+            if [ "${status}" = "completed" ] && [ "${conclusion}" = "success" ]; then
+              exit 0
+            fi
+            if [ "${status}" = "completed" ]; then
+              echo "::error::deploy-supabase completed with conclusion=${conclusion}"
+              exit 1
+            fi
+            sleep 30
+          done
+
+          echo "::error::Timed out waiting for deploy-supabase on ${TARGET_SHA}"
+          exit 1
+
+      - name: Install PostgreSQL client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+
+      - name: Safety guard
+        env:
+          TARGET_PROJECT_ID: ${{ secrets.SUPABASE_DEV_PROJECT_ID }}
+          MAIN_PROJECT_ID: ${{ secrets.SUPABASE_MAIN_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TARGET_PROJECT_ID}" ]; then
+            echo "::error::SUPABASE_DEV_PROJECT_ID secret is missing."
+            exit 1
+          fi
+          if [ "${TARGET_PROJECT_ID}" = "${MAIN_PROJECT_ID}" ]; then
+            echo "::error::Refusing to install dev event-flow cron on the main Supabase project."
+            exit 1
+          fi
+
+      - name: Install dev event-flow simulator cron
+        env:
+          SUPABASE_DEV_PROJECT_ID: ${{ secrets.SUPABASE_DEV_PROJECT_ID }}
+          SUPABASE_DEV_DB_PASSWORD: ${{ secrets.SUPABASE_DEV_DB_PASSWORD }}
+          TARGET_REF: dev
+          TARGET_SHA: ${{ github.sha }}
+        run: bash .github/scripts/install-dev-event-flow-cron.sh
+
+  notify-failure:
+    needs: [install]
+    if: always()
+    uses: ./.github/workflows/shared-notify.yml
+    with:
+      failed: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      workflow_name: 'deploy-dev-event-flow-cron'
+      severity: 'P1-high'
+      job_results: '{"install":"${{ needs.install.result }}","target_ref":"dev","target_sha":"${{ github.sha }}"}'
+      stage: 'dev-soak'
+      signal: 'backend-simulator'
+      blocks_rc_cut: true
+      commit_sha: ${{ github.sha }}
+      status_description: 'deploy-dev-event-flow-cron failed'
+    secrets: inherit

--- a/.github/workflows/deploy-dev-event-flow-cron.yml
+++ b/.github/workflows/deploy-dev-event-flow-cron.yml
@@ -3,11 +3,6 @@ name: deploy-dev-event-flow-cron
 on:
   push:
     branches: [dev]
-    paths:
-      - '.github/scripts/install-dev-event-flow-cron.sh'
-      - '.github/workflows/deploy-dev-event-flow-cron.yml'
-      - 'supabase/functions/event-flow-simulator/**'
-      - 'supabase/functions/auth-manifest.json'
   workflow_dispatch:
     inputs:
       wait_for_deploy_supabase:

--- a/.github/workflows/deploy-dev-event-flow-cron.yml
+++ b/.github/workflows/deploy-dev-event-flow-cron.yml
@@ -33,16 +33,39 @@ jobs:
     if: github.ref == 'refs/heads/dev'
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Wait for deploy-supabase on dev SHA
         env:
           GH_TOKEN: ${{ github.token }}
-          WAIT_FOR_DEPLOY_SUPABASE: ${{ github.event_name == 'push' || inputs.wait_for_deploy_supabase == true }}
+          EVENT_NAME: ${{ github.event_name }}
+          WAIT_FOR_DEPLOY_SUPABASE_INPUT: ${{ inputs.wait_for_deploy_supabase == true }}
+          BEFORE_SHA: ${{ github.event.before }}
           TARGET_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
 
-          if [ "${WAIT_FOR_DEPLOY_SUPABASE}" != "true" ]; then
+          wait_for_deploy="false"
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            if [ "${WAIT_FOR_DEPLOY_SUPABASE_INPUT}" = "true" ]; then
+              wait_for_deploy="true"
+            fi
+          elif [ "${EVENT_NAME}" = "push" ]; then
+            base_sha="${BEFORE_SHA:-}"
+            if [ -n "${base_sha}" ] && [ "${base_sha}" != "0000000000000000000000000000000000000000" ]; then
+              changed_files="$(git diff --name-only "${base_sha}" "${TARGET_SHA}" || true)"
+            else
+              changed_files="$(git show --pretty='' --name-only "${TARGET_SHA}" || true)"
+            fi
+
+            if printf '%s\n' "${changed_files}" | grep -Eq '^(supabase/(migrations|functions)/|env-manifest\.json$)'; then
+              wait_for_deploy="true"
+            fi
+          fi
+
+          echo "wait_for_deploy_supabase=${wait_for_deploy}"
+          if [ "${wait_for_deploy}" != "true" ]; then
             echo "Skipping deploy-supabase wait."
             exit 0
           fi

--- a/.github/workflows/deploy-dev-event-flow-cron.yml
+++ b/.github/workflows/deploy-dev-event-flow-cron.yml
@@ -123,6 +123,44 @@ jobs:
           TARGET_SHA: ${{ github.sha }}
         run: bash .github/scripts/install-dev-event-flow-cron.sh
 
+      - name: Verify event-flow simulator tick
+        env:
+          SUPABASE_DEV_URL: ${{ secrets.SUPABASE_DEV_URL }}
+          SUPABASE_DEV_SECRET_KEY: ${{ secrets.SUPABASE_DEV_SECRET_KEY }}
+          TARGET_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${SUPABASE_DEV_URL}" ] || [ -z "${SUPABASE_DEV_SECRET_KEY}" ]; then
+            echo "::error::Missing Supabase dev simulator secrets."
+            exit 1
+          fi
+
+          jq -n \
+            --argjson seed "$(date -u +%s)" \
+            '{
+              ticks: 1,
+              usersPerTick: 5,
+              partnersPerTick: 2,
+              delayBetweenCallsMs: 400,
+              seed: $seed,
+              targetRef: "dev",
+              targetSha: env.TARGET_SHA
+            }' > /tmp/sim_payload.json
+
+          http_code="$(curl -s -o /tmp/sim_response.json -w "%{http_code}" -X POST \
+            "${SUPABASE_DEV_URL}/functions/v1/event-flow-simulator" \
+            -H "Authorization: Bearer ${SUPABASE_DEV_SECRET_KEY}" \
+            -H "Content-Type: application/json" \
+            -d @/tmp/sim_payload.json \
+            --max-time 240)"
+          cat /tmp/sim_response.json
+          if [ "${http_code}" -lt 200 ] || [ "${http_code}" -ge 300 ]; then
+            echo "::error::event-flow-simulator returned HTTP ${http_code}"
+            exit 1
+          fi
+          jq -e '.success == true' /tmp/sim_response.json
+
   notify-failure:
     needs: [install]
     if: always()

--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -74,6 +74,10 @@ jobs:
           # process-list exposure (/proc/pid/cmdline) on shared runners.
           supabase link --project-ref $SUPABASE_PROJECT_ID
 
+          if [ -z "$GITHUB_ACCESS_TOKEN" ]; then
+            echo "::error::GH_PAT_FOR_BUG_REPORT is required for GitHub issue/status reporting"
+            exit 1
+          fi
           supabase secrets set OPENAI_API_KEY=$OPENAI_API_KEY
           supabase secrets set GITHUB_ACCESS_TOKEN=$GITHUB_ACCESS_TOKEN
           supabase secrets set SENTRY_DSN=$SENTRY_DSN

--- a/.github/workflows/dev-rc-cut-gate.yml
+++ b/.github/workflows/dev-rc-cut-gate.yml
@@ -41,7 +41,7 @@ jobs:
       min_soak_hours: ${{ inputs.min_soak_hours || '24' }}
       required_runs_json: >-
         [
-          {"workflow":"monitor-event-flow-distributed.yml","branch":"dev-staging","min_success":250,"run_limit":500}
+          {"workflow":"deploy-dev-event-flow-cron.yml","branch":"dev","min_success":1,"run_limit":20,"match_head_sha":true}
         ]
       failure_contexts: |
         dev-soak/backend-simulator

--- a/.github/workflows/monitor-event-flow-distributed.yml
+++ b/.github/workflows/monitor-event-flow-distributed.yml
@@ -1,18 +1,11 @@
 name: monitor-event-flow-distributed
 
-# Every 5 minutes — one small event-flow-simulator tick.
-# schedule always targets dev. Manual dispatch accepts dev or rc/YYYY-Www.
+# Manual smoke for one small event-flow-simulator tick.
+# Continuous 5-minute execution is installed by deploy-dev-event-flow-cron.
 
 on:
-  schedule:
-    - cron: '*/5 * * * *'
   workflow_dispatch:
     inputs:
-      target_ref:
-        description: 'Target branch. Allowed: dev or rc/YYYY-Www.'
-        required: false
-        type: string
-        default: dev
       ticks:
         description: Cascade ticks per run.
         required: false
@@ -35,7 +28,7 @@ on:
         default: '400'
 
 concurrency:
-  group: monitor-event-flow-distributed-${{ inputs.target_ref || 'dev' }}
+  group: monitor-event-flow-distributed-dev
   cancel-in-progress: false
 
 permissions:
@@ -46,53 +39,31 @@ permissions:
 
 jobs:
   resolve-target:
-    name: Resolve target branch
+    name: Resolve dev branch
     runs-on: ubuntu-latest
     outputs:
       target_ref: ${{ steps.resolve.outputs.target_ref }}
       target_sha: ${{ steps.resolve.outputs.target_sha }}
-      soak_stage: ${{ steps.resolve.outputs.soak_stage }}
-      supabase_stage: ${{ steps.resolve.outputs.supabase_stage }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
-      - name: Resolve monitored ref
+      - name: Resolve dev ref
         id: resolve
-        env:
-          REQUESTED_TARGET_REF: ${{ inputs.target_ref || 'dev' }}
-          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
 
-          TARGET_REF="${REQUESTED_TARGET_REF}"
-          if [ "${EVENT_NAME}" = "schedule" ]; then
-            TARGET_REF="dev"
+          if [ "${GITHUB_REF}" != "refs/heads/dev" ]; then
+            echo "::error::Run this manual smoke with --ref dev. Current ref: ${GITHUB_REF}"
+            exit 1
           fi
 
-          case "${TARGET_REF}" in
-            dev)
-              SOAK_STAGE="dev-soak"
-              SUPABASE_STAGE="dev"
-              ;;
-            rc/[0-9][0-9][0-9][0-9]-W[0-9][0-9])
-              SOAK_STAGE="rc-soak"
-              SUPABASE_STAGE="rc"
-              ;;
-            *)
-              echo "::error::target_ref must be dev or rc/YYYY-Www. Got: ${TARGET_REF}"
-              exit 1
-              ;;
-          esac
+          git fetch origin dev --depth=1
+          TARGET_SHA="$(git rev-parse origin/dev)"
 
-          git fetch origin "${TARGET_REF}" --depth=1
-          TARGET_SHA="$(git rev-parse "origin/${TARGET_REF}")"
-
-          echo "target_ref=${TARGET_REF}" >> "${GITHUB_OUTPUT}"
+          echo "target_ref=dev" >> "${GITHUB_OUTPUT}"
           echo "target_sha=${TARGET_SHA}" >> "${GITHUB_OUTPUT}"
-          echo "soak_stage=${SOAK_STAGE}" >> "${GITHUB_OUTPUT}"
-          echo "supabase_stage=${SUPABASE_STAGE}" >> "${GITHUB_OUTPUT}"
 
   simulate:
     name: Run distributed event-flow tick
@@ -103,15 +74,13 @@ jobs:
       - name: Invoke event-flow-simulator
         env:
           TARGET_REF: ${{ needs.resolve-target.outputs.target_ref }}
-          SUPABASE_STAGE: ${{ needs.resolve-target.outputs.supabase_stage }}
           SUPABASE_DEV_URL: ${{ secrets.SUPABASE_DEV_URL }}
           SUPABASE_DEV_SECRET_KEY: ${{ secrets.SUPABASE_DEV_SECRET_KEY }}
-          SUPABASE_RC_URL: ${{ secrets.SUPABASE_RC_URL }}
-          SUPABASE_RC_SECRET_KEY: ${{ secrets.SUPABASE_RC_SECRET_KEY }}
           INPUT_TICKS: ${{ inputs.ticks || '1' }}
           INPUT_USERS_PER_TICK: ${{ inputs.users_per_tick || '5' }}
           INPUT_PARTNERS_PER_TICK: ${{ inputs.partners_per_tick || '2' }}
           INPUT_DELAY_BETWEEN_CALLS_MS: ${{ inputs.delay_between_calls_ms || '400' }}
+          TARGET_SHA: ${{ needs.resolve-target.outputs.target_sha }}
         run: |
           set -euo pipefail
 
@@ -129,16 +98,11 @@ jobs:
           require_uint partners_per_tick "${INPUT_PARTNERS_PER_TICK}"
           require_uint delay_between_calls_ms "${INPUT_DELAY_BETWEEN_CALLS_MS}"
 
-          if [ "${SUPABASE_STAGE}" = "rc" ]; then
-            SUPABASE_URL="${SUPABASE_RC_URL}"
-            SUPABASE_SECRET_KEY="${SUPABASE_RC_SECRET_KEY}"
-          else
-            SUPABASE_URL="${SUPABASE_DEV_URL}"
-            SUPABASE_SECRET_KEY="${SUPABASE_DEV_SECRET_KEY}"
-          fi
+          SUPABASE_URL="${SUPABASE_DEV_URL}"
+          SUPABASE_SECRET_KEY="${SUPABASE_DEV_SECRET_KEY}"
 
           if [ -z "${SUPABASE_URL}" ] || [ -z "${SUPABASE_SECRET_KEY}" ]; then
-            echo "::error::Missing Supabase ${SUPABASE_STAGE} simulator secrets."
+            echo "::error::Missing Supabase dev simulator secrets."
             exit 1
           fi
 
@@ -154,7 +118,9 @@ jobs:
               usersPerTick: $usersPerTick,
               partnersPerTick: $partnersPerTick,
               delayBetweenCallsMs: $delayBetweenCallsMs,
-              seed: $seed
+              seed: $seed,
+              targetRef: "dev",
+              targetSha: env.TARGET_SHA
             }' > /tmp/sim_payload.json
 
           echo "target_ref=${TARGET_REF}"
@@ -182,7 +148,7 @@ jobs:
       workflow_name: 'monitor-event-flow-distributed'
       severity: 'P1-high'
       job_results: '{"resolve-target":"${{ needs.resolve-target.result }}","simulate":"${{ needs.simulate.result }}","target_ref":"${{ needs.resolve-target.outputs.target_ref }}","target_sha":"${{ needs.resolve-target.outputs.target_sha }}"}'
-      stage: ${{ needs.resolve-target.outputs.soak_stage }}
+      stage: 'dev-soak'
       signal: 'backend-simulator'
       blocks_rc_cut: true
       commit_sha: ${{ needs.resolve-target.outputs.target_sha }}

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -260,7 +260,7 @@ Supabase Edge Functions는 Deno 런타임 기반이며, `supabase/functions/` �
 | `health` | System | 시스템 헬스 체크 |
 | `dev-seed` | Dev | 테스트 데이터 시딩 (dev only) |
 | `dev-session-switch` | Dev | 테스트 유저 전환 (dev only) |
-| `event-flow-simulator` | Dev | dev 5분 distributed backend flow 시뮬레이터 (dev only) |
+| `event-flow-simulator` | Dev | dev pg_cron 5분 distributed backend flow 시뮬레이터 (dev only) |
 | `dev-mock-portone` | Dev | Portone 목업 서버 (dev only) |
 | `metrics-alert` | Monitoring | 정산 메트릭 알람 발송 |
 | `payout-sync` | Payment | 지급 상태 동기화 |

--- a/docs/guides/env-reference.md
+++ b/docs/guides/env-reference.md
@@ -119,6 +119,7 @@
 | Key | Description | Required |
 |-----|-------------|----------|
 | `ENVIRONMENT` | Dev guard (must be development/dev/local) | Yes |
+| `GITHUB_ACCESS_TOKEN` | GitHub issue/status reporting for simulator failures | Yes |
 | `SUPABASE_ANON_KEY` | actor sign-in for simulated user/partner JWTs | Yes |
 | `SUPABASE_SERVICE_ROLE_KEY` | simulator service client | Yes |
 | `SIM_USER_PASSWORD` | dev seed actor password | Yes |

--- a/docs/infra/branch-strategy/BLUEDOC.md
+++ b/docs/infra/branch-strategy/BLUEDOC.md
@@ -48,8 +48,8 @@ flowchart LR
 | dev-staging 지속 검증 | `monitor-dev-staging-health` | 6시간마다 EF unit/integration + user/partner CUJ 로 nightly 전 회귀 감지 |
 | dev-staging → dev cut gate | `dev-staging-dev-cut-gate` | dev 로 promote 할 coherent dev-staging snapshot 을 `v*-dev-staging` tag 로 선별 |
 | dev-staging → dev cut | `dev-staging-dev-cut` + `dev-pr-gate` | gate 가 선별한 snapshot 을 dev PR 로 promote |
-| dev → rc cut gate | `dev-rc-cut-gate` | 24h dev soak status/run history 확인 후 `dev-rc-cut-pass` status 부여 |
-| dev deploy/validation | `dev-deploy` | dev 환경 deploy/validation orchestrator. 이벤트 플로우 시뮬레이터는 `monitor-event-flow-*` batch 로 별도 운영 |
+| dev → rc cut gate | `dev-rc-cut-gate` | 24h dev soak status + dev cron install run 확인 후 `dev-rc-cut-pass` status 부여 |
+| dev deploy/validation | `dev-deploy` | dev 환경 deploy/validation orchestrator. 이벤트 플로우 시뮬레이터는 dev Supabase pg_cron 으로 별도 운영 |
 | dev → rc cut | `dev-rc-cut` | latest `dev-rc-cut-pass` commit 에서 `rc/YYYY-Wxx` 생성 |
 | rc hotfix | dev-staging fix PR + `rc-pr-gate` | dev-staging 에 먼저 반영된 fix commit 을 active RC 로 cherry-pick/promote |
 | rc deploy/validation | `rc-deploy` | Supabase branching 기반 RC 검증 환경 구성 + pre-main validation |
@@ -104,7 +104,7 @@ flowchart LR
 - cut-gate Issue 는 사람이 진행 상태를 추적하기 위한 projection 이다. 생성/갱신/닫기는 `.github/actions/cut-issue` 와 `close-cut-issue-on-pr-merge` 가 담당하며, promotion 판정 SSOT 로 사용하지 않는다
 - 모든 branch linear ON — dev-staging: squash, dev/rc/main: rebase
 - Protected branch 직접 push 는 human 금지. dev-staging version bump, promotion branch/tag, RC cleanup 은 `minglit-release-bot` 전용 token + Ruleset bypass 로만 허용
-- `monitor-event-flow-*` 는 release promotion 과 독립적인 batch signal. target 은 dev 5분 distributed tick 이고, RC 에서는 main 배포 전 검증 signal 로 사용한다
+- `deploy-dev-event-flow-cron` 은 `dev` push 에서만 `dev-event-flow-simulator` pg_cron 을 설치한다. `monitor-event-flow-*` 는 수동 smoke 이며, RC cron 은 RC project 준비 후 별도 설치한다
 - main 머지 = backend + mobile 모두 prod deploy. backend prod deploy 는 `main-deploy` 에서 한 번에 수행한다
 - 소스 파일 version bump 는 `dev-staging-dev-cut-gate` 가 만든 version-bump PR 에만 남긴다. 날짜 버전(`YY.MM.DD`) + version-bump PR 번호 build number 를 사용하고, `dev`/`rc`/`main` 은 branch state 를 바꾸지 않고 deploy workflow 가 metadata 를 build-time 에 주입한다
 - `main-deploy` 는 prod deploy execution 을 담당한다. main push 에서 version bump commit 을 만들지 않고, release asset/tag/marker 는 deploy metadata 를 기준으로 생성한다

--- a/docs/infra/branch-strategy/dev-pipeline.md
+++ b/docs/infra/branch-strategy/dev-pipeline.md
@@ -1,13 +1,13 @@
 # Dev Pipeline
 
-`dev` 브랜치가 trunk 역할: dev-staging 의 daily snapshot 을 받고, 24h soak 후 `dev-rc-cut-gate` 가 commit status 와 monitor run history 를 평가한다. RC 는 `dev-rc-cut-pass` status 를 보고 cut 한다. 이벤트 플로우 시뮬레이터는 `monitor-event-flow-*` batch 로 계속 돌며, backend prod deploy 는 main 머지 후 `main-deploy` 에서 수행한다.
+`dev` 브랜치가 trunk 역할: dev-staging 의 daily snapshot 을 받고, 24h soak 후 `dev-rc-cut-gate` 가 commit status 와 dev cron install signal 을 평가한다. RC 는 `dev-rc-cut-pass` status 를 보고 cut 한다. 이벤트 플로우 시뮬레이터는 dev Supabase pg_cron 으로 계속 돌며, backend prod deploy 는 main 머지 후 `main-deploy` 에서 수행한다.
 
 ## 4가지 workflow
 
 1. **`dev-staging-dev-cut`** — daily cron, dev-staging tip 의 snapshot 으로 PR 생성
 2. **`dev-pr-gate`** — snapshot PR 머지 전 검증 (defensive)
-3. **`dev-rc-cut-gate`** — cut 직전 evaluator. 24h soak + commit status + run history 확인 후 `dev-rc-cut-pass` set
-4. **`dev-deploy` / monitor jobs** — dev 환경 deploy/smoke 가 필요할 때만 수행. 이벤트 플로우 시뮬레이터는 `monitor-event-flow-*` 로 별도 운영
+3. **`dev-rc-cut-gate`** — cut 직전 evaluator. 24h soak + commit status + cron install run 확인 후 `dev-rc-cut-pass` set
+4. **`dev-deploy` / cron install** — dev 환경 deploy/smoke 가 필요할 때 수행. 이벤트 플로우 시뮬레이터는 dev pg_cron 으로 별도 운영
 
 ## `dev-staging-dev-cut`
 
@@ -46,7 +46,7 @@ GitHub Issue 는 source-of-truth 가 아니다. Gate 판정은 commit status con
 
 | Context | failure 작성자 | success 작성자 |
 |---------|---------------|----------------|
-| `dev-soak/backend-simulator` | `monitor-event-flow-*` 실패 path (`shared-notify`) | `dev-rc-cut-gate` |
+| `dev-soak/backend-simulator` | `event-flow-simulator` reporter 또는 `deploy-dev-event-flow-cron` 실패 path | `dev-rc-cut-gate` |
 | `dev-soak/real-device` | real-device/Test Lab workflow 또는 AI agent | `dev-rc-cut-gate` |
 | `dev-soak/app-ai-review` | AI agent | `dev-rc-cut-gate` |
 | `dev-rc-cut-pass` | 없음 | `dev-rc-cut-gate` |
@@ -60,7 +60,7 @@ GitHub Issue 는 source-of-truth 가 아니다. Gate 판정은 commit status con
 | 검증 | 조건 |
 |------|------|
 | Soak duration | candidate age >= 24h |
-| Event-flow distributed simulator | `candidate_since` 이후 `monitor-event-flow-distributed` success run >= 250 |
+| Event-flow distributed simulator | candidate SHA 에서 `deploy-dev-event-flow-cron` success >= 1 + `dev-soak/backend-simulator` failure 없음 |
 | Legacy hourly/daily simulator | 수동 smoke 전용. RC cut gate 조건에서 제외 |
 | Real device | candidate 기준 required real-device signal success >= 1 (workflow TBD) |
 | App AI review | AI agent 가 candidate 기준 app-soak pass signal 제공 (입력 방식 TBD) |
@@ -113,11 +113,11 @@ Snapshot 모델 — **auto-revert 없음**. dev 가 broken 상태로 잠시 머�
 
 ### `monitor-event-flow-*`
 
-- 이벤트 플로우 시뮬레이터 batch. target 은 `monitor-event-flow-distributed` 5분 주기 small tick
+- 이벤트 플로우 시뮬레이터 batch. target 은 dev Supabase pg_cron `dev-event-flow-simulator` 5분 주기 small tick
 - 시간은 고정 5분, 랜덤은 actor/user/partner/event sampling 에 적용한다
 - `seed.dev.sql` 은 계정/파트너 base 만 담당하고 party/event/ticket 은 EF 경유로 만든다
 - 유저 신청 대상은 DB prefix 필터가 아니라 `user-event-feed` 결과에서 선택한다
-- `monitor-event-flow-hourly` / `monitor-event-flow-daily` 는 legacy manual smoke
+- `monitor-event-flow-distributed` / hourly / daily 는 legacy manual smoke
 - release promotion 과 독립적으로 계속 돈다
 - RC 에서는 main 배포 전 pre-main validation signal 로 사용한다
 

--- a/docs/infra/branch-strategy/dev-soak-status-model.md
+++ b/docs/infra/branch-strategy/dev-soak-status-model.md
@@ -85,7 +85,7 @@ RC soak 는 dev soak 와 signal set 이 달라질 수 있으므로 별도 entry 
 
 | Context | 작성자 | 실패 시점 | 성공 시점 | 의미 |
 |---------|--------|-----------|-----------|------|
-| `dev-soak/backend-simulator` | `set-dev-soak-status` via `monitor-event-flow-*` / `dev-rc-cut-gate` | event-flow simulator 실패 즉시 `failure` | `dev-rc-cut-gate` 가 24h run history 를 확인한 뒤 `success` | backend/event-flow soak signal |
+| `dev-soak/backend-simulator` | `event-flow-simulator` reporter / `dev-rc-cut-gate` | event-flow simulator 실패 즉시 `failure` | `dev-rc-cut-gate` 가 24h soak + cron install run 을 확인한 뒤 `success` | backend/event-flow soak signal |
 | `dev-soak/real-device` | `set-dev-soak-status` via real-device workflow / `dev-rc-cut-gate` | Firebase Test Lab 또는 실디바이스 smoke 실패 즉시 `failure` | `dev-rc-cut-gate` 가 required run/signal 을 확인한 뒤 `success` | 실제 디바이스 안정성 signal |
 | `dev-soak/app-ai-review` | `set-dev-soak-status` via AI agent / `dev-rc-cut-gate` | AI/human 앱 소킹 중 blocker 발견 즉시 `failure` | `dev-rc-cut-gate` 가 AI review pass signal 을 확인한 뒤 `success` | screenshot/UX/manual-ish app soak signal |
 | `dev-rc-cut-pass` | `dev-rc-cut-gate` | 작성하지 않음 | 모든 dev soak 조건 통과 시 `success` | RC cut source marker |
@@ -120,11 +120,11 @@ Issue label 은 분류용이다. Gate 판정에는 사용하지 않는다.
 
 ## Run History Verification
 
-`dev-rc-cut-gate` 는 GitHub Actions run history 로 "soak 이 실제로 돌았는지" 검증한다.
+`dev-rc-cut-gate` 는 GitHub Actions run history 로 "candidate SHA 에 dev cron 이 설치됐는지" 검증하고, commit status 로 simulator failure 를 확인한다.
 
 | Signal | 최소 조건 |
 |--------|-----------|
-| `monitor-event-flow-distributed` | `candidate_since` 이후 `success` run >= 250 |
+| `deploy-dev-event-flow-cron` | candidate SHA 에서 `success` run >= 1 |
 | legacy `monitor-event-flow-hourly/daily` | 수동 smoke 전용. gate run requirement 에서 제외 |
 | real-device smoke | candidate 기준 required run/signal success >= 1 (workflow 이름 TBD) |
 | app AI review | AI agent 가 candidate 기준 pass signal 제공 (workflow/status 입력 방식 TBD) |
@@ -133,14 +133,13 @@ Issue label 은 분류용이다. Gate 판정에는 사용하지 않는다.
 
 ```bash
 gh run list \
-  --workflow monitor-event-flow-distributed.yml \
-  --branch dev-staging \
+  --workflow deploy-dev-event-flow-cron.yml \
+  --branch dev \
   --created ">=2026-05-24T00:00:00Z" \
-  --limit 500 \
   --json databaseId,status,conclusion,createdAt,headSha
 ```
 
-Scheduled workflow run 의 `headBranch` / `headSha` 는 default branch (`dev-staging`) 기준으로 기록된다. `monitor-event-flow-distributed` 내부에서 `origin/dev` 를 fetch 해 실제 simulator target 을 정하므로, gate run history 는 `--branch dev-staging` 으로 조회한다. `shared-soak-gate` 는 `--created >= candidate_since` 와 `run_limit >= min_success` 로 candidate 이후 성공 run 수를 센다.
+`deploy-dev-event-flow-cron` 은 `push: dev` 에서만 실행되어 Actions `headBranch` 가 `dev` 로 기록된다. workflow 는 candidate SHA 를 body 의 `targetSha` 로 cron 에 설치하고, `event-flow-simulator` 실패 시 해당 SHA 에 `dev-soak/backend-simulator` failure status 를 남긴다.
 
 ## Failure Recording
 
@@ -168,7 +167,7 @@ Issue body 에는 machine-readable metadata 를 남긴다. 단, gate 판정은 �
 <!-- minglit-release-signal
 stage: dev-soak
 signal: backend-simulator
-workflow: monitor-event-flow-distributed
+workflow: deploy-dev-event-flow-cron
 branch: dev
 commit: abc123...
 run_id: 263...
@@ -185,7 +184,7 @@ blocks_rc_cut: true
 
 1. `candidate_sha = origin/dev HEAD`
 2. candidate age 가 24h 이상인지 확인
-3. required monitor run history 가 candidate 기준으로 충분한지 확인
+3. required workflow run history 로 candidate SHA 에 dev cron 이 설치됐는지 확인
 4. candidate 의 required signal success evidence 가 존재하는지 확인
 5. candidate 의 최신 commit status 중 아래 context 가 `failure` 인지 확인:
    - `dev-soak/backend-simulator`

--- a/docs/infra/branch-strategy/dev-soak-status-model.md
+++ b/docs/infra/branch-strategy/dev-soak-status-model.md
@@ -139,7 +139,7 @@ gh run list \
   --json databaseId,status,conclusion,createdAt,headSha
 ```
 
-`deploy-dev-event-flow-cron` 은 `push: dev` 에서만 실행되어 Actions `headBranch` 가 `dev` 로 기록된다. workflow 는 candidate SHA 를 body 의 `targetSha` 로 cron 에 설치하고, `event-flow-simulator` 실패 시 해당 SHA 에 `dev-soak/backend-simulator` failure status 를 남긴다.
+`deploy-dev-event-flow-cron` 은 `push: dev` 에서만 실행되어 Actions `headBranch` 가 `dev` 로 기록된다. workflow 는 candidate SHA 를 body 의 `targetSha` 로 cron 에 설치한 뒤 즉시 1회 simulator tick 을 실행한다. 이후 `event-flow-simulator` 실패 시 해당 SHA 에 `dev-soak/backend-simulator` failure status 를 남긴다.
 
 ## Failure Recording
 

--- a/docs/infra/branch-strategy/specs/workflow-spec.md
+++ b/docs/infra/branch-strategy/specs/workflow-spec.md
@@ -199,7 +199,7 @@ Cross-branch cherry-pick PR 자동 생성.
 | Trigger | `schedule` (cut 직전, TBD) + `workflow_dispatch` |
 | Inputs | optional `candidate_sha` (default: latest `origin/dev` HEAD) |
 | Outputs | commit status `dev-rc-cut-pass` (success only) + `dev-soak/*` success confirmations + cut issue `gate/dev-rc` |
-| Steps | calls `shared-soak-gate` with candidate=`origin/dev`, min_soak_hours=24, required runs=`monitor-event-flow-distributed>=250`, failure context=`dev-soak/backend-simulator`, success context=`dev-soak/backend-simulator`, pass context=`dev-rc-cut-pass`; then upserts cut issue as `status/waiting` or `status/ready` |
+| Steps | calls `shared-soak-gate` with candidate=`origin/dev`, min_soak_hours=24, required runs=`deploy-dev-event-flow-cron>=1` on matching SHA, failure context=`dev-soak/backend-simulator`, success context=`dev-soak/backend-simulator`, pass context=`dev-rc-cut-pass`; then upserts cut issue as `status/waiting` or `status/ready` |
 | Failure path | 조건 미충족 또는 required success evidence 누락이면 `dev-rc-cut-pass` 를 쓰지 않는다. 실패를 발견한 monitor/AI agent 가 이미 `dev-soak/*` failure 를 쓴다 |
 
 > **No auto-revert** — snapshot 모델: 실패 = no `dev-rc-cut-pass`, dev keeps moving, 새 fix 가 자연스럽게 다음 dev-staging-dev-cut 후 새 candidate 로 검증됨.
@@ -214,13 +214,13 @@ Cross-branch cherry-pick PR 자동 생성.
 | Trigger | TBD (`push` to `dev` 또는 `workflow_dispatch`) |
 | Outputs | dev deploy/validation status |
 | Steps | dev 환경 배포 또는 smoke 가 필요할 때만 수행. backend prod deploy 는 여기서 하지 않고 `main-deploy` 에서 수행 |
-| Note | 이벤트 플로우 시뮬레이터는 `dev-deploy` 가 아니라 `monitor-event-flow-distributed` batch 로 계속 돈다 |
+| Note | 이벤트 플로우 시뮬레이터는 `dev-deploy` 가 아니라 dev Supabase pg_cron `dev-event-flow-simulator` 로 계속 돈다 |
 
 #### `monitor-event-flow-*` (release pipeline 외부 batch)
 
 | 항목 | 값 |
 |------|----|
-| Trigger | schedule (`monitor-event-flow-distributed`: `*/5 * * * *`; legacy hourly/daily 는 수동 smoke) |
+| Trigger | `deploy-dev-event-flow-cron` installs pg_cron on `push: dev`; monitor workflows are manual smoke |
 | Branch/env | dev 를 계속 관찰. RC cut 후에는 RC env/Supabase branch 도 pre-main 검증 signal 로 사용 |
 | Outputs | event-flow simulation signal, `set-dev-soak-status(signal=backend-simulator,state=failure)`, issue/alert |
 | Note | fixed-time small tick. actor/user/partner/event sampling 만 랜덤화하고, party/event 는 partner EF, 신청 대상은 `user-event-feed` 로 만든다 |

--- a/docs/infra/branch-strategy/test-strategy.md
+++ b/docs/infra/branch-strategy/test-strategy.md
@@ -58,7 +58,7 @@ dev 에 들어간 latest HEAD 만 RC candidate 로 평가한다. 새 dev commit 
 
 | Signal | 실행자 | 실패 status | 성공 status |
 |--------|--------|-------------|-------------|
-| backend simulator | `deploy-dev-event-flow-cron` + pg_cron `dev-event-flow-simulator` | `dev-soak/backend-simulator` failure 즉시 | `dev-rc-cut-gate` 가 cron install run + failure status 확인 |
+| backend simulator | `deploy-dev-event-flow-cron` + pg_cron `dev-event-flow-simulator` | `dev-soak/backend-simulator` failure 즉시 | `dev-rc-cut-gate` 가 cron install + 1회 simulator tick run + failure status 확인 |
 | real device | Test Lab/실디바이스 workflow | `dev-soak/real-device` failure 즉시 | `dev-rc-cut-gate` 가 required signal 확인 후 success |
 | app AI review | AI agent | `dev-soak/app-ai-review` failure 즉시 | `dev-rc-cut-gate` 가 pass signal 확인 후 success |
 

--- a/docs/infra/branch-strategy/test-strategy.md
+++ b/docs/infra/branch-strategy/test-strategy.md
@@ -1,6 +1,6 @@
 # Test Strategy
 
-4-stage 모델 (`dev-staging → dev → rc → main`) + flag staged rollout 환경에서, *어떤 테스트가 어느 단계에서 도는가* 의 단일 source. 빠른 검사 = branch별 `*-pr-gate`, 지속 소킹 = `monitor-event-flow-*`/real-device/app AI review, RC 후보 판정 = `dev-rc-cut-gate`, 프로덕션 검증 = `deploy-android-*, deploy-ios-*` smoke + flag staged.
+4-stage 모델 (`dev-staging → dev → rc → main`) + flag staged rollout 환경에서, *어떤 테스트가 어느 단계에서 도는가* 의 단일 source. 빠른 검사 = branch별 `*-pr-gate`, 지속 소킹 = dev Supabase pg_cron event-flow/real-device/app AI review, RC 후보 판정 = `dev-rc-cut-gate`, 프로덕션 검증 = `deploy-android-*, deploy-ios-*` smoke + flag staged.
 
 ## 단계별 게이트
 
@@ -58,7 +58,7 @@ dev 에 들어간 latest HEAD 만 RC candidate 로 평가한다. 새 dev commit 
 
 | Signal | 실행자 | 실패 status | 성공 status |
 |--------|--------|-------------|-------------|
-| backend simulator | `monitor-event-flow-distributed` (legacy hourly/daily 는 수동 smoke) | `dev-soak/backend-simulator` failure 즉시 | `dev-rc-cut-gate` 가 run history 확인 후 success |
+| backend simulator | `deploy-dev-event-flow-cron` + pg_cron `dev-event-flow-simulator` | `dev-soak/backend-simulator` failure 즉시 | `dev-rc-cut-gate` 가 cron install run + failure status 확인 |
 | real device | Test Lab/실디바이스 workflow | `dev-soak/real-device` failure 즉시 | `dev-rc-cut-gate` 가 required signal 확인 후 success |
 | app AI review | AI agent | `dev-soak/app-ai-review` failure 즉시 | `dev-rc-cut-gate` 가 pass signal 확인 후 success |
 
@@ -67,7 +67,8 @@ dev 에 들어간 latest HEAD 만 RC candidate 로 평가한다. 새 dev commit 
 cut 직전 schedule/manual 로 실행한다. 통과 시 commit 에 GitHub status `dev-rc-cut-pass` 를 set 한다.
 
 - candidate age >= 24h
-- `monitor-event-flow-distributed` success run >= 250 since candidate
+- candidate SHA 에서 `deploy-dev-event-flow-cron` success >= 1
+- `dev-soak/backend-simulator` failure status 없음
 - legacy hourly/daily 는 수동 smoke 로만 실행
 - candidate 의 최신 `dev-soak/*` status 가 failure 가 아님
 - real-device/app AI review required signal 충족

--- a/docs/operations/edge-functions.md
+++ b/docs/operations/edge-functions.md
@@ -215,7 +215,7 @@ curl -X POST ".../functions/v1/event-flow-simulator" \
   -d '{"ticks":1,"usersPerTick":5,"partnersPerTick":2,"seed":202605250905}'
 ```
 
-시간은 5분 고정 schedule 이 담당하고, 랜덤성은 actor/user/partner/event sampling 에만 둔다. 유저 신청 대상은 DB prefix 가 아니라 `user-event-feed` 결과에서 고른다. Assertion 실패 시 GitHub 이슈가 자동 생성되며, 이슈에 Axiom 쿼리가 포함된다.
+시간은 dev Supabase pg_cron `dev-event-flow-simulator` 가 담당하고, 랜덤성은 actor/user/partner/event sampling 에만 둔다. 유저 신청 대상은 DB prefix 가 아니라 `user-event-feed` 결과에서 고른다. Assertion 실패 시 GitHub 이슈와 `dev-soak/backend-simulator` failure status 가 자동 생성된다.
 
 ## 환경변수 참조
 

--- a/docs/qa/automation-test-guide.md
+++ b/docs/qa/automation-test-guide.md
@@ -227,7 +227,7 @@ void main() {
 | 4 (pgTAP) | `supabase/tests/database/*.sql` | 80 |
 | 5 (Deno EF) | `supabase/functions/**/*_test.ts` | 75 |
 | 6 (DB monitor) | `check_db_invariants()` RPC | 1 RPC (매시간) |
-| 7 (event-flow simulator) | `event-flow-simulator` EF + `monitor-event-flow-*` | 5분마다 + 24h soak |
+| 7 (event-flow simulator) | `event-flow-simulator` EF + dev pg_cron `dev-event-flow-simulator` | 5분마다 + 24h soak |
 
 **핵심 갭**:
 - 🔴 **Layer 3 CUJ 이관 0%** — 37 widget flow 를 Patrol 로 전환 필요 (#1586 Phase D-2)

--- a/env-manifest.json
+++ b/env-manifest.json
@@ -178,6 +178,9 @@
         "required": {
           "ENVIRONMENT": {
             "desc": "Dev guard (dev)"
+          },
+          "GITHUB_ACCESS_TOKEN": {
+            "desc": "GitHub issue/status reporting for simulator failures"
           }
         }
       },

--- a/supabase/functions/BLUEDOC.md
+++ b/supabase/functions/BLUEDOC.md
@@ -14,7 +14,7 @@ minglit 의 backend API 진입점. 60+ EF 와 공용 `_shared/`, 테스트 유�
 | [_contract_tests/](./_contract_tests/BLUEDOC.md)                         | EF 응답 JSON schema contract                                     |
 | [_integration_tests/](./_integration_tests/BLUEDOC.md)                   | local Supabase + 외부 mock integration/CUJ                       |
 | [_payment_integration_tests/](./_payment_integration_tests/BLUEDOC.md)   | 결제 chaining 시뮬. 추후 `_integration_tests/` 흡수              |
-| [event-flow-simulator/](./event-flow-simulator/BLUEDOC.md)               | dev 5분 distributed event-flow 시뮬레이터                        |
+| [event-flow-simulator/](./event-flow-simulator/BLUEDOC.md)               | dev pg_cron 5분 distributed event-flow 시뮬레이터                |
 | [user-create-order/](./user-create-order/BLUEDOC.md)                     | 이벤트 신청/주문 생성 EF                                         |
 | [payment-verify/](./payment-verify/BLUEDOC.md)                           | PortOne 결제 검증/승인 EF                                        |
 | [user-cancel-order/](./user-cancel-order/BLUEDOC.md)                     | 유저 신청 취소/환불 EF                                           |

--- a/supabase/functions/auth-manifest.json
+++ b/supabase/functions/auth-manifest.json
@@ -267,7 +267,7 @@
       "description": "PGMQ q_tags LLM 태그 추출 워커 (Fix #1489: system caller 전용)"
     },
     "event-flow-simulator": {
-      "callers": ["public"],
+      "callers": ["system", "public"],
       "envs": ["local", "development", "dev"],
       "description": "E2E/시나리오 시뮬레이터 — dev 전용 (wrapper의 auth-manifest envs 게이팅으로 dev-only 보장)"
     },

--- a/supabase/functions/event-flow-simulator/BLUEDOC.md
+++ b/supabase/functions/event-flow-simulator/BLUEDOC.md
@@ -15,7 +15,7 @@ curl -X POST "https://<project>.supabase.co/functions/v1/event-flow-simulator" \
   -d '{"ticks": 1, "usersPerTick": 5, "partnersPerTick": 2, "seed": 202605250905}'
 ```
 
-응답 = `{ success, run_id, actors, trace_summary, violations, github_issue_url }`. 실패 시 reporter 가 자동 GH 이슈 생성.
+응답 = `{ success, run_id, actors, trace_summary, violations, github_issue_url }`. 실패 시 reporter 가 자동 GH 이슈와 commit status 를 남긴다.
 
 ## 폴더 구조
 
@@ -29,7 +29,9 @@ curl -X POST "https://<project>.supabase.co/functions/v1/event-flow-simulator" \
 
 ## 트리거 / 환경 가드
 
-- target: `monitor-event-flow-distributed` 가 dev 에서 5분마다 작은 tick 실행 (하루 288회)
+- target: dev Supabase pg_cron `dev-event-flow-simulator` 가 5분마다 작은 tick 실행
+- install: `deploy-dev-event-flow-cron` 이 `dev` push 에서만 cron 을 설치
+- manual: `monitor-event-flow-distributed --ref dev` 는 수동 smoke 전용
 - legacy: `monitor-event-flow-hourly` / `monitor-event-flow-daily` 는 수동 smoke 전용
 - **prod 차단**: auth-manifest `envs: ["dev","development","local"]` 가드, `minglitEdgeFunction` wrapper 가 enforce
 - 필수 env: `SIM_USER_PASSWORD` (Fix #1508), `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`
@@ -40,11 +42,8 @@ curl -X POST "https://<project>.supabase.co/functions/v1/event-flow-simulator" \
 - 유저는 `user-event-feed` EF 결과에서 신청 대상을 선택한다. 특정 party/event prefix 직접 필터 금지
 - party/event/ticket 생성은 seed SQL 이 아니라 partner EF 경유
 - `seed.dev.sql` 은 user / partner / permission / verification 같은 base actor 데이터만 담당
-- 액션 실패 시 `sim_reporter` 가 자동 GH 이슈 생성
+- 액션 실패 시 reporter 가 GH 이슈 + `dev-soak/backend-simulator` failure status 생성
 - 단위 테스트: `cd supabase/functions && deno test event-flow-simulator/`
-
-## 한계 / 개선 계획
-v2 **Stochastic Cascade** 모델은 도입됐지만 현재 구현은 `[E2E]` prefix snapshot 과 large daily run 흔적이 남아 있다. 다음 단계는 5분 distributed tick, actor random sampling, feed-driven apply, partner-EF-driven party/event generation 으로 정렬한다. 상세는 [architecture.md](./architecture.md).
 
 ---
 _Reviewed: 2026-05-25 16:20_

--- a/supabase/functions/event-flow-simulator/README.md
+++ b/supabase/functions/event-flow-simulator/README.md
@@ -1,6 +1,6 @@
 # event-flow-simulator
 
-Stochastic Cascade 모델 기반 dev event-flow 시뮬레이터. 5분마다 작은 실제 EF traffic 을 흘리는 distributed soak signal 이다. 진입점 / 모드 / 컨벤션은 [BLUEDOC.md](./BLUEDOC.md), 아키텍처 상세는 [architecture.md](./architecture.md).
+Stochastic Cascade 모델 기반 dev event-flow 시뮬레이터. dev Supabase pg_cron 이 5분마다 작은 실제 EF traffic 을 흘리는 distributed soak signal 이다. 진입점 / 모드 / 컨벤션은 [BLUEDOC.md](./BLUEDOC.md), 아키텍처 상세는 [architecture.md](./architecture.md).
 
 ## 빠른 실행
 
@@ -15,7 +15,7 @@ curl -X POST "https://<project>.supabase.co/functions/v1/event-flow-simulator" \
   -d '{"ticks": 1, "usersPerTick": 5, "partnersPerTick": 2, "seed": 202605250905}'
 ```
 
-시간은 schedule 이 고정 5분으로 관리한다. 랜덤성은 actor/user/partner/event sampling 에만 둔다. party/event/ticket 은 SQL seed 가 아니라 partner EF 로 만들고, user 는 `user-event-feed` 결과에서 신청 대상을 고른다.
+시간은 `deploy-dev-event-flow-cron` 이 설치한 `dev-event-flow-simulator` pg_cron 이 고정 5분으로 관리한다. 랜덤성은 actor/user/partner/event sampling 에만 둔다. party/event/ticket 은 SQL seed 가 아니라 partner EF 로 만들고, user 는 `user-event-feed` 결과에서 신청 대상을 고른다.
 
 ## 폴더
 

--- a/supabase/functions/event-flow-simulator/architecture.md
+++ b/supabase/functions/event-flow-simulator/architecture.md
@@ -28,11 +28,11 @@
 
 | 항목 | 정책 |
 |---|---|
-| 실행 주기 | 5분마다 1회 (`*/5 * * * *`) — 하루 288회 |
+| 실행 주기 | dev Supabase pg_cron `dev-event-flow-simulator` 가 5분마다 1회 (`*/5 * * * *`) |
 | 호출 크기 | `ticks=1`, 작은 actor set (`usersPerTick` 3-8, `partnersPerTick` 1-2) |
 | 랜덤 위치 | 시간은 고정, actor/user/partner/event 선택만 seed 기반 랜덤 |
-| 환경 | dev 전용. `auth-manifest` env guard 로 prod 차단 |
-| 실패 처리 | 실패 즉시 `dev-soak/backend-simulator` status + release-blocker issue |
+| 환경 | dev 전용. cron 설치는 `deploy-dev-event-flow-cron` 이 `push: dev` 에서만 수행 |
+| 실패 처리 | 실패 즉시 `dev-soak/backend-simulator` status + GH issue |
 
 큰 daily cascade 한 번(`ticks=3`, `usersPerTick=50`)으로 100개 이상의 nested EF 호출을 한 trace 에 몰아넣는 방식은 Supabase per-trace rate limit 에 취약하다. 총 커버리지는 24시간 누적으로 확보하고, 각 invocation 은 작게 유지한다.
 
@@ -189,7 +189,7 @@ event-flow-simulator/
 | 2 | 액션 마이그 | 기존 8 SimAction → `action/*.ts` 8 파일. 기존 *_test.ts 유지 | 1주 | 기존 deno test 통과 |
 | 3 | policy + params | `policy/user.ts`, `policy/partner.ts`, `params/default.ts` 작성 | 3-4일 | small cascade run → 액션 발생 검증 |
 | 4 | invariant 초기 set | 실 비즈니스 규칙 정의 RFC (후보: money conservation / settlement coverage / match integrity / participant ordering / event lifecycle / PGMQ DLQ) — 각 규칙은 실 코드/스키마 정합 확인 선행 필요. 가설 invariant 작성 금지 | 2-3주 | stress params 로 의도적 위반 → 잡히는지 검증 |
-| 5 | `modes/tick.ts` | 5분 distributed tick. actor random sample + small payload | 2일 | 24h run history 에서 rate limit 0건 |
+| 5 | dev pg_cron tick | 5분 distributed tick. actor random sample + small payload | 2일 | 24h cron history 에서 rate limit 0건 |
 | 6 | user/partner discovery 경로 정렬 | 유저는 `user-event-feed`, 파트너/이벤트 생성은 partner EF 경유 | 1주 | SQL party/event seed 없이 feed→apply 가능 |
 | 7 | `modes/seed.ts` + phase 삭제 | 계정/파트너 base seed 와 EF-driven state generation 분리. 옛 phase 모드 5 파일 삭제 | 3-4일 | seed 1회 실행 후 dev 상태 다양성 측정 |
 | 8 | `modes/stress.ts` | chaos params + invariant 위반 → GH 이슈 자동 생성 | 3일 | 야간 stress run → 알림 도착 검증 |

--- a/supabase/functions/event-flow-simulator/core/reporter.ts
+++ b/supabase/functions/event-flow-simulator/core/reporter.ts
@@ -10,6 +10,8 @@ export interface ReporterInput {
   runId: string;
   trace: Trace;
   violations: InvariantViolation[];
+  targetRef?: string;
+  targetSha?: string;
 }
 
 export function summarizeTrace(trace: Trace) {
@@ -23,7 +25,9 @@ export function summarizeTrace(trace: Trace) {
  * trace 실패 또는 invariant 위반 시 GH 이슈 생성.
  * 양쪽 모두 0 이면 null 반환 (이슈 생성 안 함).
  */
-export async function reportFailure(input: ReporterInput): Promise<string | null> {
+export async function reportFailure(
+  input: ReporterInput,
+): Promise<string | null> {
   const { runId, trace, violations } = input;
   const summary = summarizeTrace(trace);
 
@@ -43,7 +47,9 @@ export async function reportFailure(input: ReporterInput): Promise<string | null
     .filter((e) => !e.ok)
     .map(
       (e) =>
-        `- tick ${e.tick} | ${e.actorId} | ${e.action.type} (${e.action.ef ?? "direct"}) ` +
+        `- tick ${e.tick} | ${e.actorId} | ${e.action.type} (${
+          e.action.ef ?? "direct"
+        }) ` +
         `→ status ${e.status}${e.error ? ` (${e.error})` : ""}`,
     )
     .join("\n");
@@ -60,7 +66,8 @@ export async function reportFailure(input: ReporterInput): Promise<string | null
   if (traceBytes.length > MAX_ISSUE_BODY_BYTES) {
     let safeEnd = MAX_ISSUE_BODY_BYTES;
     while (safeEnd > 0 && (traceBytes[safeEnd] & 0xc0) === 0x80) safeEnd--;
-    truncatedTrace = new TextDecoder().decode(traceBytes.slice(0, safeEnd)) + "\n...[truncated]";
+    truncatedTrace = new TextDecoder().decode(traceBytes.slice(0, safeEnd)) +
+      "\n...[truncated]";
   }
 
   const body = `## Stochastic Cascade Failure Report
@@ -114,9 +121,64 @@ ${truncatedTrace}
     }
 
     const data = await response.json();
-    return (data as { html_url?: string }).html_url ?? null;
+    const issueUrl = (data as { html_url?: string }).html_url ?? null;
+    await writeFailureStatus({
+      token: githubToken,
+      targetRef: input.targetRef,
+      targetSha: input.targetSha,
+      targetUrl: issueUrl,
+      description:
+        `event-flow-simulator failed: ${summary.failed} action fails, ${violations.length} violations`,
+    });
+    return issueUrl;
   } catch (err) {
     console.error("[reporter] reportFailure exception:", err);
     return null;
+  }
+}
+
+async function writeFailureStatus(input: {
+  token: string;
+  targetRef?: string;
+  targetSha?: string;
+  targetUrl?: string | null;
+  description: string;
+}) {
+  const { targetSha } = input;
+  if (!targetSha || !/^[0-9a-fA-F]{40}$/.test(targetSha)) return;
+
+  const context = input.targetRef?.startsWith("rc/")
+    ? "rc-soak/backend-simulator"
+    : "dev-soak/backend-simulator";
+  const description = input.description.length > 140
+    ? input.description.slice(0, 137) + "..."
+    : input.description;
+
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${GITHUB_REPO}/statuses/${targetSha}`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${input.token}`,
+          "Content-Type": "application/json",
+          "User-Agent": "Minglit-Cascade-Reporter",
+        },
+        body: JSON.stringify({
+          state: "failure",
+          context,
+          description,
+          target_url: input.targetUrl ?? undefined,
+        }),
+      },
+    );
+    if (!response.ok) {
+      console.error(
+        "[reporter] GitHub status API error:",
+        await response.text(),
+      );
+    }
+  } catch (err) {
+    console.error("[reporter] writeFailureStatus exception:", err);
   }
 }

--- a/supabase/functions/event-flow-simulator/core/reporter.ts
+++ b/supabase/functions/event-flow-simulator/core/reporter.ts
@@ -39,6 +39,9 @@ export async function reportFailure(
     return null;
   }
 
+  const statusDescription =
+    `event-flow-simulator failed: ${summary.failed} action fails, ${violations.length} violations`;
+
   const timestamp = new Date().toISOString();
   const title =
     `[CASCADE] ${summary.failed} action fails + ${violations.length} invariant violations — ${timestamp}`;
@@ -97,6 +100,7 @@ ${truncatedTrace}
 
 </details>`;
 
+  let issueUrl: string | null = null;
   try {
     const response = await fetch(
       `https://api.github.com/repos/${GITHUB_REPO}/issues`,
@@ -117,23 +121,23 @@ ${truncatedTrace}
 
     if (!response.ok) {
       console.error("[reporter] GitHub API error:", await response.text());
-      return null;
+      return issueUrl;
     }
 
     const data = await response.json();
-    const issueUrl = (data as { html_url?: string }).html_url ?? null;
+    issueUrl = (data as { html_url?: string }).html_url ?? null;
+    return issueUrl;
+  } catch (err) {
+    console.error("[reporter] reportFailure exception:", err);
+    return issueUrl;
+  } finally {
     await writeFailureStatus({
       token: githubToken,
       targetRef: input.targetRef,
       targetSha: input.targetSha,
       targetUrl: issueUrl,
-      description:
-        `event-flow-simulator failed: ${summary.failed} action fails, ${violations.length} violations`,
+      description: statusDescription,
     });
-    return issueUrl;
-  } catch (err) {
-    console.error("[reporter] reportFailure exception:", err);
-    return null;
   }
 }
 

--- a/supabase/functions/event-flow-simulator/core/reporter_test.ts
+++ b/supabase/functions/event-flow-simulator/core/reporter_test.ts
@@ -101,3 +101,111 @@ Deno.test("reportFailure includes issue URL in failure status when issue creatio
     assertEquals((calls[1].body as { target_url: string }).target_url, htmlUrl);
   });
 });
+
+Deno.test("reportFailure still writes status when issue request throws", async () => {
+  const calls: Array<{ url: string; body: unknown }> = [];
+  await withMockedFetch((input, init) => {
+    const url = String(input);
+    calls.push({
+      url,
+      body: init?.body ? JSON.parse(String(init.body)) : null,
+    });
+    if (calls.length === 1) {
+      throw new Error("network down");
+    }
+    return new Response("{}", { status: 201 });
+  }, async () => {
+    const issueUrl = await reportFailure({
+      runId: "run-3",
+      trace: failedTrace(),
+      violations: [],
+      targetRef: "dev",
+      targetSha: TARGET_SHA,
+    });
+
+    assertEquals(issueUrl, null);
+    assertEquals(calls.length, 2);
+    assert(calls[1].url.endsWith(`/statuses/${TARGET_SHA}`));
+  });
+});
+
+Deno.test("reportFailure writes rc context and tolerates status API failure", async () => {
+  const calls: Array<{ url: string; body: unknown }> = [];
+  await withMockedFetch((input, init) => {
+    const url = String(input);
+    calls.push({
+      url,
+      body: init?.body ? JSON.parse(String(init.body)) : null,
+    });
+    if (url.endsWith("/issues")) {
+      return Response.json({ html_url: "https://example.test/issue" });
+    }
+    return new Response("status api down", { status: 500 });
+  }, async () => {
+    const issueUrl = await reportFailure({
+      runId: "run-4",
+      trace: failedTrace(),
+      violations: [],
+      targetRef: "rc/2026-W22",
+      targetSha: TARGET_SHA,
+    });
+
+    assertEquals(issueUrl, "https://example.test/issue");
+    assertEquals(
+      (calls[1].body as { context: string }).context,
+      "rc-soak/backend-simulator",
+    );
+  });
+});
+
+Deno.test("reportFailure skips status write without a valid targetSha", async () => {
+  const calls: Array<{ url: string; body: unknown }> = [];
+  await withMockedFetch((input, init) => {
+    const url = String(input);
+    calls.push({
+      url,
+      body: init?.body ? JSON.parse(String(init.body)) : null,
+    });
+    return Response.json({ html_url: "https://example.test/issue" });
+  }, async () => {
+    await reportFailure({
+      runId: "run-5",
+      trace: failedTrace(),
+      violations: [],
+      targetRef: "dev",
+      targetSha: "short-sha",
+    });
+
+    assertEquals(calls.length, 1);
+    assert(calls[0].url.endsWith("/issues"));
+  });
+});
+
+Deno.test("reportFailure truncates oversized trace body", async () => {
+  const calls: Array<{ url: string; body: unknown }> = [];
+  const trace = failedTrace();
+  trace[0].error = "x".repeat(70_000);
+  await withMockedFetch((input, init) => {
+    const url = String(input);
+    calls.push({
+      url,
+      body: init?.body ? JSON.parse(String(init.body)) : null,
+    });
+    if (url.endsWith("/issues")) {
+      return Response.json({ html_url: "https://example.test/issue" });
+    }
+    return new Response("{}", { status: 201 });
+  }, async () => {
+    await reportFailure({
+      runId: "run-6",
+      trace,
+      violations: [],
+      targetRef: "dev",
+      targetSha: TARGET_SHA,
+    });
+
+    assert(
+      (calls[0].body as { body: string }).body.includes("...[truncated]"),
+    );
+  });
+});

--- a/supabase/functions/event-flow-simulator/core/reporter_test.ts
+++ b/supabase/functions/event-flow-simulator/core/reporter_test.ts
@@ -1,0 +1,103 @@
+import { assert, assertEquals } from "@std/assert";
+import { reportFailure } from "./reporter.ts";
+import type { Trace } from "./trace.ts";
+
+const TARGET_SHA = "0123456789abcdef0123456789abcdef01234567";
+
+function failedTrace(): Trace {
+  return [{
+    tick: 1,
+    actorId: "user-1",
+    action: {
+      type: "user_apply",
+      actorId: "user-1",
+      payload: {},
+      ef: "user-create-order",
+    },
+    status: 500,
+    ok: false,
+    error: "boom",
+  }];
+}
+
+async function withMockedFetch(
+  handler: (input: RequestInfo | URL, init?: RequestInit) => Response,
+  fn: () => Promise<void>,
+) {
+  const originalFetch = globalThis.fetch;
+  const originalToken = Deno.env.get("GITHUB_ACCESS_TOKEN");
+  globalThis.fetch =
+    ((input: RequestInfo | URL, init?: RequestInit) =>
+      Promise.resolve(handler(input, init))) as typeof fetch;
+  Deno.env.set("GITHUB_ACCESS_TOKEN", "test-token");
+  try {
+    await fn();
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalToken === undefined) {
+      Deno.env.delete("GITHUB_ACCESS_TOKEN");
+    } else {
+      Deno.env.set("GITHUB_ACCESS_TOKEN", originalToken);
+    }
+  }
+}
+
+Deno.test("reportFailure writes failure status even when issue creation fails", async () => {
+  const calls: Array<{ url: string; body: unknown }> = [];
+  await withMockedFetch((input, init) => {
+    const url = String(input);
+    calls.push({
+      url,
+      body: init?.body ? JSON.parse(String(init.body)) : null,
+    });
+    if (url.endsWith("/issues")) {
+      return new Response("issue api down", { status: 500 });
+    }
+    return new Response("{}", { status: 201 });
+  }, async () => {
+    const issueUrl = await reportFailure({
+      runId: "run-1",
+      trace: failedTrace(),
+      violations: [],
+      targetRef: "dev",
+      targetSha: TARGET_SHA,
+    });
+
+    assertEquals(issueUrl, null);
+    assertEquals(calls.length, 2);
+    assert(calls[1].url.endsWith(`/statuses/${TARGET_SHA}`));
+    assertEquals((calls[1].body as { state: string }).state, "failure");
+    assertEquals(
+      (calls[1].body as { context: string }).context,
+      "dev-soak/backend-simulator",
+    );
+  });
+});
+
+Deno.test("reportFailure includes issue URL in failure status when issue creation succeeds", async () => {
+  const calls: Array<{ url: string; body: unknown }> = [];
+  const htmlUrl = "https://github.com/Mark-Yun/minglit/issues/9999";
+  await withMockedFetch((input, init) => {
+    const url = String(input);
+    calls.push({
+      url,
+      body: init?.body ? JSON.parse(String(init.body)) : null,
+    });
+    if (url.endsWith("/issues")) {
+      return Response.json({ html_url: htmlUrl }, { status: 201 });
+    }
+    return new Response("{}", { status: 201 });
+  }, async () => {
+    const issueUrl = await reportFailure({
+      runId: "run-2",
+      trace: failedTrace(),
+      violations: [],
+      targetRef: "dev",
+      targetSha: TARGET_SHA,
+    });
+
+    assertEquals(issueUrl, htmlUrl);
+    assertEquals(calls.length, 2);
+    assertEquals((calls[1].body as { target_url: string }).target_url, htmlUrl);
+  });
+});

--- a/supabase/functions/event-flow-simulator/core/reporter_test.ts
+++ b/supabase/functions/event-flow-simulator/core/reporter_test.ts
@@ -20,6 +20,22 @@ function failedTrace(): Trace {
   }];
 }
 
+function oversizedFailedTrace(): Trace {
+  return [{
+    tick: 1,
+    actorId: "user-1",
+    action: {
+      type: "user_apply",
+      actorId: "user-1",
+      payload: {},
+      ef: "user-create-order",
+    },
+    status: 500,
+    ok: false,
+    error: "한".repeat(70_000),
+  }];
+}
+
 async function withMockedFetch(
   handler: (input: RequestInfo | URL, init?: RequestInit) => Response,
   fn: () => Promise<void>,
@@ -71,6 +87,115 @@ Deno.test("reportFailure writes failure status even when issue creation fails", 
       (calls[1].body as { context: string }).context,
       "dev-soak/backend-simulator",
     );
+  });
+});
+
+Deno.test("reportFailure truncates oversized trace payload in issue body", async () => {
+  const calls: Array<{ url: string; body: unknown }> = [];
+  await withMockedFetch((input, init) => {
+    const url = String(input);
+    calls.push({
+      url,
+      body: init?.body ? JSON.parse(String(init.body)) : null,
+    });
+    return Response.json(
+      { html_url: "https://github.com/Mark-Yun/minglit/issues/10000" },
+      { status: 201 },
+    );
+  }, async () => {
+    const issueUrl = await reportFailure({
+      runId: "run-oversized",
+      trace: oversizedFailedTrace(),
+      violations: [],
+    });
+
+    assertEquals(issueUrl, "https://github.com/Mark-Yun/minglit/issues/10000");
+    assertEquals(calls.length, 1);
+    const issueBody = (calls[0].body as { body: string }).body;
+    assert(issueBody.includes("...[truncated]"));
+  });
+});
+
+Deno.test("reportFailure returns null when issue request throws and still writes status", async () => {
+  const calls: Array<{ url: string; body: unknown }> = [];
+  await withMockedFetch((input, init) => {
+    const url = String(input);
+    calls.push({
+      url,
+      body: init?.body ? JSON.parse(String(init.body)) : null,
+    });
+    if (url.endsWith("/issues")) {
+      throw new Error("network down");
+    }
+    return new Response("{}", { status: 201 });
+  }, async () => {
+    const issueUrl = await reportFailure({
+      runId: "run-throw",
+      trace: failedTrace(),
+      violations: [],
+      targetRef: "dev",
+      targetSha: TARGET_SHA,
+    });
+
+    assertEquals(issueUrl, null);
+    assertEquals(calls.length, 2);
+    assert(calls[1].url.endsWith(`/statuses/${TARGET_SHA}`));
+  });
+});
+
+Deno.test("reportFailure swallows status API non-ok response and keeps issue URL", async () => {
+  const calls: Array<{ url: string; body: unknown }> = [];
+  const htmlUrl = "https://github.com/Mark-Yun/minglit/issues/10001";
+  await withMockedFetch((input, init) => {
+    const url = String(input);
+    calls.push({
+      url,
+      body: init?.body ? JSON.parse(String(init.body)) : null,
+    });
+    if (url.endsWith("/issues")) {
+      return Response.json({ html_url: htmlUrl }, { status: 201 });
+    }
+    return new Response("status write denied", { status: 403 });
+  }, async () => {
+    const issueUrl = await reportFailure({
+      runId: "run-status-non-ok",
+      trace: failedTrace(),
+      violations: [],
+      targetRef: "dev",
+      targetSha: TARGET_SHA,
+    });
+
+    assertEquals(issueUrl, htmlUrl);
+    assertEquals(calls.length, 2);
+    assert(calls[1].url.endsWith(`/statuses/${TARGET_SHA}`));
+  });
+});
+
+Deno.test("reportFailure swallows status API exception and keeps issue URL", async () => {
+  const calls: Array<{ url: string; body: unknown }> = [];
+  const htmlUrl = "https://github.com/Mark-Yun/minglit/issues/10002";
+  await withMockedFetch((input, init) => {
+    const url = String(input);
+    calls.push({
+      url,
+      body: init?.body ? JSON.parse(String(init.body)) : null,
+    });
+    if (url.endsWith("/issues")) {
+      return Response.json({ html_url: htmlUrl }, { status: 201 });
+    }
+    throw new Error("status write exploded");
+  }, async () => {
+    const issueUrl = await reportFailure({
+      runId: "run-status-throw",
+      trace: failedTrace(),
+      violations: [],
+      targetRef: "rc/2026-05",
+      targetSha: TARGET_SHA,
+    });
+
+    assertEquals(issueUrl, htmlUrl);
+    assertEquals(calls.length, 2);
+    assert(calls[1].url.endsWith(`/statuses/${TARGET_SHA}`));
   });
 });
 

--- a/supabase/functions/event-flow-simulator/index.ts
+++ b/supabase/functions/event-flow-simulator/index.ts
@@ -63,6 +63,8 @@ export const handler = async (
     usersPerTick?: number;
     partnersPerTick?: number;
     delayBetweenCallsMs?: number;
+    targetRef?: string;
+    targetSha?: string;
   } = {};
   try {
     if (req.headers.get("content-type")?.includes("application/json")) {
@@ -78,6 +80,12 @@ export const handler = async (
   const seed = positiveInteger(body.seed, Date.now());
   const usersPerTick = positiveInteger(body.usersPerTick, 10);
   const partnersPerTick = positiveInteger(body.partnersPerTick, 2);
+  const targetRef = typeof body.targetRef === "string"
+    ? body.targetRef
+    : undefined;
+  const targetSha = typeof body.targetSha === "string"
+    ? body.targetSha
+    : undefined;
   // Fix #2545: 기본 300ms throttle — Supabase 의 per-trace rate limit 회피.
   // 0 으로 명시하면 disable (unit test / 빠른 dev 용).
   const delayBetweenCallsMs = positiveInteger(body.delayBetweenCallsMs, 300);
@@ -93,6 +101,8 @@ export const handler = async (
       usersPerTick,
       partnersPerTick,
       delayBetweenCallsMs,
+      targetRef,
+      targetSha,
     },
   });
 
@@ -204,6 +214,8 @@ export const handler = async (
       runId,
       trace: cascade.trace,
       violations,
+      targetRef,
+      targetSha,
     });
 
     log({


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- add a dev-only deploy workflow that installs `dev-event-flow-simulator` pg_cron every 5 minutes
- make the GitHub monitor workflow manual dev smoke only, with explicit `--ref dev` behavior
- report simulator failures back to the target dev SHA via commit status and update soak docs/contracts

## Tests
- `python3 .github/scripts/check-dev-soak-workflow-contract.py`
- `ruby -e "require 'yaml'; %w[.github/workflows/deploy-dev-event-flow-cron.yml .github/workflows/monitor-event-flow-distributed.yml .github/workflows/dev-rc-cut-gate.yml].each { |f| YAML.load_file(f); puts f }"`
- `bash -n .github/scripts/install-dev-event-flow-cron.sh`
- `jq empty supabase/functions/auth-manifest.json`
- `deno test --allow-all --config supabase/functions/event-flow-simulator/deno.json supabase/functions/event-flow-simulator/`
- `git diff --check`

Fixes #2767