### PR TITLE
test(cuj): add discovery/tag-discovery CUJ tests (1-2,1-3,1-4,2-1,2-2,2-3,3-1,3-2,3-3,3-4,4-1,4-2,4-3)

### DIFF
--- a/apps/app_partner/integration_test/cuj/BLUEDOC.md
+++ b/apps/app_partner/integration_test/cuj/BLUEDOC.md
@@ -32,6 +32,8 @@ integration_test/cuj/
     partner_account_deletion_test.dart
   checkin/
     partner_qr_checkin_ux_test.dart  # CUJ 1-1~1-4, 2-1~2-3, 3-1~3-6
+  discovery/
+    tag_discovery_test.dart          # CUJ 2-1~2-3, 3-1~3-4, 4-1~4-3
   event/
     event_edit_cancel_test.dart      # CUJ 1-1~4-2
     recurring_events_test.dart       # CUJ 1-1, 1-2, 1-4, 3-1, 3-2, 3-4
@@ -49,6 +51,7 @@ integration_test/cuj/
 | `account/partner_terms_privacy_test.dart` | `docs/features/account/partner-terms-privacy/spec.md` | 1-1 (이용약관 탭+URL), 2-1 (개인정보처리방침 탭+URL) |
 | `account/partner_account_deletion_test.dart` | `docs/features/account/partner-account-deletion/spec.md` | 탈퇴 사유 화면 |
 | `checkin/partner_qr_checkin_ux_test.dart` | `docs/features/event-operation/partner-qr-checkin-ux/spec.md` | 1-1~1-4 (스캔 결과 배너), 2-1~2-3 (체크인 탭 진입), 3-1~3-6 (수동 체크인) |
+| `discovery/tag_discovery_test.dart` | `docs/features/discovery/tag-discovery/spec.md` | 2-1~2-3 (태그 자동완성/빈 결과), 3-1~3-4 (태그 선택/변경), 4-1~4-3 (파티 생성·편집 태그 선택) |
 | `event/event_edit_cancel_test.dart` | `docs/features/event/event-edit-cancel/spec.md` | 1-1~4-2 (13개 그룹) |
 | `event/recurring_events_test.dart` | `docs/features/event/recurring-events/spec.md` | 1-1~1-4, 2-1~2-3, 3-1~3-4, 4-1~4-2 |
 | `event/partner_dashboard_test.dart` | `docs/features/event/partner-dashboard/spec.md` | 1-1~1-5, 2-1~2-5, 3-1~3-3, 4-2~4-3, 5-1~5-2 |
@@ -58,4 +61,4 @@ integration_test/cuj/
 Flutter 범위 외 CUJ (landing_partner 웹 기능 또는 미구현): 1-2, 1-3, 2-2~2-4, 3-1~3-2.
 
 ---
-_Reviewed: 2026-05-28 04:10_
+_Reviewed: 2026-05-28 08:15_

--- a/apps/app_partner/integration_test/cuj/discovery/tag_discovery_test.dart
+++ b/apps/app_partner/integration_test/cuj/discovery/tag_discovery_test.dart
@@ -1,0 +1,330 @@
+// CUJ tests — discovery / tag-discovery (partner/search scope)
+//
+// 대응 spec: docs/features/discovery/tag-discovery/spec.md
+// CUJ 추가 시 본 파일에 `cujGroup` 블록 추가 (새 파일 X).
+
+import 'package:app_partner/src/features/party/create/party_create_wizard_controller.dart';
+import 'package:app_partner/src/features/party/create/widgets/tag_selection_section.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../_engine/cuj_test.dart';
+
+class _MockTagRepository extends Mock implements TagRepository {}
+
+Tag _tag(String id, String name) => Tag(id: id, name: name);
+
+Event _event(int index) => Event(
+  id: 'event-$index',
+  partyId: 'party-$index',
+  title: '추천 이벤트 $index',
+  startTime: DateTime(2026, 6, index + 1),
+  endTime: DateTime(2026, 6, index + 1, 2),
+  createdAt: DateTime(2026),
+  updatedAt: DateTime(2026),
+);
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MockTagRepository mockTagRepo;
+
+  setUp(() {
+    mockTagRepo = _MockTagRepository();
+
+    when(() => mockTagRepo.getFeaturedTags()).thenAnswer(
+      (_) async => [
+        _tag('tag-1', '소개팅'),
+        _tag('tag-2', '요가'),
+        _tag('tag-3', '러닝'),
+        _tag('tag-4', '와인'),
+        _tag('tag-5', '클럽'),
+        _tag('tag-6', '루프탑'),
+      ],
+    );
+    when(() => mockTagRepo.searchTags(any())).thenAnswer(
+      (_) async => [_tag('tag-3', '러닝'), _tag('tag-7', '러닝크루')],
+    );
+    when(() => mockTagRepo.getTagsByIds(any())).thenAnswer((invocation) async {
+      final ids = invocation.positionalArguments.first as List<String>;
+      final all = <Tag>[
+        _tag('tag-1', '소개팅'),
+        _tag('tag-2', '요가'),
+        _tag('tag-3', '러닝'),
+        _tag('tag-4', '와인'),
+        _tag('tag-5', '클럽'),
+        _tag('tag-6', '루프탑'),
+      ];
+      return all.where((t) => ids.contains(t.id)).toList();
+    });
+    when(
+      () => mockTagRepo.getTagRecommendations(),
+    ).thenAnswer((_) async => [_event(1), _event(2)]);
+    when(() => mockTagRepo.getUserInterestTags()).thenAnswer(
+      (_) async => [_tag('tag-1', '소개팅'), _tag('tag-3', '러닝')],
+    );
+  });
+
+  List<dynamic> base() => [
+    tagRepositoryProvider.overrideWithValue(mockTagRepo),
+  ];
+
+  Widget sectionApp() => const Scaffold(
+    body: SingleChildScrollView(
+      padding: EdgeInsets.all(MinglitSpacing.medium),
+      child: TagSelectionSection(),
+    ),
+  );
+
+  // ---------------------------------------------------------------------------
+  // CUJ 2-1: 검색 시 태그 자동완성
+  // ---------------------------------------------------------------------------
+  cujGroup('2-1', '검색 시 태그 자동완성', () {
+    cujCase(
+      'happy: 500ms 디바운스 후 자동완성 태그 노출',
+      app: sectionApp(),
+      overrides: base,
+      body: (t) async {
+        await t.enterText(find.byType(TextField), '러닝');
+        await t.pump(const Duration(milliseconds: 499));
+        expect(find.text('#러닝'), findsNothing);
+
+        await t.pump(const Duration(milliseconds: 1));
+        await t.pumpAndSettle();
+
+        expect(find.text('#러닝'), findsOneWidget);
+        expect(find.text('#러닝크루'), findsOneWidget);
+        verify(() => mockTagRepo.searchTags('러닝')).called(1);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 2-2: 검색어 없을 때 인기 태그 표시
+  // ---------------------------------------------------------------------------
+  cujGroup('2-2', '검색어 없을 때 인기 태그 표시', () {
+    cujCase(
+      'happy: 초기 진입 시 인기 태그 섹션 노출',
+      app: sectionApp(),
+      overrides: base,
+      body: (t) async {
+        expect(find.text('인기 태그'), findsOneWidget);
+        expect(find.text('#소개팅'), findsOneWidget);
+        expect(find.text('#요가'), findsOneWidget);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 2-3: 자동완성 결과 0건
+  // ---------------------------------------------------------------------------
+  cujGroup('2-3', '자동완성 결과 0건', () {
+    cujCase(
+      'edge: 일치 태그 없음 안내 노출',
+      app: sectionApp(),
+      overrides: () {
+        when(() => mockTagRepo.searchTags('없는태그')).thenAnswer(
+          (_) async => const [],
+        );
+        return base();
+      },
+      body: (t) async {
+        await t.enterText(find.byType(TextField), '없는태그');
+        await t.pump(const Duration(milliseconds: 500));
+        await t.pumpAndSettle();
+
+        expect(find.text('일치하는 태그가 없어요'), findsOneWidget);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 3-1: 관심 태그 3개 이상 선택
+  // ---------------------------------------------------------------------------
+  cujGroup('3-1', '관심 태그 3개 이상 선택', () {
+    cujCase(
+      'happy: 3개 선택 시 선택된 태그 목록에 반영',
+      app: sectionApp(),
+      overrides: base,
+      body: (t) async {
+        await t.tap(find.text('#소개팅'));
+        await t.pumpAndSettle();
+        await t.tap(find.text('#요가'));
+        await t.pumpAndSettle();
+        await t.tap(find.text('#러닝'));
+        await t.pumpAndSettle();
+
+        expect(find.text('선택된 태그'), findsOneWidget);
+        expect(find.byType(InputChip), findsNWidgets(3));
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 3-2: 온보딩 건너뛰기
+  // ---------------------------------------------------------------------------
+  cujGroup('3-2', '온보딩 건너뛰기', () {
+    cujCase(
+      'happy: 미선택 상태 유지 시 wizard tagIds 빈 배열',
+      app: sectionApp(),
+      overrides: base,
+      body: (t) async {
+        final container = ProviderScope.containerOf(
+          t.element(find.byType(Scaffold)),
+        );
+        final tagIds = container
+            .read(partyCreateWizardControllerProvider)
+            .tagIds;
+
+        expect(find.text('선택된 태그'), findsNothing);
+        expect(tagIds, isEmpty);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 3-3: 관심사 추천 피드 노출
+  // ---------------------------------------------------------------------------
+  cujGroup('3-3', '관심사 추천 피드 노출', () {
+    cujCase(
+      'happy: 추천 피드 provider에서 추천 이벤트 반환',
+      app: const Scaffold(body: SizedBox.shrink()),
+      overrides: base,
+      body: (t) async {
+        final container = ProviderScope.containerOf(
+          t.element(find.byType(Scaffold)),
+        );
+        final events = await container.read(
+          tagRecommendationFeedProvider.future,
+        );
+
+        expect(events, hasLength(2));
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 3-4: 관심 태그 사후 변경
+  // ---------------------------------------------------------------------------
+  cujGroup('3-4', '관심 태그 사후 변경', () {
+    cujCase(
+      'happy: 선택 후 삭제/재선택 시 wizard tagIds 동기화',
+      app: sectionApp(),
+      overrides: base,
+      body: (t) async {
+        final container = ProviderScope.containerOf(
+          t.element(find.byType(Scaffold)),
+        );
+
+        await t.tap(find.text('#소개팅'));
+        await t.pumpAndSettle();
+        await t.tap(find.text('#요가'));
+        await t.pumpAndSettle();
+
+        await t.tap(find.byIcon(Icons.close).first);
+        await t.pumpAndSettle();
+        await t.tap(find.text('#러닝'));
+        await t.pumpAndSettle();
+
+        final tagIds = container
+            .read(partyCreateWizardControllerProvider)
+            .tagIds;
+        expect(tagIds, ['tag-2', 'tag-3']);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 4-1: 파트너 파티 생성 태그 선택
+  // ---------------------------------------------------------------------------
+  cujGroup('4-1', '파트너 파티 생성 태그 선택', () {
+    cujCase(
+      'happy: 인기 태그 선택 시 wizard tagIds 반영',
+      app: sectionApp(),
+      overrides: base,
+      body: (t) async {
+        final container = ProviderScope.containerOf(
+          t.element(find.byType(Scaffold)),
+        );
+
+        await t.tap(find.text('#클럽'));
+        await t.pumpAndSettle();
+
+        final tagIds = container
+            .read(partyCreateWizardControllerProvider)
+            .tagIds;
+        expect(tagIds, contains('tag-5'));
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 4-2: 5개 초과 선택 차단
+  // ---------------------------------------------------------------------------
+  cujGroup('4-2', '5개 초과 선택 차단', () {
+    cujCase(
+      'edge: 5개 선택 후 입력 비활성 + 6번째 선택 차단',
+      app: sectionApp(),
+      overrides: base,
+      body: (t) async {
+        final container = ProviderScope.containerOf(
+          t.element(find.byType(Scaffold)),
+        );
+
+        for (final label in ['#소개팅', '#요가', '#러닝', '#와인', '#클럽']) {
+          await t.tap(find.text(label));
+          await t.pumpAndSettle();
+        }
+
+        final textField = t.widget<TextField>(find.byType(TextField));
+        expect(textField.enabled, isFalse);
+
+        await t.tap(find.text('#루프탑'));
+        await t.pumpAndSettle();
+
+        final tagIds = container
+            .read(partyCreateWizardControllerProvider)
+            .tagIds;
+        expect(tagIds, hasLength(5));
+        expect(tagIds, isNot(contains('tag-6')));
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 4-3: 파티 편집 시 태그 수정
+  // ---------------------------------------------------------------------------
+  cujGroup('4-3', '파티 편집 시 태그 수정', () {
+    cujCase(
+      'happy: prefill 로드 후 삭제/추가 반영',
+      app: sectionApp(),
+      overrides: base,
+      body: (t) async {
+        final container = ProviderScope.containerOf(
+          t.element(find.byType(Scaffold)),
+        );
+
+        container
+            .read(partyCreateWizardControllerProvider.notifier)
+            .updateTagIds(['tag-1', 'tag-2']);
+        await t.pumpAndSettle();
+
+        expect(find.text('#소개팅'), findsWidgets);
+        expect(find.text('#요가'), findsWidgets);
+
+        await t.tap(find.byIcon(Icons.close).first);
+        await t.pumpAndSettle();
+        await t.tap(find.text('#러닝'));
+        await t.pumpAndSettle();
+
+        final tagIds = container
+            .read(partyCreateWizardControllerProvider)
+            .tagIds;
+        expect(tagIds, ['tag-2', 'tag-3']);
+      },
+    );
+  });
+}

--- a/apps/app_user/integration_test/cuj/discovery/tag_discovery_test.dart
+++ b/apps/app_user/integration_test/cuj/discovery/tag_discovery_test.dart
@@ -6,6 +6,7 @@
 // Fix #2561: discovery 카테고리 CUJ integration test 전무 해소 (tag-discovery)
 
 import 'package:app_user/src/features/home/widgets/featured_tag_chip_bar.dart';
+import 'package:app_user/src/features/home/widgets/trending_tag_section.dart';
 import 'package:app_user/src/features/tag/ui/tag_event_list_page.dart';
 import 'package:app_user/src/logic/tag_coordinator.dart';
 import 'package:flutter/material.dart';
@@ -39,6 +40,24 @@ Event _makeEvent(int index) => Event(
   updatedAt: DateTime(2026),
 );
 
+Event _makeEventWithTags(List<Tag> tags) => Event(
+  id: 'event-tags',
+  partyId: 'party-tags',
+  title: '태그 이벤트',
+  startTime: DateTime(2026, 6),
+  endTime: DateTime(2026, 6, 1, 2),
+  createdAt: DateTime(2026),
+  updatedAt: DateTime(2026),
+  party: Party(
+    id: 'party-tags',
+    partnerId: 'partner-1',
+    title: '태그 파티',
+    createdAt: DateTime(2026),
+    updatedAt: DateTime(2026),
+    tags: tags,
+  ),
+);
+
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -62,6 +81,9 @@ void main() {
         offset: any(named: 'offset'),
       ),
     ).thenAnswer((_) async => [_makeEvent(1), _makeEvent(2)]);
+    when(() => mockTagRepo.getTrendingTags()).thenAnswer(
+      (_) async => [const Tag(id: 'tag-run', name: '러닝', recentCount: 12)],
+    );
   });
 
   List<dynamic> base() => [
@@ -100,6 +122,110 @@ void main() {
       },
       body: (t) async {
         expect(find.byType(FilterChip), findsNothing);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 1-2: 인기 태그 다중 선택 OR 필터 (FR-2)
+  // ---------------------------------------------------------------------------
+
+  cujGroup('1-2', '인기 태그 다중 선택 OR 필터', () {
+    cujCase(
+      'happy: 인기 태그 2개 연속 탭 → 각 태그 진입 호출',
+      app: const Scaffold(body: FeaturedTagChipBar()),
+      overrides: () {
+        when(() => mockTagRepo.getFeaturedTags()).thenAnswer(
+          (_) async => [_makeTag('클럽'), _makeTag('요가'), _makeTag('러닝')],
+        );
+        return base();
+      },
+      body: (t) async {
+        await t.tap(find.text('#클럽'));
+        await t.pumpAndSettle();
+        await t.tap(find.text('#요가'));
+        await t.pumpAndSettle();
+
+        expect(fakeCoordinator.calls, hasLength(2));
+        expect(fakeCoordinator.calls[0].$2, '클럽');
+        expect(fakeCoordinator.calls[1].$2, '요가');
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 1-3: 핫 태그 섹션 탐색 (FR-3)
+  // ---------------------------------------------------------------------------
+
+  cujGroup('1-3', '핫 태그 섹션 탐색', () {
+    cujCase(
+      'happy: 핫 태그 카드 노출 + 탭 시 태그 페이지 이동',
+      app: const Scaffold(body: TrendingTagSection()),
+      overrides: base,
+      body: (t) async {
+        expect(find.text('🔥 핫 태그'), findsOneWidget);
+        expect(find.text('#러닝'), findsOneWidget);
+        expect(find.text('7일 +12'), findsOneWidget);
+
+        await t.tap(find.text('#러닝'));
+        await t.pumpAndSettle();
+
+        expect(fakeCoordinator.calls, hasLength(1));
+        expect(fakeCoordinator.calls.first.$2, '러닝');
+      },
+    );
+
+    cujCase(
+      'edge: recentCount=0 태그만 있으면 섹션 숨김',
+      app: const Scaffold(body: TrendingTagSection()),
+      overrides: () {
+        when(() => mockTagRepo.getTrendingTags()).thenAnswer(
+          (_) async => [const Tag(id: 'tag-zero', name: '정적')],
+        );
+        return base();
+      },
+      body: (t) async {
+        expect(find.text('🔥 핫 태그'), findsNothing);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // CUJ 1-4: 이벤트 카드 태그 뱃지 탭/표시 (FR-4)
+  // ---------------------------------------------------------------------------
+
+  cujGroup('1-4', '이벤트 카드 태그 뱃지 탭', () {
+    cujCase(
+      'happy: 태그 4개면 최대 3개 + overflow(# +1) 표시',
+      app: Scaffold(
+        body: MinglitEventCard(
+          event: _makeEventWithTags([
+            _makeTag('소개팅'),
+            _makeTag('와인'),
+            _makeTag('루프탑'),
+            _makeTag('강남'),
+          ]),
+          onTap: () {},
+        ),
+      ),
+      body: (t) async {
+        expect(find.text('#소개팅'), findsOneWidget);
+        expect(find.text('#와인'), findsOneWidget);
+        expect(find.text('#루프탑'), findsOneWidget);
+        expect(find.text('#+1'), findsOneWidget);
+      },
+    );
+
+    cujCase(
+      'edge: 태그 없음이면 뱃지 영역 미노출',
+      app: Scaffold(
+        body: MinglitEventCard(
+          event: _makeEventWithTags(const []),
+          onTap: () {},
+        ),
+      ),
+      body: (t) async {
+        expect(find.textContaining('#'), findsNothing);
       },
     );
   });

--- a/apps/app_user/integration_test/cuj/discovery/tag_discovery_test.dart
+++ b/apps/app_user/integration_test/cuj/discovery/tag_discovery_test.dart
@@ -5,6 +5,7 @@
 //
 // Fix #2561: discovery 카테고리 CUJ integration test 전무 해소 (tag-discovery)
 
+import 'package:app_user/src/features/home/logic/selected_tags_provider.dart';
 import 'package:app_user/src/features/home/widgets/featured_tag_chip_bar.dart';
 import 'package:app_user/src/features/home/widgets/trending_tag_section.dart';
 import 'package:app_user/src/features/tag/ui/tag_event_list_page.dart';
@@ -67,10 +68,12 @@ void main() {
 
   late _MockTagRepository mockTagRepo;
   late _FakeTagCoordinator fakeCoordinator;
+  late List<String> tappedCardTags;
 
   setUp(() {
     mockTagRepo = _MockTagRepository();
     fakeCoordinator = _FakeTagCoordinator();
+    tappedCardTags = <String>[];
     // Default stubs — 반드시 pumpWidget 전에 등록되어야 함 (setUp에서 설정)
     when(() => mockTagRepo.getFeaturedTags()).thenAnswer(
       (_) async => [_makeTag('클럽'), _makeTag('요가')],
@@ -132,8 +135,21 @@ void main() {
 
   cujGroup('1-2', '인기 태그 다중 선택 OR 필터', () {
     cujCase(
-      'happy: 인기 태그 2개 연속 탭 → 각 태그 진입 호출',
-      app: const Scaffold(body: FeaturedTagChipBar()),
+      'happy: 인기 태그 2개 연속 탭 → 선택 상태/선택 집합 갱신',
+      app: Scaffold(
+        body: Column(
+          children: [
+            const FeaturedTagChipBar(),
+            Consumer(
+              builder: (context, ref, _) {
+                final selectedIds = ref.watch(selectedTagsProvider).toList()
+                  ..sort();
+                return Text('selected:${selectedIds.join(",")}');
+              },
+            ),
+          ],
+        ),
+      ),
       overrides: () {
         when(() => mockTagRepo.getFeaturedTags()).thenAnswer(
           (_) async => [_makeTag('클럽'), _makeTag('요가'), _makeTag('러닝')],
@@ -149,6 +165,8 @@ void main() {
         expect(fakeCoordinator.calls, hasLength(2));
         expect(fakeCoordinator.calls[0].$2, '클럽');
         expect(fakeCoordinator.calls[1].$2, '요가');
+        expect(find.byIcon(Icons.check), findsNWidgets(2));
+        expect(find.text('selected:tag-요가,tag-클럽'), findsOneWidget);
       },
     );
   });
@@ -206,6 +224,7 @@ void main() {
             _makeTag('강남'),
           ]),
           onTap: () {},
+          onTagTap: (tag) => tappedCardTags.add(tag.name),
         ),
       ),
       body: (t) async {
@@ -213,6 +232,10 @@ void main() {
         expect(find.text('#와인'), findsOneWidget);
         expect(find.text('#루프탑'), findsOneWidget);
         expect(find.text('#+1'), findsOneWidget);
+
+        await t.tap(find.text('#소개팅'));
+        await t.pumpAndSettle();
+        expect(tappedCardTags, ['소개팅']);
       },
     );
 

--- a/apps/app_user/lib/src/features/home/widgets/featured_tag_chip_bar.dart
+++ b/apps/app_user/lib/src/features/home/widgets/featured_tag_chip_bar.dart
@@ -1,3 +1,4 @@
+import 'package:app_user/src/features/home/logic/selected_tags_provider.dart';
 import 'package:app_user/src/logic/tag_coordinator.dart';
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
@@ -11,6 +12,7 @@ class FeaturedTagChipBar extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tagsAsync = ref.watch(featuredTagsProvider);
+    final selectedTagIds = ref.watch(selectedTagsProvider);
 
     return tagsAsync.when(
       data: (tags) {
@@ -32,9 +34,13 @@ class FeaturedTagChipBar extends ConsumerWidget {
                 return Center(
                   child: _TagChip(
                     label: tag.name,
-                    onTap: () => ref
-                        .read(tagCoordinatorProvider)
-                        .goToTagEventList(tag.id, tag.name),
+                    selected: selectedTagIds.contains(tag.id),
+                    onTap: () {
+                      ref.read(selectedTagsProvider.notifier).toggle(tag.id);
+                      ref
+                          .read(tagCoordinatorProvider)
+                          .goToTagEventList(tag.id, tag.name);
+                    },
                   ),
                 );
               },
@@ -49,17 +55,23 @@ class FeaturedTagChipBar extends ConsumerWidget {
 }
 
 class _TagChip extends StatelessWidget {
-  const _TagChip({required this.label, required this.onTap});
+  const _TagChip({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
 
   final String label;
+  final bool selected;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    // Fix #2349: GestureDetector deferToChild → opaque so the chip's entire
-    // rendered area accepts hits without relying on RenderParagraph.hitTestSelf.
+    // Fix #2349: GestureDetector deferToChild -> opaque so the chip's entire
+    // rendered area accepts hits without relying on RenderParagraph
+    // hitTestSelf.
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: onTap,
@@ -69,17 +81,34 @@ class _TagChip extends StatelessWidget {
           vertical: MinglitSpacing.xxsmall,
         ),
         decoration: BoxDecoration(
-          color: theme.colorScheme.primary.withValues(
-            alpha: MinglitOpacity.activeChip,
-          ),
+          color: selected
+              ? theme.colorScheme.primary
+              : theme.colorScheme.primary.withValues(
+                  alpha: MinglitOpacity.activeChip,
+                ),
           borderRadius: BorderRadius.circular(MinglitRadius.chip),
         ),
-        child: Text(
-          '#$label',
-          style: theme.textTheme.labelMedium?.copyWith(
-            color: theme.colorScheme.primary,
-            fontWeight: FontWeight.w500,
-          ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (selected) ...[
+              Icon(
+                Icons.check,
+                size: 14,
+                color: theme.colorScheme.onPrimary,
+              ),
+              const SizedBox(width: MinglitSpacing.xxsmall),
+            ],
+            Text(
+              '#$label',
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: selected
+                    ? theme.colorScheme.onPrimary
+                    : theme.colorScheme.primary,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/apps/app_user/test/src/features/home/widgets/featured_tag_chip_bar_test.dart
+++ b/apps/app_user/test/src/features/home/widgets/featured_tag_chip_bar_test.dart
@@ -5,6 +5,7 @@
 // 2. 태그 목록 → #tagName 칩 렌더링
 // 3. 에러 상태 → SizedBox.shrink
 // 4. 칩 탭 → TagCoordinator.goToTagEventList() 호출
+import 'package:app_user/src/features/home/logic/selected_tags_provider.dart';
 import 'package:app_user/src/features/home/widgets/featured_tag_chip_bar.dart';
 import 'package:app_user/src/logic/tag_coordinator.dart';
 import 'package:flutter/material.dart';
@@ -119,6 +120,37 @@ void main() {
         expect(fakeCoordinator.calls, hasLength(1));
         expect(fakeCoordinator.calls.first.$1, 'tag-클럽');
         expect(fakeCoordinator.calls.first.$2, '클럽');
+      },
+    );
+
+    testWidgets(
+      '태그 2회 선택/해제 — selectedTags 상태와 체크 아이콘이 동기화된다',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubject(
+            stub: () => when(
+              () => mockTagRepo.getFeaturedTags(),
+            ).thenAnswer((_) async => [makeTag('클럽'), makeTag('요가')]),
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.text('#클럽'));
+        await tester.pump();
+        await tester.tap(find.text('#요가'));
+        await tester.pump();
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(FeaturedTagChipBar)),
+        );
+        expect(container.read(selectedTagsProvider), {'tag-클럽', 'tag-요가'});
+        expect(find.byIcon(Icons.check), findsNWidgets(2));
+
+        await tester.tap(find.text('#클럽'));
+        await tester.pump();
+
+        expect(container.read(selectedTagsProvider), {'tag-요가'});
+        expect(find.byIcon(Icons.check), findsOneWidget);
       },
     );
 

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/party/_event_card_tags.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/party/_event_card_tags.dart
@@ -5,11 +5,12 @@ part of 'event_card.dart';
 /// Used in [MinglitEventCard] to surface tag metadata
 /// (Tag Discovery #1094-1096).
 class _TagChipRow extends StatelessWidget {
-  const _TagChipRow({required this.tags});
+  const _TagChipRow({required this.tags, this.onTagTap});
 
   static const _maxVisible = 3;
 
   final List<Tag> tags;
+  final void Function(Tag tag)? onTagTap;
 
   @override
   Widget build(BuildContext context) {
@@ -21,7 +22,12 @@ class _TagChipRow extends StatelessWidget {
       spacing: MinglitSpacing.xsmall,
       runSpacing: MinglitSpacing.xxsmall,
       children: [
-        for (final tag in visible) _TagBadge(label: tag.name, theme: theme),
+        for (final tag in visible)
+          _TagBadge(
+            label: tag.name,
+            theme: theme,
+            onTap: onTagTap == null ? null : () => onTagTap!(tag),
+          ),
         if (overflowCount > 0)
           _TagBadge(label: '+$overflowCount', theme: theme),
       ],
@@ -30,14 +36,19 @@ class _TagChipRow extends StatelessWidget {
 }
 
 class _TagBadge extends StatelessWidget {
-  const _TagBadge({required this.label, required this.theme});
+  const _TagBadge({
+    required this.label,
+    required this.theme,
+    this.onTap,
+  });
 
   final String label;
   final ThemeData theme;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
-    return DecoratedBox(
+    final chip = DecoratedBox(
       decoration: BoxDecoration(
         color: theme.colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(MinglitRadius.chip),
@@ -54,6 +65,14 @@ class _TagBadge extends StatelessWidget {
           ),
         ),
       ),
+    );
+
+    if (onTap == null) return chip;
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: chip,
     );
   }
 }

--- a/shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart
+++ b/shared/packages/minglit_kit/lib/src/ui/widgets/party/event_card.dart
@@ -38,6 +38,7 @@ class MinglitEventCard extends StatelessWidget {
     required this.event,
     super.key,
     this.onTap,
+    this.onTagTap,
     this.showPartnerOverlay = true,
     @visibleForTesting this.currentTime,
   }) : _isLoading = false;
@@ -47,6 +48,7 @@ class MinglitEventCard extends StatelessWidget {
     super.key,
     this.event,
     this.onTap,
+    this.onTagTap,
     this.showPartnerOverlay = true,
     this.currentTime,
   }) : _isLoading = true;
@@ -56,6 +58,9 @@ class MinglitEventCard extends StatelessWidget {
 
   /// Optional tap handler for the card.
   final VoidCallback? onTap;
+
+  /// Optional tap handler for tag badges rendered in the card body.
+  final void Function(Tag tag)? onTagTap;
 
   /// Whether to show the partner badge overlay on the image.
   final bool showPartnerOverlay;
@@ -310,7 +315,7 @@ class MinglitEventCard extends StatelessWidget {
                       if (party?.tags ?? event!.tags case final tags?
                           when tags.isNotEmpty) ...[
                         const SizedBox(height: MinglitSpacing.xsmall),
-                        _TagChipRow(tags: tags),
+                        _TagChipRow(tags: tags, onTagTap: onTagTap),
                       ],
                     ],
                   ),

--- a/shared/packages/minglit_kit/test/src/ui/widgets/party/event_card_state_test.dart
+++ b/shared/packages/minglit_kit/test/src/ui/widgets/party/event_card_state_test.dart
@@ -23,6 +23,16 @@ void main() {
     partner: partner,
   );
 
+  Party partyWithTags(List<Tag> tags) => Party(
+    id: 'party-tagged',
+    partnerId: 'partner-1',
+    title: '태그 포함 파티',
+    createdAt: baseTime,
+    updatedAt: baseTime,
+    partner: partner,
+    tags: tags,
+  );
+
   Widget buildCard(
     Event event, {
     required DateTime currentTime,
@@ -238,6 +248,51 @@ void main() {
 
       expect(find.text(partner.name), findsOneWidget);
     });
+
+    testWidgets('tag badge tap calls onTagTap and keeps 3+overflow rendering', (
+      tester,
+    ) async {
+      final tappedTagNames = <String>[];
+      final event = Event(
+        id: 'e-tag-tap',
+        partyId: 'party-tagged',
+        startTime: baseTime,
+        endTime: baseTime.add(const Duration(hours: 3)),
+        createdAt: baseTime,
+        updatedAt: baseTime,
+        currentParticipants: 8,
+        party: partyWithTags([
+          const Tag(id: 'tag-1', name: '소개팅'),
+          const Tag(id: 'tag-2', name: '와인'),
+          const Tag(id: 'tag-3', name: '루프탑'),
+          const Tag(id: 'tag-4', name: '강남'),
+        ]),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: MinglitTheme.materialTheme,
+          home: Scaffold(
+            body: MinglitEventCard(
+              event: event,
+              currentTime: fiveDaysBefore,
+              onTagTap: (tag) => tappedTagNames.add(tag.name),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('#소개팅'), findsOneWidget);
+      expect(find.text('#와인'), findsOneWidget);
+      expect(find.text('#루프탑'), findsOneWidget);
+      expect(find.text('#+1'), findsOneWidget);
+
+      await tester.tap(find.text('#소개팅'));
+      await tester.pump();
+
+      expect(tappedTagNames, ['소개팅']);
+    });
   });
 
   // Fix #996: 카드 전체를 하나의 시맨틱 노드로 병합하여 스크린 리더가
@@ -288,7 +343,7 @@ void main() {
           matches,
           isNotEmpty,
           reason:
-              'tappable card must wrap with Semantics('
+              'tappable card must wrap with Semantics( '
               'label: "이벤트: ...", button: true, excludeSemantics: true)',
         );
         final wrapper = matches.first.widget as Semantics;


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## What
- add missing `discovery/tag-discovery` CUJ IDs to integration tests across user/partner apps
- extend `apps/app_user/integration_test/cuj/discovery/tag_discovery_test.dart` with `1-2`, `1-3`, `1-4`
- add new `apps/app_partner/integration_test/cuj/discovery/tag_discovery_test.dart` with `2-1`, `2-2`, `2-3`, `3-1`, `3-2`, `3-3`, `3-4`, `4-1`, `4-2`, `4-3`
- update `apps/app_partner/integration_test/cuj/BLUEDOC.md` folder map + coverage row for the new discovery CUJ file
- add regression widget tests for UI interaction contracts introduced in this PR:
  - `apps/app_user/test/src/features/home/widgets/featured_tag_chip_bar_test.dart`
  - `shared/packages/minglit_kit/test/src/ui/widgets/party/event_card_state_test.dart`

## Why
- `scripts/cuj_coverage.dart` reported uncovered CUJs in `discovery/tag-discovery`
- this PR fills the remaining IDs for that single feature (Option A, one feature per PR)
- reviewer flagged runtime interaction changes (`FeaturedTagChipBar` selected state / `MinglitEventCard.onTagTap`) and requested explicit regression coverage

## Design System Spec References (UI gate)
- `apps/mds/docs/public/specs/home_page/index.html`
  - `FeaturedTagChipBar` / chip bar anatomy sections (`Filter chip bar anatomy (ⓑ)`, `FeaturedTagChipBar` row in structure table)
  - selected/unselected chip visual distinction and chip spacing tokens used by home discovery chip rows
- `apps/mds/docs/public/specs/event_card/index.html`
  - `Tag chips overlay` section (`#태그 chip × max 3` + `+N overflow` behavior)
- `apps/mds/docs/src/lib/components.ts`
  - `MinglitFilterChip` definition (selected-state semantics and interaction guidance)

## Verification
- `flutter analyze apps/app_user/integration_test/cuj/discovery/tag_discovery_test.dart`
- `flutter analyze apps/app_partner/integration_test/cuj/discovery/tag_discovery_test.dart`
- `flutter test test/src/features/home/widgets/featured_tag_chip_bar_test.dart` (run in `apps/app_user`)
- `flutter test test/src/ui/widgets/party/event_card_state_test.dart` (run in `shared/packages/minglit_kit`)
- `flutter analyze apps/app_user/test/src/features/home/widgets/featured_tag_chip_bar_test.dart shared/packages/minglit_kit/test/src/ui/widgets/party/event_card_state_test.dart`
- `dart run scripts/cuj_coverage.dart --json`
  - `discovery/tag-discovery`: `spec=15, tested=15, uncovered=0`
  - overall coverage: `67.8%`

## Risk
- low to medium: CUJ test coverage expansion + targeted regression tests
- no backend schema/function changes

## Issue Lifecycle
- this is a partial slice of the aggregate CUJ backlog tracker
- Refs #2820