### PR TITLE
test(mds): add partner_member_list_page render catalog

### DIFF
--- a/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
@@ -29,6 +29,7 @@ flutter drive \
 | `party_list_page` | default · empty · loading · error · help |
 | `partner_home_page` | default |
 | `partner_login_page` | default-ios · default-android · loading · auth-error |
+| `partner_member_list_page` | default · empty · loading · error · invite-snackbar |
 | `partner_welcome_page` | default |
 | `recurrence_management_screen` | active · paused · cancelled · no-rule · action-loading · loading · active-dark |
 | `settlement_detail_page` | completed · pending · failed · hold · loading |
@@ -73,6 +74,9 @@ mds-emulator-render/
 ├── partner_login_page/
 │   ├── builder.dart
 │   └── partner_login_page_test.dart
+├── partner_member_list_page/
+│   ├── builder.dart
+│   └── partner_member_list_page_test.dart
 ├── partner_welcome_page/
 │   ├── builder.dart
 │   └── partner_welcome_page_test.dart
@@ -95,4 +99,4 @@ mds-emulator-render/
 - [app_user mds-emulator-render](../../../app_user/integration_test/mds-emulator-render/BLUEDOC.md)
 - [architecture.md](../../../app_user/integration_test/mds-emulator-render/architecture.md)
 
-_Reviewed: 2026-05-29 11:53_
+_Reviewed: 2026-05-29 16:37_

--- a/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
@@ -14,6 +14,8 @@ import 'more_page/more_page_test.dart' as more_page;
 import 'party_list_page/party_list_page_test.dart' as party_list_page;
 import 'partner_home_page/partner_home_page_test.dart' as partner_home_page;
 import 'partner_login_page/partner_login_page_test.dart' as partner_login_page;
+import 'partner_member_list_page/partner_member_list_page_test.dart'
+    as partner_member_list_page;
 import 'partner_welcome_page/partner_welcome_page_test.dart'
     as partner_welcome_page;
 import 'recurrence_management_screen/recurrence_management_screen_test.dart'
@@ -34,6 +36,7 @@ final List<Object> catalogs = [
   party_list_page.catalog,
   partner_home_page.catalog,
   partner_login_page.catalog,
+  partner_member_list_page.catalog,
   partner_welcome_page.catalog,
   recurrence_management_screen.catalog,
   settlement_detail_page.catalog,

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_member_list_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_member_list_page/builder.dart
@@ -1,0 +1,137 @@
+import 'dart:async';
+
+import 'package:app_partner/src/features/member/partner_member_list_page.dart';
+import 'package:app_partner/src/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+
+const _mockPartnerId = 'mock-partner-1';
+
+enum _PartnerMemberListScenario { defaultState, empty, loading, error, invite }
+
+const _defaultMembers = <Map<String, dynamic>>[
+  {
+    'user_id': 'owner-1',
+    'role': 'owner',
+    'user': {'name': '박민호'},
+  },
+  {
+    'user_id': 'manager-1',
+    'role': 'manager',
+    'user': {'name': '김서연'},
+  },
+  {
+    'user_id': 'staff-1',
+    'role': 'staff',
+    'user': {'name': '이도윤'},
+  },
+];
+
+class _AutoShowInviteMessage extends StatefulWidget {
+  const _AutoShowInviteMessage({required this.child});
+
+  final Widget child;
+
+  @override
+  State<_AutoShowInviteMessage> createState() => _AutoShowInviteMessageState();
+}
+
+class _AutoShowInviteMessageState extends State<_AutoShowInviteMessage> {
+  bool _shown = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_shown) return;
+    _shown = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      context.showMinglitInfo('준비 중입니다.');
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
+
+class PartnerMemberListPageBuilder
+    extends MdsScreenBuilder<PartnerMemberListPage> {
+  PartnerMemberListPageBuilder()
+    : super(page: const PartnerMemberListPage(partnerId: _mockPartnerId));
+
+  _PartnerMemberListScenario _scenario =
+      _PartnerMemberListScenario.defaultState;
+
+  PartnerMemberListPageBuilder defaultState() {
+    _scenario = _PartnerMemberListScenario.defaultState;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartnerMemberListPageBuilder empty() {
+    _scenario = _PartnerMemberListScenario.empty;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartnerMemberListPageBuilder loading() {
+    _scenario = _PartnerMemberListScenario.loading;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartnerMemberListPageBuilder error() {
+    _scenario = _PartnerMemberListScenario.error;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartnerMemberListPageBuilder inviteSnackbar() {
+    _scenario = _PartnerMemberListScenario.invite;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  @override
+  Widget build() {
+    final scenario = _scenario;
+    final Widget home = scenario == _PartnerMemberListScenario.invite
+        ? const _AutoShowInviteMessage(
+            child: PartnerMemberListPage(partnerId: _mockPartnerId),
+          )
+        : const PartnerMemberListPage(partnerId: _mockPartnerId);
+
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => null),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+        partnerMembersProvider(
+          partnerId: _mockPartnerId,
+        ).overrideWith((ref) async {
+          switch (scenario) {
+            case _PartnerMemberListScenario.defaultState:
+            case _PartnerMemberListScenario.invite:
+              return _defaultMembers;
+            case _PartnerMemberListScenario.empty:
+              return const <Map<String, dynamic>>[];
+            case _PartnerMemberListScenario.loading:
+              return Completer<List<Map<String, dynamic>>>().future;
+            case _PartnerMemberListScenario.error:
+              throw Exception('render: forced partner member list error');
+          }
+        }),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('ko'),
+        theme: MinglitTheme.materialTheme,
+        home: home,
+      ),
+    );
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_member_list_page/partner_member_list_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_member_list_page/partner_member_list_page_test.dart
@@ -1,0 +1,34 @@
+// MDS screen: partner_member_list_page (app_partner)
+// 대응 MDS: apps/mds/docs/public/specs/partner_member_list_page/
+//
+// 출력: docs/infra/mds-emulator-render/partner_member_list_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<PartnerMemberListPageBuilder>(
+  screen: 'partner_member_list_page',
+  mdsSpec: 'apps/mds/docs/public/specs/partner_member_list_page/',
+  builder: PartnerMemberListPageBuilder.new,
+  states: [
+    MdsState('state-default', (b) => b.defaultState(), mdsIndex: 1),
+    MdsState('state-empty', (b) => b.empty(), mdsIndex: 2),
+    MdsState(
+      'state-loading',
+      (b) => b.loading(),
+      mdsIndex: 3,
+      infiniteAnimation: true,
+    ),
+    MdsState('state-error', (b) => b.error(), mdsIndex: 4),
+    MdsState(
+      'state-invite-snackbar',
+      (b) => b.inviteSnackbar(),
+      mdsIndex: 5,
+      infiniteAnimation: true,
+    ),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- add `apps/app_partner/integration_test/mds-emulator-render/partner_member_list_page/` catalog (`builder.dart`, `partner_member_list_page_test.dart`)
- register the new catalog in `apps/app_partner/integration_test/mds-emulator-render/_registry.dart`
- update app_partner mds-emulator-render BLUEDOC landmark table/structure/reviewed timestamp

## Why
- Refs #2819
- This tracker issue is aggregate coverage work; this PR handles one self-contained uncovered screen slice (`partner_member_list_page`) and does not close the parent issue yet.

## Verification
- `flutter analyze integration_test/mds-emulator-render/partner_member_list_page` (cwd: `apps/app_partner`)
- `dart run scripts/mds_render_coverage.dart --json`
  - `cataloged_screens: 41`, `screen_coverage_pct: 62.1`
  - `uncovered_screens` no longer contains `partner_member_list_page`

## Residual Risk
- The invite snackbar state is auto-triggered via post-frame info snackbar; visual timing may vary slightly per emulator frame timing.