### PR TITLE
feat(mds-render): add purchase_history_page catalog

### DIFF
--- a/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
@@ -49,6 +49,7 @@ Phase 2 (TODO, follow-up PR) — `_manifest.yaml`, coverage report, scaffold 결
 | `notification_list_screen` | loaded · empty |
 | `notification_settings_screen` | default |
 | `privacy_page` | loading · loaded · dark |
+| `purchase_history_page` | default · empty · loading · error |
 | `search_page` | idle · results · empty |
 | `event_now_bar` | waiting · check-in-ready · checked-in · matching · results · ended · offline |
 | `event_ongoing_banner` | 8 phases + dark |
@@ -70,4 +71,4 @@ MDS spec 디렉토리명과 동일 (per-screen, snake_case). 화면당 `builder.
 - [상위 BLUEDOC](../BLUEDOC.md) · 페어 워크플로우: `sync-mds-mockups.yml` (디자인 PNG)
 
 ---
-_Reviewed: 2026-05-27 21:05_
+_Reviewed: 2026-05-28 00:20_

--- a/apps/app_user/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_registry.dart
@@ -35,6 +35,8 @@ import 'notification_list_screen/notification_list_screen_test.dart'
 import 'notification_settings_screen/notification_settings_screen_test.dart'
     as notification_settings_screen;
 import 'privacy_page/privacy_page_test.dart' as privacy_page;
+import 'purchase_history_page/purchase_history_page_test.dart'
+    as purchase_history_page;
 import 'search_page/search_page_test.dart' as search_page;
 import 'signup_consent_page/signup_consent_page_test.dart'
     as signup_consent_page;
@@ -64,6 +66,7 @@ final List<MdsCatalog<MdsScreenBuilder<dynamic>>> allCatalogs = [
   notification_list_screen.catalog,
   notification_settings_screen.catalog,
   privacy_page.catalog,
+  purchase_history_page.catalog,
   search_page.catalog,
   signup_consent_page.catalog,
   tag_event_list_page.catalog,

--- a/apps/app_user/integration_test/mds-emulator-render/purchase_history_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/purchase_history_page/builder.dart
@@ -1,0 +1,138 @@
+// PurchaseHistoryPageBuilder — purchase_history_page 전용 fluent API.
+
+import 'dart:async';
+
+import 'package:app_user/src/features/payment/logic/purchase_history_controller.dart';
+import 'package:app_user/src/features/payment/ui/purchase_history_page.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+
+class _FixedPurchaseHistoryController extends PurchaseHistoryController {
+  _FixedPurchaseHistoryController(this._history);
+  final List<EventApplication> _history;
+
+  @override
+  FutureOr<List<EventApplication>> build() async => _history;
+}
+
+class _LoadingPurchaseHistoryController extends PurchaseHistoryController {
+  @override
+  FutureOr<List<EventApplication>> build() =>
+      Completer<List<EventApplication>>().future;
+}
+
+class _ErrorPurchaseHistoryController extends PurchaseHistoryController {
+  @override
+  FutureOr<List<EventApplication>> build() async =>
+      throw Exception('render: forced error');
+}
+
+final _base = DateTime(2026, 5, 20, 10);
+
+EventApplication _application({
+  required String id,
+  required String title,
+  required String ticketName,
+  required String status,
+  required int amount,
+  required DateTime startTime,
+}) {
+  final event = Event(
+    id: 'event-$id',
+    partyId: 'party-$id',
+    title: title,
+    startTime: startTime,
+    endTime: startTime.add(const Duration(hours: 2)),
+    createdAt: _base,
+    updatedAt: _base,
+    location: Location(
+      id: 'loc-$id',
+      partnerId: 'partner-$id',
+      name: '강남 밍글홀',
+      address: '서울 강남구 테헤란로 101',
+      createdAt: _base,
+      updatedAt: _base,
+    ),
+  );
+
+  return EventApplication(
+    id: id,
+    eventId: event.id,
+    ticketId: 'ticket-$id',
+    userId: 'user-render-1',
+    status: status,
+    paymentAmount: amount,
+    paymentId: 'pay-$id',
+    paidAt: _base,
+    createdAt: _base,
+    updatedAt: _base,
+    event: event,
+    ticket: Ticket(
+      id: 'ticket-$id',
+      name: ticketName,
+      price: amount,
+      createdAt: _base,
+      updatedAt: _base,
+    ),
+  );
+}
+
+final _defaultHistory = <EventApplication>[
+  _application(
+    id: 'app-1',
+    title: '강남 소셜 밍글',
+    ticketName: '얼리버드 1인',
+    status: 'paid',
+    amount: 29000,
+    startTime: DateTime(2026, 5, 18, 19),
+  ),
+  _application(
+    id: 'app-2',
+    title: '홍대 프라이데이 파티',
+    ticketName: '스탠다드 1인',
+    status: 'cancelled',
+    amount: 15000,
+    startTime: DateTime(2026, 5, 12, 20),
+  ),
+];
+
+class PurchaseHistoryPageBuilder extends MdsScreenBuilder<PurchaseHistoryPage> {
+  PurchaseHistoryPageBuilder() : super(page: const PurchaseHistoryPage());
+
+  /// 기본 상태: 구매 이력 2건 표시.
+  void withDefault() {
+    addOverride(
+      purchaseHistoryControllerProvider.overrideWith(
+        () => _FixedPurchaseHistoryController(_defaultHistory),
+      ),
+    );
+  }
+
+  /// 빈 상태.
+  void withEmpty() {
+    addOverride(
+      purchaseHistoryControllerProvider.overrideWith(
+        () => _FixedPurchaseHistoryController(const []),
+      ),
+    );
+  }
+
+  /// 로딩 상태.
+  void withLoading() {
+    addOverride(
+      purchaseHistoryControllerProvider.overrideWith(
+        _LoadingPurchaseHistoryController.new,
+      ),
+    );
+  }
+
+  /// 에러 상태.
+  void withError() {
+    addOverride(
+      purchaseHistoryControllerProvider.overrideWith(
+        _ErrorPurchaseHistoryController.new,
+      ),
+    );
+  }
+}

--- a/apps/app_user/integration_test/mds-emulator-render/purchase_history_page/purchase_history_page_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/purchase_history_page/purchase_history_page_test.dart
@@ -1,0 +1,52 @@
+// MDS screen: purchase_history_page
+// 대응 MDS: apps/mds/docs/public/specs/purchase_history_page/
+//
+// 출력: docs/infra/mds-emulator-render/purchase_history_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<PurchaseHistoryPageBuilder>(
+  screen: 'purchase_history_page',
+  mdsSpec: 'apps/mds/docs/public/specs/purchase_history_page/',
+  builder: PurchaseHistoryPageBuilder.new,
+  states: [
+    MdsState(
+      'state-default',
+      (b) {
+        b.withDefault();
+        return b;
+      },
+      mdsIndex: 1,
+    ),
+    MdsState(
+      'state-empty',
+      (b) {
+        b.withEmpty();
+        return b;
+      },
+      mdsIndex: 2,
+    ),
+    MdsState(
+      'state-loading',
+      (b) {
+        b.withLoading();
+        return b;
+      },
+      mdsIndex: 3,
+      infiniteAnimation: true,
+    ),
+    MdsState(
+      'state-error',
+      (b) {
+        b.withError();
+        return b;
+      },
+      mdsIndex: 4,
+    ),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- add `purchase_history_page` MDS emulator render catalog (`builder.dart`, `purchase_history_page_test.dart`)
- model 4 deterministic states from spec via `purchaseHistoryControllerProvider` overrides: default/empty/loading/error
- register catalog in `_registry.dart` and update app_user mds-emulator-render BLUEDOC screen table

## Why
- issue #2819 tracks uncovered/incomplete MDS render coverage slices
- this PR removes one uncovered screen (`purchase_history_page`) from coverage backlog

## Verification
- `flutter analyze integration_test/mds-emulator-render/purchase_history_page` (cwd: `apps/app_user`)
- `dart run scripts/mds_render_coverage.dart --json | jq ...` (verified `purchase_history_page` is not in `uncovered_screens`)

Refs #2819 (aggregate coverage tracker; not closed because many uncovered/incomplete screens remain)