### PR TITLE
test(app_user): add partner_detail_page MDS render catalog

### DIFF
--- a/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_user/integration_test/mds-emulator-render/BLUEDOC.md
@@ -48,6 +48,7 @@ Phase 2 (TODO, follow-up PR) — `_manifest.yaml`, coverage report, scaffold 결
 | `my_tickets_page` | active-banners · empty · logged-out |
 | `notification_list_screen` | loaded · empty |
 | `notification_settings_screen` | default |
+| `partner_detail_page` | default · loading · error · not-found · empty-events |
 | `partner_events_page` | default · empty-events · loading · error |
 | `privacy_page` | loading · loaded · dark |
 | `purchase_history_page` | default · empty · loading · error |
@@ -73,4 +74,4 @@ MDS spec 디렉토리명과 동일 (per-screen, snake_case). 화면당 `builder.
 - [상위 BLUEDOC](../BLUEDOC.md) · 페어 워크플로우: `sync-mds-mockups.yml` (디자인 PNG)
 
 ---
-_Reviewed: 2026-05-28 09:15_
+_Reviewed: 2026-05-28 15:35_

--- a/apps/app_user/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/_registry.dart
@@ -34,6 +34,8 @@ import 'notification_list_screen/notification_list_screen_test.dart'
     as notification_list_screen;
 import 'notification_settings_screen/notification_settings_screen_test.dart'
     as notification_settings_screen;
+import 'partner_detail_page/partner_detail_page_test.dart'
+    as partner_detail_page;
 import 'partner_events_page/partner_events_page_test.dart'
     as partner_events_page;
 import 'privacy_page/privacy_page_test.dart' as privacy_page;
@@ -69,6 +71,7 @@ final List<MdsCatalog<MdsScreenBuilder<dynamic>>> allCatalogs = [
   my_page.catalog,
   notification_list_screen.catalog,
   notification_settings_screen.catalog,
+  partner_detail_page.catalog,
   partner_events_page.catalog,
   privacy_page.catalog,
   purchase_history_page.catalog,

--- a/apps/app_user/integration_test/mds-emulator-render/partner_detail_page/builder.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/partner_detail_page/builder.dart
@@ -1,0 +1,142 @@
+// PartnerDetailPageBuilder — partner_detail_page 전용 fluent API.
+
+import 'dart:async';
+
+import 'package:app_user/src/features/partner/detail/partner_detail_page.dart';
+import 'package:app_user/src/features/partner/logic/partner_coordinator.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+import '../_mocks/coordinators.dart';
+
+const _partnerId = 'partner-detail-render-1';
+final _base = DateTime(2026, 5, 20, 18);
+
+Partner _mockPartner(String id) => Partner(
+  id: id,
+  name: '밍글릿 라운지',
+  introduction: '강남에서 운영하는 소셜 라운지입니다.',
+  address: '서울 강남구 테헤란로 123',
+  contactPhone: '02-555-1234',
+  contactEmail: 'hello@minglit.kr',
+  representativeName: '김대표',
+  bizName: '밍글릿 라운지',
+  bizNumber: '123-45-67890',
+);
+
+Event _mockEvent({
+  required String id,
+  required String title,
+  required DateTime startTime,
+  required String status,
+  int currentParticipants = 18,
+}) {
+  return Event(
+    id: id,
+    partyId: 'party-$id',
+    title: title,
+    startTime: startTime,
+    endTime: startTime.add(const Duration(hours: 2)),
+    createdAt: _base,
+    updatedAt: _base,
+    currentParticipants: currentParticipants,
+    status: status,
+    location: Location(
+      id: 'location-$id',
+      partnerId: _partnerId,
+      name: '밍글릿 강남홀',
+      address: '서울 강남구 테헤란로 123',
+      createdAt: _base,
+      updatedAt: _base,
+    ),
+  );
+}
+
+final _defaultEvents = <Event>[
+  _mockEvent(
+    id: 'event-1',
+    title: '강남 프라이데이 밍글',
+    startTime: DateTime(2026, 6, 1, 19),
+    status: 'scheduled',
+  ),
+  _mockEvent(
+    id: 'event-2',
+    title: '위켄드 소셜 나이트',
+    startTime: DateTime(2026, 6, 2, 20),
+    status: 'sold_out',
+    currentParticipants: 40,
+  ),
+];
+
+class PartnerDetailPageBuilder extends MdsScreenBuilder<PartnerDetailPage> {
+  PartnerDetailPageBuilder()
+    : super(
+        page: const PartnerDetailPage(partnerId: _partnerId),
+        base: [
+          partnerCoordinatorProvider.overrideWithValue(
+            MockPartnerCoordinator(),
+          ),
+        ],
+      );
+
+  /// 기본 상태: 파트너 + 진행중 이벤트 노출.
+  PartnerDetailPageBuilder withDefault() {
+    addOverride(
+      partnerDetailProvider.overrideWith(
+        (ref, partnerId) async => _mockPartner(partnerId),
+      ),
+    );
+    addOverride(
+      partnerEventsProvider.overrideWith(
+        (ref, partnerId) async => _defaultEvents,
+      ),
+    );
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  /// 로딩 상태: partner fetch pending.
+  PartnerDetailPageBuilder withLoading() {
+    addOverride(
+      partnerDetailProvider.overrideWith(
+        (ref, partnerId) => Completer<Partner?>().future,
+      ),
+    );
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  /// 에러 상태.
+  PartnerDetailPageBuilder withError() {
+    addOverride(
+      partnerDetailProvider.overrideWith(
+        (ref, partnerId) async => throw Exception('render: forced error'),
+      ),
+    );
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  /// 존재하지 않는 파트너 상태.
+  PartnerDetailPageBuilder withNotFound() {
+    addOverride(
+      partnerDetailProvider.overrideWith((ref, partnerId) async => null),
+    );
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  /// 파트너는 정상, 진행중 이벤트 없음.
+  PartnerDetailPageBuilder withEmptyEvents() {
+    addOverride(
+      partnerDetailProvider.overrideWith(
+        (ref, partnerId) async => _mockPartner(partnerId),
+      ),
+    );
+    addOverride(
+      partnerEventsProvider.overrideWith((ref, partnerId) async => const []),
+    );
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+}

--- a/apps/app_user/integration_test/mds-emulator-render/partner_detail_page/partner_detail_page_test.dart
+++ b/apps/app_user/integration_test/mds-emulator-render/partner_detail_page/partner_detail_page_test.dart
@@ -1,0 +1,29 @@
+// MDS screen: partner_detail_page
+// 대응 MDS: apps/mds/docs/public/specs/partner_detail_page/
+//
+// 출력: docs/infra/mds-emulator-render/partner_detail_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<PartnerDetailPageBuilder>(
+  screen: 'partner_detail_page',
+  mdsSpec: 'apps/mds/docs/public/specs/partner_detail_page/',
+  builder: PartnerDetailPageBuilder.new,
+  states: [
+    MdsState('state-default', (b) => b.withDefault(), mdsIndex: 1),
+    MdsState(
+      'state-loading',
+      (b) => b.withLoading(),
+      mdsIndex: 2,
+      infiniteAnimation: true,
+    ),
+    MdsState('state-error', (b) => b.withError(), mdsIndex: 3),
+    MdsState('state-not-found', (b) => b.withNotFound(), mdsIndex: 4),
+    MdsState('state-empty-events', (b) => b.withEmptyEvents(), mdsIndex: 5),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- add `partner_detail_page` MDS emulator render catalog (`builder.dart`, `partner_detail_page_test.dart`)
- map 5 MDS states for `partner_detail_page` (default/loading/error/not-found/empty-events)
- register the new catalog in `_registry.dart`
- update `mds-emulator-render/BLUEDOC.md` catalog list

## Why
- `#2819` coverage tracker reported `partner_detail_page` in `uncovered_screens`
- this PR converts that screen to cataloged coverage so subsequent runs move it to incomplete (state capture pending)

## Verification
- `flutter analyze integration_test/mds-emulator-render/partner_detail_page` (cwd: `apps/app_user`)
- `dart run scripts/mds_render_coverage.dart --json`
  - `cataloged_screens: 35`
  - `screen_coverage_pct: 53.0`
  - `partner_detail_page` removed from `uncovered_screens`

## Residual Risk
- this PR only adds catalog/test definitions; it does not generate/render PNG captures yet, so state coverage remains unchanged.

Refs #2819 — partial work: only catalog/test definitions are included here; PNG state capture and full coverage closure will be handled in a follow-up PR.