### PR TITLE
test(app_partner): add settlement_page MDS render catalog

### DIFF
--- a/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
@@ -29,6 +29,7 @@ flutter drive \
 | `party_list_page` | default · empty · loading · error · help |
 | `partner_login_page` | default-ios · default-android · loading · auth-error |
 | `recurrence_management_screen` | active · paused · cancelled · no-rule · action-loading · loading · active-dark |
+| `settlement_page` | loading · empty · error |
 | `verification_manage_page` | loading · active-empty · active-with-items · archived-with-items · dark |
 
 ## 구조
@@ -69,6 +70,9 @@ mds-emulator-render/
 ├── recurrence_management_screen/
 │   ├── builder.dart
 │   └── recurrence_management_screen_test.dart
+├── settlement_page/
+│   ├── builder.dart
+│   └── settlement_page_test.dart
 └── verification_manage_page/
     ├── builder.dart
     └── verification_manage_page_test.dart
@@ -79,4 +83,4 @@ mds-emulator-render/
 - [app_user mds-emulator-render](../../../app_user/integration_test/mds-emulator-render/BLUEDOC.md)
 - [architecture.md](../../../app_user/integration_test/mds-emulator-render/architecture.md)
 
-_Reviewed: 2026-05-28 19:08_
+_Reviewed: 2026-05-28 23:17_

--- a/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
@@ -15,6 +15,7 @@ import 'party_list_page/party_list_page_test.dart' as party_list_page;
 import 'partner_login_page/partner_login_page_test.dart' as partner_login_page;
 import 'recurrence_management_screen/recurrence_management_screen_test.dart'
     as recurrence_management_screen;
+import 'settlement_page/settlement_page_test.dart' as settlement_page;
 import 'verification_manage_page/verification_manage_page_test.dart'
     as verification_manage_page;
 
@@ -28,5 +29,6 @@ final List<Object> catalogs = [
   party_list_page.catalog,
   partner_login_page.catalog,
   recurrence_management_screen.catalog,
+  settlement_page.catalog,
   verification_manage_page.catalog,
 ];

--- a/apps/app_partner/integration_test/mds-emulator-render/settlement_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/settlement_page/builder.dart
@@ -1,0 +1,147 @@
+// SettlementPageBuilder — settlement_page 전용 fluent API.
+//
+// SettlementPage 는 현재 파트너 정보 + 정산 repository를 기준으로
+// 대시보드/목록 탭 상태를 렌더한다. MDS render에서는 provider override로
+// loading/empty/error를 결정적으로 재현한다.
+
+import 'package:app_partner/src/features/settlement/settlement_page.dart';
+import 'package:app_partner/src/logic/current_partner_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+import '../_mocks/data.dart';
+
+enum _SettlementScenario { loading, empty, error }
+
+class _FakeSettlementRepository implements SettlementRepository {
+  _FakeSettlementRepository({required this.scenario});
+
+  final _SettlementScenario scenario;
+
+  @override
+  Future<Map<String, dynamic>> getSettlementDashboard({
+    required String partnerId,
+    DateTime? periodStart,
+    DateTime? periodEnd,
+  }) async {
+    if (scenario == _SettlementScenario.error) {
+      throw Exception('render: forced settlement dashboard error');
+    }
+    return {
+      'completed_gross_total': 0,
+      'completed_net_total': 0,
+      'pending_gross_total': 0,
+      'status_counts': <String, int>{},
+    };
+  }
+
+  @override
+  Future<List<SettlementItemDetail>> getSettlementItems({
+    required String partnerId,
+    String? status,
+    DateTime? dateStart,
+    DateTime? dateEnd,
+    int limit = 20,
+    int offset = 0,
+  }) async {
+    if (scenario == _SettlementScenario.error) {
+      throw Exception('render: forced settlement list error');
+    }
+    return const <SettlementItemDetail>[];
+  }
+
+  @override
+  Future<Map<String, dynamic>?> getBankAccount(String partnerId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> upsertBankAccount({
+    required String partnerId,
+    required String bankName,
+    required String accountHolder,
+    required String accountNumber,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<SettlementItemDetail?> getSettlementItemDetail(String itemId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<Map<String, dynamic>?> getEventInfo(String eventId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<Map<String, dynamic>?> getPartnerSettlementInfo(String partnerId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<Map<String, dynamic>> retryPayout({
+    required String payoutId,
+    required String partnerId,
+  }) => throw UnimplementedError();
+}
+
+class SettlementPageBuilder extends MdsScreenBuilder<SettlementPage> {
+  SettlementPageBuilder() : super(page: const SettlementPage());
+
+  _SettlementScenario _scenario = _SettlementScenario.empty;
+  Brightness _brightness = Brightness.light;
+
+  SettlementPageBuilder loading() {
+    _scenario = _SettlementScenario.loading;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  SettlementPageBuilder empty() {
+    _scenario = _SettlementScenario.empty;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  SettlementPageBuilder error() {
+    _scenario = _SettlementScenario.error;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  SettlementPageBuilder dark() {
+    _brightness = Brightness.dark;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  @override
+  Widget build() {
+    final scenario = _scenario;
+    final isLoading = scenario == _SettlementScenario.loading;
+
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => null),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+        currentMemberPermissionsProvider.overrideWith(
+          (ref) async => const <String>[],
+        ),
+        currentPartnerInfoProvider.overrideWith((ref) async {
+          if (isLoading) {
+            await Future<void>.delayed(const Duration(days: 1));
+          }
+          return mockPartner();
+        }),
+        settlementRepositoryProvider.overrideWith(
+          (_) => _FakeSettlementRepository(scenario: scenario),
+        ),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: _brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
+        home: const SettlementPage(),
+      ),
+    );
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/settlement_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/settlement_page/builder.dart
@@ -83,7 +83,7 @@ class _FakeSettlementRepository implements SettlementRepository {
 }
 
 class SettlementPageBuilder extends MdsScreenBuilder<SettlementPage> {
-  SettlementPageBuilder() : super(page: const SettlementPage());
+  SettlementPageBuilder() : super(page: const SettlementPage(initialIndex: 1));
 
   _SettlementScenario _scenario = _SettlementScenario.empty;
   Brightness _brightness = Brightness.light;
@@ -140,7 +140,7 @@ class SettlementPageBuilder extends MdsScreenBuilder<SettlementPage> {
         theme: _brightness == Brightness.dark
             ? MinglitTheme.materialThemeDark
             : MinglitTheme.materialTheme,
-        home: const SettlementPage(),
+        home: const SettlementPage(initialIndex: 1),
       ),
     );
   }

--- a/apps/app_partner/integration_test/mds-emulator-render/settlement_page/settlement_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/settlement_page/settlement_page_test.dart
@@ -1,0 +1,30 @@
+// MDS screen: settlement_page (app_partner)
+// 대응 MDS: apps/mds/docs/public/specs/settlement_page/
+//
+// 출력: docs/infra/mds-emulator-render/settlement_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<SettlementPageBuilder>(
+  screen: 'settlement_page',
+  mdsSpec: 'apps/mds/docs/public/specs/settlement_page/',
+  builder: SettlementPageBuilder.new,
+  states: [
+    // Loading — 대시보드/목록 초기 로딩.
+    MdsState(
+      'state-loading',
+      (b) => b.loading(),
+      mdsIndex: 1,
+      infiniteAnimation: true,
+    ),
+    // Empty — 데이터 없음.
+    MdsState('state-empty', (b) => b.empty(), mdsIndex: 2),
+    // Error — 데이터 조회 실패.
+    MdsState('state-error', (b) => b.error(), mdsIndex: 3),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);

--- a/apps/app_partner/integration_test/mds-emulator-render/settlement_page/settlement_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/settlement_page/settlement_page_test.dart
@@ -13,17 +13,17 @@ final catalog = MdsCatalog<SettlementPageBuilder>(
   mdsSpec: 'apps/mds/docs/public/specs/settlement_page/',
   builder: SettlementPageBuilder.new,
   states: [
-    // Loading — 대시보드/목록 초기 로딩.
+    // Empty — state_3: 데이터 없음.
+    MdsState('state-empty', (b) => b.empty(), mdsIndex: 3),
+    // Loading — state_5: 목록 초기 로딩.
     MdsState(
       'state-loading',
       (b) => b.loading(),
-      mdsIndex: 1,
+      mdsIndex: 5,
       infiniteAnimation: true,
     ),
-    // Empty — 데이터 없음.
-    MdsState('state-empty', (b) => b.empty(), mdsIndex: 2),
-    // Error — 데이터 조회 실패.
-    MdsState('state-error', (b) => b.error(), mdsIndex: 3),
+    // Error — state_6: 데이터 조회 실패.
+    MdsState('state-error', (b) => b.error(), mdsIndex: 6),
   ],
 );
 

--- a/apps/app_partner/pubspec.yaml
+++ b/apps/app_partner/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.05.28-dev-staging+2868
+version: 26.05.28-dev-staging+2872
 resolution: workspace
 
 environment:

--- a/apps/app_user/pubspec.yaml
+++ b/apps/app_user/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 26.05.28-dev-staging+2868
+version: 26.05.28-dev-staging+2872
 resolution: workspace
 
 environment:


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- add `settlement_page` MDS emulator-render catalog for app_partner (`builder.dart`, `settlement_page_test.dart`)
- register new catalog in `apps/app_partner/integration_test/mds-emulator-render/_registry.dart`
- update app_partner mds-emulator-render BLUEDOC registered-screen table/structure

## Why
- Refs #2819
- partial coverage work: this PR adds one catalog slice only, and follow-up PRs are still needed to cover remaining `uncovered_screens`

## Verification
- `flutter analyze integration_test/mds-emulator-render/settlement_page` (cwd: `apps/app_partner`)
- `dart run scripts/mds_render_coverage.dart --json`
  - `cataloged_screens: 37`
  - `screen_coverage_pct: 56.1`
  - `uncovered_screens` no longer contains `settlement_page`

## Residual Risk
- state coverage remains unchanged (`captured_states` depends on emulator PNG capture output).