### PR TITLE
test(mds): add partner_home_page render catalog

### DIFF
--- a/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
@@ -27,6 +27,7 @@ flutter drive \
 | `location_guide_page` | default · loading |
 | `more_page` | default · limited-permissions |
 | `party_list_page` | default · empty · loading · error · help |
+| `partner_home_page` | default |
 | `partner_login_page` | default-ios · default-android · loading · auth-error |
 | `partner_welcome_page` | default |
 | `recurrence_management_screen` | active · paused · cancelled · no-rule · action-loading · loading · active-dark |
@@ -66,6 +67,9 @@ mds-emulator-render/
 ├── party_list_page/
 │   ├── builder.dart
 │   └── party_list_page_test.dart
+├── partner_home_page/
+│   ├── builder.dart
+│   └── partner_home_page_test.dart
 ├── partner_login_page/
 │   ├── builder.dart
 │   └── partner_login_page_test.dart
@@ -91,4 +95,4 @@ mds-emulator-render/
 - [app_user mds-emulator-render](../../../app_user/integration_test/mds-emulator-render/BLUEDOC.md)
 - [architecture.md](../../../app_user/integration_test/mds-emulator-render/architecture.md)
 
-_Reviewed: 2026-05-29 07:49_
+_Reviewed: 2026-05-29 11:53_

--- a/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
@@ -12,6 +12,7 @@ import 'location_guide_page/location_guide_page_test.dart'
     as location_guide_page;
 import 'more_page/more_page_test.dart' as more_page;
 import 'party_list_page/party_list_page_test.dart' as party_list_page;
+import 'partner_home_page/partner_home_page_test.dart' as partner_home_page;
 import 'partner_login_page/partner_login_page_test.dart' as partner_login_page;
 import 'partner_welcome_page/partner_welcome_page_test.dart'
     as partner_welcome_page;
@@ -31,6 +32,7 @@ final List<Object> catalogs = [
   location_guide_page.catalog,
   more_page.catalog,
   party_list_page.catalog,
+  partner_home_page.catalog,
   partner_login_page.catalog,
   partner_welcome_page.catalog,
   recurrence_management_screen.catalog,

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_home_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_home_page/builder.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+
+import 'package:app_partner/src/features/home/partner_dashboard_controller.dart';
+import 'package:app_partner/src/features/home/partner_home_coordinator.dart';
+import 'package:app_partner/src/features/home/partner_home_page.dart';
+import 'package:app_partner/src/l10n/generated/app_localizations.dart';
+import 'package:app_partner/src/logic/current_partner_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+
+class _LoadedDashboardController extends PartnerDashboardController {
+  @override
+  PartnerDashboardState build() {
+    final now = DateTime(2026, 5, 29, 12);
+    final event = Event(
+      id: 'event-1',
+      partyId: 'party-1',
+      title: '강남 소셜 밍글',
+      startTime: now.add(const Duration(hours: 5)),
+      endTime: now.add(const Duration(hours: 8)),
+      createdAt: now,
+      updatedAt: now,
+      currentParticipants: 16,
+      maxParticipants: 24,
+    );
+    final party = Party(
+      id: 'party-1',
+      partnerId: 'partner-1',
+      title: '금요일 네트워킹',
+      createdAt: now,
+      updatedAt: now,
+    );
+
+    return PartnerDashboardState(
+      status: const AsyncValue.data(null),
+      pendingReviewCount: 3,
+      recruitingEvents: [event],
+      activeParties: [party],
+      totalPartyCount: 1,
+      totalAttendees: 16,
+      hasAnyEvents: true,
+    );
+  }
+}
+
+class _NoOpNotificationList extends NotificationList {
+  @override
+  Future<List<Map<String, dynamic>>> build() async => const [];
+}
+
+class _NoOpPartnerHomeCoordinator implements PartnerHomeCoordinator {
+  @override
+  void goToApplicationList() {}
+
+  @override
+  void goToCheckin() {}
+
+  @override
+  void goToSettlement() {}
+
+  @override
+  void pushApplicationList() {}
+
+  @override
+  void pushEventCreate(String partyId) {}
+
+  @override
+  void pushEventDetail({required String partyId, required String eventId}) {}
+
+  @override
+  void pushLocationGuide() {}
+
+  @override
+  void pushNotificationCenter() {}
+
+  @override
+  void pushPartyCreate() {}
+
+  @override
+  void pushPartyEdit(String partyId) {}
+}
+
+class PartnerHomePageBuilder extends MdsScreenBuilder<PartnerHomePage> {
+  PartnerHomePageBuilder() : super(page: const PartnerHomePage());
+
+  Brightness _brightness = Brightness.light;
+
+  PartnerHomePageBuilder defaultState() {
+    _brightness = Brightness.light;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartnerHomePageBuilder dark() {
+    _brightness = Brightness.dark;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  @override
+  Widget build() {
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => null),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+        currentPartnerInfoProvider.overrideWith(
+          (_) async => const Partner(id: 'partner-1', name: '밍글릿 강남 라운지'),
+        ),
+        partnerDashboardControllerProvider.overrideWith(
+          _LoadedDashboardController.new,
+        ),
+        notificationListProvider.overrideWith(_NoOpNotificationList.new),
+        partnerHomeCoordinatorProvider.overrideWith(
+          (_) => _NoOpPartnerHomeCoordinator(),
+        ),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('ko'),
+        theme: _brightness == Brightness.dark
+            ? MinglitTheme.materialThemeDark
+            : MinglitTheme.materialTheme,
+        home: const PartnerHomePage(),
+      ),
+    );
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_home_page/partner_home_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_home_page/partner_home_page_test.dart
@@ -1,0 +1,20 @@
+// MDS screen: partner_home_page (app_partner)
+// 대응 MDS: apps/mds/docs/public/specs/partner_home_page/
+//
+// 출력: docs/infra/mds-emulator-render/partner_home_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<PartnerHomePageBuilder>(
+  screen: 'partner_home_page',
+  mdsSpec: 'apps/mds/docs/public/specs/partner_home_page/',
+  builder: PartnerHomePageBuilder.new,
+  states: [
+    MdsState('state-default', (b) => b.defaultState(), mdsIndex: 1),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- add new MDS render catalog for `partner_home_page` under `apps/app_partner/integration_test/mds-emulator-render/partner_home_page/`
- provide deterministic render builder with fake dashboard/partner/notification/coordinator overrides for `PartnerHomePage`
- register the new catalog in `_registry.dart` and update app_partner MDS render `BLUEDOC.md`

## Why
- issue #2819 tracks uncovered MDS screens; `partner_home_page` was still uncovered
- this PR handles one self-contained screen slice per PR policy

## Verification
- `flutter analyze integration_test/mds-emulator-render/partner_home_page` (cwd: `apps/app_partner`)
- `dart run scripts/mds_render_coverage.dart --json`
  - `cataloged_screens: 40`
  - `screen_coverage_pct: 60.6`
  - `.uncovered_screens | index("partner_home_page") == null`

## Residual Risk
- only baseline state is cataloged in this slice (`state-default`); remaining MDS states for `partner_home_page` are follow-up work

Refs #2819
