### PR TITLE
test(mds): add partner_member_permission_page render catalog

### DIFF
--- a/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
@@ -30,6 +30,7 @@ flutter drive \
 | `partner_home_page` | default |
 | `partner_login_page` | default-ios · default-android · loading · auth-error |
 | `partner_member_list_page` | default · empty · loading · error · invite-snackbar |
+| `partner_member_permission_page` | default · owner-role · not-found · loading · error |
 | `partner_welcome_page` | default |
 | `recurrence_management_screen` | active · paused · cancelled · no-rule · action-loading · loading · active-dark |
 | `settlement_detail_page` | completed · pending · failed · hold · loading |
@@ -77,6 +78,9 @@ mds-emulator-render/
 ├── partner_member_list_page/
 │   ├── builder.dart
 │   └── partner_member_list_page_test.dart
+├── partner_member_permission_page/
+│   ├── builder.dart
+│   └── partner_member_permission_page_test.dart
 ├── partner_welcome_page/
 │   ├── builder.dart
 │   └── partner_welcome_page_test.dart
@@ -99,4 +103,4 @@ mds-emulator-render/
 - [app_user mds-emulator-render](../../../app_user/integration_test/mds-emulator-render/BLUEDOC.md)
 - [architecture.md](../../../app_user/integration_test/mds-emulator-render/architecture.md)
 
-_Reviewed: 2026-05-29 16:37_
+_Reviewed: 2026-05-29 18:58_

--- a/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
@@ -16,6 +16,8 @@ import 'partner_home_page/partner_home_page_test.dart' as partner_home_page;
 import 'partner_login_page/partner_login_page_test.dart' as partner_login_page;
 import 'partner_member_list_page/partner_member_list_page_test.dart'
     as partner_member_list_page;
+import 'partner_member_permission_page/partner_member_permission_page_test.dart'
+    as partner_member_permission_page;
 import 'partner_welcome_page/partner_welcome_page_test.dart'
     as partner_welcome_page;
 import 'recurrence_management_screen/recurrence_management_screen_test.dart'
@@ -37,6 +39,7 @@ final List<Object> catalogs = [
   partner_home_page.catalog,
   partner_login_page.catalog,
   partner_member_list_page.catalog,
+  partner_member_permission_page.catalog,
   partner_welcome_page.catalog,
   recurrence_management_screen.catalog,
   settlement_detail_page.catalog,

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_member_permission_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_member_permission_page/builder.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+
+import 'package:app_partner/src/features/member/partner_member_permission_page.dart';
+import 'package:app_partner/src/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+
+const _mockPartnerId = 'mock-partner-1';
+const _mockTargetUserId = 'mock-user-1';
+
+enum _PartnerMemberPermissionScenario {
+  defaultState,
+  ownerRole,
+  notFound,
+  loading,
+  error,
+}
+
+const _managerMember = <String, dynamic>{
+  'user_id': _mockTargetUserId,
+  'role': 'manager',
+  'permissions': <String>[
+    'PARTNER_EDIT',
+    'SETTLEMENT_VIEW',
+    'PARTY_MANAGE',
+  ],
+  'user': <String, dynamic>{'name': '김서연', 'email': 'manager@minglit.com'},
+};
+
+const _ownerMember = <String, dynamic>{
+  'user_id': _mockTargetUserId,
+  'role': 'owner',
+  'permissions': <String>[
+    'PARTNER_EDIT',
+    'SETTLEMENT_VIEW',
+    'SETTLEMENT_EDIT',
+    'MEMBER_MANAGE',
+    'PARTY_MANAGE',
+    'VERIFY_LIST_VIEW',
+    'USER_DATA_VIEW',
+    'VERIFY_REVIEW',
+    'COMMENT_MANAGE',
+  ],
+  'user': <String, dynamic>{'name': '박민호', 'email': 'owner@minglit.com'},
+};
+
+class PartnerMemberPermissionPageBuilder
+    extends MdsScreenBuilder<PartnerMemberPermissionPage> {
+  PartnerMemberPermissionPageBuilder()
+    : super(
+        page: const PartnerMemberPermissionPage(
+          partnerId: _mockPartnerId,
+          targetUserId: _mockTargetUserId,
+        ),
+      );
+
+  _PartnerMemberPermissionScenario _scenario =
+      _PartnerMemberPermissionScenario.defaultState;
+
+  PartnerMemberPermissionPageBuilder defaultState() {
+    _scenario = _PartnerMemberPermissionScenario.defaultState;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartnerMemberPermissionPageBuilder ownerRole() {
+    _scenario = _PartnerMemberPermissionScenario.ownerRole;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartnerMemberPermissionPageBuilder notFound() {
+    _scenario = _PartnerMemberPermissionScenario.notFound;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartnerMemberPermissionPageBuilder loading() {
+    _scenario = _PartnerMemberPermissionScenario.loading;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartnerMemberPermissionPageBuilder error() {
+    _scenario = _PartnerMemberPermissionScenario.error;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  @override
+  Widget build() {
+    final scenario = _scenario;
+
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => null),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+        partnerMemberProvider(
+          partnerId: _mockPartnerId,
+          targetUserId: _mockTargetUserId,
+        ).overrideWith((ref) async {
+          switch (scenario) {
+            case _PartnerMemberPermissionScenario.defaultState:
+              return _managerMember;
+            case _PartnerMemberPermissionScenario.ownerRole:
+              return _ownerMember;
+            case _PartnerMemberPermissionScenario.notFound:
+              return null;
+            case _PartnerMemberPermissionScenario.loading:
+              return Completer<Map<String, dynamic>?>().future;
+            case _PartnerMemberPermissionScenario.error:
+              throw Exception('render: forced partner member permission error');
+          }
+        }),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('ko'),
+        theme: MinglitTheme.materialTheme,
+        home: const PartnerMemberPermissionPage(
+          partnerId: _mockPartnerId,
+          targetUserId: _mockTargetUserId,
+        ),
+      ),
+    );
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_member_permission_page/partner_member_permission_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_member_permission_page/partner_member_permission_page_test.dart
@@ -1,0 +1,29 @@
+// MDS screen: partner_member_permission_page (app_partner)
+// 대응 MDS: apps/mds/docs/public/specs/partner_member_permission_page/
+//
+// 출력: docs/infra/mds-emulator-render/partner_member_permission_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<PartnerMemberPermissionPageBuilder>(
+  screen: 'partner_member_permission_page',
+  mdsSpec: 'apps/mds/docs/public/specs/partner_member_permission_page/',
+  builder: PartnerMemberPermissionPageBuilder.new,
+  states: [
+    MdsState('state-default', (b) => b.defaultState(), mdsIndex: 1),
+    MdsState('state-owner-role', (b) => b.ownerRole(), mdsIndex: 2),
+    MdsState('state-not-found', (b) => b.notFound(), mdsIndex: 3),
+    MdsState(
+      'state-loading',
+      (b) => b.loading(),
+      mdsIndex: 4,
+      infiniteAnimation: true,
+    ),
+    MdsState('state-error', (b) => b.error(), mdsIndex: 5),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- Add `partner_member_permission_page` MDS emulator-render catalog (`builder.dart`, `partner_member_permission_page_test.dart`) for `app_partner`.
- Register the new catalog in `integration_test/mds-emulator-render/_registry.dart`.
- Update `integration_test/mds-emulator-render/BLUEDOC.md` screen table/structure and Reviewed timestamp.

## Why
- Refs #2819
- This PR is **partial** coverage work for #2819 and does not close the parent issue yet.
- It removes one uncovered screen slice by making `partner_member_permission_page` cataloged in the render registry.

## Verification
- `flutter analyze integration_test/mds-emulator-render/partner_member_permission_page` (cwd: `apps/app_partner`)
- `dart run scripts/mds_render_coverage.dart --json`
  - confirmed `uncovered_screens` no longer includes `partner_member_permission_page`
  - `cataloged_screens: 42`, `screen_coverage_pct: 63.6`

## Residual risk
- State capture completeness is still pending for this screen (`captured: 0 / mds: 7`), so this PR is catalog coverage only.