### PR TITLE
test(app_user): stabilize purchase_history_detail_page render states

### DIFF
--- a/apps/app_user/integration_test/mds-emulator-render/purchase_history_detail_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/purchase_history_detail_page/builder.dart
@@ -11,6 +11,8 @@ import '../_engine/builder.dart';
 
 const String _applicationId = 'render-app-1';
 final DateTime _base = DateTime(2026, 5, 20, 10);
+final DateTime _cancelEnabledEventStart = DateTime(2099, 1, 1, 20);
+final DateTime _cancelDisabledEventStart = DateTime(2020, 1, 1, 20);
 
 EventApplication _application({
   required String status,
@@ -74,7 +76,7 @@ EventApplication _application({
 final EventApplication _defaultApplication = _application(
   status: 'paid',
   refundStatus: 'none',
-  eventStartTime: _base.add(const Duration(days: 3)),
+  eventStartTime: _cancelEnabledEventStart,
   paymentId: 'pay-render-1',
   paymentAmount: 29000,
 );
@@ -82,7 +84,7 @@ final EventApplication _defaultApplication = _application(
 final EventApplication _disabledCancelApplication = _application(
   status: 'paid',
   refundStatus: 'none',
-  eventStartTime: _base.subtract(const Duration(days: 1)),
+  eventStartTime: _cancelDisabledEventStart,
   paymentId: 'pay-render-2',
   paymentAmount: 29000,
 );
@@ -90,7 +92,7 @@ final EventApplication _disabledCancelApplication = _application(
 final EventApplication _refundedApplication = _application(
   status: 'cancelled',
   refundStatus: 'completed',
-  eventStartTime: _base.add(const Duration(days: 3)),
+  eventStartTime: _cancelEnabledEventStart,
   paymentId: 'pay-render-3',
   paymentAmount: 29000,
 );
@@ -98,7 +100,7 @@ final EventApplication _refundedApplication = _application(
 final EventApplication _paymentFailedApplication = _application(
   status: 'payment_failed',
   refundStatus: 'none',
-  eventStartTime: _base.add(const Duration(days: 3)),
+  eventStartTime: _cancelEnabledEventStart,
   paymentId: '',
   paymentAmount: 29000,
 );


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## What
- make `purchase_history_detail_page` render catalog state fixtures time-stable
- split event start timestamps into deterministic constants:
  - cancel-enabled states: far-future fixed datetime
  - cancel-disabled state: past fixed datetime

## Why
- previous fixtures used `_base +/- Duration(...)`, which became past relative to runtime date and collapsed `state-default` into disabled state
- this caused non-deterministic render state coverage in long-running CI cycles

## Verification
- `flutter analyze integration_test/mds-emulator-render/purchase_history_detail_page` (cwd: `apps/app_user`)

## Risk
- low: test fixture timestamp constants only, no production runtime logic change

## Issue Lifecycle
- partial follow-up for #2819: this PR only stabilizes `purchase_history_detail_page` fixtures and does not close the remaining coverage backlog

Refs #2819
