### PR TITLE
test(mds-render): add event_application_detail_page catalog

### DIFF
--- a/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
+++ b/apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md
@@ -24,6 +24,7 @@ flutter drive \
 | `bank_account_page` | loading · no-account · with-account · dark |
 | `checkin_placeholder_page` | loading · error · empty · selection · selection-dark |
 | `create_verification_page` | empty · with-fields · dark |
+| `event_application_detail_page` | pending-review · approved · rejected · paid · reject-dialog · loading |
 | `location_guide_page` | default · loading |
 | `more_page` | default · limited-permissions |
 | `party_list_page` | default · empty · loading · error · help |
@@ -62,6 +63,9 @@ mds-emulator-render/
 ├── create_verification_page/
 │   ├── builder.dart
 │   └── create_verification_page_test.dart
+├── event_application_detail_page/
+│   ├── builder.dart
+│   └── event_application_detail_page_test.dart
 ├── location_guide_page/
 │   ├── builder.dart
 │   └── location_guide_page_test.dart
@@ -111,4 +115,4 @@ mds-emulator-render/
 - [app_user mds-emulator-render](../../../app_user/integration_test/mds-emulator-render/BLUEDOC.md)
 - [architecture.md](../../../app_user/integration_test/mds-emulator-render/architecture.md)
 
-_Reviewed: 2026-05-30 09:24_
+_Reviewed: 2026-05-30 09:36_

--- a/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/_registry.dart
@@ -8,6 +8,8 @@ import 'checkin_placeholder_page/checkin_placeholder_page_test.dart'
     as checkin_placeholder_page;
 import 'create_verification_page/create_verification_page_test.dart'
     as create_verification_page;
+import 'event_application_detail_page/event_application_detail_page_test.dart'
+    as event_application_detail_page;
 import 'location_guide_page/location_guide_page_test.dart'
     as location_guide_page;
 import 'more_page/more_page_test.dart' as more_page;
@@ -37,6 +39,7 @@ final List<Object> catalogs = [
   bank_account_page.catalog,
   checkin_placeholder_page.catalog,
   create_verification_page.catalog,
+  event_application_detail_page.catalog,
   location_guide_page.catalog,
   more_page.catalog,
   party_list_page.catalog,

--- a/apps/app_partner/integration_test/mds-emulator-render/event_application_detail_page/builder.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/event_application_detail_page/builder.dart
@@ -1,0 +1,197 @@
+import 'dart:async';
+
+import 'package:app_partner/src/features/application/event_application_detail_page.dart';
+import 'package:app_partner/src/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+
+import '../_engine/builder.dart';
+
+const _mockApplicationId = 'render-event-application-id';
+
+enum _EventApplicationDetailScenario {
+  pendingReview,
+  approved,
+  rejected,
+  paid,
+  rejectDialog,
+  loading,
+}
+
+class _AutoShowRejectDialog extends StatefulWidget {
+  const _AutoShowRejectDialog({required this.child});
+
+  final Widget child;
+
+  @override
+  State<_AutoShowRejectDialog> createState() => _AutoShowRejectDialogState();
+}
+
+class _AutoShowRejectDialogState extends State<_AutoShowRejectDialog> {
+  bool _shown = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_shown) return;
+    _shown = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(
+        showDialog<void>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('거절 사유'),
+            content: const TextField(
+              maxLines: 3,
+              decoration: InputDecoration(
+                hintText: '거절 사유를 입력해주세요 (선택)',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            actions: [
+              TextButton(onPressed: () {}, child: const Text('취소')),
+              TextButton(onPressed: () {}, child: const Text('거절')),
+            ],
+          ),
+        ),
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
+
+class EventApplicationDetailPageBuilder
+    extends MdsScreenBuilder<EventApplicationDetailPage> {
+  EventApplicationDetailPageBuilder()
+    : super(
+        page: const EventApplicationDetailPage(
+          applicationId: _mockApplicationId,
+        ),
+      );
+
+  _EventApplicationDetailScenario _scenario =
+      _EventApplicationDetailScenario.pendingReview;
+
+  EventApplicationDetailPageBuilder pendingReview() {
+    _scenario = _EventApplicationDetailScenario.pendingReview;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  EventApplicationDetailPageBuilder approved() {
+    _scenario = _EventApplicationDetailScenario.approved;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  EventApplicationDetailPageBuilder rejected() {
+    _scenario = _EventApplicationDetailScenario.rejected;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  EventApplicationDetailPageBuilder paid() {
+    _scenario = _EventApplicationDetailScenario.paid;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  EventApplicationDetailPageBuilder rejectDialog() {
+    _scenario = _EventApplicationDetailScenario.rejectDialog;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  EventApplicationDetailPageBuilder loading() {
+    _scenario = _EventApplicationDetailScenario.loading;
+    // ignore: avoid_returning_this, fluent builder chain style
+    return this;
+  }
+
+  @override
+  Widget build() {
+    final scenario = _scenario;
+    final Widget home = scenario == _EventApplicationDetailScenario.rejectDialog
+        ? const _AutoShowRejectDialog(
+            child: EventApplicationDetailPage(
+              applicationId: _mockApplicationId,
+            ),
+          )
+        : const EventApplicationDetailPage(applicationId: _mockApplicationId);
+
+    return ProviderScope(
+      overrides: [
+        currentUserProvider.overrideWith((_) => null),
+        authStateChangesProvider.overrideWith((_) => const Stream.empty()),
+        notificationInitializerProvider.overrideWith((_) {}),
+        eventApplicationDetailProvider(
+          _mockApplicationId,
+        ).overrideWith((ref) async {
+          switch (scenario) {
+            case _EventApplicationDetailScenario.pendingReview:
+            case _EventApplicationDetailScenario.rejectDialog:
+              return _buildApplication(status: 'pending_review');
+            case _EventApplicationDetailScenario.approved:
+              return _buildApplication(
+                status: 'approved',
+                paymentAmount: 39000,
+              );
+            case _EventApplicationDetailScenario.rejected:
+              return _buildApplication(
+                status: 'rejected',
+                rejectionReason: '모집 대상 조건과 맞지 않습니다.',
+              );
+            case _EventApplicationDetailScenario.paid:
+              return _buildApplication(
+                status: 'paid',
+                paymentAmount: 39000,
+                paidAt: DateTime(2026, 5, 29, 11, 20),
+              );
+            case _EventApplicationDetailScenario.loading:
+              return Completer<EventApplication?>().future;
+          }
+        }),
+      ],
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('ko'),
+        theme: MinglitTheme.materialTheme,
+        home: home,
+      ),
+    );
+  }
+
+  EventApplication _buildApplication({
+    required String status,
+    int? paymentAmount,
+    String? rejectionReason,
+    DateTime? paidAt,
+  }) {
+    final createdAt = DateTime(2026, 5, 29, 9, 30);
+    return EventApplication(
+      id: _mockApplicationId,
+      eventId: 'render-event-id',
+      ticketId: 'render-ticket-id',
+      userId: 'render-user-id',
+      status: status,
+      createdAt: createdAt,
+      updatedAt: createdAt,
+      paymentAmount: paymentAmount,
+      rejectionReason: rejectionReason,
+      paidAt: paidAt,
+      user: UserProfile(
+        id: 'render-user-id',
+        name: '김민수',
+        username: 'mingsu',
+        gender: 'male',
+        birthYear: 1998,
+        birthDate: DateTime(1998, 4, 7),
+      ),
+    );
+  }
+}

--- a/apps/app_partner/integration_test/mds-emulator-render/event_application_detail_page/event_application_detail_page_test.dart
+++ b/apps/app_partner/integration_test/mds-emulator-render/event_application_detail_page/event_application_detail_page_test.dart
@@ -1,0 +1,30 @@
+// MDS screen: event_application_detail_page (app_partner)
+// 대응 MDS: apps/mds/docs/public/specs/event_application_detail_page/
+//
+// 출력: docs/infra/mds-emulator-render/event_application_detail_page/state-*.png
+
+import '../_engine/catalog.dart';
+import '../_engine/runner.dart';
+import '../_engine/state.dart';
+import 'builder.dart';
+
+final catalog = MdsCatalog<EventApplicationDetailPageBuilder>(
+  screen: 'event_application_detail_page',
+  mdsSpec: 'apps/mds/docs/public/specs/event_application_detail_page/',
+  builder: EventApplicationDetailPageBuilder.new,
+  states: [
+    MdsState('state-pending-review', (b) => b.pendingReview(), mdsIndex: 1),
+    MdsState('state-approved', (b) => b.approved(), mdsIndex: 2),
+    MdsState('state-rejected', (b) => b.rejected(), mdsIndex: 3),
+    MdsState('state-paid', (b) => b.paid(), mdsIndex: 4),
+    MdsState('state-reject-dialog', (b) => b.rejectDialog(), mdsIndex: 5),
+    MdsState(
+      'state-loading',
+      (b) => b.loading(),
+      mdsIndex: 6,
+      infiniteAnimation: true,
+    ),
+  ],
+);
+
+void main() => MdsRenderEngine.run(catalog);


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- add `apps/app_partner/integration_test/mds-emulator-render/event_application_detail_page/` catalog (`builder.dart`, `event_application_detail_page_test.dart`)
- register the new catalog in `apps/app_partner/integration_test/mds-emulator-render/_registry.dart`
- update `apps/app_partner/integration_test/mds-emulator-render/BLUEDOC.md` screen table/structure and Reviewed timestamp

## Why
- Refs #2819
- partial follow-up slice for the aggregate MDS render coverage backlog; this PR intentionally does not close the umbrella issue

## Verification
- `flutter analyze integration_test/mds-emulator-render/event_application_detail_page` (cwd: `apps/app_partner`)
- `dart run scripts/mds_render_coverage.dart --json`
  - `cataloged_screens: 45`
  - `screen_coverage_pct: 68.2`
  - `uncovered_screens` no longer includes `event_application_detail_page`

## Residual Risk
- state image files are generated by the emulator render workflow; this PR only adds catalog definitions and registry wiring