### PR TITLE
docs(features): document matching results reveal CUJ

### DIFF
--- a/docs/features/event-operation/BLUEDOC.md
+++ b/docs/features/event-operation/BLUEDOC.md
@@ -5,6 +5,7 @@
 ## 포함된 피쳐
 
 - [event-now-bar](./event-now-bar/) — user 측 이벤트 진행 표시 (홈 하단 바)
+- [matching-results-reveal](./matching-results-reveal/) — user 측 이벤트 종료 후 mutual match 연락처 공개/저장
 - [participation-status-redesign](./participation-status-redesign/) — 참여 상태 화면 리디자인
 - [entry-group-management](./entry-group-management/) — 입장 그룹 관리
 - [party-entry-group-management](./party-entry-group-management/) — 파티의 입장 그룹

--- a/docs/features/event-operation/matching-results-reveal/prd.md
+++ b/docs/features/event-operation/matching-results-reveal/prd.md
@@ -1,0 +1,99 @@
+# PRD: 매칭 결과 연락처 공개
+
+## Summary
+
+이벤트 종료 후 서로 좋아요를 보낸 사용자에게 매칭 상대의 연락처를 전체 공개하고, 한 명씩 연락처를 저장할 수 있게 하는 결과 확인 흐름. 홈의 진행 중 이벤트 결과 surface와 이벤트 상세의 `매칭 결과 보기` 버튼이 같은 결과 바텀시트로 연결된다.
+
+## Motivation / Problem to Solve
+
+- 매칭 투표 후 결과 확인 진입점이 분산되어 있어 사용자가 이벤트 종료 뒤 어느 화면에서 결과를 확인해야 하는지 놓칠 수 있다.
+- mutual match가 성립된 뒤에도 연락처 공개 정책이 모호하면 사용자는 실제 연락으로 이어가기 어렵다.
+- 매치 없음과 조회 실패를 구분해 노출하면 사용자가 내부 오류를 결과로 오해하거나, 반대로 재시도를 기대할 수 있다.
+
+## Goals
+
+### Target Users
+
+- **이벤트 참가자**: 이벤트 종료 후 본인의 mutual match 결과를 확인하려는 사용자.
+- **다중 매칭 사용자**: 둘 이상과 mutual match가 성립되어 여러 연락처 중 일부를 저장하려는 사용자.
+- **매칭 없음 사용자**: mutual match가 없거나 결과 조회가 실패해 다음 이벤트 탐색으로 이동해야 하는 사용자.
+
+### Key Goals
+
+- **P0**: 홈의 event-now results surface와 이벤트 상세 `매칭 결과 보기` 버튼에서 동일한 매칭 결과 바텀시트로 진입한다.
+- **P0**: mutual match가 1건 이상이면 `partnerContact`를 마스킹 없이 전체 표시하고, 각 상대별 `연락처 저장하기` CTA를 제공한다.
+- **P0**: 여러 명과 매칭되면 가로 카드 탐색과 dot indicator로 현재 카드를 구분하며, 저장 액션은 선택한 한 명에게만 적용한다.
+- **P0**: mutual match가 없거나 조회 실패하면 같은 empty copy와 `다음 이벤트 찾기` CTA를 노출한다.
+- **P1**: loading에서 matched 또는 empty 상태로 전환될 때 sheet 높이 급변 없이 결과가 드러난다.
+
+### Non-Goals
+
+- `모두 저장` bulk action 제공. 연락처 저장은 항상 단일 partner 단위다.
+- 연락처 마스킹, 부분 공개, 메시지 CTA 제공. mutual match 이후 연락처는 공개 정보로 전체 표시한다.
+- retry 버튼 또는 내부 오류 상세 노출. 조회 실패는 empty 결과와 같은 사용자 경험으로 처리한다.
+- 이벤트 매칭 투표 입력 화면 변경. 이 문서는 종료 후 결과 reveal만 다룬다.
+
+## Product Principles
+
+1. **Mutual match 이후 명확한 공개**: 서로 좋아요가 성립된 뒤 연락처 교환이 목적이므로 연락처는 숨기거나 축약하지 않는다.
+2. **사용자 통제 단위는 한 명**: 다중 매칭이어도 저장은 각 카드의 한 상대에게만 적용해 실수로 여러 연락처를 저장하지 않게 한다.
+3. **실패 세부 은닉**: 매치 없음과 provider error는 같은 empty 결과로 처리해 내부 조회 실패를 사용자에게 노출하지 않는다.
+4. **진입 surface parity**: 홈 shortcut과 이벤트 상세 진입은 같은 콘텐츠, 같은 copy, 같은 정책을 사용한다.
+
+## Technical Approach
+
+- **화면**: 결과 전용 modal bottom sheet content. 단독 route가 아니라 홈 event-now results phase와 이벤트 상세의 결과 보기 버튼 sheet 안에서 열린다.
+- **저장**: 신규 product data 없음. 기존 이벤트, 참가 상태, mutual match 결과, partner 연락처 데이터를 결과 표시와 OS 연락처 저장 flow에 사용한다.
+- **외부 의존성**: OS 연락처 저장 flow. 사용자가 `연락처 저장하기`를 누른 한 partner만 저장 대상으로 넘긴다.
+- **가드 / 정책**: 참가자가 해당 이벤트의 mutual match 결과를 볼 수 있는 상태에서만 결과 surface를 노출한다. 내부 조회 실패 상세는 사용자에게 노출하지 않는다.
+
+## User Journey
+
+### Scenario 1: 결과 surface 진입과 단일 매칭 저장 (CUJ 1-x)
+
+이벤트가 종료되고 mutual match가 1건 이상 있는 사용자가 홈 결과 surface 또는 이벤트 상세 `매칭 결과 보기`에서 결과 바텀시트를 열고, loading 후 공개된 연락처 카드에서 한 상대의 연락처를 저장한다.
+
+### Scenario 2: 여러 명과 매칭된 결과 탐색 (CUJ 2-x)
+
+여러 명과 mutual match가 성립된 사용자가 가로 카드 목록을 넘기며 dot indicator로 현재 상대를 확인하고, 원하는 한 명의 연락처만 저장한다.
+
+### Scenario 3: 매칭 없음 또는 조회 실패 (CUJ 3-x)
+
+mutual match가 없거나 결과 조회가 실패한 사용자는 동일한 empty 안내와 `다음 이벤트 찾기` CTA를 보고 Home feed로 돌아가 다음 이벤트를 탐색한다.
+
+## Data Flow
+
+### Scenario 1
+
+이벤트 종료 상태 도달 → 홈 results surface 또는 이벤트 상세 `매칭 결과 보기` 노출 → 사용자가 결과 sheet open → 결과 loading → mutual match 1건 이상 확인 → 매칭 count/copy와 contact card 표시 → `연락처 저장하기` tap → 해당 partner만 OS 연락처 저장 flow로 전달
+
+### Scenario 2
+
+결과 sheet open → mutual match 2건 이상 확인 → horizontal card carousel 표시 → 사용자가 swipe → dot indicator가 현재 card index 반영 → 선택한 card의 `연락처 저장하기` tap → 해당 partner만 저장 대상으로 전달
+
+### Scenario 3
+
+결과 sheet open → mutual match 0건 또는 조회 실패 → 내부 실패 상세 숨김 → empty copy와 `다음 이벤트 찾기` 표시 → CTA tap → sheet dismiss 후 Home feed로 이동
+
+## KPIs / Success Metrics
+
+- **결과 확인률**: 결과 surface 노출 사용자 중 결과 sheet open 비율.
+- **연락처 저장 전환율**: mutual match 1건 이상 사용자 중 `연락처 저장하기` 완료 비율.
+- **다중 매칭 탐색률**: matches 2건 이상 사용자 중 첫 카드 외 카드까지 swipe한 비율.
+- **empty CTA 전환율**: empty/error 사용자 중 `다음 이벤트 찾기` CTA tap 비율.
+
+## Launch Strategy
+
+MDS spec PR #2918의 shared bottom-sheet contract를 기준으로 구현 issue #2919에서 앱 동작을 맞춘다. 본 feature 문서는 CUJ와 product policy의 기준이며, 실제 출시 gate는 구현 PR의 widget/controller coverage와 app integration sensor를 따른다.
+
+## Legal Basis
+
+| 근거 | 내용 |
+|------|------|
+| Product privacy policy | mutual match 성립 후 연락처 교환이 사용자 기대 행동이다. 이 상태의 partner contact는 마스킹 없이 전체 표시하되, bulk save는 제공하지 않는다. |
+
+## References
+
+- MDS spec PR: #2918
+- Implementation issue: #2919
+- MDS screen: `apps/mds/docs/public/specs/event_matching_results_screen/index.html`

--- a/docs/features/event-operation/matching-results-reveal/spec.md
+++ b/docs/features/event-operation/matching-results-reveal/spec.md
@@ -1,0 +1,116 @@
+# Spec: 매칭 결과 연락처 공개
+
+> **참조**
+>
+> - PRD: `docs/features/event-operation/matching-results-reveal/prd.md`
+> - **MDS specs**:
+>   - `apps/mds/docs/public/specs/event_matching_results_screen/` — shared `MatchResultsContent` modal bottom sheet contract, exact copy, states, motion, contact reveal policy.
+>   - `apps/mds/docs/public/specs/event_now_bar/` — home event-now results entry surface.
+>   - `apps/mds/docs/public/specs/home_page/` — `다음 이벤트 찾기` destination surface.
+> - **Apps**:
+>   - app_user: `apps/app_user/lib/src/common/widgets/match_results_content.dart`
+>   - app_user: `apps/app_user/lib/src/features/home/widgets/event_now_phases/results_content.dart`
+>   - app_user: `apps/app_user/lib/src/features/event/admission/event_admission_controller.dart`
+> - **Backend EFs**:
+>   - (해당 없음 — 기존 mutual match 결과 조회와 OS contact-save flow 사용)
+> - **CUJ tests**:
+>   - `apps/app_user/integration_test/cuj/event_operation/matching_results_reveal_test.dart`
+> - **Related work**:
+>   - MDS spec PR: #2918
+>   - Implementation issue: #2919
+
+## CUJs
+
+| ID  | Priority | CUJ Name | Details | FR | NFR |
+|-----|----------|----------|---------|----|----|
+| 1-1 | P0 | 홈 결과 surface에서 매칭 결과 열기 | • 이벤트 종료 후 홈/event-now results surface 노출<br>• 사용자가 results surface를 열면 `매칭 결과` modal bottom sheet 표시<br>• loading resolves 후 matched contact cards 표시 | FR-1, FR-2, FR-3 | NFR-1, NFR-2 |
+| 1-2 | P0 | 이벤트 상세에서 매칭 결과 열기 | • 이벤트 상세가 종료 후 결과 확인 가능 상태<br>• 사용자가 `매칭 결과 보기` tap<br>• 동일 `매칭 결과` modal bottom sheet 표시 | FR-1, FR-2, FR-3 | NFR-1, NFR-2 |
+| 1-3 | P0 | 단일 매칭 연락처 저장 | • mutual match 1건<br>• card 1장을 중앙 정렬하고 horizontal scroll/dot indicator 없음<br>• 사용자가 `연락처 저장하기` tap<br>• 해당 partner만 OS 연락처 저장 flow로 전달 | FR-4, FR-5, FR-6, FR-8 | NFR-2, NFR-3 |
+| 2-1 | P0 | 여러 매칭 카드 탐색 후 한 명 저장 | • mutual match 2건 이상<br>• horizontal cards와 dot indicator 표시<br>• 사용자가 swipe하면 active dot이 현재 card index 반영<br>• 선택 card의 `연락처 저장하기`만 해당 partner에 적용 | FR-4, FR-6, FR-7, FR-8 | NFR-2, NFR-3 |
+| 3-1 | P0 | 매칭 없음 결과에서 다음 이벤트 찾기 | • mutual match 0건<br>• empty copy와 `다음 이벤트 찾기` CTA 표시<br>• CTA tap 시 sheet dismiss 후 Home feed 이동 | FR-9, FR-10 | NFR-2 |
+| 3-2 | P0 | 조회 실패를 empty 결과로 처리 | • 결과 provider error 또는 조회 실패<br>• 내부 error detail 미노출<br>• empty copy와 `다음 이벤트 찾기` CTA 표시 | FR-9, FR-10, FR-11 | NFR-2, NFR-4 |
+
+## Functional Requirements
+
+- **FR-1**: 결과 sheet entry surface는 두 가지다. Home `EventNowBottomSheet` phase 6 results content와 이벤트 상세 `매칭 결과 보기` 버튼은 동일한 result content를 열어야 한다.
+- **FR-2**: 결과 sheet의 title copy는 `매칭 결과`다. subtitle은 이벤트명이 있으면 해당 이벤트명, 없으면 `이벤트` fallback을 사용한다.
+- **FR-3**: 결과 조회 loading 중에는 결과 list나 empty copy를 노출하지 않고 loading slot만 표시한다. 사용자는 sheet dismiss만 할 수 있다.
+- **FR-4**: mutual match가 1건 이상이면 count copy는 match 수를 반영해 `{N}명과 매칭되었어요!` 형식으로 표시한다. 예: `1명과 매칭되었어요!`, `2명과 매칭되었어요!`.
+- **FR-5**: matched state의 안내 copy는 정확히 `매칭된 상대방에게 서로의 연락처가 공유되었습니다.` / `오늘의 여운이 이어질 수 있게 편하게 연락해보세요.`를 사용한다.
+- **FR-6**: contact card는 `공유된 연락처` label, partner name, full partner contact, `연락처 저장하기` CTA를 표시한다. mutual match 이후 `partnerContact`는 마스킹 없이 전체 표시한다. 예: `010-1234-5678`.
+- **FR-7**: `matches.length == 1`이면 card 1장을 중앙 정렬하고 horizontal carousel, next-card peek, dot indicator를 만들지 않는다. `matches.length > 1`이면 horizontal carousel, next-card peek, dot indicator를 표시한다.
+- **FR-8**: `연락처 저장하기`는 해당 card의 partner 한 명만 OS contact-save flow로 넘긴다. 여러 match가 있어도 `모두 저장` bulk action은 제공하지 않는다.
+- **FR-9**: mutual match가 0건이거나 결과 조회가 실패하면 동일 empty state를 표시한다. empty copy는 정확히 `좋은 인연은 한번에 정해지지 않으니까요.` / `다음 자리에서 더 나은 인연을 만나길 기원합니다.`를 사용한다.
+- **FR-10**: empty/error state CTA copy는 `다음 이벤트 찾기`다. CTA tap 시 현재 sheet를 닫고 Home feed로 이동한다. 이 CTA는 retry가 아니다.
+- **FR-11**: 조회 실패의 내부 error detail은 사용자에게 노출하지 않는다. retry affordance는 제공하지 않는다.
+- **FR-12**: partner name이 없으면 `알 수 없음`을 표시한다. partner contact가 없으면 phone row를 노출하지 않는다.
+
+## Non-Functional Requirements
+
+- **NFR-1**: 결과 sheet open 후 first content paint는 캐시 hit 기준 에뮬레이터 baseline p95 300ms 이내다.
+- **NFR-2**: loading에서 matched 또는 empty state로 전환할 때 sheet height jump가 사용자 입력을 방해하지 않아야 한다. Loading slot은 120px 완충 영역을 사용한다.
+- **NFR-3**: carousel swipe와 dot indicator transition은 저사양 기기 baseline에서 60fps를 유지한다.
+- **NFR-4**: error fallback은 실패 상세를 화면 copy, toast, retry label로 노출하지 않는다.
+- **NFR-5**: OS reduce motion 설정이 켜진 경우 loading-to-result reveal animation duration은 0ms이며 최종 상태만 즉시 표시한다.
+
+## Edge Cases
+
+| CUJ ID | 케이스 | 기대 동작 |
+|--------|--------|----------|
+| 1-1, 1-2 | sheet open 직후 결과 pending | `매칭 결과` title과 이벤트 subtitle은 유지하고 loading slot만 표시한다. |
+| 1-3 | mutual match 1건 | 단일 card를 중앙 정렬한다. dot indicator와 horizontal scroll affordance는 없다. |
+| 1-3, 2-1 | partner contact 존재 | full contact를 표시한다. 마스킹, truncation, 일부 숨김을 하지 않는다. |
+| 1-3, 2-1 | partner contact 없음 | phone row를 숨기고, 저장 CTA는 구현 정책에 따라 숨기거나 disabled 처리한다. |
+| 1-3, 2-1 | partner name 없음 | card title에 `알 수 없음`을 표시한다. |
+| 2-1 | mutual match 2건 이상 | horizontal card carousel과 dot indicator를 표시하고, active dot은 현재 card index를 따른다. |
+| 2-1 | 사용자가 두 번째 card에서 저장 | 두 번째 partner만 OS contact-save flow로 전달한다. 다른 card는 저장하지 않는다. |
+| 3-1 | mutual match 0건 | empty copy와 `다음 이벤트 찾기` CTA를 표시한다. |
+| 3-2 | 결과 조회 실패 | empty copy와 `다음 이벤트 찾기` CTA를 표시하고 내부 오류는 숨긴다. |
+| 3-1, 3-2 | empty CTA tap | sheet dismiss 후 Home feed로 이동한다. retry 동작을 하지 않는다. |
+
+## Open Questions
+
+- [ ] partner contact가 없는 mutual match card에서 `연락처 저장하기` CTA를 disabled로 둘지 숨길지는 구현 PR #2919에서 확정한다.
+- [ ] 연락처 저장 성공/취소/실패 후 toast 또는 snackbar copy는 OS save flow 연동 정책에 맞춰 별도 구현 단계에서 확정한다.
+
+---
+
+## 화면 구성 (참고)
+
+> MDS spec이 UI SSoT다. 이 섹션은 product behavior와 exact user-facing copy 추적을 위한 요약이다.
+
+### Entry Surfaces
+
+| Surface | Trigger | Expected Sheet |
+|---------|---------|----------------|
+| Home/event-now results surface | 이벤트 종료 후 results phase surface tap | `매칭 결과` shared result content |
+| Event detail result button | `매칭 결과 보기` tap | 동일 `매칭 결과` shared result content |
+
+### Matched State Copy
+
+| 위치 | Copy |
+|------|------|
+| Sheet title | `매칭 결과` |
+| Match count | `{N}명과 매칭되었어요!` |
+| Matched message line 1 | `매칭된 상대방에게 서로의 연락처가 공유되었습니다.` |
+| Matched message line 2 | `오늘의 여운이 이어질 수 있게 편하게 연락해보세요.` |
+| Contact label | `공유된 연락처` |
+| Save CTA | `연락처 저장하기` |
+
+### Empty / Error Copy
+
+| 위치 | Copy |
+|------|------|
+| Empty message line 1 | `좋은 인연은 한번에 정해지지 않으니까요.` |
+| Empty message line 2 | `다음 자리에서 더 나은 인연을 만나길 기원합니다.` |
+| Empty CTA | `다음 이벤트 찾기` |
+
+### Privacy / Product Policy
+
+| Policy | Contract |
+|--------|----------|
+| Contact reveal | mutual match 성립 후 연락처 교환이 목적이므로 `partnerContact`는 전체 표시한다. |
+| No masking | `010-1234-5678` 같은 전체 번호를 표시하며 마스킹, truncation, 부분 공개를 하지 않는다. |
+| Single save only | `연락처 저장하기`는 해당 card의 partner 한 명에게만 적용한다. |
+| No bulk save | `모두 저장` bulk action은 제공하지 않는다. |
+| Error privacy | provider error와 empty result는 같은 copy를 사용하며 내부 오류 상세를 노출하지 않는다. |


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-high-1

## Summary
- Add `docs/features/event-operation/matching-results-reveal/` with PRD and testable CUJ spec for post-event mutual-match results reveal.
- Cover both entry surfaces: home/event-now results surface and event detail `매칭 결과 보기`.
- Capture exact MDS copy, single/multi-match behavior, empty/error fallback, full contact reveal policy, and no-bulk-save policy.
- Register the feature in `docs/features/event-operation/BLUEDOC.md`.

## Why
Closes #2920.

References:
- MDS spec PR: #2918
- Implementation issue: #2919

## Verification
- `git diff --check`
- `rg -n "Home.*results|매칭 결과 보기|1명과 매칭되었어요|2명과 매칭되었어요|매칭된 상대방에게 서로의 연락처가 공유되었습니다|오늘의 여운이 이어질 수 있게 편하게 연락해보세요|좋은 인연은 한번에 정해지지 않으니까요|다음 자리에서 더 나은 인연을 만나길 기원합니다|다음 이벤트 찾기|partnerContact|마스킹|모두 저장|#2918|#2919" docs/features/event-operation/matching-results-reveal`

## Residual Risk
- Docs-only change. The CTA behavior for missing `partnerContact` remains an explicit open question for implementation issue #2919.