### PR TITLE
feat(app_user): add purchase_history_detail_page render catalog

### DIFF
--- a/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
@@ -50,6 +50,7 @@ Phase 2 (TODO, follow-up PR) — `_manifest.yaml`, coverage report, scaffold 결
 | `notification_settings_screen` | default |
 | `privacy_page` | loading · loaded · dark |
 | `purchase_history_page` | default · empty · loading · error |
+| `purchase_history_detail_page` | default · cancel-disabled · refunded · payment-failed · loading · error |
 | `search_page` | idle · results · empty |
 | `event_now_bar` | waiting · check-in-ready · checked-in · matching · results · ended · offline |
 | `event_ongoing_banner` | 8 phases + dark |
@@ -71,4 +72,4 @@ MDS spec 디렉토리명과 동일 (per-screen, snake_case). 화면당 `builder.
 - [상위 BLUEDOC](../BLUEDOC.md) · 페어 워크플로우: `sync-mds-mockups.yml` (디자인 PNG)
 
 ---
-_Reviewed: 2026-05-28 00:20_
+_Reviewed: 2026-05-28 03:30_

--- a/apps/app_user/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_registry.dart
@@ -37,6 +37,8 @@ import 'notification_settings_screen/notification_settings_screen_test.dart'
 import 'privacy_page/privacy_page_test.dart' as privacy_page;
 import 'purchase_history_page/purchase_history_page_test.dart'
     as purchase_history_page;
+import 'purchase_history_detail_page/purchase_history_detail_page_test.dart'
+    as purchase_history_detail_page;
 import 'search_page/search_page_test.dart' as search_page;
 import 'signup_consent_page/signup_consent_page_test.dart'
     as signup_consent_page;
@@ -67,6 +69,7 @@ final List<MdsCatalog<MdsScreenBuilder<dynamic>>> allCatalogs = [
   notification_settings_screen.catalog,
   privacy_page.catalog,
   purchase_history_page.catalog,
+  purchase_history_detail_page.catalog,
   search_page.catalog,
   signup_consent_page.catalog,
   tag_event_list_page.catalog,

--- a/apps/app_user/integration_test/mds-emulator-render/purchase_history_detail_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/purchase_history_detail_page/builder.dart
@@ -74,7 +74,7 @@ EventApplication _application({
 final EventApplication _defaultApplication = _application(
   status: 'paid',
   refundStatus: 'none',
-  eventStartTime: DateTime.now().add(const Duration(days: 3)),
+  eventStartTime: _base.add(const Duration(days: 3)),
   paymentId: 'pay-render-1',
   paymentAmount: 29000,
 );
@@ -82,7 +82,7 @@ final EventApplication _defaultApplication = _application(
 final EventApplication _disabledCancelApplication = _application(
   status: 'paid',
   refundStatus: 'none',
-  eventStartTime: DateTime.now().subtract(const Duration(days: 1)),
+  eventStartTime: _base.subtract(const Duration(days: 1)),
   paymentId: 'pay-render-2',
   paymentAmount: 29000,
 );
@@ -90,7 +90,7 @@ final EventApplication _disabledCancelApplication = _application(
 final EventApplication _refundedApplication = _application(
   status: 'cancelled',
   refundStatus: 'completed',
-  eventStartTime: DateTime.now().add(const Duration(days: 3)),
+  eventStartTime: _base.add(const Duration(days: 3)),
   paymentId: 'pay-render-3',
   paymentAmount: 29000,
 );
@@ -98,7 +98,7 @@ final EventApplication _refundedApplication = _application(
 final EventApplication _paymentFailedApplication = _application(
   status: 'payment_failed',
   refundStatus: 'none',
-  eventStartTime: DateTime.now().add(const Duration(days: 3)),
+  eventStartTime: _base.add(const Duration(days: 3)),
   paymentId: '',
   paymentAmount: 29000,
 );

--- a/apps/app_user/integration_test/mds-emulator-render/purchase_history_detail_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/purchase_history_detail_page/builder.dart
@@ -1,0 +1,150 @@
+// PurchaseHistoryDetailPageBuilder
+// — purchase_history_detail_page 전용 fluent API.
+
+import 'dart:async';
+
+import 'package:app_user/src/features/payment/logic/purchase_history_detail_controller.dart';
+import 'package:app_user/src/features/payment/ui/purchase_history_detail_page.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+
+const String _applicationId = 'render-app-1';
+final DateTime _base = DateTime(2026, 5, 20, 10);
+
+EventApplication _application({
+  required String status,
+  required String refundStatus,
+  required DateTime eventStartTime,
+  required String paymentId,
+  required int paymentAmount,
+}) {
+  final party = Party(
+    id: 'party-1',
+    partnerId: 'partner-1',
+    title: '강남 밍글 클럽',
+    createdAt: _base,
+    updatedAt: _base,
+  );
+
+  final location = Location(
+    id: 'loc-1',
+    partnerId: 'partner-1',
+    name: '밍글 강남점',
+    address: '서울 강남구 테헤란로 101',
+    createdAt: _base,
+    updatedAt: _base,
+  );
+
+  final event = Event(
+    id: 'event-1',
+    partyId: party.id,
+    title: '강남 네트워킹 나이트',
+    startTime: eventStartTime,
+    endTime: eventStartTime.add(const Duration(hours: 3)),
+    createdAt: _base,
+    updatedAt: _base,
+    party: party,
+    location: location,
+  );
+
+  return EventApplication(
+    id: _applicationId,
+    eventId: event.id,
+    ticketId: 'ticket-1',
+    userId: 'user-render-1',
+    status: status,
+    refundStatus: refundStatus,
+    paymentAmount: paymentAmount,
+    paymentId: paymentId.isEmpty ? null : paymentId,
+    paidAt: _base,
+    createdAt: _base,
+    updatedAt: _base,
+    event: event,
+    ticket: Ticket(
+      id: 'ticket-1',
+      name: '일반 1인권',
+      price: paymentAmount,
+      createdAt: _base,
+      updatedAt: _base,
+    ),
+  );
+}
+
+final EventApplication _defaultApplication = _application(
+  status: 'paid',
+  refundStatus: 'none',
+  eventStartTime: DateTime.now().add(const Duration(days: 3)),
+  paymentId: 'pay-render-1',
+  paymentAmount: 29000,
+);
+
+final EventApplication _disabledCancelApplication = _application(
+  status: 'paid',
+  refundStatus: 'none',
+  eventStartTime: DateTime.now().subtract(const Duration(days: 1)),
+  paymentId: 'pay-render-2',
+  paymentAmount: 29000,
+);
+
+final EventApplication _refundedApplication = _application(
+  status: 'cancelled',
+  refundStatus: 'completed',
+  eventStartTime: DateTime.now().add(const Duration(days: 3)),
+  paymentId: 'pay-render-3',
+  paymentAmount: 29000,
+);
+
+final EventApplication _paymentFailedApplication = _application(
+  status: 'payment_failed',
+  refundStatus: 'none',
+  eventStartTime: DateTime.now().add(const Duration(days: 3)),
+  paymentId: '',
+  paymentAmount: 29000,
+);
+
+class PurchaseHistoryDetailPageBuilder
+    extends MdsScreenBuilder<PurchaseHistoryDetailPage> {
+  PurchaseHistoryDetailPageBuilder()
+    : super(
+        page: const PurchaseHistoryDetailPage(applicationId: _applicationId),
+      );
+
+  void _withApplication(EventApplication? application) {
+    addOverride(
+      purchaseHistoryDetailProvider(
+        _applicationId,
+      ).overrideWith((_) async => application),
+    );
+  }
+
+  /// 기본 상태: 환불 가능한 결제 내역.
+  void withDefault() => _withApplication(_defaultApplication);
+
+  /// 환불 불가 상태: 이벤트 시작 이후로 취소 버튼 disabled.
+  void withCancelDisabled() => _withApplication(_disabledCancelApplication);
+
+  /// 환불 완료 상태: 환불 정보 카드 노출.
+  void withRefunded() => _withApplication(_refundedApplication);
+
+  /// 결제 실패 상태.
+  void withPaymentFailed() => _withApplication(_paymentFailedApplication);
+
+  /// 로딩 상태.
+  void withLoading() {
+    addOverride(
+      purchaseHistoryDetailProvider(
+        _applicationId,
+      ).overrideWith((_) => Completer<EventApplication?>().future),
+    );
+  }
+
+  /// 에러 상태.
+  void withError() {
+    addOverride(
+      purchaseHistoryDetailProvider(
+        _applicationId,
+      ).overrideWith((_) async => throw Exception('render: forced error')),
+    );
+  }
+}

--- a/apps/app_user/integration_test/mds-emulator-render/purchase_history_detail_page/purchase_history_detail_page_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/purchase_history_detail_page/purchase_history_detail_page_test.dart
@@ -1,0 +1,68 @@
+// MDS screen: purchase_history_detail_page
+// 대응 MDS: apps/mds/docs/public/specs/purchase_history_detail_page/
+//
+// 출력: docs/infra/mds-emulator-render/purchase_history_detail_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<PurchaseHistoryDetailPageBuilder>(
+  screen: 'purchase_history_detail_page',
+  mdsSpec: 'apps/mds/docs/public/specs/purchase_history_detail_page/',
+  builder: PurchaseHistoryDetailPageBuilder.new,
+  states: [
+    MdsState(
+      'state-default',
+      (b) {
+        b.withDefault();
+        return b;
+      },
+      mdsIndex: 1,
+    ),
+    MdsState(
+      'state-cancel-disabled',
+      (b) {
+        b.withCancelDisabled();
+        return b;
+      },
+      mdsIndex: 2,
+    ),
+    MdsState(
+      'state-refunded',
+      (b) {
+        b.withRefunded();
+        return b;
+      },
+      mdsIndex: 3,
+    ),
+    MdsState(
+      'state-payment-failed',
+      (b) {
+        b.withPaymentFailed();
+        return b;
+      },
+      mdsIndex: 4,
+    ),
+    MdsState(
+      'state-loading',
+      (b) {
+        b.withLoading();
+        return b;
+      },
+      mdsIndex: 5,
+      infiniteAnimation: true,
+    ),
+    MdsState(
+      'state-error',
+      (b) {
+        b.withError();
+        return b;
+      },
+      mdsIndex: 6,
+    ),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- add new MDS emulator render catalog for `purchase_history_detail_page` with deterministic provider overrides
- cover key detail branches: default, cancel-disabled, refunded, payment-failed, loading, error
- register catalog in `_registry.dart` and update mds-emulator-render BLUEDOC table/reviewed timestamp
- replace `DateTime.now()` fixture timestamps with fixed `_base`-relative values to keep PNG output deterministic across days

## Verification
- `flutter analyze integration_test/mds-emulator-render/purchase_history_detail_page` (cwd: `apps/app_user`)
- `dart run scripts/mds_render_coverage.dart --json` (confirmed `purchase_history_detail_page` removed from `uncovered_screens`; `cataloged_screens: 33`, `screen_coverage_pct: 50.0`)

## Issue Link
- Refs #2819 (partial work for tracking issue; this PR handles one screen slice)