### PR TITLE
test(mds): add partner_application_detail_page render catalog

### DIFF
--- a/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
@@ -27,6 +27,7 @@ flutter drive \
 | `location_guide_page` | default · loading |
 | `more_page` | default · limited-permissions |
 | `party_list_page` | default · empty · loading · error · help |
+| `partner_application_detail_page` | pending · approved · rejected · needs-correction · loading · not-found |
 | `partner_apply_status_page` | pending · needs-correction · needs-correction-comment |
 | `partner_home_page` | default |
 | `partner_login_page` | default-ios · default-android · loading · auth-error |
@@ -70,6 +71,9 @@ mds-emulator-render/
 ├── party_list_page/
 │   ├── builder.dart
 │   └── party_list_page_test.dart
+├── partner_application_detail_page/
+│   ├── builder.dart
+│   └── partner_application_detail_page_test.dart
 ├── partner_apply_status_page/
 │   ├── builder.dart
 │   └── partner_apply_status_page_test.dart
@@ -107,4 +111,4 @@ mds-emulator-render/
 - [app_user mds-emulator-render](../../../app_user/integration_test/mds-emulator-render/BLUEDOC.md)
 - [architecture.md](../../../app_user/integration_test/mds-emulator-render/architecture.md)
 
-_Reviewed: 2026-05-29 23:09_
+_Reviewed: 2026-05-30 09:24_

--- a/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
@@ -12,6 +12,8 @@ import 'location_guide_page/location_guide_page_test.dart'
     as location_guide_page;
 import 'more_page/more_page_test.dart' as more_page;
 import 'party_list_page/party_list_page_test.dart' as party_list_page;
+import 'partner_application_detail_page/partner_application_detail_page_test.dart'
+    as partner_application_detail_page;
 import 'partner_apply_status_page/partner_apply_status_page_test.dart'
     as partner_apply_status_page;
 import 'partner_home_page/partner_home_page_test.dart' as partner_home_page;
@@ -38,6 +40,7 @@ final List<Object> catalogs = [
   location_guide_page.catalog,
   more_page.catalog,
   party_list_page.catalog,
+  partner_application_detail_page.catalog,
   partner_apply_status_page.catalog,
   partner_home_page.catalog,
   partner_login_page.catalog,

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_application_detail_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_application_detail_page/builder.dart
@@ -1,0 +1,140 @@
+import 'dart:async';
+
+import 'package:app_partner/src/features/admin/partner_application_detail_page.dart';
+import 'package:app_partner/src/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+
+const _mockApplicationId = 'render-application-id';
+
+enum _PartnerApplicationDetailScenario {
+  pending,
+  approved,
+  rejected,
+  needsCorrection,
+  loading,
+  notFound,
+}
+
+class PartnerApplicationDetailPageBuilder
+    extends MdsScreenBuilder<PartnerApplicationDetailPage> {
+  PartnerApplicationDetailPageBuilder()
+    : super(
+        page: const PartnerApplicationDetailPage(
+          applicationId: _mockApplicationId,
+        ),
+      );
+
+  _PartnerApplicationDetailScenario _scenario =
+      _PartnerApplicationDetailScenario.pending;
+
+  PartnerApplicationDetailPageBuilder pending() {
+    _scenario = _PartnerApplicationDetailScenario.pending;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartnerApplicationDetailPageBuilder approved() {
+    _scenario = _PartnerApplicationDetailScenario.approved;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartnerApplicationDetailPageBuilder rejected() {
+    _scenario = _PartnerApplicationDetailScenario.rejected;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartnerApplicationDetailPageBuilder needsCorrection() {
+    _scenario = _PartnerApplicationDetailScenario.needsCorrection;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartnerApplicationDetailPageBuilder loading() {
+    _scenario = _PartnerApplicationDetailScenario.loading;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  PartnerApplicationDetailPageBuilder notFound() {
+    _scenario = _PartnerApplicationDetailScenario.notFound;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  @override
+  Widget build() {
+    final scenario = _scenario;
+
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => null),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+        partnerApplicationProvider(
+          applicationId: _mockApplicationId,
+        ).overrideWith((
+          ref,
+        ) async {
+          switch (scenario) {
+            case _PartnerApplicationDetailScenario.pending:
+              return _buildApplication(status: 'pending');
+            case _PartnerApplicationDetailScenario.approved:
+              return _buildApplication(
+                status: 'approved',
+                adminComment: '서류 확인 완료. 승인합니다.',
+              );
+            case _PartnerApplicationDetailScenario.rejected:
+              return _buildApplication(
+                status: 'rejected',
+                adminComment: '사업자 정보가 확인되지 않습니다.',
+              );
+            case _PartnerApplicationDetailScenario.needsCorrection:
+              return _buildApplication(
+                status: 'needs_correction',
+                adminComment: '통장 사본 해상도가 낮아 재업로드가 필요합니다.',
+              );
+            case _PartnerApplicationDetailScenario.loading:
+              return Completer<PartnerApplication?>().future;
+            case _PartnerApplicationDetailScenario.notFound:
+              return null;
+          }
+        }),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('ko'),
+        theme: MinglitTheme.materialTheme,
+        home: const PartnerApplicationDetailPage(
+          applicationId: _mockApplicationId,
+        ),
+      ),
+    );
+  }
+
+  PartnerApplication _buildApplication({
+    required String status,
+    String? adminComment,
+  }) {
+    return PartnerApplication(
+      id: _mockApplicationId,
+      userId: 'render-user-id',
+      status: status,
+      brandName: '밍글릿 로스터리',
+      bizName: '밍글릿 로스터리 주식회사',
+      representativeName: '김대표',
+      bizNumber: '123-45-67890',
+      contactPhone: '010-1234-5678',
+      address: '서울시 성동구 성수이로 77',
+      bizRegistrationPath: 'render/biz_registration.pdf',
+      bankbookPath: 'render/bankbook.png',
+      adminComment: adminComment,
+    );
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/partner_application_detail_page/partner_application_detail_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/partner_application_detail_page/partner_application_detail_page_test.dart
@@ -1,0 +1,34 @@
+// MDS screen: partner_application_detail_page (app_partner)
+// 대응 MDS: apps/mds/docs/public/specs/partner_application_detail_page/
+//
+// 출력: docs/infra/mds-emulator-render/partner_application_detail_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<PartnerApplicationDetailPageBuilder>(
+  screen: 'partner_application_detail_page',
+  mdsSpec: 'apps/mds/docs/public/specs/partner_application_detail_page/',
+  builder: PartnerApplicationDetailPageBuilder.new,
+  states: [
+    MdsState('state-pending', (b) => b.pending(), mdsIndex: 1),
+    MdsState('state-approved', (b) => b.approved(), mdsIndex: 2),
+    MdsState('state-rejected', (b) => b.rejected(), mdsIndex: 3),
+    MdsState(
+      'state-needs-correction',
+      (b) => b.needsCorrection(),
+      mdsIndex: 4,
+    ),
+    MdsState(
+      'state-loading',
+      (b) => b.loading(),
+      mdsIndex: 5,
+      infiniteAnimation: true,
+    ),
+    MdsState('state-not-found', (b) => b.notFound(), mdsIndex: 6),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- add `app_partner` MDS emulator render catalog for `partner_application_detail_page`
- implement deterministic render states in builder: pending, approved, rejected, needs-correction, loading, not-found
- register catalog in `_registry.dart` and update `mds-emulator-render/BLUEDOC.md` map + Reviewed timestamp

## Why
- Refs #2819
- This is one incremental slice of the aggregate MDS render coverage backlog (does not close the tracker issue).

## Verification
- `flutter analyze integration_test/mds-emulator-render/partner_application_detail_page` (cwd: `apps/app_partner`)
- `dart run scripts/mds_render_coverage.dart --json`
  - `cataloged_screens: 44`
  - `screen_coverage_pct: 66.7`
  - `uncovered_screens` no longer contains `partner_application_detail_page`

## Residual Risk
- Render capture PNGs under `docs/infra/mds-emulator-render/partner_application_detail_page/` are not generated in this PR, so state coverage remains unchanged until emulator render artifacts are captured in follow-up flow.