### PR TITLE
fix(cuj): exclude non-flutter admin specs from coverage

### DIFF
--- a/.github/workflows/monitor-cuj-coverage.yml
+++ b/.github/workflows/monitor-cuj-coverage.yml
@@ -48,6 +48,7 @@ jobs:
           SPEC=$(jq -r '.spec_cujs' /tmp/cuj_cov.json)
           UNCOVERED_COUNT=$(jq -r '[.uncovered_features[].uncovered | length] | add // 0' /tmp/cuj_cov.json)
           ORPHAN_COUNT=$(jq -r '[.orphan_features[].orphan | length] | add // 0' /tmp/cuj_cov.json)
+          SKIPPED_COUNT=$(jq -r '.skipped_cujs // 0' /tmp/cuj_cov.json)
 
           ISSUE_TITLE_PREFIX="[cuj-coverage]"
 
@@ -110,7 +111,19 @@ jobs:
           - CUJ 커버리지: **${PCT}%** (${COVERED}/${SPEC})
           - Uncovered CUJs (spec 있음, 테스트 없음): **${UNCOVERED_COUNT}**
           - Orphan tests (테스트 있음, spec 없음): **${ORPHAN_COUNT}**
+          - Skipped CUJs (Flutter CUJ scope 밖): **${SKIPPED_COUNT}**
           - Pending spec.md 마이그레이션 (5섹션 미적용): **${PENDING_MIGRATION_COUNT}**
+
+          ## Coverage scope
+
+          이 monitor 는 현재 Flutter user/partner 앱 CUJ root 만 검증합니다:
+
+          - \`apps/app_user/integration_test/cuj/\`
+          - \`apps/app_partner/integration_test/cuj/\`
+
+          Flutter 앱 범위 밖 feature 는 skipped 로 표시하며, Option A 테스트 추가 대상에서 제외합니다.
+
+          $(jq -r '.skipped_features[]? | "- \(.category)/\(.feature): \(.spec_cujs) CUJs skipped — \(.reason)"' /tmp/cuj_cov.json)
 
           ## Decision rule (default action)
 

--- a/scripts/cuj_coverage.dart
+++ b/scripts/cuj_coverage.dart
@@ -28,6 +28,11 @@ const _testsRoots = [
   'apps/app_partner/integration_test/cuj',
 ];
 
+const _skippedSpecCategoryReasons = {
+  'admin': 'Admin features are outside the Flutter app CUJ scope until an '
+      'admin console test root exists.',
+};
+
 // spec.md CUJ row: `| 1-1 | P0 | name | ... |`
 // 헤더(`| ID | ...`)와 separator(`|---|`)는 ID 가 `\d+-\d+` 패턴이 아니라 자동 제외.
 final _cujRowPattern = RegExp(
@@ -59,6 +64,7 @@ void main(List<String> args) {
 
     // 1. Spec 스캔
     final features = <String, FeatureCoverage>{};
+    final skippedFeatures = <Map<String, dynamic>>[];
     for (final category in _listDirs(_specsRoot)) {
       final catPath = '$_specsRoot/$category';
       for (final feature in _listDirs(catPath)) {
@@ -67,6 +73,16 @@ void main(List<String> args) {
         if (!File(specPath).existsSync()) continue;
         final cov = FeatureCoverage(category, feature);
         _parseSpec(specPath, cov);
+        final skipReason = _skippedSpecCategoryReasons[category];
+        if (skipReason != null) {
+          skippedFeatures.add({
+            'category': category,
+            'feature': feature,
+            'spec_cujs': cov.specIds.length,
+            'reason': skipReason,
+          });
+          continue;
+        }
         features['$category/$feature'] = cov;
       }
     }
@@ -140,6 +156,11 @@ void main(List<String> args) {
       'coverage_pct': pct.toStringAsFixed(1),
       'uncovered_features': uncoveredList,
       'orphan_features': orphanList,
+      'skipped_features': skippedFeatures,
+      'skipped_cujs': skippedFeatures.fold<int>(
+        0,
+        (sum, f) => sum + (f['spec_cujs'] as int),
+      ),
       'per_feature': sortedKeys.map((k) {
         final f = features[k]!;
         return {
@@ -203,7 +224,8 @@ void _printHuman(Map<String, dynamic> s) {
   print('═' * 60);
   print('  CUJ Coverage');
   print('═' * 60);
-  print('  CUJs : ${s['covered_cujs']}/${s['spec_cujs']} (${s['coverage_pct']}%)');
+  print(
+      '  CUJs : ${s['covered_cujs']}/${s['spec_cujs']} (${s['coverage_pct']}%)');
   print('');
   print('─── Per-feature ─────────────────────────────────────────');
   for (final f in s['per_feature'] as List) {
@@ -232,6 +254,15 @@ void _printHuman(Map<String, dynamic> s) {
     for (final f in orphan) {
       print('  - ${f['category']}/${f['feature']}: '
           '${(f['orphan'] as List).join(', ')}');
+    }
+  }
+  final skipped = s['skipped_features'] as List;
+  if (skipped.isNotEmpty) {
+    print('');
+    print('─── Skipped specs (outside Flutter CUJ scope) ───────────');
+    for (final f in skipped) {
+      print('  - ${f['category']}/${f['feature']}: '
+          '${f['spec_cujs']} CUJs — ${f['reason']}');
     }
   }
 }


### PR DESCRIPTION
Scheduler: arch-codex-gpt55-high-1

## Summary
- Exclude `docs/features/admin/*` specs from the Flutter CUJ coverage denominator.
- Add `skipped_features` / `skipped_cujs` to `scripts/cuj_coverage.dart` output for non-Flutter feature specs.
- Update `monitor-cuj-coverage.yml` issue body to show Flutter CUJ scope and skipped specs explicitly.

## Why
- `docs/features/admin/BLUEDOC.md` defines admin features as internal/admin web tooling, not Flutter user/partner app flows.
- `apps/app_user/integration_test/cuj/BLUEDOC.md` explicitly says not to add admin CUJs under the Flutter user app CUJ root.
- The previous monitor counted all feature specs but only scanned Flutter test roots, which made admin CUJs permanently uncovered.

## Issue lifecycle
Refs #2937.

Partial / non-closing reason: this PR resolves the admin scope decision only. The issue should not close until the separate `event-operation/matching-results-reveal` coverage PR #2941 also lands and the monitor sees Flutter CUJ coverage reach 100%.

## Verification
- `dart format scripts/cuj_coverage.dart`
- `dart analyze scripts/cuj_coverage.dart` (exit 0; existing info-level lint output remains)
- `dart run scripts/cuj_coverage.dart --json` (exit 1 on current dev-staging because `event-operation/matching-results-reveal` is still uncovered until PR #2941 merges; admin is now reported as `skipped_cujs: 31`)
- `git diff --check`

## Residual risk
- This keeps admin outside the Flutter CUJ gate until an admin console/e2e test root exists. When that root is introduced, the skip list should be replaced with an admin-specific test mapping.