### PR TITLE
test(mds-render): add partner_welcome_page render catalog

### DIFF
--- a/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
@@ -28,6 +28,7 @@ flutter drive \
 | `more_page` | default · limited-permissions |
 | `party_list_page` | default · empty · loading · error · help |
 | `partner_login_page` | default-ios · default-android · loading · auth-error |
+| `partner_welcome_page` | default |
 | `recurrence_management_screen` | active · paused · cancelled · no-rule · action-loading · loading · active-dark |
 | `settlement_detail_page` | completed · pending · failed · hold · loading |
 | `settlement_page` | loading · empty · error |
@@ -68,6 +69,9 @@ mds-emulator-render/
 ├── partner_login_page/
 │   ├── builder.dart
 │   └── partner_login_page_test.dart
+├── partner_welcome_page/
+│   ├── builder.dart
+│   └── partner_welcome_page_test.dart
 ├── recurrence_management_screen/
 │   ├── builder.dart
 │   └── recurrence_management_screen_test.dart
@@ -87,4 +91,4 @@ mds-emulator-render/
 - [app_user mds-emulator-render](../../../app_user/integration_test/mds-emulator-render/BLUEDOC.md)
 - [architecture.md](../../../app_user/integration_test/mds-emulator-render/architecture.md)
 
-_Reviewed: 2026-05-29 03:18_
+_Reviewed: 2026-05-29 07:49_

--- a/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
@@ -13,6 +13,8 @@ import 'location_guide_page/location_guide_page_test.dart'
 import 'more_page/more_page_test.dart' as more_page;
 import 'party_list_page/party_list_page_test.dart' as party_list_page;
 import 'partner_login_page/partner_login_page_test.dart' as partner_login_page;
+import 'partner_welcome_page/partner_welcome_page_test.dart'
+    as partner_welcome_page;
 import 'recurrence_management_screen/recurrence_management_screen_test.dart'
     as recurrence_management_screen;
 import 'settlement_detail_page/settlement_detail_page_test.dart'
@@ -30,6 +32,7 @@ final List<Object> catalogs = [
   more_page.catalog,
   party_list_page.catalog,
   partner_login_page.catalog,
+  partner_welcome_page.catalog,
   recurrence_management_screen.catalog,
   settlement_detail_page.catalog,
   settlement_page.catalog,

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_welcome_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_welcome_page/builder.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+
+import 'package:app_partner/src/features/onboarding/partner_welcome_page.dart';
+import 'package:app_partner/src/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+
+class PartnerWelcomePageBuilder extends MdsScreenBuilder<PartnerWelcomePage> {
+  PartnerWelcomePageBuilder() : super(page: const PartnerWelcomePage());
+
+  Brightness _brightness = Brightness.light;
+
+  PartnerWelcomePageBuilder defaultState() {
+    _brightness = Brightness.light;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartnerWelcomePageBuilder dark() {
+    _brightness = Brightness.dark;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  @override
+  Widget build() {
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => null),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('ko'),
+        theme: _brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
+        home: const PartnerWelcomePage(),
+      ),
+    );
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_welcome_page/partner_welcome_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_welcome_page/partner_welcome_page_test.dart
@@ -1,0 +1,20 @@
+// MDS screen: partner_welcome_page (app_partner)
+// 대응 MDS: apps/mds/docs/public/specs/partner_welcome_page/
+//
+// 출력: docs/infra/mds-emulator-render/partner_welcome_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<PartnerWelcomePageBuilder>(
+  screen: 'partner_welcome_page',
+  mdsSpec: 'apps/mds/docs/public/specs/partner_welcome_page/',
+  builder: PartnerWelcomePageBuilder.new,
+  states: [
+    MdsState('state-default', (b) => b.defaultState(), mdsIndex: 1),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- add `partner_welcome_page` MDS render catalog (`builder.dart`, `partner_welcome_page_test.dart`) for app_partner
- register the catalog in `apps/app_partner/integration_test/mds-emulator-render/_registry.dart`
- update app_partner mds-emulator-render BLUEDOC index/table and Reviewed timestamp

## Why
- fix one uncovered screen slice from the aggregate coverage issue so coverage monitor can track this screen via catalog registry

## Verification
- `flutter analyze integration_test/mds-emulator-render/partner_welcome_page` (cwd: `apps/app_partner`) 
- `dart run scripts/mds_render_coverage.dart --json` → `cataloged_screens: 39`, `screen_coverage_pct: 59.1`, and `partner_welcome_page` removed from `uncovered_screens`

## Residual Risk
- only baseline state (`state_1`) is mapped in this slice; additional state mappings for `partner_welcome_page` remain for follow-up coverage work

Refs #2819
