### PR TITLE
test(app_partner): add settlement_detail_page MDS render catalog

### DIFF
--- a/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
@@ -29,6 +29,7 @@ flutter drive \
 | `party_list_page` | default · empty · loading · error · help |
 | `partner_login_page` | default-ios · default-android · loading · auth-error |
 | `recurrence_management_screen` | active · paused · cancelled · no-rule · action-loading · loading · active-dark |
+| `settlement_detail_page` | completed · pending · failed · hold · loading |
 | `settlement_page` | loading · empty · error |
 | `verification_manage_page` | loading · active-empty · active-with-items · archived-with-items · dark |
 
@@ -70,6 +71,9 @@ mds-emulator-render/
 ├── recurrence_management_screen/
 │   ├── builder.dart
 │   └── recurrence_management_screen_test.dart
+├── settlement_detail_page/
+│   ├── builder.dart
+│   └── settlement_detail_page_test.dart
 ├── settlement_page/
 │   ├── builder.dart
 │   └── settlement_page_test.dart
@@ -83,4 +87,4 @@ mds-emulator-render/
 - [app_user mds-emulator-render](../../../app_user/integration_test/mds-emulator-render/BLUEDOC.md)
 - [architecture.md](../../../app_user/integration_test/mds-emulator-render/architecture.md)
 
-_Reviewed: 2026-05-28 23:17_
+_Reviewed: 2026-05-29 03:18_

--- a/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
@@ -15,6 +15,8 @@ import 'party_list_page/party_list_page_test.dart' as party_list_page;
 import 'partner_login_page/partner_login_page_test.dart' as partner_login_page;
 import 'recurrence_management_screen/recurrence_management_screen_test.dart'
     as recurrence_management_screen;
+import 'settlement_detail_page/settlement_detail_page_test.dart'
+    as settlement_detail_page;
 import 'settlement_page/settlement_page_test.dart' as settlement_page;
 import 'verification_manage_page/verification_manage_page_test.dart'
     as verification_manage_page;
@@ -29,6 +31,7 @@ final List<Object> catalogs = [
   party_list_page.catalog,
   partner_login_page.catalog,
   recurrence_management_screen.catalog,
+  settlement_detail_page.catalog,
   settlement_page.catalog,
   verification_manage_page.catalog,
 ];

--- a/apps/app_partner/integration_test/mds-emulator-render/settlement_detail_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/settlement_detail_page/builder.dart
@@ -1,0 +1,216 @@
+// SettlementDetailPageBuilder - settlement_detail_page 전용 fluent API.
+//
+// SettlementDetailPage 는 settlementRepositoryProvider 를 통해 상세 데이터를
+// 로드한다. MDS render에서는 fake repository로 상태를 고정해
+// COMPLETED / PENDING / FAILED / HOLD / LOADING 상태를 결정적으로 재현한다.
+
+import 'dart:async';
+
+import 'package:app_partner/src/features/settlement/settlement_detail_page.dart';
+import 'package:app_partner/src/logic/current_partner_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+import '../_mocks/data.dart';
+
+enum _SettlementDetailScenario { completed, pending, failed, hold, loading }
+
+class _FakeSettlementRepository implements SettlementRepository {
+  _FakeSettlementRepository({required this.scenario});
+
+  final _SettlementDetailScenario scenario;
+
+  static final DateTime _base = DateTime.utc(2026, 5, 29, 2);
+
+  SettlementItemDetail _detail({
+    required String status,
+    required bool retryable,
+    List<SettlementHistoryEntry> histories = const <SettlementHistoryEntry>[],
+  }) {
+    return SettlementItemDetail(
+      id: 'mock-settlement-item-1',
+      partnerId: 'mock-partner-1',
+      status: status,
+      grossAmount: 560000,
+      platformFeeAmount: 56000,
+      pgFeeAmount: 16800,
+      vatAmount: 5600,
+      netAmount: 481600,
+      currency: 'KRW',
+      createdAt: _base,
+      updatedAt: _base,
+      retryable: retryable,
+      retryCount: retryable ? 1 : 0,
+      histories: histories,
+      adjustments: const <AdjustmentItemModel>[],
+      payoutId: retryable ? 'mock-payout-1' : null,
+    );
+  }
+
+  @override
+  Future<SettlementItemDetail?> getSettlementItemDetail(String itemId) async {
+    switch (scenario) {
+      case _SettlementDetailScenario.completed:
+        return _detail(
+          status: 'COMPLETED',
+          retryable: false,
+          histories: <SettlementHistoryEntry>[
+            SettlementHistoryEntry(
+              eventType: 'STATUS_CHANGED',
+              fromStatus: 'PENDING',
+              toStatus: 'READY',
+              createdAt: _base.subtract(const Duration(days: 3)),
+            ),
+            SettlementHistoryEntry(
+              eventType: 'STATUS_CHANGED',
+              fromStatus: 'READY',
+              toStatus: 'PROCESSING',
+              createdAt: _base.subtract(const Duration(days: 2)),
+            ),
+            SettlementHistoryEntry(
+              eventType: 'STATUS_CHANGED',
+              fromStatus: 'PROCESSING',
+              toStatus: 'COMPLETED',
+              createdAt: _base.subtract(const Duration(days: 1)),
+            ),
+          ],
+        );
+      case _SettlementDetailScenario.pending:
+        return _detail(
+          status: 'PENDING',
+          retryable: false,
+        );
+      case _SettlementDetailScenario.failed:
+        return _detail(
+          status: 'FAILED',
+          retryable: true,
+          histories: <SettlementHistoryEntry>[
+            SettlementHistoryEntry(
+              eventType: 'STATUS_CHANGED',
+              fromStatus: 'PROCESSING',
+              toStatus: 'FAILED',
+              createdAt: _base.subtract(const Duration(hours: 5)),
+            ),
+          ],
+        );
+      case _SettlementDetailScenario.hold:
+        return _detail(
+          status: 'HOLD',
+          retryable: false,
+        );
+      case _SettlementDetailScenario.loading:
+        return Future<SettlementItemDetail?>.delayed(const Duration(days: 1));
+    }
+  }
+
+  @override
+  Future<Map<String, dynamic>> getSettlementDashboard({
+    required String partnerId,
+    DateTime? periodStart,
+    DateTime? periodEnd,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<List<SettlementItemDetail>> getSettlementItems({
+    required String partnerId,
+    String? status,
+    DateTime? dateStart,
+    DateTime? dateEnd,
+    int limit = 20,
+    int offset = 0,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<Map<String, dynamic>?> getBankAccount(String partnerId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> upsertBankAccount({
+    required String partnerId,
+    required String bankName,
+    required String accountHolder,
+    required String accountNumber,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<Map<String, dynamic>?> getEventInfo(String eventId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<Map<String, dynamic>?> getPartnerSettlementInfo(String partnerId) =>
+      throw UnimplementedError();
+
+  @override
+  Future<Map<String, dynamic>> retryPayout({
+    required String payoutId,
+    required String partnerId,
+  }) => throw UnimplementedError();
+}
+
+class SettlementDetailPageBuilder
+    extends MdsScreenBuilder<SettlementDetailPage> {
+  SettlementDetailPageBuilder()
+    : super(page: const SettlementDetailPage(itemId: 'mock-settlement-item-1'));
+
+  _SettlementDetailScenario _scenario = _SettlementDetailScenario.completed;
+  Brightness _brightness = Brightness.light;
+
+  SettlementDetailPageBuilder completed() {
+    _scenario = _SettlementDetailScenario.completed;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  SettlementDetailPageBuilder pending() {
+    _scenario = _SettlementDetailScenario.pending;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  SettlementDetailPageBuilder failed() {
+    _scenario = _SettlementDetailScenario.failed;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  SettlementDetailPageBuilder hold() {
+    _scenario = _SettlementDetailScenario.hold;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  SettlementDetailPageBuilder loading() {
+    _scenario = _SettlementDetailScenario.loading;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  SettlementDetailPageBuilder dark() {
+    _brightness = Brightness.dark;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  @override
+  Widget build() {
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => null),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+        currentPartnerInfoProvider.overrideWith((_) async => mockPartner()),
+        settlementRepositoryProvider.overrideWith(
+          (_) => _FakeSettlementRepository(scenario: _scenario),
+        ),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: _brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
+        home: const SettlementDetailPage(itemId: 'mock-settlement-item-1'),
+      ),
+    );
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/settlement_detail_page/settlement_detail_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/settlement_detail_page/settlement_detail_page_test.dart
@@ -1,0 +1,29 @@
+// MDS screen: settlement_detail_page (app_partner)
+// 대응 MDS: apps/mds/docs/public/specs/settlement_detail_page/
+//
+// 출력: docs/infra/mds-emulator-render/settlement_detail_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<SettlementDetailPageBuilder>(
+  screen: 'settlement_detail_page',
+  mdsSpec: 'apps/mds/docs/public/specs/settlement_detail_page/',
+  builder: SettlementDetailPageBuilder.new,
+  states: [
+    MdsState('state-completed', (b) => b.completed(), mdsIndex: 1),
+    MdsState('state-pending', (b) => b.pending(), mdsIndex: 2),
+    MdsState('state-failed', (b) => b.failed(), mdsIndex: 3),
+    MdsState('state-hold', (b) => b.hold(), mdsIndex: 4),
+    MdsState(
+      'state-loading',
+      (b) => b.loading(),
+      mdsIndex: 5,
+      infiniteAnimation: true,
+    ),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- add `settlement_detail_page` MDS emulator-render catalog for app_partner
- add deterministic builder states for COMPLETED/PENDING/FAILED/HOLD/LOADING via fake settlement repository overrides
- register the catalog in `_registry.dart` and update app_partner mds-emulator-render BLUEDOC map

## Why
- Refs #2819
- This is **partial** work from the aggregate MDS render coverage backlog, so this PR should **not close** issue #2819.
- Remaining follow-up coverage work is still tracked in #2819.

## Verification
- `flutter analyze integration_test/mds-emulator-render/settlement_detail_page` (cwd: `apps/app_partner`)
- `dart run scripts/mds_render_coverage.dart --json` (confirmed `settlement_detail_page` removed from `uncovered_screens`, `cataloged_screens: 38`, `screen_coverage_pct: 57.6`)

## Residual risk
- This PR does not cover the spec's CSV bottom-sheet state (`state_6`), so state coverage for `settlement_detail_page` remains incomplete.
