### PR TITLE
test(app_partner): add party_list_page MDS render catalog

### DIFF
--- a/apps/app_partner/BLUEDOC.md
+++ b/apps/app_partner/BLUEDOC.md
@@ -48,4 +48,4 @@ Minglit 의 **파트너 사장님 Flutter 앱**. 매장 관리·멤버 초대·�
 - [README.md](./README.md) — 빌드·실행 / [integration_test/cuj](./integration_test/cuj/BLUEDOC.md) — CUJ
 
 ---
-_Reviewed: 2026-05-27 22:20_
+_Reviewed: 2026-05-28 19:40_

--- a/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
@@ -26,6 +26,7 @@ flutter drive \
 | `create_verification_page` | empty · with-fields · dark |
 | `location_guide_page` | default · loading |
 | `more_page` | default · limited-permissions |
+| `party_list_page` | default · empty · loading · error · help |
 | `partner_login_page` | default-ios · default-android · loading · auth-error |
 | `recurrence_management_screen` | active · paused · cancelled · no-rule · action-loading · loading · active-dark |
 | `verification_manage_page` | loading · active-empty · active-with-items · archived-with-items · dark |
@@ -59,6 +60,9 @@ mds-emulator-render/
 ├── more_page/
 │   ├── builder.dart
 │   └── more_page_test.dart
+├── party_list_page/
+│   ├── builder.dart
+│   └── party_list_page_test.dart
 ├── partner_login_page/
 │   ├── builder.dart
 │   └── partner_login_page_test.dart
@@ -75,4 +79,4 @@ mds-emulator-render/
 - [app_user mds-emulator-render](../../../app_user/integration_test/mds-emulator-render/BLUEDOC.md)
 - [architecture.md](../../../app_user/integration_test/mds-emulator-render/architecture.md)
 
-_Reviewed: 2026-05-27 19:36_
+_Reviewed: 2026-05-28 19:08_

--- a/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
@@ -11,6 +11,7 @@ import 'create_verification_page/create_verification_page_test.dart'
 import 'location_guide_page/location_guide_page_test.dart'
     as location_guide_page;
 import 'more_page/more_page_test.dart' as more_page;
+import 'party_list_page/party_list_page_test.dart' as party_list_page;
 import 'partner_login_page/partner_login_page_test.dart' as partner_login_page;
 import 'recurrence_management_screen/recurrence_management_screen_test.dart'
     as recurrence_management_screen;
@@ -24,6 +25,7 @@ final List<Object> catalogs = [
   create_verification_page.catalog,
   location_guide_page.catalog,
   more_page.catalog,
+  party_list_page.catalog,
   partner_login_page.catalog,
   recurrence_management_screen.catalog,
   verification_manage_page.catalog,

--- a/apps/app_partner/integration_test/mds-emulator-render/party_list_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/party_list_page/builder.dart
@@ -6,6 +6,7 @@
 
 import 'dart:async';
 
+import 'package:app_partner/src/features/party/list/party_help_sections.dart';
 import 'package:app_partner/src/features/party/list/party_list_controller.dart';
 import 'package:app_partner/src/features/party/list/party_list_coordinator.dart';
 import 'package:app_partner/src/features/party/list/party_list_page.dart';
@@ -55,20 +56,7 @@ class _AutoOpenHelpSheetState extends State<_AutoOpenHelpSheet> {
         showMinglitHelpSheet(
           context: context,
           title: '파티 관리 가이드',
-          sections: const [
-            HelpSection(
-              title: '파티가 뭔가요?',
-              body: '이벤트를 운영하는 상위 단위예요.',
-            ),
-            HelpSection(
-              title: '이벤트와 차이는?',
-              body: '파티 안에 여러 이벤트를 만들 수 있어요.',
-            ),
-            HelpSection(
-              title: '이벤트를 만들려면?',
-              body: '파티를 게시한 뒤 이벤트를 추가하면 됩니다.',
-            ),
-          ],
+          sections: kPartyHelpSections,
         ),
       );
     });

--- a/apps/app_partner/integration_test/mds-emulator-render/party_list_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/party_list_page/builder.dart
@@ -1,0 +1,216 @@
+// PartyListPageBuilder - party_list_page 전용 fluent API.
+//
+// PartyListPage 는 partyListProvider + partyListCoordinatorProvider 를 사용한다.
+// MDS render에서는 provider/coordinator를 deterministic mock으로 고정해
+// Default / Empty / Loading / Error / Help(시트 자동 오픈) 상태를 재현한다.
+
+import 'dart:async';
+
+import 'package:app_partner/src/features/party/list/party_list_controller.dart';
+import 'package:app_partner/src/features/party/list/party_list_coordinator.dart';
+import 'package:app_partner/src/features/party/list/party_list_page.dart';
+import 'package:app_partner/src/features/party/list/party_with_stats.dart';
+import 'package:app_partner/src/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+
+enum _PartyListScenario { defaultState, empty, loading, error, help }
+
+class _NoOpPartyListCoordinator implements PartyListCoordinator {
+  @override
+  void goToCreate() {}
+
+  @override
+  void goToCreateEvent(String partyId) {}
+
+  @override
+  void goToDetail(String partyId) {}
+
+  @override
+  void goToEventDetail(String partyId, String eventId) {}
+}
+
+class _AutoOpenHelpSheet extends StatefulWidget {
+  const _AutoOpenHelpSheet({required this.child});
+
+  final Widget child;
+
+  @override
+  State<_AutoOpenHelpSheet> createState() => _AutoOpenHelpSheetState();
+}
+
+class _AutoOpenHelpSheetState extends State<_AutoOpenHelpSheet> {
+  bool _opened = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_opened) return;
+    _opened = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(
+        showMinglitHelpSheet(
+          context: context,
+          title: '파티 관리 가이드',
+          sections: const [
+            HelpSection(
+              title: '파티가 뭔가요?',
+              body: '이벤트를 운영하는 상위 단위예요.',
+            ),
+            HelpSection(
+              title: '이벤트와 차이는?',
+              body: '파티 안에 여러 이벤트를 만들 수 있어요.',
+            ),
+            HelpSection(
+              title: '이벤트를 만들려면?',
+              body: '파티를 게시한 뒤 이벤트를 추가하면 됩니다.',
+            ),
+          ],
+        ),
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
+
+final _base = DateTime(2026, 5, 28, 18);
+
+Partner _mockPartner() => const Partner(
+  id: 'mock-partner-1',
+  name: '밍글릿 강남 라운지',
+);
+
+Location _mockLocation() => Location(
+  id: 'mock-location-1',
+  partnerId: 'mock-partner-1',
+  name: '밍글릿 강남홀',
+  address: '서울 강남구 테헤란로 123',
+  createdAt: _base,
+  updatedAt: _base,
+);
+
+Party _mockParty() => Party(
+  id: 'mock-party-1',
+  partnerId: 'mock-partner-1',
+  title: '금요일 소셜 나이트',
+  createdAt: _base,
+  updatedAt: _base,
+  location: _mockLocation(),
+  partner: _mockPartner(),
+  tags: const [
+    Tag(id: 'tag-1', name: '#맛집'),
+    Tag(id: 'tag-2', name: '#와인'),
+  ],
+);
+
+Event _mockNextEvent() => Event(
+  id: 'mock-event-1',
+  partyId: 'mock-party-1',
+  title: '강남 밍글 파티',
+  startTime: DateTime(2026, 6, 3, 19),
+  endTime: DateTime(2026, 6, 3, 21),
+  createdAt: _base,
+  updatedAt: _base,
+  currentParticipants: 16,
+  maxParticipants: 24,
+);
+
+final _defaultEntries = <PartyWithStats>[
+  PartyWithStats(
+    party: _mockParty(),
+    completedCount: 7,
+    upcomingCount: 2,
+    nextEvent: _mockNextEvent(),
+  ),
+];
+
+class PartyListPageBuilder extends MdsScreenBuilder<Widget> {
+  PartyListPageBuilder() : super(page: const PartyListPage());
+
+  _PartyListScenario _scenario = _PartyListScenario.defaultState;
+  Brightness _brightness = Brightness.light;
+
+  PartyListPageBuilder defaultState() {
+    _scenario = _PartyListScenario.defaultState;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartyListPageBuilder emptyState() {
+    _scenario = _PartyListScenario.empty;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartyListPageBuilder loadingState() {
+    _scenario = _PartyListScenario.loading;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartyListPageBuilder errorState() {
+    _scenario = _PartyListScenario.error;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartyListPageBuilder helpState() {
+    _scenario = _PartyListScenario.help;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartyListPageBuilder dark() {
+    _brightness = Brightness.dark;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  @override
+  Widget build() {
+    final scenario = _scenario;
+    final brightness = _brightness;
+    final coordinator = _NoOpPartyListCoordinator();
+
+    final Widget home = scenario == _PartyListScenario.help
+        ? const _AutoOpenHelpSheet(child: PartyListPage())
+        : const PartyListPage();
+
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => null),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+        partyListCoordinatorProvider.overrideWithValue(coordinator),
+        partyListProvider.overrideWith((_) async {
+          switch (scenario) {
+            case _PartyListScenario.defaultState:
+            case _PartyListScenario.help:
+              return _defaultEntries;
+            case _PartyListScenario.empty:
+              return const <PartyWithStats>[];
+            case _PartyListScenario.loading:
+              return Completer<List<PartyWithStats>>().future;
+            case _PartyListScenario.error:
+              throw Exception('render: forced party list error');
+          }
+        }),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('ko'),
+        theme: brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
+        home: home,
+      ),
+    );
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/party_list_page/party_list_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/party_list_page/party_list_page_test.dart
@@ -1,0 +1,29 @@
+// MDS screen: party_list_page (app_partner)
+// 대응 MDS: apps/mds/docs/public/specs/party_list_page/
+//
+// 출력: docs/infra/mds-emulator-render/party_list_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<PartyListPageBuilder>(
+  screen: 'party_list_page',
+  mdsSpec: 'apps/mds/docs/public/specs/party_list_page/',
+  builder: PartyListPageBuilder.new,
+  states: [
+    MdsState('state-default', (b) => b.defaultState(), mdsIndex: 1),
+    MdsState('state-empty', (b) => b.emptyState(), mdsIndex: 2),
+    MdsState(
+      'state-loading',
+      (b) => b.loadingState(),
+      mdsIndex: 3,
+      infiniteAnimation: true,
+    ),
+    MdsState('state-error', (b) => b.errorState(), mdsIndex: 4),
+    MdsState('state-help', (b) => b.helpState(), mdsIndex: 5),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);

--- a/apps/app_partner/lib/src/features/party/list/party_help_sections.dart
+++ b/apps/app_partner/lib/src/features/party/list/party_help_sections.dart
@@ -1,0 +1,21 @@
+import 'package:minglit_kit/minglit_kit.dart';
+
+/// Canonical help-sheet sections for PartyListPage.
+const kPartyHelpSections = [
+  HelpSection(
+    title: '파티가 뭔가요?',
+    body: '소셜 이벤트를 기획하고 운영하는 단위예요. 파티 안에 여러 이벤트를 만들어 참가자를 모집할 수 있어요.',
+  ),
+  HelpSection(
+    title: '이벤트와 파티의 차이는?',
+    body: '파티는 큰 틀(브랜드·카테고리), 이벤트는 실제 모임 일정이에요. 파티 하나에 이벤트를 여러 개 만들 수 있어요.',
+  ),
+  HelpSection(
+    title: '파티 상태는 어떻게 달라지나요?',
+    body: '임시저장(draft) → 게시(published) 순이에요. 게시 상태여야 참가자가 이벤트를 발견하고 신청할 수 있어요.',
+  ),
+  HelpSection(
+    title: '이벤트를 만들려면?',
+    body: '파티를 게시한 뒤 파티 상세에서 "+ 이벤트 추가"를 눌러요. 체크인은 하단 체크인 탭에서 QR 스캔으로 진행해요.',
+  ),
+];

--- a/apps/app_partner/lib/src/features/party/list/party_list_page.dart
+++ b/apps/app_partner/lib/src/features/party/list/party_list_page.dart
@@ -1,29 +1,10 @@
+import 'package:app_partner/src/features/party/list/party_help_sections.dart';
 import 'package:app_partner/src/features/party/list/party_list_controller.dart';
 import 'package:app_partner/src/features/party/list/party_list_coordinator.dart';
 import 'package:app_partner/src/features/party/list/widgets/party_list_item.dart';
 import 'package:app_partner/src/utils/l10n_ext.dart';
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
-
-// Fix #2200: AppBar info → help sheet 패턴 적용 (QR 아이콘 제거 — Checkin 탭 진입으로 대체)
-const _kPartyHelpSections = [
-  HelpSection(
-    title: '파티가 뭔가요?',
-    body: '소셜 이벤트를 기획하고 운영하는 단위예요. 파티 안에 여러 이벤트를 만들어 참가자를 모집할 수 있어요.',
-  ),
-  HelpSection(
-    title: '이벤트와 파티의 차이는?',
-    body: '파티는 큰 틀(브랜드·카테고리), 이벤트는 실제 모임 일정이에요. 파티 하나에 이벤트를 여러 개 만들 수 있어요.',
-  ),
-  HelpSection(
-    title: '파티 상태는 어떻게 달라지나요?',
-    body: '임시저장(draft) → 게시(published) 순이에요. 게시 상태여야 참가자가 이벤트를 발견하고 신청할 수 있어요.',
-  ),
-  HelpSection(
-    title: '이벤트를 만들려면?',
-    body: '파티를 게시한 뒤 파티 상세에서 "+ 이벤트 추가"를 눌러요. 체크인은 하단 체크인 탭에서 QR 스캔으로 진행해요.',
-  ),
-];
 
 class PartyListPage extends ConsumerWidget {
   const PartyListPage({super.key});
@@ -44,7 +25,7 @@ class PartyListPage extends ConsumerWidget {
             onPressed: () => showMinglitHelpSheet(
               context: context,
               title: '파티 관리 가이드',
-              sections: _kPartyHelpSections,
+              sections: kPartyHelpSections,
             ),
           ),
           IconButton(


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- add `apps/app_partner/integration_test/mds-emulator-render/party_list_page/` catalog (`builder.dart`, `party_list_page_test.dart`)
- map 5 MDS states for `party_list_page` (default/empty/loading/error/help) with deterministic provider overrides
- register the new catalog in `apps/app_partner/integration_test/mds-emulator-render/_registry.dart`
- update `apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md` milestone table/structure and Reviewed timestamp

## Verification
- `flutter analyze integration_test/mds-emulator-render/party_list_page` (cwd: `apps/app_partner`)
- `dart run scripts/mds_render_coverage.dart --json`
  - `cataloged_screens: 36`
  - `screen_coverage_pct: 54.5`
  - `uncovered_screens` no longer contains `party_list_page`

## Risk
- Help-sheet state is auto-opened via post-frame callback in render-only wrapper; production page behavior is untouched.

Refs #2819
- partial slice only: this PR handles one uncovered screen (`party_list_page`) in the aggregate tracker, so the issue is not closed.