### PR TITLE
test(mds): add partner_apply_status_page render catalog

### DIFF
--- a/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
@@ -27,6 +27,7 @@ flutter drive \
 | `location_guide_page` | default · loading |
 | `more_page` | default · limited-permissions |
 | `party_list_page` | default · empty · loading · error · help |
+| `partner_apply_status_page` | pending · needs-correction · needs-correction-comment |
 | `partner_home_page` | default |
 | `partner_login_page` | default-ios · default-android · loading · auth-error |
 | `partner_member_list_page` | default · empty · loading · error · invite-snackbar |
@@ -69,6 +70,9 @@ mds-emulator-render/
 ├── party_list_page/
 │   ├── builder.dart
 │   └── party_list_page_test.dart
+├── partner_apply_status_page/
+│   ├── builder.dart
+│   └── partner_apply_status_page_test.dart
 ├── partner_home_page/
 │   ├── builder.dart
 │   └── partner_home_page_test.dart
@@ -103,4 +107,4 @@ mds-emulator-render/
 - [app_user mds-emulator-render](../../../app_user/integration_test/mds-emulator-render/BLUEDOC.md)
 - [architecture.md](../../../app_user/integration_test/mds-emulator-render/architecture.md)
 
-_Reviewed: 2026-05-29 18:58_
+_Reviewed: 2026-05-29 23:09_

--- a/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
@@ -12,6 +12,8 @@ import 'location_guide_page/location_guide_page_test.dart'
     as location_guide_page;
 import 'more_page/more_page_test.dart' as more_page;
 import 'party_list_page/party_list_page_test.dart' as party_list_page;
+import 'partner_apply_status_page/partner_apply_status_page_test.dart'
+    as partner_apply_status_page;
 import 'partner_home_page/partner_home_page_test.dart' as partner_home_page;
 import 'partner_login_page/partner_login_page_test.dart' as partner_login_page;
 import 'partner_member_list_page/partner_member_list_page_test.dart'
@@ -36,6 +38,7 @@ final List<Object> catalogs = [
   location_guide_page.catalog,
   more_page.catalog,
   party_list_page.catalog,
+  partner_apply_status_page.catalog,
   partner_home_page.catalog,
   partner_login_page.catalog,
   partner_member_list_page.catalog,

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_apply_status_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_apply_status_page/builder.dart
@@ -1,0 +1,104 @@
+// PartnerApplyStatusPageBuilder — partner_apply_status_page 전용 fluent API.
+//
+// onboardingStateProvider + partnerRepositoryProvider 의존을 render 전용
+// override로 고정해 pending / needs-correction 상태를 deterministic하게
+// 재현한다.
+
+import 'dart:async';
+
+import 'package:app_partner/src/features/onboarding/partner_apply_status_page.dart';
+import 'package:app_partner/src/l10n/generated/app_localizations.dart';
+import 'package:app_partner/src/logic/onboarding_state_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+
+enum _Scenario { pending, needsCorrection, needsCorrectionWithComment }
+
+class _FakePartnerRepository implements PartnerRepository {
+  _FakePartnerRepository(this._application);
+
+  final PartnerApplication? _application;
+
+  @override
+  Future<PartnerApplication?> getMyApplication() async => _application;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class PartnerApplyStatusPageBuilder
+    extends MdsScreenBuilder<PartnerApplyStatusPage> {
+  PartnerApplyStatusPageBuilder() : super(page: const PartnerApplyStatusPage());
+
+  _Scenario _scenario = _Scenario.pending;
+
+  PartnerApplyStatusPageBuilder pending() {
+    _scenario = _Scenario.pending;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartnerApplyStatusPageBuilder needsCorrection() {
+    _scenario = _Scenario.needsCorrection;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartnerApplyStatusPageBuilder needsCorrectionWithComment() {
+    _scenario = _Scenario.needsCorrectionWithComment;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  @override
+  Widget build() {
+    final scenario = _scenario;
+
+    final onboardingState = switch (scenario) {
+      _Scenario.pending => OnboardingState.pendingReview,
+      _Scenario.needsCorrection ||
+      _Scenario.needsCorrectionWithComment => OnboardingState.needsCorrection,
+    };
+
+    final application = switch (scenario) {
+      _Scenario.pending => const PartnerApplication(
+        id: 'render-application-1',
+        userId: 'render-user-1',
+        status: 'pending',
+      ),
+      _Scenario.needsCorrection => const PartnerApplication(
+        id: 'render-application-2',
+        userId: 'render-user-1',
+        status: 'needs_correction',
+      ),
+      _Scenario.needsCorrectionWithComment => const PartnerApplication(
+        id: 'render-application-3',
+        userId: 'render-user-1',
+        status: 'needs_correction',
+        adminComment: '사업자등록증 이미지가 흐립니다. 재업로드해주세요.',
+      ),
+    };
+
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => null),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+        onboardingStateProvider.overrideWith((_) async => onboardingState),
+        partnerRepositoryProvider.overrideWith(
+          (_) => _FakePartnerRepository(application),
+        ),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('ko'),
+        theme: MinglitTheme.materialTheme,
+        home: const PartnerApplyStatusPage(),
+      ),
+    );
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_apply_status_page/partner_apply_status_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_apply_status_page/partner_apply_status_page_test.dart
@@ -1,0 +1,26 @@
+// MDS screen: partner_apply_status_page (app_partner)
+// 대응 MDS: apps/mds/docs/public/specs/partner_apply_status_page/
+//
+// 출력: docs/infra/mds-emulator-render/partner_apply_status_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<PartnerApplyStatusPageBuilder>(
+  screen: 'partner_apply_status_page',
+  mdsSpec: 'apps/mds/docs/public/specs/partner_apply_status_page/',
+  builder: PartnerApplyStatusPageBuilder.new,
+  states: [
+    MdsState('state-pending', (b) => b.pending(), mdsIndex: 1),
+    MdsState('state-needs-correction', (b) => b.needsCorrection(), mdsIndex: 2),
+    MdsState(
+      'state-needs-correction-comment',
+      (b) => b.needsCorrectionWithComment(),
+      mdsIndex: 3,
+    ),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- add `partner_apply_status_page` MDS emulator render catalog for app_partner
- implement render builder with deterministic overrides for `onboardingStateProvider` and `partnerRepositoryProvider` (`getMyApplication`) to cover pending / needs-correction variants
- register catalog in `_registry.dart` and update app_partner mds-emulator-render BLUEDOC index

## Why
- Refs #2819
- This PR is **partial** follow-up work from the aggregate MDS render coverage backlog.
- It does **not close** #2819; additional uncovered screen slices remain for separate PRs.

## Verification
- `flutter analyze integration_test/mds-emulator-render/partner_apply_status_page` (cwd: `apps/app_partner`) ✅
- `dart run scripts/mds_render_coverage.dart --json` ✅
  - `cataloged_screens`: 42 → 43
  - `screen_coverage_pct`: 63.6 → 65.2
  - `uncovered_screens` no longer includes `partner_apply_status_page`

## Residual Risk
- This PR adds catalog definitions only; captured PNG state coverage remains unchanged until emulator render artifacts are regenerated in the render pipeline.