### PR TITLE
feat(matching): implement contact-card match results spec

### DIFF
--- a/apps/app_user/lib/src/common/widgets/match_results_content.dart
+++ b/apps/app_user/lib/src/common/widgets/match_results_content.dart
@@ -1,18 +1,63 @@
+import 'dart:io';
+
+import 'package:app_user/src/routing/app_coordinator.dart';
+import 'package:cross_file/cross_file.dart';
 import 'package:flutter/material.dart';
 import 'package:minglit_kit/minglit_kit.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
 
 // Shared widget used by both home (EventNowBottomSheet) and
 // event/admission (eventEndedWithResults CTA).
-class MatchResultsContent extends ConsumerWidget {
-  const MatchResultsContent({required this.activeEvent, super.key});
+class MatchResultsContent extends ConsumerStatefulWidget {
+  const MatchResultsContent({
+    required this.activeEvent,
+    super.key,
+    this.onSaveContact,
+    this.onNavigateHome,
+  });
 
   final TodayActiveEvent activeEvent;
+  final Future<void> Function(MatchPair match)? onSaveContact;
+  final VoidCallback? onNavigateHome;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final event = activeEvent.event;
+  ConsumerState<MatchResultsContent> createState() =>
+      _MatchResultsContentState();
+}
+
+class _MatchResultsContentState extends ConsumerState<MatchResultsContent> {
+  late final PageController _pageController;
+  int _currentPage = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = PageController(viewportFraction: 0.88);
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final event = widget.activeEvent.event;
     final theme = Theme.of(context);
     final matchesAsync = ref.watch(myMatchesProvider(event.id));
+    final reduceMotion =
+        MediaQuery.maybeOf(context)?.disableAnimations ?? false;
+
+    final hasMatches = matchesAsync.maybeWhen(
+      data: (matches) => matches.isNotEmpty,
+      orElse: () => false,
+    );
+
+    final animationDuration = reduceMotion
+        ? Duration.zero
+        : MinglitAnimation.medium;
 
     return Padding(
       padding: const EdgeInsets.symmetric(
@@ -22,26 +67,19 @@ class MatchResultsContent extends ConsumerWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          _DragHandle(),
-          const SizedBox(height: MinglitSpacing.xlarge),
-          Container(
-            width: 64,
-            height: 64,
-            decoration: const BoxDecoration(
-              color: MinglitColors.primary,
-              shape: BoxShape.circle,
-            ),
-            child: const Icon(
-              Icons.favorite,
-              color: MinglitColors.background,
-              size: 36,
-            ),
+          const _DragHandle(),
+          SizedBox(
+            height: hasMatches ? MinglitSpacing.xlarge : MinglitSpacing.medium,
           ),
-          const SizedBox(height: MinglitSpacing.medium),
+          _MatchedHeroBadge(
+            visible: hasMatches,
+            reduceMotion: reduceMotion,
+          ),
+          SizedBox(height: hasMatches ? MinglitSpacing.medium : 0),
           Text(
             '매칭 결과',
             style: theme.textTheme.titleLarge?.copyWith(
-              fontWeight: FontWeight.bold,
+              fontWeight: FontWeight.w800,
             ),
           ),
           const SizedBox(height: MinglitSpacing.small),
@@ -53,19 +91,58 @@ class MatchResultsContent extends ConsumerWidget {
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: MinglitSpacing.xlarge),
-          matchesAsync.when(
-            data: (matches) {
-              if (matches.isEmpty) return _buildEmptyResult(theme);
-              return _buildMatchList(theme, matches);
-            },
-            loading: () => const SizedBox(
-              height: 120,
-              child: Center(child: MinglitCircularProgressIndicator()),
+          AnimatedSwitcher(
+            duration: animationDuration,
+            switchInCurve: Curves.easeOut,
+            switchOutCurve: Curves.easeOut,
+            child: _buildResultSlot(
+              context: context,
+              theme: theme,
+              matchesAsync: matchesAsync,
+              reduceMotion: reduceMotion,
             ),
-            error: (_, _) => _buildEmptyResult(theme),
           ),
           const SizedBox(height: MinglitSpacing.medium),
         ],
+      ),
+    );
+  }
+
+  Widget _buildResultSlot({
+    required BuildContext context,
+    required ThemeData theme,
+    required AsyncValue<List<MatchPair>> matchesAsync,
+    required bool reduceMotion,
+  }) {
+    return matchesAsync.when(
+      data: (matches) {
+        if (matches.isEmpty) {
+          return KeyedSubtree(
+            key: const ValueKey('empty'),
+            child: _buildEmptyResult(theme),
+          );
+        }
+
+        return KeyedSubtree(
+          key: const ValueKey('matched'),
+          child: _buildMatchedResults(
+            context: context,
+            theme: theme,
+            matches: matches,
+            reduceMotion: reduceMotion,
+          ),
+        );
+      },
+      loading: () => const KeyedSubtree(
+        key: ValueKey('loading'),
+        child: SizedBox(
+          height: 120,
+          child: Center(child: MinglitCircularProgressIndicator()),
+        ),
+      ),
+      error: (_, _) => KeyedSubtree(
+        key: const ValueKey('error'),
+        child: _buildEmptyResult(theme),
       ),
     );
   }
@@ -84,96 +161,263 @@ class MatchResultsContent extends ConsumerWidget {
           ),
           const SizedBox(height: MinglitSpacing.medium),
           Text(
-            '이번엔 아쉽지만, 다음 기회에!',
+            '좋은 인연은 한번에 정해지지 않으니까요.\n다음 자리에서 더 나은 인연을 만나길 기원합니다.',
             style: theme.textTheme.bodyMedium?.copyWith(
               color: MinglitColors.textSecondary,
             ),
             textAlign: TextAlign.center,
           ),
+          const SizedBox(height: MinglitSpacing.large),
+          MinglitButton(
+            label: '다음 이벤트 찾기',
+            size: MinglitButtonSize.medium,
+            expand: false,
+            onPressed: _goToHome,
+          ),
         ],
       ),
     );
   }
 
-  Widget _buildMatchList(ThemeData theme, List<MatchPair> matches) {
-    return Column(
-      children: [
-        Text(
-          '${matches.length}명과 매칭되었어요!',
-          style: theme.textTheme.titleSmall?.copyWith(
-            color: MinglitColors.primary,
-            fontWeight: FontWeight.w600,
+  Widget _buildMatchedResults({
+    required BuildContext context,
+    required ThemeData theme,
+    required List<MatchPair> matches,
+    required bool reduceMotion,
+  }) {
+    final duration = reduceMotion ? Duration.zero : MinglitAnimation.medium;
+
+    return TweenAnimationBuilder<double>(
+      duration: duration,
+      curve: Curves.easeOut,
+      tween: Tween(begin: 0, end: 1),
+      builder: (context, t, _) {
+        final copyOpacity = _segment(t, 0.2, 0.6);
+        final cardsOpacity = _segment(t, 0.45, 1);
+
+        return Column(
+          children: [
+            Text(
+              '${matches.length}명과 매칭되었어요!',
+              style: theme.textTheme.titleSmall?.copyWith(
+                color: MinglitColors.primary,
+                fontWeight: FontWeight.w700,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: MinglitSpacing.small),
+            Opacity(
+              opacity: copyOpacity,
+              child: Transform.translate(
+                offset: Offset(0, (1 - copyOpacity) * 6),
+                child: Text(
+                  '매칭된 상대방에게 서로의 연락처가 공유되었습니다.\n오늘의 여운이 이어질 수 있게 편하게 연락해보세요.',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: MinglitColors.textSecondary,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
+            const SizedBox(height: MinglitSpacing.medium),
+            Opacity(
+              opacity: cardsOpacity,
+              child: Transform.translate(
+                offset: Offset(0, (1 - cardsOpacity) * 10),
+                child: _buildCards(matches),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildCards(List<MatchPair> matches) {
+    if (matches.length == 1) {
+      return Align(
+        child: SizedBox(
+          width: 292,
+          child: _MatchResultCard(
+            match: matches.first,
+            onSaveContact: () => _onSaveContactPressed(matches.first),
           ),
         ),
-        const SizedBox(height: MinglitSpacing.medium),
-        for (final match in matches) ...[
-          _MatchResultCard(match: match),
-          const SizedBox(height: MinglitSpacing.small),
-        ],
+      );
+    }
+
+    return Column(
+      children: [
+        SizedBox(
+          height: 198,
+          child: PageView.builder(
+            controller: _pageController,
+            itemCount: matches.length,
+            padEnds: false,
+            onPageChanged: (index) {
+              if (!mounted) return;
+              setState(() {
+                _currentPage = index;
+              });
+            },
+            itemBuilder: (context, index) {
+              return Padding(
+                padding: EdgeInsets.only(
+                  right: index == matches.length - 1
+                      ? 0
+                      : MinglitSpacing.medium,
+                ),
+                child: _MatchResultCard(
+                  match: matches[index],
+                  onSaveContact: () => _onSaveContactPressed(matches[index]),
+                ),
+              );
+            },
+          ),
+        ),
+        const SizedBox(height: MinglitSpacing.small),
+        _CarouselIndicator(
+          itemCount: matches.length,
+          currentIndex: _currentPage,
+        ),
       ],
     );
+  }
+
+  Future<void> _onSaveContactPressed(MatchPair match) async {
+    final saveContact = widget.onSaveContact ?? _saveContactToOs;
+    try {
+      await saveContact(match);
+    } catch (error, stackTrace) {
+      if (!mounted) return;
+      handleMinglitError(context, error, stackTrace);
+    }
+  }
+
+  Future<void> _saveContactToOs(MatchPair match) async {
+    final phone = match.partnerContact?.trim();
+    if (phone == null || phone.isEmpty) return;
+
+    final name = (match.partnerName?.trim().isNotEmpty ?? false)
+        ? match.partnerName!.trim()
+        : '알 수 없음';
+
+    final directory = await getTemporaryDirectory();
+    final safeName = name.replaceAll(RegExp(r'[^a-zA-Z0-9가-힣_-]+'), '_');
+    final file = File(
+      '${directory.path}/minglit_match_${match.partnerId}_$safeName.vcf',
+    );
+
+    await file.writeAsString(
+      _buildVCard(name: name, phone: phone),
+      flush: true,
+    );
+
+    await SharePlus.instance.share(
+      ShareParams(
+        files: [
+          XFile(file.path, mimeType: 'text/vcard'),
+        ],
+        subject: '연락처 저장하기',
+      ),
+    );
+  }
+
+  void _goToHome() {
+    if (widget.onNavigateHome != null) {
+      widget.onNavigateHome!();
+      return;
+    }
+    Navigator.of(context).maybePop();
+    ref.read(appCoordinatorProvider).goToHome();
   }
 }
 
 class _MatchResultCard extends StatelessWidget {
-  const _MatchResultCard({required this.match});
+  const _MatchResultCard({
+    required this.match,
+    required this.onSaveContact,
+  });
 
   final MatchPair match;
+  final Future<void> Function() onSaveContact;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final contact = match.partnerContact?.trim();
+
     return Container(
-      padding: const EdgeInsets.all(MinglitSpacing.medium),
+      constraints: const BoxConstraints(minHeight: 190),
+      padding: const EdgeInsets.all(MinglitSpacing.large),
       decoration: BoxDecoration(
         color: MinglitColors.surface,
         borderRadius: BorderRadius.circular(MinglitRadius.card),
-        border: Border.all(
-          color: MinglitColors.primary.withValues(alpha: MinglitOpacity.muted),
-        ),
       ),
-      child: Row(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Fix #1936: MinglitAvatarImage handles caching + error fallback
-          MinglitAvatarImage(
-            radius: 24,
-            url: match.partnerProfileImage,
-            backgroundColor: MinglitColors.primary.withValues(
-              alpha: MinglitOpacity.highlight,
-            ),
-            fallbackIconColor: MinglitColors.primary.withValues(
-              alpha: MinglitOpacity.separator,
-            ),
-          ),
-          const SizedBox(width: MinglitSpacing.medium),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  match.partnerName ?? '알 수 없음',
-                  style: theme.textTheme.bodyLarge?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
+          Row(
+            children: [
+              MinglitAvatarImage(
+                radius: 24,
+                url: match.partnerProfileImage,
+                backgroundColor: MinglitColors.tertiary.withValues(
+                  alpha: MinglitOpacity.highlight,
                 ),
-                if (match.partnerContact != null) ...[
-                  const SizedBox(height: MinglitSpacing.xxsmall),
-                  Text(
-                    // Fix #1925: mask phone number to prevent PII exposure in UI
-                    // (개인정보보호법 §24 — phone numbers are sensitive PII)
-                    _maskPhone(match.partnerContact!),
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: MinglitColors.textSecondary,
+                fallbackIconColor: MinglitColors.tertiary.withValues(
+                  alpha: MinglitOpacity.mediumEmphasis,
+                ),
+              ),
+              const SizedBox(width: MinglitSpacing.medium),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '공유된 연락처',
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: MinglitColors.tertiary,
+                        fontWeight: FontWeight.w800,
+                      ),
                     ),
-                  ),
-                ],
-              ],
-            ),
+                    const SizedBox(height: MinglitSpacing.xxsmall),
+                    Text(
+                      match.partnerName ?? '알 수 없음',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                    if (contact != null && contact.isNotEmpty) ...[
+                      const SizedBox(height: MinglitSpacing.xsmall),
+                      Text(
+                        contact,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: MinglitColors.textSecondary,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
           ),
-          const Icon(
-            Icons.favorite,
-            color: MinglitColors.primary,
-            size: MinglitIconSize.small,
+          const SizedBox(height: MinglitSpacing.large),
+          Theme(
+            data: theme.copyWith(
+              colorScheme: theme.colorScheme.copyWith(
+                primary: MinglitColors.tertiary,
+                onPrimary: MinglitColors.background,
+              ),
+            ),
+            child: MinglitButton(
+              label: '연락처 저장하기',
+              size: MinglitButtonSize.medium,
+              onPressed: (contact != null && contact.isNotEmpty)
+                  ? () => onSaveContact()
+                  : null,
+            ),
           ),
         ],
       ),
@@ -181,27 +425,81 @@ class _MatchResultCard extends StatelessWidget {
   }
 }
 
-/// Fix #1925: masks middle digits of a Korean phone number to protect PII.
-/// Handles both raw (+821012345678) and local (01012345678) formats.
-/// Result: 010-****-5678
-String _maskPhone(String phone) {
-  final digits = phone.replaceAll(RegExp(r'\D'), '');
-  // Normalize country code: +82XX... → 0XX...
-  final local = digits.startsWith('82') && digits.length > 10
-      ? '0${digits.substring(2)}'
-      : digits;
-  if (local.length == 11) {
-    return '${local.substring(0, 3)}-****-${local.substring(7)}';
+class _CarouselIndicator extends StatelessWidget {
+  const _CarouselIndicator({
+    required this.itemCount,
+    required this.currentIndex,
+  });
+
+  final int itemCount;
+  final int currentIndex;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List.generate(itemCount, (index) {
+        final active = index == currentIndex;
+        return AnimatedContainer(
+          duration: MinglitAnimation.fast,
+          margin: const EdgeInsets.symmetric(
+            horizontal: MinglitSpacing.xxsmall,
+          ),
+          width: active ? 18 : 6,
+          height: 6,
+          decoration: BoxDecoration(
+            color: active
+                ? MinglitColors.tertiary
+                : MinglitColors.textSecondary.withValues(alpha: 0.24),
+            borderRadius: BorderRadius.circular(999),
+          ),
+        );
+      }),
+    );
   }
-  if (local.length == 10) {
-    return '${local.substring(0, 3)}-***-${local.substring(6)}';
+}
+
+class _MatchedHeroBadge extends StatelessWidget {
+  const _MatchedHeroBadge({
+    required this.visible,
+    required this.reduceMotion,
+  });
+
+  final bool visible;
+  final bool reduceMotion;
+
+  @override
+  Widget build(BuildContext context) {
+    final duration = reduceMotion ? Duration.zero : MinglitAnimation.medium;
+    return AnimatedOpacity(
+      duration: duration,
+      curve: Curves.easeOut,
+      opacity: visible ? 1 : 0,
+      child: AnimatedScale(
+        duration: duration,
+        curve: Curves.easeOutBack,
+        scale: visible ? 1 : 0.92,
+        child: Container(
+          width: 64,
+          height: 64,
+          decoration: const BoxDecoration(
+            color: MinglitColors.primary,
+            shape: BoxShape.circle,
+          ),
+          child: const Icon(
+            Icons.check_rounded,
+            color: MinglitColors.background,
+            size: 34,
+          ),
+        ),
+      ),
+    );
   }
-  // Fallback: never expose full input — short numbers (<=4 digits) are fully masked
-  if (local.length <= 4) return '***-****-****';
-  return '***-****-${local.substring(local.length - 4)}';
 }
 
 class _DragHandle extends StatelessWidget {
+  const _DragHandle();
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -215,4 +513,25 @@ class _DragHandle extends StatelessWidget {
       ),
     );
   }
+}
+
+double _segment(double t, double start, double end) {
+  if (t <= start) return 0;
+  if (t >= end) return 1;
+  return (t - start) / (end - start);
+}
+
+String _buildVCard({required String name, required String phone}) {
+  final escapedName = name
+      .replaceAll('\\', '\\\\')
+      .replaceAll(';', r'\;')
+      .replaceAll(',', r'\,')
+      .replaceAll('\n', r'\n');
+
+  return '''BEGIN:VCARD
+VERSION:3.0
+FN:$escapedName
+TEL;TYPE=CELL:$phone
+END:VCARD
+''';
 }

--- a/apps/app_user/lib/src/common/widgets/match_results_content.dart
+++ b/apps/app_user/lib/src/common/widgets/match_results_content.dart
@@ -450,8 +450,10 @@ class _CarouselIndicator extends StatelessWidget {
           decoration: BoxDecoration(
             color: active
                 ? MinglitColors.tertiary
-                : MinglitColors.textSecondary.withValues(alpha: 0.24),
-            borderRadius: BorderRadius.circular(999),
+                : MinglitColors.textSecondary.withValues(
+                    alpha: MinglitOpacity.lowEmphasis,
+                  ),
+            borderRadius: BorderRadius.circular(MinglitRadius.chip),
           ),
         );
       }),

--- a/apps/app_user/test/src/common/widgets/match_results_content_test.dart
+++ b/apps/app_user/test/src/common/widgets/match_results_content_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:app_user/src/common/widgets/match_results_content.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -8,10 +10,10 @@ void main() {
     id: 'event-1',
     partyId: 'party-1',
     title: '테스트 이벤트',
-    startTime: DateTime.now().subtract(const Duration(hours: 2)),
-    endTime: DateTime.now().add(const Duration(hours: 1)),
-    createdAt: DateTime.now(),
-    updatedAt: DateTime.now(),
+    startTime: DateTime(2026, 5, 1, 18),
+    endTime: DateTime(2026, 5, 1, 21),
+    createdAt: DateTime(2026, 5, 1, 16),
+    updatedAt: DateTime(2026, 5, 1, 16),
   );
 
   final activeEvent = TodayActiveEvent(
@@ -19,86 +21,187 @@ void main() {
     participantStatus: 'ticket_issued',
   );
 
-  Widget buildWidget({required List<MatchPair> matches}) {
+  MatchPair buildMatch({
+    required String id,
+    required String name,
+    required String phone,
+  }) {
+    return MatchPair(
+      matchId: id,
+      eventId: testEvent.id,
+      partnerId: 'partner-$id',
+      matchedAt: DateTime(2026, 5, 1, 20),
+      partnerName: name,
+      partnerContact: phone,
+    );
+  }
+
+  Widget buildWidget({
+    required Future<List<MatchPair>> Function() loadMatches,
+    Future<void> Function(MatchPair match)? onSaveContact,
+    VoidCallback? onNavigateHome,
+    bool reduceMotion = false,
+  }) {
     return ProviderScope(
       overrides: [
         myMatchesProvider(testEvent.id).overrideWith(
-          (ref) async => matches,
+          (ref) => loadMatches(),
         ),
       ],
       child: MaterialApp(
-        home: Scaffold(
-          body: MatchResultsContent(activeEvent: activeEvent),
+        home: MediaQuery(
+          data: MediaQueryData(disableAnimations: reduceMotion),
+          child: Scaffold(
+            body: MatchResultsContent(
+              activeEvent: activeEvent,
+              onSaveContact: onSaveContact,
+              onNavigateHome: onNavigateHome,
+            ),
+          ),
         ),
       ),
     );
   }
 
-  // Fix #1925: partnerContact (phone number) must be masked in ResultsContent UI.
-  // Personal phone numbers are sensitive PII under 개인정보보호법 §24.
-  group('MatchResultsContent — phone masking (Fix #1925)', () {
-    testWidgets('partnerContact is masked — raw phone not shown', (
+  testWidgets('loading state shows progress slot', (tester) async {
+    final completer = Completer<List<MatchPair>>();
+
+    await tester.pumpWidget(
+      buildWidget(loadMatches: () => completer.future),
+    );
+
+    expect(find.byType(MinglitCircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets(
+    'single match shows centered card with full contact and no pager',
+    (
       tester,
     ) async {
-      const rawPhone = '01012345678';
-      final match = MatchPair(
-        matchId: 'match-1',
-        eventId: testEvent.id,
-        partnerId: 'partner-1',
-        matchedAt: DateTime.now(),
-        partnerName: '홍길동',
-        partnerContact: rawPhone,
+      await tester.pumpWidget(
+        buildWidget(
+          loadMatches: () async => [
+            buildMatch(id: '1', name: '김민지', phone: '010-1234-5678'),
+          ],
+        ),
       );
-
-      await tester.pumpWidget(buildWidget(matches: [match]));
       await tester.pumpAndSettle();
 
-      // Raw phone must not appear
+      expect(find.text('1명과 매칭되었어요!'), findsOneWidget);
       expect(
-        find.text(rawPhone),
-        findsNothing,
-        reason: 'Raw phone number must not be displayed (PII)',
+        find.textContaining('매칭된 상대방에게 서로의 연락처가 공유되었습니다.'),
+        findsOneWidget,
       );
+      expect(find.text('010-1234-5678'), findsOneWidget);
+      expect(find.byType(PageView), findsNothing);
+      expect(find.widgetWithText(ElevatedButton, '연락처 저장하기'), findsOneWidget);
+    },
+  );
 
-      // Masked version must appear
-      expect(find.text('010-****-5678'), findsOneWidget);
-    });
+  testWidgets('multi match shows horizontal pager and indicator', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      buildWidget(
+        loadMatches: () async => [
+          buildMatch(id: '1', name: '김민지', phone: '010-1234-5678'),
+          buildMatch(id: '2', name: '이준호', phone: '010-9911-1188'),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
 
-    testWidgets('+82 country-code phone is also masked correctly', (
+    expect(find.text('2명과 매칭되었어요!'), findsOneWidget);
+    expect(find.byType(PageView), findsOneWidget);
+    expect(find.text('김민지'), findsOneWidget);
+
+    await tester.drag(find.byType(PageView), const Offset(-300, 0));
+    await tester.pumpAndSettle();
+
+    expect(find.text('이준호'), findsOneWidget);
+  });
+
+  testWidgets(
+    'save button calls injected contact save flow for tapped partner',
+    (
       tester,
     ) async {
-      const rawPhone = '+821012345678';
-      final match = MatchPair(
-        matchId: 'match-2',
-        eventId: testEvent.id,
-        partnerId: 'partner-2',
-        matchedAt: DateTime.now(),
-        partnerName: '김철수',
-        partnerContact: rawPhone,
-      );
+      MatchPair? savedMatch;
 
-      await tester.pumpWidget(buildWidget(matches: [match]));
+      await tester.pumpWidget(
+        buildWidget(
+          loadMatches: () async => [
+            buildMatch(id: '1', name: '김민지', phone: '010-1234-5678'),
+          ],
+          onSaveContact: (match) async {
+            savedMatch = match;
+          },
+        ),
+      );
       await tester.pumpAndSettle();
 
-      expect(find.text(rawPhone), findsNothing);
-      expect(find.text('010-****-5678'), findsOneWidget);
-    });
+      await tester.tap(find.widgetWithText(ElevatedButton, '연락처 저장하기'));
+      await tester.pump();
 
-    testWidgets('null partnerContact renders no phone text', (tester) async {
-      final match = MatchPair(
-        matchId: 'match-3',
-        eventId: testEvent.id,
-        partnerId: 'partner-3',
-        matchedAt: DateTime.now(),
-        partnerName: '이영희',
-      );
+      expect(savedMatch, isNotNull);
+      expect(savedMatch!.partnerName, '김민지');
+      expect(savedMatch!.partnerContact, '010-1234-5678');
+    },
+  );
 
-      await tester.pumpWidget(buildWidget(matches: [match]));
-      await tester.pumpAndSettle();
+  testWidgets('empty state uses fallback copy and next-event CTA', (
+    tester,
+  ) async {
+    var navigatedHome = false;
 
-      // Partner name should appear but no masked-phone text
-      expect(find.text('이영희'), findsOneWidget);
-      expect(find.textContaining('****'), findsNothing);
-    });
+    await tester.pumpWidget(
+      buildWidget(
+        loadMatches: () async => const <MatchPair>[],
+        onNavigateHome: () {
+          navigatedHome = true;
+        },
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('좋은 인연은 한번에 정해지지 않으니까요.'), findsOneWidget);
+    expect(find.widgetWithText(ElevatedButton, '다음 이벤트 찾기'), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(ElevatedButton, '다음 이벤트 찾기'));
+    await tester.pump();
+
+    expect(navigatedHome, isTrue);
+  });
+
+  testWidgets('error state hides error detail and uses empty fallback UI', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      buildWidget(
+        loadMatches: () async => throw Exception('internal failure detail'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('좋은 인연은 한번에 정해지지 않으니까요.'), findsOneWidget);
+    expect(find.textContaining('internal failure detail'), findsNothing);
+  });
+
+  testWidgets('reduce-motion renders final matched layout without delay', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      buildWidget(
+        loadMatches: () async => [
+          buildMatch(id: '1', name: '박수빈', phone: '010-4567-9012'),
+        ],
+        reduceMotion: true,
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.text('1명과 매칭되었어요!'), findsOneWidget);
+    expect(find.text('박수빈'), findsOneWidget);
   });
 }

--- a/apps/app_user/test/src/features/home/widgets/event_now_bottom_sheet_test.dart
+++ b/apps/app_user/test/src/features/home/widgets/event_now_bottom_sheet_test.dart
@@ -419,8 +419,9 @@ void main() {
         expect(find.text('매칭 결과'), findsOneWidget);
         expect(find.text('1명과 매칭되었어요!'), findsOneWidget);
         expect(find.text('김민지'), findsOneWidget);
-        expect(find.text('010-****-5678'), findsOneWidget);
-        expect(find.byIcon(Icons.favorite), findsWidgets);
+        expect(find.text('010-1234-5678'), findsOneWidget);
+        expect(find.byIcon(Icons.check_rounded), findsOneWidget);
+        expect(find.widgetWithText(ElevatedButton, '연락처 저장하기'), findsOneWidget);
       },
     );
 
@@ -440,12 +441,13 @@ void main() {
         }
 
         expect(find.text('매칭 결과'), findsOneWidget);
+        expect(find.textContaining('좋은 인연은 한번에 정해지지 않으니까요.'), findsOneWidget);
         expect(
-          find.text('이번엔 아쉽지만, 다음 기회에!'),
+          find.byIcon(Icons.sentiment_neutral),
           findsOneWidget,
         );
         expect(
-          find.byIcon(Icons.sentiment_neutral),
+          find.widgetWithText(ElevatedButton, '다음 이벤트 찾기'),
           findsOneWidget,
         );
       },


### PR DESCRIPTION
Scheduler: swe-codex-gpt53-high-1

## Summary
- Rebuild `MatchResultsContent` to match the `EventMatchingResultsScreen` contact-card results spec.
- Implement single vs multi match rendering split:
  - `matches.length == 1`: centered single card, no horizontal pager/indicator
  - `matches.length > 1`: horizontal pager with next-card peek + dot indicator
- Replace masked contact output with full `partnerContact` reveal and update matched copy.
- Replace empty/error UI with spec copy and `다음 이벤트 찾기` CTA flow.
- Add per-card `연락처 저장하기` CTA that hands off a partner-specific vCard to OS share/contact save flow.
- Add loading→result reveal with reduce-motion fallback (`MediaQuery.disableAnimations`).
- Expand focused widget coverage and update dependent bottom-sheet tests.

## Spec References (UI Gate)
- Screen spec: `apps/mds/docs/public/specs/event_matching_results_screen/index.html`
  - `Layout > Sub-anatomy ⑥ — Match result card`
  - `States > Default`, `States > Empty / Error`, `States > Loading`
  - `Global Behavior` table rows for `Contact reveal`, `Single / multiple`, `Error fallback`, `Loading → matched`, `Reduce motion`
- Component spec: `apps/mds/docs/src/lib/components.ts`
  - `MinglitButton` contract (size medium geometry, full-width CTA behavior, tokenized button radius/spacing)

## Why
- Fixes #2919
- Brings app behavior in line with spec PR #2918 (shared bottom-sheet results contract).

## Verification
- `flutter test test/src/common/widgets/match_results_content_test.dart`
- `flutter test test/src/features/home/widgets/event_now_bottom_sheet_test.dart`

## Residual Risk
- Contact save currently uses vCard handoff via OS share sheet. Platform-native direct contact insert was not added in this PR.
