### PR TITLE
ci: harden branch source guards

### DIFF
--- a/.github/workflows/pr-review-setup.yml
+++ b/.github/workflows/pr-review-setup.yml
@@ -45,6 +45,7 @@ jobs:
           fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Enable squash auto-merge
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.release-bot.outputs.token }}
         run: |

--- a/.github/workflows/pr-review-setup.yml
+++ b/.github/workflows/pr-review-setup.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
   contents: read
 
 concurrency:
@@ -31,23 +32,33 @@ jobs:
       github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Generate release bot token
+        id: release-bot
+        uses: ./.github/actions/release-bot-token
+        with:
+          fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
+          fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
+
       - name: Enable squash auto-merge
         env:
-          # Branch protection active 후 GITHUB_TOKEN 으론 enablePullRequestAutoMerge /
-          # 라벨 부여 권한 부족 ("Resource not accessible by integration"). PAT 사용.
-          GH_TOKEN: ${{ secrets.GH_PAT_VERSION_BUMP }}
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
         run: |
           # Idempotent: already-enabled is fine.
           gh pr merge "${{ github.event.pull_request.number }}" \
             --auto --squash \
-            --repo "${{ github.repository }}" || true
+            --repo "${{ github.repository }}"
 
       - name: Add needs-review label
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_VERSION_BUMP }}
+          GH_TOKEN: ${{ steps.release-bot.outputs.token }}
           REPO: ${{ github.repository }}
           PR_NUM: ${{ github.event.pull_request.number }}
         run: |
           # Idempotent: gh treats add-label on an already-present label as a no-op,
           # so re-running on the same SHA (e.g. reopened) doesn't spam reviewers.
-          gh pr edit "$PR_NUM" --repo "$REPO" --add-label needs-review || true
+          gh pr edit "$PR_NUM" --repo "$REPO" --add-label needs-review

--- a/.github/workflows/rc-pr-gate.yml
+++ b/.github/workflows/rc-pr-gate.yml
@@ -19,7 +19,7 @@ jobs:
     uses: ./.github/workflows/shared-pr-source-guard.yml
     with:
       target: rc
-      normal_head_regex: ''
+      normal_head_regex: '^(dev|cut/dev-rc/.*)$'
       hotfix_head_regex: '^rc/hotfix/'
       hotfix_label: 'hotfix:rc-approved'
     secrets: inherit

--- a/.github/workflows/rc-pr-gate.yml
+++ b/.github/workflows/rc-pr-gate.yml
@@ -19,7 +19,7 @@ jobs:
     uses: ./.github/workflows/shared-pr-source-guard.yml
     with:
       target: rc
-      normal_head_regex: '^(dev|cut/dev-rc/.*)$'
+      normal_head_regex: '^cut/dev-rc/.*$'
       hotfix_head_regex: '^rc/hotfix/'
       hotfix_label: 'hotfix:rc-approved'
     secrets: inherit

--- a/.github/workflows/rc-pr-gate.yml
+++ b/.github/workflows/rc-pr-gate.yml
@@ -19,7 +19,7 @@ jobs:
     uses: ./.github/workflows/shared-pr-source-guard.yml
     with:
       target: rc
-      normal_head_regex: '^cut/dev-rc/.*$'
+      normal_head_regex: ''
       hotfix_head_regex: '^rc/hotfix/'
       hotfix_label: 'hotfix:rc-approved'
     secrets: inherit

--- a/.github/workflows/sync-graphify.yml
+++ b/.github/workflows/sync-graphify.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   update:
+    if: github.event_name != 'push' || github.ref == 'refs/heads/dev-staging'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -32,6 +33,14 @@ jobs:
         with:
           fallback-app-id: ${{ secrets.MINGLIT_RELEASE_BOT_APP_ID }}
           fallback-private-key: ${{ secrets.MINGLIT_RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Guard target branch
+        run: |
+          branch="$(git branch --show-current)"
+          if [ "${branch}" != "dev-staging" ]; then
+            echo "::error::Graphify sync is allowed to commit only on dev-staging; checked out ${branch}."
+            exit 1
+          fi
 
       - name: Setup Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
No linked issue: harden branch protection follow-up for dev/rc/main source restrictions and graphify sync scope.\n\nChanges:\n- Allow rc promotion PRs only from dev or cut/dev-rc/* while keeping rc/hotfix/* approval path.\n- Add an explicit sync-graphify guard so graph commits can only target dev-staging.\n\nRepo settings already applied:\n- dev-rules now requires PRs plus dev-pr-gate.\n- rc-rules added for rc/* requiring rc-pr-gate.\n- main-rules added for main requiring main-pr-gate.\n- release bot bypass remains enabled.\n\nValidation:\n- python yaml parse for modified workflows\n- git diff --check\n\nGraphify update is intentionally left to the dev-staging sync-graphify workflow after merge.