### PR TITLE
fix(ui): add 64px hero token for full-page empty states

### DIFF
--- a/apps/app_partner/lib/src/features/application/event_application_manage_tab.dart
+++ b/apps/app_partner/lib/src/features/application/event_application_manage_tab.dart
@@ -48,7 +48,7 @@ class _ApplicationTab extends ConsumerWidget {
               children: [
                 Icon(
                   Icons.assignment_outlined,
-                  size: MinglitIconSize.xlarge * 2,
+                  size: MinglitIconSize.hero,
                   color: Theme.of(context).colorScheme.onSurfaceVariant,
                 ),
                 const SizedBox(height: MinglitSpacing.medium),

--- a/apps/app_partner/lib/src/features/checkin/checkin_placeholder_page.dart
+++ b/apps/app_partner/lib/src/features/checkin/checkin_placeholder_page.dart
@@ -124,7 +124,7 @@ class _CheckinSelectionPage extends StatelessWidget {
               children: [
                 Icon(
                   Icons.qr_code_scanner,
-                  size: MinglitIconSize.xlarge * 2,
+                  size: MinglitIconSize.hero,
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
                 const SizedBox(height: MinglitSpacing.medium),

--- a/apps/app_partner/lib/src/features/party/list/party_list_page.dart
+++ b/apps/app_partner/lib/src/features/party/list/party_list_page.dart
@@ -106,8 +106,8 @@ class _PartyListEmptyState extends StatelessWidget {
           children: [
             Icon(
               Icons.celebration_outlined,
-              // Fix #2423: spec 64×64 — was hardcoded 56
-              size: MinglitIconSize.xlarge * 2,
+              // Fix #2423/#2422: full-page empty states use canonical hero icon size token.
+              size: MinglitIconSize.hero,
               color: theme.colorScheme.outlineVariant,
             ),
             const SizedBox(height: MinglitSpacing.medium),

--- a/apps/app_user/lib/src/features/auth/ui/auth_guard.dart
+++ b/apps/app_user/lib/src/features/auth/ui/auth_guard.dart
@@ -30,7 +30,7 @@ class AuthGuard extends ConsumerWidget {
           children: [
             Icon(
               Icons.lock_outline,
-              size: 64,
+              size: MinglitIconSize.hero,
               color: theme.colorScheme.onSurfaceVariant,
             ),
             const SizedBox(height: MinglitSpacing.medium),

--- a/apps/app_user/lib/src/features/home/my_page.dart
+++ b/apps/app_user/lib/src/features/home/my_page.dart
@@ -27,7 +27,7 @@ class MyPage extends ConsumerWidget {
             children: [
               Icon(
                 Icons.person_outline,
-                size: 64,
+                size: MinglitIconSize.hero,
                 color: theme.colorScheme.onSurfaceVariant,
               ),
               const SizedBox(height: MinglitSpacing.medium),

--- a/apps/app_user/lib/src/features/search/search_page.dart
+++ b/apps/app_user/lib/src/features/search/search_page.dart
@@ -97,7 +97,7 @@ class _SearchPageState extends ConsumerState<SearchPage> {
                   children: [
                     Icon(
                       Icons.search,
-                      size: 64,
+                      size: MinglitIconSize.hero,
                       color: Theme.of(context).colorScheme.outlineVariant,
                     ),
                     const SizedBox(height: MinglitSpacing.medium),
@@ -157,7 +157,7 @@ class _SearchPageState extends ConsumerState<SearchPage> {
                       children: [
                         Icon(
                           Icons.search_off_outlined,
-                          size: 64,
+                          size: MinglitIconSize.hero,
                           color: Theme.of(context).colorScheme.outlineVariant,
                         ),
                         const SizedBox(height: MinglitSpacing.medium),

--- a/apps/app_user/lib/src/features/tickets/my_tickets_page.dart
+++ b/apps/app_user/lib/src/features/tickets/my_tickets_page.dart
@@ -28,7 +28,7 @@ class MyTicketsPage extends ConsumerWidget {
                   children: [
                     Icon(
                       Icons.confirmation_number_outlined,
-                      size: MinglitIconSize.display,
+                      size: MinglitIconSize.hero,
                       color: Theme.of(context).colorScheme.outline,
                     ),
                     const SizedBox(height: MinglitSpacing.medium),

--- a/shared/packages/mds/core/lib/src/theme/minglit_design_tokens.dart
+++ b/shared/packages/mds/core/lib/src/theme/minglit_design_tokens.dart
@@ -244,6 +244,10 @@ class MinglitIconSize {
   /// 48px display icon size — empty state full-page variant.
   // TODO(mds-tokens): add iconSizeDisplay to tokens.json and migrate
   static const double display = 48;
+
+  /// 64px hero icon size for full-page empty states.
+  // TODO(mds-tokens): add iconSizeHero to tokens.json and migrate
+  static const double hero = 64;
 }
 
 /// Partner app brand colors — same purple family, toned down for business feel.

--- a/shared/packages/mds/core/lib/src/ui/widgets/common/minglit_empty_state.dart
+++ b/shared/packages/mds/core/lib/src/ui/widgets/common/minglit_empty_state.dart
@@ -4,7 +4,7 @@ import 'package:mds/src/theme/minglit_theme.dart';
 /// Visual variant of [MinglitEmptyState].
 enum MinglitEmptyStateVariant {
   /// Full-page empty state — tab or page level.
-  /// Shows 48px icon with `outline` color. Transparent background. Optional CTA.
+  /// Shows 64px icon with `outline` color. Transparent background. Optional CTA.
   fullPage,
 
   /// Card/section-level empty state.
@@ -102,7 +102,7 @@ class MinglitEmptyState extends StatelessWidget {
                 icon,
                 size: variant == MinglitEmptyStateVariant.card
                     ? MinglitIconSize.xlarge
-                    : MinglitIconSize.display,
+                    : MinglitIconSize.hero,
                 color: variant == MinglitEmptyStateVariant.card
                     ? theme.colorScheme.outlineVariant
                     : theme.colorScheme.outline,

--- a/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_empty_state_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/common/minglit_empty_state_test.dart
@@ -130,13 +130,13 @@ void main() {
       expect(widget.variant, equals(MinglitEmptyStateVariant.fullPage));
     });
 
-    testWidgets('fullPage renders 48px icon (display size)', (tester) async {
+    testWidgets('fullPage renders 64px icon (hero size)', (tester) async {
       await tester.pumpWidget(
         wrap(const MinglitEmptyState(title: '빈 상태')),
       );
 
       final icon = tester.widget<Icon>(find.byType(Icon));
-      expect(icon.size, equals(MinglitIconSize.display));
+      expect(icon.size, equals(MinglitIconSize.hero));
     });
 
     testWidgets(


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- Added `MinglitIconSize.hero` (64px) in MDS tokens.
- Switched `MinglitEmptyState.fullPage` icon size from `display` to `hero`.
- Replaced hardcoded `64` / `xlarge * 2` full-page empty-state icon sizes in affected app_user/app_partner screens with `MinglitIconSize.hero`.
- Updated empty-state widget test expectation to guard 64px full-page behavior.

## Why
- Implements #2422 option A decision (`/needs-swe 옵션 a`) by introducing a canonical 64px hero icon token and applying it consistently.

Fixes #2422
Fixes #2425

## UI Spec References
- Screen specs:
  - `apps/mds/docs/public/specs/party_list_page/index.html` (Empty state section, icon 64x64)
  - `apps/mds/docs/public/specs/checkin_placeholder_page/index.html` (Empty state section, `qr_code_scanner` xlarge*2 ≈ 64)
  - `apps/mds/docs/public/specs/event_application_manage_page/index.html` (Empty state section, icon 64x64)
  - `apps/mds/docs/public/specs/search_page/index.html` (Empty / Empty results sections, icon 64x64)
  - `apps/mds/docs/public/specs/my_page/index.html` (logged-out empty state section, icon 64x64)
  - `apps/mds/docs/public/specs/my_tickets_page/index.html` (empty state icon section)
- Component spec:
  - `apps/mds/docs/src/lib/components.ts` (`MinglitEmptyState` component definition and `fullPage` variant guidance)

## Verification
- `dart format` on changed Dart files
- `flutter test test/src/ui/widgets/common/minglit_empty_state_test.dart` (workdir: `shared/packages/minglit_kit`)

## Risks
- `my_tickets_page` spec currently still documents 48px SVG in one block; this PR aligns implementation with option A policy (64px hero token). If spec artifact has stale 48 text, spec sync follow-up may still be needed.
