### PR TITLE
fix(cuj): stabilize refund policy gate

### DIFF
--- a/apps/app_partner/lib/src/features/application/event_application_detail_page.dart
+++ b/apps/app_partner/lib/src/features/application/event_application_detail_page.dart
@@ -17,10 +17,7 @@ Future<EventApplication?> eventApplicationDetail(
 }
 
 class EventApplicationDetailPage extends ConsumerStatefulWidget {
-  const EventApplicationDetailPage({
-    required this.applicationId,
-    super.key,
-  });
+  const EventApplicationDetailPage({required this.applicationId, super.key});
 
   final String applicationId;
 
@@ -37,9 +34,9 @@ class _EventApplicationDetailPageState
     ref.listenManual(eventApplicationReviewControllerProvider, (_, next) {
       if (next is AsyncData) {
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('처리가 완료되었습니다.')),
-          );
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(const SnackBar(content: Text('처리가 완료되었습니다.')));
           Navigator.of(context).pop();
         }
       }
@@ -114,6 +111,7 @@ class _ApplicationDetailBody extends StatelessWidget {
     final age = user?.birthYear != null
         ? DateTime.now().year - user!.birthYear!
         : null;
+    final birthDateLabel = birthDate == null ? null : _formatDate(birthDate);
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(MinglitSpacing.medium),
@@ -152,17 +150,14 @@ class _ApplicationDetailBody extends StatelessWidget {
                         ),
                         if (age != null || gender != null)
                           Text(
-                            [
-                              if (age != null) '$age세',
-                              ?gender,
-                            ].join(' · '),
+                            [if (age != null) '$age세', ?gender].join(' · '),
                             style: theme.textTheme.bodyMedium?.copyWith(
                               color: theme.colorScheme.onSurfaceVariant,
                             ),
                           ),
                         if (birthDate != null)
                           Text(
-                            '${birthDate.year}.${birthDate.month.toString().padLeft(2, '0')}.${birthDate.day.toString().padLeft(2, '0')}',
+                            birthDateLabel!,
                             style: theme.textTheme.labelSmall?.copyWith(
                               color: theme.colorScheme.onSurfaceVariant,
                             ),
@@ -203,7 +198,7 @@ class _ApplicationDetailBody extends StatelessWidget {
                     dense: true,
                     title: const Text('결제금액'),
                     trailing: Text(
-                      '${application.paymentAmount!.toStringAsFixed(0).replaceAllMapped(RegExp(r'(\d)(?=(\d{3})+(?!\d))'), (m) => '${m[1]},')}원',
+                      '${_formatAmount(application.paymentAmount!)}원',
                       style: theme.textTheme.bodyMedium,
                     ),
                   ),
@@ -259,37 +254,68 @@ class _ApplicationDetailBody extends StatelessWidget {
   }
 
   Future<void> _showRejectDialog(BuildContext context) async {
-    final controller = TextEditingController();
     final reason = await showDialog<String>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('거절 사유'),
-        content: TextField(
-          controller: controller,
-          maxLines: 3,
-          decoration: const InputDecoration(
-            hintText: '거절 사유를 입력해주세요 (선택)',
-            border: OutlineInputBorder(),
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('취소'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(controller.text),
-            child: const Text('거절'),
-          ),
-        ],
-      ),
+      builder: (context) => const _RejectReasonDialog(),
     );
-    controller.dispose();
     if (reason != null) onReject(reason.isEmpty ? null : reason);
   }
 
   static String _formatDate(DateTime dt) {
-    return '${dt.year}.${dt.month.toString().padLeft(2, '0')}.${dt.day.toString().padLeft(2, '0')}';
+    final month = dt.month.toString().padLeft(2, '0');
+    final day = dt.day.toString().padLeft(2, '0');
+    return '${dt.year}.$month.$day';
+  }
+
+  static String _formatAmount(num amount) {
+    return amount
+        .toStringAsFixed(0)
+        .replaceAllMapped(
+          RegExp(r'(\d)(?=(\d{3})+(?!\d))'),
+          (m) => '${m[1]},',
+        );
+  }
+}
+
+class _RejectReasonDialog extends StatefulWidget {
+  const _RejectReasonDialog();
+
+  @override
+  State<_RejectReasonDialog> createState() => _RejectReasonDialogState();
+}
+
+class _RejectReasonDialogState extends State<_RejectReasonDialog> {
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('거절 사유'),
+      content: TextField(
+        controller: _controller,
+        maxLines: 3,
+        decoration: const InputDecoration(
+          hintText: '거절 사유를 입력해주세요 (선택)',
+          border: OutlineInputBorder(),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('취소'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(_controller.text),
+          child: const Text('거절'),
+        ),
+      ],
+    );
   }
 }
 

--- a/apps/app_partner/test/BLUEDOC.md
+++ b/apps/app_partner/test/BLUEDOC.md
@@ -38,4 +38,4 @@ CI 자동 실행: `pr-gate.test-flutter-apps` matrix. 커버리지 dev 자동 �
 - [tests/_coverage/BLUEDOC](../../../tests/_coverage/BLUEDOC.md)
 
 ---
-_Reviewed: 2026-05-20 09:10_
+_Reviewed: 2026-05-30 23:22_

--- a/apps/app_partner/test/src/features/application/ui/event_application_detail_page_test.dart
+++ b/apps/app_partner/test/src/features/application/ui/event_application_detail_page_test.dart
@@ -1,0 +1,65 @@
+import 'package:app_partner/src/features/application/event_application_detail_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:minglit_kit/minglit_kit.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../utils/mocks.dart';
+
+void main() {
+  final now = DateTime(2026, 5, 30, 12);
+
+  EventApplication makePendingApplication() {
+    return EventApplication(
+      id: 'app_pending',
+      eventId: 'event_1',
+      ticketId: 'ticket_1',
+      userId: 'user_1',
+      status: 'pending_review',
+      createdAt: now,
+      updatedAt: now,
+      user: const UserProfile(
+        id: 'user_1',
+        name: '테스트유저',
+        username: 'test_user',
+        gender: 'female',
+        birthYear: 1999,
+      ),
+    );
+  }
+
+  Widget buildPage({
+    required EventRepository eventRepository,
+  }) {
+    return ProviderScope(
+      overrides: [
+        eventRepositoryProvider.overrideWithValue(eventRepository),
+      ],
+      child: const MaterialApp(
+        home: EventApplicationDetailPage(applicationId: 'app_pending'),
+      ),
+    );
+  }
+
+  testWidgets(
+    'Fix #1316: dialog open state에서 route teardown 시 예외가 발생하지 않는다',
+    (tester) async {
+      final eventRepository = MockEventRepository();
+      when(
+        () => eventRepository.getApplicationById('app_pending'),
+      ).thenAnswer((_) async => makePendingApplication());
+
+      await tester.pumpWidget(buildPage(eventRepository: eventRepository));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(OutlinedButton, '거절'));
+      await tester.pumpAndSettle();
+      expect(find.text('거절 사유'), findsOneWidget);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+    },
+  );
+}

--- a/apps/app_user/integration_test/cuj/event/refund_policy_v2_test.dart
+++ b/apps/app_user/integration_test/cuj/event/refund_policy_v2_test.dart
@@ -145,9 +145,7 @@ void main() {
   ];
 
   // Returns overrides for EventDetailPage rendering with fixed now().
-  List<dynamic> withEventDetail({
-    required DateTime now,
-  }) => [
+  List<dynamic> withEventDetail({required DateTime now}) => [
     currentUserProvider.overrideWith((_) => null),
     authStateChangesProvider.overrideWith((_) => const Stream.empty()),
     eventRepositoryProvider.overrideWithValue(mockRepo),
@@ -157,6 +155,15 @@ void main() {
           () => now,
     ),
   ];
+
+  Future<void> scrollToRefundPolicy(WidgetTester t) async {
+    await t.scrollUntilVisible(
+      find.byTooltip('환불 정책 상세'),
+      500,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await t.pumpAndSettle();
+  }
 
   // ===========================================================================
   // CUJ 1-1: grace period(3시간) 내 자동 환불
@@ -195,10 +202,8 @@ void main() {
             reason: any(named: 'reason'),
           ),
         ).thenAnswer(
-          (_) async => const CancelOrderResult(
-            type: 'refunded',
-            refundAmount: 50000,
-          ),
+          (_) async =>
+              const CancelOrderResult(type: 'refunded', refundAmount: 50000),
         );
         return withApp(app);
       },
@@ -326,10 +331,7 @@ void main() {
         await t.pumpAndSettle();
 
         // isRefunded=true → 취소 버튼 섹션 전체 미노출 (FR-1: 재취소 차단)
-        expect(
-          find.widgetWithText(ElevatedButton, '예매 취소'),
-          findsNothing,
-        );
+        expect(find.widgetWithText(ElevatedButton, '예매 취소'), findsNothing);
 
         // 환불 정보 섹션 노출 (isRefunded=true)
         expect(find.text('환불 정보'), findsOneWidget);
@@ -356,10 +358,8 @@ void main() {
             reason: any(named: 'reason'),
           ),
         ).thenAnswer(
-          (_) async => const CancelOrderResult(
-            type: 'refunded',
-            refundAmount: 50000,
-          ),
+          (_) async =>
+              const CancelOrderResult(type: 'refunded', refundAmount: 50000),
         );
         return withApp(app);
       },
@@ -408,6 +408,7 @@ void main() {
       },
       body: (t) async {
         await t.pumpAndSettle();
+        await scrollToRefundPolicy(t);
 
         expect(find.text('환불 정책'), findsOneWidget);
         await t.tap(find.byTooltip('환불 정책 상세'));
@@ -441,8 +442,12 @@ void main() {
       },
       body: (t) async {
         await t.pumpAndSettle();
+        await scrollToRefundPolicy(t);
 
-        expect(find.textContaining('까지 환불 가능'), findsOneWidget);
+        expect(
+          find.textContaining('까지 환불 가능', findRichText: true),
+          findsOneWidget,
+        );
         expect(find.textContaining('결제 후 3시간 이내에도 전액 환불 가능'), findsOneWidget);
       },
     );
@@ -462,6 +467,7 @@ void main() {
       },
       body: (t) async {
         await t.pumpAndSettle();
+        await scrollToRefundPolicy(t);
 
         expect(find.text('결제 후 3시간 이내 전액 환불 가능'), findsOneWidget);
         expect(find.text('이벤트 시작 7일 전 환불 마감'), findsOneWidget);
@@ -525,10 +531,8 @@ void main() {
       },
       body: (t) async {
         await t.pumpAndSettle();
-        final cancelBtn = t.widget<ElevatedButton>(
-          find.widgetWithText(ElevatedButton, '예매 취소'),
-        );
-        expect(cancelBtn.onPressed, isNull);
+        expect(find.text('환불 요청됨'), findsOneWidget);
+        expect(find.widgetWithText(ElevatedButton, '예매 취소'), findsNothing);
       },
     );
   });
@@ -643,9 +647,7 @@ void main() {
             eventId: any(named: 'eventId'),
             reason: any(named: 'reason'),
           ),
-        ).thenAnswer(
-          (_) async => const CancelOrderResult(type: 'cancelled'),
-        );
+        ).thenAnswer((_) async => const CancelOrderResult(type: 'cancelled'));
         return withApp(app);
       },
       body: (t) async {

--- a/apps/app_user/integration_test/cuj/event/refund_policy_v2_test.dart
+++ b/apps/app_user/integration_test/cuj/event/refund_policy_v2_test.dart
@@ -410,13 +410,13 @@ void main() {
         await t.pumpAndSettle();
         await scrollToRefundPolicy(t);
 
-        expect(find.text('환불 정책'), findsOneWidget);
+        expect(find.byTooltip('환불 정책 상세'), findsOneWidget);
         await t.tap(find.byTooltip('환불 정책 상세'));
         await t.pumpAndSettle();
 
         expect(find.text('환불 정책 상세'), findsOneWidget);
-        expect(find.textContaining('결제 후 3시간 이내'), findsOneWidget);
-        expect(find.textContaining('이벤트 시작 7일 전까지'), findsOneWidget);
+        expect(find.text('결제 후 3시간 이내'), findsOneWidget);
+        expect(find.text('이벤트 시작 7일 전까지'), findsOneWidget);
         expect(find.text('그 외'), findsOneWidget);
         expect(find.text('고객센터 문의'), findsOneWidget);
       },

--- a/apps/app_user/lib/src/features/payment/ui/purchase_history_detail_page.dart
+++ b/apps/app_user/lib/src/features/payment/ui/purchase_history_detail_page.dart
@@ -17,10 +17,7 @@ class PurchaseHistoryDetailPage extends ConsumerWidget {
     final appAsync = ref.watch(purchaseHistoryDetailProvider(applicationId));
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('구매 상세'),
-        centerTitle: false,
-      ),
+      appBar: AppBar(title: const Text('구매 상세'), centerTitle: false),
       body: MinglitAsyncValueWidget(
         value: appAsync,
         data: (application) {
@@ -53,6 +50,8 @@ class _PurchaseDetailBody extends ConsumerWidget {
     final paymentId = application.paymentId;
     final paymentAmount = application.paymentAmount ?? 0;
     final canCancel = controller.canCancel(application);
+    final refundStatusLabel = _refundStatusLabel(application.refundStatus);
+    final hasRefundStatus = refundStatusLabel != null;
     final isRefunded = application.refundStatus == 'completed';
     final theme = Theme.of(context);
     final formatter = NumberFormat('#,###');
@@ -167,17 +166,17 @@ class _PurchaseDetailBody extends ConsumerWidget {
                           Row(
                             children: [
                               StatusBadge(status: application.status),
-                              if (isRefunded) ...[
+                              if (hasRefundStatus) ...[
                                 const SizedBox(width: MinglitSpacing.xsmall),
-                                _RefundBadge(),
+                                _RefundBadge(label: refundStatusLabel),
                               ],
                             ],
                           ),
                           const SizedBox(height: MinglitSpacing.xxsmall),
                           Text(
-                            DateFormat('yyyy.MM.dd HH:mm').format(
-                              application.updatedAt.toLocal(),
-                            ),
+                            DateFormat(
+                              'yyyy.MM.dd HH:mm',
+                            ).format(application.updatedAt.toLocal()),
                             style: theme.textTheme.labelSmall?.copyWith(
                               color: theme.colorScheme.onSurfaceVariant,
                             ),
@@ -216,10 +215,7 @@ class _PurchaseDetailBody extends ConsumerWidget {
                     ),
                   ),
                   const SizedBox(height: MinglitSpacing.xsmall),
-                  _KeyValueRow(
-                    label: '티켓',
-                    value: ticket?.name ?? '티켓 정보 없음',
-                  ),
+                  _KeyValueRow(label: '티켓', value: ticket?.name ?? '티켓 정보 없음'),
                   const SizedBox(height: MinglitSpacing.xsmall),
                   _KeyValueRow(
                     label: '결제금액',
@@ -239,9 +235,7 @@ class _PurchaseDetailBody extends ConsumerWidget {
                             mode: LaunchMode.externalApplication,
                           );
                           if (!launched && context.mounted) {
-                            context.showMinglitWarning(
-                              '영수증 페이지를 열 수 없습니다.',
-                            );
+                            context.showMinglitWarning('영수증 페이지를 열 수 없습니다.');
                           }
                         } else {
                           context.showMinglitInfo('무료 티켓 — 결제 영수증이 없습니다.');
@@ -378,13 +372,14 @@ class _PurchaseDetailBody extends ConsumerWidget {
       },
       confirmRefund: (calculation) async {
         if (!context.mounted) return false;
+        final refundAmount = NumberFormat(
+          '#,###',
+        ).format(calculation.refundAmount);
         return await showDialog<bool>(
               context: context,
               builder: (_) => AlertDialog(
                 title: const Text('예매 취소'),
-                content: Text(
-                  '${NumberFormat('#,###').format(calculation.refundAmount)}원이 환불됩니다. 취소하시겠습니까?',
-                ),
+                content: Text('$refundAmount원이 환불됩니다. 취소하시겠습니까?'),
                 actions: [
                   TextButton(
                     onPressed: () => Navigator.pop(context, false),
@@ -454,10 +449,7 @@ class _PurchaseDetailBody extends ConsumerWidget {
       return;
     }
 
-    final launched = await launchUrl(
-      uri,
-      mode: LaunchMode.externalApplication,
-    );
+    final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
 
     if (!launched && context.mounted) {
       context.showMinglitWarning('연락처를 열 수 없습니다.');
@@ -489,9 +481,8 @@ class _PartnerInfoCard extends StatelessWidget {
     final theme = Theme.of(context);
     return _DetailCard(
       child: InkWell(
-        onTap: () => PartnerDetailRoute(partnerId: party.partnerId).push<void>(
-          context,
-        ),
+        onTap: () =>
+            PartnerDetailRoute(partnerId: party.partnerId).push<void>(context),
         borderRadius: BorderRadius.circular(MinglitRadius.card),
         child: Row(
           children: [
@@ -587,7 +578,20 @@ class _KeyValueRow extends StatelessWidget {
   }
 }
 
+String? _refundStatusLabel(String status) {
+  return switch (status) {
+    'requested' => '환불 요청됨',
+    'completed' => '환불완료',
+    'rejected' => '거절됨',
+    _ => null,
+  };
+}
+
 class _RefundBadge extends StatelessWidget {
+  const _RefundBadge({required this.label});
+
+  final String label;
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -601,7 +605,7 @@ class _RefundBadge extends StatelessWidget {
         borderRadius: BorderRadius.circular(MinglitRadius.chip),
       ),
       child: Text(
-        '환불완료',
+        label,
         style: theme.textTheme.labelSmall?.copyWith(
           color: theme.colorScheme.onErrorContainer,
         ),

--- a/apps/app_user/lib/src/features/payment/ui/purchase_history_detail_page.dart
+++ b/apps/app_user/lib/src/features/payment/ui/purchase_history_detail_page.dart
@@ -52,6 +52,7 @@ class _PurchaseDetailBody extends ConsumerWidget {
     final canCancel = controller.canCancel(application);
     final refundStatusLabel = _refundStatusLabel(application.refundStatus);
     final hasRefundStatus = refundStatusLabel != null;
+    final canShowCancelAction = application.refundStatus == 'none';
     final isRefunded = application.refundStatus == 'completed';
     final theme = Theme.of(context);
     final formatter = NumberFormat('#,###');
@@ -297,7 +298,7 @@ class _PurchaseDetailBody extends ConsumerWidget {
           const SizedBox(height: MinglitSpacing.medium),
 
           // 4. Refund policy card with cancel button
-          if (!isRefunded) ...[
+          if (canShowCancelAction) ...[
             _DetailCard(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
## Summary
- Stabilize refund policy CUJ assertions by scrolling lazy event-detail slivers before checking refund policy UI.
- Align requested refund UI with the refund-policy-v2 spec by showing a status label instead of a retry cancel action.
- Move partner reject dialog TextEditingController ownership into the dialog widget to avoid disposed-controller crashes during route teardown.

## Verification
- flutter analyze apps/app_user/integration_test/cuj/event/refund_policy_v2_test.dart apps/app_user/lib/src/features/payment/ui/purchase_history_detail_page.dart
- flutter analyze apps/app_partner/lib/src/features/application/event_application_detail_page.dart
- Local flutter test integration_test/cuj/event/refund_policy_v2_test.dart attempted for user/partner, but Android assemble failed due local disk exhaustion: No space left on device.

No linked issue: CUJ gate regression was discovered while checking dev promotion PR #2871 and has no dedicated tracking issue yet.