### PR TITLE
test(app_user): add partner_events_page MDS render catalog

### DIFF
--- a/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
@@ -48,6 +48,7 @@ Phase 2 (TODO, follow-up PR) — `_manifest.yaml`, coverage report, scaffold 결
 | `my_tickets_page` | active-banners · empty · logged-out |
 | `notification_list_screen` | loaded · empty |
 | `notification_settings_screen` | default |
+| `partner_events_page` | default · empty-events · loading · error |
 | `privacy_page` | loading · loaded · dark |
 | `purchase_history_page` | default · empty · loading · error |
 | `purchase_history_detail_page` | default · cancel-disabled · refunded · payment-failed · loading · error |
@@ -72,4 +73,4 @@ MDS spec 디렉토리명과 동일 (per-screen, snake_case). 화면당 `builder.
 - [상위 BLUEDOC](../BLUEDOC.md) · 페어 워크플로우: `sync-mds-mockups.yml` (디자인 PNG)
 
 ---
-_Reviewed: 2026-05-28 03:30_
+_Reviewed: 2026-05-28 09:15_

--- a/apps/app_user/integration_test/mds-emulator-render/_mocks/coordinators.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_mocks/coordinators.dart
@@ -1,6 +1,7 @@
 // 화면 builder 들이 공통으로 쓰는 Coordinator mock 풀.
 
 import 'package:app_user/src/features/home/logic/home_coordinator.dart';
+import 'package:app_user/src/features/partner/logic/partner_coordinator.dart';
 import 'package:app_user/src/features/search/logic/search_coordinator.dart';
 import 'package:app_user/src/logic/auth_coordinator.dart';
 import 'package:app_user/src/logic/event_coordinator.dart';
@@ -14,5 +15,7 @@ class MockAuthCoordinator extends Mock implements AuthCoordinator {}
 class MockSearchCoordinator extends Mock implements SearchCoordinator {}
 
 class MockEventCoordinator extends Mock implements EventCoordinator {}
+
+class MockPartnerCoordinator extends Mock implements PartnerCoordinator {}
 
 class MockAppCoordinator extends Mock implements AppCoordinator {}

--- a/apps/app_user/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_registry.dart
@@ -34,6 +34,8 @@ import 'notification_list_screen/notification_list_screen_test.dart'
     as notification_list_screen;
 import 'notification_settings_screen/notification_settings_screen_test.dart'
     as notification_settings_screen;
+import 'partner_events_page/partner_events_page_test.dart'
+    as partner_events_page;
 import 'privacy_page/privacy_page_test.dart' as privacy_page;
 import 'purchase_history_page/purchase_history_page_test.dart'
     as purchase_history_page;
@@ -67,6 +69,7 @@ final List<MdsCatalog<MdsScreenBuilder<dynamic>>> allCatalogs = [
   my_page.catalog,
   notification_list_screen.catalog,
   notification_settings_screen.catalog,
+  partner_events_page.catalog,
   privacy_page.catalog,
   purchase_history_page.catalog,
   purchase_history_detail_page.catalog,

--- a/apps/app_user/integration_test/mds-emulator-render/partner_events_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/partner_events_page/builder.dart
@@ -1,0 +1,131 @@
+// PartnerEventsPageBuilder — partner_events_page 전용 fluent API.
+
+import 'dart:async';
+
+import 'package:app_user/src/features/partner/detail/partner_detail_page.dart';
+import 'package:app_user/src/features/partner/detail/partner_events_page.dart';
+import 'package:app_user/src/features/partner/logic/partner_coordinator.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+import '../_mocks/coordinators.dart';
+
+const _partnerId = 'partner-render-1';
+final _base = DateTime(2026, 5, 20, 18);
+
+Partner _mockPartner(String id) => Partner(
+  id: id,
+  name: '밍글릿 라운지',
+  introduction: '강남에서 운영하는 소셜 라운지입니다.',
+  address: '서울 강남구 테헤란로 123',
+);
+
+Event _mockEvent({
+  required String id,
+  required String title,
+  required DateTime startTime,
+  required String status,
+  int currentParticipants = 18,
+}) {
+  return Event(
+    id: id,
+    partyId: 'party-$id',
+    title: title,
+    startTime: startTime,
+    endTime: startTime.add(const Duration(hours: 2)),
+    createdAt: _base,
+    updatedAt: _base,
+    currentParticipants: currentParticipants,
+    status: status,
+    location: Location(
+      id: 'location-$id',
+      partnerId: _partnerId,
+      name: '밍글릿 강남홀',
+      address: '서울 강남구 테헤란로 123',
+      createdAt: _base,
+      updatedAt: _base,
+    ),
+  );
+}
+
+final _defaultEvents = <Event>[
+  _mockEvent(
+    id: 'event-1',
+    title: '강남 프라이데이 밍글',
+    startTime: DateTime(2026, 6, 1, 19),
+    status: 'scheduled',
+  ),
+  _mockEvent(
+    id: 'event-2',
+    title: '위켄드 소셜 나이트',
+    startTime: DateTime(2026, 6, 2, 20),
+    status: 'sold_out',
+    currentParticipants: 40,
+  ),
+];
+
+class PartnerEventsPageBuilder extends MdsScreenBuilder<PartnerEventsPage> {
+  PartnerEventsPageBuilder()
+    : super(
+        page: const PartnerEventsPage(partnerId: _partnerId),
+        base: [
+          partnerCoordinatorProvider.overrideWithValue(
+            MockPartnerCoordinator(),
+          ),
+        ],
+      );
+
+  void _withPartner() {
+    addOverride(
+      partnerDetailProvider.overrideWith(
+        (ref, partnerId) async => _mockPartner(partnerId),
+      ),
+    );
+  }
+
+  /// 기본 상태: 이벤트 카드 리스트 노출.
+  PartnerEventsPageBuilder withDefault() {
+    _withPartner();
+    addOverride(
+      partnerEventsProvider.overrideWith(
+        (ref, partnerId) async => _defaultEvents,
+      ),
+    );
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  /// 이벤트 없음 상태.
+  PartnerEventsPageBuilder withEmpty() {
+    _withPartner();
+    addOverride(
+      partnerEventsProvider.overrideWith((ref, partnerId) async => const []),
+    );
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  /// 로딩 상태.
+  PartnerEventsPageBuilder withLoading() {
+    _withPartner();
+    addOverride(
+      partnerEventsProvider.overrideWith(
+        (ref, partnerId) => Completer<List<Event>>().future,
+      ),
+    );
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  /// 에러 상태.
+  PartnerEventsPageBuilder withError() {
+    _withPartner();
+    addOverride(
+      partnerEventsProvider.overrideWith(
+        (ref, partnerId) async => throw Exception('render: forced error'),
+      ),
+    );
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+}

--- a/apps/app_user/integration_test/mds-emulator-render/partner_events_page/partner_events_page_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/partner_events_page/partner_events_page_test.dart
@@ -1,0 +1,28 @@
+// MDS screen: partner_events_page
+// 대응 MDS: apps/mds/docs/public/specs/partner_events_page/
+//
+// 출력: docs/infra/mds-emulator-render/partner_events_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<PartnerEventsPageBuilder>(
+  screen: 'partner_events_page',
+  mdsSpec: 'apps/mds/docs/public/specs/partner_events_page/',
+  builder: PartnerEventsPageBuilder.new,
+  states: [
+    MdsState('state-default', (b) => b.withDefault(), mdsIndex: 1),
+    MdsState('state-empty-events', (b) => b.withEmpty(), mdsIndex: 2),
+    MdsState(
+      'state-loading',
+      (b) => b.withLoading(),
+      mdsIndex: 3,
+      infiniteAnimation: true,
+    ),
+    MdsState('state-error', (b) => b.withError(), mdsIndex: 4),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## What
- add new MDS emulator render catalog for `partner_events_page`
  - `apps/app_user/integration_test/mds-emulator-render/partner_events_page/builder.dart`
  - `apps/app_user/integration_test/mds-emulator-render/partner_events_page/partner_events_page_test.dart`
- cover spec-aligned 4 states: default, empty-events, loading, error (`state_1..4` mapping)
- register the new catalog in `apps/app_user/integration_test/mds-emulator-render/_registry.dart`
- add `MockPartnerCoordinator` in shared render mocks
- update `apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md` catalog table + reviewed timestamp

## Why
- `mds_render_coverage` aggregate tracker still had `partner_events_page` in `uncovered_screens`
- this PR resolves one self-contained screen slice for issue `#2819`

## Verification
- `flutter analyze apps/app_user/integration_test/mds-emulator-render/partner_events_page`
- `dart run scripts/mds_render_coverage.dart --json`
  - `cataloged_screens`: `33 -> 34`
  - `screen_coverage_pct`: `50.0 -> 51.5`
  - `uncovered_screens`: `partner_events_page` removed

## Risk
- low: integration test catalog/test-only change, no production runtime code path change

## Issue Lifecycle
- Refs #2819
- partial work: aggregate tracker `#2819` still has many uncovered/incomplete screens, so this PR does not close the parent issue